### PR TITLE
Prisma2 1377 take 2

### DIFF
--- a/libs/prisma-models/src/field.rs
+++ b/libs/prisma-models/src/field.rs
@@ -140,6 +140,13 @@ impl Field {
         }
     }
 
+    pub(crate) fn as_scalar(self) -> Option<ScalarFieldRef> {
+        match self {
+            Field::Scalar(scalar) => Some(scalar),
+            _ => None,
+        }
+    }
+
     pub fn is_required(&self) -> bool {
         match self {
             Field::Scalar(ref sf) => sf.is_required,
@@ -158,6 +165,13 @@ impl Field {
         match self {
             Self::Scalar(sf) => vec![sf.data_source_field().clone()],
             Self::Relation(rf) => rf.data_source_fields().to_vec(),
+        }
+    }
+
+    pub fn downgrade(&self) -> FieldWeak {
+        match self {
+            Field::Relation(field) => FieldWeak::Relation(Arc::downgrade(field)),
+            Field::Scalar(field) => FieldWeak::Scalar(Arc::downgrade(field)),
         }
     }
 }

--- a/libs/prisma-models/src/model.rs
+++ b/libs/prisma-models/src/model.rs
@@ -51,7 +51,7 @@ impl ModelTemplate {
             self.id_field_names,
         );
 
-        let indexes = self.indexes.into_iter().map(|i| i.build(&fields.scalar())).collect();
+        let indexes = self.indexes.into_iter().map(|i| i.build(&fields.all)).collect();
 
         // The model is created here and fields WILL BE UNSET before now!
         model.fields.set(fields).unwrap();
@@ -89,18 +89,18 @@ impl Model {
         let fields: Vec<_> = self
             .fields()
             .id()
-            .map(|fields| fields.into_iter().collect())
+            .map(|fields| fields.into_iter().map(Field::Scalar).collect())
             .or_else(|| {
                 self.fields()
                     .scalar()
                     .into_iter()
                     .find(|sf| sf.is_unique && sf.is_required)
-                    .map(|x| vec![x])
+                    .map(|x| vec![Field::Scalar(x)])
             })
             .or_else(|| {
                 self.unique_indexes()
                     .into_iter()
-                    .find(|index| index.fields().into_iter().all(|f| f.is_required))
+                    .find(|index| index.fields().into_iter().all(|f| f.is_required()))
                     .map(|index| index.fields().into_iter().collect())
             })
             .expect(&format!(

--- a/libs/prisma-models/tests/datamodel_converter_tests.rs
+++ b/libs/prisma-models/tests/datamodel_converter_tests.rs
@@ -112,10 +112,14 @@ fn db_names_work() {
 }
 
 #[test]
-#[ignore]
 fn scalar_lists_work() {
     let datamodel = convert(
         r#"
+            datasource pg {
+                provider = "postgres"
+                url = "postgres://localhost/postgres"
+            }
+
             model Test {
                 id String @id @default(cuid())
                 intList Int[]
@@ -126,10 +130,7 @@ fn scalar_lists_work() {
     model
         .assert_scalar_field("intList")
         .assert_type_identifier(TypeIdentifier::Int)
-        .assert_list()
-        .assert_behaviour(FieldBehaviour::ScalarList {
-            strategy: ScalarListStrategy::Relation,
-        });
+        .assert_list();
 }
 
 #[test]

--- a/query-engine/core/src/query_graph_builder/extractors/utils.rs
+++ b/query-engine/core/src/query_graph_builder/extractors/utils.rs
@@ -28,5 +28,5 @@ pub fn resolve_index_fields(name: &str, model: &ModelRef) -> Option<Vec<ScalarFi
         .unique_indexes()
         .into_iter()
         .find(|index| &schema_builder::compound_index_field_name(index) == name)
-        .map(|index| index.fields())
+        .map(|index| index.scalar_fields())
 }

--- a/query-engine/core/src/schema_builder/input_type_builder/mod.rs
+++ b/query-engine/core/src/schema_builder/input_type_builder/mod.rs
@@ -116,7 +116,7 @@ pub trait InputTypeBuilderBase<'a>: CachedBuilder<InputObjectType> + InputBuilde
             .unique_indexes()
             .into_iter()
             .map(|index| {
-                let typ = self.compound_field_unique_object_type(index.name.as_ref(), index.fields());
+                let typ = self.compound_field_unique_object_type(index.name.as_ref(), index.scalar_fields());
                 let name = compound_index_field_name(index);
 
                 input_field(name, InputType::opt(InputType::object(typ)), None)

--- a/query-engine/core/src/schema_builder/utils.rs
+++ b/query-engine/core/src/schema_builder/utils.rs
@@ -138,7 +138,7 @@ pub fn append_opt<T>(vec: &mut Vec<T>, opt: Option<T>) {
 pub fn compound_index_field_name(index: &Index) -> String {
     index.name.clone().unwrap_or_else(|| {
         let index_fields = index.fields();
-        let field_names: Vec<&str> = index_fields.iter().map(|sf| sf.name.as_ref()).collect();
+        let field_names: Vec<&str> = index_fields.iter().map(|sf| sf.name()).collect();
 
         field_names.join("_")
     })


### PR DESCRIPTION
The crash happens when the schema contains an index/unique covering
relation fields. So far we only considered scalar fields. This is the minimal fix to make DMMF generation not crash on the schema from the issue (https://github.com/prisma/prisma2/issues/1377).