### PR TITLE
Push stdio handling out of migration-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1297,7 +1297,6 @@ dependencies = [
  "chrono",
  "datamodel",
  "futures 0.3.4",
- "json-rpc-stdio",
  "jsonrpc-core",
  "migration-connector",
  "quaint",
@@ -1316,6 +1315,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "futures 0.3.4",
+ "json-rpc-stdio",
  "migration-connector",
  "migration-core",
  "quaint",

--- a/introspection-engine/core/src/main.rs
+++ b/introspection-engine/core/src/main.rs
@@ -19,7 +19,7 @@ async fn main() {
         let mut io_handler = IoHandler::new();
         io_handler.extend_with(RpcImpl::new().to_delegate());
 
-        json_rpc_stdio::run(io_handler).await.unwrap();
+        json_rpc_stdio::run(&io_handler).await.unwrap();
     }
 }
 

--- a/libs/json-rpc-stdio/src/lib.rs
+++ b/libs/json-rpc-stdio/src/lib.rs
@@ -2,12 +2,12 @@ use futures::compat::*;
 use jsonrpc_core::IoHandler;
 use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt};
 
-pub async fn run(handler: IoHandler) -> std::io::Result<()> {
+pub async fn run(handler: &IoHandler) -> std::io::Result<()> {
     run_with_io(handler, tokio::io::stdin(), tokio::io::stdout()).await
 }
 
 async fn run_with_io(
-    handler: IoHandler,
+    handler: &IoHandler,
     input: impl AsyncRead + Unpin,
     output: impl AsyncWrite + Unpin,
 ) -> std::io::Result<()> {

--- a/migration-engine/cli/Cargo.toml
+++ b/migration-engine/cli/Cargo.toml
@@ -13,14 +13,15 @@ sql-migration-connector = { path = "../connectors/sql-migration-connector", opti
 user-facing-errors = { path = "../../libs/user-facing-errors" }
 
 anyhow = "1.0.26"
+futures = "0.3"
+json-rpc-stdio = { path = "../../libs/json-rpc-stdio" }
 quaint = { git = "https://github.com/prisma/quaint", optional = true }
+serde_json = "1.0"
 structopt = "0.3.8"
 thiserror = "1.0.9"
 tokio = { version = "0.2", features = ["macros"] }
 tracing = "0.1"
 tracing-subscriber = "0.2"
-serde_json = "1.0"
-futures = "0.3"
 url = "2.1.1"
 
 [dev-dependencies]

--- a/migration-engine/cli/src/main.rs
+++ b/migration-engine/cli/src/main.rs
@@ -83,7 +83,8 @@ async fn start_engine(datamodel_location: &str, single_cmd: bool) -> ! {
         println!("{}", response);
     } else {
         match RpcApi::new(&datamodel).await {
-            Ok(api) => api.start_server().await.unwrap(),
+            // Block the thread and handle IO in async until EOF.
+            Ok(api) => json_rpc_stdio::run(api.io_handler()).await.unwrap(),
             Err(err) => {
                 let (error, exit_code) = match &err {
                     CoreError::DatamodelError(errors) => {

--- a/migration-engine/core/Cargo.toml
+++ b/migration-engine/core/Cargo.toml
@@ -14,7 +14,6 @@ anyhow = "1.0.26"
 async-trait = "0.1.17"
 chrono = { version = "0.4", features = ["serde"] }
 futures = { version = "0.3", features = ["compat"] }
-json-rpc-stdio = { path = "../../libs/json-rpc-stdio" }
 jsonrpc-core = "14.0"
 quaint = { git = "https://github.com/prisma/quaint", optional = true }
 serde = { version = "1.0" }

--- a/migration-engine/core/src/api/rpc.rs
+++ b/migration-engine/core/src/api/rpc.rs
@@ -63,12 +63,11 @@ impl RpcApi {
         Ok(rpc_api)
     }
 
-    /// Block the thread and handle IO in async until EOF.
-    pub async fn start_server(self) -> std::io::Result<()> {
-        json_rpc_stdio::run(self.io_handler).await
+    pub fn io_handler(&self) -> &IoHandler {
+        &self.io_handler
     }
 
-    /// Handle one request
+    /// Handle one request over stdio.
     pub fn handle(&self) -> CoreResult<String> {
         let mut json_is_complete = false;
         let mut input = String::new();


### PR DESCRIPTION
It belongs in the CLI.