### PR TITLE
Generate unique names for relation fields derived from compound FKs

### DIFF
--- a/introspection-engine/connectors/sql-introspection-connector/src/calculate_datamodel.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/calculate_datamodel.rs
@@ -30,7 +30,7 @@ pub fn calculate_model(schema: &SqlSchema) -> SqlIntrospectionResult<Datamodel> 
         }
 
         for foreign_key in &table.foreign_keys {
-            let field = calculate_relation_field(schema, table, foreign_key);
+            let field = calculate_relation_field(schema, table, foreign_key, &table.foreign_keys);
             model.add_field(field);
         }
 


### PR DESCRIPTION
This implements a fix for one of the duplicate name bugs mentioned here: https://github.com/prisma/prisma2/issues/1103

mysql_127/Basketball_men should be fixed by this. 