### PR TITLE
Take `@map` into account when migrating enum values

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
@@ -571,13 +571,12 @@ fn postgres_alter_enum(
                     "ALTER TABLE {schema_name}.{table_name} \
                         ALTER COLUMN {column_name} DROP DEFAULT,
                         ALTER COLUMN {column_name} TYPE {tmp_name} \
-                            USING ({old_name}::text::{tmp_name}),
+                            USING ({column_name}::text::{tmp_name}),
                         ALTER COLUMN {column_name} SET DEFAULT {new_enum_default}",
                     schema_name = postgres_quoted(schema_name),
                     table_name = postgres_quoted(column.table().name()),
                     column_name = postgres_quoted(column.name()),
                     tmp_name = postgres_quoted(&tmp_name),
-                    old_name = alter_enum.name,
                     new_enum_default = postgres_quoted_string(new_enum.values.first().unwrap()),
                 );
 

--- a/migration-engine/core/src/migration/datamodel_differ.rs
+++ b/migration-engine/core/src/migration/datamodel_differ.rs
@@ -115,6 +115,15 @@ fn push_created_enums<'a>(steps: &mut Steps, enums: impl Iterator<Item = &'a ast
         };
 
         push_created_directives(steps, &directive_path, r#enum.directives.iter());
+
+        for value in &r#enum.values {
+            let path = steps::DirectivePath::EnumValue {
+                r#enum: r#enum.name.name.clone(),
+                value: value.name.name.clone(),
+            };
+
+            push_created_directives(steps, &path, value.directives.iter());
+        }
     }
 }
 

--- a/migration-engine/migration-engine-tests/tests/multi_user_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/multi_user_tests.rs
@@ -77,7 +77,7 @@ async fn multi_users_sanity_check(api: &TestApi) -> TestResult {
     Ok(())
 }
 
-#[test_each_connector(log = "debug")]
+#[test_each_connector]
 async fn users_cannot_add_the_same_model_separately(api: &TestApi) -> TestResult {
     // Initial setup
     let master = {


### PR DESCRIPTION
Also fix an enum migration bug on postgres

Closes https://github.com/prisma/prisma-engines/issues/519