### PR TITLE
Test index fields ordering is preserved in postgres sql-schema-describer

### DIFF
--- a/libs/sql-schema-describer/src/lib.rs
+++ b/libs/sql-schema-describer/src/lib.rs
@@ -160,6 +160,15 @@ pub enum IndexType {
     Normal,
 }
 
+impl IndexType {
+    pub fn is_unique(&self) -> bool {
+        match self {
+            IndexType::Unique => true,
+            _ => false,
+        }
+    }
+}
+
 /// An index of a table.
 #[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
https://github.com/prisma/prisma2/issues/1666