### PR TITLE
Index join tables on the B side

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
@@ -303,7 +303,7 @@ impl<'a> SqlSchemaCalculator<'a> {
                         model: &relation.model_b,
                     };
                     let a_columns = relation_table_columns(&model_a, relation.model_a_column());
-                    let mut b_columns = relation_table_columns(&model_b, relation.model_b_column());
+                    let b_columns = relation_table_columns(&model_b, relation.model_b_column());
 
                     let foreign_keys = vec![
                         sql::ForeignKey {
@@ -331,19 +331,25 @@ impl<'a> SqlSchemaCalculator<'a> {
                     ];
 
                     let mut columns = a_columns;
-                    columns.append(&mut b_columns);
+                    columns.extend(b_columns.iter().map(|col| col.to_owned()));
 
-                    let index = sql::Index {
-                        // TODO: rename
-                        name: format!("{}_AB_unique", relation.table_name()),
-                        columns: columns.iter().map(|col| col.name.clone()).collect(),
-                        tpe: sql::IndexType::Unique,
-                    };
+                    let indexes = vec![
+                        sql::Index {
+                            name: format!("{}_AB_unique", relation.table_name()),
+                            columns: columns.iter().map(|col| col.name.clone()).collect(),
+                            tpe: sql::IndexType::Unique,
+                        },
+                        sql::Index {
+                            name: format!("{}_B_index", relation.table_name()),
+                            columns: b_columns.into_iter().map(|col| col.name).collect(),
+                            tpe: sql::IndexType::Normal,
+                        },
+                    ];
 
                     let table = sql::Table {
                         name: relation.table_name(),
                         columns,
-                        indices: vec![index],
+                        indices: indexes,
                         primary_key: None,
                         foreign_keys,
                     };

--- a/migration-engine/migration-engine-tests/src/assertions.rs
+++ b/migration-engine/migration-engine-tests/src/assertions.rs
@@ -1,5 +1,7 @@
 use pretty_assertions::assert_eq;
-use sql_schema_describer::{Column, Enum, ForeignKey, Index, IndexType, PrimaryKey, SqlSchema, Table};
+use sql_schema_describer::{
+    Column, Enum, ForeignKey, ForeignKeyAction, Index, IndexType, PrimaryKey, SqlSchema, Table,
+};
 
 pub(crate) type AssertionResult<T> = Result<T, anyhow::Error>;
 
@@ -160,6 +162,19 @@ impl<'a> TableAssertion<'a> {
         Ok(this)
     }
 
+    pub fn assert_columns_count(self, count: usize) -> AssertionResult<Self> {
+        let actual_count = self.0.columns.len();
+
+        anyhow::ensure!(
+            actual_count == count,
+            "Assertion failed: expected {} columns, found {}",
+            count,
+            actual_count,
+        );
+
+        Ok(self)
+    }
+
     pub fn assert_has_no_pk(self) -> AssertionResult<Self> {
         anyhow::ensure!(
             self.0.primary_key.is_none(),
@@ -283,6 +298,15 @@ impl<'a> ForeignKeyAssertion<'a> {
             columns,
             self.0.referenced_table,
             self.0.referenced_columns,
+        );
+
+        Ok(self)
+    }
+
+    pub fn assert_cascades_on_delete(self) -> AssertionResult<Self> {
+        anyhow::ensure!(
+            self.0.on_delete_action == ForeignKeyAction::Cascade,
+            "Assertion failed: expected foreign key to cascade on delete."
         );
 
         Ok(self)


### PR DESCRIPTION
Previously, Prisma join tables (for many-to-many relations) only had a
unique index on the A columns + B columns, but that could not be used
when the relation is queried from the B side.

This commit adds an index on the foreign key columns for B.

closes https://github.com/prisma/prisma-engines/issues/554