### PR TITLE
The dmmf cli cmd should not crash for env vars

### DIFF
--- a/query-engine/prisma/src/cli.rs
+++ b/query-engine/prisma/src/cli.rs
@@ -102,7 +102,7 @@ impl CliCommand {
     }
 
     fn dmmf(request: DmmfRequest) -> PrismaResult<()> {
-        let dm = datamodel::parse_datamodel(&request.datamodel)?;
+        let dm = datamodel::parse_datamodel_and_ignore_env_errors(&request.datamodel)?;
         let template = DatamodelConverter::convert(&dm);
 
         // temporary code duplication


### PR DESCRIPTION
If the datamodel uses env command, the dmmf should not crash even though
the variable is not set.