### PR TITLE
Replace invalid enum values in defaults with dbgenerated()

### DIFF
--- a/introspection-engine/connectors/sql-introspection-connector/src/sanitize_datamodel_names.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/sanitize_datamodel_names.rs
@@ -1,4 +1,4 @@
-use datamodel::{Datamodel, DefaultValue, FieldType, ScalarValue};
+use datamodel::{Datamodel, DefaultValue, FieldType, ScalarValue, ValueGenerator};
 use once_cell::sync::Lazy;
 use regex::Regex;
 use std::collections::HashMap;
@@ -24,35 +24,35 @@ pub fn sanitize_datamodel_names(datamodel: &mut Datamodel) {
                         .collect();
                 }
                 FieldType::Enum(enum_name) => {
-                    let (sanitized_enum_name, enum_db_name) =
-                        if *enum_name == format!("{}_{}", model.name, field.name) {
-                            //MySql
-                            if model_db_name.is_none() && field_db_name.is_none() {
-                                (enum_name.clone(), None)
-                            } else {
-                                (
-                                    format!("{}_{}", sanitized_model_name, sanitized_field_name),
-                                    Some(enum_name.clone()),
-                                )
-                            }
+                    let (sanitized_enum_name, enum_db_name) = if *enum_name == format!("{}_{}", model.name, field.name)
+                    {
+                        //MySql
+                        if model_db_name.is_none() && field_db_name.is_none() {
+                            (enum_name.clone(), None)
                         } else {
-                            sanitize_name(enum_name.clone())
-                        };
+                            (
+                                format!("{}_{}", sanitized_model_name, sanitized_field_name),
+                                Some(enum_name.clone()),
+                            )
+                        }
+                    } else {
+                        sanitize_name(enum_name.clone())
+                    };
 
                     if let Some(old_name) = enum_db_name {
-                        enum_renames.insert(
-                            old_name.clone(),
-                            (sanitized_enum_name.clone(), Some(old_name.clone())),
-                        );
+                        enum_renames.insert(old_name.clone(), (sanitized_enum_name.clone(), Some(old_name.clone())));
                     };
 
                     *enum_name = sanitized_enum_name;
 
-                    if let Some(DefaultValue::Single(ScalarValue::ConstantLiteral(name))) =
-                        &mut field.default_value
-                    {
-                        let (sanitized_value, _) = sanitize_name(name.to_string());
-                        *name = sanitized_value;
+                    if let Some(DefaultValue::Single(ScalarValue::ConstantLiteral(value))) = &mut field.default_value {
+                        let (sanitized_value, _) = sanitize_name(value.to_string());
+
+                        field.default_value = if sanitized_value == "".to_string() {
+                            Some(DefaultValue::Expression(ValueGenerator::new_dbgenerated()))
+                        } else {
+                            Some(DefaultValue::Single(ScalarValue::ConstantLiteral(sanitized_value)))
+                        };
                     };
 
                     if field.database_names.is_empty() {
@@ -71,11 +71,7 @@ pub fn sanitize_datamodel_names(datamodel: &mut Datamodel) {
         }
 
         for index in &mut model.indices {
-            index.fields = index
-                .fields
-                .iter()
-                .map(|f| sanitize_name(f.clone()).0)
-                .collect();
+            index.fields = index.fields.iter().map(|f| sanitize_name(f.clone()).0).collect();
         }
 
         model.name = sanitized_model_name;
@@ -114,10 +110,7 @@ fn sanitize_name(name: String) -> (String, Option<String>) {
 
     if needs_sanitation {
         let start_cleaned: String = RE_START.replace_all(name.as_str(), "").parse().unwrap();
-        (
-            RE.replace_all(start_cleaned.as_str(), "_").parse().unwrap(),
-            Some(name),
-        )
+        (RE.replace_all(start_cleaned.as_str(), "_").parse().unwrap(), Some(name))
     } else {
         (name, None)
     }


### PR DESCRIPTION
If we comment out the enum value during introspection we need to replace all its usages as default value with degenerated()