### PR TITLE
Drop @@id, @@unique, @@index if a commented out field is included

### DIFF
--- a/introspection-engine/connectors/sql-introspection-connector/src/calculate_datamodel.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/calculate_datamodel.rs
@@ -28,6 +28,8 @@ pub fn calculate_model(schema: &SqlSchema) -> SqlIntrospectionResult<Introspecti
         }
 
         for foreign_key in &table.foreign_keys {
+            //todo only if no unsupported types are used
+
             model.add_field(calculate_relation_field(schema, table, foreign_key));
         }
 

--- a/introspection-engine/connectors/sql-introspection-connector/src/commenting_out_guardrails.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/commenting_out_guardrails.rs
@@ -74,32 +74,6 @@ pub fn commenting_out_guardrails(datamodel: &mut Datamodel) -> Vec<Warning> {
         }
     }
 
-    // models without uniques / ids
-    for model in &mut datamodel.models {
-        if model.id_fields.is_empty()
-            && !model.fields.iter().any(|f| f.is_id || f.is_unique)
-            && !model.indices.iter().any(|i| i.is_unique())
-            && !models_with_one_to_one_relation.contains(&model.name)
-        {
-            commented_model_names.push(model.name.clone());
-            model.is_commented_out = true;
-            model.documentation = Some(
-                "The underlying table does not contain a unique identifier and can therefore currently not be handled."
-                    .to_string(),
-            );
-            models_without_identifiers.push(Model {
-                model: model.name.clone(),
-            })
-        }
-    }
-
-    // remove their backrelations
-    for name in &commented_model_names {
-        for model in &mut datamodel.models {
-            model.fields.retain(|f| !f.points_to_model(name));
-        }
-    }
-
     // fields with an empty name
     for model in &mut datamodel.models {
         for field in &mut model.fields {
@@ -145,6 +119,41 @@ pub fn commenting_out_guardrails(datamodel: &mut Datamodel) -> Vec<Warning> {
                     tpe: tpe.clone(),
                 })
             }
+        }
+    }
+
+    // use unsupported types to drop @@id / @@unique /@@index
+    for mf in &unsupported_types {
+        let model = datamodel.find_model_mut(&mf.model).unwrap();
+        model.indices.retain(|i| !i.fields.contains(&mf.field));
+        if model.id_fields.contains(&mf.field) {
+            model.id_fields = vec![]
+        };
+    }
+
+    // models without uniques / ids
+    for model in &mut datamodel.models {
+        if model.id_fields.is_empty()
+            && !model.fields.iter().any(|f| f.is_id || f.is_unique)
+            && !model.indices.iter().any(|i| i.is_unique())
+            && !models_with_one_to_one_relation.contains(&model.name)
+        {
+            commented_model_names.push(model.name.clone());
+            model.is_commented_out = true;
+            model.documentation = Some(
+                "The underlying table does not contain a unique identifier and can therefore currently not be handled."
+                    .to_string(),
+            );
+            models_without_identifiers.push(Model {
+                model: model.name.clone(),
+            })
+        }
+    }
+
+    // remove their backrelations
+    for name in &commented_model_names {
+        for model in &mut datamodel.models {
+            model.fields.retain(|f| !f.points_to_model(name));
         }
     }
 

--- a/introspection-engine/connectors/sql-introspection-connector/src/commenting_out_guardrails.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/commenting_out_guardrails.rs
@@ -134,7 +134,10 @@ pub fn commenting_out_guardrails(datamodel: &mut Datamodel) -> Vec<Warning> {
     // models without uniques / ids
     for model in &mut datamodel.models {
         if model.id_fields.is_empty()
-            && !model.fields.iter().any(|f| f.is_id || f.is_unique)
+            && !model
+                .fields
+                .iter()
+                .any(|f| (f.is_id || f.is_unique) && !f.is_commented_out)
             && !model.indices.iter().any(|i| i.is_unique())
             && !models_with_one_to_one_relation.contains(&model.name)
         {

--- a/introspection-engine/connectors/sql-introspection-connector/tests/db_specific_introspection/postgres/tables_postgres.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/tests/db_specific_introspection/postgres/tables_postgres.rs
@@ -534,3 +534,25 @@ async fn introspecting_an_unsupported_type_should_and_commenting_it_out_should_a
     let result = dbg!(api.introspect().await);
     assert_eq!(&result, "model Test {\n  dummy          Int\n  id             Int     @unique\n  // This type is currently not supported.\n  // network_mac macaddr\n}");
 }
+
+#[test_each_connector(tags("postgres"))]
+async fn introspecting_a_table_with_only_an_unsupported_id_type_should_comment_it_out(api: &TestApi) {
+    let barrel = api.barrel();
+    let _setup_schema = barrel
+        .execute(|migration| {
+            migration.create_table("Test", |t| {
+                t.add_column("dummy", types::integer());
+                t.inject_custom("network_mac  macaddr Primary Key");
+            });
+        })
+        .await;
+
+    let warnings = dbg!(api.introspection_warnings().await);
+    assert_eq!(
+        &warnings,
+        "[{\"code\":1,\"message\":\"These models do not have a unique identifier or id and are therefore commented out.\",\"affected\":[{\"model\":\"Test\"}]},{\"code\":3,\"message\":\"These fields were commented out because we currently do not support their types.\",\"affected\":[{\"model\":\"Test\",\"field\":\"network_mac\",\"tpe\":\"macaddr\"}]}]"
+    );
+
+    let result = dbg!(api.introspect().await);
+    assert_eq!(&result, "// The underlying table does not contain a unique identifier and can therefore currently not be handled.\n// model Test {\n  // dummy       Int\n  // This type is currently not supported.\n  // network_mac macaddr @id\n// }");
+}


### PR DESCRIPTION
Fixes https://github.com/prisma/prisma2/issues/1108

Also reorders the commenting logic so that models that lose all identifiers are commented out. 
