### PR TITLE
Ignore env errors when reformatting

### DIFF
--- a/libs/datamodel/core/src/ast/reformat/mod.rs
+++ b/libs/datamodel/core/src/ast/reformat/mod.rs
@@ -1,4 +1,4 @@
-use crate::{ast, parse_datamodel, parse_schema_ast, render_schema_ast_to, validator::LowerDmlToAst};
+use crate::{ast, parse_datamodel_and_ignore_env_errors, parse_schema_ast, render_schema_ast_to, validator::LowerDmlToAst};
 
 pub struct Reformatter {}
 
@@ -7,7 +7,7 @@ impl Reformatter {
         // the AST contains the datasources, generators, type aliases that are missing in the dml
         // it also contains all the original positions within the file
         let mut ast = parse_schema_ast(&input).unwrap();
-        let dml = parse_datamodel(&input).unwrap();
+        let dml = parse_datamodel_and_ignore_env_errors(&input).unwrap();
 
         for top in ast.tops.iter_mut() {
             match top {

--- a/libs/datamodel/core/tests/reformat/reformat.rs
+++ b/libs/datamodel/core/tests/reformat/reformat.rs
@@ -158,3 +158,23 @@ enum Colors {
     println!("{}", actual);
     assert_eq!(actual, expected);
 }
+
+#[test]
+fn test_reformat_config_with_env() {
+    let input = r#"
+        datasource pg { 
+            provider = "postgres"
+            url = env("DATABASE_URL")
+        }
+    "#;
+
+    let expected = r#"datasource pg {
+  provider = "postgres"
+  url      = env("DATABASE_URL")
+}"#;
+
+    let mut buf = Vec::new();
+    datamodel::ast::reformat::Reformatter::reformat_to(&input, &mut buf, 2);
+    let actual = str::from_utf8(&buf).expect("unable to convert to string");
+    assert_eq!(expected, actual);
+}


### PR DESCRIPTION
Fixes https://github.com/prisma/prisma-engines/issues/620
Fixes https://github.com/prisma/vscode/issues/40
Fixes https://github.com/prisma/vscode/issues/70