### PR TITLE
Ignore Cascade when comparing Foreign Keys

### DIFF
--- a/libs/sql-schema-describer/src/lib.rs
+++ b/libs/sql-schema-describer/src/lib.rs
@@ -368,7 +368,6 @@ impl PartialEq for ForeignKey {
         self.columns == other.columns
             && self.referenced_table == other.referenced_table
             && self.referenced_columns == other.referenced_columns
-            && self.on_delete_action == other.on_delete_action
     }
 }
 


### PR DESCRIPTION
- since we currently do not render or use it
Should fix MySql/Credit and Postgresql/Noalyss