### PR TITLE
Avoid duplicate unique indexes on required 1:1 relations

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
@@ -437,6 +437,15 @@ fn column_type_for_scalar_type(scalar_type: &ScalarType, column_arity: ColumnAri
 }
 
 fn add_one_to_one_relation_unique_index(table: &mut sql::Table, column_names: &[String]) {
+    // Don't add a duplicate index.
+    if table
+        .indices
+        .iter()
+        .any(|index| index.columns == column_names && index.tpe.is_unique())
+    {
+        return;
+    }
+
     let columns_suffix = column_names.join("_");
     let index = sql::Index {
         name: format!("{}_{}", table.name, columns_suffix),

--- a/migration-engine/migration-engine-tests/tests/migrations/indexes.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/indexes.rs
@@ -1,36 +1,37 @@
 use migration_engine_tests::sql::*;
 
-// Blocked on schema parser implementation
-//
-// #[test_each_connector]
-// async fn index_on_compound_relation_fields_must_work(api: &TestApi) -> TestResult {
-//     let dm = r#"
-//         model User {
-//             id String @id
-//             email String
-//             name String
+#[test_each_connector]
+async fn index_on_compound_relation_fields_must_work(api: &TestApi) -> TestResult {
+    let dm = r#"
+        model User {
+            id String @id
+            email String
+            name String
 
-//             @@unique([email, name])
-//         }
+            @@unique([email, name])
+        }
 
-//         model Post {
-//             id String @id
-//             author User @relation(references: [email, name])
+        model Post {
+            id String @id
+            authorEmail String
+            authorName String
+            author User @relation(fields: [authorEmail, authorName], references: [email, name])
 
-//             @@index([author])
-//         }
-//     "#;
+            @@index([authorEmail, authorName])
+        }
+    "#;
 
-//     api.infer_apply(dm).send().await?;
+    api.infer_apply(dm).send().await?;
 
-//     api.assert_schema().await?.assert_table("Post", |table| {
-//         table
-//             .assert_has_column("username")?
-//             .assert_index_on_columns(&["a", "b"], |idx| Ok(idx))
-//     })?;
+    api.assert_schema().await?.assert_table("Post", |table| {
+        table
+            .assert_has_column("authorName")?
+            .assert_has_column("authorEmail")?
+            .assert_index_on_columns(&["authorEmail", "authorName"], |idx| Ok(idx))
+    })?;
 
-//     Ok(())
-// }
+    Ok(())
+}
 
 #[test_each_connector]
 async fn index_settings_must_be_migrated(api: &TestApi) -> TestResult {


### PR DESCRIPTION
Addresses https://github.com/prisma/migrate/issues/391