### PR TITLE
Fix detection of 1:1 relations for self-relations

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/datamodel_helpers.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/datamodel_helpers.rs
@@ -222,6 +222,9 @@ impl<'a> RelationFieldRef<'a> {
             .find(|relation_field| {
                 relation_field.relation_name() == self.relation_name()
                     && relation_field.referenced_model().name.as_str() == &self.field.model.name
+                    // This is to differentiate the opposite field from self in the self relation case.
+                    && relation_field.relation_info.to_fields != self.relation_info.to_fields
+                    && relation_field.relation_info.fields != self.relation_info.fields
             })
     }
 


### PR DESCRIPTION
The field would potentially find itself, and a 1:m relation would end up
being treated as a 1:1 relation by the sql schema calculator, which
would result in an incorrect unique index on the foreign key column.

Addresses https://github.com/prisma/migrate/issues/405