### PR TITLE
Remove Unused Dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,42 +46,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
 
 [[package]]
-name = "async-std"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "538ecb01eb64eecd772087e5b6f7540cbc917f047727339a472dafed2185b267"
-dependencies = [
- "async-task",
- "broadcaster",
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-utils",
- "futures-core",
- "futures-io",
- "futures-timer",
- "kv-log-macro",
- "log",
- "memchr",
- "mio",
- "mio-uds",
- "num_cpus",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
- "slab",
-]
-
-[[package]]
-name = "async-task"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ac2c016b079e771204030951c366db398864f5026f84a44dafb0ff20f02085d"
-dependencies = [
- "libc",
- "winapi 0.3.8",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,30 +168,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "broadcaster"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c972e21e0d055a36cf73e4daae870941fe7a8abcd5ac3396aab9e4c126bd87"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-sink",
- "futures-util",
- "parking_lot",
- "slab",
-]
-
-[[package]]
 name = "byte-tools"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
-
-[[package]]
-name = "bytecount"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be0fdd54b507df8f22012890aadd099979befdba27713c767993f8380112ca7c"
 
 [[package]]
 name = "byteorder"
@@ -482,7 +426,6 @@ dependencies = [
 name = "datamodel"
 version = "0.1.0"
 dependencies = [
- "bytecount",
  "chrono",
  "clap",
  "colored",
@@ -1115,15 +1058,6 @@ checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 dependencies = [
  "winapi 0.2.8",
  "winapi-build",
-]
-
-[[package]]
-name = "kv-log-macro"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c54d9f465d530a752e6ebdc217e081a7a614b48cb200f6f0aee21ba6bc9aabb"
-dependencies = [
- "log",
 ]
 
 [[package]]
@@ -1949,7 +1883,6 @@ dependencies = [
  "migration-connector",
  "migration-core",
  "once_cell",
- "pretty_assertions",
  "prisma-inflector",
  "prisma-models",
  "quaint",
@@ -1969,7 +1902,6 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-attributes",
- "tracing-futures",
  "tracing-log",
  "tracing-subscriber",
  "url 2.1.1",
@@ -2021,7 +1953,6 @@ name = "prisma-value"
 version = "0.1.0"
 dependencies = [
  "chrono",
- "cuid",
  "quaint",
  "rust_decimal",
  "serde",
@@ -2150,7 +2081,6 @@ dependencies = [
 name = "query-core"
 version = "0.1.0"
 dependencies = [
- "async-std",
  "async-trait",
  "chrono",
  "crossbeam-queue",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1903,6 +1903,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-attributes",
+ "tracing-futures",
  "tracing-log",
  "tracing-subscriber",
  "url 2.1.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1883,6 +1883,7 @@ dependencies = [
  "migration-connector",
  "migration-core",
  "once_cell",
+ "pretty_assertions",
  "prisma-inflector",
  "prisma-models",
  "quaint",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,7 +435,6 @@ dependencies = [
  "pest_derive_tmp",
  "pest_tmp",
  "pretty_assertions",
- "prisma-inflector",
  "prisma-value",
  "serde",
  "serde_json",

--- a/libs/datamodel/core/Cargo.toml
+++ b/libs/datamodel/core/Cargo.toml
@@ -16,7 +16,6 @@ chrono = { version = "0.4.6", features = ["serde"] }
 serde = { version = "1.0.90", features = ["derive"] }
 serde_json ={version =  "1.0" ,features = ["preserve_order"]}
 failure = { version = "0.1", features = ["derive"] }
-bytecount = "0.5"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 cuid = { git = "https://github.com/prisma/cuid-rust" }
 

--- a/libs/datamodel/core/Cargo.toml
+++ b/libs/datamodel/core/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Emanuel Joebstl <emanuel.joebstl@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-prisma-inflector = { path = "../../prisma-inflector" }
 prisma-value = { path = "../../prisma-value" }
 datamodel-connector = { path = "../connectors/datamodel-connector" }
 # Temporary until PR is accepted.

--- a/libs/datamodel/core/src/validator/standardise.rs
+++ b/libs/datamodel/core/src/validator/standardise.rs
@@ -3,7 +3,6 @@ use crate::{
     ast, common::names::*, dml, dml::WithDatabaseName, error::ErrorCollection, DataSourceField, FieldArity,
     OnDeleteStrategy,
 };
-use prisma_inflector;
 
 /// Helper for standardsing a datamodel.
 ///
@@ -172,18 +171,15 @@ impl Standardiser {
                         on_delete: OnDeleteStrategy::None,
                     };
 
-                    let (arity, field_name) = if field.arity.is_singular() {
-                        (
-                            dml::FieldArity::List,
-                            prisma_inflector::classical().pluralize(&model.name).camel_case(),
-                        )
+                    let arity = if field.arity.is_singular() {
+                        dml::FieldArity::List
                     } else {
-                        (dml::FieldArity::Optional, model.name.camel_case())
+                        dml::FieldArity::Optional
                     };
 
                     result.push(AddMissingBackRelationField {
                         model: rel.to.clone(),
-                        field: field_name,
+                        field: model.name.camel_case(),
                         arity,
                         relation_info,
                         related_model: model.name.to_string(),

--- a/libs/datamodel/core/tests/directives/relations_consistency.rs
+++ b/libs/datamodel/core/tests/directives/relations_consistency.rs
@@ -55,7 +55,7 @@ fn must_add_back_relation_fields_for_given_singular_field() {
 
     let post_model = schema.assert_has_model("Post");
     post_model
-        .assert_has_field("users")
+        .assert_has_field("user")
         .assert_relation_to("User")
         .assert_relation_to_fields(&[])
         .assert_arity(&datamodel::dml::FieldArity::List);
@@ -471,7 +471,7 @@ fn must_add_back_relation_fields_for_self_relations() {
         .assert_relation_to_fields(&["id"]);
 
     model
-        .assert_has_field("humans")
+        .assert_has_field("human")
         .assert_relation_to("Human")
         .assert_arity(&FieldArity::List)
         .assert_relation_to_fields(&[]);

--- a/libs/prisma-value/Cargo.toml
+++ b/libs/prisma-value/Cargo.toml
@@ -13,7 +13,6 @@ serde_derive = "1.0"
 serde_json = "1.0"
 serde = "1.0"
 uuid = { version = "0.8", features = ["serde", "v4"] }
-cuid = { git = "https://github.com/prisma/cuid-rust" }
 chrono = { version = "0.4", features = ["serde"] }
 rust_decimal = "=1.1.0"
 quaint = { git = "https://github.com/prisma/quaint", optional = true, features = ["uuid-0_8", "array", "single-postgresql"] }

--- a/migration-engine/migration-engine-tests/tests/migrations/sql.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/sql.rs
@@ -307,8 +307,6 @@ async fn unique_constraints_on_composite_relation_fields(api: &TestApi) -> TestR
         model Child {
             id        Int    @id
             c         String
-            parent_id Int
-            parent    Parent @relation(name: "ChildParent", fields: [parent_id], references: [id])
 
             @@unique([id, c])
         }

--- a/query-engine/core/Cargo.toml
+++ b/query-engine/core/Cargo.toml
@@ -22,7 +22,6 @@ log = "0.4"
 petgraph = "0.4"
 im = "13.0"
 futures = "0.3"
-async-std = { version = "1", features = ["unstable"] }
 async-trait = "0.1"
 crossbeam-queue = "0.2"
 rust_decimal = "=1.1.0"

--- a/query-engine/prisma/Cargo.toml
+++ b/query-engine/prisma/Cargo.toml
@@ -42,8 +42,6 @@ tracing-attributes = "0.1"
 log = "0.4"
 
 user-facing-errors = { path = "../../libs/user-facing-errors" }
-pretty_assertions = "0.6.1"
-tracing-futures = "0.2.3"
 
 [build-dependencies]
 rustc_version = "0.2.3"

--- a/query-engine/prisma/Cargo.toml
+++ b/query-engine/prisma/Cargo.toml
@@ -42,7 +42,7 @@ tracing-attributes = "0.1"
 log = "0.4"
 
 user-facing-errors = { path = "../../libs/user-facing-errors" }
-
+pretty_assertions = "0.6.1"
 [build-dependencies]
 rustc_version = "0.2.3"
 

--- a/query-engine/prisma/Cargo.toml
+++ b/query-engine/prisma/Cargo.toml
@@ -43,6 +43,8 @@ log = "0.4"
 
 user-facing-errors = { path = "../../libs/user-facing-errors" }
 pretty_assertions = "0.6.1"
+tracing-futures = "0.2.3"
+
 [build-dependencies]
 rustc_version = "0.2.3"
 


### PR DESCRIPTION
Removes more unused dependencies. 
Also removes the prisma-inflector from datamodel since it should not be used anymore to align this with IE behavior.