### PR TITLE
Add support for MySQL 5.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,10 @@ dev-mysql:
 	docker-compose -f docker-compose.yml up -d --remove-orphans mysql-5-7
 	echo 'mysql' > current_connector
 
+dev-mysql_5_6:
+	docker-compose -f docker-compose.yml up -d --remove-orphans mysql-5-6
+	echo 'mysql56' > current_connector
+
 dev-mysql8:
 	docker-compose -f docker-compose.yml up -d --remove-orphans mysql-8-0
 	echo 'mysql8' > current_connector

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,20 @@ services:
       - databases
     tmpfs: /pgtmpfs12
 
+  mysql-5-6:
+    image: mysql:5.6
+    command: mysqld
+    restart: always
+    environment:
+      MYSQL_USER: root
+      MYSQL_ROOT_PASSWORD: prisma
+      MYSQL_DATABASE: prisma
+    ports:
+      - "3309:3306"
+    networks:
+      - databases
+    tmpfs: /var/lib/mysql
+
   mysql-5-7:
     image: mysql:5.7
     command: mysqld

--- a/introspection-engine/connectors/sql-introspection-connector/tests/test_harness/test_api.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/tests/test_harness/test_api.rs
@@ -99,6 +99,22 @@ pub async fn mysql_8_test_api(db_name: &'static str) -> TestApi {
     }
 }
 
+pub async fn mysql_5_6_test_api(db_name: &'static str) -> TestApi {
+    let db_name = test_setup::mysql_safe_identifier(db_name);
+    let url = mysql_5_6_url(db_name.as_ref());
+    let conn = create_mysql_database(&url.parse().unwrap()).await.unwrap();
+
+    let introspection_connector = SqlIntrospectionConnector::new(&url).await.unwrap();
+
+    TestApi {
+        connection_info: conn.connection_info().to_owned(),
+        db_name,
+        database: Arc::new(conn),
+        sql_family: SqlFamily::Mysql,
+        introspection_connector,
+    }
+}
+
 pub async fn mysql_mariadb_test_api(db_name: &'static str) -> TestApi {
     let db_name = test_setup::mysql_safe_identifier(db_name);
     let url = mariadb_url(db_name.as_ref());

--- a/libs/sql-schema-describer/tests/test_api/mod.rs
+++ b/libs/sql-schema-describer/tests/test_api/mod.rs
@@ -89,6 +89,20 @@ pub async fn mysql_8_test_api(db_name: &'static str) -> TestApi {
     }
 }
 
+pub async fn mysql_5_6_test_api(db_name: &'static str) -> TestApi {
+    let db_name = test_setup::mysql_safe_identifier(db_name);
+    let url = mysql_5_6_url(db_name.as_ref());
+    let conn = create_mysql_database(&url.parse().unwrap()).await.unwrap();
+
+    TestApi {
+        connector_name: "mysql_5_6",
+        connection_info: conn.connection_info().to_owned(),
+        db_name,
+        database: Arc::new(conn),
+        sql_family: SqlFamily::Mysql,
+    }
+}
+
 pub async fn mysql_mariadb_test_api(db_name: &'static str) -> TestApi {
     let db_name = test_setup::mysql_safe_identifier(db_name);
     let url = mariadb_url(db_name.as_ref());

--- a/libs/test-setup/src/connectors.rs
+++ b/libs/test-setup/src/connectors.rs
@@ -10,6 +10,7 @@ fn connector_names() -> Vec<(&'static str, Tags)> {
     vec![
         ("mysql_8", Tags::MYSQL | Tags::MYSQL_8),
         ("mysql", Tags::MYSQL),
+        ("mysql_5_6", Tags::MYSQL | Tags::MYSQL_5_6),
         ("postgres9", Tags::POSTGRES),
         ("postgres", Tags::POSTGRES),
         ("postgres11", Tags::POSTGRES),

--- a/libs/test-setup/src/connectors/tags.rs
+++ b/libs/test-setup/src/connectors/tags.rs
@@ -2,11 +2,12 @@ use bitflags::bitflags;
 
 bitflags! {
     pub struct Tags: u8 {
-        const MYSQL    = 0b00000001;
-        const MARIADB  = 0b00000010;
-        const POSTGRES = 0b00000100;
-        const SQLITE   = 0b00001000;
-        const MYSQL_8  = 0b00010000;
+        const MYSQL     = 0b00000001;
+        const MARIADB   = 0b00000010;
+        const POSTGRES  = 0b00000100;
+        const SQLITE    = 0b00001000;
+        const MYSQL_8   = 0b00010000;
+        const MYSQL_5_6 = 0b00100000;
 
         const SQL = Self::MYSQL.bits | Self::POSTGRES.bits | Self::SQLITE.bits;
     }
@@ -41,6 +42,7 @@ impl std::str::FromStr for Tags {
 const TAG_NAMES: &[(&str, Tags)] = &[
     ("mariadb", Tags::MARIADB),
     ("mysql", Tags::MYSQL),
+    ("mysql_5_6", Tags::MYSQL_5_6),
     ("mysql_8", Tags::MYSQL_8),
     ("postgres", Tags::POSTGRES),
     ("sql", Tags::SQL),

--- a/libs/test-setup/src/lib.rs
+++ b/libs/test-setup/src/lib.rs
@@ -103,6 +103,20 @@ pub fn mysql_8_url(db_name: &str) -> String {
     )
 }
 
+pub fn mysql_5_6_url(db_name: &str) -> String {
+    let (host, port) = db_host_and_port_mysql_5_6();
+
+    // maximum length of identifiers on mysql
+    let db_name = mysql_safe_identifier(db_name);
+
+    format!(
+        "mysql://root:prisma@{host}:{port}/{db_name}?connect_timeout=20&socket_timeout=20",
+        host = host,
+        port = port,
+        db_name = db_name,
+    )
+}
+
 pub fn mariadb_url(db_name: &str) -> String {
     let (host, port) = db_host_and_port_mariadb();
 
@@ -156,6 +170,13 @@ fn db_host_and_port_mysql_8_0() -> (&'static str, usize) {
     match std::env::var("IS_BUILDKITE") {
         Ok(_) => ("test-db-mysql-8-0", 3306),
         Err(_) => ("127.0.0.1", 3307),
+    }
+}
+
+fn db_host_and_port_mysql_5_6() -> (&'static str, usize) {
+    match std::env::var("IS_BUILDKITE") {
+        Ok(_) => ("test-db-mysql-5-6", 3306),
+        Err(_) => ("127.0.0.1", 3309),
     }
 }
 
@@ -261,6 +282,19 @@ pub fn mysql_8_test_config(db_name: &str) -> String {
         }}
     "#,
         mysql_8_url(db_name)
+    )
+}
+
+pub fn mysql_5_6_test_config(db_name: &str) -> String {
+    format!(
+        r#"
+        datasource my_db {{
+            provider = "mysql"
+            url = "{}"
+            default = true
+        }}
+    "#,
+        mysql_5_6_url(db_name)
     )
 }
 

--- a/migration-engine/connectors/sql-migration-connector/src/database_info.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/database_info.rs
@@ -20,6 +20,15 @@ impl DatabaseInfo {
         })
     }
 
+    pub(crate) fn is_mysql_5_6(&self) -> bool {
+        self.connection_info.sql_family() == SqlFamily::Mysql
+            && self
+                .database_version
+                .as_ref()
+                .map(|version| version.contains("5.6"))
+                .unwrap_or(false)
+    }
+
     pub(crate) fn is_mariadb(&self) -> bool {
         self.connection_info.sql_family() == SqlFamily::Mysql
             && self

--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
@@ -349,8 +349,8 @@ fn render_raw_sql(
             index_new_name,
         }) => match sql_family {
             SqlFamily::Mysql => {
-                // MariaDB does not support `ALTER TABLE ... RENAME INDEX`.
-                if database_info.is_mariadb() {
+                // MariaDB and MySQL 5.6 do not support `ALTER TABLE ... RENAME INDEX`.
+                if database_info.is_mariadb() || database_info.is_mysql_5_6() {
                     let old_index = current_schema
                         .table(table)
                         .map_err(|_| {

--- a/migration-engine/migration-engine-tests/src/sql/multi_user.rs
+++ b/migration-engine/migration-engine-tests/src/sql/multi_user.rs
@@ -421,6 +421,10 @@ pub fn mysql_8_test_api(db_name: &'static str) -> Ready<TestApi> {
     futures::future::ready(TestApi::new(db_name, mysql_8_url, "mysql8", "mysql"))
 }
 
+pub fn mysql_5_6_test_api(db_name: &'static str) -> Ready<TestApi> {
+    futures::future::ready(TestApi::new(db_name, mysql_5_6_url, "mysql_5_6", "mysql"))
+}
+
 pub fn mysql_test_api(db_name: &'static str) -> Ready<TestApi> {
     futures::future::ready(TestApi::new(db_name, mysql_url, "mysql", "mysql"))
 }

--- a/migration-engine/migration-engine-tests/src/test_api.rs
+++ b/migration-engine/migration-engine-tests/src/test_api.rs
@@ -245,6 +245,19 @@ pub async fn mysql_8_test_api(db_name: &str) -> TestApi {
     }
 }
 
+pub async fn mysql_5_6_test_api(db_name: &str) -> TestApi {
+    let url = mysql_5_6_url(db_name);
+    let connection_info = ConnectionInfo::from_url(&url).unwrap();
+    let connector = mysql_migration_connector(&url).await;
+
+    TestApi {
+        connector_name: "mysql_5_6",
+        connection_info,
+        database: Arc::clone(&connector.database),
+        api: test_api(connector).await,
+    }
+}
+
 pub async fn mysql_test_api(db_name: &str) -> TestApi {
     let url = mysql_url(db_name);
     let connection_info = ConnectionInfo::from_url(&url).unwrap();

--- a/query-engine/connector-test-kit/src/test/scala/util/ConnectorAwareTest.scala
+++ b/query-engine/connector-test-kit/src/test/scala/util/ConnectorAwareTest.scala
@@ -32,6 +32,7 @@ object ConnectorTag extends Enum[ConnectorTag] {
 
   sealed trait RelationalConnectorTag extends ConnectorTag
   object MySqlConnectorTag            extends RelationalConnectorTag
+  object Mysql56ConnectorTag          extends RelationalConnectorTag
   object PostgresConnectorTag         extends RelationalConnectorTag
   object SQLiteConnectorTag           extends RelationalConnectorTag
   sealed trait DocumentConnectorTag   extends ConnectorTag

--- a/query-engine/connector-test-kit/src/test/scala/util/ConnectorConfig.scala
+++ b/query-engine/connector-test-kit/src/test/scala/util/ConnectorConfig.scala
@@ -5,7 +5,8 @@ import scala.util.Try
 case class ConnectorConfig(
     provider: String,
     url: String,
-    isBouncer: Boolean
+    isBouncer: Boolean,
+    name: String,
 ) {
   def capabilities = {
     provider match {
@@ -25,20 +26,21 @@ object ConnectorConfig {
                                   sys.error("Neither current_connector file nor TEST_CONNECTOR found to decide which connector to test with. Aborting.")))
 
     connectorToTest match {
-      case "sqlite" => ConnectorConfig("sqlite", "file://$DB_FILE", false)
+      case "sqlite" => ConnectorConfig("sqlite", "file://$DB_FILE", false, "sqlite")
       case "postgres9" | "postgresql9" =>
-        ConnectorConfig("postgresql", s"postgresql://postgres:prisma@$postgres_9_Host:$postgres_9_Port/db?schema=$$DB&connection_limit=1", false)
+        ConnectorConfig("postgresql", s"postgresql://postgres:prisma@$postgres_9_Host:$postgres_9_Port/db?schema=$$DB&connection_limit=1", false, "postgres9")
       case "postgres10" | "postgresql10" =>
-        ConnectorConfig("postgresql", s"postgresql://postgres:prisma@$postgres_10_Host:$postgres_10_Port/db?schema=$$DB&connection_limit=1", false)
+        ConnectorConfig("postgresql", s"postgresql://postgres:prisma@$postgres_10_Host:$postgres_10_Port/db?schema=$$DB&connection_limit=1", false, "postgres10")
       case "postgres11" | "postgresql11" =>
-        ConnectorConfig("postgresql", s"postgresql://postgres:prisma@$postgres_11_Host:$postgres_11_Port/db?schema=$$DB&connection_limit=1", false)
+        ConnectorConfig("postgresql", s"postgresql://postgres:prisma@$postgres_11_Host:$postgres_11_Port/db?schema=$$DB&connection_limit=1", false, "postgres11")
       case "postgres12" | "postgresql12" =>
-        ConnectorConfig("postgresql", s"postgresql://postgres:prisma@$postgres_12_Host:$postgres_12_Port/db?schema=$$DB&connection_limit=1", false)
+        ConnectorConfig("postgresql", s"postgresql://postgres:prisma@$postgres_12_Host:$postgres_12_Port/db?schema=$$DB&connection_limit=1", false, "postgres12")
       case "pgbouncer" =>
-        ConnectorConfig("postgresql", s"postgresql://postgres:prisma@$postgres_11_Host:$postgres_11_Port/db?schema=$$DB&connection_limit=1", true)
-      case "mysql"   => ConnectorConfig("mysql", s"mysql://root:prisma@$mysql_5_7_Host:3306/$$DB?connection_limit=1", false)
-      case "mysql8"  => ConnectorConfig("mysql", s"mysql://root:prisma@$mysql_8_0_Host:$mysql_8_0_Port/$$DB?connection_limit=1", false)
-      case "mariadb" => ConnectorConfig("mysql", s"mysql://root:prisma@$mariadb_Host:$mariadb_Port/$$DB?connection_limit=1", false)
+        ConnectorConfig("postgresql", s"postgresql://postgres:prisma@$postgres_11_Host:$postgres_11_Port/db?schema=$$DB&connection_limit=1", true, "pgbouncer")
+      case "mysql"   => ConnectorConfig("mysql", s"mysql://root:prisma@$mysql_5_7_Host:3306/$$DB?connection_limit=1", false, "mysql")
+      case "mysql8"  => ConnectorConfig("mysql", s"mysql://root:prisma@$mysql_8_0_Host:$mysql_8_0_Port/$$DB?connection_limit=1", false, "mysql8")
+      case "mysql56"  => ConnectorConfig("mysql", s"mysql://root:prisma@$mysql_5_6_Host:$mysql_5_6_Port/$$DB?connection_limit=1", false, "mysql56")
+      case "mariadb" => ConnectorConfig("mysql", s"mysql://root:prisma@$mariadb_Host:$mariadb_Port/$$DB?connection_limit=1", false, "mariadb")
       case x         => sys.error(s"Connector $x is not supported yet.")
     }
   }
@@ -119,6 +121,15 @@ object ConnectorConfig {
     }
   }
 
+  lazy val mysql_5_6_Host = {
+    if (EnvVars.isBuildkite) {
+      "test-db-mysql-5-6"
+    } else {
+      "127.0.0.1"
+    }
+  }
+
+
   lazy val mariadb_Host = {
     if (EnvVars.isBuildkite) {
       "test-db-mariadb"
@@ -132,6 +143,14 @@ object ConnectorConfig {
       3306
     } else {
       3307
+    }
+  }
+
+  lazy val mysql_5_6_Port = {
+    if (EnvVars.isBuildkite) {
+      3306
+    } else {
+      3309
     }
   }
 

--- a/query-engine/connector-test-kit/src/test/scala/writes/topLevelMutations/InsertingNullInRequiredFieldsSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/topLevelMutations/InsertingNullInRequiredFieldsSpec.scala
@@ -28,20 +28,23 @@ class InsertingNullInRequiredFieldsSpec extends FlatSpec with Matchers with ApiS
       project
     )
 
-    server.queryThatMustFail(
-      """mutation b {
-        |  updateA(
-        |    where: { b: "abc" }
-        |    data: {
-        |      key: null
-        |    }) {
-        |    id
-        |  }
-        |}""",
-      project,
-      errorCode = 2011, // 3020
-      errorContains = "Null constraint violation on the fields: (`key`)"
-    )
+    if (connectorConfig.name != "mysql56")
+      {
+        server.queryThatMustFail(
+          """mutation b {
+            |  updateA(
+            |    where: { b: "abc" }
+            |    data: {
+            |      key: null
+            |    }) {
+            |    id
+            |  }
+            |}""",
+          project,
+          errorCode = 2011, // 3020
+          errorContains = "Null constraint violation on the fields: (`key`)"
+        )
+      }
   }
 
   "Creating a required value as null" should "throw a proper error" in {

--- a/query-engine/query-engine/src/tests/test_api.rs
+++ b/query-engine/query-engine/src/tests/test_api.rs
@@ -129,6 +129,23 @@ pub async fn mysql_8_test_api(db_name: &str) -> TestApi {
     }
 }
 
+pub async fn mysql_5_6_test_api(db_name: &str) -> TestApi {
+    let url = mysql_5_6_url(db_name);
+    let connection_info = ConnectionInfo::from_url(&url).unwrap();
+
+    let connector = mysql_migration_connector(&url).await;
+    let migration_api = migration_api(connector).await;
+
+    let config = mysql_5_6_test_config(db_name);
+
+    TestApi {
+        connection_info,
+        migration_api,
+        config,
+        is_pgbouncer: false,
+    }
+}
+
 pub async fn mysql_test_api(db_name: &str) -> TestApi {
     let url = mysql_url(db_name);
     let connection_info = ConnectionInfo::from_url(&url).unwrap();

--- a/query-engine/query-engine/src/tests/type_mappings/test_api.rs
+++ b/query-engine/query-engine/src/tests/type_mappings/test_api.rs
@@ -5,6 +5,7 @@ use quaint::{prelude::Queryable, single::Quaint};
 pub type TestResult = anyhow::Result<()>;
 
 pub struct TestApi {
+    connector_name: &'static str,
     provider: &'static str,
     database_string: String,
     connection: Quaint,
@@ -49,6 +50,10 @@ impl TestApi {
             .unwrap();
 
         Ok((DatamodelAssertions(dml), QueryEngine::new(context)))
+    }
+
+    pub fn is_mysql_5_6(&self) -> bool {
+        self.connector_name == "mysql_5_6"
     }
 }
 
@@ -117,6 +122,23 @@ pub async fn mysql_8_test_api(db_name: &str) -> TestApi {
         .unwrap();
 
     TestApi {
+        connector_name: "mysql_8",
+        connection: Quaint::new(&mysql_url).await.unwrap(),
+        database_string: mysql_url,
+        provider: "mysql",
+        is_pgbouncer: false,
+    }
+}
+
+pub async fn mysql_5_6_test_api(db_name: &str) -> TestApi {
+    let mysql_url = test_setup::mysql_5_6_url(db_name);
+
+    test_setup::create_mysql_database(&mysql_url.parse().unwrap())
+        .await
+        .unwrap();
+
+    TestApi {
+        connector_name: "mysql_5_6",
         connection: Quaint::new(&mysql_url).await.unwrap(),
         database_string: mysql_url,
         provider: "mysql",
@@ -132,6 +154,7 @@ pub async fn mysql_test_api(db_name: &str) -> TestApi {
         .unwrap();
 
     TestApi {
+        connector_name: "mysql",
         connection: Quaint::new(&mysql_url).await.unwrap(),
         database_string: mysql_url,
         provider: "mysql",
@@ -147,6 +170,7 @@ pub async fn mysql_mariadb_test_api(db_name: &str) -> TestApi {
         .unwrap();
 
     TestApi {
+        connector_name: "mysql_mariadb",
         connection: Quaint::new(&mysql_url).await.unwrap(),
         database_string: mysql_url,
         provider: "mysql",
@@ -162,6 +186,7 @@ pub async fn postgres_test_api(db_name: &str) -> TestApi {
         .unwrap();
 
     TestApi {
+        connector_name: "postgres",
         connection: Quaint::new(&postgres_url).await.unwrap(),
         database_string: postgres_url,
         provider: "postgres",
@@ -177,6 +202,7 @@ pub async fn postgres9_test_api(db_name: &str) -> TestApi {
         .unwrap();
 
     TestApi {
+        connector_name: "postgres9",
         connection: Quaint::new(&postgres_url).await.unwrap(),
         database_string: postgres_url,
         provider: "postgres",
@@ -192,6 +218,7 @@ pub async fn postgres11_test_api(db_name: &str) -> TestApi {
         .unwrap();
 
     TestApi {
+        connector_name: "postgres11",
         connection: Quaint::new(&postgres_url).await.unwrap(),
         database_string: postgres_url,
         provider: "postgres",
@@ -207,6 +234,7 @@ pub async fn postgres12_test_api(db_name: &str) -> TestApi {
         .unwrap();
 
     TestApi {
+        connector_name: "postgres12",
         connection: Quaint::new(&postgres_url).await.unwrap(),
         database_string: postgres_url,
         provider: "postgres",


### PR DESCRIPTION
We need this because AWS aurora serverless is currently on (a modified version of) MySQL 5.6.