### PR TITLE
Drop the foreign keys of dropped tables separately

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/sql_migration.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_migration.rs
@@ -86,8 +86,6 @@ pub enum TableChange {
     AddColumn(AddColumn),
     AlterColumn(AlterColumn),
     DropColumn(DropColumn),
-    /// This is actually producing SQL only on MySQL, where we have to drop the foreign key
-    /// constraint before any column that is part of it.
     DropForeignKey(DropForeignKey),
 }
 

--- a/migration-engine/migration-engine-tests/src/assertions.rs
+++ b/migration-engine/migration-engine-tests/src/assertions.rs
@@ -78,6 +78,20 @@ impl SchemaAssertion {
         Ok(self)
     }
 
+    pub fn assert_tables_count(self, expected_count: usize) -> AssertionResult<Self> {
+        let actual_count = self.0.tables.len();
+
+        anyhow::ensure!(
+            actual_count == expected_count,
+            "Assertion failed. Expected the schema to have {expected_count} tables, found {actual_count}. ({table_names:?})",
+            expected_count = expected_count,
+            actual_count = actual_count,
+            table_names = self.0.tables.iter().map(|t| t.name.as_str()).collect::<Vec<&str>>(),
+        );
+
+        Ok(self)
+    }
+
     pub fn debug_print(self) -> Self {
         dbg!(&self.0);
 


### PR DESCRIPTION
Cyclic foreign key dependencies would error when dropping the table at
either end of the foreign key. Since we run `ALTER TABLE`s before `DROP
TABLE`s, we drop the foreign keys in and to dropped tables before
dropping the tables, which should solve the problem.

SQLite is a special case because it does not have a way to drop foreign
keys separately from the table. We disable foreign key checks and rely
on the schema to forbid relations pointing to non-existent tables.

addresses https://github.com/prisma/migrate/issues/102