### PR TITLE
Improve reporting of datamodel errors in migration engine

### DIFF
--- a/libs/datamodel/core/src/error/collection.rs
+++ b/libs/datamodel/core/src/error/collection.rs
@@ -62,7 +62,11 @@ impl ErrorCollection {
 
 impl std::fmt::Display for ErrorCollection {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{:?}", self.errors)
+        for error in &self.errors {
+            writeln!(f, "{} (span: {:?})", error, error.span())?;
+        }
+
+        Ok(())
     }
 }
 

--- a/migration-engine/connectors/migration-connector/src/migration_persistence.rs
+++ b/migration-engine/connectors/migration-connector/src/migration_persistence.rs
@@ -12,16 +12,6 @@ pub trait MigrationPersistence: Send + Sync {
     /// Drop all persisted state.
     async fn reset(&self) -> Result<(), ConnectorError>;
 
-    async fn current_datamodel_ast(&self) -> Result<SchemaAst, ConnectorError> {
-        let ast = self
-            .last()
-            .await?
-            .and_then(|m| datamodel::ast::parser::parse(&m.datamodel_string).ok())
-            .unwrap_or_else(SchemaAst::empty);
-
-        Ok(ast)
-    }
-
     async fn last_non_watch_applied_migration(&self) -> Result<Option<Migration>, ConnectorError> {
         let migration =
             self.load_all().await?.into_iter().rev().find(|migration| {
@@ -261,9 +251,5 @@ impl MigrationPersistence for EmptyMigrationPersistence {
 
     async fn update(&self, _params: &MigrationUpdateParams) -> Result<(), ConnectorError> {
         unimplemented!("Not allowed on a EmptyMigrationPersistence")
-    }
-
-    async fn current_datamodel_ast(&self) -> Result<datamodel::ast::SchemaAst, ConnectorError> {
-        Ok(datamodel::ast::SchemaAst { tops: Vec::new() })
     }
 }

--- a/migration-engine/core/src/commands/infer_migration_steps.rs
+++ b/migration-engine/core/src/commands/infer_migration_steps.rs
@@ -48,7 +48,9 @@ impl<'a> MigrationCommand for InferMigrationStepsCommand<'a> {
             datamodel::lift_ast(&assumed_datamodel_ast).map_err(CommandError::ProducedBadDatamodel)?;
 
         let next_datamodel = parse_datamodel(&cmd.input.datamodel)?;
-        let next_datamodel_ast = parse(&cmd.input.datamodel).map_err(CommandError::ProducedBadDatamodel)?;
+        let next_datamodel_ast = parse(&cmd.input.datamodel).map_err(|err| {
+            CommandError::Input(anyhow::anyhow!("{}", err.to_pretty_string("", &cmd.input.datamodel)))
+        })?;
 
         let model_migration_steps = engine
             .datamodel_migration_steps_inferrer()

--- a/migration-engine/migration-engine-tests/tests/infer_migration_steps_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/infer_migration_steps_tests.rs
@@ -1,5 +1,3 @@
-#![allow(non_snake_case)]
-
 use migration_core::commands::AppliedMigration;
 use migration_engine_tests::sql::*;
 use pretty_assertions::assert_eq;


### PR DESCRIPTION
- For "synthetic" schemas created by the ME applying migrations to the AST
- For saved schemas that became invalid because of breaking changes