### PR TITLE
Fix migrations crash with mysql enums on remapped tables

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
@@ -372,7 +372,7 @@ fn enum_column_type(field: &FieldRef<'_>, database_info: &DatabaseInfo, db_name:
     match database_info.sql_family() {
         SqlFamily::Postgres => sql::ColumnType::pure(sql::ColumnTypeFamily::Enum(db_name.to_owned()), arity),
         SqlFamily::Mysql => sql::ColumnType::pure(
-            sql::ColumnTypeFamily::Enum(format!("{}_{}", field.model().name(), field.name())),
+            sql::ColumnTypeFamily::Enum(format!("{}_{}", field.model().db_name(), field.db_name())),
             arity,
         ),
         _ => column_type(field),

--- a/migration-engine/migration-engine-tests/tests/migrations/mysql.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/mysql.rs
@@ -72,3 +72,25 @@ async fn enum_creation_is_idempotent(api: &TestApi) -> TestResult {
 
     Ok(())
 }
+
+#[test_each_connector(tags("mysql"))]
+async fn enums_work_when_table_name_is_remapped(api: &TestApi) -> TestResult {
+    let schema = r#"
+    model User {
+        id         String     @default(uuid()) @id
+        status     UserStatus @map("currentStatus___")
+
+        @@map("users")
+    }
+
+    enum UserStatus {
+        CONFIRMED
+        CANCELED
+        BLOCKED
+    }
+    "#;
+
+    api.infer_apply(schema).send().await?.assert_green()?;
+
+    Ok(())
+}


### PR DESCRIPTION
The enum name did not match in the two places it is in the
sql-schema-describer schema because one used the table name, the other
the model name.

addresses https://github.com/prisma/migrate/issues/410