### PR TITLE
WIP: Nullable input

### DIFF
--- a/query-engine/core/src/schema/query_schema.rs
+++ b/query-engine/core/src/schema/query_schema.rs
@@ -293,6 +293,7 @@ pub enum InputType {
     List(Box<InputType>),
     Object(InputObjectTypeRef),
     Opt(Box<InputType>),
+    Null(Box<InputType>),
     Scalar(ScalarType),
 }
 
@@ -303,6 +304,10 @@ impl InputType {
 
     pub fn opt(containing: InputType) -> InputType {
         InputType::Opt(Box::new(containing))
+    }
+
+    pub fn null(containing: InputType) -> InputType {
+        InputType::Null(Box::new(containing))
     }
 
     pub fn object(containing: InputObjectTypeRef) -> InputType {

--- a/query-engine/core/src/schema_builder/input_type_builder/input_builder_extensions.rs
+++ b/query-engine/core/src/schema_builder/input_type_builder/input_builder_extensions.rs
@@ -7,7 +7,7 @@ pub trait InputBuilderExtensions {
     }
 
     fn map_required_input_type(&self, field: &ScalarFieldRef) -> InputType {
-        let typ = match field.type_identifier {
+        let mut typ = match field.type_identifier {
             TypeIdentifier::String => InputType::string(),
             TypeIdentifier::Int => InputType::int(),
             TypeIdentifier::Float => InputType::float(),
@@ -19,10 +19,13 @@ pub trait InputBuilderExtensions {
         };
 
         if field.is_list {
-            InputType::list(typ)
-        } else {
-            typ
+            typ = InputType::list(typ)
+        } 
+        if !field.is_required {
+            typ = InputType::null(typ)
         }
+
+        typ
     }
 
     fn map_enum_input_type(&self, field: &ScalarFieldRef) -> InputType {

--- a/query-engine/query-engine/src/dmmf/schema/ast.rs
+++ b/query-engine/query-engine/src/dmmf/schema/ast.rs
@@ -65,6 +65,7 @@ pub struct DMMFTypeInfo {
     pub typ: String,
     pub kind: TypeKind,
     pub is_required: bool,
+    pub is_nullable: bool,
     pub is_list: bool,
 }
 

--- a/query-engine/query-engine/src/dmmf/schema/type_renderer.rs
+++ b/query-engine/query-engine/src/dmmf/schema/type_renderer.rs
@@ -24,6 +24,7 @@ impl<'a> DMMFTypeRenderer<'a> {
                     typ: obj.into_arc().name.clone(),
                     kind: TypeKind::Object,
                     is_required: true,
+                    is_nullable: false,
                     is_list: false,
                 };
 
@@ -35,6 +36,7 @@ impl<'a> DMMFTypeRenderer<'a> {
                     typ: et.name().to_owned(),
                     kind: TypeKind::Enum,
                     is_required: true,
+                    is_nullable: false,
                     is_list: false,
                 };
 
@@ -52,12 +54,20 @@ impl<'a> DMMFTypeRenderer<'a> {
 
                 type_info
             }
+            InputType::Null(ref null) => {
+                let mut type_info = self.render_input_type(null, ctx);
+                type_info.is_required = false;
+                type_info.is_nullable = true;
+
+                type_info
+            }
             InputType::Scalar(ScalarType::Enum(et)) => {
                 et.into_renderer().render(ctx);
                 let type_info = DMMFTypeInfo {
                     typ: et.name().to_owned(),
                     kind: TypeKind::Scalar,
                     is_required: true,
+                    is_nullable: false,
                     is_list: false,
                 };
 
@@ -80,6 +90,7 @@ impl<'a> DMMFTypeRenderer<'a> {
                     typ: stringified.into(),
                     kind: TypeKind::Scalar,
                     is_required: true,
+                    is_nullable: false,
                     is_list: false,
                 };
 
@@ -97,6 +108,7 @@ impl<'a> DMMFTypeRenderer<'a> {
                     typ: obj.into_arc().name().to_string(),
                     kind: TypeKind::Object,
                     is_required: true,
+                    is_nullable: false,
                     is_list: false,
                 };
 
@@ -108,6 +120,7 @@ impl<'a> DMMFTypeRenderer<'a> {
                     typ: et.name().to_owned(),
                     kind: TypeKind::Enum,
                     is_required: true,
+                    is_nullable: false,
                     is_list: false,
                 };
 
@@ -131,6 +144,7 @@ impl<'a> DMMFTypeRenderer<'a> {
                     typ: et.name().to_owned(),
                     kind: TypeKind::Scalar,
                     is_required: true,
+                    is_nullable: false,
                     is_list: false,
                 };
 
@@ -153,6 +167,7 @@ impl<'a> DMMFTypeRenderer<'a> {
                     typ: stringified.into(),
                     kind: TypeKind::Scalar,
                     is_required: true,
+                    is_nullable: false,
                     is_list: false,
                 };
 

--- a/query-engine/query-engine/src/request_handlers/graphql/schema_renderer/type_renderer.rs
+++ b/query-engine/query-engine/src/request_handlers/graphql/schema_renderer/type_renderer.rs
@@ -41,6 +41,10 @@ impl<'a> GqlTypeRenderer<'a> {
                 let (substring, subctx) = self.render_input_type(opt, ctx);
                 (substring.trim_end_matches('!').to_owned(), subctx)
             }
+            InputType::Null(ref null) => {
+                let (substring, subctx) = self.render_input_type(null, ctx);
+                (substring.trim_end_matches('!').to_owned(), subctx)
+            }
             InputType::Scalar(ScalarType::Enum(et)) => {
                 let (_, subctx) = et.into_renderer().render(ctx);
                 (format!("{}!", et.name()), subctx)


### PR DESCRIPTION
This a PoC to add a new `isNullable` field to the InputType. Is is required by clients to properly generate typing when Optional is not enough (null vs undefined).
This relates to https://github.com/prisma/prisma/issues/2248