### PR TITLE
Implement compiling and running a subset of tests via env var

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2749,6 +2749,7 @@ name = "test-macros"
 version = "0.1.0"
 dependencies = [
  "darling",
+ "once_cell",
  "proc-macro2 1.0.10",
  "quote 1.0.3",
  "syn 1.0.17",

--- a/libs/test-macros/Cargo.toml
+++ b/libs/test-macros/Cargo.toml
@@ -15,3 +15,4 @@ syn = "1.0.5"
 quote = "1.0.2"
 proc-macro2 = "1.0.6"
 test-setup = { path = "../test-setup" }
+once_cell = "1.3.1"

--- a/libs/test-macros/src/lib.rs
+++ b/libs/test-macros/src/lib.rs
@@ -18,7 +18,9 @@ fn function_returns_result(func: &ItemFn) -> bool {
     }
 }
 
-/// We do this because Intellij only recognizes functions annotated with #[test] *before* macro expansion as tests. This way we can add it manually, and the test macro will strip it.
+/// We do this because Intellij only recognizes functions annotated with #[test]
+/// *before* macro expansion as tests. This way we can add it manually, and the
+/// test macro will strip it.
 fn strip_test_attribute(function: &mut ItemFn) {
     let new_attrs = function
         .attrs

--- a/libs/test-setup/src/connectors/tags.rs
+++ b/libs/test-setup/src/connectors/tags.rs
@@ -1,4 +1,5 @@
 use bitflags::bitflags;
+use std::{error::Error as StdError, str::FromStr};
 
 bitflags! {
     pub struct Tags: u8 {
@@ -23,9 +24,9 @@ impl std::fmt::Display for UnknownTagError {
     }
 }
 
-impl std::error::Error for UnknownTagError {}
+impl StdError for UnknownTagError {}
 
-impl std::str::FromStr for Tags {
+impl FromStr for Tags {
     type Err = UnknownTagError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {


### PR DESCRIPTION
Since we are going to add more connectors, running only for a specific connector or a subset is going to be useful for speed of iteration on dev machines and to potentially split up and parallelize test runs in CI. This is a quick implementation of generating tests only for certain tags via env var, to be able to run things on my laptop. It helps a bit.