### PR TITLE
Disallow nulls from resolving relations.

### DIFF
--- a/query-engine/connector-test-kit/src/test/scala/queries/RelatedNullQueries.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/RelatedNullQueries.scala
@@ -1,0 +1,166 @@
+package queries
+
+import org.scalatest.{FlatSpec, Matchers}
+import util.{ApiSpecBase, ProjectDsl}
+
+class RelatedNullQueries extends FlatSpec with Matchers with ApiSpecBase {
+  "Querying a single-field 1:n relation with nulls" should "ignore related records connected with null" in {
+    val project = ProjectDsl.fromString {
+      s"""
+         |model ModelA {
+         |  id String   @id @default(uuid())
+         |  u  String?  @unique
+         |  bs ModelB[]
+         |}
+         |
+         |model ModelB {
+         |  id  String  @id @default(uuid())
+         |  a_u String?
+         |  a   ModelA? @relation(fields: [a_u], references: [u])
+         |}
+       """.stripMargin
+    }
+    database.setup(project)
+
+    val result = server.query(
+      """
+        |mutation {
+        |  createModelA(data: { id: "1", bs: { create: {} } }){
+        |    id
+        |    bs {
+        |      id
+        |    }
+        |  }
+        |}
+      """.stripMargin,
+      project
+    )
+
+    result.toString should be("{\"data\":{\"createModelA\":{\"id\":\"1\",\"bs\":[]}}}")
+  }
+
+  "Querying a multi-field 1:n relation with nulls" should "ignore related records connected with any null in the relation fields" in {
+    val project = ProjectDsl.fromString {
+      s"""
+         |model ModelA {
+         |  id String   @id @default(uuid())
+         |  u1 String?
+         |  u2 String?
+         |  bs ModelB[]
+         |
+         |  @@unique([u1, u2])
+         |}
+         |
+         |model ModelB {
+         |  id   String  @id @default(uuid())
+         |  a_u1 String?
+         |  a_u2 String?
+         |  a    ModelA? @relation(fields: [a_u1, a_u2], references: [u1, u2])
+         |}
+       """.stripMargin
+    }
+    database.setup(project)
+
+    val result = server.query(
+      """
+        |mutation {
+        |  createModelA(data: { id: "1", bs: { create: { } } }){
+        |    id
+        |    bs {
+        |      id
+        |    }
+        |  }
+        |}
+      """.stripMargin,
+      project
+    )
+
+    result.toString should be("{\"data\":{\"createModelA\":{\"id\":\"1\",\"bs\":[]}}}")
+
+    val result2 = server.query(
+      """
+        |mutation {
+        |  createModelA(data: { id: "2", u1: "u1", bs: { create: { } } }){
+        |    id
+        |    bs {
+        |      id
+        |    }
+        |  }
+        |}
+      """.stripMargin,
+      project
+    )
+
+    result2.toString should be("{\"data\":{\"createModelA\":{\"id\":\"2\",\"bs\":[]}}}")
+  }
+
+  "Querying a single-field 1:1 relation inlined on the child with null" should "not find a related record" in {
+    val project = ProjectDsl.fromString {
+      s"""
+         |model ModelA {
+         |  id String  @id @default(uuid())
+         |  u  String? @unique
+         |  b  ModelB?
+         |}
+         |
+         |model ModelB {
+         |  id  String  @id @default(uuid())
+         |  a_u String?
+         |  a   ModelA? @relation(fields: [a_u], references: [u])
+         |}
+       """.stripMargin
+    }
+    database.setup(project)
+
+    val result = server.query(
+      """
+        |mutation {
+        |  createModelA(data: { id: "1", b: { create: { } } }){
+        |    id
+        |    b {
+        |      id
+        |    }
+        |  }
+        |}
+      """.stripMargin,
+      project
+    )
+
+    result.toString should be("{\"data\":{\"createModelA\":{\"id\":\"1\",\"b\":null}}}")
+  }
+
+  "Querying a single-field 1:1 relation inlined on the parent with null" should "not find a related record" in {
+    val project = ProjectDsl.fromString {
+      s"""
+         |model ModelA {
+         |  id  String  @id @default(uuid())
+         |  b_u String?
+         |  b   ModelB? @relation(fields: [b_u], references: [u])
+         |}
+         |
+         |model ModelB {
+         |  id String  @id @default(uuid())
+         |  u  String? @unique
+         |  a  ModelA?
+         |}
+       """.stripMargin
+    }
+    database.setup(project)
+
+    val result = server.query(
+      """
+        |mutation {
+        |  createModelA(data: { id: "1", b: { create: { } } }){
+        |    id
+        |    b {
+        |      id
+        |    }
+        |  }
+        |}
+      """.stripMargin,
+      project
+    )
+
+    result.toString should be("{\"data\":{\"createModelA\":{\"id\":\"1\",\"b\":null}}}")
+  }
+}

--- a/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/alreadyConverted/NestedConnectMutationInsideCreateSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/alreadyConverted/NestedConnectMutationInsideCreateSpec.scala
@@ -400,6 +400,8 @@ class NestedConnectMutationInsideCreateSpec extends FlatSpec with Matchers with 
           """mutation {
             |  createParent(data: {
             |    p: "p1"
+            |    p_1: "p1_1"
+            |    p_2: "p1_2"
             |    childrenOpt: {
             |      create: [{c: "c1"}, {c: "c2"}]
             |    }
@@ -419,7 +421,9 @@ class NestedConnectMutationInsideCreateSpec extends FlatSpec with Matchers with 
            |mutation {
            |  createParent(data:{
            |    p: "p2"
-           |    childrenOpt: {connect: [{c: "c1"},{c: "c2"},{c: "c2"}]}
+           |    p_1: "p2_1"
+           |    p_2: "p2_2"
+           |    childrenOpt: {connect: [{c: "c1"}, {c: "c2"}, {c: "c2"}]}
            |  }){
            |    childrenOpt {
            |      c
@@ -461,6 +465,8 @@ class NestedConnectMutationInsideCreateSpec extends FlatSpec with Matchers with 
            |mutation {
            |  createParent(data:{
            |    p: "p2"
+           |    p_1: "p2_1"
+           |    p_2: "p2_2"
            |    childrenOpt: {connect: $child1Id}
            |  }){
            |    childrenOpt {
@@ -622,8 +628,14 @@ class NestedConnectMutationInsideCreateSpec extends FlatSpec with Matchers with 
         """mutation {
         |  createParent(data: {
         |    p: "p1"
+        |    p_1: "p1_1"
+        |    p_2: "p1_2"
         |    childOpt: {
-        |      create: {c: "c1"}
+        |      create: {
+        |        c: "c1"
+        |        c_1: "c1_1"
+        |        c_2: "c1_2"
+        |      }
         |    }
         |  }){
         |    childOpt{
@@ -639,6 +651,8 @@ class NestedConnectMutationInsideCreateSpec extends FlatSpec with Matchers with 
          |mutation {
          |  createParent(data:{
          |    p: "p2"
+         |    p_1: "p2_1"
+         |    p_2: "p2_2"
          |    childOpt: {connect: {c: "c1"}}
          |  }){
          |    childOpt{
@@ -666,7 +680,11 @@ class NestedConnectMutationInsideCreateSpec extends FlatSpec with Matchers with 
 
       server.query(
         """mutation {
-        |  createChild(data: {c: "c1"}){
+        |  createChild(data: {
+        |    c: "c1"
+        |    c_1: "c1_1"
+        |    c_2: "c1_2"
+        |  }){
         |       c
         |  }
         |}""".stripMargin,
@@ -678,6 +696,8 @@ class NestedConnectMutationInsideCreateSpec extends FlatSpec with Matchers with 
          |mutation {
          |  createParent(data:{
          |    p: "p2"
+         |    p_1: "p2_1"
+         |    p_2: "p2_2"
          |    childOpt: {connect: {c: "c1"}}
          |  }){
          |    childOpt {

--- a/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/alreadyConverted/NestedCreateMutationInsideCreateSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/alreadyConverted/NestedCreateMutationInsideCreateSpec.scala
@@ -58,6 +58,8 @@ class NestedCreateMutationInsideCreateSpec extends WordSpecLike with Matchers wi
             s"""mutation {
           |  createParent(data: {
           |    p: "p1"
+          |    p_1: "p_1"
+          |    p_2: "p_2"
           |    childReq: {
           |      create: {
           |        c: "c1"
@@ -90,6 +92,8 @@ class NestedCreateMutationInsideCreateSpec extends WordSpecLike with Matchers wi
           """mutation {
             |  createParent(data: {
             |    p: "p1"
+            |    p_1: "p_1"
+            |    p_2: "p_2"
             |    childOpt: {
             |      create: {
             |        c: "c1"
@@ -126,7 +130,15 @@ class NestedCreateMutationInsideCreateSpec extends WordSpecLike with Matchers wi
             |    p_1: "p_1"
             |    p_2: "p_2"
             |    childrenOpt: {
-            |      create: [{c: "c1"},{c:"c2"}]
+            |      create: [{
+            |        c: "c1"
+            |        c_1: "c_1"
+            |        c_2: "c_2"
+            |      },{
+            |        c:"c2"
+            |        c_1: "c2_1"
+            |        c_2: "c2_2"
+            |      }]
             |    }
             |  }){
             |   childrenOpt{
@@ -189,8 +201,18 @@ class NestedCreateMutationInsideCreateSpec extends WordSpecLike with Matchers wi
           """mutation {
             |  createParent(data: {
             |    p: "p1"
+            |    p_1: "p_1"
+            |    p_2: "p_2"
             |    childrenOpt: {
-            |      create: [{c: "c1"},{c: "c2"}]
+            |      create: [{
+            |        c: "c1"
+            |        c_1: "c_1"
+            |        c_2: "c_2"
+            |      },{
+            |        c:"c2"
+            |        c_1: "c2_1"
+            |        c_2: "c2_2"
+            |      }]
             |    }
             |  }){
             |   childrenOpt{
@@ -218,6 +240,8 @@ class NestedCreateMutationInsideCreateSpec extends WordSpecLike with Matchers wi
           """mutation {
             |  createParent(data: {
             |    p: "p1"
+            |    p_1: "p_1"
+            |    p_2: "p_2"
             |    childReq: {
             |      create: {
             |        c: "c1"
@@ -251,8 +275,14 @@ class NestedCreateMutationInsideCreateSpec extends WordSpecLike with Matchers wi
           """mutation {
             |  createParent(data: {
             |    p: "p1"
+            |    p_1: "p_1"
+            |    p_2: "p_2"
             |    childOpt: {
-            |      create: {c: "c1"}
+            |      create: {
+            |        c: "c1"
+            |        c_1: "c_1"
+            |        c_2: "c_2"
+            |      }
             |    }
             |  }){
             |   childOpt{
@@ -296,8 +326,18 @@ class NestedCreateMutationInsideCreateSpec extends WordSpecLike with Matchers wi
           """mutation {
             |  createParent(data: {
             |    p: "p1"
+            |    p_1: "p_1"
+            |    p_2: "p_2"
             |    childrenOpt: {
-            |      create: [{c: "c1"},{c:"c2"}]
+            |      create: [{
+            |        c: "c1"
+            |        c_1: "c_1"
+            |        c_2: "c_2"
+            |      },{
+            |        c:"c2"
+            |        c_1: "c2_1"
+            |        c_2: "c2_2"
+            |      }]
             |    }
             |  }){
             |   childrenOpt{
@@ -487,7 +527,7 @@ class NestedCreateMutationInsideCreateSpec extends WordSpecLike with Matchers wi
 
     val errorTarget = () match {
       case _ if connectorTag == ConnectorTag.MySqlConnectorTag => "constraint: `unique`"
-      case _ => "fields: (`unique`)"
+      case _                                                   => "fields: (`unique`)"
     }
 
     server.queryThatMustFail(
@@ -548,7 +588,7 @@ class NestedCreateMutationInsideCreateSpec extends WordSpecLike with Matchers wi
 
     val errorTarget = () match {
       case _ if connectorTag == ConnectorTag.MySqlConnectorTag => "constraint: `uniquePost`"
-      case _ => "fields: (`uniquePost`)"
+      case _                                                   => "fields: (`uniquePost`)"
     }
 
     server.queryThatMustFail(

--- a/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/alreadyConverted/NestedDeleteMutationInsideUpsertSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/alreadyConverted/NestedDeleteMutationInsideUpsertSpec.scala
@@ -18,7 +18,9 @@ class NestedDeleteMutationInsideUpsertSpec extends FlatSpec with Matchers with A
         .query(
           s"""mutation {
           |  createParent(data: {
-          |    p: "p1", p_1: "p", p_2: "1"
+          |    p: "p1"
+          |    p_1: "p_1"
+          |    p_2: "p_2"
           |    childReq: {
           |      create: {
           |        c: "c1"
@@ -56,7 +58,8 @@ class NestedDeleteMutationInsideUpsertSpec extends FlatSpec with Matchers with A
       """,
         project,
         errorCode = 2009,
-        errorContains = """↳ ChildUpdateOneRequiredWithoutParentReqInput (object)\n            ↳ delete (field)\n              ↳ Field does not exist on enclosing type."""
+        errorContains =
+          """↳ ChildUpdateOneRequiredWithoutParentReqInput (object)\n            ↳ delete (field)\n              ↳ Field does not exist on enclosing type."""
       )
     }
   }
@@ -111,7 +114,8 @@ class NestedDeleteMutationInsideUpsertSpec extends FlatSpec with Matchers with A
       """,
         project,
         errorCode = 2009,
-        errorContains = """↳ update (argument)\n      ↳ ParentUpdateInput (object)\n        ↳ childReq (field)\n          ↳ ChildUpdateOneRequiredWithoutParentOptInput (object)\n            ↳ delete (field)\n              ↳ Field does not exist on enclosing type."""
+        errorContains =
+          """↳ update (argument)\n      ↳ ParentUpdateInput (object)\n        ↳ childReq (field)\n          ↳ ChildUpdateOneRequiredWithoutParentOptInput (object)\n            ↳ delete (field)\n              ↳ Field does not exist on enclosing type."""
       )
 
     }
@@ -223,7 +227,8 @@ class NestedDeleteMutationInsideUpsertSpec extends FlatSpec with Matchers with A
       """,
         project,
         errorCode = 2016,
-        errorContains = """Query interpretation error. Error for binding '3': AssertionError(\"[Query Graph] Expected a valid parent ID to be present for a nested delete on a one-to-many relation."""
+        errorContains =
+          """Query interpretation error. Error for binding '3': AssertionError(\"[Query Graph] Expected a valid parent ID to be present for a nested delete on a one-to-many relation."""
         // errorContains = """[Query Graph] Expected a valid parent ID to be present for a nested delete on a one-to-many relation."""
       )
 
@@ -420,7 +425,8 @@ class NestedDeleteMutationInsideUpsertSpec extends FlatSpec with Matchers with A
       """,
         project,
         errorCode = 2009,
-        errorContains = """Mutation (object)\n  ↳ upsertParent (field)\n    ↳ update (argument)\n      ↳ ParentUpdateInput (object)\n        ↳ childReq (field)\n          ↳ ChildUpdateOneRequiredWithoutParentsOptInput (object)\n            ↳ delete (field)\n              ↳ Field does not exist on enclosing type."""
+        errorContains =
+          """Mutation (object)\n  ↳ upsertParent (field)\n    ↳ update (argument)\n      ↳ ParentUpdateInput (object)\n        ↳ childReq (field)\n          ↳ ChildUpdateOneRequiredWithoutParentsOptInput (object)\n            ↳ delete (field)\n              ↳ Field does not exist on enclosing type."""
       )
     }
   }
@@ -435,9 +441,15 @@ class NestedDeleteMutationInsideUpsertSpec extends FlatSpec with Matchers with A
       val parentResult = server.query(
         s"""mutation {
         |  createParent(data: {
-        |    p: "p1", p_1: "p", p_2: "1"
+        |    p: "p1",
+        |    p_1: "p_1"
+        |    p_2: "p_2"
         |    childOpt: {
-        |      create: {c: "c1"}
+        |      create: {
+        |        c: "c1"
+        |        c_1: "c_1"
+        |        c_2: "c_2"
+        |      }
         |    }
         |  }){
         |    ${t.parent.selection}
@@ -595,7 +607,8 @@ class NestedDeleteMutationInsideUpsertSpec extends FlatSpec with Matchers with A
       """,
       project,
       errorCode = 5588,
-      errorContains = """Error occurred during query execution:\nInterpretationError(\"Error for binding \\'6\\': RelationViolation(RelationViolation { relation_name: \\\"ChildToReqOther\\\", model_a_name: \\\"Child\\\", model_b_name: \\\"ReqOther\\\" })\")"""
+      errorContains =
+        """Error occurred during query execution:\nInterpretationError(\"Error for binding \\'6\\': RelationViolation(RelationViolation { relation_name: \\\"ChildToReqOther\\\", model_a_name: \\\"Child\\\", model_b_name: \\\"ReqOther\\\" })\")"""
     )
 
   }

--- a/query-engine/connector-test-kit/src/test/scala/writes/topLevelMutations/DeleteManyMutationRelationsSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/topLevelMutations/DeleteManyMutationRelationsSpec.scala
@@ -143,7 +143,7 @@ class DeleteManyMutationRelationsSpec extends FlatSpec with Matchers with ApiSpe
         s"""
          |mutation {
          |  deleteManyParents(
-         |  where: $parentId
+         |    where: $parentId
          |  ) {
          |    count
          |  }
@@ -170,6 +170,8 @@ class DeleteManyMutationRelationsSpec extends FlatSpec with Matchers with ApiSpe
           s"""mutation {
           |  createParent(data: {
           |    p: "p1"
+          |    p_1: "p_1"
+          |    p_2: "p_2"
           |    childReq: {
           |      create: {
           |        c: "c1"
@@ -270,7 +272,7 @@ class DeleteManyMutationRelationsSpec extends FlatSpec with Matchers with ApiSpe
         s"""
          |mutation {
          |  deleteManyParents(
-         |    where: {p: "p1"}
+         |    where: { p: "p1" }
          |  ){
          |    count
          |  }

--- a/query-engine/connector-test-kit/src/test/scala/writes/topLevelMutations/DeleteMutationRelationsSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/topLevelMutations/DeleteMutationRelationsSpec.scala
@@ -116,6 +116,8 @@ class DeleteMutationRelationsSpec extends FlatSpec with Matchers with ApiSpecBas
           s"""mutation {
           |  createParent(data: {
           |    p: "p1"
+          |    p_1: "p_1"
+          |    p_2: "p_2"
           |    childReq: {
           |      create: {
           |        c: "c1"
@@ -160,8 +162,14 @@ class DeleteMutationRelationsSpec extends FlatSpec with Matchers with ApiSpecBas
           s"""mutation {
           |  createParent(data: {
           |    p: "p1"
+          |    p_1: "p_1"
+          |    p_2: "p_2"
           |    childOpt: {
-          |      create: {c: "c1"}
+          |      create: {
+          |        c: "c1"
+          |        c_1: "c_1"
+          |        c_2: "c_2"
+          |      }
           |    }
           |  }){
           |    p
@@ -369,7 +377,8 @@ class DeleteMutationRelationsSpec extends FlatSpec with Matchers with ApiSpecBas
         """mutation {
         |  createParent(data: {
         |    p: "p1"
-        |
+        |    p_1: "p_1"
+        |    p_2: "p_2"
         |  }){
         |    p
         |  }
@@ -381,9 +390,9 @@ class DeleteMutationRelationsSpec extends FlatSpec with Matchers with ApiSpecBas
         s"""
          |mutation {
          |  deleteParent(
-         |  where: {p: "p1"}
+         |    where: {p: "p1"}
          |  ){
-         |  p
+         |    p
          |  }
          |}
       """,
@@ -404,8 +413,18 @@ class DeleteMutationRelationsSpec extends FlatSpec with Matchers with ApiSpecBas
           """mutation {
           |  createParent(data: {
           |    p: "p1"
+          |    p_1: "p_1"
+          |    p_2: "p_2"
           |    childrenOpt: {
-          |      create: [{c: "c1"}, {c: "c2"}]
+          |      create: [{
+          |        c: "c1"
+          |        c_1: "c_1"
+          |        c_2: "c_2"
+          |      }, {
+          |        c: "c2"
+          |        c_1: "c2_1"
+          |        c_2: "p2_2"
+          |      }]
           |    }
           |  }){
           |    childrenOpt{
@@ -420,7 +439,7 @@ class DeleteMutationRelationsSpec extends FlatSpec with Matchers with ApiSpecBas
         s"""
          |mutation {
          |  deleteParent(
-         |  where: { p: "p1"}
+         |    where: { p: "p1"}
          |  ){
          |    p
          |  }
@@ -502,7 +521,7 @@ class DeleteMutationRelationsSpec extends FlatSpec with Matchers with ApiSpecBas
         s"""
          |mutation {
          |  deleteParent(
-         |  where: {p: "p1"}
+         |    where: {p: "p1"}
          |  ){
          |    p
          |  }
@@ -525,8 +544,14 @@ class DeleteMutationRelationsSpec extends FlatSpec with Matchers with ApiSpecBas
         """mutation {
         |  createParent(data: {
         |    p: "p1"
+        |    p_1: "p_1"
+        |    p_2: "p_2"
         |    childOpt: {
-        |      create: {c: "c1"}
+        |      create: {
+        |        c: "c1"
+        |        c_1: "c_1"
+        |        c_2: "c_2"
+        |      }
         |    }
         |  }){
         |    childOpt{
@@ -541,7 +566,7 @@ class DeleteMutationRelationsSpec extends FlatSpec with Matchers with ApiSpecBas
         s"""
          |mutation {
          |  deleteParent(
-         |  where: {p: "p1"}
+         |    where: {p: "p1"}
          |  ){
          |    p
          |  }
@@ -553,7 +578,7 @@ class DeleteMutationRelationsSpec extends FlatSpec with Matchers with ApiSpecBas
     }
   }
 
-  "a P1 to CM  relation " should " should succeed in deleting the parent if there is no child" in {
+  "a P1 to CM relation " should " should succeed in deleting the parent if there is no child" in {
     schemaWithRelation(onParent = ChildOpt, onChild = ParentList).test { t =>
       val project = SchemaDsl.fromStringV11() {
         t.datamodel
@@ -564,7 +589,8 @@ class DeleteMutationRelationsSpec extends FlatSpec with Matchers with ApiSpecBas
         """mutation {
         |  createParent(data: {
         |    p: "p1"
-        |
+        |    p_1: "p_1"
+        |    p_2: "p_2"
         |  }){
         |    p
         |  }
@@ -576,7 +602,7 @@ class DeleteMutationRelationsSpec extends FlatSpec with Matchers with ApiSpecBas
         s"""
          |mutation {
          |  deleteParent(
-         |  where: {p: "p1"}
+         |    where: {p: "p1"}
          |  ){
          |    p
          |  }
@@ -599,8 +625,18 @@ class DeleteMutationRelationsSpec extends FlatSpec with Matchers with ApiSpecBas
         """mutation {
         |  createParent(data: {
         |    p: "p1"
+        |    p_1: "p_1"
+        |    p_2: "p_2"
         |    childrenOpt: {
-        |      create: [{c: "c1"},{c: "c2"}]
+        |      create: [{
+        |        c: "c1"
+        |        c_1: "c_1"
+        |        c_2: "c_2"
+        |      },{
+        |        c: "c2"
+        |        c_1: "c2_1"
+        |        c_2: "c2_2"
+        |      }]
         |    }
         |  }){
         |    childrenOpt{
@@ -615,7 +651,7 @@ class DeleteMutationRelationsSpec extends FlatSpec with Matchers with ApiSpecBas
         s"""
          |mutation {
          |  deleteParent(
-         |  where: {p: "p1"}
+         |    where: {p: "p1"}
          |  ){
          |    p
          |  }
@@ -638,7 +674,8 @@ class DeleteMutationRelationsSpec extends FlatSpec with Matchers with ApiSpecBas
         """mutation {
         |  createParent(data: {
         |    p: "p1"
-        |
+        |    p_1: "p_1"
+        |    p_2: "p_2"
         |  }){
         |    p
         |  }
@@ -650,7 +687,7 @@ class DeleteMutationRelationsSpec extends FlatSpec with Matchers with ApiSpecBas
         s"""
          |mutation {
          |  deleteParent(
-         |  where: {p: "p1"}
+         |    where: {p: "p1"}
          |  ){
          |    p
          |  }
@@ -755,6 +792,7 @@ class DeleteMutationRelationsSpec extends FlatSpec with Matchers with ApiSpecBas
 
       TestDataModels(mongo = Vector(dm1, dm2), sql = Vector(dm3, dm4))
     }
+
     testDataModels.testV11 { project =>
       server.query(
         """mutation {
@@ -777,9 +815,9 @@ class DeleteMutationRelationsSpec extends FlatSpec with Matchers with ApiSpecBas
         s"""
          |mutation {
          |  deleteParent(
-         |  where: { p: "p1"}
-         | ){
-         |  p
+         |    where: { p: "p1"}
+         |  ){
+         |    p
          |  }
          |}
       """,

--- a/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
@@ -135,7 +135,7 @@ pub async fn one2m<'a, 'b>(
 
     let uniq_projections = uniq_projections
         .into_iter()
-        .filter(|p| p.contains(&PrismaValue::Null))
+        .filter(|p| !p.contains(&PrismaValue::Null))
         .collect();
 
     let filter = child_link_id.is_in(uniq_projections);

--- a/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
@@ -1,7 +1,7 @@
 use crate::interpreter::query_interpreters::nested_pagination::NestedPagination;
 use crate::{interpreter::InterpretationResult, query_ast::*};
-use connector::{self, filter::Filter, ConnectionLike, IdFilter, QueryArguments, ReadOperations, ScalarCompare};
-use prisma_models::{ManyRecords, ModelProjection, RecordProjection, RelationFieldRef, Result as DomainResult};
+use connector::{self, filter::Filter, ConnectionLike, QueryArguments, ReadOperations, ScalarCompare};
+use prisma_models::{ManyRecords, ModelProjection, RecordProjection, RelationFieldRef};
 use prisma_value::PrismaValue;
 use std::collections::HashMap;
 
@@ -114,7 +114,6 @@ pub async fn one2m<'a, 'b>(
     let mut link_mapping: HashMap<Vec<PrismaValue>, Vec<RecordProjection>> = HashMap::new();
     let idents = vec![parent_model_id, parent_link_id];
     let mut uniq_projections = Vec::new();
-    let mut all_null_checks = false;
 
     for projection in joined_projections {
         let mut split = projection.split_into(&idents);
@@ -129,33 +128,17 @@ pub async fn one2m<'a, 'b>(
 
                 ids.push(id);
                 uniq_projections.push(link_values.clone());
-                all_null_checks = link_values.iter().all(|v| v.is_null());
                 link_mapping.insert(link_values, ids);
             }
         }
     }
 
-    // TODO: this is a stupid hack to find a case where we might have `NULL`
-    // values in the query and try to do an `IN` statement with those values.
-    //
-    // Please make sure to find out WHY we'd do `one2m` with null parent ids
-    // and please use some other function than this instead.
-    let filter = if all_null_checks {
-        let filters: Vec<Filter> = link_mapping
-            .keys()
-            .into_iter()
-            .map(|id_values: &Vec<PrismaValue>| {
-                Ok(child_link_id
-                    .from_unchecked(id_values.iter().map(|v: &PrismaValue| v.clone()).collect())
-                    .filter())
-            })
-            .collect::<DomainResult<_>>()?;
+    let uniq_projections = uniq_projections
+        .into_iter()
+        .filter(|p| p.contains(&PrismaValue::Null))
+        .collect();
 
-        Filter::or(filters)
-    } else {
-        child_link_id.is_in(uniq_projections)
-    };
-
+    let filter = child_link_id.is_in(uniq_projections);
     let mut args = query_args;
 
     args.filter = match args.filter {


### PR DESCRIPTION
Implements null != null logic on resolving related records.
Nulls in _any_ field of a foreign key will cause the related record resolver to ignore that related record.