### PR TITLE
Return proper error instead of panic on bad persisted migration

### DIFF
--- a/query-engine/connectors/sql-query-connector/src/error.rs
+++ b/query-engine/connectors/sql-query-connector/src/error.rs
@@ -214,7 +214,6 @@ impl From<quaint::error::Error> for SqlError {
             e @ QuaintKind::ConnectTimeout { .. } => SqlError::ConnectionError(e.into()),
             e @ QuaintKind::Timeout(..) => SqlError::ConnectionError(e.into()),
             e @ QuaintKind::TlsError { .. } => Self::ConnectionError(e.into()),
-            e @ QuaintKind::ValueOutOfRange { .. } => todo!(),
         }
     }
 }


### PR DESCRIPTION
The `.unwrap()` was hit by users. See https://github.com/prisma/migrate/issues/435