### PR TITLE
Remove an unused TestResult alias

### DIFF
--- a/libs/sql-schema-describer/tests/test_api/mod.rs
+++ b/libs/sql-schema-describer/tests/test_api/mod.rs
@@ -7,8 +7,6 @@ use sql_schema_describer::*;
 use std::sync::Arc;
 use test_setup::*;
 
-pub type TestResult = anyhow::Result<()>;
-
 pub struct TestApi {
     /// More precise than SqlFamily.
     connector_name: &'static str,


### PR DESCRIPTION
This was creating a persistant warning in Rust-Analyzer; this fixes that so no more warnings are displayed. Thanks!