### PR TITLE
Replace `connector::IO`with async-trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,9 +47,9 @@ checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
 
 [[package]]
 name = "async-trait"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da71fef07bc806586090247e971229289f64c210a278ee5ae419314eb386b31d"
+checksum = "26c4f3195085c36ea8d24d32b2f828d23296a9370a28aa39d111f6f16bef9f3b"
 dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.3",
@@ -2025,6 +2025,7 @@ dependencies = [
 name = "query-connector"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "chrono",
  "failure",
  "futures 0.3.4",

--- a/query-engine/connectors/query-connector/Cargo.toml
+++ b/query-engine/connectors/query-connector/Cargo.toml
@@ -16,6 +16,7 @@ itertools = "0.8"
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
 user-facing-errors = { path = "../../../libs/user-facing-errors" }
+async-trait = "0.1.31"
 
 [dev-dependencies]
 serde_json = "1"

--- a/query-engine/connectors/query-connector/src/interface/dispatch.rs
+++ b/query-engine/connectors/query-connector/src/interface/dispatch.rs
@@ -1,106 +1,109 @@
 use super::*;
+use async_trait::async_trait;
 use prisma_value::PrismaValue;
 
+#[async_trait]
 impl<'conn, 'tx> ReadOperations for ConnectionLike<'conn, 'tx> {
-    fn get_single_record<'a>(
-        &'a self,
-        model: &'a ModelRef,
-        filter: &'a Filter,
-        selected_fields: &'a ModelProjection,
-    ) -> crate::IO<'a, Option<SingleRecord>> {
+    async fn get_single_record(
+        &self,
+        model: &ModelRef,
+        filter: &Filter,
+        selected_fields: &ModelProjection,
+    ) -> crate::Result<Option<SingleRecord>> {
         match self {
-            Self::Connection(c) => c.get_single_record(model, filter, selected_fields),
-            Self::Transaction(tx) => tx.get_single_record(model, filter, selected_fields),
+            Self::Connection(c) => c.get_single_record(model, filter, selected_fields).await,
+            Self::Transaction(tx) => tx.get_single_record(model, filter, selected_fields).await,
         }
     }
 
-    fn get_many_records<'a>(
-        &'a self,
-        model: &'a ModelRef,
+    async fn get_many_records(
+        &self,
+        model: &ModelRef,
         query_arguments: QueryArguments,
-        selected_fields: &'a ModelProjection,
-    ) -> crate::IO<'a, ManyRecords> {
+        selected_fields: &ModelProjection,
+    ) -> crate::Result<ManyRecords> {
         match self {
-            Self::Connection(c) => c.get_many_records(model, query_arguments, selected_fields),
-            Self::Transaction(tx) => tx.get_many_records(model, query_arguments, selected_fields),
+            Self::Connection(c) => c.get_many_records(model, query_arguments, selected_fields).await,
+            Self::Transaction(tx) => tx.get_many_records(model, query_arguments, selected_fields).await,
         }
     }
 
-    fn get_related_m2m_record_ids<'a>(
-        &'a self,
-        from_field: &'a RelationFieldRef,
-        from_record_ids: &'a [RecordProjection],
-    ) -> crate::IO<'a, Vec<(RecordProjection, RecordProjection)>> {
+    async fn get_related_m2m_record_ids(
+        &self,
+        from_field: &RelationFieldRef,
+        from_record_ids: &[RecordProjection],
+    ) -> crate::Result<Vec<(RecordProjection, RecordProjection)>> {
         match self {
-            Self::Connection(c) => c.get_related_m2m_record_ids(from_field, from_record_ids),
-            Self::Transaction(tx) => tx.get_related_m2m_record_ids(from_field, from_record_ids),
+            Self::Connection(c) => c.get_related_m2m_record_ids(from_field, from_record_ids).await,
+            Self::Transaction(tx) => tx.get_related_m2m_record_ids(from_field, from_record_ids).await,
         }
     }
 
     // This will eventually become a more generic `aggregate`
-    fn count_by_model<'a>(&'a self, model: &'a ModelRef, query_arguments: QueryArguments) -> crate::IO<'a, usize> {
+    async fn count_by_model(&self, model: &ModelRef, query_arguments: QueryArguments) -> crate::Result<usize> {
         match self {
-            Self::Connection(c) => c.count_by_model(model, query_arguments),
-            Self::Transaction(tx) => tx.count_by_model(model, query_arguments),
+            Self::Connection(c) => c.count_by_model(model, query_arguments).await,
+            Self::Transaction(tx) => tx.count_by_model(model, query_arguments).await,
         }
     }
 }
 
+#[async_trait]
 impl<'conn, 'tx> WriteOperations for ConnectionLike<'conn, 'tx> {
-    fn create_record<'a>(&'a self, model: &'a ModelRef, args: WriteArgs) -> crate::IO<RecordProjection> {
+    async fn create_record(&self, model: &ModelRef, args: WriteArgs) -> crate::Result<RecordProjection> {
         match self {
-            Self::Connection(c) => c.create_record(model, args),
-            Self::Transaction(tx) => tx.create_record(model, args),
+            Self::Connection(c) => c.create_record(model, args).await,
+            Self::Transaction(tx) => tx.create_record(model, args).await,
         }
     }
 
-    fn update_records<'a>(
-        &'a self,
-        model: &'a ModelRef,
+    async fn update_records(
+        &self,
+        model: &ModelRef,
         record_filter: RecordFilter,
         args: WriteArgs,
-    ) -> crate::IO<Vec<RecordProjection>> {
+    ) -> crate::Result<Vec<RecordProjection>> {
         match self {
-            Self::Connection(c) => c.update_records(model, record_filter, args),
-            Self::Transaction(tx) => tx.update_records(model, record_filter, args),
+            Self::Connection(c) => c.update_records(model, record_filter, args).await,
+            Self::Transaction(tx) => tx.update_records(model, record_filter, args).await,
         }
     }
 
-    fn delete_records<'a>(&'a self, model: &'a ModelRef, record_filter: RecordFilter) -> crate::IO<usize> {
+    async fn delete_records(&self, model: &ModelRef, record_filter: RecordFilter) -> crate::Result<usize> {
         match self {
-            Self::Connection(c) => c.delete_records(model, record_filter),
-            Self::Transaction(tx) => tx.delete_records(model, record_filter),
+            Self::Connection(c) => c.delete_records(model, record_filter).await,
+            Self::Transaction(tx) => tx.delete_records(model, record_filter).await,
         }
     }
 
-    fn connect<'a>(
-        &'a self,
-        field: &'a RelationFieldRef,
-        parent_id: &'a RecordProjection,
-        child_ids: &'a [RecordProjection],
-    ) -> crate::IO<()> {
+    async fn connect(
+        &self,
+        field: &RelationFieldRef,
+        parent_id: &RecordProjection,
+        child_ids: &[RecordProjection],
+    ) -> crate::Result<()> {
         match self {
-            Self::Connection(c) => c.connect(field, parent_id, child_ids),
-            Self::Transaction(tx) => tx.connect(field, parent_id, child_ids),
+            Self::Connection(c) => c.connect(field, parent_id, child_ids).await,
+            Self::Transaction(tx) => tx.connect(field, parent_id, child_ids).await,
         }
     }
 
-    fn disconnect<'a>(
-        &'a self,
-        field: &'a RelationFieldRef,
-        parent_id: &'a RecordProjection,
-        child_ids: &'a [RecordProjection],
-    ) -> crate::IO<()> {
+    async fn disconnect(
+        &self,
+        field: &RelationFieldRef,
+        parent_id: &RecordProjection,
+        child_ids: &[RecordProjection],
+    ) -> crate::Result<()> {
         match self {
-            Self::Connection(c) => c.disconnect(field, parent_id, child_ids),
-            Self::Transaction(tx) => tx.disconnect(field, parent_id, child_ids),
+            Self::Connection(c) => c.disconnect(field, parent_id, child_ids).await,
+            Self::Transaction(tx) => tx.disconnect(field, parent_id, child_ids).await,
         }
     }
 
-    fn execute_raw<'a>(&'a self, query: String, parameters: Vec<PrismaValue>) -> crate::IO<serde_json::Value> {
+    async fn execute_raw(&self, query: String, parameters: Vec<PrismaValue>) -> crate::Result<serde_json::Value> {
         match self {
-            Self::Connection(c) => c.execute_raw(query, parameters),
-            Self::Transaction(tx) => tx.execute_raw(query, parameters),
+            Self::Connection(c) => c.execute_raw(query, parameters).await,
+            Self::Transaction(tx) => tx.execute_raw(query, parameters).await,
         }
     }
 }

--- a/query-engine/connectors/query-connector/src/interface/mod.rs
+++ b/query-engine/connectors/query-connector/src/interface/mod.rs
@@ -3,20 +3,24 @@ mod dispatch;
 pub use dispatch::*;
 
 use crate::{Filter, QueryArguments, WriteArgs};
+use async_trait::async_trait;
 use prisma_models::*;
 use prisma_value::PrismaValue;
 
+#[async_trait]
 pub trait Connector {
-    fn get_connection<'a>(&'a self) -> crate::IO<Box<dyn Connection + 'a>>;
+    async fn get_connection(&self) -> crate::Result<Box<dyn Connection>>;
 }
 
+#[async_trait]
 pub trait Connection: ReadOperations + WriteOperations + Send + Sync {
-    fn start_transaction<'a>(&'a self) -> crate::IO<Box<dyn Transaction + 'a>>;
+    async fn start_transaction<'a>(&'a self) -> crate::Result<Box<dyn Transaction + 'a>>;
 }
 
-pub trait Transaction<'a>: ReadOperations + WriteOperations + Send + Sync {
-    fn commit<'b>(&'b self) -> crate::IO<'b, ()>;
-    fn rollback<'b>(&'b self) -> crate::IO<'b, ()>;
+#[async_trait]
+pub trait Transaction: ReadOperations + WriteOperations + Send + Sync {
+    async fn commit(&self) -> crate::Result<()>;
+    async fn rollback(&self) -> crate::Result<()>;
 }
 
 pub enum ConnectionLike<'conn, 'tx>
@@ -24,7 +28,7 @@ where
     'tx: 'conn,
 {
     Connection(&'conn (dyn Connection + 'conn)),
-    Transaction(&'conn (dyn Transaction<'tx> + 'tx)),
+    Transaction(&'conn (dyn Transaction + 'tx)),
 }
 
 /// A wrapper struct allowing to either filter for records or for the core to
@@ -75,6 +79,7 @@ impl From<RecordProjection> for RecordFilter {
     }
 }
 
+#[async_trait]
 pub trait ReadOperations {
     /// Gets a single record or `None` back from the database.
     ///
@@ -82,12 +87,12 @@ pub trait ReadOperations {
     /// - The `Filter` defines what item we want back and is guaranteed to be
     ///   defined to filter at most one item by the core.
     /// - The `SelectedFields` defines the values to be returned.
-    fn get_single_record<'a>(
-        &'a self,
-        model: &'a ModelRef,
-        filter: &'a Filter,
-        selected_fields: &'a ModelProjection,
-    ) -> crate::IO<'a, Option<SingleRecord>>;
+    async fn get_single_record(
+        &self,
+        model: &ModelRef,
+        filter: &Filter,
+        selected_fields: &ModelProjection,
+    ) -> crate::Result<Option<SingleRecord>>;
 
     /// Gets multiple records from the database.
     ///
@@ -96,12 +101,12 @@ pub trait ReadOperations {
     ///   data, other parameters are currently not necessary due to windowing
     ///   handled in the core.
     /// - The `SelectedFields` defines the values to be returned.
-    fn get_many_records<'a>(
-        &'a self,
-        model: &'a ModelRef,
+    async fn get_many_records(
+        &self,
+        model: &ModelRef,
         query_arguments: QueryArguments,
-        selected_fields: &'a ModelProjection,
-    ) -> crate::IO<'a, ManyRecords>;
+        selected_fields: &ModelProjection,
+    ) -> crate::Result<ManyRecords>;
 
     /// Retrieves pairs of IDs that belong together from a intermediate join
     /// table.
@@ -110,51 +115,52 @@ pub trait ReadOperations {
     /// projections with the corresponding child projections fetched from the
     /// database. The IDs returned will be used to perform a in-memory join
     /// between two datasets.
-    fn get_related_m2m_record_ids<'a>(
-        &'a self,
-        from_field: &'a RelationFieldRef,
-        from_record_ids: &'a [RecordProjection],
-    ) -> crate::IO<'a, Vec<(RecordProjection, RecordProjection)>>;
+    async fn get_related_m2m_record_ids(
+        &self,
+        from_field: &RelationFieldRef,
+        from_record_ids: &[RecordProjection],
+    ) -> crate::Result<Vec<(RecordProjection, RecordProjection)>>;
 
     // return the number of items from the `Model`, filtered by the given `QueryArguments`.
-    fn count_by_model<'a>(&'a self, model: &'a ModelRef, query_arguments: QueryArguments) -> crate::IO<'a, usize>;
+    async fn count_by_model(&self, model: &ModelRef, query_arguments: QueryArguments) -> crate::Result<usize>;
 }
 
+#[async_trait]
 pub trait WriteOperations {
     /// Insert a single record to the database.
-    fn create_record<'a>(&'a self, model: &'a ModelRef, args: WriteArgs) -> crate::IO<RecordProjection>;
+    async fn create_record(&self, model: &ModelRef, args: WriteArgs) -> crate::Result<RecordProjection>;
 
     /// Update records in the `Model` with the given `WriteArgs` filtered by the
     /// `Filter`.
-    fn update_records<'a>(
-        &'a self,
-        model: &'a ModelRef,
+    async fn update_records(
+        &self,
+        model: &ModelRef,
         record_filter: RecordFilter,
         args: WriteArgs,
-    ) -> crate::IO<Vec<RecordProjection>>;
+    ) -> crate::Result<Vec<RecordProjection>>;
 
     /// Delete records in the `Model` with the given `Filter`.
-    fn delete_records<'a>(&'a self, model: &'a ModelRef, record_filter: RecordFilter) -> crate::IO<usize>;
+    async fn delete_records(&self, model: &ModelRef, record_filter: RecordFilter) -> crate::Result<usize>;
 
     // We plan to remove the methods below in the future. We want emulate them with the ones above. Those should suffice.
 
     /// Connect the children to the parent.
-    fn connect<'a>(
-        &'a self,
-        field: &'a RelationFieldRef,
-        parent_id: &'a RecordProjection,
-        child_ids: &'a [RecordProjection],
-    ) -> crate::IO<()>;
+    async fn connect(
+        &self,
+        field: &RelationFieldRef,
+        parent_id: &RecordProjection,
+        child_ids: &[RecordProjection],
+    ) -> crate::Result<()>;
 
     /// Disconnect the children from the parent.
-    fn disconnect<'a>(
-        &'a self,
-        field: &'a RelationFieldRef,
-        parent_id: &'a RecordProjection,
-        child_ids: &'a [RecordProjection],
-    ) -> crate::IO<()>;
+    async fn disconnect(
+        &self,
+        field: &RelationFieldRef,
+        parent_id: &RecordProjection,
+        child_ids: &[RecordProjection],
+    ) -> crate::Result<()>;
 
     /// Execute the raw query in the database as-is. The `parameters` are
     /// parameterized values for databases that support prepared statements.
-    fn execute_raw<'a>(&'a self, query: String, parameters: Vec<PrismaValue>) -> crate::IO<serde_json::Value>;
+    async fn execute_raw(&self, query: String, parameters: Vec<PrismaValue>) -> crate::Result<serde_json::Value>;
 }

--- a/query-engine/connectors/query-connector/src/lib.rs
+++ b/query-engine/connectors/query-connector/src/lib.rs
@@ -14,30 +14,4 @@ pub use interface::*;
 pub use query_arguments::*;
 pub use write_args::*;
 
-use futures::future::{BoxFuture, FutureExt};
-use std::{
-    future::Future,
-    pin::Pin,
-    task::{Context, Poll},
-};
-
 pub type Result<T> = std::result::Result<T, error::ConnectorError>;
-
-pub struct IO<'a, T>(BoxFuture<'a, crate::Result<T>>);
-
-impl<'a, T> IO<'a, T> {
-    pub fn new<F>(inner: F) -> Self
-    where
-        F: Future<Output = crate::Result<T>> + Send + 'a,
-    {
-        Self(inner.boxed())
-    }
-}
-
-impl<'a, T> Future for IO<'a, T> {
-    type Output = crate::Result<T>;
-
-    fn poll(mut self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Self::Output> {
-        self.0.as_mut().poll(ctx)
-    }
-}

--- a/query-engine/connectors/sql-query-connector/src/database/connection.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/connection.rs
@@ -1,23 +1,25 @@
 use super::transaction::SqlConnectorTransaction;
 use crate::{database::operations::*, QueryExt, SqlError};
+use async_trait::async_trait;
 use connector_interface::{
     self as connector, filter::Filter, Connection, QueryArguments, ReadOperations, RecordFilter, Transaction,
-    WriteArgs, WriteOperations, IO,
+    WriteArgs, WriteOperations,
 };
 use prisma_models::prelude::*;
 use prisma_value::PrismaValue;
 use quaint::{connector::TransactionCapable, prelude::ConnectionInfo};
 
-pub struct SqlConnection<'a, C> {
+pub struct SqlConnection<C> {
     inner: C,
-    connection_info: &'a ConnectionInfo,
+    connection_info: ConnectionInfo,
 }
 
-impl<'a, C> SqlConnection<'a, C>
+impl<C> SqlConnection<C>
 where
     C: QueryExt + Send + Sync + 'static,
 {
-    pub fn new(inner: C, connection_info: &'a ConnectionInfo) -> Self {
+    pub fn new(inner: C, connection_info: &ConnectionInfo) -> Self {
+        let connection_info = connection_info.clone();
         Self { inner, connection_info }
     }
 
@@ -32,102 +34,107 @@ where
     }
 }
 
-impl<'conninfo, C> Connection for SqlConnection<'conninfo, C>
+#[async_trait]
+impl<C> Connection for SqlConnection<C>
 where
     C: QueryExt + TransactionCapable + Send + Sync + 'static,
 {
-    fn start_transaction<'a>(&'a self) -> IO<'a, Box<dyn Transaction<'a> + 'a>> {
+    async fn start_transaction<'a>(&'a self) -> crate::Result<Box<dyn Transaction + 'a>> {
         let fut_tx = self.inner.start_transaction();
         let connection_info = self.connection_info;
 
-        IO::new(self.catch(async move {
-            let tx: quaint::connector::Transaction<'a> = fut_tx.await.map_err(SqlError::from)?;
-            Ok(Box::new(SqlConnectorTransaction::new(tx, connection_info)) as Box<dyn Transaction<'a> + 'a>)
-        }))
+        let tx: quaint::connector::Transaction = fut_tx.await.map_err(SqlError::from)?;
+        Ok(Box::new(SqlConnectorTransaction::new(tx, &connection_info)) as Box<dyn Transaction>)
     }
 }
 
-impl<'a, C> ReadOperations for SqlConnection<'a, C>
+#[async_trait]
+impl<C> ReadOperations for SqlConnection<C>
 where
     C: QueryExt + Send + Sync + 'static,
 {
-    fn get_single_record<'b>(
-        &'b self,
-        model: &'b ModelRef,
-        filter: &'b Filter,
-        selected_fields: &'b ModelProjection,
-    ) -> connector::IO<'b, Option<SingleRecord>> {
-        IO::new(self.catch(async move { read::get_single_record(&self.inner, model, filter, selected_fields).await }))
+    async fn get_single_record(
+        &self,
+        model: &ModelRef,
+        filter: &Filter,
+        selected_fields: &ModelProjection,
+    ) -> connector::Result<Option<SingleRecord>> {
+        self.catch(async move { read::get_single_record(&self.inner, model, filter, selected_fields).await })
+            .await
     }
 
-    fn get_many_records<'b>(
-        &'b self,
-        model: &'b ModelRef,
+    async fn get_many_records(
+        &self,
+        model: &ModelRef,
         query_arguments: QueryArguments,
-        selected_fields: &'b ModelProjection,
-    ) -> connector::IO<'b, ManyRecords> {
-        IO::new(
-            self.catch(
-                async move { read::get_many_records(&self.inner, model, query_arguments, selected_fields).await },
-            ),
-        )
+        selected_fields: &ModelProjection,
+    ) -> connector::Result<ManyRecords> {
+        self.catch(async move { read::get_many_records(&self.inner, model, query_arguments, selected_fields).await })
+            .await
     }
 
-    fn get_related_m2m_record_ids<'b>(
-        &'b self,
-        from_field: &'b RelationFieldRef,
-        from_record_ids: &'b [RecordProjection],
-    ) -> connector::IO<'b, Vec<(RecordProjection, RecordProjection)>> {
-        IO::new(
-            self.catch(async move { read::get_related_m2m_record_ids(&self.inner, from_field, from_record_ids).await }),
-        )
+    async fn get_related_m2m_record_ids(
+        &self,
+        from_field: &RelationFieldRef,
+        from_record_ids: &[RecordProjection],
+    ) -> connector::Result<Vec<(RecordProjection, RecordProjection)>> {
+        self.catch(async move { read::get_related_m2m_record_ids(&self.inner, from_field, from_record_ids).await })
+            .await
     }
 
-    fn count_by_model<'b>(&'b self, model: &'b ModelRef, query_arguments: QueryArguments) -> connector::IO<'b, usize> {
-        IO::new(self.catch(async move { read::count_by_model(&self.inner, model, query_arguments).await }))
+    async fn count_by_model(&self, model: &ModelRef, query_arguments: QueryArguments) -> connector::Result<usize> {
+        self.catch(async move { read::count_by_model(&self.inner, model, query_arguments).await })
+            .await
     }
 }
 
-impl<'conn, C> WriteOperations for SqlConnection<'conn, C>
+#[async_trait]
+impl<C> WriteOperations for SqlConnection<C>
 where
     C: QueryExt + Send + Sync + 'static,
 {
-    fn create_record<'a>(&'a self, model: &'a ModelRef, args: WriteArgs) -> connector::IO<RecordProjection> {
-        IO::new(self.catch(async move { write::create_record(&self.inner, model, args).await }))
+    async fn create_record(&self, model: &ModelRef, args: WriteArgs) -> connector::Result<RecordProjection> {
+        self.catch(async move { write::create_record(&self.inner, model, args).await })
+            .await
     }
 
-    fn update_records<'a>(
-        &'a self,
-        model: &'a ModelRef,
+    async fn update_records(
+        &self,
+        model: &ModelRef,
         record_filter: RecordFilter,
         args: WriteArgs,
-    ) -> connector::IO<Vec<RecordProjection>> {
-        IO::new(self.catch(async move { write::update_records(&self.inner, model, record_filter, args).await }))
+    ) -> connector::Result<Vec<RecordProjection>> {
+        self.catch(async move { write::update_records(&self.inner, model, record_filter, args).await })
+            .await
     }
 
-    fn delete_records<'a>(&'a self, model: &'a ModelRef, record_filter: RecordFilter) -> connector::IO<usize> {
-        IO::new(self.catch(async move { write::delete_records(&self.inner, model, record_filter).await }))
+    async fn delete_records(&self, model: &ModelRef, record_filter: RecordFilter) -> connector::Result<usize> {
+        self.catch(async move { write::delete_records(&self.inner, model, record_filter).await })
+            .await
     }
 
-    fn connect<'a>(
-        &'a self,
-        field: &'a RelationFieldRef,
-        parent_id: &'a RecordProjection,
-        child_ids: &'a [RecordProjection],
-    ) -> connector::IO<()> {
-        IO::new(self.catch(async move { write::connect(&self.inner, field, parent_id, child_ids).await }))
+    async fn connect(
+        &self,
+        field: &RelationFieldRef,
+        parent_id: &RecordProjection,
+        child_ids: &[RecordProjection],
+    ) -> connector::Result<()> {
+        self.catch(async move { write::connect(&self.inner, field, parent_id, child_ids).await })
+            .await
     }
 
-    fn disconnect<'a>(
-        &'a self,
-        field: &'a RelationFieldRef,
-        parent_id: &'a RecordProjection,
-        child_ids: &'a [RecordProjection],
-    ) -> connector::IO<()> {
-        IO::new(self.catch(async move { write::disconnect(&self.inner, field, parent_id, child_ids).await }))
+    async fn disconnect(
+        &self,
+        field: &RelationFieldRef,
+        parent_id: &RecordProjection,
+        child_ids: &[RecordProjection],
+    ) -> connector::Result<()> {
+        self.catch(async move { write::disconnect(&self.inner, field, parent_id, child_ids).await })
+            .await
     }
 
-    fn execute_raw<'a>(&'a self, query: String, parameters: Vec<PrismaValue>) -> connector::IO<serde_json::Value> {
-        IO::new(self.catch(async move { write::execute_raw(&self.inner, query, parameters).await }))
+    async fn execute_raw(&self, query: String, parameters: Vec<PrismaValue>) -> connector::Result<serde_json::Value> {
+        self.catch(async move { write::execute_raw(&self.inner, query, parameters).await })
+            .await
     }
 }

--- a/query-engine/connectors/sql-query-connector/src/database/mysql.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/mysql.rs
@@ -38,7 +38,7 @@ impl FromSource for Mysql {
 
 #[async_trait]
 impl Connector for Mysql {
-    async fn get_connection<'a>(&'a self) -> connector::Result<Box<dyn Connection + 'a>> {
+    async fn get_connection<'a>(&'a self) -> connector::Result<Box<dyn Connection + 'static>> {
         super::catch(&self.connection_info, async move {
             let conn = self.pool.check_out().await.map_err(SqlError::from)?;
             let conn = SqlConnection::new(conn, &self.connection_info);

--- a/query-engine/connectors/sql-query-connector/src/database/postgresql.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/postgresql.rs
@@ -36,11 +36,10 @@ impl FromSource for PostgreSql {
 
 #[async_trait]
 impl Connector for PostgreSql {
-    async fn get_connection<'a>(&'a self) -> connector_interface::Result<Box<dyn Connection + 'a>> {
+    async fn get_connection<'a>(&'a self) -> connector_interface::Result<Box<dyn Connection + 'static>> {
         super::catch(&self.connection_info, async move {
             let conn = self.pool.check_out().await.map_err(SqlError::from)?;
             let conn = SqlConnection::new(conn, &self.connection_info);
-
             Ok(Box::new(conn) as Box<dyn Connection>)
         })
         .await

--- a/query-engine/connectors/sql-query-connector/src/database/sqlite.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/sqlite.rs
@@ -2,8 +2,9 @@ use super::connection::SqlConnection;
 use crate::{FromSource, SqlError};
 use async_trait::async_trait;
 use connector_interface::{
+    self as connector,
     error::{ConnectorError, ErrorKind},
-    Connection, Connector, IO,
+    Connection, Connector,
 };
 use datamodel::Source;
 use quaint::{connector::SqliteParams, error::ErrorKind as QuaintKind, pooled::Quaint, prelude::ConnectionInfo};
@@ -80,13 +81,15 @@ fn invalid_file_path_error(file_path: &str, connection_info: &ConnectionInfo) ->
     .into_connector_error(&connection_info)
 }
 
+#[async_trait]
 impl Connector for Sqlite {
-    fn get_connection<'a>(&'a self) -> IO<Box<dyn Connection + 'a>> {
-        IO::new(super::catch(&self.connection_info(), async move {
+    async fn get_connection<'a>(&'a self) -> connector::Result<Box<dyn Connection + 'a>> {
+        super::catch(&self.connection_info(), async move {
             let conn = self.pool.check_out().await.map_err(SqlError::from)?;
             let conn = SqlConnection::new(conn, self.connection_info());
 
             Ok(Box::new(conn) as Box<dyn Connection>)
-        }))
+        })
+        .await
     }
 }

--- a/query-engine/connectors/sql-query-connector/src/database/sqlite.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/sqlite.rs
@@ -83,7 +83,7 @@ fn invalid_file_path_error(file_path: &str, connection_info: &ConnectionInfo) ->
 
 #[async_trait]
 impl Connector for Sqlite {
-    async fn get_connection<'a>(&'a self) -> connector::Result<Box<dyn Connection + 'a>> {
+    async fn get_connection<'a>(&'a self) -> connector::Result<Box<dyn Connection + 'static>> {
         super::catch(&self.connection_info(), async move {
             let conn = self.pool.check_out().await.map_err(SqlError::from)?;
             let conn = SqlConnection::new(conn, self.connection_info());

--- a/query-engine/connectors/sql-query-connector/src/database/transaction.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/transaction.rs
@@ -1,20 +1,22 @@
 use crate::database::operations::*;
 use crate::SqlError;
+use async_trait::async_trait;
 use connector_interface::{
     self as connector, filter::Filter, QueryArguments, ReadOperations, RecordFilter, Transaction, WriteArgs,
-    WriteOperations, IO,
+    WriteOperations,
 };
 use prisma_models::prelude::*;
 use prisma_value::PrismaValue;
 use quaint::prelude::ConnectionInfo;
 
-pub struct SqlConnectorTransaction<'a> {
-    inner: quaint::connector::Transaction<'a>,
-    connection_info: &'a ConnectionInfo,
+pub struct SqlConnectorTransaction<'tx> {
+    inner: quaint::connector::Transaction<'tx>,
+    connection_info: ConnectionInfo,
 }
 
-impl<'a> SqlConnectorTransaction<'a> {
-    pub fn new<'b: 'a>(tx: quaint::connector::Transaction<'a>, connection_info: &'b ConnectionInfo) -> Self {
+impl<'tx> SqlConnectorTransaction<'tx> {
+    pub fn new<'b: 'tx>(tx: quaint::connector::Transaction, connection_info: &ConnectionInfo) -> Self {
+        let connection_info = connection_info.clone();
         Self {
             inner: tx,
             connection_info,
@@ -32,91 +34,100 @@ impl<'a> SqlConnectorTransaction<'a> {
     }
 }
 
-impl<'a> Transaction<'a> for SqlConnectorTransaction<'a> {
-    fn commit<'b>(&'b self) -> IO<'b, ()> {
-        IO::new(self.catch(async move { Ok(self.inner.commit().await.map_err(SqlError::from)?) }))
+#[async_trait]
+impl<'tx> Transaction for SqlConnectorTransaction<'tx> {
+    async fn commit(&self) -> connector::Result<()> {
+        self.catch(async move { Ok(self.inner.commit().await.map_err(SqlError::from)?) })
+            .await
     }
 
-    fn rollback<'b>(&'b self) -> IO<'b, ()> {
-        IO::new(self.catch(async move { Ok(self.inner.rollback().await.map_err(SqlError::from)?) }))
+    async fn rollback(&self) -> connector::Result<()> {
+        self.catch(async move { Ok(self.inner.rollback().await.map_err(SqlError::from)?) })
+            .await
     }
 }
 
-impl<'a> ReadOperations for SqlConnectorTransaction<'a> {
-    fn get_single_record<'b>(
-        &'b self,
-        model: &'b ModelRef,
-        filter: &'b Filter,
-        selected_fields: &'b ModelProjection,
-    ) -> connector::IO<'b, Option<SingleRecord>> {
-        IO::new(self.catch(async move { read::get_single_record(&self.inner, model, filter, selected_fields).await }))
+#[async_trait]
+impl<'tx> ReadOperations for SqlConnectorTransaction<'tx> {
+    async fn get_single_record(
+        &self,
+        model: &ModelRef,
+        filter: &Filter,
+        selected_fields: &ModelProjection,
+    ) -> connector::Result<Option<SingleRecord>> {
+        self.catch(async move { read::get_single_record(&self.inner, model, filter, selected_fields).await })
+            .await
     }
 
-    fn get_many_records<'b>(
-        &'b self,
-        model: &'b ModelRef,
+    async fn get_many_records(
+        &self,
+        model: &ModelRef,
         query_arguments: QueryArguments,
-        selected_fields: &'b ModelProjection,
-    ) -> connector::IO<'b, ManyRecords> {
-        IO::new(
-            self.catch(
-                async move { read::get_many_records(&self.inner, model, query_arguments, selected_fields).await },
-            ),
-        )
+        selected_fields: &ModelProjection,
+    ) -> connector::Result<ManyRecords> {
+        self.catch(async move { read::get_many_records(&self.inner, model, query_arguments, selected_fields).await })
+            .await
     }
 
-    fn get_related_m2m_record_ids<'b>(
-        &'b self,
-        from_field: &'b RelationFieldRef,
-        from_record_ids: &'b [RecordProjection],
-    ) -> connector::IO<'b, Vec<(RecordProjection, RecordProjection)>> {
-        IO::new(
-            self.catch(async move { read::get_related_m2m_record_ids(&self.inner, from_field, from_record_ids).await }),
-        )
+    async fn get_related_m2m_record_ids(
+        &self,
+        from_field: &RelationFieldRef,
+        from_record_ids: &[RecordProjection],
+    ) -> connector::Result<Vec<(RecordProjection, RecordProjection)>> {
+        self.catch(async move { read::get_related_m2m_record_ids(&self.inner, from_field, from_record_ids).await })
+            .await
     }
 
-    fn count_by_model<'b>(&'b self, model: &'b ModelRef, query_arguments: QueryArguments) -> connector::IO<'b, usize> {
-        IO::new(self.catch(async move { read::count_by_model(&self.inner, model, query_arguments).await }))
+    async fn count_by_model(&self, model: &ModelRef, query_arguments: QueryArguments) -> connector::Result<usize> {
+        self.catch(async move { read::count_by_model(&self.inner, model, query_arguments).await })
+            .await
     }
 }
 
-impl<'a> WriteOperations for SqlConnectorTransaction<'a> {
-    fn create_record<'b>(&'b self, model: &'b ModelRef, args: WriteArgs) -> connector::IO<RecordProjection> {
-        IO::new(self.catch(async move { write::create_record(&self.inner, model, args).await }))
+#[async_trait]
+impl<'tx> WriteOperations for SqlConnectorTransaction<'tx> {
+    async fn create_record(&self, model: &ModelRef, args: WriteArgs) -> connector::Result<RecordProjection> {
+        self.catch(async move { write::create_record(&self.inner, model, args).await })
+            .await
     }
 
-    fn update_records<'b>(
-        &'b self,
-        model: &'b ModelRef,
+    async fn update_records(
+        &self,
+        model: &ModelRef,
         record_filter: RecordFilter,
         args: WriteArgs,
-    ) -> connector::IO<Vec<RecordProjection>> {
-        IO::new(self.catch(async move { write::update_records(&self.inner, model, record_filter, args).await }))
+    ) -> connector::Result<Vec<RecordProjection>> {
+        self.catch(async move { write::update_records(&self.inner, model, record_filter, args).await })
+            .await
     }
 
-    fn delete_records<'b>(&'b self, model: &'b ModelRef, record_filter: RecordFilter) -> connector::IO<usize> {
-        IO::new(self.catch(async move { write::delete_records(&self.inner, model, record_filter).await }))
+    async fn delete_records(&self, model: &ModelRef, record_filter: RecordFilter) -> connector::Result<usize> {
+        self.catch(async move { write::delete_records(&self.inner, model, record_filter).await })
+            .await
     }
 
-    fn connect<'b>(
-        &'b self,
-        field: &'b RelationFieldRef,
-        parent_id: &'b RecordProjection,
-        child_ids: &'b [RecordProjection],
-    ) -> connector::IO<()> {
-        IO::new(self.catch(async move { write::connect(&self.inner, field, parent_id, child_ids).await }))
+    async fn connect(
+        &self,
+        field: &RelationFieldRef,
+        parent_id: &RecordProjection,
+        child_ids: &[RecordProjection],
+    ) -> connector::Result<()> {
+        self.catch(async move { write::connect(&self.inner, field, parent_id, child_ids).await })
+            .await
     }
 
-    fn disconnect<'b>(
-        &'b self,
-        field: &'b RelationFieldRef,
-        parent_id: &'b RecordProjection,
-        child_ids: &'b [RecordProjection],
-    ) -> connector::IO<()> {
-        IO::new(self.catch(async move { write::disconnect(&self.inner, field, parent_id, child_ids).await }))
+    async fn disconnect(
+        &self,
+        field: &RelationFieldRef,
+        parent_id: &RecordProjection,
+        child_ids: &[RecordProjection],
+    ) -> connector::Result<()> {
+        self.catch(async move { write::disconnect(&self.inner, field, parent_id, child_ids).await })
+            .await
     }
 
-    fn execute_raw(&self, query: String, parameters: Vec<PrismaValue>) -> connector::IO<serde_json::Value> {
-        IO::new(self.catch(async move { write::execute_raw(&self.inner, query, parameters).await }))
+    async fn execute_raw(&self, query: String, parameters: Vec<PrismaValue>) -> connector::Result<serde_json::Value> {
+        self.catch(async move { write::execute_raw(&self.inner, query, parameters).await })
+            .await
     }
 }

--- a/query-engine/connectors/sql-query-connector/src/database/transaction.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/transaction.rs
@@ -15,7 +15,7 @@ pub struct SqlConnectorTransaction<'tx> {
 }
 
 impl<'tx> SqlConnectorTransaction<'tx> {
-    pub fn new<'b: 'tx>(tx: quaint::connector::Transaction, connection_info: &ConnectionInfo) -> Self {
+    pub fn new<'b: 'tx>(tx: quaint::connector::Transaction<'tx>, connection_info: &ConnectionInfo) -> Self {
         let connection_info = connection_info.clone();
         Self {
             inner: tx,


### PR DESCRIPTION
This replaces our custom `connector::IO` struct with [`async-trait`](https://docs.rs/async-trait/0.1.31/async_trait/) which we use in other parts of the engines code too. This should make it easier to reason about code, sets us up for future improvements, and prepares our code for when we eventually have access to `async fn` in traits in Rust. This also allowed us to get rid of various explicit lifetimes, which should help somewhat with readability.

In the process of writing this patch I made a few simplifications. In particular `ConnectionInfo` no longer borrows strings, but allocates instead. This removes some complexity around lifetimes, trading in some memory. But it shouldn't have any noticeable performance impact..

Overall I'm fairly excited how this patch has turned out; I think this sets us up nicely for further improvements. Thanks heaps!