### PR TITLE
Enable filtering by JSON value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2005,7 +2005,7 @@ dependencies = [
 [[package]]
 name = "quaint"
 version = "0.2.0-alpha.11"
-source = "git+https://github.com/prisma/quaint#ac3772229a8eb57ea0626ff316e52c6e5b28d2b1"
+source = "git+https://github.com/prisma/quaint#f7f225d085c314be12316c59b68d3f4097f51a45"
 dependencies = [
  "async-trait",
  "base64 0.11.0",

--- a/libs/prisma-value/src/sql_ext.rs
+++ b/libs/prisma-value/src/sql_ext.rs
@@ -36,7 +36,7 @@ impl<'a> From<PrismaValue> for Value<'a> {
             PrismaValue::Null => Value::Null,
             PrismaValue::Uuid(u) => u.to_string().into(),
             PrismaValue::List(l) => Value::Array(l.into_iter().map(|x| x.into()).collect()),
-            PrismaValue::Json(s) => Value::Text(s.into()),
+            PrismaValue::Json(s) => Value::Json(serde_json::from_str(&s).unwrap()),
         }
     }
 }

--- a/query-engine/core/src/schema_builder/filter_arguments.rs
+++ b/query-engine/core/src/schema_builder/filter_arguments.rs
@@ -121,7 +121,7 @@ pub fn get_field_filters<'a>(field: &ModelField) -> Vec<&'a FilterArgument> {
             TypeIdentifier::Boolean => vec![&args.base],
             TypeIdentifier::Enum(_) => vec![&args.base, &args.inclusion],
             TypeIdentifier::DateTime => vec![&args.base, &args.inclusion, &args.alphanumeric],
-            TypeIdentifier::Json => vec![],
+            TypeIdentifier::Json => vec![&args.base],
         },
     };
 

--- a/query-engine/query-engine/src/tests/type_mappings/mysql_types.rs
+++ b/query-engine/query-engine/src/tests/type_mappings/mysql_types.rs
@@ -401,7 +401,7 @@ async fn all_mysql_identifier_types_work(api: &TestApi) -> TestResult {
     Ok(())
 }
 
-#[test_each_connector(tags("mysql"))]
+#[test_each_connector(tags("mysql"), ignore("mariadb", "mysql_5_6"))]
 async fn all_mysql_types_work_as_filter(api: &TestApi) -> TestResult {
     api.execute_sql(&create_types_table_sql(api)).await?;
 
@@ -435,7 +435,7 @@ async fn all_mysql_types_work_as_filter(api: &TestApi) -> TestResult {
                     string_text_mediumtext: \"medium dolphins\"
                     string_text_longtext: \"long dolphins\"
                     string_enum: \"jellicle_cats\"
-                    # json: \"{\\\"name\\\": null}\"
+                    json: \"{\\\"name\\\": null}\"
                 }
             ) {
                 id

--- a/query-engine/query-engine/src/tests/type_mappings/mysql_types.rs
+++ b/query-engine/query-engine/src/tests/type_mappings/mysql_types.rs
@@ -452,6 +452,107 @@ async fn all_mysql_types_work_as_filter(api: &TestApi) -> TestResult {
     Ok(())
 }
 
+#[test_each_connector(tags("mysql_5_6"))]
+async fn all_mysql_types_work_as_filter_56(api: &TestApi) -> TestResult {
+    api.execute_sql(&create_types_table_sql(api)).await?;
+
+    let (_datamodel, engine) = api.introspect_and_start_query_engine().await?;
+
+    engine.request(CREATE_ONE_TYPES_QUERY).await;
+
+    let query = "
+        query {
+            findManytypes(
+                where: {
+                    numeric_integer_tinyint: 12,
+                    numeric_integer_smallint: 350,
+                    numeric_integer_int: 9002,
+                    numeric_integer_bigint: 30000,
+                    numeric_floating_decimal: 3.14
+                    # numeric_floating_float: -32.0
+                    numeric_fixed_double: 0.14
+                    numeric_fixed_real: 12.12
+                    numeric_bit: 4
+                    numeric_boolean: true
+                    date_date: \"2020-02-27T00:00:00Z\"
+                    date_datetime: \"2020-02-27T19:10:22Z\"
+                    date_timestamp: \"2020-02-27T19:11:22Z\"
+                    # date_time: \"2020-02-20T12:50:01Z\"
+                    date_year: 2012
+                    string_char: \"make dolphins easy\"
+                    string_varchar: \"dolphins of varying characters\"
+                    string_text_tinytext: \"tiny dolphins\"
+                    string_text_text: \"dolphins\"
+                    string_text_mediumtext: \"medium dolphins\"
+                    string_text_longtext: \"long dolphins\"
+                    string_enum: \"jellicle_cats\"
+                }
+            ) {
+                id
+            }
+        }
+    ";
+
+    let response = engine.request(query).await;
+
+    let expected_json = json!({ "data": { "findManytypes": [{ "id": 1 }] } });
+
+    assert_eq!(response, expected_json);
+
+    Ok(())
+}
+
+#[test_each_connector(tags("mariadb"))]
+async fn all_mysql_types_work_as_filter_mariadb(api: &TestApi) -> TestResult {
+    api.execute_sql(&create_types_table_sql(api)).await?;
+
+    let (_datamodel, engine) = api.introspect_and_start_query_engine().await?;
+
+    engine.request(CREATE_ONE_TYPES_QUERY).await;
+
+    let query = "
+        query {
+            findManytypes(
+                where: {
+                    numeric_integer_tinyint: 12,
+                    numeric_integer_smallint: 350,
+                    numeric_integer_int: 9002,
+                    numeric_integer_bigint: 30000,
+                    numeric_floating_decimal: 3.14
+                    # numeric_floating_float: -32.0
+                    numeric_fixed_double: 0.14
+                    numeric_fixed_real: 12.12
+                    numeric_bit: 4
+                    numeric_boolean: true
+                    date_date: \"2020-02-27T00:00:00Z\"
+                    date_datetime: \"2020-02-27T19:10:22Z\"
+                    date_timestamp: \"2020-02-27T19:11:22Z\"
+                    # date_time: \"2020-02-20T12:50:01Z\"
+                    date_year: 2012
+                    string_char: \"make dolphins easy\"
+                    string_varchar: \"dolphins of varying characters\"
+                    string_text_tinytext: \"tiny dolphins\"
+                    string_text_text: \"dolphins\"
+                    string_text_mediumtext: \"medium dolphins\"
+                    string_text_longtext: \"long dolphins\"
+                    string_enum: \"jellicle_cats\"
+                    json: \"{\\\"name\\\":null}\"
+                }
+            ) {
+                id
+            }
+        }
+    ";
+
+    let response = engine.request(query).await;
+
+    let expected_json = json!({ "data": { "findManytypes": [{ "id": 1 }] } });
+
+    assert_eq!(response, expected_json);
+
+    Ok(())
+}
+
 fn create_types_table_with_defaults_sql(api: &TestApi) -> String {
     format!(
         r##"

--- a/query-engine/query-engine/src/tests/type_mappings/postgres_types.rs
+++ b/query-engine/query-engine/src/tests/type_mappings/postgres_types.rs
@@ -583,8 +583,8 @@ async fn all_postgres_types_work_as_filter(api: &TestApi) -> TestResult {
                     time_timetz: "2020-03-05T08:00:00.000"
                     boolean_boolean: true
                     network_inet: "192.168.100.14"
-                    #json_json: "{ \"isJson\": true }"
-                    #json_jsonb: "{ \"isJSONB\": true }"
+                    json_json: "{ \"isJson\": true }"
+                    json_jsonb: "{ \"isJSONB\": true }"
                 }
             ) {
                 id


### PR DESCRIPTION
The filtering logic is implemented in quaint.

This PR:

- Updates quaint
- Enables filtering on JSON fields in the graphql schema
- Adds the JSON column to the filtering tests