### PR TITLE
Nullable relations on create.

### DIFF
--- a/query-engine/connector-test-kit/src/test/scala/writes/topLevelMutations/CreateMutationSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/topLevelMutations/CreateMutationSpec.scala
@@ -12,15 +12,21 @@ class CreateMutationSpec extends FlatSpec with Matchers with ApiSpecBase {
   val schema =
     """
     |model ScalarModel {
-    |   id          String @id @default(cuid())
-    |   optString   String?
-    |   optInt      Int?
-    |   optFloat    Float?
-    |   optBoolean  Boolean?
-    |   optEnum     MyEnum?
-    |   optDateTime DateTime?
-    |   optUnique   String? @unique
-    |   createdAt   DateTime @default(now())
+    |    id          String @id @default(cuid())
+    |    optString   String?
+    |    optInt      Int?
+    |    optFloat    Float?
+    |    optBoolean  Boolean?
+    |    optEnum     MyEnum?
+    |    optDateTime DateTime?
+    |    optUnique   String? @unique
+    |    createdAt   DateTime @default(now())
+    |    relId       String?
+    |    optRel      RelatedModel? @relation(fields: [relId], references: [id])
+    |}
+    |
+    |model RelatedModel {
+    |    id String @id @default(cuid())
     |}
     |
     |enum MyEnum {
@@ -152,5 +158,17 @@ class CreateMutationSpec extends FlatSpec with Matchers with ApiSpecBase {
       errorContains =
         """↳ createScalarModel (field)\n    ↳ data (argument)\n      ↳ ScalarModelCreateInput (object)\n        ↳ optEnum (field)\n          ↳ Error parsing value: Enum value 'NOPE' is invalid for enum type MyEnum."""
     )
+  }
+
+  "A Create Mutation" should "create with an optional relation set to null." in {
+    val res = server.query(
+      """mutation {
+        |  createScalarModel(data: {
+        |    optRel: null
+        |  }){ relId }}""".stripMargin,
+      project = project
+    )
+
+    res should be("""{"data":{"createScalarModel":{"relId":null}}}""".parseJson)
   }
 }

--- a/query-engine/core/src/schema_builder/input_type_builder/create_input_type_extension.rs
+++ b/query-engine/core/src/schema_builder/input_type_builder/create_input_type_extension.rs
@@ -100,7 +100,7 @@ pub trait CreateInputTypeBuilderExtension<'a>: InputTypeBuilderBase<'a> {
                     let input_field = if rf.is_required {
                         input_field(rf.name.clone(), input_type, None)
                     } else {
-                        input_field(rf.name.clone(), InputType::opt(input_type), None)
+                        input_field(rf.name.clone(), InputType::opt(InputType::null(input_type)), None)
                     };
 
                     Some(input_field)


### PR DESCRIPTION
Allows optional relations to be null in the input data for top level create operations.