### PR TITLE
Support for Microsoft SQL Server in Query Engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2132,7 +2132,7 @@ dependencies = [
 [[package]]
 name = "quaint"
 version = "0.2.0-alpha.12"
-source = "git+https://github.com/prisma/quaint?branch=mssql-support#329b0b4473a0b63e0d99972c3d749861db1ec4f4"
+source = "git+https://github.com/prisma/quaint?branch=mssql-support#e8156d353334437ea2921f20b41ee3e477803ca5"
 dependencies = [
  "async-trait",
  "base64 0.11.0",
@@ -3020,7 +3020,7 @@ dependencies = [
 [[package]]
 name = "tiberius"
 version = "0.4.3"
-source = "git+https://github.com/prisma/tiberius?branch=nextbytes-as-send#1e8fa5c1b5640ddf4efbe1092dace66428df288c"
+source = "git+https://github.com/prisma/tiberius#ccb4e7d62455211f67a142ca8f0deafe12da62c9"
 dependencies = [
  "async-native-tls",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,14 +52,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
 
 [[package]]
-name = "async-trait"
-version = "0.1.31"
+name = "async-native-tls"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c4f3195085c36ea8d24d32b2f828d23296a9370a28aa39d111f6f16bef9f3b"
+checksum = "9e9e7a929bd34c68a82d58a4de7f86fffdaf97fb2af850162a7bb19dd7269b33"
 dependencies = [
- "proc-macro2 1.0.13",
- "quote 1.0.6",
- "syn 1.0.30",
+ "async-std",
+ "native-tls",
+ "thiserror",
+ "url 2.1.1",
+]
+
+[[package]]
+name = "async-std"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93c583a035d21e6d6f09adf48abfc55277bf48886406df370e5db6babe3ab98"
+dependencies = [
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22068c0c19514942eefcfd4daf8976ef1aad84e61539f95cd200c35202f80af5"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25f9db3b38af870bf7e5cc649167533b493928e50744e2c30ae350230b414670"
+dependencies = [
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.31",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89cb5d814ab2a47fd66d3266e9efccb53ca4c740b7451043b8ffcf9a6208f3f8"
+dependencies = [
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.31",
 ]
 
 [[package]]
@@ -172,9 +223,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5356f1d23ee24a1f785a56d1d1a5f0fd5b0f6a0c0fb2412ce11da71649ab78f6"
+checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
 
 [[package]]
 name = "byte-tools"
@@ -352,12 +403,13 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c695eeca1e7173472a32221542ae469b3e9aac3a4fc81f7696bcad82029493db"
+checksum = "774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
+ "maybe-uninit",
 ]
 
 [[package]]
@@ -383,12 +435,12 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf6b25ee9ac1995c54d7adb2eff8cfffb7260bc774fb63c601ec65467f43cd9d"
+checksum = "39858aa5bac06462d4dd4b9164848eb81ffc4aa5c479746393598fd193afa227"
 dependencies = [
- "quote 1.0.6",
- "syn 1.0.30",
+ "quote 1.0.7",
+ "syn 1.0.31",
 ]
 
 [[package]]
@@ -420,10 +472,10 @@ checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.13",
- "quote 1.0.6",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
  "strsim 0.9.3",
- "syn 1.0.30",
+ "syn 1.0.31",
 ]
 
 [[package]]
@@ -433,8 +485,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
 dependencies = [
  "darling_core",
- "quote 1.0.6",
- "syn 1.0.30",
+ "quote 1.0.7",
+ "syn 1.0.31",
 ]
 
 [[package]]
@@ -507,6 +559,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 
 [[package]]
+name = "encoding"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b0d943856b990d12d3b55b359144ff341533e516d94098b1d3fc1ac666d36ec"
+dependencies = [
+ "encoding-index-japanese",
+ "encoding-index-korean",
+ "encoding-index-simpchinese",
+ "encoding-index-singlebyte",
+ "encoding-index-tradchinese",
+]
+
+[[package]]
+name = "encoding-index-japanese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04e8b2ff42e9a05335dbf8b5c6f7567e5591d0d916ccef4e0b1710d32a0d0c91"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-korean"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dc33fb8e6bcba213fe2f14275f0963fd16f0a02c878e3095ecfdf5bee529d81"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-simpchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87a7194909b9118fc707194baa434a4e3b0fb6a5a757c73c3adb07aa25031f7"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-singlebyte"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3351d5acffb224af9ca265f435b859c7c01537c0849754d3db3fdf2bfe2ae84a"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-tradchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd0e20d5688ce3cab59eb3ef3a2083a5c77bf496cb798dc6fcdb75f323890c18"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding_index_tests"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
+
+[[package]]
 name = "failure"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -522,9 +638,9 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
- "proc-macro2 1.0.13",
- "quote 1.0.6",
- "syn 1.0.30",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.31",
  "synstructure",
 ]
 
@@ -663,9 +779,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.13",
- "quote 1.0.6",
- "syn 1.0.30",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.31",
 ]
 
 [[package]]
@@ -708,6 +824,18 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro-nested",
  "slab",
+]
+
+[[package]]
+name = "futures_codec"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe8859feb7140742ed1a2a85a07941100ad2b5f98a421b353931d718a34144d1"
+dependencies = [
+ "bytes",
+ "futures 0.3.5",
+ "memchr",
+ "pin-project",
 ]
 
 [[package]]
@@ -796,6 +924,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
+
+[[package]]
 name = "hmac"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -844,9 +978,9 @@ checksum = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
 
 [[package]]
 name = "hyper"
-version = "0.13.5"
+version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96816e1d921eca64d208a85aab4f7798455a8e34229ee5a88c935bdee1b78b14"
+checksum = "a6e7655b9594024ad0ee439f3b5a7299369dc2a3f459b47c696f9ff676f9aa1f"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -858,8 +992,8 @@ dependencies = [
  "httparse",
  "itoa",
  "log",
- "net2",
  "pin-project",
+ "socket2",
  "time 0.1.43",
  "tokio",
  "tower-service",
@@ -907,9 +1041,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.3.2"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "076f042c5b7b98f31d205f1249267e12a6518c1481e9dae9764af19b707d2292"
+checksum = "c398b2b113b55809ceb9ee3e753fcbac793f1956663f3c36549c1346015c2afe"
 dependencies = [
  "autocfg",
  "serde",
@@ -932,9 +1066,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54554010aa3d17754e484005ea0022f1c93839aabc627c2c55f3d7b47206134c"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.13",
- "quote 1.0.6",
- "syn 1.0.30",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.31",
  "unindent",
 ]
 
@@ -1014,6 +1148,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce10c23ad2ea25ceca0093bd3192229da4c5b3c0f2de499c1ecac0d98d452177"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "json-rpc-stdio"
 version = "0.1.0"
 dependencies = [
@@ -1025,9 +1168,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-client-transports"
-version = "14.1.0"
+version = "14.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2307a7e78cf969759e390a8a2151ea12e783849a45bb00aa871b468ba58ea79e"
+checksum = "ecbdaacc17243168d9d1fa6b2bd7556a27e1e60a621d8a2a6e590ae2b145d158"
 dependencies = [
  "failure",
  "futures 0.1.29",
@@ -1041,9 +1184,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-core"
-version = "14.1.0"
+version = "14.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25525f6002338fb4debb5167a89a0b47f727a5a48418417545ad3429758b7fec"
+checksum = "a0747307121ffb9703afd93afbd0fb4f854c38fb873f2c8b90e0e902f27c7b62"
 dependencies = [
  "futures 0.1.29",
  "log",
@@ -1054,34 +1197,35 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-core-client"
-version = "14.1.0"
+version = "14.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f9382e831a6d630c658df103aac3f971da096deb57c136ea2b760d3b4e3f9f"
+checksum = "34221123bc79b66279a3fde2d3363553835b43092d629b34f2e760c44dc94713"
 dependencies = [
  "jsonrpc-client-transports",
 ]
 
 [[package]]
 name = "jsonrpc-derive"
-version = "14.0.5"
+version = "14.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8609af8f63b626e8e211f52441fcdb6ec54f1a446606b10d5c89ae9bf8a20058"
+checksum = "0fadf6945e227246825a583514534d864554e9f23d80b3c77d034b10983db5ef"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.13",
- "quote 1.0.6",
- "syn 1.0.30",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.31",
 ]
 
 [[package]]
 name = "jsonrpc-pubsub"
-version = "14.1.0"
+version = "14.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4ca5e391d6c6a2261d4adca029f427fe63ea546ad6cef2957c654c08495ec16"
+checksum = "2d44f5602a11d657946aac09357956d2841299ed422035edf140c552cb057986"
 dependencies = [
  "jsonrpc-core",
  "log",
  "parking_lot",
+ "rand",
  "serde",
 ]
 
@@ -1126,9 +1270,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.70"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3baa92041a6fec78c687fa0cc2b3fae8884f743d672cf551bed1d6dac6988d0f"
+checksum = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
 
 [[package]]
 name = "libgit2-sys"
@@ -1224,6 +1368,12 @@ name = "maybe-uninit"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
+
+[[package]]
+name = "md5"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e6bcd6433cff03a4bfc3d9834d504467db1f1cf6d0ea765d37d330249ed629d"
 
 [[package]]
 name = "md5"
@@ -1352,9 +1502,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa679ff6578b1cddee93d7e82e263b94a575e0bfced07284eb0c037c1d2416a5"
+checksum = "791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435"
 dependencies = [
  "adler32",
 ]
@@ -1386,7 +1536,7 @@ checksum = "f5e374eff525ce1c5b7687c4cef63943e7686524a387933ad27ca7ec43779cb3"
 dependencies = [
  "log",
  "mio",
- "miow 0.3.4",
+ "miow 0.3.5",
  "winapi 0.3.8",
 ]
 
@@ -1415,9 +1565,9 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22dfdd1d51b2639a5abd17ed07005c3af05fb7a2a3b1a1d0d7af1000a520c1c7"
+checksum = "07b88fb9795d4d36d62a012dfbf49a8f5cf12751f36d31a9dbe66d528e58979e"
 dependencies = [
  "socket2",
  "winapi 0.3.8",
@@ -1425,9 +1575,9 @@ dependencies = [
 
 [[package]]
 name = "mobc"
-version = "0.5.7"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e595c66c678c9d2a593c17d871d95bc20b39cb4945b6ded9815caee9b67cd41"
+checksum = "8a9959a6ae8db15668b4cfdeefbcc3be1123bd99ad7432cb88b155307a12dc76"
 dependencies = [
  "async-trait",
  "futures 0.3.5",
@@ -1465,9 +1615,9 @@ dependencies = [
 
 [[package]]
 name = "mysql_common"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba1e8e1b643d108202ced08f4a74f358ab6be05dfa4a53047ef43527d9d43f2"
+checksum = "6d19114eee7404a04b8c936c721a2a41517c57e1b0780b1387a4a7d34e735abf"
 dependencies = [
  "base64 0.12.1",
  "bigdecimal",
@@ -1523,20 +1673,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8536030f9fea7127f841b45bb6243b27255787fb4eb83958aa1ef9d2fdc0c36"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1548,53 +1684,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-complex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
 name = "num-integer"
-version = "0.1.42"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
+checksum = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
 dependencies = [
  "autocfg",
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfb0800a0291891dd9f4fe7bd9c19384f98f7fbe0cd0f39a2c6b88b9868bbc00"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
-dependencies = [
- "autocfg",
- "num-bigint",
- "num-integer",
  "num-traits",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
+checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
 dependencies = [
  "autocfg",
 ]
@@ -1649,9 +1752,9 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.56"
+version = "0.9.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02309a7f127000ed50594f0b50ecc69e7c654e16d41b4e8156d1b3df8e0b52e"
+checksum = "a842db4709b604f0fe5d1170ae3565899be2ad3d9cbc72dedc789ac0511f78de"
 dependencies = [
  "autocfg",
  "cc",
@@ -1784,29 +1887,29 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.17"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc93aeee735e60ecb40cf740eb319ff23eab1c5748abfdb5c180e4ce49f7791"
+checksum = "e75373ff9037d112bb19bc61333a06a159eaeb217660dcfbea7d88e1db823919"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.17"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e58db2081ba5b4c93bd6be09c40fd36cb9193a8336c384f3b40012e531aa7e40"
+checksum = "10b4b44893d3c370407a1d6a5cfde7c41ae0478e31c516c85f67eb3adc51be6d"
 dependencies = [
- "proc-macro2 1.0.13",
- "quote 1.0.6",
- "syn 1.0.30",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.31",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.5"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7505eeebd78492e0f6108f7171c4948dbb120ee8119d9d77d0afa5469bef67f"
+checksum = "282adbf10f2698a7a77f8e983a74b2d18176c19a7fd32a45446139ae7b02b715"
 
 [[package]]
 name = "pin-utils"
@@ -1859,7 +1962,7 @@ dependencies = [
  "bytes",
  "fallible-iterator",
  "hmac",
- "md5",
+ "md5 0.7.0",
  "memchr",
  "rand",
  "sha2",
@@ -1887,6 +1990,12 @@ name = "ppv-lite86"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
+
+[[package]]
+name = "pretty-hex"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be91bcc43e73799dc46a6c194a55e7aae1d86cc867c860fd4a436019af21bd8c"
 
 [[package]]
 name = "pretty_assertions"
@@ -1971,9 +2080,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98e9e4b82e0ef281812565ea4751049f1bdcdfccda7d3f459f2e138a40c08678"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.13",
- "quote 1.0.6",
- "syn 1.0.30",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.31",
  "version_check",
 ]
 
@@ -1983,24 +2092,24 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f5444ead4e9935abd7f27dc51f7e852a0569ac888096d5ec2499470794e2e53"
 dependencies = [
- "proc-macro2 1.0.13",
- "quote 1.0.6",
- "syn 1.0.30",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.31",
  "syn-mid",
  "version_check",
 ]
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d659fe7c6d27f25e9d80a1a094c223f5246f6a6596453e09d7229bf42750b63"
+checksum = "7e0456befd48169b9f13ef0f0ad46d492cf9d2dbb918bcf38e01eed4ce3ec5e4"
 
 [[package]]
 name = "proc-macro-nested"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e946095f9d3ed29ec38de908c22f95d9ac008e424c7bcae54c75a79c527c694"
+checksum = "0afe1bd463b9e9ed51d0e0f0b50b6b146aec855c56fd182bb242388710a9b6de"
 
 [[package]]
 name = "proc-macro2"
@@ -2013,9 +2122,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.13"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f5ffe53a6b28e37c9c1ce74893477864d64f74778a93a4beb43c8fa167f639"
+checksum = "beae6331a816b1f65d04c45b078fd8e6c93e8071771f41b8163255bbd8d7c8fa"
 dependencies = [
  "unicode-xid 0.2.0",
 ]
@@ -2023,7 +2132,7 @@ dependencies = [
 [[package]]
 name = "quaint"
 version = "0.2.0-alpha.12"
-source = "git+https://github.com/prisma/quaint#7abc33de55a669ce0712c29cd946daaa8e220024"
+source = "git+https://github.com/prisma/quaint?branch=mssql-support#329b0b4473a0b63e0d99972c3d749861db1ec4f4"
 dependencies = [
  "async-trait",
  "base64 0.11.0",
@@ -2031,6 +2140,7 @@ dependencies = [
  "bytes",
  "chrono",
  "futures 0.3.5",
+ "hex",
  "libsqlite3-sys",
  "log",
  "metrics",
@@ -2046,8 +2156,10 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "tiberius",
  "tokio",
  "tokio-postgres",
+ "tokio-util 0.3.1",
  "tracing",
  "tracing-core",
  "url 2.1.1",
@@ -2162,11 +2274,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a21852a652ad6f610c9510194f398ff6f8692e334fd1145fed931f7fbe44ea"
+checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 dependencies = [
- "proc-macro2 1.0.13",
+ "proc-macro2 1.0.18",
 ]
 
 [[package]]
@@ -2218,9 +2330,9 @@ checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 
 [[package]]
 name = "regex"
-version = "1.3.7"
+version = "1.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6020f034922e3194c711b82a627453881bc4682166cabb07134a10c26ba7692"
+checksum = "9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2240,9 +2352,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.17"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae"
+checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
 
 [[package]]
 name = "remove_dir_all"
@@ -2286,9 +2398,9 @@ version = "5.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60cacc306d294556771c6e92737ba7e6be0264144bc46dd713a14ef384b0d6b8"
 dependencies = [
- "quote 1.0.6",
+ "quote 1.0.7",
  "rust-embed-utils",
- "syn 1.0.30",
+ "syn 1.0.31",
  "walkdir",
 ]
 
@@ -2303,15 +2415,16 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.1.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "554c43621fd8c80b44c0c2ba021f108497ff070d5712cba4bb7ceb4d81c280aa"
+checksum = "26b5f52edf35045e96b07aa29822bf4ce8495295fd5610270f85ab1f26df7ba5"
 dependencies = [
  "byteorder",
  "bytes",
- "num",
+ "num-traits",
  "postgres",
  "serde",
+ "tokio-postgres",
 ]
 
 [[package]]
@@ -2331,9 +2444,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3d612bc64430efeb3f7ee6ef26d590dce0c43249217bddc62112540c7941e1"
+checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "same-file"
@@ -2400,29 +2513,29 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.110"
+version = "1.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99e7b308464d16b56eba9964e4972a3eee817760ab60d88c3f86e1fecb08204c"
+checksum = "c9124df5b40cbd380080b2cc6ab894c040a3070d995f5c9dc77e18c34a8ae37d"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.110"
+version = "1.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818fbf6bfa9a42d3bfcaca148547aa00c7b915bec71d1757aa2d44ca68771984"
+checksum = "3f2c3ac8e6ca1e9c80b8be1023940162bf81ae3cffbb1809474152f2ce1eb250"
 dependencies = [
- "proc-macro2 1.0.13",
- "quote 1.0.6",
- "syn 1.0.30",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.31",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.53"
+version = "1.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993948e75b189211a9b31a7528f950c6adc21f9720b6438ff80a7fa2f864cea2"
+checksum = "ec2c5d7e739bc07a3e73381a39d61fdb5f671c60c1df26a130690665803d8226"
 dependencies = [
  "indexmap",
  "itoa",
@@ -2447,9 +2560,9 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d08338d8024b227c62bd68a12c7c9883f5c66780abaef15c550dc56f46ee6515"
 dependencies = [
- "proc-macro2 1.0.13",
- "quote 1.0.6",
- "syn 1.0.30",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.31",
 ]
 
 [[package]]
@@ -2472,9 +2585,9 @@ checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 
 [[package]]
 name = "sha2"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27044adfd2e1f077f649f59deb9490d3941d674002f7d062870a60ebe9bd47a0"
+checksum = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
 dependencies = [
  "block-buffer",
  "digest",
@@ -2635,9 +2748,12 @@ dependencies = [
 
 [[package]]
 name = "standback"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47e4b8c631c998468961a9ea159f064c5c8499b95b5e4a34b77849d45949d540"
+checksum = "b0437cfb83762844799a60e1e3b489d5ceb6a650fbacb86437badc1b6d87b246"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "static_assertions"
@@ -2665,11 +2781,11 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
 dependencies = [
- "proc-macro2 1.0.13",
- "quote 1.0.6",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
  "serde",
  "serde_derive",
- "syn 1.0.30",
+ "syn 1.0.31",
 ]
 
 [[package]]
@@ -2679,13 +2795,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
 dependencies = [
  "base-x",
- "proc-macro2 1.0.13",
- "quote 1.0.6",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
  "serde",
  "serde_derive",
  "serde_json",
  "sha1",
- "syn 1.0.30",
+ "syn 1.0.31",
 ]
 
 [[package]]
@@ -2735,9 +2851,9 @@ checksum = "d239ca4b13aee7a2142e6795cbd69e457665ff8037aed33b3effdc430d2f927a"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.13",
- "quote 1.0.6",
- "syn 1.0.30",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.31",
 ]
 
 [[package]]
@@ -2770,12 +2886,12 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.30"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93a56fabc59dce20fe48b6c832cc249c713e7ed88fa28b0ee0a3bfcaae5fe4e2"
+checksum = "b5304cfdf27365b7585c25d4af91b35016ed21ef88f17ced89c7093b43dba8b6"
 dependencies = [
- "proc-macro2 1.0.13",
- "quote 1.0.6",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
  "unicode-xid 0.2.0",
 ]
 
@@ -2785,9 +2901,9 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
 dependencies = [
- "proc-macro2 1.0.13",
- "quote 1.0.6",
- "syn 1.0.30",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.31",
 ]
 
 [[package]]
@@ -2801,13 +2917,13 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
+checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
- "proc-macro2 1.0.13",
- "quote 1.0.6",
- "syn 1.0.30",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.31",
  "unicode-xid 0.2.0",
 ]
 
@@ -2844,9 +2960,9 @@ version = "0.1.0"
 dependencies = [
  "darling",
  "once_cell",
- "proc-macro2 1.0.13",
- "quote 1.0.6",
- "syn 1.0.30",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.31",
  "test-setup",
 ]
 
@@ -2874,22 +2990,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5976891d6950b4f68477850b5b9e5aa64d955961466f9e174363f573e54e8ca7"
+checksum = "b13f926965ad00595dd129fa12823b04bbf866e9085ab0a5f2b05b850fbfc344"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab81dbd1cd69cd2ce22ecfbdd3bdb73334ba25350649408cc6c085f46d89573d"
+checksum = "893582086c2f98cde18f906265a65b5030a074b1046c674ae898be6519a7f479"
 dependencies = [
- "proc-macro2 1.0.13",
- "quote 1.0.6",
- "syn 1.0.30",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.31",
 ]
 
 [[package]]
@@ -2899,6 +3015,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "tiberius"
+version = "0.4.3"
+source = "git+https://github.com/prisma/tiberius?branch=nextbytes-as-send#1e8fa5c1b5640ddf4efbe1092dace66428df288c"
+dependencies = [
+ "async-native-tls",
+ "async-stream",
+ "async-trait",
+ "bitflags",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "encoding",
+ "futures 0.3.5",
+ "futures-sink",
+ "futures-util",
+ "futures_codec",
+ "once_cell",
+ "pin-project-lite",
+ "pretty-hex",
+ "rust_decimal",
+ "thiserror",
+ "tokio",
+ "tokio-util 0.3.1",
+ "tracing",
+ "uuid",
+ "winauth",
 ]
 
 [[package]]
@@ -2943,10 +3088,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5c3be1edfad6027c69f5491cf4cb310d1a71ecd6af742788c6ff8bced86b8fa"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.13",
- "quote 1.0.6",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
  "standback",
- "syn 1.0.30",
+ "syn 1.0.31",
 ]
 
 [[package]]
@@ -2976,9 +3121,9 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
 dependencies = [
- "proc-macro2 1.0.13",
- "quote 1.0.6",
- "syn 1.0.30",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.31",
 ]
 
 [[package]]
@@ -3035,6 +3180,7 @@ checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "log",
  "pin-project-lite",
@@ -3058,11 +3204,12 @@ checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
 
 [[package]]
 name = "tracing"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c6b59d116d218cb2d990eb06b77b64043e0268ef7323aae63d8b30ae462923"
+checksum = "a41f40ed0e162c911ac6fcb53ecdc8134c46905fdbbae8c50add462a538b495f"
 dependencies = [
  "cfg-if",
+ "log",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -3073,9 +3220,9 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99bbad0de3fd923c9c3232ead88510b783e5a4d16a6154adffa3d53308de984c"
 dependencies = [
- "proc-macro2 1.0.13",
- "quote 1.0.6",
- "syn 1.0.30",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.31",
 ]
 
 [[package]]
@@ -3266,10 +3413,10 @@ version = "0.1.0"
 dependencies = [
  "darling",
  "once_cell",
- "proc-macro2 1.0.13",
- "quote 1.0.6",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
  "regex",
- "syn 1.0.30",
+ "syn 1.0.31",
 ]
 
 [[package]]
@@ -3290,15 +3437,16 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
 dependencies = [
+ "md5 0.6.1",
  "rand",
  "serde",
 ]
 
 [[package]]
 name = "vcpkg"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168"
+checksum = "6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c"
 
 [[package]]
 name = "vec_map"
@@ -3308,9 +3456,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
+checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
 name = "void"
@@ -3364,10 +3512,22 @@ dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
- "proc-macro2 1.0.13",
- "quote 1.0.6",
- "syn 1.0.30",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.31",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64487204d863f109eb77e8462189d111f27cb5712cc9fdb3461297a76963a2f6"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -3376,7 +3536,7 @@ version = "0.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "838e423688dac18d73e31edce74ddfac468e37b1506ad163ffaf0a46f703ffe3"
 dependencies = [
- "quote 1.0.6",
+ "quote 1.0.7",
  "wasm-bindgen-macro-support",
 ]
 
@@ -3386,9 +3546,9 @@ version = "0.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3156052d8ec77142051a533cdd686cba889537b213f948cd1d20869926e68e92"
 dependencies = [
- "proc-macro2 1.0.13",
- "quote 1.0.6",
- "syn 1.0.30",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.31",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3398,6 +3558,16 @@ name = "wasm-bindgen-shared"
 version = "0.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9ba19973a58daf4db6f352eda73dc0e289493cd29fb2632eb172085b6521acd"
+
+[[package]]
+name = "web-sys"
+version = "0.3.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b72fe77fd39e4bd3eaa4412fd299a0be6b3dfe9d2597e2f1c20beb968f41d17"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "winapi"
@@ -3441,6 +3611,19 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winauth"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f820cd208ce9c6b050812dc2d724ba98c6c1e9db5ce9b3f58d925ae5723a5e6"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "md5 0.6.1",
+ "rand",
+ "winapi 0.3.8",
+]
 
 [[package]]
 name = "winutil"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2132,7 +2132,7 @@ dependencies = [
 [[package]]
 name = "quaint"
 version = "0.2.0-alpha.12"
-source = "git+https://github.com/prisma/quaint?branch=mssql-support#e8156d353334437ea2921f20b41ee3e477803ca5"
+source = "git+https://github.com/prisma/quaint#91d2dc2b1761faaf18b3327b36db6b80018eadf2"
 dependencies = [
  "async-trait",
  "base64 0.11.0",
@@ -3019,8 +3019,9 @@ dependencies = [
 
 [[package]]
 name = "tiberius"
-version = "0.4.3"
-source = "git+https://github.com/prisma/tiberius#ccb4e7d62455211f67a142ca8f0deafe12da62c9"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffa425ea5c41bae2609e881c103b3cc901ba25b293242f35ad49de4cc925ed7d"
 dependencies = [
  "async-native-tls",
  "async-stream",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,5 +122,17 @@ services:
       - databases
     tmpfs: /var/lib/mariadb
 
+  mssql-2019:
+    image: mcr.microsoft.com/mssql/server:2019-latest
+    restart: always
+    environment:
+      ACCEPT_EULA: Y
+      SA_PASSWORD: "<YourStrong@Passw0rd>"
+    ports:
+      - "1433:1433"
+    networks:
+      - databases
+    tmpfs: /var/lib/mssql
+
 networks:
   databases:

--- a/introspection-engine/connectors/sql-introspection-connector/Cargo.toml
+++ b/introspection-engine/connectors/sql-introspection-connector/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rust_decimal = "=1.1.0"
+rust_decimal = "1.6"
 prisma-value = { path = "../../../libs/prisma-value" }
 async-trait = "0.1.17"
 introspection-connector = { path = "../introspection-connector" }
@@ -26,6 +26,7 @@ once_cell = "1.3"
 
 [dependencies.quaint]
 git = "https://github.com/prisma/quaint"
+branch = "mssql-support"
 features = ["single"]
 
 [dev-dependencies]

--- a/introspection-engine/connectors/sql-introspection-connector/Cargo.toml
+++ b/introspection-engine/connectors/sql-introspection-connector/Cargo.toml
@@ -26,7 +26,6 @@ once_cell = "1.3"
 
 [dependencies.quaint]
 git = "https://github.com/prisma/quaint"
-branch = "mssql-support"
 features = ["single"]
 
 [dev-dependencies]

--- a/introspection-engine/connectors/sql-introspection-connector/src/schema_describer_loading.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/schema_describer_loading.rs
@@ -30,6 +30,7 @@ pub async fn load_describer(url: &str) -> Result<(Box<dyn SqlSchemaDescriberBack
         ))),
         SqlFamily::Mysql => Box::new(sql_schema_describer::mysql::SqlSchemaDescriber::new(Arc::new(wrapper))),
         SqlFamily::Sqlite => Box::new(sql_schema_describer::sqlite::SqlSchemaDescriber::new(Arc::new(wrapper))),
+        SqlFamily::Mssql => todo!("Greetings from Redmond"),
     };
 
     Ok((describer, connection_info))

--- a/introspection-engine/connectors/sql-introspection-connector/src/version_checker.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/version_checker.rs
@@ -197,6 +197,7 @@ impl VersionChecker {
             SqlFamily::Postgres if self.is_prisma_1(warnings) => Version::Prisma1,
             SqlFamily::Postgres if self.is_prisma_1_1(warnings) => Version::Prisma11,
             SqlFamily::Postgres => Version::NonPrisma,
+            SqlFamily::Mssql => todo!("Greetings from Redmond"),
         }
     }
 }

--- a/introspection-engine/connectors/sql-introspection-connector/tests/test_harness/test_api.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/tests/test_harness/test_api.rs
@@ -64,6 +64,7 @@ impl TestApi {
                 SqlFamily::Mysql => barrel::SqlVariant::Mysql,
                 SqlFamily::Postgres => barrel::SqlVariant::Pg,
                 SqlFamily::Sqlite => barrel::SqlVariant::Sqlite,
+                SqlFamily::Mssql => todo!("Greetings from Redmond"),
             },
         }
     }

--- a/libs/datamodel/connectors/datamodel-connector/Cargo.toml
+++ b/libs/datamodel/connectors/datamodel-connector/Cargo.toml
@@ -8,3 +8,6 @@ edition = "2018"
 
 [dependencies]
 serde = { version = "1.0.90", features = ["derive"] }
+
+[features]
+mssql = []

--- a/libs/datamodel/connectors/datamodel-connector/src/example_connector.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/example_connector.rs
@@ -14,6 +14,17 @@ impl ExampleConnector {
         }
     }
 
+    pub fn mssql() -> DeclarativeConnector {
+        DeclarativeConnector {
+            type_aliases: vec![],
+            field_type_constructors: vec![],
+            supports_scalar_lists: false,
+            supports_relations_over_non_unique_criteria: false,
+            supports_enums: false,
+            supports_json: false,
+        }
+    }
+
     pub fn mysql() -> DeclarativeConnector {
         DeclarativeConnector {
             type_aliases: vec![],

--- a/libs/datamodel/connectors/datamodel-connector/src/example_connector.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/example_connector.rs
@@ -14,6 +14,7 @@ impl ExampleConnector {
         }
     }
 
+    #[cfg(feature = "mssql")]
     pub fn mssql() -> DeclarativeConnector {
         DeclarativeConnector {
             type_aliases: vec![],

--- a/libs/datamodel/core/Cargo.toml
+++ b/libs/datamodel/core/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 prisma-value = { path = "../../prisma-value" }
-rust_decimal = "=1.1.0"
+rust_decimal = "1.6"
 datamodel-connector = { path = "../connectors/datamodel-connector" }
 # Temporary until PR is accepted.
 pest = { version = "2.1.0", package = 'pest_tmp' }

--- a/libs/datamodel/core/Cargo.toml
+++ b/libs/datamodel/core/Cargo.toml
@@ -27,3 +27,7 @@ indoc = "0.3.5"
 pretty_assertions = "0.6.1"
 clap = "2.33"
 serial_test = "*"
+
+[features]
+default = []
+mssql = ["datamodel-connector/mssql"]

--- a/libs/datamodel/core/src/configuration/source/builtin/README.md
+++ b/libs/datamodel/core/src/configuration/source/builtin/README.md
@@ -1,5 +1,5 @@
 # Builtin Sources
 
-This directory contains boilerplate for builtin sources for Postgresql, MySQL and Sqlite.
+This directory contains boilerplate for builtin sources for Postgresql, MySQL, MSSQL and Sqlite.
 
 For a more complete example, including parameter and directives, please see the unit test `source_plugin.ts`.

--- a/libs/datamodel/core/src/configuration/source/builtin/mod.rs
+++ b/libs/datamodel/core/src/configuration/source/builtin/mod.rs
@@ -1,5 +1,8 @@
+#[cfg(feature = "mssql")]
 mod mssql_source;
+#[cfg(feature = "mssql")]
 mod mssql_source_definition;
+
 mod mysql_source;
 mod mysql_source_definition;
 mod postgres_source;
@@ -8,8 +11,11 @@ mod shared_validation;
 mod sqlite_source;
 mod sqlite_source_definition;
 
+#[cfg(feature = "mssql")]
 pub use mssql_source::*;
+#[cfg(feature = "mssql")]
 pub use mssql_source_definition::*;
+
 pub use mysql_source::*;
 pub use mysql_source_definition::*;
 pub use postgres_source::*;

--- a/libs/datamodel/core/src/configuration/source/builtin/mod.rs
+++ b/libs/datamodel/core/src/configuration/source/builtin/mod.rs
@@ -1,3 +1,5 @@
+mod mssql_source;
+mod mssql_source_definition;
 mod mysql_source;
 mod mysql_source_definition;
 mod postgres_source;
@@ -6,6 +8,8 @@ mod shared_validation;
 mod sqlite_source;
 mod sqlite_source_definition;
 
+pub use mssql_source::*;
+pub use mssql_source_definition::*;
 pub use mysql_source::*;
 pub use mysql_source_definition::*;
 pub use postgres_source::*;

--- a/libs/datamodel/core/src/configuration/source/builtin/mssql_source.rs
+++ b/libs/datamodel/core/src/configuration/source/builtin/mssql_source.rs
@@ -1,0 +1,39 @@
+use crate::configuration::*;
+use datamodel_connector::{Connector, ExampleConnector};
+
+pub const MSSQL_SOURCE_NAME: &str = "sqlserver";
+
+pub struct MSSqlSource {
+    pub(super) name: String,
+    pub(super) url: StringFromEnvVar,
+    pub(super) documentation: Option<String>,
+}
+
+impl Source for MSSqlSource {
+    fn connector_type(&self) -> &str {
+        MSSQL_SOURCE_NAME
+    }
+
+    fn name(&self) -> &String {
+        &self.name
+    }
+
+    fn url(&self) -> &StringFromEnvVar {
+        &self.url
+    }
+
+    fn set_url(&mut self, url: &str) {
+        self.url = StringFromEnvVar {
+            from_env_var: None,
+            value: url.to_string(),
+        };
+    }
+
+    fn documentation(&self) -> &Option<String> {
+        &self.documentation
+    }
+
+    fn connector(&self) -> Box<dyn Connector> {
+        Box::new(ExampleConnector::mssql())
+    }
+}

--- a/libs/datamodel/core/src/configuration/source/builtin/mssql_source.rs
+++ b/libs/datamodel/core/src/configuration/source/builtin/mssql_source.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "mssql")]
+
 use crate::configuration::*;
 use datamodel_connector::{Connector, ExampleConnector};
 

--- a/libs/datamodel/core/src/configuration/source/builtin/mssql_source_definition.rs
+++ b/libs/datamodel/core/src/configuration/source/builtin/mssql_source_definition.rs
@@ -1,0 +1,29 @@
+use super::{shared_validation::*, MSSqlSource, MSSQL_SOURCE_NAME};
+use crate::configuration::*;
+
+pub struct MSSqlSourceDefinition {}
+
+impl MSSqlSourceDefinition {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl SourceDefinition for MSSqlSourceDefinition {
+    fn connector_type(&self) -> &'static str {
+        MSSQL_SOURCE_NAME
+    }
+
+    fn create(
+        &self,
+        name: &str,
+        url: StringFromEnvVar,
+        documentation: &Option<String>,
+    ) -> Result<Box<dyn Source + Send + Sync>, String> {
+        Ok(Box::new(MSSqlSource {
+            name: String::from(name),
+            url: validate_url(name, "sqlserver://", url)?,
+            documentation: documentation.clone(),
+        }))
+    }
+}

--- a/libs/datamodel/core/src/configuration/source/loader.rs
+++ b/libs/datamodel/core/src/configuration/source/loader.rs
@@ -1,5 +1,8 @@
+#[cfg(feature = "mssql")]
+use super::builtin::MSSqlSourceDefinition;
+
 use super::{
-    builtin::{MSSqlSourceDefinition, MySqlSourceDefinition, PostgresSourceDefinition, SqliteSourceDefinition},
+    builtin::{MySqlSourceDefinition, PostgresSourceDefinition, SqliteSourceDefinition},
     traits::{Source, SourceDefinition},
 };
 use crate::ast;
@@ -127,6 +130,7 @@ fn get_builtin_sources() -> Vec<Box<dyn SourceDefinition>> {
         Box::new(MySqlSourceDefinition::new()),
         Box::new(PostgresSourceDefinition::new()),
         Box::new(SqliteSourceDefinition::new()),
+        #[cfg(feature = "mssql")]
         Box::new(MSSqlSourceDefinition::new()),
     ]
 }

--- a/libs/datamodel/core/src/configuration/source/loader.rs
+++ b/libs/datamodel/core/src/configuration/source/loader.rs
@@ -1,5 +1,5 @@
 use super::{
-    builtin::{MySqlSourceDefinition, PostgresSourceDefinition, SqliteSourceDefinition},
+    builtin::{MSSqlSourceDefinition, MySqlSourceDefinition, PostgresSourceDefinition, SqliteSourceDefinition},
     traits::{Source, SourceDefinition},
 };
 use crate::ast;
@@ -127,5 +127,6 @@ fn get_builtin_sources() -> Vec<Box<dyn SourceDefinition>> {
         Box::new(MySqlSourceDefinition::new()),
         Box::new(PostgresSourceDefinition::new()),
         Box::new(SqliteSourceDefinition::new()),
+        Box::new(MSSqlSourceDefinition::new()),
     ]
 }

--- a/libs/datamodel/core/src/configuration/source/mod.rs
+++ b/libs/datamodel/core/src/configuration/source/mod.rs
@@ -5,7 +5,7 @@ mod traits;
 pub mod builtin;
 
 // TODO: i think these constants should move to a more central place.
-pub use builtin::{MYSQL_SOURCE_NAME, POSTGRES_SOURCE_NAME, SQLITE_SOURCE_NAME};
+pub use builtin::{MSSQL_SOURCE_NAME, MYSQL_SOURCE_NAME, POSTGRES_SOURCE_NAME, SQLITE_SOURCE_NAME};
 //pub use json::{render_sources_to_json, render_sources_to_json_value, sources_from_json_value_with_plugins};
 pub use loader::*;
 pub use serializer::*;

--- a/libs/datamodel/core/src/configuration/source/mod.rs
+++ b/libs/datamodel/core/src/configuration/source/mod.rs
@@ -4,8 +4,10 @@ mod traits;
 
 pub mod builtin;
 
+#[cfg(feature = "mssql")]
+pub use builtin::MSSQL_SOURCE_NAME;
 // TODO: i think these constants should move to a more central place.
-pub use builtin::{MSSQL_SOURCE_NAME, MYSQL_SOURCE_NAME, POSTGRES_SOURCE_NAME, SQLITE_SOURCE_NAME};
+pub use builtin::{MYSQL_SOURCE_NAME, POSTGRES_SOURCE_NAME, SQLITE_SOURCE_NAME};
 //pub use json::{render_sources_to_json, render_sources_to_json_value, sources_from_json_value_with_plugins};
 pub use loader::*;
 pub use serializer::*;

--- a/libs/datamodel/core/src/json/dmmf/to_dmmf.rs
+++ b/libs/datamodel/core/src/json/dmmf/to_dmmf.rs
@@ -143,7 +143,7 @@ fn prisma_value_to_serde(value: &PrismaValue) -> serde_json::Value {
         }
         PrismaValue::Int(val) => serde_json::Value::Number(serde_json::Number::from_f64(*val as f64).unwrap()),
         PrismaValue::DateTime(val) => serde_json::Value::String(val.to_rfc3339()),
-        PrismaValue::Null => serde_json::Value::Null,
+        PrismaValue::Null(_) => serde_json::Value::Null,
         PrismaValue::Uuid(val) => serde_json::Value::String(val.to_string()),
         PrismaValue::Json(val) => serde_json::Value::String(val.to_string()),
         PrismaValue::List(value_vec) => {

--- a/libs/datamodel/core/src/validator/lower.rs
+++ b/libs/datamodel/core/src/validator/lower.rs
@@ -35,7 +35,7 @@ impl LowerDmlToAst {
             }
         }
 
-        Ok(ast::SchemaAst { tops: tops })
+        Ok(ast::SchemaAst { tops })
     }
 
     pub fn lower_model(&self, model: &dml::Model, datamodel: &dml::Datamodel) -> Result<ast::Model, ErrorCollection> {
@@ -124,7 +124,7 @@ impl LowerDmlToAst {
             PrismaValue::DateTime(value) => ast::Expression::StringValue(value.to_rfc3339(), ast::Span::empty()),
             PrismaValue::Float(value) => ast::Expression::NumericValue(value.to_string(), ast::Span::empty()),
             PrismaValue::Int(value) => ast::Expression::NumericValue(value.to_string(), ast::Span::empty()),
-            PrismaValue::Null => ast::Expression::ConstantValue("null".to_string(), ast::Span::empty()),
+            PrismaValue::Null(_) => ast::Expression::ConstantValue("null".to_string(), ast::Span::empty()),
             PrismaValue::Uuid(val) => ast::Expression::StringValue(val.to_string(), ast::Span::empty()),
             PrismaValue::Json(val) => ast::Expression::StringValue(val.to_string(), ast::Span::empty()),
             PrismaValue::List(vec) => ast::Expression::Array(

--- a/libs/prisma-models/Cargo.toml
+++ b/libs/prisma-models/Cargo.toml
@@ -22,5 +22,5 @@ rand = "0.7"
 datamodel = { path = "../datamodel/core" }
 itertools = "0.8"
 rust_decimal = "1.6"
-quaint = { git = "https://github.com/prisma/quaint", optional = true, features = ["uuid-0_8"], branch = "mssql-support"}
+quaint = { git = "https://github.com/prisma/quaint", optional = true, features = ["uuid-0_8"] }
 prisma-value = { path = "../prisma-value", features = ["sql-ext"] }

--- a/libs/prisma-models/Cargo.toml
+++ b/libs/prisma-models/Cargo.toml
@@ -21,6 +21,6 @@ failure = { version = "0.1", features = ["derive"] }
 rand = "0.7"
 datamodel = { path = "../datamodel/core" }
 itertools = "0.8"
-rust_decimal = "=1.1.0"
-quaint = { git = "https://github.com/prisma/quaint", optional = true, features = ["uuid-0_8"] }
+rust_decimal = "1.6"
+quaint = { git = "https://github.com/prisma/quaint", optional = true, features = ["uuid-0_8"], branch = "mssql-support"}
 prisma-value = { path = "../prisma-value", features = ["sql-ext"] }

--- a/libs/prisma-models/src/field.rs
+++ b/libs/prisma-models/src/field.rs
@@ -6,6 +6,7 @@ pub use scalar::*;
 
 use crate::prelude::*;
 use datamodel::ScalarType;
+use prisma_value::TypeHint;
 use std::{hash::Hash, sync::Arc};
 
 #[derive(Debug)]
@@ -66,6 +67,21 @@ pub enum TypeIdentifier {
     DateTime,
     UUID,
     Int,
+}
+
+impl From<TypeIdentifier> for TypeHint {
+    fn from(typ: TypeIdentifier) -> Self {
+        match typ {
+            TypeIdentifier::String => TypeHint::String,
+            TypeIdentifier::Float => TypeHint::Float,
+            TypeIdentifier::Boolean => TypeHint::Boolean,
+            TypeIdentifier::Enum(_) => TypeHint::Enum,
+            TypeIdentifier::Json => TypeHint::Json,
+            TypeIdentifier::DateTime => TypeHint::DateTime,
+            TypeIdentifier::UUID => TypeHint::UUID,
+            TypeIdentifier::Int => TypeHint::Int,
+        }
+    }
 }
 
 impl Field {

--- a/libs/prisma-models/src/prisma_value_ext.rs
+++ b/libs/prisma-models/src/prisma_value_ext.rs
@@ -13,7 +13,7 @@ impl PrismaValueExtensions for PrismaValue {
     fn coerce(self, to_type: &TypeIdentifier) -> crate::Result<PrismaValue> {
         let coerced = match (self, to_type) {
             // Trivial cases
-            (val @ PrismaValue::Null, _) => val,
+            (PrismaValue::Null(_), identifier) => PrismaValue::null(identifier.clone()),
             (val @ PrismaValue::String(_), TypeIdentifier::String) => val,
             (val @ PrismaValue::Int(_), TypeIdentifier::Int) => val,
             (val @ PrismaValue::Float(_), TypeIdentifier::Float) => val,

--- a/libs/prisma-models/src/projections/model_projection.rs
+++ b/libs/prisma-models/src/projections/model_projection.rs
@@ -116,7 +116,7 @@ impl ModelProjection {
     /// Creates a record projection of the model projection containing only null values.
     pub fn empty_record_projection(&self) -> RecordProjection {
         self.scalar_fields()
-            .map(|f| (f.clone(), PrismaValue::Null))
+            .map(|f| (f.clone(), PrismaValue::null(f.type_identifier.clone())))
             .collect::<Vec<_>>()
             .into()
     }

--- a/libs/prisma-models/src/sql_ext/column.rs
+++ b/libs/prisma-models/src/sql_ext/column.rs
@@ -148,6 +148,11 @@ where
         let table = sf.model().db_name().to_string();
         let col = sf.db_name().to_string();
 
-        Column::from(((db, table), col))
+        let column = Column::from(((db, table), col));
+
+        match sf.default_value.as_ref().and_then(|d| d.get()) {
+            Some(default) => column.default(default),
+            None => column.default(quaint::ast::DefaultValue::Generated),
+        }
     }
 }

--- a/libs/prisma-models/src/sql_ext/table.rs
+++ b/libs/prisma-models/src/sql_ext/table.rs
@@ -1,5 +1,6 @@
+use super::AsColumn;
 use crate::Model;
-use quaint::ast::Table;
+use quaint::ast::{Column, Table};
 
 pub trait AsTable {
     fn as_table(&self) -> Table<'static>;
@@ -7,6 +8,11 @@ pub trait AsTable {
 
 impl AsTable for Model {
     fn as_table(&self) -> Table<'static> {
-        (self.internal_data_model().db_name.clone(), self.db_name().to_string()).into()
+        let table: Table<'static> = (self.internal_data_model().db_name.clone(), self.db_name().to_string()).into();
+
+        self.unique_indexes().into_iter().fold(table, |table, index| {
+            let index: Vec<Column<'static>> = index.fields().iter().map(AsColumn::as_column).collect();
+            table.add_unique_index(index)
+        })
     }
 }

--- a/libs/prisma-value/Cargo.toml
+++ b/libs/prisma-value/Cargo.toml
@@ -20,6 +20,5 @@ once_cell = "1.3"
 
 [dependencies.quaint]
 git = "https://github.com/prisma/quaint"
-branch = "mssql-support"
 optional = true
 features = ["uuid-0_8", "array", "single-postgresql"]

--- a/libs/prisma-value/Cargo.toml
+++ b/libs/prisma-value/Cargo.toml
@@ -14,11 +14,12 @@ serde_json = "1.0"
 serde = "1.0"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 chrono = { version = "0.4", features = ["serde"] }
-rust_decimal = "=1.1.0"
+rust_decimal = "1.6"
 regex = "1.2"
 once_cell = "1.3"
 
 [dependencies.quaint]
 git = "https://github.com/prisma/quaint"
+branch = "mssql-support"
 optional = true
 features = ["uuid-0_8", "array", "single-postgresql"]

--- a/libs/prisma-value/src/lib.rs
+++ b/libs/prisma-value/src/lib.rs
@@ -16,6 +16,22 @@ use rust_decimal::prelude::FromPrimitive;
 #[cfg(feature = "sql-ext")]
 pub use sql_ext::*;
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum TypeHint {
+    String,
+    Float,
+    Boolean,
+    Enum,
+    Json,
+    DateTime,
+    UUID,
+    Int,
+    Array,
+    Char,
+    Bytes,
+    Unknown,
+}
+
 #[derive(Debug, PartialEq, Clone, Eq, Hash, Serialize, Deserialize, PartialOrd, Ord)]
 #[serde(untagged)]
 pub enum PrismaValue {
@@ -23,7 +39,9 @@ pub enum PrismaValue {
     Boolean(bool),
     Enum(String),
     Int(i64),
-    Null,
+
+    #[serde(serialize_with = "serialize_null")]
+    Null(TypeHint),
     Uuid(Uuid),
     List(PrismaListValue),
     Json(String),
@@ -51,7 +69,7 @@ impl TryFrom<serde_json::Value> for PrismaValue {
                 let vals: PrismaValueResult<Vec<PrismaValue>> = v.into_iter().map(PrismaValue::try_from).collect();
                 Ok(PrismaValue::List(vals?))
             }
-            serde_json::Value::Null => Ok(PrismaValue::Null),
+            serde_json::Value::Null => Ok(PrismaValue::Null(TypeHint::Unknown)),
             serde_json::Value::Bool(b) => Ok(PrismaValue::Boolean(b)),
             serde_json::Value::Number(num) => {
                 if num.is_i64() {
@@ -76,6 +94,13 @@ where
     format!("{}", stringify_date(date)).serialize(serializer)
 }
 
+fn serialize_null<S>(_: &TypeHint, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    Option::<u8>::None.serialize(serializer)
+}
+
 fn serialize_decimal<S>(decimal: &Decimal, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
@@ -84,9 +109,16 @@ where
 }
 
 impl PrismaValue {
+    pub fn null<I>(hint: I) -> Self
+    where
+        I: Into<TypeHint>,
+    {
+        Self::Null(hint.into())
+    }
+
     pub fn is_null(&self) -> bool {
         match self {
-            PrismaValue::Null => true,
+            PrismaValue::Null(_) => true,
             _ => false,
         }
     }
@@ -123,7 +155,7 @@ impl fmt::Display for PrismaValue {
             PrismaValue::DateTime(x) => x.fmt(f),
             PrismaValue::Enum(x) => x.fmt(f),
             PrismaValue::Int(x) => x.fmt(f),
-            PrismaValue::Null => "null".fmt(f),
+            PrismaValue::Null(_) => "null".fmt(f),
             PrismaValue::Uuid(x) => x.fmt(f),
             PrismaValue::Json(x) => x.fmt(f),
             PrismaValue::List(x) => {

--- a/libs/prisma-value/src/sql_ext.rs
+++ b/libs/prisma-value/src/sql_ext.rs
@@ -1,25 +1,59 @@
-use crate::PrismaValue;
+use crate::{PrismaValue, TypeHint};
+use chrono::{DateTime, NaiveDate, Utc};
 use quaint::ast::Value;
 
 impl<'a> From<Value<'a>> for PrismaValue {
     fn from(pv: Value<'a>) -> Self {
         match pv {
-            Value::Null => PrismaValue::Null,
-            Value::Integer(i) => PrismaValue::Int(i),
-            Value::Real(d) => PrismaValue::Float(d),
-            Value::Text(s) => PrismaValue::String(s.into_owned()),
-            Value::Enum(s) => PrismaValue::Enum(s.into_owned()),
-            Value::Boolean(b) => PrismaValue::Boolean(b),
-            Value::Array(v) => PrismaValue::List(v.into_iter().map(PrismaValue::from).collect()),
-            Value::Json(val) => PrismaValue::Json(val.to_string()),
-            Value::Uuid(uuid) => PrismaValue::Uuid(uuid),
-            Value::DateTime(dt) => PrismaValue::DateTime(dt),
-            Value::Char(c) => PrismaValue::String(c.to_string()),
-            Value::Bytes(bytes) => {
-                let s = String::from_utf8(bytes.into_owned()).expect("PrismaValue::String from Value::Bytes");
-
-                PrismaValue::String(s)
-            }
+            Value::Integer(i) => i
+                .map(|i| PrismaValue::Int(i))
+                .unwrap_or(PrismaValue::null(TypeHint::Int)),
+            Value::Real(d) => d
+                .map(|d| PrismaValue::Float(d))
+                .unwrap_or(PrismaValue::null(TypeHint::Float)),
+            Value::Text(s) => s
+                .map(|s| PrismaValue::String(s.into_owned()))
+                .unwrap_or(PrismaValue::null(TypeHint::String)),
+            Value::Enum(s) => s
+                .map(|s| PrismaValue::Enum(s.into_owned()))
+                .unwrap_or(PrismaValue::null(TypeHint::Enum)),
+            Value::Boolean(b) => b
+                .map(|b| PrismaValue::Boolean(b))
+                .unwrap_or(PrismaValue::null(TypeHint::Boolean)),
+            Value::Array(v) => v
+                .map(|v| PrismaValue::List(v.into_iter().map(PrismaValue::from).collect()))
+                .unwrap_or(PrismaValue::null(TypeHint::Array)),
+            Value::Json(val) => val
+                .map(|val| PrismaValue::Json(val.to_string()))
+                .unwrap_or(PrismaValue::null(TypeHint::Json)),
+            Value::Uuid(uuid) => uuid
+                .map(|uuid| PrismaValue::Uuid(uuid))
+                .unwrap_or(PrismaValue::null(TypeHint::UUID)),
+            Value::Date(d) => d
+                .map(|d| {
+                    let dt = DateTime::<Utc>::from_utc(d.and_hms(0, 0, 0), Utc);
+                    PrismaValue::DateTime(dt)
+                })
+                .unwrap_or(PrismaValue::null(TypeHint::DateTime)),
+            Value::Time(t) => t
+                .map(|t| {
+                    let d = NaiveDate::from_ymd(1970, 1, 1);
+                    let dt = DateTime::<Utc>::from_utc(d.and_time(t), Utc);
+                    PrismaValue::DateTime(dt)
+                })
+                .unwrap_or(PrismaValue::null(TypeHint::DateTime)),
+            Value::DateTime(dt) => dt
+                .map(|dt| PrismaValue::DateTime(dt))
+                .unwrap_or(PrismaValue::null(TypeHint::DateTime)),
+            Value::Char(c) => c
+                .map(|c| PrismaValue::String(c.to_string()))
+                .unwrap_or(PrismaValue::null(TypeHint::Char)),
+            Value::Bytes(bytes) => bytes
+                .map(|bytes| {
+                    let s = String::from_utf8(bytes.into_owned()).expect("PrismaValue::String from Value::Bytes");
+                    PrismaValue::String(s)
+                })
+                .unwrap_or(PrismaValue::null(TypeHint::Bytes)),
         }
     }
 }
@@ -31,12 +65,24 @@ impl<'a> From<PrismaValue> for Value<'a> {
             PrismaValue::Float(f) => f.into(),
             PrismaValue::Boolean(b) => b.into(),
             PrismaValue::DateTime(d) => d.into(),
-            PrismaValue::Enum(e) => Value::Enum(e.into()),
+            PrismaValue::Enum(e) => e.into(),
             PrismaValue::Int(i) => (i as i64).into(),
-            PrismaValue::Null => Value::Null,
             PrismaValue::Uuid(u) => u.to_string().into(),
-            PrismaValue::List(l) => Value::Array(l.into_iter().map(|x| x.into()).collect()),
+            PrismaValue::List(l) => Value::Array(Some(l.into_iter().map(|x| x.into()).collect())),
             PrismaValue::Json(s) => Value::Json(serde_json::from_str(&s).unwrap()),
+            PrismaValue::Null(ident) => match ident {
+                TypeHint::String => Value::Text(None),
+                TypeHint::Float => Value::Real(None),
+                TypeHint::Boolean => Value::Boolean(None),
+                TypeHint::Enum => Value::Enum(None),
+                TypeHint::Json => Value::Json(None),
+                TypeHint::DateTime => Value::DateTime(None),
+                TypeHint::UUID => Value::Uuid(None),
+                TypeHint::Int => Value::Integer(None),
+                TypeHint::Array => Value::Array(None),
+                TypeHint::Char | TypeHint::Unknown => Value::Char(None),
+                TypeHint::Bytes => Value::Bytes(None),
+            },
         }
     }
 }

--- a/libs/sql-schema-describer/Cargo.toml
+++ b/libs/sql-schema-describer/Cargo.toml
@@ -18,7 +18,6 @@ thiserror = "1.0.16"
 
 [dependencies.quaint]
 git = "https://github.com/prisma/quaint"
-branch = "mssql-support"
 features = ["single", "serde-support"]
 
 [dev-dependencies]

--- a/libs/sql-schema-describer/Cargo.toml
+++ b/libs/sql-schema-describer/Cargo.toml
@@ -12,12 +12,13 @@ tracing = "0.1"
 regex = "1.2"
 async-trait = "0.1.17"
 once_cell = "1.3"
-rust_decimal = "=1.1.0"
+rust_decimal = "1.6"
 prisma-value = { path = "../prisma-value" }
 thiserror = "1.0.16"
 
 [dependencies.quaint]
 git = "https://github.com/prisma/quaint"
+branch = "mssql-support"
 features = ["single", "serde-support"]
 
 [dev-dependencies]

--- a/libs/sql-schema-describer/src/sqlite.rs
+++ b/libs/sql-schema-describer/src/sqlite.rs
@@ -143,8 +143,8 @@ impl SqlSchemaDescriber {
 
                 let default = match row.get("dflt_value") {
                     None => None,
-                    Some(Value::Null) => None,
-                    Some(Value::Text(cow_string)) => {
+                    Some(val) if val.is_null() => None,
+                    Some(Value::Text(Some(cow_string))) => {
                         let default_string = cow_string.to_string();
 
                         if default_string.to_lowercase() == "null" {

--- a/libs/sql-schema-describer/tests/introspection_tests.rs
+++ b/libs/sql-schema-describer/tests/introspection_tests.rs
@@ -20,6 +20,7 @@ fn int_full_data_type(api: &TestApi) -> String {
         (SqlFamily::Sqlite, _) => "INTEGER".to_string(),
         (SqlFamily::Mysql, "mysql8") => "int".to_string(),
         (SqlFamily::Mysql, _) => "int(11)".to_string(),
+        (SqlFamily::Mssql, _) => "int".to_string(),
     }
 }
 
@@ -29,6 +30,7 @@ fn int_data_type(api: &TestApi) -> String {
         (SqlFamily::Sqlite, _) => "INTEGER".to_string(),
         (SqlFamily::Mysql, "mysql8") => "int".to_string(),
         (SqlFamily::Mysql, _) => "int".to_string(),
+        (SqlFamily::Mssql, _) => "int".to_string(),
     }
 }
 
@@ -38,6 +40,7 @@ fn varchar_data_type(api: &TestApi, length: u64) -> String {
         (SqlFamily::Sqlite, _) => format!("VARCHAR({})", length),
         (SqlFamily::Mysql, "mysql8") => "varchar".to_string(),
         (SqlFamily::Mysql, _) => "varchar".to_string(),
+        (SqlFamily::Mssql, _) => format!("NVARCHAR({})", length),
     }
 }
 
@@ -47,6 +50,7 @@ fn varchar_full_data_type(api: &TestApi, length: u64) -> String {
         (SqlFamily::Sqlite, _) => format!("VARCHAR({})", length),
         (SqlFamily::Mysql, "mysql8") => format!("varchar({})", length),
         (SqlFamily::Mysql, _) => format!("varchar({})", length),
+        (SqlFamily::Mssql, _) => format!("NVARCHAR({})", length),
     }
 }
 
@@ -158,6 +162,7 @@ async fn foreign_keys_must_work(api: &TestApi) {
                     SqlFamily::Postgres => Some("User_city_fkey".to_owned()),
                     SqlFamily::Mysql => Some("User_ibfk_1".to_owned()),
                     SqlFamily::Sqlite => None,
+                    SqlFamily::Mssql => todo!("Greetings from Redmond"),
                 },
                 columns: vec!["city".to_string()],
                 referenced_columns: vec!["id".to_string()],
@@ -262,6 +267,7 @@ async fn multi_column_foreign_keys_must_work(api: &TestApi) {
                     (SqlFamily::Postgres, _) => Some("User_city_name_fkey".to_owned()),
                     (SqlFamily::Mysql, _) => Some("User_ibfk_1".to_owned()),
                     (SqlFamily::Sqlite, _) => None,
+                    (SqlFamily::Mssql, _) => todo!("Greetings from Redmond"),
                 },
                 columns: vec!["city_name".to_string(), "city".to_string()],
                 referenced_columns: vec!["name".to_string(), "id".to_string(),],
@@ -512,6 +518,7 @@ async fn column_uniqueness_must_be_detected(api: &TestApi) {
             columns: vec!["uniq1".to_string()],
             tpe: IndexType::Unique,
         }),
+        SqlFamily::Mssql => todo!("Greetings from Redmond"),
     };
     assert_eq!(
         user_table,

--- a/libs/sql-schema-describer/tests/test_api/mod.rs
+++ b/libs/sql-schema-describer/tests/test_api/mod.rs
@@ -27,6 +27,7 @@ impl TestApi {
             SqlFamily::Postgres => Box::new(sql_schema_describer::postgres::SqlSchemaDescriber::new(db)),
             SqlFamily::Sqlite => Box::new(sql_schema_describer::sqlite::SqlSchemaDescriber::new(db)),
             SqlFamily::Mysql => Box::new(sql_schema_describer::mysql::SqlSchemaDescriber::new(db)),
+            SqlFamily::Mssql => todo!("Greetings from Redmond"),
         };
 
         Ok(describer.describe(self.schema_name()).await?)
@@ -56,6 +57,7 @@ impl TestApi {
                 SqlFamily::Mysql => barrel::SqlVariant::Mysql,
                 SqlFamily::Postgres => barrel::SqlVariant::Pg,
                 SqlFamily::Sqlite => barrel::SqlVariant::Sqlite,
+                SqlFamily::Mssql => todo!("Hey Barrel, greetings from Redmond"),
             },
         }
     }

--- a/libs/test-setup/Cargo.toml
+++ b/libs/test-setup/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 url = "2.1.1"
 tracing-subscriber = { version = "0.2", features = ["fmt"] }
 tokio = { version = "=0.2.13", optional = true }
-quaint = { git = "https://github.com/prisma/quaint", features = ["single"], optional = true }
+quaint = { git = "https://github.com/prisma/quaint", features = ["single"], optional = true, branch = "mssql-support" }
 once_cell = "1.3.1"
 bitflags = "1.2.1"
 tracing-error = "0.1.2"

--- a/libs/test-setup/Cargo.toml
+++ b/libs/test-setup/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 url = "2.1.1"
 tracing-subscriber = { version = "0.2", features = ["fmt"] }
 tokio = { version = "=0.2.13", optional = true }
-quaint = { git = "https://github.com/prisma/quaint", features = ["single"], optional = true, branch = "mssql-support" }
+quaint = { git = "https://github.com/prisma/quaint", features = ["single"], optional = true }
 once_cell = "1.3.1"
 bitflags = "1.2.1"
 tracing-error = "0.1.2"

--- a/libs/user-facing-errors/Cargo.toml
+++ b/libs/user-facing-errors/Cargo.toml
@@ -15,7 +15,6 @@ tracing = "0.1"
 
 [dependencies.quaint]
 git = "https://github.com/prisma/quaint"
-branch = "mssql-support"
 features = ["mysql", "postgresql", "sqlite"]
 optional = true
 

--- a/libs/user-facing-errors/Cargo.toml
+++ b/libs/user-facing-errors/Cargo.toml
@@ -15,6 +15,7 @@ tracing = "0.1"
 
 [dependencies.quaint]
 git = "https://github.com/prisma/quaint"
+branch = "mssql-support"
 features = ["mysql", "postgresql", "sqlite"]
 optional = true
 

--- a/migration-engine/cli/Cargo.toml
+++ b/migration-engine/cli/Cargo.toml
@@ -23,10 +23,10 @@ tracing-subscriber = "0.2"
 tracing-error = "0.1.2"
 
 [dev-dependencies]
-quaint = { git = "https://github.com/prisma/quaint" }
 tempfile = "3.1.0"
 test-setup = { path = "../../libs/test-setup" }
 url = "2.1.1"
+quaint = { git = "https://github.com/prisma/quaint", branch = "mssql-support" }
 
 [features]
 default = ["sql"]

--- a/migration-engine/cli/Cargo.toml
+++ b/migration-engine/cli/Cargo.toml
@@ -26,7 +26,7 @@ tracing-error = "0.1.2"
 tempfile = "3.1.0"
 test-setup = { path = "../../libs/test-setup" }
 url = "2.1.1"
-quaint = { git = "https://github.com/prisma/quaint", branch = "mssql-support" }
+quaint = { git = "https://github.com/prisma/quaint" }
 
 [features]
 default = ["sql"]

--- a/migration-engine/connectors/sql-migration-connector/Cargo.toml
+++ b/migration-engine/connectors/sql-migration-connector/Cargo.toml
@@ -14,7 +14,7 @@ migration-connector = { path = "../migration-connector" }
 once_cell = "1.3"
 prisma-models = { path = "../../../libs/prisma-models" }
 prisma-value = { path = "../../../libs/prisma-value" }
-quaint = { git = "https://github.com/prisma/quaint", features = ["single"], branch = "mssql-support" }
+quaint = { git = "https://github.com/prisma/quaint", features = ["single"] }
 regex = "1"
 serde = "1.0"
 serde_json = "1.0"

--- a/migration-engine/connectors/sql-migration-connector/Cargo.toml
+++ b/migration-engine/connectors/sql-migration-connector/Cargo.toml
@@ -14,7 +14,7 @@ migration-connector = { path = "../migration-connector" }
 once_cell = "1.3"
 prisma-models = { path = "../../../libs/prisma-models" }
 prisma-value = { path = "../../../libs/prisma-value" }
-quaint = { git = "https://github.com/prisma/quaint", features = ["single"] }
+quaint = { git = "https://github.com/prisma/quaint", features = ["single"], branch = "mssql-support" }
 regex = "1"
 serde = "1.0"
 serde_json = "1.0"

--- a/migration-engine/connectors/sql-migration-connector/src/flavour.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour.rs
@@ -29,6 +29,7 @@ pub(crate) fn from_connection_info(connection_info: &ConnectionInfo) -> Box<dyn 
         ConnectionInfo::Sqlite { file_path, .. } => Box::new(SqliteFlavour {
             file_path: file_path.clone(),
         }),
+        ConnectionInfo::Mssql(_) => todo!("Greetings from Redmond!"),
     }
 }
 

--- a/migration-engine/connectors/sql-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/lib.rs
@@ -94,6 +94,7 @@ impl SqlMigrationConnector {
                     debug!("{}", sql_str);
                     self.conn().query_raw(&sql_str, &[]).await?;
                 }
+                ConnectionInfo::Mssql(_) => todo!("Greetings from Redmond"),
             };
 
             Ok(())

--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
@@ -209,6 +209,7 @@ fn render_raw_sql(
                 format!("DROP TABLE {};", renderer.quote_with_schema(&schema_name, &name)),
                 "PRAGMA foreign_keys=on".to_string(),
             ]),
+            SqlFamily::Mssql => todo!("Greetings from Redmond"),
         },
         SqlMigrationStep::DropTables(DropTables { names }) => {
             let fully_qualified_names = names.iter().map(|name| renderer.quote_with_schema(&schema_name, &name));
@@ -303,6 +304,7 @@ fn render_raw_sql(
                             lines.push(format!("DROP CONSTRAINT IF EXiSTS {}", constraint_name));
                         }
                         SqlFamily::Sqlite => (),
+                        SqlFamily::Mssql => todo!("Greetings from Redmond"),
                     },
                 };
             }
@@ -330,12 +332,14 @@ fn render_raw_sql(
                 "DROP INDEX {}",
                 renderer.quote_with_schema(&schema_name, &name)
             )]),
+            SqlFamily::Mssql => todo!("Greetings from Redmond"),
         },
         SqlMigrationStep::AlterIndex(AlterIndex {
             table,
             index_name,
             index_new_name,
         }) => match sql_family {
+            SqlFamily::Mssql => todo!("Greetings from Redmond"),
             SqlFamily::Mysql => {
                 // MariaDB and MySQL 5.6 do not support `ALTER TABLE ... RENAME INDEX`.
                 if database_info.is_mariadb() || database_info.is_mysql_5_6() {
@@ -438,6 +442,7 @@ fn create_table_suffix(sql_family: SqlFamily) -> &'static str {
         SqlFamily::Sqlite => ")",
         SqlFamily::Postgres => ")",
         SqlFamily::Mysql => "\n) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci",
+        SqlFamily::Mssql => todo!("Greetings from Redmond"),
     }
 }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker.rs
@@ -136,6 +136,7 @@ impl SqlDestructiveChangesChecker<'_> {
         use crate::sql_migration::expanded_alter_column::*;
 
         match self.sql_family() {
+            SqlFamily::Mssql => todo!("Greetings from Redmond"),
             SqlFamily::Sqlite => {
                 let arity_change_is_safe = match (&differ.previous.tpe.arity, &differ.next.tpe.arity) {
                     // column became required

--- a/migration-engine/connectors/sql-migration-connector/src/sql_migration/expanded_alter_column.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_migration/expanded_alter_column.rs
@@ -18,6 +18,7 @@ pub(crate) fn expand_alter_column(
         SqlFamily::Sqlite => expand_sqlite_alter_column(&column_differ).map(ExpandedAlterColumn::Sqlite),
         SqlFamily::Mysql => expand_mysql_alter_column(&column_differ).map(ExpandedAlterColumn::Mysql),
         SqlFamily::Postgres => expand_postgres_alter_column(&column_differ).map(ExpandedAlterColumn::Postgres),
+        SqlFamily::Mssql => todo!("Greetings from Redmond"),
     }
 }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_migration_persistence.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_migration_persistence.rs
@@ -36,6 +36,7 @@ impl MigrationPersistence for SqlMigrationPersistence<'_> {
                     m.create_table(MIGRATION_TABLE_NAME, migration_table_setup_mysql);
                     m.make_from(barrel::SqlVariant::Mysql)
                 }
+                SqlFamily::Mssql => todo!("Greetings from Detroit^H Redmond"),
             };
 
             self.conn().query_raw(&sql_str, &[]).await.ok();
@@ -112,7 +113,7 @@ impl MigrationPersistence for SqlMigrationPersistence<'_> {
             .value(DATABASE_MIGRATION_COLUMN, database_migration_json)
             .value(ERRORS_COLUMN, errors_json)
             .value(STARTED_AT_COLUMN, self.convert_datetime(migration.started_at))
-            .value(FINISHED_AT_COLUMN, Value::Null);
+            .value(FINISHED_AT_COLUMN, Option::<DateTime<Utc>>::None);
 
         match self.sql_family() {
             SqlFamily::Sqlite | SqlFamily::Mysql => {
@@ -129,6 +130,7 @@ impl MigrationPersistence for SqlMigrationPersistence<'_> {
                     cloned.revision = row["revision"].as_i64().unwrap() as usize;
                 });
             }
+            SqlFamily::Mssql => todo!("Greetings from Redmond"),
         }
 
         Ok(cloned)
@@ -138,7 +140,7 @@ impl MigrationPersistence for SqlMigrationPersistence<'_> {
         crate::catch(self.connection_info(), async {
             let finished_at_value = match params.finished_at {
                 Some(x) => self.convert_datetime(x),
-                None => Value::Null,
+                None => Value::from(Option::<DateTime<Utc>>::None),
             };
             let errors_json = serde_json::to_string(&params.errors).unwrap();
             let query = Update::table(self.table())
@@ -205,17 +207,18 @@ impl<'a> SqlMigrationPersistence<'a> {
 
     fn convert_datetime(&self, datetime: DateTime<Utc>) -> Value<'_> {
         match self.sql_family() {
-            SqlFamily::Sqlite => Value::Integer(datetime.timestamp_millis()),
-            SqlFamily::Postgres => Value::DateTime(datetime),
-            SqlFamily::Mysql => Value::DateTime(datetime),
+            SqlFamily::Sqlite => Value::integer(datetime.timestamp_millis()),
+            SqlFamily::Postgres => Value::datetime(datetime),
+            SqlFamily::Mysql => Value::datetime(datetime),
+            SqlFamily::Mssql => Value::datetime(datetime),
         }
     }
 }
 
 fn convert_parameterized_date_value(db_value: &Value<'_>) -> DateTime<Utc> {
     match db_value {
-        Value::Integer(x) => timestamp_to_datetime(*x),
-        Value::DateTime(x) => x.clone(),
+        Value::Integer(Some(x)) => timestamp_to_datetime(*x),
+        Value::DateTime(Some(x)) => x.clone(),
         x => unimplemented!("Got unsupported value {:?} in date conversion", x),
     }
 }
@@ -240,7 +243,7 @@ fn parse_rows_new(result_set: ResultSet) -> Vec<Migration> {
             let errors_json: String = row[ERRORS_COLUMN].to_string().unwrap();
 
             let finished_at = match &row[FINISHED_AT_COLUMN] {
-                Value::Null => None,
+                v if v.is_null() => None,
                 x => Some(convert_parameterized_date_value(x)),
             };
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mod.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mod.rs
@@ -40,6 +40,7 @@ impl dyn SqlRenderer {
             SqlFamily::Postgres => Box::new(PostgresRenderer {}),
             SqlFamily::Mysql => Box::new(MySqlRenderer {}),
             SqlFamily::Sqlite => Box::new(SqliteRenderer {}),
+            SqlFamily::Mssql => todo!("Greetings from Redmond"),
         }
     }
 }

--- a/migration-engine/core/Cargo.toml
+++ b/migration-engine/core/Cargo.toml
@@ -15,7 +15,7 @@ async-trait = "0.1.17"
 chrono = { version = "0.4", features = ["serde"] }
 futures = { version = "0.3", features = ["compat"] }
 jsonrpc-core = "14.0"
-quaint = { git = "https://github.com/prisma/quaint", optional = true }
+quaint = { git = "https://github.com/prisma/quaint", optional = true, branch = "mssql-support" }
 serde = { version = "1.0" }
 serde_json = "1.0"
 thiserror = "1.0.9"

--- a/migration-engine/core/Cargo.toml
+++ b/migration-engine/core/Cargo.toml
@@ -15,7 +15,7 @@ async-trait = "0.1.17"
 chrono = { version = "0.4", features = ["serde"] }
 futures = { version = "0.3", features = ["compat"] }
 jsonrpc-core = "14.0"
-quaint = { git = "https://github.com/prisma/quaint", optional = true, branch = "mssql-support" }
+quaint = { git = "https://github.com/prisma/quaint", optional = true }
 serde = { version = "1.0" }
 serde_json = "1.0"
 thiserror = "1.0.9"

--- a/migration-engine/migration-engine-tests/Cargo.toml
+++ b/migration-engine/migration-engine-tests/Cargo.toml
@@ -26,7 +26,7 @@ barrel = { version = "0.6.5", features = ["sqlite3", "mysql", "pg"], optional = 
 futures = "0.3.1"
 git2 = { version = "0.11.0", default-features = false }
 pretty_assertions = "0.6"
-quaint = { git = "https://github.com/prisma/quaint", optional = true, features = ["serde-support"] }
+quaint = { git = "https://github.com/prisma/quaint", optional = true, features = ["serde-support"], branch = "mssql-support" }
 serde = "1"
 serde_json = "1.0.45"
 tempfile = "3.1.0"

--- a/migration-engine/migration-engine-tests/Cargo.toml
+++ b/migration-engine/migration-engine-tests/Cargo.toml
@@ -26,7 +26,7 @@ barrel = { version = "0.6.5", features = ["sqlite3", "mysql", "pg"], optional = 
 futures = "0.3.1"
 git2 = { version = "0.11.0", default-features = false }
 pretty_assertions = "0.6"
-quaint = { git = "https://github.com/prisma/quaint", optional = true, features = ["serde-support"], branch = "mssql-support" }
+quaint = { git = "https://github.com/prisma/quaint", optional = true, features = ["serde-support"] }
 serde = "1"
 serde_json = "1.0.45"
 tempfile = "3.1.0"

--- a/migration-engine/migration-engine-tests/src/test_api.rs
+++ b/migration-engine/migration-engine-tests/src/test_api.rs
@@ -79,6 +79,7 @@ impl TestApi {
             SqlFamily::Mysql => mysql_test_config("unreachable"),
             SqlFamily::Postgres => postgres_12_test_config("unreachable"),
             SqlFamily::Sqlite => sqlite_test_config("unreachable"),
+            SqlFamily::Mssql => todo!("Greetings from Redmond"),
         }
     }
 
@@ -145,6 +146,7 @@ impl TestApi {
                 SqlFamily::Mysql => barrel::SqlVariant::Mysql,
                 SqlFamily::Postgres => barrel::SqlVariant::Pg,
                 SqlFamily::Sqlite => barrel::SqlVariant::Sqlite,
+                SqlFamily::Mssql => todo!("Greetings from Redmond"),
             },
         }
     }

--- a/migration-engine/migration-engine-tests/tests/existing_data/sql_unexecutable_migrations/added_required_field_to_table.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_data/sql_unexecutable_migrations/added_required_field_to_table.rs
@@ -34,7 +34,7 @@ async fn adding_a_required_field_to_an_existing_table_with_data_without_a_defaul
         .assert_unexecutable(&[format!("Added the required column `age` to the `Test` table without a default value. There are 1 rows in this table, it is not possible to execute this migration.")])?;
 
     let rows = api.select("Test").column("id").column("name").send_debug().await?;
-    assert_eq!(rows, &[&[r#"Text("abc")"#, r#"Text("george")"#]]);
+    assert_eq!(rows, &[&[r#"Text(Some("abc"))"#, r#"Text(Some("george"))"#]]);
 
     Ok(())
 }
@@ -73,7 +73,15 @@ async fn adding_a_required_field_with_a_default_to_an_existing_table_works(api: 
         .column("age")
         .send_debug()
         .await?;
-    assert_eq!(rows, &[&[r#"Text("abc")"#, r#"Text("george")"#, r#"Integer(45)"#]]);
+
+    assert_eq!(
+        rows,
+        &[&[
+            r#"Text(Some("abc"))"#,
+            r#"Text(Some("george"))"#,
+            r#"Integer(Some(45))"#
+        ]]
+    );
 
     Ok(())
 }

--- a/migration-engine/migration-engine-tests/tests/existing_data/sql_unexecutable_migrations/added_unimplementable_unique_constraint.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_data/sql_unexecutable_migrations/added_unimplementable_unique_constraint.rs
@@ -89,8 +89,8 @@ async fn adding_a_unique_constraint_when_existing_data_respects_it_works(api: &T
     assert_eq!(
         rows,
         &[
-            &[r#"Text("abc")"#, r#"Text("george")"#],
-            &[r#"Text("def")"#, r#"Text("georgina")"#]
+            &[r#"Text(Some("abc"))"#, r#"Text(Some("george"))"#],
+            &[r#"Text(Some("def"))"#, r#"Text(Some("georgina"))"#]
         ]
     );
 

--- a/migration-engine/migration-engine-tests/tests/existing_data/sql_unexecutable_migrations/made_optional_field_required.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_data/sql_unexecutable_migrations/made_optional_field_required.rs
@@ -35,7 +35,7 @@ async fn making_an_optional_field_required_with_data_without_a_default_is_unexec
         .assert_table("Test", |table| table.assert_does_not_have_column("Int"))?;
 
     let rows = api.select("Test").column("id").column("name").send_debug().await?;
-    assert_eq!(rows, &[&[r#"Text("abc")"#, r#"Text("george")"#]]);
+    assert_eq!(rows, &[&[r#"Text(Some("abc"))"#, r#"Text(Some("george"))"#]]);
 
     Ok(())
 }
@@ -79,7 +79,10 @@ async fn making_an_optional_field_required_with_data_with_a_default_works(api: &
         .column("age")
         .send_debug()
         .await?;
-    assert_eq!(rows, &[&[r#"Text("abc")"#, r#"Text("george")"#, "Integer(84)"]]);
+    assert_eq!(
+        rows,
+        &[&[r#"Text(Some("abc"))"#, r#"Text(Some("george"))"#, "Integer(Some(84))"]]
+    );
 
     Ok(())
 }

--- a/migration-engine/migration-engine-tests/tests/existing_data_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_data_tests.rs
@@ -3,9 +3,8 @@ mod existing_data;
 use migration_connector::MigrationWarning;
 use migration_engine_tests::sql::*;
 use pretty_assertions::assert_eq;
-use prisma_value::PrismaValue;
+use prisma_value::{PrismaValue, TypeHint};
 use quaint::ast::*;
-use std::borrow::Cow;
 
 #[test_each_connector(log = "debug,sql_schema_describer=info")]
 async fn dropping_a_table_with_rows_should_warn(api: &TestApi) {
@@ -226,14 +225,17 @@ async fn column_defaults_can_safely_be_changed(api: &TestApi) -> TestResult {
                     row.get("name").map(|val| {
                         val.to_string()
                             .map(|val| PrismaValue::String(val))
-                            .unwrap_or(PrismaValue::Null)
+                            .unwrap_or(PrismaValue::Null(TypeHint::String))
                     })
                 })
                 .collect();
 
             assert_eq!(
                 &[
-                    first_default.as_ref().cloned().unwrap_or(PrismaValue::Null),
+                    first_default
+                        .as_ref()
+                        .cloned()
+                        .unwrap_or(PrismaValue::Null(TypeHint::String)),
                     PrismaValue::String("Waterworld".to_string())
                 ],
                 names.as_slice()
@@ -268,13 +270,16 @@ async fn column_defaults_can_safely_be_changed(api: &TestApi) -> TestResult {
                     row.get("name").map(|val| {
                         val.to_string()
                             .map(|val| PrismaValue::String(val))
-                            .unwrap_or(PrismaValue::Null)
+                            .unwrap_or(PrismaValue::Null(TypeHint::String))
                     })
                 })
                 .collect();
             assert_eq!(
                 &[
-                    first_default.as_ref().cloned().unwrap_or(PrismaValue::Null),
+                    first_default
+                        .as_ref()
+                        .cloned()
+                        .unwrap_or(PrismaValue::Null(TypeHint::String)),
                     PrismaValue::String("Waterworld".to_string())
                 ],
                 names.as_slice()
@@ -631,7 +636,7 @@ async fn altering_the_type_of_a_column_in_a_non_empty_table_always_warns(api: &T
     );
 
     let rows = api.select("User").column("dogs").send_debug().await?;
-    assert_eq!(rows, &[["Integer(7)"]]);
+    assert_eq!(rows, &[["Integer(Some(7))"]]);
 
     api.assert_schema().await?.assert_table("User", |table| {
         table.assert_column("dogs", |col| col.assert_type_is_int()?.assert_is_required())
@@ -661,7 +666,7 @@ async fn migrating_a_required_column_from_int_to_string_should_warn_and_cast(api
     let first_row = test.get(0).unwrap();
     assert_eq!(
         format!("{:?} {:?}", first_row.get("id"), first_row.get("serialNumber")),
-        r#"Some(Text("abcd")) Some(Integer(47))"#
+        r#"Some(Text(Some("abcd"))) Some(Integer(Some(47)))"#
     );
 
     let original_schema = api.assert_schema().await?.into_schema();
@@ -700,7 +705,7 @@ async fn migrating_a_required_column_from_int_to_string_should_warn_and_cast(api
         let first_row = test.get(0).unwrap();
         assert_eq!(
             format!("{:?} {:?}", first_row.get("id"), first_row.get("serialNumber")),
-            r#"Some(Text("abcd")) Some(Text("47"))"#
+            r#"Some(Text(Some("abcd"))) Some(Text(Some("47")))"#
         );
     }
 
@@ -734,14 +739,8 @@ async fn enum_variants_can_be_added_without_data_loss(api: &TestApi) -> TestResu
 
     {
         let cat_inserts = quaint::ast::Insert::multi_into(api.render_table_name("Cat"), vec!["id", "mood"])
-            .values((
-                Value::Text(Cow::Borrowed("felix")),
-                Value::Enum(Cow::Borrowed("HUNGRY")),
-            ))
-            .values((
-                Value::Text(Cow::Borrowed("mittens")),
-                Value::Enum(Cow::Borrowed("HAPPY")),
-            ));
+            .values((Value::text("felix"), Value::enum_variant("HUNGRY")))
+            .values((Value::text("mittens"), Value::enum_variant("HAPPY")));
 
         api.database().query(cat_inserts.into()).await?;
     }
@@ -778,13 +777,13 @@ async fn enum_variants_can_be_added_without_data_loss(api: &TestApi) -> TestResu
 
         let expected_cat_data = if api.sql_family().is_mysql() {
             vec![
-                vec![Value::Text("felix".into()), Value::Text("HUNGRY".into())],
-                vec![Value::Text("mittens".into()), Value::Text("HAPPY".into())],
+                vec![Value::text("felix"), Value::text("HUNGRY")],
+                vec![Value::text("mittens"), Value::text("HAPPY")],
             ]
         } else {
             vec![
-                vec![Value::Text("felix".into()), Value::Enum("HUNGRY".into())],
-                vec![Value::Text("mittens".into()), Value::Enum("HAPPY".into())],
+                vec![Value::text("felix"), Value::enum_variant("HUNGRY")],
+                vec![Value::text("mittens"), Value::enum_variant("HAPPY")],
             ]
         };
 
@@ -842,14 +841,8 @@ async fn enum_variants_can_be_dropped_without_data_loss(api: &TestApi) -> TestRe
 
     {
         let cat_inserts = quaint::ast::Insert::multi_into(api.render_table_name("Cat"), &["id", "mood"])
-            .values((
-                Value::Text(Cow::Borrowed("felix")),
-                Value::Enum(Cow::Borrowed("HUNGRY")),
-            ))
-            .values((
-                Value::Text(Cow::Borrowed("mittens")),
-                Value::Enum(Cow::Borrowed("HAPPY")),
-            ));
+            .values((Value::text("felix"), Value::enum_variant("HUNGRY")))
+            .values((Value::text("mittens"), Value::enum_variant("HAPPY")));
 
         api.database().query(cat_inserts.into()).await?;
     }
@@ -885,13 +878,13 @@ async fn enum_variants_can_be_dropped_without_data_loss(api: &TestApi) -> TestRe
 
         let expected_cat_data = if api.sql_family().is_mysql() {
             vec![
-                vec![Value::Text("felix".into()), Value::Text("HUNGRY".into())],
-                vec![Value::Text("mittens".into()), Value::Text("HAPPY".into())],
+                vec![Value::text("felix"), Value::text("HUNGRY")],
+                vec![Value::text("mittens"), Value::text("HAPPY")],
             ]
         } else {
             vec![
-                vec![Value::Text("felix".into()), Value::Enum("HUNGRY".into())],
-                vec![Value::Text("mittens".into()), Value::Enum("HAPPY".into())],
+                vec![Value::text("felix"), Value::enum_variant("HUNGRY")],
+                vec![Value::text("mittens"), Value::enum_variant("HAPPY")],
             ]
         };
 

--- a/migration-engine/migration-engine-tests/tests/migration_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migration_tests.rs
@@ -290,6 +290,7 @@ async fn changing_the_type_of_an_id_field_must_work(api: &TestApi) {
                 SqlFamily::Postgres => Some("A_b_id_fkey".to_owned()),
                 SqlFamily::Mysql => Some("A_ibfk_1".to_owned()),
                 SqlFamily::Sqlite => None,
+                SqlFamily::Mssql => todo!("Greetings from Redmond"),
             },
             columns: vec![column.name.clone()],
             referenced_table: "B".to_string(),
@@ -319,6 +320,7 @@ async fn changing_the_type_of_an_id_field_must_work(api: &TestApi) {
                 SqlFamily::Postgres => Some("A_b_id_fkey".to_owned()),
                 SqlFamily::Mysql => Some("A_ibfk_1".to_owned()),
                 SqlFamily::Sqlite => None,
+                SqlFamily::Mssql => todo!("Greetings from Redmond"),
             },
             columns: vec!["b_id".into()],
             referenced_table: "B".to_string(),
@@ -374,6 +376,7 @@ async fn changing_a_relation_field_to_a_scalar_field_must_work(api: &TestApi) ->
                     SqlFamily::Postgres => Some("A_b_fkey".to_owned()),
                     SqlFamily::Mysql => Some("A_ibfk_1".to_owned()),
                     SqlFamily::Sqlite => None,
+                    SqlFamily::Mssql => todo!("Greetings from Redmond"),
                 },
                 columns: vec!["b".to_owned()],
                 referenced_table: "B".to_string(),
@@ -445,6 +448,7 @@ async fn changing_a_scalar_field_to_a_relation_field_must_work(api: &TestApi) {
                 SqlFamily::Postgres => Some("A_b_fkey".to_owned()),
                 SqlFamily::Mysql => Some("A_ibfk_1".to_owned()),
                 SqlFamily::Sqlite => None,
+                SqlFamily::Mssql => todo!("Greetings from Redmond"),
             },
             columns: vec![column.name.clone()],
             referenced_table: "B".to_string(),
@@ -516,6 +520,7 @@ async fn adding_a_many_to_many_relation_with_custom_name_must_work(api: &TestApi
                     SqlFamily::Postgres => Some("_my_relation_A_fkey".to_owned()),
                     SqlFamily::Mysql => Some("_my_relation_ibfk_1".to_owned()),
                     SqlFamily::Sqlite => None,
+                    SqlFamily::Mssql => todo!("Greetings from Redmond"),
                 },
                 columns: vec![a_column.name.clone()],
                 referenced_table: "A".to_string(),
@@ -527,6 +532,7 @@ async fn adding_a_many_to_many_relation_with_custom_name_must_work(api: &TestApi
                     SqlFamily::Postgres => Some("_my_relation_B_fkey".to_owned()),
                     SqlFamily::Mysql => Some("_my_relation_ibfk_2".to_owned()),
                     SqlFamily::Sqlite => None,
+                    SqlFamily::Mssql => todo!("Greetings from Redmond"),
                 },
                 columns: vec![b_column.name.clone()],
                 referenced_table: "B".to_string(),
@@ -576,6 +582,7 @@ async fn adding_an_inline_relation_must_result_in_a_foreign_key_in_the_model_tab
                     SqlFamily::Postgres => Some("A_bid_fkey".to_owned()),
                     SqlFamily::Mysql => Some("A_ibfk_1".to_owned()),
                     SqlFamily::Sqlite => None,
+                    SqlFamily::Mssql => todo!("Greetings from Redmond"),
                 },
                 columns: vec![b_column.name.clone()],
                 referenced_table: "B".to_string(),
@@ -587,6 +594,7 @@ async fn adding_an_inline_relation_must_result_in_a_foreign_key_in_the_model_tab
                     SqlFamily::Postgres => Some("A_cid_fkey".to_owned()),
                     SqlFamily::Mysql => Some("A_ibfk_2".to_owned()),
                     SqlFamily::Sqlite => None,
+                    SqlFamily::Mssql => todo!("Greetings from Redmond"),
                 },
                 columns: vec![c_column.name.clone()],
                 referenced_table: "C".to_string(),
@@ -623,6 +631,7 @@ async fn specifying_a_db_name_for_an_inline_relation_must_work(api: &TestApi) {
                 SqlFamily::Postgres => Some("A_b_column_fkey".to_owned()),
                 SqlFamily::Mysql => Some("A_ibfk_1".to_owned()),
                 SqlFamily::Sqlite => None,
+                SqlFamily::Mssql => todo!("Greetings from Redmond"),
             },
             columns: vec![column.name.clone()],
             referenced_table: "B".to_string(),
@@ -656,6 +665,7 @@ async fn adding_an_inline_relation_to_a_model_with_an_exotic_id_type(api: &TestA
                 SqlFamily::Postgres => Some("A_b_id_fkey".to_owned()),
                 SqlFamily::Mysql => Some("A_ibfk_1".to_owned()),
                 SqlFamily::Sqlite => None,
+                SqlFamily::Mssql => todo!("Greetings from Redmond"),
             },
             columns: vec![column.name.clone()],
             referenced_table: "B".to_string(),
@@ -728,6 +738,7 @@ async fn moving_an_inline_relation_to_the_other_side_must_work(api: &TestApi) ->
                 SqlFamily::Postgres => Some("A_b_id_fkey".to_owned()),
                 SqlFamily::Sqlite => None,
                 SqlFamily::Mysql => Some("A_ibfk_1".to_owned()),
+                SqlFamily::Mssql => todo!("Greetings from Redmond"),
             },
             columns: vec!["b_id".to_string()],
             referenced_table: "B".to_string(),
@@ -756,6 +767,7 @@ async fn moving_an_inline_relation_to_the_other_side_must_work(api: &TestApi) ->
                 SqlFamily::Postgres => Some("B_a_id_fkey".to_owned()),
                 SqlFamily::Sqlite => None,
                 SqlFamily::Mysql => Some("B_ibfk_1".to_owned()),
+                SqlFamily::Mssql => todo!("Greetings from Redmond"),
             },
             columns: vec!["a_id".to_string()],
             referenced_table: "A".to_string(),
@@ -1228,6 +1240,7 @@ async fn reserved_sql_key_words_must_work(api: &TestApi) {
                 SqlFamily::Postgres => Some("Group_parent_id_fkey".to_owned()),
                 SqlFamily::Mysql => Some("Group_ibfk_1".to_owned()),
                 SqlFamily::Sqlite => None,
+                SqlFamily::Mssql => todo!("Greetings from Redmond"),
             },
             columns: vec!["parent_id".to_string()],
             referenced_table: "Group".to_string(),
@@ -1461,7 +1474,7 @@ async fn column_defaults_must_be_migrated(api: &TestApi) -> TestResult {
 
 #[test_each_connector(log = "debug,sql_schema_describer=info")]
 async fn escaped_string_defaults_are_not_arbitrarily_migrated(api: &TestApi) -> TestResult {
-    use quaint::ast::*;
+    use quaint::ast::Insert;
 
     let dm1 = r#"
         model Fruit {
@@ -1516,7 +1529,7 @@ async fn escaped_string_defaults_are_not_arbitrarily_migrated(api: &TestApi) -> 
 
 #[test_each_connector]
 async fn created_at_does_not_get_arbitrarily_migrated(api: &TestApi) -> TestResult {
-    use quaint::ast::*;
+    use quaint::ast::Insert;
 
     let dm1 = r#"
         model Fruit {

--- a/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/alreadyConverted/NestedDeleteMutationInsideUpsertSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/alreadyConverted/NestedDeleteMutationInsideUpsertSpec.scala
@@ -170,7 +170,6 @@ class NestedDeleteMutationInsideUpsertSpec extends FlatSpec with Matchers with A
       )
 
       res2.toString should be("""{"data":{"upsertParent":{"childOpt":null}}}""")
-
     }
   }
 

--- a/query-engine/connectors/query-connector/src/write_args.rs
+++ b/query-engine/connectors/query-connector/src/write_args.rs
@@ -94,7 +94,7 @@ impl WriteArgs {
             .map(|field| {
                 let val = match self.get_field_value(field.db_name()) {
                     Some(val) => val.clone(),
-                    None => PrismaValue::Null,
+                    None => PrismaValue::null(field.type_identifier.clone()),
                 };
 
                 (field.clone(), val.clone())

--- a/query-engine/connectors/sql-query-connector/Cargo.toml
+++ b/query-engine/connectors/sql-query-connector/Cargo.toml
@@ -49,3 +49,6 @@ git = "https://github.com/prisma/cuid-rust"
 [dependencies.user-facing-errors]
 path = "../../../libs/user-facing-errors"
 features = ["sql"]
+
+[features]
+mssql = ["datamodel/mssql"]

--- a/query-engine/connectors/sql-query-connector/Cargo.toml
+++ b/query-engine/connectors/sql-query-connector/Cargo.toml
@@ -12,11 +12,12 @@ failure = "0.1"
 rand = "0.7"
 async-trait = "0.1"
 futures = "0.3"
-rust_decimal = "=1.1.0"
+rust_decimal = "1.6"
 tokio = "=0.2.13"
 
 [dependencies.quaint]
 git = "https://github.com/prisma/quaint"
+branch = "mssql-support"
 features = ["full", "tracing-log"]
 
 [dependencies.connector-interface]

--- a/query-engine/connectors/sql-query-connector/Cargo.toml
+++ b/query-engine/connectors/sql-query-connector/Cargo.toml
@@ -17,7 +17,6 @@ tokio = "=0.2.13"
 
 [dependencies.quaint]
 git = "https://github.com/prisma/quaint"
-branch = "mssql-support"
 features = ["full", "tracing-log"]
 
 [dependencies.connector-interface]

--- a/query-engine/connectors/sql-query-connector/src/database/mod.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/mod.rs
@@ -1,4 +1,5 @@
 mod connection;
+mod mssql;
 mod mysql;
 mod postgresql;
 mod sqlite;
@@ -10,6 +11,7 @@ use async_trait::async_trait;
 use connector_interface::{error::ConnectorError, Connector};
 use datamodel::Source;
 
+pub use mssql::*;
 pub use mysql::*;
 pub use postgresql::*;
 pub use sqlite::*;

--- a/query-engine/connectors/sql-query-connector/src/database/mod.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/mod.rs
@@ -1,4 +1,5 @@
 mod connection;
+#[cfg(feature = "mssql")]
 mod mssql;
 mod mysql;
 mod postgresql;
@@ -11,6 +12,7 @@ use async_trait::async_trait;
 use connector_interface::{error::ConnectorError, Connector};
 use datamodel::Source;
 
+#[cfg(feature = "mssql")]
 pub use mssql::*;
 pub use mysql::*;
 pub use postgresql::*;

--- a/query-engine/connectors/sql-query-connector/src/database/mssql.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/mssql.rs
@@ -1,0 +1,50 @@
+use super::connection::SqlConnection;
+use crate::{FromSource, SqlError};
+use async_trait::async_trait;
+use connector_interface::{
+    self as connector,
+    error::{ConnectorError, ErrorKind},
+    Connection, Connector,
+};
+use datamodel::Source;
+use quaint::{pooled::Quaint, prelude::ConnectionInfo};
+use std::time::Duration;
+
+pub struct Mssql {
+    pool: Quaint,
+    connection_info: ConnectionInfo,
+}
+
+#[async_trait]
+impl FromSource for Mssql {
+    async fn from_source(source: &dyn Source) -> connector_interface::Result<Self> {
+        let connection_info = ConnectionInfo::from_url(&source.url().value)
+            .map_err(|err| ConnectorError::from_kind(ErrorKind::ConnectionError(err.into())))?;
+
+        let mut builder = Quaint::builder(&source.url().value)
+            .map_err(SqlError::from)
+            .map_err(|sql_error| sql_error.into_connector_error(&connection_info))?;
+
+        builder.max_idle_lifetime(Duration::from_secs(300));
+        builder.health_check_interval(Duration::from_secs(15));
+        builder.test_on_check_out(true);
+
+        let pool = builder.build();
+        let connection_info = pool.connection_info().to_owned();
+
+        Ok(Self { pool, connection_info })
+    }
+}
+
+#[async_trait]
+impl Connector for Mssql {
+    async fn get_connection<'a>(&'a self) -> connector::Result<Box<dyn Connection + 'static>> {
+        super::catch(&self.connection_info, async move {
+            let conn = self.pool.check_out().await.map_err(SqlError::from)?;
+            let conn = SqlConnection::new(conn, &self.connection_info);
+
+            Ok(Box::new(conn) as Box<dyn Connection>)
+        })
+        .await
+    }
+}

--- a/query-engine/connectors/sql-query-connector/src/filter_conversion.rs
+++ b/query-engine/connectors/sql-query-connector/src/filter_conversion.rs
@@ -136,8 +136,8 @@ impl AliasedCondition for ScalarFilter {
     fn aliased_cond(self, alias: Option<Alias>) -> ConditionTree<'static> {
         fn compare(comparable: impl Comparable<'static>, cond: ScalarCondition) -> ConditionTree<'static> {
             let condition = match cond {
-                ScalarCondition::Equals(PrismaValue::Null) => comparable.is_null(),
-                ScalarCondition::NotEquals(PrismaValue::Null) => comparable.is_not_null(),
+                ScalarCondition::Equals(PrismaValue::Null(_)) => comparable.is_null(),
+                ScalarCondition::NotEquals(PrismaValue::Null(_)) => comparable.is_not_null(),
                 ScalarCondition::Equals(value) => comparable.equals(value),
                 ScalarCondition::NotEquals(value) => comparable.not_equals(value),
                 ScalarCondition::Contains(value) => comparable.like(format!("{}", value)),

--- a/query-engine/connectors/sql-query-connector/src/query_builder/mod.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_builder/mod.rs
@@ -31,7 +31,7 @@ pub(super) fn conditions<'a>(
     columns: &'a [Column<'static>],
     records: impl IntoIterator<Item = &'a RecordProjection>,
 ) -> ConditionTree<'static> {
-    let mut values = Values::new();
+    let mut values = Values::empty();
 
     for proj in records.into_iter() {
         let vals: Vec<_> = proj.values().collect();

--- a/query-engine/core/Cargo.toml
+++ b/query-engine/core/Cargo.toml
@@ -24,5 +24,5 @@ im = "13.0"
 futures = "0.3"
 async-trait = "0.1"
 crossbeam-queue = "0.2"
-rust_decimal = "=1.1.0"
+rust_decimal = "1.6"
 user-facing-errors = { path = "../../libs/user-facing-errors" }

--- a/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
@@ -135,7 +135,7 @@ pub async fn one2m<'a, 'b>(
 
     let uniq_projections = uniq_projections
         .into_iter()
-        .filter(|p| !p.contains(&PrismaValue::Null))
+        .filter(|p| !p.iter().any(|v| v.is_null()))
         .collect();
 
     let filter = child_link_id.is_in(uniq_projections);

--- a/query-engine/core/src/query_document/parse_ast.rs
+++ b/query-engine/core/src/query_document/parse_ast.rs
@@ -167,7 +167,7 @@ impl InputAssertions for PrismaValue {
 
     fn assert_non_null(&self) -> QueryParserResult<()> {
         match self {
-            PrismaValue::Null => Err(QueryParserError::AssertionError(format!(
+            PrismaValue::Null(_) => Err(QueryParserError::AssertionError(format!(
                 "You provided a null value for a where clause (or implicit nested selector). Please provide a non null value.",
             ))),
             _ => Ok(())

--- a/query-engine/core/src/query_document/parser.rs
+++ b/query-engine/core/src/query_document/parser.rs
@@ -149,7 +149,7 @@ impl QueryDocumentParser {
             (_, InputType::Opt(ref inner))                  => Self::parse_input_value(value, inner),
 
             // Handle null inputs
-            (QueryValue::Null, InputType::Null(_))          => Ok(ParsedInputValue::Single(PrismaValue::Null)),
+            (QueryValue::Null, InputType::Null(inner))          => Ok(ParsedInputValue::Single(PrismaValue::null(&**inner))),
             (_, InputType::Null(ref inner))                 => Self::parse_input_value(value, inner),
 
             // The optional handling above guarantees that if we hit a Null here, a required value is missing.
@@ -173,7 +173,7 @@ impl QueryDocumentParser {
     #[rustfmt::skip]
     pub fn parse_scalar(value: QueryValue, scalar_type: &ScalarType) -> QueryParserResult<PrismaValue> {
         match (value, scalar_type.clone()) {
-            (QueryValue::Null, _)                         => Ok(PrismaValue::Null),
+            (QueryValue::Null, typ)                       => Ok(PrismaValue::null(&typ)),
             (QueryValue::String(s), ScalarType::String)   => Ok(PrismaValue::String(s)),
             (QueryValue::String(s), ScalarType::DateTime) => Self::parse_datetime(s.as_str()).map(PrismaValue::DateTime),
             (QueryValue::String(s), ScalarType::Json) => Ok(PrismaValue::Json(Self::parse_json(&s).map(|_| s)?)),

--- a/query-engine/core/src/query_document/query_value.rs
+++ b/query-engine/core/src/query_document/query_value.rs
@@ -33,7 +33,7 @@ impl From<PrismaValue> for QueryValue {
             PrismaValue::Enum(s) => Self::Enum(s),
             PrismaValue::List(l) => Self::List(l.into_iter().map(QueryValue::from).collect()),
             PrismaValue::Int(i) => Self::Int(i),
-            PrismaValue::Null => Self::Null,
+            PrismaValue::Null(_) => Self::Null,
             PrismaValue::Uuid(u) => Self::String(u.to_hyphenated().to_string()),
             PrismaValue::Json(s) => Self::String(s),
         }

--- a/query-engine/core/src/query_document/transformers.rs
+++ b/query-engine/core/src/query_document/transformers.rs
@@ -49,7 +49,7 @@ impl TryInto<Option<ParsedInputMap>> for ParsedInputValue {
 
     fn try_into(self) -> QueryParserResult<Option<ParsedInputMap>> {
         match self {
-            ParsedInputValue::Single(PrismaValue::Null) => Ok(None),
+            ParsedInputValue::Single(PrismaValue::Null(_)) => Ok(None),
             ParsedInputValue::Map(val) => Ok(Some(val)),
             v => Err(QueryParserError::AssertionError(format!(
                 "Attempted conversion of non-map ParsedInputValue ({:?}) into Option map failed.",
@@ -82,7 +82,7 @@ impl TryInto<Option<String>> for ParsedInputValue {
         match prisma_value {
             PrismaValue::String(s) => Ok(Some(s)),
             PrismaValue::Enum(s) => Ok(Some(s)),
-            PrismaValue::Null => Ok(None),
+            PrismaValue::Null(_) => Ok(None),
             v => Err(QueryParserError::AssertionError(format!(
                 "Attempted conversion of non-String Prisma value type ({:?}) into String failed.",
                 v
@@ -113,7 +113,7 @@ impl TryInto<Option<f64>> for ParsedInputValue {
 
         match prisma_value {
             PrismaValue::Float(d) => Ok(d.to_f64()),
-            PrismaValue::Null => Ok(None),
+            PrismaValue::Null(_) => Ok(None),
             v => Err(QueryParserError::AssertionError(format!(
                 "Attempted conversion of non-float Prisma value type ({:?}) into float failed.",
                 v
@@ -130,7 +130,7 @@ impl TryInto<Option<bool>> for ParsedInputValue {
 
         match prisma_value {
             PrismaValue::Boolean(b) => Ok(Some(b)),
-            PrismaValue::Null => Ok(None),
+            PrismaValue::Null(_) => Ok(None),
             v => Err(QueryParserError::AssertionError(format!(
                 "Attempted conversion of non-bool Prisma value type ({:?}) into bool failed.",
                 v
@@ -147,7 +147,7 @@ impl TryInto<Option<DateTime<Utc>>> for ParsedInputValue {
 
         match prisma_value {
             PrismaValue::DateTime(dt) => Ok(Some(dt)),
-            PrismaValue::Null => Ok(None),
+            PrismaValue::Null(_) => Ok(None),
             v => Err(QueryParserError::AssertionError(format!(
                 "Attempted conversion of non-DateTime Prisma value type ({:?}) into DateTime failed.",
                 v
@@ -164,7 +164,7 @@ impl TryInto<Option<i64>> for ParsedInputValue {
 
         match prisma_value {
             PrismaValue::Int(i) => Ok(Some(i)),
-            PrismaValue::Null => Ok(None),
+            PrismaValue::Null(_) => Ok(None),
             v => Err(QueryParserError::AssertionError(format!(
                 "Attempted conversion of non-int Prisma value type ({:?}) into int failed.",
                 v

--- a/query-engine/core/src/query_graph_builder/extractors/filters.rs
+++ b/query-engine/core/src/query_graph_builder/extractors/filters.rs
@@ -183,9 +183,9 @@ fn handle_scalar_field(
     let value: PrismaValue = value.try_into()?;
 
     Ok(match (op, value) {
-        (FilterOp::In, PrismaValue::Null) => field.equals(PrismaValue::Null),
+        (FilterOp::In, PrismaValue::Null(hint)) => field.equals(PrismaValue::Null(hint)),
         (FilterOp::In, PrismaValue::List(values)) => field.is_in(values),
-        (FilterOp::NotIn, PrismaValue::Null) => field.not_equals(PrismaValue::Null),
+        (FilterOp::NotIn, PrismaValue::Null(hint)) => field.not_equals(PrismaValue::Null(hint)),
         (FilterOp::NotIn, PrismaValue::List(values)) => field.not_in(values),
         (FilterOp::Not, val) => field.not_equals(val),
         (FilterOp::Lt, val) => field.less_than(val),

--- a/query-engine/core/src/query_graph_builder/write/write_args_parser.rs
+++ b/query-engine/core/src/query_graph_builder/write/write_args_parser.rs
@@ -44,7 +44,7 @@ impl WriteArgsParser {
                     }
 
                     Field::Relation(ref rf) => match v {
-                        ParsedInputValue::Single(PrismaValue::Null) => (),
+                        ParsedInputValue::Single(PrismaValue::Null(_)) => (),
                         _ => args.nested.push((Arc::clone(rf), v.try_into()?)),
                     },
                 };

--- a/query-engine/core/src/response_ir/internal.rs
+++ b/query-engine/core/src/response_ir/internal.rs
@@ -101,7 +101,7 @@ fn serialize_record_selection(
                             if !opt {
                                 // Check that all items are non-null
                                 if items.iter().any(|item| match item {
-                                    Item::Value(PrismaValue::Null) => true,
+                                    Item::Value(PrismaValue::Null(_)) => true,
                                     _ => false,
                                 }) {
                                     return Err(CoreError::SerializationError(format!(
@@ -137,7 +137,10 @@ fn serialize_record_selection(
                                     )))
                                 }
                             } else if items.is_empty() && opt {
-                                Ok((parent, Item::Ref(ItemRef::new(Item::Value(PrismaValue::Null)))))
+                                Ok((
+                                    parent,
+                                    Item::Ref(ItemRef::new(Item::Value(PrismaValue::Null(TypeHint::Unknown)))),
+                                ))
                             } else if items.is_empty() && opt {
                                 Err(CoreError::SerializationError(format!(
                                     "Required field '{}' returned a null record",
@@ -254,7 +257,7 @@ fn write_nested_items(
                         if inner.is_list() {
                             Item::list(Vec::new())
                         } else {
-                            Item::Value(PrismaValue::Null)
+                            Item::Value(PrismaValue::Null(TypeHint::Unknown))
                         }
                     }
                     _ => panic!(
@@ -296,7 +299,7 @@ fn process_nested_results(
 
 fn serialize_scalar(value: PrismaValue, typ: &OutputTypeRef) -> crate::Result<Item> {
     match (&value, typ.as_ref()) {
-        (PrismaValue::Null, OutputType::Opt(_)) => Ok(Item::Value(PrismaValue::Null)),
+        (PrismaValue::Null(_), OutputType::Opt(_)) => Ok(Item::Value(PrismaValue::Null(TypeHint::Unknown))),
         (_, OutputType::Opt(inner)) => serialize_scalar(value, inner),
         (_, OutputType::Enum(et)) => match et.borrow() {
             EnumType::Internal(ref i) => convert_enum(value, i),

--- a/query-engine/core/src/response_ir/mod.rs
+++ b/query-engine/core/src/response_ir/mod.rs
@@ -13,7 +13,7 @@ mod internal;
 use crate::{CoreError, ExpressionResult, OutputType, OutputTypeRef, QueryResult, QueryValue};
 use indexmap::IndexMap;
 use internal::*;
-use prisma_models::PrismaValue;
+use prisma_models::{PrismaValue, TypeHint};
 use serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer};
 use std::{borrow::Borrow, fmt, sync::Arc};
 
@@ -180,7 +180,7 @@ pub enum Item {
 
 impl Item {
     pub fn null() -> Self {
-        Self::Value(PrismaValue::Null)
+        Self::Value(PrismaValue::Null(TypeHint::Unknown))
     }
 
     pub fn list(inner: Vec<Item>) -> Self {
@@ -274,7 +274,7 @@ impl IrSerializer {
                         // Todo: The following checks feel out of place. This probably needs to be handled already one level deeper.
                         let result = if result.is_empty() {
                             match self.output_type.borrow() {
-                                OutputType::Opt(_) => Item::Value(PrismaValue::Null),
+                                OutputType::Opt(_) => Item::Value(PrismaValue::Null(TypeHint::Unknown)),
                                 OutputType::List(_) => Item::list(Vec::new()),
                                 other => return Response::Error(ResponseError::from(CoreError::SerializationError(format!(
                                     "Invalid response data: the query result was required, but an empty {:?} was returned instead.",

--- a/query-engine/query-engine/Cargo.toml
+++ b/query-engine/query-engine/Cargo.toml
@@ -50,7 +50,7 @@ rustc_version = "0.2.3"
 [dev-dependencies]
 test-macros = { path = "../../libs/test-macros" }
 test-setup = { path = "../../libs/test-setup" }
-quaint = { git = "https://github.com/prisma/quaint", features = ["full", "tracing-log"], branch = "mssql-support" }
+quaint = { git = "https://github.com/prisma/quaint", features = ["full", "tracing-log"] }
 migration-connector = { path = "../../migration-engine/connectors/migration-connector" }
 migration-core = { path = "../../migration-engine/core" }
 introspection-core = { path = "../../introspection-engine/core" }

--- a/query-engine/query-engine/Cargo.toml
+++ b/query-engine/query-engine/Cargo.toml
@@ -32,7 +32,7 @@ indexmap = { version = "1.0", features = [ "serde-1" ] }
 itertools = "0.8"
 url = "2.1"
 structopt = "0.3"
-rust_decimal = "=1.1.0"
+rust_decimal = "1.6"
 once_cell = "1.3"
 
 tracing = "0.1"
@@ -49,7 +49,7 @@ rustc_version = "0.2.3"
 [dev-dependencies]
 test-macros = { path = "../../libs/test-macros" }
 test-setup = { path = "../../libs/test-setup" }
-quaint = { git = "https://github.com/prisma/quaint", features = ["full", "tracing-log"] }
+quaint = { git = "https://github.com/prisma/quaint", features = ["full", "tracing-log"], branch = "mssql-support" }
 migration-connector = { path = "../../migration-engine/connectors/migration-connector" }
 migration-core = { path = "../../migration-engine/core" }
 introspection-core = { path = "../../introspection-engine/core" }

--- a/query-engine/query-engine/Cargo.toml
+++ b/query-engine/query-engine/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 default = ["sql", "graphql"]
 sql = ["sql-connector"]
 graphql = ["graphql-parser"]
+mssql = ["datamodel/mssql", "sql-connector/mssql"]
 
 [dependencies]
 futures = "0.3"

--- a/query-engine/query-engine/src/exec_loader.rs
+++ b/query-engine/query-engine/src/exec_loader.rs
@@ -1,7 +1,8 @@
 use crate::{PrismaError, PrismaResult};
 use connector::Connector;
+
 use datamodel::{
-    configuration::{MSSQL_SOURCE_NAME, MYSQL_SOURCE_NAME, POSTGRES_SOURCE_NAME, SQLITE_SOURCE_NAME},
+    configuration::{MYSQL_SOURCE_NAME, POSTGRES_SOURCE_NAME, SQLITE_SOURCE_NAME},
     Source,
 };
 use query_core::executor::{InterpretingExecutor, QueryExecutor};
@@ -10,6 +11,9 @@ use url::Url;
 
 #[cfg(feature = "sql")]
 use sql_connector::*;
+
+#[cfg(all(feature = "sql", feature = "mssql"))]
+use datamodel::configuration::MSSQL_SOURCE_NAME;
 
 pub async fn load(
     source: &(dyn Source + Send + Sync),
@@ -24,7 +28,7 @@ pub async fn load(
         #[cfg(feature = "sql")]
         POSTGRES_SOURCE_NAME => postgres(source).await,
 
-        #[cfg(feature = "sql")]
+        #[cfg(all(feature = "sql", feature = "mssql"))]
         MSSQL_SOURCE_NAME => mssql(source).await,
 
         x => Err(PrismaError::ConfigurationError(format!(
@@ -93,7 +97,7 @@ async fn mysql(
     Ok((db_name, sql_executor("mysql", mysql, false)))
 }
 
-#[cfg(feature = "sql")]
+#[cfg(all(feature = "sql", feature = "mssql"))]
 async fn mssql(
     source: &(dyn Source + Send + Sync),
 ) -> PrismaResult<(String, Box<dyn QueryExecutor + Send + Sync + 'static>)> {

--- a/query-engine/query-engine/src/tests/execute_raw.rs
+++ b/query-engine/query-engine/src/tests/execute_raw.rs
@@ -120,7 +120,7 @@ async fn querying_model_tables(api: &TestApi) -> anyhow::Result<()> {
     let res = query_engine.request(mutation).await;
     let id = res["data"]["createOneTodo"]["id"].as_str().unwrap();
 
-    let (query, _) = api.to_sql_string(Select::from_table("Todo").value(asterisk()));
+    let (query, _) = api.to_sql_string(Select::from_table("Todo").value(asterisk()))?;
 
     assert_eq!(
         json!({
@@ -144,7 +144,7 @@ async fn inserting_into_model_table(api: &TestApi) -> anyhow::Result<()> {
         .values(("id1", "title1"))
         .values(("id2", "title2"));
 
-    let (query, params) = api.to_sql_string(insert);
+    let (query, params) = api.to_sql_string(insert)?;
 
     assert_eq!(
         json!({
@@ -155,7 +155,7 @@ async fn inserting_into_model_table(api: &TestApi) -> anyhow::Result<()> {
         query_engine.request(execute_raw(&query, params)).await,
     );
 
-    let (query, _) = api.to_sql_string(Select::from_table("Todo").value(asterisk()));
+    let (query, _) = api.to_sql_string(Select::from_table("Todo").value(asterisk()))?;
 
     assert_eq!(
         json!({
@@ -185,7 +185,7 @@ async fn querying_model_tables_with_alias(api: &TestApi) -> anyhow::Result<()> {
     query_engine.request(mutation).await;
 
     let (query, params) =
-        api.to_sql_string(Select::from_table("Todo").column(Column::from("title").alias("aliasedTitle")));
+        api.to_sql_string(Select::from_table("Todo").column(Column::from("title").alias("aliasedTitle")))?;
 
     assert_eq!(
         json!({
@@ -215,7 +215,7 @@ async fn querying_the_same_column_name_twice_with_aliasing(api: &TestApi) -> any
         .column(Column::from("title").alias("ALIASEDTITLE"))
         .column("title");
 
-    let (query, params) = api.to_sql_string(select);
+    let (query, params) = api.to_sql_string(select)?;
 
     assert_eq!(
         json!({
@@ -254,6 +254,7 @@ async fn syntactic_errors_bubbling_through_to_the_user(api: &TestApi) -> anyhow:
         ConnectionInfo::Postgres(..) => assert_eq!(Some("42601"), error_code),
         ConnectionInfo::Mysql(..) => assert_eq!(Some("1064"), error_code),
         ConnectionInfo::Sqlite { .. } => assert_eq!(Some("1"), error_code),
+        ConnectionInfo::Mssql(..) => todo!("Greetings from Redmond"),
     }
 
     Ok(())
@@ -273,7 +274,7 @@ async fn other_errors_bubbling_through_to_the_user(api: &TestApi) -> anyhow::Res
     let id = result["data"]["createOneTodo"]["id"].as_str().unwrap();
 
     let insert = Insert::single_into("Todo").value("id", id).value("title", "irrelevant");
-    let (query, params) = api.to_sql_string(insert);
+    let (query, params) = api.to_sql_string(insert)?;
 
     let result = query_engine.request(execute_raw(&query, params)).await;
     let error_code = result["errors"][0]["user_facing_error"]["meta"]["code"].as_str();
@@ -281,6 +282,7 @@ async fn other_errors_bubbling_through_to_the_user(api: &TestApi) -> anyhow::Res
     match api.connection_info() {
         ConnectionInfo::Postgres(..) => assert_eq!(Some("23505"), error_code),
         ConnectionInfo::Mysql(..) => assert_eq!(Some("1062"), error_code),
+        ConnectionInfo::Mssql(..) => todo!("Greetings from Redmond"),
         ConnectionInfo::Sqlite { .. } => assert_eq!(Some("1555"), error_code),
     }
 

--- a/query-engine/query-engine/src/tests/test_api.rs
+++ b/query-engine/query-engine/src/tests/test_api.rs
@@ -87,11 +87,12 @@ impl TestApi {
         &self.connection_info
     }
 
-    pub fn to_sql_string<'a>(&'a self, query: impl Into<Query<'a>>) -> (String, Vec<Value>) {
+    pub fn to_sql_string<'a>(&'a self, query: impl Into<Query<'a>>) -> quaint::Result<(String, Vec<Value>)> {
         match self.connection_info() {
             ConnectionInfo::Postgres(..) => visitor::Postgres::build(query),
             ConnectionInfo::Mysql(..) => visitor::Mysql::build(query),
             ConnectionInfo::Sqlite { .. } => visitor::Sqlite::build(query),
+            ConnectionInfo::Mssql(_) => todo!("Greetings from Redmond"),
         }
     }
 }


### PR DESCRIPTION
This will add support for Microsoft SQL Server. The PR will only touch the Query Engine, migrations and introspection should be in another pull requests.