### PR TITLE
Avoid migrating MySQL system databases

### DIFF
--- a/libs/test-setup/src/lib.rs
+++ b/libs/test-setup/src/lib.rs
@@ -96,7 +96,8 @@ pub fn mysql_8_url(db_name: &str) -> String {
     let db_name = mysql_safe_identifier(db_name);
 
     format!(
-        "mysql://root:prisma@{host}:{port}/{db_name}?connect_timeout=20&socket_timeout=20",
+        "mysql://root:prisma@{host}:{port}{maybe_slash}{db_name}?connect_timeout=20&socket_timeout=20",
+        maybe_slash = if db_name.is_empty() { "" } else { "/" },
         host = host,
         port = port,
         db_name = db_name,

--- a/libs/user-facing-errors/src/migration_engine.rs
+++ b/libs/user-facing-errors/src/migration_engine.rs
@@ -34,6 +34,15 @@ struct MigrationRollback {
 )]
 pub struct DatabaseMigrationFormatChanged;
 
+#[derive(Debug, UserFacingError, Serialize)]
+#[user_facing(
+    code = "P3004",
+    message = "The `${database_name}` database is a system database, it should not be altered with prisma migrate. Please connect to another database."
+)]
+pub struct MigrateSystemDatabase {
+    pub database_name: String,
+}
+
 // Tests
 
 #[cfg(test)]

--- a/migration-engine/cli/src/commands/tests.rs
+++ b/migration-engine/cli/src/commands/tests.rs
@@ -24,7 +24,12 @@ fn mysql_url(db: Option<&str>) -> String {
 
 #[tokio::test]
 async fn test_connecting_with_a_working_mysql_connection_string() {
-    let result = run(&["--datasource", &mysql_url(Some("mysql")), "can-connect-to-database"])
+    let db_name = "test_connecting_with_a_working_mysql_connection_string";
+    let url = mysql_url(Some(db_name));
+
+    run(&["--datasource", &url, "create-database"]).await.ok();
+
+    let result = run(&["--datasource", &mysql_url(Some(db_name)), "can-connect-to-database"])
         .await
         .unwrap();
 

--- a/migration-engine/connectors/sql-migration-connector/src/component.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/component.rs
@@ -1,12 +1,13 @@
 use crate::{DatabaseInfo, SqlMigrationConnector, SqlResult};
 use quaint::prelude::{ConnectionInfo, Queryable, SqlFamily};
+use sql_schema_describer::{SqlSchema, SqlSchemaDescriberBackend};
 
 #[async_trait::async_trait]
 pub(crate) trait Component {
     fn connector(&self) -> &SqlMigrationConnector;
 
     fn schema_name(&self) -> &str {
-        &self.connector().schema_name
+        &self.connection_info().schema_name()
     }
 
     fn connection_info(&self) -> &ConnectionInfo {
@@ -21,12 +22,29 @@ pub(crate) trait Component {
         &self.connector().database_info
     }
 
-    async fn describe(&self) -> SqlResult<sql_schema_describer::SqlSchema> {
-        Ok(self
-            .connector()
-            .database_describer
-            .describe(&self.schema_name())
-            .await?)
+    async fn describe(&self) -> SqlResult<SqlSchema> {
+        let conn = self.connector().database.clone();
+        let schema_name = self.schema_name();
+
+        let schema = match self.connection_info().sql_family() {
+            SqlFamily::Postgres => {
+                sql_schema_describer::postgres::SqlSchemaDescriber::new(conn)
+                    .describe(schema_name)
+                    .await?
+            }
+            SqlFamily::Mysql => {
+                sql_schema_describer::mysql::SqlSchemaDescriber::new(conn)
+                    .describe(schema_name)
+                    .await?
+            }
+            SqlFamily::Sqlite => {
+                sql_schema_describer::sqlite::SqlSchemaDescriber::new(conn)
+                    .describe(schema_name)
+                    .await?
+            }
+        };
+
+        Ok(schema)
     }
 
     fn sql_family(&self) -> SqlFamily {

--- a/migration-engine/connectors/sql-migration-connector/src/component.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/component.rs
@@ -11,7 +11,7 @@ pub(crate) trait Component {
     }
 
     fn connection_info(&self) -> &ConnectionInfo {
-        self.connector().connection_info()
+        self.connector().database_info.connection_info()
     }
 
     fn conn(&self) -> &dyn Queryable {

--- a/migration-engine/connectors/sql-migration-connector/src/component.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/component.rs
@@ -23,7 +23,7 @@ pub(crate) trait Component {
     }
 
     async fn describe(&self) -> SqlResult<SqlSchema> {
-        self.connector().describe().await
+        self.connector().describe_schema().await
     }
 
     fn sql_family(&self) -> SqlFamily {

--- a/migration-engine/connectors/sql-migration-connector/src/component.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/component.rs
@@ -1,6 +1,6 @@
 use crate::{DatabaseInfo, SqlMigrationConnector, SqlResult};
 use quaint::prelude::{ConnectionInfo, Queryable, SqlFamily};
-use sql_schema_describer::{SqlSchema, SqlSchemaDescriberBackend};
+use sql_schema_describer::SqlSchema;
 
 #[async_trait::async_trait]
 pub(crate) trait Component {
@@ -23,28 +23,7 @@ pub(crate) trait Component {
     }
 
     async fn describe(&self) -> SqlResult<SqlSchema> {
-        let conn = self.connector().database.clone();
-        let schema_name = self.schema_name();
-
-        let schema = match self.connection_info().sql_family() {
-            SqlFamily::Postgres => {
-                sql_schema_describer::postgres::SqlSchemaDescriber::new(conn)
-                    .describe(schema_name)
-                    .await?
-            }
-            SqlFamily::Mysql => {
-                sql_schema_describer::mysql::SqlSchemaDescriber::new(conn)
-                    .describe(schema_name)
-                    .await?
-            }
-            SqlFamily::Sqlite => {
-                sql_schema_describer::sqlite::SqlSchemaDescriber::new(conn)
-                    .describe(schema_name)
-                    .await?
-            }
-        };
-
-        Ok(schema)
+        self.connector().describe().await
     }
 
     fn sql_family(&self) -> SqlFamily {

--- a/migration-engine/connectors/sql-migration-connector/src/flavour.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour.rs
@@ -1,0 +1,117 @@
+//! SQL flavours implement behaviour specific to a given SQL implementation (PostgreSQL, SQLite...),
+//! in order to avoid cluttering the connector with conditionals. This is a private implementation
+//! detail of the SQL connector.
+
+use crate::{database_info::DatabaseInfo, SqlResult};
+use futures::{future::BoxFuture, FutureExt};
+use quaint::connector::Queryable;
+use std::{fs, path::PathBuf};
+
+pub(crate) fn from_database_info(database_info: &DatabaseInfo) -> Box<dyn SqlFlavour + Send + Sync + 'static> {
+    use quaint::prelude::ConnectionInfo;
+
+    match database_info.connection_info() {
+        ConnectionInfo::Mysql(_) => Box::new(MysqlFlavour),
+        ConnectionInfo::Postgres(_) => Box::new(PostgresFlavour),
+        ConnectionInfo::Sqlite { file_path, .. } => Box::new(SqliteFlavour {
+            file_path: file_path.clone(),
+        }),
+    }
+}
+
+pub trait SqlFlavour {
+    fn create_database<'a>(&'a self, _db_name: &'a str, _conn: &'a dyn Queryable) -> BoxFuture<'a, SqlResult<()>> {
+        async { Ok(()) }.boxed()
+    }
+
+    fn initialize<'a>(
+        &'a self,
+        conn: &'a dyn Queryable,
+        database_info: &'a DatabaseInfo,
+    ) -> BoxFuture<'a, SqlResult<()>>;
+}
+
+struct MysqlFlavour;
+
+impl SqlFlavour for MysqlFlavour {
+    fn create_database<'a>(&'a self, db_name: &'a str, conn: &'a dyn Queryable) -> BoxFuture<'a, SqlResult<()>> {
+        async move {
+            let query = format!("CREATE DATABASE `{}`", db_name);
+            conn.query_raw(&query, &[]).await?;
+
+            Ok(())
+        }
+        .boxed()
+    }
+
+    fn initialize<'a>(
+        &'a self,
+        conn: &'a dyn Queryable,
+        database_info: &'a DatabaseInfo,
+    ) -> BoxFuture<'a, SqlResult<()>> {
+        async move {
+            let schema_sql = format!(
+                "CREATE SCHEMA IF NOT EXISTS `{}` DEFAULT CHARACTER SET latin1;",
+                database_info.connection_info().schema_name()
+            );
+
+            conn.query_raw(&schema_sql, &[]).await?;
+
+            Ok(())
+        }
+        .boxed()
+    }
+}
+
+struct SqliteFlavour {
+    file_path: String,
+}
+
+impl SqlFlavour for SqliteFlavour {
+    fn initialize<'a>(
+        &'a self,
+        _conn: &'a dyn Queryable,
+        _database_info: &'a DatabaseInfo,
+    ) -> BoxFuture<'a, SqlResult<()>> {
+        let path_buf = PathBuf::from(&self.file_path);
+        match path_buf.parent() {
+            Some(parent_directory) => {
+                fs::create_dir_all(parent_directory).expect("creating the database folders failed")
+            }
+            None => {}
+        }
+
+        futures::future::ready(Ok(())).boxed()
+    }
+}
+
+struct PostgresFlavour;
+
+impl SqlFlavour for PostgresFlavour {
+    fn create_database<'a>(&'a self, db_name: &'a str, conn: &'a dyn Queryable) -> BoxFuture<'a, SqlResult<()>> {
+        async move {
+            let query = format!("CREATE DATABASE \"{}\"", db_name);
+            conn.query_raw(&query, &[]).await?;
+
+            Ok(())
+        }
+        .boxed()
+    }
+    fn initialize<'a>(
+        &'a self,
+        conn: &'a dyn Queryable,
+        database_info: &'a DatabaseInfo,
+    ) -> BoxFuture<'a, SqlResult<()>> {
+        async move {
+            let schema_sql = format!(
+                "CREATE SCHEMA IF NOT EXISTS \"{}\";",
+                &database_info.connection_info().schema_name()
+            );
+
+            conn.query_raw(&schema_sql, &[]).await?;
+
+            Ok(())
+        }
+        .boxed()
+    }
+}

--- a/migration-engine/connectors/sql-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/lib.rs
@@ -30,6 +30,7 @@ use sql_database_migration_inferrer::*;
 use sql_database_step_applier::*;
 use sql_destructive_changes_checker::*;
 use sql_migration_persistence::*;
+use sql_schema_describer::SqlSchema;
 use std::{collections::HashMap, path, sync::Arc, time::Duration};
 use tracing::debug;
 use url::Url;
@@ -155,6 +156,13 @@ impl SqlMigrationConnector {
         .await?;
 
         Ok(())
+    }
+
+    async fn describe(&self) -> SqlResult<SqlSchema> {
+        let conn = self.connector().database.clone();
+        let schema_name = self.schema_name();
+
+        self.flavour.describe_schema(schema_name, conn).await
     }
 }
 

--- a/migration-engine/migration-engine-tests/tests/error_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/error_tests.rs
@@ -260,7 +260,6 @@ async fn bad_datasource_url_and_provider_combinations_must_return_a_proper_error
 async fn connections_to_system_databases_must_be_rejected(_api: &TestApi) -> TestResult {
     let names = &["", "mysql", "sys", "performance_schema"];
     for name in names {
-        dbg!(name);
         let dm = format!(
             r#"
                 datasource db {{


### PR DESCRIPTION
This PR does two things:

1. Return a user-facing error on startup when connecting to a system database on MySQL. We don't want users to use migrate on the [mysql database](https://dev.mysql.com/doc/refman/5.6/en/system-schema.html) or on `performance_schema`. Querying these with the QE could still be interesting, so this is only for the migration engine.

2. Instead of adding yet another match on the SqlFamily, I thought about mechanisms to have database-specific behaviour in sql-migration-connector without match statements and conditionals everywhere, since I expect this problem to only get worse with time (as it has in the past months).

The approach I went with is a trait, `SqlFlavour`, that can be extended and split into multiple traits in the future. The connector contains a `Box<dyn SqlFlavour>`.

Alternatives:
- _Use a type parameter instead of dynamic dispatch_. I tried this at first, because it's more flexible (e.g. associated types are easier). I moved away from this for three main reasons:
  1. It's noisier (type parameters and trait bounds in many places),
  2. It makes it harder to work generically with a SqlMigrationConnector, in the test setup for example, 
  3. Generated code bloat - I was a bit afraid that we would monomorphize a lot of large async functions, and that it would considerably inflate code size.
- _Split `SqlMigrationConnector` into `MysqlMigrationConnector`, `PostgresMigrationConnector` and `SqliteMigrationConnector`_. Most of the logic is still shared, so splitting the sql-migration-connector into 3 connectors sharing modules seemed a bit excessive, and the shared components would still need a trait-based specialization mechanism.

Cons:
- _Code organization_. The `SqlFlavour` implementation for all the components lives in the same module, which breaks locality. I think this can be mitigated by having `SqlFlavour` be a subtrait of a collection of specialized traits, like `DestructiveChangeCheckerFlavour` that live in next to the same module as the shared code.