### PR TITLE
Http rework 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,12 +528,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "data-encoding"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72aa14c04dfae8dd7d8a2b1cb7ca2152618cd01336dbfe704b8dcbf8d41dbd69"
-
-[[package]]
 name = "datamodel"
 version = "0.1.0"
 dependencies = [
@@ -607,16 +601,6 @@ name = "either"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
-
-[[package]]
-name = "error-chain"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d371106cc88ffdfb1eabd7111e432da544f16f3e2d7bf1dfe8bf575f1df045cd"
-dependencies = [
- "backtrace",
- "version_check",
-]
 
 [[package]]
 name = "failure"
@@ -2551,18 +2535,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_qs"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d43eef44996bbe16e99ac720e1577eefa16f7b76b5172165c98ced20ae9903e1"
-dependencies = [
- "data-encoding",
- "error-chain",
- "percent-encoding 1.0.1",
- "serde",
-]
-
-[[package]]
 name = "serde_urlencoded"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3074,6 +3046,7 @@ dependencies = [
 [[package]]
 name = "tide"
 version = "0.9.0"
+source = "git+https://github.com/http-rs/tide#12c2e22a52ff889631f0fba4c44319fb818520fc"
 dependencies = [
  "async-h1",
  "async-sse",
@@ -3084,7 +3057,6 @@ dependencies = [
  "route-recognizer",
  "serde",
  "serde_json",
- "serde_qs",
 ]
 
 [[package]]

--- a/query-engine/query-engine/src/cli.rs
+++ b/query-engine/query-engine/src/cli.rs
@@ -1,7 +1,6 @@
 use crate::{
     context::PrismaContext,
     dmmf,
-    error::PrismaError,
     opt::{CliOpt, PrismaOpt, Subcommand},
     request_handlers::{graphql::*, PrismaRequest, RequestHandler},
     PrismaResult,
@@ -12,7 +11,7 @@ use query_core::{
     schema::{QuerySchemaRef, SupportedCapabilities},
     BuildMode, QuerySchemaBuilder,
 };
-use std::{collections::HashMap, convert::TryFrom, sync::Arc};
+use std::{collections::HashMap, sync::Arc};
 
 pub struct ExecuteRequest {
     legacy: bool,
@@ -38,14 +37,14 @@ pub enum CliCommand {
     ExecuteRequest(ExecuteRequest),
 }
 
-impl TryFrom<&PrismaOpt> for CliCommand {
-    type Error = PrismaError;
-
-    fn try_from(opts: &PrismaOpt) -> crate::PrismaResult<CliCommand> {
-        let subcommand = opts
-            .subcommand
-            .as_ref()
-            .ok_or_else(|| PrismaError::InvocationError(String::from("cli subcommand not present")))?;
+impl CliCommand {
+    /// Create a CLI command from a `PrismaOpt` instance.
+    pub(crate) fn from_opt(opts: &PrismaOpt) -> crate::PrismaResult<Option<CliCommand>> {
+        let subcommand = opts.subcommand.as_ref();
+        let subcommand = match subcommand {
+            Some(cmd) => cmd,
+            None => return Ok(None),
+        };
 
         match subcommand {
             Subcommand::Cli(ref cliopts) => match cliopts {
@@ -56,28 +55,26 @@ impl TryFrom<&PrismaOpt> for CliCommand {
                         BuildMode::Modern
                     };
 
-                    Ok(CliCommand::Dmmf(DmmfRequest {
+                    Ok(Some(CliCommand::Dmmf(DmmfRequest {
                         datamodel: opts.datamodel(true)?,
                         build_mode,
                         enable_raw_queries: opts.enable_raw_queries,
-                    }))
+                    })))
                 }
-                CliOpt::GetConfig(input) => Ok(CliCommand::GetConfig(GetConfigRequest {
+                CliOpt::GetConfig(input) => Ok(Some(CliCommand::GetConfig(GetConfigRequest {
                     config: opts.configuration(input.ignore_env_var_errors)?,
-                })),
-                CliOpt::ExecuteRequest(input) => Ok(CliCommand::ExecuteRequest(ExecuteRequest {
+                }))),
+                CliOpt::ExecuteRequest(input) => Ok(Some(CliCommand::ExecuteRequest(ExecuteRequest {
                     query: input.query.clone(),
                     enable_raw_queries: opts.enable_raw_queries,
                     legacy: input.legacy,
                     datamodel: opts.datamodel(false)?,
                     config: opts.configuration(false)?,
-                })),
+                }))),
             },
         }
     }
-}
 
-impl CliCommand {
     pub async fn execute(self) -> PrismaResult<()> {
         match self {
             CliCommand::Dmmf(request) => Self::dmmf(request),


### PR DESCRIPTION
Follow-up to #766. This allows us to remove several intermediate structs and start to simplify some of the logic around initializing the HTTP server.

This also replaces the `TryInto` impl on `PrismaOpts` with a concrete method. That way we no longer need to match on a specific error to go into a different flow -- we can use `?` and match on `Option<Subcommand>` instead.

This patch also sets us up to simplify some of the other internal structures. Thanks!