### PR TITLE
Clean up --create_database and --can_connect_to_database

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1424,7 +1424,6 @@ dependencies = [
  "migration-core",
  "quaint",
  "serde_json",
- "sql-migration-connector",
  "structopt",
  "tempfile",
  "test-setup",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,12 +528,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "data-encoding"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72aa14c04dfae8dd7d8a2b1cb7ca2152618cd01336dbfe704b8dcbf8d41dbd69"
-
-[[package]]
 name = "datamodel"
 version = "0.1.0"
 dependencies = [
@@ -607,16 +601,6 @@ name = "either"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
-
-[[package]]
-name = "error-chain"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d371106cc88ffdfb1eabd7111e432da544f16f3e2d7bf1dfe8bf575f1df045cd"
-dependencies = [
- "backtrace",
- "version_check",
-]
 
 [[package]]
 name = "failure"
@@ -2551,18 +2535,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_qs"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d43eef44996bbe16e99ac720e1577eefa16f7b76b5172165c98ced20ae9903e1"
-dependencies = [
- "data-encoding",
- "error-chain",
- "percent-encoding 1.0.1",
- "serde",
-]
-
-[[package]]
 name = "serde_urlencoded"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2732,6 +2704,7 @@ dependencies = [
  "barrel",
  "chrono",
  "datamodel",
+ "futures 0.3.5",
  "migration-connector",
  "once_cell",
  "prisma-models",
@@ -2746,6 +2719,7 @@ dependencies = [
  "tracing",
  "tracing-error",
  "tracing-futures",
+ "url 2.1.1",
  "user-facing-errors",
 ]
 
@@ -3074,6 +3048,7 @@ dependencies = [
 [[package]]
 name = "tide"
 version = "0.9.0"
+source = "git+https://github.com/http-rs/tide#12c2e22a52ff889631f0fba4c44319fb818520fc"
 dependencies = [
  "async-h1",
  "async-sse",
@@ -3084,7 +3059,6 @@ dependencies = [
  "route-recognizer",
  "serde",
  "serde_json",
- "serde_qs",
 ]
 
 [[package]]

--- a/libs/test-setup/src/lib.rs
+++ b/libs/test-setup/src/lib.rs
@@ -344,7 +344,7 @@ fn fetch_db_name<'a>(url: &'a Url, default: &'static str) -> &'a str {
 
 pub async fn create_mysql_database(original_url: &Url) -> Result<Quaint, AnyError> {
     let mut url = original_url.clone();
-    url.set_path("");
+    url.set_path("/mysql");
 
     let db_name = fetch_db_name(&original_url, "mysql");
     debug_assert!(!db_name.is_empty());

--- a/migration-engine/cli/Cargo.toml
+++ b/migration-engine/cli/Cargo.toml
@@ -9,29 +9,28 @@ edition = "2018"
 [dependencies]
 migration-connector = { path = "../connectors/migration-connector" }
 migration-core = { path = "../core" }
-sql-migration-connector = { path = "../connectors/sql-migration-connector", optional = true }
 user-facing-errors = { path = "../../libs/user-facing-errors" }
 
 anyhow = "1.0.26"
 futures = "0.3"
 json-rpc-stdio = { path = "../../libs/json-rpc-stdio" }
-quaint = { git = "https://github.com/prisma/quaint", optional = true }
 serde_json = "1.0"
 structopt = "0.3.8"
 thiserror = "1.0.9"
 tokio = { version = "=0.2.13", features = ["macros"] }
 tracing = "0.1"
 tracing-subscriber = "0.2"
-url = "2.1.1"
 tracing-error = "0.1.2"
 
 [dev-dependencies]
+quaint = { git = "https://github.com/prisma/quaint" }
 tempfile = "3.1.0"
 test-setup = { path = "../../libs/test-setup" }
+url = "2.1.1"
 
 [features]
 default = ["sql"]
-sql = ["quaint", "sql-migration-connector", "migration-core/sql"]
+sql = ["migration-core/sql"]
 
 [[bin]]
 name = "migration-engine"

--- a/migration-engine/cli/src/commands.rs
+++ b/migration-engine/cli/src/commands.rs
@@ -2,16 +2,10 @@ pub(crate) mod error;
 #[cfg(test)]
 mod tests;
 
-use anyhow::Context;
 use error::CliError;
 use futures::FutureExt;
-use migration_connector::{ConnectorError, ErrorKind, MigrationConnector};
-use migration_core::CoreResult;
-use quaint::prelude::SqlFamily;
 use sql_migration_connector::SqlMigrationConnector;
-use std::collections::HashMap;
 use structopt::StructOpt;
-use url::Url;
 
 #[derive(Debug, StructOpt)]
 pub(crate) struct Cli {
@@ -52,10 +46,7 @@ impl Cli {
     pub(crate) async fn run_inner(&self) -> Result<String, CliError> {
         match self.command {
             CliCommand::CreateDatabase => create_database(&self.datasource).await,
-            CliCommand::CanConnectToDatabase => {
-                create_conn(&self.datasource, false).await?;
-                Ok("Connection successful".to_owned())
-            }
+            CliCommand::CanConnectToDatabase => connect_to_database(&self.datasource).await,
         }
     }
 }
@@ -68,128 +59,12 @@ enum CliCommand {
     CanConnectToDatabase,
 }
 
-async fn create_conn(datasource: &str, admin_mode: bool) -> CoreResult<(String, Box<SqlMigrationConnector>)> {
-    let mut url = Url::parse(datasource).expect("Invalid url in the datasource");
-    let sql_family = SqlFamily::from_scheme(url.scheme());
-
-    match sql_family {
-        Some(SqlFamily::Sqlite) => {
-            let connector = SqlMigrationConnector::new(datasource).await?;
-            Ok((datasource.to_owned(), Box::new(connector)))
-        }
-        Some(SqlFamily::Postgres) => {
-            let db_name = fetch_db_name(&url, "postgres");
-
-            let connector = if admin_mode {
-                create_postgres_admin_conn(url).await?
-            } else {
-                SqlMigrationConnector::new(url.as_str()).await?
-            };
-
-            Ok((db_name, Box::new(connector)))
-        }
-        Some(SqlFamily::Mysql) => {
-            let db_name = fetch_db_name(&url, "mysql");
-
-            if admin_mode {
-                url.set_path("");
-            }
-
-            let inner = SqlMigrationConnector::new(url.as_str()).await?;
-            Ok((db_name, Box::new(inner)))
-        }
-        None => unimplemented!("Connector {} is not supported yet", url.scheme()),
-    }
-}
-
-fn fetch_db_name(url: &Url, default: &str) -> String {
-    let result = match url.path_segments() {
-        Some(mut segments) => segments.next().unwrap_or(default),
-        None => default,
-    };
-
-    String::from(result)
+async fn connect_to_database(database_str: &str) -> Result<String, CliError> {
+    SqlMigrationConnector::new(database_str).await?;
+    Ok("Connection successful".to_owned())
 }
 
 async fn create_database(datasource: &str) -> Result<String, CliError> {
-    let url = split_database_string(datasource)
-        .and_then(|(prefix, rest)| SqlFamily::from_scheme(prefix).map(|family| (family, rest)));
-
-    match url {
-        Some((SqlFamily::Sqlite, path)) => {
-            let path = std::path::Path::new(path);
-            if path.exists() {
-                return Ok(String::new());
-            }
-
-            let dir = path.parent();
-
-            if let Some((dir, false)) = dir.map(|dir| (dir, dir.exists())) {
-                std::fs::create_dir_all(dir)
-                    .context("Creating SQLite database parent directory.")
-                    .map_err(|io_err| CliError::Other(io_err.into()))?;
-            }
-
-            create_conn(datasource, true).await?;
-
-            Ok(String::new())
-        }
-        Some(_) => {
-            let (db_name, conn) = create_conn(datasource, true).await?;
-            conn.create_database(&db_name).await?;
-            Ok(format!("Database '{}' created successfully.", db_name))
-        }
-        None => Err(CliError::Other(anyhow::anyhow!(
-            "Invalid URL or unsupported connector in the datasource ({:?})",
-            url
-        ))),
-    }
-}
-
-/// Try to connect as an admin to a postgres database. We try to pick a default database from which
-/// we can create another database.
-async fn create_postgres_admin_conn(mut url: Url) -> CoreResult<SqlMigrationConnector> {
-    let candidate_default_databases = &["postgres", "template1"];
-
-    let mut params: HashMap<String, String> = url.query_pairs().into_owned().collect();
-    params.remove("schema");
-    let params: Vec<String> = params.into_iter().map(|(k, v)| format!("{}={}", k, v)).collect();
-    let params: String = params.join("&");
-    url.set_query(Some(&params));
-
-    let mut connector = None;
-
-    for database_name in candidate_default_databases {
-        url.set_path(&format!("/{}", database_name));
-        match SqlMigrationConnector::new(url.as_str()).await {
-            // If the database does not exist, try the next one.
-            Err(err) => match &err.kind {
-                migration_connector::ErrorKind::DatabaseDoesNotExist { .. } => (),
-                _other_outcome => {
-                    connector = Some(Err(err));
-                    break;
-                }
-            },
-            // If the outcome is anything else, use this.
-            other_outcome => {
-                connector = Some(other_outcome);
-                break;
-            }
-        }
-    }
-
-    let connector = connector
-        .ok_or_else(|| {
-            ConnectorError::from_kind(ErrorKind::DatabaseCreationFailed {
-                explanation: "Prisma could not connect to a default database (`postgres` or `template1`), it cannot create the specified database.".to_owned()
-            })
-        })??;
-
-    Ok(connector)
-}
-
-fn split_database_string(database_string: &str) -> Option<(&str, &str)> {
-    let mut split = database_string.splitn(2, ':');
-
-    split.next().and_then(|prefix| split.next().map(|rest| (prefix, rest)))
+    let db_name = SqlMigrationConnector::create_database(datasource).await?;
+    Ok(format!("Database '{}' was successfully created.", db_name))
 }

--- a/migration-engine/cli/src/commands/tests.rs
+++ b/migration-engine/cli/src/commands/tests.rs
@@ -81,7 +81,7 @@ async fn test_create_mysql_database() {
     let res = run(&["--datasource", &url, "create-database"]).await;
 
     assert_eq!(
-        "Database 'this_should_exist' created successfully.",
+        "Database 'this_should_exist' was successfully created.",
         res.as_ref().unwrap()
     );
 
@@ -123,7 +123,7 @@ async fn test_create_psql_database() {
     let res = run(&["--datasource", &url, "create-database"]).await;
 
     assert_eq!(
-        "Database 'this_should_exist' created successfully.",
+        "Database 'this_should_exist' was successfully created.",
         res.as_ref().unwrap()
     );
 
@@ -147,25 +147,10 @@ async fn test_create_sqlite_database() {
     let url = format!("file:{}", sqlite_path.to_string_lossy());
 
     let res = run(&["--datasource", &url, "create-database"]).await;
-    assert_eq!("", res.as_ref().unwrap());
+    let msg = res.as_ref().unwrap();
+
+    assert!(msg.contains("success"));
+    assert!(msg.contains("test_create_sqlite_database.db"));
 
     assert!(sqlite_path.exists());
-}
-
-#[test]
-fn test_fetch_db_name() {
-    let url: url::Url = "postgresql://postgres:prisma@127.0.0.1:5432/pgres?schema=test_schema"
-        .parse()
-        .unwrap();
-    let db_name = super::fetch_db_name(&url, "postgres");
-    assert_eq!(db_name, "pgres");
-}
-
-#[test]
-fn test_fetch_db_name_with_postgres_scheme() {
-    let url: url::Url = "postgres://postgres:prisma@127.0.0.1:5432/pgres?schema=test_schema"
-        .parse()
-        .unwrap();
-    let db_name = super::fetch_db_name(&url, "postgres");
-    assert_eq!(db_name, "pgres");
 }

--- a/migration-engine/cli/src/commands/tests.rs
+++ b/migration-engine/cli/src/commands/tests.rs
@@ -24,7 +24,7 @@ fn mysql_url(db: Option<&str>) -> String {
 
 #[tokio::test]
 async fn test_connecting_with_a_working_mysql_connection_string() {
-    let result = run(&["--datasource", &mysql_url(None), "can-connect-to-database"])
+    let result = run(&["--datasource", &mysql_url(Some("mysql")), "can-connect-to-database"])
         .await
         .unwrap();
 

--- a/migration-engine/connectors/migration-connector/src/lib.rs
+++ b/migration-engine/connectors/migration-connector/src/lib.rs
@@ -37,6 +37,9 @@ pub trait MigrationConnector: Send + Sync + 'static {
     /// Hook to perform connector-specific initialization.
     async fn initialize(&self) -> ConnectorResult<()>;
 
+    /// Create the database with the provided URL.
+    async fn create_database(database_str: &str) -> ConnectorResult<String>;
+
     /// Drop all database state.
     async fn reset(&self) -> ConnectorResult<()>;
 

--- a/migration-engine/connectors/migration-connector/src/lib.rs
+++ b/migration-engine/connectors/migration-connector/src/lib.rs
@@ -34,9 +34,6 @@ pub trait MigrationConnector: Send + Sync + 'static {
     /// the connector name. The SQL connector for example can return "postgresql", "mysql" or "sqlite".
     fn connector_type(&self) -> &'static str;
 
-    /// Create a new database with the passed in name.
-    async fn create_database(&self, create: &str) -> ConnectorResult<()>;
-
     /// Hook to perform connector-specific initialization.
     async fn initialize(&self) -> ConnectorResult<()>;
 

--- a/migration-engine/connectors/sql-migration-connector/Cargo.toml
+++ b/migration-engine/connectors/sql-migration-connector/Cargo.toml
@@ -25,3 +25,5 @@ tracing = "0.1.10"
 tracing-futures = "0.2.0"
 user-facing-errors = { path = "../../../libs/user-facing-errors", features = ["sql"] }
 tracing-error = "0.1.2"
+url = "2.1.1"
+futures = "0.3.5"

--- a/migration-engine/connectors/sql-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/lib.rs
@@ -29,8 +29,15 @@ use sql_database_step_applier::*;
 use sql_destructive_changes_checker::*;
 use sql_migration_persistence::*;
 use sql_schema_describer::SqlSchemaDescriberBackend;
-use std::{fs, path::PathBuf, sync::Arc, time::Duration};
+use std::{
+    collections::HashMap,
+    fs,
+    path::{self, PathBuf},
+    sync::Arc,
+    time::Duration,
+};
 use tracing::debug;
+use url::Url;
 use user_facing_errors::migration_engine::DatabaseMigrationFormatChanged;
 
 const CONNECTION_TIMEOUT: Duration = Duration::from_secs(10);
@@ -44,37 +51,7 @@ pub struct SqlMigrationConnector {
 
 impl SqlMigrationConnector {
     pub async fn new(database_str: &str) -> ConnectorResult<Self> {
-        let connection_info =
-            ConnectionInfo::from_url(database_str).map_err(|err| ConnectorError::url_parse_error(err, database_str))?;
-
-        let connection_fut = async {
-            let connection = Quaint::new(database_str)
-                .await
-                .map_err(SqlError::from)
-                .map_err(|err: SqlError| err.into_connector_error(&connection_info))?;
-
-            // async connections can be lazy, so we issue a simple query to fail early if the database
-            // is not reachable.
-            connection
-                .query_raw("SELECT 1", &[])
-                .await
-                .map_err(SqlError::from)
-                .map_err(|err| err.into_connector_error(&connection.connection_info()))?;
-
-            Ok(connection)
-        };
-
-        let connection = tokio::time::timeout(CONNECTION_TIMEOUT, connection_fut)
-            .await
-            .map_err(|_elapsed| {
-                // TODO: why...
-                SqlError::from(ErrorKind::ConnectTimeout("Tokio timer".into())).into_connector_error(&connection_info)
-            })??;
-
-        let database_info = DatabaseInfo::new(&connection, connection.connection_info().clone())
-            .await
-            .map_err(|sql_error| sql_error.into_connector_error(&connection_info))?;
-
+        let (connection, database_info) = connect(database_str).await?;
         let schema_name = connection.connection_info().schema_name().to_owned();
         let conn = Arc::new(connection) as Arc<dyn Queryable + Send + Sync>;
 
@@ -94,21 +71,66 @@ impl SqlMigrationConnector {
         })
     }
 
-    async fn create_database_impl(&self, db_name: &str) -> SqlResult<()> {
-        match self.database_info.sql_family() {
-            SqlFamily::Postgres => {
+    pub async fn create_database(database_str: &str) -> ConnectorResult<String> {
+        use anyhow::Context;
+        use futures::future::TryFutureExt;
+
+        match ConnectionInfo::from_url(database_str).ok() {
+            Some(ConnectionInfo::Postgres(postgres_url)) => {
+                let url = Url::parse(database_str).unwrap();
+                let db_name = postgres_url.dbname();
+
+                let (conn, _) = create_postgres_admin_conn(url).await?;
+
                 let query = format!("CREATE DATABASE \"{}\"", db_name);
-                self.database.query_raw(&query, &[]).await?;
+                catch(
+                    conn.connection_info(),
+                    conn.query_raw(&query, &[]).map_err(SqlError::from),
+                )
+                .await?;
 
-                Ok(())
+                Ok(db_name.to_owned())
             }
-            SqlFamily::Sqlite => Ok(()),
-            SqlFamily::Mysql => {
+            Some(ConnectionInfo::Sqlite { file_path, .. }) => {
+                let path = path::Path::new(&file_path);
+                if path.exists() {
+                    return Ok(file_path);
+                }
+
+                let dir = path.parent();
+
+                if let Some((dir, false)) = dir.map(|dir| (dir, dir.exists())) {
+                    std::fs::create_dir_all(dir)
+                        .context("Creating SQLite database parent directory.")
+                        .map_err(|io_err| {
+                            ConnectorError::from_kind(migration_connector::ErrorKind::Generic(io_err.into()))
+                        })?;
+                }
+
+                connect(database_str).await?;
+
+                Ok(file_path)
+            }
+            Some(ConnectionInfo::Mysql(mysql_url)) => {
+                let mut url = Url::parse(database_str).unwrap();
+                url.set_path("/mysql");
+                let (conn, _) = connect(&url.to_string()).await?;
+
+                let db_name = mysql_url.dbname();
+
                 let query = format!("CREATE DATABASE `{}`", db_name);
-                self.database.query_raw(&query, &[]).await?;
+                catch(
+                    conn.connection_info(),
+                    conn.query_raw(&query, &[]).map_err(SqlError::from),
+                )
+                .await?;
 
-                Ok(())
+                Ok(db_name.to_owned())
             }
+            None => unreachable!(
+                "Invalid URL or unsupported connector in the datasource ({:?})",
+                database_str
+            ),
         }
     }
 
@@ -196,10 +218,6 @@ impl MigrationConnector for SqlMigrationConnector {
         self.connection_info().sql_family().as_str()
     }
 
-    async fn create_database(&self, db_name: &str) -> ConnectorResult<()> {
-        catch(self.connection_info(), self.create_database_impl(db_name)).await
-    }
-
     async fn initialize(&self) -> ConnectorResult<()> {
         catch(self.connection_info(), self.initialize_impl()).await?;
 
@@ -253,4 +271,83 @@ pub(crate) async fn catch<O>(
         Ok(o) => Ok(o),
         Err(sql_error) => Err(sql_error.into_connector_error(connection_info)),
     }
+}
+
+async fn connect(database_str: &str) -> ConnectorResult<(Quaint, DatabaseInfo)> {
+    let connection_info =
+        ConnectionInfo::from_url(database_str).map_err(|err| ConnectorError::url_parse_error(err, database_str))?;
+
+    let connection_fut = async {
+        let connection = Quaint::new(database_str)
+            .await
+            .map_err(SqlError::from)
+            .map_err(|err: SqlError| err.into_connector_error(&connection_info))?;
+
+        // async connections can be lazy, so we issue a simple query to fail early if the database
+        // is not reachable.
+        connection
+            .query_raw("SELECT 1", &[])
+            .await
+            .map_err(SqlError::from)
+            .map_err(|err| err.into_connector_error(&connection.connection_info()))?;
+
+        Ok(connection)
+    };
+
+    let connection = tokio::time::timeout(CONNECTION_TIMEOUT, connection_fut)
+        .await
+        .map_err(|_elapsed| {
+            // TODO: why...
+            SqlError::from(ErrorKind::ConnectTimeout("Tokio timer".into())).into_connector_error(&connection_info)
+        })??;
+
+    let database_info = DatabaseInfo::new(&connection, connection.connection_info().clone())
+        .await
+        .map_err(|sql_error| sql_error.into_connector_error(&connection_info))?;
+
+    Ok((connection, database_info))
+}
+
+/// Try to connect as an admin to a postgres database. We try to pick a default database from which
+/// we can create another database.
+async fn create_postgres_admin_conn(mut url: Url) -> ConnectorResult<(Quaint, DatabaseInfo)> {
+    use migration_connector::ErrorKind;
+
+    let candidate_default_databases = &["postgres", "template1"];
+
+    let mut params: HashMap<String, String> = url.query_pairs().into_owned().collect();
+    params.remove("schema");
+    let params: Vec<String> = params.into_iter().map(|(k, v)| format!("{}={}", k, v)).collect();
+    let params: String = params.join("&");
+    url.set_query(Some(&params));
+
+    let mut conn = None;
+
+    for database_name in candidate_default_databases {
+        url.set_path(&format!("/{}", database_name));
+        match connect(url.as_str()).await {
+            // If the database does not exist, try the next one.
+            Err(err) => match &err.kind {
+                migration_connector::ErrorKind::DatabaseDoesNotExist { .. } => (),
+                _other_outcome => {
+                    conn = Some(Err(err));
+                    break;
+                }
+            },
+            // If the outcome is anything else, use this.
+            other_outcome => {
+                conn = Some(other_outcome);
+                break;
+            }
+        }
+    }
+
+    let conn = conn
+        .ok_or_else(|| {
+            ConnectorError::from_kind(ErrorKind::DatabaseCreationFailed {
+                explanation: "Prisma could not connect to a default database (`postgres` or `template1`), it cannot create the specified database.".to_owned()
+            })
+        })??;
+
+    Ok(conn)
 }

--- a/migration-engine/connectors/sql-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/lib.rs
@@ -218,6 +218,10 @@ impl MigrationConnector for SqlMigrationConnector {
         self.connection_info().sql_family().as_str()
     }
 
+    async fn create_database(database_str: &str) -> ConnectorResult<String> {
+        Self::create_database(database_str).await
+    }
+
     async fn initialize(&self) -> ConnectorResult<()> {
         catch(self.connection_info(), self.initialize_impl()).await?;
 

--- a/migration-engine/core/src/lib.rs
+++ b/migration-engine/core/src/lib.rs
@@ -16,6 +16,7 @@ use datamodel::{
     dml::Datamodel,
 };
 use error::Error;
+use sql_migration_connector::SqlMigrationConnector;
 use std::sync::Arc;
 
 pub async fn migration_api(datamodel: &str) -> CoreResult<Arc<dyn api::GenericApi>> {
@@ -29,7 +30,7 @@ pub async fn migration_api(datamodel: &str) -> CoreResult<Arc<dyn api::GenericAp
     let connector = match source.connector_type() {
         #[cfg(feature = "sql")]
         provider if [MYSQL_SOURCE_NAME, POSTGRES_SOURCE_NAME, SQLITE_SOURCE_NAME].contains(&provider) => {
-            sql_migration_connector::SqlMigrationConnector::new(&source.url().value).await?
+            SqlMigrationConnector::new(&source.url().value).await?
         }
         x => unimplemented!("Connector {} is not supported yet", x),
     };
@@ -37,6 +38,22 @@ pub async fn migration_api(datamodel: &str) -> CoreResult<Arc<dyn api::GenericAp
     let api = api::MigrationApi::new(connector).await?;
 
     Ok(Arc::new(api))
+}
+
+pub async fn create_database(datamodel: &str) -> CoreResult<String> {
+    let config = datamodel::parse_configuration(datamodel)?;
+
+    let source = config
+        .datasources
+        .first()
+        .ok_or_else(|| CommandError::Generic(anyhow::anyhow!("There is no datasource in the schema.")))?;
+
+    match source.connector_type() {
+        provider if [MYSQL_SOURCE_NAME, POSTGRES_SOURCE_NAME, SQLITE_SOURCE_NAME].contains(&provider) => {
+            Ok(SqlMigrationConnector::create_database(&source.url().value).await?)
+        }
+        x => unimplemented!("Connector {} is not supported yet", x),
+    }
 }
 
 pub(crate) fn parse_datamodel(datamodel: &str) -> CommandResult<Datamodel> {


### PR DESCRIPTION
https://github.com/prisma/prisma-engines/pull/774 has a big refactoring and additional validation when constructing SqlMigrationConnector, so you cannot use an instantiated SqlMigrationConnector to create a database anymore. This PR cleans up and simplifies these two CLI commands to make the validations in the other PR possible.