### PR TITLE
Remove PrismaRequest

### DIFF
--- a/query-engine/query-engine/src/main.rs
+++ b/query-engine/query-engine/src/main.rs
@@ -5,7 +5,7 @@ use cli::CliCommand;
 use error::PrismaError;
 use once_cell::sync::Lazy;
 use opt::PrismaOpt;
-use request_handlers::{PrismaRequest, PrismaResponse, RequestHandler};
+use request_handlers::PrismaResponse;
 use std::{error::Error, process};
 use structopt::StructOpt;
 use tracing::subscriber;

--- a/query-engine/query-engine/src/request_handlers/mod.rs
+++ b/query-engine/query-engine/src/request_handlers/mod.rs
@@ -3,28 +3,11 @@ pub mod graphql;
 pub use graphql::*;
 pub use query_core::{response_ir, schema::QuerySchemaRenderer};
 
-use crate::context::PrismaContext;
-use async_trait::async_trait;
-use std::{collections::HashMap, fmt::Debug, sync::Arc};
+use std::fmt::Debug;
 
 #[derive(Debug, serde::Serialize, PartialEq)]
 #[serde(untagged)]
 pub enum PrismaResponse {
     Single(response_ir::Responses),
     Multi(Vec<PrismaResponse>),
-}
-
-#[async_trait]
-pub trait RequestHandler {
-    type Body: Debug;
-
-    async fn handle<S>(&self, req: S, ctx: &Arc<PrismaContext>) -> PrismaResponse
-    where
-        S: Into<PrismaRequest<Self::Body>> + Send + Sync + 'static;
-}
-
-pub struct PrismaRequest<T> {
-    pub body: T,
-    pub headers: HashMap<String, String>,
-    pub path: String,
 }

--- a/query-engine/query-engine/src/server/mod.rs
+++ b/query-engine/query-engine/src/server/mod.rs
@@ -3,8 +3,7 @@
 use crate::context::PrismaContext;
 use crate::dmmf;
 use crate::opt::PrismaOpt;
-use crate::request_handlers::graphql::{GraphQLSchemaRenderer, GraphQlRequestHandler};
-use crate::request_handlers::{PrismaRequest, RequestHandler};
+use crate::request_handlers::graphql::{self, GraphQLSchemaRenderer, GraphQlBody};
 use crate::PrismaResult;
 use elapsed_middleware::ElapsedMiddleware;
 
@@ -73,12 +72,9 @@ pub async fn listen(opts: PrismaOpt) -> PrismaResult<()> {
 /// The main query handler. This handles incoming GraphQL queries and passes it
 /// to the query engine.
 async fn graphql_handler(mut req: Request<State>) -> tide::Result {
-    let body = req.body_json().await?;
-    let path = req.url().path().to_owned();
-    let headers = req.iter().map(|(k, v)| (format!("{}", k), format!("{}", v))).collect();
+    let body: GraphQlBody = req.body_json().await?;
     let cx = req.state().cx.clone();
-    let req = PrismaRequest { body, path, headers };
-    let result = GraphQlRequestHandler.handle(req, &cx).await;
+    let result = graphql::handle(body, cx).await;
     let mut res = Response::new(StatusCode::Ok);
     res.set_body(Body::from_json(&result)?);
     Ok(res)


### PR DESCRIPTION
This removes `PrismaRequest` and enables the API to directly interface with `GraphQlBody` instead. This simplifies the internals by removing the intermediate `RequestHandler` trait and reduces allocations by no longer iterating over each incoming header.

This patch also sets us up for a refactor of `PrismaContext`. Thanks!