### PR TITLE
Restructure SqlDestructiveChangesChecker

### DIFF
--- a/migration-engine/cli/src/main.rs
+++ b/migration-engine/cli/src/main.rs
@@ -1,3 +1,5 @@
+#![deny(rust_2018_idioms)]
+
 mod commands;
 #[cfg(test)]
 mod error_tests;

--- a/migration-engine/connectors/migration-connector/src/lib.rs
+++ b/migration-engine/connectors/migration-connector/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(rust_2018_idioms)]
+
 //! This crate defines the API exposed by the connectors to the migration engine core. The entry point for this API is the [MigrationConnector](trait.MigrationConnector.html) trait.
 
 mod database_migration_inferrer;

--- a/migration-engine/connectors/sql-migration-connector/src/component.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/component.rs
@@ -2,6 +2,8 @@ use crate::{DatabaseInfo, SqlMigrationConnector, SqlResult};
 use quaint::prelude::{ConnectionInfo, Queryable, SqlFamily};
 use sql_schema_describer::SqlSchema;
 
+/// Implemented by the components of the connector that contain a reference to the connector (like
+/// SqlDestructiveChangeChecker). It lets them conveniently access global resources.
 #[async_trait::async_trait]
 pub(crate) trait Component {
     fn connector(&self) -> &SqlMigrationConnector;

--- a/migration-engine/connectors/sql-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(rust_2018_idioms)]
+
 mod component;
 mod database_info;
 mod datamodel_helpers;

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker.rs
@@ -1,15 +1,31 @@
+mod check;
+mod database_inspection_results;
+mod destructive_check_plan;
+mod sql_migration_warning;
 mod sql_unexecutable_migration;
 
 use crate::{
-    sql_schema_differ::DiffingOptions, AddColumn, AlterColumn, Component, DropColumn, DropTable, DropTables, SqlError,
+    sql_schema_differ::DiffingOptions, AddColumn, AlterColumn, Component, DropColumn, DropTable, DropTables,
     SqlMigration, SqlMigrationStep, SqlResult, TableChange,
 };
-use migration_connector::{
-    ConnectorResult, DestructiveChangeDiagnostics, DestructiveChangesChecker, MigrationWarning, UnexecutableMigration,
-};
-use quaint::{ast::*, prelude::SqlFamily};
+use destructive_check_plan::DestructiveCheckPlan;
+use migration_connector::{ConnectorResult, DestructiveChangeDiagnostics, DestructiveChangesChecker};
+use quaint::prelude::SqlFamily;
+use sql_migration_warning::SqlMigrationWarning;
 use sql_schema_describer::{ColumnArity, SqlSchema};
+use sql_unexecutable_migration::SqlUnexecutableMigration;
 
+/// The SqlDestructiveChangesChecker is responsible for informing users about potentially
+/// destructive or impossible changes that their attempted migrations contain.
+///
+/// It proceeds in three steps:
+///
+/// - Examine the SqlMigrationSteps in the migration, to generate a `DestructiveCheckPlan`
+///   containing destructive change checks (implementors of the `Check` trait). At this stage, there
+///   is no interaction with the database.
+/// - Execute that plan (`DestructiveCheckPlan::execute`), running queries against the database to
+///   inspect its current state, depending on what information the checks require.
+/// - Render the final user-facing messages based on the plan and the gathered information.
 pub struct SqlDestructiveChangesChecker<'a> {
     pub connector: &'a crate::SqlMigrationConnector,
 }
@@ -21,96 +37,23 @@ impl Component for SqlDestructiveChangesChecker<'_> {
 }
 
 impl SqlDestructiveChangesChecker<'_> {
-    async fn check_table_drop(
-        &self,
-        table_name: &str,
-        diagnostics: &mut DestructiveChangeDiagnostics,
-    ) -> SqlResult<()> {
-        let rows_count = self.count_rows_in_table(table_name).await?;
-
-        if rows_count > 0 {
-            diagnostics.add_warning(MigrationWarning {
-                description: format!(
-                    "You are about to drop the table `{table_name}`, which is not empty ({rows_count} rows).",
-                    table_name = table_name,
-                    rows_count = rows_count
-                ),
-            });
-        }
-
-        Ok(())
-    }
-
-    async fn count_values_in_column(&self, column_name: &str, table: &sql_schema_describer::Table) -> SqlResult<i64> {
-        let query = Select::from_table((self.schema_name(), table.name.as_str()))
-            .value(count(quaint::ast::Column::new(column_name)))
-            .so_that(column_name.is_not_null());
-
-        let values_count: i64 =
-            self.conn()
-                .query(query.into())
-                .await
-                .map_err(SqlError::from)
-                .and_then(|result_set| {
-                    result_set
-                        .first()
-                        .as_ref()
-                        .and_then(|row| row.at(0))
-                        .and_then(|count| count.as_i64())
-                        .ok_or_else(|| {
-                            SqlError::Generic(anyhow::anyhow!(
-                                "Unexpected result set shape when checking dropped columns."
-                            ))
-                        })
-                })?;
-
-        Ok(values_count)
-    }
-
-    async fn count_rows_in_table(&self, table_name: &str) -> SqlResult<i64> {
-        let query = Select::from_table((self.schema_name(), table_name)).value(count(asterisk()));
-        let result_set = self.conn().query(query.into()).await?;
-        let rows_count = result_set
-            .first()
-            .ok_or_else(|| {
-                SqlError::Generic(anyhow::anyhow!(
-                    "No row was returned when checking for existing rows in the `{}` table.",
-                    table_name
-                ))
-            })?
-            .at(0)
-            .and_then(|value| value.as_i64())
-            .ok_or_else(|| {
-                SqlError::Generic(anyhow::anyhow!(
-                    "No count was returned when checking for existing rows in the `{}` table.",
-                    table_name
-                ))
-            })?;
-
-        Ok(rows_count)
+    fn check_table_drop(&self, table_name: &str, plan: &mut DestructiveCheckPlan) {
+        plan.push_warning(SqlMigrationWarning::NonEmptyTableDrop {
+            table: table_name.to_owned(),
+        });
     }
 
     /// Emit a warning when we drop a column that contains non-null values.
-    async fn check_column_drop(
+    fn check_column_drop(
         &self,
         drop_column: &DropColumn,
         table: &sql_schema_describer::Table,
-        diagnostics: &mut DestructiveChangeDiagnostics,
-    ) -> SqlResult<()> {
-        let values_count = self.count_values_in_column(&drop_column.name, table).await?;
-
-        if values_count > 0 {
-            diagnostics.add_warning(MigrationWarning {
-                description: format!(
-                    "You are about to drop the column `{column_name}` on the `{table_name}` table, which still contains {values_count} non-null values.",
-                    column_name=drop_column.name,
-                    table_name=&table.name,
-                    values_count=values_count,
-                )
-            })
-        }
-
-        Ok(())
+        plan: &mut DestructiveCheckPlan,
+    ) {
+        plan.push_warning(SqlMigrationWarning::NonEmptyColumnDrop {
+            table: table.name.clone(),
+            column: drop_column.name.clone(),
+        });
     }
 
     /// Columns cannot be added when all of the following holds:
@@ -118,38 +61,26 @@ impl SqlDestructiveChangesChecker<'_> {
     /// - There are existing rows
     /// - The new column is required
     /// - There is no default value for the new column
-    async fn check_add_column(
+    fn check_add_column(
         &self,
         add_column: &AddColumn,
         table: &sql_schema_describer::Table,
-        diagnostics: &mut DestructiveChangeDiagnostics,
-    ) -> SqlResult<()> {
+        plan: &mut DestructiveCheckPlan,
+    ) {
         let column_is_required_without_default =
             add_column.column.tpe.arity.is_required() && add_column.column.default.is_none();
 
         // Optional columns and columns with a default can safely be added.
         if !column_is_required_without_default {
-            return Ok(());
+            return;
         }
 
-        let rows_count = self.count_rows_in_table(&table.name).await?;
-
-        // Empty tables can be safely migrated.
-        if rows_count == 0 {
-            return Ok(());
-        }
-
-        let typed_unexecutable = sql_unexecutable_migration::SqlUnexecutableMigration::AddedRequiredFieldToTable {
+        let typed_unexecutable = SqlUnexecutableMigration::AddedRequiredFieldToTable {
             column: add_column.column.name.clone(),
-            rows_count: Some(rows_count as u64),
             table: table.name.clone(),
         };
 
-        diagnostics.unexecutable_migrations.push(UnexecutableMigration {
-            description: format!("{}", typed_unexecutable),
-        });
-
-        Ok(())
+        plan.push_unexecutable(typed_unexecutable);
     }
 
     /// Are considered safe at the moment:
@@ -161,12 +92,12 @@ impl SqlDestructiveChangesChecker<'_> {
     /// Are considered unexecutable:
     ///
     /// - Making an optional column required without a default, when there are existing rows in the table.
-    async fn check_alter_column(
+    fn check_alter_column(
         &self,
         alter_column: &AlterColumn,
         previous_table: &sql_schema_describer::Table,
-        diagnostics: &mut DestructiveChangeDiagnostics,
-    ) -> SqlResult<()> {
+        plan: &mut DestructiveCheckPlan,
+    ) {
         let previous_column = previous_table
             .column(&alter_column.name)
             .expect("unsupported column renaming");
@@ -180,36 +111,25 @@ impl SqlDestructiveChangesChecker<'_> {
         };
 
         if self.alter_column_is_safe(&differ) {
-            return Ok(());
+            return;
         }
 
-        self.check_for_column_arity_change(&previous_table.name, &differ, diagnostics)
-            .await?;
+        self.check_for_column_arity_change(&previous_table.name, &differ, plan);
 
-        let values_count = self.count_values_in_column(&alter_column.name, previous_table).await?;
+        plan.push_warning(SqlMigrationWarning::AlterColumn {
+            table: previous_table.name.clone(),
+            column: alter_column.column.name.clone(),
+        });
 
-        if values_count > 0 {
-            diagnostics.add_warning(MigrationWarning {
-                description: format!(
-                                 "You are about to alter the column `{column_name}` on the `{table_name}` table, which still contains {values_count} non-null values. The data in that column will be lost.",
-                                 column_name=alter_column.name,
-                                 table_name=&previous_table.name,
-                                 values_count=values_count,
-                             )
-            })
-        } else if previous_table.is_part_of_foreign_key(&alter_column.column.name)
+        if previous_table.is_part_of_foreign_key(&alter_column.column.name)
             && alter_column.column.default.is_none()
             && previous_column.default.is_some()
         {
-            diagnostics.add_warning(MigrationWarning {
-                description: format!(
-                    "The migration is about to remove a default value on the foreign key field `{}.{}`.",
-                    previous_table.name, alter_column.name,
-                ),
-            })
+            plan.push_warning(SqlMigrationWarning::ForeignKeyDefaultValueRemoved {
+                table: previous_table.name.clone(),
+                column: alter_column.name.clone(),
+            });
         }
-
-        Ok(())
     }
 
     fn alter_column_is_safe(&self, differ: &crate::sql_schema_differ::ColumnDiffer<'_>) -> bool {
@@ -274,20 +194,17 @@ impl SqlDestructiveChangesChecker<'_> {
         }
     }
 
-    async fn check_for_column_arity_change(
+    fn check_for_column_arity_change(
         &self,
         table_name: &str,
         differ: &crate::sql_schema_differ::ColumnDiffer<'_>,
-        diagnostics: &mut DestructiveChangeDiagnostics,
-    ) -> SqlResult<()> {
-        let rows_count = self.count_rows_in_table(table_name).await?;
-
+        plan: &mut DestructiveCheckPlan,
+    ) {
         if !differ.all_changes().arity_changed()
             || !differ.next.tpe.arity.is_required()
-            || rows_count == 0
             || differ.next.default.is_some()
         {
-            return Ok(());
+            return;
         }
 
         let typed_unexecutable = sql_unexecutable_migration::SqlUnexecutableMigration::MadeOptionalFieldRequired {
@@ -295,11 +212,7 @@ impl SqlDestructiveChangesChecker<'_> {
             column: differ.previous.name.clone(),
         };
 
-        diagnostics.unexecutable_migrations.push(UnexecutableMigration {
-            description: format!("{}", typed_unexecutable),
-        });
-
-        Ok(())
+        plan.push_unexecutable(typed_unexecutable);
     }
 
     async fn check_impl(
@@ -307,7 +220,7 @@ impl SqlDestructiveChangesChecker<'_> {
         steps: &[SqlMigrationStep],
         before: &SqlSchema,
     ) -> SqlResult<DestructiveChangeDiagnostics> {
-        let mut diagnostics = DestructiveChangeDiagnostics::new();
+        let mut plan = DestructiveCheckPlan::new();
 
         for step in steps {
             match step {
@@ -320,16 +233,13 @@ impl SqlDestructiveChangesChecker<'_> {
                         for change in &alter_table.changes {
                             match *change {
                                 TableChange::DropColumn(ref drop_column) => {
-                                    self.check_column_drop(drop_column, before_table, &mut diagnostics)
-                                        .await?
+                                    self.check_column_drop(drop_column, before_table, &mut plan)
                                 }
                                 TableChange::AlterColumn(ref alter_column) => {
-                                    self.check_alter_column(alter_column, before_table, &mut diagnostics)
-                                        .await?
+                                    self.check_alter_column(alter_column, before_table, &mut plan)
                                 }
                                 TableChange::AddColumn(ref add_column) => {
-                                    self.check_add_column(add_column, before_table, &mut diagnostics)
-                                        .await?
+                                    self.check_add_column(add_column, before_table, &mut plan)
                                 }
                                 _ => (),
                             }
@@ -339,11 +249,11 @@ impl SqlDestructiveChangesChecker<'_> {
                 // Here, check for each table we are going to delete if it is empty. If
                 // not, return a warning.
                 SqlMigrationStep::DropTable(DropTable { name }) => {
-                    self.check_table_drop(name, &mut diagnostics).await?;
+                    self.check_table_drop(name, &mut plan);
                 }
                 SqlMigrationStep::DropTables(DropTables { names }) => {
                     for name in names {
-                        self.check_table_drop(name, &mut diagnostics).await?;
+                        self.check_table_drop(name, &mut plan);
                     }
                 }
                 // SqlMigrationStep::CreateIndex(CreateIndex { table, index }) if index.is_unique() => todo!(),
@@ -351,6 +261,8 @@ impl SqlDestructiveChangesChecker<'_> {
                 _ => (),
             }
         }
+
+        let mut diagnostics = plan.execute(self.schema_name(), self.conn()).await?;
 
         // Temporary, for better reporting.
         diagnostics.warn_about_unexecutable_migrations();
@@ -361,6 +273,7 @@ impl SqlDestructiveChangesChecker<'_> {
 
 #[async_trait::async_trait]
 impl DestructiveChangesChecker<SqlMigration> for SqlDestructiveChangesChecker<'_> {
+    #[tracing::instrument(skip(self, database_migration), target = "SqlDestructiveChangeChecker::check")]
     async fn check(&self, database_migration: &SqlMigration) -> ConnectorResult<DestructiveChangeDiagnostics> {
         self.check_impl(&database_migration.original_steps, &database_migration.before)
             .await

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker.rs
@@ -1,8 +1,8 @@
 mod check;
 mod database_inspection_results;
 mod destructive_check_plan;
-mod sql_migration_warning;
-mod sql_unexecutable_migration;
+mod unexecutable_step_check;
+mod warning_check;
 
 use crate::{
     sql_schema_differ::DiffingOptions, AddColumn, AlterColumn, Component, DropColumn, DropTable, DropTables,
@@ -11,9 +11,9 @@ use crate::{
 use destructive_check_plan::DestructiveCheckPlan;
 use migration_connector::{ConnectorResult, DestructiveChangeDiagnostics, DestructiveChangesChecker};
 use quaint::prelude::SqlFamily;
-use sql_migration_warning::SqlMigrationWarning;
 use sql_schema_describer::{ColumnArity, SqlSchema};
-use sql_unexecutable_migration::SqlUnexecutableMigration;
+use unexecutable_step_check::UnexecutableStepCheck;
+use warning_check::SqlMigrationWarning;
 
 /// The SqlDestructiveChangesChecker is responsible for informing users about potentially
 /// destructive or impossible changes that their attempted migrations contain.
@@ -75,7 +75,7 @@ impl SqlDestructiveChangesChecker<'_> {
             return;
         }
 
-        let typed_unexecutable = SqlUnexecutableMigration::AddedRequiredFieldToTable {
+        let typed_unexecutable = UnexecutableStepCheck::AddedRequiredFieldToTable {
             column: add_column.column.name.clone(),
             table: table.name.clone(),
         };
@@ -207,7 +207,7 @@ impl SqlDestructiveChangesChecker<'_> {
             return;
         }
 
-        let typed_unexecutable = sql_unexecutable_migration::SqlUnexecutableMigration::MadeOptionalFieldRequired {
+        let typed_unexecutable = unexecutable_step_check::UnexecutableStepCheck::MadeOptionalFieldRequired {
             table: table_name.to_owned(),
             column: differ.previous.name.clone(),
         };

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/check.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/check.rs
@@ -1,0 +1,27 @@
+use super::database_inspection_results::DatabaseInspectionResults;
+
+/// This trait should be implemented by warning and unexecutable migration types. It lets them
+/// describe what data they need from the current state of the database to be as accurate and
+/// informative as possible.
+pub(super) trait Check {
+    /// Fetch the row count for the table with the returned name.
+    fn check_row_count(&self) -> Option<&str> {
+        None
+    }
+
+    /// Fetch the number of non-null values for the returned table and column.
+    fn check_existing_values(&self) -> Option<(&str, &str)> {
+        None
+    }
+
+    /// This function will always be called for every check in a migration. Each change must check
+    /// for the data it needs in the database inspection results. If there is no data, it should
+    /// assume the current state of the database could not be inspected and warn with a best effort
+    /// message explaining under which conditions the migration could not be applied or would cause
+    /// data loss.
+    ///
+    /// The only case where `None` should be returned is when there is data about the current state
+    /// of the database, and that data indicates that the migration step would be executable and
+    /// safe.
+    fn render(&self, database_check_results: &DatabaseInspectionResults) -> Option<String>;
+}

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/check.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/check.rs
@@ -4,13 +4,13 @@ use super::database_inspection_results::DatabaseInspectionResults;
 /// describe what data they need from the current state of the database to be as accurate and
 /// informative as possible.
 pub(super) trait Check {
-    /// Fetch the row count for the table with the returned name.
-    fn check_row_count(&self) -> Option<&str> {
+    /// Indicates that the row count for the table with the returned name should be inspected.
+    fn needed_table_row_count(&self) -> Option<&str> {
         None
     }
 
-    /// Fetch the number of non-null values for the returned table and column.
-    fn check_existing_values(&self) -> Option<(&str, &str)> {
+    /// Indicates that the the number of non-null values should be inspected for the returned table and column.
+    fn needed_column_value_count(&self) -> Option<(&str, &str)> {
         None
     }
 
@@ -23,5 +23,5 @@ pub(super) trait Check {
     /// The only case where `None` should be returned is when there is data about the current state
     /// of the database, and that data indicates that the migration step would be executable and
     /// safe.
-    fn render(&self, database_check_results: &DatabaseInspectionResults) -> Option<String>;
+    fn evaluate(&self, database_check_results: &DatabaseInspectionResults) -> Option<String>;
 }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/database_inspection_results.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/database_inspection_results.rs
@@ -1,0 +1,34 @@
+use std::{borrow::Cow, collections::HashMap};
+
+/// The information about the current state of the database gathered by the destructive change checker.
+#[derive(Debug, Default)]
+pub(super) struct DatabaseInspectionResults {
+    /// HashMap from table name to row count.
+    row_counts: HashMap<String, i64>,
+    /// HashMap from (table name, column name) to non-null values count.
+    value_counts: HashMap<(Cow<'static, str>, Cow<'static, str>), i64>,
+}
+
+impl DatabaseInspectionResults {
+    pub(super) fn get_row_count(&self, table: &str) -> Option<i64> {
+        self.row_counts.get(table).map(|count| *count)
+    }
+
+    pub(super) fn set_row_count(&mut self, table: String, row_count: i64) {
+        self.row_counts.insert(table, row_count);
+    }
+
+    /// Returns the row count in the table and the non-null value count in the column.
+    pub(super) fn get_value_count(&self, table: &str, column: &str) -> (Option<i64>, Option<i64>) {
+        (
+            self.row_counts.get(table).map(|count| *count),
+            self.value_counts
+                .get(&(Cow::Borrowed(table), Cow::Borrowed(column)))
+                .map(|count| *count),
+        )
+    }
+
+    pub(super) fn set_value_count(&mut self, table: Cow<'static, str>, column: Cow<'static, str>, count: i64) {
+        self.value_counts.insert((table, column), count);
+    }
+}

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/database_inspection_results.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/database_inspection_results.rs
@@ -18,8 +18,7 @@ impl DatabaseInspectionResults {
         self.row_counts.insert(table, row_count);
     }
 
-    /// Returns the row count in the table and the non-null value count in the column.
-    pub(super) fn get_value_count(&self, table: &str, column: &str) -> (Option<i64>, Option<i64>) {
+    pub(super) fn get_row_and_non_null_value_count(&self, table: &str, column: &str) -> (Option<i64>, Option<i64>) {
         (
             self.row_counts.get(table).map(|count| *count),
             self.value_counts

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/destructive_check_plan.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/destructive_check_plan.rs
@@ -1,0 +1,155 @@
+use super::{
+    check::Check, database_inspection_results::DatabaseInspectionResults, sql_migration_warning::SqlMigrationWarning,
+    sql_unexecutable_migration::SqlUnexecutableMigration,
+};
+use crate::{SqlError, SqlResult};
+use migration_connector::{DestructiveChangeDiagnostics, MigrationWarning, UnexecutableMigration};
+use quaint::prelude::Queryable;
+
+/// A DestructiveCheckPlan is the collection of destructive change checks
+/// ([Check](trait.Check.html)) for a given migration. It has an `execute` method that performs
+/// database inspection and renders user-facing messages based on the checks.
+#[derive(Debug)]
+pub(super) struct DestructiveCheckPlan {
+    warnings: Vec<SqlMigrationWarning>,
+    unexecutable_migrations: Vec<SqlUnexecutableMigration>,
+}
+
+impl DestructiveCheckPlan {
+    pub(super) fn new() -> Self {
+        DestructiveCheckPlan {
+            warnings: Vec::new(),
+            unexecutable_migrations: Vec::new(),
+        }
+    }
+
+    pub(super) fn push_warning(&mut self, warning: SqlMigrationWarning) {
+        self.warnings.push(warning)
+    }
+
+    pub(super) fn push_unexecutable(&mut self, unexecutable_migration: SqlUnexecutableMigration) {
+        self.unexecutable_migrations.push(unexecutable_migration)
+    }
+
+    /// Inspect the current database state to qualify and render destructive change warnings and
+    /// errors.
+    ///
+    /// For example, dropping a table that has 0 rows can be considered safe.
+    #[tracing::instrument(skip(conn, schema_name), level = "debug")]
+    pub(super) async fn execute(
+        &mut self,
+        schema_name: &str,
+        conn: &dyn Queryable,
+    ) -> SqlResult<DestructiveChangeDiagnostics> {
+        let mut results = DatabaseInspectionResults::default();
+
+        for unexecutable in &self.unexecutable_migrations {
+            self.inspect_for_check(unexecutable, &mut results, schema_name, conn)
+                .await?;
+        }
+
+        for warning in &self.warnings {
+            self.inspect_for_check(warning, &mut results, schema_name, conn).await?;
+        }
+
+        let mut diagnostics = DestructiveChangeDiagnostics::new();
+
+        for unexecutable in &self.unexecutable_migrations {
+            if let Some(message) = unexecutable.render(&results) {
+                diagnostics
+                    .unexecutable_migrations
+                    .push(UnexecutableMigration { description: message })
+            }
+        }
+
+        for warning in &self.warnings {
+            if let Some(message) = warning.render(&results) {
+                diagnostics.warnings.push(MigrationWarning { description: message })
+            }
+        }
+
+        Ok(diagnostics)
+    }
+
+    /// Perform the database inspection for a given [`Check`](trait.Check.html).
+    pub(super) async fn inspect_for_check(
+        &self,
+        check: &(dyn Check + Send + Sync + 'static),
+        results: &mut DatabaseInspectionResults,
+        schema_name: &str,
+        conn: &dyn Queryable,
+    ) -> SqlResult<()> {
+        if let Some(table) = check.check_row_count() {
+            if results.get_row_count(table).is_none() {
+                let count = count_rows_in_table(table, schema_name, conn).await?;
+                results.set_row_count(table.to_owned(), count)
+            }
+        }
+
+        if let Some((table, column)) = check.check_existing_values() {
+            if let (_, None) = results.get_value_count(table, column) {
+                let count = count_values_in_column(column, table, schema_name, conn).await?;
+                results.set_value_count(table.to_owned().into(), column.to_owned().into(), count);
+            }
+        }
+
+        Ok(())
+    }
+}
+
+async fn count_rows_in_table(table_name: &str, schema_name: &str, conn: &dyn Queryable) -> SqlResult<i64> {
+    use quaint::ast::*;
+
+    let query = Select::from_table((schema_name, table_name)).value(count(asterisk()));
+    let result_set = conn.query(query.into()).await?;
+    let rows_count = result_set
+        .first()
+        .ok_or_else(|| {
+            SqlError::Generic(anyhow::anyhow!(
+                "No row was returned when checking for existing rows in the `{}` table.",
+                table_name
+            ))
+        })?
+        .at(0)
+        .and_then(|value| value.as_i64())
+        .ok_or_else(|| {
+            SqlError::Generic(anyhow::anyhow!(
+                "No count was returned when checking for existing rows in the `{}` table.",
+                table_name
+            ))
+        })?;
+
+    Ok(rows_count)
+}
+
+async fn count_values_in_column(
+    column_name: &str,
+    table: &str,
+    schema_name: &str,
+    conn: &dyn Queryable,
+) -> SqlResult<i64> {
+    use quaint::ast::*;
+
+    let query = Select::from_table((schema_name, table))
+        .value(count(quaint::ast::Column::new(column_name)))
+        .so_that(column_name.is_not_null());
+
+    let values_count: i64 = conn
+        .query(query.into())
+        .await
+        .map_err(SqlError::from)
+        .and_then(|result_set| {
+            result_set
+                .first()
+                .as_ref()
+                .and_then(|row| row.at(0))
+                .and_then(|count| count.as_i64())
+                .ok_or_else(|| {
+                    SqlError::Generic(anyhow::anyhow!(
+                        "Unexpected result set shape when checking dropped columns."
+                    ))
+                })
+        })?;
+
+    Ok(values_count)
+}

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/sql_migration_warning.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/sql_migration_warning.rs
@@ -1,0 +1,53 @@
+use super::{check::Check, database_inspection_results::DatabaseInspectionResults};
+
+#[derive(Debug)]
+pub(super) enum SqlMigrationWarning {
+    NonEmptyColumnDrop { table: String, column: String },
+    NonEmptyTableDrop { table: String },
+    AlterColumn { table: String, column: String },
+    ForeignKeyDefaultValueRemoved { table: String, column: String },
+}
+
+impl Check for SqlMigrationWarning {
+    fn check_row_count(&self) -> Option<&str> {
+        match self {
+            SqlMigrationWarning::NonEmptyTableDrop { table } => Some(table),
+            SqlMigrationWarning::NonEmptyColumnDrop { .. }
+            | SqlMigrationWarning::AlterColumn { .. }
+            | SqlMigrationWarning::ForeignKeyDefaultValueRemoved { .. } => None,
+        }
+    }
+
+    fn check_existing_values(&self) -> Option<(&str, &str)> {
+        match self {
+            SqlMigrationWarning::NonEmptyColumnDrop { table, column }
+            | SqlMigrationWarning::AlterColumn { table, column } => Some((table, column)),
+            SqlMigrationWarning::ForeignKeyDefaultValueRemoved { .. }
+            | SqlMigrationWarning::NonEmptyTableDrop { .. } => None,
+        }
+    }
+
+    fn render(&self, database_check_results: &DatabaseInspectionResults) -> Option<String> {
+        match self {
+            SqlMigrationWarning::NonEmptyTableDrop { table } => match database_check_results.get_row_count(table) {
+                Some(0) => None, // dropping the table is safe if it's empty
+                Some(rows_count) => Some(format!("You are about to drop the `{table_name}` table, which is not empty ({rows_count} rows).", table_name = table, rows_count = rows_count)),
+                None => Some(format!("You are about to drop the `{}` table. If the table is not empty, all the data it contains will be lost.", table)),
+            },
+            SqlMigrationWarning::NonEmptyColumnDrop { table, column } => match database_check_results.get_value_count(table, column) {
+                (Some(0), _) => None, // it's safe to drop a column on an empty table
+                (_, Some(0)) => None, // it's safe to drop a column if it only contains null values
+                (_, Some(value_count)) => Some(format!("You are about to drop the column `{column_name}` on the `{table_name}` table, which still contains {value_count} non-null values.", column_name = column, table_name = table, value_count = value_count)),
+                (_, _) => Some(format!("You are about to drop the column `{column_name}` on the `{table_name}` table. All the data in the column will be lost.", column_name = column, table_name = table)),
+            },
+            SqlMigrationWarning::AlterColumn { table, column } => match database_check_results.get_value_count(table, column) {
+                (Some(0), _) => None, // it's safe to alter a column on an empty table
+                (_, Some(0)) => None, // it's safe to alter a column if it only contains null values
+                (_, Some(value_count)) => Some(format!("You are about to alter the column `{column_name}` on the `{table_name}` table, which still contains {value_count} non-null values. The data in that column will be lost.", column_name = column, table_name = table, value_count = value_count)),
+                (_, _) => Some(format!("You are about to alter the column `{column_name}` on the `{table_name}` table. The data in that column will be lost.", column_name = column, table_name = table)),
+
+            },
+            SqlMigrationWarning::ForeignKeyDefaultValueRemoved { table, column } => Some(format!("The migration is about to remove a default value on the foreign key field `{}.{}`.", table, column)),
+        }
+    }
+}

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/sql_unexecutable_migration.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/sql_unexecutable_migration.rs
@@ -1,14 +1,9 @@
+use super::{check::Check, database_inspection_results::DatabaseInspectionResults};
+
 #[derive(Debug)]
 pub(crate) enum SqlUnexecutableMigration {
-    AddedRequiredFieldToTable {
-        table: String,
-        column: String,
-        rows_count: Option<u64>,
-    },
-    MadeOptionalFieldRequired {
-        table: String,
-        column: String,
-    },
+    AddedRequiredFieldToTable { table: String, column: String },
+    MadeOptionalFieldRequired { table: String, column: String },
     // TODO:
     // AddedUnimplementableUniqueConstraint {
     //     table: String,
@@ -24,15 +19,71 @@ pub(crate) enum SqlUnexecutableMigration {
     // },
 }
 
-impl std::fmt::Display for SqlUnexecutableMigration {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Check for SqlUnexecutableMigration {
+    fn check_row_count(&self) -> Option<&str> {
         match self {
-            SqlUnexecutableMigration::AddedRequiredFieldToTable { table, column, rows_count } => {
-                write!(f, "Added the required column `{column}` to the `{table}` table without a default value. There are {rows_count:?} rows in this table, it is not possible.", table = table, column = column, rows_count = rows_count)?
-            },
+            SqlUnexecutableMigration::MadeOptionalFieldRequired { table, column: _ }
+            | SqlUnexecutableMigration::AddedRequiredFieldToTable { table, column: _ } => Some(table),
+        }
+    }
+
+    fn check_existing_values(&self) -> Option<(&str, &str)> {
+        match self {
+            SqlUnexecutableMigration::MadeOptionalFieldRequired { table, column } => Some((table, column)),
+            SqlUnexecutableMigration::AddedRequiredFieldToTable { .. } => None,
+        }
+    }
+
+    fn render<'a>(&self, database_checks: &DatabaseInspectionResults) -> Option<String> {
+        match self {
+            SqlUnexecutableMigration::AddedRequiredFieldToTable { table, column } => {
+                let message = |details| {
+                    format!(
+                        "Added the required column `{column}` to the `{table}` table without a default value. {details}",
+                        table = table,
+                        column = column,
+                        details = details,
+                    )
+                };
+
+                let message = match database_checks.get_row_count(table) {
+                    Some(0) => return None, // Adding a required column is possible if there is no data
+                    Some(row_count) => {
+                        message(format_args!(
+                            "There are {row_count} rows in this table, it is not possible to execute this migration.",
+                            row_count = row_count
+                        ))
+                    }
+                    None => message(format_args!("This is not possible if the table is not empty."))
+
+                };
+
+                Some(message)
+            }
             SqlUnexecutableMigration::MadeOptionalFieldRequired { table, column } => {
-                write!(f, "Made the column `{column}` on table `{table}` required, but there are existing NULL values.", column = column, table = table)?
-            },
+                match database_checks.get_value_count(table, column) {
+                    (Some(0), _) => None,
+                    (Some(row_count), Some(value_count)) => {
+                        let null_value_count = row_count - value_count;
+
+                        if null_value_count == 0 {
+                            return None
+                        }
+
+                        Some(format!(
+                            "Made the column `{column}` on table `{table}` required, but there are {null_value_count} existing NULL values.",
+                            column = column,
+                            table = table,
+                            null_value_count = null_value_count,
+                        ))
+                    },
+                    (_, _) => Some(format!(
+                        "Made the column `{column}` on table `{table}` required. The migration will fail if there are existing NULL values in that column.",
+                        column = column,
+                        table = table
+                    )),
+                }
+            }
             // TODO
             //
             // SqlUnexecutableMigration::AddedUnimplementableUniqueConstraint { table, constrained_columns } => write!(f, "Added a unique constraint that would not hold given existing data on `{table}`.{constrained_columns:?}", table = table, constrained_columns = constrained_columns)?,
@@ -45,11 +96,10 @@ impl std::fmt::Display for SqlUnexecutableMigration {
             // }
             // SqlUnexecutableMigration::PrimaryKeyChanged { table } => write!(
             //     f,
-            //     "The id field(s) for table {table} changed. This is currently not supported by prisma.",
+            //     "The id field(s) for table {table} changed. This is currently not supported by prisma
+            //     migrate.",
             //     table = table
             // )?,
         }
-
-        Ok(())
     }
 }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/warning_check.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/warning_check.rs
@@ -9,7 +9,7 @@ pub(super) enum SqlMigrationWarning {
 }
 
 impl Check for SqlMigrationWarning {
-    fn check_row_count(&self) -> Option<&str> {
+    fn needed_table_row_count(&self) -> Option<&str> {
         match self {
             SqlMigrationWarning::NonEmptyTableDrop { table } => Some(table),
             SqlMigrationWarning::NonEmptyColumnDrop { .. }
@@ -18,7 +18,7 @@ impl Check for SqlMigrationWarning {
         }
     }
 
-    fn check_existing_values(&self) -> Option<(&str, &str)> {
+    fn needed_column_value_count(&self) -> Option<(&str, &str)> {
         match self {
             SqlMigrationWarning::NonEmptyColumnDrop { table, column }
             | SqlMigrationWarning::AlterColumn { table, column } => Some((table, column)),
@@ -27,20 +27,20 @@ impl Check for SqlMigrationWarning {
         }
     }
 
-    fn render(&self, database_check_results: &DatabaseInspectionResults) -> Option<String> {
+    fn evaluate(&self, database_check_results: &DatabaseInspectionResults) -> Option<String> {
         match self {
             SqlMigrationWarning::NonEmptyTableDrop { table } => match database_check_results.get_row_count(table) {
                 Some(0) => None, // dropping the table is safe if it's empty
                 Some(rows_count) => Some(format!("You are about to drop the `{table_name}` table, which is not empty ({rows_count} rows).", table_name = table, rows_count = rows_count)),
                 None => Some(format!("You are about to drop the `{}` table. If the table is not empty, all the data it contains will be lost.", table)),
             },
-            SqlMigrationWarning::NonEmptyColumnDrop { table, column } => match database_check_results.get_value_count(table, column) {
+            SqlMigrationWarning::NonEmptyColumnDrop { table, column } => match database_check_results.get_row_and_non_null_value_count(table, column) {
                 (Some(0), _) => None, // it's safe to drop a column on an empty table
                 (_, Some(0)) => None, // it's safe to drop a column if it only contains null values
                 (_, Some(value_count)) => Some(format!("You are about to drop the column `{column_name}` on the `{table_name}` table, which still contains {value_count} non-null values.", column_name = column, table_name = table, value_count = value_count)),
                 (_, _) => Some(format!("You are about to drop the column `{column_name}` on the `{table_name}` table. All the data in the column will be lost.", column_name = column, table_name = table)),
             },
-            SqlMigrationWarning::AlterColumn { table, column } => match database_check_results.get_value_count(table, column) {
+            SqlMigrationWarning::AlterColumn { table, column } => match database_check_results.get_row_and_non_null_value_count(table, column) {
                 (Some(0), _) => None, // it's safe to alter a column on an empty table
                 (_, Some(0)) => None, // it's safe to alter a column if it only contains null values
                 (_, Some(value_count)) => Some(format!("You are about to alter the column `{column_name}` on the `{table_name}` table, which still contains {value_count} non-null values. The data in that column will be lost.", column_name = column, table_name = table, value_count = value_count)),

--- a/migration-engine/connectors/sql-migration-connector/src/sql_migration/expanded_alter_column.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_migration/expanded_alter_column.rs
@@ -21,11 +21,11 @@ pub(crate) fn expand_alter_column(
     }
 }
 
-pub(crate) fn expand_sqlite_alter_column(_columns: &ColumnDiffer) -> Option<Vec<SqliteAlterColumn>> {
+pub(crate) fn expand_sqlite_alter_column(_columns: &ColumnDiffer<'_>) -> Option<Vec<SqliteAlterColumn>> {
     None
 }
 
-pub(crate) fn expand_mysql_alter_column(columns: &ColumnDiffer) -> Option<Vec<MysqlAlterColumn>> {
+pub(crate) fn expand_mysql_alter_column(columns: &ColumnDiffer<'_>) -> Option<Vec<MysqlAlterColumn>> {
     let mut changes: Vec<MysqlAlterColumn> = Vec::new();
 
     for change in columns.all_changes().iter() {
@@ -41,7 +41,7 @@ pub(crate) fn expand_mysql_alter_column(columns: &ColumnDiffer) -> Option<Vec<My
     Some(changes)
 }
 
-pub(crate) fn expand_postgres_alter_column(columns: &ColumnDiffer) -> Option<Vec<PostgresAlterColumn>> {
+pub(crate) fn expand_postgres_alter_column(columns: &ColumnDiffer<'_>) -> Option<Vec<PostgresAlterColumn>> {
     let mut changes = Vec::new();
 
     for change in columns.all_changes().iter() {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_migration_persistence.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_migration_persistence.rs
@@ -193,7 +193,7 @@ fn migration_table_setup(
 }
 
 impl<'a> SqlMigrationPersistence<'a> {
-    fn table(&self) -> Table {
+    fn table(&self) -> Table<'_> {
         match self.sql_family() {
             SqlFamily::Sqlite => {
                 // sqlite case. Otherwise quaint produces invalid SQL
@@ -203,7 +203,7 @@ impl<'a> SqlMigrationPersistence<'a> {
         }
     }
 
-    fn convert_datetime(&self, datetime: DateTime<Utc>) -> Value {
+    fn convert_datetime(&self, datetime: DateTime<Utc>) -> Value<'_> {
         match self.sql_family() {
             SqlFamily::Sqlite => Value::Integer(datetime.timestamp_millis()),
             SqlFamily::Postgres => Value::DateTime(datetime),
@@ -212,7 +212,7 @@ impl<'a> SqlMigrationPersistence<'a> {
     }
 }
 
-fn convert_parameterized_date_value(db_value: &Value) -> DateTime<Utc> {
+fn convert_parameterized_date_value(db_value: &Value<'_>) -> DateTime<Utc> {
     match db_value {
         Value::Integer(x) => timestamp_to_datetime(*x),
         Value::DateTime(x) => x.clone(),

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
@@ -140,7 +140,7 @@ impl<'a> SqlSchemaCalculator<'a> {
             });
 
             let multiple_field_indexes = model.indexes().map(|index_definition: &IndexDefinition| {
-                let referenced_fields: Vec<FieldRef> = index_definition
+                let referenced_fields: Vec<FieldRef<'_>> = index_definition
                     .fields
                     .iter()
                     .map(|field_name| model.find_field(field_name).expect("Unknown field in index directive."))
@@ -412,7 +412,7 @@ fn add_one_to_one_relation_unique_index(table: &mut sql::Table, column_names: &[
 }
 
 /// This should match the logic in `prisma_models::Model::primary_identifier`.
-fn first_unique_criterion(model: ModelRef<'_>) -> anyhow::Result<Vec<FieldRef>> {
+fn first_unique_criterion(model: ModelRef<'_>) -> anyhow::Result<Vec<FieldRef<'_>>> {
     // First candidate: the primary key.
     {
         let id_fields: Vec<_> = model.id_fields().collect();

--- a/migration-engine/core/src/api.rs
+++ b/migration-engine/core/src/api.rs
@@ -73,7 +73,7 @@ where
     D: DatabaseMigrationMarker + Send + Sync + 'static,
 {
     async fn apply_migration(&self, input: &ApplyMigrationInput) -> CoreResult<MigrationStepsResultOutput> {
-        self.handle_command::<ApplyMigrationCommand>(input)
+        self.handle_command::<ApplyMigrationCommand<'_>>(input)
             .instrument(tracing::info_span!(
                 "ApplyMigration",
                 migration_id = input.migration_id.as_str()
@@ -85,19 +85,19 @@ where
         &self,
         input: &CalculateDatabaseStepsInput,
     ) -> CoreResult<MigrationStepsResultOutput> {
-        self.handle_command::<CalculateDatabaseStepsCommand>(input)
+        self.handle_command::<CalculateDatabaseStepsCommand<'_>>(input)
             .instrument(tracing::info_span!("CalculateDatabaseSteps"))
             .await
     }
 
     async fn calculate_datamodel(&self, input: &CalculateDatamodelInput) -> CoreResult<CalculateDatamodelOutput> {
-        self.handle_command::<CalculateDatamodelCommand>(input)
+        self.handle_command::<CalculateDatamodelCommand<'_>>(input)
             .instrument(tracing::info_span!("CalculateDatamodel"))
             .await
     }
 
     async fn infer_migration_steps(&self, input: &InferMigrationStepsInput) -> CoreResult<MigrationStepsResultOutput> {
-        self.handle_command::<InferMigrationStepsCommand>(input)
+        self.handle_command::<InferMigrationStepsCommand<'_>>(input)
             .instrument(tracing::info_span!(
                 "InferMigrationSteps",
                 migration_id = input.migration_id.as_str()
@@ -112,7 +112,7 @@ where
     }
 
     async fn migration_progress(&self, input: &MigrationProgressInput) -> CoreResult<MigrationProgressOutput> {
-        self.handle_command::<MigrationProgressCommand>(input)
+        self.handle_command::<MigrationProgressCommand<'_>>(input)
             .instrument(tracing::info_span!(
                 "MigrationProgress",
                 migration_id = input.migration_id.as_str()
@@ -127,7 +127,7 @@ where
     }
 
     async fn unapply_migration(&self, input: &UnapplyMigrationInput) -> CoreResult<UnapplyMigrationOutput> {
-        self.handle_command::<UnapplyMigrationCommand>(input)
+        self.handle_command::<UnapplyMigrationCommand<'_>>(input)
             .instrument(tracing::info_span!("UnapplyMigration"))
             .await
     }

--- a/migration-engine/core/src/lib.rs
+++ b/migration-engine/core/src/lib.rs
@@ -1,4 +1,4 @@
-//! This library API is meant for the `test-cli` binary and migration-engine-tests only.
+#![deny(rust_2018_idioms)]
 
 pub mod api;
 pub mod commands;

--- a/migration-engine/core/src/migration/datamodel_differ/fields.rs
+++ b/migration-engine/core/src/migration/datamodel_differ/fields.rs
@@ -27,7 +27,7 @@ impl<'a> FieldDiffer<'a> {
         })
     }
 
-    pub(crate) fn directive_pairs(&self) -> impl Iterator<Item = DirectiveDiffer> {
+    pub(crate) fn directive_pairs(&self) -> impl Iterator<Item = DirectiveDiffer<'_>> {
         self.previous_directives().filter_map(move |previous_directive| {
             self.next_directives()
                 .find(|next_directive| directives_match(previous_directive, next_directive))

--- a/migration-engine/migration-engine-tests/src/lib.rs
+++ b/migration-engine/migration-engine-tests/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(rust_2018_idioms)]
+
 mod assertions;
 mod command_helpers;
 mod misc_helpers;

--- a/migration-engine/migration-engine-tests/src/sql/multi_user.rs
+++ b/migration-engine/migration-engine-tests/src/sql/multi_user.rs
@@ -305,7 +305,7 @@ pub struct Save<'a> {
 }
 
 impl<'a> Save<'a> {
-    fn new(user: &'a User, migration_name: &'static str) -> Self {
+    fn new(user: &'a User<'_>, migration_name: &'static str) -> Self {
         Save { user, migration_name }
     }
 
@@ -360,7 +360,7 @@ pub struct Up<'a> {
 }
 
 impl<'a> Up<'a> {
-    fn new(user: &'a User) -> Self {
+    fn new(user: &'a User<'_>) -> Self {
         Up { user }
     }
 

--- a/migration-engine/migration-engine-tests/src/sql/multi_user/git_repo.rs
+++ b/migration-engine/migration-engine-tests/src/sql/multi_user/git_repo.rs
@@ -13,7 +13,7 @@ impl GitRepo {
     }
 
     /// Returns whether we can merge the other user.
-    pub(crate) fn prepare_merge(&self, other: &GitRepo) -> anyhow::Result<(git2::Commit, git2::Index)> {
+    pub(crate) fn prepare_merge(&self, other: &GitRepo) -> anyhow::Result<(git2::Commit<'_>, git2::Index)> {
         let mut remote = self.remote(&other.name, other.root_dir.as_os_str().to_str().unwrap())?;
         let mut fo = git2::FetchOptions::new();
         remote.fetch(&["master"], Some(&mut fo), Some("Test suite fetch"))?;
@@ -31,18 +31,18 @@ impl GitRepo {
         Ok((last_commit, index))
     }
 
-    fn remote(&self, name: &str, url: &str) -> anyhow::Result<git2::Remote> {
+    fn remote(&self, name: &str, url: &str) -> anyhow::Result<git2::Remote<'_>> {
         self.repo
             .find_remote(name)
             .or_else(|_err| self.repo.remote(name, url))
             .map_err(Into::into)
     }
 
-    fn git_commit_author(&self) -> anyhow::Result<git2::Signature> {
+    fn git_commit_author(&self) -> anyhow::Result<git2::Signature<'_>> {
         Ok(git2::Signature::now(self.name, self.name)?)
     }
 
-    fn find_last_commit(&self) -> Option<git2::Commit> {
+    fn find_last_commit(&self) -> Option<git2::Commit<'_>> {
         self.repo.head().and_then(|r| r.peel_to_commit()).ok()
     }
 
@@ -54,7 +54,7 @@ impl GitRepo {
         let tree = self.repo.find_object(oid, None)?;
 
         let last_commit = self.find_last_commit();
-        let commit_parents: Vec<&git2::Commit> = if let Some(commit) = last_commit.as_ref() {
+        let commit_parents: Vec<&git2::Commit<'_>> = if let Some(commit) = last_commit.as_ref() {
             vec![commit]
         } else {
             Vec::new()

--- a/migration-engine/migration-engine-tests/src/test_api.rs
+++ b/migration-engine/migration-engine-tests/src/test_api.rs
@@ -138,7 +138,7 @@ impl TestApi {
         }
     }
 
-    pub fn barrel(&self) -> BarrelMigrationExecutor {
+    pub fn barrel(&self) -> BarrelMigrationExecutor<'_> {
         BarrelMigrationExecutor {
             api: self,
             sql_variant: match self.sql_family() {
@@ -196,7 +196,7 @@ impl TestApi {
         }
     }
 
-    pub fn select<'a>(&'a self, table_name: &'a str) -> TestApiSelect {
+    pub fn select<'a>(&'a self, table_name: &'a str) -> TestApiSelect<'_> {
         TestApiSelect {
             select: quaint::ast::Select::from_table(self.render_table_name(table_name)),
             api: self,

--- a/migration-engine/migration-engine-tests/tests/existing_data/sql_unexecutable_migrations/added_required_field_to_table.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_data/sql_unexecutable_migrations/added_required_field_to_table.rs
@@ -31,7 +31,7 @@ async fn adding_a_required_field_to_an_existing_table_with_data_without_a_defaul
         .force(Some(false))
         .send()
         .await?
-        .assert_unexecutable(&[format!("Added the required column `age` to the `Test` table without a default value. There are Some(1) rows in this table, it is not possible.")])?;
+        .assert_unexecutable(&[format!("Added the required column `age` to the `Test` table without a default value. There are 1 rows in this table, it is not possible to execute this migration.")])?;
 
     let rows = api.select("Test").column("id").column("name").send_debug().await?;
     assert_eq!(rows, &[&[r#"Text("abc")"#, r#"Text("george")"#]]);

--- a/migration-engine/migration-engine-tests/tests/existing_data/sql_unexecutable_migrations/made_optional_field_required.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_data/sql_unexecutable_migrations/made_optional_field_required.rs
@@ -27,7 +27,7 @@ async fn making_an_optional_field_required_with_data_without_a_default_is_unexec
     "#;
 
     api.infer_apply(&dm2).send().await?.assert_unexecutable(&[
-        "Made the column `age` on table `Test` required, but there are existing NULL values.".into(),
+        "Made the column `age` on table `Test` required, but there are 1 existing NULL values.".into(),
     ])?;
 
     api.assert_schema()

--- a/migration-engine/migration-engine-tests/tests/existing_data_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_data_tests.rs
@@ -7,7 +7,7 @@ use prisma_value::PrismaValue;
 use quaint::ast::*;
 use std::borrow::Cow;
 
-#[test_each_connector]
+#[test_each_connector(log = "debug,sql_schema_describer=info")]
 async fn dropping_a_table_with_rows_should_warn(api: &TestApi) {
     let dm = r#"
         model Test {
@@ -35,7 +35,7 @@ async fn dropping_a_table_with_rows_should_warn(api: &TestApi) {
     assert_eq!(
         migration_output.warnings,
         &[MigrationWarning {
-            description: "You are about to drop the table `Test`, which is not empty (1 rows).".into()
+            description: "You are about to drop the `Test` table, which is not empty (1 rows).".into()
         }]
     );
 }


### PR DESCRIPTION
The purpose of this commit is to separate pure checks (what steps in the
migration _could_ cause problems) from IO. This serves multiple
purposes:

- It makes it easier to reuse the results of previous checks, e.g. to
avoid checking multiple times that there are non-null values in some
column.
- It makes it easier to provide alternative warnings when the database
we want to migrate is not accessible, or the checks time out. (e.g.
"This migration can be destructive if there are non-null values in such
and such column"). In other terms, we can do destructive change checks
without IO.
- It makes the code clearer, because checks have to be explicit about
what information they need about the current state of the database.
- It is a better default: the checks do not rely on information fetched
from the database at the last moment, they just use it to refine their
warnings or be more optimistic (e.g. it's safe to drop a table if it is
empty).

See the diff for a more in-depth explanation in doc comments.

Note: there is pretty good test coverage for destructive change checks, so I am reasonably confident that this did not break existing behaviour.