### PR TITLE
Add debug mode to server

### DIFF
--- a/query-engine/core/src/query_graph_builder/write/nested/connect_or_create_nested.rs
+++ b/query-engine/core/src/query_graph_builder/write/nested/connect_or_create_nested.rs
@@ -1,9 +1,8 @@
 use super::*;
-use crate::query_graph_builder::write::utils::coerce_vec;
 use crate::{
     query_ast::*,
     query_graph::{Flow, Node, NodeRef, QueryGraph, QueryGraphDependency},
-    InputAssertions, ParsedInputMap, ParsedInputValue,
+    ParsedInputMap, ParsedInputValue,
 };
 use connector::{Filter, IdFilter};
 use prisma_models::{ModelRef, RelationFieldRef};
@@ -609,9 +608,7 @@ fn one_to_one_inlined_parent(
     } else {
         // Perform checks that no existing child in a required relation is violated.
         graph.create_edge(&if_node, &parent_node, QueryGraphDependency::ExecutionOrder)?;
-
-        let read_ex_child_node =
-            utils::insert_existing_1to1_related_model_checks(graph, &parent_node, &parent_relation_field)?;
+        utils::insert_existing_1to1_related_model_checks(graph, &parent_node, &parent_relation_field)?;
 
         let parent_model = parent_relation_field.model();
         let update_parent_node = utils::update_records_node_placeholder(graph, Filter::empty(), parent_model.clone());

--- a/query-engine/query-engine/src/main.rs
+++ b/query-engine/query-engine/src/main.rs
@@ -70,7 +70,8 @@ async fn main() -> Result<(), AnyError> {
                     HttpServer::builder(config, datamodel)
                         .legacy(opts.legacy)
                         .enable_raw_queries(opts.enable_raw_queries)
-                        .enable_playground(opts.enable_playground),
+                        .enable_playground(opts.enable_playground)
+                        .enable_debug_mode(opts.enable_debug_mode),
                 )
             };
 

--- a/query-engine/query-engine/src/opt.rs
+++ b/query-engine/query-engine/src/opt.rs
@@ -48,27 +48,39 @@ pub struct PrismaOpt {
     /// The hostname or IP the query engine should bind to.
     #[structopt(long, short = "H", default_value = "127.0.0.1")]
     pub host: String,
+
     /// The port the query engine should bind to.
     #[structopt(long, short, env, default_value = "4466")]
     pub port: u16,
+
     /// Path to the Prisma datamodel file
     #[structopt(long, env = "PRISMA_DML_PATH", parse(from_os_str = load_datamodel_file))]
     datamodel_path: Option<String>,
+
     /// Base64 encoded Prisma datamodel
     #[structopt(long, env = "PRISMA_DML", parse(try_from_str = parse_base64_string))]
     datamodel: Option<String>,
+
     /// Base64 encoded datasources, overwriting the ones in the datamodel
     #[structopt(long, env, parse(try_from_str = parse_base64_string))]
     overwrite_datasources: Option<String>,
+
     /// Switches query schema generation to Prisma 1 compatible mode.
     #[structopt(long, short)]
     pub legacy: bool,
+
     /// Enables raw SQL queries with executeRaw/queryRaw mutation
     #[structopt(long, short = "r")]
     pub enable_raw_queries: bool,
+
     /// Enables the GraphQL playground
     #[structopt(long, short = "g")]
     pub enable_playground: bool,
+
+    /// Enables server debug features.
+    #[structopt(long = "debug", short = "d")]
+    pub enable_debug_mode: bool,
+
     #[structopt(subcommand)]
     pub subcommand: Option<Subcommand>,
 }


### PR DESCRIPTION
Adds `--debug` flag to query engine (QE) binary, which enables debug mode features.
For now, enabling debug enables two specific headers to be send to the QE `POST /` route:

- Sending a `X-DEBUG-NON-FATAL` header will simulate a panic in the request, returning a 200 OK with `{"is_panic":true,"message":"Debug panic","backtrace":null}`.
- Sending a `X-DEBUG-FATAL` header will terminate the QE immediately, the connection will abort. This simulates a fatal error in the QE.

