### PR TITLE
Change Query Graph child retrieval rules

### DIFF
--- a/datamodel_v2.prisma
+++ b/datamodel_v2.prisma
@@ -1,110 +1,71 @@
 datasource chinook {
   provider = "sqlite"
-  url      = "file:./db/Chinook.db"
+  url      = "file:./db/686.db"
 }
 
-model Album {
-  id       Int     @id @map("AlbumId")
-  Title    String  @default("TestDefaultTitle")
-  ArtistId Int
-  Tracks   Track[]
-  Artist   Artist  @relation(fields: [ArtistId], references: [id])
+model Dish {
+  id            String @default(cuid()) @id
+  name          String
+  calories      Float?
+  proteins      Float?
+  fats          Float?
+  carbohydrates Float?
+  meals         Meal[] @relation(references: [id])
 }
 
-model Track {
-  id           Int           @id @map("TrackId")
-  Name         String
-  Composer     String?
-  Milliseconds Int
-  UnitPrice    Float
-  AlbumId      Int?
-  GenreId      Int?
-  MediaTypeId  Int
-  MediaType    MediaType     @relation(fields: [MediaTypeId], references: [id])
-  Genre        Genre?        @relation(fields: [GenreId], references: [id])
-  Album        Album?        @relation(fields: [AlbumId], references: [id])
-  InvoiceLines InvoiceLine[]
+model Meal {
+  id                   String    @default(cuid()) @id
+  dishes               Dish[]    @relation(references: [id])
+  breakfasts           DayMenu[] @relation("breakfast")
+  snacksAfterBreakfast DayMenu[] @relation("snacksAfterBreakfast")
+  dinners              DayMenu[] @relation("dinner")
+  snacksBeforeSupper   DayMenu[] @relation("snackBeforeSupper")
+  suppers              DayMenu[] @relation("supper")
 }
 
-model MediaType {
-  id    Int     @id @map("MediaTypeId")
-  Name  String?
-  Track Track[]
+model DayMenu {
+  id                    String     @default(cuid()) @id
+  breakfast             Meal       @relation("breakfast", fields: [breakfastId], references: [id])
+  snackAfterBreakfast   Meal       @relation("snacksAfterBreakfast", fields: [snackAfterBreakfastId], references: [id])
+  dinner                Meal       @relation("dinner", fields: [dinnerId], references: [id])
+  snackBeforeSupper     Meal       @relation("snackBeforeSupper", fields: [snackBeforeSupperId], references: [id])
+  supper                Meal       @relation("supper", fields: [supperId], references: [id])
+  breakfastId           String
+  snackAfterBreakfastId String
+  dinnerId              String
+  snackBeforeSupperId   String
+  supperId              String
+  mondays               WeekMenu[] @relation("monday")
+  tuesdays              WeekMenu[] @relation("tuesday")
+  wednesdays            WeekMenu[] @relation("wednesday")
+  thursdays             WeekMenu[] @relation("thursday")
+  fridays               WeekMenu[] @relation("friday")
+  saturdays             WeekMenu[] @relation("saturday")
+  sundays               WeekMenu[] @relation("sunday")
 }
 
-model Genre {
-  id     Int     @id @map("GenreId")
-  Name   String?
-  Tracks Track[]
+model WeekMenu {
+  id            String                 @default(cuid()) @id
+  monday        DayMenu                @relation("monday", fields: [mondayId], references: [id])
+  tuesday       DayMenu                @relation("tuesday", fields: [tuesdayId], references: [id])
+  wednesday     DayMenu                @relation("wednesday", fields: [wednesdayId], references: [id])
+  thursday      DayMenu                @relation("thursday", fields: [thursdayId], references: [id])
+  friday        DayMenu                @relation("friday", fields: [fridayId], references: [id])
+  saturday      DayMenu                @relation("saturday", fields: [saturdayId], references: [id])
+  sunday        DayMenu                @relation("sunday", fields: [sundayId], references: [id])
+  mondayId      String
+  tuesdayId     String
+  wednesdayId   String
+  thursdayId    String
+  fridayId      String
+  saturdayId    String
+  sundayId      String
+  timelineItems WeekMenuTimelineItem[]
 }
 
-model Artist {
-  id     Int     @id @map("ArtistId")
-  Name   String?
-  Albums Album[]
-}
-
-model Customer {
-  id           Int       @id @map("CustomerId")
-  FirstName    String
-  LastName     String
-  Company      String?
-  Address      String?
-  City         String?
-  State        String?
-  Country      String?
-  PostalCode   String?
-  Phone        String?
-  Fax          String?
-  Email        String
-  SupportRepId Int?
-  SupportRep   Employee? @relation(fields: [SupportRepId], references: [id])
-  Invoices     Invoice[]
-}
-
-model Employee {
-  id         Int        @id @map("EmployeeId")
-  FirstName  String
-  LastName   String
-  Title      String?
-  BirthDate  DateTime?
-  HireDate   DateTime?
-  Address    String?
-  City       String?
-  State      String?
-  Country    String?
-  PostalCode String?
-  Phone      String?
-  Fax        String?
-  Email      String?
-  Customers  Customer[]
-}
-
-model Invoice {
-  id                Int           @id @map("InvoiceId")
-  InvoiceDate       DateTime
-  BillingAddress    String?
-  BillingCity       String?
-  BillingState      String?
-  BillingCountry    String?
-  BillingPostalCode String?
-  Total             Float
-  CustomerId        Int
-  Customer          Customer      @relation(fields: [CustomerId], references: [id])
-  Lines             InvoiceLine[]
-}
-
-model InvoiceLine {
-  id        Int     @id @map("InvoiceLineId")
-  UnitPrice Float
-  Quantity  Int
-  InvoiceId Int
-  TrackId   Int
-  Invoice   Invoice @relation(fields: [InvoiceId], references: [id])
-  Track     Track   @relation(fields: [TrackId], references: [id])
-}
-
-model Playlist {
-  id   Int     @id @map("PlaylistId")
-  Name String?
+model WeekMenuTimelineItem {
+  id         String   @default(cuid()) @id
+  date       DateTime
+  weekMenu   WeekMenu @relation(fields: [weekMenuId], references: [id])
+  weekMenuId String
 }

--- a/datamodel_v2.prisma
+++ b/datamodel_v2.prisma
@@ -1,71 +1,110 @@
 datasource chinook {
   provider = "sqlite"
-  url      = "file:./db/686.db"
+  url      = "file:./db/Chinook.db"
 }
 
-model Dish {
-  id            String @default(cuid()) @id
-  name          String
-  calories      Float?
-  proteins      Float?
-  fats          Float?
-  carbohydrates Float?
-  meals         Meal[] @relation(references: [id])
+model Album {
+  id       Int     @id @map("AlbumId")
+  Title    String  @default("TestDefaultTitle")
+  ArtistId Int
+  Tracks   Track[]
+  Artist   Artist  @relation(fields: [ArtistId], references: [id])
 }
 
-model Meal {
-  id                   String    @default(cuid()) @id
-  dishes               Dish[]    @relation(references: [id])
-  breakfasts           DayMenu[] @relation("breakfast")
-  snacksAfterBreakfast DayMenu[] @relation("snacksAfterBreakfast")
-  dinners              DayMenu[] @relation("dinner")
-  snacksBeforeSupper   DayMenu[] @relation("snackBeforeSupper")
-  suppers              DayMenu[] @relation("supper")
+model Track {
+  id           Int           @id @map("TrackId")
+  Name         String
+  Composer     String?
+  Milliseconds Int
+  UnitPrice    Float
+  AlbumId      Int?
+  GenreId      Int?
+  MediaTypeId  Int
+  MediaType    MediaType     @relation(fields: [MediaTypeId], references: [id])
+  Genre        Genre?        @relation(fields: [GenreId], references: [id])
+  Album        Album?        @relation(fields: [AlbumId], references: [id])
+  InvoiceLines InvoiceLine[]
 }
 
-model DayMenu {
-  id                    String     @default(cuid()) @id
-  breakfast             Meal       @relation("breakfast", fields: [breakfastId], references: [id])
-  snackAfterBreakfast   Meal       @relation("snacksAfterBreakfast", fields: [snackAfterBreakfastId], references: [id])
-  dinner                Meal       @relation("dinner", fields: [dinnerId], references: [id])
-  snackBeforeSupper     Meal       @relation("snackBeforeSupper", fields: [snackBeforeSupperId], references: [id])
-  supper                Meal       @relation("supper", fields: [supperId], references: [id])
-  breakfastId           String
-  snackAfterBreakfastId String
-  dinnerId              String
-  snackBeforeSupperId   String
-  supperId              String
-  mondays               WeekMenu[] @relation("monday")
-  tuesdays              WeekMenu[] @relation("tuesday")
-  wednesdays            WeekMenu[] @relation("wednesday")
-  thursdays             WeekMenu[] @relation("thursday")
-  fridays               WeekMenu[] @relation("friday")
-  saturdays             WeekMenu[] @relation("saturday")
-  sundays               WeekMenu[] @relation("sunday")
+model MediaType {
+  id    Int     @id @map("MediaTypeId")
+  Name  String?
+  Track Track[]
 }
 
-model WeekMenu {
-  id            String                 @default(cuid()) @id
-  monday        DayMenu                @relation("monday", fields: [mondayId], references: [id])
-  tuesday       DayMenu                @relation("tuesday", fields: [tuesdayId], references: [id])
-  wednesday     DayMenu                @relation("wednesday", fields: [wednesdayId], references: [id])
-  thursday      DayMenu                @relation("thursday", fields: [thursdayId], references: [id])
-  friday        DayMenu                @relation("friday", fields: [fridayId], references: [id])
-  saturday      DayMenu                @relation("saturday", fields: [saturdayId], references: [id])
-  sunday        DayMenu                @relation("sunday", fields: [sundayId], references: [id])
-  mondayId      String
-  tuesdayId     String
-  wednesdayId   String
-  thursdayId    String
-  fridayId      String
-  saturdayId    String
-  sundayId      String
-  timelineItems WeekMenuTimelineItem[]
+model Genre {
+  id     Int     @id @map("GenreId")
+  Name   String?
+  Tracks Track[]
 }
 
-model WeekMenuTimelineItem {
-  id         String   @default(cuid()) @id
-  date       DateTime
-  weekMenu   WeekMenu @relation(fields: [weekMenuId], references: [id])
-  weekMenuId String
+model Artist {
+  id     Int     @id @map("ArtistId")
+  Name   String?
+  Albums Album[]
+}
+
+model Customer {
+  id           Int       @id @map("CustomerId")
+  FirstName    String
+  LastName     String
+  Company      String?
+  Address      String?
+  City         String?
+  State        String?
+  Country      String?
+  PostalCode   String?
+  Phone        String?
+  Fax          String?
+  Email        String
+  SupportRepId Int?
+  SupportRep   Employee? @relation(fields: [SupportRepId], references: [id])
+  Invoices     Invoice[]
+}
+
+model Employee {
+  id         Int        @id @map("EmployeeId")
+  FirstName  String
+  LastName   String
+  Title      String?
+  BirthDate  DateTime?
+  HireDate   DateTime?
+  Address    String?
+  City       String?
+  State      String?
+  Country    String?
+  PostalCode String?
+  Phone      String?
+  Fax        String?
+  Email      String?
+  Customers  Customer[]
+}
+
+model Invoice {
+  id                Int           @id @map("InvoiceId")
+  InvoiceDate       DateTime
+  BillingAddress    String?
+  BillingCity       String?
+  BillingState      String?
+  BillingCountry    String?
+  BillingPostalCode String?
+  Total             Float
+  CustomerId        Int
+  Customer          Customer      @relation(fields: [CustomerId], references: [id])
+  Lines             InvoiceLine[]
+}
+
+model InvoiceLine {
+  id        Int     @id @map("InvoiceLineId")
+  UnitPrice Float
+  Quantity  Int
+  InvoiceId Int
+  TrackId   Int
+  Invoice   Invoice @relation(fields: [InvoiceId], references: [id])
+  Track     Track   @relation(fields: [TrackId], references: [id])
+}
+
+model Playlist {
+  id   Int     @id @map("PlaylistId")
+  Name String?
 }

--- a/query-engine/core/src/interpreter/expressionista.rs
+++ b/query-engine/core/src/interpreter/expressionista.rs
@@ -48,9 +48,13 @@ impl Expressionista {
     ) -> InterpretationResult<Expression> {
         graph.mark_visited(&node);
 
+        dbg!("Finding direct children...");
         // Child edges are ordered, evaluation order is low to high in the graph, unless other rules override.
         let direct_children = graph.direct_child_pairs(&node);
+        dbg!(&direct_children);
+
         let mut child_expressions = Self::process_children(graph, direct_children)?;
+        dbg!("Child EXPR build");
 
         let is_result = graph.is_result_node(&node);
         let node_id = node.id();

--- a/query-engine/core/src/query_graph/mod.rs
+++ b/query-engine/core/src/query_graph/mod.rs
@@ -368,19 +368,19 @@ impl QueryGraph {
     ///
     /// Criteria for a direct child (either):
     /// - Every node that only has `parent` as their parent.
-    /// - OR In case of multiple parents, has `parent` as their parent and _all_ other
+    /// - OR in case of multiple parents, has `parent` as their parent and _all_ other
     ///   parents are strict ancestors of `parent`, meaning they are "higher up" in the graph.
     /// - OR All other parents have already been visited before.
     pub fn is_direct_child(&self, parent: &NodeRef, child: &NodeRef) -> bool {
-        let ancestry_rule = self.incoming_edges(child).into_iter().all(|edge| {
-            let other_parent = self.edge_source(&edge);
+        // let ancestry_rule = self.incoming_edges(child).into_iter().all(|edge| {
+        //     let other_parent = self.edge_source(&edge);
 
-            if &other_parent != parent {
-                self.is_ancestor(&other_parent, parent)
-            } else {
-                true
-            }
-        });
+        //     if &other_parent != parent {
+        //         self.is_ancestor(&other_parent, parent)
+        //     } else {
+        //         true
+        //     }
+        // });
 
         let visitation_rule = self.incoming_edges(child).into_iter().all(|edge| {
             let other_parent = self.edge_source(&edge);
@@ -392,7 +392,8 @@ impl QueryGraph {
             }
         });
 
-        ancestry_rule || visitation_rule
+        // ancestry_rule || visitation_rule
+        visitation_rule
     }
 
     /// Returns a list of child nodes, together with their child edge for the given `node`.

--- a/query-engine/core/src/query_graph/mod.rs
+++ b/query-engine/core/src/query_graph/mod.rs
@@ -368,21 +368,9 @@ impl QueryGraph {
     ///
     /// Criteria for a direct child (either):
     /// - Every node that only has `parent` as their parent.
-    /// - OR in case of multiple parents, has `parent` as their parent and _all_ other
-    ///   parents are strict ancestors of `parent`, meaning they are "higher up" in the graph.
-    /// - OR All other parents have already been visited before.
+    /// - In case of multiple parents, _all_ parents have already been visited before.
     pub fn is_direct_child(&self, parent: &NodeRef, child: &NodeRef) -> bool {
-        // let ancestry_rule = self.incoming_edges(child).into_iter().all(|edge| {
-        //     let other_parent = self.edge_source(&edge);
-
-        //     if &other_parent != parent {
-        //         self.is_ancestor(&other_parent, parent)
-        //     } else {
-        //         true
-        //     }
-        // });
-
-        let visitation_rule = self.incoming_edges(child).into_iter().all(|edge| {
+        self.incoming_edges(child).into_iter().all(|edge| {
             let other_parent = self.edge_source(&edge);
 
             if &other_parent != parent {
@@ -390,10 +378,7 @@ impl QueryGraph {
             } else {
                 true
             }
-        });
-
-        // ancestry_rule || visitation_rule
-        visitation_rule
+        })
     }
 
     /// Returns a list of child nodes, together with their child edge for the given `node`.
@@ -434,15 +419,6 @@ impl QueryGraph {
                 (edge, target)
             })
             .collect()
-    }
-
-    /// Checks if `ancestor` is in any of the ancestor nodes of `successor_node`.
-    /// Determined by trying to reach `successor_node` from `ancestor`.
-    pub fn is_ancestor(&self, ancestor: &NodeRef, successor_node: &NodeRef) -> bool {
-        self.child_pairs(ancestor)
-            .into_iter()
-            .find(|(_, child_node)| child_node == successor_node || self.is_ancestor(&child_node, &successor_node))
-            .is_some()
     }
 
     /// Internal utility function to collect all edges of defined direction directed to, or originating from, `node`.


### PR DESCRIPTION
Fixes an issue with infinitely recursing query tree traversals when a large number of differently inlined relations is used in the same graph.