### PR TITLE
Make migration engine resilient to old database migration steps

### DIFF
--- a/introspection-engine/connectors/sql-introspection-connector/tests/db_specific_introspection/identify_version/mod.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/tests/db_specific_introspection/identify_version/mod.rs
@@ -1,7 +1,6 @@
 use crate::*;
 use barrel::types;
-use introspection_connector::Version::NonPrisma;
-use introspection_connector::{IntrospectionConnector, Version};
+use introspection_connector::Version;
 use test_harness::*;
 
 //Sqlite

--- a/libs/user-facing-errors/src/migration_engine.rs
+++ b/libs/user-facing-errors/src/migration_engine.rs
@@ -27,6 +27,7 @@ struct MigrationRollback {
     pub database_error: String,
 }
 
+// No longer used.
 #[derive(Debug, UserFacingError, Serialize)]
 #[user_facing(
     code = "P3003",

--- a/migration-engine/connectors/migration-connector/src/database_migration_step_applier.rs
+++ b/migration-engine/connectors/migration-connector/src/database_migration_step_applier.rs
@@ -1,4 +1,5 @@
 use crate::*;
+use serde::{Deserialize, Serialize};
 
 /// Apply a single migration step to the connector's database. At this level, we are working with database migrations,
 /// i.e. the [associated type on MigrationConnector](trait.MigrationConnector.html#associatedtype.DatabaseMigration).
@@ -13,5 +14,13 @@ pub trait DatabaseMigrationStepApplier<T>: Send + Sync {
     async fn unapply_step(&self, database_migration: &T, step: usize) -> ConnectorResult<bool>;
 
     /// Render steps for the CLI. Each step will contain the raw field.
-    fn render_steps_pretty(&self, database_migration: &T) -> ConnectorResult<Vec<serde_json::Value>>;
+    fn render_steps_pretty(&self, database_migration: &T) -> ConnectorResult<Vec<PrettyDatabaseMigrationStep>>;
+}
+
+/// A helper struct to serialize a database migration with an additional `raw` field containing the
+/// rendered query string for that step.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct PrettyDatabaseMigrationStep {
+    pub step: serde_json::Value,
+    pub raw: String,
 }

--- a/migration-engine/connectors/migration-connector/src/lib.rs
+++ b/migration-engine/connectors/migration-connector/src/lib.rs
@@ -20,7 +20,6 @@ pub use migration_persistence::*;
 pub use steps::MigrationStep;
 
 use std::fmt::Debug;
-use user_facing_errors::migration_engine::DatabaseMigrationFormatChanged;
 
 /// The top-level trait for connectors. This is the abstraction the migration engine core relies on to
 /// interface with different database backends.
@@ -70,10 +69,7 @@ pub trait MigrationConnector: Send + Sync + 'static {
 
     // TODO: figure out if this is the best way to do this or move to a better place/interface
     // this is placed here so i can use the associated type
-    fn deserialize_database_migration(
-        &self,
-        json: serde_json::Value,
-    ) -> Result<Self::DatabaseMigration, DatabaseMigrationFormatChanged>;
+    fn deserialize_database_migration(&self, json: serde_json::Value) -> Option<Self::DatabaseMigration>;
 
     /// See [MigrationStepApplier](trait.MigrationStepApplier.html).
     fn migration_applier<'a>(&'a self) -> Box<dyn MigrationApplier<Self::DatabaseMigration> + Send + Sync + 'a> {

--- a/migration-engine/connectors/migration-connector/src/migration_applier.rs
+++ b/migration-engine/connectors/migration-connector/src/migration_applier.rs
@@ -95,7 +95,7 @@ where
         database_migration: &T,
     ) -> ConnectorResult<()> {
         let mut step = 0;
-        while self.step_applier.unapply_step(&database_migration, step).await? {
+        while self.step_applier.apply_step(&database_migration, step).await? {
             step += 1;
             migration_updates.rolled_back += 1;
             self.migration_persistence.update(&migration_updates).await?;

--- a/migration-engine/connectors/migration-connector/src/migration_persistence.rs
+++ b/migration-engine/connectors/migration-connector/src/migration_persistence.rs
@@ -137,24 +137,6 @@ impl Migration {
         }
     }
 
-    /// This is only useful for tests. Use `Migration::new()` if you want to initialize a valid
-    /// migration.
-    pub fn empty(name: String) -> Migration {
-        Migration {
-            name,
-            revision: 0,
-            status: MigrationStatus::Pending,
-            datamodel_string: String::new(),
-            datamodel_steps: Vec::new(),
-            applied: 0,
-            rolled_back: 0,
-            database_migration: serde_json::json!({}),
-            errors: Vec::new(),
-            started_at: Self::timestamp_without_nanos(),
-            finished_at: None,
-        }
-    }
-
     pub fn update_params(&self) -> MigrationUpdateParams {
         MigrationUpdateParams {
             name: self.name.clone(),

--- a/migration-engine/connectors/migration-connector/src/migration_persistence.rs
+++ b/migration-engine/connectors/migration-connector/src/migration_persistence.rs
@@ -1,4 +1,4 @@
-use crate::{error::ConnectorError, steps::*};
+use crate::{error::ConnectorError, steps::*, ConnectorResult};
 use chrono::{DateTime, Utc};
 use datamodel::{ast::SchemaAst, error::ErrorCollection, Datamodel};
 use serde::Serialize;
@@ -31,6 +31,10 @@ pub trait MigrationPersistence: Send + Sync {
 
     /// Returns the last successful Migration.
     async fn last(&self) -> Result<Option<Migration>, ConnectorError>;
+
+    /// Returns the last two successful migrations, for rollback purposes. The tuple will be
+    /// interpreted as (last_migration, second_to_last_migration).
+    async fn last_two_migrations(&self) -> ConnectorResult<(Option<Migration>, Option<Migration>)>;
 
     /// Fetch a migration by name.
     async fn by_name(&self, name: &str) -> Result<Option<Migration>, ConnectorError>;
@@ -256,6 +260,10 @@ impl MigrationPersistence for EmptyMigrationPersistence {
 
     async fn last(&self) -> Result<Option<Migration>, ConnectorError> {
         Ok(None)
+    }
+
+    async fn last_two_migrations(&self) -> ConnectorResult<(Option<Migration>, Option<Migration>)> {
+        Ok((None, None))
     }
 
     async fn by_name(&self, _name: &str) -> Result<Option<Migration>, ConnectorError> {

--- a/migration-engine/connectors/migration-connector/src/migration_persistence.rs
+++ b/migration-engine/connectors/migration-connector/src/migration_persistence.rs
@@ -30,7 +30,9 @@ pub trait MigrationPersistence: Send + Sync {
     }
 
     /// Returns the last successful Migration.
-    async fn last(&self) -> Result<Option<Migration>, ConnectorError>;
+    async fn last(&self) -> Result<Option<Migration>, ConnectorError> {
+        Ok(self.last_two_migrations().await?.0)
+    }
 
     /// Returns the last two successful migrations, for rollback purposes. The tuple will be
     /// interpreted as (last_migration, second_to_last_migration).
@@ -238,10 +240,6 @@ impl MigrationPersistence for EmptyMigrationPersistence {
 
     async fn reset(&self) -> Result<(), ConnectorError> {
         Ok(())
-    }
-
-    async fn last(&self) -> Result<Option<Migration>, ConnectorError> {
-        Ok(None)
     }
 
     async fn last_two_migrations(&self) -> ConnectorResult<(Option<Migration>, Option<Migration>)> {

--- a/migration-engine/connectors/sql-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/lib.rs
@@ -35,7 +35,6 @@ use sql_migration_persistence::*;
 use sql_schema_describer::SqlSchema;
 use std::{sync::Arc, time::Duration};
 use tracing::debug;
-use user_facing_errors::migration_engine::DatabaseMigrationFormatChanged;
 
 const CONNECTION_TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -164,11 +163,8 @@ impl MigrationConnector for SqlMigrationConnector {
         Box::new(SqlDestructiveChangesChecker { connector: self })
     }
 
-    fn deserialize_database_migration(
-        &self,
-        json: serde_json::Value,
-    ) -> Result<SqlMigration, DatabaseMigrationFormatChanged> {
-        serde_json::from_value(json).map_err(|_| DatabaseMigrationFormatChanged)
+    fn deserialize_database_migration(&self, json: serde_json::Value) -> Option<SqlMigration> {
+        serde_json::from_value(json).ok()
     }
 }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
@@ -210,10 +210,6 @@ fn render_raw_sql(
                 "PRAGMA foreign_keys=on".to_string(),
             ]),
         },
-        SqlMigrationStep::DropTables(DropTables { names }) => {
-            let fully_qualified_names = names.iter().map(|name| renderer.quote_with_schema(&schema_name, &name));
-            Ok(vec![format!("DROP TABLE {};", fully_qualified_names.join(","))])
-        }
         SqlMigrationStep::RenameTable { name, new_name } => {
             let new_name = match sql_family {
                 SqlFamily::Sqlite => renderer.quote(new_name).to_string(),

--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
@@ -48,20 +48,17 @@ impl DatabaseMigrationStepApplier<SqlMigration> for SqlDatabaseStepApplier<'_> {
         crate::catch(self.connection_info(), fut).await
     }
 
-    fn render_steps_pretty(&self, database_migration: &SqlMigration) -> ConnectorResult<Vec<serde_json::Value>> {
+    fn render_steps_pretty(
+        &self,
+        database_migration: &SqlMigration,
+    ) -> ConnectorResult<Vec<PrettyDatabaseMigrationStep>> {
         render_steps_pretty(
             &database_migration,
             self.renderer().as_ref(),
             self.database_info(),
             &database_migration.before,
             &database_migration.after,
-        )?
-        .into_iter()
-        .map(|pretty_step| {
-            serde_json::to_value(&pretty_step)
-                .map_err(|err| ConnectorError::from_kind(migration_connector::ErrorKind::Generic(err.into())))
-        })
-        .collect()
+        )
     }
 }
 
@@ -108,7 +105,7 @@ fn render_steps_pretty(
     database_info: &DatabaseInfo,
     current_schema: &SqlSchema,
     next_schema: &SqlSchema,
-) -> ConnectorResult<Vec<PrettySqlMigrationStep>> {
+) -> ConnectorResult<Vec<PrettyDatabaseMigrationStep>> {
     let mut steps = Vec::with_capacity(database_migration.corrected_steps.len());
 
     for step in &database_migration.corrected_steps {
@@ -119,8 +116,8 @@ fn render_steps_pretty(
             .join(";\n");
 
         if !sql.is_empty() {
-            steps.push(PrettySqlMigrationStep {
-                step: step.clone(),
+            steps.push(PrettyDatabaseMigrationStep {
+                step: serde_json::to_value(&step).unwrap_or_else(|_| serde_json::json!({})),
                 raw: sql,
             });
         }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker.rs
@@ -5,8 +5,8 @@ mod unexecutable_step_check;
 mod warning_check;
 
 use crate::{
-    sql_schema_differ::DiffingOptions, AddColumn, AlterColumn, Component, DropColumn, DropTable, DropTables,
-    SqlMigration, SqlMigrationStep, SqlResult, TableChange,
+    sql_schema_differ::DiffingOptions, AddColumn, AlterColumn, Component, DropColumn, DropTable, SqlMigration,
+    SqlMigrationStep, SqlResult, TableChange,
 };
 use destructive_check_plan::DestructiveCheckPlan;
 use migration_connector::{ConnectorResult, DestructiveChangeDiagnostics, DestructiveChangesChecker};
@@ -251,11 +251,6 @@ impl SqlDestructiveChangesChecker<'_> {
                 // not, return a warning.
                 SqlMigrationStep::DropTable(DropTable { name }) => {
                     self.check_table_drop(name, &mut plan);
-                }
-                SqlMigrationStep::DropTables(DropTables { names }) => {
-                    for name in names {
-                        self.check_table_drop(name, &mut plan);
-                    }
                 }
                 // SqlMigrationStep::CreateIndex(CreateIndex { table, index }) if index.is_unique() => todo!(),
                 // do nothing

--- a/migration-engine/connectors/sql-migration-connector/src/sql_migration.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_migration.rs
@@ -40,8 +40,6 @@ pub enum SqlMigrationStep {
     CreateTable(CreateTable),
     AlterTable(AlterTable),
     DropTable(DropTable),
-    // TODO: remove this variant on next migration format breaking change.
-    DropTables(DropTables),
     RenameTable { name: String, new_name: String },
     RawSql { raw: String },
     CreateIndex(CreateIndex),
@@ -69,11 +67,6 @@ pub struct CreateTable {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct DropTable {
     pub name: String,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-pub struct DropTables {
-    pub names: Vec<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]

--- a/migration-engine/connectors/sql-migration-connector/src/sql_migration.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_migration.rs
@@ -50,15 +50,6 @@ pub enum SqlMigrationStep {
     AlterEnum(AlterEnum),
 }
 
-/// A helper struct to serialize an [SqlMigrationStep](/sql-migration/enum.SqlMigrationStep.html)
-/// with an additional `raw` field containing the rendered SQL string for that step.
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
-pub struct PrettySqlMigrationStep {
-    #[serde(flatten)]
-    pub step: SqlMigrationStep,
-    pub raw: String,
-}
-
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct CreateTable {
     pub table: Table,

--- a/migration-engine/connectors/sql-migration-connector/src/sql_migration_persistence.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_migration_persistence.rs
@@ -65,19 +65,6 @@ impl MigrationPersistence for SqlMigrationPersistence<'_> {
         .await
     }
 
-    async fn last(&self) -> Result<Option<Migration>, ConnectorError> {
-        crate::catch(self.connection_info(), async {
-            let conditions = STATUS_COLUMN.equals(MigrationStatus::MigrationSuccess.code());
-            let query = Select::from_table(self.table())
-                .so_that(conditions)
-                .order_by(REVISION_COLUMN.descend());
-
-            let result_set = self.conn().query(query.into()).await?;
-            Ok(parse_rows_new(result_set).into_iter().next())
-        })
-        .await
-    }
-
     async fn last_two_migrations(&self) -> ConnectorResult<(Option<Migration>, Option<Migration>)> {
         crate::catch(
             self.connection_info(),

--- a/migration-engine/connectors/sql-migration-connector/src/sql_migration_persistence.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_migration_persistence.rs
@@ -1,9 +1,14 @@
-use crate::Component;
+use crate::{Component, SqlError};
 use barrel::types;
 use chrono::*;
+use futures::TryFutureExt;
 use migration_connector::*;
 use quaint::ast::*;
-use quaint::{connector::ResultSet, prelude::SqlFamily};
+use quaint::{
+    connector::ResultSet,
+    error::Error as QuaintError,
+    prelude::{Queryable, SqlFamily},
+};
 use std::convert::TryFrom;
 
 pub struct SqlMigrationPersistence<'a> {
@@ -70,6 +75,14 @@ impl MigrationPersistence for SqlMigrationPersistence<'_> {
             let result_set = self.conn().query(query.into()).await?;
             Ok(parse_rows_new(result_set).into_iter().next())
         })
+        .await
+    }
+
+    async fn last_two_migrations(&self) -> ConnectorResult<(Option<Migration>, Option<Migration>)> {
+        crate::catch(
+            self.connection_info(),
+            last_applied_migrations(self.conn(), self.table()).map_err(SqlError::from),
+        )
         .await
     }
 
@@ -160,6 +173,24 @@ impl MigrationPersistence for SqlMigrationPersistence<'_> {
         })
         .await
     }
+}
+
+/// Returns the last 2 applied migrations, or a shorter vec in absence of applied migrations.
+async fn last_applied_migrations(
+    conn: &dyn Queryable,
+    table: Table<'_>,
+) -> Result<(Option<Migration>, Option<Migration>), QuaintError> {
+    let conditions = STATUS_COLUMN.equals(MigrationStatus::MigrationSuccess.code());
+    let query = Select::from_table(table)
+        .so_that(conditions)
+        .order_by(REVISION_COLUMN.descend())
+        .limit(2);
+
+    let result_set = conn.query(query.into()).await?;
+    let mut rows = parse_rows_new(result_set).into_iter();
+    let last = rows.next();
+    let second_to_last = rows.next();
+    Ok((last, second_to_last))
 }
 
 fn migration_table_setup_sqlite(t: &mut barrel::Table) {

--- a/migration-engine/core/src/api/error_rendering.rs
+++ b/migration-engine/core/src/api/error_rendering.rs
@@ -13,9 +13,6 @@ pub fn render_error(crate_error: CoreError) -> Error {
             user_facing_error: Some(user_facing_error),
             ..
         })) => user_facing_error.into(),
-        CoreError::CommandError(CommandError::DatabaseMigrationFormatChanged(err)) => {
-            KnownError::new(err).unwrap().into()
-        }
         CoreError::CommandError(CommandError::ReceivedBadDatamodel(full_error)) => {
             KnownError::new(user_facing_errors::common::SchemaParserError { full_error })
                 .unwrap()

--- a/migration-engine/core/src/commands/apply_migration.rs
+++ b/migration-engine/core/src/commands/apply_migration.rs
@@ -170,7 +170,7 @@ impl<'a> ApplyMigrationCommand<'a> {
         Ok(MigrationStepsResultOutput {
             datamodel: datamodel::render_datamodel_to_string(&next_datamodel).unwrap(),
             datamodel_steps: self.input.steps.clone(),
-            database_steps: serde_json::Value::Array(database_steps_json_pretty),
+            database_steps: database_steps_json_pretty,
             errors,
             warnings,
             general_errors: Vec::new(),

--- a/migration-engine/core/src/commands/apply_migration.rs
+++ b/migration-engine/core/src/commands/apply_migration.rs
@@ -133,11 +133,13 @@ impl<'a> ApplyMigrationCommand<'a> {
 
         let database_migration_json = database_migration.serialize();
 
-        let mut migration = Migration::new(self.input.migration_id.clone());
-        migration.datamodel_steps = self.input.steps.clone();
-        migration.database_migration = database_migration_json;
-        migration.datamodel_string =
-            datamodel::render_schema_ast_to_string(&next_schema_ast).map_err(CommandError::ProducedBadDatamodel)?;
+        let migration = Migration::new(NewMigration {
+            name: self.input.migration_id.clone(),
+            datamodel_steps: self.input.steps.clone(),
+            datamodel_string: datamodel::render_schema_ast_to_string(&next_schema_ast)
+                .map_err(CommandError::ProducedBadDatamodel)?,
+            database_migration: database_migration_json,
+        });
 
         let diagnostics = connector
             .destructive_changes_checker()

--- a/migration-engine/core/src/commands/calculate_database_steps.rs
+++ b/migration-engine/core/src/commands/calculate_database_steps.rs
@@ -66,7 +66,7 @@ impl<'a> MigrationCommand for CalculateDatabaseStepsCommand<'a> {
         Ok(MigrationStepsResultOutput {
             datamodel: datamodel::render_schema_ast_to_string(&next_datamodel_ast).unwrap(),
             datamodel_steps: steps_to_apply.to_vec(),
-            database_steps: serde_json::Value::Array(database_steps_json),
+            database_steps: database_steps_json,
             errors: Vec::new(),
             warnings,
             general_errors: Vec::new(),

--- a/migration-engine/core/src/commands/command.rs
+++ b/migration-engine/core/src/commands/command.rs
@@ -4,7 +4,6 @@ use migration_connector::*;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use thiserror::Error;
-use user_facing_errors::migration_engine::DatabaseMigrationFormatChanged;
 
 #[async_trait::async_trait]
 pub trait MigrationCommand {
@@ -21,9 +20,6 @@ pub type CommandResult<T> = Result<T, CommandError>;
 
 #[derive(Debug, Error)]
 pub enum CommandError {
-    #[error("Database migration format changed.")]
-    DatabaseMigrationFormatChanged(DatabaseMigrationFormatChanged),
-
     /// When there was a bad datamodel as part of the input.
     #[error("{0}")]
     ReceivedBadDatamodel(String),
@@ -54,12 +50,6 @@ pub enum CommandError {
 
     #[error("Error in command input. (error: {0})")]
     Input(#[source] anyhow::Error),
-}
-
-impl From<DatabaseMigrationFormatChanged> for CommandError {
-    fn from(v: DatabaseMigrationFormatChanged) -> Self {
-        CommandError::DatabaseMigrationFormatChanged(v)
-    }
 }
 
 fn render_datamodel_error(err: &datamodel::error::ErrorCollection, schema: Option<&String>) -> String {

--- a/migration-engine/core/src/commands/infer_migration_steps.rs
+++ b/migration-engine/core/src/commands/infer_migration_steps.rs
@@ -109,7 +109,7 @@ impl<'a> MigrationCommand for InferMigrationStepsCommand<'a> {
         Ok(MigrationStepsResultOutput {
             datamodel: datamodel::render_datamodel_to_string(&next_datamodel).unwrap(),
             datamodel_steps: returned_datamodel_steps,
-            database_steps: serde_json::Value::Array(database_steps),
+            database_steps,
             errors: version_check_errors,
             warnings,
             general_errors: vec![],

--- a/migration-engine/core/src/commands/list_migrations.rs
+++ b/migration-engine/core/src/commands/list_migrations.rs
@@ -46,15 +46,18 @@ where
     D: DatabaseMigrationMarker + 'static,
 {
     let connector = engine.connector();
-    let database_migration = connector.deserialize_database_migration(migration.database_migration)?;
-    let database_steps_json = connector
-        .database_migration_step_applier()
-        .render_steps_pretty(&database_migration)?;
+
+    let database_steps_json = match connector.deserialize_database_migration(migration.database_migration) {
+        Ok(database_migration) => connector
+            .database_migration_step_applier()
+            .render_steps_pretty(&database_migration)?,
+        Err(_) => vec![],
+    };
 
     Ok(ListMigrationsOutput {
         id: migration.name,
         datamodel_steps: migration.datamodel_steps,
-        database_steps: serde_json::Value::Array(database_steps_json),
+        database_steps: database_steps_json,
         status: migration.status,
         datamodel: migration.datamodel_string,
     })
@@ -65,7 +68,7 @@ where
 pub struct ListMigrationsOutput {
     pub id: String,
     pub datamodel_steps: Vec<MigrationStep>,
-    pub database_steps: serde_json::Value,
+    pub database_steps: Vec<PrettyDatabaseMigrationStep>,
     pub status: MigrationStatus,
     pub datamodel: String,
 }

--- a/migration-engine/core/src/commands/list_migrations.rs
+++ b/migration-engine/core/src/commands/list_migrations.rs
@@ -48,10 +48,10 @@ where
     let connector = engine.connector();
 
     let database_steps_json = match connector.deserialize_database_migration(migration.database_migration) {
-        Ok(database_migration) => connector
+        Some(database_migration) => connector
             .database_migration_step_applier()
             .render_steps_pretty(&database_migration)?,
-        Err(_) => vec![],
+        None => vec![],
     };
 
     Ok(ListMigrationsOutput {

--- a/migration-engine/core/src/commands/mod.rs
+++ b/migration-engine/core/src/commands/mod.rs
@@ -18,7 +18,9 @@ pub use migration_progress::*;
 pub use reset::*;
 pub use unapply_migration::*;
 
-use migration_connector::{MigrationError, MigrationStep, MigrationWarning, UnexecutableMigration};
+use migration_connector::{
+    MigrationError, MigrationStep, MigrationWarning, PrettyDatabaseMigrationStep, UnexecutableMigration,
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -26,7 +28,7 @@ use serde::{Deserialize, Serialize};
 pub struct MigrationStepsResultOutput {
     pub datamodel: String,
     pub datamodel_steps: Vec<MigrationStep>,
-    pub database_steps: serde_json::Value,
+    pub database_steps: Vec<PrettyDatabaseMigrationStep>,
     pub warnings: Vec<MigrationWarning>,
     pub errors: Vec<MigrationError>,
     pub general_errors: Vec<String>,

--- a/migration-engine/core/src/commands/unapply_migration.rs
+++ b/migration-engine/core/src/commands/unapply_migration.rs
@@ -1,5 +1,6 @@
 use crate::commands::command::*;
 use crate::migration_engine::MigrationEngine;
+use datamodel::{ast::SchemaAst, Datamodel};
 use migration_connector::*;
 use serde::{Deserialize, Serialize};
 use tracing::debug;
@@ -22,20 +23,44 @@ impl<'a> MigrationCommand for UnapplyMigrationCommand<'a> {
         debug!("{:?}", cmd.input);
         let connector = engine.connector();
 
-        let result = match connector.migration_persistence().last().await? {
-            None => UnapplyMigrationOutput {
+        let result = match connector.migration_persistence().last_two_migrations().await? {
+            (None, _) => UnapplyMigrationOutput {
                 rolled_back: "not-applicable".to_string(),
                 active: None,
                 errors: vec!["There is no last migration that can be rolled back.".to_string()],
                 warnings: Vec::new(),
             },
-            Some(migration_to_rollback) => {
-                let database_migration =
-                    connector.deserialize_database_migration(migration_to_rollback.database_migration.clone())?;
+            (Some(migration_to_rollback), second_to_last) => {
+                let schema_ast_before_last_migration = second_to_last
+                    .as_ref()
+                    .map(|migration| migration.parse_schema_ast())
+                    .unwrap_or_else(|| Ok(SchemaAst::empty()))
+                    .map_err(|(err, schema)| CommandError::InvalidPersistedDatamodel(err, schema))?;
+                let schema_before_last_migration = second_to_last
+                    .as_ref()
+                    .map(|migration| migration.parse_datamodel())
+                    .unwrap_or_else(|| Ok(Datamodel::empty()))
+                    .map_err(|(err, schema)| CommandError::InvalidPersistedDatamodel(err, schema))?;
+
+                let last_schema_ast = migration_to_rollback
+                    .parse_schema_ast()
+                    .map_err(|(err, schema)| CommandError::InvalidPersistedDatamodel(err, schema))?;
+                let last_schema = migration_to_rollback
+                    .parse_datamodel()
+                    .map_err(|(err, schema)| CommandError::InvalidPersistedDatamodel(err, schema))?;
+
+                // Generate backwards datamodel steps.
+                let datamodel_migration =
+                    crate::migration::datamodel_differ::diff(&last_schema_ast, &schema_ast_before_last_migration);
+
+                let database_migration = connector
+                    .database_migration_inferrer()
+                    .infer(&last_schema, &schema_before_last_migration, &datamodel_migration)
+                    .await?;
 
                 let destructive_changes_checker = connector.destructive_changes_checker();
 
-                let warnings = destructive_changes_checker.check_unapply(&database_migration).await?;
+                let warnings = destructive_changes_checker.check(&database_migration).await?;
 
                 match (warnings.has_warnings(), input.force) {
                     (false, _) | (true, None) | (true, Some(true)) => {

--- a/migration-engine/migration-engine-tests/src/command_helpers.rs
+++ b/migration-engine/migration-engine-tests/src/command_helpers.rs
@@ -1,4 +1,3 @@
-use migration_connector::PrettyDatabaseMigrationStep;
 use migration_core::commands::*;
 use sql_migration_connector::SqlMigrationStep;
 use sql_schema_describer::*;

--- a/migration-engine/migration-engine-tests/src/command_helpers.rs
+++ b/migration-engine/migration-engine-tests/src/command_helpers.rs
@@ -1,5 +1,6 @@
+use migration_connector::PrettyDatabaseMigrationStep;
 use migration_core::commands::*;
-use sql_migration_connector::{PrettySqlMigrationStep, SqlMigrationStep};
+use sql_migration_connector::SqlMigrationStep;
 use sql_schema_describer::*;
 
 #[derive(Debug)]
@@ -10,9 +11,7 @@ pub struct InferAndApplyOutput {
 
 impl InferAndApplyOutput {
     pub fn sql_migration(&self) -> Vec<SqlMigrationStep> {
-        let steps: Vec<PrettySqlMigrationStep> =
-            serde_json::from_value(self.migration_output.database_steps.clone()).unwrap();
-        steps.into_iter().map(|pretty_step| pretty_step.step).collect()
+        self.migration_output.sql_migration()
     }
 }
 
@@ -22,7 +21,9 @@ pub trait MigrationStepsResultOutputExt {
 
 impl MigrationStepsResultOutputExt for MigrationStepsResultOutput {
     fn sql_migration(&self) -> Vec<SqlMigrationStep> {
-        let steps: Vec<PrettySqlMigrationStep> = serde_json::from_value(self.database_steps.clone()).unwrap();
-        steps.into_iter().map(|pretty_step| pretty_step.step).collect()
+        self.database_steps
+            .iter()
+            .map(|pretty_step| serde_json::from_value(pretty_step.step.clone()).unwrap())
+            .collect()
     }
 }

--- a/migration-engine/migration-engine-tests/src/test_api/infer.rs
+++ b/migration-engine/migration-engine-tests/src/test_api/infer.rs
@@ -108,7 +108,7 @@ impl<'a> InferAssertion<'a> {
         );
 
         anyhow::ensure!(
-            self.result.database_steps.as_array().unwrap().is_empty(),
+            self.result.database_steps.is_empty(),
             "Assertion failed. Database migration steps should be empty, but found {:#?}",
             self.result.database_steps
         );

--- a/migration-engine/migration-engine-tests/src/test_api/infer_apply.rs
+++ b/migration-engine/migration-engine-tests/src/test_api/infer_apply.rs
@@ -101,7 +101,7 @@ impl<'a> InferApplyAssertion<'a> {
         );
 
         anyhow::ensure!(
-            self.result.database_steps.as_array().unwrap().is_empty(),
+            self.result.database_steps.is_empty(),
             "Assertion failed. Database migration steps should be empty, but found {:#?}",
             self.result.database_steps
         );

--- a/migration-engine/migration-engine-tests/tests/migration_persistence_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migration_persistence_tests.rs
@@ -13,7 +13,7 @@ async fn last_should_return_none_if_there_is_no_migration(api: &TestApi) {
 #[test_each_connector]
 async fn last_must_return_none_if_there_is_no_successful_migration(api: &TestApi) -> TestResult {
     let persistence = api.migration_persistence();
-    persistence.create(Migration::new("my_migration".to_string())).await?;
+    persistence.create(Migration::empty("my_migration".to_string())).await?;
     let loaded = persistence.last().await?;
     assert_eq!(loaded, None);
 
@@ -31,15 +31,15 @@ async fn load_all_should_return_empty_if_there_is_no_migration(api: &TestApi) {
 async fn load_all_must_return_all_created_migrations(api: &TestApi) {
     let persistence = api.migration_persistence();
     let migration1 = persistence
-        .create(Migration::new("migration_1".to_string()))
+        .create(Migration::empty("migration_1".to_string()))
         .await
         .unwrap();
     let migration2 = persistence
-        .create(Migration::new("migration_2".to_string()))
+        .create(Migration::empty("migration_2".to_string()))
         .await
         .unwrap();
     let migration3 = persistence
-        .create(Migration::new("migration_3".to_string()))
+        .create(Migration::empty("migration_3".to_string()))
         .await
         .unwrap();
 
@@ -62,7 +62,7 @@ async fn create_should_allow_to_create_a_new_migration(api: &TestApi) {
     "#;
 
     let persistence = api.migration_persistence();
-    let mut migration = Migration::new("my_migration".to_string());
+    let mut migration = Migration::empty("my_migration".to_string());
     migration.status = MigrationStatus::MigrationSuccess;
     migration.datamodel_string = dm.to_owned();
     migration.datamodel_steps = vec![MigrationStep::CreateEnum(CreateEnum {
@@ -89,11 +89,11 @@ async fn create_should_allow_to_create_a_new_migration(api: &TestApi) {
 async fn create_should_increment_revisions(api: &TestApi) {
     let persistence = api.migration_persistence();
     let migration1 = persistence
-        .create(Migration::new("migration_1".to_string()))
+        .create(Migration::empty("migration_1".to_string()))
         .await
         .unwrap();
     let migration2 = persistence
-        .create(Migration::new("migration_2".to_string()))
+        .create(Migration::empty("migration_2".to_string()))
         .await
         .unwrap();
     assert_eq!(migration1.revision + 1, migration2.revision);
@@ -103,7 +103,7 @@ async fn create_should_increment_revisions(api: &TestApi) {
 async fn update_must_work(api: &TestApi) {
     let persistence = api.migration_persistence();
     let migration = persistence
-        .create(Migration::new("my_migration".to_string()))
+        .create(Migration::empty("my_migration".to_string()))
         .await
         .unwrap();
 
@@ -133,12 +133,12 @@ async fn update_must_work(api: &TestApi) {
 async fn migration_is_already_applied_must_work(api: &TestApi) -> TestResult {
     let persistence = api.migration_persistence();
 
-    let mut migration_1 = Migration::new("migration_1".to_string());
+    let mut migration_1 = Migration::empty("migration_1".to_string());
     migration_1.status = MigrationStatus::MigrationSuccess;
 
     persistence.create(migration_1).await?;
 
-    let mut migration_2 = Migration::new("migration_2".to_string());
+    let mut migration_2 = Migration::empty("migration_2".to_string());
     migration_2.status = MigrationStatus::MigrationFailure;
 
     persistence.create(migration_2).await?;


### PR DESCRIPTION
The goal in this PR is to avoid user-facing breakage when we change the shape of database migrations (at the moment this means `SqlMigration`), since we will most likely break things multiple times as we start working on migrations again and add mssql support. This is also decoupling breaking changes in the migration engine and sql-schema-describer.

We were deserializing and using database migrations from CLI input/the migrations table in two places.

## listMigrations

Here we only deserialize database migrations to render them for the CLI. The only change here is that we still try, but won't crash if the format changed, and only return an empty array of steps instead. @Jolg42 I did my best to not break anything, but I'm not 100% that this won't cause light breakage in the CLI.

If we still want to render useful information in presence of breakage in the future, we could pre-render and store migration steps rendered to strings (SQL queries or descriptive string). I did not do this because it is unclear what will happen with this feature.

## unapplyMigration

The way unapplyMigration works before this PR:

- Grab the last migration from the migrations table, and use the `rollback` database migration from the stored database migration.

This has two issues:

- If the database steps format breaks, we won't be able to rollback
- The current state of the database is ignored, so the steps could easily be wrong

This PR changes unapplyMigration to:

- Get the last two migrations from the migrations table, so we have the current datamodel and the one before that (otherwise assume an empty datamodel).
- Diff these
- Apply the migration from last datamodel to the one before that like any regular migration
- The only difference between `applyMigration` and `unapplyMigration` now is how they interact with the migrations table, and also watch mode. This means some of the `unapply` infrastructure is not needed anymore, but I haven't outright removed it yet.

closes https://github.com/prisma/prisma-engines/issues/741