### PR TITLE
Specialize alter column checks by SqlFlavour

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/component.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/component.rs
@@ -1,4 +1,4 @@
-use crate::{DatabaseInfo, SqlMigrationConnector, SqlResult};
+use crate::{flavour::SqlFlavour, DatabaseInfo, SqlMigrationConnector, SqlResult};
 use quaint::prelude::{ConnectionInfo, Queryable, SqlFamily};
 use sql_schema_describer::SqlSchema;
 
@@ -30,6 +30,10 @@ pub(crate) trait Component {
 
     fn sql_family(&self) -> SqlFamily {
         self.connection_info().sql_family()
+    }
+
+    fn flavour(&self) -> &(dyn SqlFlavour + Send + Sync + 'static) {
+        self.connector().flavour.as_ref()
     }
 }
 

--- a/migration-engine/connectors/sql-migration-connector/src/flavour.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour.rs
@@ -3,7 +3,8 @@
 //! detail of the SQL connector.
 
 use crate::{
-    catch, connect, database_info::DatabaseInfo, CheckDatabaseInfoResult, SqlError, SqlResult, SystemDatabase,
+    catch, connect, database_info::DatabaseInfo, sql_destructive_changes_checker::DestructiveChangeCheckerFlavour,
+    CheckDatabaseInfoResult, SqlError, SqlResult, SystemDatabase,
 };
 use futures::future::TryFutureExt;
 use migration_connector::{ConnectorError, ConnectorResult};
@@ -34,7 +35,7 @@ pub(crate) fn from_connection_info(connection_info: &ConnectionInfo) -> Box<dyn 
 }
 
 #[async_trait::async_trait]
-pub(crate) trait SqlFlavour {
+pub(crate) trait SqlFlavour: DestructiveChangeCheckerFlavour {
     /// Optionally validate the database info.
     fn check_database_info(&self, _database_info: &DatabaseInfo) -> CheckDatabaseInfoResult {
         Ok(())
@@ -54,7 +55,7 @@ pub(crate) trait SqlFlavour {
     async fn initialize(&self, conn: &dyn Queryable, database_info: &DatabaseInfo) -> SqlResult<()>;
 }
 
-struct MysqlFlavour(MysqlUrl);
+pub(crate) struct MysqlFlavour(MysqlUrl);
 
 #[async_trait::async_trait]
 impl SqlFlavour for MysqlFlavour {
@@ -117,7 +118,7 @@ impl SqlFlavour for MysqlFlavour {
     }
 }
 
-struct SqliteFlavour {
+pub(crate) struct SqliteFlavour {
     file_path: String,
 }
 
@@ -167,7 +168,7 @@ impl SqlFlavour for SqliteFlavour {
     }
 }
 
-struct PostgresFlavour(PostgresUrl);
+pub(crate) struct PostgresFlavour(PostgresUrl);
 
 #[async_trait::async_trait]
 impl SqlFlavour for PostgresFlavour {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/destructive_change_checker_flavour.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/destructive_change_checker_flavour.rs
@@ -1,0 +1,13 @@
+mod mysql;
+mod postgres;
+mod sqlite;
+
+use super::DestructiveCheckPlan;
+use crate::sql_schema_differ::ColumnDiffer;
+use sql_schema_describer::Table;
+
+/// Flavour-specific destructive change checks.
+pub(crate) trait DestructiveChangeCheckerFlavour {
+    /// Check for potential destructive or unexecutable alter column steps.
+    fn check_alter_column(&self, previous_table: &Table, columns: &ColumnDiffer<'_>, plan: &mut DestructiveCheckPlan);
+}

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/destructive_change_checker_flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/destructive_change_checker_flavour/mysql.rs
@@ -1,0 +1,27 @@
+use super::DestructiveChangeCheckerFlavour;
+use crate::{
+    expanded_alter_column::{expand_mysql_alter_column, MysqlAlterColumn},
+    flavour::MysqlFlavour,
+    sql_destructive_changes_checker::{
+        destructive_check_plan::DestructiveCheckPlan, warning_check::SqlMigrationWarning,
+    },
+    sql_schema_differ::ColumnDiffer,
+};
+use sql_schema_describer::Table;
+
+impl DestructiveChangeCheckerFlavour for MysqlFlavour {
+    fn check_alter_column(&self, previous_table: &Table, columns: &ColumnDiffer<'_>, plan: &mut DestructiveCheckPlan) {
+        if let Some(steps) = expand_mysql_alter_column(columns) {
+            for step in steps {
+                match step {
+                    MysqlAlterColumn::DropDefault | MysqlAlterColumn::SetDefault(_) => return,
+                }
+            }
+        }
+
+        plan.push_warning(SqlMigrationWarning::AlterColumn {
+            table: previous_table.name.clone(),
+            column: columns.next.name.clone(),
+        });
+    }
+}

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/destructive_change_checker_flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/destructive_change_checker_flavour/postgres.rs
@@ -1,0 +1,39 @@
+use super::DestructiveChangeCheckerFlavour;
+use crate::{
+    expanded_alter_column::{expand_postgres_alter_column, PostgresAlterColumn},
+    flavour::PostgresFlavour,
+    sql_destructive_changes_checker::{
+        destructive_check_plan::DestructiveCheckPlan, warning_check::SqlMigrationWarning,
+    },
+    sql_schema_differ::ColumnDiffer,
+};
+use sql_schema_describer::Table;
+
+impl DestructiveChangeCheckerFlavour for PostgresFlavour {
+    fn check_alter_column(&self, previous_table: &Table, columns: &ColumnDiffer<'_>, plan: &mut DestructiveCheckPlan) {
+        let expanded = expand_postgres_alter_column(columns);
+
+        // We keep the match here to keep the exhaustiveness checking for when we add variants.
+        if let Some(steps) = expanded {
+            let mut is_safe = true;
+
+            for step in steps {
+                match step {
+                    PostgresAlterColumn::SetDefault(_)
+                    | PostgresAlterColumn::DropDefault
+                    | PostgresAlterColumn::DropNotNull => (),
+                    PostgresAlterColumn::SetType(_) => is_safe = false,
+                }
+            }
+
+            if is_safe {
+                return;
+            }
+        }
+
+        plan.push_warning(SqlMigrationWarning::AlterColumn {
+            table: previous_table.name.clone(),
+            column: columns.next.name.clone(),
+        });
+    }
+}

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/destructive_change_checker_flavour/sqlite.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/destructive_change_checker_flavour/sqlite.rs
@@ -1,0 +1,33 @@
+use super::DestructiveChangeCheckerFlavour;
+use crate::{
+    flavour::SqliteFlavour,
+    sql_destructive_changes_checker::{
+        destructive_check_plan::DestructiveCheckPlan, warning_check::SqlMigrationWarning,
+    },
+    sql_schema_differ::ColumnDiffer,
+};
+use sql_schema_describer::{ColumnArity, Table};
+
+impl DestructiveChangeCheckerFlavour for SqliteFlavour {
+    fn check_alter_column(&self, previous_table: &Table, columns: &ColumnDiffer<'_>, plan: &mut DestructiveCheckPlan) {
+        let arity_change_is_safe = match (&columns.previous.tpe.arity, &columns.next.tpe.arity) {
+            // column became required
+            (ColumnArity::Nullable, ColumnArity::Required) => false,
+            // column became nullable
+            (ColumnArity::Required, ColumnArity::Nullable) => true,
+            // nothing changed
+            (ColumnArity::Required, ColumnArity::Required) | (ColumnArity::Nullable, ColumnArity::Nullable) => true,
+            // not supported on SQLite
+            (ColumnArity::List, _) | (_, ColumnArity::List) => unreachable!(),
+        };
+
+        if !columns.all_changes().type_changed() && arity_change_is_safe {
+            return;
+        }
+
+        plan.push_warning(SqlMigrationWarning::AlterColumn {
+            table: previous_table.name.clone(),
+            column: columns.next.name.clone(),
+        });
+    }
+}

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/destructive_check_plan.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/destructive_check_plan.rs
@@ -10,7 +10,7 @@ use quaint::prelude::Queryable;
 /// ([Check](trait.Check.html)) for a given migration. It has an `execute` method that performs
 /// database inspection and renders user-facing messages based on the checks.
 #[derive(Debug)]
-pub(super) struct DestructiveCheckPlan {
+pub(crate) struct DestructiveCheckPlan {
     warnings: Vec<SqlMigrationWarning>,
     unexecutable_migrations: Vec<UnexecutableStepCheck>,
 }

--- a/migration-engine/migration-engine-tests/tests/existing_data_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_data_tests.rs
@@ -6,7 +6,7 @@ use pretty_assertions::assert_eq;
 use prisma_value::{PrismaValue, TypeHint};
 use quaint::ast::*;
 
-#[test_each_connector(log = "debug,sql_schema_describer=info")]
+#[test_each_connector]
 async fn dropping_a_table_with_rows_should_warn(api: &TestApi) {
     let dm = r#"
         model Test {
@@ -137,6 +137,7 @@ async fn altering_a_column_with_non_null_values_should_warn(api: &TestApi) -> Te
     "#;
 
     let migration_output = api.infer_apply(&dm2).send().await?.into_inner();
+
     // The schema should not change because the migration should not run if there are warnings
     // and the force flag isn't passed.
     api.assert_schema().await?.assert_equals(&original_database_schema)?;
@@ -157,7 +158,7 @@ async fn altering_a_column_with_non_null_values_should_warn(api: &TestApi) -> Te
     Ok(())
 }
 
-#[test_each_connector(log = "debug")]
+#[test_each_connector]
 async fn column_defaults_can_safely_be_changed(api: &TestApi) -> TestResult {
     let combinations = &[
         ("Meow", Some(PrismaValue::String("Cats".to_string())), None),


### PR DESCRIPTION
This is a small refactoring to have clear places to put the code in the MySQL column default migrations (https://github.com/prisma/migrate/issues/429) and primary key migrations (https://github.com/prisma/migrate/issues/468) PRs.

edit: it's fairly well tested, so I am pretty sure nothing broke, it's just moving code around.