### PR TITLE
[MySQL] Make alter columns of fields w/ @default(now()) work

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
@@ -478,7 +478,7 @@ fn safe_alter_column(
             .collect(),
         ExpandedAlterColumn::Mysql(step) => match step {
             MysqlAlterColumn::DropDefault => vec![format!("{} DROP DEFAULT", &alter_column_prefix)],
-            MysqlAlterColumn::Modify { .. } => vec![format!(
+            MysqlAlterColumn::Modify { new_default, .. } => vec![format!(
                 "MODIFY {column_name} {column_type} {nullability} {default}",
                 column_name = Quoted::mysql_ident(&next_column.name()),
                 column_type = Some(next_column.column.tpe.full_data_type.clone())
@@ -493,11 +493,10 @@ fn safe_alter_column(
                 } else {
                     ""
                 },
-                default = next_column
-                    .default()
+                default = new_default
                     .map(|default| format!(
                         "DEFAULT {}",
-                        renderer.render_default(default, &next_column.column_type().family)
+                        renderer.render_default(&default, &next_column.column_type().family)
                     ))
                     .unwrap_or_else(String::new),
             )],

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker.rs
@@ -114,8 +114,6 @@ impl SqlDestructiveChangesChecker<'_> {
 
         self.flavour().check_alter_column(previous_table, &differ, plan);
 
-        self.check_for_column_arity_change(&previous_table.name, &differ, plan);
-
         if previous_table.is_part_of_foreign_key(&alter_column.column.name)
             && alter_column.column.default.is_none()
             && previous_column.default.is_some()
@@ -125,27 +123,6 @@ impl SqlDestructiveChangesChecker<'_> {
                 column: alter_column.name.clone(),
             });
         }
-    }
-
-    fn check_for_column_arity_change(
-        &self,
-        table_name: &str,
-        differ: &crate::sql_schema_differ::ColumnDiffer<'_>,
-        plan: &mut DestructiveCheckPlan,
-    ) {
-        if !differ.all_changes().arity_changed()
-            || !differ.next.tpe.arity.is_required()
-            || differ.next.default.is_some()
-        {
-            return;
-        }
-
-        let typed_unexecutable = unexecutable_step_check::UnexecutableStepCheck::MadeOptionalFieldRequired {
-            table: table_name.to_owned(),
-            column: differ.previous.name.clone(),
-        };
-
-        plan.push_unexecutable(typed_unexecutable);
     }
 
     #[tracing::instrument(skip(self, steps, before), target = "SqlDestructiveChangeChecker::check")]

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/destructive_change_checker_flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/destructive_change_checker_flavour/mysql.rs
@@ -3,7 +3,8 @@ use crate::{
     expanded_alter_column::{expand_mysql_alter_column, MysqlAlterColumn},
     flavour::MysqlFlavour,
     sql_destructive_changes_checker::{
-        destructive_check_plan::DestructiveCheckPlan, warning_check::SqlMigrationWarning,
+        destructive_check_plan::DestructiveCheckPlan, unexecutable_step_check::UnexecutableStepCheck,
+        warning_check::SqlMigrationWarning,
     },
     sql_schema_differ::ColumnDiffer,
 };
@@ -11,17 +12,29 @@ use sql_schema_describer::Table;
 
 impl DestructiveChangeCheckerFlavour for MysqlFlavour {
     fn check_alter_column(&self, previous_table: &Table, columns: &ColumnDiffer<'_>, plan: &mut DestructiveCheckPlan) {
-        if let Some(steps) = expand_mysql_alter_column(columns) {
-            for step in steps {
-                match step {
-                    MysqlAlterColumn::DropDefault | MysqlAlterColumn::SetDefault(_) => return,
+        match expand_mysql_alter_column(columns) {
+            MysqlAlterColumn::DropDefault => return, // dropping a default is safe
+
+            // If only the default changed, the step is safe.
+            MysqlAlterColumn::Modify { changes, .. } if changes.only_default_changed() => return,
+
+            // Otherwise, case by case.
+            MysqlAlterColumn::Modify { .. } => {
+                // Column went from optional to required. This is unexecutable unless the table is
+                // empty or the column has no existing NULLs.
+                if columns.all_changes().arity_changed() && columns.next.tpe.arity.is_required() {
+                    plan.push_unexecutable(UnexecutableStepCheck::MadeOptionalFieldRequired {
+                        column: columns.previous.name.clone(),
+                        table: previous_table.name.clone(),
+                    });
+                } else {
+                    // Executable drop and recreate.
+                    plan.push_warning(SqlMigrationWarning::AlterColumn {
+                        table: previous_table.name.clone(),
+                        column: columns.next.name.clone(),
+                    });
                 }
             }
         }
-
-        plan.push_warning(SqlMigrationWarning::AlterColumn {
-            table: previous_table.name.clone(),
-            column: columns.next.name.clone(),
-        });
     }
 }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/destructive_change_checker_flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/destructive_change_checker_flavour/mysql.rs
@@ -28,7 +28,6 @@ impl DestructiveChangeCheckerFlavour for MysqlFlavour {
                         table: previous_table.name.clone(),
                     });
                 } else {
-                    // Executable drop and recreate.
                     plan.push_warning(SqlMigrationWarning::AlterColumn {
                         table: previous_table.name.clone(),
                         column: columns.next.name.clone(),

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mod.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mod.rs
@@ -6,6 +6,7 @@ mod postgres_renderer;
 mod sqlite_renderer;
 
 pub(crate) use common::{IteratorJoin, Quoted, QuotedWithSchema};
+pub(crate) use mysql_renderer::render_column_type as mysql_render_column_type;
 pub(crate) use postgres_renderer::render_column_type as postgres_render_column_type;
 
 use crate::{sql_schema_helpers::ColumnRef, SqlFamily};

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
@@ -322,6 +322,9 @@ fn migration_value_new(field: &FieldRef<'_>) -> Option<sql_schema_describer::Def
         dml::DefaultValue::Expression(expression) if expression.name == "now" && expression.args.is_empty() => {
             return Some(sql_schema_describer::DefaultValue::NOW)
         }
+        dml::DefaultValue::Expression(expression) if expression.name == "dbgenerated" && expression.args.is_empty() => {
+            return Some(sql_schema_describer::DefaultValue::DBGENERATED(String::new()))
+        }
         dml::DefaultValue::Expression(_) => return None,
     };
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
@@ -3,7 +3,7 @@ mod enums;
 mod index;
 mod table;
 
-pub(crate) use column::{ColumnChange, ColumnDiffer};
+pub(crate) use column::{ColumnChange, ColumnChanges, ColumnDiffer};
 pub(crate) use table::TableDiffer;
 
 use crate::*;

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/column.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/column.rs
@@ -76,7 +76,6 @@ impl<'a> ColumnDiffer<'a> {
 
         match (&self.previous.default, &self.next.default) {
             (Some(DefaultValue::VALUE(prev)), Some(DefaultValue::VALUE(next))) => prev == next,
-            (Some(DefaultValue::VALUE(_)), Some(DefaultValue::DBGENERATED(_))) => true,
             (Some(DefaultValue::VALUE(_)), Some(DefaultValue::SEQUENCE(_))) => true,
             (Some(DefaultValue::VALUE(_)), Some(DefaultValue::NOW)) => false,
             (Some(DefaultValue::VALUE(_)), None) => false,

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/column.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/column.rs
@@ -132,6 +132,14 @@ impl ColumnChanges {
     pub(crate) fn arity_changed(&self) -> bool {
         self.changes.iter().any(|c| c.as_ref() == Some(&ColumnChange::Arity))
     }
+
+    pub(crate) fn only_default_changed(&self) -> bool {
+        matches!(self.changes, [None, None, None, Some(ColumnChange::Default)])
+    }
+
+    pub(crate) fn column_was_renamed(&self) -> bool {
+        matches!(self.changes, [Some(ColumnChange::Renaming), _, _, _])
+    }
 }
 
 #[cfg(test)]

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_helpers.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_helpers.rs
@@ -9,6 +9,20 @@ pub(crate) fn walk_columns<'a>(schema: &'a SqlSchema) -> impl Iterator<Item = Co
     })
 }
 
+pub(crate) fn find_column<'a>(schema: &'a SqlSchema, table_name: &str, column_name: &str) -> Option<ColumnRef<'a>> {
+    schema
+        .tables
+        .iter()
+        .find(move |table| table.name == table_name)
+        .and_then(move |table| {
+            table
+                .columns
+                .iter()
+                .find(|column| column.name == column_name)
+                .map(|column| ColumnRef { schema, table, column })
+        })
+}
+
 pub(crate) struct ColumnRef<'a> {
     pub(crate) schema: &'a SqlSchema,
     pub(crate) column: &'a Column,

--- a/migration-engine/migration-engine-tests/src/test_api.rs
+++ b/migration-engine/migration-engine-tests/src/test_api.rs
@@ -240,7 +240,7 @@ impl<'a> TestApiSelect<'a> {
     }
 
     pub async fn send_debug(self) -> Result<Vec<Vec<String>>, anyhow::Error> {
-        let rows = self.api.database().query(self.select.into()).await?;
+        let rows = self.send().await?;
 
         let rows: Vec<Vec<String>> = rows
             .into_iter()
@@ -248,6 +248,10 @@ impl<'a> TestApiSelect<'a> {
             .collect();
 
         Ok(rows)
+    }
+
+    pub async fn send(self) -> anyhow::Result<quaint::prelude::ResultSet> {
+        Ok(self.api.database().query(self.select.into()).await?)
     }
 }
 

--- a/migration-engine/migration-engine-tests/src/test_api/infer.rs
+++ b/migration-engine/migration-engine-tests/src/test_api/infer.rs
@@ -115,4 +115,15 @@ impl<'a> InferAssertion<'a> {
 
         Ok(self)
     }
+
+    pub fn assert_warnings(self, warnings: &[String]) -> AssertionResult<Self> {
+        for (idx, warning) in warnings.iter().enumerate() {
+            assert_eq!(
+                Some(warning),
+                self.result.warnings.get(idx).map(|warning| &warning.description)
+            );
+        }
+
+        Ok(self)
+    }
 }

--- a/migration-engine/migration-engine-tests/tests/existing_data/sql_unexecutable_migrations/made_optional_field_required.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_data/sql_unexecutable_migrations/made_optional_field_required.rs
@@ -1,4 +1,7 @@
 use migration_engine_tests::sql::*;
+use prisma_value::PrismaValue;
+use quaint::Value;
+use sql_schema_describer::DefaultValue;
 
 #[test_each_connector(tags("sql"))]
 async fn making_an_optional_field_required_with_data_without_a_default_is_unexecutable(api: &TestApi) -> TestResult {
@@ -40,7 +43,7 @@ async fn making_an_optional_field_required_with_data_without_a_default_is_unexec
     Ok(())
 }
 
-#[test_each_connector]
+#[test_each_connector(tags("sqlite"))]
 async fn making_an_optional_field_required_with_data_with_a_default_works(api: &TestApi) -> TestResult {
     let dm1 = r#"
         model Test {
@@ -58,6 +61,13 @@ async fn making_an_optional_field_required_with_data_with_a_default_works(api: &
         .result_raw()
         .await?;
 
+    api.insert("Test")
+        .value("id", "def")
+        .value("name", "X Æ A-12")
+        .value("age", 7)
+        .result_raw()
+        .await?;
+
     let dm2 = r#"
         model Test {
             id String @id
@@ -66,22 +76,105 @@ async fn making_an_optional_field_required_with_data_with_a_default_works(api: &
         }
     "#;
 
-    api.infer_apply(&dm2).send().await?.assert_green()?;
+    api.infer_apply(&dm2).force(Some(true)).send().await?;
 
-    api.assert_schema()
-        .await?
-        .assert_table("Test", |table| table.assert_does_not_have_column("Int"))?;
+    api.assert_schema().await?.assert_table("Test", |table| {
+        table.assert_column("age", |column| {
+            column
+                .assert_is_required()?
+                .assert_default(Some(DefaultValue::VALUE(PrismaValue::Int(84))))
+        })
+    })?;
 
     let rows = api
         .select("Test")
         .column("id")
         .column("name")
         .column("age")
-        .send_debug()
+        .send()
         .await?;
+
     assert_eq!(
-        rows,
-        &[&[r#"Text(Some("abc"))"#, r#"Text(Some("george"))"#, "Integer(Some(84))"]]
+        rows.into_iter()
+            .map(|row| row.into_iter().collect::<Vec<Value>>())
+            .collect::<Vec<_>>(),
+        &[
+            &[Value::text("abc"), Value::text("george"), Value::integer(84)],
+            &[Value::text("def"), Value::text("X Æ A-12"), Value::integer(7)],
+        ]
+    );
+    Ok(())
+}
+
+// CONFIRMED: this is unexecutable on postgres
+// CONFIRMED: all mysql versions except 5.6 will return an error. 5.6 will just insert 0s, which
+// seems very wrong, so we should warn against it.
+#[test_each_connector(log = "debug", ignore("sqlite"))]
+async fn making_an_optional_field_required_with_data_with_a_default_is_unexecutable(api: &TestApi) -> TestResult {
+    let dm1 = r#"
+        model Test {
+            id String @id
+            name String
+            age Int?
+        }
+    "#;
+
+    api.infer_apply(&dm1).send().await?.assert_green()?;
+
+    let initial_schema = api.assert_schema().await?.into_schema();
+
+    api.insert("Test")
+        .value("id", "abc")
+        .value("name", "george")
+        .result_raw()
+        .await?;
+
+    api.insert("Test")
+        .value("id", "def")
+        .value("name", "X Æ A-12")
+        .value("age", 7i64)
+        .result_raw()
+        .await?;
+
+    let dm2 = r#"
+        model Test {
+            id String @id
+            name String
+            age Int @default(84)
+        }
+    "#;
+
+    api.infer_apply(&dm2)
+        .force(Some(false))
+        .send()
+        .await?
+        .assert_unexecutable(&[
+            "Made the column `age` on table `Test` required, but there are 1 existing NULL values.".into(),
+        ])?
+        .assert_warnings(&[
+            // TEMPORARY, until the CLI displays unexecutable migration messages.
+            "Made the column `age` on table `Test` required, but there are 1 existing NULL values.".into(),
+        ])?
+        .assert_no_error()?;
+
+    api.assert_schema().await?.assert_equals(&initial_schema)?;
+
+    let rows = api
+        .select("Test")
+        .column("id")
+        .column("name")
+        .column("age")
+        .send()
+        .await?;
+
+    assert_eq!(
+        rows.into_iter()
+            .map(|row| row.into_iter().collect::<Vec<Value>>())
+            .collect::<Vec<_>>(),
+        &[
+            &[Value::text("abc"), Value::text("george"), Value::Integer(None)],
+            &[Value::text("def"), Value::text("X Æ A-12"), Value::integer(7)],
+        ]
     );
 
     Ok(())

--- a/migration-engine/migration-engine-tests/tests/existing_databases_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_databases_tests.rs
@@ -425,30 +425,3 @@ async fn removing_a_default_from_a_non_nullable_foreign_key_column_must_warn(api
 
     Ok(())
 }
-
-#[test_each_connector(tags("mysql"))]
-async fn migrating_a_dbgenerated_default_should_warn(api: &TestApi) -> TestResult {
-    let dm1 = r#"
-        model User {
-            id Int @id
-            dogs String @default(dbgenerated())
-        }
-    "#;
-
-    api.infer_apply(dm1).send().await?.assert_green()?;
-
-    let dm2 = r#"
-        model User {
-            id Int @id
-            dogs String? @default(dbgenerated())
-        }
-    "#;
-
-    api.infer_apply(dm2)
-        .send()
-        .await?
-        .assert_executable()?
-        .assert_warnings(&["heh".into()])?;
-
-    Ok(())
-}

--- a/migration-engine/migration-engine-tests/tests/existing_databases_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_databases_tests.rs
@@ -425,3 +425,30 @@ async fn removing_a_default_from_a_non_nullable_foreign_key_column_must_warn(api
 
     Ok(())
 }
+
+#[test_each_connector(tags("mysql"))]
+async fn migrating_a_dbgenerated_default_should_warn(api: &TestApi) -> TestResult {
+    let dm1 = r#"
+        model User {
+            id Int @id
+            dogs String @default(dbgenerated())
+        }
+    "#;
+
+    api.infer_apply(dm1).send().await?.assert_green()?;
+
+    let dm2 = r#"
+        model User {
+            id Int @id
+            dogs String? @default(dbgenerated())
+        }
+    "#;
+
+    api.infer_apply(dm2)
+        .send()
+        .await?
+        .assert_executable()?
+        .assert_warnings(&["heh".into()])?;
+
+    Ok(())
+}


### PR DESCRIPTION
This seemingly simple changed needed a lot of background work to happen.

- Switch MySQL default migrations from `SET DEFAULT` to `MODIFY`, since `SET DEFAULT` does not support expressions like `CURRENT_TIMESTAMP`.
- Use introspected `@default(dbgenerated())` from previous schema in MODIFY statements (otherwise we would end up with a column without a default).
- Refine destructive change checks. The main refinement is that unexecutable migration checks assumed making an optional column required, when the column has a default, is possible. But on Postgres and MySQL it isn't, and on SQLite the situation is completely different.
- New destructive change checks for migrations to and from scalar lists.

addresses  https://github.com/prisma/migrate/issues/429 
closes https://github.com/prisma/prisma-engines/issues/710