### PR TITLE
Primary key migrations

### DIFF
--- a/introspection-engine/connectors/sql-introspection-connector/tests/common_unit_tests/mod.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/tests/common_unit_tests/mod.rs
@@ -183,6 +183,7 @@ fn arity_is_preserved_when_generating_data_model_from_a_schema() {
             primary_key: Some(PrimaryKey {
                 columns: vec!["required".to_string()],
                 sequence: None,
+                constraint_name: None,
             }),
             foreign_keys: vec![],
         }],
@@ -432,6 +433,7 @@ fn primary_key_is_preserved_when_generating_data_model_from_a_schema() {
                 primary_key: Some(PrimaryKey {
                     columns: vec!["primary".to_string()],
                     sequence: None,
+                    constraint_name: None,
                 }),
                 foreign_keys: vec![],
             },
@@ -453,6 +455,7 @@ fn primary_key_is_preserved_when_generating_data_model_from_a_schema() {
                 primary_key: Some(PrimaryKey {
                     columns: vec!["primary".to_string()],
                     sequence: None,
+                    constraint_name: None,
                 }),
                 foreign_keys: vec![],
             },
@@ -479,6 +482,7 @@ fn primary_key_is_preserved_when_generating_data_model_from_a_schema() {
                         initial_value: 1,
                         allocation_size: 1,
                     }),
+                    constraint_name: None,
                 }),
                 foreign_keys: vec![],
             },
@@ -739,6 +743,7 @@ fn compound_foreign_keys_are_preserved_when_generating_data_model_from_a_schema(
                 primary_key: Some(PrimaryKey {
                     columns: vec!["id".to_string()],
                     sequence: None,
+                    constraint_name: None,
                 }),
                 foreign_keys: vec![],
             },
@@ -789,6 +794,7 @@ fn compound_foreign_keys_are_preserved_when_generating_data_model_from_a_schema(
                 primary_key: Some(PrimaryKey {
                     columns: vec!["id".to_string()],
                     sequence: None,
+                    constraint_name: None,
                 }),
                 foreign_keys: vec![ForeignKey {
                     // what does this mean? the from columns are not targeting a specific to column?
@@ -921,6 +927,7 @@ fn multi_field_uniques_are_preserved_when_generating_data_model_from_a_schema() 
             primary_key: Some(PrimaryKey {
                 columns: vec!["id".to_string()],
                 sequence: None,
+                constraint_name: None,
             }),
             foreign_keys: vec![],
         }],
@@ -1090,6 +1097,7 @@ fn foreign_keys_are_preserved_when_generating_data_model_from_a_schema() {
                 primary_key: Some(PrimaryKey {
                     columns: vec!["id".to_string()],
                     sequence: None,
+                    constraint_name: None,
                 }),
                 foreign_keys: vec![],
             },
@@ -1127,6 +1135,7 @@ fn foreign_keys_are_preserved_when_generating_data_model_from_a_schema() {
                 primary_key: Some(PrimaryKey {
                     columns: vec!["id".to_string()],
                     sequence: None,
+                    constraint_name: None,
                 }),
                 foreign_keys: vec![ForeignKey {
                     constraint_name: None,

--- a/introspection-engine/connectors/sql-introspection-connector/tests/rpc_calls/get_database_description.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/tests/rpc_calls/get_database_description.rs
@@ -1,12 +1,13 @@
 use crate::{test_harness::*, BarrelMigrationExecutor};
 use barrel::types;
+use pretty_assertions::assert_eq;
 
 #[test_each_connector(tags("mysql_5_6", "mariadb"))]
 async fn database_description_for_mysql_should_work(api: &TestApi) {
     let barrel = api.barrel();
     setup(&barrel, api.db_name()).await;
     let result = dbg!(api.get_database_description().await);
-    assert_eq!(result, "{\"tables\":[{\"name\":\"Blog\",\"columns\":[{\"name\":\"id\",\"tpe\":{\"dataType\":\"int\",\"fullDataType\":\"int(11)\",\"characterMaximumLength\":null,\"family\":\"int\",\"arity\":\"required\"},\"default\":null,\"autoIncrement\":true},{\"name\":\"string\",\"tpe\":{\"dataType\":\"text\",\"fullDataType\":\"text\",\"characterMaximumLength\":65535,\"family\":\"string\",\"arity\":\"required\"},\"default\":null,\"autoIncrement\":false}],\"indices\":[],\"primaryKey\":{\"columns\":[\"id\"],\"sequence\":null},\"foreignKeys\":[]}],\"enums\":[],\"sequences\":[]}".to_string());
+    assert_eq!(result, "{\"tables\":[{\"name\":\"Blog\",\"columns\":[{\"name\":\"id\",\"tpe\":{\"dataType\":\"int\",\"fullDataType\":\"int(11)\",\"characterMaximumLength\":null,\"family\":\"int\",\"arity\":\"required\"},\"default\":null,\"autoIncrement\":true},{\"name\":\"string\",\"tpe\":{\"dataType\":\"text\",\"fullDataType\":\"text\",\"characterMaximumLength\":65535,\"family\":\"string\",\"arity\":\"required\"},\"default\":null,\"autoIncrement\":false}],\"indices\":[],\"primaryKey\":{\"columns\":[\"id\"],\"sequence\":null,\"constraintName\":null},\"foreignKeys\":[]}],\"enums\":[],\"sequences\":[]}".to_string());
 }
 
 #[test_each_connector(tags("mysql_8"))]
@@ -14,7 +15,7 @@ async fn database_description_for_mysql_8_should_work(api: &TestApi) {
     let barrel = api.barrel();
     setup(&barrel, api.db_name()).await;
     let result = dbg!(api.get_database_description().await);
-    assert_eq!(result, "{\"tables\":[{\"name\":\"Blog\",\"columns\":[{\"name\":\"id\",\"tpe\":{\"dataType\":\"int\",\"fullDataType\":\"int\",\"characterMaximumLength\":null,\"family\":\"int\",\"arity\":\"required\"},\"default\":null,\"autoIncrement\":true},{\"name\":\"string\",\"tpe\":{\"dataType\":\"text\",\"fullDataType\":\"text\",\"characterMaximumLength\":65535,\"family\":\"string\",\"arity\":\"required\"},\"default\":null,\"autoIncrement\":false}],\"indices\":[],\"primaryKey\":{\"columns\":[\"id\"],\"sequence\":null},\"foreignKeys\":[]}],\"enums\":[],\"sequences\":[]}".to_string());
+    assert_eq!(result, "{\"tables\":[{\"name\":\"Blog\",\"columns\":[{\"name\":\"id\",\"tpe\":{\"dataType\":\"int\",\"fullDataType\":\"int\",\"characterMaximumLength\":null,\"family\":\"int\",\"arity\":\"required\"},\"default\":null,\"autoIncrement\":true},{\"name\":\"string\",\"tpe\":{\"dataType\":\"text\",\"fullDataType\":\"text\",\"characterMaximumLength\":65535,\"family\":\"string\",\"arity\":\"required\"},\"default\":null,\"autoIncrement\":false}],\"indices\":[],\"primaryKey\":{\"columns\":[\"id\"],\"sequence\":null,\"constraintName\":null},\"foreignKeys\":[]}],\"enums\":[],\"sequences\":[]}".to_string());
 }
 
 #[test_each_connector(tags("postgres"))]
@@ -22,7 +23,7 @@ async fn database_description_for_postgres_should_work(api: &TestApi) {
     let barrel = api.barrel();
     setup(&barrel, api.schema_name()).await;
     let result = dbg!(api.get_database_description().await);
-    assert_eq!(result, "{\"tables\":[{\"name\":\"Blog\",\"columns\":[{\"name\":\"id\",\"tpe\":{\"dataType\":\"integer\",\"fullDataType\":\"int4\",\"characterMaximumLength\":null,\"family\":\"int\",\"arity\":\"required\"},\"default\":{\"SEQUENCE\":\"nextval(\'\\\"Blog_id_seq\\\"\'::regclass)\"},\"autoIncrement\":true},{\"name\":\"string\",\"tpe\":{\"dataType\":\"text\",\"fullDataType\":\"text\",\"characterMaximumLength\":null,\"family\":\"string\",\"arity\":\"required\"},\"default\":null,\"autoIncrement\":false}],\"indices\":[],\"primaryKey\":{\"columns\":[\"id\"],\"sequence\":{\"name\":\"Blog_id_seq\",\"initialValue\":1,\"allocationSize\":1}},\"foreignKeys\":[]}],\"enums\":[],\"sequences\":[{\"name\":\"Blog_id_seq\",\"initialValue\":1,\"allocationSize\":1}]}".to_string());
+    assert_eq!(result, "{\"tables\":[{\"name\":\"Blog\",\"columns\":[{\"name\":\"id\",\"tpe\":{\"dataType\":\"integer\",\"fullDataType\":\"int4\",\"characterMaximumLength\":null,\"family\":\"int\",\"arity\":\"required\"},\"default\":{\"SEQUENCE\":\"nextval(\'\\\"Blog_id_seq\\\"\'::regclass)\"},\"autoIncrement\":true},{\"name\":\"string\",\"tpe\":{\"dataType\":\"text\",\"fullDataType\":\"text\",\"characterMaximumLength\":null,\"family\":\"string\",\"arity\":\"required\"},\"default\":null,\"autoIncrement\":false}],\"indices\":[],\"primaryKey\":{\"columns\":[\"id\"],\"sequence\":{\"name\":\"Blog_id_seq\",\"initialValue\":1,\"allocationSize\":1},\"constraintName\":\"Blog_pkey\"},\"foreignKeys\":[]}],\"enums\":[],\"sequences\":[{\"name\":\"Blog_id_seq\",\"initialValue\":1,\"allocationSize\":1}]}".to_string());
 }
 
 #[test_each_connector(tags("sqlite"))]
@@ -30,7 +31,7 @@ async fn database_description_for_sqlite_should_work(api: &TestApi) {
     let barrel = api.barrel();
     setup(&barrel, api.schema_name()).await;
     let result = dbg!(api.get_database_description().await);
-    assert_eq!(result, "{\"tables\":[{\"name\":\"Blog\",\"columns\":[{\"name\":\"id\",\"tpe\":{\"dataType\":\"INTEGER\",\"fullDataType\":\"INTEGER\",\"characterMaximumLength\":null,\"family\":\"int\",\"arity\":\"required\"},\"default\":null,\"autoIncrement\":true},{\"name\":\"string\",\"tpe\":{\"dataType\":\"TEXT\",\"fullDataType\":\"TEXT\",\"characterMaximumLength\":null,\"family\":\"string\",\"arity\":\"required\"},\"default\":null,\"autoIncrement\":false}],\"indices\":[],\"primaryKey\":{\"columns\":[\"id\"],\"sequence\":null},\"foreignKeys\":[]}],\"enums\":[],\"sequences\":[]}".to_string());
+    assert_eq!(result, "{\"tables\":[{\"name\":\"Blog\",\"columns\":[{\"name\":\"id\",\"tpe\":{\"dataType\":\"INTEGER\",\"fullDataType\":\"INTEGER\",\"characterMaximumLength\":null,\"family\":\"int\",\"arity\":\"required\"},\"default\":null,\"autoIncrement\":true},{\"name\":\"string\",\"tpe\":{\"dataType\":\"TEXT\",\"fullDataType\":\"TEXT\",\"characterMaximumLength\":null,\"family\":\"string\",\"arity\":\"required\"},\"default\":null,\"autoIncrement\":false}],\"indices\":[],\"primaryKey\":{\"columns\":[\"id\"],\"sequence\":null,\"constraintName\":null},\"foreignKeys\":[]}],\"enums\":[],\"sequences\":[]}".to_string());
 }
 
 async fn setup(barrel: &BarrelMigrationExecutor, db_name: &str) {

--- a/libs/sql-schema-describer/src/lib.rs
+++ b/libs/sql-schema-describer/src/lib.rs
@@ -200,6 +200,8 @@ pub struct PrimaryKey {
     pub columns: Vec<String>,
     /// The sequence optionally seeding this primary key.
     pub sequence: Option<Sequence>,
+    /// The name of the primary key constraint, when available.
+    pub constraint_name: Option<String>,
 }
 
 impl PrimaryKey {

--- a/libs/sql-schema-describer/src/mysql.rs
+++ b/libs/sql-schema-describer/src/mysql.rs
@@ -182,7 +182,7 @@ async fn get_all_columns(
                 column_name column_name,
                 data_type data_type,
                 column_type full_data_type,
-                character_maximum_length character_maximum_length, 
+                character_maximum_length character_maximum_length,
                 column_default column_default,
                 is_nullable is_nullable,
                 extra extra,
@@ -378,6 +378,7 @@ async fn get_all_indexes(
                         Some(PrimaryKey {
                             columns: vec![column_name],
                             sequence: None,
+                            constraint_name: None,
                         }),
                     );
                 }

--- a/libs/sql-schema-describer/src/postgres.rs
+++ b/libs/sql-schema-describer/src/postgres.rs
@@ -515,6 +515,7 @@ impl SqlSchemaDescriber {
                         entry.1 = Some(PrimaryKey {
                             columns: vec![column_name],
                             sequence,
+                            constraint_name: Some(name.clone()),
                         });
                     }
                 }

--- a/libs/sql-schema-describer/src/sqlite.rs
+++ b/libs/sql-schema-describer/src/sqlite.rs
@@ -248,6 +248,7 @@ impl SqlSchemaDescriber {
                 Some(PrimaryKey {
                     columns,
                     sequence: None,
+                    constraint_name: None,
                 })
             }
         };

--- a/libs/sql-schema-describer/tests/introspection_tests.rs
+++ b/libs/sql-schema-describer/tests/introspection_tests.rs
@@ -372,6 +372,11 @@ async fn composite_primary_keys_must_work(api: &TestApi) {
             primary_key: Some(PrimaryKey {
                 columns: vec!["id".to_string(), "name".to_string()],
                 sequence: None,
+                constraint_name: if api.sql_family().is_postgres() {
+                    Some("User_pkey".into())
+                } else {
+                    None
+                },
             }),
             foreign_keys: vec![],
         }
@@ -445,6 +450,11 @@ async fn indices_must_work(api: &TestApi) {
             primary_key: Some(PrimaryKey {
                 columns: vec!["id".to_string()],
                 sequence: pk_sequence,
+                constraint_name: if api.sql_family().is_postgres() {
+                    Some("User_pkey".into())
+                } else {
+                    None
+                },
             }),
             foreign_keys: vec![],
         }

--- a/libs/sql-schema-describer/tests/mysql_introspection_tests.rs
+++ b/libs/sql-schema-describer/tests/mysql_introspection_tests.rs
@@ -581,6 +581,7 @@ async fn all_mysql_column_types_must_work() {
             primary_key: Some(PrimaryKey {
                 columns: vec!["primary_col".to_string()],
                 sequence: None,
+                constraint_name: None,
             }),
             foreign_keys: vec![],
         }
@@ -702,6 +703,7 @@ async fn mysql_foreign_key_on_delete_must_be_handled() {
             primary_key: Some(PrimaryKey {
                 columns: vec!["id".to_string()],
                 sequence: None,
+                constraint_name: None,
             }),
             foreign_keys: vec![
                 ForeignKey {

--- a/libs/sql-schema-describer/tests/postgres_introspection_tests.rs
+++ b/libs/sql-schema-describer/tests/postgres_introspection_tests.rs
@@ -687,6 +687,7 @@ async fn all_postgres_column_types_must_work() {
                     initial_value: 1,
                     allocation_size: 1,
                 },),
+                constraint_name: Some("User_pkey".into()),
             }),
             foreign_keys: vec![],
         }
@@ -803,6 +804,7 @@ async fn postgres_foreign_key_on_delete_must_be_handled() {
             primary_key: Some(PrimaryKey {
                 columns: vec!["id".into()],
                 sequence: None,
+                constraint_name: Some("User_pkey".into()),
             }),
             foreign_keys: vec![
                 ForeignKey {

--- a/libs/sql-schema-describer/tests/serialization_tests.rs
+++ b/libs/sql-schema-describer/tests/serialization_tests.rs
@@ -72,6 +72,7 @@ fn database_schema_is_serializable() {
                 primary_key: Some(PrimaryKey {
                     columns: vec!["column1".to_string()],
                     sequence: None,
+                    constraint_name: None,
                 }),
                 foreign_keys: vec![ForeignKey {
                     constraint_name: None,
@@ -100,6 +101,7 @@ fn database_schema_is_serializable() {
                 primary_key: Some(PrimaryKey {
                     columns: vec!["id".to_string()],
                     sequence: None,
+                    constraint_name: None,
                 }),
                 foreign_keys: vec![],
             },

--- a/libs/sql-schema-describer/tests/sqlite_introspection_tests.rs
+++ b/libs/sql-schema-describer/tests/sqlite_introspection_tests.rs
@@ -111,6 +111,7 @@ async fn sqlite_column_types_must_work() {
             primary_key: Some(PrimaryKey {
                 columns: vec!["primary_col".to_string()],
                 sequence: None,
+                constraint_name: None,
             }),
             foreign_keys: vec![],
         }
@@ -220,6 +221,7 @@ async fn sqlite_foreign_key_on_delete_must_be_handled() {
             primary_key: Some(PrimaryKey {
                 columns: vec!["id".to_string()],
                 sequence: None,
+                constraint_name: None,
             }),
             foreign_keys: vec![
                 ForeignKey {
@@ -291,7 +293,8 @@ async fn sqlite_text_primary_keys_must_be_inferred_on_table_and_not_as_separate_
         table.primary_key.as_ref().unwrap(),
         &PrimaryKey {
             columns: vec!["primary_col".to_owned()],
-            sequence: None
+            sequence: None,
+            constraint_name: None,
         }
     );
 }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_migration_inferrer/sqlite.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_migration_inferrer/sqlite.rs
@@ -41,6 +41,9 @@ pub(super) fn fix(
             SqlMigrationStep::AddForeignKey(add_foreign_key) if fixed_tables.contains(&add_foreign_key.table) => {
                 // The fixed alter table step will already create the foreign key.
             }
+            SqlMigrationStep::DropForeignKey(drop_foreign_key) if fixed_tables.contains(&drop_foreign_key.table) => {
+                // The fixed alter table step will already create the foreign key.
+            }
             SqlMigrationStep::CreateIndex(ref create_index) if fixed_tables.contains(&create_index.table) => {
                 // The fixed alter table step will already create the index.
             }
@@ -82,9 +85,10 @@ fn needs_fix(alter_table: &AlterTable) -> bool {
             // https://laracasts.com/discuss/channels/general-discussion/migrations-sqlite-general-error-1-cannot-add-a-not-null-column-with-default-value-null
             add_column.column.tpe.arity == ColumnArity::Required
         }
-        TableChange::DropColumn(_) => true,
-        TableChange::AlterColumn(_) => true,
-        TableChange::DropForeignKey(_) => true,
+        TableChange::DropColumn(_)
+        | TableChange::AlterColumn(_)
+        | TableChange::DropPrimaryKey { .. }
+        | TableChange::AddPrimaryKey { .. } => true,
     });
 
     change_that_does_not_work_on_sqlite.is_some()

--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
@@ -242,10 +242,41 @@ fn render_raw_sql(
                 Ok(vec![add_constraint])
             }
         },
+        SqlMigrationStep::DropForeignKey(DropForeignKey { table, constraint_name }) => match sql_family {
+            SqlFamily::Mysql => Ok(vec![format!(
+                "ALTER TABLE {table} DROP FOREIGN KEY {constraint_name}",
+                table = renderer.quote_with_schema(&schema_name, table),
+                constraint_name = Quoted::mysql_ident(constraint_name),
+            )]),
+            SqlFamily::Postgres => Ok(vec![format!(
+                "ALTER TABLE {table} DROP CONSTRAINT {constraint_name}",
+                table = renderer.quote_with_schema(&schema_name, table),
+                constraint_name = Quoted::postgres_ident(constraint_name),
+            )]),
+            SqlFamily::Sqlite => Ok(Vec::new()),
+            SqlFamily::Mssql => todo!("Greetings from Redmond"),
+        },
+
         SqlMigrationStep::AlterTable(AlterTable { table, changes }) => {
             let mut lines = Vec::new();
             for change in changes {
                 match change {
+                    TableChange::DropPrimaryKey { constraint_name } => match renderer.sql_family() {
+                        SqlFamily::Mysql => lines.push(format!("DROP PRIMARY KEY")),
+                        SqlFamily::Postgres => lines.push(format!(
+                            "DROP CONSTRAINT {}",
+                            Quoted::postgres_ident(
+                                constraint_name
+                                    .as_ref()
+                                    .expect("Missing constraint name for DROP CONSTRAINT on Postgres.")
+                            )
+                        )),
+                        _ => (),
+                    },
+                    TableChange::AddPrimaryKey { columns } => lines.push(format!(
+                        "ADD PRIMARY KEY ({})",
+                        columns.iter().map(|colname| renderer.quote(colname)).join(", ")
+                    )),
                     TableChange::AddColumn(AddColumn { column }) => {
                         let column = ColumnRef {
                             table,
@@ -285,18 +316,6 @@ fn render_raw_sql(
                             }
                         }
                     }
-                    TableChange::DropForeignKey(DropForeignKey { constraint_name }) => match sql_family {
-                        SqlFamily::Mysql => {
-                            let constraint_name = renderer.quote(&constraint_name);
-                            lines.push(format!("DROP FOREIGN KEY {}", constraint_name));
-                        }
-                        SqlFamily::Postgres => {
-                            let constraint_name = renderer.quote(&constraint_name);
-                            lines.push(format!("DROP CONSTRAINT IF EXiSTS {}", constraint_name));
-                        }
-                        SqlFamily::Sqlite => (),
-                        SqlFamily::Mssql => todo!("Greetings from Redmond"),
-                    },
                 };
             }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker.rs
@@ -159,6 +159,11 @@ impl SqlDestructiveChangesChecker<'_> {
                                 TableChange::AddColumn(ref add_column) => {
                                     self.check_add_column(add_column, &before_table.table, &mut plan)
                                 }
+                                TableChange::DropPrimaryKey { .. } => {
+                                    plan.push_warning(SqlMigrationWarning::PrimaryKeyChange {
+                                        table: alter_table.table.name.clone(),
+                                    })
+                                }
                                 _ => (),
                             }
                         }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker.rs
@@ -16,7 +16,7 @@ use destructive_check_plan::DestructiveCheckPlan;
 use migration_connector::{ConnectorResult, DestructiveChangeDiagnostics, DestructiveChangesChecker};
 use sql_schema_describer::SqlSchema;
 use unexecutable_step_check::UnexecutableStepCheck;
-use warning_check::SqlMigrationWarning;
+use warning_check::SqlMigrationWarningCheck;
 
 /// The SqlDestructiveChangesChecker is responsible for informing users about potentially
 /// destructive or impossible changes that their attempted migrations contain.
@@ -41,7 +41,7 @@ impl Component for SqlDestructiveChangesChecker<'_> {
 
 impl SqlDestructiveChangesChecker<'_> {
     fn check_table_drop(&self, table_name: &str, plan: &mut DestructiveCheckPlan) {
-        plan.push_warning(SqlMigrationWarning::NonEmptyTableDrop {
+        plan.push_warning(SqlMigrationWarningCheck::NonEmptyTableDrop {
             table: table_name.to_owned(),
         });
     }
@@ -53,7 +53,7 @@ impl SqlDestructiveChangesChecker<'_> {
         table: &sql_schema_describer::Table,
         plan: &mut DestructiveCheckPlan,
     ) {
-        plan.push_warning(SqlMigrationWarning::NonEmptyColumnDrop {
+        plan.push_warning(SqlMigrationWarningCheck::NonEmptyColumnDrop {
             table: table.name.clone(),
             column: drop_column.name.clone(),
         });
@@ -108,7 +108,7 @@ impl SqlDestructiveChangesChecker<'_> {
             && alter_column.column.default.is_none()
             && differ.previous.default().is_some()
         {
-            plan.push_warning(SqlMigrationWarning::ForeignKeyDefaultValueRemoved {
+            plan.push_warning(SqlMigrationWarningCheck::ForeignKeyDefaultValueRemoved {
                 table: previous_table.name.clone(),
                 column: alter_column.name.clone(),
             });
@@ -160,7 +160,7 @@ impl SqlDestructiveChangesChecker<'_> {
                                     self.check_add_column(add_column, &before_table.table, &mut plan)
                                 }
                                 TableChange::DropPrimaryKey { .. } => {
-                                    plan.push_warning(SqlMigrationWarning::PrimaryKeyChange {
+                                    plan.push_warning(SqlMigrationWarningCheck::PrimaryKeyChange {
                                         table: alter_table.table.name.clone(),
                                     })
                                 }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/destructive_change_checker_flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/destructive_change_checker_flavour/mysql.rs
@@ -4,7 +4,7 @@ use crate::{
     flavour::MysqlFlavour,
     sql_destructive_changes_checker::{
         destructive_check_plan::DestructiveCheckPlan, unexecutable_step_check::UnexecutableStepCheck,
-        warning_check::SqlMigrationWarning,
+        warning_check::SqlMigrationWarningCheck,
     },
     sql_schema_differ::ColumnDiffer,
 };
@@ -28,7 +28,7 @@ impl DestructiveChangeCheckerFlavour for MysqlFlavour {
                         table: previous_table.name.clone(),
                     });
                 } else {
-                    plan.push_warning(SqlMigrationWarning::AlterColumn {
+                    plan.push_warning(SqlMigrationWarningCheck::AlterColumn {
                         table: previous_table.name.clone(),
                         column: columns.next.name().to_owned(),
                     });

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/destructive_change_checker_flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/destructive_change_checker_flavour/postgres.rs
@@ -4,7 +4,7 @@ use crate::{
     flavour::PostgresFlavour,
     sql_destructive_changes_checker::{
         destructive_check_plan::DestructiveCheckPlan, unexecutable_step_check::UnexecutableStepCheck,
-        warning_check::SqlMigrationWarning,
+        warning_check::SqlMigrationWarningCheck,
     },
     sql_schema_differ::ColumnDiffer,
 };
@@ -33,7 +33,7 @@ impl DestructiveChangeCheckerFlavour for PostgresFlavour {
                                 column: columns.previous.name().to_owned(),
                             })
                         } else {
-                            plan.push_warning(SqlMigrationWarning::AlterColumn {
+                            plan.push_warning(SqlMigrationWarningCheck::AlterColumn {
                                 table: previous_table.name.clone(),
                                 column: columns.previous.name().to_owned(),
                             });
@@ -57,7 +57,7 @@ impl DestructiveChangeCheckerFlavour for PostgresFlavour {
                 })
             } else {
                 // Executable drop and recreate.
-                plan.push_warning(SqlMigrationWarning::AlterColumn {
+                plan.push_warning(SqlMigrationWarningCheck::AlterColumn {
                     table: previous_table.name.clone(),
                     column: columns.next.name().to_owned(),
                 });

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/destructive_change_checker_flavour/sqlite.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/destructive_change_checker_flavour/sqlite.rs
@@ -3,7 +3,7 @@ use crate::{
     flavour::SqliteFlavour,
     sql_destructive_changes_checker::{
         destructive_check_plan::DestructiveCheckPlan, unexecutable_step_check::UnexecutableStepCheck,
-        warning_check::SqlMigrationWarning,
+        warning_check::SqlMigrationWarningCheck,
     },
     sql_schema_differ::ColumnDiffer,
 };
@@ -36,7 +36,7 @@ impl DestructiveChangeCheckerFlavour for SqliteFlavour {
             });
         }
 
-        plan.push_warning(SqlMigrationWarning::AlterColumn {
+        plan.push_warning(SqlMigrationWarningCheck::AlterColumn {
             table: previous_table.name.clone(),
             column: columns.next.name().to_owned(),
         });

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/destructive_check_plan.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/destructive_check_plan.rs
@@ -1,6 +1,6 @@
 use super::{
     check::Check, database_inspection_results::DatabaseInspectionResults,
-    unexecutable_step_check::UnexecutableStepCheck, warning_check::SqlMigrationWarning,
+    unexecutable_step_check::UnexecutableStepCheck, warning_check::SqlMigrationWarningCheck,
 };
 use crate::{SqlError, SqlResult};
 use migration_connector::{DestructiveChangeDiagnostics, MigrationWarning, UnexecutableMigration};
@@ -15,7 +15,7 @@ const DESTRUCTIVE_TIMEOUT_DURATION: Duration = Duration::from_secs(60);
 /// database inspection and renders user-facing messages based on the checks.
 #[derive(Debug)]
 pub(crate) struct DestructiveCheckPlan {
-    warnings: Vec<SqlMigrationWarning>,
+    warnings: Vec<SqlMigrationWarningCheck>,
     unexecutable_migrations: Vec<UnexecutableStepCheck>,
 }
 
@@ -27,7 +27,7 @@ impl DestructiveCheckPlan {
         }
     }
 
-    pub(super) fn push_warning(&mut self, warning: SqlMigrationWarning) {
+    pub(super) fn push_warning(&mut self, warning: SqlMigrationWarningCheck) {
         self.warnings.push(warning)
     }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/warning_check.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/warning_check.rs
@@ -43,7 +43,7 @@ impl Check for SqlMigrationWarning {
             SqlMigrationWarning::AlterColumn { table, column } => match database_check_results.get_row_and_non_null_value_count(table, column) {
                 (Some(0), _) => None, // it's safe to alter a column on an empty table
                 (_, Some(0)) => None, // it's safe to alter a column if it only contains null values
-                (_, Some(value_count)) => Some(format!("You are about to alter the column `{column_name}` on the `{table_name}` table, which still contains {value_count} non-null values. The data in that column will be lost.", column_name = column, table_name = table, value_count = value_count)),
+                (_, Some(value_count)) => Some(format!("You are about to alter the column `{column_name}` on the `{table_name}` table, which still contains {value_count} non-null values. The data in that column could be lost.", column_name = column, table_name = table, value_count = value_count)),
                 (_, _) => Some(format!("You are about to alter the column `{column_name}` on the `{table_name}` table. The data in that column could be lost.", column_name = column, table_name = table)),
 
             },

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/warning_check.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/warning_check.rs
@@ -1,7 +1,7 @@
 use super::{check::Check, database_inspection_results::DatabaseInspectionResults};
 
 #[derive(Debug)]
-pub(super) enum SqlMigrationWarning {
+pub(super) enum SqlMigrationWarningCheck {
     NonEmptyColumnDrop { table: String, column: String },
     NonEmptyTableDrop { table: String },
     AlterColumn { table: String, column: String },
@@ -9,50 +9,49 @@ pub(super) enum SqlMigrationWarning {
     PrimaryKeyChange { table: String },
 }
 
-impl Check for SqlMigrationWarning {
+impl Check for SqlMigrationWarningCheck {
     fn needed_table_row_count(&self) -> Option<&str> {
         match self {
-            SqlMigrationWarning::NonEmptyTableDrop { table } | SqlMigrationWarning::PrimaryKeyChange { table } => {
-                Some(table)
-            }
-            SqlMigrationWarning::NonEmptyColumnDrop { .. }
-            | SqlMigrationWarning::AlterColumn { .. }
-            | SqlMigrationWarning::ForeignKeyDefaultValueRemoved { .. } => None,
+            SqlMigrationWarningCheck::NonEmptyTableDrop { table }
+            | SqlMigrationWarningCheck::PrimaryKeyChange { table } => Some(table),
+            SqlMigrationWarningCheck::NonEmptyColumnDrop { .. }
+            | SqlMigrationWarningCheck::AlterColumn { .. }
+            | SqlMigrationWarningCheck::ForeignKeyDefaultValueRemoved { .. } => None,
         }
     }
 
     fn needed_column_value_count(&self) -> Option<(&str, &str)> {
         match self {
-            SqlMigrationWarning::NonEmptyColumnDrop { table, column }
-            | SqlMigrationWarning::AlterColumn { table, column } => Some((table, column)),
-            SqlMigrationWarning::ForeignKeyDefaultValueRemoved { .. }
-            | SqlMigrationWarning::NonEmptyTableDrop { .. }
-            | SqlMigrationWarning::PrimaryKeyChange { .. } => None,
+            SqlMigrationWarningCheck::NonEmptyColumnDrop { table, column }
+            | SqlMigrationWarningCheck::AlterColumn { table, column } => Some((table, column)),
+            SqlMigrationWarningCheck::ForeignKeyDefaultValueRemoved { .. }
+            | SqlMigrationWarningCheck::NonEmptyTableDrop { .. }
+            | SqlMigrationWarningCheck::PrimaryKeyChange { .. } => None,
         }
     }
 
     fn evaluate(&self, database_check_results: &DatabaseInspectionResults) -> Option<String> {
         match self {
-            SqlMigrationWarning::NonEmptyTableDrop { table } => match database_check_results.get_row_count(table) {
+            SqlMigrationWarningCheck::NonEmptyTableDrop { table } => match database_check_results.get_row_count(table) {
                 Some(0) => None, // dropping the table is safe if it's empty
                 Some(rows_count) => Some(format!("You are about to drop the `{table_name}` table, which is not empty ({rows_count} rows).", table_name = table, rows_count = rows_count)),
                 None => Some(format!("You are about to drop the `{}` table. If the table is not empty, all the data it contains will be lost.", table)),
             },
-            SqlMigrationWarning::NonEmptyColumnDrop { table, column } => match database_check_results.get_row_and_non_null_value_count(table, column) {
+            SqlMigrationWarningCheck::NonEmptyColumnDrop { table, column } => match database_check_results.get_row_and_non_null_value_count(table, column) {
                 (Some(0), _) => None, // it's safe to drop a column on an empty table
                 (_, Some(0)) => None, // it's safe to drop a column if it only contains null values
                 (_, Some(value_count)) => Some(format!("You are about to drop the column `{column_name}` on the `{table_name}` table, which still contains {value_count} non-null values.", column_name = column, table_name = table, value_count = value_count)),
                 (_, _) => Some(format!("You are about to drop the column `{column_name}` on the `{table_name}` table. All the data in the column will be lost.", column_name = column, table_name = table)),
             },
-            SqlMigrationWarning::AlterColumn { table, column } => match database_check_results.get_row_and_non_null_value_count(table, column) {
+            SqlMigrationWarningCheck::AlterColumn { table, column } => match database_check_results.get_row_and_non_null_value_count(table, column) {
                 (Some(0), _) => None, // it's safe to alter a column on an empty table
                 (_, Some(0)) => None, // it's safe to alter a column if it only contains null values
                 (_, Some(value_count)) => Some(format!("You are about to alter the column `{column_name}` on the `{table_name}` table, which still contains {value_count} non-null values. The data in that column could be lost.", column_name = column, table_name = table, value_count = value_count)),
                 (_, _) => Some(format!("You are about to alter the column `{column_name}` on the `{table_name}` table. The data in that column could be lost.", column_name = column, table_name = table)),
 
             },
-            SqlMigrationWarning::ForeignKeyDefaultValueRemoved { table, column } => Some(format!("The migration is about to remove a default value on the foreign key field `{}.{}`.", table, column)),
-            SqlMigrationWarning::PrimaryKeyChange { table } => match database_check_results.get_row_count(table) {
+            SqlMigrationWarningCheck::ForeignKeyDefaultValueRemoved { table, column } => Some(format!("The migration is about to remove a default value on the foreign key field `{}.{}`.", table, column)),
+            SqlMigrationWarningCheck::PrimaryKeyChange { table } => match database_check_results.get_row_count(table) {
                 Some(0) => None,
                 _ => Some(format!("The migration will change the primary key for the `{table}` table. If it partially fails, the table could be left without primary key constraint.", table = table)),
             }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/warning_check.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/warning_check.rs
@@ -44,7 +44,7 @@ impl Check for SqlMigrationWarning {
                 (Some(0), _) => None, // it's safe to alter a column on an empty table
                 (_, Some(0)) => None, // it's safe to alter a column if it only contains null values
                 (_, Some(value_count)) => Some(format!("You are about to alter the column `{column_name}` on the `{table_name}` table, which still contains {value_count} non-null values. The data in that column will be lost.", column_name = column, table_name = table, value_count = value_count)),
-                (_, _) => Some(format!("You are about to alter the column `{column_name}` on the `{table_name}` table. The data in that column will be lost.", column_name = column, table_name = table)),
+                (_, _) => Some(format!("You are about to alter the column `{column_name}` on the `{table_name}` table. The data in that column could be lost.", column_name = column, table_name = table)),
 
             },
             SqlMigrationWarning::ForeignKeyDefaultValueRemoved { table, column } => Some(format!("The migration is about to remove a default value on the foreign key field `{}.{}`.", table, column)),

--- a/migration-engine/connectors/sql-migration-connector/src/sql_migration.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_migration.rs
@@ -39,6 +39,7 @@ pub enum SqlMigrationStep {
     AddForeignKey(AddForeignKey),
     CreateTable(CreateTable),
     AlterTable(AlterTable),
+    DropForeignKey(DropForeignKey),
     DropTable(DropTable),
     RenameTable { name: String, new_name: String },
     RawSql { raw: String },
@@ -71,7 +72,8 @@ pub enum TableChange {
     AddColumn(AddColumn),
     AlterColumn(AlterColumn),
     DropColumn(DropColumn),
-    DropForeignKey(DropForeignKey),
+    DropPrimaryKey { constraint_name: Option<String> },
+    AddPrimaryKey { columns: Vec<String> },
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
@@ -98,6 +100,7 @@ pub struct AddForeignKey {
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct DropForeignKey {
+    pub table: String,
     pub constraint_name: String,
 }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
@@ -119,13 +119,14 @@ impl<'a> SqlSchemaCalculator<'a> {
                 })
                 .collect();
 
-            let primary_key = sql::PrimaryKey {
+            let primary_key = Some(sql::PrimaryKey {
                 columns: model
                     .id_fields()
                     .map(|field| field.db_name().to_owned())
                     .collect(),
                 sequence: None,
-            };
+                constraint_name: None,
+            }).filter(|pk| !pk.columns.is_empty());
 
             let single_field_indexes = model.fields().filter_map(|f| {
                 if f.is_unique() {
@@ -172,7 +173,7 @@ impl<'a> SqlSchemaCalculator<'a> {
                 name: model.database_name().to_owned(),
                 columns,
                 indices: single_field_indexes.chain(multiple_field_indexes).collect(),
-                primary_key: Some(primary_key),
+                primary_key,
                 foreign_keys: Vec::new(),
             };
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
@@ -251,7 +251,7 @@ impl<'schema> SqlSchemaDiffer<'schema> {
             .created_primary_key()
             .filter(|pk| !pk.columns.is_empty())
             .map(|pk| TableChange::AddPrimaryKey {
-                columns: dbg!(pk).columns.clone(),
+                columns: pk.columns.clone(),
             })
     }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
@@ -11,8 +11,8 @@ use enums::EnumDiffer;
 use once_cell::sync::Lazy;
 use regex::RegexSet;
 use sql_schema_describer::*;
+use sql_schema_helpers::ForeignKeyRef;
 use sql_schema_helpers::TableRef;
-use tracing::debug;
 
 #[derive(Debug)]
 pub(crate) struct DiffingOptions {
@@ -53,6 +53,7 @@ pub struct SqlSchemaDiffer<'a> {
 #[derive(Debug, Clone)]
 pub struct SqlSchemaDiff {
     pub add_foreign_keys: Vec<AddForeignKey>,
+    pub drop_foreign_keys: Vec<DropForeignKey>,
     pub drop_tables: Vec<DropTable>,
     pub create_tables: Vec<CreateTable>,
     pub alter_tables: Vec<AlterTable>,
@@ -65,15 +66,14 @@ pub struct SqlSchemaDiff {
 }
 
 impl SqlSchemaDiff {
+    /// Translate the diff into steps that should be executed in order. The general idea in the
+    /// ordering of steps is to drop obsolete constraints first, alter/create tables, then add the new constraints.
     pub fn into_steps(self) -> Vec<SqlMigrationStep> {
         wrap_as_step(self.create_enums, SqlMigrationStep::CreateEnum)
             .chain(wrap_as_step(self.alter_enums, SqlMigrationStep::AlterEnum))
             .chain(wrap_as_step(self.drop_indexes, SqlMigrationStep::DropIndex))
-            // Order matters: we must create tables before `alter_table`s because we could
-            // be adding foreign keys to the new tables there.
+            .chain(wrap_as_step(self.drop_foreign_keys, SqlMigrationStep::DropForeignKey))
             .chain(wrap_as_step(self.create_tables, SqlMigrationStep::CreateTable))
-            // Order matters: we must run `alter table`s before `drop`s because we want to
-            // drop foreign keys before the tables they are pointing to.
             .chain(wrap_as_step(self.alter_tables, SqlMigrationStep::AlterTable))
             // Order matters: we must create indexes after ALTER TABLEs because the indexes can be
             // on fields that are dropped/created there.
@@ -106,15 +106,15 @@ impl<'schema> SqlSchemaDiffer<'schema> {
 
     fn diff_internal(&self) -> SqlSchemaDiff {
         let alter_indexes: Vec<_> = self.alter_indexes();
-        let (drop_tables, drop_foreign_keys) = self.drop_tables();
-        let mut alter_tables = self.alter_tables();
-        alter_tables.extend(drop_foreign_keys.into_iter());
+        let (drop_tables, mut drop_foreign_keys) = self.drop_tables();
+        self.drop_foreign_keys(&mut drop_foreign_keys);
 
         SqlSchemaDiff {
             add_foreign_keys: self.add_foreign_keys(),
+            drop_foreign_keys,
             drop_tables,
             create_tables: self.create_tables(),
-            alter_tables,
+            alter_tables: self.alter_tables(),
             create_indexes: self.create_indexes(),
             drop_indexes: self.drop_indexes(),
             alter_indexes,
@@ -134,7 +134,7 @@ impl<'schema> SqlSchemaDiffer<'schema> {
 
     // We drop the foreign keys of dropped tables first, so we can drop tables in whatever order we
     // please later.
-    fn drop_tables(&self) -> (Vec<DropTable>, Vec<AlterTable>) {
+    fn drop_tables(&self) -> (Vec<DropTable>, Vec<DropForeignKey>) {
         let (dropped_tables_count, dropped_fks_count) = self.dropped_tables().fold((0, 0), |(tables, fks), item| {
             (tables + 1, fks + item.foreign_keys.len())
         });
@@ -153,14 +153,12 @@ impl<'schema> SqlSchemaDiffer<'schema> {
                 .iter()
                 .filter_map(|fk| fk.constraint_name.as_ref())
             {
-                let alter_table = AlterTable {
-                    table: dropped_table.clone(),
-                    changes: vec![TableChange::DropForeignKey(DropForeignKey {
-                        constraint_name: fk_name.clone(),
-                    })],
+                let drop_foreign_key = DropForeignKey {
+                    table: dropped_table.name.clone(),
+                    constraint_name: fk_name.clone(),
                 };
 
-                dropped_foreign_keys.push(alter_table);
+                dropped_foreign_keys.push(drop_foreign_key);
             }
         }
 
@@ -177,24 +175,23 @@ impl<'schema> SqlSchemaDiffer<'schema> {
     }
 
     fn alter_tables(&self) -> Vec<AlterTable> {
-        // TODO: this does not diff primary key columns yet
         self.table_pairs()
-            .filter_map(|differ| {
-                let changes: Vec<TableChange> = Self::drop_foreign_keys(&differ)
-                    .chain(Self::drop_columns(&differ))
-                    .chain(Self::add_columns(&differ))
-                    .chain(Self::alter_columns(&differ))
+            .filter_map(|tables| {
+                // Order matters.
+                let changes: Vec<TableChange> = Self::drop_primary_key(&tables)
+                    .into_iter()
+                    .chain(Self::drop_columns(&tables))
+                    .chain(Self::add_columns(&tables))
+                    .chain(Self::alter_columns(&tables))
+                    .chain(Self::add_primary_key(&tables))
                     .collect();
 
-                if !changes.is_empty() {
-                    let update = AlterTable {
-                        table: differ.next.table.clone(),
+                Some(changes)
+                    .filter(|changes| !changes.is_empty())
+                    .map(|changes| AlterTable {
+                        table: tables.next.table.clone(),
                         changes,
-                    };
-                    return Some(update);
-                }
-
-                None
+                    })
             })
             .collect()
     }
@@ -221,13 +218,7 @@ impl<'schema> SqlSchemaDiffer<'schema> {
 
     fn alter_columns<'a>(table_differ: &'a TableDiffer<'schema>) -> impl Iterator<Item = TableChange> + 'a {
         table_differ.column_pairs().filter_map(move |column_differ| {
-            let previous_fk = table_differ
-                .previous
-                .foreign_key_for_column(column_differ.previous.name());
-
-            let next_fk = table_differ.next.foreign_key_for_column(column_differ.next.name());
-
-            if column_differ.differs_in_something() || foreign_key_changed(previous_fk, next_fk) {
+            if column_differ.differs_in_something() {
                 let change = AlterColumn {
                     name: column_differ.previous.name().to_owned(),
                     column: column_differ.next.column.clone(),
@@ -240,21 +231,34 @@ impl<'schema> SqlSchemaDiffer<'schema> {
         })
     }
 
-    fn drop_foreign_keys<'a>(differ: &'a TableDiffer<'schema>) -> impl Iterator<Item = TableChange> + 'a {
+    fn drop_foreign_keys<'a>(&'a self, drop_foreign_keys: &mut Vec<DropForeignKey>) {
+        for differ in self.table_pairs() {
+            let table_name = differ.previous.name();
+            for dropped_foreign_key_name in differ
+                .dropped_foreign_keys()
+                .filter_map(|foreign_key| foreign_key.constraint_name())
+            {
+                drop_foreign_keys.push(DropForeignKey {
+                    table: table_name.to_owned(),
+                    constraint_name: dropped_foreign_key_name.to_owned(),
+                })
+            }
+        }
+    }
+
+    fn add_primary_key(differ: &TableDiffer<'_>) -> Option<TableChange> {
         differ
-            .dropped_foreign_keys()
-            .filter_map(|foreign_key| foreign_key.constraint_name.as_ref())
-            .map(move |dropped_foreign_key_name| {
-                debug!(
-                    "Dropping foreign key '{}' on table '{}'",
-                    &dropped_foreign_key_name,
-                    &differ.previous.name()
-                );
-                let drop_step = DropForeignKey {
-                    constraint_name: dropped_foreign_key_name.clone(),
-                };
-                TableChange::DropForeignKey(drop_step)
+            .created_primary_key()
+            .filter(|pk| !pk.columns.is_empty())
+            .map(|pk| TableChange::AddPrimaryKey {
+                columns: dbg!(pk).columns.clone(),
             })
+    }
+
+    fn drop_primary_key(differ: &TableDiffer<'_>) -> Option<TableChange> {
+        differ.dropped_primary_key().map(|pk| TableChange::DropPrimaryKey {
+            constraint_name: pk.constraint_name.clone(),
+        })
     }
 
     fn create_indexes(&self) -> Vec<CreateIndex> {
@@ -438,7 +442,7 @@ fn push_created_foreign_keys<'a, 'schema>(
     table_pairs.for_each(|differ| {
         added_foreign_keys.extend(differ.created_foreign_keys().map(|created_fk| AddForeignKey {
             table: differ.next.name().to_owned(),
-            foreign_key: created_fk.clone(),
+            foreign_key: created_fk.inner().clone(),
         }))
     })
 }
@@ -455,23 +459,34 @@ fn push_foreign_keys_from_created_tables<'a>(
     }
 }
 
-/// Compare two [ForeignKey](/sql-schema-describer/struct.ForeignKey.html)s and return whether a
-/// migration needs to be applied.
-fn foreign_key_changed(previous: Option<&ForeignKey>, next: Option<&ForeignKey>) -> bool {
-    match (previous, next) {
-        (None, None) => false,
-        (Some(previous), Some(next)) => !foreign_keys_match(previous, next),
-        _ => true,
-    }
-}
-
 /// Compare two [ForeignKey](/sql-schema-describer/struct.ForeignKey.html)s and return whether they
 /// should be considered equivalent for schema diffing purposes.
-fn foreign_keys_match(previous: &ForeignKey, next: &ForeignKey) -> bool {
-    previous.referenced_table == next.referenced_table
-        && previous.referenced_columns == next.referenced_columns
-        && previous.columns == next.columns
-        && previous.on_delete_action == next.on_delete_action
+fn foreign_keys_match(previous: &ForeignKeyRef<'_, '_>, next: &ForeignKeyRef<'_, '_>) -> bool {
+    // Foreign keys point to different tables.
+    if previous.referenced_table().name() != next.referenced_table().name() {
+        return false;
+    }
+
+    // Foreign keys point to different columns.
+    if previous.referenced_columns_count() != next.referenced_columns_count() {
+        return false;
+    }
+
+    // Foreign keys constrain different columns.
+    if previous.constrained_columns().count() != next.constrained_columns().count() {
+        return false;
+    }
+
+    // Foreign keys constrain the same columns in a different order, or their types changed.
+    for (previous_column, next_column) in previous.constrained_columns().zip(next.constrained_columns()) {
+        if previous_column.name() != next_column.name()
+            || previous_column.column_type_family() != next_column.column_type_family()
+        {
+            return false;
+        }
+    }
+
+    true
 }
 
 fn tables_match(previous: &Table, next: &Table) -> bool {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/table.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/table.rs
@@ -40,7 +40,7 @@ impl<'schema> TableDiffer<'schema> {
         })
     }
 
-    pub(crate) fn created_foreign_keys<'a>(&'a self) -> impl Iterator<Item = ForeignKeyRef<'a, 'schema>> + 'a {
+    pub(crate) fn created_foreign_keys(&self) -> impl Iterator<Item = ForeignKeyRef<'_, 'schema>> {
         self.next_foreign_keys().filter(move |next_fk| {
             self.previous_foreign_keys()
                 .find(|previous_fk| super::foreign_keys_match(previous_fk, next_fk))
@@ -48,7 +48,7 @@ impl<'schema> TableDiffer<'schema> {
         })
     }
 
-    pub(crate) fn dropped_foreign_keys<'a>(&'a self) -> impl Iterator<Item = ForeignKeyRef<'a, 'schema>> + 'a {
+    pub(crate) fn dropped_foreign_keys(&self) -> impl Iterator<Item = ForeignKeyRef<'_, 'schema>> {
         self.previous_foreign_keys().filter(move |previous_fk| {
             self.next_foreign_keys()
                 .find(|next_fk| super::foreign_keys_match(previous_fk, next_fk))
@@ -80,6 +80,7 @@ impl<'schema> TableDiffer<'schema> {
         })
     }
 
+    /// The primary key present in `next` but not `previous`, if applicable.
     pub(crate) fn created_primary_key(&self) -> Option<&'schema PrimaryKey> {
         match (self.previous.primary_key(), self.next.primary_key()) {
             (None, Some(pk)) => Some(pk),
@@ -95,6 +96,7 @@ impl<'schema> TableDiffer<'schema> {
         }
     }
 
+    /// The primary key present in `previous` but not `next`, if applicable.
     pub(crate) fn dropped_primary_key(&self) -> Option<&'schema PrimaryKey> {
         match (self.previous.primary_key(), self.next.primary_key()) {
             (Some(pk), None) => Some(pk),

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/table.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/table.rs
@@ -1,6 +1,7 @@
 use super::column::ColumnDiffer;
+use crate::sql_schema_helpers::ForeignKeyRef;
 use crate::sql_schema_helpers::{ColumnRef, TableRef};
-use sql_schema_describer::{ForeignKey, Index};
+use sql_schema_describer::{Index, PrimaryKey};
 
 pub(crate) struct TableDiffer<'a> {
     pub(crate) diffing_options: &'a super::DiffingOptions,
@@ -39,7 +40,7 @@ impl<'schema> TableDiffer<'schema> {
         })
     }
 
-    pub(crate) fn created_foreign_keys(&self) -> impl Iterator<Item = &ForeignKey> {
+    pub(crate) fn created_foreign_keys<'a>(&'a self) -> impl Iterator<Item = ForeignKeyRef<'a, 'schema>> + 'a {
         self.next_foreign_keys().filter(move |next_fk| {
             self.previous_foreign_keys()
                 .find(|previous_fk| super::foreign_keys_match(previous_fk, next_fk))
@@ -47,7 +48,7 @@ impl<'schema> TableDiffer<'schema> {
         })
     }
 
-    pub(crate) fn dropped_foreign_keys(&self) -> impl Iterator<Item = &ForeignKey> {
+    pub(crate) fn dropped_foreign_keys<'a>(&'a self) -> impl Iterator<Item = ForeignKeyRef<'a, 'schema>> + 'a {
         self.previous_foreign_keys().filter(move |previous_fk| {
             self.next_foreign_keys()
                 .find(|next_fk| super::foreign_keys_match(previous_fk, next_fk))
@@ -79,6 +80,48 @@ impl<'schema> TableDiffer<'schema> {
         })
     }
 
+    pub(crate) fn created_primary_key(&self) -> Option<&'schema PrimaryKey> {
+        match (self.previous.primary_key(), self.next.primary_key()) {
+            (None, Some(pk)) => Some(pk),
+            (Some(previous_pk), Some(next_pk)) if previous_pk.columns != next_pk.columns => Some(next_pk),
+            (Some(previous_pk), Some(next_pk)) => {
+                if self.primary_key_column_changed(previous_pk) {
+                    Some(next_pk)
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+
+    pub(crate) fn dropped_primary_key(&self) -> Option<&'schema PrimaryKey> {
+        match (self.previous.primary_key(), self.next.primary_key()) {
+            (Some(pk), None) => Some(pk),
+            (Some(previous_pk), Some(next_pk)) if previous_pk.columns != next_pk.columns => Some(previous_pk),
+            (Some(previous_pk), Some(_next_pk)) => {
+                if self.primary_key_column_changed(previous_pk) {
+                    Some(previous_pk)
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+
+    /// Returns true if any of the columns of the primary key changed type.
+    fn primary_key_column_changed(&self, previous_pk: &PrimaryKey) -> bool {
+        self.column_pairs()
+            .filter(|columns| {
+                previous_pk
+                    .columns
+                    .iter()
+                    .any(|pk_col| pk_col == columns.previous.name())
+            })
+            .any(|columns| columns.all_changes().type_changed())
+    }
+
     fn previous_columns<'a>(&'a self) -> impl Iterator<Item = ColumnRef<'schema>> + 'a {
         self.previous.columns()
     }
@@ -87,12 +130,12 @@ impl<'schema> TableDiffer<'schema> {
         self.next.columns()
     }
 
-    fn previous_foreign_keys(&self) -> impl Iterator<Item = &ForeignKey> {
-        self.previous.table.foreign_keys.iter()
+    fn previous_foreign_keys<'a>(&'a self) -> impl Iterator<Item = ForeignKeyRef<'a, 'schema>> + 'a {
+        self.previous.foreign_keys()
     }
 
-    fn next_foreign_keys(&self) -> impl Iterator<Item = &ForeignKey> {
-        self.next.table.foreign_keys.iter()
+    fn next_foreign_keys<'a>(&'a self) -> impl Iterator<Item = ForeignKeyRef<'a, 'schema>> + 'a {
+        self.next.foreign_keys()
     }
 
     fn previous_indexes<'a>(&'a self) -> impl Iterator<Item = &'schema Index> + 'a {
@@ -104,7 +147,7 @@ impl<'schema> TableDiffer<'schema> {
     }
 }
 
-fn columns_match(a: &ColumnRef<'_>, b: &ColumnRef<'_>) -> bool {
+pub(crate) fn columns_match(a: &ColumnRef<'_>, b: &ColumnRef<'_>) -> bool {
     a.name() == b.name()
 }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_helpers.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_helpers.rs
@@ -129,7 +129,7 @@ impl<'a, 'schema> ForeignKeyRef<'a, 'schema> {
     }
 
     pub(crate) fn constraint_name(&self) -> Option<&'a str> {
-        self.foreign_key.constraint_name.as_ref().map(String::as_str)
+        self.foreign_key.constraint_name.as_deref()
     }
 
     pub(crate) fn inner(&self) -> &'a ForeignKey {

--- a/migration-engine/migration-engine-tests/src/assertions.rs
+++ b/migration-engine/migration-engine-tests/src/assertions.rs
@@ -251,6 +251,26 @@ impl<'a> TableAssertion<'a> {
 pub struct ColumnAssertion<'a>(&'a Column);
 
 impl<'a> ColumnAssertion<'a> {
+    pub fn assert_auto_increments(self) -> AssertionResult<Self> {
+        anyhow::ensure!(
+            self.0.auto_increment,
+            "Assertion failed. Expected column `{}` to be auto-incrementing.",
+            self.0.name,
+        );
+
+        Ok(self)
+    }
+
+    pub fn assert_no_auto_increment(self) -> AssertionResult<Self> {
+        anyhow::ensure!(
+            !self.0.auto_increment,
+            "Assertion failed. Expected column `{}` not to be auto-incrementing.",
+            self.0.name,
+        );
+
+        Ok(self)
+    }
+
     pub fn assert_default(self, expected: Option<DefaultValue>) -> AssertionResult<Self> {
         let found = &self.0.default;
 
@@ -355,6 +375,15 @@ pub struct PrimaryKeyAssertion<'a>(&'a PrimaryKey);
 impl<'a> PrimaryKeyAssertion<'a> {
     pub fn assert_columns(self, column_names: &[&str]) -> AssertionResult<Self> {
         assert_eq!(self.0.columns, column_names);
+
+        Ok(self)
+    }
+
+    pub fn assert_has_sequence(self) -> AssertionResult<Self> {
+        anyhow::ensure!(
+            self.0.sequence.is_some(),
+            "Assertion failed: expected a sequence on the primary, found none."
+        );
 
         Ok(self)
     }

--- a/migration-engine/migration-engine-tests/src/test_api/infer_apply.rs
+++ b/migration-engine/migration-engine-tests/src/test_api/infer_apply.rs
@@ -89,6 +89,14 @@ impl<'a> InferApplyAssertion<'a> {
     }
 
     pub fn assert_warnings(self, warnings: &[Cow<'_, str>]) -> AssertionResult<Self> {
+        anyhow::ensure!(
+            self.result.warnings.len() == warnings.len(),
+            "Expected {} warnings, got {}.\n{:#?}",
+            warnings.len(),
+            self.result.warnings.len(),
+            self.result.warnings
+        );
+
         for (idx, warning) in warnings.iter().enumerate() {
             assert_eq!(
                 Some(warning.as_ref()),

--- a/migration-engine/migration-engine-tests/tests/existing_data_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_data_tests.rs
@@ -1191,6 +1191,7 @@ async fn primary_key_migrations_do_not_cause_data_loss(api: &TestApi) -> TestRes
         .assert_executable()?
         .assert_no_error()?
         .assert_warnings(&[
+            "The migration will change the primary key for the `Dog` table. If it partially fails, the table could be left without primary key constraint.".into(),
             "You are about to alter the column `passportNumber` on the `Dog` table, which still contains 1 non-null values. The data in that column could be lost.".into(),
             "You are about to alter the column `motherPassportNumber` on the `Puppy` table, which still contains 1 non-null values. The data in that column could be lost.".into(),
         ])?;

--- a/migration-engine/migration-engine-tests/tests/existing_data_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_data_tests.rs
@@ -148,7 +148,7 @@ async fn altering_a_column_with_non_null_values_should_warn(api: &TestApi) -> Te
         &[MigrationWarning {
             description:
                 "You are about to alter the column `age` on the `Test` table, which still contains 2 non-null values. \
-                 The data in that column will be lost."
+                 The data in that column could be lost."
                     .to_owned()
         }]
     );
@@ -339,7 +339,7 @@ async fn changing_a_column_from_required_to_optional_should_work(api: &TestApi) 
 
         assert_eq!(
             migration_output.warnings.get(0).unwrap().description,
-            "You are about to alter the column `age` on the `Test` table, which still contains 2 non-null values. The data in that column will be lost.",
+            "You are about to alter the column `age` on the `Test` table, which still contains 2 non-null values. The data in that column could be lost.",
         );
 
         api.assert_schema().await?.assert_equals(&original_database_schema)?;
@@ -455,7 +455,7 @@ async fn changing_a_column_from_optional_to_required_must_warn(api: &TestApi) ->
         .await?
         .assert_executable()?
         .assert_no_error()?
-        .assert_warnings(&["You are about to alter the column `age` on the `Test` table, which still contains 2 non-null values. The data in that column will be lost.".into()])?;
+        .assert_warnings(&["You are about to alter the column `age` on the `Test` table, which still contains 2 non-null values. The data in that column could be lost.".into()])?;
 
     api.assert_schema().await?.assert_table("Test", |table| {
         table.assert_column("age", |column| {
@@ -687,7 +687,7 @@ async fn altering_the_type_of_a_column_in_a_non_empty_table_always_warns(api: &T
         &[MigrationWarning {
             // TODO: the message should say that altering the type of a column is not guaranteed to preserve the data, but the database is going to do its best.
             // Also think about timeouts.
-            description: "You are about to alter the column `dogs` on the `User` table, which still contains 1 non-null values. The data in that column will be lost.".to_owned()
+            description: "You are about to alter the column `dogs` on the `User` table, which still contains 1 non-null values. The data in that column could be lost.".to_owned()
         }]
     );
 
@@ -735,7 +735,7 @@ async fn migrating_a_required_column_from_int_to_string_should_warn_and_cast(api
     "#;
 
     let expected_warning = MigrationWarning {
-        description: "You are about to alter the column `serialNumber` on the `Test` table, which still contains 1 non-null values. The data in that column will be lost.".to_owned(),
+        description: "You are about to alter the column `serialNumber` on the `Test` table, which still contains 1 non-null values. The data in that column could be lost.".to_owned(),
     };
 
     // Apply once without forcing
@@ -1051,7 +1051,7 @@ async fn changing_an_array_column_to_scalar_must_warn(api: &TestApi) -> TestResu
         .await?
         .assert_executable()?
         .assert_no_error()?
-        .assert_warnings(&["You are about to alter the column `mainProtagonist` on the `Film` table, which still contains 1 non-null values. The data in that column will be lost.".into()])?;
+        .assert_warnings(&["You are about to alter the column `mainProtagonist` on the `Film` table, which still contains 1 non-null values. The data in that column could be lost.".into()])?;
 
     api.assert_schema().await?.assert_table("Film", |table| {
         table.assert_column("mainProtagonist", |column| column.assert_is_required())


### PR DESCRIPTION
This PR contains the following changes:

- `sql_schema_describer::PrimaryKey` now contains the PK's constraint name.
- `DropForeignKey` is now a separate SQL migration step, so it can run before `AlterTable`s.
- `AddPrimaryKey` and `DropPrimaryKey` variants have been added 
- The old process for primary key migrations (dropping and recreating the table with primary key and any table with a foreign key pointing to it) now looks like:
  - Drop all foreign key constraints referencing that primary key
  - Drop and recreate the primary key, possibly changing the columns it contains in the process.
  - Recreate foreign key constraints
- A new warning to make the danger in migrating primary keys clear, in case the migration fails halfway.
- Renaming: `SqlMigrationWarning` -> `SqlMigrationWarningCheck`

Future improvements: it may not be always necessary to drop and recreate all the constraints.