### PR TITLE
[refactoring] Use ColumnRef in ColumnDiffer

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_migration_inferrer/sqlite.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_migration_inferrer/sqlite.rs
@@ -172,8 +172,8 @@ fn copy_current_table_into_new_table(
         .column_pairs()
         .filter(|columns| {
             columns.all_changes().arity_changed()
-                && columns.next.tpe.arity.is_required()
-                && columns.next.default.is_some()
+                && columns.next.column.tpe.arity.is_required()
+                && columns.next.column.default.is_some()
         })
         .collect();
     let intersection_columns: Vec<&str> = differ
@@ -225,10 +225,11 @@ fn copy_current_table_into_new_table(
                 default_value = SqlRenderer::for_family(&SqlFamily::Sqlite).render_default(
                     columns
                         .next
+                        .column
                         .default
                         .as_ref()
                         .expect("default on required column with default"),
-                    &columns.next.tpe.family
+                    &columns.next.column.tpe.family
                 )
             )
         }))

--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
@@ -1,8 +1,8 @@
 use crate::*;
 use sql_renderer::{postgres_render_column_type, rendered_step::RenderedStep, IteratorJoin, Quoted, SqlRenderer};
 use sql_schema_describer::*;
-use sql_schema_differ::DiffingOptions;
-use sql_schema_helpers::{find_column, walk_columns, ColumnRef};
+use sql_schema_differ::{ColumnDiffer, DiffingOptions};
+use sql_schema_helpers::{find_column, walk_columns, ColumnRef, SqlSchemaExt};
 use std::fmt::Write as _;
 use tracing_futures::Instrument;
 
@@ -265,8 +265,8 @@ fn render_raw_sql(
                     TableChange::AlterColumn(AlterColumn { name, column }) => {
                         match safe_alter_column(
                             renderer,
-                            current_schema.get_table(&table.name).unwrap().column(&name).unwrap(),
-                            &find_column(next_schema, &table.name, &column.name)
+                            current_schema.table_ref(&table.name).unwrap().column(&name).unwrap(),
+                            find_column(next_schema, &table.name, &column.name)
                                 .expect("Invariant violation: could not find column referred to in AlterColumn."),
                             &DiffingOptions::from_database_info(database_info),
                         )? {
@@ -442,20 +442,21 @@ fn create_table_suffix(sql_family: SqlFamily) -> &'static str {
 
 fn safe_alter_column(
     renderer: &dyn SqlRenderer,
-    previous_column: &Column,
-    next_column: &ColumnRef<'_>,
+    previous_column: ColumnRef<'_>,
+    next_column: ColumnRef<'_>,
     diffing_options: &DiffingOptions,
 ) -> anyhow::Result<Option<Vec<String>>> {
     use crate::sql_migration::expanded_alter_column::*;
 
-    let expanded = crate::sql_migration::expanded_alter_column::expand_alter_column(
-        previous_column,
-        next_column.column,
-        &renderer.sql_family(),
+    let differ = ColumnDiffer {
+        previous: previous_column,
+        next: next_column,
         diffing_options,
-    );
+    };
 
-    let alter_column_prefix = format!("ALTER COLUMN {}", renderer.quote(&previous_column.name));
+    let expanded = expand_alter_column(&differ, &renderer.sql_family());
+
+    let alter_column_prefix = format!("ALTER COLUMN {}", renderer.quote(differ.previous.name()));
 
     let steps = match expanded {
         Some(ExpandedAlterColumn::Postgres(steps)) => steps
@@ -480,7 +481,7 @@ fn safe_alter_column(
             MysqlAlterColumn::DropDefault => vec![format!("{} DROP DEFAULT", &alter_column_prefix)],
             MysqlAlterColumn::Modify { new_default, changes } => {
                 let column_type: Option<String> = if changes.type_changed() {
-                    Some(next_column.column.tpe.full_data_type.clone())
+                    Some(next_column.column_type().full_data_type.clone())
                         .filter(|r| !r.is_empty() || r.contains("datetime")) // @default(now()) does not work with datetimes of certain sizes
                 } else {
                     Some(next_column.column.tpe.full_data_type.clone()).filter(|r| !r.is_empty())
@@ -489,7 +490,7 @@ fn safe_alter_column(
 
                 let column_type = column_type
                     .map(Ok)
-                    .unwrap_or_else(|| sql_renderer::mysql_render_column_type(next_column).map(String::from))?;
+                    .unwrap_or_else(|| sql_renderer::mysql_render_column_type(&next_column).map(String::from))?;
 
                 let default = new_default
                     .map(|default| {
@@ -504,7 +505,7 @@ fn safe_alter_column(
                     "MODIFY {column_name} {column_type} {nullability} {default}",
                     column_name = Quoted::mysql_ident(&next_column.name()),
                     column_type = column_type,
-                    nullability = if next_column.column.tpe.arity.is_required() {
+                    nullability = if next_column.arity().is_required() {
                         "NOT NULL "
                     } else {
                         ""

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/destructive_change_checker_flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/destructive_change_checker_flavour/mysql.rs
@@ -22,15 +22,15 @@ impl DestructiveChangeCheckerFlavour for MysqlFlavour {
             MysqlAlterColumn::Modify { .. } => {
                 // Column went from optional to required. This is unexecutable unless the table is
                 // empty or the column has no existing NULLs.
-                if columns.all_changes().arity_changed() && columns.next.tpe.arity.is_required() {
+                if columns.all_changes().arity_changed() && columns.next.column.tpe.arity.is_required() {
                     plan.push_unexecutable(UnexecutableStepCheck::MadeOptionalFieldRequired {
-                        column: columns.previous.name.clone(),
+                        column: columns.previous.name().to_owned(),
                         table: previous_table.name.clone(),
                     });
                 } else {
                     plan.push_warning(SqlMigrationWarning::AlterColumn {
                         table: previous_table.name.clone(),
-                        column: columns.next.name.clone(),
+                        column: columns.next.name().to_owned(),
                     });
                 }
             }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/destructive_change_checker_flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/destructive_change_checker_flavour/postgres.rs
@@ -20,22 +20,22 @@ impl DestructiveChangeCheckerFlavour for PostgresFlavour {
                 match step {
                     PostgresAlterColumn::SetNotNull => {
                         plan.push_unexecutable(UnexecutableStepCheck::MadeOptionalFieldRequired {
-                            column: columns.previous.name.clone(),
+                            column: columns.previous.name().to_owned(),
                             table: previous_table.name.clone(),
                         })
                     }
                     PostgresAlterColumn::SetType(_) => {
-                        if !matches!(columns.previous.tpe.arity, ColumnArity::List)
-                            && matches!(columns.next.tpe.arity, ColumnArity::List)
+                        if !matches!(columns.previous.column.tpe.arity, ColumnArity::List)
+                            && matches!(columns.next.column.tpe.arity, ColumnArity::List)
                         {
                             plan.push_unexecutable(UnexecutableStepCheck::MadeScalarFieldIntoArrayField {
                                 table: previous_table.name.clone(),
-                                column: columns.previous.name.clone(),
+                                column: columns.previous.name().to_owned(),
                             })
                         } else {
                             plan.push_warning(SqlMigrationWarning::AlterColumn {
                                 table: previous_table.name.clone(),
-                                column: columns.previous.name.clone(),
+                                column: columns.previous.name().to_owned(),
                             });
                         }
                     }
@@ -47,19 +47,19 @@ impl DestructiveChangeCheckerFlavour for PostgresFlavour {
         } else {
             // Unexecutable drop and recreate.
             if columns.all_changes().arity_changed()
-                && columns.previous.tpe.arity.is_nullable()
-                && columns.next.tpe.arity.is_required()
-                && !default_can_be_rendered(columns.next.default.as_ref())
+                && columns.previous.column.tpe.arity.is_nullable()
+                && columns.next.column.tpe.arity.is_required()
+                && !default_can_be_rendered(columns.next.default())
             {
                 plan.push_unexecutable(UnexecutableStepCheck::AddedRequiredFieldToTable {
-                    column: columns.previous.name.clone(),
+                    column: columns.previous.name().to_owned(),
                     table: previous_table.name.clone(),
                 })
             } else {
                 // Executable drop and recreate.
                 plan.push_warning(SqlMigrationWarning::AlterColumn {
                     table: previous_table.name.clone(),
-                    column: columns.next.name.clone(),
+                    column: columns.next.name().to_owned(),
                 });
             }
         }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/destructive_change_checker_flavour/sqlite.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/destructive_change_checker_flavour/sqlite.rs
@@ -11,7 +11,7 @@ use sql_schema_describer::{ColumnArity, Table};
 
 impl DestructiveChangeCheckerFlavour for SqliteFlavour {
     fn check_alter_column(&self, previous_table: &Table, columns: &ColumnDiffer<'_>, plan: &mut DestructiveCheckPlan) {
-        let arity_change_is_safe = match (&columns.previous.tpe.arity, &columns.next.tpe.arity) {
+        let arity_change_is_safe = match (&columns.previous.arity(), &columns.next.arity()) {
             // column became required
             (ColumnArity::Nullable, ColumnArity::Required) => false,
             // column became nullable
@@ -27,18 +27,18 @@ impl DestructiveChangeCheckerFlavour for SqliteFlavour {
         }
 
         if columns.all_changes().arity_changed()
-            && columns.next.tpe.arity.is_required()
-            && columns.next.default.is_none()
+            && columns.next.arity().is_required()
+            && columns.next.default().is_none()
         {
             plan.push_unexecutable(UnexecutableStepCheck::MadeOptionalFieldRequired {
                 table: previous_table.name.clone(),
-                column: columns.previous.name.clone(),
+                column: columns.previous.name().to_owned(),
             });
         }
 
         plan.push_warning(SqlMigrationWarning::AlterColumn {
             table: previous_table.name.clone(),
-            column: columns.next.name.clone(),
+            column: columns.next.name().to_owned(),
         });
     }
 }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_migration/expanded_alter_column.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_migration/expanded_alter_column.rs
@@ -1,19 +1,11 @@
-use crate::sql_schema_differ::{ColumnChange, ColumnChanges, ColumnDiffer, DiffingOptions};
+use crate::sql_schema_differ::{ColumnChange, ColumnChanges, ColumnDiffer};
 use quaint::prelude::SqlFamily;
-use sql_schema_describer::{Column, ColumnArity, ColumnType, ColumnTypeFamily, DefaultValue};
+use sql_schema_describer::{ColumnArity, ColumnType, ColumnTypeFamily, DefaultValue};
 
 pub(crate) fn expand_alter_column(
-    previous_column: &Column,
-    next_column: &Column,
+    column_differ: &ColumnDiffer<'_>,
     sql_family: &SqlFamily,
-    diffing_options: &DiffingOptions,
 ) -> Option<ExpandedAlterColumn> {
-    let column_differ = ColumnDiffer {
-        diffing_options,
-        previous: previous_column,
-        next: next_column,
-    };
-
     match sql_family {
         SqlFamily::Sqlite => expand_sqlite_alter_column(&column_differ).map(ExpandedAlterColumn::Sqlite),
         SqlFamily::Mysql => Some(ExpandedAlterColumn::Mysql(expand_mysql_alter_column(&column_differ))),
@@ -29,7 +21,7 @@ pub(crate) fn expand_sqlite_alter_column(_columns: &ColumnDiffer<'_>) -> Option<
 pub(crate) fn expand_mysql_alter_column(columns: &ColumnDiffer<'_>) -> MysqlAlterColumn {
     let column_changes = columns.all_changes();
 
-    if column_changes.only_default_changed() && columns.next.default.is_none() {
+    if column_changes.only_default_changed() && columns.next.default().is_none() {
         return MysqlAlterColumn::DropDefault;
     }
 
@@ -39,13 +31,13 @@ pub(crate) fn expand_mysql_alter_column(columns: &ColumnDiffer<'_>) -> MysqlAlte
 
     // @default(dbgenerated()) does not give us the information in the prisma schema, so we have to
     // transfer it from the introspected current state of the database.
-    let new_default = match (&columns.previous.default, &columns.next.default) {
+    let new_default = match (&columns.previous.default(), &columns.next.default()) {
         (Some(DefaultValue::DBGENERATED(previous)), Some(DefaultValue::DBGENERATED(next)))
             if next.is_empty() && !previous.is_empty() =>
         {
             Some(DefaultValue::DBGENERATED(previous.clone()))
         }
-        _ => columns.next.default.clone(),
+        _ => columns.next.default().cloned(),
     };
 
     MysqlAlterColumn::Modify {
@@ -59,32 +51,35 @@ pub(crate) fn expand_postgres_alter_column(columns: &ColumnDiffer<'_>) -> Option
 
     for change in columns.all_changes().iter() {
         match change {
-            ColumnChange::Default => match (&columns.previous.default, &columns.next.default) {
-                (_, Some(next_default)) => changes.push(PostgresAlterColumn::SetDefault(next_default.clone())),
+            ColumnChange::Default => match (&columns.previous.default(), &columns.next.default()) {
+                (_, Some(next_default)) => changes.push(PostgresAlterColumn::SetDefault((**next_default).clone())),
                 (_, None) => changes.push(PostgresAlterColumn::DropDefault),
             },
-            ColumnChange::Arity => match (&columns.previous.tpe.arity, &columns.next.tpe.arity) {
+            ColumnChange::Arity => match (&columns.previous.arity(), &columns.next.arity()) {
                 (ColumnArity::Required, ColumnArity::Nullable) => changes.push(PostgresAlterColumn::DropNotNull),
                 (ColumnArity::Nullable, ColumnArity::Required) => changes.push(PostgresAlterColumn::SetNotNull),
                 (ColumnArity::List, ColumnArity::Nullable) => {
-                    changes.push(PostgresAlterColumn::SetType(columns.next.tpe.clone()));
+                    changes.push(PostgresAlterColumn::SetType(columns.next.column_type().clone()));
                     changes.push(PostgresAlterColumn::DropNotNull)
                 }
                 (ColumnArity::List, ColumnArity::Required) => {
-                    changes.push(PostgresAlterColumn::SetType(columns.next.tpe.clone()));
+                    changes.push(PostgresAlterColumn::SetType(columns.next.column_type().clone()));
                     changes.push(PostgresAlterColumn::SetNotNull)
                 }
                 (ColumnArity::Nullable, ColumnArity::List) | (ColumnArity::Required, ColumnArity::List) => {
-                    changes.push(PostgresAlterColumn::SetType(columns.next.tpe.clone()))
+                    changes.push(PostgresAlterColumn::SetType(columns.next.column_type().clone()))
                 }
                 (ColumnArity::Nullable, ColumnArity::Nullable)
                 | (ColumnArity::Required, ColumnArity::Required)
                 | (ColumnArity::List, ColumnArity::List) => (),
             },
-            ColumnChange::Type => match (&columns.previous.tpe.family, &columns.next.tpe.family) {
+            ColumnChange::Type => match (
+                &columns.previous.column_type_family(),
+                &columns.next.column_type_family(),
+            ) {
                 // Ints can be cast to text.
                 (ColumnTypeFamily::Int, ColumnTypeFamily::String) => {
-                    changes.push(PostgresAlterColumn::SetType(columns.next.tpe.clone()))
+                    changes.push(PostgresAlterColumn::SetType(columns.next.column_type().clone()))
                 }
                 _ => return None,
             },

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
@@ -202,7 +202,7 @@ impl<'schema> SqlSchemaDiffer<'schema> {
     fn drop_columns<'a>(differ: &'a TableDiffer<'schema>) -> impl Iterator<Item = TableChange> + 'a {
         differ.dropped_columns().map(|column| {
             let change = DropColumn {
-                name: column.name.clone(),
+                name: column.name().to_owned(),
             };
 
             TableChange::DropColumn(change)
@@ -211,7 +211,9 @@ impl<'schema> SqlSchemaDiffer<'schema> {
 
     fn add_columns<'a>(differ: &'a TableDiffer<'schema>) -> impl Iterator<Item = TableChange> + 'a {
         differ.added_columns().map(move |column| {
-            let change = AddColumn { column: column.clone() };
+            let change = AddColumn {
+                column: column.column.clone(),
+            };
 
             TableChange::AddColumn(change)
         })
@@ -221,14 +223,14 @@ impl<'schema> SqlSchemaDiffer<'schema> {
         table_differ.column_pairs().filter_map(move |column_differ| {
             let previous_fk = table_differ
                 .previous
-                .foreign_key_for_column(&column_differ.previous.name);
+                .foreign_key_for_column(column_differ.previous.name());
 
-            let next_fk = table_differ.next.foreign_key_for_column(&column_differ.next.name);
+            let next_fk = table_differ.next.foreign_key_for_column(column_differ.next.name());
 
             if column_differ.differs_in_something() || foreign_key_changed(previous_fk, next_fk) {
                 let change = AlterColumn {
-                    name: column_differ.previous.name.clone(),
-                    column: column_differ.next.clone(),
+                    name: column_differ.previous.name().to_owned(),
+                    column: column_differ.next.column.clone(),
                 };
 
                 return Some(TableChange::AlterColumn(change));

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/column.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/column.rs
@@ -1,10 +1,11 @@
-use sql_schema_describer::{Column, ColumnTypeFamily, DefaultValue};
+use crate::sql_schema_helpers::ColumnRef;
+use sql_schema_describer::{ColumnTypeFamily, DefaultValue};
 
 #[derive(Debug)]
 pub(crate) struct ColumnDiffer<'a> {
     pub(crate) diffing_options: &'a super::DiffingOptions,
-    pub(crate) previous: &'a Column,
-    pub(crate) next: &'a Column,
+    pub(crate) previous: ColumnRef<'a>,
+    pub(crate) next: ColumnRef<'a>,
 }
 
 /// On MariaDB, JSON is an alias for LONGTEXT. https://mariadb.com/kb/en/json-data-type/
@@ -12,9 +13,9 @@ const MARIADB_ALIASES: &[ColumnTypeFamily] = &[ColumnTypeFamily::String, ColumnT
 
 impl<'a> ColumnDiffer<'a> {
     pub(crate) fn name(&self) -> &'a str {
-        debug_assert_eq!(self.previous.name, self.next.name);
+        debug_assert_eq!(self.previous.name(), self.next.name());
 
-        self.previous.name.as_str()
+        self.previous.name()
     }
 
     pub(crate) fn differs_in_something(&self) -> bool {
@@ -22,13 +23,13 @@ impl<'a> ColumnDiffer<'a> {
     }
 
     pub(crate) fn all_changes(&self) -> ColumnChanges {
-        let renaming = if self.previous.name != self.next.name {
+        let renaming = if self.previous.name() != self.next.name() {
             Some(ColumnChange::Renaming)
         } else {
             None
         };
 
-        let arity = if self.previous.tpe.arity != self.next.tpe.arity {
+        let arity = if self.previous.arity() != self.next.arity() {
             Some(ColumnChange::Arity)
         } else {
             None
@@ -53,13 +54,13 @@ impl<'a> ColumnDiffer<'a> {
 
     fn column_type_changed(&self) -> bool {
         if self.diffing_options.is_mariadb
-            && MARIADB_ALIASES.contains(&self.previous.tpe.family)
-            && MARIADB_ALIASES.contains(&self.next.tpe.family)
+            && MARIADB_ALIASES.contains(&self.previous.column_type_family())
+            && MARIADB_ALIASES.contains(&self.next.column_type_family())
         {
             return false;
         }
 
-        self.previous.tpe.family != self.next.tpe.family
+        self.previous.column_type_family() != self.next.column_type_family()
     }
 
     /// There are workarounds to cope with current migration and introspection limitations.
@@ -70,11 +71,11 @@ impl<'a> ColumnDiffer<'a> {
     ///
     /// - We bail on a number of cases that are too complex to deal with right now or underspecified.
     fn defaults_match(&self) -> bool {
-        if self.previous.auto_increment {
+        if self.previous.auto_increment() {
             return true;
         }
 
-        match (&self.previous.default, &self.next.default) {
+        match (&self.previous.default(), &self.next.default()) {
             (Some(DefaultValue::VALUE(prev)), Some(DefaultValue::VALUE(next))) => prev == next,
             (Some(DefaultValue::VALUE(_)), Some(DefaultValue::SEQUENCE(_))) => true,
             (Some(DefaultValue::VALUE(_)), Some(DefaultValue::NOW)) => false,
@@ -138,122 +139,5 @@ impl ColumnChanges {
 
     pub(crate) fn column_was_renamed(&self) -> bool {
         matches!(self.changes, [Some(ColumnChange::Renaming), _, _, _])
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use prisma_value::PrismaValue;
-    use sql_schema_describer::{ColumnArity, ColumnType, ColumnTypeFamily, DefaultValue};
-
-    #[test]
-    #[ignore] // these values should already be cleaned up during introspection / datamodel validation
-    fn quoted_string_defaults_match() {
-        let col_a = Column {
-            name: "A".to_owned(),
-            tpe: ColumnType::pure(ColumnTypeFamily::String, ColumnArity::Required),
-            default: Some(DefaultValue::VALUE(PrismaValue::String("abc".to_owned()))),
-            auto_increment: false,
-        };
-
-        let col_b = Column {
-            name: "A".to_owned(),
-            tpe: ColumnType::pure(ColumnTypeFamily::String, ColumnArity::Required),
-            default: Some(DefaultValue::VALUE(PrismaValue::String(r##""abc""##.to_owned()))),
-            auto_increment: false,
-        };
-
-        let col_c = Column {
-            name: "A".to_owned(),
-            tpe: ColumnType::pure(ColumnTypeFamily::String, ColumnArity::Required),
-            default: Some(DefaultValue::VALUE(PrismaValue::String(r##"'abc'"##.to_owned()))),
-            auto_increment: false,
-        };
-
-        assert!(ColumnDiffer {
-            diffing_options: &Default::default(),
-            previous: &col_a,
-            next: &col_b
-        }
-        .defaults_match());
-
-        assert!(ColumnDiffer {
-            diffing_options: &Default::default(),
-            previous: &col_a,
-            next: &col_c
-        }
-        .defaults_match());
-
-        assert!(ColumnDiffer {
-            diffing_options: &Default::default(),
-            previous: &col_c,
-            next: &col_b
-        }
-        .defaults_match());
-    }
-
-    #[test]
-    fn datetime_defaults_match() {
-        let col_a = Column {
-            name: "A".to_owned(),
-            tpe: ColumnType::pure(ColumnTypeFamily::DateTime, ColumnArity::Required),
-            default: Some(DefaultValue::VALUE(PrismaValue::new_datetime("2019-09-01T08:00:00Z"))),
-            auto_increment: false,
-        };
-
-        let col_b = Column {
-            name: "A".to_owned(),
-            tpe: ColumnType::pure(ColumnTypeFamily::DateTime, ColumnArity::Required),
-            default: Some(DefaultValue::VALUE(PrismaValue::new_datetime(
-                "2019-09-01 08:00:00 UTC",
-            ))),
-            auto_increment: false,
-        };
-
-        assert!(ColumnDiffer {
-            diffing_options: &Default::default(),
-            previous: &col_a,
-            next: &col_b,
-        }
-        .defaults_match());
-    }
-
-    #[test]
-    fn float_defaults_match() {
-        let col_a = Column {
-            name: "A".to_owned(),
-            tpe: ColumnType::pure(ColumnTypeFamily::Float, ColumnArity::Required),
-            default: Some(DefaultValue::VALUE(PrismaValue::new_float(0.33))),
-            auto_increment: false,
-        };
-
-        let col_b = Column {
-            name: "A".to_owned(),
-            tpe: ColumnType::pure(ColumnTypeFamily::Float, ColumnArity::Required),
-            default: Some(DefaultValue::VALUE(PrismaValue::new_float(0.3300))),
-            auto_increment: false,
-        };
-
-        assert!(ColumnDiffer {
-            diffing_options: &Default::default(),
-            previous: &col_a,
-            next: &col_b,
-        }
-        .defaults_match());
-
-        let col_c = Column {
-            name: "A".to_owned(),
-            tpe: ColumnType::pure(ColumnTypeFamily::Float, ColumnArity::Required),
-            default: Some(DefaultValue::VALUE(PrismaValue::new_float(0.34))),
-            auto_increment: false,
-        };
-
-        assert!(!ColumnDiffer {
-            diffing_options: &Default::default(),
-            previous: &col_a,
-            next: &col_c,
-        }
-        .defaults_match());
     }
 }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/table.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/table.rs
@@ -1,10 +1,11 @@
 use super::column::ColumnDiffer;
-use sql_schema_describer::{Column, ForeignKey, Index, Table};
+use crate::sql_schema_helpers::TableRef;
+use sql_schema_describer::{Column, ForeignKey, Index};
 
 pub(crate) struct TableDiffer<'a> {
     pub(crate) diffing_options: &'a super::DiffingOptions,
-    pub(crate) previous: &'a Table,
-    pub(crate) next: &'a Table,
+    pub(crate) previous: TableRef<'a>,
+    pub(crate) next: TableRef<'a>,
 }
 
 impl<'schema> TableDiffer<'schema> {
@@ -79,27 +80,27 @@ impl<'schema> TableDiffer<'schema> {
     }
 
     fn previous_columns(&self) -> impl Iterator<Item = &'schema Column> {
-        self.previous.columns.iter()
+        self.previous.table.columns.iter()
     }
 
     fn next_columns(&self) -> impl Iterator<Item = &'schema Column> {
-        self.next.columns.iter()
+        self.next.table.columns.iter()
     }
 
     fn previous_foreign_keys(&self) -> impl Iterator<Item = &ForeignKey> {
-        self.previous.foreign_keys.iter()
+        self.previous.table.foreign_keys.iter()
     }
 
     fn next_foreign_keys(&self) -> impl Iterator<Item = &ForeignKey> {
-        self.next.foreign_keys.iter()
+        self.next.table.foreign_keys.iter()
     }
 
     fn previous_indexes<'a>(&'a self) -> impl Iterator<Item = &'schema Index> + 'a {
-        self.previous.indices.iter()
+        self.previous.table.indices.iter()
     }
 
     fn next_indexes<'a>(&'a self) -> impl Iterator<Item = &'schema Index> + 'a {
-        self.next.indices.iter()
+        self.next.table.indices.iter()
     }
 }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_helpers.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_helpers.rs
@@ -1,4 +1,6 @@
-use sql_schema_describer::{Column, ColumnType, DefaultValue, ForeignKey, SqlSchema, Table};
+use sql_schema_describer::{
+    Column, ColumnArity, ColumnType, ColumnTypeFamily, DefaultValue, ForeignKey, SqlSchema, Table,
+};
 
 pub(crate) fn walk_columns<'a>(schema: &'a SqlSchema) -> impl Iterator<Item = ColumnRef<'a>> + 'a {
     schema.tables.iter().flat_map(move |table| {
@@ -23,6 +25,7 @@ pub(crate) fn find_column<'a>(schema: &'a SqlSchema, table_name: &str, column_na
         })
 }
 
+#[derive(Debug, Clone, Copy)]
 pub(crate) struct ColumnRef<'a> {
     pub(crate) schema: &'a SqlSchema,
     pub(crate) column: &'a Column,
@@ -30,6 +33,10 @@ pub(crate) struct ColumnRef<'a> {
 }
 
 impl<'a> ColumnRef<'a> {
+    pub(crate) fn arity(&self) -> &ColumnArity {
+        &self.column.tpe.arity
+    }
+
     pub(crate) fn name(&self) -> &'a str {
         &self.column.name
     }
@@ -40,6 +47,10 @@ impl<'a> ColumnRef<'a> {
 
     pub(crate) fn column_type(&self) -> &'a ColumnType {
         &self.column.tpe
+    }
+
+    pub(crate) fn column_type_family(&self) -> &'a ColumnTypeFamily {
+        &self.column.tpe.family
     }
 
     pub(crate) fn auto_increment(&self) -> bool {
@@ -71,6 +82,18 @@ pub(crate) struct TableRef<'a> {
 impl<'a> TableRef<'a> {
     pub(crate) fn new(schema: &'a SqlSchema, table: &'a Table) -> Self {
         Self { schema, table }
+    }
+
+    pub(crate) fn column(&self, column_name: &str) -> Option<ColumnRef<'a>> {
+        self.columns().find(|column| column.name() == column_name)
+    }
+
+    pub(crate) fn columns<'b>(&'b self) -> impl Iterator<Item = ColumnRef<'a>> + 'b {
+        self.table.columns.iter().map(move |column| ColumnRef {
+            column,
+            schema: self.schema,
+            table: self.table,
+        })
     }
 
     pub(crate) fn name(&self) -> &'a str {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_helpers.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_helpers.rs
@@ -52,7 +52,7 @@ impl<'a> ColumnRef<'a> {
 
     pub(crate) fn table(&self) -> TableRef<'a> {
         TableRef {
-            _schema: self.schema,
+            schema: self.schema,
             table: self.table,
         }
     }
@@ -62,17 +62,35 @@ impl<'a> ColumnRef<'a> {
     }
 }
 
+#[derive(Clone, Copy)]
 pub(crate) struct TableRef<'a> {
-    _schema: &'a SqlSchema,
-    table: &'a Table,
+    pub(crate) schema: &'a SqlSchema,
+    pub(crate) table: &'a Table,
 }
 
 impl<'a> TableRef<'a> {
+    pub(crate) fn new(schema: &'a SqlSchema, table: &'a Table) -> Self {
+        Self { schema, table }
+    }
+
     pub(crate) fn name(&self) -> &'a str {
         &self.table.name
     }
 
     pub(crate) fn foreign_key_for_column(&self, column: &str) -> Option<&'a ForeignKey> {
         self.table.foreign_key_for_column(column)
+    }
+}
+
+pub(crate) trait SqlSchemaExt {
+    fn table_ref<'a>(&'a self, name: &str) -> Option<TableRef<'a>>;
+}
+
+impl SqlSchemaExt for SqlSchema {
+    fn table_ref<'a>(&'a self, name: &str) -> Option<TableRef<'a>> {
+        Some(TableRef {
+            table: self.table(name).ok()?,
+            schema: self,
+        })
     }
 }


### PR DESCRIPTION
This is split off from the primary key migrations PR. We need to traverse relations there,and it's hard to pass around table and column references + names, and remember which side of the foreign key they are. With this change, the bookkeeping is kept inside sql_schema_helpers.rs and the differs.