### PR TITLE
ci(github/windows): Fix step name to output commit and prefix with "Checkout "

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -9,7 +9,7 @@ jobs:
       SQLITE_MAX_EXPR_DEPTH: 10000
     runs-on: windows-latest
     steps:
-      - name: $ {{ github.event.client_payload.commit }}
+      - name: Checkout ${{ github.event.client_payload.commit }}
         uses: actions/checkout@v2
         with:
           ref: ${{ github.event.client_payload.commit }}


### PR DESCRIPTION
Step currently does not output commit hash as there is one space too much.
Also adding `Checkout ` will make clearer what happens.