### PR TITLE
Support dates in raw queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2249,6 +2249,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.10.1",
+ "chrono",
  "datamodel",
  "failure",
  "futures 0.3.5",

--- a/query-engine/query-engine/Cargo.toml
+++ b/query-engine/query-engine/Cargo.toml
@@ -58,3 +58,4 @@ sql-migration-connector = { path = "../../migration-engine/connectors/sql-migrat
 indoc = "0.3"
 anyhow = "1"
 serial_test = "*"
+chrono = "0.4"


### PR DESCRIPTION
Addresses issue https://github.com/prisma/prisma/issues/2533

This is the engines part of the issue and needs support from the client. To allow querying with dates, the user should pass a date object in the query, which client coerces into a JSON object, marking the type correctly:

```
{
  "prisma__type": "date",
  "prisma__value": "1996-12-19T16:39:57+00:00"
}
```

This gets then parsed as a `DateTime`, allowing its usage in the query parameters.