### PR TITLE
Use raw_cmd instead of query_raw where possible in the ME

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/flavour.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour.rs
@@ -87,11 +87,7 @@ impl SqlFlavour for MysqlFlavour {
         let db_name = self.0.dbname();
 
         let query = format!("CREATE DATABASE `{}`", db_name);
-        catch(
-            conn.connection_info(),
-            conn.query_raw(&query, &[]).map_err(SqlError::from),
-        )
-        .await?;
+        catch(conn.connection_info(), conn.raw_cmd(&query).map_err(SqlError::from)).await?;
 
         Ok(db_name.to_owned())
     }
@@ -112,7 +108,7 @@ impl SqlFlavour for MysqlFlavour {
             database_info.connection_info().schema_name()
         );
 
-        conn.query_raw(&schema_sql, &[]).await?;
+        conn.raw_cmd(&schema_sql).await?;
 
         Ok(())
     }
@@ -179,11 +175,7 @@ impl SqlFlavour for PostgresFlavour {
         let (conn, _) = create_postgres_admin_conn(url).await?;
 
         let query = format!("CREATE DATABASE \"{}\"", db_name);
-        catch(
-            conn.connection_info(),
-            conn.query_raw(&query, &[]).map_err(SqlError::from),
-        )
-        .await?;
+        catch(conn.connection_info(), conn.raw_cmd(&query).map_err(SqlError::from)).await?;
 
         Ok(db_name.to_owned())
     }
@@ -204,7 +196,7 @@ impl SqlFlavour for PostgresFlavour {
             &database_info.connection_info().schema_name()
         );
 
-        conn.query_raw(&schema_sql, &[]).await?;
+        conn.raw_cmd(&schema_sql).await?;
 
         Ok(())
     }

--- a/migration-engine/connectors/sql-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/lib.rs
@@ -73,7 +73,7 @@ impl SqlMigrationConnector {
                     let sql_str = format!(r#"DROP SCHEMA "{}" CASCADE;"#, self.schema_name());
                     debug!("{}", sql_str);
 
-                    self.conn().query_raw(&sql_str, &[]).await.ok();
+                    self.conn().raw_cmd(&sql_str).await.ok();
                 }
                 ConnectionInfo::Sqlite { file_path, .. } => {
                     self.conn()
@@ -91,7 +91,7 @@ impl SqlMigrationConnector {
                 ConnectionInfo::Mysql(_) => {
                     let sql_str = format!(r#"DROP SCHEMA `{}`;"#, self.schema_name());
                     debug!("{}", sql_str);
-                    self.conn().query_raw(&sql_str, &[]).await?;
+                    self.conn().raw_cmd(&sql_str).await?;
                 }
                 ConnectionInfo::Mssql(_) => todo!("Greetings from Redmond"),
             };
@@ -192,7 +192,7 @@ async fn connect(database_str: &str) -> ConnectorResult<(Quaint, DatabaseInfo)> 
         // async connections can be lazy, so we issue a simple query to fail early if the database
         // is not reachable.
         connection
-            .query_raw("SELECT 1", &[])
+            .raw_cmd("SELECT 1")
             .await
             .map_err(SqlError::from)
             .map_err(|err| err.into_connector_error(&connection.connection_info()))?;

--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
@@ -84,10 +84,7 @@ impl SqlDatabaseStepApplier<'_> {
         {
             tracing::debug!(index, %sql_string);
 
-            let result = self.conn().query_raw(&sql_string, &[]).await;
-
-            // TODO: this does not evaluate the results of SQLites PRAGMA foreign_key_check
-            result?;
+            self.conn().raw_cmd(&sql_string).await?;
         }
 
         let has_more = steps.get(index + 1).is_some();

--- a/migration-engine/connectors/sql-migration-connector/src/sql_migration_persistence.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_migration_persistence.rs
@@ -44,7 +44,7 @@ impl MigrationPersistence for SqlMigrationPersistence<'_> {
                 SqlFamily::Mssql => todo!("Greetings from Detroit^H Redmond"),
             };
 
-            self.conn().query_raw(&sql_str, &[]).await.ok();
+            self.conn().raw_cmd(&sql_str).await.ok();
 
             Ok(())
         };


### PR DESCRIPTION
This corresponds to the simple query API in postgres. It's a better fit
for DDL statements because it avoids preparing the query and we don't
care about the result set. In the future, this could also let us send
multiple statements in one go.