### PR TITLE
Support @default on Json fields

### DIFF
--- a/libs/sql-schema-describer/src/lib.rs
+++ b/libs/sql-schema-describer/src/lib.rs
@@ -293,6 +293,12 @@ pub enum ColumnTypeFamily {
     Unsupported(String),
 }
 
+impl ColumnTypeFamily {
+    pub fn is_json(&self) -> bool {
+        matches!(self, ColumnTypeFamily::Json)
+    }
+}
+
 impl fmt::Display for ColumnTypeFamily {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let str = match self {

--- a/libs/sql-schema-describer/src/postgres.rs
+++ b/libs/sql-schema-describer/src/postgres.rs
@@ -249,7 +249,11 @@ impl SqlSchemaDescriber {
                                 }
                             }
                             ColumnTypeFamily::Binary => DefaultValue::DBGENERATED(default_string),
-                            ColumnTypeFamily::Json => DefaultValue::DBGENERATED(default_string),
+                            // JSON/JSONB defaults come in the '{}'::jsonb form.
+                            ColumnTypeFamily::Json => unsuffix_default_literal(&default_string, "jsonb", "jsonb")
+                                .or(unsuffix_default_literal(&default_string, "json", "json"))
+                                .map(|default| DefaultValue::VALUE(PrismaValue::Json(unquote_string(&default))))
+                                .unwrap_or_else(move || DefaultValue::DBGENERATED(default_string)),
                             ColumnTypeFamily::Uuid => DefaultValue::DBGENERATED(default_string),
                             ColumnTypeFamily::Geometric => DefaultValue::DBGENERATED(default_string),
                             ColumnTypeFamily::LogSequenceNumber => DefaultValue::DBGENERATED(default_string),

--- a/libs/test-setup/src/connectors.rs
+++ b/libs/test-setup/src/connectors.rs
@@ -28,9 +28,17 @@ fn mysql_capabilities() -> Capabilities {
     Capabilities::ENUMS | Capabilities::JSON
 }
 
+fn mysql_5_6_capabilities() -> Capabilities {
+    Capabilities::ENUMS
+}
+
 fn infer_capabilities(tags: Tags) -> Capabilities {
     if tags.intersects(Tags::POSTGRES) {
         return postgres_capabilities();
+    }
+
+    if tags.intersects(Tags::MYSQL_5_6) {
+        return mysql_5_6_capabilities();
     }
 
     if tags.intersects(Tags::MYSQL) {

--- a/libs/test-setup/src/connectors/capabilities.rs
+++ b/libs/test-setup/src/connectors/capabilities.rs
@@ -1,4 +1,5 @@
 use bitflags::bitflags;
+use std::{error::Error, fmt::Display, str::FromStr};
 
 bitflags! {
     pub struct Capabilities: u8 {
@@ -11,7 +12,7 @@ bitflags! {
 #[derive(Debug)]
 pub struct UnknownCapabilityError(String);
 
-impl std::fmt::Display for UnknownCapabilityError {
+impl Display for UnknownCapabilityError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let available_capability_names: Vec<&str> = CAPABILITY_NAMES.iter().map(|(name, _)| *name).collect();
 
@@ -23,9 +24,9 @@ impl std::fmt::Display for UnknownCapabilityError {
     }
 }
 
-impl std::error::Error for UnknownCapabilityError {}
+impl Error for UnknownCapabilityError {}
 
-impl std::str::FromStr for Capabilities {
+impl FromStr for Capabilities {
     type Err = UnknownCapabilityError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
@@ -25,7 +25,11 @@ impl SqlRenderer for MySqlRenderer {
         let nullability_str = render_nullability(&column);
         let default_str = column
             .default()
-            .filter(|default| !matches!(default, DefaultValue::DBGENERATED(_)))
+            .filter(|default| {
+                !matches!(default, DefaultValue::DBGENERATED(_))
+                    // We do not want to render JSON defaults because they are not supported by MySQL.
+                    && !matches!(column.column_type_family(), ColumnTypeFamily::Json)
+            })
             .map(|default| format!("DEFAULT {}", self.render_default(default, &column.column.tpe.family)))
             .unwrap_or_else(String::new);
         let foreign_key = column.table().foreign_key_for_column(column.name());

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
@@ -60,6 +60,7 @@ impl super::SqlRenderer for PostgresRenderer {
             (DefaultValue::NOW, ColumnTypeFamily::DateTime) => "CURRENT_TIMESTAMP".into(),
             (DefaultValue::NOW, _) => unreachable!("NOW default on non-datetime column"),
             (DefaultValue::VALUE(val), ColumnTypeFamily::DateTime) => format!("'{}'", val).into(),
+            (DefaultValue::VALUE(PrismaValue::String(val)), ColumnTypeFamily::Json) => format!("'{}'", val).into(),
             (DefaultValue::VALUE(val), _) => val.to_string().into(),
             (DefaultValue::SEQUENCE(_), _) => todo!("rendering of sequence defaults"),
         }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
@@ -17,10 +17,15 @@ use sql_schema_helpers::TableRef;
 #[derive(Debug)]
 pub(crate) struct DiffingOptions {
     is_mariadb: bool,
+    sql_family: SqlFamily,
     ignore_tables: Lazy<RegexSet>,
 }
 
 impl DiffingOptions {
+    pub(crate) fn sql_family(&self) -> SqlFamily {
+        self.sql_family
+    }
+
     pub(crate) fn from_database_info(database_info: &DatabaseInfo) -> Self {
         DiffingOptions {
             is_mariadb: database_info.is_mariadb(),
@@ -28,6 +33,7 @@ impl DiffingOptions {
                 SqlFamily::Postgres => POSTGRES_IGNORED_TABLES,
                 _ => EMPTY_REGEXSET,
             },
+            sql_family: database_info.sql_family(),
         }
     }
 }
@@ -38,6 +44,7 @@ impl Default for DiffingOptions {
         DiffingOptions {
             is_mariadb: false,
             ignore_tables: EMPTY_REGEXSET,
+            sql_family: SqlFamily::Postgres,
         }
     }
 }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/column.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/column.rs
@@ -96,12 +96,7 @@ impl<'a> ColumnDiffer<'a> {
             | (
                 Some(DefaultValue::VALUE(PrismaValue::Json(prev_json))),
                 Some(DefaultValue::VALUE(PrismaValue::String(next_json))),
-            ) => serde_json::from_str::<serde_json::Value>(prev_json)
-                .and_then(|prev_json| {
-                    serde_json::from_str::<serde_json::Value>(next_json).map(|next_json| (prev_json, next_json))
-                })
-                .map(|(prev_json, next_json)| prev_json == next_json)
-                .unwrap_or_else(|_| true),
+            ) => json_defaults_match(prev_json, next_json),
 
             (Some(DefaultValue::VALUE(prev)), Some(DefaultValue::VALUE(next))) => prev == next,
             (Some(DefaultValue::VALUE(_)), Some(DefaultValue::SEQUENCE(_))) => true,
@@ -132,6 +127,13 @@ impl<'a> ColumnDiffer<'a> {
             (_, Some(DefaultValue::DBGENERATED(_))) => true,
         }
     }
+}
+
+fn json_defaults_match(previous: &str, next: &str) -> bool {
+    serde_json::from_str::<serde_json::Value>(previous)
+        .and_then(|previous| serde_json::from_str::<serde_json::Value>(next).map(|next| (previous, next)))
+        .map(|(previous, next)| previous == next)
+        .unwrap_or(true)
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/migration-engine/migration-engine-tests/tests/migrations/json.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/json.rs
@@ -1,0 +1,44 @@
+use migration_engine_tests::sql::*;
+use prisma_value::PrismaValue;
+use quaint::prelude::SqlFamily;
+use sql_schema_describer::{ColumnTypeFamily, DefaultValue};
+
+#[test_each_connector(capabilities("json"))]
+async fn database_level_json_defaults_can_be_defined(api: &TestApi) -> TestResult {
+    let dm = format!(
+        r#"
+            {datasource}
+
+            model Dog {{
+                id Int @id
+                favouriteThings Json @default("[\"sticks\",\"chimken\",100,  \"dog park\"]")
+            }}
+        "#,
+        datasource = api.datasource()
+    );
+
+    api.infer_apply(&dm).send().await?.assert_green()?;
+
+    api.assert_schema().await?.assert_table("Dog", |table| {
+        table.assert_column("favouriteThings", |column| {
+            column
+                .assert_type_family(if api.is_mariadb() {
+                    ColumnTypeFamily::String
+                } else {
+                    ColumnTypeFamily::Json
+                })?
+                .assert_default(match api.sql_family() {
+                    SqlFamily::Postgres => Some(DefaultValue::VALUE(PrismaValue::Json(
+                        "[\"sticks\", \"chimken\", 100, \"dog park\"]".into(),
+                    ))),
+                    SqlFamily::Mysql => None,
+                    _ => unreachable!(),
+                })
+        })
+    })?;
+
+    // Check that the migration is idempotent.
+    api.infer_apply(&dm).send().await?.assert_green()?.assert_no_steps()?;
+
+    Ok(())
+}

--- a/migration-engine/migration-engine-tests/tests/migrations/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/mod.rs
@@ -1,4 +1,5 @@
 mod indexes;
+mod json;
 mod mariadb;
 mod mysql;
 mod postgres;


### PR DESCRIPTION
- On MySQL: does not translate to a database-level default, since this
  is not supported by the database.
- On Postgres, we set proper database-level JSON column defaults.

closes https://github.com/prisma/prisma-engines/issues/731