### PR TITLE
Add notion of input unions to DMMF for WhereUniqueInputs

### DIFF
--- a/query-engine/core/src/schema/query_schema.rs
+++ b/query-engine/core/src/schema/query_schema.rs
@@ -256,6 +256,9 @@ pub struct Argument {
 #[derive(DebugStub)]
 pub struct InputObjectType {
     pub name: String,
+    /// If true this means that _exactly_ one of the contained fields must be specified in an incoming query.
+    /// This allows clients to handle this input type in a special way and ensure this invariant in a typesafe way.
+    pub is_one_of: bool,
 
     #[debug_stub = "#Input Fields Cell#"]
     pub fields: OnceCell<Vec<InputFieldRef>>,

--- a/query-engine/core/src/schema_builder/input_type_builder/mod.rs
+++ b/query-engine/core/src/schema_builder/input_type_builder/mod.rs
@@ -91,7 +91,10 @@ pub trait InputTypeBuilderBase<'a>: CachedBuilder<InputObjectType> + InputBuilde
         let name = format!("{}WhereUniqueInput", model.name);
         return_cached!(self.get_cache(), &name);
 
-        let input_object = Arc::new(init_input_object_type(name.clone()));
+        let mut x = init_input_object_type(name.clone());
+        x.is_one_of = true;
+
+        let input_object = Arc::new(x);
         self.cache(name, Arc::clone(&input_object));
 
         // Single unique or ID fields.

--- a/query-engine/core/src/schema_builder/utils.rs
+++ b/query-engine/core/src/schema_builder/utils.rs
@@ -34,6 +34,7 @@ where
 {
     InputObjectType {
         name: name.into(),
+        is_one_of: false,
         fields: OnceCell::new(),
     }
 }

--- a/query-engine/query-engine/src/dmmf/schema/ast.rs
+++ b/query-engine/query-engine/src/dmmf/schema/ast.rs
@@ -35,6 +35,7 @@ pub struct DMMFArgument {
 #[serde(rename_all = "camelCase")]
 pub struct DMMFInputType {
     pub name: String,
+    pub is_one_of: bool,
     pub fields: Vec<DMMFInputField>,
 }
 

--- a/query-engine/query-engine/src/dmmf/schema/object_renderer.rs
+++ b/query-engine/query-engine/src/dmmf/schema/object_renderer.rs
@@ -38,6 +38,7 @@ impl DMMFObjectRenderer {
 
         let input_type = DMMFInputType {
             name: input_object.name.clone(),
+            is_one_of: input_object.is_one_of,
             fields: rendered_fields,
         };
 

--- a/query-engine/query-engine/src/tests/dmmf.rs
+++ b/query-engine/query-engine/src/tests/dmmf.rs
@@ -74,6 +74,29 @@ fn dmmf_create_inputs_without_fields_for_parent_records_are_correct() {
 
 #[test]
 #[serial]
+fn where_unique_inputs_must_be_flagged_as_union() {
+    let dm = r#"
+        model Blog {
+            blogId String @id
+        }
+    "#;
+
+    let (query_schema, datamodel) = get_query_schema(dm);
+
+    let dmmf = crate::dmmf::render_dmmf(&datamodel, Arc::new(query_schema));
+
+    let inputs = &dmmf.schema.input_types;
+
+    let where_unique_input = inputs
+        .iter()
+        .find(|input| input.name == "BlogWhereUniqueInput")
+        .expect("finding BlogWhereUniqueInput");
+
+    assert!(where_unique_input.is_one_of);
+}
+
+#[test]
+#[serial]
 fn must_not_fail_on_missing_env_vars_in_a_datasource() {
     let dm = r#"
         datasource pg {


### PR DESCRIPTION
This PR is the result of a discussion with Luca today to understand some of his pain around using input types in the DMMF. 
**Context**
The query schema exposes types that uniquely identify a record which are called e.g. `BlogWhereUniqueInput`. This input contains an input field for each criteria of a model that uniquely identifies a record. It only makes sense to provide one of those input fields in a query. This invariant is also enforced by the query engine. In our spirit of only providing typesafe APIs the client generators try to express this invariant in the generated code. 
In the typescript client this is handled through this [snippet](https://github.com/prisma/prisma/blob/master/src/packages/client/src/runtime/transformDmmf.ts#L82) which lead union types being used for this parameter. The go client needs a similar mechanism and has chosen to derive the client based on model types instead of input types.

**Change Description**
This PR introduces the `is_union` flag for DMMF input types. If this flag is set to true, the client should generate some kind of union in the programming language so that always exactly one of the input fields is supplied.