### PR TITLE
Adjust Re-Introspection Warnings

### DIFF
--- a/introspection-engine/connectors/sql-introspection-connector/src/calculate_datamodel.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/calculate_datamodel.rs
@@ -1,10 +1,11 @@
 use crate::commenting_out_guardrails::commenting_out_guardrails;
+use crate::introspection::introspect;
 use crate::misc_helpers::*;
 use crate::prisma_1_defaults::*;
 use crate::sanitize_datamodel_names::sanitize_datamodel_names;
 use crate::version_checker::VersionChecker;
 use crate::SqlIntrospectionResult;
-use datamodel::{dml, Datamodel, FieldType, Model};
+use datamodel::Datamodel;
 use introspection_connector::{IntrospectionResult, Warning};
 use quaint::connector::SqlFamily;
 use sql_schema_describer::*;
@@ -15,117 +16,10 @@ pub fn calculate_datamodel(schema: &SqlSchema, family: &SqlFamily) -> SqlIntrosp
     debug!("Calculating data model.");
 
     let mut version_check = VersionChecker::new(family.clone(), schema);
-
     let mut data_model = Datamodel::new();
-    for table in schema
-        .tables
-        .iter()
-        .filter(|table| !is_migration_table(&table))
-        .filter(|table| !is_prisma_1_point_1_or_2_join_table(&table))
-        .filter(|table| !is_prisma_1_point_0_join_table(&table))
-        .filter(|table| !is_relay_table(&table))
-    {
-        debug!("Calculating model: {}", table.name);
-        let mut model = Model::new(table.name.clone(), None);
 
-        for column in &table.columns {
-            version_check.check_column_for_type_and_default_value(&column);
-            let field = calculate_scalar_field(&table, &column);
-            model.add_field(field);
-        }
+    introspect(schema, &mut version_check, &mut data_model)?;
 
-        let mut foreign_keys_copy = table.foreign_keys.clone();
-        let model_copy = model.clone();
-        foreign_keys_copy.clear_duplicates();
-
-        for foreign_key in foreign_keys_copy.iter().filter(|fk| {
-            !fk.columns
-                .iter()
-                .any(|c| matches!(model_copy.find_field(c).unwrap().field_type, FieldType::Unsupported(_)))
-        }) {
-            version_check.has_inline_relations(table);
-            version_check.uses_on_delete(foreign_key, table);
-            model.add_field(calculate_relation_field(schema, table, foreign_key)?);
-        }
-
-        for index in table
-            .indices
-            .iter()
-            .filter(|i| !(i.columns.len() == 1 && i.is_unique()))
-        {
-            model.add_index(calculate_index(index));
-        }
-
-        if table.primary_key_columns().len() > 1 {
-            model.id_fields = table.primary_key_columns();
-        }
-
-        version_check.always_has_created_at_updated_at(table, &model);
-        version_check.has_p1_compatible_primary_key_column(table);
-
-        data_model.add_model(model);
-    }
-
-    for e in schema.enums.iter() {
-        data_model.add_enum(dml::Enum {
-            name: e.name.clone(),
-            values: e.values.iter().map(|v| dml::EnumValue::new(v, None)).collect(),
-            database_name: None,
-            documentation: None,
-        });
-    }
-
-    let mut fields_to_be_added = Vec::new();
-
-    // add backrelation fields
-    for model in data_model.models.iter() {
-        for relation_field in model.fields.iter() {
-            if let FieldType::Relation(relation_info) = &relation_field.field_type {
-                if data_model
-                    .related_field(
-                        &model.name,
-                        &relation_info.to,
-                        &relation_info.name,
-                        &relation_field.name,
-                    )
-                    .is_none()
-                {
-                    let other_model = data_model.find_model(relation_info.to.as_str()).unwrap();
-                    let field =
-                        calculate_backrelation_field(schema, model, other_model, relation_field, relation_info)?;
-
-                    fields_to_be_added.push((other_model.name.clone(), field));
-                }
-            }
-        }
-    }
-
-    // add prisma many to many relation fields
-    for table in schema
-        .tables
-        .iter()
-        .filter(|table| is_prisma_1_point_1_or_2_join_table(&table) || is_prisma_1_point_0_join_table(&table))
-    {
-        if let (Some(f), Some(s)) = (table.foreign_keys.get(0), table.foreign_keys.get(1)) {
-            let is_self_relation = f.referenced_table == s.referenced_table;
-
-            fields_to_be_added.push((
-                s.referenced_table.clone(),
-                calculate_many_to_many_field(f, table.name[1..].to_string(), is_self_relation),
-            ));
-            fields_to_be_added.push((
-                f.referenced_table.clone(),
-                calculate_many_to_many_field(s, table.name[1..].to_string(), is_self_relation),
-            ));
-        }
-    }
-
-    for (model, field) in fields_to_be_added {
-        let model = data_model.find_model_mut(&model).unwrap();
-        model.add_field(field);
-    }
-
-    //todo sanitizing might need to be adjusted to also change the fields in the RelationInfo
     sanitize_datamodel_names(&mut data_model);
 
     let mut warnings: Vec<Warning> = commenting_out_guardrails(&mut data_model);
@@ -142,21 +36,4 @@ pub fn calculate_datamodel(schema: &SqlSchema, family: &SqlFamily) -> SqlIntrosp
         version,
         warnings,
     })
-}
-
-trait Dedup<T: PartialEq + Clone> {
-    fn clear_duplicates(&mut self);
-}
-
-impl<T: PartialEq + Clone> Dedup<T> for Vec<T> {
-    fn clear_duplicates(&mut self) {
-        let mut already_seen = vec![];
-        self.retain(|item| match already_seen.contains(item) {
-            true => false,
-            _ => {
-                already_seen.push(item.clone());
-                true
-            }
-        })
-    }
 }

--- a/introspection-engine/connectors/sql-introspection-connector/src/introspection.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/introspection.rs
@@ -1,0 +1,143 @@
+use crate::misc_helpers::{
+    calculate_backrelation_field, calculate_index, calculate_many_to_many_field, calculate_relation_field,
+    calculate_scalar_field, is_migration_table, is_prisma_1_point_0_join_table, is_prisma_1_point_1_or_2_join_table,
+    is_relay_table,
+};
+use crate::version_checker::VersionChecker;
+use crate::SqlError;
+use datamodel::{dml, Datamodel, FieldType, Model};
+use sql_schema_describer::SqlSchema;
+use tracing::debug;
+
+pub fn introspect(
+    schema: &SqlSchema,
+    version_check: &mut VersionChecker,
+    data_model: &mut Datamodel,
+) -> Result<(), SqlError> {
+    for table in schema
+        .tables
+        .iter()
+        .filter(|table| !is_migration_table(&table))
+        .filter(|table| !is_prisma_1_point_1_or_2_join_table(&table))
+        .filter(|table| !is_prisma_1_point_0_join_table(&table))
+        .filter(|table| !is_relay_table(&table))
+    {
+        debug!("Calculating model: {}", table.name);
+        let mut model = Model::new(table.name.clone(), None);
+
+        for column in &table.columns {
+            version_check.check_column_for_type_and_default_value(&column);
+            let field = calculate_scalar_field(&table, &column);
+            model.add_field(field);
+        }
+
+        let mut foreign_keys_copy = table.foreign_keys.clone();
+        let model_copy = model.clone();
+        foreign_keys_copy.clear_duplicates();
+
+        for foreign_key in foreign_keys_copy.iter().filter(|fk| {
+            !fk.columns
+                .iter()
+                .any(|c| matches!(model_copy.find_field(c).unwrap().field_type, FieldType::Unsupported(_)))
+        }) {
+            version_check.has_inline_relations(table);
+            version_check.uses_on_delete(foreign_key, table);
+            model.add_field(calculate_relation_field(schema, table, foreign_key)?);
+        }
+
+        for index in table
+            .indices
+            .iter()
+            .filter(|i| !(i.columns.len() == 1 && i.is_unique()))
+        {
+            model.add_index(calculate_index(index));
+        }
+
+        if table.primary_key_columns().len() > 1 {
+            model.id_fields = table.primary_key_columns();
+        }
+
+        version_check.always_has_created_at_updated_at(table, &model);
+        version_check.has_p1_compatible_primary_key_column(table);
+
+        data_model.add_model(model);
+    }
+
+    for e in schema.enums.iter() {
+        data_model.add_enum(dml::Enum {
+            name: e.name.clone(),
+            values: e.values.iter().map(|v| dml::EnumValue::new(v, None)).collect(),
+            database_name: None,
+            documentation: None,
+        });
+    }
+
+    let mut fields_to_be_added = Vec::new();
+
+    // add backrelation fields
+    for model in data_model.models.iter() {
+        for relation_field in model.fields.iter() {
+            if let FieldType::Relation(relation_info) = &relation_field.field_type {
+                if data_model
+                    .related_field(
+                        &model.name,
+                        &relation_info.to,
+                        &relation_info.name,
+                        &relation_field.name,
+                    )
+                    .is_none()
+                {
+                    let other_model = data_model.find_model(relation_info.to.as_str()).unwrap();
+                    let field =
+                        calculate_backrelation_field(schema, model, other_model, relation_field, relation_info)?;
+
+                    fields_to_be_added.push((other_model.name.clone(), field));
+                }
+            }
+        }
+    }
+
+    // add prisma many to many relation fields
+    for table in schema
+        .tables
+        .iter()
+        .filter(|table| is_prisma_1_point_1_or_2_join_table(&table) || is_prisma_1_point_0_join_table(&table))
+    {
+        if let (Some(f), Some(s)) = (table.foreign_keys.get(0), table.foreign_keys.get(1)) {
+            let is_self_relation = f.referenced_table == s.referenced_table;
+
+            fields_to_be_added.push((
+                s.referenced_table.clone(),
+                calculate_many_to_many_field(f, table.name[1..].to_string(), is_self_relation),
+            ));
+            fields_to_be_added.push((
+                f.referenced_table.clone(),
+                calculate_many_to_many_field(s, table.name[1..].to_string(), is_self_relation),
+            ));
+        }
+    }
+
+    for (model, field) in fields_to_be_added {
+        let model = data_model.find_model_mut(&model).unwrap();
+        model.add_field(field);
+    }
+
+    Ok(())
+}
+
+trait Dedup<T: PartialEq + Clone> {
+    fn clear_duplicates(&mut self);
+}
+
+impl<T: PartialEq + Clone> Dedup<T> for Vec<T> {
+    fn clear_duplicates(&mut self) {
+        let mut already_seen = vec![];
+        self.retain(|item| match already_seen.contains(item) {
+            true => false,
+            _ => {
+                already_seen.push(item.clone());
+                true
+            }
+        })
+    }
+}

--- a/introspection-engine/connectors/sql-introspection-connector/src/lib.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod calculate_datamodel; // only exported to be able to unit test it
 mod commenting_out_guardrails;
 mod error;
+mod introspection;
 mod misc_helpers;
 mod prisma_1_defaults;
 mod re_introspection;

--- a/introspection-engine/connectors/sql-introspection-connector/src/re_introspection.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/re_introspection.rs
@@ -344,21 +344,27 @@ pub fn enrich(old_data_model: &Datamodel, introspection_result: &mut Introspecti
     }
 
     if !changed_scalar_field_names.is_empty() {
-        let models_and_fields = changed_scalar_field_names.iter().map(|c| c.0.clone()).collect();
+        let models_and_fields = changed_scalar_field_names
+            .iter()
+            .map(|c| ModelAndField::new(&c.0.model, &c.1))
+            .collect();
         introspection_result
             .warnings
             .push(warning_enriched_with_map_on_field(&models_and_fields));
     }
 
     if !changed_enum_names.is_empty() {
-        let enums = changed_enum_names.iter().map(|c| c.0.clone()).collect();
+        let enums = changed_enum_names.iter().map(|c| Enum::new(&c.1)).collect();
         introspection_result
             .warnings
             .push(warning_enriched_with_map_on_enum(&enums));
     }
 
     if !changed_enum_values.is_empty() {
-        let enums_and_values = changed_enum_values.iter().map(|c| c.0.clone()).collect();
+        let enums_and_values = changed_enum_values
+            .iter()
+            .map(|c| EnumAndValue::new(&c.0.enm, &c.1))
+            .collect();
         introspection_result
             .warnings
             .push(warning_enriched_with_map_on_enum_value(&enums_and_values));

--- a/introspection-engine/connectors/sql-introspection-connector/src/sanitize_datamodel_names.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/sanitize_datamodel_names.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 static EMPTY_ENUM_PLACEHOLDER: &'static str = "EMPTY_ENUM_VALUE";
 static EMPTY_STRING: &'static str = "";
 
+//todo sanitizing might need to be adjusted to also change the fields in the RelationInfo
 pub fn sanitize_datamodel_names(datamodel: &mut Datamodel) {
     let mut enum_renames = HashMap::new();
 

--- a/introspection-engine/connectors/sql-introspection-connector/src/warnings.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/warnings.rs
@@ -11,6 +11,12 @@ pub struct Enum {
     pub(crate) enm: String,
 }
 
+impl Enum {
+    pub fn new(name: &str) -> Self {
+        Enum { enm: name.to_owned() }
+    }
+}
+
 #[derive(Serialize, Debug, Clone)]
 pub struct ModelAndField {
     pub(crate) model: String,

--- a/introspection-engine/connectors/sql-introspection-connector/tests/re_introspection/mod.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/tests/re_introspection/mod.rs
@@ -81,7 +81,7 @@ async fn re_introspecting_manually_overwritten_mapped_field_name(api: &TestApi) 
     custom_assert(&result, final_dm);
     let warnings = api.re_introspect_warnings(input_dm).await;
 
-    assert_eq!(&warnings, "[{\"code\":8,\"message\":\"These fields were enriched with @map information taken from the previous Prisma schema.\",\"affected\":[{\"model\":\"User\",\"field\":\"test\"}]}]");
+    assert_eq!(&warnings, "[{\"code\":8,\"message\":\"These fields were enriched with @map information taken from the previous Prisma schema.\",\"affected\":[{\"model\":\"User\",\"field\":\"custom_test\"}]}]");
 }
 
 #[test_each_connector(tags("postgres"))]
@@ -141,7 +141,7 @@ async fn re_introspecting_mapped_model_and_field_name(api: &TestApi) {
     custom_assert(&result, final_dm);
     let warnings = api.re_introspect_warnings(input_dm).await;
 
-    assert_eq!(&warnings, "[{\"code\":7,\"message\":\"These models were enriched with @@map information taken from the previous Prisma schema.\",\"affected\":[{\"model\":\"Custom_User\"}]},{\"code\":8,\"message\":\"These fields were enriched with @map information taken from the previous Prisma schema.\",\"affected\":[{\"model\":\"Post\",\"field\":\"user_id\"},{\"model\":\"Custom_User\",\"field\":\"id\"}]}]");
+    assert_eq!(&warnings, "[{\"code\":7,\"message\":\"These models were enriched with @@map information taken from the previous Prisma schema.\",\"affected\":[{\"model\":\"Custom_User\"}]},{\"code\":8,\"message\":\"These fields were enriched with @map information taken from the previous Prisma schema.\",\"affected\":[{\"model\":\"Post\",\"field\":\"c_user_id\"},{\"model\":\"Custom_User\",\"field\":\"c_id\"}]}]");
 }
 
 #[test_each_connector(tags("postgres"))]
@@ -201,7 +201,7 @@ async fn re_introspecting_manually_mapped_model_and_field_name(api: &TestApi) {
     custom_assert(&result, final_dm);
     let warnings = api.re_introspect_warnings(input_dm).await;
 
-    assert_eq!(&warnings, "[{\"code\":7,\"message\":\"These models were enriched with @@map information taken from the previous Prisma schema.\",\"affected\":[{\"model\":\"Custom_User\"}]},{\"code\":8,\"message\":\"These fields were enriched with @map information taken from the previous Prisma schema.\",\"affected\":[{\"model\":\"Post\",\"field\":\"user_id\"},{\"model\":\"Custom_User\",\"field\":\"id\"}]}]");
+    assert_eq!(&warnings, "[{\"code\":7,\"message\":\"These models were enriched with @@map information taken from the previous Prisma schema.\",\"affected\":[{\"model\":\"Custom_User\"}]},{\"code\":8,\"message\":\"These fields were enriched with @map information taken from the previous Prisma schema.\",\"affected\":[{\"model\":\"Post\",\"field\":\"c_user_id\"},{\"model\":\"Custom_User\",\"field\":\"c_id\"}]}]");
 }
 
 #[test_each_connector(tags("postgres"))]
@@ -268,7 +268,7 @@ async fn re_introspecting_mapped_field_name(api: &TestApi) {
     custom_assert(&result, final_dm);
 
     let warnings = api.re_introspect_warnings(input_dm).await;
-    assert_eq!(&warnings, "[{\"code\":8,\"message\":\"These fields were enriched with @map information taken from the previous Prisma schema.\",\"affected\":[{\"model\":\"User\",\"field\":\"id_1\"},{\"model\":\"User\",\"field\":\"index\"},{\"model\":\"User\",\"field\":\"unique_1\"}]}]");
+    assert_eq!(&warnings, "[{\"code\":8,\"message\":\"These fields were enriched with @map information taken from the previous Prisma schema.\",\"affected\":[{\"model\":\"User\",\"field\":\"c_id_1\"},{\"model\":\"User\",\"field\":\"c_index\"},{\"model\":\"User\",\"field\":\"c_unique_1\"}]}]");
 }
 
 #[test_each_connector(tags("postgres"))]
@@ -324,7 +324,7 @@ async fn re_introspecting_mapped_enum_name(api: &TestApi) {
     custom_assert(&result, final_dm);
     let warnings = api.re_introspect_warnings(input_dm).await;
 
-    assert_eq!(&warnings, "[{\"code\":9,\"message\":\"These enums were enriched with @@map information taken from the previous Prisma schema.\",\"affected\":[{\"enm\":\"color\"}]}]");
+    assert_eq!(&warnings, "[{\"code\":9,\"message\":\"These enums were enriched with @@map information taken from the previous Prisma schema.\",\"affected\":[{\"enm\":\"BlackNWhite\"}]}]");
 }
 
 #[test_each_connector(tags("postgres"))]
@@ -376,7 +376,7 @@ async fn re_introspecting_mapped_enum_value_name(api: &TestApi) {
     custom_assert(&result, final_dm);
     let warnings = api.re_introspect_warnings(input_dm).await;
 
-    assert_eq!(&warnings, "[{\"code\":10,\"message\":\"These enum values were enriched with @map information taken from the previous Prisma schema.\",\"affected\":[{\"enm\":\"color\",\"value\":\"black\"}]}]");
+    assert_eq!(&warnings, "[{\"code\":10,\"message\":\"These enum values were enriched with @map information taken from the previous Prisma schema.\",\"affected\":[{\"enm\":\"color\",\"value\":\"BLACK\"}]}]");
 }
 
 #[test_each_connector(tags("postgres"))]
@@ -428,7 +428,7 @@ async fn re_introspecting_manually_remapped_enum_value_name(api: &TestApi) {
     custom_assert(&result, final_dm);
     let warnings = api.re_introspect_warnings(input_dm).await;
 
-    assert_eq!(&warnings, "[{\"code\":10,\"message\":\"These enum values were enriched with @map information taken from the previous Prisma schema.\",\"affected\":[{\"enm\":\"color\",\"value\":\"black\"}]}]");
+    assert_eq!(&warnings, "[{\"code\":10,\"message\":\"These enum values were enriched with @map information taken from the previous Prisma schema.\",\"affected\":[{\"enm\":\"color\",\"value\":\"BLACK\"}]}]");
 }
 
 #[test_each_connector(tags("postgres"))]
@@ -484,7 +484,7 @@ async fn re_introspecting_manually_re_mapped_enum_name(api: &TestApi) {
     custom_assert(&result, final_dm);
     let warnings = api.re_introspect_warnings(input_dm).await;
 
-    assert_eq!(&warnings, "[{\"code\":9,\"message\":\"These enums were enriched with @@map information taken from the previous Prisma schema.\",\"affected\":[{\"enm\":\"color\"}]}]");
+    assert_eq!(&warnings, "[{\"code\":9,\"message\":\"These enums were enriched with @@map information taken from the previous Prisma schema.\",\"affected\":[{\"enm\":\"BlackNWhite\"}]}]");
 }
 
 #[test_each_connector(tags("postgres"))]


### PR DESCRIPTION
Always refer to change entities in the warnings by their new names. 
Also a small refactoring pulling out the introspection logic. 