### PR TITLE
Update invalid_model_names.rs

### DIFF
--- a/libs/datamodel/core/src/validator/invalid_model_names.rs
+++ b/libs/datamodel/core/src/validator/invalid_model_names.rs
@@ -64,6 +64,7 @@ pub const RESERVED_MODEL_NAMES: [&str; 108] = [
     "PrismaClientInitializationError",
     "PrismaClientRustPanicError",
     "PrismaVersion",
+    "Transaction",
     // JavaScript keywords
     "await",
     "async",

--- a/libs/datamodel/core/src/validator/invalid_model_names.rs
+++ b/libs/datamodel/core/src/validator/invalid_model_names.rs
@@ -64,6 +64,7 @@ pub const RESERVED_MODEL_NAMES: [&str; 108] = [
     "PrismaClientInitializationError",
     "PrismaClientRustPanicError",
     "PrismaVersion",
+    "transaction",
     "Transaction",
     // JavaScript keywords
     "await",


### PR DESCRIPTION
To prevent a naming conflict with the transaction API, we need to deny models called `Transaction`