### PR TITLE
Use utf8mb4 as the default character set for MySQL dbs created by the migration engine

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/flavour.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour.rs
@@ -86,7 +86,10 @@ impl SqlFlavour for MysqlFlavour {
 
         let db_name = self.0.dbname();
 
-        let query = format!("CREATE DATABASE `{}`", db_name);
+        let query = format!(
+            "CREATE DATABASE `{}` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;",
+            db_name
+        );
         catch(conn.connection_info(), conn.raw_cmd(&query).map_err(SqlError::from)).await?;
 
         Ok(db_name.to_owned())


### PR DESCRIPTION
Read this blog post on the why of utf8mb4 instead of utf8:

https://mathiasbynens.be/notes/mysql-utf8mb4

We currently create tables with the same defaults, but that did not apply to the database default and to the migrations table, so this is a step towards more consistency.

Related: https://github.com/prisma/migrate/issues/245