### PR TITLE
remove macros from schema parsing

### DIFF
--- a/libs/datamodel/core/src/ast/parser/helpers.rs
+++ b/libs/datamodel/core/src/ast/parser/helpers.rs
@@ -14,7 +14,7 @@ impl ToIdentifier for pest::iterators::Pair<'_, Rule> {
     }
 }
 
-pub fn parsing_catch_all(token: &pest::iterators::Pair<'_, Rule>, kind: &str) {
+pub fn parsing_catch_all(token: &Token, kind: &str) {
     match token.as_rule() {
         Rule::comment | Rule::comment_and_new_line | Rule::comment_block => {}
         x => unreachable!(

--- a/libs/datamodel/core/src/ast/parser/helpers.rs
+++ b/libs/datamodel/core/src/ast/parser/helpers.rs
@@ -24,3 +24,25 @@ pub fn parsing_catch_all(token: &pest::iterators::Pair<'_, Rule>) {
         ),
     }
 }
+
+pub type Token<'a> = pest::iterators::Pair<'a, Rule>;
+
+pub trait TokenExtensions {
+    fn first_child(&self) -> Token;
+}
+
+// this is not implemented for Token because auto completion does not work then
+impl TokenExtensions for pest::iterators::Pair<'_, Rule> {
+    fn first_child(&self) -> Token<'_> {
+        self.clone()
+            .into_inner()
+            .filter(|rule| {
+                rule.as_rule() != Rule::BLOCK_CLOSE
+                    && rule.as_rule() != Rule::BLOCK_OPEN
+                    && rule.as_rule() != Rule::WHITESPACE
+                    && rule.as_rule() != Rule::NEWLINE
+            })
+            .next()
+            .unwrap()
+    }
+}

--- a/libs/datamodel/core/src/ast/parser/helpers.rs
+++ b/libs/datamodel/core/src/ast/parser/helpers.rs
@@ -1,18 +1,7 @@
 use super::Rule;
 use crate::ast::{Identifier, Span};
 
-pub trait ToIdentifier {
-    fn to_id(&self) -> Identifier;
-}
-
-impl ToIdentifier for pest::iterators::Pair<'_, Rule> {
-    fn to_id(&self) -> Identifier {
-        Identifier {
-            name: String::from(self.as_str()),
-            span: Span::from_pest(self.as_span()),
-        }
-    }
-}
+pub type Token<'a> = pest::iterators::Pair<'a, Rule>;
 
 pub fn parsing_catch_all(token: &Token, kind: &str) {
     match token.as_rule() {
@@ -26,7 +15,19 @@ pub fn parsing_catch_all(token: &Token, kind: &str) {
     }
 }
 
-pub type Token<'a> = pest::iterators::Pair<'a, Rule>;
+pub trait ToIdentifier {
+    fn to_id(&self) -> Identifier;
+}
+
+// this is not implemented for Token because auto completion does not work then
+impl ToIdentifier for pest::iterators::Pair<'_, Rule> {
+    fn to_id(&self) -> Identifier {
+        Identifier {
+            name: String::from(self.as_str()),
+            span: Span::from_pest(self.as_span()),
+        }
+    }
+}
 
 pub trait TokenExtensions {
     fn first_child(&self) -> Token;

--- a/libs/datamodel/core/src/ast/parser/helpers.rs
+++ b/libs/datamodel/core/src/ast/parser/helpers.rs
@@ -30,18 +30,25 @@ impl ToIdentifier for pest::iterators::Pair<'_, Rule> {
 }
 
 pub trait TokenExtensions {
-    fn first_child(&self) -> Token;
+    /// Gets the first child token that is relevant.
+    /// Irrelevant Tokens are e.g. new lines which we do not want to match during parsing.
+    fn first_relevant_child(&self) -> Token;
 
-    fn filtered_children(&self) -> Vec<Token>;
+    /// Returns all child token of this Token that are relevant.
+    /// Irrelevant Tokens are e.g. new lines which we do not want to match during parsing.
+    fn relevant_children(&self) -> Vec<Token>;
 }
 
 // this is not implemented for Token because auto completion does not work then
 impl TokenExtensions for pest::iterators::Pair<'_, Rule> {
-    fn first_child(&self) -> Token<'_> {
-        self.filtered_children().into_iter().next().unwrap()
+    fn first_relevant_child(&self) -> Token<'_> {
+        self.relevant_children()
+            .into_iter()
+            .next()
+            .expect(&format!("Token `{}` had no children.", &self))
     }
 
-    fn filtered_children(&self) -> Vec<Token> {
+    fn relevant_children(&self) -> Vec<Token> {
         self.clone()
             .into_inner()
             .filter(|rule| {

--- a/libs/datamodel/core/src/ast/parser/helpers.rs
+++ b/libs/datamodel/core/src/ast/parser/helpers.rs
@@ -37,16 +37,7 @@ pub trait TokenExtensions {
 // this is not implemented for Token because auto completion does not work then
 impl TokenExtensions for pest::iterators::Pair<'_, Rule> {
     fn first_child(&self) -> Token<'_> {
-        self.clone()
-            .into_inner()
-            .filter(|rule| {
-                rule.as_rule() != Rule::BLOCK_CLOSE
-                    && rule.as_rule() != Rule::BLOCK_OPEN
-                    && rule.as_rule() != Rule::WHITESPACE
-                    && rule.as_rule() != Rule::NEWLINE
-            })
-            .next()
-            .unwrap()
+        self.filtered_children().into_iter().next().unwrap()
     }
 
     fn filtered_children(&self) -> Vec<Token> {

--- a/libs/datamodel/core/src/ast/parser/helpers.rs
+++ b/libs/datamodel/core/src/ast/parser/helpers.rs
@@ -29,6 +29,8 @@ pub type Token<'a> = pest::iterators::Pair<'a, Rule>;
 
 pub trait TokenExtensions {
     fn first_child(&self) -> Token;
+
+    fn filtered_children(&self) -> Vec<Token>;
 }
 
 // this is not implemented for Token because auto completion does not work then
@@ -44,5 +46,17 @@ impl TokenExtensions for pest::iterators::Pair<'_, Rule> {
             })
             .next()
             .unwrap()
+    }
+
+    fn filtered_children(&self) -> Vec<Token> {
+        self.clone()
+            .into_inner()
+            .filter(|rule| {
+                rule.as_rule() != Rule::BLOCK_CLOSE
+                    && rule.as_rule() != Rule::BLOCK_OPEN
+                    && rule.as_rule() != Rule::WHITESPACE
+                    && rule.as_rule() != Rule::NEWLINE
+            })
+            .collect()
     }
 }

--- a/libs/datamodel/core/src/ast/parser/helpers.rs
+++ b/libs/datamodel/core/src/ast/parser/helpers.rs
@@ -14,11 +14,12 @@ impl ToIdentifier for pest::iterators::Pair<'_, Rule> {
     }
 }
 
-pub fn parsing_catch_all(token: &pest::iterators::Pair<'_, Rule>) {
+pub fn parsing_catch_all(token: &pest::iterators::Pair<'_, Rule>, kind: &str) {
     match token.as_rule() {
         Rule::comment | Rule::comment_and_new_line | Rule::comment_block => {}
         x => unreachable!(
-            "Encountered impossible field declaration during parsing: {:?} {:?}",
+            "Encountered impossible {} during parsing: {:?} {:?}",
+            kind,
             &x,
             token.clone().tokens()
         ),

--- a/libs/datamodel/core/src/ast/parser/parse_comments.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_comments.rs
@@ -1,4 +1,7 @@
-use super::{helpers::parsing_catch_all, Rule};
+use super::{
+    helpers::{parsing_catch_all, Token, TokenExtensions},
+    Rule,
+};
 use crate::ast::Comment;
 
 pub fn parse_comment_block(token: &pest::iterators::Pair<'_, Rule>) -> Comment {
@@ -16,16 +19,16 @@ pub fn parse_comment_block(token: &pest::iterators::Pair<'_, Rule>) -> Comment {
     }
 }
 
-// Documentation parsing
-pub fn parse_doc_comment(token: &pest::iterators::Pair<'_, Rule>) -> String {
-    match_first! { token, current,
-        Rule::doc_content => {
-            String::from(current.as_str().trim())
-        },
-        Rule::doc_comment => {
-            parse_doc_comment(&current)
-        },
-        x => unreachable!("Encountered impossible doc comment during parsing: {:?}, {:?}", x, current.tokens())
+pub fn parse_doc_comment(token: &Token) -> String {
+    let child = token.first_child();
+    match child.as_rule() {
+        Rule::doc_content => String::from(child.as_str().trim()),
+        Rule::doc_comment => parse_doc_comment(&child),
+        x => unreachable!(
+            "Encountered impossible doc comment during parsing: {:?}, {:?}",
+            x,
+            child.tokens()
+        ),
     }
 }
 

--- a/libs/datamodel/core/src/ast/parser/parse_comments.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_comments.rs
@@ -10,7 +10,7 @@ pub fn parse_comment_block(token: &pest::iterators::Pair<'_, Rule>) -> Comment {
         match comment.as_rule() {
             Rule::doc_comment | Rule::doc_comment_and_new_line => comments.push(parse_doc_comment(&comment)),
             Rule::comment | Rule::comment_and_new_line => {}
-            _ => parsing_catch_all(&comment),
+            _ => parsing_catch_all(&comment, "comment block"),
         }
     }
 

--- a/libs/datamodel/core/src/ast/parser/parse_comments.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_comments.rs
@@ -20,7 +20,7 @@ pub fn parse_comment_block(token: &Token) -> Comment {
 }
 
 pub fn parse_doc_comment(token: &Token) -> String {
-    let child = token.first_child();
+    let child = token.first_relevant_child();
     match child.as_rule() {
         Rule::doc_content => String::from(child.as_str().trim()),
         Rule::doc_comment => parse_doc_comment(&child),

--- a/libs/datamodel/core/src/ast/parser/parse_comments.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_comments.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use crate::ast::Comment;
 
-pub fn parse_comment_block(token: &pest::iterators::Pair<'_, Rule>) -> Comment {
+pub fn parse_comment_block(token: &Token) -> Comment {
     let mut comments: Vec<String> = Vec::new();
     for comment in token.clone().into_inner() {
         match comment.as_rule() {

--- a/libs/datamodel/core/src/ast/parser/parse_directive.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_directive.rs
@@ -1,11 +1,11 @@
 use super::{
-    helpers::{parsing_catch_all, ToIdentifier, TokenExtensions},
+    helpers::{parsing_catch_all, ToIdentifier, Token, TokenExtensions},
     parse_expression::parse_arg_value,
     Rule,
 };
 use crate::ast::*;
 
-pub fn parse_directive(token: &pest::iterators::Pair<'_, Rule>) -> Directive {
+pub fn parse_directive(token: &Token) -> Directive {
     let mut name: Option<Identifier> = None;
     let mut arguments: Vec<Argument> = vec![];
 
@@ -28,7 +28,7 @@ pub fn parse_directive(token: &pest::iterators::Pair<'_, Rule>) -> Directive {
     }
 }
 
-fn parse_directive_args(token: &pest::iterators::Pair<'_, Rule>, arguments: &mut Vec<Argument>) {
+fn parse_directive_args(token: &Token, arguments: &mut Vec<Argument>) {
     for current in token.filtered_children().into_iter() {
         match current.as_rule() {
             // This is a named arg.
@@ -44,7 +44,7 @@ fn parse_directive_args(token: &pest::iterators::Pair<'_, Rule>, arguments: &mut
     }
 }
 
-fn parse_directive_arg(token: &pest::iterators::Pair<'_, Rule>) -> Argument {
+fn parse_directive_arg(token: &Token) -> Argument {
     let mut name: Option<Identifier> = None;
     let mut argument: Option<Expression> = None;
 

--- a/libs/datamodel/core/src/ast/parser/parse_directive.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_directive.rs
@@ -1,16 +1,26 @@
-use super::{helpers::ToIdentifier, parse_expression::parse_arg_value, Rule};
+use super::{
+    helpers::{ToIdentifier, TokenExtensions},
+    parse_expression::parse_arg_value,
+    Rule,
+};
 use crate::ast::*;
 
 pub fn parse_directive(token: &pest::iterators::Pair<'_, Rule>) -> Directive {
     let mut name: Option<Identifier> = None;
     let mut arguments: Vec<Argument> = vec![];
 
-    match_children! { token, current,
-        Rule::directive => return parse_directive(&current),
-        Rule::directive_name => name = Some(current.to_id()),
-        Rule::directive_arguments => parse_directive_args(&current, &mut arguments),
-        _ => unreachable!("Encountered impossible directive during parsing: {:?} \n {:?}", token, current.tokens())
-    };
+    for current in token.filtered_children().into_iter() {
+        match current.as_rule() {
+            Rule::directive => return parse_directive(&current),
+            Rule::directive_name => name = Some(current.to_id()),
+            Rule::directive_arguments => parse_directive_args(&current, &mut arguments),
+            _ => unreachable!(
+                "Encountered impossible directive during parsing: {:?} \n {:?}",
+                token,
+                current.tokens()
+            ),
+        }
+    }
 
     match name {
         Some(name) => Directive {
@@ -23,16 +33,21 @@ pub fn parse_directive(token: &pest::iterators::Pair<'_, Rule>) -> Directive {
 }
 
 fn parse_directive_args(token: &pest::iterators::Pair<'_, Rule>, arguments: &mut Vec<Argument>) {
-    match_children! { token, current,
-        // This is a named arg.
-        Rule::argument => arguments.push(parse_directive_arg(&current)),
-        // This is a an unnamed arg.
-        Rule::argument_value => arguments.push(Argument {
-            name: Identifier::new(""),
-            value: parse_arg_value(&current),
-            span: Span::from_pest(current.as_span())
-        }),
-        _ => unreachable!("Encountered impossible directive argument during parsing: {:?}", current.tokens())
+    for current in token.filtered_children().into_iter() {
+        match current.as_rule() {
+            // This is a named arg.
+            Rule::argument => arguments.push(parse_directive_arg(&current)),
+            // This is a an unnamed arg.
+            Rule::argument_value => arguments.push(Argument {
+                name: Identifier::new(""),
+                value: parse_arg_value(&current),
+                span: Span::from_pest(current.as_span()),
+            }),
+            _ => unreachable!(
+                "Encountered impossible directive argument during parsing: {:?}",
+                current.tokens()
+            ),
+        }
     }
 }
 
@@ -40,11 +55,16 @@ fn parse_directive_arg(token: &pest::iterators::Pair<'_, Rule>) -> Argument {
     let mut name: Option<Identifier> = None;
     let mut argument: Option<Expression> = None;
 
-    match_children! { token, current,
-        Rule::argument_name => name = Some(current.to_id()),
-        Rule::argument_value => argument = Some(parse_arg_value(&current)),
-        _ => unreachable!("Encountered impossible directive argument during parsing: {:?}", current.tokens())
-    };
+    for current in token.filtered_children().into_iter() {
+        match current.as_rule() {
+            Rule::argument_name => name = Some(current.to_id()),
+            Rule::argument_value => argument = Some(parse_arg_value(&current)),
+            _ => unreachable!(
+                "Encountered impossible directive argument during parsing: {:?}",
+                current.tokens()
+            ),
+        }
+    }
 
     match (name, argument) {
         (Some(name), Some(value)) => Argument {

--- a/libs/datamodel/core/src/ast/parser/parse_directive.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_directive.rs
@@ -9,7 +9,7 @@ pub fn parse_directive(token: &Token) -> Directive {
     let mut name: Option<Identifier> = None;
     let mut arguments: Vec<Argument> = vec![];
 
-    for current in token.filtered_children().into_iter() {
+    for current in token.filtered_children() {
         match current.as_rule() {
             Rule::directive => return parse_directive(&current),
             Rule::directive_name => name = Some(current.to_id()),
@@ -29,7 +29,7 @@ pub fn parse_directive(token: &Token) -> Directive {
 }
 
 fn parse_directive_args(token: &Token, arguments: &mut Vec<Argument>) {
-    for current in token.filtered_children().into_iter() {
+    for current in token.filtered_children() {
         match current.as_rule() {
             // This is a named arg.
             Rule::argument => arguments.push(parse_directive_arg(&current)),
@@ -48,7 +48,7 @@ fn parse_directive_arg(token: &Token) -> Argument {
     let mut name: Option<Identifier> = None;
     let mut argument: Option<Expression> = None;
 
-    for current in token.filtered_children().into_iter() {
+    for current in token.filtered_children() {
         match current.as_rule() {
             Rule::argument_name => name = Some(current.to_id()),
             Rule::argument_value => argument = Some(parse_arg_value(&current)),

--- a/libs/datamodel/core/src/ast/parser/parse_directive.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_directive.rs
@@ -1,5 +1,5 @@
 use super::{
-    helpers::{ToIdentifier, TokenExtensions},
+    helpers::{parsing_catch_all, ToIdentifier, TokenExtensions},
     parse_expression::parse_arg_value,
     Rule,
 };
@@ -14,11 +14,7 @@ pub fn parse_directive(token: &pest::iterators::Pair<'_, Rule>) -> Directive {
             Rule::directive => return parse_directive(&current),
             Rule::directive_name => name = Some(current.to_id()),
             Rule::directive_arguments => parse_directive_args(&current, &mut arguments),
-            _ => unreachable!(
-                "Encountered impossible directive during parsing: {:?} \n {:?}",
-                token,
-                current.tokens()
-            ),
+            _ => parsing_catch_all(&current, "directive"),
         }
     }
 
@@ -43,10 +39,7 @@ fn parse_directive_args(token: &pest::iterators::Pair<'_, Rule>, arguments: &mut
                 value: parse_arg_value(&current),
                 span: Span::from_pest(current.as_span()),
             }),
-            _ => unreachable!(
-                "Encountered impossible directive argument during parsing: {:?}",
-                current.tokens()
-            ),
+            _ => parsing_catch_all(&current, "directive arguments"),
         }
     }
 }
@@ -59,10 +52,7 @@ fn parse_directive_arg(token: &pest::iterators::Pair<'_, Rule>) -> Argument {
         match current.as_rule() {
             Rule::argument_name => name = Some(current.to_id()),
             Rule::argument_value => argument = Some(parse_arg_value(&current)),
-            _ => unreachable!(
-                "Encountered impossible directive argument during parsing: {:?}",
-                current.tokens()
-            ),
+            _ => parsing_catch_all(&current, "directive argument"),
         }
     }
 

--- a/libs/datamodel/core/src/ast/parser/parse_directive.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_directive.rs
@@ -9,7 +9,7 @@ pub fn parse_directive(token: &Token) -> Directive {
     let mut name: Option<Identifier> = None;
     let mut arguments: Vec<Argument> = vec![];
 
-    for current in token.filtered_children() {
+    for current in token.relevant_children() {
         match current.as_rule() {
             Rule::directive => return parse_directive(&current),
             Rule::directive_name => name = Some(current.to_id()),
@@ -29,7 +29,7 @@ pub fn parse_directive(token: &Token) -> Directive {
 }
 
 fn parse_directive_args(token: &Token, arguments: &mut Vec<Argument>) {
-    for current in token.filtered_children() {
+    for current in token.relevant_children() {
         match current.as_rule() {
             // This is a named arg.
             Rule::argument => arguments.push(parse_directive_arg(&current)),
@@ -48,7 +48,7 @@ fn parse_directive_arg(token: &Token) -> Argument {
     let mut name: Option<Identifier> = None;
     let mut argument: Option<Expression> = None;
 
-    for current in token.filtered_children() {
+    for current in token.relevant_children() {
         match current.as_rule() {
             Rule::argument_name => name = Some(current.to_id()),
             Rule::argument_value => argument = Some(parse_arg_value(&current)),

--- a/libs/datamodel/core/src/ast/parser/parse_enum.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_enum.rs
@@ -1,5 +1,5 @@
 use super::{
-    helpers::{parsing_catch_all, ToIdentifier},
+    helpers::{parsing_catch_all, ToIdentifier, Token},
     parse_comments::*,
     parse_directive::parse_directive,
     Rule,
@@ -8,7 +8,7 @@ use crate::ast::parser::helpers::TokenExtensions;
 use crate::ast::*;
 use crate::error::{DatamodelError, ErrorCollection};
 
-pub fn parse_enum(token: &pest::iterators::Pair<'_, Rule>) -> Result<Enum, ErrorCollection> {
+pub fn parse_enum(token: &Token) -> Result<Enum, ErrorCollection> {
     let mut errors = ErrorCollection::new();
     let mut name: Option<Identifier> = None;
     let mut directives: Vec<Directive> = vec![];
@@ -49,7 +49,7 @@ pub fn parse_enum(token: &pest::iterators::Pair<'_, Rule>) -> Result<Enum, Error
     }
 }
 
-fn parse_enum_value(enum_name: &str, token: &pest::iterators::Pair<'_, Rule>) -> Result<EnumValue, DatamodelError> {
+fn parse_enum_value(enum_name: &str, token: &Token) -> Result<EnumValue, DatamodelError> {
     let mut name: Option<Identifier> = None;
     let mut directives: Vec<Directive> = vec![];
     let mut comments: Vec<String> = vec![];

--- a/libs/datamodel/core/src/ast/parser/parse_enum.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_enum.rs
@@ -4,6 +4,7 @@ use super::{
     parse_directive::parse_directive,
     Rule,
 };
+use crate::ast::parser::helpers::TokenExtensions;
 use crate::ast::*;
 use crate::error::{DatamodelError, ErrorCollection};
 
@@ -15,24 +16,21 @@ pub fn parse_enum(token: &pest::iterators::Pair<'_, Rule>) -> Result<Enum, Error
     let mut values: Vec<EnumValue> = vec![];
     let mut comment: Option<Comment> = None;
 
-    match_children! { token, current,
-        Rule::non_empty_identifier => name = Some(current.to_id()),
-        Rule::block_level_directive => directives.push(parse_directive(&current)),
-        Rule::enum_value_declaration => {
-            match parse_enum_value(&name.as_ref().unwrap().name, &current) {
+    for current in token.filtered_children().into_iter() {
+        match current.as_rule() {
+            Rule::non_empty_identifier => name = Some(current.to_id()),
+            Rule::block_level_directive => directives.push(parse_directive(&current)),
+            Rule::enum_value_declaration => match parse_enum_value(&name.as_ref().unwrap().name, &current) {
                 Ok(enum_value) => values.push(enum_value),
-                Err(err) => errors.push(err)
-            }
-        },
-        Rule::comment_block => {
-            comment = Some(parse_comment_block(&current))
-        },
-        Rule::BLOCK_LEVEL_CATCH_ALL => { errors.push(
-            DatamodelError::new_validation_error(
+                Err(err) => errors.push(err),
+            },
+            Rule::comment_block => comment = Some(parse_comment_block(&current)),
+            Rule::BLOCK_LEVEL_CATCH_ALL => errors.push(DatamodelError::new_validation_error(
                 "This line is not a enum value definition.",
-                Span::from_pest(current.as_span()))
-        ) },
-        _ => parsing_catch_all(&current)
+                Span::from_pest(current.as_span()),
+            )),
+            _ => parsing_catch_all(&current),
+        }
     }
 
     errors.ok()?;
@@ -58,25 +56,30 @@ fn parse_enum_value(enum_name: &str, token: &pest::iterators::Pair<'_, Rule>) ->
     let mut directives: Vec<Directive> = vec![];
     let mut comments: Vec<String> = vec![];
 
-    //todo validate that the identifier is valid???
-    match_children! { token, current,
-        Rule::non_empty_identifier => name = Some(current.to_id()),
-        Rule::maybe_empty_identifier => name = Some(current.to_id()),
-        Rule::directive => directives.push(parse_directive(&current)),
-        Rule::number => {
-            return Err(DatamodelError::new_enum_validation_error(
-                &format!("The enum value `{}` is not valid. Enum values must not start with a number.", current.as_str()),
-                enum_name,
-                Span::from_pest(token.as_span()))
-            );
-        },
-        Rule::doc_comment => {
-            comments.push(parse_doc_comment(&current));
-        },
-        Rule::doc_comment_and_new_line => {
-            comments.push(parse_doc_comment(&current));
-        },
-        _ => parsing_catch_all(&current)
+    // todo validate that the identifier is valid???
+    for current in token.filtered_children().into_iter() {
+        match current.as_rule() {
+            Rule::non_empty_identifier => name = Some(current.to_id()),
+            Rule::maybe_empty_identifier => name = Some(current.to_id()),
+            Rule::directive => directives.push(parse_directive(&current)),
+            Rule::number => {
+                return Err(DatamodelError::new_enum_validation_error(
+                    &format!(
+                        "The enum value `{}` is not valid. Enum values must not start with a number.",
+                        current.as_str()
+                    ),
+                    enum_name,
+                    Span::from_pest(token.as_span()),
+                ));
+            }
+            Rule::doc_comment => {
+                comments.push(parse_doc_comment(&current));
+            }
+            Rule::doc_comment_and_new_line => {
+                comments.push(parse_doc_comment(&current));
+            }
+            _ => parsing_catch_all(&current),
+        }
     }
 
     match name {

--- a/libs/datamodel/core/src/ast/parser/parse_enum.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_enum.rs
@@ -8,7 +8,6 @@ use crate::ast::parser::helpers::TokenExtensions;
 use crate::ast::*;
 use crate::error::{DatamodelError, ErrorCollection};
 
-// Enum parsing
 pub fn parse_enum(token: &pest::iterators::Pair<'_, Rule>) -> Result<Enum, ErrorCollection> {
     let mut errors = ErrorCollection::new();
     let mut name: Option<Identifier> = None;
@@ -29,7 +28,7 @@ pub fn parse_enum(token: &pest::iterators::Pair<'_, Rule>) -> Result<Enum, Error
                 "This line is not a enum value definition.",
                 Span::from_pest(current.as_span()),
             )),
-            _ => parsing_catch_all(&current),
+            _ => parsing_catch_all(&current, "enum"),
         }
     }
 
@@ -50,7 +49,6 @@ pub fn parse_enum(token: &pest::iterators::Pair<'_, Rule>) -> Result<Enum, Error
     }
 }
 
-// Enum value parsing
 fn parse_enum_value(enum_name: &str, token: &pest::iterators::Pair<'_, Rule>) -> Result<EnumValue, DatamodelError> {
     let mut name: Option<Identifier> = None;
     let mut directives: Vec<Directive> = vec![];
@@ -78,7 +76,7 @@ fn parse_enum_value(enum_name: &str, token: &pest::iterators::Pair<'_, Rule>) ->
             Rule::doc_comment_and_new_line => {
                 comments.push(parse_doc_comment(&current));
             }
-            _ => parsing_catch_all(&current),
+            _ => parsing_catch_all(&current, "enum value"),
         }
     }
 

--- a/libs/datamodel/core/src/ast/parser/parse_enum.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_enum.rs
@@ -15,7 +15,7 @@ pub fn parse_enum(token: &Token) -> Result<Enum, ErrorCollection> {
     let mut values: Vec<EnumValue> = vec![];
     let mut comment: Option<Comment> = None;
 
-    for current in token.filtered_children().into_iter() {
+    for current in token.filtered_children() {
         match current.as_rule() {
             Rule::non_empty_identifier => name = Some(current.to_id()),
             Rule::block_level_directive => directives.push(parse_directive(&current)),
@@ -55,7 +55,7 @@ fn parse_enum_value(enum_name: &str, token: &Token) -> Result<EnumValue, Datamod
     let mut comments: Vec<String> = vec![];
 
     // todo validate that the identifier is valid???
-    for current in token.filtered_children().into_iter() {
+    for current in token.filtered_children() {
         match current.as_rule() {
             Rule::non_empty_identifier => name = Some(current.to_id()),
             Rule::maybe_empty_identifier => name = Some(current.to_id()),

--- a/libs/datamodel/core/src/ast/parser/parse_enum.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_enum.rs
@@ -15,7 +15,7 @@ pub fn parse_enum(token: &Token) -> Result<Enum, ErrorCollection> {
     let mut values: Vec<EnumValue> = vec![];
     let mut comment: Option<Comment> = None;
 
-    for current in token.filtered_children() {
+    for current in token.relevant_children() {
         match current.as_rule() {
             Rule::non_empty_identifier => name = Some(current.to_id()),
             Rule::block_level_directive => directives.push(parse_directive(&current)),
@@ -55,7 +55,7 @@ fn parse_enum_value(enum_name: &str, token: &Token) -> Result<EnumValue, Datamod
     let mut comments: Vec<String> = vec![];
 
     // todo validate that the identifier is valid???
-    for current in token.filtered_children() {
+    for current in token.relevant_children() {
         match current.as_rule() {
             Rule::non_empty_identifier => name = Some(current.to_id()),
             Rule::maybe_empty_identifier => name = Some(current.to_id()),

--- a/libs/datamodel/core/src/ast/parser/parse_expression.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_expression.rs
@@ -2,11 +2,11 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 use std::borrow::Cow;
 
-use super::helpers::{parsing_catch_all, TokenExtensions};
+use super::helpers::{parsing_catch_all, Token, TokenExtensions};
 use super::Rule;
 use crate::ast::*;
 
-pub fn parse_expression(token: &pest::iterators::Pair<'_, Rule>) -> Expression {
+pub fn parse_expression(token: &Token) -> Expression {
     let first_child = token.first_child();
     let span = Span::from_pest(first_child.as_span());
     match first_child.as_rule() {
@@ -23,7 +23,7 @@ pub fn parse_expression(token: &pest::iterators::Pair<'_, Rule>) -> Expression {
     }
 }
 
-fn parse_function(token: &pest::iterators::Pair<'_, Rule>) -> Expression {
+fn parse_function(token: &Token) -> Expression {
     let mut name: Option<String> = None;
     let mut arguments: Vec<Expression> = vec![];
 
@@ -41,7 +41,7 @@ fn parse_function(token: &pest::iterators::Pair<'_, Rule>) -> Expression {
     }
 }
 
-fn parse_array(token: &pest::iterators::Pair<'_, Rule>) -> Expression {
+fn parse_array(token: &Token) -> Expression {
     let mut elements: Vec<Expression> = vec![];
 
     for current in token.filtered_children().into_iter() {
@@ -54,7 +54,7 @@ fn parse_array(token: &pest::iterators::Pair<'_, Rule>) -> Expression {
     Expression::Array(elements, Span::from_pest(token.as_span()))
 }
 
-pub fn parse_arg_value(token: &pest::iterators::Pair<'_, Rule>) -> Expression {
+pub fn parse_arg_value(token: &Token) -> Expression {
     let current = token.first_child();
     match current.as_rule() {
         Rule::expression => parse_expression(&current),
@@ -62,7 +62,7 @@ pub fn parse_arg_value(token: &pest::iterators::Pair<'_, Rule>) -> Expression {
     }
 }
 
-fn parse_string_literal(token: &pest::iterators::Pair<'_, Rule>) -> String {
+fn parse_string_literal(token: &Token) -> String {
     let current = token.first_child();
     match current.as_rule() {
         Rule::string_content => unescape_string_literal(current.as_str()).into_owned(),

--- a/libs/datamodel/core/src/ast/parser/parse_expression.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_expression.rs
@@ -27,7 +27,7 @@ fn parse_function(token: &Token) -> Expression {
     let mut name: Option<String> = None;
     let mut arguments: Vec<Expression> = vec![];
 
-    for current in token.filtered_children().into_iter() {
+    for current in token.filtered_children() {
         match current.as_rule() {
             Rule::non_empty_identifier => name = Some(current.as_str().to_string()),
             Rule::expression => arguments.push(parse_expression(&current)),
@@ -44,7 +44,7 @@ fn parse_function(token: &Token) -> Expression {
 fn parse_array(token: &Token) -> Expression {
     let mut elements: Vec<Expression> = vec![];
 
-    for current in token.filtered_children().into_iter() {
+    for current in token.filtered_children() {
         match current.as_rule() {
             Rule::expression => elements.push(parse_expression(&current)),
             _ => parsing_catch_all(&current, "array"),

--- a/libs/datamodel/core/src/ast/parser/parse_expression.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_expression.rs
@@ -2,6 +2,7 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 use std::borrow::Cow;
 
+use super::helpers::TokenExtensions;
 use super::Rule;
 use crate::ast::*;
 
@@ -9,15 +10,20 @@ use crate::ast::*;
 
 /// Parses an expression, given a Pest parser token.
 pub fn parse_expression(token: &pest::iterators::Pair<'_, Rule>) -> Expression {
-    return match_first! { token, current,
-        Rule::numeric_literal => Expression::NumericValue(current.as_str().to_string(), Span::from_pest(current.as_span())),
-        Rule::string_literal => Expression::StringValue(parse_string_literal(&current), Span::from_pest(current.as_span())),
-        Rule::boolean_literal => Expression::BooleanValue(current.as_str().to_string(), Span::from_pest(current.as_span())),
-        Rule::constant_literal => Expression::ConstantValue(current.as_str().to_string(), Span::from_pest(current.as_span())),
-        Rule::function => parse_function(&current),
-        Rule::array_expression => parse_array(&current),
-        _ => unreachable!("Encountered impossible literal during parsing: {:?}", current.tokens())
-    };
+    let first_child = token.first_child();
+    let span = Span::from_pest(first_child.as_span());
+    match first_child.as_rule() {
+        Rule::numeric_literal => Expression::NumericValue(first_child.as_str().to_string(), span),
+        Rule::string_literal => Expression::StringValue(parse_string_literal(&first_child), span),
+        Rule::boolean_literal => Expression::BooleanValue(first_child.as_str().to_string(), span),
+        Rule::constant_literal => Expression::ConstantValue(first_child.as_str().to_string(), span),
+        Rule::function => parse_function(&first_child),
+        Rule::array_expression => parse_array(&first_child),
+        _ => unreachable!(
+            "Encountered impossible literal during parsing: {:?}",
+            first_child.tokens()
+        ),
+    }
 }
 
 fn parse_function(token: &pest::iterators::Pair<'_, Rule>) -> Expression {
@@ -48,17 +54,22 @@ fn parse_array(token: &pest::iterators::Pair<'_, Rule>) -> Expression {
 }
 
 pub fn parse_arg_value(token: &pest::iterators::Pair<'_, Rule>) -> Expression {
-    match_first! { token, current,
+    let current = token.first_child();
+    match current.as_rule() {
         Rule::expression => parse_expression(&current),
-        _ => unreachable!("Encountered impossible value during parsing: {:?}", current.tokens())
+        _ => unreachable!("Encountered impossible value during parsing: {:?}", current.tokens()),
     }
 }
 
 fn parse_string_literal(token: &pest::iterators::Pair<'_, Rule>) -> String {
-    return match_first! { token, current,
+    let current = token.first_child();
+    match current.as_rule() {
         Rule::string_content => unescape_string_literal(current.as_str()).into_owned(),
-        _ => unreachable!("Encountered impossible string content during parsing: {:?}", current.tokens())
-    };
+        _ => unreachable!(
+            "Encountered impossible string content during parsing: {:?}",
+            current.tokens()
+        ),
+    }
 }
 
 fn unescape_string_literal(original: &str) -> Cow<'_, str> {

--- a/libs/datamodel/core/src/ast/parser/parse_expression.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_expression.rs
@@ -2,7 +2,7 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 use std::borrow::Cow;
 
-use super::helpers::TokenExtensions;
+use super::helpers::{parsing_catch_all, TokenExtensions};
 use super::Rule;
 use crate::ast::*;
 
@@ -31,7 +31,7 @@ fn parse_function(token: &pest::iterators::Pair<'_, Rule>) -> Expression {
         match current.as_rule() {
             Rule::non_empty_identifier => name = Some(current.as_str().to_string()),
             Rule::expression => arguments.push(parse_expression(&current)),
-            _ => unreachable!("Encountered impossible function during parsing: {:?}", current.tokens()),
+            _ => parsing_catch_all(&current, "function"),
         }
     }
 
@@ -47,7 +47,7 @@ fn parse_array(token: &pest::iterators::Pair<'_, Rule>) -> Expression {
     for current in token.filtered_children().into_iter() {
         match current.as_rule() {
             Rule::expression => elements.push(parse_expression(&current)),
-            _ => unreachable!("Encountered impossible array during parsing: {:?}", current.tokens()),
+            _ => parsing_catch_all(&current, "array"),
         }
     }
 

--- a/libs/datamodel/core/src/ast/parser/parse_expression.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_expression.rs
@@ -7,7 +7,7 @@ use super::Rule;
 use crate::ast::*;
 
 pub fn parse_expression(token: &Token) -> Expression {
-    let first_child = token.first_child();
+    let first_child = token.first_relevant_child();
     let span = Span::from_pest(first_child.as_span());
     match first_child.as_rule() {
         Rule::numeric_literal => Expression::NumericValue(first_child.as_str().to_string(), span),
@@ -27,7 +27,7 @@ fn parse_function(token: &Token) -> Expression {
     let mut name: Option<String> = None;
     let mut arguments: Vec<Expression> = vec![];
 
-    for current in token.filtered_children() {
+    for current in token.relevant_children() {
         match current.as_rule() {
             Rule::non_empty_identifier => name = Some(current.as_str().to_string()),
             Rule::expression => arguments.push(parse_expression(&current)),
@@ -44,7 +44,7 @@ fn parse_function(token: &Token) -> Expression {
 fn parse_array(token: &Token) -> Expression {
     let mut elements: Vec<Expression> = vec![];
 
-    for current in token.filtered_children() {
+    for current in token.relevant_children() {
         match current.as_rule() {
             Rule::expression => elements.push(parse_expression(&current)),
             _ => parsing_catch_all(&current, "array"),
@@ -55,7 +55,7 @@ fn parse_array(token: &Token) -> Expression {
 }
 
 pub fn parse_arg_value(token: &Token) -> Expression {
-    let current = token.first_child();
+    let current = token.first_relevant_child();
     match current.as_rule() {
         Rule::expression => parse_expression(&current),
         _ => unreachable!("Encountered impossible value during parsing: {:?}", current.tokens()),
@@ -63,7 +63,7 @@ pub fn parse_arg_value(token: &Token) -> Expression {
 }
 
 fn parse_string_literal(token: &Token) -> String {
-    let current = token.first_child();
+    let current = token.first_relevant_child();
     match current.as_rule() {
         Rule::string_content => unescape_string_literal(current.as_str()).into_owned(),
         _ => unreachable!(

--- a/libs/datamodel/core/src/ast/parser/parse_field.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_field.rs
@@ -14,7 +14,7 @@ pub fn parse_field(model_name: &str, token: &Token) -> Result<Field, DatamodelEr
     let mut field_type: Option<((FieldArity, String), Span)> = None;
     let mut comments: Vec<String> = Vec::new();
 
-    for current in token.filtered_children().into_iter() {
+    for current in token.filtered_children() {
         match current.as_rule() {
             Rule::non_empty_identifier => name = Some(current.to_id()),
             Rule::field_type => field_type = Some((parse_field_type(&current)?, Span::from_pest(current.as_span()))),

--- a/libs/datamodel/core/src/ast/parser/parse_field.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_field.rs
@@ -1,5 +1,5 @@
 use super::{
-    helpers::{parsing_catch_all, ToIdentifier, TokenExtensions},
+    helpers::{parsing_catch_all, ToIdentifier, Token, TokenExtensions},
     parse_comments::*,
     parse_directive::parse_directive,
     parse_types::parse_field_type,
@@ -8,7 +8,7 @@ use super::{
 use crate::ast::*;
 use crate::error::DatamodelError;
 
-pub fn parse_field(model_name: &str, token: &pest::iterators::Pair<'_, Rule>) -> Result<Field, DatamodelError> {
+pub fn parse_field(model_name: &str, token: &Token) -> Result<Field, DatamodelError> {
     let mut name: Option<Identifier> = None;
     let mut directives: Vec<Directive> = Vec::new();
     let mut field_type: Option<((FieldArity, String), Span)> = None;

--- a/libs/datamodel/core/src/ast/parser/parse_field.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_field.rs
@@ -27,7 +27,7 @@ pub fn parse_field(model_name: &str, token: &pest::iterators::Pair<'_, Rule>) ->
             Rule::directive => directives.push(parse_directive(&current)),
             Rule::doc_comment_and_new_line => comments.push(parse_doc_comment(&current)),
             Rule::doc_comment => comments.push(parse_doc_comment(&current)),
-            _ => parsing_catch_all(&current),
+            _ => parsing_catch_all(&current, "field"),
         }
     }
 

--- a/libs/datamodel/core/src/ast/parser/parse_field.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_field.rs
@@ -14,7 +14,7 @@ pub fn parse_field(model_name: &str, token: &Token) -> Result<Field, DatamodelEr
     let mut field_type: Option<((FieldArity, String), Span)> = None;
     let mut comments: Vec<String> = Vec::new();
 
-    for current in token.filtered_children() {
+    for current in token.relevant_children() {
         match current.as_rule() {
             Rule::non_empty_identifier => name = Some(current.to_id()),
             Rule::field_type => field_type = Some((parse_field_type(&current)?, Span::from_pest(current.as_span()))),

--- a/libs/datamodel/core/src/ast/parser/parse_field.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_field.rs
@@ -1,5 +1,5 @@
 use super::{
-    helpers::{parsing_catch_all, ToIdentifier},
+    helpers::{parsing_catch_all, ToIdentifier, TokenExtensions},
     parse_comments::*,
     parse_directive::parse_directive,
     parse_types::parse_field_type,
@@ -14,21 +14,21 @@ pub fn parse_field(model_name: &str, token: &pest::iterators::Pair<'_, Rule>) ->
     let mut field_type: Option<((FieldArity, String), Span)> = None;
     let mut comments: Vec<String> = Vec::new();
 
-    match_children! { token, current,
-        Rule::non_empty_identifier => name = Some(current.to_id()),
-        Rule::field_type => field_type = Some(
-            (
-                parse_field_type(&current)?,
-                Span::from_pest(current.as_span())
-            )
-        ),
-        Rule::LEGACY_COLON => return Err(DatamodelError::new_legacy_parser_error(
-            "Field declarations don't require a `:`.",
-            Span::from_pest(current.as_span()))),
-        Rule::directive => directives.push(parse_directive(&current)),
-        Rule::doc_comment_and_new_line => comments.push(parse_doc_comment(&current)),
-        Rule::doc_comment => comments.push(parse_doc_comment(&current)),
-        _ => parsing_catch_all(&current)
+    for current in token.filtered_children().into_iter() {
+        match current.as_rule() {
+            Rule::non_empty_identifier => name = Some(current.to_id()),
+            Rule::field_type => field_type = Some((parse_field_type(&current)?, Span::from_pest(current.as_span()))),
+            Rule::LEGACY_COLON => {
+                return Err(DatamodelError::new_legacy_parser_error(
+                    "Field declarations don't require a `:`.",
+                    Span::from_pest(current.as_span()),
+                ))
+            }
+            Rule::directive => directives.push(parse_directive(&current)),
+            Rule::doc_comment_and_new_line => comments.push(parse_doc_comment(&current)),
+            Rule::doc_comment => comments.push(parse_doc_comment(&current)),
+            _ => parsing_catch_all(&current),
+        }
     }
 
     match (name, field_type) {

--- a/libs/datamodel/core/src/ast/parser/parse_model.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_model.rs
@@ -1,5 +1,5 @@
 use super::{
-    helpers::{parsing_catch_all, ToIdentifier, TokenExtensions},
+    helpers::{parsing_catch_all, ToIdentifier, Token, TokenExtensions},
     parse_comments::*,
     parse_directive::parse_directive,
     parse_field::parse_field,
@@ -8,7 +8,7 @@ use super::{
 use crate::ast::*;
 use crate::error::{DatamodelError, ErrorCollection};
 
-pub fn parse_model(token: &pest::iterators::Pair<'_, Rule>) -> Result<Model, ErrorCollection> {
+pub fn parse_model(token: &Token) -> Result<Model, ErrorCollection> {
     let mut errors = ErrorCollection::new();
     let mut name: Option<Identifier> = None;
     let mut directives: Vec<Directive> = vec![];

--- a/libs/datamodel/core/src/ast/parser/parse_model.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_model.rs
@@ -15,7 +15,7 @@ pub fn parse_model(token: &Token) -> Result<Model, ErrorCollection> {
     let mut fields: Vec<Field> = vec![];
     let mut comment: Option<Comment> = None;
 
-    for current in token.filtered_children().into_iter() {
+    for current in token.filtered_children() {
         match current.as_rule() {
             Rule::TYPE_KEYWORD => errors.push(DatamodelError::new_legacy_parser_error(
                 "Model declarations have to be indicated with the `model` keyword.",

--- a/libs/datamodel/core/src/ast/parser/parse_model.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_model.rs
@@ -1,5 +1,5 @@
 use super::{
-    helpers::{parsing_catch_all, ToIdentifier},
+    helpers::{parsing_catch_all, ToIdentifier, TokenExtensions},
     parse_comments::*,
     parse_directive::parse_directive,
     parse_field::parse_field,
@@ -16,29 +16,25 @@ pub fn parse_model(token: &pest::iterators::Pair<'_, Rule>) -> Result<Model, Err
     let mut fields: Vec<Field> = vec![];
     let mut comment: Option<Comment> = None;
 
-    match_children! { token, current,
-        Rule::TYPE_KEYWORD => { errors.push(
-            DatamodelError::new_legacy_parser_error(
+    for current in token.filtered_children().into_iter() {
+        match current.as_rule() {
+            Rule::TYPE_KEYWORD => errors.push(DatamodelError::new_legacy_parser_error(
                 "Model declarations have to be indicated with the `model` keyword.",
-                Span::from_pest(current.as_span()))
-        ) },
-        Rule::non_empty_identifier => name = Some(current.to_id()),
-        Rule::directive => directives.push(parse_directive(&current)),
-        Rule::field_declaration => {
-            match parse_field(&name.as_ref().unwrap().name, &current) {
+                Span::from_pest(current.as_span()),
+            )),
+            Rule::non_empty_identifier => name = Some(current.to_id()),
+            Rule::directive => directives.push(parse_directive(&current)),
+            Rule::field_declaration => match parse_field(&name.as_ref().unwrap().name, &current) {
                 Ok(field) => fields.push(field),
-                Err(err) => errors.push(err)
-            }
-        },
-        Rule::comment_block => {
-            comment = Some(parse_comment_block(&current))
-        },
-        Rule::BLOCK_LEVEL_CATCH_ALL => { errors.push(
-            DatamodelError::new_validation_error(
+                Err(err) => errors.push(err),
+            },
+            Rule::comment_block => comment = Some(parse_comment_block(&current)),
+            Rule::BLOCK_LEVEL_CATCH_ALL => errors.push(DatamodelError::new_validation_error(
                 "This line is not a valid field or directive definition.",
-                Span::from_pest(current.as_span()))
-        ) },
-        _ => parsing_catch_all(&current)
+                Span::from_pest(current.as_span()),
+            )),
+            _ => parsing_catch_all(&current),
+        }
     }
 
     errors.ok()?;

--- a/libs/datamodel/core/src/ast/parser/parse_model.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_model.rs
@@ -8,7 +8,6 @@ use super::{
 use crate::ast::*;
 use crate::error::{DatamodelError, ErrorCollection};
 
-// Model parsing
 pub fn parse_model(token: &pest::iterators::Pair<'_, Rule>) -> Result<Model, ErrorCollection> {
     let mut errors = ErrorCollection::new();
     let mut name: Option<Identifier> = None;
@@ -33,7 +32,7 @@ pub fn parse_model(token: &pest::iterators::Pair<'_, Rule>) -> Result<Model, Err
                 "This line is not a valid field or directive definition.",
                 Span::from_pest(current.as_span()),
             )),
-            _ => parsing_catch_all(&current),
+            _ => parsing_catch_all(&current, "model"),
         }
     }
 

--- a/libs/datamodel/core/src/ast/parser/parse_model.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_model.rs
@@ -15,7 +15,7 @@ pub fn parse_model(token: &Token) -> Result<Model, ErrorCollection> {
     let mut fields: Vec<Field> = vec![];
     let mut comment: Option<Comment> = None;
 
-    for current in token.filtered_children() {
+    for current in token.relevant_children() {
         match current.as_rule() {
             Rule::TYPE_KEYWORD => errors.push(DatamodelError::new_legacy_parser_error(
                 "Model declarations have to be indicated with the `model` keyword.",

--- a/libs/datamodel/core/src/ast/parser/parse_schema.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_schema.rs
@@ -21,7 +21,7 @@ pub fn parse_schema(datamodel_string: &str) -> Result<SchemaAst, ErrorCollection
             let datamodel = datamodel_wrapped.next().unwrap();
             let mut top_level_definitions: Vec<Top> = vec![];
 
-            for current in datamodel.filtered_children().into_iter() {
+            for current in datamodel.filtered_children() {
                 match current.as_rule() {
                     Rule::model_declaration => match parse_model(&current) {
                         Ok(model) => top_level_definitions.push(Top::Model(model)),

--- a/libs/datamodel/core/src/ast/parser/parse_schema.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_schema.rs
@@ -1,7 +1,7 @@
 use pest::Parser;
 
 use super::{
-    helpers::TokenExtensions,
+    helpers::{parsing_catch_all, TokenExtensions},
     parse_enum::parse_enum,
     parse_model::parse_model,
     parse_source_and_generator::{parse_generator, parse_source},
@@ -50,10 +50,7 @@ pub fn parse_schema(datamodel_string: &str) -> Result<SchemaAst, ErrorCollection
                         &format!("This block is invalid. It does not start with any known Prisma schema keyword."),
                         Span::from_pest(current.as_span()),
                     )),
-                    _ => panic!(
-                        "Encountered impossible datamodel declaration during parsing: {:?}",
-                        current.tokens()
-                    ),
+                    _ => parsing_catch_all(&current, "datamodel"),
                 }
             }
 

--- a/libs/datamodel/core/src/ast/parser/parse_schema.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_schema.rs
@@ -21,7 +21,7 @@ pub fn parse_schema(datamodel_string: &str) -> Result<SchemaAst, ErrorCollection
             let datamodel = datamodel_wrapped.next().unwrap();
             let mut top_level_definitions: Vec<Top> = vec![];
 
-            for current in datamodel.filtered_children() {
+            for current in datamodel.relevant_children() {
                 match current.as_rule() {
                     Rule::model_declaration => match parse_model(&current) {
                         Ok(model) => top_level_definitions.push(Top::Model(model)),

--- a/libs/datamodel/core/src/ast/parser/parse_schema.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_schema.rs
@@ -1,6 +1,7 @@
 use pest::Parser;
 
 use super::{
+    helpers::TokenExtensions,
     parse_enum::parse_enum,
     parse_model::parse_model,
     parse_source_and_generator::{parse_generator, parse_source},
@@ -20,39 +21,40 @@ pub fn parse_schema(datamodel_string: &str) -> Result<SchemaAst, ErrorCollection
             let datamodel = datamodel_wrapped.next().unwrap();
             let mut top_level_definitions: Vec<Top> = vec![];
 
-            match_children! { datamodel, current,
-                Rule::model_declaration => match parse_model(&current) {
-                    Ok(model) => top_level_definitions.push(Top::Model(model)),
-                    Err(mut err) => errors.append(&mut err)
-                },
-                Rule::enum_declaration => match parse_enum(&current){
-                    Ok(enm) => top_level_definitions.push(Top::Enum(enm)),
-                    Err(mut err) => errors.append(&mut err)
-                },
-                Rule::source_block => match parse_source(&current) {
-                    Ok(source) => top_level_definitions.push(Top::Source(source)),
-                    Err(mut err) => errors.append(&mut err)
-                },
-                Rule::generator_block => match parse_generator(&current) {
-                    Ok(generator) => top_level_definitions.push(Top::Generator(generator)),
-                    Err(mut err) => errors.append(&mut err)
-                },
-                Rule::type_alias => top_level_definitions.push(Top::Type(parse_type_alias(&current))),
-                Rule::comment_block => (),
-                Rule::EOI => {},
-                Rule::CATCH_ALL => {
-                    errors.push(DatamodelError::new_validation_error(
+            for current in datamodel.filtered_children().into_iter() {
+                match current.as_rule() {
+                    Rule::model_declaration => match parse_model(&current) {
+                        Ok(model) => top_level_definitions.push(Top::Model(model)),
+                        Err(mut err) => errors.append(&mut err),
+                    },
+                    Rule::enum_declaration => match parse_enum(&current) {
+                        Ok(enm) => top_level_definitions.push(Top::Enum(enm)),
+                        Err(mut err) => errors.append(&mut err),
+                    },
+                    Rule::source_block => match parse_source(&current) {
+                        Ok(source) => top_level_definitions.push(Top::Source(source)),
+                        Err(mut err) => errors.append(&mut err),
+                    },
+                    Rule::generator_block => match parse_generator(&current) {
+                        Ok(generator) => top_level_definitions.push(Top::Generator(generator)),
+                        Err(mut err) => errors.append(&mut err),
+                    },
+                    Rule::type_alias => top_level_definitions.push(Top::Type(parse_type_alias(&current))),
+                    Rule::comment_block => (),
+                    Rule::EOI => {}
+                    Rule::CATCH_ALL => errors.push(DatamodelError::new_validation_error(
                         &format!("This line is invalid. It does not start with any known Prisma schema keyword."),
-                        Span::from_pest(current.as_span()))
-                    )
-                },
-                Rule::arbitrary_block => {
-                    errors.push(DatamodelError::new_validation_error(
+                        Span::from_pest(current.as_span()),
+                    )),
+                    Rule::arbitrary_block => errors.push(DatamodelError::new_validation_error(
                         &format!("This block is invalid. It does not start with any known Prisma schema keyword."),
-                        Span::from_pest(current.as_span()))
-                    )
-                },
-                _ => panic!("Encountered impossible datamodel declaration during parsing: {:?}", current.tokens())
+                        Span::from_pest(current.as_span()),
+                    )),
+                    _ => panic!(
+                        "Encountered impossible datamodel declaration during parsing: {:?}",
+                        current.tokens()
+                    ),
+                }
             }
 
             errors.ok()?;

--- a/libs/datamodel/core/src/ast/parser/parse_source_and_generator.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_source_and_generator.rs
@@ -1,5 +1,5 @@
 use super::{
-    helpers::{parsing_catch_all, ToIdentifier, TokenExtensions},
+    helpers::{parsing_catch_all, ToIdentifier, Token, TokenExtensions},
     parse_comments::*,
     parse_expression::parse_expression,
     Rule,
@@ -7,7 +7,7 @@ use super::{
 use crate::ast::*;
 use crate::error::{DatamodelError, ErrorCollection};
 
-pub fn parse_source(token: &pest::iterators::Pair<'_, Rule>) -> Result<SourceConfig, ErrorCollection> {
+pub fn parse_source(token: &Token) -> Result<SourceConfig, ErrorCollection> {
     let mut errors = ErrorCollection::new();
     let mut name: Option<Identifier> = None;
     let mut properties: Vec<Argument> = vec![];
@@ -42,7 +42,7 @@ pub fn parse_source(token: &pest::iterators::Pair<'_, Rule>) -> Result<SourceCon
     }
 }
 
-pub fn parse_generator(token: &pest::iterators::Pair<'_, Rule>) -> Result<GeneratorConfig, ErrorCollection> {
+pub fn parse_generator(token: &Token) -> Result<GeneratorConfig, ErrorCollection> {
     let mut errors = ErrorCollection::new();
     let mut name: Option<Identifier> = None;
     let mut properties: Vec<Argument> = vec![];
@@ -78,7 +78,7 @@ pub fn parse_generator(token: &pest::iterators::Pair<'_, Rule>) -> Result<Genera
     }
 }
 
-fn parse_key_value(token: &pest::iterators::Pair<'_, Rule>) -> Argument {
+fn parse_key_value(token: &Token) -> Argument {
     let mut name: Option<Identifier> = None;
     let mut value: Option<Expression> = None;
 

--- a/libs/datamodel/core/src/ast/parser/parse_source_and_generator.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_source_and_generator.rs
@@ -7,7 +7,6 @@ use super::{
 use crate::ast::*;
 use crate::error::{DatamodelError, ErrorCollection};
 
-// Source parsing
 pub fn parse_source(token: &pest::iterators::Pair<'_, Rule>) -> Result<SourceConfig, ErrorCollection> {
     let mut errors = ErrorCollection::new();
     let mut name: Option<Identifier> = None;
@@ -23,7 +22,7 @@ pub fn parse_source(token: &pest::iterators::Pair<'_, Rule>) -> Result<SourceCon
                 "This line is not a valid definition within a datasource.",
                 Span::from_pest(current.as_span()),
             )),
-            _ => parsing_catch_all(&current),
+            _ => parsing_catch_all(&current, "source"),
         }
     }
 
@@ -43,7 +42,6 @@ pub fn parse_source(token: &pest::iterators::Pair<'_, Rule>) -> Result<SourceCon
     }
 }
 
-// Generator parsing
 pub fn parse_generator(token: &pest::iterators::Pair<'_, Rule>) -> Result<GeneratorConfig, ErrorCollection> {
     let mut errors = ErrorCollection::new();
     let mut name: Option<Identifier> = None;
@@ -60,7 +58,7 @@ pub fn parse_generator(token: &pest::iterators::Pair<'_, Rule>) -> Result<Genera
                 "This line is not a valid definition within a generator.",
                 Span::from_pest(current.as_span()),
             )),
-            _ => parsing_catch_all(&current),
+            _ => parsing_catch_all(&current, "generator"),
         }
     }
 

--- a/libs/datamodel/core/src/ast/parser/parse_source_and_generator.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_source_and_generator.rs
@@ -13,7 +13,7 @@ pub fn parse_source(token: &Token) -> Result<SourceConfig, ErrorCollection> {
     let mut properties: Vec<Argument> = vec![];
     let mut comment: Option<Comment> = None;
 
-    for current in token.filtered_children() {
+    for current in token.relevant_children() {
         match current.as_rule() {
             Rule::non_empty_identifier => name = Some(current.to_id()),
             Rule::key_value => properties.push(parse_key_value(&current)),
@@ -48,7 +48,7 @@ pub fn parse_generator(token: &Token) -> Result<GeneratorConfig, ErrorCollection
     let mut properties: Vec<Argument> = vec![];
     let mut comments: Vec<String> = Vec::new();
 
-    for current in token.filtered_children() {
+    for current in token.relevant_children() {
         match current.as_rule() {
             Rule::non_empty_identifier => name = Some(current.to_id()),
             Rule::key_value => properties.push(parse_key_value(&current)),
@@ -82,7 +82,7 @@ fn parse_key_value(token: &Token) -> Argument {
     let mut name: Option<Identifier> = None;
     let mut value: Option<Expression> = None;
 
-    for current in token.filtered_children() {
+    for current in token.relevant_children() {
         match current.as_rule() {
             Rule::non_empty_identifier => name = Some(current.to_id()),
             Rule::expression => value = Some(parse_expression(&current)),

--- a/libs/datamodel/core/src/ast/parser/parse_source_and_generator.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_source_and_generator.rs
@@ -13,7 +13,7 @@ pub fn parse_source(token: &Token) -> Result<SourceConfig, ErrorCollection> {
     let mut properties: Vec<Argument> = vec![];
     let mut comment: Option<Comment> = None;
 
-    for current in token.filtered_children().into_iter() {
+    for current in token.filtered_children() {
         match current.as_rule() {
             Rule::non_empty_identifier => name = Some(current.to_id()),
             Rule::key_value => properties.push(parse_key_value(&current)),
@@ -48,7 +48,7 @@ pub fn parse_generator(token: &Token) -> Result<GeneratorConfig, ErrorCollection
     let mut properties: Vec<Argument> = vec![];
     let mut comments: Vec<String> = Vec::new();
 
-    for current in token.filtered_children().into_iter() {
+    for current in token.filtered_children() {
         match current.as_rule() {
             Rule::non_empty_identifier => name = Some(current.to_id()),
             Rule::key_value => properties.push(parse_key_value(&current)),
@@ -82,7 +82,7 @@ fn parse_key_value(token: &Token) -> Argument {
     let mut name: Option<Identifier> = None;
     let mut value: Option<Expression> = None;
 
-    for current in token.filtered_children().into_iter() {
+    for current in token.filtered_children() {
         match current.as_rule() {
             Rule::non_empty_identifier => name = Some(current.to_id()),
             Rule::expression => value = Some(parse_expression(&current)),

--- a/libs/datamodel/core/src/ast/parser/parse_types.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_types.rs
@@ -1,4 +1,9 @@
-use super::{helpers::ToIdentifier, parse_comments::parse_comment_block, parse_directive::parse_directive, Rule};
+use super::{
+    helpers::{ToIdentifier, TokenExtensions},
+    parse_comments::parse_comment_block,
+    parse_directive::parse_directive,
+    Rule,
+};
 use crate::ast::*;
 use crate::error::DatamodelError;
 
@@ -42,29 +47,31 @@ pub fn parse_type_alias(token: &pest::iterators::Pair<'_, Rule>) -> Field {
 }
 
 pub fn parse_field_type(token: &pest::iterators::Pair<'_, Rule>) -> Result<(FieldArity, String), DatamodelError> {
-    match_first! { token, current,
+    let current = token.first_child();
+    match current.as_rule() {
         Rule::optional_type => Ok((FieldArity::Optional, parse_base_type(&current))),
-        Rule::base_type =>  Ok((FieldArity::Required, parse_base_type(&current))),
-        Rule::list_type =>  Ok((FieldArity::List, parse_base_type(&current))),
+        Rule::base_type => Ok((FieldArity::Required, parse_base_type(&current))),
+        Rule::list_type => Ok((FieldArity::List, parse_base_type(&current))),
         Rule::legacy_required_type => Err(DatamodelError::new_legacy_parser_error(
             "Fields are required by default, `!` is no longer required.",
-            Span::from_pest(current.as_span())
+            Span::from_pest(current.as_span()),
         )),
         Rule::legacy_list_type => Err(DatamodelError::new_legacy_parser_error(
             "To specify a list, please use `Type[]` instead of `[Type]`.",
-            Span::from_pest(current.as_span())
+            Span::from_pest(current.as_span()),
         )),
         Rule::unsupported_optional_list_type => Err(DatamodelError::new_legacy_parser_error(
             "Optional lists are not supported. Use either `Type[]` or `Type?`.",
-            Span::from_pest(current.as_span())
+            Span::from_pest(current.as_span()),
         )),
-        _ => unreachable!("Encountered impossible field during parsing: {:?}", current.tokens())
+        _ => unreachable!("Encountered impossible field during parsing: {:?}", current.tokens()),
     }
 }
 
 fn parse_base_type(token: &pest::iterators::Pair<'_, Rule>) -> String {
-    match_first! { token, current,
+    let current = token.first_child();
+    match current.as_rule() {
         Rule::non_empty_identifier => current.as_str().to_string(),
-        _ => unreachable!("Encountered impossible type during parsing: {:?}", current.tokens())
+        _ => unreachable!("Encountered impossible type during parsing: {:?}", current.tokens()),
     }
 }

--- a/libs/datamodel/core/src/ast/parser/parse_types.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_types.rs
@@ -1,5 +1,5 @@
 use super::{
-    helpers::{ToIdentifier, TokenExtensions},
+    helpers::{parsing_catch_all, ToIdentifier, TokenExtensions},
     parse_comments::parse_comment_block,
     parse_directive::parse_directive,
     Rule,
@@ -20,10 +20,7 @@ pub fn parse_type_alias(token: &pest::iterators::Pair<'_, Rule>) -> Field {
             Rule::base_type => base_type = Some((parse_base_type(&current), Span::from_pest(current.as_span()))),
             Rule::directive => directives.push(parse_directive(&current)),
             Rule::comment_block => comment = Some(parse_comment_block(&current)),
-            _ => unreachable!(
-                "Encountered impossible custom type during parsing: {:?}",
-                current.tokens()
-            ),
+            _ => parsing_catch_all(&current, "custom type"),
         }
     }
 

--- a/libs/datamodel/core/src/ast/parser/parse_types.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_types.rs
@@ -13,7 +13,7 @@ pub fn parse_type_alias(token: &Token) -> Field {
     let mut base_type: Option<(String, Span)> = None;
     let mut comment: Option<Comment> = None;
 
-    for current in token.filtered_children().into_iter() {
+    for current in token.filtered_children() {
         match current.as_rule() {
             Rule::TYPE_KEYWORD => {}
             Rule::non_empty_identifier => name = Some(current.to_id()),

--- a/libs/datamodel/core/src/ast/parser/parse_types.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_types.rs
@@ -1,5 +1,5 @@
 use super::{
-    helpers::{parsing_catch_all, ToIdentifier, TokenExtensions},
+    helpers::{parsing_catch_all, ToIdentifier, Token, TokenExtensions},
     parse_comments::parse_comment_block,
     parse_directive::parse_directive,
     Rule,
@@ -7,7 +7,7 @@ use super::{
 use crate::ast::*;
 use crate::error::DatamodelError;
 
-pub fn parse_type_alias(token: &pest::iterators::Pair<'_, Rule>) -> Field {
+pub fn parse_type_alias(token: &Token) -> Field {
     let mut name: Option<Identifier> = None;
     let mut directives: Vec<Directive> = vec![];
     let mut base_type: Option<(String, Span)> = None;
@@ -44,7 +44,7 @@ pub fn parse_type_alias(token: &pest::iterators::Pair<'_, Rule>) -> Field {
     }
 }
 
-pub fn parse_field_type(token: &pest::iterators::Pair<'_, Rule>) -> Result<(FieldArity, String), DatamodelError> {
+pub fn parse_field_type(token: &Token) -> Result<(FieldArity, String), DatamodelError> {
     let current = token.first_child();
     match current.as_rule() {
         Rule::optional_type => Ok((FieldArity::Optional, parse_base_type(&current))),
@@ -66,7 +66,7 @@ pub fn parse_field_type(token: &pest::iterators::Pair<'_, Rule>) -> Result<(Fiel
     }
 }
 
-fn parse_base_type(token: &pest::iterators::Pair<'_, Rule>) -> String {
+fn parse_base_type(token: &Token) -> String {
     let current = token.first_child();
     match current.as_rule() {
         Rule::non_empty_identifier => current.as_str().to_string(),

--- a/libs/datamodel/core/src/ast/parser/parse_types.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_types.rs
@@ -13,17 +13,18 @@ pub fn parse_type_alias(token: &pest::iterators::Pair<'_, Rule>) -> Field {
     let mut base_type: Option<(String, Span)> = None;
     let mut comment: Option<Comment> = None;
 
-    match_children! { token, current,
-        Rule::TYPE_KEYWORD => { },
-        Rule::non_empty_identifier => name = Some(current.to_id()),
-        Rule::base_type => {
-            base_type = Some((parse_base_type(&current), Span::from_pest(current.as_span())))
-        },
-        Rule::directive => directives.push(parse_directive(&current)),
-        Rule::comment_block => {
-            comment = Some(parse_comment_block(&current))
-        },
-        _ => unreachable!("Encountered impossible custom type during parsing: {:?}", current.tokens())
+    for current in token.filtered_children().into_iter() {
+        match current.as_rule() {
+            Rule::TYPE_KEYWORD => {}
+            Rule::non_empty_identifier => name = Some(current.to_id()),
+            Rule::base_type => base_type = Some((parse_base_type(&current), Span::from_pest(current.as_span()))),
+            Rule::directive => directives.push(parse_directive(&current)),
+            Rule::comment_block => comment = Some(parse_comment_block(&current)),
+            _ => unreachable!(
+                "Encountered impossible custom type during parsing: {:?}",
+                current.tokens()
+            ),
+        }
     }
 
     match (name, base_type) {

--- a/libs/datamodel/core/src/ast/parser/parse_types.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_types.rs
@@ -13,7 +13,7 @@ pub fn parse_type_alias(token: &Token) -> Field {
     let mut base_type: Option<(String, Span)> = None;
     let mut comment: Option<Comment> = None;
 
-    for current in token.filtered_children() {
+    for current in token.relevant_children() {
         match current.as_rule() {
             Rule::TYPE_KEYWORD => {}
             Rule::non_empty_identifier => name = Some(current.to_id()),
@@ -45,7 +45,7 @@ pub fn parse_type_alias(token: &Token) -> Field {
 }
 
 pub fn parse_field_type(token: &Token) -> Result<(FieldArity, String), DatamodelError> {
-    let current = token.first_child();
+    let current = token.first_relevant_child();
     match current.as_rule() {
         Rule::optional_type => Ok((FieldArity::Optional, parse_base_type(&current))),
         Rule::base_type => Ok((FieldArity::Required, parse_base_type(&current))),
@@ -67,7 +67,7 @@ pub fn parse_field_type(token: &Token) -> Result<(FieldArity, String), Datamodel
 }
 
 fn parse_base_type(token: &Token) -> String {
-    let current = token.first_child();
+    let current = token.first_relevant_child();
     match current.as_rule() {
         Rule::non_empty_identifier => current.as_str().to_string(),
         _ => unreachable!("Encountered impossible type during parsing: {:?}", current.tokens()),

--- a/libs/datamodel/core/src/lib.rs
+++ b/libs/datamodel/core/src/lib.rs
@@ -19,30 +19,6 @@ macro_rules! match_children (
     );
 );
 
-// Macro to match the first child in a parse tree
-#[macro_use]
-macro_rules! match_first (
-    ($token:ident, $current:ident, $($pattern:pat => $result:expr),*) => ( {
-            // Explicit clone, as into_inner consumes the pair.
-        // We only need a reference to the pair later for logging.
-            let $current = $token.clone()
-                .into_inner()
-                .filter(|rule|
-                    rule.as_rule() != Rule::BLOCK_CLOSE &&
-                    rule.as_rule() != Rule::BLOCK_OPEN &&
-                    rule.as_rule() != Rule::WHITESPACE &&
-                    rule.as_rule() != Rule::NEWLINE
-                )
-                .next().unwrap();
-            match $current.as_rule() {
-                $(
-                    $pattern => $result
-                ),*
-            }
-        }
-    );
-);
-
 extern crate pest; // Pest grammar generation on compile time.
 #[macro_use]
 extern crate pest_derive;

--- a/libs/datamodel/core/src/lib.rs
+++ b/libs/datamodel/core/src/lib.rs
@@ -1,24 +1,3 @@
-// Load macros first - Global Macros used for parsing.
-// Macro to match all children in a parse tree
-#[macro_use]
-macro_rules! match_children (
-    ($token:ident, $current:ident, $($pattern:pat => $result:expr),*) => (
-        // Explicit clone, as into_inner consumes the pair.
-        // We only need a reference to the pair later for logging.
-        for $current in $token.clone().into_inner() {
-            match $current.as_rule() {
-                Rule::WHITESPACE => { },
-                Rule::BLOCK_OPEN => { },
-                Rule::BLOCK_CLOSE => { },
-                Rule::NEWLINE => { },
-                $(
-                    $pattern => $result
-                ),*
-            }
-        }
-    );
-);
-
 extern crate pest; // Pest grammar generation on compile time.
 #[macro_use]
 extern crate pest_derive;


### PR DESCRIPTION
This PR removes two macros that were not necessary and made code reading harder imo.