### PR TITLE
Upstream migration engine datamodel helpers

### DIFF
--- a/libs/datamodel/core/src/lib.rs
+++ b/libs/datamodel/core/src/lib.rs
@@ -58,6 +58,7 @@ pub mod dml;
 pub mod error;
 pub mod json;
 pub mod validator;
+pub mod walkers;
 
 pub use common::DefaultNames;
 pub use configuration::*;

--- a/libs/datamodel/core/src/walkers.rs
+++ b/libs/datamodel/core/src/walkers.rs
@@ -7,7 +7,10 @@ use crate::{
 };
 
 pub fn walk_models<'a>(datamodel: &'a Datamodel) -> impl Iterator<Item = ModelWalker<'a>> + 'a {
-    datamodel.models.iter().map(move |model| ModelWalker { datamodel, model })
+    datamodel
+        .models
+        .iter()
+        .map(move |model| ModelWalker { datamodel, model })
 }
 
 /// Iterator to walk all the scalar fields in the schema, associating them with their parent model.

--- a/migration-engine/connectors/sql-migration-connector/src/database_info.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/database_info.rs
@@ -1,5 +1,5 @@
 use super::SqlResult;
-use datamodel::{Datamodel, walkers::walk_scalar_fields};
+use datamodel::{walkers::walk_scalar_fields, Datamodel};
 use migration_connector::MigrationError;
 use quaint::{
     prelude::{ConnectionInfo, Queryable, SqlFamily},

--- a/migration-engine/connectors/sql-migration-connector/src/database_info.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/database_info.rs
@@ -1,5 +1,5 @@
 use super::SqlResult;
-use datamodel::Datamodel;
+use datamodel::{Datamodel, walkers::walk_scalar_fields};
 use migration_connector::MigrationError;
 use quaint::{
     prelude::{ConnectionInfo, Queryable, SqlFamily},
@@ -77,7 +77,7 @@ async fn get_database_version(connection: &Quaint, connection_info: &ConnectionI
 }
 
 fn check_datamodel_for_mysql_5_6(datamodel: &Datamodel, errors: &mut Vec<MigrationError>) {
-    crate::datamodel_helpers::walk_scalar_fields(datamodel).for_each(|field| {
+    walk_scalar_fields(datamodel).for_each(|field| {
         if field.field_type().is_json() {
             errors.push(MigrationError {
                 description: format!(

--- a/migration-engine/connectors/sql-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/lib.rs
@@ -4,7 +4,6 @@
 
 mod component;
 mod database_info;
-mod datamodel_helpers;
 mod error;
 mod flavour;
 mod sql_database_migration_inferrer;

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
@@ -1,9 +1,10 @@
-use crate::{
-    error::SqlError,
-    sql_renderer::IteratorJoin,
-    DatabaseInfo, SqlResult,
+use crate::{error::SqlError, sql_renderer::IteratorJoin, DatabaseInfo, SqlResult};
+use datamodel::{
+    common::*,
+    walkers::{walk_models, walk_scalar_fields, ModelWalker, ScalarFieldWalker, TypeWalker},
+    Datamodel, DefaultValue, FieldArity, IndexDefinition, IndexType, ValueGenerator, ValueGeneratorFn,
+    WithDatabaseName,
 };
-use datamodel::{walkers::{ModelWalker, ScalarFieldWalker, TypeWalker, walk_scalar_fields, walk_models}, common::*, Datamodel, WithDatabaseName, DefaultValue, ValueGenerator, ValueGeneratorFn, IndexDefinition, IndexType, FieldArity};
 use prisma_models::{DatamodelConverter, TempManifestationHolder, TempRelationHolder};
 use prisma_value::PrismaValue;
 use quaint::prelude::SqlFamily;
@@ -309,7 +310,9 @@ fn migration_value_new(field: &ScalarFieldWalker<'_>) -> Option<sql_schema_descr
         datamodel::DefaultValue::Expression(expression) if expression.name == "now" && expression.args.is_empty() => {
             return Some(sql_schema_describer::DefaultValue::NOW)
         }
-        datamodel::DefaultValue::Expression(expression) if expression.name == "dbgenerated" && expression.args.is_empty() => {
+        datamodel::DefaultValue::Expression(expression)
+            if expression.name == "dbgenerated" && expression.args.is_empty() =>
+        {
             return Some(sql_schema_describer::DefaultValue::DBGENERATED(String::new()))
         }
         datamodel::DefaultValue::Expression(_) => return None,


### PR DESCRIPTION
They are renamed to `*Walker` to make the purpose clear: they allow traversing the datamodel structure in all directions, for example from field to model, or from a relation field to the opposite relation field.