### PR TITLE
Implement migration of autoincrement sequences in isolation

### DIFF
--- a/libs/sql-schema-describer/src/postgres.rs
+++ b/libs/sql-schema-describer/src/postgres.rs
@@ -714,7 +714,8 @@ fn is_autoincrement(value: &str, schema_name: &str, table_name: &str, column_nam
                         let matched_segments = matched.as_str().split('_');
                         matched_segments
                             .zip(table_name_segments.chain(column_name_segments))
-                            .all(|(found, expected)| found == expected)
+                            // postgres automatically lower-cases table/column names when generating sequence names
+                            .all(|(found, expected)| found == expected || found == expected.to_lowercase())
                     })
                 })
                 .map(|_| true)

--- a/libs/sql-schema-describer/src/postgres.rs
+++ b/libs/sql-schema-describer/src/postgres.rs
@@ -277,17 +277,13 @@ impl SqlSchemaDescriber {
                 },
             };
 
-            let is_auto_increment = is_identity
-                || match default {
-                    Some(DefaultValue::SEQUENCE(_)) => true,
-                    _ => false,
-                };
+            let auto_increment = is_identity || matches!(default, Some(DefaultValue::SEQUENCE(_)));
 
             let col = Column {
                 name: col_name,
                 tpe,
                 default,
-                auto_increment: is_auto_increment,
+                auto_increment,
             };
 
             columns.entry(table_name).or_default().push(col);

--- a/migration-engine/connectors/sql-migration-connector/src/flavour.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour.rs
@@ -179,7 +179,7 @@ impl SqlFlavour for SqliteFlavour {
     }
 }
 
-pub(crate) struct PostgresFlavour(PostgresUrl);
+pub(crate) struct PostgresFlavour(pub(crate) PostgresUrl);
 
 #[async_trait::async_trait]
 impl SqlFlavour for PostgresFlavour {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
@@ -1,7 +1,7 @@
 use crate::*;
-use sql_renderer::{postgres_render_column_type, rendered_step::RenderedStep, IteratorJoin, Quoted};
+use sql_renderer::{rendered_step::RenderedStep, IteratorJoin, Quoted};
 use sql_schema_describer::*;
-use sql_schema_differ::{ColumnChanges, ColumnDiffer, DiffingOptions};
+use sql_schema_differ::{ColumnDiffer, DiffingOptions};
 use sql_schema_helpers::{find_column, walk_columns, ColumnRef, SqlSchemaExt};
 use std::fmt::Write as _;
 use tracing_futures::Instrument;
@@ -290,7 +290,7 @@ fn render_raw_sql(
                             find_column(next_schema, &table.name, &column.name)
                                 .expect("Invariant violation: could not find column referred to in AlterColumn."),
                             &DiffingOptions::from_database_info(database_info),
-                        )? {
+                        ) {
                             Some(safe_sql) => {
                                 for line in safe_sql {
                                     lines.push(line)
@@ -454,97 +454,14 @@ fn safe_alter_column(
     previous_column: ColumnRef<'_>,
     next_column: ColumnRef<'_>,
     diffing_options: &DiffingOptions,
-) -> anyhow::Result<Option<Vec<String>>> {
-    use crate::sql_migration::expanded_alter_column::*;
-
+) -> Option<Vec<String>> {
     let differ = ColumnDiffer {
         previous: previous_column,
         next: next_column,
         diffing_options,
     };
 
-    let expanded = expand_alter_column(&differ, &renderer.sql_family());
-
-    let alter_column_prefix = format!("ALTER COLUMN {}", renderer.quote(differ.previous.name()));
-
-    let steps = match expanded {
-        Some(ExpandedAlterColumn::Postgres(steps)) => steps
-            .into_iter()
-            .map(|step| match step {
-                PostgresAlterColumn::DropDefault => format!("{} DROP DEFAULT", &alter_column_prefix),
-                PostgresAlterColumn::SetDefault(new_default) => format!(
-                    "{} SET DEFAULT {}",
-                    &alter_column_prefix,
-                    renderer.render_default(&new_default, &next_column.column.tpe.family)
-                ),
-                PostgresAlterColumn::DropNotNull => format!("{} DROP NOT NULL", &alter_column_prefix),
-                PostgresAlterColumn::SetNotNull => format!("{} SET NOT NULL", &alter_column_prefix),
-                PostgresAlterColumn::SetType(ty) => format!(
-                    "{} SET DATA TYPE {}",
-                    &alter_column_prefix,
-                    postgres_render_column_type(&ty)
-                ),
-                PostgresAlterColumn::AddSequence => todo!("postgres AddSequence"),
-            })
-            .collect(),
-        Some(ExpandedAlterColumn::Mysql(step)) => match step {
-            MysqlAlterColumn::DropDefault => vec![format!("{} DROP DEFAULT", &alter_column_prefix)],
-            MysqlAlterColumn::Modify { new_default, changes } => vec![render_mysql_modify(
-                &changes,
-                new_default.as_ref(),
-                next_column,
-                renderer,
-            )?],
-        },
-        Some(ExpandedAlterColumn::Sqlite(_steps)) => vec![],
-        None => return Ok(None),
-    };
-
-    Ok(Some(steps))
-}
-
-fn render_mysql_modify(
-    changes: &ColumnChanges,
-    new_default: Option<&sql_schema_describer::DefaultValue>,
-    next_column: ColumnRef<'_>,
-    renderer: &dyn SqlFlavour,
-) -> anyhow::Result<String> {
-    let column_type: Option<String> = if changes.type_changed() {
-        Some(next_column.column_type().full_data_type.clone()).filter(|r| !r.is_empty() || r.contains("datetime"))
-    // @default(now()) does not work with datetimes of certain sizes
-    } else {
-        Some(next_column.column.tpe.full_data_type.clone()).filter(|r| !r.is_empty())
-    };
-
-    let column_type = column_type
-        .map(Ok)
-        .unwrap_or_else(|| sql_renderer::mysql_render_column_type(&next_column).map(String::from))?;
-
-    let default = new_default
-        .map(|default| {
-            format!(
-                " DEFAULT {}",
-                renderer.render_default(&default, &next_column.column_type().family)
-            )
-        })
-        .unwrap_or_else(String::new);
-
-    Ok(format!(
-        "MODIFY {column_name} {column_type}{nullability}{default}{sequence}",
-        column_name = Quoted::mysql_ident(&next_column.name()),
-        column_type = column_type,
-        nullability = if next_column.arity().is_required() {
-            " NOT NULL"
-        } else {
-            ""
-        },
-        default = default,
-        sequence = if next_column.is_autoincrement() {
-            " AUTO_INCREMENT"
-        } else {
-            ""
-        },
-    ))
+    renderer.render_alter_column(&differ)
 }
 
 fn render_create_enum(

--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
@@ -296,14 +296,18 @@ fn render_raw_sql(
                         ) {
                             Some(RenderedAlterColumn {
                                 alter_columns,
-                                before_and_after,
+                                before,
+                                after,
                             }) => {
                                 for statement in alter_columns {
                                     lines.push(statement);
                                 }
 
-                                if let Some((before, after)) = before_and_after {
+                                if let Some(before) = before {
                                     before_statements.push(before);
+                                }
+
+                                if let Some(after) = after {
                                     after_statements.push(after);
                                 }
                             }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
@@ -507,7 +507,7 @@ fn render_mysql_modify(
     changes: &ColumnChanges,
     new_default: Option<&sql_schema_describer::DefaultValue>,
     next_column: ColumnRef<'_>,
-    renderer: &dyn SqlRenderer,
+    renderer: &dyn SqlFlavour,
 ) -> anyhow::Result<String> {
     let column_type: Option<String> = if changes.type_changed() {
         Some(next_column.column_type().full_data_type.clone()).filter(|r| !r.is_empty() || r.contains("datetime"))

--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
@@ -484,6 +484,7 @@ fn safe_alter_column(
                     &alter_column_prefix,
                     postgres_render_column_type(&ty)
                 ),
+                PostgresAlterColumn::AddSequence => todo!("postgres AddSequence"),
             })
             .collect(),
         Some(ExpandedAlterColumn::Mysql(step)) => match step {
@@ -538,7 +539,7 @@ fn render_mysql_modify(
             ""
         },
         default = default,
-        sequence = if next_column.auto_increment() {
+        sequence = if next_column.is_autoincrement() {
             " AUTO_INCREMENT"
         } else {
             ""

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/destructive_change_checker_flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/destructive_change_checker_flavour/postgres.rs
@@ -40,6 +40,7 @@ impl DestructiveChangeCheckerFlavour for PostgresFlavour {
                         }
                     }
                     PostgresAlterColumn::SetDefault(_)
+                    | PostgresAlterColumn::AddSequence
                     | PostgresAlterColumn::DropDefault
                     | PostgresAlterColumn::DropNotNull => (),
                 }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_migration/expanded_alter_column.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_migration/expanded_alter_column.rs
@@ -85,8 +85,8 @@ pub(crate) fn expand_postgres_alter_column(columns: &ColumnDiffer<'_>) -> Option
             },
             ColumnChange::Sequence => {
                 if columns.previous.is_autoincrement() {
-                    // // The sequence should be dropped.
-                    // changes.push(PostgresAlterColumn::DropDefault)
+                    // The sequence should be dropped.
+                    changes.push(PostgresAlterColumn::DropDefault)
                 } else {
                     // The sequence should be created.
                     changes.push(PostgresAlterColumn::AddSequence)

--- a/migration-engine/connectors/sql-migration-connector/src/sql_migration/expanded_alter_column.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_migration/expanded_alter_column.rs
@@ -131,7 +131,8 @@ pub(crate) enum MysqlAlterColumn {
     },
 }
 
+// Not used yet: SQLite only supports column renamings, which we don't. All
+// other transformations will involve redefining the table.
+// https://www.sqlite.org/lang_altertable.html
 #[derive(Debug)]
-pub(crate) enum SqliteAlterColumn {
-    // Not used yet
-}
+pub(crate) enum SqliteAlterColumn {}

--- a/migration-engine/connectors/sql-migration-connector/src/sql_migration/expanded_alter_column.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_migration/expanded_alter_column.rs
@@ -83,7 +83,15 @@ pub(crate) fn expand_postgres_alter_column(columns: &ColumnDiffer<'_>) -> Option
                 }
                 _ => return None,
             },
-            ColumnChange::Sequence => todo!("Sequence migrations on postgres"),
+            ColumnChange::Sequence => {
+                if columns.previous.is_autoincrement() {
+                    // // The sequence should be dropped.
+                    // changes.push(PostgresAlterColumn::DropDefault)
+                } else {
+                    // The sequence should be created.
+                    changes.push(PostgresAlterColumn::AddSequence)
+                }
+            }
             ColumnChange::Renaming => unreachable!("column renaming"),
         }
     }
@@ -106,6 +114,8 @@ pub(crate) enum PostgresAlterColumn {
     DropNotNull,
     SetType(ColumnType),
     SetNotNull,
+    // Add an auto-incrementing sequence as a default on the column.
+    AddSequence,
 }
 
 /// https://dev.mysql.com/doc/refman/8.0/en/alter-table.html

--- a/migration-engine/connectors/sql-migration-connector/src/sql_migration/expanded_alter_column.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_migration/expanded_alter_column.rs
@@ -1,22 +1,5 @@
 use crate::sql_schema_differ::{ColumnChange, ColumnChanges, ColumnDiffer};
-use quaint::prelude::SqlFamily;
 use sql_schema_describer::{ColumnArity, ColumnType, ColumnTypeFamily, DefaultValue};
-
-pub(crate) fn expand_alter_column(
-    column_differ: &ColumnDiffer<'_>,
-    sql_family: &SqlFamily,
-) -> Option<ExpandedAlterColumn> {
-    match sql_family {
-        SqlFamily::Sqlite => expand_sqlite_alter_column(&column_differ).map(ExpandedAlterColumn::Sqlite),
-        SqlFamily::Mysql => Some(ExpandedAlterColumn::Mysql(expand_mysql_alter_column(&column_differ))),
-        SqlFamily::Postgres => expand_postgres_alter_column(&column_differ).map(ExpandedAlterColumn::Postgres),
-        SqlFamily::Mssql => todo!("Greetings from Redmond"),
-    }
-}
-
-pub(crate) fn expand_sqlite_alter_column(_columns: &ColumnDiffer<'_>) -> Option<Vec<SqliteAlterColumn>> {
-    None
-}
 
 pub(crate) fn expand_mysql_alter_column(columns: &ColumnDiffer<'_>) -> MysqlAlterColumn {
     let column_changes = columns.all_changes();
@@ -100,13 +83,6 @@ pub(crate) fn expand_postgres_alter_column(columns: &ColumnDiffer<'_>) -> Option
 }
 
 #[derive(Debug)]
-pub(crate) enum ExpandedAlterColumn {
-    Postgres(Vec<PostgresAlterColumn>),
-    Mysql(MysqlAlterColumn),
-    Sqlite(Vec<SqliteAlterColumn>),
-}
-
-#[derive(Debug)]
 /// https://www.postgresql.org/docs/9.1/sql-altertable.html
 pub(crate) enum PostgresAlterColumn {
     SetDefault(sql_schema_describer::DefaultValue),
@@ -114,7 +90,7 @@ pub(crate) enum PostgresAlterColumn {
     DropNotNull,
     SetType(ColumnType),
     SetNotNull,
-    // Add an auto-incrementing sequence as a default on the column.
+    /// Add an auto-incrementing sequence as a default on the column.
     AddSequence,
 }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_migration/expanded_alter_column.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_migration/expanded_alter_column.rs
@@ -83,6 +83,7 @@ pub(crate) fn expand_postgres_alter_column(columns: &ColumnDiffer<'_>) -> Option
                 }
                 _ => return None,
             },
+            ColumnChange::Sequence => todo!("Sequence migrations on postgres"),
             ColumnChange::Renaming => unreachable!("column renaming"),
         }
     }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer.rs
@@ -31,8 +31,6 @@ pub(crate) trait SqlRenderer {
     /// passed-in differ. `None` means that we could not generate a good (set
     /// of) ALTER COLUMN(s), and we should fall back to dropping and recreating
     /// the column.
-    ///
-    /// The return type should be interpreted as (alter table lines, (statement before, statement after))
     fn render_alter_column(&self, differ: &ColumnDiffer<'_>) -> Option<RenderedAlterColumn>;
 }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer.rs
@@ -6,10 +6,8 @@ mod postgres_renderer;
 mod sqlite_renderer;
 
 pub(crate) use common::{IteratorJoin, Quoted, QuotedWithSchema};
-pub(crate) use mysql_renderer::render_column_type as mysql_render_column_type;
-pub(crate) use postgres_renderer::render_column_type as postgres_render_column_type;
 
-use crate::sql_schema_helpers::ColumnRef;
+use crate::{sql_schema_differ::ColumnDiffer, sql_schema_helpers::ColumnRef};
 use sql_schema_describer::*;
 use std::borrow::Cow;
 
@@ -28,4 +26,6 @@ pub(crate) trait SqlRenderer {
     fn render_references(&self, schema_name: &str, foreign_key: &ForeignKey) -> String;
 
     fn render_default<'a>(&self, default: &'a DefaultValue, family: &ColumnTypeFamily) -> Cow<'a, str>;
+
+    fn render_alter_column(&self, differ: &ColumnDiffer<'_>) -> Option<Vec<String>>;
 }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer.rs
@@ -27,5 +27,9 @@ pub(crate) trait SqlRenderer {
 
     fn render_default<'a>(&self, default: &'a DefaultValue, family: &ColumnTypeFamily) -> Cow<'a, str>;
 
+    /// Attempt to render a database-specific ALTER COLUMN based on the
+    /// passed-in differ. `None` means that we could not generate a good (set
+    /// of) ALTER COLUMN(s), and we should fall back to dropping and recreating
+    /// the column.
     fn render_alter_column(&self, differ: &ColumnDiffer<'_>) -> Option<Vec<String>>;
 }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer.rs
@@ -31,5 +31,15 @@ pub(crate) trait SqlRenderer {
     /// passed-in differ. `None` means that we could not generate a good (set
     /// of) ALTER COLUMN(s), and we should fall back to dropping and recreating
     /// the column.
-    fn render_alter_column(&self, differ: &ColumnDiffer<'_>) -> Option<Vec<String>>;
+    ///
+    /// The return type should be interpreted as (alter table lines, (statement before, statement after))
+    fn render_alter_column(&self, differ: &ColumnDiffer<'_>) -> Option<RenderedAlterColumn>;
+}
+
+#[derive(Default)]
+pub(crate) struct RenderedAlterColumn {
+    /// The statements that will be included in the ALTER TABLE
+    pub(crate) alter_columns: Vec<String>,
+    /// The statements to be run before and after the ALTER TABLE.
+    pub(crate) before_and_after: Option<(String, String)>,
 }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer.rs
@@ -40,6 +40,8 @@ pub(crate) trait SqlRenderer {
 pub(crate) struct RenderedAlterColumn {
     /// The statements that will be included in the ALTER TABLE
     pub(crate) alter_columns: Vec<String>,
-    /// The statements to be run before and after the ALTER TABLE.
-    pub(crate) before_and_after: Option<(String, String)>,
+    /// The statements to be run before the ALTER TABLE.
+    pub(crate) before: Option<String>,
+    /// The statements to be run after the ALTER TABLE.
+    pub(crate) after: Option<String>,
 }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
@@ -93,7 +93,8 @@ impl SqlRenderer for MysqlFlavour {
 
         Some(RenderedAlterColumn {
             alter_columns: sql,
-            before_and_after: None,
+            before: None,
+            after: None,
         })
     }
 }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
@@ -1,4 +1,4 @@
-use super::{common::*, SqlRenderer};
+use super::{common::*, RenderedAlterColumn, SqlRenderer};
 use crate::{
     expanded_alter_column::{expand_mysql_alter_column, MysqlAlterColumn},
     flavour::{MysqlFlavour, SqlFlavour},
@@ -78,7 +78,7 @@ impl SqlRenderer for MysqlFlavour {
         }
     }
 
-    fn render_alter_column<'a>(&self, differ: &ColumnDiffer<'_>) -> Option<Vec<String>> {
+    fn render_alter_column<'a>(&self, differ: &ColumnDiffer<'_>) -> Option<RenderedAlterColumn> {
         let expanded = expand_mysql_alter_column(differ);
 
         let sql = match expanded {
@@ -91,7 +91,10 @@ impl SqlRenderer for MysqlFlavour {
             }
         };
 
-        Some(sql)
+        Some(RenderedAlterColumn {
+            alter_columns: sql,
+            before_and_after: None,
+        })
     }
 }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
@@ -1,5 +1,10 @@
 use super::{common::*, SqlRenderer};
-use crate::{flavour::MysqlFlavour, sql_schema_helpers::ColumnRef};
+use crate::{
+    expanded_alter_column::{expand_mysql_alter_column, MysqlAlterColumn},
+    flavour::{MysqlFlavour, SqlFlavour},
+    sql_schema_differ::{ColumnChanges, ColumnDiffer},
+    sql_schema_helpers::ColumnRef,
+};
 use once_cell::sync::Lazy;
 use prisma_models::PrismaValue;
 use regex::Regex;
@@ -15,7 +20,7 @@ impl SqlRenderer for MysqlFlavour {
 
     fn render_column(&self, _schema_name: &str, column: ColumnRef<'_>, _add_fk_prefix: bool) -> String {
         let column_name = self.quote(column.name());
-        let tpe_str = render_column_type(&column).unwrap();
+        let tpe_str = render_column_type(&column);
         let nullability_str = render_nullability(&column);
         let default_str = column
             .default()
@@ -72,35 +77,95 @@ impl SqlRenderer for MysqlFlavour {
             (DefaultValue::SEQUENCE(_), _) => todo!("rendering of sequence defaults"),
         }
     }
+
+    fn render_alter_column<'a>(&self, differ: &ColumnDiffer<'_>) -> Option<Vec<String>> {
+        let expanded = expand_mysql_alter_column(differ);
+
+        let sql = match expanded {
+            MysqlAlterColumn::DropDefault => vec![format!(
+                "ALTER COLUMN {column} DROP DEFAULT",
+                column = Quoted::mysql_ident(differ.previous.name())
+            )],
+            MysqlAlterColumn::Modify { new_default, changes } => {
+                vec![render_mysql_modify(&changes, new_default.as_ref(), differ.next, self)]
+            }
+        };
+
+        Some(sql)
+    }
 }
 
-pub(crate) fn render_column_type(column: &ColumnRef<'_>) -> anyhow::Result<Cow<'static, str>> {
+fn render_mysql_modify(
+    changes: &ColumnChanges,
+    new_default: Option<&sql_schema_describer::DefaultValue>,
+    next_column: ColumnRef<'_>,
+    renderer: &dyn SqlFlavour,
+) -> String {
+    let column_type: Option<String> = if changes.type_changed() {
+        Some(next_column.column_type().full_data_type.clone()).filter(|r| !r.is_empty() || r.contains("datetime"))
+    // @default(now()) does not work with datetimes of certain sizes
+    } else {
+        Some(next_column.column.tpe.full_data_type.clone()).filter(|r| !r.is_empty())
+    };
+
+    let column_type = column_type
+        .map(Cow::Owned)
+        .unwrap_or_else(|| render_column_type(&next_column));
+
+    let default = new_default
+        .map(|default| {
+            format!(
+                " DEFAULT {}",
+                renderer.render_default(&default, &next_column.column_type().family)
+            )
+        })
+        .unwrap_or_else(String::new);
+
+    format!(
+        "MODIFY {column_name} {column_type}{nullability}{default}{sequence}",
+        column_name = Quoted::mysql_ident(&next_column.name()),
+        column_type = column_type,
+        nullability = if next_column.arity().is_required() {
+            " NOT NULL"
+        } else {
+            ""
+        },
+        default = default,
+        sequence = if next_column.is_autoincrement() {
+            " AUTO_INCREMENT"
+        } else {
+            ""
+        },
+    )
+}
+
+pub(crate) fn render_column_type(column: &ColumnRef<'_>) -> Cow<'static, str> {
     match &column.column_type().family {
-        ColumnTypeFamily::Boolean => Ok("boolean".into()),
+        ColumnTypeFamily::Boolean => "boolean".into(),
         ColumnTypeFamily::DateTime => {
             // CURRENT_TIMESTAMP has up to second precision, not more.
             if let Some(DefaultValue::NOW) = column.default() {
-                Ok("datetime".into())
+                "datetime".into()
             } else {
-                Ok("datetime(3)".into())
+                "datetime(3)".into()
             }
         }
-        ColumnTypeFamily::Float => Ok("Decimal(65,30)".into()),
-        ColumnTypeFamily::Int => Ok("int".into()),
+        ColumnTypeFamily::Float => "Decimal(65,30)".into(),
+        ColumnTypeFamily::Int => "int".into(),
         // we use varchar right now as mediumtext doesn't allow default values
         // a bigger length would not allow to use such a column as primary key
-        ColumnTypeFamily::String => Ok(format!("varchar{}", VARCHAR_LENGTH_PREFIX).into()),
+        ColumnTypeFamily::String => format!("varchar{}", VARCHAR_LENGTH_PREFIX).into(),
         ColumnTypeFamily::Enum(enum_name) => {
             let r#enum = column
                 .schema()
                 .get_enum(&enum_name)
-                .ok_or_else(|| anyhow::anyhow!("Could not render the variants of enum `{}`", enum_name))?;
+                .unwrap_or_else(|| panic!("Could not render the variants of enum `{}`", enum_name));
 
             let variants: String = r#enum.values.iter().map(Quoted::mysql_string).join(", ");
 
-            Ok(format!("ENUM({})", variants).into())
+            format!("ENUM({})", variants).into()
         }
-        ColumnTypeFamily::Json => Ok("json".into()),
+        ColumnTypeFamily::Json => "json".into(),
         x => unimplemented!("{:?} not handled yet", x),
     }
 }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
@@ -27,12 +27,16 @@ impl SqlRenderer for MysqlFlavour {
             .map(|default| format!("DEFAULT {}", self.render_default(default, &column.column.tpe.family)))
             .unwrap_or_else(String::new);
         let foreign_key = column.table().foreign_key_for_column(column.name());
-        let auto_increment_str = if column.auto_increment() { "AUTO_INCREMENT" } else { "" };
+        let auto_increment_str = if column.is_autoincrement() {
+            " AUTO_INCREMENT"
+        } else {
+            ""
+        };
 
         match foreign_key {
             Some(_) => format!("{} {} {} {}", column_name, tpe_str, nullability_str, default_str),
             None => format!(
-                "{} {} {} {} {}",
+                "{} {} {} {}{}",
                 column_name, tpe_str, nullability_str, default_str, auto_increment_str
             ),
         }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
@@ -41,7 +41,7 @@ impl super::SqlRenderer for PostgresFlavour {
             .join(",");
 
         format!(
-            "REFERENCES {}({}) {}  ON UPDATE CASCADE",
+            "REFERENCES {}({}) {} ON UPDATE CASCADE",
             self.quote_with_schema(schema_name, &foreign_key.referenced_table),
             referenced_columns,
             render_on_delete(&foreign_key.on_delete_action)

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
@@ -20,7 +20,7 @@ impl super::SqlRenderer for PostgresFlavour {
             .filter(|default| !matches!(default, DefaultValue::DBGENERATED(_)))
             .map(|default| format!("DEFAULT {}", self.render_default(default, &column.column.tpe.family)))
             .unwrap_or_else(String::new);
-        let is_serial = column.auto_increment();
+        let is_serial = column.is_autoincrement();
 
         if is_serial {
             format!("{} SERIAL", column_name)

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
@@ -85,7 +85,7 @@ impl super::SqlRenderer for PostgresFlavour {
                         .alter_columns
                         .push(format!("{} DROP DEFAULT", &alter_column_prefix));
 
-                    // We may also need to drop the sequence, in case it isn't used by any other column.
+                    // We also need to drop the sequence, in case it isn't used by any other column.
                     if let Some(DefaultValue::SEQUENCE(sequence_expression)) = differ.previous.default() {
                         let sequence_name = SEQUENCE_DEFAULT_RE
                             .captures(sequence_expression)
@@ -103,7 +103,6 @@ impl super::SqlRenderer for PostgresFlavour {
                         }
                     }
                 }
-                // TODO: change sequence to default, then back to sequence
                 PostgresAlterColumn::SetDefault(new_default) => rendered_steps.alter_columns.push(format!(
                     "{} SET DEFAULT {}",
                     &alter_column_prefix,

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
@@ -61,7 +61,7 @@ impl super::SqlRenderer for PostgresFlavour {
             (DefaultValue::VALUE(val), ColumnTypeFamily::DateTime) => format!("'{}'", val).into(),
             (DefaultValue::VALUE(PrismaValue::String(val)), ColumnTypeFamily::Json) => format!("'{}'", val).into(),
             (DefaultValue::VALUE(val), _) => val.to_string().into(),
-            (DefaultValue::SEQUENCE(_), _) => todo!("rendering of sequence defaults"),
+            (DefaultValue::SEQUENCE(_), _) => "".into(),
         }
     }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
@@ -20,7 +20,7 @@ impl SqlRenderer for SqliteFlavour {
             .filter(|default| !matches!(default, DefaultValue::DBGENERATED(_)))
             .map(|default| format!(" DEFAULT {}", self.render_default(default, &column.column.tpe.family)))
             .unwrap_or_else(String::new);
-        let auto_increment_str = if column.auto_increment() {
+        let auto_increment_str = if column.is_autoincrement() {
             " PRIMARY KEY AUTOINCREMENT"
         } else {
             ""

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
@@ -1,4 +1,4 @@
-use super::{common::*, SqlRenderer};
+use super::{common::*, RenderedAlterColumn, SqlRenderer};
 use crate::{flavour::SqliteFlavour, sql_schema_helpers::*};
 use once_cell::sync::Lazy;
 use prisma_models::PrismaValue;
@@ -66,7 +66,7 @@ impl SqlRenderer for SqliteFlavour {
         }
     }
 
-    fn render_alter_column(&self, _differ: &crate::sql_schema_differ::ColumnDiffer<'_>) -> Option<Vec<String>> {
+    fn render_alter_column(&self, _differ: &crate::sql_schema_differ::ColumnDiffer<'_>) -> Option<RenderedAlterColumn> {
         None
     }
 }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
@@ -65,6 +65,10 @@ impl SqlRenderer for SqliteFlavour {
             (DefaultValue::SEQUENCE(_), _) => unreachable!("rendering of sequence defaults"),
         }
     }
+
+    fn render_alter_column(&self, _differ: &crate::sql_schema_differ::ColumnDiffer<'_>) -> Option<Vec<String>> {
+        None
+    }
 }
 
 fn render_column_type(t: &ColumnType) -> String {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
@@ -17,7 +17,7 @@ impl SqlRenderer for SqliteFlavour {
         let nullability_str = render_nullability(&column);
         let default_str = column
             .default()
-            .filter(|default| !matches!(default, DefaultValue::DBGENERATED(_)))
+            .filter(|default| !matches!(default, DefaultValue::DBGENERATED(_) | DefaultValue::SEQUENCE(_)))
             .map(|default| format!(" DEFAULT {}", self.render_default(default, &column.column.tpe.family)))
             .unwrap_or_else(String::new);
         let auto_increment_str = if column.is_autoincrement() {
@@ -62,7 +62,7 @@ impl SqlRenderer for SqliteFlavour {
             (DefaultValue::NOW, _) => unreachable!("NOW default on non-datetime column"),
             (DefaultValue::VALUE(val), ColumnTypeFamily::DateTime) => format!("'{}'", val).into(),
             (DefaultValue::VALUE(val), _) => format!("{}", val).into(),
-            (DefaultValue::SEQUENCE(_), _) => unreachable!("rendering of sequence defaults"),
+            (DefaultValue::SEQUENCE(_), _) => "".into(),
         }
     }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
@@ -290,10 +290,6 @@ fn relation_table_column(referenced_model: &ModelWalker<'_>, reference_field_nam
 }
 
 fn migration_value_new(field: &ScalarFieldWalker<'_>) -> Option<sql_schema_describer::DefaultValue> {
-    if field.is_id() {
-        return None;
-    }
-
     let value = match &field.default_value()? {
         datamodel::DefaultValue::Single(s) => match field.field_type() {
             TypeWalker::Enum(inum) => {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
@@ -315,6 +315,11 @@ fn migration_value_new(field: &ScalarFieldWalker<'_>) -> Option<sql_schema_descr
         {
             return Some(sql_schema_describer::DefaultValue::DBGENERATED(String::new()))
         }
+        datamodel::DefaultValue::Expression(expression)
+            if expression.name == "autoincrement" && expression.args.is_empty() =>
+        {
+            return Some(sql_schema_describer::DefaultValue::SEQUENCE(String::new()))
+        }
         datamodel::DefaultValue::Expression(_) => return None,
     };
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
@@ -225,7 +225,8 @@ impl<'schema> SqlSchemaDiffer<'schema> {
 
     fn alter_columns<'a>(table_differ: &'a TableDiffer<'schema>) -> impl Iterator<Item = TableChange> + 'a {
         table_differ.column_pairs().filter_map(move |column_differ| {
-            if column_differ.differs_in_something() {
+            dbg!(column_differ.previous.name());
+            if dbg!(column_differ.differs_in_something()) {
                 let change = AlterColumn {
                     name: column_differ.previous.name().to_owned(),
                     column: column_differ.next.column.clone(),

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
@@ -225,8 +225,7 @@ impl<'schema> SqlSchemaDiffer<'schema> {
 
     fn alter_columns<'a>(table_differ: &'a TableDiffer<'schema>) -> impl Iterator<Item = TableChange> + 'a {
         table_differ.column_pairs().filter_map(move |column_differ| {
-            dbg!(column_differ.previous.name());
-            if dbg!(column_differ.differs_in_something()) {
+            if column_differ.differs_in_something() {
                 let change = AlterColumn {
                     name: column_differ.previous.name().to_owned(),
                     column: column_differ.next.column.clone(),

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/column.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/column.rs
@@ -48,7 +48,8 @@ impl<'a> ColumnDiffer<'a> {
             None
         };
 
-        let sequence = if self.previous.is_autoincrement() != self.next.is_autoincrement() {
+        dbg!(self.previous.name());
+        let sequence = if dbg!(self.previous.is_autoincrement()) != dbg!(self.next.is_autoincrement()) {
             Some(ColumnChange::Sequence)
         } else {
             None

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/column.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/column.rs
@@ -48,7 +48,7 @@ impl<'a> ColumnDiffer<'a> {
             None
         };
 
-        let sequence = if self.previous.auto_increment() != self.next.auto_increment() {
+        let sequence = if self.previous.is_autoincrement() != self.next.is_autoincrement() {
             Some(ColumnChange::Sequence)
         } else {
             None
@@ -78,7 +78,7 @@ impl<'a> ColumnDiffer<'a> {
     ///
     /// - We bail on a number of cases that are too complex to deal with right now or underspecified.
     fn defaults_match(&self) -> bool {
-        if self.previous.auto_increment() {
+        if self.previous.is_autoincrement() {
             return true;
         }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/column.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/column.rs
@@ -81,8 +81,6 @@ impl<'a> ColumnDiffer<'a> {
             return true;
         }
 
-        dbg!(&self.previous.name(), &self.previous.default(), &self.next.default());
-
         match (&self.previous.default(), &self.next.default()) {
             // Avoid naive string comparisons for JSON defaults.
             (

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/column.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/column.rs
@@ -48,8 +48,14 @@ impl<'a> ColumnDiffer<'a> {
             None
         };
 
+        let sequence = if self.previous.auto_increment() != self.next.auto_increment() {
+            Some(ColumnChange::Sequence)
+        } else {
+            None
+        };
+
         ColumnChanges {
-            changes: [renaming, r#type, arity, default],
+            changes: [renaming, r#type, arity, default, sequence],
         }
     }
 
@@ -142,11 +148,12 @@ pub(crate) enum ColumnChange {
     Arity,
     Default,
     Type,
+    Sequence,
 }
 
 #[derive(Debug, Clone)]
 pub(crate) struct ColumnChanges {
-    changes: [Option<ColumnChange>; 4],
+    changes: [Option<ColumnChange>; 5],
 }
 
 impl ColumnChanges {
@@ -163,10 +170,10 @@ impl ColumnChanges {
     }
 
     pub(crate) fn only_default_changed(&self) -> bool {
-        matches!(self.changes, [None, None, None, Some(ColumnChange::Default)])
+        matches!(self.changes, [None, None, None, Some(ColumnChange::Default), None])
     }
 
     pub(crate) fn column_was_renamed(&self) -> bool {
-        matches!(self.changes, [Some(ColumnChange::Renaming), _, _, _])
+        matches!(self.changes, [Some(ColumnChange::Renaming), _, _, _, _])
     }
 }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/column.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/column.rs
@@ -48,8 +48,7 @@ impl<'a> ColumnDiffer<'a> {
             None
         };
 
-        dbg!(self.previous.name());
-        let sequence = if dbg!(self.previous.is_autoincrement()) != dbg!(self.next.is_autoincrement()) {
+        let sequence = if self.previous.is_autoincrement() != self.next.is_autoincrement() {
             Some(ColumnChange::Sequence)
         } else {
             None
@@ -73,22 +72,16 @@ impl<'a> ColumnDiffer<'a> {
 
     /// There are workarounds to cope with current migration and introspection limitations.
     ///
-    /// - Since the values we set and introspect for timestamps are stringly typed, matching exactly the default value strings does not work on any database. Therefore we consider all datetime defaults as the same.
-    ///
-    /// - Postgres autoincrement fields get inferred with a default, which we want to ignore.
-    ///
     /// - We bail on a number of cases that are too complex to deal with right now or underspecified.
     fn defaults_match(&self) -> bool {
-        if self.previous.is_autoincrement() {
-            return true;
-        }
-
         // JSON defaults on MySQL should be ignored.
         if self.diffing_options.sql_family().is_mysql()
             && (self.previous.column_type_family().is_json() || self.next.column_type_family().is_json())
         {
             return true;
         }
+
+        dbg!(&self.previous.name(), &self.previous.default(), &self.next.default());
 
         match (&self.previous.default(), &self.next.default()) {
             // Avoid naive string comparisons for JSON defaults.

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_helpers.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_helpers.rs
@@ -54,15 +54,15 @@ impl<'a> ColumnRef<'a> {
     }
 
     pub(crate) fn is_autoincrement(&self) -> bool {
-        if self.column.auto_increment {
-            return true;
-        }
+        self.column.auto_increment
+        //     return true;
+        // }
 
-        let pk = self.table().primary_key();
+        // let pk = self.table().primary_key();
 
-        pk.as_ref()
-            .map(|pk| pk.sequence.is_some() && pk.columns.contains(&self.column.name))
-            .unwrap_or(false)
+        // pk.as_ref()
+        //     .map(|pk| pk.sequence.is_some() && pk.columns.contains(&self.column.name))
+        //     .unwrap_or(false)
     }
 
     pub(crate) fn is_required(&self) -> bool {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_helpers.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_helpers.rs
@@ -69,6 +69,10 @@ impl<'a> ColumnRef<'a> {
         self.column.is_required()
     }
 
+    pub(crate) fn is_same_column(&self, other: &ColumnRef<'_>) -> bool {
+        self.name() == other.name() && self.table().name() == other.table().name()
+    }
+
     pub(crate) fn table(&self) -> TableRef<'a> {
         TableRef {
             schema: self.schema,

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_helpers.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_helpers.rs
@@ -53,8 +53,16 @@ impl<'a> ColumnRef<'a> {
         &self.column.tpe
     }
 
-    pub(crate) fn auto_increment(&self) -> bool {
-        self.column.auto_increment
+    pub(crate) fn is_autoincrement(&self) -> bool {
+        if self.column.auto_increment {
+            return true;
+        }
+
+        let pk = self.table().primary_key();
+
+        pk.as_ref()
+            .map(|pk| pk.sequence.is_some() && pk.columns.contains(&self.column.name))
+            .unwrap_or(false)
     }
 
     pub(crate) fn is_required(&self) -> bool {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_helpers.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_helpers.rs
@@ -55,14 +55,6 @@ impl<'a> ColumnRef<'a> {
 
     pub(crate) fn is_autoincrement(&self) -> bool {
         self.column.auto_increment
-        //     return true;
-        // }
-
-        // let pk = self.table().primary_key();
-
-        // pk.as_ref()
-        //     .map(|pk| pk.sequence.is_some() && pk.columns.contains(&self.column.name))
-        //     .unwrap_or(false)
     }
 
     pub(crate) fn is_required(&self) -> bool {

--- a/migration-engine/migration-engine-tests/src/assertions.rs
+++ b/migration-engine/migration-engine-tests/src/assertions.rs
@@ -387,28 +387,25 @@ impl<'a> PrimaryKeyAssertion<'a> {
         Ok(self)
     }
 
-    pub fn assert_has_sequence(self) -> AssertionResult<Self> {
+    pub fn assert_has_autoincrement(self) -> AssertionResult<Self> {
         anyhow::ensure!(
-            self.pk.sequence.is_some()
-                || self
-                    .table
-                    .columns
-                    .iter()
-                    .any(|column| self.pk.columns.contains(&column.name) && column.auto_increment),
+            self.table
+                .columns
+                .iter()
+                .any(|column| self.pk.columns.contains(&column.name) && column.auto_increment),
             "Assertion failed: expected a sequence on the primary key, found none."
         );
 
         Ok(self)
     }
 
-    pub fn assert_has_no_sequence(self) -> AssertionResult<Self> {
+    pub fn assert_has_no_autoincrement(self) -> AssertionResult<Self> {
         anyhow::ensure!(
-            self.pk.sequence.is_none()
-                && !self
-                    .table
-                    .columns
-                    .iter()
-                    .any(|column| self.pk.columns.contains(&column.name) && column.auto_increment),
+            !self
+                .table
+                .columns
+                .iter()
+                .any(|column| self.pk.columns.contains(&column.name) && column.auto_increment),
             "Assertion failed: expected no sequence on the primary key, but found one."
         );
 

--- a/migration-engine/migration-engine-tests/src/test_api/infer_apply.rs
+++ b/migration-engine/migration-engine-tests/src/test_api/infer_apply.rs
@@ -74,6 +74,7 @@ pub struct InferApplyAssertion<'a> {
 }
 
 impl<'a> InferApplyAssertion<'a> {
+    /// Asserts that the command produced no warning, no error, and no unexecutable migration message.
     pub fn assert_green(self) -> AssertionResult<Self> {
         self.assert_no_warning()?.assert_no_error()?.assert_executable()
     }

--- a/migration-engine/migration-engine-tests/tests/existing_databases/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_databases/mod.rs
@@ -273,7 +273,7 @@ async fn deleting_a_scalar_list_field_for_a_non_existent_column_must_work(api: &
     Ok(())
 }
 
-#[test_each_connector(tags("sql"))]
+#[test_each_connector(log = "debug,sql-schema-describer=info", tags("sql"))]
 async fn updating_a_field_for_a_non_existent_column(api: &TestApi) -> TestResult {
     let dm1 = r#"
             model Blog {

--- a/migration-engine/migration-engine-tests/tests/existing_databases/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_databases/mod.rs
@@ -17,7 +17,7 @@ async fn adding_a_model_for_an_existing_table_must_work(api: &TestApi) -> TestRe
 
     let dm = r#"
             model Blog {
-                id Int @id
+                id Int @id @default(autoincrement())
             }
         "#;
     let result = api.infer_and_apply(&dm).await.sql_schema;
@@ -78,8 +78,8 @@ async fn creating_a_field_for_an_existing_column_with_a_compatible_type_must_wor
 
     let dm = r#"
         model Blog {
-            id Int @id
-            title String
+            id      Int @id @default(autoincrement())
+            title   String
         }
     "#;
 
@@ -198,12 +198,14 @@ async fn creating_a_scalar_list_field_for_an_existing_table_must_work(api: &Test
 async fn delete_a_field_for_a_non_existent_column_must_work(api: &TestApi) -> TestResult {
     let dm1 = r#"
             model Blog {
-                id Int @id
-                title String
+                id      Int @id
+                title   String
             }
         "#;
-    let initial_result = api.infer_and_apply(&dm1).await.sql_schema;
-    assert_eq!(initial_result.table_bang("Blog").column("title").is_some(), true);
+
+    api.infer_apply(&dm1).send().await?.into_inner();
+    let initial_result = api.describe_database().await?;
+    assert!(initial_result.table_bang("Blog").column("title").is_some());
 
     let result = api
         .barrel()
@@ -215,11 +217,11 @@ async fn delete_a_field_for_a_non_existent_column_must_work(api: &TestApi) -> Te
             });
         })
         .await?;
-    assert_eq!(result.table_bang("Blog").column("title").is_some(), false);
+    assert!(result.table_bang("Blog").column("title").is_none());
 
     let dm2 = r#"
             model Blog {
-                id Int @id
+                id Int @id @default(autoincrement())
             }
         "#;
     let final_result = api.infer_and_apply(&dm2).await.sql_schema;

--- a/migration-engine/migration-engine-tests/tests/migration_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migration_tests.rs
@@ -204,7 +204,7 @@ async fn making_an_existing_id_field_autoincrement_works(api: &TestApi) -> TestR
     api.infer_apply(dm1).send().await?.assert_green()?;
 
     api.assert_schema().await?.assert_table("Post", |model| {
-        model.assert_pk(|pk| pk.assert_columns(&["id"])?.assert_has_no_sequence())
+        model.assert_pk(|pk| pk.assert_columns(&["id"])?.assert_has_no_autoincrement())
     })?;
 
     let dm2 = r#"
@@ -221,9 +221,7 @@ async fn making_an_existing_id_field_autoincrement_works(api: &TestApi) -> TestR
     api.infer_apply(dm2).send().await?.assert_green()?;
 
     api.assert_schema().await?.assert_table("Post", |model| {
-        model
-            .debug_print()?
-            .assert_pk(|pk| pk.assert_columns(&["id"])?.debug_print()?.assert_has_sequence())
+        model.assert_pk(|pk| pk.assert_columns(&["id"])?.assert_has_autoincrement())
     })?;
 
     Ok(())
@@ -246,7 +244,7 @@ async fn removing_autoincrement_from_an_existing_field_works(api: &TestApi) -> T
     api.infer_apply(dm1).send().await?.assert_green()?;
 
     api.assert_schema().await?.assert_table("Post", |model| {
-        model.assert_pk(|pk| pk.assert_columns(&["id"])?.assert_has_sequence())
+        model.assert_pk(|pk| pk.assert_columns(&["id"])?.assert_has_autoincrement())
     })?;
 
     let dm2 = r#"
@@ -263,9 +261,7 @@ async fn removing_autoincrement_from_an_existing_field_works(api: &TestApi) -> T
     api.infer_apply(dm2).send().await?.assert_green()?;
 
     api.assert_schema().await?.assert_table("Post", |model| {
-        model
-            .debug_print()?
-            .assert_pk(|pk| pk.assert_columns(&["id"])?.debug_print()?.assert_has_no_sequence())
+        model.assert_pk(|pk| pk.assert_columns(&["id"])?.assert_has_no_autoincrement())
     })?;
 
     Ok(())


### PR DESCRIPTION
i.e. without dropping and recreating columns.

closes https://github.com/prisma/migrate/issues/498
closes https://github.com/prisma/migrate/issues/467