### PR TITLE
Add --unix-path flag to CLI

### DIFF
--- a/query-engine/query-engine/src/opt.rs
+++ b/query-engine/query-engine/src/opt.rs
@@ -50,8 +50,14 @@ pub struct PrismaOpt {
     pub host: String,
 
     /// The port the query engine should bind to.
-    #[structopt(long, short, env, default_value = "4466")]
+    // NOTE: this is mutually exclusive with path
+    #[structopt(long, short, env, default_value = "4466", group = "port")]
     pub port: u16,
+
+    /// The unix socket path to listen on
+    // NOTE: this is mutually exclusive with port.
+    #[structopt(long, short, env, group = "port")]
+    unix_path: Option<String>,
 
     /// Path to the Prisma datamodel file
     #[structopt(long, env = "PRISMA_DML_PATH", parse(from_os_str = load_datamodel_file))]
@@ -154,6 +160,11 @@ impl PrismaOpt {
             Some("devel") => crate::LogFormat::Text,
             _ => crate::LogFormat::Json,
         }
+    }
+
+    /// The unix path to listen on.
+    pub(crate) fn unix_path(&self) -> Option<&String> {
+        self.unix_path.as_ref()
     }
 }
 

--- a/query-engine/query-engine/src/server/mod.rs
+++ b/query-engine/query-engine/src/server/mod.rs
@@ -68,7 +68,20 @@ pub async fn listen(opts: PrismaOpt) -> PrismaResult<()> {
     info!("Started http server");
 
     // Start the Tide server and log the server details.
-    app.listen((&*opts.host, opts.port)).await?;
+    // TODO: Tide should have a panicking listen_unix impl.
+    #[allow(unused_variables)]
+    if let Some(path) = opts.unix_path() {
+        #[cfg(unix)]
+        {
+            app.listen_unix(path).await?;
+        }
+        #[cfg(not(unix))]
+        {
+            panic!("Unix domain sockets are only supported on Unix; please use TCP instead.")
+        }
+    } else {
+        app.listen((&*opts.host, opts.port)).await?;
+    }
     Ok(())
 }
 


### PR DESCRIPTION
Adds the `--unix-path` option to the CLI. This option is mutually exclusive with `--port` so only a single option can be passed at a single time.

## Implementation notes

Setting mutually exclusive groups in structopt is fairly limited, so I could only group `--unix-flag` with one other option, so I picked `--port`. Also Tide's `listen_unix` option isn't available on Windows, so in order to compile I had to `cfg` it out. Tide should probably own this logic and panic when trying to start a UDS socket on Windows.

## Output
```txt
    -u, --unix-path <unix-path>                            The unix socket path to listen on [env: UNIX_PATH=]
```