### PR TITLE
Absorb SqlRenderer impls into SqlFlavour

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer.rs
@@ -9,11 +9,8 @@ pub(crate) use common::{IteratorJoin, Quoted, QuotedWithSchema};
 pub(crate) use mysql_renderer::render_column_type as mysql_render_column_type;
 pub(crate) use postgres_renderer::render_column_type as postgres_render_column_type;
 
-use crate::{sql_schema_helpers::ColumnRef, SqlFamily};
-use mysql_renderer::MySqlRenderer;
-use postgres_renderer::PostgresRenderer;
+use crate::sql_schema_helpers::ColumnRef;
 use sql_schema_describer::*;
-use sqlite_renderer::SqliteRenderer;
 use std::borrow::Cow;
 
 pub(crate) trait SqlRenderer {
@@ -31,17 +28,4 @@ pub(crate) trait SqlRenderer {
     fn render_references(&self, schema_name: &str, foreign_key: &ForeignKey) -> String;
 
     fn render_default<'a>(&self, default: &'a DefaultValue, family: &ColumnTypeFamily) -> Cow<'a, str>;
-
-    fn sql_family(&self) -> SqlFamily;
-}
-
-impl dyn SqlRenderer {
-    pub fn for_family<'a>(sql_family: &SqlFamily) -> Box<dyn SqlRenderer + Send + Sync + 'a> {
-        match sql_family {
-            SqlFamily::Postgres => Box::new(PostgresRenderer {}),
-            SqlFamily::Mysql => Box::new(MySqlRenderer {}),
-            SqlFamily::Sqlite => Box::new(SqliteRenderer {}),
-            SqlFamily::Mssql => todo!("Greetings from Redmond"),
-        }
-    }
 }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
@@ -1,5 +1,5 @@
 use super::{common::*, SqlRenderer};
-use crate::{sql_schema_helpers::ColumnRef, SqlFamily};
+use crate::{flavour::MysqlFlavour, sql_schema_helpers::ColumnRef};
 use once_cell::sync::Lazy;
 use prisma_models::PrismaValue;
 use regex::Regex;
@@ -8,13 +8,7 @@ use std::borrow::Cow;
 
 const VARCHAR_LENGTH_PREFIX: &str = "(191)";
 
-pub struct MySqlRenderer {}
-
-impl SqlRenderer for MySqlRenderer {
-    fn sql_family(&self) -> SqlFamily {
-        SqlFamily::Mysql
-    }
-
+impl SqlRenderer for MysqlFlavour {
     fn quote<'a>(&self, name: &'a str) -> Quoted<&'a str> {
         Quoted::Backticks(name)
     }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
@@ -1,18 +1,12 @@
 use super::common::*;
-use crate::{sql_schema_helpers::*, SqlFamily};
+use crate::{flavour::PostgresFlavour, sql_schema_helpers::*};
 use once_cell::sync::Lazy;
 use prisma_models::PrismaValue;
 use regex::Regex;
 use sql_schema_describer::*;
 use std::borrow::Cow;
 
-pub struct PostgresRenderer {}
-
-impl super::SqlRenderer for PostgresRenderer {
-    fn sql_family(&self) -> SqlFamily {
-        SqlFamily::Postgres
-    }
-
+impl super::SqlRenderer for PostgresFlavour {
     fn quote<'a>(&self, name: &'a str) -> Quoted<&'a str> {
         Quoted::postgres_ident(name)
     }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
@@ -1,25 +1,19 @@
-use super::common::*;
-use crate::{sql_schema_helpers::*, SqlFamily};
+use super::{common::*, SqlRenderer};
+use crate::{flavour::SqliteFlavour, sql_schema_helpers::*};
 use once_cell::sync::Lazy;
 use prisma_models::PrismaValue;
 use regex::Regex;
 use sql_schema_describer::*;
 use std::borrow::Cow;
 
-pub struct SqliteRenderer;
-
-impl super::SqlRenderer for SqliteRenderer {
-    fn sql_family(&self) -> SqlFamily {
-        SqlFamily::Sqlite
-    }
-
+impl SqlRenderer for SqliteFlavour {
     fn quote<'a>(&self, name: &'a str) -> Quoted<&'a str> {
         Quoted::Double(name)
     }
 
     fn render_column(&self, _schema_name: &str, column: ColumnRef<'_>, _add_fk_prefix: bool) -> String {
         let column_name = self.quote(column.name());
-        let tpe_str = self.render_column_type(column.column_type());
+        let tpe_str = render_column_type(column.column_type());
         let nullability_str = render_nullability(&column);
         let default_str = column
             .default()
@@ -73,16 +67,14 @@ impl super::SqlRenderer for SqliteRenderer {
     }
 }
 
-impl SqliteRenderer {
-    fn render_column_type(&self, t: &ColumnType) -> String {
-        match &t.family {
-            ColumnTypeFamily::Boolean => "BOOLEAN".to_string(),
-            ColumnTypeFamily::DateTime => "DATE".to_string(),
-            ColumnTypeFamily::Float => "REAL".to_string(),
-            ColumnTypeFamily::Int => "INTEGER".to_string(),
-            ColumnTypeFamily::String => "TEXT".to_string(),
-            x => unimplemented!("{:?} not handled yet", x),
-        }
+fn render_column_type(t: &ColumnType) -> String {
+    match &t.family {
+        ColumnTypeFamily::Boolean => "BOOLEAN".to_string(),
+        ColumnTypeFamily::DateTime => "DATE".to_string(),
+        ColumnTypeFamily::Float => "REAL".to_string(),
+        ColumnTypeFamily::Int => "INTEGER".to_string(),
+        ColumnTypeFamily::String => "TEXT".to_string(),
+        x => unimplemented!("{:?} not handled yet", x),
     }
 }
 


### PR DESCRIPTION
This is so we only have to resolve what database we are on once in the
SqlMigrationConnector, and so we have one clear mechanism for
specialization.

This refactoring was prompted by an upcoming PR on autoincrement
sequence migrations, that will require very different implementations on
postgres, sqlite and mysql.