### PR TITLE
Fix multi-field ids including an autoincrement integer on sqlite

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
@@ -159,16 +159,16 @@ fn render_raw_sql(
 
             if !primary_columns.is_empty() && !primary_key_is_already_set {
                 let column_names = primary_columns.iter().map(|col| renderer.quote(&col)).join(",");
-                write!(create_table, ",\n    PRIMARY KEY ({})", column_names)?;
+                write!(create_table, ",\nPRIMARY KEY ({})", column_names)?;
             }
 
             if sql_family == SqlFamily::Sqlite && !table.foreign_keys.is_empty() {
-                write!(create_table, ",")?;
+                writeln!(create_table, ",")?;
 
                 let mut fks = table.foreign_keys.iter().peekable();
 
                 while let Some(fk) = fks.next() {
-                    write!(
+                    writeln!(
                         create_table,
                         "FOREIGN KEY ({constrained_columns}) {references}{comma}",
                         constrained_columns = fk.columns.iter().map(|col| format!(r#""{}""#, col)).join(","),

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
@@ -20,7 +20,7 @@ impl SqlRenderer for SqliteFlavour {
             .filter(|default| !matches!(default, DefaultValue::DBGENERATED(_) | DefaultValue::SEQUENCE(_)))
             .map(|default| format!(" DEFAULT {}", self.render_default(default, &column.column.tpe.family)))
             .unwrap_or_else(String::new);
-        let auto_increment_str = if column.is_autoincrement() {
+        let auto_increment_str = if column.is_autoincrement() && column.is_single_primary_key() {
             " PRIMARY KEY AUTOINCREMENT"
         } else {
             ""

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_helpers.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_helpers.rs
@@ -65,6 +65,14 @@ impl<'a> ColumnRef<'a> {
         self.name() == other.name() && self.table().name() == other.table().name()
     }
 
+    /// Returns whether this column is the primary key. If it is only part of the primary key, this will return false.
+    pub(crate) fn is_single_primary_key(&self) -> bool {
+        self.table()
+            .primary_key()
+            .map(|pk| pk.columns == &[self.name()])
+            .unwrap_or(false)
+    }
+
     pub(crate) fn table(&self) -> TableRef<'a> {
         TableRef {
             schema: self.schema,

--- a/query-engine/connector-test-kit/src/test/scala/writes/ids/IntIdUpdateSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/ids/IntIdUpdateSpec.scala
@@ -157,7 +157,7 @@ class IntIdUpdateSpec extends FlatSpec with Matchers with ApiSpecBase {
     )
   }
 
-  "Updating a unique field of type Int with autoincrement" should "error"  taggedAs (IgnoreMySql)  in {
+  "Updating a unique field of type Int with autoincrement" should "error"  taggedAs (IgnoreSQLite, IgnoreMySql)  in {
     val project = ProjectDsl.fromString {
       s"""
          |model Todo {
@@ -197,7 +197,7 @@ class IntIdUpdateSpec extends FlatSpec with Matchers with ApiSpecBase {
   }
 
 
-  "Updating a non-unique field of type Int with autoincrement" should "work"  taggedAs (IgnoreMySql)  in {
+  "Updating a non-unique field of type Int with autoincrement" should "work"  taggedAs (IgnoreSQLite, IgnoreMySql)  in {
     val project = ProjectDsl.fromString {
       s"""
          |model Todo {


### PR DESCRIPTION
This should be forbidden by the schema parser. For now we do not crash and go with the multi-field id without autoincrement.