### PR TITLE
Make nested create and update inputs for relation fields non-nullable

### DIFF
--- a/query-engine/connector-test-kit/src/test/scala/writes/relations/OptionalRelationSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/relations/OptionalRelationSpec.scala
@@ -1,0 +1,69 @@
+package writes.relations
+
+import org.scalatest.{FlatSpec, Matchers}
+import util.ConnectorCapability.JoinRelationLinksCapability
+import util._
+
+class OptionalRelationSpec extends FlatSpec with Matchers with ApiSpecBase {
+  override def runOnlyForCapabilities = Set(JoinRelationLinksCapability)
+
+  val schema =
+    """
+      | model List{
+      |   id     Int  @id @default(autoincrement())
+      |   name   String
+      |   todoId Int?
+      |   todo   Todo?   @relation(fields: [todoId], references: [id])
+      | }
+      |
+      | model Todo{
+      |   id     Int  @id @default(autoincrement())
+      |   name   String
+      |   lists  List[]
+      | }
+    """
+
+  val project = SchemaDsl.fromStringV11() { schema }
+
+  "Updating an optional relation with null" should "return an error" in {
+    database.setup(project)
+
+    // Setup
+    val result = server.query(
+      """
+        | mutation {
+        |  createList(data: { name: "A", todo: { create: { name: "B" } } }) {
+        |    id
+        |    name
+        |    todo {
+        |      id
+        |      name
+        |    }
+        |   }
+        | }
+      """,
+      project
+    )
+
+    result.toString should equal("""{"data":{"createList":{"id":1,"name":"A","todo":{"id":1,"name":"B"}}}}""")
+
+    // Check that the engine rejects `null` as a `TodoUpdateInput`.
+    server.queryThatMustFail(
+      """
+        | mutation {
+        |  updateList(where: { id: 1 }, data: { name: "C", todo: null }) {
+        |    name
+        |    todo {
+        |      id
+        |      name
+        |    }
+        |   }
+        | }
+      """,
+      project,
+      errorCode = 2012,
+      errorContains = "Missing a required value at `Mutation.updateList.data.ListUpdateInput.todo"
+    )
+  }
+
+}

--- a/query-engine/connector-test-kit/src/test/scala/writes/relations/RequiredRelationSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/relations/RequiredRelationSpec.scala
@@ -1,0 +1,69 @@
+package writes.relations
+
+import org.scalatest.{FlatSpec, Matchers}
+import util.ConnectorCapability.JoinRelationLinksCapability
+import util._
+
+class RequiredRelationSpec extends FlatSpec with Matchers with ApiSpecBase {
+  override def runOnlyForCapabilities = Set(JoinRelationLinksCapability)
+
+  val schema =
+    """
+      | model List{
+      |   id     Int  @id @default(autoincrement())
+      |   name   String
+      |   todoId Int
+      |   todo   Todo   @relation(fields: [todoId], references: [id])
+      | }
+      |
+      | model Todo{
+      |   id     Int  @id @default(autoincrement())
+      |   name   String
+      |   lists  List[]
+      | }
+    """
+
+  val project = SchemaDsl.fromStringV11() { schema }
+
+  "Updating a required relation with null" should "return an error" in {
+    database.setup(project)
+
+    // Setup
+    val result = server.query(
+      """
+        | mutation {
+        |  createList(data: { name: "A", todo: { create: { name: "B" } } }) {
+        |    id
+        |    name
+        |    todo {
+        |      id
+        |      name
+        |    }
+        |   }
+        | }
+      """,
+      project
+    )
+
+    result.toString should equal("""{"data":{"createList":{"id":1,"name":"A","todo":{"id":1,"name":"B"}}}}""")
+
+    // Check that the engine rejects `null` as a `TodoUpdateInput`.
+    server.queryThatMustFail(
+      """
+        | mutation {
+        |  updateList(where: { id: 1 }, data: { name: "C", todo: null }) {
+        |    name
+        |    todo {
+        |      id
+        |      name
+        |    }
+        |   }
+        | }
+      """,
+      project,
+      errorCode = 2012,
+      errorContains = "Missing a required value at `Mutation.updateList.data.ListUpdateInput.todo"
+    )
+  }
+
+}

--- a/query-engine/connector-test-kit/src/test/scala/writes/topLevelMutations/CreateMutationSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/topLevelMutations/CreateMutationSpec.scala
@@ -160,12 +160,24 @@ class CreateMutationSpec extends FlatSpec with Matchers with ApiSpecBase {
     )
   }
 
-  "A Create Mutation" should "create with an optional relation set to null." in {
-    val res = server.query(
+  "A Create Mutation" should "reject an optional relation set to null." in {
+    server.queryThatMustFail(
       """mutation {
         |  createScalarModel(data: {
         |    optRel: null
         |  }){ relId }}""".stripMargin,
+      project = project,
+      errorCode = 2012,
+      errorContains = "Missing a required value at `Mutation.createScalarModel.data.ScalarModelCreateInput.optRel`"
+    )
+  }
+
+  "A Create Mutation" should "create with an optional relation omitted." in {
+    val res = server.query(
+      """mutation {
+        |  createScalarModel(data: {}) {
+        |    relId
+        |  }}""".stripMargin,
       project = project
     )
 

--- a/query-engine/core/src/schema_builder/input_type_builder/create_input_type_extension.rs
+++ b/query-engine/core/src/schema_builder/input_type_builder/create_input_type_extension.rs
@@ -109,10 +109,8 @@ pub trait CreateInputTypeBuilderExtension<'a>: InputTypeBuilderBase<'a> {
                 let arity_part = if rf.is_list { "Many" } else { "One" };
                 let without_part = format!("Without{}", capitalize(&related_field.name));
                 let input_name = format!("{}Create{}{}Input", related_model.name, arity_part, without_part);
-                let field_is_opposite_relation_field = parent_field
-                    .as_ref()
-                    .filter(|pf| pf.related_field().name == rf.name)
-                    .is_some();
+                let field_is_opposite_relation_field =
+                    parent_field.filter(|pf| pf.related_field().name == rf.name).is_some();
 
                 if field_is_opposite_relation_field {
                     None

--- a/query-engine/core/src/schema_builder/input_type_builder/create_input_type_extension.rs
+++ b/query-engine/core/src/schema_builder/input_type_builder/create_input_type_extension.rs
@@ -144,7 +144,7 @@ pub trait CreateInputTypeBuilderExtension<'a>: InputTypeBuilderBase<'a> {
                     let input_field = if rf.is_required && !all_required_scalar_fields_have_defaults {
                         input_field(rf.name.clone(), input_type, None)
                     } else {
-                        input_field(rf.name.clone(), InputType::opt(InputType::null(input_type)), None)
+                        input_field(rf.name.clone(), InputType::opt(input_type), None)
                     };
 
                     Some(input_field)

--- a/query-engine/core/src/schema_builder/input_type_builder/update_input_type_extension.rs
+++ b/query-engine/core/src/schema_builder/input_type_builder/update_input_type_extension.rs
@@ -72,16 +72,8 @@ pub trait UpdateInputTypeBuilderExtension<'a>: InputTypeBuilderBase<'a> + Create
                 let without_part = format!("Without{}", capitalize(related_field.name.clone()));
 
                 let input_name = format!("{}Update{}{}Input", related_model.name, arity_part, without_part);
-                let field_is_opposite_relation_field = parent_field
-                    .as_ref()
-                    .and_then(|pf| {
-                        if pf.related_field().name == rf.name {
-                            Some(pf)
-                        } else {
-                            None
-                        }
-                    })
-                    .is_some();
+                let field_is_opposite_relation_field =
+                    parent_field.filter(|pf| pf.related_field().name == rf.name).is_some();
 
                 if field_is_opposite_relation_field {
                     None
@@ -112,11 +104,14 @@ pub trait UpdateInputTypeBuilderExtension<'a>: InputTypeBuilderBase<'a> + Create
                         }
                     };
 
-                    Some(input_field(
-                        rf.name.clone(),
-                        InputType::opt(InputType::null(InputType::object(input_object))),
-                        None,
-                    ))
+                    let field_type = InputType::object(input_object);
+                    let field_type = if rf.is_optional() {
+                        InputType::opt(InputType::null(field_type))
+                    } else {
+                        InputType::opt(field_type)
+                    };
+
+                    Some(input_field(rf.name.clone(), field_type, None))
                 }
             })
             .collect()

--- a/query-engine/core/src/schema_builder/input_type_builder/update_input_type_extension.rs
+++ b/query-engine/core/src/schema_builder/input_type_builder/update_input_type_extension.rs
@@ -104,12 +104,7 @@ pub trait UpdateInputTypeBuilderExtension<'a>: InputTypeBuilderBase<'a> + Create
                         }
                     };
 
-                    let field_type = InputType::object(input_object);
-                    let field_type = if rf.is_optional() {
-                        InputType::opt(InputType::null(field_type))
-                    } else {
-                        InputType::opt(field_type)
-                    };
+                    let field_type = InputType::opt(InputType::object(input_object));
 
                     Some(input_field(rf.name.clone(), field_type, None))
                 }


### PR DESCRIPTION
They are still optional, but they cannot be `null` because that is not possible for a required relation field.

This aims to address https://github.com/prisma/prisma/issues/2839