### PR TITLE
Eliminate intermediate `cli` subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,22 +86,7 @@ OPTIONS:
     -p, --port <port>    The port the query engine should bind to [env: PORT=]  [default: 4466]
 
 SUBCOMMANDS:
-    cli     Doesn't start a server, but allows running specific commands against Prisma
-    help    Prints this message or the help of the given subcommand(s)
-
-> ./target/release/query-engine cli --help
-Doesn't start a server, but allows running specific commands against Prisma
-
-USAGE:
-    query-engine cli <SUBCOMMAND>
-
-FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
-
-SUBCOMMANDS:
     dmmf               Output the DMMF from the loaded data model
-    dmmf-to-dml        Convert the given DMMF JSON file to a data model
     execute-request    Executes one request and then terminates
     get-config         Get the configuration from the given data model
     help               Prints this message or the help of the given subcommand(s)

--- a/libs/test-cli/src/main.rs
+++ b/libs/test-cli/src/main.rs
@@ -208,7 +208,6 @@ async fn generate_dmmf(cmd: &DmmfCommand) -> anyhow::Result<()> {
     );
 
     let cmd = std::process::Command::new(&cmd.query_engine_binary_path)
-        .arg("cli")
         .arg("dmmf")
         .env("PRISMA_DML_PATH", schema_path)
         .spawn()?;

--- a/query-engine/connector-test-kit/src/test/scala/util/TestServer.scala
+++ b/query-engine/connector-test-kit/src/test/scala/util/TestServer.scala
@@ -87,7 +87,6 @@ case class TestServer() extends PlayJsonExtensions with LogSupport {
             EnvVars.prismaBinaryPath,
             "--enable-experimental=all",
             "--enable-raw-queries",
-            "cli",
             "execute-request",
             "--legacy",
             encoded_query
@@ -104,7 +103,6 @@ case class TestServer() extends PlayJsonExtensions with LogSupport {
             EnvVars.prismaBinaryPath,
             "--enable-experimental=all",
             "--enable-raw-queries",
-            "cli",
             "execute-request",
             encoded_query
           ),
@@ -120,7 +118,6 @@ case class TestServer() extends PlayJsonExtensions with LogSupport {
             EnvVars.prismaBinaryPath,
             "--enable-experimental=all",
             "--enable-raw-queries",
-            "cli",
             "execute-request",
             "--legacy",
             encoded_query
@@ -137,7 +134,6 @@ case class TestServer() extends PlayJsonExtensions with LogSupport {
             EnvVars.prismaBinaryPath,
             "--enable-experimental=all",
             "--enable-raw-queries",
-            "cli",
             "execute-request",
             encoded_query
           ),

--- a/query-engine/query-engine/src/cli.rs
+++ b/query-engine/query-engine/src/cli.rs
@@ -1,18 +1,14 @@
+use crate::context::PrismaContext;
+use crate::dmmf;
+use crate::opt::{CliOpt, PrismaOpt};
 use crate::request_handlers::graphql::{self, GraphQlBody};
-
-use crate::{
-    context::PrismaContext,
-    dmmf,
-    opt::{CliOpt, PrismaOpt, Subcommand},
-    PrismaResult,
-};
+use crate::PrismaResult;
 
 use datamodel::{Configuration, Datamodel};
 use prisma_models::DatamodelConverter;
-use query_core::{
-    schema::{QuerySchemaRef, SupportedCapabilities},
-    BuildMode, QuerySchemaBuilder,
-};
+use query_core::schema::{QuerySchemaRef, SupportedCapabilities};
+use query_core::{BuildMode, QuerySchemaBuilder};
+
 use std::sync::Arc;
 
 pub struct ExecuteRequest {
@@ -49,31 +45,29 @@ impl CliCommand {
         };
 
         match subcommand {
-            Subcommand::Cli(ref cliopts) => match cliopts {
-                CliOpt::Dmmf => {
-                    let build_mode = if opts.legacy {
-                        BuildMode::Legacy
-                    } else {
-                        BuildMode::Modern
-                    };
+            CliOpt::Dmmf => {
+                let build_mode = if opts.legacy {
+                    BuildMode::Legacy
+                } else {
+                    BuildMode::Modern
+                };
 
-                    Ok(Some(CliCommand::Dmmf(DmmfRequest {
-                        datamodel: opts.datamodel(true)?,
-                        build_mode,
-                        enable_raw_queries: opts.enable_raw_queries,
-                    })))
-                }
-                CliOpt::GetConfig(input) => Ok(Some(CliCommand::GetConfig(GetConfigRequest {
-                    config: opts.configuration(input.ignore_env_var_errors)?,
-                }))),
-                CliOpt::ExecuteRequest(input) => Ok(Some(CliCommand::ExecuteRequest(ExecuteRequest {
-                    query: input.query.clone(),
+                Ok(Some(CliCommand::Dmmf(DmmfRequest {
+                    datamodel: opts.datamodel(true)?,
+                    build_mode,
                     enable_raw_queries: opts.enable_raw_queries,
-                    legacy: input.legacy,
-                    datamodel: opts.datamodel(false)?,
-                    config: opts.configuration(false)?,
-                }))),
-            },
+                })))
+            }
+            CliOpt::GetConfig(input) => Ok(Some(CliCommand::GetConfig(GetConfigRequest {
+                config: opts.configuration(input.ignore_env_var_errors)?,
+            }))),
+            CliOpt::ExecuteRequest(input) => Ok(Some(CliCommand::ExecuteRequest(ExecuteRequest {
+                query: input.query.clone(),
+                enable_raw_queries: opts.enable_raw_queries,
+                legacy: input.legacy,
+                datamodel: opts.datamodel(false)?,
+                config: opts.configuration(false)?,
+            }))),
         }
     }
 

--- a/query-engine/query-engine/src/opt.rs
+++ b/query-engine/query-engine/src/opt.rs
@@ -4,12 +4,6 @@ use serde::Deserialize;
 use std::{ffi::OsStr, fs::File, io::Read};
 use structopt::StructOpt;
 
-#[derive(Debug, StructOpt, Clone)]
-pub enum Subcommand {
-    /// Doesn't start a server, but allows running specific commands against Prisma.
-    Cli(CliOpt),
-}
-
 #[derive(Debug, Clone, StructOpt)]
 pub struct DmmfToDmlInput {
     #[structopt(name = "path")]
@@ -92,7 +86,7 @@ pub struct PrismaOpt {
     log_format: Option<String>,
 
     #[structopt(subcommand)]
-    pub subcommand: Option<Subcommand>,
+    pub subcommand: Option<CliOpt>,
 
     #[structopt(long = "enable-experimental", use_delimiter = true)]
     pub raw_feature_flags: Vec<String>,


### PR DESCRIPTION
Eliminates the intermediate `cli` subcommand. This is one step to bring the functionality captured in `opt.rs` and `cli.rs` closer together, allowing us to have a canonical location to handle configuration. I noticed that the intermediate `cli` subcommand only acted as a singular gate for other subcommands — this removes that, allowing us to flatten the internal hierarchy somewhat.

## Example
```sh
# before this patch
$ query-engine cli get-config

# with this patch
$ query-engine get-config
```