### PR TITLE
Normalize trailing zeroes off from decimals

### DIFF
--- a/libs/prisma-value/src/sql_ext.rs
+++ b/libs/prisma-value/src/sql_ext.rs
@@ -9,7 +9,8 @@ impl<'a> From<Value<'a>> for PrismaValue {
                 .map(|i| PrismaValue::Int(i))
                 .unwrap_or(PrismaValue::null(TypeHint::Int)),
             Value::Real(d) => d
-                .map(|d| PrismaValue::Float(d))
+                // chop the trailing zeroes off so javascript doesn't start rounding things wrong
+                .map(|d| PrismaValue::Float(d.normalize()))
                 .unwrap_or(PrismaValue::null(TypeHint::Float)),
             Value::Text(s) => s
                 .map(|s| PrismaValue::String(s.into_owned()))


### PR DESCRIPTION
...to cope with javascript float precision

So, what happens here is we store `NUMERIC` to PostgreSQL as `numeric(65,30)`. Our pg crate translates this directly to `Decimal` with all the accuracy, leading to 30 trailing zeroes. Now the border between Rust and JavaScript converts the number to a JavaScript float, meaning a stupid rounding happens due to js floats having less precision than our `Decimal` here.

For a quick fix to most of the problems people will face here is how we can chop off the trailing zeroes, so when the value hits the js client it'll not get any rounding errors.

Of course storing something super precise, such as `1.233456789012345678901234567890` to the database will be rounded incorrectly in JavaScript. If we want to support super high precisions, we might want to consider using a decimal library such as [decimal.js](https://github.com/MikeMcl/decimal.js/).

Closes https://github.com/prisma/prisma/issues/2903