### PR TITLE
Initial implementation of schemaPush command

### DIFF
--- a/migration-engine/connectors/migration-connector/src/database_migration_step_applier.rs
+++ b/migration-engine/connectors/migration-connector/src/database_migration_step_applier.rs
@@ -6,11 +6,11 @@ use serde::{Deserialize, Serialize};
 #[async_trait::async_trait]
 pub trait DatabaseMigrationStepApplier<T>: Send + Sync {
     /// Applies the step to the database
-    /// Returns true to signal to the caller that there are more steps to apply.
+    /// Returns true to signal to the caller that the step was applied, and there could be a next one.
     async fn apply_step(&self, database_migration: &T, step: usize) -> ConnectorResult<bool>;
 
     /// Applies the step to the database.
-    /// Returns true to signal to the caller that there are more steps to unapply.
+    /// Returns true to signal to the caller that the step was unapplied, and there could be a next one.
     async fn unapply_step(&self, database_migration: &T, step: usize) -> ConnectorResult<bool>;
 
     /// Render steps for the CLI. Each step will contain the raw field.

--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
@@ -71,6 +71,7 @@ impl SqlDatabaseStepApplier<'_> {
         next_schema: &SqlSchema,
     ) -> SqlResult<bool> {
         let has_this_one = steps.get(index).is_some();
+
         if !has_this_one {
             return Ok(false);
         }
@@ -86,8 +87,7 @@ impl SqlDatabaseStepApplier<'_> {
             self.conn().raw_cmd(&sql_string).await?;
         }
 
-        let has_more = steps.get(index + 1).is_some();
-        Ok(has_more)
+        Ok(true)
     }
 }
 

--- a/migration-engine/core/src/api.rs
+++ b/migration-engine/core/src/api.rs
@@ -53,6 +53,7 @@ pub trait GenericApi: Send + Sync + 'static {
     async fn list_migrations(&self, input: &serde_json::Value) -> CoreResult<Vec<ListMigrationsOutput>>;
     async fn migration_progress(&self, input: &MigrationProgressInput) -> CoreResult<MigrationProgressOutput>;
     async fn reset(&self, input: &serde_json::Value) -> CoreResult<serde_json::Value>;
+    async fn schema_push(&self, input: &SchemaPushInput) -> CoreResult<SchemaPushOutput>;
     async fn unapply_migration(&self, input: &UnapplyMigrationInput) -> CoreResult<UnapplyMigrationOutput>;
     fn migration_persistence<'a>(&'a self) -> Box<dyn MigrationPersistence + 'a>;
     fn connector_type(&self) -> &'static str;
@@ -123,6 +124,12 @@ where
     async fn reset(&self, input: &serde_json::Value) -> CoreResult<serde_json::Value> {
         self.handle_command::<ResetCommand>(input)
             .instrument(tracing::info_span!("Reset"))
+            .await
+    }
+
+    async fn schema_push(&self, input: &SchemaPushInput) -> CoreResult<SchemaPushOutput> {
+        self.handle_command::<SchemaPushCommand<'_>>(input)
+            .instrument(tracing::info_span!("SchemaPush"))
             .await
     }
 

--- a/migration-engine/core/src/api/rpc.rs
+++ b/migration-engine/core/src/api/rpc.rs
@@ -19,6 +19,7 @@ enum RpcCommand {
     ApplyMigration,
     UnapplyMigration,
     Reset,
+    SchemaPush,
     CalculateDatamodel,
     CalculateDatabaseSteps,
 }
@@ -32,6 +33,7 @@ impl RpcCommand {
             RpcCommand::ApplyMigration => "applyMigration",
             RpcCommand::UnapplyMigration => "unapplyMigration",
             RpcCommand::Reset => "reset",
+            RpcCommand::SchemaPush => "schemaPush",
             RpcCommand::CalculateDatamodel => "calculateDatamodel",
             RpcCommand::CalculateDatabaseSteps => "calculateDatabaseSteps",
         }
@@ -45,6 +47,7 @@ static AVAILABLE_COMMANDS: &[RpcCommand] = &[
     RpcCommand::MigrationProgress,
     RpcCommand::UnapplyMigration,
     RpcCommand::Reset,
+    RpcCommand::SchemaPush,
     RpcCommand::CalculateDatamodel,
     RpcCommand::CalculateDatabaseSteps,
 ];
@@ -137,6 +140,11 @@ impl RpcApi {
                 render(executor.unapply_migration(&input).await?)
             }
             RpcCommand::Reset => render(executor.reset(&serde_json::Value::Null).await?),
+            RpcCommand::SchemaPush => {
+                let input: SchemaPushInput = params.clone().parse()?;
+
+                render(executor.schema_push(&input).await?)
+            }
             RpcCommand::CalculateDatamodel => {
                 let input: CalculateDatamodelInput = params.clone().parse()?;
                 render(executor.calculate_datamodel(&input).await?)

--- a/migration-engine/core/src/commands/mod.rs
+++ b/migration-engine/core/src/commands/mod.rs
@@ -6,6 +6,7 @@ mod infer_migration_steps;
 mod list_migrations;
 mod migration_progress;
 mod reset;
+mod schema_push;
 mod unapply_migration;
 
 pub use apply_migration::*;
@@ -16,6 +17,7 @@ pub use infer_migration_steps::*;
 pub use list_migrations::*;
 pub use migration_progress::*;
 pub use reset::*;
+pub use schema_push::*;
 pub use unapply_migration::*;
 
 use migration_connector::{

--- a/migration-engine/core/src/commands/schema_push.rs
+++ b/migration-engine/core/src/commands/schema_push.rs
@@ -1,0 +1,78 @@
+use super::MigrationCommand;
+use crate::parse_datamodel;
+use migration_connector::{DatabaseMigrationMarker, MigrationConnector};
+use serde::{Deserialize, Serialize};
+
+pub struct SchemaPushCommand<'a> {
+    pub input: &'a SchemaPushInput,
+}
+
+#[async_trait::async_trait]
+impl<'a> MigrationCommand for SchemaPushCommand<'a> {
+    type Input = SchemaPushInput;
+    type Output = SchemaPushOutput;
+
+    async fn execute<C, D>(
+        input: &Self::Input,
+        engine: &crate::migration_engine::MigrationEngine<C, D>,
+    ) -> super::CommandResult<Self::Output>
+    where
+        C: MigrationConnector<DatabaseMigration = D>,
+        D: DatabaseMigrationMarker + Send + Sync + 'static,
+    {
+        let connector = engine.connector();
+        let schema = parse_datamodel(&input.schema)?;
+        let inferrer = connector.database_migration_inferrer();
+        let applier = connector.database_migration_step_applier();
+        let checker = connector.destructive_changes_checker();
+
+        let sql_migration = inferrer.infer(&schema, &schema, &[]).await?;
+
+        let checks = checker.check(&sql_migration).await?;
+
+        let mut step = 0u32;
+
+        match (checks.unexecutable_migrations.len(), checks.warnings.len(), input.force) {
+            (unexecutable, _, _) if unexecutable > 0 => (),
+            (0, 0, _) | (0, _, true) => {
+                while applier.apply_step(&sql_migration, step as usize).await? {
+                    step += 1
+                }
+            }
+            _ => (),
+        }
+
+        Ok(SchemaPushOutput {
+            executed_steps: step,
+            warnings: checks.warnings.into_iter().map(|warning| warning.description).collect(),
+            unexecutable: checks
+                .unexecutable_migrations
+                .into_iter()
+                .map(|unexecutable| unexecutable.description)
+                .collect(),
+        })
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SchemaPushInput {
+    /// The prisma schema.
+    pub schema: String,
+    /// Push the schema ignoring destructive change warnings.
+    pub force: bool,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SchemaPushOutput {
+    pub executed_steps: u32,
+    pub warnings: Vec<String>,
+    pub unexecutable: Vec<String>,
+}
+
+impl SchemaPushOutput {
+    pub fn had_no_changes_to_push(&self) -> bool {
+        self.warnings.is_empty() && self.unexecutable.is_empty() && self.executed_steps == 0
+    }
+}

--- a/migration-engine/migration-engine-tests/src/test_api.rs
+++ b/migration-engine/migration-engine-tests/src/test_api.rs
@@ -2,12 +2,14 @@ mod apply;
 mod calculate_database_steps;
 mod infer;
 mod infer_apply;
+mod schema_push;
 mod unapply_migration;
 
 pub use apply::Apply;
 pub use calculate_database_steps::CalculateDatabaseSteps;
 pub use infer::Infer;
 pub use infer_apply::InferApply;
+pub use schema_push::SchemaPush;
 pub use unapply_migration::UnapplyMigration;
 
 use super::assertions::SchemaAssertion;
@@ -137,6 +139,10 @@ impl TestApi {
             api: &self.api,
             force: None,
         }
+    }
+
+    pub fn schema_push<'a>(&'a self, dm: impl Into<String>) -> SchemaPush<'a> {
+        SchemaPush::new(&self.api, dm.into())
     }
 
     pub fn barrel(&self) -> BarrelMigrationExecutor<'_> {

--- a/migration-engine/migration-engine-tests/src/test_api/schema_push.rs
+++ b/migration-engine/migration-engine-tests/src/test_api/schema_push.rs
@@ -1,0 +1,126 @@
+use super::super::assertions::AssertionResult;
+use migration_core::{
+    api::GenericApi,
+    commands::{SchemaPushInput, SchemaPushOutput},
+};
+use std::borrow::Cow;
+
+pub struct SchemaPush<'a> {
+    api: &'a dyn GenericApi,
+    schema: String,
+    force: bool,
+}
+
+impl<'a> SchemaPush<'a> {
+    pub fn new(api: &'a dyn GenericApi, schema: String) -> Self {
+        SchemaPush {
+            api,
+            schema,
+            force: false,
+        }
+    }
+
+    pub fn force(mut self, force: bool) -> Self {
+        self.force = force;
+        self
+    }
+
+    pub async fn send(self) -> anyhow::Result<SchemaPushAssertion<'a>> {
+        let input = SchemaPushInput {
+            schema: self.schema,
+            force: self.force,
+        };
+
+        let output = self.api.schema_push(&input).await?;
+
+        Ok(SchemaPushAssertion {
+            result: output,
+            _api: self.api,
+        })
+    }
+}
+
+pub struct SchemaPushAssertion<'a> {
+    pub(super) result: SchemaPushOutput,
+    pub(super) _api: &'a dyn GenericApi,
+}
+
+impl<'a> SchemaPushAssertion<'a> {
+    /// Asserts that the command produced no warning and no unexecutable migration message.
+    pub fn assert_green(self) -> AssertionResult<Self> {
+        self.assert_no_warning()?.assert_executable()
+    }
+
+    pub fn assert_no_warning(self) -> AssertionResult<Self> {
+        anyhow::ensure!(
+            self.result.warnings.is_empty(),
+            "Assertion failed. Expected no warning, got {:?}",
+            self.result.warnings
+        );
+
+        Ok(self)
+    }
+
+    pub fn assert_warnings(self, warnings: &[Cow<'_, str>]) -> AssertionResult<Self> {
+        anyhow::ensure!(
+            self.result.warnings.len() == warnings.len(),
+            "Expected {} warnings, got {}.\n{:#?}",
+            warnings.len(),
+            self.result.warnings.len(),
+            self.result.warnings
+        );
+
+        for (idx, warning) in warnings.iter().enumerate() {
+            assert_eq!(
+                Some(warning.as_ref()),
+                self.result.warnings.get(idx).map(String::as_str)
+            );
+        }
+
+        Ok(self)
+    }
+
+    pub fn assert_no_steps(self) -> AssertionResult<Self> {
+        anyhow::ensure!(
+            self.result.executed_steps == 0,
+            "Assertion failed. Executed steps should be zero, but found {:#?}",
+            self.result.executed_steps
+        );
+
+        Ok(self)
+    }
+
+    pub fn assert_has_executed_steps(self) -> AssertionResult<Self> {
+        anyhow::ensure!(
+            self.result.executed_steps != 0,
+            "Assertion failed. Executed steps should be not zero.",
+        );
+
+        Ok(self)
+    }
+
+    pub fn assert_executable(self) -> AssertionResult<Self> {
+        assert!(self.result.unexecutable.is_empty());
+
+        Ok(self)
+    }
+
+    pub fn assert_unexecutable(self, expected_messages: &[String]) -> AssertionResult<Self> {
+        anyhow::ensure!(
+            self.result.unexecutable.len() == expected_messages.len(),
+            "Expected {} unexecutable step errors, got {}.\n({:#?})",
+            expected_messages.len(),
+            self.result.unexecutable.len(),
+            self.result.unexecutable,
+        );
+
+        for (expected, actual) in expected_messages
+            .iter()
+            .zip(self.result.unexecutable.iter().map(String::as_str))
+        {
+            assert_eq!(actual, expected);
+        }
+
+        Ok(self)
+    }
+}

--- a/migration-engine/migration-engine-tests/tests/migration_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migration_tests.rs
@@ -9,6 +9,7 @@ mod infer_migration_steps;
 mod migration_persistence;
 mod migrations;
 mod multi_user;
+mod schema_push;
 mod unapply_migration;
 
 use migration_engine_tests::sql::*;

--- a/migration-engine/migration-engine-tests/tests/schema_push/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/schema_push/mod.rs
@@ -14,7 +14,7 @@ model Box {
 }
 "#;
 
-#[test_each_connector]
+#[test_each_connector(log = "sql_schema_describer=info,debug")]
 async fn schema_push_happy_path(api: &TestApi) -> TestResult {
     api.schema_push(SCHEMA)
         .send()


### PR DESCRIPTION
This is something we want to experiment with. It takes a prisma schema and migrates the database to match it, without interacting with the migrations, which we think should be a separate workflow. This is meant as a dev workflow, when you are doing initial iteration on your application and do not care about migrations yet. It may also become the recommended way to iterate on your schema before generating your next migration.

The name of the command is a draft name, it will likely change.

Open work items:
- we should persist schema pushes to the migrations table for auditability/debuggability.
- we should look at the README.md we generate, and the SQL in there after a few schema pushes, then `migrate save`. It should be SQL generated only from the prisma schemas diff, without introspection (or it would be off).

roadmap issue: https://github.com/prisma/prisma/issues/3050