### PR TITLE
Replace failure with anyhow + thiserror

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -737,7 +737,6 @@ dependencies = [
  "colored",
  "cuid",
  "datamodel-connector",
- "failure",
  "indoc",
  "itertools",
  "once_cell",
@@ -750,6 +749,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
+ "thiserror",
  "tracing",
  "uuid",
 ]
@@ -943,8 +943,8 @@ checksum = "36a9cb09840f81cd211e435d00a4e487edd263dc3c8ff815c32dd76ad668ebed"
 name = "feature-flags"
 version = "0.1.0"
 dependencies = [
- "failure",
  "once_cell",
+ "thiserror",
 ]
 
 [[package]]
@@ -2447,7 +2447,6 @@ dependencies = [
  "cuid",
  "datamodel",
  "debug_stub_derive",
- "failure",
  "itertools",
  "once_cell",
  "prisma-value",
@@ -2457,6 +2456,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "thiserror",
  "uuid",
 ]
 
@@ -2583,9 +2583,9 @@ dependencies = [
 name = "query-connector"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "chrono",
- "failure",
  "futures 0.3.5",
  "itertools",
  "once_cell",
@@ -2593,6 +2593,7 @@ dependencies = [
  "prisma-value",
  "serde",
  "serde_json",
+ "thiserror",
  "user-facing-errors",
  "uuid",
 ]
@@ -2605,7 +2606,6 @@ dependencies = [
  "chrono",
  "crossbeam-queue",
  "debug_stub_derive",
- "failure",
  "feature-flags",
  "futures 0.3.5",
  "im",
@@ -2620,6 +2620,7 @@ dependencies = [
  "rust_decimal 1.7.0 (git+https://github.com/pimeys/rust-decimal?branch=pgbouncer-mode)",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio",
  "tracing",
  "user-facing-errors",
@@ -2636,7 +2637,6 @@ dependencies = [
  "base64 0.10.1",
  "chrono",
  "datamodel",
- "failure",
  "feature-flags",
  "futures 0.3.5",
  "graphql-parser",
@@ -2662,6 +2662,7 @@ dependencies = [
  "structopt",
  "test-macros",
  "test-setup",
+ "thiserror",
  "tide",
  "tokio",
  "tracing",
@@ -3161,11 +3162,11 @@ dependencies = [
 name = "sql-query-connector"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "chrono",
  "cuid",
  "datamodel",
- "failure",
  "futures 0.3.5",
  "itertools",
  "prisma-models",
@@ -3176,6 +3177,7 @@ dependencies = [
  "rust_decimal 1.7.0 (git+https://github.com/pimeys/rust-decimal?branch=pgbouncer-mode)",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio",
  "user-facing-errors",
  "uuid",

--- a/libs/datamodel/core/Cargo.toml
+++ b/libs/datamodel/core/Cargo.toml
@@ -15,8 +15,8 @@ colored = "1.8.0"
 chrono = { version = "0.4.6", features = ["serde"] }
 itertools = "0.8"
 serde = { version = "1.0.90", features = ["derive"] }
-serde_json ={version =  "1.0" ,features = ["preserve_order"]}
-failure = { version = "0.1", features = ["derive"] }
+serde_json = { version =  "1.0", features = ["preserve_order"] }
+thiserror = "1.0"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 cuid = { git = "https://github.com/prisma/cuid-rust" }
 bytecount = "0.5"

--- a/libs/datamodel/core/src/ast/reformat/reformatter.rs
+++ b/libs/datamodel/core/src/ast/reformat/reformatter.rs
@@ -5,7 +5,6 @@ use pest::Parser;
 // do multiple mutable borrows inside a match statement.
 use super::helpers::*;
 use crate::common::WritableString;
-use std::thread::current;
 
 pub struct Reformatter<'a> {
     input: &'a str,

--- a/libs/datamodel/core/src/error/collection.rs
+++ b/libs/datamodel/core/src/error/collection.rs
@@ -67,12 +67,12 @@ impl ErrorCollection {
 
 impl std::fmt::Display for ErrorCollection {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        let msg: Vec<String> = self.errors.iter().map(|e| format!("{}", e)).collect();
+        let msg: Vec<String> = self.errors.iter().map(|e| e.to_string()).collect();
         f.write_str(&msg.join("\n"))
     }
 }
 
-impl std::convert::From<DatamodelError> for ErrorCollection {
+impl From<DatamodelError> for ErrorCollection {
     fn from(error: DatamodelError) -> Self {
         let mut col = ErrorCollection::new();
         col.push(error);

--- a/libs/datamodel/core/src/error/mod.rs
+++ b/libs/datamodel/core/src/error/mod.rs
@@ -3,6 +3,7 @@ pub use collection::*;
 
 use crate::ast::Span;
 use colored::Colorize;
+use thiserror::Error;
 
 // No format for this file, on purpose.
 // Line breaks make the declarations very hard to read.
@@ -11,106 +12,106 @@ use colored::Colorize;
 /// parsing or validation.
 ///
 /// For fancy printing, please use the `pretty_print_error` function.
-#[derive(Debug, Fail, Clone, PartialEq)]
+#[derive(Debug, Error, Clone, PartialEq)]
 pub enum DatamodelError {
-    #[fail(display = "Argument \"{}\" is missing.", argument_name)]
+    #[error("Argument \"{}\" is missing.", argument_name)]
     ArgumentNotFound { argument_name: String, span: Span },
 
-    #[fail(display = "Function \"{}\" takes {} arguments, but received {}.", function_name, required_count, given_count)]
+    #[error("Function \"{}\" takes {} arguments, but received {}.", function_name, required_count, given_count)]
     ArgumentCountMissmatch { function_name: String, required_count: usize, given_count: usize, span: Span },
 
-    #[fail(display = "Argument \"{}\" is missing in attribute \"@{}\".", argument_name, directive_name)]
+    #[error("Argument \"{}\" is missing in attribute \"@{}\".", argument_name, directive_name)]
     DirectiveArgumentNotFound { argument_name: String, directive_name: String, span: Span },
 
-    #[fail(display = "Argument \"{}\" is missing in data source block \"{}\".", argument_name, source_name)]
+    #[error("Argument \"{}\" is missing in data source block \"{}\".", argument_name, source_name)]
     SourceArgumentNotFound { argument_name: String, source_name: String, span: Span },
 
-    #[fail(display = "Argument \"{}\" is missing in generator block \"{}\".", argument_name, generator_name)]
+    #[error("Argument \"{}\" is missing in generator block \"{}\".", argument_name, generator_name)]
     GeneratorArgumentNotFound { argument_name: String, generator_name: String, span: Span },
 
-    #[fail(display = "Error parsing attribute \"@{}\": {}", directive_name, message)]
+    #[error("Error parsing attribute \"@{}\": {}", directive_name, message)]
     DirectiveValidationError { message: String, directive_name: String, span: Span },
 
-    #[fail(display = "Attribute \"@{}\" is defined twice.", directive_name)]
+    #[error("Attribute \"@{}\" is defined twice.", directive_name)]
     DuplicateDirectiveError { directive_name: String, span: Span },
 
-    #[fail(display = "\"{}\" is a reserved scalar type name and can not be used.", type_name)]
+    #[error("\"{}\" is a reserved scalar type name and can not be used.", type_name)]
     ReservedScalarTypeError { type_name: String, span: Span },
 
-    #[fail(display = "The {} \"{}\" cannot be defined because a {} with that name already exists.", top_type, name, existing_top_type)]
+    #[error("The {} \"{}\" cannot be defined because a {} with that name already exists.", top_type, name, existing_top_type)]
     DuplicateTopError { name: String, top_type: String, existing_top_type: String, span: Span },
 
     // conf_block_name is pre-populated with "" in precheck.ts.
-    #[fail(display = "Key \"{}\" is already defined in {}.", key_name, conf_block_name)]
+    #[error("Key \"{}\" is already defined in {}.", key_name, conf_block_name)]
     DuplicateConfigKeyError { conf_block_name: String, key_name: String, span: Span },
 
-    #[fail(display = "Argument \"{}\" is already specified as unnamed argument.", arg_name)]
+    #[error("Argument \"{}\" is already specified as unnamed argument.", arg_name)]
     DuplicateDefaultArgumentError { arg_name: String, span: Span },
 
-    #[fail(display = "Argument \"{}\" is already specified.", arg_name)]
+    #[error("Argument \"{}\" is already specified.", arg_name)]
     DuplicateArgumentError { arg_name: String, span: Span },
 
-    #[fail(display = "No such argument.")]
+    #[error("No such argument.")]
     UnusedArgumentError { arg_name: String, span: Span },
 
-    #[fail(display = "Field \"{}\" is already defined on model \"{}\".", field_name, model_name)]
+    #[error("Field \"{}\" is already defined on model \"{}\".", field_name, model_name)]
     DuplicateFieldError { model_name: String, field_name: String, span: Span },
 
-    #[fail(display = "Field \"{}\" in model \"{}\" can't be a list. The current connector does not support lists of primitive types.", field_name, model_name)]
+    #[error("Field \"{}\" in model \"{}\" can't be a list. The current connector does not support lists of primitive types.", field_name, model_name)]
     ScalarListFieldsAreNotSupported { model_name: String, field_name: String, span: Span },
 
-    #[fail(display = "Value \"{}\" is already defined on enum \"{}\".", value_name, enum_name)]
+    #[error("Value \"{}\" is already defined on enum \"{}\".", value_name, enum_name)]
     DuplicateEnumValueError { enum_name: String, value_name: String, span: Span },
-    
-    #[fail(display = "Attribute not known: \"@{}\".", directive_name)]
+
+    #[error("Attribute not known: \"@{}\".", directive_name)]
     DirectiveNotKnownError { directive_name: String, span: Span },
 
-    #[fail(display = "Function not known: \"{}\".", function_name)]
+    #[error("Function not known: \"{}\".", function_name)]
     FunctionNotKnownError { function_name: String, span: Span },
 
-    #[fail(display = "Datasource provider not known: \"{}\".", source_name)]
+    #[error("Datasource provider not known: \"{}\".", source_name)]
     DatasourceProviderNotKnownError { source_name: String, span: Span },
 
-    #[fail(display = "\"{}\" is not a valid value for {}.", raw_value, literal_type)]
+    #[error("\"{}\" is not a valid value for {}.", raw_value, literal_type)]
     LiteralParseError { literal_type: String, raw_value: String, span: Span },
 
-    #[fail(display = "Type \"{}\" is neither a built-in type, nor refers to another model, custom type, or enum.", type_name)]
+    #[error("Type \"{}\" is neither a built-in type, nor refers to another model, custom type, or enum.", type_name)]
     TypeNotFoundError { type_name: String, span: Span },
 
-    #[fail(display = "Type \"{}\" is not a built-in type.", type_name)]
+    #[error("Type \"{}\" is not a built-in type.", type_name)]
     ScalarTypeNotFoundError { type_name: String, span: Span },
 
-    #[fail(display = "Unexpected token. Expected one of: {}", expected_str)]
+    #[error("Unexpected token. Expected one of: {}", expected_str)]
     ParserError { expected: Vec<&'static str>, expected_str: String, span: Span },
 
-    #[fail(display = "{}", message)]
+    #[error("{}", message)]
     LegacyParserError { message: String, span: Span },
 
-    #[fail(display = "{}", message)]
+    #[error("{}", message)]
     FunctionalEvaluationError { message: String, span: Span },
 
-    #[fail(display = "Environment variable not found: {}.", var_name)]
+    #[error("Environment variable not found: {}.", var_name)]
     EnvironmentFunctionalEvaluationError { var_name: String, span: Span },
 
-    #[fail(display = "Expected a {} value, but received {} value \"{}\".", expected_type, received_type, raw)]
+    #[error("Expected a {} value, but received {} value \"{}\".", expected_type, received_type, raw)]
     TypeMismatchError { expected_type: String, received_type: String, raw: String, span: Span },
 
-    #[fail(display = "Expected a {} value, but failed while parsing \"{}\": {}.", expected_type, raw, parser_error)]
+    #[error("Expected a {} value, but failed while parsing \"{}\": {}.", expected_type, raw, parser_error)]
     ValueParserError { expected_type: String, parser_error: String, raw: String, span: Span },
 
-    #[fail(display = "Error validating model \"{}\": {}", model_name, message)]
+    #[error("Error validating model \"{}\": {}", model_name, message)]
     ModelValidationError { message: String, model_name: String, span: Span  },
 
-    #[fail(display = "Error validating field `{}` in model `{}`: {}", field, model, message)]
+    #[error("Error validating field `{}` in model `{}`: {}", field, model, message)]
     FieldValidationError { message: String, model: String, field: String, span: Span },
 
-    #[fail(display = "Error validating datasource `{}`: {}", source, message)]
-    SourceValidationError { message: String, source: String, span: Span },
+    #[error("Error validating datasource `{datasource}`: {message}")]
+    SourceValidationError { message: String, datasource: String, span: Span },
 
-    #[fail(display = "Error validating enum `{}`: {}", enum_name, message)]
+    #[error("Error validating enum `{}`: {}", enum_name, message)]
     EnumValidationError { message: String, enum_name: String, span: Span },
 
-    #[fail(display = "Error validating: {}", message)]
+    #[error("Error validating: {}", message)]
     ValidationError { message: String, span: Span  },
 }
 
@@ -274,7 +275,7 @@ impl DatamodelError {
     pub fn new_source_validation_error(message: &str, source: &str, span: Span) -> DatamodelError {
         DatamodelError::SourceValidationError {
             message: message.to_owned(),
-            source: source.to_owned(),
+            datasource: source.to_owned(),
             span,
         }
     }
@@ -413,18 +414,18 @@ fn pretty_print_error(f: &mut dyn std::io::Write, file_name: &str, text: &str, e
     writeln!(f, "{}: {}", "error".bright_red().bold(), error.bold())?;
     writeln!(f, "  {}  {}", arrow, file_path)?;
     writeln!(f, "{}", format_line_number(0))?;
-    
+
     writeln!(f, "{}", format_line_number_with_line(start_line_number, &file_lines))?;
     writeln!(f, "{}{}{}{}", format_line_number(start_line_number + 1), prefix, offending, suffix)?;
     if offending.len() == 0 {
         let spacing = std::iter::repeat(" ").take(start_in_line).collect::<String>();
         writeln!(f, "{}{}{}", format_line_number(0), spacing, "^ Unexpected token.".bold().bright_red())?;
     }
-    
+
     for line_number in start_line_number + 2 .. end_line_number + 2 {
         writeln!(f, "{}", format_line_number_with_line(line_number, &file_lines))?;
     }
-    
+
     writeln!(f, "{}", format_line_number(0))
 }
 

--- a/libs/datamodel/core/src/lib.rs
+++ b/libs/datamodel/core/src/lib.rs
@@ -2,8 +2,6 @@ extern crate pest; // Pest grammar generation on compile time.
 #[macro_use]
 extern crate pest_derive;
 #[macro_use]
-extern crate failure; // Failure enum display derivation
-#[macro_use]
 extern crate tracing;
 
 pub mod ast;

--- a/libs/feature-flags/Cargo.toml
+++ b/libs/feature-flags/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2018"
 
 [dependencies]
 once_cell = "1.4"
-failure = { version = "0.1", features = ["derive"] }
+thiserror = "1.0"

--- a/libs/feature-flags/src/lib.rs
+++ b/libs/feature-flags/src/lib.rs
@@ -8,14 +8,14 @@
 //! - Make sure that the flags are initialized in the app stack with `feature_flags::initialize(_)`.
 //! - Use the flag in crates that have a dependency on the feature flags crate with: `feature_flags::get().<bool_flag_name>`.
 
-use failure::Fail;
 use once_cell::sync::OnceCell;
+use thiserror::Error;
 
 static FEATURE_FLAGS: OnceCell<FeatureFlags> = OnceCell::new();
 
-#[derive(Debug, Fail)]
+#[derive(Debug, Error)]
 pub enum FeatureFlagError {
-    #[fail(display = "Invalid feature flag: {}", _0)]
+    #[error("Invalid feature flag: {0}")]
     InvalidFlag(String),
 }
 

--- a/libs/prisma-models/Cargo.toml
+++ b/libs/prisma-models/Cargo.toml
@@ -17,7 +17,7 @@ debug_stub_derive = "0.3"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 cuid = { git = "https://github.com/prisma/cuid-rust" }
 chrono = { version = "0.4", features = ["serde"] }
-failure = { version = "0.1", features = ["derive"] }
+thiserror = "1.0"
 rand = "0.7"
 datamodel = { path = "../datamodel/core" }
 itertools = "0.8"

--- a/libs/prisma-models/src/error.rs
+++ b/libs/prisma-models/src/error.rs
@@ -1,30 +1,30 @@
-use failure::Fail;
 use prisma_value::ConversionFailure;
+use thiserror::Error;
 
-#[derive(Debug, Fail)]
+#[derive(Debug, Error)]
 pub enum DomainError {
-    #[fail(display = "Model `{}` not found", name)]
+    #[error("Model `{}` not found", name)]
     ModelNotFound { name: String },
 
-    #[fail(display = "Field `{}` on model `{}` not found", name, model)]
+    #[error("Field `{}` on model `{}` not found", name, model)]
     FieldNotFound { name: String, model: String },
 
-    #[fail(display = "Relation `{}` not found", name)]
+    #[error("Relation `{}` not found", name)]
     RelationNotFound { name: String },
 
-    #[fail(display = "ScalarField `{}` on model `{}` not found", name, model)]
+    #[error("ScalarField `{}` on model `{}` not found", name, model)]
     ScalarFieldNotFound { name: String, model: String },
 
-    #[fail(display = "RelationField `{}` on model `{}` not found", name, model)]
+    #[error("RelationField `{}` on model `{}` not found", name, model)]
     RelationFieldNotFound { name: String, model: String },
 
-    #[fail(display = "Relation field `{}` on model `{}` not found", relation, model)]
+    #[error("Relation field `{}` on model `{}` not found", relation, model)]
     FieldForRelationNotFound { relation: String, model: String },
 
-    #[fail(display = "Model id `{}` for relation `{}` not found", model_id, relation)]
+    #[error("Model id `{}` for relation `{}` not found", model_id, relation)]
     ModelForRelationNotFound { model_id: String, relation: String },
 
-    #[fail(display = "Conversion from `{}` to `{}` failed.", _0, _1)]
+    #[error("Conversion from `{}` to `{}` failed.", _0, _1)]
     ConversionFailure(String, String),
 }
 

--- a/query-engine/connectors/query-connector/Cargo.toml
+++ b/query-engine/connectors/query-connector/Cargo.toml
@@ -5,12 +5,13 @@ authors = []
 edition = "2018"
 
 [dependencies]
+anyhow = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 once_cell = "1.3"
 prisma-models = { path = "../../../libs/prisma-models" }
 prisma-value = { path = "../../../libs/prisma-value" }
-failure = { version = "0.1", features = ["derive"] }
+thiserror = "1.0"
 uuid = "0.8"
 itertools = "0.8"
 chrono = { version = "0.4", features = ["serde"] }

--- a/query-engine/connectors/query-connector/src/error.rs
+++ b/query-engine/connectors/query-connector/src/error.rs
@@ -1,10 +1,10 @@
 use crate::filter::Filter;
-use failure::{Error, Fail};
 use prisma_models::prelude::DomainError;
+use thiserror::Error;
 use user_facing_errors::{query_engine::DatabaseConstraint, KnownError};
 
-#[derive(Debug, Fail)]
-#[fail(display = "{}", kind)]
+#[derive(Debug, Error)]
+#[error("{}", kind)]
 pub struct ConnectorError {
     /// An optional error already rendered for users in case the migration core does not handle it.
     pub user_facing_error: Option<KnownError>,
@@ -31,47 +31,49 @@ impl ConnectorError {
     }
 }
 
-#[derive(Debug, Fail)]
+#[derive(Debug, Error)]
 pub enum ErrorKind {
-    #[fail(display = "Unique constraint failed: {}", constraint)]
+    #[error("Unique constraint failed: {}", constraint)]
     UniqueConstraintViolation { constraint: DatabaseConstraint },
 
-    #[fail(display = "Null constraint failed: {}", constraint)]
+    #[error("Null constraint failed: {}", constraint)]
     NullConstraintViolation { constraint: DatabaseConstraint },
 
-    #[fail(display = "Foreign key constraint failed")]
+    #[error("Foreign key constraint failed")]
     ForeignKeyConstraintViolation { constraint: DatabaseConstraint },
 
-    #[fail(display = "Record does not exist.")]
+    #[error("Record does not exist.")]
     RecordDoesNotExist,
 
-    #[fail(display = "Column does not exist")]
+    #[error("Column does not exist")]
     ColumnDoesNotExist,
 
-    #[fail(display = "Error creating a database connection. ({})", _0)]
-    ConnectionError(Error),
+    #[error("Error creating a database connection. ({})", _0)]
+    ConnectionError(anyhow::Error),
 
-    #[fail(display = "Error querying the database: {}", _0)]
+    #[error("Error querying the database: {}", _0)]
     QueryError(Box<dyn std::error::Error + Send + Sync>),
 
-    #[fail(display = "The provided arguments are not supported.")]
+    #[error("The provided arguments are not supported.")]
     InvalidConnectionArguments,
 
-    #[fail(display = "The column value was different from the model")]
+    #[error("The column value was different from the model")]
     ColumnReadFailure(Box<dyn std::error::Error + Send + Sync>),
 
-    #[fail(display = "Field cannot be null: {}", field)]
+    #[error("Field cannot be null: {}", field)]
     FieldCannotBeNull { field: String },
 
-    #[fail(display = "{}", _0)]
+    #[error("{}", _0)]
     DomainError(DomainError),
 
-    #[fail(display = "Record not found: {:?}", _0)]
+    #[error("Record not found: {:?}", _0)]
     RecordNotFoundForWhere(Filter),
 
-    #[fail(
-        display = "Violating a relation {} between {} and {}",
-        relation_name, model_a_name, model_b_name
+    #[error(
+        "Violating a relation {} between {} and {}",
+        relation_name,
+        model_a_name,
+        model_b_name
     )]
     RelationViolation {
         relation_name: String,
@@ -79,9 +81,11 @@ pub enum ErrorKind {
         model_b_name: String,
     },
 
-    #[fail(
-        display = "The relation {} has no record for the model {} connected to a record for the model {} on your write path.",
-        relation_name, parent_name, child_name
+    #[error(
+        "The relation {} has no record for the model {} connected to a record for the model {} on your write path.",
+        relation_name,
+        parent_name,
+        child_name
     )]
     RecordsNotConnected {
         relation_name: String,
@@ -89,25 +93,25 @@ pub enum ErrorKind {
         child_name: String,
     },
 
-    #[fail(display = "Conversion error: {}", _0)]
-    ConversionError(Error),
+    #[error("Conversion error: {}", _0)]
+    ConversionError(anyhow::Error),
 
-    #[fail(display = "Conversion error: {}", _0)]
+    #[error("Conversion error: {}", _0)]
     InternalConversionError(String),
 
-    #[fail(display = "Database creation error: {}", _0)]
+    #[error("Database creation error: {}", _0)]
     DatabaseCreationError(&'static str),
 
-    #[fail(display = "Database '{}' does not exist.", db_name)]
+    #[error("Database '{}' does not exist.", db_name)]
     DatabaseDoesNotExist { db_name: String },
 
-    #[fail(display = "Access denied to database '{}'", db_name)]
+    #[error("Access denied to database '{}'", db_name)]
     DatabaseAccessDenied { db_name: String },
 
-    #[fail(display = "Authentication failed for user '{}'", user)]
+    #[error("Authentication failed for user '{}'", user)]
     AuthenticationFailed { user: String },
 
-    #[fail(display = "Database error. error code: {}, error message: {}", code, message)]
+    #[error("Database error. error code: {}, error message: {}", code, message)]
     RawError { code: String, message: String },
 }
 

--- a/query-engine/connectors/sql-query-connector/Cargo.toml
+++ b/query-engine/connectors/sql-query-connector/Cargo.toml
@@ -5,13 +5,14 @@ name = "sql-query-connector"
 version = "0.1.0"
 
 [dependencies]
+anyhow = "1.0"
 async-trait = "0.1"
-failure = "0.1"
 futures = "0.3"
 itertools = "0.8"
 rand = "0.7"
 rust_decimal = { git = "https://github.com/pimeys/rust-decimal", branch = "pgbouncer-mode" }
 serde_json = "1.0"
+thiserror = "1.0"
 tokio = "=0.2.13"
 uuid = "0.8"
 

--- a/query-engine/connectors/sql-query-connector/src/database/connection.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/connection.rs
@@ -8,6 +8,7 @@ use connector_interface::{
 use prisma_models::prelude::*;
 use prisma_value::PrismaValue;
 use quaint::{connector::TransactionCapable, prelude::ConnectionInfo};
+use std::future::Future;
 
 pub struct SqlConnection<C> {
     inner: C,
@@ -25,7 +26,7 @@ where
 
     async fn catch<O>(
         &self,
-        fut: impl std::future::Future<Output = Result<O, SqlError>>,
+        fut: impl Future<Output = Result<O, SqlError>>,
     ) -> Result<O, connector_interface::error::ConnectorError> {
         match fut.await {
             Ok(o) => Ok(o),

--- a/query-engine/connectors/sql-query-connector/src/error.rs
+++ b/query-engine/connectors/sql-query-connector/src/error.rs
@@ -1,8 +1,8 @@
 use connector_interface::{error::*, Filter};
-use failure::{Error, Fail};
 use prisma_models::prelude::DomainError;
 use quaint::error::ErrorKind as QuaintKind;
 use std::{any::Any, string::FromUtf8Error};
+use thiserror::Error;
 use user_facing_errors::query_engine::DatabaseConstraint;
 
 pub struct RawError {
@@ -38,44 +38,46 @@ impl From<Box<dyn Any + Send>> for RawError {
     }
 }
 
-#[derive(Debug, Fail)]
+#[derive(Debug, Error)]
 pub enum SqlError {
-    #[fail(display = "Unique constraint failed: {:?}", constraint)]
+    #[error("Unique constraint failed: {:?}", constraint)]
     UniqueConstraintViolation { constraint: DatabaseConstraint },
 
-    #[fail(display = "Null constraint failed: {:?}", constraint)]
+    #[error("Null constraint failed: {:?}", constraint)]
     NullConstraintViolation { constraint: DatabaseConstraint },
 
-    #[fail(display = "Foreign key constraint failed")]
+    #[error("Foreign key constraint failed")]
     ForeignKeyConstraintViolation { constraint: DatabaseConstraint },
 
-    #[fail(display = "Record does not exist.")]
+    #[error("Record does not exist.")]
     RecordDoesNotExist,
 
-    #[fail(display = "Column does not exist")]
+    #[error("Column does not exist")]
     ColumnDoesNotExist,
 
-    #[fail(display = "Error creating a database connection. ({})", _0)]
+    #[error("Error creating a database connection. ({})", _0)]
     ConnectionError(QuaintKind),
 
-    #[fail(display = "Error querying the database: {}", _0)]
+    #[error("Error querying the database: {}", _0)]
     QueryError(Box<dyn std::error::Error + Send + Sync>),
 
-    #[fail(display = "The column value was different from the model")]
+    #[error("The column value was different from the model")]
     ColumnReadFailure(Box<dyn std::error::Error + Send + Sync>),
 
-    #[fail(display = "Field cannot be null: {}", field)]
+    #[error("Field cannot be null: {}", field)]
     FieldCannotBeNull { field: String },
 
-    #[fail(display = "{}", _0)]
+    #[error("{}", _0)]
     DomainError(DomainError),
 
-    #[fail(display = "Record not found: {:?}", _0)]
+    #[error("Record not found: {:?}", _0)]
     RecordNotFoundForWhere(Filter),
 
-    #[fail(
-        display = "Violating a relation {} between {} and {}",
-        relation_name, model_a_name, model_b_name
+    #[error(
+        "Violating a relation {} between {} and {}",
+        relation_name,
+        model_a_name,
+        model_b_name
     )]
     RelationViolation {
         relation_name: String,
@@ -83,9 +85,11 @@ pub enum SqlError {
         model_b_name: String,
     },
 
-    #[fail(
-        display = "The relation {} has no record for the model {} connected to a record for the model {} on your write path.",
-        relation_name, parent_name, child_name
+    #[error(
+        "The relation {} has no record for the model {} connected to a record for the model {} on your write path.",
+        relation_name,
+        parent_name,
+        child_name
     )]
     RecordsNotConnected {
         relation_name: String,
@@ -95,10 +99,10 @@ pub enum SqlError {
         // child_where: Option<Box<RecordFinderInfo>>,
     },
 
-    #[fail(display = "Conversion error: {}", _0)]
-    ConversionError(Error),
+    #[error("Conversion error: {0}")]
+    ConversionError(anyhow::Error),
 
-    #[fail(display = "Database error. error code: {}, error message: {}", code, message)]
+    #[error("Database error. error code: {}, error message: {}", code, message)]
     RawError { code: String, message: String },
 }
 

--- a/query-engine/connectors/sql-query-connector/src/row.rs
+++ b/query-engine/connectors/sql-query-connector/src/row.rs
@@ -154,7 +154,7 @@ pub fn row_value_to_prisma_value(p_value: Value, type_identifier: &TypeIdentifie
                 let dt = DateTime::parse_from_rfc3339(dt_string.borrow())
                     .or_else(|_| DateTime::parse_from_rfc2822(dt_string.borrow()))
                     .map_err(|err| {
-                        failure::format_err!("Could not parse stored DateTime string: {} ({})", dt_string, err)
+                        anyhow::format_err!("Could not parse stored DateTime string: {} ({})", dt_string, err)
                     })
                     .unwrap();
 

--- a/query-engine/core/Cargo.toml
+++ b/query-engine/core/Cargo.toml
@@ -10,7 +10,7 @@ prisma-value = { path = "../../libs/prisma-value" }
 feature-flags = { path = "../../libs/feature-flags" }
 prisma-inflector = { path = "../../libs/prisma-inflector" }
 connector = { path = "../connectors/query-connector", package = "query-connector" }
-failure = { version =  "0.1", features = ["derive"] }
+thiserror = "1.0"
 uuid = "0.8"
 indexmap = { version = "1.0", features = ["serde-1"] }
 itertools = "0.8"

--- a/query-engine/core/src/error.rs
+++ b/query-engine/core/src/error.rs
@@ -1,36 +1,36 @@
 use crate::{InterpreterError, QueryGraphBuilderError, QueryGraphError, QueryParserError, RelationViolation};
 use connector::error::ConnectorError;
-use failure::Fail;
 use prisma_models::DomainError;
+use thiserror::Error;
 
 // TODO: Cleanup unused errors after refactorings.
-#[derive(Debug, Fail)]
+#[derive(Debug, Error)]
 pub enum CoreError {
-    #[fail(display = "Error in query graph construction: {:?}", _0)]
+    #[error("Error in query graph construction: {:?}", _0)]
     QueryGraphError(QueryGraphError),
 
-    #[fail(display = "Error in query graph construction: {:?}", _0)]
+    #[error("Error in query graph construction: {:?}", _0)]
     QueryGraphBuilderError(QueryGraphBuilderError),
 
-    #[fail(display = "Error in connector: {}", _0)]
+    #[error("Error in connector: {}", _0)]
     ConnectorError(ConnectorError),
 
-    #[fail(display = "Error in domain logic: {}", _0)]
+    #[error("Error in domain logic: {}", _0)]
     DomainError(DomainError),
 
-    #[fail(display = "{}", _0)]
+    #[error("{0}")]
     QueryParserError(QueryParserError),
 
-    #[fail(display = "Unsupported feature: {}", _0)]
+    #[error("Unsupported feature: {}", _0)]
     UnsupportedFeatureError(String),
 
-    #[fail(display = "{}", _0)]
+    #[error("{}", _0)]
     ConversionError(String),
 
-    #[fail(display = "{}", _0)]
+    #[error("{}", _0)]
     SerializationError(String),
 
-    #[fail(display = "{}", _0)]
+    #[error("{}", _0)]
     InterpreterError(InterpreterError),
 }
 
@@ -171,7 +171,7 @@ impl From<CoreError> for user_facing_errors::Error {
                     .into(),
                 }
             }
-            _ => user_facing_errors::Error::from_dyn_error(&err.compat()),
+            _ => user_facing_errors::Error::from_dyn_error(&err),
         }
     }
 }

--- a/query-engine/query-engine/Cargo.toml
+++ b/query-engine/query-engine/Cargo.toml
@@ -14,6 +14,7 @@ mssql = ["datamodel/mssql", "sql-connector/mssql"]
 futures = "0.3"
 tokio = { version = "=0.2.13", features = ["rt-threaded", "macros"] }
 
+anyhow = "1.0"
 async-trait = "0.1"
 feature-flags = { path = "../../libs/feature-flags" }
 datamodel = { path = "../../libs/datamodel/core" }
@@ -27,7 +28,7 @@ serde_json = { version = "1.0", features = [ "preserve_order" ] }
 tide = "0.10.0"
 async-std = { version = "1.6.2", features = ["attributes", "tokio02"] }
 base64 = "0.10"
-failure = { version = "0.1" }
+thiserror = "1.0"
 indexmap = { version = "1.0", features = [ "serde-1" ] }
 itertools = "0.8"
 url = "2.1"

--- a/query-engine/query-engine/src/error.rs
+++ b/query-engine/query-engine/src/error.rs
@@ -1,53 +1,53 @@
 use connector::error::ConnectorError;
 use datamodel::error::ErrorCollection;
-use failure::{Error, Fail};
 use feature_flags::FeatureFlagError;
 use graphql_parser::query::ParseError as GqlParseError;
 use query_core::CoreError;
 use serde_json;
+use thiserror::Error;
 
-#[derive(Debug, Fail)]
+#[derive(Debug, Error)]
 pub enum PrismaError {
-    #[fail(display = "{}", _0)]
+    #[error("{}", _0)]
     SerializationError(String),
 
-    #[fail(display = "{}", _0)]
+    #[error("{}", _0)]
     CoreError(CoreError),
 
-    #[fail(display = "{}", _0)]
-    JsonDecodeError(Error),
+    #[error("{}", _0)]
+    JsonDecodeError(anyhow::Error),
 
-    #[fail(display = "{}", _0)]
+    #[error("{}", _0)]
     ConfigurationError(String),
 
-    #[fail(display = "{}", _0)]
+    #[error("{}", _0)]
     ConnectorError(ConnectorError),
 
-    #[fail(display = "{}", _0)]
+    #[error("{}", _0)]
     ConversionError(ErrorCollection, String),
 
-    #[fail(display = "{}", _0)]
-    IOError(Error),
+    #[error("{}", _0)]
+    IOError(anyhow::Error),
 
-    #[fail(display = "{}", _0)]
+    #[error("{}", _0)]
     InvocationError(String),
 
     /// (Feature name, additional error text)
-    #[fail(display = "Unsupported feature: {}. {}", _0, _1)]
+    #[error("Unsupported feature: {}. {}", _0, _1)]
     UnsupportedFeatureError(&'static str, String),
 
-    #[fail(display = "Error in data model: {}", _0)]
+    #[error("Error in data model: {}", _0)]
     DatamodelError(ErrorCollection),
 
-    #[fail(display = "{}", _0)]
+    #[error("{}", _0)]
     QueryConversionError(String),
 
-    #[fail(display = "{}", _0)]
+    #[error("{}", _0)]
     FeatureError(String),
 }
 
 impl PrismaError {
-    pub(crate) fn render_as_json(self) -> Result<(), failure::Error> {
+    pub(crate) fn render_as_json(self) -> Result<(), anyhow::Error> {
         use std::fmt::Write as _;
         use std::io::Write as _;
 

--- a/query-engine/query-engine/src/request_handlers/graphql/response.rs
+++ b/query-engine/query-engine/src/request_handlers/graphql/response.rs
@@ -2,7 +2,6 @@
 use indexmap::IndexMap;
 // use internal::*;
 use crate::PrismaError;
-use failure::Fail;
 use query_core::{
     response_ir::{Item, Map, ResponseData},
     CoreError,
@@ -90,7 +89,7 @@ impl From<PrismaError> for GQLError {
     fn from(other: PrismaError) -> Self {
         match other {
             PrismaError::CoreError(core_error) => GQLError::from(core_error),
-            err => GQLError::from(user_facing_errors::Error::from_dyn_error(&err.compat())),
+            err => GQLError::from(user_facing_errors::Error::from_dyn_error(&err)),
         }
     }
 }


### PR DESCRIPTION
This is mostly a drop-in replacement. Failure is an older crate. Two important differences:

- anyhow and thiserror work with std::error::Error, failure has its own
Fail trait, that needs to be converted from and to standard errors. This is because std::error::Error was unusable when failure was written, it's better now.
- Failure is no longer maintained

part of https://github.com/prisma/prisma-engines/issues/912