### PR TITLE
Drop dependency on debug-stub

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -762,16 +762,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "debug_stub_derive"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "496b7f8a2f853313c3ca370641d7ff3e42c32974fdccda8f0684599ed0a3ff6b"
-dependencies = [
- "quote 0.3.15",
- "syn 0.11.11",
-]
-
-[[package]]
 name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2446,7 +2436,6 @@ dependencies = [
  "chrono",
  "cuid",
  "datamodel",
- "debug_stub_derive",
  "itertools",
  "once_cell",
  "prisma-value",
@@ -2605,7 +2594,6 @@ dependencies = [
  "async-trait",
  "chrono",
  "crossbeam-queue",
- "debug_stub_derive",
  "feature-flags",
  "futures 0.3.5",
  "im",
@@ -2672,12 +2660,6 @@ dependencies = [
  "url 2.1.1",
  "user-facing-errors",
 ]
-
-[[package]]
-name = "quote"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 
 [[package]]
 name = "quote"
@@ -3337,17 +3319,6 @@ checksum = "502d53007c02d7605a05df1c1a73ee436952781653da5d0bf57ad608f66932c1"
 
 [[package]]
 name = "syn"
-version = "0.11.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
-dependencies = [
- "quote 0.3.15",
- "synom",
- "unicode-xid 0.0.4",
-]
-
-[[package]]
-name = "syn"
 version = "0.15.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
@@ -3377,15 +3348,6 @@ dependencies = [
  "proc-macro2 1.0.19",
  "quote 1.0.7",
  "syn 1.0.35",
-]
-
-[[package]]
-name = "synom"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
-dependencies = [
- "unicode-xid 0.0.4",
 ]
 
 [[package]]
@@ -3837,12 +3799,6 @@ name = "unicode-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
-
-[[package]]
-name = "unicode-xid"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 
 [[package]]
 name = "unicode-xid"

--- a/libs/prisma-models/Cargo.toml
+++ b/libs/prisma-models/Cargo.toml
@@ -13,7 +13,6 @@ once_cell = "1.3"
 serde_derive = "1.0"
 serde_json = "1.0"
 serde = "1.0"
-debug_stub_derive = "0.3"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 cuid = { git = "https://github.com/prisma/cuid-rust" }
 chrono = { version = "0.4", features = ["serde"] }

--- a/libs/prisma-models/src/field/relation.rs
+++ b/libs/prisma-models/src/field/relation.rs
@@ -2,6 +2,7 @@ use crate::prelude::*;
 use datamodel::{FieldArity, RelationInfo};
 use once_cell::sync::OnceCell;
 use std::{
+    fmt::Debug,
     hash::{Hash, Hasher},
     sync::{Arc, Weak},
 };
@@ -22,7 +23,7 @@ pub struct RelationFieldTemplate {
     pub relation_info: RelationInfo,
 }
 
-#[derive(DebugStub, Clone)]
+#[derive(Clone)]
 pub struct RelationField {
     pub name: String,
     pub is_required: bool,
@@ -32,9 +33,24 @@ pub struct RelationField {
     pub relation: OnceCell<RelationWeakRef>,
     pub relation_info: RelationInfo,
 
-    #[debug_stub = "#ModelWeakRef#"]
     pub model: ModelWeakRef,
     pub(crate) fields: OnceCell<Vec<ScalarFieldWeak>>,
+}
+
+impl Debug for RelationField {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RelationField")
+            .field("name", &self.name)
+            .field("is_required", &self.is_required)
+            .field("is_list", &self.is_list)
+            .field("relation_name", &self.relation_name)
+            .field("relation_side", &self.relation_side)
+            .field("relation", &self.relation)
+            .field("relation_info", &self.relation_info)
+            .field("model", &"#ModelWeakRef#")
+            .field("fields", &self.fields)
+            .finish()
+    }
 }
 
 impl Eq for RelationField {}

--- a/libs/prisma-models/src/field/scalar.rs
+++ b/libs/prisma-models/src/field/scalar.rs
@@ -2,6 +2,7 @@ use crate::prelude::*;
 use datamodel::{DefaultValue, FieldArity};
 use once_cell::sync::OnceCell;
 use std::{
+    fmt::Debug,
     hash::{Hash, Hasher},
     sync::{Arc, Weak},
 };
@@ -31,7 +32,6 @@ pub struct ScalarFieldTemplate {
     pub default_value: Option<DefaultValue>,
 }
 
-#[derive(DebugStub)]
 pub struct ScalarField {
     pub name: String,
     pub type_identifier: TypeIdentifier,
@@ -46,10 +46,31 @@ pub struct ScalarField {
     pub db_name: Option<String>,
     pub default_value: Option<DefaultValue>,
 
-    #[debug_stub = "#ModelWeakRef#"]
     pub model: ModelWeakRef,
     pub(crate) is_unique: bool,
     pub(crate) read_only: OnceCell<bool>,
+}
+
+impl Debug for ScalarField {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ScalarField")
+            .field("name", &self.name)
+            .field("type_identifier", &self.type_identifier)
+            .field("is_required", &self.is_required)
+            .field("is_list", &self.is_list)
+            .field("is_id", &self.is_id)
+            .field("is_auto_generated_int_id", &self.is_auto_generated_int_id)
+            .field("is_autoincrement", &self.is_autoincrement)
+            .field("internal_enum", &self.internal_enum)
+            .field("behaviour", &self.behaviour)
+            .field("arity", &self.arity)
+            .field("db_name", &self.db_name)
+            .field("default_value", &self.default_value)
+            .field("model", &"#ModelWeakRef#")
+            .field("is_unique", &self.is_unique)
+            .field("read_only", &self.read_only)
+            .finish()
+    }
 }
 
 impl Eq for ScalarField {}

--- a/libs/prisma-models/src/internal_data_model.rs
+++ b/libs/prisma-models/src/internal_data_model.rs
@@ -13,7 +13,7 @@ pub struct InternalDataModelTemplate {
     pub version: Option<String>,
 }
 
-#[derive(DebugStub)]
+#[derive(Debug)]
 pub struct InternalDataModel {
     pub enums: Vec<InternalEnum>,
     version: Option<String>,

--- a/libs/prisma-models/src/lib.rs
+++ b/libs/prisma-models/src/lib.rs
@@ -1,8 +1,5 @@
 #![deny(warnings)]
 
-#[macro_use]
-extern crate debug_stub_derive;
-
 mod datamodel_converter;
 mod error;
 mod field;

--- a/libs/prisma-models/src/model.rs
+++ b/libs/prisma-models/src/model.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
 use once_cell::sync::OnceCell;
 use std::{
+    fmt::Debug,
     hash::{Hash, Hasher},
     sync::{Arc, Weak},
 };
@@ -19,7 +20,6 @@ pub struct ModelTemplate {
     pub dml_model: datamodel::Model,
 }
 
-#[derive(DebugStub)]
 pub struct Model {
     pub name: String,
     pub is_embedded: bool,
@@ -30,8 +30,22 @@ pub struct Model {
     primary_identifier: OnceCell<ModelProjection>,
     dml_model: datamodel::Model,
 
-    #[debug_stub = "#InternalDataModelWeakRef#"]
     pub internal_data_model: InternalDataModelWeakRef,
+}
+
+impl Debug for Model {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Model")
+            .field("name", &self.name)
+            .field("is_embedded", &self.is_embedded)
+            .field("manifestation", &self.manifestation)
+            .field("fields", &self.fields)
+            .field("indexes", &self.indexes)
+            .field("primary_identifier", &self.primary_identifier)
+            .field("dml_model", &self.dml_model)
+            .field("internal_data_model", &"#InternalDataModelWeakRef#")
+            .finish()
+    }
 }
 
 impl ModelTemplate {

--- a/libs/prisma-models/src/relation.rs
+++ b/libs/prisma-models/src/relation.rs
@@ -1,6 +1,9 @@
 use crate::prelude::*;
 use once_cell::sync::OnceCell;
-use std::sync::{Arc, Weak};
+use std::{
+    fmt::Debug,
+    sync::{Arc, Weak},
+};
 
 pub type RelationRef = Arc<Relation>;
 pub type RelationWeakRef = Weak<Relation>;
@@ -17,7 +20,6 @@ pub struct RelationTemplate {
 
 /// A relation between two models. Can be either using a `RelationTable` or
 /// model a direct link between two `RelationField`s.
-#[derive(DebugStub)]
 pub struct Relation {
     pub name: String,
 
@@ -35,8 +37,25 @@ pub struct Relation {
 
     pub manifestation: RelationLinkManifestation,
 
-    #[debug_stub = "#InternalDataModelWeakRef#"]
     pub internal_data_model: InternalDataModelWeakRef,
+}
+
+impl Debug for Relation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Relation")
+            .field("name", &self.name)
+            .field("model_a_name", &self.model_a_name)
+            .field("model_b_name", &self.model_b_name)
+            .field("model_a_on_delete", &self.model_a_on_delete)
+            .field("model_b_on_delete", &self.model_b_on_delete)
+            .field("model_a", &self.model_a)
+            .field("model_b", &self.model_b)
+            .field("field_a", &self.field_a)
+            .field("field_b", &self.field_b)
+            .field("manifestation", &self.manifestation)
+            .field("internal_data_model", &"#InternalDataModelWeakRef#")
+            .finish()
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/query-engine/core/Cargo.toml
+++ b/query-engine/core/Cargo.toml
@@ -18,7 +18,6 @@ serde_json = "1"
 serde = { version = "1", features = ["derive"] }
 chrono = "0.4"
 once_cell = "1.3"
-debug_stub_derive = "0.3"
 tracing = "0.1"
 petgraph = "0.4"
 im = "13.0"

--- a/query-engine/core/src/lib.rs
+++ b/query-engine/core/src/lib.rs
@@ -3,9 +3,6 @@
 #[macro_use]
 extern crate tracing;
 
-#[macro_use]
-extern crate debug_stub_derive;
-
 pub mod error;
 pub mod executor;
 pub mod interpreter;

--- a/query-engine/core/src/schema/query_schema.rs
+++ b/query-engine/core/src/schema/query_schema.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::{ParsedField, QueryGraph, QueryGraphBuilderResult};
+use fmt::Debug;
 use once_cell::sync::OnceCell;
 use prisma_models::{dml, InternalDataModelRef, ModelRef, TypeHint};
 use std::{
@@ -101,15 +102,23 @@ impl QuerySchema {
     }
 }
 
-#[derive(DebugStub)]
 pub struct ObjectType {
     name: String,
 
-    #[debug_stub = "#Fields Cell#"]
     fields: OnceCell<Vec<FieldRef>>,
 
     // Object types can directly map to models.
     model: Option<ModelRef>,
+}
+
+impl Debug for ObjectType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ObjectType")
+            .field("name", &self.name)
+            .field("fields", &"#Fields Cell#")
+            .field("model", &self.model)
+            .finish()
+    }
 }
 
 impl ObjectType {
@@ -187,7 +196,6 @@ impl SchemaQueryBuilder {
 pub type QueryBuilderFn = dyn (Fn(ModelRef, ParsedField) -> QueryGraphBuilderResult<QueryGraph>) + Send + Sync;
 
 /// Designates a specific top-level operation on a corresponding model.
-#[derive(DebugStub)]
 pub struct ModelQueryBuilder {
     pub model: ModelRef,
     pub tag: QueryTag,
@@ -195,8 +203,17 @@ pub struct ModelQueryBuilder {
     /// An associated builder is responsible for building queries
     /// that the executer will execute. The result info is required
     /// by the serialization to correctly build the response.
-    #[debug_stub = "#BuilderFn#"]
     pub builder_fn: Box<QueryBuilderFn>,
+}
+
+impl Debug for ModelQueryBuilder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ModelQueryBuilder")
+            .field("model", &self.model)
+            .field("tag", &self.tag)
+            .field("builder_fn", &"#BuilderFn")
+            .finish()
+    }
 }
 
 impl ModelQueryBuilder {
@@ -237,7 +254,7 @@ impl fmt::Display for QueryTag {
             QueryTag::Aggregate => "aggregate",
         };
 
-        s.fmt(f)
+        write!(f, "{}", s)
     }
 }
 
@@ -253,15 +270,23 @@ pub struct Argument {
     pub default_value: Option<dml::DefaultValue>,
 }
 
-#[derive(DebugStub)]
 pub struct InputObjectType {
     pub name: String,
     /// If true this means that _exactly_ one of the contained fields must be specified in an incoming query.
     /// This allows clients to handle this input type in a special way and ensure this invariant in a typesafe way.
     pub is_one_of: bool,
 
-    #[debug_stub = "#Input Fields Cell#"]
     pub fields: OnceCell<Vec<InputFieldRef>>,
+}
+
+impl Debug for InputObjectType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("InputObjectType")
+            .field("name", &self.name)
+            .field("is_one_of", &self.is_one_of)
+            .field("fields", &"#Input Fields Cell#")
+            .finish()
+    }
 }
 
 impl InputObjectType {


### PR DESCRIPTION
It is a heavy dependency. We write debug impls by hand instead.

Alternatively, we could find a replacement for `debug_stub` that doesn't have the heavy outdated dependencies problem.

part of #912