### PR TITLE
Tiny DMMF cleanups

### DIFF
--- a/query-engine/query-engine/src/dmmf/schema/enum_renderer.rs
+++ b/query-engine/query-engine/src/dmmf/schema/enum_renderer.rs
@@ -5,7 +5,7 @@ pub struct DMMFEnumRenderer<'a> {
 }
 
 impl<'a> Renderer<'a, ()> for DMMFEnumRenderer<'a> {
-    fn render(&self, ctx: &RenderContext) {
+    fn render(&self, ctx: &mut RenderContext) {
         if ctx.already_rendered(self.enum_type.name()) {
             return;
         }

--- a/query-engine/query-engine/src/dmmf/schema/field_renderer.rs
+++ b/query-engine/query-engine/src/dmmf/schema/field_renderer.rs
@@ -7,7 +7,7 @@ pub enum DMMFFieldRenderer {
 }
 
 impl<'a> Renderer<'a, DMMFFieldWrapper> for DMMFFieldRenderer {
-    fn render(&self, ctx: &RenderContext) -> DMMFFieldWrapper {
+    fn render(&self, ctx: &mut RenderContext) -> DMMFFieldWrapper {
         match self {
             DMMFFieldRenderer::Input(input) => self.render_input_field(Arc::clone(input), ctx),
             DMMFFieldRenderer::Output(output) => self.render_output_field(Arc::clone(output), ctx),
@@ -16,7 +16,7 @@ impl<'a> Renderer<'a, DMMFFieldWrapper> for DMMFFieldRenderer {
 }
 
 impl DMMFFieldRenderer {
-    fn render_input_field(&self, input_field: InputFieldRef, ctx: &RenderContext) -> DMMFFieldWrapper {
+    fn render_input_field(&self, input_field: InputFieldRef, ctx: &mut RenderContext) -> DMMFFieldWrapper {
         let type_info = input_field.field_type.into_renderer().render(ctx);
         let field = DMMFInputField {
             name: input_field.name.clone(),
@@ -26,7 +26,7 @@ impl DMMFFieldRenderer {
         DMMFFieldWrapper::Input(field)
     }
 
-    fn render_output_field(&self, field: FieldRef, ctx: &RenderContext) -> DMMFFieldWrapper {
+    fn render_output_field(&self, field: FieldRef, ctx: &mut RenderContext) -> DMMFFieldWrapper {
         let args = self.render_arguments(&field.arguments, ctx);
         let output_type = field.field_type.into_renderer().render(ctx);
         let output_field = DMMFField {
@@ -39,11 +39,11 @@ impl DMMFFieldRenderer {
         DMMFFieldWrapper::Output(output_field)
     }
 
-    fn render_arguments(&self, args: &[Argument], ctx: &RenderContext) -> Vec<DMMFArgument> {
+    fn render_arguments(&self, args: &[Argument], ctx: &mut RenderContext) -> Vec<DMMFArgument> {
         args.iter().map(|arg| self.render_argument(arg, ctx)).collect()
     }
 
-    fn render_argument(&self, arg: &Argument, ctx: &RenderContext) -> DMMFArgument {
+    fn render_argument(&self, arg: &Argument, ctx: &mut RenderContext) -> DMMFArgument {
         let input_type = (&arg.argument_type).into_renderer().render(ctx);
         let rendered_arg = DMMFArgument {
             name: arg.name.clone(),

--- a/query-engine/query-engine/src/dmmf/schema/mod.rs
+++ b/query-engine/query-engine/src/dmmf/schema/mod.rs
@@ -13,7 +13,6 @@ use object_renderer::*;
 use query_core::schema::*;
 use schema_renderer::*;
 use std::{
-    cell::RefCell,
     collections::HashSet,
     sync::{Arc, Weak},
 };
@@ -25,8 +24,8 @@ pub struct DMMFQuerySchemaRenderer;
 
 impl QuerySchemaRenderer<(DMMFSchema, Vec<DMMFMapping>)> for DMMFQuerySchemaRenderer {
     fn render(query_schema: QuerySchemaRef) -> (DMMFSchema, Vec<DMMFMapping>) {
-        let ctx = RenderContext::new();
-        query_schema.into_renderer().render(&ctx);
+        let mut ctx = RenderContext::new();
+        query_schema.into_renderer().render(&mut ctx);
 
         ctx.finalize()
     }
@@ -34,65 +33,63 @@ impl QuerySchemaRenderer<(DMMFSchema, Vec<DMMFMapping>)> for DMMFQuerySchemaRend
 
 pub struct RenderContext {
     /// Aggregator for query schema
-    schema: RefCell<DMMFSchema>,
+    schema: DMMFSchema,
 
     /// Aggregator for mappings
-    mappings: RefCell<Vec<DMMFMapping>>,
+    mappings: Vec<DMMFMapping>,
 
     /// Prevents double rendering of elements that are referenced multiple times.
     /// Names of input / output types / enums / models are globally unique.
-    rendered: RefCell<HashSet<String>>,
+    rendered: HashSet<String>,
 }
 
 impl RenderContext {
     pub fn new() -> Self {
         RenderContext {
-            schema: RefCell::new(DMMFSchema::new()),
-            mappings: RefCell::new(vec![]),
-            rendered: RefCell::new(HashSet::new()),
+            schema: DMMFSchema::new(),
+            mappings: vec![],
+            rendered: HashSet::new(),
         }
     }
 
     pub fn finalize(self) -> (DMMFSchema, Vec<DMMFMapping>) {
-        let mappings = self.mappings.replace(vec![]);
-        let mut schema = self.schema.into_inner();
+        let mut schema = self.schema;
 
         schema.root_query_type = "Query".into();
         schema.root_mutation_type = "Mutation".into();
 
-        (schema, mappings)
+        (schema, self.mappings)
     }
 
     pub fn already_rendered(&self, cache_key: &str) -> bool {
-        self.rendered.borrow().contains(cache_key)
+        self.rendered.contains(cache_key)
     }
 
-    pub fn mark_as_rendered(&self, cache_key: String) {
-        self.rendered.borrow_mut().insert(cache_key);
+    pub fn mark_as_rendered(&mut self, cache_key: String) {
+        self.rendered.insert(cache_key);
     }
 
-    pub fn add_enum(&self, name: String, dmmf_enum: DMMFEnum) {
-        self.schema.borrow_mut().enums.push(dmmf_enum);
+    pub fn add_enum(&mut self, name: String, dmmf_enum: DMMFEnum) {
+        self.schema.enums.push(dmmf_enum);
         self.mark_as_rendered(name);
     }
 
-    pub fn add_input_type(&self, input_type: DMMFInputType) {
+    pub fn add_input_type(&mut self, input_type: DMMFInputType) {
         self.mark_as_rendered(input_type.name.clone());
-        self.schema.borrow_mut().input_types.push(input_type);
+        self.schema.input_types.push(input_type);
     }
 
-    pub fn add_output_type(&self, output_type: DMMFOutputType) {
+    pub fn add_output_type(&mut self, output_type: DMMFOutputType) {
         self.mark_as_rendered(output_type.name.clone());
-        self.schema.borrow_mut().output_types.push(output_type);
+        self.schema.output_types.push(output_type);
     }
 
-    pub fn add_mapping(&self, name: String, operation: Option<&SchemaQueryBuilder>) {
+    pub fn add_mapping(&mut self, name: String, operation: Option<&SchemaQueryBuilder>) {
         operation.into_iter().for_each(|op| {
             if let SchemaQueryBuilder::ModelQueryBuilder(m) = op {
                 let model_name = m.model.name.clone();
                 let tag_str = format!("{}", m.tag);
-                let mut mappings = self.mappings.borrow_mut();
-                let mapping = mappings.iter().find(|mapping| mapping.model_name == model_name);
+                let mapping = self.mappings.iter().find(|mapping| mapping.model_name == model_name);
 
                 match mapping {
                     Some(ref existing) => existing.add_operation(tag_str, name.clone()),
@@ -100,7 +97,7 @@ impl RenderContext {
                         let new_mapping = DMMFMapping::new(model_name);
 
                         new_mapping.add_operation(tag_str, name.clone());
-                        mappings.push(new_mapping);
+                        self.mappings.push(new_mapping);
                     }
                 };
             }
@@ -109,7 +106,7 @@ impl RenderContext {
 }
 
 pub trait Renderer<'a, T> {
-    fn render(&self, ctx: &RenderContext) -> T;
+    fn render(&self, ctx: &mut RenderContext) -> T;
 }
 
 trait IntoRenderer<'a, T> {

--- a/query-engine/query-engine/src/dmmf/schema/mod.rs
+++ b/query-engine/query-engine/src/dmmf/schema/mod.rs
@@ -85,23 +85,21 @@ impl RenderContext {
     }
 
     pub fn add_mapping(&mut self, name: String, operation: Option<&SchemaQueryBuilder>) {
-        operation.into_iter().for_each(|op| {
-            if let SchemaQueryBuilder::ModelQueryBuilder(m) = op {
-                let model_name = m.model.name.clone();
-                let tag_str = format!("{}", m.tag);
-                let mapping = self.mappings.iter().find(|mapping| mapping.model_name == model_name);
+        if let Some(SchemaQueryBuilder::ModelQueryBuilder(m)) = operation {
+            let model_name = m.model.name.clone();
+            let tag_str = format!("{}", m.tag);
+            let mapping = self.mappings.iter().find(|mapping| mapping.model_name == model_name);
 
-                match mapping {
-                    Some(ref existing) => existing.add_operation(tag_str, name.clone()),
-                    None => {
-                        let new_mapping = DMMFMapping::new(model_name);
+            match mapping {
+                Some(ref existing) => existing.add_operation(tag_str, name.clone()),
+                None => {
+                    let new_mapping = DMMFMapping::new(model_name);
 
-                        new_mapping.add_operation(tag_str, name.clone());
-                        self.mappings.push(new_mapping);
-                    }
-                };
-            }
-        });
+                    new_mapping.add_operation(tag_str, name.clone());
+                    self.mappings.push(new_mapping);
+                }
+            };
+        }
     }
 }
 

--- a/query-engine/query-engine/src/dmmf/schema/object_renderer.rs
+++ b/query-engine/query-engine/src/dmmf/schema/object_renderer.rs
@@ -7,7 +7,7 @@ pub enum DMMFObjectRenderer {
 }
 
 impl<'a> Renderer<'a, ()> for DMMFObjectRenderer {
-    fn render(&self, ctx: &RenderContext) {
+    fn render(&self, ctx: &mut RenderContext) {
         match &self {
             DMMFObjectRenderer::Input(input) => self.render_input_object(input, ctx),
             DMMFObjectRenderer::Output(output) => self.render_output_object(output, ctx),
@@ -16,7 +16,7 @@ impl<'a> Renderer<'a, ()> for DMMFObjectRenderer {
 }
 
 impl DMMFObjectRenderer {
-    fn render_input_object(&self, input_object: &InputObjectTypeRef, ctx: &RenderContext) {
+    fn render_input_object(&self, input_object: &InputObjectTypeRef, ctx: &mut RenderContext) {
         let input_object = input_object.into_arc();
         if ctx.already_rendered(&input_object.name) {
             return;
@@ -46,7 +46,7 @@ impl DMMFObjectRenderer {
     }
 
     // WIP dedup code
-    fn render_output_object(&self, output_object: &ObjectTypeRef, ctx: &RenderContext) {
+    fn render_output_object(&self, output_object: &ObjectTypeRef, ctx: &mut RenderContext) {
         let output_object = output_object.into_arc();
         if ctx.already_rendered(output_object.name()) {
             return;

--- a/query-engine/query-engine/src/dmmf/schema/schema_renderer.rs
+++ b/query-engine/query-engine/src/dmmf/schema/schema_renderer.rs
@@ -5,7 +5,7 @@ pub struct DMMFSchemaRenderer {
 }
 
 impl<'a> Renderer<'a, ()> for DMMFSchemaRenderer {
-    fn render(&self, ctx: &RenderContext) {
+    fn render(&self, ctx: &mut RenderContext) {
         self.query_schema.query.into_renderer().render(ctx);
         self.query_schema.mutation.into_renderer().render(ctx);
     }

--- a/query-engine/query-engine/src/dmmf/schema/type_renderer.rs
+++ b/query-engine/query-engine/src/dmmf/schema/type_renderer.rs
@@ -7,7 +7,7 @@ pub enum DMMFTypeRenderer<'a> {
 }
 
 impl<'a> Renderer<'a, DMMFTypeInfo> for DMMFTypeRenderer<'a> {
-    fn render(&self, ctx: &RenderContext) -> DMMFTypeInfo {
+    fn render(&self, ctx: &mut RenderContext) -> DMMFTypeInfo {
         match self {
             DMMFTypeRenderer::Input(i) => self.render_input_type(i, ctx),
             DMMFTypeRenderer::Output(o) => self.render_output_type(o, ctx),
@@ -16,7 +16,7 @@ impl<'a> Renderer<'a, DMMFTypeInfo> for DMMFTypeRenderer<'a> {
 }
 
 impl<'a> DMMFTypeRenderer<'a> {
-    fn render_input_type(&self, i: &InputType, ctx: &RenderContext) -> DMMFTypeInfo {
+    fn render_input_type(&self, i: &InputType, ctx: &mut RenderContext) -> DMMFTypeInfo {
         match i {
             InputType::Object(ref obj) => {
                 obj.into_renderer().render(ctx);
@@ -105,7 +105,7 @@ impl<'a> DMMFTypeRenderer<'a> {
     }
 
     // WIP dedup code
-    fn render_output_type(&self, o: &OutputType, ctx: &RenderContext) -> DMMFTypeInfo {
+    fn render_output_type(&self, o: &OutputType, ctx: &mut RenderContext) -> DMMFTypeInfo {
         match o {
             OutputType::Object(ref obj) => {
                 obj.into_renderer().render(ctx);


### PR DESCRIPTION
I started looking into https://github.com/prisma/prisma/issues/3051

From looking at the stack when crashing with that huge schema, it is clear that we are overflowing it because DMMF rendering recurses depth first, and very deep in case of big schemas with many relations.

If we decide this is worth fixing, the solution I would recommend would be to make rendering iterative instead of recursive: when rendering the type of a (input or output) field, instead of doing so right away recursively, enqueue the render into RenderContext, then repeat rendering passes until there is nothing left in the queue. I played with the idea and I think this can be done without really losing in readability or clarity of the control flow (maybe even the opposite).

I also noticed by looking at the open PRs that there is an [upcoming DMMF refactoring in the OrderBy multiple fields PR](https://github.com/prisma/prisma-engines/pull/947), so I don't think I can work on this before that PR is merged, or we'll run into a massive merge conflict.

In the meantime, here are two commits with small cleanups to DMMF rendering:

- Removed unnecessary `RefCell` usage, making it clearer in the Renderer API that RenderContext is mutable.
- Made into_mapping a bit more straightforward, removed one level of nesting