### PR TITLE
Add DestructiveChangeChecker::pure_check()

### DIFF
--- a/migration-engine/connectors/migration-connector/src/destructive_changes_checker.rs
+++ b/migration-engine/connectors/migration-connector/src/destructive_changes_checker.rs
@@ -16,6 +16,9 @@ where
 
     /// Check destructive changes resulting of reverting the provided migration.
     async fn check_unapply(&self, database_migration: &T) -> ConnectorResult<DestructiveChangeDiagnostics>;
+
+    /// Check the database migration without performing any IO.
+    fn pure_check(&self, database_migration: &T) -> ConnectorResult<DestructiveChangeDiagnostics>;
 }
 
 /// The errors and warnings emitted by the [DestructiveChangesChecker](trait.DestructiveChangesChecker.html).
@@ -87,6 +90,10 @@ where
     }
 
     async fn check_unapply(&self, _database_migration: &T) -> ConnectorResult<DestructiveChangeDiagnostics> {
+        Ok(DestructiveChangeDiagnostics::new())
+    }
+
+    fn pure_check(&self, _database_migration: &T) -> ConnectorResult<DestructiveChangeDiagnostics> {
         Ok(DestructiveChangeDiagnostics::new())
     }
 }

--- a/migration-engine/connectors/migration-connector/src/destructive_changes_checker.rs
+++ b/migration-engine/connectors/migration-connector/src/destructive_changes_checker.rs
@@ -2,9 +2,11 @@ use crate::ConnectorResult;
 use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;
 
-/// Implementors of this trait are responsible for checking whether a migration could lead to data loss.
+/// Implementors of this trait are responsible for checking whether a migration
+/// could lead to data loss, or if it would be potentially unexecutable.
 ///
-/// The type parameter is the connector's [DatabaseMigration](trait.MigrationConnector.html#associatedtype.DatabaseMigration)
+/// The type parameter is the connector's
+/// [DatabaseMigration](trait.MigrationConnector.html#associatedtype.DatabaseMigration)
 /// type.
 #[async_trait::async_trait]
 pub trait DestructiveChangesChecker<T>: Send + Sync
@@ -17,7 +19,8 @@ where
     /// Check destructive changes resulting of reverting the provided migration.
     async fn check_unapply(&self, database_migration: &T) -> ConnectorResult<DestructiveChangeDiagnostics>;
 
-    /// Check the database migration without performing any IO.
+    /// Check the database migration for destructive or unexecutable steps
+    /// without performing any IO.
     fn pure_check(&self, database_migration: &T) -> ConnectorResult<DestructiveChangeDiagnostics>;
 }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker.rs
@@ -86,13 +86,7 @@ impl SqlDestructiveChangesChecker<'_> {
         plan.push_unexecutable(typed_unexecutable);
     }
 
-    #[tracing::instrument(skip(self, steps, before), target = "SqlDestructiveChangeChecker::check")]
-    async fn check_impl(
-        &self,
-        steps: &[SqlMigrationStep],
-        before: &SqlSchema,
-        after: &SqlSchema,
-    ) -> SqlResult<DestructiveChangeDiagnostics> {
+    fn plan(&self, steps: &[SqlMigrationStep], before: &SqlSchema, after: &SqlSchema) -> DestructiveCheckPlan {
         let mut plan = DestructiveCheckPlan::new();
 
         for step in steps {
@@ -149,6 +143,17 @@ impl SqlDestructiveChangesChecker<'_> {
             }
         }
 
+        plan
+    }
+
+    #[tracing::instrument(skip(self, steps, before), target = "SqlDestructiveChangeChecker::check")]
+    async fn check_impl(
+        &self,
+        steps: &[SqlMigrationStep],
+        before: &SqlSchema,
+        after: &SqlSchema,
+    ) -> SqlResult<DestructiveChangeDiagnostics> {
+        let plan = self.plan(steps, before, after);
         let mut diagnostics = plan.execute(self.schema_name(), self.conn()).await?;
 
         // Temporary, for better reporting.
@@ -178,5 +183,14 @@ impl DestructiveChangesChecker<SqlMigration> for SqlDestructiveChangesChecker<'_
         )
         .await
         .map_err(|sql_error| sql_error.into_connector_error(&self.connection_info()))
+    }
+
+    fn pure_check(&self, database_migration: &SqlMigration) -> ConnectorResult<DestructiveChangeDiagnostics> {
+        let plan = self.plan(
+            &database_migration.original_steps,
+            &database_migration.before,
+            &database_migration.after,
+        );
+        Ok(plan.pure_check())
     }
 }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/destructive_check_plan.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_changes_checker/destructive_check_plan.rs
@@ -110,6 +110,11 @@ impl DestructiveCheckPlan {
         Ok(())
     }
 
+    /// Return hypothetical warnings and errors, without performing any database
+    /// IO. This is useful when we want to return diagnostics in reference to a
+    /// database we cannot check directly. For example when we want to emit
+    /// warnings about the production database, when creating a migration in
+    /// development.
     pub(super) fn pure_check(&self) -> DestructiveChangeDiagnostics {
         let results = DatabaseInspectionResults::default();
         let mut diagnostics = DestructiveChangeDiagnostics::new();


### PR DESCRIPTION
For checks without access to the target database, when generating a new migration for example.

This was very much planned in my recent rework of the destructive change checker, so it fits pretty easily within the current model.

This method is extracted from some prototyping with different migration models I've been doing. I am pretty sure we will need it. It has been tested manually, but is not used by any of the current commands, so there is no test suite for it.