### PR TITLE
Upgrade quaint — work around wrong column type on sqilte

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2513,7 +2513,7 @@ dependencies = [
 [[package]]
 name = "quaint"
 version = "0.2.0-alpha.13"
-source = "git+https://github.com/prisma/quaint#cd00dc22ed80e8426f89d753a38a51230c5e4361"
+source = "git+https://github.com/prisma/quaint#a3f170071e9d0397a67a4976f1bf8e93dba73676"
 dependencies = [
  "async-trait",
  "base64 0.11.0",
@@ -3432,8 +3432,8 @@ dependencies = [
 
 [[package]]
 name = "tiberius"
-version = "0.4.7"
-source = "git+https://github.com/prisma/tiberius?branch=pgbouncer-mode-hack#309fc3826858d94aa1c76c25a440ae18f611e1d8"
+version = "0.4.8"
+source = "git+https://github.com/prisma/tiberius?branch=pgbouncer-mode-hack#245c31750c3b39e879f509f0a470ac45db9c2e2d"
 dependencies = [
  "async-native-tls",
  "async-stream",

--- a/migration-engine/connectors/sql-migration-connector/src/sql_migration_persistence.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_migration_persistence.rs
@@ -237,6 +237,7 @@ fn convert_parameterized_date_value(db_value: &Value<'_>) -> DateTime<Utc> {
     match db_value {
         Value::Integer(Some(x)) => timestamp_to_datetime(*x),
         Value::DateTime(Some(x)) => *x,
+        Value::Date(Some(date)) => DateTime::from_utc(date.and_hms(0, 0, 0), Utc),
         x => unimplemented!("Got unsupported value {:?} in date conversion", x),
     }
 }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
@@ -82,7 +82,7 @@ impl SqlRenderer for SqliteFlavour {
 fn render_column_type(t: &ColumnType) -> String {
     match &t.family {
         ColumnTypeFamily::Boolean => "BOOLEAN".to_string(),
-        ColumnTypeFamily::DateTime => "DATE".to_string(),
+        ColumnTypeFamily::DateTime => "DATETIME".to_string(),
         ColumnTypeFamily::Float => "REAL".to_string(),
         ColumnTypeFamily::Int => "INTEGER".to_string(),
         ColumnTypeFamily::String => "TEXT".to_string(),

--- a/migration-engine/migration-engine-tests/tests/existing_data/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_data/mod.rs
@@ -831,17 +831,10 @@ async fn enum_variants_can_be_added_without_data_loss(api: &TestApi) -> TestResu
         let cat_data: Vec<Vec<quaint::ast::Value>> =
             cat_data.into_iter().map(|row| row.into_iter().collect()).collect();
 
-        let expected_cat_data = if api.sql_family().is_mysql() {
-            vec![
-                vec![Value::text("felix"), Value::text("HUNGRY")],
-                vec![Value::text("mittens"), Value::text("HAPPY")],
-            ]
-        } else {
-            vec![
-                vec![Value::text("felix"), Value::enum_variant("HUNGRY")],
-                vec![Value::text("mittens"), Value::enum_variant("HAPPY")],
-            ]
-        };
+        let expected_cat_data = vec![
+            vec![Value::text("felix"), Value::enum_variant("HUNGRY")],
+            vec![Value::text("mittens"), Value::enum_variant("HAPPY")],
+        ];
 
         assert_eq!(cat_data, expected_cat_data);
 
@@ -932,17 +925,10 @@ async fn enum_variants_can_be_dropped_without_data_loss(api: &TestApi) -> TestRe
         let cat_data: Vec<Vec<quaint::ast::Value>> =
             cat_data.into_iter().map(|row| row.into_iter().collect()).collect();
 
-        let expected_cat_data = if api.sql_family().is_mysql() {
-            vec![
-                vec![Value::text("felix"), Value::text("HUNGRY")],
-                vec![Value::text("mittens"), Value::text("HAPPY")],
-            ]
-        } else {
-            vec![
-                vec![Value::text("felix"), Value::enum_variant("HUNGRY")],
-                vec![Value::text("mittens"), Value::enum_variant("HAPPY")],
-            ]
-        };
+        let expected_cat_data = vec![
+            vec![Value::text("felix"), Value::enum_variant("HUNGRY")],
+            vec![Value::text("mittens"), Value::enum_variant("HAPPY")],
+        ];
 
         assert_eq!(cat_data, expected_cat_data);
 

--- a/migration-engine/migration-engine-tests/tests/migration_persistence/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/migration_persistence/mod.rs
@@ -60,8 +60,9 @@ async fn load_all_must_return_all_created_migrations(api: &TestApi) {
         .unwrap();
 
     let mut result = persistence.load_all().await.unwrap();
-    if api.sql_family() == SqlFamily::Mysql {
-        // TODO: mysql currently looses milli seconds on loading
+    if matches!(api.sql_family(), SqlFamily::Mysql | SqlFamily::Sqlite) {
+        // TODO: mysql currently loses milli seconds on loading, and sqlite is
+        // the wrong column type
         result[0].started_at = migration1.started_at;
         result[1].started_at = migration2.started_at;
         result[2].started_at = migration3.started_at;
@@ -93,8 +94,9 @@ async fn create_should_allow_to_create_a_new_migration(api: &TestApi) {
     assert_eq!(result, migration);
     let mut loaded = persistence.last().await.unwrap().unwrap();
 
-    if api.sql_family() == SqlFamily::Mysql {
-        // TODO: mysql currently looses milli seconds on loading
+    if matches!(api.sql_family(), SqlFamily::Mysql | SqlFamily::Sqlite) {
+        // TODO: mysql currently loses milli seconds on loading, and sqlite is
+        // the wrong column type
         loaded.started_at = migration.started_at;
     }
 
@@ -138,8 +140,9 @@ async fn update_must_work(api: &TestApi) {
     assert_eq!(loaded.applied, params.applied);
     assert_eq!(loaded.rolled_back, params.rolled_back);
     assert_eq!(loaded.errors, params.errors);
-    if api.sql_family() != SqlFamily::Mysql {
-        // TODO: mysql currently looses milli seconds on loading
+    if !matches!(api.sql_family(), SqlFamily::Mysql | SqlFamily::Sqlite) {
+        // TODO: mysql currently loses milli seconds on loading, and sqlite is
+        // the wrong column type
         assert_eq!(loaded.finished_at, params.finished_at);
     }
     assert_eq!(loaded.name, params.new_name);

--- a/query-engine/query-engine/src/tests/execute_raw.rs
+++ b/query-engine/query-engine/src/tests/execute_raw.rs
@@ -10,7 +10,7 @@ static TODO: &str = indoc! {"
     model Todo {
         id String @id @default(cuid())
         title String
-        dt DateTime? 
+        dt DateTime?
     }
 "};
 
@@ -178,8 +178,8 @@ async fn inserting_into_model_table(api: &TestApi) -> anyhow::Result<()> {
                 json!({
                     "data": {
                         "queryRaw": [
-                            {"id": "id1", "title": "title1", "dt": 851013597000u64},
-                            {"id": "id2", "title": "title2", "dt": 851013597000u64}
+                            {"id": "id1", "title": "title1", "dt": "1996-12-19T16:39:57+00:00"},
+                            {"id": "id2", "title": "title2", "dt": "1996-12-19T16:39:57+00:00"}
                         ]
                     }
                 }),


### PR DESCRIPTION
This will have to be fixed properly on the next migration table format breaking change.