### PR TITLE
Standardize on not finishing statements with semicolons

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_migration_inferrer/sqlite.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_migration_inferrer/sqlite.rs
@@ -23,7 +23,7 @@ pub(super) fn fix(
     let mut fixed_tables = Vec::new();
 
     result.push(SqlMigrationStep::RawSql {
-        raw: "PRAGMA foreign_keys=OFF;".to_string(),
+        raw: "PRAGMA foreign_keys=OFF".to_string(),
     });
 
     for step in steps {
@@ -71,11 +71,11 @@ pub(super) fn fix(
     }
 
     result.push(SqlMigrationStep::RawSql {
-        raw: format!("PRAGMA {}.foreign_key_check;", Quoted::sqlite_ident(schema_name)),
+        raw: format!("PRAGMA {}.foreign_key_check", Quoted::sqlite_ident(schema_name)),
     });
 
     result.push(SqlMigrationStep::RawSql {
-        raw: "PRAGMA foreign_keys=ON;".to_string(),
+        raw: "PRAGMA foreign_keys=ON".to_string(),
     });
 
     Ok(result)

--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
@@ -184,7 +184,7 @@ fn render_raw_sql(
         }
         SqlMigrationStep::DropTable(DropTable { name }) => match sql_family {
             SqlFamily::Mysql | SqlFamily::Postgres => Ok(vec![format!(
-                "DROP TABLE {};",
+                "DROP TABLE {}",
                 renderer.quote_with_schema(&schema_name, &name)
             )]),
             // Turning off the pragma is safe, because schema validation would forbid foreign keys
@@ -193,7 +193,7 @@ fn render_raw_sql(
             // constraints on SQLite.
             SqlFamily::Sqlite => Ok(vec![
                 "PRAGMA foreign_keys=off".to_string(),
-                format!("DROP TABLE {};", renderer.quote_with_schema(&schema_name, &name)),
+                format!("DROP TABLE {}", renderer.quote_with_schema(&schema_name, &name)),
                 "PRAGMA foreign_keys=on".to_string(),
             ]),
             SqlFamily::Mssql => todo!("Greetings from Redmond"),
@@ -204,7 +204,7 @@ fn render_raw_sql(
                 _ => renderer.quote_with_schema(&schema_name, &new_name).to_string(),
             };
             Ok(vec![format!(
-                "ALTER TABLE {} RENAME TO {};",
+                "ALTER TABLE {} RENAME TO {}",
                 renderer.quote_with_schema(&schema_name, &name),
                 new_name
             )])
@@ -332,7 +332,7 @@ fn render_raw_sql(
             }
 
             let alter_table = format!(
-                "ALTER TABLE {} {};",
+                "ALTER TABLE {} {}",
                 renderer.quote_with_schema(&schema_name, &table.name),
                 lines.join(",\n")
             );

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
@@ -99,7 +99,7 @@ impl super::SqlRenderer for PostgresFlavour {
 
                         if !sequence_is_still_used {
                             rendered_steps.after =
-                                Some(format!("DROP SEQUENCE {};", Quoted::postgres_ident(sequence_name)));
+                                Some(format!("DROP SEQUENCE {}", Quoted::postgres_ident(sequence_name)));
                         }
                     }
                 }
@@ -131,14 +131,14 @@ impl super::SqlRenderer for PostgresFlavour {
                     )
                     .to_lowercase();
 
-                    let create_sequence = format!("CREATE SEQUENCE {};", Quoted::postgres_ident(&sequence_name));
+                    let create_sequence = format!("CREATE SEQUENCE {}", Quoted::postgres_ident(&sequence_name));
                     let set_default = format!(
-                        "{prefix} SET DEFAULT {default};",
+                        "{prefix} SET DEFAULT {default}",
                         prefix = alter_column_prefix,
                         default = format_args!("nextval({})", Quoted::postgres_string(&sequence_name))
                     );
                     let alter_sequence = format!(
-                        "ALTER SEQUENCE {sequence_name} OWNED BY {schema_name}.{table_name}.{column_name};",
+                        "ALTER SEQUENCE {sequence_name} OWNED BY {schema_name}.{table_name}.{column_name}",
                         sequence_name = Quoted::postgres_ident(sequence_name),
                         schema_name = Quoted::postgres_ident(self.0.schema()),
                         table_name = table_name,
@@ -157,7 +157,7 @@ impl super::SqlRenderer for PostgresFlavour {
 
     fn render_create_enum(&self, create_enum: &crate::CreateEnum) -> Vec<String> {
         let sql = format!(
-            r#"CREATE TYPE {enum_name} AS ENUM ({variants});"#,
+            r#"CREATE TYPE {enum_name} AS ENUM ({variants})"#,
             enum_name = Quoted::postgres_ident(&create_enum.name),
             variants = create_enum.variants.iter().map(Quoted::postgres_string).join(", "),
         );


### PR DESCRIPTION
... in SqlDatabaseStepApplier/SqlRenderer

We add the semicolons later when rendering them one after another.