### PR TITLE
OrderBy multiple fields schema change

### DIFF
--- a/query-engine/connector-test-kit/src/test/scala/queries/aggregation/AggregationCombinationQuerySpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/aggregation/AggregationCombinationQuerySpec.scala
@@ -290,7 +290,7 @@ class AggregationCombinationQuerySpec extends FlatSpec with Matchers with ApiSpe
 
     server.queryThatMustFail(
       s"""{
-         |  aggregateItem(cursor: { id: "3" }, orderBy: { float: ASC }) {
+         |  aggregateItem(cursor: { id: "3" }, orderBy: { float: asc }) {
          |    count
          |  }
          |}

--- a/query-engine/connector-test-kit/src/test/scala/queries/aggregation/CountAggregationQuerySpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/aggregation/CountAggregationQuerySpec.scala
@@ -114,7 +114,7 @@ class CountAggregationQuerySpec extends FlatSpec with Matchers with ApiSpecBase 
 
     val result5 = server.query(
       """{
-        |  aggregateItem(where: { name_gt: "1" } orderBy: { name: DESC }) {
+        |  aggregateItem(where: { name_gt: "1" } orderBy: { name: desc }) {
         |    count
         |  }
         |}

--- a/query-engine/connector-test-kit/src/test/scala/queries/batch/InSelectionBatching.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/batch/InSelectionBatching.scala
@@ -95,7 +95,7 @@ class InSelectionBatching extends FlatSpec with Matchers with ApiSpecBase {
   "ascending ordering of batched IN queries" should "work when having more than the specified amount of items" in {
     val res = server.query(
       """query idInTest {
-        |   findManyA(where: { id_in: [5,4,3,2,1,2,1,1,3,4,5,6,7,6,5,4,3,2,1,2,3,4,5,6] }, orderBy: { id: ASC }) { id }
+        |   findManyA(where: { id_in: [5,4,3,2,1,2,1,1,3,4,5,6,7,6,5,4,3,2,1,2,3,4,5,6] }, orderBy: { id: asc }) { id }
         |}
         |""".stripMargin,
       project = project,
@@ -111,7 +111,7 @@ class InSelectionBatching extends FlatSpec with Matchers with ApiSpecBase {
   "descending ordering of batched IN queries" should "work when having more than the specified amount of items" in {
     val res = server.query(
       """query idInTest {
-        |   findManyA(where: {id_in: [5,4,3,2,1,1,1,2,3,4,5,6,7,6,5,4,3,2,1,2,3,4,5,6] }, orderBy: { id: DESC }) { id }
+        |   findManyA(where: {id_in: [5,4,3,2,1,1,1,2,3,4,5,6,7,6,5,4,3,2,1,2,3,4,5,6] }, orderBy: { id: desc }) { id }
         |}
         |""".stripMargin,
       project = project,

--- a/query-engine/connector-test-kit/src/test/scala/queries/distinct/DistinctQuerySpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/distinct/DistinctQuerySpec.scala
@@ -107,7 +107,7 @@ class DistinctQuerySpec extends FlatSpec with Matchers with ApiSpecBase {
 
     val result = server.query(
       s"""{
-         |  findManyModelA(distinct: [fieldA, fieldB], skip: 1, orderBy: { fieldB: DESC }) {
+         |  findManyModelA(distinct: [fieldA, fieldB], skip: 1, orderBy: { fieldB: desc }) {
          |    fieldA
          |    fieldB
          |  }
@@ -128,7 +128,7 @@ class DistinctQuerySpec extends FlatSpec with Matchers with ApiSpecBase {
 
     val result = server.query(
       s"""{
-         |  findManyModelA(distinct: [fieldA, fieldB], orderBy: { id: DESC }) {
+         |  findManyModelA(distinct: [fieldA, fieldB], orderBy: { id: desc }) {
          |    fieldA
          |    fieldB
          |  }
@@ -156,7 +156,7 @@ class DistinctQuerySpec extends FlatSpec with Matchers with ApiSpecBase {
          |  findManyModelA(distinct: [fieldA, fieldB]) {
          |    fieldA
          |    fieldB
-         |    b(distinct: [field], orderBy: { id: ASC }) {
+         |    b(distinct: [field], orderBy: { id: asc }) {
          |      field
          |    }
          |  }
@@ -182,10 +182,10 @@ class DistinctQuerySpec extends FlatSpec with Matchers with ApiSpecBase {
 
     val result = server.query(
       s"""{
-         |  findManyModelA(distinct: [fieldA, fieldB], orderBy: { fieldB: DESC}) {
+         |  findManyModelA(distinct: [fieldA, fieldB], orderBy: { fieldB: desc}) {
          |    fieldA
          |    fieldB
-         |    b(distinct: [field], orderBy: { id: DESC }) {
+         |    b(distinct: [field], orderBy: { id: desc }) {
          |      field
          |    }
          |  }

--- a/query-engine/connector-test-kit/src/test/scala/queries/filters/ExtendedRelationFilterSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/filters/ExtendedRelationFilterSpec.scala
@@ -252,7 +252,7 @@ class ExtendedRelationFilterSpec extends FlatSpec with Matchers with ApiSpecBase
 
   "PostGres 1 level m-relation filter" should "work for  _some" taggedAs (IgnoreMySql) in {
 
-    server.query(query = """{artists(where:{Albums_some:{Title_starts_with: "Album"}}, orderBy: { id: ASC }){Name}}""", project = project).toString should be(
+    server.query(query = """{artists(where:{Albums_some:{Title_starts_with: "Album"}}, orderBy: { id: asc }){Name}}""", project = project).toString should be(
       """{"data":{"artists":[{"Name":"CompleteArtist"},{"Name":"CompleteArtist2"},{"Name":"CompleteArtistWith2Albums"}]}}""")
 
     server.query(query = """{artists(where:{Albums_some:{Title_starts_with: "T"}}){Name}}""", project = project).toString should be(
@@ -346,7 +346,7 @@ class ExtendedRelationFilterSpec extends FlatSpec with Matchers with ApiSpecBase
   "2 level m-relation filters that have subfilters that are connected with an implicit AND" should "work for _some" in {
 
     server
-      .query(query = """{albums(where:{Tracks_some:{MediaType: {Name: "MediaType1"},Genre: {Name: "Genre1"}}}, orderBy: { id: ASC }){Title}}""",
+      .query(query = """{albums(where:{Tracks_some:{MediaType: {Name: "MediaType1"},Genre: {Name: "Genre1"}}}, orderBy: { id: asc }){Title}}""",
              project = project)
       .toString should be("""{"data":{"albums":[{"Title":"Album1"},{"Title":"Album4"},{"Title":"Album5"}]}}""")
 
@@ -364,7 +364,7 @@ class ExtendedRelationFilterSpec extends FlatSpec with Matchers with ApiSpecBase
 
     server
       .query(
-        query = """{albums(where:{Tracks_some:{AND:[{MediaType: {Name: "MediaType1"}},{Genre: {Name: "Genre1"}}]}}, orderBy: { id: ASC }){Title}}""",
+        query = """{albums(where:{Tracks_some:{AND:[{MediaType: {Name: "MediaType1"}},{Genre: {Name: "Genre1"}}]}}, orderBy: { id: asc }){Title}}""",
         project = project
       )
       .toString should be("""{"data":{"albums":[{"Title":"Album1"},{"Title":"Album4"},{"Title":"Album5"}]}}""")

--- a/query-engine/connector-test-kit/src/test/scala/queries/filters/ManyRelationFilterSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/filters/ManyRelationFilterSpec.scala
@@ -89,18 +89,18 @@ class ManyRelationFilterSpec extends FlatSpec with Matchers with ApiSpecBase {
   }
 
   "simple scalar filter" should "work" in {
-    server.query(query = """{blogs{posts(where:{popularity_gte: 5},orderBy: { id: ASC }){title}}}""", project = project).toString should be(
+    server.query(query = """{blogs{posts(where:{popularity_gte: 5},orderBy: { id: asc }){title}}}""", project = project).toString should be(
       """{"data":{"blogs":[{"posts":[{"title":"post 1"}]},{"posts":[{"title":"post 3"}]}]}}""")
   }
 
   "1 level 1-relation filter" should "work" in {
-    server.query(query = """{posts(where:{blog:{name: "blog 1"}},orderBy: { id: ASC }){title}}""", project = project).toString should be(
+    server.query(query = """{posts(where:{blog:{name: "blog 1"}},orderBy: { id: asc }){title}}""", project = project).toString should be(
       """{"data":{"posts":[{"title":"post 1"},{"title":"post 2"}]}}""")
   }
 
   "1 level m-relation filter" should "work for _some" in {
 
-    server.query(query = """{blogs(where:{posts_some:{popularity_gte: 5}},orderBy: { id: ASC }){name}}""", project = project).toString should be(
+    server.query(query = """{blogs(where:{posts_some:{popularity_gte: 5}},orderBy: { id: asc }){name}}""", project = project).toString should be(
       """{"data":{"blogs":[{"name":"blog 1"},{"name":"blog 2"}]}}""")
 
     server.query(query = """{blogs(where:{posts_some:{popularity_gte: 50}}){name}}""", project = project).toString should be(
@@ -118,7 +118,7 @@ class ManyRelationFilterSpec extends FlatSpec with Matchers with ApiSpecBase {
   }
 
   "1 level m-relation filter" should "work for _every " taggedAs (IgnoreMongo) in {
-    server.query(query = """{blogs(where:{posts_every:{popularity_gte: 2}},orderBy: { id: ASC }){name}}""", project = project).toString should be(
+    server.query(query = """{blogs(where:{posts_every:{popularity_gte: 2}},orderBy: { id: asc }){name}}""", project = project).toString should be(
       """{"data":{"blogs":[{"name":"blog 1"},{"name":"blog 2"}]}}""")
 
     server.query(query = """{blogs(where:{posts_every:{popularity_gte: 3}}){name}}""", project = project).toString should be(
@@ -143,14 +143,14 @@ class ManyRelationFilterSpec extends FlatSpec with Matchers with ApiSpecBase {
 
   "2 level m-relation filter" should "work for _every, _some and _none" taggedAs (IgnoreMongo) in {
     // some|every
-    server.query(query = """{blogs(where:{posts_some:{comments_every: {likes_gte: 0}}},orderBy: { id: ASC }){name}}""", project = project).toString should be(
+    server.query(query = """{blogs(where:{posts_some:{comments_every: {likes_gte: 0}}},orderBy: { id: asc }){name}}""", project = project).toString should be(
       """{"data":{"blogs":[{"name":"blog 1"},{"name":"blog 2"}]}}""")
 
     server.query(query = """{blogs(where:{posts_some:{comments_every: {likes: 0}}}){name}}""", project = project).toString should be(
       """{"data":{"blogs":[]}}""")
 
     // some|none
-    server.query(query = """{blogs(where:{posts_some:{comments_none: {likes: 0}}},orderBy: { id: ASC }){name}}""", project = project).toString should be(
+    server.query(query = """{blogs(where:{posts_some:{comments_none: {likes: 0}}},orderBy: { id: asc }){name}}""", project = project).toString should be(
       """{"data":{"blogs":[{"name":"blog 1"},{"name":"blog 2"}]}}""")
 
     server.query(query = """{blogs(where:{posts_some:{comments_none: {likes_gte: 0}}}){name}}""", project = project).toString should be(
@@ -164,7 +164,7 @@ class ManyRelationFilterSpec extends FlatSpec with Matchers with ApiSpecBase {
       """{"data":{"blogs":[]}}""")
 
     // every|every
-    server.query(query = """{blogs(where:{posts_every:{comments_every: {likes_gte: 0}}},orderBy: { id: ASC }){name}}""", project = project).toString should be(
+    server.query(query = """{blogs(where:{posts_every:{comments_every: {likes_gte: 0}}},orderBy: { id: asc }){name}}""", project = project).toString should be(
       """{"data":{"blogs":[{"name":"blog 1"},{"name":"blog 2"}]}}""")
 
     server.query(query = """{blogs(where:{posts_every:{comments_every: {likes: 0}}}){name}}""", project = project).toString should be(
@@ -192,7 +192,7 @@ class ManyRelationFilterSpec extends FlatSpec with Matchers with ApiSpecBase {
       """{"data":{"blogs":[]}}""")
 
     // none|none
-    server.query(query = """{blogs(where:{posts_none:{comments_none: {likes_gte: 0}}},orderBy: { id: ASC }){name}}""", project = project).toString should be(
+    server.query(query = """{blogs(where:{posts_none:{comments_none: {likes_gte: 0}}},orderBy: { id: asc }){name}}""", project = project).toString should be(
       """{"data":{"blogs":[{"name":"blog 1"},{"name":"blog 2"}]}}""")
 
     server.query(query = """{blogs(where:{posts_none:{comments_none: {likes_gte: 11}}}){name}}""", project = project).toString should be(
@@ -264,14 +264,14 @@ class ManyRelationFilterSpec extends FlatSpec with Matchers with ApiSpecBase {
       server.query(s""" mutation {updateAUser(where: { name: "Author1"}, data:{posts:{connect:[{title: "Title1"},{title: "Title2"}]}}) {name}} """, project)
       server.query(s""" mutation {updateAUser(where: { name: "Author2"}, data:{posts:{connect:[{title: "Title1"},{title: "Title2"}]}}) {name}} """, project)
 
-      server.query("""query{aUsers (orderBy: { id: ASC }){name, posts(orderBy: { id: ASC }){title}}}""", project).toString should be(
+      server.query("""query{aUsers (orderBy: { id: asc }){name, posts(orderBy: { id: asc }){title}}}""", project).toString should be(
         """{"data":{"aUsers":[{"name":"Author1","posts":[{"title":"Title1"},{"title":"Title2"}]},{"name":"Author2","posts":[{"title":"Title1"},{"title":"Title2"}]}]}}""")
 
-      server.query("""query{posts(orderBy: { id: ASC }) {title, authors (orderBy: { id: ASC }){name}}}""", project).toString should be(
+      server.query("""query{posts(orderBy: { id: asc }) {title, authors (orderBy: { id: asc }){name}}}""", project).toString should be(
         """{"data":{"posts":[{"title":"Title1","authors":[{"name":"Author1"},{"name":"Author2"}]},{"title":"Title2","authors":[{"name":"Author1"},{"name":"Author2"}]}]}}""")
 
       val res = server.query(
-        """query{aUsers(where:{name_starts_with: "Author2", posts_some:{title_ends_with: "1"}},orderBy: { id: ASC }){name, posts(orderBy: { id: ASC }){title}}}""",
+        """query{aUsers(where:{name_starts_with: "Author2", posts_some:{title_ends_with: "1"}},orderBy: { id: asc }){name, posts(orderBy: { id: asc }){title}}}""",
         project
       )
       res.toString should be("""{"data":{"aUsers":[{"name":"Author2","posts":[{"title":"Title1"},{"title":"Title2"}]}]}}""")

--- a/query-engine/connector-test-kit/src/test/scala/queries/filters/PortedFiltersSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/filters/PortedFiltersSpec.scala
@@ -115,7 +115,7 @@ class PortedFiltersSpec extends FlatSpec with Matchers with ApiSpecBase {
 
     val res =
       server.query(
-        query = """{scalarModels(where: {optBoolean: false, OR: [{optString_starts_with: "foo"}, {idTest_ends_with: "5"}]},orderBy: { id: ASC }){idTest}}""",
+        query = """{scalarModels(where: {optBoolean: false, OR: [{optString_starts_with: "foo"}, {idTest_ends_with: "5"}]},orderBy: { id: asc }){idTest}}""",
         project = project
       )
 
@@ -133,7 +133,7 @@ class PortedFiltersSpec extends FlatSpec with Matchers with ApiSpecBase {
     val res =
       server.query(
         query =
-          """{scalarModels(where: {OR: [{optString_starts_with: "foo", OR: [{optBoolean: false},{idTest_ends_with: "5"}]}]},orderBy: { id: ASC }){idTest}}""",
+          """{scalarModels(where: {OR: [{optString_starts_with: "foo", OR: [{optBoolean: false},{idTest_ends_with: "5"}]}]},orderBy: { id: asc }){idTest}}""",
         project = project
       )
 
@@ -147,27 +147,27 @@ class PortedFiltersSpec extends FlatSpec with Matchers with ApiSpecBase {
     createTest("id2", optString = "foo bar", 1, 1, optBoolean = false, "A", "2016-09-23T12:29:32.342")
     createTest("id3", optString = null, 1, 1, optBoolean = false, "A", "2016-09-23T12:29:32.342")
 
-    val filterOnNull  = server.query(query = """{scalarModels(where: {optString: null} ,orderBy: { id: ASC }){idTest}}""", project = project)
-    val filterOnNull2 = server.query(query = """{scalarModels(where: {b: {int:1},optString: null},orderBy: { id: ASC }){idTest}}""", project = project)
+    val filterOnNull  = server.query(query = """{scalarModels(where: {optString: null} ,orderBy: { id: asc }){idTest}}""", project = project)
+    val filterOnNull2 = server.query(query = """{scalarModels(where: {b: {int:1},optString: null},orderBy: { id: asc }){idTest}}""", project = project)
 
     filterOnNull.toString() should be("""{"data":{"scalarModels":[{"idTest":"id1"},{"idTest":"id3"}]}}""")
     filterOnNull2.toString() should be("""{"data":{"scalarModels":[{"idTest":"id1"},{"idTest":"id3"}]}}""")
 
-    val filterOnNotNull  = server.query(query = """{scalarModels(where: {optString_not: null},orderBy: { id: ASC }){idTest}}""", project = project)
-    val filterOnNotNull2 = server.query(query = """{scalarModels(where: {b: {int:1},optString_not: null},orderBy: { id: ASC }){idTest}}""", project = project)
+    val filterOnNotNull  = server.query(query = """{scalarModels(where: {optString_not: null},orderBy: { id: asc }){idTest}}""", project = project)
+    val filterOnNotNull2 = server.query(query = """{scalarModels(where: {b: {int:1},optString_not: null},orderBy: { id: asc }){idTest}}""", project = project)
 
     filterOnNotNull.toString() should be("""{"data":{"scalarModels":[{"idTest":"id2"}]}}""")
     filterOnNotNull2.toString() should be("""{"data":{"scalarModels":[{"idTest":"id2"}]}}""")
 
-    val filterOnInNull  = server.query(query = """{scalarModels(where: {optString_in: null},orderBy: { id: ASC }){idTest}}""", project = project)
-    val filterOnInNull2 = server.query(query = """{scalarModels(where: {b: {int:1}, optString_in: null},orderBy: { id: ASC }){idTest}}""", project = project)
+    val filterOnInNull  = server.query(query = """{scalarModels(where: {optString_in: null},orderBy: { id: asc }){idTest}}""", project = project)
+    val filterOnInNull2 = server.query(query = """{scalarModels(where: {b: {int:1}, optString_in: null},orderBy: { id: asc }){idTest}}""", project = project)
 
     filterOnInNull.toString() should be("""{"data":{"scalarModels":[{"idTest":"id1"},{"idTest":"id3"}]}}""")
     filterOnInNull2.toString() should be("""{"data":{"scalarModels":[{"idTest":"id1"},{"idTest":"id3"}]}}""")
 
-    val filterOnNotInNull = server.query(query = """{scalarModels(where: {optString_not_in: null},orderBy: { id: ASC }){idTest}}""", project = project)
+    val filterOnNotInNull = server.query(query = """{scalarModels(where: {optString_not_in: null},orderBy: { id: asc }){idTest}}""", project = project)
     val filterOnNotInNull2 =
-      server.query(query = """{scalarModels(where: {b: {int:1}, optString_not_in: null},orderBy: { id: ASC }){idTest}}""", project = project)
+      server.query(query = """{scalarModels(where: {b: {int:1}, optString_not_in: null},orderBy: { id: asc }){idTest}}""", project = project)
 
     filterOnNotInNull.toString() should be("""{"data":{"scalarModels":[{"idTest":"id2"}]}}""")
     filterOnNotInNull2.toString() should be("""{"data":{"scalarModels":[{"idTest":"id2"}]}}""")
@@ -194,8 +194,8 @@ class PortedFiltersSpec extends FlatSpec with Matchers with ApiSpecBase {
     createTest("id2", "foo bar", 1, 1, optBoolean = false, "A", "2016-09-23T12:29:32.342")
     createTest("id3", "foo bar barz", 1, 1, optBoolean = false, "A", "2016-09-23T12:29:32.342")
 
-    val res  = server.query(query = """{scalarModels(where: {optString_not: "bar"}, orderBy: { id: ASC }){idTest}}""", project = project)
-    val res2 = server.query(query = """{scalarModels(where: {b: {int:1}, optString_not: "bar"}, orderBy: { id: ASC }){idTest}}""", project = project)
+    val res  = server.query(query = """{scalarModels(where: {optString_not: "bar"}, orderBy: { id: asc }){idTest}}""", project = project)
+    val res2 = server.query(query = """{scalarModels(where: {b: {int:1}, optString_not: "bar"}, orderBy: { id: asc }){idTest}}""", project = project)
 
     res.toString() should be("""{"data":{"scalarModels":[{"idTest":"id2"},{"idTest":"id3"}]}}""")
     res2.toString() should be("""{"data":{"scalarModels":[{"idTest":"id2"},{"idTest":"id3"}]}}""")
@@ -218,8 +218,8 @@ class PortedFiltersSpec extends FlatSpec with Matchers with ApiSpecBase {
     createTest("id2", "foo bar", 1, 1, optBoolean = false, "A", "2016-09-23T12:29:32.342")
     createTest("id3", "foo bar barz", 1, 1, optBoolean = false, "A", "2016-09-23T12:29:32.342")
 
-    val res  = server.query(query = """{scalarModels(where: {optString_not_contains: "bara"},orderBy: { id: ASC }){idTest}}""", project = project)
-    val res2 = server.query(query = """{scalarModels(where: {b: {int:1}, optString_not_contains: "bara"},orderBy: { id: ASC }){idTest}}""", project = project)
+    val res  = server.query(query = """{scalarModels(where: {optString_not_contains: "bara"},orderBy: { id: asc }){idTest}}""", project = project)
+    val res2 = server.query(query = """{scalarModels(where: {b: {int:1}, optString_not_contains: "bara"},orderBy: { id: asc }){idTest}}""", project = project)
 
     res.toString() should be("""{"data":{"scalarModels":[{"idTest":"id2"},{"idTest":"id3"}]}}""")
     res2.toString() should be("""{"data":{"scalarModels":[{"idTest":"id2"},{"idTest":"id3"}]}}""")
@@ -242,8 +242,8 @@ class PortedFiltersSpec extends FlatSpec with Matchers with ApiSpecBase {
     createTest("id2", "foo bar", 1, 1, optBoolean = false, "A", "2016-09-23T12:29:32.342")
     createTest("id3", "foo bar barz", 1, 1, optBoolean = false, "A", "2016-09-23T12:29:32.342")
 
-    val res  = server.query(query = """{scalarModels(where: {optString_not_starts_with: "bar"},orderBy: { id: ASC }){idTest}}""", project = project)
-    val res2 = server.query(query = """{scalarModels(where: {b: {int:1}, optString_not_starts_with: "bar"},orderBy: { id: ASC }){idTest}}""", project = project)
+    val res  = server.query(query = """{scalarModels(where: {optString_not_starts_with: "bar"},orderBy: { id: asc }){idTest}}""", project = project)
+    val res2 = server.query(query = """{scalarModels(where: {b: {int:1}, optString_not_starts_with: "bar"},orderBy: { id: asc }){idTest}}""", project = project)
 
     res.toString() should be("""{"data":{"scalarModels":[{"idTest":"id2"},{"idTest":"id3"}]}}""")
     res2.toString() should be("""{"data":{"scalarModels":[{"idTest":"id2"},{"idTest":"id3"}]}}""")
@@ -254,8 +254,8 @@ class PortedFiltersSpec extends FlatSpec with Matchers with ApiSpecBase {
     createTest("id2", "foo bar", 1, 1, optBoolean = false, "A", "2016-09-23T12:29:32.342")
     createTest("id3", "foo bar bar", 1, 1, optBoolean = false, "A", "2016-09-23T12:29:32.342")
 
-    val res  = server.query(query = """{scalarModels(where: {optString_ends_with: "bara"},orderBy: { id: ASC }){idTest}}""", project = project)
-    val res2 = server.query(query = """{scalarModels(where: {b: {int:1}, optString_ends_with: "bara"},orderBy: { id: ASC }){idTest}}""", project = project)
+    val res  = server.query(query = """{scalarModels(where: {optString_ends_with: "bara"},orderBy: { id: asc }){idTest}}""", project = project)
+    val res2 = server.query(query = """{scalarModels(where: {b: {int:1}, optString_ends_with: "bara"},orderBy: { id: asc }){idTest}}""", project = project)
 
     res.toString() should be("""{"data":{"scalarModels":[{"idTest":"id1"}]}}""")
     res2.toString() should be("""{"data":{"scalarModels":[{"idTest":"id1"}]}}""")
@@ -266,8 +266,8 @@ class PortedFiltersSpec extends FlatSpec with Matchers with ApiSpecBase {
     createTest("id2", "foo bar", 1, 1, optBoolean = false, "A", "2016-09-23T12:29:32.342")
     createTest("id3", "foo bar bar", 1, 1, optBoolean = false, "A", "2016-09-23T12:29:32.342")
 
-    val res  = server.query(query = """{scalarModels(where: {optString_not_ends_with: "bara"},orderBy: { id: ASC }){idTest}}""", project = project)
-    val res2 = server.query(query = """{scalarModels(where: {b: {int:1}, optString_not_ends_with: "bara"},orderBy: { id: ASC }){idTest}}""", project = project)
+    val res  = server.query(query = """{scalarModels(where: {optString_not_ends_with: "bara"},orderBy: { id: asc }){idTest}}""", project = project)
+    val res2 = server.query(query = """{scalarModels(where: {b: {int:1}, optString_not_ends_with: "bara"},orderBy: { id: asc }){idTest}}""", project = project)
 
     res.toString() should be("""{"data":{"scalarModels":[{"idTest":"id2"},{"idTest":"id3"}]}}""")
     res2.toString() should be("""{"data":{"scalarModels":[{"idTest":"id2"},{"idTest":"id3"}]}}""")
@@ -290,8 +290,8 @@ class PortedFiltersSpec extends FlatSpec with Matchers with ApiSpecBase {
     createTest("id2", "2", 1, 1, optBoolean = false, "A", "2016-09-23T12:29:32.342")
     createTest("id3", "3", 1, 1, optBoolean = false, "A", "2016-09-23T12:29:32.342")
 
-    val res  = server.query(query = """{scalarModels(where: {optString_lte: "2"},orderBy: { id: ASC }){idTest}}""", project = project)
-    val res2 = server.query(query = """{scalarModels(where: {b: {int:1}, optString_lte: "2"},orderBy: { id: ASC }){idTest}}""", project = project)
+    val res  = server.query(query = """{scalarModels(where: {optString_lte: "2"},orderBy: { id: asc }){idTest}}""", project = project)
+    val res2 = server.query(query = """{scalarModels(where: {b: {int:1}, optString_lte: "2"},orderBy: { id: asc }){idTest}}""", project = project)
 
     res.toString() should be("""{"data":{"scalarModels":[{"idTest":"id1"},{"idTest":"id2"}]}}""")
     res2.toString() should be("""{"data":{"scalarModels":[{"idTest":"id1"},{"idTest":"id2"}]}}""")
@@ -314,8 +314,8 @@ class PortedFiltersSpec extends FlatSpec with Matchers with ApiSpecBase {
     createTest("id2", "2", 1, 1, optBoolean = false, "A", "2016-09-23T12:29:32.342")
     createTest("id3", "3", 1, 1, optBoolean = false, "A", "2016-09-23T12:29:32.342")
 
-    val res  = server.query(query = """{scalarModels(where: {optString_gte: "2"},orderBy: { id: ASC }){idTest}}""", project = project)
-    val res2 = server.query(query = """{scalarModels(where: {b: {int:1}, optString_gte: "2"},orderBy: { id: ASC }){idTest}}""", project = project)
+    val res  = server.query(query = """{scalarModels(where: {optString_gte: "2"},orderBy: { id: asc }){idTest}}""", project = project)
+    val res2 = server.query(query = """{scalarModels(where: {b: {int:1}, optString_gte: "2"},orderBy: { id: asc }){idTest}}""", project = project)
 
     res.toString() should be("""{"data":{"scalarModels":[{"idTest":"id2"},{"idTest":"id3"}]}}""")
     res2.toString() should be("""{"data":{"scalarModels":[{"idTest":"id2"},{"idTest":"id3"}]}}""")
@@ -336,8 +336,8 @@ class PortedFiltersSpec extends FlatSpec with Matchers with ApiSpecBase {
     resB.toString() should be("""{"data":{"scalarModels":[{"idTest":"id1"}]}}""")
     resB2.toString() should be("""{"data":{"scalarModels":[{"idTest":"id1"}]}}""")
 
-    val resC  = server.query(query = """{scalarModels(where: {optString_in: ["a","abc"]},orderBy: { id: ASC }){idTest}}""", project = project)
-    val resC2 = server.query(query = """{scalarModels(where: {b: {int:1}, optString_in: ["a","abc"]},orderBy: { id: ASC }){idTest}}""", project = project)
+    val resC  = server.query(query = """{scalarModels(where: {optString_in: ["a","abc"]},orderBy: { id: asc }){idTest}}""", project = project)
+    val resC2 = server.query(query = """{scalarModels(where: {b: {int:1}, optString_in: ["a","abc"]},orderBy: { id: asc }){idTest}}""", project = project)
     resC.toString() should be("""{"data":{"scalarModels":[{"idTest":"id1"},{"idTest":"id3"}]}}""")
     resC2.toString() should be("""{"data":{"scalarModels":[{"idTest":"id1"},{"idTest":"id3"}]}}""")
 
@@ -352,14 +352,14 @@ class PortedFiltersSpec extends FlatSpec with Matchers with ApiSpecBase {
     createTest("id2", "ab", 1, 1, optBoolean = false, "A", "2016-09-23T12:29:32.342")
     createTest("id3", "abc", 1, 1, optBoolean = false, "A", "2016-09-23T12:29:32.342")
 
-    val resA  = server.query(query = """{scalarModels(where: {optString_not_in: ["a"]},orderBy: { id: ASC }){idTest}}""", project = project)
-    val resA2 = server.query(query = """{scalarModels(where: {b: {int:1}, optString_not_in: ["a"]},orderBy: { id: ASC }){idTest}}""", project = project)
+    val resA  = server.query(query = """{scalarModels(where: {optString_not_in: ["a"]},orderBy: { id: asc }){idTest}}""", project = project)
+    val resA2 = server.query(query = """{scalarModels(where: {b: {int:1}, optString_not_in: ["a"]},orderBy: { id: asc }){idTest}}""", project = project)
     resA.toString should be("""{"data":{"scalarModels":[{"idTest":"id2"},{"idTest":"id3"}]}}""")
 
     val resB =
-      server.query(query = """{scalarModels(orderBy: { idTest: ASC }, where: {optString_not_in: []},orderBy: { id: ASC }){idTest}}""", project = project)
+      server.query(query = """{scalarModels(orderBy: { idTest: asc }, where: {optString_not_in: []},orderBy: { id: asc }){idTest}}""", project = project)
     val resB2 =
-      server.query(query = """{scalarModels(orderBy: { idTest: ASC }, where: {b: {int:1}, optString_not_in: []},orderBy: { id: ASC }){idTest}}""",
+      server.query(query = """{scalarModels(orderBy: { idTest: asc }, where: {b: {int:1}, optString_not_in: []},orderBy: { id: asc }){idTest}}""",
                    project = project)
     resB.toString should be("""{"data":{"scalarModels":[{"idTest":"id1"},{"idTest":"id2"},{"idTest":"id3"}]}}""")
     resB2.toString should be("""{"data":{"scalarModels":[{"idTest":"id1"},{"idTest":"id2"},{"idTest":"id3"}]}}""")
@@ -385,8 +385,8 @@ class PortedFiltersSpec extends FlatSpec with Matchers with ApiSpecBase {
     createTest("id2", "ab", 2, 1, optBoolean = false, "A", "2016-09-23T12:29:32.342")
     createTest("id3", "abc", 3, 1, optBoolean = false, "A", "2016-09-23T12:29:32.342")
 
-    val res  = server.query(query = """{scalarModels(where: {optInt_not: 1},orderBy: { id: ASC }){idTest}}""", project = project)
-    val res2 = server.query(query = """{scalarModels(where: {b: {int:1}, optInt_not: 1},orderBy: { id: ASC }){idTest}}""", project = project)
+    val res  = server.query(query = """{scalarModels(where: {optInt_not: 1},orderBy: { id: asc }){idTest}}""", project = project)
+    val res2 = server.query(query = """{scalarModels(where: {b: {int:1}, optInt_not: 1},orderBy: { id: asc }){idTest}}""", project = project)
 
     res.toString() should be("""{"data":{"scalarModels":[{"idTest":"id2"},{"idTest":"id3"}]}}""")
     res2.toString() should be("""{"data":{"scalarModels":[{"idTest":"id2"},{"idTest":"id3"}]}}""")
@@ -397,8 +397,8 @@ class PortedFiltersSpec extends FlatSpec with Matchers with ApiSpecBase {
     createTest("id2", "2", 2, 1, optBoolean = false, "A", "2016-09-23T12:29:32.342")
     createTest("id3", "3", 3, 1, optBoolean = false, "A", "2016-09-23T12:29:32.342")
 
-    val res  = server.query(query = """{scalarModels(where: {optInt_lt: 2},orderBy: { id: ASC }){idTest}}""", project = project)
-    val res2 = server.query(query = """{scalarModels(where: {b: {int:1}, optInt_lt: 2},orderBy: { id: ASC }){idTest}}""", project = project)
+    val res  = server.query(query = """{scalarModels(where: {optInt_lt: 2},orderBy: { id: asc }){idTest}}""", project = project)
+    val res2 = server.query(query = """{scalarModels(where: {b: {int:1}, optInt_lt: 2},orderBy: { id: asc }){idTest}}""", project = project)
 
     res.toString() should be("""{"data":{"scalarModels":[{"idTest":"id1"}]}}""")
     res2.toString() should be("""{"data":{"scalarModels":[{"idTest":"id1"}]}}""")
@@ -409,8 +409,8 @@ class PortedFiltersSpec extends FlatSpec with Matchers with ApiSpecBase {
     createTest("id2", "2", 2, 1, optBoolean = false, "A", "2016-09-23T12:29:32.342")
     createTest("id3", "3", 3, 1, optBoolean = false, "A", "2016-09-23T12:29:32.342")
 
-    val res  = server.query(query = """{scalarModels(where: {optInt_lte: 2},orderBy: { id: ASC }){idTest}}""", project = project)
-    val res2 = server.query(query = """{scalarModels(where: {b: {int:1}, optInt_lte: 2},orderBy: { id: ASC }){idTest}}""", project = project)
+    val res  = server.query(query = """{scalarModels(where: {optInt_lte: 2},orderBy: { id: asc }){idTest}}""", project = project)
+    val res2 = server.query(query = """{scalarModels(where: {b: {int:1}, optInt_lte: 2},orderBy: { id: asc }){idTest}}""", project = project)
 
     res.toString() should be("""{"data":{"scalarModels":[{"idTest":"id1"},{"idTest":"id2"}]}}""")
     res2.toString() should be("""{"data":{"scalarModels":[{"idTest":"id1"},{"idTest":"id2"}]}}""")
@@ -433,8 +433,8 @@ class PortedFiltersSpec extends FlatSpec with Matchers with ApiSpecBase {
     createTest("id2", "2", 2, 1, optBoolean = false, "A", "2016-09-23T12:29:32.342")
     createTest("id3", "3", 3, 1, optBoolean = false, "A", "2016-09-23T12:29:32.342")
 
-    val res  = server.query(query = """{scalarModels(where: {optInt_gte: 2},orderBy: { id: ASC }){idTest}}""", project = project)
-    val res2 = server.query(query = """{scalarModels(where: {b: {int:1}, optInt_gte: 2},orderBy: { id: ASC }){idTest}}""", project = project)
+    val res  = server.query(query = """{scalarModels(where: {optInt_gte: 2},orderBy: { id: asc }){idTest}}""", project = project)
+    val res2 = server.query(query = """{scalarModels(where: {b: {int:1}, optInt_gte: 2},orderBy: { id: asc }){idTest}}""", project = project)
 
     res.toString() should be("""{"data":{"scalarModels":[{"idTest":"id2"},{"idTest":"id3"}]}}""")
     res2.toString() should be("""{"data":{"scalarModels":[{"idTest":"id2"},{"idTest":"id3"}]}}""")
@@ -457,8 +457,8 @@ class PortedFiltersSpec extends FlatSpec with Matchers with ApiSpecBase {
     createTest("id2", "ab", 2, 1, optBoolean = false, "A", "2016-09-23T12:29:32.342")
     createTest("id3", "abc", 3, 1, optBoolean = false, "A", "2016-09-23T12:29:32.342")
 
-    val res  = server.query(query = """{scalarModels(where: {optInt_not_in: [1]},orderBy: { id: ASC }){idTest}}""", project = project)
-    val res2 = server.query(query = """{scalarModels(where: {b: {int:1}, optInt_not_in: [1]},orderBy: { id: ASC }){idTest}}""", project = project)
+    val res  = server.query(query = """{scalarModels(where: {optInt_not_in: [1]},orderBy: { id: asc }){idTest}}""", project = project)
+    val res2 = server.query(query = """{scalarModels(where: {b: {int:1}, optInt_not_in: [1]},orderBy: { id: asc }){idTest}}""", project = project)
 
     res.toString() should be("""{"data":{"scalarModels":[{"idTest":"id2"},{"idTest":"id3"}]}}""")
     res2.toString() should be("""{"data":{"scalarModels":[{"idTest":"id2"},{"idTest":"id3"}]}}""")
@@ -484,8 +484,8 @@ class PortedFiltersSpec extends FlatSpec with Matchers with ApiSpecBase {
     createTest("id2", "ab", 2, 2, optBoolean = false, "A", "2016-09-23T12:29:32.342")
     createTest("id3", "abc", 3, 3, optBoolean = false, "A", "2016-09-23T12:29:32.342")
 
-    val res  = server.query(query = """{scalarModels(where: {optFloat_not: 1},orderBy: { id: ASC }){idTest}}""", project = project)
-    val res2 = server.query(query = """{scalarModels(where: {b: {int:1}, optFloat_not: 1},orderBy: { id: ASC }){idTest}}""", project = project)
+    val res  = server.query(query = """{scalarModels(where: {optFloat_not: 1},orderBy: { id: asc }){idTest}}""", project = project)
+    val res2 = server.query(query = """{scalarModels(where: {b: {int:1}, optFloat_not: 1},orderBy: { id: asc }){idTest}}""", project = project)
 
     res.toString() should be("""{"data":{"scalarModels":[{"idTest":"id2"},{"idTest":"id3"}]}}""")
     res2.toString() should be("""{"data":{"scalarModels":[{"idTest":"id2"},{"idTest":"id3"}]}}""")
@@ -496,8 +496,8 @@ class PortedFiltersSpec extends FlatSpec with Matchers with ApiSpecBase {
     createTest("id2", "2", 2, 2, optBoolean = false, "A", "2016-09-23T12:29:32.342")
     createTest("id3", "3", 3, 3, optBoolean = false, "A", "2016-09-23T12:29:32.342")
 
-    val res  = server.query(query = """{scalarModels(where: {optFloat_lt: 2},orderBy: { id: ASC }){idTest}}""", project = project)
-    val res2 = server.query(query = """{scalarModels(where: {b: {int:1}, optFloat_lt: 2},orderBy: { id: ASC }){idTest}}""", project = project)
+    val res  = server.query(query = """{scalarModels(where: {optFloat_lt: 2},orderBy: { id: asc }){idTest}}""", project = project)
+    val res2 = server.query(query = """{scalarModels(where: {b: {int:1}, optFloat_lt: 2},orderBy: { id: asc }){idTest}}""", project = project)
 
     res.toString() should be("""{"data":{"scalarModels":[{"idTest":"id1"}]}}""")
     res2.toString() should be("""{"data":{"scalarModels":[{"idTest":"id1"}]}}""")
@@ -508,8 +508,8 @@ class PortedFiltersSpec extends FlatSpec with Matchers with ApiSpecBase {
     createTest("id2", "2", 2, 2, optBoolean = false, "A", "2016-09-23T12:29:32.342")
     createTest("id3", "3", 3, 3, optBoolean = false, "A", "2016-09-23T12:29:32.342")
 
-    val res  = server.query(query = """{scalarModels(where: {optFloat_lte: 2},orderBy: { id: ASC }){idTest}}""", project = project)
-    val res2 = server.query(query = """{scalarModels(where: {b: {int:1}, optFloat_lte: 2},orderBy: { id: ASC }){idTest}}""", project = project)
+    val res  = server.query(query = """{scalarModels(where: {optFloat_lte: 2},orderBy: { id: asc }){idTest}}""", project = project)
+    val res2 = server.query(query = """{scalarModels(where: {b: {int:1}, optFloat_lte: 2},orderBy: { id: asc }){idTest}}""", project = project)
 
     res.toString() should be("""{"data":{"scalarModels":[{"idTest":"id1"},{"idTest":"id2"}]}}""")
     res2.toString() should be("""{"data":{"scalarModels":[{"idTest":"id1"},{"idTest":"id2"}]}}""")
@@ -532,8 +532,8 @@ class PortedFiltersSpec extends FlatSpec with Matchers with ApiSpecBase {
     createTest("id2", "2", 2, 2, optBoolean = false, "A", "2016-09-23T12:29:32.342")
     createTest("id3", "3", 3, 3, optBoolean = false, "A", "2016-09-23T12:29:32.342")
 
-    val res  = server.query(query = """{scalarModels(where: {optFloat_gte: 2},orderBy: { id: ASC }){idTest}}""", project = project)
-    val res2 = server.query(query = """{scalarModels(where: {b: {int:1}, optFloat_gte: 2},orderBy: { id: ASC }){idTest}}""", project = project)
+    val res  = server.query(query = """{scalarModels(where: {optFloat_gte: 2},orderBy: { id: asc }){idTest}}""", project = project)
+    val res2 = server.query(query = """{scalarModels(where: {b: {int:1}, optFloat_gte: 2},orderBy: { id: asc }){idTest}}""", project = project)
 
     res.toString() should be("""{"data":{"scalarModels":[{"idTest":"id2"},{"idTest":"id3"}]}}""")
     res2.toString() should be("""{"data":{"scalarModels":[{"idTest":"id2"},{"idTest":"id3"}]}}""")
@@ -556,8 +556,8 @@ class PortedFiltersSpec extends FlatSpec with Matchers with ApiSpecBase {
     createTest("id2", "ab", 2, 2, optBoolean = false, "A", "2016-09-23T12:29:32.342")
     createTest("id3", "abc", 3, 3, optBoolean = false, "A", "2016-09-23T12:29:32.342")
 
-    val res  = server.query(query = """{scalarModels(where: {optFloat_not_in: [1]},orderBy: { id: ASC }){idTest}}""", project = project)
-    val res2 = server.query(query = """{scalarModels(where: {b: {int:1}, optFloat_not_in: [1]},orderBy: { id: ASC }){idTest}}""", project = project)
+    val res  = server.query(query = """{scalarModels(where: {optFloat_not_in: [1]},orderBy: { id: asc }){idTest}}""", project = project)
+    val res2 = server.query(query = """{scalarModels(where: {b: {int:1}, optFloat_not_in: [1]},orderBy: { id: asc }){idTest}}""", project = project)
 
     res.toString() should be("""{"data":{"scalarModels":[{"idTest":"id2"},{"idTest":"id3"}]}}""")
     res2.toString() should be("""{"data":{"scalarModels":[{"idTest":"id2"},{"idTest":"id3"}]}}""")
@@ -583,8 +583,8 @@ class PortedFiltersSpec extends FlatSpec with Matchers with ApiSpecBase {
     createTest("id2", "foo bar", 1, 1, optBoolean = false, "A", "2016-09-23T12:29:32.342")
     createTest("id3", "foo bar barz", 1, 1, optBoolean = false, "A", "2016-09-23T12:29:32.342")
 
-    val res  = server.query(query = """{scalarModels(where: {optBoolean_not: true},orderBy: { id: ASC }){idTest}}""", project = project)
-    val res2 = server.query(query = """{scalarModels(where: {b: {int:1}, optBoolean_not: true},orderBy: { id: ASC }){idTest}}""", project = project)
+    val res  = server.query(query = """{scalarModels(where: {optBoolean_not: true},orderBy: { id: asc }){idTest}}""", project = project)
+    val res2 = server.query(query = """{scalarModels(where: {b: {int:1}, optBoolean_not: true},orderBy: { id: asc }){idTest}}""", project = project)
 
     res.toString() should be("""{"data":{"scalarModels":[{"idTest":"id2"},{"idTest":"id3"}]}}""")
     res2.toString() should be("""{"data":{"scalarModels":[{"idTest":"id2"},{"idTest":"id3"}]}}""")
@@ -610,9 +610,9 @@ class PortedFiltersSpec extends FlatSpec with Matchers with ApiSpecBase {
     createTest("id2", "2", 2, 2, optBoolean = false, "A", "2016-09-24T12:29:32.342")
     createTest("id3", "3", 3, 3, optBoolean = false, "A", "2016-09-25T12:29:32.342")
 
-    val res = server.query(query = """{scalarModels(where: {optDateTime_not: "2016-09-24T12:29:32.342Z"},orderBy: { id: ASC }){idTest}}""", project = project)
+    val res = server.query(query = """{scalarModels(where: {optDateTime_not: "2016-09-24T12:29:32.342Z"},orderBy: { id: asc }){idTest}}""", project = project)
     val res2 =
-      server.query(query = """{scalarModels(where: {b: {int:1}, optDateTime_not: "2016-09-24T12:29:32.342Z"},orderBy: { id: ASC }){idTest}}""",
+      server.query(query = """{scalarModels(where: {b: {int:1}, optDateTime_not: "2016-09-24T12:29:32.342Z"},orderBy: { id: asc }){idTest}}""",
                    project = project)
 
     res.toString() should be("""{"data":{"scalarModels":[{"idTest":"id1"},{"idTest":"id3"}]}}""")
@@ -636,9 +636,9 @@ class PortedFiltersSpec extends FlatSpec with Matchers with ApiSpecBase {
     createTest("id2", "2", 2, 2, optBoolean = false, "A", "2016-09-24T12:29:32.342")
     createTest("id3", "3", 3, 3, optBoolean = false, "A", "2016-09-25T12:29:32.342")
 
-    val res = server.query(query = """{scalarModels(where: {optDateTime_lte: "2016-09-24T12:29:32.342Z"},orderBy: { id: ASC }){idTest}}""", project = project)
+    val res = server.query(query = """{scalarModels(where: {optDateTime_lte: "2016-09-24T12:29:32.342Z"},orderBy: { id: asc }){idTest}}""", project = project)
     val res2 =
-      server.query(query = """{scalarModels(where: {b: {int:1}, optDateTime_lte: "2016-09-24T12:29:32.342Z"},orderBy: { id: ASC }){idTest}}""",
+      server.query(query = """{scalarModels(where: {b: {int:1}, optDateTime_lte: "2016-09-24T12:29:32.342Z"},orderBy: { id: asc }){idTest}}""",
                    project = project)
 
     res.toString() should be("""{"data":{"scalarModels":[{"idTest":"id1"},{"idTest":"id2"}]}}""")
@@ -662,9 +662,9 @@ class PortedFiltersSpec extends FlatSpec with Matchers with ApiSpecBase {
     createTest("id2", "2", 2, 2, optBoolean = false, "A", "2016-09-24T12:29:32.342")
     createTest("id3", "3", 3, 3, optBoolean = false, "A", "2016-09-25T12:29:32.342")
 
-    val res = server.query(query = """{scalarModels(where: {optDateTime_gte: "2016-09-24T12:29:32.342Z"},orderBy: { id: ASC }){idTest}}""", project = project)
+    val res = server.query(query = """{scalarModels(where: {optDateTime_gte: "2016-09-24T12:29:32.342Z"},orderBy: { id: asc }){idTest}}""", project = project)
     val res2 =
-      server.query(query = """{scalarModels(where: {b: {int:1}, optDateTime_gte: "2016-09-24T12:29:32.342Z"},orderBy: { id: ASC }){idTest}}""",
+      server.query(query = """{scalarModels(where: {b: {int:1}, optDateTime_gte: "2016-09-24T12:29:32.342Z"},orderBy: { id: asc }){idTest}}""",
                    project = project)
 
     res.toString() should be("""{"data":{"scalarModels":[{"idTest":"id2"},{"idTest":"id3"}]}}""")
@@ -689,8 +689,8 @@ class PortedFiltersSpec extends FlatSpec with Matchers with ApiSpecBase {
     createTest("id3", "3", 3, 3, optBoolean = false, "A", "2016-09-25T12:29:32.342")
 
     val res =
-      server.query(query = """{scalarModels(where: {optDateTime_not_in: ["2016-09-24T12:29:32.342Z"]},orderBy: { id: ASC }){idTest}}""", project = project)
-    val res2 = server.query(query = """{scalarModels(where: {b: {int:1}, optDateTime_not_in: ["2016-09-24T12:29:32.342Z"]},orderBy: { id: ASC }){idTest}}""",
+      server.query(query = """{scalarModels(where: {optDateTime_not_in: ["2016-09-24T12:29:32.342Z"]},orderBy: { id: asc }){idTest}}""", project = project)
+    val res2 = server.query(query = """{scalarModels(where: {b: {int:1}, optDateTime_not_in: ["2016-09-24T12:29:32.342Z"]},orderBy: { id: asc }){idTest}}""",
                             project = project)
 
     res.toString() should be("""{"data":{"scalarModels":[{"idTest":"id1"},{"idTest":"id3"}]}}""")
@@ -717,8 +717,8 @@ class PortedFiltersSpec extends FlatSpec with Matchers with ApiSpecBase {
     createTest("id2", "2", 2, 2, optBoolean = false, "B", "2016-09-24T12:29:32.342")
     createTest("id3", "3", 3, 3, optBoolean = false, "B", "2016-09-25T12:29:32.342")
 
-    val res  = server.query(query = """{scalarModels(where: {optEnum_not: A},orderBy: { id: ASC }){idTest}}""", project = project)
-    val res2 = server.query(query = """{scalarModels(where: {b: {int:1}, optEnum_not: A},orderBy: { id: ASC }){idTest}}""", project = project)
+    val res  = server.query(query = """{scalarModels(where: {optEnum_not: A},orderBy: { id: asc }){idTest}}""", project = project)
+    val res2 = server.query(query = """{scalarModels(where: {b: {int:1}, optEnum_not: A},orderBy: { id: asc }){idTest}}""", project = project)
 
     res.toString() should be("""{"data":{"scalarModels":[{"idTest":"id2"},{"idTest":"id3"}]}}""")
     res2.toString() should be("""{"data":{"scalarModels":[{"idTest":"id2"},{"idTest":"id3"}]}}""")
@@ -741,8 +741,8 @@ class PortedFiltersSpec extends FlatSpec with Matchers with ApiSpecBase {
     createTest("id2", "2", 2, 2, optBoolean = false, "B", "2016-09-24T12:29:32.342")
     createTest("id3", "3", 3, 3, optBoolean = false, "B", "2016-09-25T12:29:32.342")
 
-    val res  = server.query(query = """{scalarModels(where: {optEnum_not_in: [A]},orderBy: { id: ASC }){idTest}}""", project = project)
-    val res2 = server.query(query = """{scalarModels(where: {b: {int:1}, optEnum_not_in: [A]},orderBy: { id: ASC }){idTest}}""", project = project)
+    val res  = server.query(query = """{scalarModels(where: {optEnum_not_in: [A]},orderBy: { id: asc }){idTest}}""", project = project)
+    val res2 = server.query(query = """{scalarModels(where: {b: {int:1}, optEnum_not_in: [A]},orderBy: { id: asc }){idTest}}""", project = project)
 
     res.toString() should be("""{"data":{"scalarModels":[{"idTest":"id2"},{"idTest":"id3"}]}}""")
     res2.toString() should be("""{"data":{"scalarModels":[{"idTest":"id2"},{"idTest":"id3"}]}}""")

--- a/query-engine/connector-test-kit/src/test/scala/queries/filters/SelfRelationFilterBugSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/filters/SelfRelationFilterBugSpec.scala
@@ -43,7 +43,7 @@ class SelfRelationFilterBugSpec extends FlatSpec with Matchers with ApiSpecBase 
   "Getting all categories" should "succeed" in {
     val allCategories =
       s"""{
-         |  allCategories: categories(orderBy: { id: ASC }) {
+         |  allCategories: categories(orderBy: { id: asc }) {
          |    name
          |    parent {
          |      name

--- a/query-engine/connector-test-kit/src/test/scala/queries/filters/SelfRelationFilterSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/filters/SelfRelationFilterSpec.scala
@@ -201,7 +201,7 @@ class SelfRelationFilterSpec extends FlatSpec with Matchers with ApiSpecBase {
                                                   }
                                                 }
                                               },
-                                           orderBy: { id: ASC }
+                                           orderBy: { id: asc }
                                             ) {
                                               title
                                             }
@@ -290,7 +290,7 @@ class SelfRelationFilterSpec extends FlatSpec with Matchers with ApiSpecBase {
 
     val filterGroupies = s"""query{humans(
                                           where: {fans_none: {}},
-                                           orderBy: { id: ASC }
+                                           orderBy: { id: asc }
                                             ) {
                                               name
                                             }
@@ -307,7 +307,7 @@ class SelfRelationFilterSpec extends FlatSpec with Matchers with ApiSpecBase {
   "Filter Queries along ManyToMany self relations" should "succeed with {} filter _every" taggedAs (IgnoreMongo) in {
     val filterGroupies = s"""query{humans(
                                           where: {fans_every: {}},
-                                           orderBy: { id: ASC }
+                                           orderBy: { id: asc }
                                             ) {
                                               name
                                             }
@@ -341,7 +341,7 @@ class SelfRelationFilterSpec extends FlatSpec with Matchers with ApiSpecBase {
 
     val filterSingers = s"""query{humans(
                                           where: {singer:{}},
-                                           orderBy: { id: ASC }
+                                           orderBy: { id: asc }
                                             ) {
                                               name
                                             }
@@ -354,7 +354,7 @@ class SelfRelationFilterSpec extends FlatSpec with Matchers with ApiSpecBase {
 
     val filterSingers = s"""query{humans(
                                           where: {singer: null},
-                                           orderBy: { id: ASC }
+                                           orderBy: { id: asc }
                                             ) {
                                               name
                                             }

--- a/query-engine/connector-test-kit/src/test/scala/queries/filters/WhereUniqueSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/filters/WhereUniqueSpec.scala
@@ -54,7 +54,7 @@ class WhereUniqueSpec extends FlatSpec with Matchers with ApiSpecBase {
       s"""query{user(where: {id:"wrong", email: "test@test.com"}){unique}}""",
       project,
       errorCode = 2009, // 3045,
-      errorContains = """"Expected object to have exactly 1 key-value pairs, got: 2 (id, email)"""
+      errorContains = """Expected at most 1 fields to be present, got 2"""
       // """You provided more than one field for the unique selector on User. If you want that behavior you can use the many query and combine fields with AND / OR."""
     )
   }

--- a/query-engine/connector-test-kit/src/test/scala/queries/orderAndPagination/NestedMultiOrderPaginationSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/orderAndPagination/NestedMultiOrderPaginationSpec.scala
@@ -63,7 +63,7 @@ class NestedMultiOrderPaginationSpec extends FlatSpec with Matchers with ApiSpec
           |query {
           |  findManyTestModel {
           |    id
-          |    related(take: 1, orderBy: { fieldA: DESC, fieldB: ASC, fieldC: ASC, fieldD: DESC }) {
+          |    related(take: 1, orderBy: [{ fieldA: desc }, {fieldB: asc }, { fieldC: asc }, { fieldD: desc }]) {
           |      id
           |    }
           |  }
@@ -73,7 +73,7 @@ class NestedMultiOrderPaginationSpec extends FlatSpec with Matchers with ApiSpec
         legacy = false
       )
 
-    // Ordered: DESC, ASC, ASC, DESC
+    // Ordered: desc, ASC, ASC, DESC
     // 1 => 2 B B B B <- take
     // 1 => 1 A B C D
     // 2 => 3 B A B B <- take
@@ -90,7 +90,7 @@ class NestedMultiOrderPaginationSpec extends FlatSpec with Matchers with ApiSpec
           |query {
           |  findManyTestModel {
           |    id
-          |    related(take: -1, orderBy: { fieldA: DESC, fieldB: ASC, fieldC: ASC, fieldD: DESC }) {
+          |    related(take: -1, orderBy: [{ fieldA: desc }, { fieldB: asc }, { fieldC: asc }, { fieldD: desc }]) {
           |      id
           |    }
           |  }
@@ -100,7 +100,7 @@ class NestedMultiOrderPaginationSpec extends FlatSpec with Matchers with ApiSpec
         legacy = false
       )
 
-    // Ordered: DESC, ASC, ASC, DESC
+    // Ordered: desc, ASC, ASC, DESC
     // 1 => 2 B B B B
     // 1 => 1 A B C D <- take
     // 2 => 3 B A B B
@@ -117,7 +117,7 @@ class NestedMultiOrderPaginationSpec extends FlatSpec with Matchers with ApiSpec
           |query {
           |  findManyTestModel {
           |    id
-          |    related(cursor: { id: 3 }, orderBy: { fieldA: DESC, fieldB: ASC, fieldC: ASC, fieldD: DESC }) {
+          |    related(cursor: { id: 3 }, orderBy: [{ fieldA: desc }, { fieldB: asc }, { fieldC: asc }, { fieldD: desc }]) {
           |      id
           |    }
           |  }
@@ -127,7 +127,7 @@ class NestedMultiOrderPaginationSpec extends FlatSpec with Matchers with ApiSpec
         legacy = false
       )
 
-    // Ordered: DESC, ASC, ASC, DESC
+    // Ordered: desc, ASC, ASC, DESC
     // 1 => 2 B B B B
     // 1 => 1 A B C D
     // 2 => 3 B A B B <- take
@@ -193,7 +193,7 @@ class NestedMultiOrderPaginationSpec extends FlatSpec with Matchers with ApiSpec
           |query {
           |  findManyTestModel {
           |    id
-          |    related(take: 1, orderBy: { fieldA: DESC, fieldB: ASC, fieldC: ASC, fieldD: DESC }) {
+          |    related(take: 1, orderBy: [{ fieldA: desc }, { fieldB: asc }, { fieldC: asc }, { fieldD: desc }]) {
           |      id
           |    }
           |  }
@@ -203,7 +203,7 @@ class NestedMultiOrderPaginationSpec extends FlatSpec with Matchers with ApiSpec
         legacy = false
       )
 
-    // Ordered: DESC, ASC, ASC, DESC
+    // Ordered: desc, ASC, ASC, DESC
     // 1 => 2 B B B B <- take
     // 1 => 1 A B C D
     // 2 => 3 B B B B <- take
@@ -225,7 +225,7 @@ class NestedMultiOrderPaginationSpec extends FlatSpec with Matchers with ApiSpec
           |query {
           |  findManyTestModel {
           |    id
-          |    related(take: -1, orderBy: { fieldA: DESC, fieldB: ASC, fieldC: ASC, fieldD: DESC }) {
+          |    related(take: -1, orderBy: [{ fieldA: desc }, { fieldB: asc }, { fieldC: asc }, { fieldD: desc }]) {
           |      id
           |    }
           |  }
@@ -235,7 +235,7 @@ class NestedMultiOrderPaginationSpec extends FlatSpec with Matchers with ApiSpec
         legacy = false
       )
 
-    // Ordered: DESC, ASC, ASC, DESC
+    // Ordered: desc, ASC, ASC, DESC
     // 1 => 2 B B B B
     // 1 => 1 A B C D <- take
     // 2 => 3 B B B B <- take
@@ -257,7 +257,7 @@ class NestedMultiOrderPaginationSpec extends FlatSpec with Matchers with ApiSpec
           |query {
           |  findManyTestModel {
           |    id
-          |    related(cursor: { id: 3 }, orderBy: { fieldA: DESC, fieldB: ASC, fieldC: ASC, fieldD: DESC }) {
+          |    related(cursor: { id: 3 }, orderBy: [{ fieldA: desc }, { fieldB: asc }, { fieldC: asc }, { fieldD: desc }]) {
           |      id
           |    }
           |  }
@@ -267,7 +267,7 @@ class NestedMultiOrderPaginationSpec extends FlatSpec with Matchers with ApiSpec
         legacy = false
       )
 
-    // Ordered: DESC, ASC, ASC, DESC
+    // Ordered: desc, ASC, ASC, DESC
     // 1 => 2 B B B B
     // 1 => 1 A B C D
     // 2 => 3 B B B B <- take

--- a/query-engine/connector-test-kit/src/test/scala/queries/orderAndPagination/NestedPaginationSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/orderAndPagination/NestedPaginationSpec.scala
@@ -88,7 +88,7 @@ class NestedPaginationSpec extends FlatSpec with Matchers with ApiSpecBase {
       val result = server.query(
         """
           |{
-          |  tops{t, middles(cursor: { m: "M22" }, orderBy: { id: ASC }){ m }}
+          |  tops{t, middles(cursor: { m: "M22" }, orderBy: { id: asc }){ m }}
           |
           |}
         """,
@@ -364,7 +364,7 @@ class NestedPaginationSpec extends FlatSpec with Matchers with ApiSpecBase {
       val result = server.query(
         """
         |{
-        |  tops{t, middles(take: -1, orderBy: { id: ASC }){m}}
+        |  tops{t, middles(take: -1, orderBy: { id: asc }){m}}
         |}
       """,
         project
@@ -381,7 +381,7 @@ class NestedPaginationSpec extends FlatSpec with Matchers with ApiSpecBase {
       val result = server.query(
         """
         |{
-        |  tops{t, middles(take: -3, orderBy: { id: ASC }) {m}}
+        |  tops{t, middles(take: -3, orderBy: { id: asc }) {m}}
         |}
       """,
         project
@@ -398,7 +398,7 @@ class NestedPaginationSpec extends FlatSpec with Matchers with ApiSpecBase {
       val result = server.query(
         """
         |{
-        |  tops{t, middles(take: -4, orderBy: { id: ASC }){m}}
+        |  tops{t, middles(take: -4, orderBy: { id: asc }){m}}
         |}
       """,
         project
@@ -415,7 +415,7 @@ class NestedPaginationSpec extends FlatSpec with Matchers with ApiSpecBase {
       val result = server.query(
         """
         |{
-        |  tops{middles{bottoms(take: -1, orderBy: { id: ASC }){b}}}
+        |  tops{middles{bottoms(take: -1, orderBy: { id: asc }){b}}}
         |}
       """,
         project
@@ -432,7 +432,7 @@ class NestedPaginationSpec extends FlatSpec with Matchers with ApiSpecBase {
       val result = server.query(
         """
         |{
-        |  tops{middles{bottoms(take: -3, orderBy: { id: ASC }){b}}}
+        |  tops{middles{bottoms(take: -3, orderBy: { id: asc }){b}}}
         |}
       """,
         project
@@ -449,7 +449,7 @@ class NestedPaginationSpec extends FlatSpec with Matchers with ApiSpecBase {
       val result = server.query(
         """
         |{
-        |  tops{middles{bottoms(take: -4, orderBy: { id: ASC }){b}}}
+        |  tops{middles{bottoms(take: -4, orderBy: { id: asc }){b}}}
         |}
       """,
         project
@@ -536,7 +536,7 @@ class NestedPaginationSpec extends FlatSpec with Matchers with ApiSpecBase {
       val result = server.query(
         """
         |{
-        |  tops(skip: 1, take: -1, orderBy: { id: ASC }){t, middles{m}}
+        |  tops(skip: 1, take: -1, orderBy: { id: asc }){t, middles{m}}
         |}
       """,
         project
@@ -552,7 +552,7 @@ class NestedPaginationSpec extends FlatSpec with Matchers with ApiSpecBase {
       val result = server.query(
         """
         |{
-        |  tops(skip: 1, take: -3, orderBy: { id: ASC }){t, middles{m}}
+        |  tops(skip: 1, take: -3, orderBy: { id: asc }){t, middles{m}}
         |}
       """,
         project
@@ -569,7 +569,7 @@ class NestedPaginationSpec extends FlatSpec with Matchers with ApiSpecBase {
       val result = server.query(
         """
         |{
-        |  tops{t, middles(skip: 1, take: -1, orderBy: { id: ASC }){m}}
+        |  tops{t, middles(skip: 1, take: -1, orderBy: { id: asc }){m}}
         |}
       """,
         project
@@ -586,7 +586,7 @@ class NestedPaginationSpec extends FlatSpec with Matchers with ApiSpecBase {
       val result = server.query(
         """
         |{
-        |  tops{t, middles(skip: 1, take: -3, orderBy: { id: ASC }){m}}
+        |  tops{t, middles(skip: 1, take: -3, orderBy: { id: asc }){m}}
         |}
       """,
         project
@@ -606,7 +606,7 @@ class NestedPaginationSpec extends FlatSpec with Matchers with ApiSpecBase {
       val result = server.query(
         """
         |{
-        |  tops{t, middles(orderBy: { m: DESC }, take: 1){m}}
+        |  tops{t, middles(orderBy: { m: desc }, take: 1){m}}
         |}
       """,
         project
@@ -623,7 +623,7 @@ class NestedPaginationSpec extends FlatSpec with Matchers with ApiSpecBase {
       val result = server.query(
         """
         |{
-        |  tops{t, middles(orderBy: { m: DESC }, take: 3){m}}
+        |  tops{t, middles(orderBy: { m: desc }, take: 3){m}}
         |}
       """,
         project
@@ -988,7 +988,7 @@ class NestedPaginationSpec extends FlatSpec with Matchers with ApiSpecBase {
          |    id
          |    manyB(cursor: {
          |      id: "B5"
-         |    }, skip: 1, take: -2, orderBy: { id: ASC }) {
+         |    }, skip: 1, take: -2, orderBy: { id: asc }) {
          |      id
          |    }
          |  }

--- a/query-engine/connector-test-kit/src/test/scala/queries/orderAndPagination/OrderByInMutationSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/orderAndPagination/OrderByInMutationSpec.scala
@@ -63,7 +63,7 @@ class OrderByInMutationSpec extends FlatSpec with Matchers with ApiSpecBase {
         |    }
         |  ) {
         |    test
-        |    bars(take: 1, orderBy: { orderField: DESC }) {
+        |    bars(take: 1, orderBy: { orderField: desc }) {
         |      quantity
         |    }
         |  }

--- a/query-engine/connector-test-kit/src/test/scala/queries/orderAndPagination/OrderBySpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/orderAndPagination/OrderBySpec.scala
@@ -61,7 +61,7 @@ class OrderBySpec extends FlatSpec with Matchers with ApiSpecBase {
     val result = server.query(
       """
         |{
-        |  findManyOrderTest(orderBy: { nonUniqFieldA: desc, uniqueField: desc}) {
+        |  findManyOrderTest(orderBy: [{ nonUniqFieldA: desc }, { uniqueField: desc}]) {
         |    nonUniqFieldA
         |    uniqueField
         |  }
@@ -79,7 +79,7 @@ class OrderBySpec extends FlatSpec with Matchers with ApiSpecBase {
     val result = server.query(
       """
         |{
-        |  findManyOrderTest(orderBy: { nonUniqFieldB: asc, nonUniqFieldA: asc, uniqueField: asc}) {
+        |  findManyOrderTest(orderBy: [{ nonUniqFieldB: asc }, { nonUniqFieldA: asc }, { uniqueField: asc}]) {
         |    nonUniqFieldB
         |    nonUniqFieldA
         |    uniqueField

--- a/query-engine/connector-test-kit/src/test/scala/queries/orderAndPagination/OrderBySpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/orderAndPagination/OrderBySpec.scala
@@ -27,7 +27,7 @@ class OrderBySpec extends FlatSpec with Matchers with ApiSpecBase {
     val result = server.query(
       """
         |{
-        |  findManyOrderTest(orderBy: { uniqueField: ASC }) {
+        |  findManyOrderTest(orderBy: { uniqueField: asc }) {
         |    uniqueField
         |  }
         |}
@@ -44,7 +44,7 @@ class OrderBySpec extends FlatSpec with Matchers with ApiSpecBase {
     val result = server.query(
       """
         |{
-        |  findManyOrderTest(orderBy: { uniqueField: DESC }) {
+        |  findManyOrderTest(orderBy: { uniqueField: desc }) {
         |    uniqueField
         |  }
         |}
@@ -61,7 +61,7 @@ class OrderBySpec extends FlatSpec with Matchers with ApiSpecBase {
     val result = server.query(
       """
         |{
-        |  findManyOrderTest(orderBy: { nonUniqFieldA: DESC, uniqueField: DESC}) {
+        |  findManyOrderTest(orderBy: { nonUniqFieldA: desc, uniqueField: desc}) {
         |    nonUniqFieldA
         |    uniqueField
         |  }
@@ -79,7 +79,7 @@ class OrderBySpec extends FlatSpec with Matchers with ApiSpecBase {
     val result = server.query(
       """
         |{
-        |  findManyOrderTest(orderBy: { nonUniqFieldB: ASC, nonUniqFieldA: ASC, uniqueField: ASC}) {
+        |  findManyOrderTest(orderBy: { nonUniqFieldB: asc, nonUniqFieldA: asc, uniqueField: asc}) {
         |    nonUniqFieldB
         |    nonUniqFieldA
         |    uniqueField
@@ -105,7 +105,7 @@ class OrderBySpec extends FlatSpec with Matchers with ApiSpecBase {
     val result = server.query(
       """
         |{
-        |  findManyOrderTest(take: -3, orderBy: { uniqueField: DESC }) {
+        |  findManyOrderTest(take: -3, orderBy: { uniqueField: desc }) {
         |    uniqueField
         |  }
         |}

--- a/query-engine/connector-test-kit/src/test/scala/queries/orderAndPagination/PaginationRegressionSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/orderAndPagination/PaginationRegressionSpec.scala
@@ -28,7 +28,7 @@ class PaginationRegressionSpec extends FlatSpec with Matchers with ApiSpecBase {
     val page1 = server.query(
       """
       |{
-      |  findManyModelB(take: 5, orderBy: { createdAt: DESC, id: ASC }) {
+      |  findManyModelB(take: 5, orderBy: [{ createdAt: desc}, { id: asc }]) {
       |    id
       |    createdAt
       |  }
@@ -44,7 +44,7 @@ class PaginationRegressionSpec extends FlatSpec with Matchers with ApiSpecBase {
     val page2 = server.query(
       """
         |{
-        |  findManyModelB(cursor: { id: "9505b8a9-45a1-4aae-a284-5bacfe9f835c" }, skip: 1, take: 5, orderBy: { createdAt: DESC, id: ASC } ) {
+        |  findManyModelB(cursor: { id: "9505b8a9-45a1-4aae-a284-5bacfe9f835c" }, skip: 1, take: 5, orderBy: [{ createdAt: desc}, { id: asc }] ) {
         |    id
         |    createdAt
         |  }
@@ -60,7 +60,7 @@ class PaginationRegressionSpec extends FlatSpec with Matchers with ApiSpecBase {
     val page3 = server.query(
       """
         |{
-        |  findManyModelB(cursor: { id: "3c0f269f-0796-427e-af67-8c1a99f3524d" }, skip: 1, take: 5, orderBy: { createdAt: DESC, id: ASC } ) {
+        |  findManyModelB(cursor: { id: "3c0f269f-0796-427e-af67-8c1a99f3524d" }, skip: 1, take: 5, orderBy: [{ createdAt: desc}, { id: asc }] ) {
         |    id
         |    createdAt
         |  }
@@ -76,7 +76,7 @@ class PaginationRegressionSpec extends FlatSpec with Matchers with ApiSpecBase {
     val page4 = server.query(
       """
         |{
-        |  findManyModelB(cursor: { id: "8c7a3864-285c-4f06-9c9a-273e19e19a05" }, skip: 1, take: 5, orderBy: { createdAt: DESC, id: ASC } ) {
+        |  findManyModelB(cursor: { id: "8c7a3864-285c-4f06-9c9a-273e19e19a05" }, skip: 1, take: 5, orderBy: [{ createdAt: desc}, { id: asc }] ) {
         |    id
         |    createdAt
         |  }

--- a/query-engine/connector-test-kit/src/test/scala/queries/orderAndPagination/PaginationSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/orderAndPagination/PaginationSpec.scala
@@ -819,7 +819,7 @@ class PaginationSpec extends FlatSpec with Matchers with ApiSpecBase {
       .query(
         """
           |query {
-          |  findManyTestModel(cursor: { id: 4 }, take: -3, skip: 1, orderBy: [{ fieldA: desc }, { fieldB: asc }, { fieldC: asc }, { fieldD: desc }) {
+          |  findManyTestModel(cursor: { id: 4 }, take: -3, skip: 1, orderBy: [{ fieldA: desc }, { fieldB: asc }, { fieldC: asc }, { fieldD: desc }]) {
           |    id
           |  }
           |}

--- a/query-engine/connector-test-kit/src/test/scala/queries/orderAndPagination/PaginationSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/orderAndPagination/PaginationSpec.scala
@@ -60,7 +60,7 @@ class PaginationSpec extends FlatSpec with Matchers with ApiSpecBase {
           |query {
           |  findManyTestModel(cursor: {
           |    id: 5
-          |  }, orderBy: { id: DESC }) {
+          |  }, orderBy: { id: desc }) {
           |    id
           |  }
           |}
@@ -81,7 +81,7 @@ class PaginationSpec extends FlatSpec with Matchers with ApiSpecBase {
           |query {
           |  findManyTestModel(cursor: {
           |    id: 5
-          |  }, orderBy: { field: DESC }) {
+          |  }, orderBy: { field: desc }) {
           |    id
           |    field
           |  }
@@ -104,7 +104,7 @@ class PaginationSpec extends FlatSpec with Matchers with ApiSpecBase {
           |query {
           |  findManyTestModel(cursor: {
           |    id: 5
-          |  }, orderBy: { field: ASC }) {
+          |  }, orderBy: { field: asc }) {
           |    id
           |    field
           |  }
@@ -144,7 +144,7 @@ class PaginationSpec extends FlatSpec with Matchers with ApiSpecBase {
           |query {
           |  findManyTestModel(cursor: {
           |    id: 1
-          |  }, orderBy: { id: DESC }) {
+          |  }, orderBy: { id: desc }) {
           |    id
           |  }
           |}
@@ -219,7 +219,7 @@ class PaginationSpec extends FlatSpec with Matchers with ApiSpecBase {
       .query(
         """
           |query {
-          |  findManyTestModel(take: 1, orderBy: { id: DESC }) {
+          |  findManyTestModel(take: 1, orderBy: { id: desc }) {
           |    id
           |  }
           |}
@@ -253,7 +253,7 @@ class PaginationSpec extends FlatSpec with Matchers with ApiSpecBase {
       .query(
         """
           |query {
-          |  findManyTestModel(take: -1, orderBy: { id: ASC }) {
+          |  findManyTestModel(take: -1, orderBy: { id: asc }) {
           |    id
           |  }
           |}
@@ -273,7 +273,7 @@ class PaginationSpec extends FlatSpec with Matchers with ApiSpecBase {
       .query(
         """
           |query {
-          |  findManyTestModel(skip: 5, orderBy: { id: ASC }) {
+          |  findManyTestModel(skip: 5, orderBy: { id: asc }) {
           |    id
           |  }
           |}
@@ -290,7 +290,7 @@ class PaginationSpec extends FlatSpec with Matchers with ApiSpecBase {
       .query(
         """
           |query {
-          |  findManyTestModel(skip: 5, orderBy: { id: DESC }) {
+          |  findManyTestModel(skip: 5, orderBy: { id: desc }) {
           |    id
           |  }
           |}
@@ -324,7 +324,7 @@ class PaginationSpec extends FlatSpec with Matchers with ApiSpecBase {
       .query(
         """
           |query {
-          |  findManyTestModel(skip: 0, orderBy: { id: ASC }) {
+          |  findManyTestModel(skip: 0, orderBy: { id: asc }) {
           |    id
           |  }
           |}
@@ -365,7 +365,7 @@ class PaginationSpec extends FlatSpec with Matchers with ApiSpecBase {
           |query {
           |  findManyTestModel(cursor: {
           |    id: 5
-          |  }, take: -2, orderBy: { id: ASC }) {
+          |  }, take: -2, orderBy: { id: asc }) {
           |    id
           |  }
           |}
@@ -441,7 +441,7 @@ class PaginationSpec extends FlatSpec with Matchers with ApiSpecBase {
           |query {
           |  findManyTestModel(cursor: {
           |    id: 5
-          |  }, take: 2, orderBy: { id: DESC }) {
+          |  }, take: 2, orderBy: { id: desc }) {
           |    id
           |  }
           |}
@@ -460,7 +460,7 @@ class PaginationSpec extends FlatSpec with Matchers with ApiSpecBase {
           |query {
           |  findManyTestModel(cursor: {
           |    id: 5
-          |  }, take: -2, orderBy: { id: DESC }) {
+          |  }, take: -2, orderBy: { id: desc }) {
           |    id
           |  }
           |}
@@ -501,7 +501,7 @@ class PaginationSpec extends FlatSpec with Matchers with ApiSpecBase {
           |query {
           |  findManyTestModel(cursor: {
           |    id: 5
-          |  }, take: -2, skip: 2, orderBy: { id: ASC }) {
+          |  }, take: -2, skip: 2, orderBy: { id: asc }) {
           |    id
           |  }
           |}
@@ -558,7 +558,7 @@ class PaginationSpec extends FlatSpec with Matchers with ApiSpecBase {
           |query {
           |  findManyTestModel(cursor: {
           |    id: 5
-          |  }, take: 2, skip: 2, orderBy: { id: DESC }) {
+          |  }, take: 2, skip: 2, orderBy: { id: desc }) {
           |    id
           |  }
           |}
@@ -577,7 +577,7 @@ class PaginationSpec extends FlatSpec with Matchers with ApiSpecBase {
           |query {
           |  findManyTestModel(cursor: {
           |    id: 5
-          |  }, take: -2, skip: 2, orderBy: { id: DESC }) {
+          |  }, take: -2, skip: 2, orderBy: { id: desc }) {
           |    id
           |  }
           |}
@@ -630,7 +630,7 @@ class PaginationSpec extends FlatSpec with Matchers with ApiSpecBase {
       .query(
         """
           |query {
-          |  findManyTestModel(cursor: { id: 4 }, take: 2, skip: 1, orderBy: { fieldA: DESC, fieldB: ASC, fieldC: ASC, fieldD: DESC }) {
+          |  findManyTestModel(cursor: { id: 4 }, take: 2, skip: 1, orderBy: [{ fieldA: desc }, { fieldB: asc }, { fieldC: asc }, { fieldD: desc }]) {
           |    id
           |  }
           |}
@@ -639,7 +639,7 @@ class PaginationSpec extends FlatSpec with Matchers with ApiSpecBase {
         legacy = false
       )
 
-    // Ordered: DESC, ASC, ASC, DESC
+    // Ordered: desc, ASC, ASC, DESC
     // 5 => C C B A
     // 6 => C C D C
     // 4 => B B B C <- cursor, skipped
@@ -653,7 +653,7 @@ class PaginationSpec extends FlatSpec with Matchers with ApiSpecBase {
       .query(
         """
           |query {
-          |  findManyTestModel(cursor: { id: 4 }, take: 2, skip: 1, orderBy: { fieldA: ASC, fieldB: DESC, fieldC: DESC, fieldD: ASC }) {
+          |  findManyTestModel(cursor: { id: 4 }, take: 2, skip: 1, orderBy: [{ fieldA: asc }, { fieldB: desc }, { fieldC: desc }, { fieldD: asc }]) {
           |    id
           |  }
           |}
@@ -662,7 +662,7 @@ class PaginationSpec extends FlatSpec with Matchers with ApiSpecBase {
         legacy = false
       )
 
-    // Ordered (reverse from test #1): ASC, DESC, DESC, ASC
+    // Ordered (reverse from test #1): asc, DESC, DESC, ASC
     // 1 => A B C D
     // 2 => A A A B
     // 3 => B B B B
@@ -678,7 +678,7 @@ class PaginationSpec extends FlatSpec with Matchers with ApiSpecBase {
       .query(
         """
           |query {
-          |  findManyTestModel(cursor: { id: 4 }, take: -2, skip: 1, orderBy: { fieldA: DESC, fieldB: ASC, fieldC: ASC, fieldD: DESC }) {
+          |  findManyTestModel(cursor: { id: 4 }, take: -2, skip: 1, orderBy: [{ fieldA: desc }, {fieldB: asc }, {fieldC: asc }, {fieldD: desc }]) {
           |    id
           |  }
           |}
@@ -687,7 +687,7 @@ class PaginationSpec extends FlatSpec with Matchers with ApiSpecBase {
         legacy = false
       )
 
-    // Originally the query orders: DESC, ASC, ASC, DESC. With -2 instead of 2, it wants to take:
+    // Originally the query orders: desc, ASC, ASC, DESC. With -2 instead of 2, it wants to take:
     // 5 => C C B A <- take
     // 6 => C C D C <- take
     // 4 => B B B C <- cursor, skipped
@@ -695,7 +695,7 @@ class PaginationSpec extends FlatSpec with Matchers with ApiSpecBase {
     // 2 => A A A B
     // 1 => A B C D
     //
-    // The connectors reverse this to (equivalent to test #2): ASC, DESC, DESC, ASC
+    // The connectors reverse this to (equivalent to test #2): asc, DESC, DESC, ASC
     // 1 => A B C D
     // 2 => A A A B
     // 3 => B B B B
@@ -743,7 +743,7 @@ class PaginationSpec extends FlatSpec with Matchers with ApiSpecBase {
       .query(
         """
           |query {
-          |  findManyTestModel(cursor: { id: 4 }, take: 3, skip: 1, orderBy: { fieldA: DESC, fieldB: ASC, fieldC: ASC, fieldD: DESC }) {
+          |  findManyTestModel(cursor: { id: 4 }, take: 3, skip: 1, orderBy: [{ fieldA: desc }, { fieldB: asc }, { fieldC: asc }, { fieldD: desc }]) {
           |    id
           |  }
           |}
@@ -752,7 +752,7 @@ class PaginationSpec extends FlatSpec with Matchers with ApiSpecBase {
         legacy = false
       )
 
-    // Ordered: DESC, ASC, ASC, DESC
+    // Ordered: desc, ASC, ASC, DESC
     // The order is at the discretion of the db, possible result options:
     // - 3 and 5 are included in the result: (3, 5, 2) | (5, 3, 2)
     // - Only 3 or only 5 are included in the result: (3, 2, 1) | (5, 2, 1)
@@ -780,7 +780,7 @@ class PaginationSpec extends FlatSpec with Matchers with ApiSpecBase {
       .query(
         """
           |query {
-          |  findManyTestModel(cursor: { id: 4 }, take: 3, skip: 1, orderBy: { fieldA: ASC, fieldB: DESC, fieldC: DESC, fieldD: ASC }) {
+          |  findManyTestModel(cursor: { id: 4 }, take: 3, skip: 1, orderBy: [{ fieldA: asc }, { fieldB: desc }, { fieldC: desc }, { fieldD: asc }]) {
           |    id
           |  }
           |}
@@ -789,7 +789,7 @@ class PaginationSpec extends FlatSpec with Matchers with ApiSpecBase {
         legacy = false
       )
 
-    // Ordered (reverse from test #1): ASC, DESC, DESC, ASC
+    // Ordered (reverse from test #1): asc, DESC, DESC, ASC
     // The order is at the discretion of the db, possible result options (cursor on 4):
     // - 3 and 5 are included in the result: (3, 5, 6) | (5, 3, 6)
     // - Only 3 or only 5 are included in the result: (3, 6) | (5, 6)
@@ -819,7 +819,7 @@ class PaginationSpec extends FlatSpec with Matchers with ApiSpecBase {
       .query(
         """
           |query {
-          |  findManyTestModel(cursor: { id: 4 }, take: -3, skip: 1, orderBy: { fieldA: DESC, fieldB: ASC, fieldC: ASC, fieldD: DESC }) {
+          |  findManyTestModel(cursor: { id: 4 }, take: -3, skip: 1, orderBy: [{ fieldA: desc }, { fieldB: asc }, { fieldC: asc }, { fieldD: desc }) {
           |    id
           |  }
           |}
@@ -828,7 +828,7 @@ class PaginationSpec extends FlatSpec with Matchers with ApiSpecBase {
         legacy = false
       )
 
-    // Originally the query orders: DESC, ASC, ASC, DESC (equivalent to test #1).
+    // Originally the query orders: desc, ASC, ASC, DESC (equivalent to test #1).
     // With -3 instead of 3, it wants to take (possibility):
     // 6 => C C D C <- take
     // 5 => B B B B <- take
@@ -837,7 +837,7 @@ class PaginationSpec extends FlatSpec with Matchers with ApiSpecBase {
     // 2 => A A A B
     // 1 => A B C D
     //
-    // The connectors reverse this to (equivalent to test #2): ASC, DESC, DESC, ASC
+    // The connectors reverse this to (equivalent to test #2): asc, DESC, DESC, ASC
     // 1 => A B C D
     // 2 => A A A B
     // 4 => B B B B <- cursor, skipped

--- a/query-engine/connector-test-kit/src/test/scala/queries/orderAndPagination/RelationFilterOrderingSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/orderAndPagination/RelationFilterOrderingSpec.scala
@@ -47,11 +47,11 @@ class RelationFilterOrderingSpec extends FlatSpec with Matchers with ApiSpecBase
       server.query(s"""mutation {createBlog(data: {title: "blog_1", score: 20,labels: {connect: {text: "x"}}}) {title}}""", project)
       server.query(s"""mutation {createBlog(data: {title: "blog_1", score: 30,labels: {connect: {text: "x"}}}) {title}}""", project)
 
-      val res1 = server.query("""query {blogs(take: 2, orderBy: { score: DESC }) {title, score}}""", project)
+      val res1 = server.query("""query {blogs(take: 2, orderBy: { score: desc }) {title, score}}""", project)
 
       res1.toString should be("""{"data":{"blogs":[{"title":"blog_1","score":30},{"title":"blog_1","score":20}]}}""")
 
-      val res2 = server.query("""query {blogs (take: 2, orderBy: { score: DESC }, where:{labels_some: {text: "x"}}) {title, score}}""", project)
+      val res2 = server.query("""query {blogs (take: 2, orderBy: { score: desc }, where:{labels_some: {text: "x"}}) {title, score}}""", project)
       res2.toString should be("""{"data":{"blogs":[{"title":"blog_1","score":30},{"title":"blog_1","score":20}]}}""")
 
     }

--- a/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/CombiningDifferentNestedMutationsSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/CombiningDifferentNestedMutationsSpec.scala
@@ -34,7 +34,7 @@ class CombiningDifferentNestedMutationsSpec extends FlatSpec with Matchers with 
         |      create: [{c: "c1"},{c: "c2"}]
         |    }
         |  }){
-        |    childrenOpt(orderBy: { c: ASC }){
+        |    childrenOpt(orderBy: { c: asc }){
         |       c
         |    }
         |  }
@@ -54,7 +54,7 @@ class CombiningDifferentNestedMutationsSpec extends FlatSpec with Matchers with 
         |    update: [{where: {c: "c3"} data: {c: "cUpdated"}}]
         |    }
         |  }){
-        |    childrenOpt(orderBy: { c: ASC }){
+        |    childrenOpt(orderBy: { c: asc }){
         |       c
         |    }
         |  }
@@ -66,7 +66,7 @@ class CombiningDifferentNestedMutationsSpec extends FlatSpec with Matchers with 
 
 //      // ifConnectorIsActive { dataResolver(project).countByTable("_ChildToParent").await should be(4) }
 
-      server.query(s"""query{children(orderBy: { c: ASC }){c, parentsOpt(orderBy: { p: ASC }){p}}}""", project).toString should be(
+      server.query(s"""query{children(orderBy: { c: asc }){c, parentsOpt(orderBy: { p: asc }){p}}}""", project).toString should be(
         """{"data":{"children":[{"c":"c1","parentsOpt":[{"p":"p1"}]},{"c":"c2","parentsOpt":[{"p":"p1"}]},{"c":"c4","parentsOpt":[{"p":"p1"}]},{"c":"cUpdated","parentsOpt":[{"p":"p1"}]}]}}""")
 
     }
@@ -193,7 +193,7 @@ class CombiningDifferentNestedMutationsSpec extends FlatSpec with Matchers with 
         |      create: [{c: "c1"},{c: "c2"}]
         |    }
         |  }){
-        |    childrenOpt(orderBy: { c: ASC }){
+        |    childrenOpt(orderBy: { c: asc }){
         |       c
         |    }
         |  }
@@ -219,7 +219,7 @@ class CombiningDifferentNestedMutationsSpec extends FlatSpec with Matchers with 
         |              ]
         |    }
         |  }){
-        |    childrenOpt(orderBy: { c: ASC }){
+        |    childrenOpt(orderBy: { c: asc }){
         |       c
         |    }
         |  }
@@ -231,7 +231,7 @@ class CombiningDifferentNestedMutationsSpec extends FlatSpec with Matchers with 
 
       // ifConnectorIsActive { dataResolver(project).countByTable("_ChildToParent").await should be(5) }
 
-      server.query(s"""query{children(orderBy: { c: ASC }){c, parentsOpt(orderBy: { p: ASC }){p}}}""", project).toString should be(
+      server.query(s"""query{children(orderBy: { c: asc }){c, parentsOpt(orderBy: { p: asc }){p}}}""", project).toString should be(
         """{"data":{"children":[{"c":"c1","parentsOpt":[{"p":"p1"}]},{"c":"c2","parentsOpt":[{"p":"p1"}]},{"c":"c4","parentsOpt":[{"p":"p1"}]},{"c":"cNew","parentsOpt":[{"p":"p1"}]},{"c":"cUpdated","parentsOpt":[{"p":"p1"}]}]}}""")
     }
   }

--- a/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/alreadyConverted/NestedConnectMutationInsideUpdateSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/alreadyConverted/NestedConnectMutationInsideUpdateSpec.scala
@@ -725,7 +725,7 @@ class NestedConnectMutationInsideUpdateSpec extends FlatSpec with Matchers with 
            |      childrenOpt: {connect: $child}
            |    }
            |  ){
-           |    childrenOpt(take:10, orderBy: { c: ASC }) {
+           |    childrenOpt(take:10, orderBy: { c: asc }) {
            |      c
            |    }
            |  }
@@ -1290,7 +1290,7 @@ class NestedConnectMutationInsideUpdateSpec extends FlatSpec with Matchers with 
            |  data:{
            |    childrenOpt: {connect: $children}
            |  }){
-           |    childrenOpt(orderBy: { c: ASC }){
+           |    childrenOpt(orderBy: { c: asc }){
            |      c
            |    }
            |  }

--- a/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/alreadyConverted/NestedDeleteMutationInsideUpdateSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/alreadyConverted/NestedDeleteMutationInsideUpdateSpec.scala
@@ -1405,9 +1405,9 @@ class NestedDeleteMutationInsideUpdateSpec extends FlatSpec with Matchers with A
          |   }
          |  ) {
          |    nameTop
-         |    middles (orderBy: { id: ASC }){
+         |    middles (orderBy: { id: asc }){
          |      nameMiddle
-         |      bottoms (orderBy: { id: ASC }){
+         |      bottoms (orderBy: { id: asc }){
          |        nameBottom
          |      }
          |    }
@@ -1484,7 +1484,7 @@ class NestedDeleteMutationInsideUpdateSpec extends FlatSpec with Matchers with A
          |   }
          |  ) {
          |    nameTop
-         |    middles (orderBy: { id: ASC }){
+         |    middles (orderBy: { id: asc }){
          |      nameMiddle
          |      bottoms {
          |        nameBottom
@@ -1562,7 +1562,7 @@ class NestedDeleteMutationInsideUpdateSpec extends FlatSpec with Matchers with A
          |   }
          |  ) {
          |    nameTop
-         |    middles (orderBy: { id: ASC }) {
+         |    middles (orderBy: { id: asc }) {
          |      nameMiddle
          |      bottom {
          |        nameBottom

--- a/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/alreadyConverted/NestedDeleteMutationInsideUpsertSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/alreadyConverted/NestedDeleteMutationInsideUpsertSpec.scala
@@ -1133,9 +1133,9 @@ class NestedDeleteMutationInsideUpsertSpec extends FlatSpec with Matchers with A
          |   }
          |  ) {
          |    nameTop
-         |    middles (orderBy: { id: ASC }){
+         |    middles (orderBy: { id: asc }){
          |      nameMiddle
-         |      bottoms (orderBy: { id: ASC }){
+         |      bottoms (orderBy: { id: asc }){
          |        nameBottom
          |      }
          |    }
@@ -1212,7 +1212,7 @@ class NestedDeleteMutationInsideUpsertSpec extends FlatSpec with Matchers with A
          |   }
          |  ) {
          |    nameTop
-         |    middles (orderBy: { id: ASC }){
+         |    middles (orderBy: { id: asc }){
          |      nameMiddle
          |      bottoms {
          |        nameBottom
@@ -1289,7 +1289,7 @@ class NestedDeleteMutationInsideUpsertSpec extends FlatSpec with Matchers with A
          |   }
          |  ) {
          |    nameTop
-         |    middles (orderBy: { id: ASC }) {
+         |    middles (orderBy: { id: asc }) {
          |      nameMiddle
          |      bottom {
          |        nameBottom

--- a/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/alreadyConverted/NestedDisconnectMutationInsideUpdateSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/alreadyConverted/NestedDisconnectMutationInsideUpdateSpec.scala
@@ -1064,9 +1064,9 @@ class NestedDisconnectMutationInsideUpdateSpec extends FlatSpec with Matchers wi
          |   }
          |  ) {
          |    nameTop
-         |    middles (orderBy: { id: ASC }){
+         |    middles (orderBy: { id: asc }){
          |      nameMiddle
-         |      bottoms (orderBy: { id: ASC }){
+         |      bottoms (orderBy: { id: asc }){
          |        nameBottom
          |      }
          |    }
@@ -1079,7 +1079,7 @@ class NestedDisconnectMutationInsideUpdateSpec extends FlatSpec with Matchers wi
     result.toString should be(
       """{"data":{"updateTop":{"nameTop":"updated top","middles":[{"nameMiddle":"updated middle","bottoms":[{"nameBottom":"the second bottom"}]},{"nameMiddle":"the second middle","bottoms":[{"nameBottom":"the third bottom"},{"nameBottom":"the fourth bottom"}]}]}}}""")
 
-    server.query("query{bottoms(orderBy: { id: ASC }){nameBottom}}", project).toString should be(
+    server.query("query{bottoms(orderBy: { id: asc }){nameBottom}}", project).toString should be(
       """{"data":{"bottoms":[{"nameBottom":"the bottom"},{"nameBottom":"the second bottom"},{"nameBottom":"the third bottom"},{"nameBottom":"the fourth bottom"}]}}""")
   }
 
@@ -1146,9 +1146,9 @@ class NestedDisconnectMutationInsideUpdateSpec extends FlatSpec with Matchers wi
          |   }
          |  ) {
          |    nameTop
-         |    middles (orderBy: { id: ASC }){
+         |    middles (orderBy: { id: asc }){
          |      nameMiddle
-         |      bottoms (orderBy: { id: ASC }){
+         |      bottoms (orderBy: { id: asc }){
          |        nameBottom
          |      }
          |    }
@@ -1161,7 +1161,7 @@ class NestedDisconnectMutationInsideUpdateSpec extends FlatSpec with Matchers wi
     result.toString should be(
       """{"data":{"updateTop":{"nameTop":"updated top","middles":[{"nameMiddle":"updated middle","bottoms":[{"nameBottom":"the second bottom"}]},{"nameMiddle":"the second middle","bottoms":[{"nameBottom":"the third bottom"},{"nameBottom":"the fourth bottom"}]}]}}}""")
 
-    server.query("query{bottoms(orderBy: { id: ASC }){nameBottom}}", project).toString should be(
+    server.query("query{bottoms(orderBy: { id: asc }){nameBottom}}", project).toString should be(
       """{"data":{"bottoms":[{"nameBottom":"the bottom"},{"nameBottom":"the second bottom"},{"nameBottom":"the third bottom"},{"nameBottom":"the fourth bottom"}]}}""")
   }
 
@@ -1226,7 +1226,7 @@ class NestedDisconnectMutationInsideUpdateSpec extends FlatSpec with Matchers wi
          |   }
          |  ) {
          |    nameTop
-         |    middles (orderBy: { id: ASC }) {
+         |    middles (orderBy: { id: asc }) {
          |      nameMiddle
          |      bottom {
          |        nameBottom
@@ -1317,7 +1317,7 @@ class NestedDisconnectMutationInsideUpdateSpec extends FlatSpec with Matchers wi
          |      nameMiddle
          |      bottom {
          |        nameBottom
-         |        below (orderBy: { id: ASC }){
+         |        below (orderBy: { id: asc }){
          |           nameBelow
          |        }
          |
@@ -1332,7 +1332,7 @@ class NestedDisconnectMutationInsideUpdateSpec extends FlatSpec with Matchers wi
     result.toString should be(
       """{"data":{"updateTop":{"nameTop":"updated top","middle":{"nameMiddle":"updated middle","bottom":{"nameBottom":"updated bottom","below":[{"nameBelow":"second below"}]}}}}}""")
 
-    server.query("query{belows(orderBy: { id: ASC }){nameBelow}}", project).toString should be(
+    server.query("query{belows(orderBy: { id: asc }){nameBelow}}", project).toString should be(
       """{"data":{"belows":[{"nameBelow":"below"},{"nameBelow":"second below"}]}}""")
   }
 

--- a/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/alreadyConverted/NestedDisconnectMutationInsideUpsertSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/alreadyConverted/NestedDisconnectMutationInsideUpsertSpec.scala
@@ -910,9 +910,9 @@ class NestedDisconnectMutationInsideUpsertSpec extends FlatSpec with Matchers wi
          |   }
          |  ) {
          |    nameTop
-         |    middles (orderBy: { id: ASC }){
+         |    middles (orderBy: { id: asc }){
          |      nameMiddle
-         |      bottoms (orderBy: { id: ASC }){
+         |      bottoms (orderBy: { id: asc }){
          |        nameBottom
          |      }
          |    }
@@ -925,7 +925,7 @@ class NestedDisconnectMutationInsideUpsertSpec extends FlatSpec with Matchers wi
     result.toString should be(
       """{"data":{"updateTop":{"nameTop":"updated top","middles":[{"nameMiddle":"updated middle","bottoms":[{"nameBottom":"the second bottom"}]},{"nameMiddle":"the second middle","bottoms":[{"nameBottom":"the third bottom"},{"nameBottom":"the fourth bottom"}]}]}}}""")
 
-    server.query("query{bottoms(orderBy: { id: ASC }){nameBottom}}", project).toString should be(
+    server.query("query{bottoms(orderBy: { id: asc }){nameBottom}}", project).toString should be(
       """{"data":{"bottoms":[{"nameBottom":"the bottom"},{"nameBottom":"the second bottom"},{"nameBottom":"the third bottom"},{"nameBottom":"the fourth bottom"}]}}""")
   }
 
@@ -992,9 +992,9 @@ class NestedDisconnectMutationInsideUpsertSpec extends FlatSpec with Matchers wi
          |   }
          |  ) {
          |    nameTop
-         |    middles  (orderBy: { id: ASC }){
+         |    middles  (orderBy: { id: asc }){
          |      nameMiddle
-         |      bottoms  (orderBy: { id: ASC }){
+         |      bottoms  (orderBy: { id: asc }){
          |        nameBottom
          |      }
          |    }
@@ -1007,7 +1007,7 @@ class NestedDisconnectMutationInsideUpsertSpec extends FlatSpec with Matchers wi
     result.toString should be(
       """{"data":{"updateTop":{"nameTop":"updated top","middles":[{"nameMiddle":"updated middle","bottoms":[{"nameBottom":"the second bottom"}]},{"nameMiddle":"the second middle","bottoms":[{"nameBottom":"the third bottom"},{"nameBottom":"the fourth bottom"}]}]}}}""")
 
-    server.query("query{bottoms (orderBy: { id: ASC }){nameBottom}}", project).toString should be(
+    server.query("query{bottoms (orderBy: { id: asc }){nameBottom}}", project).toString should be(
       """{"data":{"bottoms":[{"nameBottom":"the bottom"},{"nameBottom":"the second bottom"},{"nameBottom":"the third bottom"},{"nameBottom":"the fourth bottom"}]}}""")
   }
 
@@ -1072,7 +1072,7 @@ class NestedDisconnectMutationInsideUpsertSpec extends FlatSpec with Matchers wi
          |   }
          |  ) {
          |    nameTop
-         |    middles (orderBy: { id: ASC }) {
+         |    middles (orderBy: { id: asc }) {
          |      nameMiddle
          |      bottom {
          |        nameBottom
@@ -1161,7 +1161,7 @@ class NestedDisconnectMutationInsideUpsertSpec extends FlatSpec with Matchers wi
          |      nameMiddle
          |      bottom {
          |        nameBottom
-         |        below (orderBy: { id: ASC }){
+         |        below (orderBy: { id: asc }){
          |           nameBelow
          |        }
          |      }
@@ -1175,7 +1175,7 @@ class NestedDisconnectMutationInsideUpsertSpec extends FlatSpec with Matchers wi
     result.toString should be(
       """{"data":{"updateTop":{"nameTop":"updated top","middle":{"nameMiddle":"updated middle","bottom":{"nameBottom":"updated bottom","below":[{"nameBelow":"second below"}]}}}}}""")
 
-    server.query("query{belows (orderBy: { id: ASC }){nameBelow}}", project).toString should be(
+    server.query("query{belows (orderBy: { id: asc }){nameBelow}}", project).toString should be(
       """{"data":{"belows":[{"nameBelow":"below"},{"nameBelow":"second below"}]}}""")
   }
 

--- a/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/alreadyConverted/NestedSetMutationInsideUpdateSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/alreadyConverted/NestedSetMutationInsideUpdateSpec.scala
@@ -314,7 +314,7 @@ class NestedSetMutationInsideUpdateSpec extends FlatSpec with Matchers with ApiS
 
       res.toString should be("""{"data":{"updateParent":{"childrenOpt":[]}}}""")
 
-      server.query(s"""query{children(orderBy: { c: ASC }){c, parentsOpt{p}}}""", project).toString should be(
+      server.query(s"""query{children(orderBy: { c: asc }){c, parentsOpt{p}}}""", project).toString should be(
         """{"data":{"children":[{"c":"c1","parentsOpt":[{"p":"p1"}]},{"c":"c2","parentsOpt":[{"p":"p1"}]},{"c":"c3","parentsOpt":[]},{"c":"c4","parentsOpt":[]}]}}""")
 
     }

--- a/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/alreadyConverted/NestedUpdateManyMutationInsideUpdateSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/alreadyConverted/NestedUpdateManyMutationInsideUpdateSpec.scala
@@ -307,7 +307,7 @@ class NestedUpdateManyMutationInsideUpdateSpec extends FlatSpec with Matchers wi
          |    }
          |    ]}
          |  }){
-         |    childrenOpt (orderBy: { c: ASC }){
+         |    childrenOpt (orderBy: { c: asc }){
          |      c
          |      non_unique
          |    }
@@ -317,7 +317,7 @@ class NestedUpdateManyMutationInsideUpdateSpec extends FlatSpec with Matchers wi
         project
       )
 
-      server.query("query{parents{p,childrenOpt(orderBy: { c: ASC }){c, non_unique}}}", project).toString() should be(
+      server.query("query{parents{p,childrenOpt(orderBy: { c: asc }){c, non_unique}}}", project).toString() should be(
         """{"data":{"parents":[{"p":"p1","childrenOpt":[{"c":"c1","non_unique":"updated2"},{"c":"c2","non_unique":"updated1"}]},{"p":"p2","childrenOpt":[{"c":"c3","non_unique":null},{"c":"c4","non_unique":null}]}]}}""")
     }
   }

--- a/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/alreadyConverted/NestedUpsertMutationInsideUpdateSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/alreadyConverted/NestedUpsertMutationInsideUpdateSpec.scala
@@ -205,7 +205,7 @@ class NestedUpsertMutationInsideUpdateSpec extends FlatSpec with Matchers with A
          |    create :{c: "DOES NOT MATTER"}
          |    }]}
          |  }){
-         |    childrenOpt (orderBy: { c: ASC }){
+         |    childrenOpt (orderBy: { c: asc }){
          |      c
          |    }
          |  }
@@ -354,7 +354,7 @@ class NestedUpsertMutationInsideUpdateSpec extends FlatSpec with Matchers with A
         |    }
         |  ){
         |    id
-        |    comments (orderBy: { id: ASC }){ id }
+        |    comments (orderBy: { id: asc }){ id }
         |  }
         |}""",
       project
@@ -378,7 +378,7 @@ class NestedUpsertMutationInsideUpdateSpec extends FlatSpec with Matchers with A
          |      }
          |    }
          |  ){
-         |    comments (orderBy: { id: ASC }){
+         |    comments (orderBy: { id: asc }){
          |      text
          |    }
          |  }
@@ -801,9 +801,9 @@ class NestedUpsertMutationInsideUpdateSpec extends FlatSpec with Matchers with A
          |   }
          |  ) {
          |    nameTop
-         |    middles (orderBy: { id: ASC }){
+         |    middles (orderBy: { id: asc }){
          |      nameMiddle
-         |      bottoms (orderBy: { id: ASC }){
+         |      bottoms (orderBy: { id: asc }){
          |        nameBottom
          |      }
          |    }
@@ -816,7 +816,7 @@ class NestedUpsertMutationInsideUpdateSpec extends FlatSpec with Matchers with A
     result.toString should be(
       """{"data":{"updateTop":{"nameTop":"updated top","middles":[{"nameMiddle":"updated middle","bottoms":[{"nameBottom":"updated bottom"},{"nameBottom":"the second bottom"}]},{"nameMiddle":"the second middle","bottoms":[{"nameBottom":"the third bottom"},{"nameBottom":"the fourth bottom"}]}]}}}""")
 
-    server.query("query{bottoms(orderBy: { id: ASC }){nameBottom}}", project).toString should be(
+    server.query("query{bottoms(orderBy: { id: asc }){nameBottom}}", project).toString should be(
       """{"data":{"bottoms":[{"nameBottom":"updated bottom"},{"nameBottom":"the second bottom"},{"nameBottom":"the third bottom"},{"nameBottom":"the fourth bottom"}]}}""")
   }
 
@@ -888,9 +888,9 @@ class NestedUpsertMutationInsideUpdateSpec extends FlatSpec with Matchers with A
          |   }
          |  ) {
          |    nameTop
-         |    middles (orderBy: { id: ASC }) {
+         |    middles (orderBy: { id: asc }) {
          |      nameMiddle
-         |      bottoms (orderBy: { id: ASC }){
+         |      bottoms (orderBy: { id: asc }){
          |        nameBottom
          |      }
          |    }
@@ -903,7 +903,7 @@ class NestedUpsertMutationInsideUpdateSpec extends FlatSpec with Matchers with A
     result.toString should be(
       """{"data":{"updateTop":{"nameTop":"updated top","middles":[{"nameMiddle":"updated middle","bottoms":[{"nameBottom":"the bottom"},{"nameBottom":"the second bottom"},{"nameBottom":"created bottom"}]},{"nameMiddle":"the second middle","bottoms":[{"nameBottom":"the third bottom"},{"nameBottom":"the fourth bottom"}]}]}}}""")
 
-    server.query("query{bottoms(orderBy: { id: ASC }){nameBottom}}", project).toString should be(
+    server.query("query{bottoms(orderBy: { id: asc }){nameBottom}}", project).toString should be(
       """{"data":{"bottoms":[{"nameBottom":"the bottom"},{"nameBottom":"the second bottom"},{"nameBottom":"the third bottom"},{"nameBottom":"the fourth bottom"},{"nameBottom":"created bottom"}]}}""")
   }
 
@@ -973,9 +973,9 @@ class NestedUpsertMutationInsideUpdateSpec extends FlatSpec with Matchers with A
          |   }
          |  ) {
          |    nameTop
-         |    middles (orderBy: { id: ASC }){
+         |    middles (orderBy: { id: asc }){
          |      nameMiddle
-         |      bottoms (orderBy: { id: ASC }){
+         |      bottoms (orderBy: { id: asc }){
          |        nameBottom
          |      }
          |    }
@@ -988,7 +988,7 @@ class NestedUpsertMutationInsideUpdateSpec extends FlatSpec with Matchers with A
     result.toString should be(
       """{"data":{"updateTop":{"nameTop":"updated top","middles":[{"nameMiddle":"updated middle","bottoms":[{"nameBottom":"updated bottom"},{"nameBottom":"the second bottom"}]},{"nameMiddle":"the second middle","bottoms":[{"nameBottom":"the third bottom"},{"nameBottom":"the fourth bottom"}]}]}}}""")
 
-    server.query("query{bottoms(orderBy: { id: ASC }){nameBottom}}", project).toString should be(
+    server.query("query{bottoms(orderBy: { id: asc }){nameBottom}}", project).toString should be(
       """{"data":{"bottoms":[{"nameBottom":"updated bottom"},{"nameBottom":"the second bottom"},{"nameBottom":"the third bottom"},{"nameBottom":"the fourth bottom"}]}}""")
   }
 
@@ -1058,9 +1058,9 @@ class NestedUpsertMutationInsideUpdateSpec extends FlatSpec with Matchers with A
          |   }
          |  ) {
          |    nameTop
-         |    middles (orderBy: { id: ASC }){
+         |    middles (orderBy: { id: asc }){
          |      nameMiddle
-         |      bottoms (orderBy: { id: ASC }){
+         |      bottoms (orderBy: { id: asc }){
          |        nameBottom
          |      }
          |    }
@@ -1073,7 +1073,7 @@ class NestedUpsertMutationInsideUpdateSpec extends FlatSpec with Matchers with A
     result.toString should be(
       """{"data":{"updateTop":{"nameTop":"updated top","middles":[{"nameMiddle":"updated middle","bottoms":[{"nameBottom":"the bottom"},{"nameBottom":"the second bottom"},{"nameBottom":"created bottom"}]},{"nameMiddle":"the second middle","bottoms":[{"nameBottom":"the third bottom"},{"nameBottom":"the fourth bottom"}]}]}}}""")
 
-    server.query("query{bottoms(orderBy: { id: ASC }){nameBottom}}", project).toString should be(
+    server.query("query{bottoms(orderBy: { id: asc }){nameBottom}}", project).toString should be(
       """{"data":{"bottoms":[{"nameBottom":"the bottom"},{"nameBottom":"the second bottom"},{"nameBottom":"the third bottom"},{"nameBottom":"the fourth bottom"},{"nameBottom":"created bottom"}]}}""")
   }
 
@@ -1139,7 +1139,7 @@ class NestedUpsertMutationInsideUpdateSpec extends FlatSpec with Matchers with A
          |   }
          |  ) {
          |    nameTop
-         |    middles (orderBy: { id: ASC }){
+         |    middles (orderBy: { id: asc }){
          |      nameMiddle
          |      bottom {
          |        nameBottom
@@ -1154,7 +1154,7 @@ class NestedUpsertMutationInsideUpdateSpec extends FlatSpec with Matchers with A
     result.toString should be(
       """{"data":{"updateTop":{"nameTop":"updated top","middles":[{"nameMiddle":"updated middle","bottom":{"nameBottom":"updated bottom"}},{"nameMiddle":"the second middle","bottom":{"nameBottom":"the second bottom"}}]}}}""")
 
-    server.query("query{bottoms(orderBy: { id: ASC }){nameBottom}}", project).toString should be(
+    server.query("query{bottoms(orderBy: { id: asc }){nameBottom}}", project).toString should be(
       """{"data":{"bottoms":[{"nameBottom":"updated bottom"},{"nameBottom":"the second bottom"}]}}""")
   }
 
@@ -1220,7 +1220,7 @@ class NestedUpsertMutationInsideUpdateSpec extends FlatSpec with Matchers with A
          |   }
          |  ) {
          |    nameTop
-         |    middles (orderBy: { id: ASC }) {
+         |    middles (orderBy: { id: asc }) {
          |      nameMiddle
          |      bottom {
          |        nameBottom
@@ -1235,7 +1235,7 @@ class NestedUpsertMutationInsideUpdateSpec extends FlatSpec with Matchers with A
     result should be(
       """{"data":{"updateTop":{"nameTop":"updated top","middles":[{"nameMiddle":"updated middle","bottom":{"nameBottom":"created bottom"}},{"nameMiddle":"the second middle","bottom":{"nameBottom":"the second bottom"}}]}}}""".parseJson)
 
-    server.query("query{bottoms(orderBy: { id: ASC }){nameBottom}}", project) should be(
+    server.query("query{bottoms(orderBy: { id: asc }){nameBottom}}", project) should be(
       """{"data":{"bottoms":[{"nameBottom":"the second bottom"},{"nameBottom":"created bottom"}]}}""".parseJson)
   }
 
@@ -1314,7 +1314,7 @@ class NestedUpsertMutationInsideUpdateSpec extends FlatSpec with Matchers with A
          |      nameMiddle
          |      bottom {
          |        nameBottom
-         |        below (orderBy: { id: ASC }){
+         |        below (orderBy: { id: asc }){
          |           nameBelow
          |        }
          |      }
@@ -1328,7 +1328,7 @@ class NestedUpsertMutationInsideUpdateSpec extends FlatSpec with Matchers with A
     result.toString should be(
       """{"data":{"updateTop":{"nameTop":"updated top","middle":{"nameMiddle":"updated middle","bottom":{"nameBottom":"updated bottom","below":[{"nameBelow":"updated below"},{"nameBelow":"second below"}]}}}}}""")
 
-    server.query("query{belows(orderBy: { id: ASC }){nameBelow}}", project).toString should be(
+    server.query("query{belows(orderBy: { id: asc }){nameBelow}}", project).toString should be(
       """{"data":{"belows":[{"nameBelow":"updated below"},{"nameBelow":"second below"}]}}""")
   }
 
@@ -1422,7 +1422,7 @@ class NestedUpsertMutationInsideUpdateSpec extends FlatSpec with Matchers with A
     result.toString should be(
       """{"data":{"updateTop":{"nameTop":"updated top","middle":{"nameMiddle":"updated middle","bottom":{"nameBottom":"updated bottom","below":[{"nameBelow":"below"},{"nameBelow":"second below"},{"nameBelow":"created below"}]}}}}}""")
 
-    server.query("query{belows(orderBy: { id: ASC }){nameBelow}}", project).toString should be(
+    server.query("query{belows(orderBy: { id: asc }){nameBelow}}", project).toString should be(
       """{"data":{"belows":[{"nameBelow":"below"},{"nameBelow":"second below"},{"nameBelow":"created below"}]}}""")
   }
 

--- a/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/notUsingSchemaBase/NestedUpdateMutationInsideUpdateSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/notUsingSchemaBase/NestedUpdateMutationInsideUpdateSpec.scala
@@ -152,7 +152,7 @@ class NestedUpdateMutationInsideUpdateSpec extends FlatSpec with Matchers with A
            |        ]  
            |      }
            |  }){
-           |    childrenOpt (orderBy: { c: ASC } ){
+           |    childrenOpt (orderBy: { c: asc } ){
            |      non_unique
            |    }
            |  }
@@ -206,7 +206,7 @@ class NestedUpdateMutationInsideUpdateSpec extends FlatSpec with Matchers with A
            |        ]  
            |      }
            |  }){
-           |    childrenOpt (orderBy: { c: ASC } ){
+           |    childrenOpt (orderBy: { c: asc } ){
            |      non_unique
            |    }
            |  }
@@ -788,9 +788,9 @@ class NestedUpdateMutationInsideUpdateSpec extends FlatSpec with Matchers with A
          |   }
          |  ) {
          |    nameTop
-         |    middles (orderBy: { id: ASC }){
+         |    middles (orderBy: { id: asc }){
          |      nameMiddle
-         |      bottoms (orderBy: { id: ASC }){
+         |      bottoms (orderBy: { id: asc }){
          |        nameBottom
          |      }
          |    }
@@ -869,9 +869,9 @@ class NestedUpdateMutationInsideUpdateSpec extends FlatSpec with Matchers with A
          |   }
          |  ) {
          |    nameTop
-         |    middles  (orderBy: { id: ASC }) {
+         |    middles  (orderBy: { id: asc }) {
          |      nameMiddle
-         |      bottoms  (orderBy: { id: ASC }){
+         |      bottoms  (orderBy: { id: asc }){
          |        nameBottom
          |      }
          |    }
@@ -946,7 +946,7 @@ class NestedUpdateMutationInsideUpdateSpec extends FlatSpec with Matchers with A
          |   }
          |  ) {
          |    nameTop
-         |    middles (orderBy: { id: ASC }) {
+         |    middles (orderBy: { id: asc }) {
          |      nameMiddle
          |      bottom {
          |        nameBottom
@@ -1036,7 +1036,7 @@ class NestedUpdateMutationInsideUpdateSpec extends FlatSpec with Matchers with A
          |      nameMiddle
          |      bottom {
          |        nameBottom
-         |        below  (orderBy: { id: ASC }){
+         |        below  (orderBy: { id: asc }){
          |           nameBelow
          |        }
          |

--- a/query-engine/connector-test-kit/src/test/scala/writes/topLevelMutations/DefaultValueSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/topLevelMutations/DefaultValueSpec.scala
@@ -204,7 +204,7 @@ class DefaultValueSpec extends FlatSpec with Matchers with ApiSpecBase {
          |    where:{
          |      name_in: [Spiderman, Superman]
          |      }
-         |    orderBy: { age: ASC }
+         |    orderBy: { age: asc }
          |  ){
          |    name,
          |    age

--- a/query-engine/connector-test-kit/src/test/scala/writes/topLevelMutations/UpdateManySpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/topLevelMutations/UpdateManySpec.scala
@@ -40,7 +40,7 @@ class UpdateManySpec extends FlatSpec with Matchers with ApiSpecBase {
 
     val todoes = server.query(
       """{
-        |  todoes (orderBy: { id: ASC }) {
+        |  todoes (orderBy: { id: asc }) {
         |    title
         |    opt
         |  }

--- a/query-engine/connector-test-kit/src/test/scala/writes/uniquesAndNodeSelectors/NonEmbeddedSettingNodeSelectorToNullSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/uniquesAndNodeSelectors/NonEmbeddedSettingNodeSelectorToNullSpec.scala
@@ -80,7 +80,7 @@ class NonEmbeddedSettingNodeSelectorToNullSpec extends FlatSpec with Matchers wi
     val result = server.query(
       """
         |{
-        | as  (orderBy: { id: ASC }){
+        | as  (orderBy: { id: asc }){
         |   b
         |   c{
         |     c

--- a/query-engine/core/src/query_graph_builder/extractors/query_arguments.rs
+++ b/query-engine/core/src/query_graph_builder/extractors/query_arguments.rs
@@ -68,9 +68,13 @@ pub fn extract_query_args(arguments: Vec<ParsedArgument>, model: &ModelRef) -> Q
 /// Extracts order by conditions in order of appearance, as defined in
 fn extract_order_by(model: &ModelRef, value: ParsedInputValue) -> QueryGraphBuilderResult<Vec<OrderBy>> {
     match value {
-        ParsedInputValue::Map(map) => map
+        ParsedInputValue::List(list) => list
             .into_iter()
-            .map(|(field_name, sort_order)| {
+            .map(|list_value| {
+                let object: ParsedInputMap = list_value.try_into()?;
+                object.assert_size(1)?;
+
+                let (field_name, sort_order) = object.into_iter().next().unwrap();
                 let field = model.fields().find_from_scalar(&field_name)?;
                 let value: PrismaValue = sort_order.try_into()?;
                 let sort_order = match value.into_string().unwrap().to_lowercase().as_str() {

--- a/query-engine/core/src/schema/query_schema.rs
+++ b/query-engine/core/src/schema/query_schema.rs
@@ -272,6 +272,7 @@ pub struct Argument {
 
 pub struct InputObjectType {
     pub name: String,
+
     /// If true this means that _exactly_ one of the contained fields must be specified in an incoming query.
     /// This allows clients to handle this input type in a special way and ensure this invariant in a typesafe way.
     pub is_one_of: bool,
@@ -311,6 +312,10 @@ impl InputObjectType {
     {
         let name = name.into();
         self.get_fields().into_iter().find(|f| f.name == name).cloned()
+    }
+
+    pub fn set_one_of(&mut self, one_of: bool) {
+        self.is_one_of = one_of;
     }
 }
 

--- a/query-engine/core/src/schema_builder/arguments.rs
+++ b/query-engine/core/src/schema_builder/arguments.rs
@@ -129,5 +129,9 @@ pub(crate) fn many_records_arguments(ctx: &mut BuilderContext, model: &ModelRef)
 pub(crate) fn order_by_argument(ctx: &mut BuilderContext, model: &ModelRef) -> Argument {
     let object_type = input_types::order_by_object_type(ctx, model);
 
-    argument("orderBy", InputType::opt(InputType::object(object_type)), None)
+    argument(
+        "orderBy",
+        InputType::opt(InputType::list(InputType::object(object_type))),
+        None,
+    )
 }

--- a/query-engine/core/src/schema_builder/input_types/mod.rs
+++ b/query-engine/core/src/schema_builder/input_types/mod.rs
@@ -15,7 +15,10 @@ pub(crate) fn order_by_object_type(ctx: &mut BuilderContext, model: &ModelRef) -
 
     return_cached_input!(ctx, &name);
 
-    let input_object = Arc::new(init_input_object_type(name.clone()));
+    let mut input_object = init_input_object_type(name.clone());
+    input_object.set_one_of(true);
+
+    let input_object = Arc::new(input_object);
     ctx.cache_input_type(name, input_object.clone());
 
     let fields = model

--- a/query-engine/core/src/schema_builder/input_types/mod.rs
+++ b/query-engine/core/src/schema_builder/input_types/mod.rs
@@ -10,7 +10,7 @@ use prisma_models::{RelationFieldRef, ScalarFieldRef};
 
 /// Builds "<Model>OrderByInput" object types.
 pub(crate) fn order_by_object_type(ctx: &mut BuilderContext, model: &ModelRef) -> InputObjectTypeWeakRef {
-    let enum_type = Arc::new(string_enum_type("SortOrder", vec!["ASC".to_owned(), "DESC".to_owned()]));
+    let enum_type = Arc::new(string_enum_type("SortOrder", vec!["asc".to_owned(), "desc".to_owned()]));
     let name = format!("{}OrderByInput", model.name);
 
     return_cached_input!(ctx, &name);


### PR DESCRIPTION
Changelog:
- Changes input type of `orderBy` to `list(object(oneOf))`.
- Reintroduces guarantee that argument object with the same fields but different order can be batch optimized (will now again be batch optimized):
```
query {findOneX(where:{a_b: {a: "a", b: "b"}){ id }
query {findOneX(where:{a_b: {b: "b", a: "a"}){ id }
```
- Adds engine object validation for `oneOf`.