### PR TITLE
Refactor DMMF generation and schema building away from deep recursion

### DIFF
--- a/query-engine/core/Cargo.toml
+++ b/query-engine/core/Cargo.toml
@@ -28,7 +28,3 @@ tokio = {version = "=0.2.13"}
 tracing = "0.1"
 user-facing-errors = {path = "../../libs/user-facing-errors"}
 uuid = "0.8"
-
-# TODO: remove this
-[profile.release]
-debug = true

--- a/query-engine/core/Cargo.toml
+++ b/query-engine/core/Cargo.toml
@@ -28,3 +28,7 @@ tokio = {version = "=0.2.13"}
 tracing = "0.1"
 user-facing-errors = {path = "../../libs/user-facing-errors"}
 uuid = "0.8"
+
+# TODO: remove this
+[profile.release]
+debug = true

--- a/query-engine/core/src/schema/query_schema.rs
+++ b/query-engine/core/src/schema/query_schema.rs
@@ -298,7 +298,7 @@ impl InputObjectType {
     pub fn set_fields(&self, fields: Vec<InputField>) {
         self.fields
             .set(fields.into_iter().map(|f| Arc::new(f)).collect())
-            .unwrap();
+            .expect("InputObjectType::set_fields");
     }
 
     /// True if fields are empty, false otherwise.

--- a/query-engine/core/src/schema_builder/input_types/update_input_objects.rs
+++ b/query-engine/core/src/schema_builder/input_types/update_input_objects.rs
@@ -57,7 +57,7 @@ fn relation_input_fields_for_update(
     model
         .fields()
         .relation()
-        .iter()
+        .into_iter()
         .filter_map(|rf| {
             let related_model = rf.related_model();
             let related_field = rf.related_field();
@@ -84,22 +84,13 @@ fn relation_input_fields_for_update(
                         let input_object = Arc::new(init_input_object_type(input_name.clone()));
                         ctx.cache_input_type(input_name, input_object.clone());
 
-                        let mut fields = vec![input_fields::nested_create_input_field(ctx, rf)];
+                        // Enqueue the nested update input for its fields to be
+                        // created at a later point, to avoid recursing too deep
+                        // (that has caused stack overflows on large schemas in
+                        // the past).
+                        ctx.nested_update_inputs_queue
+                            .push((Arc::clone(&input_object), Arc::clone(&rf)));
 
-                        append_opt(&mut fields, input_fields::nested_connect_input_field(ctx, rf));
-                        append_opt(&mut fields, input_fields::nested_set_input_field(ctx, rf));
-                        append_opt(&mut fields, input_fields::nested_disconnect_input_field(ctx, rf));
-                        append_opt(&mut fields, input_fields::nested_delete_input_field(ctx, rf));
-                        fields.push(input_fields::nested_update_input_field(ctx, rf));
-                        append_opt(&mut fields, input_fields::nested_update_many_field(ctx, rf));
-                        append_opt(&mut fields, input_fields::nested_delete_many_field(ctx, rf));
-                        append_opt(&mut fields, input_fields::nested_upsert_field(ctx, rf));
-
-                        if feature_flags::get().connectOrCreate {
-                            append_opt(&mut fields, input_fields::nested_connect_or_create_field(ctx, rf));
-                        }
-
-                        input_object.set_fields(fields);
                         Arc::downgrade(&input_object)
                     }
                 };

--- a/query-engine/core/src/schema_builder/mod.rs
+++ b/query-engine/core/src/schema_builder/mod.rs
@@ -40,7 +40,7 @@ mod utils;
 use crate::schema::*;
 use cache::TypeRefCache;
 use datamodel_connector::ConnectorCapabilities;
-use prisma_models::{Field as ModelField, Index, InternalDataModelRef, ModelRef, TypeIdentifier};
+use prisma_models::{Field as ModelField, Index, InternalDataModelRef, ModelRef, RelationFieldRef, TypeIdentifier};
 use std::sync::Arc;
 
 pub use utils::*;
@@ -63,6 +63,8 @@ pub(crate) struct BuilderContext {
     enable_raw_queries: bool,
     cache: TypeCache,
     capabilities: ConnectorCapabilities,
+    nested_create_inputs_queue: NestedInputsQueue,
+    nested_update_inputs_queue: NestedInputsQueue,
 }
 
 impl BuilderContext {
@@ -78,6 +80,8 @@ impl BuilderContext {
             enable_raw_queries,
             cache: TypeCache::new(),
             capabilities,
+            nested_create_inputs_queue: Vec::new(),
+            nested_update_inputs_queue: Vec::new(),
         }
     }
 
@@ -164,3 +168,5 @@ pub fn build(
         ctx.internal_data_model,
     )
 }
+
+type NestedInputsQueue = Vec<(Arc<InputObjectType>, RelationFieldRef)>;

--- a/query-engine/core/src/schema_builder/utils.rs
+++ b/query-engine/core/src/schema_builder/utils.rs
@@ -132,7 +132,7 @@ where
 
 /// Appends an option of type T to a vector over T if the option is Some.
 pub fn append_opt<T>(vec: &mut Vec<T>, opt: Option<T>) {
-    opt.into_iter().for_each(|t| vec.push(t));
+    vec.extend(opt.into_iter())
 }
 
 /// Computes a compound field name based on an index.

--- a/query-engine/query-engine/src/dmmf/mod.rs
+++ b/query-engine/query-engine/src/dmmf/mod.rs
@@ -1,6 +1,5 @@
 mod schema;
 
-use datamodel;
 use query_core::schema::{QuerySchemaRef, QuerySchemaRenderer};
 use schema::*;
 use serde::{ser::SerializeMap, Serialize, Serializer};

--- a/query-engine/query-engine/src/dmmf/schema/ast.rs
+++ b/query-engine/query-engine/src/dmmf/schema/ast.rs
@@ -53,12 +53,6 @@ pub struct DMMFInputField {
     pub input_type: DMMFTypeInfo,
 }
 
-/// Intermediate type for generic field passing during serialization.
-pub enum DMMFFieldWrapper {
-    Input(DMMFInputField),
-    Output(DMMFField),
-}
-
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DMMFTypeInfo {

--- a/query-engine/query-engine/src/dmmf/schema/enum_renderer.rs
+++ b/query-engine/query-engine/src/dmmf/schema/enum_renderer.rs
@@ -21,7 +21,7 @@ impl Renderer for DMMFEnumRenderer {
     }
 }
 
-impl<'a> DMMFEnumRenderer {
+impl DMMFEnumRenderer {
     pub fn new(enum_type: &EnumType) -> DMMFEnumRenderer {
         DMMFEnumRenderer {
             enum_type: enum_type.clone(),

--- a/query-engine/query-engine/src/dmmf/schema/enum_renderer.rs
+++ b/query-engine/query-engine/src/dmmf/schema/enum_renderer.rs
@@ -1,10 +1,10 @@
 use super::*;
 
-pub struct DMMFEnumRenderer<'a> {
-    enum_type: &'a EnumType,
+pub struct DMMFEnumRenderer {
+    enum_type: EnumType,
 }
 
-impl<'a> Renderer<'a> for DMMFEnumRenderer<'a> {
+impl Renderer for DMMFEnumRenderer {
     fn render(&self, ctx: &mut RenderContext) {
         if ctx.already_rendered(self.enum_type.name()) {
             return;
@@ -21,13 +21,15 @@ impl<'a> Renderer<'a> for DMMFEnumRenderer<'a> {
     }
 }
 
-impl<'a> DMMFEnumRenderer<'a> {
-    pub fn new(enum_type: &'a EnumType) -> DMMFEnumRenderer<'a> {
-        DMMFEnumRenderer { enum_type }
+impl<'a> DMMFEnumRenderer {
+    pub fn new(enum_type: &EnumType) -> DMMFEnumRenderer {
+        DMMFEnumRenderer {
+            enum_type: enum_type.clone(),
+        }
     }
 
     fn format_enum_values(&self) -> Vec<String> {
-        match self.enum_type {
+        match &self.enum_type {
             EnumType::String(s) => s.values().to_owned(),
             EnumType::Internal(i) => i.external_values(),
             EnumType::FieldRef(f) => f.values(),

--- a/query-engine/query-engine/src/dmmf/schema/enum_renderer.rs
+++ b/query-engine/query-engine/src/dmmf/schema/enum_renderer.rs
@@ -4,7 +4,7 @@ pub struct DMMFEnumRenderer<'a> {
     enum_type: &'a EnumType,
 }
 
-impl<'a> Renderer<'a, ()> for DMMFEnumRenderer<'a> {
+impl<'a> Renderer<'a> for DMMFEnumRenderer<'a> {
     fn render(&self, ctx: &mut RenderContext) {
         if ctx.already_rendered(self.enum_type.name()) {
             return;

--- a/query-engine/query-engine/src/dmmf/schema/field_renderer.rs
+++ b/query-engine/query-engine/src/dmmf/schema/field_renderer.rs
@@ -1,55 +1,40 @@
-use super::*;
+use super::{DMMFArgument, DMMFField, DMMFInputField, IntoRenderer, RenderContext};
+use query_core::{Argument, FieldRef, InputFieldRef};
 
-#[derive(Debug)]
-pub enum DMMFFieldRenderer {
-    Input(InputFieldRef),
-    Output(FieldRef),
+pub(super) fn render_input_field(input_field: &InputFieldRef, ctx: &mut RenderContext) -> DMMFInputField {
+    let type_info = input_field.field_type.into_renderer().render(ctx);
+    let field = DMMFInputField {
+        name: input_field.name.clone(),
+        input_type: type_info,
+    };
+
+    field
 }
 
-impl<'a> Renderer<'a, DMMFFieldWrapper> for DMMFFieldRenderer {
-    fn render(&self, ctx: &mut RenderContext) -> DMMFFieldWrapper {
-        match self {
-            DMMFFieldRenderer::Input(input) => self.render_input_field(Arc::clone(input), ctx),
-            DMMFFieldRenderer::Output(output) => self.render_output_field(Arc::clone(output), ctx),
-        }
-    }
+pub(super) fn render_output_field(field: &FieldRef, ctx: &mut RenderContext) -> DMMFField {
+    let args = render_arguments(&field.arguments, ctx);
+    let output_type = field.field_type.into_renderer().render(ctx);
+    let output_field = DMMFField {
+        name: field.name.clone(),
+        args,
+        output_type,
+    };
+
+    ctx.add_mapping(field.name.clone(), field.query_builder.as_ref());
+
+    output_field
 }
 
-impl DMMFFieldRenderer {
-    fn render_input_field(&self, input_field: InputFieldRef, ctx: &mut RenderContext) -> DMMFFieldWrapper {
-        let type_info = input_field.field_type.into_renderer().render(ctx);
-        let field = DMMFInputField {
-            name: input_field.name.clone(),
-            input_type: type_info,
-        };
+fn render_arguments(args: &[Argument], ctx: &mut RenderContext) -> Vec<DMMFArgument> {
+    args.iter().map(|arg| render_argument(arg, ctx)).collect()
+}
 
-        DMMFFieldWrapper::Input(field)
-    }
+fn render_argument(arg: &Argument, ctx: &mut RenderContext) -> DMMFArgument {
+    let input_type = (&arg.argument_type).into_renderer().render(ctx);
+    let rendered_arg = DMMFArgument {
+        name: arg.name.clone(),
+        input_type,
+    };
 
-    fn render_output_field(&self, field: FieldRef, ctx: &mut RenderContext) -> DMMFFieldWrapper {
-        let args = self.render_arguments(&field.arguments, ctx);
-        let output_type = field.field_type.into_renderer().render(ctx);
-        let output_field = DMMFField {
-            name: field.name.clone(),
-            args,
-            output_type,
-        };
-
-        ctx.add_mapping(field.name.clone(), field.query_builder.as_ref());
-        DMMFFieldWrapper::Output(output_field)
-    }
-
-    fn render_arguments(&self, args: &[Argument], ctx: &mut RenderContext) -> Vec<DMMFArgument> {
-        args.iter().map(|arg| self.render_argument(arg, ctx)).collect()
-    }
-
-    fn render_argument(&self, arg: &Argument, ctx: &mut RenderContext) -> DMMFArgument {
-        let input_type = (&arg.argument_type).into_renderer().render(ctx);
-        let rendered_arg = DMMFArgument {
-            name: arg.name.clone(),
-            input_type,
-        };
-
-        rendered_arg
-    }
+    rendered_arg
 }

--- a/query-engine/query-engine/src/dmmf/schema/field_renderer.rs
+++ b/query-engine/query-engine/src/dmmf/schema/field_renderer.rs
@@ -1,8 +1,11 @@
-use super::{DMMFArgument, DMMFField, DMMFInputField, IntoRenderer, RenderContext};
+use super::{
+    type_renderer::{render_input_type, render_output_type},
+    DMMFArgument, DMMFField, DMMFInputField, RenderContext,
+};
 use query_core::{Argument, FieldRef, InputFieldRef};
 
 pub(super) fn render_input_field(input_field: &InputFieldRef, ctx: &mut RenderContext) -> DMMFInputField {
-    let type_info = input_field.field_type.into_renderer().render(ctx);
+    let type_info = render_input_type(&input_field.field_type, ctx);
     let field = DMMFInputField {
         name: input_field.name.clone(),
         input_type: type_info,
@@ -13,7 +16,7 @@ pub(super) fn render_input_field(input_field: &InputFieldRef, ctx: &mut RenderCo
 
 pub(super) fn render_output_field(field: &FieldRef, ctx: &mut RenderContext) -> DMMFField {
     let args = render_arguments(&field.arguments, ctx);
-    let output_type = field.field_type.into_renderer().render(ctx);
+    let output_type = render_output_type(&field.field_type, ctx);
     let output_field = DMMFField {
         name: field.name.clone(),
         args,
@@ -30,7 +33,7 @@ fn render_arguments(args: &[Argument], ctx: &mut RenderContext) -> Vec<DMMFArgum
 }
 
 fn render_argument(arg: &Argument, ctx: &mut RenderContext) -> DMMFArgument {
-    let input_type = (&arg.argument_type).into_renderer().render(ctx);
+    let input_type = render_input_type(&arg.argument_type, ctx);
     let rendered_arg = DMMFArgument {
         name: arg.name.clone(),
         input_type,

--- a/query-engine/query-engine/src/dmmf/schema/mod.rs
+++ b/query-engine/query-engine/src/dmmf/schema/mod.rs
@@ -117,18 +117,6 @@ impl<'a> IntoRenderer<'a, ()> for QuerySchemaRef {
     }
 }
 
-impl<'a> IntoRenderer<'a, DMMFTypeInfo> for OutputType {
-    fn into_renderer(&'a self) -> Box<dyn Renderer<'a, DMMFTypeInfo> + 'a> {
-        Box::new(DMMFTypeRenderer::Output(self))
-    }
-}
-
-impl<'a> IntoRenderer<'a, DMMFTypeInfo> for InputType {
-    fn into_renderer(&'a self) -> Box<dyn Renderer<'a, DMMFTypeInfo> + 'a> {
-        Box::new(DMMFTypeRenderer::Input(self))
-    }
-}
-
 impl<'a> IntoRenderer<'a, ()> for EnumType {
     fn into_renderer(&'a self) -> Box<dyn Renderer<'a, ()> + 'a> {
         Box::new(DMMFEnumRenderer::new(self))

--- a/query-engine/query-engine/src/dmmf/schema/mod.rs
+++ b/query-engine/query-engine/src/dmmf/schema/mod.rs
@@ -25,7 +25,15 @@ pub struct DMMFQuerySchemaRenderer;
 impl QuerySchemaRenderer<(DMMFSchema, Vec<DMMFMapping>)> for DMMFQuerySchemaRenderer {
     fn render(query_schema: QuerySchemaRef) -> (DMMFSchema, Vec<DMMFMapping>) {
         let mut ctx = RenderContext::new();
-        query_schema.into_renderer().render(&mut ctx);
+        ctx.mark_to_be_rendered(&query_schema);
+
+        while !ctx.next_pass.is_empty() {
+            let renderers = std::mem::replace(&mut ctx.next_pass, Vec::new());
+
+            for renderer in renderers {
+                renderer.render(&mut ctx)
+            }
+        }
 
         ctx.finalize()
     }
@@ -41,6 +49,10 @@ pub struct RenderContext {
     /// Prevents double rendering of elements that are referenced multiple times.
     /// Names of input / output types / enums / models are globally unique.
     rendered: HashSet<String>,
+
+    /// The child objects to render next. Rendering is considered complete when
+    /// this is empty.
+    next_pass: Vec<Box<dyn Renderer>>,
 }
 
 impl RenderContext {
@@ -49,6 +61,7 @@ impl RenderContext {
             schema: DMMFSchema::new(),
             mappings: vec![],
             rendered: HashSet::new(),
+            next_pass: Vec::new(),
         }
     }
 
@@ -101,36 +114,62 @@ impl RenderContext {
             };
         }
     }
+
+    fn mark_to_be_rendered(&mut self, into_renderer: &dyn IntoRenderer) {
+        if !into_renderer.is_already_rendered(self) {
+            let renderer: Box<dyn Renderer> = into_renderer.into_renderer();
+            self.next_pass.push(renderer)
+        }
+    }
 }
 
 pub trait Renderer {
     fn render(&self, ctx: &mut RenderContext);
 }
 
-trait IntoRenderer<'a> {
-    fn into_renderer(&'a self) -> Box<dyn Renderer>;
+trait IntoRenderer {
+    fn into_renderer(&self) -> Box<dyn Renderer>;
+
+    /// Returns whether the item still needs to be rendered.
+    fn is_already_rendered(&self, ctx: &RenderContext) -> bool;
 }
 
-impl<'a> IntoRenderer<'a> for QuerySchemaRef {
-    fn into_renderer(&'a self) -> Box<dyn Renderer> {
+impl IntoRenderer for QuerySchemaRef {
+    fn into_renderer(&self) -> Box<dyn Renderer> {
         Box::new(DMMFSchemaRenderer::new(Arc::clone(self)))
     }
+
+    fn is_already_rendered(&self, _ctx: &RenderContext) -> bool {
+        false
+    }
 }
 
-impl<'a> IntoRenderer<'a> for EnumType {
-    fn into_renderer(&'a self) -> Box<dyn Renderer> {
+impl<'a> IntoRenderer for &'a EnumType {
+    fn into_renderer(&self) -> Box<dyn Renderer> {
         Box::new(DMMFEnumRenderer::new(self))
     }
-}
 
-impl<'a> IntoRenderer<'a> for InputObjectTypeWeakRef {
-    fn into_renderer(&'a self) -> Box<dyn Renderer> {
-        Box::new(DMMFObjectRenderer::Input(Weak::clone(self)))
+    fn is_already_rendered(&self, ctx: &RenderContext) -> bool {
+        ctx.already_rendered(self.name())
     }
 }
 
-impl<'a> IntoRenderer<'a> for ObjectTypeWeakRef {
-    fn into_renderer(&'a self) -> Box<dyn Renderer> {
+impl IntoRenderer for InputObjectTypeWeakRef {
+    fn into_renderer(&self) -> Box<dyn Renderer> {
+        Box::new(DMMFObjectRenderer::Input(Weak::clone(self)))
+    }
+
+    fn is_already_rendered(&self, ctx: &RenderContext) -> bool {
+        ctx.already_rendered(&self.into_arc().name)
+    }
+}
+
+impl IntoRenderer for ObjectTypeWeakRef {
+    fn into_renderer(&self) -> Box<dyn Renderer> {
         Box::new(DMMFObjectRenderer::Output(Weak::clone(self)))
+    }
+
+    fn is_already_rendered(&self, ctx: &RenderContext) -> bool {
+        ctx.already_rendered(self.into_arc().name())
     }
 }

--- a/query-engine/query-engine/src/dmmf/schema/mod.rs
+++ b/query-engine/query-engine/src/dmmf/schema/mod.rs
@@ -103,34 +103,34 @@ impl RenderContext {
     }
 }
 
-pub trait Renderer<'a> {
+pub trait Renderer {
     fn render(&self, ctx: &mut RenderContext);
 }
 
 trait IntoRenderer<'a> {
-    fn into_renderer(&'a self) -> Box<dyn Renderer<'a> + 'a>;
+    fn into_renderer(&'a self) -> Box<dyn Renderer>;
 }
 
 impl<'a> IntoRenderer<'a> for QuerySchemaRef {
-    fn into_renderer(&'a self) -> Box<dyn Renderer<'a> + 'a> {
+    fn into_renderer(&'a self) -> Box<dyn Renderer> {
         Box::new(DMMFSchemaRenderer::new(Arc::clone(self)))
     }
 }
 
 impl<'a> IntoRenderer<'a> for EnumType {
-    fn into_renderer(&'a self) -> Box<dyn Renderer<'a> + 'a> {
+    fn into_renderer(&'a self) -> Box<dyn Renderer> {
         Box::new(DMMFEnumRenderer::new(self))
     }
 }
 
 impl<'a> IntoRenderer<'a> for InputObjectTypeWeakRef {
-    fn into_renderer(&'a self) -> Box<dyn Renderer<'a> + 'a> {
+    fn into_renderer(&'a self) -> Box<dyn Renderer> {
         Box::new(DMMFObjectRenderer::Input(Weak::clone(self)))
     }
 }
 
 impl<'a> IntoRenderer<'a> for ObjectTypeWeakRef {
-    fn into_renderer(&'a self) -> Box<dyn Renderer<'a> + 'a> {
+    fn into_renderer(&'a self) -> Box<dyn Renderer> {
         Box::new(DMMFObjectRenderer::Output(Weak::clone(self)))
     }
 }

--- a/query-engine/query-engine/src/dmmf/schema/mod.rs
+++ b/query-engine/query-engine/src/dmmf/schema/mod.rs
@@ -135,18 +135,6 @@ impl<'a> IntoRenderer<'a, ()> for EnumType {
     }
 }
 
-impl<'a> IntoRenderer<'a, DMMFFieldWrapper> for InputFieldRef {
-    fn into_renderer(&'a self) -> Box<dyn Renderer<'a, DMMFFieldWrapper> + 'a> {
-        Box::new(DMMFFieldRenderer::Input(Arc::clone(self)))
-    }
-}
-
-impl<'a> IntoRenderer<'a, DMMFFieldWrapper> for FieldRef {
-    fn into_renderer(&'a self) -> Box<dyn Renderer<'a, DMMFFieldWrapper> + 'a> {
-        Box::new(DMMFFieldRenderer::Output(Arc::clone(self)))
-    }
-}
-
 impl<'a> IntoRenderer<'a, ()> for InputObjectTypeWeakRef {
     fn into_renderer(&'a self) -> Box<dyn Renderer<'a, ()> + 'a> {
         Box::new(DMMFObjectRenderer::Input(Weak::clone(self)))

--- a/query-engine/query-engine/src/dmmf/schema/mod.rs
+++ b/query-engine/query-engine/src/dmmf/schema/mod.rs
@@ -103,34 +103,34 @@ impl RenderContext {
     }
 }
 
-pub trait Renderer<'a, T> {
-    fn render(&self, ctx: &mut RenderContext) -> T;
+pub trait Renderer<'a> {
+    fn render(&self, ctx: &mut RenderContext);
 }
 
-trait IntoRenderer<'a, T> {
-    fn into_renderer(&'a self) -> Box<dyn Renderer<'a, T> + 'a>;
+trait IntoRenderer<'a> {
+    fn into_renderer(&'a self) -> Box<dyn Renderer<'a> + 'a>;
 }
 
-impl<'a> IntoRenderer<'a, ()> for QuerySchemaRef {
-    fn into_renderer(&'a self) -> Box<dyn Renderer<'a, ()> + 'a> {
+impl<'a> IntoRenderer<'a> for QuerySchemaRef {
+    fn into_renderer(&'a self) -> Box<dyn Renderer<'a> + 'a> {
         Box::new(DMMFSchemaRenderer::new(Arc::clone(self)))
     }
 }
 
-impl<'a> IntoRenderer<'a, ()> for EnumType {
-    fn into_renderer(&'a self) -> Box<dyn Renderer<'a, ()> + 'a> {
+impl<'a> IntoRenderer<'a> for EnumType {
+    fn into_renderer(&'a self) -> Box<dyn Renderer<'a> + 'a> {
         Box::new(DMMFEnumRenderer::new(self))
     }
 }
 
-impl<'a> IntoRenderer<'a, ()> for InputObjectTypeWeakRef {
-    fn into_renderer(&'a self) -> Box<dyn Renderer<'a, ()> + 'a> {
+impl<'a> IntoRenderer<'a> for InputObjectTypeWeakRef {
+    fn into_renderer(&'a self) -> Box<dyn Renderer<'a> + 'a> {
         Box::new(DMMFObjectRenderer::Input(Weak::clone(self)))
     }
 }
 
-impl<'a> IntoRenderer<'a, ()> for ObjectTypeWeakRef {
-    fn into_renderer(&'a self) -> Box<dyn Renderer<'a, ()> + 'a> {
+impl<'a> IntoRenderer<'a> for ObjectTypeWeakRef {
+    fn into_renderer(&'a self) -> Box<dyn Renderer<'a> + 'a> {
         Box::new(DMMFObjectRenderer::Output(Weak::clone(self)))
     }
 }

--- a/query-engine/query-engine/src/dmmf/schema/object_renderer.rs
+++ b/query-engine/query-engine/src/dmmf/schema/object_renderer.rs
@@ -6,7 +6,7 @@ pub enum DMMFObjectRenderer {
     Output(ObjectTypeWeakRef),
 }
 
-impl<'a> Renderer<'a, ()> for DMMFObjectRenderer {
+impl<'a> Renderer<'a> for DMMFObjectRenderer {
     fn render(&self, ctx: &mut RenderContext) {
         match &self {
             DMMFObjectRenderer::Input(input) => self.render_input_object(input, ctx),

--- a/query-engine/query-engine/src/dmmf/schema/object_renderer.rs
+++ b/query-engine/query-engine/src/dmmf/schema/object_renderer.rs
@@ -29,11 +29,7 @@ impl DMMFObjectRenderer {
         let mut rendered_fields = Vec::with_capacity(fields.len());
 
         for field in fields {
-            let rendered_field = field.into_renderer().render(ctx);
-            match rendered_field {
-                DMMFFieldWrapper::Input(f) => rendered_fields.push(f),
-                _ => unreachable!(),
-            };
+            rendered_fields.push(render_input_field(&field, ctx));
         }
 
         let input_type = DMMFInputType {
@@ -59,12 +55,7 @@ impl DMMFObjectRenderer {
         let mut rendered_fields: Vec<DMMFField> = Vec::with_capacity(fields.len());
 
         for field in fields {
-            let rendered_field = field.into_renderer().render(ctx);
-
-            match rendered_field {
-                DMMFFieldWrapper::Output(f) => rendered_fields.push(f),
-                _ => unreachable!(),
-            }
+            rendered_fields.push(render_output_field(&field, ctx))
         }
 
         let output_type = DMMFOutputType {

--- a/query-engine/query-engine/src/dmmf/schema/object_renderer.rs
+++ b/query-engine/query-engine/src/dmmf/schema/object_renderer.rs
@@ -18,12 +18,13 @@ impl Renderer for DMMFObjectRenderer {
 impl DMMFObjectRenderer {
     fn render_input_object(&self, input_object: &InputObjectTypeWeakRef, ctx: &mut RenderContext) {
         let input_object = input_object.into_arc();
+
         if ctx.already_rendered(&input_object.name) {
             return;
-        } else {
-            // This short circuits recursive processing for fields.
-            ctx.mark_as_rendered(input_object.name.clone())
         }
+
+        // This will prevent the type and its fields to be re-rendered.
+        ctx.mark_as_rendered(input_object.name.clone());
 
         let fields = input_object.get_fields();
         let mut rendered_fields = Vec::with_capacity(fields.len());
@@ -44,12 +45,13 @@ impl DMMFObjectRenderer {
     // WIP dedup code
     fn render_output_object(&self, output_object: &ObjectTypeWeakRef, ctx: &mut RenderContext) {
         let output_object = output_object.into_arc();
-        if ctx.already_rendered(output_object.name()) {
+
+        if ctx.already_rendered(&output_object.name()) {
             return;
-        } else {
-            // This short circuits recursive processing for fields.
-            ctx.mark_as_rendered(output_object.name().to_string())
         }
+
+        // This will prevent the type and its fields to be re-rendered.
+        ctx.mark_as_rendered(output_object.name().to_owned());
 
         let fields = output_object.get_fields();
         let mut rendered_fields: Vec<DMMFField> = Vec::with_capacity(fields.len());

--- a/query-engine/query-engine/src/dmmf/schema/object_renderer.rs
+++ b/query-engine/query-engine/src/dmmf/schema/object_renderer.rs
@@ -6,7 +6,7 @@ pub enum DMMFObjectRenderer {
     Output(ObjectTypeWeakRef),
 }
 
-impl<'a> Renderer<'a> for DMMFObjectRenderer {
+impl Renderer for DMMFObjectRenderer {
     fn render(&self, ctx: &mut RenderContext) {
         match &self {
             DMMFObjectRenderer::Input(input) => self.render_input_object(input, ctx),

--- a/query-engine/query-engine/src/dmmf/schema/schema_renderer.rs
+++ b/query-engine/query-engine/src/dmmf/schema/schema_renderer.rs
@@ -6,8 +6,8 @@ pub struct DMMFSchemaRenderer {
 
 impl<'a> Renderer<'a, ()> for DMMFSchemaRenderer {
     fn render(&self, ctx: &mut RenderContext) {
-        self.query_schema.query.into_renderer().render(ctx);
-        self.query_schema.mutation.into_renderer().render(ctx);
+        render_output_type(&self.query_schema.query, ctx);
+        render_output_type(&self.query_schema.mutation, ctx);
     }
 }
 

--- a/query-engine/query-engine/src/dmmf/schema/schema_renderer.rs
+++ b/query-engine/query-engine/src/dmmf/schema/schema_renderer.rs
@@ -4,7 +4,7 @@ pub struct DMMFSchemaRenderer {
     query_schema: QuerySchemaRef,
 }
 
-impl<'a> Renderer<'a> for DMMFSchemaRenderer {
+impl Renderer for DMMFSchemaRenderer {
     fn render(&self, ctx: &mut RenderContext) {
         render_output_type(&self.query_schema.query, ctx);
         render_output_type(&self.query_schema.mutation, ctx);

--- a/query-engine/query-engine/src/dmmf/schema/schema_renderer.rs
+++ b/query-engine/query-engine/src/dmmf/schema/schema_renderer.rs
@@ -4,7 +4,7 @@ pub struct DMMFSchemaRenderer {
     query_schema: QuerySchemaRef,
 }
 
-impl<'a> Renderer<'a, ()> for DMMFSchemaRenderer {
+impl<'a> Renderer<'a> for DMMFSchemaRenderer {
     fn render(&self, ctx: &mut RenderContext) {
         render_output_type(&self.query_schema.query, ctx);
         render_output_type(&self.query_schema.mutation, ctx);

--- a/query-engine/query-engine/src/dmmf/schema/type_renderer.rs
+++ b/query-engine/query-engine/src/dmmf/schema/type_renderer.rs
@@ -1,183 +1,167 @@
-use super::*;
+use super::{DMMFTypeInfo, IntoRenderer, RenderContext, TypeKind};
+use query_core::{InputType, IntoArc, OutputType, ScalarType};
 
-#[derive(Debug)]
-pub enum DMMFTypeRenderer<'a> {
-    Input(&'a InputType),
-    Output(&'a OutputType),
-}
+// WIP dedup code
+pub(super) fn render_output_type(output_type: &OutputType, ctx: &mut RenderContext) -> DMMFTypeInfo {
+    match output_type {
+        OutputType::Object(ref obj) => {
+            obj.into_renderer().render(ctx);
+            let type_info = DMMFTypeInfo {
+                typ: obj.into_arc().name().to_string(),
+                kind: TypeKind::Object,
+                is_required: true,
+                is_list: false,
+                is_nullable: false,
+            };
 
-impl<'a> Renderer<'a, DMMFTypeInfo> for DMMFTypeRenderer<'a> {
-    fn render(&self, ctx: &mut RenderContext) -> DMMFTypeInfo {
-        match self {
-            DMMFTypeRenderer::Input(i) => self.render_input_type(i, ctx),
-            DMMFTypeRenderer::Output(o) => self.render_output_type(o, ctx),
+            type_info
+        }
+        OutputType::Enum(et) => {
+            et.into_renderer().render(ctx);
+            let type_info = DMMFTypeInfo {
+                typ: et.name().to_owned(),
+                kind: TypeKind::Enum,
+                is_required: true,
+                is_list: false,
+                is_nullable: false,
+            };
+
+            type_info
+        }
+        OutputType::List(ref l) => {
+            let mut type_info = render_output_type(l, ctx);
+            type_info.is_list = true;
+
+            type_info
+        }
+        OutputType::Opt(ref opt) => {
+            let mut type_info = render_output_type(opt, ctx);
+            type_info.is_required = false;
+
+            type_info
+        }
+        OutputType::Scalar(ScalarType::Enum(et)) => {
+            et.into_renderer().render(ctx);
+            let type_info = DMMFTypeInfo {
+                typ: et.name().to_owned(),
+                kind: TypeKind::Scalar,
+                is_required: true,
+                is_list: false,
+                is_nullable: false,
+            };
+
+            type_info
+        }
+        OutputType::Scalar(ref scalar) => {
+            let stringified = match scalar {
+                ScalarType::String => "String",
+                ScalarType::Int => "Int",
+                ScalarType::Boolean => "Boolean",
+                ScalarType::Float => "Float",
+                ScalarType::DateTime => "DateTime",
+                ScalarType::Json => "Json",
+                ScalarType::UUID => "UUID",
+                ScalarType::JsonList => "Json",
+                ScalarType::Enum(_) => unreachable!(), // Handled separately above.
+            };
+
+            let type_info = DMMFTypeInfo {
+                typ: stringified.into(),
+                kind: TypeKind::Scalar,
+                is_required: true,
+                is_list: false,
+                is_nullable: false,
+            };
+
+            type_info
         }
     }
 }
 
-impl<'a> DMMFTypeRenderer<'a> {
-    fn render_input_type(&self, i: &InputType, ctx: &mut RenderContext) -> DMMFTypeInfo {
-        match i {
-            InputType::Object(ref obj) => {
-                obj.into_renderer().render(ctx);
-                let type_info = DMMFTypeInfo {
-                    typ: obj.into_arc().name.clone(),
-                    kind: TypeKind::Object,
-                    is_required: true,
-                    is_list: false,
-                    is_nullable: false,
-                };
+pub(super) fn render_input_type(input_type: &InputType, ctx: &mut RenderContext) -> DMMFTypeInfo {
+    match input_type {
+        InputType::Object(ref obj) => {
+            obj.into_renderer().render(ctx);
+            let type_info = DMMFTypeInfo {
+                typ: obj.into_arc().name.clone(),
+                kind: TypeKind::Object,
+                is_required: true,
+                is_list: false,
+                is_nullable: false,
+            };
 
-                type_info
-            }
-
-            InputType::Enum(et) => {
-                et.into_renderer().render(ctx);
-                let type_info = DMMFTypeInfo {
-                    typ: et.name().to_owned(),
-                    kind: TypeKind::Enum,
-                    is_required: true,
-                    is_list: false,
-                    is_nullable: false,
-                };
-
-                type_info
-            }
-
-            InputType::List(ref l) => {
-                let mut type_info = self.render_input_type(l, ctx);
-                type_info.is_list = true;
-
-                type_info
-            }
-
-            InputType::Opt(ref inner) => {
-                let mut type_info = self.render_input_type(inner, ctx);
-                type_info.is_required = false;
-
-                type_info
-            }
-
-            InputType::Null(ref inner) => {
-                let mut type_info = self.render_input_type(inner, ctx);
-                type_info.is_nullable = true;
-
-                type_info
-            }
-
-            InputType::Scalar(ScalarType::Enum(et)) => {
-                et.into_renderer().render(ctx);
-                let type_info = DMMFTypeInfo {
-                    typ: et.name().to_owned(),
-                    kind: TypeKind::Scalar,
-                    is_required: true,
-                    is_list: false,
-                    is_nullable: false,
-                };
-
-                type_info
-            }
-
-            InputType::Scalar(ref scalar) => {
-                let stringified = match scalar {
-                    ScalarType::String => "String",
-                    ScalarType::Int => "Int",
-                    ScalarType::Boolean => "Boolean",
-                    ScalarType::Float => "Float",
-                    ScalarType::DateTime => "DateTime",
-                    ScalarType::Json => "Json",
-                    ScalarType::UUID => "UUID",
-                    ScalarType::JsonList => "Json",
-                    ScalarType::Enum(_) => unreachable!(), // Handled separately above.
-                };
-
-                let type_info = DMMFTypeInfo {
-                    typ: stringified.into(),
-                    kind: TypeKind::Scalar,
-                    is_required: true,
-                    is_list: false,
-                    is_nullable: false,
-                };
-
-                type_info
-            }
+            type_info
         }
-    }
 
-    // WIP dedup code
-    fn render_output_type(&self, o: &OutputType, ctx: &mut RenderContext) -> DMMFTypeInfo {
-        match o {
-            OutputType::Object(ref obj) => {
-                obj.into_renderer().render(ctx);
-                let type_info = DMMFTypeInfo {
-                    typ: obj.into_arc().name().to_string(),
-                    kind: TypeKind::Object,
-                    is_required: true,
-                    is_list: false,
-                    is_nullable: false,
-                };
+        InputType::Enum(et) => {
+            et.into_renderer().render(ctx);
+            let type_info = DMMFTypeInfo {
+                typ: et.name().to_owned(),
+                kind: TypeKind::Enum,
+                is_required: true,
+                is_list: false,
+                is_nullable: false,
+            };
 
-                type_info
-            }
-            OutputType::Enum(et) => {
-                et.into_renderer().render(ctx);
-                let type_info = DMMFTypeInfo {
-                    typ: et.name().to_owned(),
-                    kind: TypeKind::Enum,
-                    is_required: true,
-                    is_list: false,
-                    is_nullable: false,
-                };
+            type_info
+        }
 
-                type_info
-            }
-            OutputType::List(ref l) => {
-                let mut type_info = self.render_output_type(l, ctx);
-                type_info.is_list = true;
+        InputType::List(ref l) => {
+            let mut type_info = render_input_type(l, ctx);
+            type_info.is_list = true;
 
-                type_info
-            }
-            OutputType::Opt(ref opt) => {
-                let mut type_info = self.render_output_type(opt, ctx);
-                type_info.is_required = false;
+            type_info
+        }
 
-                type_info
-            }
-            OutputType::Scalar(ScalarType::Enum(et)) => {
-                et.into_renderer().render(ctx);
-                let type_info = DMMFTypeInfo {
-                    typ: et.name().to_owned(),
-                    kind: TypeKind::Scalar,
-                    is_required: true,
-                    is_list: false,
-                    is_nullable: false,
-                };
+        InputType::Opt(ref inner) => {
+            let mut type_info = render_input_type(inner, ctx);
+            type_info.is_required = false;
 
-                type_info
-            }
-            OutputType::Scalar(ref scalar) => {
-                let stringified = match scalar {
-                    ScalarType::String => "String",
-                    ScalarType::Int => "Int",
-                    ScalarType::Boolean => "Boolean",
-                    ScalarType::Float => "Float",
-                    ScalarType::DateTime => "DateTime",
-                    ScalarType::Json => "Json",
-                    ScalarType::UUID => "UUID",
-                    ScalarType::JsonList => "Json",
-                    ScalarType::Enum(_) => unreachable!(), // Handled separately above.
-                };
+            type_info
+        }
 
-                let type_info = DMMFTypeInfo {
-                    typ: stringified.into(),
-                    kind: TypeKind::Scalar,
-                    is_required: true,
-                    is_list: false,
-                    is_nullable: false,
-                };
+        InputType::Null(ref inner) => {
+            let mut type_info = render_input_type(inner, ctx);
+            type_info.is_nullable = true;
 
-                type_info
-            }
+            type_info
+        }
+
+        InputType::Scalar(ScalarType::Enum(et)) => {
+            et.into_renderer().render(ctx);
+            let type_info = DMMFTypeInfo {
+                typ: et.name().to_owned(),
+                kind: TypeKind::Scalar,
+                is_required: true,
+                is_list: false,
+                is_nullable: false,
+            };
+
+            type_info
+        }
+
+        InputType::Scalar(ref scalar) => {
+            let stringified = match scalar {
+                ScalarType::String => "String",
+                ScalarType::Int => "Int",
+                ScalarType::Boolean => "Boolean",
+                ScalarType::Float => "Float",
+                ScalarType::DateTime => "DateTime",
+                ScalarType::Json => "Json",
+                ScalarType::UUID => "UUID",
+                ScalarType::JsonList => "Json",
+                ScalarType::Enum(_) => unreachable!(), // Handled separately above.
+            };
+
+            let type_info = DMMFTypeInfo {
+                typ: stringified.into(),
+                kind: TypeKind::Scalar,
+                is_required: true,
+                is_list: false,
+                is_nullable: false,
+            };
+
+            type_info
         }
     }
 }

--- a/query-engine/query-engine/src/dmmf/schema/type_renderer.rs
+++ b/query-engine/query-engine/src/dmmf/schema/type_renderer.rs
@@ -1,11 +1,11 @@
-use super::{DMMFTypeInfo, IntoRenderer, RenderContext, TypeKind};
+use super::{DMMFTypeInfo, RenderContext, TypeKind};
 use query_core::{InputType, IntoArc, OutputType, ScalarType};
 
 // WIP dedup code
 pub(super) fn render_output_type(output_type: &OutputType, ctx: &mut RenderContext) -> DMMFTypeInfo {
     match output_type {
         OutputType::Object(ref obj) => {
-            obj.into_renderer().render(ctx);
+            ctx.mark_to_be_rendered(obj);
             let type_info = DMMFTypeInfo {
                 typ: obj.into_arc().name().to_string(),
                 kind: TypeKind::Object,
@@ -17,7 +17,7 @@ pub(super) fn render_output_type(output_type: &OutputType, ctx: &mut RenderConte
             type_info
         }
         OutputType::Enum(et) => {
-            et.into_renderer().render(ctx);
+            ctx.mark_to_be_rendered(&et.as_ref());
             let type_info = DMMFTypeInfo {
                 typ: et.name().to_owned(),
                 kind: TypeKind::Enum,
@@ -41,7 +41,7 @@ pub(super) fn render_output_type(output_type: &OutputType, ctx: &mut RenderConte
             type_info
         }
         OutputType::Scalar(ScalarType::Enum(et)) => {
-            et.into_renderer().render(ctx);
+            ctx.mark_to_be_rendered(&et.as_ref());
             let type_info = DMMFTypeInfo {
                 typ: et.name().to_owned(),
                 kind: TypeKind::Scalar,
@@ -81,7 +81,7 @@ pub(super) fn render_output_type(output_type: &OutputType, ctx: &mut RenderConte
 pub(super) fn render_input_type(input_type: &InputType, ctx: &mut RenderContext) -> DMMFTypeInfo {
     match input_type {
         InputType::Object(ref obj) => {
-            obj.into_renderer().render(ctx);
+            ctx.mark_to_be_rendered(obj);
             let type_info = DMMFTypeInfo {
                 typ: obj.into_arc().name.clone(),
                 kind: TypeKind::Object,
@@ -94,7 +94,7 @@ pub(super) fn render_input_type(input_type: &InputType, ctx: &mut RenderContext)
         }
 
         InputType::Enum(et) => {
-            et.into_renderer().render(ctx);
+            ctx.mark_to_be_rendered(&et.as_ref());
             let type_info = DMMFTypeInfo {
                 typ: et.name().to_owned(),
                 kind: TypeKind::Enum,
@@ -128,7 +128,7 @@ pub(super) fn render_input_type(input_type: &InputType, ctx: &mut RenderContext)
         }
 
         InputType::Scalar(ScalarType::Enum(et)) => {
-            et.into_renderer().render(ctx);
+            ctx.mark_to_be_rendered(&et.as_ref());
             let type_info = DMMFTypeInfo {
                 typ: et.name().to_owned(),
                 kind: TypeKind::Scalar,

--- a/query-engine/query-engine/src/request_handlers/graphql/schema_renderer/enum_renderer.rs
+++ b/query-engine/query-engine/src/request_handlers/graphql/schema_renderer/enum_renderer.rs
@@ -5,16 +5,16 @@ pub struct GqlEnumRenderer<'a> {
 }
 
 impl<'a> Renderer for GqlEnumRenderer<'a> {
-    fn render(&self, ctx: RenderContext) -> (String, RenderContext) {
+    fn render(&self, ctx: &mut RenderContext) -> String {
         if ctx.already_rendered(self.enum_type.name()) {
-            return ("".to_owned(), ctx);
+            return "".to_owned();
         }
 
         let values = self.format_enum_values();
         let rendered = format!("enum {} {{\n{}\n}}", self.enum_type.name(), values.join("\n"));
 
         ctx.add(self.enum_type.name().to_owned(), rendered.clone());
-        (rendered, ctx)
+        rendered
     }
 }
 

--- a/query-engine/query-engine/src/request_handlers/graphql/schema_renderer/field_renderer.rs
+++ b/query-engine/query-engine/src/request_handlers/graphql/schema_renderer/field_renderer.rs
@@ -7,7 +7,7 @@ pub enum GqlFieldRenderer {
 }
 
 impl Renderer for GqlFieldRenderer {
-    fn render(&self, ctx: RenderContext) -> (String, RenderContext) {
+    fn render(&self, ctx: &mut RenderContext) -> String {
         match self {
             GqlFieldRenderer::Input(input) => self.render_input_field(Arc::clone(input), ctx),
             GqlFieldRenderer::Output(output) => self.render_output_field(Arc::clone(output), ctx),
@@ -16,14 +16,14 @@ impl Renderer for GqlFieldRenderer {
 }
 
 impl GqlFieldRenderer {
-    fn render_input_field(&self, input_field: InputFieldRef, ctx: RenderContext) -> (String, RenderContext) {
-        let (rendered_type, ctx) = (&input_field.field_type).into_renderer().render(ctx);
+    fn render_input_field(&self, input_field: InputFieldRef, ctx: &mut RenderContext) -> String {
+        let rendered_type = (&input_field.field_type).into_renderer().render(ctx);
 
-        (format!("{}: {}", input_field.name, rendered_type), ctx)
+        format!("{}: {}", input_field.name, rendered_type)
     }
 
-    fn render_output_field(&self, field: FieldRef, ctx: RenderContext) -> (String, RenderContext) {
-        let (rendered_args, ctx) = self.render_arguments(&field.arguments, ctx);
+    fn render_output_field(&self, field: FieldRef, ctx: &mut RenderContext) -> String {
+        let rendered_args = self.render_arguments(&field.arguments, ctx);
         let rendered_args = if rendered_args.is_empty() {
             "".into()
         } else if rendered_args.len() > 1 {
@@ -42,21 +42,23 @@ impl GqlFieldRenderer {
             format!("({})", rendered_args.join(", "))
         };
 
-        let (rendered_type, ctx) = field.field_type.into_renderer().render(ctx);
-        (format!("{}{}: {}", field.name, rendered_args, rendered_type), ctx)
+        let rendered_type = field.field_type.into_renderer().render(ctx);
+        format!("{}{}: {}", field.name, rendered_args, rendered_type)
     }
 
-    fn render_arguments(&self, args: &[Argument], ctx: RenderContext) -> (Vec<String>, RenderContext) {
-        args.iter().fold((vec![], ctx), |(mut prev, ctx), arg| {
-            let (rendered, ctx) = self.render_argument(arg, ctx);
+    fn render_arguments(&self, args: &[Argument], ctx: &mut RenderContext) -> Vec<String> {
+        let mut output = Vec::with_capacity(args.len());
 
-            prev.push(rendered);
-            (prev, ctx)
-        })
+        for arg in args {
+            output.push(self.render_argument(arg, ctx))
+        }
+
+        output
     }
 
-    fn render_argument(&self, arg: &Argument, ctx: RenderContext) -> (String, RenderContext) {
-        let (rendered_type, ctx) = (&arg.argument_type).into_renderer().render(ctx);
-        (format!("{}: {}", arg.name, rendered_type), ctx)
+    fn render_argument(&self, arg: &Argument, ctx: &mut RenderContext) -> String {
+        let rendered_type = (&arg.argument_type).into_renderer().render(ctx);
+
+        format!("{}: {}", arg.name, rendered_type)
     }
 }

--- a/query-engine/query-engine/src/request_handlers/graphql/schema_renderer/type_renderer.rs
+++ b/query-engine/query-engine/src/request_handlers/graphql/schema_renderer/type_renderer.rs
@@ -7,7 +7,7 @@ pub enum GqlTypeRenderer<'a> {
 }
 
 impl<'a> Renderer for GqlTypeRenderer<'a> {
-    fn render(&self, ctx: RenderContext) -> (String, RenderContext) {
+    fn render(&self, ctx: &mut RenderContext) -> String {
         match self {
             GqlTypeRenderer::Input(i) => self.render_input_type(i, ctx),
             GqlTypeRenderer::Output(o) => self.render_output_type(o, ctx),
@@ -22,29 +22,29 @@ impl<'a> Renderer for GqlTypeRenderer<'a> {
 /// Important to note: The way the AST is build, it's easier to remove "!" (required) suffixes instead of adding them, which is why you
 /// will see types always appending "!" until optional removes them.
 impl<'a> GqlTypeRenderer<'a> {
-    fn render_input_type(&self, i: &InputType, ctx: RenderContext) -> (String, RenderContext) {
+    fn render_input_type(&self, i: &InputType, ctx: &mut RenderContext) -> String {
         match i {
             InputType::Object(ref obj) => {
-                let (_, subctx) = obj.into_renderer().render(ctx);
-                (format!("{}!", obj.into_arc().name), subctx)
+                let _ = obj.into_renderer().render(ctx);
+                format!("{}!", obj.into_arc().name)
             }
             InputType::Enum(et) => {
                 // Not sure how this fits together with the enum handling below.
-                let (_, subctx) = et.into_renderer().render(ctx);
-                (format!("{}!", et.name()), subctx)
+                let _ = et.into_renderer().render(ctx);
+                format!("{}!", et.name())
             }
             InputType::List(ref l) => {
-                let (substring, subctx) = self.render_input_type(l, ctx);
-                (format!("[{}]!", substring), subctx)
+                let substring = self.render_input_type(l, ctx);
+                format!("[{}]!", substring)
             }
             InputType::Opt(ref opt) => {
-                let (substring, subctx) = self.render_input_type(opt, ctx);
-                (substring.trim_end_matches('!').to_owned(), subctx)
+                let substring = self.render_input_type(opt, ctx);
+                substring.trim_end_matches('!').to_owned()
             }
             InputType::Null(ref inner) => self.render_input_type(inner, ctx), // Nullability has no representation in GQL
             InputType::Scalar(ScalarType::Enum(et)) => {
-                let (_, subctx) = et.into_renderer().render(ctx);
-                (format!("{}!", et.name()), subctx)
+                let _ = et.into_renderer().render(ctx);
+                format!("{}!", et.name())
             }
             InputType::Scalar(ref scalar) => {
                 let stringified = match scalar {
@@ -59,33 +59,33 @@ impl<'a> GqlTypeRenderer<'a> {
                     ScalarType::Enum(_) => unreachable!(), // Handled separately above.
                 };
 
-                (format!("{}!", stringified), ctx)
+                format!("{}!", stringified)
             }
         }
     }
 
-    fn render_output_type(&self, o: &OutputType, ctx: RenderContext) -> (String, RenderContext) {
+    fn render_output_type(&self, o: &OutputType, ctx: &mut RenderContext) -> String {
         match o {
             OutputType::Object(obj) => {
-                let (_, subctx) = obj.into_renderer().render(ctx);
-                (format!("{}!", obj.into_arc().name()), subctx)
+                let _ = obj.into_renderer().render(ctx);
+                format!("{}!", obj.into_arc().name())
             }
             OutputType::Enum(et) => {
                 // Not sure how this fits together with the enum handling below.
-                let (_, subctx) = et.into_renderer().render(ctx);
-                (format!("{}!", et.name()), subctx)
+                let _ = et.into_renderer().render(ctx);
+                format!("{}!", et.name())
             }
             OutputType::List(l) => {
-                let (substring, subctx) = self.render_output_type(l, ctx);
-                (format!("[{}]!", substring), subctx)
+                let substring = self.render_output_type(l, ctx);
+                format!("[{}]!", substring)
             }
             OutputType::Opt(ref opt) => {
-                let (substring, subctx) = self.render_output_type(opt, ctx);
-                (substring.trim_end_matches('!').to_owned(), subctx)
+                let substring = self.render_output_type(opt, ctx);
+                substring.trim_end_matches('!').to_owned()
             }
             OutputType::Scalar(ScalarType::Enum(et)) => {
-                let (_, subctx) = et.into_renderer().render(ctx);
-                (format!("{}!", et.name()), subctx)
+                let _ = et.into_renderer().render(ctx);
+                format!("{}!", et.name())
             }
             OutputType::Scalar(ref scalar) => {
                 let stringified = match scalar {
@@ -100,7 +100,7 @@ impl<'a> GqlTypeRenderer<'a> {
                     ScalarType::Enum(_) => unreachable!(), // Handled separately above.
                 };
 
-                (format!("{}!", stringified), ctx)
+                format!("{}!", stringified)
             }
         }
     }


### PR DESCRIPTION
I tested this manually: it produces DMMF of the same size on the same schemas. The order of the objects is different, but I am  pretty sure the logic did not change, so it should be correct.

closes https://github.com/prisma/prisma/issues/3051