### PR TITLE
Fix RHEL builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,12 +103,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b602bfe940d21c130f3895acd65221e8a61270debe89d628b9cb4e3ccb8569b"
 
 [[package]]
-name = "arrayref"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
-
-[[package]]
 name = "arrayvec"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -167,27 +161,6 @@ dependencies = [
  "native-tls",
  "thiserror",
  "url 2.1.1",
-]
-
-[[package]]
-name = "async-session"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "345022a2eed092cd105cc1b26fd61c341e100bd5fcbbd792df4baf31c2cc631f"
-dependencies = [
- "anyhow",
- "async-std",
- "async-trait",
- "base64 0.12.3",
- "bincode",
- "blake3",
- "chrono",
- "hmac",
- "kv-log-macro",
- "rand",
- "serde",
- "serde_json",
- "sha2 0.9.1",
 ]
 
 [[package]]
@@ -350,16 +323,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bincode"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30d3a39baa26f9651f17b375061f3233dde33424a8b72b0dbe93a68a0bc896d"
-dependencies = [
- "byteorder",
- "serde",
-]
-
-[[package]]
 name = "bit-vec"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -370,21 +333,6 @@ name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-
-[[package]]
-name = "blake3"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce4f9586c9a3151c4b49b19e82ba163dd073614dd057e53c969e1a4db5b52720"
-dependencies = [
- "arrayref",
- "arrayvec",
- "cc",
- "cfg-if",
- "constant_time_eq",
- "crypto-mac",
- "digest 0.9.0",
-]
 
 [[package]]
 name = "block-buffer"
@@ -577,12 +525,6 @@ checksum = "e296417c8154304ac70aceda41f05318f986f7c0c767bcb0a2366fbb890e78e1"
 dependencies = [
  "cache-padded",
 ]
-
-[[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "cookie"
@@ -3546,7 +3488,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c4c4e35f5a89ed08cbb59b6e4e1d648e563d6f8daa804002f3557d11d3c8f9"
 dependencies = [
  "async-h1",
- "async-session",
  "async-sse",
  "async-std",
  "async-trait",

--- a/query-engine/query-engine/Cargo.toml
+++ b/query-engine/query-engine/Cargo.toml
@@ -33,7 +33,7 @@ serde_json = {version = "1.0", features = ["preserve_order"]}
 sql-connector = {path = "../connectors/sql-query-connector", optional = true, package = "sql-query-connector"}
 structopt = "0.3"
 thiserror = "1.0"
-tide = "0.13.0"
+tide = { version = "0.13.0", default-features = false, features = ["h1-server", "logger"] }
 url = "2.1"
 
 tracing = "0.1"


### PR DESCRIPTION
This fixes the current build failure on main by disabling the `sessions` feature in Tide 0.13. This version of tide newly depends on the `blake3` crate which in turn requires gcc 4.7 (2012) or higher to build.

See https://github.com/prisma/engine-images/issues/4 for a proposal for a more structural solution.