### PR TITLE
Add tide-server-timing middleware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1288,9 +1288,9 @@ dependencies = [
 
 [[package]]
 name = "http-types"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bc341c4b7a71eb0d85c760dc7363648b82ecc38fa5ead50f69b52858df708b9"
+checksum = "bb4daf8dc001485f4a32a7a17c54c67fa8a10340188f30ba87ac0fe1a9451e97"
 dependencies = [
  "anyhow",
  "async-std",
@@ -2646,6 +2646,7 @@ dependencies = [
  "test-setup",
  "thiserror",
  "tide",
+ "tide-server-timing",
  "tokio",
  "tracing",
  "tracing-attributes",
@@ -3502,6 +3503,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tide-server-timing"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9168516930bba237e1e651fcbea0c0e428c7635b6c3da2fd7aeddef78c90567"
+dependencies = [
+ "async-channel",
+ "http-types",
+ "tide",
+ "tracing",
+ "tracing-core",
+ "tracing-futures",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "time"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3857,6 +3873,7 @@ dependencies = [
  "idna 0.2.0",
  "matches",
  "percent-encoding 2.1.0",
+ "serde",
 ]
 
 [[package]]

--- a/query-engine/query-engine/Cargo.toml
+++ b/query-engine/query-engine/Cargo.toml
@@ -34,6 +34,7 @@ sql-connector = {path = "../connectors/sql-query-connector", optional = true, pa
 structopt = "0.3"
 thiserror = "1.0"
 tide = { version = "0.13.0", default-features = false, features = ["h1-server", "logger"] }
+tide-server-timing = "0.13.1"
 url = "2.1"
 
 tracing = "0.1"

--- a/query-engine/query-engine/src/main.rs
+++ b/query-engine/query-engine/src/main.rs
@@ -10,6 +10,9 @@ use structopt::StructOpt;
 use tracing::subscriber;
 use tracing_subscriber::{EnvFilter, FmtSubscriber};
 
+use tide_server_timing::TimingLayer;
+use tracing_subscriber::layer::SubscriberExt;
+
 mod cli;
 mod context;
 mod dmmf;
@@ -60,11 +63,19 @@ fn init_logger(log_format: LogFormat) {
 
     match log_format {
         LogFormat::Text => {
-            let subscriber = FmtSubscriber::builder().with_env_filter(filter).finish();
+            let subscriber = FmtSubscriber::builder()
+                .with_max_level(tracing::Level::TRACE)
+                .finish()
+                .with(TimingLayer::new());
+
             subscriber::set_global_default(subscriber).expect("Could not initialize logger");
         }
         LogFormat::Json => {
-            let subscriber = FmtSubscriber::builder().json().with_env_filter(filter).finish();
+            let subscriber = FmtSubscriber::builder()
+                .json()
+                .with_env_filter(filter)
+                .finish()
+                .with(TimingLayer::new());
             subscriber::set_global_default(subscriber).expect("Could not initialize logger");
         }
     }

--- a/query-engine/query-engine/src/server/mod.rs
+++ b/query-engine/query-engine/src/server/mod.rs
@@ -11,6 +11,7 @@ use query_core::schema::QuerySchemaRenderer;
 use serde_json::json;
 use tide::http::{mime, StatusCode};
 use tide::{Body, Request, Response};
+use tide_server_timing::TimingMiddleware;
 
 use std::sync::Arc;
 
@@ -56,6 +57,10 @@ pub async fn listen(opts: PrismaOpt) -> PrismaResult<()> {
 
     let mut app = tide::with_state(State::new(cx, opts.enable_playground, opts.enable_debug_mode));
     app.with(ElapsedMiddleware::new());
+
+    if opts.enable_playground {
+        app.with(TimingMiddleware::new());
+    }
 
     app.at("/").post(graphql_handler);
     app.at("/").get(playground_handler);


### PR DESCRIPTION
This PR adds the `Server-Timing` middleware. It's only runs when the playground is enabled, allowing us to capture traces in a graphical display. Ref #933.

## Usage

The way to get the timings to show up is by starting prisma-engines with the playground enabled, and navigating to the playground using Chrome.

```sh
$ cargo run --release --bin query-engine -- --datamodel-path .\datamodel_v2.prisma --enable-playground
```

The output looks like this:

![Screenshot 2020-08-10 17 20 22](https://user-images.githubusercontent.com/2467194/89800551-3e191b00-db2f-11ea-9980-cf85b8f3da6f.png)

For each request we're populating the `Server Timing` field which contains a breakdown of where we've spent our time. Currently this is only the top-level span. But the goal is to provide more tracing spans so we can say more about this.

## Next Steps

As you may see in the screenshot we're currently not populating the `tracing` panel in the GraphQL overview. This is something we could do for the graphql playground; duplicating the `tide-timing-middleware` and using it to populate the graphql responses.

As I mentioned earlier we should also add more traces to our project. This is not only constrained to `query-engine`. We can add more traces to `tide` and `async-std` itself, where I'm a team member on. But also to other dependencies such as `SQLx`. This will be an ongoing process. Part of this will likely also include eventually migrating the middleware from an external repo into `tide` proper.

Finally the knowledge we've accrued from building `tide-server-timing` enables us to build more `tracing`-based libraries. Examples include forwarding `Trace-Context` headers, and streaming traces out over e.g. SSE so that the client can pick them back up.