### PR TITLE
Fix warnings in prisma-engines

### DIFF
--- a/libs/datamodel/core/src/lib.rs
+++ b/libs/datamodel/core/src/lib.rs
@@ -130,8 +130,7 @@ fn parse_datamodel_internal(
 ) -> Result<Datamodel, error::ErrorCollection> {
     let ast = ast::parser::parse_schema(datamodel_string)?;
     let sources = load_sources(&ast, ignore_datasource_urls, vec![])?;
-    let generators = GeneratorLoader::load_generators_from_ast(&ast)?;
-    let validator = ValidationPipeline::new(&sources, &generators);
+    let validator = ValidationPipeline::new(&sources);
 
     validator.validate(&ast)
 }
@@ -142,8 +141,7 @@ pub fn lift_ast_to_datamodel(ast: &ast::SchemaAst) -> Result<Datamodel, error::E
     let mut errors = error::ErrorCollection::new();
     // we are not interested in the sources in this case. Hence we can ignore the datasource urls.
     let sources = load_sources(ast, true, vec![])?;
-    let generators = GeneratorLoader::load_generators_from_ast(&ast)?;
-    let validator = ValidationPipeline::new(&sources, &generators);
+    let validator = ValidationPipeline::new(&sources);
 
     match validator.validate(&ast) {
         Ok(src) => Ok(src),

--- a/libs/datamodel/core/src/transform/ast_to_dml/validate.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validate.rs
@@ -12,7 +12,6 @@ use std::collections::HashSet;
 /// When validating, we check if the datamodel is valid, and generate errors otherwise.
 pub struct Validator<'a> {
     source: Option<&'a configuration::Datasource>,
-    generator: Option<&'a configuration::Generator>,
 }
 
 /// State error message. Seeing this error means something went really wrong internally. It's the datamodel equivalent of a bluescreen.
@@ -23,11 +22,8 @@ const PRISMA_FORMAT_HINT: &str = "You can run `prisma format` to fix this automa
 
 impl<'a> Validator<'a> {
     /// Creates a new instance, with all builtin directives registered.
-    pub fn new(
-        source: Option<&'a configuration::Datasource>,
-        generator: Option<&'a configuration::Generator>,
-    ) -> Validator<'a> {
-        Self { source, generator }
+    pub fn new(source: Option<&'a configuration::Datasource>) -> Validator<'a> {
+        Self { source }
     }
 
     pub fn validate(&self, ast_schema: &ast::SchemaAst, schema: &mut dml::Datamodel) -> Result<(), ErrorCollection> {

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline.rs
@@ -10,15 +10,11 @@ pub struct ValidationPipeline<'a> {
 }
 
 impl<'a> ValidationPipeline<'a> {
-    pub fn new(
-        sources: &'a [configuration::Datasource],
-        generators: &'a [configuration::Generator],
-    ) -> ValidationPipeline<'a> {
+    pub fn new(sources: &'a [configuration::Datasource]) -> ValidationPipeline<'a> {
         let source = sources.first();
-        let generator = generators.first();
         ValidationPipeline {
             lifter: LiftAstToDml::new(source),
-            validator: Validator::new(source, generator),
+            validator: Validator::new(source),
             standardiser: Standardiser::new(),
         }
     }


### PR DESCRIPTION
This fixes the warning on the current main branch by removing all unused code. This is a follow-up to #935 which introduced the warning. Thanks!