### PR TITLE
Fix relation name collisions in introspection

### DIFF
--- a/introspection-engine/connectors/sql-introspection-connector/src/introspection.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/introspection.rs
@@ -131,7 +131,7 @@ fn calculate_fields_for_prisma_join_table(
             // Avoid duplicate field names, in case a generated relation field name is the same as the M2M relation table's name.
             let relation_name = &join_table.name[1..];
             let relation_name = if existing_relations.any(|existing_relation| existing_relation == relation_name) {
-                format!("{}Table", relation_name)
+                format!("{}ManyToMany", relation_name)
             } else {
                 relation_name.to_owned()
             };

--- a/introspection-engine/connectors/sql-introspection-connector/src/misc_helpers.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/misc_helpers.rs
@@ -83,22 +83,22 @@ fn common_prisma_m_to_n_relation_conditions(table: &Table) -> bool {
 //calculators
 
 pub fn calculate_many_to_many_field(
-    foreign_key: &ForeignKey,
+    opposite_foreign_key: &ForeignKey,
     relation_name: String,
     is_self_relation: bool,
 ) -> RelationField {
     let relation_info = RelationInfo {
         name: relation_name,
         fields: vec![],
-        to: foreign_key.referenced_table.clone(),
-        to_fields: foreign_key.referenced_columns.clone(),
+        to: opposite_foreign_key.referenced_table.clone(),
+        to_fields: opposite_foreign_key.referenced_columns.clone(),
         on_delete: OnDeleteStrategy::None,
     };
 
-    let basename = foreign_key.referenced_table.clone();
+    let basename = opposite_foreign_key.referenced_table.clone();
 
     let name = match is_self_relation {
-        true => format!("{}_{}", basename, foreign_key.columns[0]),
+        true => format!("{}_{}", basename, opposite_foreign_key.columns[0]),
         false => basename,
     };
 

--- a/introspection-engine/connectors/sql-introspection-connector/tests/common_unit_tests/mod.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/tests/common_unit_tests/mod.rs
@@ -1159,14 +1159,14 @@ async fn one_to_many_relation_field_names_do_not_conflict_with_many_to_many_rela
         model User {
             id                      Int     @default(autoincrement()) @id
             Event_EventToUser       Event[]
-            Event_EventToUserTable  Event[] @relation("EventToUserTable")
+            Event_EventToUserManyToMany  Event[] @relation("EventToUserManyToMany")
         }
 
         model Event {
             id                      Int    @default(autoincrement()) @id
             hostId                  Int
             User_EventToUser        User   @relation(fields: [hostId], references: [id])
-            User_EventToUserTable   User[] @relation("EventToUserTable")
+            User_EventToUserManyToMany   User[] @relation("EventToUserManyToMany")
 
             @@index([hostId], name: "hostId")
         }
@@ -1176,14 +1176,14 @@ async fn one_to_many_relation_field_names_do_not_conflict_with_many_to_many_rela
         model User {
             id                      Int     @default(autoincrement()) @id
             Event_EventToUser       Event[]
-            Event_EventToUserTable  Event[] @relation("EventToUserTable")
+            Event_EventToUserManyToMany  Event[] @relation("EventToUserManyToMany")
         }
 
         model Event {
             id                      Int    @default(autoincrement()) @id
             hostId                  Int
             User_EventToUser        User   @relation(fields: [hostId], references: [id])
-            User_EventToUserTable   User[] @relation("EventToUserTable")
+            User_EventToUserManyToMany   User[] @relation("EventToUserManyToMany")
         }
         "#
     };

--- a/introspection-engine/connectors/sql-introspection-connector/tests/common_unit_tests/mod.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/tests/common_unit_tests/mod.rs
@@ -1,3 +1,4 @@
+use crate::test_harness::*;
 use datamodel::{
     dml, Datamodel, DefaultValue as DMLDefault, Field, FieldArity, FieldType, IndexDefinition, Model, OnDeleteStrategy,
     RelationField, RelationInfo, ScalarField, ScalarType, ValueGenerator,
@@ -7,6 +8,7 @@ use prisma_value::PrismaValue;
 use quaint::connector::SqlFamily;
 use sql_introspection_connector::calculate_datamodel::calculate_datamodel;
 use sql_schema_describer::*;
+use test_macros::test_each_connector;
 
 #[test]
 fn a_data_model_can_be_generated_from_a_schema() {
@@ -1097,4 +1099,107 @@ fn enums_are_preserved_when_generating_data_model_from_a_schema() {
         calculate_datamodel(&schema, &SqlFamily::Postgres, &Datamodel::new(), false).expect("calculate data model");
 
     assert_eq!(introspection_result.data_model, ref_data_model);
+}
+
+#[test_each_connector]
+async fn one_to_many_relation_field_names_do_not_conflict_with_many_to_many_relation_field_names(
+    api: &TestApi,
+) -> TestResult {
+    let sql_family = api.sql_family();
+    api.barrel()
+        .execute(move |migration| {
+            if sql_family.is_mysql() {
+                migration.create_table("User", |table| {
+                    table.inject_custom("id INTEGER AUTO_INCREMENT PRIMARY KEY");
+                });
+
+                migration.create_table("Event", |table| {
+                    table.inject_custom("id INTEGER AUTO_INCREMENT PRIMARY KEY");
+                    table.inject_custom("`hostId` INTEGER NOT NULL, FOREIGN KEY (`hostId`) REFERENCES `User`(`id`)");
+                });
+
+                migration.create_table("_EventToUser", |table| {
+                    table.inject_custom("`A` INTEGER NOT NULL, FOREIGN KEY (`A`) REFERENCES `Event`(`id`)");
+                    table.inject_custom("`B` INTEGER NOT NULL, FOREIGN KEY (`B`) REFERENCES `User`(`id`)");
+
+                    table.add_index(
+                        "_EventToUser_AB_unique",
+                        barrel::types::index(vec!["A", "B"]).unique(true),
+                    );
+                    table.add_index("_EventToUser_B_index", barrel::types::index(vec!["B"]));
+                });
+            } else {
+                migration.create_table("User", |table| {
+                    table.add_column("id", barrel::types::primary().nullable(true));
+                });
+
+                migration.create_table("Event", |table| {
+                    table.add_column("id", barrel::types::primary().nullable(true));
+                    table.add_column("hostId", barrel::types::foreign("User", vec!["id".to_owned()]));
+                });
+
+                migration.create_table("_EventToUser", |table| {
+                    table.add_column("A", barrel::types::foreign("Event", vec!["id".to_owned()]));
+                    table.add_column("B", barrel::types::foreign("User", vec!["id".to_owned()]));
+
+                    table.add_index(
+                        "_EventToUser_AB_unique",
+                        barrel::types::index(vec!["A", "B"]).unique(true),
+                    );
+                    table.add_index("_EventToUser_B_index", barrel::types::index(vec!["B"]));
+                });
+            }
+        })
+        .await;
+
+    let schema = api.describe_schema().await?;
+
+    let expected_dm = if sql_family.is_mysql() {
+        r#"
+        model User {
+            id                      Int     @default(autoincrement()) @id
+            Event_EventToUser       Event[]
+            Event_EventToUserTable  Event[] @relation("EventToUserTable")
+        }
+
+        model Event {
+            id                      Int    @default(autoincrement()) @id
+            hostId                  Int
+            User_EventToUser        User   @relation(fields: [hostId], references: [id])
+            User_EventToUserTable   User[] @relation("EventToUserTable")
+
+            @@index([hostId], name: "hostId")
+        }
+        "#
+    } else {
+        r#"
+        model User {
+            id                      Int     @default(autoincrement()) @id
+            Event_EventToUser       Event[]
+            Event_EventToUserTable  Event[] @relation("EventToUserTable")
+        }
+
+        model Event {
+            id                      Int    @default(autoincrement()) @id
+            hostId                  Int
+            User_EventToUser        User   @relation(fields: [hostId], references: [id])
+            User_EventToUserTable   User[] @relation("EventToUserTable")
+        }
+        "#
+    };
+
+    // Align formatting
+    let expected_dm =
+        datamodel::render_datamodel_to_string(&datamodel::parse_datamodel(&expected_dm).unwrap()).unwrap();
+
+    let mut introspected_dm = calculate_datamodel(&schema, &SqlFamily::Postgres, &Datamodel::new(), false)?.data_model;
+    introspected_dm.models.sort_by(|a, b| b.name.cmp(&a.name));
+
+    let introspected_dm_string = datamodel::render_datamodel_to_string(&introspected_dm).unwrap();
+
+    println!("{}", introspected_dm_string);
+
+    assert_eq!(introspected_dm_string, expected_dm);
+
+    Ok(())
 }

--- a/libs/datamodel/core/src/dml/datamodel.rs
+++ b/libs/datamodel/core/src/dml/datamodel.rs
@@ -70,7 +70,8 @@ impl Datamodel {
         self.models().find(|model| model.name == name)
     }
 
-    /// Finds a model by database name.
+    /// Finds a model by database name. This will only find models with a name
+    /// remapped to the provided `db_name`.
     pub fn find_model_db_name(&self, db_name: &str) -> Option<&Model> {
         self.models()
             .find(|model| model.database_name.as_deref() == Some(db_name))

--- a/libs/datamodel/core/src/walkers.rs
+++ b/libs/datamodel/core/src/walkers.rs
@@ -40,6 +40,13 @@ pub fn walk_relations(datamodel: &Datamodel) -> impl Iterator<Item = RelationWal
         })
 }
 
+pub fn find_model_by_db_name<'a>(datamodel: &'a Datamodel, db_name: &str) -> Option<ModelWalker<'a>> {
+    datamodel
+        .models()
+        .find(|model| model.database_name() == Some(db_name) || model.name == db_name)
+        .map(|model| ModelWalker { datamodel, model })
+}
+
 #[derive(Debug, Copy, Clone)]
 pub struct ModelWalker<'a> {
     datamodel: &'a Datamodel,


### PR DESCRIPTION
This addresses an edge case that happens when a relation field name generated by introspection is identical to the table name of a many to many relation, that we use as relation field name as well, causing a name collision in the introspected schema.

closes https://github.com/prisma/prisma/issues/2591