### PR TITLE
Reorder migration steps to allow refactoring an enum into a model

### DIFF
--- a/migration-engine/migration-engine-tests/src/assertions.rs
+++ b/migration-engine/migration-engine-tests/src/assertions.rs
@@ -122,6 +122,22 @@ impl<'a> EnumAssertion<'a> {
 pub struct TableAssertion<'a>(&'a Table);
 
 impl<'a> TableAssertion<'a> {
+    pub fn assert_column_count(self, n: usize) -> AssertionResult<Self> {
+        let columns_count = self.0.columns.len();
+
+        anyhow::ensure!(
+            columns_count == n,
+            anyhow::anyhow!(
+                "Assertion failed. Expected {n} columns, found {columns_count}. {columns:#?}",
+                n = n,
+                columns_count = columns_count,
+                columns = &self.0.columns,
+            )
+        );
+
+        Ok(self)
+    }
+
     pub fn assert_foreign_keys_count(self, n: usize) -> AssertionResult<Self> {
         let fk_count = self.0.foreign_keys.len();
         anyhow::ensure!(

--- a/migration-engine/migration-engine-tests/tests/migrations/enums.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/enums.rs
@@ -1,0 +1,52 @@
+use migration_engine_tests::sql::*;
+
+#[test_each_connector(capabilities("enums"), log = "debug,sql_schema_describer=info")]
+async fn an_enum_can_be_turned_into_a_model(api: &TestApi) -> TestResult {
+    let dm1 = r#"
+        model Cat {
+            id Int @id
+            mood CatMood
+        }
+
+        enum CatMood {
+            HUNGRY
+            HAPPY
+        }
+    "#;
+
+    api.schema_push(dm1).send().await?.assert_green()?;
+
+    let enum_name = if api.sql_family().is_mysql() {
+        "Cat_mood"
+    } else {
+        "CatMood"
+    };
+
+    api.assert_schema().await?.assert_enum(enum_name, |enm| Ok(enm))?;
+
+    let dm2 = r#"
+        model Cat {
+            id Int @id
+            moodId Int
+            mood CatMood @relation(fields: [moodId], references: [id])
+        }
+
+        model CatMood {
+            id Int @id
+            description String
+            biteRisk Int
+        }
+    "#;
+
+    api.schema_push(dm2).send().await?.assert_green()?;
+
+    api.assert_schema()
+        .await?
+        .assert_table("Cat", |table| {
+            table.assert_columns_count(2)?.assert_column("moodId", |col| Ok(col))
+        })?
+        .assert_table("CatMood", |table| table.assert_column_count(3))?
+        .assert_has_no_enum("CatMood")?;
+
+    Ok(())
+}

--- a/migration-engine/migration-engine-tests/tests/migrations/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/mod.rs
@@ -1,3 +1,4 @@
+mod enums;
 mod indexes;
 mod json;
 mod mariadb;


### PR DESCRIPTION
Closes https://github.com/prisma/migrate/issues/509