### PR TITLE
(introspection) Fix regression on M2M relation field naming

### DIFF
--- a/introspection-engine/connectors/sql-introspection-connector/src/introspection.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/introspection.rs
@@ -130,7 +130,9 @@ fn calculate_fields_for_prisma_join_table(
 
             // Avoid duplicate field names, in case a generated relation field name is the same as the M2M relation table's name.
             let relation_name = &join_table.name[1..];
-            let relation_name = if existing_relations.any(|existing_relation| existing_relation == relation_name) {
+            let relation_name = if !is_self_relation
+                && existing_relations.any(|existing_relation| existing_relation == relation_name)
+            {
                 format!("{}ManyToMany", relation_name)
             } else {
                 relation_name.to_owned()


### PR DESCRIPTION
This fixes a regression introduced by https://github.com/prisma/prisma-engines/pull/1012