### PR TITLE
require one datasource to be provided during 'prisma generate'

### DIFF
--- a/libs/datamodel/core/src/configuration/configuration.rs
+++ b/libs/datamodel/core/src/configuration/configuration.rs
@@ -1,6 +1,21 @@
 use super::{Datasource, Generator};
+use crate::error::{DatamodelError, ErrorCollection};
 
 pub struct Configuration {
     pub generators: Vec<Generator>,
     pub datasources: Vec<Datasource>,
+}
+
+impl Configuration {
+    pub fn validate_that_one_datasource_is_provided(self) -> Result<Self, ErrorCollection> {
+        if self.datasources.is_empty() {
+            Err(DatamodelError::new_validation_error(
+                "You defined no datasource. You must define exactly one datasource.",
+                crate::ast::Span::new(0, 5),
+            )
+            .into())
+        } else {
+            Ok(self)
+        }
+    }
 }

--- a/libs/datamodel/core/tests/config/sources.rs
+++ b/libs/datamodel/core/tests/config/sources.rs
@@ -316,6 +316,22 @@ fn fail_to_load_sources_for_invalid_source() {
     }
 }
 
+#[test]
+#[serial]
+fn fail_when_no_source_is_declared() {
+    let invalid_datamodel: &str = r#"        "#;
+    let res = datamodel::parse_configuration(invalid_datamodel).unwrap();
+
+    if let Err(error) = res.validate_that_one_datasource_is_provided() {
+        error.assert_is(DatamodelError::ValidationError {
+            message: "You defined no datasource. You must define exactly one datasource.".to_string(),
+            span: datamodel::ast::Span::new(0, 5),
+        });
+    } else {
+        panic!("Expected error.")
+    }
+}
+
 fn assert_eq_json(a: &str, b: &str) {
     let json_a: serde_json::Value = serde_json::from_str(a).expect("The String a was not valid JSON.");
     let json_b: serde_json::Value = serde_json::from_str(b).expect("The String b was not valid JSON.");

--- a/query-engine/query-engine/src/opt.rs
+++ b/query-engine/query-engine/src/opt.rs
@@ -151,6 +151,8 @@ impl PrismaOpt {
             datamodel::parse_configuration_with_url_overrides(datamodel_str, datasource_url_overrides)
         };
 
+        let config_result = config_result.and_then(|c| c.validate_that_one_datasource_is_provided());
+
         config_result.map_err(|errors| PrismaError::ConversionError(errors, datamodel_str.to_string()))
     }
 


### PR DESCRIPTION
In an internal conversation we realized that the query engine now requires one datasource to be present for the DMMF call. This crashed with a not very readable panic. This PR adds validation for this case that is only performed within the dmmf call.