### PR TITLE
Optimize Generated Read Queries

### DIFF
--- a/libs/prisma-models/src/record.rs
+++ b/libs/prisma-models/src/record.rs
@@ -43,9 +43,23 @@ impl ManyRecords {
             field_names,
         }
     }
+
     pub fn empty(selected_fields: &ModelProjection) -> Self {
         Self {
             records: Vec::new(),
+            field_names: selected_fields.names().map(|n| n.to_string()).collect(),
+        }
+    }
+
+    pub fn from_projection(projection: Vec<Vec<PrismaValue>>, selected_fields: &ModelProjection) -> Self {
+        Self {
+            records: projection
+                .into_iter()
+                .map(|v| Record {
+                    values: v,
+                    parent_id: None,
+                })
+                .collect(),
             field_names: selected_fields.names().map(|n| n.to_string()).collect(),
         }
     }

--- a/libs/prisma-models/src/record.rs
+++ b/libs/prisma-models/src/record.rs
@@ -102,10 +102,6 @@ impl ManyRecords {
     pub fn reverse(&mut self) {
         self.records.reverse();
     }
-
-    pub fn is_empty(&self) -> bool {
-        self.records.is_empty()
-    }
 }
 
 #[derive(Debug, Default, Clone)]

--- a/libs/prisma-models/src/record.rs
+++ b/libs/prisma-models/src/record.rs
@@ -102,6 +102,10 @@ impl ManyRecords {
     pub fn reverse(&mut self) {
         self.records.reverse();
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.records.is_empty()
+    }
 }
 
 #[derive(Debug, Default, Clone)]

--- a/libs/prisma-models/src/record.rs
+++ b/libs/prisma-models/src/record.rs
@@ -43,6 +43,12 @@ impl ManyRecords {
             field_names,
         }
     }
+    pub fn empty(selected_fields: &ModelProjection) -> Self {
+        Self {
+            records: Vec::new(),
+            field_names: selected_fields.names().map(|n| n.to_string()).collect(),
+        }
+    }
 
     pub fn order_by(&mut self, order_bys: &[OrderBy]) {
         let field_indices: HashMap<&str, usize> = self

--- a/query-engine/connector-test-kit/src/test/scala/queries/relations/UnnecessaryDBRequests.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/relations/UnnecessaryDBRequests.scala
@@ -1,0 +1,117 @@
+package queries.relations
+
+import org.scalatest.{FlatSpec, Matchers}
+import util.{ApiSpecBase, ProjectDsl}
+
+class UnnecessaryDBRequests extends FlatSpec with Matchers with ApiSpecBase {
+  "Querying the scalar field that backs a relation and the relation itself" should "work" in {
+    val project = ProjectDsl.fromString {
+      s"""
+         |model Top {
+         |  id            String  @id
+         |  middle_id     String?
+         |  middle        Middle? @relation(fields: [middle_id], references: [id])
+         |}
+         |
+         |model Middle {
+         |  id            String  @id
+         |  bottom_id     String?
+         |  bottom        Bottom? @relation(fields: [bottom_id], references: [id])
+         |}
+         |
+         |model Bottom {
+         |  id            String  @id
+         |}
+       """.stripMargin
+    }
+    database.setup(project)
+
+    server.query("""
+        |mutation {
+        |  createTop(data: { id: "lonely_top" }){
+        |    id
+        |  }
+        |}
+      """,
+                 project)
+
+    server.query(
+      """
+                   |mutation {
+                   |  createTop(data: { 
+                   |    id: "family_top"
+                   |    middle: { create:{
+                   |      id: "middle"
+                   |      bottom: { create:{
+                   |        id: "bottom"
+                   |      }}
+                   |    }
+                   |    }
+                   |   }){
+                   | id,
+                   | middle{
+                   |    id
+                   |    bottom {
+                   |      id
+                   |    }
+                   | }
+                   |  }
+                   |}
+      """,
+      project
+    )
+
+//    //just top
+//    server.query(
+//      """
+//                   |query {
+//                   |  tops(where: { id: { equals: "lonely_top" }}){
+//                        id
+//                   |  }
+//                   |}
+//      """,
+//      project
+//    )
+
+    //lonely top
+    val lonely = server.query(
+      """
+                   |query {
+                   |  tops(where: { id: { equals: "lonely_top" }}){
+                   |     id,
+                   |  middle{
+                   |     id
+                   |     bottom {
+                   |       id
+                   |     }
+                   |  }
+                   |  }
+                   |}
+      """,
+      project
+    )
+
+    lonely.toString() should be("{\"data\":{\"tops\":[{\"id\":\"lonely_top\",\"middle\":null}]}}")
+
+    //family top
+    val family = server.query(
+      """
+        |query {
+        |  tops(where: { id: { equals: "family_top" }}){
+        |     id,
+        |  middle{
+        |     id
+        |     bottom {
+        |       id
+        |     }
+        |  }
+        |  }
+        |}
+      """,
+      project
+    )
+
+    family.toString() should be("{\"data\":{\"tops\":[{\"id\":\"family_top\",\"middle\":{\"id\":\"middle\",\"bottom\":{\"id\":\"bottom\"}}}]}}")
+
+  }
+}

--- a/query-engine/connector-test-kit/src/test/scala/queries/relations/UnnecessaryDBRequests.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/relations/UnnecessaryDBRequests.scala
@@ -213,6 +213,7 @@ class UnnecessaryDBRequests extends FlatSpec with Matchers with ApiSpecBase {
   }
 
   //Todo
+  // how to test this??
   // what about 1:1
   // the unnecessary second level request for one2many is still generated
   // relation{id} extra request for id

--- a/query-engine/connector-test-kit/src/test/scala/queries/relations/UnnecessaryDBRequests.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/relations/UnnecessaryDBRequests.scala
@@ -149,7 +149,6 @@ class UnnecessaryDBRequests extends FlatSpec with Matchers with ApiSpecBase {
 
     two_levels._1.toString() should be("{\"data\":{\"tops\":[{\"id\":\"family_top\",\"middle\":{\"id\":\"middle\"}}]}}")
     assert_request_count(two_levels._2, 1)
-
   }
 
   "Many to Many relations" should "not create unnecessary round trips" in {

--- a/query-engine/connector-test-kit/src/test/scala/queries/relations/UnnecessaryDBRequests.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/relations/UnnecessaryDBRequests.scala
@@ -216,6 +216,6 @@ class UnnecessaryDBRequests extends FlatSpec with Matchers with ApiSpecBase {
   // what about 1:1
   // the unnecessary second level request for one2many is still generated
   // relation{id} extra request for id
-  // fetching related id when resolving m2m (its already in the relationtable)
+  // fetching related id when resolving m2m (its already in the relation table)
   //
 }

--- a/query-engine/connector-test-kit/src/test/scala/queries/relations/UnnecessaryDBRequests.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/relations/UnnecessaryDBRequests.scala
@@ -4,7 +4,7 @@ import org.scalatest.{FlatSpec, Matchers}
 import util.{ApiSpecBase, ProjectDsl}
 
 class UnnecessaryDBRequests extends FlatSpec with Matchers with ApiSpecBase {
-  "Querying the scalar field that backs a relation and the relation itself" should "work" in {
+  "One to Many relations" should "not create unnecessary requests" in {
     val project = ProjectDsl.fromString {
       s"""
          |model Top {
@@ -61,19 +61,11 @@ class UnnecessaryDBRequests extends FlatSpec with Matchers with ApiSpecBase {
       project
     )
 
-//    //just top
-//    server.query(
-//      """
-//                   |query {
-//                   |  tops(where: { id: { equals: "lonely_top" }}){
-//                        id
-//                   |  }
-//                   |}
-//      """,
-//      project
-//    )
-
     //lonely top
+    // todo
+    //  Start:    3 request
+    //  Current:  2 request
+    //  Goal:     1 request
     val lonely = server.query(
       """
                    |query {
@@ -114,4 +106,116 @@ class UnnecessaryDBRequests extends FlatSpec with Matchers with ApiSpecBase {
     family.toString() should be("{\"data\":{\"tops\":[{\"id\":\"family_top\",\"middle\":{\"id\":\"middle\",\"bottom\":{\"id\":\"bottom\"}}}]}}")
 
   }
+
+  "Many to Many relations" should "not create unnecessary requests" in {
+    val project = ProjectDsl.fromString {
+      s"""
+         |model Top {
+         |  id            String  @id
+         |  middle        Middle[]
+         |}
+         |
+         |model Middle {
+         |  id            String  @id
+         |  top           Top[]
+         |  bottom        Bottom[]
+         |}
+         |
+         |model Bottom {
+         |  id            String  @id
+         |  middle        Middle[]
+         |}
+       """.stripMargin
+    }
+    database.setup(project)
+
+    server.query(
+      """
+                   |mutation {
+                   |  createTop(data: { id: "lonely_top" }){
+                   |    id
+                   |  }
+                   |}
+      """,
+      project
+    )
+
+    server.query(
+      """
+        |mutation {
+        |  createTop(data: { 
+        |    id: "family_top"
+        |    middle: { create:{
+        |      id: "middle"
+        |      bottom: { create:{
+        |        id: "bottom"
+        |      }}
+        |    }
+        |    }
+        |   }){
+        | id,
+        | middle{
+        |    id
+        |    bottom {
+        |      id
+        |    }
+        | }
+        |  }
+        |}
+      """,
+      project
+    )
+
+    //lonely top
+    // todo
+    //  Start:    5 request
+    //  Current:  2 request
+    //  Goal:     2 request
+    val lonely = server.query(
+      """
+        |query {
+        |  tops(where: { id: { equals: "lonely_top" }}){
+        |     id,
+        |  middle{
+        |     id
+        |     bottom {
+        |       id
+        |     }
+        |  }
+        |  }
+        |}
+      """,
+      project
+    )
+
+    lonely.toString() should be("{\"data\":{\"tops\":[{\"id\":\"lonely_top\",\"middle\":[]}]}}")
+
+    //family top
+    val family = server.query(
+      """
+        |query {
+        |  tops(where: { id: { equals: "family_top" }}){
+        |     id,
+        |  middle{
+        |     id
+        |     bottom {
+        |       id
+        |     }
+        |  }
+        |  }
+        |}
+      """,
+      project
+    )
+
+    family.toString() should be("{\"data\":{\"tops\":[{\"id\":\"family_top\",\"middle\":[{\"id\":\"middle\",\"bottom\":[{\"id\":\"bottom\"}]}]}]}}")
+
+  }
+
+  //Todo
+  // what about 1:1
+  // the unnecessary second level request for one2many is still generated
+  // relation{id} extra request for id
+  // fetching related id when resolving m2m (its already in the relationtable)
+  //
 }

--- a/query-engine/connector-test-kit/src/test/scala/queries/relations/UnnecessaryDBRequests.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/relations/UnnecessaryDBRequests.scala
@@ -64,7 +64,7 @@ class UnnecessaryDBRequests extends FlatSpec with Matchers with ApiSpecBase {
     //lonely top
     // todo
     //  Start:    3 request
-    //  Current:  2 request
+    //  Current:  1 request
     //  Goal:     1 request
     val lonely = server.query(
       """
@@ -169,7 +169,7 @@ class UnnecessaryDBRequests extends FlatSpec with Matchers with ApiSpecBase {
     //lonely top
     // todo
     //  Start:    5 request
-    //  Current:  3 request
+    //  Current:  2 request
     //  Goal:     2 request
     val lonely = server.query(
       """

--- a/query-engine/connector-test-kit/src/test/scala/queries/relations/UnnecessaryDBRequests.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/relations/UnnecessaryDBRequests.scala
@@ -275,8 +275,7 @@ class UnnecessaryDBRequests extends FlatSpec with Matchers with ApiSpecBase {
 
     //two levels
     //  Start:    3 roundtrip
-    //  Current:  3 roundtrip
-    //  Goal:     2 roundtrip
+    //  Current:  2 roundtrip
     val two_levels = server.query(
       """
         |query {

--- a/query-engine/connector-test-kit/src/test/scala/queries/relations/UnnecessaryDBRequests.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/relations/UnnecessaryDBRequests.scala
@@ -189,7 +189,6 @@ class UnnecessaryDBRequests extends FlatSpec with Matchers with ApiSpecBase {
     )
 
     //family top
-    //lonely top
     //  Start:    5 roundtrip
     //  Current:  5 roundtrip
     val family = server.query(

--- a/query-engine/connector-test-kit/src/test/scala/queries/relations/UnnecessaryDBRequests.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/relations/UnnecessaryDBRequests.scala
@@ -64,7 +64,7 @@ class UnnecessaryDBRequests extends FlatSpec with Matchers with ApiSpecBase {
     //family top
     //  Start:    3 roundtrip
     //  Current:  2 roundtrip
-    val family = server.query_with_log(
+    val family = server.query_with_logged_requests(
       """
         |query {
         |  tops(where: { id: { equals: "family_top" }}){
@@ -87,7 +87,7 @@ class UnnecessaryDBRequests extends FlatSpec with Matchers with ApiSpecBase {
     //lonely top
     //  Start:    3 roundtrip
     //  Current:  1 roundtrip
-    val lonely = server.query_with_log(
+    val lonely = server.query_with_logged_requests(
       """
                    |query {
                    |  tops(where: { id: { equals: "lonely_top" }}){
@@ -110,7 +110,7 @@ class UnnecessaryDBRequests extends FlatSpec with Matchers with ApiSpecBase {
     //no top
     //  Start:    3 roundtrip
     //  Current:  1 roundtrip
-    val no = server.query_with_log(
+    val no = server.query_with_logged_requests(
       """
         |query {
         |  tops(where: { id: { equals: "does not exist" }}){
@@ -133,7 +133,7 @@ class UnnecessaryDBRequests extends FlatSpec with Matchers with ApiSpecBase {
     //two levels
     //  Start:    3 roundtrip
     //  Current:  1 roundtrip
-    val two_levels = server.query_with_log(
+    val two_levels = server.query_with_logged_requests(
       """
         |query {
         |  tops(where: { id: { equals: "family_top" }}){
@@ -213,7 +213,7 @@ class UnnecessaryDBRequests extends FlatSpec with Matchers with ApiSpecBase {
     //family top
     //  Start:    5 roundtrip
     //  Current:  3 roundtrip
-    val family = server.query_with_log(
+    val family = server.query_with_logged_requests(
       """
         |query {
         |  tops(where: { id: { equals: "family_top" }}){
@@ -236,7 +236,7 @@ class UnnecessaryDBRequests extends FlatSpec with Matchers with ApiSpecBase {
     //lonely top
     //  Start:    5 roundtrip
     //  Current:  2 roundtrip
-    val lonely = server.query_with_log(
+    val lonely = server.query_with_logged_requests(
       """
         |query {
         |  tops(where: { id: { equals: "lonely_top" }}){
@@ -259,7 +259,7 @@ class UnnecessaryDBRequests extends FlatSpec with Matchers with ApiSpecBase {
     //no top
     //  Start:    5 roundtrip
     //  Current:  1 roundtrip
-    val no = server.query_with_log(
+    val no = server.query_with_logged_requests(
       """
         |query {
         |  tops(where: { id: { equals: "does not exist" }}){
@@ -282,7 +282,7 @@ class UnnecessaryDBRequests extends FlatSpec with Matchers with ApiSpecBase {
     //two levels
     //  Start:    3 roundtrip
     //  Current:  2 roundtrip
-    val two_levels = server.query_with_log(
+    val two_levels = server.query_with_logged_requests(
       """
         |query {
         |  tops(where: { id: { equals: "family_top" }}){

--- a/query-engine/connector-test-kit/src/test/scala/queries/relations/UnnecessaryDBRequests.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/relations/UnnecessaryDBRequests.scala
@@ -127,9 +127,28 @@ class UnnecessaryDBRequests extends FlatSpec with Matchers with ApiSpecBase {
 
     no.toString() should be("{\"data\":{\"tops\":[]}}")
 
+    //two levels
+    //  Start:    3 roundtrip
+    //  Current:  1 roundtrip
+    val two_levels = server.query(
+      """
+        |query {
+        |  tops(where: { id: { equals: "family_top" }}){
+        |     id,
+        |     middle{
+        |       id
+        |   }
+        |  }
+        |}
+      """,
+      project
+    )
+
+    two_levels.toString() should be("{\"data\":{\"tops\":[{\"id\":\"family_top\",\"middle\":{\"id\":\"middle\"}}]}}")
+
   }
 
-  "Many to Many relations" should "not create unnecessary roundtrips" in {
+  "Many to Many relations" should "not create unnecessary round trips" in {
     val project = ProjectDsl.fromString {
       s"""
          |model Top {
@@ -254,5 +273,24 @@ class UnnecessaryDBRequests extends FlatSpec with Matchers with ApiSpecBase {
 
     no.toString() should be("{\"data\":{\"tops\":[]}}")
 
+    //two levels
+    //  Start:    3 roundtrip
+    //  Current:  3 roundtrip
+    //  Goal:     2 roundtrip
+    val two_levels = server.query(
+      """
+        |query {
+        |  tops(where: { id: { equals: "family_top" }}){
+        |     id,
+        |     middle{
+        |       id
+        |   }
+        |  }
+        |}
+      """,
+      project
+    )
+
+    two_levels.toString() should be("{\"data\":{\"tops\":[{\"id\":\"family_top\",\"middle\":[{\"id\":\"middle\"}]}]}}")
   }
 }

--- a/query-engine/connector-test-kit/src/test/scala/queries/relations/UnnecessaryDBRequests.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/relations/UnnecessaryDBRequests.scala
@@ -169,7 +169,7 @@ class UnnecessaryDBRequests extends FlatSpec with Matchers with ApiSpecBase {
     //lonely top
     // todo
     //  Start:    5 request
-    //  Current:  2 request
+    //  Current:  3 request
     //  Goal:     2 request
     val lonely = server.query(
       """

--- a/query-engine/connector-test-kit/src/test/scala/util/PlayJson.scala
+++ b/query-engine/connector-test-kit/src/test/scala/util/PlayJson.scala
@@ -96,7 +96,7 @@ trait PlayJsonExtensions extends JsonUtils {
   }
 
   implicit class PlayJsonAssertionsExtension(json: JsValue) {
-    def assertSuccessfulResponse(dataContains: String): Unit = {
+    def assertSuccessfulResponse(dataContains: String = ""): Unit = {
       require(
         requirement = !hasErrors,
         message = s"The query had to result in a success but it returned errors. Here's the response: \n $json"

--- a/query-engine/connector-test-kit/src/test/scala/util/TestServer.scala
+++ b/query-engine/connector-test-kit/src/test/scala/util/TestServer.scala
@@ -42,6 +42,7 @@ case class TestServer() extends PlayJsonExtensions with LogSupport {
       project = project,
       legacy = legacy,
       batchSize = batchSize,
+      log_level = "info"
     )
     result._1.assertSuccessfulResponse(dataContains)
     result
@@ -93,9 +94,13 @@ case class TestServer() extends PlayJsonExtensions with LogSupport {
     Json.obj("batch" -> queries.map(createSingleQuery), "transaction" -> transaction)
   }
 
-  def queryBinaryCLI(request: JsValue, project: Project, legacy: Boolean = true, batchSize: Int = 5000): (JsValue, Vector[String]) = {
+  def queryBinaryCLI(request: JsValue,
+                     project: Project,
+                     legacy: Boolean = true,
+                     batchSize: Int = 5000,
+                     log_level: String = logLevel): (JsValue, Vector[String]) = {
     val encoded_query  = UTF8Base64.encode(Json.stringify(request))
-    val binaryLogLevel = "RUST_LOG" -> s"query_engine=$logLevel,quaint=$logLevel,query_core=$logLevel,query_connector=$logLevel,sql_query_connector=$logLevel,prisma_models=$logLevel,sql_introspection_connector=$logLevel"
+    val binaryLogLevel = "RUST_LOG" -> s"query_engine=$log_level,quaint=$log_level,query_core=$log_level,query_connector=$log_level,sql_query_connector=$log_level,prisma_models=$log_level,sql_introspection_connector=$log_level"
 
     val response = (project.isPgBouncer, legacy) match {
       case (true, true) =>

--- a/query-engine/connector-test-kit/src/test/scala/util/TestServer.scala
+++ b/query-engine/connector-test-kit/src/test/scala/util/TestServer.scala
@@ -33,18 +33,16 @@ case class TestServer() extends PlayJsonExtensions with LogSupport {
   def query_with_log(
       query: String,
       project: Project,
-      dataContains: String = "",
-      legacy: Boolean = true,
-      batchSize: Int = 5000,
   ): (JsValue, Vector[String]) = {
+    Logger.setDefaultFormatter(SimpleLogFormatter)
+    Logger.setDefaultLogLevel(LogLevel.apply("info"))
+
     val result = queryBinaryCLI(
       request = createSingleQuery(query),
       project = project,
-      legacy = legacy,
-      batchSize = batchSize,
       log_level = "info"
     )
-    result._1.assertSuccessfulResponse(dataContains)
+    result._1.assertSuccessfulResponse()
     result
   }
 

--- a/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/alreadyConverted/NestedDisconnectMutationInsideUpdateSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/alreadyConverted/NestedDisconnectMutationInsideUpdateSpec.scala
@@ -443,7 +443,7 @@ class NestedDisconnectMutationInsideUpdateSpec extends FlatSpec with Matchers wi
         |    }
         |  }){
         |    ${t.parent.selection}
-        |    childrenOpt{
+        |    childrenOpt(orderBy: { id: asc }){
         |       ${t.child.selection}
         |    }
         |  }
@@ -465,7 +465,7 @@ class NestedDisconnectMutationInsideUpdateSpec extends FlatSpec with Matchers wi
         |      connect: [$child1Identifier]
         |    }
         |  }){
-        |    childrenOpt{
+        |    childrenOpt(orderBy: { id: asc }){
         |       ${t.child.selection}
         |    }
         |  }

--- a/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/alreadyConverted/NestedDisconnectMutationInsideUpdateSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/alreadyConverted/NestedDisconnectMutationInsideUpdateSpec.scala
@@ -324,6 +324,10 @@ class NestedDisconnectMutationInsideUpdateSpec extends FlatSpec with Matchers wi
       }
       database.setup(project)
 
+      // Note for review
+      // we were relying of the order of the returned child ids without specifying an order by.
+      // with the direct return of the manyrecord that order seems to have changed in the case where we return the id field
+      // that means depending on whether you have queryargs that do nothing or not your order might change -.-
       val parentResult = server.query(
         s"""mutation {
         |  createParent(data: {
@@ -336,7 +340,7 @@ class NestedDisconnectMutationInsideUpdateSpec extends FlatSpec with Matchers wi
         |    }
         |  }){
         |    ${t.parent.selection}
-        |    childrenOpt{
+        |    childrenOpt(orderBy: { id: asc }){
         |       ${t.child.selection}
         |    }
         |  }
@@ -358,7 +362,7 @@ class NestedDisconnectMutationInsideUpdateSpec extends FlatSpec with Matchers wi
         |      connect: [$firstChild]
         |    }
         |  }){
-        |    childrenOpt{
+        |    childrenOpt(orderBy: { id: asc }){
         |       ${t.child.selection}
         |    }
         |  }
@@ -367,6 +371,9 @@ class NestedDisconnectMutationInsideUpdateSpec extends FlatSpec with Matchers wi
       )
       val otherChild = t.child.whereMulti(otherParentResult, "data.createParent.childrenOpt")(1)
 
+      println("Identifiers")
+      println(parentResult)
+      println(otherParentResult)
       server.queryThatMustFail(
         s"""
          |mutation {

--- a/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/alreadyConverted/NestedDisconnectMutationInsideUpdateSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/alreadyConverted/NestedDisconnectMutationInsideUpdateSpec.scala
@@ -371,9 +371,6 @@ class NestedDisconnectMutationInsideUpdateSpec extends FlatSpec with Matchers wi
       )
       val otherChild = t.child.whereMulti(otherParentResult, "data.createParent.childrenOpt")(1)
 
-      println("Identifiers")
-      println(parentResult)
-      println(otherParentResult)
       server.queryThatMustFail(
         s"""
          |mutation {

--- a/query-engine/connectors/query-connector/src/query_arguments.rs
+++ b/query-engine/connectors/query-connector/src/query_arguments.rs
@@ -47,6 +47,15 @@ impl QueryArguments {
         }
     }
 
+    pub fn do_nothing(&self) -> bool {
+        self.cursor.is_none()
+            && self.take.is_none()
+            && self.skip.is_none()
+            && self.filter.is_none()
+            && self.order_by.is_empty()
+            && self.distinct.is_none()
+    }
+
     /// An unstable cursor is a cursor that is used in conjunction with an unstable (non-unique) combination of orderBys.
     pub fn contains_unstable_cursor(&self) -> bool {
         self.cursor.is_some() && !self.is_stable_ordering()

--- a/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
@@ -27,15 +27,11 @@ pub async fn m2m<'a, 'b>(
         }
     };
     if parent_ids.is_empty() {
-        return Ok(ManyRecords::new(
-            query.selected_fields.names().map(|n| n.to_string()).collect(),
-        ));
+        return Ok(ManyRecords::empty(&query.selected_fields));
     }
     let ids = tx.get_related_m2m_record_ids(&query.parent_field, &parent_ids).await?;
     if ids.is_empty() {
-        return Ok(ManyRecords::new(
-            query.selected_fields.names().map(|n| n.to_string()).collect(),
-        ));
+        return Ok(ManyRecords::empty(&query.selected_fields));
     }
 
     let child_model_id = query.parent_field.related_model().primary_identifier();
@@ -165,9 +161,7 @@ pub async fn one2m<'a, 'b>(
         .collect();
 
     if uniq_projections.is_empty() {
-        return Ok(ManyRecords::new(
-            selected_fields.names().map(|n| n.to_string()).collect(),
-        ));
+        return Ok(ManyRecords::empty(selected_fields));
     }
 
     let filter = child_link_id.is_in(uniq_projections);

--- a/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
@@ -45,7 +45,8 @@ pub async fn m2m<'a, 'b>(
         .collect::<std::result::Result<Vec<_>, _>>()?;
 
     // a roundtrip can be avoided if: there is no additional filter AND the selection set is the child_link_id
-    let mut scalars = if query.args.filter.is_none() && child_link_id == query.selected_fields {
+    println!("{:?}", query.args);
+    let mut scalars = if query.args.do_nothing() && child_link_id == query.selected_fields {
         ManyRecords::from_projection(child_ids, &query.selected_fields)
     } else {
         let mut args = query.args.clone();
@@ -124,7 +125,7 @@ pub async fn one2m<'a, 'b>(
     println!("one2m: {:?}", parent_result);
 
     // Primary ID to link ID
-    let joined_projections = match parent_projections.clone() {
+    let joined_projections = match parent_projections {
         Some(projections) => projections,
         None => {
             let extractor = parent_model_id.clone().merge(parent_link_id.clone());
@@ -168,7 +169,7 @@ pub async fn one2m<'a, 'b>(
     }
 
     // a roundtrip can be avoided if: there is no additional filter AND the selection set is the child_link_id
-    let mut scalars = if query_args.filter.is_none() && &child_link_id == selected_fields {
+    let mut scalars = if query_args.do_nothing() && &child_link_id == selected_fields {
         ManyRecords::from_projection(uniq_projections, selected_fields)
     } else {
         let filter = child_link_id.is_in(uniq_projections);

--- a/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
@@ -26,17 +26,17 @@ pub async fn m2m<'a, 'b>(
                 .projections(&parent_model_id)?
         }
     };
-    if parent_ids.is_empty() {
-        return Ok(ManyRecords::new(
-            query.selected_fields.names().map(|n| n.to_string()).collect(),
-        ));
-    }
+    // if parent_ids.is_empty() {
+    //     return Ok(ManyRecords::new(
+    //         query.selected_fields.names().map(|n| n.to_string()).collect(),
+    //     ));
+    // }
     let ids = tx.get_related_m2m_record_ids(&query.parent_field, &parent_ids).await?;
-    if ids.is_empty() {
-        return Ok(ManyRecords::new(
-            query.selected_fields.names().map(|n| n.to_string()).collect(),
-        ));
-    }
+    // if ids.is_empty() {
+    //     return Ok(ManyRecords::new(
+    //         query.selected_fields.names().map(|n| n.to_string()).collect(),
+    //     ));
+    // }
 
     let child_model_id = query.parent_field.related_model().primary_identifier();
 
@@ -164,11 +164,11 @@ pub async fn one2m<'a, 'b>(
         .filter(|p| !p.iter().any(|v| v.is_null()))
         .collect();
 
-    if uniq_projections.is_empty() {
-        return Ok(ManyRecords::new(
-            selected_fields.names().map(|n| n.to_string()).collect(),
-        ));
-    }
+    // if uniq_projections.is_empty() {
+    //     return Ok(ManyRecords::new(
+    //         selected_fields.names().map(|n| n.to_string()).collect(),
+    //     ));
+    // }
 
     let filter = child_link_id.is_in(uniq_projections);
     let mut args = query_args;

--- a/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
@@ -26,81 +26,80 @@ pub async fn m2m<'a, 'b>(
     };
 
     if parent_ids.is_empty() {
-        Ok(ManyRecords::new(
+        return Ok(ManyRecords::new(
             query.selected_fields.names().map(|n| n.to_string()).collect(),
-        ))
-    } else {
-        let ids = tx.get_related_m2m_record_ids(&query.parent_field, &parent_ids).await?;
-
-        let child_model_id = query.parent_field.related_model().primary_identifier();
-
-        let child_ids: Vec<Vec<PrismaValue>> = ids
-            .iter()
-            .map(|ri| {
-                let proj = child_model_id.assimilate(ri.1.clone());
-                proj.map(|ri| ri.values().collect::<Vec<_>>())
-            })
-            .collect::<std::result::Result<Vec<_>, _>>()?;
-
-        let mut args = query.args.clone();
-        let filter = child_link_id.is_in(child_ids);
-
-        args.filter = match args.filter {
-            Some(existing_filter) => Some(Filter::and(vec![existing_filter, filter])),
-            None => Some(filter),
-        };
-
-        let mut scalars = tx
-            .get_many_records(&query.parent_field.related_model(), args, &query.selected_fields)
-            .await?;
-
-        // Child id to parent ids
-        let mut id_map: HashMap<RecordProjection, Vec<RecordProjection>> = HashMap::new();
-
-        for (parent_id, child_id) in ids {
-            match id_map.get_mut(&child_id) {
-                Some(v) => v.push(parent_id),
-                None => {
-                    id_map.insert(child_id, vec![parent_id]);
-                }
-            };
-        }
-
-        let fields = &scalars.field_names;
-        let mut additional_records: Vec<(usize, Vec<Record>)> = vec![];
-
-        for (index, record) in scalars.records.iter_mut().enumerate() {
-            let record_id = record.projection(fields, &child_model_id)?;
-            let mut parent_ids = id_map.remove(&record_id).expect("1");
-            let first = parent_ids.pop().expect("2");
-
-            record.parent_id = Some(first);
-
-            let mut more_records = vec![];
-
-            for parent_id in parent_ids {
-                let mut record = record.clone();
-
-                record.parent_id = Some(parent_id);
-                more_records.push(record);
-            }
-
-            if !more_records.is_empty() {
-                additional_records.push((index + 1, more_records));
-            }
-        }
-
-        // Start to insert in the back to keep other indices valid.
-        additional_records.reverse();
-
-        for (index, records) in additional_records {
-            for (offset, record) in records.into_iter().enumerate() {
-                scalars.records.insert(index + offset, record);
-            }
-        }
-
-        Ok(processor.apply(scalars))
+        ));
     }
+    let ids = tx.get_related_m2m_record_ids(&query.parent_field, &parent_ids).await?;
+
+    let child_model_id = query.parent_field.related_model().primary_identifier();
+
+    let child_ids: Vec<Vec<PrismaValue>> = ids
+        .iter()
+        .map(|ri| {
+            let proj = child_model_id.assimilate(ri.1.clone());
+            proj.map(|ri| ri.values().collect::<Vec<_>>())
+        })
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+
+    let mut args = query.args.clone();
+    let filter = child_link_id.is_in(child_ids);
+
+    args.filter = match args.filter {
+        Some(existing_filter) => Some(Filter::and(vec![existing_filter, filter])),
+        None => Some(filter),
+    };
+
+    let mut scalars = tx
+        .get_many_records(&query.parent_field.related_model(), args, &query.selected_fields)
+        .await?;
+
+    // Child id to parent ids
+    let mut id_map: HashMap<RecordProjection, Vec<RecordProjection>> = HashMap::new();
+
+    for (parent_id, child_id) in ids {
+        match id_map.get_mut(&child_id) {
+            Some(v) => v.push(parent_id),
+            None => {
+                id_map.insert(child_id, vec![parent_id]);
+            }
+        };
+    }
+
+    let fields = &scalars.field_names;
+    let mut additional_records: Vec<(usize, Vec<Record>)> = vec![];
+
+    for (index, record) in scalars.records.iter_mut().enumerate() {
+        let record_id = record.projection(fields, &child_model_id)?;
+        let mut parent_ids = id_map.remove(&record_id).expect("1");
+        let first = parent_ids.pop().expect("2");
+
+        record.parent_id = Some(first);
+
+        let mut more_records = vec![];
+
+        for parent_id in parent_ids {
+            let mut record = record.clone();
+
+            record.parent_id = Some(parent_id);
+            more_records.push(record);
+        }
+
+        if !more_records.is_empty() {
+            additional_records.push((index + 1, more_records));
+        }
+    }
+
+    // Start to insert in the back to keep other indices valid.
+    additional_records.reverse();
+
+    for (index, records) in additional_records {
+        for (offset, record) in records.into_iter().enumerate() {
+            scalars.records.insert(index + offset, record);
+        }
+    }
+
+    Ok(processor.apply(scalars))
 }
 
 // [DTODO] This is implemented in an inefficient fashion, e.g. too much Arc cloning going on.
@@ -129,100 +128,99 @@ pub async fn one2m<'a, 'b>(
     };
 
     if joined_projections.is_empty() {
-        Ok(ManyRecords::new(
+        return Ok(ManyRecords::new(
             selected_fields.names().map(|n| n.to_string()).collect(),
-        ))
-    } else {
-        // Maps the identifying link values to all primary IDs they are tied to.
-        // Only the values are hashed for easier comparison.
-        let mut link_mapping: HashMap<Vec<PrismaValue>, Vec<RecordProjection>> = HashMap::new();
-        let idents = vec![parent_model_id, parent_link_id];
-        let mut uniq_projections = Vec::new();
+        ));
+    }
+    // Maps the identifying link values to all primary IDs they are tied to.
+    // Only the values are hashed for easier comparison.
+    let mut link_mapping: HashMap<Vec<PrismaValue>, Vec<RecordProjection>> = HashMap::new();
+    let idents = vec![parent_model_id, parent_link_id];
+    let mut uniq_projections = Vec::new();
 
-        let mut scalars = if !joined_projections.is_empty() {
-            for projection in joined_projections {
-                let mut split = projection.split_into(&idents);
-                let link_id = split.pop().unwrap();
-                let id = split.pop().unwrap();
-                let link_values: Vec<PrismaValue> = link_id.pairs.into_iter().map(|(_, v)| v).collect();
+    let mut scalars = if !joined_projections.is_empty() {
+        for projection in joined_projections {
+            let mut split = projection.split_into(&idents);
+            let link_id = split.pop().unwrap();
+            let id = split.pop().unwrap();
+            let link_values: Vec<PrismaValue> = link_id.pairs.into_iter().map(|(_, v)| v).collect();
 
-                match link_mapping.get_mut(&link_values) {
-                    Some(records) => records.push(id),
-                    None => {
-                        let mut ids = Vec::new();
+            match link_mapping.get_mut(&link_values) {
+                Some(records) => records.push(id),
+                None => {
+                    let mut ids = Vec::new();
 
-                        ids.push(id);
-                        uniq_projections.push(link_values.clone());
-                        link_mapping.insert(link_values, ids);
-                    }
+                    ids.push(id);
+                    uniq_projections.push(link_values.clone());
+                    link_mapping.insert(link_values, ids);
                 }
             }
-
-            let uniq_projections = uniq_projections
-                .into_iter()
-                .filter(|p| !p.iter().any(|v| v.is_null()))
-                .collect();
-
-            let filter = child_link_id.is_in(uniq_projections);
-            let mut args = query_args;
-
-            args.filter = match args.filter {
-                Some(existing_filter) => Some(Filter::and(vec![existing_filter, filter])),
-                None => Some(filter),
-            };
-
-            tx.get_many_records(&parent_field.related_model(), args, selected_fields)
-                .await?
-        } else {
-            ManyRecords::new(selected_fields.names().map(|n| n.to_string()).collect())
-        };
-
-        // Inlining is done on the parent, this means that we need to write the primary parent ID
-        // into the child records that we retrieved. The matching is done based on the parent link values.
-        if parent_field.is_inlined_on_enclosing_model() {
-            let mut additional_records = vec![];
-
-            for mut record in scalars.records.iter_mut() {
-                let child_link: RecordProjection = record.projection(&scalars.field_names, &child_link_id)?;
-                let child_link_values: Vec<PrismaValue> = child_link.pairs.into_iter().map(|(_, v)| v).collect();
-
-                if let Some(parent_ids) = link_mapping.get_mut(&child_link_values) {
-                    parent_ids.reverse();
-
-                    let parent_id = parent_ids.pop().unwrap();
-                    record.parent_id = Some(parent_id);
-
-                    for parent_id in parent_ids {
-                        let mut record = record.clone();
-
-                        record.parent_id = Some((*parent_id).clone());
-                        additional_records.push(record);
-                    }
-                }
-            }
-
-            scalars.records.extend(additional_records);
-        } else if parent_field.related_field().is_inlined_on_enclosing_model() {
-            // Parent to map is inlined on the child records
-            let child_link_fields = parent_field.related_field().linking_fields();
-
-            for record in scalars.records.iter_mut() {
-                let child_link: RecordProjection = record.projection(&scalars.field_names, &child_link_fields)?;
-                let child_link_values: Vec<PrismaValue> = child_link.pairs.into_iter().map(|(_, v)| v).collect();
-
-                if let Some(parent_ids) = link_mapping.get(&child_link_values) {
-                    let parent_id = parent_ids.last().unwrap();
-                    record.parent_id = Some(parent_id.clone());
-                }
-            }
-        } else {
-            panic!(format!(
-                "parent result: {:?}, relation: {:?}",
-                &parent_result,
-                &parent_field.relation()
-            ));
         }
 
-        Ok(processor.apply(scalars))
+        let uniq_projections = uniq_projections
+            .into_iter()
+            .filter(|p| !p.iter().any(|v| v.is_null()))
+            .collect();
+
+        let filter = child_link_id.is_in(uniq_projections);
+        let mut args = query_args;
+
+        args.filter = match args.filter {
+            Some(existing_filter) => Some(Filter::and(vec![existing_filter, filter])),
+            None => Some(filter),
+        };
+
+        tx.get_many_records(&parent_field.related_model(), args, selected_fields)
+            .await?
+    } else {
+        ManyRecords::new(selected_fields.names().map(|n| n.to_string()).collect())
+    };
+
+    // Inlining is done on the parent, this means that we need to write the primary parent ID
+    // into the child records that we retrieved. The matching is done based on the parent link values.
+    if parent_field.is_inlined_on_enclosing_model() {
+        let mut additional_records = vec![];
+
+        for mut record in scalars.records.iter_mut() {
+            let child_link: RecordProjection = record.projection(&scalars.field_names, &child_link_id)?;
+            let child_link_values: Vec<PrismaValue> = child_link.pairs.into_iter().map(|(_, v)| v).collect();
+
+            if let Some(parent_ids) = link_mapping.get_mut(&child_link_values) {
+                parent_ids.reverse();
+
+                let parent_id = parent_ids.pop().unwrap();
+                record.parent_id = Some(parent_id);
+
+                for parent_id in parent_ids {
+                    let mut record = record.clone();
+
+                    record.parent_id = Some((*parent_id).clone());
+                    additional_records.push(record);
+                }
+            }
+        }
+
+        scalars.records.extend(additional_records);
+    } else if parent_field.related_field().is_inlined_on_enclosing_model() {
+        // Parent to map is inlined on the child records
+        let child_link_fields = parent_field.related_field().linking_fields();
+
+        for record in scalars.records.iter_mut() {
+            let child_link: RecordProjection = record.projection(&scalars.field_names, &child_link_fields)?;
+            let child_link_values: Vec<PrismaValue> = child_link.pairs.into_iter().map(|(_, v)| v).collect();
+
+            if let Some(parent_ids) = link_mapping.get(&child_link_values) {
+                let parent_id = parent_ids.last().unwrap();
+                record.parent_id = Some(parent_id.clone());
+            }
+        }
+    } else {
+        panic!(format!(
+            "parent result: {:?}, relation: {:?}",
+            &parent_result,
+            &parent_field.relation()
+        ));
     }
+
+    Ok(processor.apply(scalars))
 }

--- a/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
@@ -26,17 +26,17 @@ pub async fn m2m<'a, 'b>(
                 .projections(&parent_model_id)?
         }
     };
-    // if parent_ids.is_empty() {
-    //     return Ok(ManyRecords::new(
-    //         query.selected_fields.names().map(|n| n.to_string()).collect(),
-    //     ));
-    // }
+    if parent_ids.is_empty() {
+        return Ok(ManyRecords::new(
+            query.selected_fields.names().map(|n| n.to_string()).collect(),
+        ));
+    }
     let ids = tx.get_related_m2m_record_ids(&query.parent_field, &parent_ids).await?;
-    // if ids.is_empty() {
-    //     return Ok(ManyRecords::new(
-    //         query.selected_fields.names().map(|n| n.to_string()).collect(),
-    //     ));
-    // }
+    if ids.is_empty() {
+        return Ok(ManyRecords::new(
+            query.selected_fields.names().map(|n| n.to_string()).collect(),
+        ));
+    }
 
     let child_model_id = query.parent_field.related_model().primary_identifier();
 
@@ -164,11 +164,11 @@ pub async fn one2m<'a, 'b>(
         .filter(|p| !p.iter().any(|v| v.is_null()))
         .collect();
 
-    // if uniq_projections.is_empty() {
-    //     return Ok(ManyRecords::new(
-    //         selected_fields.names().map(|n| n.to_string()).collect(),
-    //     ));
-    // }
+    if uniq_projections.is_empty() {
+        return Ok(ManyRecords::new(
+            selected_fields.names().map(|n| n.to_string()).collect(),
+        ));
+    }
 
     let filter = child_link_id.is_in(uniq_projections);
     let mut args = query_args;

--- a/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
@@ -138,43 +138,40 @@ pub async fn one2m<'a, 'b>(
     let idents = vec![parent_model_id, parent_link_id];
     let mut uniq_projections = Vec::new();
 
-    let mut scalars = if !joined_projections.is_empty() {
-        for projection in joined_projections {
-            let mut split = projection.split_into(&idents);
-            let link_id = split.pop().unwrap();
-            let id = split.pop().unwrap();
-            let link_values: Vec<PrismaValue> = link_id.pairs.into_iter().map(|(_, v)| v).collect();
+    for projection in joined_projections {
+        let mut split = projection.split_into(&idents);
+        let link_id = split.pop().unwrap();
+        let id = split.pop().unwrap();
+        let link_values: Vec<PrismaValue> = link_id.pairs.into_iter().map(|(_, v)| v).collect();
 
-            match link_mapping.get_mut(&link_values) {
-                Some(records) => records.push(id),
-                None => {
-                    let mut ids = Vec::new();
+        match link_mapping.get_mut(&link_values) {
+            Some(records) => records.push(id),
+            None => {
+                let mut ids = Vec::new();
 
-                    ids.push(id);
-                    uniq_projections.push(link_values.clone());
-                    link_mapping.insert(link_values, ids);
-                }
+                ids.push(id);
+                uniq_projections.push(link_values.clone());
+                link_mapping.insert(link_values, ids);
             }
         }
+    }
 
-        let uniq_projections = uniq_projections
-            .into_iter()
-            .filter(|p| !p.iter().any(|v| v.is_null()))
-            .collect();
+    let uniq_projections = uniq_projections
+        .into_iter()
+        .filter(|p| !p.iter().any(|v| v.is_null()))
+        .collect();
 
-        let filter = child_link_id.is_in(uniq_projections);
-        let mut args = query_args;
+    let filter = child_link_id.is_in(uniq_projections);
+    let mut args = query_args;
 
-        args.filter = match args.filter {
-            Some(existing_filter) => Some(Filter::and(vec![existing_filter, filter])),
-            None => Some(filter),
-        };
-
-        tx.get_many_records(&parent_field.related_model(), args, selected_fields)
-            .await?
-    } else {
-        ManyRecords::new(selected_fields.names().map(|n| n.to_string()).collect())
+    args.filter = match args.filter {
+        Some(existing_filter) => Some(Filter::and(vec![existing_filter, filter])),
+        None => Some(filter),
     };
+
+    let mut scalars = tx
+        .get_many_records(&parent_field.related_model(), args, selected_fields)
+        .await?;
 
     // Inlining is done on the parent, this means that we need to write the primary parent ID
     // into the child records that we retrieved. The matching is done based on the parent link values.

--- a/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
@@ -30,6 +30,8 @@ pub async fn m2m<'a, 'b>(
         return Ok(ManyRecords::empty(&query.selected_fields));
     }
     let ids = tx.get_related_m2m_record_ids(&query.parent_field, &parent_ids).await?;
+
+    println!("M2M id pairs: {:?}", ids);
     if ids.is_empty() {
         return Ok(ManyRecords::empty(&query.selected_fields));
     }
@@ -44,8 +46,8 @@ pub async fn m2m<'a, 'b>(
         })
         .collect::<std::result::Result<Vec<_>, _>>()?;
 
+    println!("M2M args {:?}", query.args.do_nothing());
     // a roundtrip can be avoided if: there is no additional filter AND the selection set is the child_link_id
-    println!("{:?}", query.args);
     let mut scalars = if query.args.do_nothing() && child_link_id == query.selected_fields {
         ManyRecords::from_projection(child_ids, &query.selected_fields)
     } else {

--- a/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
@@ -14,8 +14,6 @@ pub async fn m2m<'a, 'b>(
     let parent_field = &query.parent_field;
     let child_link_id = parent_field.related_field().linking_fields();
 
-    println!("m2m: {:?}", parent_result);
-
     // We know that in a m2m scenario, we always require the ID of the parent, nothing else.
     let parent_ids = match query.parent_projections {
         Some(ref links) => links.clone(),
@@ -31,7 +29,6 @@ pub async fn m2m<'a, 'b>(
     }
     let ids = tx.get_related_m2m_record_ids(&query.parent_field, &parent_ids).await?;
 
-    println!("M2M id pairs: {:?}", ids);
     if ids.is_empty() {
         return Ok(ManyRecords::empty(&query.selected_fields));
     }
@@ -46,7 +43,6 @@ pub async fn m2m<'a, 'b>(
         })
         .collect::<std::result::Result<Vec<_>, _>>()?;
 
-    println!("M2M args {:?}", query.args.do_nothing());
     // a roundtrip can be avoided if: there is no additional filter AND the selection set is the child_link_id
     let mut scalars = if query.args.do_nothing() && child_link_id == query.selected_fields {
         ManyRecords::from_projection(child_ids, &query.selected_fields)
@@ -123,8 +119,6 @@ pub async fn one2m<'a, 'b>(
     let parent_model_id = parent_field.model().primary_identifier();
     let parent_link_id = parent_field.linking_fields();
     let child_link_id = parent_field.related_field().linking_fields();
-
-    println!("one2m: {:?}", parent_result);
 
     // Primary ID to link ID
     let joined_projections = match parent_projections {

--- a/query-engine/core/src/interpreter/query_interpreters/read.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/read.rs
@@ -76,9 +76,6 @@ fn read_many<'a, 'b>(
     let fut = async move {
         println!("Read many: {:?}", query.args.filter);
 
-        // let scalars = if query.args.returns_nothing() {
-        //     ManyRecords::new(query.selected_fields.names().map(|n| n.to_string()).collect())
-        // } else
         let scalars = if query.args.distinct.is_some() || query.args.contains_unstable_cursor() {
             let processor = InMemoryRecordProcessor::new_from_query_args(&mut query.args);
             let scalars = tx

--- a/query-engine/core/src/interpreter/query_interpreters/read.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/read.rs
@@ -176,6 +176,8 @@ fn process_nested<'a, 'b>(
         println!("Process nested: {:?}", parent_result);
 
         let results = if matches!(parent_result, Some(parent_records) if parent_records.records.is_empty()) {
+            //this catches most cases where there is no parent to cause a nested query. but sometimes even with parent records,
+            // we do not need to do roundtrips which is why the nested_reads contain additional logic
             vec![]
         } else {
             let mut nested_results = Vec::with_capacity(nested.len());

--- a/query-engine/core/src/interpreter/query_interpreters/read.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/read.rs
@@ -175,13 +175,18 @@ fn process_nested<'a, 'b>(
     let fut = async move {
         println!("Process nested: {:?}", parent_result);
 
-        let mut results = Vec::with_capacity(nested.len());
+        let results = if matches!(parent_result, Some(parent_records) if parent_records.records.is_empty()) {
+            vec![]
+        } else {
+            let mut nested_results = Vec::with_capacity(nested.len());
 
-        for query in nested {
-            let result = execute(tx, query, parent_result).await?;
-            results.push(result);
-        }
+            for query in nested {
+                let result = execute(tx, query, parent_result).await?;
+                nested_results.push(result);
+            }
 
+            nested_results
+        };
         Ok(results)
     };
 

--- a/query-engine/core/src/interpreter/query_interpreters/read.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/read.rs
@@ -138,11 +138,8 @@ fn read_related<'a, 'b>(
         let model = query.parent_field.related_model();
         let model_id = model.primary_identifier();
 
-        // let nested: Vec<QueryResult> = if scalars.records.is_empty() {
-        //     vec![]
-        // } else {
-        //     process_nested(tx, query.nested, Some(&scalars)).await?
-        // };
+        println!("Read related scalars: {:?}", scalars);
+
         let nested: Vec<QueryResult> = process_nested(tx, query.nested, Some(&scalars)).await?;
 
         Ok(QueryResult::RecordSelection(RecordSelection {
@@ -180,18 +177,15 @@ fn process_nested<'a, 'b>(
 ) -> BoxFuture<'a, InterpretationResult<Vec<QueryResult>>> {
     let fut = async move {
         println!("Process nested: {:?}", parent_result);
-        if matches!(parent_result, Some(records) if records.is_empty()) {
-            Ok(vec![])
-        } else {
-            let mut results = Vec::with_capacity(nested.len());
 
-            for query in nested {
-                let result = execute(tx, query, parent_result).await?;
-                results.push(result);
-            }
+        let mut results = Vec::with_capacity(nested.len());
 
-            Ok(results)
+        for query in nested {
+            let result = execute(tx, query, parent_result).await?;
+            results.push(result);
         }
+
+        Ok(results)
     };
 
     fut.boxed()

--- a/query-engine/core/src/interpreter/query_interpreters/read.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/read.rs
@@ -30,7 +30,6 @@ fn read_one<'conn, 'tx>(
     let fut = async move {
         let model = query.model;
         let model_id = model.primary_identifier();
-        println!("Read One: {:?}", &query.filter);
         let filter = query.filter.expect("Expected filter to be set for ReadOne query.");
         let scalars = tx.get_single_record(&model, &filter, &query.selected_fields).await?;
 
@@ -74,8 +73,6 @@ fn read_many<'a, 'b>(
     mut query: ManyRecordsQuery,
 ) -> BoxFuture<'a, InterpretationResult<QueryResult>> {
     let fut = async move {
-        println!("Read many: {:?}", query.args.filter);
-
         let scalars = if query.args.distinct.is_some() || query.args.contains_unstable_cursor() {
             let processor = InMemoryRecordProcessor::new_from_query_args(&mut query.args);
             let scalars = tx
@@ -111,8 +108,6 @@ fn read_related<'a, 'b>(
     parent_result: Option<&'a ManyRecords>,
 ) -> BoxFuture<'a, InterpretationResult<QueryResult>> {
     let fut = async move {
-        println!("Read related: {:?}", parent_result);
-
         let relation = query.parent_field.relation();
         let is_m2m = relation.is_many_to_many();
         let processor = InMemoryRecordProcessor::new_from_query_args(&mut query.args);
@@ -134,9 +129,6 @@ fn read_related<'a, 'b>(
 
         let model = query.parent_field.related_model();
         let model_id = model.primary_identifier();
-
-        println!("Read related scalars: {:?}", scalars);
-
         let nested: Vec<QueryResult> = process_nested(tx, query.nested, Some(&scalars)).await?;
 
         Ok(QueryResult::RecordSelection(RecordSelection {
@@ -173,8 +165,6 @@ fn process_nested<'a, 'b>(
     parent_result: Option<&'a ManyRecords>,
 ) -> BoxFuture<'a, InterpretationResult<Vec<QueryResult>>> {
     let fut = async move {
-        println!("Process nested: {:?}", parent_result);
-
         let results = if matches!(parent_result, Some(parent_records) if parent_records.records.is_empty()) {
             //this catches most cases where there is no parent to cause a nested query. but sometimes even with parent records,
             // we do not need to do roundtrips which is why the nested_reads contain additional logic


### PR DESCRIPTION
- stop trying to fetch children if there are no parent records
- do not do queries like: `Select id from User where User.id in [...]`
- plumbing to parse and validate generated sql statements

Fixes https://github.com/prisma/prisma-engines/issues/969
Fixes https://github.com/prisma/prisma-engines/issues/1045