### PR TITLE
 Specialize ALTER TABLE on SQLite to avoid multi-line alter tables 

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/flavour.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour.rs
@@ -3,9 +3,13 @@
 //! detail of the SQL connector.
 
 use crate::{
-    catch, connect, database_info::DatabaseInfo, sql_destructive_change_checker::DestructiveChangeCheckerFlavour,
-    sql_renderer::SqlRenderer, sql_schema_differ::SqlSchemaDifferFlavour, CheckDatabaseInfoResult, SqlError, SqlResult,
-    SystemDatabase,
+    catch, connect,
+    database_info::DatabaseInfo,
+    error::{CheckDatabaseInfoResult, SystemDatabase},
+    sql_destructive_change_checker::DestructiveChangeCheckerFlavour,
+    sql_renderer::SqlRenderer,
+    sql_schema_differ::SqlSchemaDifferFlavour,
+    SqlError, SqlResult,
 };
 use futures::future::TryFutureExt;
 use migration_connector::{ConnectorError, ConnectorResult};

--- a/migration-engine/connectors/sql-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/lib.rs
@@ -1,6 +1,8 @@
-#![deny(rust_2018_idioms)]
-#![deny(unsafe_code)]
+#![deny(rust_2018_idioms, unsafe_code)]
 #![allow(clippy::trivial_regex)] // these will grow
+
+// This is public for test purposes.
+pub mod sql_migration;
 
 mod component;
 mod database_info;
@@ -9,14 +11,12 @@ mod flavour;
 mod sql_database_migration_inferrer;
 mod sql_database_step_applier;
 mod sql_destructive_change_checker;
-mod sql_migration;
 mod sql_migration_persistence;
 mod sql_renderer;
 mod sql_schema_calculator;
 mod sql_schema_differ;
 
-pub use error::*;
-pub use sql_migration::*;
+pub use error::{SqlError, SqlResult};
 pub use sql_migration_persistence::MIGRATION_TABLE_NAME;
 
 use component::Component;
@@ -31,6 +31,7 @@ use quaint::{
 use sql_database_migration_inferrer::*;
 use sql_database_step_applier::*;
 use sql_destructive_change_checker::*;
+use sql_migration::SqlMigration;
 use sql_migration_persistence::*;
 use sql_schema_describer::SqlSchema;
 use std::{sync::Arc, time::Duration};

--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_migration_inferrer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_migration_inferrer.rs
@@ -3,6 +3,7 @@ use crate::{sql_schema_calculator::SqlSchemaCalculator, sql_schema_differ::SqlSc
 use datamodel::*;
 use migration_connector::steps::MigrationStep;
 use migration_connector::*;
+use sql_migration::SqlMigrationStep;
 use sql_schema_describer::*;
 
 pub struct SqlDatabaseMigrationInferrer<'a> {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
@@ -1,12 +1,9 @@
 use crate::*;
-use sql_migration::{
-    AddColumn, AddForeignKey, AlterColumn, AlterTable, CreateTable, DropColumn, DropForeignKey, DropTable,
-    SqlMigrationStep, TableChange,
-};
-use sql_renderer::{IteratorJoin, Quoted, RenderedAlterColumn};
-use sql_schema_describer::walkers::{find_column, ColumnWalker, SqlSchemaExt};
+use sql_migration::{AddForeignKey, CreateTable, DropForeignKey, DropTable, SqlMigrationStep};
+use sql_renderer::{IteratorJoin, Quoted};
+use sql_schema_describer::walkers::SqlSchemaExt;
 use sql_schema_describer::{Index, IndexType, SqlSchema};
-use sql_schema_differ::{ColumnDiffer, SqlSchemaDiffer};
+use sql_schema_differ::SqlSchemaDiffer;
 use std::fmt::Write as _;
 use tracing_futures::Instrument;
 use SqlFlavour;
@@ -202,101 +199,8 @@ fn render_raw_sql(
             SqlFamily::Mssql => todo!("Greetings from Redmond"),
         },
 
-        SqlMigrationStep::AlterTable(AlterTable { table, changes }) => {
-            let mut lines = Vec::new();
-            let mut before_statements = Vec::new();
-            let mut after_statements = Vec::new();
-
-            for change in changes {
-                match change {
-                    TableChange::DropPrimaryKey { constraint_name } => match renderer.sql_family() {
-                        SqlFamily::Mysql => lines.push("DROP PRIMARY KEY".to_owned()),
-                        SqlFamily::Postgres => lines.push(format!(
-                            "DROP CONSTRAINT {}",
-                            Quoted::postgres_ident(
-                                constraint_name
-                                    .as_ref()
-                                    .expect("Missing constraint name for DROP CONSTRAINT on Postgres.")
-                            )
-                        )),
-                        _ => (),
-                    },
-                    TableChange::AddPrimaryKey { columns } => lines.push(format!(
-                        "ADD PRIMARY KEY ({})",
-                        columns.iter().map(|colname| renderer.quote(colname)).join(", ")
-                    )),
-                    TableChange::AddColumn(AddColumn { column }) => {
-                        let column = ColumnWalker {
-                            table,
-                            schema: next_schema,
-                            column,
-                        };
-                        let col_sql = renderer.render_column(&schema_name, column, true);
-                        lines.push(format!("ADD COLUMN {}", col_sql));
-                    }
-                    TableChange::DropColumn(DropColumn { name }) => {
-                        let name = renderer.quote(&name);
-                        lines.push(format!("DROP COLUMN {}", name));
-                    }
-                    TableChange::AlterColumn(AlterColumn { name, column }) => {
-                        match safe_alter_column(
-                            renderer,
-                            current_schema.table_walker(&table.name).unwrap().column(&name).unwrap(),
-                            find_column(next_schema, &table.name, &column.name)
-                                .expect("Invariant violation: could not find column referred to in AlterColumn."),
-                            &database_info,
-                            renderer,
-                        ) {
-                            Some(RenderedAlterColumn {
-                                alter_columns,
-                                before,
-                                after,
-                            }) => {
-                                for statement in alter_columns {
-                                    lines.push(statement);
-                                }
-
-                                if let Some(before) = before {
-                                    before_statements.push(before);
-                                }
-
-                                if let Some(after) = after {
-                                    after_statements.push(after);
-                                }
-                            }
-                            None => {
-                                let name = renderer.quote(&name);
-                                lines.push(format!("DROP COLUMN {}", name));
-                                let column = ColumnWalker {
-                                    schema: next_schema,
-                                    table,
-                                    column,
-                                };
-                                let col_sql = renderer.render_column(&schema_name, column, true);
-                                lines.push(format!("ADD COLUMN {}", col_sql));
-                            }
-                        }
-                    }
-                };
-            }
-
-            if lines.is_empty() {
-                return Ok(Vec::new());
-            }
-
-            let alter_table = format!(
-                "ALTER TABLE {} {}",
-                renderer.quote_with_schema(&schema_name, &table.name),
-                lines.join(",\n")
-            );
-
-            let statements = before_statements
-                .into_iter()
-                .chain(std::iter::once(alter_table))
-                .chain(after_statements.into_iter())
-                .collect();
-
-            Ok(statements)
+        SqlMigrationStep::AlterTable(alter_table) => {
+            Ok(renderer.render_alter_table(alter_table, database_info, &differ))
         }
         SqlMigrationStep::CreateIndex(create_index) => {
             Ok(vec![renderer.render_create_index(create_index, database_info)])
@@ -337,21 +241,4 @@ pub(crate) fn render_create_index(
         table_reference = table_reference,
         columns = columns.join(", ")
     )
-}
-
-fn safe_alter_column(
-    renderer: &dyn SqlFlavour,
-    previous_column: ColumnWalker<'_>,
-    next_column: ColumnWalker<'_>,
-    database_info: &DatabaseInfo,
-    flavour: &dyn SqlFlavour,
-) -> Option<RenderedAlterColumn> {
-    let differ = ColumnDiffer {
-        previous: previous_column,
-        next: next_column,
-        database_info,
-        flavour,
-    };
-
-    renderer.render_alter_column(&differ)
 }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
@@ -1,4 +1,8 @@
 use crate::*;
+use sql_migration::{
+    AddColumn, AddForeignKey, AlterColumn, AlterTable, CreateTable, DropColumn, DropForeignKey, DropTable,
+    SqlMigrationStep, TableChange,
+};
 use sql_renderer::{IteratorJoin, Quoted, RenderedAlterColumn};
 use sql_schema_describer::walkers::{find_column, ColumnWalker, SqlSchemaExt};
 use sql_schema_describer::{Index, IndexType, SqlSchema};

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker.rs
@@ -8,8 +8,9 @@ mod warning_check;
 pub(crate) use destructive_change_checker_flavour::DestructiveChangeCheckerFlavour;
 
 use crate::{
+    sql_migration::{AlterEnum, CreateIndex, DropTable, SqlMigrationStep, TableChange},
     sql_schema_differ::{ColumnDiffer, TableDiffer},
-    AlterEnum, Component, CreateIndex, DropTable, SqlMigration, SqlMigrationStep, SqlResult, TableChange,
+    Component, SqlMigration, SqlResult,
 };
 use destructive_check_plan::DestructiveCheckPlan;
 use migration_connector::{ConnectorResult, DestructiveChangeChecker, DestructiveChangeDiagnostics};

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/mysql.rs
@@ -1,11 +1,11 @@
 use super::DestructiveChangeCheckerFlavour;
 use crate::{
-    expanded_alter_column::{expand_mysql_alter_column, MysqlAlterColumn},
     flavour::MysqlFlavour,
     sql_destructive_change_checker::{
         destructive_check_plan::DestructiveCheckPlan, unexecutable_step_check::UnexecutableStepCheck,
         warning_check::SqlMigrationWarningCheck,
     },
+    sql_migration::expanded_alter_column::{expand_mysql_alter_column, MysqlAlterColumn},
     sql_schema_differ::ColumnDiffer,
 };
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/postgres.rs
@@ -1,11 +1,11 @@
 use super::DestructiveChangeCheckerFlavour;
 use crate::{
-    expanded_alter_column::{expand_postgres_alter_column, PostgresAlterColumn},
     flavour::PostgresFlavour,
     sql_destructive_change_checker::{
         destructive_check_plan::DestructiveCheckPlan, unexecutable_step_check::UnexecutableStepCheck,
         warning_check::SqlMigrationWarningCheck,
     },
+    sql_migration::expanded_alter_column::{expand_postgres_alter_column, PostgresAlterColumn},
     sql_schema_differ::ColumnDiffer,
 };
 use sql_schema_describer::{ColumnArity, DefaultValue};

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer.rs
@@ -7,8 +7,8 @@ pub(crate) use common::{IteratorJoin, Quoted, QuotedWithSchema};
 
 use crate::{
     database_info::DatabaseInfo,
+    sql_migration::{AlterEnum, AlterIndex, AlterTable, CreateEnum, CreateIndex, DropEnum, DropIndex},
     sql_schema_differ::{ColumnDiffer, SqlSchemaDiffer},
-    AlterEnum, AlterIndex, CreateEnum, CreateIndex, DropEnum, DropIndex,
 };
 use sql_schema_describer::walkers::{ColumnWalker, TableWalker};
 use sql_schema_describer::*;

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer.rs
@@ -7,9 +7,13 @@ pub(crate) use common::{IteratorJoin, Quoted, QuotedWithSchema};
 
 use crate::{
     database_info::DatabaseInfo,
-    sql_migration::{AlterEnum, AlterIndex, AlterTable, CreateEnum, CreateIndex, DropEnum, DropIndex},
+    sql_migration::{
+        AddColumn, AlterColumn, AlterEnum, AlterIndex, AlterTable, CreateEnum, CreateIndex, DropColumn, DropEnum,
+        DropIndex, TableChange,
+    },
     sql_schema_differ::{ColumnDiffer, SqlSchemaDiffer},
 };
+use quaint::prelude::SqlFamily;
 use sql_schema_describer::walkers::{ColumnWalker, TableWalker};
 use sql_schema_describer::*;
 use std::borrow::Cow;
@@ -50,6 +54,107 @@ pub(crate) trait SqlRenderer {
         database_info: &DatabaseInfo,
         current_schema: &SqlSchema,
     ) -> anyhow::Result<Vec<String>>;
+
+    fn render_alter_table(
+        &self,
+        alter_table: &AlterTable,
+        database_info: &DatabaseInfo,
+        differ: &SqlSchemaDiffer<'_>,
+    ) -> Vec<String> {
+        let AlterTable { table, changes } = alter_table;
+        let schema_name = database_info.connection_info().schema_name();
+
+        {
+            let mut lines = Vec::new();
+            let mut before_statements = Vec::new();
+            let mut after_statements = Vec::new();
+
+            for change in changes {
+                match change {
+                    TableChange::DropPrimaryKey { constraint_name } => match database_info.sql_family() {
+                        SqlFamily::Mysql => lines.push("DROP PRIMARY KEY".to_owned()),
+                        SqlFamily::Postgres => lines.push(format!(
+                            "DROP CONSTRAINT {}",
+                            Quoted::postgres_ident(
+                                constraint_name
+                                    .as_ref()
+                                    .expect("Missing constraint name for DROP CONSTRAINT on Postgres.")
+                            )
+                        )),
+                        _ => (),
+                    },
+                    TableChange::AddPrimaryKey { columns } => lines.push(format!(
+                        "ADD PRIMARY KEY ({})",
+                        columns.iter().map(|colname| self.quote(colname)).join(", ")
+                    )),
+                    TableChange::AddColumn(AddColumn { column }) => {
+                        let column = ColumnWalker {
+                            table,
+                            schema: differ.next,
+                            column,
+                        };
+                        let col_sql = self.render_column(&schema_name, column, true);
+                        lines.push(format!("ADD COLUMN {}", col_sql));
+                    }
+                    TableChange::DropColumn(DropColumn { name }) => {
+                        let name = self.quote(&name);
+                        lines.push(format!("DROP COLUMN {}", name));
+                    }
+                    TableChange::AlterColumn(AlterColumn { name, column: _ }) => {
+                        let column = differ
+                            .diff_table(&table.name)
+                            .expect("AlterTable on unknown table.")
+                            .diff_column(name)
+                            .expect("AlterColumn on unknown column.");
+                        match self.render_alter_column(&column) {
+                            Some(RenderedAlterColumn {
+                                alter_columns,
+                                before,
+                                after,
+                            }) => {
+                                for statement in alter_columns {
+                                    lines.push(statement);
+                                }
+
+                                if let Some(before) = before {
+                                    before_statements.push(before);
+                                }
+
+                                if let Some(after) = after {
+                                    after_statements.push(after);
+                                }
+                            }
+                            None => {
+                                let name = self.quote(&name);
+                                lines.push(format!("DROP COLUMN {}", name));
+
+                                let col_sql = self.render_column(&schema_name, column.next, true);
+                                lines.push(format!("ADD COLUMN {}", col_sql));
+                            }
+                        }
+                    }
+                };
+            }
+
+            if lines.is_empty() {
+                return Vec::new();
+            }
+
+            let alter_table = format!(
+                "ALTER TABLE {} {}",
+                self.quote_with_schema(&schema_name, &table.name),
+                lines.join(",\n")
+            );
+
+            let statements = before_statements
+                .into_iter()
+                .chain(std::iter::once(alter_table))
+                .chain(after_statements.into_iter())
+                .collect();
+
+            statements
+        }
+    }
 
     /// Render a `CreateEnum` step.
     fn render_create_enum(&self, create_enum: &CreateEnum) -> Vec<String>;

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
@@ -1,11 +1,13 @@
 use super::{common::*, RenderedAlterColumn, SqlRenderer};
 use crate::{
     database_info::DatabaseInfo,
-    expanded_alter_column::{expand_mysql_alter_column, MysqlAlterColumn},
     flavour::{MysqlFlavour, SqlFlavour},
     sql_database_step_applier::render_create_index,
+    sql_migration::{
+        expanded_alter_column::{expand_mysql_alter_column, MysqlAlterColumn},
+        AlterEnum, AlterIndex, CreateEnum, CreateIndex, DropEnum, DropIndex,
+    },
     sql_schema_differ::{ColumnChanges, ColumnDiffer, SqlSchemaDiffer},
-    AlterEnum, AlterIndex, CreateIndex, DropIndex,
 };
 use once_cell::sync::Lazy;
 use prisma_value::PrismaValue;
@@ -190,7 +192,7 @@ impl SqlRenderer for MysqlFlavour {
         })
     }
 
-    fn render_create_enum(&self, _create_enum: &crate::CreateEnum) -> Vec<String> {
+    fn render_create_enum(&self, _create_enum: &CreateEnum) -> Vec<String> {
         Vec::new() // enums are defined on each column that uses them on MySQL
     }
 
@@ -256,7 +258,7 @@ impl SqlRenderer for MysqlFlavour {
         ))
     }
 
-    fn render_drop_enum(&self, _drop_enum: &crate::DropEnum) -> Vec<String> {
+    fn render_drop_enum(&self, _drop_enum: &DropEnum) -> Vec<String> {
         Vec::new()
     }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
@@ -1,11 +1,13 @@
 use super::{common::*, RenderedAlterColumn, SqlRenderer};
 use crate::{
     database_info::DatabaseInfo,
-    expanded_alter_column::{expand_postgres_alter_column, PostgresAlterColumn},
     flavour::PostgresFlavour,
     sql_database_step_applier::render_create_index,
+    sql_migration::{
+        expanded_alter_column::{expand_postgres_alter_column, PostgresAlterColumn},
+        AlterEnum, AlterIndex, CreateEnum, CreateIndex, DropEnum, DropIndex,
+    },
     sql_schema_differ::{ColumnDiffer, SqlSchemaDiffer},
-    AlterEnum, AlterIndex, CreateIndex, DropIndex,
 };
 use once_cell::sync::Lazy;
 use prisma_value::PrismaValue;
@@ -278,7 +280,7 @@ impl SqlRenderer for PostgresFlavour {
         Some(rendered_steps)
     }
 
-    fn render_create_enum(&self, create_enum: &crate::CreateEnum) -> Vec<String> {
+    fn render_create_enum(&self, create_enum: &CreateEnum) -> Vec<String> {
         let sql = format!(
             r#"CREATE TYPE {enum_name} AS ENUM ({variants})"#,
             enum_name = Quoted::postgres_ident(&create_enum.name),
@@ -320,7 +322,7 @@ impl SqlRenderer for PostgresFlavour {
         ))
     }
 
-    fn render_drop_enum(&self, drop_enum: &crate::DropEnum) -> Vec<String> {
+    fn render_drop_enum(&self, drop_enum: &DropEnum) -> Vec<String> {
         let sql = format!(
             "DROP TYPE {enum_name}",
             enum_name = Quoted::postgres_ident(&drop_enum.name),

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
@@ -3,8 +3,8 @@ use crate::{
     database_info::DatabaseInfo,
     flavour::{SqlFlavour, SqliteFlavour},
     sql_database_step_applier::render_create_index,
+    sql_migration::{AlterEnum, AlterIndex, CreateEnum, CreateIndex, DropEnum, DropIndex},
     sql_schema_differ::{ColumnDiffer, SqlSchemaDiffer, TableDiffer},
-    AlterEnum, AlterIndex, CreateIndex, DropIndex,
 };
 use once_cell::sync::Lazy;
 use prisma_value::PrismaValue;
@@ -105,7 +105,7 @@ impl SqlRenderer for SqliteFlavour {
         None
     }
 
-    fn render_create_enum(&self, _create_enum: &crate::CreateEnum) -> Vec<String> {
+    fn render_create_enum(&self, _create_enum: &CreateEnum) -> Vec<String> {
         Vec::new()
     }
 
@@ -155,7 +155,7 @@ impl SqlRenderer for SqliteFlavour {
         ))
     }
 
-    fn render_drop_enum(&self, _drop_enum: &crate::DropEnum) -> Vec<String> {
+    fn render_drop_enum(&self, _drop_enum: &DropEnum) -> Vec<String> {
         Vec::new()
     }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
@@ -10,9 +10,14 @@ pub(crate) use table::TableDiffer;
 
 use crate::*;
 use enums::EnumDiffer;
-use sql_schema_describer::walkers::ForeignKeyWalker;
-use sql_schema_describer::walkers::TableWalker;
-use sql_schema_describer::*;
+use sql_migration::{
+    AddColumn, AddForeignKey, AlterColumn, AlterEnum, AlterIndex, AlterTable, CreateEnum, CreateIndex, CreateTable,
+    DropColumn, DropEnum, DropForeignKey, DropIndex, DropTable, SqlMigrationStep, TableChange,
+};
+use sql_schema_describer::{
+    walkers::{ForeignKeyWalker, TableWalker},
+    *,
+};
 use std::collections::HashSet;
 
 #[derive(Debug)]

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
@@ -19,6 +19,7 @@ use sql_schema_describer::{
     *,
 };
 use std::collections::HashSet;
+use walkers::SqlSchemaExt;
 
 #[derive(Debug)]
 pub(crate) struct SqlSchemaDiffer<'a> {
@@ -93,6 +94,15 @@ impl<'schema> SqlSchemaDiffer<'schema> {
             database_info,
         };
         differ.diff_internal()
+    }
+
+    pub(crate) fn diff_table(&self, table_name: &str) -> Option<TableDiffer<'schema>> {
+        Some(TableDiffer {
+            database_info: self.database_info,
+            flavour: self.flavour,
+            previous: self.previous.table_walker(table_name)?,
+            next: self.next.table_walker(table_name)?,
+        })
     }
 
     fn diff_internal(&self) -> SqlSchemaDiff {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/table.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/table.rs
@@ -28,6 +28,15 @@ impl<'schema> TableDiffer<'schema> {
             })
     }
 
+    pub(crate) fn diff_column(&self, column_name: &str) -> Option<ColumnDiffer<'schema>> {
+        Some(ColumnDiffer {
+            flavour: self.flavour,
+            database_info: self.database_info,
+            previous: self.previous.column(column_name)?,
+            next: self.next.column(column_name)?,
+        })
+    }
+
     pub(crate) fn dropped_columns<'a>(&'a self) -> impl Iterator<Item = ColumnWalker<'schema>> + 'a {
         self.previous_columns().filter(move |previous_column| {
             self.next_columns()

--- a/migration-engine/migration-engine-tests/src/command_helpers.rs
+++ b/migration-engine/migration-engine-tests/src/command_helpers.rs
@@ -1,5 +1,5 @@
 use migration_core::commands::*;
-use sql_migration_connector::SqlMigrationStep;
+use sql_migration_connector::sql_migration::SqlMigrationStep;
 use sql_schema_describer::*;
 
 #[derive(Debug)]

--- a/migration-engine/migration-engine-tests/src/sql/multi_user.rs
+++ b/migration-engine/migration-engine-tests/src/sql/multi_user.rs
@@ -9,6 +9,7 @@ use futures::{future::Ready, FutureExt, TryFutureExt};
 use git_repo::GitRepo;
 use migration_connector::{Migration, MigrationConnector};
 use migration_core::{api::MigrationApi, commands::MigrationStepsResultOutput};
+use sql_migration_connector::{sql_migration::SqlMigration, SqlMigrationConnector};
 use std::{
     io::{Read as _, Write as _},
     path::{Path, PathBuf},
@@ -87,7 +88,7 @@ pub struct User<'a> {
     migrations_folder: PathBuf,
     schema_path: PathBuf,
     git_repo: GitRepo,
-    engine: MigrationApi<sql_migration_connector::SqlMigrationConnector, sql_migration_connector::SqlMigration>,
+    engine: MigrationApi<SqlMigrationConnector, SqlMigration>,
 }
 
 impl<'a> User<'a> {
@@ -397,10 +398,7 @@ fn user_engine<'b>(
     db_name: String,
     url: String,
     provider: &'static str,
-) -> BoxFut<
-    'b,
-    anyhow::Result<MigrationApi<sql_migration_connector::SqlMigrationConnector, sql_migration_connector::SqlMigration>>,
-> {
+) -> BoxFut<'b, anyhow::Result<MigrationApi<SqlMigrationConnector, SqlMigration>>> {
     let fut = async move {
         let connector = match provider {
             "mysql" => mysql_migration_connector(&url).await,

--- a/migration-engine/migration-engine-tests/src/test_api.rs
+++ b/migration-engine/migration-engine-tests/src/test_api.rs
@@ -24,7 +24,7 @@ use migration_core::{
     commands::ApplyMigrationInput,
 };
 use quaint::prelude::{ConnectionInfo, Queryable, SqlFamily};
-use sql_migration_connector::MIGRATION_TABLE_NAME;
+use sql_migration_connector::{sql_migration::SqlMigration, SqlMigrationConnector, MIGRATION_TABLE_NAME};
 use sql_schema_describer::*;
 use std::sync::Arc;
 use test_setup::*;
@@ -35,7 +35,7 @@ pub struct TestApi {
     /// More precise than SqlFamily.
     connector_name: &'static str,
     database: Arc<dyn Queryable + Send + Sync + 'static>,
-    api: MigrationApi<sql_migration_connector::SqlMigrationConnector, sql_migration_connector::SqlMigration>,
+    api: MigrationApi<SqlMigrationConnector, SqlMigration>,
     connection_info: ConnectionInfo,
 }
 

--- a/migration-engine/migration-engine-tests/tests/migration_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migration_tests.rs
@@ -2405,7 +2405,7 @@ async fn migrating_a_unique_constraint_to_a_primary_key_works(api: &TestApi) -> 
     Ok(())
 }
 
-#[test_each_connector]
+#[test_each_connector(log = "sql_schema_describer=info,debug")]
 async fn adding_multiple_optional_fields_to_an_existing_model_works(api: &TestApi) -> TestResult {
     let dm1 = r#"
         model Cat {

--- a/migration-engine/migration-engine-tests/tests/migration_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migration_tests.rs
@@ -16,7 +16,7 @@ use migration_engine_tests::sql::*;
 use pretty_assertions::assert_eq;
 use prisma_value::PrismaValue;
 use quaint::prelude::SqlFamily;
-use sql_migration_connector::{AlterIndex, CreateIndex, DropIndex, SqlMigrationStep};
+use sql_migration_connector::sql_migration::{AlterIndex, CreateIndex, DropIndex, SqlMigrationStep};
 use sql_schema_describer::*;
 
 #[test_each_connector]

--- a/query-engine/query-engine/src/tests/test_api.rs
+++ b/query-engine/query-engine/src/tests/test_api.rs
@@ -13,7 +13,7 @@ use quaint::{
     connector::ConnectionInfo,
     visitor::{self, Visitor},
 };
-use sql_migration_connector::SqlMigrationConnector;
+use sql_migration_connector::{sql_migration::SqlMigration, SqlMigrationConnector};
 use std::sync::Arc;
 use test_setup::*;
 
@@ -38,7 +38,7 @@ impl QueryEngine {
 
 pub struct TestApi {
     connection_info: ConnectionInfo,
-    migration_api: MigrationApi<sql_migration_connector::SqlMigrationConnector, sql_migration_connector::SqlMigration>,
+    migration_api: MigrationApi<SqlMigrationConnector, SqlMigration>,
     config: String,
 }
 


### PR DESCRIPTION
SQLite migrations would fail when adding multiple optional fields to a model, prior to this change.

closes https://github.com/prisma/prisma-engines/issues/1023