### PR TITLE
Re-Introspect Comments in the Schema

### DIFF
--- a/introspection-engine/connectors/sql-introspection-connector/src/re_introspection.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/re_introspection.rs
@@ -303,7 +303,7 @@ pub fn enrich(old_data_model: &Datamodel, new_data_model: &mut Datamodel) -> Vec
         }
     }
 
-    // comments - we do NOT generated warnings for comments
+    // comments - we do NOT generate warnings for comments
     {
         let mut re_introspected_model_comments = vec![];
         let mut re_introspected_field_comments = vec![];

--- a/introspection-engine/connectors/sql-introspection-connector/src/re_introspection.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/re_introspection.rs
@@ -312,16 +312,16 @@ pub fn enrich(old_data_model: &Datamodel, new_data_model: &mut Datamodel) -> Vec
     let mut re_introspected_field_comments = vec![];
     {
         for model in new_data_model.models() {
-            for field in model {
+            for field in &model.fields {
                 if let Some(old_model) = old_data_model.find_model(&model.name) {
                     if old_model.documentation.is_some() {
                         re_introspected_model_comments.push((Model::new(&model.name), &old_model.documentation))
                     }
-                    if let Some(old_field) = old_model.find_field(&field.name) {
+                    if let Some(old_field) = old_model.find_field(&field.name()) {
                         if old_field.documentation().is_some() {
                             re_introspected_field_comments.push((
                                 ModelAndField::new(&model.name, &field.name()),
-                                old_field.documentation(),
+                                old_field.documentation().map(|s| s.to_string()),
                             ))
                         }
                     }
@@ -333,11 +333,44 @@ pub fn enrich(old_data_model: &Datamodel, new_data_model: &mut Datamodel) -> Vec
             new_data_model.find_model_mut(&model_comment.0.model).documentation = model_comment.1.clone();
         }
 
-        // for field_comment in &re_introspected_field_comments {
-        //     new_data_model
-        //         .find_field_mut(&uuid.0.model, &uuid.0.field)
-        //         .default_value = Some(DefaultValue::Expression(ValueGenerator::new_uuid()));
-        // }
+        for field_comment in &re_introspected_field_comments {
+            new_data_model
+                .find_field_mut(&field_comment.0.model, &field_comment.0.field)
+                .set_documentation(field_comment.1.clone());
+        }
+    }
+
+    let mut re_introspected_enum_comments = vec![];
+    let mut re_introspected_enum_value_comments = vec![];
+    {
+        for enm in new_data_model.enums() {
+            for value in &enm.values {
+                if let Some(old_enum) = old_data_model.find_enum(&enm.name) {
+                    if old_enum.documentation.is_some() {
+                        re_introspected_enum_comments.push((Enum::new(&enm.name), &old_enum.documentation))
+                    }
+                    if let Some(old_value) = old_enum.find_value(&value.name) {
+                        if old_value.documentation.is_some() {
+                            re_introspected_enum_value_comments.push((
+                                EnumAndValue::new(&enm.name, &value.name),
+                                old_value.documentation.clone(),
+                            ))
+                        }
+                    }
+                }
+            }
+        }
+
+        for enum_comment in &re_introspected_enum_comments {
+            new_data_model.find_enum_mut(&enum_comment.0.enm).documentation = enum_comment.1.clone();
+        }
+
+        for enum_value_comment in &re_introspected_enum_value_comments {
+            new_data_model
+                .find_enum_mut(&enum_value_comment.0.enm)
+                .find_value_mut(&enum_value_comment.0.value)
+                .documentation = enum_value_comment.1.clone();
+        }
     }
 
     // restore old model order

--- a/introspection-engine/connectors/sql-introspection-connector/tests/re_introspection/mod.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/tests/re_introspection/mod.rs
@@ -980,7 +980,7 @@ async fn re_introspecting_comments(api: &TestApi) {
         "#;
 
     let final_dm = r#"
-                /// A really helpful comment about the model
+            /// A really helpful comment about the model
             model User {
                /// A really helpful comment about the field
                id        String    @id @default(cuid())

--- a/introspection-engine/connectors/sql-introspection-connector/tests/re_introspection/mod.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/tests/re_introspection/mod.rs
@@ -936,3 +936,72 @@ async fn re_introspecting_virtual_cuid_default(api: &TestApi) {
     let result = dbg!(api.re_introspect(input_dm).await);
     custom_assert(&result, final_dm);
 }
+
+#[test_each_connector(tags("postgres"))]
+async fn re_introspecting_comments(api: &TestApi) {
+    let barrel = api.barrel();
+    let sql = format!("CREATE Type a as ENUM ( 'A')");
+    api.database().execute_raw(&sql, &[]).await.unwrap();
+
+    let _setup_schema = barrel
+        .execute(|migration| {
+            migration.create_table("User", |t| {
+                t.add_column("id", types::varchar(30).primary(true));
+            });
+
+            migration.create_table("User2", |t| {
+                t.add_column("id", types::varchar(30).primary(true));
+            });
+
+            migration.create_table("Unrelated", |t| {
+                t.add_column("id", types::primary());
+            });
+        })
+        .await;
+
+    let input_dm = r#"
+            /// A really helpful comment about the model
+            model User {
+               /// A really helpful comment about the field
+               id        String    @id @default(cuid())
+            }
+            
+            model User2 {
+               id        String    @id @default(uuid())
+            }
+            
+            /// A really helpful comment about the enum
+            enum a{
+               /// A really helpful comment about the enum value
+               A
+            }
+            
+            /// just floating around here
+        "#;
+
+    let final_dm = r#"
+                /// A really helpful comment about the model
+            model User {
+               /// A really helpful comment about the field
+               id        String    @id @default(cuid())
+            }
+            
+            model User2 {
+               id        String    @id @default(uuid())
+            }
+            
+            model Unrelated {
+               id               Int @id @default(autoincrement())
+            }
+            
+            /// A really helpful comment about the enum
+            enum a{
+               /// A really helpful comment about the enum value
+               A
+            }
+            
+            /// just floating around here       
+        "#;
+    let result = dbg!(api.re_introspect(input_dm).await);
+    custom_assert(&result, final_dm);
+}

--- a/libs/datamodel/core/src/dml/datamodel.rs
+++ b/libs/datamodel/core/src/dml/datamodel.rs
@@ -82,6 +82,11 @@ impl Datamodel {
         self.find_model(&self.find_related_field_bang(&field).relation_info.to)
     }
 
+    /// Finds a mutable field reference by a model and field name.
+    pub fn find_field_mut(&mut self, model: &str, field: &str) -> &mut Field {
+        self.find_model_mut(model).find_field_mut(field)
+    }
+
     /// Finds a mutable scalar field reference by a model and field name.
     pub fn find_scalar_field_mut(&mut self, model: &str, field: &str) -> &mut ScalarField {
         // This uses the memory location of field for equality.

--- a/libs/datamodel/core/src/dml/field.rs
+++ b/libs/datamodel/core/src/dml/field.rs
@@ -86,6 +86,13 @@ impl Field {
         }
     }
 
+    pub fn set_documentation(&mut self, documentation: Option<String>) {
+        match self {
+            Field::ScalarField(sf) => sf.documentation = documentation,
+            Field::RelationField(rf) => rf.documentation = documentation,
+        }
+    }
+
     pub fn is_commented_out(&self) -> bool {
         match self {
             Field::ScalarField(sf) => sf.is_commented_out,

--- a/libs/datamodel/core/src/dml/model.rs
+++ b/libs/datamodel/core/src/dml/model.rs
@@ -127,6 +127,11 @@ impl Model {
         self.fields().find(|f| f.name() == name)
     }
 
+    /// Finds a field by name and returns a mutable reference.
+    pub fn find_field_mut(&mut self, name: &str) -> &mut Field {
+        self.fields_mut().find(|f| f.name() == name).unwrap()
+    }
+
     /// Finds a scalar field by name.
     pub fn find_scalar_field(&self, name: &str) -> Option<&ScalarField> {
         self.scalar_fields().find(|f| f.name == *name)


### PR DESCRIPTION
Fixes https://github.com/prisma/prisma/issues/3052

As per the documentation only `///` comments are re-introspected. 
https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-schema#comments