### PR TITLE
Make Reintrospection the default

### DIFF
--- a/introspection-engine/connectors/introspection-connector/src/lib.rs
+++ b/introspection-engine/connectors/introspection-connector/src/lib.rs
@@ -16,11 +16,7 @@ pub trait IntrospectionConnector: Send + Sync + 'static {
 
     async fn get_database_description(&self) -> ConnectorResult<String>;
 
-    async fn introspect(
-        &self,
-        existing_data_model: &Datamodel,
-        reintrospect: bool,
-    ) -> ConnectorResult<IntrospectionResult>;
+    async fn introspect(&self, existing_data_model: &Datamodel) -> ConnectorResult<IntrospectionResult>;
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/introspection-engine/connectors/sql-introspection-connector/src/calculate_datamodel.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/calculate_datamodel.rs
@@ -17,7 +17,6 @@ pub fn calculate_datamodel(
     schema: &SqlSchema,
     family: &SqlFamily,
     previous_data_model: &Datamodel,
-    reintrospect: bool,
 ) -> SqlIntrospectionResult<IntrospectionResult> {
     debug!("Calculating data model.");
 
@@ -34,10 +33,8 @@ pub fn calculate_datamodel(
     deduplicate_relation_field_names(&mut data_model);
 
     let mut warnings = vec![];
-    if reintrospect {
-        warnings.append(&mut enrich(previous_data_model, &mut data_model));
-        tracing::debug!("Enriching datamodel is done: {:?}", data_model);
-    }
+    warnings.append(&mut enrich(previous_data_model, &mut data_model));
+    tracing::debug!("Enriching datamodel is done: {:?}", data_model);
 
     // commenting out models, fields, enums, enum values
     warnings.append(&mut commenting_out_guardrails(&mut data_model));

--- a/introspection-engine/connectors/sql-introspection-connector/src/lib.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/lib.rs
@@ -86,21 +86,14 @@ impl IntrospectionConnector for SqlIntrospectionConnector {
         Ok(description)
     }
 
-    async fn introspect(
-        &self,
-        previous_data_model: &Datamodel,
-        reintrospect: bool,
-    ) -> ConnectorResult<IntrospectionResult> {
+    async fn introspect(&self, previous_data_model: &Datamodel) -> ConnectorResult<IntrospectionResult> {
         let sql_schema = self.catch(self.describe()).await?;
         tracing::debug!("SQL Schema Describer is done: {:?}", sql_schema);
 
         let family = self.connection_info.sql_family();
 
-        let introspection_result =
-            calculate_datamodel::calculate_datamodel(&sql_schema, &family, &previous_data_model, reintrospect)
-                .map_err(|sql_introspection_error| {
-                    sql_introspection_error.into_connector_error(&self.connection_info)
-                })?;
+        let introspection_result = calculate_datamodel::calculate_datamodel(&sql_schema, &family, &previous_data_model)
+            .map_err(|sql_introspection_error| sql_introspection_error.into_connector_error(&self.connection_info))?;
 
         tracing::debug!("Calculating datamodel is done: {:?}", introspection_result.data_model);
 

--- a/introspection-engine/connectors/sql-introspection-connector/tests/common_unit_tests/mod.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/tests/common_unit_tests/mod.rs
@@ -97,7 +97,7 @@ fn a_data_model_can_be_generated_from_a_schema() {
         sequences: vec![],
     };
     let introspection_result =
-        calculate_datamodel(&schema, &SqlFamily::Postgres, &Datamodel::new(), false).expect("calculate data model");
+        calculate_datamodel(&schema, &SqlFamily::Postgres, &Datamodel::new()).expect("calculate data model");
 
     assert_eq!(introspection_result.data_model, ref_data_model);
 }
@@ -178,7 +178,7 @@ fn arity_is_preserved_when_generating_data_model_from_a_schema() {
         sequences: vec![],
     };
     let introspection_result =
-        calculate_datamodel(&schema, &SqlFamily::Postgres, &Datamodel::new(), false).expect("calculate data model");
+        calculate_datamodel(&schema, &SqlFamily::Postgres, &Datamodel::new()).expect("calculate data model");
 
     assert_eq!(introspection_result.data_model, ref_data_model);
 }
@@ -309,7 +309,7 @@ fn defaults_are_preserved_when_generating_data_model_from_a_schema() {
         sequences: vec![],
     };
     let introspection_result =
-        calculate_datamodel(&schema, &SqlFamily::Postgres, &Datamodel::new(), false).expect("calculate data model");
+        calculate_datamodel(&schema, &SqlFamily::Postgres, &Datamodel::new()).expect("calculate data model");
 
     assert_eq!(introspection_result.data_model, ref_data_model);
 }
@@ -472,7 +472,7 @@ fn primary_key_is_preserved_when_generating_data_model_from_a_schema() {
         sequences: vec![],
     };
     let introspection_result =
-        calculate_datamodel(&schema, &SqlFamily::Postgres, &Datamodel::new(), false).expect("calculate data model");
+        calculate_datamodel(&schema, &SqlFamily::Postgres, &Datamodel::new()).expect("calculate data model");
 
     assert_eq!(introspection_result.data_model, ref_data_model);
 }
@@ -542,7 +542,7 @@ fn uniqueness_is_preserved_when_generating_data_model_from_a_schema() {
         sequences: vec![],
     };
     let introspection_result =
-        calculate_datamodel(&schema, &SqlFamily::Postgres, &Datamodel::new(), false).expect("calculate data model");
+        calculate_datamodel(&schema, &SqlFamily::Postgres, &Datamodel::new()).expect("calculate data model");
 
     assert_eq!(introspection_result.data_model, ref_data_model);
 }
@@ -761,7 +761,7 @@ fn compound_foreign_keys_are_preserved_when_generating_data_model_from_a_schema(
         sequences: vec![],
     };
     let introspection_result =
-        calculate_datamodel(&schema, &SqlFamily::Postgres, &Datamodel::new(), false).expect("calculate data model");
+        calculate_datamodel(&schema, &SqlFamily::Postgres, &Datamodel::new()).expect("calculate data model");
 
     assert_eq!(introspection_result.data_model, expected_data_model);
 }
@@ -871,7 +871,7 @@ fn multi_field_uniques_are_preserved_when_generating_data_model_from_a_schema() 
         sequences: vec![],
     };
     let introspection_result =
-        calculate_datamodel(&schema, &SqlFamily::Postgres, &Datamodel::new(), false).expect("calculate data model");
+        calculate_datamodel(&schema, &SqlFamily::Postgres, &Datamodel::new()).expect("calculate data model");
 
     assert_eq!(introspection_result.data_model, ref_data_model);
 }
@@ -1055,7 +1055,7 @@ fn foreign_keys_are_preserved_when_generating_data_model_from_a_schema() {
         sequences: vec![],
     };
     let introspection_result =
-        calculate_datamodel(&schema, &SqlFamily::Postgres, &Datamodel::new(), false).expect("calculate data model");
+        calculate_datamodel(&schema, &SqlFamily::Postgres, &Datamodel::new()).expect("calculate data model");
 
     assert_eq!(introspection_result.data_model, ref_data_model);
 }
@@ -1096,7 +1096,7 @@ fn enums_are_preserved_when_generating_data_model_from_a_schema() {
         sequences: vec![],
     };
     let introspection_result =
-        calculate_datamodel(&schema, &SqlFamily::Postgres, &Datamodel::new(), false).expect("calculate data model");
+        calculate_datamodel(&schema, &SqlFamily::Postgres, &Datamodel::new()).expect("calculate data model");
 
     assert_eq!(introspection_result.data_model, ref_data_model);
 }
@@ -1192,7 +1192,7 @@ async fn one_to_many_relation_field_names_do_not_conflict_with_many_to_many_rela
     let expected_dm =
         datamodel::render_schema_ast_to_string(&datamodel::parse_schema_ast(&expected_dm).unwrap()).unwrap();
 
-    let mut introspected_dm = calculate_datamodel(&schema, &SqlFamily::Postgres, &Datamodel::new(), false)?.data_model;
+    let mut introspected_dm = calculate_datamodel(&schema, &SqlFamily::Postgres, &Datamodel::new())?.data_model;
     introspected_dm.models.sort_by(|a, b| b.name.cmp(&a.name));
 
     let introspected_dm_string = datamodel::render_datamodel_to_string(&introspected_dm).unwrap();
@@ -1251,7 +1251,7 @@ async fn many_to_many_relation_field_names_do_not_conflict_with_themselves(api: 
     let expected_dm =
         datamodel::render_schema_ast_to_string(&datamodel::parse_schema_ast(&expected_dm).unwrap()).unwrap();
 
-    let mut introspected_dm = calculate_datamodel(&schema, &SqlFamily::Postgres, &Datamodel::new(), false)?.data_model;
+    let mut introspected_dm = calculate_datamodel(&schema, &SqlFamily::Postgres, &Datamodel::new())?.data_model;
     introspected_dm.models.sort_by(|a, b| b.name.cmp(&a.name));
     for model in &mut introspected_dm.models {
         model.fields.sort_by(|a, b| a.name().cmp(b.name()));

--- a/introspection-engine/connectors/sql-introspection-connector/tests/test_harness/test_api.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/tests/test_harness/test_api.rs
@@ -62,7 +62,7 @@ impl TestApi {
     pub async fn introspect(&self) -> String {
         let introspection_result = self
             .introspection_connector
-            .introspect(&Datamodel::new(), false)
+            .introspect(&Datamodel::new())
             .await
             .unwrap();
         datamodel::render_datamodel_to_string(&introspection_result.data_model).expect("Datamodel rendering failed")
@@ -70,28 +70,20 @@ impl TestApi {
 
     pub async fn re_introspect(&self, data_model_string: &str) -> String {
         let data_model = datamodel::parse_datamodel(data_model_string).unwrap();
-        let introspection_result = self
-            .introspection_connector
-            .introspect(&data_model, true)
-            .await
-            .unwrap();
+        let introspection_result = self.introspection_connector.introspect(&data_model).await.unwrap();
         datamodel::render_datamodel_to_string(&introspection_result.data_model).expect("Datamodel rendering failed")
     }
 
     pub async fn re_introspect_warnings(&self, data_model_string: &str) -> String {
         let data_model = datamodel::parse_datamodel(data_model_string).unwrap();
-        let introspection_result = self
-            .introspection_connector
-            .introspect(&data_model, true)
-            .await
-            .unwrap();
+        let introspection_result = self.introspection_connector.introspect(&data_model).await.unwrap();
         serde_json::to_string(&introspection_result.warnings).unwrap()
     }
 
     pub async fn introspect_version(&self) -> Version {
         let introspection_result = self
             .introspection_connector
-            .introspect(&Datamodel::new(), false)
+            .introspect(&Datamodel::new())
             .await
             .unwrap();
         introspection_result.version
@@ -100,7 +92,7 @@ impl TestApi {
     pub async fn introspection_warnings(&self) -> String {
         let introspection_result = self
             .introspection_connector
-            .introspect(&Datamodel::new(), false)
+            .introspect(&Datamodel::new())
             .await
             .unwrap();
         serde_json::to_string(&introspection_result.warnings).unwrap()

--- a/libs/test-cli/src/main.rs
+++ b/libs/test-cli/src/main.rs
@@ -78,7 +78,7 @@ async fn main() -> anyhow::Result<()> {
                 unreachable!()
             };
             //todo configurable
-            let introspected = introspection_core::RpcImpl::introspect_internal(schema, false, false)
+            let introspected = introspection_core::RpcImpl::introspect_internal(schema, false)
                 .await
                 .map_err(|err| anyhow::anyhow!("{:?}", err.data))?;
 
@@ -188,7 +188,7 @@ async fn generate_dmmf(cmd: &DmmfCommand) -> anyhow::Result<()> {
         if let Some(url) = cmd.url.as_ref() {
             let skeleton = minimal_schema_from_url(url)?;
             //todo make this configurable
-            let introspected = introspection_core::RpcImpl::introspect_internal(skeleton, false, false)
+            let introspected = introspection_core::RpcImpl::introspect_internal(skeleton, false)
                 .await
                 .map_err(|err| anyhow::anyhow!("{:?}", err.data))?;
 

--- a/query-engine/query-engine/src/tests/type_mappings/test_api.rs
+++ b/query-engine/query-engine/src/tests/type_mappings/test_api.rs
@@ -34,7 +34,7 @@ impl TestApi {
     pub async fn introspect_and_start_query_engine(&self) -> anyhow::Result<(DatamodelAssertions, QueryEngine)> {
         let datasource = self.datasource();
 
-        let introspection_result = introspection_core::RpcImpl::introspect_internal(datasource, false, false)
+        let introspection_result = introspection_core::RpcImpl::introspect_internal(datasource, false)
             .await
             .map_err(|err| anyhow::anyhow!("{:?}", err.data))?;
 


### PR DESCRIPTION
Fixes https://github.com/prisma/prisma/issues/2829

This removes the reintrospect field from the rpc call and cleans out some internal logic.