### PR TITLE
Let native column types be created in MySQL migrations

### DIFF
--- a/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
@@ -225,6 +225,7 @@ impl Connector for MySqlDatamodelConnector {
                     MySqlType::DateTime(None)
                 }
             }
+            TIMESTAMP_TYPE_NAME => MySqlType::Timestamp(args.first().map(|i| *i)),
             YEAR_TYPE_NAME => MySqlType::Year,
             JSON_TYPE_NAME => MySqlType::JSON,
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
@@ -299,6 +299,10 @@ fn render_mysql_modify(
 }
 
 pub(crate) fn render_column_type(column: &ColumnWalker<'_>) -> Cow<'static, str> {
+    if !column.column_type().full_data_type.is_empty() {
+        return column.column_type().full_data_type.clone().into();
+    }
+
     match &column.column_type().family {
         ColumnTypeFamily::Boolean => "boolean".into(),
         ColumnTypeFamily::DateTime => "datetime(3)".into(),

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour.rs
@@ -17,7 +17,5 @@ pub(crate) trait SqlSchemaCalculatorFlavour {
         _field: &ScalarFieldWalker<'_>,
         _scalar_type: ScalarType,
         _native_type_instance: &NativeTypeInstance,
-    ) -> sql::ColumnType {
-        todo!()
-    }
+    ) -> sql::ColumnType;
 }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/mysql.rs
@@ -1,6 +1,11 @@
 use super::SqlSchemaCalculatorFlavour;
 use crate::{flavour::MysqlFlavour, sql_schema_calculator::SqlSchemaCalculator};
-use datamodel::walkers::walk_scalar_fields;
+use datamodel::{
+    walkers::{walk_scalar_fields, ScalarFieldWalker},
+    ScalarType,
+};
+use datamodel_connector::NativeTypeInstance;
+use native_types::MySqlType;
 use sql_schema_describer::{self as sql};
 
 impl SqlSchemaCalculatorFlavour for MysqlFlavour {
@@ -26,5 +31,60 @@ impl SqlSchemaCalculatorFlavour for MysqlFlavour {
         }
 
         enums
+    }
+
+    fn column_type_for_native_type(
+        &self,
+        field: &ScalarFieldWalker<'_>,
+        _scalar_type: ScalarType,
+        native_type_instance: &NativeTypeInstance,
+    ) -> sql::ColumnType {
+        let mysql_type: MySqlType = native_type_instance.deserialize_native_type();
+
+        let data_type: String = match mysql_type {
+            MySqlType::Int => "INTEGER".into(),
+            MySqlType::SmallInt => "SMALLINT".into(),
+            MySqlType::TinyInt => "TINYINT".into(),
+            MySqlType::MediumInt => "MEDIUMINT".into(),
+            MySqlType::BigInt => "BIGINT".into(),
+            MySqlType::Decimal(precision, scale) => format!("DECIMAL({}, {})", precision, scale),
+            MySqlType::Numeric(precision, scale) => format!("NUMERIC({}, {})", precision, scale),
+            MySqlType::Float => "FLOAT".into(),
+            MySqlType::Double => "DOUBLE".into(),
+            MySqlType::Bit(size) => format!("BIT({size})", size = size),
+            MySqlType::Char(size) => format!("CHAR({size})", size = size),
+            MySqlType::VarChar(size) => format!("VARCHAR({size})", size = size),
+            MySqlType::Binary(size) => format!("BINARY({size})", size = size),
+            MySqlType::VarBinary(size) => format!("VARBINARY({size})", size = size),
+            MySqlType::TinyBlob => "TINYBLOB".into(),
+            MySqlType::Blob => "BLOB".into(),
+            MySqlType::MediumBlob => "MEDIUMBLOB".into(),
+            MySqlType::LongBlob => "LONGBLOB".into(),
+            MySqlType::TinyText => "TINYTEXT".into(),
+            MySqlType::Text => "TEXT".into(),
+            MySqlType::MediumText => "MEDIUMTEXT".into(),
+            MySqlType::LongText => "LONGTEXT".into(),
+            MySqlType::Date => "DATE".into(),
+            MySqlType::Time(Some(precision)) => format!("TIME({precision})", precision = precision),
+            MySqlType::Time(None) => "TIME".into(),
+            MySqlType::DateTime(Some(precision)) => format!("DATETIME({precision})", precision = precision),
+            MySqlType::DateTime(None) => "DATETIME".into(),
+            MySqlType::Timestamp(Some(precision)) => format!("TIMESTAMP({precision})", precision = precision),
+            MySqlType::Timestamp(None) => "TIMESTAMP".into(),
+            MySqlType::Year => "YEAR".into(),
+            MySqlType::JSON => "JSON".into(),
+        };
+
+        sql::ColumnType {
+            data_type: data_type.clone(),
+            full_data_type: data_type,
+            character_maximum_length: None,
+            family: sql::ColumnTypeFamily::String,
+            arity: match field.arity() {
+                datamodel::FieldArity::Required => sql::ColumnArity::Required,
+                datamodel::FieldArity::Optional => sql::ColumnArity::Nullable,
+                datamodel::FieldArity::List => sql::ColumnArity::List,
+            },
+        }
     }
 }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/sqlite.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/sqlite.rs
@@ -1,4 +1,13 @@
 use super::SqlSchemaCalculatorFlavour;
 use crate::flavour::SqliteFlavour;
 
-impl SqlSchemaCalculatorFlavour for SqliteFlavour {}
+impl SqlSchemaCalculatorFlavour for SqliteFlavour {
+    fn column_type_for_native_type(
+        &self,
+        _field: &datamodel::walkers::ScalarFieldWalker<'_>,
+        _scalar_type: datamodel::ScalarType,
+        _native_type_instance: &datamodel_connector::NativeTypeInstance,
+    ) -> sql_schema_describer::ColumnType {
+        unreachable!("column_type_for_native_type on SQLite")
+    }
+}

--- a/migration-engine/migration-engine-tests/src/test_api.rs
+++ b/migration-engine/migration-engine-tests/src/test_api.rs
@@ -60,6 +60,10 @@ impl TestApi {
         self.sql_family() == SqlFamily::Mysql
     }
 
+    pub fn is_mysql_8(&self) -> bool {
+        self.connector_name == "mysql_8"
+    }
+
     pub fn is_mariadb(&self) -> bool {
         self.connector_name == "mysql_mariadb"
     }

--- a/migration-engine/migration-engine-tests/tests/migrations/mysql.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/mysql.rs
@@ -1,4 +1,5 @@
 use migration_engine_tests::sql::*;
+use std::fmt::Write as _;
 
 /// We need to test this specifically for mysql, because foreign keys are indexes, and they are
 /// inferred as both foreign key and index by the sql-schema-describer. We do not want to
@@ -193,6 +194,90 @@ async fn arity_is_preserved_by_alter_enum(api: &TestApi) -> TestResult {
         table
             .assert_column("primaryColor", |col| col.assert_is_required())?
             .assert_column("secondaryColor", |col| col.assert_is_nullable())
+    })?;
+
+    Ok(())
+}
+
+#[test_each_connector(tags("mysql"))]
+async fn native_type_columns_can_be_created(api: &TestApi) -> TestResult {
+    let types = &[
+        ("int", "Int", "Int", if api.is_mysql_8() { "int" } else { "int(11)" }),
+        (
+            "smallint",
+            "Int",
+            "SmallInt",
+            if api.is_mysql_8() { "smallint" } else { "smallint(6)" },
+        ),
+        (
+            "tinyint",
+            "Int",
+            "TinyInt",
+            if api.is_mysql_8() { "tinyint" } else { "tinyint(4)" },
+        ),
+        (
+            "mediumint",
+            "Int",
+            "MediumInt",
+            if api.is_mysql_8() { "mediumint" } else { "mediumint(9)" },
+        ),
+        (
+            "bigint",
+            "Int",
+            "BigInt",
+            if api.is_mysql_8() { "bigint" } else { "bigint(20)" },
+        ),
+        ("decimal", "Decimal", "Decimal(5, 3)", "decimal(5,3)"),
+        ("numeric", "Decimal", "Numeric(4,1)", "decimal(4,1)"),
+        ("float", "Float", "Float", "float"),
+        ("double", "Float", "Double", "double"),
+        ("bits", "Bytes", "Bit(10)", "bit(10)"),
+        ("chars", "String", "Char(10)", "char(10)"),
+        ("varchars", "String", "VarChar(500)", "varchar(500)"),
+        ("binary", "Bytes", "Binary(230)", "binary(230)"),
+        ("varbinary", "Bytes", "VarBinary(150)", "varbinary(150)"),
+        ("tinyBlob", "Bytes", "TinyBlob", "tinyblob"),
+        ("blob", "Bytes", "Blob", "blob"),
+        ("mediumBlob", "Bytes", "MediumBlob", "mediumblob"),
+        ("longBlob", "Bytes", "LongBlob", "longblob"),
+        ("tinytext", "String", "TinyText", "tinytext"),
+        ("text", "String", "Text", "text"),
+        ("mediumText", "String", "MediumText", "mediumtext"),
+        ("longText", "String", "LongText", "longtext"),
+        ("date", "DateTime", "Date", "date"),
+        ("timeWithPrecision", "DateTime", "Time(3)", "time(3)"),
+        ("dateTimeWithPrecision", "DateTime", "Datetime(3)", "datetime(3)"),
+        ("timestampWithPrecision", "DateTime", "Timestamp(3)", "timestamp(3)"),
+        ("year", "Int", "Year", if api.is_mysql_8() { "year" } else { "year(4)" }),
+    ];
+
+    let mut dm = r#"
+        datasource mysql {
+            provider = "mysql"
+            url = "mysql://localhost/test"
+            previewFeatures = ["nativeTypes"]
+        }
+
+        model A {
+            id Int @id
+    "#
+    .to_owned();
+
+    for (field_name, prisma_type, native_type, _) in types {
+        writeln!(&mut dm, "    {} {} @mysql.{}", field_name, prisma_type, native_type)?;
+    }
+
+    dm.push_str("}\n");
+
+    api.schema_push(dm).send().await?.assert_green()?;
+
+    api.assert_schema().await?.assert_table("A", |table| {
+        types.iter().fold(
+            Ok(table),
+            |table, (field_name, _prisma_type, _native_type, database_type)| {
+                table.and_then(|table| table.assert_column(field_name, |col| col.assert_full_data_type(database_type)))
+            },
+        )
     })?;
 
     Ok(())

--- a/migration-engine/migration-engine-tests/tests/migrations/postgres.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/postgres.rs
@@ -98,7 +98,7 @@ async fn existing_postgis_tables_must_not_be_migrated(api: &TestApi) -> TestResu
     Ok(())
 }
 
-#[test_each_connector(tags("postgres"), log = "debug,sql_schema_describer=info")]
+#[test_each_connector(tags("postgres"))]
 async fn native_type_columns_can_be_created(api: &TestApi) -> TestResult {
     let types = &[
         ("smallint", "Int", "SmallInt", "int2"),


### PR DESCRIPTION
Last part of the first phase of https://github.com/prisma/prisma-engines/issues/72

After this PR, the migration engine will create tables and columns with native types on MySQL (postgres is already implemented). The next step will be diffing existing columns with native types, so we can migrate between them. I expect that second step to be significantly harder.

This unblocks work on native types in the query engine.