### PR TITLE
Finish moving all SQL rendering to SqlRenderer

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/flavour.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour.rs
@@ -76,6 +76,12 @@ pub(crate) trait SqlFlavour:
 #[derive(Debug)]
 pub(crate) struct MysqlFlavour(MysqlUrl);
 
+impl MysqlFlavour {
+    pub(crate) fn schema_name(&self) -> &str {
+        self.0.dbname()
+    }
+}
+
 #[async_trait::async_trait]
 impl SqlFlavour for MysqlFlavour {
     fn check_database_info(&self, database_info: &DatabaseInfo) -> CheckDatabaseInfoResult {
@@ -222,6 +228,12 @@ impl SqlFlavour for SqliteFlavour {
 
 #[derive(Debug)]
 pub(crate) struct PostgresFlavour(pub(crate) PostgresUrl);
+
+impl PostgresFlavour {
+    pub(crate) fn schema_name(&self) -> &str {
+        self.0.schema()
+    }
+}
 
 #[async_trait::async_trait]
 impl SqlFlavour for PostgresFlavour {

--- a/migration-engine/connectors/sql-migration-connector/src/flavour.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour.rs
@@ -35,8 +35,9 @@ pub(crate) fn from_connection_info(connection_info: &ConnectionInfo) -> Box<dyn 
     match connection_info {
         ConnectionInfo::Mysql(url) => Box::new(MysqlFlavour(url.clone())),
         ConnectionInfo::Postgres(url) => Box::new(PostgresFlavour(url.clone())),
-        ConnectionInfo::Sqlite { file_path, .. } => Box::new(SqliteFlavour {
+        ConnectionInfo::Sqlite { file_path, db_name } => Box::new(SqliteFlavour {
             file_path: file_path.clone(),
+            attached_name: db_name.clone(),
         }),
         ConnectionInfo::Mssql(_) => todo!("Greetings from Redmond!"),
     }
@@ -158,6 +159,13 @@ impl SqlFlavour for MysqlFlavour {
 #[derive(Debug)]
 pub(crate) struct SqliteFlavour {
     file_path: String,
+    attached_name: String,
+}
+
+impl SqliteFlavour {
+    pub(crate) fn attached_name(&self) -> &str {
+        &self.attached_name
+    }
 }
 
 #[async_trait::async_trait]

--- a/migration-engine/connectors/sql-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/lib.rs
@@ -25,7 +25,7 @@ use flavour::SqlFlavour;
 use migration_connector::*;
 use quaint::{
     error::ErrorKind,
-    prelude::{ConnectionInfo, Queryable, SqlFamily},
+    prelude::{ConnectionInfo, Queryable},
     single::Quaint,
 };
 use sql_database_migration_inferrer::*;

--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
@@ -131,9 +131,7 @@ fn render_raw_sql(
             Ok(vec![renderer.render_create_table(&table, &schema_name)?])
         }
         SqlMigrationStep::DropTable(DropTable { name }) => Ok(renderer.render_drop_table(name, &schema_name)),
-        SqlMigrationStep::RenameTable { name, new_name } => {
-            Ok(vec![renderer.render_rename_table(name, new_name, &schema_name)])
-        }
+        SqlMigrationStep::RenameTable { name, new_name } => Ok(vec![renderer.render_rename_table(name, new_name)]),
         SqlMigrationStep::AddForeignKey(add_foreign_key) => {
             Ok(vec![renderer.render_add_foreign_key(add_foreign_key, &schema_name)])
         }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
@@ -130,22 +130,7 @@ fn render_raw_sql(
 
             Ok(vec![renderer.render_create_table(&table, &schema_name)?])
         }
-        SqlMigrationStep::DropTable(DropTable { name }) => match sql_family {
-            SqlFamily::Mysql | SqlFamily::Postgres => Ok(vec![format!(
-                "DROP TABLE {}",
-                renderer.quote_with_schema(&schema_name, &name)
-            )]),
-            // Turning off the pragma is safe, because schema validation would forbid foreign keys
-            // to a non-existent model. There appears to be no other way to deal with cyclic
-            // dependencies in the dropping order of tables in the presence of foreign key
-            // constraints on SQLite.
-            SqlFamily::Sqlite => Ok(vec![
-                "PRAGMA foreign_keys=off".to_string(),
-                format!("DROP TABLE {}", renderer.quote_with_schema(&schema_name, &name)),
-                "PRAGMA foreign_keys=on".to_string(),
-            ]),
-            SqlFamily::Mssql => todo!("Greetings from Redmond"),
-        },
+        SqlMigrationStep::DropTable(DropTable { name }) => Ok(renderer.render_drop_table(name, &schema_name)),
         SqlMigrationStep::RenameTable { name, new_name } => {
             let new_name = match sql_family {
                 SqlFamily::Sqlite => renderer.quote(new_name).to_string(),

--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
@@ -122,13 +122,13 @@ fn render_raw_sql(
         SqlMigrationStep::RedefineTables { names } => Ok(renderer.render_redefine_tables(names, differ, database_info)),
         SqlMigrationStep::CreateEnum(create_enum) => Ok(renderer.render_create_enum(create_enum)),
         SqlMigrationStep::DropEnum(drop_enum) => Ok(renderer.render_drop_enum(drop_enum)),
-        SqlMigrationStep::AlterEnum(alter_enum) => renderer.render_alter_enum(alter_enum, &differ, &schema_name),
+        SqlMigrationStep::AlterEnum(alter_enum) => renderer.render_alter_enum(alter_enum, &differ),
         SqlMigrationStep::CreateTable(CreateTable { table }) => {
             let table = next_schema
                 .table_walker(&table.name)
                 .expect("CreateTable referring to an unknown table.");
 
-            Ok(vec![renderer.render_create_table(&table, &schema_name)?])
+            Ok(vec![renderer.render_create_table(&table)?])
         }
         SqlMigrationStep::DropTable(DropTable { name }) => Ok(renderer.render_drop_table(name, &schema_name)),
         SqlMigrationStep::RenameTable { name, new_name } => Ok(vec![renderer.render_rename_table(name, new_name)]),

--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
@@ -1,6 +1,6 @@
 use crate::*;
-use sql_migration::{CreateTable, DropForeignKey, DropTable, SqlMigrationStep};
-use sql_renderer::{IteratorJoin, Quoted};
+use sql_migration::{CreateTable, DropTable, SqlMigrationStep};
+use sql_renderer::IteratorJoin;
 use sql_schema_describer::walkers::SqlSchemaExt;
 use sql_schema_describer::{Index, IndexType, SqlSchema};
 use sql_schema_differ::SqlSchemaDiffer;
@@ -145,21 +145,9 @@ fn render_raw_sql(
         SqlMigrationStep::AddForeignKey(add_foreign_key) => {
             Ok(vec![renderer.render_add_foreign_key(add_foreign_key, &schema_name)])
         }
-        SqlMigrationStep::DropForeignKey(DropForeignKey { table, constraint_name }) => match sql_family {
-            SqlFamily::Mysql => Ok(vec![format!(
-                "ALTER TABLE {table} DROP FOREIGN KEY {constraint_name}",
-                table = renderer.quote_with_schema(&schema_name, table),
-                constraint_name = Quoted::mysql_ident(constraint_name),
-            )]),
-            SqlFamily::Postgres => Ok(vec![format!(
-                "ALTER TABLE {table} DROP CONSTRAINT {constraint_name}",
-                table = renderer.quote_with_schema(&schema_name, table),
-                constraint_name = Quoted::postgres_ident(constraint_name),
-            )]),
-            SqlFamily::Sqlite => Ok(Vec::new()),
-            SqlFamily::Mssql => todo!("Greetings from Redmond"),
-        },
-
+        SqlMigrationStep::DropForeignKey(drop_foreign_key) => {
+            Ok(vec![renderer.render_drop_foreign_key(drop_foreign_key)])
+        }
         SqlMigrationStep::AlterTable(alter_table) => {
             Ok(renderer.render_alter_table(alter_table, database_info, &differ))
         }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer.rs
@@ -196,6 +196,14 @@ pub(crate) trait SqlRenderer {
     /// Render a `DropIndex` step.
     fn render_drop_index(&self, drop_index: &DropIndex, database_info: &DatabaseInfo) -> String;
 
+    /// Render a `DropTable` step.
+    fn render_drop_table(&self, table_name: &str, schema_name: &str) -> Vec<String> {
+        vec![format!(
+            "DROP TABLE {}",
+            self.quote_with_schema(&schema_name, &table_name)
+        )]
+    }
+
     /// Render a `RedefineTables` step.
     fn render_redefine_tables(
         &self,

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer.rs
@@ -50,21 +50,16 @@ pub(crate) trait SqlRenderer {
         )
         .unwrap();
 
-        add_constraint.push_str(&self.render_references(&schema_name, &foreign_key));
+        add_constraint.push_str(&self.render_references(&foreign_key));
 
         add_constraint
     }
 
-    fn render_alter_enum(
-        &self,
-        alter_enum: &AlterEnum,
-        differ: &SqlSchemaDiffer<'_>,
-        schema_name: &str,
-    ) -> anyhow::Result<Vec<String>>;
+    fn render_alter_enum(&self, alter_enum: &AlterEnum, differ: &SqlSchemaDiffer<'_>) -> anyhow::Result<Vec<String>>;
 
-    fn render_column(&self, schema_name: &str, column: ColumnWalker<'_>, add_fk_prefix: bool) -> String;
+    fn render_column(&self, column: ColumnWalker<'_>) -> String;
 
-    fn render_references(&self, schema_name: &str, foreign_key: &ForeignKey) -> String;
+    fn render_references(&self, foreign_key: &ForeignKey) -> String;
 
     fn render_default<'a>(&self, default: &'a DefaultValue, family: &ColumnTypeFamily) -> Cow<'a, str>;
 
@@ -119,7 +114,7 @@ pub(crate) trait SqlRenderer {
                         schema: differ.next,
                         column,
                     };
-                    let col_sql = self.render_column(&schema_name, column, true);
+                    let col_sql = self.render_column(column);
                     lines.push(format!("ADD COLUMN {}", col_sql));
                 }
                 TableChange::DropColumn(DropColumn { name }) => {
@@ -154,7 +149,7 @@ pub(crate) trait SqlRenderer {
                             let name = self.quote(&name);
                             lines.push(format!("DROP COLUMN {}", name));
 
-                            let col_sql = self.render_column(&schema_name, column.next, true);
+                            let col_sql = self.render_column(column.next);
                             lines.push(format!("ADD COLUMN {}", col_sql));
                         }
                     }
@@ -188,7 +183,7 @@ pub(crate) trait SqlRenderer {
     fn render_create_index(&self, create_index: &CreateIndex, database_info: &DatabaseInfo) -> String;
 
     /// Render a `CreateTable` step.
-    fn render_create_table(&self, table: &TableWalker<'_>, schema_name: &str) -> anyhow::Result<String>;
+    fn render_create_table(&self, table: &TableWalker<'_>) -> anyhow::Result<String>;
 
     /// Render a `DropEnum` step.
     fn render_drop_enum(&self, drop_enum: &DropEnum) -> Vec<String>;

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer.rs
@@ -214,6 +214,8 @@ pub(crate) trait SqlRenderer {
         differ: SqlSchemaDiffer<'_>,
         database_info: &DatabaseInfo,
     ) -> Vec<String>;
+
+    fn render_rename_table(&self, name: &str, new_name: &str, schema_name: &str) -> String;
 }
 
 #[derive(Default)]

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer.rs
@@ -9,7 +9,7 @@ use crate::{
     database_info::DatabaseInfo,
     sql_migration::{
         AddColumn, AddForeignKey, AlterColumn, AlterEnum, AlterIndex, AlterTable, CreateEnum, CreateIndex, DropColumn,
-        DropEnum, DropIndex, TableChange,
+        DropEnum, DropForeignKey, DropIndex, TableChange,
     },
     sql_schema_differ::{ColumnDiffer, SqlSchemaDiffer},
 };
@@ -192,6 +192,9 @@ pub(crate) trait SqlRenderer {
 
     /// Render a `DropEnum` step.
     fn render_drop_enum(&self, drop_enum: &DropEnum) -> Vec<String>;
+
+    /// Render a `DropForeignKey` step.
+    fn render_drop_foreign_key(&self, drop_foreign_key: &DropForeignKey) -> String;
 
     /// Render a `DropIndex` step.
     fn render_drop_index(&self, drop_index: &DropIndex, database_info: &DatabaseInfo) -> String;

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer.rs
@@ -215,7 +215,7 @@ pub(crate) trait SqlRenderer {
         database_info: &DatabaseInfo,
     ) -> Vec<String>;
 
-    fn render_rename_table(&self, name: &str, new_name: &str, schema_name: &str) -> String;
+    fn render_rename_table(&self, name: &str, new_name: &str) -> String;
 }
 
 #[derive(Default)]

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
@@ -263,11 +263,11 @@ impl SqlRenderer for MysqlFlavour {
         unreachable!("render_redefine_table on MySQL")
     }
 
-    fn render_rename_table(&self, name: &str, new_name: &str, schema_name: &str) -> String {
+    fn render_rename_table(&self, name: &str, new_name: &str) -> String {
         format!(
             "ALTER TABLE {} RENAME TO {}",
-            self.quote_with_schema(&schema_name, &name),
-            new_name = self.quote_with_schema(&schema_name, &new_name).to_string(),
+            self.quote_with_schema(self.schema_name(), &name),
+            new_name = self.quote_with_schema(self.schema_name(), &new_name).to_string(),
         )
     }
 }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
@@ -5,7 +5,7 @@ use crate::{
     sql_database_step_applier::render_create_index,
     sql_migration::{
         expanded_alter_column::{expand_mysql_alter_column, MysqlAlterColumn},
-        AlterEnum, AlterIndex, CreateEnum, CreateIndex, DropEnum, DropIndex,
+        AlterEnum, AlterIndex, CreateEnum, CreateIndex, DropEnum, DropForeignKey, DropIndex,
     },
     sql_schema_differ::{ColumnChanges, ColumnDiffer, SqlSchemaDiffer},
 };
@@ -236,6 +236,14 @@ impl SqlRenderer for MysqlFlavour {
 
     fn render_drop_enum(&self, _drop_enum: &DropEnum) -> Vec<String> {
         Vec::new()
+    }
+
+    fn render_drop_foreign_key(&self, drop_foreign_key: &DropForeignKey) -> String {
+        format!(
+            "ALTER TABLE {table} DROP FOREIGN KEY {constraint_name}",
+            table = self.quote_with_schema(self.schema_name(), &drop_foreign_key.table),
+            constraint_name = Quoted::mysql_ident(&drop_foreign_key.constraint_name),
+        )
     }
 
     fn render_drop_index(&self, drop_index: &DropIndex, database_info: &DatabaseInfo) -> String {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
@@ -262,6 +262,14 @@ impl SqlRenderer for MysqlFlavour {
     ) -> Vec<String> {
         unreachable!("render_redefine_table on MySQL")
     }
+
+    fn render_rename_table(&self, name: &str, new_name: &str, schema_name: &str) -> String {
+        format!(
+            "ALTER TABLE {} RENAME TO {}",
+            self.quote_with_schema(&schema_name, &name),
+            new_name = self.quote_with_schema(&schema_name, &new_name).to_string(),
+        )
+    }
 }
 
 fn render_mysql_modify(

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
@@ -2,7 +2,6 @@ use super::{common::*, RenderedAlterColumn, SqlRenderer};
 use crate::{
     database_info::DatabaseInfo,
     flavour::{MysqlFlavour, SqlFlavour},
-    sql_database_step_applier::render_create_index,
     sql_migration::{
         expanded_alter_column::{expand_mysql_alter_column, MysqlAlterColumn},
         AlterEnum, AlterIndex, CreateEnum, CreateIndex, DropEnum, DropForeignKey, DropIndex,

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
@@ -2,7 +2,6 @@ use super::{common::*, RenderedAlterColumn, SqlRenderer};
 use crate::{
     database_info::DatabaseInfo,
     flavour::PostgresFlavour,
-    sql_database_step_applier::render_create_index,
     sql_migration::{
         expanded_alter_column::{expand_postgres_alter_column, PostgresAlterColumn},
         AlterEnum, AlterIndex, CreateEnum, CreateIndex, DropEnum, DropForeignKey, DropIndex,

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
@@ -5,7 +5,7 @@ use crate::{
     sql_database_step_applier::render_create_index,
     sql_migration::{
         expanded_alter_column::{expand_postgres_alter_column, PostgresAlterColumn},
-        AlterEnum, AlterIndex, CreateEnum, CreateIndex, DropEnum, DropIndex,
+        AlterEnum, AlterIndex, CreateEnum, CreateIndex, DropEnum, DropForeignKey, DropIndex,
     },
     sql_schema_differ::{ColumnDiffer, SqlSchemaDiffer},
 };
@@ -335,6 +335,14 @@ impl SqlRenderer for PostgresFlavour {
         );
 
         vec![sql]
+    }
+
+    fn render_drop_foreign_key(&self, drop_foreign_key: &DropForeignKey) -> String {
+        format!(
+            "ALTER TABLE {table} DROP CONSTRAINT {constraint_name}",
+            table = self.quote_with_schema(self.schema_name(), &drop_foreign_key.table),
+            constraint_name = Quoted::postgres_ident(&drop_foreign_key.constraint_name),
+        )
     }
 
     fn render_drop_index(&self, drop_index: &DropIndex, database_info: &DatabaseInfo) -> String {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
@@ -359,6 +359,14 @@ impl SqlRenderer for PostgresFlavour {
     ) -> Vec<String> {
         unreachable!("render_redefine_table on Postgres")
     }
+
+    fn render_rename_table(&self, name: &str, new_name: &str, schema_name: &str) -> String {
+        format!(
+            "ALTER TABLE {} RENAME TO {}",
+            self.quote_with_schema(&schema_name, &name),
+            new_name = self.quote_with_schema(&schema_name, &new_name).to_string(),
+        )
+    }
 }
 
 pub(crate) fn render_column_type(t: &ColumnType) -> String {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
@@ -360,11 +360,11 @@ impl SqlRenderer for PostgresFlavour {
         unreachable!("render_redefine_table on Postgres")
     }
 
-    fn render_rename_table(&self, name: &str, new_name: &str, schema_name: &str) -> String {
+    fn render_rename_table(&self, name: &str, new_name: &str) -> String {
         format!(
             "ALTER TABLE {} RENAME TO {}",
-            self.quote_with_schema(&schema_name, &name),
-            new_name = self.quote_with_schema(&schema_name, &new_name).to_string(),
+            self.quote_with_schema(self.schema_name(), &name),
+            new_name = self.quote_with_schema(self.schema_name(), &new_name).to_string(),
         )
     }
 }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
@@ -20,12 +20,7 @@ impl SqlRenderer for PostgresFlavour {
         Quoted::postgres_ident(name)
     }
 
-    fn render_alter_enum(
-        &self,
-        alter_enum: &AlterEnum,
-        differ: &SqlSchemaDiffer<'_>,
-        schema_name: &str,
-    ) -> anyhow::Result<Vec<String>> {
+    fn render_alter_enum(&self, alter_enum: &AlterEnum, differ: &SqlSchemaDiffer<'_>) -> anyhow::Result<Vec<String>> {
         if alter_enum.dropped_variants.is_empty() {
             let stmts: Vec<String> = alter_enum
                 .created_variants
@@ -59,7 +54,7 @@ impl SqlRenderer for PostgresFlavour {
             let create_new_enum = format!(
                 "CREATE TYPE {enum_name} AS ENUM ({variants})",
                 enum_name = QuotedWithSchema {
-                    schema_name: schema_name,
+                    schema_name: self.schema_name(),
                     name: Quoted::postgres_ident(&tmp_name),
                 },
                 variants = new_enum.values.iter().map(Quoted::postgres_string).join(", ")
@@ -82,7 +77,7 @@ impl SqlRenderer for PostgresFlavour {
                             ALTER COLUMN {column_name} TYPE {tmp_name} \
                                 USING ({column_name}::text::{tmp_name}),
                             ALTER COLUMN {column_name} SET DEFAULT {new_enum_default}",
-                    schema_name = Quoted::postgres_ident(schema_name),
+                    schema_name = Quoted::postgres_ident(self.schema_name()),
                     table_name = Quoted::postgres_ident(column.table().name()),
                     column_name = Quoted::postgres_ident(column.name()),
                     tmp_name = Quoted::postgres_ident(&tmp_name),
@@ -143,7 +138,7 @@ impl SqlRenderer for PostgresFlavour {
         )])
     }
 
-    fn render_column(&self, _schema_name: &str, column: ColumnWalker<'_>, _add_fk_prefix: bool) -> String {
+    fn render_column(&self, column: ColumnWalker<'_>) -> String {
         let column_name = self.quote(column.name());
         let tpe_str = render_column_type(column.column_type());
         let nullability_str = render_nullability(&column);
@@ -161,7 +156,7 @@ impl SqlRenderer for PostgresFlavour {
         }
     }
 
-    fn render_references(&self, schema_name: &str, foreign_key: &ForeignKey) -> String {
+    fn render_references(&self, foreign_key: &ForeignKey) -> String {
         let referenced_columns = foreign_key
             .referenced_columns
             .iter()
@@ -170,7 +165,7 @@ impl SqlRenderer for PostgresFlavour {
 
         format!(
             "REFERENCES {}({}) {} ON UPDATE CASCADE",
-            self.quote_with_schema(schema_name, &foreign_key.referenced_table),
+            self.quote_with_schema(self.schema_name(), &foreign_key.referenced_table),
             referenced_columns,
             render_on_delete(&foreign_key.on_delete_action)
         )
@@ -305,11 +300,8 @@ impl SqlRenderer for PostgresFlavour {
         )
     }
 
-    fn render_create_table(&self, table: &TableWalker<'_>, schema_name: &str) -> anyhow::Result<String> {
-        let columns: String = table
-            .columns()
-            .map(|column| self.render_column(&schema_name, column, false))
-            .join(",\n");
+    fn render_create_table(&self, table: &TableWalker<'_>) -> anyhow::Result<String> {
+        let columns: String = table.columns().map(|column| self.render_column(column)).join(",\n");
 
         let primary_columns = table.table.primary_key_columns();
         let pk_column_names = primary_columns.iter().map(|col| self.quote(&col)).join(",");
@@ -321,7 +313,7 @@ impl SqlRenderer for PostgresFlavour {
 
         Ok(format!(
             "CREATE TABLE {table_name} (\n{columns}{primary_key}\n)",
-            table_name = self.quote_with_schema(&schema_name, table.name()),
+            table_name = self.quote_with_schema(self.schema_name(), table.name()),
             columns = columns,
             primary_key = pk,
         ))

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
@@ -4,8 +4,8 @@ use crate::{
     flavour::{SqlFlavour, SqliteFlavour},
     sql_database_step_applier::render_create_index,
     sql_migration::{
-        AddColumn, AddForeignKey, AlterEnum, AlterIndex, AlterTable, CreateEnum, CreateIndex, DropEnum, DropIndex,
-        TableChange,
+        AddColumn, AddForeignKey, AlterEnum, AlterIndex, AlterTable, CreateEnum, CreateIndex, DropEnum, DropForeignKey,
+        DropIndex, TableChange,
     },
     sql_schema_differ::{ColumnDiffer, SqlSchemaDiffer, TableDiffer},
 };
@@ -206,6 +206,10 @@ impl SqlRenderer for SqliteFlavour {
 
     fn render_drop_enum(&self, _drop_enum: &DropEnum) -> Vec<String> {
         Vec::new()
+    }
+
+    fn render_drop_foreign_key(&self, _drop_foreign_key: &DropForeignKey) -> String {
+        unreachable!("render_drop_foreign_key on SQLite")
     }
 
     fn render_drop_index(&self, drop_index: &DropIndex, database_info: &DatabaseInfo) -> String {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
@@ -2,7 +2,6 @@ use super::{common::*, RenderedAlterColumn, SqlRenderer};
 use crate::{
     database_info::DatabaseInfo,
     flavour::{SqlFlavour, SqliteFlavour},
-    sql_database_step_applier::render_create_index,
     sql_migration::{
         AddColumn, AddForeignKey, AlterEnum, AlterIndex, AlterTable, CreateEnum, CreateIndex, DropEnum, DropForeignKey,
         DropIndex, TableChange,

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
@@ -298,6 +298,14 @@ impl SqlRenderer for SqliteFlavour {
 
         result
     }
+
+    fn render_rename_table(&self, name: &str, new_name: &str, schema_name: &str) -> String {
+        format!(
+            "ALTER TABLE {} RENAME TO {}",
+            self.quote_with_schema(&schema_name, &name),
+            new_name = self.quote(new_name).to_string(),
+        )
+    }
 }
 
 fn render_column_type(t: &ColumnType) -> String {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
@@ -215,6 +215,18 @@ impl SqlRenderer for SqliteFlavour {
         )
     }
 
+    fn render_drop_table(&self, table_name: &str, schema_name: &str) -> Vec<String> {
+        // Turning off the pragma is safe, because schema validation would forbid foreign keys
+        // to a non-existent model. There appears to be no other way to deal with cyclic
+        // dependencies in the dropping order of tables in the presence of foreign key
+        // constraints on SQLite.
+        vec![
+            "PRAGMA foreign_keys=off".to_string(),
+            format!("DROP TABLE {}", self.quote_with_schema(&schema_name, &table_name)),
+            "PRAGMA foreign_keys=on".to_string(),
+        ]
+    }
+
     fn render_redefine_tables(
         &self,
         tables: &[String],

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
@@ -4,7 +4,8 @@ use crate::{
     flavour::{SqlFlavour, SqliteFlavour},
     sql_database_step_applier::render_create_index,
     sql_migration::{
-        AddColumn, AlterEnum, AlterIndex, AlterTable, CreateEnum, CreateIndex, DropEnum, DropIndex, TableChange,
+        AddColumn, AddForeignKey, AlterEnum, AlterIndex, AlterTable, CreateEnum, CreateIndex, DropEnum, DropIndex,
+        TableChange,
     },
     sql_schema_differ::{ColumnDiffer, SqlSchemaDiffer, TableDiffer},
 };
@@ -101,6 +102,10 @@ impl SqlRenderer for SqliteFlavour {
             (DefaultValue::VALUE(val), _) => format!("{}", val).into(),
             (DefaultValue::SEQUENCE(_), _) => "".into(),
         }
+    }
+
+    fn render_add_foreign_key(&self, _add_foreign_key: &AddForeignKey, _schema_name: &str) -> String {
+        unreachable!("AddForeignKey on SQLite")
     }
 
     fn render_alter_column(&self, _differ: &ColumnDiffer<'_>) -> Option<RenderedAlterColumn> {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
@@ -299,22 +299,22 @@ impl SqlRenderer for SqliteFlavour {
         result
     }
 
-    fn render_rename_table(&self, name: &str, new_name: &str, schema_name: &str) -> String {
+    fn render_rename_table(&self, name: &str, new_name: &str) -> String {
         format!(
             "ALTER TABLE {} RENAME TO {}",
-            self.quote_with_schema(&schema_name, &name),
+            self.quote_with_schema(self.attached_name(), &name),
             new_name = self.quote(new_name).to_string(),
         )
     }
 }
 
-fn render_column_type(t: &ColumnType) -> String {
+fn render_column_type(t: &ColumnType) -> &'static str {
     match &t.family {
-        ColumnTypeFamily::Boolean => "BOOLEAN".to_string(),
-        ColumnTypeFamily::DateTime => "DATETIME".to_string(),
-        ColumnTypeFamily::Float => "REAL".to_string(),
-        ColumnTypeFamily::Int => "INTEGER".to_string(),
-        ColumnTypeFamily::String => "TEXT".to_string(),
+        ColumnTypeFamily::Boolean => "BOOLEAN",
+        ColumnTypeFamily::DateTime => "DATETIME",
+        ColumnTypeFamily::Float => "REAL",
+        ColumnTypeFamily::Int => "INTEGER",
+        ColumnTypeFamily::String => "TEXT",
         x => unimplemented!("{:?} not handled yet", x),
     }
 }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
@@ -174,7 +174,10 @@ impl<'schema> SqlSchemaDiffer<'schema> {
             .table_pairs()
             .filter(|tables| !tables_to_redefine.contains(tables.next.name()));
 
-        push_foreign_keys_from_created_tables(&mut add_foreign_keys, self.created_tables());
+        if self.flavour.should_push_foreign_keys_from_created_tables() {
+            push_foreign_keys_from_created_tables(&mut add_foreign_keys, self.created_tables());
+        }
+
         push_created_foreign_keys(&mut add_foreign_keys, table_pairs);
 
         add_foreign_keys

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour.rs
@@ -8,12 +8,19 @@ mod sqlite;
 
 /// Trait to specialize SQL schema diffing (resulting in migration steps) by SQL backend.
 pub(crate) trait SqlSchemaDifferFlavour {
+    /// Return potential `AlterEnum` steps.
     fn alter_enums(&self, _differ: &SqlSchemaDiffer<'_>) -> Vec<AlterEnum> {
         Vec::new()
     }
 
+    /// Return whether a column's type needs to be migrated.
     fn column_type_changed(&self, differ: &ColumnDiffer<'_>) -> bool {
         differ.previous.column_type_family() != differ.next.column_type_family()
+    }
+
+    /// Whether `AddForeignKey` steps should be generated for created tables.
+    fn should_push_foreign_keys_from_created_tables(&self) -> bool {
+        true
     }
 
     /// Return the tables that cannot be migrated without being redefined. This is currently useful only on SQLite.

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/sqlite.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/sqlite.rs
@@ -20,4 +20,8 @@ impl SqlSchemaDifferFlavour for SqliteFlavour {
             .map(|table| table.next.name().to_owned())
             .collect()
     }
+
+    fn should_push_foreign_keys_from_created_tables(&self) -> bool {
+        false
+    }
 }


### PR DESCRIPTION
This clearly separates the responsibilities of the SqlDatabaseStepApplier from SqlRenderer, and lets us specialize SQL rendering by SQL flavour without constantly matching on the SQL family at runtime.