### PR TITLE
User-facing error for non-existing table

### DIFF
--- a/libs/user-facing-errors/src/query_engine.rs
+++ b/libs/user-facing-errors/src/query_engine.rs
@@ -226,3 +226,12 @@ pub struct InputError {
 pub struct ValueOutOfRange {
     pub details: String,
 }
+
+#[derive(Debug, UserFacingError, Serialize)]
+#[user_facing(
+    code = "P2021",
+    message = "The table `${table}` does not exist in the current database."
+)]
+pub struct TableDoesNotExist {
+    pub table: String,
+}

--- a/query-engine/connectors/query-connector/src/error.rs
+++ b/query-engine/connectors/query-connector/src/error.rs
@@ -21,6 +21,9 @@ impl ConnectorError {
                 })
                 .unwrap(),
             ),
+            ErrorKind::TableDoesNotExist { table } => Some(
+                KnownError::new(user_facing_errors::query_engine::TableDoesNotExist { table: table.clone() }).unwrap(),
+            ),
             _ => None,
         };
 


### PR DESCRIPTION
If the table does not exist in the current database, we should provide a shiny and nice user-facing error instead of a Rust struct.

Closes: https://github.com/prisma/prisma-client-js/issues/847