### PR TITLE
[PROTOTYPE DO NOT MERGE] exploring useful dmmf additions with a rust client generator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,6 +452,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "codegen"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34c59e8a9b988977ec3bd61ab380cf1167048817ecd3d6999fac03657f85a609"
+dependencies = [
+ "indexmap",
+]
+
+[[package]]
 name = "colored"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2495,6 +2504,7 @@ dependencies = [
  "async-trait",
  "base64 0.10.1",
  "chrono",
+ "codegen",
  "datamodel",
  "failure",
  "feature-flags",

--- a/query-engine/core/src/schema/query_schema.rs
+++ b/query-engine/core/src/schema/query_schema.rs
@@ -270,6 +270,8 @@ pub struct InputObjectType {
 
     #[debug_stub = "#Input Fields Cell#"]
     pub fields: OnceCell<Vec<InputFieldRef>>,
+
+    pub model: Option<String>,
 }
 
 impl InputObjectType {

--- a/query-engine/core/src/schema/query_schema.rs
+++ b/query-engine/core/src/schema/query_schema.rs
@@ -152,11 +152,19 @@ pub struct Field {
     pub arguments: Vec<Argument>,
     pub field_type: OutputTypeRef,
     pub query_builder: Option<SchemaQueryBuilder>,
+    // set if this can be attributed to a Model somehow
+    pub model: Option<String>,
 }
 
 impl Field {
     pub fn query_builder(&self) -> Option<&SchemaQueryBuilder> {
         self.query_builder.as_ref()
+    }
+
+    pub fn set_model(self, model: &str) -> Self {
+        let mut mut_self = self;
+        mut_self.model = Some(model.to_string());
+        mut_self
     }
 }
 

--- a/query-engine/core/src/schema_builder/filter_type_builder.rs
+++ b/query-engine/core/src/schema_builder/filter_type_builder.rs
@@ -31,7 +31,9 @@ impl<'a> FilterObjectTypeBuilder<'a> {
         let object_name = format!("{}ScalarWhereInput", model.name);
         return_cached!(self.get_cache(), &object_name);
 
-        let input_object = Arc::new(init_input_object_type(object_name.clone()));
+        let mut input_object = init_input_object_type(object_name.clone());
+        input_object.model = Some(model.name.to_string());
+        let input_object = Arc::new(input_object);
         self.cache(object_name, Arc::clone(&input_object));
 
         let weak_ref = Arc::downgrade(&input_object);
@@ -74,7 +76,9 @@ impl<'a> FilterObjectTypeBuilder<'a> {
         let name = format!("{}WhereInput", model.name.clone());
         return_cached!(self.input_object_cache, &name);
 
-        let input_object = Arc::new(init_input_object_type(name.clone()));
+        let mut input_object = init_input_object_type(name.clone());
+        input_object.model = Some(model.name.to_string());
+        let input_object = Arc::new(input_object);
         self.cache(name, Arc::clone(&input_object));
 
         let weak_ref = Arc::downgrade(&input_object);

--- a/query-engine/core/src/schema_builder/input_type_builder/create_input_type_extension.rs
+++ b/query-engine/core/src/schema_builder/input_type_builder/create_input_type_extension.rs
@@ -52,7 +52,9 @@ pub trait CreateInputTypeBuilderExtension<'a>: InputTypeBuilderBase<'a> {
 
         return_cached!(self.get_cache(), &name);
 
-        let input_object = Arc::new(init_input_object_type(name.clone()));
+        let mut input_object = init_input_object_type(name.clone());
+        input_object.model = Some(model.name.to_string());
+        let input_object = Arc::new(input_object);
 
         // Cache empty object for circuit breaking
         self.cache(name, Arc::clone(&input_object));

--- a/query-engine/core/src/schema_builder/query_schema_builder.rs
+++ b/query-engine/core/src/schema_builder/query_schema_builder.rs
@@ -222,6 +222,7 @@ impl<'a> QuerySchemaBuilder<'a> {
                         }),
                     ))),
                 )
+                .set_model(&model.name)
             })
     }
 
@@ -251,6 +252,7 @@ impl<'a> QuerySchemaBuilder<'a> {
                 }),
             ))),
         )
+        .set_model(&model.name)
     }
 
     /// Builds an "aggregate" query field (e.g. "aggregateUser") for given model.
@@ -276,6 +278,7 @@ impl<'a> QuerySchemaBuilder<'a> {
                 }),
             ))),
         )
+        .set_model(&model.name)
     }
 
     fn create_execute_raw_field(&self) -> Field {
@@ -337,6 +340,7 @@ impl<'a> QuerySchemaBuilder<'a> {
                 }),
             ))),
         )
+        .set_model(&model.name)
     }
 
     /// Builds a delete mutation field (e.g. deleteUser) for given model.
@@ -364,6 +368,7 @@ impl<'a> QuerySchemaBuilder<'a> {
                     }),
                 ))),
             )
+            .set_model(&model.name)
         })
     }
 
@@ -390,6 +395,7 @@ impl<'a> QuerySchemaBuilder<'a> {
                 }),
             ))),
         )
+        .set_model(&model.name)
     }
 
     /// Builds an update mutation field (e.g. updateUser) for given model.
@@ -415,6 +421,7 @@ impl<'a> QuerySchemaBuilder<'a> {
                     }),
                 ))),
             )
+            .set_model(&model.name)
         })
     }
 
@@ -441,6 +448,7 @@ impl<'a> QuerySchemaBuilder<'a> {
                 }),
             ))),
         )
+        .set_model(&model.name)
     }
 
     /// Builds an upsert mutation field (e.g. upsertUser) for given model.
@@ -464,6 +472,7 @@ impl<'a> QuerySchemaBuilder<'a> {
                     }),
                 ))),
             )
+            .set_model(&model.name)
         })
     }
 

--- a/query-engine/core/src/schema_builder/utils.rs
+++ b/query-engine/core/src/schema_builder/utils.rs
@@ -77,6 +77,7 @@ where
         arguments,
         field_type: Arc::new(field_type),
         query_builder,
+        model: None,
     }
 }
 

--- a/query-engine/core/src/schema_builder/utils.rs
+++ b/query-engine/core/src/schema_builder/utils.rs
@@ -36,6 +36,7 @@ where
         name: name.into(),
         is_one_of: false,
         fields: OnceCell::new(),
+        model: None,
     }
 }
 

--- a/query-engine/query-engine/Cargo.toml
+++ b/query-engine/query-engine/Cargo.toml
@@ -35,6 +35,7 @@ url = "2.1"
 structopt = "0.3"
 rust_decimal = "1.6"
 once_cell = "1.3"
+codegen = "0.1.3"
 
 tracing = "0.1"
 tracing-subscriber = { version = "0.2", features = ["json"] }

--- a/query-engine/query-engine/src/dmmf/mod.rs
+++ b/query-engine/query-engine/src/dmmf/mod.rs
@@ -2,7 +2,7 @@ mod schema;
 
 use datamodel;
 use query_core::schema::{QuerySchemaRef, QuerySchemaRenderer};
-use schema::*;
+pub use schema::*;
 use serde::{ser::SerializeMap, Serialize, Serializer};
 use std::cmp::Ordering;
 use std::{cell::RefCell, collections::HashMap};

--- a/query-engine/query-engine/src/dmmf/schema/ast.rs
+++ b/query-engine/query-engine/src/dmmf/schema/ast.rs
@@ -22,6 +22,7 @@ pub struct DMMFField {
     pub name: String,
     pub args: Vec<DMMFArgument>,
     pub output_type: DMMFTypeInfo,
+    pub model: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/query-engine/query-engine/src/dmmf/schema/ast.rs
+++ b/query-engine/query-engine/src/dmmf/schema/ast.rs
@@ -38,6 +38,7 @@ pub struct DMMFInputType {
     pub name: String,
     pub is_one_of: bool,
     pub fields: Vec<DMMFInputField>,
+    pub model: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/query-engine/query-engine/src/dmmf/schema/field_renderer.rs
+++ b/query-engine/query-engine/src/dmmf/schema/field_renderer.rs
@@ -33,6 +33,7 @@ impl DMMFFieldRenderer {
             name: field.name.clone(),
             args,
             output_type,
+            model: field.model.clone(),
         };
 
         ctx.add_mapping(field.name.clone(), field.query_builder.as_ref());

--- a/query-engine/query-engine/src/dmmf/schema/object_renderer.rs
+++ b/query-engine/query-engine/src/dmmf/schema/object_renderer.rs
@@ -40,6 +40,7 @@ impl DMMFObjectRenderer {
             name: input_object.name.clone(),
             is_one_of: input_object.is_one_of,
             fields: rendered_fields,
+            model: input_object.model.clone(),
         };
 
         ctx.add_input_type(input_type);

--- a/query-engine/query-engine/src/tests.rs
+++ b/query-engine/query-engine/src/tests.rs
@@ -1,4 +1,5 @@
 mod dmmf;
 mod execute_raw;
+mod rust_client_generator;
 mod test_api;
 mod type_mappings;

--- a/query-engine/query-engine/src/tests/dmmf.rs
+++ b/query-engine/query-engine/src/tests/dmmf.rs
@@ -120,7 +120,7 @@ fn must_not_fail_on_missing_env_vars_in_a_datasource() {
         .expect("finding BlogCreateInput");
 }
 
-fn get_query_schema(datamodel_string: &str) -> (QuerySchema, datamodel::dml::Datamodel) {
+pub fn get_query_schema(datamodel_string: &str) -> (QuerySchema, datamodel::dml::Datamodel) {
     feature_flags::initialize(&vec![String::from("all")]).unwrap();
 
     let dm = datamodel::parse_datamodel_and_ignore_datasource_urls(datamodel_string).unwrap();

--- a/query-engine/query-engine/src/tests/rust_client_generator.rs
+++ b/query-engine/query-engine/src/tests/rust_client_generator.rs
@@ -36,6 +36,7 @@ fn client_generator_test() {
 
     let mut scope = Scope::new();
 
+    scope.raw("#![allow(non_snake_case, dead_code, unused_variables, non_camel_case_types)]");
     scope.raw("/// INPUT TYPES");
     for input in inputs.iter() {
         if input.is_one_of {
@@ -104,6 +105,13 @@ fn client_generator_test() {
             function.ret(&map_type(&mutation_field.output_type));
         }
         function.line("todo!()");
+    }
+
+    for an_enum in dmmf.schema.enums.iter() {
+        let the_enum = scope.new_enum(&an_enum.name).vis("pub");
+        for variant in an_enum.values.iter() {
+            the_enum.new_variant(&variant);
+        }
     }
 
     write_to_disk(&scope.to_string());

--- a/query-engine/query-engine/src/tests/rust_client_generator.rs
+++ b/query-engine/query-engine/src/tests/rust_client_generator.rs
@@ -1,0 +1,163 @@
+use super::dmmf::get_query_schema;
+use crate::dmmf::*;
+use codegen::{Scope, Struct, Type};
+use serial_test::serial;
+use std::fs::File;
+use std::io::prelude::*;
+use std::sync::Arc;
+
+// Tests in this file run serially because the function `get_query_schema` depends on setting an env var.
+
+#[test]
+#[serial]
+fn client_generator_test() {
+    let dm = r#"
+        model Blog {
+            blogId String @id
+            name   String
+        }
+
+        model Post {
+            postId   String  @id
+            title    String
+            subTitle String
+            
+            @@unique([title, subTitle])
+        }
+    "#;
+
+    let (query_schema, datamodel) = get_query_schema(dm);
+
+    let dmmf = crate::dmmf::render_dmmf(&datamodel, Arc::new(query_schema));
+
+    dbg!(&dmmf);
+
+    let inputs = &dmmf.schema.input_types;
+
+    let mut scope = Scope::new();
+
+    scope.raw("/// INPUT TYPES");
+    for input in inputs.iter() {
+        if input.is_one_of {
+            let input_enum = scope.new_enum(&input.name).vis("pub");
+            for field in input.fields.iter() {
+                input_enum
+                    .new_variant(&field.name.pascal_case())
+                    .tuple(&field.input_type.typ);
+            }
+        } else {
+            let input_struct = new_struct(&mut scope, &input.name);
+            for field in input.fields.iter() {
+                input_struct.field(&format!("pub {}", &field.name), map_type(&field.input_type));
+            }
+        }
+    }
+
+    scope.raw("/// OUTPUT TYPES");
+
+    let non_model_types = vec!["Query", "Mutation"];
+    let model_output_types: Vec<_> = dmmf
+        .schema
+        .output_types
+        .iter()
+        .filter(|ot| !non_model_types.contains(&ot.name.as_str()))
+        .collect();
+
+    for output in model_output_types.iter() {
+        let output_struct = new_struct(&mut scope, &output.name);
+        for field in output.fields.iter() {
+            output_struct.field(&format!("pub {}", &field.name), map_type(&field.output_type));
+        }
+    }
+
+    let query_type = dmmf.schema.output_types.iter().find(|ot| ot.name == "Query").unwrap();
+    let mutation_type = dmmf
+        .schema
+        .output_types
+        .iter()
+        .find(|ot| ot.name == "Mutation")
+        .unwrap();
+
+    let _ = new_struct(&mut scope, "PrismaClient");
+    let client_impl = scope.new_impl("PrismaClient");
+    client_impl.new_fn("new").vis("pub").ret("PrismaClient").line("todo!()");
+
+    for query_field in query_type.fields.iter() {
+        let function = client_impl.new_fn(&query_field.name);
+        function.arg_ref_self();
+        for arg in query_field.args.iter() {
+            let arg_name = if &arg.name == "where" { "where_" } else { &arg.name };
+
+            function.arg(arg_name, &map_type(&arg.input_type)).vis("pub");
+        }
+        function.ret(&map_type(&query_field.output_type));
+        function.line("todo!()");
+    }
+
+    for mutation_field in mutation_type.fields.iter() {
+        let function = client_impl.new_fn(&mutation_field.name);
+        function.arg_ref_self();
+        for arg in mutation_field.args.iter() {
+            let arg_name = if &arg.name == "where" { "where_" } else { &arg.name };
+
+            function.arg(arg_name, &map_type(&arg.input_type)).vis("pub");
+            function.ret(&map_type(&mutation_field.output_type));
+        }
+        function.line("todo!()");
+    }
+
+    write_to_disk(&scope.to_string());
+}
+
+fn map_type(dmmf_type: &DMMFTypeInfo) -> Type {
+    let x = match dmmf_type.typ.as_str() {
+        "Int" => "i64",
+        x => x,
+    };
+
+    if dmmf_type.is_nullable {
+        let mut tpe = Type::new("Option");
+        tpe.generic(x);
+        tpe
+    } else if dmmf_type.is_list {
+        let mut tpe = Type::new("Vec");
+        tpe.generic(x);
+        tpe
+    } else {
+        Type::new(x)
+    }
+}
+
+fn new_struct<'a>(scope: &'a mut Scope, name: &str) -> &'a mut Struct {
+    scope.new_struct(name).vis("pub")
+}
+
+fn write_to_disk(content: &str) {
+    let path = "/Users/marcusboehm/R/github.com/prisma/rust-client-test/src/client.rs";
+    let mut file = File::create(path).expect("creating file failed");
+    file.write_all(content.as_bytes()).expect("writing to file failed");
+}
+
+pub trait NameNormalizer {
+    fn camel_case(&self) -> String;
+
+    fn pascal_case(&self) -> String;
+}
+
+impl NameNormalizer for String {
+    fn camel_case(&self) -> String {
+        let mut c = self.chars();
+        match c.next() {
+            None => String::new(),
+            Some(f) => f.to_lowercase().collect::<String>() + c.as_str(),
+        }
+    }
+
+    fn pascal_case(&self) -> String {
+        let mut c = self.chars();
+        match c.next() {
+            None => String::new(),
+            Some(f) => f.to_uppercase().collect::<String>() + c.as_str(),
+        }
+    }
+}


### PR DESCRIPTION
This PR explores what kind of tiny improvements we could introduce into the DMMF in order to ease the work of a client generator. In order to get a feel for what makes a good improvement i started to prototype a rust client generator. It relies purely on the `schema` part of DMMF to generate the client. This in contrast to our existing generators that make use of the `data_model` information as well. @dpetrick and I always had the feeling that this is an antipattern that leads to brittle generator implementations.

The generated client for the example schema in this PR can be found [here](https://gist.github.com/mavilein/9b1bbeeeba01859fee5dd226606e81d1). 
A tiny example script using this client can be found [here](https://gist.github.com/mavilein/9da5cc7a8db0786952988043adb3faea).