### PR TITLE
(pg) Add missing schema name in MigrationPersistence init

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/sql_migration_persistence.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_migration_persistence.rs
@@ -34,7 +34,7 @@ impl MigrationPersistence for SqlMigrationPersistence<'_> {
                 SqlFamily::Postgres => {
                     let mut m = barrel::Migration::new().schema(self.schema_name());
                     m.create_table(MIGRATION_TABLE_NAME, migration_table_setup_postgres);
-                    m.make_from(barrel::SqlVariant::Pg)
+                    m.schema(self.schema_name()).make_from(barrel::SqlVariant::Pg)
                 }
                 SqlFamily::Mysql => {
                     let mut m = barrel::Migration::new().schema(self.schema_name());

--- a/query-engine/connectors/sql-query-connector/src/row.rs
+++ b/query-engine/connectors/sql-query-connector/src/row.rs
@@ -2,7 +2,7 @@ use crate::error::SqlError;
 use chrono::{DateTime, NaiveDate, Utc};
 use connector_interface::{AggregationResult, Aggregator};
 use datamodel::FieldArity;
-use prisma_models::{PrismaValue, Record, ScalarFieldRef, TypeIdentifier};
+use prisma_models::{PrismaValue, Record, TypeIdentifier};
 use quaint::{
     ast::{Expression, Value},
     connector::ResultRow,


### PR DESCRIPTION
This should address https://github.com/prisma/migrate/issues/572