### PR TITLE
Test that enums can be altered on empty databases

### DIFF
--- a/migration-engine/migration-engine-tests/src/assertions.rs
+++ b/migration-engine/migration-engine-tests/src/assertions.rs
@@ -113,7 +113,13 @@ pub struct EnumAssertion<'a>(&'a Enum);
 
 impl<'a> EnumAssertion<'a> {
     pub fn assert_values(self, expected_values: &[&'static str]) -> AssertionResult<Self> {
-        assert_eq!(self.0.values, expected_values);
+        anyhow::ensure!(
+            self.0.values == expected_values,
+            "Assertion failed. The `{}` enum does not contain the expected variants.\nExpected:\n{:#?}\n\nFound:\n{:#?}\n",
+            self.0.name,
+            expected_values,
+            self.0.values
+        );
 
         Ok(self)
     }

--- a/migration-engine/migration-engine-tests/tests/migrations/enums.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/enums.rs
@@ -1,6 +1,6 @@
 use migration_engine_tests::sql::*;
 
-#[test_each_connector(capabilities("enums"), log = "debug,sql_schema_describer=info")]
+#[test_each_connector(capabilities("enums"))]
 async fn an_enum_can_be_turned_into_a_model(api: &TestApi) -> TestResult {
     let dm1 = r#"
         model Cat {
@@ -47,6 +47,103 @@ async fn an_enum_can_be_turned_into_a_model(api: &TestApi) -> TestResult {
         })?
         .assert_table("CatMood", |table| table.assert_column_count(3))?
         .assert_has_no_enum("CatMood")?;
+
+    Ok(())
+}
+
+#[test_each_connector(capabilities("enums"))]
+async fn variants_can_be_added_to_an_existing_enum(api: &TestApi) -> TestResult {
+    let dm1 = r#"
+        model Cat {
+            id Int @id
+            mood CatMood
+        }
+
+        enum CatMood {
+            HUNGRY
+        }
+    "#;
+
+    api.schema_push(dm1).send().await?.assert_green()?;
+
+    let enum_name = if api.sql_family().is_mysql() {
+        "Cat_mood"
+    } else {
+        "CatMood"
+    };
+
+    api.assert_schema()
+        .await?
+        .assert_enum(enum_name, |enm| enm.assert_values(&["HUNGRY"]))?;
+
+    let dm2 = r#"
+        model Cat {
+            id Int @id
+            mood CatMood
+        }
+
+        enum CatMood {
+            HAPPY
+            HUNGRY
+        }
+    "#;
+
+    api.schema_push(dm2).send().await?.assert_green()?;
+
+    api.assert_schema()
+        .await?
+        .assert_enum(enum_name, |enm| enm.assert_values(&["HAPPY", "HUNGRY"]))?;
+
+    Ok(())
+}
+
+#[test_each_connector(capabilities("enums"))]
+async fn variants_can_be_removed_from_an_existing_enum(api: &TestApi) -> TestResult {
+    let dm1 = r#"
+        model Cat {
+            id Int @id
+            mood CatMood
+        }
+
+        enum CatMood {
+            HAPPY
+            HUNGRY
+        }
+    "#;
+
+    api.schema_push(dm1).send().await?.assert_green()?;
+
+    let enum_name = if api.sql_family().is_mysql() {
+        "Cat_mood"
+    } else {
+        "CatMood"
+    };
+
+    api.assert_schema()
+        .await?
+        .assert_enum(enum_name, |enm| enm.assert_values(&["HAPPY", "HUNGRY"]))?;
+
+    let dm2 = r#"
+        model Cat {
+            id Int @id
+            mood CatMood
+        }
+
+        enum CatMood {
+            HUNGRY
+        }
+    "#;
+
+    api.schema_push(dm2)
+        .force(true)
+        .send()
+        .await?
+        .assert_warnings(&[format!("The migration will remove the values [HAPPY] on the enum `{}`. If these variants are still used in the database, the migration will fail.", enum_name).into()])?
+        .assert_executable()?;
+
+    api.assert_schema()
+        .await?
+        .assert_enum(enum_name, |enm| enm.assert_values(&["HUNGRY"]))?;
 
     Ok(())
 }


### PR DESCRIPTION
This is already covered for databases with existing rows using the enum values.

Attempt at reproducing https://github.com/prisma/migrate/issues/580

closes https://github.com/prisma/migrate/issues/580