### PR TITLE
Specialize ALTER TABLE rendering

### DIFF
--- a/libs/sql-schema-describer/src/walkers.rs
+++ b/libs/sql-schema-describer/src/walkers.rs
@@ -66,10 +66,6 @@ impl<'a> ColumnWalker<'a> {
         self.column.auto_increment
     }
 
-    pub fn is_required(&self) -> bool {
-        self.column.is_required()
-    }
-
     pub fn is_same_column(&self, other: &ColumnWalker<'_>) -> bool {
         self.name() == other.name() && self.table().name() == other.table().name()
     }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
@@ -135,9 +135,7 @@ fn render_raw_sql(
         SqlMigrationStep::DropForeignKey(drop_foreign_key) => {
             Ok(vec![renderer.render_drop_foreign_key(drop_foreign_key)])
         }
-        SqlMigrationStep::AlterTable(alter_table) => {
-            Ok(renderer.render_alter_table(alter_table, database_info, &differ))
-        }
+        SqlMigrationStep::AlterTable(alter_table) => Ok(renderer.render_alter_table(alter_table, &differ)),
         SqlMigrationStep::CreateIndex(create_index) => Ok(vec![renderer.render_create_index(create_index)]),
         SqlMigrationStep::DropIndex(drop_index) => Ok(vec![renderer.render_drop_index(drop_index)]),
         SqlMigrationStep::AlterIndex(alter_index) => {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker.rs
@@ -63,7 +63,7 @@ impl SqlDestructiveChangeChecker<'_> {
     /// - The new column is required
     /// - There is no default value for the new column
     fn check_add_column(&self, column: &ColumnWalker<'_>, plan: &mut DestructiveCheckPlan) {
-        let column_is_required_without_default = column.is_required() && column.default().is_none();
+        let column_is_required_without_default = column.arity().is_required() && column.default().is_none();
 
         // Optional columns and columns with a default can safely be added.
         if !column_is_required_without_default {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/mysql.rs
@@ -21,7 +21,7 @@ impl DestructiveChangeCheckerFlavour for MysqlFlavour {
             MysqlAlterColumn::Modify { .. } => {
                 // Column went from optional to required. This is unexecutable unless the table is
                 // empty or the column has no existing NULLs.
-                if columns.all_changes().arity_changed() && columns.next.column.tpe.arity.is_required() {
+                if columns.all_changes().arity_changed() && columns.next.arity().is_required() {
                     plan.push_unexecutable(UnexecutableStepCheck::MadeOptionalFieldRequired {
                         column: columns.previous.name().to_owned(),
                         table: columns.previous.table().name().to_owned(),

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/postgres.rs
@@ -25,8 +25,8 @@ impl DestructiveChangeCheckerFlavour for PostgresFlavour {
                         })
                     }
                     PostgresAlterColumn::SetType(_) => {
-                        if !matches!(columns.previous.column.tpe.arity, ColumnArity::List)
-                            && matches!(columns.next.column.tpe.arity, ColumnArity::List)
+                        if !matches!(columns.previous.arity(), ColumnArity::List)
+                            && matches!(columns.next.arity(), ColumnArity::List)
                         {
                             plan.push_unexecutable(UnexecutableStepCheck::MadeScalarFieldIntoArrayField {
                                 table: columns.previous.table().name().to_owned(),
@@ -48,8 +48,8 @@ impl DestructiveChangeCheckerFlavour for PostgresFlavour {
         } else {
             // Unexecutable drop and recreate.
             if columns.all_changes().arity_changed()
-                && columns.previous.column.tpe.arity.is_nullable()
-                && columns.next.column.tpe.arity.is_required()
+                && columns.previous.arity().is_nullable()
+                && columns.next.arity().is_required()
                 && !default_can_be_rendered(columns.next.default())
             {
                 plan.push_unexecutable(UnexecutableStepCheck::AddedRequiredFieldToTable {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/common.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/common.rs
@@ -74,7 +74,7 @@ where
 }
 
 pub(crate) fn render_nullability(column: &ColumnWalker<'_>) -> &'static str {
-    if column.is_required() {
+    if column.arity().is_required() {
         " NOT NULL"
     } else {
         ""

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
@@ -1,12 +1,17 @@
-use super::{common::*, RenderedAlterColumn, SqlRenderer};
+use super::{common::*, SqlRenderer};
 use crate::{
     database_info::DatabaseInfo,
     flavour::{MysqlFlavour, SqlFlavour},
+    sql_migration::AddColumn,
+    sql_migration::AlterColumn,
+    sql_migration::AlterTable,
+    sql_migration::DropColumn,
+    sql_migration::TableChange,
     sql_migration::{
         expanded_alter_column::{expand_mysql_alter_column, MysqlAlterColumn},
         AlterEnum, AlterIndex, CreateEnum, CreateIndex, DropEnum, DropForeignKey, DropIndex,
     },
-    sql_schema_differ::{ColumnChanges, ColumnDiffer, SqlSchemaDiffer},
+    sql_schema_differ::{ColumnChanges, SqlSchemaDiffer},
 };
 use once_cell::sync::Lazy;
 use prisma_value::PrismaValue;
@@ -83,6 +88,64 @@ impl SqlRenderer for MysqlFlavour {
         }
     }
 
+    fn render_alter_table(&self, alter_table: &AlterTable, differ: &SqlSchemaDiffer<'_>) -> Vec<String> {
+        let AlterTable { table, changes } = alter_table;
+
+        let mut lines = Vec::new();
+
+        for change in changes {
+            match change {
+                TableChange::DropPrimaryKey { constraint_name: _ } => lines.push("DROP PRIMARY KEY".to_owned()),
+                TableChange::AddPrimaryKey { columns } => lines.push(format!(
+                    "ADD PRIMARY KEY ({})",
+                    columns.iter().map(|colname| self.quote(colname)).join(", ")
+                )),
+                TableChange::AddColumn(AddColumn { column }) => {
+                    let column = ColumnWalker {
+                        table,
+                        schema: differ.next,
+                        column,
+                    };
+                    let col_sql = self.render_column(column);
+                    lines.push(format!("ADD COLUMN {}", col_sql));
+                }
+                TableChange::DropColumn(DropColumn { name }) => {
+                    let name = self.quote(&name);
+                    lines.push(format!("DROP COLUMN {}", name));
+                }
+                TableChange::AlterColumn(AlterColumn { name, column: _ }) => {
+                    let columns = differ
+                        .diff_table(&table.name)
+                        .expect("AlterTable on unknown table.")
+                        .diff_column(name)
+                        .expect("AlterColumn on unknown column.");
+
+                    let expanded = expand_mysql_alter_column(&columns);
+
+                    match expanded {
+                        MysqlAlterColumn::DropDefault => lines.push(format!(
+                            "ALTER COLUMN {column} DROP DEFAULT",
+                            column = Quoted::mysql_ident(columns.previous.name())
+                        )),
+                        MysqlAlterColumn::Modify { new_default, changes } => {
+                            lines.push(render_mysql_modify(&changes, new_default.as_ref(), columns.next, self))
+                        }
+                    };
+                }
+            };
+        }
+
+        if lines.is_empty() {
+            return Vec::new();
+        }
+
+        vec![format!(
+            "ALTER TABLE {} {}",
+            self.quote_with_schema(&table.name),
+            lines.join(",\n")
+        )]
+    }
+
     fn render_column(&self, column: ColumnWalker<'_>) -> String {
         let column_name = self.quote(column.name());
         let tpe_str = render_column_type(&column);
@@ -94,7 +157,7 @@ impl SqlRenderer for MysqlFlavour {
                     // We do not want to render JSON defaults because they are not supported by MySQL.
                     && !matches!(column.column_type_family(), ColumnTypeFamily::Json)
             })
-            .map(|default| format!("DEFAULT {}", self.render_default(default, &column.column.tpe.family)))
+            .map(|default| format!("DEFAULT {}", self.render_default(default, &column.column_type_family())))
             .unwrap_or_else(String::new);
         let foreign_key = column.table().foreign_key_for_column(column.name());
         let auto_increment_str = if column.is_autoincrement() {
@@ -141,26 +204,6 @@ impl SqlRenderer for MysqlFlavour {
             (DefaultValue::VALUE(val), _) => format!("{}", val).into(),
             (DefaultValue::SEQUENCE(_), _) => "".into(),
         }
-    }
-
-    fn render_alter_column<'a>(&self, differ: &ColumnDiffer<'_>) -> Option<RenderedAlterColumn> {
-        let expanded = expand_mysql_alter_column(differ);
-
-        let sql = match expanded {
-            MysqlAlterColumn::DropDefault => vec![format!(
-                "ALTER COLUMN {column} DROP DEFAULT",
-                column = Quoted::mysql_ident(differ.previous.name())
-            )],
-            MysqlAlterColumn::Modify { new_default, changes } => {
-                vec![render_mysql_modify(&changes, new_default.as_ref(), differ.next, self)]
-            }
-        };
-
-        Some(RenderedAlterColumn {
-            alter_columns: sql,
-            before: None,
-            after: None,
-        })
     }
 
     fn render_create_enum(&self, _create_enum: &CreateEnum) -> Vec<String> {
@@ -259,7 +302,7 @@ fn render_mysql_modify(
         Some(next_column.column_type().full_data_type.clone()).filter(|r| !r.is_empty() || r.contains("datetime"))
     // @default(now()) does not work with datetimes of certain sizes
     } else {
-        Some(next_column.column.tpe.full_data_type.clone()).filter(|r| !r.is_empty())
+        Some(next_column.column_type().full_data_type.clone()).filter(|r| !r.is_empty())
     };
 
     let column_type = column_type

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/column.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/column.rs
@@ -99,7 +99,7 @@ impl<'a> ColumnDiffer<'a> {
             (Some(DefaultValue::DBGENERATED(_)), Some(DefaultValue::NOW)) => false,
             (Some(DefaultValue::DBGENERATED(_)), None) => false,
 
-            (Some(DefaultValue::SEQUENCE(_)), None) => false,
+            (Some(DefaultValue::SEQUENCE(_)), None) => true, // sequences are dropped separately
             (Some(DefaultValue::SEQUENCE(_)), Some(DefaultValue::VALUE(_))) => false,
             (Some(DefaultValue::SEQUENCE(_)), Some(DefaultValue::NOW)) => false,
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/sqlite.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/sqlite.rs
@@ -10,7 +10,7 @@ impl SqlSchemaDifferFlavour for SqliteFlavour {
                 differ.created_primary_key().is_some()
                     || differ.dropped_primary_key().is_some()
                     || differ.dropped_columns().next().is_some()
-                    || differ.added_columns().filter(|col| col.is_required()).next().is_some()
+                    || differ.added_columns().filter(|col| col.arity().is_required()).next().is_some()
                     || differ.column_pairs().filter(|columns| columns.all_changes().iter().next().is_some()).next().is_some()
                     // ALTER INDEX does not exist on SQLite
                     || differ.index_pairs().next().is_some()

--- a/migration-engine/migration-engine-tests/tests/migration_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migration_tests.rs
@@ -1674,7 +1674,7 @@ async fn column_defaults_must_be_migrated(api: &TestApi) -> TestResult {
     Ok(())
 }
 
-#[test_each_connector]
+#[test_each_connector(log = "debug,sql-schema-describer=info")]
 async fn escaped_string_defaults_are_not_arbitrarily_migrated(api: &TestApi) -> TestResult {
     use quaint::ast::Insert;
 


### PR DESCRIPTION
Small refactoring to avoid bundling all the complexity across multiple databases in one method implementation. Only postgres needs to deal with extra statements before and after the alter table for example.

This separates MySQL and Postgres. SQLite already had its own implementation.