### PR TITLE
Change the way how we convert Decimal to f64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2628,7 +2628,7 @@ dependencies = [
 [[package]]
 name = "quaint"
 version = "0.2.0-alpha.13"
-source = "git+https://github.com/prisma/quaint#d77f14eda7e8d96665a43ee19f45312f0a8fbdb0"
+source = "git+https://github.com/prisma/quaint#1455588c41009394b504bac4052838a83b00a9fd"
 dependencies = [
  "async-trait",
  "base64 0.11.0",
@@ -3459,6 +3459,7 @@ version = "0.1.0"
 dependencies = [
  "darling",
  "enumflags2",
+ "feature-flags",
  "once_cell",
  "proc-macro2 1.0.20",
  "quote 1.0.7",

--- a/libs/prisma-value/src/lib.rs
+++ b/libs/prisma-value/src/lib.rs
@@ -119,7 +119,7 @@ fn serialize_decimal<S>(decimal: &Decimal, serializer: S) -> Result<S::Ok, S::Er
 where
     S: Serializer,
 {
-    decimal.to_f64().expect("Decimal is not a f64.").serialize(serializer)
+    decimal.to_string().parse::<f64>().unwrap().serialize(serializer)
 }
 
 impl PrismaValue {

--- a/libs/test-macros/Cargo.toml
+++ b/libs/test-macros/Cargo.toml
@@ -11,6 +11,7 @@ proc-macro = true
 
 [dependencies]
 test-setup = { path = "../test-setup" }
+feature-flags = { path = "../feature-flags" }
 
 darling = "0.10.1"
 enumflags2 = "0.6.0"

--- a/query-engine/query-engine/src/tests.rs
+++ b/query-engine/query-engine/src/tests.rs
@@ -1,3 +1,4 @@
+mod decimal;
 mod dmmf;
 mod execute_raw;
 mod test_api;

--- a/query-engine/query-engine/src/tests/decimal.rs
+++ b/query-engine/query-engine/src/tests/decimal.rs
@@ -1,0 +1,36 @@
+use super::test_api::*;
+use indoc::indoc;
+use serde_json::json;
+use test_macros::*;
+
+static MODEL: &str = indoc! {"
+    model Transaction {
+        id       Int    @id @default(autoincrement())
+        amount   Float
+    }
+"};
+
+#[test_each_connector]
+async fn decimal_conversion(api: &TestApi) -> anyhow::Result<()> {
+    feature_flags::initialize(&vec![String::from("all")]).unwrap();
+    let query_engine = api.create_engine(&MODEL).await?;
+
+    let query = indoc! {r#"
+        mutation {
+            createOneTransaction(data: {amount: 1.59283191 }) { amount }
+        }
+    "#};
+
+    assert_eq!(
+        json!({
+            "data": {
+                "createOneTransaction": {
+                    "amount": 1.59283191
+                }
+            }
+        }),
+        query_engine.request(query).await
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
In our JSON responses we go from `Decimal` to `f64`. rust_decimal recently changed their conversion algorithm from `Decimal` -> `String` -> `f64` to a faster mantissa algorithm that goes `Decimal` -> `f64` directly. This seems to cause some loss of precision for now, so we'll do the conversion as the crate used to do through a `String`, that is slower but keeps the accuracy.

Closes: https://github.com/prisma/prisma/issues/3479