### PR TITLE
Add #![deny(missing-docs)] lint to migration-connector

### DIFF
--- a/migration-engine/connectors/migration-connector/src/database_migration_step_applier.rs
+++ b/migration-engine/connectors/migration-connector/src/database_migration_step_applier.rs
@@ -17,6 +17,8 @@ pub trait DatabaseMigrationStepApplier<T>: Send + Sync {
 /// rendered query string for that step.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct PrettyDatabaseMigrationStep {
+    /// The serialized database migration step.
     pub step: serde_json::Value,
+    /// The raw query string.
     pub raw: String,
 }

--- a/migration-engine/connectors/migration-connector/src/destructive_change_checker.rs
+++ b/migration-engine/connectors/migration-connector/src/destructive_change_checker.rs
@@ -24,22 +24,28 @@ where
 /// The errors and warnings emitted by the [DestructiveChangeChecker](trait.DestructiveChangeChecker.html).
 #[derive(Debug, Default)]
 pub struct DestructiveChangeDiagnostics {
+    /// Soon to be deleted.
     pub errors: Vec<MigrationError>,
+    /// The warnings.
     pub warnings: Vec<MigrationWarning>,
+    /// Steps that are not executable.
     pub unexecutable_migrations: Vec<UnexecutableMigration>,
 }
 
 impl DestructiveChangeDiagnostics {
+    /// Equivalent to Default::default()
     pub fn new() -> DestructiveChangeDiagnostics {
         Default::default()
     }
 
+    /// Add a warning to the diagnostics.
     pub fn add_warning<T: Into<Option<MigrationWarning>>>(&mut self, warning: T) {
         if let Some(warning) = warning.into() {
             self.warnings.push(warning)
         }
     }
 
+    /// Is there any warning to be rendered?
     pub fn has_warnings(&self) -> bool {
         !self.warnings.is_empty()
     }
@@ -49,6 +55,7 @@ impl DestructiveChangeDiagnostics {
 /// prevent a migration from being applied, unless the `force` flag is passed.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct MigrationWarning {
+    /// The user-facing warning description.
     pub description: String,
 }
 
@@ -56,13 +63,14 @@ pub struct MigrationWarning {
 /// always prevent a migration from being applied.
 #[derive(Debug, Serialize, PartialEq, Deserialize)]
 pub struct MigrationError {
-    pub tpe: String,
+    /// The user-facing error description.
     pub description: String,
-    pub field: Option<String>,
 }
 
+/// An unexecutable migration step detected by the DestructiveChangeChecker.
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct UnexecutableMigration {
+    /// The user-facing problem description.
     pub description: String,
 }
 

--- a/migration-engine/connectors/migration-connector/src/lib.rs
+++ b/migration-engine/connectors/migration-connector/src/lib.rs
@@ -1,15 +1,18 @@
-#![deny(rust_2018_idioms)]
-#![deny(unsafe_code)]
+#![deny(rust_2018_idioms, unsafe_code, missing_docs)]
 
 //! This crate defines the API exposed by the connectors to the migration engine core. The entry point for this API is the [MigrationConnector](trait.MigrationConnector.html) trait.
 
 mod database_migration_inferrer;
 mod database_migration_step_applier;
 mod destructive_change_checker;
+#[allow(missing_docs)]
 mod error;
+#[allow(missing_docs)]
 mod migration_applier;
+#[allow(missing_docs)]
 mod migration_persistence;
 
+#[allow(missing_docs)]
 pub mod steps;
 
 pub use database_migration_inferrer::*;
@@ -70,6 +73,7 @@ pub trait MigrationConnector: Send + Sync + 'static {
 
     // TODO: figure out if this is the best way to do this or move to a better place/interface
     // this is placed here so i can use the associated type
+    /// Deprecated
     fn deserialize_database_migration(&self, json: serde_json::Value) -> Option<Self::DatabaseMigration>;
 
     /// See [MigrationStepApplier](trait.MigrationStepApplier.html).
@@ -82,7 +86,9 @@ pub trait MigrationConnector: Send + Sync + 'static {
     }
 }
 
+/// Marker for the associated migration type for a connector.
 pub trait DatabaseMigrationMarker: Debug + Send + Sync {
+    /// Render the migration as JSON.
     fn serialize(&self) -> serde_json::Value;
 }
 

--- a/migration-engine/connectors/sql-migration-connector/src/database_info.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/database_info.rs
@@ -85,8 +85,6 @@ fn check_datamodel_for_mysql_5_6(datamodel: &Datamodel, errors: &mut Vec<Migrati
                     field.model().name(),
                     field.name()
                 ),
-                field: None,
-                tpe: "".into(),
             })
         }
     });


### PR DESCRIPTION
migration-connector's purpose is to be a public interface, it should be documented.