### PR TITLE
Remove TypeHint

### DIFF
--- a/libs/datamodel/core/src/json/dmmf/to_dmmf.rs
+++ b/libs/datamodel/core/src/json/dmmf/to_dmmf.rs
@@ -141,7 +141,7 @@ fn prisma_value_to_serde(value: &PrismaValue) -> serde_json::Value {
         }
         PrismaValue::Int(val) => serde_json::Value::Number(serde_json::Number::from_f64(*val as f64).unwrap()),
         PrismaValue::DateTime(val) => serde_json::Value::String(val.to_rfc3339()),
-        PrismaValue::Null(_) => serde_json::Value::Null,
+        PrismaValue::Null => serde_json::Value::Null,
         PrismaValue::Uuid(val) => serde_json::Value::String(val.to_string()),
         PrismaValue::Json(val) => serde_json::Value::String(val.to_string()),
         PrismaValue::List(value_vec) => {

--- a/libs/datamodel/core/src/transform/directives/default.rs
+++ b/libs/datamodel/core/src/transform/directives/default.rs
@@ -81,7 +81,7 @@ pub fn lower_prisma_value(pv: &PrismaValue) -> ast::Expression {
         PrismaValue::DateTime(value) => ast::Expression::StringValue(value.to_rfc3339(), ast::Span::empty()),
         PrismaValue::Float(value) => ast::Expression::NumericValue(value.to_string(), ast::Span::empty()),
         PrismaValue::Int(value) => ast::Expression::NumericValue(value.to_string(), ast::Span::empty()),
-        PrismaValue::Null(_) => ast::Expression::ConstantValue("null".to_string(), ast::Span::empty()),
+        PrismaValue::Null => ast::Expression::ConstantValue("null".to_string(), ast::Span::empty()),
         PrismaValue::Uuid(val) => ast::Expression::StringValue(val.to_string(), ast::Span::empty()),
         PrismaValue::Json(val) => ast::Expression::StringValue(val.to_string(), ast::Span::empty()),
         PrismaValue::List(vec) => ast::Expression::Array(

--- a/libs/prisma-models/src/field.rs
+++ b/libs/prisma-models/src/field.rs
@@ -6,7 +6,6 @@ pub use scalar::*;
 
 use crate::prelude::*;
 use datamodel::ScalarType;
-use prisma_value::TypeHint;
 use std::{hash::Hash, sync::Arc};
 
 #[derive(Debug)]
@@ -67,21 +66,6 @@ pub enum TypeIdentifier {
     DateTime,
     UUID,
     Int,
-}
-
-impl From<TypeIdentifier> for TypeHint {
-    fn from(typ: TypeIdentifier) -> Self {
-        match typ {
-            TypeIdentifier::String => TypeHint::String,
-            TypeIdentifier::Float => TypeHint::Float,
-            TypeIdentifier::Boolean => TypeHint::Boolean,
-            TypeIdentifier::Enum(_) => TypeHint::Enum,
-            TypeIdentifier::Json => TypeHint::Json,
-            TypeIdentifier::DateTime => TypeHint::DateTime,
-            TypeIdentifier::UUID => TypeHint::UUID,
-            TypeIdentifier::Int => TypeHint::Int,
-        }
-    }
 }
 
 impl Field {

--- a/libs/prisma-models/src/prisma_value_ext.rs
+++ b/libs/prisma-models/src/prisma_value_ext.rs
@@ -13,7 +13,7 @@ impl PrismaValueExtensions for PrismaValue {
     fn coerce(self, to_type: &TypeIdentifier) -> crate::Result<PrismaValue> {
         let coerced = match (self, to_type) {
             // Trivial cases
-            (PrismaValue::Null(_), identifier) => PrismaValue::null(identifier.clone()),
+            (PrismaValue::Null, _) => PrismaValue::Null,
             (val @ PrismaValue::String(_), TypeIdentifier::String) => val,
             (val @ PrismaValue::Int(_), TypeIdentifier::Int) => val,
             (val @ PrismaValue::Float(_), TypeIdentifier::Float) => val,

--- a/libs/prisma-models/src/projections/model_projection.rs
+++ b/libs/prisma-models/src/projections/model_projection.rs
@@ -117,7 +117,7 @@ impl ModelProjection {
     /// Creates a record projection of the model projection containing only null values.
     pub fn empty_record_projection(&self) -> RecordProjection {
         self.scalar_fields()
-            .map(|f| (f.clone(), PrismaValue::null(f.type_identifier.clone())))
+            .map(|f| (f.clone(), PrismaValue::Null))
             .collect::<Vec<_>>()
             .into()
     }

--- a/libs/prisma-models/src/sql_ext.rs
+++ b/libs/prisma-models/src/sql_ext.rs
@@ -1,9 +1,11 @@
 mod column;
 mod record;
 mod relation;
+mod scalar_field;
 mod table;
 
 pub use column::*;
 pub use record::*;
 pub use relation::*;
+pub use scalar_field::*;
 pub use table::*;

--- a/libs/prisma-models/src/sql_ext/column.rs
+++ b/libs/prisma-models/src/sql_ext/column.rs
@@ -1,4 +1,4 @@
-use crate::{Field, ModelProjection, RelationField, RelationLinkManifestation, ScalarField};
+use crate::{Field, ModelProjection, RelationField, RelationLinkManifestation, ScalarField, ScalarFieldExt};
 use itertools::Itertools;
 use quaint::ast::{Column, Row};
 use std::convert::AsRef;
@@ -156,7 +156,7 @@ where
         let column = Column::from(((db, table), col));
 
         match sf.default_value.as_ref().and_then(|d| d.get()) {
-            Some(default) => column.default(default),
+            Some(default) => column.default(sf.value(default)),
             None => column.default(quaint::ast::DefaultValue::Generated),
         }
     }

--- a/libs/prisma-models/src/sql_ext/record.rs
+++ b/libs/prisma-models/src/sql_ext/record.rs
@@ -1,5 +1,5 @@
-use crate::{error::DomainError, ModelProjection, RecordProjection};
-use quaint::connector::ResultSet;
+use crate::{error::DomainError, ModelProjection, RecordProjection, ScalarFieldExt};
+use quaint::{connector::ResultSet, Value};
 use std::convert::TryFrom;
 
 impl TryFrom<(&ModelProjection, ResultSet)> for RecordProjection {
@@ -37,5 +37,15 @@ impl TryFrom<(&ModelProjection, ResultSet)> for RecordProjection {
                 "RecordProjection".to_owned(),
             ))
         }
+    }
+}
+
+pub trait RecordProjectionExt {
+    fn db_values<'a>(&self) -> Vec<Value<'a>>;
+}
+
+impl RecordProjectionExt for RecordProjection {
+    fn db_values<'a>(&self) -> Vec<Value<'a>> {
+        self.pairs.iter().map(|(f, v)| f.value(v.clone())).collect()
     }
 }

--- a/libs/prisma-models/src/sql_ext/scalar_field.rs
+++ b/libs/prisma-models/src/sql_ext/scalar_field.rs
@@ -47,6 +47,6 @@ pub fn convert_lossy<'a>(pv: PrismaValue) -> Value<'a> {
         PrismaValue::Uuid(u) => u.to_string().into(),
         PrismaValue::List(l) => Value::Array(Some(l.into_iter().map(|x| convert_lossy(x)).collect())),
         PrismaValue::Json(s) => Value::Json(serde_json::from_str(&s).unwrap()),
-        PrismaValue::Null => Value::Char(None), // Can't tell which type the null is supposed to be.
+        PrismaValue::Null => Value::Integer(None), // Can't tell which type the null is supposed to be.
     }
 }

--- a/libs/prisma-models/src/sql_ext/scalar_field.rs
+++ b/libs/prisma-models/src/sql_ext/scalar_field.rs
@@ -1,0 +1,35 @@
+use prisma_value::PrismaValue;
+use quaint::ast::Value;
+
+use crate::{ScalarField, TypeIdentifier};
+
+pub trait ScalarFieldExt {
+    fn value<'a>(&self, pv: PrismaValue) -> Value<'a>;
+}
+
+impl ScalarFieldExt for ScalarField {
+    fn value<'a>(&self, pv: PrismaValue) -> Value<'a> {
+        match (pv, &self.type_identifier) {
+            (PrismaValue::String(s), _) => s.into(),
+            (PrismaValue::Float(f), _) => f.into(),
+            (PrismaValue::Boolean(b), _) => b.into(),
+            (PrismaValue::DateTime(d), _) => d.into(),
+            (PrismaValue::Enum(e), _) => e.into(),
+            (PrismaValue::Int(i), _) => (i as i64).into(),
+            (PrismaValue::Uuid(u), _) => u.to_string().into(),
+            (PrismaValue::List(l), _) => Value::Array(Some(l.into_iter().map(|x| self.value(x)).collect())),
+            (PrismaValue::Json(s), _) => Value::Json(serde_json::from_str(&s).unwrap()),
+            (PrismaValue::Null, ident) => match ident {
+                _ if self.is_list => Value::Array(None),
+                TypeIdentifier::String => Value::Text(None),
+                TypeIdentifier::Float => Value::Real(None),
+                TypeIdentifier::Boolean => Value::Boolean(None),
+                TypeIdentifier::Enum(_) => Value::Enum(None),
+                TypeIdentifier::Json => Value::Json(None),
+                TypeIdentifier::DateTime => Value::DateTime(None),
+                TypeIdentifier::UUID => Value::Uuid(None),
+                TypeIdentifier::Int => Value::Integer(None),
+            },
+        }
+    }
+}

--- a/libs/prisma-value/src/arithmetic.rs
+++ b/libs/prisma-value/src/arithmetic.rs
@@ -10,7 +10,7 @@ macro_rules! number_operation {
 
       fn $fname(self, rhs: Self) -> Self::Output {
         match (self, rhs) {
-          (PrismaValue::Null(_), _) | (_, PrismaValue::Null(_)) => PrismaValue::Null(TypeHint::Unknown),
+          (PrismaValue::Null, _) | (_, PrismaValue::Null) => PrismaValue::Null,
 
           (PrismaValue::Int(l), PrismaValue::Int(r)) => PrismaValue::Int(l $op r),
           (PrismaValue::Int(l), PrismaValue::Float(r)) => {

--- a/libs/prisma-value/src/sql_ext.rs
+++ b/libs/prisma-value/src/sql_ext.rs
@@ -1,89 +1,81 @@
-use crate::{PrismaValue, TypeHint};
+use crate::PrismaValue;
 use chrono::{DateTime, NaiveDate, Utc};
 use quaint::ast::Value;
 
 impl<'a> From<Value<'a>> for PrismaValue {
     fn from(pv: Value<'a>) -> Self {
         match pv {
-            Value::Integer(i) => i
-                .map(|i| PrismaValue::Int(i))
-                .unwrap_or(PrismaValue::null(TypeHint::Int)),
+            Value::Integer(i) => i.map(|i| PrismaValue::Int(i)).unwrap_or(PrismaValue::Null),
             Value::Real(d) => d
                 // chop the trailing zeroes off so javascript doesn't start rounding things wrong
                 .map(|d| PrismaValue::Float(d.normalize()))
-                .unwrap_or(PrismaValue::null(TypeHint::Float)),
+                .unwrap_or(PrismaValue::Null),
             Value::Text(s) => s
                 .map(|s| PrismaValue::String(s.into_owned()))
-                .unwrap_or(PrismaValue::null(TypeHint::String)),
+                .unwrap_or(PrismaValue::Null),
             Value::Enum(s) => s
                 .map(|s| PrismaValue::Enum(s.into_owned()))
-                .unwrap_or(PrismaValue::null(TypeHint::Enum)),
-            Value::Boolean(b) => b
-                .map(|b| PrismaValue::Boolean(b))
-                .unwrap_or(PrismaValue::null(TypeHint::Boolean)),
+                .unwrap_or(PrismaValue::Null),
+            Value::Boolean(b) => b.map(|b| PrismaValue::Boolean(b)).unwrap_or(PrismaValue::Null),
             Value::Array(v) => v
                 .map(|v| PrismaValue::List(v.into_iter().map(PrismaValue::from).collect()))
-                .unwrap_or(PrismaValue::null(TypeHint::Array)),
+                .unwrap_or(PrismaValue::Null),
             Value::Json(val) => val
                 .map(|val| PrismaValue::Json(val.to_string()))
-                .unwrap_or(PrismaValue::null(TypeHint::Json)),
-            Value::Uuid(uuid) => uuid
-                .map(|uuid| PrismaValue::Uuid(uuid))
-                .unwrap_or(PrismaValue::null(TypeHint::UUID)),
+                .unwrap_or(PrismaValue::Null),
+            Value::Uuid(uuid) => uuid.map(|uuid| PrismaValue::Uuid(uuid)).unwrap_or(PrismaValue::Null),
             Value::Date(d) => d
                 .map(|d| {
                     let dt = DateTime::<Utc>::from_utc(d.and_hms(0, 0, 0), Utc);
                     PrismaValue::DateTime(dt)
                 })
-                .unwrap_or(PrismaValue::null(TypeHint::DateTime)),
+                .unwrap_or(PrismaValue::Null),
             Value::Time(t) => t
                 .map(|t| {
                     let d = NaiveDate::from_ymd(1970, 1, 1);
                     let dt = DateTime::<Utc>::from_utc(d.and_time(t), Utc);
                     PrismaValue::DateTime(dt)
                 })
-                .unwrap_or(PrismaValue::null(TypeHint::DateTime)),
-            Value::DateTime(dt) => dt
-                .map(|dt| PrismaValue::DateTime(dt))
-                .unwrap_or(PrismaValue::null(TypeHint::DateTime)),
+                .unwrap_or(PrismaValue::Null),
+            Value::DateTime(dt) => dt.map(|dt| PrismaValue::DateTime(dt)).unwrap_or(PrismaValue::Null),
             Value::Char(c) => c
                 .map(|c| PrismaValue::String(c.to_string()))
-                .unwrap_or(PrismaValue::null(TypeHint::Char)),
+                .unwrap_or(PrismaValue::Null),
             Value::Bytes(bytes) => bytes
                 .map(|bytes| {
                     let s = String::from_utf8(bytes.into_owned()).expect("PrismaValue::String from Value::Bytes");
                     PrismaValue::String(s)
                 })
-                .unwrap_or(PrismaValue::null(TypeHint::Bytes)),
+                .unwrap_or(PrismaValue::Null),
         }
     }
 }
 
-impl<'a> From<PrismaValue> for Value<'a> {
-    fn from(pv: PrismaValue) -> Self {
-        match pv {
-            PrismaValue::String(s) => s.into(),
-            PrismaValue::Float(f) => f.into(),
-            PrismaValue::Boolean(b) => b.into(),
-            PrismaValue::DateTime(d) => d.into(),
-            PrismaValue::Enum(e) => e.into(),
-            PrismaValue::Int(i) => (i as i64).into(),
-            PrismaValue::Uuid(u) => u.to_string().into(),
-            PrismaValue::List(l) => Value::Array(Some(l.into_iter().map(|x| x.into()).collect())),
-            PrismaValue::Json(s) => Value::Json(serde_json::from_str(&s).unwrap()),
-            PrismaValue::Null(ident) => match ident {
-                TypeHint::String => Value::Text(None),
-                TypeHint::Float => Value::Real(None),
-                TypeHint::Boolean => Value::Boolean(None),
-                TypeHint::Enum => Value::Enum(None),
-                TypeHint::Json => Value::Json(None),
-                TypeHint::DateTime => Value::DateTime(None),
-                TypeHint::UUID => Value::Uuid(None),
-                TypeHint::Int => Value::Integer(None),
-                TypeHint::Array => Value::Array(None),
-                TypeHint::Char | TypeHint::Unknown => Value::Char(None),
-                TypeHint::Bytes => Value::Bytes(None),
-            },
-        }
-    }
-}
+// impl<'a> From<PrismaValue> for Value<'a> {
+//     fn from(pv: PrismaValue) -> Self {
+//         match pv {
+//             PrismaValue::String(s) => s.into(),
+//             PrismaValue::Float(f) => f.into(),
+//             PrismaValue::Boolean(b) => b.into(),
+//             PrismaValue::DateTime(d) => d.into(),
+//             PrismaValue::Enum(e) => e.into(),
+//             PrismaValue::Int(i) => (i as i64).into(),
+//             PrismaValue::Uuid(u) => u.to_string().into(),
+//             PrismaValue::List(l) => Value::Array(Some(l.into_iter().map(|x| x.into()).collect())),
+//             PrismaValue::Json(s) => Value::Json(serde_json::from_str(&s).unwrap()),
+//             PrismaValue::Null {
+//                 TypeHint::String => Value::Text(None),
+//                 TypeHint::Float => Value::Real(None),
+//                 TypeHint::Boolean => Value::Boolean(None),
+//                 TypeHint::Enum => Value::Enum(None),
+//                 TypeHint::Json => Value::Json(None),
+//                 TypeHint::DateTime => Value::DateTime(None),
+//                 TypeHint::UUID => Value::Uuid(None),
+//                 TypeHint::Int => Value::Integer(None),
+//                 TypeHint::Array => Value::Array(None),
+//                 TypeHint::Char | TypeHint::Unknown => Value::Char(None),
+//                 TypeHint::Bytes => Value::Bytes(None),
+//             },
+//         }
+//     }
+// }

--- a/libs/prisma-value/src/sql_ext.rs
+++ b/libs/prisma-value/src/sql_ext.rs
@@ -50,32 +50,3 @@ impl<'a> From<Value<'a>> for PrismaValue {
         }
     }
 }
-
-// impl<'a> From<PrismaValue> for Value<'a> {
-//     fn from(pv: PrismaValue) -> Self {
-//         match pv {
-//             PrismaValue::String(s) => s.into(),
-//             PrismaValue::Float(f) => f.into(),
-//             PrismaValue::Boolean(b) => b.into(),
-//             PrismaValue::DateTime(d) => d.into(),
-//             PrismaValue::Enum(e) => e.into(),
-//             PrismaValue::Int(i) => (i as i64).into(),
-//             PrismaValue::Uuid(u) => u.to_string().into(),
-//             PrismaValue::List(l) => Value::Array(Some(l.into_iter().map(|x| x.into()).collect())),
-//             PrismaValue::Json(s) => Value::Json(serde_json::from_str(&s).unwrap()),
-//             PrismaValue::Null {
-//                 TypeHint::String => Value::Text(None),
-//                 TypeHint::Float => Value::Real(None),
-//                 TypeHint::Boolean => Value::Boolean(None),
-//                 TypeHint::Enum => Value::Enum(None),
-//                 TypeHint::Json => Value::Json(None),
-//                 TypeHint::DateTime => Value::DateTime(None),
-//                 TypeHint::UUID => Value::Uuid(None),
-//                 TypeHint::Int => Value::Integer(None),
-//                 TypeHint::Array => Value::Array(None),
-//                 TypeHint::Char | TypeHint::Unknown => Value::Char(None),
-//                 TypeHint::Bytes => Value::Bytes(None),
-//             },
-//         }
-//     }
-// }

--- a/migration-engine/migration-engine-tests/tests/existing_data/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_data/mod.rs
@@ -2,7 +2,7 @@ mod sql_unexecutable_migrations;
 
 use migration_engine_tests::sql::*;
 use pretty_assertions::assert_eq;
-use prisma_value::{PrismaValue, TypeHint};
+use prisma_value::PrismaValue;
 use quaint::ast::*;
 use sql_schema_describer::DefaultValue;
 
@@ -210,17 +210,14 @@ async fn column_defaults_can_safely_be_changed(api: &TestApi) -> TestResult {
                     row.get("name").map(|val| {
                         val.to_string()
                             .map(|val| PrismaValue::String(val))
-                            .unwrap_or(PrismaValue::Null(TypeHint::String))
+                            .unwrap_or(PrismaValue::Null)
                     })
                 })
                 .collect();
 
             assert_eq!(
                 &[
-                    first_default
-                        .as_ref()
-                        .cloned()
-                        .unwrap_or(PrismaValue::Null(TypeHint::String)),
+                    first_default.as_ref().cloned().unwrap_or(PrismaValue::Null),
                     PrismaValue::String("Waterworld".to_string())
                 ],
                 names.as_slice()
@@ -255,16 +252,13 @@ async fn column_defaults_can_safely_be_changed(api: &TestApi) -> TestResult {
                     row.get("name").map(|val| {
                         val.to_string()
                             .map(|val| PrismaValue::String(val))
-                            .unwrap_or(PrismaValue::Null(TypeHint::String))
+                            .unwrap_or(PrismaValue::Null)
                     })
                 })
                 .collect();
             assert_eq!(
                 &[
-                    first_default
-                        .as_ref()
-                        .cloned()
-                        .unwrap_or(PrismaValue::Null(TypeHint::String)),
+                    first_default.as_ref().cloned().unwrap_or(PrismaValue::Null),
                     PrismaValue::String("Waterworld".to_string())
                 ],
                 names.as_slice()

--- a/query-engine/connectors/query-connector/src/write_args.rs
+++ b/query-engine/connectors/query-connector/src/write_args.rs
@@ -191,10 +191,10 @@ impl WriteArgs {
                         let p: Option<PrismaValue> = val.clone().try_into().ok();
                         match p {
                             Some(p) => p,
-                            None => PrismaValue::null(field.type_identifier.clone()),
+                            None => PrismaValue::Null,
                         }
                     }
-                    None => PrismaValue::null(field.type_identifier.clone()),
+                    None => PrismaValue::Null,
                 };
 
                 (field.clone(), val.clone())

--- a/query-engine/connectors/sql-query-connector/src/cursor_condition.rs
+++ b/query-engine/connectors/sql-query-connector/src/cursor_condition.rs
@@ -67,7 +67,7 @@ pub fn build(query_arguments: &QueryArguments, model: &ModelRef) -> (Option<Tabl
         None => (None, ConditionTree::NoCondition),
         Some(ref cursor) => {
             let cursor_fields: Vec<_> = cursor.fields().collect();
-            let cursor_values: Vec<_> = cursor.values().collect();
+            let cursor_values: Vec<_> = cursor.pairs.iter().map(|(f, v)| f.value(v.clone())).collect();
             let cursor_columns: Vec<_> = cursor_fields.as_slice().as_columns().collect();
             let cursor_row = Row::from(cursor_columns);
 

--- a/query-engine/connectors/sql-query-connector/src/filter_conversion.rs
+++ b/query-engine/connectors/sql-query-connector/src/filter_conversion.rs
@@ -141,15 +141,16 @@ impl AliasedCondition for ScalarFilter {
                     QueryMode::Insensitive => lower(field.as_column().table(alias.to_string(None))).into(),
                 };
 
-                convert_scalar_filter(comparable, self.condition, self.mode)
+                convert_scalar_filter(comparable, self.condition, self.mode, &[field])
             }
             (Some(alias), ScalarProjection::Compound(fields)) => {
                 let columns: Vec<Column<'static>> = fields
+                    .clone()
                     .into_iter()
                     .map(|field| field.as_column().table(alias.to_string(None)))
                     .collect();
 
-                convert_scalar_filter(Row::from(columns), self.condition, self.mode)
+                convert_scalar_filter(Row::from(columns), self.condition, self.mode, &fields)
             }
             (None, ScalarProjection::Single(field)) => {
                 let comparable: Expression = match self.mode {
@@ -157,12 +158,12 @@ impl AliasedCondition for ScalarFilter {
                     QueryMode::Insensitive => lower(field.as_column()).into(),
                 };
 
-                convert_scalar_filter(comparable, self.condition, self.mode)
+                convert_scalar_filter(comparable, self.condition, self.mode, &[field])
             }
             (None, ScalarProjection::Compound(fields)) => {
-                let columns: Vec<Column<'static>> = fields.into_iter().map(|field| field.as_column()).collect();
+                let columns: Vec<Column<'static>> = fields.clone().into_iter().map(|field| field.as_column()).collect();
 
-                convert_scalar_filter(Row::from(columns), self.condition, self.mode)
+                convert_scalar_filter(Row::from(columns), self.condition, self.mode, &fields)
             }
         }
     }
@@ -298,84 +299,95 @@ fn convert_scalar_filter(
     comparable: impl Comparable<'static>,
     cond: ScalarCondition,
     mode: QueryMode,
+    fields: &[ScalarFieldRef],
 ) -> ConditionTree<'static> {
     match mode {
-        QueryMode::Default => default_scalar_filter(comparable, cond),
-        QueryMode::Insensitive => insensitive_scalar_filter(comparable, cond),
+        QueryMode::Default => default_scalar_filter(comparable, cond, fields),
+        QueryMode::Insensitive => insensitive_scalar_filter(comparable, cond, fields),
     }
 }
 
-fn default_scalar_filter(comparable: impl Comparable<'static>, cond: ScalarCondition) -> ConditionTree<'static> {
+fn default_scalar_filter(
+    comparable: impl Comparable<'static>,
+    cond: ScalarCondition,
+    fields: &[ScalarFieldRef],
+) -> ConditionTree<'static> {
     let condition = match cond {
         ScalarCondition::Equals(PrismaValue::Null) => comparable.is_null(),
         ScalarCondition::NotEquals(PrismaValue::Null) => comparable.is_not_null(),
-        ScalarCondition::Equals(value) => comparable.equals(value),
-        ScalarCondition::NotEquals(value) => comparable.not_equals(value),
+        ScalarCondition::Equals(value) => comparable.equals(convert_value(fields, value)),
+        ScalarCondition::NotEquals(value) => comparable.not_equals(convert_value(fields, value)),
         ScalarCondition::Contains(value) => comparable.like(format!("{}", value)),
         ScalarCondition::NotContains(value) => comparable.not_like(format!("{}", value)),
         ScalarCondition::StartsWith(value) => comparable.begins_with(format!("{}", value)),
         ScalarCondition::NotStartsWith(value) => comparable.not_begins_with(format!("{}", value)),
         ScalarCondition::EndsWith(value) => comparable.ends_into(format!("{}", value)),
         ScalarCondition::NotEndsWith(value) => comparable.not_ends_into(format!("{}", value)),
-        ScalarCondition::LessThan(value) => comparable.less_than(value),
-        ScalarCondition::LessThanOrEquals(value) => comparable.less_than_or_equals(value),
-        ScalarCondition::GreaterThan(value) => comparable.greater_than(value),
-        ScalarCondition::GreaterThanOrEquals(value) => comparable.greater_than_or_equals(value),
+        ScalarCondition::LessThan(value) => comparable.less_than(convert_value(fields, value)),
+        ScalarCondition::LessThanOrEquals(value) => comparable.less_than_or_equals(convert_value(fields, value)),
+        ScalarCondition::GreaterThan(value) => comparable.greater_than(convert_value(fields, value)),
+        ScalarCondition::GreaterThanOrEquals(value) => comparable.greater_than_or_equals(convert_value(fields, value)),
         ScalarCondition::In(values) => match values.split_first() {
             Some((PrismaValue::List(_), _)) => {
                 let mut sql_values = Values::with_capacity(values.len());
 
                 for pv in values {
-                    let list_value = pv.into_list().unwrap();
+                    let list_value = convert_values(fields, pv.into_list().unwrap());
                     sql_values.push(list_value);
                 }
 
                 comparable.in_selection(sql_values)
             }
-            _ => comparable.in_selection(values),
+            _ => comparable.in_selection(convert_values(fields, values)),
         },
         ScalarCondition::NotIn(values) => match values.split_first() {
             Some((PrismaValue::List(_), _)) => {
                 let mut sql_values = Values::with_capacity(values.len());
 
                 for pv in values {
-                    let list_value = pv.into_list().unwrap();
+                    let list_value = convert_values(fields, pv.into_list().unwrap());
                     sql_values.push(list_value);
                 }
 
                 comparable.not_in_selection(sql_values)
             }
-            _ => comparable.not_in_selection(values),
+            _ => comparable.not_in_selection(convert_values(fields, values)),
         },
     };
 
     ConditionTree::single(condition)
 }
 
-fn insensitive_scalar_filter(comparable: impl Comparable<'static>, cond: ScalarCondition) -> ConditionTree<'static> {
+fn insensitive_scalar_filter(
+    comparable: impl Comparable<'static>,
+    cond: ScalarCondition,
+    fields: &[ScalarFieldRef],
+) -> ConditionTree<'static> {
     // Current workaround: We assume we can use ILIKE when we see `mode: insensitive`, because postgres is the only DB that has
     // insensitive. We need a connector context for filter building that is unexpectedly complicated to integrate.
     let condition = match cond {
         ScalarCondition::Equals(PrismaValue::Null) => comparable.is_null(),
         ScalarCondition::NotEquals(PrismaValue::Null) => comparable.is_not_null(),
-        ScalarCondition::Equals(value) => comparable.equals(lower(value)),
-        ScalarCondition::NotEquals(value) => comparable.not_equals(value),
+        ScalarCondition::Equals(value) => comparable.equals(lower(convert_value(fields, value))),
+        ScalarCondition::NotEquals(value) => comparable.not_equals(convert_value(fields, value)),
         ScalarCondition::Contains(value) => comparable.compare_raw("ILIKE", format!("%{}%", value)),
         ScalarCondition::NotContains(value) => comparable.compare_raw("NOT ILIKE", format!("%{}%", value)),
         ScalarCondition::StartsWith(value) => comparable.compare_raw("ILIKE", format!("{}%", value)),
         ScalarCondition::NotStartsWith(value) => comparable.compare_raw("NOT ILIKE", format!("{}%", value)),
         ScalarCondition::EndsWith(value) => comparable.compare_raw("ILIKE", format!("%{}", value)),
         ScalarCondition::NotEndsWith(value) => comparable.compare_raw("NOT ILIKE", format!("%{}", value)),
-        ScalarCondition::LessThan(value) => comparable.less_than(lower(value)),
-        ScalarCondition::LessThanOrEquals(value) => comparable.less_than_or_equals(lower(value)),
-        ScalarCondition::GreaterThan(value) => comparable.greater_than(lower(value)),
-        ScalarCondition::GreaterThanOrEquals(value) => comparable.greater_than_or_equals(lower(value)),
+        ScalarCondition::LessThan(value) => comparable.less_than(lower(convert_value(fields, value))),
+        ScalarCondition::LessThanOrEquals(value) => comparable.less_than_or_equals(lower(convert_value(fields, value))),
+        ScalarCondition::GreaterThan(value) => comparable.greater_than(lower(convert_value(fields, value))),
+        ScalarCondition::GreaterThanOrEquals(value) => {
+            comparable.greater_than_or_equals(lower(convert_value(fields, value)))
+        }
         ScalarCondition::In(values) => match values.split_first() {
             Some((PrismaValue::List(_), _)) => {
                 let mut sql_values = Values::with_capacity(values.len());
 
                 for pv in values {
-                    let list_value = pv.into_list().unwrap();
+                    let list_value = convert_values(fields, pv.into_list().unwrap());
                     sql_values.push(list_value);
                 }
 
@@ -385,7 +397,7 @@ fn insensitive_scalar_filter(comparable: impl Comparable<'static>, cond: ScalarC
                 values
                     .into_iter()
                     .map(|v| {
-                        let val: Expression = lower(v).into();
+                        let val: Expression = lower(convert_value(fields, v)).into();
                         val
                     })
                     .collect::<Vec<_>>(),
@@ -396,7 +408,7 @@ fn insensitive_scalar_filter(comparable: impl Comparable<'static>, cond: ScalarC
                 let mut sql_values = Values::with_capacity(values.len());
 
                 for pv in values {
-                    let list_value = pv.into_list().unwrap();
+                    let list_value = convert_values(fields, pv.into_list().unwrap());
                     sql_values.push(list_value);
                 }
 
@@ -406,7 +418,7 @@ fn insensitive_scalar_filter(comparable: impl Comparable<'static>, cond: ScalarC
                 values
                     .into_iter()
                     .map(|v| {
-                        let val: Expression = lower(v).into();
+                        let val: Expression = lower(convert_value(fields, v)).into();
                         val
                     })
                     .collect::<Vec<_>>(),
@@ -415,4 +427,16 @@ fn insensitive_scalar_filter(comparable: impl Comparable<'static>, cond: ScalarC
     };
 
     ConditionTree::single(condition)
+}
+
+fn convert_value<'a>(fields: &[ScalarFieldRef], value: PrismaValue) -> Value<'a> {
+    fields.first().unwrap().value(value)
+}
+
+fn convert_values<'a>(fields: &[ScalarFieldRef], values: Vec<PrismaValue>) -> Vec<Value<'a>> {
+    fields
+        .into_iter()
+        .zip(values)
+        .map(|(field, value)| field.value(value))
+        .collect()
 }

--- a/query-engine/connectors/sql-query-connector/src/filter_conversion.rs
+++ b/query-engine/connectors/sql-query-connector/src/filter_conversion.rs
@@ -307,8 +307,8 @@ fn convert_scalar_filter(
 
 fn default_scalar_filter(comparable: impl Comparable<'static>, cond: ScalarCondition) -> ConditionTree<'static> {
     let condition = match cond {
-        ScalarCondition::Equals(PrismaValue::Null(_)) => comparable.is_null(),
-        ScalarCondition::NotEquals(PrismaValue::Null(_)) => comparable.is_not_null(),
+        ScalarCondition::Equals(PrismaValue::Null) => comparable.is_null(),
+        ScalarCondition::NotEquals(PrismaValue::Null) => comparable.is_not_null(),
         ScalarCondition::Equals(value) => comparable.equals(value),
         ScalarCondition::NotEquals(value) => comparable.not_equals(value),
         ScalarCondition::Contains(value) => comparable.like(format!("{}", value)),
@@ -356,8 +356,8 @@ fn insensitive_scalar_filter(comparable: impl Comparable<'static>, cond: ScalarC
     // Current workaround: We assume we can use ILIKE when we see `mode: insensitive`, because postgres is the only DB that has
     // insensitive. We need a connector context for filter building that is unexpectedly complicated to integrate.
     let condition = match cond {
-        ScalarCondition::Equals(PrismaValue::Null(_)) => comparable.is_null(),
-        ScalarCondition::NotEquals(PrismaValue::Null(_)) => comparable.is_not_null(),
+        ScalarCondition::Equals(PrismaValue::Null) => comparable.is_null(),
+        ScalarCondition::NotEquals(PrismaValue::Null) => comparable.is_not_null(),
         ScalarCondition::Equals(value) => comparable.equals(lower(value)),
         ScalarCondition::NotEquals(value) => comparable.not_equals(value),
         ScalarCondition::Contains(value) => comparable.compare_raw("ILIKE", format!("%{}%", value)),

--- a/query-engine/connectors/sql-query-connector/src/filter_conversion.rs
+++ b/query-engine/connectors/sql-query-connector/src/filter_conversion.rs
@@ -434,9 +434,14 @@ fn convert_value<'a>(fields: &[ScalarFieldRef], value: PrismaValue) -> Value<'a>
 }
 
 fn convert_values<'a>(fields: &[ScalarFieldRef], values: Vec<PrismaValue>) -> Vec<Value<'a>> {
-    fields
-        .into_iter()
-        .zip(values)
-        .map(|(field, value)| field.value(value))
-        .collect()
+    if fields.len() == values.len() {
+        fields
+            .into_iter()
+            .zip(values)
+            .map(|(field, value)| field.value(value))
+            .collect()
+    } else {
+        let field = fields.first().unwrap();
+        values.into_iter().map(|value| field.value(value)).collect()
+    }
 }

--- a/query-engine/connectors/sql-query-connector/src/query_builder/mod.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_builder/mod.rs
@@ -4,7 +4,7 @@ pub mod write;
 pub use read::*;
 pub use write::*;
 
-use prisma_models::RecordProjection;
+use prisma_models::{RecordProjection, RecordProjectionExt};
 use quaint::ast::{Column, Comparable, ConditionTree, Query, Row, Values};
 
 const PARAMETER_LIMIT: usize = 10000;
@@ -34,7 +34,7 @@ pub(super) fn conditions<'a>(
     let mut values = Values::empty();
 
     for proj in records.into_iter() {
-        let vals: Vec<_> = proj.values().collect();
+        let vals: Vec<_> = proj.db_values();
         values.push(vals)
     }
 

--- a/query-engine/connectors/sql-query-connector/src/query_builder/write.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_builder/write.rs
@@ -12,14 +12,7 @@ pub fn create_record(model: &ModelRef, mut args: WriteArgs) -> (Insert<'static>,
         .fields()
         .scalar()
         .into_iter()
-        .filter(|field| {
-            args.has_arg_for(&field.db_name())
-            // if  {
-            //     Some(db_name)
-            // } else {
-            //     None
-            // }
-        })
+        .filter(|field| args.has_arg_for(&field.db_name()))
         .collect();
 
     let insert = fields

--- a/query-engine/connectors/sql-query-connector/src/query_builder/write.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_builder/write.rs
@@ -10,25 +10,28 @@ pub fn create_record(model: &ModelRef, mut args: WriteArgs) -> (Insert<'static>,
 
     let fields: Vec<_> = model
         .fields()
-        .db_names()
-        .filter_map(|db_name| {
-            if args.has_arg_for(&db_name) {
-                Some(db_name)
-            } else {
-                None
-            }
+        .scalar()
+        .into_iter()
+        .filter(|field| {
+            args.has_arg_for(&field.db_name())
+            // if  {
+            //     Some(db_name)
+            // } else {
+            //     None
+            // }
         })
         .collect();
 
     let insert = fields
         .into_iter()
-        .fold(Insert::single_into(model.as_table()), |insert, db_name| {
-            let value = args.take_field_value(&db_name).unwrap();
+        .fold(Insert::single_into(model.as_table()), |insert, field| {
+            let db_name = field.db_name();
+            let value = args.take_field_value(db_name).unwrap();
             let value: PrismaValue = value
                 .try_into()
                 .expect("Create calls can only use PrismaValue write expressions (right now).");
 
-            insert.value(db_name, value)
+            insert.value(db_name.to_owned(), field.value(value))
         });
 
     (
@@ -42,33 +45,39 @@ pub fn update_many(model: &ModelRef, ids: &[&RecordProjection], args: WriteArgs)
         return Ok(Vec::new());
     }
 
+    let scalar_fields = model.fields().scalar();
+
     let query = args
         .args
         .into_iter()
         .fold(Update::table(model.as_table()), |acc, (field_name, val)| {
             let DatasourceFieldName(name) = field_name;
+            let field = scalar_fields
+                .iter()
+                .find(|f| f.db_name() == &name)
+                .expect("Expected field to be valid");
 
             let value: Expression = match val {
                 WriteExpression::Field(_) => unimplemented!(),
-                WriteExpression::Value(rhs) => rhs.into(),
+                WriteExpression::Value(rhs) => field.value(rhs).into(),
                 WriteExpression::Add(rhs) => {
                     let e: Expression<'_> = Column::from(name.clone()).into();
-                    e + rhs.into()
+                    e + field.value(rhs).into()
                 }
 
                 WriteExpression::Substract(rhs) => {
                     let e: Expression<'_> = Column::from(name.clone()).into();
-                    e - rhs.into()
+                    e - field.value(rhs).into()
                 }
 
                 WriteExpression::Multiply(rhs) => {
                     let e: Expression<'_> = Column::from(name.clone()).into();
-                    e * rhs.into()
+                    e * field.value(rhs).into()
                 }
 
                 WriteExpression::Divide(rhs) => {
                     let e: Expression<'_> = Column::from(name.clone()).into();
-                    e / rhs.into()
+                    e / field.value(rhs).into()
                 }
             };
 
@@ -104,7 +113,9 @@ pub fn create_relation_table_records(
     let insert: MultiRowInsert = child_ids
         .into_iter()
         .fold(insert, |insert, child_id| {
-            let values: Vec<_> = parent_id.values().chain(child_id.values()).collect();
+            let mut values: Vec<_> = parent_id.db_values();
+
+            values.extend(child_id.db_values());
             insert.values(values)
         })
         .into();
@@ -131,11 +142,11 @@ pub fn delete_relation_table_records(
         .map(|name| Column::from(name))
         .collect();
 
-    let parent_id: Vec<PrismaValue> = parent_id.values().collect();
+    let parent_id_values = parent_id.db_values();
     let parent_id_criteria = if parent_columns.len() > 1 {
-        Row::from(parent_columns).equals(parent_id)
+        Row::from(parent_columns).equals(parent_id_values)
     } else {
-        parent_columns.pop().unwrap().equals(parent_id)
+        parent_columns.pop().unwrap().equals(parent_id_values)
     };
 
     let child_id_criteria = super::conditions(&child_columns, child_ids);

--- a/query-engine/connectors/sql-query-connector/src/query_ext.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_ext.rs
@@ -39,7 +39,7 @@ pub trait QueryExt: Queryable + Send + Sync {
         q: String,
         params: Vec<PrismaValue>,
     ) -> std::result::Result<Value, crate::error::RawError> {
-        let params: Vec<_> = params.into_iter().map(quaint::ast::Value::from).collect();
+        let params: Vec<_> = params.into_iter().map(convert_lossy).collect();
         let result_set = AssertUnwindSafe(self.query_raw(&q, &params)).catch_unwind().await??;
 
         let columns: Vec<String> = result_set.columns().into_iter().map(ToString::to_string).collect();
@@ -66,7 +66,7 @@ pub trait QueryExt: Queryable + Send + Sync {
         q: String,
         params: Vec<PrismaValue>,
     ) -> std::result::Result<usize, crate::error::RawError> {
-        let params: Vec<_> = params.into_iter().map(quaint::ast::Value::from).collect();
+        let params: Vec<_> = params.into_iter().map(convert_lossy).collect();
         let changes = AssertUnwindSafe(self.execute_raw(&q, &params)).catch_unwind().await??;
 
         Ok(changes as usize)

--- a/query-engine/connectors/sql-query-connector/src/row.rs
+++ b/query-engine/connectors/sql-query-connector/src/row.rs
@@ -62,7 +62,7 @@ impl SqlRow {
 }
 
 fn coerce_null_to_zero_value(value: PrismaValue) -> PrismaValue {
-    if let PrismaValue::Null(_) = value {
+    if let PrismaValue::Null = value {
         PrismaValue::Int(0)
     } else {
         value
@@ -121,7 +121,7 @@ pub fn row_value_to_prisma_value(p_value: Value, type_identifier: &TypeIdentifie
     Ok(match type_identifier {
         TypeIdentifier::Boolean => match p_value {
             // Value::Array(vec) => PrismaValue::Boolean(b),
-            value if value.is_null() => PrismaValue::null(type_identifier.clone()),
+            value if value.is_null() => PrismaValue::Null,
             Value::Integer(Some(i)) => PrismaValue::Boolean(i != 0),
             Value::Boolean(Some(b)) => PrismaValue::Boolean(b),
             _ => {
@@ -130,7 +130,7 @@ pub fn row_value_to_prisma_value(p_value: Value, type_identifier: &TypeIdentifie
             }
         },
         TypeIdentifier::Enum(_) => match p_value {
-            value if value.is_null() => PrismaValue::null(type_identifier.clone()),
+            value if value.is_null() => PrismaValue::Null,
             Value::Enum(Some(cow)) => PrismaValue::Enum(cow.into_owned()),
             Value::Text(Some(cow)) => PrismaValue::Enum(cow.into_owned()),
             _ => {
@@ -140,7 +140,7 @@ pub fn row_value_to_prisma_value(p_value: Value, type_identifier: &TypeIdentifie
         },
 
         TypeIdentifier::Json => match p_value {
-            value if value.is_null() => PrismaValue::null(type_identifier.clone()),
+            value if value.is_null() => PrismaValue::Null,
             Value::Text(Some(json)) => PrismaValue::Json(json.into()),
             Value::Json(Some(json)) => PrismaValue::Json(json.to_string()),
             _ => {
@@ -149,7 +149,7 @@ pub fn row_value_to_prisma_value(p_value: Value, type_identifier: &TypeIdentifie
             }
         },
         TypeIdentifier::UUID => match p_value {
-            value if value.is_null() => PrismaValue::null(type_identifier.clone()),
+            value if value.is_null() => PrismaValue::Null,
             Value::Text(Some(uuid)) => PrismaValue::Uuid(Uuid::parse_str(&uuid)?),
             Value::Uuid(Some(uuid)) => PrismaValue::Uuid(uuid),
             _ => {
@@ -158,7 +158,7 @@ pub fn row_value_to_prisma_value(p_value: Value, type_identifier: &TypeIdentifie
             }
         },
         TypeIdentifier::DateTime => match p_value {
-            value if value.is_null() => PrismaValue::null(type_identifier.clone()),
+            value if value.is_null() => PrismaValue::Null,
             Value::DateTime(Some(dt)) => PrismaValue::DateTime(dt),
             Value::Integer(Some(ts)) => {
                 let nsecs = ((ts % 1000) * 1_000_000) as u32;
@@ -196,7 +196,7 @@ pub fn row_value_to_prisma_value(p_value: Value, type_identifier: &TypeIdentifie
             }
         },
         TypeIdentifier::Float => match p_value {
-            value if value.is_null() => PrismaValue::null(type_identifier.clone()),
+            value if value.is_null() => PrismaValue::Null,
             Value::Real(Some(f)) => PrismaValue::Float(f.normalize()),
             Value::Integer(Some(i)) => {
                 // Decimal::from_f64 is buggy. Issue: https://github.com/paupino/rust-decimal/issues/228
@@ -228,7 +228,7 @@ pub fn row_value_to_prisma_value(p_value: Value, type_identifier: &TypeIdentifie
             other => PrismaValue::from(other),
         },
         TypeIdentifier::String => match p_value {
-            value if value.is_null() => PrismaValue::null(type_identifier.clone()),
+            value if value.is_null() => PrismaValue::Null,
             Value::Uuid(Some(uuid)) => PrismaValue::String(uuid.to_string()),
             Value::Json(Some(json_value)) => {
                 PrismaValue::String(serde_json::to_string(&json_value).expect("JSON value to string"))

--- a/query-engine/core/src/query_document/parser.rs
+++ b/query-engine/core/src/query_document/parser.rs
@@ -2,7 +2,6 @@ use super::*;
 use crate::schema::*;
 use chrono::prelude::*;
 use indexmap::IndexMap;
-use prisma_models::TypeHint;
 use prisma_value::PrismaValue;
 use rust_decimal::{prelude::ToPrimitive, Decimal};
 use std::{borrow::Borrow, collections::HashSet, convert::TryFrom, sync::Arc};
@@ -153,7 +152,7 @@ impl QueryDocumentParser {
             let result = match (&value, input_type) {
                 // Null handling
                 (QueryValue::Null, InputType::Scalar(ScalarType::Null)) => {
-                    Ok(ParsedInputValue::Single(PrismaValue::null(TypeHint::Unknown)))
+                    Ok(ParsedInputValue::Single(PrismaValue::Null))
                 }
                 (QueryValue::Null, _) => Err(QueryParserError {
                     path: parent_path.clone(),

--- a/query-engine/core/src/query_document/query_value.rs
+++ b/query-engine/core/src/query_document/query_value.rs
@@ -52,7 +52,7 @@ impl From<PrismaValue> for QueryValue {
             PrismaValue::Enum(s) => Self::Enum(s),
             PrismaValue::List(l) => Self::List(l.into_iter().map(QueryValue::from).collect()),
             PrismaValue::Int(i) => Self::Int(i),
-            PrismaValue::Null(_) => Self::Null,
+            PrismaValue::Null => Self::Null,
             PrismaValue::Uuid(u) => Self::String(u.to_hyphenated().to_string()),
             PrismaValue::Json(s) => Self::String(s),
         }

--- a/query-engine/core/src/query_document/transformers.rs
+++ b/query-engine/core/src/query_document/transformers.rs
@@ -55,7 +55,7 @@ impl TryInto<Option<ParsedInputMap>> for ParsedInputValue {
 
     fn try_into(self) -> QueryParserResult<Option<ParsedInputMap>> {
         match self {
-            ParsedInputValue::Single(PrismaValue::Null(_)) => Ok(None),
+            ParsedInputValue::Single(PrismaValue::Null) => Ok(None),
             ParsedInputValue::Map(val) => Ok(Some(val)),
             v => Err(QueryParserError {
                 path: QueryPath::default(),
@@ -94,7 +94,7 @@ impl TryInto<Option<String>> for ParsedInputValue {
         match prisma_value {
             PrismaValue::String(s) => Ok(Some(s)),
             PrismaValue::Enum(s) => Ok(Some(s)),
-            PrismaValue::Null(_) => Ok(None),
+            PrismaValue::Null => Ok(None),
             v => Err(QueryParserError {
                 path: QueryPath::default(),
                 error_kind: QueryParserErrorKind::AssertionError(format!(
@@ -148,7 +148,7 @@ impl TryInto<Option<f64>> for ParsedInputValue {
 
         match prisma_value {
             PrismaValue::Float(d) => Ok(d.to_f64()),
-            PrismaValue::Null(_) => Ok(None),
+            PrismaValue::Null => Ok(None),
             v => Err(QueryParserError {
                 path: QueryPath::default(),
                 error_kind: QueryParserErrorKind::AssertionError(format!(
@@ -168,7 +168,7 @@ impl TryInto<Option<bool>> for ParsedInputValue {
 
         match prisma_value {
             PrismaValue::Boolean(b) => Ok(Some(b)),
-            PrismaValue::Null(_) => Ok(None),
+            PrismaValue::Null => Ok(None),
             v => Err(QueryParserError {
                 path: QueryPath::default(),
                 error_kind: QueryParserErrorKind::AssertionError(format!(
@@ -188,7 +188,7 @@ impl TryInto<Option<DateTime<Utc>>> for ParsedInputValue {
 
         match prisma_value {
             PrismaValue::DateTime(dt) => Ok(Some(dt)),
-            PrismaValue::Null(_) => Ok(None),
+            PrismaValue::Null => Ok(None),
             v => Err(QueryParserError {
                 path: QueryPath::default(),
                 error_kind: QueryParserErrorKind::AssertionError(format!(
@@ -208,7 +208,7 @@ impl TryInto<Option<i64>> for ParsedInputValue {
 
         match prisma_value {
             PrismaValue::Int(i) => Ok(Some(i)),
-            PrismaValue::Null(_) => Ok(None),
+            PrismaValue::Null => Ok(None),
             v => Err(QueryParserError {
                 path: QueryPath::default(),
                 error_kind: QueryParserErrorKind::AssertionError(format!(

--- a/query-engine/core/src/query_graph_builder/extractors/filters/mod.rs
+++ b/query-engine/core/src/query_graph_builder/extractors/filters/mod.rs
@@ -122,7 +122,7 @@ fn extract_scalar_filters(field: &ScalarFieldRef, value: ParsedInputValue) -> Qu
 fn extract_relation_filters(field: &RelationFieldRef, value: ParsedInputValue) -> QueryGraphBuilderResult<Vec<Filter>> {
     match value {
         // Implicit is null filter (`where: { <field>: null }`)
-        ParsedInputValue::Single(PrismaValue::Null(_)) => Ok(vec![field.one_relation_is_null()]),
+        ParsedInputValue::Single(PrismaValue::Null) => Ok(vec![field.one_relation_is_null()]),
 
         // Either implicit `is`, or complex filter.
         ParsedInputValue::Map(filter_map) => {

--- a/query-engine/core/src/query_graph_builder/extractors/filters/scalar.rs
+++ b/query-engine/core/src/query_graph_builder/extractors/filters/scalar.rs
@@ -30,10 +30,10 @@ pub fn parse(
         "in" => {
             let value: PrismaValue = input.try_into()?;
             match value {
-                PrismaValue::Null(_) if reverse => field.not_equals(value),
+                PrismaValue::Null if reverse => field.not_equals(value),
                 PrismaValue::List(values) if reverse => field.not_in(values),
 
-                PrismaValue::Null(_) => field.equals(value),
+                PrismaValue::Null => field.equals(value),
                 PrismaValue::List(values) => field.is_in(values),
 
                 _ => unreachable!(), // Validation guarantees this.
@@ -44,10 +44,10 @@ pub fn parse(
             // Legacy operation
             let value: PrismaValue = input.try_into()?;
             match value {
-                PrismaValue::Null(_) if reverse => field.equals(value), // not not in null => in null
+                PrismaValue::Null if reverse => field.equals(value), // not not in null => in null
                 PrismaValue::List(values) if reverse => field.is_in(values), // not not in values => in values
 
-                PrismaValue::Null(_) => field.not_equals(value),
+                PrismaValue::Null => field.not_equals(value),
                 PrismaValue::List(values) => field.not_in(values),
 
                 _ => unreachable!(), // Validation guarantees this.

--- a/query-engine/core/src/query_graph_builder/write/write_args_parser.rs
+++ b/query-engine/core/src/query_graph_builder/write/write_args_parser.rs
@@ -53,7 +53,7 @@ impl WriteArgsParser {
                     }
 
                     Field::Relation(ref rf) => match v {
-                        ParsedInputValue::Single(PrismaValue::Null(_)) => (),
+                        ParsedInputValue::Single(PrismaValue::Null) => (),
                         _ => args.nested.push((Arc::clone(rf), v.try_into()?)),
                     },
                 };

--- a/query-engine/core/src/response_ir/internal.rs
+++ b/query-engine/core/src/response_ir/internal.rs
@@ -137,7 +137,7 @@ fn serialize_record_selection(
                             if !opt {
                                 // Check that all items are non-null
                                 if items.iter().any(|item| match item {
-                                    Item::Value(PrismaValue::Null(_)) => true,
+                                    Item::Value(PrismaValue::Null) => true,
                                     _ => false,
                                 }) {
                                     return Err(CoreError::SerializationError(format!(
@@ -173,10 +173,7 @@ fn serialize_record_selection(
                                     )))
                                 }
                             } else if items.is_empty() && opt {
-                                Ok((
-                                    parent,
-                                    Item::Ref(ItemRef::new(Item::Value(PrismaValue::Null(TypeHint::Unknown)))),
-                                ))
+                                Ok((parent, Item::Ref(ItemRef::new(Item::Value(PrismaValue::Null)))))
                             } else if items.is_empty() && opt {
                                 Err(CoreError::SerializationError(format!(
                                     "Required field '{}' returned a null record",
@@ -289,7 +286,7 @@ fn write_nested_items(
                 let field = enclosing_type.find_field(field_name).unwrap();
                 let default = match field.field_type.borrow() {
                     OutputType::List(_) => Item::list(Vec::new()),
-                    _ if !field.is_required => Item::Value(PrismaValue::Null(TypeHint::Unknown)),
+                    _ if !field.is_required => Item::Value(PrismaValue::Null),
                     _ => panic!(
                         "Application logic invariant error: received null value for field {} which may not be null",
                         &field_name
@@ -329,7 +326,7 @@ fn process_nested_results(
 
 fn serialize_scalar(field: &OutputFieldRef, value: PrismaValue) -> crate::Result<Item> {
     match (&value, field.field_type.as_ref()) {
-        (PrismaValue::Null(_), _) if !field.is_required => Ok(Item::Value(PrismaValue::Null(TypeHint::Unknown))),
+        (PrismaValue::Null, _) if !field.is_required => Ok(Item::Value(PrismaValue::Null)),
         (_, OutputType::Enum(et)) => match et.borrow() {
             EnumType::Internal(ref i) => convert_enum(value, i),
             _ => unreachable!(),

--- a/query-engine/core/src/response_ir/ir_serializer.rs
+++ b/query-engine/core/src/response_ir/ir_serializer.rs
@@ -30,7 +30,7 @@ impl IrSerializer {
                 // Todo: The following checks feel out of place. This probably needs to be handled already one level deeper.
                 let result = if serialized.is_empty() {
                     if !self.output_field.is_required {
-                        Item::Value(PrismaValue::Null(TypeHint::Unknown))
+                        Item::Value(PrismaValue::Null)
                     } else {
                         match self.output_field.field_type.borrow() {
                             OutputType::List(_) => Item::list(Vec::new()),

--- a/query-engine/core/src/response_ir/mod.rs
+++ b/query-engine/core/src/response_ir/mod.rs
@@ -14,7 +14,7 @@ mod response;
 
 use crate::QueryValue;
 use indexmap::IndexMap;
-use prisma_models::{PrismaValue, TypeHint};
+use prisma_models::PrismaValue;
 use serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer};
 use std::{fmt, sync::Arc};
 
@@ -106,7 +106,7 @@ pub enum Item {
 
 impl Item {
     pub fn null() -> Self {
-        Self::Value(PrismaValue::Null(TypeHint::Unknown))
+        Self::Value(PrismaValue::Null)
     }
 
     pub fn list(inner: Vec<Item>) -> Self {

--- a/query-engine/core/src/schema/query_schema.rs
+++ b/query-engine/core/src/schema/query_schema.rs
@@ -407,7 +407,7 @@ pub enum InputType {
 impl PartialEq for InputType {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
-            (InputType::Scalar(_), InputType::Scalar(_)) => true,
+            (InputType::Scalar(st), InputType::Scalar(ost)) => st.eq(ost),
             (InputType::Enum(_), InputType::Enum(_)) => true,
             (InputType::List(lt), InputType::List(olt)) => lt.eq(olt),
             (InputType::Object(obj), InputType::Object(oobj)) => obj.into_arc().name == oobj.into_arc().name,

--- a/query-engine/core/src/schema/query_schema.rs
+++ b/query-engine/core/src/schema/query_schema.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::{ParsedField, QueryGraph, QueryGraphBuilderResult};
 use fmt::Debug;
 use once_cell::sync::OnceCell;
-use prisma_models::{dml, InternalDataModelRef, ModelRef, TypeHint};
+use prisma_models::{dml, InternalDataModelRef, ModelRef};
 use std::{
     borrow::Borrow,
     boxed::Box,
@@ -427,17 +427,6 @@ impl Debug for InputType {
     }
 }
 
-impl From<&InputType> for TypeHint {
-    fn from(i: &InputType) -> Self {
-        match i {
-            InputType::Scalar(st) => st.into(),
-            InputType::Enum(_) => TypeHint::Enum,
-            InputType::List(_) => TypeHint::Array,
-            InputType::Object(_) => TypeHint::Unknown,
-        }
-    }
-}
-
 impl InputType {
     pub fn list(containing: InputType) -> InputType {
         InputType::List(Box::new(containing))
@@ -571,23 +560,6 @@ pub enum ScalarType {
     Json,
     JsonList,
     UUID,
-}
-
-impl From<&ScalarType> for TypeHint {
-    fn from(t: &ScalarType) -> Self {
-        match t {
-            ScalarType::Null => TypeHint::Unknown, // [DTODO] Note for MSSQL and Julius: Collecting typehints this far up isn't feasible anymore.
-            ScalarType::String => TypeHint::String,
-            ScalarType::Int => TypeHint::Int,
-            ScalarType::Float => TypeHint::Float,
-            ScalarType::Boolean => TypeHint::Boolean,
-            ScalarType::Enum(_) => TypeHint::Enum,
-            ScalarType::DateTime => TypeHint::DateTime,
-            ScalarType::Json => TypeHint::Json,
-            ScalarType::JsonList => TypeHint::Json,
-            ScalarType::UUID => TypeHint::UUID,
-        }
-    }
 }
 
 impl From<EnumType> for OutputType {


### PR DESCRIPTION
Removes `TypeHint` concept from the engines. Type-specific translation (for null types) is now done as close to the connector as possible, fixing an abstraction leak to the parsing layers and simplifying code at the expense of slightly more complicated SQL connector value translation logic.