### PR TITLE
Drop superfluous arc-ing in sql-schema-describer

### DIFF
--- a/introspection-engine/connectors/sql-introspection-connector/src/schema_describer_loading.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/schema_describer_loading.rs
@@ -5,7 +5,6 @@ use quaint::{
     single::Quaint,
 };
 use sql_schema_describer::SqlSchemaDescriberBackend;
-use std::sync::Arc;
 use std::time::Duration;
 
 const CONNECTION_TIMEOUT: Duration = Duration::from_secs(10);
@@ -25,11 +24,9 @@ pub async fn load_describer(url: &str) -> Result<(Box<dyn SqlSchemaDescriberBack
     let connection_info = wrapper.connection_info().to_owned();
 
     let describer: Box<dyn SqlSchemaDescriberBackend> = match connection_info.sql_family() {
-        SqlFamily::Postgres => Box::new(sql_schema_describer::postgres::SqlSchemaDescriber::new(Arc::new(
-            wrapper,
-        ))),
-        SqlFamily::Mysql => Box::new(sql_schema_describer::mysql::SqlSchemaDescriber::new(Arc::new(wrapper))),
-        SqlFamily::Sqlite => Box::new(sql_schema_describer::sqlite::SqlSchemaDescriber::new(Arc::new(wrapper))),
+        SqlFamily::Postgres => Box::new(sql_schema_describer::postgres::SqlSchemaDescriber::new(wrapper)),
+        SqlFamily::Mysql => Box::new(sql_schema_describer::mysql::SqlSchemaDescriber::new(wrapper)),
+        SqlFamily::Sqlite => Box::new(sql_schema_describer::sqlite::SqlSchemaDescriber::new(wrapper)),
         SqlFamily::Mssql => todo!("Greetings from Redmond"),
     };
 

--- a/introspection-engine/connectors/sql-introspection-connector/tests/commenting_out/mod.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/tests/commenting_out/mod.rs
@@ -1,6 +1,7 @@
 use crate::*;
 use barrel::types;
 use pretty_assertions::assert_eq;
+use quaint::prelude::Queryable;
 use test_harness::*;
 
 #[test_each_connector(tags("sqlite"))]

--- a/introspection-engine/connectors/sql-introspection-connector/tests/db_specific_introspection/postgres/enums_postgres.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/tests/db_specific_introspection/postgres/enums_postgres.rs
@@ -1,5 +1,6 @@
 use crate::*;
 use barrel::types;
+use quaint::prelude::Queryable;
 use test_harness::*;
 
 #[test_each_connector(tags("postgres"))]

--- a/introspection-engine/connectors/sql-introspection-connector/tests/db_specific_introspection/postgres/relations_postgres.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/tests/db_specific_introspection/postgres/relations_postgres.rs
@@ -1,5 +1,6 @@
 use crate::*;
 use barrel::types;
+use quaint::prelude::Queryable;
 use test_harness::*;
 
 #[test_each_connector(tags("postgres"))]

--- a/introspection-engine/connectors/sql-introspection-connector/tests/db_specific_introspection/postgres/remapping_database_names_postgres.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/tests/db_specific_introspection/postgres/remapping_database_names_postgres.rs
@@ -1,5 +1,6 @@
 use crate::*;
 use barrel::types;
+use quaint::prelude::Queryable;
 use test_harness::*;
 
 #[test_each_connector(tags("postgres"))]
@@ -92,7 +93,7 @@ async fn remapping_fk_columns_with_invalid_characters_should_work(api: &TestApi)
                 id   Int    @default(autoincrement()) @id
                 User User[]
             }
-            
+
             model User {
                 id      Int  @default(autoincrement()) @id
                 post_id Int  @map("post id")
@@ -127,15 +128,15 @@ async fn remapping_models_in_relations_should_work(api: &TestApi) {
                 user_id         Int             @unique
                 User_with_Space User_with_Space @relation(fields: [user_id], references: [id])
             }
-            
+
             model User_with_Space {
                 id   Int    @default(autoincrement()) @id
                 name String
                 Post Post?
-                
+
                 @@map("User with Space")
             }
-            
+
         "#;
     let result = dbg!(api.introspect().await);
     custom_assert(&result, dm);
@@ -170,19 +171,19 @@ async fn remapping_models_in_compound_relations_should_work(api: &TestApi) {
                 user_id         Int
                 user_name       String
                 User_with_Space User_with_Space @relation(fields: [user_id, user_name], references: [id, name])
-                
+
                 @@unique([user_id, user_name], name: "post_user_unique")
             }
-            
+
             model User_with_Space {
                 id   Int    @default(autoincrement()) @id
                 name String
                 Post Post?
-                
+
                 @@map("User with Space")
                 @@unique([id, name], name: "user_unique")
             }
-            
+
         "#;
     let result = dbg!(api.introspect().await);
     custom_assert(&result, dm);
@@ -217,18 +218,18 @@ async fn remapping_fields_in_compound_relations_should_work(api: &TestApi) {
                 user_id   Int
                 user_name String
                 User      User   @relation(fields: [user_id, user_name], references: [id, name_that_is_invalid])
-                
+
                 @@unique([user_id, user_name], name: "post_user_unique")
             }
-            
+
             model User {
                 id                   Int    @default(autoincrement()) @id
                 name_that_is_invalid String @map("name-that-is-invalid")
                 Post                 Post?
-                
+
                 @@unique([id, name_that_is_invalid], name: "user_unique")
             }
-            
+
         "#;
     let result = dbg!(api.introspect().await);
     custom_assert(&result, dm);

--- a/introspection-engine/connectors/sql-introspection-connector/tests/db_specific_introspection/postgres/tables_postgres.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/tests/db_specific_introspection/postgres/tables_postgres.rs
@@ -1,6 +1,7 @@
 use crate::*;
 use barrel::types;
 use pretty_assertions::assert_eq;
+use quaint::prelude::Queryable;
 use test_harness::*;
 
 #[test_each_connector(tags("postgres"))]
@@ -54,7 +55,7 @@ async fn introspecting_a_table_with_json_type_must_work(api: &TestApi) {
                 provider = "postgres"
                 url = "postgresql://asdlj"
             }
-    
+
             model Blog {
                 id      Int @id @default(autoincrement())
                 json    Json
@@ -429,7 +430,7 @@ async fn introspecting_a_default_value_as_dbgenerated_should_work(api: &TestApi)
                 int_static              Int?        @default(2)
                 int_serial              Int        @default(autoincrement())
                 int_function            Int?        @default(dbgenerated())
-                int_sequence            Int?        @default(dbgenerated())    
+                int_sequence            Int?        @default(dbgenerated())
                 float_static            Float?      @default(1.43)
                 boolean_static          Boolean?    @default(true)
                 datetime_now_current    DateTime?   @default(now())
@@ -565,10 +566,10 @@ async fn introspecting_a_table_with_partial_indexes_should_ignore_them(api: &Tes
     let dm = r#"
             model pages {
               id       Int     @id
-              staticid Int     
+              staticid Int
               islatest Boolean
               other    Int     @unique
-            }      
+            }
         "#;
     let result = dbg!(api.introspect().await);
     custom_assert(&result, dm);

--- a/introspection-engine/connectors/sql-introspection-connector/tests/db_specific_introspection/sqlite/relations_sqlite.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/tests/db_specific_introspection/sqlite/relations_sqlite.rs
@@ -1,5 +1,6 @@
 use crate::*;
 use barrel::types;
+use quaint::prelude::Queryable;
 use test_harness::*;
 
 #[test_each_connector(tags("sqlite"))]
@@ -99,7 +100,7 @@ async fn introspecting_two_one_to_one_relations_between_the_same_models_should_w
                 Post_PostToUser_post_id Post  @relation("PostToUser_post_id", fields: [post_id], references: [id])
                 Post_Post_user_idToUser Post? @relation("Post_user_idToUser")
             }
-            
+
             model Post {
                 id                      Int   @default(autoincrement()) @id
                 user_id                 Int   @unique
@@ -134,7 +135,7 @@ async fn introspecting_a_one_to_one_relation_should_work(api: &TestApi) {
                 id   Int   @default(autoincrement()) @id
                 Post Post?
             }
-            
+
             model Post {
                 id      Int   @default(autoincrement()) @id
                 user_id Int?  @unique
@@ -169,7 +170,7 @@ async fn introspecting_a_one_to_one_relation_referencing_non_id_should_work(api:
                 email String? @unique
                 Post  Post?
             }
-            
+
             model Post {
                 id         Int     @default(autoincrement()) @id
                 user_email String? @unique
@@ -203,7 +204,7 @@ async fn introspecting_a_one_to_many_relation_should_work(api: &TestApi) {
                 id   Int    @default(autoincrement()) @id
                 Post Post[]
             }
-            
+
             model Post {
                 id      Int   @default(autoincrement()) @id
                 user_id Int?
@@ -237,7 +238,7 @@ async fn introspecting_a_one_req_to_many_relation_should_work(api: &TestApi) {
                 id   Int    @default(autoincrement()) @id
                 Post Post[]
             }
-                
+
             model Post {
                 id      Int  @default(autoincrement()) @id
                 user_id Int
@@ -423,12 +424,12 @@ async fn introspecting_a_many_to_many_relation_with_an_id_should_work(api: &Test
                 id           Int            @default(autoincrement()) @id
                 PostsToUsers PostsToUsers[]
             }
-            
+
             model Post {
                 id           Int            @default(autoincrement()) @id
                 PostsToUsers PostsToUsers[]
             }
-            
+
             model PostsToUsers {
                 id      Int    @default(autoincrement()) @id
                 user_id Int
@@ -436,7 +437,7 @@ async fn introspecting_a_many_to_many_relation_with_an_id_should_work(api: &Test
                 Post    Post   @relation(fields: [post_id], references: [id])
                 User    User   @relation(fields: [user_id], references: [id])
             }
-            
+
         "#;
     let result = dbg!(api.introspect().await);
     custom_assert(&result, dm);
@@ -526,12 +527,12 @@ async fn introspecting_id_fields_with_foreign_key_should_work(api: &TestApi) {
         })
         .await;
 
-    let dm = r#"    
+    let dm = r#"
             model User {
                 id   Int    @default(autoincrement()) @id
                 Post Post[]
             }
-            
+
             model Post {
                 test    String
                 user_id Int    @default(autoincrement()) @id

--- a/introspection-engine/connectors/sql-introspection-connector/tests/db_specific_introspection/sqlite/tables_sqlite.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/tests/db_specific_introspection/sqlite/tables_sqlite.rs
@@ -1,5 +1,6 @@
 use crate::*;
 use barrel::types;
+use quaint::prelude::Queryable;
 use test_harness::*;
 
 #[test_each_connector(tags("sqlite"))]
@@ -149,7 +150,7 @@ async fn introspecting_a_table_with_datetime_default_values_should_work(api: &Te
              id     Int       @id @default(autoincrement())
              name   String
              joined DateTime? @default(dbgenerated())
-           }        
+           }
        "#;
     let result = dbg!(api.introspect().await);
     custom_assert(&result, dm);
@@ -318,13 +319,13 @@ async fn introspecting_a_table_with_partial_indexes_should_ignore_them(api: &Tes
         .await;
 
     let partial = format!(
-        r#"CREATE UNIQUE INDEX "{}"."idx_pages_unique_staticId_partial"  on pages (staticId) WHERE isLatest = true;"#,
+        r#"CREATE UNIQUE INDEX "{}"."idx_pages_unique_staticId_partial" on pages (staticId) WHERE isLatest = true;"#,
         api.schema_name(),
     );
     api.database().raw_cmd(&partial).await.unwrap();
 
     let non_partial = format!(
-        r#"CREATE UNIQUE INDEX "{}"."idx_pages_unique_staticId_non_partial"  on pages (other);"#,
+        r#"CREATE UNIQUE INDEX "{}"."idx_pages_unique_staticId_non_partial" on pages (other);"#,
         api.schema_name(),
     );
     api.database().execute_raw(&non_partial, &[]).await.unwrap();
@@ -332,10 +333,10 @@ async fn introspecting_a_table_with_partial_indexes_should_ignore_them(api: &Tes
     let dm = r#"
             model Pages {
               id       Int     @id @default(autoincrement())
-              staticid Int     
+              staticid Int
               islatest Boolean
               other    Int     @unique
-            }      
+            }
         "#;
     let result = dbg!(api.introspect().await);
     custom_assert(&result, dm);

--- a/introspection-engine/connectors/sql-introspection-connector/tests/re_introspection/mod.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/tests/re_introspection/mod.rs
@@ -1,6 +1,7 @@
 use crate::*;
 use crate::{custom_assert, test_each_connector, TestApi};
 use barrel::types;
+use quaint::prelude::Queryable;
 use test_harness::*;
 
 #[test_each_connector(tags("postgres"))]
@@ -21,18 +22,18 @@ async fn re_introspecting_manually_overwritten_mapped_model_name(api: &TestApi) 
     let input_dm = r#"
             model Custom_User {
                id               Int         @id @default(autoincrement())
-               
+
                @@map(name: "_User")
             }
         "#;
 
-    let final_dm = r#"  
+    let final_dm = r#"
             model Custom_User {
-               id               Int         @id @default(autoincrement()) 
-               
+               id               Int         @id @default(autoincrement())
+
                @@map(name: "_User")
             }
-              
+
             model Unrelated {
                id               Int         @id @default(autoincrement())
             }
@@ -69,10 +70,10 @@ async fn re_introspecting_manually_overwritten_mapped_field_name(api: &TestApi) 
 
     let final_dm = r#"
             model User {
-               id               Int         @id @default(autoincrement()) 
+               id               Int         @id @default(autoincrement())
                custom_test      Int         @map("_test")
-            }  
-            
+            }
+
             model Unrelated {
                id               Int         @id @default(autoincrement())
             }
@@ -110,11 +111,11 @@ async fn re_introspecting_mapped_model_and_field_name(api: &TestApi) {
                c_user_id        Int         @map("user_id")
                Custom_User      Custom_User @relation(fields: [c_user_id], references: [c_id])
             }
-            
+
             model Custom_User {
                c_id             Int         @id @default(autoincrement()) @map("id")
                Post             Post[]
-               
+
                @@map(name: "User")
             }
         "#;
@@ -129,13 +130,13 @@ async fn re_introspecting_mapped_model_and_field_name(api: &TestApi) {
             model Custom_User {
                c_id             Int         @id @default(autoincrement()) @map("id")
                Post             Post[]
-               
+
                @@map(name: "User")
-            }  
-            
+            }
+
             model Unrelated {
                id               Int         @id @default(autoincrement())
-            }          
+            }
         "#;
     let result = dbg!(api.re_introspect(input_dm).await);
     custom_assert(&result, final_dm);
@@ -170,11 +171,11 @@ async fn re_introspecting_manually_mapped_model_and_field_name(api: &TestApi) {
                c_user_id        Int         @map("user_id")
                Custom_User      Custom_User @relation(fields: [c_user_id], references: [c_id])
             }
-            
+
             model Custom_User {
                c_id             Int         @id @default(autoincrement()) @map("_id")
                Post             Post[]
-               
+
                @@map(name: "_User")
             }
         "#;
@@ -185,14 +186,14 @@ async fn re_introspecting_manually_mapped_model_and_field_name(api: &TestApi) {
                c_user_id        Int         @map("user_id")
                Custom_User      Custom_User @relation(fields: [c_user_id], references: [c_id])
             }
-            
+
             model Custom_User {
                c_id             Int         @id @default(autoincrement()) @map("_id")
                Post             Post[]
-               
+
                @@map(name: "_User")
-            }  
-                        
+            }
+
             model Unrelated {
                id               Int         @id @default(autoincrement())
             }
@@ -234,13 +235,13 @@ async fn re_introspecting_mapped_field_name(api: &TestApi) {
         .unwrap();
 
     let input_dm = r#"
-            model User { 
+            model User {
                 c_id_1      Int     @map("id_1")
                 id_2        Int
                 c_index     Int     @map("index")
-                c_unique_1  Int     @map("unique_1") 
+                c_unique_1  Int     @map("unique_1")
                 unique_2    Int
-                    
+
                 @@id([c_id_1, id_2])
                 @@index([c_index], name: "test2")
                 @@unique([c_unique_1, unique_2], name: "User_unique_1_unique_2_key")
@@ -248,18 +249,18 @@ async fn re_introspecting_mapped_field_name(api: &TestApi) {
         "#;
 
     let final_dm = r#"
-            model User { 
+            model User {
                 c_id_1      Int     @map("id_1")
                 id_2        Int
                 c_index     Int     @map("index")
-                c_unique_1  Int     @map("unique_1") 
+                c_unique_1  Int     @map("unique_1")
                 unique_2    Int
-                    
+
                 @@id([c_id_1, id_2])
                 @@index([c_index], name: "test2")
                 @@unique([c_unique_1, unique_2], name: "User_unique_1_unique_2_key")
             }
-            
+
             model Unrelated {
                id               Int @id @default(autoincrement())
             }
@@ -293,13 +294,13 @@ async fn re_introspecting_mapped_enum_name(api: &TestApi) {
     let input_dm = r#"
             model User {
                id               Int @id @default(autoincrement())
-               color            BlackNWhite            
+               color            BlackNWhite
             }
-            
+
             enum BlackNWhite{
                 black
                 white
-                
+
                 @@map("color")
             }
         "#;
@@ -307,17 +308,17 @@ async fn re_introspecting_mapped_enum_name(api: &TestApi) {
     let final_dm = r#"
              model User {
                id               Int @id @default(autoincrement())
-               color            BlackNWhite            
+               color            BlackNWhite
             }
-            
+
             model Unrelated {
                id               Int @id @default(autoincrement())
             }
-            
+
             enum BlackNWhite{
                 black
                 white
-                
+
                 @@map("color")
             }
         "#;
@@ -349,9 +350,9 @@ async fn re_introspecting_mapped_enum_value_name(api: &TestApi) {
     let input_dm = r#"
             model User {
                id               Int @id @default(autoincrement())
-               color            color @default(BLACK)            
+               color            color @default(BLACK)
             }
-            
+
             enum color{
                 BLACK @map("black")
                 white
@@ -361,9 +362,9 @@ async fn re_introspecting_mapped_enum_value_name(api: &TestApi) {
     let final_dm = r#"
              model User {
                id               Int @id @default(autoincrement())
-               color            color @default(BLACK)            
+               color            color @default(BLACK)
             }
-            
+
             model Unrelated {
                id               Int @id @default(autoincrement())
             }
@@ -401,9 +402,9 @@ async fn re_introspecting_manually_remapped_enum_value_name(api: &TestApi) {
     let input_dm = r#"
             model User {
                id               Int @id @default(autoincrement())
-               color            color @default(BLACK)            
+               color            color @default(BLACK)
             }
-            
+
             enum color{
                 BLACK @map("_black")
                 white
@@ -413,13 +414,13 @@ async fn re_introspecting_manually_remapped_enum_value_name(api: &TestApi) {
     let final_dm = r#"
              model User {
                id               Int @id @default(autoincrement())
-               color            color @default(BLACK)            
+               color            color @default(BLACK)
             }
-            
+
             model Unrelated {
                id               Int @id @default(autoincrement())
             }
-            
+
             enum color{
                 BLACK @map("_black")
                 white
@@ -453,31 +454,31 @@ async fn re_introspecting_manually_re_mapped_enum_name(api: &TestApi) {
     let input_dm = r#"
             model User {
                id               Int @id @default(autoincrement())
-               color            BlackNWhite            
+               color            BlackNWhite
             }
-            
+
             enum BlackNWhite{
                 black
                 white
-                
+
                 @@map("_color")
             }
         "#;
 
-    let final_dm = r#" 
+    let final_dm = r#"
              model User {
                id               Int @id @default(autoincrement())
-               color            BlackNWhite            
+               color            BlackNWhite
             }
-            
+
             model Unrelated {
                id               Int @id @default(autoincrement())
             }
-            
+
             enum BlackNWhite{
                 black
                 white
-                
+
                 @@map("_color")
             }
         "#;
@@ -509,25 +510,25 @@ async fn re_introspecting_manually_re_mapped_invalid_enum_values(api: &TestApi) 
     let input_dm = r#"
             model User {
                id               Int @id @default(autoincrement())
-               sign             invalid           
+               sign             invalid
             }
-            
+
             enum invalid{
                 dash    @map("-")
                 at      @map("@")
             }
         "#;
 
-    let final_dm = r#" 
+    let final_dm = r#"
               model User {
                id               Int @id @default(autoincrement())
-               sign             invalid           
+               sign             invalid
             }
-            
+
             model Unrelated {
                id               Int @id @default(autoincrement())
             }
-            
+
             enum invalid{
                 dash    @map("-")
                 at      @map("@")
@@ -565,7 +566,7 @@ async fn re_introspecting_multiple_changed_relation_names(api: &TestApi) {
                   A                                             Schedule[]  @relation("EmployeeToSchedule_eveningEmployeeId")
                   Schedule_EmployeeToSchedule_morningEmployeeId Schedule[]  @relation("EmployeeToSchedule_morningEmployeeId")
             }
-            
+
             model Schedule {
                   id                                            Int         @default(autoincrement()) @id
                   morningEmployeeId                             Int
@@ -581,7 +582,7 @@ async fn re_introspecting_multiple_changed_relation_names(api: &TestApi) {
                   A                                             Schedule[]  @relation("EmployeeToSchedule_eveningEmployeeId")
                   Schedule_EmployeeToSchedule_morningEmployeeId Schedule[]  @relation("EmployeeToSchedule_morningEmployeeId")
             }
-            
+
             model Schedule {
                   id                                            Int         @default(autoincrement()) @id
                   morningEmployeeId                             Int
@@ -635,16 +636,16 @@ async fn re_introspecting_custom_virtual_relation_field_names(api: &TestApi) {
                user_id          Int  @unique
                custom_User      User @relation(fields: [user_id], references: [id])
             }
- 
+
             model User {
                id               Int @id @default(autoincrement())
                custom_Post      Post?
             }
-            
+
             model Unrelated {
                id               Int @id @default(autoincrement())
             }
-           
+
         "#;
     let result = dbg!(api.re_introspect(input_dm).await);
     custom_assert(&result, final_dm);
@@ -683,27 +684,27 @@ async fn re_introspecting_custom_model_order(api: &TestApi) {
             model B {
                id               Int @id @default(autoincrement())
             }
-             
+
             model A {
                id               Int @id @default(autoincrement())
             }
-            
+
             model F {
                id               Int @id @default(autoincrement())
             }
-             
+
             model C {
                id               Int @id @default(autoincrement())
             }
-            
+
             model J {
                id               Int @id @default(autoincrement())
             }
-             
+
             model Z {
                id               Int @id @default(autoincrement())
             }
-            
+
             model K {
                id               Int @id @default(autoincrement())
             }
@@ -713,27 +714,27 @@ async fn re_introspecting_custom_model_order(api: &TestApi) {
             model B {
                id               Int @id @default(autoincrement())
             }
-             
+
             model A {
                id               Int @id @default(autoincrement())
             }
-            
+
             model F {
                id               Int @id @default(autoincrement())
             }
-             
+
             model J {
                id               Int @id @default(autoincrement())
             }
-            
+
             model Z {
                id               Int @id @default(autoincrement())
             }
-             
+
             model L {
                id               Int @id @default(autoincrement())
             }
-            
+
             model M {
                id               Int @id @default(autoincrement())
             }
@@ -769,27 +770,27 @@ async fn re_introspecting_custom_enum_order(api: &TestApi) {
             enum b {
                id
             }
-             
+
             enum a {
                id
             }
-            
+
             enum f {
                id
             }
-             
+
             enum c {
                id
             }
-            
+
             enum j {
                id
             }
-             
+
             enum z {
                id
             }
-            
+
             enum k {
                id
             }
@@ -799,27 +800,27 @@ async fn re_introspecting_custom_enum_order(api: &TestApi) {
             enum b {
                id
             }
-             
+
             enum a {
                id
             }
-            
+
             enum f {
                id
             }
-             
+
             enum j {
                id
             }
-            
+
             enum z {
                id
             }
-             
+
             enum l {
                id
             }
-            
+
             enum m {
                id
             }
@@ -860,7 +861,7 @@ async fn re_introspecting_multiple_changed_relation_names_due_to_mapped_models(a
                id               Int @id @default(autoincrement())
                custom_Post      Post? @relation("CustomRelationName")
                custom_Post2     Post? @relation("AnotherCustomRelationName")
-               
+
                @@map("User")
             }
         "#;
@@ -878,14 +879,14 @@ async fn re_introspecting_multiple_changed_relation_names_due_to_mapped_models(a
                id               Int @id @default(autoincrement())
                custom_Post      Post? @relation("CustomRelationName")
                custom_Post2     Post? @relation("AnotherCustomRelationName")
-               
+
                @@map("User")
             }
-            
+
             model Unrelated {
                id               Int @id @default(autoincrement())
             }
-           
+
         "#;
     let result = dbg!(api.re_introspect(input_dm).await);
     custom_assert(&result, final_dm);
@@ -916,7 +917,7 @@ async fn re_introspecting_virtual_cuid_default(api: &TestApi) {
                id        String    @id @default(cuid())
                non_id    String    @default(cuid())
             }
-            
+
             model User2 {
                id        String    @id @default(uuid())
             }
@@ -927,11 +928,11 @@ async fn re_introspecting_virtual_cuid_default(api: &TestApi) {
                id        String    @id @default(cuid())
                non_id    String    @default(cuid())
             }
-            
+
             model User2 {
                id        String    @id @default(uuid())
             }
-            
+
             model Unrelated {
                id               Int @id @default(autoincrement())
             }
@@ -968,17 +969,17 @@ async fn re_introspecting_comments(api: &TestApi) {
                /// A really helpful comment about the field
                id        String    @id @default(cuid())
             }
-            
+
             model User2 {
                id        String    @id @default(uuid())
             }
-            
+
             /// A really helpful comment about the enum
             enum a{
                /// A really helpful comment about the enum value
                A
             }
-            
+
             /// just floating around here
         "#;
 
@@ -988,22 +989,22 @@ async fn re_introspecting_comments(api: &TestApi) {
                /// A really helpful comment about the field
                id        String    @id @default(cuid())
             }
-            
+
             model User2 {
                id        String    @id @default(uuid())
             }
-            
+
             model Unrelated {
                id               Int @id @default(autoincrement())
             }
-            
+
             /// A really helpful comment about the enum
             enum a{
                /// A really helpful comment about the enum value
                A
             }
-            
-            /// just floating around here       
+
+            /// just floating around here
         "#;
     let result = dbg!(api.re_introspect(input_dm).await);
     custom_assert(&result, final_dm);
@@ -1037,7 +1038,7 @@ async fn re_introspecting_updated_at(api: &TestApi) {
                id           String    @id
                lastupdated  DateTime? @updatedAt
             }
-            
+
             model Unrelated {
                id               Int @id @default(autoincrement())
             }
@@ -1117,7 +1118,7 @@ async fn re_introspecting_multiple_many_to_many_on_same_model(api: &TestApi) {
                 custom_A        A[]
                 special_A       A[] @relation("AToB2")
               }
-                    
+
               model A {
                 id              Int @default(autoincrement()) @id
                 custom_B        B[]
@@ -1131,13 +1132,13 @@ async fn re_introspecting_multiple_many_to_many_on_same_model(api: &TestApi) {
                 custom_A        A[]
                 special_A       A[] @relation("AToB2")
               }
-                    
+
               model A {
                 id              Int @default(autoincrement()) @id
                 custom_B        B[]
                 special_B       B[] @relation("AToB2")
               }
-                          
+
               model Unrelated {
                 id Int @default(autoincrement()) @id
               }

--- a/introspection-engine/connectors/sql-introspection-connector/tests/test_harness/misc_helpers.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/tests/test_harness/misc_helpers.rs
@@ -1,7 +1,6 @@
 use barrel::Migration;
 use pretty_assertions::assert_eq;
-use quaint::connector::Queryable;
-use std::sync::Arc;
+use quaint::{connector::Queryable, single::Quaint};
 
 pub(crate) fn custom_assert(left: &str, right: &str) {
     let parsed_expected = datamodel::parse_datamodel(&right).unwrap();
@@ -21,7 +20,7 @@ pub(crate) fn assert_eq_json(a: &str, b: &str) {
 // barrel
 
 pub struct BarrelMigrationExecutor {
-    pub(super) database: Arc<dyn Queryable + Send + Sync>,
+    pub(super) database: Quaint,
     pub(super) sql_variant: barrel::backend::SqlVariant,
     pub(super) schema_name: String,
 }
@@ -45,7 +44,7 @@ impl BarrelMigrationExecutor {
     }
 }
 
-async fn run_full_sql(database: &Arc<dyn Queryable + Send + Sync>, full_sql: &str) {
+async fn run_full_sql(database: &Quaint, full_sql: &str) {
     for sql in full_sql.split(";") {
         if sql != "" {
             database.query_raw(&sql, &[]).await.unwrap();

--- a/introspection-engine/connectors/sql-introspection-connector/tests/test_harness/test_api.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/tests/test_harness/test_api.rs
@@ -2,12 +2,11 @@ use super::misc_helpers::*;
 use datamodel::Datamodel;
 use introspection_connector::{DatabaseMetadata, IntrospectionConnector, Version};
 use quaint::{
-    prelude::{ConnectionInfo, Queryable, SqlFamily},
+    prelude::{ConnectionInfo, SqlFamily},
     single::Quaint,
 };
 use sql_introspection_connector::SqlIntrospectionConnector;
 use sql_schema_describer::{SqlSchema, SqlSchemaDescriberBackend};
-use std::sync::Arc;
 use test_setup::*;
 
 pub type TestResult = Result<(), anyhow::Error>;
@@ -16,7 +15,7 @@ pub struct TestApi {
     db_name: &'static str,
     connection_info: quaint::prelude::ConnectionInfo,
     sql_family: SqlFamily,
-    database: Arc<dyn Queryable + Send + Sync + 'static>,
+    database: Quaint,
     introspection_connector: SqlIntrospectionConnector,
 }
 
@@ -25,7 +24,7 @@ impl TestApi {
         self.introspection_connector.list_databases().await.unwrap()
     }
 
-    pub fn database(&self) -> &Arc<dyn Queryable + Send + Sync + 'static> {
+    pub fn database(&self) -> &Quaint {
         &self.database
     }
 
@@ -33,14 +32,14 @@ impl TestApi {
         match &self.connection_info {
             ConnectionInfo::Mssql(_) => todo!("implement MSSQL"),
             ConnectionInfo::Postgres(url) => {
-                let sql_schema = sql_schema_describer::postgres::SqlSchemaDescriber::new(Arc::clone(&self.database))
+                let sql_schema = sql_schema_describer::postgres::SqlSchemaDescriber::new(self.database.clone())
                     .describe(url.schema())
                     .await?;
 
                 Ok(sql_schema)
             }
             ConnectionInfo::Mysql(_url) => {
-                let sql_schema = sql_schema_describer::mysql::SqlSchemaDescriber::new(Arc::clone(&self.database))
+                let sql_schema = sql_schema_describer::mysql::SqlSchemaDescriber::new(self.database.clone())
                     .describe(self.connection_info.schema_name())
                     .await?;
 
@@ -50,7 +49,7 @@ impl TestApi {
                 file_path: _,
                 db_name: _,
             } => {
-                let sql_schema = sql_schema_describer::sqlite::SqlSchemaDescriber::new(Arc::clone(&self.database))
+                let sql_schema = sql_schema_describer::sqlite::SqlSchemaDescriber::new(self.database.clone())
                     .describe(self.connection_info.schema_name())
                     .await?;
 
@@ -121,7 +120,7 @@ impl TestApi {
     pub fn barrel(&self) -> BarrelMigrationExecutor {
         BarrelMigrationExecutor {
             schema_name: self.schema_name().to_owned(),
-            database: Arc::clone(&self.database),
+            database: self.database.clone(),
             sql_variant: match self.sql_family {
                 SqlFamily::Mysql => barrel::SqlVariant::Mysql,
                 SqlFamily::Postgres => barrel::SqlVariant::Pg,
@@ -145,7 +144,7 @@ pub async fn mysql_test_api(db_name: &'static str) -> TestApi {
     TestApi {
         connection_info: conn.connection_info().to_owned(),
         db_name,
-        database: Arc::new(conn),
+        database: conn,
         sql_family: SqlFamily::Mysql,
         introspection_connector,
     }
@@ -161,7 +160,7 @@ pub async fn mysql_8_test_api(db_name: &'static str) -> TestApi {
     TestApi {
         connection_info: conn.connection_info().to_owned(),
         db_name,
-        database: Arc::new(conn),
+        database: conn,
         sql_family: SqlFamily::Mysql,
         introspection_connector,
     }
@@ -177,7 +176,7 @@ pub async fn mysql_5_6_test_api(db_name: &'static str) -> TestApi {
     TestApi {
         connection_info: conn.connection_info().to_owned(),
         db_name,
-        database: Arc::new(conn),
+        database: conn,
         sql_family: SqlFamily::Mysql,
         introspection_connector,
     }
@@ -193,7 +192,7 @@ pub async fn mysql_mariadb_test_api(db_name: &'static str) -> TestApi {
     TestApi {
         db_name,
         connection_info: conn.connection_info().to_owned(),
-        database: Arc::new(conn),
+        database: conn,
         sql_family: SqlFamily::Mysql,
         introspection_connector,
     }
@@ -229,7 +228,7 @@ pub async fn test_api_helper_for_postgres(url: String, db_name: &'static str) ->
     TestApi {
         connection_info,
         db_name,
-        database: Arc::new(database),
+        database,
         sql_family: SqlFamily::Postgres,
         introspection_connector,
     }
@@ -244,7 +243,7 @@ pub async fn sqlite_test_api(db_name: &'static str) -> TestApi {
     TestApi {
         db_name,
         connection_info: database.connection_info().to_owned(),
-        database: Arc::new(database),
+        database,
         sql_family: SqlFamily::Sqlite,
         introspection_connector,
     }

--- a/libs/sql-schema-describer/Cargo.toml
+++ b/libs/sql-schema-describer/Cargo.toml
@@ -16,7 +16,7 @@ thiserror = "1.0.16"
 tracing = "0.1"
 
 [dependencies.quaint]
-features = ["single-postgresql", "single-mysql", "single-sqlite", "serde-support"]
+features = ["single-postgresql", "single-mysql", "single-sqlite", "serde-support", "tracing-log"]
 git = "https://github.com/prisma/quaint"
 
 [dev-dependencies]

--- a/libs/sql-schema-describer/src/mssql.rs
+++ b/libs/sql-schema-describer/src/mssql.rs
@@ -315,8 +315,6 @@ impl SqlSchemaDescriber {
             ORDER BY index_name, seq_in_index
         "#;
 
-        debug!("describing indices, SQL: {}", sql);
-
         let rows = self
             .conn
             .query_raw(sql, &[schema.into()])
@@ -445,8 +443,6 @@ impl SqlSchemaDescriber {
             ORDER BY
                 ordinal_position
         "#;
-
-        debug!("describing table foreign keys, SQL: '{}'", sql);
 
         let result_set = self
             .conn

--- a/libs/sql-schema-describer/src/mssql.rs
+++ b/libs/sql-schema-describer/src/mssql.rs
@@ -1,18 +1,17 @@
 use super::*;
 use once_cell::sync::Lazy;
-use quaint::prelude::Queryable;
+use quaint::{prelude::Queryable, single::Quaint};
 use regex::Regex;
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     convert::TryInto,
-    sync::Arc,
 };
 
 static DEFAULT_INT: Lazy<Regex> = Lazy::new(|| Regex::new(r"\(\((.*)\)\)").unwrap());
 static DEFAULT_NON_INT: Lazy<Regex> = Lazy::new(|| Regex::new(r"\((.*)\)").unwrap());
 
 pub struct SqlSchemaDescriber {
-    conn: Arc<dyn Queryable + Send + Sync + 'static>,
+    conn: Quaint,
 }
 
 #[async_trait::async_trait]
@@ -60,7 +59,7 @@ impl super::SqlSchemaDescriberBackend for SqlSchemaDescriber {
 }
 
 impl SqlSchemaDescriber {
-    pub fn new(conn: Arc<dyn Queryable + Send + Sync + 'static>) -> Self {
+    pub fn new(conn: Quaint) -> Self {
         Self { conn }
     }
 

--- a/libs/sql-schema-describer/src/mysql.rs
+++ b/libs/sql-schema-describer/src/mysql.rs
@@ -339,7 +339,6 @@ async fn get_all_indexes(
             WHERE table_schema = ?
             ORDER BY index_name, seq_in_index
             ";
-    debug!("describing indices, SQL: {}", sql);
     let rows = conn
         .query_raw(sql, &[schema_name.into()])
         .await
@@ -451,8 +450,6 @@ async fn get_foreign_keys(conn: &dyn Queryable, schema_name: &str) -> HashMap<St
             AND referenced_column_name IS NOT NULL
         ORDER BY ordinal_position
     ";
-
-    debug!("describing table foreign keys, SQL: '{}'", sql);
 
     let result_set = conn
         .query_raw(sql, &[schema_name.into(), schema_name.into()])

--- a/libs/sql-schema-describer/src/postgres.rs
+++ b/libs/sql-schema-describer/src/postgres.rs
@@ -1,12 +1,12 @@
 //! Postgres description.
 use super::*;
-use quaint::prelude::Queryable;
+use quaint::{prelude::Queryable, single::Quaint};
 use regex::Regex;
-use std::{borrow::Cow, collections::HashMap, convert::TryInto, sync::Arc};
+use std::{borrow::Cow, collections::HashMap, convert::TryInto};
 use tracing::debug;
 
 pub struct SqlSchemaDescriber {
-    conn: Arc<dyn Queryable + Send + Sync + 'static>,
+    conn: Quaint,
 }
 
 #[async_trait::async_trait]
@@ -55,7 +55,7 @@ impl super::SqlSchemaDescriberBackend for SqlSchemaDescriber {
 
 impl SqlSchemaDescriber {
     /// Constructor.
-    pub fn new(conn: Arc<dyn Queryable + Send + Sync + 'static>) -> SqlSchemaDescriber {
+    pub fn new(conn: Quaint) -> SqlSchemaDescriber {
         SqlSchemaDescriber { conn }
     }
 

--- a/libs/sql-schema-describer/src/postgres.rs
+++ b/libs/sql-schema-describer/src/postgres.rs
@@ -340,7 +340,6 @@ impl SqlSchemaDescriber {
             JOIN pg_attribute att2 on
                 att2.attrelid = con.conrelid and att2.attnum = con.parent
             ORDER BY con_id, con.colidx"#;
-        debug!("describing table foreign keys, SQL: '{}'", sql);
 
         // One foreign key with multiple columns will be represented here as several
         // rows with the same ID, which we will have to combine into corresponding foreign key
@@ -480,7 +479,6 @@ impl SqlSchemaDescriber {
         GROUP BY tableInfos.relname, indexInfos.relname, rawIndex.indisunique, rawIndex.indisprimary, columnInfos.attname, rawIndex.indkeyidx
         ORDER BY rawIndex.indkeyidx
         "#;
-        debug!("Getting indices: {}", sql);
         let rows = self
             .conn
             .query_raw(&sql, &[schema.into()])

--- a/libs/sql-schema-describer/src/sqlite.rs
+++ b/libs/sql-schema-describer/src/sqlite.rs
@@ -1,11 +1,11 @@
 //! SQLite description.
 use super::*;
-use quaint::{ast::Value, prelude::Queryable};
-use std::{borrow::Cow, collections::HashMap, convert::TryInto, sync::Arc};
+use quaint::{ast::Value, prelude::Queryable, single::Quaint};
+use std::{borrow::Cow, collections::HashMap, convert::TryInto};
 use tracing::debug;
 
 pub struct SqlSchemaDescriber {
-    conn: Arc<dyn Queryable + Send + Sync + 'static>,
+    conn: Quaint,
 }
 
 #[async_trait::async_trait]
@@ -66,7 +66,7 @@ impl super::SqlSchemaDescriberBackend for SqlSchemaDescriber {
 
 impl SqlSchemaDescriber {
     /// Constructor.
-    pub fn new(conn: Arc<dyn Queryable + Send + Sync + 'static>) -> SqlSchemaDescriber {
+    pub fn new(conn: Quaint) -> SqlSchemaDescriber {
         SqlSchemaDescriber { conn }
     }
 

--- a/libs/sql-schema-describer/src/sqlite.rs
+++ b/libs/sql-schema-describer/src/sqlite.rs
@@ -359,7 +359,6 @@ impl SqlSchemaDescriber {
 
     async fn get_indices(&self, schema: &str, table: &str) -> Vec<Index> {
         let sql = format!(r#"PRAGMA "{}".index_list("{}");"#, schema, table);
-        debug!("describing table indices, SQL: '{}'", sql);
         let result_set = self.conn.query_raw(&sql, &[]).await.expect("querying for indices");
         debug!("Got indices description results: {:?}", result_set);
 
@@ -384,7 +383,6 @@ impl SqlSchemaDescriber {
             };
 
             let sql = format!(r#"PRAGMA "{}".index_info("{}");"#, schema, name);
-            debug!("describing table index '{}', SQL: '{}'", name, sql);
             let result_set = self.conn.query_raw(&sql, &[]).await.expect("querying for index info");
             debug!("Got index description results: {:?}", result_set);
             for row in result_set.into_iter() {

--- a/libs/sql-schema-describer/tests/introspection_tests.rs
+++ b/libs/sql-schema-describer/tests/introspection_tests.rs
@@ -1,6 +1,6 @@
 use barrel::types;
 use pretty_assertions::assert_eq;
-use quaint::prelude::SqlFamily;
+use quaint::prelude::{Queryable, SqlFamily};
 use sql_schema_describer::*;
 use test_macros::test_each_connector_mssql as test_each_connector;
 

--- a/libs/sql-schema-describer/tests/mssql/mod.rs
+++ b/libs/sql-schema-describer/tests/mssql/mod.rs
@@ -1,7 +1,7 @@
-use tracing::debug;
-
 use super::test_api::mssql_2019_test_api;
+use quaint::prelude::Queryable;
 use sql_schema_describer::*;
+use tracing::debug;
 
 #[allow(dead_code)]
 pub async fn get_mssql_describer_for_schema(sql: &str, schema: &'static str) -> mssql::SqlSchemaDescriber {

--- a/libs/sql-schema-describer/tests/mysql/mod.rs
+++ b/libs/sql-schema-describer/tests/mysql/mod.rs
@@ -24,5 +24,5 @@ pub async fn get_mysql_describer_for_schema(sql: &str, schema: &str) -> mysql::S
             .expect("executing migration statement");
     }
 
-    mysql::SqlSchemaDescriber::new(Arc::new(conn))
+    mysql::SqlSchemaDescriber::new(conn)
 }

--- a/libs/sql-schema-describer/tests/mysql_introspection_tests.rs
+++ b/libs/sql-schema-describer/tests/mysql_introspection_tests.rs
@@ -4,6 +4,7 @@ mod test_api;
 use crate::mysql::*;
 use barrel::{types, Migration};
 use pretty_assertions::assert_eq;
+use quaint::prelude::Queryable;
 use sql_schema_describer::*;
 use test_api::*;
 use test_macros::*;

--- a/libs/sql-schema-describer/tests/postgres/mod.rs
+++ b/libs/sql-schema-describer/tests/postgres/mod.rs
@@ -34,5 +34,5 @@ pub async fn get_postgres_describer(sql: &str, db_name: &str) -> postgres::SqlSc
         client.raw_cmd(statement).await.expect("executing migration statement");
     }
 
-    postgres::SqlSchemaDescriber::new(Arc::new(client))
+    postgres::SqlSchemaDescriber::new(client)
 }

--- a/libs/sql-schema-describer/tests/postgres_introspection_tests.rs
+++ b/libs/sql-schema-describer/tests/postgres_introspection_tests.rs
@@ -5,6 +5,7 @@ mod test_api;
 use crate::{common::*, postgres::*};
 use barrel::{types, Migration};
 use pretty_assertions::assert_eq;
+use quaint::prelude::Queryable;
 use sql_schema_describer::*;
 use test_api::*;
 use test_macros::test_each_connector;

--- a/libs/sql-schema-describer/tests/sqlite/mod.rs
+++ b/libs/sql-schema-describer/tests/sqlite/mod.rs
@@ -25,5 +25,5 @@ pub async fn get_sqlite_describer(sql: &str, db_name: &str) -> sqlite::SqlSchema
         conn.query_raw(statement, &[]).await.expect("executing migration");
     }
 
-    sqlite::SqlSchemaDescriber::new(Arc::new(conn))
+    sqlite::SqlSchemaDescriber::new(conn)
 }

--- a/libs/sql-schema-describer/tests/sqlite_introspection_tests.rs
+++ b/libs/sql-schema-describer/tests/sqlite_introspection_tests.rs
@@ -5,6 +5,7 @@ mod test_api;
 use barrel::{types, Migration};
 use common::*;
 use pretty_assertions::assert_eq;
+use quaint::prelude::Queryable;
 use sql_schema_describer::*;
 use sqlite::*;
 use test_api::{sqlite_test_api, TestApi, TestResult};

--- a/migration-engine/connectors/sql-migration-connector/src/component.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/component.rs
@@ -17,7 +17,7 @@ pub(crate) trait Component {
     }
 
     fn conn(&self) -> &dyn Queryable {
-        self.connector().database.as_ref()
+        &self.connector().database
     }
 
     fn database_info(&self) -> &DatabaseInfo {

--- a/migration-engine/connectors/sql-migration-connector/src/flavour.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour.rs
@@ -24,7 +24,7 @@ use quaint::{
     single::Quaint,
 };
 use sql_schema_describer::SqlSchema;
-use std::{fmt::Debug, sync::Arc};
+use std::fmt::Debug;
 
 /// The maximum size of identifiers on MySQL, in bytes.
 ///
@@ -76,11 +76,7 @@ pub(crate) trait SqlFlavour:
     async fn qe_setup(&self, database_url: &str) -> ConnectorResult<()>;
 
     /// Introspect the SQL schema.
-    async fn describe_schema<'a>(
-        &'a self,
-        schema_name: &'a str,
-        conn: Arc<dyn Queryable + Send + Sync>,
-    ) -> SqlResult<SqlSchema>;
+    async fn describe_schema<'a>(&'a self, schema_name: &'a str, conn: Quaint) -> SqlResult<SqlSchema>;
 
     /// Drop the database the connector is connected to and recreate it empty.
     /// This should not be used for other databases, temporary databases for

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/mysql.rs
@@ -9,7 +9,6 @@ use once_cell::sync::Lazy;
 use quaint::{connector::MysqlUrl, prelude::ConnectionInfo, prelude::Queryable, prelude::SqlFamily, single::Quaint};
 use regex::RegexSet;
 use sql_schema_describer::{SqlSchema, SqlSchemaDescriberBackend};
-use std::sync::Arc;
 use url::Url;
 
 #[derive(Debug)]
@@ -59,11 +58,7 @@ impl SqlFlavour for MysqlFlavour {
         Ok(db_name.to_owned())
     }
 
-    async fn describe_schema<'a>(
-        &'a self,
-        schema_name: &'a str,
-        conn: Arc<dyn Queryable + Send + Sync>,
-    ) -> SqlResult<SqlSchema> {
+    async fn describe_schema<'a>(&'a self, schema_name: &'a str, conn: Quaint) -> SqlResult<SqlSchema> {
         Ok(sql_schema_describer::mysql::SqlSchemaDescriber::new(conn)
             .describe(schema_name)
             .await?)
@@ -211,7 +206,7 @@ impl SqlFlavour for MysqlFlavour {
 
         let sql_schema = catch(
             &connection_info,
-            self.describe_schema(connection_info.schema_name(), Arc::new(quaint)),
+            self.describe_schema(connection_info.schema_name(), quaint),
         )
         .await?;
 

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/postgres.rs
@@ -4,7 +4,7 @@ use futures::TryFutureExt;
 use migration_connector::{ConnectorError, ConnectorResult, ErrorKind, MigrationDirectory};
 use quaint::{connector::PostgresUrl, prelude::ConnectionInfo, prelude::Queryable, prelude::SqlFamily, single::Quaint};
 use sql_schema_describer::{SqlSchema, SqlSchemaDescriberBackend};
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
 use url::Url;
 
 #[derive(Debug)]
@@ -57,11 +57,7 @@ impl SqlFlavour for PostgresFlavour {
         Ok(db_name.to_owned())
     }
 
-    async fn describe_schema<'a>(
-        &'a self,
-        schema_name: &'a str,
-        conn: Arc<dyn Queryable + Send + Sync>,
-    ) -> SqlResult<SqlSchema> {
+    async fn describe_schema<'a>(&'a self, schema_name: &'a str, conn: Quaint) -> SqlResult<SqlSchema> {
         Ok(sql_schema_describer::postgres::SqlSchemaDescriber::new(conn)
             .describe(schema_name)
             .await?)
@@ -243,7 +239,7 @@ impl SqlFlavour for PostgresFlavour {
 
         let sql_schema = catch(
             &quaint.connection_info().clone(),
-            self.describe_schema(self.schema_name(), Arc::new(quaint)),
+            self.describe_schema(self.schema_name(), quaint),
         )
         .await?;
 

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/sqlite.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/sqlite.rs
@@ -4,7 +4,7 @@ use futures::TryFutureExt;
 use migration_connector::{ConnectorError, ConnectorResult, ErrorKind, MigrationDirectory};
 use quaint::{prelude::ConnectionInfo, prelude::Queryable, prelude::SqlFamily, single::Quaint};
 use sql_schema_describer::{SqlSchema, SqlSchemaDescriberBackend};
-use std::{path::Path, sync::Arc};
+use std::path::Path;
 
 #[derive(Debug)]
 pub(crate) struct SqliteFlavour {
@@ -41,11 +41,7 @@ impl SqlFlavour for SqliteFlavour {
         Ok(self.file_path.clone())
     }
 
-    async fn describe_schema<'a>(
-        &'a self,
-        schema_name: &'a str,
-        conn: Arc<dyn Queryable + Send + Sync>,
-    ) -> SqlResult<SqlSchema> {
+    async fn describe_schema<'a>(&'a self, schema_name: &'a str, conn: Quaint) -> SqlResult<SqlSchema> {
         Ok(sql_schema_describer::sqlite::SqlSchemaDescriber::new(conn)
             .describe(schema_name)
             .await?)
@@ -157,7 +153,7 @@ impl SqlFlavour for SqliteFlavour {
 
         let sql_schema = catch(
             &conn.connection_info().clone(),
-            self.describe_schema(&self.attached_name, Arc::new(conn)),
+            self.describe_schema(&self.attached_name, conn),
         )
         .await?;
 

--- a/migration-engine/connectors/sql-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/lib.rs
@@ -24,20 +24,16 @@ use component::Component;
 use database_info::DatabaseInfo;
 use flavour::SqlFlavour;
 use migration_connector::*;
-use quaint::{
-    prelude::{ConnectionInfo, Queryable},
-    single::Quaint,
-};
+use quaint::{prelude::ConnectionInfo, single::Quaint};
 use sql_database_migration_inferrer::*;
 use sql_database_step_applier::*;
 use sql_destructive_change_checker::*;
 use sql_migration::SqlMigration;
 use sql_migration_persistence::*;
 use sql_schema_describer::SqlSchema;
-use std::sync::Arc;
 
 pub struct SqlMigrationConnector {
-    pub database: Arc<dyn Queryable + Send + Sync + 'static>,
+    pub database: Quaint,
     pub database_info: DatabaseInfo,
     flavour: Box<dyn SqlFlavour + Send + Sync + 'static>,
 }
@@ -53,7 +49,7 @@ impl SqlMigrationConnector {
         Ok(Self {
             flavour,
             database_info,
-            database: Arc::new(connection),
+            database: connection,
         })
     }
 

--- a/migration-engine/migration-engine-tests/src/sql/barrel_migration_executor.rs
+++ b/migration-engine/migration-engine-tests/src/sql/barrel_migration_executor.rs
@@ -1,8 +1,7 @@
 use crate::sql::TestApi;
-use quaint::prelude::Queryable;
+use quaint::{prelude::Queryable, single::Quaint};
 use sql_migration_connector::MIGRATION_TABLE_NAME;
 use sql_schema_describer::SqlSchema;
-use std::sync::Arc;
 
 pub struct BarrelMigrationExecutor<'a> {
     pub(crate) api: &'a TestApi,
@@ -35,7 +34,7 @@ impl BarrelMigrationExecutor<'_> {
     }
 }
 
-async fn run_full_sql(database: &Arc<dyn Queryable + Send + Sync>, full_sql: &str) -> anyhow::Result<()> {
+async fn run_full_sql(database: &Quaint, full_sql: &str) -> anyhow::Result<()> {
     for sql in full_sql.split(";").filter(|sql| !sql.is_empty()) {
         database.query_raw(&sql, &[]).await?;
     }

--- a/migration-engine/migration-engine-tests/src/test_api.rs
+++ b/migration-engine/migration-engine-tests/src/test_api.rs
@@ -35,10 +35,12 @@ use migration_core::{
     api::{GenericApi, MigrationApi},
     commands::ApplyMigrationInput,
 };
-use quaint::prelude::{ConnectionInfo, Queryable, SqlFamily};
+use quaint::{
+    prelude::{ConnectionInfo, Queryable, SqlFamily},
+    single::Quaint,
+};
 use sql_migration_connector::{sql_migration::SqlMigration, SqlMigrationConnector, MIGRATION_TABLE_NAME};
 use sql_schema_describer::*;
-use std::sync::Arc;
 use tempfile::TempDir;
 use test_setup::*;
 
@@ -47,7 +49,7 @@ use test_setup::*;
 pub struct TestApi {
     /// More precise than SqlFamily.
     connector_name: &'static str,
-    database: Arc<dyn Queryable + Send + Sync + 'static>,
+    database: Quaint,
     api: MigrationApi<SqlMigrationConnector, SqlMigration>,
     connection_info: ConnectionInfo,
 }
@@ -61,7 +63,7 @@ impl TestApi {
         self.connection_info.schema_name()
     }
 
-    pub fn database(&self) -> &Arc<dyn Queryable + Send + Sync + 'static> {
+    pub fn database(&self) -> &Quaint {
         &self.database
     }
 
@@ -230,7 +232,7 @@ impl TestApi {
     }
 
     fn describer(&self) -> Box<dyn SqlSchemaDescriberBackend> {
-        let db = Arc::clone(&self.database);
+        let db = self.database.clone();
         match self.api.connector_type() {
             "postgresql" => Box::new(sql_schema_describer::postgres::SqlSchemaDescriber::new(db)),
             "sqlite" => Box::new(sql_schema_describer::sqlite::SqlSchemaDescriber::new(db)),
@@ -341,7 +343,7 @@ pub async fn mysql_8_test_api(db_name: &str) -> TestApi {
     TestApi {
         connector_name: "mysql_8",
         connection_info,
-        database: Arc::clone(&connector.database),
+        database: connector.database.clone(),
         api: test_api(connector).await,
     }
 }
@@ -354,7 +356,7 @@ pub async fn mysql_5_6_test_api(db_name: &str) -> TestApi {
     TestApi {
         connector_name: "mysql_5_6",
         connection_info,
-        database: Arc::clone(&connector.database),
+        database: connector.database.clone(),
         api: test_api(connector).await,
     }
 }
@@ -367,7 +369,7 @@ pub async fn mysql_test_api(db_name: &str) -> TestApi {
     TestApi {
         connector_name: "mysql",
         connection_info,
-        database: Arc::clone(&connector.database),
+        database: connector.database.clone(),
         api: test_api(connector).await,
     }
 }
@@ -380,7 +382,7 @@ pub async fn mysql_mariadb_test_api(db_name: &str) -> TestApi {
     TestApi {
         connector_name: "mysql_mariadb",
         connection_info,
-        database: Arc::clone(&connector.database),
+        database: connector.database.clone(),
         api: test_api(connector).await,
     }
 }
@@ -393,7 +395,7 @@ pub async fn postgres9_test_api(db_name: &str) -> TestApi {
     TestApi {
         connector_name: "postgres9",
         connection_info,
-        database: Arc::clone(&connector.database),
+        database: connector.database.clone(),
         api: test_api(connector).await,
     }
 }
@@ -406,7 +408,7 @@ pub async fn postgres_test_api(db_name: &str) -> TestApi {
     TestApi {
         connector_name: "postgres",
         connection_info,
-        database: Arc::clone(&connector.database),
+        database: connector.database.clone(),
         api: test_api(connector).await,
     }
 }
@@ -419,7 +421,7 @@ pub async fn postgres11_test_api(db_name: &str) -> TestApi {
     TestApi {
         connector_name: "postgres11",
         connection_info,
-        database: Arc::clone(&connector.database),
+        database: connector.database.clone(),
         api: test_api(connector).await,
     }
 }
@@ -432,7 +434,7 @@ pub async fn postgres12_test_api(db_name: &str) -> TestApi {
     TestApi {
         connector_name: "postgres12",
         connection_info,
-        database: Arc::clone(&connector.database),
+        database: connector.database.clone(),
         api: test_api(connector).await,
     }
 }
@@ -445,7 +447,7 @@ pub async fn postgres13_test_api(db_name: &str) -> TestApi {
     TestApi {
         connector_name: "postgres13",
         connection_info,
-        database: Arc::clone(&connector.database),
+        database: connector.database.clone(),
         api: test_api(connector).await,
     }
 }
@@ -457,7 +459,7 @@ pub async fn sqlite_test_api(db_name: &str) -> TestApi {
     TestApi {
         connector_name: "sqlite",
         connection_info,
-        database: Arc::clone(&connector.database),
+        database: connector.database.clone(),
         api: test_api(connector).await,
     }
 }

--- a/migration-engine/migration-engine-tests/tests/existing_data/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_data/mod.rs
@@ -3,7 +3,7 @@ mod sql_unexecutable_migrations;
 use migration_engine_tests::sql::*;
 use pretty_assertions::assert_eq;
 use prisma_value::PrismaValue;
-use quaint::ast::*;
+use quaint::{ast::*, prelude::Queryable};
 use sql_schema_describer::DefaultValue;
 
 #[test_each_connector]

--- a/migration-engine/migration-engine-tests/tests/existing_databases/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_databases/mod.rs
@@ -1,6 +1,7 @@
 use barrel::types;
 use migration_engine_tests::sql::*;
 use pretty_assertions::assert_eq;
+use quaint::prelude::Queryable;
 use sql_schema_describer::*;
 
 #[test_each_connector]

--- a/migration-engine/migration-engine-tests/tests/migration_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migration_tests.rs
@@ -21,7 +21,7 @@ mod unapply_migration;
 use migration_engine_tests::sql::*;
 use pretty_assertions::assert_eq;
 use prisma_value::PrismaValue;
-use quaint::prelude::SqlFamily;
+use quaint::prelude::{Queryable, SqlFamily};
 use sql_schema_describer::*;
 
 #[test_each_connector]

--- a/migration-engine/migration-engine-tests/tests/migrations/mariadb.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/mariadb.rs
@@ -1,5 +1,5 @@
 use migration_engine_tests::*;
-use quaint::ast as quaint_ast;
+use quaint::{ast as quaint_ast, prelude::Queryable};
 
 #[test_each_connector(tags("mariadb"))]
 async fn foreign_keys_to_indexes_being_renamed_must_work(api: &TestApi) -> TestResult {

--- a/migration-engine/migration-engine-tests/tests/migrations/postgres.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/postgres.rs
@@ -1,4 +1,5 @@
 use migration_engine_tests::*;
+use quaint::prelude::Queryable;
 use sql_schema_describer::{ColumnArity, ColumnTypeFamily};
 use std::fmt::Write;
 

--- a/migration-engine/migration-engine-tests/tests/migrations/sql.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/sql.rs
@@ -1,4 +1,5 @@
 use migration_engine_tests::sql::*;
+use quaint::prelude::Queryable;
 use std::borrow::Cow;
 
 #[test_each_connector(tags("sql"))]

--- a/migration-engine/migration-engine-tests/tests/unapply_migration/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/unapply_migration/mod.rs
@@ -1,5 +1,5 @@
 use migration_engine_tests::*;
-use quaint::ast as quaint_ast;
+use quaint::{ast as quaint_ast, prelude::Queryable};
 
 #[test_each_connector]
 async fn unapply_must_work(api: &TestApi) -> TestResult {


### PR DESCRIPTION
This made constructing SqlSchemaDescriber structs unnecessary convoluted and forced unnecessary arc-ing (and loss of functionality) on connections in the migration engine.