### PR TITLE
Simplify error handling in sql-migration-connector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3209,7 +3209,6 @@ dependencies = [
  "datamodel",
  "datamodel-connector",
  "enumflags2",
- "futures 0.3.5",
  "migration-connector",
  "native-types",
  "once_cell",

--- a/migration-engine/connectors/migration-connector/src/error.rs
+++ b/migration-engine/connectors/migration-connector/src/error.rs
@@ -1,3 +1,4 @@
+use crate::migrations_directory::ReadMigrationScriptError;
 use std::fmt::Display;
 use thiserror::Error;
 use tracing_error::SpanTrace;
@@ -108,4 +109,15 @@ pub enum ErrorKind {
 
     #[error("Unique constraint violation.")]
     UniqueConstraintViolation { field_name: String },
+}
+
+impl From<ReadMigrationScriptError> for ConnectorError {
+    fn from(err: ReadMigrationScriptError) -> Self {
+        let context = err.1.clone();
+        ConnectorError {
+            user_facing_error: None,
+            kind: ErrorKind::Generic(err.into()),
+            context,
+        }
+    }
 }

--- a/migration-engine/connectors/migration-connector/src/error.rs
+++ b/migration-engine/connectors/migration-connector/src/error.rs
@@ -23,6 +23,14 @@ impl ConnectorError {
         }
     }
 
+    pub fn generic(error: anyhow::Error) -> Self {
+        ConnectorError {
+            user_facing_error: None,
+            kind: ErrorKind::Generic(error),
+            context: SpanTrace::capture(),
+        }
+    }
+
     pub fn into_migration_failed(self, migration_name: String) -> Self {
         let context = self.context.clone();
         let user_facing_error = self.user_facing_error.clone();

--- a/migration-engine/connectors/migration-connector/src/error.rs
+++ b/migration-engine/connectors/migration-connector/src/error.rs
@@ -46,6 +46,16 @@ impl ConnectorError {
         }
     }
 
+    pub fn query_error(error: anyhow::Error) -> Self {
+        let kind = ErrorKind::QueryError(error);
+
+        ConnectorError {
+            user_facing_error: None,
+            kind,
+            context: SpanTrace::capture(),
+        }
+    }
+
     pub fn url_parse_error(err: impl Display, url: &str) -> Self {
         ConnectorError {
             user_facing_error: None,

--- a/migration-engine/connectors/migration-connector/src/migrations_directory.rs
+++ b/migration-engine/connectors/migration-connector/src/migrations_directory.rs
@@ -16,6 +16,7 @@ use std::{
     path::{Path, PathBuf},
 };
 use thiserror::Error;
+use tracing_error::SpanTrace;
 
 use crate::FormatChecksum;
 
@@ -85,11 +86,13 @@ pub struct MigrationDirectory {
 
 #[derive(Debug, Error)]
 #[error("Failed to read migration script")]
-pub struct ReadMigrationScriptError(
-    #[source]
-    #[from]
-    io::Error,
-);
+pub struct ReadMigrationScriptError(#[source] pub(crate) io::Error, pub(crate) SpanTrace);
+
+impl From<io::Error> for ReadMigrationScriptError {
+    fn from(err: io::Error) -> Self {
+        ReadMigrationScriptError(err, SpanTrace::capture())
+    }
+}
 
 impl MigrationDirectory {
     /// The `{timestamp}_{name}` formatted migration name.

--- a/migration-engine/connectors/sql-migration-connector/Cargo.toml
+++ b/migration-engine/connectors/sql-migration-connector/Cargo.toml
@@ -18,7 +18,6 @@ async-trait = "0.1.17"
 barrel = {git = "https://github.com/prisma/barrel.git", features = ["sqlite3", "mysql", "pg", "mssql"], branch = "mssql-support"}
 chrono = { version = "0.4" }
 enumflags2 = "0.6.0"
-futures = "0.3.5"
 once_cell = "1.3"
 quaint = { git = "https://github.com/prisma/quaint", features = ["single"] }
 regex = "1"

--- a/migration-engine/connectors/sql-migration-connector/src/component.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/component.rs
@@ -17,8 +17,8 @@ pub(crate) trait Component {
         self.connector().database_info.connection_info()
     }
 
-    fn conn(&self) -> Connection<'_> {
-        Connection::new(&self.connector().database)
+    fn conn(&self) -> &Connection {
+        &self.connector().connection
     }
 
     fn database_info(&self) -> &DatabaseInfo {

--- a/migration-engine/connectors/sql-migration-connector/src/component.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/component.rs
@@ -1,5 +1,6 @@
-use crate::{flavour::SqlFlavour, DatabaseInfo, SqlMigrationConnector, SqlResult};
-use quaint::prelude::{ConnectionInfo, Queryable, SqlFamily};
+use crate::{connection_wrapper::Connection, flavour::SqlFlavour, DatabaseInfo, SqlMigrationConnector};
+use migration_connector::ConnectorResult;
+use quaint::prelude::{ConnectionInfo, SqlFamily};
 use sql_schema_describer::SqlSchema;
 
 /// Implemented by the components of the connector that contain a reference to the connector (like
@@ -16,15 +17,15 @@ pub(crate) trait Component {
         self.connector().database_info.connection_info()
     }
 
-    fn conn(&self) -> &dyn Queryable {
-        &self.connector().database
+    fn conn(&self) -> Connection<'_> {
+        Connection::new(&self.connector().database)
     }
 
     fn database_info(&self) -> &DatabaseInfo {
         &self.connector().database_info
     }
 
-    async fn describe(&self) -> SqlResult<SqlSchema> {
+    async fn describe(&self) -> ConnectorResult<SqlSchema> {
         self.connector().describe_schema().await
     }
 

--- a/migration-engine/connectors/sql-migration-connector/src/connection_wrapper.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/connection_wrapper.rs
@@ -1,11 +1,13 @@
+use crate::SqlError;
 use migration_connector::ConnectorResult;
 use quaint::{
     prelude::{ConnectionInfo, Query, Queryable, ResultSet},
     single::Quaint,
 };
 
-use crate::SqlError;
-
+/// An internal helper for the SQL connector. It wraps a `Quaint` struct and
+/// exposes a similar API, with additional error handling to return
+/// `ConnectorResult`s.
 #[derive(Clone, Debug)]
 pub(crate) struct Connection(Quaint);
 

--- a/migration-engine/connectors/sql-migration-connector/src/connection_wrapper.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/connection_wrapper.rs
@@ -1,4 +1,4 @@
-use crate::SqlError;
+use crate::error::quaint_error_to_connector_error;
 use migration_connector::ConnectorResult;
 use quaint::{
     prelude::{ConnectionInfo, Query, Queryable, ResultSet},
@@ -24,16 +24,14 @@ impl Connection {
         self.0
             .execute(query.into())
             .await
-            .map_err(SqlError::from)
-            .map_err(|sql_error| sql_error.into_connector_error(self.0.connection_info()))
+            .map_err(|err| quaint_error_to_connector_error(err, self.connection_info()))
     }
 
     pub(crate) async fn execute_raw(&self, sql: &str, params: &[quaint::Value<'_>]) -> ConnectorResult<u64> {
         self.0
             .execute_raw(sql, params)
             .await
-            .map_err(SqlError::from)
-            .map_err(|sql_error| sql_error.into_connector_error(self.0.connection_info()))
+            .map_err(|err| quaint_error_to_connector_error(err, self.connection_info()))
     }
 
     pub(crate) fn quaint(&self) -> &Quaint {
@@ -44,23 +42,20 @@ impl Connection {
         self.0
             .query(query.into())
             .await
-            .map_err(SqlError::from)
-            .map_err(|sql_error| sql_error.into_connector_error(self.0.connection_info()))
+            .map_err(|err| quaint_error_to_connector_error(err, self.connection_info()))
     }
 
     pub(crate) async fn query_raw(&self, sql: &str, params: &[quaint::Value<'_>]) -> ConnectorResult<ResultSet> {
         self.0
             .query_raw(sql, params)
             .await
-            .map_err(SqlError::from)
-            .map_err(|sql_error| sql_error.into_connector_error(self.0.connection_info()))
+            .map_err(|err| quaint_error_to_connector_error(err, self.connection_info()))
     }
 
     pub(crate) async fn raw_cmd(&self, sql: &str) -> ConnectorResult<()> {
         self.0
             .raw_cmd(sql)
             .await
-            .map_err(SqlError::from)
-            .map_err(|sql_error| sql_error.into_connector_error(self.0.connection_info()))
+            .map_err(|err| quaint_error_to_connector_error(err, self.connection_info()))
     }
 }

--- a/migration-engine/connectors/sql-migration-connector/src/connection_wrapper.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/connection_wrapper.rs
@@ -6,11 +6,11 @@ use quaint::{
 
 use crate::SqlError;
 
-#[derive(Clone, Copy, Debug)]
-pub(crate) struct Connection<'a>(&'a Quaint);
+#[derive(Clone, Debug)]
+pub(crate) struct Connection(Quaint);
 
-impl<'a> Connection<'a> {
-    pub(crate) fn new(quaint: &'a Quaint) -> Self {
+impl Connection {
+    pub(crate) fn new(quaint: Quaint) -> Self {
         Connection(quaint)
     }
 
@@ -35,7 +35,7 @@ impl<'a> Connection<'a> {
     }
 
     pub(crate) fn quaint(&self) -> &Quaint {
-        self.0
+        &self.0
     }
 
     pub(crate) async fn query(&self, query: impl Into<Query<'_>>) -> ConnectorResult<ResultSet> {

--- a/migration-engine/connectors/sql-migration-connector/src/connection_wrapper.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/connection_wrapper.rs
@@ -1,0 +1,64 @@
+use migration_connector::ConnectorResult;
+use quaint::{
+    prelude::{ConnectionInfo, Query, Queryable, ResultSet},
+    single::Quaint,
+};
+
+use crate::SqlError;
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct Connection<'a>(&'a Quaint);
+
+impl<'a> Connection<'a> {
+    pub(crate) fn new(quaint: &'a Quaint) -> Self {
+        Connection(quaint)
+    }
+
+    pub(crate) fn connection_info(&self) -> &ConnectionInfo {
+        self.0.connection_info()
+    }
+
+    pub(crate) async fn execute(&self, query: impl Into<Query<'_>>) -> ConnectorResult<u64> {
+        self.0
+            .execute(query.into())
+            .await
+            .map_err(SqlError::from)
+            .map_err(|sql_error| sql_error.into_connector_error(self.0.connection_info()))
+    }
+
+    pub(crate) async fn execute_raw(&self, sql: &str, params: &[quaint::Value<'_>]) -> ConnectorResult<u64> {
+        self.0
+            .execute_raw(sql, params)
+            .await
+            .map_err(SqlError::from)
+            .map_err(|sql_error| sql_error.into_connector_error(self.0.connection_info()))
+    }
+
+    pub(crate) fn quaint(&self) -> &Quaint {
+        self.0
+    }
+
+    pub(crate) async fn query(&self, query: impl Into<Query<'_>>) -> ConnectorResult<ResultSet> {
+        self.0
+            .query(query.into())
+            .await
+            .map_err(SqlError::from)
+            .map_err(|sql_error| sql_error.into_connector_error(self.0.connection_info()))
+    }
+
+    pub(crate) async fn query_raw(&self, sql: &str, params: &[quaint::Value<'_>]) -> ConnectorResult<ResultSet> {
+        self.0
+            .query_raw(sql, params)
+            .await
+            .map_err(SqlError::from)
+            .map_err(|sql_error| sql_error.into_connector_error(self.0.connection_info()))
+    }
+
+    pub(crate) async fn raw_cmd(&self, sql: &str) -> ConnectorResult<()> {
+        self.0
+            .raw_cmd(sql)
+            .await
+            .map_err(SqlError::from)
+            .map_err(|sql_error| sql_error.into_connector_error(self.0.connection_info()))
+    }
+}

--- a/migration-engine/connectors/sql-migration-connector/src/database_info.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/database_info.rs
@@ -1,11 +1,10 @@
+use crate::error::SqlError;
 use datamodel::{walkers::walk_scalar_fields, Datamodel};
 use migration_connector::{ConnectorResult, MigrationError};
 use quaint::{
     prelude::{ConnectionInfo, Queryable, SqlFamily},
     single::Quaint,
 };
-
-use crate::error::SqlError;
 
 #[derive(Debug, Clone)]
 pub struct DatabaseInfo {

--- a/migration-engine/connectors/sql-migration-connector/src/database_info.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/database_info.rs
@@ -1,4 +1,4 @@
-use crate::error::SqlError;
+use crate::error::quaint_error_to_connector_error;
 use datamodel::{walkers::walk_scalar_fields, Datamodel};
 use migration_connector::{ConnectorResult, MigrationError};
 use quaint::{
@@ -17,8 +17,7 @@ impl DatabaseInfo {
         let database_version = connection
             .version()
             .await
-            .map_err(SqlError::from)
-            .map_err(|err| err.into_connector_error(&connection_info))?;
+            .map_err(|err| quaint_error_to_connector_error(err, &connection_info))?;
 
         Ok(DatabaseInfo {
             connection_info,

--- a/migration-engine/connectors/sql-migration-connector/src/error.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/error.rs
@@ -1,194 +1,45 @@
 use migration_connector::{ConnectorError, ErrorKind};
-use quaint::error::{Error as QuaintError, ErrorKind as QuaintKind};
+use quaint::{
+    error::{Error as QuaintError, ErrorKind as QuaintKind},
+    prelude::ConnectionInfo,
+};
 use thiserror::Error;
 use tracing_error::SpanTrace;
-use user_facing_errors::{
-    migration_engine::MigrateSystemDatabase, quaint::render_quaint_error, query_engine::DatabaseConstraint, KnownError,
-};
+use user_facing_errors::{migration_engine::MigrateSystemDatabase, quaint::render_quaint_error, KnownError};
 
-#[derive(Debug, Error)]
-pub enum SqlError {
-    #[error(transparent)]
-    Generic(anyhow::Error),
+pub(crate) fn quaint_error_to_connector_error(error: QuaintError, connection_info: &ConnectionInfo) -> ConnectorError {
+    let user_facing_error = render_quaint_error(error.kind(), connection_info);
 
-    #[error("Error connecting to the database {cause}")]
-    ConnectionError {
-        #[source]
-        cause: QuaintKind,
-    },
+    let kind = match error.kind() {
+        QuaintKind::DatabaseDoesNotExist { ref db_name } => ErrorKind::DatabaseDoesNotExist {
+            db_name: db_name.clone(),
+        },
+        QuaintKind::DatabaseAlreadyExists { ref db_name } => ErrorKind::DatabaseAlreadyExists {
+            db_name: db_name.clone(),
+        },
+        QuaintKind::DatabaseAccessDenied { ref db_name } => ErrorKind::DatabaseAccessDenied {
+            database_name: db_name.clone(),
+        },
+        QuaintKind::AuthenticationFailed { ref user } => ErrorKind::AuthenticationFailed { user: user.clone() },
+        QuaintKind::ConnectTimeout(..) => ErrorKind::ConnectTimeout,
+        QuaintKind::ConnectionError { .. } => ErrorKind::ConnectionError {
+            cause: error.into(),
+            host: connection_info.host().to_owned(),
+        },
+        QuaintKind::Timeout(..) => ErrorKind::Timeout,
+        QuaintKind::TlsError { message } => ErrorKind::TlsError {
+            message: message.clone(),
+        },
+        QuaintKind::UniqueConstraintViolation { ref constraint } => ErrorKind::UniqueConstraintViolation {
+            field_name: constraint.to_string(),
+        },
+        _ => ErrorKind::QueryError(error.into()),
+    };
 
-    #[error(transparent)]
-    QueryError(anyhow::Error),
-
-    #[error("Database '{}' does not exist", db_name)]
-    DatabaseDoesNotExist {
-        db_name: String,
-        #[source]
-        cause: QuaintKind,
-    },
-
-    #[error("Access denied to database '{}'", db_name)]
-    DatabaseAccessDenied {
-        db_name: String,
-        #[source]
-        cause: QuaintKind,
-    },
-
-    #[error("Database '{}' already exists", db_name)]
-    DatabaseAlreadyExists {
-        db_name: String,
-        #[source]
-        cause: QuaintKind,
-    },
-
-    #[error("Authentication failed for user '{}'", user)]
-    AuthenticationFailed {
-        user: String,
-        #[source]
-        cause: QuaintKind,
-    },
-
-    #[error("Connect timed out")]
-    ConnectTimeout(#[source] QuaintKind),
-
-    #[error("Operation timed out")]
-    Timeout,
-
-    #[error("Error opening a TLS connection. {}", cause)]
-    TlsError {
-        #[source]
-        cause: QuaintKind,
-    },
-
-    #[error("Unique constraint violation")]
-    UniqueConstraintViolation {
-        constraint: DatabaseConstraint,
-        #[source]
-        cause: QuaintKind,
-    },
-}
-
-impl SqlError {
-    pub(crate) fn into_connector_error(self, connection_info: &super::ConnectionInfo) -> ConnectorError {
-        let context = SpanTrace::capture();
-
-        match self {
-            SqlError::DatabaseDoesNotExist { db_name, cause } => ConnectorError {
-                user_facing_error: render_quaint_error(&cause, connection_info),
-                kind: ErrorKind::DatabaseDoesNotExist { db_name },
-                context,
-            },
-            SqlError::DatabaseAccessDenied { db_name, cause } => ConnectorError {
-                user_facing_error: render_quaint_error(&cause, connection_info),
-                kind: ErrorKind::DatabaseAccessDenied { database_name: db_name },
-                context,
-            },
-
-            SqlError::DatabaseAlreadyExists { db_name, cause } => ConnectorError {
-                user_facing_error: render_quaint_error(&cause, connection_info),
-                kind: ErrorKind::DatabaseAlreadyExists { db_name },
-                context,
-            },
-            SqlError::AuthenticationFailed { user, cause } => ConnectorError {
-                user_facing_error: render_quaint_error(&cause, connection_info),
-                kind: ErrorKind::AuthenticationFailed { user },
-                context,
-            },
-            SqlError::ConnectTimeout(cause) => {
-                let user_facing_error = render_quaint_error(&cause, connection_info);
-
-                ConnectorError {
-                    user_facing_error,
-                    kind: ErrorKind::ConnectTimeout,
-                    context,
-                }
-            }
-            SqlError::Timeout => ConnectorError::from_kind(ErrorKind::Timeout),
-            SqlError::TlsError { cause } => {
-                let user_facing_error = render_quaint_error(&cause, connection_info);
-
-                ConnectorError {
-                    user_facing_error,
-                    kind: ErrorKind::TlsError {
-                        message: cause.to_string(),
-                    },
-                    context,
-                }
-            }
-            SqlError::ConnectionError { cause } => {
-                let user_facing_error = render_quaint_error(&cause, connection_info);
-                ConnectorError {
-                    user_facing_error,
-                    kind: ErrorKind::ConnectionError {
-                        host: connection_info.host().to_owned(),
-                        cause: cause.into(),
-                    },
-                    context,
-                }
-            }
-            SqlError::UniqueConstraintViolation { cause, .. } => {
-                let user_facing_error = render_quaint_error(&cause, connection_info);
-                ConnectorError {
-                    user_facing_error,
-                    kind: ErrorKind::ConnectionError {
-                        host: connection_info.host().to_owned(),
-                        cause: cause.into(),
-                    },
-                    context,
-                }
-            }
-            error => ConnectorError::from_kind(ErrorKind::QueryError(error.into())),
-        }
-    }
-}
-
-impl From<QuaintKind> for SqlError {
-    fn from(kind: QuaintKind) -> Self {
-        match kind {
-            QuaintKind::DatabaseDoesNotExist { ref db_name } => Self::DatabaseDoesNotExist {
-                db_name: db_name.clone(),
-                cause: kind,
-            },
-            QuaintKind::DatabaseAlreadyExists { ref db_name } => Self::DatabaseAlreadyExists {
-                db_name: db_name.clone(),
-                cause: kind,
-            },
-            QuaintKind::DatabaseAccessDenied { ref db_name } => Self::DatabaseAccessDenied {
-                db_name: db_name.clone(),
-                cause: kind,
-            },
-            QuaintKind::AuthenticationFailed { ref user } => Self::AuthenticationFailed {
-                user: user.clone(),
-                cause: kind,
-            },
-            e @ QuaintKind::ConnectTimeout(..) => Self::ConnectTimeout(e),
-            QuaintKind::ConnectionError { .. } => Self::ConnectionError { cause: kind },
-            QuaintKind::Timeout(..) => Self::Timeout,
-            QuaintKind::TlsError { .. } => Self::TlsError { cause: kind },
-            QuaintKind::UniqueConstraintViolation { ref constraint } => Self::UniqueConstraintViolation {
-                constraint: constraint.into(),
-                cause: kind,
-            },
-            _ => SqlError::QueryError(kind.into()),
-        }
-    }
-}
-
-impl From<QuaintError> for SqlError {
-    fn from(e: QuaintError) -> Self {
-        QuaintKind::from(e).into()
-    }
-}
-
-impl From<sql_schema_describer::SqlSchemaDescriberError> for SqlError {
-    fn from(error: sql_schema_describer::SqlSchemaDescriberError) -> Self {
-        SqlError::QueryError(anyhow::anyhow!("{}", error))
-    }
-}
-
-impl From<String> for SqlError {
-    fn from(error: String) -> Self {
-        SqlError::Generic(anyhow::anyhow!(error))
+    ConnectorError {
+        user_facing_error,
+        kind,
+        context: SpanTrace::capture(),
     }
 }
 

--- a/migration-engine/connectors/sql-migration-connector/src/error.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/error.rs
@@ -6,8 +6,6 @@ use user_facing_errors::{
     migration_engine::MigrateSystemDatabase, quaint::render_quaint_error, query_engine::DatabaseConstraint, KnownError,
 };
 
-pub type SqlResult<T> = Result<T, SqlError>;
-
 #[derive(Debug, Error)]
 pub enum SqlError {
     #[error(transparent)]

--- a/migration-engine/connectors/sql-migration-connector/src/flavour.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour.rs
@@ -20,7 +20,7 @@ use crate::{
     sql_schema_calculator::SqlSchemaCalculatorFlavour, sql_schema_differ::SqlSchemaDifferFlavour,
 };
 use migration_connector::{ConnectorResult, MigrationDirectory};
-use quaint::{connector::ConnectionInfo, prelude::SqlFamily, single::Quaint};
+use quaint::{connector::ConnectionInfo, prelude::SqlFamily};
 use sql_schema_describer::SqlSchema;
 use std::fmt::Debug;
 
@@ -70,7 +70,7 @@ pub(crate) trait SqlFlavour:
     async fn qe_setup(&self, database_url: &str) -> ConnectorResult<()>;
 
     /// Introspect the SQL schema.
-    async fn describe_schema<'a>(&'a self, schema_name: &'a str, conn: Quaint) -> ConnectorResult<SqlSchema>;
+    async fn describe_schema<'a>(&'a self, conn: &Connection) -> ConnectorResult<SqlSchema>;
 
     /// Drop the database and recreate it empty.
     async fn reset(&self, connection: &Connection) -> ConnectorResult<()>;

--- a/migration-engine/connectors/sql-migration-connector/src/flavour.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour.rs
@@ -58,10 +58,10 @@ pub(crate) trait SqlFlavour:
     /// Check a connection to make sure it is usable by the migration engine.
     /// This can include some set up on the database, like ensuring that the
     /// schema we connect to exists.
-    async fn ensure_connection_validity(&self, connection: Connection<'_>) -> ConnectorResult<()>;
+    async fn ensure_connection_validity(&self, connection: &Connection) -> ConnectorResult<()>;
 
     /// Make sure that the `_prisma_migrations` table exists.
-    async fn ensure_imperative_migrations_table(&self, connection: Connection<'_>) -> ConnectorResult<()>;
+    async fn ensure_imperative_migrations_table(&self, connection: &Connection) -> ConnectorResult<()>;
 
     /// Create a database for the given URL on the server, if applicable.
     async fn create_database(&self, database_url: &str) -> ConnectorResult<String>;
@@ -73,13 +73,13 @@ pub(crate) trait SqlFlavour:
     async fn describe_schema<'a>(&'a self, schema_name: &'a str, conn: Quaint) -> ConnectorResult<SqlSchema>;
 
     /// Drop the database and recreate it empty.
-    async fn reset(&self, connection: Connection<'_>) -> ConnectorResult<()>;
+    async fn reset(&self, connection: &Connection) -> ConnectorResult<()>;
 
     /// Apply the given migration history to a temporary database, and return
     /// the final introspected SQL schema.
     async fn sql_schema_from_migration_history(
         &self,
         migrations: &[MigrationDirectory],
-        connection: Connection<'_>,
+        connection: &Connection,
     ) -> ConnectorResult<SqlSchema>;
 }

--- a/migration-engine/connectors/sql-migration-connector/src/flavour.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour.rs
@@ -15,16 +15,12 @@ pub(crate) use postgres::PostgresFlavour;
 pub(crate) use sqlite::SqliteFlavour;
 
 use crate::{
-    database_info::DatabaseInfo, error::CheckDatabaseInfoResult,
+    connection_wrapper::Connection, database_info::DatabaseInfo, error::CheckDatabaseInfoResult,
     sql_destructive_change_checker::DestructiveChangeCheckerFlavour, sql_renderer::SqlRenderer,
-    sql_schema_calculator::SqlSchemaCalculatorFlavour, sql_schema_differ::SqlSchemaDifferFlavour, SqlResult,
+    sql_schema_calculator::SqlSchemaCalculatorFlavour, sql_schema_differ::SqlSchemaDifferFlavour,
 };
 use migration_connector::{ConnectorResult, MigrationDirectory};
-use quaint::{
-    connector::{ConnectionInfo, Queryable},
-    prelude::SqlFamily,
-    single::Quaint,
-};
+use quaint::{connector::ConnectionInfo, prelude::SqlFamily, single::Quaint};
 use sql_schema_describer::SqlSchema;
 use std::fmt::Debug;
 
@@ -62,14 +58,10 @@ pub(crate) trait SqlFlavour:
     /// Check a connection to make sure it is usable by the migration engine.
     /// This can include some set up on the database, like ensuring that the
     /// schema we connect to exists.
-    async fn ensure_connection_validity(&self, connection: &Quaint) -> ConnectorResult<()>;
+    async fn ensure_connection_validity(&self, connection: Connection<'_>) -> ConnectorResult<()>;
 
     /// Make sure that the `_prisma_migrations` table exists.
-    async fn ensure_imperative_migrations_table(
-        &self,
-        connection: &dyn Queryable,
-        connection_info: &ConnectionInfo,
-    ) -> ConnectorResult<()>;
+    async fn ensure_imperative_migrations_table(&self, connection: Connection<'_>) -> ConnectorResult<()>;
 
     /// Create a database for the given URL on the server, if applicable.
     async fn create_database(&self, database_url: &str) -> ConnectorResult<String>;
@@ -78,19 +70,16 @@ pub(crate) trait SqlFlavour:
     async fn qe_setup(&self, database_url: &str) -> ConnectorResult<()>;
 
     /// Introspect the SQL schema.
-    async fn describe_schema<'a>(&'a self, schema_name: &'a str, conn: Quaint) -> SqlResult<SqlSchema>;
+    async fn describe_schema<'a>(&'a self, schema_name: &'a str, conn: Quaint) -> ConnectorResult<SqlSchema>;
 
-    /// Drop the database the connector is connected to and recreate it empty.
-    /// This should not be used for other databases, temporary databases for
-    /// example.
-    async fn reset(&self, conn: &dyn Queryable, connection_info: &ConnectionInfo) -> ConnectorResult<()>;
+    /// Drop the database and recreate it empty.
+    async fn reset(&self, connection: Connection<'_>) -> ConnectorResult<()>;
 
     /// Apply the given migration history to a temporary database, and return
     /// the final introspected SQL schema.
     async fn sql_schema_from_migration_history(
         &self,
         migrations: &[MigrationDirectory],
-        connection: &dyn Queryable,
-        connection_info: &ConnectionInfo,
+        connection: Connection<'_>,
     ) -> ConnectorResult<SqlSchema>;
 }

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/mssql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/mssql.rs
@@ -1,9 +1,8 @@
 use super::SqlFlavour;
-use crate::{connect, connection_wrapper::Connection, SqlError, SqlResult};
-use futures::TryFutureExt;
-use migration_connector::{ConnectorResult, MigrationDirectory};
-use quaint::{connector::MssqlUrl, prelude::ConnectionInfo, prelude::Queryable, prelude::SqlFamily, single::Quaint};
-use sql_schema_describer::{SqlSchema, SqlSchemaDescriberBackend};
+use crate::{connect, connection_wrapper::Connection};
+use migration_connector::{ConnectorError, ConnectorResult, MigrationDirectory};
+use quaint::{connector::MssqlUrl, prelude::SqlFamily};
+use sql_schema_describer::{SqlSchema, SqlSchemaDescriberBackend, SqlSchemaDescriberError};
 use std::collections::HashMap;
 
 #[derive(Debug)]
@@ -54,10 +53,15 @@ impl SqlFlavour for MssqlFlavour {
         Ok(db_name)
     }
 
-    async fn describe_schema<'a>(&'a self, schema_name: &'a str, conn: Quaint) -> SqlResult<SqlSchema> {
-        Ok(sql_schema_describer::mssql::SqlSchemaDescriber::new(conn)
-            .describe(schema_name)
-            .await?)
+    async fn describe_schema<'a>(&'a self, connection: &Connection) -> ConnectorResult<SqlSchema> {
+        sql_schema_describer::mssql::SqlSchemaDescriber::new(connection.quaint().clone())
+            .describe(connection.connection_info().schema_name())
+            .await
+            .map_err(|err| match err {
+                SqlSchemaDescriberError::UnknownError => {
+                    ConnectorError::query_error(anyhow::anyhow!("An unknown error occured in sql-schema-describer"))
+                }
+            })
     }
 
     async fn reset(&self, connection: &Connection) -> ConnectorResult<()> {
@@ -104,7 +108,7 @@ impl SqlFlavour for MssqlFlavour {
 
     async fn qe_setup(&self, database_str: &str) -> ConnectorResult<()> {
         let (db_name, master_uri) = Self::master_url(database_str);
-        let (conn, info) = connect(&master_uri).await?;
+        let conn = connect(&master_uri).await?;
 
         // Without these, our poor connection gets deadlocks if other schemas
         // are modified while we introspect.
@@ -115,16 +119,15 @@ impl SqlFlavour for MssqlFlavour {
 
         conn.raw_cmd(&allow_snapshot_isolation).await.unwrap();
 
-        self.reset(&conn, info.connection_info()).await?;
+        self.reset(&conn).await?;
 
         conn.raw_cmd(&format!(
             "DROP SCHEMA IF EXISTS {}",
-            info.connection_info().schema_name()
+            conn.connection_info().schema_name()
         ))
-        .await
-        .unwrap();
+        .await?;
 
-        conn.raw_cmd(&format!("CREATE SCHEMA {}", info.connection_info().schema_name()))
+        conn.raw_cmd(&format!("CREATE SCHEMA {}", conn.connection_info().schema_name()))
             .await
             .unwrap();
 
@@ -135,21 +138,13 @@ impl SqlFlavour for MssqlFlavour {
         SqlFamily::Mssql
     }
 
-    async fn ensure_connection_validity(&self, connection: &Quaint) -> ConnectorResult<()> {
-        catch(
-            connection.connection_info(),
-            connection.raw_cmd("SELECT 1").map_err(SqlError::from),
-        )
-        .await?;
+    async fn ensure_connection_validity(&self, connection: &Connection) -> ConnectorResult<()> {
+        connection.raw_cmd("SELECT 1").await?;
 
         Ok(())
     }
 
-    async fn ensure_imperative_migrations_table(
-        &self,
-        connection: &dyn Queryable,
-        connection_info: &ConnectionInfo,
-    ) -> ConnectorResult<()> {
+    async fn ensure_imperative_migrations_table(&self, connection: &Connection) -> ConnectorResult<()> {
         let sql = r#"
             CREATE TABLE IF NOT EXISTS [_prisma_migrations] (
                 id                      VARCHAR(36) PRIMARY KEY NOT NULL,
@@ -164,14 +159,13 @@ impl SqlFlavour for MssqlFlavour {
             );
         "#;
 
-        catch(connection_info, connection.raw_cmd(sql).map_err(SqlError::from)).await
+        connection.raw_cmd(sql).await
     }
 
     async fn sql_schema_from_migration_history(
         &self,
         _: &[MigrationDirectory],
-        _: &dyn Queryable,
-        _: &ConnectionInfo,
+        _: &Connection,
     ) -> ConnectorResult<SqlSchema> {
         todo!("Needs the connection string crate, so leaving it unimplemented for now")
     }

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/mysql.rs
@@ -1,12 +1,12 @@
 use super::SqlFlavour;
 use crate::{
-    catch, connect, database_info::DatabaseInfo, error::CheckDatabaseInfoResult, error::SystemDatabase, SqlError,
-    SqlResult,
+    connect, connection_wrapper::Connection, database_info::DatabaseInfo, error::CheckDatabaseInfoResult,
+    error::SystemDatabase, SqlError,
 };
 use futures::TryFutureExt;
 use migration_connector::{ConnectorError, ConnectorResult, MigrationDirectory};
 use once_cell::sync::Lazy;
-use quaint::{connector::MysqlUrl, prelude::ConnectionInfo, prelude::Queryable, prelude::SqlFamily, single::Quaint};
+use quaint::{connector::MysqlUrl, prelude::SqlFamily, single::Quaint};
 use regex::RegexSet;
 use sql_schema_describer::{SqlSchema, SqlSchemaDescriberBackend};
 use url::Url;
@@ -47,38 +47,34 @@ impl SqlFlavour for MysqlFlavour {
         url.set_path("/mysql");
 
         let (conn, _) = connect(&url.to_string()).await?;
+        let conn = Connection::new(&conn);
         let db_name = self.0.dbname();
 
         let query = format!(
             "CREATE DATABASE `{}` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;",
             db_name
         );
-        catch(conn.connection_info(), conn.raw_cmd(&query).map_err(SqlError::from)).await?;
+
+        conn.raw_cmd(&query).await?;
 
         Ok(db_name.to_owned())
     }
 
-    async fn describe_schema<'a>(&'a self, schema_name: &'a str, conn: Quaint) -> SqlResult<SqlSchema> {
-        Ok(sql_schema_describer::mysql::SqlSchemaDescriber::new(conn)
+    async fn describe_schema<'a>(&'a self, schema_name: &'a str, conn: Quaint) -> ConnectorResult<SqlSchema> {
+        Ok(sql_schema_describer::mysql::SqlSchemaDescriber::new(conn.clone())
             .describe(schema_name)
+            .map_err(SqlError::from)
+            .map_err(|err| err.into_connector_error(conn.connection_info()))
             .await?)
     }
 
-    async fn ensure_connection_validity(&self, connection: &Quaint) -> ConnectorResult<()> {
-        catch(
-            connection.connection_info(),
-            connection.raw_cmd("SELECT 1").map_err(SqlError::from),
-        )
-        .await?;
+    async fn ensure_connection_validity(&self, connection: Connection<'_>) -> ConnectorResult<()> {
+        connection.raw_cmd("SELECT 1").await?;
 
         Ok(())
     }
 
-    async fn ensure_imperative_migrations_table(
-        &self,
-        connection: &dyn Queryable,
-        connection_info: &ConnectionInfo,
-    ) -> ConnectorResult<()> {
+    async fn ensure_imperative_migrations_table(&self, connection: Connection<'_>) -> ConnectorResult<()> {
         let sql = r#"
             CREATE TABLE IF NOT EXISTS _prisma_migrations (
                 id                      VARCHAR(36) PRIMARY KEY NOT NULL,
@@ -93,7 +89,7 @@ impl SqlFlavour for MysqlFlavour {
             ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
         "#;
 
-        catch(connection_info, connection.raw_cmd(sql).map_err(SqlError::from)).await
+        connection.raw_cmd(sql).await
     }
 
     async fn qe_setup(&self, database_str: &str) -> ConnectorResult<()> {
@@ -101,47 +97,28 @@ impl SqlFlavour for MysqlFlavour {
         url.set_path("/mysql");
 
         let (conn, _) = connect(&url.to_string()).await?;
+        let conn = Connection::new(&conn);
 
         let db_name = self.0.dbname();
 
         let query = format!("DROP DATABASE IF EXISTS `{}`", db_name);
-        catch(conn.connection_info(), conn.raw_cmd(&query).map_err(SqlError::from)).await?;
+        conn.raw_cmd(&query).await?;
 
         let query = format!(
             "CREATE DATABASE `{}` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;",
             db_name
         );
-        catch(conn.connection_info(), conn.raw_cmd(&query).map_err(SqlError::from)).await?;
+        conn.raw_cmd(&query).await?;
 
         Ok(())
     }
 
-    async fn reset(&self, connection: &dyn Queryable, connection_info: &ConnectionInfo) -> ConnectorResult<()> {
-        let db_name = connection_info.dbname().unwrap();
+    async fn reset(&self, connection: Connection<'_>) -> ConnectorResult<()> {
+        let db_name = connection.connection_info().dbname().unwrap();
 
-        catch(
-            connection_info,
-            connection
-                .raw_cmd(&format!("DROP DATABASE `{}`", db_name))
-                .map_err(SqlError::from),
-        )
-        .await?;
-
-        catch(
-            connection_info,
-            connection
-                .raw_cmd(&format!("CREATE DATABASE `{}`", db_name))
-                .map_err(SqlError::from),
-        )
-        .await?;
-
-        catch(
-            connection_info,
-            connection
-                .raw_cmd(&format!("USE `{}`", db_name))
-                .map_err(SqlError::from),
-        )
-        .await?;
+        connection.raw_cmd(&format!("DROP DATABASE `{}`", db_name)).await?;
+        connection.raw_cmd(&format!("CREATE DATABASE `{}`", db_name)).await?;
+        connection.raw_cmd(&format!("USE `{}`", db_name)).await?;
 
         Ok(())
     }
@@ -150,27 +127,18 @@ impl SqlFlavour for MysqlFlavour {
         SqlFamily::Mysql
     }
 
-    #[tracing::instrument(skip(self, migrations, connection, connection_info))]
+    #[tracing::instrument(skip(self, migrations, connection))]
     async fn sql_schema_from_migration_history(
         &self,
         migrations: &[MigrationDirectory],
-        connection: &dyn Queryable,
-        connection_info: &ConnectionInfo,
+        connection: Connection<'_>,
     ) -> ConnectorResult<SqlSchema> {
         let database_name = format!("prisma_shadow_db{}", uuid::Uuid::new_v4());
         let drop_database = format!("DROP DATABASE IF EXISTS `{}`", database_name);
         let create_database = format!("CREATE DATABASE `{}`", database_name);
 
-        catch(
-            connection_info,
-            connection.raw_cmd(&drop_database).map_err(SqlError::from),
-        )
-        .await?;
-        catch(
-            connection_info,
-            connection.raw_cmd(&create_database).map_err(SqlError::from),
-        )
-        .await?;
+        connection.raw_cmd(&drop_database).await?;
+        connection.raw_cmd(&create_database).await?;
 
         let mut temporary_database_url = self.0.url().clone();
         temporary_database_url.set_path(&format!("/{}", database_name));
@@ -178,11 +146,9 @@ impl SqlFlavour for MysqlFlavour {
 
         tracing::debug!("Connecting to temporary database at {:?}", temporary_database_url);
 
-        let quaint = catch(
-            connection_info,
-            Quaint::new(&temporary_database_url).map_err(SqlError::from),
-        )
-        .await?;
+        let (quaint, _database_info) = crate::connect(&temporary_database_url).await?;
+
+        let temp_database = Connection::new(&quaint);
 
         for migration in migrations {
             let script = migration
@@ -194,27 +160,16 @@ impl SqlFlavour for MysqlFlavour {
                 migration.migration_name()
             );
 
-            catch(
-                quaint.connection_info(),
-                quaint.raw_cmd(&script).map_err(SqlError::from),
-            )
-            .await
-            .map_err(|connector_error| connector_error.into_migration_failed(migration.migration_name().to_owned()))?;
+            temp_database.raw_cmd(&script).await.map_err(|connector_error| {
+                connector_error.into_migration_failed(migration.migration_name().to_owned())
+            })?;
         }
 
         let connection_info = quaint.connection_info().clone();
 
-        let sql_schema = catch(
-            &connection_info,
-            self.describe_schema(connection_info.schema_name(), quaint),
-        )
-        .await?;
+        let sql_schema = self.describe_schema(connection_info.schema_name(), quaint).await?;
 
-        catch(
-            &connection_info,
-            connection.raw_cmd(&drop_database).map_err(SqlError::from),
-        )
-        .await?;
+        connection.raw_cmd(&drop_database).await?;
 
         Ok(sql_schema)
     }

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/mysql.rs
@@ -145,9 +145,7 @@ impl SqlFlavour for MysqlFlavour {
         let temp_database = crate::connect(&temporary_database_url).await?;
 
         for migration in migrations {
-            let script = migration
-                .read_migration_script()
-                .expect("failed to read migration script");
+            let script = migration.read_migration_script()?;
 
             tracing::debug!(
                 "Applying migration `{}` to temporary database.",

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/mysql.rs
@@ -1,7 +1,7 @@
 use super::SqlFlavour;
 use crate::{
     connect, connection_wrapper::Connection, database_info::DatabaseInfo, error::CheckDatabaseInfoResult,
-    error::SystemDatabase, SqlError,
+    error::SystemDatabase,
 };
 use migration_connector::{ConnectorError, ConnectorResult, MigrationDirectory};
 use once_cell::sync::Lazy;
@@ -62,8 +62,8 @@ impl SqlFlavour for MysqlFlavour {
         sql_schema_describer::mysql::SqlSchemaDescriber::new(connection.quaint().clone())
             .describe(connection.connection_info().schema_name())
             .await
-            .map_err(SqlError::from)
-            .map_err(|err| err.into_connector_error(connection.connection_info()))
+            .map_err(anyhow::Error::from)
+            .map_err(ConnectorError::query_error)
     }
 
     async fn ensure_connection_validity(&self, connection: &Connection) -> ConnectorResult<()> {

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/postgres.rs
@@ -182,9 +182,7 @@ impl SqlFlavour for PostgresFlavour {
         temporary_database.raw_cmd(&create_schema).await?;
 
         for migration in migrations {
-            let script = migration
-                .read_migration_script()
-                .expect("failed to read migration script");
+            let script = migration.read_migration_script()?;
 
             tracing::debug!(
                 "Applying migration `{}` to temporary database.",

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/postgres.rs
@@ -136,18 +136,14 @@ impl SqlFlavour for PostgresFlavour {
     }
 
     async fn reset(&self, connection: &Connection) -> ConnectorResult<()> {
+        let schema_name = connection.connection_info().schema_name();
+
         connection
-            .raw_cmd(&format!(
-                "DROP SCHEMA \"{}\" CASCADE",
-                connection.connection_info().schema_name()
-            ))
+            .raw_cmd(&format!("DROP SCHEMA \"{}\" CASCADE", schema_name))
             .await?;
 
         connection
-            .raw_cmd(&format!(
-                "CREATE SCHEMA \"{}\"",
-                connection.connection_info().schema_name()
-            ))
+            .raw_cmd(&format!("CREATE SCHEMA \"{}\"", schema_name))
             .await?;
 
         Ok(())

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/postgres.rs
@@ -1,5 +1,5 @@
 use super::SqlFlavour;
-use crate::{connect, connection_wrapper::Connection, SqlError};
+use crate::{connect, connection_wrapper::Connection};
 use migration_connector::{ConnectorError, ConnectorResult, ErrorKind, MigrationDirectory};
 use quaint::{connector::PostgresUrl, prelude::SqlFamily};
 use sql_schema_describer::{SqlSchema, SqlSchemaDescriberBackend};
@@ -60,8 +60,8 @@ impl SqlFlavour for PostgresFlavour {
         sql_schema_describer::postgres::SqlSchemaDescriber::new(connection.quaint().clone())
             .describe(connection.connection_info().schema_name())
             .await
-            .map_err(SqlError::from)
-            .map_err(|err| err.into_connector_error(connection.connection_info()))
+            .map_err(anyhow::Error::from)
+            .map_err(ConnectorError::query_error)
     }
 
     async fn ensure_connection_validity(&self, connection: &Connection) -> ConnectorResult<()> {

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/sqlite.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/sqlite.rs
@@ -126,9 +126,7 @@ impl SqlFlavour for SqliteFlavour {
         let conn = crate::connect(&database_url).await?;
 
         for migration in migrations {
-            let script = migration
-                .read_migration_script()
-                .expect("failed to read migration script");
+            let script = migration.read_migration_script()?;
 
             tracing::debug!(
                 "Applying migration `{}` to temporary database.",

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/sqlite.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/sqlite.rs
@@ -1,8 +1,8 @@
 use super::SqlFlavour;
-use crate::{catch, connect, SqlError, SqlResult};
+use crate::{connect, connection_wrapper::Connection, SqlError};
 use futures::TryFutureExt;
 use migration_connector::{ConnectorError, ConnectorResult, ErrorKind, MigrationDirectory};
-use quaint::{prelude::ConnectionInfo, prelude::Queryable, prelude::SqlFamily, single::Quaint};
+use quaint::{prelude::SqlFamily, single::Quaint};
 use sql_schema_describer::{SqlSchema, SqlSchemaDescriberBackend};
 use std::path::Path;
 
@@ -41,21 +41,19 @@ impl SqlFlavour for SqliteFlavour {
         Ok(self.file_path.clone())
     }
 
-    async fn describe_schema<'a>(&'a self, schema_name: &'a str, conn: Quaint) -> SqlResult<SqlSchema> {
-        Ok(sql_schema_describer::sqlite::SqlSchemaDescriber::new(conn)
+    async fn describe_schema<'a>(&'a self, schema_name: &'a str, conn: Quaint) -> ConnectorResult<SqlSchema> {
+        Ok(sql_schema_describer::sqlite::SqlSchemaDescriber::new(conn.clone())
             .describe(schema_name)
+            .map_err(SqlError::from)
+            .map_err(|err| err.into_connector_error(conn.connection_info()))
             .await?)
     }
 
-    async fn ensure_connection_validity(&self, _connection: &Quaint) -> ConnectorResult<()> {
+    async fn ensure_connection_validity(&self, _connection: Connection<'_>) -> ConnectorResult<()> {
         Ok(())
     }
 
-    async fn ensure_imperative_migrations_table(
-        &self,
-        connection: &dyn Queryable,
-        connection_info: &ConnectionInfo,
-    ) -> ConnectorResult<()> {
+    async fn ensure_imperative_migrations_table(&self, connection: Connection<'_>) -> ConnectorResult<()> {
         let sql = format!(
             r#"
             CREATE TABLE IF NOT EXISTS "{}"."_prisma_migrations" (
@@ -69,11 +67,11 @@ impl SqlFlavour for SqliteFlavour {
                 "applied_steps_count"   INTEGER UNSIGNED NOT NULL DEFAULT 0,
                 "script"                TEXT NOT NULL
             );
-        "#,
+            "#,
             self.attached_name()
         );
 
-        catch(connection_info, connection.raw_cmd(&sql).map_err(SqlError::from)).await
+        connection.raw_cmd(sql).await
     }
 
     async fn qe_setup(&self, _database_url: &str) -> ConnectorResult<()> {
@@ -82,8 +80,8 @@ impl SqlFlavour for SqliteFlavour {
         Ok(())
     }
 
-    async fn reset(&self, conn: &dyn Queryable, connection_info: &ConnectionInfo) -> ConnectorResult<()> {
-        let file_path = connection_info.file_path().unwrap();
+    async fn reset(&self, connection: Connection<'_>) -> ConnectorResult<()> {
+        let file_path = connection.connection_info().file_path().unwrap();
 
         std::fs::remove_file(file_path).map_err(|err| {
             ConnectorError::from_kind(ErrorKind::Generic(anyhow::anyhow!(
@@ -93,22 +91,16 @@ impl SqlFlavour for SqliteFlavour {
             )))
         })?;
 
-        catch(
-            connection_info,
-            conn.execute_raw("DETACH ?", &[connection_info.schema_name().into()])
-                .map_err(SqlError::from),
-        )
-        .await?;
+        connection
+            .execute_raw("DETACH ?", &[connection.connection_info().schema_name().into()])
+            .await?;
 
-        catch(
-            connection_info,
-            conn.execute_raw(
+        connection
+            .execute_raw(
                 "ATTACH DATABASE ? AS ?",
-                &[file_path.into(), connection_info.schema_name().into()],
+                &[file_path.into(), connection.connection_info().schema_name().into()],
             )
-            .map_err(SqlError::from),
-        )
-        .await?;
+            .await?;
 
         Ok(())
     }
@@ -117,12 +109,11 @@ impl SqlFlavour for SqliteFlavour {
         SqlFamily::Sqlite
     }
 
-    #[tracing::instrument(skip(self, migrations, _connection, _connection_info))]
+    #[tracing::instrument(skip(self, migrations, _connection))]
     async fn sql_schema_from_migration_history(
         &self,
         migrations: &[MigrationDirectory],
-        _connection: &dyn Queryable,
-        _connection_info: &ConnectionInfo,
+        _connection: Connection<'_>,
     ) -> ConnectorResult<SqlSchema> {
         let temp_dir = tempfile::tempdir().expect("Failed to create temporary directory.");
         let database_url = format!(
@@ -133,9 +124,8 @@ impl SqlFlavour for SqliteFlavour {
 
         tracing::debug!("Applying migrations to temporary SQLite database at `{}`", database_url);
 
-        let connection_info = ConnectionInfo::from_url(&database_url)
-            .map_err(|err| ConnectorError::url_parse_error(err, &database_url))?;
-        let conn = catch(&connection_info, Quaint::new(&database_url).map_err(SqlError::from)).await?;
+        let (conn, _) = crate::connect(&database_url).await?;
+        let conn = Connection::new(&conn);
 
         for migration in migrations {
             let script = migration
@@ -147,18 +137,12 @@ impl SqlFlavour for SqliteFlavour {
                 migration.migration_name()
             );
 
-            catch(conn.connection_info(), conn.raw_cmd(&script).map_err(SqlError::from))
-                .await
-                .map_err(|connector_error| {
-                    connector_error.into_migration_failed(migration.migration_name().to_owned())
-                })?;
+            conn.raw_cmd(&script).await.map_err(|connector_error| {
+                connector_error.into_migration_failed(migration.migration_name().to_owned())
+            })?;
         }
 
-        let sql_schema = catch(
-            &conn.connection_info().clone(),
-            self.describe_schema(&self.attached_name, conn),
-        )
-        .await?;
+        let sql_schema = self.describe_schema(&self.attached_name, conn.quaint().clone()).await?;
 
         Ok(sql_schema)
     }

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/sqlite.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/sqlite.rs
@@ -49,11 +49,11 @@ impl SqlFlavour for SqliteFlavour {
             .await?)
     }
 
-    async fn ensure_connection_validity(&self, _connection: Connection<'_>) -> ConnectorResult<()> {
+    async fn ensure_connection_validity(&self, _connection: &Connection) -> ConnectorResult<()> {
         Ok(())
     }
 
-    async fn ensure_imperative_migrations_table(&self, connection: Connection<'_>) -> ConnectorResult<()> {
+    async fn ensure_imperative_migrations_table(&self, connection: &Connection) -> ConnectorResult<()> {
         let sql = format!(
             r#"
             CREATE TABLE IF NOT EXISTS "{}"."_prisma_migrations" (
@@ -80,7 +80,7 @@ impl SqlFlavour for SqliteFlavour {
         Ok(())
     }
 
-    async fn reset(&self, connection: Connection<'_>) -> ConnectorResult<()> {
+    async fn reset(&self, connection: &Connection) -> ConnectorResult<()> {
         let file_path = connection.connection_info().file_path().unwrap();
 
         std::fs::remove_file(file_path).map_err(|err| {
@@ -113,7 +113,7 @@ impl SqlFlavour for SqliteFlavour {
     async fn sql_schema_from_migration_history(
         &self,
         migrations: &[MigrationDirectory],
-        _connection: Connection<'_>,
+        _connection: &Connection,
     ) -> ConnectorResult<SqlSchema> {
         let temp_dir = tempfile::tempdir().expect("Failed to create temporary directory.");
         let database_url = format!(
@@ -125,7 +125,6 @@ impl SqlFlavour for SqliteFlavour {
         tracing::debug!("Applying migrations to temporary SQLite database at `{}`", database_url);
 
         let (conn, _) = crate::connect(&database_url).await?;
-        let conn = Connection::new(&conn);
 
         for migration in migrations {
             let script = migration

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/sqlite.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/sqlite.rs
@@ -73,7 +73,7 @@ impl SqlFlavour for SqliteFlavour {
             self.attached_name()
         );
 
-        connection.raw_cmd(sql).await
+        connection.raw_cmd(&sql).await
     }
 
     async fn qe_setup(&self, _database_url: &str) -> ConnectorResult<()> {

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/sqlite.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/sqlite.rs
@@ -1,5 +1,5 @@
 use super::SqlFlavour;
-use crate::{connect, connection_wrapper::Connection, SqlError};
+use crate::{connect, connection_wrapper::Connection};
 use migration_connector::{ConnectorError, ConnectorResult, ErrorKind, MigrationDirectory};
 use quaint::prelude::SqlFamily;
 use sql_schema_describer::{SqlSchema, SqlSchemaDescriberBackend};
@@ -44,8 +44,8 @@ impl SqlFlavour for SqliteFlavour {
         sql_schema_describer::sqlite::SqlSchemaDescriber::new(connection.quaint().clone())
             .describe(connection.connection_info().schema_name())
             .await
-            .map_err(SqlError::from)
-            .map_err(|err| err.into_connector_error(connection.connection_info()))
+            .map_err(anyhow::Error::from)
+            .map_err(ConnectorError::query_error)
     }
 
     async fn ensure_connection_validity(&self, _connection: &Connection) -> ConnectorResult<()> {

--- a/migration-engine/connectors/sql-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/lib.rs
@@ -19,7 +19,7 @@ mod sql_schema_calculator;
 mod sql_schema_differ;
 
 use connection_wrapper::Connection;
-use error::SqlError;
+use error::quaint_error_to_connector_error;
 pub use sql_migration_persistence::MIGRATION_TABLE_NAME;
 
 use component::Component;
@@ -148,8 +148,7 @@ async fn connect(database_str: &str) -> ConnectorResult<Connection> {
 
     let connection = Quaint::new(database_str)
         .await
-        .map_err(SqlError::from)
-        .map_err(|err: SqlError| err.into_connector_error(&connection_info))?;
+        .map_err(|err| quaint_error_to_connector_error(err, &connection_info))?;
 
     Ok(Connection::new(connection))
 }

--- a/migration-engine/connectors/sql-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/lib.rs
@@ -19,7 +19,7 @@ mod sql_schema_calculator;
 mod sql_schema_differ;
 
 use connection_wrapper::Connection;
-use error::{SqlError, SqlResult};
+use error::SqlError;
 pub use sql_migration_persistence::MIGRATION_TABLE_NAME;
 
 use component::Component;
@@ -150,9 +150,7 @@ async fn connect(database_str: &str) -> ConnectorResult<(Connection, DatabaseInf
         .map_err(SqlError::from)
         .map_err(|err: SqlError| err.into_connector_error(&connection_info))?;
 
-    let database_info = DatabaseInfo::new(&connection, connection.connection_info().clone())
-        .await
-        .map_err(|sql_error| sql_error.into_connector_error(&connection_info))?;
+    let database_info = DatabaseInfo::new(&connection, connection.connection_info().clone()).await?;
 
     Ok((Connection::new(connection), database_info))
 }

--- a/migration-engine/connectors/sql-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/lib.rs
@@ -77,10 +77,7 @@ impl SqlMigrationConnector {
     }
 
     async fn describe_schema(&self) -> ConnectorResult<SqlSchema> {
-        let conn = self.connection.quaint().clone();
-        let schema_name = self.schema_name();
-
-        self.flavour.describe_schema(schema_name, conn).await
+        self.flavour.describe_schema(&self.connection).await
     }
 }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker.rs
@@ -10,7 +10,7 @@ pub(crate) use destructive_change_checker_flavour::DestructiveChangeCheckerFlavo
 use crate::{
     sql_migration::{AlterEnum, CreateIndex, DropTable, SqlMigrationStep, TableChange},
     sql_schema_differ::{ColumnDiffer, TableDiffer},
-    Component, SqlMigration, SqlResult,
+    Component, SqlMigration,
 };
 use destructive_check_plan::DestructiveCheckPlan;
 use migration_connector::{ConnectorResult, DestructiveChangeChecker, DestructiveChangeDiagnostics};
@@ -208,7 +208,7 @@ impl SqlDestructiveChangeChecker<'_> {
         steps: &[SqlMigrationStep],
         before: &SqlSchema,
         after: &SqlSchema,
-    ) -> SqlResult<DestructiveChangeDiagnostics> {
+    ) -> ConnectorResult<DestructiveChangeDiagnostics> {
         let plan = self.plan(steps, before, after);
 
         plan.execute(self.schema_name(), self.conn()).await
@@ -218,13 +218,13 @@ impl SqlDestructiveChangeChecker<'_> {
 #[async_trait::async_trait]
 impl DestructiveChangeChecker<SqlMigration> for SqlDestructiveChangeChecker<'_> {
     async fn check(&self, database_migration: &SqlMigration) -> ConnectorResult<DestructiveChangeDiagnostics> {
-        self.check_impl(
+        let plan = self.plan(
             &database_migration.steps,
             &database_migration.before,
             &database_migration.after,
-        )
-        .await
-        .map_err(|sql_error| sql_error.into_connector_error(&self.connection_info()))
+        );
+
+        plan.execute(self.schema_name(), self.conn()).await
     }
 
     fn pure_check(&self, database_migration: &SqlMigration) -> DestructiveChangeDiagnostics {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker.rs
@@ -211,7 +211,7 @@ impl SqlDestructiveChangeChecker<'_> {
     ) -> ConnectorResult<DestructiveChangeDiagnostics> {
         let plan = self.plan(steps, before, after);
 
-        plan.execute(self.schema_name(), self.conn()).await
+        plan.execute(self.conn()).await
     }
 }
 
@@ -224,7 +224,7 @@ impl DestructiveChangeChecker<SqlMigration> for SqlDestructiveChangeChecker<'_> 
             &database_migration.after,
         );
 
-        plan.execute(self.schema_name(), self.conn()).await
+        plan.execute(self.conn()).await
     }
 
     fn pure_check(&self, database_migration: &SqlMigration) -> DestructiveChangeDiagnostics {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_check_plan.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_check_plan.rs
@@ -44,7 +44,7 @@ impl DestructiveCheckPlan {
     pub(super) async fn execute(
         &self,
         schema_name: &str,
-        conn: Connection<'_>,
+        conn: &Connection,
     ) -> ConnectorResult<DestructiveChangeDiagnostics> {
         let mut results = DatabaseInspectionResults::default();
 
@@ -96,7 +96,7 @@ impl DestructiveCheckPlan {
         check: &(dyn Check + Send + Sync + 'static),
         results: &mut DatabaseInspectionResults,
         schema_name: &str,
-        conn: Connection<'_>,
+        conn: &Connection,
     ) -> ConnectorResult<()> {
         if let Some(table) = check.needed_table_row_count() {
             if results.get_row_count(table).is_none() {
@@ -146,7 +146,7 @@ impl DestructiveCheckPlan {
     }
 }
 
-async fn count_rows_in_table(table_name: &str, schema_name: &str, conn: Connection<'_>) -> ConnectorResult<i64> {
+async fn count_rows_in_table(table_name: &str, schema_name: &str, conn: &Connection) -> ConnectorResult<i64> {
     use quaint::ast::*;
 
     let query = Select::from_table((schema_name, table_name)).value(count(asterisk()));
@@ -175,7 +175,7 @@ async fn count_values_in_column(
     column_name: &str,
     table: &str,
     schema_name: &str,
-    conn: Connection<'_>,
+    conn: &Connection,
 ) -> ConnectorResult<i64> {
     use quaint::ast::*;
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_check_plan.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_check_plan.rs
@@ -40,22 +40,17 @@ impl DestructiveCheckPlan {
     /// errors.
     ///
     /// For example, dropping a table that has 0 rows can be considered safe.
-    #[tracing::instrument(skip(conn, schema_name), level = "debug")]
-    pub(super) async fn execute(
-        &self,
-        schema_name: &str,
-        conn: &Connection,
-    ) -> ConnectorResult<DestructiveChangeDiagnostics> {
+    #[tracing::instrument(skip(conn), level = "debug")]
+    pub(super) async fn execute(&self, conn: &Connection) -> ConnectorResult<DestructiveChangeDiagnostics> {
         let mut results = DatabaseInspectionResults::default();
 
         let inspection = async {
             for (unexecutable, _idx) in &self.unexecutable_migrations {
-                self.inspect_for_check(unexecutable, &mut results, schema_name, conn)
-                    .await?;
+                self.inspect_for_check(unexecutable, &mut results, conn).await?;
             }
 
             for (warning, _idx) in &self.warnings {
-                self.inspect_for_check(warning, &mut results, schema_name, conn).await?;
+                self.inspect_for_check(warning, &mut results, conn).await?;
             }
 
             Ok::<(), ConnectorError>(())
@@ -95,19 +90,18 @@ impl DestructiveCheckPlan {
         &self,
         check: &(dyn Check + Send + Sync + 'static),
         results: &mut DatabaseInspectionResults,
-        schema_name: &str,
         conn: &Connection,
     ) -> ConnectorResult<()> {
         if let Some(table) = check.needed_table_row_count() {
             if results.get_row_count(table).is_none() {
-                let count = count_rows_in_table(table, schema_name, conn).await?;
+                let count = count_rows_in_table(table, conn).await?;
                 results.set_row_count(table.to_owned(), count)
             }
         }
 
         if let Some((table, column)) = check.needed_column_value_count() {
             if let (_, None) = results.get_row_and_non_null_value_count(table, column) {
-                let count = count_values_in_column(column, table, schema_name, conn).await?;
+                let count = count_values_in_column(column, table, conn).await?;
                 results.set_value_count(table.to_owned().into(), column.to_owned().into(), count);
             }
         }
@@ -146,10 +140,10 @@ impl DestructiveCheckPlan {
     }
 }
 
-async fn count_rows_in_table(table_name: &str, schema_name: &str, conn: &Connection) -> ConnectorResult<i64> {
+async fn count_rows_in_table(table_name: &str, conn: &Connection) -> ConnectorResult<i64> {
     use quaint::ast::*;
 
-    let query = Select::from_table((schema_name, table_name)).value(count(asterisk()));
+    let query = Select::from_table((conn.connection_info().schema_name(), table_name)).value(count(asterisk()));
     let result_set = conn.query(query).await?;
     let rows_count = result_set
         .first()
@@ -171,15 +165,10 @@ async fn count_rows_in_table(table_name: &str, schema_name: &str, conn: &Connect
     Ok(rows_count)
 }
 
-async fn count_values_in_column(
-    column_name: &str,
-    table: &str,
-    schema_name: &str,
-    conn: &Connection,
-) -> ConnectorResult<i64> {
+async fn count_values_in_column(column_name: &str, table: &str, conn: &Connection) -> ConnectorResult<i64> {
     use quaint::ast::*;
 
-    let query = Select::from_table((schema_name, table))
+    let query = Select::from_table((conn.connection_info().schema_name(), table))
         .value(count(quaint::ast::Column::new(column_name)))
         .so_that(column_name.is_not_null());
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_imperative_migration_persistence.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_imperative_migration_persistence.rs
@@ -1,4 +1,4 @@
-use crate::{component::Component, SqlError, SqlMigrationConnector};
+use crate::{component::Component, error::quaint_error_to_connector_error, SqlMigrationConnector};
 use migration_connector::{ConnectorResult, FormatChecksum, ImperativeMigrationsPersistence, MigrationRecord};
 use quaint::ast::*;
 use sha2::{Digest, Sha256};
@@ -86,8 +86,7 @@ impl ImperativeMigrationsPersistence for SqlMigrationConnector {
         let result = self.conn().query(select).await?;
 
         let rows = quaint::serde::from_rows(result)
-            .map_err(SqlError::from)
-            .map_err(|err| err.into_connector_error(self.connection_info()))?;
+            .map_err(|err| quaint_error_to_connector_error(err, self.connection_info()))?;
 
         Ok(rows)
     }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_migration_persistence.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_migration_persistence.rs
@@ -170,7 +170,7 @@ impl MigrationPersistence for SqlMigrationPersistence<'_> {
 
 /// Returns the last 2 applied migrations, or a shorter vec in absence of applied migrations.
 async fn last_applied_migrations(
-    conn: Connection<'_>,
+    conn: &Connection,
     table: Table<'_>,
 ) -> ConnectorResult<(Option<Migration>, Option<Migration>)> {
     let conditions = STATUS_COLUMN.equals(MigrationStatus::MigrationSuccess.code());

--- a/migration-engine/connectors/sql-migration-connector/src/sql_migration_persistence.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_migration_persistence.rs
@@ -1,14 +1,9 @@
-use crate::{Component, SqlError};
+use crate::{connection_wrapper::Connection, Component};
 use barrel::types;
 use chrono::*;
-use futures::TryFutureExt;
 use migration_connector::*;
 use quaint::ast::*;
-use quaint::{
-    connector::ResultSet,
-    error::Error as QuaintError,
-    prelude::{Queryable, SqlFamily},
-};
+use quaint::{connector::ResultSet, prelude::SqlFamily};
 use std::convert::TryFrom;
 
 pub struct SqlMigrationPersistence<'a> {
@@ -24,6 +19,7 @@ impl Component for SqlMigrationPersistence<'_> {
 #[async_trait::async_trait]
 impl MigrationPersistence for SqlMigrationPersistence<'_> {
     async fn init(&self) -> Result<(), ConnectorError> {
+<<<<<<< HEAD
         let fut = async {
             let sql_str = match self.sql_family() {
                 SqlFamily::Sqlite => {
@@ -51,54 +47,62 @@ impl MigrationPersistence for SqlMigrationPersistence<'_> {
             self.conn().raw_cmd(&sql_str).await.ok();
 
             Ok(())
+=======
+        let sql_str = match self.sql_family() {
+            SqlFamily::Sqlite => {
+                let mut m = barrel::Migration::new().schema(self.schema_name());
+                m.create_table_if_not_exists(MIGRATION_TABLE_NAME, migration_table_setup_sqlite);
+                m.make_from(barrel::SqlVariant::Sqlite)
+            }
+            SqlFamily::Postgres => {
+                let mut m = barrel::Migration::new().schema(self.schema_name());
+                m.create_table(MIGRATION_TABLE_NAME, migration_table_setup_postgres);
+                m.schema(self.schema_name()).make_from(barrel::SqlVariant::Pg)
+            }
+            SqlFamily::Mysql => {
+                let mut m = barrel::Migration::new().schema(self.schema_name());
+                m.create_table(MIGRATION_TABLE_NAME, migration_table_setup_mysql);
+                m.make_from(barrel::SqlVariant::Mysql)
+            }
+            SqlFamily::Mssql => todo!("Greetings from Detroit^H Redmond"),
+>>>>>>> 105750539... Simplify error handling in sql-migration-connector
         };
 
-        crate::catch(self.connection_info(), fut).await
+        self.conn().raw_cmd(&sql_str).await.ok();
+
+        Ok(())
     }
 
-    async fn reset(&self) -> Result<(), ConnectorError> {
+    async fn reset(&self) -> ConnectorResult<()> {
         use quaint::ast::Delete;
 
-        crate::catch(self.connection_info(), async {
-            self.conn()
-                .query(Delete::from_table((self.schema_name(), MIGRATION_TABLE_NAME)).into())
-                .await
-                .ok();
+        self.conn()
+            .query(Delete::from_table((self.schema_name(), MIGRATION_TABLE_NAME)))
+            .await
+            .ok();
 
-            Ok(())
-        })
-        .await
+        Ok(())
     }
 
     async fn last_two_migrations(&self) -> ConnectorResult<(Option<Migration>, Option<Migration>)> {
-        crate::catch(
-            self.connection_info(),
-            last_applied_migrations(self.conn(), self.table()).map_err(SqlError::from),
-        )
-        .await
+        last_applied_migrations(self.conn(), self.table()).await
     }
 
-    async fn load_all(&self) -> Result<Vec<Migration>, ConnectorError> {
-        crate::catch(self.connection_info(), async {
-            let query = Select::from_table(self.table()).order_by(REVISION_COLUMN.ascend());
+    async fn load_all(&self) -> ConnectorResult<Vec<Migration>> {
+        let query = Select::from_table(self.table()).order_by(REVISION_COLUMN.ascend());
+        let result_set = self.conn().query(query).await?;
 
-            let result_set = self.conn().query(query.into()).await?;
-            Ok(parse_rows_new(result_set))
-        })
-        .await
+        Ok(parse_rows_new(result_set))
     }
 
-    async fn by_name(&self, name: &str) -> Result<Option<Migration>, ConnectorError> {
-        crate::catch(self.connection_info(), async {
-            let conditions = NAME_COLUMN.equals(name);
-            let query = Select::from_table(self.table())
-                .so_that(conditions)
-                .order_by(REVISION_COLUMN.descend());
+    async fn by_name(&self, name: &str) -> ConnectorResult<Option<Migration>> {
+        let conditions = NAME_COLUMN.equals(name);
+        let query = Select::from_table(self.table())
+            .so_that(conditions)
+            .order_by(REVISION_COLUMN.descend());
+        let result_set = self.conn().query(query).await?;
 
-            let result_set = self.conn().query(query.into()).await?;
-            Ok(parse_rows_new(result_set).into_iter().next())
-        })
-        .await
+        Ok(parse_rows_new(result_set).into_iter().next())
     }
 
     async fn create(&self, migration: Migration) -> Result<Migration, ConnectorError> {
@@ -121,14 +125,14 @@ impl MigrationPersistence for SqlMigrationPersistence<'_> {
 
         match self.sql_family() {
             SqlFamily::Sqlite | SqlFamily::Mysql => {
-                let result_set = self.conn().insert(insert.into()).await.unwrap();
+                let result_set = self.conn().query(insert).await.unwrap();
                 let id = result_set.last_insert_id().unwrap();
 
                 cloned.revision = usize::try_from(id).unwrap();
             }
             SqlFamily::Postgres | SqlFamily::Mssql => {
                 let returning_insert = Insert::from(insert).returning(&["revision"]);
-                let result_set = self.conn().query(returning_insert.into()).await.unwrap();
+                let result_set = self.conn().query(returning_insert).await.unwrap();
 
                 if let Some(row) = result_set.into_iter().next() {
                     cloned.revision = row["revision"].as_i64().unwrap() as usize;
@@ -140,45 +144,42 @@ impl MigrationPersistence for SqlMigrationPersistence<'_> {
     }
 
     async fn update(&self, params: &MigrationUpdateParams) -> Result<(), ConnectorError> {
-        crate::catch(self.connection_info(), async {
-            let finished_at_value = match params.finished_at {
-                Some(x) => self.convert_datetime(x),
-                None => Value::from(Option::<DateTime<Utc>>::None),
-            };
-            let errors_json = serde_json::to_string(&params.errors).unwrap();
-            let query = Update::table(self.table())
-                .set(NAME_COLUMN, params.new_name.clone())
-                .set(STATUS_COLUMN, params.status.code())
-                .set(APPLIED_COLUMN, params.applied)
-                .set(ROLLED_BACK_COLUMN, params.rolled_back)
-                .set(ERRORS_COLUMN, errors_json)
-                .set(FINISHED_AT_COLUMN, finished_at_value)
-                .so_that(
-                    NAME_COLUMN
-                        .equals(params.name.clone())
-                        .and(REVISION_COLUMN.equals(params.revision)),
-                );
+        let finished_at_value = match params.finished_at {
+            Some(x) => self.convert_datetime(x),
+            None => Value::from(Option::<DateTime<Utc>>::None),
+        };
+        let errors_json = serde_json::to_string(&params.errors).unwrap();
+        let query = Update::table(self.table())
+            .set(NAME_COLUMN, params.new_name.clone())
+            .set(STATUS_COLUMN, params.status.code())
+            .set(APPLIED_COLUMN, params.applied)
+            .set(ROLLED_BACK_COLUMN, params.rolled_back)
+            .set(ERRORS_COLUMN, errors_json)
+            .set(FINISHED_AT_COLUMN, finished_at_value)
+            .so_that(
+                NAME_COLUMN
+                    .equals(params.name.clone())
+                    .and(REVISION_COLUMN.equals(params.revision)),
+            );
 
-            self.conn().query(query.into()).await?;
+        self.conn().query(query).await?;
 
-            Ok(())
-        })
-        .await
+        Ok(())
     }
 }
 
 /// Returns the last 2 applied migrations, or a shorter vec in absence of applied migrations.
 async fn last_applied_migrations(
-    conn: &dyn Queryable,
+    conn: Connection<'_>,
     table: Table<'_>,
-) -> Result<(Option<Migration>, Option<Migration>), QuaintError> {
+) -> ConnectorResult<(Option<Migration>, Option<Migration>)> {
     let conditions = STATUS_COLUMN.equals(MigrationStatus::MigrationSuccess.code());
     let query = Select::from_table(table)
         .so_that(conditions)
         .order_by(REVISION_COLUMN.descend())
         .limit(2);
 
-    let result_set = conn.query(query.into()).await?;
+    let result_set = conn.query(query).await?;
     let mut rows = parse_rows_new(result_set).into_iter();
     let last = rows.next();
     let second_to_last = rows.next();

--- a/migration-engine/connectors/sql-migration-connector/src/sql_migration_persistence.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_migration_persistence.rs
@@ -19,35 +19,6 @@ impl Component for SqlMigrationPersistence<'_> {
 #[async_trait::async_trait]
 impl MigrationPersistence for SqlMigrationPersistence<'_> {
     async fn init(&self) -> Result<(), ConnectorError> {
-<<<<<<< HEAD
-        let fut = async {
-            let sql_str = match self.sql_family() {
-                SqlFamily::Sqlite => {
-                    let mut m = barrel::Migration::new().schema(self.schema_name());
-                    m.create_table_if_not_exists(MIGRATION_TABLE_NAME, migration_table_setup_sqlite);
-                    m.make_from(barrel::SqlVariant::Sqlite)
-                }
-                SqlFamily::Postgres => {
-                    let mut m = barrel::Migration::new().schema(self.schema_name());
-                    m.create_table(MIGRATION_TABLE_NAME, migration_table_setup_postgres);
-                    m.schema(self.schema_name()).make_from(barrel::SqlVariant::Pg)
-                }
-                SqlFamily::Mysql => {
-                    let mut m = barrel::Migration::new().schema(self.schema_name());
-                    m.create_table(MIGRATION_TABLE_NAME, migration_table_setup_mysql);
-                    m.make_from(barrel::SqlVariant::Mysql)
-                }
-                SqlFamily::Mssql => {
-                    let mut m = barrel::Migration::new().schema(self.schema_name());
-                    m.create_table_if_not_exists(MIGRATION_TABLE_NAME, migration_table_setup_mssql);
-                    m.make_from(barrel::SqlVariant::Mssql)
-                }
-            };
-
-            self.conn().raw_cmd(&sql_str).await.ok();
-
-            Ok(())
-=======
         let sql_str = match self.sql_family() {
             SqlFamily::Sqlite => {
                 let mut m = barrel::Migration::new().schema(self.schema_name());
@@ -64,8 +35,11 @@ impl MigrationPersistence for SqlMigrationPersistence<'_> {
                 m.create_table(MIGRATION_TABLE_NAME, migration_table_setup_mysql);
                 m.make_from(barrel::SqlVariant::Mysql)
             }
-            SqlFamily::Mssql => todo!("Greetings from Detroit^H Redmond"),
->>>>>>> 105750539... Simplify error handling in sql-migration-connector
+            SqlFamily::Mssql => {
+                let mut m = barrel::Migration::new().schema(self.schema_name());
+                m.create_table_if_not_exists(MIGRATION_TABLE_NAME, migration_table_setup_mssql);
+                m.make_from(barrel::SqlVariant::Mssql)
+            }
         };
 
         self.conn().raw_cmd(&sql_str).await.ok();

--- a/migration-engine/core/src/commands/apply_migrations.rs
+++ b/migration-engine/core/src/commands/apply_migrations.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use super::{CommandError, CommandResult, MigrationCommand};
 use crate::migration_engine::MigrationEngine;
-use migration_connector::{MigrationDirectory, MigrationRecord};
+use migration_connector::{ConnectorError, MigrationDirectory, MigrationRecord};
 use serde::{Deserialize, Serialize};
 
 /// The input to the `ApplyMigrations` command.
@@ -63,7 +63,7 @@ impl<'a> MigrationCommand for ApplyMigrationsCommand {
         for unapplied_migration in unapplied_migrations {
             let script = unapplied_migration
                 .read_migration_script()
-                .expect("Failed to read the migration script.");
+                .map_err(ConnectorError::from)?;
 
             tracing::info!(
                 script = script.as_str(),

--- a/migration-engine/migration-engine-tests/src/test_api.rs
+++ b/migration-engine/migration-engine-tests/src/test_api.rs
@@ -343,7 +343,7 @@ pub async fn mysql_8_test_api(db_name: &str) -> TestApi {
     TestApi {
         connector_name: "mysql_8",
         connection_info,
-        database: connector.database.clone(),
+        database: connector.quaint().clone(),
         api: test_api(connector).await,
     }
 }
@@ -356,7 +356,7 @@ pub async fn mysql_5_6_test_api(db_name: &str) -> TestApi {
     TestApi {
         connector_name: "mysql_5_6",
         connection_info,
-        database: connector.database.clone(),
+        database: connector.quaint().clone(),
         api: test_api(connector).await,
     }
 }
@@ -369,7 +369,7 @@ pub async fn mysql_test_api(db_name: &str) -> TestApi {
     TestApi {
         connector_name: "mysql",
         connection_info,
-        database: connector.database.clone(),
+        database: connector.quaint().clone(),
         api: test_api(connector).await,
     }
 }
@@ -382,7 +382,7 @@ pub async fn mysql_mariadb_test_api(db_name: &str) -> TestApi {
     TestApi {
         connector_name: "mysql_mariadb",
         connection_info,
-        database: connector.database.clone(),
+        database: connector.quaint().clone(),
         api: test_api(connector).await,
     }
 }
@@ -395,7 +395,7 @@ pub async fn postgres9_test_api(db_name: &str) -> TestApi {
     TestApi {
         connector_name: "postgres9",
         connection_info,
-        database: connector.database.clone(),
+        database: connector.quaint().clone(),
         api: test_api(connector).await,
     }
 }
@@ -408,7 +408,7 @@ pub async fn postgres_test_api(db_name: &str) -> TestApi {
     TestApi {
         connector_name: "postgres",
         connection_info,
-        database: connector.database.clone(),
+        database: connector.quaint().clone(),
         api: test_api(connector).await,
     }
 }
@@ -421,7 +421,7 @@ pub async fn postgres11_test_api(db_name: &str) -> TestApi {
     TestApi {
         connector_name: "postgres11",
         connection_info,
-        database: connector.database.clone(),
+        database: connector.quaint().clone(),
         api: test_api(connector).await,
     }
 }
@@ -434,7 +434,7 @@ pub async fn postgres12_test_api(db_name: &str) -> TestApi {
     TestApi {
         connector_name: "postgres12",
         connection_info,
-        database: connector.database.clone(),
+        database: connector.quaint().clone(),
         api: test_api(connector).await,
     }
 }
@@ -447,7 +447,7 @@ pub async fn postgres13_test_api(db_name: &str) -> TestApi {
     TestApi {
         connector_name: "postgres13",
         connection_info,
-        database: connector.database.clone(),
+        database: connector.quaint().clone(),
         api: test_api(connector).await,
     }
 }
@@ -459,7 +459,7 @@ pub async fn sqlite_test_api(db_name: &str) -> TestApi {
     TestApi {
         connector_name: "sqlite",
         connection_info,
-        database: connector.database.clone(),
+        database: connector.quaint().clone(),
         api: test_api(connector).await,
     }
 }


### PR DESCRIPTION
As part of the effort towards https://github.com/prisma/prisma-engines/issues/1129, we need a way to swap the `Quaint` struct in a running migration engine. This is very challenging with a bare `Quaint` connection, so this PR introduces a wrapper as a first step.

This wrapper made a big simplification of the error handling code in sql-migration-connector possible, and this is the main subject of this PR.