### PR TITLE
Fix missing attached name for migrations table on SQLite

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/flavour/sqlite.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/sqlite.rs
@@ -56,8 +56,9 @@ impl SqlFlavour for SqliteFlavour {
         connection: &dyn Queryable,
         connection_info: &ConnectionInfo,
     ) -> ConnectorResult<()> {
-        let sql = r#"
-            CREATE TABLE IF NOT EXISTS "_prisma_migrations" (
+        let sql = format!(
+            r#"
+            CREATE TABLE IF NOT EXISTS "{}"."_prisma_migrations" (
                 "id"                    TEXT PRIMARY KEY NOT NULL,
                 "checksum"              TEXT NOT NULL,
                 "finished_at"           DATETIME,
@@ -68,9 +69,11 @@ impl SqlFlavour for SqliteFlavour {
                 "applied_steps_count"   INTEGER UNSIGNED NOT NULL DEFAULT 0,
                 "script"                TEXT NOT NULL
             );
-        "#;
+        "#,
+            self.attached_name()
+        );
 
-        catch(connection_info, connection.raw_cmd(sql).map_err(SqlError::from)).await
+        catch(connection_info, connection.raw_cmd(&sql).map_err(SqlError::from)).await
     }
 
     async fn qe_setup(&self, _database_url: &str) -> ConnectorResult<()> {

--- a/migration-engine/core/src/migration/datamodel_differ.rs
+++ b/migration-engine/core/src/migration/datamodel_differ.rs
@@ -1,5 +1,3 @@
-#![deny(rust_2018_idioms)]
-
 mod directives;
 mod enum_values;
 mod enums;


### PR DESCRIPTION
Fixes a bug noticed by @Jolg42

This is hard to unit test in the engine, but it would be caught immediately by end-to-end tests.

The migrations table was created in the in-memory database, which was fine in our tests, because we only ever use one connection that we don't close, but if you run the CLI multiple times, it opens a new connection, and the migrations table is gone