### PR TITLE
Change the shape of diagnoseMigrationHistoryOutput

### DIFF
--- a/migration-engine/core/src/commands.rs
+++ b/migration-engine/core/src/commands.rs
@@ -36,7 +36,8 @@ pub use command::{CommandError, CommandResult, MigrationCommand};
 pub use create_migration::{CreateMigrationCommand, CreateMigrationInput, CreateMigrationOutput};
 pub use debug_panic::DebugPanicCommand;
 pub use diagnose_migration_history::{
-    DiagnoseMigrationHistoryCommand, DiagnoseMigrationHistoryInput, DiagnoseMigrationHistoryOutput, HistoryDiagnostic,
+    DiagnoseMigrationHistoryCommand, DiagnoseMigrationHistoryInput, DiagnoseMigrationHistoryOutput, DriftDiagnostic,
+    HistoryDiagnostic,
 };
 pub use get_database_version::*;
 pub use infer_migration_steps::*;


### PR DESCRIPTION
It came out of a discussion with Joël that this is a more convenient
shape for the typescript client. The contents should be strictly the
same, just organized differently.