### PR TITLE
(user-facing-errors) Make KnownError::new() infallible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3220,7 +3220,6 @@ dependencies = [
  "sha2 0.9.1",
  "sql-schema-describer",
  "tempfile",
- "thiserror",
  "tokio",
  "tracing",
  "tracing-error",

--- a/introspection-engine/connectors/sql-introspection-connector/src/error.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/error.rs
@@ -134,17 +134,15 @@ impl SqlError {
                 }
             }
             SqlError::SchemaInconsistent { explanation } => ConnectorError {
-                user_facing_error: KnownError::new(DatabaseSchemaInconsistent {
+                user_facing_error: Some(KnownError::new(DatabaseSchemaInconsistent {
                     explanation: explanation.to_owned(),
-                })
-                .ok(),
+                })),
                 kind: ErrorKind::DatabaseSchemaInconsistent { explanation },
             },
             SqlError::DatabaseUrlIsInvalid(reason) => {
-                let user_facing_error = KnownError::new(common::InvalidDatabaseString {
+                let user_facing_error = Some(KnownError::new(common::InvalidDatabaseString {
                     details: reason.clone(),
-                })
-                .ok();
+                }));
 
                 ConnectorError {
                     user_facing_error,

--- a/introspection-engine/core/src/error_rendering.rs
+++ b/introspection-engine/core/src/error_rendering.rs
@@ -12,12 +12,10 @@ pub fn render_error(crate_error: Error) -> UserFacingError {
             ..
         }) => user_facing_error.into(),
         Error::CommandError(CommandError::IntrospectionResultEmpty(connection_string)) => {
-            KnownError::new(IntrospectionResultEmpty { connection_string })
-                .unwrap()
-                .into()
+            KnownError::new(IntrospectionResultEmpty { connection_string }).into()
         }
         Error::CommandError(CommandError::ReceivedBadDatamodel(full_error)) => {
-            KnownError::new(SchemaParserError { full_error }).unwrap().into()
+            KnownError::new(SchemaParserError { full_error }).into()
         }
         _ => UserFacingError::from_dyn_error(&crate_error),
     }

--- a/libs/user-facing-errors/src/lib.rs
+++ b/libs/user-facing-errors/src/lib.rs
@@ -27,12 +27,12 @@ pub struct KnownError {
 }
 
 impl KnownError {
-    pub fn new<T: UserFacingError>(inner: T) -> Result<KnownError, serde_json::Error> {
-        Ok(KnownError {
+    pub fn new<T: UserFacingError>(inner: T) -> KnownError {
+        KnownError {
             message: inner.message(),
-            meta: serde_json::to_value(&inner)?,
+            meta: serde_json::to_value(&inner).expect("Failed to render user facing error metadata to JSON"),
             error_code: T::ERROR_CODE,
-        })
+        }
     }
 }
 

--- a/migration-engine/cli/src/commands/error.rs
+++ b/migration-engine/cli/src/commands/error.rs
@@ -16,7 +16,7 @@ pub enum CliError {
         exit_code: i32,
     },
 
-    #[error("Unknown error occured: {0}")]
+    #[error("Unknown error occurred: {0}")]
     Other(anyhow::Error),
 }
 

--- a/migration-engine/connectors/migration-connector/src/migrations_directory.rs
+++ b/migration-engine/connectors/migration-connector/src/migrations_directory.rs
@@ -51,9 +51,9 @@ pub fn create_migration_directory(
     Ok(MigrationDirectory { path: directory_path })
 }
 
-/// An IO error that occured while reading the migrations directory.
+/// An IO error that occurred while reading the migrations directory.
 #[derive(Debug, Error)]
-#[error("An error occured when reading the migrations directory.")]
+#[error("An error occurred when reading the migrations directory.")]
 pub struct ListMigrationsError(
     #[source]
     #[from]

--- a/migration-engine/connectors/sql-migration-connector/Cargo.toml
+++ b/migration-engine/connectors/sql-migration-connector/Cargo.toml
@@ -21,10 +21,9 @@ enumflags2 = "0.6.0"
 once_cell = "1.3"
 quaint = { git = "https://github.com/prisma/quaint", features = ["single"] }
 regex = "1"
-serde = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.9.1"
-thiserror = "1.0.9"
 tokio = { version = "=0.2.13", features = ["time"] }
 tracing = "0.1.10"
 tracing-error = "0.1.2"

--- a/migration-engine/connectors/sql-migration-connector/Cargo.toml
+++ b/migration-engine/connectors/sql-migration-connector/Cargo.toml
@@ -24,10 +24,10 @@ regex = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.9.1"
-tokio = { version = "=0.2.13", features = ["time"] }
+tempfile = "3.1.0"
+tokio = { version = "=0.2.13", default-features = false, features = ["time"] }
 tracing = "0.1.10"
 tracing-error = "0.1.2"
 tracing-futures = "0.2.0"
 uuid = { version = "*", features = ["v4"] }
 url = "2.1.1"
-tempfile = "3.1.0"

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/mssql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/mssql.rs
@@ -59,7 +59,7 @@ impl SqlFlavour for MssqlFlavour {
             .await
             .map_err(|err| match err {
                 SqlSchemaDescriberError::UnknownError => {
-                    ConnectorError::query_error(anyhow::anyhow!("An unknown error occured in sql-schema-describer"))
+                    ConnectorError::query_error(anyhow::anyhow!("An unknown error occurred in sql-schema-describer"))
                 }
             })
     }

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/mysql.rs
@@ -64,7 +64,7 @@ impl SqlFlavour for MysqlFlavour {
             .await
             .map_err(|err| match err {
                 SqlSchemaDescriberError::UnknownError => {
-                    ConnectorError::query_error(anyhow::anyhow!("An unknown error occured in sql-schema-describer"))
+                    ConnectorError::query_error(anyhow::anyhow!("An unknown error occurred in sql-schema-describer"))
                 }
             })
     }

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/postgres.rs
@@ -62,7 +62,7 @@ impl SqlFlavour for PostgresFlavour {
             .await
             .map_err(|err| match err {
                 SqlSchemaDescriberError::UnknownError => {
-                    ConnectorError::query_error(anyhow::anyhow!("An unknown error occured in sql-schema-describer"))
+                    ConnectorError::query_error(anyhow::anyhow!("An unknown error occurred in sql-schema-describer"))
                 }
             })
     }

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/sqlite.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/sqlite.rs
@@ -46,7 +46,7 @@ impl SqlFlavour for SqliteFlavour {
             .await
             .map_err(|err| match err {
                 SqlSchemaDescriberError::UnknownError => {
-                    ConnectorError::query_error(anyhow::anyhow!("An unknown error occured in sql-schema-describer"))
+                    ConnectorError::query_error(anyhow::anyhow!("An unknown error occurred in sql-schema-describer"))
                 }
             })
     }

--- a/migration-engine/core/src/api/error_rendering.rs
+++ b/migration-engine/core/src/api/error_rendering.rs
@@ -14,9 +14,7 @@ pub fn render_error(crate_error: CoreError) -> Error {
             ..
         })) => user_facing_error.into(),
         CoreError::CommandError(CommandError::ReceivedBadDatamodel(full_error)) => {
-            KnownError::new(user_facing_errors::common::SchemaParserError { full_error })
-                .unwrap()
-                .into()
+            KnownError::new(user_facing_errors::common::SchemaParserError { full_error }).into()
         }
         _ => Error::from_dyn_error(&crate_error),
     }

--- a/query-engine/connectors/query-connector/src/error.rs
+++ b/query-engine/connectors/query-connector/src/error.rs
@@ -15,19 +15,21 @@ pub struct ConnectorError {
 impl ConnectorError {
     pub fn from_kind(kind: ErrorKind) -> Self {
         let user_facing_error = match &kind {
-            ErrorKind::NullConstraintViolation { constraint } => Some(
-                KnownError::new(user_facing_errors::query_engine::NullConstraintViolation {
+            ErrorKind::NullConstraintViolation { constraint } => Some(KnownError::new(
+                user_facing_errors::query_engine::NullConstraintViolation {
                     constraint: constraint.to_owned(),
-                })
-                .unwrap(),
-            ),
-            ErrorKind::TableDoesNotExist { table } => Some(
-                KnownError::new(user_facing_errors::query_engine::TableDoesNotExist { table: table.clone() }).unwrap(),
-            ),
-            ErrorKind::ColumnDoesNotExist { column } => Some(
-                KnownError::new(user_facing_errors::query_engine::ColumnDoesNotExist { column: column.clone() })
-                    .unwrap(),
-            ),
+                },
+            )),
+            ErrorKind::TableDoesNotExist { table } => {
+                Some(KnownError::new(user_facing_errors::query_engine::TableDoesNotExist {
+                    table: table.clone(),
+                }))
+            }
+            ErrorKind::ColumnDoesNotExist { column } => {
+                Some(KnownError::new(user_facing_errors::query_engine::ColumnDoesNotExist {
+                    column: column.clone(),
+                }))
+            }
             _ => None,
         };
 

--- a/query-engine/connectors/sql-query-connector/src/error.rs
+++ b/query-engine/connectors/sql-query-connector/src/error.rs
@@ -113,12 +113,11 @@ impl SqlError {
     pub(crate) fn into_connector_error(self, connection_info: &quaint::prelude::ConnectionInfo) -> ConnectorError {
         match self {
             SqlError::UniqueConstraintViolation { constraint } => ConnectorError {
-                user_facing_error: user_facing_errors::KnownError::new(
+                user_facing_error: Some(user_facing_errors::KnownError::new(
                     user_facing_errors::query_engine::UniqueKeyViolation {
                         constraint: constraint.clone(),
                     },
-                )
-                .ok(),
+                )),
                 kind: ErrorKind::UniqueConstraintViolation { constraint },
             },
             SqlError::NullConstraintViolation { constraint } => {
@@ -173,13 +172,12 @@ impl SqlError {
                 }
             }
             SqlError::RawError { code, message } => ConnectorError {
-                user_facing_error: user_facing_errors::KnownError::new(
+                user_facing_error: Some(user_facing_errors::KnownError::new(
                     user_facing_errors::query_engine::RawQueryFailed {
                         code: code.clone(),
                         message: message.clone(),
                     },
-                )
-                .ok(),
+                )),
                 kind: ErrorKind::RawError { code, message },
             },
         }

--- a/query-engine/core/src/error.rs
+++ b/query-engine/core/src/error.rs
@@ -91,13 +91,11 @@ impl From<CoreError> for user_facing_errors::Error {
                         user_facing_errors::KnownError::new(user_facing_errors::query_engine::MissingRequiredValue {
                             path: format!("{}", query_parser_error.path),
                         })
-                        .unwrap()
                     }
                     _ => user_facing_errors::KnownError::new(user_facing_errors::query_engine::QueryValidationFailed {
                         query_validation_error: format!("{}", query_parser_error.error_kind),
                         query_position: format!("{}", query_parser_error.path),
-                    })
-                    .unwrap(),
+                    }),
                 };
 
                 known_error.into()
@@ -111,7 +109,6 @@ impl From<CoreError> for user_facing_errors::Error {
                 field_name,
                 object_name,
             })
-            .unwrap()
             .into(),
             CoreError::QueryGraphBuilderError(QueryGraphBuilderError::RelationViolation(RelationViolation {
                 model_a_name,
@@ -129,7 +126,6 @@ impl From<CoreError> for user_facing_errors::Error {
                 model_b_name,
                 relation_name,
             })
-            .unwrap()
             .into(),
             CoreError::QueryGraphBuilderError(QueryGraphBuilderError::RecordNotFound(details))
             | CoreError::InterpreterError(InterpreterError::QueryGraphBuilderError(
@@ -137,12 +133,9 @@ impl From<CoreError> for user_facing_errors::Error {
             )) => user_facing_errors::KnownError::new(user_facing_errors::query_engine::ConnectedRecordsNotFound {
                 details,
             })
-            .unwrap()
             .into(),
             CoreError::QueryGraphBuilderError(QueryGraphBuilderError::InputError(details)) => {
-                user_facing_errors::KnownError::new(user_facing_errors::query_engine::InputError { details })
-                    .unwrap()
-                    .into()
+                user_facing_errors::KnownError::new(user_facing_errors::query_engine::InputError { details }).into()
             }
             CoreError::InterpreterError(InterpreterError::InterpretationError(msg, Some(cause))) => {
                 match cause.as_ref() {
@@ -157,7 +150,6 @@ impl From<CoreError> for user_facing_errors::Error {
                         model_b_name: model_b_name.clone(),
                         relation_name: relation_name.clone(),
                     })
-                    .unwrap()
                     .into(),
                     InterpreterError::QueryGraphBuilderError(QueryGraphBuilderError::RecordsNotConnected {
                         parent_name,
@@ -168,12 +160,10 @@ impl From<CoreError> for user_facing_errors::Error {
                         child_name: child_name.clone(),
                         relation_name: relation_name.clone(),
                     })
-                    .unwrap()
                     .into(),
                     _ => user_facing_errors::KnownError::new(user_facing_errors::query_engine::InterpretationError {
                         details: format!("{}: {}", msg, cause),
                     })
-                    .unwrap()
                     .into(),
                 }
             }

--- a/query-engine/query-engine/src/error.rs
+++ b/query-engine/query-engine/src/error.rs
@@ -60,10 +60,9 @@ impl PrismaError {
                 let mut full_error = errors.to_pretty_string("schema.prisma", &dml_string);
                 write!(full_error, "\nValidation Error Count: {}", errors.to_iter().len())?;
 
-                user_facing_errors::Error::from(
-                    user_facing_errors::KnownError::new(user_facing_errors::common::SchemaParserError { full_error })
-                        .unwrap(),
-                )
+                user_facing_errors::Error::from(user_facing_errors::KnownError::new(
+                    user_facing_errors::common::SchemaParserError { full_error },
+                ))
             }
             other => user_facing_errors::Error::new_non_panic_with_current_backtrace(other.to_string()),
         };


### PR DESCRIPTION
`serde_json::to_value()` can technically fail, but 1. it is very rare, 2.
it would always be caught in tests in our case, so it's more ergonomic
to assume it will not fail. We do not handle that error properly anyway.

An alternative to a hard error when failing to render would be rendering
to `null` and logging the error.