### PR TITLE
Fixing uri parsing until we get the connection-string crate

### DIFF
--- a/libs/datamodel/core/src/transform/ast_to_dml/builtin_datasource_providers.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/builtin_datasource_providers.rs
@@ -104,7 +104,7 @@ impl DatasourceProvider for MsSqlDatasourceProvider {
     }
 
     fn can_handle_url(&self, name: &str, url: &StringFromEnvVar) -> Result<(), String> {
-        validate_url(name, "sqlserver://", url)
+        validate_url(name, "sqlserver://", url).or_else(|_| validate_url(name, "jdbc:sqlserver://", url))
     }
 
     fn connector(&self) -> Box<dyn Connector> {

--- a/query-engine/query-engine/src/exec_loader.rs
+++ b/query-engine/query-engine/src/exec_loader.rs
@@ -102,7 +102,7 @@ async fn mssql(source: &Datasource) -> PrismaResult<(String, Box<dyn QueryExecut
 
     let mssql = Mssql::from_source(source).await?;
 
-    let mut splitted = source.url().value.split(";");
+    let mut splitted = source.url().value.split(";").filter(|kv| kv != &"");
     splitted.next();
 
     let mut params: HashMap<String, String> = splitted


### PR DESCRIPTION
The uris can contain a `;` character in the end, which means crash and burn if we don't filter those out.