### PR TITLE
Make user facing error string templates regular rust format strings

### DIFF
--- a/libs/user-facing-error-macros/src/lib.rs
+++ b/libs/user-facing-error-macros/src/lib.rs
@@ -33,10 +33,6 @@ fn user_error_derive_on_struct(input: &DeriveInput) -> TokenStream {
     let message_template = input.message;
     let template_variables = message_template_variables(message_template.value().as_str(), &message_template.span());
 
-    // Transform from the spec string templates with `${var}` to a rust format string we can use
-    // with `format!()`.
-    let message_template = message_template.value().replace("${", "{");
-
     let template_variables = template_variables.iter();
 
     let output = quote! {
@@ -146,7 +142,7 @@ struct UserErrorDeriveInput {
 
 /// See MESSAGE_VARIABLE_REGEX
 const MESSAGE_VARIABLE_REGEX_PATTERN: &str = r##"(?x)
-    \$\{  # A curly brace preceded by a dollar sign
+    \{  # an opening curly brace
     (
         [a-zA-Z0-9_]+  # any number of alphanumeric characters and underscores
     )

--- a/libs/user-facing-errors/src/common.rs
+++ b/libs/user-facing-errors/src/common.rs
@@ -6,9 +6,9 @@ use user_facing_error_macros::*;
 #[user_facing(
     code = "P1000",
     message = "\
-Authentication failed against database server at `${database_host}`, the provided database credentials for `${database_user}` are not valid.
+Authentication failed against database server at `{database_host}`, the provided database credentials for `{database_user}` are not valid.
 
-Please make sure to provide valid database credentials for the database server at `${database_host}`."
+Please make sure to provide valid database credentials for the database server at `{database_host}`."
 )]
 // **Notes**: Might vary for different data source, For example, SQLite has no concept of user accounts, and instead relies on the file system for all database permissions. This makes enforcing storage quotas difficult and enforcing user permissions impossible.
 pub struct IncorrectDatabaseCredentials {
@@ -23,9 +23,9 @@ pub struct IncorrectDatabaseCredentials {
 #[user_facing(
     code = "P1001",
     message = "\
-Can't reach database server at `${database_host}`:`${database_port}`
+Can't reach database server at `{database_host}`:`{database_port}`
 
-Please make sure your database server is running at `${database_host}`:`${database_port}`."
+Please make sure your database server is running at `{database_host}`:`{database_port}`."
 )]
 pub struct DatabaseNotReachable {
     /// Database host URI
@@ -39,11 +39,11 @@ pub struct DatabaseNotReachable {
 #[user_facing(
     code = "P1002",
     message = "\
-The database server at `${database_host}`:`${database_port}` was reached but timed out.
+The database server at `{database_host}`:`{database_port}` was reached but timed out.
 
 Please try again.
 
-Please make sure your database server is running at `${database_host}`:`${database_port}`.
+Please make sure your database server is running at `{database_host}`:`{database_port}`.
 "
 )]
 pub struct DatabaseTimeout {
@@ -58,13 +58,13 @@ pub struct DatabaseTimeout {
 #[serde(untagged)]
 #[user_facing(code = "P1003")]
 pub enum DatabaseDoesNotExist {
-    #[user_facing(message = "Database ${database_file_name} does not exist at ${database_file_path}")]
+    #[user_facing(message = "Database {database_file_name} does not exist at {database_file_path}")]
     Sqlite {
         database_file_name: String,
         database_file_path: String,
     },
     #[user_facing(
-        message = "Database `${database_name}.${database_schema_name}` does not exist on the database server at `${database_host}:${database_port}`."
+        message = "Database `{database_name}.{database_schema_name}` does not exist on the database server at `{database_host}:{database_port}`."
     )]
     Postgres {
         database_name: String,
@@ -73,7 +73,7 @@ pub enum DatabaseDoesNotExist {
         database_port: u16,
     },
     #[user_facing(
-        message = "Database `${database_name}` does not exist on the database server at `${database_host}:${database_port}`."
+        message = "Database `{database_name}` does not exist on the database server at `{database_host}:{database_port}`."
     )]
     Mysql {
         database_name: String,
@@ -83,7 +83,7 @@ pub enum DatabaseDoesNotExist {
 }
 
 #[derive(Debug, UserFacingError, Serialize)]
-#[user_facing(code = "P1008", message = "Operations timed out after `${time}`")]
+#[user_facing(code = "P1008", message = "Operations timed out after `{time}`")]
 pub struct DatabaseOperationTimeout {
     /// Operation time in s or ms (if <1000ms)
     pub time: String,
@@ -92,7 +92,7 @@ pub struct DatabaseOperationTimeout {
 #[derive(Debug, UserFacingError, Serialize)]
 #[user_facing(
     code = "P1009",
-    message = "Database `${database_name}` already exists on the database server at `${database_host}:${database_port}`"
+    message = "Database `{database_name}` already exists on the database server at `{database_host}:{database_port}`"
 )]
 pub struct DatabaseAlreadyExists {
     /// Database name, append `database_schema_name` when applicable
@@ -109,7 +109,7 @@ pub struct DatabaseAlreadyExists {
 #[derive(Debug, UserFacingError, Serialize)]
 #[user_facing(
     code = "P1010",
-    message = "User `${database_user}` was denied access on the database `${database_name}`"
+    message = "User `{database_user}` was denied access on the database `{database_name}`"
 )]
 pub struct DatabaseAccessDenied {
     /// Database user name
@@ -121,19 +121,19 @@ pub struct DatabaseAccessDenied {
 }
 
 #[derive(Debug, UserFacingError, Serialize)]
-#[user_facing(code = "P1011", message = "Error opening a TLS connection: ${message}")]
+#[user_facing(code = "P1011", message = "Error opening a TLS connection: {message}")]
 pub struct TlsConnectionError {
     pub message: String,
 }
 
 #[derive(Debug, UserFacingError, Serialize)]
-#[user_facing(code = "P1012", message = "${full_error}")]
+#[user_facing(code = "P1012", message = "{full_error}")]
 pub struct SchemaParserError {
     pub full_error: String,
 }
 
 #[derive(Debug, UserFacingError, Serialize)]
-#[user_facing(code = "P1013", message = "The provided database string is invalid. ${details}")]
+#[user_facing(code = "P1013", message = "The provided database string is invalid. {details}")]
 pub struct InvalidDatabaseString {
     pub details: String,
 }
@@ -154,7 +154,7 @@ impl Display for ModelKind {
 #[derive(Debug, UserFacingError, Serialize)]
 #[user_facing(
     code = "P1014",
-    message = "The underlying ${kind} for model `${model}` does not exist."
+    message = "The underlying {kind} for model `{model}` does not exist."
 )]
 pub struct InvalidModel {
     pub model: String,

--- a/libs/user-facing-errors/src/introspection_engine.rs
+++ b/libs/user-facing-errors/src/introspection_engine.rs
@@ -4,7 +4,7 @@ use user_facing_error_macros::*;
 #[derive(Debug, UserFacingError, Serialize)]
 #[user_facing(
     code = "P4000",
-    message = "Introspection operation failed to produce a schema file: ${introspection_error}"
+    message = "Introspection operation failed to produce a schema file: {introspection_error}"
 )]
 pub struct IntrospectionFailed {
     /// Generic error received from the introspection engine. Indicator of why an introspection failed.
@@ -12,10 +12,7 @@ pub struct IntrospectionFailed {
 }
 
 #[derive(Debug, UserFacingError, Serialize)]
-#[user_facing(
-    code = "P4001",
-    message = "The introspected database was empty: ${connection_string}"
-)]
+#[user_facing(code = "P4001", message = "The introspected database was empty: {connection_string}")]
 pub struct IntrospectionResultEmpty {
     /// There were no models and no enums detected in the database.
     pub connection_string: String,
@@ -24,7 +21,7 @@ pub struct IntrospectionResultEmpty {
 #[derive(Debug, UserFacingError, Serialize)]
 #[user_facing(
     code = "P4002",
-    message = "The schema of the introspected database was inconsistent: ${explanation}"
+    message = "The schema of the introspected database was inconsistent: {explanation}"
 )]
 pub struct DatabaseSchemaInconsistent {
     /// The schema was inconsistent and therefore introspection failed.

--- a/libs/user-facing-errors/src/migration_engine.rs
+++ b/libs/user-facing-errors/src/migration_engine.rs
@@ -3,7 +3,7 @@ use user_facing_error_macros::*;
 
 /// [spec](https://github.com/prisma/specs/tree/master/errors#p3000-database-creation-failed)
 #[derive(Debug, UserFacingError, Serialize)]
-#[user_facing(code = "P3000", message = "Failed to create database: ${database_error}")]
+#[user_facing(code = "P3000", message = "Failed to create database: {database_error}")]
 pub struct DatabaseCreationFailed {
     pub database_error: String,
 }
@@ -12,7 +12,7 @@ pub struct DatabaseCreationFailed {
 #[derive(Debug, UserFacingError, Serialize)]
 #[user_facing(
     code = "P3001",
-    message = "Migration possible with destructive changes and possible data loss: ${migration_engine_destructive_details}"
+    message = "Migration possible with destructive changes and possible data loss: {migration_engine_destructive_details}"
 )]
 pub struct DestructiveMigrationDetected {
     pub migration_engine_destructive_details: String,
@@ -21,7 +21,7 @@ pub struct DestructiveMigrationDetected {
 #[derive(Debug, UserFacingError, Serialize)]
 #[user_facing(
     code = "P3002",
-    message = "The attempted migration was rolled back: ${database_error}"
+    message = "The attempted migration was rolled back: {database_error}"
 )]
 struct MigrationRollback {
     pub database_error: String,
@@ -38,7 +38,7 @@ pub struct DatabaseMigrationFormatChanged;
 #[derive(Debug, UserFacingError, Serialize)]
 #[user_facing(
     code = "P3004",
-    message = "The `${database_name}` database is a system database, it should not be altered with prisma migrate. Please connect to another database."
+    message = "The `{database_name}` database is a system database, it should not be altered with prisma migrate. Please connect to another database."
 )]
 pub struct MigrateSystemDatabase {
     pub database_name: String,

--- a/libs/user-facing-errors/src/query_engine.rs
+++ b/libs/user-facing-errors/src/query_engine.rs
@@ -32,7 +32,7 @@ impl From<Vec<String>> for DatabaseConstraint {
 #[derive(Debug, UserFacingError, Serialize)]
 #[user_facing(
     code = "P2000",
-    message = "The provided value for the column is too long for the column's type. Column: ${column_name}"
+    message = "The provided value for the column is too long for the column's type. Column: {column_name}"
 )]
 pub struct InputValueTooLong {
     pub column_name: String,
@@ -41,7 +41,7 @@ pub struct InputValueTooLong {
 #[derive(Debug, UserFacingError, Serialize)]
 #[user_facing(
     code = "P2001",
-    message = "The record searched for in the where condition (`${model_name}.${argument_name} = ${argument_value}`) does not exist"
+    message = "The record searched for in the where condition (`{model_name}.{argument_name} = {argument_value}`) does not exist"
 )]
 pub struct RecordNotFound {
     /// Model name from Prisma schema
@@ -56,7 +56,7 @@ pub struct RecordNotFound {
 }
 
 #[derive(Debug, UserFacingError, Serialize)]
-#[user_facing(code = "P2002", message = "Unique constraint failed on the ${constraint}")]
+#[user_facing(code = "P2002", message = "Unique constraint failed on the {constraint}")]
 pub struct UniqueKeyViolation {
     /// Field name from one model from Prisma schema
     #[serde(rename = "target")]
@@ -66,7 +66,7 @@ pub struct UniqueKeyViolation {
 #[derive(Debug, UserFacingError, Serialize)]
 #[user_facing(
     code = "P2003",
-    message = "Foreign key constraint failed on the field: `${field_name}`"
+    message = "Foreign key constraint failed on the field: `{field_name}`"
 )]
 pub struct ForeignKeyViolation {
     /// Field name from one model from Prisma schema
@@ -74,7 +74,7 @@ pub struct ForeignKeyViolation {
 }
 
 #[derive(Debug, UserFacingError, Serialize)]
-#[user_facing(code = "P2004", message = "A constraint failed on the database: `${database_error}`")]
+#[user_facing(code = "P2004", message = "A constraint failed on the database: `{database_error}`")]
 pub struct ConstraintViolation {
     /// Database error returned by the underlying data source
     pub database_error: String,
@@ -83,7 +83,7 @@ pub struct ConstraintViolation {
 #[derive(Debug, UserFacingError, Serialize)]
 #[user_facing(
     code = "P2005",
-    message = "The value `${field_value}` stored in the database for the field `${field_name}` is invalid for the field's type"
+    message = "The value `{field_value}` stored in the database for the field `{field_name}` is invalid for the field's type"
 )]
 pub struct StoredValueIsInvalid {
     /// Concrete value provided for a field on a model in Prisma schema. Should be peeked/truncated if too long to display in the error message
@@ -96,7 +96,7 @@ pub struct StoredValueIsInvalid {
 #[derive(Debug, UserFacingError, Serialize)]
 #[user_facing(
     code = "P2006",
-    message = "The provided value `${field_value}` for `${model_name}` field `${field_name}` is not valid"
+    message = "The provided value `{field_value}` for `{model_name}` field `{field_name}` is not valid"
 )]
 pub struct TypeMismatch {
     /// Concrete value provided for a field on a model in Prisma schema. Should be peeked/truncated if too long to display in the error message
@@ -110,7 +110,7 @@ pub struct TypeMismatch {
 }
 
 #[derive(Debug, UserFacingError, Serialize)]
-#[user_facing(code = "P2007", message = "Data validation error `${database_error}`")]
+#[user_facing(code = "P2007", message = "Data validation error `{database_error}`")]
 pub struct TypeMismatchInvalidCustomType {
     /// Database error returned by the underlying data source
     pub database_error: String,
@@ -119,7 +119,7 @@ pub struct TypeMismatchInvalidCustomType {
 #[derive(Debug, UserFacingError, Serialize)]
 #[user_facing(
     code = "P2008",
-    message = "Failed to parse the query `${query_parsing_error}` at `${query_position}`"
+    message = "Failed to parse the query `{query_parsing_error}` at `{query_position}`"
 )]
 pub struct QueryParsingFailed {
     /// Error(s) encountered when trying to parse a query in the query engine
@@ -132,7 +132,7 @@ pub struct QueryParsingFailed {
 #[derive(Debug, UserFacingError, Serialize)]
 #[user_facing(
     code = "P2009",
-    message = "Failed to validate the query: `${query_validation_error}` at `${query_position}`"
+    message = "Failed to validate the query: `{query_validation_error}` at `{query_position}`"
 )]
 pub struct QueryValidationFailed {
     /// Error(s) encountered when trying to validate a query in the query engine
@@ -143,20 +143,20 @@ pub struct QueryValidationFailed {
 }
 
 #[derive(Debug, UserFacingError, Serialize)]
-#[user_facing(code = "P2010", message = "Raw query failed. Code: `${code}`. Message: `${message}`")]
+#[user_facing(code = "P2010", message = "Raw query failed. Code: `{code}`. Message: `{message}`")]
 pub struct RawQueryFailed {
     pub code: String,
     pub message: String,
 }
 
 #[derive(Debug, UserFacingError, Serialize)]
-#[user_facing(code = "P2011", message = "Null constraint violation on the ${constraint}")]
+#[user_facing(code = "P2011", message = "Null constraint violation on the {constraint}")]
 pub struct NullConstraintViolation {
     pub constraint: DatabaseConstraint,
 }
 
 #[derive(Debug, UserFacingError, Serialize)]
-#[user_facing(code = "P2012", message = "Missing a required value at `${path}`")]
+#[user_facing(code = "P2012", message = "Missing a required value at `{path}`")]
 pub struct MissingRequiredValue {
     pub path: String,
 }
@@ -164,7 +164,7 @@ pub struct MissingRequiredValue {
 #[derive(Debug, UserFacingError, Serialize)]
 #[user_facing(
     code = "P2013",
-    message = "Missing the required argument `${argument_name}` for field `${field_name}` on `${object_name}`."
+    message = "Missing the required argument `{argument_name}` for field `{field_name}` on `{object_name}`."
 )]
 pub struct MissingRequiredArgument {
     pub argument_name: String,
@@ -175,7 +175,7 @@ pub struct MissingRequiredArgument {
 #[derive(Debug, UserFacingError, Serialize)]
 #[user_facing(
     code = "P2014",
-    message = "The change you are trying to make would violate the required relation '${relation_name}' between the `${model_a_name}` and `${model_b_name}` models."
+    message = "The change you are trying to make would violate the required relation '{relation_name}' between the `{model_a_name}` and `{model_b_name}` models."
 )]
 pub struct RelationViolation {
     pub relation_name: String,
@@ -184,13 +184,13 @@ pub struct RelationViolation {
 }
 
 #[derive(Debug, UserFacingError, Serialize)]
-#[user_facing(code = "P2015", message = "A related record could not be found. ${details}")]
+#[user_facing(code = "P2015", message = "A related record could not be found. {details}")]
 pub struct RelatedRecordNotFound {
     pub details: String,
 }
 
 #[derive(Debug, UserFacingError, Serialize)]
-#[user_facing(code = "P2016", message = "Query interpretation error. ${details}")]
+#[user_facing(code = "P2016", message = "Query interpretation error. {details}")]
 pub struct InterpretationError {
     pub details: String,
 }
@@ -198,7 +198,7 @@ pub struct InterpretationError {
 #[derive(Debug, UserFacingError, Serialize)]
 #[user_facing(
     code = "P2017",
-    message = "The records for relation `${relation_name}` between the `${parent_name}` and `${child_name}` models are not connected."
+    message = "The records for relation `{relation_name}` between the `{parent_name}` and `{child_name}` models are not connected."
 )]
 pub struct RecordsNotConnected {
     pub relation_name: String,
@@ -207,22 +207,19 @@ pub struct RecordsNotConnected {
 }
 
 #[derive(Debug, UserFacingError, Serialize)]
-#[user_facing(
-    code = "P2018",
-    message = "The required connected records were not found. ${details}"
-)]
+#[user_facing(code = "P2018", message = "The required connected records were not found. {details}")]
 pub struct ConnectedRecordsNotFound {
     pub details: String,
 }
 
 #[derive(Debug, UserFacingError, Serialize)]
-#[user_facing(code = "P2019", message = "Input error. ${details}")]
+#[user_facing(code = "P2019", message = "Input error. {details}")]
 pub struct InputError {
     pub details: String,
 }
 
 #[derive(Debug, UserFacingError, Serialize)]
-#[user_facing(code = "P2020", message = "Value out of range for the type. ${details}")]
+#[user_facing(code = "P2020", message = "Value out of range for the type. {details}")]
 pub struct ValueOutOfRange {
     pub details: String,
 }
@@ -230,7 +227,7 @@ pub struct ValueOutOfRange {
 #[derive(Debug, UserFacingError, Serialize)]
 #[user_facing(
     code = "P2021",
-    message = "The table `${table}` does not exist in the current database."
+    message = "The table `{table}` does not exist in the current database."
 )]
 pub struct TableDoesNotExist {
     pub table: String,
@@ -239,7 +236,7 @@ pub struct TableDoesNotExist {
 #[derive(Debug, UserFacingError, Serialize)]
 #[user_facing(
     code = "P2022",
-    message = "The column `${column}` does not exist in the current database."
+    message = "The column `{column}` does not exist in the current database."
 )]
 pub struct ColumnDoesNotExist {
     pub column: String,


### PR DESCRIPTION
- It is not harder to understand
- It gives better in-editor diagnostics when misspelling / using unknown fields / typos
- It's already documented in the rust std lib docs
- Potential for macro code simplification