### PR TITLE
Stop including the database name in rendered SQL on MySQL

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
@@ -5,8 +5,8 @@ use crate::{
     Component, SqlFlavour,
 };
 use migration_connector::{
-    ConnectorError, ConnectorResult, DatabaseMigrationMarker, DatabaseMigrationStepApplier,
-    DestructiveChangeDiagnostics, PrettyDatabaseMigrationStep,
+    ConnectorResult, DatabaseMigrationMarker, DatabaseMigrationStepApplier, DestructiveChangeDiagnostics,
+    PrettyDatabaseMigrationStep,
 };
 use sql_schema_describer::{walkers::SqlSchemaExt, SqlSchema};
 
@@ -81,8 +81,7 @@ impl DatabaseMigrationStepApplier<SqlMigration> for SqlDatabaseStepApplier<'_> {
                 self.database_info(),
                 &database_migration.before,
                 &database_migration.after,
-            )
-            .unwrap();
+            );
 
             script.push_str("-- ");
             script.push_str(step.description());
@@ -120,9 +119,7 @@ impl SqlDatabaseStepApplier<'_> {
         let step = &steps[index];
         tracing::debug!(?step);
 
-        for sql_string in render_raw_sql(&step, renderer, self.database_info(), current_schema, next_schema)
-            .map_err(|err| ConnectorError::generic(err))?
-        {
+        for sql_string in render_raw_sql(&step, renderer, self.database_info(), current_schema, next_schema) {
             tracing::debug!(index, %sql_string);
 
             self.conn().raw_cmd(&sql_string).await?;
@@ -142,9 +139,7 @@ fn render_steps_pretty(
     let mut steps = Vec::with_capacity(database_migration.steps.len());
 
     for step in &database_migration.steps {
-        let sql = render_raw_sql(&step, renderer, database_info, current_schema, next_schema)
-            .map_err(|err: anyhow::Error| ConnectorError::from_kind(migration_connector::ErrorKind::Generic(err)))?
-            .join(";\n");
+        let sql = render_raw_sql(&step, renderer, database_info, current_schema, next_schema).join(";\n");
 
         if !sql.is_empty() {
             steps.push(PrettyDatabaseMigrationStep {
@@ -163,7 +158,7 @@ fn render_raw_sql(
     database_info: &DatabaseInfo,
     current_schema: &SqlSchema,
     next_schema: &SqlSchema,
-) -> Result<Vec<String>, anyhow::Error> {
+) -> Vec<String> {
     let differ = SqlSchemaDiffer {
         previous: current_schema,
         next: next_schema,
@@ -172,26 +167,25 @@ fn render_raw_sql(
     };
 
     match step {
-        SqlMigrationStep::RedefineTables { names } => Ok(renderer.render_redefine_tables(names, differ)),
-        SqlMigrationStep::CreateEnum(create_enum) => Ok(renderer.render_create_enum(create_enum)),
-        SqlMigrationStep::DropEnum(drop_enum) => Ok(renderer.render_drop_enum(drop_enum)),
+        SqlMigrationStep::RedefineTables { names } => renderer.render_redefine_tables(names, differ),
+        SqlMigrationStep::CreateEnum(create_enum) => renderer.render_create_enum(create_enum),
+        SqlMigrationStep::DropEnum(drop_enum) => renderer.render_drop_enum(drop_enum),
         SqlMigrationStep::AlterEnum(alter_enum) => renderer.render_alter_enum(alter_enum, &differ),
         SqlMigrationStep::CreateTable(CreateTable { table }) => {
             let table = next_schema
                 .table_walker(&table.name)
-                .expect("CreateTable referring to an unknown table.");
+                .ok_or_else(|| anyhow::anyhow!("CreateTable referring to an unknown table: `{}`.", &table.name))
+                .unwrap();
 
-            Ok(vec![renderer.render_create_table(&table)])
+            vec![renderer.render_create_table(&table)]
         }
-        SqlMigrationStep::DropTable(DropTable { name }) => Ok(renderer.render_drop_table(name)),
-        SqlMigrationStep::RenameTable { name, new_name } => Ok(vec![renderer.render_rename_table(name, new_name)]),
-        SqlMigrationStep::AddForeignKey(add_foreign_key) => Ok(vec![renderer.render_add_foreign_key(add_foreign_key)]),
-        SqlMigrationStep::DropForeignKey(drop_foreign_key) => {
-            Ok(vec![renderer.render_drop_foreign_key(drop_foreign_key)])
-        }
-        SqlMigrationStep::AlterTable(alter_table) => Ok(renderer.render_alter_table(alter_table, &differ)),
-        SqlMigrationStep::CreateIndex(create_index) => Ok(vec![renderer.render_create_index(create_index)]),
-        SqlMigrationStep::DropIndex(drop_index) => Ok(vec![renderer.render_drop_index(drop_index)]),
+        SqlMigrationStep::DropTable(DropTable { name }) => renderer.render_drop_table(name),
+        SqlMigrationStep::RenameTable { name, new_name } => vec![renderer.render_rename_table(name, new_name)],
+        SqlMigrationStep::AddForeignKey(add_foreign_key) => vec![renderer.render_add_foreign_key(add_foreign_key)],
+        SqlMigrationStep::DropForeignKey(drop_foreign_key) => vec![renderer.render_drop_foreign_key(drop_foreign_key)],
+        SqlMigrationStep::AlterTable(alter_table) => renderer.render_alter_table(alter_table, &differ),
+        SqlMigrationStep::CreateIndex(create_index) => vec![renderer.render_create_index(create_index)],
+        SqlMigrationStep::DropIndex(drop_index) => vec![renderer.render_drop_index(drop_index)],
         SqlMigrationStep::AlterIndex(alter_index) => {
             renderer.render_alter_index(alter_index, database_info, current_schema)
         }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
@@ -181,7 +181,7 @@ fn render_raw_sql(
                 .table_walker(&table.name)
                 .expect("CreateTable referring to an unknown table.");
 
-            Ok(vec![renderer.render_create_table(&table)?])
+            Ok(vec![renderer.render_create_table(&table)])
         }
         SqlMigrationStep::DropTable(DropTable { name }) => Ok(renderer.render_drop_table(name)),
         SqlMigrationStep::RenameTable { name, new_name } => Ok(vec![renderer.render_rename_table(name, new_name)]),

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer.rs
@@ -1,10 +1,12 @@
+#![deny(missing_docs)]
+
 mod common;
 mod mssql_renderer;
 mod mysql_renderer;
 mod postgres_renderer;
 mod sqlite_renderer;
 
-pub(crate) use common::{IteratorJoin, Quoted, QuotedWithSchema};
+pub(crate) use common::IteratorJoin;
 
 use crate::{
     database_info::DatabaseInfo,
@@ -13,41 +15,17 @@ use crate::{
     },
     sql_schema_differ::SqlSchemaDiffer,
 };
-use sql_schema_describer::walkers::{ColumnWalker, TableWalker};
-use sql_schema_describer::*;
-use std::{borrow::Cow, fmt::Write as _};
+use common::{Quoted, QuotedWithSchema};
+use sql_schema_describer::{
+    walkers::{ColumnWalker, TableWalker},
+    ColumnTypeFamily, DefaultValue, ForeignKey, SqlSchema,
+};
+use std::borrow::Cow;
 
 pub(crate) trait SqlRenderer {
     fn quote<'a>(&self, name: &'a str) -> Quoted<&'a str>;
 
-    fn quote_with_schema<'a, 'b>(&'a self, name: &'b str) -> QuotedWithSchema<'a, &'b str>;
-
-    fn render_add_foreign_key(&self, add_foreign_key: &AddForeignKey) -> String {
-        let AddForeignKey { foreign_key, table } = add_foreign_key;
-        let mut add_constraint = String::with_capacity(120);
-
-        write!(
-            add_constraint,
-            "ALTER TABLE {table} ADD ",
-            table = self.quote_with_schema(table)
-        )
-        .unwrap();
-
-        if let Some(constraint_name) = foreign_key.constraint_name.as_ref() {
-            write!(add_constraint, "CONSTRAINT {} ", self.quote(constraint_name)).unwrap();
-        }
-
-        write!(
-            add_constraint,
-            "FOREIGN KEY ({})",
-            foreign_key.columns.iter().map(|col| self.quote(col)).join(", ")
-        )
-        .unwrap();
-
-        add_constraint.push_str(&self.render_references(&table, &foreign_key));
-
-        add_constraint
-    }
+    fn render_add_foreign_key(&self, add_foreign_key: &AddForeignKey) -> String;
 
     fn render_alter_enum(&self, alter_enum: &AlterEnum, differ: &SqlSchemaDiffer<'_>) -> anyhow::Result<Vec<String>>;
 
@@ -93,5 +71,6 @@ pub(crate) trait SqlRenderer {
     /// Render a `RedefineTables` step.
     fn render_redefine_tables(&self, tables: &[String], differ: SqlSchemaDiffer<'_>) -> Vec<String>;
 
+    /// Render a table renaming step.
     fn render_rename_table(&self, name: &str, new_name: &str) -> String;
 }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer.rs
@@ -27,7 +27,7 @@ pub(crate) trait SqlRenderer {
 
     fn render_add_foreign_key(&self, add_foreign_key: &AddForeignKey) -> String;
 
-    fn render_alter_enum(&self, alter_enum: &AlterEnum, differ: &SqlSchemaDiffer<'_>) -> anyhow::Result<Vec<String>>;
+    fn render_alter_enum(&self, alter_enum: &AlterEnum, differ: &SqlSchemaDiffer<'_>) -> Vec<String>;
 
     fn render_column(&self, column: ColumnWalker<'_>) -> String;
 
@@ -41,7 +41,7 @@ pub(crate) trait SqlRenderer {
         alter_index: &AlterIndex,
         database_info: &DatabaseInfo,
         current_schema: &SqlSchema,
-    ) -> anyhow::Result<Vec<String>>;
+    ) -> Vec<String>;
 
     fn render_alter_table(&self, alter_table: &AlterTable, differ: &SqlSchemaDiffer<'_>) -> Vec<String>;
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer.rs
@@ -52,7 +52,7 @@ pub(crate) trait SqlRenderer {
     fn render_create_index(&self, create_index: &CreateIndex) -> String;
 
     /// Render a `CreateTable` step.
-    fn render_create_table(&self, table: &TableWalker<'_>) -> anyhow::Result<String>;
+    fn render_create_table(&self, table: &TableWalker<'_>) -> String;
 
     /// Render a `DropEnum` step.
     fn render_drop_enum(&self, drop_enum: &DropEnum) -> Vec<String>;

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mssql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mssql_renderer.rs
@@ -15,16 +15,18 @@ use sql_schema_describer::{
 };
 use std::{borrow::Cow, fmt::Write};
 
-impl SqlRenderer for MssqlFlavour {
-    fn quote<'a>(&self, name: &'a str) -> Quoted<&'a str> {
-        Quoted::mssql_ident(name)
-    }
-
+impl MssqlFlavour {
     fn quote_with_schema<'a, 'b>(&'a self, name: &'b str) -> QuotedWithSchema<'a, &'b str> {
         QuotedWithSchema {
             schema_name: self.schema_name(),
             name: self.quote(name),
         }
+    }
+}
+
+impl SqlRenderer for MssqlFlavour {
+    fn quote<'a>(&self, name: &'a str) -> Quoted<&'a str> {
+        Quoted::mssql_ident(name)
     }
 
     fn render_alter_table(&self, alter_table: &AlterTable, differ: &SqlSchemaDiffer<'_>) -> Vec<String> {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mssql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mssql_renderer.rs
@@ -211,7 +211,7 @@ impl SqlRenderer for MssqlFlavour {
         )
     }
 
-    fn render_create_table(&self, table: &TableWalker<'_>) -> anyhow::Result<String> {
+    fn render_create_table(&self, table: &TableWalker<'_>) -> String {
         let columns: String = table.columns().map(|column| self.render_column(column)).join(",\n");
 
         let primary_columns = table.table.primary_key_columns();
@@ -248,13 +248,13 @@ impl SqlRenderer for MssqlFlavour {
             String::new()
         };
 
-        Ok(format!(
+        format!(
             "CREATE TABLE {} ({columns}{primary_key}{constraints})",
             table_name = self.quote_with_schema(table.name()),
             columns = columns,
             primary_key = primary_key,
             constraints = constraints,
-        ))
+        )
     }
 
     fn render_drop_enum(&self, _drop_enum: &DropEnum) -> Vec<String> {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mssql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mssql_renderer.rs
@@ -72,7 +72,7 @@ impl SqlRenderer for MssqlFlavour {
         )]
     }
 
-    fn render_alter_enum(&self, _: &AlterEnum, _: &SqlSchemaDiffer<'_>) -> anyhow::Result<Vec<String>> {
+    fn render_alter_enum(&self, _: &AlterEnum, _: &SqlSchemaDiffer<'_>) -> Vec<String> {
         unreachable!("render_alter_enum on Microsoft SQL Server")
     }
 
@@ -149,7 +149,7 @@ impl SqlRenderer for MssqlFlavour {
         alter_index: &AlterIndex,
         _database_info: &DatabaseInfo,
         _current_schema: &SqlSchema,
-    ) -> anyhow::Result<Vec<String>> {
+    ) -> Vec<String> {
         let AlterIndex {
             table,
             index_name,
@@ -158,11 +158,11 @@ impl SqlRenderer for MssqlFlavour {
 
         let index_with_table = Quoted::Single(format!("{}.{}.{}", self.schema_name(), table, index_name));
 
-        Ok(vec![format!(
+        vec![format!(
             "EXEC SP_RENAME N{index_with_table}, N{index_new_name}, N'INDEX'",
             index_with_table = Quoted::Single(index_with_table),
             index_new_name = Quoted::Single(index_new_name),
-        )])
+        )]
     }
 
     fn render_create_enum(&self, _: &CreateEnum) -> Vec<String> {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
@@ -258,7 +258,7 @@ impl SqlRenderer for MysqlFlavour {
         )
     }
 
-    fn render_create_table(&self, table: &TableWalker<'_>) -> anyhow::Result<String> {
+    fn render_create_table(&self, table: &TableWalker<'_>) -> String {
         let columns: String = table.columns().map(|column| self.render_column(column)).join(",\n");
 
         let primary_columns = table.table.primary_key_columns();
@@ -297,13 +297,13 @@ impl SqlRenderer for MysqlFlavour {
             String::new()
         };
 
-        Ok(format!(
+        format!(
             "CREATE TABLE {} (\n{columns}{indexes}{primary_key}\n) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci",
             table_name = self.quote(table.name()),
             columns = columns,
             indexes = indexes,
             primary_key = primary_key,
-        ))
+        )
     }
 
     fn render_drop_enum(&self, _drop_enum: &DropEnum) -> Vec<String> {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
@@ -29,10 +29,6 @@ impl SqlRenderer for MysqlFlavour {
         Quoted::Backticks(name)
     }
 
-    fn quote_with_schema<'a, 'b>(&'a self, _name: &'b str) -> QuotedWithSchema<'a, &'b str> {
-        unreachable!("quote_with_schema on MySQL")
-    }
-
     fn render_add_foreign_key(&self, add_foreign_key: &AddForeignKey) -> String {
         use std::fmt::Write;
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
@@ -325,7 +325,7 @@ impl SqlRenderer for PostgresFlavour {
         )
     }
 
-    fn render_create_table(&self, table: &TableWalker<'_>) -> anyhow::Result<String> {
+    fn render_create_table(&self, table: &TableWalker<'_>) -> String {
         let columns: String = table.columns().map(|column| self.render_column(column)).join(",\n");
 
         let primary_columns = table.table.primary_key_columns();
@@ -336,12 +336,12 @@ impl SqlRenderer for PostgresFlavour {
             String::new()
         };
 
-        Ok(format!(
+        format!(
             "CREATE TABLE {table_name} (\n{columns}{primary_key}\n)",
             table_name = self.quote_with_schema(table.name()),
             columns = columns,
             primary_key = pk,
-        ))
+        )
     }
 
     fn render_drop_enum(&self, drop_enum: &DropEnum) -> Vec<String> {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
@@ -19,10 +19,6 @@ impl SqlRenderer for SqliteFlavour {
         Quoted::Double(name)
     }
 
-    fn quote_with_schema<'a, 'b>(&'a self, _name: &'b str) -> QuotedWithSchema<'a, &'b str> {
-        unreachable!("quote_with_schema on sqlite");
-    }
-
     fn render_alter_enum(&self, _alter_enum: &AlterEnum, _differ: &SqlSchemaDiffer<'_>) -> anyhow::Result<Vec<String>> {
         unreachable!("render_alter_enum on sqlite")
     }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
@@ -19,7 +19,7 @@ impl SqlRenderer for SqliteFlavour {
         Quoted::Double(name)
     }
 
-    fn render_alter_enum(&self, _alter_enum: &AlterEnum, _differ: &SqlSchemaDiffer<'_>) -> anyhow::Result<Vec<String>> {
+    fn render_alter_enum(&self, _alter_enum: &AlterEnum, _differ: &SqlSchemaDiffer<'_>) -> Vec<String> {
         unreachable!("render_alter_enum on sqlite")
     }
 
@@ -28,7 +28,7 @@ impl SqlRenderer for SqliteFlavour {
         _alter_index: &AlterIndex,
         _database_info: &DatabaseInfo,
         _current_schema: &SqlSchema,
-    ) -> anyhow::Result<Vec<String>> {
+    ) -> Vec<String> {
         unreachable!("render_alter_index on sqlite")
     }
 


### PR DESCRIPTION
Also includes a small refactoring in SqlRenderer to remove error handling with results. Crashing hard is the right thing to do if we can't render a SQL migration, we have to assume the engine generates migrations that make sense, and we are rendering in-memory, so IO errors are not to be expected.

closes https://github.com/prisma/prisma-engines/issues/1130
closes https://github.com/prisma/migrations-team/issues/23