### PR TITLE
Simplify error handling in migration-engine-cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1930,7 +1930,6 @@ dependencies = [
 name = "migration-engine-cli"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "futures 0.3.5",
  "json-rpc-stdio",
  "migration-connector",
@@ -1940,7 +1939,6 @@ dependencies = [
  "structopt",
  "tempfile",
  "test-setup",
- "thiserror",
  "tokio",
  "tracing",
  "tracing-error",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3329,7 +3329,6 @@ dependencies = [
  "serde_json",
  "test-macros",
  "test-setup",
- "thiserror",
  "tokio",
  "tracing",
 ]

--- a/libs/sql-schema-describer/Cargo.toml
+++ b/libs/sql-schema-describer/Cargo.toml
@@ -13,7 +13,6 @@ regex = "1.2"
 rust_decimal = {git = "https://github.com/pimeys/rust-decimal", branch = "pgbouncer-mode"}
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"
-thiserror = "1.0.16"
 tracing = "0.1"
 
 [dependencies.quaint]

--- a/libs/sql-schema-describer/src/lib.rs
+++ b/libs/sql-schema-describer/src/lib.rs
@@ -3,14 +3,17 @@
 
 //! Database description. This crate is used heavily in the introspection and migration engines.
 
+use fmt::Display;
 use once_cell::sync::Lazy;
 use prisma_value::PrismaValue;
 use regex::Regex;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
-use std::fmt::Debug;
-use std::{fmt, str::FromStr};
-use thiserror::Error;
+use std::{
+    error::Error,
+    fmt::{self, Debug},
+    str::FromStr,
+};
 use tracing::debug;
 
 pub mod mssql;
@@ -20,12 +23,19 @@ pub mod sqlite;
 pub mod walkers;
 
 /// description errors.
-#[derive(Debug, Error)]
+#[derive(Debug)]
 pub enum SqlSchemaDescriberError {
     /// An unknown error occurred.
-    #[error("unknown")]
     UnknownError,
 }
+
+impl Display for SqlSchemaDescriberError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "unknown")
+    }
+}
+
+impl Error for SqlSchemaDescriberError {}
 
 /// The result type.
 pub type SqlSchemaDescriberResult<T> = core::result::Result<T, SqlSchemaDescriberError>;

--- a/migration-engine/cli/Cargo.toml
+++ b/migration-engine/cli/Cargo.toml
@@ -11,12 +11,10 @@ migration-connector = { path = "../connectors/migration-connector" }
 migration-core = { path = "../core" }
 user-facing-errors = { path = "../../libs/user-facing-errors" }
 
-anyhow = "1.0.26"
 futures = "0.3"
 json-rpc-stdio = { path = "../../libs/json-rpc-stdio" }
 serde_json = "1.0"
 structopt = "0.3.8"
-thiserror = "1.0.9"
 tokio = { version = "0.2.13", features = ["macros"] }
 tracing = "0.1"
 tracing-subscriber = "0.2"

--- a/migration-engine/cli/src/commands.rs
+++ b/migration-engine/cli/src/commands.rs
@@ -6,6 +6,7 @@ use error::CliError;
 use futures::FutureExt;
 use migration_core::migration_api;
 use structopt::StructOpt;
+use user_facing_errors::{common::InvalidDatabaseString, KnownError};
 
 #[derive(Debug, StructOpt)]
 pub(crate) struct Cli {
@@ -92,10 +93,10 @@ fn datasource_from_database_str(database_str: &str) -> Result<String, CliError> 
         Some("file") => "sqlite",
         Some(other) => other,
         None => {
-            return Err(CliError::Other(anyhow::anyhow!(
-                "Invalid database string format: {}",
-                database_str
-            )))
+            return Err(CliError::Known {
+                error: KnownError::new(InvalidDatabaseString { details: String::new() }),
+                exit_code: 255,
+            })
         }
     };
 

--- a/migration-engine/core/src/lib.rs
+++ b/migration-engine/core/src/lib.rs
@@ -1,10 +1,14 @@
-#![deny(rust_2018_idioms)]
-#![deny(unsafe_code)]
+#![deny(rust_2018_idioms, unsafe_code, missing_docs)]
 
+//! The top-level library crate for the migration engine.
+
+#[allow(missing_docs)]
 pub mod api;
 pub mod commands;
 pub mod error;
+#[allow(missing_docs)]
 pub mod migration;
+#[allow(missing_docs)]
 pub mod migration_engine;
 
 pub use api::GenericApi;


### PR DESCRIPTION
...improve diagnostics a bit and drop two dependencies in the process.