### PR TITLE
Generate less async code in test-macros

### DIFF
--- a/introspection-engine/connectors/sql-introspection-connector/tests/add_prisma1_defaults/mod.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/tests/add_prisma1_defaults/mod.rs
@@ -80,7 +80,7 @@ async fn add_uuid_default_for_mysql(api: &TestApi) {
             model Book {
                 id  String @default(uuid()) @id
             }
-            
+
         "#;
     let result = dbg!(api.introspect().await);
     custom_assert(&result, dm);


### PR DESCRIPTION
Instead of one async block per connector per test, add only one async
block of overhead per test.