### PR TITLE
 Split some tests out of existing_data/mod.rs 

### DIFF
--- a/migration-engine/migration-engine-tests/src/sql.rs
+++ b/migration-engine/migration-engine-tests/src/sql.rs
@@ -1,9 +1,12 @@
+pub(crate) mod barrel_migration_executor;
+
+mod quaint_result_set_ext;
+
 pub use super::assertions::*;
 pub use super::command_helpers::*;
 pub use super::misc_helpers::*;
 pub use super::step_helpers::*;
 pub use super::test_api::*;
+pub use quaint_result_set_ext::*;
 pub use test_macros::*;
 pub use test_setup::*;
-
-pub(crate) mod barrel_migration_executor;

--- a/migration-engine/migration-engine-tests/src/sql/quaint_result_set_ext.rs
+++ b/migration-engine/migration-engine-tests/src/sql/quaint_result_set_ext.rs
@@ -1,0 +1,79 @@
+use crate::AssertionResult;
+use quaint::{connector::ResultRowRef, prelude::ResultSet, Value};
+
+pub trait ResultSetExt: Sized {
+    fn assert_row_count(self, expected_count: usize) -> AssertionResult<Self>;
+
+    fn assert_row(
+        self,
+        rowidx: usize,
+        assertions: impl for<'a> FnOnce(RowAssertion<'a>) -> AssertionResult<RowAssertion<'a>>,
+    ) -> AssertionResult<Self>;
+
+    fn assert_first_row(
+        self,
+        assertions: impl for<'a> FnOnce(RowAssertion<'a>) -> AssertionResult<RowAssertion<'a>>,
+    ) -> AssertionResult<Self> {
+        self.assert_row(0, assertions)
+    }
+
+    fn assert_single_row(
+        self,
+        assertions: impl for<'a> FnOnce(RowAssertion<'a>) -> AssertionResult<RowAssertion<'a>>,
+    ) -> AssertionResult<Self> {
+        self.assert_row_count(1)?.assert_first_row(assertions)
+    }
+}
+
+impl ResultSetExt for ResultSet {
+    fn assert_row_count(self, expected_count: usize) -> AssertionResult<Self> {
+        assert_eq!(self.len(), expected_count);
+
+        Ok(self)
+    }
+
+    fn assert_row(
+        self,
+        rowidx: usize,
+        assertions: impl for<'a> FnOnce(RowAssertion<'a>) -> AssertionResult<RowAssertion<'a>>,
+    ) -> AssertionResult<Self> {
+        let assertion = RowAssertion(self.get(rowidx).ok_or_else(|| anyhow::anyhow!("TODO"))?);
+
+        assertions(assertion)?;
+
+        Ok(self)
+    }
+}
+
+#[derive(Debug)]
+pub struct RowAssertion<'a>(ResultRowRef<'a>);
+
+impl<'a> RowAssertion<'a> {
+    pub fn assert_text_value(self, column_name: &str, expected_value: &str) -> AssertionResult<Self> {
+        let actual_value = self.0.get(column_name).and_then(|col: &Value<'_>| (*col).to_string());
+
+        anyhow::ensure!(
+            actual_value.as_deref() == Some(expected_value),
+            "Value assertion failed for {}. Expected: {:?}, got: {:?}",
+            column_name,
+            expected_value,
+            actual_value,
+        );
+
+        Ok(self)
+    }
+
+    pub fn assert_int_value(self, column_name: &str, expected_value: i64) -> AssertionResult<Self> {
+        let actual_value = self.0.get(column_name).and_then(|col: &Value<'_>| (*col).as_i64());
+
+        anyhow::ensure!(
+            actual_value == Some(expected_value),
+            "Value assertion failed for {}. Expected: {:?}, got: {:?}",
+            column_name,
+            expected_value,
+            actual_value,
+        );
+
+        Ok(self)
+    }
+}

--- a/migration-engine/migration-engine-tests/tests/existing_data/sqlite_existing_data_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_data/sqlite_existing_data_tests.rs
@@ -1,0 +1,58 @@
+use prisma_value::PrismaValue;
+use sql_schema_describer::DefaultValue;
+
+#[test_each_connector(tags("sqlite"))]
+async fn changing_a_column_from_optional_to_required_must_warn(api: &TestApi) -> TestResult {
+    let dm = r#"
+        model Test {
+            id String @id @default(cuid())
+            age Int?
+        }
+    "#;
+
+    api.infer_apply(&dm).send().await?.assert_green()?;
+
+    let insert = Insert::multi_into(api.render_table_name("Test"), &["id", "age"])
+        .values(("a", 12))
+        .values(("b", 22))
+        .values(("c", Value::Integer(None)));
+
+    api.database().query(insert.into()).await.unwrap();
+
+    let dm2 = r#"
+        model Test {
+            id String @id @default(cuid())
+            age Int @default(30)
+        }
+    "#;
+
+    // TODO: this should not warn, since this specific migration is safe.
+    api.infer_apply(&dm2)
+        .force(Some(true))
+        .send()
+        .await?
+        .assert_executable()?
+        .assert_no_error()?
+        .assert_warnings(&["You are about to alter the column `age` on the `Test` table, which still contains 2 non-null values. The data in that column could be lost.".into()])?;
+
+    api.assert_schema().await?.assert_table("Test", |table| {
+        table.assert_column("age", |column| {
+            column
+                .assert_default(Some(DefaultValue::VALUE(PrismaValue::Int(30))))?
+                .assert_is_required()
+        })
+    })?;
+
+    // Check that no data was lost.
+    {
+        let data = api.dump_table("Test").await?;
+        assert_eq!(data.len(), 3);
+        let ages: Vec<Option<i64>> = data.into_iter().map(|row| row.get("age").unwrap().as_i64()).collect();
+
+        // TODO: this is NOT what users would expect (it's a consequence of the stepped migration
+        // process), we should have a more specific warning for this.
+        assert_eq!(ages, &[Some(12), Some(22), Some(30)]);
+    }
+
+    Ok(())
+}

--- a/migration-engine/migration-engine-tests/tests/existing_data/sqlite_existing_data_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_data/sqlite_existing_data_tests.rs
@@ -1,4 +1,6 @@
+use migration_engine_tests::sql::*;
 use prisma_value::PrismaValue;
+use quaint::{prelude::Insert, prelude::Queryable, Value};
 use sql_schema_describer::DefaultValue;
 
 #[test_each_connector(tags("sqlite"))]

--- a/migration-engine/migration-engine-tests/tests/existing_data/type_migration_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_data/type_migration_tests.rs
@@ -1,0 +1,241 @@
+use crate::*;
+use pretty_assertions::assert_eq;
+
+#[test_each_connector]
+async fn altering_the_type_of_a_column_in_a_non_empty_table_always_warns(api: &TestApi) -> TestResult {
+    let dm1 = r#"
+        model User {
+            id String @id @default(cuid())
+            name String
+            dogs Int
+        }
+    "#;
+
+    api.infer_apply(dm1).send().await?.assert_green()?;
+
+    let insert = quaint::ast::Insert::single_into(api.render_table_name("User"))
+        .value("id", "abc")
+        .value("name", "Shinzo")
+        .value("dogs", 7);
+
+    api.database().query(insert.into()).await?;
+
+    let dm2 = r#"
+        model User {
+            id String @id @default(cuid())
+            name String
+            dogs String
+        }
+    "#;
+
+    api.infer_apply(dm2).send().await?.assert_warnings(&[
+        // TODO: the message should say that altering the type of a column is not guaranteed to preserve the data, but the database is going to do its best.
+        // Also think about timeouts.
+        "You are about to alter the column `dogs` on the `User` table, which still contains 1 non-null values. The data in that column could be lost.".into()
+    ])?;
+
+    let rows = api.select("User").column("dogs").send_debug().await?;
+    assert_eq!(rows, &[["Integer(Some(7))"]]);
+
+    api.assert_schema().await?.assert_table("User", |table| {
+        table.assert_column("dogs", |col| col.assert_type_is_int()?.assert_is_required())
+    })?;
+
+    Ok(())
+}
+
+#[test_each_connector(ignore("mysql"))]
+async fn migrating_a_required_column_from_int_to_string_should_warn_and_cast(api: &TestApi) -> TestResult {
+    let dm1 = r#"
+        model Test {
+            id String @id
+            serialNumber Int
+        }
+    "#;
+
+    api.infer_apply(dm1).send().await?.assert_green()?;
+
+    api.insert("Test")
+        .value("id", "abcd")
+        .value("serialNumber", 47i64)
+        .result_raw()
+        .await?;
+
+    let test = api.dump_table("Test").await?;
+    let first_row = test.get(0).unwrap();
+    assert_eq!(
+        format!("{:?} {:?}", first_row.get("id"), first_row.get("serialNumber")),
+        r#"Some(Text(Some("abcd"))) Some(Integer(Some(47)))"#
+    );
+
+    let original_schema = api.assert_schema().await?.into_schema();
+
+    let dm2 = r#"
+        model Test {
+            id String @id
+            serialNumber String
+        }
+    "#;
+
+    let expected_warning = "You are about to alter the column `serialNumber` on the `Test` table, which still contains 1 non-null values. The data in that column could be lost.";
+
+    // Apply once without forcing
+    {
+        api.infer_apply(dm2)
+            .send()
+            .await?
+            .assert_warnings(&[expected_warning.into()])?;
+        api.assert_schema().await?.assert_equals(&original_schema)?;
+    }
+
+    // Force apply
+    {
+        api.infer_apply(dm2)
+            .force(Some(true))
+            .send()
+            .await?
+            .assert_warnings(&[expected_warning.into()])?;
+
+        api.assert_schema().await?.assert_table("Test", |table| {
+            table.assert_column("serialNumber", |col| col.assert_type_is_string())
+        })?;
+
+        let test = api.dump_table("Test").await?;
+        let first_row = test.get(0).unwrap();
+        assert_eq!(
+            format!("{:?} {:?}", first_row.get("id"), first_row.get("serialNumber")),
+            r#"Some(Text(Some("abcd"))) Some(Text(Some("47")))"#
+        );
+    }
+
+    Ok(())
+}
+
+#[test_each_connector(capabilities("scalar_lists"))]
+async fn changing_an_array_column_to_scalar_must_warn(api: &TestApi) -> TestResult {
+    let datasource_block = api.datasource();
+
+    let dm1 = format!(
+        r#"
+        {datasource_block}
+
+        model Film {{
+            id String @id
+            mainProtagonist String[]
+        }}
+        "#,
+        datasource_block = datasource_block,
+    );
+
+    api.infer_apply(&dm1).send().await?.assert_green()?;
+
+    api.insert("Film")
+        .value("id", "film1")
+        .value(
+            "mainProtagonist",
+            Value::Array(Some(vec!["giant shark".into(), "jason statham".into()])),
+        )
+        // .value("mainProtagonist", Value::array(vec!["giant shark", "jason statham"]))
+        .result_raw()
+        .await?;
+
+    let dm2 = format!(
+        r#"
+            {datasource_block}
+
+            model Film {{
+                id String @id
+                mainProtagonist String
+            }}
+            "#,
+        datasource_block = datasource_block,
+    );
+
+    api.infer_apply(&dm2)
+        .force(Some(true))
+        .send()
+        .await?
+        .assert_executable()?
+        .assert_no_error()?
+        .assert_warnings(&["You are about to alter the column `mainProtagonist` on the `Film` table, which still contains 1 non-null values. The data in that column could be lost.".into()])?;
+
+    api.assert_schema().await?.assert_table("Film", |table| {
+        table.assert_column("mainProtagonist", |column| column.assert_is_required())
+    })?;
+
+    let rows = api.select("Film").column("id").column("mainProtagonist").send().await?;
+
+    let rows: Vec<Vec<Value>> = rows
+        .into_iter()
+        .map(|row| row.into_iter().collect::<Vec<_>>())
+        .collect();
+
+    assert_eq!(
+        rows,
+        &[&["film1".into(), "{\"giant shark\",\"jason statham\"}".into()]] // the array got cast ot a string by postgres
+    );
+
+    Ok(())
+}
+
+#[test_each_connector(capabilities("scalar_lists"))]
+async fn changing_a_scalar_column_to_an_array_is_unexecutable(api: &TestApi) -> TestResult {
+    let datasource_block = api.datasource();
+
+    let dm1 = format!(
+        r#"
+        {datasource_block}
+
+        model Film {{
+            id String @id
+            mainProtagonist String
+        }}
+        "#,
+        datasource_block = datasource_block,
+    );
+
+    api.infer_apply(&dm1).send().await?.assert_green()?;
+
+    api.insert("Film")
+        .value("id", "film1")
+        .value("mainProtagonist", "left shark")
+        // .value("mainProtagonist", Value::array(vec!["giant shark", "jason statham"]))
+        .result_raw()
+        .await?;
+
+    let dm2 = format!(
+        r#"
+            {datasource_block}
+
+            model Film {{
+                id String @id
+                mainProtagonist String[]
+            }}
+            "#,
+        datasource_block = datasource_block,
+    );
+
+    api.infer_apply(&dm2)
+        .send()
+        .await?
+        .assert_unexecutable(&[
+            "Changed the column `mainProtagonist` on the `Film` table from a scalar field to a list field. There are 1 existing non-null values in that column, this migration step cannot be executed.".into(),
+        ])?
+        .assert_no_warning()?
+        .assert_no_error()?;
+
+    api.assert_schema().await?.assert_table("Film", |table| {
+        table.assert_column("mainProtagonist", |column| column.assert_is_required())
+    })?;
+
+    let rows = api.select("Film").column("id").column("mainProtagonist").send().await?;
+
+    let rows: Vec<Vec<Value>> = rows
+        .into_iter()
+        .map(|row| row.into_iter().collect::<Vec<_>>())
+        .collect();
+
+    assert_eq!(rows, &[&["film1".into(), Value::text("left shark")]]);
+
+    Ok(())
+}


### PR DESCRIPTION
Split out tests and improve assertions. We are going to need to expand these tests a lot with the ongoing work on https://github.com/prisma/migrate/issues/545