### PR TITLE
Use connection-string for MS SQL Server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -604,9 +604,9 @@ dependencies = [
 
 [[package]]
 name = "connection-string"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d672ca0b0ad00e87bf383a2c68e76dc4408d198473fd221c44605f0e37af118"
+checksum = "4792f31bcb812a45b6776af34a2dc1d70d38fb93ab6f74548796afe43988eae9"
 
 [[package]]
 name = "const-random"
@@ -2812,6 +2812,7 @@ dependencies = [
  "async-trait",
  "base64 0.12.3",
  "chrono",
+ "connection-string",
  "datamodel",
  "datamodel-connector",
  "feature-flags",
@@ -3552,6 +3553,7 @@ dependencies = [
 name = "test-setup"
 version = "0.1.0"
 dependencies = [
+ "connection-string",
  "enumflags2",
  "once_cell",
  "quaint",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -604,9 +604,9 @@ dependencies = [
 
 [[package]]
 name = "connection-string"
-version = "0.1.7"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4792f31bcb812a45b6776af34a2dc1d70d38fb93ab6f74548796afe43988eae9"
+checksum = "8cf9ff4ef35828f9e55249d69d57c1727c5409f168a4434d7bb6bb2c0e08bacc"
 
 [[package]]
 name = "const-random"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3278,6 +3278,7 @@ dependencies = [
  "async-trait",
  "barrel",
  "chrono",
+ "connection-string",
  "datamodel",
  "datamodel-connector",
  "enumflags2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -604,9 +604,9 @@ dependencies = [
 
 [[package]]
 name = "connection-string"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf9ff4ef35828f9e55249d69d57c1727c5409f168a4434d7bb6bb2c0e08bacc"
+checksum = "479c8a899d8b4fb4abe469c53f53e472131688245b0e3327537f36392b7b84e8"
 
 [[package]]
 name = "const-random"

--- a/libs/test-setup/Cargo.toml
+++ b/libs/test-setup/Cargo.toml
@@ -14,7 +14,7 @@ quaint = { git = "https://github.com/prisma/quaint", features = ["single"], opti
 once_cell = "1.3.1"
 enumflags2 = "0.6.0"
 tracing-error = "0.1.2"
-connection-string = "0.1.7"
+connection-string = "0.1.9"
 
 [features]
 default = ["sql"]

--- a/libs/test-setup/Cargo.toml
+++ b/libs/test-setup/Cargo.toml
@@ -14,7 +14,7 @@ quaint = { git = "https://github.com/prisma/quaint", features = ["single"], opti
 once_cell = "1.3.1"
 enumflags2 = "0.6.0"
 tracing-error = "0.1.2"
-connection-string = "0.1.9"
+connection-string = "0.1.10"
 
 [features]
 default = ["sql"]

--- a/libs/test-setup/Cargo.toml
+++ b/libs/test-setup/Cargo.toml
@@ -14,6 +14,7 @@ quaint = { git = "https://github.com/prisma/quaint", features = ["single"], opti
 once_cell = "1.3.1"
 enumflags2 = "0.6.0"
 tracing-error = "0.1.2"
+connection-string = "0.1.7"
 
 [features]
 default = ["sql"]

--- a/libs/test-setup/src/lib.rs
+++ b/libs/test-setup/src/lib.rs
@@ -538,7 +538,7 @@ pub async fn create_mssql_database(jdbc_string: &str) -> Result<Quaint, AnyError
     match params.remove("database") {
         Some(ref db_name) if db_name != "master" => {
             params.insert("database".into(), "master".into());
-            let conn = Quaint::new(conn.to_string()).await?;
+            let conn = Quaint::new(&conn.to_string()).await?;
             conn.raw_cmd(&format!("DROP DATABASE IF EXISTS {}", db_name)).await?;
             conn.raw_cmd(&format!("CREATE DATABASE {}", db_name)).await?;
         }

--- a/libs/test-setup/src/lib.rs
+++ b/libs/test-setup/src/lib.rs
@@ -532,7 +532,7 @@ pub async fn create_postgres_database(original_url: &Url) -> Result<Quaint, AnyE
 
 /// Create an MSSQL database from a JDBC connection string..
 pub async fn create_mssql_database(jdbc_string: &str) -> Result<Quaint, AnyError> {
-    let mut conn = connection_string::JdbcString::from_str(jdbc_string)?;
+    let mut conn = connection_string::JdbcString::from_str(&format!("jdbc:{}", jdbc_string))?;
 
     let params = conn.properties_mut();
     match params.remove("database") {

--- a/migration-engine/connectors/sql-migration-connector/Cargo.toml
+++ b/migration-engine/connectors/sql-migration-connector/Cargo.toml
@@ -17,7 +17,7 @@ anyhow = "1.0.26"
 async-trait = "0.1.17"
 barrel = {git = "https://github.com/prisma/barrel.git", features = ["sqlite3", "mysql", "pg", "mssql"], branch = "mssql-support"}
 chrono = { version = "0.4" }
-connection-string = "0.1.6"
+connection-string = "0.1.9"
 enumflags2 = "0.6.0"
 once_cell = "1.3"
 quaint = { git = "https://github.com/prisma/quaint", features = ["single", "tracing-log"] }

--- a/migration-engine/connectors/sql-migration-connector/Cargo.toml
+++ b/migration-engine/connectors/sql-migration-connector/Cargo.toml
@@ -17,7 +17,7 @@ anyhow = "1.0.26"
 async-trait = "0.1.17"
 barrel = {git = "https://github.com/prisma/barrel.git", features = ["sqlite3", "mysql", "pg", "mssql"], branch = "mssql-support"}
 chrono = { version = "0.4" }
-connection-string = "0.1.9"
+connection-string = "0.1.10"
 enumflags2 = "0.6.0"
 once_cell = "1.3"
 quaint = { git = "https://github.com/prisma/quaint", features = ["single", "tracing-log"] }

--- a/migration-engine/connectors/sql-migration-connector/Cargo.toml
+++ b/migration-engine/connectors/sql-migration-connector/Cargo.toml
@@ -16,7 +16,8 @@ user-facing-errors = {path = "../../../libs/user-facing-errors", features = ["sq
 anyhow = "1.0.26"
 async-trait = "0.1.17"
 barrel = {git = "https://github.com/prisma/barrel.git", features = ["sqlite3", "mysql", "pg", "mssql"], branch = "mssql-support"}
-chrono = {version = "0.4"}
+chrono = { version = "0.4" }
+connection-string = "0.1.6"
 enumflags2 = "0.6.0"
 once_cell = "1.3"
 quaint = { git = "https://github.com/prisma/quaint", features = ["single", "tracing-log"] }

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/mssql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/mssql.rs
@@ -15,7 +15,8 @@ impl MssqlFlavour {
 
     /// Get the url as a JDBC string, extract the database name, and re-encode the string.
     fn master_url(input: &str) -> ConnectorResult<(String, String)> {
-        let mut conn = JdbcString::from_str(input).map_err(|e| ConnectorError::generic(anyhow::Error::new(e)))?;
+        let mut conn = JdbcString::from_str(&format!("jdbc:{}", input))
+            .map_err(|e| ConnectorError::generic(anyhow::Error::new(e)))?;
         let params = conn.properties_mut();
 
         let db_name = params.remove("database").unwrap_or_else(|| String::from("master"));

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/mssql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/mssql.rs
@@ -1,8 +1,10 @@
 use crate::{connect, connection_wrapper::Connection, error::quaint_error_to_connector_error, SqlFlavour};
+use anyhow::format_err;
+use connection_string::JdbcString;
 use migration_connector::{ConnectorError, ConnectorResult, MigrationDirectory};
 use quaint::connector::MssqlUrl;
 use sql_schema_describer::{DescriberErrorKind, SqlSchema, SqlSchemaDescriberBackend};
-use std::collections::HashMap;
+use std::str::FromStr;
 
 #[derive(Debug)]
 pub(crate) struct MssqlFlavour(pub(crate) MssqlUrl);
@@ -12,33 +14,31 @@ impl MssqlFlavour {
         self.0.schema()
     }
 
-    fn master_url(jdbc_string: &str) -> (String, String) {
-        let mut splitted = jdbc_string.split(';');
-        let uri = splitted.next().unwrap().to_string();
+    fn master_url(input: &str) -> ConnectorResult<(String, String)> {
+        let mut conn = JdbcString::from_str(input).map_err(|e| ConnectorError::generic(anyhow::Error::new(e)))?;
+        let server_name = conn.server_name().ok_or_else(|| {
+            ConnectorError::generic(format_err!("JDBC connection string did not contain a server name"))
+        })?;
 
-        let mut params: HashMap<String, String> = splitted
-            .map(|kv| kv.split('='))
-            .map(|mut kv| {
-                let key = kv.next().unwrap().to_string();
-                let value = kv.next().unwrap().to_string();
-
-                (key, value)
-            })
-            .collect();
+        let host = match conn.instance_name() {
+            Some(instance_name) => format!(r#"{}\{}"#, server_name, instance_name),
+            None => server_name.to_string(),
+        };
+        let params = conn.properties_mut();
 
         let db_name = params.remove("database").unwrap_or_else(|| String::from("master"));
         let params: Vec<_> = params.into_iter().map(|(k, v)| format!("{}={}", k, v)).collect();
 
-        let master_uri = format!("{};{}", uri, params.join(";"));
+        let master_url = format!("{};{}", host, params.join(";"));
 
-        (db_name, master_uri)
+        Ok((db_name, master_url))
     }
 }
 
 #[async_trait::async_trait]
 impl SqlFlavour for MssqlFlavour {
     async fn create_database(&self, jdbc_string: &str) -> ConnectorResult<String> {
-        let (db_name, master_uri) = Self::master_url(jdbc_string);
+        let (db_name, master_uri) = Self::master_url(jdbc_string)?;
         let conn = connect(&master_uri.to_string()).await?;
 
         let query = format!("CREATE DATABASE [{}]", db_name);
@@ -131,7 +131,7 @@ impl SqlFlavour for MssqlFlavour {
     }
 
     async fn qe_setup(&self, database_str: &str) -> ConnectorResult<()> {
-        let (db_name, master_uri) = Self::master_url(database_str);
+        let (db_name, master_uri) = Self::master_url(database_str)?;
         let conn = connect(&master_uri).await?;
 
         // Without these, our poor connection gets deadlocks if other schemas

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/mssql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/mssql.rs
@@ -1,5 +1,4 @@
 use crate::{connect, connection_wrapper::Connection, error::quaint_error_to_connector_error, SqlFlavour};
-use anyhow::format_err;
 use connection_string::JdbcString;
 use migration_connector::{ConnectorError, ConnectorResult, MigrationDirectory};
 use quaint::connector::MssqlUrl;
@@ -20,8 +19,6 @@ impl MssqlFlavour {
         let params = conn.properties_mut();
 
         let db_name = params.remove("database").unwrap_or_else(|| String::from("master"));
-        let params: Vec<_> = params.into_iter().map(|(k, v)| format!("{}={}", k, v)).collect();
-
         Ok((db_name, conn.to_string()))
     }
 }

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/mssql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/mssql.rs
@@ -14,6 +14,7 @@ impl MssqlFlavour {
         self.0.schema()
     }
 
+    /// Get the url as a JDBC string, extract the database name, and re-encode the string.
     fn master_url(input: &str) -> ConnectorResult<(String, String)> {
         let mut conn = JdbcString::from_str(input).map_err(|e| ConnectorError::generic(anyhow::Error::new(e)))?;
         let server_name = conn.server_name().ok_or_else(|| {

--- a/query-engine/query-engine/Cargo.toml
+++ b/query-engine/query-engine/Cargo.toml
@@ -18,7 +18,7 @@ async-std = {version = "1.6.2", features = ["attributes", "tokio02"]}
 async-trait = "0.1"
 base64 = "0.12"
 connector = {path = "../connectors/query-connector", package = "query-connector"}
-connection-string = "0.1.9"
+connection-string = "0.1.10"
 datamodel = {path = "../../libs/datamodel/core"}
 datamodel-connector = {path = "../../libs/datamodel/connectors/datamodel-connector"}
 feature-flags = {path = "../../libs/feature-flags"}

--- a/query-engine/query-engine/Cargo.toml
+++ b/query-engine/query-engine/Cargo.toml
@@ -18,6 +18,7 @@ async-std = {version = "1.6.2", features = ["attributes", "tokio02"]}
 async-trait = "0.1"
 base64 = "0.12"
 connector = {path = "../connectors/query-connector", package = "query-connector"}
+connection-string = "0.1.7"
 datamodel = {path = "../../libs/datamodel/core"}
 datamodel-connector = {path = "../../libs/datamodel/connectors/datamodel-connector"}
 feature-flags = {path = "../../libs/feature-flags"}

--- a/query-engine/query-engine/Cargo.toml
+++ b/query-engine/query-engine/Cargo.toml
@@ -18,7 +18,7 @@ async-std = {version = "1.6.2", features = ["attributes", "tokio02"]}
 async-trait = "0.1"
 base64 = "0.12"
 connector = {path = "../connectors/query-connector", package = "query-connector"}
-connection-string = "0.1.7"
+connection-string = "0.1.9"
 datamodel = {path = "../../libs/datamodel/core"}
 datamodel-connector = {path = "../../libs/datamodel/connectors/datamodel-connector"}
 feature-flags = {path = "../../libs/feature-flags"}

--- a/query-engine/query-engine/src/error.rs
+++ b/query-engine/query-engine/src/error.rs
@@ -97,6 +97,12 @@ impl From<url::ParseError> for PrismaError {
     }
 }
 
+impl From<connection_string::Error> for PrismaError {
+    fn from(e: connection_string::Error) -> PrismaError {
+        PrismaError::ConfigurationError(format!("Error parsing connection string: {}", e))
+    }
+}
+
 impl From<serde_json::error::Error> for PrismaError {
     fn from(e: serde_json::error::Error) -> PrismaError {
         PrismaError::JsonDecodeError(e.into())

--- a/query-engine/query-engine/src/exec_loader.rs
+++ b/query-engine/query-engine/src/exec_loader.rs
@@ -104,7 +104,7 @@ async fn mssql(source: &Datasource) -> PrismaResult<(String, Box<dyn QueryExecut
 
     let mssql = Mssql::from_source(source).await?;
 
-    let mut conn = JdbcString::from_str(&source.url().value)?;
+    let mut conn = JdbcString::from_str(&format!("jdbc:{}", &source.url().value))?;
     let db_name = conn
         .properties_mut()
         .remove("schema")

--- a/query-engine/query-engine/src/exec_loader.rs
+++ b/query-engine/query-engine/src/exec_loader.rs
@@ -1,5 +1,7 @@
 use crate::{PrismaError, PrismaResult};
+use connection_string::JdbcString;
 use connector::Connector;
+use std::str::FromStr;
 
 use datamodel::{
     common::provider_names::{MSSQL_SOURCE_NAME, MYSQL_SOURCE_NAME, POSTGRES_SOURCE_NAME, SQLITE_SOURCE_NAME},
@@ -102,20 +104,11 @@ async fn mssql(source: &Datasource) -> PrismaResult<(String, Box<dyn QueryExecut
 
     let mssql = Mssql::from_source(source).await?;
 
-    let mut splitted = source.url().value.split(';');
-    splitted.next();
-
-    let mut params: HashMap<String, String> = splitted
-        .map(|kv| {
-            let mut splitted = kv.split('=');
-            let key = splitted.next().unwrap();
-            let value = splitted.next().unwrap();
-
-            (key.to_lowercase(), value.to_string())
-        })
-        .collect();
-
-    let db_name = params.remove("schema").unwrap_or_else(|| String::from("dbo"));
+    let mut conn = JdbcString::from_str(&source.url().value)?;
+    let db_name = conn
+        .properties_mut()
+        .remove("schema")
+        .unwrap_or_else(|| String::from("dbo"));
 
     trace!("Loaded SQL Server connector.");
     Ok((db_name, sql_executor(mssql, false)))


### PR DESCRIPTION
Uses connection-string to parse JDBC connection strings in engines. This was mostly a straightforward process to replace some code; most what changed is that we now handle errors in the connection string. Thanks!