### PR TITLE
Escape raw parameters correctly

### DIFF
--- a/libs/prisma-value/src/lib.rs
+++ b/libs/prisma-value/src/lib.rs
@@ -48,9 +48,7 @@ impl TryFrom<serde_json::Value> for PrismaValue {
 
     fn try_from(v: serde_json::Value) -> PrismaValueResult<Self> {
         match v {
-            serde_json::Value::String(s) => Ok(serde_json::from_str(&s)
-                .map(PrismaValue::Json)
-                .unwrap_or(PrismaValue::String(s))),
+            serde_json::Value::String(s) => Ok(PrismaValue::String(s)),
             serde_json::Value::Array(v) => {
                 let vals: PrismaValueResult<Vec<PrismaValue>> = v.into_iter().map(PrismaValue::try_from).collect();
                 Ok(PrismaValue::List(vals?))


### PR DESCRIPTION
Allows using parameters such as `"foo"` in raw queries without stripping the quotes.

Closes https://github.com/prisma/prisma-client-js/issues/831