### PR TITLE
Remove direct dependency on sha2 in sql-migration-connector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3229,7 +3229,6 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha2 0.9.1",
  "sql-schema-describer",
  "tempfile",
  "tokio",

--- a/migration-engine/connectors/migration-connector/src/lib.rs
+++ b/migration-engine/connectors/migration-connector/src/lib.rs
@@ -29,6 +29,7 @@ pub use migration_persistence::*;
 pub use migrations_directory::{create_migration_directory, list_migrations, ListMigrationsError, MigrationDirectory};
 pub use steps::MigrationStep;
 
+use sha2::{Digest, Sha256};
 use std::fmt::Debug;
 
 /// The top-level trait for connectors. This is the abstraction the migration engine core relies on to
@@ -111,6 +112,14 @@ pub trait DatabaseMigrationMarker: Debug + Send + Sync {
 /// Shorthand for a [Result](https://doc.rust-lang.org/std/result/enum.Result.html) where the error
 /// variant is a [ConnectorError](/error/enum.ConnectorError.html).
 pub type ConnectorResult<T> = Result<T, ConnectorError>;
+
+/// Compute the checksum for a migration script, and return it formatted to be human-readable.
+fn checksum(script: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(script.as_bytes());
+    let checksum: [u8; 32] = hasher.finalize().into();
+    checksum.format_checksum()
+}
 
 /// Format a checksum to a hexadecimal string. This is used to checksum
 /// migration scripts with Sha256.

--- a/migration-engine/connectors/migration-connector/src/migration_persistence.rs
+++ b/migration-engine/connectors/migration-connector/src/migration_persistence.rs
@@ -1,6 +1,6 @@
 use crate::{error::ConnectorError, steps::*, ConnectorResult};
 use chrono::{DateTime, Utc};
-use datamodel::{ast::SchemaAst, error::ErrorCollection, Datamodel};
+use datamodel::{ast::SchemaAst, Datamodel};
 use serde::Serialize;
 use std::str::FromStr;
 
@@ -163,13 +163,14 @@ impl Migration {
         datetime
     }
 
-    pub fn parse_datamodel(&self) -> Result<Datamodel, (ErrorCollection, String)> {
+    pub fn parse_datamodel(&self) -> Result<Datamodel, String> {
         datamodel::parse_datamodel_and_ignore_datasource_urls(&self.datamodel_string)
-            .map_err(|err| (err, self.datamodel_string.clone()))
+            .map_err(|err| err.to_pretty_string("schema.prisma", &self.datamodel_string))
     }
 
-    pub fn parse_schema_ast(&self) -> Result<SchemaAst, (ErrorCollection, String)> {
-        datamodel::parse_schema_ast(&self.datamodel_string).map_err(|err| (err, self.datamodel_string.clone()))
+    pub fn parse_schema_ast(&self) -> Result<SchemaAst, String> {
+        datamodel::parse_schema_ast(&self.datamodel_string)
+            .map_err(|err| err.to_pretty_string("schema.prisma", &self.datamodel_string))
     }
 }
 

--- a/migration-engine/connectors/sql-migration-connector/Cargo.toml
+++ b/migration-engine/connectors/sql-migration-connector/Cargo.toml
@@ -23,7 +23,6 @@ quaint = { git = "https://github.com/prisma/quaint", features = ["single", "trac
 regex = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-sha2 = "0.9.1"
 tempfile = "3.1.0"
 tokio = { version = "0.2.13", default-features = false, features = ["time"] }
 tracing = "0.1.10"

--- a/migration-engine/core/src/commands/apply_migration.rs
+++ b/migration-engine/core/src/commands/apply_migration.rs
@@ -51,14 +51,14 @@ impl<'a> ApplyMigrationCommand<'a> {
         let current_datamodel = last_migration
             .map(|migration| migration.parse_datamodel())
             .unwrap_or_else(|| Ok(Datamodel::new()))
-            .map_err(|(err, schema)| CoreError::InvalidPersistedDatamodel(err, schema))?;
+            .map_err(CoreError::InvalidPersistedDatamodel)?;
 
         let last_non_watch_datamodel = migration_persistence
             .last_non_watch_migration()
             .await?
             .map(|m| m.parse_schema_ast())
             .unwrap_or_else(|| Ok(SchemaAst::empty()))
-            .map_err(|(err, schema)| CoreError::InvalidPersistedDatamodel(err, schema))?;
+            .map_err(CoreError::InvalidPersistedDatamodel)?;
         let next_datamodel_ast = engine
             .datamodel_calculator()
             .infer(&last_non_watch_datamodel, self.input.steps.as_slice())?;
@@ -93,11 +93,11 @@ impl<'a> ApplyMigrationCommand<'a> {
             .as_ref()
             .map(|migration| migration.parse_schema_ast())
             .unwrap_or_else(|| Ok(SchemaAst::empty()))
-            .map_err(|(err, schema)| CoreError::InvalidPersistedDatamodel(err, schema))?;
+            .map_err(CoreError::InvalidPersistedDatamodel)?;
         let current_datamodel = last_migration
             .map(|migration| migration.parse_datamodel())
             .unwrap_or_else(|| Ok(Datamodel::new()))
-            .map_err(|(err, schema)| CoreError::InvalidPersistedDatamodel(err, schema))?;
+            .map_err(CoreError::InvalidPersistedDatamodel)?;
 
         let next_datamodel_ast = engine
             .datamodel_calculator()

--- a/migration-engine/core/src/commands/infer_migration_steps.rs
+++ b/migration-engine/core/src/commands/infer_migration_steps.rs
@@ -37,7 +37,7 @@ impl<'a> MigrationCommand for InferMigrationStepsCommand<'a> {
         let current_datamodel_ast = if let Some(migration) = last_migration.as_ref() {
             migration
                 .parse_schema_ast()
-                .map_err(|(err, schema)| CoreError::InvalidPersistedDatamodel(err, schema))?
+                .map_err(CoreError::InvalidPersistedDatamodel)?
         } else {
             SchemaAst::empty()
         };
@@ -78,11 +78,11 @@ impl<'a> MigrationCommand for InferMigrationStepsCommand<'a> {
                     .as_ref()
                     .map(|m| m.parse_schema_ast())
                     .unwrap_or_else(|| Ok(SchemaAst::empty()))
-                    .map_err(|(err, schema)| CoreError::InvalidPersistedDatamodel(err, schema))?;
+                    .map_err(CoreError::InvalidPersistedDatamodel)?;
                 let last_non_watch_datamodel = last_non_watch_applied_migration
                     .map(|m| m.parse_datamodel())
                     .unwrap_or_else(|| Ok(Datamodel::new()))
-                    .map_err(|(err, schema)| CoreError::InvalidPersistedDatamodel(err, schema))?;
+                    .map_err(CoreError::InvalidPersistedDatamodel)?;
                 let datamodel_steps = engine
                     .datamodel_migration_steps_inferrer()
                     .infer(&last_non_watch_datamodel_ast, &next_datamodel_ast);

--- a/migration-engine/core/src/commands/unapply_migration.rs
+++ b/migration-engine/core/src/commands/unapply_migration.rs
@@ -34,19 +34,19 @@ impl<'a> MigrationCommand for UnapplyMigrationCommand<'a> {
                     .as_ref()
                     .map(|migration| migration.parse_schema_ast())
                     .unwrap_or_else(|| Ok(SchemaAst::empty()))
-                    .map_err(|(err, schema)| CoreError::InvalidPersistedDatamodel(err, schema))?;
+                    .map_err(CoreError::InvalidPersistedDatamodel)?;
                 let schema_before_last_migration = second_to_last
                     .as_ref()
                     .map(|migration| migration.parse_datamodel())
                     .unwrap_or_else(|| Ok(Datamodel::new()))
-                    .map_err(|(err, schema)| CoreError::InvalidPersistedDatamodel(err, schema))?;
+                    .map_err(CoreError::InvalidPersistedDatamodel)?;
 
                 let last_schema_ast = migration_to_rollback
                     .parse_schema_ast()
-                    .map_err(|(err, schema)| CoreError::InvalidPersistedDatamodel(err, schema))?;
+                    .map_err(CoreError::InvalidPersistedDatamodel)?;
                 let last_schema = migration_to_rollback
                     .parse_datamodel()
-                    .map_err(|(err, schema)| CoreError::InvalidPersistedDatamodel(err, schema))?;
+                    .map_err(CoreError::InvalidPersistedDatamodel)?;
 
                 // Generate backwards datamodel steps.
                 let datamodel_migration =

--- a/migration-engine/core/src/core_error.rs
+++ b/migration-engine/core/src/core_error.rs
@@ -17,7 +17,7 @@ pub enum CoreError {
     ProducedBadDatamodel(datamodel::error::ErrorCollection),
 
     /// When a saved datamodel from a migration in the migrations table is no longer valid.
-    InvalidPersistedDatamodel(datamodel::error::ErrorCollection, String),
+    InvalidPersistedDatamodel(String),
 
     /// Failed to render a prisma schema to a string.
     DatamodelRenderingError(datamodel::error::ErrorCollection),
@@ -41,11 +41,9 @@ impl Display for CoreError {
                 "The migration produced an invalid schema.\n{}",
                 render_datamodel_error(err, None)
             ),
-            CoreError::InvalidPersistedDatamodel(err, schema) => write!(
-                f,
-                "The migration contains an invalid schema.\n{}",
-                render_datamodel_error(err, Some(schema))
-            ),
+            CoreError::InvalidPersistedDatamodel(err) => {
+                write!(f, "The migration contains an invalid schema.\n{}", err)
+            }
             CoreError::DatamodelRenderingError(err) => write!(f, "Failed to render the schema to a string ({:?})", err),
             CoreError::ConnectorError(err) => write!(f, "Connector error: {}", err),
             CoreError::Generic(src) => write!(f, "Generic error: {}", src),
@@ -59,7 +57,7 @@ impl StdError for CoreError {
         match self {
             CoreError::ReceivedBadDatamodel(_) => None,
             CoreError::ProducedBadDatamodel(_) => None,
-            CoreError::InvalidPersistedDatamodel(_, _) => None,
+            CoreError::InvalidPersistedDatamodel(_) => None,
             CoreError::DatamodelRenderingError(_) => None,
             CoreError::ConnectorError(err) => Some(err),
             CoreError::Generic(err) => Some(err.as_ref()),


### PR DESCRIPTION
migration-connector is now the sole responsible for hashing.