### PR TITLE
Remove MigrationStepsResultOutput::{general_errors, errors}

### DIFF
--- a/libs/user-facing-errors/src/common.rs
+++ b/libs/user-facing-errors/src/common.rs
@@ -161,6 +161,16 @@ pub struct InvalidModel {
     pub kind: ModelKind,
 }
 
+#[derive(Debug, UserFacingError, Serialize)]
+#[user_facing(
+    code = "P1015",
+    message = "Your Prisma schema is using features that are not supported for the version of the database.\nDatabase version: {database_version}\nErrors:\n{errors}"
+)]
+pub struct DatabaseVersionIncompatibility {
+    pub database_version: String,
+    pub errors: String,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/migration-engine/connectors/migration-connector/src/destructive_change_checker.rs
+++ b/migration-engine/connectors/migration-connector/src/destructive_change_checker.rs
@@ -24,8 +24,6 @@ where
 /// The errors and warnings emitted by the [DestructiveChangeChecker](trait.DestructiveChangeChecker.html).
 #[derive(Debug, Default)]
 pub struct DestructiveChangeDiagnostics {
-    /// Soon to be deleted.
-    pub errors: Vec<MigrationError>,
     /// The warnings.
     pub warnings: Vec<MigrationWarning>,
     /// Steps that are not executable.
@@ -59,14 +57,6 @@ pub struct MigrationWarning {
     pub description: String,
     /// The index of the step in the migration that this warning applies to.
     pub step_index: usize,
-}
-
-/// An error emitted by the [DestructiveChangeChecker](trait.DestructiveChangeChecker.html). Errors will
-/// always prevent a migration from being applied.
-#[derive(Debug, Serialize, PartialEq, Deserialize)]
-pub struct MigrationError {
-    /// The user-facing error description.
-    pub description: String,
 }
 
 /// An unexecutable migration step detected by the DestructiveChangeChecker.

--- a/migration-engine/connectors/migration-connector/src/lib.rs
+++ b/migration-engine/connectors/migration-connector/src/lib.rs
@@ -63,8 +63,8 @@ pub trait MigrationConnector: Send + Sync + 'static {
     fn check_database_version_compatibility(
         &self,
         _datamodel: &datamodel::dml::Datamodel,
-    ) -> Vec<destructive_change_checker::MigrationError> {
-        Vec::new()
+    ) -> Option<user_facing_errors::common::DatabaseVersionIncompatibility> {
+        None
     }
 
     /// See [MigrationPersistence](trait.MigrationPersistence.html).

--- a/migration-engine/connectors/sql-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/lib.rs
@@ -136,7 +136,10 @@ impl MigrationConnector for SqlMigrationConnector {
 
     /// Optionally check that the features implied by the provided datamodel are all compatible with
     /// the specific database version being used.
-    fn check_database_version_compatibility(&self, datamodel: &datamodel::dml::Datamodel) -> Vec<MigrationError> {
+    fn check_database_version_compatibility(
+        &self,
+        datamodel: &datamodel::dml::Datamodel,
+    ) -> Option<user_facing_errors::common::DatabaseVersionIncompatibility> {
         self.database_info.check_database_version_compatibility(datamodel)
     }
 

--- a/migration-engine/core/src/commands.rs
+++ b/migration-engine/core/src/commands.rs
@@ -51,9 +51,7 @@ pub use reset::ResetCommand;
 pub use schema_push::{SchemaPushCommand, SchemaPushInput, SchemaPushOutput};
 pub use unapply_migration::*;
 
-use migration_connector::{
-    MigrationError, MigrationStep, MigrationWarning, PrettyDatabaseMigrationStep, UnexecutableMigration,
-};
+use migration_connector::{MigrationStep, MigrationWarning, PrettyDatabaseMigrationStep, UnexecutableMigration};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -64,7 +62,7 @@ pub struct MigrationStepsResultOutput {
     pub datamodel_steps: Vec<MigrationStep>,
     pub database_steps: Vec<PrettyDatabaseMigrationStep>,
     pub warnings: Vec<MigrationWarning>,
-    pub errors: Vec<MigrationError>,
-    pub general_errors: Vec<String>,
+    pub errors: [(); 0],
+    pub general_errors: [(); 0],
     pub unexecutable_migrations: Vec<UnexecutableMigration>,
 }

--- a/migration-engine/core/src/commands/apply_migration.rs
+++ b/migration-engine/core/src/commands/apply_migration.rs
@@ -174,7 +174,6 @@ impl<'a> ApplyMigrationCommand<'a> {
 
         let DestructiveChangeDiagnostics {
             warnings,
-            errors,
             unexecutable_migrations,
         } = diagnostics;
 
@@ -182,9 +181,9 @@ impl<'a> ApplyMigrationCommand<'a> {
             datamodel: datamodel::render_datamodel_to_string(&next_datamodel.subject).unwrap(),
             datamodel_steps: self.input.steps.clone(),
             database_steps: database_steps_json_pretty,
-            errors,
+            errors: [],
             warnings,
-            general_errors: Vec::new(),
+            general_errors: [],
             unexecutable_migrations,
         })
     }

--- a/migration-engine/core/src/commands/calculate_database_steps.rs
+++ b/migration-engine/core/src/commands/calculate_database_steps.rs
@@ -51,7 +51,6 @@ impl<'a> MigrationCommand for CalculateDatabaseStepsCommand<'a> {
 
         let DestructiveChangeDiagnostics {
             warnings,
-            errors: _,
             unexecutable_migrations,
         } = connector
             .destructive_change_checker()
@@ -66,9 +65,9 @@ impl<'a> MigrationCommand for CalculateDatabaseStepsCommand<'a> {
             datamodel: datamodel::render_schema_ast_to_string(&next_datamodel_ast).unwrap(),
             datamodel_steps: steps_to_apply.to_vec(),
             database_steps: database_steps_json,
-            errors: Vec::new(),
+            errors: [],
             warnings,
-            general_errors: Vec::new(),
+            general_errors: [],
             unexecutable_migrations,
         })
     }

--- a/migration-engine/migration-engine-tests/src/test_api/infer.rs
+++ b/migration-engine/migration-engine-tests/src/test_api/infer.rs
@@ -4,6 +4,7 @@ use migration_connector::MigrationStep;
 use migration_core::{
     api::GenericApi,
     commands::{AppliedMigration, InferMigrationStepsInput, MigrationStepsResultOutput},
+    CoreResult,
 };
 
 pub struct Infer<'a> {
@@ -47,7 +48,7 @@ impl<'a> Infer<'a> {
         Ok(InferAssertion { result, _api: api })
     }
 
-    pub async fn send(self) -> Result<MigrationStepsResultOutput, anyhow::Error> {
+    pub async fn send(self) -> CoreResult<MigrationStepsResultOutput> {
         let migration_id = self.migration_id.unwrap_or_else(unique_migration_id);
 
         let input = InferMigrationStepsInput {


### PR DESCRIPTION
- Clean up unused API surface
- Improve error reporting