### PR TITLE
Refine MySQL 5.6 version matching

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/database_info.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/database_info.rs
@@ -30,7 +30,7 @@ impl DatabaseInfo {
             && self
                 .database_version
                 .as_ref()
-                .map(|version| version.contains("5.6"))
+                .map(|version| version.starts_with("5.6"))
                 .unwrap_or(false)
     }
 


### PR DESCRIPTION
Tests started failing in CI because a new minor version of MariaDB has a minor version including the "5.6" substring.