### PR TITLE
Clean up RedefineTable diffing hack in migration engine 

### DIFF
--- a/libs/sql-schema-describer/src/lib.rs
+++ b/libs/sql-schema-describer/src/lib.rs
@@ -15,6 +15,7 @@ use std::{
     str::FromStr,
 };
 use tracing::debug;
+use walkers::TableWalker;
 
 pub mod mssql;
 pub mod mysql;
@@ -123,6 +124,10 @@ impl SqlSchema {
             enums: Vec::new(),
             sequences: Vec::new(),
         }
+    }
+
+    pub fn table_walkers<'a>(&'a self) -> impl Iterator<Item = TableWalker<'a>> + 'a {
+        self.tables.iter().map(move |table| TableWalker::new(self, table))
     }
 }
 

--- a/libs/sql-schema-describer/src/walkers.rs
+++ b/libs/sql-schema-describer/src/walkers.rs
@@ -35,18 +35,23 @@ pub fn find_column<'a>(schema: &'a SqlSchema, table_name: &str, column_name: &st
 /// Traverse a table column.
 #[derive(Debug, Clone, Copy)]
 pub struct ColumnWalker<'a> {
-    /// The schema the column is contained in. This field will become private.
-    pub schema: &'a SqlSchema,
-    /// The underlying column struct. This field will become private.
-    pub column: &'a Column,
-    /// The underlying table struct. This field will become private.
-    pub table: &'a Table,
+    /// The schema the column is contained in.
+    schema: &'a SqlSchema,
+    /// The underlying column struct.
+    column: &'a Column,
+    /// The underlying table struct.
+    table: &'a Table,
 }
 
 impl<'a> ColumnWalker<'a> {
     /// The nullability and arity of the column.
     pub fn arity(&self) -> &ColumnArity {
         &self.column.tpe.arity
+    }
+
+    /// A reference to the underlying Column struct.
+    pub fn column(&self) -> &Column {
+        &self.column
     }
 
     /// The type family.
@@ -121,7 +126,7 @@ pub struct TableWalker<'a> {
 }
 
 impl<'a> TableWalker<'a> {
-    /// Create a TableWalker from a schema and a reference to one of its tables.
+    /// Create a TableWalker from a schema and a reference to one of its tables. This should stay private.
     pub(crate) fn new(schema: &'a SqlSchema, table: &'a Table) -> Self {
         Self { schema, table }
     }

--- a/libs/sql-schema-describer/src/walkers.rs
+++ b/libs/sql-schema-describer/src/walkers.rs
@@ -3,8 +3,8 @@
 #![deny(missing_docs)]
 
 use crate::{
-    Column, ColumnArity, ColumnType, ColumnTypeFamily, DefaultValue, Enum, ForeignKey, Index, IndexType, PrimaryKey,
-    SqlSchema, Table,
+    Column, ColumnArity, ColumnType, ColumnTypeFamily, DefaultValue, Enum, ForeignKey, ForeignKeyAction, Index,
+    IndexType, PrimaryKey, SqlSchema, Table,
 };
 
 /// Traverse all the columns in the schema.
@@ -114,15 +114,15 @@ impl<'a> ColumnWalker<'a> {
 /// Traverse a table.
 #[derive(Clone, Copy)]
 pub struct TableWalker<'a> {
-    /// The schema the column is contained in. This field will become private.
-    pub schema: &'a SqlSchema,
-    /// The underlying table struct. This field will become private.
-    pub table: &'a Table,
+    /// The schema the column is contained in.
+    schema: &'a SqlSchema,
+    /// The underlying table struct.
+    table: &'a Table,
 }
 
 impl<'a> TableWalker<'a> {
     /// Create a TableWalker from a schema and a reference to one of its tables.
-    pub fn new(schema: &'a SqlSchema, table: &'a Table) -> Self {
+    pub(crate) fn new(schema: &'a SqlSchema, table: &'a Table) -> Self {
         Self { schema, table }
     }
 
@@ -140,6 +140,11 @@ impl<'a> TableWalker<'a> {
         })
     }
 
+    /// The number of foreign key constraints on the table.
+    pub fn foreign_key_count(&self) -> usize {
+        self.table.foreign_keys.len()
+    }
+
     /// Traverse the indexes on the table.
     pub fn indexes<'b>(&'b self) -> impl Iterator<Item = IndexWalker<'a>> + 'b {
         self.table.indices.iter().map(move |index| IndexWalker {
@@ -149,12 +154,31 @@ impl<'a> TableWalker<'a> {
         })
     }
 
+    /// Same as `TableWalker::columns()`, but takes ownership.
+    pub fn into_columns(self) -> impl Iterator<Item = ColumnWalker<'a>> {
+        self.table.columns.iter().map(move |column| ColumnWalker {
+            column,
+            schema: self.schema,
+            table: self.table,
+        })
+    }
+
     /// Traverse the foreign keys on the table.
     pub fn foreign_keys(self) -> impl Iterator<Item = ForeignKeyWalker<'a>> {
         self.table.foreign_keys.iter().map(move |foreign_key| ForeignKeyWalker {
             foreign_key,
-            table: self,
+            table: self.table,
+            schema: self.schema,
         })
+    }
+
+    /// Get a foreign key by index.
+    pub fn foreign_key_at(&self, index: usize) -> ForeignKeyWalker<'a> {
+        ForeignKeyWalker {
+            schema: self.schema,
+            table: self.table,
+            foreign_key: &self.table.foreign_keys[index],
+        }
     }
 
     /// The table name.
@@ -171,12 +195,33 @@ impl<'a> TableWalker<'a> {
     pub fn primary_key(&self) -> Option<&'a PrimaryKey> {
         self.table.primary_key.as_ref()
     }
+
+    /// The names of the columns that are part of the primary key. `None` means
+    /// there is no primary key on the table.
+    pub fn primary_key_column_names(&self) -> Option<&[String]> {
+        self.table.primary_key.as_ref().map(|pk| pk.columns.as_slice())
+    }
+
+    /// Reference to the underlying `Table` struct.
+    pub fn table(&self) -> &Table {
+        &self.table
+    }
+
+    /// Walks the parent schema to find the index of the table inside it.
+    pub fn table_index(&self) -> usize {
+        self.schema
+            .tables
+            .iter()
+            .position(|table| table.name == self.table.name)
+            .unwrap()
+    }
 }
 
 /// Traverse a foreign key.
 pub struct ForeignKeyWalker<'schema> {
-    table: TableWalker<'schema>,
     foreign_key: &'schema ForeignKey,
+    table: &'schema Table,
+    schema: &'schema SqlSchema,
 }
 
 impl<'a, 'schema> ForeignKeyWalker<'schema> {
@@ -188,7 +233,7 @@ impl<'a, 'schema> ForeignKeyWalker<'schema> {
     /// The foreign key columns on the referencing table.
     pub fn constrained_columns<'b>(&'b self) -> impl Iterator<Item = ColumnWalker<'schema>> + 'b {
         self.table()
-            .columns()
+            .into_columns()
             .filter(move |column| self.foreign_key.columns.contains(&column.column.name))
     }
 
@@ -197,9 +242,40 @@ impl<'a, 'schema> ForeignKeyWalker<'schema> {
         self.foreign_key.constraint_name.as_deref()
     }
 
+    /// The underlying ForeignKey struct.
+    pub fn foreign_key(&self) -> &ForeignKey {
+        &self.foreign_key
+    }
+
+    /// Walks the parent schema to find the index of the table inside it.
+    pub fn foreign_key_index(&self) -> usize {
+        self.table
+            .foreign_keys
+            .iter()
+            .position(|fk| {
+                fk.constraint_name == self.foreign_key.constraint_name && fk.columns == self.foreign_key.columns
+            })
+            .unwrap()
+    }
+
     /// Access the underlying ForeignKey struct.
     pub fn inner(&self) -> &'schema ForeignKey {
         self.foreign_key
+    }
+
+    /// The `ON DELETE` behaviour of the foreign key.
+    pub fn on_delete_action(&self) -> &ForeignKeyAction {
+        &self.foreign_key.on_delete_action
+    }
+
+    /// The `ON UPDATE` behaviour of the foreign key.
+    pub fn on_update_action(&self) -> &ForeignKeyAction {
+        &self.foreign_key.on_update_action
+    }
+
+    /// The names of the columns referenced by the foreign key on the referenced table.
+    pub fn referenced_column_names(&self) -> &[String] {
+        &self.foreign_key.referenced_columns
     }
 
     /// The number of columns referenced by the constraint.
@@ -210,9 +286,8 @@ impl<'a, 'schema> ForeignKeyWalker<'schema> {
     /// The table the foreign key "points to".
     pub fn referenced_table(&self) -> TableWalker<'schema> {
         TableWalker {
-            schema: self.table.schema,
+            schema: self.schema,
             table: self
-                .table
                 .schema
                 .table(&self.foreign_key.referenced_table)
                 .expect("foreign key references unknown table"),
@@ -220,8 +295,11 @@ impl<'a, 'schema> ForeignKeyWalker<'schema> {
     }
 
     /// Traverse to the referencing table.
-    pub fn table(&self) -> &TableWalker<'schema> {
-        &self.table
+    pub fn table(&self) -> TableWalker<'schema> {
+        TableWalker {
+            schema: self.schema,
+            table: self.table,
+        }
     }
 }
 
@@ -277,6 +355,9 @@ impl<'a> IndexWalker<'a> {
 pub trait SqlSchemaExt {
     /// Find a table by name.
     fn table_walker<'a>(&'a self, name: &str) -> Option<TableWalker<'a>>;
+
+    /// Find a table by index.
+    fn table_walker_at<'a>(&'a self, index: usize) -> TableWalker<'a>;
 }
 
 impl SqlSchemaExt for SqlSchema {
@@ -285,5 +366,12 @@ impl SqlSchemaExt for SqlSchema {
             table: self.table(name).ok()?,
             schema: self,
         })
+    }
+
+    fn table_walker_at<'a>(&'a self, index: usize) -> TableWalker<'a> {
+        TableWalker {
+            table: &self.tables[index],
+            schema: self,
+        }
     }
 }

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/mysql.rs
@@ -13,12 +13,6 @@ use url::Url;
 #[derive(Debug)]
 pub(crate) struct MysqlFlavour(pub(super) MysqlUrl);
 
-impl MysqlFlavour {
-    pub(crate) fn schema_name(&self) -> &str {
-        self.0.dbname()
-    }
-}
-
 #[async_trait::async_trait]
 impl SqlFlavour for MysqlFlavour {
     fn check_database_info(&self, database_info: &DatabaseInfo) -> CheckDatabaseInfoResult {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
@@ -171,7 +171,12 @@ fn render_raw_sql(
         }
         SqlMigrationStep::DropTable(DropTable { name }) => renderer.render_drop_table(name),
         SqlMigrationStep::RenameTable { name, new_name } => vec![renderer.render_rename_table(name, new_name)],
-        SqlMigrationStep::AddForeignKey(add_foreign_key) => vec![renderer.render_add_foreign_key(add_foreign_key)],
+        SqlMigrationStep::AddForeignKey(add_foreign_key) => {
+            let foreign_key = next_schema
+                .table_walker_at(add_foreign_key.table_index)
+                .foreign_key_at(add_foreign_key.foreign_key_index);
+            vec![renderer.render_add_foreign_key(&foreign_key)]
+        }
         SqlMigrationStep::DropForeignKey(drop_foreign_key) => vec![renderer.render_drop_foreign_key(drop_foreign_key)],
         SqlMigrationStep::AlterTable(alter_table) => renderer.render_alter_table(alter_table, &differ),
         SqlMigrationStep::CreateIndex(create_index) => vec![renderer.render_create_index(create_index)],

--- a/migration-engine/connectors/sql-migration-connector/src/sql_migration.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_migration.rs
@@ -114,6 +114,12 @@ pub struct AlterColumn {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct AddForeignKey {
     pub table: String,
+    /// The index of the table in the next schema.
+    #[serde(skip)]
+    pub table_index: usize,
+    /// The index of the foreign key in the table.
+    #[serde(skip)]
+    pub foreign_key_index: usize,
     pub foreign_key: ForeignKey,
 }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
@@ -4,17 +4,16 @@ use crate::{
     flavour::PostgresFlavour,
     sql_migration::{
         expanded_alter_column::{expand_postgres_alter_column, PostgresAlterColumn},
-        AddColumn, AddForeignKey, AlterColumn, AlterEnum, AlterIndex, AlterTable, CreateEnum, CreateIndex, DropColumn,
-        DropEnum, DropForeignKey, DropIndex, TableChange,
+        AddColumn, AlterColumn, AlterEnum, AlterIndex, AlterTable, CreateEnum, CreateIndex, DropColumn, DropEnum,
+        DropForeignKey, DropIndex, TableChange,
     },
     sql_schema_differ::{ColumnDiffer, SqlSchemaDiffer},
 };
 use once_cell::sync::Lazy;
 use prisma_value::PrismaValue;
 use regex::Regex;
-use sql_schema_describer::walkers::*;
-use sql_schema_describer::*;
-use std::{borrow::Cow, fmt::Write as _};
+use sql_schema_describer::{walkers::*, *};
+use std::borrow::Cow;
 
 impl PostgresFlavour {
     fn quote_with_schema<'a, 'b>(&'a self, name: &'b str) -> QuotedWithSchema<'a, &'b str> {
@@ -30,31 +29,23 @@ impl SqlRenderer for PostgresFlavour {
         Quoted::postgres_ident(name)
     }
 
-    fn render_add_foreign_key(&self, add_foreign_key: &AddForeignKey) -> String {
-        let AddForeignKey { foreign_key, table } = add_foreign_key;
-        let mut add_constraint = String::with_capacity(120);
+    fn render_add_foreign_key(&self, foreign_key: &ForeignKeyWalker<'_>) -> String {
+        let constraint_clause = foreign_key
+            .constraint_name()
+            .map(|constraint_name| format!("CONSTRAINT {} ", self.quote(constraint_name)))
+            .unwrap_or_else(String::new);
 
-        write!(
-            add_constraint,
-            "ALTER TABLE {table} ADD ",
-            table = self.quote_with_schema(table)
+        format!(
+            "ALTER TABLE {table} ADD {constraint_clause}FOREIGN KEY({columns}){references}",
+            table = self.quote_with_schema(foreign_key.table().name()),
+            constraint_clause = constraint_clause,
+            columns = foreign_key
+                .constrained_column_names()
+                .iter()
+                .map(Quoted::postgres_ident)
+                .join(", "),
+            references = self.render_references(foreign_key),
         )
-        .unwrap();
-
-        if let Some(constraint_name) = foreign_key.constraint_name.as_ref() {
-            write!(add_constraint, "CONSTRAINT {} ", self.quote(constraint_name)).unwrap();
-        }
-
-        write!(
-            add_constraint,
-            "FOREIGN KEY ({})",
-            foreign_key.columns.iter().map(|col| self.quote(col)).join(", ")
-        )
-        .unwrap();
-
-        add_constraint.push_str(&self.render_references(&table, &foreign_key));
-
-        add_constraint
     }
 
     fn render_alter_enum(&self, alter_enum: &AlterEnum, differ: &SqlSchemaDiffer<'_>) -> Vec<String> {
@@ -258,18 +249,18 @@ impl SqlRenderer for PostgresFlavour {
         }
     }
 
-    fn render_references(&self, _table: &str, foreign_key: &ForeignKey) -> String {
+    fn render_references(&self, foreign_key: &ForeignKeyWalker<'_>) -> String {
         let referenced_columns = foreign_key
-            .referenced_columns
+            .referenced_column_names()
             .iter()
             .map(Quoted::postgres_ident)
             .join(",");
 
         format!(
             "REFERENCES {}({}) {} ON UPDATE CASCADE",
-            self.quote_with_schema(&foreign_key.referenced_table),
+            self.quote_with_schema(&foreign_key.referenced_table().name()),
             referenced_columns,
-            render_on_delete(&foreign_key.on_delete_action)
+            render_on_delete(&foreign_key.on_delete_action())
         )
     }
 
@@ -321,11 +312,15 @@ impl SqlRenderer for PostgresFlavour {
         )
     }
 
-    fn render_create_table(&self, table: &TableWalker<'_>) -> String {
+    fn render_create_table_as(&self, table: &TableWalker<'_>, table_name: &str) -> String {
         let columns: String = table.columns().map(|column| self.render_column(column)).join(",\n");
 
-        let primary_columns = table.table.primary_key_columns();
-        let pk_column_names = primary_columns.iter().map(|col| self.quote(&col)).join(",");
+        let primary_columns = table.primary_key_column_names();
+        let pk_column_names = primary_columns
+            .into_iter()
+            .flat_map(|cols| cols.into_iter())
+            .map(|col| self.quote(col))
+            .join(",");
         let pk = if !pk_column_names.is_empty() {
             format!(",\nPRIMARY KEY ({})", pk_column_names)
         } else {
@@ -334,7 +329,7 @@ impl SqlRenderer for PostgresFlavour {
 
         format!(
             "CREATE TABLE {table_name} (\n{columns}{primary_key}\n)",
-            table_name = self.quote_with_schema(table.name()),
+            table_name = self.quote_with_schema(table_name),
             columns = columns,
             primary_key = pk,
         )

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
@@ -183,11 +183,13 @@ impl SqlRenderer for PostgresFlavour {
                     columns.iter().map(|colname| self.quote(colname)).join(", ")
                 )),
                 TableChange::AddColumn(AddColumn { column }) => {
-                    let column = ColumnWalker {
-                        table,
-                        schema: differ.next,
-                        column,
-                    };
+                    let column = differ
+                        .next
+                        .table_walker(&table.name)
+                        .expect("Invariant violation: add column on unknown table")
+                        .columns()
+                        .find(|col| col.name() == column.name)
+                        .expect("Invariant violation: add column with unknown column");
                     let col_sql = self.render_column(column);
                     lines.push(format!("ADD COLUMN {}", col_sql));
                 }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
@@ -122,11 +122,13 @@ impl SqlRenderer for SqliteFlavour {
         for change in changes {
             match change {
                 TableChange::AddColumn(AddColumn { column }) => {
-                    let column = ColumnWalker {
-                        table,
-                        schema: differ.next,
-                        column,
-                    };
+                    let column = differ
+                        .next
+                        .table_walker(&table.name)
+                        .expect("Invariant violation: add column on unknown table")
+                        .columns()
+                        .find(|col| col.name() == column.name)
+                        .expect("Invariant violation: add column with unknown column");
 
                     let col_sql = self.render_column(column);
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
@@ -215,7 +215,7 @@ impl<'schema> SqlSchemaDiffer<'schema> {
     fn add_columns<'a>(differ: &'a TableDiffer<'schema>) -> impl Iterator<Item = TableChange> + 'a {
         differ.added_columns().map(move |column| {
             let change = AddColumn {
-                column: column.column.clone(),
+                column: column.column().clone(),
             };
 
             TableChange::AddColumn(change)
@@ -227,7 +227,7 @@ impl<'schema> SqlSchemaDiffer<'schema> {
             if column_differ.differs_in_something() {
                 let change = AlterColumn {
                     name: column_differ.previous.name().to_owned(),
-                    column: column_differ.next.column.clone(),
+                    column: column_differ.next.column().clone(),
                 };
 
                 return Some(TableChange::AlterColumn(change));

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
@@ -130,7 +130,7 @@ impl<'schema> SqlSchemaDiffer<'schema> {
     fn create_tables(&self) -> Vec<CreateTable> {
         self.created_tables()
             .map(|created_table| CreateTable {
-                table: created_table.clone(),
+                table: created_table.table().clone(),
             })
             .collect()
     }
@@ -139,26 +139,22 @@ impl<'schema> SqlSchemaDiffer<'schema> {
     // please later.
     fn drop_tables(&self) -> (Vec<DropTable>, Vec<DropForeignKey>) {
         let (dropped_tables_count, dropped_fks_count) = self.dropped_tables().fold((0, 0), |(tables, fks), item| {
-            (tables + 1, fks + item.foreign_keys.len())
+            (tables + 1, fks + item.foreign_key_count())
         });
         let mut dropped_tables = Vec::with_capacity(dropped_tables_count);
         let mut dropped_foreign_keys = Vec::with_capacity(dropped_fks_count);
 
         for dropped_table in self.dropped_tables() {
             let drop_table = DropTable {
-                name: dropped_table.name.clone(),
+                name: dropped_table.name().to_owned(),
             };
 
             dropped_tables.push(drop_table);
 
-            for fk_name in dropped_table
-                .foreign_keys
-                .iter()
-                .filter_map(|fk| fk.constraint_name.as_ref())
-            {
+            for fk_name in dropped_table.foreign_keys().filter_map(|fk| fk.constraint_name()) {
                 let drop_foreign_key = DropForeignKey {
-                    table: dropped_table.name.clone(),
-                    constraint_name: fk_name.clone(),
+                    table: dropped_table.name().to_owned(),
+                    constraint_name: fk_name.to_owned(),
                 };
 
                 dropped_foreign_keys.push(drop_foreign_key);
@@ -199,7 +195,7 @@ impl<'schema> SqlSchemaDiffer<'schema> {
                 Some(changes)
                     .filter(|changes| !changes.is_empty())
                     .map(|changes| AlterTable {
-                        table: tables.next.table.clone(),
+                        table: tables.next.table().clone(),
                         changes,
                     })
             })
@@ -285,7 +281,7 @@ impl<'schema> SqlSchemaDiffer<'schema> {
 
         if !family.is_mysql() {
             for table in self.created_tables() {
-                let walker = self.next.table_walker(&table.name).unwrap();
+                let walker = self.next.table_walker(table.name()).unwrap();
 
                 for walker in walker.indexes() {
                     if family.is_mssql() && walker.index_type().is_unique() {
@@ -293,7 +289,7 @@ impl<'schema> SqlSchemaDiffer<'schema> {
                     }
 
                     steps.push(CreateIndex {
-                        table: table.name.clone(),
+                        table: table.name().to_owned(),
                         index: walker.index().clone(),
                         caused_by_create_table: true,
                     });
@@ -364,16 +360,15 @@ impl<'schema> SqlSchemaDiffer<'schema> {
     where
         'schema: 'a,
     {
-        self.previous.tables.iter().filter_map(move |previous_table| {
+        self.previous.table_walkers().filter_map(move |previous_table| {
             self.next
-                .tables
-                .iter()
-                .find(move |next_table| tables_match(previous_table, next_table))
+                .table_walkers()
+                .find(move |next_table| tables_match(&previous_table, &next_table))
                 .map(move |next_table| TableDiffer {
                     flavour: self.flavour,
                     database_info: self.database_info,
-                    previous: TableWalker::new(self.previous, previous_table),
-                    next: TableWalker::new(self.next, next_table),
+                    previous: previous_table,
+                    next: next_table,
                 })
         })
     }
@@ -401,31 +396,29 @@ impl<'schema> SqlSchemaDiffer<'schema> {
         alter_indexes
     }
 
-    fn created_tables<'a>(&'a self) -> impl Iterator<Item = &'a Table> + 'a {
+    fn created_tables<'a>(&'a self) -> impl Iterator<Item = TableWalker<'a>> + 'a {
         self.next_tables()
-            .filter(move |next_table| !self.previous.has_table(&next_table.name))
+            .filter(move |next_table| !self.previous.has_table(next_table.name()))
     }
 
-    fn dropped_tables(&self) -> impl Iterator<Item = &Table> {
+    fn dropped_tables<'a>(&'a self) -> impl Iterator<Item = TableWalker<'schema>> + 'a {
         self.previous_tables().filter(move |previous_table| {
             !self
                 .next_tables()
-                .any(|next_table| tables_match(previous_table, next_table))
+                .any(|next_table| tables_match(previous_table, &next_table))
         })
     }
 
-    fn previous_tables(&self) -> impl Iterator<Item = &Table> {
+    fn previous_tables<'a>(&'a self) -> impl Iterator<Item = TableWalker<'schema>> + 'a {
         self.previous
-            .tables
-            .iter()
-            .filter(move |table| !self.table_is_ignored(&table.name))
+            .table_walkers()
+            .filter(move |table| !self.table_is_ignored(&table.name()))
     }
 
-    fn next_tables(&self) -> impl Iterator<Item = &Table> {
+    fn next_tables<'a>(&'a self) -> impl Iterator<Item = TableWalker<'schema>> + 'a {
         self.next
-            .tables
-            .iter()
-            .filter(move |table| !self.table_is_ignored(&table.name))
+            .table_walkers()
+            .filter(move |table| !self.table_is_ignored(&table.name()))
     }
 
     fn table_is_ignored(&self, table_name: &str) -> bool {
@@ -468,19 +461,23 @@ fn push_created_foreign_keys<'a, 'schema>(
     table_pairs.for_each(|differ| {
         added_foreign_keys.extend(differ.created_foreign_keys().map(|created_fk| AddForeignKey {
             table: differ.next.name().to_owned(),
+            table_index: differ.next.table_index(),
             foreign_key: created_fk.inner().clone(),
+            foreign_key_index: created_fk.foreign_key_index(),
         }))
     })
 }
 
 fn push_foreign_keys_from_created_tables<'a>(
     steps: &mut Vec<AddForeignKey>,
-    created_tables: impl Iterator<Item = &'a Table>,
+    created_tables: impl Iterator<Item = TableWalker<'a>>,
 ) {
     for table in created_tables {
-        steps.extend(table.foreign_keys.iter().map(|fk| AddForeignKey {
-            table: table.name.clone(),
-            foreign_key: fk.clone(),
+        steps.extend(table.foreign_keys().map(|fk| AddForeignKey {
+            table: table.name().to_owned(),
+            table_index: table.table_index(),
+            foreign_key: fk.foreign_key().clone(),
+            foreign_key_index: fk.foreign_key_index(),
         }));
     }
 }
@@ -515,8 +512,8 @@ fn foreign_keys_match(previous: &ForeignKeyWalker<'_>, next: &ForeignKeyWalker<'
     true
 }
 
-fn tables_match(previous: &Table, next: &Table) -> bool {
-    previous.name == next.name
+fn tables_match(previous: &TableWalker<'_>, next: &TableWalker<'_>) -> bool {
+    previous.name() == next.name()
 }
 
 fn enums_match(previous: &Enum, next: &Enum) -> bool {


### PR DESCRIPTION
The core enabler is `SqlRenderer::create_table_as()`. This lets us make
instanciation of `TableWalker`s private to sql_schema_describer, leading
into a series of much needed encapsulation improvements.