### PR TITLE
Include more context in SqlMigration::RedefineTables

### DIFF
--- a/libs/sql-schema-describer/src/walkers.rs
+++ b/libs/sql-schema-describer/src/walkers.rs
@@ -54,7 +54,9 @@ impl<'a> ColumnWalker<'a> {
         &self.column
     }
 
-    /// Walks the parent table's column to get to this column's index.
+    /// Walks the parent table's column to get to this column's index. This
+    /// should be considered a temporary crutch. We should strive to keep track
+    /// of indexes where we need them.
     pub fn column_index(&self) -> usize {
         self.table
             .columns
@@ -146,12 +148,12 @@ impl<'a> TableWalker<'a> {
     }
 
     /// Get a column in the table by index.
-    pub fn column_at(&self, idx: usize) -> Option<ColumnWalker<'a>> {
-        self.table.columns.get(idx).map(|column| ColumnWalker {
+    pub fn column_at(&self, idx: usize) -> ColumnWalker<'a> {
+        ColumnWalker {
             schema: self.schema,
-            column,
+            column: &self.table.columns[idx],
             table: self.table,
-        })
+        }
     }
 
     /// Traverse the table's columns.
@@ -230,7 +232,9 @@ impl<'a> TableWalker<'a> {
         &self.table
     }
 
-    /// Walks the parent schema to find the index of the table inside it.
+    /// Walks the parent schema to find the index of the table inside it. This
+    /// should be considered a temporary crutch. We should strive to keep track
+    /// of indexes where we need them.
     pub fn table_index(&self) -> usize {
         self.schema
             .tables

--- a/libs/test-setup/src/lib.rs
+++ b/libs/test-setup/src/lib.rs
@@ -40,7 +40,6 @@ impl TestAPIArgs {
     }
 }
 
-/// DANGER. This will be used for destructive filesystem access, be careful when changing this. DANGER.
 pub fn server_root() -> &'static str {
     static SERVER_ROOT: Lazy<String> =
         Lazy::new(|| std::env::var("SERVER_ROOT").expect("SERVER_ROOT env var is not defined"));

--- a/migration-engine/connectors/sql-migration-connector/src/flavour.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour.rs
@@ -1,5 +1,3 @@
-#![deny(missing_docs)]
-
 //! SQL flavours implement behaviour specific to a given SQL implementation (PostgreSQL, SQLite...),
 //! in order to avoid cluttering the connector with conditionals. This is a private implementation
 //! detail of the SQL connector.

--- a/migration-engine/connectors/sql-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/lib.rs
@@ -21,6 +21,7 @@ mod sql_schema_calculator;
 mod sql_schema_differ;
 
 use connection_wrapper::Connection;
+use datamodel::Datamodel;
 use error::quaint_error_to_connector_error;
 pub use sql_migration_persistence::MIGRATION_TABLE_NAME;
 
@@ -147,7 +148,7 @@ impl MigrationConnector for SqlMigrationConnector {
     /// the specific database version being used.
     fn check_database_version_compatibility(
         &self,
-        datamodel: &datamodel::dml::Datamodel,
+        datamodel: &Datamodel,
     ) -> Option<user_facing_errors::common::DatabaseVersionIncompatibility> {
         self.database_info.check_database_version_compatibility(datamodel)
     }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
@@ -157,7 +157,7 @@ fn render_raw_sql(
     };
 
     match step {
-        SqlMigrationStep::RedefineTables { names, .. } => renderer.render_redefine_tables(names, differ),
+        SqlMigrationStep::RedefineTables { tables } => renderer.render_redefine_tables(tables, differ),
         SqlMigrationStep::CreateEnum(create_enum) => renderer.render_create_enum(create_enum),
         SqlMigrationStep::DropEnum(drop_enum) => renderer.render_drop_enum(drop_enum),
         SqlMigrationStep::AlterEnum(alter_enum) => renderer.render_alter_enum(alter_enum, &differ),

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour.rs
@@ -3,6 +3,8 @@ mod mysql;
 mod postgres;
 mod sqlite;
 
+use sql_schema_describer::walkers::ColumnWalker;
+
 use super::DestructiveCheckPlan;
 use crate::{sql_migration::AlterColumn, sql_schema_differ::ColumnChanges, sql_schema_differ::ColumnDiffer};
 
@@ -12,7 +14,7 @@ pub(crate) trait DestructiveChangeCheckerFlavour {
     fn check_alter_column(
         &self,
         alter_column: &AlterColumn,
-        columns: &ColumnDiffer<'_>,
+        columns: (&ColumnWalker<'_>, &ColumnWalker<'_>),
         plan: &mut DestructiveCheckPlan,
         step_index: usize,
     );

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/mssql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/mssql.rs
@@ -1,3 +1,5 @@
+use sql_schema_describer::walkers::ColumnWalker;
+
 use super::DestructiveChangeCheckerFlavour;
 use crate::{
     flavour::MssqlFlavour, sql_destructive_change_checker::destructive_check_plan::DestructiveCheckPlan,
@@ -8,7 +10,7 @@ impl DestructiveChangeCheckerFlavour for MssqlFlavour {
     fn check_alter_column(
         &self,
         _alter_column: &AlterColumn,
-        _columns: &ColumnDiffer<'_>,
+        _columns: (&ColumnWalker<'_>, &ColumnWalker<'_>),
         _plan: &mut DestructiveCheckPlan,
         _step_index: usize,
     ) {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/mysql.rs
@@ -8,12 +8,13 @@ use crate::{
     sql_migration::{AlterColumn, ColumnTypeChange},
     sql_schema_differ::{ColumnChanges, ColumnDiffer},
 };
+use sql_schema_describer::walkers::ColumnWalker;
 
 impl DestructiveChangeCheckerFlavour for MysqlFlavour {
     fn check_alter_column(
         &self,
         alter_column: &AlterColumn,
-        columns: &ColumnDiffer<'_>,
+        (previous, next): (&ColumnWalker<'_>, &ColumnWalker<'_>),
         plan: &mut DestructiveCheckPlan,
         step_index: usize,
     ) {
@@ -31,11 +32,11 @@ impl DestructiveChangeCheckerFlavour for MysqlFlavour {
         // Otherwise, case by case.
         // Column went from optional to required. This is unexecutable unless the table is
         // empty or the column has no existing NULLs.
-        if changes.arity_changed() && columns.next.arity().is_required() {
+        if changes.arity_changed() && next.arity().is_required() {
             plan.push_unexecutable(
                 UnexecutableStepCheck::MadeOptionalFieldRequired {
-                    column: columns.previous.name().to_owned(),
-                    table: columns.previous.table().name().to_owned(),
+                    column: previous.name().to_owned(),
+                    table: previous.table().name().to_owned(),
                 },
                 step_index,
             );
@@ -43,7 +44,7 @@ impl DestructiveChangeCheckerFlavour for MysqlFlavour {
             return;
         }
 
-        if changes.only_type_changed() && is_safe_enum_change(columns, plan, step_index) {
+        if changes.only_type_changed() && is_safe_enum_change((previous, next), plan, step_index) {
             return;
         }
 
@@ -52,10 +53,10 @@ impl DestructiveChangeCheckerFlavour for MysqlFlavour {
             Some(ColumnTypeChange::RiskyCast) => {
                 plan.push_warning(
                     SqlMigrationWarningCheck::RiskyCast {
-                        table: columns.previous.table().name().to_owned(),
-                        column: columns.previous.name().to_owned(),
-                        previous_type: format!("{:?}", columns.previous.column_type_family()),
-                        next_type: format!("{:?}", columns.next.column_type_family()),
+                        table: previous.table().name().to_owned(),
+                        column: previous.name().to_owned(),
+                        previous_type: format!("{:?}", previous.column_type_family()),
+                        next_type: format!("{:?}", next.column_type_family()),
                     },
                     step_index,
                 );
@@ -75,11 +76,14 @@ impl DestructiveChangeCheckerFlavour for MysqlFlavour {
 }
 
 /// If the type change is an enum change, diagnose it, and return whether it _was_ an enum change.
-fn is_safe_enum_change(columns: &ColumnDiffer<'_>, plan: &mut DestructiveCheckPlan, step_index: usize) -> bool {
-    if let (Some(previous_enum), Some(next_enum)) = (
-        columns.previous.column_type_family_as_enum(),
-        columns.next.column_type_family_as_enum(),
-    ) {
+fn is_safe_enum_change(
+    (previous, next): (&ColumnWalker<'_>, &ColumnWalker<'_>),
+    plan: &mut DestructiveCheckPlan,
+    step_index: usize,
+) -> bool {
+    if let (Some(previous_enum), Some(next_enum)) =
+        (previous.column_type_family_as_enum(), next.column_type_family_as_enum())
+    {
         let removed_values: Vec<String> = previous_enum
             .values
             .iter()

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/sqlite.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/sqlite.rs
@@ -5,32 +5,20 @@ use crate::{
         destructive_check_plan::DestructiveCheckPlan, unexecutable_step_check::UnexecutableStepCheck,
         warning_check::SqlMigrationWarningCheck,
     },
-    sql_migration::AlterColumn,
-    sql_schema_differ::{ColumnChanges, ColumnDiffer, ColumnTypeChange},
+    sql_migration::{AlterColumn, ColumnTypeChange},
+    sql_schema_differ::{ColumnChanges, ColumnDiffer},
 };
-use sql_schema_describer::ColumnArity;
+use sql_schema_describer::{walkers::ColumnWalker, ColumnArity};
 
 impl DestructiveChangeCheckerFlavour for SqliteFlavour {
     fn check_alter_column(
         &self,
-        _alter_column: &AlterColumn,
-        _columns: &ColumnDiffer<'_>,
-        _plan: &mut DestructiveCheckPlan,
-        _step_index: usize,
-    ) {
-        unreachable!("check_alter_column on SQLite");
-    }
-
-    fn check_drop_and_recreate_column(
-        &self,
-        columns: &ColumnDiffer<'_>,
-        _changes: &ColumnChanges,
+        alter_column: &AlterColumn,
+        (previous, next): (&ColumnWalker<'_>, &ColumnWalker<'_>),
         plan: &mut DestructiveCheckPlan,
         step_index: usize,
     ) {
-        let (changes, type_change) = columns.all_changes();
-
-        let arity_change_is_safe = match (&columns.previous.arity(), &columns.next.arity()) {
+        let arity_change_is_safe = match (&previous.arity(), &next.arity()) {
             // column became required
             (ColumnArity::Nullable, ColumnArity::Required) => false,
             // column became nullable
@@ -41,34 +29,43 @@ impl DestructiveChangeCheckerFlavour for SqliteFlavour {
             (ColumnArity::List, _) | (_, ColumnArity::List) => unreachable!(),
         };
 
-        if !changes.type_changed() && arity_change_is_safe {
+        if !alter_column.changes.type_changed() && arity_change_is_safe {
             return;
         }
 
-        if changes.arity_changed() && columns.next.arity().is_required() && columns.next.default().is_none() {
+        if alter_column.changes.arity_changed() && next.arity().is_required() && next.default().is_none() {
             plan.push_unexecutable(
                 UnexecutableStepCheck::MadeOptionalFieldRequired {
-                    table: columns.previous.table().name().to_owned(),
-                    column: columns.previous.name().to_owned(),
+                    table: previous.table().name().to_owned(),
+                    column: previous.name().to_owned(),
                 },
                 step_index,
             );
         }
 
-        match type_change {
+        match alter_column.type_change {
             Some(ColumnTypeChange::SafeCast) | None => (),
             Some(ColumnTypeChange::RiskyCast) => {
                 plan.push_warning(
                     SqlMigrationWarningCheck::RiskyCast {
-                        table: columns.previous.table().name().to_owned(),
-                        column: columns.previous.name().to_owned(),
-                        previous_type: format!("{:?}", columns.previous.column_type_family()),
-                        next_type: format!("{:?}", columns.next.column_type_family()),
+                        table: previous.table().name().to_owned(),
+                        column: previous.name().to_owned(),
+                        previous_type: format!("{:?}", previous.column_type_family()),
+                        next_type: format!("{:?}", next.column_type_family()),
                     },
                     step_index,
                 );
             }
-            Some(ColumnTypeChange::NotCastable) => unreachable!("uncastable change on SQLite"),
         }
+    }
+
+    fn check_drop_and_recreate_column(
+        &self,
+        _columns: &ColumnDiffer<'_>,
+        _changes: &ColumnChanges,
+        _plan: &mut DestructiveCheckPlan,
+        _step_index: usize,
+    ) {
+        unreachable!("check_drop_and_recreate_column on SQLite");
     }
 }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_migration/expanded_alter_column.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_migration/expanded_alter_column.rs
@@ -1,8 +1,11 @@
-use crate::sql_schema_differ::{ColumnChange, ColumnChanges, ColumnDiffer};
-use sql_schema_describer::{ColumnArity, ColumnType, DefaultValue};
+use crate::sql_schema_differ::{ColumnChange, ColumnChanges};
+use sql_schema_describer::{walkers::ColumnWalker, ColumnArity, ColumnType, DefaultValue};
 
-pub(crate) fn expand_mysql_alter_column(columns: &ColumnDiffer<'_>, changes: &ColumnChanges) -> MysqlAlterColumn {
-    if changes.only_default_changed() && columns.next.default().is_none() {
+pub(crate) fn expand_mysql_alter_column(
+    (previous, next): (&ColumnWalker<'_>, &ColumnWalker<'_>),
+    changes: &ColumnChanges,
+) -> MysqlAlterColumn {
+    if changes.only_default_changed() && next.default().is_none() {
         return MysqlAlterColumn::DropDefault;
     }
 
@@ -12,13 +15,13 @@ pub(crate) fn expand_mysql_alter_column(columns: &ColumnDiffer<'_>, changes: &Co
 
     // @default(dbgenerated()) does not give us the information in the prisma schema, so we have to
     // transfer it from the introspected current state of the database.
-    let new_default = match (&columns.previous.default(), &columns.next.default()) {
+    let new_default = match (&previous.default(), &next.default()) {
         (Some(DefaultValue::DBGENERATED(previous)), Some(DefaultValue::DBGENERATED(next)))
             if next.is_empty() && !previous.is_empty() =>
         {
             Some(DefaultValue::DBGENERATED(previous.clone()))
         }
-        _ => columns.next.default().cloned(),
+        _ => next.default().cloned(),
     };
 
     MysqlAlterColumn::Modify {
@@ -28,7 +31,7 @@ pub(crate) fn expand_mysql_alter_column(columns: &ColumnDiffer<'_>, changes: &Co
 }
 
 pub(crate) fn expand_postgres_alter_column(
-    columns: &ColumnDiffer<'_>,
+    (previous, next): (&ColumnWalker<'_>, &ColumnWalker<'_>),
     column_changes: &ColumnChanges,
 ) -> Vec<PostgresAlterColumn> {
     let mut changes = Vec::new();
@@ -36,11 +39,11 @@ pub(crate) fn expand_postgres_alter_column(
 
     for change in column_changes.iter() {
         match change {
-            ColumnChange::Default => match (&columns.previous.default(), &columns.next.default()) {
+            ColumnChange::Default => match (&previous.default(), &next.default()) {
                 (_, Some(next_default)) => changes.push(PostgresAlterColumn::SetDefault((**next_default).clone())),
                 (_, None) => changes.push(PostgresAlterColumn::DropDefault),
             },
-            ColumnChange::Arity => match (&columns.previous.arity(), &columns.next.arity()) {
+            ColumnChange::Arity => match (&previous.arity(), &next.arity()) {
                 (ColumnArity::Required, ColumnArity::Nullable) => changes.push(PostgresAlterColumn::DropNotNull),
                 (ColumnArity::Nullable, ColumnArity::Required) => changes.push(PostgresAlterColumn::SetNotNull),
                 (ColumnArity::List, ColumnArity::Nullable) => {
@@ -60,7 +63,7 @@ pub(crate) fn expand_postgres_alter_column(
             },
             ColumnChange::TypeChanged => set_type = true,
             ColumnChange::Sequence => {
-                if columns.previous.is_autoincrement() {
+                if previous.is_autoincrement() {
                     // The sequence should be dropped.
                     changes.push(PostgresAlterColumn::DropDefault)
                 } else {
@@ -74,7 +77,7 @@ pub(crate) fn expand_postgres_alter_column(
 
     // This is a flag so we don't push multiple SetTypes from arity and type changes.
     if set_type {
-        changes.push(PostgresAlterColumn::SetType(columns.next.column_type().clone()));
+        changes.push(PostgresAlterColumn::SetType(next.column_type().clone()));
     }
 
     changes

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer.rs
@@ -1,5 +1,3 @@
-#![deny(missing_docs)]
-
 mod common;
 mod mssql_renderer;
 mod mysql_renderer;
@@ -73,7 +71,7 @@ pub(crate) trait SqlRenderer {
     }
 
     /// Render a `RedefineTables` step.
-    fn render_redefine_tables(&self, tables: &[String], differ: SqlSchemaDiffer<'_>) -> Vec<String>;
+    fn render_redefine_tables(&self, tables: &[AlterTable], differ: SqlSchemaDiffer<'_>) -> Vec<String>;
 
     /// Render a table renaming step.
     fn render_rename_table(&self, name: &str, new_name: &str) -> String;

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mssql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mssql_renderer.rs
@@ -56,7 +56,7 @@ impl SqlRenderer for MssqlFlavour {
                     let col_sql = self.render_column(column);
                     lines.push(format!("ADD COLUMN {}", col_sql));
                 }
-                TableChange::DropColumn(DropColumn { name }) => {
+                TableChange::DropColumn(DropColumn { name, .. }) => {
                     let name = self.quote(&name);
                     lines.push(format!("DROP COLUMN {}", name));
                 }
@@ -278,7 +278,7 @@ impl SqlRenderer for MssqlFlavour {
         )
     }
 
-    fn render_redefine_tables(&self, _tables: &[String], _differ: SqlSchemaDiffer<'_>) -> Vec<String> {
+    fn render_redefine_tables(&self, _tables: &[AlterTable], _differ: SqlSchemaDiffer<'_>) -> Vec<String> {
         unreachable!("render_redefine_table on MSSQL")
     }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
@@ -131,7 +131,7 @@ impl SqlRenderer for MysqlFlavour {
                     let col_sql = self.render_column(column);
                     lines.push(format!("ADD COLUMN {}", col_sql));
                 }
-                TableChange::DropColumn(DropColumn { name }) => {
+                TableChange::DropColumn(DropColumn { name, .. }) => {
                     let name = self.quote(&name);
                     lines.push(format!("DROP COLUMN {}", name));
                 }
@@ -146,7 +146,7 @@ impl SqlRenderer for MysqlFlavour {
                         .diff_column(column_name)
                         .expect("AlterColumn on unknown column.");
 
-                    let expanded = expand_mysql_alter_column(&columns, &changes);
+                    let expanded = expand_mysql_alter_column((&columns.previous, &columns.next), &changes);
 
                     match expanded {
                         MysqlAlterColumn::DropDefault => lines.push(format!(
@@ -329,7 +329,7 @@ impl SqlRenderer for MysqlFlavour {
         vec![format!("DROP TABLE {}", self.quote(&table_name))]
     }
 
-    fn render_redefine_tables(&self, _names: &[String], _differ: SqlSchemaDiffer<'_>) -> Vec<String> {
+    fn render_redefine_tables(&self, _names: &[AlterTable], _differ: SqlSchemaDiffer<'_>) -> Vec<String> {
         unreachable!("render_redefine_table on MySQL")
     }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
@@ -229,13 +229,14 @@ impl SqlRenderer for SqliteFlavour {
         ]
     }
 
-    fn render_redefine_tables(&self, tables: &[String], differ: SqlSchemaDiffer<'_>) -> Vec<String> {
+    fn render_redefine_tables(&self, tables: &[AlterTable], differ: SqlSchemaDiffer<'_>) -> Vec<String> {
         // Based on 'Making Other Kinds Of Table Schema Changes' from https://www.sqlite.org/lang_altertable.html
         let mut result: Vec<String> = Vec::new();
 
         result.push("PRAGMA foreign_keys=OFF".to_string());
 
-        for table_name in tables {
+        for table in tables {
+            let table_name = &table.table.name;
             let differ = differ
                 .diff_table(table_name)
                 .expect("Invariant violation: diffing unknown table.");

--- a/migration-engine/core/src/lib.rs
+++ b/migration-engine/core/src/lib.rs
@@ -14,9 +14,9 @@ mod core_error;
 
 pub use api::GenericApi;
 pub use commands::{ApplyMigrationInput, InferMigrationStepsInput, MigrationStepsResultOutput, SchemaPushInput};
-use commands::{MigrationCommand, SchemaPushCommand};
 pub use core_error::{CoreError, CoreResult};
 
+use commands::{MigrationCommand, SchemaPushCommand};
 use datamodel::{
     common::provider_names::{MSSQL_SOURCE_NAME, MYSQL_SOURCE_NAME, POSTGRES_SOURCE_NAME, SQLITE_SOURCE_NAME},
     dml::Datamodel,

--- a/migration-engine/migration-engine-tests/tests/migration_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migration_tests.rs
@@ -1763,7 +1763,7 @@ async fn foreign_keys_are_added_on_existing_tables(api: &TestApi) -> TestResult 
     Ok(())
 }
 
-#[test_each_connector]
+#[test_each_connector(log = "debug,sql_schema_describer=info")]
 async fn foreign_keys_can_be_added_on_existing_columns(api: &TestApi) -> TestResult {
     let dm1 = r#"
         model User {


### PR DESCRIPTION
This is for redefining tables on sqlite. This commit makes it a step
that is inferred like all the others.

The idea is to refactor towards making the differ structs private to
the sql_schema_differ module. The SqlMigration struct should have all the necessary context. This PR starts this refactoring.