### PR TITLE
validate scale and precision for decimal native types

### DIFF
--- a/libs/datamodel/connectors/datamodel-connector/src/error.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/error.rs
@@ -24,6 +24,13 @@ impl ConnectorError {
         })
     }
 
+    pub fn new_scale_larger_than_precision_error(native_type: &str, connector_name: &str) -> ConnectorError {
+        ConnectorError::from_kind(ErrorKind::ScaleLargerThanPrecisionError {
+            native_type: String::from(native_type),
+            connector_name: String::from(connector_name),
+        })
+    }
+
     pub fn new_incompatible_native_type_with_unique(native_type: &str, connector_name: &str) -> ConnectorError {
         ConnectorError::from_kind(ErrorKind::IncompatibleNativeTypeWithUniqueAttribute {
             native_type: String::from(native_type),
@@ -89,6 +96,16 @@ pub enum ErrorKind {
 
     #[error("Native type {} can not be unique in {}.", native_type, connector_name)]
     IncompatibleNativeTypeWithUniqueAttribute {
+        native_type: String,
+        connector_name: String,
+    },
+
+    #[error(
+        "The scale must not be larger than the precision for the {} native type in {}.",
+        native_type,
+        connector_name
+    )]
+    ScaleLargerThanPrecisionError {
         native_type: String,
         connector_name: String,
     },

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
@@ -156,6 +156,19 @@ impl Connector for MySqlDatamodelConnector {
                     "MySQL",
                 ));
             }
+            if native_type_name == DECIMAL_TYPE_NAME || native_type_name == NUMERIC_TYPE_NAME {
+                match native_type.args.as_slice() {
+                    [precision, scale] => {
+                        if scale > precision {
+                            return Err(ConnectorError::new_scale_larger_than_precision_error(
+                                native_type_name,
+                                "MySQL",
+                            ));
+                        }
+                    }
+                    _ => panic!(),
+                }
+            }
         }
         Ok(())
     }

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
@@ -158,15 +158,13 @@ impl Connector for MySqlDatamodelConnector {
             }
             if native_type_name == DECIMAL_TYPE_NAME || native_type_name == NUMERIC_TYPE_NAME {
                 match native_type.args.as_slice() {
-                    [precision, scale] => {
-                        if scale > precision {
-                            return Err(ConnectorError::new_scale_larger_than_precision_error(
-                                native_type_name,
-                                "MySQL",
-                            ));
-                        }
+                    [precision, scale] if scale > precision => {
+                        return Err(ConnectorError::new_scale_larger_than_precision_error(
+                            native_type_name,
+                            "MySQL",
+                        ));
                     }
-                    _ => panic!(),
+                    _ => {}
                 }
             }
         }

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
@@ -135,7 +135,7 @@ impl Connector for PostgresDatamodelConnector {
                             "Postgres",
                         ));
                     }
-                    _ => panic!(),
+                    _ => {}
                 }
             }
         }

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
@@ -129,13 +129,11 @@ impl Connector for PostgresDatamodelConnector {
             let native_type_name = native_type.name.as_str();
             if native_type_name == DECIMAL_TYPE_NAME || native_type_name == NUMERIC_TYPE_NAME {
                 match native_type.args.as_slice() {
-                    [precision, scale] => {
-                        if scale > precision {
-                            return Err(ConnectorError::new_scale_larger_than_precision_error(
-                                native_type_name,
-                                "Postgres",
-                            ));
-                        }
+                    [precision, scale] if scale > precision => {
+                        return Err(ConnectorError::new_scale_larger_than_precision_error(
+                            native_type_name,
+                            "Postgres",
+                        ));
                     }
                     _ => panic!(),
                 }

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
@@ -1,6 +1,6 @@
 use datamodel_connector::error::{ConnectorError, ErrorKind};
 use datamodel_connector::{Connector, ConnectorCapability};
-use dml::field::Field;
+use dml::field::{Field, FieldType};
 use dml::native_type_constructor::NativeTypeConstructor;
 use dml::native_type_instance::NativeTypeInstance;
 use dml::scalars::ScalarType;
@@ -124,7 +124,23 @@ impl Connector for PostgresDatamodelConnector {
         &self.capabilities
     }
 
-    fn validate_field(&self, _field: &Field) -> Result<(), ConnectorError> {
+    fn validate_field(&self, field: &Field) -> Result<(), ConnectorError> {
+        if let FieldType::NativeType(_scalar_type, native_type) = field.field_type() {
+            let native_type_name = native_type.name.as_str();
+            if native_type_name == DECIMAL_TYPE_NAME || native_type_name == NUMERIC_TYPE_NAME {
+                match native_type.args.as_slice() {
+                    [precision, scale] => {
+                        if scale > precision {
+                            return Err(ConnectorError::new_scale_larger_than_precision_error(
+                                native_type_name,
+                                "Postgres",
+                            ));
+                        }
+                    }
+                    _ => panic!(),
+                }
+            }
+        }
         Ok(())
     }
 

--- a/libs/datamodel/core/tests/types/mod.rs
+++ b/libs/datamodel/core/tests/types/mod.rs
@@ -1,3 +1,4 @@
 pub mod mysql_native_types;
 pub mod negative;
 pub mod positive;
+mod postgres_native_types;

--- a/libs/datamodel/core/tests/types/mysql_native_types.rs
+++ b/libs/datamodel/core/tests/types/mysql_native_types.rs
@@ -216,3 +216,57 @@ fn should_fail_on_native_type_long_blob_with_unique_attribute() {
         ast::Span::new(281, 315),
     ));
 }
+
+#[test]
+fn should_fail_on_native_type_decimal_when_scale_is_bigger_than_precision() {
+    let dml = r#"
+        datasource db {
+          provider = "mysql"
+          url      = "mysql://"
+        }
+
+        generator js {
+            provider = "prisma-client-js"
+            previewFeatures = ["nativeTypes"]
+        }
+
+        model Blog {
+            id     Int   @id
+            dec Decimal @db.Decimal(2, 4)
+        }
+    "#;
+
+    let error = parse_error(dml);
+
+    error.assert_is(DatamodelError::new_connector_error(
+        "The scale must not be larger than the precision for the Decimal native type in MySQL.",
+        ast::Span::new(281, 311),
+    ));
+}
+
+#[test]
+fn should_fail_on_native_type_numeric_when_scale_is_bigger_than_precision() {
+    let dml = r#"
+        datasource db {
+          provider = "mysql"
+          url      = "mysql://"
+        }
+
+        generator js {
+            provider = "prisma-client-js"
+            previewFeatures = ["nativeTypes"]
+        }
+
+        model Blog {
+            id     Int   @id
+            dec Decimal @db.Numeric(2, 4)
+        }
+    "#;
+
+    let error = parse_error(dml);
+
+    error.assert_is(DatamodelError::new_connector_error(
+        "The scale must not be larger than the precision for the Numeric native type in MySQL.",
+        ast::Span::new(281, 311),
+    ));
+}

--- a/libs/datamodel/core/tests/types/postgres_native_types.rs
+++ b/libs/datamodel/core/tests/types/postgres_native_types.rs
@@ -1,0 +1,56 @@
+use crate::common::*;
+use datamodel::{ast, diagnostics::DatamodelError};
+
+#[test]
+fn should_fail_on_native_type_decimal_when_scale_is_bigger_than_precision() {
+    let dml = r#"
+        datasource db {
+          provider = "postgres"
+          url      = "postgresql://"
+        }
+
+        generator js {
+            provider = "prisma-client-js"
+            previewFeatures = ["nativeTypes"]
+        }
+
+        model Blog {
+            id     Int   @id
+            dec Decimal @db.Decimal(2, 4)
+        }
+    "#;
+
+    let error = parse_error(dml);
+
+    error.assert_is(DatamodelError::new_connector_error(
+        "The scale must not be larger than the precision for the Decimal native type in Postgres.",
+        ast::Span::new(289, 319),
+    ));
+}
+
+#[test]
+fn should_fail_on_native_type_numeric_when_scale_is_bigger_than_precision() {
+    let dml = r#"
+        datasource db {
+          provider = "postgres"
+          url      = "postgresql://"
+        }
+
+        generator js {
+            provider = "prisma-client-js"
+            previewFeatures = ["nativeTypes"]
+        }
+
+        model Blog {
+            id     Int   @id
+            dec Decimal @db.Numeric(2, 4)
+        }
+    "#;
+
+    let error = parse_error(dml);
+
+    error.assert_is(DatamodelError::new_connector_error(
+        "The scale must not be larger than the precision for the Numeric native type in Postgres.",
+        ast::Span::new(289, 319),
+    ));
+}


### PR DESCRIPTION
Scale must not be larger than the precision for decimal native types in both MySQL and Postgres.