### PR TITLE
Rework error handling in sql-schema-describer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3361,6 +3361,8 @@ dependencies = [
  "test-setup",
  "tokio",
  "tracing",
+ "tracing-error",
+ "tracing-futures",
 ]
 
 [[package]]

--- a/introspection-engine/connectors/sql-introspection-connector/src/error.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/error.rs
@@ -193,8 +193,8 @@ impl From<QuaintError> for SqlError {
     }
 }
 
-impl From<sql_schema_describer::SqlSchemaDescriberError> for SqlError {
-    fn from(error: sql_schema_describer::SqlSchemaDescriberError) -> Self {
+impl From<sql_schema_describer::DescriberError> for SqlError {
+    fn from(error: sql_schema_describer::DescriberError) -> Self {
         SqlError::QueryError(anyhow::anyhow!("{}", error))
     }
 }

--- a/libs/sql-schema-describer/Cargo.toml
+++ b/libs/sql-schema-describer/Cargo.toml
@@ -15,6 +15,8 @@ serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"
 tracing = "0.1"
 enumflags2 = "0.6.0"
+tracing-futures = "0.2.4"
+tracing-error = "0.1.2"
 
 [dependencies.quaint]
 features = ["single-postgresql", "single-mysql", "single-sqlite", "serde-support", "tracing-log"]

--- a/libs/sql-schema-describer/src/error.rs
+++ b/libs/sql-schema-describer/src/error.rs
@@ -1,0 +1,64 @@
+#![deny(missing_docs)]
+
+use std::{
+    error::Error,
+    fmt::{self, Display},
+};
+use tracing_error::SpanTrace;
+
+/// The result type.
+pub type DescriberResult<T> = Result<T, DescriberError>;
+
+/// Description errors.
+#[derive(Debug)]
+pub struct DescriberError {
+    kind: DescriberErrorKind,
+    context: SpanTrace,
+}
+
+impl DescriberError {
+    /// The `DescriberErrorKind` wrapped by the error.
+    pub fn into_kind(self) -> DescriberErrorKind {
+        self.kind
+    }
+
+    /// The `tracing_error::SpanTrace` contained in the error.
+    pub fn span_trace(&self) -> SpanTrace {
+        self.context.clone()
+    }
+}
+
+/// Variants of DescriberError.
+#[derive(Debug)]
+pub enum DescriberErrorKind {
+    /// An error originating from Quaint or the database.
+    QuaintError(quaint::error::Error),
+}
+
+impl Display for DescriberError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.kind {
+            DescriberErrorKind::QuaintError(err) => {
+                err.fmt(f)?;
+                self.context.fmt(f)
+            }
+        }
+    }
+}
+
+impl Error for DescriberError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match &self.kind {
+            DescriberErrorKind::QuaintError(err) => Some(err),
+        }
+    }
+}
+
+impl From<quaint::error::Error> for DescriberError {
+    fn from(err: quaint::error::Error) -> Self {
+        DescriberError {
+            kind: DescriberErrorKind::QuaintError(err),
+            context: SpanTrace::capture(),
+        }
+    }
+}

--- a/libs/sql-schema-describer/src/lib.rs
+++ b/libs/sql-schema-describer/src/lib.rs
@@ -3,17 +3,12 @@
 
 //! Database description. This crate is used heavily in the introspection and migration engines.
 
-use fmt::Display;
 use once_cell::sync::Lazy;
 use prisma_value::PrismaValue;
 use regex::Regex;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
-use std::{
-    error::Error,
-    fmt::{self, Debug},
-    str::FromStr,
-};
+use std::{fmt, str::FromStr};
 use tracing::debug;
 use walkers::TableWalker;
 
@@ -24,38 +19,24 @@ pub mod postgres;
 pub mod sqlite;
 pub mod walkers;
 
-/// description errors.
-#[derive(Debug)]
-pub enum SqlSchemaDescriberError {
-    /// An unknown error occurred.
-    UnknownError,
-}
+mod error;
 
-impl Display for SqlSchemaDescriberError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "unknown")
-    }
-}
-
-impl Error for SqlSchemaDescriberError {}
-
-/// The result type.
-pub type SqlSchemaDescriberResult<T> = core::result::Result<T, SqlSchemaDescriberError>;
+pub use error::{DescriberError, DescriberErrorKind, DescriberResult};
 
 /// A database description connector.
 #[async_trait::async_trait]
 pub trait SqlSchemaDescriberBackend: Send + Sync + 'static {
     /// List the database's schemas.
-    async fn list_databases(&self) -> SqlSchemaDescriberResult<Vec<String>>;
+    async fn list_databases(&self) -> DescriberResult<Vec<String>>;
 
     /// Get the databases metadata.
-    async fn get_metadata(&self, schema: &str) -> SqlSchemaDescriberResult<SQLMetadata>;
+    async fn get_metadata(&self, schema: &str) -> DescriberResult<SQLMetadata>;
 
     /// Describe a database schema.
-    async fn describe(&self, schema: &str) -> SqlSchemaDescriberResult<SqlSchema>;
+    async fn describe(&self, schema: &str) -> DescriberResult<SqlSchema>;
 
     /// Get the database version.
-    async fn version(&self, schema: &str) -> SqlSchemaDescriberResult<Option<String>>;
+    async fn version(&self, schema: &str) -> DescriberResult<Option<String>>;
 }
 
 #[derive(Serialize, Deserialize)]

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/mssql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/mssql.rs
@@ -1,7 +1,7 @@
-use crate::{connect, connection_wrapper::Connection, SqlFlavour};
-use migration_connector::{ConnectorError, ConnectorResult, MigrationDirectory};
+use crate::{connect, connection_wrapper::Connection, error::quaint_error_to_connector_error, SqlFlavour};
+use migration_connector::{ConnectorResult, MigrationDirectory};
 use quaint::connector::MssqlUrl;
-use sql_schema_describer::{SqlSchema, SqlSchemaDescriberBackend, SqlSchemaDescriberError};
+use sql_schema_describer::{DescriberErrorKind, SqlSchema, SqlSchemaDescriberBackend};
 use std::collections::HashMap;
 
 #[derive(Debug)]
@@ -74,9 +74,9 @@ impl SqlFlavour for MssqlFlavour {
         sql_schema_describer::mssql::SqlSchemaDescriber::new(connection.quaint().clone())
             .describe(connection.connection_info().schema_name())
             .await
-            .map_err(|err| match err {
-                SqlSchemaDescriberError::UnknownError => {
-                    ConnectorError::generic(anyhow::anyhow!("An unknown error occurred in sql-schema-describer"))
+            .map_err(|err| match err.into_kind() {
+                DescriberErrorKind::QuaintError(err) => {
+                    quaint_error_to_connector_error(err, connection.connection_info())
                 }
             })
     }

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/mysql.rs
@@ -1,13 +1,16 @@
 use super::SqlFlavour;
 use crate::{
-    connect, connection_wrapper::Connection, database_info::DatabaseInfo, error::CheckDatabaseInfoResult,
-    error::SystemDatabase,
+    connect,
+    connection_wrapper::Connection,
+    database_info::DatabaseInfo,
+    error::CheckDatabaseInfoResult,
+    error::{quaint_error_to_connector_error, SystemDatabase},
 };
 use migration_connector::{ConnectorError, ConnectorResult, MigrationDirectory};
 use once_cell::sync::Lazy;
 use quaint::connector::MysqlUrl;
 use regex::RegexSet;
-use sql_schema_describer::{SqlSchema, SqlSchemaDescriberBackend, SqlSchemaDescriberError};
+use sql_schema_describer::{DescriberErrorKind, SqlSchema, SqlSchemaDescriberBackend};
 use url::Url;
 
 #[derive(Debug)]
@@ -74,9 +77,9 @@ impl SqlFlavour for MysqlFlavour {
         sql_schema_describer::mysql::SqlSchemaDescriber::new(connection.quaint().clone())
             .describe(connection.connection_info().schema_name())
             .await
-            .map_err(|err| match err {
-                SqlSchemaDescriberError::UnknownError => {
-                    ConnectorError::generic(anyhow::anyhow!("An unknown error occurred in sql-schema-describer"))
+            .map_err(|err| match err.into_kind() {
+                DescriberErrorKind::QuaintError(err) => {
+                    quaint_error_to_connector_error(err, connection.connection_info())
                 }
             })
     }

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/sqlite.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/sqlite.rs
@@ -1,7 +1,7 @@
-use crate::{connect, connection_wrapper::Connection, flavour::SqlFlavour};
+use crate::{connect, connection_wrapper::Connection, error::quaint_error_to_connector_error, flavour::SqlFlavour};
 use migration_connector::{ConnectorError, ConnectorResult, MigrationDirectory};
 use quaint::prelude::ConnectionInfo;
-use sql_schema_describer::{SqlSchema, SqlSchemaDescriberBackend, SqlSchemaDescriberError};
+use sql_schema_describer::{DescriberErrorKind, SqlSchema, SqlSchemaDescriberBackend};
 use std::path::Path;
 
 #[derive(Debug)]
@@ -46,7 +46,7 @@ impl SqlFlavour for SqliteFlavour {
                 "applied_steps_count"   INTEGER UNSIGNED NOT NULL DEFAULT 0,
                 "script"                TEXT NOT NULL
             );
-            "#;
+        "#;
 
         Ok(connection.raw_cmd(sql).await?)
     }
@@ -55,9 +55,9 @@ impl SqlFlavour for SqliteFlavour {
         sql_schema_describer::sqlite::SqlSchemaDescriber::new(connection.quaint().clone())
             .describe(connection.connection_info().schema_name())
             .await
-            .map_err(|err| match err {
-                SqlSchemaDescriberError::UnknownError => {
-                    ConnectorError::generic(anyhow::anyhow!("An unknown error occurred in sql-schema-describer"))
+            .map_err(|err| match err.into_kind() {
+                DescriberErrorKind::QuaintError(err) => {
+                    quaint_error_to_connector_error(err, connection.connection_info())
                 }
             })
     }


### PR DESCRIPTION
Replace unwraps with results, and add proper error context so we can
bubble up meaningful errors.

closes https://github.com/prisma/migrate/issues/606