### PR TITLE
Gatekeeping certain features from Migration Engine

### DIFF
--- a/libs/datamodel/core/src/configuration/configuration.rs
+++ b/libs/datamodel/core/src/configuration/configuration.rs
@@ -1,5 +1,6 @@
 use super::{Datasource, Generator};
 use crate::diagnostics::{DatamodelError, Diagnostics};
+use crate::preview_features::PreviewFeatures;
 
 pub struct Configuration {
     pub generators: Vec<Generator>,
@@ -17,5 +18,11 @@ impl Configuration {
         } else {
             Ok(self)
         }
+    }
+
+    pub fn preview_features(&self) -> impl Iterator<Item = &str> {
+        self.generators
+            .iter()
+            .flat_map(|generator| generator.preview_features().iter().map(|feat| feat.as_str()))
     }
 }

--- a/libs/test-cli/src/main.rs
+++ b/libs/test-cli/src/main.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 use colored::Colorize;
-use migration_core::commands::SchemaPushInput;
+use migration_core::{commands::SchemaPushInput, GateKeeper};
 use std::{fs::File, io::Read};
 use structopt::*;
 
@@ -98,12 +98,12 @@ async fn main() -> anyhow::Result<()> {
                 (None, false) => anyhow::bail!("{}", "either --stdin or --file-path is required".bold().red()),
             };
 
-            migration_core::migration_api(&datamodel_string)
+            migration_core::migration_api(&datamodel_string, GateKeeper::allow_all_whitelist())
                 .await?
                 .reset(&())
                 .await?;
 
-            let api = migration_core::migration_api(&datamodel_string).await?;
+            let api = migration_core::migration_api(&datamodel_string, GateKeeper::allow_all_whitelist()).await?;
             let migration_id = "test-cli-migration".to_owned();
 
             let infer_input = migration_core::InferMigrationStepsInput {
@@ -233,7 +233,7 @@ async fn generate_dmmf(cmd: &DmmfCommand) -> anyhow::Result<()> {
 
 async fn schema_push(cmd: &SchemaPush) -> anyhow::Result<()> {
     let schema = read_datamodel_from_file(&cmd.schema_path).context("Error reading the schema from file")?;
-    let api = migration_core::migration_api(&schema).await?;
+    let api = migration_core::migration_api(&schema, GateKeeper::allow_all_whitelist()).await?;
 
     let response = api
         .schema_push(&SchemaPushInput {

--- a/libs/user-facing-errors/src/migration_engine.rs
+++ b/libs/user-facing-errors/src/migration_engine.rs
@@ -76,6 +76,21 @@ impl crate::UserFacingError for MigrationDoesNotApplyCleanly {
     }
 }
 
+#[derive(Debug, Serialize)]
+pub struct PreviewFeaturesBlocked {
+    pub features: Vec<String>,
+}
+
+impl crate::UserFacingError for PreviewFeaturesBlocked {
+    const ERROR_CODE: &'static str = "P3007";
+
+    fn message(&self) -> String {
+        format!(
+            "Some of the requested preview features are not yet allowed in migration engine. Please remove them from your data model before using migrations."
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/libs/user-facing-errors/src/migration_engine.rs
+++ b/libs/user-facing-errors/src/migration_engine.rs
@@ -85,8 +85,11 @@ impl crate::UserFacingError for PreviewFeaturesBlocked {
     const ERROR_CODE: &'static str = "P3007";
 
     fn message(&self) -> String {
+        let blocked: Vec<_> = self.features.iter().map(|s| format!("`{}`", s)).collect();
+
         format!(
-            "Some of the requested preview features are not yet allowed in migration engine. Please remove them from your data model before using migrations."
+            "Some of the requested preview features are not yet allowed in migration engine. Please remove them from your data model before using migrations. (blocked: {})",
+            blocked.join(", "),
         )
     }
 }

--- a/migration-engine/cli/src/commands/tests.rs
+++ b/migration-engine/cli/src/commands/tests.rs
@@ -1,11 +1,12 @@
 use super::CliError;
+use migration_core::GateKeeper;
 use quaint::{prelude::*, single::Quaint};
 use structopt::StructOpt;
 use user_facing_errors::{common::DatabaseDoesNotExist, UserFacingError};
 
 async fn run(args: &[&str]) -> Result<String, CliError> {
     let cli = super::Cli::from_iter(std::iter::once(&"migration-engine-cli-test").chain(args.iter()));
-    cli.run_inner().await
+    cli.run_inner(GateKeeper::allow_all_whitelist()).await
 }
 
 fn postgres_url(db: Option<&str>) -> String {

--- a/migration-engine/cli/src/error_tests.rs
+++ b/migration-engine/cli/src/error_tests.rs
@@ -1,3 +1,4 @@
+use migration_core::GateKeeper;
 use quaint::{prelude::*, single::Quaint};
 use serde_json::json;
 use test_setup::*;
@@ -131,7 +132,7 @@ async fn get_cli_error(cli_args: &[&str]) -> user_facing_errors::Error {
     let cli_command = matches.cli_subcommand.expect("cli subcommand is passed");
     cli_command
         .unwrap_cli()
-        .run_inner()
+        .run_inner(GateKeeper::allow_all_whitelist())
         .await
         .map_err(crate::commands::error::render_error)
         .unwrap_err()

--- a/migration-engine/core/src/api/rpc.rs
+++ b/migration-engine/core/src/api/rpc.rs
@@ -76,10 +76,10 @@ const AVAILABLE_COMMANDS: &[RpcCommand] = &[
 ];
 
 impl RpcApi {
-    pub async fn new(datamodel: &str) -> CoreResult<Self> {
+    pub async fn new(datamodel: &str, enabled_preview_features: Vec<String>) -> CoreResult<Self> {
         let mut rpc_api = Self {
             io_handler: IoHandler::default(),
-            executor: crate::migration_api(datamodel).await?,
+            executor: crate::migration_api(datamodel, enabled_preview_features).await?,
         };
 
         for cmd in AVAILABLE_COMMANDS {

--- a/migration-engine/core/src/gate_keeper.rs
+++ b/migration-engine/core/src/gate_keeper.rs
@@ -1,0 +1,47 @@
+use crate::{CoreError, CoreResult};
+
+/// A tool to prevent using unfinished features from the Migration Engine.
+pub struct GateKeeper {
+    blacklist: &'static [&'static str],
+    whitelist: Vec<String>,
+}
+
+impl GateKeeper {
+    /// Creates a new instance, blocking features defined in the constructor.
+    pub fn new(whitelist: Vec<String>) -> Self {
+        Self {
+            blacklist: &["nativeTypes", "microsoftSqlServer"],
+            whitelist,
+        }
+    }
+
+    /// Returns an error if any of the given features are blocked.
+    pub fn any_blocked<'a, I>(&'a self, features: I) -> CoreResult<()>
+    where
+        I: Iterator<Item = &'a str>,
+    {
+        if self.whitelist.iter().any(|s| s == "all") {
+            return Ok(());
+        }
+
+        let blacklist = self.blacklist;
+        let whitelist = &self.whitelist;
+
+        let mut blocked = features
+            .filter(move |s| !whitelist.iter().any(|w| s == w) && blacklist.contains(s))
+            .peekable();
+
+        if blocked.peek().is_some() {
+            Err(CoreError::GatedPreviewFeatures(
+                blocked.map(ToString::to_string).collect(),
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Returns a whitelist vector allowing all gated features.
+    pub fn allow_all_whitelist() -> Vec<String> {
+        vec![String::from("all")]
+    }
+}

--- a/migration-engine/core/src/lib.rs
+++ b/migration-engine/core/src/lib.rs
@@ -11,11 +11,14 @@ pub mod migration;
 pub mod migration_engine;
 
 mod core_error;
+mod gate_keeper;
 
+use anyhow::anyhow;
 pub use api::GenericApi;
 pub use commands::{ApplyMigrationInput, InferMigrationStepsInput, MigrationStepsResultOutput, SchemaPushInput};
 use commands::{MigrationCommand, SchemaPushCommand};
 pub use core_error::{CoreError, CoreResult};
+pub use gate_keeper::GateKeeper;
 
 use datamodel::{
     common::provider_names::{MSSQL_SOURCE_NAME, MYSQL_SOURCE_NAME, POSTGRES_SOURCE_NAME, SQLITE_SOURCE_NAME},
@@ -28,13 +31,18 @@ use sql_migration_connector::SqlMigrationConnector;
 use std::sync::Arc;
 
 /// Top-level constructor for the migration engine API.
-pub async fn migration_api(datamodel: &str) -> CoreResult<Arc<dyn api::GenericApi>> {
+pub async fn migration_api(
+    datamodel: &str,
+    enabled_preview_features: Vec<String>,
+) -> CoreResult<Arc<dyn api::GenericApi>> {
     let config = parse_configuration(datamodel)?;
+
+    GateKeeper::new(enabled_preview_features).any_blocked(config.preview_features())?;
 
     let source = config
         .datasources
         .first()
-        .ok_or_else(|| CoreError::Generic(anyhow::anyhow!("There is no datasource in the schema.")))?;
+        .ok_or_else(|| CoreError::Generic(anyhow!("There is no datasource in the schema.")))?;
 
     let connector = match &source.active_provider {
         #[cfg(feature = "sql")]
@@ -80,7 +88,7 @@ pub async fn create_database(schema: &str) -> CoreResult<String> {
     let source = config
         .datasources
         .first()
-        .ok_or_else(|| CoreError::Generic(anyhow::anyhow!("There is no datasource in the schema.")))?;
+        .ok_or_else(|| CoreError::Generic(anyhow!("There is no datasource in the schema.")))?;
 
     match &source.active_provider {
         provider
@@ -105,7 +113,7 @@ pub async fn drop_database(schema: &str) -> CoreResult<()> {
     let source = config
         .datasources
         .first()
-        .ok_or_else(|| CoreError::Generic(anyhow::anyhow!("There is no datasource in the schema.")))?;
+        .ok_or_else(|| CoreError::Generic(anyhow!("There is no datasource in the schema.")))?;
 
     match &source.active_provider {
         provider
@@ -130,7 +138,7 @@ pub async fn qe_setup(prisma_schema: &str) -> CoreResult<()> {
     let source = config
         .datasources
         .first()
-        .ok_or_else(|| CoreError::Generic(anyhow::anyhow!("There is no datasource in the schema.")))?;
+        .ok_or_else(|| CoreError::Generic(anyhow!("There is no datasource in the schema.")))?;
 
     let connector = match &source.active_provider {
         provider

--- a/migration-engine/migration-engine-tests/tests/errors/error_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/errors/error_tests.rs
@@ -505,7 +505,7 @@ async fn microsoft_sql_server_is_not_allowed_in_migration_engine() {
 
     let expected = json!({
         "is_panic": false,
-        "message": "Some of the requested preview features are not yet allowed in migration engine. Please remove them from your data model before using migrations.",
+        "message": "Some of the requested preview features are not yet allowed in migration engine. Please remove them from your data model before using migrations. (blocked: `microsoftSqlServer`)",
         "meta": {
             "features": ["microsoftSqlServer"]
         },
@@ -543,7 +543,7 @@ async fn native_types_are_not_allowed_in_migration_engine() {
 
     let expected = json!({
         "is_panic": false,
-        "message": "Some of the requested preview features are not yet allowed in migration engine. Please remove them from your data model before using migrations.",
+        "message": "Some of the requested preview features are not yet allowed in migration engine. Please remove them from your data model before using migrations. (blocked: `nativeTypes`)",
         "meta": {
             "features": ["nativeTypes"]
         },

--- a/migration-engine/migration-engine-tests/tests/initialization/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/initialization/mod.rs
@@ -1,4 +1,4 @@
-use migration_core::migration_api;
+use migration_core::{migration_api, GateKeeper};
 use migration_engine_tests::postgres_10_url;
 use quaint::prelude::Queryable;
 use url::Url;
@@ -61,7 +61,9 @@ async fn connecting_to_a_postgres_database_with_missing_schema_creates_it() {
             url
         );
 
-        migration_api(&datamodel).await.unwrap();
+        migration_api(&datamodel, GateKeeper::allow_all_whitelist())
+            .await
+            .unwrap();
     }
 
     // Check that the "unexpected" schema now exists.

--- a/query-engine/connector-test-kit/src/test/scala/util/TestDatabase.scala
+++ b/query-engine/connector-test-kit/src/test/scala/util/TestDatabase.scala
@@ -19,8 +19,8 @@ case class MigrationEngine(project: Project) {
 
   def resetAndSetupDatabase(): Unit = {
     import scala.sys.process._
-    val cmd = List(EnvVars.migrationEngineBinaryPath, "cli", "-d", project.fullDatamodel, "qe-setup")
 
+    val cmd = List(EnvVars.migrationEngineBinaryPath, "--enabled-preview-features=all", "cli", "-d", project.fullDatamodel, "qe-setup")
     cmd.!
   }
 }


### PR DESCRIPTION
- Blocking `microsoftSqlServer` and `nativeTypes` for now from Migration Engine
- New parameter `--enabled-preview-features`, a comma-separated list of features to allow. Can hold either of the blocked items, or `all` to allow them both
- Introduces a new user-facing error for Migration Engine: `P3007`

Closes: https://github.com/prisma/prisma-engines/issues/1222 and https://github.com/prisma/migrations-team/issues/57