### PR TITLE
Native types: validation for mysql native types and id attributes

### DIFF
--- a/libs/datamodel/connectors/datamodel-connector/src/connector_error.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/connector_error.rs
@@ -139,7 +139,11 @@ pub enum ErrorKind {
         connector_name: String,
     },
 
-    #[error("Native type {} can not be used in an ID field in {}.", native_type, connector_name)]
+    #[error(
+        "Native type {} of {} can not be used on a field that is `@id` or `@@id`.",
+        native_type,
+        connector_name
+    )]
     IncompatibleNativeTypeWithIdAttribute {
         native_type: String,
         connector_name: String,

--- a/libs/datamodel/connectors/datamodel-connector/src/connector_error.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/connector_error.rs
@@ -50,6 +50,13 @@ impl ConnectorError {
         })
     }
 
+    pub fn new_incompatible_native_type_with_id(native_type: &str, connector_name: &str) -> ConnectorError {
+        ConnectorError::from_kind(ErrorKind::IncompatibleNativeTypeWithIdAttribute {
+            native_type: String::from(native_type),
+            connector_name: String::from(connector_name),
+        })
+    }
+
     pub fn new_value_parser_error(expected_type: &str, parser_error: &str, raw: &str) -> ConnectorError {
         ConnectorError::from_kind(ErrorKind::ValueParserError {
             expected_type: String::from(expected_type),
@@ -128,6 +135,12 @@ pub enum ErrorKind {
 
     #[error("Native type {} can not be unique in {}.", native_type, connector_name)]
     IncompatibleNativeTypeWithUniqueAttribute {
+        native_type: String,
+        connector_name: String,
+    },
+
+    #[error("Native type {} can not be used in an ID field in {}.", native_type, connector_name)]
+    IncompatibleNativeTypeWithIdAttribute {
         native_type: String,
         connector_name: String,
     },

--- a/libs/datamodel/core/tests/common.rs
+++ b/libs/datamodel/core/tests/common.rs
@@ -64,6 +64,7 @@ pub trait ErrorAsserts {
     fn assert_is_message(&self, msg: &str) -> &Self;
     fn assert_is_at(&self, index: usize, error: DatamodelError) -> &Self;
     fn assert_length(&self, length: usize) -> &Self;
+    fn assert_is_message_at(&self, index: usize, msg: &str) -> &Self;
 }
 
 pub trait WarningAsserts {
@@ -327,6 +328,11 @@ impl ErrorAsserts for Diagnostics {
             self.errors.len(),
             &self.errors,
         );
+        self
+    }
+
+    fn assert_is_message_at(&self, index: usize, msg: &str) -> &Self {
+        assert_eq!(self.errors[index].description(), msg);
         self
     }
 }

--- a/libs/datamodel/core/tests/types/mysql_native_types.rs
+++ b/libs/datamodel/core/tests/types/mysql_native_types.rs
@@ -410,3 +410,355 @@ fn should_fail_on_native_type_numeric_when_scale_is_bigger_than_precision() {
         ast::Span::new(281, 311),
     ));
 }
+
+#[test]
+fn should_fail_on_native_type_text_with_id_attribute() {
+    let dml = r#"
+        datasource db {
+          provider = "mysql"
+          url = "mysql://"
+        }
+
+        generator js {
+            provider = "prisma-client-js"
+            previewFeatures = ["nativeTypes"]
+        }
+
+        model Blog {
+            bigInt String @db.Text @id
+        }
+
+        model User {
+            firstname String @db.Text
+            lastname  String @db.Text
+            @@id([firstname, lastname])
+        }
+    "#;
+
+    let error = parse_error(dml);
+
+    error.assert_length(2);
+
+    error.assert_is_at(
+        0,
+        DatamodelError::new_connector_error(
+            "Native type Text can not be used in an ID field in MySQL.",
+            ast::Span::new(247, 274),
+        ),
+    );
+    error.assert_is_at(
+        1,
+        DatamodelError::new_connector_error(
+            "Native type Text can not be used in an ID field in MySQL.",
+            ast::Span::new(293, 431),
+        ),
+    );
+}
+
+#[test]
+fn should_fail_on_native_type_long_text_with_id_attribute() {
+    let dml = r#"
+        datasource db {
+          provider = "mysql"
+          url = "mysql://"
+        }
+
+        generator js {
+            provider = "prisma-client-js"
+            previewFeatures = ["nativeTypes"]
+        }
+
+        model Blog {
+            bigInt String @db.LongText @id
+        }
+
+        model User {
+            firstname String @db.LongText
+            lastname  String @db.LongText
+            @@id([firstname, lastname])
+        }
+    "#;
+
+    let error = parse_error(dml);
+
+    error.assert_length(2);
+
+    error.assert_is_at(
+        0,
+        DatamodelError::new_connector_error(
+            "Native type LongText can not be used in an ID field in MySQL.",
+            ast::Span::new(247, 278),
+        ),
+    );
+    error.assert_is_at(
+        1,
+        DatamodelError::new_connector_error(
+            "Native type LongText can not be used in an ID field in MySQL.",
+            ast::Span::new(297, 443),
+        ),
+    );
+}
+
+#[test]
+fn should_fail_on_native_type_medium_text_with_id_attribute() {
+    let dml = r#"
+        datasource db {
+          provider = "mysql"
+          url = "mysql://"
+        }
+
+        generator js {
+            provider = "prisma-client-js"
+            previewFeatures = ["nativeTypes"]
+        }
+
+        model Blog {
+            bigInt String @db.MediumText @id
+        }
+
+        model User {
+            firstname String @db.MediumText
+            lastname  String @db.MediumText
+            @@id([firstname, lastname])
+        }
+    "#;
+
+    let error = parse_error(dml);
+
+    error.assert_length(2);
+
+    error.assert_is_at(
+        0,
+        DatamodelError::new_connector_error(
+            "Native type MediumText can not be used in an ID field in MySQL.",
+            ast::Span::new(247, 280),
+        ),
+    );
+    error.assert_is_at(
+        1,
+        DatamodelError::new_connector_error(
+            "Native type MediumText can not be used in an ID field in MySQL.",
+            ast::Span::new(299, 449),
+        ),
+    );
+}
+
+#[test]
+fn should_fail_on_native_type_tiny_text_with_id_attribute() {
+    let dml = r#"
+        datasource db {
+          provider = "mysql"
+          url = "mysql://"
+        }
+
+        generator js {
+            provider = "prisma-client-js"
+            previewFeatures = ["nativeTypes"]
+        }
+
+        model Blog {
+            bigInt String @db.TinyText @id
+        }
+
+        model User {
+            firstname String @db.TinyText
+            lastname  String @db.TinyText
+            @@id([firstname, lastname])
+        }
+    "#;
+
+    let error = parse_error(dml);
+
+    error.assert_length(2);
+
+    error.assert_is_at(
+        0,
+        DatamodelError::new_connector_error(
+            "Native type TinyText can not be used in an ID field in MySQL.",
+            ast::Span::new(247, 278),
+        ),
+    );
+    error.assert_is_at(
+        1,
+        DatamodelError::new_connector_error(
+            "Native type TinyText can not be used in an ID field in MySQL.",
+            ast::Span::new(297, 443),
+        ),
+    );
+}
+
+#[test]
+fn should_fail_on_native_type_blob_with_id_attribute() {
+    let dml = r#"
+        datasource db {
+          provider = "mysql"
+          url = "mysql://"
+        }
+
+        generator js {
+            provider = "prisma-client-js"
+            previewFeatures = ["nativeTypes"]
+        }
+
+        model Blog {
+            bigInt Bytes @db.Blob @id
+        }
+
+        model User {
+            firstname Bytes @db.Blob
+            lastname  Bytes @db.Blob
+            @@id([firstname, lastname])
+        }
+    "#;
+
+    let error = parse_error(dml);
+
+    error.assert_length(2);
+
+    error.assert_is_at(
+        0,
+        DatamodelError::new_connector_error(
+            "Native type Blob can not be used in an ID field in MySQL.",
+            ast::Span::new(247, 273),
+        ),
+    );
+    error.assert_is_at(
+        1,
+        DatamodelError::new_connector_error(
+            "Native type Blob can not be used in an ID field in MySQL.",
+            ast::Span::new(292, 428),
+        ),
+    );
+}
+
+#[test]
+fn should_fail_on_native_type_tiny_blob_with_id_attribute() {
+    let dml = r#"
+        datasource db {
+          provider = "mysql"
+          url = "mysql://"
+        }
+
+        generator js {
+            provider = "prisma-client-js"
+            previewFeatures = ["nativeTypes"]
+        }
+
+        model Blog {
+            bigInt Bytes @db.TinyBlob @id
+        }
+
+        model User {
+            firstname Bytes @db.TinyBlob
+            lastname  Bytes @db.TinyBlob
+            @@id([firstname, lastname])
+        }
+    "#;
+
+    let error = parse_error(dml);
+
+    error.assert_length(2);
+
+    error.assert_is_at(
+        0,
+        DatamodelError::new_connector_error(
+            "Native type TinyBlob can not be used in an ID field in MySQL.",
+            ast::Span::new(247, 277),
+        ),
+    );
+    error.assert_is_at(
+        1,
+        DatamodelError::new_connector_error(
+            "Native type TinyBlob can not be used in an ID field in MySQL.",
+            ast::Span::new(296, 440),
+        ),
+    );
+}
+
+#[test]
+fn should_fail_on_native_type_medium_blob_with_id_attribute() {
+    let dml = r#"
+        datasource db {
+          provider = "mysql"
+          url = "mysql://"
+        }
+
+        generator js {
+            provider = "prisma-client-js"
+            previewFeatures = ["nativeTypes"]
+        }
+
+        model Blog {
+            bigInt Bytes @db.MediumBlob @id
+        }
+
+        model User {
+            firstname Bytes @db.MediumBlob
+            lastname  Bytes @db.MediumBlob
+            @@id([firstname, lastname])
+        }
+    "#;
+
+    let error = parse_error(dml);
+
+    error.assert_length(2);
+
+    error.assert_is_at(
+        0,
+        DatamodelError::new_connector_error(
+            "Native type MediumBlob can not be used in an ID field in MySQL.",
+            ast::Span::new(247, 279),
+        ),
+    );
+    error.assert_is_at(
+        1,
+        DatamodelError::new_connector_error(
+            "Native type MediumBlob can not be used in an ID field in MySQL.",
+            ast::Span::new(298, 446),
+        ),
+    );
+}
+
+#[test]
+fn should_fail_on_native_type_long_blob_with_id_attribute() {
+    let dml = r#"
+        datasource db {
+          provider = "mysql"
+          url      = "mysql://"
+        }
+
+        generator js {
+            provider = "prisma-client-js"
+            previewFeatures = ["nativeTypes"]
+        }
+
+        model Blog {
+            bigInt Bytes @db.LongBlob @id
+        }
+
+        model User {
+            firstname Bytes @db.LongBlob
+            lastname  Bytes @db.LongBlob
+            @@id([firstname, lastname])
+        }
+    "#;
+
+    let error = parse_error(dml);
+
+    error.assert_length(2);
+
+    error.assert_is_at(
+        0,
+        DatamodelError::new_connector_error(
+            "Native type LongBlob can not be used in an ID field in MySQL.",
+            ast::Span::new(252, 282),
+        ),
+    );
+    error.assert_is_at(
+        1,
+        DatamodelError::new_connector_error(
+            "Native type LongBlob can not be used in an ID field in MySQL.",
+            ast::Span::new(301, 445),
+        ),
+    );
+}

--- a/libs/datamodel/core/tests/types/mysql_native_types.rs
+++ b/libs/datamodel/core/tests/types/mysql_native_types.rs
@@ -1,360 +1,94 @@
 use crate::common::*;
 use datamodel::{ast, diagnostics::DatamodelError};
 
+const BLOB_TYPES: &[&'static str] = &["Blob", "LongBlob", "MediumBlob", "TinyBlob"];
+const TEXT_TYPES: &[&'static str] = &["Text", "LongText", "MediumText", "TinyText"];
+
 #[test]
-fn should_fail_on_native_type_text_with_unique_attribute() {
-    let dml = r#"
-        datasource db {
-          provider = "mysql"
-          url = "mysql://"
-        }
+fn text_and_blob_data_types_can_not_be_unique() {
+    fn error_msg(type_name: &str) -> String {
+        format!("Native type {} can not be unique in MySQL.", type_name)
+    }
 
-        generator js {
-            provider = "prisma-client-js"
-            previewFeatures = ["nativeTypes"]
-        }
+    for tpe in BLOB_TYPES {
+        test_field_and_block_attribute_support(tpe, "Bytes", "unique", &error_msg(tpe));
+    }
 
-        model Blog {
-            id     Int    @id
-            bigInt String @db.Text @unique
-        }
-
-        model User {
-            id        Int     @default(autoincrement()) @id
-            firstname String @db.Text
-            lastname  String @db.Text
-            @@unique([firstname, lastname])
-        }
-    "#;
-
-    let error = parse_error(dml);
-
-    error.assert_length(2);
-
-    error.assert_is_at(
-        0,
-        DatamodelError::new_connector_error("Native type Text can not be unique in MySQL.", ast::Span::new(277, 308)),
-    );
-    error.assert_is_at(
-        1,
-        DatamodelError::new_connector_error("Native type Text can not be unique in MySQL.", ast::Span::new(327, 529)),
-    );
+    for tpe in TEXT_TYPES {
+        test_field_and_block_attribute_support(tpe, "String", "unique", &error_msg(tpe));
+    }
 }
 
 #[test]
-fn should_fail_on_native_type_long_text_with_unique_attribute() {
-    let dml = r#"
-        datasource db {
-          provider = "mysql"
-          url = "mysql://"
-        }
+fn text_and_blob_data_types_should_fail_on_id_attribute() {
+    fn error_msg(type_name: &str) -> String {
+        format!(
+            "Native type {} of MySQL can not be used on a field that is `@id` or `@@id`.",
+            type_name
+        )
+    }
 
-        generator js {
-            provider = "prisma-client-js"
-            previewFeatures = ["nativeTypes"]
-        }
+    for tpe in BLOB_TYPES {
+        test_field_and_block_attribute_support(tpe, "Bytes", "id", &error_msg(tpe));
+    }
 
-        model Blog {
-            id     Int    @id
-            bigInt String @db.LongText @unique
-        }
-
-        model User {
-            id        Int     @default(autoincrement()) @id
-            firstname String @db.LongText
-            lastname  String @db.LongText
-            @@unique([firstname, lastname])
-        }
-    "#;
-
-    let error = parse_error(dml);
-
-    error.assert_length(2);
-
-    error.assert_is_at(
-        0,
-        DatamodelError::new_connector_error(
-            "Native type LongText can not be unique in MySQL.",
-            ast::Span::new(277, 312),
-        ),
-    );
-    error.assert_is_at(
-        1,
-        DatamodelError::new_connector_error(
-            "Native type LongText can not be unique in MySQL.",
-            ast::Span::new(331, 541),
-        ),
-    );
+    for tpe in TEXT_TYPES {
+        test_field_and_block_attribute_support(tpe, "String", "id", &error_msg(tpe));
+    }
 }
 
-#[test]
-fn should_fail_on_native_type_medium_text_with_unique_attribute() {
-    let dml = r#"
-        datasource db {
-          provider = "mysql"
-          url = "mysql://"
-        }
+fn test_field_and_block_attribute_support(native_type: &str, scalar_type: &str, attribute_name: &str, error_msg: &str) {
+    let id_field = if attribute_name == "id" {
+        ""
+    } else {
+        "id     Int    @id"
+    };
+    let dml = format!(
+        r#"
+    model Blog {{
+      {id_field}
+      bigInt {scalar_type} @db.{native_type} @{attribute_name}
+    }}
 
-        generator js {
-            provider = "prisma-client-js"
-            previewFeatures = ["nativeTypes"]
-        }
-
-        model Blog {
-            id     Int    @id
-            bigInt String @db.MediumText @unique
-        }
-
-        model User {
-            id        Int     @default(autoincrement()) @id
-            firstname String @db.MediumText
-            lastname  String @db.MediumText
-            @@unique([firstname, lastname])
-        }
-    "#;
-
-    let error = parse_error(dml);
-
-    error.assert_length(2);
-
-    error.assert_is_at(
-        0,
-        DatamodelError::new_connector_error(
-            "Native type MediumText can not be unique in MySQL.",
-            ast::Span::new(277, 314),
-        ),
+    model User {{
+      {id_field}
+      firstname {scalar_type} @db.{native_type}
+      lastname  {scalar_type} @db.{native_type}
+      @@{attribute_name}([firstname, lastname])
+    }}
+    "#,
+        id_field = id_field,
+        native_type = native_type,
+        scalar_type = scalar_type,
+        attribute_name = attribute_name
     );
-    error.assert_is_at(
-        1,
-        DatamodelError::new_connector_error(
-            "Native type MediumText can not be unique in MySQL.",
-            ast::Span::new(333, 547),
-        ),
-    );
+
+    test_compatibility(&dml, &error_msg);
 }
 
-#[test]
-fn should_fail_on_native_type_tiny_text_with_unique_attribute() {
-    let dml = r#"
-        datasource db {
+fn test_compatibility(datamodel: &str, error_msg: &str) {
+    let dml = format!(
+        r#"
+    datasource db {{
           provider = "mysql"
           url = "mysql://"
-        }
+        }}
 
-        generator js {
+        generator js {{
             provider = "prisma-client-js"
             previewFeatures = ["nativeTypes"]
-        }
+        }}
 
-        model Blog {
-            id     Int    @id
-            bigInt String @db.TinyText @unique
-        }
+    {datamodel}
+    "#,
+        datamodel = datamodel,
+    );
 
-        model User {
-            id        Int     @default(autoincrement()) @id
-            firstname String @db.TinyText
-            lastname  String @db.TinyText
-            @@unique([firstname, lastname])
-        }
-    "#;
-
-    let error = parse_error(dml);
+    let error = parse_error(&dml);
 
     error.assert_length(2);
-
-    error.assert_is_at(
-        0,
-        DatamodelError::new_connector_error(
-            "Native type TinyText can not be unique in MySQL.",
-            ast::Span::new(277, 312),
-        ),
-    );
-    error.assert_is_at(
-        1,
-        DatamodelError::new_connector_error(
-            "Native type TinyText can not be unique in MySQL.",
-            ast::Span::new(331, 541),
-        ),
-    );
-}
-
-#[test]
-fn should_fail_on_native_type_blob_with_unique_attribute() {
-    let dml = r#"
-        datasource db {
-          provider = "mysql"
-          url = "mysql://"
-        }
-
-        generator js {
-            provider = "prisma-client-js"
-            previewFeatures = ["nativeTypes"]
-        }
-
-        model Blog {
-            id     Int   @id
-            bigInt Bytes @db.Blob @unique
-        }
-
-        model User {
-            id        Int     @default(autoincrement()) @id
-            firstname Bytes @db.Blob
-            lastname  Bytes @db.Blob
-            @@unique([firstname, lastname])
-        }
-    "#;
-
-    let error = parse_error(dml);
-
-    error.assert_length(2);
-
-    error.assert_is_at(
-        0,
-        DatamodelError::new_connector_error("Native type Blob can not be unique in MySQL.", ast::Span::new(276, 306)),
-    );
-    error.assert_is_at(
-        1,
-        DatamodelError::new_connector_error("Native type Blob can not be unique in MySQL.", ast::Span::new(325, 525)),
-    );
-}
-
-#[test]
-fn should_fail_on_native_type_tiny_blob_with_unique_attribute() {
-    let dml = r#"
-        datasource db {
-          provider = "mysql"
-          url = "mysql://"
-        }
-
-        generator js {
-            provider = "prisma-client-js"
-            previewFeatures = ["nativeTypes"]
-        }
-
-        model Blog {
-            id     Int    @id
-            bigInt Bytes @db.TinyBlob @unique
-        }
-
-        model User {
-            id        Int     @default(autoincrement()) @id
-            firstname Bytes @db.TinyBlob
-            lastname  Bytes @db.TinyBlob
-            @@unique([firstname, lastname])
-        }
-    "#;
-
-    let error = parse_error(dml);
-
-    error.assert_length(2);
-
-    error.assert_is_at(
-        0,
-        DatamodelError::new_connector_error(
-            "Native type TinyBlob can not be unique in MySQL.",
-            ast::Span::new(277, 311),
-        ),
-    );
-    error.assert_is_at(
-        1,
-        DatamodelError::new_connector_error(
-            "Native type TinyBlob can not be unique in MySQL.",
-            ast::Span::new(330, 538),
-        ),
-    );
-}
-
-#[test]
-fn should_fail_on_native_type_medium_blob_with_unique_attribute() {
-    let dml = r#"
-        datasource db {
-          provider = "mysql"
-          url = "mysql://"
-        }
-
-        generator js {
-            provider = "prisma-client-js"
-            previewFeatures = ["nativeTypes"]
-        }
-
-        model Blog {
-            id     Int    @id
-            bigInt Bytes @db.MediumBlob @unique
-        }
-
-        model User {
-            id        Int     @default(autoincrement()) @id
-            firstname Bytes @db.MediumBlob
-            lastname  Bytes @db.MediumBlob
-            @@unique([firstname, lastname])
-        }
-    "#;
-
-    let error = parse_error(dml);
-
-    error.assert_length(2);
-
-    error.assert_is_at(
-        0,
-        DatamodelError::new_connector_error(
-            "Native type MediumBlob can not be unique in MySQL.",
-            ast::Span::new(277, 313),
-        ),
-    );
-    error.assert_is_at(
-        1,
-        DatamodelError::new_connector_error(
-            "Native type MediumBlob can not be unique in MySQL.",
-            ast::Span::new(332, 544),
-        ),
-    );
-}
-
-#[test]
-fn should_fail_on_native_type_long_blob_with_unique_attribute() {
-    let dml = r#"
-        datasource db {
-          provider = "mysql"
-          url      = "mysql://"
-        }
-
-        generator js {
-            provider = "prisma-client-js"
-            previewFeatures = ["nativeTypes"]
-        }
-
-        model Blog {
-            id     Int   @id
-            bigInt Bytes @db.LongBlob @unique
-        }
-
-        model User {
-            id        Int     @default(autoincrement()) @id
-            firstname Bytes @db.LongBlob
-            lastname  Bytes @db.LongBlob
-            @@unique([firstname, lastname])
-        }
-    "#;
-
-    let error = parse_error(dml);
-
-    error.assert_length(2);
-
-    error.assert_is_at(
-        0,
-        DatamodelError::new_connector_error(
-            "Native type LongBlob can not be unique in MySQL.",
-            ast::Span::new(281, 315),
-        ),
-    );
-    error.assert_is_at(
-        1,
-        DatamodelError::new_connector_error(
-            "Native type LongBlob can not be unique in MySQL.",
-            ast::Span::new(334, 542),
-        ),
-    );
+    error.assert_is_message_at(0, error_msg);
+    error.assert_is_message_at(1, error_msg);
 }
 
 #[test]
@@ -409,356 +143,4 @@ fn should_fail_on_native_type_numeric_when_scale_is_bigger_than_precision() {
         "The scale must not be larger than the precision for the Numeric native type in MySQL.",
         ast::Span::new(281, 311),
     ));
-}
-
-#[test]
-fn should_fail_on_native_type_text_with_id_attribute() {
-    let dml = r#"
-        datasource db {
-          provider = "mysql"
-          url = "mysql://"
-        }
-
-        generator js {
-            provider = "prisma-client-js"
-            previewFeatures = ["nativeTypes"]
-        }
-
-        model Blog {
-            bigInt String @db.Text @id
-        }
-
-        model User {
-            firstname String @db.Text
-            lastname  String @db.Text
-            @@id([firstname, lastname])
-        }
-    "#;
-
-    let error = parse_error(dml);
-
-    error.assert_length(2);
-
-    error.assert_is_at(
-        0,
-        DatamodelError::new_connector_error(
-            "Native type Text can not be used in an ID field in MySQL.",
-            ast::Span::new(247, 274),
-        ),
-    );
-    error.assert_is_at(
-        1,
-        DatamodelError::new_connector_error(
-            "Native type Text can not be used in an ID field in MySQL.",
-            ast::Span::new(293, 431),
-        ),
-    );
-}
-
-#[test]
-fn should_fail_on_native_type_long_text_with_id_attribute() {
-    let dml = r#"
-        datasource db {
-          provider = "mysql"
-          url = "mysql://"
-        }
-
-        generator js {
-            provider = "prisma-client-js"
-            previewFeatures = ["nativeTypes"]
-        }
-
-        model Blog {
-            bigInt String @db.LongText @id
-        }
-
-        model User {
-            firstname String @db.LongText
-            lastname  String @db.LongText
-            @@id([firstname, lastname])
-        }
-    "#;
-
-    let error = parse_error(dml);
-
-    error.assert_length(2);
-
-    error.assert_is_at(
-        0,
-        DatamodelError::new_connector_error(
-            "Native type LongText can not be used in an ID field in MySQL.",
-            ast::Span::new(247, 278),
-        ),
-    );
-    error.assert_is_at(
-        1,
-        DatamodelError::new_connector_error(
-            "Native type LongText can not be used in an ID field in MySQL.",
-            ast::Span::new(297, 443),
-        ),
-    );
-}
-
-#[test]
-fn should_fail_on_native_type_medium_text_with_id_attribute() {
-    let dml = r#"
-        datasource db {
-          provider = "mysql"
-          url = "mysql://"
-        }
-
-        generator js {
-            provider = "prisma-client-js"
-            previewFeatures = ["nativeTypes"]
-        }
-
-        model Blog {
-            bigInt String @db.MediumText @id
-        }
-
-        model User {
-            firstname String @db.MediumText
-            lastname  String @db.MediumText
-            @@id([firstname, lastname])
-        }
-    "#;
-
-    let error = parse_error(dml);
-
-    error.assert_length(2);
-
-    error.assert_is_at(
-        0,
-        DatamodelError::new_connector_error(
-            "Native type MediumText can not be used in an ID field in MySQL.",
-            ast::Span::new(247, 280),
-        ),
-    );
-    error.assert_is_at(
-        1,
-        DatamodelError::new_connector_error(
-            "Native type MediumText can not be used in an ID field in MySQL.",
-            ast::Span::new(299, 449),
-        ),
-    );
-}
-
-#[test]
-fn should_fail_on_native_type_tiny_text_with_id_attribute() {
-    let dml = r#"
-        datasource db {
-          provider = "mysql"
-          url = "mysql://"
-        }
-
-        generator js {
-            provider = "prisma-client-js"
-            previewFeatures = ["nativeTypes"]
-        }
-
-        model Blog {
-            bigInt String @db.TinyText @id
-        }
-
-        model User {
-            firstname String @db.TinyText
-            lastname  String @db.TinyText
-            @@id([firstname, lastname])
-        }
-    "#;
-
-    let error = parse_error(dml);
-
-    error.assert_length(2);
-
-    error.assert_is_at(
-        0,
-        DatamodelError::new_connector_error(
-            "Native type TinyText can not be used in an ID field in MySQL.",
-            ast::Span::new(247, 278),
-        ),
-    );
-    error.assert_is_at(
-        1,
-        DatamodelError::new_connector_error(
-            "Native type TinyText can not be used in an ID field in MySQL.",
-            ast::Span::new(297, 443),
-        ),
-    );
-}
-
-#[test]
-fn should_fail_on_native_type_blob_with_id_attribute() {
-    let dml = r#"
-        datasource db {
-          provider = "mysql"
-          url = "mysql://"
-        }
-
-        generator js {
-            provider = "prisma-client-js"
-            previewFeatures = ["nativeTypes"]
-        }
-
-        model Blog {
-            bigInt Bytes @db.Blob @id
-        }
-
-        model User {
-            firstname Bytes @db.Blob
-            lastname  Bytes @db.Blob
-            @@id([firstname, lastname])
-        }
-    "#;
-
-    let error = parse_error(dml);
-
-    error.assert_length(2);
-
-    error.assert_is_at(
-        0,
-        DatamodelError::new_connector_error(
-            "Native type Blob can not be used in an ID field in MySQL.",
-            ast::Span::new(247, 273),
-        ),
-    );
-    error.assert_is_at(
-        1,
-        DatamodelError::new_connector_error(
-            "Native type Blob can not be used in an ID field in MySQL.",
-            ast::Span::new(292, 428),
-        ),
-    );
-}
-
-#[test]
-fn should_fail_on_native_type_tiny_blob_with_id_attribute() {
-    let dml = r#"
-        datasource db {
-          provider = "mysql"
-          url = "mysql://"
-        }
-
-        generator js {
-            provider = "prisma-client-js"
-            previewFeatures = ["nativeTypes"]
-        }
-
-        model Blog {
-            bigInt Bytes @db.TinyBlob @id
-        }
-
-        model User {
-            firstname Bytes @db.TinyBlob
-            lastname  Bytes @db.TinyBlob
-            @@id([firstname, lastname])
-        }
-    "#;
-
-    let error = parse_error(dml);
-
-    error.assert_length(2);
-
-    error.assert_is_at(
-        0,
-        DatamodelError::new_connector_error(
-            "Native type TinyBlob can not be used in an ID field in MySQL.",
-            ast::Span::new(247, 277),
-        ),
-    );
-    error.assert_is_at(
-        1,
-        DatamodelError::new_connector_error(
-            "Native type TinyBlob can not be used in an ID field in MySQL.",
-            ast::Span::new(296, 440),
-        ),
-    );
-}
-
-#[test]
-fn should_fail_on_native_type_medium_blob_with_id_attribute() {
-    let dml = r#"
-        datasource db {
-          provider = "mysql"
-          url = "mysql://"
-        }
-
-        generator js {
-            provider = "prisma-client-js"
-            previewFeatures = ["nativeTypes"]
-        }
-
-        model Blog {
-            bigInt Bytes @db.MediumBlob @id
-        }
-
-        model User {
-            firstname Bytes @db.MediumBlob
-            lastname  Bytes @db.MediumBlob
-            @@id([firstname, lastname])
-        }
-    "#;
-
-    let error = parse_error(dml);
-
-    error.assert_length(2);
-
-    error.assert_is_at(
-        0,
-        DatamodelError::new_connector_error(
-            "Native type MediumBlob can not be used in an ID field in MySQL.",
-            ast::Span::new(247, 279),
-        ),
-    );
-    error.assert_is_at(
-        1,
-        DatamodelError::new_connector_error(
-            "Native type MediumBlob can not be used in an ID field in MySQL.",
-            ast::Span::new(298, 446),
-        ),
-    );
-}
-
-#[test]
-fn should_fail_on_native_type_long_blob_with_id_attribute() {
-    let dml = r#"
-        datasource db {
-          provider = "mysql"
-          url      = "mysql://"
-        }
-
-        generator js {
-            provider = "prisma-client-js"
-            previewFeatures = ["nativeTypes"]
-        }
-
-        model Blog {
-            bigInt Bytes @db.LongBlob @id
-        }
-
-        model User {
-            firstname Bytes @db.LongBlob
-            lastname  Bytes @db.LongBlob
-            @@id([firstname, lastname])
-        }
-    "#;
-
-    let error = parse_error(dml);
-
-    error.assert_length(2);
-
-    error.assert_is_at(
-        0,
-        DatamodelError::new_connector_error(
-            "Native type LongBlob can not be used in an ID field in MySQL.",
-            ast::Span::new(252, 282),
-        ),
-    );
-    error.assert_is_at(
-        1,
-        DatamodelError::new_connector_error(
-            "Native type LongBlob can not be used in an ID field in MySQL.",
-            ast::Span::new(301, 445),
-        ),
-    );
 }


### PR DESCRIPTION
related https://www.notion.so/Compatibilities-with-Prisma-attributes-6e0902265bc94b8f88ccb47d780fcccb
All `TEXT` and `BLOB` data types are incompatible with the `@id` and `@@id` attribute. 