### PR TITLE
Update to quaint version with in-memory SQLite 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3290,7 +3290,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sql-schema-describer",
- "tempfile",
  "tokio",
  "tracing",
  "tracing-futures",

--- a/introspection-engine/introspection-engine-tests/src/test_api.rs
+++ b/introspection-engine/introspection-engine-tests/src/test_api.rs
@@ -57,7 +57,8 @@ impl TestApi {
             ConnectionInfo::Sqlite {
                 file_path: _,
                 db_name: _,
-            } => {
+            }
+            | ConnectionInfo::InMemorySqlite { .. } => {
                 let sql_schema = sqlite::SqlSchemaDescriber::new(self.database.clone())
                     .describe(self.connection_info.schema_name())
                     .await?;

--- a/migration-engine/connectors/sql-migration-connector/Cargo.toml
+++ b/migration-engine/connectors/sql-migration-connector/Cargo.toml
@@ -23,7 +23,6 @@ quaint = { git = "https://github.com/prisma/quaint", features = ["single", "trac
 regex = "1"
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"
-tempfile = "3.1.0"
 tokio = {version = "0.2.13", default-features = false, features = ["time"]}
 tracing = "0.1.10"
 tracing-futures = "0.2.0"

--- a/migration-engine/connectors/sql-migration-connector/src/flavour.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour.rs
@@ -36,7 +36,7 @@ pub(crate) fn from_connection_info(connection_info: &ConnectionInfo) -> Box<dyn 
             attached_name: db_name.clone(),
         }),
         ConnectionInfo::Mssql(url) => Box::new(MssqlFlavour(url.clone())),
-        ConnectionInfo::InMemorySqlite { .. } => todo!("Not yet"),
+        ConnectionInfo::InMemorySqlite { .. } => unreachable!("SqlFlavour for in-memory SQLite"),
     }
 }
 

--- a/query-engine/query-engine/src/tests/execute_raw.rs
+++ b/query-engine/query-engine/src/tests/execute_raw.rs
@@ -293,7 +293,7 @@ async fn syntactic_errors_bubbling_through_to_the_user(api: &TestApi) -> anyhow:
     match api.connection_info() {
         ConnectionInfo::Postgres(..) => assert_eq!(Some("42601"), error_code),
         ConnectionInfo::Mysql(..) => assert_eq!(Some("1064"), error_code),
-        ConnectionInfo::Sqlite { .. } => assert_eq!(Some("1"), error_code),
+        ConnectionInfo::Sqlite { .. } | ConnectionInfo::InMemorySqlite { .. } => assert_eq!(Some("1"), error_code),
         ConnectionInfo::Mssql(..) => assert_eq!(Some("102"), error_code),
         ConnectionInfo::InMemorySqlite { .. } => todo!("Not yet"),
     }
@@ -324,7 +324,7 @@ async fn other_errors_bubbling_through_to_the_user(api: &TestApi) -> anyhow::Res
     match api.connection_info() {
         ConnectionInfo::Postgres(..) => assert_eq!(Some("23505"), error_code),
         ConnectionInfo::Mysql(..) => assert_eq!(Some("1062"), error_code),
-        ConnectionInfo::Sqlite { .. } => assert_eq!(Some("1555"), error_code),
+        ConnectionInfo::Sqlite { .. } | ConnectionInfo::InMemorySqlite { .. } => assert_eq!(Some("1555"), error_code),
         ConnectionInfo::Mssql { .. } => assert_eq!(Some("2627"), error_code),
         ConnectionInfo::InMemorySqlite { .. } => todo!("Not yet"),
     }

--- a/query-engine/query-engine/src/tests/test_api.rs
+++ b/query-engine/query-engine/src/tests/test_api.rs
@@ -77,7 +77,7 @@ impl TestApi {
         match self.connection_info() {
             ConnectionInfo::Postgres(..) => visitor::Postgres::build(query),
             ConnectionInfo::Mysql(..) => visitor::Mysql::build(query),
-            ConnectionInfo::Sqlite { .. } => visitor::Sqlite::build(query),
+            ConnectionInfo::Sqlite { .. } | ConnectionInfo::InMemorySqlite { .. } => visitor::Sqlite::build(query),
             ConnectionInfo::Mssql(_) => visitor::Mssql::build(query),
             ConnectionInfo::InMemorySqlite { .. } => todo!("Not yet"),
         }


### PR DESCRIPTION
This lets us drop the tempfile dependency in the sql-migration-connector.

Depends on https://github.com/prisma/prisma-engines/pull/1280