### PR TITLE
validate native type bit and varbit

### DIFF
--- a/libs/datamodel/connectors/datamodel-connector/src/connector_error.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/connector_error.rs
@@ -81,6 +81,14 @@ impl ConnectorError {
             connector_name: String::from(connector_name),
         })
     }
+
+    pub fn new_argument_m_out_of_range_error(message: &str, native_type: &str, connector_name: &str) -> ConnectorError {
+        ConnectorError::from_kind(ErrorKind::ArgumentOutOfRangeError {
+            native_type: String::from(native_type),
+            connector_name: String::from(connector_name),
+            message: String::from(message),
+        })
+    }
 }
 
 #[derive(Debug, Error, Clone)]
@@ -206,5 +214,17 @@ pub enum ErrorKind {
     IncompatibleSequentialTypeWithStaticDefaultValue {
         native_type: String,
         connector_name: String,
+    },
+
+    #[error(
+        "Argument M is out of range for Native type {} of {}: {}",
+        native_type,
+        connector_name,
+        message
+    )]
+    ArgumentOutOfRangeError {
+        native_type: String,
+        connector_name: String,
+        message: String,
     },
 }

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
@@ -167,6 +167,18 @@ impl Connector for MySqlDatamodelConnector {
                     _ => {}
                 }
             }
+            if matches!(native_type_name, BIT_TYPE_NAME) {
+                match native_type.args.as_slice() {
+                    [length] if length == &0 || length > &64 => {
+                        return Err(ConnectorError::new_argument_m_out_of_range_error(
+                            "M can range from 1 to 64",
+                            native_type_name,
+                            "MySQL",
+                        ))
+                    }
+                    _ => {}
+                }
+            }
             if field.is_unique() && NATIVE_TYPES_THAT_CAN_NOT_BE_USED_IN_KEY_SPECIFICATION.contains(&native_type_name) {
                 return Err(ConnectorError::new_incompatible_native_type_with_unique(
                     native_type_name,

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
@@ -140,6 +140,18 @@ impl Connector for PostgresDatamodelConnector {
                     _ => {}
                 }
             }
+            if matches!(native_type_name, BIT_TYPE_NAME | VAR_BIT_TYPE_NAME) {
+                match native_type.args.as_slice() {
+                    [length] if length == &0 => {
+                        return Err(ConnectorError::new_argument_m_out_of_range_error(
+                            "M must be a positive integer.",
+                            native_type_name,
+                            "MySQL",
+                        ))
+                    }
+                    _ => {}
+                }
+            }
             if matches!(
                 native_type_name,
                 SMALL_SERIAL_TYPE_NAME | SERIAL_TYPE_NAME | BIG_SERIAL_TYPE_NAME

--- a/libs/datamodel/core/tests/types/helper.rs
+++ b/libs/datamodel/core/tests/types/helper.rs
@@ -48,3 +48,18 @@ pub fn test_native_types_with_field_attribute_support(
 
     test_native_types_compatibility(&dml, &error_msg, datasource);
 }
+
+pub fn test_native_types_without_attributes(native_type: &str, scalar_type: &str, error_msg: &str, datasource: &str) {
+    let dml = format!(
+        r#"
+    model Blog {{
+      id     Int    @id
+      bigInt {scalar_type} @db.{native_type}
+    }}
+    "#,
+        native_type = native_type,
+        scalar_type = scalar_type,
+    );
+
+    test_native_types_compatibility(&dml, &error_msg, datasource);
+}

--- a/libs/datamodel/core/tests/types/mysql_native_types.rs
+++ b/libs/datamodel/core/tests/types/mysql_native_types.rs
@@ -1,5 +1,8 @@
 use crate::common::*;
-use crate::types::helper::{test_native_types_compatibility, test_native_types_with_field_attribute_support};
+use crate::types::helper::{
+    test_native_types_compatibility, test_native_types_with_field_attribute_support,
+    test_native_types_without_attributes,
+};
 use datamodel::{ast, diagnostics::DatamodelError};
 
 const BLOB_TYPES: &[&'static str] = &["Blob", "LongBlob", "MediumBlob", "TinyBlob"];
@@ -82,6 +85,15 @@ fn test_block_attribute_support(native_type: &str, scalar_type: &str, attribute_
     );
 
     test_native_types_compatibility(&dml, &error_msg, MYSQL_SOURCE);
+}
+
+#[test]
+fn should_fail_on_argument_out_of_range_for_bit_type() {
+    let error_msg = "Argument M is out of range for Native type Bit of MySQL: M can range from 1 to 64";
+
+    for tpe in &["Bit(0)", "Bit(65)"] {
+        test_native_types_without_attributes(tpe, "Bytes", error_msg, MYSQL_SOURCE);
+    }
 }
 
 #[test]

--- a/libs/datamodel/core/tests/types/postgres_native_types.rs
+++ b/libs/datamodel/core/tests/types/postgres_native_types.rs
@@ -1,5 +1,5 @@
 use crate::common::*;
-use crate::types::helper::test_native_types_with_field_attribute_support;
+use crate::types::helper::{test_native_types_with_field_attribute_support, test_native_types_without_attributes};
 use datamodel::{ast, diagnostics::DatamodelError};
 
 #[test]
@@ -13,6 +13,20 @@ fn should_fail_on_serial_data_types_with_number_default() {
 
     for tpe in &["SmallSerial", "Serial", "BigSerial"] {
         test_native_types_with_field_attribute_support(tpe, "Int", "default(4)", &error_msg(tpe), POSTGRES_SOURCE);
+    }
+}
+
+#[test]
+fn should_fail_on_argument_out_of_range_for_bit_data_types() {
+    fn error_msg(type_name: &str) -> String {
+        format!(
+            "Argument M is out of range for Native type {} of MySQL: M must be a positive integer.",
+            type_name
+        )
+    }
+
+    for tpe in &["Bit", "VarBit"] {
+        test_native_types_without_attributes(&format!("{}(0)", tpe), "String", &error_msg(tpe), POSTGRES_SOURCE);
     }
 }
 


### PR DESCRIPTION
- in Postgres: n in Bit(n) and VarBit(n) must not be 0
- in MySQL: n in Bit(n) must be in 1-64

related https://www.notion.so/prismaio/Compatibilities-with-Prisma-attributes-6e0902265bc94b8f88ccb47d780fcccb