### PR TITLE
Enforce the right key order on SQL Server

### DIFF
--- a/libs/datamodel/connectors/datamodel-connector/src/lib.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/lib.rs
@@ -71,6 +71,10 @@ pub trait Connector: Send + Sync {
         self.has_capability(ConnectorCapability::AutoIncrementNonIndexedAllowed)
     }
 
+    fn allows_relation_fields_in_arbitrary_order(&self) -> bool {
+        self.has_capability(ConnectorCapability::RelationFieldsInArbitraryOrder)
+    }
+
     fn wrap_in_argument_count_mismatch_error(
         &self,
         native_type: &str,
@@ -103,6 +107,7 @@ pub enum ConnectorCapability {
     AutoIncrementAllowedOnNonId,
     AutoIncrementMultipleAllowed,
     AutoIncrementNonIndexedAllowed,
+    RelationFieldsInArbitraryOrder,
     // start of Query Engine Capabilities
     InsensitiveFilters,
 }

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
@@ -66,6 +66,7 @@ impl MySqlDatamodelConnector {
             ConnectorCapability::Json,
             ConnectorCapability::MultipleIndexesWithSameName,
             ConnectorCapability::AutoIncrementAllowedOnNonId,
+            ConnectorCapability::RelationFieldsInArbitraryOrder,
         ];
 
         let int = NativeTypeConstructor::without_args(INT_TYPE_NAME, vec![ScalarType::Int]);

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
@@ -52,6 +52,7 @@ impl PostgresDatamodelConnector {
             ConnectorCapability::AutoIncrementAllowedOnNonId,
             ConnectorCapability::AutoIncrementNonIndexedAllowed,
             ConnectorCapability::InsensitiveFilters,
+            ConnectorCapability::RelationFieldsInArbitraryOrder,
         ];
 
         let small_int = NativeTypeConstructor::without_args(SMALL_INT_TYPE_NAME, vec![ScalarType::Int]);

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/sqlite_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/sqlite_datamodel_connector.rs
@@ -12,7 +12,7 @@ pub struct SqliteDatamodelConnector {
 
 impl SqliteDatamodelConnector {
     pub fn new() -> SqliteDatamodelConnector {
-        let capabilities = vec![];
+        let capabilities = vec![ConnectorCapability::RelationFieldsInArbitraryOrder];
         let constructors: Vec<NativeTypeConstructor> = vec![];
 
         SqliteDatamodelConnector {


### PR DESCRIPTION
SQL Server enforces the correct order of the keys a foreign key points. The error it gives is kind of not useful, so we should give a better validation error in the data model validation.

Closes: https://github.com/prisma/prisma-engines/issues/1209