### PR TITLE
Avoid some index name collisions in migrations

### DIFF
--- a/libs/sql-schema-describer/src/walkers.rs
+++ b/libs/sql-schema-describer/src/walkers.rs
@@ -188,6 +188,15 @@ impl<'a> TableWalker<'a> {
         })
     }
 
+    /// Same as `TableWalker::indexes()`, but takes ownership.
+    pub fn into_indexes(self) -> impl Iterator<Item = IndexWalker<'a>> {
+        self.table.indices.iter().map(move |index| IndexWalker {
+            index,
+            schema: self.schema,
+            table: self.table,
+        })
+    }
+
     /// Traverse the foreign keys on the table.
     pub fn foreign_keys(self) -> impl Iterator<Item = ForeignKeyWalker<'a>> {
         self.table.foreign_keys.iter().map(move |foreign_key| ForeignKeyWalker {
@@ -375,6 +384,14 @@ impl<'a> IndexWalker<'a> {
     /// The name of the index.
     pub fn name(&self) -> &str {
         &self.index.name
+    }
+
+    /// Traverse to the table of the index.
+    pub fn table(&self) -> TableWalker<'a> {
+        TableWalker {
+            table: self.table,
+            schema: self.schema,
+        }
     }
 }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker.rs
@@ -174,7 +174,7 @@ impl SqlMigrationConnector {
                         }
 
                         for (previous_column_index, next_column_index, changes, type_change) in
-                            redefine_table.intersection_columns()
+                            redefine_table.column_pairs.iter()
                         {
                             let previous = previous.column_at(*previous_column_index);
                             let next = next.column_at(*next_column_index);

--- a/migration-engine/connectors/sql-migration-connector/src/sql_migration.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_migration.rs
@@ -209,20 +209,8 @@ pub struct RedefineTable {
     #[serde(skip)]
     pub dropped_columns: Vec<usize>,
     #[serde(skip)]
-    pub columns_that_became_required_with_a_default: Vec<(usize, usize, ColumnChanges, Option<ColumnTypeChange>)>,
-    #[serde(skip)]
     pub dropped_primary_key: bool,
     #[serde(skip)]
-    pub other_columns: Vec<(usize, usize, ColumnChanges, Option<ColumnTypeChange>)>,
+    pub column_pairs: Vec<(usize, usize, ColumnChanges, Option<ColumnTypeChange>)>,
     pub table_index: (usize, usize),
-}
-
-impl RedefineTable {
-    pub(crate) fn intersection_columns(
-        &self,
-    ) -> impl Iterator<Item = &(usize, usize, ColumnChanges, Option<ColumnTypeChange>)> {
-        self.columns_that_became_required_with_a_default
-            .iter()
-            .chain(self.other_columns.iter())
-    }
 }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
@@ -69,13 +69,16 @@ impl SqlSchemaDiff {
             .chain(wrap_as_step(self.drop_enums, SqlMigrationStep::DropEnum))
             .chain(wrap_as_step(self.create_tables, SqlMigrationStep::CreateTable))
             .chain(redefine_tables.into_iter())
+            // Order matters: we must drop tables before we create indexes,
+            // because on Postgres and SQLite, we may create indexes whose names
+            // clash with the names of indexes on the dropped tables.
+            .chain(wrap_as_step(self.drop_tables, SqlMigrationStep::DropTable))
             // Order matters: we must create indexes after ALTER TABLEs because the indexes can be
             // on fields that are dropped/created there.
             .chain(wrap_as_step(self.create_indexes, SqlMigrationStep::CreateIndex))
             // Order matters: this needs to come after create_indexes, because the foreign keys can depend on unique
             // indexes created there.
             .chain(wrap_as_step(self.add_foreign_keys, SqlMigrationStep::AddForeignKey))
-            .chain(wrap_as_step(self.drop_tables, SqlMigrationStep::DropTable))
             .chain(wrap_as_step(self.alter_indexes, SqlMigrationStep::AlterIndex))
             .collect()
     }
@@ -119,7 +122,7 @@ impl<'schema> SqlSchemaDiffer<'schema> {
             create_tables: self.create_tables(),
             alter_tables: self.alter_tables(&tables_to_redefine),
             create_indexes: self.create_indexes(&tables_to_redefine),
-            drop_indexes: self.drop_indexes(),
+            drop_indexes: self.drop_indexes(&tables_to_redefine),
             alter_indexes,
             create_enums: self.create_enums(),
             drop_enums: self.drop_enums(),
@@ -303,6 +306,8 @@ impl<'schema> SqlSchemaDiffer<'schema> {
 
         let family = self.database_info.sql_family();
 
+        // TODO: move this into SqlSchemaDescriberFlavour methods, it is
+        // extremely ugly.
         if !family.is_mysql() {
             for table in self.created_tables() {
                 let walker = self.next.table_walker(table.name()).unwrap();
@@ -337,7 +342,7 @@ impl<'schema> SqlSchemaDiffer<'schema> {
         steps
     }
 
-    fn drop_indexes(&self) -> Vec<DropIndex> {
+    fn drop_indexes(&self, tables_to_redefine: &HashSet<String>) -> Vec<DropIndex> {
         let mut drop_indexes = Vec::new();
 
         for tables in self.table_pairs() {
@@ -353,6 +358,17 @@ impl<'schema> SqlSchemaDiffer<'schema> {
                     name: index.name().to_owned(),
                 })
             }
+        }
+
+        // On SQLite, we will recreate indexes in the RedefineTables step,
+        // because they are needed for implementing new foreign key constraints.
+        if !tables_to_redefine.is_empty() && self.flavour.should_drop_indexes_from_dropped_tables() {
+            drop_indexes.extend(self.dropped_tables().flat_map(|table| {
+                table.into_indexes().map(move |index| DropIndex {
+                    table: table.name().to_owned(),
+                    name: index.name().to_owned(),
+                })
+            }))
         }
 
         drop_indexes

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour.rs
@@ -29,6 +29,11 @@ pub(crate) trait SqlSchemaDifferFlavour {
         previous.name() != next.name()
     }
 
+    /// Whether the indexes of dropped tables should be dropped before the table is dropped.
+    fn should_drop_indexes_from_dropped_tables(&self) -> bool {
+        false
+    }
+
     /// Whether `AddForeignKey` steps should be generated for created tables.
     fn should_push_foreign_keys_from_created_tables(&self) -> bool {
         true

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/sqlite.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/sqlite.rs
@@ -17,6 +17,10 @@ impl SqlSchemaDifferFlavour for SqliteFlavour {
         }
     }
 
+    fn should_drop_indexes_from_dropped_tables(&self) -> bool {
+        true
+    }
+
     fn tables_to_redefine(&self, differ: &SqlSchemaDiffer<'_>) -> HashSet<String> {
         differ
             .table_pairs()


### PR DESCRIPTION
Specifically, when creating an index whose name collides with one from a
dropped table where index names are global (postgres and sqlite).

Also includes a small RedefineTable migration step simplification.