### PR TITLE
change default mapping for String of MySQL to longtext

### DIFF
--- a/documentation/psl-sql-conversion.md
+++ b/documentation/psl-sql-conversion.md
@@ -151,7 +151,7 @@ CREATE TABLE "test"."User_ints" (
 model Blog {
     id        String @id @default(cuid())
     title     String
-    slug      String @unique
+    slug      Int @unique
 }
 ```
 

--- a/introspection-engine/introspection-engine-tests/tests/tables/mod.rs
+++ b/introspection-engine/introspection-engine-tests/tests/tables/mod.rs
@@ -89,7 +89,7 @@ async fn a_table_with_unique_index(api: &TestApi) -> crate::TestResult {
     let dm = indoc! {r##"
         model Blog {
             id      Int @id @default(autoincrement())
-            authorId String @unique
+            authorId Int @unique
         }
     "##};
 

--- a/libs/datamodel/connectors/datamodel-connector/src/connector_error.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/connector_error.rs
@@ -24,6 +24,10 @@ impl ConnectorError {
         })
     }
 
+    pub fn new_scalar_type_string_used_with_id_or_index_on_mysql_error() -> ConnectorError {
+        ConnectorError::from_kind(ErrorKind::ScalarTypeStringWithIdOrIndexOnMySQLError {})
+    }
+
     pub fn new_optional_argument_count_mismatch_error(
         native_type: &str,
         optional_count: usize,
@@ -227,4 +231,9 @@ pub enum ErrorKind {
         connector_name: String,
         message: String,
     },
+
+    #[error(
+    "Scalar Type String can not be used in combination with an id or unique field attribute when no native type is used."
+    )]
+    ScalarTypeStringWithIdOrIndexOnMySQLError {},
 }

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
@@ -193,6 +193,11 @@ impl Connector for MySqlDatamodelConnector {
                 ));
             }
         }
+        if let FieldType::Base(scalar_type, _) = field.field_type() {
+            if scalar_type == ScalarType::String && (field.is_id() || field.is_unique()) {
+                return Err(ConnectorError::new_scalar_type_string_used_with_id_or_index_on_mysql_error());
+            }
+        }
         Ok(())
     }
 
@@ -216,6 +221,11 @@ impl Connector for MySqlDatamodelConnector {
                         };
                     }
                 }
+                if let FieldType::Base(scalar_field, _) = f.field_type() {
+                    if scalar_field == ScalarType::String {
+                        return Err(ConnectorError::new_scalar_type_string_used_with_id_or_index_on_mysql_error());
+                    }
+                }
             }
         }
         for id_field in model.id_fields.iter() {
@@ -227,6 +237,11 @@ impl Connector for MySqlDatamodelConnector {
                         native_type_name,
                         "MySQL",
                     ));
+                }
+            }
+            if let FieldType::Base(scalar_type, _) = field.field_type() {
+                if scalar_type == ScalarType::String {
+                    return Err(ConnectorError::new_scalar_type_string_used_with_id_or_index_on_mysql_error());
                 }
             }
         }

--- a/libs/datamodel/core/tests/attributes/builtin_attributes.rs
+++ b/libs/datamodel/core/tests/attributes/builtin_attributes.rs
@@ -6,7 +6,7 @@ fn unique_attribute() {
     let dml = r#"
         model Test {
             id Int @id
-            unique String @unique
+            unique Int @unique
         }
     "#;
 
@@ -29,7 +29,7 @@ fn duplicate_attributes_should_error() {
     let dml = r#"
         model Test {
             id Int @id
-            unique String @unique @unique
+            unique Id @unique @unique
         }
     "#;
 

--- a/libs/datamodel/core/tests/attributes/builtin_attributes.rs
+++ b/libs/datamodel/core/tests/attributes/builtin_attributes.rs
@@ -28,7 +28,7 @@ fn unique_attribute() {
 fn duplicate_attributes_should_error() {
     let dml = r#"
         model Test {
-            id String @id
+            id Int @id
             unique String @unique @unique
         }
     "#;

--- a/libs/datamodel/core/tests/attributes/id_positive.rs
+++ b/libs/datamodel/core/tests/attributes/id_positive.rs
@@ -84,7 +84,7 @@ fn should_allow_string_ids_with_uuid() {
 fn should_allow_string_ids_without_default() {
     let dml = r#"
     model Model {
-        id String @id
+        id Int @id
     }
     "#;
 

--- a/libs/datamodel/core/tests/attributes/relations_basic.rs
+++ b/libs/datamodel/core/tests/attributes/relations_basic.rs
@@ -43,7 +43,7 @@ fn resolve_related_field() {
     let dml = r#"
     model User {
         id        Int    @id
-        firstName String @unique
+        firstName Int @unique
         posts Post[]
     }
 

--- a/libs/datamodel/core/tests/attributes/relations_new.rs
+++ b/libs/datamodel/core/tests/attributes/relations_new.rs
@@ -288,7 +288,7 @@ fn relation_must_error_when_referenced_fields_are_multiple_uniques() {
     let dml = r#"
     model User {
         id Int @id
-        firstName String @unique
+        firstName Int @unique
         posts Post[]
     }
 

--- a/libs/datamodel/core/tests/attributes/unique.rs
+++ b/libs/datamodel/core/tests/attributes/unique.rs
@@ -244,7 +244,7 @@ fn must_error_when_using_the_same_field_multiple_times() {
     let dml = r#"
     model User {
         id    Int    @id
-        email String @unique
+        email Int @unique
 
         @@unique([email, email])
     }

--- a/libs/datamodel/core/tests/attributes/unique_criteria.rs
+++ b/libs/datamodel/core/tests/attributes/unique_criteria.rs
@@ -59,7 +59,7 @@ fn must_succeed_on_model_with_unique_criteria() {
 
     let dml3 = r#"
     model Model {
-        unique String @unique
+        unique Int @unique
     }
     "#;
     let _ = parse(dml3);

--- a/libs/datamodel/core/tests/attributes/unique_criteria.rs
+++ b/libs/datamodel/core/tests/attributes/unique_criteria.rs
@@ -43,7 +43,7 @@ fn must_error_if_only_loose_unique_criterias_are_present() {
 fn must_succeed_on_model_with_unique_criteria() {
     let dml1 = r#"
     model Model {
-        id String @id
+        id Int @id
     }
     "#;
     let _ = parse(dml1);

--- a/libs/datamodel/core/tests/parsing/literals.rs
+++ b/libs/datamodel/core/tests/parsing/literals.rs
@@ -7,7 +7,7 @@ fn strings_with_quotes_are_unescaped() {
     let input = indoc!(
         r#"
         model Category {
-          id   String @id
+          id   Int @id
           name String @default("a \" b\"c d")
         }"#
     );
@@ -33,7 +33,7 @@ fn strings_with_newlines_are_unescpaed() {
     let input = indoc!(
         r#"
         model Category {
-          id   String @id
+          id   Int @id
           name String @default("Jean\nClaude\nVan\nDamme")
         }"#
     );

--- a/libs/datamodel/core/tests/reformat/reformat.rs
+++ b/libs/datamodel/core/tests/reformat/reformat.rs
@@ -44,7 +44,7 @@ fn test_reformat_model_complex() {
     let expected = r#"/// model doc comment
 model User {
   id                    Int    @id // doc comment on the side
-  fieldA                String @unique // comment on the side
+  fieldA                Int @unique // comment on the side
   // comment before
   /// doc comment before
   anotherWeirdFieldName Int
@@ -211,7 +211,7 @@ fn comments_in_a_model_must_not_move() {
         model User {
           id     Int    @id
           // Comment
-          email  String @unique
+          email  Int @unique
           // Comment 2
         }
     "#;
@@ -219,7 +219,7 @@ fn comments_in_a_model_must_not_move() {
     let expected = r#"model User {
   id    Int    @id
   // Comment
-  email String @unique
+  email Int @unique
   // Comment 2
 }
 "#;

--- a/libs/datamodel/core/tests/renderer/literals.rs
+++ b/libs/datamodel/core/tests/renderer/literals.rs
@@ -8,7 +8,7 @@ fn strings_with_quotes_render_as_escaped_literals() {
     let input = indoc!(
         r#"
         model Category {
-          id   String @id
+          id   Int @id
           name String
         }"#
     );
@@ -16,7 +16,7 @@ fn strings_with_quotes_render_as_escaped_literals() {
     let expected = indoc!(
         r#"
         model Category {
-          id   String @id
+          id   Int @id
           name String @default("a \" b\"c d")
         }
         "#
@@ -37,7 +37,7 @@ fn strings_with_quotes_roundtrip() {
     let input = indoc!(
         r#"
         model Category {
-          id   String @id
+          id   Int @id
           name String @default("a \" b\"c d")
         }
         "#
@@ -54,7 +54,7 @@ fn strings_with_newlines_render_as_escaped_literals() {
     let input = indoc!(
         r#"
         model Category {
-          id   String @id
+          id   Int @id
           name String
         }"#
     );
@@ -62,7 +62,7 @@ fn strings_with_newlines_render_as_escaped_literals() {
     let expected = indoc!(
         r#"
         model Category {
-          id   String @id
+          id   Int @id
           name String @default("Jean\nClaude\nVan\nDamme")
         }
         "#
@@ -85,7 +85,7 @@ fn strings_with_newlines_roundtrip() {
     let input = indoc!(
         r#"
         model Category {
-          id   String @id
+          id   Int @id
           name String @default("Jean\nClaude\nVan\nDamme")
         }
         "#
@@ -102,7 +102,7 @@ fn strings_with_backslashes_roundtrip() {
     let input = indoc!(
         r#"
         model Category {
-          id   String @id
+          id   Int @id
           name String @default("xyz\\Datasource\\Model")
         }
         "#

--- a/libs/datamodel/core/tests/types/helper.rs
+++ b/libs/datamodel/core/tests/types/helper.rs
@@ -49,6 +49,59 @@ pub fn test_native_types_with_field_attribute_support(
     test_native_types_compatibility(&dml, &error_msg, datasource);
 }
 
+pub fn test_field_attribute_support(scalar_type: &str, attribute_name: &str, error_msg: &str, datasource: &str) {
+    let id_field = if attribute_name == "id" {
+        ""
+    } else {
+        "id     Int    @id"
+    };
+
+    let dml = format!(
+        r#"
+    {datasource}
+    model Blog {{
+      {id_field}
+      bigInt {scalar_type} @{attribute_name}
+    }}
+    "#,
+        datasource = datasource,
+        id_field = id_field,
+        scalar_type = scalar_type,
+        attribute_name = attribute_name
+    );
+
+    let error = parse_error(&dml);
+
+    error.assert_is_message(error_msg);
+}
+
+pub fn test_block_attribute_support(scalar_type: &str, attribute_name: &str, error_msg: &str, datasource: &str) {
+    let id_field = if attribute_name == "id" {
+        ""
+    } else {
+        "id     Int    @id"
+    };
+    let dml = format!(
+        r#"
+    {datasource}
+    model User {{
+      {id_field}
+      firstname {scalar_type}
+      lastname  {scalar_type}
+      @@{attribute_name}([firstname, lastname])
+    }}
+    "#,
+        datasource = datasource,
+        id_field = id_field,
+        scalar_type = scalar_type,
+        attribute_name = attribute_name
+    );
+
+    let error = parse_error(&dml);
+
+    error.assert_is_message(error_msg);
+}
+
 pub fn test_native_types_without_attributes(native_type: &str, scalar_type: &str, error_msg: &str, datasource: &str) {
     let dml = format!(
         r#"

--- a/libs/datamodel/core/tests/types/negative.rs
+++ b/libs/datamodel/core/tests/types/negative.rs
@@ -1,4 +1,5 @@
 use crate::common::*;
+use crate::types::helper::{test_block_attribute_support, test_field_attribute_support};
 use datamodel::{ast, diagnostics::DatamodelError};
 
 #[test]
@@ -212,6 +213,21 @@ fn should_fail_on_missing_native_types_feature_flag() {
         "Native types can only be used if the corresponding feature flag is enabled. Please add this field in your datasource block: `previewFeatures = [\"nativeTypes\"]`",
         ast::Span::new(178, 196),
     ));
+}
+
+#[test]
+fn should_fail_on_scalar_type_string_with_unique_or_id_constraint() {
+    let error_msg = "Scalar Type String can not be used in combination with an id or unique field attribute when no native type is used.";
+
+    test_field_attribute_support("String", "unique", error_msg, MYSQL_SOURCE);
+    test_block_attribute_support("String", "unique", error_msg, MYSQL_SOURCE);
+    test_field_attribute_support("String", "id", error_msg, MYSQL_SOURCE);
+    test_block_attribute_support("String", "id", error_msg, MYSQL_SOURCE);
+
+    for attr in &["id", "unique"] {
+        test_field_attribute_support("String", attr, error_msg, MYSQL_SOURCE);
+        test_block_attribute_support("String", attr, error_msg, MYSQL_SOURCE);
+    }
 }
 
 #[test]

--- a/libs/datamodel/core/tests/types/negative.rs
+++ b/libs/datamodel/core/tests/types/negative.rs
@@ -88,7 +88,7 @@ fn shound_fail_on_unresolvable_type() {
 fn should_fail_on_custom_related_types() {
     let dml = r#"
     type UserViaEmail = User @relation(references: email)
-    type UniqueString = String @unique
+    type UniqueString = Int @unique
 
     model User {
         id Int @id

--- a/libs/datamodel/core/tests/types/positive.rs
+++ b/libs/datamodel/core/tests/types/positive.rs
@@ -120,7 +120,7 @@ fn should_be_able_to_handle_native_type_combined_with_default_attribute() {
 fn should_be_able_to_handle_multiple_types() {
     let dml = r#"
     type ID = String @id @default(cuid())
-    type UniqueString = String @unique
+    type UniqueString = Int @unique
     type Cash = Int @default(0)
 
     model User {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
@@ -21,8 +21,6 @@ use sql_schema_describer::{
 };
 use std::borrow::Cow;
 
-const VARCHAR_LENGTH_PREFIX: &str = "(191)";
-
 impl SqlRenderer for MysqlFlavour {
     fn quote<'a>(&self, name: &'a str) -> Quoted<&'a str> {
         Quoted::Backticks(name)
@@ -399,7 +397,7 @@ pub(crate) fn render_column_type(column: &ColumnWalker<'_>) -> Cow<'static, str>
         ColumnTypeFamily::Int => "int".into(),
         // we use varchar right now as mediumtext doesn't allow default values
         // a bigger length would not allow to use such a column as primary key
-        ColumnTypeFamily::String => format!("varchar{}", VARCHAR_LENGTH_PREFIX).into(),
+        ColumnTypeFamily::String => "longtext".into(),
         ColumnTypeFamily::Enum(enum_name) => {
             let r#enum = column
                 .schema()

--- a/migration-engine/migration-engine-tests/tests/existing_data/sql_unexecutable_migrations/added_required_field_to_table.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_data/sql_unexecutable_migrations/added_required_field_to_table.rs
@@ -59,7 +59,7 @@ async fn adding_a_required_field_with_a_default_to_an_existing_table_works(api: 
 
     let dm2 = r#"
         model Test {
-            id String @id
+            id Int @id
             name String
             age Int @default(45)
         }
@@ -91,7 +91,7 @@ async fn adding_a_required_field_with_a_default_to_an_existing_table_works(api: 
 async fn adding_a_required_field_without_default_to_an_existing_table_without_data_works(api: &TestApi) -> TestResult {
     let dm1 = r#"
         model Test {
-            id String @id
+            id Int @id
             name String
         }
     "#;
@@ -100,7 +100,7 @@ async fn adding_a_required_field_without_default_to_an_existing_table_without_da
 
     let dm2 = r#"
         model Test {
-            id String @id
+            id Int @id
             name String
             age Int
         }

--- a/migration-engine/migration-engine-tests/tests/existing_data/sql_unexecutable_migrations/added_required_field_to_table.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_data/sql_unexecutable_migrations/added_required_field_to_table.rs
@@ -6,7 +6,7 @@ async fn adding_a_required_field_to_an_existing_table_with_data_without_a_defaul
 ) -> TestResult {
     let dm1 = r#"
         model Test {
-            id String @id
+            id Int @id
             name String
         }
     "#;
@@ -21,7 +21,7 @@ async fn adding_a_required_field_to_an_existing_table_with_data_without_a_defaul
 
     let dm2 = r#"
         model Test {
-            id String @id
+            id Int @id
             name String
             age Int
         }
@@ -44,7 +44,7 @@ async fn adding_a_required_field_to_an_existing_table_with_data_without_a_defaul
 async fn adding_a_required_field_with_a_default_to_an_existing_table_works(api: &TestApi) -> TestResult {
     let dm1 = r#"
         model Test {
-            id String @id
+            id Int @id
             name String
         }
     "#;

--- a/migration-engine/migration-engine-tests/tests/existing_data/sql_unexecutable_migrations/added_unimplementable_unique_constraint.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_data/sql_unexecutable_migrations/added_unimplementable_unique_constraint.rs
@@ -4,7 +4,7 @@ use migration_engine_tests::sql::*;
 async fn adding_a_unique_constraint_should_warn(api: &TestApi) -> TestResult {
     let dm1 = r#"
         model Test {
-            id String @id
+            id Int @id
             name String
         }
     "#;
@@ -27,7 +27,7 @@ async fn adding_a_unique_constraint_should_warn(api: &TestApi) -> TestResult {
 
     let dm2 = r#"
         model Test {
-            id String @id
+            id Int @id
             name String @unique
         }
     "#;
@@ -65,7 +65,7 @@ async fn adding_a_unique_constraint_should_warn(api: &TestApi) -> TestResult {
 async fn dropping_enum_values_should_warn(api: &TestApi) -> TestResult {
     let dm1 = r#"
         model Test {
-            id String @id
+            id Int @id
             name Test_name
         }
         
@@ -95,7 +95,7 @@ async fn dropping_enum_values_should_warn(api: &TestApi) -> TestResult {
 
     let dm2 = r#"
              model Test {
-            id String @id
+            id Int @id
             name Test_name
         }
         
@@ -139,7 +139,7 @@ async fn dropping_enum_values_should_warn(api: &TestApi) -> TestResult {
 async fn adding_a_unique_constraint_when_existing_data_respects_it_works(api: &TestApi) -> TestResult {
     let dm1 = r#"
         model Test {
-            id String @id
+            id Int @id
             name String
         }
     "#;
@@ -160,7 +160,7 @@ async fn adding_a_unique_constraint_when_existing_data_respects_it_works(api: &T
 
     let dm2 = r#"
         model Test {
-            id String @id
+            id Int @id
             name String @unique
         }
     "#;

--- a/migration-engine/migration-engine-tests/tests/existing_data/sql_unexecutable_migrations/added_unimplementable_unique_constraint.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_data/sql_unexecutable_migrations/added_unimplementable_unique_constraint.rs
@@ -28,7 +28,7 @@ async fn adding_a_unique_constraint_should_warn(api: &TestApi) -> TestResult {
     let dm2 = r#"
         model Test {
             id Int @id
-            name String @unique
+            name Int @unique
         }
     "#;
 
@@ -161,7 +161,7 @@ async fn adding_a_unique_constraint_when_existing_data_respects_it_works(api: &T
     let dm2 = r#"
         model Test {
             id Int @id
-            name String @unique
+            name Int @unique
         }
     "#;
 

--- a/migration-engine/migration-engine-tests/tests/existing_data/type_migration_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_data/type_migration_tests.rs
@@ -47,7 +47,7 @@ async fn altering_the_type_of_a_column_in_a_non_empty_table_always_warns(api: &T
 async fn migrating_a_required_column_from_int_to_string_should_cast(api: &TestApi) -> TestResult {
     let dm1 = r#"
         model Test {
-            id String @id
+            id Int @id
             serialNumber Int
         }
     "#;
@@ -67,7 +67,7 @@ async fn migrating_a_required_column_from_int_to_string_should_cast(api: &TestAp
 
     let dm2 = r#"
         model Test {
-            id String @id
+            id Int @id
             serialNumber String
         }
     "#;
@@ -95,7 +95,7 @@ async fn changing_a_string_array_column_to_scalar_is_fine(api: &TestApi) -> Test
         {datasource_block}
 
         model Film {{
-            id String @id
+            id Int @id
             mainProtagonist String[]
         }}
         "#,
@@ -118,7 +118,7 @@ async fn changing_a_string_array_column_to_scalar_is_fine(api: &TestApi) -> Test
             {datasource_block}
 
             model Film {{
-                id String @id
+                id Int @id
                 mainProtagonist String
             }}
             "#,
@@ -154,7 +154,7 @@ async fn changing_an_int_array_column_to_scalar_is_not_possible(api: &TestApi) -
         {datasource_block}
 
         model Film {{
-            id String @id
+            id Int @id
             mainProtagonist Int[]
         }}
         "#,
@@ -174,7 +174,7 @@ async fn changing_an_int_array_column_to_scalar_is_not_possible(api: &TestApi) -
             {datasource_block}
 
             model Film {{
-                id String @id
+                id Int @id
                 mainProtagonist Int
             }}
             "#,
@@ -214,7 +214,7 @@ async fn changing_a_scalar_column_to_an_array_is_unexecutable(api: &TestApi) -> 
         {datasource_block}
 
         model Film {{
-            id String @id
+            id Int @id
             mainProtagonist String
         }}
         "#,
@@ -235,7 +235,7 @@ async fn changing_a_scalar_column_to_an_array_is_unexecutable(api: &TestApi) -> 
             {datasource_block}
 
             model Film {{
-                id String @id
+                id Int @id
                 mainProtagonist String[]
             }}
             "#,

--- a/migration-engine/migration-engine-tests/tests/existing_databases/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_databases/mod.rs
@@ -110,7 +110,7 @@ async fn creating_a_field_for_an_existing_column_and_changing_its_type_must_work
     let dm = r#"
             model Blog {
                 id Int @id
-                title String @unique
+                title Int @unique
             }
         "#;
     let result = api.infer_and_apply_forcefully(&dm).await.sql_schema;

--- a/migration-engine/migration-engine-tests/tests/infer_migration_steps/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/infer_migration_steps/mod.rs
@@ -62,7 +62,7 @@ async fn infer_migration_steps_validates_that_already_applied_migrations_are_not
 ) -> TestResult {
     let dm1 = r#"
         model Test {
-            id String @id
+            id Int @id
             name String
         }
     "#;
@@ -80,7 +80,7 @@ async fn infer_migration_steps_validates_that_already_applied_migrations_are_not
 
     let dm2 = r#"
         model Test {
-            id String @id
+            id Int @id
             name String
             age Int
         }

--- a/migration-engine/migration-engine-tests/tests/migration_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migration_tests.rs
@@ -1024,7 +1024,7 @@ async fn adding_a_new_unique_field_must_work(api: &TestApi) -> TestResult {
     let dm1 = r#"
         model A {
             id Int @id
-            field String @unique
+            field Int @unique
         }
     "#;
 
@@ -1063,7 +1063,7 @@ async fn unique_in_conjunction_with_custom_column_name_must_work(api: &TestApi) 
     let dm1 = r#"
         model A {
             id Int @id
-            field String @unique @map("custom_field_name")
+            field Int @unique @map("custom_field_name")
         }
     "#;
 
@@ -1104,7 +1104,7 @@ async fn removing_an_existing_unique_field_must_work(api: &TestApi) {
     let dm1 = r#"
         model A {
             id    Int    @id
-            field String @unique
+            field Int @unique
         }
     "#;
 
@@ -1150,7 +1150,7 @@ async fn adding_unique_to_an_existing_field_must_work(api: &TestApi) -> TestResu
     let dm2 = r#"
         model A {
             id    Int    @id
-            field String @unique
+            field Int @unique
         }
     "#;
 
@@ -1176,7 +1176,7 @@ async fn removing_unique_from_an_existing_field_must_work(api: &TestApi) {
     let dm1 = r#"
         model A {
             id    Int    @id
-            field String @unique
+            field Int @unique
         }
     "#;
 
@@ -1531,7 +1531,7 @@ async fn relations_can_reference_arbitrary_unique_fields(api: &TestApi) -> TestR
     let dm = r#"
         model User {
             id Int @id
-            email String @unique
+            email Int @unique
         }
 
         model Account {
@@ -1563,7 +1563,7 @@ async fn relations_can_reference_arbitrary_unique_fields_with_maps(api: &TestApi
     let dm = r#"
         model User {
             id Int @id
-            email String @unique @map("emergency-mail")
+            email Int @unique @map("emergency-mail")
             accounts Account[]
 
             @@map("users")
@@ -1724,7 +1724,7 @@ async fn foreign_keys_are_added_on_existing_tables(api: &TestApi) -> TestResult 
     let dm1 = r#"
         model User {
             id Int @id
-            email String @unique
+            email Int @unique
         }
 
         model Account {
@@ -1742,7 +1742,7 @@ async fn foreign_keys_are_added_on_existing_tables(api: &TestApi) -> TestResult 
     let dm2 = r#"
         model User {
             id Int @id
-            email String @unique
+            email Int @unique
         }
 
         model Account {
@@ -1768,7 +1768,7 @@ async fn foreign_keys_can_be_added_on_existing_columns(api: &TestApi) -> TestRes
     let dm1 = r#"
         model User {
             id Int @id
-            email String @unique
+            email Int @unique
         }
 
         model Account {
@@ -1787,7 +1787,7 @@ async fn foreign_keys_can_be_added_on_existing_columns(api: &TestApi) -> TestRes
     let dm2 = r#"
         model User {
             id Int @id
-            email String @unique
+            email Int @unique
         }
 
         model Account {
@@ -1813,7 +1813,7 @@ async fn foreign_keys_can_be_dropped_on_existing_columns(api: &TestApi) -> TestR
     let dm1 = r#"
         model User {
             id Int @id
-            email String @unique
+            email Int @unique
         }
 
         model Account {
@@ -1834,7 +1834,7 @@ async fn foreign_keys_can_be_dropped_on_existing_columns(api: &TestApi) -> TestR
     let dm2 = r#"
         model User {
             id Int @id
-            email String @unique
+            email Int @unique
         }
 
         model Account {
@@ -2082,14 +2082,14 @@ async fn adding_mutual_references_on_existing_tables_works(api: &TestApi) -> Tes
     let dm2 = r#"
         model A {
             id Int
-            name String @unique
+            name Int @unique
             b_email String
             brel B @relation("AtoB", fields: [b_email], references: [email])
         }
 
         model B {
             id Int
-            email String @unique
+            email Int @unique
             a_name String
             arel A @relation("BtoA", fields: [a_name], references: [name])
         }

--- a/migration-engine/migration-engine-tests/tests/migration_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migration_tests.rs
@@ -1904,7 +1904,7 @@ async fn references_to_models_with_compound_primary_keys_must_work(api: &TestApi
         }
 
         model Pet {
-            id              String @id
+            id              Int @id
             human_firstName String
             human_lastName  String
 
@@ -1953,7 +1953,7 @@ async fn join_tables_between_models_with_compound_primary_keys_must_work(api: &T
         }
 
         model Cat {
-            id String @id
+            id Int @id
             humans HumanToCat[]
         }
     "#;
@@ -2006,7 +2006,7 @@ async fn join_tables_between_models_with_mapped_compound_primary_keys_must_work(
         }
 
         model Cat {
-            id String @id
+            id Int @id
             humans HumanToCat[]
         }
     "#;
@@ -2038,7 +2038,7 @@ async fn switching_databases_must_work(api: &TestApi) -> TestResult {
         }
 
         model Test {
-            id String @id
+            id Int @id
             name String
         }
     "#;

--- a/migration-engine/migration-engine-tests/tests/migrations/mariadb.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/mariadb.rs
@@ -5,7 +5,7 @@ use quaint::{ast as quaint_ast, prelude::Queryable};
 async fn foreign_keys_to_indexes_being_renamed_must_work(api: &TestApi) -> TestResult {
     let dm1 = r#"
         model User {
-            id String @id
+            id Int @id
             name String
 
             @@unique([name], name: "idxname")

--- a/migration-engine/migration-engine-tests/tests/migrations/mariadb.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/mariadb.rs
@@ -12,7 +12,7 @@ async fn foreign_keys_to_indexes_being_renamed_must_work(api: &TestApi) -> TestR
         }
 
         model Post {
-            id String @id
+            id Int @id
             author String
             author_rel User @relation(fields: [author], references: name)
         }
@@ -43,14 +43,14 @@ async fn foreign_keys_to_indexes_being_renamed_must_work(api: &TestApi) -> TestR
 
     let dm2 = r#"
         model User {
-            id String @id
+            id Int @id
             name String
 
             @@unique([name], name: "idxrenamed")
         }
 
         model Post {
-            id String @id
+            id Int @id
             author String
             author_rel User @relation(fields: [author], references: name)
         }

--- a/migration-engine/migration-engine-tests/tests/migrations/mysql.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/mysql.rs
@@ -8,13 +8,13 @@ use std::fmt::Write as _;
 async fn indexes_on_foreign_key_fields_are_not_created_twice(api: &TestApi) -> TestResult {
     let schema = r#"
         model Human {
-            id String @id
+            id Int @id
             catname String
             cat_rel Cat @relation(fields: [catname], references: [name])
         }
 
         model Cat {
-            id String @id
+            id Int @id
             name String @unique
             humans Human[]
         }
@@ -52,12 +52,12 @@ async fn indexes_on_foreign_key_fields_are_not_created_twice(api: &TestApi) -> T
 async fn enum_creation_is_idempotent(api: &TestApi) -> TestResult {
     let dm1 = r#"
         model Cat {
-            id String @id
+            id Int @id
             mood Mood
         }
 
         model Human {
-            id String @id
+            id Int @id
             mood Mood
         }
 

--- a/migration-engine/migration-engine-tests/tests/migrations/mysql.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/mysql.rs
@@ -15,7 +15,7 @@ async fn indexes_on_foreign_key_fields_are_not_created_twice(api: &TestApi) -> T
 
         model Cat {
             id Int @id
-            name String @unique
+            name Int @unique
             humans Human[]
         }
     "#;

--- a/migration-engine/migration-engine-tests/tests/migrations/postgres.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/postgres.rs
@@ -7,7 +7,7 @@ use std::fmt::Write;
 async fn enums_can_be_dropped_on_postgres(api: &TestApi) -> TestResult {
     let dm1 = r#"
         model Cat {
-            id String @id
+            id Int @id
             name String
             mood CatMood
         }
@@ -26,7 +26,7 @@ async fn enums_can_be_dropped_on_postgres(api: &TestApi) -> TestResult {
 
     let dm2 = r#"
         model Cat {
-            id String @id
+            id Int @id
             name String
         }
     "#;

--- a/migration-engine/migration-engine-tests/tests/migrations/sql.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/sql.rs
@@ -37,7 +37,7 @@ async fn relations_to_models_without_a_primary_key_work(api: &TestApi) -> TestRe
         }
 
         model PairMetadata {
-            id String @id
+            id Int @id
             pairidx Int
             pairname String
             pair Pair @relation(fields: [pairidx, pairname], references: [index, name])
@@ -70,7 +70,7 @@ async fn relations_to_models_with_no_pk_and_a_single_unique_required_field_work(
         }
 
         model PairMetadata {
-            id String @id
+            id Int @id
             pweight Float
             pair Pair @relation(fields: [pweight], references: [weight])
         }
@@ -94,7 +94,7 @@ async fn relations_to_models_with_no_pk_and_a_single_unique_required_field_work(
 async fn enum_value_with_database_names_must_work(api: &TestApi) -> TestResult {
     let dm = r##"
         model Cat {
-            id String @id
+            id Int @id
             mood CatMood
         }
 
@@ -122,7 +122,7 @@ async fn enum_value_with_database_names_must_work(api: &TestApi) -> TestResult {
 
     let dm = r##"
         model Cat {
-            id String @id
+            id Int @id
             mood CatMood
         }
 
@@ -159,7 +159,7 @@ struct Cat<'a> {
 async fn enum_defaults_must_work(api: &TestApi) -> TestResult {
     let dm = r##"
         model Cat {
-            id String @id
+            id Int @id
             mood CatMood @default(HUNGRY)
             previousMood CatMood @default(ANGRY)
         }
@@ -207,12 +207,12 @@ async fn enum_defaults_must_work(api: &TestApi) -> TestResult {
 async fn id_as_part_of_relation_must_work(api: &TestApi) -> TestResult {
     let dm = r##"
         model Cat {
-            nemesis_id String @id
+            nemesis_id Int @id
             nemesis Dog @relation(fields: [nemesis_id], references: [id])
         }
 
         model Dog {
-            id String @id
+            id Int @id
         }
     "##;
 

--- a/migration-engine/migration-engine-tests/tests/migrations/sqlite.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/sqlite.rs
@@ -7,7 +7,7 @@ async fn sqlite_must_recreate_indexes(api: &TestApi) -> TestResult {
     let dm1 = r#"
         model A {
             id Int @id
-            field String @unique
+            field Int @unique
         }
     "#;
 
@@ -20,7 +20,7 @@ async fn sqlite_must_recreate_indexes(api: &TestApi) -> TestResult {
     let dm2 = r#"
         model A {
             id    Int    @id
-            field String @unique
+            field Int @unique
             other String
         }
     "#;

--- a/migration-engine/migration-engine-tests/tests/schema_push/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/schema_push/mod.rs
@@ -145,7 +145,7 @@ async fn indexes_and_unique_constraints_on_the_same_field_do_not_collide(api: &T
     let dm = r#"
         model User {
             id     Int    @id @default(autoincrement())
-            email  String @unique
+            email  Int @unique
             name   String
 
             @@index([email])

--- a/migration-engine/migration-engine-tests/tests/unapply_migration/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/unapply_migration/mod.rs
@@ -44,7 +44,7 @@ async fn unapply_must_work(api: &TestApi) -> TestResult {
 async fn destructive_change_checks_run_on_unapply_migration(api: &TestApi) -> TestResult {
     let dm1 = r#"
         model Test {
-            id String @id
+            id Int @id
             field String
         }
     "#;

--- a/query-engine/connector-test-kit/src/test/scala/queries/filters/ManyRelationFilterSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/filters/ManyRelationFilterSpec.scala
@@ -277,7 +277,7 @@ class ManyRelationFilterSpec extends FlatSpec with Matchers with ApiSpecBase {
         |
         |model AUser {
         |  id    String @id @default(cuid())
-        |  name  String @unique
+        |  name  Int @unique
         |  posts Post[] @relation(references: [id])
         |}"""
 
@@ -290,7 +290,7 @@ class ManyRelationFilterSpec extends FlatSpec with Matchers with ApiSpecBase {
         |
         |model AUser {
         |  id    String @id @default(cuid())
-        |  name  String @unique
+        |  name  Int @unique
         |  posts Post[] @relation(references: [id])
         |}"""
 

--- a/query-engine/connector-test-kit/src/test/scala/queries/filters/OneRelationFilterSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/filters/OneRelationFilterSpec.scala
@@ -157,7 +157,7 @@ class OneRelationFilterSpec extends FlatSpec with Matchers with ApiSpecBase {
       """
         |model Post {
         |  id      String @id @default(cuid())
-        |  title   String @unique
+        |  title   Int @unique
         |
         |  author  AUser?
         |}

--- a/query-engine/connector-test-kit/src/test/scala/queries/orderAndPagination/NestedPaginationSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/orderAndPagination/NestedPaginationSpec.scala
@@ -26,7 +26,7 @@ class NestedPaginationSpec extends FlatSpec with Matchers with ApiSpecBase {
 
       model Bottom {
         id        String @id @default(cuid())
-        b         String @unique
+        b         Int @unique
         middle_id String
 
         middle Middle @relation(fields: [middle_id], references: [id])
@@ -52,7 +52,7 @@ class NestedPaginationSpec extends FlatSpec with Matchers with ApiSpecBase {
 
       model Bottom {
         id        String @id @default(cuid())
-        b         String @unique
+        b         Int @unique
         middle_id String
 
         middle Middle @relation(fields: [middle_id], references: [id])

--- a/query-engine/connector-test-kit/src/test/scala/queries/orderAndPagination/NonEmbeddedOrderBySpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/orderAndPagination/NonEmbeddedOrderBySpec.scala
@@ -11,7 +11,7 @@ class NonEmbeddedOrderBySpec extends FlatSpec with Matchers with ApiSpecBase {
     val s1 = """
       model  List {
         id    String @id @default(cuid())
-        name  String @unique
+        name  Int @unique
 
         todos Todo[]
       }

--- a/query-engine/connector-test-kit/src/test/scala/queries/orderAndPagination/PaginationSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/orderAndPagination/PaginationSpec.scala
@@ -9,7 +9,7 @@ class PaginationSpec extends FlatSpec with Matchers with ApiSpecBase {
       |model TestModel {
       |  id          Int    @id
       |  field       String
-      |  uniqueField String @unique
+      |  uniqueField Int @unique
       |}
     """.stripMargin
   }

--- a/query-engine/connector-test-kit/src/test/scala/queries/orderAndPagination/RelationFilterOrderingSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/orderAndPagination/RelationFilterOrderingSpec.scala
@@ -16,7 +16,7 @@ class RelationFilterOrderingSpec extends FlatSpec with Matchers with ApiSpecBase
 
                 model Label {
                   id String @id @default(cuid())
-                  text String @unique
+                  text Int @unique
 
                   blogs Blog[]
                 }"""
@@ -31,7 +31,7 @@ class RelationFilterOrderingSpec extends FlatSpec with Matchers with ApiSpecBase
 
                 model Label {
                   id String @id @default(cuid())
-                  text String @unique
+                  text Int @unique
 
                   blogs Blog[]
                 }"""

--- a/query-engine/connector-test-kit/src/test/scala/queries/regressions/PaginationRegressionSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/regressions/PaginationRegressionSpec.scala
@@ -14,7 +14,7 @@ class PaginationRegressionSpec extends FlatSpec with Matchers with ApiSpecBase {
         |}
         |
         |model ModelB {
-        |  id String @id
+        |  id Int @id
         |  createdAt DateTime @default(now())
         |  a_id Int
         |  a ModelA @relation(fields: [a_id], references: [id])

--- a/query-engine/connector-test-kit/src/test/scala/queries/simple/FindOneQuerySpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/simple/FindOneQuerySpec.scala
@@ -41,7 +41,7 @@ class FindOneQuerySpec extends FlatSpec with Matchers with ApiSpecBase {
     val project = SchemaDsl.fromStringV11() {
       """model TestModel {
         |  id   Int    @id
-        |  uniq String @unique
+        |  uniq Int @unique
         |}
       """.stripMargin
     }

--- a/query-engine/connector-test-kit/src/test/scala/queries/simple/M2mQuerySpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/simple/M2mQuerySpec.scala
@@ -9,14 +9,14 @@ class M2mQuerySpec extends FlatSpec with Matchers with ApiSpecBase {
 
   val project: Project = ProjectDsl.fromString { """
                                                    |model Blog {
-                                                   |  slug       String @id
+                                                   |  slug       Int @id
                                                    |  title      String
                                                    |  content    String
                                                    |  categories Category[]
                                                    |}
                                                    |
                                                    |model Category {
-                                                   |  name  String @id
+                                                   |  name  Int @id
                                                    |  blogs Blog[]
                                                    |}
                                                    """.stripMargin }

--- a/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/alreadyConverted/NestedCreateMutationInsideUpdateSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/alreadyConverted/NestedCreateMutationInsideUpdateSpec.scala
@@ -679,13 +679,13 @@ class NestedCreateMutationInsideUpdateSpec extends FlatSpec with Matchers with A
     val project = SchemaDsl.fromStringV11() {
       """model Comment{
         |   id   String @id @default(cuid())
-        |   text String @unique
+        |   text Int @unique
         |   todo Todo?  @relation(references: [id])
         |}
         |
         |model Todo{
         |   id       String @id @default(cuid())
-        |   title    String @unique
+        |   title    Int @unique
         |   comments Comment[]
         |}"""
     }

--- a/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/alreadyConverted/NestedDeleteMutationInsideUpdateSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/alreadyConverted/NestedDeleteMutationInsideUpdateSpec.scala
@@ -755,7 +755,7 @@ class NestedDeleteMutationInsideUpdateSpec extends FlatSpec with Matchers with A
       s"""
         |model Parent{
         | id          String @id @default(cuid())
-        | p           String @unique
+        | p           Int @unique
         | childrenOpt Child[] $relationInlineAttribute
         |}
         |
@@ -768,7 +768,7 @@ class NestedDeleteMutationInsideUpdateSpec extends FlatSpec with Matchers with A
         |
         |model Other{
         | id       String @id @default(cuid())
-        | o        String @unique
+        | o        Int @unique
         | childReq Child
         |}
       """
@@ -843,7 +843,7 @@ class NestedDeleteMutationInsideUpdateSpec extends FlatSpec with Matchers with A
         |
         |model Other{
         | id       String @id @default(cuid())
-        | o        String @unique
+        | o        Int @unique
         | childOpt Child?
         |}
       """
@@ -1221,13 +1221,13 @@ class NestedDeleteMutationInsideUpdateSpec extends FlatSpec with Matchers with A
       """
         |model Todo{
         | id    String @id @default(cuid())
-        | title String @unique
+        | title Int @unique
         | note  Note?  @relation(references: [id])
         |}
         |
         |model Note{
         | id   String @id @default(cuid())
-        | text String @unique
+        | text Int @unique
         | todo Todo?
         |}
       """
@@ -1346,13 +1346,13 @@ class NestedDeleteMutationInsideUpdateSpec extends FlatSpec with Matchers with A
   "a deeply nested mutation" should "execute all levels of the mutation if there are only node edges on the path" ignore {
     val project = SchemaDsl.fromStringV11() { s"""model Top {
                                              |  id      String @id @default(cuid())
-                                             |  nameTop String @unique
+                                             |  nameTop Int @unique
                                              |  middles Middle[] $relationInlineAttribute
                                              |}
                                              |
                                              |model Middle {
                                              |  id         String @id @default(cuid())
-                                             |  nameMiddle String @unique
+                                             |  nameMiddle Int @unique
                                              |  tops       Top[]
                                              |  bottoms    Bottom[] $relationInlineAttribute
                                              |}
@@ -1443,7 +1443,7 @@ class NestedDeleteMutationInsideUpdateSpec extends FlatSpec with Matchers with A
                                              |
                                              |model Bottom {
                                              |  id         String @id @default(cuid())
-                                             |  nameBottom String @unique
+                                             |  nameBottom Int @unique
                                              |}""" }
     database.setup(project)
 
@@ -1514,7 +1514,7 @@ class NestedDeleteMutationInsideUpdateSpec extends FlatSpec with Matchers with A
   "a deeply nested mutation" should "execute all levels of the mutation if there are model and node edges on the path " ignore {
     val project = SchemaDsl.fromStringV11() { s"""model Top {
                                              |  id      String @id @default(cuid())
-                                             |  nameTop String @unique
+                                             |  nameTop Int @unique
                                              |  middles Middle[] $relationInlineAttribute
                                              |}
                                              |
@@ -1613,7 +1613,7 @@ class NestedDeleteMutationInsideUpdateSpec extends FlatSpec with Matchers with A
                                              |
                                              |model Below {
                                              |  id        String @id @default(cuid())
-                                             |  nameBelow String @unique
+                                             |  nameBelow Int @unique
                                              |}""" }
     database.setup(project)
 
@@ -1687,7 +1687,7 @@ class NestedDeleteMutationInsideUpdateSpec extends FlatSpec with Matchers with A
                                              |
                                              |model Middle {
                                              |  id         String @id @default(cuid())
-                                             |  nameMiddle String @unique
+                                             |  nameMiddle Int @unique
                                              |  top        Top?
                                              |  bottom     Bottom? @relation(references: [id])
                                              |}
@@ -1756,7 +1756,7 @@ class NestedDeleteMutationInsideUpdateSpec extends FlatSpec with Matchers with A
   "a deeply nested mutation" should "execute all levels of the mutation if there are only model edges on the path and there are no backrelations" ignore {
     val project = SchemaDsl.fromStringV11() { """model Top {
                                              |  id      String @id @default(cuid())
-                                             |  nameTop String @unique
+                                             |  nameTop Int @unique
                                              |  middle  Middle? @relation(references: [id])
                                              |}
                                              |
@@ -1768,7 +1768,7 @@ class NestedDeleteMutationInsideUpdateSpec extends FlatSpec with Matchers with A
                                              |
                                              |model Bottom {
                                              |  id         String @id @default(cuid())
-                                             |  nameBottom String @unique
+                                             |  nameBottom Int @unique
                                              |}""" }
     database.setup(project)
 
@@ -1828,7 +1828,7 @@ class NestedDeleteMutationInsideUpdateSpec extends FlatSpec with Matchers with A
   "Nested delete on self relations" should "only delete the specified nodes" ignore {
     val project = SchemaDsl.fromStringV11() { s"""model User {
                                              |  id        String @id @default(cuid())
-                                             |  name      String @unique
+                                             |  name      Int @unique
                                              |  follower  User[] @relation(name: "UserFollow" $listInlineArgument)
                                              |  following User[] @relation(name: "UserFollow")
                                              |}""" }

--- a/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/alreadyConverted/NestedDeleteMutationInsideUpsertSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/alreadyConverted/NestedDeleteMutationInsideUpsertSpec.scala
@@ -553,7 +553,7 @@ class NestedDeleteMutationInsideUpsertSpec extends FlatSpec with Matchers with A
 
                         model ReqOther{
                             id       String @id @default(cuid())
-                            r        String @unique
+                            r        Int @unique
                             childReq Child
                         }"""
 
@@ -628,7 +628,7 @@ class NestedDeleteMutationInsideUpsertSpec extends FlatSpec with Matchers with A
 
                         model OptOther{
                             id       String @id @default(cuid())
-                            o        String @unique
+                            o        Int @unique
                             childOpt Child?
                         }"""
 
@@ -758,7 +758,7 @@ class NestedDeleteMutationInsideUpsertSpec extends FlatSpec with Matchers with A
     val schema = s"""model Comment{
                             id     String @id @default(cuid())
                             text   String
-                            alias  String @unique
+                            alias  Int @unique
                             todo   Todo?
                         }
 
@@ -952,7 +952,7 @@ class NestedDeleteMutationInsideUpsertSpec extends FlatSpec with Matchers with A
 
                         model Todo{
                             id    String @id @default(cuid())
-                            title String @unique
+                            title Int @unique
                             note  Note?  @relation(references: [id])
                         }"""
 
@@ -1077,14 +1077,14 @@ class NestedDeleteMutationInsideUpsertSpec extends FlatSpec with Matchers with A
                                              |
                                              |model Middle {
                                              |  id         String @id @default(cuid())
-                                             |  nameMiddle String @unique
+                                             |  nameMiddle Int @unique
                                              |  tops       Top[]
                                              |  bottoms    Bottom[] $relationInlineAttribute
                                              |}
                                              |
                                              |model Bottom {
                                              |  id         String @id @default(cuid())
-                                             |  nameBottom String @unique
+                                             |  nameBottom Int @unique
                                              |  middles    Middle
                                              |}""" }
     database.setup(project)
@@ -1178,7 +1178,7 @@ class NestedDeleteMutationInsideUpsertSpec extends FlatSpec with Matchers with A
                                              |
                                              |model Bottom {
                                              |  id         String @id @default(cuid())
-                                             |  nameBottom String @unique
+                                             |  nameBottom Int @unique
                                              |}""" }
     database.setup(project)
 
@@ -1260,7 +1260,7 @@ class NestedDeleteMutationInsideUpsertSpec extends FlatSpec with Matchers with A
   "a deeply nested mutation" should "execute all levels of the mutation if there are model and node edges on the path " ignore {
     val project = SchemaDsl.fromStringV11() { s"""model Top {
                                              |  id      String @id @default(cuid())
-                                             |  nameTop String @unique
+                                             |  nameTop Int @unique
                                              |  middles Middle[] $relationInlineAttribute
                                              |}
                                              |
@@ -1273,7 +1273,7 @@ class NestedDeleteMutationInsideUpsertSpec extends FlatSpec with Matchers with A
                                              |
                                              |model Bottom {
                                              |  id         String @id @default(cuid())
-                                             |  nameBottom String @unique
+                                             |  nameBottom Int @unique
                                              |  middle     Middle
                                              |}""" }
     database.setup(project)
@@ -1364,7 +1364,7 @@ class NestedDeleteMutationInsideUpsertSpec extends FlatSpec with Matchers with A
                                              |
                                              |model Below {
                                              |  id        String @id @default(cuid())
-                                             |  nameBelow String @unique
+                                             |  nameBelow Int @unique
                                              |}""" }
     database.setup(project)
 

--- a/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/alreadyConverted/NestedDisconnectMutationInsideUpsertSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/alreadyConverted/NestedDisconnectMutationInsideUpsertSpec.scala
@@ -942,13 +942,13 @@ class NestedDisconnectMutationInsideUpsertSpec extends FlatSpec with Matchers wi
                                              |
                                              |model Middle {
                                              |  id         String @id @default(cuid())
-                                             |  nameMiddle String @unique
+                                             |  nameMiddle Int @unique
                                              |  bottoms    Bottom[] $relationInlineAttribute
                                              |}
                                              |
                                              |model Bottom {
                                              |  id         String @id @default(cuid())
-                                             |  nameBottom String @unique
+                                             |  nameBottom Int @unique
                                              |}""" }
     database.setup(project)
 
@@ -1024,7 +1024,7 @@ class NestedDisconnectMutationInsideUpsertSpec extends FlatSpec with Matchers wi
                                              |
                                              |model Middle {
                                              |  id         String @id @default(cuid())
-                                             |  nameMiddle String @unique
+                                             |  nameMiddle Int @unique
                                              |  tops       Top[]
                                              |  bottom     Bottom? @relation(references: [id])
                                              |}
@@ -1116,7 +1116,7 @@ class NestedDisconnectMutationInsideUpsertSpec extends FlatSpec with Matchers wi
                                              |
                                              |model Below {
                                              |  id        String @id @default(cuid())
-                                             |  nameBelow String @unique
+                                             |  nameBelow Int @unique
                                              |}""" }
     database.setup(project)
 
@@ -1276,7 +1276,7 @@ class NestedDisconnectMutationInsideUpsertSpec extends FlatSpec with Matchers wi
                                              |
                                              |model Bottom {
                                              |  id         String @id @default(cuid())
-                                             |  nameBottom String @unique
+                                             |  nameBottom Int @unique
                                              |}""" }
     database.setup(project)
 

--- a/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/alreadyConverted/NestedSetMutationInsideUpdateSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/alreadyConverted/NestedSetMutationInsideUpdateSpec.scala
@@ -549,7 +549,7 @@ class NestedSetMutationInsideUpdateSpec extends FlatSpec with Matchers with ApiS
         |
         |model AUser {
         |  id    String @id @default(cuid())
-        |  name  String @unique
+        |  name  Int @unique
         |  posts Post[]
         |}"""
     }

--- a/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/alreadyConverted/NestedUpsertMutationInsideUpdateSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/alreadyConverted/NestedUpsertMutationInsideUpdateSpec.scala
@@ -742,7 +742,7 @@ class NestedUpsertMutationInsideUpdateSpec extends FlatSpec with Matchers with A
                                              |
                                              |model Middle {
                                              |  id         String @id @default(cuid())
-                                             |  nameMiddle String @unique
+                                             |  nameMiddle Int @unique
                                              |  tops       Top[]
                                              |  bottoms    Bottom[] $relationInlineAttribute
                                              |}
@@ -829,7 +829,7 @@ class NestedUpsertMutationInsideUpdateSpec extends FlatSpec with Matchers with A
                                              |
                                              |model Middle {
                                              |  id         String @id @default(cuid())
-                                             |  nameMiddle String @unique
+                                             |  nameMiddle Int @unique
                                              |  tops       Top[]
                                              |  bottoms    Bottom[] $relationInlineAttribute
                                              |}
@@ -922,7 +922,7 @@ class NestedUpsertMutationInsideUpdateSpec extends FlatSpec with Matchers with A
                                              |
                                              |model Bottom {
                                              |  id         String @id @default(cuid())
-                                             |  nameBottom String @unique
+                                             |  nameBottom Int @unique
                                              |}""" }
     database.setup(project)
 
@@ -1007,7 +1007,7 @@ class NestedUpsertMutationInsideUpdateSpec extends FlatSpec with Matchers with A
                                              |
                                              |model Bottom {
                                              |  id         String @id @default(cuid())
-                                             |  nameBottom String @unique
+                                             |  nameBottom Int @unique
                                              |}""" }
     database.setup(project)
 
@@ -1086,14 +1086,14 @@ class NestedUpsertMutationInsideUpdateSpec extends FlatSpec with Matchers with A
                                              |
                                              |model Middle {
                                              |  id         String @id @default(cuid())
-                                             |  nameMiddle String @unique
+                                             |  nameMiddle Int @unique
                                              |  tops       Top[]
                                              |  bottom     Bottom? @relation(references: [id])
                                              |}
                                              |
                                              |model Bottom {
                                              |  id         String @id @default(cuid())
-                                             |  nameBottom String @unique
+                                             |  nameBottom Int @unique
                                              |  middle     Middle
                                              |}""" }
     database.setup(project)
@@ -1174,7 +1174,7 @@ class NestedUpsertMutationInsideUpdateSpec extends FlatSpec with Matchers with A
                                              |
                                              |model Bottom {
                                              |  id         String @id @default(cuid())
-                                             |  nameBottom String @unique
+                                             |  nameBottom Int @unique
                                              |  middle     Middle?
                                              |}""" }
 
@@ -1242,13 +1242,13 @@ class NestedUpsertMutationInsideUpdateSpec extends FlatSpec with Matchers with A
   "a deeply nested mutation" should "execute all levels of the mutation if there are model and node edges on the path  and back relations are missing and node edges follow model edges for update" ignore {
     val project = SchemaDsl.fromStringV11() { s"""model Top {
                                              |  id      String @id @default(cuid())
-                                             |  nameTop String @unique
+                                             |  nameTop Int @unique
                                              |  middle  Middle? @relation(references: [id])
                                              |}
                                              |
                                              |model Middle {
                                              |  id         String @id @default(cuid())
-                                             |  nameMiddle String @unique
+                                             |  nameMiddle Int @unique
                                              |  bottom     Bottom? @relation(references: [id])
                                              |}
                                              |
@@ -1260,7 +1260,7 @@ class NestedUpsertMutationInsideUpdateSpec extends FlatSpec with Matchers with A
                                              |
                                              |model Below {
                                              |  id        String @id @default(cuid())
-                                             |  nameBelow String @unique
+                                             |  nameBelow Int @unique
                                              |}""" }
     database.setup(project)
 
@@ -1353,7 +1353,7 @@ class NestedUpsertMutationInsideUpdateSpec extends FlatSpec with Matchers with A
                                              |
                                              |model Below {
                                              |  id        String @id @default(cuid())
-                                             |  nameBelow String @unique
+                                             |  nameBelow Int @unique
                                              |}""" }
     database.setup(project)
 
@@ -1517,7 +1517,7 @@ class NestedUpsertMutationInsideUpdateSpec extends FlatSpec with Matchers with A
                                              |
                                              |model Middle {
                                              |  id         String @id @default(cuid())
-                                             |  nameMiddle String @unique
+                                             |  nameMiddle Int @unique
                                              |  top        Top?
                                              |  bottom     Bottom? @relation(references: [id])
                                              |}
@@ -1597,7 +1597,7 @@ class NestedUpsertMutationInsideUpdateSpec extends FlatSpec with Matchers with A
                                              |
                                              |model Bottom {
                                              |  id         String @id @default(cuid())
-                                             |  nameBottom String @unique
+                                             |  nameBottom Int @unique
                                              |}""" }
     database.setup(project)
 

--- a/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/notUsingSchemaBase/NestedConnectOrCreateMutationSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/notUsingSchemaBase/NestedConnectOrCreateMutationSpec.scala
@@ -127,7 +127,7 @@ class NestedConnectOrCreateMutationSpec extends FlatSpec with Matchers with ApiS
         |
         |model ModelB {
         |  id  String @id @default(cuid())
-        |  b_u String @unique
+        |  b_u Int @unique
         |
         |  manyA ModelA[]
         |}
@@ -288,7 +288,7 @@ class NestedConnectOrCreateMutationSpec extends FlatSpec with Matchers with ApiS
         |
         |model ModelB {
         |  id  String @id @default(cuid())
-        |  b_u String @unique
+        |  b_u Int @unique
         |
         |  manyA ModelA[]
         |}
@@ -449,7 +449,7 @@ class NestedConnectOrCreateMutationSpec extends FlatSpec with Matchers with ApiS
         |
         |model ModelB {
         |  id  String @id @default(cuid())
-        |  b_u String @unique
+        |  b_u Int @unique
         |
         |  oneA ModelA
         |}
@@ -643,7 +643,7 @@ class NestedConnectOrCreateMutationSpec extends FlatSpec with Matchers with ApiS
         |
         |model ModelB {
         |  id  String @id @default(cuid())
-        |  b_u String @unique
+        |  b_u Int @unique
         |
         |  oneA ModelA
         |}

--- a/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/notUsingSchemaBase/NestedUpdateMutationInsideUpdateSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/notUsingSchemaBase/NestedUpdateMutationInsideUpdateSpec.scala
@@ -291,7 +291,7 @@ class NestedUpdateMutationInsideUpdateSpec extends FlatSpec with Matchers with A
         |
         |model Comment {
         | id    String @id @default(cuid())
-        | alias String @unique
+        | alias Int @unique
         | text  String?
         | todo  Todo
         |}
@@ -348,13 +348,13 @@ class NestedUpdateMutationInsideUpdateSpec extends FlatSpec with Matchers with A
     val project = SchemaDsl.fromStringV11() {
       s"""model List {
         | id         String @id @default(cuid())
-        | listUnique String @unique
+        | listUnique Int @unique
         | todoes     Todo[] $relationInlineAttribute
         |}
         |
         |model Todo {
         | id         String @id @default(cuid())
-        | todoUnique String @unique
+        | todoUnique Int @unique
         |}
       """
     }


### PR DESCRIPTION
closes https://github.com/prisma/prisma-engines/issues/1288

Open questions:
- [ ]  what should we change `id String @id @default(uuid())` and `id String @id @default(uuid())` to?
- [ ] is `@@unique` and `@@id` also disallowed in combination with a `String` field?