### PR TITLE
Native type argument validations

### DIFF
--- a/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
@@ -165,13 +165,6 @@ impl Connector for MySqlDatamodelConnector {
                             "MySQL",
                         ));
                     }
-                    [precision, _] if *precision > 1000 || *precision <= 0 => {
-                        return Err(ConnectorError::new_argument_m_out_of_range_error(
-                            "Precision must be positive with the maximum value of 1000.",
-                            native_type_name,
-                            "MySQL",
-                        ));
-                    }
                     _ => {}
                 }
             }
@@ -198,18 +191,6 @@ impl Connector for MySqlDatamodelConnector {
                     native_type_name,
                     "MySQL",
                 ));
-            }
-            if matches!(native_type_name, TIMESTAMP_TYPE_NAME | TIME_TYPE_NAME) {
-                match native_type.args.as_slice() {
-                    [precision] if *precision > 6 => {
-                        return Err(ConnectorError::new_argument_m_out_of_range_error(
-                            "M can range from 0 to 6.",
-                            native_type_name,
-                            "MySQL",
-                        ))
-                    }
-                    _ => {}
-                }
             }
         }
         Ok(())

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
@@ -165,6 +165,13 @@ impl Connector for MySqlDatamodelConnector {
                             "MySQL",
                         ));
                     }
+                    [precision, _] if *precision > 1000 || *precision <= 0 => {
+                        return Err(ConnectorError::new_argument_m_out_of_range_error(
+                            "Precision must be positive with the maximum value of 1000.",
+                            native_type_name,
+                            "MySQL",
+                        ));
+                    }
                     _ => {}
                 }
             }

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
@@ -186,7 +186,7 @@ impl Connector for MySqlDatamodelConnector {
                 match native_type.args.as_slice() {
                     [length] if length == &0 || length > &64 => {
                         return Err(ConnectorError::new_argument_m_out_of_range_error(
-                            "M can range from 1 to 64",
+                            "M can range from 1 to 64.",
                             native_type_name,
                             "MySQL",
                         ))
@@ -205,6 +205,30 @@ impl Connector for MySqlDatamodelConnector {
                     native_type_name,
                     "MySQL",
                 ));
+            }
+            if matches!(native_type_name, CHAR_TYPE_NAME) {
+                match native_type.args.as_slice() {
+                    [length] if *length > 255 => {
+                        return Err(ConnectorError::new_argument_m_out_of_range_error(
+                            "M can range from 0 to 255.",
+                            native_type_name,
+                            "MySQL",
+                        ))
+                    }
+                    _ => {}
+                }
+            }
+            if matches!(native_type_name, VAR_CHAR_TYPE_NAME) {
+                match native_type.args.as_slice() {
+                    [length] if *length > 65535 => {
+                        return Err(ConnectorError::new_argument_m_out_of_range_error(
+                            "M can range from 0 to 65,535.",
+                            native_type_name,
+                            "MySQL",
+                        ))
+                    }
+                    _ => {}
+                }
             }
         }
         Ok(())

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
@@ -199,6 +199,18 @@ impl Connector for MySqlDatamodelConnector {
                     "MySQL",
                 ));
             }
+            if matches!(native_type_name, TIMESTAMP_TYPE_NAME) {
+                match native_type.args.as_slice() {
+                    [precision] if *precision > 6 => {
+                        return Err(ConnectorError::new_argument_m_out_of_range_error(
+                            "M can range from 0 to 6.",
+                            native_type_name,
+                            "MySQL",
+                        ))
+                    }
+                    _ => {}
+                }
+            }
         }
         Ok(())
     }

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
@@ -199,7 +199,7 @@ impl Connector for MySqlDatamodelConnector {
                     "MySQL",
                 ));
             }
-            if matches!(native_type_name, TIMESTAMP_TYPE_NAME) {
+            if matches!(native_type_name, TIMESTAMP_TYPE_NAME | TIME_TYPE_NAME) {
                 match native_type.args.as_slice() {
                     [precision] if *precision > 6 => {
                         return Err(ConnectorError::new_argument_m_out_of_range_error(

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
@@ -163,7 +163,21 @@ impl Connector for MySqlDatamodelConnector {
                         return Err(ConnectorError::new_scale_larger_than_precision_error(
                             native_type_name,
                             "MySQL",
-                        ));
+                        ))
+                    }
+                    [precision, _] if *precision > 65 => {
+                        return Err(ConnectorError::new_argument_m_out_of_range_error(
+                            "Precision can range from 1 to 65.",
+                            native_type_name,
+                            "MySQL",
+                        ))
+                    }
+                    [_, scale] if *scale > 30 => {
+                        return Err(ConnectorError::new_argument_m_out_of_range_error(
+                            "Scale can range from 0 to 30.",
+                            native_type_name,
+                            "MySQL",
+                        ))
                     }
                     _ => {}
                 }

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
@@ -138,6 +138,13 @@ impl Connector for PostgresDatamodelConnector {
                             "Postgres",
                         ));
                     }
+                    [precision, _] if *precision > 1000 || *precision <= 0 => {
+                        return Err(ConnectorError::new_argument_m_out_of_range_error(
+                            "Precision must be positive with the maximum value of 1000.",
+                            native_type_name,
+                            "Postgres",
+                        ));
+                    }
                     _ => {}
                 }
             }
@@ -147,7 +154,7 @@ impl Connector for PostgresDatamodelConnector {
                         return Err(ConnectorError::new_argument_m_out_of_range_error(
                             "M must be a positive integer.",
                             native_type_name,
-                            "MySQL",
+                            "Postgres",
                         ))
                     }
                     _ => {}
@@ -164,6 +171,25 @@ impl Connector for PostgresDatamodelConnector {
                             "Postgres",
                         ),
                     );
+                }
+            }
+            if matches!(
+                native_type_name,
+                TIMESTAMP_TYPE_NAME
+                    | TIME_TYPE_NAME
+                    | INTERVAL_TYPE_NAME
+                    | TIME_WITH_TIMEZONE_TYPE_NAME
+                    | TIMESTAMP_WITH_TIMEZONE_TYPE_NAME
+            ) {
+                match native_type.args.as_slice() {
+                    [precision] if *precision > 6 => {
+                        return Err(ConnectorError::new_argument_m_out_of_range_error(
+                            "M can range from 0 to 6.",
+                            native_type_name,
+                            "Postgres",
+                        ))
+                    }
+                    _ => {}
                 }
             }
         }

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
@@ -140,7 +140,7 @@ impl Connector for PostgresDatamodelConnector {
                     }
                     [precision, _] if *precision > 1000 || *precision <= 0 => {
                         return Err(ConnectorError::new_argument_m_out_of_range_error(
-                            "Precision must be positive with the maximum value of 1000.",
+                            "Precision must be positive with a maximum value of 1000.",
                             native_type_name,
                             "Postgres",
                         ));

--- a/libs/datamodel/core/tests/types/mysql_native_types.rs
+++ b/libs/datamodel/core/tests/types/mysql_native_types.rs
@@ -111,7 +111,7 @@ fn should_fail_on_invalid_precision_for_decimal_and_numeric_type() {
 }
 
 #[test]
-fn should_fail_on_invalid_precision_for_timestamp() {
+fn should_fail_on_invalid_precision_for_timestamp_and_time() {
     fn error_msg(type_name: &str) -> String {
         format!(
             "Argument M is out of range for Native type {} of MySQL: M can range from 0 to 6.",
@@ -119,7 +119,7 @@ fn should_fail_on_invalid_precision_for_timestamp() {
         )
     }
 
-    for tpe in &["Timestamp", "Timestamp"] {
+    for tpe in &["Timestamp", "Time"] {
         test_native_types_without_attributes(&format!("{}(7)", tpe), "DateTime", &error_msg(tpe), MYSQL_SOURCE);
         test_native_types_without_attributes(&format!("{}(-1)", tpe), "DateTime", &error_msg(tpe), MYSQL_SOURCE);
     }

--- a/libs/datamodel/core/tests/types/mysql_native_types.rs
+++ b/libs/datamodel/core/tests/types/mysql_native_types.rs
@@ -97,6 +97,31 @@ fn should_fail_on_argument_out_of_range_for_bit_type() {
 }
 
 #[test]
+fn should_fail_on_argument_out_of_range_for_decimal_and_numeric_type() {
+    fn error_msg(type_name: &str, arg: &str, range: &str) -> String {
+        format!(
+            "Argument M is out of range for Native type {} of MySQL: {} can range from {}.",
+            type_name, arg, range
+        )
+    };
+
+    for tpe in &["Numeric", "Decimal"] {
+        test_native_types_without_attributes(
+            &format!("{}(66, 20)", tpe),
+            "Decimal",
+            &error_msg(tpe, "Precision", "1 to 65"),
+            MYSQL_SOURCE,
+        );
+        test_native_types_without_attributes(
+            &format!("{}(44, 33)", tpe),
+            "Decimal",
+            &error_msg(tpe, "Scale", "0 to 30"),
+            MYSQL_SOURCE,
+        );
+    }
+}
+
+#[test]
 fn should_fail_on_native_type_decimal_when_scale_is_bigger_than_precision() {
     let dml = r#"
         datasource db {

--- a/libs/datamodel/core/tests/types/mysql_native_types.rs
+++ b/libs/datamodel/core/tests/types/mysql_native_types.rs
@@ -111,6 +111,21 @@ fn should_fail_on_invalid_precision_for_decimal_and_numeric_type() {
 }
 
 #[test]
+fn should_fail_on_invalid_precision_for_timestamp() {
+    fn error_msg(type_name: &str) -> String {
+        format!(
+            "Argument M is out of range for Native type {} of MySQL: M can range from 0 to 6.",
+            type_name
+        )
+    }
+
+    for tpe in &["Timestamp", "Timestamp"] {
+        test_native_types_without_attributes(&format!("{}(7)", tpe), "DateTime", &error_msg(tpe), MYSQL_SOURCE);
+        test_native_types_without_attributes(&format!("{}(-1)", tpe), "DateTime", &error_msg(tpe), MYSQL_SOURCE);
+    }
+}
+
+#[test]
 fn should_fail_on_native_type_decimal_when_scale_is_bigger_than_precision() {
     let dml = r#"
         datasource db {

--- a/libs/datamodel/core/tests/types/mysql_native_types.rs
+++ b/libs/datamodel/core/tests/types/mysql_native_types.rs
@@ -97,6 +97,20 @@ fn should_fail_on_argument_out_of_range_for_bit_type() {
 }
 
 #[test]
+fn should_fail_on_invalid_precision_for_decimal_and_numeric_type() {
+    fn error_msg(type_name: &str) -> String {
+        format!(
+            "Argument M is out of range for Native type {} of MySQL: Precision must be positive with the maximum value of 1000.",
+            type_name
+        )
+    }
+
+    for tpe in &["Decimal", "Numeric"] {
+        test_native_types_without_attributes(&format!("{}(1001, 3)", tpe), "Decimal", &error_msg(tpe), MYSQL_SOURCE);
+    }
+}
+
+#[test]
 fn should_fail_on_native_type_decimal_when_scale_is_bigger_than_precision() {
     let dml = r#"
         datasource db {

--- a/libs/datamodel/core/tests/types/mysql_native_types.rs
+++ b/libs/datamodel/core/tests/types/mysql_native_types.rs
@@ -89,11 +89,25 @@ fn test_block_attribute_support(native_type: &str, scalar_type: &str, attribute_
 
 #[test]
 fn should_fail_on_argument_out_of_range_for_bit_type() {
-    let error_msg = "Argument M is out of range for Native type Bit of MySQL: M can range from 1 to 64";
+    let error_msg = "Argument M is out of range for Native type Bit of MySQL: M can range from 1 to 64.";
 
     for tpe in &["Bit(0)", "Bit(65)"] {
         test_native_types_without_attributes(tpe, "Bytes", error_msg, MYSQL_SOURCE);
     }
+}
+
+#[test]
+fn should_fail_on_argument_out_of_range_for_char_type() {
+    let error_msg = "Argument M is out of range for Native type Char of MySQL: M can range from 0 to 255.";
+
+    test_native_types_without_attributes("Char(256)", "String", error_msg, MYSQL_SOURCE);
+}
+
+#[test]
+fn should_fail_on_argument_out_of_range_for_varchar_type() {
+    let error_msg = "Argument M is out of range for Native type VarChar of MySQL: M can range from 0 to 65,535.";
+
+    test_native_types_without_attributes("VarChar(655350)", "String", error_msg, MYSQL_SOURCE);
 }
 
 #[test]

--- a/libs/datamodel/core/tests/types/mysql_native_types.rs
+++ b/libs/datamodel/core/tests/types/mysql_native_types.rs
@@ -97,35 +97,6 @@ fn should_fail_on_argument_out_of_range_for_bit_type() {
 }
 
 #[test]
-fn should_fail_on_invalid_precision_for_decimal_and_numeric_type() {
-    fn error_msg(type_name: &str) -> String {
-        format!(
-            "Argument M is out of range for Native type {} of MySQL: Precision must be positive with the maximum value of 1000.",
-            type_name
-        )
-    }
-
-    for tpe in &["Decimal", "Numeric"] {
-        test_native_types_without_attributes(&format!("{}(1001, 3)", tpe), "Decimal", &error_msg(tpe), MYSQL_SOURCE);
-    }
-}
-
-#[test]
-fn should_fail_on_invalid_precision_for_timestamp_and_time() {
-    fn error_msg(type_name: &str) -> String {
-        format!(
-            "Argument M is out of range for Native type {} of MySQL: M can range from 0 to 6.",
-            type_name
-        )
-    }
-
-    for tpe in &["Timestamp", "Time"] {
-        test_native_types_without_attributes(&format!("{}(7)", tpe), "DateTime", &error_msg(tpe), MYSQL_SOURCE);
-        test_native_types_without_attributes(&format!("{}(-1)", tpe), "DateTime", &error_msg(tpe), MYSQL_SOURCE);
-    }
-}
-
-#[test]
 fn should_fail_on_native_type_decimal_when_scale_is_bigger_than_precision() {
     let dml = r#"
         datasource db {

--- a/libs/datamodel/core/tests/types/postgres_native_types.rs
+++ b/libs/datamodel/core/tests/types/postgres_native_types.rs
@@ -21,7 +21,7 @@ fn should_fail_on_serial_data_types_with_number_default() {
 fn should_fail_on_invalid_precision_for_decimal_and_numeric_type() {
     fn error_msg(type_name: &str) -> String {
         format!(
-            "Argument M is out of range for Native type {} of Postgres: Precision must be positive with the maximum value of 1000.",
+            "Argument M is out of range for Native type {} of Postgres: Precision must be positive with a maximum value of 1000.",
             type_name
         )
     }

--- a/libs/datamodel/core/tests/types/postgres_native_types.rs
+++ b/libs/datamodel/core/tests/types/postgres_native_types.rs
@@ -18,10 +18,47 @@ fn should_fail_on_serial_data_types_with_number_default() {
 }
 
 #[test]
+fn should_fail_on_invalid_precision_for_decimal_and_numeric_type() {
+    fn error_msg(type_name: &str) -> String {
+        format!(
+            "Argument M is out of range for Native type {} of Postgres: Precision must be positive with the maximum value of 1000.",
+            type_name
+        )
+    }
+
+    for tpe in &["Decimal", "Numeric"] {
+        test_native_types_without_attributes(
+            &format!("{}(1001, 3)", tpe),
+            "Decimal",
+            &error_msg(tpe),
+            POSTGRES_SOURCE,
+        );
+    }
+}
+
+#[test]
+fn should_fail_on_invalid_precision_for_time_types() {
+    fn error_msg(type_name: &str) -> String {
+        format!(
+            "Argument M is out of range for Native type {} of Postgres: M can range from 0 to 6.",
+            type_name
+        )
+    }
+
+    for tpe in &["Timestamp", "Time", "TimestampWithTimeZone", "TimeWithTimeZone"] {
+        test_native_types_without_attributes(&format!("{}(7)", tpe), "DateTime", &error_msg(tpe), POSTGRES_SOURCE);
+        test_native_types_without_attributes(&format!("{}(-1)", tpe), "DateTime", &error_msg(tpe), POSTGRES_SOURCE);
+    }
+
+    test_native_types_without_attributes("Interval(7)", "Duration", &error_msg("Interval"), POSTGRES_SOURCE);
+    test_native_types_without_attributes("Interval(-1)", "Duration", &error_msg("Interval"), POSTGRES_SOURCE);
+}
+
+#[test]
 fn should_fail_on_argument_out_of_range_for_bit_data_types() {
     fn error_msg(type_name: &str) -> String {
         format!(
-            "Argument M is out of range for Native type {} of MySQL: M must be a positive integer.",
+            "Argument M is out of range for Native type {} of Postgres: M must be a positive integer.",
             type_name
         )
     }


### PR DESCRIPTION
Validates:
Postgres:
- Decimal(p, s), Numeric(p, s): p <= 1000
- Time(p), Timestamp(p), TimestampWithTimezone(p), TimeWithTimezone(p), Interval(p): p <= 6

MySQL:
- Decimal(p, s), Numeric(p, s): p <= 65, s <= 30
- Char(m): m <= 255
- VarChar(m): m <= 65535