### PR TITLE
(chore) Lifetimes simplification in sql-schema-describer::walkers

### DIFF
--- a/libs/sql-schema-describer/src/lib.rs
+++ b/libs/sql-schema-describer/src/lib.rs
@@ -135,7 +135,7 @@ impl Table {
             .unwrap_or_else(|| panic!("Column {} not found in Table {}", name, self.name))
     }
 
-    pub fn column(&self, name: &str) -> Option<&Column> {
+    pub fn column<'a>(&'a self, name: &str) -> Option<&'a Column> {
         self.columns.iter().find(|c| c.name == name)
     }
 

--- a/libs/sql-schema-describer/src/lib.rs
+++ b/libs/sql-schema-describer/src/lib.rs
@@ -108,8 +108,8 @@ impl SqlSchema {
         }
     }
 
-    pub fn table_walkers<'a>(&'a self) -> impl Iterator<Item = TableWalker<'a>> + 'a {
-        self.tables.iter().map(move |table| TableWalker::new(self, table))
+    pub fn table_walkers<'a>(&'a self) -> impl Iterator<Item = TableWalker<'a>> {
+        (0..self.tables.len()).map(move |table_index| TableWalker::new(self, table_index))
     }
 }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
@@ -364,7 +364,7 @@ impl<'schema> SqlSchemaDiffer<'schema> {
         // because they are needed for implementing new foreign key constraints.
         if !tables_to_redefine.is_empty() && self.flavour.should_drop_indexes_from_dropped_tables() {
             drop_indexes.extend(self.dropped_tables().flat_map(|table| {
-                table.into_indexes().map(move |index| DropIndex {
+                table.indexes().map(move |index| DropIndex {
                     table: table.name().to_owned(),
                     name: index.name().to_owned(),
                 })


### PR DESCRIPTION
No more `TableWalker::columns()` and `TableWalker::into_columns()`. Same
for indexes. Also makes `ColumnWalker::column_index()` a lot more
efficient.