### PR TITLE
Cut and clean Quaint feature flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2716,7 +2716,7 @@ dependencies = [
 [[package]]
 name = "quaint"
 version = "0.2.0-alpha.13"
-source = "git+https://github.com/prisma/quaint#4d8fcaefea19480121e349466ba7e92a80da08f9"
+source = "git+https://github.com/prisma/quaint#4382be1ae081978deacce635b56fbf1bde3a1613"
 dependencies = [
  "async-trait",
  "base64 0.11.0",

--- a/introspection-engine/connectors/sql-introspection-connector/Cargo.toml
+++ b/introspection-engine/connectors/sql-introspection-connector/Cargo.toml
@@ -28,8 +28,16 @@ tracing-futures = "0.2.0"
 user-facing-errors = {path = "../../../libs/user-facing-errors", features = ["sql"]}
 
 [dependencies.quaint]
-features = ["single"]
 git = "https://github.com/prisma/quaint"
+features = [
+    "postgresql",
+    "mysql",
+    "mssql",
+    "sqlite",
+    "json",
+    "uuid",
+    "chrono",
+]
 
 [dev-dependencies]
 barrel = {git = "https://github.com/prisma/barrel.git", features = ["sqlite3", "mysql", "pg", "mssql"], branch = "mssql-support"}

--- a/introspection-engine/introspection-engine-tests/Cargo.toml
+++ b/introspection-engine/introspection-engine-tests/Cargo.toml
@@ -29,5 +29,13 @@ features = ["sqlite3", "mysql", "pg", "mssql"]
 branch = "mssql-support"
 
 [dependencies.quaint]
-features = ["single"]
 git = "https://github.com/prisma/quaint"
+features = [
+    "postgresql",
+    "mysql",
+    "mssql",
+    "sqlite",
+    "json",
+    "uuid",
+    "chrono",
+]

--- a/libs/prisma-models/Cargo.toml
+++ b/libs/prisma-models/Cargo.toml
@@ -20,7 +20,7 @@ datamodel = {path = "../datamodel/core"}
 itertools = "0.8"
 once_cell = "1.3"
 prisma-value = {path = "../prisma-value", features = ["sql-ext"]}
-quaint = { git = "https://github.com/prisma/quaint", optional = true, features = ["uuid-0_8"] }
+quaint = { git = "https://github.com/prisma/quaint", optional = true, features = ["uuid"] }
 rand = "0.7"
 rust_decimal = "1.8.1"
 serde = "1.0"

--- a/libs/prisma-value/Cargo.toml
+++ b/libs/prisma-value/Cargo.toml
@@ -20,6 +20,6 @@ serde_json = "1.0"
 uuid = {version = "0.8", features = ["serde", "v4"]}
 
 [dependencies.quaint]
-features = ["uuid-0_8", "array", "single-postgresql", "xml"]
+features = ["uuid", "json", "chrono", "postgresql"]
 git = "https://github.com/prisma/quaint"
 optional = true

--- a/libs/sql-schema-describer/Cargo.toml
+++ b/libs/sql-schema-describer/Cargo.toml
@@ -19,8 +19,18 @@ tracing-futures = "0.2.4"
 tracing-error = "0.1.2"
 
 [dependencies.quaint]
-features = ["single-postgresql", "single-mysql", "single-sqlite", "serde-support", "tracing-log"]
 git = "https://github.com/prisma/quaint"
+features = [
+    "serde-support",
+    "json",
+    "uuid",
+    "chrono",
+    "sqlite",
+    "postgresql",
+    "mysql",
+    "mssql",
+    "tracing-log"
+]
 
 [dev-dependencies]
 anyhow = "1.0.28"

--- a/libs/test-setup/Cargo.toml
+++ b/libs/test-setup/Cargo.toml
@@ -10,11 +10,23 @@ edition = "2018"
 url = "2.1.1"
 tracing-subscriber = { version = "0.2", features = ["fmt"] }
 tokio = { version = "0.2.13", optional = true }
-quaint = { git = "https://github.com/prisma/quaint", features = ["single"], optional = true }
 once_cell = "1.3.1"
 enumflags2 = "0.6.0"
 tracing-error = "0.1.2"
 connection-string = "0.1.10"
+
+[dependencies.quaint]
+git = "https://github.com/prisma/quaint"
+optional = true
+features = [
+    "postgresql",
+    "mysql",
+    "mssql",
+    "sqlite",
+    "json",
+    "uuid",
+    "chrono",
+]
 
 [features]
 default = ["sql"]

--- a/migration-engine/connectors/sql-migration-connector/Cargo.toml
+++ b/migration-engine/connectors/sql-migration-connector/Cargo.toml
@@ -20,7 +20,6 @@ chrono = { version = "0.4" }
 connection-string = "0.1.10"
 enumflags2 = "0.6.0"
 once_cell = "1.3"
-quaint = { git = "https://github.com/prisma/quaint", features = ["single", "tracing-log"] }
 regex = "1"
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"
@@ -29,3 +28,16 @@ tracing = "0.1.10"
 tracing-futures = "0.2.0"
 url = "2.1.1"
 uuid = { version = "0.8", features = ["v4"] }
+
+[dependencies.quaint]
+git = "https://github.com/prisma/quaint"
+features = [
+    "json",
+    "uuid",
+    "chrono",
+    "sqlite",
+    "postgresql",
+    "mysql",
+    "mssql",
+    "tracing-log"
+]

--- a/migration-engine/migration-engine-tests/Cargo.toml
+++ b/migration-engine/migration-engine-tests/Cargo.toml
@@ -27,7 +27,6 @@ barrel = { git = "https://github.com/prisma/barrel.git", features = ["sqlite3", 
 chrono = "0.4.15"
 indoc = "1.0.2"
 pretty_assertions = "0.6"
-quaint = { git = "https://github.com/prisma/quaint", optional = true, features = ["serde-support", "tracing-log"] }
 serde = "1"
 serde_json = "1.0.45"
 tempfile = "3.1.0"
@@ -35,3 +34,8 @@ tokio = { version = "0.2.13", features = ["macros"] }
 tracing = "0.1.12"
 tracing-futures = "0.2.1"
 url = "2.1.1"
+
+[dependencies.quaint]
+git = "https://github.com/prisma/quaint"
+optional = true
+features = ["serde-support", "tracing-log"]

--- a/query-engine/connectors/sql-query-connector/Cargo.toml
+++ b/query-engine/connectors/sql-query-connector/Cargo.toml
@@ -17,8 +17,18 @@ tokio = "0.2.13"
 uuid = "0.8"
 
 [dependencies.quaint]
-features = ["full", "tracing-log"]
 git = "https://github.com/prisma/quaint"
+features = [
+    "pooled",
+    "json",
+    "uuid",
+    "chrono",
+    "sqlite",
+    "postgresql",
+    "mysql",
+    "mssql",
+    "tracing-log"
+]
 
 [dependencies.connector-interface]
 package = "query-connector"

--- a/query-engine/query-engine/Cargo.toml
+++ b/query-engine/query-engine/Cargo.toml
@@ -56,8 +56,21 @@ indoc = "0.3"
 introspection-core = {path = "../../introspection-engine/core"}
 migration-connector = {path = "../../migration-engine/connectors/migration-connector"}
 migration-core = {path = "../../migration-engine/core"}
-quaint = { git = "https://github.com/prisma/quaint", features = ["full", "tracing-log"] }
 serial_test = "*"
 sql-migration-connector = {path = "../../migration-engine/connectors/sql-migration-connector"}
 test-macros = {path = "../../libs/test-macros"}
 test-setup = {path = "../../libs/test-setup"}
+
+[dev-dependencies.quaint]
+git = "https://github.com/prisma/quaint"
+features = [
+    "pooled",
+    "json",
+    "uuid",
+    "chrono",
+    "sqlite",
+    "postgresql",
+    "mysql",
+    "mssql",
+    "tracing-log"
+]


### PR DESCRIPTION
- No more `array` or `xml` flags, they're always enabled
- No more `single` or `full` variants, just add `pooled` for pooling, and choose the databases and features included
- Confusing names like `chrono-0_4` or `json-1` are now just `chrono` and `json`