### PR TITLE
Catch unwinds when rendering persisted database migrations

### DIFF
--- a/libs/datamodel/core/tests/parsing/nice_errors.rs
+++ b/libs/datamodel/core/tests/parsing/nice_errors.rs
@@ -1,6 +1,5 @@
 use crate::common::*;
 use datamodel::ast::Span;
-use datamodel::common::preview_features::DATASOURCE_PREVIEW_FEATURES;
 use datamodel::diagnostics::DatamodelError;
 
 #[test]


### PR DESCRIPTION
Deserializing old database migrations from the migrations table, then
rendering them would cause crashes because they do not match the
introspected SQL schema, breaking invariants we were relying on.

There is no test setup for ListMigrations, but manual testing identified this call as the source of panics.