### PR TITLE
Remove MigrationConnector::deserialize_database_migration()

### DIFF
--- a/migration-engine/connectors/migration-connector/src/lib.rs
+++ b/migration-engine/connectors/migration-connector/src/lib.rs
@@ -82,11 +82,6 @@ pub trait MigrationConnector: Send + Sync + 'static {
     /// See [DestructiveChangeChecker](trait.DestructiveChangeChecker.html).
     fn destructive_change_checker(&self) -> &dyn DestructiveChangeChecker<Self::DatabaseMigration>;
 
-    // TODO: figure out if this is the best way to do this or move to a better place/interface
-    // this is placed here so i can use the associated type
-    /// Deprecated
-    fn deserialize_database_migration(&self, json: serde_json::Value) -> Option<Self::DatabaseMigration>;
-
     /// See [MigrationStepApplier](trait.MigrationStepApplier.html).
     fn migration_applier<'a>(&'a self) -> Box<dyn MigrationApplier<Self::DatabaseMigration> + Send + Sync + 'a> {
         let applier = MigrationApplierImpl {

--- a/migration-engine/connectors/sql-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/lib.rs
@@ -169,10 +169,6 @@ impl MigrationConnector for SqlMigrationConnector {
         self
     }
 
-    fn deserialize_database_migration(&self, json: serde_json::Value) -> Option<SqlMigration> {
-        serde_json::from_value(json).ok()
-    }
-
     fn new_migration_persistence(&self) -> &dyn ImperativeMigrationsPersistence {
         self
     }

--- a/migration-engine/core/src/commands/list_migrations.rs
+++ b/migration-engine/core/src/commands/list_migrations.rs
@@ -18,53 +18,31 @@ impl<'a> MigrationCommand for ListMigrationsCommand {
     {
         let migration_persistence = engine.connector().migration_persistence();
 
-        let result: CoreResult<Self::Output> = migration_persistence
+        let migrations: Self::Output = migration_persistence
             .load_all()
             .await?
             .into_iter()
-            .map(|migration| convert_migration_to_list_migration_steps_output(&engine, migration))
+            .map(convert_migration_to_list_migration_steps_output)
             .collect();
 
-        if let Ok(migrations) = result.as_ref() {
-            tracing::info!(
-                "Returning {migrations_count} migrations ({pending_count} pending).",
-                migrations_count = migrations.len(),
-                pending_count = migrations.iter().filter(|mig| mig.status.is_pending()).count(),
-            );
-        }
+        tracing::info!(
+            "Returning {migrations_count} migrations ({pending_count} pending).",
+            migrations_count = migrations.len(),
+            pending_count = migrations.iter().filter(|mig| mig.status.is_pending()).count(),
+        );
 
-        result
+        Ok(migrations)
     }
 }
 
-pub fn convert_migration_to_list_migration_steps_output<C, D>(
-    engine: &MigrationEngine<C, D>,
-    migration: Migration,
-) -> CoreResult<ListMigrationsOutput>
-where
-    C: MigrationConnector<DatabaseMigration = D>,
-    D: DatabaseMigrationMarker + 'static,
-{
-    let connector = engine.connector();
-    let database_migration = migration.database_migration;
-
-    let database_steps_json = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        match connector.deserialize_database_migration(database_migration) {
-            Some(database_migration) => connector
-                .database_migration_step_applier()
-                .render_steps_pretty(&database_migration)
-                .unwrap_or_else(|_| Vec::new()),
-            None => vec![],
-        }
-    }));
-
-    Ok(ListMigrationsOutput {
+pub fn convert_migration_to_list_migration_steps_output(migration: Migration) -> ListMigrationsOutput {
+    ListMigrationsOutput {
         id: migration.name,
         datamodel_steps: migration.datamodel_steps,
-        database_steps: database_steps_json.unwrap_or_else(|_| Vec::new()),
+        database_steps: vec![],
         status: migration.status,
         datamodel: migration.datamodel_string,
-    })
+    }
 }
 
 #[derive(Debug, Serialize)]


### PR DESCRIPTION
This method is only used in `ListMigrations` anymore, and I confirmed
its output is not used by the CLI. It was however causing crashes with
recent changes to the SqlMigration structure. This is one step in the
refactoring of SqlMigration into an internal data structure private to
sql-migration-connector.