### PR TITLE
Validate that migration squashing is possible

### DIFF
--- a/libs/sql-schema-describer/src/lib.rs
+++ b/libs/sql-schema-describer/src/lib.rs
@@ -10,7 +10,7 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::{fmt, str::FromStr};
 use tracing::debug;
-use walkers::TableWalker;
+use walkers::{EnumWalker, TableWalker};
 
 pub mod getters;
 pub mod mssql;
@@ -110,6 +110,13 @@ impl SqlSchema {
 
     pub fn table_walkers<'a>(&'a self) -> impl Iterator<Item = TableWalker<'a>> {
         (0..self.tables.len()).map(move |table_index| TableWalker::new(self, table_index))
+    }
+
+    pub fn enum_walkers<'a>(&'a self) -> impl Iterator<Item = EnumWalker<'a>> {
+        (0..self.enums.len()).map(move |enum_index| EnumWalker {
+            schema: self,
+            enum_index,
+        })
     }
 }
 

--- a/libs/sql-schema-describer/src/walkers.rs
+++ b/libs/sql-schema-describer/src/walkers.rs
@@ -352,8 +352,38 @@ impl<'a> IndexWalker<'a> {
     }
 }
 
+/// Traverse an enum.
+pub struct EnumWalker<'a> {
+    pub(crate) schema: &'a SqlSchema,
+    pub(crate) enum_index: usize,
+}
+
+impl<'a> EnumWalker<'a> {
+    /// The index of the enum in the parent schema.
+    pub fn enum_index(&self) -> usize {
+        self.enum_index
+    }
+
+    fn get(&self) -> &'a Enum {
+        &self.schema.enums[self.enum_index]
+    }
+
+    /// The name of the enum. This is a made up name on MySQL.
+    pub fn name(&self) -> &'a str {
+        &self.get().name
+    }
+
+    /// The values of the enum
+    pub fn values(&self) -> &'a [String] {
+        &self.get().values
+    }
+}
+
 /// Extension methods for the traversal of a SqlSchema.
 pub trait SqlSchemaExt {
+    /// Find an enum by index.
+    fn enum_walker_at<'a>(&'a self, index: usize) -> EnumWalker<'a>;
+
     /// Find a table by name.
     fn table_walker<'a>(&'a self, name: &str) -> Option<TableWalker<'a>>;
 
@@ -362,6 +392,13 @@ pub trait SqlSchemaExt {
 }
 
 impl SqlSchemaExt for SqlSchema {
+    fn enum_walker_at<'a>(&'a self, index: usize) -> EnumWalker<'a> {
+        EnumWalker {
+            schema: self,
+            enum_index: index,
+        }
+    }
+
     fn table_walker<'a>(&'a self, name: &str) -> Option<TableWalker<'a>> {
         Some(TableWalker {
             table_index: self.tables.iter().position(|table| table.name == name)?,

--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_migration_inferrer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_migration_inferrer.rs
@@ -76,6 +76,7 @@ impl DatabaseMigrationInferrer<SqlMigration> for SqlMigrationConnector {
         ))
     }
 
+    #[tracing::instrument(skip(self, applied_migrations))]
     async fn calculate_drift(&self, applied_migrations: &[MigrationDirectory]) -> ConnectorResult<Option<String>> {
         let expected_schema = self
             .flavour()

--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
@@ -157,14 +157,20 @@ fn render_raw_sql(
     match step {
         SqlMigrationStep::AlterEnum(alter_enum) => renderer.render_alter_enum(alter_enum, schemas),
         SqlMigrationStep::RedefineTables(redefine_tables) => renderer.render_redefine_tables(redefine_tables, schemas),
-        SqlMigrationStep::CreateEnum(create_enum) => renderer.render_create_enum(create_enum),
-        SqlMigrationStep::DropEnum(drop_enum) => renderer.render_drop_enum(drop_enum),
+        SqlMigrationStep::CreateEnum(create_enum) => {
+            renderer.render_create_enum(&schemas.next().enum_walker_at(create_enum.enum_index))
+        }
+        SqlMigrationStep::DropEnum(drop_enum) => {
+            renderer.render_drop_enum(&schemas.previous().enum_walker_at(drop_enum.enum_index))
+        }
         SqlMigrationStep::CreateTable(CreateTable { table_index }) => {
             let table = schemas.next().table_walker_at(*table_index);
 
             vec![renderer.render_create_table(&table)]
         }
-        SqlMigrationStep::DropTable(DropTable { name }) => renderer.render_drop_table(name),
+        SqlMigrationStep::DropTable(DropTable { table_index }) => {
+            renderer.render_drop_table(schemas.previous().table_walker_at(*table_index).name())
+        }
         SqlMigrationStep::AddForeignKey(add_foreign_key) => {
             let foreign_key = schemas
                 .next()

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker.rs
@@ -31,7 +31,10 @@ use crate::{
 };
 use destructive_check_plan::DestructiveCheckPlan;
 use migration_connector::{ConnectorResult, DestructiveChangeChecker, DestructiveChangeDiagnostics};
-use sql_schema_describer::{walkers::ColumnWalker, ColumnArity, SqlSchema};
+use sql_schema_describer::{
+    walkers::{ColumnWalker, SqlSchemaExt},
+    ColumnArity, SqlSchema,
+};
 use unexecutable_step_check::UnexecutableStepCheck;
 use warning_check::SqlMigrationWarningCheck;
 
@@ -193,8 +196,12 @@ impl SqlMigrationConnector {
                         }
                     }
                 }
-                SqlMigrationStep::DropTable(DropTable { name }) => {
-                    self.check_table_drop(name, &mut plan, step_index);
+                SqlMigrationStep::DropTable(DropTable { table_index }) => {
+                    self.check_table_drop(
+                        schemas.previous().table_walker_at(*table_index).name(),
+                        &mut plan,
+                        step_index,
+                    );
                 }
                 SqlMigrationStep::CreateIndex(CreateIndex {
                     table,
@@ -208,12 +215,12 @@ impl SqlMigrationConnector {
                     step_index,
                 ),
                 SqlMigrationStep::AlterEnum(AlterEnum {
-                    name,
+                    index,
                     created_variants: _,
                     dropped_variants,
                 }) if !dropped_variants.is_empty() => plan.push_warning(
                     SqlMigrationWarningCheck::EnumValueRemoval {
-                        enm: name.clone(),
+                        enm: schemas.next().enum_walker_at(*index.next()).name().to_owned(),
                         values: dropped_variants.clone(),
                     },
                     step_index,

--- a/migration-engine/connectors/sql-migration-connector/src/sql_migration.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_migration.rs
@@ -108,9 +108,7 @@ pub(crate) enum TableChange {
         /// The change mask for the column.
         changes: ColumnChanges,
     },
-    DropPrimaryKey {
-        constraint_name: Option<String>,
-    },
+    DropPrimaryKey,
     AddPrimaryKey {
         columns: Vec<String>,
     },

--- a/migration-engine/connectors/sql-migration-connector/src/sql_migration.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_migration.rs
@@ -87,7 +87,7 @@ pub(crate) struct CreateTable {
 
 #[derive(Debug)]
 pub(crate) struct DropTable {
-    pub name: String,
+    pub table_index: usize,
 }
 
 #[derive(Debug)]
@@ -123,7 +123,6 @@ pub(crate) struct AddColumn {
 
 #[derive(Debug)]
 pub(crate) struct DropColumn {
-    pub name: String,
     pub index: usize,
 }
 
@@ -149,7 +148,7 @@ pub(crate) struct AddForeignKey {
 }
 
 #[derive(Debug)]
-pub struct DropForeignKey {
+pub(crate) struct DropForeignKey {
     pub table: String,
     pub table_index: usize,
     pub foreign_key_index: usize,
@@ -157,39 +156,38 @@ pub struct DropForeignKey {
 }
 
 #[derive(Debug)]
-pub struct CreateIndex {
+pub(crate) struct CreateIndex {
     pub table: String,
     pub index: Index,
     pub caused_by_create_table: bool,
 }
 
 #[derive(Debug)]
-pub struct DropIndex {
+pub(crate) struct DropIndex {
     pub table: String,
     pub name: String,
 }
 
 #[derive(Debug)]
-pub struct AlterIndex {
+pub(crate) struct AlterIndex {
     pub table: String,
     pub index_name: String,
     pub index_new_name: String,
 }
 
 #[derive(Debug)]
-pub struct CreateEnum {
-    pub name: String,
-    pub variants: Vec<String>,
+pub(crate) struct CreateEnum {
+    pub enum_index: usize,
 }
 
 #[derive(Debug)]
-pub struct DropEnum {
-    pub name: String,
+pub(crate) struct DropEnum {
+    pub enum_index: usize,
 }
 
 #[derive(Debug)]
 pub(crate) struct AlterEnum {
-    pub name: String,
+    pub index: Pair<usize>,
     pub created_variants: Vec<String>,
     pub dropped_variants: Vec<String>,
 }
@@ -224,7 +222,7 @@ mod tests {
                     foreign_key_index: 0,
                 }),
                 SqlMigrationStep::RedefineTables(vec![]),
-                SqlMigrationStep::DropTable(DropTable { name: "myTable".into() }),
+                SqlMigrationStep::DropTable(DropTable { table_index: 9 }),
             ],
         };
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer.rs
@@ -9,12 +9,11 @@ pub(crate) use common::IteratorJoin;
 use crate::{
     database_info::DatabaseInfo,
     pair::Pair,
-    sql_migration::{
-        AlterEnum, AlterIndex, AlterTable, CreateEnum, CreateIndex, DropEnum, DropForeignKey, DropIndex, RedefineTable,
-    },
+    sql_migration::{AlterEnum, AlterIndex, AlterTable, CreateIndex, DropForeignKey, DropIndex, RedefineTable},
 };
 use common::{Quoted, QuotedWithSchema};
 use sql_schema_describer::{
+    walkers::EnumWalker,
     walkers::ForeignKeyWalker,
     walkers::{ColumnWalker, TableWalker},
     ColumnTypeFamily, DefaultValue, SqlSchema,
@@ -45,7 +44,7 @@ pub(crate) trait SqlRenderer {
     fn render_alter_table(&self, alter_table: &AlterTable, schemas: &Pair<&SqlSchema>) -> Vec<String>;
 
     /// Render a `CreateEnum` step.
-    fn render_create_enum(&self, create_enum: &CreateEnum) -> Vec<String>;
+    fn render_create_enum(&self, create_enum: &EnumWalker<'_>) -> Vec<String>;
 
     /// Render a `CreateIndex` step.
     fn render_create_index(&self, create_index: &CreateIndex) -> String;
@@ -59,7 +58,7 @@ pub(crate) trait SqlRenderer {
     fn render_create_table_as(&self, table: &TableWalker<'_>, table_name: &str) -> String;
 
     /// Render a `DropEnum` step.
-    fn render_drop_enum(&self, drop_enum: &DropEnum) -> Vec<String>;
+    fn render_drop_enum(&self, dropped_enum: &EnumWalker<'_>) -> Vec<String>;
 
     /// Render a `DropForeignKey` step.
     fn render_drop_foreign_key(&self, drop_foreign_key: &DropForeignKey) -> String;

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mssql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mssql_renderer.rs
@@ -4,14 +4,13 @@ use crate::{
     flavour::MssqlFlavour,
     pair::Pair,
     sql_migration::{
-        AddColumn, AlterColumn, AlterEnum, AlterIndex, AlterTable, CreateEnum, CreateIndex, DropColumn, DropEnum,
-        DropForeignKey, DropIndex, RedefineTable, TableChange,
+        AddColumn, AlterColumn, AlterEnum, AlterIndex, AlterTable, CreateIndex, DropColumn, DropForeignKey, DropIndex,
+        RedefineTable, TableChange,
     },
 };
 use prisma_value::PrismaValue;
 use sql_schema_describer::{
-    walkers::ForeignKeyWalker,
-    walkers::{ColumnWalker, TableWalker},
+    walkers::{ColumnWalker, EnumWalker, ForeignKeyWalker, TableWalker},
     ColumnTypeFamily, DefaultValue, IndexType, SqlSchema,
 };
 use std::{borrow::Cow, fmt::Write};
@@ -53,8 +52,8 @@ impl SqlRenderer for MssqlFlavour {
 
                     lines.push(format!("ADD COLUMN {}", col_sql));
                 }
-                TableChange::DropColumn(DropColumn { name, .. }) => {
-                    let name = self.quote(&name);
+                TableChange::DropColumn(DropColumn { index }) => {
+                    let name = self.quote(tables.previous().column_at(*index).name());
                     lines.push(format!("DROP COLUMN {}", name));
                 }
                 TableChange::DropAndRecreateColumn { .. } => todo!("DropAndRecreateColumn on MSSQL"),
@@ -178,7 +177,7 @@ impl SqlRenderer for MssqlFlavour {
         )]
     }
 
-    fn render_create_enum(&self, _: &CreateEnum) -> Vec<String> {
+    fn render_create_enum(&self, _: &EnumWalker<'_>) -> Vec<String> {
         unreachable!("render_create_enum on Microsoft SQL Server")
     }
 
@@ -253,7 +252,7 @@ impl SqlRenderer for MssqlFlavour {
         )
     }
 
-    fn render_drop_enum(&self, _drop_enum: &DropEnum) -> Vec<String> {
+    fn render_drop_enum(&self, _: &EnumWalker<'_>) -> Vec<String> {
         unreachable!("render_drop_enum on MSSQL")
     }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mssql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mssql_renderer.rs
@@ -38,8 +38,12 @@ impl SqlRenderer for MssqlFlavour {
 
         for change in changes {
             match change {
-                TableChange::DropPrimaryKey { constraint_name } => {
-                    let constraint = constraint_name.as_ref().unwrap();
+                TableChange::DropPrimaryKey => {
+                    let constraint = tables
+                        .previous()
+                        .primary_key()
+                        .and_then(|pk| pk.constraint_name.as_ref())
+                        .expect("Missing constraint name in DropPrimaryKey on MSSQL");
                     lines.push(format!("DROP CONSTRAINT {}", self.quote(constraint)));
                 }
                 TableChange::AddPrimaryKey { columns } => {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
@@ -119,7 +119,7 @@ impl SqlRenderer for MysqlFlavour {
 
         for change in changes {
             match change {
-                TableChange::DropPrimaryKey { constraint_name: _ } => lines.push("DROP PRIMARY KEY".to_owned()),
+                TableChange::DropPrimaryKey => lines.push("DROP PRIMARY KEY".to_owned()),
                 TableChange::AddPrimaryKey { columns } => lines.push(format!(
                     "ADD PRIMARY KEY ({})",
                     columns.iter().map(|colname| self.quote(colname)).join(", ")

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
@@ -5,8 +5,8 @@ use crate::{
     pair::Pair,
     sql_migration::{
         expanded_alter_column::{expand_postgres_alter_column, PostgresAlterColumn},
-        AddColumn, AlterColumn, AlterEnum, AlterIndex, AlterTable, CreateEnum, CreateIndex, DropColumn, DropEnum,
-        DropForeignKey, DropIndex, RedefineTable, TableChange,
+        AddColumn, AlterColumn, AlterEnum, AlterIndex, AlterTable, CreateIndex, DropColumn, DropForeignKey, DropIndex,
+        RedefineTable, TableChange,
     },
     sql_schema_differ::ColumnChanges,
 };
@@ -48,7 +48,7 @@ impl SqlRenderer for PostgresFlavour {
                 .map(|created_value| {
                     format!(
                         "ALTER TYPE {enum_name} ADD VALUE {value}",
-                        enum_name = Quoted::postgres_ident(&alter_enum.name),
+                        enum_name = Quoted::postgres_ident(schemas.enums(&alter_enum.index).previous().name()),
                         value = Quoted::postgres_string(created_value)
                     )
                 })
@@ -57,16 +57,12 @@ impl SqlRenderer for PostgresFlavour {
             return stmts;
         }
 
-        let new_enum = schemas
-            .next()
-            .get_enum(&alter_enum.name)
-            .ok_or_else(|| anyhow::anyhow!("Enum `{}` not found in target schema.", alter_enum.name))
-            .unwrap();
+        let enums = schemas.enums(&alter_enum.index);
 
         let mut stmts = Vec::with_capacity(10);
 
-        let tmp_name = format!("{}_new", &new_enum.name);
-        let tmp_old_name = format!("{}_old", &alter_enum.name);
+        let tmp_name = format!("{}_new", &enums.next().name());
+        let tmp_old_name = format!("{}_old", &enums.previous().name());
 
         stmts.push("Begin".to_string());
 
@@ -74,11 +70,8 @@ impl SqlRenderer for PostgresFlavour {
         {
             let create_new_enum = format!(
                 "CREATE TYPE {enum_name} AS ENUM ({variants})",
-                enum_name = QuotedWithSchema {
-                    schema_name: self.schema_name(),
-                    name: Quoted::postgres_ident(&tmp_name),
-                },
-                variants = new_enum.values.iter().map(Quoted::postgres_string).join(", ")
+                enum_name = Quoted::postgres_ident(&tmp_name),
+                variants = enums.next().values().iter().map(Quoted::postgres_string).join(", ")
             );
 
             stmts.push(create_new_enum);
@@ -86,7 +79,7 @@ impl SqlRenderer for PostgresFlavour {
 
         // alter type of the current columns to new, with a cast
         {
-            let affected_columns = walk_columns(schemas.next()).filter(|column| matches!(&column.column_type().family, ColumnTypeFamily::Enum(name) if name.as_str() == alter_enum.name.as_str()));
+            let affected_columns = walk_columns(schemas.next()).filter(|column| matches!(&column.column_type().family, ColumnTypeFamily::Enum(name) if name.as_str() == enums.next().name()));
 
             for column in affected_columns {
                 let sql = format!(
@@ -107,7 +100,7 @@ impl SqlRenderer for PostgresFlavour {
         {
             let sql = format!(
                 "ALTER TYPE {enum_name} RENAME TO {tmp_old_name}",
-                enum_name = Quoted::postgres_ident(&alter_enum.name),
+                enum_name = Quoted::postgres_ident(enums.previous().name()),
                 tmp_old_name = Quoted::postgres_ident(&tmp_old_name)
             );
 
@@ -119,7 +112,7 @@ impl SqlRenderer for PostgresFlavour {
             let sql = format!(
                 "ALTER TYPE {tmp_name} RENAME TO {enum_name}",
                 tmp_name = Quoted::postgres_ident(&tmp_name),
-                enum_name = Quoted::postgres_ident(&new_enum.name)
+                enum_name = Quoted::postgres_ident(enums.next().name())
             );
 
             stmts.push(sql)
@@ -182,8 +175,8 @@ impl SqlRenderer for PostgresFlavour {
 
                     lines.push(format!("ADD COLUMN {}", col_sql));
                 }
-                TableChange::DropColumn(DropColumn { name, .. }) => {
-                    let name = self.quote(&name);
+                TableChange::DropColumn(DropColumn { index }) => {
+                    let name = self.quote(tables.previous().column_at(*index).name());
                     lines.push(format!("DROP COLUMN {}", name));
                 }
                 TableChange::AlterColumn(AlterColumn {
@@ -286,14 +279,14 @@ impl SqlRenderer for PostgresFlavour {
         }
     }
 
-    fn render_create_enum(&self, create_enum: &CreateEnum) -> Vec<String> {
+    fn render_create_enum(&self, enm: &EnumWalker<'_>) -> Vec<String> {
         let sql = format!(
             r#"CREATE TYPE {enum_name} AS ENUM ({variants})"#,
             enum_name = QuotedWithSchema {
                 schema_name: &self.0.schema(),
-                name: Quoted::postgres_ident(&create_enum.name)
+                name: Quoted::postgres_ident(enm.name())
             },
-            variants = create_enum.variants.iter().map(Quoted::postgres_string).join(", "),
+            variants = enm.values().iter().map(Quoted::postgres_string).join(", "),
         );
 
         vec![sql]
@@ -341,10 +334,10 @@ impl SqlRenderer for PostgresFlavour {
         )
     }
 
-    fn render_drop_enum(&self, drop_enum: &DropEnum) -> Vec<String> {
+    fn render_drop_enum(&self, dropped_enum: &EnumWalker<'_>) -> Vec<String> {
         let sql = format!(
             "DROP TYPE {enum_name}",
-            enum_name = Quoted::postgres_ident(&drop_enum.name),
+            enum_name = Quoted::postgres_ident(dropped_enum.name()),
         );
 
         vec![sql]

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
@@ -157,11 +157,13 @@ impl SqlRenderer for PostgresFlavour {
 
         for change in changes {
             match change {
-                TableChange::DropPrimaryKey { constraint_name } => lines.push(format!(
+                TableChange::DropPrimaryKey => lines.push(format!(
                     "DROP CONSTRAINT {}",
                     Quoted::postgres_ident(
-                        constraint_name
-                            .as_ref()
+                        tables
+                            .previous()
+                            .primary_key()
+                            .and_then(|pk| pk.constraint_name.as_ref())
                             .expect("Missing constraint name for DROP CONSTRAINT on Postgres.")
                     )
                 )),

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
@@ -4,8 +4,8 @@ use crate::{
     flavour::SqliteFlavour,
     pair::Pair,
     sql_migration::{
-        AddColumn, AlterEnum, AlterIndex, AlterTable, CreateEnum, CreateIndex, DropEnum, DropForeignKey, DropIndex,
-        RedefineTable, TableChange,
+        AddColumn, AlterEnum, AlterIndex, AlterTable, CreateIndex, DropForeignKey, DropIndex, RedefineTable,
+        TableChange,
     },
 };
 use once_cell::sync::Lazy;
@@ -147,7 +147,7 @@ impl SqlRenderer for SqliteFlavour {
         statements
     }
 
-    fn render_create_enum(&self, _create_enum: &CreateEnum) -> Vec<String> {
+    fn render_create_enum(&self, _: &EnumWalker<'_>) -> Vec<String> {
         Vec::new()
     }
 
@@ -208,7 +208,7 @@ impl SqlRenderer for SqliteFlavour {
         )
     }
 
-    fn render_drop_enum(&self, _drop_enum: &DropEnum) -> Vec<String> {
+    fn render_drop_enum(&self, _: &EnumWalker<'_>) -> Vec<String> {
         Vec::new()
     }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
@@ -18,10 +18,7 @@ use crate::{
 };
 use column::ColumnTypeChange;
 use enums::EnumDiffer;
-use sql_schema_describer::{
-    walkers::{ForeignKeyWalker, TableWalker},
-    Enum,
-};
+use sql_schema_describer::walkers::{EnumWalker, ForeignKeyWalker, TableWalker};
 use std::collections::HashSet;
 use table::TableDiffer;
 
@@ -140,11 +137,9 @@ impl<'schema> SqlSchemaDiffer<'schema> {
         let mut dropped_foreign_keys = Vec::with_capacity(dropped_fks_count);
 
         for dropped_table in self.dropped_tables() {
-            let drop_table = DropTable {
-                name: dropped_table.name().to_owned(),
-            };
-
-            dropped_tables.push(drop_table);
+            dropped_tables.push(DropTable {
+                table_index: dropped_table.table_index(),
+            });
 
             for (fk, fk_name) in dropped_table
                 .foreign_keys()
@@ -168,7 +163,7 @@ impl<'schema> SqlSchemaDiffer<'schema> {
         let mut add_foreign_keys = Vec::new();
         let table_pairs = self
             .table_pairs()
-            .filter(|tables| !tables_to_redefine.contains(tables.next.name()));
+            .filter(|tables| !tables_to_redefine.contains(tables.next().name()));
 
         if self.flavour.should_push_foreign_keys_from_created_tables() {
             push_foreign_keys_from_created_tables(&mut add_foreign_keys, self.created_tables());
@@ -181,21 +176,21 @@ impl<'schema> SqlSchemaDiffer<'schema> {
 
     fn alter_tables(&self, tables_to_redefine: &HashSet<String>) -> Vec<AlterTable> {
         self.table_pairs()
-            .filter(|tables| !tables_to_redefine.contains(tables.next.name()))
-            .filter_map(|tables| {
+            .filter(|tables| !tables_to_redefine.contains(tables.next().name()))
+            .filter_map(|differ| {
                 // Order matters.
-                let changes: Vec<TableChange> = SqlSchemaDiffer::drop_primary_key(&tables)
+                let changes: Vec<TableChange> = SqlSchemaDiffer::drop_primary_key(&differ)
                     .into_iter()
-                    .chain(SqlSchemaDiffer::drop_columns(&tables))
-                    .chain(SqlSchemaDiffer::add_columns(&tables))
-                    .chain(SqlSchemaDiffer::alter_columns(&tables))
-                    .chain(SqlSchemaDiffer::add_primary_key(&tables))
+                    .chain(SqlSchemaDiffer::drop_columns(&differ))
+                    .chain(SqlSchemaDiffer::add_columns(&differ))
+                    .chain(SqlSchemaDiffer::alter_columns(&differ))
+                    .chain(SqlSchemaDiffer::add_primary_key(&differ))
                     .collect();
 
                 Some(changes)
                     .filter(|changes| !changes.is_empty())
                     .map(|changes| AlterTable {
-                        table_index: Pair::new(tables.previous.table_index(), tables.next.table_index()),
+                        table_index: differ.tables.map(|t| t.table_index()),
                         changes,
                     })
             })
@@ -205,7 +200,6 @@ impl<'schema> SqlSchemaDiffer<'schema> {
     fn drop_columns<'a>(differ: &'a TableDiffer<'schema>) -> impl Iterator<Item = TableChange> + 'a {
         differ.dropped_columns().map(|column| {
             let change = DropColumn {
-                name: column.name().to_owned(),
                 index: column.column_index(),
             };
 
@@ -263,15 +257,15 @@ impl<'schema> SqlSchemaDiffer<'schema> {
     ) {
         for differ in self
             .table_pairs()
-            .filter(|tables| !tables_to_redefine.contains(tables.next.name()))
+            .filter(|tables| !tables_to_redefine.contains(tables.next().name()))
         {
             for (dropped_fk, dropped_foreign_key_name) in differ
                 .dropped_foreign_keys()
                 .filter_map(|foreign_key| foreign_key.constraint_name().map(|name| (foreign_key, name)))
             {
                 drop_foreign_keys.push(DropForeignKey {
-                    table_index: differ.previous.table_index(),
-                    table: differ.previous.name().to_owned(),
+                    table_index: differ.previous().table_index(),
+                    table: differ.previous().name().to_owned(),
                     foreign_key_index: dropped_fk.foreign_key_index(),
                     constraint_name: dropped_foreign_key_name.to_owned(),
                 })
@@ -313,11 +307,11 @@ impl<'schema> SqlSchemaDiffer<'schema> {
 
         for tables in self
             .table_pairs()
-            .filter(|tables| !tables_to_redefine.contains(tables.next.name()))
+            .filter(|tables| !tables_to_redefine.contains(tables.next().name()))
         {
             for index in tables.created_indexes() {
                 steps.push(CreateIndex {
-                    table: tables.next.name().to_owned(),
+                    table: tables.next().name().to_owned(),
                     index: index.index().clone(),
                     caused_by_create_table: false,
                 })
@@ -334,12 +328,12 @@ impl<'schema> SqlSchemaDiffer<'schema> {
             for index in tables.dropped_indexes() {
                 // On MySQL, foreign keys automatically create indexes. These foreign-key-created
                 // indexes should only be dropped as part of the foreign key.
-                if self.database_info.sql_family().is_mysql() && index::index_covers_fk(&tables.previous, &index) {
+                if self.database_info.sql_family().is_mysql() && index::index_covers_fk(&tables.previous(), &index) {
                     continue;
                 }
 
                 drop_indexes.push(DropIndex {
-                    table: tables.previous.name().to_owned(),
+                    table: tables.previous().name().to_owned(),
                     name: index.name().to_owned(),
                 })
             }
@@ -362,8 +356,7 @@ impl<'schema> SqlSchemaDiffer<'schema> {
     fn create_enums(&self) -> Vec<CreateEnum> {
         self.created_enums()
             .map(|r#enum| CreateEnum {
-                name: r#enum.name.clone(),
-                variants: r#enum.values.clone(),
+                enum_index: r#enum.enum_index(),
             })
             .collect()
     }
@@ -371,7 +364,7 @@ impl<'schema> SqlSchemaDiffer<'schema> {
     fn drop_enums(&self) -> Vec<DropEnum> {
         self.dropped_enums()
             .map(|r#enum| DropEnum {
-                name: r#enum.name.clone(),
+                enum_index: r#enum.enum_index(),
             })
             .collect()
     }
@@ -382,9 +375,9 @@ impl<'schema> SqlSchemaDiffer<'schema> {
 
     fn redefine_tables(&self, tables_to_redefine: &HashSet<String>) -> Vec<RedefineTable> {
         self.table_pairs()
-            .filter(|tables| tables_to_redefine.contains(tables.next.name()))
-            .map(|tables| {
-                let column_pairs = tables
+            .filter(|tables| tables_to_redefine.contains(tables.next().name()))
+            .map(|differ| {
+                let column_pairs = differ
                     .column_pairs()
                     .map(|columns| {
                         let (changes, type_change) = columns.all_changes();
@@ -403,10 +396,10 @@ impl<'schema> SqlSchemaDiffer<'schema> {
                     .collect();
 
                 RedefineTable {
-                    table_index: Pair::new(tables.previous.table_index(), tables.next.table_index()),
-                    dropped_primary_key: SqlSchemaDiffer::drop_primary_key(&tables).is_some(),
-                    added_columns: tables.added_columns().map(|col| col.column_index()).collect(),
-                    dropped_columns: tables.dropped_columns().map(|col| col.column_index()).collect(),
+                    table_index: differ.tables.as_ref().map(|t| t.table_index()),
+                    dropped_primary_key: SqlSchemaDiffer::drop_primary_key(&differ).is_some(),
+                    added_columns: differ.added_columns().map(|col| col.column_index()).collect(),
+                    dropped_columns: differ.dropped_columns().map(|col| col.column_index()).collect(),
                     column_pairs,
                 }
             })
@@ -429,8 +422,7 @@ impl<'schema> SqlSchemaDiffer<'schema> {
                     .map(move |next_table| TableDiffer {
                         flavour: self.flavour,
                         database_info: self.database_info,
-                        previous: previous_table,
-                        next: next_table,
+                        tables: Pair::new(previous_table, next_table),
                     })
             })
     }
@@ -439,7 +431,7 @@ impl<'schema> SqlSchemaDiffer<'schema> {
         let mut alter_indexes = Vec::new();
 
         self.table_pairs()
-            .filter(|tables| !tables_to_redefine.contains(tables.next.name()))
+            .filter(|tables| !tables_to_redefine.contains(tables.next().name()))
             .for_each(|differ| {
                 differ
                     .index_pairs()
@@ -450,7 +442,7 @@ impl<'schema> SqlSchemaDiffer<'schema> {
                         alter_indexes.push(AlterIndex {
                             index_name: previous_index.name().to_owned(),
                             index_new_name: renamed_index.name().to_owned(),
-                            table: differ.next.name().to_owned(),
+                            table: differ.next().name().to_owned(),
                         })
                     })
             });
@@ -494,27 +486,29 @@ impl<'schema> SqlSchemaDiffer<'schema> {
     fn enum_pairs(&self) -> impl Iterator<Item = EnumDiffer<'_>> {
         self.previous_enums().filter_map(move |previous| {
             self.next_enums()
-                .find(|next| enums_match(previous, next))
-                .map(|next| EnumDiffer { previous, next })
+                .find(|next| enums_match(&previous, &next))
+                .map(|next| EnumDiffer {
+                    enums: Pair::new(previous, next),
+                })
         })
     }
 
-    fn created_enums(&self) -> impl Iterator<Item = &Enum> {
+    fn created_enums<'a>(&'a self) -> impl Iterator<Item = EnumWalker<'schema>> + 'a {
         self.next_enums()
-            .filter(move |next| !self.previous_enums().any(|previous| enums_match(previous, next)))
+            .filter(move |next| !self.previous_enums().any(|previous| enums_match(&previous, next)))
     }
 
-    fn dropped_enums(&self) -> impl Iterator<Item = &Enum> {
+    fn dropped_enums<'a>(&'a self) -> impl Iterator<Item = EnumWalker<'schema>> + 'a {
         self.previous_enums()
-            .filter(move |previous| !self.next_enums().any(|next| enums_match(previous, next)))
+            .filter(move |previous| !self.next_enums().any(|next| enums_match(previous, &next)))
     }
 
-    fn previous_enums(&self) -> impl Iterator<Item = &Enum> {
-        self.schemas.previous().enums.iter()
+    fn previous_enums(&self) -> impl Iterator<Item = EnumWalker<'schema>> {
+        self.schemas.previous().enum_walkers()
     }
 
-    fn next_enums(&self) -> impl Iterator<Item = &Enum> {
-        self.schemas.next().enums.iter()
+    fn next_enums(&self) -> impl Iterator<Item = EnumWalker<'schema>> {
+        self.schemas.next().enum_walkers()
     }
 }
 
@@ -524,7 +518,7 @@ fn push_created_foreign_keys<'a, 'schema>(
 ) {
     table_pairs.for_each(|differ| {
         added_foreign_keys.extend(differ.created_foreign_keys().map(|created_fk| AddForeignKey {
-            table_index: differ.next.table_index(),
+            table_index: differ.next().table_index(),
             foreign_key_index: created_fk.foreign_key_index(),
         }))
     })
@@ -576,6 +570,6 @@ fn tables_match(previous: &TableWalker<'_>, next: &TableWalker<'_>) -> bool {
     previous.name() == next.name()
 }
 
-fn enums_match(previous: &Enum, next: &Enum) -> bool {
-    previous.name == next.name
+fn enums_match(previous: &EnumWalker<'_>, next: &EnumWalker<'_>) -> bool {
+    previous.name() == next.name()
 }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
@@ -283,9 +283,7 @@ impl<'schema> SqlSchemaDiffer<'schema> {
     }
 
     fn drop_primary_key(differ: &TableDiffer<'_>) -> Option<TableChange> {
-        differ.dropped_primary_key().map(|pk| TableChange::DropPrimaryKey {
-            constraint_name: pk.constraint_name.clone(),
-        })
+        differ.dropped_primary_key().map(|_pk| TableChange::DropPrimaryKey)
     }
 
     fn create_indexes(&self, tables_to_redefine: &HashSet<String>) -> Vec<CreateIndex> {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/enums.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/enums.rs
@@ -1,19 +1,22 @@
-use sql_schema_describer::Enum;
+use sql_schema_describer::walkers::EnumWalker;
+
+use crate::pair::Pair;
 
 pub(crate) struct EnumDiffer<'a> {
-    pub(crate) previous: &'a Enum,
-    pub(crate) next: &'a Enum,
+    pub(crate) enums: Pair<EnumWalker<'a>>,
 }
 
 impl<'a> EnumDiffer<'a> {
     pub(crate) fn created_values<'b>(&'b self) -> impl Iterator<Item = &'a str> + 'b {
-        self.next
-            .values
+        self.enums
+            .next()
+            .values()
             .iter()
             .filter(move |next_value| {
                 !self
-                    .previous
-                    .values
+                    .enums
+                    .previous()
+                    .values()
                     .iter()
                     .any(|previous_value| values_match(previous_value, next_value))
             })
@@ -21,13 +24,15 @@ impl<'a> EnumDiffer<'a> {
     }
 
     pub(crate) fn dropped_values<'b>(&'b self) -> impl Iterator<Item = &'a str> + 'b {
-        self.previous
-            .values
+        self.enums
+            .previous()
+            .values()
             .iter()
             .filter(move |previous_value| {
                 !self
-                    .next
-                    .values
+                    .enums
+                    .next()
+                    .values()
                     .iter()
                     .any(|next_value| values_match(previous_value, next_value))
             })

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/postgres.rs
@@ -20,9 +20,9 @@ impl SqlSchemaDifferFlavour for PostgresFlavour {
             .enum_pairs()
             .filter_map(|differ| {
                 let step = AlterEnum {
+                    index: differ.enums.as_ref().map(|e| e.enum_index()),
                     created_variants: differ.created_values().map(String::from).collect(),
                     dropped_variants: differ.dropped_values().map(String::from).collect(),
-                    name: differ.previous.name.clone(),
                 };
 
                 if step.is_empty() {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/sqlite.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/sqlite.rs
@@ -35,7 +35,7 @@ impl SqlSchemaDifferFlavour for SqliteFlavour {
                     || differ.created_foreign_keys().next().is_some()
                     || differ.dropped_foreign_keys().next().is_some()
             })
-            .map(|table| table.next.name().to_owned())
+            .map(|table| table.next().name().to_owned())
             .collect()
     }
 

--- a/migration-engine/migration-engine-tests/tests/migrations/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/mod.rs
@@ -9,4 +9,5 @@ mod mysql;
 mod postgres;
 mod sql;
 mod sqlite;
+mod squashing_tests;
 mod types;

--- a/migration-engine/migration-engine-tests/tests/migrations/squashing_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/squashing_tests.rs
@@ -1,0 +1,480 @@
+use migration_core::commands::{DiagnoseMigrationHistoryOutput, HistoryDiagnostic};
+
+use crate::*;
+use std::io::Write;
+
+#[test_each_connector]
+async fn squashing_whole_migration_history_works(api: &TestApi) -> TestResult {
+    let directory = api.create_migrations_directory()?;
+
+    // Create and apply a bunch of migrations
+    let _initial_migration_names = {
+        let dm1 = r#"
+            model Cat {
+                id Int @id
+            }
+        "#;
+
+        let dm2 = r#"
+            model Cat {
+                id Int @id
+            }
+
+            model Dog {
+                id Int @id
+            }
+        "#;
+
+        let dm3 = r#"
+            model Cat {
+                id Int @id
+            }
+
+            model Hyena {
+                id Int @id
+                laughterFrequency Float
+            }
+        "#;
+
+        let mut migrations_counter: i32 = 0;
+        let mut initial_migration_names: Vec<String> = Vec::with_capacity(3);
+
+        for schema in &[dm1, dm2, dm3] {
+            let name = api
+                .create_migration(&format!("migration{}", migrations_counter), schema, &directory)
+                .send()
+                .await?
+                .into_output()
+                .generated_migration_name
+                .unwrap();
+
+            migrations_counter += 1;
+            initial_migration_names.push(name);
+        }
+
+        api.apply_migrations(&directory).send().await?;
+
+        initial_migration_names
+    };
+
+    let initial_schema = api.assert_schema().await?.assert_tables_count(3)?.into_schema();
+
+    // Squash the files, mark migration applied, assert the schema is the same.
+
+    let mut squashed_migrations: Vec<(String, String)> = Vec::with_capacity(3);
+
+    for entry in std::fs::read_dir(directory.path())? {
+        let entry = entry?;
+
+        assert!(entry.metadata()?.is_dir());
+
+        let file_path = entry.path().join("migration.sql");
+        let contents = std::fs::read_to_string(file_path)?;
+
+        squashed_migrations.push((entry.file_name().into_string().unwrap(), contents));
+
+        std::fs::remove_dir_all(entry.path())?;
+    }
+
+    squashed_migrations.sort_by(|left, right| left.0.cmp(&right.0));
+
+    let squashed_migration_directory_path = directory.path().join("0000_initial");
+    std::fs::create_dir_all(&squashed_migration_directory_path)?;
+
+    let mut migration_file = std::fs::File::create(squashed_migration_directory_path.join("migration.sql"))?;
+
+    for (_, squashed_migration) in squashed_migrations {
+        migration_file.write_all(squashed_migration.as_bytes())?;
+    }
+
+    api.assert_schema().await?.assert_tables_count(3)?;
+
+    let DiagnoseMigrationHistoryOutput {
+        drift,
+        history,
+        failed_migration_names,
+        edited_migration_names,
+        has_migrations_table,
+    } = api.diagnose_migration_history(&directory).send().await?.into_output();
+
+    assert!(drift.is_some());
+    assert!(
+        matches!(
+            &history,
+            Some(HistoryDiagnostic::HistoriesDiverge {
+                unapplied_migration_names,
+                unpersisted_migration_names: _,
+                last_common_migration_name: None,
+            }) if unapplied_migration_names == &["0000_initial"]
+        ),
+        "got: {:#?}",
+        history
+    );
+    assert!(failed_migration_names.is_empty());
+    assert!(edited_migration_names.is_empty());
+    assert!(has_migrations_table);
+
+    api.mark_migration_applied("0000_initial", &directory).send().await?;
+
+    let DiagnoseMigrationHistoryOutput {
+        drift,
+        history,
+        failed_migration_names,
+        edited_migration_names,
+        has_migrations_table,
+    } = api.diagnose_migration_history(&directory).send().await?.into_output();
+
+    assert!(drift.is_none());
+    assert!(
+        matches!(&history, Some(HistoryDiagnostic::MigrationsDirectoryIsBehind { unpersisted_migration_names }) if unpersisted_migration_names.len() == 3),
+        "got: {:#?}",
+        history
+    );
+    assert!(failed_migration_names.is_empty());
+    assert!(edited_migration_names.is_empty());
+    assert!(has_migrations_table);
+
+    api.apply_migrations(&directory)
+        .send()
+        .await?
+        .assert_applied_migrations(&[])?;
+
+    let DiagnoseMigrationHistoryOutput {
+        drift,
+        history,
+        failed_migration_names,
+        edited_migration_names,
+        has_migrations_table,
+    } = api.diagnose_migration_history(&directory).send().await?.into_output();
+
+    assert!(drift.is_none());
+    assert!(
+        matches!(&history, Some(HistoryDiagnostic::MigrationsDirectoryIsBehind { unpersisted_migration_names }) if unpersisted_migration_names.len() == 3),
+        "got: {:#?}",
+        history
+    );
+    assert!(failed_migration_names.is_empty());
+    assert!(edited_migration_names.is_empty());
+    assert!(has_migrations_table);
+
+    api.assert_schema().await?.assert_equals(&initial_schema)?;
+
+    // The following does not work because we validate that migrations are failed before marking them as rolled back.
+    //
+    // // Confirm we can get back to a clean diagnoseMigrationHistory if we mark the squashed migrations as rolled back.
+    // {
+    //     for migration_name in initial_migration_names {
+    //         api.mark_migration_rolled_back(migration_name).send().await?;
+    //     }
+
+    //     let DiagnoseMigrationHistoryOutput {
+    //         drift,
+    //         history,
+    //         failed_migration_names,
+    //         edited_migration_names,
+    //         has_migrations_table,
+    //     } = api.diagnose_migration_history(&directory).send().await?.into_output();
+
+    //     assert!(drift.is_none());
+    //     assert!(history.is_none());
+    //     assert!(failed_migration_names.is_empty());
+    //     assert!(edited_migration_names.is_empty());
+    //     assert!(has_migrations_table);
+    // }
+
+    Ok(())
+}
+
+#[test_each_connector(log = "debug")]
+async fn squashing_migrations_history_at_the_start_works(api: &TestApi) -> TestResult {
+    let directory = api.create_migrations_directory()?;
+
+    // Create and apply a bunch of migrations
+    let _initial_migration_names = {
+        let dm1 = r#"
+            model Cat {
+                id Int @id
+            }
+        "#;
+
+        let dm2 = r#"
+            model Cat {
+                id Int @id
+            }
+
+            model Dog {
+                id Int @id
+            }
+        "#;
+
+        let dm3 = r#"
+            model Cat {
+                id Int @id
+            }
+
+            model Hyena {
+                id Int @id
+                laughterFrequency Float
+            }
+        "#;
+
+        let mut migrations_counter: i32 = 0;
+        let mut initial_migration_names: Vec<String> = Vec::with_capacity(3);
+
+        for schema in &[dm1, dm2, dm3] {
+            let name = api
+                .create_migration(&format!("migration{}", migrations_counter), schema, &directory)
+                .send()
+                .await?
+                .into_output()
+                .generated_migration_name
+                .unwrap();
+
+            migrations_counter += 1;
+            initial_migration_names.push(name);
+        }
+
+        api.apply_migrations(&directory).send().await?;
+
+        initial_migration_names
+    };
+
+    let initial_schema = api
+        .assert_schema()
+        .await?
+        .assert_tables_count(3)?
+        .assert_has_table("Hyena")?
+        .into_schema();
+
+    // Squash the files, mark migration applied, assert the schema is the same.
+
+    let mut squashed_migrations: Vec<(String, String)> = Vec::with_capacity(3);
+
+    for entry in std::fs::read_dir(directory.path())? {
+        let entry = entry?;
+
+        assert!(entry.metadata()?.is_dir());
+
+        let file_path = entry.path().join("migration.sql");
+        let contents = std::fs::read_to_string(file_path)?;
+
+        squashed_migrations.push((entry.file_name().into_string().unwrap(), contents));
+    }
+
+    squashed_migrations.sort_by(|left, right| left.0.cmp(&right.0));
+
+    // Only squash the first two migrations
+    squashed_migrations = squashed_migrations.drain(..).take(2).collect();
+
+    for migration_name in squashed_migrations.iter().map(|(a, _)| a) {
+        let migration_directory_path = directory.path().join(migration_name);
+
+        tracing::debug!("Deleting migration at {:?}", migration_directory_path);
+
+        std::fs::remove_dir_all(migration_directory_path)?;
+    }
+
+    let squashed_migration_directory_path = directory.path().join("0000_initial");
+    std::fs::create_dir_all(&squashed_migration_directory_path)?;
+
+    let mut migration_file = std::fs::File::create(squashed_migration_directory_path.join("migration.sql"))?;
+
+    for (_, squashed_migration) in squashed_migrations {
+        migration_file.write_all(squashed_migration.as_bytes())?;
+    }
+
+    api.assert_schema().await?.assert_tables_count(3)?;
+    api.mark_migration_applied("0000_initial", &directory).send().await?;
+
+    let DiagnoseMigrationHistoryOutput {
+        drift,
+        history,
+        failed_migration_names,
+        edited_migration_names,
+        has_migrations_table,
+    } = api.diagnose_migration_history(&directory).send().await?.into_output();
+
+    assert!(drift.is_none());
+    assert!(
+        matches!(&history, Some(HistoryDiagnostic::MigrationsDirectoryIsBehind { unpersisted_migration_names }) if unpersisted_migration_names.len() == 2),
+        "got: {:#?}",
+        history
+    );
+    assert!(failed_migration_names.is_empty());
+    assert!(edited_migration_names.is_empty());
+    assert!(has_migrations_table);
+
+    api.apply_migrations(&directory)
+        .send()
+        .await?
+        .assert_applied_migrations(&[])?;
+
+    let DiagnoseMigrationHistoryOutput {
+        drift,
+        history,
+        failed_migration_names,
+        edited_migration_names,
+        has_migrations_table,
+    } = api.diagnose_migration_history(&directory).send().await?.into_output();
+
+    assert!(drift.is_none());
+    assert!(
+        matches!(&history, Some(HistoryDiagnostic::MigrationsDirectoryIsBehind { unpersisted_migration_names }) if unpersisted_migration_names.len() == 2),
+        "got: {:#?}",
+        history
+    );
+    assert!(failed_migration_names.is_empty());
+    assert!(edited_migration_names.is_empty());
+    assert!(has_migrations_table);
+
+    api.assert_schema().await?.assert_equals(&initial_schema)?;
+
+    Ok(())
+}
+
+#[test_each_connector(log = "debug")]
+async fn squashing_migrations_history_at_the_end_works(api: &TestApi) -> TestResult {
+    let directory = api.create_migrations_directory()?;
+
+    // Create and apply a bunch of migrations
+    let _initial_migration_names = {
+        let dm1 = r#"
+            model Cat {
+                id Int @id
+            }
+        "#;
+
+        let dm2 = r#"
+            model Cat {
+                id Int @id
+            }
+
+            model Dog {
+                id Int @id
+            }
+        "#;
+
+        let dm3 = r#"
+            model Cat {
+                id Int @id
+            }
+
+            model Hyena {
+                id Int @id
+                laughterFrequency Float
+            }
+        "#;
+
+        let mut migrations_counter: i32 = 0;
+        let mut initial_migration_names: Vec<String> = Vec::with_capacity(3);
+
+        for schema in &[dm1, dm2, dm3] {
+            let name = api
+                .create_migration(&format!("migration{}", migrations_counter), schema, &directory)
+                .send()
+                .await?
+                .into_output()
+                .generated_migration_name
+                .unwrap();
+
+            migrations_counter += 1;
+            initial_migration_names.push(name);
+        }
+
+        api.apply_migrations(&directory).send().await?;
+
+        initial_migration_names
+    };
+
+    let initial_schema = api
+        .assert_schema()
+        .await?
+        .assert_tables_count(3)?
+        .assert_has_table("Hyena")?
+        .into_schema();
+
+    // Squash the files, mark migration applied, assert the schema is the same.
+
+    let mut squashed_migrations: Vec<(String, String)> = Vec::with_capacity(3);
+
+    for entry in std::fs::read_dir(directory.path())? {
+        let entry = entry?;
+
+        assert!(entry.metadata()?.is_dir());
+
+        let file_path = entry.path().join("migration.sql");
+        let contents = std::fs::read_to_string(file_path)?;
+
+        squashed_migrations.push((entry.file_name().into_string().unwrap(), contents));
+    }
+
+    squashed_migrations.sort_by(|left, right| left.0.cmp(&right.0));
+
+    // Only squash the last two migrations
+    squashed_migrations = squashed_migrations.drain(..).skip(1).collect();
+
+    for migration_name in squashed_migrations.iter().map(|(a, _)| a) {
+        let migration_directory_path = directory.path().join(migration_name);
+
+        tracing::debug!("Deleting migration at {:?}", migration_directory_path);
+
+        std::fs::remove_dir_all(migration_directory_path)?;
+    }
+
+    let squashed_migration_directory_path = directory.path().join("0000_initial");
+    std::fs::create_dir_all(&squashed_migration_directory_path)?;
+
+    let mut migration_file = std::fs::File::create(squashed_migration_directory_path.join("migration.sql"))?;
+
+    for (_, squashed_migration) in squashed_migrations {
+        migration_file.write_all(squashed_migration.as_bytes())?;
+    }
+
+    api.assert_schema().await?.assert_tables_count(3)?;
+    api.mark_migration_applied("0000_initial", &directory).send().await?;
+
+    let DiagnoseMigrationHistoryOutput {
+        drift,
+        history,
+        failed_migration_names,
+        edited_migration_names,
+        has_migrations_table,
+    } = api.diagnose_migration_history(&directory).send().await?.into_output();
+
+    assert!(drift.is_none());
+    assert!(
+        matches!(&history, Some(HistoryDiagnostic::MigrationsDirectoryIsBehind { unpersisted_migration_names }) if unpersisted_migration_names.len() == 2),
+        "got: {:#?}",
+        history
+    );
+    assert!(failed_migration_names.is_empty());
+    assert!(edited_migration_names.is_empty());
+    assert!(has_migrations_table);
+
+    api.apply_migrations(&directory)
+        .send()
+        .await?
+        .assert_applied_migrations(&[])?;
+
+    let DiagnoseMigrationHistoryOutput {
+        drift,
+        history,
+        failed_migration_names,
+        edited_migration_names,
+        has_migrations_table,
+    } = api.diagnose_migration_history(&directory).send().await?.into_output();
+
+    assert!(drift.is_none());
+    assert!(
+        matches!(&history, Some(HistoryDiagnostic::MigrationsDirectoryIsBehind { unpersisted_migration_names }) if unpersisted_migration_names.len() == 2),
+        "got: {:#?}",
+        history
+    );
+    assert!(failed_migration_names.is_empty());
+    assert!(edited_migration_names.is_empty());
+    assert!(has_migrations_table);
+
+    api.assert_schema().await?.assert_equals(&initial_schema)?;
+
+    Ok(())
+}

--- a/migration-engine/migration-engine-tests/tests/migrations/squashing_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/squashing_tests.rs
@@ -1,6 +1,5 @@
-use migration_core::commands::{DiagnoseMigrationHistoryOutput, HistoryDiagnostic};
-
 use crate::*;
+use migration_core::commands::{DiagnoseMigrationHistoryOutput, HistoryDiagnostic};
 use std::io::Write;
 
 #[test_each_connector]


### PR DESCRIPTION
The two commits can be reviewed separately. The first is a sequel of previous PRs about simplifying SqlMigration, and introducing a `Pair` type in sql-migration-connector. There is more to come. The second adds tests showing that we can implement a migrations squashing workflow with the engine commands.