### PR TITLE
Remove DatabaseInfo references in SqlRenderer

### DIFF
--- a/libs/sql-schema-describer/src/walkers.rs
+++ b/libs/sql-schema-describer/src/walkers.rs
@@ -153,6 +153,15 @@ impl<'a> TableWalker<'a> {
         self.table().foreign_keys.len()
     }
 
+    /// Traverse to an index by index.
+    pub fn index_at(&self, index_index: usize) -> IndexWalker<'a> {
+        IndexWalker {
+            schema: self.schema,
+            table_index: self.table_index,
+            index_index,
+        }
+    }
+
     /// Traverse the indexes on the table.
     pub fn indexes(&self) -> impl Iterator<Item = IndexWalker<'a>> {
         let schema = self.schema;
@@ -316,31 +325,35 @@ pub struct IndexWalker<'a> {
 impl<'a> IndexWalker<'a> {
     /// The names of the indexed columns.
     pub fn column_names(&self) -> &[String] {
-        &self.index().columns
+        &self.get().columns
     }
 
     /// Traverse the indexed columns.
     pub fn columns<'b>(&'b self) -> impl Iterator<Item = ColumnWalker<'a>> + 'b {
-        self.index().columns.iter().map(move |column_name| {
+        self.get().columns.iter().map(move |column_name| {
             self.table()
                 .column(column_name)
                 .expect("Failed to find column referenced in index")
         })
     }
 
-    /// The underlying index struct.
-    pub fn index(&self) -> &'a Index {
+    fn get(&self) -> &'a Index {
         &self.table().table().indices[self.index_index]
+    }
+
+    /// The index of the index in the parent table.
+    pub fn index(&self) -> usize {
+        self.index_index
     }
 
     /// The IndexType
     pub fn index_type(&self) -> &IndexType {
-        &self.index().tpe
+        &self.get().tpe
     }
 
     /// The name of the index.
     pub fn name(&self) -> &str {
-        &self.index().name
+        &self.get().name
     }
 
     /// Traverse to the table of the index.

--- a/migration-engine/connectors/sql-migration-connector/src/sql_migration.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_migration.rs
@@ -3,7 +3,7 @@ pub(crate) mod expanded_alter_column;
 use crate::{pair::Pair, sql_schema_differ::ColumnChanges};
 use migration_connector::DatabaseMigrationMarker;
 use serde::{Serialize, Serializer};
-use sql_schema_describer::{Index, SqlSchema};
+use sql_schema_describer::SqlSchema;
 
 /// The database migration type for SqlMigrationConnector.
 #[derive(Debug, Serialize)]
@@ -38,10 +38,11 @@ pub(crate) enum SqlMigrationStep {
     AlterTable(AlterTable),
     DropForeignKey(DropForeignKey),
     DropTable(DropTable),
+    RedefineIndex { table: Pair<usize>, index: Pair<usize> },
     RedefineTables(Vec<RedefineTable>),
     CreateIndex(CreateIndex),
     DropIndex(DropIndex),
-    AlterIndex(AlterIndex),
+    AlterIndex { table: Pair<usize>, index: Pair<usize> },
     CreateEnum(CreateEnum),
     DropEnum(DropEnum),
     AlterEnum(AlterEnum),
@@ -67,12 +68,13 @@ impl SqlMigrationStep {
             SqlMigrationStep::AddForeignKey(_) => "AddForeignKey",
             SqlMigrationStep::CreateTable(_) => "CreateTable",
             SqlMigrationStep::AlterTable(_) => "AlterTable",
+            SqlMigrationStep::RedefineIndex { .. } => "RedefineIndex",
             SqlMigrationStep::DropForeignKey(_) => "DropForeignKey",
             SqlMigrationStep::DropTable(_) => "DropTable",
             SqlMigrationStep::RedefineTables { .. } => "RedefineTables",
             SqlMigrationStep::CreateIndex(_) => "CreateIndex",
             SqlMigrationStep::DropIndex(_) => "DropIndex",
-            SqlMigrationStep::AlterIndex(_) => "AlterIndex",
+            SqlMigrationStep::AlterIndex { .. } => "AlterIndex",
             SqlMigrationStep::CreateEnum(_) => "CreateEnum",
             SqlMigrationStep::DropEnum(_) => "DropEnum",
             SqlMigrationStep::AlterEnum(_) => "AlterEnum",
@@ -155,8 +157,8 @@ pub(crate) struct DropForeignKey {
 
 #[derive(Debug)]
 pub(crate) struct CreateIndex {
-    pub table: String,
-    pub index: Index,
+    pub table_index: usize,
+    pub index_index: usize,
     pub caused_by_create_table: bool,
 }
 
@@ -164,13 +166,6 @@ pub(crate) struct CreateIndex {
 pub(crate) struct DropIndex {
     pub table: String,
     pub name: String,
-}
-
-#[derive(Debug)]
-pub(crate) struct AlterIndex {
-    pub table: String,
-    pub index_name: String,
-    pub index_new_name: String,
 }
 
 #[derive(Debug)]

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer.rs
@@ -7,14 +7,14 @@ mod sqlite_renderer;
 pub(crate) use common::IteratorJoin;
 
 use crate::{
-    database_info::DatabaseInfo,
     pair::Pair,
-    sql_migration::{AlterEnum, AlterIndex, AlterTable, CreateIndex, DropForeignKey, DropIndex, RedefineTable},
+    sql_migration::{AlterEnum, AlterTable, DropForeignKey, DropIndex, RedefineTable},
 };
 use common::{Quoted, QuotedWithSchema};
 use sql_schema_describer::{
     walkers::EnumWalker,
     walkers::ForeignKeyWalker,
+    walkers::IndexWalker,
     walkers::{ColumnWalker, TableWalker},
     ColumnTypeFamily, DefaultValue, SqlSchema,
 };
@@ -33,21 +33,16 @@ pub(crate) trait SqlRenderer {
 
     fn render_default<'a>(&self, default: &'a DefaultValue, family: &ColumnTypeFamily) -> Cow<'a, str>;
 
-    /// Render an `AlterIndex` step.
-    fn render_alter_index(
-        &self,
-        alter_index: &AlterIndex,
-        database_info: &DatabaseInfo,
-        current_schema: &SqlSchema,
-    ) -> Vec<String>;
+    fn render_alter_index(&self, _indexes: Pair<&IndexWalker<'_>>) -> Vec<String> {
+        unreachable!("unreachable render_alter_index")
+    }
 
     fn render_alter_table(&self, alter_table: &AlterTable, schemas: &Pair<&SqlSchema>) -> Vec<String>;
 
     /// Render a `CreateEnum` step.
     fn render_create_enum(&self, create_enum: &EnumWalker<'_>) -> Vec<String>;
 
-    /// Render a `CreateIndex` step.
-    fn render_create_index(&self, create_index: &CreateIndex) -> String;
+    fn render_create_index(&self, index: &IndexWalker<'_>) -> String;
 
     /// Render a `CreateTable` step.
     fn render_create_table(&self, table: &TableWalker<'_>) -> String {
@@ -56,6 +51,10 @@ pub(crate) trait SqlRenderer {
 
     /// Render a `CreateTable` step with the provided table name.
     fn render_create_table_as(&self, table: &TableWalker<'_>, table_name: &str) -> String;
+
+    fn render_drop_and_recreate_index(&self, _indexes: Pair<&IndexWalker<'_>>) -> Vec<String> {
+        unreachable!("unreachable render_drop_and_recreate_index")
+    }
 
     /// Render a `DropEnum` step.
     fn render_drop_enum(&self, dropped_enum: &EnumWalker<'_>) -> Vec<String>;

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
@@ -1,12 +1,11 @@
 use super::{common::*, SqlRenderer};
 use crate::{
-    database_info::DatabaseInfo,
     flavour::PostgresFlavour,
     pair::Pair,
     sql_migration::{
         expanded_alter_column::{expand_postgres_alter_column, PostgresAlterColumn},
-        AddColumn, AlterColumn, AlterEnum, AlterIndex, AlterTable, CreateIndex, DropColumn, DropForeignKey, DropIndex,
-        RedefineTable, TableChange,
+        AddColumn, AlterColumn, AlterEnum, AlterTable, DropColumn, DropForeignKey, DropIndex, RedefineTable,
+        TableChange,
     },
     sql_schema_differ::ColumnChanges,
 };
@@ -133,16 +132,11 @@ impl SqlRenderer for PostgresFlavour {
         stmts
     }
 
-    fn render_alter_index(
-        &self,
-        alter_index: &AlterIndex,
-        _database_info: &DatabaseInfo,
-        _current_schema: &SqlSchema,
-    ) -> Vec<String> {
+    fn render_alter_index(&self, indexes: Pair<&IndexWalker<'_>>) -> Vec<String> {
         vec![format!(
             "ALTER INDEX {} RENAME TO {}",
-            self.quote(&alter_index.index_name),
-            self.quote(&alter_index.index_new_name)
+            self.quote(indexes.previous().name()),
+            self.quote(indexes.next().name())
         )]
     }
 
@@ -294,15 +288,15 @@ impl SqlRenderer for PostgresFlavour {
         vec![sql]
     }
 
-    fn render_create_index(&self, create_index: &CreateIndex) -> String {
-        let Index { name, columns, tpe } = &create_index.index;
-        let index_type = match tpe {
+    fn render_create_index(&self, index: &IndexWalker<'_>) -> String {
+        let index_type = match index.index_type() {
             IndexType::Unique => "UNIQUE ",
             IndexType::Normal => "",
         };
-        let index_name = self.quote(&name).to_string();
-        let table_reference = self.quote(&create_index.table).to_string();
-        let columns = columns.iter().map(|c| self.quote(c));
+
+        let index_name = self.quote(index.name());
+        let table_reference = self.quote(index.table().name());
+        let columns = index.columns().map(|c| self.quote(c.name()));
 
         format!(
             "CREATE {index_type}INDEX {index_name} ON {table_reference}({columns})",

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/mysql.rs
@@ -1,6 +1,6 @@
 use super::SqlSchemaDifferFlavour;
 use crate::{
-    flavour::MysqlFlavour, flavour::MYSQL_IDENTIFIER_SIZE_LIMIT, sql_schema_differ::column::ColumnDiffer,
+    flavour::MysqlFlavour, flavour::MYSQL_IDENTIFIER_SIZE_LIMIT, pair::Pair, sql_schema_differ::column::ColumnDiffer,
     sql_schema_differ::ColumnTypeChange,
 };
 use sql_schema_describer::{walkers::IndexWalker, ColumnTypeFamily};
@@ -47,12 +47,14 @@ impl SqlSchemaDifferFlavour for MysqlFlavour {
         None
     }
 
-    fn index_should_be_renamed(&self, previous: &IndexWalker<'_>, next: &IndexWalker<'_>) -> bool {
+    fn index_should_be_renamed(&self, indexes: &Pair<IndexWalker<'_>>) -> bool {
         // Implements correct comparison for truncated index names.
-        if previous.name().len() == MYSQL_IDENTIFIER_SIZE_LIMIT && next.name().len() > MYSQL_IDENTIFIER_SIZE_LIMIT {
-            previous.name()[0..MYSQL_IDENTIFIER_SIZE_LIMIT] != next.name()[0..MYSQL_IDENTIFIER_SIZE_LIMIT]
+        let (previous_name, next_name) = indexes.as_ref().map(|idx| idx.name()).into_tuple();
+
+        if previous_name.len() == MYSQL_IDENTIFIER_SIZE_LIMIT && next_name.len() > MYSQL_IDENTIFIER_SIZE_LIMIT {
+            previous_name[0..MYSQL_IDENTIFIER_SIZE_LIMIT] != next_name[0..MYSQL_IDENTIFIER_SIZE_LIMIT]
         } else {
-            previous.name() != next.name()
+            previous_name != next_name
         }
     }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/postgres.rs
@@ -1,6 +1,7 @@
 use super::SqlSchemaDifferFlavour;
 use crate::{
     flavour::PostgresFlavour,
+    pair::Pair,
     sql_migration::AlterEnum,
     sql_schema_differ::column::{ColumnDiffer, ColumnTypeChange},
     sql_schema_differ::SqlSchemaDiffer,
@@ -68,13 +69,14 @@ impl SqlSchemaDifferFlavour for PostgresFlavour {
         }
     }
 
-    fn index_should_be_renamed(&self, previous: &IndexWalker<'_>, next: &IndexWalker<'_>) -> bool {
+    fn index_should_be_renamed(&self, pair: &Pair<IndexWalker<'_>>) -> bool {
         // Implements correct comparison for truncated index names.
-        if previous.name().len() == POSTGRES_IDENTIFIER_SIZE_LIMIT && next.name().len() > POSTGRES_IDENTIFIER_SIZE_LIMIT
-        {
-            previous.name()[0..POSTGRES_IDENTIFIER_SIZE_LIMIT] != next.name()[0..POSTGRES_IDENTIFIER_SIZE_LIMIT]
+        let (previous_name, next_name) = pair.as_ref().map(|idx| idx.name()).into_tuple();
+
+        if previous_name.len() == POSTGRES_IDENTIFIER_SIZE_LIMIT && next_name.len() > POSTGRES_IDENTIFIER_SIZE_LIMIT {
+            previous_name[0..POSTGRES_IDENTIFIER_SIZE_LIMIT] != next_name[0..POSTGRES_IDENTIFIER_SIZE_LIMIT]
         } else {
-            previous.name() != next.name()
+            previous_name != next_name
         }
     }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/sqlite.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/sqlite.rs
@@ -31,7 +31,7 @@ impl SqlSchemaDifferFlavour for SqliteFlavour {
                     || differ.added_columns().any(|col| col.arity().is_required())
                     || differ.column_pairs().any(|columns| columns.all_changes().0.differs_in_something())
                     // ALTER INDEX does not exist on SQLite
-                    || differ.index_pairs().any(|(previous, next)| self.index_should_be_renamed(&previous, &next))
+                    || differ.index_pairs().any(|pair| self.index_should_be_renamed(&pair))
                     || differ.created_foreign_keys().next().is_some()
                     || differ.dropped_foreign_keys().next().is_some()
             })

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/table.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/table.rs
@@ -75,11 +75,11 @@ impl<'schema> TableDiffer<'schema> {
         })
     }
 
-    pub(crate) fn index_pairs<'a>(&'a self) -> impl Iterator<Item = (IndexWalker<'schema>, IndexWalker<'schema>)> + 'a {
+    pub(crate) fn index_pairs<'a>(&'a self) -> impl Iterator<Item = Pair<IndexWalker<'schema>>> + 'a {
         self.previous_indexes().filter_map(move |previous_index| {
             self.next_indexes()
                 .find(|next_index| indexes_match(&previous_index, next_index))
-                .map(|renamed_index| (previous_index, renamed_index))
+                .map(|renamed_index| Pair::new(previous_index, renamed_index))
         })
     }
 
@@ -143,11 +143,11 @@ impl<'schema> TableDiffer<'schema> {
         self.next().foreign_keys()
     }
 
-    fn previous_indexes<'a>(&'a self) -> impl Iterator<Item = IndexWalker<'schema>> + 'a {
+    fn previous_indexes(&self) -> impl Iterator<Item = IndexWalker<'schema>> {
         self.previous().indexes()
     }
 
-    fn next_indexes<'a>(&'a self) -> impl Iterator<Item = IndexWalker<'schema>> + 'a {
+    fn next_indexes(&self) -> impl Iterator<Item = IndexWalker<'schema>> {
         self.next().indexes()
     }
 


### PR DESCRIPTION
A refactoring of index diffing was necessary to remove the need for
DatabaseInfo in SQL rendering.

This is part of a large refactoring of connection handling that will culminate in closing https://github.com/prisma/prisma-engines/issues/1118