### PR TITLE
Use accurate f64 -> JSON -> f64 parsing

### DIFF
--- a/introspection-engine/connectors/introspection-connector/Cargo.toml
+++ b/introspection-engine/connectors/introspection-connector/Cargo.toml
@@ -13,5 +13,5 @@ thiserror = "1.0.9"
 anyhow = "1.0.26"
 
 serde = { version = "1.0", features = ["derive"]}
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["float_roundtrip"] }
 user-facing-errors = { path = "../../../libs/user-facing-errors" }

--- a/introspection-engine/connectors/sql-introspection-connector/Cargo.toml
+++ b/introspection-engine/connectors/sql-introspection-connector/Cargo.toml
@@ -19,7 +19,7 @@ prisma-value = {path = "../../../libs/prisma-value"}
 regex = "1.2"
 bigdecimal = "0.2"
 serde = {version = "1", features = ["derive"]}
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["float_roundtrip"] }
 sql-schema-describer = {path = "../../../libs/sql-schema-describer"}
 thiserror = "1.0.9"
 tokio = {version = "0.2.13", features = ["rt-threaded", "time"]}

--- a/introspection-engine/core/Cargo.toml
+++ b/introspection-engine/core/Cargo.toml
@@ -18,7 +18,7 @@ thiserror = "1.0.9"
 futures = { version = "0.3", features = ["compat"] }
 futures01 = { package = "futures", version = "0.1" }
 
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["float_roundtrip"] }
 serde_derive = "1.0"
 async-trait = "0.1.17"
 jsonrpc-core = "14.0"

--- a/introspection-engine/introspection-engine-tests/Cargo.toml
+++ b/introspection-engine/introspection-engine-tests/Cargo.toml
@@ -18,7 +18,7 @@ enumflags2 = "0.6.0"
 serde = { version = "1", features = ["derive"] }
 pretty_assertions = "0.6.1"
 tracing-futures = "0.2"
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["float_roundtrip"] }
 tracing = "0.1.10"
 eyre = "0.6.1"
 indoc = "1"

--- a/libs/datamodel/connectors/datamodel-connector/Cargo.toml
+++ b/libs/datamodel/connectors/datamodel-connector/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["float_roundtrip"] }
 dml = { path = "../dml" }
 thiserror = "1.0"
 itertools = "0.8"

--- a/libs/datamodel/connectors/dml/Cargo.toml
+++ b/libs/datamodel/connectors/dml/Cargo.toml
@@ -12,6 +12,6 @@ cuid = {git = "https://github.com/prisma/cuid-rust"}
 prisma-value = {path = "../../../prisma-value"}
 chrono = {version = "0.4.6", features = ["serde"]}
 serde = { version = "1.0.90", features = ["derive"] }
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["float_roundtrip"] }
 native-types = { path = "../../../native-types" }
 

--- a/libs/datamodel/connectors/sql-datamodel-connector/Cargo.toml
+++ b/libs/datamodel/connectors/sql-datamodel-connector/Cargo.toml
@@ -10,4 +10,4 @@ edition = "2018"
 datamodel-connector = { path = "../datamodel-connector" }
 dml = { path = "../dml" }
 native-types = { path = "../../../native-types" }
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["float_roundtrip"] }

--- a/libs/datamodel/core/Cargo.toml
+++ b/libs/datamodel/core/Cargo.toml
@@ -21,7 +21,7 @@ pest = {version = "2.1.0", package = 'pest_tmp'}
 pest_derive = {version = "2.1.0", package = 'pest_derive_tmp'}
 regex = "1.3.7"
 serde = {version = "1.0.90", features = ["derive"]}
-serde_json = {version = "1.0", features = ["preserve_order"]}
+serde_json = {version = "1.0", features = ["preserve_order", "float_roundtrip"]}
 thiserror = "1.0"
 tracing = "0.1"
 

--- a/libs/native-types/Cargo.toml
+++ b/libs/native-types/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2018"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["float_roundtrip"] }

--- a/libs/prisma-models/Cargo.toml
+++ b/libs/prisma-models/Cargo.toml
@@ -25,6 +25,6 @@ rand = "0.7"
 bigdecimal = "0.2"
 serde = "1.0"
 serde_derive = "1.0"
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["float_roundtrip"] }
 thiserror = "1.0"
 uuid = {version = "0.8", features = ["serde", "v4"]}

--- a/libs/prisma-value/Cargo.toml
+++ b/libs/prisma-value/Cargo.toml
@@ -16,7 +16,7 @@ regex = "1.2"
 bigdecimal = "0.2"
 serde = "1.0"
 serde_derive = "1.0"
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["float_roundtrip"] }
 uuid = {version = "0.8", features = ["serde", "v4"]}
 
 [dependencies.quaint]

--- a/libs/sql-schema-describer/Cargo.toml
+++ b/libs/sql-schema-describer/Cargo.toml
@@ -12,7 +12,7 @@ native-types = {path = "../native-types"}
 regex = "1.2"
 bigdecimal = "0.2"
 serde = {version = "1.0", features = ["derive"]}
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["float_roundtrip"] }
 tracing = "0.1"
 enumflags2 = "0.6.0"
 tracing-futures = "0.2.4"

--- a/libs/test-cli/Cargo.toml
+++ b/libs/test-cli/Cargo.toml
@@ -13,7 +13,7 @@ structopt = "0.3.8"
 migration-core = { path = "../../migration-engine/core" }
 introspection-core = { path = "../../introspection-engine/core"}
 tokio = "0.2.13"
-serde_json = "1.0.44"
+serde_json = { version = "1.0", features = ["float_roundtrip"] }
 tracing = "0.1.15"
 tracing-subscriber = "0.2.6"
 tracing-error = "0.1.2"

--- a/libs/user-facing-errors/Cargo.toml
+++ b/libs/user-facing-errors/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 user-facing-error-macros = { path = "../user-facing-error-macros" }
-serde_json = "1.0.41"
+serde_json = { version = "1.0", features = ["float_roundtrip"] }
 serde = { version = "1.0.102", features = ["derive"] }
 backtrace = "0.3.40"
 tracing = "0.1"

--- a/migration-engine/cli/Cargo.toml
+++ b/migration-engine/cli/Cargo.toml
@@ -14,7 +14,7 @@ user-facing-errors = { path = "../../libs/user-facing-errors" }
 base64 = "0.13"
 futures = "0.3"
 json-rpc-stdio = { path = "../../libs/json-rpc-stdio" }
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["float_roundtrip"] }
 structopt = "0.3.8"
 tokio = { version = "0.2.13", features = ["macros"] }
 tracing = "0.1"

--- a/migration-engine/connectors/migration-connector/Cargo.toml
+++ b/migration-engine/connectors/migration-connector/Cargo.toml
@@ -12,7 +12,7 @@ anyhow = "1.0.26"
 async-trait = "0.1.17"
 chrono = "0.4"
 serde = "1.0"
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["float_roundtrip"] }
 sha2 = "0.9.1"
 tracing = "0.1.19"
 tracing-error = "0.1.2"

--- a/migration-engine/connectors/sql-migration-connector/Cargo.toml
+++ b/migration-engine/connectors/sql-migration-connector/Cargo.toml
@@ -22,7 +22,7 @@ enumflags2 = "0.6.0"
 once_cell = "1.3"
 regex = "1"
 serde = {version = "1.0", features = ["derive"]}
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["float_roundtrip"] }
 tokio = {version = "0.2.13", default-features = false, features = ["time"]}
 tracing = "0.1.10"
 tracing-futures = "0.2.0"

--- a/migration-engine/core/Cargo.toml
+++ b/migration-engine/core/Cargo.toml
@@ -16,7 +16,7 @@ chrono = { version = "0.4", features = ["serde"] }
 futures = { version = "0.3", default-features = false, features = ["compat"] }
 jsonrpc-core = "14.0"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["float_roundtrip"] }
 tracing = "0.1.10"
 tracing-futures = "0.2.0"
 url = "2.1.1"

--- a/migration-engine/migration-engine-tests/Cargo.toml
+++ b/migration-engine/migration-engine-tests/Cargo.toml
@@ -29,7 +29,7 @@ chrono = "0.4.15"
 indoc = "1.0.3"
 pretty_assertions = "0.6"
 serde = "1"
-serde_json = "1.0.45"
+serde_json = { version = "1.0", features = ["float_roundtrip"] }
 tempfile = "3.1.0"
 tokio = { version = "0.2.13", features = ["macros"] }
 tracing = "0.1.12"

--- a/prisma-fmt/Cargo.toml
+++ b/prisma-fmt/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2018"
 datamodel = { path = "../libs/datamodel/core" }
 structopt = "0.3"
 serde = { version = "1.0.90", features = ["derive"] }
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["float_roundtrip"] }

--- a/query-engine/connector-test-kit/src/test/scala/writes/dataTypes/json/JsonSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/dataTypes/json/JsonSpec.scala
@@ -4,6 +4,35 @@ import org.scalatest.{FlatSpec, Matchers}
 import util._
 
 class JsonSpec extends FlatSpec with Matchers with ApiSpecBase {
+  "Json float accuracy" should "work" taggedAs (IgnoreMsSql, IgnoreMySql, IgnoreSQLite, IgnoreMySql56) in {
+    val project = ProjectDsl.fromString {
+      """|model Model {
+         | id    String @id
+         | field Json?  @default("{}")
+         |}"""
+    }
+
+    database.setup(project)
+
+    val res = server.query(
+      s"""
+         |mutation {
+         |  createOneModel(
+         |    data: {
+         |      id: "B"
+         |      field: "0.9215686321258545"
+         |    }
+         |  ) {
+         |    field
+         |  }
+         |}""".stripMargin,
+      project,
+      legacy = false
+    )
+
+    res.toString should be("""{"data":{"createOneModel":{"field":"0.9215686321258545"}}}""")
+  }
+
   "Using a json field" should "work" taggedAs (IgnoreMySql56, IgnoreSQLite, IgnoreMsSql) in {
     val project = ProjectDsl.fromString {
       """|model Model {

--- a/query-engine/connectors/query-connector/Cargo.toml
+++ b/query-engine/connectors/query-connector/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["float_roundtrip"] }
 once_cell = "1.3"
 prisma-models = { path = "../../../libs/prisma-models" }
 prisma-value = { path = "../../../libs/prisma-value" }
@@ -18,6 +18,3 @@ chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
 user-facing-errors = { path = "../../../libs/user-facing-errors" }
 async-trait = "0.1.31"
-
-[dev-dependencies]
-serde_json = "1"

--- a/query-engine/connectors/sql-query-connector/Cargo.toml
+++ b/query-engine/connectors/sql-query-connector/Cargo.toml
@@ -11,7 +11,7 @@ futures = "0.3"
 itertools = "0.8"
 rand = "0.7"
 bigdecimal = "0.2"
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["float_roundtrip"] }
 thiserror = "1.0"
 tokio = "0.2.13"
 uuid = "0.8"

--- a/query-engine/query-engine/Cargo.toml
+++ b/query-engine/query-engine/Cargo.toml
@@ -30,7 +30,7 @@ prisma-models = {path = "../../libs/prisma-models"}
 query-core = {path = "../core"}
 bigdecimal = "0.2"
 serde = {version = "1.0", features = ["derive"]}
-serde_json = {version = "1.0", features = ["preserve_order"]}
+serde_json = {version = "1.0", features = ["preserve_order", "float_roundtrip"]}
 sql-connector = {path = "../connectors/sql-query-connector", optional = true, package = "sql-query-connector"}
 structopt = "0.3"
 thiserror = "1.0"


### PR DESCRIPTION
We lose performance here, it's about 2x slower than the old code. Only for float values though.

The problem is how JSON doesn't really use `f64` for floats, but its own interpretation on how they should be represented. This causes accuracy issues when going from its number format to standard 64bit floating point. Luckily `serde_json` has a feature flag, that implements 1:1 conversion, with a hefty performance penalty of course.

Closes: https://github.com/prisma/prisma/issues/3918