### PR TITLE
Allow OVERWRITE_DATASOURCES

### DIFF
--- a/query-engine/connector-test-kit/src/test/scala/binary/QueryEngine.scala
+++ b/query-engine/connector-test-kit/src/test/scala/binary/QueryEngine.scala
@@ -1,0 +1,45 @@
+package binary
+
+import org.scalatest.{FlatSpec, Matchers}
+import util._
+
+class QueryEngine extends FlatSpec with Matchers with ApiSpecBase {
+  "Setting a data source override via env" should "prevent env errors" in {
+    val config = ConnectorConfig.instance
+
+    val header = s"""
+        |datasource test {
+        |  provider = "${config.provider}"
+        |  url = env("NON_EXISTENT_KEY")
+        |}
+        |
+        |generator js {
+        |  provider = "prisma-client-js"
+        |}
+        """.stripMargin
+
+    val datamodel =
+      s"""
+        |model A {
+        |  id Int @id
+        |}
+      """.stripMargin
+
+    // Used for datamodel string utilities to allow running in context of the current connector.
+    val project = ProjectDsl.fromString(datamodel)
+    database.setup(project)
+
+    val result = server.queryDirect(
+      """
+          |mutation {
+          |  createOneA(data: { id: 1 }) { id }
+          |}
+        """.stripMargin,
+      header + "\n" + datamodel, // With invalid url
+      env_overrides = Map("OVERWRITE_DATASOURCES" -> s"""[{"name": "test", "url": "${project.dataSourceUrl}"}]""") // Inject valid url
+    )
+
+    result.assertSuccessfulResponse()
+    result.toString() should be("""{"data":{"createOneA":{"id":1}}}""")
+  }
+}

--- a/query-engine/connector-test-kit/src/test/scala/binary/QueryEngine.scala
+++ b/query-engine/connector-test-kit/src/test/scala/binary/QueryEngine.scala
@@ -9,7 +9,7 @@ class QueryEngine extends FlatSpec with Matchers with ApiSpecBase {
 
     val header = s"""
         |datasource test {
-        |  provider = "${config.provider}"
+        |  provider = "${config.provider.stripSuffix("56")}"
         |  url = env("NON_EXISTENT_KEY")
         |}
         |

--- a/query-engine/connector-test-kit/src/test/scala/util/TestServer.scala
+++ b/query-engine/connector-test-kit/src/test/scala/util/TestServer.scala
@@ -13,6 +13,7 @@ case class TestServer() extends PlayJsonExtensions with LogSupport {
   Logger.setDefaultFormatter(SimpleLogFormatter)
   Logger.setDefaultLogLevel(LogLevel.apply(logLevel))
 
+  // The standard query test method using projects.
   def query(
       query: String,
       project: Project,
@@ -20,44 +21,18 @@ case class TestServer() extends PlayJsonExtensions with LogSupport {
       legacy: Boolean = true,
       batchSize: Int = 5000,
   ): JsValue = {
-    val result = queryBinaryCLI(
+    val result = queryBinary(
       request = createSingleQuery(query),
-      project = project,
+      encodedDataModel = project.fullDatamodelBase64Encoded,
       legacy = legacy,
       batchSize = batchSize,
     )
+
     result._1.assertSuccessfulResponse(dataContains)
     result._1
   }
 
-  def query_with_logged_requests(
-      query: String,
-      project: Project,
-  ): (JsValue, Vector[String]) = {
-
-    val result = queryBinaryCLI(
-      request = createSingleQuery(query),
-      project = project,
-      log_requests = true
-    )
-    result._1.assertSuccessfulResponse()
-    result
-  }
-
-  def batch(
-      queries: Seq[String],
-      transaction: Boolean,
-      project: Project,
-      legacy: Boolean = true,
-  ): JsValue = {
-    val result = queryBinaryCLI(
-      request = createMultiQuery(queries, transaction),
-      project = project,
-      legacy = legacy,
-    )
-    result._1
-  }
-
+  // The standard query test method for failures, using projects.
   def queryThatMustFail(
       query: String,
       project: Project,
@@ -69,32 +44,84 @@ case class TestServer() extends PlayJsonExtensions with LogSupport {
       errorMetaContains: Array[(String, String)] = Array.empty,
   ): JsValue = {
     val result =
-      queryBinaryCLI(
+      queryBinary(
         request = createSingleQuery(query),
-        project = project,
+        encodedDataModel = project.fullDatamodelBase64Encoded,
         legacy = legacy,
       )
 
-    // Ignore error codes for external tests (0) and containment checks ("")
     result._1.assertFailingResponse(errorCode, errorCount, errorContains, errorMetaContains)
     result._1
   }
 
-  def createSingleQuery(query: String): JsValue = {
+  // Only for testing low level queries, usually not required.
+  def query_with_logged_requests(
+      query: String,
+      project: Project,
+  ): (JsValue, Vector[String]) = {
+    val result = queryBinary(
+      request = createSingleQuery(query),
+      encodedDataModel = project.fullDatamodelBase64Encoded,
+      log_requests = true
+    )
+
+    result._1.assertSuccessfulResponse()
+    result
+  }
+
+  // Standard method for testing batch requests.
+  def batch(
+      queries: Seq[String],
+      transaction: Boolean,
+      project: Project,
+      legacy: Boolean = true,
+  ): JsValue = {
+    val result = queryBinary(
+      request = createMultiQuery(queries, transaction),
+      encodedDataModel = project.fullDatamodelBase64Encoded,
+      legacy = legacy,
+    )
+    result._1
+  }
+
+  // Query without the intermediate utility of `Project`, which means that the caller
+  // is responsible to provide a full data model with generator and data source if the
+  // call is to be successful.
+  // Return value is the raw request. Caller has to do assertions.
+  def queryDirect(
+      query: String,
+      datamodel: String,
+      env_overrides: Map[String, String] = Map()
+  ): JsValue = {
+    val result = queryBinary(
+      request = createSingleQuery(query),
+      encodedDataModel = UTF8Base64.encode(datamodel),
+      legacy = false,
+      env_overrides = env_overrides,
+    )
+
+    result._1
+  }
+
+  private def createSingleQuery(query: String): JsValue = {
     val formattedQuery = query.stripMargin.replace("\n", "")
     debug(formattedQuery)
     Json.obj("query" -> formattedQuery, "variables" -> Json.obj())
   }
 
-  def createMultiQuery(queries: Seq[String], transaction: Boolean): JsValue = {
+  private def createMultiQuery(queries: Seq[String], transaction: Boolean): JsValue = {
     Json.obj("batch" -> queries.map(createSingleQuery), "transaction" -> transaction)
   }
 
-  def queryBinaryCLI(request: JsValue,
-                     project: Project,
-                     legacy: Boolean = true,
-                     batchSize: Int = 5000,
-                     log_requests: Boolean = false): (JsValue, Vector[String]) = {
+  // Fires a one-off query against the query engine binary, using the CLI mode instead of the server mode.
+  private def queryBinary(
+      request: JsValue,
+      encodedDataModel: String, // Base64 encoded full data model string
+      legacy: Boolean = true,
+      batchSize: Int = 5000,
+      log_requests: Boolean = false,
+      env_overrides: Map[String, String] = Map() // Overrides existing env keys, else additive.
+  ): (JsValue, Vector[String]) = {
     val encoded_query    = UTF8Base64.encode(Json.stringify(request))
     val binaryLogLevel   = "RUST_LOG" -> s"query_engine=$logLevel,quaint=$logLevel,query_core=$logLevel,query_connector=$logLevel,sql_query_connector=$logLevel,prisma_models=$logLevel,sql_introspection_connector=$logLevel"
     val log_requests_env = if (log_requests) { "LOG_QUERIES" -> "y" } else { ("", "") }
@@ -106,7 +133,7 @@ case class TestServer() extends PlayJsonExtensions with LogSupport {
           "--enable-experimental=all",
           "--enable-raw-queries",
           "--datamodel",
-          project.fullDatamodelBase64Encoded,
+          encodedDataModel,
           "cli",
           "execute-request",
           "--legacy",
@@ -119,12 +146,18 @@ case class TestServer() extends PlayJsonExtensions with LogSupport {
           "--enable-experimental=all",
           "--enable-raw-queries",
           "--datamodel",
-          project.fullDatamodelBase64Encoded,
+          encodedDataModel,
           "cli",
           "execute-request",
           encoded_query
         )
     }
+
+    val env = Seq(
+      "QUERY_BATCH_SIZE" -> batchSize.toString,
+      binaryLogLevel,
+      log_requests_env,
+    )
 
     val process = if (EnvVars.isWindows) {
       Process(params)
@@ -132,14 +165,12 @@ case class TestServer() extends PlayJsonExtensions with LogSupport {
       Process(
         params,
         None,
-        "QUERY_BATCH_SIZE" -> batchSize.toString,
-        binaryLogLevel,
-        log_requests_env
+        env ++ env_overrides.toSeq: _*
       )
     }
 
     val response = process.!!
-    val lines = response.linesIterator.toVector
+    val lines    = response.linesIterator.toVector
     debug(lines.mkString("\n"))
 
     val responseMarker = "Response: " // due to race conditions the response can not always be found in the last line

--- a/query-engine/query-engine/src/cli.rs
+++ b/query-engine/query-engine/src/cli.rs
@@ -71,7 +71,7 @@ impl CliCommand {
                     query: input.query.clone(),
                     enable_raw_queries: opts.enable_raw_queries,
                     legacy: input.legacy,
-                    datamodel: opts.datamodel(false)?,
+                    datamodel: opts.datamodel(true)?,
                     config: opts.configuration(false)?.subject,
                 }))),
             },

--- a/query-engine/query-engine/src/main.rs
+++ b/query-engine/query-engine/src/main.rs
@@ -44,8 +44,10 @@ async fn main() -> Result<(), AnyError> {
 
     async fn main() -> Result<(), PrismaError> {
         let opts = PrismaOpt::from_args();
+
         init_logger(opts.log_format());
         feature_flags::initialize(opts.raw_feature_flags.as_slice())?;
+
         match CliCommand::from_opt(&opts)? {
             Some(cmd) => cmd.execute().await?,
             None => {

--- a/query-engine/query-engine/src/opt.rs
+++ b/query-engine/query-engine/src/opt.rs
@@ -69,7 +69,7 @@ pub struct PrismaOpt {
     pub datamodel: Option<String>,
 
     /// Base64 encoded datasource urls, overwriting the ones in the schema
-    #[structopt(long, env, parse(try_from_str = parse_base64_string))]
+    #[structopt(long, env = "OVERWRITE_DATASOURCES", parse(try_from_str = parse_base64_string))]
     pub overwrite_datasources: Option<String>,
 
     /// Switches query schema generation to Prisma 1 compatible mode.

--- a/query-engine/query-engine/src/opt.rs
+++ b/query-engine/query-engine/src/opt.rs
@@ -120,10 +120,10 @@ impl PrismaOpt {
         Ok(res)
     }
 
-    pub fn datamodel(&self, ignore_env_errors: bool) -> PrismaResult<Datamodel> {
+    pub fn datamodel(&self, ignore_data_sources: bool) -> PrismaResult<Datamodel> {
         let datamodel_str = self.datamodel_str()?;
 
-        let datamodel = if ignore_env_errors {
+        let datamodel = if ignore_data_sources {
             datamodel::parse_datamodel_and_ignore_datasource_urls(datamodel_str)
         } else {
             datamodel::parse_datamodel(datamodel_str)

--- a/query-engine/query-engine/src/server/mod.rs
+++ b/query-engine/query-engine/src/server/mod.rs
@@ -51,7 +51,8 @@ pub async fn listen(opts: PrismaOpt) -> PrismaResult<()> {
         .configuration(false)?
         .subject
         .validate_that_one_datasource_is_provided()?;
-    let datamodel = opts.datamodel(false)?;
+
+    let datamodel = opts.datamodel(true)?;
     let cx = PrismaContext::builder(config, datamodel)
         .legacy(opts.legacy)
         .enable_raw_queries(opts.enable_raw_queries)

--- a/query-engine/query-engine/src/tests/dmmf.rs
+++ b/query-engine/query-engine/src/tests/dmmf.rs
@@ -39,23 +39,6 @@ fn must_not_fail_on_missing_env_vars_in_a_datasource() {
 
 #[test]
 #[serial]
-fn must_succeed_if_env_var_is_missing_and_override_was_provided() {
-    let schema = r#"
-        datasource ds {
-          provider = "postgresql"
-          url = env("DATABASE_URL")
-        }
-    "#;
-
-    let url = "postgres://hostbar";
-
-    let overrides = serde_json::to_string(&vec![("ds".to_string(), url.to_string())]);
-
-    test_dmmf_cli_command(schema, Option::from(overrides.unwrap())).unwrap();
-}
-
-#[test]
-#[serial]
 fn list_of_reserved_model_names_must_be_up_to_date() {
     let dm = r#"
         datasource mydb {

--- a/query-engine/query-engine/src/tests/dmmf.rs
+++ b/query-engine/query-engine/src/tests/dmmf.rs
@@ -108,7 +108,7 @@ fn must_not_fail_if_no_datasource_is_defined() {
         }
     "#;
 
-    test_dmmf_cli_command(schema, None).unwrap();
+    test_dmmf_cli_command(schema).unwrap();
 }
 
 #[test]
@@ -125,7 +125,7 @@ fn must_not_fail_if_an_invalid_datasource_url_is_provided() {
         }
     "#;
 
-    test_dmmf_cli_command(schema, None).unwrap();
+    test_dmmf_cli_command(schema).unwrap();
 }
 
 #[test]
@@ -138,10 +138,10 @@ fn must_fail_if_the_schema_is_invalid() {
         }
     "#;
 
-    assert!(test_dmmf_cli_command(schema, None).is_err());
+    assert!(test_dmmf_cli_command(schema).is_err());
 }
 
-fn test_dmmf_cli_command(schema: &str, overwrite_datasource: Option<String>) -> PrismaResult<()> {
+fn test_dmmf_cli_command(schema: &str) -> PrismaResult<()> {
     feature_flags::initialize(&[String::from("all")]).unwrap();
 
     let prisma_opt = PrismaOpt {
@@ -153,7 +153,7 @@ fn test_dmmf_cli_command(schema: &str, overwrite_datasource: Option<String>) -> 
         enable_playground: false,
         legacy: false,
         log_format: None,
-        overwrite_datasources: overwrite_datasource,
+        overwrite_datasources: None,
         port: 123,
         raw_feature_flags: vec![],
         unix_path: None,


### PR DESCRIPTION
Ensures that the query engine does not crash in case no valid datasource is provided in the datamodel but a valid override is present in the `OVERWRITE_DATASOURCES` env var.