### PR TITLE
Connector Validations: use specific native type instead of generic native type instance

### DIFF
--- a/libs/datamodel/core/tests/config/sources.rs
+++ b/libs/datamodel/core/tests/config/sources.rs
@@ -271,6 +271,9 @@ fn must_succeed_if_env_var_exists_and_override_was_provided() {
         from_env_var: None,
         value: url.to_string(),
     });
+
+    // make sure other tests that run afterwards are not run in a modified environment
+    std::env::remove_var("DATABASE_URL");
 }
 
 #[test]

--- a/libs/datamodel/core/tests/types/positive.rs
+++ b/libs/datamodel/core/tests/types/positive.rs
@@ -49,7 +49,7 @@ fn should_be_able_to_handle_native_type_combined_with_default_autoincrement_attr
     let dml = r#"
         datasource db {
             provider        = "postgres"
-            url             = env("DATABASE_URL")
+            url             = "postgresql://"
         }
 
         generator client {


### PR DESCRIPTION
Small refactoring to rely on our custom native types instead of more generic data structures.