### PR TITLE
Use `tide::Server::bind`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1503,10 +1503,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "http-types"
-version = "2.7.0"
+name = "http-client"
+version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffa4e35764a650ce8e709c50e985431eb8963eee7fc793d923134d4aa8e530b4"
+checksum = "010092b71b94ee49293995625ce7a607778b8b4099c8088fa84fd66bd3e0f21c"
+dependencies = [
+ "async-trait",
+ "http-types",
+ "log",
+]
+
+[[package]]
+name = "http-types"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f316f6a06306570e899238d3b85375f350cfceda60ec47807c4164d6e169e58"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -3756,9 +3767,9 @@ dependencies = [
 
 [[package]]
 name = "tide"
-version = "0.13.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c4c4e35f5a89ed08cbb59b6e4e1d648e563d6f8daa804002f3557d11d3c8f9"
+checksum = "c832ca099a0645f6446b6c8900b09e3b76978dedc0d7383438698b32ff07f734"
 dependencies = [
  "async-h1",
  "async-sse",
@@ -3766,8 +3777,10 @@ dependencies = [
  "async-trait",
  "femme",
  "futures-util",
+ "http-client",
  "http-types",
  "kv-log-macro",
+ "log",
  "pin-project-lite",
  "route-recognizer",
  "serde",
@@ -3776,9 +3789,9 @@ dependencies = [
 
 [[package]]
 name = "tide-server-timing"
-version = "0.13.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9168516930bba237e1e651fcbea0c0e428c7635b6c3da2fd7aeddef78c90567"
+checksum = "51d7f5600e46cba84a874bd0caae3455b771ecebd7d6a8d65798dbe9fd636a81"
 dependencies = [
  "async-channel",
  "http-types",

--- a/query-engine/query-engine/Cargo.toml
+++ b/query-engine/query-engine/Cargo.toml
@@ -34,8 +34,8 @@ serde_json = {version = "1.0", features = ["preserve_order", "float_roundtrip"]}
 sql-connector = {path = "../connectors/sql-query-connector", optional = true, package = "sql-query-connector"}
 structopt = "0.3"
 thiserror = "1.0"
-tide = { version = "0.13.0", default-features = false, features = ["h1-server", "logger"] }
-tide-server-timing = "0.13.1"
+tide = { version = "0.15.0", default-features = false, features = ["h1-server", "logger"] }
+tide-server-timing = "0.15.0"
 url = "2.1"
 
 tracing = "0.1"


### PR DESCRIPTION
This enables logging the "Started http server" message _after_ the HTTP server has started listening, fixing a race condition with the client. Closes https://github.com/prisma/prisma-engines/issues/1173. Thanks!