### PR TITLE
Replace migration splitting with raw_cmd in tests

### DIFF
--- a/introspection-engine/introspection-engine-tests/src/lib.rs
+++ b/introspection-engine/introspection-engine-tests/src/lib.rs
@@ -53,18 +53,13 @@ impl BarrelMigrationExecutor {
         migration_fn(&mut migration);
 
         let full_sql = migration.make_from(self.sql_variant);
-        run_full_sql(&self.database, &full_sql).await?;
+
+        if full_sql.is_empty() {
+            return Ok(());
+        }
+
+        self.database.raw_cmd(&full_sql).await?;
 
         Ok(())
     }
-}
-
-async fn run_full_sql(database: &Quaint, full_sql: &str) -> Result<()> {
-    for sql in full_sql.split(';') {
-        if sql != "" {
-            database.raw_cmd(&sql).await?;
-        }
-    }
-
-    Ok(())
 }

--- a/libs/sql-schema-describer/tests/mssql/mod.rs
+++ b/libs/sql-schema-describer/tests/mssql/mod.rs
@@ -9,16 +9,7 @@ pub async fn get_mssql_describer_for_schema(sql: &str, schema: &'static str) -> 
     let api = mssql_2019_test_api(TestAPIArgs::new(schema, 0b01000000)).await;
     debug!("Executing SQL Server migrations: {}", sql);
 
-    let statements = sql.split(';').filter(|s| !s.is_empty());
-
-    for statement in statements {
-        debug!("Executing migration statement: '{}'", statement);
-
-        api.database()
-            .query_raw(&statement, &[])
-            .await
-            .expect("executing migration statement");
-    }
+    api.database().raw_cmd(sql).await.unwrap();
 
     mssql::SqlSchemaDescriber::new(api.database().clone())
 }

--- a/libs/sql-schema-describer/tests/mysql/mod.rs
+++ b/libs/sql-schema-describer/tests/mysql/mod.rs
@@ -16,13 +16,8 @@ pub async fn get_mysql_describer_for_schema(sql: &str, schema: &str) -> mysql::S
     // Migrate the database we just created.
 
     debug!("Executing MySQL migrations: {}", sql);
-    let statements = sql.split(';').filter(|s| !s.is_empty());
-    for statement in statements {
-        debug!("Executing migration statement: '{}'", statement);
-        conn.query_raw(&statement, &[])
-            .await
-            .expect("executing migration statement");
-    }
+
+    conn.raw_cmd(&sql).await.expect("executing migration");
 
     mysql::SqlSchemaDescriber::new(conn)
 }

--- a/libs/sql-schema-describer/tests/postgres/mod.rs
+++ b/libs/sql-schema-describer/tests/postgres/mod.rs
@@ -27,12 +27,7 @@ pub async fn get_postgres_describer(sql: &str, db_name: &str) -> postgres::SqlSc
         .await
         .expect("creating schema");
 
-    let sql_string = sql.to_string();
-    let statements: Vec<&str> = sql_string.split(';').filter(|s| !s.is_empty()).collect();
-    for statement in statements {
-        debug!("Executing migration statement: '{}'", statement);
-        client.raw_cmd(statement).await.expect("executing migration statement");
-    }
+    client.raw_cmd(sql).await.expect("executing migration");
 
     postgres::SqlSchemaDescriber::new(client)
 }

--- a/libs/sql-schema-describer/tests/sqlite/mod.rs
+++ b/libs/sql-schema-describer/tests/sqlite/mod.rs
@@ -9,9 +9,7 @@ use tracing::debug;
 pub async fn get_sqlite_describer(sql: &str, db_name: &str) -> sqlite::SqlSchemaDescriber {
     let conn = Quaint::new_in_memory(Some(db_name.into())).unwrap();
 
-    for statement in sql.split(';').filter(|statement| !statement.is_empty()) {
-        conn.query_raw(statement, &[]).await.expect("executing migration");
-    }
+    conn.raw_cmd(sql).await.unwrap();
 
     sqlite::SqlSchemaDescriber::new(conn)
 }

--- a/libs/sql-schema-describer/tests/test_api/mod.rs
+++ b/libs/sql-schema-describer/tests/test_api/mod.rs
@@ -244,14 +244,6 @@ impl BarrelMigrationExecutor {
         migration_fn(&mut migration);
 
         let full_sql = migration.make_from(self.sql_variant);
-        run_full_sql(&self.database, &full_sql).await;
-    }
-}
-
-async fn run_full_sql(database: &Quaint, full_sql: &str) {
-    for sql in full_sql.split(';') {
-        if sql != "" {
-            database.query_raw(&sql, &[]).await.unwrap();
-        }
+        self.database.raw_cmd(&full_sql).await.unwrap();
     }
 }

--- a/migration-engine/migration-engine-tests/src/sql/barrel_migration_executor.rs
+++ b/migration-engine/migration-engine-tests/src/sql/barrel_migration_executor.rs
@@ -1,5 +1,5 @@
 use crate::sql::TestApi;
-use quaint::{prelude::Queryable, single::Quaint};
+use quaint::prelude::Queryable;
 use sql_migration_connector::MIGRATION_TABLE_NAME;
 use sql_schema_describer::SqlSchema;
 
@@ -24,7 +24,7 @@ impl BarrelMigrationExecutor<'_> {
         migration_fn(&mut migration);
 
         let full_sql = migration.make_from(self.sql_variant);
-        run_full_sql(&self.api.database(), &full_sql).await?;
+        self.api.database().raw_cmd(&full_sql).await.unwrap();
 
         let mut result = self.api.describe_database().await.expect("Description failed");
 
@@ -37,12 +37,4 @@ impl BarrelMigrationExecutor<'_> {
 
         Ok(result)
     }
-}
-
-async fn run_full_sql(database: &Quaint, full_sql: &str) -> anyhow::Result<()> {
-    for sql in full_sql.split(';').filter(|sql| !sql.is_empty()) {
-        database.query_raw(&sql, &[]).await?;
-    }
-
-    Ok(())
 }


### PR DESCRIPTION
This awkward pattern is not needed anymore.