### PR TITLE
Return whether unapplied migrations can apply cleanly

### DIFF
--- a/migration-engine/cli/src/commands/tests.rs
+++ b/migration-engine/cli/src/commands/tests.rs
@@ -207,16 +207,6 @@ async fn test_drop_postgres_database() {
 async fn test_drop_mysql_database() {
     let url = mysql_url(Some("this_should_be_dropped"));
 
-    // Drop the existing database
-    {
-        let url = mysql_url(Some("mysql"));
-        let conn = Quaint::new(&url).await.unwrap();
-
-        conn.raw_cmd("DROP DATABASE IF EXISTS `this_should_exist`")
-            .await
-            .unwrap();
-    }
-
     run(&["--datasource", &url, "create-database"]).await.unwrap();
     run(&["--datasource", &url, "can-connect-to-database"]).await.unwrap();
     run(&["--datasource", &url, "drop-database"]).await.unwrap();

--- a/migration-engine/connectors/migration-connector/src/database_migration_inferrer.rs
+++ b/migration-engine/connectors/migration-connector/src/database_migration_inferrer.rs
@@ -41,4 +41,7 @@ pub trait DatabaseMigrationInferrer<T>: Send + Sync {
     /// state at the end of the passed in migrations history. If there is drift,
     /// it should return a script to attempt to correct it.
     async fn calculate_drift(&self, applied_migrations: &[MigrationDirectory]) -> ConnectorResult<Option<String>>;
+
+    /// If possible, check that the passed in migrations apply cleanly.
+    async fn validate_migrations(&self, migrations: &[MigrationDirectory]) -> ConnectorResult<()>;
 }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_migration_inferrer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_migration_inferrer.rs
@@ -115,6 +115,15 @@ impl DatabaseMigrationInferrer<SqlMigration> for SqlMigrationConnector {
 
         Ok(Some(rollback))
     }
+
+    #[tracing::instrument(skip(self, migrations))]
+    async fn validate_migrations(&self, migrations: &[MigrationDirectory]) -> ConnectorResult<()> {
+        self.flavour()
+            .sql_schema_from_migration_history(migrations, self.conn())
+            .await?;
+
+        Ok(())
+    }
 }
 
 fn infer(

--- a/migration-engine/migration-engine-tests/tests/migrations/squashing_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/squashing_tests.rs
@@ -94,6 +94,7 @@ async fn squashing_whole_migration_history_works(api: &TestApi) -> TestResult {
         failed_migration_names,
         edited_migration_names,
         has_migrations_table,
+        error_in_unapplied_migration,
     } = api.diagnose_migration_history(&directory).send().await?.into_output();
 
     assert!(drift.is_some());
@@ -112,6 +113,7 @@ async fn squashing_whole_migration_history_works(api: &TestApi) -> TestResult {
     assert!(failed_migration_names.is_empty());
     assert!(edited_migration_names.is_empty());
     assert!(has_migrations_table);
+    assert!(error_in_unapplied_migration.is_none());
 
     api.mark_migration_applied("0000_initial", &directory).send().await?;
 
@@ -121,8 +123,10 @@ async fn squashing_whole_migration_history_works(api: &TestApi) -> TestResult {
         failed_migration_names,
         edited_migration_names,
         has_migrations_table,
+        error_in_unapplied_migration,
     } = api.diagnose_migration_history(&directory).send().await?.into_output();
 
+    assert!(error_in_unapplied_migration.is_none());
     assert!(drift.is_none());
     assert!(
         matches!(&history, Some(HistoryDiagnostic::MigrationsDirectoryIsBehind { unpersisted_migration_names }) if unpersisted_migration_names.len() == 3),
@@ -144,6 +148,7 @@ async fn squashing_whole_migration_history_works(api: &TestApi) -> TestResult {
         failed_migration_names,
         edited_migration_names,
         has_migrations_table,
+        error_in_unapplied_migration,
     } = api.diagnose_migration_history(&directory).send().await?.into_output();
 
     assert!(drift.is_none());
@@ -155,6 +160,7 @@ async fn squashing_whole_migration_history_works(api: &TestApi) -> TestResult {
     assert!(failed_migration_names.is_empty());
     assert!(edited_migration_names.is_empty());
     assert!(has_migrations_table);
+    assert!(error_in_unapplied_migration.is_none());
 
     api.assert_schema().await?.assert_equals(&initial_schema)?;
 
@@ -291,6 +297,7 @@ async fn squashing_migrations_history_at_the_start_works(api: &TestApi) -> TestR
         failed_migration_names,
         edited_migration_names,
         has_migrations_table,
+        error_in_unapplied_migration,
     } = api.diagnose_migration_history(&directory).send().await?.into_output();
 
     assert!(drift.is_none());
@@ -302,6 +309,7 @@ async fn squashing_migrations_history_at_the_start_works(api: &TestApi) -> TestR
     assert!(failed_migration_names.is_empty());
     assert!(edited_migration_names.is_empty());
     assert!(has_migrations_table);
+    assert!(error_in_unapplied_migration.is_none());
 
     api.apply_migrations(&directory)
         .send()
@@ -314,6 +322,7 @@ async fn squashing_migrations_history_at_the_start_works(api: &TestApi) -> TestR
         failed_migration_names,
         edited_migration_names,
         has_migrations_table,
+        error_in_unapplied_migration,
     } = api.diagnose_migration_history(&directory).send().await?.into_output();
 
     assert!(drift.is_none());
@@ -325,6 +334,7 @@ async fn squashing_migrations_history_at_the_start_works(api: &TestApi) -> TestR
     assert!(failed_migration_names.is_empty());
     assert!(edited_migration_names.is_empty());
     assert!(has_migrations_table);
+    assert!(error_in_unapplied_migration.is_none());
 
     api.assert_schema().await?.assert_equals(&initial_schema)?;
 
@@ -438,6 +448,7 @@ async fn squashing_migrations_history_at_the_end_works(api: &TestApi) -> TestRes
         failed_migration_names,
         edited_migration_names,
         has_migrations_table,
+        error_in_unapplied_migration,
     } = api.diagnose_migration_history(&directory).send().await?.into_output();
 
     assert!(drift.is_none());
@@ -449,6 +460,7 @@ async fn squashing_migrations_history_at_the_end_works(api: &TestApi) -> TestRes
     assert!(failed_migration_names.is_empty());
     assert!(edited_migration_names.is_empty());
     assert!(has_migrations_table);
+    assert!(error_in_unapplied_migration.is_none());
 
     api.apply_migrations(&directory)
         .send()
@@ -461,6 +473,7 @@ async fn squashing_migrations_history_at_the_end_works(api: &TestApi) -> TestRes
         failed_migration_names,
         edited_migration_names,
         has_migrations_table,
+        error_in_unapplied_migration,
     } = api.diagnose_migration_history(&directory).send().await?.into_output();
 
     assert!(drift.is_none());
@@ -472,6 +485,7 @@ async fn squashing_migrations_history_at_the_end_works(api: &TestApi) -> TestRes
     assert!(failed_migration_names.is_empty());
     assert!(edited_migration_names.is_empty());
     assert!(has_migrations_table);
+    assert!(error_in_unapplied_migration.is_none());
 
     api.assert_schema().await?.assert_equals(&initial_schema)?;
 


### PR DESCRIPTION
...in diagnoseMigrationHistory

We also return this diagnostic when a migration failed to apply, and
fails to apply again in the shadow database.

closes https://github.com/prisma/migrations-team/issues/106

co-authored with @do4gr 

This is a naive first implementation we want to get out as soon as possible, we will optimize later.