### PR TITLE
Update validate.rs to tweak the error message

### DIFF
--- a/libs/datamodel/core/src/transform/ast_to_dml/validate.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validate.rs
@@ -946,8 +946,8 @@ impl<'a> Validator<'a> {
                     if field.is_required() && !related_field_rel_info.to_fields.is_empty() {
                         errors.push_error(DatamodelError::new_attribute_validation_error(
                             &format!(
-                                "The relation field `{}` on Model `{}` is required. This is no longer valid because it's not possible to enforce this constraint on the database. Change field `{}` to `{}?` to fix this.",
-                                &field.name, &model.name, &field.name, &field.name,
+                                "The relation field `{}` on Model `{}` is required. This is no longer valid because it's not possible to enforce this constraint on the database level. Please change the field type from `{}` to `{}?` to fix this.",
+                                &field.name, &model.name, &related_model.name, &related_model.name,
                             ),
                             RELATION_ATTRIBUTE_NAME,
                             field_span,

--- a/libs/datamodel/core/src/transform/ast_to_dml/validate.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validate.rs
@@ -946,8 +946,8 @@ impl<'a> Validator<'a> {
                     if field.is_required() && !related_field_rel_info.to_fields.is_empty() {
                         errors.push_error(DatamodelError::new_attribute_validation_error(
                             &format!(
-                                "The relation field `{}` on Model `{}` is required. This is invalid as it is not possible to enforce this constraint at the database level. Please make it optional instead.",
-                                &field.name, &model.name,
+                                "The relation field `{}` on Model `{}` is required. This is no longer valid because it's not possible to enforce this constraint on the database. Change field `{}` to `{}?` to fix this.",
+                                &field.name, &model.name, &field.name, &field.name,
                             ),
                             RELATION_ATTRIBUTE_NAME,
                             field_span,

--- a/libs/datamodel/core/tests/attributes/relations_new.rs
+++ b/libs/datamodel/core/tests/attributes/relations_new.rs
@@ -209,7 +209,7 @@ fn required_relation_field_must_error_if_it_is_virtual() {
 
     let errors = parse_error(dml);
     errors.assert_is(DatamodelError::new_attribute_validation_error(
-        "The relation field `address` on Model `User` is required. This is invalid as it is not possible to enforce this constraint at the database level. Please make it optional instead.",
+        "The relation field `address` on Model `User` is required. This is no longer valid because it\'s not possible to enforce this constraint on the database level. Please change the field type from `Address` to `Address?` to fix this.",
         "relation",
         Span::new(54, 77),
     ));


### PR DESCRIPTION
**Untested**: Tweak the error message

**Before**

```
$ npx prisma generate
Prisma schema loaded from prisma/schema.prisma
Error: Schema parsing
error: Error parsing attribute "@relation": The relation field `profile` on Model `User` is required. This is invalid as it is not possible to enforce this constraint at the database level. Please make it optional instead.
  -->  schema.prisma:24
   | 
23 |   posts   Post[]
24 |   profile Profile
25 | }
   | 
Validation Error Count: 1
```

**After**

```
$ npx prisma generate
Prisma schema loaded from prisma/schema.prisma
Error: Schema parsing
error: Error parsing attribute "@relation": The relation field `profile` on Model `User` is required. This is no longer valid because it's not possible to enforce this constraint on the database. Change field `profile` to `profile?` to fix this.
  -->  schema.prisma:24
   | 
23 |   posts   Post[]
24 |   profile Profile
25 | }
   | 
Validation Error Count: 1
```