### PR TITLE
[Introspection] Tables without columns

### DIFF
--- a/introspection-engine/connectors/sql-introspection-connector/src/calculate_datamodel.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/calculate_datamodel.rs
@@ -38,7 +38,7 @@ pub fn calculate_datamodel(
     tracing::debug!("Enriching datamodel is done: {:?}", data_model);
 
     // commenting out models, fields, enums, enum values
-    warnings.append(&mut commenting_out_guardrails(&mut data_model));
+    warnings.append(&mut commenting_out_guardrails(&mut data_model, family));
 
     // try to identify whether the schema was created by a previous Prisma version
     let version = version_check.version(&warnings, &data_model);

--- a/introspection-engine/connectors/sql-introspection-connector/src/commenting_out_guardrails.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/commenting_out_guardrails.rs
@@ -73,6 +73,8 @@ pub fn commenting_out_guardrails(datamodel: &mut Datamodel) -> Vec<Warning> {
         };
     }
 
+    // we could have a separate case and warning for models without columns
+    //on postgres this is allowed, on the other dbs, this could be a symptom of missing privileges
     // models without uniques / ids
     for model in datamodel.models_mut() {
         if model.strict_unique_criterias().is_empty() {
@@ -99,6 +101,8 @@ pub fn commenting_out_guardrails(datamodel: &mut Datamodel) -> Vec<Warning> {
     }
 
     let mut warnings = vec![];
+
+    //extra warning about missing columns
 
     if !models_without_identifiers.is_empty() {
         warnings.push(warning_models_without_identifier(&models_without_identifiers))

--- a/introspection-engine/connectors/sql-introspection-connector/src/warnings.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/warnings.rs
@@ -178,3 +178,11 @@ pub fn warning_enriched_with_updated_at(affected: &Vec<ModelAndField>) -> Warnin
         affected: serde_json::to_value(&affected).unwrap(),
     }
 }
+
+pub fn warning_models_without_columns(affected: &Vec<Model>) -> Warning {
+    Warning {
+        code: 14,
+        message: "The following models were commented out as we could not retrieve columns for them. Please check your privileges.".into(),
+        affected: serde_json::to_value(&affected).unwrap(),
+    }
+}

--- a/introspection-engine/introspection-engine-tests/tests/commenting_out/mod.rs
+++ b/introspection-engine/introspection-engine-tests/tests/commenting_out/mod.rs
@@ -282,7 +282,7 @@ async fn commenting_out_a_table_without_columns(api: &TestApi) -> crate::TestRes
     assert_eq_json!(expected, api.introspection_warnings().await?);
 
     let dm = indoc! {r#"
-        // We could not retrieve columns for the underlying table. Please check your privileges.
+        // We could not retrieve columns for the underlying table. Either it has none or you are missing rights to see them. Please check your privileges.
         // model Test {
         // }
     "#};

--- a/introspection-engine/introspection-engine-tests/tests/commenting_out/mod.rs
+++ b/introspection-engine/introspection-engine-tests/tests/commenting_out/mod.rs
@@ -260,3 +260,34 @@ async fn db_genererated_values_should_add_comments(api: &TestApi) -> crate::Test
 
     Ok(())
 }
+
+#[test_each_connector(tags("postgres"))]
+async fn commenting_out_a_table_without_columns(api: &TestApi) -> crate::TestResult {
+    api.barrel()
+        .execute(|migration| {
+            migration.create_table("Test", |_t| {});
+        })
+        .await?;
+
+    let expected = json!([{
+        "code": 14,
+        "message": "The following models were commented out as we could not retrieve columns for them. Please check your privileges.",
+        "affected": [
+            {
+                "model": "Test"
+            }
+        ]
+    }]);
+
+    assert_eq_json!(expected, api.introspection_warnings().await?);
+
+    let dm = indoc! {r#"
+        // We could not retrieve columns for the underlying table. Please check your privileges.
+        // model Test {
+        // }
+    "#};
+
+    assert_eq!(dm, &api.introspect().await?);
+
+    Ok(())
+}

--- a/libs/sql-schema-describer/src/mssql.rs
+++ b/libs/sql-schema-describer/src/mssql.rs
@@ -179,7 +179,7 @@ impl SqlSchemaDescriber {
         indexes: &mut HashMap<String, (BTreeMap<String, Index>, Option<PrimaryKey>)>,
         foreign_keys: &mut HashMap<String, Vec<ForeignKey>>,
     ) -> Table {
-        let columns = columns.remove(name).expect("table columns not found");
+        let columns = columns.remove(name).unwrap_or(vec![]);
         let (indices, primary_key) = indexes.remove(name).unwrap_or_else(|| (BTreeMap::new(), None));
 
         let foreign_keys = foreign_keys.remove(name).unwrap_or_default();

--- a/libs/sql-schema-describer/src/mysql.rs
+++ b/libs/sql-schema-describer/src/mysql.rs
@@ -156,7 +156,9 @@ impl SqlSchemaDescriber {
         indexes: &mut HashMap<String, (BTreeMap<String, Index>, Option<PrimaryKey>)>,
         foreign_keys: &mut HashMap<String, Vec<ForeignKey>>,
     ) -> (Table, Vec<Enum>) {
-        let (columns, enums) = columns.remove(name).expect("table columns not found");
+        let (columns, enums) = columns
+            .remove(name)
+            .expect(&format!("Columns not found for table {}", name));
         let (indices, primary_key) = indexes.remove(name).unwrap_or_else(|| (BTreeMap::new(), None));
 
         let foreign_keys = foreign_keys.remove(name).unwrap_or_default();
@@ -207,7 +209,7 @@ impl SqlSchemaDescriber {
             trace!("Got column: {:?}", col);
             let table_name = col.get_expect_string("table_name");
             let name = col.get_expect_string("column_name");
-            let data_type = col.get("data_type").and_then(|x| x.to_string()).expect("get data_type");
+            let data_type = col.get_expect_string("data_type");
             let full_data_type = col.get_expect_string("full_data_type");
 
             let is_nullable = col.get_expect_string("is_nullable").to_lowercase();

--- a/libs/sql-schema-describer/src/mysql.rs
+++ b/libs/sql-schema-describer/src/mysql.rs
@@ -156,9 +156,7 @@ impl SqlSchemaDescriber {
         indexes: &mut HashMap<String, (BTreeMap<String, Index>, Option<PrimaryKey>)>,
         foreign_keys: &mut HashMap<String, Vec<ForeignKey>>,
     ) -> (Table, Vec<Enum>) {
-        let (columns, enums) = columns
-            .remove(name)
-            .expect(&format!("Columns not found for table {}", name));
+        let (columns, enums) = columns.remove(name).unwrap_or((vec![], vec![]));
         let (indices, primary_key) = indexes.remove(name).unwrap_or_else(|| (BTreeMap::new(), None));
 
         let foreign_keys = foreign_keys.remove(name).unwrap_or_default();

--- a/libs/sql-schema-describer/src/postgres.rs
+++ b/libs/sql-schema-describer/src/postgres.rs
@@ -136,9 +136,7 @@ impl SqlSchemaDescriber {
     ) -> Table {
         let (indices, primary_key) = indices.remove(name).unwrap_or_else(|| (Vec::new(), None));
         let foreign_keys = foreign_keys.remove(name).unwrap_or_else(Vec::new);
-        let columns = columns
-            .remove(name)
-            .expect(&format!("Columns not found for table {}", name));
+        let columns = columns.remove(name).unwrap_or(vec![]);
         Table {
             name: name.to_string(),
             columns,

--- a/libs/sql-schema-describer/src/postgres.rs
+++ b/libs/sql-schema-describer/src/postgres.rs
@@ -136,7 +136,9 @@ impl SqlSchemaDescriber {
     ) -> Table {
         let (indices, primary_key) = indices.remove(name).unwrap_or_else(|| (Vec::new(), None));
         let foreign_keys = foreign_keys.remove(name).unwrap_or_else(Vec::new);
-        let columns = columns.remove(name).expect("could not get columns");
+        let columns = columns
+            .remove(name)
+            .expect(&format!("Columns not found for table {}", name));
         Table {
             name: name.to_string(),
             columns,


### PR DESCRIPTION
This can be a result of missing privileges. On Postgres it's also just valid to not have columns. 

We should render the table and comment it out with a hint to check privileges. 

Fixes https://github.com/prisma/prisma/issues/4101
Fixes https://github.com/prisma/prisma/issues/3838
Fixes https://github.com/prisma/prisma/issues/3695
Fixes https://github.com/prisma/prisma/issues/3125
Fixes https://github.com/prisma/migrate/issues/649