### PR TITLE
Empty AND filters should return all items

### DIFF
--- a/query-engine/connector-test-kit/src/test/scala/queries/filters/ExtendedRelationFilterSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/filters/ExtendedRelationFilterSpec.scala
@@ -391,8 +391,7 @@ class ExtendedRelationFilterSpec extends FlatSpec with Matchers with ApiSpecBase
 
     server
       .query(query = """{albums(where:{Tracks: { some: { AND:[] }}}){Title}}""", project = project)
-      .toString should be("""{"data":{"albums":[]}}""")
-
+      .toString should be("""{"data":{"albums":[{"Title":"Album1"},{"Title":"Album3"},{"Title":"Album4"},{"Title":"Album5"}]}}""")
   }
 
   "2 level m-relation filters that have subfilters that are connected with an explicit AND" should "work for `every`" taggedAs (IgnoreMongo) in {
@@ -411,7 +410,7 @@ class ExtendedRelationFilterSpec extends FlatSpec with Matchers with ApiSpecBase
     server
       .query(query = """{albums(where: { Tracks: { every:{ AND: [] }}}){Title}}""", project = project)
       .toString should be(
-      """{"data":{"albums":[{"Title":"TheAlbumWithoutTracks"}]}}""")
+      """{"data":{"albums":[{"Title":"Album1"},{"Title":"TheAlbumWithoutTracks"},{"Title":"Album3"},{"Title":"Album4"},{"Title":"Album5"}]}}""")
   }
 
   "2 level m-relation filters that have subfilters that are connected with an explicit OR" should "work" taggedAs (IgnoreMongo) in {

--- a/query-engine/connector-test-kit/src/test/scala/queries/filters/FilterSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/filters/FilterSpec.scala
@@ -124,7 +124,7 @@ class FilterSpec extends FlatSpec with Matchers with ApiSpecBase {
   "Empty AND filter" should "work" in {
     val filter = """(where: {AND:[]})"""
 
-    userUniques(filter) should be(Vector())
+    userUniques(filter) should be(Vector(1, 2, 3, 4))
   }
 
   "OR filter" should "work" taggedAs (IgnoreMongo) in {

--- a/query-engine/connector-test-kit/src/test/scala/queries/regressions/Prisma_4088Spec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/regressions/Prisma_4088Spec.scala
@@ -102,7 +102,7 @@ class Regression4088Spec extends FlatSpec with Matchers with ApiSpecBase with Sc
     res.toString() should be(s"""{\"data\":{\"findManyTestModel\":[]}}""")
   }
 
-  "FindMany queries with an AND condition and no filters" should "return an empty list" in {
+  "FindMany queries with an AND condition and no filters" should "return all items" in {
     database.setup(project)
     create("aa", project)
     create("ab", project)
@@ -120,7 +120,7 @@ class Regression4088Spec extends FlatSpec with Matchers with ApiSpecBase with Sc
       legacy = false
     )
 
-    res.toString() should be(s"""{\"data\":{\"findManyTestModel\":[]}}""")
+    res.toString() should be(s"""{\"data\":{\"findManyTestModel\":[{\"str\":\"aa\"},{\"str\":\"ab\"},{\"str\":\"ac\"}]}}""")
   }
 
   "FindMany queries with an AND condition and one filter" should "only apply one filter" in {


### PR DESCRIPTION
This reverts empty AND filters to prior behavior, changed in #1371. Thanks!

## Rules table

This function recurses to create a structure of `AND/OR/NOT` conditions. The
rules are defined as follows:

| Name | 0 filters         | 1 filter               | n filters            |
|---   |---                |---                     |---                   |
| OR   | return empty list | validate single filter | validate all filters |
| AND  | return all items  | validate single filter | validate all filters |
| NOT  | return all items  | validate single filter | validate all filters |