### PR TITLE
Tweak imperative migrations table schema

### DIFF
--- a/migration-engine/connectors/migration-connector/src/imperative_migrations_persistence.rs
+++ b/migration-engine/connectors/migration-connector/src/imperative_migrations_persistence.rs
@@ -55,8 +55,8 @@ pub trait ImperativeMigrationsPersistence: Send + Sync {
     /// `record_migration_started()` instead.
     async fn record_migration_started_impl(&self, migration_name: &str, checksum: &str) -> ConnectorResult<String>;
 
-    /// Increase the applied_steps_count counter, and append the given logs.
-    async fn record_successful_step(&self, id: &str, logs: &str) -> ConnectorResult<()>;
+    /// Increase the applied_steps_count counter.
+    async fn record_successful_step(&self, id: &str) -> ConnectorResult<()>;
 
     /// Report logs for a failed migration step. We assume the next steps in the
     /// migration will not be applied, and the error reported.

--- a/migration-engine/connectors/migration-connector/src/imperative_migrations_persistence.rs
+++ b/migration-engine/connectors/migration-connector/src/imperative_migrations_persistence.rs
@@ -100,10 +100,7 @@ pub struct MigrationRecord {
     pub migration_name: String,
     /// The human-readable log of actions performed by the engine, up to and
     /// including the point where the migration failed, with the relevant error.
-    ///
-    /// Implementation detail note: a tracing collector with specific events in
-    /// the database applier.
-    pub logs: String,
+    pub logs: Option<String>,
     /// If the migration was rolled back, and when.
     pub rolled_back_at: Option<Timestamp>,
     /// The time the migration started being applied.

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/mysql.rs
@@ -96,8 +96,8 @@ impl SqlFlavour for MysqlFlavour {
                 id                      VARCHAR(36) PRIMARY KEY NOT NULL,
                 checksum                VARCHAR(64) NOT NULL,
                 finished_at             DATETIME(3),
-                migration_name          TEXT NOT NULL,
-                logs                    TEXT NOT NULL,
+                migration_name          VARCHAR(255) NOT NULL,
+                logs                    TEXT,
                 rolled_back_at          DATETIME(3),
                 started_at              DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
                 applied_steps_count     INTEGER UNSIGNED NOT NULL DEFAULT 0

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/postgres.rs
@@ -62,8 +62,8 @@ impl SqlFlavour for PostgresFlavour {
                 id                      VARCHAR(36) PRIMARY KEY NOT NULL,
                 checksum                VARCHAR(64) NOT NULL,
                 finished_at             TIMESTAMPTZ,
-                migration_name          TEXT NOT NULL,
-                logs                    TEXT NOT NULL,
+                migration_name          VARCHAR(255) NOT NULL,
+                logs                    TEXT,
                 rolled_back_at          TIMESTAMPTZ,
                 started_at              TIMESTAMPTZ NOT NULL DEFAULT now(),
                 applied_steps_count     INTEGER NOT NULL DEFAULT 0

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/sqlite.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/sqlite.rs
@@ -40,7 +40,7 @@ impl SqlFlavour for SqliteFlavour {
                 "checksum"              TEXT NOT NULL,
                 "finished_at"           DATETIME,
                 "migration_name"        TEXT NOT NULL,
-                "logs"                  TEXT NOT NULL,
+                "logs"                  TEXT,
                 "rolled_back_at"        DATETIME,
                 "started_at"            DATETIME NOT NULL DEFAULT current_timestamp,
                 "applied_steps_count"   INTEGER UNSIGNED NOT NULL DEFAULT 0

--- a/migration-engine/connectors/sql-migration-connector/src/sql_imperative_migration_persistence.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_imperative_migration_persistence.rs
@@ -85,7 +85,7 @@ impl ImperativeMigrationsPersistence for SqlMigrationConnector {
         Ok(id)
     }
 
-    async fn record_successful_step(&self, id: &str, logs: &str) -> ConnectorResult<()> {
+    async fn record_successful_step(&self, id: &str) -> ConnectorResult<()> {
         use quaint::ast::*;
 
         let update = Update::table(IMPERATIVE_MIGRATIONS_TABLE_NAME)
@@ -93,8 +93,7 @@ impl ImperativeMigrationsPersistence for SqlMigrationConnector {
             .set(
                 "applied_steps_count",
                 Expression::from(Column::from("applied_steps_count")) + Expression::from(1),
-            )
-            .set("logs", logs);
+            );
 
         self.conn().execute(update).await?;
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_imperative_migration_persistence.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_imperative_migration_persistence.rs
@@ -78,8 +78,6 @@ impl ImperativeMigrationsPersistence for SqlMigrationConnector {
             .value("id", id.as_str())
             .value("checksum", checksum)
             .value("started_at", now)
-            // We need this line because MySQL can't default a text field to an empty string
-            .value("logs", "")
             .value("migration_name", migration_name);
 
         conn.execute(insert).await?;

--- a/migration-engine/core/src/commands/apply_migrations.rs
+++ b/migration-engine/core/src/commands/apply_migrations.rs
@@ -90,9 +90,7 @@ impl<'a> MigrationCommand for ApplyMigrationsCommand {
             match applier.apply_script(&script).await {
                 Ok(()) => {
                     tracing::debug!("Successfully applied the script.");
-                    migration_persistence
-                        .record_successful_step(&migration_id, &script)
-                        .await?;
+                    migration_persistence.record_successful_step(&migration_id).await?;
                     migration_persistence.record_migration_finished(&migration_id).await?;
                     applied_migration_names.push(unapplied_migration.migration_name().to_owned());
                 }

--- a/migration-engine/core/src/commands/apply_migrations.rs
+++ b/migration-engine/core/src/commands/apply_migrations.rs
@@ -136,7 +136,11 @@ fn detect_failed_migrations(migrations_from_database: &[MigrationRecord]) -> Cor
             "The `{name}` migration started at {started_at} failed with the following logs:\n{logs}",
             name = failed_migration.migration_name,
             started_at = failed_migration.started_at,
-            logs = failed_migration.logs
+            logs = if let Some(logs) = &failed_migration.logs {
+                format!("with the following logs:\n{}", logs)
+            } else {
+                String::new()
+            }
         )
         .unwrap();
     }

--- a/migration-engine/migration-engine-tests/src/test_api.rs
+++ b/migration-engine/migration-engine-tests/src/test_api.rs
@@ -505,7 +505,7 @@ impl MigrationsAssertions for MigrationRecord {
     }
 
     fn assert_logs(self, expected: &str) -> AssertionResult<Self> {
-        assert_eq!(self.logs, expected);
+        assert_eq!(self.logs.as_deref(), Some(expected));
 
         Ok(self)
     }

--- a/migration-engine/migration-engine-tests/tests/migration_persistence/imperative_migration_persistence_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migration_persistence/imperative_migration_persistence_tests.rs
@@ -27,7 +27,7 @@ async fn starting_a_migration_works(api: &TestApi) -> TestResult {
     );
     assert_eq!(first_migration.finished_at, None);
     assert_eq!(first_migration.migration_name, "initial_migration");
-    assert_eq!(first_migration.logs, "");
+    assert_eq!(first_migration.logs.as_deref(), Some(""));
     assert_eq!(first_migration.rolled_back_at, None);
     assert_eq!(first_migration.applied_steps_count, 0);
 
@@ -64,7 +64,7 @@ async fn finishing_a_migration_works(api: &TestApi) -> TestResult {
         "e0c9674d3b332d71b8bc304aae5b7b8a8bb8ec72e772429fb20d8cc69a864"
     );
     assert_eq!(first_migration.migration_name, "initial_migration");
-    assert_eq!(first_migration.logs, "");
+    assert_eq!(first_migration.logs.as_deref(), Some(""));
     assert_eq!(first_migration.rolled_back_at, None);
     assert_eq!(first_migration.applied_steps_count, 0);
 
@@ -106,7 +106,7 @@ async fn updating_then_finishing_a_migration_works(api: &TestApi) -> TestResult 
         "e0c9674d3b332d71b8bc304aae5b7b8a8bb8ec72e772429fb20d8cc69a864"
     );
     assert_eq!(first_migration.migration_name, "initial_migration");
-    assert_eq!(first_migration.logs, "oï");
+    assert_eq!(first_migration.logs.as_deref(), Some("oï"));
     assert_eq!(first_migration.rolled_back_at, None);
     assert_eq!(first_migration.applied_steps_count, 1);
 
@@ -160,7 +160,7 @@ async fn multiple_successive_migrations_work(api: &TestApi) -> TestResult {
             "e0c9674d3b332d71b8bc304aae5b7b8a8bb8ec72e772429fb20d8cc69a864"
         );
         assert_eq!(first_migration.migration_name, "initial_migration");
-        assert_eq!(first_migration.logs, "oï");
+        assert_eq!(first_migration.logs.as_deref(), Some("oï"));
         assert_eq!(first_migration.rolled_back_at, None);
         assert_eq!(first_migration.applied_steps_count, 1);
 
@@ -184,7 +184,7 @@ async fn multiple_successive_migrations_work(api: &TestApi) -> TestResult {
             "822db1ee793d76eaa1319eb2c453a7ec92ab6ec235268b4d27ac395c6c5a6ef"
         );
         assert_eq!(second_migration.migration_name, "second_migration");
-        assert_eq!(second_migration.logs, "logs for the second migration");
+        assert_eq!(second_migration.logs.as_deref(), Some("logs for the second migration"));
         assert_eq!(second_migration.rolled_back_at, None);
         assert_eq!(second_migration.applied_steps_count, 1);
         assert_eq!(second_migration.finished_at, None);

--- a/migration-engine/migration-engine-tests/tests/migration_persistence/imperative_migration_persistence_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migration_persistence/imperative_migration_persistence_tests.rs
@@ -27,7 +27,7 @@ async fn starting_a_migration_works(api: &TestApi) -> TestResult {
     );
     assert_eq!(first_migration.finished_at, None);
     assert_eq!(first_migration.migration_name, "initial_migration");
-    assert_eq!(first_migration.logs.as_deref(), Some(""));
+    assert_eq!(first_migration.logs.as_deref(), None);
     assert_eq!(first_migration.rolled_back_at, None);
     assert_eq!(first_migration.applied_steps_count, 0);
 
@@ -64,7 +64,7 @@ async fn finishing_a_migration_works(api: &TestApi) -> TestResult {
         "e0c9674d3b332d71b8bc304aae5b7b8a8bb8ec72e772429fb20d8cc69a864"
     );
     assert_eq!(first_migration.migration_name, "initial_migration");
-    assert_eq!(first_migration.logs.as_deref(), Some(""));
+    assert_eq!(first_migration.logs.as_deref(), None);
     assert_eq!(first_migration.rolled_back_at, None);
     assert_eq!(first_migration.applied_steps_count, 0);
 
@@ -91,7 +91,7 @@ async fn updating_then_finishing_a_migration_works(api: &TestApi) -> TestResult 
     let id = persistence
         .record_migration_started("initial_migration", script)
         .await?;
-    persistence.record_successful_step(&id, "oï").await?;
+    persistence.record_successful_step(&id).await?;
     persistence.record_migration_finished(&id).await?;
 
     let migrations = persistence.list_migrations().await?.unwrap();
@@ -106,7 +106,7 @@ async fn updating_then_finishing_a_migration_works(api: &TestApi) -> TestResult 
         "e0c9674d3b332d71b8bc304aae5b7b8a8bb8ec72e772429fb20d8cc69a864"
     );
     assert_eq!(first_migration.migration_name, "initial_migration");
-    assert_eq!(first_migration.logs.as_deref(), Some("oï"));
+    assert!(first_migration.logs.is_none());
     assert_eq!(first_migration.rolled_back_at, None);
     assert_eq!(first_migration.applied_steps_count, 1);
 
@@ -133,7 +133,7 @@ async fn multiple_successive_migrations_work(api: &TestApi) -> TestResult {
     let id_1 = persistence
         .record_migration_started("initial_migration", script_1)
         .await?;
-    persistence.record_successful_step(&id_1, "oï").await?;
+    persistence.record_successful_step(&id_1).await?;
     persistence.record_migration_finished(&id_1).await?;
 
     std::thread::sleep(std::time::Duration::from_millis(10));
@@ -142,9 +142,7 @@ async fn multiple_successive_migrations_work(api: &TestApi) -> TestResult {
     let id_2 = persistence
         .record_migration_started("second_migration", script_2)
         .await?;
-    persistence
-        .record_successful_step(&id_2, "logs for the second migration")
-        .await?;
+    persistence.record_successful_step(&id_2).await?;
 
     let migrations = persistence.list_migrations().await?.unwrap();
 
@@ -160,7 +158,7 @@ async fn multiple_successive_migrations_work(api: &TestApi) -> TestResult {
             "e0c9674d3b332d71b8bc304aae5b7b8a8bb8ec72e772429fb20d8cc69a864"
         );
         assert_eq!(first_migration.migration_name, "initial_migration");
-        assert_eq!(first_migration.logs.as_deref(), Some("oï"));
+        assert!(first_migration.logs.is_none());
         assert_eq!(first_migration.rolled_back_at, None);
         assert_eq!(first_migration.applied_steps_count, 1);
 
@@ -184,7 +182,7 @@ async fn multiple_successive_migrations_work(api: &TestApi) -> TestResult {
             "822db1ee793d76eaa1319eb2c453a7ec92ab6ec235268b4d27ac395c6c5a6ef"
         );
         assert_eq!(second_migration.migration_name, "second_migration");
-        assert_eq!(second_migration.logs.as_deref(), Some("logs for the second migration"));
+        assert!(second_migration.logs.is_none());
         assert_eq!(second_migration.rolled_back_at, None);
         assert_eq!(second_migration.applied_steps_count, 1);
         assert_eq!(second_migration.finished_at, None);


### PR DESCRIPTION
- Introduce a maximum length for migration names
  - As a defensive measure
- Make the logs column nullable
  - We are not sure we want to use it, since it could leak sensitive
  information and grow without bounds