### PR TITLE
Stop refusing to apply migrations when changes are detected

### DIFF
--- a/libs/user-facing-errors/src/migration_engine.rs
+++ b/libs/user-facing-errors/src/migration_engine.rs
@@ -104,6 +104,16 @@ pub struct MigrationAlreadyApplied {
     pub migration_name: String,
 }
 
+#[derive(Debug, Serialize, UserFacingError)]
+#[user_facing(
+    code = "P3009",
+    message = "migrate found failed migrations in the target database, new migrations will not be applied. Read more about how to resolve migration issues in a production database: https://pris.ly/d/migrate-resolve\n{details}"
+)]
+pub struct FoundFailedMigrations {
+    /// The details about each failed migration.
+    pub details: String,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/migration-engine/core/src/commands/apply_migrations.rs
+++ b/migration-engine/core/src/commands/apply_migrations.rs
@@ -98,11 +98,11 @@ impl<'a> MigrationCommand for ApplyMigrationsCommand {
                 Err(err) => {
                     tracing::debug!("Failed to apply the script.");
 
-                    let logs = format!("script:\n{}\n\nerror:\n{}", script, err);
+                    let logs = err.to_string();
 
                     migration_persistence.record_failed_step(&migration_id, &logs).await?;
 
-                    return Err(err.into()); // todo: give more context
+                    return Err(err.into());
                 }
             }
         }


### PR DESCRIPTION
Before this PR, we would intentionally crash hard when edited migrations
are detected in the migrations history in applyMigrations. This
behaviour is too strict, so we will now only abort in case of failed
migrations in the history.

Also return a better error (user-facing with a code and link to docs) when failed migrations are detected.

closes https://github.com/prisma/migrations-team/issues/137