### PR TITLE
Stop printing newlines between columns of indexes...

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
@@ -85,6 +85,8 @@ impl DatabaseMigrationStepApplier<SqlMigration> for SqlMigrationConnector {
                     script.push_str(&statement);
                     script.push_str(";\n");
                 }
+
+                script.push('\n');
             }
         }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
@@ -244,7 +244,7 @@ impl SqlRenderer for MysqlFlavour {
                         "{}INDEX {}({})",
                         tpe,
                         self.quote(&index_name),
-                        index.columns().map(|col| self.quote(col.name())).join(",\n")
+                        index.columns().map(|col| self.quote(col.name())).join(", ")
                     )
                 })
                 .join(",\n");

--- a/migration-engine/migration-engine-tests/tests/create_migration/create_migration_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/create_migration/create_migration_tests.rs
@@ -29,6 +29,7 @@ async fn basic_create_migration_works(api: &TestApi) -> TestResult {
 
                             PRIMARY KEY ("id")
                         );
+
                         "#
                     }
                 }
@@ -42,6 +43,7 @@ async fn basic_create_migration_works(api: &TestApi) -> TestResult {
 
                             PRIMARY KEY (`id`)
                         ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
                         "#
                     }
                 }
@@ -53,6 +55,7 @@ async fn basic_create_migration_works(api: &TestApi) -> TestResult {
                             "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
                             "name" TEXT NOT NULL
                         );
+
                         "#
                     }
                 }
@@ -65,6 +68,7 @@ async fn basic_create_migration_works(api: &TestApi) -> TestResult {
                             [name] NVARCHAR(1000) NOT NULL,
                             CONSTRAINT [PK_Cat_id] PRIMARY KEY ([id])
                         );
+
                         "#
                     }
                 }
@@ -120,6 +124,7 @@ async fn creating_a_second_migration_should_have_the_previous_sql_schema_as_base
 
                             PRIMARY KEY ("id")
                         );
+
                         "#
                     }
                 }
@@ -133,6 +138,7 @@ async fn creating_a_second_migration_should_have_the_previous_sql_schema_as_base
 
                             PRIMARY KEY (`id`)
                         ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
                         "#
                     }
                 }
@@ -144,6 +150,7 @@ async fn creating_a_second_migration_should_have_the_previous_sql_schema_as_base
                             "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
                             "name" TEXT NOT NULL
                         );
+
                         "#
                     }
                 }
@@ -156,6 +163,7 @@ async fn creating_a_second_migration_should_have_the_previous_sql_schema_as_base
                             [name] NVARCHAR(1000) NOT NULL,
                             CONSTRAINT [PK_Dog_id] PRIMARY KEY ([id])
                         );
+
                         "#
                     }
                 }
@@ -319,6 +327,7 @@ async fn create_enum_step_only_rendered_when_needed(api: &TestApi) -> TestResult
                         r#"
                         -- CreateEnum
                         CREATE TYPE "prisma-tests"."Mood" AS ENUM ('HUNGRY', 'SLEEPY');
+
                         -- CreateTable
                         CREATE TABLE "Cat" (
                             "id" INTEGER NOT NULL,
@@ -326,6 +335,7 @@ async fn create_enum_step_only_rendered_when_needed(api: &TestApi) -> TestResult
 
                             PRIMARY KEY ("id")
                         );
+
                         "#
                     }
                 }
@@ -339,6 +349,7 @@ async fn create_enum_step_only_rendered_when_needed(api: &TestApi) -> TestResult
 
                             PRIMARY KEY (`id`)
                         ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
                         "#
                     }
                 }


### PR DESCRIPTION
in MySQL CREATE TABLEs.

Before:

INDEX `myindex`(`a`,
`b`,
`c`)

After:

INDEX `myindex`(`a`,`b`,`c`)