### PR TITLE
Move newline printed after migration steps _before_ the migration step

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
@@ -77,7 +77,11 @@ impl DatabaseMigrationStepApplier<SqlMigration> for SqlMigrationConnector {
             );
 
             if !statements.is_empty() {
-                script.push_str("-- ");
+                // We print a newline *before* migration steps and not after,
+                // because we do not want two newlines at the end of the file:
+                // many editors will remove trailing newlines, and automatically
+                // edit the migration.
+                script.push_str("\n-- ");
                 script.push_str(step.description());
                 script.push('\n');
 
@@ -85,8 +89,6 @@ impl DatabaseMigrationStepApplier<SqlMigration> for SqlMigrationConnector {
                     script.push_str(&statement);
                     script.push_str(";\n");
                 }
-
-                script.push('\n');
             }
         }
 

--- a/migration-engine/migration-engine-tests/tests/create_migration/create_migration_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/create_migration/create_migration_tests.rs
@@ -22,7 +22,6 @@ async fn basic_create_migration_works(api: &TestApi) -> TestResult {
                 SqlFamily::Postgres => {
                     indoc! {
                         r#"
-
                         -- CreateTable
                         CREATE TABLE "Cat" (
                             "id" INTEGER NOT NULL,
@@ -36,7 +35,6 @@ async fn basic_create_migration_works(api: &TestApi) -> TestResult {
                 SqlFamily::Mysql => {
                     indoc! {
                         r#"
-
                         -- CreateTable
                         CREATE TABLE `Cat` (
                             `id` INT NOT NULL,
@@ -50,7 +48,6 @@ async fn basic_create_migration_works(api: &TestApi) -> TestResult {
                 SqlFamily::Sqlite => {
                     indoc! {
                         r#"
-
                         -- CreateTable
                         CREATE TABLE "Cat" (
                             "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
@@ -62,7 +59,6 @@ async fn basic_create_migration_works(api: &TestApi) -> TestResult {
                 SqlFamily::Mssql => {
                     indoc! {
                         r#"
-
                         -- CreateTable
                         CREATE TABLE [basic_create_migration_works].[Cat] (
                             [id] INT NOT NULL,
@@ -117,7 +113,6 @@ async fn creating_a_second_migration_should_have_the_previous_sql_schema_as_base
                 SqlFamily::Postgres => {
                     indoc! {
                         r#"
-
                         -- CreateTable
                         CREATE TABLE "Dog" (
                             "id" INTEGER NOT NULL,
@@ -131,7 +126,6 @@ async fn creating_a_second_migration_should_have_the_previous_sql_schema_as_base
                 SqlFamily::Mysql => {
                     indoc! {
                         r#"
-
                         -- CreateTable
                         CREATE TABLE `Dog` (
                             `id` INT NOT NULL,
@@ -145,7 +139,6 @@ async fn creating_a_second_migration_should_have_the_previous_sql_schema_as_base
                 SqlFamily::Sqlite => {
                     indoc! {
                         r#"
-
                         -- CreateTable
                         CREATE TABLE "Dog" (
                             "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
@@ -157,7 +150,6 @@ async fn creating_a_second_migration_should_have_the_previous_sql_schema_as_base
                 SqlFamily::Mssql => {
                     indoc! {
                         r#"
-
                         -- CreateTable
                         CREATE TABLE [creating_a_second_migration_should_have_the_previous_sql_schema_as_baseline].[Dog] (
                             [id] INT NOT NULL,
@@ -325,7 +317,6 @@ async fn create_enum_step_only_rendered_when_needed(api: &TestApi) -> TestResult
                 SqlFamily::Postgres => {
                     indoc! {
                         r#"
-
                         -- CreateEnum
                         CREATE TYPE "prisma-tests"."Mood" AS ENUM ('HUNGRY', 'SLEEPY');
 
@@ -342,7 +333,6 @@ async fn create_enum_step_only_rendered_when_needed(api: &TestApi) -> TestResult
                 SqlFamily::Mysql => {
                     indoc! {
                         r#"
-
                         -- CreateTable
                         CREATE TABLE `Cat` (
                             `id` INT NOT NULL,

--- a/migration-engine/migration-engine-tests/tests/create_migration/create_migration_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/create_migration/create_migration_tests.rs
@@ -22,6 +22,7 @@ async fn basic_create_migration_works(api: &TestApi) -> TestResult {
                 SqlFamily::Postgres => {
                     indoc! {
                         r#"
+
                         -- CreateTable
                         CREATE TABLE "Cat" (
                             "id" INTEGER NOT NULL,
@@ -29,13 +30,13 @@ async fn basic_create_migration_works(api: &TestApi) -> TestResult {
 
                             PRIMARY KEY ("id")
                         );
-
                         "#
                     }
                 }
                 SqlFamily::Mysql => {
                     indoc! {
                         r#"
+
                         -- CreateTable
                         CREATE TABLE `Cat` (
                             `id` INT NOT NULL,
@@ -43,32 +44,31 @@ async fn basic_create_migration_works(api: &TestApi) -> TestResult {
 
                             PRIMARY KEY (`id`)
                         ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-
                         "#
                     }
                 }
                 SqlFamily::Sqlite => {
                     indoc! {
                         r#"
+
                         -- CreateTable
                         CREATE TABLE "Cat" (
                             "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
                             "name" TEXT NOT NULL
                         );
-
                         "#
                     }
                 }
                 SqlFamily::Mssql => {
                     indoc! {
                         r#"
+
                         -- CreateTable
                         CREATE TABLE [basic_create_migration_works].[Cat] (
                             [id] INT NOT NULL,
                             [name] NVARCHAR(1000) NOT NULL,
                             CONSTRAINT [PK_Cat_id] PRIMARY KEY ([id])
                         );
-
                         "#
                     }
                 }
@@ -117,6 +117,7 @@ async fn creating_a_second_migration_should_have_the_previous_sql_schema_as_base
                 SqlFamily::Postgres => {
                     indoc! {
                         r#"
+
                         -- CreateTable
                         CREATE TABLE "Dog" (
                             "id" INTEGER NOT NULL,
@@ -124,13 +125,13 @@ async fn creating_a_second_migration_should_have_the_previous_sql_schema_as_base
 
                             PRIMARY KEY ("id")
                         );
-
                         "#
                     }
                 }
                 SqlFamily::Mysql => {
                     indoc! {
                         r#"
+
                         -- CreateTable
                         CREATE TABLE `Dog` (
                             `id` INT NOT NULL,
@@ -138,32 +139,31 @@ async fn creating_a_second_migration_should_have_the_previous_sql_schema_as_base
 
                             PRIMARY KEY (`id`)
                         ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-
                         "#
                     }
                 }
                 SqlFamily::Sqlite => {
                     indoc! {
                         r#"
+
                         -- CreateTable
                         CREATE TABLE "Dog" (
                             "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
                             "name" TEXT NOT NULL
                         );
-
                         "#
                     }
                 }
                 SqlFamily::Mssql => {
                     indoc! {
                         r#"
+
                         -- CreateTable
                         CREATE TABLE [creating_a_second_migration_should_have_the_previous_sql_schema_as_baseline].[Dog] (
                             [id] INT NOT NULL,
                             [name] NVARCHAR(1000) NOT NULL,
                             CONSTRAINT [PK_Dog_id] PRIMARY KEY ([id])
                         );
-
                         "#
                     }
                 }
@@ -325,6 +325,7 @@ async fn create_enum_step_only_rendered_when_needed(api: &TestApi) -> TestResult
                 SqlFamily::Postgres => {
                     indoc! {
                         r#"
+
                         -- CreateEnum
                         CREATE TYPE "prisma-tests"."Mood" AS ENUM ('HUNGRY', 'SLEEPY');
 
@@ -335,13 +336,13 @@ async fn create_enum_step_only_rendered_when_needed(api: &TestApi) -> TestResult
 
                             PRIMARY KEY ("id")
                         );
-
                         "#
                     }
                 }
                 SqlFamily::Mysql => {
                     indoc! {
                         r#"
+
                         -- CreateTable
                         CREATE TABLE `Cat` (
                             `id` INT NOT NULL,
@@ -349,16 +350,10 @@ async fn create_enum_step_only_rendered_when_needed(api: &TestApi) -> TestResult
 
                             PRIMARY KEY (`id`)
                         ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-
                         "#
                     }
                 }
-                SqlFamily::Sqlite => unreachable!("no enums -.-"),
-                SqlFamily::Mssql => {
-                    indoc! {
-                        r#"say hi to Musti and Nauki"#
-                    }
-                }
+                SqlFamily::Sqlite | SqlFamily::Mssql => unreachable!("no enums -.-"),
             };
 
             migration.assert_contents(expected_script)


### PR DESCRIPTION
Previous behaviour would result in double newlines at the end of files.
This is a serious issue because many editors, including mine, will
automatically delete the redundant newline on save, making the migration
edited, which prompts a database reset.