### PR TITLE
SQL Server: Fixes for constraint naming and using the shadow database

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mssql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mssql_renderer.rs
@@ -358,6 +358,14 @@ impl SqlRenderer for MssqlFlavour {
 
         if let Some(constraint_name) = foreign_key.constraint_name() {
             write!(add_constraint, "CONSTRAINT {} ", self.quote(constraint_name)).unwrap();
+        } else {
+            write!(
+                add_constraint,
+                "CONSTRAINT [FK__{}__{}] ",
+                foreign_key.table().name(),
+                foreign_key.constrained_column_names().join("__"),
+            )
+            .unwrap();
         }
 
         write!(

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mssql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mssql_renderer.rs
@@ -50,8 +50,11 @@ impl SqlRenderer for MssqlFlavour {
             .default()
             .filter(|default| !matches!(default.kind(), DefaultKind::DBGENERATED(_)))
             .map(|default| {
+                let constraint_name = format!("DF__{}__{}", column.table().name(), column.name());
+
                 format!(
-                    " DEFAULT {}",
+                    " CONSTRAINT {} DEFAULT {}",
+                    self.quote(&constraint_name),
                     self.render_default(default, &column.column_type_family())
                 )
             })
@@ -150,7 +153,7 @@ impl SqlRenderer for MssqlFlavour {
         let primary_columns = table.primary_key_column_names();
 
         let primary_key = if let Some(primary_columns) = primary_columns.as_ref().filter(|cols| !cols.is_empty()) {
-            let index_name = format!("PK_{}_{}", table.name(), primary_columns.iter().join("_"));
+            let index_name = format!("PK__{}__{}", table.name(), primary_columns.iter().join("_"));
             let column_names = primary_columns.iter().map(|col| self.quote(&col)).join(",");
 
             format!(

--- a/migration-engine/migration-engine-tests/tests/create_migration/create_migration_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/create_migration/create_migration_tests.rs
@@ -63,7 +63,7 @@ async fn basic_create_migration_works(api: &TestApi) -> TestResult {
                         CREATE TABLE [basic_create_migration_works].[Cat] (
                             [id] INT NOT NULL,
                             [name] NVARCHAR(1000) NOT NULL,
-                            CONSTRAINT [PK_Cat_id] PRIMARY KEY ([id])
+                            CONSTRAINT [PK__Cat__id] PRIMARY KEY ([id])
                         );
                         "#
                     }
@@ -154,7 +154,7 @@ async fn creating_a_second_migration_should_have_the_previous_sql_schema_as_base
                         CREATE TABLE [creating_a_second_migration_should_have_the_previous_sql_schema_as_baseline].[Dog] (
                             [id] INT NOT NULL,
                             [name] NVARCHAR(1000) NOT NULL,
-                            CONSTRAINT [PK_Dog_id] PRIMARY KEY ([id])
+                            CONSTRAINT [PK__Dog__id] PRIMARY KEY ([id])
                         );
                         "#
                     }

--- a/migration-engine/migration-engine-tests/tests/migration_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migration_tests.rs
@@ -2672,3 +2672,37 @@ async fn a_model_can_be_removed(api: &TestApi) -> TestResult {
 
     Ok(())
 }
+
+#[test_each_connector]
+async fn a_default_can_be_dropped(api: &TestApi) -> TestResult {
+    let directory = api.create_migrations_directory()?;
+
+    let dm1 = r#"
+        model User {
+            id   Int     @id @default(autoincrement())
+            name String  @default("Musti")
+        }
+    "#;
+
+    api.create_migration("initial", dm1, &directory).send().await?;
+
+    let dm2 = r#"
+        model User {
+            id   Int     @id @default(autoincrement())
+            name String?
+        }
+    "#;
+
+    api.create_migration("second-migration", dm2, &directory).send().await?;
+
+    api.apply_migrations(&directory)
+        .send()
+        .await?
+        .assert_applied_migrations(&["initial", "second-migration"])?;
+
+    let output = api.diagnose_migration_history(&directory).send().await?.into_output();
+
+    assert!(output.is_empty());
+
+    Ok(())
+}

--- a/migration-engine/migration-engine-tests/tests/migration_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migration_tests.rs
@@ -2630,3 +2630,45 @@ async fn a_table_recreation_with_noncastable_columns_should_trigger_warnings(api
 
     Ok(())
 }
+
+#[test_each_connector]
+async fn a_model_can_be_removed(api: &TestApi) -> TestResult {
+    let directory = api.create_migrations_directory()?;
+
+    let dm1 = r#"
+        model User {
+            id   Int     @id @default(autoincrement())
+            name String?
+            Post Post[]
+        }
+
+        model Post {
+            id     Int    @id @default(autoincrement())
+            title  String
+            User   User   @relation(fields: [userId], references: [id])
+            userId Int
+        }
+    "#;
+
+    api.create_migration("initial", dm1, &directory).send().await?;
+
+    let dm2 = r#"
+        model User {
+            id   Int     @id @default(autoincrement())
+            name String?
+        }
+    "#;
+
+    api.create_migration("second-migration", dm2, &directory).send().await?;
+
+    api.apply_migrations(&directory)
+        .send()
+        .await?
+        .assert_applied_migrations(&["initial", "second-migration"])?;
+
+    let output = api.diagnose_migration_history(&directory).send().await?.into_output();
+
+    assert!(output.is_empty());
+
+    Ok(())
+}


### PR DESCRIPTION
If we don't name them, the name is randomized in the shadow database, and if we need to drop the constraint, the name can differ between the shadow and actual.

This affects now the foreign keys and default values, which both are constraints and should be named accordingly.

Closes: https://github.com/prisma/migrate/issues/667