### PR TITLE
Apply Clippy to datamodel components

### DIFF
--- a/libs/datamodel/connectors/datamodel-connector/src/combined_connector.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/combined_connector.rs
@@ -10,7 +10,7 @@ pub struct CombinedConnector {
 
 impl CombinedConnector {
     // returns a connector representing the intersection of all provided connectors
-    pub fn new(connectors: Vec<Box<dyn Connector>>) -> Box<dyn Connector> {
+    pub fn new(connectors: Vec<Box<dyn Connector>>) -> Self {
         // the standard library does not seem to offer an elegant way to do this. Don't want to pull in a dependency for this.
         let mut combined_capabilities = vec![];
         for connector in &connectors {
@@ -23,9 +23,9 @@ impl CombinedConnector {
             }
         }
 
-        Box::new(CombinedConnector {
+        CombinedConnector {
             capabilities: combined_capabilities,
-        })
+        }
     }
 }
 

--- a/libs/datamodel/connectors/dml/src/datamodel.rs
+++ b/libs/datamodel/connectors/dml/src/datamodel.rs
@@ -9,7 +9,7 @@ use crate::relation_info::RelationInfo;
 /// string, only introspection and the lowering of the datamodel to the ast care about these flags.
 /// The FieldType: Unsupported behaves in the same way.
 /// Both of these are never converted into the internal datamodel.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Default)]
 pub struct Datamodel {
     pub enums: Vec<Enum>,
     pub models: Vec<Model>,
@@ -17,10 +17,7 @@ pub struct Datamodel {
 
 impl Datamodel {
     pub fn new() -> Datamodel {
-        Datamodel {
-            enums: Vec::new(),
-            models: Vec::new(),
-        }
+        Datamodel { ..Default::default() }
     }
 
     /// Checks if a datamodel contains neither enums nor models.

--- a/libs/datamodel/connectors/dml/src/native_type_instance.rs
+++ b/libs/datamodel/connectors/dml/src/native_type_instance.rs
@@ -33,7 +33,7 @@ impl NativeTypeInstance {
     }
 
     pub fn render(&self) -> String {
-        if self.args.len() == 0 {
+        if self.args.is_empty() {
             self.name.to_string()
         } else {
             let args_as_strings: Vec<String> = self.args.iter().map(|a| a.to_string()).collect();

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/mssql_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/mssql_datamodel_connector.rs
@@ -308,6 +308,12 @@ impl Connector for MsSqlDatamodelConnector {
     }
 }
 
+impl Default for MsSqlDatamodelConnector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 static HEAP_ALLOCATED: Lazy<Vec<MsSqlType>> = Lazy::new(|| {
     vec![
         MsSqlType::Text,

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
@@ -372,3 +372,9 @@ impl Connector for MySqlDatamodelConnector {
         }
     }
 }
+
+impl Default for MySqlDatamodelConnector {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
@@ -140,7 +140,7 @@ impl Connector for PostgresDatamodelConnector {
                         "Postgres",
                     ));
                 }
-                Some((precision, _)) if precision > 1000 || precision <= 0 => {
+                Some((precision, _)) if precision > 1000 || precision == 0 => {
                     return Err(ConnectorError::new_argument_m_out_of_range_error(
                         "Precision must be positive with a maximum value of 1000.",
                         native_type_name,
@@ -281,5 +281,11 @@ impl Connector for PostgresDatamodelConnector {
                 connector_name: "Postgres".parse().unwrap(),
             }))
         }
+    }
+}
+
+impl Default for PostgresDatamodelConnector {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/sqlite_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/sqlite_datamodel_connector.rs
@@ -55,3 +55,9 @@ impl Connector for SqliteDatamodelConnector {
         ))
     }
 }
+
+impl Default for SqliteDatamodelConnector {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/libs/datamodel/core/src/transform/ast_to_dml/datasource_loader.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/datasource_loader.rs
@@ -203,7 +203,7 @@ impl DatasourceLoader {
 
         let combined_connector: Box<dyn Connector> = {
             let connectors = all_datasource_providers.iter().map(|sd| sd.connector()).collect();
-            CombinedConnector::new(connectors)
+            Box::new(CombinedConnector::new(connectors))
         };
 
         // The first provider that can handle the URL is used to construct the Datasource.

--- a/libs/prisma-value/src/lib.rs
+++ b/libs/prisma-value/src/lib.rs
@@ -86,7 +86,7 @@ impl TryFrom<serde_json::Value> for PrismaValue {
                     let date = DateTime::parse_from_rfc3339(value)
                         .map_err(|_| ConversionFailure::new("JSON date object", "PrismaValue"))?;
 
-                    Ok(PrismaValue::DateTime(date.into()))
+                    Ok(PrismaValue::DateTime(date))
                 }
                 _ => Ok(PrismaValue::Json(serde_json::to_string(&obj).unwrap())),
             },

--- a/libs/prisma-value/src/sql_ext.rs
+++ b/libs/prisma-value/src/sql_ext.rs
@@ -12,10 +12,12 @@ impl<'a> TryFrom<Value<'a>> for PrismaValue {
             Value::Integer(i) => i.map(PrismaValue::Int).unwrap_or(PrismaValue::Null),
 
             Value::Float(Some(f)) => match f {
-                f if f.is_nan() => Err(crate::ConversionFailure {
-                    from: "NaN",
-                    to: "BigDecimal",
-                })?,
+                f if f.is_nan() => {
+                    return Err(crate::ConversionFailure {
+                        from: "NaN",
+                        to: "BigDecimal",
+                    })
+                }
                 f if f.is_infinite() => Err(crate::ConversionFailure {
                     from: "Infinity",
                     to: "BigDecimal",


### PR DESCRIPTION
As I was poking at clippy last Thursday (resulting in https://github.com/prisma/prisma-engines/pull/1454) I ended up making a few changes that were out of scope for `query-engine`, but I did not realize at the time. I turns out that if you pass `-t query-engine` to clippy it will also lint the dependencies in the same monorepo.

So this PR includes a few changes that I applied, before realizing I was working through deps and moved onto investigating how to enable clippy in CI (which became: "disallow warnings in CI" + https://github.com/prisma/prisma-engines/issues/1453).

This prevents someone from having to write this code again in the future as part of #1389. Thanks!