### PR TITLE
disconnect must not error if there is no connected record

### DIFF
--- a/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/alreadyConverted/NestedDisconnectMutationInsideUpdateSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/alreadyConverted/NestedDisconnectMutationInsideUpdateSpec.scala
@@ -58,7 +58,7 @@ class NestedDisconnectMutationInsideUpdateSpec extends FlatSpec with Matchers wi
     }
   }
 
-  "a P1 to C1  relation with the child and the parent without a relation" should "not be disconnectable through a nested mutation by id" in {
+  "a P1 to C1 relation with the child and the parent without a relation" should "be disconnectable through a nested mutation by id" in {
     schemaWithRelation(onParent = ChildOpt, onChild = ParentOpt).test { t =>
       val project = SchemaDsl.fromStringV11() {
         t.datamodel
@@ -92,7 +92,7 @@ class NestedDisconnectMutationInsideUpdateSpec extends FlatSpec with Matchers wi
 
       val parentIdentifier = t.parent.where(parentResult, "data.createParent")
 
-      val res = server.queryThatMustFail(
+      val res = server.query(
         s"""
          |mutation {
          |  updateParent(
@@ -108,8 +108,6 @@ class NestedDisconnectMutationInsideUpdateSpec extends FlatSpec with Matchers wi
          |}
       """,
         project,
-        errorCode = 2017,
-        errorContains = """The records for relation `ChildToParent` between the `Parent` and `Child` models are not connected."""
       )
 
     }

--- a/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/alreadyConverted/NestedDisconnectMutationInsideUpsertSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/nestedMutations/alreadyConverted/NestedDisconnectMutationInsideUpsertSpec.scala
@@ -66,7 +66,7 @@ class NestedDisconnectMutationInsideUpsertSpec extends FlatSpec with Matchers wi
     }
   }
 
-  "a P1 to C1  relation with the child and the parent without a relation" should "not be disconnectable through a nested mutation by id" in {
+  "a P1 to C1  relation with the child and the parent without a relation" should "be disconnectable through a nested mutation by id" in {
     schemaWithRelation(onParent = ChildOpt, onChild = ParentOpt).test { t =>
       val project = SchemaDsl.fromStringV11() {
         t.datamodel
@@ -97,7 +97,7 @@ class NestedDisconnectMutationInsideUpsertSpec extends FlatSpec with Matchers wi
         )
       val parent1Id = t.parent.where(parent1Result, "data.createParent")
 
-      val res = server.queryThatMustFail(
+      val res = server.query(
         s"""mutation {
          |  upsertParent(
          |  where: $parent1Id
@@ -118,8 +118,6 @@ class NestedDisconnectMutationInsideUpsertSpec extends FlatSpec with Matchers wi
          |}
       """,
         project,
-        errorCode = 2017,
-        errorContains = """The records for relation `ChildToParent` between the `Parent` and `Child` models are not connected.""",
       )
 
     }

--- a/query-engine/core/src/query_graph_builder/write/nested/disconnect_nested.rs
+++ b/query-engine/core/src/query_graph_builder/write/nested/disconnect_nested.rs
@@ -227,13 +227,13 @@ fn handle_one_to_x(
         QueryGraphDependency::ParentProjection(
             extractor_model_id,
             Box::new(move |mut update_node, links| {
-                if links.is_empty() {
-                    return Err(QueryGraphBuilderError::RecordsNotConnected {
-                        relation_name,
-                        parent_name,
-                        child_name,
-                    });
-                }
+                //                if links.is_empty() {
+                //                    return Err(QueryGraphBuilderError::RecordsNotConnected {
+                //                        relation_name,
+                //                        parent_name,
+                //                        child_name,
+                //                    });
+                //                }
 
                 // Handle filter & arg injection
                 if let Node::Query(Query::Write(ref mut wq @ WriteQuery::UpdateManyRecords(_))) = update_node {
@@ -245,10 +245,6 @@ fn handle_one_to_x(
             }),
         ),
     )?;
-
-    let relation_name = parent_relation_field.relation().name.clone();
-    let parent_name = parent_relation_field.model().name.clone();
-    let child_name = parent_relation_field.related_model().name.clone();
 
     // Edge to check that IDs have been returned.
     graph.create_edge(


### PR DESCRIPTION
implements https://github.com/prisma/prisma/issues/3069

With this change `{ disconnect: true }` won't error anymore if there is no connected record. This applies only to 1:1 and 1:n relations where this syntax can be used on the side with the optional arity.