### PR TITLE
Another round of Clippy

### DIFF
--- a/libs/datamodel/core/src/common/string_helper.rs
+++ b/libs/datamodel/core/src/common/string_helper.rs
@@ -1,10 +1,11 @@
+#[derive(Debug, Default)]
 pub struct WritableString {
     inner: String,
 }
 
 impl WritableString {
     pub fn new() -> WritableString {
-        WritableString { inner: "".to_string() }
+        Default::default()
     }
 
     pub fn into(self) -> String {

--- a/libs/datamodel/core/src/diagnostics/collection.rs
+++ b/libs/datamodel/core/src/diagnostics/collection.rs
@@ -114,3 +114,9 @@ impl From<DatamodelWarning> for Diagnostics {
         col
     }
 }
+
+impl Default for Diagnostics {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/libs/datamodel/core/src/lib.rs
+++ b/libs/datamodel/core/src/lib.rs
@@ -279,7 +279,7 @@ pub fn render_schema_ast_to_string(schema: &SchemaAst) -> String {
 
 /// Renders as a string into the stream.
 pub fn render_datamodel_to(stream: &mut dyn std::io::Write, datamodel: &dml::Datamodel) {
-    let lowered = LowerDmlToAst::new(None, &vec![]).lower(datamodel);
+    let lowered = LowerDmlToAst::new(None, &[]).lower(datamodel);
     render_schema_ast_to(stream, &lowered, 2);
 }
 

--- a/libs/datamodel/core/src/transform/ast_to_dml/datasource_loader.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/datasource_loader.rs
@@ -229,6 +229,7 @@ impl DatasourceLoader {
         }
     }
 
+    #[allow(clippy::borrowed_box)]
     fn get_datasource_provider(&self, provider: &str) -> Option<&Box<dyn DatasourceProvider>> {
         self.source_definitions.iter().find(|sd| sd.is_provider(provider))
     }

--- a/libs/datamodel/core/src/transform/ast_to_dml/datasource_loader.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/datasource_loader.rs
@@ -242,3 +242,9 @@ fn get_builtin_datasource_providers() -> Vec<Box<dyn DatasourceProvider>> {
         Box::new(MsSqlDatasourceProvider::new()),
     ]
 }
+
+impl Default for DatasourceLoader {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/libs/datamodel/core/src/transform/ast_to_dml/lift.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/lift.rs
@@ -17,7 +17,7 @@ use itertools::Itertools;
 pub struct LiftAstToDml<'a, 'b> {
     attributes: AllAttributes,
     source: Option<&'a configuration::Datasource>,
-    generators: &'b Vec<configuration::Generator>,
+    generators: &'b [configuration::Generator],
 }
 
 impl<'a, 'b> LiftAstToDml<'a, 'b> {
@@ -27,7 +27,7 @@ impl<'a, 'b> LiftAstToDml<'a, 'b> {
     /// The attributes defined by the given sources will be namespaced.
     pub fn new(
         source: Option<&'a configuration::Datasource>,
-        generators: &'b Vec<configuration::Generator>,
+        generators: &'b [configuration::Generator],
     ) -> LiftAstToDml<'a, 'b> {
         LiftAstToDml {
             attributes: AllAttributes::new(),

--- a/libs/datamodel/core/src/transform/ast_to_dml/reserved_model_names.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/reserved_model_names.rs
@@ -65,3 +65,9 @@ impl TypeNameValidator {
         self.reserved_names.contains(&name.as_ref())
     }
 }
+
+impl Default for TypeNameValidator {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/libs/datamodel/core/src/transform/ast_to_dml/validate.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validate.rs
@@ -942,9 +942,8 @@ impl<'a> Validator<'a> {
                     }
                 }
 
-                if !errors.has_errors() {
-                    if field.is_required() && !related_field_rel_info.references.is_empty() {
-                        errors.push_error(DatamodelError::new_attribute_validation_error(
+                if !errors.has_errors() && field.is_required() && !related_field_rel_info.references.is_empty() {
+                    errors.push_error(DatamodelError::new_attribute_validation_error(
                             &format!(
                                 "The relation field `{}` on Model `{}` is required. This is no longer valid because it's not possible to enforce this constraint on the database level. Please change the field type from `{}` to `{}?` to fix this.",
                                 &field.name, &model.name, &related_model.name, &related_model.name,
@@ -952,7 +951,6 @@ impl<'a> Validator<'a> {
                             RELATION_ATTRIBUTE_NAME,
                             field_span,
                         ));
-                    }
                 }
             }
 

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline.rs
@@ -12,7 +12,7 @@ pub struct ValidationPipeline<'a, 'b> {
 impl<'a, 'b> ValidationPipeline<'a, 'b> {
     pub fn new(
         sources: &'a [configuration::Datasource],
-        generators: &'b Vec<configuration::Generator>,
+        generators: &'b [configuration::Generator],
     ) -> ValidationPipeline<'a, 'b> {
         let source = sources.first();
         ValidationPipeline {

--- a/libs/datamodel/core/src/transform/dml_to_ast/lower.rs
+++ b/libs/datamodel/core/src/transform/dml_to_ast/lower.rs
@@ -7,12 +7,12 @@ use crate::{ast, dml, Datasource, Generator};
 pub struct LowerDmlToAst<'a> {
     attributes: AllAttributes,
     datasource: Option<&'a Datasource>,
-    generators: &'a Vec<Generator>,
+    generators: &'a [Generator],
 }
 
 impl<'a> LowerDmlToAst<'a> {
     /// Creates a new instance, with all builtin attributes registered.
-    pub fn new(datasource: Option<&'a Datasource>, generators: &'a Vec<Generator>) -> Self {
+    pub fn new(datasource: Option<&'a Datasource>, generators: &'a [Generator]) -> Self {
         Self {
             attributes: AllAttributes::new(),
             datasource,

--- a/libs/datamodel/core/tests/attributes/default_positive.rs
+++ b/libs/datamodel/core/tests/attributes/default_positive.rs
@@ -10,7 +10,7 @@ fn should_set_default_for_all_scalar_types() {
     model Model {
         id Int @id
         int Int @default(3)
-        float Float @default(3.14)
+        float Float @default(3.20)
         string String @default("String")
         boolean Boolean @default(false)
         dateTime DateTime @default("2019-06-17T14:20:57Z")
@@ -27,7 +27,7 @@ fn should_set_default_for_all_scalar_types() {
         .assert_has_scalar_field("float")
         .assert_base_type(&ScalarType::Float)
         .assert_default_value(DefaultValue::Single(PrismaValue::Float(
-            BigDecimal::from_f64(3.14).unwrap(),
+            BigDecimal::from_f64(3.20).unwrap(),
         )));
 
     user_model

--- a/libs/datamodel/core/tests/common.rs
+++ b/libs/datamodel/core/tests/common.rs
@@ -256,7 +256,7 @@ impl ModelAsserts for dml::Model {
 impl EnumAsserts for dml::Enum {
     fn assert_has_value(&self, t: &str) -> &dml::EnumValue {
         self.values()
-            .find(|x| *x.name == t.to_owned())
+            .find(|x| x.name == t)
             .unwrap_or_else(|| panic!("Enum Value {} not found", t))
     }
 

--- a/libs/datamodel/core/tests/renderer/literals.rs
+++ b/libs/datamodel/core/tests/renderer/literals.rs
@@ -46,7 +46,7 @@ fn strings_with_quotes_roundtrip() {
     let dml = datamodel::parse_datamodel(input).unwrap().subject;
     let rendered = datamodel::render_datamodel_to_string(&dml);
 
-    assert_eq!(input, rendered);
+    assert_eq!(rendered, input);
 }
 
 #[test]
@@ -94,7 +94,7 @@ fn strings_with_newlines_roundtrip() {
     let dml = datamodel::parse_datamodel(input).unwrap().subject;
     let rendered = datamodel::render_datamodel_to_string(&dml);
 
-    assert_eq!(input, rendered);
+    assert_eq!(rendered, input);
 }
 
 #[test]
@@ -111,7 +111,7 @@ fn strings_with_backslashes_roundtrip() {
     let dml = datamodel::parse_datamodel(input).unwrap().subject;
     let rendered = datamodel::render_datamodel_to_string(&dml);
 
-    assert_eq!(input, rendered);
+    assert_eq!(rendered, input);
 }
 
 #[test]
@@ -128,7 +128,7 @@ fn strings_with_multiple_escaped_characters_roundtrip() {
     let dml = datamodel::parse_datamodel(dm).unwrap().subject;
     let rendered = datamodel::render_datamodel_to_string(&dml);
 
-    assert_eq!(dm, rendered);
+    assert_eq!(rendered, dm);
 }
 
 #[test]
@@ -158,5 +158,5 @@ fn internal_escaped_values_are_rendered_correctly() {
 
     let rendered = datamodel::render_datamodel_to_string(&dml);
 
-    assert_eq!(expected_dm, rendered);
+    assert_eq!(rendered, expected_dm);
 }

--- a/libs/datamodel/core/tests/types/mysql_native_types.rs
+++ b/libs/datamodel/core/tests/types/mysql_native_types.rs
@@ -5,8 +5,8 @@ use crate::types::helper::{
 };
 use datamodel::{ast, diagnostics::DatamodelError};
 
-const BLOB_TYPES: &[&'static str] = &["Blob", "LongBlob", "MediumBlob", "TinyBlob"];
-const TEXT_TYPES: &[&'static str] = &["Text", "LongText", "MediumText", "TinyText"];
+const BLOB_TYPES: &[&str] = &["Blob", "LongBlob", "MediumBlob", "TinyBlob"];
+const TEXT_TYPES: &[&str] = &["Text", "LongText", "MediumText", "TinyText"];
 
 #[test]
 fn text_and_blob_data_types_should_fail_on_index() {

--- a/libs/prisma-value/src/sql_ext.rs
+++ b/libs/prisma-value/src/sql_ext.rs
@@ -18,24 +18,30 @@ impl<'a> TryFrom<Value<'a>> for PrismaValue {
                         to: "BigDecimal",
                     })
                 }
-                f if f.is_infinite() => Err(crate::ConversionFailure {
-                    from: "Infinity",
-                    to: "BigDecimal",
-                })?,
+                f if f.is_infinite() => {
+                    return Err(crate::ConversionFailure {
+                        from: "Infinity",
+                        to: "BigDecimal",
+                    })
+                }
                 _ => PrismaValue::Float(BigDecimal::from_f32(f).unwrap().normalized()),
             },
 
             Value::Float(None) => PrismaValue::Null,
 
             Value::Double(Some(f)) => match f {
-                f if f.is_nan() => Err(crate::ConversionFailure {
-                    from: "NaN",
-                    to: "BigDecimal",
-                })?,
-                f if f.is_infinite() => Err(crate::ConversionFailure {
-                    from: "Infinity",
-                    to: "BigDecimal",
-                })?,
+                f if f.is_nan() => {
+                    return Err(crate::ConversionFailure {
+                        from: "NaN",
+                        to: "BigDecimal",
+                    })
+                }
+                f if f.is_infinite() => {
+                    return Err(crate::ConversionFailure {
+                        from: "Infinity",
+                        to: "BigDecimal",
+                    })
+                }
                 _ => PrismaValue::Float(BigDecimal::from_f64(f).unwrap().normalized()),
             },
 

--- a/migration-engine/migration-engine-tests/tests/diagnose_migration_history/diagnose_migration_history_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/diagnose_migration_history/diagnose_migration_history_tests.rs
@@ -735,7 +735,7 @@ async fn with_an_invalid_unapplied_migration_should_report_it(api: &TestApi) -> 
     assert!(edited_migration_names.is_empty());
     assert!(failed_migration_names.is_empty());
     assert!(
-        matches!(history, Some(HistoryDiagnostic::DatabaseIsBehind { unapplied_migration_names: names }) if names == &[generated_migration_name.unwrap()])
+        matches!(history, Some(HistoryDiagnostic::DatabaseIsBehind { unapplied_migration_names: names }) if names == [generated_migration_name.unwrap()])
     );
     assert!(drift.is_none());
 

--- a/migration-engine/migration-engine-tests/tests/errors/error_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/errors/error_tests.rs
@@ -318,7 +318,7 @@ async fn datamodel_parser_errors_must_return_a_known_error(api: &TestApi) {
     let expected_msg = "\u{1b}[1;91merror\u{1b}[0m: \u{1b}[1mType \"Post\" is neither a built-in type, nor refers to another model, custom type, or enum.\u{1b}[0m\n  \u{1b}[1;94m-->\u{1b}[0m  \u{1b}[4mschema.prisma:4\u{1b}[0m\n\u{1b}[1;94m   | \u{1b}[0m\n\u{1b}[1;94m 3 | \u{1b}[0m            id Float @id\n\u{1b}[1;94m 4 | \u{1b}[0m            post \u{1b}[1;91mPost[]\u{1b}[0m\n\u{1b}[1;94m   | \u{1b}[0m\n";
 
     let expected_error = user_facing_errors::Error::from(user_facing_errors::KnownError {
-        error_code: "P1012".into(),
+        error_code: "P1012",
         message: expected_msg.into(),
         meta: serde_json::json!({ "full_error": expected_msg }),
     });

--- a/migration-engine/migration-engine-tests/tests/errors/error_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/errors/error_tests.rs
@@ -259,7 +259,7 @@ async fn bad_datasource_url_and_provider_combinations_must_return_a_proper_error
 
     let expected = json!({
         "is_panic": false,
-        "message": err_message.clone(),
+        "message": err_message,
         "meta": {
             "full_error": err_message,
         },

--- a/migration-engine/migration-engine-tests/tests/existing_data/sql_unexecutable_migrations/added_unimplementable_unique_constraint.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_data/sql_unexecutable_migrations/added_unimplementable_unique_constraint.rs
@@ -40,23 +40,13 @@ async fn adding_a_unique_constraint_should_warn(api: &TestApi) -> TestResult {
 
     let rows = api.select("Test").column("id").column("name").send_debug().await?;
 
-    if api.is_mysql() {
-        assert_eq!(
-            rows,
-            &[
-                &[r#"Text(Some("abc"))"#, r#"Text(Some("george"))"#],
-                &[r#"Text(Some("def"))"#, r#"Text(Some("george"))"#]
-            ]
-        );
-    } else {
-        assert_eq!(
-            rows,
-            &[
-                &[r#"Text(Some("abc"))"#, r#"Text(Some("george"))"#],
-                &[r#"Text(Some("def"))"#, r#"Text(Some("george"))"#]
-            ]
-        );
-    }
+    assert_eq!(
+        rows,
+        &[
+            &[r#"Text(Some("abc"))"#, r#"Text(Some("george"))"#],
+            &[r#"Text(Some("def"))"#, r#"Text(Some("george"))"#]
+        ]
+    );
 
     Ok(())
 }

--- a/migration-engine/migration-engine-tests/tests/existing_databases/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_databases/mod.rs
@@ -131,7 +131,7 @@ async fn creating_a_field_for_an_existing_column_and_changing_its_type_must_work
     assert_eq!(column.tpe.family, ColumnTypeFamily::String);
     assert!(column.is_required());
 
-    let index = table.indices.iter().find(|i| i.columns == &["title"]);
+    let index = table.indices.iter().find(|i| i.columns == ["title"]);
 
     assert!(index.is_some());
     assert_eq!(index.unwrap().tpe, IndexType::Unique);

--- a/migration-engine/migration-engine-tests/tests/migration_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migration_tests.rs
@@ -473,7 +473,7 @@ async fn making_an_existing_id_field_autoincrement_works_with_foreign_keys(api: 
     })?;
 
     // Data to see we don't lose anything in the translation.
-    for (i, content) in (&["A", "B", "C"]).into_iter().enumerate() {
+    for (i, content) in (&["A", "B", "C"]).iter().enumerate() {
         let insert = Insert::single_into(api.render_table_name("Author"));
 
         let author_id = api

--- a/migration-engine/migration-engine-tests/tests/migration_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migration_tests.rs
@@ -247,7 +247,7 @@ async fn making_an_existing_id_field_autoincrement_works(api: &TestApi) -> TestR
     // MySQL cannot add autoincrement property to a column that already has data.
     if !api.sql_family().is_mysql() {
         // Data to see we don't lose anything in the translation.
-        for (i, content) in (&["A", "B", "C"]).into_iter().enumerate() {
+        for (i, content) in (&["A", "B", "C"]).iter().enumerate() {
             let insert = Insert::single_into(api.render_table_name("Post"))
                 .value("content", *content)
                 .value("id", i);
@@ -392,7 +392,7 @@ async fn making_an_existing_id_field_autoincrement_works_with_indices(api: &Test
     })?;
 
     // Data to see we don't lose anything in the translation.
-    for (i, content) in (&["A", "B", "C"]).into_iter().enumerate() {
+    for (i, content) in (&["A", "B", "C"]).iter().enumerate() {
         let insert = Insert::single_into(api.render_table_name("Post"))
             .value("content", *content)
             .value("id", i);
@@ -1397,8 +1397,7 @@ async fn unique_in_conjunction_with_custom_column_name_must_work(api: &TestApi) 
         .table_bang("A")
         .indices
         .iter()
-        .find(|i| i.columns == &["custom_field_name"]);
-
+        .find(|i| i.columns == ["custom_field_name"]);
     assert!(index.is_some());
     assert_eq!(index.unwrap().tpe, IndexType::Unique);
 
@@ -1425,7 +1424,7 @@ async fn multi_column_unique_in_conjunction_with_custom_column_name_must_work(ap
         .table_bang("A")
         .indices
         .iter()
-        .find(|i| i.columns == &["custom_field_name", "second_custom_field_name"]);
+        .find(|i| i.columns == ["custom_field_name", "second_custom_field_name"]);
     assert!(index.is_some());
     assert_eq!(index.unwrap().tpe, IndexType::Unique);
 
@@ -1526,7 +1525,7 @@ async fn removing_unique_from_an_existing_field_must_work(api: &TestApi) -> Test
 
     let result = api.describe_database().await?;
 
-    let index = result.table_bang("A").indices.iter().find(|i| i.columns == &["field"]);
+    let index = result.table_bang("A").indices.iter().find(|i| i.columns == ["field"]);
     assert!(index.is_some());
     assert_eq!(index.unwrap().tpe, IndexType::Unique);
 
@@ -1541,7 +1540,7 @@ async fn removing_unique_from_an_existing_field_must_work(api: &TestApi) -> Test
 
     let result = api.describe_database().await?;
 
-    let index = result.table_bang("A").indices.iter().find(|i| i.columns == &["field"]);
+    let index = result.table_bang("A").indices.iter().find(|i| i.columns == ["field"]);
     assert!(index.is_none());
 
     Ok(())

--- a/migration-engine/migration-engine-tests/tests/migrations/indexes.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/indexes.rs
@@ -197,7 +197,7 @@ async fn removing_multi_field_unique_index_must_work(api: &TestApi) -> TestResul
         .table_bang("A")
         .indices
         .iter()
-        .find(|i| i.columns == &["field", "secondField"]);
+        .find(|i| i.columns == ["field", "secondField"]);
     assert!(index.is_some());
     assert_eq!(index.unwrap().tpe, IndexType::Unique);
 
@@ -215,7 +215,7 @@ async fn removing_multi_field_unique_index_must_work(api: &TestApi) -> TestResul
         .table_bang("A")
         .indices
         .iter()
-        .find(|i| i.columns == &["field", "secondField"]);
+        .find(|i| i.columns == ["field", "secondField"]);
     assert!(index.is_none());
 
     Ok(())
@@ -315,7 +315,7 @@ async fn index_renaming_must_work_when_renaming_to_default(api: &TestApi) -> Tes
         .table_bang("A")
         .indices
         .iter()
-        .filter(|i| i.columns == &["field", "secondField"] && i.name == "A.field_secondField_unique");
+        .filter(|i| i.columns == ["field", "secondField"] && i.name == "A.field_secondField_unique");
     assert_eq!(indexes.count(), 1);
 
     Ok(())
@@ -384,7 +384,7 @@ async fn index_updates_with_rename_must_work(api: &TestApi) -> TestResult {
         .table_bang("A")
         .indices
         .iter()
-        .find(|i| i.name == "customName" && i.columns == &["field", "secondField"]);
+        .find(|i| i.name == "customName" && i.columns == ["field", "secondField"]);
     assert!(index.is_some());
     assert_eq!(index.unwrap().tpe, IndexType::Unique);
 
@@ -406,7 +406,7 @@ async fn index_updates_with_rename_must_work(api: &TestApi) -> TestResult {
         .table_bang("A")
         .indices
         .iter()
-        .filter(|i| i.columns == &["field", "id"] && i.name == "customNameA");
+        .filter(|i| i.columns == ["field", "id"] && i.name == "customNameA");
     assert_eq!(indexes.count(), 1);
 
     Ok(())
@@ -432,8 +432,7 @@ async fn dropping_a_model_with_a_multi_field_unique_index_must_work(api: &TestAp
         .table_bang("A")
         .indices
         .iter()
-        .find(|i| i.name == "customName" && i.columns == &["field", "secondField"]);
-
+        .find(|i| i.name == "customName" && i.columns == ["field", "secondField"]);
     assert!(index.is_some());
     assert_eq!(index.unwrap().tpe, IndexType::Unique);
 

--- a/migration-engine/migration-engine-tests/tests/migrations/squashing_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/squashing_tests.rs
@@ -35,19 +35,17 @@ async fn squashing_whole_migration_history_works(api: &TestApi) -> TestResult {
             }
         "#;
 
-        let mut migrations_counter: i32 = 0;
         let mut initial_migration_names: Vec<String> = Vec::with_capacity(3);
 
-        for schema in &[dm1, dm2, dm3] {
+        for (i, schema) in [dm1, dm2, dm3].iter().enumerate() {
             let name = api
-                .create_migration(&format!("migration{}", migrations_counter), schema, &directory)
+                .create_migration(&format!("migration{}", i), schema, &directory)
                 .send()
                 .await?
                 .into_output()
                 .generated_migration_name
                 .unwrap();
 
-            migrations_counter += 1;
             initial_migration_names.push(name);
         }
 
@@ -238,19 +236,17 @@ async fn squashing_migrations_history_at_the_start_works(api: &TestApi) -> TestR
             }
         "#;
 
-        let mut migrations_counter: i32 = 0;
         let mut initial_migration_names: Vec<String> = Vec::with_capacity(3);
 
-        for schema in &[dm1, dm2, dm3] {
+        for (i, schema) in [dm1, dm2, dm3].iter().enumerate() {
             let name = api
-                .create_migration(&format!("migration{}", migrations_counter), schema, &directory)
+                .create_migration(&format!("migration{}", i), schema, &directory)
                 .send()
                 .await?
                 .into_output()
                 .generated_migration_name
                 .unwrap();
 
-            migrations_counter += 1;
             initial_migration_names.push(name);
         }
 
@@ -399,19 +395,17 @@ async fn squashing_migrations_history_at_the_end_works(api: &TestApi) -> TestRes
             }
         "#;
 
-        let mut migrations_counter: i32 = 0;
         let mut initial_migration_names: Vec<String> = Vec::with_capacity(3);
 
-        for schema in &[dm1, dm2, dm3] {
+        for (i, schema) in [dm1, dm2, dm3].iter().enumerate() {
             let name = api
-                .create_migration(&format!("migration{}", migrations_counter), schema, &directory)
+                .create_migration(&format!("migration{}", i), schema, &directory)
                 .send()
                 .await?
                 .into_output()
                 .generated_migration_name
                 .unwrap();
 
-            migrations_counter += 1;
             initial_migration_names.push(name);
         }
 

--- a/query-engine/connectors/query-connector/src/query_arguments.rs
+++ b/query-engine/connectors/query-connector/src/query_arguments.rs
@@ -91,7 +91,7 @@ impl QueryArguments {
     }
 
     pub fn take_abs(&self) -> Option<i64> {
-        self.take.clone().map(|t| if t < 0 { t * -1 } else { t })
+        self.take.clone().map(|t| if t < 0 { -t } else { t })
     }
 
     pub fn can_batch(&self) -> bool {

--- a/query-engine/connectors/sql-query-connector/src/database/operations/read.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/read.rs
@@ -165,7 +165,7 @@ pub async fn aggregate(
     group_by: Vec<ScalarFieldRef>,
     having: Option<Filter>,
 ) -> crate::Result<Vec<AggregationRow>> {
-    if group_by.len() > 0 {
+    if !group_by.is_empty() {
         group_by_aggregate(conn, model, query_arguments, selections, group_by, having).await
     } else {
         plain_aggregate(conn, model, query_arguments, selections)

--- a/query-engine/connectors/sql-query-connector/src/database/transaction.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/transaction.rs
@@ -15,7 +15,7 @@ pub struct SqlConnectorTransaction<'tx> {
 }
 
 impl<'tx> SqlConnectorTransaction<'tx> {
-    pub fn new<'b: 'tx>(tx: quaint::connector::Transaction<'tx>, connection_info: &ConnectionInfo) -> Self {
+    pub fn new(tx: quaint::connector::Transaction<'tx>, connection_info: &ConnectionInfo) -> Self {
         let connection_info = connection_info.clone();
         Self {
             inner: tx,

--- a/query-engine/connectors/sql-query-connector/src/query_builder/write.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_builder/write.rs
@@ -47,7 +47,7 @@ pub fn update_many(model: &ModelRef, ids: &[&RecordProjection], args: WriteArgs)
             let DatasourceFieldName(name) = field_name;
             let field = scalar_fields
                 .iter()
-                .find(|f| f.db_name() == &name)
+                .find(|f| f.db_name() == name)
                 .expect("Expected field to be valid");
 
             let value: Expression = match val {

--- a/query-engine/connectors/sql-query-connector/src/row.rs
+++ b/query-engine/connectors/sql-query-connector/src/row.rs
@@ -100,7 +100,11 @@ pub trait ToSqlRow {
     /// Conversion from a database specific row to an allocated `SqlRow`. To
     /// help deciding the right types, the provided `ColumnMetadata`s should map
     /// to the returned columns in the right order.
+<<<<<<< HEAD
     fn to_sql_row<'b>(self, meta: &[ColumnMetadata<'_>]) -> crate::Result<SqlRow>;
+=======
+    fn to_sql_row(self, idents: &[(TypeIdentifier, FieldArity)]) -> crate::Result<SqlRow>;
+>>>>>>> a1838fbed... clipppy pass II
 }
 
 impl ToSqlRow for ResultRow {

--- a/query-engine/connectors/sql-query-connector/src/row.rs
+++ b/query-engine/connectors/sql-query-connector/src/row.rs
@@ -100,11 +100,7 @@ pub trait ToSqlRow {
     /// Conversion from a database specific row to an allocated `SqlRow`. To
     /// help deciding the right types, the provided `ColumnMetadata`s should map
     /// to the returned columns in the right order.
-<<<<<<< HEAD
     fn to_sql_row<'b>(self, meta: &[ColumnMetadata<'_>]) -> crate::Result<SqlRow>;
-=======
-    fn to_sql_row(self, idents: &[(TypeIdentifier, FieldArity)]) -> crate::Result<SqlRow>;
->>>>>>> a1838fbed... clipppy pass II
 }
 
 impl ToSqlRow for ResultRow {

--- a/query-engine/core/src/interpreter/expression.rs
+++ b/query-engine/core/src/interpreter/expression.rs
@@ -34,7 +34,7 @@ pub enum Expression {
     },
 
     Return {
-        result: ExpressionResult,
+        result: Box<ExpressionResult>,
     },
 }
 
@@ -47,5 +47,10 @@ impl Expression {
     /// Construct a new instance from a `Query`.
     pub fn from_query(query: Query) -> Self {
         Self::Query { query: Box::new(query) }
+    }
+
+    /// Construct a new instance from an `ExpressionResult`.
+    pub fn from_expression_result(res: ExpressionResult) -> Self {
+        Self::Return { result: Box::new(res) }
     }
 }

--- a/query-engine/core/src/interpreter/expression.rs
+++ b/query-engine/core/src/interpreter/expression.rs
@@ -11,7 +11,7 @@ pub enum Expression {
     },
 
     Query {
-        query: Query,
+        query: Box<Query>,
     },
 
     Let {
@@ -41,4 +41,11 @@ pub enum Expression {
 pub struct Binding {
     pub name: String,
     pub expr: Expression,
+}
+
+impl Expression {
+    /// Construct a new instance from a `Query`.
+    pub fn from_query(query: Query) -> Self {
+        Self::Query { query: Box::new(query) }
+    }
 }

--- a/query-engine/core/src/interpreter/expressionista.rs
+++ b/query-engine/core/src/interpreter/expressionista.rs
@@ -1,7 +1,7 @@
 use super::{
     expression::*, ComputationResult, DiffResult, Env, ExpressionResult, InterpretationResult, InterpreterError,
 };
-use crate::{query_graph::*, Query};
+use crate::query_graph::*;
 use prisma_models::RecordProjection;
 use std::{collections::VecDeque, convert::TryInto};
 
@@ -56,10 +56,7 @@ impl Expressionista {
         let is_result = graph.is_result_node(&node);
         let node_id = node.id();
         let node = graph.pluck_node(&node);
-        let into_expr = Box::new(|node: Node| {
-            let query: Query = node.try_into()?;
-            Ok(Expression::Query { query })
-        });
+        let into_expr = Box::new(|node: Node| Ok(Expression::from_query(node.try_into()?)));
 
         let expr = Self::transform_node(graph, parent_edges, node, into_expr)?;
 

--- a/query-engine/core/src/interpreter/expressionista.rs
+++ b/query-engine/core/src/interpreter/expressionista.rs
@@ -168,12 +168,12 @@ impl Expressionista {
                         let left_diff: Vec<&RecordProjection> = left.difference(&right).collect();
                         let right_diff: Vec<&RecordProjection> = right.difference(&left).collect();
 
-                        Ok(Expression::Return {
-                            result: ExpressionResult::Computation(ComputationResult::Diff(DiffResult {
+                        Ok(Expression::from_expression_result(ExpressionResult::Computation(
+                            ComputationResult::Diff(DiffResult {
                                 left: left_diff.into_iter().map(Clone::clone).collect(),
                                 right: right_diff.into_iter().map(Clone::clone).collect(),
-                            })),
-                        })
+                            }),
+                        )))
                     }
                     _ => unreachable!(),
                 }),
@@ -290,8 +290,7 @@ impl Expressionista {
                     Some(r) => ExpressionResult::RawProjections(r),
                     None => ExpressionResult::Empty,
                 };
-
-                Ok(Expression::Return { result })
+                Ok(Expression::from_expression_result(result))
             } else {
                 unreachable!()
             }

--- a/query-engine/core/src/interpreter/formatters.rs
+++ b/query-engine/core/src/interpreter/formatters.rs
@@ -9,7 +9,7 @@ pub fn format_expression(expr: &Expression, indent: usize) -> String {
             .collect::<Vec<String>>()
             .join("\n"),
 
-        Expression::Query { query } => match query {
+        Expression::Query { query } => match &**query {
             Query::Read(rq) => add_indent(indent, format!("{}", rq)),
             Query::Write(wq) => add_indent(indent, format!("{}", wq)),
         },

--- a/query-engine/core/src/interpreter/interpreter.rs
+++ b/query-engine/core/src/interpreter/interpreter.rs
@@ -202,7 +202,7 @@ where
 
             Expression::Query { query } => {
                 let fut = async move {
-                    match query {
+                    match *query {
                         Query::Read(read) => {
                             self.log_line(level, || format!("READ {}", read));
                             Ok(read::execute(&self.conn, read, None)

--- a/query-engine/core/src/interpreter/interpreter.rs
+++ b/query-engine/core/src/interpreter/interpreter.rs
@@ -68,10 +68,9 @@ impl ExpressionResult {
             _ => None,
         };
 
-        converted.ok_or(InterpreterError::InterpretationError(
-            "Unable to convert result into a set of projections".to_owned(),
-            None,
-        ))
+        converted.ok_or_else(|| {
+            InterpreterError::InterpretationError("Unable to convert result into a set of projections".to_owned(), None)
+        })
     }
 
     pub fn as_query_result(&self) -> InterpretationResult<&QueryResult> {
@@ -80,10 +79,9 @@ impl ExpressionResult {
             _ => None,
         };
 
-        converted.ok_or(InterpreterError::InterpretationError(
-            "Unable to convert result into a query result".to_owned(),
-            None,
-        ))
+        converted.ok_or_else(|| {
+            InterpreterError::InterpretationError("Unable to convert result into a query result".to_owned(), None)
+        })
     }
 
     pub fn as_diff_result(&self) -> InterpretationResult<&DiffResult> {
@@ -92,10 +90,9 @@ impl ExpressionResult {
             _ => None,
         };
 
-        converted.ok_or(InterpreterError::InterpretationError(
-            "Unable to convert result into a computation result".to_owned(),
-            None,
-        ))
+        converted.ok_or_else(|| {
+            InterpreterError::InterpretationError("Unable to convert result into a computation result".to_owned(), None)
+        })
     }
 }
 

--- a/query-engine/core/src/interpreter/interpreter.rs
+++ b/query-engine/core/src/interpreter/interpreter.rs
@@ -261,7 +261,7 @@ where
 
             Expression::Return { result } => async move {
                 self.log_line(level, || "RETURN");
-                Ok(result)
+                Ok(*result)
             }
             .boxed(),
         }

--- a/query-engine/core/src/interpreter/query_interpreters/inmemory_record_processor.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/inmemory_record_processor.rs
@@ -31,7 +31,7 @@ impl InMemoryRecordProcessor {
     }
 
     fn take_abs(&self) -> Option<i64> {
-        self.take.clone().map(|t| if t < 0 { t * -1 } else { t })
+        self.take.clone().map(|t| if t < 0 { -t } else { t })
     }
 
     /// Checks whether or not we need to take records going backwards in the record list,

--- a/query-engine/core/src/query_document/parser.rs
+++ b/query-engine/core/src/query_document/parser.rs
@@ -447,7 +447,7 @@ impl QueryDocumentParser {
                 })?;
 
                 let path = path.add(field.name.clone());
-                let parsed = Self::parse_input_value(path.clone(), v, &field.field_types)?;
+                let parsed = Self::parse_input_value(path, v, &field.field_types)?;
 
                 Ok((k, parsed))
             })

--- a/query-engine/core/src/query_document/query_value.rs
+++ b/query-engine/core/src/query_document/query_value.rs
@@ -3,7 +3,7 @@ use indexmap::IndexMap;
 use prisma_value::{stringify_date, PrismaValue};
 use std::hash::Hash;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Eq)]
 pub enum QueryValue {
     Int(i64),
     Float(BigDecimal),
@@ -13,6 +13,12 @@ pub enum QueryValue {
     Enum(String),
     List(Vec<QueryValue>),
     Object(IndexMap<String, QueryValue>),
+}
+
+impl PartialEq for QueryValue {
+    fn eq(&self, other: &Self) -> bool {
+        self == other
+    }
 }
 
 impl Hash for QueryValue {

--- a/query-engine/core/src/query_graph/mod.rs
+++ b/query-engine/core/src/query_graph/mod.rs
@@ -263,7 +263,7 @@ impl QueryGraph {
 
         graph
             .node_indices()
-            .filter(|ix| graph.edges_directed(*ix, Direction::Incoming).next().is_some())
+            .filter(|ix| !graph.edges_directed(*ix, Direction::Incoming).next().is_some())
             .map(|node_ix: NodeIndex| NodeRef { node_ix })
             .collect()
     }

--- a/query-engine/core/src/query_graph/mod.rs
+++ b/query-engine/core/src/query_graph/mod.rs
@@ -250,14 +250,10 @@ impl QueryGraph {
     /// Checks if the subgraph starting at the given node contains the node designated as the overall result.
     pub fn subgraph_contains_result(&self, node: &NodeRef) -> bool {
         self.is_result_node(node)
-            || self
-                .outgoing_edges(node)
-                .into_iter()
-                .find(|edge| {
-                    let child_node = self.edge_target(edge);
-                    self.subgraph_contains_result(&child_node)
-                })
-                .is_some()
+            || self.outgoing_edges(node).into_iter().any(|edge| {
+                let child_node = self.edge_target(&edge);
+                self.subgraph_contains_result(&child_node)
+            })
     }
 
     /// Returns all root nodes of the graph.

--- a/query-engine/core/src/query_graph/mod.rs
+++ b/query-engine/core/src/query_graph/mod.rs
@@ -263,13 +263,7 @@ impl QueryGraph {
 
         graph
             .node_indices()
-            .filter_map(|ix| {
-                if graph.edges_directed(ix, Direction::Incoming).next().is_some() {
-                    None
-                } else {
-                    Some(ix)
-                }
-            })
+            .filter(|ix| graph.edges_directed(*ix, Direction::Incoming).next().is_some())
             .map(|node_ix: NodeIndex| NodeRef { node_ix })
             .collect()
     }

--- a/query-engine/core/src/query_graph_builder/extractors/filters/mod.rs
+++ b/query-engine/core/src/query_graph_builder/extractors/filters/mod.rs
@@ -24,10 +24,12 @@ pub fn extract_unique_filter(value_map: ParsedInputMap, model: &ModelRef) -> Que
                     Ok(field.equals(value))
                 }
                 Err(_) => utils::resolve_compound_field(&field_name, &model)
-                    .ok_or(QueryGraphBuilderError::AssertionError(format!(
-                        "Unable to resolve field {} to a field or set of scalar fields on model {}",
-                        field_name, model.name
-                    )))
+                    .ok_or_else(|| {
+                        QueryGraphBuilderError::AssertionError(format!(
+                            "Unable to resolve field {} to a field or set of scalar fields on model {}",
+                            field_name, model.name
+                        ))
+                    })
                     .and_then(|fields| handle_compound_field(fields, value)),
             }
         })

--- a/query-engine/core/src/query_graph_builder/extractors/utils.rs
+++ b/query-engine/core/src/query_graph_builder/extractors/utils.rs
@@ -24,6 +24,6 @@ pub fn resolve_index_fields(name: &str, model: &ModelRef) -> Option<Vec<ScalarFi
     model
         .unique_indexes()
         .into_iter()
-        .find(|index| &schema_builder::compound_index_field_name(index) == name)
+        .find(|index| schema_builder::compound_index_field_name(index) == name)
         .map(|index| index.fields())
 }

--- a/query-engine/core/src/query_graph_builder/read/utils.rs
+++ b/query-engine/core/src/query_graph_builder/read/utils.rs
@@ -70,7 +70,7 @@ pub fn merge_relation_selections(
     };
 
     let nested: Vec<_> = nested_queries
-        .into_iter()
+        .iter()
         .map(|nested_query| {
             if let ReadQuery::RelatedRecordsQuery(ref rq) = nested_query {
                 rq.parent_field.linking_fields()
@@ -87,7 +87,7 @@ pub fn merge_relation_selections(
 /// Necessary for post-processing of unstable orderings with cursor operations.
 pub fn merge_cursor_fields(selected_fields: ModelProjection, cursor: &Option<RecordProjection>) -> ModelProjection {
     match cursor {
-        Some(cursor) => selected_fields.clone().merge(cursor.into()),
+        Some(cursor) => selected_fields.merge(cursor.into()),
         None => selected_fields,
     }
 }

--- a/query-engine/core/src/query_graph_builder/write/utils.rs
+++ b/query-engine/core/src/query_graph_builder/write/utils.rs
@@ -49,15 +49,12 @@ where
 fn get_selected_fields(model: &ModelRef, projection: ModelProjection) -> ModelProjection {
     // Always fetch the primary identifier as well.
     let primary_model_id = model.primary_identifier();
-    let mismatches = projection != primary_model_id;
 
-    let projection = if mismatches {
+    if projection != primary_model_id {
         primary_model_id.merge(projection)
     } else {
         projection
-    };
-
-    projection
+    }
 }
 
 /// Adds a read query to the query graph that finds related records by parent ID.

--- a/query-engine/core/src/schema/enum_type.rs
+++ b/query-engine/core/src/schema/enum_type.rs
@@ -73,18 +73,18 @@ pub struct DatabaseEnumType {
 }
 
 impl DatabaseEnumType {
-    pub fn map_input_value(&self, val: &String) -> Option<PrismaValue> {
+    pub fn map_input_value(&self, val: &str) -> Option<PrismaValue> {
         Some(PrismaValue::Enum(
             self.internal_enum
                 .values
                 .iter()
-                .find(|ev| &ev.name == val)?
+                .find(|ev| ev.name == val)?
                 .db_name()
                 .clone(),
         ))
     }
 
-    pub fn map_output_value(&self, val: &String) -> Option<PrismaValue> {
+    pub fn map_output_value(&self, val: &str) -> Option<PrismaValue> {
         Some(PrismaValue::Enum(
             self.internal_enum
                 .values
@@ -115,7 +115,7 @@ impl FieldRefEnumType {
     pub fn value_for(&self, name: &str) -> Option<&ScalarFieldRef> {
         self.values
             .iter()
-            .find_map(|val| if &val.0 == name { Some(&val.1) } else { None })
+            .find_map(|val| if val.0 == name { Some(&val.1) } else { None })
     }
 
     pub fn values(&self) -> Vec<String> {

--- a/query-engine/core/src/schema/output_types.rs
+++ b/query-engine/core/src/schema/output_types.rs
@@ -129,7 +129,7 @@ impl ObjectType {
     }
 
     pub fn find_field(&self, name: &str) -> Option<OutputFieldRef> {
-        self.get_fields().iter().find(|f| &f.name == name).cloned()
+        self.get_fields().iter().find(|f| f.name == name).cloned()
     }
 
     /// True if fields are empty, false otherwise.

--- a/query-engine/core/src/schema_builder/cache.rs
+++ b/query-engine/core/src/schema_builder/cache.rs
@@ -71,8 +71,8 @@ impl<T> From<Vec<(Identifier, Arc<T>)>> for TypeRefCache<T> {
 macro_rules! return_cached_input {
     ($ctx:expr, $ident:expr) => {
         let existing_type = $ctx.get_input_type($ident);
-        if existing_type.is_some() {
-            return existing_type.unwrap();
+        if let Some(ty) = existing_type {
+            return ty;
         }
     };
 }
@@ -81,8 +81,8 @@ macro_rules! return_cached_input {
 macro_rules! return_cached_output {
     ($ctx:ident, $name:expr) => {
         let existing_type = $ctx.get_output_type($name);
-        if existing_type.is_some() {
-            return existing_type.unwrap();
+        if let Some(ty) = existing_type {
+            return ty;
         }
     };
 }

--- a/query-engine/core/src/schema_builder/output_types/aggregation/group_by.rs
+++ b/query-engine/core/src/schema_builder/output_types/aggregation/group_by.rs
@@ -52,7 +52,7 @@ pub(crate) fn group_by_output_object_type(ctx: &mut BuilderContext, model: &Mode
             ctx,
             "sum",
             &model,
-            numeric_fields.clone(),
+            numeric_fields,
             map_scalar_output_type_for_field,
             identity,
         ),

--- a/query-engine/core/src/schema_builder/output_types/aggregation/plain.rs
+++ b/query-engine/core/src/schema_builder/output_types/aggregation/plain.rs
@@ -46,7 +46,7 @@ pub(crate) fn aggregation_object_type(ctx: &mut BuilderContext, model: &ModelRef
             ctx,
             "sum",
             &model,
-            numeric_fields.clone(),
+            numeric_fields,
             map_scalar_output_type_for_field,
             identity,
         ),

--- a/query-engine/core/src/schema_builder/output_types/output_objects.rs
+++ b/query-engine/core/src/schema_builder/output_types/output_objects.rs
@@ -14,7 +14,7 @@ pub(crate) fn initialize_model_object_type_cache(ctx: &mut BuilderContext) {
         .into_iter()
         .for_each(|model| {
             let ident = Identifier::new(model.name.clone(), MODEL_NAMESPACE);
-            ctx.cache_output_type(ident.clone(), Arc::new(ObjectType::new(ident.clone(), Some(model))))
+            ctx.cache_output_type(ident.clone(), Arc::new(ObjectType::new(ident, Some(model))))
         });
 
     // Compute fields on all cached object types.

--- a/query-engine/query-engine/src/dmmf/schema/field_renderer.rs
+++ b/query-engine/query-engine/src/dmmf/schema/field_renderer.rs
@@ -11,15 +11,13 @@ pub(super) fn render_input_field(input_field: &InputFieldRef, ctx: &mut RenderCo
         .iter()
         .any(|typ| matches!(typ, InputType::Scalar(ScalarType::Null)));
 
-    let field = DmmfInputField {
+    DmmfInputField {
         name: input_field.name.clone(),
         input_types: type_references,
         is_required: input_field.is_required,
         is_nullable: nullable,
         deprecation: input_field.deprecation.as_ref().map(Into::into),
-    };
-
-    field
+    }
 }
 
 pub(super) fn render_output_field(field: &OutputFieldRef, ctx: &mut RenderContext) -> DmmfOutputField {

--- a/query-engine/query-engine/src/dmmf/schema/mod.rs
+++ b/query-engine/query-engine/src/dmmf/schema/mod.rs
@@ -126,11 +126,11 @@ impl RenderContext {
                     .find(|mapping| mapping.model_name == model_name);
 
                 match model_op {
-                    Some(ref existing) => existing.add_operation(tag_str, name.clone()),
+                    Some(ref existing) => existing.add_operation(tag_str, name),
                     None => {
                         let new_mapping = DmmfModelOperations::new(model_name);
 
-                        new_mapping.add_operation(tag_str, name.clone());
+                        new_mapping.add_operation(tag_str, name);
                         self.mappings.model_operations.push(new_mapping);
                     }
                 };

--- a/query-engine/query-engine/src/dmmf/schema/type_renderer.rs
+++ b/query-engine/query-engine/src/dmmf/schema/type_renderer.rs
@@ -67,14 +67,12 @@ pub(super) fn render_output_type(output_type: &OutputType, ctx: &mut RenderConte
                 ScalarType::Enum(_) => unreachable!(), // Handled separately above.
             };
 
-            let type_reference = DmmfTypeReference {
+            DmmfTypeReference {
                 typ: stringified.into(),
                 namespace: None,
                 location: TypeLocation::Scalar,
                 is_list: false,
-            };
-
-            type_reference
+            }
         }
     }
 }
@@ -151,14 +149,12 @@ pub(super) fn render_input_type(input_type: &InputType, ctx: &mut RenderContext)
                 ScalarType::Enum(_) => unreachable!(), // Handled separately above.
             };
 
-            let type_reference = DmmfTypeReference {
+            DmmfTypeReference {
                 typ: stringified.into(),
                 namespace: None,
                 location: TypeLocation::Scalar,
                 is_list: false,
-            };
-
-            type_reference
+            }
         }
     }
 }

--- a/query-engine/query-engine/src/error.rs
+++ b/query-engine/query-engine/src/error.rs
@@ -12,7 +12,7 @@ pub enum PrismaError {
     SerializationError(String),
 
     #[error("{}", _0)]
-    CoreError(CoreError),
+    CoreError(Box<CoreError>),
 
     #[error("{}", _0)]
     JsonDecodeError(anyhow::Error),
@@ -88,7 +88,7 @@ impl PrismaError {
 
 impl From<CoreError> for PrismaError {
     fn from(e: CoreError) -> Self {
-        PrismaError::CoreError(e)
+        PrismaError::CoreError(Box::new(e))
     }
 }
 

--- a/query-engine/query-engine/src/exec_loader.rs
+++ b/query-engine/query-engine/src/exec_loader.rs
@@ -32,7 +32,7 @@ pub async fn load(source: &Datasource) -> PrismaResult<(String, Box<dyn QueryExe
                     "Microsoft SQL Server (experimental feature, needs to be enabled)".into(),
                 );
 
-                return Err(PrismaError::CoreError(error));
+                return Err(error.into());
             }
 
             mssql(source).await

--- a/query-engine/query-engine/src/opt.rs
+++ b/query-engine/query-engine/src/opt.rs
@@ -110,7 +110,7 @@ impl PrismaOpt {
         let res = self
             .datamodel
             .as_deref()
-            .or(self.datamodel_path.as_deref())
+            .or_else(|| self.datamodel_path.as_deref())
             .ok_or_else(|| {
                 PrismaError::ConfigurationError(
                     "Datamodel should be provided either as path or base64-encoded string.".into(),

--- a/query-engine/query-engine/src/request_handlers/graphql/response.rs
+++ b/query-engine/query-engine/src/request_handlers/graphql/response.rs
@@ -88,7 +88,7 @@ impl From<CoreError> for GQLError {
 impl From<PrismaError> for GQLError {
     fn from(other: PrismaError) -> Self {
         match other {
-            PrismaError::CoreError(core_error) => GQLError::from(core_error),
+            PrismaError::CoreError(core_error) => GQLError::from(*core_error),
             err => GQLError::from(user_facing_errors::Error::from_dyn_error(&err)),
         }
     }


### PR DESCRIPTION
Follow up to #1466; applies another round of clippy lints. This brings us down to 2 failing clippy lints on the whole codebase.

Probably the easiest way to review is to step through commit-by-commit. A few files have been inlined into their respective `mod.rs` files to satisfy the [module_inception](https://rust-lang.github.io/rust-clippy/master/index.html#module_inception) lint. That's where most of the diff comes from; we don't actually have 1000 lines of changes haha.

The last two lints are relatively easy to apply, but I ran out of time so I might do that whenever I have a slow moment again. Thanks!