### PR TITLE
Update windows CI toolchain to 1.48.0

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.46.0
+          toolchain: 1.48.0
           default: true
 
       - uses: actions/cache@v2


### PR DESCRIPTION
The hope is that the random LLVM failures will stop,
https://github.com/rust-lang/rust/issues/72470 being fixed.