### PR TITLE
`findOne` deprecation

### DIFF
--- a/query-engine/core/src/schema/input_types.rs
+++ b/query-engine/core/src/schema/input_types.rs
@@ -127,11 +127,16 @@ impl InputField {
         self
     }
 
-    pub fn deprecate(mut self, reason: String, since_version: String, planned_removal_version: Option<String>) -> Self {
+    pub fn deprecate<T, S, U>(mut self, reason: T, since_version: S, planned_removal_version: Option<U>) -> Self
+    where
+        T: Into<String>,
+        S: Into<String>,
+        U: Into<String>,
+    {
         self.deprecation = Some(Deprecation {
-            reason,
-            since_version,
-            planned_removal_version,
+            reason: reason.into(),
+            since_version: since_version.into(),
+            planned_removal_version: planned_removal_version.map(Into::into),
         });
 
         self

--- a/query-engine/core/src/schema/input_types.rs
+++ b/query-engine/core/src/schema/input_types.rs
@@ -81,6 +81,7 @@ impl InputObjectType {
 pub struct InputField {
     pub name: String,
     pub default_value: Option<dml::DefaultValue>,
+    pub deprecation: Option<Deprecation>,
 
     /// Possible field types, represented as a union of input types, but only one can be provided at any time.
     pub field_types: Vec<InputType>,
@@ -123,6 +124,16 @@ impl InputField {
     /// Adds possible input type to this input field's type union.
     pub fn add_type(mut self, typ: InputType) -> Self {
         self.field_types.push(typ);
+        self
+    }
+
+    pub fn deprecate(mut self, reason: String, since_version: String, planned_removal_version: Option<String>) -> Self {
+        self.deprecation = Some(Deprecation {
+            reason,
+            since_version,
+            planned_removal_version,
+        });
+
         self
     }
 }

--- a/query-engine/core/src/schema/mod.rs
+++ b/query-engine/core/src/schema/mod.rs
@@ -40,3 +40,10 @@ impl<T> IntoArc<T> for Weak<T> {
         self.upgrade().expect("Expected weak reference to be valid.")
     }
 }
+
+#[derive(Debug, PartialEq)]
+pub struct Deprecation {
+    pub since_version: String,
+    pub planned_removal_version: Option<String>,
+    pub reason: String,
+}

--- a/query-engine/core/src/schema/output_types.rs
+++ b/query-engine/core/src/schema/output_types.rs
@@ -170,10 +170,14 @@ impl OutputField {
         }
     }
 
-    pub fn deprecate(mut self, reason: String, since_version: String, planned_removal_version: Option<String>) -> Self {
+    pub fn deprecate<T, S>(mut self, reason: T, since_version: S, planned_removal_version: Option<String>) -> Self
+    where
+        T: Into<String>,
+        S: Into<String>,
+    {
         self.deprecation = Some(Deprecation {
-            reason,
-            since_version,
+            reason: reason.into(),
+            since_version: since_version.into(),
             planned_removal_version,
         });
 

--- a/query-engine/core/src/schema/output_types.rs
+++ b/query-engine/core/src/schema/output_types.rs
@@ -142,6 +142,7 @@ impl ObjectType {
 pub struct OutputField {
     pub name: String,
     pub field_type: OutputTypeRef,
+    pub deprecation: Option<Deprecation>,
 
     /// Arguments are input fields, but positioned in context of an output field
     /// instead of being attached to an input object.
@@ -167,5 +168,15 @@ impl OutputField {
         } else {
             self
         }
+    }
+
+    pub fn deprecate(mut self, reason: String, since_version: String, planned_removal_version: Option<String>) -> Self {
+        self.deprecation = Some(Deprecation {
+            reason,
+            since_version,
+            planned_removal_version,
+        });
+
+        self
     }
 }

--- a/query-engine/core/src/schema/query_schema.rs
+++ b/query-engine/core/src/schema/query_schema.rs
@@ -89,6 +89,7 @@ pub struct QueryInfo {
 #[derive(Debug, Clone, PartialEq)]
 pub enum QueryTag {
     FindOne,
+    FindUnique,
     FindFirst,
     FindMany,
     CreateOne,
@@ -107,6 +108,7 @@ impl fmt::Display for QueryTag {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let s = match self {
             Self::FindOne => "findOne",
+            Self::FindUnique => "findUnique",
             Self::FindFirst => "findFirst",
             Self::FindMany => "findMany",
             Self::CreateOne => "createOne",

--- a/query-engine/core/src/schema_builder/output_types/query_type.rs
+++ b/query-engine/core/src/schema_builder/output_types/query_type.rs
@@ -47,7 +47,7 @@ fn find_one_field(ctx: &mut BuilderContext, model: &ModelRef) -> Option<OutputFi
         .deprecate(
             "The `findOne` query has been deprecated and replaced with `findUnique`.",
             "2.14",
-            None,
+            Some("2.15".to_owned()),
         )
     })
 }

--- a/query-engine/core/src/schema_builder/output_types/query_type.rs
+++ b/query-engine/core/src/schema_builder/output_types/query_type.rs
@@ -17,6 +17,7 @@ pub(crate) fn build(ctx: &mut BuilderContext) -> (OutputType, ObjectTypeStrongRe
             }
 
             append_opt(&mut vec, find_one_field(ctx, &model));
+            append_opt(&mut vec, find_unique_field(ctx, &model));
             vec
         })
         .flatten()
@@ -28,8 +29,7 @@ pub(crate) fn build(ctx: &mut BuilderContext) -> (OutputType, ObjectTypeStrongRe
     (OutputType::Object(Arc::downgrade(&strong_ref)), strong_ref)
 }
 
-/// Builds a "single" query arity item field (e.g. "user", "post" ...) for given model.
-/// Find one unique semantics.
+/// Deprecated field. Semantics are identical to `findUnique`.
 fn find_one_field(ctx: &mut BuilderContext, model: &ModelRef) -> Option<OutputField> {
     arguments::where_unique_argument(ctx, model).map(|arg| {
         let field_name = ctx.pluralize_internal(camel_case(&model.name), format!("findOne{}", model.name));
@@ -41,6 +41,30 @@ fn find_one_field(ctx: &mut BuilderContext, model: &ModelRef) -> Option<OutputFi
             Some(QueryInfo {
                 model: Some(Arc::clone(&model)),
                 tag: QueryTag::FindOne,
+            }),
+        )
+        .optional()
+        .deprecate(
+            "The `findOne` query has been deprecated and replaced with `findUnique`.",
+            "2.14",
+            None,
+        )
+    })
+}
+
+/// Builds a "single" query arity item field (e.g. "user", "post" ...) for given model.
+/// Find one unique semantics.
+fn find_unique_field(ctx: &mut BuilderContext, model: &ModelRef) -> Option<OutputField> {
+    arguments::where_unique_argument(ctx, model).map(|arg| {
+        let field_name = ctx.pluralize_internal(camel_case(&model.name), format!("findUnique{}", model.name));
+
+        field(
+            field_name,
+            vec![arg],
+            OutputType::object(output_objects::map_model_object_type(ctx, &model)),
+            Some(QueryInfo {
+                model: Some(Arc::clone(&model)),
+                tag: QueryTag::FindUnique,
             }),
         )
         .optional()

--- a/query-engine/core/src/schema_builder/utils.rs
+++ b/query-engine/core/src/schema_builder/utils.rs
@@ -57,6 +57,7 @@ where
         field_type: Arc::new(field_type),
         query_info,
         is_required: true,
+        deprecation: None,
     }
 }
 
@@ -71,6 +72,7 @@ where
         field_types: field_types.into(),
         default_value,
         is_required: true,
+        deprecation: None,
     }
 }
 

--- a/query-engine/query-engine/src/dmmf/schema/ast.rs
+++ b/query-engine/query-engine/src/dmmf/schema/ast.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use query_core::Deprecation;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Default)]
@@ -18,6 +19,9 @@ pub struct DmmfOutputField {
     pub is_required: bool,
     pub is_nullable: bool,
     pub output_type: DmmfTypeReference,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deprecation: Option<DmmfDeprecation>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -49,6 +53,9 @@ pub struct DmmfInputField {
     pub is_required: bool,
     pub is_nullable: bool,
     pub input_types: Vec<DmmfTypeReference>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deprecation: Option<DmmfDeprecation>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -77,4 +84,22 @@ pub enum TypeLocation {
 pub struct DmmfEnum {
     pub name: String,
     pub values: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DmmfDeprecation {
+    pub since_version: String,
+    pub planned_removal_version: Option<String>,
+    pub reason: String,
+}
+
+impl From<&Deprecation> for DmmfDeprecation {
+    fn from(deprecation: &Deprecation) -> Self {
+        Self {
+            since_version: deprecation.since_version.clone(),
+            planned_removal_version: deprecation.planned_removal_version.clone(),
+            reason: deprecation.reason.clone(),
+        }
+    }
 }

--- a/query-engine/query-engine/src/dmmf/schema/ast.rs
+++ b/query-engine/query-engine/src/dmmf/schema/ast.rs
@@ -90,8 +90,10 @@ pub struct DmmfEnum {
 #[serde(rename_all = "camelCase")]
 pub struct DmmfDeprecation {
     pub since_version: String,
-    pub planned_removal_version: Option<String>,
     pub reason: String,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub planned_removal_version: Option<String>,
 }
 
 impl From<&Deprecation> for DmmfDeprecation {

--- a/query-engine/query-engine/src/dmmf/schema/field_renderer.rs
+++ b/query-engine/query-engine/src/dmmf/schema/field_renderer.rs
@@ -16,6 +16,7 @@ pub(super) fn render_input_field(input_field: &InputFieldRef, ctx: &mut RenderCo
         input_types: type_references,
         is_required: input_field.is_required,
         is_nullable: nullable,
+        deprecation: input_field.deprecation.as_ref().map(Into::into),
     };
 
     field
@@ -31,6 +32,7 @@ pub(super) fn render_output_field(field: &OutputFieldRef, ctx: &mut RenderContex
         output_type,
         is_required: field.is_required,
         is_nullable: !field.is_required,
+        deprecation: field.deprecation.as_ref().map(Into::into),
     };
 
     ctx.add_mapping(field.name.clone(), field.query_info.as_ref());


### PR DESCRIPTION
Deprecates the `findOne<Model>` query, replacing it with `findUnique`. The query engine now accepts both API calls. Semantics are identical.

To this end, a deprecation mechanism on the DMMF fields (in/out) level has been added:
```json
{
    "...": "...",
    "deprecation": {
       "sinceVersion": "Prisma version string like 2.14 or 2.14.1",
       "plannedRemovalVerison": "[Optional] Prisma version string this deprecated field will be removed completely.",
       "reason": "Free text description of why this feature has been deprecated."
    }
}
```

Example for `findOne` deprecation (output field on the query output object):
```json
{
    "name": "findOneTestModel",
    "args": [{ "...": "..." }],
    "isRequired": false,
    "isNullable": true,
    "outputType": { "...": "..." },
    "deprecation": {
        "sinceVersion": "2.14",
        "reason": "The `findOne` query has been deprecated and replaced with `findUnique`."
    }
},
```