### PR TITLE
Query engine/4230

### DIFF
--- a/datamodel_v2.prisma
+++ b/datamodel_v2.prisma
@@ -1,110 +1,47 @@
 datasource chinook {
   provider = "sqlite"
-  url      = "file:./db/Chinook.db?connection_limit=1&socket_timeout=20"
+  url      = "file:./db/4230.db?connection_limit=1&socket_timeout=20"
 }
 
-model Album {
-  id       Int     @id @map("AlbumId")
-  Title    String  @default("TestDefaultTitle")
-  ArtistId Int
-  Tracks   Track[]
-  Artist   Artist  @relation(fields: [ArtistId], references: [id])
+model Container {
+  id  Int     @id @default(autoincrement())
+  gql String?
+
+  Record Record[]
 }
 
-model Track {
-  id           Int           @id @map("TrackId")
-  Name         String
-  Composer     String?
-  Milliseconds Int
-  UnitPrice    Float
-  AlbumId      Int?
-  GenreId      Int?
-  MediaTypeId  Int
-  MediaType    MediaType     @relation(fields: [MediaTypeId], references: [id])
-  Genre        Genre?        @relation(fields: [GenreId], references: [id])
-  Album        Album?        @relation(fields: [AlbumId], references: [id])
-  InvoiceLines InvoiceLine[]
+model RecordConfig {
+  id  Int     @id @default(autoincrement())
+  gql String?
+
+  Record Record[]
 }
 
-model MediaType {
-  id    Int     @id @map("MediaTypeId")
-  Name  String?
-  Track Track[]
+model RecordLocation {
+  id       Int     @id @default(autoincrement())
+  location String  @unique
+  gql      String?
+
+  Record Record[]
 }
 
-model Genre {
-  id     Int     @id @map("GenreId")
-  Name   String?
-  Tracks Track[]
+model RecordType {
+  id   Int     @id @default(autoincrement())
+  type String  @unique
+  gql  String?
+
+  Record Record[]
 }
 
-model Artist {
-  id     Int     @id @map("ArtistId")
-  Name   String?
-  Albums Album[]
-}
-
-model Customer {
-  id           Int       @id @map("CustomerId")
-  FirstName    String
-  LastName     String
-  Company      String?
-  Address      String?
-  City         String?
-  State        String?
-  Country      String?
-  PostalCode   String?
-  Phone        String?
-  Fax          String?
-  Email        String
-  SupportRepId Int?
-  SupportRep   Employee? @relation(fields: [SupportRepId], references: [id])
-  Invoices     Invoice[]
-}
-
-model Employee {
-  id         Int        @id @map("EmployeeId")
-  FirstName  String
-  LastName   String
-  Title      String?
-  BirthDate  DateTime?
-  HireDate   DateTime?
-  Address    String?
-  City       String?
-  State      String?
-  Country    String?
-  PostalCode String?
-  Phone      String?
-  Fax        String?
-  Email      String?
-  Customers  Customer[]
-}
-
-model Invoice {
-  id                Int           @id @map("InvoiceId")
-  InvoiceDate       DateTime
-  BillingAddress    String?
-  BillingCity       String?
-  BillingState      String?
-  BillingCountry    String?
-  BillingPostalCode String?
-  Total             Float
-  CustomerId        Int
-  Customer          Customer      @relation(fields: [CustomerId], references: [id])
-  Lines             InvoiceLine[]
-}
-
-model InvoiceLine {
-  id        Int     @id @map("InvoiceLineId")
-  UnitPrice Float
-  Quantity  Int
-  InvoiceId Int
-  TrackId   Int
-  Invoice   Invoice @relation(fields: [InvoiceId], references: [id])
-  Track     Track   @relation(fields: [TrackId], references: [id])
-}
-
-model Playlist {
-  id   Int     @id @map("PlaylistId")
-  Name String?
+model Record {
+  id           Int            @id @default(autoincrement())
+  gql          String?
+  location     RecordLocation @relation(fields: [locationId], references: [id])
+  locationId   Int
+  type         RecordType     @relation(fields: [recordTypeId], references: [id])
+  recordTypeId Int
+  config       RecordConfig?  @relation(fields: [configId], references: [id])
+  configId     Int?
+  container    Container      @relation(fields: [containerId], references: [id])
+  containerId  Int
 }

--- a/query-engine/connector-test-kit/src/test/scala/writes/regressions/IfNodeSiblingDepRegressionSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/regressions/IfNodeSiblingDepRegressionSpec.scala
@@ -1,0 +1,102 @@
+package writes.regressions
+
+import org.scalatest.{FlatSpec, Matchers}
+import util._
+
+class IfNodeSiblingDepRegressionSpec extends FlatSpec with Matchers with ApiSpecBase {
+  // Related issue: https://github.com/prisma/prisma/issues/4230
+  "The if node sibling reordering" should "include all siblings that are not another if" in {
+    val project = ProjectDsl.fromString {
+      """
+        |model Container {
+        |  id     Int      @id @default(autoincrement())
+        |
+        |  Record Record[]
+        |}
+        |
+        |model RecordConfig {
+        |  id     Int      @id @default(autoincrement())
+        |
+        |  Record Record[]
+        |}
+        |
+        |model RecordLocation {
+        |  id       Int    @id @default(autoincrement())
+        |  location String @unique
+        |
+        |  Record Record[]
+        |}
+        |
+        |model RecordType {
+        |  id     Int      @id @default(autoincrement())
+        |  type   String   @unique
+        |
+        |  Record Record[]
+        |}
+        |
+        |model Record {
+        |  id           Int            @id @default(autoincrement())
+        |  location     RecordLocation @relation(fields: [locationId], references: [id])
+        |  locationId   Int
+        |  type         RecordType     @relation(fields: [recordTypeId], references: [id])
+        |  recordTypeId Int
+        |  config       RecordConfig?  @relation(fields: [configId], references: [id])
+        |  configId     Int?
+        |  container    Container      @relation(fields: [containerId], references: [id])
+        |  containerId  Int
+        |}
+      """.stripMargin
+    }
+    database.setup(project)
+
+    // Setup
+    server.query(
+      """
+        |mutation {
+        |  createOneRecordConfig(data: {}) {id}
+        |}
+      """.stripMargin,
+      project,
+      legacy = false
+    )
+
+    server.query(
+      """
+        |mutation {
+        |  createOneContainer(data: {}) {id}
+        |}
+      """.stripMargin,
+      project,
+      legacy = false
+    )
+
+    val result = server.query(
+      """
+        |mutation {
+        |  createOneRecord(data:{
+        |    container: { connect: { id: 1 }}
+        |    config: { connect: { id: 1 }}
+        |  	location: {
+        |      connectOrCreate: {
+        |        where: { location: "something" }
+        |        create: { location: "something" }
+        |      }
+        |    }
+        |    type: {
+        |      connectOrCreate: {
+        |        where: { type: "test" }
+        |        create: { type: "test" }
+        |      }
+        |    }
+        |  }) {
+        |    id
+        |  }
+        |}
+      """.stripMargin,
+      project,
+      legacy = false
+    )
+
+    result.toString() should be("""{"data":{"createOneRecord":{"id":1}}}""")
+  }
+}

--- a/query-engine/core/src/query_graph/mod.rs
+++ b/query-engine/core/src/query_graph/mod.rs
@@ -575,30 +575,33 @@ impl QueryGraph {
 
     /// Inserts ordering edges into the graph to prevent interdependency issues when rotating
     /// nodes for `if`-flow nodes.
-    /// All sibling nodes of an if that are _not_ an if node themself or _not_ already connected
-    /// to the if node in any form (to prevent double edges) will be ordered below the if node
-    /// in execution predence.
+    ///
+    /// All sibling nodes of an if-node that are...
+    /// - ... not an `if`-flow node themself
+    /// - ... not already connected to the current `if`-flow node in any form (to prevent double edges)
+    /// - ... not connected to another `if`-flow node with control flow edges (indirect sibling)
+    /// will be ordered below the currently processed `if`-flow node in execution predence.
     ///
     /// ```text
     ///      ┌ ─ ─ ─ ─ ─ ─
-    /// ┌ ─ ─    Parent   │─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─
-    ///      └ ─ ─ ─ ─ ─ ─            │                 │
-    /// │           │
-    ///             │                 │                 │
-    /// │           │
-    ///             ▼                 ▼                 ▼
-    /// │    ┌ ─ ─ ─ ─ ─ ─     ┌ ─ ─ ─ ─ ─ ─     ┌ ─ ─ ─ ─ ─ ─
-    ///   ┌ ─      If     │       Sibling   │      Sibling If │
-    /// │    └ ─ ─ ─ ─ ─ ─     └ ─ ─ ─ ─ ─ ─     └ ─ ─ ─ ─ ─ ─
-    ///   │         │                 ▲
-    /// │           │                 │
-    ///   │         └────Inserted ────┘
+    /// ┌ ─ ─    Parent   │─ ─ ─ ─ ┬ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┬ ─ ─ ─ ─
+    ///      └ ─ ─ ─ ─ ─ ─                        │                       │
+    /// │           │              │                             │
+    ///             │                             │                       │
+    /// │           │              │                             │
+    ///             ▼              ▼              ▼              ▼        │
+    /// │    ┌ ─ ─ ─ ─ ─ ─  ┌ ─ ─ ─ ─ ─ ─  ┌ ─ ─ ─ ─ ─ ─  ┌ ─ ─ ─ ─ ─ ─
+    ///   ┌ ─      If     │    Sibling   │   Sibling If │   Sibling If │  │
+    /// │    └ ─ ─ ─ ─ ─ ─  └ ─ ─ ─ ─ ─ ─  └ ─ ─ ─ ─ ─ ─  └ ─ ─ ─ ─ ─ ─
+    ///   │         │              ▲                             │        │
+    /// │           │              │
+    ///   │         └────Inserted ─┘                       (Then / Else)  │
     /// │                Ordering
-    ///   │
-    /// │    ┌ ─ ─ ─ ─ ─ ─
-    ///   │     Already   │
-    /// └ ──▶│ connected
-    ///         sibling   │
+    ///   │                                                      ▼        │
+    /// │    ┌ ─ ─ ─ ─ ─ ─                                ┌ ─ ─ ─ ─ ─ ─
+    ///   │     Already   │                                  Indirect  │  │
+    /// └ ──▶│ connected                                  │  sibling    ◀─
+    ///         sibling   │                                ─ ─ ─ ─ ─ ─ ┘
     ///      └ ─ ─ ─ ─ ─ ─
     /// ```
     fn normalize_if_nodes(&mut self) -> QueryGraphResult<()> {
@@ -614,9 +617,20 @@ impl QueryGraph {
 
                     for (_, sibling) in siblings {
                         let possible_edge = self.graph.find_edge(node.node_ix, sibling.node_ix);
+                        let is_if_node_child = self
+                            .incoming_edges(&sibling)
+                            .into_iter()
+                            .find(|edge| {
+                                matches!(
+                                    self.edge_content(&edge).unwrap(),
+                                    QueryGraphDependency::Then | QueryGraphDependency::Else
+                                )
+                            })
+                            .is_some();
 
                         if sibling != node
                             && possible_edge.is_none()
+                            && !is_if_node_child
                             && !matches!(self.node_content(&sibling).unwrap(), Node::Flow(_))
                         {
                             self.create_edge(&node, &sibling, QueryGraphDependency::ExecutionOrder)?;

--- a/query-engine/core/src/query_graph/mod.rs
+++ b/query-engine/core/src/query_graph/mod.rs
@@ -601,7 +601,7 @@ impl QueryGraph {
 
                 for parent_edge in parents {
                     let parent = self.edge_source(&parent_edge);
-                    let siblings = self.direct_child_pairs(&parent);
+                    let siblings = self.child_pairs(&parent);
 
                     for (_, sibling) in siblings {
                         if sibling != node && !matches!(self.node_content(&sibling).unwrap(), Node::Flow(_)) {


### PR DESCRIPTION
Related issue: https://github.com/prisma/prisma/issues/4230

Fixes inconsistent query graph ordering when multiple connectOrCreate operations cause graph node rotations.