### PR TITLE
Rename ImperativeMigrationPersistence to MigrationPersistence

### DIFF
--- a/migration-engine/connectors/migration-connector/src/lib.rs
+++ b/migration-engine/connectors/migration-connector/src/lib.rs
@@ -7,7 +7,7 @@ mod database_migration_step_applier;
 mod destructive_change_checker;
 mod error;
 pub mod features;
-mod imperative_migrations_persistence;
+mod migration_persistence;
 
 #[allow(missing_docs)]
 pub mod steps;
@@ -19,9 +19,7 @@ pub use database_migration_step_applier::*;
 pub use destructive_change_checker::*;
 pub use error::*;
 pub use features::MigrationFeature;
-pub use imperative_migrations_persistence::{
-    ImperativeMigrationsPersistence, MigrationRecord, PersistenceNotInitializedError, Timestamp,
-};
+pub use migration_persistence::{MigrationPersistence, MigrationRecord, PersistenceNotInitializedError, Timestamp};
 pub use migrations_directory::{create_migration_directory, list_migrations, ListMigrationsError, MigrationDirectory};
 pub use steps::MigrationStep;
 
@@ -60,8 +58,8 @@ pub trait MigrationConnector: Send + Sync + 'static {
         None
     }
 
-    /// See [ImperativeMigrationPersistence](trait.ImperativeMigrationPersistence.html).
-    fn new_migration_persistence(&self) -> &dyn ImperativeMigrationsPersistence;
+    /// See [MigrationPersistence](trait.MigrationPersistence.html).
+    fn migration_persistence(&self) -> &dyn MigrationPersistence;
 
     /// See [DatabaseMigrationInferrer](trait.DatabaseMigrationInferrer.html).
     fn database_migration_inferrer(&self) -> &dyn DatabaseMigrationInferrer<Self::DatabaseMigration>;

--- a/migration-engine/connectors/migration-connector/src/migration_persistence.rs
+++ b/migration-engine/connectors/migration-connector/src/migration_persistence.rs
@@ -6,7 +6,7 @@ pub type Timestamp = chrono::DateTime<chrono::Utc>;
 
 /// Management of imperative migrations state in the database.
 #[async_trait::async_trait]
-pub trait ImperativeMigrationsPersistence: Send + Sync {
+pub trait MigrationPersistence: Send + Sync {
     /// Initialize the migration persistence without checking the database first.
     async fn baseline_initialize(&self) -> ConnectorResult<()>;
 

--- a/migration-engine/connectors/sql-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/lib.rs
@@ -10,8 +10,8 @@ mod pair;
 mod sql_database_migration_inferrer;
 mod sql_database_step_applier;
 mod sql_destructive_change_checker;
-mod sql_imperative_migration_persistence;
 mod sql_migration;
+mod sql_migration_persistence;
 mod sql_renderer;
 mod sql_schema_calculator;
 mod sql_schema_differ;
@@ -140,7 +140,7 @@ impl MigrationConnector for SqlMigrationConnector {
         self
     }
 
-    fn new_migration_persistence(&self) -> &dyn ImperativeMigrationsPersistence {
+    fn migration_persistence(&self) -> &dyn MigrationPersistence {
         self
     }
 }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_migration_persistence.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_migration_persistence.rs
@@ -1,12 +1,12 @@
 use crate::{error::quaint_error_to_connector_error, SqlMigrationConnector};
 use migration_connector::{
-    ConnectorError, ConnectorResult, ImperativeMigrationsPersistence, MigrationRecord, PersistenceNotInitializedError,
+    ConnectorError, ConnectorResult, MigrationPersistence, MigrationRecord, PersistenceNotInitializedError,
 };
 use quaint::{ast::*, error::ErrorKind as QuaintKind};
 use uuid::Uuid;
 
 #[async_trait::async_trait]
-impl ImperativeMigrationsPersistence for SqlMigrationConnector {
+impl MigrationPersistence for SqlMigrationConnector {
     async fn baseline_initialize(&self) -> ConnectorResult<()> {
         self.flavour.create_imperative_migrations_table(&self.conn()).await?;
 

--- a/migration-engine/core/src/commands/apply_migrations.rs
+++ b/migration-engine/core/src/commands/apply_migrations.rs
@@ -38,7 +38,7 @@ impl<'a> MigrationCommand for ApplyMigrationsCommand {
     {
         let connector = engine.connector();
         let applier = connector.database_migration_step_applier();
-        let migration_persistence = connector.new_migration_persistence();
+        let migration_persistence = connector.migration_persistence();
 
         migration_persistence.initialize().await?;
 

--- a/migration-engine/core/src/commands/diagnose_migration_history.rs
+++ b/migration-engine/core/src/commands/diagnose_migration_history.rs
@@ -69,7 +69,7 @@ impl<'a> MigrationCommand for DiagnoseMigrationHistoryCommand {
 
     async fn execute<C: MigrationConnector>(input: &Self::Input, engine: &MigrationApi<C>) -> CoreResult<Self::Output> {
         let connector = engine.connector();
-        let migration_persistence = connector.new_migration_persistence();
+        let migration_persistence = connector.migration_persistence();
         let migration_inferrer = connector.database_migration_inferrer();
 
         tracing::debug!("Diagnosing migration history");

--- a/migration-engine/core/src/commands/mark_migration_applied.rs
+++ b/migration-engine/core/src/commands/mark_migration_applied.rs
@@ -29,7 +29,7 @@ impl MigrationCommand for MarkMigrationAppliedCommand {
     async fn execute<C: MigrationConnector>(input: &Self::Input, engine: &MigrationApi<C>) -> CoreResult<Self::Output> {
         // We should take a lock on the migrations table.
 
-        let persistence = engine.connector().new_migration_persistence();
+        let persistence = engine.connector().migration_persistence();
 
         let migration_directory =
             MigrationDirectory::new(Path::new(&input.migrations_directory_path).join(&input.migration_name));

--- a/migration-engine/core/src/commands/mark_migration_rolled_back.rs
+++ b/migration-engine/core/src/commands/mark_migration_rolled_back.rs
@@ -27,7 +27,7 @@ impl MigrationCommand for MarkMigrationRolledBackCommand {
     async fn execute<C: MigrationConnector>(input: &Self::Input, engine: &MigrationApi<C>) -> CoreResult<Self::Output> {
         // We should take a lock on the migrations table.
 
-        let persistence = engine.connector().new_migration_persistence();
+        let persistence = engine.connector().migration_persistence();
 
         let all_migrations = persistence.list_migrations().await?.map_err(|_err| {
             CoreError::Generic(anyhow::anyhow!(

--- a/migration-engine/migration-engine-tests/src/test_api.rs
+++ b/migration-engine/migration-engine-tests/src/test_api.rs
@@ -28,7 +28,7 @@ use super::{
 use crate::{connectors::Tags, test_api::list_migration_directories::ListMigrationDirectories, AssertionResult};
 use enumflags2::BitFlags;
 use indoc::formatdoc;
-use migration_connector::{ImperativeMigrationsPersistence, MigrationFeature, MigrationRecord};
+use migration_connector::{MigrationFeature, MigrationPersistence, MigrationRecord};
 use migration_core::{
     api::{GenericApi, MigrationApi},
     commands::ApplyScriptInput,
@@ -75,7 +75,7 @@ impl TestApi {
         self.tags.contains(Tags::Mariadb)
     }
 
-    pub fn imperative_migration_persistence<'a>(&'a self) -> &(dyn ImperativeMigrationsPersistence + 'a) {
+    pub fn migration_persistence<'a>(&'a self) -> &(dyn MigrationPersistence + 'a) {
         self.api.connector()
     }
 

--- a/migration-engine/migration-engine-tests/tests/apply_migrations/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/apply_migrations/mod.rs
@@ -112,7 +112,7 @@ async fn migrations_should_fail_when_the_script_is_invalid(api: &TestApi) -> Tes
 
     assert!(result.is_err());
 
-    let mut migrations = api.imperative_migration_persistence().list_migrations().await?.unwrap();
+    let mut migrations = api.migration_persistence().list_migrations().await?.unwrap();
 
     assert_eq!(migrations.len(), 2);
 

--- a/migration-engine/migration-engine-tests/tests/migrations/apply_script_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/apply_script_tests.rs
@@ -34,7 +34,7 @@ async fn apply_script_applies_the_script_without_touching_migrations_persistence
     out.assert_migration_directories_count(1)?;
 
     // There is no new migration in the table.
-    let migrations = api.imperative_migration_persistence().list_migrations().await?.unwrap();
+    let migrations = api.migration_persistence().list_migrations().await?.unwrap();
     assert_eq!(migrations.len(), 1);
 
     // The script was applied

--- a/migration-engine/migration-engine-tests/tests/migrations/mark_migration_applied_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/mark_migration_applied_tests.rs
@@ -5,7 +5,7 @@ use pretty_assertions::assert_eq;
 #[test_each_connector]
 async fn mark_migration_applied_on_an_empty_database_works(api: &TestApi) -> TestResult {
     let migrations_directory = api.create_migrations_directory()?;
-    let persistence = api.imperative_migration_persistence();
+    let persistence = api.migration_persistence();
 
     let dm = r#"
         model Test {
@@ -53,7 +53,7 @@ async fn mark_migration_applied_on_an_empty_database_works(api: &TestApi) -> Tes
 #[test_each_connector]
 async fn mark_migration_applied_on_a_non_empty_database_works(api: &TestApi) -> TestResult {
     let migrations_directory = api.create_migrations_directory()?;
-    let persistence = api.imperative_migration_persistence();
+    let persistence = api.migration_persistence();
 
     // Create and apply a first migration
     let initial_migration_name = {
@@ -126,7 +126,7 @@ async fn mark_migration_applied_on_a_non_empty_database_works(api: &TestApi) -> 
 #[test_each_connector]
 async fn mark_migration_applied_when_the_migration_is_already_applied_errors(api: &TestApi) -> TestResult {
     let migrations_directory = api.create_migrations_directory()?;
-    let persistence = api.imperative_migration_persistence();
+    let persistence = api.migration_persistence();
 
     // Create and apply a first migration
     let initial_migration_name = {
@@ -206,7 +206,7 @@ async fn mark_migration_applied_when_the_migration_is_already_applied_errors(api
 #[test_each_connector]
 async fn mark_migration_applied_when_the_migration_is_failed(api: &TestApi) -> TestResult {
     let migrations_directory = api.create_migrations_directory()?;
-    let persistence = api.imperative_migration_persistence();
+    let persistence = api.migration_persistence();
 
     // Create and apply a first migration
     let initial_migration_name = {
@@ -296,7 +296,7 @@ async fn mark_migration_applied_when_the_migration_is_failed(api: &TestApi) -> T
 #[test_each_connector]
 async fn baselining_should_work(api: &TestApi) -> TestResult {
     let migrations_directory = api.create_migrations_directory()?;
-    let persistence = api.imperative_migration_persistence();
+    let persistence = api.migration_persistence();
 
     api.barrel()
         .execute(|migration| {

--- a/migration-engine/migration-engine-tests/tests/migrations/mark_migration_rolled_back_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/mark_migration_rolled_back_tests.rs
@@ -15,7 +15,7 @@ async fn mark_migration_rolled_back_on_an_empty_database_errors(api: &TestApi) -
 
 #[test_each_connector]
 async fn mark_migration_rolled_back_on_a_database_with_migrations_table_errors(api: &TestApi) -> TestResult {
-    api.imperative_migration_persistence().initialize().await?;
+    api.migration_persistence().initialize().await?;
 
     let err = api.mark_migration_rolled_back("anything").send().await.unwrap_err();
 
@@ -30,7 +30,7 @@ async fn mark_migration_rolled_back_on_a_database_with_migrations_table_errors(a
 #[test_each_connector]
 async fn mark_migration_rolled_back_with_a_failed_migration_works(api: &TestApi) -> TestResult {
     let migrations_directory = api.create_migrations_directory()?;
-    let persistence = api.imperative_migration_persistence();
+    let persistence = api.migration_persistence();
 
     // Create and apply a first migration
     let initial_migration_name = {
@@ -112,7 +112,7 @@ async fn mark_migration_rolled_back_with_a_failed_migration_works(api: &TestApi)
 #[test_each_connector]
 async fn mark_migration_rolled_back_with_a_successful_migration_errors(api: &TestApi) -> TestResult {
     let migrations_directory = api.create_migrations_directory()?;
-    let persistence = api.imperative_migration_persistence();
+    let persistence = api.migration_persistence();
 
     // Create and apply a first migration
     let initial_migration_name = {
@@ -196,7 +196,7 @@ async fn mark_migration_rolled_back_with_a_successful_migration_errors(api: &Tes
 #[test_each_connector]
 async fn rolling_back_applying_again_then_rolling_back_again_should_error(api: &TestApi) -> TestResult {
     let migrations_directory = api.create_migrations_directory()?;
-    let persistence = api.imperative_migration_persistence();
+    let persistence = api.migration_persistence();
 
     // Create and apply a first migration
     let initial_migration_name = {

--- a/migration-engine/migration-engine-tests/tests/migrations/migration_persistence_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/migration_persistence_tests.rs
@@ -4,7 +4,7 @@ use pretty_assertions::assert_eq;
 
 #[test_each_connector]
 async fn starting_a_migration_works(api: &TestApi) -> TestResult {
-    let persistence = api.imperative_migration_persistence();
+    let persistence = api.migration_persistence();
 
     persistence.initialize().await?;
 
@@ -41,7 +41,7 @@ async fn starting_a_migration_works(api: &TestApi) -> TestResult {
 
 #[test_each_connector]
 async fn finishing_a_migration_works(api: &TestApi) -> TestResult {
-    let persistence = api.imperative_migration_persistence();
+    let persistence = api.migration_persistence();
 
     persistence.initialize().await?;
 
@@ -82,7 +82,7 @@ async fn finishing_a_migration_works(api: &TestApi) -> TestResult {
 
 #[test_each_connector]
 async fn updating_then_finishing_a_migration_works(api: &TestApi) -> TestResult {
-    let persistence = api.imperative_migration_persistence();
+    let persistence = api.migration_persistence();
 
     persistence.initialize().await?;
 
@@ -124,7 +124,7 @@ async fn updating_then_finishing_a_migration_works(api: &TestApi) -> TestResult 
 
 #[test_each_connector]
 async fn multiple_successive_migrations_work(api: &TestApi) -> TestResult {
-    let persistence = api.imperative_migration_persistence();
+    let persistence = api.migration_persistence();
 
     persistence.initialize().await?;
 

--- a/migration-engine/migration-engine-tests/tests/migrations/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/mod.rs
@@ -6,6 +6,7 @@ mod json;
 mod mariadb;
 mod mark_migration_applied_tests;
 mod mark_migration_rolled_back_tests;
+mod migration_persistence_tests;
 mod mysql;
 mod postgres;
 mod sql;


### PR DESCRIPTION
There is no naming conflict anymore.