### PR TITLE
Error for referencing over schemas

### DIFF
--- a/libs/sql-schema-describer/src/error.rs
+++ b/libs/sql-schema-describer/src/error.rs
@@ -77,7 +77,7 @@ impl Display for DescriberErrorKind {
             Self::CrossSchemaReference { from, to, constraint } => {
                 write!(
                     f,
-                    "Illegal cross schema reference from `{}` to `{}` in constraint `{}`. Foreign keys between database schemas are not supported in Prisma. Please follow up the GitHub ticket: https://github.com/prisma/prisma/issues/1175",
+                    "Illegal cross schema reference from `{}` to `{}` in constraint `{}`. Foreign keys between database schemas are not supported in Prisma. Please follow the GitHub ticket: https://github.com/prisma/prisma/issues/1175",
                     from, to, constraint
                 )
             }

--- a/libs/sql-schema-describer/tests/mssql_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/mssql_describer_tests.rs
@@ -507,7 +507,7 @@ async fn mssql_cross_schema_references_are_not_allowed() {
     let err = inspector.describe(db_name).await.unwrap_err();
 
     assert_eq!(
-        format!("Illegal cross schema reference from `mssql_cross_schema_references_are_not_allowed.User` to `mssql_foreign_key_on_delete_must_be_handled_B.City` in constraint `FK__city`. Foreign keys between database schemas are not supported in Prisma. Please follow up the GitHub ticket: https://github.com/prisma/prisma/issues/1175"),
+        format!("Illegal cross schema reference from `mssql_cross_schema_references_are_not_allowed.User` to `mssql_foreign_key_on_delete_must_be_handled_B.City` in constraint `FK__city`. Foreign keys between database schemas are not supported in Prisma. Please follow the GitHub ticket: https://github.com/prisma/prisma/issues/1175"),
         format!("{}", err),
     );
 }

--- a/libs/sql-schema-describer/tests/mssql_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/mssql_describer_tests.rs
@@ -5,7 +5,9 @@ use crate::mssql::*;
 use barrel::{types, Migration};
 use native_types::{MsSqlType, MsSqlTypeParameter::*, NativeType};
 use pretty_assertions::assert_eq;
+use quaint::single::Quaint;
 use sql_schema_describer::*;
+use test_setup::mssql_2019_url;
 
 #[tokio::test]
 async fn all_mssql_column_types_must_work() {
@@ -472,6 +474,42 @@ async fn all_mssql_column_types_must_work() {
         .as_ref()
         .map(|s| s.starts_with("PK__User__"))
         .unwrap_or(false));
+}
+
+#[tokio::test]
+async fn mssql_cross_schema_references_are_not_allowed() {
+    let db_name = "mssql_cross_schema_references_are_not_allowed";
+    let secondary = "mssql_foreign_key_on_delete_must_be_handled_B";
+
+    for s in &[db_name, secondary] {
+        let connection_string = mssql_2019_url("master");
+        let conn = Quaint::new(&connection_string).await.unwrap();
+
+        test_setup::connectors::mssql::reset_schema(&conn, s).await.unwrap();
+    }
+
+    let sql = format!(
+        "
+            CREATE TABLE [{1}].[City] (id INT NOT NULL IDENTITY(1,1), CONSTRAINT [PK__City] PRIMARY KEY ([id]));
+            CREATE TABLE [{0}].[User]
+            (
+                id           INT NOT NULL IDENTITY (1,1),
+                city         INT,
+                city_cascade INT,
+                CONSTRAINT [FK__city] FOREIGN KEY (city) REFERENCES [{1}].[City] (id) ON DELETE NO ACTION,
+                CONSTRAINT [PK__User] PRIMARY KEY ([id])
+            );
+        ",
+        db_name, secondary
+    );
+
+    let inspector = get_mssql_describer_for_schema(dbg!(&sql), db_name).await;
+    let err = inspector.describe(db_name).await.unwrap_err();
+
+    assert_eq!(
+        format!("Illegal cross schema reference from `mssql_cross_schema_references_are_not_allowed.User` to `mssql_foreign_key_on_delete_must_be_handled_B.City` in constraint `FK__city`. Foreign keys between database schemas are not supported in Prisma. Please follow up the GitHub ticket: https://github.com/prisma/prisma/issues/1175"),
+        format!("{}", err),
+    );
 }
 
 #[tokio::test]

--- a/libs/sql-schema-describer/tests/postgres_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/postgres_describer_tests.rs
@@ -674,7 +674,7 @@ async fn postgres_cross_schema_references_are_not_allowed() {
     let err = inspector.describe(SCHEMA).await.unwrap_err();
 
     assert_eq!(
-        format!("Illegal cross schema reference from `DatabaseInspector-Test.User` to `DatabaseInspector-Test_2.City` in constraint `User_city_fkey`. Foreign keys between database schemas are not supported in Prisma. Please follow up the GitHub ticket: https://github.com/prisma/prisma/issues/1175"),
+        format!("Illegal cross schema reference from `DatabaseInspector-Test.User` to `DatabaseInspector-Test_2.City` in constraint `User_city_fkey`. Foreign keys between database schemas are not supported in Prisma. Please follow the GitHub ticket: https://github.com/prisma/prisma/issues/1175"),
         format!("{}", err),
     );
 }

--- a/libs/sql-schema-describer/tests/postgres_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/postgres_describer_tests.rs
@@ -654,6 +654,32 @@ async fn all_postgres_column_types_must_work() {
 }
 
 #[tokio::test]
+async fn postgres_cross_schema_references_are_not_allowed() {
+    let schema2 = format!("{}_2", SCHEMA);
+
+    let sql = format!(
+        "DROP SCHEMA IF EXISTS \"{0}\" CASCADE;
+         CREATE SCHEMA \"{0}\";
+         CREATE TABLE \"{0}\".\"City\" (id INT PRIMARY KEY);
+         CREATE TABLE \"{1}\".\"User\" (
+            id INT PRIMARY KEY,
+            city INT REFERENCES \"{0}\".\"City\" (id) ON DELETE NO ACTION
+        );
+        ",
+        schema2, SCHEMA
+    );
+
+    let inspector = get_postgres_describer(&sql, "postgres_cross_schema_references_are_not_allowed").await;
+
+    let err = inspector.describe(SCHEMA).await.unwrap_err();
+
+    assert_eq!(
+        format!("Illegal cross schema reference from `DatabaseInspector-Test.User` to `DatabaseInspector-Test_2.City` in constraint `User_city_fkey`. Foreign keys between database schemas are not supported in Prisma. Please follow up the GitHub ticket: https://github.com/prisma/prisma/issues/1175"),
+        format!("{}", err),
+    );
+}
+
+#[tokio::test]
 async fn postgres_foreign_key_on_delete_must_be_handled() {
     let sql = format!(
         "CREATE TABLE \"{0}\".\"City\" (id INT PRIMARY KEY);

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/mysql.rs
@@ -116,6 +116,9 @@ impl SqlFlavour for MysqlFlavour {
                 DescriberErrorKind::QuaintError(err) => {
                     quaint_error_to_connector_error(err, connection.connection_info())
                 }
+                DescriberErrorKind::CrossSchemaReference { .. } => {
+                    unreachable!("No schemas in MySQL")
+                }
             })
     }
 

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/sqlite.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/sqlite.rs
@@ -59,6 +59,9 @@ impl SqlFlavour for SqliteFlavour {
                 DescriberErrorKind::QuaintError(err) => {
                     quaint_error_to_connector_error(err, connection.connection_info())
                 }
+                DescriberErrorKind::CrossSchemaReference { .. } => {
+                    unreachable!("No schemas in SQLite")
+                }
             })
     }
 


### PR DESCRIPTION
We do not support referencing between different schemas, so we should give a proper error for the user.

Example:

> Illegal cross schema reference from `mssql_cross_schema_references_are_not_allowed.User` to `mssql_foreign_key_on_delete_must_be_handled_B.City` in constraint `FK__city`. Foreign keys between database schemas are not supported in Prisma. Please follow the GitHub ticket: https://github.com/prisma/prisma/issues/1175

Closes: https://github.com/prisma/prisma/issues/4890