### PR TITLE
fix: nested m2m when selecting only the id field

### DIFF
--- a/libs/prisma-models/src/record.rs
+++ b/libs/prisma-models/src/record.rs
@@ -1,5 +1,4 @@
 use crate::{DomainError, ModelProjection, OrderBy, PrismaValue, RecordProjection, ScalarFieldRef, SortOrder};
-use itertools::Itertools;
 use std::collections::HashMap;
 
 #[derive(Debug, Clone)]
@@ -120,9 +119,10 @@ impl ManyRecords {
         self.records.reverse();
     }
 
-    pub fn with_unique_records(mut self) -> Self {
-        self.records = self.records.into_iter().unique().collect();
-        self
+    /// Reverses the wrapped records in place
+    pub fn dedup(&mut self) {
+        self.records.sort_unstable();
+        self.records.dedup();
     }
 }
 
@@ -130,6 +130,18 @@ impl ManyRecords {
 pub struct Record {
     pub values: Vec<PrismaValue>,
     pub parent_id: Option<RecordProjection>,
+}
+
+impl Ord for Record {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.values.cmp(&other.values)
+    }
+}
+
+impl PartialOrd for Record {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.values.partial_cmp(&other.values)
+    }
 }
 
 impl Record {

--- a/libs/prisma-models/src/record.rs
+++ b/libs/prisma-models/src/record.rs
@@ -120,6 +120,13 @@ impl ManyRecords {
     pub fn reverse(&mut self) {
         self.records.reverse();
     }
+
+    pub fn with_unique_records(self) -> Self {
+        Self {
+            records: self.records.into_iter().unique().collect(),
+            field_names: self.field_names,
+        }
+    }
 }
 
 #[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]

--- a/libs/prisma-models/src/record.rs
+++ b/libs/prisma-models/src/record.rs
@@ -1,5 +1,6 @@
 use crate::{DomainError, ModelProjection, OrderBy, PrismaValue, RecordProjection, ScalarFieldRef, SortOrder};
 use std::collections::HashMap;
+use itertools::Itertools;
 
 #[derive(Debug, Clone)]
 pub struct SingleRecord {
@@ -59,6 +60,7 @@ impl ManyRecords {
                     values: v,
                     parent_id: None,
                 })
+                .unique()
                 .collect(),
             field_names: selected_fields.db_names().collect(),
         }
@@ -120,7 +122,7 @@ impl ManyRecords {
     }
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
 pub struct Record {
     pub values: Vec<PrismaValue>,
     pub parent_id: Option<RecordProjection>,

--- a/libs/prisma-models/src/record.rs
+++ b/libs/prisma-models/src/record.rs
@@ -120,7 +120,7 @@ impl ManyRecords {
         self.records.reverse();
     }
 
-    /// Reverses the wrapped records in place
+    /// Deduplicate the wrapped records
     pub fn with_unique_records(mut self) -> Self {
         self.records = self.records.into_iter().unique().collect();
         self

--- a/libs/prisma-models/src/record.rs
+++ b/libs/prisma-models/src/record.rs
@@ -1,4 +1,5 @@
 use crate::{DomainError, ModelProjection, OrderBy, PrismaValue, RecordProjection, ScalarFieldRef, SortOrder};
+use itertools::Itertools;
 use std::collections::HashMap;
 
 #[derive(Debug, Clone)]
@@ -120,28 +121,16 @@ impl ManyRecords {
     }
 
     /// Reverses the wrapped records in place
-    pub fn dedup(&mut self) {
-        self.records.sort_unstable();
-        self.records.dedup();
+    pub fn with_unique_records(mut self) -> Self {
+        self.records = self.records.into_iter().unique().collect();
+        self
     }
 }
 
-#[derive(Debug, Default, Clone, Eq, PartialEq)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
 pub struct Record {
     pub values: Vec<PrismaValue>,
     pub parent_id: Option<RecordProjection>,
-}
-
-impl Ord for Record {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.values.cmp(&other.values)
-    }
-}
-
-impl PartialOrd for Record {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.values.partial_cmp(&other.values)
-    }
 }
 
 impl Record {

--- a/libs/prisma-models/src/record.rs
+++ b/libs/prisma-models/src/record.rs
@@ -126,7 +126,7 @@ impl ManyRecords {
     }
 }
 
-#[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub struct Record {
     pub values: Vec<PrismaValue>,
     pub parent_id: Option<RecordProjection>,

--- a/libs/prisma-models/src/record.rs
+++ b/libs/prisma-models/src/record.rs
@@ -1,6 +1,6 @@
 use crate::{DomainError, ModelProjection, OrderBy, PrismaValue, RecordProjection, ScalarFieldRef, SortOrder};
-use std::collections::HashMap;
 use itertools::Itertools;
+use std::collections::HashMap;
 
 #[derive(Debug, Clone)]
 pub struct SingleRecord {

--- a/libs/prisma-models/src/record.rs
+++ b/libs/prisma-models/src/record.rs
@@ -60,7 +60,6 @@ impl ManyRecords {
                     values: v,
                     parent_id: None,
                 })
-                .unique()
                 .collect(),
             field_names: selected_fields.db_names().collect(),
         }
@@ -121,11 +120,9 @@ impl ManyRecords {
         self.records.reverse();
     }
 
-    pub fn with_unique_records(self) -> Self {
-        Self {
-            records: self.records.into_iter().unique().collect(),
-            field_names: self.field_names,
-        }
+    pub fn with_unique_records(mut self) -> Self {
+        self.records = self.records.into_iter().unique().collect();
+        self
     }
 }
 

--- a/query-engine/connector-test-kit/src/test/scala/queries/regressions/Prisma_933Spec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/regressions/Prisma_933Spec.scala
@@ -15,21 +15,13 @@ class Prisma_933Spec extends FlatSpec with Matchers with ApiSpecBase {
          |  buyer_id Int    @id @default(autoincrement())
          |  name     String?
          |  sales    Sale[]    @relation("BuyersOnSale", references: [sale_id])
-         |  products Product[] @relation("BuyersOnProduct", references: [product_id])
          |}
          |
          |model Sale {
          |  sale_id  Int    @id @default(autoincrement())
          |  buyers   Buyer[]   @relation("BuyersOnSale", references: [buyer_id])
-         |  products Product[] @relation("SalesOnProduct", references: [product_id])
          |}
          |
-         |model Product {
-         |  product_id Int  @id @default(autoincrement())
-         |  name       String?
-         |  buyers     Buyer[] @relation("BuyersOnProduct", references: [buyer_id])
-         |  sales      Sale[]  @relation("SalesOnProduct", references: [sale_id])
-         |}
          |
        """.stripMargin
     }
@@ -42,7 +34,6 @@ class Prisma_933Spec extends FlatSpec with Matchers with ApiSpecBase {
        |   createOneBuyer(
        |    data: {
        |      name: "Foo",
-       |      products: { create: [{ name: "product 1" }, { name: "product2" }] },
        |      sales: {
        |        create: [{}, {}]
        |      }
@@ -52,9 +43,6 @@ class Prisma_933Spec extends FlatSpec with Matchers with ApiSpecBase {
        |     sales {
        |       sale_id
        |     }
-       |     products {
-       |       product_id
-       |     }
        |  }
        |}
       """,
@@ -62,19 +50,6 @@ class Prisma_933Spec extends FlatSpec with Matchers with ApiSpecBase {
       "",
       false
     )
-
-    server.query(
-      """
-       |mutation {
-       |  updateOneSale(
-       |    where: { sale_id: 1 },
-       |    data: { products: { connect: [{ product_id: 1, product_id: 2 }] } }
-       |  ) {
-       |    sale_id
-       |  }
-       |}
-       |
-       """, project, "", false)
 
     val res = server.query(
       """

--- a/query-engine/connector-test-kit/src/test/scala/queries/regressions/Prisma_933Spec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/regressions/Prisma_933Spec.scala
@@ -1,0 +1,95 @@
+package queries.regressions
+
+import org.scalatest.{FlatSpec, Matchers}
+import util.ConnectorCapability.JoinRelationLinksCapability
+import util._
+
+class Prisma_933Spec extends FlatSpec with Matchers with ApiSpecBase {
+  // validates fix for
+  //https://github.com/prisma/prisma-client-js/issues/933
+
+  "Querying the same M:M at different levels with only the ID field" should "work" in {
+    val project = ProjectDsl.fromString {
+      s"""
+         |model Buyer {
+         |  buyer_id Int    @id @default(autoincrement())
+         |  name     String?
+         |  sales    Sale[]    @relation("BuyersOnSale", references: [sale_id])
+         |  products Product[] @relation("BuyersOnProduct", references: [product_id])
+         |}
+         |
+         |model Sale {
+         |  sale_id  Int    @id @default(autoincrement())
+         |  buyers   Buyer[]   @relation("BuyersOnSale", references: [buyer_id])
+         |  products Product[] @relation("SalesOnProduct", references: [product_id])
+         |}
+         |
+         |model Product {
+         |  product_id Int  @id @default(autoincrement())
+         |  name       String?
+         |  buyers     Buyer[] @relation("BuyersOnProduct", references: [buyer_id])
+         |  sales      Sale[]  @relation("SalesOnProduct", references: [sale_id])
+         |}
+         |
+       """.stripMargin
+    }
+
+    database.setup(project)
+
+    server.query(
+      """
+       | mutation {
+       |   createOneBuyer(
+       |    data: {
+       |      name: "Foo",
+       |      products: { create: [{ name: "product 1" }, { name: "product2" }] },
+       |      sales: {
+       |        create: [{}, {}]
+       |      }
+       |    }
+       |   ) {
+       |    buyer_id
+       |     sales {
+       |       sale_id
+       |     }
+       |     products {
+       |       product_id
+       |     }
+       |  }
+       |}
+      """,
+      project,
+      "",
+      false
+    )
+
+    server.query(
+      """
+       |mutation {
+       |  updateOneSale(
+       |    where: { sale_id: 1 },
+       |    data: { products: { connect: [{ product_id: 1, product_id: 2 }] } }
+       |  ) {
+       |    sale_id
+       |  }
+       |}
+       |
+       """, project, "", false)
+
+    val res = server.query(
+      """
+        | query {
+        |   findManyBuyer {
+        |     sales {
+        |       buyers {
+        |         buyer_id
+        |       }
+        |     }
+        |   }
+        | }
+        |
+      """, project, "", false)
+
+    res.toString() should be("{\"data\":{\"findManyBuyer\":[{\"sales\":[{\"buyers\":[{\"buyer_id\":1}]},{\"buyers\":[{\"buyer_id\":1}]}]}]}}")
+  }
+}

--- a/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
@@ -45,9 +45,9 @@ pub async fn m2m<'a, 'b>(
 
     // a roundtrip can be avoided if: there is no additional filter AND the selection set is the child_link_id
     let mut scalars = if query.args.do_nothing() && child_link_id == query.selected_fields {
-            let mut projected_scalars = ManyRecords::from_projection(child_ids, &query.selected_fields);
-            projected_scalars.dedup();
-            projected_scalars
+        let mut projected_scalars = ManyRecords::from_projection(child_ids, &query.selected_fields);
+        projected_scalars.dedup();
+        projected_scalars
     } else {
         let mut args = query.args.clone();
         let filter = child_link_id.is_in(child_ids);

--- a/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
@@ -45,7 +45,7 @@ pub async fn m2m<'a, 'b>(
 
     // a roundtrip can be avoided if: there is no additional filter AND the selection set is the child_link_id
     let mut scalars = if query.args.do_nothing() && child_link_id == query.selected_fields {
-        ManyRecords::from_projection(child_ids, &query.selected_fields)
+        ManyRecords::from_projection(child_ids, &query.selected_fields).with_unique_records()
     } else {
         let mut args = query.args.clone();
         let filter = child_link_id.is_in(child_ids);
@@ -166,7 +166,7 @@ pub async fn one2m<'a, 'b>(
 
     // a roundtrip can be avoided if: there is no additional filter AND the selection set is the child_link_id
     let mut scalars = if query_args.do_nothing() && &child_link_id == selected_fields {
-        ManyRecords::from_projection(uniq_projections, selected_fields)
+        ManyRecords::from_projection(uniq_projections, selected_fields).with_unique_records()
     } else {
         let filter = child_link_id.is_in(uniq_projections);
         let mut args = query_args;

--- a/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
@@ -45,7 +45,9 @@ pub async fn m2m<'a, 'b>(
 
     // a roundtrip can be avoided if: there is no additional filter AND the selection set is the child_link_id
     let mut scalars = if query.args.do_nothing() && child_link_id == query.selected_fields {
-        ManyRecords::from_projection(child_ids, &query.selected_fields).with_unique_records()
+            let mut projected_scalars = ManyRecords::from_projection(child_ids, &query.selected_fields);
+            projected_scalars.dedup();
+            projected_scalars
     } else {
         let mut args = query.args.clone();
         let filter = child_link_id.is_in(child_ids);
@@ -166,7 +168,9 @@ pub async fn one2m<'a, 'b>(
 
     // a roundtrip can be avoided if: there is no additional filter AND the selection set is the child_link_id
     let mut scalars = if query_args.do_nothing() && &child_link_id == selected_fields {
-        ManyRecords::from_projection(uniq_projections, selected_fields).with_unique_records()
+        let mut projected_scalars = ManyRecords::from_projection(uniq_projections, selected_fields);
+        projected_scalars.dedup();
+        projected_scalars
     } else {
         let filter = child_link_id.is_in(uniq_projections);
         let mut args = query_args;

--- a/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
@@ -45,9 +45,7 @@ pub async fn m2m<'a, 'b>(
 
     // a roundtrip can be avoided if: there is no additional filter AND the selection set is the child_link_id
     let mut scalars = if query.args.do_nothing() && child_link_id == query.selected_fields {
-        let mut projected_scalars = ManyRecords::from_projection(child_ids, &query.selected_fields);
-        projected_scalars.dedup();
-        projected_scalars
+        ManyRecords::from_projection(child_ids, &query.selected_fields).with_unique_records()
     } else {
         let mut args = query.args.clone();
         let filter = child_link_id.is_in(child_ids);
@@ -168,9 +166,7 @@ pub async fn one2m<'a, 'b>(
 
     // a roundtrip can be avoided if: there is no additional filter AND the selection set is the child_link_id
     let mut scalars = if query_args.do_nothing() && &child_link_id == selected_fields {
-        let mut projected_scalars = ManyRecords::from_projection(uniq_projections, selected_fields);
-        projected_scalars.dedup();
-        projected_scalars
+        ManyRecords::from_projection(uniq_projections, selected_fields).with_unique_records()
     } else {
         let filter = child_link_id.is_in(uniq_projections);
         let mut args = query_args;


### PR DESCRIPTION
Fixes https://github.com/prisma/prisma-client-js/issues/933
Fixes https://github.com/prisma/prisma/issues/5073

### Explanation

This issue only occurred when resolving m2m in an optimized way to reduce roundtrips, that is to say when the child data is already fetched by a parent.

In this case, we compute in-memory what the db would give us back. That in-memory computation isn't properly mirroring what the db gives us back.

Assuming the following datamodel:

```prisma
model Buyer {
  buyer_id Int    @id @default(autoincrement())
  name     String?
  sales    Sale[]    @relation("BuyersOnSale", references: [sale_id])
}

model Sale {
  sale_id  Int    @id @default(autoincrement())
  date     DateTime?
  buyers   Buyer[]   @relation("BuyersOnSale", references: [buyer_id])
}
```

And the following query:

```graphql
{
  findManyBuyer {
    sales {
      buyers {
        buyer_id
      }
    }
  }
}
```

When resolving `sales.buyers`, assuming we're doing a db roundtrip, we roughly send the following SQL query:

```sql
SELECT buyer_id FROM Buyer WHERE buyer_id IN (parent_buyer_ids...)
```

Assuming we only have a single buyer with id `1`, associated with 2 sales, it'd resolve to:

```sql
SELECT buyer_id FROM Buyer WHERE buyer_id IN (1, 1)
```

Thus returning roughly:

```
[Record { values: [1], field_names: ["buyer_id"] }]
```

When going into in-memory computation path though, we were directly remapping the child ids to some `Record`. Since we'd have `[{ buyer_id: 1 }, { buyer_id: 1 }]` as child ids, that'd resolve to:

```
[Record { values: [1], field_names: ["buyer_id"] }, Record { values: [1], field_names: ["buyer_id"] }]
```

This inconsistency was leading to unexpected behavior later in the function.

The proposed fix simply removes duplicates so that we mirror the SQL semantic, which, "by nature" doesn't allow duplicates.