### PR TITLE
feat: make OR filter always a list

### DIFF
--- a/query-engine/core/src/schema_builder/input_types/objects/filter_objects.rs
+++ b/query-engine/core/src/schema_builder/input_types/objects/filter_objects.rs
@@ -25,7 +25,7 @@ pub(crate) fn scalar_filter_object_type(
         .optional(),
         input_field(
             "OR",
-            vec![object_type.clone(), InputType::list(object_type.clone())],
+            vec![InputType::list(object_type.clone())],
             None,
         )
         .optional(),
@@ -60,7 +60,7 @@ pub(crate) fn where_object_type(ctx: &mut BuilderContext, model: &ModelRef) -> I
         .optional(),
         input_field(
             "OR",
-            vec![object_type.clone(), InputType::list(object_type.clone())],
+            vec![InputType::list(object_type.clone())],
             None,
         )
         .optional(),

--- a/query-engine/core/src/schema_builder/input_types/objects/filter_objects.rs
+++ b/query-engine/core/src/schema_builder/input_types/objects/filter_objects.rs
@@ -23,12 +23,7 @@ pub(crate) fn scalar_filter_object_type(
             None,
         )
         .optional(),
-        input_field(
-            "OR",
-            vec![InputType::list(object_type.clone())],
-            None,
-        )
-        .optional(),
+        input_field("OR", vec![InputType::list(object_type.clone())], None).optional(),
         input_field("NOT", vec![object_type.clone(), InputType::list(object_type)], None).optional(),
     ];
 
@@ -58,12 +53,7 @@ pub(crate) fn where_object_type(ctx: &mut BuilderContext, model: &ModelRef) -> I
             None,
         )
         .optional(),
-        input_field(
-            "OR",
-            vec![InputType::list(object_type.clone())],
-            None,
-        )
-        .optional(),
+        input_field("OR", vec![InputType::list(object_type.clone())], None).optional(),
         input_field("NOT", vec![object_type.clone(), InputType::list(object_type)], None).optional(),
     ];
 


### PR DESCRIPTION
Fixes https://github.com/prisma/prisma/issues/4831

BREAKING CHANGE: The OR filter as object will no longer be part of the schema. Users will be forced to input an OR filter as an array from now on.