### PR TITLE
User-facing error for inconsistent column data

### DIFF
--- a/libs/user-facing-errors/src/query_engine.rs
+++ b/libs/user-facing-errors/src/query_engine.rs
@@ -241,3 +241,9 @@ pub struct TableDoesNotExist {
 pub struct ColumnDoesNotExist {
     pub column: String,
 }
+
+#[derive(Debug, UserFacingError, Serialize)]
+#[user_facing(code = "P2023", message = "Inconsistent column data: {message}")]
+pub struct InconsistentColumnData {
+    pub message: String,
+}

--- a/query-engine/connectors/query-connector/src/error.rs
+++ b/query-engine/connectors/query-connector/src/error.rs
@@ -48,6 +48,11 @@ impl ConnectorError {
                     field_name,
                 }))
             }
+            ErrorKind::ConversionError(message) => Some(KnownError::new(
+                user_facing_errors::query_engine::InconsistentColumnData {
+                    message: format!("{}", message),
+                },
+            )),
 
             _ => None,
         };

--- a/query-engine/connectors/sql-query-connector/src/column_metadata.rs
+++ b/query-engine/connectors/sql-query-connector/src/column_metadata.rs
@@ -1,0 +1,64 @@
+use datamodel::FieldArity;
+use prisma_models::TypeIdentifier;
+
+/// Helps dealing with column value conversion and possible error resolution.
+#[derive(Clone, Debug, Copy)]
+pub struct ColumnMetadata<'a> {
+    identifier: &'a TypeIdentifier,
+    name: Option<&'a str>,
+    arity: FieldArity,
+}
+
+impl<'a> ColumnMetadata<'a> {
+    fn new(identifier: &'a TypeIdentifier, arity: FieldArity) -> Self {
+        Self {
+            identifier,
+            name: None,
+            arity,
+        }
+    }
+
+    /// If set, the errors can refer to the column holding broken data.
+    fn set_name(mut self, name: &'a str) -> Self {
+        self.name = Some(name);
+        self
+    }
+
+    /// The type of the column.
+    pub fn identifier(self) -> &'a TypeIdentifier {
+        self.identifier
+    }
+
+    /// The name of the column.
+    pub fn name(self) -> Option<&'a str> {
+        self.name
+    }
+
+    /// The arity of the column.
+    pub fn arity(self) -> FieldArity {
+        self.arity
+    }
+}
+
+/// Create a set of metadata objects, combining column names and type
+/// information.
+pub fn create<'a, T>(field_names: &'a [T], idents: &'a [(TypeIdentifier, FieldArity)]) -> Vec<ColumnMetadata<'a>>
+where
+    T: AsRef<str>,
+{
+    assert_eq!(field_names.len(), idents.len());
+
+    idents
+        .iter()
+        .zip(field_names.iter())
+        .map(|((identifier, arity), name)| ColumnMetadata::new(identifier, *arity).set_name(name.as_ref()))
+        .collect()
+}
+
+/// Create a set of metadata objects.
+pub fn create_anonymous<'a>(idents: &'a [(TypeIdentifier, FieldArity)]) -> Vec<ColumnMetadata<'a>> {
+    idents
+        .iter()
+        .map(|(identifier, arity)| ColumnMetadata::new(identifier, *arity))
+        .collect()
+}

--- a/query-engine/connectors/sql-query-connector/src/lib.rs
+++ b/query-engine/connectors/sql-query-connector/src/lib.rs
@@ -1,3 +1,4 @@
+mod column_metadata;
 mod cursor_condition;
 mod database;
 mod error;
@@ -8,6 +9,7 @@ mod query_builder;
 mod query_ext;
 mod row;
 
+use column_metadata::*;
 use filter_conversion::*;
 use query_ext::QueryExt;
 use row::*;


### PR DESCRIPTION
E.g. SQLite column mixing booleans and strings.

Example:

> Inconsistent column data: Could not convert value \"\" of the field `fips` to type `Int`.

Closes: https://github.com/prisma/prisma/issues/4778