### PR TITLE
Vendor OpenSSL on macOS platforms for SQL Server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2418,6 +2418,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
+name = "openssl-src"
+version = "111.13.0+1.1.1i"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "045e4dc48af57aad93d665885789b43222ae26f4886494da12d1ed58d309dcb6"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2426,8 +2435,23 @@ dependencies = [
  "autocfg 1.0.1",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "opentls"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a764fc7777a53b3fa76a73322c3fd5bf1112dc1c7cad548156c43398198bc4de"
+dependencies = [
+ "futures-util",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "url 2.2.0",
 ]
 
 [[package]]
@@ -2857,7 +2881,7 @@ dependencies = [
 [[package]]
 name = "quaint"
 version = "0.2.0-alpha.13"
-source = "git+https://github.com/prisma/quaint#347a02912c2d8e03aca2461423909d66b45cab92"
+source = "git+https://github.com/prisma/quaint#7dff04ba464aae3b02c567d804a4956fda5115fd"
 dependencies = [
  "async-trait",
  "base64 0.12.3",
@@ -3759,9 +3783,9 @@ dependencies = [
 
 [[package]]
 name = "tiberius"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f37c1be8e69f882687c9cfd554b9de4630331217437f509614cc21933a5d7600"
+checksum = "bd76149fef873316b9032e970f2b2d4665904b3f1fe60157f16261545115a4e2"
 dependencies = [
  "async-native-tls",
  "async-stream",
@@ -3780,6 +3804,7 @@ dependencies = [
  "num-bigint 0.3.1",
  "num-traits",
  "once_cell",
+ "opentls",
  "pin-project-lite 0.1.11",
  "pretty-hex",
  "thiserror",

--- a/libs/test-setup/src/lib.rs
+++ b/libs/test-setup/src/lib.rs
@@ -184,7 +184,7 @@ pub fn mssql_2017_url(db_name: &str) -> String {
     let (host, port) = db_host_mssql_2017();
 
     format!(
-        "sqlserver://{host}:{port};database={db_name};user=SA;password=<YourStrong@Passw0rd>;trustServerCertificate=true;socket_timeout=60;encrypt=DANGER_PLAINTEXT;isolationLevel=READ UNCOMMITTED",
+        "sqlserver://{host}:{port};database={db_name};user=SA;password=<YourStrong@Passw0rd>;trustServerCertificate=true;socket_timeout=60;isolationLevel=READ UNCOMMITTED",
         db_name = db_name,
         host = host,
         port = port,
@@ -195,7 +195,7 @@ pub fn mssql_2019_url(db_name: &str) -> String {
     let (host, port) = db_host_and_port_mssql_2019();
 
     format!(
-        "sqlserver://{host}:{port};database={db_name};user=SA;password=<YourStrong@Passw0rd>;trustServerCertificate=true;socket_timeout=60;encrypt=DANGER_PLAINTEXT;isolationLevel=READ UNCOMMITTED",
+        "sqlserver://{host}:{port};database={db_name};user=SA;password=<YourStrong@Passw0rd>;trustServerCertificate=true;socket_timeout=60;isolationLevel=READ UNCOMMITTED",
         db_name = db_name,
         host = host,
         port = port,

--- a/migration-engine/migration-engine-tests/tests/diagnose_migration_history/diagnose_migration_history_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/diagnose_migration_history/diagnose_migration_history_tests.rs
@@ -934,7 +934,7 @@ async fn shadow_database_creation_error_is_special_cased_mssql(api: &TestApi) ->
         r#"
         datasource db {{
             provider = "sqlserver"
-            url = "sqlserver://{dbhost}:{dbport};database={dbname};user=prismashadowdbtestuser;password=1234batmanZ;encrypt=DANGER_PLAINTEXT"
+            url = "sqlserver://{dbhost}:{dbport};database={dbname};user=prismashadowdbtestuser;password=1234batmanZ;trustservercertificate=true"
         }}
         "#,
         dbhost = host,

--- a/migration-engine/migration-engine-tests/tests/migrations/dev_diagnostic_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/dev_diagnostic_tests.rs
@@ -673,7 +673,7 @@ async fn shadow_database_creation_error_is_special_cased_mssql(api: &TestApi) ->
         r#"
         datasource db {{
             provider = "sqlserver"
-            url = "sqlserver://{dbhost}:{dbport};database={dbname};user=prismashadowdbtestuser;password=1234batmanZ;encrypt=DANGER_PLAINTEXT"
+            url = "sqlserver://{dbhost}:{dbport};database={dbname};user=prismashadowdbtestuser;password=1234batmanZ;trustservercertificate=true"
         }}
         "#,
         dbhost = host,

--- a/query-engine/connector-test-kit/src/test/scala/util/ConnectorConfig.scala
+++ b/query-engine/connector-test-kit/src/test/scala/util/ConnectorConfig.scala
@@ -61,8 +61,8 @@ object ConnectorConfig {
       case "mysql8"  => ConnectorConfig("mysql", s"mysql://root:prisma@$mysql_8_0_Host:$mysql_8_0_Port/$$DB?connection_limit=1", false, "mysql8")
       case "mysql56" => ConnectorConfig("mysql56", s"mysql://root:prisma@$mysql_5_6_Host:$mysql_5_6_Port/$$DB?connection_limit=1", false, "mysql56")
       case "mariadb" => ConnectorConfig("mysql", s"mysql://root:prisma@$mariadb_Host:$mariadb_Port/$$DB?connection_limit=1", false, "mariadb")
-      case "mssql2017" => ConnectorConfig("sqlserver", s"sqlserver://$mssql_2017_Host:$mssql_2017_Port;database=master;schema=$$DB;user=SA;password=<YourStrong@Passw0rd>;trustServerCertificate=true;isolationLevel=READ UNCOMMITTED;encrypt=DANGER_PLAINTEXT", false, "mssql2017")
-      case "mssql2019" => ConnectorConfig("sqlserver", s"sqlserver://$mssql_2019_Host:$mssql_2019_Port;database=master;schema=$$DB;user=SA;password=<YourStrong@Passw0rd>;trustServerCertificate=true;isolationLevel=READ UNCOMMITTED;encrypt=DANGER_PLAINTEXT", false, "mssql2019")
+      case "mssql2017" => ConnectorConfig("sqlserver", s"sqlserver://$mssql_2017_Host:$mssql_2017_Port;database=master;schema=$$DB;user=SA;password=<YourStrong@Passw0rd>;trustServerCertificate=true;isolationLevel=READ UNCOMMITTED", false, "mssql2017")
+      case "mssql2019" => ConnectorConfig("sqlserver", s"sqlserver://$mssql_2019_Host:$mssql_2019_Port;database=master;schema=$$DB;user=SA;password=<YourStrong@Passw0rd>;trustServerCertificate=true;isolationLevel=READ UNCOMMITTED", false, "mssql2019")
       case x         => sys.error(s"Connector $x is not supported yet.")
     }
   }


### PR DESCRIPTION
This removes the need for using `encrypt=DANGER_PLAINTEXT` parameter in the connection string and enables Azure SQL connections for macOS users.