### PR TITLE
fix: groupBy nullable fields should stay nullable

### DIFF
--- a/query-engine/core/src/response_ir/ir_serializer.rs
+++ b/query-engine/core/src/response_ir/ir_serializer.rs
@@ -29,7 +29,7 @@ impl IrSerializer {
                 // so we just unpack the only result possible.
                 // Todo: The following checks feel out of place. This probably needs to be handled already one level deeper.
                 let result = if serialized.is_empty() {
-                    if !self.output_field.is_required {
+                    if self.output_field.is_nullable {
                         Item::Value(PrismaValue::Null)
                     } else {
                         match self.output_field.field_type.borrow() {

--- a/query-engine/core/src/schema/output_types.rs
+++ b/query-engine/core/src/schema/output_types.rs
@@ -150,7 +150,7 @@ pub struct OutputField {
 
     /// Indicates if the presence of the field on the higher output objects.
     /// As opposed to input fields, optional output fields are also automatically nullable.
-    pub is_required: bool,
+    pub is_nullable: bool,
 
     /// Relevant for resolving top level queries.
     pub query_info: Option<QueryInfo>,
@@ -158,7 +158,7 @@ pub struct OutputField {
 
 impl OutputField {
     pub fn optional(mut self) -> Self {
-        self.is_required = false;
+        self.is_nullable = true;
         self
     }
 

--- a/query-engine/core/src/schema/output_types.rs
+++ b/query-engine/core/src/schema/output_types.rs
@@ -148,8 +148,8 @@ pub struct OutputField {
     /// instead of being attached to an input object.
     pub arguments: Vec<InputFieldRef>,
 
-    /// Indicates if the presence of the field on the higher output objects.
-    /// As opposed to input fields, optional output fields are also automatically nullable.
+    /// Indicates the presence of the field on the higher output objects.
+    /// States whether the field can be null or can't
     pub is_nullable: bool,
 
     /// Relevant for resolving top level queries.
@@ -157,14 +157,14 @@ pub struct OutputField {
 }
 
 impl OutputField {
-    pub fn optional(mut self) -> Self {
+    pub fn nullable(mut self) -> Self {
         self.is_nullable = true;
         self
     }
 
-    pub fn optional_if(self, condition: bool) -> Self {
+    pub fn nullable_if(self, condition: bool) -> Self {
         if condition {
-            self.optional()
+            self.nullable()
         } else {
             self
         }

--- a/query-engine/core/src/schema/output_types.rs
+++ b/query-engine/core/src/schema/output_types.rs
@@ -149,7 +149,7 @@ pub struct OutputField {
     pub arguments: Vec<InputFieldRef>,
 
     /// Indicates the presence of the field on the higher output objects.
-    /// States whether the field can be null or can't
+    /// States whether or not the field can be null.
     pub is_nullable: bool,
 
     /// Relevant for resolving top level queries.

--- a/query-engine/core/src/schema_builder/output_types/aggregation/group_by.rs
+++ b/query-engine/core/src/schema_builder/output_types/aggregation/group_by.rs
@@ -94,7 +94,7 @@ fn scalar_fields(ctx: &mut BuilderContext, model: &ModelRef) -> Vec<OutputField>
     fields
         .into_iter()
         .map(|f| {
-            field(f.name.clone(), vec![], map_scalar_output_type_for_field(ctx, &f), None).optional_if(!f.is_required)
+            field(f.name.clone(), vec![], map_scalar_output_type_for_field(ctx, &f), None).nullable_if(!f.is_required)
         })
         .collect()
 }

--- a/query-engine/core/src/schema_builder/output_types/aggregation/group_by.rs
+++ b/query-engine/core/src/schema_builder/output_types/aggregation/group_by.rs
@@ -93,6 +93,8 @@ fn scalar_fields(ctx: &mut BuilderContext, model: &ModelRef) -> Vec<OutputField>
 
     fields
         .into_iter()
-        .map(|f| field(f.name.clone(), vec![], map_scalar_output_type_for_field(ctx, &f), None).optional())
+        .map(|f| {
+            field(f.name.clone(), vec![], map_scalar_output_type_for_field(ctx, &f), None).optional_if(!f.is_required)
+        })
         .collect()
 }

--- a/query-engine/core/src/schema_builder/output_types/aggregation/mod.rs
+++ b/query-engine/core/src/schema_builder/output_types/aggregation/mod.rs
@@ -52,7 +52,7 @@ where
             object_mapper,
         ));
 
-        Some(field(name, vec![], object_type, None).optional())
+        Some(field(name, vec![], object_type, None).nullable())
     }
 }
 
@@ -78,7 +78,7 @@ where
     let fields: Vec<OutputField> = fields
         .iter()
         .map(|sf| {
-            field(sf.name.clone(), vec![], type_mapper(ctx, sf), None).optional_if(!sf.is_required || !sf.is_numeric())
+            field(sf.name.clone(), vec![], type_mapper(ctx, sf), None).nullable_if(!sf.is_required || !sf.is_numeric())
         })
         .collect();
 

--- a/query-engine/core/src/schema_builder/output_types/aggregation/mod.rs
+++ b/query-engine/core/src/schema_builder/output_types/aggregation/mod.rs
@@ -75,9 +75,13 @@ where
     );
     return_cached_output!(ctx, &ident);
 
+    // Non-numerical fields are always set as nullable
+    // This is because when there's no data, doing aggregation on them will return NULL
     let fields: Vec<OutputField> = fields
         .iter()
-        .map(|sf| field(sf.name.clone(), vec![], type_mapper(ctx, sf), None).nullable_if(!sf.is_required))
+        .map(|sf| {
+            field(sf.name.clone(), vec![], type_mapper(ctx, sf), None).nullable_if(!sf.is_required || !sf.is_numeric())
+        })
         .collect();
 
     let object = object_mapper(object_type(ident.clone(), fields, None));

--- a/query-engine/core/src/schema_builder/output_types/aggregation/mod.rs
+++ b/query-engine/core/src/schema_builder/output_types/aggregation/mod.rs
@@ -78,7 +78,7 @@ where
     let fields: Vec<OutputField> = fields
         .iter()
         .map(|sf| {
-            field(sf.name.clone(), vec![], type_mapper(ctx, sf), None).nullable_if(!sf.is_required || !sf.is_numeric())
+            field(sf.name.clone(), vec![], type_mapper(ctx, sf), None).nullable_if(!sf.is_required)
         })
         .collect();
 

--- a/query-engine/core/src/schema_builder/output_types/aggregation/mod.rs
+++ b/query-engine/core/src/schema_builder/output_types/aggregation/mod.rs
@@ -77,9 +77,7 @@ where
 
     let fields: Vec<OutputField> = fields
         .iter()
-        .map(|sf| {
-            field(sf.name.clone(), vec![], type_mapper(ctx, sf), None).nullable_if(!sf.is_required)
-        })
+        .map(|sf| field(sf.name.clone(), vec![], type_mapper(ctx, sf), None).nullable_if(!sf.is_required))
         .collect();
 
     let object = object_mapper(object_type(ident.clone(), fields, None));

--- a/query-engine/core/src/schema_builder/output_types/mutation_type.rs
+++ b/query-engine/core/src/schema_builder/output_types/mutation_type.rs
@@ -145,7 +145,7 @@ fn delete_item_field(ctx: &mut BuilderContext, model: &ModelRef) -> Option<Outpu
                 tag: QueryTag::DeleteOne,
             }),
         )
-        .optional()
+        .nullable()
     })
 }
 
@@ -182,7 +182,7 @@ fn update_item_field(ctx: &mut BuilderContext, model: &ModelRef) -> Option<Outpu
                 tag: QueryTag::UpdateOne,
             }),
         )
-        .optional()
+        .nullable()
     })
 }
 

--- a/query-engine/core/src/schema_builder/output_types/output_objects.rs
+++ b/query-engine/core/src/schema_builder/output_types/output_objects.rs
@@ -56,7 +56,7 @@ pub(crate) fn map_field(ctx: &mut BuilderContext, model_field: &ModelField) -> O
         map_output_type(ctx, &model_field),
         None,
     )
-    .optional_if(!model_field.is_required())
+    .nullable_if(!model_field.is_required())
 }
 
 pub(crate) fn map_output_type(ctx: &mut BuilderContext, model_field: &ModelField) -> OutputType {

--- a/query-engine/core/src/schema_builder/output_types/query_type.rs
+++ b/query-engine/core/src/schema_builder/output_types/query_type.rs
@@ -43,7 +43,7 @@ fn find_one_field(ctx: &mut BuilderContext, model: &ModelRef) -> Option<OutputFi
                 tag: QueryTag::FindOne,
             }),
         )
-        .optional()
+        .nullable()
         .deprecate(
             "The `findOne` query has been deprecated and replaced with `findUnique`.",
             "2.14",
@@ -67,7 +67,7 @@ fn find_unique_field(ctx: &mut BuilderContext, model: &ModelRef) -> Option<Outpu
                 tag: QueryTag::FindUnique,
             }),
         )
-        .optional()
+        .nullable()
     })
 }
 
@@ -85,7 +85,7 @@ fn find_first_field(ctx: &mut BuilderContext, model: &ModelRef) -> OutputField {
             tag: QueryTag::FindFirst,
         }),
     )
-    .optional()
+    .nullable()
 }
 
 /// Builds a "multiple" query arity items field (e.g. "users", "posts", ...) for given model.

--- a/query-engine/core/src/schema_builder/utils.rs
+++ b/query-engine/core/src/schema_builder/utils.rs
@@ -56,7 +56,7 @@ where
         arguments: arguments.into_iter().map(Arc::new).collect(),
         field_type: Arc::new(field_type),
         query_info,
-        is_required: true,
+        is_nullable: false,
         deprecation: None,
     }
 }

--- a/query-engine/query-engine/src/dmmf/mod.rs
+++ b/query-engine/query-engine/src/dmmf/mod.rs
@@ -1,4 +1,4 @@
-mod schema;
+pub mod schema;
 
 use query_core::schema::{QuerySchemaRef, QuerySchemaRenderer};
 use schema::*;

--- a/query-engine/query-engine/src/dmmf/schema/ast.rs
+++ b/query-engine/query-engine/src/dmmf/schema/ast.rs
@@ -15,7 +15,6 @@ pub struct DmmfSchema {
 pub struct DmmfOutputField {
     pub name: String,
     pub args: Vec<DmmfInputField>,
-    pub is_required: bool,
     pub is_nullable: bool,
     pub output_type: DmmfTypeReference,
 

--- a/query-engine/query-engine/src/dmmf/schema/field_renderer.rs
+++ b/query-engine/query-engine/src/dmmf/schema/field_renderer.rs
@@ -30,8 +30,7 @@ pub(super) fn render_output_field(field: &OutputFieldRef, ctx: &mut RenderContex
         name: field.name.clone(),
         args: rendered_inputs,
         output_type,
-        is_required: field.is_required,
-        is_nullable: !field.is_required,
+        is_nullable: field.is_nullable,
         deprecation: field.deprecation.as_ref().map(Into::into),
     };
 

--- a/query-engine/query-engine/src/dmmf/schema/mod.rs
+++ b/query-engine/query-engine/src/dmmf/schema/mod.rs
@@ -1,4 +1,4 @@
-pub mod ast;
+mod ast;
 
 mod enum_renderer;
 mod field_renderer;

--- a/query-engine/query-engine/src/dmmf/schema/mod.rs
+++ b/query-engine/query-engine/src/dmmf/schema/mod.rs
@@ -1,6 +1,6 @@
 mod ast;
-
 mod enum_renderer;
+
 mod field_renderer;
 mod object_renderer;
 mod schema_renderer;

--- a/query-engine/query-engine/src/dmmf/schema/mod.rs
+++ b/query-engine/query-engine/src/dmmf/schema/mod.rs
@@ -1,6 +1,6 @@
-mod ast;
-mod enum_renderer;
+pub mod ast;
 
+mod enum_renderer;
 mod field_renderer;
 mod object_renderer;
 mod schema_renderer;

--- a/query-engine/query-engine/src/request_handlers/graphql/schema_renderer/field_renderer.rs
+++ b/query-engine/query-engine/src/request_handlers/graphql/schema_renderer/field_renderer.rs
@@ -45,7 +45,8 @@ impl GqlFieldRenderer {
         };
 
         let rendered_type = field.field_type.into_renderer().render(ctx);
-        format!("{}{}: {}", field.name, rendered_args, rendered_type)
+        let bang = if !field.is_nullable { "!" } else { "" };
+        format!("{}{}: {}{}", field.name, rendered_args, rendered_type, bang)
     }
 
     fn render_arguments(&self, args: &[InputFieldRef], ctx: &mut RenderContext) -> Vec<String> {

--- a/query-engine/query-engine/src/request_handlers/graphql/schema_renderer/type_renderer.rs
+++ b/query-engine/query-engine/src/request_handlers/graphql/schema_renderer/type_renderer.rs
@@ -103,7 +103,7 @@ impl<'a> GqlTypeRenderer<'a> {
                     ScalarType::Null => unreachable!("Null types should not be picked for GQL rendering."),
                 };
 
-                format!("{}!", stringified)
+                format!("{}", stringified)
             }
         }
     }

--- a/query-engine/query-engine/src/tests/dmmf.rs
+++ b/query-engine/query-engine/src/tests/dmmf.rs
@@ -37,7 +37,49 @@ fn must_not_fail_on_missing_env_vars_in_a_datasource() {
 
 #[test]
 #[serial]
-fn nullable_fields_should_be_nullable_in_group_by_output_type() {
+fn must_not_fail_if_no_datasource_is_defined() {
+    let schema = r#"
+        model Blog {
+            blogId String @id
+        }
+    "#;
+
+    test_dmmf_cli_command(schema).unwrap();
+}
+
+#[test]
+#[serial]
+fn must_not_fail_if_an_invalid_datasource_url_is_provided() {
+    let schema = r#"
+        datasource pg {
+            provider = "postgresql"
+            url      = "mysql:://"
+        }
+
+        model Blog {
+            blogId String @id
+        }
+    "#;
+
+    test_dmmf_cli_command(schema).unwrap();
+}
+
+#[test]
+#[serial]
+fn must_fail_if_the_schema_is_invalid() {
+    let schema = r#"
+        // invalid because of field type
+        model Blog {
+            blogId StringyString @id
+        }
+    "#;
+
+    assert!(test_dmmf_cli_command(schema).is_err());
+}
+
+#[test]
+#[serial]
+fn nullable_fields_should_be_nullable_in_group_by_output_types() {
     let dm = r#"
         datasource pg {
             provider = "postgresql"
@@ -82,50 +124,9 @@ fn nullable_fields_should_be_nullable_in_group_by_output_type() {
             }
         }
     }
+    
     let group_by_output_type = find_output_type(&dmmf, "BlogGroupByOutputType");
     recursively_assert_fields(&dmmf, &group_by_output_type.fields)
-}
-
-#[test]
-#[serial]
-fn must_not_fail_if_no_datasource_is_defined() {
-    let schema = r#"
-        model Blog {
-            blogId String @id
-        }
-    "#;
-
-    test_dmmf_cli_command(schema).unwrap();
-}
-
-#[test]
-#[serial]
-fn must_not_fail_if_an_invalid_datasource_url_is_provided() {
-    let schema = r#"
-        datasource pg {
-            provider = "postgresql"
-            url      = "mysql:://"
-        }
-
-        model Blog {
-            blogId String @id
-        }
-    "#;
-
-    test_dmmf_cli_command(schema).unwrap();
-}
-
-#[test]
-#[serial]
-fn must_fail_if_the_schema_is_invalid() {
-    let schema = r#"
-        // invalid because of field type
-        model Blog {
-            blogId StringyString @id
-        }
-    "#;
-
-    assert!(test_dmmf_cli_command(schema).is_err());
 }
 
 fn test_dmmf_cli_command(schema: &str) -> PrismaResult<()> {

--- a/query-engine/query-engine/src/tests/dmmf.rs
+++ b/query-engine/query-engine/src/tests/dmmf.rs
@@ -87,11 +87,11 @@ fn nullable_fields_should_be_nullable_in_group_by_output_types() {
         }
 
         model Blog {
-            blogId String @id
-            firstName   String?
-            lastName    String
-            age    Int?
-
+            id           String @id
+            optional_string   String?
+            required_string   String
+            optional_int      Int?
+            required_int      Int
         }
     "#;
     let (query_schema, datamodel) = get_query_schema(dm);
@@ -114,15 +114,17 @@ fn nullable_fields_should_be_nullable_in_group_by_output_types() {
                     recursively_assert_fields(dmmf, &output_type.fields, true);
                 }
                 TypeLocation::Scalar => match (in_aggregation_type, field.name.as_str()) {
-                    (false, "blogId") => assert_eq!(field.is_nullable, false),
-                    (false, "firstName") => assert_eq!(field.is_nullable, true),
-                    (false, "lastName") => assert_eq!(field.is_nullable, false),
-                    (false, "age") => assert_eq!(field.is_nullable, true),
+                    (false, "id") => assert_eq!(field.is_nullable, false),
+                    (false, "optional_string") => assert_eq!(field.is_nullable, true),
+                    (false, "required_string") => assert_eq!(field.is_nullable, false),
+                    (false, "optional_int") => assert_eq!(field.is_nullable, true),
+                    (false, "required_int") => assert_eq!(field.is_nullable, false),
 
-                    (true, "blogId") => assert_eq!(field.is_nullable, true),
-                    (true, "firstName") => assert_eq!(field.is_nullable, true),
-                    (true, "lastName") => assert_eq!(field.is_nullable, true),
-                    (true, "age") => assert_eq!(field.is_nullable, true),
+                    (true, "id") => assert_eq!(field.is_nullable, true),
+                    (true, "optional_string") => assert_eq!(field.is_nullable, true),
+                    (true, "required_string") => assert_eq!(field.is_nullable, true),
+                    (true, "optional_int") => assert_eq!(field.is_nullable, true),
+                    (true, "required_int") => assert_eq!(field.is_nullable, false),
 
                     _ => (),
                 },

--- a/query-engine/query-engine/src/tests/dmmf.rs
+++ b/query-engine/query-engine/src/tests/dmmf.rs
@@ -124,7 +124,7 @@ fn nullable_fields_should_be_nullable_in_group_by_output_types() {
             }
         }
     }
-    
+
     let group_by_output_type = find_output_type(&dmmf, "BlogGroupByOutputType");
     recursively_assert_fields(&dmmf, &group_by_output_type.fields)
 }


### PR DESCRIPTION
### Overview

- Fields of the output type of a groupBy field are now nullable if they're defined as optional in the datamodel
- In the nested aggregation output types of a groupBy field, non-numerical fields will keep staying nullable regardless of how they're defined in the datamodel. That's because doing aggregation on those fields when there's no data returns NULL.

**Example**

Given that Prisma Schema

```prisma
model Item {
  a String
  b String?
  c Int
  d Int?
}
```

We'll generate the following GraphQL Schema

```graphql
type Query {
  groupByItem(...): GroupByItemOutputType
}

type GroupByOutputType {
  a: String! # non-nullable because defined as required in the Item model
  b: String  # nullable because defined as optional in the Item model
  c: Int!    # non-nullable because defined as required in the Item model
  d: Int     # nullable because defined as optional in the Item model
  max: {
    a: String # nullable because non-numerical
    b: String
    c: Int
    d: Int!
  }
}
```

### BREAKING CHANGES
- Removed field `isRequired` in `DmmfOutputField`