### PR TITLE
(native types) Remove Numeric alias (pg/mysql)

### DIFF
--- a/introspection-engine/introspection-engine-tests/tests/native_types/postgres.rs
+++ b/introspection-engine/introspection-engine-tests/tests/native_types/postgres.rs
@@ -70,8 +70,8 @@ async fn native_type_columns_feature_on(api: &TestApi) -> crate::TestResult {
             smallint        Int      @postgres.SmallInt
             int             Int      @postgres.Integer
             bigint          BigInt   @postgres.BigInt
-            decimal         Decimal  @postgres.Numeric(4, 2)
-            numeric         Decimal  @postgres.Numeric(4, 2)
+            decimal         Decimal  @postgres.Decimal(4, 2)
+            numeric         Decimal  @postgres.Decimal(4, 2)
             real            Float    @postgres.Real
             doublePrecision Float    @postgres.DoublePrecision
             smallSerial     Int      @default(autoincrement()) @postgres.SmallInt
@@ -219,10 +219,10 @@ async fn native_type_array_columns_feature_on(api: &TestApi) -> crate::TestResul
 
          model Blog {
           id                Int        @id @postgres.Integer
-          decimal_array     Decimal[]  @postgres.Numeric(42, 0)
-          decimal_array_2   Decimal[]  @postgres.Numeric
-          numeric_array     Decimal[]  @postgres.Numeric(4, 2)
-          numeric_array_2   Decimal[]  @postgres.Numeric
+          decimal_array     Decimal[]  @postgres.Decimal(42, 0)
+          decimal_array_2   Decimal[]  @postgres.Decimal
+          numeric_array     Decimal[]  @postgres.Decimal(4, 2)
+          numeric_array_2   Decimal[]  @postgres.Decimal
           varchar_array     String[]   @postgres.VarChar(42)
           varchar_array_2   String[]   @postgres.VarChar
           char_array        String[]   @postgres.Char(200)

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
@@ -20,7 +20,6 @@ const UNSIGNED_MEDIUM_INT_TYPE_NAME: &str = "UnsignedMediumInt";
 const BIG_INT_TYPE_NAME: &str = "BigInt";
 const UNSIGNED_BIG_INT_TYPE_NAME: &str = "UnsignedBigInt";
 const DECIMAL_TYPE_NAME: &str = "Decimal";
-const NUMERIC_TYPE_NAME: &str = "Numeric";
 const FLOAT_TYPE_NAME: &str = "Float";
 const DOUBLE_TYPE_NAME: &str = "Double";
 const BIT_TYPE_NAME: &str = "Bit";
@@ -85,7 +84,6 @@ impl MySqlDatamodelConnector {
         let unsigned_big_int =
             NativeTypeConstructor::without_args(UNSIGNED_BIG_INT_TYPE_NAME, vec![ScalarType::BigInt]);
         let decimal = NativeTypeConstructor::with_optional_args(DECIMAL_TYPE_NAME, 2, vec![ScalarType::Decimal]);
-        let numeric = NativeTypeConstructor::with_optional_args(NUMERIC_TYPE_NAME, 2, vec![ScalarType::Decimal]);
         let float = NativeTypeConstructor::without_args(FLOAT_TYPE_NAME, vec![ScalarType::Float]);
         let double = NativeTypeConstructor::without_args(DOUBLE_TYPE_NAME, vec![ScalarType::Float]);
         let bit = NativeTypeConstructor::with_args(BIT_TYPE_NAME, 1, vec![ScalarType::Bytes]);
@@ -120,7 +118,6 @@ impl MySqlDatamodelConnector {
             big_int,
             unsigned_big_int,
             decimal,
-            numeric,
             float,
             double,
             bit,
@@ -170,13 +167,13 @@ impl Connector for MySqlDatamodelConnector {
                     NATIVE_TYPES_THAT_CAN_NOT_BE_USED_IN_KEY_SPECIFICATION.contains(&native_type_name);
 
                 match native_type {
-                    Decimal(Some((precision, scale))) | Numeric(Some((precision, scale))) if scale > precision => {
+                    Decimal(Some((precision, scale))) if scale > precision => {
                         error.new_scale_larger_than_precision_error()
                     }
-                    Decimal(Some((precision, _))) | Numeric(Some((precision, _))) if precision > 65 => {
+                    Decimal(Some((precision, _))) if precision > 65 => {
                         error.new_argument_m_out_of_range_error("Precision can range from 1 to 65.")
                     }
-                    Decimal(Some((_, scale))) | Numeric(Some((_, scale))) if scale > 30 => {
+                    Decimal(Some((_, scale))) if scale > 30 => {
                         error.new_argument_m_out_of_range_error("Scale can range from 0 to 30.")
                     }
                     Bit(length) if length == 0 || length > 64 => {
@@ -249,7 +246,6 @@ impl Connector for MySqlDatamodelConnector {
             BIG_INT_TYPE_NAME => BigInt,
             UNSIGNED_BIG_INT_TYPE_NAME => UnsignedBigInt,
             DECIMAL_TYPE_NAME => Decimal(parse_two_opt_u32(args, DECIMAL_TYPE_NAME)?),
-            NUMERIC_TYPE_NAME => Numeric(parse_two_opt_u32(args, NUMERIC_TYPE_NAME)?),
             FLOAT_TYPE_NAME => Float,
             DOUBLE_TYPE_NAME => Double,
             BIT_TYPE_NAME => Bit(parse_one_u32(args, BIT_TYPE_NAME)?),
@@ -294,7 +290,6 @@ impl Connector for MySqlDatamodelConnector {
             BigInt => (BIG_INT_TYPE_NAME, vec![]),
             UnsignedBigInt => (UNSIGNED_BIG_INT_TYPE_NAME, vec![]),
             Decimal(x) => (DECIMAL_TYPE_NAME, args_vec_from_opt(x)),
-            Numeric(x) => (NUMERIC_TYPE_NAME, args_vec_from_opt(x)),
             Float => (FLOAT_TYPE_NAME, vec![]),
             Double => (DOUBLE_TYPE_NAME, vec![]),
             Bit(x) => (BIT_TYPE_NAME, vec![x.to_string()]),

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
@@ -13,7 +13,6 @@ const SMALL_INT_TYPE_NAME: &str = "SmallInt";
 const INTEGER_TYPE_NAME: &str = "Integer";
 const BIG_INT_TYPE_NAME: &str = "BigInt";
 const DECIMAL_TYPE_NAME: &str = "Decimal";
-const NUMERIC_TYPE_NAME: &str = "Numeric";
 const REAL_TYPE_NAME: &str = "Real";
 const DOUBLE_PRECISION_TYPE_NAME: &str = "DoublePrecision";
 const VARCHAR_TYPE_NAME: &str = "VarChar";
@@ -56,7 +55,6 @@ impl PostgresDatamodelConnector {
         let integer = NativeTypeConstructor::without_args(INTEGER_TYPE_NAME, vec![ScalarType::Int]);
         let big_int = NativeTypeConstructor::without_args(BIG_INT_TYPE_NAME, vec![ScalarType::BigInt]);
         let decimal = NativeTypeConstructor::with_optional_args(DECIMAL_TYPE_NAME, 2, vec![ScalarType::Decimal]);
-        let numeric = NativeTypeConstructor::with_optional_args(NUMERIC_TYPE_NAME, 2, vec![ScalarType::Decimal]);
         let real = NativeTypeConstructor::without_args(REAL_TYPE_NAME, vec![ScalarType::Float]);
         let double_precision = NativeTypeConstructor::without_args(DOUBLE_PRECISION_TYPE_NAME, vec![ScalarType::Float]);
         let varchar = NativeTypeConstructor::with_optional_args(VARCHAR_TYPE_NAME, 1, vec![ScalarType::String]);
@@ -82,7 +80,6 @@ impl PostgresDatamodelConnector {
             integer,
             big_int,
             decimal,
-            numeric,
             real,
             double_precision,
             varchar,
@@ -126,10 +123,10 @@ impl Connector for PostgresDatamodelConnector {
                 let error = self.native_instance_error(native_type_instance);
 
                 match native_type {
-                    Decimal(Some((precision, scale))) | Numeric(Some((precision, scale))) if scale > precision => {
+                    Decimal(Some((precision, scale))) if scale > precision => {
                         error.new_scale_larger_than_precision_error()
                     }
-                    Decimal(Some((prec, _))) | Numeric(Some((prec, _))) if prec > 1000 || prec == 0 => error
+                    Decimal(Some((prec, _))) if prec > 1000 || prec == 0 => error
                         .new_argument_m_out_of_range_error("Precision must be positive with a maximum value of 1000."),
                     Bit(Some(0)) | VarBit(Some(0)) => {
                         error.new_argument_m_out_of_range_error("M must be a positive integer.")
@@ -160,7 +157,6 @@ impl Connector for PostgresDatamodelConnector {
             INTEGER_TYPE_NAME => Integer,
             BIG_INT_TYPE_NAME => BigInt,
             DECIMAL_TYPE_NAME => Decimal(parse_two_opt_u32(args, DECIMAL_TYPE_NAME)?),
-            NUMERIC_TYPE_NAME => Numeric(parse_two_opt_u32(args, NUMERIC_TYPE_NAME)?),
             REAL_TYPE_NAME => Real,
             DOUBLE_PRECISION_TYPE_NAME => DoublePrecision,
             VARCHAR_TYPE_NAME => VarChar(parse_one_opt_u32(args, VARCHAR_TYPE_NAME)?),
@@ -192,7 +188,6 @@ impl Connector for PostgresDatamodelConnector {
             Integer => (INTEGER_TYPE_NAME, vec![]),
             BigInt => (BIG_INT_TYPE_NAME, vec![]),
             Decimal(x) => (DECIMAL_TYPE_NAME, args_vec_from_opt(x)),
-            Numeric(x) => (NUMERIC_TYPE_NAME, args_vec_from_opt(x)),
             Real => (REAL_TYPE_NAME, vec![]),
             DoublePrecision => (DOUBLE_PRECISION_TYPE_NAME, vec![]),
             VarChar(x) => (VARCHAR_TYPE_NAME, arg_vec_from_opt(x)),

--- a/libs/datamodel/core/tests/types/mysql_native_types.rs
+++ b/libs/datamodel/core/tests/types/mysql_native_types.rs
@@ -114,7 +114,7 @@ fn should_fail_on_argument_out_of_range_for_varchar_type() {
 }
 
 #[test]
-fn should_fail_on_argument_out_of_range_for_decimal_and_numeric_type() {
+fn should_fail_on_argument_out_of_range_for_decimal_type() {
     fn error_msg(type_name: &str, arg: &str, range: &str) -> String {
         format!(
             "Argument M is out of range for Native type {} of MySQL: {} can range from {}.",
@@ -122,24 +122,23 @@ fn should_fail_on_argument_out_of_range_for_decimal_and_numeric_type() {
         )
     };
 
-    for tpe in &["Numeric", "Decimal"] {
-        let native_type = &format!("{}(66,20)", tpe);
+    let native_type = "Decimal(66,20)";
 
-        test_native_types_without_attributes(
-            native_type,
-            "Decimal",
-            &error_msg(native_type, "Precision", "1 to 65"),
-            MYSQL_SOURCE,
-        );
-        let native_type = &format!("{}(44,33)", tpe);
+    test_native_types_without_attributes(
+        native_type,
+        "Decimal",
+        &error_msg(native_type, "Precision", "1 to 65"),
+        MYSQL_SOURCE,
+    );
 
-        test_native_types_without_attributes(
-            native_type,
-            "Decimal",
-            &error_msg(native_type, "Scale", "0 to 30"),
-            MYSQL_SOURCE,
-        );
-    }
+    let native_type = "Decimal(44,33)";
+
+    test_native_types_without_attributes(
+        native_type,
+        "Decimal",
+        &error_msg(native_type, "Scale", "0 to 30"),
+        MYSQL_SOURCE,
+    );
 }
 
 #[test]
@@ -165,33 +164,6 @@ fn should_fail_on_native_type_decimal_when_scale_is_bigger_than_precision() {
 
     error.assert_is(DatamodelError::new_connector_error(
         "The scale must not be larger than the precision for the Decimal(2,4) native type in MySQL.",
-        ast::Span::new(281, 311),
-    ));
-}
-
-#[test]
-fn should_fail_on_native_type_numeric_when_scale_is_bigger_than_precision() {
-    let dml = r#"
-        datasource db {
-          provider = "mysql"
-          url      = "mysql://"
-        }
-
-        generator js {
-            provider = "prisma-client-js"
-            previewFeatures = ["nativeTypes"]
-        }
-
-        model Blog {
-            id     Int   @id
-            dec Decimal @db.Numeric(2, 4)
-        }
-    "#;
-
-    let error = parse_error(dml);
-
-    error.assert_is(DatamodelError::new_connector_error(
-        "The scale must not be larger than the precision for the Numeric(2,4) native type in MySQL.",
         ast::Span::new(281, 311),
     ));
 }

--- a/libs/datamodel/core/tests/types/postgres_native_types.rs
+++ b/libs/datamodel/core/tests/types/postgres_native_types.rs
@@ -3,22 +3,8 @@ use crate::types::helper::test_native_types_without_attributes;
 use datamodel::{ast, diagnostics::DatamodelError};
 use native_types::PostgresType;
 
-// #[test] no more serial currently
-// fn should_fail_on_serial_data_types_with_number_default() {
-//     fn error_msg(type_name: &str) -> String {
-//         format!(
-//             "Sequential native type {} of Postgres must not have a static default value.",
-//             type_name
-//         )
-//     }
-//
-//     for tpe in &["SmallSerial", "Serial", "BigSerial"] {
-//         test_native_types_with_field_attribute_support(tpe, "Int", "default(4)", &error_msg(tpe), POSTGRES_SOURCE);
-//     }
-// }
-
 #[test]
-fn should_fail_on_invalid_precision_for_decimal_and_numeric_type() {
+fn should_fail_on_invalid_precision_for_decimal_type() {
     fn error_msg(type_name: &str) -> String {
         format!(
             "Argument M is out of range for Native type {} of Postgres: Precision must be positive with a maximum value of 1000.",
@@ -26,10 +12,8 @@ fn should_fail_on_invalid_precision_for_decimal_and_numeric_type() {
         )
     }
 
-    for tpe in &["Decimal", "Numeric"] {
-        let native_type = &format!("{}(1001,3)", tpe);
-        test_native_types_without_attributes(native_type, "Decimal", &error_msg(native_type), POSTGRES_SOURCE);
-    }
+    let native_type = "Decimal(1001,3)";
+    test_native_types_without_attributes(native_type, "Decimal", &error_msg(native_type), POSTGRES_SOURCE);
 }
 
 #[test]
@@ -87,33 +71,6 @@ fn should_fail_on_native_type_decimal_when_scale_is_bigger_than_precision() {
 
     error.assert_is(DatamodelError::new_connector_error(
         "The scale must not be larger than the precision for the Decimal(2,4) native type in Postgres.",
-        ast::Span::new(289, 319),
-    ));
-}
-
-#[test]
-fn should_fail_on_native_type_numeric_when_scale_is_bigger_than_precision() {
-    let dml = r#"
-        datasource db {
-          provider = "postgres"
-          url      = "postgresql://"
-        }
-
-        generator js {
-            provider = "prisma-client-js"
-            previewFeatures = ["nativeTypes"]
-        }
-
-        model Blog {
-            id     Int   @id
-            dec Decimal @db.Numeric(2, 4)
-        }
-    "#;
-
-    let error = parse_error(dml);
-
-    error.assert_is(DatamodelError::new_connector_error(
-        "The scale must not be larger than the precision for the Numeric(2,4) native type in Postgres.",
         ast::Span::new(289, 319),
     ));
 }

--- a/libs/native-types/src/mysql.rs
+++ b/libs/native-types/src/mysql.rs
@@ -13,7 +13,6 @@ pub enum MySqlType {
     UnsignedMediumInt,
     BigInt,
     Decimal(Option<(u32, u32)>),
-    Numeric(Option<(u32, u32)>),
     UnsignedBigInt,
     Float,
     Double,

--- a/libs/native-types/src/postgres.rs
+++ b/libs/native-types/src/postgres.rs
@@ -7,7 +7,6 @@ pub enum PostgresType {
     Integer,
     BigInt,
     Decimal(Option<(u32, u32)>),
-    Numeric(Option<(u32, u32)>),
     Real,
     DoublePrecision,
     VarChar(Option<u32>),

--- a/libs/sql-schema-describer/src/mysql.rs
+++ b/libs/sql-schema-describer/src/mysql.rs
@@ -574,13 +574,6 @@ impl SqlSchemaDescriber {
                     precision.numeric_scale.unwrap(),
                 )))),
             ),
-            "numeric" => (
-                ColumnTypeFamily::Decimal,
-                Some(MySqlType::Numeric(Some((
-                    precision.numeric_precision.unwrap(),
-                    precision.numeric_scale.unwrap(),
-                )))),
-            ),
             "float" => (ColumnTypeFamily::Float, Some(MySqlType::Float)),
             "double" => (ColumnTypeFamily::Float, Some(MySqlType::Double)),
 

--- a/libs/sql-schema-describer/src/postgres.rs
+++ b/libs/sql-schema-describer/src/postgres.rs
@@ -695,7 +695,7 @@ fn get_column_type(row: &ResultRow, enums: &[Enum]) -> ColumnType {
         "varbit" | "_varbit" => (String, Some(PostgresType::VarBit(precision.character_maximum_length))),
         "numeric" | "_numeric" => (
             Decimal,
-            Some(PostgresType::Numeric(
+            Some(PostgresType::Decimal(
                 match (precision.numeric_precision, precision.numeric_scale) {
                     (None, None) => None,
                     (Some(prec), Some(scale)) => Some((prec, scale)),

--- a/libs/sql-schema-describer/tests/postgres_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/postgres_describer_tests.rs
@@ -466,7 +466,7 @@ async fn all_postgres_column_types_must_work() {
                 character_maximum_length: None,
                 family: ColumnTypeFamily::Decimal,
                 arity: ColumnArity::Required,
-                native_type: Some(PostgresType::Numeric(None).to_json()),
+                native_type: Some(PostgresType::Decimal(None).to_json()),
             },
             default: None,
             auto_increment: false,

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/mysql.rs
@@ -61,7 +61,6 @@ impl SqlSchemaCalculatorFlavour for MysqlFlavour {
             MySqlType::MediumInt => "MEDIUMINT".into(),
             MySqlType::BigInt => "BIGINT".into(),
             MySqlType::Decimal(precision) => format!("DECIMAL{}", render_decimal(precision)),
-            MySqlType::Numeric(precision) => format!("NUMERIC{}", render_decimal(precision)),
             MySqlType::Float => "FLOAT".into(),
             MySqlType::Double => "DOUBLE".into(),
             MySqlType::Bit(size) => format!("BIT({size})", size = size),

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/postgres.rs
@@ -41,7 +41,6 @@ impl SqlSchemaCalculatorFlavour for PostgresFlavour {
             PostgresType::Integer => "INTEGER".to_owned(),
             PostgresType::BigInt => "BIGINT".to_owned(),
             PostgresType::Decimal(precision) => format!("DECIMAL{}", render_decimal(precision)),
-            PostgresType::Numeric(precision) => format!("NUMERIC{}", render_decimal(precision)),
             PostgresType::Real => "REAL".to_owned(),
             PostgresType::DoublePrecision => "DOUBLE PRECISION".to_owned(),
             PostgresType::VarChar(length) => format!("VARCHAR{}", render(length)),

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/postgres.rs
@@ -127,7 +127,7 @@ fn native_type_change_riskyness(previous: PostgresType, next: PostgresType) -> O
         SmallInt => match next {
             Integer => SafeCast,
             BigInt => SafeCast,
-            Decimal(params) | Numeric(params) => match params {
+            Decimal(params) => match params {
                 // SmallInt can be at most three digits, so this might fail.
                 Some((p, s)) if p - s < 3 => RiskyCast,
                 _ => SafeCast,
@@ -146,7 +146,7 @@ fn native_type_change_riskyness(previous: PostgresType, next: PostgresType) -> O
         Integer => match next {
             SmallInt => RiskyCast,
             BigInt => SafeCast,
-            Decimal(params) | Numeric(params) => match params {
+            Decimal(params) => match params {
                 // Integer can be at most 10 digits, so this might fail.
                 Some((p, s)) if p - s < 10 => RiskyCast,
                 _ => SafeCast,
@@ -165,7 +165,7 @@ fn native_type_change_riskyness(previous: PostgresType, next: PostgresType) -> O
         BigInt => match next {
             SmallInt => RiskyCast,
             Integer => RiskyCast,
-            Decimal(params) | Numeric(params) => match params {
+            Decimal(params) => match params {
                 // Bigint can be at most nineteen digits, so this might fail.
                 Some((p, s)) if p - s < 19 => RiskyCast,
                 _ => SafeCast,
@@ -181,7 +181,7 @@ fn native_type_change_riskyness(previous: PostgresType, next: PostgresType) -> O
             Text => SafeCast,
             _ => NotCastable,
         },
-        Decimal(old_params) | Numeric(old_params) => match next {
+        Decimal(old_params) => match next {
             SmallInt => match old_params {
                 None => RiskyCast,
                 Some((_, s)) if s > 0 => RiskyCast,
@@ -200,7 +200,7 @@ fn native_type_change_riskyness(previous: PostgresType, next: PostgresType) -> O
                 Some((p, 0)) if p > 18 => RiskyCast,
                 _ => SafeCast,
             },
-            Decimal(new_params) | Numeric(new_params) => match (old_params, new_params) {
+            Decimal(new_params) => match (old_params, new_params) {
                 (Some(_), None) => SafeCast,
                 (None, Some((p_new, s_new))) if p_new < 131072 || s_new < 16383 => RiskyCast,
                 // Sigh... So, numeric(4,0) to numeric(4,2) would be risky,
@@ -233,7 +233,7 @@ fn native_type_change_riskyness(previous: PostgresType, next: PostgresType) -> O
             SmallInt => RiskyCast,
             Integer => RiskyCast,
             BigInt => RiskyCast,
-            Decimal(_) | Numeric(_) => RiskyCast,
+            Decimal(_) => RiskyCast,
             Real => SafeCast,
             DoublePrecision => SafeCast,
             VarChar(len) | Char(len) => match len {
@@ -249,7 +249,7 @@ fn native_type_change_riskyness(previous: PostgresType, next: PostgresType) -> O
             SmallInt => RiskyCast,
             Integer => RiskyCast,
             BigInt => RiskyCast,
-            Decimal(_) | Numeric(_) => RiskyCast,
+            Decimal(_) => RiskyCast,
             Real => RiskyCast,
             DoublePrecision => SafeCast,
             VarChar(len) | Char(len) => match len {

--- a/migration-engine/migration-engine-tests/tests/migrations/mysql.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/mysql.rs
@@ -228,7 +228,6 @@ async fn native_type_columns_can_be_created(api: &TestApi) -> TestResult {
             if api.is_mysql_8() { "bigint" } else { "bigint(20)" },
         ),
         ("decimal", "Decimal", "Decimal(5, 3)", "decimal(5,3)"),
-        ("numeric", "Decimal", "Numeric(4,1)", "decimal(4,1)"),
         ("float", "Float", "Float", "float"),
         ("double", "Float", "Double", "double"),
         ("bits", "Bytes", "Bit(10)", "bit(10)"),

--- a/migration-engine/migration-engine-tests/tests/migrations/postgres.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/postgres.rs
@@ -111,7 +111,6 @@ async fn native_type_columns_can_be_created(api: &TestApi) -> TestResult {
         ("int", "Int", "Integer", "int4"),
         ("bigint", "BigInt", "BigInt", "int8"),
         ("decimal", "Decimal", "Decimal(4, 2)", "numeric"),
-        ("numeric", "Decimal", "Numeric(4, 2)", "numeric"),
         ("real", "Float", "Real", "float4"),
         ("doublePrecision", "Float", "DoublePrecision", "float8"),
         ("varChar", "String", "VarChar(200)", "varchar"),

--- a/migration-engine/migration-engine-tests/tests/native_types/postgres.rs
+++ b/migration-engine/migration-engine-tests/tests/native_types/postgres.rs
@@ -9,10 +9,6 @@ use quaint::{
 use sql_datamodel_connector::SqlDatamodelConnectors;
 use std::{collections::HashMap, str::FromStr};
 
-//how to handle aliases
-// serial
-// decimal
-
 // do not castable ✓
 // split castable into safe and risky ✓
 // split seeds into risky succeeds ✓
@@ -62,18 +58,18 @@ static SAFE_CASTS: Lazy<Vec<(&str, Value, &[&str])>> = Lazy::new(|| {
             &["BigInt", "Real", "DoublePrecision", "VarChar(53)", "Char(53)", "Text"],
         ),
         (
-            "Numeric(10,2)",
+            "Decimal(10,2)",
             Value::numeric(BigDecimal::from_str("12345678.90").unwrap()),
-            &["Numeric(32,16)", "VarChar(53)", "Char(53)", "Text"],
+            &["Decimal(32,16)", "VarChar(53)", "Char(53)", "Text"],
         ),
         (
-            "Numeric(2,0)",
+            "Decimal(2,0)",
             Value::numeric(BigDecimal::from_str("12").unwrap()),
             &[
                 "SmallInt",
                 "Integer",
                 "BigInt",
-                "Numeric(32,16)",
+                "Decimal(32,16)",
                 "VarChar(53)",
                 "Char(53)",
                 "Text",
@@ -176,12 +172,12 @@ static RISKY_CASTS: Lazy<Vec<(&str, Value, &[&str])>> = Lazy::new(|| {
         (
             "SmallInt",
             Value::integer(2),
-            &["Numeric(2,1)", "VarChar(3)", "Char(1)"],
+            &["Decimal(2,1)", "VarChar(3)", "Char(1)"],
         ),
-        ("Integer", Value::integer(1), &["Numeric(2,1)", "VarChar(4)", "Char(1)"]),
-        ("BigInt", Value::integer(2), &["Numeric(2,1)", "VarChar(17)", "Char(1)"]),
+        ("Integer", Value::integer(1), &["Decimal(2,1)", "VarChar(4)", "Char(1)"]),
+        ("BigInt", Value::integer(2), &["Decimal(2,1)", "VarChar(17)", "Char(1)"]),
         (
-            "Numeric(10,2)",
+            "Decimal(10,2)",
             Value::numeric(BigDecimal::from_str("1").unwrap()),
             &[
                 "SmallInt",
@@ -194,7 +190,7 @@ static RISKY_CASTS: Lazy<Vec<(&str, Value, &[&str])>> = Lazy::new(|| {
             ],
         ),
         (
-            "Numeric(5,0)",
+            "Decimal(5,0)",
             Value::numeric(BigDecimal::from_str("10").unwrap()),
             &["SmallInt", "VarChar(5)", "Char(5)", "Real", "DoublePrecision"],
         ),
@@ -205,7 +201,7 @@ static RISKY_CASTS: Lazy<Vec<(&str, Value, &[&str])>> = Lazy::new(|| {
                 "SmallInt",
                 "Integer",
                 "BigInt",
-                "Numeric(32,16)",
+                "Decimal(32,16)",
                 "VarChar(10)",
                 "Char(1)",
             ],
@@ -217,7 +213,7 @@ static RISKY_CASTS: Lazy<Vec<(&str, Value, &[&str])>> = Lazy::new(|| {
                 "SmallInt",
                 "Integer",
                 "BigInt",
-                "Numeric(32,16)",
+                "Decimal(32,16)",
                 "Real",
                 "VarChar(5)",
                 "Char(1)",
@@ -301,7 +297,7 @@ static NOT_CASTABLE: Lazy<Vec<(&str, Value, &[&str])>> = Lazy::new(|| {
             ],
         ),
         (
-            "Numeric(10,2)",
+            "Decimal(10,2)",
             Value::numeric(BigDecimal::from_str("1").unwrap()),
             &[
                 "ByteA",
@@ -320,7 +316,7 @@ static NOT_CASTABLE: Lazy<Vec<(&str, Value, &[&str])>> = Lazy::new(|| {
             ],
         ),
         (
-            "Numeric(5,0)",
+            "Decimal(5,0)",
             Value::numeric(BigDecimal::from_str("1").unwrap()),
             &[
                 "ByteA",
@@ -382,7 +378,7 @@ static NOT_CASTABLE: Lazy<Vec<(&str, Value, &[&str])>> = Lazy::new(|| {
                 "SmallInt",
                 "Integer",
                 "BigInt",
-                "Numeric(32,16)",
+                "Decimal(32,16)",
                 "Real",
                 "DoublePrecision",
                 "ByteA",
@@ -407,7 +403,7 @@ static NOT_CASTABLE: Lazy<Vec<(&str, Value, &[&str])>> = Lazy::new(|| {
                 "SmallInt",
                 "Integer",
                 "BigInt",
-                "Numeric(32,16)",
+                "Decimal(32,16)",
                 "Real",
                 "DoublePrecision",
                 "ByteA",
@@ -432,7 +428,7 @@ static NOT_CASTABLE: Lazy<Vec<(&str, Value, &[&str])>> = Lazy::new(|| {
                 "SmallInt",
                 "Integer",
                 "BigInt",
-                "Numeric(32,16)",
+                "Decimal(32,16)",
                 "Real",
                 "DoublePrecision",
                 "ByteA",
@@ -457,7 +453,7 @@ static NOT_CASTABLE: Lazy<Vec<(&str, Value, &[&str])>> = Lazy::new(|| {
                 "SmallInt",
                 "Integer",
                 "BigInt",
-                "Numeric(32,16)",
+                "Decimal(32,16)",
                 "Real",
                 "DoublePrecision",
                 "Timestamp(3)",
@@ -481,7 +477,7 @@ static NOT_CASTABLE: Lazy<Vec<(&str, Value, &[&str])>> = Lazy::new(|| {
                 "SmallInt",
                 "Integer",
                 "BigInt",
-                "Numeric(32,16)",
+                "Decimal(32,16)",
                 "Real",
                 "DoublePrecision",
                 "ByteA",
@@ -501,7 +497,7 @@ static NOT_CASTABLE: Lazy<Vec<(&str, Value, &[&str])>> = Lazy::new(|| {
                 "SmallInt",
                 "Integer",
                 "BigInt",
-                "Numeric(32,16)",
+                "Decimal(32,16)",
                 "Real",
                 "DoublePrecision",
                 "ByteA",
@@ -521,7 +517,7 @@ static NOT_CASTABLE: Lazy<Vec<(&str, Value, &[&str])>> = Lazy::new(|| {
                 "SmallInt",
                 "Integer",
                 "BigInt",
-                "Numeric(32,16)",
+                "Decimal(32,16)",
                 "Real",
                 "DoublePrecision",
                 "ByteA",
@@ -543,7 +539,7 @@ static NOT_CASTABLE: Lazy<Vec<(&str, Value, &[&str])>> = Lazy::new(|| {
                 "SmallInt",
                 "Integer",
                 "BigInt",
-                "Numeric(32,16)",
+                "Decimal(32,16)",
                 "Real",
                 "DoublePrecision",
                 "ByteA",
@@ -566,7 +562,7 @@ static NOT_CASTABLE: Lazy<Vec<(&str, Value, &[&str])>> = Lazy::new(|| {
                 "SmallInt",
                 "Integer",
                 "BigInt",
-                "Numeric(32,16)",
+                "Decimal(32,16)",
                 "Real",
                 "DoublePrecision",
                 "ByteA",
@@ -589,7 +585,7 @@ static NOT_CASTABLE: Lazy<Vec<(&str, Value, &[&str])>> = Lazy::new(|| {
                 "SmallInt",
                 "Integer",
                 "BigInt",
-                "Numeric(32,16)",
+                "Decimal(32,16)",
                 "Real",
                 "DoublePrecision",
                 "ByteA",
@@ -613,7 +609,7 @@ static NOT_CASTABLE: Lazy<Vec<(&str, Value, &[&str])>> = Lazy::new(|| {
                 "SmallInt",
                 "Integer",
                 "BigInt",
-                "Numeric(32,16)",
+                "Decimal(32,16)",
                 "Real",
                 "DoublePrecision",
                 "ByteA",
@@ -636,7 +632,7 @@ static NOT_CASTABLE: Lazy<Vec<(&str, Value, &[&str])>> = Lazy::new(|| {
                 "SmallInt",
                 "Integer",
                 "BigInt",
-                "Numeric(32,16)",
+                "Decimal(32,16)",
                 "Real",
                 "DoublePrecision",
                 "ByteA",
@@ -660,7 +656,7 @@ static NOT_CASTABLE: Lazy<Vec<(&str, Value, &[&str])>> = Lazy::new(|| {
                 "SmallInt",
                 "Integer",
                 "BigInt",
-                "Numeric(32,16)",
+                "Decimal(32,16)",
                 "Real",
                 "DoublePrecision",
                 "ByteA",
@@ -684,7 +680,7 @@ static NOT_CASTABLE: Lazy<Vec<(&str, Value, &[&str])>> = Lazy::new(|| {
                 "SmallInt",
                 "Integer",
                 "BigInt",
-                "Numeric(32,16)",
+                "Decimal(32,16)",
                 "Real",
                 "DoublePrecision",
                 "ByteA",
@@ -708,7 +704,7 @@ static NOT_CASTABLE: Lazy<Vec<(&str, Value, &[&str])>> = Lazy::new(|| {
                 "SmallInt",
                 "Integer",
                 "BigInt",
-                "Numeric(32,16)",
+                "Decimal(32,16)",
                 "Real",
                 "DoublePrecision",
                 "ByteA",
@@ -731,7 +727,7 @@ static NOT_CASTABLE: Lazy<Vec<(&str, Value, &[&str])>> = Lazy::new(|| {
                 "SmallInt",
                 "Integer",
                 "BigInt",
-                "Numeric(32,16)",
+                "Decimal(32,16)",
                 "Real",
                 "DoublePrecision",
                 "ByteA",
@@ -756,7 +752,7 @@ static TYPE_MAPS: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
     maps.insert("SmallInt", "Int");
     maps.insert("Integer", "Int");
     maps.insert("BigInt", "BigInt");
-    maps.insert("Numeric", "Decimal");
+    maps.insert("Decimal", "Decimal");
     maps.insert("Real", "Float");
     maps.insert("DoublePrecision", "Float");
     maps.insert("VarChar", "String");
@@ -1101,7 +1097,7 @@ static SAFE_CASTS_NON_LIST_TO_STRING: Lazy<Vec<(&str, Vec<(&str, Value)>)>> = La
                 ("Integer", Value::array(vec![Value::integer(i32::MAX)])),
                 ("BigInt", Value::array(vec![Value::integer(i64::MAX)])),
                 (
-                    "Numeric(10,2)",
+                    "Decimal(10,2)",
                     Value::array(vec![Value::numeric(BigDecimal::from_str("128.90").unwrap())]),
                 ),
                 ("Real", Value::array(vec![Value::float(f32::MIN)])),
@@ -1140,7 +1136,7 @@ static SAFE_CASTS_NON_LIST_TO_STRING: Lazy<Vec<(&str, Vec<(&str, Value)>)>> = La
                 ("Integer", Value::array(vec![Value::integer(i32::MAX)])),
                 ("BigInt", Value::array(vec![Value::integer(i64::MAX)])),
                 (
-                    "Numeric(10,2)",
+                    "Decimal(10,2)",
                     Value::array(vec![Value::numeric(BigDecimal::from_str("128.90").unwrap())]),
                 ),
                 ("Real", Value::array(vec![Value::float(f32::MIN)])),

--- a/query-engine/connector-test-kit/src/test/scala/writes/dataTypes/native_types/MySqlNativeTypesSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/dataTypes/native_types/MySqlNativeTypesSpec.scala
@@ -66,7 +66,6 @@ class MySqlNativeTypesSpec extends FlatSpec with Matchers with ApiSpecBase with 
         |  float    Float   @test.Float
         |  dfloat   Float   @test.Double
         |  decFloat Decimal @test.Decimal(2, 1)
-        |  numFloat Decimal @test.Numeric(10, 6)
         |}"""
     }
 
@@ -80,13 +79,11 @@ class MySqlNativeTypesSpec extends FlatSpec with Matchers with ApiSpecBase with 
        |      float: 1.1
        |      dfloat: 2.2
        |      decFloat: 3.1234
-       |      numFloat: "4.12345"
        |    }
        |  ) {
        |    float
        |    dfloat
        |    decFloat
-       |    numFloat
        |  }
        |}""".stripMargin,
       project,
@@ -94,7 +91,7 @@ class MySqlNativeTypesSpec extends FlatSpec with Matchers with ApiSpecBase with 
     )
 
     // decFloat is cut due to precision
-    res.toString should be("""{"data":{"createOneModel":{"float":1.1,"dfloat":2.2,"decFloat":"3.1","numFloat":"4.12345"}}}""")
+    res.toString should be("""{"data":{"createOneModel":{"float":1.1,"dfloat":2.2,"decFloat":"3.1"}}}""")
   }
 
   "MySQL native string types" should "work" in {

--- a/query-engine/connector-test-kit/src/test/scala/writes/dataTypes/native_types/PostgresNativeTypesSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/dataTypes/native_types/PostgresNativeTypesSpec.scala
@@ -57,7 +57,6 @@ class PostgresNativeTypesSpec extends FlatSpec with Matchers with ApiSpecBase wi
         |  float    Float   @test.Real
         |  dfloat   Float   @test.DoublePrecision
         |  decFloat Decimal @test.Decimal(2, 1)
-        |  numFloat Decimal @test.Numeric(10, 6)
         |}"""
     }
 
@@ -71,13 +70,11 @@ class PostgresNativeTypesSpec extends FlatSpec with Matchers with ApiSpecBase wi
        |      float: 1.1
        |      dfloat: 2.2
        |      decFloat: 3.1234
-       |      numFloat: "4.12345"
        |    }
        |  ) {
        |    float
        |    dfloat
        |    decFloat
-       |    numFloat
        |  }
        |}""".stripMargin,
       project,
@@ -85,7 +82,7 @@ class PostgresNativeTypesSpec extends FlatSpec with Matchers with ApiSpecBase wi
     )
 
     // decFloat is cut due to precision
-    res.toString should be("""{"data":{"createOneModel":{"float":1.1,"dfloat":2.2,"decFloat":"3.1","numFloat":"4.12345"}}}""")
+    res.toString should be("""{"data":{"createOneModel":{"float":1.1,"dfloat":2.2,"decFloat":"3.1"}}}""")
   }
 
   "Postgres native string types" should "work" in {


### PR DESCRIPTION
This was discussed with product. It is strictly the same as decimal —
this will save some complexity on our side.