### PR TITLE
Scalar filter operations

### DIFF
--- a/datamodel_v2.prisma
+++ b/datamodel_v2.prisma
@@ -1,11 +1,11 @@
 datasource chinook {
-  provider = "sqlite"
-  url      = "file:./db/4230.db?connection_limit=1&socket_timeout=20"
+  provider = "postgres"
+  url      = "postgresql://postgres:prisma@localhost:5432/postgres"
 }
 
 model Container {
   id  Int     @id @default(autoincrement())
-  gql String?
+  gql String[]
 
   Record Record[]
 }

--- a/datamodel_v2.prisma
+++ b/datamodel_v2.prisma
@@ -1,47 +1,110 @@
 datasource chinook {
-  provider = "postgres"
-  url      = "postgresql://postgres:prisma@localhost:5432/postgres"
+  provider = "sqlite"
+  url      = "file:./db/Chinook.db?connection_limit=1&socket_timeout=20"
 }
 
-model Container {
-  id  Int     @id @default(autoincrement())
-  gql String[]
-
-  Record Record[]
+model Album {
+  id       Int     @id @map("AlbumId")
+  Title    String  @default("TestDefaultTitle")
+  ArtistId Int
+  Tracks   Track[]
+  Artist   Artist  @relation(fields: [ArtistId], references: [id])
 }
 
-model RecordConfig {
-  id  Int     @id @default(autoincrement())
-  gql String?
-
-  Record Record[]
+model Track {
+  id           Int           @id @map("TrackId")
+  Name         String
+  Composer     String?
+  Milliseconds Int
+  UnitPrice    Float
+  AlbumId      Int?
+  GenreId      Int?
+  MediaTypeId  Int
+  MediaType    MediaType     @relation(fields: [MediaTypeId], references: [id])
+  Genre        Genre?        @relation(fields: [GenreId], references: [id])
+  Album        Album?        @relation(fields: [AlbumId], references: [id])
+  InvoiceLines InvoiceLine[]
 }
 
-model RecordLocation {
-  id       Int     @id @default(autoincrement())
-  location String  @unique
-  gql      String?
-
-  Record Record[]
+model MediaType {
+  id    Int     @id @map("MediaTypeId")
+  Name  String?
+  Track Track[]
 }
 
-model RecordType {
-  id   Int     @id @default(autoincrement())
-  type String  @unique
-  gql  String?
-
-  Record Record[]
+model Genre {
+  id     Int     @id @map("GenreId")
+  Name   String?
+  Tracks Track[]
 }
 
-model Record {
-  id           Int            @id @default(autoincrement())
-  gql          String?
-  location     RecordLocation @relation(fields: [locationId], references: [id])
-  locationId   Int
-  type         RecordType     @relation(fields: [recordTypeId], references: [id])
-  recordTypeId Int
-  config       RecordConfig?  @relation(fields: [configId], references: [id])
-  configId     Int?
-  container    Container      @relation(fields: [containerId], references: [id])
-  containerId  Int
+model Artist {
+  id     Int     @id @map("ArtistId")
+  Name   String?
+  Albums Album[]
+}
+
+model Customer {
+  id           Int       @id @map("CustomerId")
+  FirstName    String
+  LastName     String
+  Company      String?
+  Address      String?
+  City         String?
+  State        String?
+  Country      String?
+  PostalCode   String?
+  Phone        String?
+  Fax          String?
+  Email        String
+  SupportRepId Int?
+  SupportRep   Employee? @relation(fields: [SupportRepId], references: [id])
+  Invoices     Invoice[]
+}
+
+model Employee {
+  id         Int        @id @map("EmployeeId")
+  FirstName  String
+  LastName   String
+  Title      String?
+  BirthDate  DateTime?
+  HireDate   DateTime?
+  Address    String?
+  City       String?
+  State      String?
+  Country    String?
+  PostalCode String?
+  Phone      String?
+  Fax        String?
+  Email      String?
+  Customers  Customer[]
+}
+
+model Invoice {
+  id                Int           @id @map("InvoiceId")
+  InvoiceDate       DateTime
+  BillingAddress    String?
+  BillingCity       String?
+  BillingState      String?
+  BillingCountry    String?
+  BillingPostalCode String?
+  Total             Float
+  CustomerId        Int
+  Customer          Customer      @relation(fields: [CustomerId], references: [id])
+  Lines             InvoiceLine[]
+}
+
+model InvoiceLine {
+  id        Int     @id @map("InvoiceLineId")
+  UnitPrice Float
+  Quantity  Int
+  InvoiceId Int
+  TrackId   Int
+  Invoice   Invoice @relation(fields: [InvoiceId], references: [id])
+  Track     Track   @relation(fields: [TrackId], references: [id])
+}
+
+model Playlist {
+  id   Int     @id @map("PlaylistId")
+  Name String?
 }

--- a/query-engine/connector-test-kit/src/test/scala/queries/filters/ListFilterSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/filters/ListFilterSpec.scala
@@ -10,7 +10,7 @@ class ListFilterSpec extends FlatSpec with Matchers with ApiSpecBase with Connec
 
   val project: Project = ProjectDsl.fromString { """
      |model Test {
-     |  id        String   @id @default(cuid())
+     |  id        String    @id
      |  strList   String[]
      |  intList   Int[]
      |  floatList Float[]
@@ -32,7 +32,80 @@ class ListFilterSpec extends FlatSpec with Matchers with ApiSpecBase with Connec
   override protected def beforeAll(): Unit = {
     super.beforeAll()
     database.setup(project)
+    createTestData()
   }
 
-  "Queries" should "display all items if no filter is given" in {}
+  // equals
+  // not equals
+  // has
+  // hasEvery
+  // hasSome
+  // isEmpty
+
+  "The equals operation" should "work as expected" in {
+    query("strList", "equals", """["a", "A", "c"]""", 1)
+    query("intList", "equals", """[1, 2, 3]""", 1)
+    query("floatList", "equals", """[1.1, 2.2, 3.3]""", 1)
+    query("bIntList", "equals", """["100", "200", "300"]""", 1)
+    query("decList", "equals", """["11.11", "22.22", "33.33"]""", 1)
+    query("dtList", "equals", """["1969-01-01T10:33:59+00:00", "2018-12-05T12:34:23+00:00"]""", 1)
+    query("boolList", "equals", """[true, false, false, true]""", 1)
+    query("jsonList", "equals", """["{}", "{\"int\":5}", "[1, 2, 3]"]""", 1)
+    query("bytesList", "equals", """["dGVzdA==", "dA=="]""", 1)
+    query("enumList", "equals", """[A, B, B, A]""", 1)
+  }
+
+  "The has operation" should "work as expected" in {
+    query("strList", "has", """"A"""", 1)
+    query("intList", "has", """2""", 1)
+    query("floatList", "has", """1.1""", 1)
+    query("bIntList", "has", """"200"""", 1)
+    query("decList", "has", """33.33""", 1)
+    query("dtList", "has", """"2018-12-05T12:34:23+00:00"""", 1)
+    query("boolList", "has", """true""", 1)
+    query("jsonList", "has", """"[1, 2, 3]"""", 1)
+    query("bytesList", "has", """"dGVzdA=="""", 1)
+    query("enumList", "has", """A""", 1)
+  }
+
+  def query(field: String, operation: String, comparator: String, numExpectedRecords: Int): Unit = {
+    val result = server.query(
+      s"""
+        |query {
+        |  findManyTest(where: {
+        |    $field: { $operation: $comparator }
+        |  }) {
+        |    id
+        |  }
+        |}
+        |""".stripMargin,
+      project,
+      legacy = false
+    )
+
+    result.pathAsJsArray("data.findManyTest").value.length should be(numExpectedRecords)
+  }
+
+  def createTestData(): Unit = {
+    server.query(
+      s"""mutation {
+        |createOneTest(data: {
+        |  id:        "1",
+        |  strList:   ["a", "A", "c"],
+        |  intList:   [1, 2, 3],
+        |  floatList: [1.1, 2.2, 3.3],
+        |  bIntList:  ["100", "200", "300"],
+        |  decList:   ["11.11", "22.22", "33.33"],
+        |  dtList:    ["1969-01-01T10:33:59+00:00", "2018-12-05T12:34:23+00:00"],
+        |  boolList:  [true, false, false, true],
+        |  jsonList:  ["{}", "{\\"int\\":5}", "[1, 2, 3]"],
+        |  bytesList: ["dGVzdA==", "dA=="],
+        |  enumList:  [A, B, B, A]
+        |}) { id }
+        |}
+        |""".stripMargin,
+      project,
+      legacy = false
+    )
+  }
 }

--- a/query-engine/connector-test-kit/src/test/scala/queries/filters/ListFilterSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/filters/ListFilterSpec.scala
@@ -1,0 +1,38 @@
+package queries.filters
+
+import org.scalatest.{FlatSpec, Matchers}
+import util.ConnectorCapability.JoinRelationLinksCapability
+import util.ConnectorTag.PostgresConnectorTag
+import util._
+
+class ListFilterSpec extends FlatSpec with Matchers with ApiSpecBase with ConnectorAwareTest {
+  override def runOnlyForConnectors: Set[ConnectorTag] = Set(PostgresConnectorTag)
+
+  val project: Project = ProjectDsl.fromString { """
+     |model Test {
+     |  id        String   @id @default(cuid())
+     |  strList   String[]
+     |  intList   Int[]
+     |  floatList Float[]
+     |  bIntList  BigInt[]
+     |  decList   Decimal[]
+     |  dtList    DateTime[]
+     |  boolList  Boolean[]
+     |  jsonList  Json[]
+     |  bytesList Bytes[]
+     |  enumList  TestEnum[]
+     |}
+     |
+     |enum TestEnum {
+     |  A
+     |  B
+     |}
+     """.stripMargin }
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    database.setup(project)
+  }
+
+  "Queries" should "display all items if no filter is given" in {}
+}

--- a/query-engine/connector-test-kit/src/test/scala/queries/filters/ListFilterSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/filters/ListFilterSpec.scala
@@ -42,33 +42,121 @@ class ListFilterSpec extends FlatSpec with Matchers with ApiSpecBase with Connec
   // hasSome
   // isEmpty
 
-  "The equals operation" should "work as expected" in {
-    query("strList", "equals", """["a", "A", "c"]""", 1)
-    query("intList", "equals", """[1, 2, 3]""", 1)
-    query("floatList", "equals", """[1.1, 2.2, 3.3]""", 1)
-    query("bIntList", "equals", """["100", "200", "300"]""", 1)
-    query("decList", "equals", """["11.11", "22.22", "33.33"]""", 1)
-    query("dtList", "equals", """["1969-01-01T10:33:59+00:00", "2018-12-05T12:34:23+00:00"]""", 1)
-    query("boolList", "equals", """[true, false, false, true]""", 1)
-    query("jsonList", "equals", """["{}", "{\"int\":5}", "[1, 2, 3]"]""", 1)
-    query("bytesList", "equals", """["dGVzdA==", "dA=="]""", 1)
-    query("enumList", "equals", """[A, B, B, A]""", 1)
+  "The `equals` operation" should "work as expected" in {
+    query("strList", "equals", """["a", "A", "c"]""", Some(1))
+    query("intList", "equals", """[1, 2, 3]""", Some(1))
+    query("floatList", "equals", """[1.1, 2.2, 3.3]""", Some(1))
+    query("bIntList", "equals", """["100", "200", "300"]""", Some(1))
+    query("decList", "equals", """["11.11", "22.22", "33.33"]""", Some(1))
+    query("dtList", "equals", """["1969-01-01T10:33:59+00:00", "2018-12-05T12:34:23+00:00"]""", Some(1))
+    query("boolList", "equals", """[true]""", Some(1))
+    query("jsonList", "equals", """["{}", "{\"int\":5}", "[1, 2, 3]"]""", Some(1))
+    query("bytesList", "equals", """["dGVzdA==", "dA=="]""", Some(1))
+    query("enumList", "equals", """[A, B, B, A]""", Some(1))
   }
 
-  "The has operation" should "work as expected" in {
-    query("strList", "has", """"A"""", 1)
-    query("intList", "has", """2""", 1)
-    query("floatList", "has", """1.1""", 1)
-    query("bIntList", "has", """"200"""", 1)
-    query("decList", "has", """33.33""", 1)
-    query("dtList", "has", """"2018-12-05T12:34:23+00:00"""", 1)
-    query("boolList", "has", """true""", 1)
-    query("jsonList", "has", """"[1, 2, 3]"""", 1)
-    query("bytesList", "has", """"dGVzdA=="""", 1)
-    query("enumList", "has", """A""", 1)
+  "The `has` operation" should "work as expected" in {
+    query("strList", "has", """"A"""", Some(1))
+    query("intList", "has", """2""", Some(1))
+    query("floatList", "has", """1.1""", Some(1))
+    query("bIntList", "has", """"200"""", Some(1))
+    query("decList", "has", """33.33""", Some(1))
+    query("dtList", "has", """"2018-12-05T12:34:23+00:00"""", Some(1))
+    query("boolList", "has", """true""", Some(1))
+    query("jsonList", "has", """"[1, 2, 3]"""", Some(1))
+    query("bytesList", "has", """"dGVzdA=="""", Some(1))
+    query("enumList", "has", """A""", Some(1))
   }
 
-  def query(field: String, operation: String, comparator: String, numExpectedRecords: Int): Unit = {
+  "The `hasSome` operation" should "work as expected" in {
+    query("strList", "hasSome", """["A", "c"]""", Some(1))
+    query("intList", "hasSome", """[2, 10]""", Some(1))
+    query("floatList", "hasSome", """[1.1, 5.5]""", Some(1))
+    query("bIntList", "hasSome", """["200", "5000"]""", Some(1))
+    query("decList", "hasSome", """[55.55, 33.33]""", Some(1))
+    query("dtList", "hasSome", """["2018-12-05T12:34:23+00:00", "2019-12-05T12:34:23+00:00"]""", Some(1))
+    query("boolList", "hasSome", """[true, false]""", Some(1))
+    query("jsonList", "hasSome", """["{}", "[1]"]""", Some(1))
+    query("bytesList", "hasSome", """["dGVzdA==", "bG9va2luZyBmb3Igc29tZXRoaW5nPw=="]""", Some(1))
+    query("enumList", "hasSome", """[A]""", Some(1))
+
+    query("strList", "hasSome", """[]""", None)
+  }
+
+  "The `hasEvery` operation" should "work as expected" in {
+    query("strList", "hasEvery", """["A", "d"]""", None)
+    query("strList", "hasEvery", """["A"]""", Some(1))
+
+    query("intList", "hasEvery", """[2, 10]""", None)
+    query("intList", "hasEvery", """[2]""", Some(1))
+
+    query("floatList", "hasEvery", """[1.1, 5.5]""", None)
+    query("floatList", "hasEvery", """[1.1]""", Some(1))
+
+    query("bIntList", "hasEvery", """["200", "5000"]""", None)
+    query("bIntList", "hasEvery", """["200"]""", Some(1))
+
+    query("decList", "hasEvery", """[55.55, 33.33]""", None)
+    query("decList", "hasEvery", """[33.33]""", Some(1))
+
+    query("dtList", "hasEvery", """["2018-12-05T12:34:23+00:00", "2019-12-05T12:34:23+00:00"]""", None)
+    query("dtList", "hasEvery", """["2018-12-05T12:34:23+00:00"]""", Some(1))
+
+    query("boolList", "hasEvery", """[true, false]""", None)
+    query("boolList", "hasEvery", """[true]""", Some(1))
+
+    query("jsonList", "hasEvery", """["{}", "[1]"]""", None)
+    query("jsonList", "hasEvery", """["{}"]""", Some(1))
+
+    query("bytesList", "hasEvery", """["dGVzdA==", "bG9va2luZyBmb3Igc29tZXRoaW5nPw=="]""", None)
+    query("bytesList", "hasEvery", """["dGVzdA=="]""", Some(1))
+
+    query("enumList", "hasEvery", """[A, B]""", Some(1))
+  }
+
+  "Querying `hasEvery` with an empty input" should "return all" in {
+    val result = server.query(
+      s"""
+         |query {
+         |  findManyTest(where: {
+         |    strList: { hasEvery: [] }
+         |  }) {
+         |    id
+         |  }
+         |}
+         |""".stripMargin,
+      project,
+      legacy = false
+    )
+
+    result.toString() should be("""{"data":{"findManyTest":[{"id":"1"},{"id":"2"}]}}""")
+  }
+
+  "The `isEmpty` operation" should "work as expected" in {
+    query("strList", "isEmpty", "true", Some(2))
+    query("intList", "isEmpty", "true", Some(2))
+    query("floatList", "isEmpty", "true", Some(2))
+    query("bIntList", "isEmpty", "true", Some(2))
+    query("decList", "isEmpty", "true", Some(2))
+    query("dtList", "isEmpty", "true", Some(2))
+    query("boolList", "isEmpty", "true", Some(2))
+    query("jsonList", "isEmpty", "true", Some(2))
+    query("bytesList", "isEmpty", "true", Some(2))
+    query("enumList", "isEmpty", "true", Some(2))
+
+    query("strList", "isEmpty", "false", Some(1))
+    query("intList", "isEmpty", "false", Some(1))
+    query("floatList", "isEmpty", "false", Some(1))
+    query("bIntList", "isEmpty", "false", Some(1))
+    query("decList", "isEmpty", "false", Some(1))
+    query("dtList", "isEmpty", "false", Some(1))
+    query("boolList", "isEmpty", "false", Some(1))
+    query("jsonList", "isEmpty", "false", Some(1))
+    query("bytesList", "isEmpty", "false", Some(1))
+    query("enumList", "isEmpty", "false", Some(1))
+  }
+
+  def query(field: String, operation: String, comparator: String, expectedId: Option[Int]): Unit = {
     val result = server.query(
       s"""
         |query {
@@ -83,9 +171,14 @@ class ListFilterSpec extends FlatSpec with Matchers with ApiSpecBase with Connec
       legacy = false
     )
 
-    result.pathAsJsArray("data.findManyTest").value.length should be(numExpectedRecords)
+    expectedId match {
+      case Some(id) => result.toString() should be(s"""{"data":{"findManyTest":[{"id":"$id"}]}}""")
+      case None     => result.pathAsSeq("data.findManyTest").length should be(0)
+    }
   }
 
+  // 1 with full data
+  // 1 empty
   def createTestData(): Unit = {
     server.query(
       s"""mutation {
@@ -97,13 +190,34 @@ class ListFilterSpec extends FlatSpec with Matchers with ApiSpecBase with Connec
         |  bIntList:  ["100", "200", "300"],
         |  decList:   ["11.11", "22.22", "33.33"],
         |  dtList:    ["1969-01-01T10:33:59+00:00", "2018-12-05T12:34:23+00:00"],
-        |  boolList:  [true, false, false, true],
+        |  boolList:  [true],
         |  jsonList:  ["{}", "{\\"int\\":5}", "[1, 2, 3]"],
         |  bytesList: ["dGVzdA==", "dA=="],
         |  enumList:  [A, B, B, A]
         |}) { id }
         |}
         |""".stripMargin,
+      project,
+      legacy = false
+    )
+
+    server.query(
+      s"""mutation {
+         |createOneTest(data: {
+         |  id:        "2",
+         |  strList:   [],
+         |  intList:   [],
+         |  floatList: [],
+         |  bIntList:  [],
+         |  decList:   [],
+         |  dtList:    [],
+         |  boolList:  [],
+         |  jsonList:  [],
+         |  bytesList: [],
+         |  enumList:  []
+         |}) { id }
+         |}
+         |""".stripMargin,
       project,
       legacy = false
     )

--- a/query-engine/connector-test-kit/src/test/scala/queries/filters/ListFilterSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/filters/ListFilterSpec.scala
@@ -35,13 +35,6 @@ class ListFilterSpec extends FlatSpec with Matchers with ApiSpecBase with Connec
     createTestData()
   }
 
-  // equals
-  // not equals
-  // has
-  // hasEvery
-  // hasSome
-  // isEmpty
-
   "The `equals` operation" should "work as expected" in {
     query("strList", "equals", """["a", "A", "c"]""", Some(1))
     query("intList", "equals", """[1, 2, 3]""", Some(1))

--- a/query-engine/connector-test-kit/src/test/scala/writes/dataTypes/scalarLists/ScalarListsSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/dataTypes/scalarLists/ScalarListsSpec.scala
@@ -101,7 +101,7 @@ class ScalarListsSpec extends FlatSpec with Matchers with ApiSpecBase {
       s"""mutation {
          |  createScalarModel(data: {
          |    id: 1
-         |    strings:    ["test${TroubleCharacters.value}"]
+         |    strings:   ["test${TroubleCharacters.value}"]
          |    ints:      [1337, 12]
          |    floats:    [1.234, 1.45]
          |    decimals:  ["1.234", "1.45"]

--- a/query-engine/connectors/query-connector/src/compare.rs
+++ b/query-engine/connectors/query-connector/src/compare.rs
@@ -89,11 +89,11 @@ pub trait ScalarListCompare {
 
     fn contains_every_element<T>(&self, filter: Vec<T>) -> Filter
     where
-        T: Into<Filter>;
+        T: Into<PrismaValue>;
 
     fn contains_some_element<T>(&self, filter: Vec<T>) -> Filter
     where
-        T: Into<Filter>;
+        T: Into<PrismaValue>;
 
-    fn contains_none(&self) -> Filter;
+    fn is_empty_list(&self, b: bool) -> Filter;
 }

--- a/query-engine/connectors/query-connector/src/filter/list.rs
+++ b/query-engine/connectors/query-connector/src/filter/list.rs
@@ -20,8 +20,8 @@ pub enum ScalarListCondition {
     /// List contains some of the given values
     ContainsSome(Vec<PrismaValue>),
 
-    /// List is empty
-    ContainsNone,
+    /// List emptiness check
+    IsEmpty(bool),
 }
 
 #[allow(warnings)]
@@ -38,30 +38,28 @@ impl ScalarListCompare for Arc<ScalarField> {
 
     fn contains_every_element<T>(&self, values: Vec<T>) -> Filter
     where
-        T: Into<Filter>,
+        T: Into<PrismaValue>,
     {
-        // Filter::from(ScalarListFilter {
-        //     field: Arc::clone(self),
-        //     condition: ScalarListCondition::ContainsEvery(values.into()),
-        // })
-        unimplemented!()
+        Filter::from(ScalarListFilter {
+            field: Arc::clone(self),
+            condition: ScalarListCondition::ContainsEvery(values.into_iter().map(Into::into).collect()),
+        })
     }
 
     fn contains_some_element<T>(&self, values: Vec<T>) -> Filter
     where
-        T: Into<Filter>,
+        T: Into<PrismaValue>,
     {
-        // Filter::from(ScalarListFilter {
-        //     field: Arc::clone(self),
-        //     condition: ScalarListCondition::ContainsSome(values.into()),
-        // })
-        unimplemented!()
-    }
-
-    fn contains_none(&self) -> Filter {
         Filter::from(ScalarListFilter {
             field: Arc::clone(self),
-            condition: ScalarListCondition::ContainsNone,
+            condition: ScalarListCondition::ContainsSome(values.into_iter().map(Into::into).collect()),
+        })
+    }
+
+    fn is_empty_list(&self, b: bool) -> Filter {
+        Filter::from(ScalarListFilter {
+            field: Arc::clone(self),
+            condition: ScalarListCondition::IsEmpty(b),
         })
     }
 }

--- a/query-engine/connectors/query-connector/src/filter/mod.rs
+++ b/query-engine/connectors/query-connector/src/filter/mod.rs
@@ -23,7 +23,6 @@ pub enum Filter {
     ScalarList(ScalarListFilter),
     OneRelationIsNull(OneRelationIsNullFilter),
     Relation(RelationFilter),
-    NodeSubscription,
     BoolFilter(bool),
     Aggregation(AggregationFilter),
     Empty,

--- a/query-engine/connectors/sql-query-connector/src/filter_conversion.rs
+++ b/query-engine/connectors/sql-query-connector/src/filter_conversion.rs
@@ -191,11 +191,13 @@ fn convert_scalar_list_filter(
     field: &ScalarFieldRef,
 ) -> ConditionTree<'static> {
     let condition = match cond {
-        ScalarListCondition::Contains(val) => comparable.compare_raw("@>", convert_value(field, val)),
-        ScalarListCondition::ContainsEvery(vals) => comparable.compare_raw("<@", convert_list_value(field, vals)),
+        ScalarListCondition::Contains(val) => {
+            comparable.compare_raw("@>", Value::Array(Some(vec![convert_value(field, val)])))
+        }
+        ScalarListCondition::ContainsEvery(vals) => comparable.compare_raw("@>", convert_list_value(field, vals)),
         ScalarListCondition::ContainsSome(vals) => comparable.compare_raw("&&", convert_list_value(field, vals)),
-        ScalarListCondition::IsEmpty(cond) if cond => comparable.compare_raw("=", "{}"),
-        ScalarListCondition::IsEmpty(_) => comparable.compare_raw("<>", "{}"),
+        ScalarListCondition::IsEmpty(cond) if cond => comparable.compare_raw("=", Value::Array(Some(vec![])).raw()),
+        ScalarListCondition::IsEmpty(_) => comparable.compare_raw("<>", Value::Array(Some(vec![])).raw()),
     };
 
     ConditionTree::single(condition)

--- a/query-engine/core/src/query_document/transformers.rs
+++ b/query-engine/core/src/query_document/transformers.rs
@@ -85,6 +85,26 @@ impl TryInto<Vec<ParsedInputValue>> for ParsedInputValue {
     }
 }
 
+impl TryInto<Vec<PrismaValue>> for ParsedInputValue {
+    type Error = QueryParserError;
+
+    fn try_into(self) -> QueryParserResult<Vec<PrismaValue>> {
+        match self {
+            ParsedInputValue::List(vals) => vals
+                .into_iter()
+                .map(|val| val.try_into())
+                .collect::<QueryParserResult<Vec<_>>>(),
+            v => Err(QueryParserError {
+                path: QueryPath::default(),
+                error_kind: QueryParserErrorKind::AssertionError(format!(
+                    "Attempted conversion of non-list ParsedInputValue ({:?}) into prisma value list failed.",
+                    v
+                )),
+            }),
+        }
+    }
+}
+
 impl TryInto<Option<String>> for ParsedInputValue {
     type Error = QueryParserError;
 

--- a/query-engine/core/src/query_graph_builder/extractors/filters/scalar.rs
+++ b/query-engine/core/src/query_graph_builder/extractors/filters/scalar.rs
@@ -3,6 +3,21 @@ use connector::{Filter, ScalarCompare};
 use prisma_models::{PrismaValue, ScalarFieldRef};
 use std::convert::TryInto;
 
+pub fn parse_list(
+    filter_key: &str,
+    field: &ScalarFieldRef,
+    input: ParsedInputValue,
+    reverse: bool,
+) -> QueryGraphBuilderResult<Vec<Filter>> {
+    // let filter = match filter_key {
+    //     "not" => {
+    //         match input {
+    //         }
+    //     }
+
+    todo!()
+}
+
 pub fn parse(
     filter_key: &str,
     field: &ScalarFieldRef,


### PR DESCRIPTION
Related issue: https://github.com/prisma/prisma/issues/5010

Adds 4 new operations to all list types:
- `has`: List must contain the value.
- `hasSome`: List must contain at least one of the given values.
- `hasEvery`: List must contain all values of the given list
- `isEmpty` (bool): Filters lists that are either empty (true) or non-empty (false).

```graphql
query {
  findManyModel(where: {
      strList: {
          # Exactly one of the following needed
          has: "test"
          hasSome: ["a", "b"]
          hasEvery: ["a", "b", "test"]
          isEmpty: true
      }
      # Other list types follow exactly the same serializtion rules as their base type, e.g.:
      jsonList: {
          has: "{}"
          hasSome: ["{}", "[]"]
          hasEvery: ["{}", "[]", "[1,2,3]"]
          isEmpty: true
      }
  })
}
```