### PR TITLE
Rename the MySQL JSON native type to Json

### DIFF
--- a/introspection-engine/introspection-engine-tests/tests/native_types/mysql.rs
+++ b/introspection-engine/introspection-engine-tests/tests/native_types/mysql.rs
@@ -66,7 +66,7 @@ async fn native_type_columns_feature_on(api: &TestApi) -> crate::TestResult {
         .await?;
 
     let (json, default) = match api {
-        _ if api.tags.contains(Tags::Mysql8) => ("Json     @mysql.JSON", ""),
+        _ if api.tags.contains(Tags::Mysql8) => ("Json     @mysql.Json", ""),
         _ if api.tags.contains(Tags::Mariadb) => ("String   @mysql.LongText", "@default(now())"),
         _ => unreachable!(),
     };

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
@@ -40,7 +40,7 @@ const TIME_TYPE_NAME: &str = "Time";
 const DATETIME_TYPE_NAME: &str = "Datetime";
 const TIMESTAMP_TYPE_NAME: &str = "Timestamp";
 const YEAR_TYPE_NAME: &str = "Year";
-const JSON_TYPE_NAME: &str = "JSON";
+const JSON_TYPE_NAME: &str = "Json";
 
 const NATIVE_TYPES_THAT_CAN_NOT_BE_USED_IN_KEY_SPECIFICATION: &[&str] = &[
     TEXT_TYPE_NAME,
@@ -266,7 +266,7 @@ impl Connector for MySqlDatamodelConnector {
             DATETIME_TYPE_NAME => DateTime(parse_one_opt_u32(args, DATETIME_TYPE_NAME)?),
             TIMESTAMP_TYPE_NAME => Timestamp(parse_one_opt_u32(args, TIMESTAMP_TYPE_NAME)?),
             YEAR_TYPE_NAME => Year,
-            JSON_TYPE_NAME => JSON,
+            JSON_TYPE_NAME => Json,
             x => unreachable!(format!(
                 "This code is unreachable as the core must guarantee to just call with known names. {}",
                 x
@@ -310,7 +310,7 @@ impl Connector for MySqlDatamodelConnector {
             DateTime(x) => (DATETIME_TYPE_NAME, arg_vec_from_opt(x)),
             Timestamp(x) => (TIMESTAMP_TYPE_NAME, arg_vec_from_opt(x)),
             Year => (YEAR_TYPE_NAME, vec![]),
-            JSON => (JSON_TYPE_NAME, vec![]),
+            Json => (JSON_TYPE_NAME, vec![]),
         };
 
         fn arg_vec_from_opt(input: Option<u32>) -> Vec<String> {

--- a/libs/native-types/src/mysql.rs
+++ b/libs/native-types/src/mysql.rs
@@ -34,7 +34,7 @@ pub enum MySqlType {
     DateTime(Option<u32>),
     Timestamp(Option<u32>),
     Year,
-    JSON,
+    Json,
 }
 
 impl super::NativeType for MySqlType {

--- a/libs/sql-schema-describer/src/mysql.rs
+++ b/libs/sql-schema-describer/src/mysql.rs
@@ -590,7 +590,7 @@ impl SqlSchemaDescriber {
             "mediumtext" => (ColumnTypeFamily::String, Some(MySqlType::MediumText)),
             "longtext" => (ColumnTypeFamily::String, Some(MySqlType::LongText)),
             "enum" => (ColumnTypeFamily::Enum(format!("{}_{}", table, column_name)), None),
-            "json" => (ColumnTypeFamily::Json, Some(MySqlType::JSON)),
+            "json" => (ColumnTypeFamily::Json, Some(MySqlType::Json)),
             "set" => (ColumnTypeFamily::String, None),
             //temporal
             "date" => (ColumnTypeFamily::DateTime, Some(MySqlType::Date)),

--- a/libs/sql-schema-describer/tests/mysql_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/mysql_describer_tests.rs
@@ -604,7 +604,7 @@ async fn all_mysql_column_types_must_work() {
                 character_maximum_length: None,
                 family: ColumnTypeFamily::Json,
                 arity: ColumnArity::Required,
-                native_type: Some(MySqlType::JSON.to_json()),
+                native_type: Some(MySqlType::Json.to_json()),
             },
 
             default: None,

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
@@ -408,7 +408,7 @@ fn render_column_type(column: &ColumnWalker<'_>) -> Cow<'static, str> {
 
             format!("ENUM({})", variants).into()
         }
-        ColumnTypeFamily::Json => "JSON".into(),
+        ColumnTypeFamily::Json => "Json".into(),
         ColumnTypeFamily::Binary => "LONGBLOB".into(),
         ColumnTypeFamily::Uuid => unimplemented!("Uuid not handled yet"),
         ColumnTypeFamily::Unsupported(x) => unimplemented!("{} not handled yet", x),

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/mysql.rs
@@ -81,7 +81,7 @@ impl SqlSchemaCalculatorFlavour for MysqlFlavour {
             MySqlType::DateTime(precision) => format!("DATETIME{}", render(precision)),
             MySqlType::Timestamp(precision) => format!("TIMESTAMP{}", render(precision)),
             MySqlType::Year => "YEAR".into(),
-            MySqlType::JSON => "JSON".into(),
+            MySqlType::Json => "JSON".into(),
             MySqlType::UnsignedInt => "INTEGER UNSIGNED".into(),
             MySqlType::UnsignedSmallInt => "SMALLINT UNSIGNED".into(),
             MySqlType::UnsignedTinyInt => "TINYINT UNSIGNED".into(),

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/mysql.rs
@@ -21,7 +21,7 @@ impl SqlSchemaDifferFlavour for MysqlFlavour {
                 differ.previous.column_type_family(),
                 differ.next.column_type_family(),
             ) {
-                (Some(MySqlType::LongText), Some(MySqlType::JSON), _, _) => return None,
+                (Some(MySqlType::LongText), Some(MySqlType::Json), _, _) => return None,
                 (Some(_), Some(_), _, _) => (),
                 (_, _, ColumnTypeFamily::String, ColumnTypeFamily::Json) => return None,
                 _ => (),
@@ -154,7 +154,7 @@ fn native_type_change(types: Pair<MySqlType>) -> Option<ColumnTypeChange> {
             | MySqlType::Date
             | MySqlType::DateTime(_)
             | MySqlType::Timestamp(_)
-            | MySqlType::JSON => not_castable(),
+            | MySqlType::Json => not_castable(),
         },
         MySqlType::Binary(size) => match next {
             MySqlType::Binary(n) if n == size => return None,
@@ -192,7 +192,7 @@ fn native_type_change(types: Pair<MySqlType>) -> Option<ColumnTypeChange> {
             | MySqlType::UnsignedTinyInt
             | MySqlType::Year => risky(),
 
-            MySqlType::Date | MySqlType::DateTime(_) | MySqlType::JSON | MySqlType::Timestamp(_) => not_castable(),
+            MySqlType::Date | MySqlType::DateTime(_) | MySqlType::Json | MySqlType::Timestamp(_) => not_castable(),
         },
         MySqlType::Bit(n) => match next {
             MySqlType::Bit(m) if n == m => return None,
@@ -232,7 +232,7 @@ fn native_type_change(types: Pair<MySqlType>) -> Option<ColumnTypeChange> {
             | MySqlType::DateTime(_)
             | MySqlType::Time(_)
             | MySqlType::Timestamp(_)
-            | MySqlType::JSON => not_castable(),
+            | MySqlType::Json => not_castable(),
         },
         MySqlType::Blob => match next {
             MySqlType::Blob => return None,
@@ -257,7 +257,7 @@ fn native_type_change(types: Pair<MySqlType>) -> Option<ColumnTypeChange> {
             | MySqlType::Double
             | MySqlType::Float
             | MySqlType::Int
-            | MySqlType::JSON
+            | MySqlType::Json
             | MySqlType::MediumInt
             | MySqlType::SmallInt
             | MySqlType::Time(_)
@@ -303,7 +303,7 @@ fn native_type_change(types: Pair<MySqlType>) -> Option<ColumnTypeChange> {
             | MySqlType::UnsignedTinyInt => risky(),
 
             MySqlType::Bit(_)
-            | MySqlType::JSON
+            | MySqlType::Json
             | MySqlType::Date
             | MySqlType::DateTime(_)
             | MySqlType::Timestamp(_)
@@ -328,7 +328,7 @@ fn native_type_change(types: Pair<MySqlType>) -> Option<ColumnTypeChange> {
             | MySqlType::MediumInt
             | MySqlType::Time(_)
             | MySqlType::Timestamp(_)
-            | MySqlType::JSON
+            | MySqlType::Json
             | MySqlType::UnsignedMediumInt
             | MySqlType::UnsignedSmallInt => not_castable(),
 
@@ -375,7 +375,7 @@ fn native_type_change(types: Pair<MySqlType>) -> Option<ColumnTypeChange> {
             | MySqlType::Decimal(_)
             | MySqlType::TinyInt
             | MySqlType::Int
-            | MySqlType::JSON
+            | MySqlType::Json
             | MySqlType::UnsignedInt
             | MySqlType::SmallInt
             | MySqlType::UnsignedSmallInt
@@ -419,7 +419,7 @@ fn native_type_change(types: Pair<MySqlType>) -> Option<ColumnTypeChange> {
             | MySqlType::Float
             | MySqlType::Double
             | MySqlType::Year
-            | MySqlType::JSON => risky(),
+            | MySqlType::Json => risky(),
 
             MySqlType::DateTime(_) | MySqlType::Timestamp(_) | MySqlType::Date => not_castable(),
         },
@@ -437,7 +437,7 @@ fn native_type_change(types: Pair<MySqlType>) -> Option<ColumnTypeChange> {
             | MySqlType::UnsignedBigInt
             | MySqlType::TinyInt
             | MySqlType::Int
-            | MySqlType::JSON
+            | MySqlType::Json
             | MySqlType::UnsignedInt
             | MySqlType::SmallInt
             | MySqlType::UnsignedSmallInt
@@ -482,7 +482,7 @@ fn native_type_change(types: Pair<MySqlType>) -> Option<ColumnTypeChange> {
             | MySqlType::UnsignedBigInt
             | MySqlType::TinyInt
             | MySqlType::Int
-            | MySqlType::JSON
+            | MySqlType::Json
             | MySqlType::UnsignedInt
             | MySqlType::SmallInt
             | MySqlType::UnsignedSmallInt
@@ -551,10 +551,10 @@ fn native_type_change(types: Pair<MySqlType>) -> Option<ColumnTypeChange> {
             | MySqlType::DateTime(_)
             | MySqlType::Timestamp(_)
             | MySqlType::Time(_)
-            | MySqlType::JSON => not_castable(),
+            | MySqlType::Json => not_castable(),
         },
-        MySqlType::JSON => match next {
-            MySqlType::JSON => return None,
+        MySqlType::Json => match next {
+            MySqlType::Json => return None,
 
             // To string
             MySqlType::Binary(_)
@@ -615,7 +615,7 @@ fn native_type_change(types: Pair<MySqlType>) -> Option<ColumnTypeChange> {
             | MySqlType::Double
             | MySqlType::Float
             | MySqlType::Int
-            | MySqlType::JSON
+            | MySqlType::Json
             | MySqlType::MediumInt
             | MySqlType::SmallInt
             | MySqlType::Time(_)
@@ -662,7 +662,7 @@ fn native_type_change(types: Pair<MySqlType>) -> Option<ColumnTypeChange> {
             MySqlType::Date
             | MySqlType::DateTime(_)
             | MySqlType::Timestamp(_)
-            | MySqlType::JSON
+            | MySqlType::Json
             | MySqlType::Time(_)
             | MySqlType::Year => risky(),
         },
@@ -689,7 +689,7 @@ fn native_type_change(types: Pair<MySqlType>) -> Option<ColumnTypeChange> {
             | MySqlType::Double
             | MySqlType::Float
             | MySqlType::Int
-            | MySqlType::JSON
+            | MySqlType::Json
             | MySqlType::MediumInt
             | MySqlType::SmallInt
             | MySqlType::Time(_)
@@ -740,7 +740,7 @@ fn native_type_change(types: Pair<MySqlType>) -> Option<ColumnTypeChange> {
             | MySqlType::DateTime(_)
             | MySqlType::Timestamp(_)
             | MySqlType::Time(_)
-            | MySqlType::JSON => not_castable(),
+            | MySqlType::Json => not_castable(),
         },
         MySqlType::MediumText => match next {
             MySqlType::MediumText => return None,
@@ -777,7 +777,7 @@ fn native_type_change(types: Pair<MySqlType>) -> Option<ColumnTypeChange> {
             MySqlType::Date
             | MySqlType::DateTime(_)
             | MySqlType::Timestamp(_)
-            | MySqlType::JSON
+            | MySqlType::Json
             | MySqlType::Time(_)
             | MySqlType::Year => risky(),
         },
@@ -816,7 +816,7 @@ fn native_type_change(types: Pair<MySqlType>) -> Option<ColumnTypeChange> {
             | MySqlType::Date
             | MySqlType::DateTime(_)
             | MySqlType::Timestamp(_)
-            | MySqlType::JSON => not_castable(),
+            | MySqlType::Json => not_castable(),
         },
 
         MySqlType::Text => match next {
@@ -854,7 +854,7 @@ fn native_type_change(types: Pair<MySqlType>) -> Option<ColumnTypeChange> {
             MySqlType::Date
             | MySqlType::DateTime(_)
             | MySqlType::Timestamp(_)
-            | MySqlType::JSON
+            | MySqlType::Json
             | MySqlType::Time(_)
             | MySqlType::Year => risky(),
         },
@@ -880,7 +880,7 @@ fn native_type_change(types: Pair<MySqlType>) -> Option<ColumnTypeChange> {
 
             MySqlType::Date | MySqlType::DateTime(_) | MySqlType::Timestamp(_) => risky(),
 
-            MySqlType::JSON | MySqlType::Year => not_castable(),
+            MySqlType::Json | MySqlType::Year => not_castable(),
 
             // To numeric
             MySqlType::BigInt
@@ -925,7 +925,7 @@ fn native_type_change(types: Pair<MySqlType>) -> Option<ColumnTypeChange> {
             | MySqlType::Decimal(_)
             | MySqlType::TinyInt
             | MySqlType::Int
-            | MySqlType::JSON
+            | MySqlType::Json
             | MySqlType::UnsignedInt
             | MySqlType::SmallInt
             | MySqlType::UnsignedSmallInt
@@ -959,7 +959,7 @@ fn native_type_change(types: Pair<MySqlType>) -> Option<ColumnTypeChange> {
             | MySqlType::Double
             | MySqlType::Float
             | MySqlType::Int
-            | MySqlType::JSON
+            | MySqlType::Json
             | MySqlType::MediumInt
             | MySqlType::SmallInt
             | MySqlType::Time(_)
@@ -1008,7 +1008,7 @@ fn native_type_change(types: Pair<MySqlType>) -> Option<ColumnTypeChange> {
             | MySqlType::Date
             | MySqlType::DateTime(_)
             | MySqlType::Timestamp(_)
-            | MySqlType::JSON => not_castable(),
+            | MySqlType::Json => not_castable(),
         },
 
         MySqlType::TinyText => match next {
@@ -1047,7 +1047,7 @@ fn native_type_change(types: Pair<MySqlType>) -> Option<ColumnTypeChange> {
             MySqlType::Date
             | MySqlType::DateTime(_)
             | MySqlType::Timestamp(_)
-            | MySqlType::JSON
+            | MySqlType::Json
             | MySqlType::Time(_)
             | MySqlType::Year => risky(),
         },
@@ -1089,7 +1089,7 @@ fn native_type_change(types: Pair<MySqlType>) -> Option<ColumnTypeChange> {
             | MySqlType::Date
             | MySqlType::DateTime(_)
             | MySqlType::Timestamp(_)
-            | MySqlType::JSON => not_castable(),
+            | MySqlType::Json => not_castable(),
         },
 
         MySqlType::UnsignedInt => match next {
@@ -1129,7 +1129,7 @@ fn native_type_change(types: Pair<MySqlType>) -> Option<ColumnTypeChange> {
             | MySqlType::Date
             | MySqlType::DateTime(_)
             | MySqlType::Timestamp(_)
-            | MySqlType::JSON => not_castable(),
+            | MySqlType::Json => not_castable(),
         },
         MySqlType::UnsignedMediumInt => match next {
             MySqlType::UnsignedMediumInt => return None,
@@ -1168,7 +1168,7 @@ fn native_type_change(types: Pair<MySqlType>) -> Option<ColumnTypeChange> {
             | MySqlType::Date
             | MySqlType::DateTime(_)
             | MySqlType::Timestamp(_)
-            | MySqlType::JSON => not_castable(),
+            | MySqlType::Json => not_castable(),
         },
         MySqlType::UnsignedSmallInt => match next {
             MySqlType::UnsignedSmallInt => return None,
@@ -1206,7 +1206,7 @@ fn native_type_change(types: Pair<MySqlType>) -> Option<ColumnTypeChange> {
             | MySqlType::Date
             | MySqlType::DateTime(_)
             | MySqlType::Timestamp(_)
-            | MySqlType::JSON => not_castable(),
+            | MySqlType::Json => not_castable(),
         },
         MySqlType::UnsignedTinyInt => match next {
             MySqlType::UnsignedTinyInt => return None,
@@ -1246,7 +1246,7 @@ fn native_type_change(types: Pair<MySqlType>) -> Option<ColumnTypeChange> {
             | MySqlType::Date
             | MySqlType::DateTime(_)
             | MySqlType::Timestamp(_)
-            | MySqlType::JSON => not_castable(),
+            | MySqlType::Json => not_castable(),
         },
         MySqlType::VarBinary(n) => match next {
             MySqlType::VarBinary(m) if n > m => risky(),
@@ -1274,7 +1274,7 @@ fn native_type_change(types: Pair<MySqlType>) -> Option<ColumnTypeChange> {
             | MySqlType::Double
             | MySqlType::Float
             | MySqlType::Int
-            | MySqlType::JSON
+            | MySqlType::Json
             | MySqlType::MediumInt
             | MySqlType::SmallInt
             | MySqlType::Time(_)
@@ -1324,7 +1324,7 @@ fn native_type_change(types: Pair<MySqlType>) -> Option<ColumnTypeChange> {
             | MySqlType::UnsignedSmallInt
             | MySqlType::UnsignedTinyInt
             | MySqlType::Year
-            | MySqlType::JSON => risky(),
+            | MySqlType::Json => risky(),
         },
         MySqlType::Year => match next {
             MySqlType::Year => return None,
@@ -1356,7 +1356,7 @@ fn native_type_change(types: Pair<MySqlType>) -> Option<ColumnTypeChange> {
 
             MySqlType::Float | MySqlType::Double => safe(),
 
-            MySqlType::Decimal(_) | MySqlType::JSON => risky(),
+            MySqlType::Decimal(_) | MySqlType::Json => risky(),
 
             MySqlType::Date
             | MySqlType::DateTime(_)

--- a/migration-engine/migration-engine-tests/tests/native_types/mysql.rs
+++ b/migration-engine/migration-engine-tests/tests/native_types/mysql.rs
@@ -161,7 +161,7 @@ const SAFE_CASTS: Cases = &[
             "Decimal(10,5)",
             "TinyInt",
             "Int",
-            "JSON",
+            "Json",
             "UnsignedInt",
             "SmallInt",
             "UnsignedSmallInt",
@@ -186,7 +186,7 @@ const SAFE_CASTS: Cases = &[
             "Decimal(10,5)",
             "TinyInt",
             "Int",
-            "JSON",
+            "Json",
             "UnsignedInt",
             "SmallInt",
             "UnsignedSmallInt",
@@ -198,7 +198,7 @@ const SAFE_CASTS: Cases = &[
         ],
     ),
     (
-        "JSON",
+        "Json",
         quaint::Value::Text(Some(Cow::Borrowed("{\"a\":\"b\"}"))),
         &[
             // To string
@@ -326,7 +326,7 @@ const RISKY_CASTS: Cases = &[
     (
         "Decimal(20,5)",
         quaint::Value::Text(Some(Cow::Borrowed("350"))),
-        &["BigInt", "UnsignedBigInt", "Time(0)", "JSON"],
+        &["BigInt", "UnsignedBigInt", "Time(0)", "Json"],
     ),
     (
         "Double",
@@ -389,7 +389,7 @@ const RISKY_CASTS: Cases = &[
     (
         "Year",
         quaint::Value::Text(Some(Cow::Borrowed("1999"))),
-        &["Decimal(10,0)", "JSON"],
+        &["Decimal(10,0)", "Json"],
     ),
 ];
 
@@ -397,17 +397,17 @@ const IMPOSSIBLE_CASTS: Cases = &[
     (
         "BigInt",
         quaint::Value::Integer(Some(500)),
-        &["Decimal(15,6)", "Date", "Datetime(0)", "JSON", "Timestamp(0)"],
+        &["Decimal(15,6)", "Date", "Datetime(0)", "Json", "Timestamp(0)"],
     ),
     (
         "Binary(12)",
         quaint::Value::Bytes(Some(Cow::Borrowed(b"8080008"))),
-        &["Date", "Datetime(0)", "JSON", "Timestamp(0)"],
+        &["Date", "Datetime(0)", "Json", "Timestamp(0)"],
     ),
     (
         "Bit(32)",
         quaint::Value::Bytes(Some(Cow::Borrowed(b""))),
-        &["Date", "Datetime(0)", "Time(0)", "Timestamp(0)", "JSON"],
+        &["Date", "Datetime(0)", "Time(0)", "Timestamp(0)", "Json"],
     ),
     (
         "Blob",
@@ -421,7 +421,7 @@ const IMPOSSIBLE_CASTS: Cases = &[
             "Double",
             "Float",
             "Int",
-            "JSON",
+            "Json",
             "MediumInt",
             "SmallInt",
             "Time(0)",
@@ -473,7 +473,7 @@ const IMPOSSIBLE_CASTS: Cases = &[
         &["Binary(10)", "Date", "Timestamp(0)", "Datetime(0)"],
     ),
     (
-        "JSON",
+        "Json",
         quaint::Value::Text(Some(Cow::Borrowed("{\"a\":\"b\"}"))),
         &[
             // Integer types
@@ -492,7 +492,7 @@ const IMPOSSIBLE_CASTS: Cases = &[
         ],
     ),
     (
-        "JSON",
+        "Json",
         quaint::Value::Text(Some(Cow::Borrowed("\"2020-06-02\""))),
         &["Date", "Time(0)", "Timestamp(0)", "Datetime(0)", "Year"],
     ),
@@ -508,7 +508,7 @@ const IMPOSSIBLE_CASTS: Cases = &[
             "Double",
             "Float",
             "Int",
-            "JSON",
+            "Json",
             "MediumInt",
             "SmallInt",
             "Time(0)",
@@ -533,7 +533,7 @@ const IMPOSSIBLE_CASTS: Cases = &[
             "Double",
             "Float",
             "Int",
-            "JSON",
+            "Json",
             "MediumInt",
             "SmallInt",
             "Time(0)",
@@ -546,7 +546,7 @@ const IMPOSSIBLE_CASTS: Cases = &[
             "Year",
         ],
     ),
-    ("Time(0)", quaint::Value::Integer(Some(0)), &["JSON", "Year"]),
+    ("Time(0)", quaint::Value::Integer(Some(0)), &["Json", "Year"]),
     (
         "TinyBlob",
         quaint::Value::Bytes(Some(Cow::Borrowed(&[0x00]))),
@@ -559,7 +559,7 @@ const IMPOSSIBLE_CASTS: Cases = &[
             "Double",
             "Float",
             "Int",
-            "JSON",
+            "Json",
             "MediumInt",
             "SmallInt",
             "Time(0)",
@@ -600,7 +600,7 @@ fn native_type_name_to_prisma_scalar_type_name(scalar_type: &str) -> &'static st
         ("Double", "Float"),
         ("Float", "Float"),
         ("Int", "Int"),
-        ("JSON", "Json"),
+        ("Json", "Json"),
         ("LongBlob", "Bytes"),
         ("LongText", "String"),
         ("MediumBlob", "Bytes"),
@@ -695,7 +695,7 @@ fn expand_cases<'a, 'b>(
 }
 
 fn type_is_unsupported_mariadb(ty: &str) -> bool {
-    ty == "Time(0)" || ty == "JSON"
+    ty == "Time(0)" || ty == "Json"
 }
 
 fn type_is_unsupported_mysql_5_6(ty: &str) -> bool {


### PR DESCRIPTION
This is for consistency with other acronym types, like Xml and Uuid.