### PR TITLE
Fix non-idempotent migrations on postgres with native types on

### DIFF
--- a/libs/test-setup/src/connectors.rs
+++ b/libs/test-setup/src/connectors.rs
@@ -1,6 +1,7 @@
+pub mod mssql;
+
 mod capabilities;
 mod features;
-pub mod mssql;
 mod tags;
 
 pub use capabilities::*;
@@ -12,8 +13,8 @@ use once_cell::sync::Lazy;
 
 fn connector_names() -> Vec<(&'static str, BitFlags<Tags>)> {
     vec![
-        ("mssql_2017", Tags::Mssql2017.into()),
-        ("mssql_2019", Tags::Mssql2019.into()),
+        ("mssql_2017", (Tags::Mssql | Tags::Mssql2017)),
+        ("mssql_2019", (Tags::Mssql | Tags::Mssql2019)),
         ("mysql_8", Tags::Mysql | Tags::Mysql8),
         ("mysql", Tags::Mysql.into()),
         ("mysql_5_6", Tags::Mysql | Tags::Mysql56),

--- a/libs/test-setup/src/connectors/tags.rs
+++ b/libs/test-setup/src/connectors/tags.rs
@@ -14,6 +14,7 @@ pub enum Tags {
     Mssql2017 = 0b01000000,
     Mssql2019 = 0b10000000,
     Postgres12 = 0b100000000,
+    Mssql = 0b1000000000,
 }
 
 impl Tags {
@@ -47,6 +48,7 @@ impl StdError for UnknownTagError {}
 static TAG_NAMES: Lazy<Vec<(&str, BitFlags<Tags>)>> = Lazy::new(|| {
     vec![
         ("mariadb", Tags::Mariadb.into()),
+        ("mssql", Tags::Mssql.into()),
         ("mssql_2017", Tags::Mssql2017.into()),
         ("mssql_2019", Tags::Mssql2019.into()),
         ("mysql", Tags::Mysql.into()),
@@ -54,7 +56,7 @@ static TAG_NAMES: Lazy<Vec<(&str, BitFlags<Tags>)>> = Lazy::new(|| {
         ("mysql_8", Tags::Mysql8.into()),
         ("postgres", Tags::Postgres.into()),
         ("postgres_12", Tags::Postgres12.into()),
-        ("sql", Tags::Mysql | Tags::Postgres | Tags::Sqlite),
+        ("sql", Tags::Mysql | Tags::Postgres | Tags::Sqlite), // TODO: include MSSQL
         ("sqlite", Tags::Sqlite.into()),
     ]
 });

--- a/migration-engine/connectors/sql-migration-connector/src/flavour.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour.rs
@@ -108,7 +108,5 @@ pub(crate) trait SqlFlavour:
     }
 
     /// Feature flags for the flavor
-    fn features(&self) -> BitFlags<MigrationFeature> {
-        BitFlags::empty()
-    }
+    fn features(&self) -> BitFlags<MigrationFeature>;
 }

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/mysql.rs
@@ -42,10 +42,6 @@ impl MysqlFlavour {
             .unwrap_or_default()
             .contains(Circumstances::LowerCasesTableNames)
     }
-
-    pub(crate) fn features(&self) -> BitFlags<MigrationFeature> {
-        self.features
-    }
 }
 
 #[async_trait::async_trait]
@@ -275,6 +271,10 @@ impl SqlFlavour for MysqlFlavour {
         connection.raw_cmd(&drop_database).await?;
 
         sql_schema_result
+    }
+
+    fn features(&self) -> BitFlags<MigrationFeature> {
+        self.features
     }
 }
 

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/sqlite.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/sqlite.rs
@@ -1,6 +1,7 @@
 use crate::{connect, connection_wrapper::Connection, error::quaint_error_to_connector_error, flavour::SqlFlavour};
+use enumflags2::BitFlags;
 use indoc::indoc;
-use migration_connector::{ConnectorError, ConnectorResult, MigrationDirectory};
+use migration_connector::{ConnectorError, ConnectorResult, MigrationDirectory, MigrationFeature};
 use quaint::prelude::{ConnectionInfo, SqlFamily};
 use sql_schema_describer::{DescriberErrorKind, SqlSchema, SqlSchemaDescriberBackend};
 use std::path::Path;
@@ -139,5 +140,9 @@ impl SqlFlavour for SqliteFlavour {
         let sql_schema = self.describe_schema(&conn).await?;
 
         Ok(sql_schema)
+    }
+
+    fn features(&self) -> BitFlags<MigrationFeature> {
+        BitFlags::empty()
     }
 }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/mysql.rs
@@ -1,6 +1,6 @@
 use super::DestructiveChangeCheckerFlavour;
 use crate::{
-    flavour::MysqlFlavour,
+    flavour::{MysqlFlavour, SqlFlavour},
     pair::Pair,
     sql_destructive_change_checker::{
         destructive_check_plan::DestructiveCheckPlan, unexecutable_step_check::UnexecutableStepCheck,

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour.rs
@@ -18,6 +18,8 @@ pub(crate) trait SqlSchemaCalculatorFlavour {
         native_type_instance: &NativeTypeInstance,
     ) -> sql::ColumnType;
 
+    fn default_native_type_for_family(&self, family: sql::ColumnTypeFamily) -> Option<serde_json::Value>;
+
     fn enum_column_type(&self, _field: &ScalarFieldWalker<'_>, _db_name: &str) -> sql::ColumnType {
         unreachable!("unreachable enum_column_type")
     }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/mysql.rs
@@ -5,6 +5,7 @@ use datamodel::{
     Datamodel, NativeTypeInstance, ScalarType,
 };
 use native_types::MySqlType;
+use sql::ColumnTypeFamily;
 use sql_schema_describer::{self as sql};
 
 impl SqlSchemaCalculatorFlavour for MysqlFlavour {
@@ -54,46 +55,49 @@ impl SqlSchemaCalculatorFlavour for MysqlFlavour {
             }
         }
 
-        let data_type: String = match mysql_type {
-            MySqlType::Int => "INTEGER".into(),
-            MySqlType::SmallInt => "SMALLINT".into(),
-            MySqlType::TinyInt => "TINYINT".into(),
-            MySqlType::MediumInt => "MEDIUMINT".into(),
-            MySqlType::BigInt => "BIGINT".into(),
-            MySqlType::Decimal(precision) => format!("DECIMAL{}", render_decimal(precision)),
-            MySqlType::Float => "FLOAT".into(),
-            MySqlType::Double => "DOUBLE".into(),
-            MySqlType::Bit(size) => format!("BIT({size})", size = size),
-            MySqlType::Char(size) => format!("CHAR({size})", size = size),
-            MySqlType::VarChar(size) => format!("VARCHAR({size})", size = size),
-            MySqlType::Binary(size) => format!("BINARY({size})", size = size),
-            MySqlType::VarBinary(size) => format!("VARBINARY({size})", size = size),
-            MySqlType::TinyBlob => "TINYBLOB".into(),
-            MySqlType::Blob => "BLOB".into(),
-            MySqlType::MediumBlob => "MEDIUMBLOB".into(),
-            MySqlType::LongBlob => "LONGBLOB".into(),
-            MySqlType::TinyText => "TINYTEXT".into(),
-            MySqlType::Text => "TEXT".into(),
-            MySqlType::MediumText => "MEDIUMTEXT".into(),
-            MySqlType::LongText => "LONGTEXT".into(),
-            MySqlType::Date => "DATE".into(),
-            MySqlType::Time(precision) => format!("TIME{}", render(precision)),
-            MySqlType::DateTime(precision) => format!("DATETIME{}", render(precision)),
-            MySqlType::Timestamp(precision) => format!("TIMESTAMP{}", render(precision)),
-            MySqlType::Year => "YEAR".into(),
-            MySqlType::Json => "JSON".into(),
-            MySqlType::UnsignedInt => "INTEGER UNSIGNED".into(),
-            MySqlType::UnsignedSmallInt => "SMALLINT UNSIGNED".into(),
-            MySqlType::UnsignedTinyInt => "TINYINT UNSIGNED".into(),
-            MySqlType::UnsignedMediumInt => "MEDIUMINT UNSIGNED".into(),
-            MySqlType::UnsignedBigInt => "BIGINT UNSIGNED".into(),
+        let (family, data_type) = match mysql_type {
+            MySqlType::Int => (ColumnTypeFamily::Int, "INTEGER".into()),
+            MySqlType::SmallInt => (ColumnTypeFamily::Int, "SMALLINT".into()),
+            MySqlType::TinyInt => (ColumnTypeFamily::Int, "TINYINT".into()),
+            MySqlType::MediumInt => (ColumnTypeFamily::Int, "MEDIUMINT".into()),
+            MySqlType::BigInt => (ColumnTypeFamily::BigInt, "BIGINT".into()),
+            MySqlType::Decimal(precision) => (
+                ColumnTypeFamily::Decimal,
+                format!("DECIMAL{}", render_decimal(precision)),
+            ),
+            MySqlType::Float => (ColumnTypeFamily::Float, "FLOAT".into()),
+            MySqlType::Double => (ColumnTypeFamily::Float, "DOUBLE".into()),
+            MySqlType::Bit(size) => (ColumnTypeFamily::Binary, format!("BIT({size})", size = size)),
+            MySqlType::Char(size) => (ColumnTypeFamily::String, format!("CHAR({size})", size = size)),
+            MySqlType::VarChar(size) => (ColumnTypeFamily::String, format!("VARCHAR({size})", size = size)),
+            MySqlType::Binary(size) => (ColumnTypeFamily::Binary, format!("BINARY({size})", size = size)),
+            MySqlType::VarBinary(size) => (ColumnTypeFamily::Binary, format!("VARBINARY({size})", size = size)),
+            MySqlType::TinyBlob => (ColumnTypeFamily::Binary, "TINYBLOB".into()),
+            MySqlType::Blob => (ColumnTypeFamily::Binary, "BLOB".into()),
+            MySqlType::MediumBlob => (ColumnTypeFamily::Binary, "MEDIUMBLOB".into()),
+            MySqlType::LongBlob => (ColumnTypeFamily::Binary, "LONGBLOB".into()),
+            MySqlType::TinyText => (ColumnTypeFamily::String, "TINYTEXT".into()),
+            MySqlType::Text => (ColumnTypeFamily::String, "TEXT".into()),
+            MySqlType::MediumText => (ColumnTypeFamily::String, "MEDIUMTEXT".into()),
+            MySqlType::LongText => (ColumnTypeFamily::String, "LONGTEXT".into()),
+            MySqlType::Date => (ColumnTypeFamily::DateTime, "DATE".into()),
+            MySqlType::Time(precision) => (ColumnTypeFamily::DateTime, format!("TIME{}", render(precision))),
+            MySqlType::DateTime(precision) => (ColumnTypeFamily::DateTime, format!("DATETIME{}", render(precision))),
+            MySqlType::Timestamp(precision) => (ColumnTypeFamily::DateTime, format!("TIMESTAMP{}", render(precision))),
+            MySqlType::Year => (ColumnTypeFamily::Int, "YEAR".into()),
+            MySqlType::Json => (ColumnTypeFamily::Json, "JSON".into()),
+            MySqlType::UnsignedInt => (ColumnTypeFamily::Int, "INTEGER UNSIGNED".into()),
+            MySqlType::UnsignedSmallInt => (ColumnTypeFamily::Int, "SMALLINT UNSIGNED".into()),
+            MySqlType::UnsignedTinyInt => (ColumnTypeFamily::Int, "TINYINT UNSIGNED".into()),
+            MySqlType::UnsignedMediumInt => (ColumnTypeFamily::Int, "MEDIUMINT UNSIGNED".into()),
+            MySqlType::UnsignedBigInt => (ColumnTypeFamily::BigInt, "BIGINT UNSIGNED".into()),
         };
 
         sql::ColumnType {
             data_type: data_type.clone(),
             full_data_type: data_type,
             character_maximum_length: None,
-            family: sql::ColumnTypeFamily::String,
+            family,
             arity: match field.arity() {
                 datamodel::FieldArity::Required => sql::ColumnArity::Required,
                 datamodel::FieldArity::Optional => sql::ColumnArity::Nullable,
@@ -110,5 +114,24 @@ impl SqlSchemaCalculatorFlavour for MysqlFlavour {
             sql::ColumnTypeFamily::Enum(format!("{}_{}", field.model().db_name(), field.db_name())),
             arity,
         )
+    }
+
+    fn default_native_type_for_family(&self, family: sql::ColumnTypeFamily) -> Option<serde_json::Value> {
+        let ty = match family {
+            ColumnTypeFamily::Int => MySqlType::Int,
+            ColumnTypeFamily::BigInt => MySqlType::BigInt,
+            ColumnTypeFamily::Float => MySqlType::Decimal(Some((65, 30))),
+            ColumnTypeFamily::Decimal => MySqlType::Decimal(Some((65, 30))),
+            ColumnTypeFamily::Boolean => MySqlType::TinyInt,
+            ColumnTypeFamily::String => MySqlType::VarChar(191),
+            ColumnTypeFamily::DateTime => MySqlType::DateTime(Some(3)),
+            ColumnTypeFamily::Binary => MySqlType::VarBinary(191),
+            ColumnTypeFamily::Json => MySqlType::Json,
+            ColumnTypeFamily::Uuid => MySqlType::VarChar(37),
+            ColumnTypeFamily::Enum(_) => return None,
+            ColumnTypeFamily::Unsupported(_) => return None,
+        };
+
+        Some(serde_json::to_value(ty).expect("MySqlType to JSON failed"))
     }
 }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/postgres.rs
@@ -2,6 +2,7 @@ use super::SqlSchemaCalculatorFlavour;
 use crate::flavour::PostgresFlavour;
 use datamodel::{walkers::ScalarFieldWalker, Datamodel, NativeTypeInstance, ScalarType, WithDatabaseName};
 use native_types::PostgresType;
+use sql::ColumnTypeFamily;
 use sql_schema_describer::{self as sql};
 
 impl SqlSchemaCalculatorFlavour for PostgresFlavour {
@@ -13,6 +14,25 @@ impl SqlSchemaCalculatorFlavour for PostgresFlavour {
                 values: r#enum.database_values(),
             })
             .collect()
+    }
+
+    fn default_native_type_for_family(&self, family: ColumnTypeFamily) -> Option<serde_json::Value> {
+        let ty = match family {
+            ColumnTypeFamily::Int => PostgresType::Integer,
+            ColumnTypeFamily::BigInt => PostgresType::BigInt,
+            ColumnTypeFamily::Float => PostgresType::Decimal(Some((65, 30))),
+            ColumnTypeFamily::Decimal => PostgresType::Decimal(Some((65, 30))),
+            ColumnTypeFamily::Boolean => PostgresType::Boolean,
+            ColumnTypeFamily::String => PostgresType::Text,
+            ColumnTypeFamily::DateTime => PostgresType::Timestamp(Some(3)),
+            ColumnTypeFamily::Binary => PostgresType::ByteA,
+            ColumnTypeFamily::Json => PostgresType::JSONB,
+            ColumnTypeFamily::Uuid => PostgresType::UUID,
+            ColumnTypeFamily::Enum(_) => return None,
+            ColumnTypeFamily::Unsupported(_) => return None,
+        };
+
+        Some(serde_json::to_value(ty).expect("PostgresType to json failed"))
     }
 
     fn column_type_for_native_type(
@@ -36,38 +56,43 @@ impl SqlSchemaCalculatorFlavour for PostgresFlavour {
             }
         }
 
-        let data_type = match postgres_type {
-            PostgresType::SmallInt => "SMALLINT".to_owned(),
-            PostgresType::Integer => "INTEGER".to_owned(),
-            PostgresType::BigInt => "BIGINT".to_owned(),
-            PostgresType::Decimal(precision) => format!("DECIMAL{}", render_decimal(precision)),
-            PostgresType::Real => "REAL".to_owned(),
-            PostgresType::DoublePrecision => "DOUBLE PRECISION".to_owned(),
-            PostgresType::VarChar(length) => format!("VARCHAR{}", render(length)),
-            PostgresType::Char(length) => format!("CHAR{}", render(length)),
-            PostgresType::Text => "TEXT".to_owned(),
-            PostgresType::ByteA => "BYTEA".to_owned(),
-            PostgresType::Timestamp(precision) => format!("TIMESTAMP{}", render(precision)),
-            PostgresType::Timestamptz(precision) => format!("TIMESTAMPTZ{}", render(precision)),
-            PostgresType::Date => "DATE".to_owned(),
-            PostgresType::Time(precision) => format!("TIME{}", render(precision)),
-            PostgresType::Timetz(precision) => format!("TIMETZ{}", render(precision)),
-            PostgresType::Boolean => "BOOLEAN".to_owned(),
-            PostgresType::Bit(length) => format!("BIT{}", render(length)),
-            PostgresType::VarBit(length) => format!("VARBIT{}", render(length)),
-            PostgresType::UUID => "UUID".to_owned(),
-            PostgresType::Xml => "XML".to_owned(),
-            PostgresType::JSON => "JSON".to_owned(),
-            PostgresType::JSONB => "JSONB".to_owned(),
+        let (family, data_type) = match postgres_type {
+            PostgresType::SmallInt => (ColumnTypeFamily::Int, "SMALLINT".to_owned()),
+            PostgresType::Integer => (ColumnTypeFamily::Int, "INTEGER".to_owned()),
+            PostgresType::BigInt => (ColumnTypeFamily::BigInt, "BIGINT".to_owned()),
+            PostgresType::Decimal(precision) => (
+                ColumnTypeFamily::Decimal,
+                format!("DECIMAL{}", render_decimal(precision)),
+            ),
+            PostgresType::Real => (ColumnTypeFamily::Float, "REAL".to_owned()),
+            PostgresType::DoublePrecision => (ColumnTypeFamily::Float, "DOUBLE PRECISION".to_owned()),
+            PostgresType::VarChar(length) => (ColumnTypeFamily::String, format!("VARCHAR{}", render(length))),
+            PostgresType::Char(length) => (ColumnTypeFamily::String, format!("CHAR{}", render(length))),
+            PostgresType::Text => (ColumnTypeFamily::String, "TEXT".to_owned()),
+            PostgresType::ByteA => (ColumnTypeFamily::Binary, "BYTEA".to_owned()),
+            PostgresType::Date => (ColumnTypeFamily::DateTime, "DATE".to_owned()),
+            PostgresType::Timestamp(precision) => {
+                (ColumnTypeFamily::DateTime, format!("TIMESTAMP{}", render(precision)))
+            }
+            PostgresType::Timestamptz(precision) => {
+                (ColumnTypeFamily::DateTime, format!("TIMESTAMPTZ{}", render(precision)))
+            }
+            PostgresType::Time(precision) => (ColumnTypeFamily::DateTime, format!("TIME{}", render(precision))),
+            PostgresType::Timetz(precision) => (ColumnTypeFamily::DateTime, format!("TIMETZ{}", render(precision))),
+            PostgresType::Boolean => (ColumnTypeFamily::Boolean, "BOOLEAN".to_owned()),
+            PostgresType::Bit(length) => (ColumnTypeFamily::String, format!("BIT{}", render(length))),
+            PostgresType::VarBit(length) => (ColumnTypeFamily::String, format!("VARBIT{}", render(length))),
+            PostgresType::UUID => (ColumnTypeFamily::Uuid, "UUID".to_owned()),
+            PostgresType::Xml => (ColumnTypeFamily::String, "XML".to_owned()),
+            PostgresType::JSON => (ColumnTypeFamily::Json, "JSON".to_owned()),
+            PostgresType::JSONB => (ColumnTypeFamily::Json, "JSONB".to_owned()),
         };
 
         sql::ColumnType {
             data_type: data_type.clone(),
             full_data_type: data_type,
             character_maximum_length: None,
-            family: sql::ColumnTypeFamily::String, //todo this is wrong
-            //maybe we should have a mapping from Native type to ColumnTypeFamily in the datamodel connector
-            //this could be used here and in the describer to remove duplication
+            family,
             arity: match field.arity() {
                 datamodel::FieldArity::Required => sql::ColumnArity::Required,
                 datamodel::FieldArity::Optional => sql::ColumnArity::Nullable,

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/sqlite.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/sqlite.rs
@@ -1,4 +1,5 @@
 use datamodel::walkers::ScalarFieldWalker;
+use sql_schema_describer::ColumnTypeFamily;
 
 use super::SqlSchemaCalculatorFlavour;
 use crate::flavour::SqliteFlavour;
@@ -11,6 +12,10 @@ impl SqlSchemaCalculatorFlavour for SqliteFlavour {
         _native_type_instance: &datamodel::NativeTypeInstance,
     ) -> sql_schema_describer::ColumnType {
         unreachable!("column_type_for_native_type on SQLite")
+    }
+
+    fn default_native_type_for_family(&self, _family: ColumnTypeFamily) -> Option<serde_json::Value> {
+        None
     }
 
     // Integer primary keys on SQLite are automatically assigned the rowid, which means they are automatically autoincrementing.

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/mysql.rs
@@ -1,6 +1,9 @@
 use super::SqlSchemaDifferFlavour;
 use crate::{
-    flavour::MysqlFlavour, flavour::MYSQL_IDENTIFIER_SIZE_LIMIT, pair::Pair, sql_schema_differ::column::ColumnDiffer,
+    flavour::MYSQL_IDENTIFIER_SIZE_LIMIT,
+    flavour::{MysqlFlavour, SqlFlavour},
+    pair::Pair,
+    sql_schema_differ::column::ColumnDiffer,
     sql_schema_differ::ColumnTypeChange,
 };
 use migration_connector::MigrationFeature;
@@ -350,7 +353,7 @@ fn native_type_change(types: Pair<MySqlType>) -> Option<ColumnTypeChange> {
         MySqlType::DateTime(n) => match next {
             MySqlType::DateTime(m) if n < m => safe(),
             MySqlType::DateTime(m) if n > m => risky(),
-            MySqlType::DateTime(_) => risky(),
+            MySqlType::DateTime(_) => return None,
 
             // To string
             MySqlType::Binary(_)
@@ -900,7 +903,7 @@ fn native_type_change(types: Pair<MySqlType>) -> Option<ColumnTypeChange> {
         MySqlType::Timestamp(n) => match next {
             MySqlType::Timestamp(m) if n < m => safe(),
             MySqlType::Timestamp(m) if n > m => risky(),
-            MySqlType::Timestamp(_) => risky(),
+            MySqlType::Timestamp(_) => return None,
 
             // To string
             MySqlType::Binary(_)

--- a/migration-engine/core/src/commands/create_migration.rs
+++ b/migration-engine/core/src/commands/create_migration.rs
@@ -66,6 +66,8 @@ impl<'a> MigrationCommand for CreateMigrationCommand {
             .await?;
 
         if migration.is_empty() && !input.draft {
+            tracing::info!("Database is up-to-date, returning without creating new migration.");
+
             return Ok(CreateMigrationOutput {
                 generated_migration_name: None,
             });

--- a/migration-engine/migration-engine-tests/src/test_api.rs
+++ b/migration-engine/migration-engine-tests/src/test_api.rs
@@ -112,6 +112,31 @@ impl TestApi {
         Ok(tempfile::tempdir()?)
     }
 
+    pub fn display_migrations(&self, migrations_directory: &TempDir) -> anyhow::Result<()> {
+        for entry in std::fs::read_dir(migrations_directory.path())? {
+            let entry = entry?;
+            if entry.file_type()?.is_dir() {
+                for file in std::fs::read_dir(&entry.path())? {
+                    let entry = file?;
+
+                    if entry.file_type()?.is_dir() {
+                        continue;
+                    }
+
+                    let s = std::fs::read_to_string(entry.path())?;
+                    dbg!(entry.path());
+                    dbg!(s);
+                }
+            } else {
+                let s = std::fs::read_to_string(entry.path())?;
+                dbg!(entry.path());
+                dbg!(s);
+            }
+        }
+
+        Ok(())
+    }
+
     pub fn apply_migrations<'a>(&'a self, migrations_directory: &'a TempDir) -> ApplyMigrations<'a> {
         ApplyMigrations::new(&self.api, migrations_directory)
     }

--- a/migration-engine/migration-engine-tests/tests/native_types/common.rs
+++ b/migration-engine/migration-engine-tests/tests/native_types/common.rs
@@ -1,0 +1,66 @@
+use migration_engine_tests::sql::*;
+
+#[test_each_connector(features("native_types"))]
+async fn typescript_starter_schema_is_idempotent_without_native_type_annotations(api: &TestApi) -> TestResult {
+    let dm = api.native_types_datamodel(
+        r#"
+        model Post {
+            id        Int     @id @default(autoincrement())
+            title     String
+            content   String?
+            published Boolean @default(false)
+            author    User?   @relation(fields: [authorId], references: [id])
+            authorId  Int?
+        }
+          
+        model User {
+            id    Int     @id @default(autoincrement())
+            email String  @unique
+            name  String?
+            posts Post[]
+        }
+    "#,
+    );
+
+    api.schema_push(&dm)
+        .send()
+        .await?
+        .assert_green()?
+        .assert_has_executed_steps()?;
+    api.schema_push(&dm).send().await?.assert_green()?.assert_no_steps()?;
+    api.schema_push(&dm).send().await?.assert_green()?.assert_no_steps()?;
+
+    Ok(())
+}
+#[test_each_connector(features("native_types"))]
+async fn typescript_starter_schema_starting_without_native_types_is_idempotent(api: &TestApi) -> TestResult {
+    let dm = r#"
+        model Post {
+            id        Int     @id @default(autoincrement())
+            title     String
+            content   String?
+            published Boolean @default(false)
+            author    User?   @relation(fields: [authorId], references: [id])
+            authorId  Int?
+        }
+
+        model User {
+            id    Int     @id @default(autoincrement())
+            email String  @unique
+            name  String?
+            posts Post[]
+        }
+    "#;
+
+    let dm2 = api.native_types_datamodel(dm);
+
+    api.schema_push(dm)
+        .send()
+        .await?
+        .assert_green()?
+        .assert_has_executed_steps()?;
+    api.schema_push(dm).send().await?.assert_green()?.assert_no_steps()?;
+    api.schema_push(&dm2).send().await?.assert_green()?.assert_no_steps()?;
+
+    Ok(())
+}

--- a/migration-engine/migration-engine-tests/tests/native_types/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/native_types/mod.rs
@@ -1,3 +1,4 @@
+mod common;
 mod mssql;
 mod mysql;
 mod postgres;


### PR DESCRIPTION
For model fields without a native type annotation, the schema parser
does not provide a native type to diff with. This caused the diffing to
behave badly in different ways on postgres/mysql/mssql when diffing a
field without annotation and a field with annotation.

Solution: populate the native type in the calculated SQL schemas for
diffing. The default mappings are located in the SQL migration
connector.

Additionally, we now populate the right column type family in generated
SQL schemas with native types, because it is used when diffing foreign
keys. This fixes another issue on postgres where foreign key migrations
were not idempotent.