### PR TITLE
Refine enum diffing on postgres

### DIFF
--- a/migration-engine/connectors/migration-connector/src/features.rs
+++ b/migration-engine/connectors/migration-connector/src/features.rs
@@ -1,9 +1,8 @@
 //! The feature handling for SQL Migration Connector.
 
-use std::{fmt::Display, io, str::FromStr};
-
 use datamodel::Configuration;
 use enumflags2::BitFlags;
+use std::{fmt::Display, io, str::FromStr};
 
 static NATIVE_TYPES: &str = "nativeTypes";
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/postgres.rs
@@ -72,7 +72,7 @@ impl SqlSchemaDifferFlavour for PostgresFlavour {
             .map(|column| column.column_type_family_as_enum())
             .as_tuple()
         {
-            if previous_enum == next_enum {
+            if previous_enum.name == next_enum.name {
                 return None;
             }
         }


### PR DESCRIPTION
Without this fix, we would migrate columns of an enum type everytime the
enum is altered, but this is not necessary.