### PR TITLE
Ensure builtin-scalar migrations with native types on are idempotent

### DIFF
--- a/libs/sql-schema-describer/src/mssql.rs
+++ b/libs/sql-schema-describer/src/mssql.rs
@@ -597,12 +597,12 @@ impl SqlSchemaDescriber {
             "bigint" => (BigInt, Some(MsSqlType::BigInt)),
             "numeric" => match (numeric_precision, numeric_scale) {
                 (Some(p), Some(s)) => (Decimal, Some(MsSqlType::Decimal(Some((p, s))))),
-                (None, None) => (Decimal, Some(MsSqlType::Decimal(None))),
+                (None, None) => (Decimal, Some(MsSqlType::Decimal(Some((18, 0))))),
                 _ => unreachable!("Unexpected params for a numeric field."),
             },
             "decimal" => match (numeric_precision, numeric_scale) {
                 (Some(p), Some(s)) => (Decimal, Some(MsSqlType::Decimal(Some((p, s))))),
-                (None, None) => (Decimal, Some(MsSqlType::Decimal(None))),
+                (None, None) => (Decimal, Some(MsSqlType::Decimal(Some((18, 0))))),
                 _ => unreachable!("Unexpected params for a decimal field."),
             },
             "money" => (Float, Some(MsSqlType::Money)),

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/mssql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/mssql.rs
@@ -115,8 +115,8 @@ impl SqlSchemaCalculatorFlavour for MssqlFlavour {
         let ty = match family {
             ColumnTypeFamily::Int => MsSqlType::Int,
             ColumnTypeFamily::BigInt => MsSqlType::BigInt,
-            ColumnTypeFamily::Float => MsSqlType::Decimal(Some((65, 30))),
-            ColumnTypeFamily::Decimal => MsSqlType::Decimal(Some((65, 30))),
+            ColumnTypeFamily::Float => MsSqlType::Decimal(Some((32, 16))),
+            ColumnTypeFamily::Decimal => MsSqlType::Decimal(Some((32, 16))),
             ColumnTypeFamily::Boolean => MsSqlType::Bit,
             ColumnTypeFamily::String => MsSqlType::NVarChar(Some(MsSqlTypeParameter::Number(1000))),
             ColumnTypeFamily::DateTime => MsSqlType::DateTime2,

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/mysql.rs
@@ -125,7 +125,7 @@ impl SqlSchemaCalculatorFlavour for MysqlFlavour {
             ColumnTypeFamily::Boolean => MySqlType::TinyInt,
             ColumnTypeFamily::String => MySqlType::VarChar(191),
             ColumnTypeFamily::DateTime => MySqlType::DateTime(Some(3)),
-            ColumnTypeFamily::Binary => MySqlType::VarBinary(191),
+            ColumnTypeFamily::Binary => MySqlType::LongBlob,
             ColumnTypeFamily::Json => MySqlType::Json,
             ColumnTypeFamily::Uuid => MySqlType::VarChar(37),
             ColumnTypeFamily::Enum(_) => return None,

--- a/migration-engine/migration-engine-tests/tests/migrations/dev_diagnostic_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/dev_diagnostic_tests.rs
@@ -536,7 +536,7 @@ async fn drift_can_be_detected_without_migrations_table(api: &TestApi) -> TestRe
 }
 
 #[test_each_connector(tags("mysql_8"))]
-async fn shadow_database_creation_error_is_special_cased_mysql(api: &TestApi) -> TestResult {
+async fn dev_diagnostic_shadow_database_creation_error_is_special_cased_mysql(api: &TestApi) -> TestResult {
     let directory = api.create_migrations_directory()?;
 
     let dm1 = r#"
@@ -589,7 +589,7 @@ async fn shadow_database_creation_error_is_special_cased_mysql(api: &TestApi) ->
 }
 
 #[test_each_connector(tags("postgres_12"), log = "debug")]
-async fn shadow_database_creation_error_is_special_cased_postgres(api: &TestApi) -> TestResult {
+async fn dev_diagnostic_shadow_database_creation_error_is_special_cased_postgres(api: &TestApi) -> TestResult {
     let directory = api.create_migrations_directory()?;
 
     let dm1 = r#"
@@ -639,8 +639,8 @@ async fn shadow_database_creation_error_is_special_cased_postgres(api: &TestApi)
     Ok(())
 }
 
-#[test_each_connector(tags("mssql_2019"))]
-async fn shadow_database_creation_error_is_special_cased_mssql(api: &TestApi) -> TestResult {
+#[test_each_connector(tags("mssql"))]
+async fn dev_diagnostic_shadow_database_creation_error_is_special_cased_mssql(api: &TestApi) -> TestResult {
     let directory = api.create_migrations_directory()?;
 
     let dm1 = r#"


### PR DESCRIPTION


Problems were discovered on MySQL and MSSQL with Bytes and Decimal.

