### PR TITLE
Remove the number of connections in use from pool timeout error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2882,7 +2882,7 @@ dependencies = [
 [[package]]
 name = "quaint"
 version = "0.2.0-alpha.13"
-source = "git+https://github.com/prisma/quaint#2d8c9c7fcf40c3c708b2a17d3b785102609935a0"
+source = "git+https://github.com/prisma/quaint#79130113115d4a5f016e7d447b13a81aa778d59e"
 dependencies = [
  "async-trait",
  "base64 0.12.3",

--- a/libs/user-facing-errors/src/quaint.rs
+++ b/libs/user-facing-errors/src/quaint.rs
@@ -179,9 +179,8 @@ pub fn render_quaint_error(kind: &ErrorKind, connection_info: &ConnectionInfo) -
             Some(KnownError::new(common::DatabaseOperationTimeout { time }))
         }
 
-        (ErrorKind::PoolTimeout { max_open, in_use }, _) => Some(KnownError::new(query_engine::PoolTimeout {
+        (ErrorKind::PoolTimeout { max_open, .. }, _) => Some(KnownError::new(query_engine::PoolTimeout {
             connection_limit: *max_open,
-            current_connections: *in_use,
         })),
 
         (ErrorKind::DatabaseUrlIsInvalid(details), _connection_info) => {

--- a/libs/user-facing-errors/src/query_engine.rs
+++ b/libs/user-facing-errors/src/query_engine.rs
@@ -251,9 +251,8 @@ pub struct InconsistentColumnData {
 #[derive(Debug, UserFacingError, Serialize)]
 #[user_facing(
     code = "P2024",
-    message = "Timed out fetching a new connection from the pool. Please consider reducing the number of requests or increasing the `connection_limit` parameter (https://www.prisma.io/docs/concepts/components/prisma-client/connection-management#connection-pool). Current limit: {connection_limit}, amount of connections currently in use: {current_connections}."
+    message = "Timed out fetching a new connection from the pool. Please consider reducing the number of requests or increasing the `connection_limit` parameter (https://www.prisma.io/docs/concepts/components/prisma-client/connection-management#connection-pool). Current limit: {connection_limit}."
 )]
 pub struct PoolTimeout {
     pub connection_limit: u64,
-    pub current_connections: u64,
 }


### PR DESCRIPTION
Also removes the connections in use from the pool timeout, it's too confusing.

closes https://github.com/prisma/prisma/issues/5228