### PR TITLE
Eliminate unexpected code path in sql_schema_calculator

### DIFF
--- a/libs/datamodel/core/src/walkers.rs
+++ b/libs/datamodel/core/src/walkers.rs
@@ -168,7 +168,8 @@ impl<'a> ScalarFieldWalker<'a> {
             }),
             FieldType::Base(scalar_type, _) => TypeWalker::Base(*scalar_type),
             FieldType::NativeType(scalar_type, native_type) => TypeWalker::NativeType(*scalar_type, native_type),
-            _ => TypeWalker::Other,
+            FieldType::Unsupported(_) => todo!("Unsupported field type"),
+            FieldType::Relation(_) => unreachable!("FieldType::Relation in ScalarFieldWalker"),
         }
     }
 
@@ -201,7 +202,6 @@ pub enum TypeWalker<'a> {
     Enum(EnumWalker<'a>),
     Base(ScalarType),
     NativeType(ScalarType, &'a NativeTypeInstance),
-    Other,
 }
 
 impl<'a> TypeWalker<'a> {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour.rs
@@ -3,7 +3,7 @@ mod mysql;
 mod postgres;
 mod sqlite;
 
-use datamodel::{walkers::ModelWalker, walkers::ScalarFieldWalker, Datamodel, NativeTypeInstance, ScalarType};
+use datamodel::{walkers::ModelWalker, walkers::ScalarFieldWalker, Datamodel, NativeTypeInstance};
 use sql_schema_describer as sql;
 
 pub(crate) trait SqlSchemaCalculatorFlavour {
@@ -14,11 +14,10 @@ pub(crate) trait SqlSchemaCalculatorFlavour {
     fn column_type_for_native_type(
         &self,
         field: &ScalarFieldWalker<'_>,
-        scalar_type: ScalarType,
         native_type_instance: &NativeTypeInstance,
     ) -> sql::ColumnType;
 
-    fn default_native_type_for_family(&self, family: sql::ColumnTypeFamily) -> Option<serde_json::Value>;
+    fn default_native_type_for_family(&self, family: &sql::ColumnTypeFamily) -> Option<serde_json::Value>;
 
     fn enum_column_type(&self, _field: &ScalarFieldWalker<'_>, _db_name: &str) -> sql::ColumnType {
         unreachable!("unreachable enum_column_type")

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/mssql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/mssql.rs
@@ -2,7 +2,7 @@ use super::SqlSchemaCalculatorFlavour;
 use crate::flavour::MssqlFlavour;
 use datamodel::{
     walkers::{ModelWalker, ScalarFieldWalker},
-    FieldArity, NativeTypeInstance, ScalarType,
+    FieldArity, NativeTypeInstance,
 };
 use native_types::{MsSqlType, MsSqlTypeParameter, NativeType};
 use sql_schema_describer::{ColumnArity, ColumnType, ColumnTypeFamily, ForeignKeyAction};
@@ -11,7 +11,6 @@ impl SqlSchemaCalculatorFlavour for MssqlFlavour {
     fn column_type_for_native_type(
         &self,
         field: &ScalarFieldWalker<'_>,
-        _scalar_type: ScalarType,
         native_type_instance: &NativeTypeInstance,
     ) -> ColumnType {
         use MsSqlType::*;
@@ -111,7 +110,7 @@ impl SqlSchemaCalculatorFlavour for MssqlFlavour {
         format!("{}_{}_unique", model_name, field_name)
     }
 
-    fn default_native_type_for_family(&self, family: ColumnTypeFamily) -> Option<serde_json::Value> {
+    fn default_native_type_for_family(&self, family: &ColumnTypeFamily) -> Option<serde_json::Value> {
         let ty = match family {
             ColumnTypeFamily::Int => MsSqlType::Int,
             ColumnTypeFamily::BigInt => MsSqlType::BigInt,

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/mysql.rs
@@ -2,7 +2,7 @@ use super::SqlSchemaCalculatorFlavour;
 use crate::flavour::MysqlFlavour;
 use datamodel::{
     walkers::{walk_scalar_fields, ScalarFieldWalker},
-    Datamodel, NativeTypeInstance, ScalarType,
+    Datamodel, NativeTypeInstance,
 };
 use native_types::MySqlType;
 use sql::ColumnTypeFamily;
@@ -36,7 +36,6 @@ impl SqlSchemaCalculatorFlavour for MysqlFlavour {
     fn column_type_for_native_type(
         &self,
         field: &ScalarFieldWalker<'_>,
-        _scalar_type: ScalarType,
         native_type_instance: &NativeTypeInstance,
     ) -> sql::ColumnType {
         let mysql_type: MySqlType = native_type_instance.deserialize_native_type();
@@ -116,7 +115,7 @@ impl SqlSchemaCalculatorFlavour for MysqlFlavour {
         )
     }
 
-    fn default_native_type_for_family(&self, family: sql::ColumnTypeFamily) -> Option<serde_json::Value> {
+    fn default_native_type_for_family(&self, family: &sql::ColumnTypeFamily) -> Option<serde_json::Value> {
         let ty = match family {
             ColumnTypeFamily::Int => MySqlType::Int,
             ColumnTypeFamily::BigInt => MySqlType::BigInt,

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/postgres.rs
@@ -1,6 +1,6 @@
 use super::SqlSchemaCalculatorFlavour;
 use crate::flavour::PostgresFlavour;
-use datamodel::{walkers::ScalarFieldWalker, Datamodel, NativeTypeInstance, ScalarType, WithDatabaseName};
+use datamodel::{walkers::ScalarFieldWalker, Datamodel, NativeTypeInstance, WithDatabaseName};
 use native_types::PostgresType;
 use sql::ColumnTypeFamily;
 use sql_schema_describer::{self as sql};
@@ -16,7 +16,7 @@ impl SqlSchemaCalculatorFlavour for PostgresFlavour {
             .collect()
     }
 
-    fn default_native_type_for_family(&self, family: ColumnTypeFamily) -> Option<serde_json::Value> {
+    fn default_native_type_for_family(&self, family: &ColumnTypeFamily) -> Option<serde_json::Value> {
         let ty = match family {
             ColumnTypeFamily::Int => PostgresType::Integer,
             ColumnTypeFamily::BigInt => PostgresType::BigInt,
@@ -38,7 +38,6 @@ impl SqlSchemaCalculatorFlavour for PostgresFlavour {
     fn column_type_for_native_type(
         &self,
         field: &ScalarFieldWalker<'_>,
-        _scalar_type: ScalarType,
         native_type_instance: &NativeTypeInstance,
     ) -> sql::ColumnType {
         let postgres_type: PostgresType = native_type_instance.deserialize_native_type();

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/sqlite.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/sqlite.rs
@@ -8,13 +8,12 @@ impl SqlSchemaCalculatorFlavour for SqliteFlavour {
     fn column_type_for_native_type(
         &self,
         _field: &datamodel::walkers::ScalarFieldWalker<'_>,
-        _scalar_type: datamodel::ScalarType,
         _native_type_instance: &datamodel::NativeTypeInstance,
     ) -> sql_schema_describer::ColumnType {
         unreachable!("column_type_for_native_type on SQLite")
     }
 
-    fn default_native_type_for_family(&self, _family: ColumnTypeFamily) -> Option<serde_json::Value> {
+    fn default_native_type_for_family(&self, _family: &ColumnTypeFamily) -> Option<serde_json::Value> {
         None
     }
 


### PR DESCRIPTION
This takes the shape of a much needed sql_schema_calculator
re-organization.

This substantially shrinks the amount of sql_schema_calculator code paths.

We will be able to do better once sql_schema_describer::ColumnTypeFamily
is gone.

closes prisma/prisma#5238
closes prisma/prisma#5214