### PR TITLE
Delete superfluous #![deny(missing_docs)] annotations in ME

### DIFF
--- a/migration-engine/connectors/migration-connector/src/migrations_directory.rs
+++ b/migration-engine/connectors/migration-connector/src/migrations_directory.rs
@@ -1,5 +1,3 @@
-#![deny(missing_docs)]
-
 //! Migrations directory management.
 //!
 //! This module is responsible for the management of the contents of the

--- a/migration-engine/core/src/commands.rs
+++ b/migration-engine/core/src/commands.rs
@@ -1,5 +1,3 @@
-#![deny(missing_docs)]
-
 //! The commands exposed by the migration engine core are defined in this
 //! module.
 


### PR DESCRIPTION
We already have these annotations at the crate root, so they are
redundant in modules.