### PR TITLE
fix: filter json from min/max aggregate/groupBy

### DIFF
--- a/query-engine/core/src/schema_builder/output_types/aggregation/group_by.rs
+++ b/query-engine/core/src/schema_builder/output_types/aggregation/group_by.rs
@@ -17,7 +17,7 @@ pub(crate) fn group_by_output_object_type(ctx: &mut BuilderContext, model: &Mode
     let mut object_fields = scalar_fields(ctx, model);
 
     // Fields used in aggregations
-    let non_list_fields = collect_non_list_fields(model);
+    let non_list_nor_json_fields = collect_non_list_nor_json_fields(model);
     let numeric_fields = collect_numeric_fields(model);
 
     // Count is available on all fields.
@@ -66,7 +66,7 @@ pub(crate) fn group_by_output_object_type(ctx: &mut BuilderContext, model: &Mode
             ctx,
             fields::MIN,
             &model,
-            non_list_fields.clone(),
+            non_list_nor_json_fields.clone(),
             map_scalar_output_type_for_field,
             identity,
         ),
@@ -78,7 +78,7 @@ pub(crate) fn group_by_output_object_type(ctx: &mut BuilderContext, model: &Mode
             ctx,
             fields::MAX,
             &model,
-            non_list_fields,
+            non_list_nor_json_fields,
             map_scalar_output_type_for_field,
             identity,
         ),

--- a/query-engine/core/src/schema_builder/output_types/aggregation/mod.rs
+++ b/query-engine/core/src/schema_builder/output_types/aggregation/mod.rs
@@ -13,8 +13,13 @@ fn field_avg_output_type(ctx: &mut BuilderContext, field: &ScalarFieldRef) -> Ou
     }
 }
 
-fn collect_non_list_fields(model: &ModelRef) -> Vec<ScalarFieldRef> {
-    model.fields().scalar().into_iter().filter(|f| !f.is_list).collect()
+fn collect_non_list_nor_json_fields(model: &ModelRef) -> Vec<ScalarFieldRef> {
+    model
+        .fields()
+        .scalar()
+        .into_iter()
+        .filter(|f| !f.is_list && f.type_identifier != TypeIdentifier::Json)
+        .collect()
 }
 
 fn collect_numeric_fields(model: &ModelRef) -> Vec<ScalarFieldRef> {

--- a/query-engine/core/src/schema_builder/output_types/aggregation/plain.rs
+++ b/query-engine/core/src/schema_builder/output_types/aggregation/plain.rs
@@ -11,7 +11,7 @@ pub(crate) fn aggregation_object_type(ctx: &mut BuilderContext, model: &ModelRef
     let object = ObjectTypeStrongRef::new(ObjectType::new(ident.clone(), Some(ModelRef::clone(model))));
     let mut object_fields = vec![];
 
-    let non_list_fields = collect_non_list_fields(model);
+    let non_list_nor_json_fields = collect_non_list_nor_json_fields(model);
     let numeric_fields = collect_numeric_fields(model);
 
     // Count is available on all fields.
@@ -19,7 +19,7 @@ pub(crate) fn aggregation_object_type(ctx: &mut BuilderContext, model: &ModelRef
         &mut object_fields,
         aggregation_field(
             ctx,
-            "count",
+            fields::COUNT,
             &model,
             model.fields().scalar(),
             |_, _| OutputType::int(),
@@ -60,7 +60,7 @@ pub(crate) fn aggregation_object_type(ctx: &mut BuilderContext, model: &ModelRef
             ctx,
             fields::MIN,
             &model,
-            non_list_fields.clone(),
+            non_list_nor_json_fields.clone(),
             map_scalar_output_type_for_field,
             identity,
         ),
@@ -72,7 +72,7 @@ pub(crate) fn aggregation_object_type(ctx: &mut BuilderContext, model: &ModelRef
             ctx,
             fields::MAX,
             &model,
-            non_list_fields,
+            non_list_nor_json_fields,
             map_scalar_output_type_for_field,
             identity,
         ),


### PR DESCRIPTION
## Overview

Fixes https://github.com/prisma/prisma-engines/issues/1496

- Removes json fields from aggregate/groupBy `min` and `max` output types