### PR TITLE
Skip rendering of native type attributes

### DIFF
--- a/introspection-engine/introspection-engine-tests/tests/native_types/mssql.rs
+++ b/introspection-engine/introspection-engine-tests/tests/native_types/mssql.rs
@@ -74,11 +74,11 @@ async fn native_type_columns_feature_on(api: &TestApi) -> crate::TestResult {
 
     let types = indoc! {r#"
         model Blog {
-          id          Int      @id @default(autoincrement()) @sqlserver.Int
-          int         Int      @sqlserver.Int
+          id          Int      @id @default(autoincrement())
+          int         Int
           smallint    Int      @sqlserver.SmallInt
           tinyint     Int      @sqlserver.TinyInt
-          bigint      BigInt   @sqlserver.BigInt
+          bigint      BigInt
           decimal     Decimal  @sqlserver.Decimal(5, 3)
           decimal_2   Decimal  @sqlserver.Decimal(18, 0)
           numeric     Decimal  @sqlserver.Decimal(4, 1)
@@ -87,7 +87,7 @@ async fn native_type_columns_feature_on(api: &TestApi) -> crate::TestResult {
           smallmoney  Float    @sqlserver.SmallMoney
           float       Float    @sqlserver.Real
           double      Float    @sqlserver.Float(53)
-          bit         Boolean  @sqlserver.Bit
+          bit         Boolean
           chars       String   @sqlserver.Char(10)
           nchars      String   @sqlserver.NChar(10)
           varchars    String   @sqlserver.VarChar(500)
@@ -96,11 +96,11 @@ async fn native_type_columns_feature_on(api: &TestApi) -> crate::TestResult {
           nvarchars_2 String   @sqlserver.NVarChar(Max)
           binary      Bytes    @sqlserver.Binary(230)
           varbinary   Bytes    @sqlserver.VarBinary(150)
-          varbinary_2 Bytes    @sqlserver.VarBinary(Max)
+          varbinary_2 Bytes
           date        DateTime @sqlserver.Date
           time        DateTime @sqlserver.Time
           datetime    DateTime @sqlserver.DateTime
-          datetime2   DateTime @sqlserver.DateTime2
+          datetime2   DateTime
           xml         String   @sqlserver.Xml
           image       Bytes    @sqlserver.Image
           text        String   @sqlserver.Text

--- a/introspection-engine/introspection-engine-tests/tests/native_types/mysql.rs
+++ b/introspection-engine/introspection-engine-tests/tests/native_types/mysql.rs
@@ -66,7 +66,7 @@ async fn native_type_columns_feature_on(api: &TestApi) -> crate::TestResult {
         .await?;
 
     let (json, default) = match api {
-        _ if api.tags.contains(Tags::Mysql8) => ("Json     @mysql.Json", ""),
+        _ if api.tags.contains(Tags::Mysql8) => ("Json", ""),
         _ if api.tags.contains(Tags::Mariadb) => ("String   @mysql.LongText", "@default(now())"),
         _ => unreachable!(),
     };
@@ -85,17 +85,17 @@ async fn native_type_columns_feature_on(api: &TestApi) -> crate::TestResult {
 
     let types = formatdoc! {r#"
         model Blog {{
-            int                            Int      @mysql.Int
+            int                            Int
             unsignedint                    Int      @mysql.UnsignedInt
             smallint                       Int      @mysql.SmallInt
             unsignedsmallint               Int      @mysql.UnsignedSmallInt
             tinyint                        Int      @mysql.TinyInt
             unsignedtinyint                Int      @mysql.UnsignedTinyInt
-            tinyint_bool                   Boolean  @mysql.TinyInt
+            tinyint_bool                   Boolean
             mediumint                      Int      @mysql.MediumInt
             unsignedmediumint              Int      @mysql.UnsignedMediumInt
-            bigint                         BigInt   @mysql.BigInt
-            bigint_autoincrement           BigInt   @id  @default(autoincrement()) @mysql.BigInt
+            bigint                         BigInt
+            bigint_autoincrement           BigInt   @id  @default(autoincrement())
             unsignedbigint                 BigInt   @mysql.UnsignedBigInt
             decimal                        Decimal  @mysql.Decimal(5, 3)
             decimal_2                      Decimal  @mysql.Decimal(10, 0)
@@ -110,7 +110,7 @@ async fn native_type_columns_feature_on(api: &TestApi) -> crate::TestResult {
             tinyBlob                       Bytes    @mysql.TinyBlob
             blob                           Bytes    @mysql.Blob
             mediumBlob                     Bytes    @mysql.MediumBlob
-            longBlob                       Bytes    @mysql.LongBlob
+            longBlob                       Bytes
             tinytext                       String   @mysql.TinyText
             text                           String   @mysql.Text
             mediumText                     String   @mysql.MediumText
@@ -118,7 +118,7 @@ async fn native_type_columns_feature_on(api: &TestApi) -> crate::TestResult {
             date                           DateTime @mysql.Date
             timeWithPrecision              DateTime @mysql.Time(3)
             timeWithPrecision_no_precision DateTime @mysql.DateTime(0)
-            dateTimeWithPrecision          DateTime @mysql.DateTime(3)
+            dateTimeWithPrecision          DateTime
             timestampWithPrecision         DateTime {default} @mysql.Timestamp(3)
             year                           Int      @mysql.Year
             json                           {json}

--- a/introspection-engine/introspection-engine-tests/tests/native_types/postgres.rs
+++ b/introspection-engine/introspection-engine-tests/tests/native_types/postgres.rs
@@ -69,34 +69,34 @@ async fn native_type_columns_feature_on(api: &TestApi) -> crate::TestResult {
 
     let types = indoc! {r#"
         model Blog {
-            id              Int      @id @postgres.Integer
+            id              Int      @id
             smallint        Int      @postgres.SmallInt
-            int             Int      @postgres.Integer
-            bigint          BigInt   @postgres.BigInt
+            int             Int
+            bigint          BigInt
             decimal         Decimal  @postgres.Decimal(4, 2)
             numeric         Decimal  @postgres.Decimal(4, 2)
             real            Float    @postgres.Real
             doublePrecision Float    @postgres.DoublePrecision
             smallSerial     Int      @default(autoincrement()) @postgres.SmallInt
-            serial          Int      @default(autoincrement()) @postgres.Integer
-            bigSerial       BigInt   @default(autoincrement()) @postgres.BigInt
+            serial          Int      @default(autoincrement())
+            bigSerial       BigInt   @default(autoincrement())
             varChar         String   @postgres.VarChar(200)
             char            String   @postgres.Char(200)
-            text            String   @postgres.Text
-            bytea           Bytes    @postgres.ByteA
+            text            String
+            bytea           Bytes
             ts              DateTime @postgres.Timestamp(0)
             tstz            DateTime @postgres.Timestamptz(2)
             date            DateTime @postgres.Date
             time            DateTime @postgres.Time(2)
             time_2          DateTime @postgres.Time(6)
             timetz          DateTime @postgres.Timetz(2)
-            bool            Boolean  @postgres.Boolean
+            bool            Boolean
             bit             String   @postgres.Bit(1)
             varbit          String   @postgres.VarBit(1)
             uuid            String   @postgres.Uuid
             xml             String   @postgres.Xml
             json            Json     @postgres.Json
-            jsonb           Json     @postgres.JsonB
+            jsonb           Json
             money           Decimal  @postgres.Money
             oid             Int      @postgres.Oid
             inet            String   @postgres.Inet
@@ -227,7 +227,7 @@ async fn native_type_array_columns_feature_on(api: &TestApi) -> crate::TestResul
          }
 
          model Blog {
-          id                Int        @id @postgres.Integer
+          id                Int        @id
           decimal_array     Decimal[]  @postgres.Decimal(42, 0)
           decimal_array_2   Decimal[]  @postgres.Decimal
           numeric_array     Decimal[]  @postgres.Decimal(4, 2)

--- a/libs/datamodel/connectors/datamodel-connector/src/combined_connector.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/combined_connector.rs
@@ -1,8 +1,7 @@
 use super::Connector;
-use crate::connector_error::ConnectorError;
-use crate::{ConnectorCapability, NativeTypeConstructor, NativeTypeInstance};
-use dml::field::Field;
-use dml::model::Model;
+use crate::{connector_error::ConnectorError, ConnectorCapability, NativeTypeConstructor, NativeTypeInstance};
+use dml::{field::Field, model::Model, scalars::ScalarType};
+use std::unimplemented;
 
 pub struct CombinedConnector {
     capabilities: Vec<ConnectorCapability>,
@@ -46,7 +45,15 @@ impl Connector for CombinedConnector {
         Ok(())
     }
 
-    fn available_native_type_constructors(&self) -> &Vec<NativeTypeConstructor> {
+    fn native_type_is_default_for_scalar_type(
+        &self,
+        _native_type: serde_json::Value,
+        _scalar_type: &ScalarType,
+    ) -> bool {
+        unimplemented!("A combined connector must not be used for native types")
+    }
+
+    fn available_native_type_constructors(&self) -> &[NativeTypeConstructor] {
         unimplemented!("A combined connector must not be used for native types")
     }
 
@@ -55,6 +62,10 @@ impl Connector for CombinedConnector {
     }
 
     fn introspect_native_type(&self, _native_type: serde_json::Value) -> Result<NativeTypeInstance, ConnectorError> {
+        unimplemented!("A combined connector must not be used for native types")
+    }
+
+    fn default_native_type_for_scalar_type(&self, _scalar_type: &ScalarType) -> serde_json::Value {
         unimplemented!("A combined connector must not be used for native types")
     }
 }

--- a/libs/datamodel/connectors/datamodel-connector/src/lib.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/lib.rs
@@ -3,12 +3,13 @@ mod combined_connector;
 pub mod connector_error;
 pub mod helper;
 
-use crate::connector_error::{ConnectorError, ConnectorErrorFactory, ErrorKind};
 pub use combined_connector::CombinedConnector;
-use dml::field::Field;
-use dml::model::Model;
-use dml::native_type_constructor::NativeTypeConstructor;
-use dml::native_type_instance::NativeTypeInstance;
+
+use crate::connector_error::{ConnectorError, ConnectorErrorFactory, ErrorKind};
+use dml::{
+    field::Field, model::Model, native_type_constructor::NativeTypeConstructor,
+    native_type_instance::NativeTypeInstance, scalars::ScalarType,
+};
 
 pub trait Connector: Send + Sync {
     fn name(&self) -> String;
@@ -25,7 +26,14 @@ pub trait Connector: Send + Sync {
 
     /// Returns all available native type constructors available through this connector.
     /// Powers the auto completion of the vs code plugin.
-    fn available_native_type_constructors(&self) -> &Vec<NativeTypeConstructor>;
+    fn available_native_type_constructors(&self) -> &[NativeTypeConstructor];
+
+    /// On each connector, each built-in Prisma scalar type (`Boolean`,
+    /// `String`, `Float`, etc.) has a corresponding native type.
+    fn default_native_type_for_scalar_type(&self, scalar_type: &ScalarType) -> serde_json::Value;
+
+    /// Same mapping as `default_native_type_for_scalar_type()`, but in the opposite direction.
+    fn native_type_is_default_for_scalar_type(&self, native_type: serde_json::Value, scalar_type: &ScalarType) -> bool;
 
     fn find_native_type_constructor(&self, name: &str) -> Option<&NativeTypeConstructor> {
         self.available_native_type_constructors()

--- a/libs/datamodel/connectors/dml/src/field.rs
+++ b/libs/datamodel/connectors/dml/src/field.rs
@@ -45,6 +45,13 @@ pub enum FieldType {
 }
 
 impl FieldType {
+    pub fn as_native_type(&self) -> Option<(&ScalarType, &NativeTypeInstance)> {
+        match self {
+            FieldType::NativeType(a, b) => Some((a, b)),
+            _ => None,
+        }
+    }
+
     pub fn is_compatible_with(&self, other: &Self) -> bool {
         match (self, other) {
             (Self::Base(a, _), Self::Base(b, _)) => a == b, // the name of the type alias is not important for the comparison
@@ -76,6 +83,13 @@ pub enum Field {
 }
 
 impl Field {
+    pub fn as_scalar_field(&self) -> Option<&ScalarField> {
+        match self {
+            Field::ScalarField(sf) => Some(sf),
+            _ => None,
+        }
+    }
+
     pub fn is_relation(&self) -> bool {
         match self {
             Field::ScalarField(_) => false,

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/mssql_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/mssql_datamodel_connector.rs
@@ -91,6 +91,24 @@ impl MsSqlDatamodelConnector {
     }
 }
 
+const SCALAR_TYPE_DEFAULTS: &[(ScalarType, MsSqlType)] = &[
+    (ScalarType::Int, MsSqlType::Int),
+    (ScalarType::BigInt, MsSqlType::BigInt),
+    (ScalarType::Float, MsSqlType::Decimal(Some((32, 16)))),
+    (ScalarType::Decimal, MsSqlType::Decimal(Some((32, 16)))),
+    (ScalarType::Boolean, MsSqlType::Bit),
+    (
+        ScalarType::String,
+        MsSqlType::NVarChar(Some(MsSqlTypeParameter::Number(1000))),
+    ),
+    (ScalarType::DateTime, MsSqlType::DateTime2),
+    (ScalarType::Bytes, MsSqlType::VarBinary(Some(MsSqlTypeParameter::Max))),
+    (
+        ScalarType::Json,
+        MsSqlType::NVarChar(Some(MsSqlTypeParameter::Number(1000))),
+    ),
+];
+
 impl Connector for MsSqlDatamodelConnector {
     fn name(&self) -> String {
         "SQL Server".to_string()
@@ -98,6 +116,25 @@ impl Connector for MsSqlDatamodelConnector {
 
     fn capabilities(&self) -> &Vec<ConnectorCapability> {
         &self.capabilities
+    }
+
+    fn default_native_type_for_scalar_type(&self, scalar_type: &ScalarType) -> serde_json::Value {
+        let native_type = SCALAR_TYPE_DEFAULTS
+            .iter()
+            .find(|(st, _)| st == scalar_type)
+            .map(|(_, native_type)| native_type)
+            .ok_or_else(|| format!("Could not find scalar type {:?} in SCALAR_TYPE_DEFAULTS", scalar_type))
+            .unwrap();
+
+        serde_json::to_value(native_type).expect("MsSqlType to JSON failed")
+    }
+
+    fn native_type_is_default_for_scalar_type(&self, native_type: serde_json::Value, scalar_type: &ScalarType) -> bool {
+        let native_type: MsSqlType = serde_json::from_value(native_type).expect("MsSqlType from JSON failed");
+
+        SCALAR_TYPE_DEFAULTS
+            .iter()
+            .any(|(st, nt)| scalar_type == st && &native_type == nt)
     }
 
     fn validate_field(&self, field: &Field) -> Result<(), ConnectorError> {
@@ -182,7 +219,7 @@ impl Connector for MsSqlDatamodelConnector {
         Ok(())
     }
 
-    fn available_native_type_constructors(&self) -> &Vec<NativeTypeConstructor> {
+    fn available_native_type_constructors(&self) -> &[NativeTypeConstructor] {
         &self.constructors
     }
 

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
@@ -148,6 +148,18 @@ impl MySqlDatamodelConnector {
     }
 }
 
+const SCALAR_TYPE_DEFAULTS: &[(ScalarType, MySqlType)] = &[
+    (ScalarType::Int, MySqlType::Int),
+    (ScalarType::BigInt, MySqlType::BigInt),
+    (ScalarType::Float, MySqlType::Decimal(Some((65, 30)))),
+    (ScalarType::Decimal, MySqlType::Decimal(Some((65, 30)))),
+    (ScalarType::Boolean, MySqlType::TinyInt),
+    (ScalarType::String, MySqlType::VarChar(191)),
+    (ScalarType::DateTime, MySqlType::DateTime(Some(3))),
+    (ScalarType::Bytes, MySqlType::LongBlob),
+    (ScalarType::Json, MySqlType::Json),
+];
+
 impl Connector for MySqlDatamodelConnector {
     fn name(&self) -> String {
         "MySQL".to_string()
@@ -155,6 +167,25 @@ impl Connector for MySqlDatamodelConnector {
 
     fn capabilities(&self) -> &Vec<ConnectorCapability> {
         &self.capabilities
+    }
+
+    fn default_native_type_for_scalar_type(&self, scalar_type: &ScalarType) -> serde_json::Value {
+        let native_type = SCALAR_TYPE_DEFAULTS
+            .iter()
+            .find(|(st, _)| st == scalar_type)
+            .map(|(_, native_type)| native_type)
+            .ok_or_else(|| format!("Could not find scalar type {:?} in SCALAR_TYPE_DEFAULTS", scalar_type))
+            .unwrap();
+
+        serde_json::to_value(native_type).expect("MySqlType to JSON failed")
+    }
+
+    fn native_type_is_default_for_scalar_type(&self, native_type: serde_json::Value, scalar_type: &ScalarType) -> bool {
+        let native_type: MySqlType = serde_json::from_value(native_type).expect("MySqlType from JSON failed");
+
+        SCALAR_TYPE_DEFAULTS
+            .iter()
+            .any(|(st, nt)| scalar_type == st && &native_type == nt)
     }
 
     fn validate_field(&self, field: &Field) -> Result<(), ConnectorError> {
@@ -227,7 +258,7 @@ impl Connector for MySqlDatamodelConnector {
         Ok(())
     }
 
-    fn available_native_type_constructors(&self) -> &Vec<NativeTypeConstructor> {
+    fn available_native_type_constructors(&self) -> &[NativeTypeConstructor] {
         &self.constructors
     }
 

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/sqlite_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/sqlite_datamodel_connector.rs
@@ -1,9 +1,8 @@
-use datamodel_connector::connector_error::ConnectorError;
-use datamodel_connector::{Connector, ConnectorCapability};
-use dml::field::Field;
+use datamodel_connector::{connector_error::ConnectorError, Connector, ConnectorCapability};
 use dml::model::Model;
 use dml::native_type_constructor::NativeTypeConstructor;
 use dml::native_type_instance::NativeTypeInstance;
+use dml::{field::Field, scalars::ScalarType};
 
 pub struct SqliteDatamodelConnector {
     capabilities: Vec<ConnectorCapability>,
@@ -30,6 +29,18 @@ impl Connector for SqliteDatamodelConnector {
         &self.capabilities
     }
 
+    fn default_native_type_for_scalar_type(&self, _scalar_type: &ScalarType) -> serde_json::Value {
+        serde_json::Value::Null
+    }
+
+    fn native_type_is_default_for_scalar_type(
+        &self,
+        _native_type: serde_json::Value,
+        _scalar_type: &ScalarType,
+    ) -> bool {
+        false
+    }
+
     fn validate_field(&self, _field: &Field) -> Result<(), ConnectorError> {
         Ok(())
     }
@@ -38,7 +49,7 @@ impl Connector for SqliteDatamodelConnector {
         Ok(())
     }
 
-    fn available_native_type_constructors(&self) -> &Vec<NativeTypeConstructor> {
+    fn available_native_type_constructors(&self) -> &[NativeTypeConstructor] {
         &self.constructors
     }
 

--- a/libs/datamodel/core/src/lib.rs
+++ b/libs/datamodel/core/src/lib.rs
@@ -70,7 +70,6 @@
 //!                       └──────────────────┘
 //!</pre>
 //!
-extern crate pest; // Pest grammar generation on compile time.
 #[macro_use]
 extern crate tracing;
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour.rs
@@ -4,8 +4,7 @@ mod postgres;
 mod sqlite;
 
 use datamodel::{walkers::ModelWalker, walkers::ScalarFieldWalker, Datamodel, FieldArity, ScalarType};
-use sql_schema_describer as sql;
-use sql_schema_describer::{ColumnArity, ColumnType, ColumnTypeFamily};
+use sql_schema_describer::{self as sql, ColumnArity, ColumnType, ColumnTypeFamily};
 
 pub(crate) trait SqlSchemaCalculatorFlavour {
     fn calculate_enums(&self, _datamodel: &Datamodel) -> Vec<sql::Enum> {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/mssql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/mssql.rs
@@ -1,10 +1,14 @@
 use super::SqlSchemaCalculatorFlavour;
 use crate::flavour::MssqlFlavour;
 use datamodel::{walkers::ModelWalker, ScalarType};
-use native_types::{MsSqlType, MsSqlTypeParameter};
+use datamodel_connector::Connector;
 use sql_schema_describer::ForeignKeyAction;
 
 impl SqlSchemaCalculatorFlavour for MssqlFlavour {
+    fn default_native_type_for_scalar_type(&self, scalar_type: &ScalarType) -> serde_json::Value {
+        sql_datamodel_connector::SqlDatamodelConnectors::mssql().default_native_type_for_scalar_type(scalar_type)
+    }
+
     fn m2m_foreign_key_action(&self, model_a: &ModelWalker<'_>, model_b: &ModelWalker<'_>) -> ForeignKeyAction {
         // MSSQL will crash when creating a cyclic cascade
         if model_a.name() == model_b.name() {
@@ -16,21 +20,5 @@ impl SqlSchemaCalculatorFlavour for MssqlFlavour {
 
     fn single_field_index_name(&self, model_name: &str, field_name: &str) -> String {
         format!("{}_{}_unique", model_name, field_name)
-    }
-
-    fn default_native_type_for_scalar_type(&self, scalar_type: &ScalarType) -> serde_json::Value {
-        let ty = match scalar_type {
-            ScalarType::Int => MsSqlType::Int,
-            ScalarType::BigInt => MsSqlType::BigInt,
-            ScalarType::Float => MsSqlType::Decimal(Some((32, 16))),
-            ScalarType::Decimal => MsSqlType::Decimal(Some((32, 16))),
-            ScalarType::Boolean => MsSqlType::Bit,
-            ScalarType::String => MsSqlType::NVarChar(Some(MsSqlTypeParameter::Number(1000))),
-            ScalarType::DateTime => MsSqlType::DateTime2,
-            ScalarType::Bytes => MsSqlType::VarBinary(Some(MsSqlTypeParameter::Max)),
-            ScalarType::Json => MsSqlType::NVarChar(Some(MsSqlTypeParameter::Number(1000))),
-        };
-
-        serde_json::to_value(ty).expect("MsSqlType to JSON failed")
     }
 }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/postgres.rs
@@ -1,7 +1,7 @@
 use super::SqlSchemaCalculatorFlavour;
 use crate::flavour::PostgresFlavour;
 use datamodel::{walkers::ScalarFieldWalker, Datamodel, ScalarType, WithDatabaseName};
-use native_types::PostgresType;
+use datamodel_connector::Connector;
 use sql_schema_describer::{self as sql};
 
 impl SqlSchemaCalculatorFlavour for PostgresFlavour {
@@ -16,19 +16,7 @@ impl SqlSchemaCalculatorFlavour for PostgresFlavour {
     }
 
     fn default_native_type_for_scalar_type(&self, scalar_type: &ScalarType) -> serde_json::Value {
-        let ty = match scalar_type {
-            ScalarType::Int => PostgresType::Integer,
-            ScalarType::BigInt => PostgresType::BigInt,
-            ScalarType::Float => PostgresType::Decimal(Some((65, 30))),
-            ScalarType::Decimal => PostgresType::Decimal(Some((65, 30))),
-            ScalarType::Boolean => PostgresType::Boolean,
-            ScalarType::String => PostgresType::Text,
-            ScalarType::DateTime => PostgresType::Timestamp(Some(3)),
-            ScalarType::Bytes => PostgresType::ByteA,
-            ScalarType::Json => PostgresType::JSONB,
-        };
-
-        serde_json::to_value(ty).expect("PostgresType to json failed")
+        sql_datamodel_connector::PostgresDatamodelConnector::new().default_native_type_for_scalar_type(scalar_type)
     }
 
     fn enum_column_type(&self, field: &ScalarFieldWalker<'_>, db_name: &str) -> sql::ColumnType {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/sqlite.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/sqlite.rs
@@ -1,10 +1,11 @@
 use super::SqlSchemaCalculatorFlavour;
 use crate::flavour::SqliteFlavour;
 use datamodel::{walkers::ScalarFieldWalker, ScalarType};
+use datamodel_connector::Connector;
 
 impl SqlSchemaCalculatorFlavour for SqliteFlavour {
-    fn default_native_type_for_scalar_type(&self, _scalar_type: &ScalarType) -> serde_json::Value {
-        serde_json::Value::Null
+    fn default_native_type_for_scalar_type(&self, scalar_type: &ScalarType) -> serde_json::Value {
+        sql_datamodel_connector::SqlDatamodelConnectors::sqlite().default_native_type_for_scalar_type(scalar_type)
     }
 
     // Integer primary keys on SQLite are automatically assigned the rowid, which means they are automatically autoincrementing.

--- a/migration-engine/migration-engine-tests/tests/native_types/mysql.rs
+++ b/migration-engine/migration-engine-tests/tests/native_types/mysql.rs
@@ -1,6 +1,5 @@
 use migration_engine_tests::sql::*;
 use quaint::prelude::Queryable;
-use sql_datamodel_connector::SqlDatamodelConnectors;
 use std::{borrow::Cow, fmt::Write};
 
 /// (source native type, test value to insert, target native type)
@@ -752,7 +751,7 @@ fn filter_to_types(api: &TestApi, to_types: &'static [&'static str]) -> Cow<'sta
 
 #[test_each_connector(tags("mysql"), features("native_types"), log = "debug")]
 async fn safe_casts_with_existing_data_should_work(api: &TestApi) -> TestResult {
-    let connector = SqlDatamodelConnectors::mysql();
+    let connector = sql_datamodel_connector::MySqlDatamodelConnector::new();
     let mut dm1 = String::with_capacity(256);
     let mut dm2 = String::with_capacity(256);
     let colnames = colnames_for_cases(SAFE_CASTS);
@@ -803,7 +802,7 @@ async fn safe_casts_with_existing_data_should_work(api: &TestApi) -> TestResult 
 
 #[test_each_connector(tags("mysql"), features("native_types"), log = "debug")]
 async fn risky_casts_with_existing_data_should_warn(api: &TestApi) -> TestResult {
-    let connector = SqlDatamodelConnectors::mysql();
+    let connector = sql_datamodel_connector::MySqlDatamodelConnector::new();
     let mut dm1 = String::with_capacity(256);
     let mut dm2 = String::with_capacity(256);
     let colnames = colnames_for_cases(RISKY_CASTS);
@@ -869,7 +868,7 @@ async fn risky_casts_with_existing_data_should_warn(api: &TestApi) -> TestResult
 
 #[test_each_connector(tags("mysql"), features("native_types"), log = "debug")]
 async fn impossible_casts_with_existing_data_should_warn(api: &TestApi) -> TestResult {
-    let connector = SqlDatamodelConnectors::mysql();
+    let connector = sql_datamodel_connector::MySqlDatamodelConnector::new();
     let mut dm1 = String::with_capacity(256);
     let mut dm2 = String::with_capacity(256);
     let colnames = colnames_for_cases(IMPOSSIBLE_CASTS);


### PR DESCRIPTION
...when they match the default for their scalar type.

This affects introspection and prisma format.

closes https://github.com/prisma/prisma/issues/5218