### PR TITLE
fix: filter create/upsert in nested ops for relations that don't support create

### DIFF
--- a/libs/prisma-models/src/datamodel_converter.rs
+++ b/libs/prisma-models/src/datamodel_converter.rs
@@ -395,7 +395,7 @@ impl ModelConverterUtilities for dml::Model {
                 _ => false,
             };
 
-            self.field_is_indexed(field.name()) && is_supported_field == true
+            self.field_is_indexed(field.name()) && is_supported_field
         })
     }
 

--- a/query-engine/core/src/schema_builder/output_types/mutation_type.rs
+++ b/query-engine/core/src/schema_builder/output_types/mutation_type.rs
@@ -56,7 +56,7 @@ fn create_nested_inputs(ctx: &mut BuilderContext) {
         for (input_object, rf) in nested_create_inputs_queue.drain(..) {
             let mut fields = vec![];
 
-            if rf.related_model().supports_create_operation == true {
+            if rf.related_model().supports_create_operation {
                 fields.push(input_fields::nested_create_one_input_field(ctx, &rf));
 
                 append_opt(&mut fields, input_fields::nested_connect_or_create_field(ctx, &rf));
@@ -75,7 +75,7 @@ fn create_nested_inputs(ctx: &mut BuilderContext) {
         for (input_object, rf) in nested_update_inputs_queue.drain(..) {
             let mut fields = vec![];
 
-            if rf.related_model().supports_create_operation == true {
+            if rf.related_model().supports_create_operation {
                 fields.push(input_fields::nested_create_one_input_field(ctx, &rf));
 
                 append_opt(&mut fields, input_fields::nested_connect_or_create_field(ctx, &rf));

--- a/query-engine/query-engine/src/tests/dmmf/helpers.rs
+++ b/query-engine/query-engine/src/tests/dmmf/helpers.rs
@@ -75,7 +75,7 @@ where
     for field in &input_type.fields {
         for input_type_ref in &field.input_types {
             match input_type_ref.location {
-                TypeLocation::OutputObjectTypes => {
+                TypeLocation::InputObjectTypes => {
                     let namespace = input_type_ref
                         .namespace
                         .as_ref()

--- a/query-engine/query-engine/src/tests/dmmf/helpers.rs
+++ b/query-engine/query-engine/src/tests/dmmf/helpers.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::dmmf::{schema::*, DataModelMetaFormat};
 use datamodel_connector::ConnectorCapabilities;
 use prisma_models::DatamodelConverter;
@@ -68,27 +70,38 @@ where
     }
 }
 
-pub fn iterate_input_type_fields<P>(input_type: &DmmfInputType, dmmf: &DataModelMetaFormat, iteratee: &P)
+pub fn iterate_input_type_fields<P>(root: &DmmfInputType, dmmf: &DataModelMetaFormat, iteratee: &P)
 where
     P: Fn(&DmmfTypeReference, &DmmfInputField, &DmmfInputType),
 {
-    for field in &input_type.fields {
-        for input_type_ref in &field.input_types {
-            match input_type_ref.location {
-                TypeLocation::InputObjectTypes => {
-                    let namespace = input_type_ref
-                        .namespace
-                        .as_ref()
-                        .expect("a namespace is required to iterate over a nested output type but could not find one");
-                    let nested_input_type = find_input_type(dmmf, namespace, input_type_ref.typ.as_str());
+    let mut stack: Vec<&DmmfInputType> = vec![root];
+    let mut visited: HashMap<&str, bool> = HashMap::new();
 
-                    iteratee(&input_type_ref, &field, nested_input_type);
-                    iterate_input_type_fields(nested_input_type, dmmf, iteratee)
+    while !stack.is_empty() {
+        let input_type = stack.pop().unwrap();
+
+        visited.insert(input_type.name.as_str(), true);
+
+        for field in &input_type.fields {
+            for input_type_ref in &field.input_types {
+                match input_type_ref.location {
+                    TypeLocation::InputObjectTypes => {
+                        let namespace = input_type_ref.namespace.as_ref().expect(
+                            "a namespace is required to iterate over a nested output type but could not find one",
+                        );
+                        let nested_input_type = find_input_type(dmmf, namespace, input_type_ref.typ.as_str());
+
+                        iteratee(&input_type_ref, &field, nested_input_type);
+
+                        if visited.get(nested_input_type.name.as_str()).is_none() {
+                            stack.push(nested_input_type);
+                        }
+                    }
+                    TypeLocation::Scalar | TypeLocation::EnumTypes => {
+                        iteratee(&input_type_ref, &field, input_type);
+                    }
+                    _ => (),
                 }
-                TypeLocation::Scalar | TypeLocation::EnumTypes => {
-                    iteratee(&input_type_ref, &field, input_type);
-                }
-                _ => (),
             }
         }
     }

--- a/query-engine/query-engine/src/tests/dmmf/unsupported.rs
+++ b/query-engine/query-engine/src/tests/dmmf/unsupported.rs
@@ -112,7 +112,7 @@ fn relation_with_unsupported_fk_fields_should_be_filtered_from_input_output_type
     }
 
     for o in input_types {
-        iterate_input_type_fields(o, &dmmf, &|_, field, parent_type| {
+        iterate_input_type_fields(o, &dmmf, &|_, field, _| {
             assert_ne!(field.name, "user");
             assert_ne!(field.name, "post");
         })

--- a/query-engine/query-engine/src/tests/dmmf/unsupported.rs
+++ b/query-engine/query-engine/src/tests/dmmf/unsupported.rs
@@ -112,7 +112,7 @@ fn relation_with_unsupported_fk_fields_should_be_filtered_from_input_output_type
     }
 
     for o in input_types {
-        iterate_input_type_fields(o, &dmmf, &|_, field, _| {
+        iterate_input_type_fields(o, &dmmf, &|_, field, parent_type| {
             assert_ne!(field.name, "user");
             assert_ne!(field.name, "post");
         })


### PR DESCRIPTION
## Overview

When a model has a relation to another model that cannot support create/upsert operations, filter out create/upsert nested operations for that model

Follow up to #1561