### PR TITLE
@ignore on fields

### DIFF
--- a/introspection-engine/connectors/sql-introspection-connector/src/calculate_datamodel.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/calculate_datamodel.rs
@@ -128,6 +128,7 @@ mod tests {
                             is_generated: false,
                             is_updated_at: false,
                             is_commented_out,
+                            is_ignored: false,
                         })
                     })
                     .collect(),
@@ -192,6 +193,7 @@ mod tests {
                         is_generated: false,
                         is_updated_at: false,
                         is_commented_out: false,
+                        is_ignored: false,
                     }),
                     Field::ScalarField(ScalarField::new(
                         "list",
@@ -274,6 +276,7 @@ mod tests {
                         is_generated: false,
                         is_updated_at: false,
                         is_commented_out: false,
+                        is_ignored: false,
                     }),
                     Field::ScalarField(ScalarField {
                         name: "bool_default".to_string(),
@@ -287,6 +290,7 @@ mod tests {
                         is_generated: false,
                         is_updated_at: false,
                         is_commented_out: false,
+                        is_ignored: false,
                     }),
                     Field::ScalarField(ScalarField {
                         name: "float_default".to_string(),
@@ -300,6 +304,7 @@ mod tests {
                         is_generated: false,
                         is_updated_at: false,
                         is_commented_out: false,
+                        is_ignored: false,
                     }),
                     Field::ScalarField(ScalarField {
                         name: "string_default".to_string(),
@@ -313,6 +318,7 @@ mod tests {
                         is_generated: false,
                         is_updated_at: false,
                         is_commented_out: false,
+                        is_ignored: false,
                     }),
                 ],
                 is_generated: false,
@@ -402,6 +408,7 @@ mod tests {
                         is_generated: false,
                         is_updated_at: false,
                         is_commented_out: false,
+                        is_ignored: false,
                     })],
                     is_generated: false,
                     indices: vec![],
@@ -427,6 +434,7 @@ mod tests {
                         is_generated: false,
                         is_updated_at: false,
                         is_commented_out: false,
+                        is_ignored: false,
                     })],
                     is_generated: false,
                     indices: vec![],
@@ -452,6 +460,7 @@ mod tests {
                         is_generated: false,
                         is_updated_at: false,
                         is_commented_out: false,
+                        is_ignored: false,
                     })],
                     is_generated: false,
                     indices: vec![],
@@ -566,6 +575,7 @@ mod tests {
                         is_generated: false,
                         is_updated_at: false,
                         is_commented_out: false,
+                        is_ignored: false,
                     }),
                 ],
                 is_generated: false,
@@ -633,6 +643,7 @@ mod tests {
                             is_generated: false,
                             is_updated_at: false,
                             is_commented_out: false,
+                            is_ignored: false,
                         }),
                         Field::ScalarField(ScalarField::new(
                             "name",
@@ -675,6 +686,7 @@ mod tests {
                             is_generated: false,
                             is_updated_at: false,
                             is_commented_out: false,
+                            is_ignored: false,
                         }),
                         Field::ScalarField(ScalarField {
                             name: "city_id".to_string(),
@@ -688,6 +700,7 @@ mod tests {
                             is_generated: false,
                             is_updated_at: false,
                             is_commented_out: false,
+                            is_ignored: false,
                         }),
                         Field::ScalarField(ScalarField {
                             name: "city_name".to_string(),
@@ -701,6 +714,7 @@ mod tests {
                             is_generated: false,
                             is_updated_at: false,
                             is_commented_out: false,
+                            is_ignored: false,
                         }),
                         Field::RelationField(RelationField::new(
                             "City",
@@ -844,6 +858,7 @@ mod tests {
                         is_generated: false,
                         is_updated_at: false,
                         is_commented_out: false,
+                        is_ignored: false,
                     }),
                     Field::ScalarField(ScalarField::new(
                         "name",
@@ -950,6 +965,7 @@ mod tests {
                             is_generated: false,
                             is_updated_at: false,
                             is_commented_out: false,
+                            is_ignored: false,
                         }),
                         Field::ScalarField(ScalarField::new(
                             "name",
@@ -992,6 +1008,7 @@ mod tests {
                             is_generated: false,
                             is_updated_at: false,
                             is_commented_out: false,
+                            is_ignored: false,
                         }),
                         Field::ScalarField(ScalarField::new(
                             "city_id",

--- a/introspection-engine/connectors/sql-introspection-connector/src/commenting_out_guardrails.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/commenting_out_guardrails.rs
@@ -129,7 +129,11 @@ pub fn commenting_out_guardrails(
         for model in datamodel.models_mut() {
             for field in model.relation_fields_mut() {
                 if field.points_to_model(&model_without_identifier.model) {
-                    field.is_commented_out = true;
+                    if native_types_enabled {
+                        field.is_ignored = true;
+                    } else {
+                        field.is_commented_out = true;
+                    }
                 }
             }
         }

--- a/introspection-engine/connectors/sql-introspection-connector/src/introspection_helpers.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/introspection_helpers.rs
@@ -183,6 +183,7 @@ pub(crate) fn calculate_scalar_field(
         is_generated: false,
         is_updated_at: false,
         is_commented_out,
+        is_ignored: false,
     }
 }
 

--- a/introspection-engine/introspection-engine-tests/tests/commenting_out/mod.rs
+++ b/introspection-engine/introspection-engine-tests/tests/commenting_out/mod.rs
@@ -88,8 +88,8 @@ async fn a_table_without_uniques_using_native_types_should_ignore(api: &TestApi)
             }
 
             model User {
-              id      Int    @id @default(autoincrement())
-              // Post Post[]
+              id   Int    @id @default(autoincrement())
+              Post Post[] @ignore
             }
         "#}
     } else {
@@ -104,8 +104,8 @@ async fn a_table_without_uniques_using_native_types_should_ignore(api: &TestApi)
             }
 
             model User {
-              id      Int    @id @default(autoincrement())
-              // Post Post[]
+              id   Int    @id @default(autoincrement())
+              Post Post[] @ignore
             }
         "#}
     };
@@ -486,7 +486,7 @@ async fn commenting_out_a_table_without_columns(api: &TestApi) -> crate::TestRes
 }
 
 #[test_each_connector(tags("postgres"))]
-async fn ignore_on_relation_field_if_pointing_to_ignored_model(api: &TestApi) -> crate::TestResult {
+async fn ignore_on_back_relation_field_if_pointing_to_ignored_model(api: &TestApi) -> crate::TestResult {
     api.barrel()
         .execute(|migration| {
             migration.create_table("User", |t| {

--- a/libs/datamodel/connectors/dml/src/field.rs
+++ b/libs/datamodel/connectors/dml/src/field.rs
@@ -233,6 +233,9 @@ pub struct RelationField {
 
     /// Indicates if this field has to be commented out.
     pub is_commented_out: bool,
+
+    /// Indicates if this field has to be ignored by the Client.
+    pub is_ignored: bool,
 }
 
 impl RelationField {
@@ -245,6 +248,7 @@ impl RelationField {
             documentation: None,
             is_generated: false,
             is_commented_out: false,
+            is_ignored: false,
         }
     }
     /// Creates a new field with the given name and type, marked as generated and optional.
@@ -318,6 +322,9 @@ pub struct ScalarField {
 
     /// Indicates if this field has to be commented out.
     pub is_commented_out: bool,
+
+    /// Indicates if this field is ignored by the Client.
+    pub is_ignored: bool,
 }
 
 impl ScalarField {
@@ -335,6 +342,7 @@ impl ScalarField {
             is_generated: false,
             is_updated_at: false,
             is_commented_out: false,
+            is_ignored: false,
         }
     }
     /// Creates a new field with the given name and type, marked as generated and optional.
@@ -400,6 +408,9 @@ impl WithDatabaseName for ScalarField {
 
 impl Ignorable for Field {
     fn is_ignored(&self) -> bool {
-        false
+        match self {
+            Field::RelationField(rf) => rf.is_ignored,
+            Field::ScalarField(sf) => sf.is_ignored,
+        }
     }
 }

--- a/libs/datamodel/core/src/transform/ast_to_dml/standardise.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/standardise.rs
@@ -226,6 +226,7 @@ impl Standardiser {
                     };
                     let mut back_relation_field = dml::RelationField::new_generated(&model.name, relation_info);
                     back_relation_field.arity = dml::FieldArity::List;
+                    back_relation_field.is_ignored = model.is_ignored;
 
                     result.push(AddMissingBackRelationField {
                         model: rel_info.to.clone(),

--- a/libs/datamodel/core/src/transform/ast_to_dml/validate.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validate.rs
@@ -56,10 +56,6 @@ impl<'a> Validator<'a> {
                 errors_for_model.push_error(err);
             }
 
-            if let Err(err) = self.validate_embedded_types_have_no_back_relation(ast_schema, schema, model) {
-                errors_for_model.push_error(err);
-            }
-
             if let Err(ref mut the_errors) =
                 self.validate_field_arities(ast_schema.find_model(&model.name).expect(STATE_ERROR), model)
             {
@@ -504,36 +500,6 @@ impl<'a> Validator<'a> {
         } else {
             Ok(())
         }
-    }
-
-    /// Ensures that embedded types do not have back relations
-    /// to their parent types.
-    fn validate_embedded_types_have_no_back_relation(
-        &self,
-        ast_schema: &ast::SchemaAst,
-        datamodel: &dml::Datamodel,
-        model: &dml::Model,
-    ) -> Result<(), DatamodelError> {
-        if model.is_embedded {
-            for field in model.relation_fields() {
-                if !field.is_generated {
-                    let rel_info = &field.relation_info;
-                    // TODO: I am not sure if this check is d'accord with the query engine.
-                    let related_field = datamodel.find_related_field_bang(&field);
-
-                    if rel_info.references.is_empty() && !related_field.is_generated {
-                        // TODO: Refactor that out, it's way too much boilerplate.
-                        return Err(DatamodelError::new_model_validation_error(
-                            "Embedded models cannot have back relation fields.",
-                            &model.name,
-                            ast_schema.find_field(&model.name, &field.name).expect(STATE_ERROR).span,
-                        ));
-                    }
-                }
-            }
-        }
-
-        Ok(())
     }
 
     fn validate_base_fields_for_relation(

--- a/libs/datamodel/core/src/transform/attributes/ignore.rs
+++ b/libs/datamodel/core/src/transform/attributes/ignore.rs
@@ -1,7 +1,9 @@
 use super::{super::helpers::*, AttributeValidator};
 use crate::diagnostics::DatamodelError;
+use crate::Field::{RelationField, ScalarField};
 use crate::Ignorable;
 use crate::{ast, dml, Datamodel};
+
 /// Prismas builtin `@ignore` attribute.
 pub struct IgnoreAttributeValidator {}
 
@@ -28,15 +30,10 @@ impl AttributeValidator<dml::Field> for IgnoreAttributeValidatorForField {
         ATTRIBUTE_NAME
     }
 
-    fn validate_and_apply(&self, args: &mut Arguments, obj: &mut dml::Field) -> Result<(), DatamodelError> {
-        if obj.is_relation() {
-            return self.new_attribute_validation_error(
-                &format!(
-                    "The attribute `@{}` can not be used on relation fields.",
-                    ATTRIBUTE_NAME
-                ),
-                args.span(),
-            );
+    fn validate_and_apply(&self, _args: &mut Arguments, obj: &mut dml::Field) -> Result<(), DatamodelError> {
+        match obj {
+            ScalarField(sf) => sf.is_ignored = true,
+            RelationField(rf) => rf.is_ignored = true,
         }
         Ok(())
     }

--- a/libs/datamodel/core/src/transform/attributes/mod.rs
+++ b/libs/datamodel/core/src/transform/attributes/mod.rs
@@ -41,6 +41,7 @@ fn new_builtin_field_attributes() -> AttributeListValidator<dml::Field> {
     validator.add(Box::new(updated_at::UpdatedAtAttributeValidator {}));
     validator.add(Box::new(map::MapAttributeValidatorForField {}));
     validator.add(Box::new(relation::RelationAttributeValidator {}));
+    validator.add(Box::new(ignore::IgnoreAttributeValidatorForField {}));
 
     validator
 }

--- a/libs/datamodel/core/src/transform/dml_to_ast/lower.rs
+++ b/libs/datamodel/core/src/transform/dml_to_ast/lower.rs
@@ -75,7 +75,6 @@ impl<'a> LowerDmlToAst<'a> {
 
     pub fn lower_field(&self, field: &dml::Field, datamodel: &dml::Datamodel) -> ast::Field {
         let mut attributes = self.attributes.field.serialize(field, datamodel);
-
         if let (Some((scalar_type, native_type)), Some(datasource)) = (
             field.as_scalar_field().and_then(|sf| sf.field_type.as_native_type()),
             self.datasource,

--- a/libs/datamodel/core/tests/reformat/reformat.rs
+++ b/libs/datamodel/core/tests/reformat/reformat.rs
@@ -883,7 +883,6 @@ fn db_generated_is_allowed() {
 fn reformatting_ignore_with_relations_works() {
     let input = r#"model client {
   client_id                 Int                         @id
-   // order                 order[]
 }
 
 /// The underlying table does not contain a valid unique identifier and can therefore currently not be handled by the Prisma Client.
@@ -905,7 +904,8 @@ model bill {
 
     let expected = r#"model client {
   client_id Int     @id
-  // order                 order[]
+  order     order[] @ignore
+  bill      bill[]  @ignore
 }
 
 /// The underlying table does not contain a valid unique identifier and can therefore currently not be handled by the Prisma Client.

--- a/libs/datamodel/core/tests/reformat/reformat.rs
+++ b/libs/datamodel/core/tests/reformat/reformat.rs
@@ -879,6 +879,55 @@ fn db_generated_is_allowed() {
     assert_reformat(input, expected);
 }
 
+#[test]
+fn reformatting_ignore_with_relations_works() {
+    let input = r#"model client {
+  client_id                 Int                         @id
+   // order                 order[]
+}
+
+/// The underlying table does not contain a valid unique identifier and can therefore currently not be handled by the Prisma Client.
+model order {
+  client_id                  Int?
+  client                     client?  @relation(fields: [client_id], references: [client_id])
+
+  @@ignore
+}
+
+/// The underlying table does not contain a valid unique identifier and can therefore currently not be handled by the Prisma Client.
+model bill {
+  client_id                  Int?
+  client                     client?  @relation(fields: [client_id], references: [client_id])
+
+  @@ignore
+}
+"#;
+
+    let expected = r#"model client {
+  client_id Int     @id
+  // order                 order[]
+}
+
+/// The underlying table does not contain a valid unique identifier and can therefore currently not be handled by the Prisma Client.
+model order {
+  client_id Int?
+  client    client? @relation(fields: [client_id], references: [client_id])
+
+  @@ignore
+}
+
+/// The underlying table does not contain a valid unique identifier and can therefore currently not be handled by the Prisma Client.
+model bill {
+  client_id Int?
+  client    client? @relation(fields: [client_id], references: [client_id])
+
+  @@ignore
+}
+"#;
+
+    assert_reformat(input, expected);
+}
+
 fn assert_reformat(schema: &str, expected_result: &str) {
     println!("schema: {:?}", schema);
     let result = datamodel::ast::reformat::Reformatter::new(&schema).reformat_to_string();

--- a/libs/prisma-models/src/datamodel_converter.rs
+++ b/libs/prisma-models/src/datamodel_converter.rs
@@ -1,5 +1,5 @@
 use crate::*;
-use datamodel::{dml, DefaultValue, WithDatabaseName};
+use datamodel::{dml, DefaultValue, Ignorable, WithDatabaseName};
 use itertools::Itertools;
 
 pub struct DatamodelConverter<'a> {
@@ -73,6 +73,7 @@ impl<'a> DatamodelConverter<'a> {
     fn convert_fields(&self, model: &dml::Model) -> Vec<FieldTemplate> {
         model
             .fields()
+            .filter(|field| !field.is_ignored())
             .filter_map(|field| match field {
                 dml::Field::RelationField(rf) => {
                     let relation = self
@@ -157,8 +158,8 @@ impl<'a> DatamodelConverter<'a> {
 
     pub fn calculate_relations(datamodel: &dml::Datamodel) -> Vec<TempRelationHolder> {
         let mut result = Vec::new();
-        for model in datamodel.models() {
-            for field in model.relation_fields() {
+        for model in datamodel.models().filter(|model| !model.is_ignored) {
+            for field in model.relation_fields().filter(|field| !field.is_ignored) {
                 let dml::RelationInfo {
                     to, references, name, ..
                 } = &field.relation_info;


### PR DESCRIPTION
Introspection and the reformatter will now automatically add @ignore on backrelationfields pointing to ignored models. This is necessary since much of our code depends on there always being two relationfields. Since we now no longer comment out ignored models, their relationfields are present and need an opposite.

The QE engine should not be aware of these fields and relations since they are dropped in the datamodel converter. 