### PR TITLE
[DoNotMerge] Only create a new relationname for a relationfield with one if there …

### DIFF
--- a/introspection-engine/connectors/sql-introspection-connector/src/calculate_datamodel.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/calculate_datamodel.rs
@@ -33,9 +33,11 @@ pub fn calculate_datamodel(
     // deduplicating relation field names
     deduplicate_relation_field_names(&mut data_model);
 
+    tracing::debug!("Enriching datamodel previous datamodel: {:#?}", previous_data_model);
+    tracing::debug!("Enriching datamodel introspected datamodel: {:#?}", data_model);
     let mut warnings = vec![];
     warnings.append(&mut enrich(previous_data_model, &mut data_model, family));
-    tracing::debug!("Enriching datamodel is done: {:?}", data_model);
+    tracing::debug!("Enriching datamodel is done. Resulting datamodel: {:#?}", data_model);
 
     // commenting out models, fields, enums, enum values
     warnings.append(&mut commenting_out_guardrails(&mut data_model, family, native_types));

--- a/introspection-engine/connectors/sql-introspection-connector/src/re_introspection.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/re_introspection.rs
@@ -112,7 +112,6 @@ pub fn enrich(old_data_model: &Datamodel, new_data_model: &mut Datamodel, family
                         let old_related_field = &old_data_model.find_related_field_bang(&old_field);
                         //the relationinfos of both sides need to be compared since the relationinfo of the
                         // non-fk side does not contain enough information to uniquely identify the correct relationfield
-
                         let relation_info_partial_eq = old_field.relation_info == field.relation_info
                             && old_related_field.relation_info == related_field.relation_info;
                         let many_to_many = old_field.is_list() && old_related_field.is_list();
@@ -140,7 +139,7 @@ pub fn enrich(old_data_model: &Datamodel, new_data_model: &mut Datamodel, family
 
     //keep old virtual relation names on non M:N relations
     // M:N relations cannot be uniquely identified without ignoring the relationname and their relationnames cant
-    // be changed without necessitation db changes since RelationName -> Join table name
+    // be changed without necessitating db changes since RelationName -> Join table name
 
     let mut changed_relation_names = vec![];
     {

--- a/introspection-engine/introspection-engine-tests/tests/re_introspection/mod.rs
+++ b/introspection-engine/introspection-engine-tests/tests/re_introspection/mod.rs
@@ -1682,7 +1682,6 @@ async fn custom_relation_names(api: &TestApi) -> crate::TestResult {
 
     let result = api.re_introspect(input_dm).await?;
 
-
     assert_eq_datamodels!(final_dm, &result);
 
     Ok(())

--- a/libs/datamodel/connectors/dml/src/relation_info.rs
+++ b/libs/datamodel/connectors/dml/src/relation_info.rs
@@ -15,7 +15,7 @@ pub struct RelationInfo {
 }
 
 impl PartialEq for RelationInfo {
-    //ignores the relation name for reintrospection
+    //ignores the relation name for re-introspection
     fn eq(&self, other: &Self) -> bool {
         self.to == other.to
             && self.fields == other.fields

--- a/libs/datamodel/core/src/transform/ast_to_dml/standardise.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/standardise.rs
@@ -369,7 +369,7 @@ impl Standardiser {
                         .collect();
 
                     let rel_name = match related_fields.as_slice() {
-                        [rf] if !rf.name.is_empty() => rf.relation_info.name.clone(),
+                        [rf] if !rf.relation_info.name.is_empty() => rf.relation_info.name.clone(),
                         _ => RelationNames::name_for_unambiguous_relation(&model.name, &field.relation_info.to),
                     };
 

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline.rs
@@ -40,6 +40,7 @@ impl<'a, 'b> ValidationPipeline<'a, 'b> {
         if let Err(mut err) = precheck::Precheck::precheck(&ast_schema) {
             diagnostics.append(&mut err);
         }
+        tracing::debug!("Prechecked AST: {:#?}", ast_schema);
 
         // Early return so that the validator does not have to deal with invalid schemas
         if diagnostics.has_errors() {
@@ -55,6 +56,7 @@ impl<'a, 'b> ValidationPipeline<'a, 'b> {
             }
             Ok(schema) => schema,
         };
+        tracing::debug!("AST lifted to DML: {:#?}", schema);
 
         // Phase 4: Validation
         if let Err(mut err) = self.validator.validate(ast_schema, &mut schema) {
@@ -71,6 +73,7 @@ impl<'a, 'b> ValidationPipeline<'a, 'b> {
         if let Err(mut err) = self.standardiser.standardise(ast_schema, &mut schema) {
             diagnostics.append(&mut err);
         }
+        tracing::debug!("Standardized DML: {:#?}", schema);
 
         // Early return so that the post validation does not have to deal with invalid schemas
         if diagnostics.has_errors() {


### PR DESCRIPTION
…is no opposing field that already has one.

Fixes https://github.com/prisma/prisma/issues/4822