### PR TITLE
Apply clippy lints

### DIFF
--- a/libs/datamodel/core/src/lib.rs
+++ b/libs/datamodel/core/src/lib.rs
@@ -267,7 +267,7 @@ pub fn render_schema_ast_to_string(schema: &SchemaAst) -> String {
 
 /// Renders as a string into the stream.
 pub fn render_datamodel_to(stream: &mut dyn std::io::Write, datamodel: &dml::Datamodel) {
-    let lowered = LowerDmlToAst::new(None, &vec![]).lower(datamodel);
+    let lowered = LowerDmlToAst::new(None, &[]).lower(datamodel);
     render_schema_ast_to(stream, &lowered, 2);
 }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mssql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mssql_renderer.rs
@@ -423,7 +423,7 @@ fn render_column_type(column: &ColumnWalker<'_>) -> Cow<'static, str> {
     }
 
     if let ColumnTypeFamily::Unsupported(description) = &column.column_type().family {
-        return format!("{}", description).into();
+        return description.to_string().into();
     }
 
     let native_type = column

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
@@ -395,7 +395,7 @@ fn render_column_type(column: &ColumnWalker<'_>) -> Cow<'static, str> {
     }
 
     if let ColumnTypeFamily::Unsupported(description) = &column.column_type().family {
-        return format!("{}", description).into();
+        return description.to_string().into();
     }
 
     let native_type = column

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
@@ -257,12 +257,12 @@ fn column_for_scalar_field(field: &ScalarFieldWalker<'_>, flavour: &dyn SqlFlavo
                 default: field
                     .default_value()
                     .and_then(|default| default.as_single().and_then(|v| v.as_enum_value()))
-                    .and_then(|value| {
+                    .map(|value| {
                         let corresponding_value = r#enum.value(value).expect("Could not find enum value");
 
-                        Some(sql::DefaultValue::value(PrismaValue::Enum(
+                        sql::DefaultValue::value(PrismaValue::Enum(
                             corresponding_value.final_database_name().to_owned(),
-                        )))
+                        ))
                     }),
                 auto_increment: false,
             }
@@ -329,7 +329,5 @@ fn column_arity(arity: FieldArity) -> sql::ColumnArity {
 }
 
 fn db_generated(default: &DefaultValue) -> Option<sql::DefaultValue> {
-    default
-        .db_generated_description()
-        .map(|description| sql::DefaultValue::db_generated(description))
+    default.db_generated_description().map(sql::DefaultValue::db_generated)
 }

--- a/migration-engine/migration-engine-tests/src/sql/quaint_result_set_ext.rs
+++ b/migration-engine/migration-engine-tests/src/sql/quaint_result_set_ext.rs
@@ -84,6 +84,7 @@ impl<'a> RowAssertion<'a> {
         Ok(self)
     }
 
+    #[allow(clippy::float_cmp)]
     pub fn assert_float_value(self, column_name: &str, expected_value: f64) -> AssertionResult<Self> {
         let actual_value = self
             .0

--- a/migration-engine/migration-engine-tests/tests/migrations/squashing_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/squashing_tests.rs
@@ -237,19 +237,17 @@ async fn squashing_migrations_history_at_the_start_works(api: &TestApi) -> TestR
             }
         "#;
 
-        let mut migrations_counter: i32 = 0;
         let mut initial_migration_names: Vec<String> = Vec::with_capacity(3);
 
-        for schema in &[dm1, dm2, dm3] {
+        for (count, schema) in [dm1, dm2, dm3].iter().enumerate() {
             let name = api
-                .create_migration(&format!("migration{}", migrations_counter), schema, &directory)
+                .create_migration(&format!("migration{}", count), schema, &directory)
                 .send()
                 .await?
                 .into_output()
                 .generated_migration_name
                 .unwrap();
 
-            migrations_counter += 1;
             initial_migration_names.push(name);
         }
 

--- a/query-engine/core/src/query_graph_builder/write/nested/set_nested.rs
+++ b/query-engine/core/src/query_graph_builder/write/nested/set_nested.rs
@@ -3,7 +3,8 @@ use crate::{query_ast::*, query_graph::*, ParsedInputValue};
 use connector::Filter;
 use itertools::Itertools;
 use prisma_models::{ModelRef, RelationFieldRef};
-use std::{collections::HashSet, convert::TryInto, iter::FromIterator, sync::Arc};
+use std::convert::TryInto;
+use std::sync::Arc;
 
 /// Only for x-to-many relations.
 ///
@@ -229,7 +230,7 @@ fn handle_one_to_many(
             child_model_identifier.clone(),
             Box::new(move |mut diff_node, child_ids| {
                 if let Node::Computation(Computation::Diff(ref mut diff)) = diff_node {
-                    diff.left = HashSet::from_iter(child_ids.into_iter());
+                    diff.left = child_ids.into_iter().collect();
                 }
 
                 Ok(diff_node)
@@ -245,7 +246,7 @@ fn handle_one_to_many(
             child_model_identifier,
             Box::new(move |mut diff_node, child_ids| {
                 if let Node::Computation(Computation::Diff(ref mut diff)) = diff_node {
-                    diff.right = HashSet::from_iter(child_ids.into_iter());
+                    diff.right = child_ids.into_iter().collect();
                 }
 
                 Ok(diff_node)

--- a/query-engine/query-engine/src/tests/dmmf/unsupported.rs
+++ b/query-engine/query-engine/src/tests/dmmf/unsupported.rs
@@ -165,9 +165,9 @@ fn no_find_unique_when_model_only_has_unsupported_index_or_compound() {
         .unwrap();
     let field_names: Vec<&str> = query_type.fields.iter().map(|f| f.name.as_str()).collect();
 
-    assert!(field_names.contains(&"findUniqueItemA") == false);
-    assert!(field_names.contains(&"findUniqueItemB") == false);
-    assert!(field_names.contains(&"findUniqueItemC") == false);
+    assert!(!field_names.contains(&"findUniqueItemA"));
+    assert!(!field_names.contains(&"findUniqueItemB"));
+    assert!(!field_names.contains(&"findUniqueItemC"));
 }
 
 // Write
@@ -203,7 +203,7 @@ fn no_create_or_upsert_should_exist_with_unsupported_field_without_default_value
     let unsupported_ops: [&str; 3] = ["createOne", "createMany", "upsertOne"];
     unsupported_ops.iter().for_each(|op| {
         assert!(
-            field_names.contains(&format!("{}Item", *op).as_str()) == false,
+            !field_names.contains(&format!("{}Item", *op).as_str()),
             format!("operation '{}' should not be supported", op)
         );
     });


### PR DESCRIPTION
This patch applies another round of clippy. The only lint I found non-obvious was [`float_cmp`](https://rust-lang.github.io/rust-clippy/master/index.html#float_cmp); but that seems reasonable and prevents odd rounding errors in floats. Thanks!