### PR TITLE
Do not panic in certain index validations

### DIFF
--- a/libs/datamodel/core/src/ast/attribute.rs
+++ b/libs/datamodel/core/src/ast/attribute.rs
@@ -15,6 +15,10 @@ impl Attribute {
             span: Span::empty(),
         }
     }
+
+    pub fn is_index(&self) -> bool {
+        matches!(self.name.name.as_str(), "index" | "unique")
+    }
 }
 
 impl WithIdentifier for Attribute {

--- a/libs/datamodel/core/src/transform/ast_to_dml/validate.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validate.rs
@@ -218,8 +218,9 @@ impl<'a> Validator<'a> {
                             let ast_index = ast_model
                                 .attributes
                                 .iter()
-                                .find(|attribute| attribute.name.name == "index")
+                                .find(|attribute| attribute.is_index())
                                 .unwrap();
+
                             errors.push_error(DatamodelError::new_multiple_indexes_with_same_name_are_not_supported(
                                 index_name,
                                 ast_index.span,

--- a/libs/datamodel/core/tests/attributes/index.rs
+++ b/libs/datamodel/core/tests/attributes/index.rs
@@ -186,6 +186,41 @@ fn multiple_indexes_with_same_name_are_not_supported_by_postgres() {
         id Int @id
         optionId Int
 
+        @@index([id], name: "MyIndexName")
+     }
+    "#;
+
+    let errors = parse_error(dml);
+    for error in errors.errors.iter() {
+        println!("DATAMODEL ERROR: {:?}", error);
+    }
+
+    errors.assert_length(1);
+    errors.assert_is_at(
+        0,
+        DatamodelError::new_multiple_indexes_with_same_name_are_not_supported("MyIndexName", Span::new(285, 317)),
+    );
+}
+
+#[test]
+fn unique_insert_with_same_name_are_not_supported_by_postgres() {
+    let dml = r#"
+    datasource postgres {
+        provider = "postgres"
+        url = "postgres://asdlj"
+    }
+
+    model User {
+        id         Int @id
+        neighborId Int
+
+        @@index([id], name: "MyIndexName")
+     }
+
+     model Post {
+        id Int @id
+        optionId Int
+
         @@unique([id], name: "MyIndexName")
      }
     "#;

--- a/libs/datamodel/core/tests/attributes/index.rs
+++ b/libs/datamodel/core/tests/attributes/index.rs
@@ -186,7 +186,7 @@ fn multiple_indexes_with_same_name_are_not_supported_by_postgres() {
         id Int @id
         optionId Int
 
-        @@index([id], name: "MyIndexName")
+        @@unique([id], name: "MyIndexName")
      }
     "#;
 
@@ -198,7 +198,7 @@ fn multiple_indexes_with_same_name_are_not_supported_by_postgres() {
     errors.assert_length(1);
     errors.assert_is_at(
         0,
-        DatamodelError::new_multiple_indexes_with_same_name_are_not_supported("MyIndexName", Span::new(285, 317)),
+        DatamodelError::new_multiple_indexes_with_same_name_are_not_supported("MyIndexName", Span::new(285, 318)),
     );
 }
 


### PR DESCRIPTION
If we have two models:

```prisma
model A {
  id Int @id @derfault(autoincrement())
  b  Int

  @@index([b], name: "foo")
}

model B {
  id Int @id @derfault(autoincrement())
  a  Int

  @@unique([a], name: "foo")
}
```

Both models will have an index with a same name, but the data we only looked with the attribute name `index`, not with `unique`. On PostgreSQL this is a validation error, but instead we panic.

Closes: https://github.com/prisma/prisma/issues/5171