### PR TITLE
Apply Clippy lints

### DIFF
--- a/libs/datamodel/core/src/lib.rs
+++ b/libs/datamodel/core/src/lib.rs
@@ -70,6 +70,9 @@
 //!                       └──────────────────┘
 //!</pre>
 //!
+
+#![allow(clippy::module_inception)]
+
 #[macro_use]
 extern crate tracing;
 

--- a/libs/datamodel/core/tests/mod.rs
+++ b/libs/datamodel/core/tests/mod.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::module_inception)]
+
 pub mod attributes;
 pub mod base;
 pub mod capabilities;

--- a/libs/prisma-inflector/src/rules.rs
+++ b/libs/prisma-inflector/src/rules.rs
@@ -8,7 +8,7 @@ pub trait Pluralize {
 #[derive(Debug)]
 pub enum Rule {
     Category(CategoryRule),
-    Regex(RegexRule),
+    Regex(Box<RegexRule>),
 }
 
 impl Rule {
@@ -21,7 +21,7 @@ impl Rule {
     }
 
     pub fn regex(singular: Regex, plural: String) -> Rule {
-        Rule::Regex(RegexRule { singular, plural })
+        Rule::Regex(Box::new(RegexRule { singular, plural }))
     }
 }
 

--- a/query-engine/core/src/interpreter/expression.rs
+++ b/query-engine/core/src/interpreter/expression.rs
@@ -11,7 +11,7 @@ pub enum Expression {
     },
 
     Query {
-        query: Query,
+        query: Box<Query>,
     },
 
     Let {
@@ -34,7 +34,7 @@ pub enum Expression {
     },
 
     Return {
-        result: ExpressionResult,
+        result: Box<ExpressionResult>,
     },
 }
 

--- a/query-engine/core/src/interpreter/expressionista.rs
+++ b/query-engine/core/src/interpreter/expressionista.rs
@@ -57,7 +57,7 @@ impl Expressionista {
         let node_id = node.id();
         let node = graph.pluck_node(&node);
         let into_expr = Box::new(|node: Node| {
-            let query: Query = node.try_into()?;
+            let query: Box<Query> = Box::new(node.try_into()?);
             Ok(Expression::Query { query })
         });
 
@@ -172,10 +172,10 @@ impl Expressionista {
                         let right_diff: Vec<&RecordProjection> = right.difference(&left).collect();
 
                         Ok(Expression::Return {
-                            result: ExpressionResult::Computation(ComputationResult::Diff(DiffResult {
+                            result: Box::new(ExpressionResult::Computation(ComputationResult::Diff(DiffResult {
                                 left: left_diff.into_iter().map(Clone::clone).collect(),
                                 right: right_diff.into_iter().map(Clone::clone).collect(),
-                            })),
+                            }))),
                         })
                     }
                     _ => unreachable!(),
@@ -290,8 +290,8 @@ impl Expressionista {
 
             if let Flow::Return(result) = flow {
                 let result = match result {
-                    Some(r) => ExpressionResult::RawProjections(r),
-                    None => ExpressionResult::Empty,
+                    Some(r) => Box::new(ExpressionResult::RawProjections(r)),
+                    None => Box::new(ExpressionResult::Empty),
                 };
 
                 Ok(Expression::Return { result })

--- a/query-engine/core/src/interpreter/formatters.rs
+++ b/query-engine/core/src/interpreter/formatters.rs
@@ -9,7 +9,7 @@ pub fn format_expression(expr: &Expression, indent: usize) -> String {
             .collect::<Vec<String>>()
             .join("\n"),
 
-        Expression::Query { query } => match query {
+        Expression::Query { query } => match &**query {
             Query::Read(rq) => add_indent(indent, format!("{}", rq)),
             Query::Write(wq) => add_indent(indent, format!("{}", wq)),
         },

--- a/query-engine/core/src/interpreter/query_interpreters/read.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/read.rs
@@ -38,24 +38,25 @@ fn read_one<'conn, 'tx>(
                 let records: ManyRecords = record.into();
                 let nested: Vec<QueryResult> = process_nested(tx, query.nested, Some(&records)).await?;
 
-                Ok(QueryResult::RecordSelection(RecordSelection {
+                Ok(RecordSelection {
                     name: query.name,
                     fields: query.selection_order,
                     scalars: records,
                     nested,
                     model_id,
                     query_arguments: QueryArguments::new(model),
-                }))
+                }
+                .into())
             }
 
-            None => Ok(QueryResult::RecordSelection(RecordSelection {
+            None => Ok(QueryResult::RecordSelection(Box::new(RecordSelection {
                 name: query.name,
                 fields: query.selection_order,
                 model_id,
                 scalars: ManyRecords::default(),
                 nested: vec![],
                 query_arguments: QueryArguments::new(model),
-            })),
+            }))),
         }
     };
 
@@ -88,14 +89,15 @@ fn read_many<'a, 'b>(
         let model_id = query.model.primary_identifier();
         let nested: Vec<QueryResult> = process_nested(tx, query.nested, Some(&scalars)).await?;
 
-        Ok(QueryResult::RecordSelection(RecordSelection {
+        Ok(RecordSelection {
             name: query.name,
             fields: query.selection_order,
             query_arguments: query.args,
             model_id,
             scalars,
             nested,
-        }))
+        }
+        .into())
     };
 
     fut.boxed()
@@ -131,14 +133,15 @@ fn read_related<'a, 'b>(
         let model_id = model.primary_identifier();
         let nested: Vec<QueryResult> = process_nested(tx, query.nested, Some(&scalars)).await?;
 
-        Ok(QueryResult::RecordSelection(RecordSelection {
+        Ok(RecordSelection {
             name: query.name,
             fields: query.selection_order,
             query_arguments: query.args,
             model_id,
             scalars,
             nested,
-        }))
+        }
+        .into())
     };
 
     fut.boxed()

--- a/query-engine/core/src/lib.rs
+++ b/query-engine/core/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::module_inception)]
 #![warn(warnings)] // Todo deny warnings once done
 
 #[macro_use]

--- a/query-engine/core/src/query_graph/mod.rs
+++ b/query-engine/core/src/query_graph/mod.rs
@@ -523,13 +523,10 @@ impl QueryGraph {
                 {
                     // Exception rule: Only swap `Then` and `Else` edges.
                     Node::Flow(Flow::If(_)) => {
-                        let do_swap = match self.edge_content(&parent_edge) {
-                            Some(QueryGraphDependency::Then) => true,
-                            Some(QueryGraphDependency::Else) => true,
-                            _ => false,
-                        };
-
-                        if do_swap {
+                        if matches!(
+                            self.edge_content(&parent_edge),
+                            Some(QueryGraphDependency::Then) | Some(QueryGraphDependency::Else)
+                        ) {
                             let content = self
                                 .remove_edge(parent_edge)
                                 .expect("Expected edges between marked nodes to be non-empty.");

--- a/query-engine/core/src/response_ir/internal.rs
+++ b/query-engine/core/src/response_ir/internal.rs
@@ -40,7 +40,7 @@ pub fn serialize_internal(
     is_list: bool,
 ) -> crate::Result<CheckedItemsWithParents> {
     match result {
-        QueryResult::RecordSelection(rs) => serialize_record_selection(rs, field, &field.field_type, is_list),
+        QueryResult::RecordSelection(rs) => serialize_record_selection(*rs, field, &field.field_type, is_list),
         QueryResult::RecordAggregations(ras) => serialize_aggregations(field, ras),
 
         QueryResult::Count(c) => {

--- a/query-engine/core/src/result_ast/mod.rs
+++ b/query-engine/core/src/result_ast/mod.rs
@@ -5,7 +5,7 @@ use prisma_models::{ManyRecords, ModelProjection, RecordProjection};
 pub enum QueryResult {
     Id(Option<RecordProjection>),
     Count(usize),
-    RecordSelection(RecordSelection),
+    RecordSelection(Box<RecordSelection>),
     Json(serde_json::Value),
     RecordAggregations(RecordAggregations),
     Unit,
@@ -32,6 +32,12 @@ pub struct RecordSelection {
 
     /// Model projection that can be used to retrieve the IDs of the contained records.
     pub model_id: ModelProjection,
+}
+
+impl From<RecordSelection> for QueryResult {
+    fn from(selection: RecordSelection) -> Self {
+        QueryResult::RecordSelection(Box::new(selection))
+    }
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## Summary
Applies another round of clippy lints. After we merge this there are only 4 lints missing before we can turn on CI -- all of which are non-trivial, and may either need their own PRs, or need to be disabled. But that puts us in a good spot.

## Config
I also took a look at `clippy.toml`, and it seems there's no way to disable individual lints through config. Instead I've disabled the `clippy::module_inception` lint at the crate level for the few crates which were flagged. We talked about this in an engines meeting at the start of the year, and we felt that this was one lint that we unanimously agreed on had no value for us.

Thanks!