### PR TITLE
remove hash fragment from url in error

### DIFF
--- a/libs/user-facing-errors/src/migration_engine.rs
+++ b/libs/user-facing-errors/src/migration_engine.rs
@@ -31,7 +31,7 @@ struct MigrationRollback {
 #[derive(Debug, UserFacingError, Serialize)]
 #[user_facing(
     code = "P3003",
-    message = "The format of migrations changed, the saved migrations are no longer valid. To solve this problem, please follow the steps at: https://pris.ly/d/migrate#troubleshooting"
+    message = "The format of migrations changed, the saved migrations are no longer valid. To solve this problem, please follow the steps at: https://pris.ly/d/migrate"
 )]
 pub struct DatabaseMigrationFormatChanged;
 


### PR DESCRIPTION
These errors end up in the https://www.prisma.io/docs/reference/api-reference/error-reference and should have the correct URL.