### PR TITLE
An example of standardization problems on migrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -820,6 +820,7 @@ dependencies = [
  "cuid",
  "datamodel-connector",
  "dml",
+ "enumflags2",
  "indoc",
  "itertools",
  "native-types",

--- a/introspection-engine/introspection-engine-tests/src/lib.rs
+++ b/introspection-engine/introspection-engine-tests/src/lib.rs
@@ -17,8 +17,10 @@ macro_rules! assert_eq_schema {
 #[macro_export]
 macro_rules! assert_eq_datamodels {
     ($left:expr, $right:expr) => {
-        let parsed_expected = datamodel::parse_datamodel($left).unwrap().subject;
-        let parsed_result = datamodel::parse_datamodel($right).unwrap().subject;
+        let validator = datamodel::diagnostics::Validator::<datamodel::dml::Datamodel>::new();
+
+        let parsed_expected = validator.parse_str($left).unwrap().subject;
+        let parsed_result = validator.parse_str($right).unwrap().subject;
 
         let reformatted_expected = datamodel::render_datamodel_to_string(&parsed_expected);
         let reformatted_result = datamodel::render_datamodel_to_string(&parsed_result);

--- a/introspection-engine/introspection-engine-tests/src/test_api.rs
+++ b/introspection-engine/introspection-engine-tests/src/test_api.rs
@@ -1,5 +1,5 @@
 use crate::BarrelMigrationExecutor;
-use datamodel::{Configuration, Datamodel};
+use datamodel::{diagnostics::Validator, Configuration, Datamodel};
 use enumflags2::BitFlags;
 use eyre::{Context, Report, Result};
 use introspection_connector::{DatabaseMetadata, IntrospectionConnector, Version};
@@ -157,7 +157,7 @@ fn parse_datamodel(dm: &str) -> Result<Datamodel> {
 }
 
 fn parse_configuration(dm: &str) -> Result<Configuration> {
-    match datamodel::parse_configuration(dm) {
+    match Validator::<Configuration>::new().parse_str(dm) {
         Ok(dm) => Ok(dm.subject),
         Err(e) => Err(Report::msg(e.to_pretty_string("schema.prisma", dm))),
     }

--- a/libs/datamodel/core/Cargo.toml
+++ b/libs/datamodel/core/Cargo.toml
@@ -17,6 +17,7 @@ itertools = "0.8"
 once_cell = "1.3.1"
 pest = "2.1.3"
 pest_derive ="2.1.0"
+enumflags2 = "0.6"
 regex = "1.3.7"
 serde = {version = "1.0.90", features = ["derive"]}
 serde_json = {version = "1.0", features = ["preserve_order", "float_roundtrip"]}

--- a/libs/datamodel/core/examples/dml-to-dmmf.rs
+++ b/libs/datamodel/core/examples/dml-to-dmmf.rs
@@ -1,4 +1,5 @@
 use clap::{App, Arg};
+use datamodel::{diagnostics::Validator, Datamodel};
 use std::fs;
 
 fn main() {
@@ -17,11 +18,11 @@ fn main() {
     let file_name = matches.value_of("INPUT").unwrap();
     let file = fs::read_to_string(&file_name).unwrap_or_else(|_| panic!("Unable to open file {}", file_name));
 
-    let validated = datamodel::parse_datamodel_or_pretty_error(&file, &file_name);
+    let validator = Validator::<Datamodel>::new();
 
-    match &validated {
+    match validator.parse_str(&file) {
         Err(formatted) => {
-            println!("{}", formatted);
+            println!("{}", formatted.to_pretty_string(file_name, &file));
         }
         Ok(dml) => {
             let json = datamodel::json::dmmf::render_to_dmmf(&dml.subject);

--- a/libs/datamodel/core/examples/dml-to-mcf.rs
+++ b/libs/datamodel/core/examples/dml-to-mcf.rs
@@ -1,6 +1,7 @@
 use std::fs;
 
 use clap::{App, Arg};
+use datamodel::{Configuration, Validator};
 
 fn main() {
     let matches = App::new("Prisma Datamodel v2 to DMMF")
@@ -17,10 +18,9 @@ fn main() {
 
     let file_name = matches.value_of("INPUT").unwrap();
     let file = fs::read_to_string(&file_name).unwrap_or_else(|_| panic!("Unable to open file {}", file_name));
+    let validator = Validator::<Configuration>::new();
 
-    let res = datamodel::parse_configuration(&file);
-
-    match &res {
+    match validator.parse_str(&file) {
         Err(errors) => {
             for error in errors.to_error_iter() {
                 println!();

--- a/libs/datamodel/core/src/diagnostics/mod.rs
+++ b/libs/datamodel/core/src/diagnostics/mod.rs
@@ -2,9 +2,11 @@ mod collection;
 mod error;
 mod helper;
 mod validated;
+mod validator;
 pub(crate) mod warning;
 
 pub use collection::*;
 pub use error::DatamodelError;
 pub use validated::*;
+pub use validator::*;
 pub use warning::DatamodelWarning;

--- a/libs/datamodel/core/src/diagnostics/validated.rs
+++ b/libs/datamodel/core/src/diagnostics/validated.rs
@@ -1,6 +1,29 @@
-use crate::ast::reformat::MissingField;
-use crate::diagnostics::DatamodelWarning;
-use crate::{Configuration, Datamodel, Datasource, Generator};
+use crate::{
+    ast::reformat::MissingField,
+    diagnostics::{DatamodelWarning, Diagnostics},
+    Configuration, Datamodel, Datasource, Generator, ValidationFeature,
+};
+use enumflags2::BitFlags;
+
+pub trait ParseDatamodel {
+    fn parse_datamodel_with_flags<T>(&self, flags: T) -> Result<Validated<Datamodel>, Diagnostics>
+    where
+        T: Into<BitFlags<ValidationFeature>>;
+
+    fn parse_datamodel(&self) -> Result<Validated<Datamodel>, Diagnostics> {
+        self.parse_datamodel_with_flags(BitFlags::empty())
+    }
+}
+
+pub trait ParseConfiguration {
+    fn parse_config_with_flags<T>(&self, flags: T) -> Result<Validated<Configuration>, Diagnostics>
+    where
+        T: Into<BitFlags<ValidationFeature>>;
+
+    fn parse_config(&self) -> Result<Validated<Configuration>, Diagnostics> {
+        self.parse_config_with_flags(BitFlags::empty())
+    }
+}
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct Validated<T> {

--- a/libs/datamodel/core/src/diagnostics/validator.rs
+++ b/libs/datamodel/core/src/diagnostics/validator.rs
@@ -1,0 +1,126 @@
+use std::marker::PhantomData;
+
+use dml::datamodel::Datamodel;
+use enumflags2::BitFlags;
+
+use crate::{
+    ast,
+    transform::ast_to_dml::{DatasourceLoader, GeneratorLoader, ValidationPipeline},
+    Configuration, Diagnostics, Validated, ValidatedConfiguration, ValidationFeature,
+};
+
+#[derive(Debug, Clone)]
+pub struct Validator<T>
+where
+    T: Sized,
+{
+    flags: BitFlags<ValidationFeature>,
+    datasource_url_overrides: Vec<(String, String)>,
+    _phantom: PhantomData<T>,
+}
+
+impl<T> Validator<T> {
+    pub fn new() -> Self {
+        Self {
+            _phantom: PhantomData,
+            flags: BitFlags::empty(),
+            datasource_url_overrides: Vec::new(),
+        }
+    }
+
+    /// Override the datasource URL in the given datasource.
+    pub fn datasource_url_override(&mut self, datasource_name: impl ToString, datasource_url: impl ToString) {
+        self.datasource_url_overrides
+            .push((datasource_name.to_string(), datasource_url.to_string()));
+    }
+
+    /// Do not validate uris in the datasource part.
+    pub fn ignore_datasource_urls(&mut self) {
+        self.flags.insert(ValidationFeature::IgnoreDatasourceUrls)
+    }
+}
+
+impl Validator<Datamodel> {
+    /// Run the standardizer to modify the data model.
+    pub fn standardize_models(&mut self) {
+        self.flags.insert(ValidationFeature::StandardizeModels)
+    }
+
+    /// Parse a data model string into a validated data model.
+    pub fn parse_str(&self, schema: &str) -> Result<Validated<Datamodel>, Diagnostics> {
+        let mut diagnostics = Diagnostics::new();
+        let ast = ast::parser::parse_schema(schema)?;
+
+        let source_loader = DatasourceLoader::new(self.flags);
+        let sources = source_loader.load_datasources_from_ast(&ast, self.datasource_url_overrides.clone())?;
+
+        let generators = GeneratorLoader::load_generators_from_ast(&ast)?;
+        let validator = ValidationPipeline::new(&sources.subject, self.flags);
+
+        diagnostics.append_warning_vec(sources.warnings);
+        diagnostics.append_warning_vec(generators.warnings);
+
+        match validator.validate(&ast) {
+            Ok(mut src) => {
+                src.warnings.append(&mut diagnostics.warnings);
+                Ok(src)
+            }
+            Err(mut err) => {
+                diagnostics.append(&mut err);
+                Err(diagnostics)
+            }
+        }
+    }
+
+    /// Validates a [Schema AST](/ast/struct.SchemaAst.html) and returns its
+    /// [Datamodel](/struct.Datamodel.html).
+    pub fn lift_ast(&self, ast: &ast::SchemaAst) -> Result<Validated<Datamodel>, Diagnostics> {
+        // we are not interested in the sources in this case. Hence we can ignore the datasource urls.
+        let flags = self.flags & ValidationFeature::IgnoreDatasourceUrls;
+
+        let mut diagnostics = Diagnostics::new();
+        let source_loader = DatasourceLoader::new(flags);
+        let sources = source_loader.load_datasources_from_ast(ast, self.datasource_url_overrides.clone())?;
+
+        let generators = GeneratorLoader::load_generators_from_ast(&ast)?;
+        let validator = ValidationPipeline::new(&sources.subject, self.flags);
+
+        diagnostics.append_warning_vec(sources.warnings);
+        diagnostics.append_warning_vec(generators.warnings);
+
+        match validator.validate(&ast) {
+            Ok(mut src) => {
+                src.warnings.append(&mut diagnostics.warnings);
+                Ok(src)
+            }
+            Err(mut err) => {
+                diagnostics.append(&mut err);
+                Err(diagnostics)
+            }
+        }
+    }
+}
+
+impl Validator<Configuration> {
+    /// Parse a data model string into a validated configuration.
+    pub fn parse_str(&self, schema: &str) -> Result<Validated<Configuration>, Diagnostics> {
+        let mut warnings = Vec::new();
+        let ast = ast::parser::parse_schema(schema)?;
+        let source_loader = DatasourceLoader::new(self.flags);
+
+        let mut validated_sources =
+            source_loader.load_datasources_from_ast(&ast, self.datasource_url_overrides.clone())?;
+        let mut validated_generators = GeneratorLoader::load_generators_from_ast(&ast)?;
+
+        warnings.append(&mut validated_generators.warnings);
+        warnings.append(&mut validated_sources.warnings);
+
+        Ok(ValidatedConfiguration {
+            subject: Configuration {
+                datasources: validated_sources.subject,
+                generators: validated_generators.subject,
+            },
+            warnings,
+        })
+    }
+}

--- a/libs/datamodel/core/src/features.rs
+++ b/libs/datamodel/core/src/features.rs
@@ -1,0 +1,12 @@
+use enumflags2::BitFlags;
+
+#[derive(Debug, Clone, Copy, BitFlags, PartialEq)]
+#[repr(u8)]
+pub enum ValidationFeature {
+    // Do not validate datasoure
+    IgnoreDatasourceUrls = 0b0000_0001,
+    // Make implicit relations explicit and all that.
+    StandardizeModels = 0b0000_0010,
+    // Make errors pretty.
+    PrettifyErrors = 0b0000_0100,
+}

--- a/libs/datamodel/core/src/transform/ast_to_dml/validate.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validate.rs
@@ -797,7 +797,7 @@ impl<'a> Validator<'a> {
 
             let rel_info = &field.relation_info;
             let related_model = datamodel.find_model(&rel_info.to).expect(STATE_ERROR);
-            let related_field = datamodel.find_related_field_bang(&field);
+            let related_field = datamodel.find_related_field_bang(dbg!(&field));
             let related_field_rel_info = &related_field.relation_info;
 
             // ONE TO MANY

--- a/libs/datamodel/core/tests/attributes/index.rs
+++ b/libs/datamodel/core/tests/attributes/index.rs
@@ -1,4 +1,4 @@
-use datamodel::{ast::Span, diagnostics::*, render_datamodel_to_string, IndexDefinition, IndexType};
+use datamodel::{ast::Span, diagnostics::*, render_datamodel_to_string, Datamodel, IndexDefinition, IndexType};
 
 use crate::common::*;
 
@@ -296,7 +296,9 @@ fn index_attributes_must_serialize_to_valid_dml() {
             @@index([firstName,lastName], name: "customName")
         }
     "#;
-    let schema = parse(dml);
 
-    assert!(datamodel::parse_datamodel(&render_datamodel_to_string(&schema)).is_ok());
+    let schema = parse(dml);
+    let dml_str = render_datamodel_to_string(&schema);
+
+    assert!(Validator::<Datamodel>::new().parse_str(&dml_str).is_ok());
 }

--- a/libs/datamodel/core/tests/attributes/relations_new.rs
+++ b/libs/datamodel/core/tests/attributes/relations_new.rs
@@ -1,7 +1,9 @@
 use crate::common::*;
-use datamodel::ast::Span;
-use datamodel::diagnostics::DatamodelError;
-use datamodel::dml;
+use datamodel::{
+    ast::Span,
+    diagnostics::{DatamodelError, Validator},
+    dml, Datamodel,
+};
 use indoc::indoc;
 
 #[test]
@@ -824,11 +826,10 @@ fn must_allow_relations_with_default_native_types_with_annotation_on_one_side() 
         "#
     };
 
+    let validator = Validator::<Datamodel>::new();
+
     for dm in &[dm1, dm2, dm3] {
-        assert!(
-            datamodel::parse_datamodel(dm).is_ok(),
-            "{:?}",
-            datamodel::parse_datamodel(dm).unwrap_err()
-        );
+        let validated = validator.parse_str(dm);
+        assert!(validated.is_ok(), "{:?}", validated.unwrap_err(),);
     }
 }

--- a/libs/datamodel/core/tests/attributes/unique.rs
+++ b/libs/datamodel/core/tests/attributes/unique.rs
@@ -1,6 +1,6 @@
 #![allow(non_snake_case)]
 
-use datamodel::{ast::Span, diagnostics::*, render_datamodel_to_string, IndexDefinition, IndexType};
+use datamodel::{ast::Span, diagnostics::*, render_datamodel_to_string, Datamodel, IndexDefinition, IndexType};
 
 use crate::common::*;
 
@@ -270,7 +270,10 @@ fn unique_attributes_must_serialize_to_valid_dml() {
             @@unique([firstName,lastName], name: "customName")
         }
     "#;
-    let schema = parse(dml);
 
-    assert!(datamodel::parse_datamodel(&render_datamodel_to_string(&schema)).is_ok());
+    let schema = parse(dml);
+    let validator = Validator::<Datamodel>::new();
+    let dml_string = render_datamodel_to_string(&schema);
+
+    assert!(validator.parse_str(&dml_string).is_ok());
 }

--- a/libs/datamodel/core/tests/common.rs
+++ b/libs/datamodel/core/tests/common.rs
@@ -350,7 +350,9 @@ impl ErrorAsserts for Diagnostics {
 
 #[allow(dead_code)] // Not sure why the compiler thinks this is never used.
 pub fn parse(datamodel_string: &str) -> Datamodel {
-    match datamodel::parse_datamodel(datamodel_string) {
+    let validator = Validator::<Datamodel>::new();
+
+    match validator.parse_str(datamodel_string) {
         Ok(s) => s.subject,
         Err(errs) => {
             for err in errs.to_error_iter() {
@@ -364,7 +366,9 @@ pub fn parse(datamodel_string: &str) -> Datamodel {
 }
 
 pub fn parse_configuration(datamodel_string: &str) -> Configuration {
-    match datamodel::parse_configuration(datamodel_string) {
+    let validator = Validator::<Configuration>::new();
+
+    match validator.parse_str(datamodel_string) {
         Ok(c) => c.subject,
         Err(errs) => {
             for err in errs.to_error_iter() {
@@ -381,7 +385,13 @@ pub fn parse_configuration_with_url_overrides(
     datamodel_string: &str,
     datasource_url_overrides: Vec<(String, String)>,
 ) -> Configuration {
-    match datamodel::parse_configuration_with_url_overrides(datamodel_string, datasource_url_overrides) {
+    let mut validator = Validator::<Configuration>::new();
+
+    for (key, val) in datasource_url_overrides.into_iter() {
+        validator.datasource_url_override(key, val);
+    }
+
+    match validator.parse_str(datamodel_string) {
         Ok(c) => c.subject,
         Err(errs) => {
             for err in errs.to_error_iter() {
@@ -395,7 +405,9 @@ pub fn parse_configuration_with_url_overrides(
 }
 
 pub fn parse_with_diagnostics(datamodel_string: &str) -> ValidatedDatamodel {
-    match datamodel::parse_datamodel(datamodel_string) {
+    let validator = Validator::<Datamodel>::new();
+
+    match validator.parse_str(datamodel_string) {
         Ok(s) => s,
         Err(errs) => {
             for err in errs.to_error_iter() {
@@ -410,14 +422,19 @@ pub fn parse_with_diagnostics(datamodel_string: &str) -> ValidatedDatamodel {
 
 #[allow(dead_code)] // Not sure why the compiler thinks this is never used.
 pub fn parse_error(datamodel_string: &str) -> Diagnostics {
-    match datamodel::parse_datamodel(datamodel_string) {
+    let validator = Validator::<Datamodel>::new();
+
+    match validator.parse_str(datamodel_string) {
         Ok(_) => panic!("Expected an error when parsing schema."),
         Err(errs) => errs,
     }
 }
 
 pub fn parse_error_and_ignore_datasource_urls(datamodel_string: &str) -> Diagnostics {
-    match datamodel::parse_datamodel_and_ignore_datasource_urls(datamodel_string) {
+    let mut validator = Validator::<Datamodel>::new();
+    validator.ignore_datasource_urls();
+
+    match validator.parse_str(datamodel_string) {
         Ok(_) => panic!("Expected an error when parsing schema."),
         Err(errs) => errs,
     }

--- a/libs/datamodel/core/tests/config/generators.rs
+++ b/libs/datamodel/core/tests/config/generators.rs
@@ -1,7 +1,9 @@
-use crate::common::parse_configuration;
-use crate::common::ErrorAsserts;
-use datamodel::common::preview_features::GENERATOR_PREVIEW_FEATURES;
-use datamodel::diagnostics::DatamodelError;
+use crate::common::{parse_configuration, ErrorAsserts};
+use datamodel::{
+    common::preview_features::GENERATOR_PREVIEW_FEATURES,
+    diagnostics::{DatamodelError, Validator},
+    Configuration,
+};
 
 #[test]
 fn serialize_generators_to_cmf() {
@@ -129,7 +131,8 @@ generator js1 {
     output = "../../js"
 }
     "#;
-    let res = datamodel::parse_configuration(schema);
+
+    let res = Validator::<Configuration>::new().parse_str(schema);
 
     if let Err(diagnostics) = res {
         diagnostics.assert_is(DatamodelError::GeneratorArgumentNotFound {
@@ -151,7 +154,7 @@ fn nice_error_for_unknown_generator_preview_feature() {
     }
     "#;
 
-    let res = datamodel::parse_configuration(schema);
+    let res = Validator::<Configuration>::new().parse_str(schema);
 
     if let Err(diagnostics) = res {
         diagnostics.assert_is(DatamodelError::new_preview_feature_not_known_error(

--- a/libs/datamodel/core/tests/config/nice_warnings.rs
+++ b/libs/datamodel/core/tests/config/nice_warnings.rs
@@ -1,6 +1,9 @@
 use crate::common::*;
-use datamodel::ast::Span;
-use datamodel::diagnostics::DatamodelWarning;
+use datamodel::{
+    ast::Span,
+    diagnostics::{DatamodelWarning, Validator},
+    Configuration,
+};
 
 #[test]
 fn nice_warning_for_deprecated_generator_preview_feature() {
@@ -11,7 +14,7 @@ fn nice_warning_for_deprecated_generator_preview_feature() {
     }
     "#;
 
-    let res = datamodel::parse_configuration(schema).unwrap();
+    let res = Validator::<Configuration>::new().parse_str(schema).unwrap();
 
     res.warnings
         .assert_is(DatamodelWarning::new_deprecated_preview_feature_warning(

--- a/libs/datamodel/core/tests/functions/functionals_environment.rs
+++ b/libs/datamodel/core/tests/functions/functionals_environment.rs
@@ -1,5 +1,5 @@
 use crate::common::*;
-use datamodel::{DefaultValue, ScalarType};
+use datamodel::{diagnostics::Validator, Datamodel, DefaultValue, ScalarType};
 use prisma_value::PrismaValue;
 
 #[test]
@@ -19,14 +19,17 @@ fn skipping_of_env_vars() {
     // must fail without env var
     parse_error(dml);
 
+    let mut validator = Validator::<Datamodel>::new();
+    validator.ignore_datasource_urls();
+
     // must not fail when ignore flag is set
-    if let Err(err) = datamodel::parse_datamodel_and_ignore_datasource_urls(dml) {
+    if let Err(err) = validator.parse_str(dml) {
         panic!("Skipping env var errors did not work. Error was {:?}", err)
     }
 
     // must not fail with invalid env var set and ignore flag is set
     std::env::set_var("POSTGRES_URL", "mysql://"); // wrong protocol
-    if let Err(err) = datamodel::parse_datamodel_and_ignore_datasource_urls(dml) {
+    if let Err(err) = validator.parse_str(dml) {
         panic!("Skipping env var errors did not work. Error was {:?}", err)
     }
 

--- a/libs/datamodel/core/tests/renderer/literals.rs
+++ b/libs/datamodel/core/tests/renderer/literals.rs
@@ -1,7 +1,12 @@
-use datamodel::DefaultValue;
+use datamodel::{diagnostics::Validator, Datamodel, DefaultValue};
 use indoc::indoc;
 use pretty_assertions::assert_eq;
 use prisma_value::PrismaValue;
+
+fn parse_datamodel(input: &str) -> Datamodel {
+    let validator = Validator::<Datamodel>::new();
+    validator.parse_str(input).unwrap().subject
+}
 
 #[test]
 fn strings_with_quotes_render_as_escaped_literals() {
@@ -22,7 +27,7 @@ fn strings_with_quotes_render_as_escaped_literals() {
         "#
     );
 
-    let mut dml = datamodel::parse_datamodel(input).unwrap().subject;
+    let mut dml = parse_datamodel(input);
     let cat = dml.models_mut().find(|m| m.name == "Category").unwrap();
     let name = cat.scalar_fields_mut().find(|f| f.name == "name").unwrap();
     name.default_value = Some(DefaultValue::Single(PrismaValue::String("a \" b\"c d".into())));
@@ -43,7 +48,7 @@ fn strings_with_quotes_roundtrip() {
         "#
     );
 
-    let dml = datamodel::parse_datamodel(input).unwrap().subject;
+    let dml = parse_datamodel(input);
     let rendered = datamodel::render_datamodel_to_string(&dml);
 
     assert_eq!(input, rendered);
@@ -68,7 +73,7 @@ fn strings_with_newlines_render_as_escaped_literals() {
         "#
     );
 
-    let mut dml = datamodel::parse_datamodel(input).unwrap().subject;
+    let mut dml = parse_datamodel(input);
     let cat = dml.models_mut().find(|m| m.name == "Category").unwrap();
     let name = cat.scalar_fields_mut().find(|f| f.name == "name").unwrap();
     name.default_value = Some(DefaultValue::Single(PrismaValue::String(
@@ -91,7 +96,7 @@ fn strings_with_newlines_roundtrip() {
         "#
     );
 
-    let dml = datamodel::parse_datamodel(input).unwrap().subject;
+    let dml = parse_datamodel(input);
     let rendered = datamodel::render_datamodel_to_string(&dml);
 
     assert_eq!(input, rendered);
@@ -108,7 +113,7 @@ fn strings_with_backslashes_roundtrip() {
         "#
     );
 
-    let dml = datamodel::parse_datamodel(input).unwrap().subject;
+    let dml = parse_datamodel(input);
     let rendered = datamodel::render_datamodel_to_string(&dml);
 
     assert_eq!(input, rendered);
@@ -125,7 +130,7 @@ fn strings_with_multiple_escaped_characters_roundtrip() {
         "#
     );
 
-    let dml = datamodel::parse_datamodel(dm).unwrap().subject;
+    let dml = parse_datamodel(dm);
     let rendered = datamodel::render_datamodel_to_string(&dml);
 
     assert_eq!(dm, rendered);
@@ -148,7 +153,7 @@ fn internal_escaped_values_are_rendered_correctly() {
         "#
     );
 
-    let mut dml = datamodel::parse_datamodel(dm).unwrap().subject;
+    let mut dml = parse_datamodel(dm);
 
     let model = dml.models_mut().find(|m| m.name == "FilmQuote").unwrap();
     let field = model.scalar_fields_mut().find(|f| f.name == "id").unwrap();

--- a/libs/prisma-models/src/datamodel_converter.rs
+++ b/libs/prisma-models/src/datamodel_converter.rs
@@ -1,5 +1,5 @@
 use crate::*;
-use datamodel::{dml, DefaultValue, Ignorable, WithDatabaseName};
+use datamodel::{diagnostics::Validator, dml, Datamodel, DefaultValue, Ignorable, WithDatabaseName};
 use itertools::Itertools;
 
 pub struct DatamodelConverter<'a> {
@@ -9,8 +9,10 @@ pub struct DatamodelConverter<'a> {
 
 impl<'a> DatamodelConverter<'a> {
     pub fn convert_string(datamodel: String) -> InternalDataModelTemplate {
-        let datamodel = datamodel::parse_datamodel(&datamodel).unwrap().subject;
-        Self::convert(&datamodel)
+        let validator = Validator::<Datamodel>::new();
+        let datamodel = validator.parse_str(&datamodel).unwrap();
+
+        Self::convert(&datamodel.subject)
     }
 
     pub fn convert(datamodel: &dml::Datamodel) -> InternalDataModelTemplate {

--- a/libs/prisma-models/tests/datamodel_converter_tests.rs
+++ b/libs/prisma-models/tests/datamodel_converter_tests.rs
@@ -1,4 +1,5 @@
 #![allow(non_snake_case)]
+use datamodel::{diagnostics::Validator, Datamodel};
 use prisma_models::*;
 use std::sync::Arc;
 
@@ -490,7 +491,8 @@ fn implicit_many_to_many_relation() {
 }
 
 fn convert(datamodel: &str) -> Arc<InternalDataModel> {
-    let datamodel = datamodel::parse_datamodel(datamodel).unwrap().subject;
+    let validator = Validator::<Datamodel>::new();
+    let datamodel = validator.parse_str(datamodel).unwrap().subject;
     let template = DatamodelConverter::convert(&datamodel);
     template.build("not_important".to_string())
 }

--- a/migration-engine/core/src/lib.rs
+++ b/migration-engine/core/src/lib.rs
@@ -16,6 +16,7 @@ use commands::{MigrationCommand, SchemaPushCommand};
 pub use core_error::{CoreError, CoreResult};
 use datamodel::{
     common::provider_names::{MSSQL_SOURCE_NAME, MYSQL_SOURCE_NAME, POSTGRES_SOURCE_NAME, SQLITE_SOURCE_NAME},
+    diagnostics::Validator,
     dml::Datamodel,
     Configuration,
 };
@@ -175,13 +176,15 @@ pub async fn qe_setup(prisma_schema: &str) -> CoreResult<()> {
 }
 
 fn parse_configuration(datamodel: &str) -> CoreResult<Configuration> {
-    datamodel::parse_configuration(&datamodel)
+    Validator::<Configuration>::new()
+        .parse_str(datamodel)
         .map(|validated_config| validated_config.subject)
         .map_err(|err| CoreError::ReceivedBadDatamodel(err.to_pretty_string("schema.prisma", datamodel)))
 }
 
 fn parse_datamodel(datamodel: &str) -> CoreResult<Datamodel> {
-    datamodel::parse_datamodel(&datamodel)
+    Validator::<Datamodel>::new()
+        .parse_str(datamodel)
         .map(|d| d.subject)
         .map_err(|err| CoreError::ReceivedBadDatamodel(err.to_pretty_string("schema.prisma", datamodel)))
 }

--- a/prisma-fmt/src/native.rs
+++ b/prisma-fmt/src/native.rs
@@ -1,5 +1,7 @@
 use std::io::{self, Read};
 
+use datamodel::{diagnostics::Validator, Configuration};
+
 pub fn run() {
     let mut datamodel_string = String::new();
 
@@ -7,9 +9,9 @@ pub fn run() {
         .read_to_string(&mut datamodel_string)
         .expect("Unable to read from stdin.");
 
-    let datamodel_result = datamodel::parse_configuration_and_ignore_datasource_urls(&datamodel_string);
+    let validator = Validator::<Configuration>::new();
 
-    match datamodel_result {
+    match validator.parse_str(&datamodel_string) {
         Ok(validated_configuration) => {
             if validated_configuration.subject.datasources.len() != 1 {
                 print!("[]")

--- a/query-engine/query-engine/src/tests/errors.rs
+++ b/query-engine/query-engine/src/tests/errors.rs
@@ -1,3 +1,4 @@
+use datamodel::{diagnostics::Validator, Configuration, Datamodel};
 use indoc::formatdoc;
 use serde_json::json;
 
@@ -32,10 +33,10 @@ async fn connection_string_problems_give_a_nice_error() {
             provider.1
         );
 
-        let dml = datamodel::parse_datamodel(&dm).unwrap().subject;
-        let config = datamodel::parse_configuration(&dm).unwrap();
+        let dml = Validator::<Datamodel>::new().parse_str(&dm).unwrap().subject;
+        let config = Validator::<Configuration>::new().parse_str(&dm).unwrap().subject;
 
-        let error = PrismaContext::builder(config.subject, dml)
+        let error = PrismaContext::builder(config, dml)
             .enable_raw_queries(true)
             .build()
             .await

--- a/query-engine/query-engine/src/tests/test_api.rs
+++ b/query-engine/query-engine/src/tests/test_api.rs
@@ -3,6 +3,7 @@ use crate::{
     request_handlers::{graphql, GraphQlBody, SingleQuery},
     PrismaResponse,
 };
+use datamodel::{diagnostics::Validator, Configuration, Datamodel};
 use enumflags2::BitFlags;
 use migration_core::{
     api::{GenericApi, MigrationApi},
@@ -48,8 +49,13 @@ impl TestApi {
         feature_flags::initialize(&[String::from("all")]).unwrap();
 
         let datamodel_string = format!("{}\n\n{}", self.config, datamodel);
-        let dml = datamodel::parse_datamodel(&datamodel_string).unwrap().subject;
-        let config = datamodel::parse_configuration(&datamodel_string).unwrap();
+
+        let dml = Validator::<Datamodel>::new()
+            .parse_str(&datamodel_string)
+            .unwrap()
+            .subject;
+
+        let config = Validator::<Configuration>::new().parse_str(&datamodel_string).unwrap();
 
         self.migration_api
             .schema_push(&SchemaPushInput {


### PR DESCRIPTION
This fixes multiple issues by giving users a clear error message when we don't have proper `@relation` field attribute, but we do some standardization, might do it a bit wrong, but still try to run the migrations. It divides the paths, so formatting uses standardization for relation field names, migration and everybody else not, but instead give a validation error.

Fixes at least https://github.com/prisma/prisma/issues/5069

This is not a final solution. We should map our whole data model pipeline from the beginning, splitting it into different passes:

- parsing into raw ast
- validations
- reformatting
- standardization
- post-standardization validations
- bla

Then having them as separate modules, we must write down who needs what from the data model system, and then decide what components to run.

Examples of problems, caused by standardization of relation fields:

```prisma
datasource db {
  provider = "postgresql"
  url      = env("DATABASE_URL")
}

generator client {
  provider = "prisma-client-js"
}

model Code {
  id          String        @id
  type        String
  singleUse   Boolean
  userId      String?
  createdById String?
  createdBy   User?         
  user        User?         @relation("code", fields: [userId], references: [id])

  @@map(name: "codes")
}

model User {
  id                String            @default(dbgenerated()) @id
  name              String?
  codes             Code[]            @relation("code")

  @@map(name: "users")
}
```

This maps into SQL:

```sql
CREATE TABLE "codes" (
    "id" TEXT NOT NULL,
    "type" TEXT NOT NULL,
    "singleUse" BOOLEAN NOT NULL,
    "userId" TEXT,
    "createdById" TEXT,
    "userId" TEXT,

    PRIMARY KEY ("id")
);

-- CreateTable
CREATE TABLE "users" (
    "id" TEXT NOT NULL,
    "name" TEXT,

    PRIMARY KEY ("id")
);

-- AddForeignKey
ALTER TABLE "codes" ADD FOREIGN KEY ("userId", "userId") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;

-- AddForeignKey
ALTER TABLE "codes" ADD FOREIGN KEY ("userId", "userId") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
```

And this of course fails to migrate, and is also quite horror to debug if you don't know about magic modifications to the data model during a run.