### PR TITLE
(cleanup) Remove SqlFlavour::sql_family()

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/flavour.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour.rs
@@ -20,10 +20,7 @@ use crate::{
 use datamodel::Datamodel;
 use enumflags2::BitFlags;
 use migration_connector::{ConnectorResult, MigrationDirectory, MigrationFeature};
-use quaint::{
-    connector::ConnectionInfo,
-    prelude::{SqlFamily, Table},
-};
+use quaint::prelude::{ConnectionInfo, Table};
 use sql_schema_describer::SqlSchema;
 use std::fmt::Debug;
 
@@ -86,9 +83,6 @@ pub(crate) trait SqlFlavour:
 
     /// Drop the database and recreate it empty.
     async fn reset(&self, connection: &Connection) -> ConnectorResult<()>;
-
-    /// This should be considered deprecated.
-    fn sql_family(&self) -> SqlFamily;
 
     /// Apply the given migration history to a temporary database, and return
     /// the final introspected SQL schema.

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/mssql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/mssql.rs
@@ -3,10 +3,7 @@ use connection_string::JdbcString;
 use enumflags2::BitFlags;
 use indoc::formatdoc;
 use migration_connector::{ConnectorError, ConnectorResult, MigrationDirectory, MigrationFeature};
-use quaint::{
-    connector::MssqlUrl,
-    prelude::{SqlFamily, Table},
-};
+use quaint::{connector::MssqlUrl, prelude::Table};
 use sql_schema_describer::{DescriberErrorKind, SqlSchema, SqlSchemaDescriberBackend};
 use std::str::FromStr;
 use user_facing_errors::{introspection_engine::DatabaseSchemaInconsistent, KnownError};
@@ -175,10 +172,6 @@ impl SqlFlavour for MssqlFlavour {
         connection.raw_cmd("SELECT 1").await?;
 
         Ok(())
-    }
-
-    fn sql_family(&self) -> SqlFamily {
-        SqlFamily::Mssql
     }
 
     async fn sql_schema_from_migration_history(

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/mysql.rs
@@ -9,7 +9,7 @@ use enumflags2::BitFlags;
 use indoc::indoc;
 use migration_connector::{ConnectorError, ConnectorResult, MigrationDirectory, MigrationFeature};
 use once_cell::sync::Lazy;
-use quaint::{connector::MysqlUrl, prelude::SqlFamily};
+use quaint::connector::MysqlUrl;
 use regex::RegexSet;
 use sql_schema_describer::{DescriberErrorKind, SqlSchema, SqlSchemaDescriberBackend};
 use std::sync::atomic::{AtomicU8, Ordering};
@@ -210,10 +210,6 @@ impl SqlFlavour for MysqlFlavour {
         connection.raw_cmd(&format!("USE `{}`", db_name)).await?;
 
         Ok(())
-    }
-
-    fn sql_family(&self) -> SqlFamily {
-        SqlFamily::Mysql
     }
 
     #[tracing::instrument(skip(self, migrations, connection))]

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/postgres.rs
@@ -2,7 +2,7 @@ use crate::{connect, connection_wrapper::Connection, error::quaint_error_to_conn
 use enumflags2::BitFlags;
 use indoc::indoc;
 use migration_connector::{ConnectorError, ConnectorResult, MigrationDirectory, MigrationFeature};
-use quaint::{connector::PostgresUrl, error::ErrorKind as QuaintKind, prelude::SqlFamily};
+use quaint::{connector::PostgresUrl, error::ErrorKind as QuaintKind};
 use sql_schema_describer::{DescriberErrorKind, SqlSchema, SqlSchemaDescriberBackend};
 use std::collections::HashMap;
 use url::Url;
@@ -183,10 +183,6 @@ impl SqlFlavour for PostgresFlavour {
             .await?;
 
         Ok(())
-    }
-
-    fn sql_family(&self) -> SqlFamily {
-        SqlFamily::Postgres
     }
 
     #[tracing::instrument(skip(self, migrations, connection))]

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/sqlite.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/sqlite.rs
@@ -2,7 +2,7 @@ use crate::{connect, connection_wrapper::Connection, error::quaint_error_to_conn
 use enumflags2::BitFlags;
 use indoc::indoc;
 use migration_connector::{ConnectorError, ConnectorResult, MigrationDirectory, MigrationFeature};
-use quaint::prelude::{ConnectionInfo, SqlFamily};
+use quaint::prelude::ConnectionInfo;
 use sql_schema_describer::{DescriberErrorKind, SqlSchema, SqlSchemaDescriberBackend};
 use std::path::Path;
 
@@ -99,10 +99,6 @@ impl SqlFlavour for SqliteFlavour {
         std::fs::File::create(file_path).expect("failed to truncate sqlite file");
 
         Ok(())
-    }
-
-    fn sql_family(&self) -> SqlFamily {
-        SqlFamily::Sqlite
     }
 
     #[tracing::instrument(skip(self, migrations, _connection))]


### PR DESCRIPTION
It is not needed anywhere anymore. We use trait-based dispatch instead
of matching on the sql family, now.