### PR TITLE
Remove indirection through MigrationApi in MigrationCommand 

### DIFF
--- a/migration-engine/core/src/api.rs
+++ b/migration-engine/core/src/api.rs
@@ -1,3 +1,5 @@
+//! The external facing programmatic API to the migration engine.
+
 mod error_rendering;
 mod rpc;
 
@@ -7,6 +9,7 @@ use crate::{commands::*, CoreResult};
 use migration_connector::MigrationConnector;
 use tracing_futures::Instrument;
 
+#[allow(missing_docs)]
 #[async_trait::async_trait]
 pub trait GenericApi: Send + Sync + 'static {
     async fn version(&self, input: &serde_json::Value) -> CoreResult<String>;

--- a/migration-engine/core/src/api.rs
+++ b/migration-engine/core/src/api.rs
@@ -23,7 +23,7 @@ impl<C: MigrationConnector> MigrationApi<C> {
     where
         E: MigrationCommand,
     {
-        Ok(E::execute(input, self).await?)
+        Ok(E::execute(input, self.connector()).await?)
     }
 
     pub fn connector(&self) -> &C {

--- a/migration-engine/core/src/api.rs
+++ b/migration-engine/core/src/api.rs
@@ -7,30 +7,6 @@ use crate::{commands::*, CoreResult};
 use migration_connector::MigrationConnector;
 use tracing_futures::Instrument;
 
-pub struct MigrationApi<C>
-where
-    C: MigrationConnector,
-{
-    connector: C,
-}
-
-impl<C: MigrationConnector> MigrationApi<C> {
-    pub fn new(connector: C) -> Self {
-        MigrationApi { connector }
-    }
-
-    pub async fn handle_command<'a, E>(&'a self, input: &'a E::Input) -> CoreResult<E::Output>
-    where
-        E: MigrationCommand,
-    {
-        Ok(E::execute(input, self.connector()).await?)
-    }
-
-    pub fn connector(&self) -> &C {
-        &self.connector
-    }
-}
-
 #[async_trait::async_trait]
 pub trait GenericApi: Send + Sync + 'static {
     async fn version(&self, input: &serde_json::Value) -> CoreResult<String>;
@@ -60,27 +36,27 @@ pub trait GenericApi: Send + Sync + 'static {
 }
 
 #[async_trait::async_trait]
-impl<C: MigrationConnector> GenericApi for MigrationApi<C> {
+impl<C: MigrationConnector> GenericApi for C {
     async fn version(&self, input: &serde_json::Value) -> CoreResult<String> {
-        self.handle_command::<VersionCommand>(input)
+        VersionCommand::execute(input, self)
             .instrument(tracing::info_span!("Version"))
             .await
     }
 
     async fn apply_migrations(&self, input: &ApplyMigrationsInput) -> CoreResult<ApplyMigrationsOutput> {
-        self.handle_command::<ApplyMigrationsCommand>(input)
+        ApplyMigrationsCommand::execute(input, self)
             .instrument(tracing::info_span!("ApplyMigrations"))
             .await
     }
 
     async fn apply_script(&self, input: &ApplyScriptInput) -> CoreResult<ApplyScriptOutput> {
-        self.handle_command::<ApplyScriptCommand>(input)
+        ApplyScriptCommand::execute(input, self)
             .instrument(tracing::info_span!("ApplyScript"))
             .await
     }
 
     async fn create_migration(&self, input: &CreateMigrationInput) -> CoreResult<CreateMigrationOutput> {
-        self.handle_command::<CreateMigrationCommand>(input)
+        CreateMigrationCommand::execute(input, self)
             .instrument(tracing::info_span!(
                 "CreateMigration",
                 migration_name = input.migration_name.as_str(),
@@ -90,13 +66,13 @@ impl<C: MigrationConnector> GenericApi for MigrationApi<C> {
     }
 
     async fn debug_panic(&self, input: &()) -> CoreResult<()> {
-        self.handle_command::<DebugPanicCommand>(input)
+        DebugPanicCommand::execute(input, self)
             .instrument(tracing::info_span!("DebugPanic"))
             .await
     }
 
     async fn dev_diagnostic(&self, input: &DevDiagnosticInput) -> CoreResult<DevDiagnosticOutput> {
-        self.handle_command::<DevDiagnosticCommand>(input)
+        DevDiagnosticCommand::execute(input, self)
             .instrument(tracing::info_span!("DevDiagnostic"))
             .await
     }
@@ -105,13 +81,13 @@ impl<C: MigrationConnector> GenericApi for MigrationApi<C> {
         &self,
         input: &DiagnoseMigrationHistoryInput,
     ) -> CoreResult<DiagnoseMigrationHistoryOutput> {
-        self.handle_command::<DiagnoseMigrationHistoryCommand>(input)
+        DiagnoseMigrationHistoryCommand::execute(input, self)
             .instrument(tracing::info_span!("DiagnoseMigrationHistory"))
             .await
     }
 
     async fn evaluate_data_loss(&self, input: &EvaluateDataLossInput) -> CoreResult<EvaluateDataLossOutput> {
-        self.handle_command::<EvaluateDataLoss>(input)
+        EvaluateDataLoss::execute(input, self)
             .instrument(tracing::info_span!("EvaluateDataLoss"))
             .await
     }
@@ -120,7 +96,7 @@ impl<C: MigrationConnector> GenericApi for MigrationApi<C> {
         &self,
         input: &ListMigrationDirectoriesInput,
     ) -> CoreResult<ListMigrationDirectoriesOutput> {
-        self.handle_command::<ListMigrationDirectoriesCommand>(input)
+        ListMigrationDirectoriesCommand::execute(input, self)
             .instrument(tracing::info_span!("ListMigrationDirectories"))
             .await
     }
@@ -129,7 +105,7 @@ impl<C: MigrationConnector> GenericApi for MigrationApi<C> {
         &self,
         input: &MarkMigrationAppliedInput,
     ) -> CoreResult<MarkMigrationAppliedOutput> {
-        self.handle_command::<MarkMigrationAppliedCommand>(input)
+        MarkMigrationAppliedCommand::execute(input, self)
             .instrument(tracing::info_span!(
                 "MarkMigrationApplied",
                 migration_name = input.migration_name.as_str()
@@ -141,7 +117,7 @@ impl<C: MigrationConnector> GenericApi for MigrationApi<C> {
         &self,
         input: &MarkMigrationRolledBackInput,
     ) -> CoreResult<MarkMigrationRolledBackOutput> {
-        self.handle_command::<MarkMigrationRolledBackCommand>(input)
+        MarkMigrationRolledBackCommand::execute(input, self)
             .instrument(tracing::info_span!(
                 "MarkMigrationRolledBack",
                 migration_name = input.migration_name.as_str()
@@ -150,19 +126,19 @@ impl<C: MigrationConnector> GenericApi for MigrationApi<C> {
     }
 
     async fn plan_migration(&self, input: &PlanMigrationInput) -> CoreResult<PlanMigrationOutput> {
-        self.handle_command::<PlanMigrationCommand>(input)
+        PlanMigrationCommand::execute(input, self)
             .instrument(tracing::info_span!("PlanMigration"))
             .await
     }
 
     async fn reset(&self, input: &()) -> CoreResult<()> {
-        self.handle_command::<ResetCommand>(input)
+        ResetCommand::execute(input, self)
             .instrument(tracing::info_span!("Reset"))
             .await
     }
 
     async fn schema_push(&self, input: &SchemaPushInput) -> CoreResult<SchemaPushOutput> {
-        self.handle_command::<SchemaPushCommand>(input)
+        SchemaPushCommand::execute(input, self)
             .instrument(tracing::info_span!("SchemaPush"))
             .await
     }

--- a/migration-engine/core/src/api/rpc.rs
+++ b/migration-engine/core/src/api/rpc.rs
@@ -4,6 +4,7 @@ use futures::{FutureExt, TryFutureExt};
 use jsonrpc_core::{types::error::Error as JsonRpcError, IoHandler, Params};
 use std::sync::Arc;
 
+/// A JSON-RPC ready migration API.
 pub struct RpcApi {
     io_handler: jsonrpc_core::IoHandler<()>,
     executor: Arc<dyn GenericApi>,
@@ -66,6 +67,7 @@ const AVAILABLE_COMMANDS: &[RpcCommand] = &[
 ];
 
 impl RpcApi {
+    /// Initialize a migration engine API. This entails starting a database connection.
     pub async fn new(datamodel: &str) -> CoreResult<Self> {
         let mut rpc_api = Self {
             io_handler: IoHandler::default(),
@@ -79,6 +81,7 @@ impl RpcApi {
         Ok(rpc_api)
     }
 
+    /// The JSON-RPC IO handler. This is what you can plug onto a transport.
     pub fn io_handler(&self) -> &IoHandler {
         &self.io_handler
     }

--- a/migration-engine/core/src/commands/apply_migrations.rs
+++ b/migration-engine/core/src/commands/apply_migrations.rs
@@ -1,4 +1,4 @@
-use crate::{api::MigrationApi, CoreError, CoreResult};
+use crate::{CoreError, CoreResult};
 use migration_connector::{ConnectorError, MigrationDirectory, MigrationRecord, PersistenceNotInitializedError};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
@@ -32,11 +32,10 @@ impl<'a> MigrationCommand for ApplyMigrationsCommand {
     type Input = ApplyMigrationsInput;
     type Output = ApplyMigrationsOutput;
 
-    async fn execute<C>(input: &Self::Input, engine: &MigrationApi<C>) -> CoreResult<Self::Output>
+    async fn execute<C>(input: &Self::Input, connector: &C) -> CoreResult<Self::Output>
     where
         C: migration_connector::MigrationConnector,
     {
-        let connector = engine.connector();
         let applier = connector.database_migration_step_applier();
         let migration_persistence = connector.migration_persistence();
 

--- a/migration-engine/core/src/commands/apply_script.rs
+++ b/migration-engine/core/src/commands/apply_script.rs
@@ -1,5 +1,5 @@
 use super::MigrationCommand;
-use crate::{api::MigrationApi, CoreResult};
+use crate::CoreResult;
 use serde::Deserialize;
 use std::collections::HashMap;
 
@@ -25,11 +25,11 @@ impl MigrationCommand for ApplyScriptCommand {
 
     type Output = ApplyScriptOutput;
 
-    async fn execute<C>(input: &Self::Input, engine: &MigrationApi<C>) -> CoreResult<Self::Output>
+    async fn execute<C>(input: &Self::Input, connector: &C) -> CoreResult<Self::Output>
     where
         C: migration_connector::MigrationConnector,
     {
-        let applier = engine.connector().database_migration_step_applier();
+        let applier = connector.database_migration_step_applier();
 
         applier.apply_script(&input.script).await?;
 

--- a/migration-engine/core/src/commands/command.rs
+++ b/migration-engine/core/src/commands/command.rs
@@ -1,4 +1,4 @@
-use crate::{api::MigrationApi, CoreResult};
+use crate::CoreResult;
 use migration_connector::*;
 use serde::{de::DeserializeOwned, Serialize};
 
@@ -11,5 +11,5 @@ pub trait MigrationCommand {
     type Output: Serialize + 'static;
 
     /// Handle the input, producing the response or an error.
-    async fn execute<C: MigrationConnector>(input: &Self::Input, engine: &MigrationApi<C>) -> CoreResult<Self::Output>;
+    async fn execute<C: MigrationConnector>(input: &Self::Input, connector: &C) -> CoreResult<Self::Output>;
 }

--- a/migration-engine/core/src/commands/debug_panic.rs
+++ b/migration-engine/core/src/commands/debug_panic.rs
@@ -1,5 +1,5 @@
 use super::MigrationCommand;
-use crate::{api::MigrationApi, core_error::CoreResult};
+use crate::core_error::CoreResult;
 use migration_connector::MigrationConnector;
 
 /// Make the migration engine crash. This is useful only for debugging error handling in clients.
@@ -10,10 +10,7 @@ impl<'a> MigrationCommand for DebugPanicCommand {
     type Input = ();
     type Output = ();
 
-    async fn execute<C: MigrationConnector>(
-        _input: &Self::Input,
-        _engine: &MigrationApi<C>,
-    ) -> CoreResult<Self::Output> {
+    async fn execute<C: MigrationConnector>(_input: &Self::Input, _connector: &C) -> CoreResult<Self::Output> {
         panic!("This is the debugPanic artificial panic")
     }
 }

--- a/migration-engine/core/src/commands/diagnose_migration_history.rs
+++ b/migration-engine/core/src/commands/diagnose_migration_history.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use super::MigrationCommand;
-use crate::{api::MigrationApi, CoreResult};
+use crate::CoreResult;
 use migration_connector::{
     ConnectorError, MigrationConnector, MigrationDirectory, MigrationRecord, PersistenceNotInitializedError,
 };
@@ -69,8 +69,7 @@ impl<'a> MigrationCommand for DiagnoseMigrationHistoryCommand {
     type Input = DiagnoseMigrationHistoryInput;
     type Output = DiagnoseMigrationHistoryOutput;
 
-    async fn execute<C: MigrationConnector>(input: &Self::Input, engine: &MigrationApi<C>) -> CoreResult<Self::Output> {
-        let connector = engine.connector();
+    async fn execute<C: MigrationConnector>(input: &Self::Input, connector: &C) -> CoreResult<Self::Output> {
         let migration_persistence = connector.migration_persistence();
         let migration_inferrer = connector.database_migration_inferrer();
 

--- a/migration-engine/core/src/commands/evaluate_data_loss.rs
+++ b/migration-engine/core/src/commands/evaluate_data_loss.rs
@@ -1,5 +1,5 @@
 use super::MigrationCommand;
-use crate::{api::MigrationApi, parse_datamodel, CoreResult};
+use crate::{parse_datamodel, CoreResult};
 use migration_connector::{list_migrations, MigrationConnector};
 use serde::{Deserialize, Serialize};
 
@@ -50,8 +50,7 @@ impl MigrationCommand for EvaluateDataLoss {
     type Input = EvaluateDataLossInput;
     type Output = EvaluateDataLossOutput;
 
-    async fn execute<C: MigrationConnector>(input: &Self::Input, engine: &MigrationApi<C>) -> CoreResult<Self::Output> {
-        let connector = engine.connector();
+    async fn execute<C: MigrationConnector>(input: &Self::Input, connector: &C) -> CoreResult<Self::Output> {
         let inferrer = connector.database_migration_inferrer();
         let applier = connector.database_migration_step_applier();
         let checker = connector.destructive_change_checker();

--- a/migration-engine/core/src/commands/get_database_version.rs
+++ b/migration-engine/core/src/commands/get_database_version.rs
@@ -1,4 +1,4 @@
-use crate::{api::MigrationApi, commands::command::*, CoreResult};
+use crate::{commands::command::*, CoreResult};
 use migration_connector::*;
 
 /// Returns the version of the used db if available.
@@ -9,11 +9,7 @@ impl MigrationCommand for VersionCommand {
     type Input = serde_json::Value;
     type Output = String;
 
-    async fn execute<C: MigrationConnector>(
-        _input: &Self::Input,
-        engine: &MigrationApi<C>,
-    ) -> CoreResult<Self::Output> {
-        let connector = engine.connector();
+    async fn execute<C: MigrationConnector>(_input: &Self::Input, connector: &C) -> CoreResult<Self::Output> {
         Ok(connector.version().await?)
     }
 }

--- a/migration-engine/core/src/commands/list_migration_directories.rs
+++ b/migration-engine/core/src/commands/list_migration_directories.rs
@@ -1,5 +1,5 @@
 use super::MigrationCommand;
-use crate::{api::MigrationApi, CoreResult};
+use crate::CoreResult;
 use migration_connector::MigrationConnector;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
@@ -28,10 +28,7 @@ impl<'a> MigrationCommand for ListMigrationDirectoriesCommand {
     type Input = ListMigrationDirectoriesInput;
     type Output = ListMigrationDirectoriesOutput;
 
-    async fn execute<C: MigrationConnector>(
-        input: &Self::Input,
-        _engine: &MigrationApi<C>,
-    ) -> CoreResult<Self::Output> {
+    async fn execute<C: MigrationConnector>(input: &Self::Input, _engine: &C) -> CoreResult<Self::Output> {
         let migrations_from_filesystem =
             migration_connector::list_migrations(&Path::new(&input.migrations_directory_path))?;
 

--- a/migration-engine/core/src/commands/mark_migration_applied.rs
+++ b/migration-engine/core/src/commands/mark_migration_applied.rs
@@ -1,5 +1,5 @@
 use super::MigrationCommand;
-use crate::{api::MigrationApi, CoreError, CoreResult};
+use crate::{CoreError, CoreResult};
 use migration_connector::{MigrationConnector, MigrationDirectory};
 use serde::Deserialize;
 use std::{collections::HashMap, path::Path};
@@ -26,14 +26,10 @@ impl MigrationCommand for MarkMigrationAppliedCommand {
     type Input = MarkMigrationAppliedInput;
     type Output = MarkMigrationAppliedOutput;
 
-    async fn execute<C: MigrationConnector>(input: &Self::Input, engine: &MigrationApi<C>) -> CoreResult<Self::Output> {
-        let connector = engine.connector();
-        let persistence = engine.connector().migration_persistence();
+    async fn execute<C: MigrationConnector>(input: &Self::Input, connector: &C) -> CoreResult<Self::Output> {
+        let persistence = connector.migration_persistence();
 
-        migration_connector::error_on_changed_provider(
-            &input.migrations_directory_path,
-            engine.connector().connector_type(),
-        )?;
+        migration_connector::error_on_changed_provider(&input.migrations_directory_path, connector.connector_type())?;
 
         connector.acquire_lock().await?;
 

--- a/migration-engine/core/src/commands/mark_migration_rolled_back.rs
+++ b/migration-engine/core/src/commands/mark_migration_rolled_back.rs
@@ -1,5 +1,5 @@
 use super::MigrationCommand;
-use crate::{api::MigrationApi, CoreError, CoreResult};
+use crate::{CoreError, CoreResult};
 use migration_connector::MigrationConnector;
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -24,11 +24,10 @@ impl MigrationCommand for MarkMigrationRolledBackCommand {
     type Input = MarkMigrationRolledBackInput;
     type Output = MarkMigrationRolledBackOutput;
 
-    async fn execute<C: MigrationConnector>(input: &Self::Input, engine: &MigrationApi<C>) -> CoreResult<Self::Output> {
-        //todo the input currently does not take the migration directory as input. therefore no error atm, but I think the behaviour
+    async fn execute<C: MigrationConnector>(input: &Self::Input, connector: &C) -> CoreResult<Self::Output> {
+        // todo the input currently does not take the migration directory as input. therefore no error atm, but I think the behaviour
         // should be consistent between mark applied and mark rolled back
-        let connector = engine.connector();
-        let persistence = engine.connector().migration_persistence();
+        let persistence = connector.migration_persistence();
 
         connector.acquire_lock().await?;
 

--- a/migration-engine/core/src/commands/plan_migration.rs
+++ b/migration-engine/core/src/commands/plan_migration.rs
@@ -1,5 +1,5 @@
 use super::MigrationCommand;
-use crate::{api::MigrationApi, CoreResult};
+use crate::CoreResult;
 use migration_connector::MigrationConnector;
 use serde::{Deserialize, Serialize};
 
@@ -27,10 +27,7 @@ impl<'a> MigrationCommand for PlanMigrationCommand {
 
     type Output = PlanMigrationOutput;
 
-    async fn execute<C: MigrationConnector>(
-        _input: &Self::Input,
-        _engine: &MigrationApi<C>,
-    ) -> CoreResult<Self::Output> {
+    async fn execute<C: MigrationConnector>(_input: &Self::Input, _engine: &C) -> CoreResult<Self::Output> {
         unreachable!("PlanMigration command")
     }
 }

--- a/migration-engine/core/src/commands/plan_migration.rs
+++ b/migration-engine/core/src/commands/plan_migration.rs
@@ -24,7 +24,6 @@ pub struct PlanMigrationCommand;
 #[async_trait::async_trait]
 impl<'a> MigrationCommand for PlanMigrationCommand {
     type Input = PlanMigrationInput;
-
     type Output = PlanMigrationOutput;
 
     async fn execute<C: MigrationConnector>(_input: &Self::Input, _engine: &C) -> CoreResult<Self::Output> {

--- a/migration-engine/core/src/commands/reset.rs
+++ b/migration-engine/core/src/commands/reset.rs
@@ -1,4 +1,4 @@
-use crate::{api::MigrationApi, commands::command::MigrationCommand, CoreResult};
+use crate::{commands::command::MigrationCommand, CoreResult};
 use migration_connector::MigrationConnector;
 
 /// The `reset` command.
@@ -9,13 +9,10 @@ impl<'a> MigrationCommand for ResetCommand {
     type Input = ();
     type Output = ();
 
-    async fn execute<C: MigrationConnector>(
-        _input: &Self::Input,
-        engine: &MigrationApi<C>,
-    ) -> CoreResult<Self::Output> {
+    async fn execute<C: MigrationConnector>(_input: &Self::Input, connector: &C) -> CoreResult<Self::Output> {
         tracing::debug!("Resetting the database.");
 
-        engine.connector().reset().await?;
+        connector.reset().await?;
 
         Ok(())
     }

--- a/migration-engine/core/src/commands/schema_push.rs
+++ b/migration-engine/core/src/commands/schema_push.rs
@@ -1,5 +1,5 @@
 use super::MigrationCommand;
-use crate::{api::MigrationApi, parse_datamodel, CoreResult};
+use crate::{parse_datamodel, CoreResult};
 use migration_connector::{ConnectorError, MigrationConnector};
 use serde::{Deserialize, Serialize};
 
@@ -12,8 +12,7 @@ impl MigrationCommand for SchemaPushCommand {
     type Input = SchemaPushInput;
     type Output = SchemaPushOutput;
 
-    async fn execute<C: MigrationConnector>(input: &Self::Input, engine: &MigrationApi<C>) -> CoreResult<Self::Output> {
-        let connector = engine.connector();
+    async fn execute<C: MigrationConnector>(input: &Self::Input, connector: &C) -> CoreResult<Self::Output> {
         let schema = parse_datamodel(&input.schema)?;
         let inferrer = connector.database_migration_inferrer();
         let applier = connector.database_migration_step_applier();

--- a/migration-engine/core/src/lib.rs
+++ b/migration-engine/core/src/lib.rs
@@ -10,7 +10,6 @@ mod core_error;
 
 use anyhow::anyhow;
 pub use api::GenericApi;
-use api::MigrationApi;
 pub use commands::SchemaPushInput;
 use commands::{MigrationCommand, SchemaPushCommand};
 pub use core_error::{CoreError, CoreResult};
@@ -78,9 +77,7 @@ pub async fn migration_api(datamodel: &str) -> CoreResult<Arc<dyn api::GenericAp
         x => unimplemented!("Connector {} is not supported yet", x),
     };
 
-    let api = api::MigrationApi::new(connector);
-
-    Ok(Arc::new(api))
+    Ok(Arc::new(connector))
 }
 
 /// Create the database referenced by the passed in Prisma schema.
@@ -160,8 +157,6 @@ pub async fn qe_setup(prisma_schema: &str) -> CoreResult<()> {
         x => unimplemented!("Connector {} is not supported yet", x),
     };
 
-    let engine = MigrationApi::new(connector);
-
     // 2. create the database schema for given Prisma schema
     let schema_push_input = SchemaPushInput {
         schema: prisma_schema.to_string(),
@@ -169,7 +164,7 @@ pub async fn qe_setup(prisma_schema: &str) -> CoreResult<()> {
         force: true,
     };
 
-    SchemaPushCommand::execute(&schema_push_input, engine.connector()).await?;
+    SchemaPushCommand::execute(&schema_push_input, &connector).await?;
 
     Ok(())
 }

--- a/migration-engine/core/src/lib.rs
+++ b/migration-engine/core/src/lib.rs
@@ -2,17 +2,17 @@
 
 //! The top-level library crate for the migration engine.
 
-#[allow(missing_docs)]
 pub mod api;
 pub mod commands;
 
 mod core_error;
 
-use anyhow::anyhow;
 pub use api::GenericApi;
 pub use commands::SchemaPushInput;
-use commands::{MigrationCommand, SchemaPushCommand};
 pub use core_error::{CoreError, CoreResult};
+
+use anyhow::anyhow;
+use commands::{MigrationCommand, SchemaPushCommand};
 use datamodel::{
     common::provider_names::{MSSQL_SOURCE_NAME, MYSQL_SOURCE_NAME, POSTGRES_SOURCE_NAME, SQLITE_SOURCE_NAME},
     dml::Datamodel,

--- a/migration-engine/core/src/lib.rs
+++ b/migration-engine/core/src/lib.rs
@@ -169,7 +169,7 @@ pub async fn qe_setup(prisma_schema: &str) -> CoreResult<()> {
         force: true,
     };
 
-    SchemaPushCommand::execute(&schema_push_input, &engine).await?;
+    SchemaPushCommand::execute(&schema_push_input, engine.connector()).await?;
 
     Ok(())
 }

--- a/migration-engine/migration-engine-tests/src/test_api.rs
+++ b/migration-engine/migration-engine-tests/src/test_api.rs
@@ -26,10 +26,7 @@ use super::{
 use crate::{connectors::Tags, test_api::list_migration_directories::ListMigrationDirectories, AssertionResult};
 use enumflags2::BitFlags;
 use migration_connector::{MigrationFeature, MigrationPersistence, MigrationRecord};
-use migration_core::{
-    api::{GenericApi, MigrationApi},
-    commands::ApplyScriptInput,
-};
+use migration_core::{api::GenericApi, commands::ApplyScriptInput};
 use quaint::{
     prelude::{ConnectionInfo, Queryable, SqlFamily},
     single::Quaint,
@@ -44,7 +41,7 @@ use test_setup::*;
 /// connectors.
 pub struct TestApi {
     database: Quaint,
-    api: MigrationApi<SqlMigrationConnector>,
+    api: SqlMigrationConnector,
     tags: BitFlags<Tags>,
 }
 
@@ -86,7 +83,7 @@ impl TestApi {
     }
 
     pub fn migration_persistence<'a>(&'a self) -> &(dyn MigrationPersistence + 'a) {
-        self.api.connector()
+        &self.api
     }
 
     pub fn connection_info(&self) -> &ConnectionInfo {
@@ -222,7 +219,7 @@ impl TestApi {
     }
 
     pub async fn describe_database(&self) -> Result<SqlSchema, anyhow::Error> {
-        let result = self.api.connector().describe_schema().await?;
+        let result = self.api.describe_schema().await?;
         Ok(result)
     }
 
@@ -343,7 +340,7 @@ pub async fn mysql_8_test_api(args: TestAPIArgs) -> TestApi {
 
     TestApi {
         database: connector.quaint().clone(),
-        api: MigrationApi::new(connector),
+        api: connector,
         tags: args.test_tag,
     }
 }
@@ -356,7 +353,7 @@ pub async fn mysql_5_6_test_api(args: TestAPIArgs) -> TestApi {
 
     TestApi {
         database: connector.quaint().clone(),
-        api: MigrationApi::new(connector),
+        api: connector,
         tags: args.test_tag,
     }
 }
@@ -369,7 +366,7 @@ pub async fn mysql_test_api(args: TestAPIArgs) -> TestApi {
 
     TestApi {
         database: connector.quaint().clone(),
-        api: MigrationApi::new(connector),
+        api: connector,
         tags: args.test_tag,
     }
 }
@@ -382,7 +379,7 @@ pub async fn mysql_mariadb_test_api(args: TestAPIArgs) -> TestApi {
 
     TestApi {
         database: connector.quaint().clone(),
-        api: MigrationApi::new(connector),
+        api: connector,
         tags: args.test_tag,
     }
 }
@@ -395,7 +392,7 @@ pub async fn postgres9_test_api(args: TestAPIArgs) -> TestApi {
 
     TestApi {
         database: connector.quaint().clone(),
-        api: MigrationApi::new(connector),
+        api: connector,
         tags: args.test_tag,
     }
 }
@@ -408,7 +405,7 @@ pub async fn postgres_test_api(args: TestAPIArgs) -> TestApi {
 
     TestApi {
         database: connector.quaint().clone(),
-        api: MigrationApi::new(connector),
+        api: connector,
         tags: args.test_tag,
     }
 }
@@ -421,7 +418,7 @@ pub async fn postgres11_test_api(args: TestAPIArgs) -> TestApi {
 
     TestApi {
         database: connector.quaint().clone(),
-        api: MigrationApi::new(connector),
+        api: connector,
         tags: args.test_tag,
     }
 }
@@ -433,7 +430,7 @@ pub async fn postgres12_test_api(args: TestAPIArgs) -> TestApi {
 
     TestApi {
         database: connector.quaint().clone(),
-        api: MigrationApi::new(connector),
+        api: connector,
         tags: args.test_tag,
     }
 }
@@ -445,7 +442,7 @@ pub async fn postgres13_test_api(args: TestAPIArgs) -> TestApi {
 
     TestApi {
         database: connector.quaint().clone(),
-        api: MigrationApi::new(connector),
+        api: connector,
         tags: args.test_tag,
     }
 }
@@ -457,7 +454,7 @@ pub async fn sqlite_test_api(args: TestAPIArgs) -> TestApi {
 
     TestApi {
         database: connector.quaint().clone(),
-        api: MigrationApi::new(connector),
+        api: connector,
         tags: args.test_tag,
     }
 }
@@ -481,7 +478,7 @@ async fn mssql_test_api(connection_string: String, args: TestAPIArgs) -> TestApi
 
     TestApi {
         database: connector.quaint().clone(),
-        api: MigrationApi::new(connector),
+        api: connector,
         tags: args.test_tag,
     }
 }

--- a/query-engine/query-engine/src/tests/test_api.rs
+++ b/query-engine/query-engine/src/tests/test_api.rs
@@ -4,10 +4,7 @@ use crate::{
     PrismaResponse,
 };
 use enumflags2::BitFlags;
-use migration_core::{
-    api::{GenericApi, MigrationApi},
-    commands::SchemaPushInput,
-};
+use migration_core::{api::GenericApi, commands::SchemaPushInput};
 use quaint::{
     ast::*,
     connector::ConnectionInfo,
@@ -39,7 +36,7 @@ impl QueryEngine {
 
 pub struct TestApi {
     connection_info: ConnectionInfo,
-    migration_api: MigrationApi<SqlMigrationConnector>,
+    migration_api: SqlMigrationConnector,
     config: String,
 }
 
@@ -89,7 +86,7 @@ pub async fn mysql_8_test_api(args: TestAPIArgs) -> TestApi {
     let url = mysql_8_url(db_name);
     let connection_info = ConnectionInfo::from_url(&url).unwrap();
 
-    let migration_api = MigrationApi::new(mysql_migration_connector(&url).await);
+    let migration_api = mysql_migration_connector(&url).await;
 
     let config = mysql_8_test_config(db_name);
 
@@ -105,7 +102,7 @@ pub async fn mysql_5_6_test_api(args: TestAPIArgs) -> TestApi {
     let url = mysql_5_6_url(db_name);
     let connection_info = ConnectionInfo::from_url(&url).unwrap();
 
-    let migration_api = MigrationApi::new(mysql_migration_connector(&url).await);
+    let migration_api = mysql_migration_connector(&url).await;
 
     let config = mysql_5_6_test_config(db_name);
 
@@ -121,7 +118,7 @@ pub async fn mysql_test_api(args: TestAPIArgs) -> TestApi {
     let url = mysql_url(db_name);
     let connection_info = ConnectionInfo::from_url(&url).unwrap();
 
-    let migration_api = MigrationApi::new(mysql_migration_connector(&url).await);
+    let migration_api = mysql_migration_connector(&url).await;
 
     let config = mysql_test_config(db_name);
 
@@ -137,7 +134,7 @@ pub async fn mysql_mariadb_test_api(args: TestAPIArgs) -> TestApi {
     let url = mariadb_url(db_name);
     let connection_info = ConnectionInfo::from_url(&url).unwrap();
 
-    let migration_api = MigrationApi::new(mysql_migration_connector(&url).await);
+    let migration_api = mysql_migration_connector(&url).await;
 
     let config = mariadb_test_config(db_name);
 
@@ -153,7 +150,7 @@ pub async fn postgres9_test_api(args: TestAPIArgs) -> TestApi {
     let url = postgres_9_url(db_name);
     let connection_info = ConnectionInfo::from_url(&url).unwrap();
 
-    let migration_api = MigrationApi::new(postgres_migration_connector(&url).await);
+    let migration_api = postgres_migration_connector(&url).await;
 
     let config = postgres_9_test_config(db_name);
 
@@ -169,7 +166,7 @@ pub async fn postgres_test_api(args: TestAPIArgs) -> TestApi {
     let url = postgres_10_url(db_name);
     let connection_info = ConnectionInfo::from_url(&url).unwrap();
 
-    let migration_api = MigrationApi::new(postgres_migration_connector(&url).await);
+    let migration_api = postgres_migration_connector(&url).await;
 
     let config = postgres_10_test_config(db_name);
 
@@ -185,7 +182,7 @@ pub async fn postgres11_test_api(args: TestAPIArgs) -> TestApi {
     let url = postgres_11_url(db_name);
     let connection_info = ConnectionInfo::from_url(&url).unwrap();
 
-    let migration_api = MigrationApi::new(postgres_migration_connector(&url).await);
+    let migration_api = postgres_migration_connector(&url).await;
 
     let config = postgres_11_test_config(db_name);
 
@@ -201,7 +198,7 @@ pub async fn postgres12_test_api(args: TestAPIArgs) -> TestApi {
     let url = postgres_12_url(db_name);
     let connection_info = ConnectionInfo::from_url(&url).unwrap();
 
-    let migration_api = MigrationApi::new(postgres_migration_connector(&url).await);
+    let migration_api = postgres_migration_connector(&url).await;
 
     let config = postgres_12_test_config(db_name);
 
@@ -217,7 +214,7 @@ pub async fn postgres13_test_api(args: TestAPIArgs) -> TestApi {
     let url = postgres_13_url(db_name);
     let connection_info = ConnectionInfo::from_url(&url).unwrap();
 
-    let migration_api = MigrationApi::new(postgres_migration_connector(&url).await);
+    let migration_api = postgres_migration_connector(&url).await;
 
     let config = postgres_13_test_config(db_name);
 
@@ -233,7 +230,7 @@ pub async fn sqlite_test_api(args: TestAPIArgs) -> TestApi {
     let url = sqlite_test_url(db_name);
     let connection_info = ConnectionInfo::from_url(&url).unwrap();
 
-    let migration_api = MigrationApi::new(sqlite_migration_connector(db_name).await);
+    let migration_api = sqlite_migration_connector(db_name).await;
 
     let config = sqlite_test_config(db_name);
 
@@ -249,7 +246,7 @@ pub async fn mssql_2017_test_api(args: TestAPIArgs) -> TestApi {
     let url = mssql_2017_url(db_name);
     let connection_info = ConnectionInfo::from_url(&url).unwrap();
 
-    let migration_api = MigrationApi::new(mssql_migration_connector(&url).await);
+    let migration_api = mssql_migration_connector(&url).await;
 
     let config = mssql_2017_test_config(db_name);
 
@@ -265,7 +262,7 @@ pub async fn mssql_2019_test_api(args: TestAPIArgs) -> TestApi {
     let url = mssql_2019_url(db_name);
     let connection_info = ConnectionInfo::from_url(&url).unwrap();
 
-    let migration_api = MigrationApi::new(mssql_migration_connector(&url).await);
+    let migration_api = mssql_migration_connector(&url).await;
 
     let config = mssql_2019_test_config(db_name);
 


### PR DESCRIPTION
This venerable abstraction does not buy us anything currently, so let's simplify.