### PR TITLE
Rename `can_batch` to `should_batch`

### DIFF
--- a/query-engine/connectors/query-connector/src/filter/mod.rs
+++ b/query-engine/connectors/query-connector/src/filter/mod.rs
@@ -65,11 +65,11 @@ impl Filter {
         }
     }
 
-    pub fn can_batch(&self) -> bool {
+    pub fn should_batch(&self) -> bool {
         match self {
-            Self::Scalar(sf) => sf.can_batch(),
-            Self::And(filters) => filters.iter().any(|f| f.can_batch()),
-            Self::Or(filters) => filters.iter().any(|f| f.can_batch()),
+            Self::Scalar(sf) => sf.should_batch(),
+            Self::And(filters) => filters.iter().any(|f| f.should_batch()),
+            Self::Or(filters) => filters.iter().any(|f| f.should_batch()),
             _ => false,
         }
     }
@@ -85,7 +85,7 @@ impl Filter {
                         let previous = longest.replace(sf);
                         other.push(Filter::Scalar(previous.unwrap()));
                     }
-                    (Filter::Scalar(sf), None) if sf.can_batch() => {
+                    (Filter::Scalar(sf), None) if sf.should_batch() => {
                         longest = Some(sf);
                     }
                     (filter, _) => other.push(filter),

--- a/query-engine/connectors/query-connector/src/filter/scalar.rs
+++ b/query-engine/connectors/query-connector/src/filter/scalar.rs
@@ -56,9 +56,9 @@ impl ScalarFilter {
         self.len() == 0
     }
 
-    /// If `true`, the filter can be split into smaller filters executed in
+    /// If `true`, the filter should be split into smaller filters executed in
     /// separate queries.
-    pub fn can_batch(&self) -> bool {
+    pub fn should_batch(&self) -> bool {
         self.len() > *MAX_BATCH_SIZE
     }
 

--- a/query-engine/connectors/query-connector/src/query_arguments.rs
+++ b/query-engine/connectors/query-connector/src/query_arguments.rs
@@ -94,8 +94,12 @@ impl QueryArguments {
         self.take.clone().map(|t| if t < 0 { -t } else { t })
     }
 
-    pub fn can_batch(&self) -> bool {
-        self.filter.as_ref().map(|filter| filter.can_batch()).unwrap_or(false) && self.cursor.is_none()
+    pub fn should_batch(&self) -> bool {
+        self.filter
+            .as_ref()
+            .map(|filter| filter.should_batch())
+            .unwrap_or(false)
+            && self.cursor.is_none()
     }
 
     pub fn batched(self) -> Vec<Self> {

--- a/query-engine/connectors/sql-query-connector/src/database/operations/read.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/read.rs
@@ -53,8 +53,8 @@ pub async fn get_many_records(
 
     // Todo: This can't work for all cases. Cursor-based pagination will not work, because it relies on the ordering
     // to determine the right queries to fire, and will default to incorrect orderings if no ordering is found.
-    // The can_batch has been adjusted to reflect that as a band-aid, but deeper investigation is necessary.
-    if query_arguments.can_batch() {
+    // The should_batch has been adjusted to reflect that as a band-aid, but deeper investigation is necessary.
+    if query_arguments.should_batch() {
         // We don't need to order in the database due to us ordering in this function.
         let order = std::mem::replace(&mut query_arguments.order_by, vec![]);
 


### PR DESCRIPTION
This came up yesterday in a conversation with @dpetrick about https://github.com/prisma/prisma-engines/issues/1610. `can_batch` does not describe a recommendation, it describes an obligation. This PR updates the name to `should_batch` which is more descriptive. Thanks!