### PR TITLE
Do best-effort resets when drop+recreate fails 

### DIFF
--- a/migration-engine/connectors/migration-connector/src/database_migration_step_applier.rs
+++ b/migration-engine/connectors/migration-connector/src/database_migration_step_applier.rs
@@ -4,9 +4,8 @@ use crate::{destructive_change_checker::DestructiveChangeDiagnostics, ConnectorR
 /// i.e. the [associated type on MigrationConnector](trait.MigrationConnector.html#associatedtype.DatabaseMigration).
 #[async_trait::async_trait]
 pub trait DatabaseMigrationStepApplier<T>: Send + Sync {
-    /// Applies the step to the database
-    /// Returns true to signal to the caller that the step was applied, and there could be a next one.
-    async fn apply_step(&self, database_migration: &T, step: usize) -> ConnectorResult<bool>;
+    /// Applies the migration to the database. Returns the number of executed steps.
+    async fn apply_migration(&self, database_migration: &T) -> ConnectorResult<u32>;
 
     /// Render steps for the CLI. Each step will contain the raw field.
     fn render_steps_pretty(&self, database_migration: &T) -> ConnectorResult<Vec<PrettyDatabaseMigrationStep>>;

--- a/migration-engine/connectors/sql-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/lib.rs
@@ -79,7 +79,7 @@ impl SqlMigrationConnector {
         self.flavour.as_ref()
     }
 
-    /// For tests.
+    /// Made public for tests.
     pub fn quaint(&self) -> &Quaint {
         self.connection.quaint()
     }

--- a/migration-engine/connectors/sql-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/lib.rs
@@ -22,6 +22,7 @@ use enumflags2::BitFlags;
 use error::quaint_error_to_connector_error;
 use flavour::SqlFlavour;
 use migration_connector::*;
+use pair::Pair;
 use quaint::{prelude::ConnectionInfo, single::Quaint};
 use sql_migration::SqlMigration;
 use sql_schema_describer::SqlSchema;
@@ -88,6 +89,29 @@ impl SqlMigrationConnector {
     pub async fn describe_schema(&self) -> ConnectorResult<SqlSchema> {
         self.flavour.describe_schema(&self.connection).await
     }
+
+    /// Try to reset the database to an empty state. This should only be used
+    /// when we don't have the permissions to do a full reset.
+    #[tracing::instrument(skip(self))]
+    async fn best_effort_reset(&self) -> ConnectorResult<()> {
+        tracing::info!("Attempting best_effort_reset");
+
+        let source_schema = self.describe_schema().await?;
+        let target_schema = SqlSchema::empty();
+
+        let steps =
+            sql_schema_differ::calculate_steps(Pair::new(&source_schema, &target_schema), self.flavour.as_ref());
+
+        let migration = SqlMigration {
+            before: source_schema,
+            after: target_schema,
+            steps,
+        };
+
+        self.apply_migration(&migration).await?;
+
+        Ok(())
+    }
 }
 
 #[async_trait::async_trait]
@@ -115,7 +139,11 @@ impl MigrationConnector for SqlMigrationConnector {
     }
 
     async fn reset(&self) -> ConnectorResult<()> {
-        self.flavour.reset(self.conn()).await
+        if let Err(_) = self.flavour.reset(self.conn()).await {
+            self.best_effort_reset().await?;
+        }
+
+        Ok(())
     }
 
     /// Optionally check that the features implied by the provided datamodel are all compatible with

--- a/migration-engine/core/src/lib.rs
+++ b/migration-engine/core/src/lib.rs
@@ -20,11 +20,10 @@ use datamodel::{
 };
 use migration_connector::{features, ConnectorError};
 use sql_migration_connector::SqlMigrationConnector;
-use std::sync::Arc;
 use user_facing_errors::{common::InvalidDatabaseString, migration_engine::DeprecatedProviderArray, KnownError};
 
 /// Top-level constructor for the migration engine API.
-pub async fn migration_api(datamodel: &str) -> CoreResult<Arc<dyn api::GenericApi>> {
+pub async fn migration_api(datamodel: &str) -> CoreResult<Box<dyn api::GenericApi>> {
     let config = parse_configuration(datamodel)?;
     let features = features::from_config(&config);
 
@@ -77,7 +76,7 @@ pub async fn migration_api(datamodel: &str) -> CoreResult<Arc<dyn api::GenericAp
         x => unimplemented!("Connector {} is not supported yet", x),
     };
 
-    Ok(Arc::new(connector))
+    Ok(Box::new(connector))
 }
 
 /// Create the database referenced by the passed in Prisma schema.

--- a/migration-engine/migration-engine-tests/tests/migrations/advisory_locking.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/advisory_locking.rs
@@ -2,7 +2,6 @@ use migration_core::{
     commands::{ApplyMigrationsInput, CreateMigrationInput},
     GenericApi,
 };
-use std::sync::Arc;
 use tempfile::TempDir;
 use test_macros::test_each_connector;
 use test_setup::{connectors::Tags, TestAPIArgs};
@@ -21,7 +20,7 @@ impl TestApi {
         Ok(tempfile::tempdir()?)
     }
 
-    async fn new_engine(&self) -> anyhow::Result<Arc<dyn GenericApi>> {
+    async fn new_engine(&self) -> anyhow::Result<Box<dyn GenericApi>> {
         Ok(migration_core::migration_api(&self.source).await?)
     }
 


### PR DESCRIPTION
This is intended for users who do not have permissions to drop and
recreate the database.

This is not a perfect solution, because there are a lot of elements
sql_schema_describer does not know about (views, stored procedures,
roles, etc.), so the cleanup will be less than perfect.

closes prisma/prisma#4803