### PR TITLE
Add a warning if adding multiple enum variants

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
@@ -47,7 +47,7 @@ impl SqlRenderer for PostgresFlavour {
 
     fn render_alter_enum(&self, alter_enum: &AlterEnum, schemas: &Pair<&SqlSchema>) -> Vec<String> {
         if alter_enum.dropped_variants.is_empty() {
-            let stmts: Vec<String> = alter_enum
+            let mut stmts: Vec<String> = alter_enum
                 .created_variants
                 .iter()
                 .map(|created_value| {
@@ -58,6 +58,17 @@ impl SqlRenderer for PostgresFlavour {
                     )
                 })
                 .collect();
+
+            if stmts.len() > 1 {
+                let warning = indoc::indoc! {
+                    r#"-- This migration adds more than one variant into an enum.
+                       -- With PostgreSQL versions 11 and earlier, this is not possible
+                       -- in one migration. Either split them into separate files, or run
+                       -- them manually in SQL console."#
+                };
+
+                stmts[0] = format!("{}\n\n{}", warning, stmts[0]);
+            }
 
             return stmts;
         }

--- a/migration-engine/migration-engine-tests/tests/migrations/enums.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/enums.rs
@@ -86,6 +86,7 @@ async fn variants_can_be_added_to_an_existing_enum(api: &TestApi) -> TestResult 
         enum CatMood {
             HUNGRY
             HAPPY
+            JOYJOY
         }
     "#;
 
@@ -93,7 +94,7 @@ async fn variants_can_be_added_to_an_existing_enum(api: &TestApi) -> TestResult 
 
     api.assert_schema()
         .await?
-        .assert_enum(enum_name, |enm| enm.assert_values(&["HUNGRY", "HAPPY"]))?;
+        .assert_enum(enum_name, |enm| enm.assert_values(&["HUNGRY", "HAPPY", "JOYJOY"]))?;
 
     Ok(())
 }


### PR DESCRIPTION
Does not migrate on PostgreSQL versions 11 and earlier.

Closes: https://github.com/prisma/prisma/issues/5290
Closes: https://github.com/prisma/prisma/issues/5543