### PR TITLE
Disable shadow database url validation in datasources

### DIFF
--- a/libs/datamodel/core/src/transform/ast_to_dml/datasource_loader.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/datasource_loader.rs
@@ -196,14 +196,15 @@ impl DatasourceLoader {
 
             validate_datasource_url(&shadow_database_url, source_name, &url_arg)?;
 
-            if url.value == shadow_database_url.value {
-                return Err(
-                    diagnostics.merge_error(DatamodelError::new_shadow_database_is_same_as_main_url_error(
-                        source_name.clone(),
-                        shadow_database_url_arg.span(),
-                    )),
-                );
-            }
+            // Temporarily disabled because of processing/hacks on URLs that make comparing the two URLs unreliable.
+            // if url.value == shadow_database_url.value {
+            //     return Err(
+            //         diagnostics.merge_error(DatamodelError::new_shadow_database_is_same_as_main_url_error(
+            //             source_name.clone(),
+            //             shadow_database_url_arg.span(),
+            //         )),
+            //     );
+            // }
 
             Some(shadow_database_url)
         } else {

--- a/libs/datamodel/core/tests/config/sources.rs
+++ b/libs/datamodel/core/tests/config/sources.rs
@@ -380,21 +380,22 @@ fn assert_eq_json(a: &str, b: &str) {
     assert_eq!(json_a, json_b);
 }
 
-#[test]
-fn must_error_when_both_url_and_shadow_database_url_are_the_same() {
-    let schema = r#"
-        datasource redmond {
-            provider = "postgres"
-            url = "postgresql://abcd"
-            shadowDatabaseUrl = "postgresql://abcd"
-        }
-    "#;
+// Temporarily disabled because of processing/hacks on URLs that make comparing the two URLs unreliable.
+// #[test]
+// fn must_error_when_both_url_and_shadow_database_url_are_the_same() {
+//     let schema = r#"
+//         datasource redmond {
+//             provider = "postgres"
+//             url = "postgresql://abcd"
+//             shadowDatabaseUrl = "postgresql://abcd"
+//         }
+//     "#;
 
-    let config = datamodel::parse_configuration(schema);
-    assert!(config.is_err());
-    let diagnostics = config.err().expect("This must error");
-    diagnostics.assert_is(DatamodelError::new_shadow_database_is_same_as_main_url_error(
-        "redmond".into(),
-        Span::new(134, 153),
-    ));
-}
+//     let config = datamodel::parse_configuration(schema);
+//     assert!(config.is_err());
+//     let diagnostics = config.err().expect("This must error");
+//     diagnostics.assert_is(DatamodelError::new_shadow_database_is_same_as_main_url_error(
+//         "redmond".into(),
+//         Span::new(134, 153),
+//     ));
+// }


### PR DESCRIPTION
Something unintuitive is happening in practice, where even URLs that are
not the same are transformed, and passed through validation as the same
URL, at least in certain circumstances. We should discuss this in the
meeting planned for wednesday.

There is a second layer of validation in the migration engine, we well
rely on it for now.