### PR TITLE
Validate shadow database url against provider

### DIFF
--- a/libs/datamodel/core/src/transform/ast_to_dml/datasource_loader.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/datasource_loader.rs
@@ -233,7 +233,7 @@ impl DatasourceLoader {
             .iter()
             .map(|provider| {
                 // Validate the URL
-                provider.can_handle_url(source_name, &url).map_err(|err_msg| {
+                provider.validate_url(source_name, &url).map_err(|err_msg| {
                     DatamodelError::new_source_validation_error(&err_msg, source_name, url_arg.span())
                 })?;
 
@@ -242,7 +242,7 @@ impl DatasourceLoader {
                     (shadow_database_url.as_ref(), shadow_database_url_arg.as_ref())
                 {
                     provider
-                        .can_handle_url(source_name, shadow_database_url)
+                        .validate_shadow_database_url(source_name, shadow_database_url)
                         .map_err(|err_msg| {
                             DatamodelError::new_source_validation_error(
                                 &err_msg,

--- a/libs/datamodel/core/src/transform/ast_to_dml/datasource_loader.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/datasource_loader.rs
@@ -160,7 +160,7 @@ impl DatasourceLoader {
 
         let shadow_database_url_arg = args.optional_arg(SHADOW_DATABASE_URL_KEY);
 
-        let shadow_database_url = if let Some(shadow_database_url_arg) = shadow_database_url_arg {
+        let shadow_database_url = if let Some(shadow_database_url_arg) = shadow_database_url_arg.as_ref() {
             let shadow_database_url = match (shadow_database_url_arg.as_str_from_env(), override_url) {
                 (Err(err), _)
                     if ignore_datasource_urls
@@ -232,10 +232,27 @@ impl DatasourceLoader {
         let validated_providers: Vec<_> = all_datasource_providers
             .iter()
             .map(|provider| {
-                let url_check_result = provider.can_handle_url(source_name, &url).map_err(|err_msg| {
+                // Validate the URL
+                provider.can_handle_url(source_name, &url).map_err(|err_msg| {
                     DatamodelError::new_source_validation_error(&err_msg, source_name, url_arg.span())
-                });
-                url_check_result.map(|_| provider)
+                })?;
+
+                // Validate the shadow database URL
+                if let (Some(shadow_database_url), Some(shadow_database_url_arg)) =
+                    (shadow_database_url.as_ref(), shadow_database_url_arg.as_ref())
+                {
+                    provider
+                        .can_handle_url(source_name, shadow_database_url)
+                        .map_err(|err_msg| {
+                            DatamodelError::new_source_validation_error(
+                                &err_msg,
+                                source_name,
+                                shadow_database_url_arg.span(),
+                            )
+                        })?;
+                }
+
+                Ok(provider)
             })
             .collect();
 

--- a/libs/datamodel/core/src/transform/ast_to_dml/datasource_provider.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/datasource_provider.rs
@@ -7,7 +7,9 @@ pub trait DatasourceProvider {
 
     fn canonical_name(&self) -> &str;
 
-    fn can_handle_url(&self, name: &str, url: &StringFromEnvVar) -> Result<(), String>;
+    fn validate_url(&self, name: &str, url: &StringFromEnvVar) -> Result<(), String>;
+
+    fn validate_shadow_database_url(&self, name: &str, url: &StringFromEnvVar) -> Result<(), String>;
 
     fn connector(&self) -> Box<dyn Connector>;
 }

--- a/libs/datamodel/core/tests/config/sources.rs
+++ b/libs/datamodel/core/tests/config/sources.rs
@@ -158,7 +158,7 @@ fn must_error_if_wrong_protocol_is_used_for_mysql_shadow_database_url() {
     let diagnostics = config.err().expect("This must error");
 
     diagnostics.assert_is(DatamodelError::new_source_validation_error(
-        "The URL for datasource `myds` must start with the protocol `mysql://`.",
+        "The shadow database URL for datasource `myds` must start with the protocol `mysql://`.",
         "myds",
         Span::new(119, 134),
     ));
@@ -195,7 +195,7 @@ fn must_error_if_wrong_protocol_is_used_for_postgresql_shadow_database_url() {
     assert!(config.is_err());
     let diagnostics = config.err().expect("This must error");
     diagnostics.assert_is(DatamodelError::new_source_validation_error(
-        "The URL for datasource `myds` must start with the protocol `postgresql://`.",
+        "The shadow database URL for datasource `myds` must start with the protocol `postgresql://`.",
         "myds",
         Span::new(129, 139),
     ));

--- a/libs/datamodel/core/tests/config/sources.rs
+++ b/libs/datamodel/core/tests/config/sources.rs
@@ -144,6 +144,27 @@ fn must_error_if_wrong_protocol_is_used_for_mysql() {
 }
 
 #[test]
+fn must_error_if_wrong_protocol_is_used_for_mysql_shadow_database_url() {
+    let schema = r#"
+        datasource myds {
+            provider = "mysql"
+            url = "mysql://"
+            shadowDatabaseUrl = "postgresql://"
+        }
+    "#;
+
+    let config = datamodel::parse_configuration(schema);
+
+    let diagnostics = config.err().expect("This must error");
+
+    diagnostics.assert_is(DatamodelError::new_source_validation_error(
+        "The URL for datasource `myds` must start with the protocol `mysql://`.",
+        "myds",
+        Span::new(119, 134),
+    ));
+}
+
+#[test]
 fn must_error_if_wrong_protocol_is_used_for_postgresql() {
     let schema = r#"
         datasource myds {
@@ -158,6 +179,25 @@ fn must_error_if_wrong_protocol_is_used_for_postgresql() {
         "The URL for datasource `myds` must start with the protocol `postgresql://`.",
         "myds",
         Span::new(81, 91),
+    ));
+}
+
+#[test]
+fn must_error_if_wrong_protocol_is_used_for_postgresql_shadow_database_url() {
+    let schema = r#"
+        datasource myds {
+            provider = "postgresql"
+            url = "postgresql://"
+            shadowDatabaseUrl = "mysql://"
+        }
+    "#;
+    let config = datamodel::parse_configuration(schema);
+    assert!(config.is_err());
+    let diagnostics = config.err().expect("This must error");
+    diagnostics.assert_is(DatamodelError::new_source_validation_error(
+        "The URL for datasource `myds` must start with the protocol `postgresql://`.",
+        "myds",
+        Span::new(129, 139),
     ));
 }
 


### PR DESCRIPTION
Question to the reviewers: is the error confusing because it doesn't specifically refer to the shadow database URL? Is it worth implementing a different code path and code reuse for this?

closes https://github.com/prisma/migrations-team/issues/196