### PR TITLE
A channel-based log stream for N-API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2864,7 +2864,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "tracing-attributes",
  "tracing-futures",
  "tracing-subscriber",
  "url 2.2.0",

--- a/libs/feature-flags/src/lib.rs
+++ b/libs/feature-flags/src/lib.rs
@@ -56,7 +56,7 @@ macro_rules! flags {
 // `groupBy`: Group-By aggregations in the QE.
 // `createMany`: Create many (bulk insert) API operation.
 // `orderByRelation`: Allows ordering by to-one relation in the QE API.
-flags!(microsoftSqlServer, groupBy, createMany, orderByRelation);
+flags!(microsoftSqlServer, groupBy, createMany, orderByRelation, napi);
 
 /// Initializes the feature flags with given flags.
 /// Noop if already initialized.

--- a/query-engine/query-engine-napi/Cargo.toml
+++ b/query-engine/query-engine-napi/Cargo.toml
@@ -27,9 +27,8 @@ url = "2"
 serde_json = "1"
 serde = "1"
 tracing = "0.1"
-tracing-attributes = "0.1"
-tracing-subscriber = { version = "0.2", features = ["json"] }
-tracing-futures = "0.2.3"
+tracing-subscriber = "0.2"
+tracing-futures = "0.2"
 tokio = { version = "1", features = ["sync"] }
 
 [build-dependencies]

--- a/query-engine/query-engine-napi/src/engine.rs
+++ b/query-engine/query-engine-napi/src/engine.rs
@@ -115,7 +115,7 @@ impl QueryEngine {
         let flags: Vec<_> = config.subject.preview_features().map(|s| s.to_string()).collect();
 
         if feature_flags::initialize(&flags).is_err() {
-            panic!("How feature flags are currently implemented, you must start a new node process to re-initialize a new Query Engine. Sorry Tim!");
+            eprintln!("We currently cannot change the feature flags more than once per process.");
         }
 
         let datamodel = EngineDatamodel {

--- a/query-engine/query-engine-napi/src/lib.rs
+++ b/query-engine/query-engine-napi/src/lib.rs
@@ -116,7 +116,7 @@ fn next_log_event(ctx: CallContext) -> napi::Result<JsObject> {
     let engine: QueryEngine = engine.clone();
 
     ctx.env.execute_tokio_future(
-        async move { Ok(engine.next_log_event().await?) },
+        async move { Ok(engine.next_log_event().await) },
         |&mut env, event| match event {
             Some(event) => env.create_string(&event),
             None => env.get_null().and_then(|nil| nil.coerce_to_string()),

--- a/query-engine/query-engine-napi/src/logger.rs
+++ b/query-engine/query-engine-napi/src/logger.rs
@@ -39,11 +39,6 @@ impl ChannelLogger {
         }
     }
 
-    /// The current log level of the logger.
-    pub fn log_level(&self) -> LevelFilter {
-        self.level
-    }
-
     /// Wraps a future to a logger, storing all events in the pipeline to
     /// the channel.
     pub async fn with_logging<F, U, T>(&self, f: F) -> crate::Result<T>
@@ -58,5 +53,16 @@ impl ChannelLogger {
     /// closed.
     pub async fn next_event(&self) -> Option<String> {
         self.receiver.lock().await.recv().await
+    }
+
+    /// A special event to notify the JavaScript listener to stop listening,
+    /// helping us to get around of the problem of not having streams on
+    /// JavaScript.
+    pub async fn disconnect_listeners(&self) -> crate::Result<()> {
+        self.with_logging(|| async {
+            tracing::info!("disconnected");
+            Ok(())
+        })
+        .await
     }
 }

--- a/query-engine/query-engine-napi/src/logger.rs
+++ b/query-engine/query-engine-napi/src/logger.rs
@@ -1,8 +1,62 @@
-use tracing::subscriber;
-use tracing_subscriber::{EnvFilter, FmtSubscriber};
+mod channel;
+mod registry;
+mod visitor;
 
-pub fn init() {
-    let filter = EnvFilter::from_default_env();
-    let subscriber = FmtSubscriber::builder().json().with_env_filter(filter).finish();
-    let _ = subscriber::set_global_default(subscriber);
+use std::{future::Future, sync::Arc};
+
+use channel::EventChannel;
+use registry::EventRegistry;
+use tokio::sync::{mpsc, Mutex};
+use tracing::level_filters::LevelFilter;
+use tracing_futures::WithSubscriber;
+use tracing_subscriber::layer::{Layered, SubscriberExt};
+
+/// A logger logging to a bounded channel. When in scope, all log messages from
+/// the scope are stored to the channel, which must be consumed or after some
+/// point, further log lines will just be dropped.
+#[derive(Clone)]
+pub struct ChannelLogger {
+    receiver: Arc<Mutex<mpsc::Receiver<String>>>,
+    subscriber: Layered<EventChannel, EventRegistry>,
+    level: LevelFilter,
+}
+
+impl ChannelLogger {
+    /// Creates a new instance of a logger with the minimum log level.
+    pub fn new(level: LevelFilter) -> Self {
+        // We store 10_000 events, after that we drop until we have
+        // space again. We might want this to be user-configurable
+        // in the future.
+        let (sender, receiver) = mpsc::channel(10000);
+
+        let mut layer = EventChannel::new(sender);
+        layer.filter_level(level);
+
+        Self {
+            receiver: Arc::new(Mutex::new(receiver)),
+            subscriber: EventRegistry::new().with(layer),
+            level,
+        }
+    }
+
+    /// The current log level of the logger.
+    pub fn log_level(&self) -> LevelFilter {
+        self.level
+    }
+
+    /// Wraps a future to a logger, storing all events in the pipeline to
+    /// the channel.
+    pub async fn with_logging<F, U, T>(&self, f: F) -> crate::Result<T>
+    where
+        U: Future<Output = crate::Result<T>>,
+        F: FnOnce() -> U,
+    {
+        f().with_subscriber(self.subscriber.clone()).await
+    }
+
+    /// Takes the oldest log event from the channel. None, if channel is
+    /// closed.
+    pub async fn next_event(&self) -> Option<String> {
+        self.receiver.lock().await.recv().await
+    }
 }

--- a/query-engine/query-engine-napi/src/logger/channel.rs
+++ b/query-engine/query-engine-napi/src/logger/channel.rs
@@ -1,0 +1,103 @@
+use super::visitor::JsonVisitor;
+use serde_json::{Map, Value};
+use tokio::sync::mpsc;
+use tracing::{metadata::LevelFilter, span::Record, Event, Id, Subscriber};
+use tracing_subscriber::{layer::Context, registry::LookupSpan, Layer};
+
+#[derive(Clone)]
+pub struct EventChannel {
+    sender: mpsc::Sender<String>,
+    level_filter: LevelFilter,
+}
+
+impl EventChannel {
+    pub fn new(sender: mpsc::Sender<String>) -> Self {
+        Self {
+            sender,
+            level_filter: LevelFilter::OFF,
+        }
+    }
+
+    pub fn filter_level(&mut self, level_filter: LevelFilter) {
+        self.level_filter = level_filter;
+    }
+}
+
+impl<S> Layer<S> for EventChannel
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn new_span(&self, attrs: &tracing::span::Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+        let span = ctx.span(id).unwrap();
+
+        let mut extensions = span.extensions_mut();
+
+        if extensions.get_mut::<Map<String, Value>>().is_none() {
+            let mut object = Map::with_capacity(10);
+            let mut visitor = JsonVisitor::new(&mut object);
+            attrs.record(&mut visitor);
+            extensions.insert(object);
+        }
+    }
+
+    fn on_record(&self, id: &Id, values: &Record<'_>, ctx: Context<'_, S>) {
+        let span = ctx.span(id).unwrap();
+        let mut extensions = span.extensions_mut();
+
+        if let Some(mut object) = extensions.get_mut::<Map<String, Value>>() {
+            let mut visitor = JsonVisitor::new(&mut object);
+
+            values.record(&mut visitor);
+        } else {
+            let mut object = Map::with_capacity(10);
+            let mut visitor = JsonVisitor::new(&mut object);
+
+            values.record(&mut visitor);
+            extensions.insert(object);
+        }
+    }
+
+    fn on_event(&self, event: &Event<'_>, _: Context<'_, S>) {
+        let mut object: Map<String, Value> = Map::with_capacity(5);
+
+        object.insert("level".to_string(), format!("{}", event.metadata().level()).into());
+
+        let metadata = event.metadata();
+        if let Some(file) = metadata.file() {
+            object.insert("file".to_string(), file.into());
+        }
+
+        if let Some(line) = metadata.line() {
+            object.insert("line".to_string(), line.into());
+        }
+
+        if let Some(module_path) = metadata.module_path() {
+            object.insert("module_path".to_string(), module_path.into());
+        }
+
+        let mut visitor = JsonVisitor::new(&mut object);
+        event.record(&mut visitor);
+
+        let js_object = Value::Object(object);
+        let json_str = serde_json::to_string(&js_object).unwrap();
+
+        if let Err(e) = self.sender.try_send(json_str) {
+            match e {
+                mpsc::error::TrySendError::Full(_) => {
+                    eprintln!("Dropped a log message, buffer is full.")
+                }
+                mpsc::error::TrySendError::Closed(_) => {
+                    eprintln!("Event channel closed while we're still logging.")
+                }
+            }
+        }
+    }
+
+    fn enabled(&self, metadata: &tracing::Metadata<'_>, ctx: Context<'_, S>) -> bool {
+        self.level_filter.enabled(metadata, ctx)
+    }
+
+    fn max_level_hint(&self) -> Option<LevelFilter> {
+        Some(self.level_filter)
+    }
+}

--- a/query-engine/query-engine-napi/src/logger/channel.rs
+++ b/query-engine/query-engine-napi/src/logger/channel.rs
@@ -63,14 +63,6 @@ where
         object.insert("level".to_string(), format!("{}", event.metadata().level()).into());
 
         let metadata = event.metadata();
-        if let Some(file) = metadata.file() {
-            object.insert("file".to_string(), file.into());
-        }
-
-        if let Some(line) = metadata.line() {
-            object.insert("line".to_string(), line.into());
-        }
-
         if let Some(module_path) = metadata.module_path() {
             object.insert("module_path".to_string(), module_path.into());
         }

--- a/query-engine/query-engine-napi/src/logger/registry.rs
+++ b/query-engine/query-engine-napi/src/logger/registry.rs
@@ -1,0 +1,67 @@
+use std::sync::Arc;
+
+use tracing::{
+    span::{Attributes, Record},
+    Event, Id, Metadata, Subscriber,
+};
+use tracing_subscriber::{
+    registry::{Data, LookupSpan},
+    Registry,
+};
+
+#[derive(Clone)]
+pub struct EventRegistry {
+    inner: Arc<Registry>,
+}
+
+impl Default for EventRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl EventRegistry {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Registry::default()),
+        }
+    }
+}
+
+impl<'a> LookupSpan<'a> for EventRegistry {
+    type Data = Data<'a>;
+
+    fn span_data(&'a self, id: &Id) -> Option<Self::Data> {
+        self.inner.span_data(id)
+    }
+}
+
+impl Subscriber for EventRegistry {
+    fn enabled(&self, metadata: &Metadata<'_>) -> bool {
+        self.inner.enabled(metadata)
+    }
+
+    fn new_span(&self, span: &Attributes<'_>) -> Id {
+        self.inner.new_span(span)
+    }
+
+    fn record(&self, span: &Id, values: &Record<'_>) {
+        self.inner.record(span, values)
+    }
+
+    fn record_follows_from(&self, span: &Id, follows: &Id) {
+        self.inner.record_follows_from(span, follows)
+    }
+
+    fn event(&self, event: &Event<'_>) {
+        self.inner.event(event)
+    }
+
+    fn enter(&self, span: &Id) {
+        self.inner.enter(span)
+    }
+
+    fn exit(&self, span: &Id) {
+        self.inner.exit(span)
+    }
+}

--- a/query-engine/query-engine-napi/src/logger/visitor.rs
+++ b/query-engine/query-engine-napi/src/logger/visitor.rs
@@ -1,0 +1,39 @@
+use serde_json::{Map, Value};
+use std::fmt;
+use tracing::field::{Field, Visit};
+
+pub struct JsonVisitor<'a> {
+    object: &'a mut Map<String, Value>,
+}
+
+impl<'a> JsonVisitor<'a> {
+    pub fn new(object: &'a mut Map<String, Value>) -> Self {
+        Self { object }
+    }
+}
+
+impl<'a> Visit for JsonVisitor<'a> {
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        self.object
+            .insert(field.name().to_string(), format!("{:?}", value).into());
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.object
+            .insert(field.name().to_string(), format!("{}", value).into());
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.object
+            .insert(field.name().to_string(), format!("{}", value).into());
+    }
+
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.object
+            .insert(field.name().to_string(), format!("{}", value).into());
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.object.insert(field.name().to_string(), value.to_string().into());
+    }
+}


### PR DESCRIPTION
When creating the Query Engine, a new parameter is added to the configuration:

```javascript
let qe = new QueryEngine({
  logLevel: "info",
  ...
});
```

This parameter can be any of: `trace`, `debug`, `info`, `warn`, `error` or `off`. The parameter is case-insensitive and sets the minimum level. `trace` logs everything, `off` logs none.

Additionally, the engine got a new method:

```javascript
let event = await qe.nextLogEvent();
```

Calling the method will pause the caller until a log event is produced to the channel, which is then returned from the method. The event is stringified JSON, which can be parsed on the JavaScript side. The method can only be called when the engine is connected.

The log level in the returned event is always capitalized.

The log channel is bounded and has a maximum capacity of 10 000 events. If the channel is not consumed fast enough and it gets full, further log events will get dropped and an error gets produced to stderr.

If the method returns a `null` value, it means engine got disconnected, and a new callback should get registered when re-connecting the engine.

Please be aware of setting the `LOG_QUERIES` environment variable to any value, if wanting to get the executed SQL queries on the channel. The queries will then arrive with the log level of `INFO`.

The compiled N-API modules are published from this branch to here:

https://prisma-builds.s3-eu-west-1.amazonaws.com/napi/log-channel/$COMMIT_ID/$PLATFORM/$FILE

The backend part of https://github.com/prisma/prisma/issues/5690