### PR TITLE
Sync Rust toolchain version in Dockerfile and doc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.44.0
+FROM rust:1.48.0
 MAINTAINER Julius de Bruijn <bruijn@prisma.io>
 
 ENV USER root

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The engines and their respective binary crates are:
 ## Building Prisma Engines
 
 **Prerequisites:**
-- Installed the stable Rust toolchain, at least version 1.39.0. You can get the
+- Installed the stable Rust toolchain, at least version 1.48.0. You can get the
   toolchain at [rustup](https://rustup.rs/) or the package manager of your
   choice.
 - Linux only: OpenSSL is required to be installed.


### PR DESCRIPTION
* Sync Rust toolchain version in Dockerfile with CI specification (.github/workflows/build-windows.yml)
  - To fix compile errors by dependencies (https://github.com/prisma/connection-string/pull/14, https://github.com/prisma/quaint/pull/257)
* Fix minimum version of Rust toolchain described in README.md https://github.com/prisma/quaint/pull/257