### PR TITLE
Foreign keys should always be in the written order

### DIFF
--- a/libs/sql-schema-describer/src/walkers.rs
+++ b/libs/sql-schema-describer/src/walkers.rs
@@ -306,12 +306,10 @@ impl<'schema> ForeignKeyWalker<'schema> {
 
     /// The foreign key columns on the referencing table.
     pub fn constrained_columns<'b>(&'b self) -> impl Iterator<Item = ColumnWalker<'schema>> + 'b {
-        self.table().columns().filter(move |column| {
-            self.foreign_key()
-                .columns
-                .iter()
-                .any(|colname| colname == column.name())
-        })
+        self.foreign_key()
+            .columns
+            .iter()
+            .filter_map(move |colname| self.table().columns().find(|column| colname == column.name()))
     }
 
     /// The name of the foreign key constraint.

--- a/migration-engine/migration-engine-tests/tests/migrations/relations.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/relations.rs
@@ -256,6 +256,50 @@ async fn removing_an_inline_relation_must_work(api: &TestApi) -> TestResult {
 }
 
 #[test_each_connector]
+async fn compound_foreign_keys_should_work_in_correct_order(api: &TestApi) -> TestResult {
+    let dm1 = r#"
+        model A {
+            id Int @id
+            b Int
+            a Int
+            d Int
+            bb B @relation(fields: [a, b, d], references: [a_id, b_id, d_id])
+        }
+
+        model B {
+            b_id Int
+            a_id Int
+            d_id Int
+            @@id([a_id, b_id, d_id])
+        }
+    "#;
+
+    api.schema_push(dm1).send().await?.assert_green()?;
+
+    let result = api.describe_database().await?;
+    let table = result.table_bang("A");
+
+    assert_eq!(
+        table.foreign_keys,
+        &[ForeignKey {
+            constraint_name: match api.sql_family() {
+                SqlFamily::Postgres => Some("A_a_b_d_fkey".to_owned()),
+                SqlFamily::Sqlite => None,
+                SqlFamily::Mysql => Some("A_ibfk_1".to_owned()),
+                SqlFamily::Mssql => Some("A_a_b_d_fkey".to_owned()),
+            },
+            columns: vec!["a".to_string(), "b".to_string(), "d".to_string()],
+            referenced_table: "B".to_string(),
+            referenced_columns: vec!["a_id".to_string(), "b_id".to_string(), "d_id".to_string()],
+            on_delete_action: ForeignKeyAction::Cascade,
+            on_update_action: ForeignKeyAction::NoAction,
+        }]
+    );
+
+    Ok(())
+}
+
+#[test_each_connector]
 async fn moving_an_inline_relation_to_the_other_side_must_work(api: &TestApi) -> TestResult {
     let dm1 = r#"
         model A {


### PR DESCRIPTION
In this bug, we iterate first from the table's columns, finding the columns to the given foreign key. If the table has columns in a
different order than in the key, we try to create a foreign key with the compound columns in a wrong order.

We should instead iterate from the foreign key columns, which preserves the column ordering.

Closes: https://github.com/prisma/prisma/issues/5589