### PR TITLE
Do not fail on missing/empty shadow database URLs

### DIFF
--- a/libs/datamodel/core/src/transform/ast_to_dml/datasource_loader.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/datasource_loader.rs
@@ -160,56 +160,51 @@ impl DatasourceLoader {
 
         let shadow_database_url_arg = args.optional_arg(SHADOW_DATABASE_URL_KEY);
 
-        let shadow_database_url = if let Some(shadow_database_url_arg) = shadow_database_url_arg.as_ref() {
-            let shadow_database_url = match (shadow_database_url_arg.as_str_from_env(), override_url) {
-                (Err(err), _)
-                    if ignore_datasource_urls
-                        && err.description().contains("Expected a String value, but received") =>
-                {
-                    return Err(diagnostics.merge_error(err));
-                }
-                (_, _) if ignore_datasource_urls => {
-                    // glorious hack. ask marcus
-                    StringFromEnvVar {
-                        from_env_var: None,
-                        value: format!("{}://", providers.first().unwrap()),
+        let shadow_database_url: Option<StringFromEnvVar> =
+            if let Some(shadow_database_url_arg) = shadow_database_url_arg.as_ref() {
+                let shadow_database_url = match shadow_database_url_arg.as_str_from_env() {
+                    Err(err)
+                        if ignore_datasource_urls
+                            && err.description().contains("Expected a String value, but received") =>
+                    {
+                        return Err(diagnostics.merge_error(err));
                     }
-                }
-                (_, Some(url)) => {
-                    debug!(
-                        "overwriting datasource `{}` shadow database url with url '{}'",
-                        &source_name, &url
-                    );
-                    StringFromEnvVar {
-                        from_env_var: None,
-                        value: url.to_owned(),
+                    _ if ignore_datasource_urls => {
+                        // glorious hack. ask marcus
+                        Some(StringFromEnvVar {
+                            from_env_var: None,
+                            value: format!("{}://", providers.first().unwrap()),
+                        })
                     }
-                }
-                (Ok((env_var, url)), _) => StringFromEnvVar {
-                    from_env_var: env_var,
-                    value: url.trim().to_owned(),
-                },
-                (Err(err), _) => {
-                    return Err(diagnostics.merge_error(err));
-                }
+
+                    Ok((env_var, url)) => Some(StringFromEnvVar {
+                        from_env_var: env_var,
+                        value: url.trim().to_owned(),
+                    })
+                    .filter(|s| !s.value.is_empty()),
+
+                    // We intentionally ignore the shadow database URL if it is defined in an env var that is missing.
+                    Err(DatamodelError::EnvironmentFunctionalEvaluationError { .. }) => None,
+
+                    Err(err) => {
+                        return Err(diagnostics.merge_error(err));
+                    }
+                };
+
+                // Temporarily disabled because of processing/hacks on URLs that make comparing the two URLs unreliable.
+                // if url.value == shadow_database_url.value {
+                //     return Err(
+                //         diagnostics.merge_error(DatamodelError::new_shadow_database_is_same_as_main_url_error(
+                //             source_name.clone(),
+                //             shadow_database_url_arg.span(),
+                //         )),
+                //     );
+                // }
+
+                shadow_database_url
+            } else {
+                None
             };
-
-            validate_datasource_url(&shadow_database_url, source_name, &url_arg)?;
-
-            // Temporarily disabled because of processing/hacks on URLs that make comparing the two URLs unreliable.
-            // if url.value == shadow_database_url.value {
-            //     return Err(
-            //         diagnostics.merge_error(DatamodelError::new_shadow_database_is_same_as_main_url_error(
-            //             source_name.clone(),
-            //             shadow_database_url_arg.span(),
-            //         )),
-            //     );
-            // }
-
-            Some(shadow_database_url)
-        } else {
-            None
-        };
 
         preview_features_guardrail(&mut args)?;
 
@@ -320,6 +315,7 @@ fn preview_features_guardrail(args: &mut Arguments) -> Result<(), DatamodelError
     ))
 }
 
+/// Validate that the `url` argument in the datasource block is not empty.
 fn validate_datasource_url(
     url: &StringFromEnvVar,
     source_name: &str,

--- a/libs/datamodel/core/src/transform/helpers/value_validator.rs
+++ b/libs/datamodel/core/src/transform/helpers/value_validator.rs
@@ -92,11 +92,11 @@ impl ValueValidator {
         match &self.value {
             ast::Expression::Function(name, _, _) if name == "env" => {
                 let env_function = self.as_env_function()?;
-                let var_name = Some(env_function.var_name().to_string());
+                let var_name = Some(env_function.var_name().to_owned());
                 let value = env_function.evaluate().and_then(|x| x.as_str())?;
                 Ok((var_name, value))
             }
-            ast::Expression::StringValue(value, _) => Ok((None, value.to_string())),
+            ast::Expression::StringValue(value, _) => Ok((None, value.clone())),
             _ => Err(self.construct_type_mismatch_error("String")),
         }
     }

--- a/libs/datamodel/core/tests/config/sources.rs
+++ b/libs/datamodel/core/tests/config/sources.rs
@@ -165,6 +165,39 @@ fn must_error_if_wrong_protocol_is_used_for_mysql_shadow_database_url() {
 }
 
 #[test]
+#[serial]
+fn must_not_error_for_empty_shadow_database_urls_derived_from_env_vars() {
+    std::env::set_var("DB_URL", "  ");
+
+    let schema = r#"
+        datasource myds {
+            provider = "postgres"
+            url = "postgres://"
+            shadowDatabaseUrl = env("DB_URL")
+        }
+    "#;
+
+    let config = datamodel::parse_configuration(schema).unwrap();
+
+    assert!(config.subject.datasources[0].shadow_database_url.is_none());
+}
+
+#[test]
+fn must_not_error_for_shadow_database_urls_derived_from_missing_env_vars() {
+    let schema = r#"
+        datasource myds {
+            provider = "postgres"
+            url = "postgres://"
+            shadowDatabaseUrl = env("SHADOW_DATABASE_URL_NOT_SET_21357")
+        }
+    "#;
+
+    let config = datamodel::parse_configuration(schema).unwrap();
+
+    assert!(config.subject.datasources[0].shadow_database_url.is_none());
+}
+
+#[test]
 fn must_error_if_wrong_protocol_is_used_for_postgresql() {
     let schema = r#"
         datasource myds {


### PR DESCRIPTION
The current behaviour forces users to specify a shadow database URL in
their environment, even for situations (e.g. deployment) where you would
not need, and indeed should not use a shadow database.

This PR makes the datamodel parser ignore the shadow database URL if it
is empty, or the env var is not defined.

closes https://github.com/prisma/prisma/issues/5704