### PR TITLE
Replace direct references with indexes in datamodel walkers

### DIFF
--- a/introspection-engine/connectors/sql-introspection-connector/src/re_introspection.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/re_introspection.rs
@@ -108,8 +108,8 @@ pub fn enrich(old_data_model: &Datamodel, new_data_model: &mut Datamodel, family
             for field in model.relation_fields() {
                 if let Some(old_model) = old_data_model.find_model(&model.name) {
                     for old_field in old_model.relation_fields() {
-                        let related_field = &new_data_model.find_related_field_bang(&field);
-                        let old_related_field = &old_data_model.find_related_field_bang(&old_field);
+                        let (_, related_field) = &new_data_model.find_related_field_bang(&field);
+                        let (_, old_related_field) = &old_data_model.find_related_field_bang(&old_field);
                         //the relationinfos of both sides need to be compared since the relationinfo of the
                         // non-fk side does not contain enough information to uniquely identify the correct relationfield
 
@@ -148,8 +148,8 @@ pub fn enrich(old_data_model: &Datamodel, new_data_model: &mut Datamodel, family
             for field in model.relation_fields() {
                 if let Some(old_model) = old_data_model.find_model(&model.name) {
                     for old_field in old_model.relation_fields() {
-                        let related_field = &new_data_model.find_related_field_bang(&field);
-                        let old_related_field = &old_data_model.find_related_field_bang(&old_field);
+                        let (_, related_field) = &new_data_model.find_related_field_bang(&field);
+                        let (_, old_related_field) = &old_data_model.find_related_field_bang(&old_field);
                         //the relationinfos of both sides need to be compared since the relationinfo of the
                         // non-fk side does not contain enough information to uniquely identify the correct relationfield
 

--- a/libs/datamodel/connectors/dml/src/datamodel.rs
+++ b/libs/datamodel/connectors/dml/src/datamodel.rs
@@ -69,7 +69,7 @@ impl Datamodel {
 
     /// Finds parent  model for a field reference.
     pub fn find_model_by_relation_field_ref(&self, field: &RelationField) -> Option<&Model> {
-        self.find_model(&self.find_related_field_bang(&field).relation_info.to)
+        self.find_model(&self.find_related_field_bang(&field).1.relation_info.to)
     }
 
     /// Finds a mutable field reference by a model and field name.
@@ -138,12 +138,15 @@ impl Datamodel {
         fields
     }
 
-    /// Finds a relation field related to a relation info
-    pub fn find_related_field_for_info(&self, info: &RelationInfo, exclude: &str) -> Option<&RelationField> {
+    /// Finds a relation field related to a relation info. Returns a tuple (index_of_relation_field_in_model, relation_field).
+    pub fn find_related_field_for_info(&self, info: &RelationInfo, exclude: &str) -> Option<(usize, &RelationField)> {
         self.find_model(&info.to)
             .expect("The model referred to by a RelationInfo should always exist.")
-            .relation_fields()
-            .find(|f| {
+            .fields
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, field)| field.as_relation_field().map(|f| (idx, f)))
+            .find(|(_idx, f)| {
                 f.relation_info.name == info.name
                     && (f.relation_info.to != info.to ||
           // This is to differentiate the opposite field from self in the self relation case.
@@ -152,12 +155,12 @@ impl Datamodel {
     }
 
     /// This finds the related field for a relationfield if available
-    pub fn find_related_field(&self, rf: &RelationField) -> Option<&RelationField> {
+    pub fn find_related_field(&self, rf: &RelationField) -> Option<(usize, &RelationField)> {
         self.find_related_field_for_info(&rf.relation_info, &rf.name)
     }
 
     /// This is used once we assume the datamodel to be internally valid
-    pub fn find_related_field_bang(&self, rf: &RelationField) -> &RelationField {
+    pub fn find_related_field_bang(&self, rf: &RelationField) -> (usize, &RelationField) {
         self.find_related_field(rf)
             .expect("Every RelationInfo should have a complementary RelationInfo on the opposite relation field.")
     }

--- a/libs/datamodel/connectors/dml/src/field.rs
+++ b/libs/datamodel/connectors/dml/src/field.rs
@@ -98,6 +98,13 @@ pub enum Field {
 }
 
 impl Field {
+    pub fn as_relation_field(&self) -> Option<&RelationField> {
+        match self {
+            Field::RelationField(sf) => Some(sf),
+            _ => None,
+        }
+    }
+
     pub fn as_scalar_field(&self) -> Option<&ScalarField> {
         match self {
             Field::ScalarField(sf) => Some(sf),
@@ -106,10 +113,11 @@ impl Field {
     }
 
     pub fn is_relation(&self) -> bool {
-        match self {
-            Field::ScalarField(_) => false,
-            Field::RelationField(_) => true,
-        }
+        matches!(self, Field::RelationField(_))
+    }
+
+    pub fn is_scalar_field(&self) -> bool {
+        matches!(self, Field::ScalarField(_))
     }
 
     pub fn name(&self) -> &str {

--- a/libs/datamodel/connectors/dml/src/model.rs
+++ b/libs/datamodel/connectors/dml/src/model.rs
@@ -92,18 +92,12 @@ impl Model {
 
     /// Gets an iterator over all scalar fields.
     pub fn scalar_fields(&self) -> impl Iterator<Item = &ScalarField> {
-        self.fields().filter_map(|fw| match fw {
-            Field::RelationField(_) => None,
-            Field::ScalarField(sf) => Some(sf),
-        })
+        self.fields.iter().filter_map(|f| f.as_scalar_field())
     }
 
     /// Gets an iterator over all relation fields.
     pub fn relation_fields(&self) -> impl Iterator<Item = &RelationField> {
-        self.fields().filter_map(|fw| match fw {
-            Field::RelationField(rf) => Some(rf),
-            Field::ScalarField(_) => None,
-        })
+        self.fields.iter().filter_map(|f| f.as_relation_field())
     }
 
     /// Gets a mutable iterator over all scalar fields.

--- a/libs/datamodel/core/src/ast/helper.rs
+++ b/libs/datamodel/core/src/ast/helper.rs
@@ -1,16 +1,14 @@
-pub fn get_sort_index_of_attribute(is_field_attribute: bool, attribute_name: &str) -> usize {
+/// Get the sort order for an attribute, in the canonical sorting order.
+pub(crate) fn get_sort_index_of_attribute(is_field_attribute: bool, attribute_name: &str) -> usize {
     // this must match the order defined for rendering in libs/datamodel/core/src/transform/attributes/mod.rs
-    let correct_order = if is_field_attribute {
-        vec!["id", "unique", "default", "updatedAt", "map", "relation"]
+    let correct_order: &[&str] = if is_field_attribute {
+        &["id", "unique", "default", "updatedAt", "map", "relation"]
     } else {
-        vec!["id", "unique", "index", "map"]
+        &["id", "unique", "index", "map"]
     };
-    if let Some(sort_index) = correct_order
+
+    correct_order
         .iter()
-        .position(|p| attribute_name.starts_with(p) || attribute_name.starts_with(&format!("@@{}", p)))
-    {
-        sort_index
-    } else {
-        usize::MAX
-    }
+        .position(|p| attribute_name.trim_start_matches('@').starts_with(p))
+        .unwrap_or(usize::MAX)
 }

--- a/libs/datamodel/core/src/transform/ast_to_dml/standardise.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/standardise.rs
@@ -54,7 +54,7 @@ impl Standardiser {
             for field in model.fields_mut() {
                 if let Field::RelationField(field) = field {
                     let related_model = schema_copy.find_model(&field.relation_info.to).expect(STATE_ERROR);
-                    let related_field = schema_copy.find_related_field_bang(field);
+                    let (_related_field_idx, related_field) = schema_copy.find_related_field_bang(field);
                     let related_model_name = &related_model.name;
                     let is_m2m = field.is_list() && related_field.is_list();
                     let rel_info = &mut field.relation_info;

--- a/libs/datamodel/core/src/transform/ast_to_dml/validate.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validate.rs
@@ -735,7 +735,7 @@ impl<'a> Validator<'a> {
                 let is_many_to_many = {
                     // Back relation fields have not been added yet. So we must calculate this on our own.
                     match datamodel.find_related_field(&field) {
-                        Some(related_field) => field.is_list() && related_field.is_list(),
+                        Some((_, related_field)) => field.is_list() && related_field.is_list(),
                         None => false,
                     }
                 };
@@ -817,7 +817,7 @@ impl<'a> Validator<'a> {
 
             let rel_info = &field.relation_info;
             let related_model = datamodel.find_model(&rel_info.to).expect(STATE_ERROR);
-            let related_field = datamodel.find_related_field_bang(&field);
+            let (_, related_field) = datamodel.find_related_field_bang(&field);
             let related_field_rel_info = &related_field.relation_info;
 
             if related_model.is_ignored && !field.is_ignored && !model.is_ignored {

--- a/libs/datamodel/core/src/transform/attributes/relation.rs
+++ b/libs/datamodel/core/src/transform/attributes/relation.rs
@@ -81,7 +81,7 @@ impl AttributeValidator<dml::Field> for RelationAttributeValidator {
             if !relation_info.references.is_empty() {
                 let is_many_to_many = match &field {
                     Field::RelationField(relation_field) => {
-                        let related_field = datamodel.find_related_field(&relation_field).unwrap();
+                        let (_, related_field) = datamodel.find_related_field(&relation_field).unwrap();
                         relation_field.arity.is_list() && related_field.arity.is_list()
                     }
                     _ => false,

--- a/libs/datamodel/core/src/walkers.rs
+++ b/libs/datamodel/core/src/walkers.rs
@@ -115,7 +115,7 @@ impl<'a> ModelWalker<'a> {
     }
 
     pub fn id_fields(&self) -> impl Iterator<Item = ScalarFieldWalker<'a>> + 'a {
-        let walker = self.clone();
+        let walker = *self;
         let model_idx = self.model_idx;
         let datamodel = self.datamodel;
 

--- a/libs/prisma-models/src/datamodel_converter.rs
+++ b/libs/prisma-models/src/datamodel_converter.rs
@@ -168,7 +168,7 @@ impl<'a> DatamodelConverter<'a> {
                     .find_model(&to)
                     .unwrap_or_else(|| panic!("Related model {} not found", to));
 
-                let related_field = datamodel.find_related_field_bang(&field);
+                let (_, related_field) = datamodel.find_related_field_bang(&field);
 
                 let related_field_info: &dml::RelationInfo = &related_field.relation_info;
 


### PR DESCRIPTION
This is a necessary refactoring for an upcoming PR.

The sql_schema_describer walkers were refactored in this direction
months ago, and it proved better overall: for the same datastructure
size, we have more information and fewer lifetime problems.