### PR TITLE
Drop views on schema soft reset

### DIFF
--- a/libs/sql-schema-describer/src/lib.rs
+++ b/libs/sql-schema-describer/src/lib.rs
@@ -8,7 +8,7 @@ use std::fmt::Debug;
 
 pub use error::{DescriberError, DescriberErrorKind, DescriberResult};
 use prisma_value::PrismaValue;
-use walkers::{EnumWalker, TableWalker};
+use walkers::{EnumWalker, TableWalker, ViewWalker};
 
 pub mod getters;
 pub mod mssql;
@@ -119,6 +119,10 @@ impl SqlSchema {
 
     pub fn table_walkers(&self) -> impl Iterator<Item = TableWalker<'_>> {
         (0..self.tables.len()).map(move |table_index| TableWalker::new(self, table_index))
+    }
+
+    pub fn view_walkers(&self) -> impl Iterator<Item = ViewWalker<'_>> {
+        (0..self.views.len()).map(move |view_index| ViewWalker::new(self, view_index))
     }
 
     pub fn enum_walkers(&self) -> impl Iterator<Item = EnumWalker<'_>> {

--- a/libs/sql-schema-describer/src/mssql.rs
+++ b/libs/sql-schema-describer/src/mssql.rs
@@ -1,7 +1,7 @@
 use crate::{
     getters::Getter, parsers::Parser, Column, ColumnArity, ColumnType, ColumnTypeFamily, DefaultValue, DescriberError,
-    DescriberErrorKind, DescriberResult, ForeignKey, ForeignKeyAction, Index, IndexType, PrimaryKey, SQLMetadata,
-    SqlSchema, Table, View,
+    DescriberErrorKind, DescriberResult, ForeignKey, ForeignKeyAction, Index, IndexType, PrimaryKey, Procedure,
+    SQLMetadata, SqlSchema, Table, View,
 };
 use indoc::indoc;
 use native_types::{MsSqlType, MsSqlTypeParameter, NativeType};

--- a/libs/sql-schema-describer/src/walkers.rs
+++ b/libs/sql-schema-describer/src/walkers.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     Column, ColumnArity, ColumnType, ColumnTypeFamily, DefaultValue, Enum, ForeignKey, ForeignKeyAction, Index,
-    IndexType, PrimaryKey, SqlSchema, Table,
+    IndexType, PrimaryKey, SqlSchema, Table, View,
 };
 use serde::de::DeserializeOwned;
 use std::fmt;
@@ -140,10 +140,45 @@ impl<'a> ColumnWalker<'a> {
     }
 }
 
+/// Traverse a view
+#[derive(Clone, Copy)]
+pub struct ViewWalker<'a> {
+    /// The schema the view is contained in.
+    schema: &'a SqlSchema,
+    /// The index of the view in the schema.
+    view_index: usize,
+}
+
+impl<'a> ViewWalker<'a> {
+    /// Create a ViewWalker from a schema and a reference to one of its views.
+    pub fn new(schema: &'a SqlSchema, view_index: usize) -> Self {
+        Self { schema, view_index }
+    }
+
+    /// The name of the view
+    pub fn name(&self) -> &'a str {
+        &self.view().name
+    }
+
+    /// The SQL definition of the view
+    pub fn definition(&self) -> &'a str {
+        &self.view().definition
+    }
+
+    /// The index of the view in the schema.
+    pub fn view_index(&self) -> usize {
+        self.view_index
+    }
+
+    fn view(&self) -> &'a View {
+        &self.schema.views[self.view_index]
+    }
+}
+
 /// Traverse a table.
 #[derive(Clone, Copy)]
 pub struct TableWalker<'a> {
-    /// The schema the column is contained in.
+    /// The schema the table is contained in.
     schema: &'a SqlSchema,
     /// The index of the table in the schema.
     table_index: usize,
@@ -491,6 +526,9 @@ pub trait SqlSchemaExt {
 
     /// Find a table by index.
     fn table_walker_at(&self, index: usize) -> TableWalker<'_>;
+
+    /// Find a view by index.
+    fn view_walker_at(&self, index: usize) -> ViewWalker<'_>;
 }
 
 impl SqlSchemaExt for SqlSchema {
@@ -511,6 +549,13 @@ impl SqlSchemaExt for SqlSchema {
     fn table_walker_at(&self, index: usize) -> TableWalker<'_> {
         TableWalker {
             table_index: index,
+            schema: self,
+        }
+    }
+
+    fn view_walker_at(&self, index: usize) -> ViewWalker<'_> {
+        ViewWalker {
+            view_index: index,
             schema: self,
         }
     }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
@@ -172,5 +172,10 @@ fn render_raw_sql(
         SqlMigrationStep::AlterIndex { table, index } => {
             renderer.render_alter_index(schemas.tables(table).indexes(index).as_ref())
         }
+        SqlMigrationStep::DropView(drop_view) => {
+            let view = schemas.previous().view_walker_at(drop_view.view_index);
+
+            vec![renderer.render_drop_view(&view)]
+        }
     }
 }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_migration.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_migration.rs
@@ -39,6 +39,7 @@ pub(crate) enum SqlMigrationStep {
     CreateEnum(CreateEnum),
     DropEnum(DropEnum),
     AlterEnum(AlterEnum),
+    DropView(DropView),
 }
 
 impl SqlMigrationStep {
@@ -57,6 +58,7 @@ impl SqlMigrationStep {
             SqlMigrationStep::CreateEnum(_) => "CreateEnum",
             SqlMigrationStep::DropEnum(_) => "DropEnum",
             SqlMigrationStep::AlterEnum(_) => "AlterEnum",
+            SqlMigrationStep::DropView(_) => "DropView",
         }
     }
 }
@@ -101,6 +103,17 @@ impl TableChange {
             TableChange::AlterColumn(col) => Some(col),
             _ => None,
         }
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub(crate) struct DropView {
+    pub view_index: usize,
+}
+
+impl DropView {
+    pub fn new(view_index: usize) -> Self {
+        Self { view_index }
     }
 }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer.rs
@@ -22,10 +22,7 @@ use crate::{
 };
 use common::Quoted;
 use sql_schema_describer::{
-    walkers::EnumWalker,
-    walkers::ForeignKeyWalker,
-    walkers::IndexWalker,
-    walkers::{ColumnWalker, TableWalker},
+    walkers::{ColumnWalker, EnumWalker, ForeignKeyWalker, IndexWalker, TableWalker, ViewWalker},
     ColumnTypeFamily, DefaultValue, SqlSchema,
 };
 use std::borrow::Cow;
@@ -85,4 +82,6 @@ pub(crate) trait SqlRenderer {
 
     /// Render a table renaming step.
     fn render_rename_table(&self, name: &str, new_name: &str) -> String;
+
+    fn render_drop_view(&self, view: &ViewWalker<'_>) -> String;
 }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mssql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mssql_renderer.rs
@@ -11,7 +11,7 @@ use indoc::formatdoc;
 use native_types::{MsSqlType, MsSqlTypeParameter};
 use prisma_value::PrismaValue;
 use sql_schema_describer::{
-    walkers::{ColumnWalker, EnumWalker, ForeignKeyWalker, IndexWalker, TableWalker},
+    walkers::{ColumnWalker, EnumWalker, ForeignKeyWalker, IndexWalker, TableWalker, ViewWalker},
     ColumnTypeFamily, DefaultKind, DefaultValue, IndexType, SqlSchema,
 };
 use std::{
@@ -404,6 +404,10 @@ impl SqlRenderer for MssqlFlavour {
 
     fn render_drop_table(&self, table_name: &str) -> Vec<String> {
         vec![format!("DROP TABLE {}", self.quote_with_schema(&table_name))]
+    }
+
+    fn render_drop_view(&self, view: &ViewWalker<'_>) -> String {
+        format!("DROP VIEW {}", self.quote_with_schema(view.name()))
     }
 }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
@@ -15,7 +15,7 @@ use prisma_value::PrismaValue;
 use regex::Regex;
 use sql_ddl::mysql as ddl;
 use sql_schema_describer::{
-    walkers::{ColumnWalker, EnumWalker, ForeignKeyWalker, IndexWalker, TableWalker},
+    walkers::{ColumnWalker, EnumWalker, ForeignKeyWalker, IndexWalker, TableWalker, ViewWalker},
     ColumnTypeFamily, DefaultKind, DefaultValue, ForeignKeyAction, SqlSchema,
 };
 use std::borrow::Cow;
@@ -338,6 +338,10 @@ impl SqlRenderer for MysqlFlavour {
 
     fn render_create_table(&self, table: &TableWalker<'_>) -> String {
         self.render_create_table_as(table, table.name())
+    }
+
+    fn render_drop_view(&self, view: &ViewWalker<'_>) -> String {
+        format!("DROP VIEW {}", Quoted::mysql_ident(view.name()))
     }
 }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
@@ -371,6 +371,10 @@ impl SqlRenderer for PostgresFlavour {
             new_name = self.quote(new_name),
         )
     }
+
+    fn render_drop_view(&self, view: &ViewWalker<'_>) -> String {
+        format!("DROP VIEW {}", self.quote(view.name()))
+    }
 }
 
 pub(crate) fn render_column_type(col: &ColumnWalker<'_>) -> Cow<'static, str> {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
@@ -211,6 +211,10 @@ impl SqlRenderer for SqliteFlavour {
     fn render_rename_table(&self, name: &str, new_name: &str) -> String {
         format!(r#"ALTER TABLE "{}" RENAME TO "{}""#, name, new_name)
     }
+
+    fn render_drop_view(&self, view: &ViewWalker<'_>) -> String {
+        format!(r#"DROP VIEW "{}""#, view.name())
+    }
 }
 
 fn render_column_type(t: &ColumnType) -> &str {

--- a/migration-engine/migration-engine-tests/src/multi_engine_test_api.rs
+++ b/migration-engine/migration-engine-tests/src/multi_engine_test_api.rs
@@ -6,7 +6,7 @@
 use crate::{ApplyMigrations, CreateMigration, DiagnoseMigrationHistory, Reset, SchemaAssertion, SchemaPush};
 use enumflags2::BitFlags;
 use migration_core::GenericApi;
-use quaint::single::Quaint;
+use quaint::{prelude::Queryable, single::Quaint};
 use sql_migration_connector::SqlMigrationConnector;
 use tempfile::TempDir;
 use test_setup::{connectors::Tags, TestApiArgs};
@@ -126,5 +126,15 @@ impl EngineTestApi {
     /// Plan a `schemaPush` command
     pub fn schema_push(&self, dm: impl Into<String>) -> SchemaPush<'_> {
         SchemaPush::new(&self.0, dm.into())
+    }
+
+    /// The schema name of the current connected database.
+    pub fn schema_name(&self) -> &str {
+        self.0.quaint().connection_info().schema_name()
+    }
+
+    /// Execute a raw SQL command.
+    pub async fn raw_cmd(&self, cmd: &str) -> Result<(), quaint::error::Error> {
+        self.0.quaint().raw_cmd(cmd).await
     }
 }

--- a/migration-engine/migration-engine-tests/tests/migrations/soft_resets.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/soft_resets.rs
@@ -64,6 +64,13 @@ async fn soft_resets_work_on_postgres(api: TestApi) -> TestResult {
             .await?
             .assert_applied_migrations(&["01init"])?;
 
+        let add_view = format!(
+            r#"CREATE VIEW "{0}"."catcat" AS SELECT * FROM "{0}"."Cat" LIMIT 2"#,
+            engine.schema_name(),
+        );
+
+        engine.raw_cmd(&add_view).await?;
+
         engine
             .assert_schema()
             .await?
@@ -72,7 +79,6 @@ async fn soft_resets_work_on_postgres(api: TestApi) -> TestResult {
             .assert_has_table("Cat")?;
 
         engine.reset().send().await?;
-
         engine.assert_schema().await?.assert_tables_count(0)?;
 
         engine
@@ -89,7 +95,6 @@ async fn soft_resets_work_on_postgres(api: TestApi) -> TestResult {
             .assert_has_table("Cat")?;
 
         engine.reset().send().await?;
-
         engine.assert_schema().await?.assert_tables_count(0)?;
     }
 


### PR DESCRIPTION
We have mechanisms for diffing them now, but we do not use them in the normal diffing path. I left the mechanisms in place due to them being very handy when we support views in our data models. Now we only use the mechanism when triggering a soft reset.

Part of ticket: https://github.com/prisma/migrations-team/issues/192