### PR TITLE
Test SQL Server soft resets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1943,6 +1943,7 @@ dependencies = [
  "barrel",
  "bigdecimal",
  "chrono",
+ "connection-string",
  "datamodel",
  "datamodel-connector",
  "enumflags2",

--- a/libs/sql-schema-describer/src/lib.rs
+++ b/libs/sql-schema-describer/src/lib.rs
@@ -42,7 +42,7 @@ pub struct SQLMetadata {
 }
 
 /// The result of describing a database schema.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct SqlSchema {
     /// The schema's tables.
     pub tables: Vec<Table>,
@@ -108,13 +108,7 @@ impl SqlSchema {
     }
 
     pub fn empty() -> SqlSchema {
-        SqlSchema {
-            tables: Vec::new(),
-            enums: Vec::new(),
-            sequences: Vec::new(),
-            views: Vec::new(),
-            procedures: Vec::new(),
-        }
+        SqlSchema::default()
     }
 
     pub fn table_walkers(&self) -> impl Iterator<Item = TableWalker<'_>> {

--- a/migration-engine/migration-engine-tests/Cargo.toml
+++ b/migration-engine/migration-engine-tests/Cargo.toml
@@ -38,6 +38,7 @@ tokio = { version = "1.0" }
 tracing = "0.1.12"
 tracing-futures = "0.2.1"
 url = "2.1.1"
+connection-string = "0.1.13"
 
 [dependencies.quaint]
 git = "https://github.com/prisma/quaint"

--- a/migration-engine/migration-engine-tests/tests/migrations/soft_resets.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/soft_resets.rs
@@ -1,8 +1,9 @@
+use connection_string::JdbcString;
 use migration_engine_tests::{multi_engine_test_api::TestApi, TestResult};
 use quaint::{prelude::Queryable, single::Quaint};
 use test_macros::test_connectors;
 
-#[test_connectors(tags("postgres"), log = "debug")]
+#[test_connectors(tags("postgres"))]
 async fn soft_resets_work_on_postgres(api: TestApi) -> TestResult {
     let migrations_directory = api.create_migrations_directory()?;
     let mut url: url::Url = api.connection_string().parse()?;
@@ -66,6 +67,132 @@ async fn soft_resets_work_on_postgres(api: TestApi) -> TestResult {
 
         let add_view = format!(
             r#"CREATE VIEW "{0}"."catcat" AS SELECT * FROM "{0}"."Cat" LIMIT 2"#,
+            engine.schema_name(),
+        );
+
+        engine.raw_cmd(&add_view).await?;
+
+        engine
+            .assert_schema()
+            .await?
+            .assert_tables_count(2)?
+            .assert_has_table("_prisma_migrations")?
+            .assert_has_table("Cat")?;
+
+        engine.reset().send().await?;
+        engine.assert_schema().await?.assert_tables_count(0)?;
+
+        engine
+            .schema_push(dm)
+            .send()
+            .await?
+            .assert_has_executed_steps()?
+            .assert_green()?;
+
+        engine
+            .assert_schema()
+            .await?
+            .assert_tables_count(1)?
+            .assert_has_table("Cat")?;
+
+        engine.reset().send().await?;
+        engine.assert_schema().await?.assert_tables_count(0)?;
+    }
+
+    Ok(())
+}
+
+#[test_connectors(tags("mssql"))]
+async fn soft_resets_work_on_sql_server(api: TestApi) -> TestResult {
+    let migrations_directory = api.create_migrations_directory()?;
+
+    let mut url: JdbcString = format!("jdbc:{}", api.connection_string()).parse()?;
+
+    let dm = r#"
+        model Cat {
+            id Int @id
+            litterConsumption Int
+            hungry Boolean @default(true)
+        }
+    "#;
+
+    // Create the database, a first migration and the test user.
+    {
+        let admin_connection = api.initialize().await?;
+
+        api.new_engine()
+            .await?
+            .create_migration("01init", dm, &migrations_directory)
+            .send()
+            .await?;
+
+        let create_database = r#"
+            IF(DB_ID(N'resetTest') IS NOT NULL)
+            BEGIN
+                DROP DATABASE [resetTest]
+            END;
+
+            CREATE DATABASE [resetTest];
+        "#;
+
+        let create_user = r#"
+            USE [resetTest];
+
+            IF EXISTS (SELECT loginname from dbo.syslogins 
+                WHERE name = 'softresetstestuser')
+            BEGIN
+                DROP LOGIN softresetstestuser;
+            END;
+
+            CREATE LOGIN softresetstestuser WITH PASSWORD = 'Password123Password123';
+            CREATE USER softresetstestuser FROM LOGIN softresetstestuser;
+            GRANT CONTROL TO softresetstestuser;
+            REVOKE ALTER TO softresetstestuser;
+        "#;
+
+        admin_connection.raw_cmd(create_database).await?;
+        admin_connection.raw_cmd(create_user).await?;
+    }
+
+    let test_user_connection_string = {
+        let properties = url.properties_mut();
+
+        properties.insert("user".into(), "softresetstestuser".into());
+        properties.insert("password".into(), "Password123Password123".into());
+        properties.insert("database".into(), "resetTest".into());
+
+        url.to_string()
+    };
+
+    // Check that the test user can't drop databases.
+    {
+        let test_user_connection = Quaint::new(&test_user_connection_string).await?;
+
+        let err = test_user_connection
+            .raw_cmd(&format!(r#"DROP DATABASE {}"#, api.test_fn_name()))
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.original_code().unwrap(), "3701"); // insufficient_privilege (https://www.postgresql.org/docs/current/errcodes-appendix.html)
+    }
+
+    // Check that the soft reset works with migrations, then with schema push.
+    {
+        let engine = api
+            .new_engine_with_connection_strings(&test_user_connection_string, None)
+            .await?;
+
+        let create_schema = format!("CREATE SCHEMA [{}];", engine.schema_name());
+        engine.raw_cmd(&create_schema).await?;
+
+        engine
+            .apply_migrations(&migrations_directory)
+            .send()
+            .await?
+            .assert_applied_migrations(&["01init"])?;
+
+        let add_view = format!(
+            r#"CREATE VIEW [{0}].[catcat] AS SELECT * FROM [{0}].[Cat]"#,
             engine.schema_name(),
         );
 

--- a/migration-engine/migration-engine-tests/tests/migrations/soft_resets.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/soft_resets.rs
@@ -173,7 +173,9 @@ async fn soft_resets_work_on_sql_server(api: TestApi) -> TestResult {
             .await
             .unwrap_err();
 
-        assert_eq!(err.original_code().unwrap(), "3701"); // insufficient_privilege (https://www.postgresql.org/docs/current/errcodes-appendix.html)
+        // insofficient privilege
+        // https://docs.microsoft.com/en-us/sql/relational-databases/errors-events/database-engine-events-and-errors
+        assert_eq!(err.original_code().unwrap(), "3701");
     }
 
     // Check that the soft reset works with migrations, then with schema push.


### PR DESCRIPTION
So, whew.

I spent 1.5 days digging into SQL Server permissions and getting the test right. So we don't have permission to drop a database, creating users and all that. Only to find out we actually never drop the database on SQL Server resets. :thinking: 

So yeah, we test it but we never execute the drop.

Then, digging forward, PostgreSQL also never drops the database -- only the schema! There we can drop and cascade, but on SQL Server cascading doesn't work with `DROP SCHEMA`, so we must manually clean it.