### PR TITLE
Callback-based NAPI logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,9 +11,9 @@ dependencies = [
 
 [[package]]
 name = "adler"
-version = "0.2.3"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
+checksum = "bedc89c5c7b5550ffb9372eb5c5ffc7f9f705cc3f4a128bd4669b9745f555093"
 
 [[package]]
 name = "aead"
@@ -132,9 +132,9 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "1.5.1"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59740d83946db6a5af71ae25ddf9562c2b176b2ca42cf99a455f09f4a220d6b9"
+checksum = "2114d64672151c0c5eaa5e131ec84a74f06e1e559830dabba01ca30605d66319"
 dependencies = [
  "concurrent-queue",
  "event-listener",
@@ -247,7 +247,7 @@ dependencies = [
  "async-std",
  "native-tls",
  "thiserror",
- "url 2.2.0",
+ "url 2.2.1",
 ]
 
 [[package]]
@@ -292,7 +292,7 @@ dependencies = [
  "async-io",
  "async-lock",
  "async-process",
- "crossbeam-utils 0.8.1",
+ "crossbeam-utils 0.8.3",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -490,9 +490,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.6.0"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099e596ef14349721d9016f6b80dd3419ea1bf289ab9b44df8e4dfd3a005d5d9"
+checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
 
 [[package]]
 name = "byte-pool"
@@ -530,9 +530,9 @@ checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
 name = "cc"
-version = "1.0.66"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
+checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
 
 [[package]]
 name = "cfg-if"
@@ -725,9 +725,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
+checksum = "e7e9d99fa91428effe99c5c6d4634cdeba32b8cf784fc428a2a687f61a952c49"
 dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
@@ -1127,9 +1127,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
  "percent-encoding 2.1.0",
@@ -1137,15 +1137,15 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7e4c2612746b0df8fed4ce0c69156021b704c9aefa360311c04e6e9e002eed"
+checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
 name = "futures"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9052a1a50244d8d5aa9bf55cbc2fb6f357c86cc52e46c62ed390a7180cf150"
+checksum = "7f55667319111d593ba876406af7c409c0ebb44dc4be6132a783ccf163ea14c1"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1158,9 +1158,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d31b7ec7efab6eefc7c57233bb10b847986139d88cc2f5a02a1ae6871a1846"
+checksum = "8c2dd2df839b57db9ab69c2c9d8f3e8c81984781937fe2807dc6dcf3b2ad2939"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1168,15 +1168,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79e5145dde8da7d1b3892dad07a9c98fc04bc39892b1ecc9692cf53e2b780a65"
+checksum = "15496a72fabf0e62bdc3df11a59a3787429221dd0710ba8ef163d6f7a9112c94"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e59fdc009a4b3096bf94f740a0f2424c082521f20a9b08c5c07c48d90fd9b9"
+checksum = "891a4b7b96d84d5940084b2a37632dd65deeae662c114ceaa2c879629c9c0ad1"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1185,9 +1185,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28be053525281ad8259d47e4de5de657b25e7bac113458555bb4b70bc6870500"
+checksum = "d71c2c65c57704c32f5241c1223167c2c3294fd34ac020c807ddbe6db287ba59"
 
 [[package]]
 name = "futures-lite"
@@ -1206,9 +1206,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c287d25add322d9f9abdcdc5927ca398917996600182178774032e9f8258fedd"
+checksum = "ea405816a5139fb39af82c2beb921d52143f556038378d6db21183a5c37fbfb7"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -1218,18 +1218,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf5c69029bda2e743fddd0582d1083951d65cc9539aebf8812f36c3491342d6"
+checksum = "85754d98985841b7d4f5e8e6fbfa4a4ac847916893ec511a2917ccd8525b8bb3"
 
 [[package]]
 name = "futures-task"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13de07eb8ea81ae445aca7b69f5f7bf15d7bf4912d8ca37d6645c77ae8a58d86"
-dependencies = [
- "once_cell",
-]
+checksum = "fa189ef211c15ee602667a6fcfe1c1fd9e07d42250d2156382820fba33c9df80"
 
 [[package]]
 name = "futures-timer"
@@ -1239,11 +1236,11 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632a8cd0f2a4b3fdea1657f08bde063848c3bd00f9bbf6e256b8be78802e624b"
+checksum = "1812c7ab8aedf8d6f2701a43e1243acdbcc2b36ab26e2ad421eb99ac963d96d1"
 dependencies = [
- "futures 0.1.30",
+ "futures 0.1.31",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -1433,7 +1430,7 @@ dependencies = [
  "serde_json",
  "serde_qs",
  "serde_urlencoded",
- "url 2.2.0",
+ "url 2.2.1",
 ]
 
 [[package]]
@@ -1461,9 +1458,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de910d521f7cc3135c4de8db1cb910e0b5ed1dc6f57c381cd07e8e661ce10094"
+checksum = "89829a5d69c23d348314a7ac337fe39173b61149a9864deabd260983aed48c21"
 dependencies = [
  "matches",
  "unicode-bidi",
@@ -1483,9 +1480,9 @@ dependencies = [
 
 [[package]]
 name = "indenter"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4d5eb2e114fec2b7fe0fadc22888ad2658789bb7acac4dbee9cf8389f971ec8"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
@@ -1542,8 +1539,8 @@ dependencies = [
  "anyhow",
  "async-trait",
  "datamodel",
- "futures 0.1.30",
- "futures 0.3.12",
+ "futures 0.1.31",
+ "futures 0.3.13",
  "introspection-connector",
  "json-rpc-stdio",
  "jsonrpc-core",
@@ -1616,7 +1613,7 @@ dependencies = [
 name = "json-rpc-stdio"
 version = "0.1.0"
 dependencies = [
- "futures 0.3.12",
+ "futures 0.3.13",
  "jsonrpc-core",
  "tokio",
  "tracing",
@@ -1629,7 +1626,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2773fa94a2a1fd51efb89a8f45b8861023dbb415d18d3c9235ae9388d780f9ec"
 dependencies = [
  "failure",
- "futures 0.1.30",
+ "futures 0.1.31",
  "jsonrpc-core",
  "jsonrpc-pubsub",
  "log",
@@ -1644,7 +1641,7 @@ version = "14.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0747307121ffb9703afd93afbd0fb4f854c38fb873f2c8b90e0e902f27c7b62"
 dependencies = [
- "futures 0.1.30",
+ "futures 0.1.31",
  "log",
  "serde",
  "serde_derive",
@@ -1900,7 +1897,7 @@ dependencies = [
  "chrono",
  "datamodel",
  "enumflags2",
- "futures 0.3.12",
+ "futures 0.3.13",
  "jsonrpc-core",
  "migration-connector",
  "serde",
@@ -1909,7 +1906,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-futures",
- "url 2.2.0",
+ "url 2.2.1",
  "user-facing-errors",
 ]
 
@@ -1918,7 +1915,7 @@ name = "migration-engine-cli"
 version = "0.1.0"
 dependencies = [
  "base64 0.13.0",
- "futures 0.3.12",
+ "futures 0.3.13",
  "json-rpc-stdio",
  "migration-connector",
  "migration-core",
@@ -1931,7 +1928,7 @@ dependencies = [
  "tracing",
  "tracing-error",
  "tracing-subscriber",
- "url 2.2.0",
+ "url 2.2.1",
  "user-facing-errors",
 ]
 
@@ -1965,15 +1962,15 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-futures",
- "url 2.2.0",
+ "url 2.2.1",
  "user-facing-errors",
 ]
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f2d26ec3309788e423cfbf68ad1800f061638098d76a83681af979dc4eda19d"
+checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
 dependencies = [
  "adler",
  "autocfg",
@@ -1981,9 +1978,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.7"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e50ae3f04d169fcc9bde0b547d1c205219b7157e07ded9c5aff03e0637cb3ed7"
+checksum = "a5dede4e2065b3842b8b0af444119f3aa331cc7cc2dd20388bfb0f5d5a38823a"
 dependencies = [
  "libc",
  "log",
@@ -2019,9 +2016,9 @@ dependencies = [
 
 [[package]]
 name = "mysql_async"
-version = "0.27.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aeff5e5c76df07ad00ce5e2654d503516d1576343aa6c5553f6b7dc8f885c58"
+checksum = "9bbc817368f1989a90d541834eda5d9a5b56405cea2f916956efb0fa472d3a27"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2042,7 +2039,7 @@ dependencies = [
  "tokio-native-tls",
  "tokio-util",
  "twox-hash",
- "url 2.2.0",
+ "url 2.2.1",
  "uuid",
 ]
 
@@ -2077,11 +2074,11 @@ dependencies = [
 
 [[package]]
 name = "napi"
-version = "1.1.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d33071632a03aa76aa97b5baaba92034460e5a5261f9d7c9aef87da5d0205e19"
+checksum = "8ddaa8cda32a9c91ee2fda0c540f553c8cdac5203ce5ed8ef8dbb316d204e3ad"
 dependencies = [
- "futures 0.3.12",
+ "futures 0.3.13",
  "napi-build",
  "napi-sys",
  "once_cell",
@@ -2211,9 +2208,9 @@ checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
 
 [[package]]
 name = "once_cell"
-version = "1.5.2"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
+checksum = "10acf907b94fc1b1a152d08ef97e7759650268cf986bf127f387e602b02c7e5a"
 
 [[package]]
 name = "opaque-debug"
@@ -2249,9 +2246,9 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-src"
-version = "111.13.0+1.1.1i"
+version = "111.14.0+1.1.1j"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "045e4dc48af57aad93d665885789b43222ae26f4886494da12d1ed58d309dcb6"
+checksum = "055b569b5bd7e5462a1700f595c7c7d487691d73b5ce064176af7f9f0cbb80a9"
 dependencies = [
  "cc",
 ]
@@ -2281,7 +2278,7 @@ dependencies = [
  "openssl",
  "openssl-probe",
  "openssl-sys",
- "url 2.2.0",
+ "url 2.2.1",
 ]
 
 [[package]]
@@ -2527,7 +2524,7 @@ name = "postgres-native-tls"
 version = "0.5.0"
 source = "git+https://github.com/pimeys/rust-postgres?branch=pgbouncer-mode#7d3753ee3f7c214c2b062f9573f112deadb0d6ed"
 dependencies = [
- "futures 0.3.12",
+ "futures 0.3.13",
  "native-tls",
  "tokio",
  "tokio-native-tls",
@@ -2702,7 +2699,7 @@ dependencies = [
 [[package]]
 name = "quaint"
 version = "0.2.0-alpha.13"
-source = "git+https://github.com/prisma/quaint#ac3d9f22875c899ef8d1c0aff7d2b0d206f0e314"
+source = "git+https://github.com/prisma/quaint#47aa6b2a15122e55ee54509743fa779673902f12"
 dependencies = [
  "async-trait",
  "base64 0.12.3",
@@ -2713,7 +2710,7 @@ dependencies = [
  "chrono",
  "connection-string",
  "either",
- "futures 0.3.12",
+ "futures 0.3.13",
  "hex",
  "libsqlite3-sys",
  "log",
@@ -2738,7 +2735,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-core",
- "url 2.2.0",
+ "url 2.2.1",
  "uuid",
 ]
 
@@ -2749,7 +2746,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
- "futures 0.3.12",
+ "futures 0.3.13",
  "itertools",
  "once_cell",
  "prisma-models",
@@ -2774,7 +2771,7 @@ dependencies = [
  "datamodel",
  "datamodel-connector",
  "feature-flags",
- "futures 0.3.12",
+ "futures 0.3.13",
  "im",
  "indexmap",
  "itertools",
@@ -2811,7 +2808,7 @@ dependencies = [
  "datamodel-connector",
  "enumflags2",
  "feature-flags",
- "futures 0.3.12",
+ "futures 0.3.13",
  "graphql-parser",
  "indexmap",
  "indoc",
@@ -2841,7 +2838,7 @@ dependencies = [
  "tracing-attributes",
  "tracing-futures",
  "tracing-subscriber",
- "url 2.2.0",
+ "url 2.2.1",
  "user-facing-errors",
 ]
 
@@ -2867,7 +2864,7 @@ dependencies = [
  "tracing",
  "tracing-futures",
  "tracing-subscriber",
- "url 2.2.0",
+ "url 2.2.1",
  "user-facing-errors",
 ]
 
@@ -3022,7 +3019,7 @@ dependencies = [
  "datamodel",
  "datamodel-connector",
  "feature-flags",
- "futures 0.3.12",
+ "futures 0.3.13",
  "graphql-parser",
  "indexmap",
  "itertools",
@@ -3034,7 +3031,7 @@ dependencies = [
  "test-setup",
  "thiserror",
  "tracing",
- "url 2.2.0",
+ "url 2.2.1",
  "user-facing-errors",
 ]
 
@@ -3149,9 +3146,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1759c2e3c8580017a484a7ac56d3abc5a6c1feadf88db2f3633f12ae4268c69"
+checksum = "2dfd318104249865096c8da1dfabf09ddbb6d0330ea176812a62ec75e40c4166"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -3162,9 +3159,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f99b9d5e26d2a71633cc4f2ebae7cc9f874044e0c351a27e17892d76dce5678b"
+checksum = "dee48cdde5ed250b0d3252818f646e174ab414036edb884dde62d80a3ac6082d"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3207,9 +3204,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.62"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea1c6153794552ea7cf7cf63b1231a25de00ec90db326ba6264440fa08e31486"
+checksum = "43535db9747a4ba938c0ce0a98cc631a46ebf943c9e1d604e091df6007620bf6"
 dependencies = [
  "indexmap",
  "itoa",
@@ -3305,9 +3302,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.3.4"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "780f5e3fe0c66f67197236097d89de1e86216f1f6fdeaf47c442f854ab46c240"
+checksum = "8a7f3f92a1da3d6b1d32245d0cbcbbab0cfc45996d8df619c42bccfa6d2bbb5f"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -3445,7 +3442,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-futures",
- "url 2.2.0",
+ "url 2.2.1",
  "user-facing-errors",
  "uuid",
 ]
@@ -3460,7 +3457,7 @@ dependencies = [
  "chrono",
  "cuid",
  "datamodel",
- "futures 0.3.12",
+ "futures 0.3.13",
  "itertools",
  "prisma-models",
  "prisma-value",
@@ -3709,7 +3706,7 @@ dependencies = [
  "tokio",
  "tracing-error",
  "tracing-subscriber",
- "url 2.2.0",
+ "url 2.2.1",
 ]
 
 [[package]]
@@ -3723,18 +3720,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76cc616c6abf8c8928e2fdcc0dbfab37175edd8fb49a4641066ad1364fdab146"
+checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
+checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3752,22 +3749,22 @@ dependencies = [
 
 [[package]]
 name = "tiberius"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668fbe3b735034470545b219da784979cbb2e4d8dcdc03d90ed367f9d3e622bd"
+checksum = "617bbab54c56dd520b5f49ee50c71c9ee7b4944aefdb67d9e26ccea57c1381c6"
 dependencies = [
  "async-native-tls",
  "async-stream",
  "async-trait",
  "asynchronous-codec",
  "bigdecimal",
- "bitflags",
  "byteorder",
  "bytes",
  "chrono",
  "connection-string",
  "encoding",
- "futures 0.3.12",
+ "enumflags2",
+ "futures 0.3.13",
  "futures-sink",
  "futures-util",
  "num-bigint",
@@ -3930,7 +3927,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "fallible-iterator",
- "futures 0.3.12",
+ "futures 0.3.13",
  "log",
  "parking_lot 0.11.1",
  "percent-encoding 2.1.0",
@@ -3969,9 +3966,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.23"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d40a22fd029e33300d8d89a5cc8ffce18bb7c587662f54629e94c9de5487f3"
+checksum = "01ebdc2bb4498ab1ab5f5b73c5803825e60199229ccba0698170e3be0e7f959f"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
@@ -3982,9 +3979,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f080ea7e4107844ef4766459426fa2d5c1ada2e47edba05dc7fa99d9629f47"
+checksum = "a8a9bd1db7706f2373a190b0d067146caa39350c486f3d455b0e33b431f94c07"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4022,9 +4019,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e0f8c7178e13481ff6765bd169b33e8d554c5d2bbede5e32c356194be02b9b9"
+checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
 dependencies = [
  "lazy_static",
  "log",
@@ -4043,9 +4040,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1fa8f0c8f4c594e4fc9debc1990deab13238077271ba84dd853d54902ee3401"
+checksum = "8ab8966ac3ca27126141f7999361cc97dd6fb4b71da04c02044fa9045d98bb96"
 dependencies = [
  "ansi_term 0.12.1",
  "chrono",
@@ -4155,16 +4152,16 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "ureq"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96014ded8c85822677daee4f909d18acccca744810fd4f8ffc492c284f2324bc"
+checksum = "6585dcbf3483242f77b502864478ede62431baf3442b99367d3456ec20c1707b"
 dependencies = [
  "base64 0.13.0",
  "chunked_transfer",
  "log",
  "once_cell",
  "rustls",
- "url 2.2.0",
+ "url 2.2.1",
  "webpki",
  "webpki-roots",
 ]
@@ -4182,12 +4179,12 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5909f2b0817350449ed73e8bcd81c8c3c8d9a7a5d8acba4b27db277f1868976e"
+checksum = "9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b"
 dependencies = [
  "form_urlencoded",
- "idna 0.2.1",
+ "idna 0.2.2",
  "matches",
  "percent-encoding 2.1.0",
  "serde",

--- a/query-engine/query-engine-napi/Cargo.toml
+++ b/query-engine/query-engine-napi/Cargo.toml
@@ -19,7 +19,7 @@ datamodel = { path = "../../libs/datamodel/core" }
 feature-flags = {path = "../../libs/feature-flags"}
 sql-connector = {path = "../connectors/sql-query-connector", package = "sql-query-connector"}
 prisma-models = { path = "../../libs/prisma-models" }
-napi = { version = "1", default-features = false, features = ["napi4", "tokio_rt", "serde-json"] }
+napi = { version = "1.2", default-features = false, features = ["napi4", "tokio_rt", "serde-json"] }
 napi-derive = "1"
 thiserror = "1"
 connection-string = "0.1"

--- a/query-engine/query-engine-napi/src/engine.rs
+++ b/query-engine/query-engine-napi/src/engine.rs
@@ -198,8 +198,6 @@ impl QueryEngine {
 
         match *inner {
             Inner::Connected(ref engine) => {
-                engine.logger.disconnect_listeners().await?;
-
                 let config = datamodel::parse_configuration_with_url_overrides(
                     &engine.datamodel.raw,
                     engine.datamodel.datasource_overrides.clone(),

--- a/query-engine/query-engine-napi/src/engine.rs
+++ b/query-engine/query-engine-napi/src/engine.rs
@@ -1,5 +1,6 @@
 use crate::{error::ApiError, logger::ChannelLogger};
 use datamodel::{diagnostics::ValidatedConfiguration, Datamodel};
+use napi::threadsafe_function::ThreadsafeFunction;
 use prisma_models::DatamodelConverter;
 use query_core::{exec_loader, schema_builder, BuildMode, QueryExecutor, QuerySchema, QuerySchemaRenderer};
 use request_handlers::{
@@ -92,7 +93,7 @@ where
 
 impl QueryEngine {
     /// Parse a validated datamodel and configuration to allow connecting later on.
-    pub fn new(opts: ConstructorOptions) -> crate::Result<Self> {
+    pub fn new(opts: ConstructorOptions, log_callback: ThreadsafeFunction<String>) -> crate::Result<Self> {
         let ConstructorOptions {
             datamodel,
             log_level,
@@ -124,7 +125,7 @@ impl QueryEngine {
             datasource_overrides: overrides,
         };
 
-        let logger = ChannelLogger::new(log_level);
+        let logger = ChannelLogger::new(log_level, log_callback);
 
         let builder = EngineBuilder {
             config,
@@ -279,17 +280,6 @@ impl QueryEngine {
                 version: env!("CARGO_PKG_VERSION").into(),
                 primary_connector: None,
             }),
-        }
-    }
-
-    /// Returns the next log event from the system, if any. Pauses the task if
-    /// the channel is empty. Engine should be connected before calling.
-    ///
-    /// Returns `None` when the logger is dropped.
-    pub async fn next_log_event(&self) -> Option<String> {
-        match *self.inner.read().await {
-            Inner::Connected(ref engine) => engine.logger.next_event().await,
-            Inner::Builder(ref builder) => builder.logger.next_event().await,
         }
     }
 }

--- a/query-engine/query-engine-napi/src/logger.rs
+++ b/query-engine/query-engine-napi/src/logger.rs
@@ -40,15 +40,4 @@ impl ChannelLogger {
     {
         f().with_subscriber(self.subscriber.clone()).await
     }
-
-    /// A special event to notify the JavaScript listener to stop listening,
-    /// helping us to get around of the problem of not having streams on
-    /// JavaScript.
-    pub async fn disconnect_listeners(&self) -> crate::Result<()> {
-        self.with_logging(|| async {
-            tracing::info!("disconnected");
-            Ok(())
-        })
-        .await
-    }
 }

--- a/query-engine/query-engine-napi/src/logger/channel.rs
+++ b/query-engine/query-engine-napi/src/logger/channel.rs
@@ -1,19 +1,29 @@
 use super::visitor::JsonVisitor;
+use napi::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
 use serde_json::{Map, Value};
-use tokio::sync::mpsc;
 use tracing::{metadata::LevelFilter, span::Record, Event, Id, Subscriber};
 use tracing_subscriber::{layer::Context, registry::LookupSpan, Layer};
 
-#[derive(Clone)]
 pub struct EventChannel {
-    sender: mpsc::Sender<String>,
+    callback: ThreadsafeFunction<String>,
     level_filter: LevelFilter,
 }
 
-impl EventChannel {
-    pub fn new(sender: mpsc::Sender<String>) -> Self {
+impl Clone for EventChannel {
+    fn clone(&self) -> Self {
         Self {
-            sender,
+            level_filter: self.level_filter,
+            // we crash if javascript aborts the callback, but continues using
+            // the engine.
+            callback: self.callback.try_clone().unwrap(),
+        }
+    }
+}
+
+impl EventChannel {
+    pub fn new(callback: ThreadsafeFunction<String>) -> Self {
+        Self {
+            callback,
             level_filter: LevelFilter::OFF,
         }
     }
@@ -73,16 +83,7 @@ where
         let js_object = Value::Object(object);
         let json_str = serde_json::to_string(&js_object).unwrap();
 
-        if let Err(e) = self.sender.try_send(json_str) {
-            match e {
-                mpsc::error::TrySendError::Full(_) => {
-                    eprintln!("Dropped a log message, buffer is full.")
-                }
-                mpsc::error::TrySendError::Closed(_) => {
-                    eprintln!("Event channel closed while we're still logging.")
-                }
-            }
-        }
+        self.callback.call(Ok(json_str), ThreadsafeFunctionCallMode::Blocking);
     }
 
     fn enabled(&self, metadata: &tracing::Metadata<'_>, ctx: Context<'_, S>) -> bool {

--- a/query-engine/query-engine-napi/src/logger/channel.rs
+++ b/query-engine/query-engine-napi/src/logger/channel.rs
@@ -73,7 +73,8 @@ where
         let js_object = Value::Object(object);
         let json_str = serde_json::to_string(&js_object).unwrap();
 
-        self.callback.call(Ok(json_str), ThreadsafeFunctionCallMode::Blocking);
+        self.callback
+            .call(Ok(json_str), ThreadsafeFunctionCallMode::NonBlocking);
     }
 
     fn enabled(&self, metadata: &tracing::Metadata<'_>, ctx: Context<'_, S>) -> bool {

--- a/query-engine/query-engine-napi/src/logger/channel.rs
+++ b/query-engine/query-engine-napi/src/logger/channel.rs
@@ -4,20 +4,10 @@ use serde_json::{Map, Value};
 use tracing::{metadata::LevelFilter, span::Record, Event, Id, Subscriber};
 use tracing_subscriber::{layer::Context, registry::LookupSpan, Layer};
 
+#[derive(Clone)]
 pub struct EventChannel {
     callback: ThreadsafeFunction<String>,
     level_filter: LevelFilter,
-}
-
-impl Clone for EventChannel {
-    fn clone(&self) -> Self {
-        Self {
-            level_filter: self.level_filter,
-            // we crash if javascript aborts the callback, but continues using
-            // the engine.
-            callback: self.callback.try_clone().unwrap(),
-        }
-    }
 }
 
 impl EventChannel {


### PR DESCRIPTION
This is a better and more fool-proof solution for our logging needs.

Usage:

```javascript
let qe = new QueryEngine({
  datamodel: dm,
  logLevel: "info",
  datasourceOverrides: {}
}, (err, log) => {
  console.log(JSON.parse(log));
});
```

The old apis of `fetchNextEvent` and all that are now gone.