### PR TITLE
Compare foreign key table names case-insensitively

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/pair.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/pair.rs
@@ -25,6 +25,17 @@ impl<T> Pair<T> {
         (&self.previous, &self.next)
     }
 
+    pub(crate) fn interleave<F, I, O>(&self, f: F) -> impl Iterator<Item = Pair<O>>
+    where
+        I: IntoIterator<Item = O>,
+        F: Fn(&T) -> I,
+    {
+        f(&self.previous)
+            .into_iter()
+            .zip(f(&self.next).into_iter())
+            .map(Pair::from)
+    }
+
     pub(crate) fn into_tuple(self) -> (T, T) {
         (self.previous, self.next)
     }
@@ -84,5 +95,11 @@ impl<'a> Pair<TableWalker<'a>> {
 
     pub(crate) fn indexes(&self, index_indexes: &Pair<usize>) -> Pair<IndexWalker<'a>> {
         self.as_ref().zip(index_indexes.as_ref()).map(|(t, i)| t.index_at(*i))
+    }
+}
+
+impl<T> From<(T, T)> for Pair<T> {
+    fn from((previous, next): (T, T)) -> Self {
+        Pair { previous, next }
     }
 }

--- a/migration-engine/connectors/sql-migration-connector/src/pair.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/pair.rs
@@ -25,6 +25,7 @@ impl<T> Pair<T> {
         (&self.previous, &self.next)
     }
 
+    /// Map each element to an iterator, and zip the two iterators into an iterator over pairs.
     pub(crate) fn interleave<F, I, O>(&self, f: F) -> impl Iterator<Item = Pair<O>>
     where
         I: IntoIterator<Item = O>,

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/table.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/table.rs
@@ -44,7 +44,7 @@ impl<'schema> TableDiffer<'schema> {
     pub(crate) fn created_foreign_keys<'a>(&'a self) -> impl Iterator<Item = ForeignKeyWalker<'schema>> + 'a {
         self.next_foreign_keys().filter(move |next_fk| {
             self.previous_foreign_keys()
-                .find(|previous_fk| super::foreign_keys_match(previous_fk, next_fk))
+                .find(|previous_fk| super::foreign_keys_match(Pair::new(previous_fk, next_fk), self.flavour))
                 .is_none()
         })
     }
@@ -52,7 +52,7 @@ impl<'schema> TableDiffer<'schema> {
     pub(crate) fn dropped_foreign_keys<'a>(&'a self) -> impl Iterator<Item = ForeignKeyWalker<'schema>> + 'a {
         self.previous_foreign_keys().filter(move |previous_fk| {
             self.next_foreign_keys()
-                .find(|next_fk| super::foreign_keys_match(previous_fk, next_fk))
+                .find(|next_fk| super::foreign_keys_match(Pair::new(previous_fk, next_fk), self.flavour))
                 .is_none()
         })
     }


### PR DESCRIPTION
...on MySQL on windows.

The relevant diff is mostly this line:

```
-    let references_same_table = previous.referenced_table().name() == next.referenced_table().name();
+    let references_same_table = flavour.table_names_match(fks.map(|fk| fk.referenced_table().name()));
```

Related: https://github.com/prisma/prisma/issues/5551 and https://github.com/prisma/prisma/issues/4748