### PR TITLE
Opentelemetry tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,9 +11,9 @@ dependencies = [
 
 [[package]]
 name = "adler"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bedc89c5c7b5550ffb9372eb5c5ffc7f9f705cc3f4a128bd4669b9745f555093"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aead"
@@ -184,9 +184,9 @@ dependencies = [
 
 [[package]]
 name = "async-h1"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e9e2a9745d9cd0d92ed7641ce4d07568985762f92633260f0afe8ac7917d9d7"
+checksum = "cc5142de15b549749cce62923a50714b0d7b77f5090ced141599e78899865451"
 dependencies = [
  "async-channel",
  "async-dup",
@@ -277,7 +277,7 @@ dependencies = [
  "http-types",
  "log",
  "memchr",
- "pin-project-lite 0.1.11",
+ "pin-project-lite 0.1.12",
 ]
 
 [[package]]
@@ -303,7 +303,7 @@ dependencies = [
  "memchr",
  "num_cpus",
  "once_cell",
- "pin-project-lite 0.2.4",
+ "pin-project-lite 0.2.6",
  "pin-utils",
  "slab",
  "wasm-bindgen-futures",
@@ -315,7 +315,17 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22068c0c19514942eefcfd4daf8976ef1aad84e61539f95cd200c35202f80af5"
 dependencies = [
- "async-stream-impl",
+ "async-stream-impl 0.2.1",
+ "futures-core",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3670df70cbc01729f901f94c887814b3c68db038aad1329a418bae178bc5295c"
+dependencies = [
+ "async-stream-impl 0.3.0",
  "futures-core",
 ]
 
@@ -331,6 +341,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream-impl"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3548b8efc9f8e8a5a0a2808c5bd8451a9031b9e5b879a79590304ae928b0a70"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-task"
 version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -338,9 +359,9 @@ checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
 
 [[package]]
 name = "async-trait"
-version = "0.1.42"
+version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d3a45e77e34375a7923b1e8febb049bb011f064714a8e17a1a616fef01da13d"
+checksum = "36ea56748e10732c49404c153638a15ec3d6211ec5ff35d9bb20e13b93576adf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -353,11 +374,11 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb4401f0a3622dad2e0763fa79e0eb328bc70fb7dccfdd645341f00d671247d6"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "futures-sink",
  "futures-util",
  "memchr",
- "pin-project-lite 0.2.4",
+ "pin-project-lite 0.2.6",
 ]
 
 [[package]]
@@ -459,7 +480,7 @@ dependencies = [
  "block-padding",
  "byte-tools",
  "byteorder",
- "generic-array 0.12.3",
+ "generic-array 0.12.4",
 ]
 
 [[package]]
@@ -496,9 +517,9 @@ dependencies = [
 
 [[package]]
 name = "bson"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c11f16001d679cb13d14b2c93c7d0fa13bb484a87c34a6c4c39707ad936499b5"
+checksum = "2abd828df036867b89a07c5a4824df1168b42d74f41af7253f20e55a32e5ca4b"
 dependencies = [
  "base64 0.12.3",
  "chrono",
@@ -508,6 +529,7 @@ dependencies = [
  "rand 0.7.3",
  "serde",
  "serde_json",
+ "uuid",
 ]
 
 [[package]]
@@ -534,9 +556,15 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "bytes"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "bytes"
@@ -578,7 +606,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "time 0.1.43",
+ "time 0.1.44",
  "winapi",
 ]
 
@@ -671,16 +699,16 @@ checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
 
 [[package]]
 name = "cookie"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784ad0fbab4f3e9cef09f20e0aea6000ae08d2cb98ac4c0abc53df18803d702f"
+checksum = "03a5d7b21829bc7b4bf4754a978a241ae54ea55a40f92bb20216e54096f4b951"
 dependencies = [
  "aes-gcm",
- "base64 0.12.3",
+ "base64 0.13.0",
  "hkdf",
  "hmac 0.10.1",
  "percent-encoding 2.1.0",
- "rand 0.7.3",
+ "rand 0.8.3",
  "sha2 0.9.3",
  "time 0.2.25",
  "version_check",
@@ -762,7 +790,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
 dependencies = [
- "generic-array 0.12.3",
+ "generic-array 0.12.4",
  "subtle 1.0.0",
 ]
 
@@ -812,8 +840,18 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.10.2",
+ "darling_macro 0.10.2",
+]
+
+[[package]]
+name = "darling"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06d4a9551359071d1890820e3571252b91229e0712e7c36b08940e603c5a8fc"
+dependencies = [
+ "darling_core 0.12.2",
+ "darling_macro 0.12.2",
 ]
 
 [[package]]
@@ -831,12 +869,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b443e5fb0ddd56e0c9bfa47dc060c5306ee500cb731f2b91432dd65589a77684"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
 dependencies = [
- "darling_core",
+ "darling_core 0.10.2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0220073ce504f12a70efc4e7cdaea9e9b1b324872e7ad96a208056d7a638b81"
+dependencies = [
+ "darling_core 0.12.2",
  "quote",
  "syn",
 ]
@@ -868,7 +931,7 @@ dependencies = [
  "datamodel-connector",
  "dml",
  "indoc",
- "itertools",
+ "itertools 0.8.2",
  "mongodb-datamodel-connector",
  "native-types",
  "once_cell",
@@ -891,7 +954,7 @@ name = "datamodel-connector"
 version = "0.1.0"
 dependencies = [
  "dml",
- "itertools",
+ "itertools 0.8.2",
  "serde_json",
  "thiserror",
 ]
@@ -930,7 +993,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
- "generic-array 0.12.3",
+ "generic-array 0.12.4",
 ]
 
 [[package]]
@@ -1033,9 +1096,9 @@ checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.26"
+version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "801bbab217d7f79c0062f4f7205b5d4427c6d1a7bd7aafdd1475f7c59d62b283"
+checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -1070,20 +1133,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "err-derive"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22deed3a8124cff5fa835713fa105621e43bbdc46690c3a6b68328a012d350d4"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
- "synstructure",
 ]
 
 [[package]]
@@ -1158,6 +1207,12 @@ name = "fixedbitset"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
+
+[[package]]
+name = "fixedbitset"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "flate2"
@@ -1269,7 +1324,7 @@ dependencies = [
  "futures-io",
  "memchr",
  "parking",
- "pin-project-lite 0.2.4",
+ "pin-project-lite 0.2.6",
  "waker-fn",
 ]
 
@@ -1317,7 +1372,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite 0.2.4",
+ "pin-project-lite 0.2.6",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -1326,9 +1381,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
 dependencies = [
  "typenum",
 ]
@@ -1362,7 +1417,7 @@ checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasi 0.10.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1406,11 +1461,11 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b67e66362108efccd8ac053abafc8b7a8d86a37e6e48fc4f6f7485eb5e9e6a5"
+checksum = "d832b01df74254fe364568d6ddc294443f61cbec82816b60904303af87efae78"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -1421,7 +1476,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "tracing-futures",
 ]
 
 [[package]]
@@ -1453,9 +1507,9 @@ dependencies = [
 
 [[package]]
 name = "hex"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hkdf"
@@ -1514,7 +1568,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7245cd7449cc792608c3c8a9eaf69bd4eabbabf802713748fd739c98b82f0747"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "fnv",
  "itoa",
 ]
@@ -1525,15 +1579,15 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2861bd27ee074e5ee891e8b539837a9430012e249d7f0ca2d795650f579c1994"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "http",
 ]
 
 [[package]]
 name = "http-client"
-version = "6.3.1"
+version = "6.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "034fc6371e1657295cd261c2f705941af300a8438ce41dedbdf74d674f52ad0f"
+checksum = "5566ecc26bc6b04e773e680d66141fced78e091ad818e420d726c152b05a64ff"
 dependencies = [
  "async-trait",
  "cfg-if 1.0.0",
@@ -1555,7 +1609,7 @@ dependencies = [
  "cookie",
  "futures-lite",
  "infer",
- "pin-project-lite 0.2.4",
+ "pin-project-lite 0.2.6",
  "rand 0.7.3",
  "serde",
  "serde_json",
@@ -1578,11 +1632,11 @@ checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 
 [[package]]
 name = "hyper"
-version = "0.14.2"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12219dc884514cb4a6a03737f4413c0e01c23a1b059b0156004b23f1e19dccbe"
+checksum = "e8e946c2b1349055e0b72ae281b238baf1a3ea7307c7e9f9d64673bdd9c26ac7"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -1662,9 +1716,9 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b"
+checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -1785,6 +1839,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1792,9 +1855,9 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "js-sys"
-version = "0.3.47"
+version = "0.3.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cfb73131c35423a367daf8cbd24100af0d077668c8c2943f0e7dd775fef0f65"
+checksum = "dc9f84f9b115ce7843d60706df1422a916680bfdfcbdb0447c5614ff9d7e4d78"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1914,9 +1977,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.86"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
+checksum = "03b07a082330a35e43f63177cc01689da34fbffa0105e1246cf0311472cac73a"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -2214,9 +2277,9 @@ dependencies = [
 
 [[package]]
 name = "mobc"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aa3b9ceb9719088450638d86cbd1df968f78aa72c2c0076758b47ef59d48fb4"
+checksum = "9683da7a001bde699f3467cb64628749f4459cb6fa3f4a3ba488fce605170d2c"
 dependencies = [
  "async-trait",
  "futures-channel",
@@ -2230,7 +2293,7 @@ dependencies = [
 [[package]]
 name = "mongodb"
 version = "2.0.0-alpha"
-source = "git+https://github.com/mongodb/mongo-rust-driver.git#50c94100b6d2154d3f18dd8cb077f146fd1e036f"
+source = "git+https://github.com/mongodb/mongo-rust-driver.git#9166b66488a3038b8a6e22db4535279a8057ba16"
 dependencies = [
  "async-trait",
  "base64 0.11.0",
@@ -2238,7 +2301,6 @@ dependencies = [
  "bson",
  "chrono",
  "derivative",
- "err-derive",
  "futures 0.3.13",
  "hex",
  "hmac 0.7.1",
@@ -2259,7 +2321,8 @@ dependencies = [
  "stringprep",
  "strsim 0.10.0",
  "take_mut",
- "time 0.1.43",
+ "thiserror",
+ "time 0.1.44",
  "tokio",
  "tokio-rustls",
  "tokio-util",
@@ -2322,7 +2385,7 @@ dependencies = [
  "cuid",
  "datamodel",
  "futures 0.3.13",
- "itertools",
+ "itertools 0.8.2",
  "mongodb",
  "native-types",
  "prisma-models",
@@ -2342,12 +2405,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "multimap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1255076139a83bb467426e7f8d0134968a8118844faa755985e077cf31850333"
+
+[[package]]
 name = "mysql_async"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bbc817368f1989a90d541834eda5d9a5b56405cea2f916956efb0fa472d3a27"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "futures-core",
  "futures-sink",
  "futures-util",
@@ -2380,7 +2449,7 @@ dependencies = [
  "bigdecimal",
  "bitflags",
  "byteorder",
- "bytes",
+ "bytes 1.0.1",
  "chrono",
  "flate2",
  "lazy_static",
@@ -2489,9 +2558,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e9a41747ae4633fce5adffb4d2e81ffc5e89593cb19917f8fb2cc5ff76507bf"
+checksum = "7d0a3d5e207573f948a9e5376662aa743a2ea13f7c50a554d7af443a73fbfeba"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -2535,9 +2604,9 @@ checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
 
 [[package]]
 name = "once_cell"
-version = "1.7.0"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10acf907b94fc1b1a152d08ef97e7759650268cf986bf127f387e602b02c7e5a"
+checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
 
 [[package]]
 name = "opaque-debug"
@@ -2553,15 +2622,15 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.32"
+version = "0.10.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038d43985d1ddca7a9900630d8cd031b56e4794eecc2e9ea39dd17aa04399a70"
+checksum = "a61075b62a23fef5a29815de7536d940aa35ce96d18ce0cc5076272db678a577"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
  "foreign-types",
- "lazy_static",
  "libc",
+ "once_cell",
  "openssl-sys",
 ]
 
@@ -2582,9 +2651,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.60"
+version = "0.9.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921fc71883267538946025deffb622905ecad223c28efbfdef9bb59a0175f3e6"
+checksum = "313752393519e876837e09e1fa183ddef0be7735868dced3196f4472d536277f"
 dependencies = [
  "autocfg",
  "cc",
@@ -2592,6 +2661,39 @@ dependencies = [
  "openssl-src",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "opentelemetry"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "514d24875c140ed269eecc2d1b56d7b71b573716922a763c317fb1b1b4b58f15"
+dependencies = [
+ "async-std",
+ "async-trait",
+ "futures 0.3.13",
+ "js-sys",
+ "lazy_static",
+ "percent-encoding 2.1.0",
+ "pin-project",
+ "rand 0.8.3",
+ "thiserror",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff889e68a02000126fa635a311abc329ce128c576b7dddc4cd3270f3c240afd0"
+dependencies = [
+ "async-trait",
+ "futures 0.3.13",
+ "opentelemetry",
+ "prost 0.7.0",
+ "thiserror",
+ "tokio",
+ "tonic",
+ "tonic-build",
 ]
 
 [[package]]
@@ -2690,9 +2792,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5d65c4d95931acda4498f675e332fcbdc9a06705cd07086c510e9b6009cd1c1"
+checksum = "acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58"
 
 [[package]]
 name = "pbkdf2"
@@ -2776,8 +2878,18 @@ version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c3659d1ee90221741f65dd128d9998311b0e40c5d3c23a62445938214abce4f"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.1.9",
  "ordermap",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
+dependencies = [
+ "fixedbitset 0.2.0",
+ "indexmap",
 ]
 
 [[package]]
@@ -2820,15 +2932,15 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
+checksum = "257b64915a082f7811703966789728173279bdebb956b143dbcd23f6f970a777"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
+checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
 
 [[package]]
 name = "pin-utils"
@@ -2885,7 +2997,7 @@ source = "git+https://github.com/pimeys/rust-postgres?branch=pgbouncer-mode#7d37
 dependencies = [
  "base64 0.13.0",
  "byteorder",
- "bytes",
+ "bytes 1.0.1",
  "fallible-iterator",
  "hmac 0.10.1",
  "md-5 0.9.1",
@@ -2901,7 +3013,7 @@ version = "0.2.0"
 source = "git+https://github.com/pimeys/rust-postgres?branch=pgbouncer-mode#7d3753ee3f7c214c2b062f9573f112deadb0d6ed"
 dependencies = [
  "bit-vec",
- "bytes",
+ "bytes 1.0.1",
  "chrono",
  "fallible-iterator",
  "postgres-protocol",
@@ -2961,7 +3073,7 @@ dependencies = [
  "chrono",
  "cuid",
  "datamodel",
- "itertools",
+ "itertools 0.8.2",
  "once_cell",
  "prisma-value",
  "quaint",
@@ -3044,6 +3156,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce49aefe0a6144a45de32927c77bd2859a5f7677b55f220ae5b744e87389c212"
+dependencies = [
+ "bytes 0.5.6",
+ "prost-derive 0.6.1",
+]
+
+[[package]]
+name = "prost"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
+dependencies = [
+ "bytes 1.0.1",
+ "prost-derive 0.7.0",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b10678c913ecbd69350e8535c3aef91a8676c0773fc1d7b95cdd196d7f2f26"
+dependencies = [
+ "bytes 0.5.6",
+ "heck",
+ "itertools 0.8.2",
+ "log",
+ "multimap",
+ "petgraph 0.5.1",
+ "prost 0.6.1",
+ "prost-types",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537aa19b95acde10a12fec4301466386f757403de4cd4e5b4fa78fb5ecb18f72"
+dependencies = [
+ "anyhow",
+ "itertools 0.8.2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "169a15f3008ecb5160cba7d37bcd690a7601b6d30cfb87a117d45e59d52af5d4"
+dependencies = [
+ "anyhow",
+ "itertools 0.9.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1834f67c0697c001304b75be76f67add9c89742eda3a085ad8ee0bb38c3417aa"
+dependencies = [
+ "bytes 0.5.6",
+ "prost 0.6.1",
+]
+
+[[package]]
 name = "quaint"
 version = "0.2.0-alpha.13"
 source = "git+https://github.com/prisma/quaint#bf427c07c01b9ee15225fab3b8bde86794d49e38"
@@ -3053,7 +3239,7 @@ dependencies = [
  "bigdecimal",
  "bit-vec",
  "byteorder",
- "bytes",
+ "bytes 1.0.1",
  "chrono",
  "connection-string",
  "either",
@@ -3093,7 +3279,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "futures 0.3.13",
- "itertools",
+ "itertools 0.8.2",
  "once_cell",
  "prisma-models",
  "prisma-value",
@@ -3120,10 +3306,10 @@ dependencies = [
  "futures 0.3.13",
  "im",
  "indexmap",
- "itertools",
+ "itertools 0.8.2",
  "mongodb-query-connector",
  "once_cell",
- "petgraph",
+ "petgraph 0.4.13",
  "prisma-inflector",
  "prisma-models",
  "prisma-value",
@@ -3158,15 +3344,18 @@ dependencies = [
  "graphql-parser",
  "indexmap",
  "indoc",
- "itertools",
+ "itertools 0.8.2",
  "migration-connector",
  "migration-core",
  "mongodb-query-connector",
  "once_cell",
+ "opentelemetry",
+ "opentelemetry-otlp",
  "prisma-models",
  "quaint",
  "query-connector",
  "query-core",
+ "rand 0.8.3",
  "request-handlers",
  "rustc_version",
  "serde",
@@ -3181,9 +3370,11 @@ dependencies = [
  "tide",
  "tide-server-timing",
  "tokio",
+ "tonic",
  "tracing",
  "tracing-attributes",
  "tracing-futures",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "url 2.2.1",
  "user-facing-errors",
@@ -3199,6 +3390,8 @@ dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
+ "opentelemetry",
+ "opentelemetry-otlp",
  "prisma-models",
  "query-connector",
  "query-core",
@@ -3210,6 +3403,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-futures",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "url 2.2.1",
  "user-facing-errors",
@@ -3338,14 +3532,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.3"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
+checksum = "957056ecddbeba1b26965114e191d2e8589ce74db242b6ea25fc4062427a5c19"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-syntax",
- "thread_local",
 ]
 
 [[package]]
@@ -3360,9 +3553,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.22"
+version = "0.6.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
+checksum = "24d5f089152e60f62d28b835fbff2cd2e8dc0baf1ac13343bef92ab7eed84548"
 
 [[package]]
 name = "remove_dir_all"
@@ -3385,7 +3578,7 @@ dependencies = [
  "futures 0.3.13",
  "graphql-parser",
  "indexmap",
- "itertools",
+ "itertools 0.8.2",
  "prisma-models",
  "query-core",
  "serde",
@@ -3400,12 +3593,12 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.0"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd281b1030aa675fb90aa994d07187645bb3c8fc756ca766e7c3070b439de9de"
+checksum = "bf12057f289428dbf5c591c74bf10392e4a8003f993405a902f20117019022d4"
 dependencies = [
  "base64 0.13.0",
- "bytes",
+ "bytes 1.0.1",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -3419,7 +3612,7 @@ dependencies = [
  "log",
  "mime",
  "percent-encoding 2.1.0",
- "pin-project-lite 0.2.4",
+ "pin-project-lite 0.2.6",
  "rustls",
  "serde",
  "serde_json",
@@ -3479,7 +3672,7 @@ dependencies = [
  "lru-cache",
  "memchr",
  "smallvec",
- "time 0.1.43",
+ "time 0.1.44",
 ]
 
 [[package]]
@@ -3522,10 +3715,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.4"
+name = "rustls-native-certs"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb5d2a036dc6d2d8fd16fde3498b04306e29bd193bf306a57427019b823d5acd"
+checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
+dependencies = [
+ "openssl-probe",
+ "rustls",
+ "schannel",
+ "security-framework",
+]
 
 [[package]]
 name = "ryu"
@@ -3561,9 +3760,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfd318104249865096c8da1dfabf09ddbb6d0330ea176812a62ec75e40c4166"
+checksum = "d493c5f39e02dfb062cd8f33301f90f9b13b650e8c1b1d0fd75c19dd64bff69d"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -3599,9 +3798,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.123"
+version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
+checksum = "bd761ff957cb2a45fbb9ab3da6512de9de55872866160b23c25f1a841e99d29f"
 dependencies = [
  "serde_derive",
 ]
@@ -3617,9 +3816,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.123"
+version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
+checksum = "1800f7693e94e186f5e25a28291ae1570da908aff7d97a095dec1e56ff99069b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3628,9 +3827,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43535db9747a4ba938c0ce0a98cc631a46ebf943c9e1d604e091df6007620bf6"
+checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 dependencies = [
  "indexmap",
  "itoa",
@@ -3664,9 +3863,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "1.6.2"
+version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42fa8fb0da0bf5aa7dd5d8fe1f9ec769833eb7cf97ff89942903809e600de908"
+checksum = "b44be9227e214a0420707c9ca74c2d4991d9955bae9415a8f93f05cebf561be5"
 dependencies = [
  "serde",
  "serde_with_macros",
@@ -3674,11 +3873,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "1.3.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1197ff7de45494f290c1e3e1a6f80e108974681984c87a3e480991ef3d0f1950"
+checksum = "e48b35457e9d855d3dc05ef32a73e0df1e2c0fd72c38796a4ee909160c8eeec2"
 dependencies = [
- "darling",
+ "darling 0.12.2",
  "proc-macro2",
  "quote",
  "syn",
@@ -3760,9 +3959,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7f3f92a1da3d6b1d32245d0cbcbbab0cfc45996d8df619c42bccfa6d2bbb5f"
+checksum = "6aa894ef3fade0ee7243422f4fbbd6c2b48e6de767e621d37ef65f2310f53cea"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -3915,7 +4114,7 @@ dependencies = [
  "cuid",
  "datamodel",
  "futures 0.3.13",
- "itertools",
+ "itertools 0.8.2",
  "prisma-models",
  "prisma-value",
  "quaint",
@@ -4098,24 +4297,12 @@ checksum = "45f6ee7c7b87caf59549e9fe45d6a69c75c8019e79e212a835c5da0e92f0ba08"
 
 [[package]]
 name = "syn"
-version = "1.0.60"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
+checksum = "3fd9d1e9976102a03c542daa2eff1b43f9d72306342f3f8b3ed5fb8908195d6f"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
  "unicode-xid",
 ]
 
@@ -4160,7 +4347,7 @@ dependencies = [
 name = "test-macros"
 version = "0.1.0"
 dependencies = [
- "darling",
+ "darling 0.10.2",
  "enumflags2",
  "once_cell",
  "proc-macro2",
@@ -4228,12 +4415,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97383edb2eac690d48010a75edff0b9cc99451bff60b506f6af66b575ce57297"
 dependencies = [
  "async-native-tls",
- "async-stream",
+ "async-stream 0.2.1",
  "async-trait",
  "asynchronous-codec",
  "bigdecimal",
  "byteorder",
- "bytes",
+ "bytes 1.0.1",
  "chrono",
  "connection-string",
  "encoding",
@@ -4245,7 +4432,7 @@ dependencies = [
  "num-traits",
  "once_cell",
  "opentls",
- "pin-project-lite 0.2.4",
+ "pin-project-lite 0.2.6",
  "pretty-hex",
  "thiserror",
  "tokio",
@@ -4271,7 +4458,7 @@ dependencies = [
  "http-types",
  "kv-log-macro",
  "log",
- "pin-project-lite 0.1.11",
+ "pin-project-lite 0.1.12",
  "route-recognizer",
  "serde",
  "serde_json",
@@ -4294,11 +4481,12 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
@@ -4357,18 +4545,22 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8190d04c665ea9e6b6a0dc45523ade572c088d2e6566244c1122671dbf4ae3a"
+checksum = "8d56477f6ed99e10225f38f9f75f872f29b8b8bd8c0b946f63345bb144e9eeda"
 dependencies = [
  "autocfg",
- "bytes",
+ "bytes 1.0.1",
  "libc",
  "memchr",
  "mio",
  "num_cpus",
- "pin-project-lite 0.2.4",
+ "once_cell",
+ "parking_lot 0.11.1",
+ "pin-project-lite 0.2.6",
+ "signal-hook-registry",
  "tokio-macros",
+ "winapi",
 ]
 
 [[package]]
@@ -4399,14 +4591,14 @@ source = "git+https://github.com/pimeys/rust-postgres?branch=pgbouncer-mode#7d37
 dependencies = [
  "async-trait",
  "byteorder",
- "bytes",
+ "bytes 1.0.1",
  "fallible-iterator",
  "futures 0.3.13",
  "log",
  "parking_lot 0.11.1",
  "percent-encoding 2.1.0",
  "phf",
- "pin-project-lite 0.2.4",
+ "pin-project-lite 0.2.6",
  "postgres-protocol",
  "postgres-types",
  "socket2",
@@ -4426,17 +4618,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-util"
-version = "0.6.3"
+name = "tokio-stream"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebb7cb2f00c5ae8df755b252306272cd1790d39728363936e01827e11f0b017b"
+checksum = "c535f53c0cfa1acace62995a8994fc9cc1f12d202420da96ff306ee24d576469"
 dependencies = [
- "bytes",
+ "futures-core",
+ "pin-project-lite 0.2.6",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec31e5cc6b46e653cf57762f36f71d5e6386391d88a72fd6db4508f8f676fb29"
+dependencies = [
+ "bytes 1.0.1",
  "futures-core",
  "futures-io",
  "futures-sink",
  "log",
- "pin-project-lite 0.2.4",
+ "pin-project-lite 0.2.6",
  "tokio",
 ]
 
@@ -4448,6 +4651,75 @@ checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "tonic"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ba8f479158947373b6df40cf48f4779bb25c99ca3c661bd95e0ab1963ad8b0e"
+dependencies = [
+ "async-stream 0.3.0",
+ "async-trait",
+ "base64 0.13.0",
+ "bytes 1.0.1",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "percent-encoding 2.1.0",
+ "pin-project",
+ "prost 0.7.0",
+ "prost-derive 0.7.0",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tokio-util",
+ "tower",
+ "tower-service",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19970cf58f3acc820962be74c4021b8bbc8e8a1c4e3a02095d0aa60cde5f3633"
+dependencies = [
+ "proc-macro2",
+ "prost-build",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f715efe02c0862926eb463e49368d38ddb119383475686178e32e26d15d06a66"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap",
+ "pin-project",
+ "rand 0.8.3",
+ "slab",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
 
 [[package]]
 name = "tower-service"
@@ -4463,16 +4735,16 @@ checksum = "01ebdc2bb4498ab1ab5f5b73c5803825e60199229ccba0698170e3be0e7f959f"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
- "pin-project-lite 0.2.4",
+ "pin-project-lite 0.2.6",
  "tracing-attributes",
  "tracing-core",
 ]
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.13"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a9bd1db7706f2373a190b0d067146caa39350c486f3d455b0e33b431f94c07"
+checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4520,6 +4792,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-opentelemetry"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccdf13c28f1654fe806838f28c5b9cb23ca4c0eae71450daa489f50e523ceb1"
+dependencies = [
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-serde"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4531,9 +4816,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ab8966ac3ca27126141f7999361cc97dd6fb4b71da04c02044fa9045d98bb96"
+checksum = "705096c6f83bf68ea5d357a6aa01829ddbdac531b357b45abeca842938085baa"
 dependencies = [
  "ansi_term 0.12.1",
  "chrono",
@@ -4625,9 +4910,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
 
 [[package]]
 name = "ucd-trie"
@@ -4746,7 +5031,7 @@ dependencies = [
 name = "user-facing-error-macros"
 version = "0.1.0"
 dependencies = [
- "darling",
+ "darling 0.10.2",
  "once_cell",
  "proc-macro2",
  "quote",
@@ -4842,15 +5127,15 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.70"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55c0f7123de74f0dab9b7d00fd614e7b19349cd1e2f5252bbe9b1754b59433be"
+checksum = "7ee1280240b7c461d6a0071313e08f34a60b0365f14260362e5a2b17d1d31aa7"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -4860,9 +5145,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.70"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bc45447f0d4573f3d65720f636bbcc3dd6ce920ed704670118650bcd47764c7"
+checksum = "5b7d8b6942b8bb3a9b0e73fc79b98095a27de6fa247615e59d096754a3bc2aa8"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -4875,9 +5160,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3de431a2910c86679c34283a33f66f4e4abd7e0aec27b6669060148872aadf94"
+checksum = "8e67a5806118af01f0d9045915676b22aaebecf4178ae7021bc171dab0b897ab"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -4887,9 +5172,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.70"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b8853882eef39593ad4174dd26fc9865a64e84026d223f63bb2c42affcbba2c"
+checksum = "e5ac38da8ef716661f0f36c0d8320b89028efe10c7c0afde65baffb496ce0d3b"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4897,9 +5182,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.70"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4133b5e7f2a531fa413b3a1695e925038a05a71cf67e87dafa295cb645a01385"
+checksum = "cc053ec74d454df287b9374ee8abb36ffd5acb95ba87da3ba5b7d3fe20eb401e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4910,15 +5195,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.70"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd4945e4943ae02d15c13962b38a5b1e81eadd4b71214eee75af64a4d6a4fd64"
+checksum = "7d6f8ec44822dd71f5f221a5847fb34acd9060535c1211b70a05844c0f6383b1"
 
 [[package]]
 name = "web-sys"
-version = "0.3.47"
+version = "0.3.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c40dc691fc48003eba817c38da7113c15698142da971298003cac3ef175680b3"
+checksum = "ec600b26223b2948cedfde2a0aa6756dcf1fef616f43d7b3097aaf53a6c4d92b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4959,6 +5244,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fcb14dea929042224824779fbc82d9fab8d2e6d3cbc0ac404de8edf489e77ff"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "which"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -168,5 +168,27 @@ services:
     networks:
       - databases
 
+  jaeger:
+    image: jaegertracing/all-in-one:latest
+    restart: always
+    ports:
+      - "16686:16686" # the trace viewer (http)
+    networks:
+      - telemetry
+
+  otel-agent:
+    image: otel/opentelemetry-collector-dev:latest
+    command: ["--config=/etc/otel-agent-config.yaml"]
+    restart: always
+    volumes:
+      - ./otel-agent-config.yaml:/etc/otel-agent-config.yaml
+    ports:
+      - "4317:4317" # OTLP gRPC receiver
+    depends_on:
+      - jaeger
+    networks:
+      - telemetry
+
 networks:
   databases:
+  telemetry:

--- a/libs/sql-schema-describer/src/mssql.rs
+++ b/libs/sql-schema-describer/src/mssql.rs
@@ -108,7 +108,7 @@ impl super::SqlSchemaDescriberBackend for SqlSchemaDescriber {
     }
 
     #[tracing::instrument]
-    async fn version(&self, schema: &str) -> DescriberResult<Option<String>> {
+    async fn version(&self, _schema: &str) -> DescriberResult<Option<String>> {
         Ok(self.conn.version().await?)
     }
 }

--- a/libs/sql-schema-describer/src/mysql.rs
+++ b/libs/sql-schema-describer/src/mysql.rs
@@ -87,7 +87,7 @@ impl super::SqlSchemaDescriberBackend for SqlSchemaDescriber {
     }
 
     #[tracing::instrument(skip(self))]
-    async fn version(&self, schema: &str) -> crate::DescriberResult<Option<String>> {
+    async fn version(&self, _schema: &str) -> crate::DescriberResult<Option<String>> {
         Ok(self.conn.version().await?)
     }
 }

--- a/libs/sql-schema-describer/src/postgres.rs
+++ b/libs/sql-schema-describer/src/postgres.rs
@@ -59,7 +59,7 @@ impl super::SqlSchemaDescriberBackend for SqlSchemaDescriber {
     }
 
     #[tracing::instrument]
-    async fn version(&self, schema: &str) -> crate::DescriberResult<Option<String>> {
+    async fn version(&self, _schema: &str) -> crate::DescriberResult<Option<String>> {
         Ok(self.conn.version().await?)
     }
 }

--- a/libs/sql-schema-describer/src/sqlite.rs
+++ b/libs/sql-schema-describer/src/sqlite.rs
@@ -74,7 +74,7 @@ impl SqlSchemaDescriberBackend for SqlSchemaDescriber {
     }
 
     #[tracing::instrument]
-    async fn version(&self, schema: &str) -> DescriberResult<Option<String>> {
+    async fn version(&self, _schema: &str) -> DescriberResult<Option<String>> {
         Ok(self.conn.version().await?)
     }
 }

--- a/otel-agent-config.yaml
+++ b/otel-agent-config.yaml
@@ -1,0 +1,17 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+
+exporters:
+  jaeger:
+    endpoint: "jaeger:14250"
+    insecure: true
+  logging:
+    loglevel: debug
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [jaeger, logging]

--- a/query-engine/connectors/sql-query-connector/src/cursor_condition.rs
+++ b/query-engine/connectors/sql-query-connector/src/cursor_condition.rs
@@ -105,6 +105,7 @@ struct CursorOrderDefinition {
 ///     OR `main`.`ModelA`.`modelB_id` IS NULL -- >>> Additional check for the nullable foreign key
 ///   )
 /// ```
+#[tracing::instrument(name = "build_cursor_condition", skip(query_arguments, model, ordering_joins))]
 pub fn build(
     query_arguments: &QueryArguments,
     model: &ModelRef,
@@ -119,7 +120,7 @@ pub fn build(
             let cursor_row = Row::from(cursor_columns);
 
             // Invariant: Cursors are unique. This means we can create a subquery to find at most one row
-            // that contains all the values required for the odering row comparison (order_subquery).
+            // that contains all the values required for the ordering row comparison (order_subquery).
             // That does _not_ mean that this retrieved row has an ordering unique across all records, because
             // that can only be true if the orderBy contains a combination of fields that are unique, or a single unique field.
             let cursor_condition = cursor_row.clone().equals(cursor_values.clone());

--- a/query-engine/connectors/sql-query-connector/src/database/connection.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/connection.rs
@@ -41,6 +41,7 @@ impl<C> Connection for SqlConnection<C>
 where
     C: QueryExt + TransactionCapable + Send + Sync + 'static,
 {
+    #[tracing::instrument(skip(self))]
     async fn start_transaction<'a>(&'a self) -> connector::Result<Box<dyn Transaction + 'a>> {
         let fut_tx = self.inner.start_transaction();
         let connection_info = &self.connection_info;

--- a/query-engine/connectors/sql-query-connector/src/database/mssql.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/mssql.rs
@@ -44,6 +44,7 @@ impl FromSource for Mssql {
 
 #[async_trait]
 impl Connector for Mssql {
+    #[tracing::instrument(skip(self))]
     async fn get_connection<'a>(&'a self) -> connector::Result<Box<dyn Connection + Send + Sync + 'static>> {
         super::catch(&self.connection_info, async move {
             let conn = self.pool.check_out().await.map_err(SqlError::from)?;

--- a/query-engine/connectors/sql-query-connector/src/database/mysql.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/mysql.rs
@@ -44,6 +44,7 @@ impl FromSource for Mysql {
 
 #[async_trait]
 impl Connector for Mysql {
+    #[tracing::instrument(skip(self))]
     async fn get_connection<'a>(&'a self) -> connector::Result<Box<dyn Connection + Send + Sync + 'static>> {
         super::catch(&self.connection_info, async move {
             let conn = self.pool.check_out().await.map_err(SqlError::from)?;

--- a/query-engine/connectors/sql-query-connector/src/database/operations/read.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/read.rs
@@ -9,6 +9,7 @@ use futures::stream::{FuturesUnordered, StreamExt};
 use prisma_models::*;
 use quaint::ast::*;
 
+#[tracing::instrument(skip(conn, model, filter, selected_fields))]
 pub async fn get_single_record(
     conn: &dyn QueryExt,
     model: &ModelRef,
@@ -33,6 +34,7 @@ pub async fn get_single_record(
     Ok(record)
 }
 
+#[tracing::instrument(skip(conn, model, query_arguments, selected_fields))]
 pub async fn get_many_records(
     conn: &dyn QueryExt,
     model: &ModelRef,
@@ -102,6 +104,7 @@ pub async fn get_many_records(
     Ok(records)
 }
 
+#[tracing::instrument(skip(conn, from_field, from_record_ids))]
 pub async fn get_related_m2m_record_ids(
     conn: &dyn QueryExt,
     from_field: &RelationFieldRef,
@@ -169,6 +172,7 @@ pub async fn get_related_m2m_record_ids(
         .collect())
 }
 
+#[tracing::instrument(skip(conn, model, query_arguments, selections, group_by, having))]
 pub async fn aggregate(
     conn: &dyn QueryExt,
     model: &ModelRef,
@@ -186,6 +190,7 @@ pub async fn aggregate(
     }
 }
 
+#[tracing::instrument(skip(conn, model, query_arguments, selections))]
 async fn plain_aggregate(
     conn: &dyn QueryExt,
     model: &ModelRef,
@@ -209,6 +214,7 @@ async fn plain_aggregate(
     Ok(row.into_aggregation_results(&selections))
 }
 
+#[tracing::instrument(skip(conn, model, query_arguments, selections, group_by, having))]
 async fn group_by_aggregate(
     conn: &dyn QueryExt,
     model: &ModelRef,

--- a/query-engine/connectors/sql-query-connector/src/database/operations/write.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/write.rs
@@ -10,6 +10,7 @@ use user_facing_errors::query_engine::DatabaseConstraint;
 
 /// Create a single record to the database defined in `conn`, resulting into a
 /// `RecordProjection` as an identifier pointing to the just-created record.
+#[tracing::instrument(skip(conn, model, args))]
 pub async fn create_record(conn: &dyn QueryExt, model: &ModelRef, args: WriteArgs) -> crate::Result<RecordProjection> {
     let (insert, returned_id) = write::create_record(model, args);
 
@@ -73,6 +74,7 @@ pub async fn create_record(conn: &dyn QueryExt, model: &ModelRef, args: WriteArg
     }
 }
 
+#[tracing::instrument(skip(conn, sql_info, model, args, skip_duplicates))]
 pub async fn create_records(
     conn: &dyn QueryExt,
     sql_info: SqlInfo,
@@ -166,6 +168,7 @@ pub async fn create_records(
 /// Update multiple records in a database defined in `conn` and the records
 /// defined in `args`, resulting the identifiers that were modified in the
 /// operation.
+#[tracing::instrument(skip(conn, model, record_filter, args))]
 pub async fn update_records(
     conn: &dyn QueryExt,
     model: &ModelRef,
@@ -192,6 +195,7 @@ pub async fn update_records(
 }
 
 /// Delete multiple records in `conn`, defined in the `Filter`. Result is the number of items deleted.
+#[tracing::instrument(skip(conn, model, record_filter))]
 pub async fn delete_records(
     conn: &dyn QueryExt,
     model: &ModelRef,
@@ -214,6 +218,7 @@ pub async fn delete_records(
 
 /// Connect relations defined in `child_ids` to a parent defined in `parent_id`.
 /// The relation information is in the `RelationFieldRef`.
+#[tracing::instrument(skip(conn, field, parent_id, child_ids))]
 pub async fn m2m_connect(
     conn: &dyn QueryExt,
     field: &RelationFieldRef,
@@ -228,6 +233,7 @@ pub async fn m2m_connect(
 
 /// Disconnect relations defined in `child_ids` to a parent defined in `parent_id`.
 /// The relation information is in the `RelationFieldRef`.
+#[tracing::instrument(skip(conn, field, parent_id, child_ids))]
 pub async fn m2m_disconnect(
     conn: &dyn QueryExt,
     field: &RelationFieldRef,
@@ -242,6 +248,7 @@ pub async fn m2m_disconnect(
 
 /// Execute a plain SQL query with the given parameters, returning the number of
 /// affected rows.
+#[tracing::instrument(skip(conn, query, parameters))]
 pub async fn execute_raw(conn: &dyn QueryExt, query: String, parameters: Vec<PrismaValue>) -> crate::Result<usize> {
     let value = conn.raw_count(query, parameters).await?;
     Ok(value)
@@ -249,6 +256,7 @@ pub async fn execute_raw(conn: &dyn QueryExt, query: String, parameters: Vec<Pri
 
 /// Execute a plain SQL query with the given parameters, returning the answer as
 /// a JSON `Value`.
+#[tracing::instrument(skip(conn, query, parameters))]
 pub async fn query_raw(
     conn: &dyn QueryExt,
     query: String,

--- a/query-engine/connectors/sql-query-connector/src/database/postgresql.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/postgresql.rs
@@ -42,6 +42,7 @@ impl FromSource for PostgreSql {
 
 #[async_trait]
 impl Connector for PostgreSql {
+    #[tracing::instrument(skip(self))]
     async fn get_connection<'a>(&'a self) -> connector_interface::Result<Box<dyn Connection + Send + Sync + 'static>> {
         super::catch(&self.connection_info, async move {
             let conn = self.pool.check_out().await.map_err(SqlError::from)?;

--- a/query-engine/connectors/sql-query-connector/src/database/sqlite.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/sqlite.rs
@@ -68,6 +68,7 @@ fn invalid_file_path_error(file_path: &str, connection_info: &ConnectionInfo) ->
 
 #[async_trait]
 impl Connector for Sqlite {
+    #[tracing::instrument(skip(self))]
     async fn get_connection<'a>(&'a self) -> connector::Result<Box<dyn Connection + Send + Sync + 'static>> {
         super::catch(&self.connection_info(), async move {
             let conn = self.pool.check_out().await.map_err(SqlError::from)?;

--- a/query-engine/connectors/sql-query-connector/src/database/transaction.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/transaction.rs
@@ -37,11 +37,13 @@ impl<'tx> SqlConnectorTransaction<'tx> {
 
 #[async_trait]
 impl<'tx> Transaction for SqlConnectorTransaction<'tx> {
+    #[tracing::instrument(skip(self))]
     async fn commit(&self) -> connector::Result<()> {
         self.catch(async move { Ok(self.inner.commit().await.map_err(SqlError::from)?) })
             .await
     }
 
+    #[tracing::instrument(skip(self))]
     async fn rollback(&self) -> connector::Result<()> {
         self.catch(async move { Ok(self.inner.rollback().await.map_err(SqlError::from)?) })
             .await

--- a/query-engine/connectors/sql-query-connector/src/filter_conversion.rs
+++ b/query-engine/connectors/sql-query-connector/src/filter_conversion.rs
@@ -74,6 +74,7 @@ trait AliasedSelect {
 
 impl AliasedCondition for Filter {
     /// Conversion from a `Filter` to a query condition tree. Aliased when in a nested `SELECT`.
+    #[tracing::instrument(skip(self, alias))]
     fn aliased_cond(self, alias: Option<Alias>) -> ConditionTree<'static> {
         match self {
             Filter::And(mut filters) => match filters.len() {

--- a/query-engine/connectors/sql-query-connector/src/ordering.rs
+++ b/query-engine/connectors/sql-query-connector/src/ordering.rs
@@ -15,6 +15,7 @@ pub struct OrderingJoins {
 }
 
 /// Builds all expressions for an `ORDER BY` clause based on the query arguments.
+#[tracing::instrument(skip(query_arguments, base_model))]
 pub fn build(
     query_arguments: &QueryArguments,
     base_model: &ModelRef, // The model the ordering will start from

--- a/query-engine/connectors/sql-query-connector/src/query_builder/mod.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_builder/mod.rs
@@ -9,6 +9,7 @@ use quaint::ast::{Column, Comparable, ConditionTree, Query, Row, Values};
 
 const PARAMETER_LIMIT: usize = 2000;
 
+#[tracing::instrument(skip(columns, records, f))]
 pub(super) fn chunked_conditions<F, Q>(
     columns: &[Column<'static>],
     records: &[&RecordProjection],
@@ -27,6 +28,7 @@ where
         .collect()
 }
 
+#[tracing::instrument(skip(columns, records))]
 pub(super) fn conditions<'a>(
     columns: &'a [Column<'static>],
     records: impl IntoIterator<Item = &'a RecordProjection>,

--- a/query-engine/connectors/sql-query-connector/src/query_builder/read.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_builder/read.rs
@@ -40,6 +40,7 @@ impl SelectDefinition for Select<'static> {
 }
 
 impl SelectDefinition for QueryArguments {
+    #[tracing::instrument(skip(self, model, aggr_selections))]
     fn into_select(
         self,
         model: &ModelRef,
@@ -94,6 +95,7 @@ impl SelectDefinition for QueryArguments {
     }
 }
 
+#[tracing::instrument(skip(model, columns, aggr_selections, query))]
 pub fn get_records<T>(
     model: &ModelRef,
     columns: impl Iterator<Item = Column<'static>>,
@@ -135,6 +137,7 @@ where
 /// ```
 /// Important note: Do not use the AsColumn trait here as we need to construct column references that are relative,
 /// not absolute - e.g. `SELECT "field" FROM (...)` NOT `SELECT "full"."path"."to"."field" FROM (...)`.
+#[tracing::instrument(skip(model, selections, args))]
 pub fn aggregate(model: &ModelRef, selections: &[AggregationSelection], args: QueryArguments) -> Select<'static> {
     let columns = extract_columns(model, &selections);
     let sub_query = get_records(model, columns.into_iter(), &[], args);
@@ -175,6 +178,7 @@ pub fn aggregate(model: &ModelRef, selections: &[AggregationSelection], args: Qu
         })
 }
 
+#[tracing::instrument(skip(model, args, selections, group_by, having))]
 pub fn group_by_aggregate(
     model: &ModelRef,
     args: QueryArguments,
@@ -226,6 +230,7 @@ pub fn group_by_aggregate(
     }
 }
 
+#[tracing::instrument(skip(model, selections))]
 fn extract_columns(model: &ModelRef, selections: &[AggregationSelection]) -> Vec<Column<'static>> {
     let fields: Vec<_> = selections
         .iter()

--- a/query-engine/connectors/sql-query-connector/src/query_builder/write.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_builder/write.rs
@@ -5,6 +5,7 @@ use std::convert::TryInto;
 
 /// `INSERT` a new record to the database. Resulting an `INSERT` ast and an
 /// optional `RecordProjection` if available from the arguments or model.
+#[tracing::instrument(skip(model, args))]
 pub fn create_record(model: &ModelRef, mut args: WriteArgs) -> (Insert<'static>, Option<RecordProjection>) {
     let return_id = args.as_record_projection(model.primary_identifier());
 
@@ -35,6 +36,7 @@ pub fn create_record(model: &ModelRef, mut args: WriteArgs) -> (Insert<'static>,
 
 /// `INSERT` new records into the database based on the given write arguments,
 /// where each `WriteArg` in the Vec is one row.
+#[tracing::instrument(skip(model, args, skip_duplicates))]
 pub fn create_records(model: &ModelRef, args: Vec<WriteArgs>, skip_duplicates: bool) -> Insert<'static> {
     // We need to bring all write args into a uniform shape.
     // The easiest way to do this is to take go over all fields of the batch and apply the following:
@@ -76,6 +78,7 @@ pub fn create_records(model: &ModelRef, args: Vec<WriteArgs>, skip_duplicates: b
     }
 }
 
+#[tracing::instrument(skip(model, ids, args))]
 pub fn update_many(model: &ModelRef, ids: &[&RecordProjection], args: WriteArgs) -> crate::Result<Vec<Query<'static>>> {
     if args.args.is_empty() || ids.is_empty() {
         return Ok(Vec::new());
@@ -126,6 +129,7 @@ pub fn update_many(model: &ModelRef, ids: &[&RecordProjection], args: WriteArgs)
     Ok(result)
 }
 
+#[tracing::instrument(skip(model, ids))]
 pub fn delete_many(model: &ModelRef, ids: &[&RecordProjection]) -> Vec<Query<'static>> {
     let columns: Vec<_> = model.primary_identifier().as_columns().collect();
 
@@ -134,6 +138,7 @@ pub fn delete_many(model: &ModelRef, ids: &[&RecordProjection]) -> Vec<Query<'st
     })
 }
 
+#[tracing::instrument(skip(field, parent_id, child_ids))]
 pub fn create_relation_table_records(
     field: &RelationFieldRef,
     parent_id: &RecordProjection,
@@ -156,6 +161,7 @@ pub fn create_relation_table_records(
     insert.build().on_conflict(OnConflict::DoNothing).into()
 }
 
+#[tracing::instrument(skip(parent_field, parent_id, child_ids))]
 pub fn delete_relation_table_records(
     parent_field: &RelationFieldRef,
     parent_id: &RecordProjection,

--- a/query-engine/connectors/sql-query-connector/src/row.rs
+++ b/query-engine/connectors/sql-query-connector/src/row.rs
@@ -18,6 +18,7 @@ pub struct SqlRow {
 }
 
 impl SqlRow {
+    #[tracing::instrument(skip(self, selections))]
     pub fn into_aggregation_results(self, selections: &[AggregationSelection]) -> Vec<AggregationResult> {
         let mut values = self.values;
         values.reverse();
@@ -96,6 +97,7 @@ pub trait ToSqlRow {
 }
 
 impl ToSqlRow for ResultRow {
+    #[tracing::instrument(skip(self, meta))]
     fn to_sql_row(self, meta: &[ColumnMetadata<'_>]) -> crate::Result<SqlRow> {
         let mut row = SqlRow::default();
         let row_width = meta.len();
@@ -130,6 +132,7 @@ impl ToSqlRow for ResultRow {
     }
 }
 
+#[tracing::instrument(skip(p_value, meta))]
 pub fn row_value_to_prisma_value(p_value: Value, meta: ColumnMetadata<'_>) -> Result<PrismaValue, SqlError> {
     let create_error = |value: &Value| {
         let message = match meta.name() {

--- a/query-engine/core/src/exec_loader.rs
+++ b/query-engine/core/src/exec_loader.rs
@@ -22,6 +22,7 @@ use mongodb_connector::MongoDb;
 
 const DEFAULT_SQLITE_DB_NAME: &str = "main";
 
+#[tracing::instrument(name = "exec_loader", skip(source))]
 pub async fn load(source: &Datasource) -> crate::Result<(String, Box<dyn QueryExecutor + Send + Sync>)> {
     match source.active_provider.as_str() {
         SQLITE_SOURCE_NAME => sqlite(source).await,

--- a/query-engine/core/src/executor/interpreting_executor.rs
+++ b/query-engine/core/src/executor/interpreting_executor.rs
@@ -72,6 +72,7 @@ where
     /// A failing operation does not fail the batch, instead, an error is returned alongside other responses.
     /// Note that individual operations executed in non-transactional mode can still be transactions in themselves
     /// if the query (e.g. a write op) requires it.
+    #[tracing::instrument(skip(self, operations, query_schema))]
     async fn execute_batch(
         &self,
         operations: Vec<Operation>,

--- a/query-engine/core/src/executor/pipeline.rs
+++ b/query-engine/core/src/executor/pipeline.rs
@@ -1,5 +1,6 @@
 use crate::{Env, Expressionista, IrSerializer, QueryGraph, QueryInterpreter, ResponseData};
 
+#[derive(Debug)]
 pub struct QueryPipeline<'conn, 'tx> {
     graph: QueryGraph,
     interpreter: QueryInterpreter<'conn, 'tx>,

--- a/query-engine/core/src/interpreter/expressionista.rs
+++ b/query-engine/core/src/interpreter/expressionista.rs
@@ -16,6 +16,7 @@ struct IfNodeAcc {
 }
 
 impl Expressionista {
+    #[tracing::instrument(skip(graph))]
     pub fn translate(mut graph: QueryGraph) -> InterpretationResult<Expression> {
         graph
             .root_nodes()
@@ -25,6 +26,7 @@ impl Expressionista {
             .map(|res| Expression::Sequence { seq: res })
     }
 
+    #[tracing::instrument(skip(graph, node, parent_edges))]
     fn build_expression(
         graph: &mut QueryGraph,
         node: &NodeRef,
@@ -41,6 +43,7 @@ impl Expressionista {
         }
     }
 
+    #[tracing::instrument(skip(graph, node, parent_edges))]
     fn build_query_expression(
         graph: &mut QueryGraph,
         node: &NodeRef,
@@ -86,6 +89,7 @@ impl Expressionista {
         }
     }
 
+    #[tracing::instrument(skip(graph, child_pairs))]
     fn process_children(
         graph: &mut QueryGraph,
         mut child_pairs: Vec<(EdgeRef, NodeRef)>,
@@ -131,6 +135,7 @@ impl Expressionista {
         Ok(expressions)
     }
 
+    #[tracing::instrument(skip(graph, node, parent_edges))]
     fn build_empty_expression(
         graph: &mut QueryGraph,
         node: &NodeRef,
@@ -148,6 +153,7 @@ impl Expressionista {
         Self::transform_node(graph, parent_edges, Node::Empty, into_expr)
     }
 
+    #[tracing::instrument(skip(graph, node, parent_edges))]
     fn build_computation_expression(
         graph: &mut QueryGraph,
         node: &NodeRef,
@@ -200,6 +206,7 @@ impl Expressionista {
         }
     }
 
+    #[tracing::instrument(skip(graph, node, parent_edges))]
     fn build_flow_expression(
         graph: &mut QueryGraph,
         node: &NodeRef,
@@ -214,6 +221,7 @@ impl Expressionista {
         }
     }
 
+    #[tracing::instrument(skip(graph, node, parent_edges))]
     fn translate_if_node(
         graph: &mut QueryGraph,
         node: &NodeRef,
@@ -280,6 +288,7 @@ impl Expressionista {
         Self::transform_node(graph, parent_edges, node, into_expr)
     }
 
+    #[tracing::instrument(skip(graph, node, parent_edges))]
     fn translate_return_node(
         graph: &mut QueryGraph,
         node: &NodeRef,
@@ -306,6 +315,7 @@ impl Expressionista {
 
     /// Runs transformer functions (e.g. `ParentIdsFn`) via `Expression::Func` if necessary, or if none present,
     /// builds an expression directly. `into_expr` does the final expression building based on the node coming in.
+    #[tracing::instrument(skip(graph, parent_edges, node, into_expr))]
     fn transform_node(
         graph: &mut QueryGraph,
         parent_edges: Vec<EdgeRef>,
@@ -364,6 +374,7 @@ impl Expressionista {
     }
 
     /// Collects all edge dependencies that perform a node transformation based on the parent.
+    #[tracing::instrument(skip(graph, parent_edges))]
     fn collect_parent_transformers(
         graph: &mut QueryGraph,
         parent_edges: Vec<EdgeRef>,
@@ -384,6 +395,7 @@ impl Expressionista {
             .collect()
     }
 
+    #[tracing::instrument(skip(graph, result_subgraphs))]
     fn fold_result_scopes(
         graph: &mut QueryGraph,
         result_subgraphs: Vec<(EdgeRef, NodeRef)>,

--- a/query-engine/core/src/interpreter/formatters.rs
+++ b/query-engine/core/src/interpreter/formatters.rs
@@ -1,6 +1,7 @@
 use super::Expression;
 use crate::Query;
 
+#[tracing::instrument(skip(expr, indent))]
 pub fn format_expression(expr: &Expression, indent: usize) -> String {
     match expr {
         Expression::Sequence { seq } => seq

--- a/query-engine/core/src/interpreter/query_interpreters/inmemory_record_processor.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/inmemory_record_processor.rs
@@ -20,6 +20,7 @@ impl Deref for InMemoryRecordProcessor {
 impl InMemoryRecordProcessor {
     /// Creates a new processor from the given query args.
     /// The original args will be modified to prevent db level processing.
+    #[tracing::instrument(skip(args))]
     pub fn new_from_query_args(args: &mut QueryArguments) -> Self {
         let processor = Self { args: args.clone() };
 
@@ -40,6 +41,7 @@ impl InMemoryRecordProcessor {
         self.take.map(|t| t < 0).unwrap_or(false)
     }
 
+    #[tracing::instrument(skip(self, records))]
     pub fn apply(&self, mut records: ManyRecords) -> ManyRecords {
         if self.needs_reversed_order() {
             records.reverse();

--- a/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
@@ -5,6 +5,7 @@ use prisma_models::{ManyRecords, ModelProjection, Record, RecordProjection, Rela
 use prisma_value::PrismaValue;
 use std::collections::HashMap;
 
+#[tracing::instrument(skip(tx, query, parent_result, processor))]
 pub async fn m2m<'a, 'b>(
     tx: &'a ConnectionLike<'a, 'b>,
     query: &RelatedRecordsQuery,
@@ -107,6 +108,15 @@ pub async fn m2m<'a, 'b>(
 }
 
 // [DTODO] This is implemented in an inefficient fashion, e.g. too much Arc cloning going on.
+#[tracing::instrument(skip(
+    tx,
+    parent_field,
+    parent_projections,
+    parent_result,
+    query_args,
+    selected_fields,
+    processor
+))]
 pub async fn one2m<'a, 'b>(
     tx: &'a ConnectionLike<'a, 'b>,
     parent_field: &RelationFieldRef,

--- a/query-engine/core/src/query_ast/write.rs
+++ b/query-engine/core/src/query_ast/write.rs
@@ -19,6 +19,7 @@ pub enum WriteQuery {
 }
 
 impl WriteQuery {
+    #[tracing::instrument(skip(self, projection))]
     pub fn inject_projection_into_args(&mut self, projection: RecordProjection) {
         let keys: Vec<_> = projection.fields().map(|sf| sf.db_name().to_owned()).collect();
         let values: Vec<_> = projection.values().collect();
@@ -39,6 +40,7 @@ impl WriteQuery {
         args.update_datetimes(model);
     }
 
+    #[tracing::instrument(skip(self, projection))]
     pub fn returns(&self, projection: &ModelProjection) -> bool {
         let returns_id = &self.model().primary_identifier() == projection;
 
@@ -59,6 +61,7 @@ impl WriteQuery {
         }
     }
 
+    #[tracing::instrument(skip(self))]
     pub fn model(&self) -> ModelRef {
         match self {
             Self::CreateRecord(q) => Arc::clone(&q.model),
@@ -132,6 +135,7 @@ pub struct CreateManyRecords {
 }
 
 impl CreateManyRecords {
+    #[tracing::instrument(skip(self, projection))]
     pub fn inject_all(&mut self, projection: RecordProjection) {
         let keys: Vec<_> = projection.fields().map(|sf| sf.db_name().to_owned()).collect();
         let values: Vec<_> = projection.values().collect();

--- a/query-engine/core/src/query_document/mod.rs
+++ b/query-engine/core/src/query_document/mod.rs
@@ -107,6 +107,7 @@ impl CompactedDocument {
 
 /// Here be the dragons. Ay caramba!
 impl From<Vec<Operation>> for CompactedDocument {
+    #[tracing::instrument(name = "find_one_optimization", skip(ops))]
     fn from(ops: Vec<Operation>) -> Self {
         // Unpack all read queries (an enum) into a collection of selections.
         // We already took care earlier that all operations here must be reads.

--- a/query-engine/core/src/query_document/parser.rs
+++ b/query-engine/core/src/query_document/parser.rs
@@ -17,6 +17,7 @@ impl QueryDocumentParser {
     /// In contrast, nullable and optional types on an input object are separate concepts.
     /// The above is the reason we don't need to check nullability here, as it is done by the output
     /// validation in the serialization step.
+    #[tracing::instrument(skip(parent_path, selections, schema_object))]
     pub fn parse_object(
         parent_path: QueryPath,
         selections: &[Selection],
@@ -81,6 +82,7 @@ impl QueryDocumentParser {
     }
 
     /// Parses and validates selection arguments against a schema defined field.
+    #[tracing::instrument(skip(parent_path, schema_field, given_arguments))]
     pub fn parse_arguments(
         parent_path: QueryPath,
         schema_field: &OutputFieldRef,
@@ -139,6 +141,7 @@ impl QueryDocumentParser {
 
     /// Parses and validates a QueryValue against possible input types.
     /// Matching is done in order of definition on the input type. First matching type wins.
+    #[tracing::instrument(skip(parent_path, value, possible_input_types))]
     pub fn parse_input_value(
         parent_path: QueryPath,
         value: QueryValue,
@@ -215,6 +218,7 @@ impl QueryDocumentParser {
     }
 
     /// Attempts to parse given query value into a concrete PrismaValue based on given scalar type.
+    #[tracing::instrument(skip(parent_path, value))]
     pub fn parse_scalar(
         parent_path: &QueryPath,
         value: QueryValue,
@@ -259,6 +263,7 @@ impl QueryDocumentParser {
         }
     }
 
+    #[tracing::instrument(skip(path, s))]
     pub fn parse_datetime(path: &QueryPath, s: &str) -> QueryParserResult<DateTime<FixedOffset>> {
         DateTime::parse_from_rfc3339(s).map_err(|err| QueryParserError {
             path: path.clone(),
@@ -269,6 +274,7 @@ impl QueryDocumentParser {
         })
     }
 
+    #[tracing::instrument(skip(path, s))]
     pub fn parse_bytes(path: &QueryPath, s: String) -> QueryParserResult<PrismaValue> {
         prisma_value::decode_bytes(&s)
             .map(PrismaValue::Bytes)
@@ -281,6 +287,7 @@ impl QueryDocumentParser {
             })
     }
 
+    #[tracing::instrument(skip(path, s))]
     pub fn parse_decimal(path: &QueryPath, s: String) -> QueryParserResult<PrismaValue> {
         BigDecimal::from_str(&s)
             .map(PrismaValue::Float)
@@ -290,6 +297,7 @@ impl QueryDocumentParser {
             })
     }
 
+    #[tracing::instrument(skip(path, s))]
     pub fn parse_bigint(path: &QueryPath, s: String) -> QueryParserResult<PrismaValue> {
         s.parse::<i64>().map(PrismaValue::BigInt).map_err(|_| QueryParserError {
             path: path.clone(),
@@ -298,6 +306,7 @@ impl QueryDocumentParser {
     }
 
     // [DTODO] This is likely incorrect or at least using the wrong abstractions.
+    #[tracing::instrument(skip(path, s))]
     pub fn parse_json_list(path: &QueryPath, s: &str) -> QueryParserResult<PrismaValue> {
         let json = Self::parse_json(path, s)?;
 
@@ -320,6 +329,7 @@ impl QueryDocumentParser {
         Ok(PrismaValue::List(prisma_values))
     }
 
+    #[tracing::instrument(skip(path, s))]
     pub fn parse_json(path: &QueryPath, s: &str) -> QueryParserResult<serde_json::Value> {
         serde_json::from_str(s).map_err(|err| QueryParserError {
             path: path.clone(),
@@ -327,6 +337,7 @@ impl QueryDocumentParser {
         })
     }
 
+    #[tracing::instrument(skip(path, s))]
     pub fn parse_uuid(path: &QueryPath, s: &str) -> QueryParserResult<Uuid> {
         Uuid::parse_str(s).map_err(|err| QueryParserError {
             path: path.clone(),
@@ -334,6 +345,7 @@ impl QueryDocumentParser {
         })
     }
 
+    #[tracing::instrument(skip(path, values, value_type))]
     pub fn parse_list(
         path: &QueryPath,
         values: Vec<QueryValue>,
@@ -345,6 +357,7 @@ impl QueryDocumentParser {
             .collect::<QueryParserResult<Vec<ParsedInputValue>>>()
     }
 
+    #[tracing::instrument(skip(path, val, typ))]
     pub fn parse_enum(path: &QueryPath, val: QueryValue, typ: &EnumTypeRef) -> QueryParserResult<ParsedInputValue> {
         let raw = match val {
             QueryValue::Enum(s) => s,
@@ -389,6 +402,7 @@ impl QueryDocumentParser {
     }
 
     /// Parses and validates an input object recursively.
+    #[tracing::instrument(skip(parent_path, object, schema_object))]
     pub fn parse_input_object(
         parent_path: QueryPath,
         object: IndexMap<String, QueryValue>,

--- a/query-engine/core/src/query_graph/formatters.rs
+++ b/query-engine/core/src/query_graph/formatters.rs
@@ -1,6 +1,7 @@
 use super::*;
 use std::fmt::{self, Display};
 
+#[tracing::instrument(name = "debug_query_graph", skip(graph))]
 pub fn format(graph: &QueryGraph) -> String {
     format!(
         "---- Query Graph ----\nResult Nodes: {}\nMarked Nodes: {}\nRoot Nodes: {}\n\n{}\n----------------------",

--- a/query-engine/core/src/query_graph/mod.rs
+++ b/query-engine/core/src/query_graph/mod.rs
@@ -14,7 +14,7 @@ use connector::{IdFilter, QueryArguments};
 use guard::*;
 use petgraph::{graph::*, visit::EdgeRef as PEdgeRef, *};
 use prisma_models::{ModelProjection, ModelRef, RecordProjection};
-use std::{borrow::Borrow, collections::HashSet};
+use std::{borrow::Borrow, collections::HashSet, fmt};
 
 pub type QueryGraphResult<T> = std::result::Result<T, QueryGraphError>;
 
@@ -182,6 +182,19 @@ pub struct QueryGraph {
     visited: Vec<NodeIndex>,
 }
 
+impl fmt::Debug for QueryGraph {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("QueryGraph")
+            .field("graph", &"InnerGraph")
+            .field("result_nodes", &self.result_nodes)
+            .field("marked_node_pairs", &self.marked_node_pairs)
+            .field("finalized", &self.finalized)
+            .field("needs_transaction", &self.needs_transaction)
+            .field("visited", &self.visited)
+            .finish()
+    }
+}
+
 /// Implementation detail of the QueryGraph.
 type InnerGraph = Graph<Guard<Node>, Guard<QueryGraphDependency>>;
 
@@ -202,6 +215,7 @@ impl QueryGraph {
         Ok(graph)
     }
 
+    #[tracing::instrument(skip(self))]
     pub fn finalize(&mut self) -> QueryGraphResult<()> {
         if !self.finalized {
             self.swap_marked()?;
@@ -503,6 +517,7 @@ impl QueryGraph {
     ///                                                                                                         └───┘
     /// ```
     /// [DTODO] put if flow exception illustration here.
+    #[tracing::instrument(skip(self))]
     fn swap_marked(&mut self) -> QueryGraphResult<()> {
         if !self.marked_node_pairs.is_empty() {
             trace!("[Graph][Swap] Before shape: {}", self);
@@ -599,6 +614,7 @@ impl QueryGraph {
     ///         sibling   │                                ─ ─ ─ ─ ─ ─ ┘
     ///      └ ─ ─ ─ ─ ─ ─
     /// ```
+    #[tracing::instrument(skip(self))]
     fn normalize_if_nodes(&mut self) -> QueryGraphResult<()> {
         for node_ix in self.graph.node_indices() {
             let node = NodeRef { node_ix };
@@ -684,6 +700,7 @@ impl QueryGraph {
     ///
     /// The `Reload` node is always a find many query.
     /// Unwraps are safe because we're operating on the unprocessed state of the graph (`Expressionista` changes that).
+    #[tracing::instrument(skip(self))]
     fn insert_reloads(&mut self) -> QueryGraphResult<()> {
         let reloads: Vec<(NodeRef, ModelRef, Vec<ModelProjection>)> = self
             .graph

--- a/query-engine/core/src/query_graph_builder/builder.rs
+++ b/query-engine/core/src/query_graph_builder/builder.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use super::*;
 use crate::{constants::inputs::args, query_document::*, query_graph::*, schema::*, IrSerializer};
 use prisma_value::PrismaValue;
@@ -6,6 +8,12 @@ use prisma_value::PrismaValue;
 // the query_document module, possibly already as part of the parser.
 pub struct QueryGraphBuilder {
     pub query_schema: QuerySchemaRef,
+}
+
+impl fmt::Debug for QueryGraphBuilder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("QueryGraphBuilder").finish()
+    }
 }
 
 #[derive(Default)]
@@ -43,6 +51,7 @@ impl QueryGraphBuilder {
     }
 
     /// Maps an operation to a query.
+    #[tracing::instrument(skip(self, operation))]
     pub fn build(self, operation: Operation) -> QueryGraphBuilderResult<(QueryGraph, IrSerializer)> {
         match operation {
             Operation::Read(selection) => self.build_internal(selection, &self.query_schema.query()),
@@ -50,6 +59,7 @@ impl QueryGraphBuilder {
         }
     }
 
+    #[tracing::instrument(skip(self, selection, root_object))]
     fn build_internal(
         &self,
         selection: Selection,
@@ -74,6 +84,7 @@ impl QueryGraphBuilder {
         }
     }
 
+    #[tracing::instrument(skip(self, field_pair))]
     fn dispatch_build(&self, field_pair: FieldPair) -> QueryGraphBuilderResult<QueryGraph> {
         let query_info = field_pair.schema_field.query_info.as_ref().unwrap();
         let parsed_field = field_pair.parsed_field;

--- a/query-engine/core/src/query_graph_builder/extractors/filters/mod.rs
+++ b/query-engine/core/src/query_graph_builder/extractors/filters/mod.rs
@@ -13,6 +13,7 @@ use prisma_models::{Field, ModelRef, PrismaValue, RelationFieldRef, ScalarFieldR
 use std::{convert::TryInto, str::FromStr};
 
 /// Extracts a filter for a unique selector, i.e. a filter that selects exactly one record.
+#[tracing::instrument(skip(value_map, model))]
 pub fn extract_unique_filter(value_map: ParsedInputMap, model: &ModelRef) -> QueryGraphBuilderResult<Filter> {
     let filters = value_map
         .into_iter()
@@ -64,6 +65,7 @@ fn handle_compound_field(fields: Vec<ScalarFieldRef>, value: ParsedInputValue) -
 /// | OR   | return empty list | validate single filter | validate all filters |
 /// | AND  | return all items  | validate single filter | validate all filters |
 /// | NOT  | return all items  | validate single filter | validate all filters |
+#[tracing::instrument(skip(value_map, model))]
 pub fn extract_filter(value_map: ParsedInputMap, model: &ModelRef) -> QueryGraphBuilderResult<Filter> {
     // We define an internal function so we can track the recursion depth. Empty
     // filters at the root layer can not always be removed.

--- a/query-engine/core/src/query_graph_builder/extractors/filters/relation.rs
+++ b/query-engine/core/src/query_graph_builder/extractors/filters/relation.rs
@@ -6,6 +6,7 @@ use connector::{Filter, RelationCompare};
 use prisma_models::RelationFieldRef;
 use std::convert::TryInto;
 
+#[tracing::instrument(name = "parse_relation_field", skip(filter_key, field, input))]
 pub fn parse(filter_key: &str, field: &RelationFieldRef, input: ParsedInputValue) -> QueryGraphBuilderResult<Filter> {
     let value: Option<ParsedInputMap> = input.try_into()?;
 

--- a/query-engine/core/src/query_graph_builder/extractors/filters/scalar.rs
+++ b/query-engine/core/src/query_graph_builder/extractors/filters/scalar.rs
@@ -5,6 +5,7 @@ use connector::{Filter, ScalarCompare, ScalarListCompare};
 use prisma_models::{PrismaValue, ScalarFieldRef};
 use std::convert::TryInto;
 
+#[tracing::instrument(name = "parse_scalar_field", skip(filter_key, field, input, reverse))]
 pub fn parse(
     filter_key: &str,
     field: &ScalarFieldRef,

--- a/query-engine/core/src/query_graph_builder/extractors/query_arguments.rs
+++ b/query-engine/core/src/query_graph_builder/extractors/query_arguments.rs
@@ -16,6 +16,7 @@ use std::convert::{identity, TryInto};
 /// Expects the caller to know that it is structurally guaranteed that query arguments can be extracted,
 /// e.g. that the query schema guarantees that required fields are present.
 /// Errors occur if conversions fail.
+#[tracing::instrument(skip(arguments, model))]
 pub fn extract_query_args(arguments: Vec<ParsedArgument>, model: &ModelRef) -> QueryGraphBuilderResult<QueryArguments> {
     let query_args = arguments.into_iter().fold(
         Ok(QueryArguments::new(model.clone())),
@@ -90,6 +91,7 @@ fn extract_order_by(model: &ModelRef, value: ParsedInputValue) -> QueryGraphBuil
     }
 }
 
+#[tracing::instrument(skip(model, object, path))]
 fn process_order_object(
     model: &ModelRef,
     object: ParsedInputMap,

--- a/query-engine/core/src/query_graph_builder/read/aggregations/aggregate.rs
+++ b/query-engine/core/src/query_graph_builder/read/aggregations/aggregate.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::{query_document::ParsedField, AggregateRecordsQuery, ReadQuery};
 use prisma_models::ModelRef;
 
+#[tracing::instrument(skip(field, model))]
 pub fn aggregate(field: ParsedField, model: ModelRef) -> QueryGraphBuilderResult<ReadQuery> {
     let name = field.name;
     let alias = field.alias;

--- a/query-engine/core/src/query_graph_builder/read/aggregations/group_by.rs
+++ b/query-engine/core/src/query_graph_builder/read/aggregations/group_by.rs
@@ -8,6 +8,7 @@ use crate::{
 use connector::Filter;
 use prisma_models::{ModelRef, OrderBy, ScalarFieldRef};
 
+#[tracing::instrument(skip(field, model))]
 pub fn group_by(mut field: ParsedField, model: ModelRef) -> QueryGraphBuilderResult<ReadQuery> {
     let name = field.name;
     let alias = field.alias;

--- a/query-engine/core/src/query_graph_builder/read/aggregations/mod.rs
+++ b/query-engine/core/src/query_graph_builder/read/aggregations/mod.rs
@@ -13,6 +13,7 @@ use prisma_models::{ModelRef, ScalarFieldRef};
 
 /// Resolves the given field as a aggregation query.
 #[allow(clippy::unnecessary_wraps)]
+#[tracing::instrument(skip(field, model))]
 fn resolve_query(mut field: FieldPair, model: &ModelRef) -> QueryGraphBuilderResult<AggregationSelection> {
     let query = match field.parsed_field.name.as_str() {
         fields::COUNT => {

--- a/query-engine/core/src/query_graph_builder/read/first.rs
+++ b/query-engine/core/src/query_graph_builder/read/first.rs
@@ -3,6 +3,7 @@ use prisma_models::ModelRef;
 use super::*;
 use crate::ParsedField;
 
+#[tracing::instrument(skip(field, model))]
 pub fn find_first(field: ParsedField, model: ModelRef) -> QueryGraphBuilderResult<ReadQuery> {
     let mut many_query = many::find_many(field, model)?;
 

--- a/query-engine/core/src/query_graph_builder/read/many.rs
+++ b/query-engine/core/src/query_graph_builder/read/many.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::{query_document::ParsedField, ManyRecordsQuery, ReadQuery};
 use prisma_models::ModelRef;
 
+#[tracing::instrument(skip(field, model))]
 pub fn find_many(field: ParsedField, model: ModelRef) -> QueryGraphBuilderResult<ReadQuery> {
     let args = extractors::extract_query_args(field.arguments, &model)?;
     let name = field.name;

--- a/query-engine/core/src/query_graph_builder/read/one.rs
+++ b/query-engine/core/src/query_graph_builder/read/one.rs
@@ -4,6 +4,7 @@ use prisma_models::ModelRef;
 use std::convert::TryInto;
 
 /// Builds a read query from a parsed incoming read query field.
+#[tracing::instrument(skip(field, model))]
 pub fn find_unique(mut field: ParsedField, model: ModelRef) -> QueryGraphBuilderResult<ReadQuery> {
     let filter = match field.arguments.lookup(args::WHERE) {
         Some(where_arg) => {

--- a/query-engine/core/src/query_graph_builder/read/related.rs
+++ b/query-engine/core/src/query_graph_builder/read/related.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::{query_document::ParsedField, ReadQuery, RelatedRecordsQuery};
 use prisma_models::{ModelRef, RelationFieldRef};
 
+#[tracing::instrument(skip(field, parent, model))]
 pub fn find_related(
     field: ParsedField,
     parent: RelationFieldRef,

--- a/query-engine/core/src/query_graph_builder/write/connect.rs
+++ b/query-engine/core/src/query_graph_builder/write/connect.rs
@@ -34,6 +34,7 @@ use std::sync::Arc;
 /// └─▶│     Connect     │
 ///    └─────────────────┘
 /// ```
+#[tracing::instrument(skip(graph, parent_node, child_node, parent_relation_field, expected_connects))]
 pub fn connect_records_node(
     graph: &mut QueryGraph,
     parent_node: &NodeRef,

--- a/query-engine/core/src/query_graph_builder/write/create.rs
+++ b/query-engine/core/src/query_graph_builder/write/create.rs
@@ -11,6 +11,7 @@ use std::{convert::TryInto, sync::Arc};
 use write_args_parser::*;
 
 /// Creates a create record query and adds it to the query graph, together with it's nested queries and companion read query.
+#[tracing::instrument(skip(graph, model, field))]
 pub fn create_record(graph: &mut QueryGraph, model: ModelRef, mut field: ParsedField) -> QueryGraphBuilderResult<()> {
     graph.flag_transactional();
 
@@ -52,6 +53,7 @@ pub fn create_record(graph: &mut QueryGraph, model: ModelRef, mut field: ParsedF
 }
 
 /// Creates a create record query and adds it to the query graph, together with it's nested queries and companion read query.
+#[tracing::instrument(skip(graph, model, field))]
 pub fn create_many_records(
     graph: &mut QueryGraph,
     model: ModelRef,
@@ -90,6 +92,7 @@ pub fn create_many_records(
     Ok(())
 }
 
+#[tracing::instrument(skip(graph, model, data_map))]
 pub fn create_record_node(
     graph: &mut QueryGraph,
     model: ModelRef,

--- a/query-engine/core/src/query_graph_builder/write/delete.rs
+++ b/query-engine/core/src/query_graph_builder/write/delete.rs
@@ -10,6 +10,7 @@ use prisma_models::ModelRef;
 use std::{convert::TryInto, sync::Arc};
 
 /// Creates a top level delete record query and adds it to the query graph.
+#[tracing::instrument(skip(graph, model, field))]
 pub fn delete_record(graph: &mut QueryGraph, model: ModelRef, mut field: ParsedField) -> QueryGraphBuilderResult<()> {
     graph.flag_transactional();
 
@@ -51,6 +52,7 @@ pub fn delete_record(graph: &mut QueryGraph, model: ModelRef, mut field: ParsedF
 }
 
 /// Creates a top level delete many records query and adds it to the query graph.
+#[tracing::instrument(skip(graph, model, field))]
 pub fn delete_many_records(
     graph: &mut QueryGraph,
     model: ModelRef,

--- a/query-engine/core/src/query_graph_builder/write/disconnect.rs
+++ b/query-engine/core/src/query_graph_builder/write/disconnect.rs
@@ -33,6 +33,7 @@ use std::sync::Arc;
 /// └─▶│   Disconnect    │
 ///    └─────────────────┘
 /// ```
+#[tracing::instrument(skip(graph, parent_node, child_node, parent_relation_field, expected_disconnects))]
 pub fn disconnect_records_node(
     graph: &mut QueryGraph,
     parent_node: &NodeRef,

--- a/query-engine/core/src/query_graph_builder/write/nested/connect_nested.rs
+++ b/query-engine/core/src/query_graph_builder/write/nested/connect_nested.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 ///
 /// The resulting graph can take multiple forms, based on the relation type to the parent model.
 /// Information on the graph shapes can be found on the individual handlers.
+#[tracing::instrument(skip(graph, parent_node, parent_relation_field, value, child_model))]
 pub fn nested_connect(
     graph: &mut QueryGraph,
     parent_node: NodeRef,
@@ -73,6 +74,7 @@ pub fn nested_connect(
 /// └─▶│     Connect     │
 ///    └─────────────────┘
 /// ```
+#[tracing::instrument(skip(graph, parent_node, parent_relation_field, filter, child_model))]
 fn handle_many_to_many(
     graph: &mut QueryGraph,
     parent_node: NodeRef,
@@ -151,6 +153,7 @@ fn handle_many_to_many(
 ///
 /// We do not need to do relation requirement checks because the many side of the relation can't be required,
 /// and if the one side is required it's automatically satisfied because the record to connect has to exist.
+#[tracing::instrument(skip(graph, parent_node, parent_relation_field, child_filter, child_model))]
 fn handle_one_to_many(
     graph: &mut QueryGraph,
     parent_node: NodeRef,
@@ -335,6 +338,7 @@ fn handle_one_to_many(
 /// ... because we just updated the relation.
 ///
 /// This is why we need to have an extra update at the end if it's inlined on the parent and a non-create.
+#[tracing::instrument(skip(graph, parent_node, parent_relation_field, filter, child_model))]
 fn handle_one_to_one(
     graph: &mut QueryGraph,
     parent_node: NodeRef,

--- a/query-engine/core/src/query_graph_builder/write/nested/connect_or_create_nested.rs
+++ b/query-engine/core/src/query_graph_builder/write/nested/connect_or_create_nested.rs
@@ -13,6 +13,7 @@ use std::{convert::TryInto, sync::Arc};
 ///
 /// The resulting graph can take multiple forms, based on the relation type to the parent model.
 /// Information on the graph shapes can be found on the individual handlers.
+#[tracing::instrument(skip(graph, parent_node, parent_relation_field, value, child_model))]
 pub fn nested_connect_or_create(
     graph: &mut QueryGraph,
     parent_node: NodeRef,
@@ -66,6 +67,7 @@ pub fn nested_connect_or_create(
 ///                          │     Connect     │◀─┘
 ///                          └─────────────────┘
 /// ```
+#[tracing::instrument(skip(graph, parent_node, parent_relation_field, values, child_model))]
 fn handle_many_to_many(
     graph: &mut QueryGraph,
     parent_node: NodeRef,
@@ -122,6 +124,7 @@ fn handle_many_to_many(
 }
 
 /// Dispatcher for one-to-many relations.
+#[tracing::instrument(skip(graph, parent_node, parent_relation_field, values, child_model))]
 fn handle_one_to_many(
     graph: &mut QueryGraph,
     parent_node: NodeRef,
@@ -137,6 +140,7 @@ fn handle_one_to_many(
 }
 
 /// Dispatcher for one-to-one relations.
+#[tracing::instrument(skip(graph, parent_node, parent_relation_field, values, child_model))]
 fn handle_one_to_one(
     graph: &mut QueryGraph,
     parent_node: NodeRef,
@@ -205,6 +209,7 @@ fn handle_one_to_one(
 /// └─▶│  Update Child   │   │  Create Child   │◀─┘
 ///    └─────────────────┘   └─────────────────┘
 /// ```
+#[tracing::instrument(skip(graph, parent_node, parent_relation_field, values, child_model))]
 fn one_to_many_inlined_child(
     graph: &mut QueryGraph,
     parent_node: NodeRef,
@@ -345,6 +350,7 @@ fn one_to_many_inlined_child(
 ///    ┌ ─ ─ ─ ─ ─ ─ ─ ─ ┐
 ///          Result
 ///    └ ─ ─ ─ ─ ─ ─ ─ ─ ┘
+#[tracing::instrument(skip(graph, parent_node, parent_relation_field, values, child_model))]
 fn one_to_many_inlined_parent(
     graph: &mut QueryGraph,
     parent_node: NodeRef,
@@ -515,6 +521,7 @@ fn one_to_many_inlined_parent(
 ///
 /// Important note: We can't inject directly from the if node into the parent if the parent is a non-create, because we need to perform a check in between,
 /// and updating the record with the injection beforehand prevents that check. Instead, we need an additional update.
+#[tracing::instrument(skip(graph, parent_node, parent_relation_field, filter, create_data, child_model))]
 fn one_to_one_inlined_parent(
     graph: &mut QueryGraph,
     parent_node: NodeRef,
@@ -738,6 +745,7 @@ fn one_to_one_inlined_parent(
 ///
 /// Important note: We can't inject directly from the if node into the parent if the parent is a non-create, because we need to perform a check in between,
 /// and updating the record with the injection beforehand prevents that check. Instead, we need an additional update.
+#[tracing::instrument(skip(graph, parent_node, parent_relation_field, filter, create_data, child_model))]
 fn one_to_one_inlined_child(
     graph: &mut QueryGraph,
     parent_node: NodeRef,

--- a/query-engine/core/src/query_graph_builder/write/nested/create_nested.rs
+++ b/query-engine/core/src/query_graph_builder/write/nested/create_nested.rs
@@ -13,6 +13,7 @@ use std::{convert::TryInto, sync::Arc};
 /// Handles nested create one cases.
 /// The resulting graph can take multiple forms, based on the relation type to the parent model.
 /// Information on the graph shapes can be found on the individual handlers.
+#[tracing::instrument(skip(graph, parent_node, parent_relation_field, value, child_model))]
 pub fn nested_create(
     graph: &mut QueryGraph,
     parent_node: NodeRef,
@@ -59,6 +60,8 @@ pub fn nested_create(
 /// └─▶│  Connect   │   │  Connect   │◀─┘
 ///    └────────────┘   └────────────┘
 /// ```
+#[tracing::instrument]
+#[tracing::instrument(skip(graph, parent_node, parent_relation_field, create_nodes))]
 fn handle_many_to_many(
     graph: &mut QueryGraph,
     parent_node: NodeRef,
@@ -126,6 +129,7 @@ fn handle_many_to_many(
 /// │Create Child│  │Create Child│      Result   │
 /// └────────────┘  └────────────┘  └ ─ ─ ─ ─ ─ ─
 /// ```
+#[tracing::instrument(skip(graph, parent_node, parent_relation_field, create_nodes))]
 fn handle_one_to_many(
     graph: &mut QueryGraph,
     parent_node: NodeRef,
@@ -282,6 +286,7 @@ fn handle_one_to_many(
 /// ... because we just updated the relation.
 ///
 /// For these reasons, we need to have an extra update at the end if it's inlined on the parent and a non-create.
+#[tracing::instrument(skip(graph, parent_node, parent_relation_field, create_nodes))]
 fn handle_one_to_one(
     graph: &mut QueryGraph,
     parent_node: NodeRef,
@@ -414,6 +419,7 @@ fn handle_one_to_one(
     Ok(())
 }
 
+#[tracing::instrument(skip(graph, parent_node, parent_relation_field, value, child_model))]
 pub fn nested_create_many(
     graph: &mut QueryGraph,
     parent_node: NodeRef,

--- a/query-engine/core/src/query_graph_builder/write/nested/delete_nested.rs
+++ b/query-engine/core/src/query_graph_builder/write/nested/delete_nested.rs
@@ -20,6 +20,7 @@ use std::{convert::TryInto, sync::Arc};
 /// - If the relation is inlined but not in the parent, we can directly generate a delete on the record with the parent ID.
 ///
 /// We always need to make sure that the records are connected before deletion.
+#[tracing::instrument(skip(graph, parent_node, parent_relation_field, value, child_model))]
 pub fn nested_delete(
     graph: &mut QueryGraph,
     parent_node: &NodeRef,
@@ -123,6 +124,7 @@ pub fn nested_delete(
     Ok(())
 }
 
+#[tracing::instrument(skip(graph, parent, parent_relation_field, value, child_model))]
 pub fn nested_delete_many(
     graph: &mut QueryGraph,
     parent: &NodeRef,

--- a/query-engine/core/src/query_graph_builder/write/nested/disconnect_nested.rs
+++ b/query-engine/core/src/query_graph_builder/write/nested/disconnect_nested.rs
@@ -12,6 +12,7 @@ use std::convert::TryInto;
 ///
 /// The resulting graph can take multiple forms, based on the relation type to the parent model.
 /// Information on the graph shapes can be found on the individual handlers.
+#[tracing::instrument(skip(graph, parent_node, parent_relation_field, value, child_model))]
 pub fn nested_disconnect(
     graph: &mut QueryGraph,
     parent_node: NodeRef,
@@ -98,6 +99,7 @@ pub fn nested_disconnect(
 /// └─▶│   Disconnect    │
 ///    └─────────────────┘
 /// ```
+#[tracing::instrument(skip(graph, parent_node, parent_relation_field, filter))]
 fn handle_many_to_many(
     graph: &mut QueryGraph,
     parent_node: &NodeRef,
@@ -154,6 +156,7 @@ fn handle_many_to_many(
 /// regardless of which ID is used in the end to perform the update.
 ///
 /// Todo pretty sure it's better do redo this code with separate handlers.
+#[tracing::instrument(skip(graph, parent_node, parent_relation_field, filter))]
 fn handle_one_to_x(
     graph: &mut QueryGraph,
     parent_node: &NodeRef,

--- a/query-engine/core/src/query_graph_builder/write/nested/mod.rs
+++ b/query-engine/core/src/query_graph_builder/write/nested/mod.rs
@@ -23,6 +23,7 @@ use set_nested::*;
 use update_nested::*;
 use upsert_nested::*;
 
+#[tracing::instrument(skip(graph, parent, parent_relation_field, data_map))]
 pub fn connect_nested_query(
     graph: &mut QueryGraph,
     parent: NodeRef,

--- a/query-engine/core/src/query_graph_builder/write/nested/set_nested.rs
+++ b/query-engine/core/src/query_graph_builder/write/nested/set_nested.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 /// Handles nested set cases.
 /// The resulting graph can take multiple forms, based on the relation type to the parent model.
 /// Information on the graph shapes can be found on the individual handlers.
+#[tracing::instrument(skip(graph, parent_node, parent_relation_field, value, child_model))]
 pub fn nested_set(
     graph: &mut QueryGraph,
     parent_node: &NodeRef,
@@ -82,6 +83,7 @@ pub fn nested_set(
 ///
 /// Connects only happen if the query specifies at least one record to be connected.
 /// If none are specified, set effectively acts as a "disconnect all".
+#[tracing::instrument(skip(graph, parent_node, parent_relation_field, filter))]
 fn handle_many_to_many(
     graph: &mut QueryGraph,
     parent_node: &NodeRef,
@@ -206,6 +208,7 @@ fn handle_many_to_many(
 /// └─┴─▶│   ("connect")   │     │ ("disconnect")  │◀─┘
 ///      └─────────────────┘     └─────────────────┘
 /// ```
+#[tracing::instrument(skip(graph, parent_node, parent_relation_field, filter))]
 fn handle_one_to_many(
     graph: &mut QueryGraph,
     parent_node: &NodeRef,

--- a/query-engine/core/src/query_graph_builder/write/nested/update_nested.rs
+++ b/query-engine/core/src/query_graph_builder/write/nested/update_nested.rs
@@ -27,6 +27,7 @@ use write_args_parser::*;
 /// └─▶│   Update   │
 ///    └────────────┘
 /// ```
+#[tracing::instrument(skip(graph, parent, parent_relation_field, value, child_model))]
 pub fn nested_update(
     graph: &mut QueryGraph,
     parent: &NodeRef,
@@ -84,6 +85,7 @@ pub fn nested_update(
     Ok(())
 }
 
+#[tracing::instrument(skip(graph, parent, parent_relation_field, value, child_model))]
 pub fn nested_update_many(
     graph: &mut QueryGraph,
     parent: &NodeRef,

--- a/query-engine/core/src/query_graph_builder/write/nested/upsert_nested.rs
+++ b/query-engine/core/src/query_graph_builder/write/nested/upsert_nested.rs
@@ -84,6 +84,7 @@ use std::{convert::TryInto, sync::Arc};
 ///                          └─────────────────┘
 /// ```
 /// Todo split this mess up and clean up the code.
+#[tracing::instrument(skip(graph, parent_node, parent_relation_field, value))]
 pub fn nested_upsert(
     graph: &mut QueryGraph,
     parent_node: NodeRef,

--- a/query-engine/core/src/query_graph_builder/write/raw.rs
+++ b/query-engine/core/src/query_graph_builder/write/raw.rs
@@ -3,6 +3,7 @@ use crate::{constants::inputs::args, query_ast::*, query_graph::QueryGraph, Argu
 use prisma_value::PrismaValue;
 use std::convert::TryInto;
 
+#[tracing::instrument(skip(graph, field))]
 pub fn execute_raw(graph: &mut QueryGraph, field: ParsedField) -> QueryGraphBuilderResult<()> {
     let raw_query = Query::Write(WriteQuery::ExecuteRaw(raw_query(field)?));
 
@@ -10,6 +11,7 @@ pub fn execute_raw(graph: &mut QueryGraph, field: ParsedField) -> QueryGraphBuil
     Ok(())
 }
 
+#[tracing::instrument(skip(graph, field))]
 pub fn query_raw(graph: &mut QueryGraph, field: ParsedField) -> QueryGraphBuilderResult<()> {
     let raw_query = Query::Write(WriteQuery::QueryRaw(raw_query(field)?));
 

--- a/query-engine/core/src/query_graph_builder/write/update.rs
+++ b/query-engine/core/src/query_graph_builder/write/update.rs
@@ -10,6 +10,7 @@ use prisma_models::ModelRef;
 use std::{convert::TryInto, sync::Arc};
 
 /// Creates an update record query and adds it to the query graph, together with it's nested queries and companion read query.
+#[tracing::instrument(skip(graph, model, field))]
 pub fn update_record(graph: &mut QueryGraph, model: ModelRef, mut field: ParsedField) -> QueryGraphBuilderResult<()> {
     // "where"
     let where_arg: ParsedInputMap = field.arguments.lookup(args::WHERE).unwrap().value.try_into()?;
@@ -51,6 +52,7 @@ pub fn update_record(graph: &mut QueryGraph, model: ModelRef, mut field: ParsedF
 }
 
 /// Creates an update many record query and adds it to the query graph.
+#[tracing::instrument(skip(graph, model, field))]
 pub fn update_many_records(
     graph: &mut QueryGraph,
     model: ModelRef,
@@ -82,6 +84,7 @@ pub fn update_many_records(
 }
 
 /// Creates an update record query node and adds it to the query graph.
+#[tracing::instrument(skip(graph, filter, model, data_map))]
 pub fn update_record_node<T>(
     graph: &mut QueryGraph,
     filter: T,

--- a/query-engine/core/src/query_graph_builder/write/upsert.rs
+++ b/query-engine/core/src/query_graph_builder/write/upsert.rs
@@ -9,6 +9,7 @@ use connector::IdFilter;
 use prisma_models::ModelRef;
 use std::{convert::TryInto, sync::Arc};
 
+#[tracing::instrument(skip(graph, model, field))]
 pub fn upsert_record(graph: &mut QueryGraph, model: ModelRef, mut field: ParsedField) -> QueryGraphBuilderResult<()> {
     graph.flag_transactional();
 

--- a/query-engine/core/src/query_graph_builder/write/utils.rs
+++ b/query-engine/core/src/query_graph_builder/write/utils.rs
@@ -84,6 +84,7 @@ fn get_selected_fields(model: &ModelRef, projection: ModelProjection) -> ModelPr
 /// - `parent_node` needs to return a blog ID during execution.
 /// - `parent_relation_field` is the field on the `Blog` model, e.g. `posts`.
 /// - `filter` narrows down posts, e.g. posts where their titles start with a given string.
+#[tracing::instrument(skip(graph, parent_node, parent_relation_field, filter))]
 pub fn insert_find_children_by_parent_node<T>(
     graph: &mut QueryGraph,
     parent_node: &NodeRef,
@@ -188,6 +189,7 @@ where
 /// the relation is also inlined on that models side, so we put that check into the if flow.
 ///
 /// Returns a `NodeRef` to the "Read Related" node in the graph illustrated above.
+#[tracing::instrument(skip(graph, parent_node, parent_relation_field))]
 pub fn insert_existing_1to1_related_model_checks(
     graph: &mut QueryGraph,
     parent_node: &NodeRef,
@@ -302,6 +304,7 @@ pub fn insert_existing_1to1_related_model_checks(
 /// └─▶│       Delete       │
 ///    └────────────────────┘
 /// ```
+#[tracing::instrument(skip(graph, model, parent_node, child_node))]
 pub fn insert_deletion_checks(
     graph: &mut QueryGraph,
     model: &ModelRef,

--- a/query-engine/core/src/query_graph_builder/write/write_args_parser.rs
+++ b/query-engine/core/src/query_graph_builder/write/write_args_parser.rs
@@ -16,6 +16,7 @@ pub struct WriteArgsParser {
 impl WriteArgsParser {
     /// Creates a new set of WriteArgsParser. Expects the parsed input map from the respective data key, not the enclosing map.
     /// E.g.: { data: { THIS MAP } } from the `data` argument of a write query.
+    #[tracing::instrument(name = "write_args_parser_from", skip(model, data_map))]
     pub fn from(model: &ModelRef, data_map: ParsedInputMap) -> QueryGraphBuilderResult<Self> {
         data_map.into_iter().try_fold(
             WriteArgsParser::default(),

--- a/query-engine/core/src/response_ir/internal.rs
+++ b/query-engine/core/src/response_ir/internal.rs
@@ -34,6 +34,7 @@ type UncheckedItemsWithParents = IndexMap<Option<RecordProjection>, Vec<Item>>;
 /// // todo more here
 ///
 /// Returns a map of pairs of (parent ID, response)
+#[tracing::instrument(skip(result, field, is_list))]
 pub fn serialize_internal(
     result: QueryResult,
     field: &OutputFieldRef,
@@ -74,6 +75,7 @@ pub fn serialize_internal(
     }
 }
 
+#[tracing::instrument(skip(output_field, record_aggregations))]
 fn serialize_aggregations(
     output_field: &OutputFieldRef,
     record_aggregations: RecordAggregations,
@@ -232,6 +234,7 @@ fn coerce_non_numeric(value: PrismaValue, output: &OutputType) -> PrismaValue {
     }
 }
 
+#[tracing::instrument(skip(record_selection, field, typ, is_list))]
 fn serialize_record_selection(
     record_selection: RecordSelection,
     field: &OutputFieldRef,
@@ -303,6 +306,7 @@ fn serialize_record_selection(
 /// Serializes the given result into objects of given type.
 /// Doesn't validate the shape of the result set ("unchecked" result).
 /// Returns a vector of serialized objects (as Item::Map), grouped into a map by parent, if present.
+#[tracing::instrument(skip(result, typ))]
 fn serialize_objects(
     mut result: RecordSelection,
     typ: ObjectTypeStrongRef,
@@ -375,6 +379,7 @@ fn serialize_objects(
 }
 
 /// Unwraps are safe due to query validation.
+#[tracing::instrument(skip(record_id, items_with_parent, into, enclosing_type))]
 fn write_nested_items(
     record_id: &Option<RecordProjection>,
     items_with_parent: &mut HashMap<String, CheckedItemsWithParents>,
@@ -409,6 +414,7 @@ fn write_nested_items(
 }
 
 /// Processes nested results into a more ergonomic structure of { <nested field name> -> { parent ID -> item (list, map, ...) } }.
+#[tracing::instrument(skip(nested, enclosing_type))]
 fn process_nested_results(
     nested: Vec<QueryResult>,
     enclosing_type: &ObjectTypeStrongRef,

--- a/query-engine/core/src/response_ir/ir_serializer.rs
+++ b/query-engine/core/src/response_ir/ir_serializer.rs
@@ -15,6 +15,7 @@ pub struct IrSerializer {
 }
 
 impl IrSerializer {
+    #[tracing::instrument(skip(self, result))]
     pub fn serialize(&self, result: ExpressionResult) -> crate::Result<ResponseData> {
         match result {
             ExpressionResult::Query(QueryResult::Json(json)) => {

--- a/query-engine/core/src/schema_builder/input_types/field_filter_types.rs
+++ b/query-engine/core/src/schema_builder/input_types/field_filter_types.rs
@@ -4,6 +4,7 @@ use datamodel_connector::ConnectorCapability;
 use prisma_models::{dml::DefaultValue, PrismaValue};
 
 /// Builds filter types for the given model field.
+#[tracing::instrument(skip(ctx, field, include_aggregates))]
 pub(crate) fn get_field_filter_types(
     ctx: &mut BuilderContext,
     field: &ModelField,
@@ -41,6 +42,7 @@ pub(crate) fn get_field_filter_types(
 
 /// Builds shorthand relation equality (`is`) filter for to-one: `where: { relation_field: { ... } }` (no `is` in between).
 /// If the field is also not required, null is also added as possible type.
+#[tracing::instrument(skip(ctx, rf))]
 fn mto1_relation_filter_shorthand_types(ctx: &mut BuilderContext, rf: &RelationFieldRef) -> Vec<InputType> {
     let mut types = vec![];
 
@@ -57,6 +59,7 @@ fn mto1_relation_filter_shorthand_types(ctx: &mut BuilderContext, rf: &RelationF
     types
 }
 
+#[tracing::instrument(skip(ctx, rf))]
 fn full_relation_filter(ctx: &mut BuilderContext, rf: &RelationFieldRef) -> InputObjectTypeWeakRef {
     let related_model = rf.related_model();
     let related_input_type = filter_objects::where_object_type(ctx, &related_model);
@@ -91,6 +94,7 @@ fn full_relation_filter(ctx: &mut BuilderContext, rf: &RelationFieldRef) -> Inpu
     Arc::downgrade(&object)
 }
 
+#[tracing::instrument(skip(ctx, sf))]
 fn scalar_list_filter_type(ctx: &mut BuilderContext, sf: &ScalarFieldRef) -> InputObjectTypeWeakRef {
     let ident = Identifier::new(
         scalar_filter_name(&sf.type_identifier, true, !sf.is_required, false, false),
@@ -122,6 +126,7 @@ fn scalar_list_filter_type(ctx: &mut BuilderContext, sf: &ScalarFieldRef) -> Inp
     Arc::downgrade(&object)
 }
 
+#[tracing::instrument(skip(ctx, typ, list, nullable, nested, include_aggregates))]
 fn full_scalar_filter_type(
     ctx: &mut BuilderContext,
     typ: &TypeIdentifier,

--- a/query-engine/core/src/schema_builder/input_types/objects/connect_or_create_objects.rs
+++ b/query-engine/core/src/schema_builder/input_types/objects/connect_or_create_objects.rs
@@ -2,6 +2,7 @@ use super::*;
 use constants::inputs::args;
 
 /// Builds "<x>CreateOrConnectNestedInput" input object types.
+#[tracing::instrument(skip(ctx, parent_field))]
 pub(crate) fn nested_connect_or_create_input_object(
     ctx: &mut BuilderContext,
     parent_field: &RelationFieldRef,

--- a/query-engine/core/src/schema_builder/input_types/objects/create_many_objects.rs
+++ b/query-engine/core/src/schema_builder/input_types/objects/create_many_objects.rs
@@ -6,6 +6,7 @@ use prisma_models::dml::DefaultValue;
 /// Input type allows to write all scalar fields except if in a nested case,
 /// where we don't allow the parent scalar to be written (ie. when the relation
 /// is inlined on the child).
+#[tracing::instrument(skip(ctx, model, parent_field))]
 pub(crate) fn create_many_object_type(
     ctx: &mut BuilderContext,
     model: &ModelRef,

--- a/query-engine/core/src/schema_builder/input_types/objects/create_one_objects.rs
+++ b/query-engine/core/src/schema_builder/input_types/objects/create_one_objects.rs
@@ -1,6 +1,7 @@
 use super::*;
 use prisma_models::dml::DefaultValue;
 
+#[tracing::instrument(skip(ctx, model, parent_field))]
 pub(crate) fn create_one_input_types(
     ctx: &mut BuilderContext,
     model: &ModelRef,
@@ -21,6 +22,7 @@ pub(crate) fn create_one_input_types(
 /// Also valid for nested inputs. A nested input is constructed if the `parent_field` is provided.
 /// "Checked" input refers to disallowing writing relation scalars directly, as it can lead to unintended
 /// data integrity violations if used incorrectly.
+#[tracing::instrument(skip(ctx, model, parent_field))]
 fn checked_create_input_type(
     ctx: &mut BuilderContext,
     model: &ModelRef,
@@ -73,6 +75,7 @@ fn checked_create_input_type(
 }
 
 /// For checked create input types only. Compute input fields for relational fields.
+#[tracing::instrument(skip(ctx, model, parent_field))]
 fn relation_input_fields_for_checked_create(
     ctx: &mut BuilderContext,
     model: &ModelRef,
@@ -142,6 +145,7 @@ fn field_should_be_kept_for_checked_create_input_type(field: &ScalarFieldRef) ->
 /// Also valid for nested inputs. A nested input is constructed if the `parent_field` is provided.
 /// "Unchecked" input refers to allowing to write _all_ scalars on a model directly, which can
 /// lead to unintended data integrity violations if used incorrectly.
+#[tracing::instrument(skip(ctx, model, parent_field))]
 fn unchecked_create_input_type(
     ctx: &mut BuilderContext,
     model: &ModelRef,
@@ -208,6 +212,7 @@ fn unchecked_create_input_type(
 }
 
 /// For unchecked create input types only. Compute input fields for relational fields.
+#[tracing::instrument(skip(ctx, model, parent_field))]
 fn relation_input_fields_for_unchecked_create(
     ctx: &mut BuilderContext,
     model: &ModelRef,

--- a/query-engine/core/src/schema_builder/input_types/objects/filter_objects.rs
+++ b/query-engine/core/src/schema_builder/input_types/objects/filter_objects.rs
@@ -2,6 +2,7 @@ use super::*;
 use constants::inputs::filters;
 use std::sync::Arc;
 
+#[tracing::instrument(skip(ctx, model, include_aggregates))]
 pub(crate) fn scalar_filter_object_type(
     ctx: &mut BuilderContext,
     model: &ModelRef,
@@ -42,6 +43,7 @@ pub(crate) fn scalar_filter_object_type(
     weak_ref
 }
 
+#[tracing::instrument(skip(ctx, model))]
 pub(crate) fn where_object_type(ctx: &mut BuilderContext, model: &ModelRef) -> InputObjectTypeWeakRef {
     let ident = Identifier::new(format!("{}WhereInput", model.name), PRISMA_NAMESPACE);
     return_cached_input!(ctx, &ident);
@@ -80,6 +82,7 @@ pub(crate) fn where_object_type(ctx: &mut BuilderContext, model: &ModelRef) -> I
     weak_ref
 }
 
+#[tracing::instrument(skip(ctx, model))]
 pub(crate) fn where_unique_object_type(ctx: &mut BuilderContext, model: &ModelRef) -> InputObjectTypeWeakRef {
     let ident = Identifier::new(format!("{}WhereUniqueInput", model.name), PRISMA_NAMESPACE);
     return_cached_input!(ctx, &ident);

--- a/query-engine/core/src/schema_builder/input_types/objects/order_by_objects.rs
+++ b/query-engine/core/src/schema_builder/input_types/objects/order_by_objects.rs
@@ -2,6 +2,7 @@ use super::*;
 use constants::inputs::filters;
 
 /// Builds "<Model>OrderByInput" object types.
+#[tracing::instrument(skip(ctx, model, include_relations))]
 pub(crate) fn order_by_object_type(
     ctx: &mut BuilderContext,
     model: &ModelRef,

--- a/query-engine/core/src/schema_builder/input_types/objects/update_many_objects.rs
+++ b/query-engine/core/src/schema_builder/input_types/objects/update_many_objects.rs
@@ -1,6 +1,7 @@
 use super::*;
 use constants::inputs::args;
 
+#[tracing::instrument(skip(ctx, model, parent_field))]
 pub(crate) fn update_many_input_types(
     ctx: &mut BuilderContext,
     model: &ModelRef,
@@ -30,6 +31,7 @@ pub(crate) fn checked_update_many_input_type(ctx: &mut BuilderContext, model: &M
 }
 
 /// Builds "<x>UncheckedUpdateManyWithout<y>MutationInput" input object type.
+#[tracing::instrument(skip(ctx, model, parent_field))]
 pub(crate) fn unchecked_update_many_input_type(
     ctx: &mut BuilderContext,
     model: &ModelRef,
@@ -56,6 +58,7 @@ pub(crate) fn unchecked_update_many_input_type(
 
 /// Builds "<x>UpdateManyWithWhereWithout<y>Input" input object type.
 /// Simple combination object of "where" and "data".
+#[tracing::instrument(skip(ctx, parent_field))]
 pub(crate) fn update_many_where_combination_object(
     ctx: &mut BuilderContext,
     parent_field: &RelationFieldRef,

--- a/query-engine/core/src/schema_builder/input_types/objects/update_one_objects.rs
+++ b/query-engine/core/src/schema_builder/input_types/objects/update_one_objects.rs
@@ -3,6 +3,7 @@ use constants::inputs::{args, operations};
 use datamodel_connector::ConnectorCapability;
 use prisma_models::{dml::DefaultValue, ModelProjection};
 
+#[tracing::instrument(skip(ctx, model, parent_field))]
 pub(crate) fn update_one_input_types(
     ctx: &mut BuilderContext,
     model: &ModelRef,
@@ -20,6 +21,7 @@ pub(crate) fn update_one_input_types(
 }
 
 /// Builds "<x>UpdateInput" input object type.
+#[tracing::instrument(skip(ctx, model, parent_field))]
 fn checked_update_one_input_type(
     ctx: &mut BuilderContext,
     model: &ModelRef,
@@ -48,6 +50,7 @@ fn checked_update_one_input_type(
 }
 
 /// Builds "<x>UncheckedUpdateInput" input object type.
+#[tracing::instrument(skip(ctx, model, parent_field))]
 fn unchecked_update_one_input_type(
     ctx: &mut BuilderContext,
     model: &ModelRef,
@@ -79,6 +82,7 @@ fn unchecked_update_one_input_type(
     Arc::downgrade(&input_object)
 }
 
+#[tracing::instrument(skip(ctx, model))]
 pub(super) fn scalar_input_fields_for_checked_update(ctx: &mut BuilderContext, model: &ModelRef) -> Vec<InputField> {
     input_fields::scalar_input_fields(
         ctx,
@@ -94,6 +98,7 @@ pub(super) fn scalar_input_fields_for_checked_update(ctx: &mut BuilderContext, m
     )
 }
 
+#[tracing::instrument(skip(ctx, model, parent_field))]
 pub(super) fn scalar_input_fields_for_unchecked_update(
     ctx: &mut BuilderContext,
     model: &ModelRef,
@@ -127,6 +132,7 @@ pub(super) fn scalar_input_fields_for_unchecked_update(
     )
 }
 
+#[tracing::instrument(skip(ctx, field, default))]
 fn non_list_scalar_update_field_mapper(
     ctx: &mut BuilderContext,
     field: &ScalarFieldRef,
@@ -158,6 +164,7 @@ fn non_list_scalar_update_field_mapper(
     input_field.optional().nullable_if(!field.is_required)
 }
 
+#[tracing::instrument(skip(ctx, prefix, field, with_number_operators))]
 fn operations_object_type(
     ctx: &mut BuilderContext,
     prefix: &str,
@@ -197,6 +204,7 @@ fn operations_object_type(
 }
 
 /// For update input types only. Compute input fields for checked relational fields.
+#[tracing::instrument(skip(ctx, model, parent_field))]
 fn relation_input_fields_for_checked_update_one(
     ctx: &mut BuilderContext,
     model: &ModelRef,
@@ -253,6 +261,7 @@ fn relation_input_fields_for_checked_update_one(
 }
 
 /// For unchecked update input types only. Compute input fields for checked relational fields.
+#[tracing::instrument(skip(ctx, model, parent_field))]
 fn relation_input_fields_for_unchecked_update_one(
     ctx: &mut BuilderContext,
     model: &ModelRef,
@@ -315,6 +324,7 @@ fn relation_input_fields_for_unchecked_update_one(
 
 /// Builds "<x>UpdateWithWhereUniqueNestedInput" / "<x>UpdateWithWhereUniqueWithout<y>Input" input object types.
 /// Simple combination object of "where" and "data".
+#[tracing::instrument(skip(ctx, update_types, parent_field))]
 pub(crate) fn update_one_where_combination_object(
     ctx: &mut BuilderContext,
     update_types: Vec<InputType>,

--- a/query-engine/core/src/schema_builder/input_types/objects/upsert_objects.rs
+++ b/query-engine/core/src/schema_builder/input_types/objects/upsert_objects.rs
@@ -2,6 +2,7 @@ use crate::constants::inputs::args;
 
 use super::*;
 
+#[tracing::instrument(skip(ctx, parent_field))]
 pub(crate) fn nested_upsert_input_object(
     ctx: &mut BuilderContext,
     parent_field: &RelationFieldRef,
@@ -14,6 +15,7 @@ pub(crate) fn nested_upsert_input_object(
 }
 
 /// Builds "<x>UpsertWithWhereUniqueNestedInput" / "<x>UpsertWithWhereUniqueWithout<y>Input" input object types.
+#[tracing::instrument(skip(ctx, parent_field))]
 fn nested_upsert_list_input_object(
     ctx: &mut BuilderContext,
     parent_field: &RelationFieldRef,
@@ -55,6 +57,7 @@ fn nested_upsert_list_input_object(
 }
 
 /// Builds "<x>UpsertNestedInput" / "<x>UpsertWithout<y>Input" input object types.
+#[tracing::instrument(skip(ctx, parent_field))]
 fn nested_upsert_nonlist_input_object(
     ctx: &mut BuilderContext,
     parent_field: &RelationFieldRef,

--- a/query-engine/core/src/schema_builder/mod.rs
+++ b/query-engine/core/src/schema_builder/mod.rs
@@ -140,6 +140,10 @@ impl TypeCache {
     }
 }
 
+#[tracing::instrument(
+    name = "build_query_schema",
+    skip(internal_data_model, enable_raw_queries, capabilities)
+)]
 pub fn build(
     internal_data_model: InternalDataModelRef,
     mode: BuildMode,

--- a/query-engine/core/src/schema_builder/output_types/aggregation/group_by.rs
+++ b/query-engine/core/src/schema_builder/output_types/aggregation/group_by.rs
@@ -4,6 +4,7 @@ use super::*;
 use std::convert::identity;
 
 /// Builds group by aggregation object type for given model (e.g. GroupByUserOutputType).
+#[tracing::instrument(skip(ctx, model))]
 pub(crate) fn group_by_output_object_type(ctx: &mut BuilderContext, model: &ModelRef) -> ObjectTypeWeakRef {
     let ident = Identifier::new(
         format!("{}GroupByOutputType", capitalize(&model.name)),

--- a/query-engine/core/src/schema_builder/output_types/aggregation/plain.rs
+++ b/query-engine/core/src/schema_builder/output_types/aggregation/plain.rs
@@ -4,6 +4,7 @@ use super::*;
 use std::convert::identity;
 
 /// Builds plain aggregation object type for given model (e.g. AggregateUser).
+#[tracing::instrument(skip(ctx, model))]
 pub(crate) fn aggregation_object_type(ctx: &mut BuilderContext, model: &ModelRef) -> ObjectTypeWeakRef {
     let ident = Identifier::new(format!("Aggregate{}", capitalize(&model.name)), PRISMA_NAMESPACE);
     return_cached_output!(ctx, &ident);

--- a/query-engine/core/src/schema_builder/output_types/mutation_type.rs
+++ b/query-engine/core/src/schema_builder/output_types/mutation_type.rs
@@ -6,6 +6,7 @@ use input_types::input_fields;
 use prisma_models::{dml, PrismaValue};
 
 /// Builds the root `Mutation` type.
+#[tracing::instrument(skip(ctx))]
 pub(crate) fn build(ctx: &mut BuilderContext) -> (OutputType, ObjectTypeStrongRef) {
     let non_embedded_models = ctx.internal_data_model.non_embedded_models();
     let mut fields: Vec<OutputField> = non_embedded_models
@@ -47,6 +48,7 @@ pub(crate) fn build(ctx: &mut BuilderContext) -> (OutputType, ObjectTypeStrongRe
 }
 
 // implementation note: these need to be in the same function, because these vecs interact: the create inputs will enqueue update inputs, and vice versa.
+#[tracing::instrument(skip(ctx))]
 fn create_nested_inputs(ctx: &mut BuilderContext) {
     let mut nested_create_inputs_queue = std::mem::replace(&mut ctx.nested_create_inputs_queue, Vec::new());
     let mut nested_update_inputs_queue = std::mem::replace(&mut ctx.nested_update_inputs_queue, Vec::new());

--- a/query-engine/core/src/schema_builder/output_types/output_objects.rs
+++ b/query-engine/core/src/schema_builder/output_types/output_objects.rs
@@ -8,6 +8,7 @@ use prisma_models::ScalarFieldRef;
 /// This is a critical first step to ensure that all model output object types are present
 /// and that subsequent schema computation has a base to rely on.
 /// Called only once at the very beginning of schema building.
+#[tracing::instrument(skip(ctx))]
 pub(crate) fn initialize_model_object_type_cache(ctx: &mut BuilderContext) {
     // Compute initial cache. No fields are computed because we first
     // need all models to be present, then we can compute fields in a second pass.

--- a/query-engine/core/src/schema_builder/output_types/query_type.rs
+++ b/query-engine/core/src/schema_builder/output_types/query_type.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 /// Builds the root `Query` type.
+#[tracing::instrument(name = "build_query_type", skip(ctx))]
 pub(crate) fn build(ctx: &mut BuilderContext) -> (OutputType, ObjectTypeStrongRef) {
     let non_embedded_models = ctx.internal_data_model.non_embedded_models();
     let fields = non_embedded_models

--- a/query-engine/query-engine-napi/Cargo.toml
+++ b/query-engine/query-engine-napi/Cargo.toml
@@ -29,6 +29,9 @@ serde = "1"
 tracing = "0.1"
 tracing-subscriber = "0.2"
 tracing-futures = "0.2"
+tracing-opentelemetry = "0.11"
+opentelemetry = "0.12"
+opentelemetry-otlp = { version = "0.5", features = ["tls", "tls-roots"] }
 tokio = { version = "1", features = ["sync"] }
 
 [build-dependencies]

--- a/query-engine/query-engine-napi/src/logger.rs
+++ b/query-engine/query-engine-napi/src/logger.rs
@@ -1,33 +1,84 @@
 mod channel;
 mod registry;
+mod telemetry;
 mod visitor;
 
 use channel::EventChannel;
 use napi::threadsafe_function::ThreadsafeFunction;
+use opentelemetry::{
+    global,
+    sdk::{propagation::TraceContextPropagator, trace::Config, Resource},
+    KeyValue,
+};
+use opentelemetry_otlp::Uninstall;
 use registry::EventRegistry;
-use std::future::Future;
+use std::{future::Future, sync::Arc};
+use telemetry::WithTelemetry;
 use tracing::level_filters::LevelFilter;
 use tracing_futures::WithSubscriber;
 use tracing_subscriber::layer::{Layered, SubscriberExt};
+
+#[derive(Clone)]
+enum Subscriber {
+    Normal(Layered<EventChannel, EventRegistry>),
+    WithTelemetry(WithTelemetry),
+}
 
 /// A logger logging to a bounded channel. When in scope, all log messages from
 /// the scope are stored to the channel, which must be consumed or after some
 /// point, further log lines will just be dropped.
 #[derive(Clone)]
 pub struct ChannelLogger {
-    subscriber: Layered<EventChannel, EventRegistry>,
+    subscriber: Subscriber,
     level: LevelFilter,
+    guard: Option<Arc<Uninstall>>,
 }
 
 impl ChannelLogger {
     /// Creates a new instance of a logger with the minimum log level.
     pub fn new(level: LevelFilter, callback: ThreadsafeFunction<String>) -> Self {
-        let mut layer = EventChannel::new(callback);
-        layer.filter_level(level);
+        let mut javascript_cb = EventChannel::new(callback);
+        javascript_cb.filter_level(level);
+
+        let subscriber = Subscriber::Normal(EventRegistry::new().with(javascript_cb));
 
         Self {
-            subscriber: EventRegistry::new().with(layer),
+            subscriber,
             level,
+            guard: None,
+        }
+    }
+
+    /// Creates a new instance of a logger with the `trace` minimum level.
+    /// Enables tracing events to OTLP endpoint.
+    pub fn new_with_telemetry(callback: ThreadsafeFunction<String>, endpoint: Option<String>) -> Self {
+        let mut javascript_cb = EventChannel::new(callback);
+        javascript_cb.filter_level(LevelFilter::TRACE);
+
+        global::set_text_map_propagator(TraceContextPropagator::new());
+
+        // A special parameter for Jaeger to set the service name in spans.
+        let resource = Resource::new(vec![KeyValue::new("service.name", "query-engine-napi")]);
+        let config = Config::default().with_resource(resource);
+
+        let mut builder = opentelemetry_otlp::new_pipeline().with_trace_config(config);
+
+        if let Some(endpoint) = endpoint {
+            builder = builder.with_endpoint(endpoint);
+        }
+
+        let (tracer, guard) = builder.install().unwrap();
+
+        let telemetry_layer = tracing_opentelemetry::layer().with_tracer(tracer);
+        let registry = EventRegistry::new().with(telemetry_layer).with(javascript_cb);
+        let with_telemetry = WithTelemetry::new(registry);
+
+        let subscriber = Subscriber::WithTelemetry(with_telemetry);
+
+        Self {
+            subscriber,
+            level: LevelFilter::TRACE,
+            guard: Some(Arc::new(guard)),
         }
     }
 
@@ -38,6 +89,9 @@ impl ChannelLogger {
         U: Future<Output = crate::Result<T>>,
         F: FnOnce() -> U,
     {
-        f().with_subscriber(self.subscriber.clone()).await
+        match self.subscriber {
+            Subscriber::Normal(ref subscriber) => f().with_subscriber(subscriber.clone()).await,
+            Subscriber::WithTelemetry(ref subscriber) => f().with_subscriber(subscriber.clone()).await,
+        }
     }
 }

--- a/query-engine/query-engine-napi/src/logger/telemetry.rs
+++ b/query-engine/query-engine-napi/src/logger/telemetry.rs
@@ -1,0 +1,54 @@
+use std::sync::Arc;
+
+use opentelemetry::sdk::trace::Tracer;
+use tracing_opentelemetry::OpenTelemetryLayer;
+use tracing_subscriber::layer::Layered;
+
+use super::{channel::EventChannel, registry::EventRegistry};
+
+type TelemetryLayer = Layered<
+    EventChannel,
+    Layered<OpenTelemetryLayer<EventRegistry, Tracer>, EventRegistry>,
+    Layered<OpenTelemetryLayer<EventRegistry, Tracer>, EventRegistry>,
+>;
+
+#[derive(Clone)]
+pub struct WithTelemetry {
+    inner: Arc<TelemetryLayer>,
+}
+
+impl WithTelemetry {
+    pub fn new(inner: TelemetryLayer) -> Self {
+        Self { inner: Arc::new(inner) }
+    }
+}
+
+impl tracing::Subscriber for WithTelemetry {
+    fn enabled(&self, metadata: &tracing::Metadata<'_>) -> bool {
+        self.inner.enabled(metadata)
+    }
+
+    fn new_span(&self, span: &tracing::span::Attributes<'_>) -> tracing::Id {
+        self.inner.new_span(span)
+    }
+
+    fn record(&self, span: &tracing::Id, values: &tracing::span::Record<'_>) {
+        self.inner.record(span, values)
+    }
+
+    fn record_follows_from(&self, span: &tracing::Id, follows: &tracing::Id) {
+        self.inner.record_follows_from(span, follows)
+    }
+
+    fn event(&self, event: &tracing::Event<'_>) {
+        self.inner.event(event)
+    }
+
+    fn enter(&self, span: &tracing::Id) {
+        self.inner.enter(span)
+    }
+
+    fn exit(&self, span: &tracing::Id) {
+        self.inner.exit(span)
+    }
+}

--- a/query-engine/query-engine/Cargo.toml
+++ b/query-engine/query-engine/Cargo.toml
@@ -41,11 +41,16 @@ tide-server-timing = "0.15.0"
 url = "2.1"
 
 tracing = "0.1"
+tracing-opentelemetry = "0.11"
 tracing-attributes = "0.1"
 tracing-subscriber = { version = "0.2", features = ["json"] }
-
 tracing-futures = "0.2.3"
-user-facing-errors = { path = "../../libs/user-facing-errors" }
+opentelemetry = { version = "0.12", features = ["async-std"] }
+opentelemetry-otlp = { version = "0.5", features = ["tls", "tls-roots"] }
+rand = "0.8"
+tonic = { version = "0.4", default-features = false }
+
+user-facing-errors = {path = "../../libs/user-facing-errors"}
 
 [build-dependencies]
 rustc_version = "0.2.3"

--- a/query-engine/query-engine/src/logger.rs
+++ b/query-engine/query-engine/src/logger.rs
@@ -1,0 +1,109 @@
+use opentelemetry::{
+    global,
+    sdk::{propagation::TraceContextPropagator, trace::Config, Resource},
+    KeyValue,
+};
+use opentelemetry_otlp::Uninstall;
+use tracing::{dispatcher::SetGlobalDefaultError, subscriber};
+use tracing_subscriber::{layer::SubscriberExt, registry::LookupSpan, EnvFilter, FmtSubscriber};
+
+use crate::LogFormat;
+
+type LoggerResult<T> = Result<T, SetGlobalDefaultError>;
+
+/// An installer for a global logger.
+#[derive(Debug, Clone)]
+pub struct Logger<'a> {
+    service_name: &'static str,
+    log_format: LogFormat,
+    enable_telemetry: bool,
+    telemetry_endpoint: Option<&'a str>,
+}
+
+impl<'a> Logger<'a> {
+    /// Initialize a new global logger installer.
+    pub fn new(service_name: &'static str) -> Self {
+        Self {
+            service_name,
+            log_format: LogFormat::Json,
+            enable_telemetry: false,
+            telemetry_endpoint: None,
+        }
+    }
+
+    /// Sets the STDOUT log output format. Default: Json.
+    pub fn log_format(&mut self, log_format: LogFormat) {
+        self.log_format = log_format;
+    }
+
+    /// Enables Jaeger telemetry.
+    pub fn enable_telemetry(&mut self, enable_telemetry: bool) {
+        self.enable_telemetry = enable_telemetry;
+    }
+
+    /// Sets a custom telemetry endpoint (default: http://localhost:4317)
+    pub fn telemetry_endpoint(&mut self, endpoint: &'a str) {
+        self.telemetry_endpoint = Some(endpoint);
+    }
+
+    /// Install logger as a global. Can be called only once per application
+    /// instance. The returned guard value needs to stay in scope for the whole
+    /// lifetime of the service.
+    pub fn install(self) -> LoggerResult<Option<Uninstall>> {
+        let filter = EnvFilter::from_default_env()
+            .add_directive("tide=error".parse().unwrap())
+            .add_directive("tonic=error".parse().unwrap())
+            .add_directive("h2=error".parse().unwrap())
+            .add_directive("hyper=error".parse().unwrap())
+            .add_directive("tower=error".parse().unwrap());
+
+        match self.log_format {
+            LogFormat::Text => {
+                if self.enable_telemetry {
+                    let subscriber = FmtSubscriber::builder()
+                        .with_env_filter(filter.add_directive("trace".parse().unwrap()))
+                        .finish();
+
+                    self.finalize(subscriber)
+                } else {
+                    let subscriber = FmtSubscriber::builder().with_max_level(tracing::Level::TRACE).finish();
+                    self.finalize(subscriber)
+                }
+            }
+            LogFormat::Json => {
+                let subscriber = FmtSubscriber::builder().json().with_env_filter(filter).finish();
+                self.finalize(subscriber)
+            }
+        }
+    }
+
+    fn finalize<T>(self, subscriber: T) -> LoggerResult<Option<Uninstall>>
+    where
+        T: SubscriberExt + Send + Sync + 'static + for<'span> LookupSpan<'span>,
+    {
+        if self.enable_telemetry {
+            global::set_text_map_propagator(TraceContextPropagator::new());
+
+            // A special parameter for Jaeger to set the service name in spans.
+            let resource = Resource::new(vec![KeyValue::new("service.name", self.service_name)]);
+            let config = Config::default().with_resource(resource);
+
+            let mut builder = opentelemetry_otlp::new_pipeline().with_trace_config(config);
+
+            if let Some(endpoint) = self.telemetry_endpoint {
+                builder = builder.with_endpoint(endpoint);
+            }
+
+            let (tracer, guard) = builder.install().unwrap();
+
+            let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
+            subscriber::set_global_default(subscriber.with(telemetry))?;
+
+            Ok(Some(guard))
+        } else {
+            subscriber::set_global_default(subscriber)?;
+
+            Ok(None)
+        }
+    }
+}

--- a/query-engine/query-engine/src/opt.rs
+++ b/query-engine/query-engine/src/opt.rs
@@ -86,6 +86,14 @@ pub struct PrismaOpt {
     #[structopt(long = "log-format", env = "RUST_LOG_FORMAT")]
     pub log_format: Option<String>,
 
+    /// Enable OpenTelemetry streaming from requests.
+    #[structopt(long)]
+    pub open_telemetry: bool,
+
+    /// The url to the OpenTelemetry collector.
+    #[structopt(long, default_value = "http://localhost:4317")]
+    pub open_telemetry_endpoint: String,
+
     #[structopt(subcommand)]
     pub subcommand: Option<Subcommand>,
 

--- a/query-engine/query-engine/src/tests/dmmf.rs
+++ b/query-engine/query-engine/src/tests/dmmf.rs
@@ -110,6 +110,8 @@ fn test_dmmf_cli_command(schema: &str) -> PrismaResult<()> {
         raw_feature_flags: vec![],
         unix_path: None,
         subcommand: Some(Subcommand::Cli(CliOpt::Dmmf)),
+        open_telemetry: false,
+        open_telemetry_endpoint: String::new(),
     };
 
     let cli_cmd = CliCommand::from_opt(&prisma_opt)?.unwrap();

--- a/query-engine/request-handlers/src/graphql/handler.rs
+++ b/query-engine/request-handlers/src/graphql/handler.rs
@@ -6,11 +6,17 @@ use query_core::{
     BatchDocument, CompactedDocument, Item, Operation, QueryDocument, QueryExecutor, QuerySchemaRef, QueryValue,
     ResponseData,
 };
-use std::panic::AssertUnwindSafe;
+use std::{fmt, panic::AssertUnwindSafe};
 
 pub struct GraphQlHandler<'a> {
     executor: &'a (dyn QueryExecutor + Send + Sync + 'a),
     query_schema: &'a QuerySchemaRef,
+}
+
+impl<'a> fmt::Debug for GraphQlHandler<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GraphQlHandler").finish()
+    }
 }
 
 impl<'a> GraphQlHandler<'a> {
@@ -79,6 +85,7 @@ impl<'a> GraphQlHandler<'a> {
         }
     }
 
+    #[tracing::instrument(skip(self, document))]
     async fn handle_compacted(&self, document: CompactedDocument) -> PrismaResponse {
         use user_facing_errors::Error;
 

--- a/query-engine/request-handlers/src/graphql/protocol_adapter.rs
+++ b/query-engine/request-handlers/src/graphql/protocol_adapter.rs
@@ -23,6 +23,7 @@ use query_core::query_document::*;
 pub struct GraphQLProtocolAdapter;
 
 impl GraphQLProtocolAdapter {
+    #[tracing::instrument(name = "graphql_to_query_document", skip(gql_doc, operation))]
     pub fn convert(gql_doc: Document<String>, operation: Option<String>) -> crate::Result<Operation> {
         let mut operations: Vec<Operation> = match operation {
             Some(ref op) => gql_doc

--- a/query-engine/request-handlers/src/graphql/schema_renderer/object_renderer.rs
+++ b/query-engine/request-handlers/src/graphql/schema_renderer/object_renderer.rs
@@ -7,6 +7,7 @@ pub enum GqlObjectRenderer {
 }
 
 impl Renderer for GqlObjectRenderer {
+    #[tracing::instrument(name = "render_graphql_object", skip(self, ctx))]
     fn render(&self, ctx: &mut RenderContext) -> String {
         match &self {
             GqlObjectRenderer::Input(input) => self.render_input_object(input, ctx),

--- a/shell.nix
+++ b/shell.nix
@@ -4,6 +4,8 @@ with pkgs;
 
 mkShell {
   LIBCLANG_PATH="${pkgs.llvmPackages.libclang}/lib";
+  PROTOC="${pkgs.protobuf}/bin/protoc";
+  PROTOC_INCLUDE="${pkgs.protobuf}/include";
   buildInputs = with pkgs; [
     sbt
     sbt-extras
@@ -13,5 +15,6 @@ mkShell {
     clangStdenv
     llvmPackages.libclang
     kerberos
+    protobuf
   ];
 }


### PR DESCRIPTION
Part of: https://github.com/prisma/prisma/issues/5956

Implementing OTLP tracing for the Query Engine HTTP and N-API endpoints. A collector talking OTLP protocol with gRPC is required for the metrics to be enabled. See included `docker-compose.yml` and `otel-agent-config.yaml` for the services needed for the minimal usage:

- otel-agent: an opentelemetry agent that takes standard OTLP gRPC messages in with HTTP/2, writing to the telemetry endpoint defined in `otel-agent-config.yaml`. Listens in `localhost:4317`.
- jaeger: Uber's telemetry endpoint. The otel-agent writes here in our configuration, and you can browse the traces in `localhost:16686`.

## Changes in HTTP bridge

The HTTP bridge has two new parameters:

- `--open-telemetry` enables OpenTelemetry
- `--open-telemetry-endpoint <open-telemetry-endpoint>` allows changing the endpoint (`otel-agent`) url.

When using the graphql Query endpoint, it is possible to define the trace and span ids from the client using the `traceparent` header, value generated with w3c standard trace context formatting (see later).

## Changes in N-API bridge

The constructor allows enabling telemetry with new options:

```javascript
const qe = new QueryEngine({
  telemetry: {
    enabled: true,
    endpoint: "http://localhost:4317"
  },
  ..
});
```

Endpoint is optional and the default value is `http://localhost:4317`.

When querying, a the trace context parameters must be added:

```javascript
await qe.query(q, { traceparent: ',,,' });
```

The `traceparent` value follows the w3c standard (see later).

## Passing the trace context

The trace and span ids should be passed from JavaScript to Rust to group both sides in one trace. This is done using the [W3C Trace Context](https://www.npmjs.com/package/@opentelemetry/core#httptracecontext-propagator) propagator. In general, it should work like this

```javascript
// The user is in control creating the trace and setting the global.
// This starts a new span from the global trace.
const span = api.span.startSpan('findOneUser');

const propagator = new HttpTraceContext();
var headers = {};
// This should set a new key `traceparent` with a
// correctly formatted trace context to the map.
propagator.extract(api.context.active(), headers);
await qe.query(query, headers);
span.end();
```

The `traceparent` is constructed from a span context with the following method:

```javascript
const traceParent = `00-${cx.traceId}-${cx.spanId}-0${Number(cx.traceFlags || api.TraceFlags.NONE).toString(16)}`;
```

## User responsibilities

The user is responsible of creating and starting the provider, processor and exporter. For our test setup, we should use the following libraries:

```javascript
const { BasicTracerProvider, SimpleSpanProcessor } = require('@opentelemetry/tracing');
const { CollectorTraceExporter } =  require('@opentelemetry/exporter-collector-grpc');
const { HttpTraceContext } = require("@opentelemetry/core");
```

We should talk to the same collector from Rust and JavaScript in our test setup, using HTTP/2 with gRPC.

When using Jaeger, an extra resource should be provided when storing traces: `service.name` with a value of `query-engine-napi`.

## Using for development

If needing spans for the development, launch the engine with `--open-telemetry`. The Jaeger service will be called `query-engine-http`, and new spans are available when triggering requests to the engine.

## Bonus

I wrote a quick and dirty javascript client with telemetry. I got this working when talking directly with Jaeger, but when I changed it to speak OTLP protocol, the javascript produces no traces (but when calling Rust, we get all the traces from there as usual).

https://gist.github.com/pimeys/992ad257305426af27b6655c30187004

## Links

- https://www.npmjs.com/package/@opentelemetry/exporter-collector-grpc
- https://www.npmjs.com/package/@opentelemetry/core
- https://www.npmjs.com/package/@opentelemetry/api
- https://github.com/open-telemetry/opentelemetry-js