### PR TITLE
Upgrade jsonrpc crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -908,6 +908,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "0.99.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cb0e6161ad61ed084a36ba71fbba9e3ac5aee3606fb607fe08da6acbcf3d8c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,28 +1103,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
 name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1260,6 +1249,7 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+ "num_cpus",
 ]
 
 [[package]]
@@ -1724,8 +1714,6 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "datamodel",
- "futures 0.1.31",
- "futures 0.3.13",
  "introspection-connector",
  "json-rpc-stdio",
  "jsonrpc-core",
@@ -1815,7 +1803,6 @@ dependencies = [
 name = "json-rpc-stdio"
 version = "0.1.0"
 dependencies = [
- "futures 0.3.13",
  "jsonrpc-core",
  "tokio",
  "tracing",
@@ -1823,12 +1810,12 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-client-transports"
-version = "14.2.1"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2773fa94a2a1fd51efb89a8f45b8861023dbb415d18d3c9235ae9388d780f9ec"
+checksum = "15b6c6ad01c7354d60de493148c30ac8a82b759e22ae678c8705e9b8e0c566a4"
 dependencies = [
- "failure",
- "futures 0.1.31",
+ "derive_more",
+ "futures 0.3.13",
  "jsonrpc-core",
  "jsonrpc-pubsub",
  "log",
@@ -1839,11 +1826,11 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-core"
-version = "14.2.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0747307121ffb9703afd93afbd0fb4f854c38fb873f2c8b90e0e902f27c7b62"
+checksum = "07569945133257ff557eb37b015497104cea61a2c9edaf126c1cbd6e8332397f"
 dependencies = [
- "futures 0.1.31",
+ "futures 0.3.13",
  "log",
  "serde",
  "serde_derive",
@@ -1852,18 +1839,19 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-core-client"
-version = "14.2.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34221123bc79b66279a3fde2d3363553835b43092d629b34f2e760c44dc94713"
+checksum = "7ac9d56dc729912796637c30f475bbf834594607b27740dfea6e5fa7ba40d1f1"
 dependencies = [
+ "futures 0.3.13",
  "jsonrpc-client-transports",
 ]
 
 [[package]]
 name = "jsonrpc-derive"
-version = "14.2.2"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0e77e8812f02155b85a677a96e1d16b60181950c0636199bc4528524fba98dc"
+checksum = "b68ba7e76e5c7796cfa4d2a30e83986550c34404c6d40551c902ca6f7bd4a137"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1873,13 +1861,15 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-pubsub"
-version = "14.2.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d44f5602a11d657946aac09357956d2841299ed422035edf140c552cb057986"
+checksum = "0c48dbebce7a9c88ab272a4db7d6478aa4c6d9596e6c086366e89efc4e9ed89e"
 dependencies = [
+ "futures 0.3.13",
  "jsonrpc-core",
+ "lazy_static",
  "log",
- "parking_lot 0.10.2",
+ "parking_lot 0.11.1",
  "rand 0.7.3",
  "serde",
 ]
@@ -2116,7 +2106,6 @@ dependencies = [
  "chrono",
  "datamodel",
  "enumflags2",
- "futures 0.3.13",
  "jsonrpc-core",
  "migration-connector",
  "mongodb-migration-connector",

--- a/introspection-engine/core/Cargo.toml
+++ b/introspection-engine/core/Cargo.toml
@@ -14,16 +14,14 @@ user-facing-errors = { path = "../../libs/user-facing-errors" }
 introspection-connector = { path = "../connectors/introspection-connector" }
 sql-introspection-connector = { path = "../connectors/sql-introspection-connector" }
 
+futures = { version = "0.3", default-features = false }
 serde = "1.0"
-futures = { version = "0.3", features = ["compat"] }
-futures01 = { package = "futures", version = "0.1" }
-
 serde_json = { version = "1.0", features = ["float_roundtrip"] }
 serde_derive = "1.0"
 async-trait = "0.1.17"
-jsonrpc-core = "14.0"
-jsonrpc-derive = "14.0"
-jsonrpc-core-client = "14.0"
+jsonrpc-core = "17.0"
+jsonrpc-derive = "17.0"
+jsonrpc-core-client = "17.0"
 json-rpc-stdio = { path = "../../libs/json-rpc-stdio" }
 
 tracing = "0.1"

--- a/introspection-engine/core/Cargo.toml
+++ b/introspection-engine/core/Cargo.toml
@@ -14,7 +14,6 @@ user-facing-errors = { path = "../../libs/user-facing-errors" }
 introspection-connector = { path = "../connectors/introspection-connector" }
 sql-introspection-connector = { path = "../connectors/sql-introspection-connector" }
 
-futures = { version = "0.3", default-features = false }
 serde = "1.0"
 serde_json = { version = "1.0", features = ["float_roundtrip"] }
 serde_derive = "1.0"

--- a/introspection-engine/core/src/rpc.rs
+++ b/introspection-engine/core/src/rpc.rs
@@ -1,6 +1,5 @@
 use crate::error::Error;
 use datamodel::{Configuration, Datamodel};
-use futures::FutureExt;
 use introspection_connector::{ConnectorResult, DatabaseMetadata, IntrospectionConnector, IntrospectionResultOutput};
 use jsonrpc_core::BoxFuture;
 use jsonrpc_derive::rpc;
@@ -36,27 +35,27 @@ pub struct RpcImpl;
 
 impl Rpc for RpcImpl {
     fn list_databases(&self, input: IntrospectionInput) -> RpcFutureResult<Vec<String>> {
-        Self::list_databases_internal(input.schema).boxed()
+        Box::pin(Self::list_databases_internal(input.schema))
     }
 
     fn get_database_metadata(&self, input: IntrospectionInput) -> RpcFutureResult<DatabaseMetadata> {
-        Self::get_database_metadata_internal(input.schema).boxed()
+        Box::pin(Self::get_database_metadata_internal(input.schema))
     }
 
     fn get_database_description(&self, input: IntrospectionInput) -> RpcFutureResult<String> {
-        Self::get_database_description_internal(input.schema).boxed()
+        Box::pin(Self::get_database_description_internal(input.schema))
     }
 
     fn get_database_version(&self, input: IntrospectionInput) -> RpcFutureResult<String> {
-        Self::get_database_version_internal(input.schema).boxed()
+        Box::pin(Self::get_database_version_internal(input.schema))
     }
 
     fn introspect(&self, input: IntrospectionInput) -> RpcFutureResult<IntrospectionResultOutput> {
-        Self::introspect_internal(input.schema, input.force).boxed()
+        Box::pin(Self::introspect_internal(input.schema, input.force))
     }
 
     fn debug_panic(&self) -> RpcFutureResult<()> {
-        Self::debug_panic().boxed()
+        Box::pin(Self::debug_panic())
     }
 }
 

--- a/introspection-engine/core/src/rpc.rs
+++ b/introspection-engine/core/src/rpc.rs
@@ -1,14 +1,15 @@
 use crate::error::Error;
 use datamodel::{Configuration, Datamodel};
-use futures::{FutureExt, TryFutureExt};
+use futures::FutureExt;
 use introspection_connector::{ConnectorResult, DatabaseMetadata, IntrospectionConnector, IntrospectionResultOutput};
+use jsonrpc_core::BoxFuture;
 use jsonrpc_derive::rpc;
 use serde_derive::*;
 use sql_introspection_connector::SqlIntrospectionConnector;
 
 type RpcError = jsonrpc_core::Error;
 type RpcResult<T> = Result<T, RpcError>;
-type RpcFutureResult<T> = Box<dyn futures01::Future<Item = T, Error = RpcError> + Send + 'static>;
+type RpcFutureResult<T> = BoxFuture<RpcResult<T>>;
 
 #[rpc]
 pub trait Rpc {
@@ -35,27 +36,27 @@ pub struct RpcImpl;
 
 impl Rpc for RpcImpl {
     fn list_databases(&self, input: IntrospectionInput) -> RpcFutureResult<Vec<String>> {
-        Box::new(Self::list_databases_internal(input.schema).boxed().compat())
+        Self::list_databases_internal(input.schema).boxed()
     }
 
     fn get_database_metadata(&self, input: IntrospectionInput) -> RpcFutureResult<DatabaseMetadata> {
-        Box::new(Self::get_database_metadata_internal(input.schema).boxed().compat())
+        Self::get_database_metadata_internal(input.schema).boxed()
     }
 
     fn get_database_description(&self, input: IntrospectionInput) -> RpcFutureResult<String> {
-        Box::new(Self::get_database_description_internal(input.schema).boxed().compat())
+        Self::get_database_description_internal(input.schema).boxed()
     }
 
     fn get_database_version(&self, input: IntrospectionInput) -> RpcFutureResult<String> {
-        Box::new(Self::get_database_version_internal(input.schema).boxed().compat())
+        Self::get_database_version_internal(input.schema).boxed()
     }
 
     fn introspect(&self, input: IntrospectionInput) -> RpcFutureResult<IntrospectionResultOutput> {
-        Box::new(Self::introspect_internal(input.schema, input.force).boxed().compat())
+        Self::introspect_internal(input.schema, input.force).boxed()
     }
 
     fn debug_panic(&self) -> RpcFutureResult<()> {
-        Box::new(Self::debug_panic().boxed().compat())
+        Self::debug_panic().boxed()
     }
 }
 

--- a/libs/json-rpc-stdio/Cargo.toml
+++ b/libs/json-rpc-stdio/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-futures = { version = "0.3.1", features = ["compat"] }
-jsonrpc-core = "14.0.5"
+jsonrpc-core = "17"
 tokio = { version = "1.0", features = ["io-std", "io-util"] }
 tracing = "0.1.12"

--- a/libs/json-rpc-stdio/src/lib.rs
+++ b/libs/json-rpc-stdio/src/lib.rs
@@ -1,4 +1,3 @@
-use futures::compat::Future01CompatExt;
 use jsonrpc_core::IoHandler;
 use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt};
 
@@ -27,12 +26,10 @@ async fn run_with_io(
 
 /// Process a request asynchronously
 async fn handle_request(io: &IoHandler, input: &str) -> String {
-    let response = io.handle_request(input).compat().await;
+    let response = io.handle_request(input).await;
 
-    response
-        .expect("jsonrpc-core returned an empty error")
-        .unwrap_or_else(|| {
-            tracing::info!("JSON RPC request produced no response: {:?}", input);
-            String::from("")
-        })
+    response.unwrap_or_else(|| {
+        tracing::info!("JSON RPC request produced no response: {:?}", input);
+        String::from("")
+    })
 }

--- a/migration-engine/cli/Cargo.toml
+++ b/migration-engine/cli/Cargo.toml
@@ -16,7 +16,7 @@ futures = { version = "0.3", default-features = false }
 json-rpc-stdio = { path = "../../libs/json-rpc-stdio" }
 serde_json = { version = "1.0", features = ["float_roundtrip"] }
 structopt = "0.3.8"
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", default-features = false, features = ["macros"] }
 tracing = "0.1"
 tracing-subscriber = "0.2"
 tracing-error = "0.1.2"

--- a/migration-engine/cli/Cargo.toml
+++ b/migration-engine/cli/Cargo.toml
@@ -12,7 +12,7 @@ migration-core = { path = "../core" }
 user-facing-errors = { path = "../../libs/user-facing-errors" }
 
 base64 = "0.13"
-futures = "0.3"
+futures = { version = "0.3", default-features = false }
 json-rpc-stdio = { path = "../../libs/json-rpc-stdio" }
 serde_json = { version = "1.0", features = ["float_roundtrip"] }
 structopt = "0.3.8"

--- a/migration-engine/cli/src/commands.rs
+++ b/migration-engine/cli/src/commands.rs
@@ -1,4 +1,5 @@
 pub(crate) mod error;
+
 #[cfg(test)]
 mod tests;
 

--- a/migration-engine/core/Cargo.toml
+++ b/migration-engine/core/Cargo.toml
@@ -15,8 +15,8 @@ anyhow = "1.0.26"
 async-trait = "0.1.17"
 chrono = { version = "0.4", features = ["serde"] }
 enumflags2 = "0.6.0"
-futures = { version = "0.3", default-features = false, features = ["compat"] }
-jsonrpc-core = "14.0"
+futures = { version = "0.3", default-features = false }
+jsonrpc-core = "17.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["float_roundtrip"] }
 tracing = "0.1.10"

--- a/migration-engine/core/Cargo.toml
+++ b/migration-engine/core/Cargo.toml
@@ -15,7 +15,6 @@ anyhow = "1.0.26"
 async-trait = "0.1.17"
 chrono = { version = "0.4", features = ["serde"] }
 enumflags2 = "0.6.0"
-futures = { version = "0.3", default-features = false }
 jsonrpc-core = "17.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["float_roundtrip"] }

--- a/migration-engine/core/src/api/rpc.rs
+++ b/migration-engine/core/src/api/rpc.rs
@@ -1,6 +1,6 @@
 use super::error_rendering::render_jsonrpc_error;
 use crate::{CoreError, CoreResult, GenericApi};
-use futures::{FutureExt, TryFutureExt};
+use futures::FutureExt;
 use jsonrpc_core::{types::error::Error as JsonRpcError, IoHandler, Params};
 use std::sync::Arc;
 
@@ -88,7 +88,7 @@ impl RpcApi {
 
         self.io_handler.add_method(cmd.name(), move |params: Params| {
             let executor = Arc::clone(&executor);
-            Self::create_handler(executor, cmd, params).boxed().compat()
+            Self::create_handler(executor, cmd, params).boxed()
         });
     }
 

--- a/migration-engine/core/src/api/rpc.rs
+++ b/migration-engine/core/src/api/rpc.rs
@@ -1,6 +1,5 @@
 use super::error_rendering::render_jsonrpc_error;
 use crate::{CoreError, CoreResult, GenericApi};
-use futures::FutureExt;
 use jsonrpc_core::{types::error::Error as JsonRpcError, IoHandler, Params};
 use std::sync::Arc;
 
@@ -88,7 +87,7 @@ impl RpcApi {
 
         self.io_handler.add_method(cmd.name(), move |params: Params| {
             let executor = Arc::clone(&executor);
-            Self::create_handler(executor, cmd, params).boxed()
+            Box::pin(Self::create_handler(executor, cmd, params))
         });
     }
 


### PR DESCRIPTION
This lets us drop futures 0.1 and old macro support code.