### PR TITLE
Strip debug symbols to reduce engines binary size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["strip"]
+
 [workspace]
 members = [
   "introspection-engine/connectors/introspection-connector",
@@ -31,10 +33,12 @@ members = [
   "libs/user-facing-errors",
 ]
 
+[profile.release]
+strip = 'symbols'
+
 [profile.dev.package.backtrace]
 opt-level = 3
 
 [profile.release.package.introspection-core]
-codegen-units = 1 
+codegen-units = 1
 opt-level = 'z' # Optimize for size.
-#strip="symbols"


### PR DESCRIPTION
I couldn't test this because I got problems with a missing OpenSSL library needed for all compiling any of the engines it seems, hoping for a rustls future ;)

Anyways I did test with `strip` locally, also note that the strip functionality is still marked as unstable and thus only available for Nightly. But thought I would open this PR to get the ball rolling.

On Linux this saves about 22MB:

*Before*
```
18M Mar  9 14:33 introspection-engine-rhel-openssl-1.1.x*
21M Mar  9 14:33 migration-engine-rhel-openssl-1.1.x*
7.2M Mar  9 14:33 prisma-fmt-rhel-openssl-1.1.x*
25M Mar  9 14:33 query-engine-rhel-openssl-1.1.x*
```

*After*
```
12M Mar  9 14:34 introspection-engine-rhel-openssl-1.1.x*
15M Mar  9 14:34 migration-engine-rhel-openssl-1.1.x*
3.5M Mar  9 14:34 prisma-fmt-rhel-openssl-1.1.x*
18M Mar  9 14:34 query-engine-rhel-openssl-1.1.x*
```