### PR TITLE
feat: add _count aggregation to findMany

### DIFF
--- a/query-engine/connector-test-kit/src/test/scala/queries/aggregation/FindManyCountRelAggregationQuerySpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/aggregation/FindManyCountRelAggregationQuerySpec.scala
@@ -91,7 +91,7 @@ class FindManyCountRelAggregationQuerySpec extends FlatSpec with Matchers with A
     val res = server.query(
       s"""
          |query {
-         |  findManyPost {
+         |  findManyPost(orderBy: { id: asc }) {
          |    _count { comments categories }
          |  }
          |}
@@ -100,7 +100,7 @@ class FindManyCountRelAggregationQuerySpec extends FlatSpec with Matchers with A
       legacy = false
     )
 
-    res.toString() should be("""{"data":{"findManyPost":[{"_count":{"comments":3,"categories":4}},{"_count":{"comments":1,"categories":2}}]}}""")
+    res.toString() should be("""{"data":{"findManyPost":[{"_count":{"comments":1,"categories":2}},{"_count":{"comments":3,"categories":4}}]}}""")
   }
 
   "Counting with some records and filters" should "not affect the count" in {
@@ -110,8 +110,8 @@ class FindManyCountRelAggregationQuerySpec extends FlatSpec with Matchers with A
       s"""
          |query {
          |  findManyPost(where: { id: 1 }) {
-         |    comments(cursor: { id: 1 }, take: 2) { id }
-         |    categories(cursor: { id: 1 }, take: 2) { id }
+         |    comments(cursor: { id: 1 }, take: 1) { id }
+         |    categories(cursor: { id: 1 }, take: 1) { id }
          |    _count { comments categories }
          |  }
          |}
@@ -120,7 +120,7 @@ class FindManyCountRelAggregationQuerySpec extends FlatSpec with Matchers with A
       legacy = false
     )
 
-    res.toString() should be("""{"data":{"findManyPost":[{"comments":[{"id":1},{"id":2}],"categories":[{"id":1},{"id":2}],"_count":{"comments":4,"categories":4}}]}}""")
+    res.toString() should be("""{"data":{"findManyPost":[{"comments":[{"id":1}],"categories":[{"id":1}],"_count":{"comments":4,"categories":4}}]}}""")
   }
 
 }

--- a/query-engine/connector-test-kit/src/test/scala/queries/aggregation/FindManyCountRelAggregationQuerySpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/aggregation/FindManyCountRelAggregationQuerySpec.scala
@@ -1,0 +1,126 @@
+package queries.aggregation
+
+import org.scalatest.{FlatSpec, Matchers}
+import util._
+
+class FindManyCountRelAggregationQuerySpec extends FlatSpec with Matchers with ApiSpecBase {
+  val project = SchemaDsl.fromStringV11() {
+    """
+      |model Post {
+      |  id         Int        @id @default(autoincrement())
+      |  title      String
+      |  comments   Comment[]
+      |  categories Category[]
+      |}
+      |
+      |model Comment {
+      |  id      Int     @id @default(autoincrement())
+      |  post    Post    @relation(fields: [postId], references: [id])
+      |  postId  Int
+      |}
+      |
+      |model Category {
+      |  id    Int    @id @default(autoincrement())
+      |  posts Post[]
+      |}
+      |
+    """.stripMargin
+  }
+
+  override protected def beforeEach(): Unit = {
+    super.beforeEach()
+    database.setup(project)
+  }
+
+  def createPost(n_comments: Int, n_categories: Int) = {
+    var renderedComments = Array.fill[Int](n_comments)(0).map(c => s"""{}""").mkString(",")
+    var renderedCategories = Array.fill[Int](n_categories)(0).map(c => s"""{}""").mkString(",")
+
+    if (n_comments == 0) {
+      renderedComments = ""
+    } else {
+      renderedComments = s"""comments: { create: [$renderedComments] }"""
+    }
+
+    if (n_categories == 0) {
+      renderedCategories = ""
+    } else {
+      renderedCategories = s"""categories: { create: [$renderedCategories] }"""
+    }
+
+    server.query(
+      s"""mutation {
+        |  createOnePost(
+        |    data: {
+        |      title: "a"
+        |      $renderedComments
+        |      $renderedCategories
+        |    }
+        |  ) {
+        |    id
+        |  }
+        |}
+        |""".stripMargin,
+      project,
+      legacy = false
+    )
+  }
+
+  "Counting with no records in the database" should "return 0" in {
+    createPost(0, 0)
+
+    val res = server.query(
+      s"""
+         |query {
+         |  findManyPost {
+         |    _count { comments categories }
+         |  }
+         |}
+         |""".stripMargin,
+      project,
+      legacy = false
+    )
+
+    res.toString() should be("""{"data":{"findManyPost":[{"_count":{"comments":0,"categories":0}}]}}""")
+  }
+
+  "Counting one2m and m2m records" should "work" in {
+    createPost(1, 2)
+    createPost(3, 4)
+
+    val res = server.query(
+      s"""
+         |query {
+         |  findManyPost {
+         |    _count { comments categories }
+         |  }
+         |}
+         |""".stripMargin,
+      project,
+      legacy = false
+    )
+
+    res.toString() should be("""{"data":{"findManyPost":[{"_count":{"comments":3,"categories":4}},{"_count":{"comments":1,"categories":2}}]}}""")
+  }
+
+  "Counting with some records and filters" should "not affect the count" in {
+    createPost(4, 4)
+
+    val res = server.query(
+      s"""
+         |query {
+         |  findManyPost(where: { id: 1 }) {
+         |    comments(cursor: { id: 1 }, take: 2) { id }
+         |    categories(cursor: { id: 1 }, take: 2) { id }
+         |    _count { comments categories }
+         |  }
+         |}
+         |""".stripMargin,
+      project,
+      legacy = false
+    )
+
+    res.toString() should be("""{"data":{"findManyPost":[{"comments":[{"id":1},{"id":2}],"categories":[{"id":1},{"id":2}],"_count":{"comments":4,"categories":4}}]}}""")
+  }
+
+}

--- a/query-engine/connectors/query-connector/src/coerce.rs
+++ b/query-engine/connectors/query-connector/src/coerce.rs
@@ -1,0 +1,9 @@
+use prisma_models::PrismaValue;
+
+pub fn coerce_null_to_zero_value(value: PrismaValue) -> PrismaValue {
+    if let PrismaValue::Null = value {
+        PrismaValue::Int(0)
+    } else {
+        value
+    }
+}

--- a/query-engine/connectors/query-connector/src/interface/dispatch.rs
+++ b/query-engine/connectors/query-connector/src/interface/dispatch.rs
@@ -21,10 +21,17 @@ impl<'conn, 'tx> ReadOperations for ConnectionLike<'conn, 'tx> {
         model: &ModelRef,
         query_arguments: QueryArguments,
         selected_fields: &ModelProjection,
+        aggregation_selections: &[RelAggregationSelection],
     ) -> crate::Result<ManyRecords> {
         match self {
-            Self::Connection(c) => c.get_many_records(model, query_arguments, selected_fields).await,
-            Self::Transaction(tx) => tx.get_many_records(model, query_arguments, selected_fields).await,
+            Self::Connection(c) => {
+                c.get_many_records(model, query_arguments, selected_fields, aggregation_selections)
+                    .await
+            }
+            Self::Transaction(tx) => {
+                tx.get_many_records(model, query_arguments, selected_fields, aggregation_selections)
+                    .await
+            }
         }
     }
 

--- a/query-engine/connectors/query-connector/src/interface/mod.rs
+++ b/query-engine/connectors/query-connector/src/interface/mod.rs
@@ -192,11 +192,9 @@ impl RelAggregationSelection {
         }
     }
 
-    pub fn into_result(&self, val: PrismaValue) -> RelAggregationResult {
+    pub fn into_result(self, val: PrismaValue) -> RelAggregationResult {
         match self {
-            RelAggregationSelection::Count(rf) => {
-                RelAggregationResult::Count(rf.clone(), coerce_null_to_zero_value(val))
-            }
+            RelAggregationSelection::Count(rf) => RelAggregationResult::Count(rf, coerce_null_to_zero_value(val)),
         }
     }
 }

--- a/query-engine/connectors/query-connector/src/interface/mod.rs
+++ b/query-engine/connectors/query-connector/src/interface/mod.rs
@@ -1,8 +1,7 @@
 mod dispatch;
-pub use dispatch::*;
-
-use crate::{Filter, QueryArguments, WriteArgs};
+use crate::{coerce_null_to_zero_value, Filter, QueryArguments, WriteArgs};
 use async_trait::async_trait;
+pub use dispatch::*;
 use dml::FieldArity;
 use prisma_models::*;
 use prisma_value::PrismaValue;
@@ -190,6 +189,14 @@ impl RelAggregationSelection {
     pub fn type_identifier_with_arity(&self) -> (TypeIdentifier, FieldArity) {
         match self {
             RelAggregationSelection::Count(_) => (TypeIdentifier::Int, FieldArity::Required),
+        }
+    }
+
+    pub fn into_result(&self, val: PrismaValue) -> RelAggregationResult {
+        match self {
+            RelAggregationSelection::Count(rf) => {
+                RelAggregationResult::Count(rf.clone(), coerce_null_to_zero_value(val))
+            }
         }
     }
 }

--- a/query-engine/connectors/query-connector/src/lib.rs
+++ b/query-engine/connectors/query-connector/src/lib.rs
@@ -3,11 +3,13 @@
 pub mod error;
 pub mod filter;
 
+mod coerce;
 mod compare;
 mod interface;
 mod query_arguments;
 mod write_args;
 
+pub use coerce::*;
 pub use compare::*;
 pub use filter::*;
 pub use interface::*;

--- a/query-engine/connectors/sql-query-connector/src/database/connection.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/connection.rs
@@ -1,6 +1,7 @@
 use super::transaction::SqlConnectorTransaction;
 use crate::{database::operations::*, sql_info::SqlInfo, QueryExt, SqlError};
 use async_trait::async_trait;
+use connector::RelAggregationSelection;
 use connector_interface::{
     self as connector, filter::Filter, AggregationRow, AggregationSelection, Connection, QueryArguments,
     ReadOperations, RecordFilter, Transaction, WriteArgs, WriteOperations,
@@ -72,9 +73,12 @@ where
         model: &ModelRef,
         query_arguments: QueryArguments,
         selected_fields: &ModelProjection,
+        aggr_selections: &[RelAggregationSelection],
     ) -> connector::Result<ManyRecords> {
-        self.catch(async move { read::get_many_records(&self.inner, model, query_arguments, selected_fields).await })
-            .await
+        self.catch(async move {
+            read::get_many_records(&self.inner, model, query_arguments, selected_fields, aggr_selections).await
+        })
+        .await
     }
 
     async fn get_related_m2m_record_ids(

--- a/query-engine/connectors/sql-query-connector/src/database/operations/read.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/read.rs
@@ -48,7 +48,7 @@ pub async fn get_many_records(
     field_names.append(&mut aggr_field_names);
 
     let mut aggr_idents = aggr_selections
-        .into_iter()
+        .iter()
         .map(|aggr_sel| aggr_sel.type_identifier_with_arity())
         .collect();
     let mut idents = selected_fields.type_identifiers_with_arities();

--- a/query-engine/connectors/sql-query-connector/src/database/operations/read.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/read.rs
@@ -15,7 +15,7 @@ pub async fn get_single_record(
     filter: &Filter,
     selected_fields: &ModelProjection,
 ) -> crate::Result<Option<SingleRecord>> {
-    let query = read::get_records(&model, selected_fields.as_columns(), filter);
+    let query = read::get_records(&model, selected_fields.as_columns(), &vec![], filter);
 
     let field_names: Vec<_> = selected_fields.db_names().collect();
     let idents = selected_fields.type_identifiers_with_arities();
@@ -38,13 +38,27 @@ pub async fn get_many_records(
     model: &ModelRef,
     mut query_arguments: QueryArguments,
     selected_fields: &ModelProjection,
+    aggr_selections: &[RelAggregationSelection],
 ) -> crate::Result<ManyRecords> {
     let reversed = query_arguments.needs_reversed_order();
 
-    let field_names: Vec<_> = selected_fields.db_names().collect();
-    let idents = selected_fields.type_identifiers_with_arities();
-    let meta = column_metadata::create(field_names.as_slice(), idents.as_slice());
+    let mut field_names: Vec<_> = selected_fields.db_names().collect();
+    let mut aggr_field_names: Vec<_> = aggr_selections
+        .into_iter()
+        .map(|aggr_sel| aggr_sel.db_alias())
+        .collect();
 
+    field_names.append(&mut aggr_field_names);
+
+    let mut aggr_idents = aggr_selections
+        .into_iter()
+        .map(|aggr_sel| aggr_sel.type_identifier_with_arity())
+        .collect();
+    let mut idents = selected_fields.type_identifiers_with_arities();
+
+    idents.append(&mut aggr_idents);
+
+    let meta = column_metadata::create(field_names.as_slice(), idents.as_slice());
     let mut records = ManyRecords::new(field_names.clone());
 
     if let Some(0) = query_arguments.take {
@@ -62,7 +76,8 @@ pub async fn get_many_records(
         let mut futures = FuturesUnordered::new();
 
         for args in batches.into_iter() {
-            let query = read::get_records(model, selected_fields.as_columns(), args);
+            let query = read::get_records(model, selected_fields.as_columns(), aggr_selections, args);
+
             futures.push(conn.filter(query.into(), meta.as_slice()));
         }
 
@@ -76,7 +91,7 @@ pub async fn get_many_records(
             records.order_by(&order)
         }
     } else {
-        let query = read::get_records(model, selected_fields.as_columns(), query_arguments);
+        let query = read::get_records(model, selected_fields.as_columns(), aggr_selections, query_arguments);
 
         for item in conn.filter(query.into(), meta.as_slice()).await?.into_iter() {
             records.push(Record::from(item))

--- a/query-engine/connectors/sql-query-connector/src/database/operations/read.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/read.rs
@@ -15,7 +15,7 @@ pub async fn get_single_record(
     filter: &Filter,
     selected_fields: &ModelProjection,
 ) -> crate::Result<Option<SingleRecord>> {
-    let query = read::get_records(&model, selected_fields.as_columns(), &vec![], filter);
+    let query = read::get_records(&model, selected_fields.as_columns(), &[], filter);
 
     let field_names: Vec<_> = selected_fields.db_names().collect();
     let idents = selected_fields.type_identifiers_with_arities();
@@ -43,10 +43,7 @@ pub async fn get_many_records(
     let reversed = query_arguments.needs_reversed_order();
 
     let mut field_names: Vec<_> = selected_fields.db_names().collect();
-    let mut aggr_field_names: Vec<_> = aggr_selections
-        .into_iter()
-        .map(|aggr_sel| aggr_sel.db_alias())
-        .collect();
+    let mut aggr_field_names: Vec<_> = aggr_selections.iter().map(|aggr_sel| aggr_sel.db_alias()).collect();
 
     field_names.append(&mut aggr_field_names);
 

--- a/query-engine/connectors/sql-query-connector/src/database/transaction.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/transaction.rs
@@ -1,6 +1,7 @@
 use crate::SqlError;
 use crate::{database::operations::*, sql_info::SqlInfo};
 use async_trait::async_trait;
+use connector::RelAggregationSelection;
 use connector_interface::{
     self as connector, filter::Filter, AggregationRow, AggregationSelection, QueryArguments, ReadOperations,
     RecordFilter, Transaction, WriteArgs, WriteOperations,
@@ -64,9 +65,12 @@ impl<'tx> ReadOperations for SqlConnectorTransaction<'tx> {
         model: &ModelRef,
         query_arguments: QueryArguments,
         selected_fields: &ModelProjection,
+        aggr_selections: &[RelAggregationSelection],
     ) -> connector::Result<ManyRecords> {
-        self.catch(async move { read::get_many_records(&self.inner, model, query_arguments, selected_fields).await })
-            .await
+        self.catch(async move {
+            read::get_many_records(&self.inner, model, query_arguments, selected_fields, aggr_selections).await
+        })
+        .await
     }
 
     async fn get_related_m2m_record_ids(

--- a/query-engine/connectors/sql-query-connector/src/join_utils.rs
+++ b/query-engine/connectors/sql-query-connector/src/join_utils.rs
@@ -1,0 +1,206 @@
+use prisma_models::*;
+use quaint::prelude::*;
+
+#[derive(Debug, Clone)]
+pub struct AliasedJoin {
+    // Actual join data to be passed to quaint
+    pub(crate) data: JoinData<'static>,
+    // Alias used for the join. eg: LEFT JOIN ... AS <alias>
+    pub(crate) alias: String,
+}
+
+#[derive(Debug, Clone)]
+pub enum AggregationType {
+    Count { _all: bool },
+}
+
+pub fn compute_aggr_join(
+    rf: &RelationFieldRef,
+    aggregation: AggregationType,
+    aggregator_alias: &str,
+    join_alias: &str,
+    previous_join: Option<&AliasedJoin>,
+) -> AliasedJoin {
+    let join_alias = format!("{}_{}", join_alias, &rf.related_model().name);
+
+    if rf.relation().is_many_to_many() {
+        compute_aggr_join_m2m(rf, aggregation, aggregator_alias, join_alias.as_str(), previous_join)
+    } else {
+        compute_aggr_join_one2m(rf, aggregation, aggregator_alias, join_alias.as_str(), previous_join)
+    }
+}
+
+fn compute_aggr_join_one2m(
+    rf: &RelationFieldRef,
+    sort_aggregation: AggregationType,
+    aggregator_alias: &str,
+    join_alias: &str,
+    previous_join: Option<&AliasedJoin>,
+) -> AliasedJoin {
+    let (left_fields, right_fields) = if rf.is_inlined_on_enclosing_model() {
+        (rf.scalar_fields(), rf.referenced_fields())
+    } else {
+        (
+            rf.related_field().referenced_fields(),
+            rf.related_field().scalar_fields(),
+        )
+    };
+    let select_columns = right_fields.iter().map(|f| f.as_column());
+
+    // + SELECT A.fk FROM A
+    let query = Select::from_table(rf.related_model().as_table()).columns(select_columns);
+    let aggr_expr = match sort_aggregation {
+        AggregationType::Count { _all } => count(asterisk()),
+    };
+
+    // SELECT A.fk,
+    // + COUNT(*) AS <AGGREGATOR_ALIAS>
+    // FROM A
+    let query = query.value(aggr_expr.alias(aggregator_alias.to_owned()));
+
+    // SELECT A.<fk>, COUNT(*) AS <AGGREGATOR_ALIAS> FROM A
+    // + GROUP BY A.<fk>
+    let query = right_fields.iter().fold(query, |acc, f| acc.group_by(f.as_column()));
+
+    let pairs = left_fields.into_iter().zip(right_fields.into_iter());
+    let on_conditions = pairs
+        .map(|(a, b)| {
+            let col_a = match previous_join {
+                Some(prev_join) => Column::from((prev_join.alias.to_owned(), a.db_name().to_owned())),
+                None => a.as_column(),
+            };
+            let col_b = Column::from((join_alias.to_owned(), b.db_name().to_owned()));
+
+            col_a.equals(col_b)
+        })
+        .collect::<Vec<_>>();
+
+    // + LEFT JOIN (
+    //     SELECT A.<fk>, COUNT(*) AS <AGGREGATOR_ALIAS> FROM A
+    //     GROUP BY A.<fk>
+    // + ) AS <ORDER_JOIN_PREFIX> ON (<A | previous_join_alias>.<fk> = <ORDER_JOIN_PREFIX>.<fk>)
+    let join = Table::from(query)
+        .alias(join_alias.to_owned())
+        .on(ConditionTree::single(on_conditions));
+
+    AliasedJoin {
+        data: join,
+        alias: join_alias.to_owned(),
+    }
+}
+
+fn compute_aggr_join_m2m(
+    rf: &RelationFieldRef,
+    aggregation: AggregationType,
+    aggregator_alias: &str,
+    join_alias: &str,
+    previous_join: Option<&AliasedJoin>,
+) -> AliasedJoin {
+    let relation_table = rf.as_table();
+    let a_ids = rf.model().primary_identifier();
+    let b_ids = rf.related_model().primary_identifier();
+
+    // + SELECT A.id FROM _AtoB
+    let query = Select::from_table(relation_table).columns(a_ids.as_columns());
+
+    let aggr_expr = match aggregation {
+        AggregationType::Count { _all } => count(asterisk()),
+    };
+    // SELECT A.id,
+    // + COUNT(*) AS <AGGREGATOR_ALIAS>
+    // FROM _AtoB
+    let query = query.value(aggr_expr.alias(aggregator_alias.to_owned()));
+
+    let conditions_a: Vec<_> = a_ids
+        .as_columns()
+        .map(|c| c.equals(rf.related_field().m2m_columns()))
+        .collect();
+    let conditions_b: Vec<_> = b_ids.as_columns().map(|c| c.equals(rf.m2m_columns())).collect();
+
+    // SELECT A.id, COUNT(*) AS <AGGREGATOR_ALIAS> FROM _AtoB
+    // + INNER JOIN A ON A.id = _AtoB.A
+    // + INNER JOIN B ON B.id = _AtoB.B
+    let query = query
+        .inner_join(rf.model().as_table().on(ConditionTree::single(conditions_a)))
+        .inner_join(rf.related_model().as_table().on(ConditionTree::single(conditions_b)));
+
+    // SELECT A.id, COUNT(*) AS <AGGREGATOR_ALIAS> FROM _AtoB
+    // INNER JOIN A ON A.id = _AtoB.A
+    // INNER JOIN B ON B.id = _AtoB.B
+    // + GROUP BY A.id
+    let query = a_ids.as_columns().fold(query, |acc, f| acc.group_by(f.clone()));
+
+    let (left_fields, right_fields) = (a_ids.scalar_fields(), b_ids.scalar_fields());
+    let pairs = left_fields.zip(right_fields);
+    let on_conditions = pairs
+        .map(|(a, b)| {
+            let col_a = match previous_join {
+                Some(prev_join) => Column::from((prev_join.alias.to_owned(), a.db_name().to_owned())),
+                None => a.as_column(),
+            };
+            let col_b = Column::from((join_alias.to_owned(), b.db_name().to_owned()));
+
+            col_a.equals(col_b)
+        })
+        .collect::<Vec<_>>();
+
+    // + LEFT JOIN (
+    //     SELECT A.id, COUNT(*) AS <AGGREGATOR_ALIAS> FROM _AtoB
+    //       INNER JOIN A ON (A.id = _AtoB.A)
+    //       INNER JOIN B ON (B.id = _AtoB.B)
+    //     GROUP BY A.id
+    // + ) AS <ORDER_JOIN_PREFIX> ON (<A | previous_join_alias >.id = <ORDER_JOIN_PREFIX>.id)
+    let join = Table::from(query)
+        .alias(join_alias.to_owned())
+        .on(ConditionTree::single(on_conditions));
+
+    AliasedJoin {
+        alias: join_alias.to_owned(),
+        data: join,
+    }
+}
+
+pub fn compute_one2m_join(base_model: &ModelRef, rf: &RelationFieldRef, join_prefix: &str) -> AliasedJoin {
+    let (left_fields, right_fields) = if rf.is_inlined_on_enclosing_model() {
+        (rf.scalar_fields(), rf.referenced_fields())
+    } else {
+        (
+            rf.related_field().referenced_fields(),
+            rf.related_field().scalar_fields(),
+        )
+    };
+
+    // `rf` is always the relation field on the left model in the join (parent).
+    let left_table_alias = if rf.model().name != base_model.name {
+        Some(format!("{}_{}", join_prefix, &rf.model().name))
+    } else {
+        None
+    };
+
+    let right_table_alias = format!("{}_{}", join_prefix, &rf.related_model().name);
+
+    let related_model = rf.related_model();
+    let pairs = left_fields.into_iter().zip(right_fields.into_iter());
+
+    let on_conditions = pairs
+        .map(|(a, b)| {
+            let a_col = if let Some(alias) = left_table_alias.clone() {
+                Column::from((alias, a.db_name().to_owned()))
+            } else {
+                a.as_column()
+            };
+
+            let b_col = Column::from((right_table_alias.clone(), b.db_name().to_owned()));
+
+            a_col.equals(b_col)
+        })
+        .collect::<Vec<_>>();
+
+    AliasedJoin {
+        alias: right_table_alias.to_owned(),
+        data: related_model
+            .as_table()
+            .alias(right_table_alias)
+            .on(ConditionTree::single(on_conditions)),
+    }
+}

--- a/query-engine/connectors/sql-query-connector/src/lib.rs
+++ b/query-engine/connectors/sql-query-connector/src/lib.rs
@@ -5,6 +5,8 @@ mod cursor_condition;
 mod database;
 mod error;
 mod filter_conversion;
+mod join_utils;
+mod nested_aggregations;
 mod ordering;
 mod query_arguments_ext;
 mod query_builder;

--- a/query-engine/connectors/sql-query-connector/src/nested_aggregations.rs
+++ b/query-engine/connectors/sql-query-connector/src/nested_aggregations.rs
@@ -1,0 +1,36 @@
+use crate::join_utils::{compute_aggr_join, AggregationType, AliasedJoin};
+use connector_interface::RelAggregationSelection;
+use quaint::prelude::*;
+
+#[derive(Debug)]
+pub struct RelAggregationJoins {
+    // Joins necessary to perform the relation aggregations
+    pub(crate) joins: Vec<AliasedJoin>,
+    // Aggregator columns
+    pub(crate) columns: Vec<Column<'static>>,
+}
+
+pub fn build(aggr_selections: &[RelAggregationSelection]) -> RelAggregationJoins {
+    let mut joins = vec![];
+    let mut columns: Vec<Column<'static>> = vec![];
+    for (index, selection) in aggr_selections.iter().enumerate() {
+        match selection {
+            RelAggregationSelection::Count(rf) => {
+                let join_alias = format!("aggr_selection_{}", index);
+                let aggregator_alias = selection.db_alias();
+                let join = compute_aggr_join(
+                    rf,
+                    AggregationType::Count { _all: true },
+                    aggregator_alias.as_str(),
+                    join_alias.as_str(),
+                    None,
+                );
+
+                columns.push(Column::from((join.alias.clone(), aggregator_alias)));
+                joins.push(join);
+            }
+        }
+    }
+
+    RelAggregationJoins { joins, columns }
+}

--- a/query-engine/connectors/sql-query-connector/src/ordering.rs
+++ b/query-engine/connectors/sql-query-connector/src/ordering.rs
@@ -1,4 +1,4 @@
-use crate::query_arguments_ext::QueryArgumentsExt;
+use crate::{join_utils::*, query_arguments_ext::QueryArgumentsExt};
 use connector_interface::QueryArguments;
 use prisma_models::*;
 use quaint::ast::*;
@@ -7,16 +7,9 @@ static ORDER_JOIN_PREFIX: &str = "orderby_";
 static ORDER_AGGREGATOR_ALIAS: &str = "orderby_aggregator";
 
 #[derive(Debug, Clone)]
-pub struct OrderingJoin {
-    // Actual join data to be passed to quaint
-    pub(crate) data: JoinData<'static>,
-    // Alias used for the join. eg: LEFT JOIN ... AS <alias>
-    pub(crate) alias: String,
-}
-#[derive(Debug, Clone)]
 pub struct OrderingJoins {
     // Joins necessary to perform the order by
-    pub(crate) joins: Vec<OrderingJoin>,
+    pub(crate) joins: Vec<AliasedJoin>,
     // Final column identifier to be used for the scalar field to order by
     pub(crate) order_column: Column<'static>,
 }
@@ -55,7 +48,7 @@ pub fn compute_joins(
     order_by: &OrderBy,
     order_by_index: usize,
     base_model: &ModelRef,
-) -> (Vec<OrderingJoin>, Column<'static>) {
+) -> (Vec<AliasedJoin>, Column<'static>) {
     let join_prefix = format!("{}{}", ORDER_JOIN_PREFIX, order_by_index);
     let mut joins = vec![];
     let last_path = order_by.path.last();
@@ -63,11 +56,21 @@ pub fn compute_joins(
     for rf in order_by.path.iter() {
         // If it's an order by aggregation, we change the last join to compute the aggregation
         if order_by.sort_aggregation.is_some() && Some(rf) == last_path {
-            let ordering_join = compute_aggr_join(order_by, rf, join_prefix.as_str(), joins.last());
+            let sort_aggregation = order_by.sort_aggregation.unwrap();
+            let aggregation_type = match sort_aggregation {
+                SortAggregation::Count { _all } => AggregationType::Count { _all },
+            };
+            let ordering_join = compute_aggr_join(
+                rf,
+                aggregation_type,
+                ORDER_AGGREGATOR_ALIAS,
+                join_prefix.as_str(),
+                joins.last(),
+            );
 
             joins.push(ordering_join);
         } else {
-            let ordering_join = compute_join(base_model, rf, join_prefix.as_str());
+            let ordering_join = compute_one2m_join(base_model, rf, join_prefix.as_str());
 
             joins.push(ordering_join);
         }
@@ -92,198 +95,4 @@ pub fn compute_joins(
     };
 
     (joins, order_by_column)
-}
-
-fn compute_join(base_model: &ModelRef, rf: &RelationFieldRef, join_prefix: &str) -> OrderingJoin {
-    let (left_fields, right_fields) = if rf.is_inlined_on_enclosing_model() {
-        (rf.scalar_fields(), rf.referenced_fields())
-    } else {
-        (
-            rf.related_field().referenced_fields(),
-            rf.related_field().scalar_fields(),
-        )
-    };
-
-    // `rf` is always the relation field on the left model in the join (parent).
-    let left_table_alias = if rf.model().name != base_model.name {
-        Some(format!("{}_{}", join_prefix, &rf.model().name))
-    } else {
-        None
-    };
-
-    let right_table_alias = format!("{}_{}", join_prefix, &rf.related_model().name);
-
-    let related_model = rf.related_model();
-    let pairs = left_fields.into_iter().zip(right_fields.into_iter());
-
-    let on_conditions = pairs
-        .map(|(a, b)| {
-            let a_col = if let Some(alias) = left_table_alias.clone() {
-                Column::from((alias, a.db_name().to_owned()))
-            } else {
-                a.as_column()
-            };
-
-            let b_col = Column::from((right_table_alias.clone(), b.db_name().to_owned()));
-
-            a_col.equals(b_col)
-        })
-        .collect::<Vec<_>>();
-
-    OrderingJoin {
-        alias: right_table_alias.to_owned(),
-        data: related_model
-            .as_table()
-            .alias(right_table_alias)
-            .on(ConditionTree::single(on_conditions)),
-    }
-}
-
-fn compute_aggr_join(
-    order_by: &OrderBy,
-    rf: &RelationFieldRef,
-    join_alias: &str,
-    previous_join: Option<&OrderingJoin>,
-) -> OrderingJoin {
-    let join_alias = format!("{}_{}", join_alias, &rf.related_model().name);
-
-    if rf.relation().is_many_to_many() {
-        compute_aggr_join_m2m(order_by, rf, join_alias.as_str(), previous_join)
-    } else {
-        compute_aggr_join_one2m(order_by, rf, join_alias.as_str(), previous_join)
-    }
-}
-
-fn compute_aggr_join_one2m(
-    order_by: &OrderBy,
-    rf: &RelationFieldRef,
-    join_alias: &str,
-    previous_join: Option<&OrderingJoin>,
-) -> OrderingJoin {
-    let (left_fields, right_fields) = if rf.is_inlined_on_enclosing_model() {
-        (rf.scalar_fields(), rf.referenced_fields())
-    } else {
-        (
-            rf.related_field().referenced_fields(),
-            rf.related_field().scalar_fields(),
-        )
-    };
-    let select_columns = right_fields.iter().map(|f| f.as_column());
-
-    // + SELECT A.fk FROM A
-    let query = Select::from_table(rf.related_model().as_table()).columns(select_columns);
-    let aggr_expr = match order_by
-        .sort_aggregation
-        .expect("This function should be guaranteed to be passed a sort_aggregation")
-    {
-        SortAggregation::Count { _all } => count(asterisk()),
-    };
-
-    // SELECT A.fk,
-    // + COUNT(*) AS <ORDER_AGGREGATOR_ALIAS>
-    // FROM A
-    let query = query.value(aggr_expr.alias(ORDER_AGGREGATOR_ALIAS.to_owned()));
-
-    // SELECT A.<fk>, COUNT(*) AS <ORDER_AGGREGATOR_ALIAS> FROM A
-    // + GROUP BY A.<fk>
-    let query = right_fields.iter().fold(query, |acc, f| acc.group_by(f.as_column()));
-
-    let pairs = left_fields.into_iter().zip(right_fields.into_iter());
-    let on_conditions = pairs
-        .map(|(a, b)| {
-            let col_a = match previous_join {
-                Some(prev_join) => Column::from((prev_join.alias.to_owned(), a.db_name().to_owned())),
-                None => a.as_column(),
-            };
-            let col_b = Column::from((join_alias.to_owned(), b.db_name().to_owned()));
-
-            col_a.equals(col_b)
-        })
-        .collect::<Vec<_>>();
-
-    // + LEFT JOIN (
-    //     SELECT A.<fk>, COUNT(*) AS <ORDER_AGGREGATOR_ALIAS> FROM A
-    //     GROUP BY A.<fk>
-    // + ) AS <ORDER_JOIN_PREFIX> ON (<A | previous_join_alias>.<fk> = <ORDER_JOIN_PREFIX>.<fk>)
-    let join = Table::from(query)
-        .alias(join_alias.to_owned())
-        .on(ConditionTree::single(on_conditions));
-
-    OrderingJoin {
-        data: join,
-        alias: join_alias.to_owned(),
-    }
-}
-
-fn compute_aggr_join_m2m(
-    order_by: &OrderBy,
-    rf: &RelationFieldRef,
-    join_alias: &str,
-    previous_join: Option<&OrderingJoin>,
-) -> OrderingJoin {
-    let relation_table = rf.as_table();
-    let a_ids = rf.model().primary_identifier();
-    let b_ids = rf.related_model().primary_identifier();
-
-    // + SELECT A.id FROM _AtoB
-    let query = Select::from_table(relation_table).columns(a_ids.as_columns());
-
-    let aggr_expr = match order_by
-        .sort_aggregation
-        .expect("This function should be guaranteed to be passed a sort_aggregation")
-    {
-        SortAggregation::Count { _all } => count(asterisk()),
-    };
-    // SELECT A.id,
-    // + COUNT(*) AS <ORDER_AGGREGATOR_ALIAS>
-    // FROM _AtoB
-    let query = query.value(aggr_expr.alias(ORDER_AGGREGATOR_ALIAS.to_owned()));
-
-    let conditions_a: Vec<_> = a_ids
-        .as_columns()
-        .map(|c| c.equals(rf.related_field().m2m_columns()))
-        .collect();
-    let conditions_b: Vec<_> = b_ids.as_columns().map(|c| c.equals(rf.m2m_columns())).collect();
-
-    // SELECT A.id, COUNT(*) AS <ORDER_AGGREGATOR_ALIAS> FROM _AtoB
-    // + INNER JOIN A ON A.id = _AtoB.A
-    // + INNER JOIN B ON B.id = _AtoB.B
-    let query = query
-        .inner_join(rf.model().as_table().on(ConditionTree::single(conditions_a)))
-        .inner_join(rf.related_model().as_table().on(ConditionTree::single(conditions_b)));
-
-    // SELECT A.id, COUNT(*) AS <ORDER_AGGREGATOR_ALIAS> FROM _AtoB
-    // INNER JOIN A ON A.id = _AtoB.A
-    // INNER JOIN B ON B.id = _AtoB.B
-    // + GROUP BY A.id
-    let query = a_ids.as_columns().fold(query, |acc, f| acc.group_by(f.clone()));
-
-    let (left_fields, right_fields) = (a_ids.scalar_fields(), b_ids.scalar_fields());
-    let pairs = left_fields.zip(right_fields);
-    let on_conditions = pairs
-        .map(|(a, b)| {
-            let col_a = match previous_join {
-                Some(prev_join) => Column::from((prev_join.alias.to_owned(), a.db_name().to_owned())),
-                None => a.as_column(),
-            };
-            let col_b = Column::from((join_alias.to_owned(), b.db_name().to_owned()));
-
-            col_a.equals(col_b)
-        })
-        .collect::<Vec<_>>();
-
-    // + LEFT JOIN (
-    //     SELECT A.id, COUNT(*) AS <ORDER_AGGREGATOR_ALIAS> FROM _AtoB
-    //       INNER JOIN A ON (A.id = _AtoB.A)
-    //       INNER JOIN B ON (B.id = _AtoB.B)
-    //     GROUP BY A.id
-    // + ) AS <ORDER_JOIN_PREFIX> ON (<A | previous_join_alias >.id = <ORDER_JOIN_PREFIX>.id)
-    let join = Table::from(query)
-        .alias(join_alias.to_owned())
-        .on(ConditionTree::single(on_conditions));
-
-    OrderingJoin {
-        alias: join_alias.to_owned(),
-        data: join,
-    }
 }

--- a/query-engine/connectors/sql-query-connector/src/query_builder/read.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_builder/read.rs
@@ -1,36 +1,53 @@
-use crate::{cursor_condition, filter_conversion::AliasedCondition, ordering};
-use connector_interface::{filter::Filter, AggregationSelection, QueryArguments};
+use crate::{cursor_condition, filter_conversion::AliasedCondition, nested_aggregations, ordering};
+use connector_interface::{filter::Filter, AggregationSelection, QueryArguments, RelAggregationSelection};
 use itertools::Itertools;
 use prisma_models::*;
 use quaint::ast::*;
 
 pub trait SelectDefinition {
-    fn into_select(self, _: &ModelRef) -> Select<'static>;
+    fn into_select(
+        self,
+        _: &ModelRef,
+        aggr_selections: &[RelAggregationSelection],
+    ) -> (Select<'static>, Vec<Column<'static>>);
 }
 
 impl SelectDefinition for Filter {
-    fn into_select(self, model: &ModelRef) -> Select<'static> {
+    fn into_select(
+        self,
+        model: &ModelRef,
+        aggr_selections: &[RelAggregationSelection],
+    ) -> (Select<'static>, Vec<Column<'static>>) {
         let args = QueryArguments::from((model.clone(), self));
-        args.into_select(model)
+        args.into_select(model, aggr_selections)
     }
 }
 
 impl SelectDefinition for &Filter {
-    fn into_select(self, model: &ModelRef) -> Select<'static> {
-        self.clone().into_select(model)
+    fn into_select(
+        self,
+        model: &ModelRef,
+        aggr_selections: &[RelAggregationSelection],
+    ) -> (Select<'static>, Vec<Column<'static>>) {
+        self.clone().into_select(model, aggr_selections)
     }
 }
 
 impl SelectDefinition for Select<'static> {
-    fn into_select(self, _: &ModelRef) -> Select<'static> {
-        self
+    fn into_select(self, _: &ModelRef, _: &[RelAggregationSelection]) -> (Select<'static>, Vec<Column<'static>>) {
+        (self, vec![])
     }
 }
 
 impl SelectDefinition for QueryArguments {
-    fn into_select(self, model: &ModelRef) -> Select<'static> {
+    fn into_select(
+        self,
+        model: &ModelRef,
+        aggr_selections: &[RelAggregationSelection],
+    ) -> (Select<'static>, Vec<Column<'static>>) {
         let (orderings, ordering_joins) = ordering::build(&self, &model);
         let (table_opt, cursor_condition) = cursor_condition::build(&self, &model, &ordering_joins);
+        let aggregation_joins = nested_aggregations::build(aggr_selections);
 
         let limit = if self.ignore_take { None } else { self.take_abs() };
         let skip = if self.ignore_skip { 0 } else { self.skip.unwrap_or(0) };
@@ -46,10 +63,17 @@ impl SelectDefinition for QueryArguments {
             (filter, cursor) => ConditionTree::and(filter, cursor),
         };
 
+        // Add joins necessary to the ordering
         let joined_table = ordering_joins
             .into_iter()
             .flat_map(|j| j.joins)
             .fold(model.as_table(), |acc, join| acc.left_join(join.data));
+
+        // Add joins necessary to the nested aggregations
+        let joined_table = aggregation_joins
+            .joins
+            .into_iter()
+            .fold(joined_table, |acc, join| acc.left_join(join.data));
 
         let select_ast = Select::from_table(joined_table)
             .so_that(conditions)
@@ -64,17 +88,26 @@ impl SelectDefinition for QueryArguments {
         let select_ast = orderings.into_iter().fold(select_ast, |acc, ord| acc.order_by(ord));
 
         match limit {
-            Some(limit) => select_ast.limit(limit as usize),
-            None => select_ast,
+            Some(limit) => (select_ast.limit(limit as usize), aggregation_joins.columns),
+            None => (select_ast, aggregation_joins.columns),
         }
     }
 }
 
-pub fn get_records<T>(model: &ModelRef, columns: impl Iterator<Item = Column<'static>>, query: T) -> Select<'static>
+pub fn get_records<T>(
+    model: &ModelRef,
+    columns: impl Iterator<Item = Column<'static>>,
+    aggr_selections: &[RelAggregationSelection],
+    query: T,
+) -> Select<'static>
 where
     T: SelectDefinition,
 {
-    columns.fold(query.into_select(model), |acc, col| acc.column(col))
+    let (select, aggr_columns) = query.into_select(model, aggr_selections);
+    let select = columns.fold(select, |acc, col| acc.column(col));
+    let select_with_aggr_columns = aggr_columns.into_iter().fold(select, |acc, col| acc.column(col));
+
+    select_with_aggr_columns
 }
 
 /// Generates a query of the form:
@@ -105,42 +138,50 @@ where
 /// not absolute - e.g. `SELECT "field" FROM (...)` NOT `SELECT "full"."path"."to"."field" FROM (...)`.
 pub fn aggregate(model: &ModelRef, selections: &[AggregationSelection], args: QueryArguments) -> Select<'static> {
     let columns = extract_columns(model, &selections);
-    let sub_query = get_records(model, columns.into_iter(), args);
+    let sub_query = get_records(model, columns.into_iter(), &vec![], args);
     let sub_table = Table::from(sub_query).alias("sub");
 
+    select_aggregates(Select::from_table(sub_table), selections)
+}
+
+pub fn select_aggregates(select: Select<'static>, selections: &[AggregationSelection]) -> Select<'static> {
     selections
         .iter()
-        .fold(Select::from_table(sub_table), |select, next_op| match next_op {
-            AggregationSelection::Field(field) => select.column(Column::from(field.db_name().to_owned())),
+        .fold(select, |acc, next_op| select_aggregate(acc, next_op))
+}
 
-            AggregationSelection::Count { all, fields } => {
-                let select = fields.iter().fold(select, |select, next_field| {
-                    select.value(count(Column::from(next_field.db_name().to_owned())))
-                });
+pub fn select_aggregate(select: Select<'static>, selection: &AggregationSelection) -> Select<'static> {
+    match selection {
+        AggregationSelection::Field(field) => select.column(Column::from(field.db_name().to_owned())),
 
-                if *all {
-                    select.value(count(asterisk()))
-                } else {
-                    select
-                }
+        AggregationSelection::Count { all, fields } => {
+            let select = fields.iter().fold(select, |select, next_field| {
+                select.value(count(Column::from(next_field.db_name().to_owned())))
+            });
+
+            if *all {
+                select.value(count(asterisk()))
+            } else {
+                select
             }
+        }
 
-            AggregationSelection::Average(fields) => fields.iter().fold(select, |select, next_field| {
-                select.value(avg(Column::from(next_field.db_name().to_owned())))
-            }),
+        AggregationSelection::Average(fields) => fields.iter().fold(select, |select, next_field| {
+            select.value(avg(Column::from(next_field.db_name().to_owned())))
+        }),
 
-            AggregationSelection::Sum(fields) => fields.iter().fold(select, |select, next_field| {
-                select.value(sum(Column::from(next_field.db_name().to_owned())))
-            }),
+        AggregationSelection::Sum(fields) => fields.iter().fold(select, |select, next_field| {
+            select.value(sum(Column::from(next_field.db_name().to_owned())))
+        }),
 
-            AggregationSelection::Min(fields) => fields.iter().fold(select, |select, next_field| {
-                select.value(min(Column::from(next_field.db_name().to_owned())))
-            }),
+        AggregationSelection::Min(fields) => fields.iter().fold(select, |select, next_field| {
+            select.value(min(Column::from(next_field.db_name().to_owned())))
+        }),
 
-            AggregationSelection::Max(fields) => fields.iter().fold(select, |select, next_field| {
-                select.value(max(Column::from(next_field.db_name().to_owned())))
-            }),
-        })
+        AggregationSelection::Max(fields) => fields.iter().fold(select, |select, next_field| {
+            select.value(max(Column::from(next_field.db_name().to_owned())))
+        }),
+    }
 }
 
 pub fn group_by_aggregate(
@@ -150,7 +191,7 @@ pub fn group_by_aggregate(
     group_by: Vec<ScalarFieldRef>,
     having: Option<Filter>,
 ) -> Select<'static> {
-    let base_query: Select = args.into_select(model);
+    let (base_query, _) = args.into_select(model, &vec![]);
 
     let select_query = selections.iter().fold(base_query, |select, next_op| match next_op {
         AggregationSelection::Field(field) => select.column(field.as_column()),

--- a/query-engine/connectors/sql-query-connector/src/row.rs
+++ b/query-engine/connectors/sql-query-connector/src/row.rs
@@ -1,7 +1,7 @@
 use crate::{column_metadata::ColumnMetadata, error::SqlError};
 use bigdecimal::{BigDecimal, FromPrimitive};
 use chrono::{DateTime, NaiveDate, Utc};
-use connector_interface::{AggregationResult, AggregationSelection};
+use connector_interface::{coerce_null_to_zero_value, AggregationResult, AggregationSelection};
 use datamodel::FieldArity;
 use prisma_models::{PrismaValue, Record, TypeIdentifier};
 use quaint::{
@@ -79,14 +79,6 @@ impl SqlRow {
                     .collect(),
             })
             .collect()
-    }
-}
-
-fn coerce_null_to_zero_value(value: PrismaValue) -> PrismaValue {
-    if let PrismaValue::Null = value {
-        PrismaValue::Int(0)
-    } else {
-        value
     }
 }
 

--- a/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
@@ -54,13 +54,8 @@ pub async fn m2m<'a, 'b>(
             Some(existing_filter) => Some(Filter::and(vec![existing_filter, filter])),
             None => Some(filter),
         };
-        tx.get_many_records(
-            &query.parent_field.related_model(),
-            args,
-            &query.selected_fields,
-            &vec![],
-        )
-        .await?
+        tx.get_many_records(&query.parent_field.related_model(), args, &query.selected_fields, &[])
+            .await?
     };
 
     // Child id to parent ids
@@ -180,7 +175,7 @@ pub async fn one2m<'a, 'b>(
             Some(existing_filter) => Some(Filter::and(vec![existing_filter, filter])),
             None => Some(filter),
         };
-        tx.get_many_records(&parent_field.related_model(), args, selected_fields, &vec![])
+        tx.get_many_records(&parent_field.related_model(), args, selected_fields, &[])
             .await?
     };
 

--- a/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
@@ -54,8 +54,13 @@ pub async fn m2m<'a, 'b>(
             Some(existing_filter) => Some(Filter::and(vec![existing_filter, filter])),
             None => Some(filter),
         };
-        tx.get_many_records(&query.parent_field.related_model(), args, &query.selected_fields)
-            .await?
+        tx.get_many_records(
+            &query.parent_field.related_model(),
+            args,
+            &query.selected_fields,
+            &vec![],
+        )
+        .await?
     };
 
     // Child id to parent ids
@@ -175,7 +180,7 @@ pub async fn one2m<'a, 'b>(
             Some(existing_filter) => Some(Filter::and(vec![existing_filter, filter])),
             None => Some(filter),
         };
-        tx.get_many_records(&parent_field.related_model(), args, selected_fields)
+        tx.get_many_records(&parent_field.related_model(), args, selected_fields, &vec![])
             .await?
     };
 

--- a/query-engine/core/src/interpreter/query_interpreters/read.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/read.rs
@@ -211,7 +211,14 @@ fn process_nested<'a, 'b>(
     fut.boxed()
 }
 
-// TODO: Add comment explaining what this does
+/// Removes the relation aggregation data from the database result and collect it into some RelAggregationRow
+/// Explanation: Relation aggregations on a findMany are selected from an output object type. eg:
+/// findManyX { _count { rel_1, rel 2 } }
+/// Output object types are typically used for selecting relations, so they're are queried in a different request
+/// In the case of relation aggregations though, we query that data along side the request sent for the base model ("X" in the query above)
+/// This means the SQL result we get back from the database contains additional aggregation data that needs to be remapped according to the shema
+/// This function takes care of removing the aggregation data from the database result and collects it separately
+/// so that it can be serialized separately later according to the schema
 fn extract_aggr_results_from_scalars(
     mut scalars: ManyRecords,
     aggr_selections: Vec<RelAggregationSelection>,

--- a/query-engine/core/src/interpreter/query_interpreters/read.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/read.rs
@@ -220,8 +220,8 @@ fn extract_aggr_results_from_scalars(
         return (scalars, None);
     }
 
-    let aggr_field_names: HashMap<String, RelAggregationSelection> = aggr_selections
-        .into_iter()
+    let aggr_field_names: HashMap<String, &RelAggregationSelection> = aggr_selections
+        .iter()
         .map(|aggr_sel| (aggr_sel.db_alias(), aggr_sel))
         .collect();
     let indexes_to_remove: Vec<_> = scalars
@@ -230,7 +230,7 @@ fn extract_aggr_results_from_scalars(
         .enumerate()
         .filter_map(|(i, field_name)| {
             if let Some(aggr_sel) = aggr_field_names.get(field_name) {
-                Some((i, aggr_sel))
+                Some((i, *aggr_sel))
             } else {
                 None
             }
@@ -248,7 +248,7 @@ fn extract_aggr_results_from_scalars(
         // Remove and collect all aggr prisma values
         for (r_index, record) in scalars.records.iter_mut().enumerate() {
             let val = record.values.remove(index_to_remove);
-            let aggr_result = aggr_sel.into_result(val);
+            let aggr_result = aggr_sel.clone().into_result(val);
 
             // Group the aggregation results by record
             match aggregation_rows.get_mut(r_index) {

--- a/query-engine/core/src/interpreter/query_interpreters/read.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/read.rs
@@ -231,6 +231,7 @@ fn extract_aggr_results_from_scalars(
         .iter()
         .map(|aggr_sel| (aggr_sel.db_alias(), aggr_sel))
         .collect();
+
     let indexes_to_remove: Vec<_> = scalars
         .field_names
         .iter()
@@ -243,6 +244,7 @@ fn extract_aggr_results_from_scalars(
             }
         })
         .collect();
+
     let mut aggregation_rows: Vec<RelAggregationRow> = vec![];
     let mut n_record_removed = 0;
 

--- a/query-engine/core/src/query_ast/read.rs
+++ b/query-engine/core/src/query_ast/read.rs
@@ -1,6 +1,6 @@
 //! Prisma read query AST
 use super::FilteredQuery;
-use connector::{filter::Filter, AggregationSelection, QueryArguments};
+use connector::{filter::Filter, AggregationSelection, QueryArguments, RelAggregationSelection};
 use prisma_models::prelude::*;
 use std::fmt::Display;
 
@@ -112,6 +112,7 @@ pub struct ManyRecordsQuery {
     pub selected_fields: ModelProjection,
     pub nested: Vec<ReadQuery>,
     pub selection_order: Vec<String>,
+    pub aggregation_selections: Vec<RelAggregationSelection>,
 }
 
 #[derive(Debug, Clone)]

--- a/query-engine/core/src/query_graph/mod.rs
+++ b/query-engine/core/src/query_graph/mod.rs
@@ -735,6 +735,7 @@ impl QueryGraph {
                 selected_fields: ModelProjection::union(identifiers),
                 nested: vec![],
                 selection_order: vec![],
+                aggregation_selections: vec![],
             });
 
             let query = Query::Read(read_query);

--- a/query-engine/core/src/query_graph_builder/extractors/mod.rs
+++ b/query-engine/core/src/query_graph_builder/extractors/mod.rs
@@ -1,8 +1,10 @@
 mod filters;
 mod query_arguments;
+mod rel_aggregations;
 mod utils;
 
 pub use filters::*;
 pub use query_arguments::*;
+pub use rel_aggregations::*;
 
 use crate::query_document::*;

--- a/query-engine/core/src/query_graph_builder/extractors/rel_aggregations.rs
+++ b/query-engine/core/src/query_graph_builder/extractors/rel_aggregations.rs
@@ -1,0 +1,8 @@
+use super::*;
+use crate::constants::outputs;
+
+pub fn extract_nested_rel_aggr_selections(field_pairs: Vec<FieldPair>) -> (Vec<FieldPair>, Vec<FieldPair>) {
+    field_pairs
+        .into_iter()
+        .partition(|pair| pair.parsed_field.name == outputs::fields::UNDERSCORE_COUNT)
+}

--- a/query-engine/core/src/query_graph_builder/read/many.rs
+++ b/query-engine/core/src/query_graph_builder/read/many.rs
@@ -7,6 +7,8 @@ pub fn find_many(field: ParsedField, model: ModelRef) -> QueryGraphBuilderResult
     let name = field.name;
     let alias = field.alias;
     let nested_fields = field.nested_fields.unwrap().fields;
+    let (aggr_fields_pairs, nested_fields) = extractors::extract_nested_rel_aggr_selections(nested_fields);
+    let aggr_selections: Vec<_> = utils::collect_relation_aggr_selections(&aggr_fields_pairs, &model);
     let selection_order: Vec<String> = utils::collect_selection_order(&nested_fields);
     let selected_fields = utils::collect_selected_fields(&nested_fields, &model);
     let nested = utils::collect_nested_queries(nested_fields, &model)?;
@@ -23,5 +25,6 @@ pub fn find_many(field: ParsedField, model: ModelRef) -> QueryGraphBuilderResult
         selected_fields,
         nested,
         selection_order,
+        aggregation_selections: aggr_selections,
     }))
 }

--- a/query-engine/core/src/query_graph_builder/write/utils.rs
+++ b/query-engine/core/src/query_graph_builder/write/utils.rs
@@ -41,6 +41,7 @@ where
         selected_fields,
         nested: vec![],
         selection_order: vec![],
+        aggregation_selections: vec![],
     });
 
     Query::Read(read_query)

--- a/query-engine/core/src/response_ir/internal.rs
+++ b/query-engine/core/src/response_ir/internal.rs
@@ -42,7 +42,7 @@ pub fn serialize_internal(
     match result {
         QueryResult::RecordSelection(rs) => {
             if let Some(aggr_rows) = &rs.aggregation_rows {
-                let serialized_aggrs = serialize_rel_aggregations(field, aggr_rows)?;
+                let serialized_aggrs = serialize_rel_aggregations(aggr_rows)?;
                 let mut serialized_rs = serialize_record_selection(*rs, field, &field.field_type, is_list)?;
 
                 let (_, aggr_item) = serialized_aggrs.first().unwrap();
@@ -171,13 +171,10 @@ fn serialize_aggregations(
     Ok(envelope)
 }
 
-fn serialize_rel_aggregations(
-    _output_field: &OutputFieldRef,
-    rel_aggregations: &[RelAggregationRow],
-) -> crate::Result<CheckedItemsWithParents> {
+fn serialize_rel_aggregations(aggregation_rows: &[RelAggregationRow]) -> crate::Result<CheckedItemsWithParents> {
     let mut results = vec![];
 
-    for row in rel_aggregations.into_iter() {
+    for row in aggregation_rows.into_iter() {
         let mut map: Map = IndexMap::with_capacity(row.len());
 
         for result in row {

--- a/query-engine/core/src/response_ir/internal.rs
+++ b/query-engine/core/src/response_ir/internal.rs
@@ -5,7 +5,7 @@ use crate::{
     CoreError, DatabaseEnumType, EnumType, OutputFieldRef, QueryResult, RecordAggregations, RecordSelection,
 };
 use bigdecimal::ToPrimitive;
-use connector::AggregationResult;
+use connector::{AggregationResult, RelAggregationResult, RelAggregationRow};
 use indexmap::IndexMap;
 use prisma_models::{PrismaValue, RecordProjection};
 use std::{borrow::Borrow, collections::HashMap};
@@ -40,9 +40,23 @@ pub fn serialize_internal(
     is_list: bool,
 ) -> crate::Result<CheckedItemsWithParents> {
     match result {
-        QueryResult::RecordSelection(rs) => serialize_record_selection(*rs, field, &field.field_type, is_list),
-        QueryResult::RecordAggregations(ras) => serialize_aggregations(field, ras),
+        QueryResult::RecordSelection(rs) => {
+            if let Some(aggr_rows) = &rs.aggregation_rows {
+                let serialized_aggrs = serialize_rel_aggregations(field, aggr_rows)?;
+                let mut serialized_rs = serialize_record_selection(*rs, field, &field.field_type, is_list)?;
 
+                let (_, aggr_item) = serialized_aggrs.first().unwrap();
+
+                for (_, rs_item) in serialized_rs.iter_mut() {
+                    *rs_item = rs_item.clone().merge(&aggr_item);
+                }
+
+                Ok(serialized_rs)
+            } else {
+                serialize_record_selection(*rs, field, &field.field_type, is_list)
+            }
+        }
+        QueryResult::RecordAggregations(ras) => serialize_aggregations(field, ras),
         QueryResult::Count(c) => {
             // Todo needs a real implementation or needs to move to RecordAggregation
             let mut map: Map = IndexMap::with_capacity(1);
@@ -153,6 +167,40 @@ fn serialize_aggregations(
         }
         _ => unreachable!(),
     };
+
+    Ok(envelope)
+}
+
+fn serialize_rel_aggregations(
+    _output_field: &OutputFieldRef,
+    rel_aggregations: &[RelAggregationRow],
+) -> crate::Result<CheckedItemsWithParents> {
+    let mut results = vec![];
+
+    for row in rel_aggregations.into_iter() {
+        let mut map: Map = IndexMap::with_capacity(row.len());
+
+        for result in row {
+            match result {
+                RelAggregationResult::Count(rf, count) => match map.get_mut(fields::UNDERSCORE_COUNT) {
+                    Some(item) => match item {
+                        Item::Map(inner_map) => inner_map.insert(rf.name.clone(), Item::Value(count.clone())),
+                        _ => unreachable!(),
+                    },
+                    None => {
+                        let mut inner_map: Map = Map::new();
+                        inner_map.insert(rf.name.clone(), Item::Value(count.clone()));
+                        map.insert(fields::UNDERSCORE_COUNT.to_owned(), Item::Map(inner_map))
+                    }
+                },
+            };
+        }
+
+        results.push(Item::Map(map));
+    }
+
+    let mut envelope = CheckedItemsWithParents::new();
+    envelope.insert(None, Item::List(results.into()));
 
     Ok(envelope)
 }

--- a/query-engine/core/src/response_ir/mod.rs
+++ b/query-engine/core/src/response_ir/mod.rs
@@ -144,6 +144,49 @@ impl Item {
             _ => None,
         }
     }
+
+    pub fn merge(self, other: &Item) -> Item {
+        fn internal_merge(mut a: Item, b: &Item) -> Item {
+            match a {
+                Item::Map(ref mut map_a) => match b {
+                    Item::Map(map_b) => {
+                        for b_entry in map_b.into_iter() {
+                            map_a.insert(b_entry.0.clone(), b_entry.1.clone());
+                        }
+                    }
+                    Item::Ref(inner_b) => {
+                        a = internal_merge(a, &**inner_b);
+                    }
+                    Item::List(_) | Item::Value(_) | Item::Json(_) => panic!("Unexpected types couldn't be merged"),
+                },
+                Item::List(ref mut list_a) => match b {
+                    Item::List(list_b) => {
+                        for (i, item_a) in list_a.inner.iter_mut().enumerate() {
+                            if let Some(item_b) = list_b.inner.get(i) {
+                                *item_a = internal_merge(item_a.clone(), item_b);
+                            }
+                        }
+                    }
+                    Item::Ref(inner_b) => {
+                        a = internal_merge(a, &**inner_b);
+                    }
+                    Item::Map(_) | Item::Value(_) | Item::Json(_) => panic!("Unexpected types couldn't be merged"),
+                },
+                Item::Ref(ref mut inner) => {
+                    let inner_ref = &**inner;
+                    let merged: Item = internal_merge(inner_ref.clone(), b);
+
+                    *inner = Arc::new(merged.clone());
+                }
+                Item::Value(_) => panic!("Values cannot be merged"),
+                Item::Json(_) => panic!("Json cannot be merged"),
+            }
+
+            a
+        }
+
+        internal_merge(self, other)
+    }
 }
 
 impl Serialize for Item {

--- a/query-engine/core/src/result_ast/mod.rs
+++ b/query-engine/core/src/result_ast/mod.rs
@@ -1,4 +1,4 @@
-use connector::{AggregationRow, QueryArguments};
+use connector::{AggregationRow, QueryArguments, RelAggregationRow};
 use prisma_models::{ManyRecords, ModelProjection, RecordProjection};
 
 #[derive(Debug, Clone)]
@@ -32,6 +32,9 @@ pub struct RecordSelection {
 
     /// Model projection that can be used to retrieve the IDs of the contained records.
     pub model_id: ModelProjection,
+
+    /// Aggregation selections results
+    pub aggregation_rows: Option<Vec<RelAggregationRow>>,
 }
 
 impl From<RecordSelection> for QueryResult {

--- a/query-engine/core/src/schema_builder/constants.rs
+++ b/query-engine/core/src/schema_builder/constants.rs
@@ -119,5 +119,8 @@ pub mod outputs {
         pub const MIN: &str = "min";
         pub const MAX: &str = "max";
         pub const SUM: &str = "sum";
+
+        // aggregation findMany fields
+        pub const UNDERSCORE_COUNT: &str = "_count";
     }
 }

--- a/query-engine/core/src/schema_builder/output_types/output_objects.rs
+++ b/query-engine/core/src/schema_builder/output_types/output_objects.rs
@@ -203,11 +203,9 @@ where
     let ident = Identifier::new(format!("{}CountOutputType", capitalize(&model.name)), PRISMA_NAMESPACE);
     return_cached_output!(ctx, &ident);
 
-    // Non-numerical fields are always set as nullable
-    // This is because when there's no data, doing aggregation on them will return NULL
     let fields: Vec<OutputField> = fields
         .iter()
-        .map(|sf| field(sf.name.clone(), vec![], type_mapper(ctx, sf), None))
+        .map(|rf| field(rf.name.clone(), vec![], type_mapper(ctx, rf), None))
         .collect();
 
     let object = object_mapper(object_type(ident.clone(), fields, None));

--- a/query-engine/core/src/schema_builder/output_types/output_objects.rs
+++ b/query-engine/core/src/schema_builder/output_types/output_objects.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::convert::identity;
 
 use crate::constants::outputs::fields;
 use prisma_models::ScalarFieldRef;
@@ -16,7 +17,12 @@ pub(crate) fn initialize_model_object_type_cache(ctx: &mut BuilderContext) {
         .into_iter()
         .for_each(|model| {
             let ident = Identifier::new(model.name.clone(), MODEL_NAMESPACE);
-            ctx.cache_output_type(ident.clone(), Arc::new(ObjectType::new(ident, Some(model))))
+            let ident_with_aggr = Identifier::new(format!("{}WithAggregations", model.name.clone()), PRISMA_NAMESPACE);
+            ctx.cache_output_type(ident.clone(), Arc::new(ObjectType::new(ident, Some(model.clone()))));
+            ctx.cache_output_type(
+                ident_with_aggr.clone(),
+                Arc::new(ObjectType::new(ident_with_aggr, Some(model))),
+            );
         });
 
     // Compute fields on all cached object types.
@@ -29,6 +35,22 @@ pub(crate) fn initialize_model_object_type_cache(ctx: &mut BuilderContext) {
             let fields = compute_model_object_type_fields(ctx, &model);
 
             obj.into_arc().set_fields(fields);
+
+            let obj_with_aggr: ObjectTypeWeakRef = output_objects::map_model_object_type_with_aggregations(ctx, &model);
+            let mut fields_with_aggr = compute_model_object_type_fields(ctx, &model);
+
+            append_opt(
+                &mut fields_with_aggr,
+                aggregation_relation_field(
+                    ctx,
+                    fields::UNDERSCORE_COUNT,
+                    &model,
+                    model.fields().relation(),
+                    |_, _| OutputType::int(),
+                    identity,
+                ),
+            );
+            obj_with_aggr.into_arc().set_fields(fields_with_aggr);
         });
 }
 
@@ -47,6 +69,14 @@ fn compute_model_object_type_fields(ctx: &mut BuilderContext, model: &ModelRef) 
 /// Relies on the output type cache being initalized.
 pub(crate) fn map_model_object_type(ctx: &mut BuilderContext, model: &ModelRef) -> ObjectTypeWeakRef {
     let ident = Identifier::new(model.name.clone(), MODEL_NAMESPACE);
+    ctx.get_output_type(&ident)
+        .expect("Invariant violation: Initialized output object type for each model.")
+}
+
+/// Returns an output object type with nested aggregations for the given model.
+/// Relies on the output type cache being initalized.
+pub(crate) fn map_model_object_type_with_aggregations(ctx: &mut BuilderContext, model: &ModelRef) -> ObjectTypeWeakRef {
+    let ident = Identifier::new(format!("{}WithAggregations", model.name.clone()), PRISMA_NAMESPACE);
     ctx.get_output_type(&ident)
         .expect("Invariant violation: Initialized output object type for each model.")
 }
@@ -96,10 +126,10 @@ pub(crate) fn map_scalar_output_type(ctx: &mut BuilderContext, typ: &TypeIdentif
     }
 }
 
-pub(crate) fn map_relation_output_type(ctx: &mut BuilderContext, field: &RelationFieldRef) -> OutputType {
-    let related_model_obj = OutputType::object(map_model_object_type(ctx, &field.related_model()));
+pub(crate) fn map_relation_output_type(ctx: &mut BuilderContext, rf: &RelationFieldRef) -> OutputType {
+    let related_model_obj = OutputType::object(map_model_object_type(ctx, &rf.related_model()));
 
-    if field.is_list {
+    if rf.is_list {
         OutputType::list(related_model_obj)
     } else {
         related_model_obj
@@ -127,4 +157,63 @@ pub(crate) fn affected_records_object_type(ctx: &mut BuilderContext) -> ObjectTy
 
     ctx.cache_output_type(ident, object_type.clone());
     Arc::downgrade(&object_type)
+}
+
+/// Returns an aggregation field with given name if the passed fields contains any fields.
+/// Field types inside the object type of the field are determined by the passed mapper fn.
+pub(crate) fn aggregation_relation_field<F, G>(
+    ctx: &mut BuilderContext,
+    name: &str,
+    model: &ModelRef,
+    fields: Vec<RelationFieldRef>,
+    type_mapper: F,
+    object_mapper: G,
+) -> Option<OutputField>
+where
+    F: Fn(&mut BuilderContext, &RelationFieldRef) -> OutputType,
+    G: Fn(ObjectType) -> ObjectType,
+{
+    if fields.is_empty() {
+        None
+    } else {
+        let object_type = OutputType::object(map_field_aggration_relation(
+            ctx,
+            model,
+            &fields,
+            type_mapper,
+            object_mapper,
+        ));
+
+        Some(field(name, vec![], object_type, None).nullable())
+    }
+}
+
+/// Maps the object type for aggregations that operate on a field level.
+fn map_field_aggration_relation<F, G>(
+    ctx: &mut BuilderContext,
+    model: &ModelRef,
+    fields: &[RelationFieldRef],
+    type_mapper: F,
+    object_mapper: G,
+) -> ObjectTypeWeakRef
+where
+    F: Fn(&mut BuilderContext, &RelationFieldRef) -> OutputType,
+    G: Fn(ObjectType) -> ObjectType,
+{
+    let ident = Identifier::new(format!("{}CountOutputType", capitalize(&model.name)), PRISMA_NAMESPACE);
+    return_cached_output!(ctx, &ident);
+
+    // Non-numerical fields are always set as nullable
+    // This is because when there's no data, doing aggregation on them will return NULL
+    let fields: Vec<OutputField> = fields
+        .iter()
+        .map(|sf| field(sf.name.clone(), vec![], type_mapper(ctx, sf), None))
+        .collect();
+
+    let object = object_mapper(object_type(ident.clone(), fields, None));
+    let object = Arc::new(object);
+
+    ctx.cache_output_type(ident, object.clone());
+
+    Arc::downgrade(&object)
 }

--- a/query-engine/core/src/schema_builder/output_types/query_type.rs
+++ b/query-engine/core/src/schema_builder/output_types/query_type.rs
@@ -72,7 +72,9 @@ fn all_items_field(ctx: &mut BuilderContext, model: &ModelRef) -> OutputField {
     field(
         field_name,
         args,
-        OutputType::list(OutputType::object(output_objects::map_model_object_type(ctx, &model))),
+        OutputType::list(OutputType::object(
+            output_objects::map_model_object_type_with_aggregations(ctx, &model),
+        )),
         Some(QueryInfo {
             model: Some(Arc::clone(&model)),
             tag: QueryTag::FindMany,


### PR DESCRIPTION
Partially closes https://github.com/prisma/prisma/issues/5079 (filters aren't implemented yet)

## Overview

Given this datamodel

```prisma
model Post {
  id         Int        @id
  title      String
  comments   Comment[]
  categories Category[]
}

model Comment {
  id      Int     @id
  comment String
  is_spam Boolean
  post    Post    @relation(fields: [postId], references: [id])
  postId  Int
}

model Category {
  id    Int    @id @default(autoincrement())
  name  String
  posts Post[]
}

```

This adds the following fields to `findMany`:

```graphql
{
  findManyPost {
    _count {
      comments # one2m
      categories # m2m
    }
  }
}
```

It is **_not_** yet possible to filter with _count.

## TODO:

- [x] add tests