### PR TITLE
Merge model types, accept runtime errors for select aggregates

### DIFF
--- a/libs/datamodel/connectors/mongodb-datamodel-connector/src/mongodb_types.rs
+++ b/libs/datamodel/connectors/mongodb-datamodel-connector/src/mongodb_types.rs
@@ -116,5 +116,5 @@ fn parse_array_type(args: &[String]) -> crate::Result<MongoDbType> {
     let type_arg = args.iter().next().unwrap();
     let inner_type = mongo_type_from_input(type_arg.as_str(), &[])?;
 
-    Ok(dbg!(MongoDbType::Array(Box::new(inner_type))))
+    Ok(MongoDbType::Array(Box::new(inner_type)))
 }

--- a/libs/datamodel/core/src/common/preview_features.rs
+++ b/libs/datamodel/core/src/common/preview_features.rs
@@ -10,6 +10,7 @@ const GROUP_BY: &str = "groupBy";
 const CREATE_MANY: &str = "createMany";
 const ORDER_BY_RELATION: &str = "orderByRelation";
 const NAPI: &str = "napi";
+const SELECT_RELATION_COUNT: &str = "selectRelationCount";
 
 // deprecated preview features
 const ATOMIC_NUMBER_OPERATIONS: &str = "atomicNumberOperations";
@@ -20,7 +21,14 @@ const UNCHECKED_SCALAR_INPUTS: &str = "uncheckedScalarInputs";
 
 pub const DATASOURCE_PREVIEW_FEATURES: &[&str] = &[];
 
-pub const GENERATOR_PREVIEW_FEATURES: &[&str] = &[SQL_SERVER, GROUP_BY, CREATE_MANY, ORDER_BY_RELATION, NAPI];
+pub const GENERATOR_PREVIEW_FEATURES: &[&str] = &[
+    SQL_SERVER,
+    GROUP_BY,
+    CREATE_MANY,
+    ORDER_BY_RELATION,
+    NAPI,
+    SELECT_RELATION_COUNT,
+];
 
 pub const DEPRECATED_GENERATOR_PREVIEW_FEATURES: &[&str] = &[
     ATOMIC_NUMBER_OPERATIONS,

--- a/query-engine/core/src/query_graph_builder/read/one.rs
+++ b/query-engine/core/src/query_graph_builder/read/one.rs
@@ -17,6 +17,14 @@ pub fn find_unique(mut field: ParsedField, model: ModelRef) -> QueryGraphBuilder
     let alias = field.alias;
     let model = model;
     let nested_fields = field.nested_fields.unwrap().fields;
+    let (aggr_fields_pairs, nested_fields) = extractors::extract_nested_rel_aggr_selections(nested_fields);
+
+    if !aggr_fields_pairs.is_empty() {
+        return Err(QueryGraphBuilderError::InputError(
+            "Aggregation selections are not yet implemented for findUnique queries.".to_owned(),
+        ));
+    }
+
     let selection_order: Vec<String> = utils::collect_selection_order(&nested_fields);
     let selected_fields = utils::collect_selected_fields(&nested_fields, &model);
     let nested = utils::collect_nested_queries(nested_fields, &model)?;

--- a/query-engine/core/src/schema_builder/output_types/output_objects.rs
+++ b/query-engine/core/src/schema_builder/output_types/output_objects.rs
@@ -16,7 +16,7 @@ pub(crate) fn initialize_model_object_type_cache(ctx: &mut BuilderContext) {
         .to_owned()
         .into_iter()
         .for_each(|model| {
-            let ident = Identifier::new(model.name.clone(), MODEL_NAMESPACE);            
+            let ident = Identifier::new(model.name.clone(), MODEL_NAMESPACE);
             ctx.cache_output_type(ident.clone(), Arc::new(ObjectType::new(ident, Some(model.clone()))));
         });
 

--- a/query-engine/core/src/schema_builder/output_types/query_type.rs
+++ b/query-engine/core/src/schema_builder/output_types/query_type.rs
@@ -68,12 +68,7 @@ fn find_first_field(ctx: &mut BuilderContext, model: &ModelRef) -> OutputField {
 fn all_items_field(ctx: &mut BuilderContext, model: &ModelRef) -> OutputField {
     let args = arguments::many_records_arguments(ctx, &model, true);
     let field_name = ctx.pluralize_internal(camel_case(pluralize(&model.name)), format!("findMany{}", model.name));
-
-    let object_type = if feature_flags::get().selectRelationCount {
-        output_objects::map_model_object_type_with_aggregations(ctx, &model)
-    } else {
-        output_objects::map_model_object_type(ctx, &model)
-    };
+    let object_type = output_objects::map_model_object_type(ctx, &model);
 
     field(
         field_name,


### PR DESCRIPTION
Expands the current (i.e. stable) model type instead of splitting model types into `<Model>WithAggregates` (new) and `<Model>` (current). The tradeoff is that `findUnique<Model>` will show `_count` if there's a to-one relation present on the model and the feature flag is enabled, but will fail at runtime with a comprehensible error.