### PR TITLE
Handle panic messages correctly, so they are displayed in the resulting error.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2402,9 +2402,9 @@ dependencies = [
 
 [[package]]
 name = "napi"
-version = "1.2.0"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddaa8cda32a9c91ee2fda0c540f553c8cdac5203ce5ed8ef8dbb316d204e3ad"
+checksum = "5e1981522b098db959ffc2e93908bc4d789b515b4fef3d1c0ceb771e68e19e4d"
 dependencies = [
  "futures 0.3.13",
  "napi-build",
@@ -3692,7 +3692,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0bccbcf40c8938196944a3da0e133e031a33f4d6b72db3bda3cc556e361905d"
 dependencies = [
  "lazy_static",
- "parking_lot 0.10.2",
+ "parking_lot 0.11.1",
  "serial_test_derive",
 ]
 

--- a/migration-engine/cli/src/commands.rs
+++ b/migration-engine/cli/src/commands.rs
@@ -37,11 +37,8 @@ impl Cli {
                 std::process::exit(exit_code)
             }
             Err(panic) => {
-                serde_json::to_writer(
-                    std::io::stdout(),
-                    &user_facing_errors::Error::from_panic_payload(panic.as_ref()),
-                )
-                .expect("failed to write to stdout");
+                serde_json::to_writer(std::io::stdout(), &user_facing_errors::Error::from_panic_payload(panic))
+                    .expect("failed to write to stdout");
                 println!();
                 std::process::exit(255);
             }

--- a/query-engine/query-engine/src/server/mod.rs
+++ b/query-engine/query-engine/src/server/mod.rs
@@ -159,7 +159,7 @@ async fn handle_debug_headers(req: &Request<State>) -> tide::Result<Option<impl 
         info!("Query engine debug fatal error, shutting down.");
         std::process::exit(1)
     } else if req.header(DEBUG_NON_FATAL_HEADER).is_some() {
-        let err = user_facing_errors::Error::from_panic_payload(&String::from("Debug panic"));
+        let err = user_facing_errors::Error::from_panic_payload(Box::new("Debug panic"));
         let mut res = Response::new(200);
         res.set_body(Body::from_json(&err)?);
         Ok(Some(res))

--- a/query-engine/request-handlers/src/graphql/handler.rs
+++ b/query-engine/request-handlers/src/graphql/handler.rs
@@ -39,7 +39,7 @@ impl<'a> GraphQlHandler<'a> {
             Ok(Err(err)) => err.into(),
             Err(err) => {
                 // panicked
-                let error = Error::from_panic_payload(&err);
+                let error = Error::from_panic_payload(err);
                 error.into()
             }
         };
@@ -71,7 +71,7 @@ impl<'a> GraphQlHandler<'a> {
             Ok(Err(err)) => PrismaResponse::Multi(err.into()),
             Err(err) => {
                 // panicked
-                let error = Error::from_panic_payload(&err);
+                let error = Error::from_panic_payload(err);
                 let resp: GQLBatchResponse = error.into();
 
                 PrismaResponse::Multi(resp)
@@ -140,7 +140,7 @@ impl<'a> GraphQlHandler<'a> {
 
             // panicked
             Err(err) => {
-                let error = Error::from_panic_payload(&err);
+                let error = Error::from_panic_payload(err);
                 PrismaResponse::Multi(error.into())
             }
         }


### PR DESCRIPTION
For some mysterious reason, we can't downcast a dynamic type to an error message, if the trait object is not owned. Therefore sending a `Box<dyn Any>` works, but `&(dyn Any)` not.

Part of https://github.com/prisma/prisma-engines/issues/1627
