### PR TITLE
Make `definition` optional in Procedure

### DIFF
--- a/libs/sql-schema-describer/src/lib.rs
+++ b/libs/sql-schema-describer/src/lib.rs
@@ -236,7 +236,7 @@ pub struct Procedure {
     /// Procedure name.
     pub name: String,
     /// The definition of the procedure.
-    pub definition: String,
+    pub definition: Option<String>,
 }
 
 /// The primary key of a table.

--- a/libs/sql-schema-describer/src/mssql.rs
+++ b/libs/sql-schema-describer/src/mssql.rs
@@ -148,7 +148,7 @@ impl SqlSchemaDescriber {
         for row in rows.into_iter() {
             procedures.push(Procedure {
                 name: row.get_expect_string("name"),
-                definition: row.get_expect_string("definition"),
+                definition: row.get_string("definition"),
             });
         }
 

--- a/libs/sql-schema-describer/src/mysql.rs
+++ b/libs/sql-schema-describer/src/mysql.rs
@@ -151,7 +151,7 @@ impl SqlSchemaDescriber {
         for row in rows.into_iter() {
             procedures.push(Procedure {
                 name: row.get_expect_string("name"),
-                definition: row.get_expect_string("definition"),
+                definition: row.get_string("definition"),
             });
         }
 

--- a/libs/sql-schema-describer/src/postgres.rs
+++ b/libs/sql-schema-describer/src/postgres.rs
@@ -116,7 +116,7 @@ impl SqlSchemaDescriber {
         for row in rows.into_iter() {
             procedures.push(Procedure {
                 name: row.get_expect_string("name"),
-                definition: row.get_expect_string("definition"),
+                definition: row.get_string("definition"),
             });
         }
 

--- a/libs/sql-schema-describer/tests/mssql_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/mssql_describer_tests.rs
@@ -63,7 +63,7 @@ async fn procedures_can_be_described() {
     let procedure = result.get_procedure("foo").unwrap();
 
     assert_eq!("foo", &procedure.name);
-    assert_eq!(sql, procedure.definition);
+    assert_eq!(Some(sql), procedure.definition);
 }
 
 #[tokio::test]

--- a/libs/sql-schema-describer/tests/mysql_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/mysql_describer_tests.rs
@@ -68,7 +68,7 @@ async fn procedures_can_be_described() {
     let procedure = result.get_procedure("foo").unwrap();
 
     assert_eq!("foo", &procedure.name);
-    assert_eq!("SELECT 1 INTO res", &procedure.definition);
+    assert_eq!(Some("SELECT 1 INTO res"), procedure.definition.as_deref());
 }
 
 #[tokio::test]


### PR DESCRIPTION
closes https://github.com/prisma/prisma/issues/6134