### PR TITLE
fix: findUnique batch with date arguments

### DIFF
--- a/libs/prisma-value/src/lib.rs
+++ b/libs/prisma-value/src/lib.rs
@@ -42,7 +42,13 @@ pub enum PrismaValue {
     Bytes(Vec<u8>),
 }
 
+/// Stringify a date to the following shape
+/// 1999-05-01T00:00:00.000Z
 pub fn stringify_date(date: &DateTime<FixedOffset>) -> String {
+    // Warning: Be careful if you plan on changing the code below
+    // The findUnique batch optimization expects date inputs to have exactly the same format as date outputs
+    // This works today because clients always send date inputs in the same format as the serialized format below
+    // Updating this without transforming date inputs to the same format WILL break the findUnique batch optimization
     date.to_rfc3339_opts(SecondsFormat::Millis, true)
 }
 

--- a/libs/prisma-value/src/lib.rs
+++ b/libs/prisma-value/src/lib.rs
@@ -42,7 +42,7 @@ pub enum PrismaValue {
     Bytes(Vec<u8>),
 }
 
-/// Stringify a date to the following shape
+/// Stringify a date to the following format
 /// 1999-05-01T00:00:00.000Z
 pub fn stringify_date(date: &DateTime<FixedOffset>) -> String {
     // Warning: Be careful if you plan on changing the code below

--- a/libs/prisma-value/src/lib.rs
+++ b/libs/prisma-value/src/lib.rs
@@ -43,7 +43,7 @@ pub enum PrismaValue {
 }
 
 pub fn stringify_date(date: &DateTime<FixedOffset>) -> String {
-    date.to_rfc3339()
+    date.to_rfc3339_opts(SecondsFormat::Millis, true)
 }
 
 pub fn encode_bytes(bytes: &[u8]) -> String {

--- a/query-engine/connector-test-kit/src/test/scala/queries/batch/SelectOneCompoundIdBatchSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/batch/SelectOneCompoundIdBatchSpec.scala
@@ -107,6 +107,7 @@ class SelectOneCompoundIdBatchSpec extends FlatSpec with Matchers with ApiSpecBa
     )
   }
 
+  // https://github.com/prisma/prisma/issues/5941
   "input dates in two queries" should "not return nulls" in {
     val project = ProjectDsl.fromString {
       """model Artist {

--- a/query-engine/connector-test-kit/src/test/scala/queries/batch/SelectOneCompoundIdBatchSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/batch/SelectOneCompoundIdBatchSpec.scala
@@ -106,4 +106,37 @@ class SelectOneCompoundIdBatchSpec extends FlatSpec with Matchers with ApiSpecBa
       """{"batchResult":[{"data":{"findUniqueArtist":{"firstName":"Musti","lastName":"Naukio"}}},{"data":{"findUniqueArtist":null}}]}"""
     )
   }
+
+  "input dates in two queries" should "not return nulls" in {
+    val project = ProjectDsl.fromString {
+      """model Artist {
+        |  firstName String
+        |  lastName  String
+        |  birth     DateTime
+        |
+        |  @@unique([firstName, lastName, birth])
+        |}
+        |"""
+    }
+
+    database.setup(project)
+
+    server.query(
+      """mutation artists {createArtist(data:{
+        |                         firstName: "Sponge"
+        |                         lastName: "Bob"
+        |                         birth: "1999-05-01T00:00:00.000Z"
+        |        |}){firstName lastName birth}}""".stripMargin,
+      project = project
+    )
+
+    val queries = Seq(
+      """query {findUniqueArtist(where:{firstName_lastName_birth:{firstName:"Sponge",lastName:"Bob", birth: "1999-05-01T00:00:00.000Z"}}) {firstName lastName birth}}""",
+      """query {findUniqueArtist(where:{firstName_lastName_birth:{firstName:"Sponge",lastName:"Bob", birth: "1999-05-01T00:00:00.000Z"}}) {firstName lastName birth}}""",
+    )
+
+    server.batch(queries, transaction = false, project, legacy = false).toString should be(
+      """{"batchResult":[{"data":{"findUniqueArtist":{"firstName":"Sponge","lastName":"Bob","birth":"1999-05-01T00:00:00.000Z"}}},{"data":{"findUniqueArtist":{"firstName":"Sponge","lastName":"Bob","birth":"1999-05-01T00:00:00.000Z"}}}]}"""
+    )
+  }
 }

--- a/query-engine/connector-test-kit/src/test/scala/queries/filters/ListFilterSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/filters/ListFilterSpec.scala
@@ -41,7 +41,7 @@ class ListFilterSpec extends FlatSpec with Matchers with ApiSpecBase with Connec
     query("floatList", "equals", """[1.1, 2.2, 3.3]""", Some(1))
     query("bIntList", "equals", """["100", "200", "300"]""", Some(1))
     query("decList", "equals", """["11.11", "22.22", "33.33"]""", Some(1))
-    query("dtList", "equals", """["1969-01-01T10:33:59+00:00", "2018-12-05T12:34:23+00:00"]""", Some(1))
+    query("dtList", "equals", """["1969-01-01T10:33:59.000Z", "2018-12-05T12:34:23.000Z"]""", Some(1))
     query("boolList", "equals", """[true]""", Some(1))
     query("jsonList", "equals", """["{}", "{\"int\":5}", "[1, 2, 3]"]""", Some(1))
     query("bytesList", "equals", """["dGVzdA==", "dA=="]""", Some(1))
@@ -54,7 +54,7 @@ class ListFilterSpec extends FlatSpec with Matchers with ApiSpecBase with Connec
     query("floatList", "has", """1.1""", Some(1))
     query("bIntList", "has", """"200"""", Some(1))
     query("decList", "has", """33.33""", Some(1))
-    query("dtList", "has", """"2018-12-05T12:34:23+00:00"""", Some(1))
+    query("dtList", "has", """"2018-12-05T12:34:23.000Z"""", Some(1))
     query("boolList", "has", """true""", Some(1))
     query("jsonList", "has", """"[1, 2, 3]"""", Some(1))
     query("bytesList", "has", """"dGVzdA=="""", Some(1))
@@ -67,7 +67,7 @@ class ListFilterSpec extends FlatSpec with Matchers with ApiSpecBase with Connec
     query("floatList", "hasSome", """[1.1, 5.5]""", Some(1))
     query("bIntList", "hasSome", """["200", "5000"]""", Some(1))
     query("decList", "hasSome", """[55.55, 33.33]""", Some(1))
-    query("dtList", "hasSome", """["2018-12-05T12:34:23+00:00", "2019-12-05T12:34:23+00:00"]""", Some(1))
+    query("dtList", "hasSome", """["2018-12-05T12:34:23.000Z", "2019-12-05T12:34:23.000Z"]""", Some(1))
     query("boolList", "hasSome", """[true, false]""", Some(1))
     query("jsonList", "hasSome", """["{}", "[1]"]""", Some(1))
     query("bytesList", "hasSome", """["dGVzdA==", "bG9va2luZyBmb3Igc29tZXRoaW5nPw=="]""", Some(1))
@@ -92,8 +92,8 @@ class ListFilterSpec extends FlatSpec with Matchers with ApiSpecBase with Connec
     query("decList", "hasEvery", """[55.55, 33.33]""", None)
     query("decList", "hasEvery", """[33.33]""", Some(1))
 
-    query("dtList", "hasEvery", """["2018-12-05T12:34:23+00:00", "2019-12-05T12:34:23+00:00"]""", None)
-    query("dtList", "hasEvery", """["2018-12-05T12:34:23+00:00"]""", Some(1))
+    query("dtList", "hasEvery", """["2018-12-05T12:34:23.000Z", "2019-12-05T12:34:23.000Z"]""", None)
+    query("dtList", "hasEvery", """["2018-12-05T12:34:23.000Z"]""", Some(1))
 
     query("boolList", "hasEvery", """[true, false]""", None)
     query("boolList", "hasEvery", """[true]""", Some(1))
@@ -182,7 +182,7 @@ class ListFilterSpec extends FlatSpec with Matchers with ApiSpecBase with Connec
         |  floatList: [1.1, 2.2, 3.3],
         |  bIntList:  ["100", "200", "300"],
         |  decList:   ["11.11", "22.22", "33.33"],
-        |  dtList:    ["1969-01-01T10:33:59+00:00", "2018-12-05T12:34:23+00:00"],
+        |  dtList:    ["1969-01-01T10:33:59.000Z", "2018-12-05T12:34:23.000Z"],
         |  boolList:  [true],
         |  jsonList:  ["{}", "{\\"int\\":5}", "[1, 2, 3]"],
         |  bytesList: ["dGVzdA==", "dA=="],

--- a/query-engine/connector-test-kit/src/test/scala/queries/regressions/PaginationRegressionSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/regressions/PaginationRegressionSpec.scala
@@ -39,7 +39,7 @@ class PaginationRegressionSpec extends FlatSpec with Matchers with ApiSpecBase {
     )
 
     page1.toString should equal(
-      """{"data":{"findManyModelB":[{"id":"7e00aa78-5951-4c05-8e42-4edb0927e964","createdAt":"2020-06-25T20:05:38+00:00"},{"id":"84c01d52-838d-4cdd-9035-c09cf54a06a0","createdAt":"2020-06-25T19:44:50+00:00"},{"id":"3e7d6b95-c62d-4e66-bb8c-66a317386e40","createdAt":"2020-06-19T21:32:11+00:00"},{"id":"99f1734d-6ad1-4cf0-b851-2ed551cbabc6","createdAt":"2020-06-19T21:32:02+00:00"},{"id":"9505b8a9-45a1-4aae-a284-5bacfe9f835c","createdAt":"2020-06-19T21:31:51+00:00"}]}}""")
+      """{"data":{"findManyModelB":[{"id":"7e00aa78-5951-4c05-8e42-4edb0927e964","createdAt":"2020-06-25T20:05:38.000Z"},{"id":"84c01d52-838d-4cdd-9035-c09cf54a06a0","createdAt":"2020-06-25T19:44:50.000Z"},{"id":"3e7d6b95-c62d-4e66-bb8c-66a317386e40","createdAt":"2020-06-19T21:32:11.000Z"},{"id":"99f1734d-6ad1-4cf0-b851-2ed551cbabc6","createdAt":"2020-06-19T21:32:02.000Z"},{"id":"9505b8a9-45a1-4aae-a284-5bacfe9f835c","createdAt":"2020-06-19T21:31:51.000Z"}]}}""")
 
     val page2 = server.query(
       """
@@ -55,7 +55,7 @@ class PaginationRegressionSpec extends FlatSpec with Matchers with ApiSpecBase {
     )
 
     page2.toString should equal(
-      """{"data":{"findManyModelB":[{"id":"ea732052-aac6-429b-84ea-976ca1f645d0","createdAt":"2020-06-11T22:34:15+00:00"},{"id":"13394728-24a6-4a37-aa6e-369e7f70c10b","createdAt":"2020-06-10T21:52:26+00:00"},{"id":"16fa1ce3-5243-4a30-970e-8ec98d077810","createdAt":"2020-06-10T21:52:26+00:00"},{"id":"36e88f2e-9f4c-4e26-9add-fbf76e404959","createdAt":"2020-06-10T21:52:26+00:00"},{"id":"3c0f269f-0796-427e-af67-8c1a99f3524d","createdAt":"2020-06-10T21:52:26+00:00"}]}}""")
+      """{"data":{"findManyModelB":[{"id":"ea732052-aac6-429b-84ea-976ca1f645d0","createdAt":"2020-06-11T22:34:15.000Z"},{"id":"13394728-24a6-4a37-aa6e-369e7f70c10b","createdAt":"2020-06-10T21:52:26.000Z"},{"id":"16fa1ce3-5243-4a30-970e-8ec98d077810","createdAt":"2020-06-10T21:52:26.000Z"},{"id":"36e88f2e-9f4c-4e26-9add-fbf76e404959","createdAt":"2020-06-10T21:52:26.000Z"},{"id":"3c0f269f-0796-427e-af67-8c1a99f3524d","createdAt":"2020-06-10T21:52:26.000Z"}]}}""")
 
     val page3 = server.query(
       """
@@ -71,7 +71,7 @@ class PaginationRegressionSpec extends FlatSpec with Matchers with ApiSpecBase {
     )
 
     page3.toString should equal(
-      """{"data":{"findManyModelB":[{"id":"517e8f7f-980a-44bf-8500-4e279a120b72","createdAt":"2020-06-10T21:52:26+00:00"},{"id":"620d09a6-f5bd-48b5-bbe6-d55fcf341392","createdAt":"2020-06-10T21:52:26+00:00"},{"id":"755f5bba-25e3-4510-a991-e0cfe02d864d","createdAt":"2020-06-10T21:52:26+00:00"},{"id":"8a49e477-1f12-4a81-953f-c7b0ca5696dc","createdAt":"2020-06-10T21:52:26+00:00"},{"id":"8c7a3864-285c-4f06-9c9a-273e19e19a05","createdAt":"2020-06-10T21:52:26+00:00"}]}}""")
+      """{"data":{"findManyModelB":[{"id":"517e8f7f-980a-44bf-8500-4e279a120b72","createdAt":"2020-06-10T21:52:26.000Z"},{"id":"620d09a6-f5bd-48b5-bbe6-d55fcf341392","createdAt":"2020-06-10T21:52:26.000Z"},{"id":"755f5bba-25e3-4510-a991-e0cfe02d864d","createdAt":"2020-06-10T21:52:26.000Z"},{"id":"8a49e477-1f12-4a81-953f-c7b0ca5696dc","createdAt":"2020-06-10T21:52:26.000Z"},{"id":"8c7a3864-285c-4f06-9c9a-273e19e19a05","createdAt":"2020-06-10T21:52:26.000Z"}]}}""")
 
     val page4 = server.query(
       """
@@ -87,7 +87,7 @@ class PaginationRegressionSpec extends FlatSpec with Matchers with ApiSpecBase {
     )
 
     page4.toString should equal(
-      """{"data":{"findManyModelB":[{"id":"bae99648-bdad-440f-953b-ddab33c6ea0b","createdAt":"2020-06-10T21:52:26+00:00"},{"id":"eb8c5a20-ae61-402b-830f-f9518957f195","createdAt":"2020-06-10T21:52:26+00:00"},{"id":"79066f5a-3640-42e9-be04-2a702924f4c6","createdAt":"2020-06-04T16:00:21+00:00"},{"id":"a4b0472a-52fc-4b2d-8c44-4c401c18f469","createdAt":"2020-06-03T21:13:57+00:00"},{"id":"fc34b132-e376-406e-ab89-10ee35b4d58d","createdAt":"2020-05-12T12:30:12+00:00"}]}}""")
+      """{"data":{"findManyModelB":[{"id":"bae99648-bdad-440f-953b-ddab33c6ea0b","createdAt":"2020-06-10T21:52:26.000Z"},{"id":"eb8c5a20-ae61-402b-830f-f9518957f195","createdAt":"2020-06-10T21:52:26.000Z"},{"id":"79066f5a-3640-42e9-be04-2a702924f4c6","createdAt":"2020-06-04T16:00:21.000Z"},{"id":"a4b0472a-52fc-4b2d-8c44-4c401c18f469","createdAt":"2020-06-03T21:13:57.000Z"},{"id":"fc34b132-e376-406e-ab89-10ee35b4d58d","createdAt":"2020-05-12T12:30:12.000Z"}]}}""")
   }
 
   "[prisma/3505][Case 1] Paging and ordering with potential null values ON a null row" should "still allow paging through records predictably" in {

--- a/query-engine/connector-test-kit/src/test/scala/queries/simple/ScalarListsQuerySpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/simple/ScalarListsQuerySpec.scala
@@ -210,7 +210,7 @@ class ScalarListsQuerySpec extends FlatSpec with Matchers with ApiSpecBase {
   "full scalar list" should "return full list for datetime" in {
     val fieldName   = "datetimes"
     val inputValue  = """"2018-01-01T00:00:00.000Z""""
-    val outputValue = """"2018-01-01T00:00:00+00:00""""
+    val outputValue = """"2018-01-01T00:00:00.000Z""""
 
     val project = SchemaDsl.fromStringV11() {
       s"""model Model{

--- a/query-engine/connector-test-kit/src/test/scala/writes/dataTypes/datetime/DateTimeSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/dataTypes/datetime/DateTimeSpec.scala
@@ -18,25 +18,25 @@ class DateTimeSpec extends FlatSpec with Matchers with ApiSpecBase {
   "Using a date before 1970" should "work" taggedAs IgnoreSQLite in {
     server.query(s"""mutation {createPerson(data: {name: "First", born: "1969-01-01T10:33:59Z"}){name}}""", project)
     val res = server.query(s"""query {person(where:{name: "First"}){name, born}}""", project)
-    res.toString should be("""{"data":{"person":{"name":"First","born":"1969-01-01T10:33:59+00:00"}}}""")
+    res.toString should be("""{"data":{"person":{"name":"First","born":"1969-01-01T10:33:59.000Z"}}}""")
   }
 
   "Using milliseconds in a date before 1970" should "work" taggedAs IgnoreSQLite in {
     server.query(s"""mutation {createPerson(data: {name: "Second", born: "1969-01-01T10:33:59.828Z"}){name}}""", project)
     val res = server.query(s"""query {person(where:{name: "Second"}){name, born}}""", project)
-    res.toString should be("""{"data":{"person":{"name":"Second","born":"1969-01-01T10:33:59.828+00:00"}}}""")
+    res.toString should be("""{"data":{"person":{"name":"Second","born":"1969-01-01T10:33:59.828Z"}}}""")
   }
 
   "Using a date after 1970" should "work" in {
     server.query(s"""mutation {createPerson(data: {name: "Third", born: "1979-01-01T10:33:59Z"}){name}}""", project)
     val res = server.query(s"""query {person(where:{name: "Third"}){name, born}}""", project)
-    res.toString should be("""{"data":{"person":{"name":"Third","born":"1979-01-01T10:33:59+00:00"}}}""")
+    res.toString should be("""{"data":{"person":{"name":"Third","born":"1979-01-01T10:33:59.000Z"}}}""")
   }
 
   "Using milliseconds in a date after 1970" should "work" in {
     server.query(s"""mutation {createPerson(data: {name: "Fourth", born: "1979-01-01T10:33:59.828Z"}){name}}""", project)
     val res = server.query(s"""query {person(where:{name: "Fourth"}){name, born}}""", project)
-    res.toString should be("""{"data":{"person":{"name":"Fourth","born":"1979-01-01T10:33:59.828+00:00"}}}""")
+    res.toString should be("""{"data":{"person":{"name":"Fourth","born":"1979-01-01T10:33:59.828Z"}}}""")
   }
 
   // https://tools.ietf.org/html/rfc3339 doesn't support 5-digit years. Therefore Rust date libraries will give a parse
@@ -44,7 +44,7 @@ class DateTimeSpec extends FlatSpec with Matchers with ApiSpecBase {
   "Using a date after 10000" should "work" ignore {
     server.query(s"""mutation {createPerson(data: {name: "Fifth", born: "11979-01-01T10:33:59Z"}){name}}""", project)
     val res = server.query(s"""query {person(where:{name: "Fifth"}){name, born}}""", project)
-    res.toString should be("""{"data":{"person":{"name":"Fifth","born":"11979-01-01T10:33:59+00:00"}}}""")
+    res.toString should be("""{"data":{"person":{"name":"Fifth","born":"11979-01-01T10:33:59.000Z"}}}""")
   }
 
   "Using milliseconds in a date after 10000" should "work" ignore {
@@ -58,7 +58,7 @@ class DateTimeSpec extends FlatSpec with Matchers with ApiSpecBase {
 //  "Using a date before 0" should "work" in {
 //    server.query(s"""mutation {createPerson(data: {name: "Seventh", born: "-0500-01-01T10:33:59Z"}){name}}""", project)
 //    val res = server.query(s"""query {person(where:{name: "Seventh"}){name, born}}""", project)
-//    res.toString should be("""{"data":{"person":{"name":"Seventh","born":"-0500-01-01T10:33:59+00:00"}}}""")
+//    res.toString should be("""{"data":{"person":{"name":"Seventh","born":"-0500-01-01T10:33:59Z"}}}""")
 //  }
 //
 //  "Using milliseconds in a date before 0" should "work" in {

--- a/query-engine/connector-test-kit/src/test/scala/writes/dataTypes/datetime/WhereAndDateTimeSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/dataTypes/datetime/WhereAndDateTimeSpec.scala
@@ -24,8 +24,8 @@ class WhereAndDateTimeSpec extends FlatSpec with Matchers with ApiSpecBase {
   }
 
   "Using the same input in an update using where as used during creation of the item" should "work" in {
-    val outerWhere = """"2018-12-05T12:34:23+00:00""""
-    val innerWhere = """"2019-12-05T12:34:23+00:00""""
+    val outerWhere = """"2018-12-05T12:34:23.000Z""""
+    val innerWhere = """"2019-12-05T12:34:23.000Z""""
 
     database.setup(project)
 
@@ -73,19 +73,19 @@ class WhereAndDateTimeSpec extends FlatSpec with Matchers with ApiSpecBase {
     server.query(
       s"""query{note(where:{outerDateTime:$outerWhere}){outerString, outerDateTime}}""",
       project,
-      dataContains = """{"note":{"outerString":"Changed Outer String","outerDateTime":"2018-12-05T12:34:23+00:00"}}"""
+      dataContains = """{"note":{"outerString":"Changed Outer String","outerDateTime":"2018-12-05T12:34:23.000Z"}}"""
     )
 
     server.query(
       s"""query{todo(where:{innerDateTime:$innerWhere}){innerString, innerDateTime}}""",
       project,
-      dataContains = """{"todo":{"innerString":"Changed Inner String","innerDateTime":"2019-12-05T12:34:23+00:00"}}"""
+      dataContains = """{"todo":{"innerString":"Changed Inner String","innerDateTime":"2019-12-05T12:34:23.000Z"}}"""
     )
   }
 
   "Using the same input in an update using where as used during creation of the item" should "work with the same time for inner and outer" in {
-    val outerWhere = """"2018-01-03T11:27:38+00:00""""
-    val innerWhere = """"2018-01-03T11:27:38+00:00""""
+    val outerWhere = """"2018-01-03T11:27:38.000Z""""
+    val innerWhere = """"2018-01-03T11:27:38.000Z""""
 
     database.setup(project)
 
@@ -135,12 +135,12 @@ class WhereAndDateTimeSpec extends FlatSpec with Matchers with ApiSpecBase {
     server.query(
       s"""query{note(where:{outerDateTime:$outerWhere}){outerString, outerDateTime}}""",
       project,
-      dataContains = s"""{"note":{"outerString":"Changed Outer String","outerDateTime":"2018-01-03T11:27:38+00:00"}}"""
+      dataContains = s"""{"note":{"outerString":"Changed Outer String","outerDateTime":"2018-01-03T11:27:38.000Z"}}"""
     )
     server.query(
       s"""query{todo(where:{innerDateTime:$innerWhere}){innerString, innerDateTime}}""",
       project,
-      dataContains = s"""{"todo":{"innerString":"Changed Inner String","innerDateTime":"2018-01-03T11:27:38+00:00"}}"""
+      dataContains = s"""{"todo":{"innerString":"Changed Inner String","innerDateTime":"2018-01-03T11:27:38.000Z"}}"""
     )
   }
 

--- a/query-engine/connector-test-kit/src/test/scala/writes/dataTypes/native_types/MySqlNativeTypesSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/dataTypes/native_types/MySqlNativeTypesSpec.scala
@@ -178,7 +178,7 @@ class MySqlNativeTypesSpec extends FlatSpec with Matchers with ApiSpecBase with 
     )
 
     res.toString should be(
-      """{"data":{"createOneModel":{"date":"2016-09-24T00:00:00+00:00","time":"1970-01-01T13:14:15.123+00:00","dtime":"2016-09-24T12:29:32+00:00","ts":"2016-09-24T12:29:32+00:00","year":1973}}}""")
+      """{"data":{"createOneModel":{"date":"2016-09-24T00:00:00.000Z","time":"1970-01-01T13:14:15.123Z","dtime":"2016-09-24T12:29:32.000Z","ts":"2016-09-24T12:29:32.000Z","year":1973}}}""")
   }
 
   "MySQL native binary types" should "work" in {

--- a/query-engine/connector-test-kit/src/test/scala/writes/dataTypes/native_types/PostgresNativeTypesSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/dataTypes/native_types/PostgresNativeTypesSpec.scala
@@ -234,7 +234,7 @@ class PostgresNativeTypesSpec extends FlatSpec with Matchers with ApiSpecBase wi
     )
 
     res.toString should be(
-      """{"data":{"createOneModel":{"date":"2016-09-24T00:00:00+00:00","date_2":"2016-09-23T00:00:00+00:00","time":"1970-01-01T13:02:20.321+00:00","time_2":"1970-01-01T10:02:20.321+00:00","time_tz":"1970-01-01T13:02:20.321+00:00","time_tz_2":"1970-01-01T10:02:20.321+00:00","ts":"2016-09-24T14:01:30.213+00:00","ts_2":"2016-09-24T11:01:30.213+00:00","ts_tz":"2016-09-24T14:01:30.213+00:00","ts_tz_2":"2016-09-24T11:01:30.213+00:00"}}}""")
+      """{"data":{"createOneModel":{"date":"2016-09-24T00:00:00.000Z","date_2":"2016-09-23T00:00:00.000Z","time":"1970-01-01T13:02:20.321Z","time_2":"1970-01-01T10:02:20.321Z","time_tz":"1970-01-01T13:02:20.321Z","time_tz_2":"1970-01-01T10:02:20.321Z","ts":"2016-09-24T14:01:30.213Z","ts_2":"2016-09-24T11:01:30.213Z","ts_tz":"2016-09-24T14:01:30.213Z","ts_tz_2":"2016-09-24T11:01:30.213Z"}}}""")
   }
 
   "Postgres native fixed-size char type" should "be handled correctly wrt. padding for comparisons" in {

--- a/query-engine/connector-test-kit/src/test/scala/writes/dataTypes/native_types/SqlServerNativeTypesSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/dataTypes/native_types/SqlServerNativeTypesSpec.scala
@@ -198,7 +198,7 @@ class SqlServerNativeTypesSpec extends FlatSpec with Matchers with ApiSpecBase w
     )
 
     res should be(
-      """{"data":{"createOneModel":{"date":"2016-09-24T00:00:00+00:00","time":"1970-01-01T13:14:15.123+00:00","dtime":"2016-09-24T12:29:32.343333333+00:00","dtime2":"2016-09-24T12:29:32.342+00:00","dtoff":"2016-09-24T12:29:32.342+00:00","small":"2016-09-24T12:30:00+00:00"}}}""".parseJson)
+      """{"data":{"createOneModel":{"date":"2016-09-24T00:00:00.000Z","time":"1970-01-01T13:14:15.123Z","dtime":"2016-09-24T12:29:32.343Z","dtime2":"2016-09-24T12:29:32.342Z","dtoff":"2016-09-24T12:29:32.342Z","small":"2016-09-24T12:30:00.000Z"}}}""".parseJson)
   }
 
   "SQL Server native binary types" should "work" in {

--- a/query-engine/connector-test-kit/src/test/scala/writes/dataTypes/scalarLists/ScalarListsSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/dataTypes/scalarLists/ScalarListsSpec.scala
@@ -65,7 +65,7 @@ class ScalarListsSpec extends FlatSpec with Matchers with ApiSpecBase {
     )
 
     res should be(
-      s"""{"data":{"createScalarModel":{"strings":["test${TroubleCharacters.value}"],"ints":[1337,12],"floats":[1.234,1.45],"decimals":["1.234","1.45"],"booleans":[true,false],"enums":["A","A"],"dateTimes":["2016-07-31T23:59:01+00:00","2017-07-31T23:59:01+00:00"],"bytes":["dGVzdA==","dA=="]}}}""".parseJson)
+      s"""{"data":{"createScalarModel":{"strings":["test${TroubleCharacters.value}"],"ints":[1337,12],"floats":[1.234,1.45],"decimals":["1.234","1.45"],"booleans":[true,false],"enums":["A","A"],"dateTimes":["2016-07-31T23:59:01.000Z","2017-07-31T23:59:01.000Z"],"bytes":["dGVzdA==","dA=="]}}}""".parseJson)
 
     res = server.query(
       s"""mutation {
@@ -93,7 +93,7 @@ class ScalarListsSpec extends FlatSpec with Matchers with ApiSpecBase {
     )
 
     res should be(
-      s"""{"data":{"updateScalarModel":{"strings":["updated","now"],"ints":[14],"floats":[1.2345678],"decimals":["1.2345678"],"booleans":[false,false,true],"enums":[],"dateTimes":["2019-07-31T23:59:01+00:00"],"bytes":["dGVzdA=="]}}}""".parseJson)
+      s"""{"data":{"updateScalarModel":{"strings":["updated","now"],"ints":[14],"floats":[1.2345678],"decimals":["1.2345678"],"booleans":[false,false,true],"enums":[],"dateTimes":["2019-07-31T23:59:01.000Z"],"bytes":["dGVzdA=="]}}}""".parseJson)
 
     res = server.query(
       s"""mutation {
@@ -121,7 +121,7 @@ class ScalarListsSpec extends FlatSpec with Matchers with ApiSpecBase {
     )
 
     res should be(
-      s"""{"data":{"updateScalarModel":{"strings":["updated","now","future"],"ints":[14,15],"floats":[1.2345678,2],"decimals":["1.2345678","2"],"booleans":[false,false,true,true],"enums":["A"],"dateTimes":["2019-07-31T23:59:01+00:00","2019-07-31T23:59:01+00:00"],"bytes":["dGVzdA==","dGVzdA=="]}}}""".parseJson)
+      s"""{"data":{"updateScalarModel":{"strings":["updated","now","future"],"ints":[14,15],"floats":[1.2345678,2],"decimals":["1.2345678","2"],"booleans":[false,false,true,true],"enums":["A"],"dateTimes":["2019-07-31T23:59:01.000Z","2019-07-31T23:59:01.000Z"],"bytes":["dGVzdA==","dGVzdA=="]}}}""".parseJson)
   }
 
   "A Create Mutation" should "create and return items with list values with shorthand notation" in {
@@ -152,7 +152,7 @@ class ScalarListsSpec extends FlatSpec with Matchers with ApiSpecBase {
     )
 
     res should be(
-      s"""{"data":{"createScalarModel":{"strings":["test${TroubleCharacters.value}"],"ints":[1337,12],"floats":[1.234,1.45],"decimals":["1.234","1.45"],"booleans":[true,false],"enums":["A","A"],"dateTimes":["2016-07-31T23:59:01+00:00","2017-07-31T23:59:01+00:00"],"bytes":["dGVzdA==","dA=="]}}}""".parseJson)
+      s"""{"data":{"createScalarModel":{"strings":["test${TroubleCharacters.value}"],"ints":[1337,12],"floats":[1.234,1.45],"decimals":["1.234","1.45"],"booleans":[true,false],"enums":["A","A"],"dateTimes":["2016-07-31T23:59:01.000Z","2017-07-31T23:59:01.000Z"],"bytes":["dGVzdA==","dA=="]}}}""".parseJson)
   }
 
   "A Create Mutation" should "create and return items with empty list values" in {
@@ -252,6 +252,6 @@ class ScalarListsSpec extends FlatSpec with Matchers with ApiSpecBase {
     )
 
     res should be(
-      s"""{"data":{"updateScalarModel":{"strings":["future"],"ints":[15],"floats":[2.0],"decimals":["2"],"booleans":[true],"enums":["A"],"dateTimes":["2019-07-31T23:59:01+00:00"],"bytes":["dGVzdA=="]}}}""".parseJson)
+      s"""{"data":{"updateScalarModel":{"strings":["future"],"ints":[15],"floats":[2.0],"decimals":["2"],"booleans":[true],"enums":["A"],"dateTimes":["2019-07-31T23:59:01.000Z"],"bytes":["dGVzdA=="]}}}""".parseJson)
   }
 }

--- a/query-engine/connector-test-kit/src/test/scala/writes/topLevelMutations/CreateMutationSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/topLevelMutations/CreateMutationSpec.scala
@@ -56,12 +56,12 @@ class CreateMutationSpec extends FlatSpec with Matchers with ApiSpecBase {
     val id = res.pathAsString("data.createScalarModel.id")
 
     res should be(
-      s"""{"data":{"createScalarModel":{"id":"$id","optInt":1337,"optBoolean":true,"optDateTime":"2016-07-31T23:59:01+00:00","optString":"lala${TroubleCharacters.value}","optEnum":"A","optFloat":1.234}}}""".parseJson)
+      s"""{"data":{"createScalarModel":{"id":"$id","optInt":1337,"optBoolean":true,"optDateTime":"2016-07-31T23:59:01.000Z","optString":"lala${TroubleCharacters.value}","optEnum":"A","optFloat":1.234}}}""".parseJson)
 
     val queryRes = server.query("""{ scalarModels{optString, optInt, optFloat, optBoolean, optEnum, optDateTime }}""", project = project)
 
     queryRes should be(
-      s"""{"data":{"scalarModels":[{"optInt":1337,"optBoolean":true,"optDateTime":"2016-07-31T23:59:01+00:00","optString":"lala${TroubleCharacters.value}","optEnum":"A","optFloat":1.234}]}}""".parseJson)
+      s"""{"data":{"scalarModels":[{"optInt":1337,"optBoolean":true,"optDateTime":"2016-07-31T23:59:01.000Z","optString":"lala${TroubleCharacters.value}","optEnum":"A","optFloat":1.234}]}}""".parseJson)
   }
 
   "A Create Mutation" should "create and return item with empty string" in {

--- a/query-engine/connector-test-kit/src/test/scala/writes/topLevelMutations/DefaultValueSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/topLevelMutations/DefaultValueSpec.scala
@@ -129,8 +129,8 @@ class DefaultValueSpec extends FlatSpec with Matchers with ApiSpecBase {
     )
 
     // We currently have a datetime precision of 3, so Prisma will add .000
-    res.pathAsString("data.createUser.createdAt") should be("2000-01-01T00:00:00+00:00")
-    res.pathAsString("data.createUser.updatedAt") should be("2001-01-01T00:00:00+00:00")
+    res.pathAsString("data.createUser.createdAt") should be("2000-01-01T00:00:00.000Z")
+    res.pathAsString("data.createUser.updatedAt") should be("2001-01-01T00:00:00.000Z")
   }
 
   "Remapped enum default values" should "work" taggedAs (IgnoreSQLite, IgnoreMsSql) in {

--- a/query-engine/connector-test-kit/src/test/scala/writes/topLevelMutations/UpdateMutationSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/topLevelMutations/UpdateMutationSpec.scala
@@ -61,7 +61,7 @@ class UpdateMutationSpec extends FlatSpec with Matchers with ApiSpecBase {
 
     updateResult.pathAsJsValue("data.updateOneTestModel") should be(
       Json.parse(
-        s"""{"optString":"test${TroubleCharacters.value}","optInt":1337,"optFloat":1.234,"optBoolean":true,"optDateTime":"2016-07-31T23:59:01+00:00"}"""))
+        s"""{"optString":"test${TroubleCharacters.value}","optInt":1337,"optFloat":1.234,"optBoolean":true,"optDateTime":"2016-07-31T23:59:01.000Z"}"""))
 
     val readResult = server.query(
       s"""
@@ -134,7 +134,7 @@ class UpdateMutationSpec extends FlatSpec with Matchers with ApiSpecBase {
 
     updateResult.pathAsJsValue("data.updateOneTestModel") should be(
       Json.parse(
-        s"""{"optString":"test${TroubleCharacters.value}","optInt":1337,"optFloat":1.234,"optBoolean":true,"optDateTime":"2016-07-31T23:59:01+00:00"}"""))
+        s"""{"optString":"test${TroubleCharacters.value}","optInt":1337,"optFloat":1.234,"optBoolean":true,"optDateTime":"2016-07-31T23:59:01.000Z"}"""))
 
     val readResult = server.query(
       s"""
@@ -383,8 +383,8 @@ class UpdateMutationSpec extends FlatSpec with Matchers with ApiSpecBase {
         legacy = false,
       )
 
-    res.pathAsString("data.updateOneTestModel.createdAt") should be("2000-01-01T00:00:00+00:00")
-    res.pathAsString("data.updateOneTestModel.updatedAt") should be("2001-01-01T00:00:00+00:00")
+    res.pathAsString("data.updateOneTestModel.createdAt") should be("2000-01-01T00:00:00.000Z")
+    res.pathAsString("data.updateOneTestModel.updatedAt") should be("2001-01-01T00:00:00.000Z")
   }
 
   "An updateOne mutation" should "correctly apply all number operations for Int" in {


### PR DESCRIPTION
## Overview

Closes https://github.com/prisma/prisma/issues/5941

The findUnique batch optimization expects inputs to be strictly equal to outputs. In the case of dates, they were serialized in a different format than the input format, causing nulls to be returned.

Given that clients always send input dates in the following format, `1999-05-01T00:00:00.000Z`, we updated the output date serialization format to always render dates in the same format as above.