### PR TITLE
test: regression test for creation of model with datetime as id

### DIFF
--- a/query-engine/connector-test-kit/src/test/scala/writes/topLevelMutations/CreateMutationSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/topLevelMutations/CreateMutationSpec.scala
@@ -186,4 +186,27 @@ class CreateMutationSpec extends FlatSpec with Matchers with ApiSpecBase {
 
     res should be("""{"data":{"createScalarModel":{"relId":null}}}""".parseJson)
   }
+
+  "A Create Mutation with datetime as identifier" should "work" in {
+    val project = ProjectDsl.fromString {
+      s"""
+         |model A {
+         |  timestamp DateTime @id @default(now())
+         |}
+    """.stripMargin
+    }
+
+    database.setup(project)
+
+    val res = server.query(
+      """mutation {
+        |  createOneA(data: {}) {
+        |    timestamp
+        |  }}""".stripMargin,
+      project = project,
+      legacy = false
+    )
+
+    res.toString() should be("""{"data":{"createOneA":{"timestamp":"2021-03-25T15:20:31.342+00:00"}}}""")
+  }
 }

--- a/query-engine/connector-test-kit/src/test/scala/writes/topLevelMutations/CreateMutationSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/topLevelMutations/CreateMutationSpec.scala
@@ -191,7 +191,7 @@ class CreateMutationSpec extends FlatSpec with Matchers with ApiSpecBase {
     val project = ProjectDsl.fromString {
       s"""
          |model A {
-         |  timestamp DateTime @id @default(now())
+         |  timestamp DateTime @id
          |}
     """.stripMargin
     }
@@ -200,13 +200,13 @@ class CreateMutationSpec extends FlatSpec with Matchers with ApiSpecBase {
 
     val res = server.query(
       """mutation {
-        |  createOneA(data: {}) {
+        |  createOneA(data: { timestamp: "1999-05-01T00:00:00.000Z" }) {
         |    timestamp
         |  }}""".stripMargin,
       project = project,
       legacy = false
     )
 
-    res.toString() should be("""{"data":{"createOneA":{"timestamp":"2021-03-25T15:20:31.342+00:00"}}}""")
+    res.toString() should be("""{"data":{"createOneA":{"timestamp":"1999-05-01T00:00:00.000Z"}}}""")
   }
 }


### PR DESCRIPTION
## Overview

Closes https://github.com/prisma/prisma/issues/5762
Issue fixed by #1771
This PR only adds a test to prevent future regressions