### PR TITLE
Override relative path prefix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -953,6 +953,7 @@ dependencies = [
  "sql-datamodel-connector",
  "thiserror",
  "tracing",
+ "url 2.2.1",
 ]
 
 [[package]]

--- a/libs/datamodel/core/Cargo.toml
+++ b/libs/datamodel/core/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = { version = "1.0", features = ["preserve_order", "float_roundtrip"]
 sql-datamodel-connector = { path = "../connectors/sql-datamodel-connector" }
 thiserror = "1.0"
 tracing = "0.1"
+url = "2"
 
 [dev-dependencies]
 clap = "2.33"

--- a/libs/datamodel/core/src/configuration/datasource.rs
+++ b/libs/datamodel/core/src/configuration/datasource.rs
@@ -1,5 +1,8 @@
+use std::{collections::BTreeMap, path::Path};
+
 use datamodel_connector::{Connector, ConnectorCapabilities};
 use serde::Serialize;
+use url::Url;
 
 /// a `datasource` from the prisma schema.
 pub struct Datasource {
@@ -39,6 +42,61 @@ impl Datasource {
     pub fn capabilities(&self) -> ConnectorCapabilities {
         let capabilities = self.active_connector.capabilities().clone();
         ConnectorCapabilities::new(capabilities)
+    }
+
+    /// JavaScript wants to set the CWD, but can't due to changing it for itself
+    /// too. This method is an ugly hack to convert all relative paths in the
+    /// connection string to include a given config directory as its prefix, but
+    /// only if the path is relative.
+    ///
+    /// The other option would've been to just point in our docs that a path
+    /// in a connection string is relative only from the caller point of view.
+    ///
+    /// Now, there is a promise to change this behavior to follow how everybody
+    /// else is doing it, but I wouldn't hold my breath.
+    ///
+    /// P.S. Don't forget to add new parameters here if needed!
+    pub fn set_config_dir(&mut self, config_dir: &Path) {
+        let set_root = |path: &str| {
+            let path = Path::new(path);
+
+            if path.is_relative() {
+                Some(config_dir.join(&path).to_str().map(ToString::to_string).unwrap())
+            } else {
+                None
+            }
+        };
+
+        match self.active_provider.as_str() {
+            "sqlserver" => (),
+            "sqlite" => {
+                if let Some(path) = set_root(&self.url.value.trim_start_matches("file:")) {
+                    self.url.value = format!("file:{}", path);
+                };
+            }
+            _ => {
+                let mut url = Url::parse(&self.url.value).unwrap();
+
+                let mut params: BTreeMap<String, String> =
+                    url.query_pairs().map(|(k, v)| (k.to_string(), v.to_string())).collect();
+
+                url.query_pairs_mut().clear();
+
+                if let Some(path) = params.get("sslcert").map(|s| s.as_str()).and_then(set_root) {
+                    params.insert("sslcert".into(), path);
+                }
+
+                if let Some(path) = params.get("sslidentity").map(|s| s.as_str()).and_then(set_root) {
+                    params.insert("sslidentity".into(), path);
+                }
+
+                for (k, v) in params.into_iter() {
+                    url.query_pairs_mut().append_pair(&k, &v);
+                }
+
+                self.url.value = url.to_string();
+            }
+        }
     }
 }
 

--- a/libs/datamodel/core/tests/parsing/literals.rs
+++ b/libs/datamodel/core/tests/parsing/literals.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use crate::common::parse;
 use indoc::indoc;
 use pretty_assertions::assert_eq;
@@ -52,4 +54,188 @@ fn strings_with_newlines_are_unescpaed() {
             .unwrap(),
         "Jean\nClaude\nVan\nDamme"
     );
+}
+
+#[test]
+fn relative_sqlite_paths_can_be_modified() {
+    let schema = indoc!(
+        r#"
+        datasource boo {
+          provider = "sqlite"
+          url = "file:dev.db"
+        }"#
+    );
+
+    let config =
+        datamodel::parse_configuration_with_config_dir(schema, Vec::new(), &Path::new("/path/to/prisma")).unwrap();
+
+    assert_eq!("file:/path/to/prisma/dev.db", &config.subject.datasources[0].url.value)
+}
+
+#[test]
+fn absolute_sqlite_paths_are_not_modified() {
+    let schema = indoc!(
+        r#"
+        datasource boo {
+          provider = "sqlite"
+          url = "file:/foo/bar/dev.db"
+        }"#
+    );
+
+    let config =
+        datamodel::parse_configuration_with_config_dir(schema, Vec::new(), &Path::new("/path/to/prisma")).unwrap();
+
+    assert_eq!("file:/foo/bar/dev.db", &config.subject.datasources[0].url.value)
+}
+
+#[test]
+fn postgres_relative_sslidentity_can_be_modified() {
+    let schema = indoc!(
+        r#"
+        datasource boo {
+          provider = "postgres"
+          url = "postgres://localhost:420/?foo=bar&sslidentity=we%2Fare%2Fhere.key"
+        }"#
+    );
+
+    let config =
+        datamodel::parse_configuration_with_config_dir(schema, Vec::new(), &Path::new("/path/to/prisma")).unwrap();
+
+    assert_eq!(
+        "postgres://localhost:420/?foo=bar&sslidentity=%2Fpath%2Fto%2Fprisma%2Fwe%2Fare%2Fhere.key",
+        &config.subject.datasources[0].url.value
+    )
+}
+
+#[test]
+fn postgres_absolute_sslidentity_should_not_be_modified() {
+    let schema = indoc!(
+        r#"
+        datasource boo {
+          provider = "postgres"
+          url = "postgres://localhost:420/?foo=bar&sslidentity=%2Fwe%2Fare%2Fhere.key"
+        }"#
+    );
+
+    let config =
+        datamodel::parse_configuration_with_config_dir(schema, Vec::new(), &Path::new("/path/to/prisma")).unwrap();
+
+    assert_eq!(
+        "postgres://localhost:420/?foo=bar&sslidentity=%2Fwe%2Fare%2Fhere.key",
+        &config.subject.datasources[0].url.value
+    )
+}
+
+#[test]
+fn mysql_relative_sslidentity_can_be_modified() {
+    let schema = indoc!(
+        r#"
+        datasource boo {
+          provider = "mysql"
+          url = "mysql://localhost:420/?foo=bar&sslidentity=we%2Fare%2Fhere.key"
+        }"#
+    );
+
+    let config =
+        datamodel::parse_configuration_with_config_dir(schema, Vec::new(), &Path::new("/path/to/prisma")).unwrap();
+
+    assert_eq!(
+        "mysql://localhost:420/?foo=bar&sslidentity=%2Fpath%2Fto%2Fprisma%2Fwe%2Fare%2Fhere.key",
+        &config.subject.datasources[0].url.value
+    )
+}
+
+#[test]
+fn mysql_absolute_sslidentity_should_not_be_modified() {
+    let schema = indoc!(
+        r#"
+        datasource boo {
+          provider = "mysql"
+          url = "mysql://localhost:420/?foo=bar&sslidentity=%2Fwe%2Fare%2Fhere.key"
+        }"#
+    );
+
+    let config =
+        datamodel::parse_configuration_with_config_dir(schema, Vec::new(), &Path::new("/path/to/prisma")).unwrap();
+
+    assert_eq!(
+        "mysql://localhost:420/?foo=bar&sslidentity=%2Fwe%2Fare%2Fhere.key",
+        &config.subject.datasources[0].url.value
+    )
+}
+
+#[test]
+fn postgres_relative_sslcert_can_be_modified() {
+    let schema = indoc!(
+        r#"
+        datasource boo {
+          provider = "postgres"
+          url = "postgres://localhost:420/?foo=bar&sslcert=we%2Fare%2Fhere.crt"
+        }"#
+    );
+
+    let config =
+        datamodel::parse_configuration_with_config_dir(schema, Vec::new(), &Path::new("/path/to/prisma")).unwrap();
+
+    assert_eq!(
+        "postgres://localhost:420/?foo=bar&sslcert=%2Fpath%2Fto%2Fprisma%2Fwe%2Fare%2Fhere.crt",
+        &config.subject.datasources[0].url.value
+    )
+}
+
+#[test]
+fn postgres_absolute_sslcert_should_not_be_modified() {
+    let schema = indoc!(
+        r#"
+        datasource boo {
+          provider = "postgres"
+          url = "postgres://localhost:420/?foo=bar&sslcert=%2Fwe%2Fare%2Fhere.crt"
+        }"#
+    );
+
+    let config =
+        datamodel::parse_configuration_with_config_dir(schema, Vec::new(), &Path::new("/path/to/prisma")).unwrap();
+
+    assert_eq!(
+        "postgres://localhost:420/?foo=bar&sslcert=%2Fwe%2Fare%2Fhere.crt",
+        &config.subject.datasources[0].url.value
+    )
+}
+
+#[test]
+fn mysql_relative_sslcert_can_be_modified() {
+    let schema = indoc!(
+        r#"
+        datasource boo {
+          provider = "mysql"
+          url = "mysql://localhost:420/?foo=bar&sslcert=we%2Fare%2Fhere.crt"
+        }"#
+    );
+
+    let config =
+        datamodel::parse_configuration_with_config_dir(schema, Vec::new(), &Path::new("/path/to/prisma")).unwrap();
+
+    assert_eq!(
+        "mysql://localhost:420/?foo=bar&sslcert=%2Fpath%2Fto%2Fprisma%2Fwe%2Fare%2Fhere.crt",
+        &config.subject.datasources[0].url.value
+    )
+}
+
+#[test]
+fn mysql_absolute_sslcert_should_not_be_modified() {
+    let schema = indoc!(
+        r#"
+        datasource boo {
+          provider = "mysql"
+          url = "mysql://localhost:420/?foo=bar&sslcert=%2Fwe%2Fare%2Fhere.crt"
+        }"#
+    );
+
+    let config =
+        datamodel::parse_configuration_with_config_dir(schema, Vec::new(), &Path::new("/path/to/prisma")).unwrap();
+
+    assert_eq!(
+        "mysql://localhost:420/?foo=bar&sslcert=%2Fwe%2Fare%2Fhere.crt",
+        &config.subject.datasources[0].url.value
+    )
 }


### PR DESCRIPTION
Usage from JavaScript/N-API:

```
let qe = new QueryEngine(datamodel: dm, config_dir: "/path/to/prisma")
```