### PR TITLE
Change ME warnings/errors to not mention migrations

### DIFF
--- a/libs/test-setup/src/lib.rs
+++ b/libs/test-setup/src/lib.rs
@@ -80,6 +80,24 @@ impl TestApiArgs {
 }
 
 mod urls {
+    use super::SCHEMA_NAME;
+
+    fn db_host_and_port_postgres_11() -> (&'static str, usize) {
+        match std::env::var("IS_BUILDKITE") {
+            Ok(_) => ("test-db-postgres-11", 5432),
+            Err(_) => ("127.0.0.1", 5433),
+        }
+    }
+
+    pub fn postgres11(db_name: &str) -> String {
+        let (host, port) = db_host_and_port_postgres_11();
+
+        format!(
+            "postgresql://postgres:prisma@{}:{}/{}?schema={}&statement_cache_size=0&socket_timeout=60",
+            host, port, db_name, SCHEMA_NAME
+        )
+    }
+
     pub use super::mariadb_url as mysql_mariadb;
     pub use super::mssql_2017_url as mssql_2017;
     pub use super::mssql_2019_url as mssql_2019;
@@ -87,7 +105,6 @@ mod urls {
     pub use super::mysql_8_url as mysql_8;
     pub use super::mysql_url as mysql;
     pub use super::postgres_10_url as postgres;
-    pub use super::postgres_11_url as postgres11;
     pub use super::postgres_12_url as postgres12;
     pub use super::postgres_13_url as postgres13;
     pub use super::postgres_9_url as postgres9;
@@ -140,15 +157,6 @@ pub fn pgbouncer_url(db_name: &str) -> String {
 
 pub fn postgres_10_url(db_name: &str) -> String {
     let (host, port) = db_host_and_port_postgres_10();
-
-    format!(
-        "postgresql://postgres:prisma@{}:{}/{}?schema={}&statement_cache_size=0&socket_timeout=60",
-        host, port, db_name, SCHEMA_NAME
-    )
-}
-
-pub fn postgres_11_url(db_name: &str) -> String {
-    let (host, port) = db_host_and_port_postgres_11();
 
     format!(
         "postgresql://postgres:prisma@{}:{}/{}?schema={}&statement_cache_size=0&socket_timeout=60",
@@ -269,13 +277,6 @@ fn db_host_and_port_for_pgbouncer() -> (&'static str, usize) {
     match std::env::var("IS_BUILDKITE") {
         Ok(_) => ("test-db-pgbouncer", 6432),
         Err(_) => ("127.0.0.1", 6432),
-    }
-}
-
-fn db_host_and_port_postgres_11() -> (&'static str, usize) {
-    match std::env::var("IS_BUILDKITE") {
-        Ok(_) => ("test-db-postgres-11", 5432),
-        Err(_) => ("127.0.0.1", 5433),
     }
 }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/unexecutable_step_check.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/unexecutable_step_check.rs
@@ -92,7 +92,7 @@ impl Check for UnexecutableStepCheck {
                         ))
                     },
                     (_, _) => Some(format!(
-                        "Made the column `{column}` on table `{table}` required. The step will fail if there are existing NULL values in that column.",
+                        "Made the column `{column}` on table `{table}` required. This step will fail if there are existing NULL values in that column.",
                         column = column,
                         table = table
                     )),

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/unexecutable_step_check.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/unexecutable_step_check.rs
@@ -45,7 +45,7 @@ impl Check for UnexecutableStepCheck {
                 let message = match database_checks.get_row_count(table) {
                     Some(0) => return None, // Adding a required column is possible if there is no data
                     Some(row_count) => message(format_args!(
-                        "There are {row_count} rows in this table, it is not possible to execute this migration.",
+                        "There are {row_count} rows in this table, it is not possible to execute this step.",
                         row_count = row_count
                     )),
                     None => message(format_args!("This is not possible if the table is not empty.")),
@@ -66,7 +66,7 @@ impl Check for UnexecutableStepCheck {
                 let message = match database_checks.get_row_count(table) {
                     Some(0) => return None, // Adding a required column is possible if there is no data
                     Some(row_count) => message(format_args!(
-                        "There are {row_count} rows in this table, it is not possible to execute this migration.",
+                        "There are {row_count} rows in this table, it is not possible to execute this step.",
                         row_count = row_count
                     )),
                     None => message(format_args!("This is not possible if the table is not empty.")),
@@ -92,7 +92,7 @@ impl Check for UnexecutableStepCheck {
                         ))
                     },
                     (_, _) => Some(format!(
-                        "Made the column `{column}` on table `{table}` required. The migration will fail if there are existing NULL values in that column.",
+                        "Made the column `{column}` on table `{table}` required. The step will fail if there are existing NULL values in that column.",
                         column = column,
                         table = table
                     )),
@@ -107,11 +107,11 @@ impl Check for UnexecutableStepCheck {
                     (Some(0), _) => None,
                     (_, Some(0)) => None,
                     (_, Some(value_count)) => Some(message(format_args!(
-                        "There are {} existing non-null values in that column, this migration step cannot be executed.",
+                        "There are {} existing non-null values in that column, this step cannot be executed.",
                         value_count
                     ))),
                     (_, _) => Some(message(format_args!(
-                        "If there are non-null values in that column, this migration step will fail."
+                        "If there are non-null values in that column, this step will fail."
                     ))),
                 }
             }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/warning_check.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/warning_check.rs
@@ -96,16 +96,16 @@ impl Check for SqlMigrationWarningCheck {
             SqlMigrationWarningCheck::NotCastable { table, column, previous_type, next_type } => match database_check_results.get_row_and_non_null_value_count(table, column) {
                 (Some(0), _) => None, // it's safe to alter a column on an empty table
                 (_, Some(0)) => None, // it's safe to alter a column if it only contains null values
-                (_, Some(value_count)) => Some(format!("You are about to alter the column `{column_name}` on the `{table_name}` table, which contains {value_count} non-null values. The data in that column will be cast from `{old_type}` to `{new_type}`. This cast may fail and the migration will stop. Please make sure the data in the column can be cast.", column_name = column, table_name = table, value_count = value_count, old_type = previous_type, new_type = next_type)),
-                (_, _) => Some(format!("You are about to alter the column `{column_name}` on the `{table_name}` table. The data in that column will be cast from `{old_type}` to `{new_type}`. This cast may fail and the migration will stop. Please make sure the data in the column can be cast.", column_name = column, table_name = table, old_type = previous_type, new_type = next_type)),
+                (_, Some(value_count)) => Some(format!("You are about to alter the column `{column_name}` on the `{table_name}` table, which contains {value_count} non-null values. The data in that column will be cast from `{old_type}` to `{new_type}`. This cast may fail. Please make sure the data in the column can be cast.", column_name = column, table_name = table, value_count = value_count, old_type = previous_type, new_type = next_type)),
+                (_, _) => Some(format!("You are about to alter the column `{column_name}` on the `{table_name}` table. The data in that column will be cast from `{old_type}` to `{new_type}`. This cast may fail. Please make sure the data in the column can be cast.", column_name = column, table_name = table, old_type = previous_type, new_type = next_type)),
 
             },
             SqlMigrationWarningCheck::PrimaryKeyChange { table } => match database_check_results.get_row_count(table) {
                 Some(0) => None,
-                _ => Some(format!("The migration will change the primary key for the `{table}` table. If it partially fails, the table could be left without primary key constraint.", table = table)),
+                _ => Some(format!("The primary key for the `{table}` table will be changed. If it partially fails, the table could be left without primary key constraint.", table = table)),
             },
-            SqlMigrationWarningCheck::UniqueConstraintAddition { table, columns } =>  Some(format!("The migration will add a unique constraint covering the columns `{columns}` on the table `{table}`. If there are existing duplicate values, the migration will fail.", table = table, columns = format!("[{}]",columns.join(",")))),
-            SqlMigrationWarningCheck::EnumValueRemoval { enm, values } =>  Some(format!("The migration will remove the values {values} on the enum `{enm}`. If these variants are still used in the database, the migration will fail.", enm = enm, values = format!("[{}]",values.join(",")))),
+            SqlMigrationWarningCheck::UniqueConstraintAddition { table, columns } =>  Some(format!("A unique constraint covering the columns `{columns}` on the table `{table}` will be removed. If there are existing duplicate values, this will fail.", table = table, columns = format!("[{}]",columns.join(",")))),
+            SqlMigrationWarningCheck::EnumValueRemoval { enm, values } =>  Some(format!("The values {values} on the enum `{enm}` will be removed. If these variants are still used in the database, this will fail.", enm = enm, values = format!("[{}]",values.join(",")))),
 
         }
     }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/warning_check.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/warning_check.rs
@@ -104,7 +104,7 @@ impl Check for SqlMigrationWarningCheck {
                 Some(0) => None,
                 _ => Some(format!("The primary key for the `{table}` table will be changed. If it partially fails, the table could be left without primary key constraint.", table = table)),
             },
-            SqlMigrationWarningCheck::UniqueConstraintAddition { table, columns } =>  Some(format!("A unique constraint covering the columns `{columns}` on the table `{table}` will be removed. If there are existing duplicate values, this will fail.", table = table, columns = format!("[{}]",columns.join(",")))),
+            SqlMigrationWarningCheck::UniqueConstraintAddition { table, columns } =>  Some(format!("A unique constraint covering the columns `{columns}` on the table `{table}` will be added. If there are existing duplicate values, this will fail.", table = table, columns = format!("[{}]",columns.join(",")))),
             SqlMigrationWarningCheck::EnumValueRemoval { enm, values } =>  Some(format!("The values {values} on the enum `{enm}` will be removed. If these variants are still used in the database, this will fail.", enm = enm, values = format!("[{}]",values.join(",")))),
 
         }

--- a/migration-engine/migration-engine-tests/tests/existing_data/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_data/mod.rs
@@ -2,7 +2,7 @@ mod sql_unexecutable_migrations;
 mod sqlite_existing_data_tests;
 mod type_migration_tests;
 
-use migration_engine_tests::sql::*;
+use migration_engine_tests::sql::{test_each_connector, TestApi, TestResult};
 use pretty_assertions::assert_eq;
 use prisma_value::PrismaValue;
 use quaint::{
@@ -717,9 +717,9 @@ async fn enum_variants_can_be_dropped_without_data_loss(api: &TestApi) -> TestRe
         .await?;
 
     if api.sql_family().is_mysql() {
-        res.assert_warnings(&["The migration will remove the values [OUTRAGED] on the enum `Cat_mood`. If these variants are still used in the database, the migration will fail.".into(), "The migration will remove the values [OUTRAGED] on the enum `Human_mood`. If these variants are still used in the database, the migration will fail.".into()])?;
+        res.assert_warnings(&["The values [OUTRAGED] on the enum `Cat_mood` will be removed. If these variants are still used in the database, this will fail.".into(), "The values [OUTRAGED] on the enum `Human_mood` will be removed. If these variants are still used in the database, this will fail.".into()])?;
     } else {
-        res.assert_warnings(&["The migration will remove the values [OUTRAGED] on the enum `Mood`. If these variants are still used in the database, the migration will fail.".into()])?;
+        res.assert_warnings(&["The values [OUTRAGED] on the enum `Mood` will be removed. If these variants are still used in the database, this will fail.".into()])?;
     }
 
     // Assertions
@@ -867,7 +867,7 @@ async fn primary_key_migrations_do_not_cause_data_loss(api: &TestApi) -> TestRes
         .await?
         .assert_executable()?
         .assert_warnings(&[
-            "The migration will change the primary key for the `Dog` table. If it partially fails, the table could be left without primary key constraint.".into(),
+            "The primary key for the `Dog` table will be changed. If it partially fails, the table could be left without primary key constraint.".into(),
         ])?;
 
     api.assert_schema().await?.assert_table("Dog", |table| {

--- a/migration-engine/migration-engine-tests/tests/existing_data/sql_unexecutable_migrations/added_required_field_to_table.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_data/sql_unexecutable_migrations/added_required_field_to_table.rs
@@ -32,7 +32,7 @@ async fn adding_a_required_field_to_an_existing_table_with_data_without_a_defaul
         .send()
         .await?
         .assert_no_warning()?
-        .assert_unexecutable(&["Added the required column `age` to the `Test` table without a default value. There are 1 rows in this table, it is not possible to execute this migration.".to_string()])?;
+        .assert_unexecutable(&["Added the required column `age` to the `Test` table without a default value. There are 1 rows in this table, it is not possible to execute this step.".to_string()])?;
 
     let rows = api.select("Test").column("id").column("name").send().await?;
 
@@ -71,7 +71,7 @@ async fn adding_a_required_field_with_prisma_level_default_works(api: &TestApi) 
         .send()
         .await?
         .assert_no_warning()?
-        .assert_unexecutable(&["The required column `name` was added to the `Test` table with a prisma-level default value. There are 1 rows in this table, it is not possible to execute this migration. Please add this column as optional, then populate it before making it required.".into()])?;
+        .assert_unexecutable(&["The required column `name` was added to the `Test` table with a prisma-level default value. There are 1 rows in this table, it is not possible to execute this step. Please add this column as optional, then populate it before making it required.".into()])?;
 
     let rows = api.select("Test").column("id").column("age").send().await?;
 

--- a/migration-engine/migration-engine-tests/tests/existing_data/sql_unexecutable_migrations/added_unimplementable_unique_constraint.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_data/sql_unexecutable_migrations/added_unimplementable_unique_constraint.rs
@@ -36,7 +36,7 @@ async fn adding_a_unique_constraint_should_warn(api: &TestApi) -> TestResult {
         .force(false)
         .send()
         .await?
-        .assert_warnings(&["The migration will add a unique constraint covering the columns `[name]` on the table `Test`. If there are existing duplicate values, the migration will fail.".into()])?;
+        .assert_warnings(&["A unique constraint covering the columns `[name]` on the table `Test` will be added. If there are existing duplicate values, this will fail.".into()])?;
 
     let rows = api.select("Test").column("id").column("name").send_debug().await?;
 
@@ -100,7 +100,7 @@ async fn dropping_enum_values_should_warn(api: &TestApi) -> TestResult {
         .force(false)
         .send()
         .await?
-        .assert_warnings(&["The migration will remove the values [george] on the enum `Test_name`. If these variants are still used in the database, the migration will fail.".into()])?;
+        .assert_warnings(&["The values [george] on the enum `Test_name` will be removed. If these variants are still used in the database, this will fail.".into()])?;
 
     let rows = api.select("Test").column("id").column("name").send_debug().await?;
 
@@ -159,7 +159,7 @@ async fn adding_a_unique_constraint_when_existing_data_respects_it_works(api: &T
         .force(true)
         .send()
         .await?
-        .assert_warnings(&["The migration will add a unique constraint covering the columns `[name]` on the table `Test`. If there are existing duplicate values, the migration will fail.".into()])?;
+        .assert_warnings(&["A unique constraint covering the columns `[name]` on the table `Test` will be added. If there are existing duplicate values, this will fail.".into()])?;
 
     let rows = api.select("Test").column("id").column("name").send_debug().await?;
     assert_eq!(

--- a/migration-engine/migration-engine-tests/tests/migration_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migration_tests.rs
@@ -1219,7 +1219,7 @@ async fn adding_unique_to_an_existing_field_must_work(api: &TestApi) -> TestResu
         .send()
         .await?
         .assert_executable()?
-        .assert_warnings(&["The migration will add a unique constraint covering the columns `[field]` on the table `A`. If there are existing duplicate values, the migration will fail.".into()])?
+        .assert_warnings(&["A unique constraint covering the columns `[field]` on the table `A` will be added. If there are existing duplicate values, this will fail.".into()])?
         .assert_has_executed_steps()?;
 
     api.assert_schema().await?.assert_table("A", |table| {
@@ -2219,7 +2219,7 @@ async fn adding_mutual_references_on_existing_tables_works(api: &TestApi) -> Tes
     if api.sql_family().is_sqlite() {
         res.assert_green()?;
     } else {
-        res.assert_warnings(&["The migration will add a unique constraint covering the columns `[name]` on the table `A`. If there are existing duplicate values, the migration will fail.".into(), "The migration will add a unique constraint covering the columns `[email]` on the table `B`. If there are existing duplicate values, the migration will fail.".into()])?;
+        res.assert_warnings(&["A unique constraint covering the columns `[name]` on the table `A` will be added. If there are existing duplicate values, this will fail.".into(), "A unique constraint covering the columns `[email]` on the table `B` will be added. If there are existing duplicate values, this will fail.".into()])?;
     };
 
     Ok(())
@@ -2355,7 +2355,7 @@ async fn migrating_a_unique_constraint_to_a_primary_key_works(api: &TestApi) -> 
         .send()
         .await?
         .assert_executable()?
-        .assert_warnings(&["The migration will change the primary key for the `model1` table. If it partially fails, the table could be left without primary key constraint.".into(), "You are about to drop the column `id` on the `model1` table, which still contains 1 non-null values.".into()])?;
+        .assert_warnings(&["The primary key for the `model1` table will be changed. If it partially fails, the table could be left without primary key constraint.".into(), "You are about to drop the column `id` on the `model1` table, which still contains 1 non-null values.".into()])?;
 
     api.assert_schema().await?.assert_table("model1", |table| {
         table.assert_pk(|pk| pk.assert_columns(&["a", "b", "c"]))

--- a/migration-engine/migration-engine-tests/tests/migrations/enums.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/enums.rs
@@ -141,7 +141,7 @@ async fn variants_can_be_removed_from_an_existing_enum(api: &TestApi) -> TestRes
         .force(true)
         .send()
         .await?
-        .assert_warnings(&[format!("The migration will remove the values [HAPPY] on the enum `{}`. If these variants are still used in the database, the migration will fail.", enum_name).into()])?
+        .assert_warnings(&[format!("The values [HAPPY] on the enum `{}` will be removed. If these variants are still used in the database, this will fail.", enum_name).into()])?
         .assert_executable()?;
 
     api.assert_schema()
@@ -267,7 +267,7 @@ async fn string_field_to_enum_field_works(api: &TestApi) -> TestResult {
     Ok(())
 }
 
-#[test_each_connector(log = "debug", capabilities("enums"))]
+#[test_each_connector(capabilities("enums"))]
 async fn enums_used_in_default_can_be_changed(api: &TestApi) -> TestResult {
     let dm1 = r#"
         model Panther {
@@ -354,7 +354,7 @@ async fn enums_used_in_default_can_be_changed(api: &TestApi) -> TestResult {
             .send()
             .await?
             .assert_executable()?
-            .assert_warnings(&["The migration will remove the values [HUNGRY] on the enum `CatMood`. If these variants are still used in the database, the migration will fail.".into()]
+            .assert_warnings(&["The values [HUNGRY] on the enum `CatMood` will be removed. If these variants are still used in the database, this will fail.".into()]
             )?;
     } else {
         api.schema_push(dm2)
@@ -362,8 +362,8 @@ async fn enums_used_in_default_can_be_changed(api: &TestApi) -> TestResult {
             .send()
             .await?
             .assert_executable()?
-            .assert_warnings(& ["The migration will remove the values [HUNGRY] on the enum `Panther_mood`. If these variants are still used in the database, the migration will fail.".into(),
-                "The migration will remove the values [HUNGRY] on the enum `Tiger_mood`. If these variants are still used in the database, the migration will fail.".into(),]
+            .assert_warnings(& ["The values [HUNGRY] on the enum `Panther_mood` will be removed. If these variants are still used in the database, this will fail.".into(),
+                "The values [HUNGRY] on the enum `Tiger_mood` will be removed. If these variants are still used in the database, this will fail.".into(),]
             )?;
     };
 

--- a/migration-engine/migration-engine-tests/tests/migrations/indexes.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/indexes.rs
@@ -71,7 +71,7 @@ async fn index_settings_must_be_migrated(api: &TestApi) -> TestResult {
         .force(true)
         .send()
         .await?
-        .assert_warnings(&["The migration will add a unique constraint covering the columns `[name,followersCount]` on the table `Test`. If there are existing duplicate values, the migration will fail.".into()])?;
+        .assert_warnings(&["A unique constraint covering the columns `[name,followersCount]` on the table `Test` will be added. If there are existing duplicate values, this will fail.".into()])?;
 
     api.assert_schema().await?.assert_table("Test", |table| {
         table

--- a/migration-engine/migration-engine-tests/tests/migrations/sql.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/sql.rs
@@ -135,12 +135,12 @@ async fn enum_value_with_database_names_must_work(api: &TestApi) -> TestResult {
     "##;
 
     if api.is_mysql() {
-        api.schema_push(dm).force(true).send().await?.assert_warnings(&["The migration will remove the values [hongry] on the enum `Cat_mood`. If these variants are still used in the database, the migration will fail.".into()])?;
+        api.schema_push(dm).force(true).send().await?.assert_warnings(&["The values [hongry] on the enum `Cat_mood` will be removed. If these variants are still used in the database, this will fail.".into()])?;
         api.assert_schema()
             .await?
             .assert_enum("Cat_mood", |enm| enm.assert_values(&["ANGRY", "hongery"]))?;
     } else {
-        api.schema_push(dm).force(true).send().await?.assert_warnings(&["The migration will remove the values [hongry] on the enum `CatMood`. If these variants are still used in the database, the migration will fail.".into()])?;
+        api.schema_push(dm).force(true).send().await?.assert_warnings(&["The values [hongry] on the enum `CatMood` will be removed. If these variants are still used in the database, this will fail.".into()])?;
         api.assert_schema()
             .await?
             .assert_enum("CatMood", |enm| enm.assert_values(&["ANGRY", "hongery"]))?;

--- a/migration-engine/migration-engine-tests/tests/migrations/unsupported_types.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/unsupported_types.rs
@@ -164,7 +164,7 @@ async fn adding_and_removing_properties_on_unsupported_should_work(api: &TestApi
         }
     "#;
 
-    api.schema_push(dm2).force(true).send().await?.assert_warnings(&["The migration will add a unique constraint covering the columns `[user_ip]` on the table `Post`. If there are existing duplicate values, the migration will fail.".into()])?;
+    api.schema_push(dm2).force(true).send().await?.assert_warnings(&["A unique constraint covering the columns `[user_ip]` on the table `Post` will be added. If there are existing duplicate values, this will fail.".into()])?;
 
     api.assert_schema().await?.assert_table("Post", |table| {
         table

--- a/migration-engine/migration-engine-tests/tests/schema_push/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/schema_push/mod.rs
@@ -137,7 +137,7 @@ async fn schema_push_with_an_unexecutable_migration_returns_a_message_and_aborts
     api.schema_push(dm2)
         .send()
         .await?
-        .assert_unexecutable(&["Added the required column `volumeCm3` to the `Box` table without a default value. There are 1 rows in this table, it is not possible to execute this migration.".into()])?
+        .assert_unexecutable(&["Added the required column `volumeCm3` to the `Box` table without a default value. There are 1 rows in this table, it is not possible to execute this step.".into()])?
         .assert_no_steps()?;
 
     Ok(())


### PR DESCRIPTION
Because they are also displayed in `db push`, and this is confusing.

closes https://github.com/prisma/migrations-team/issues/212