### PR TITLE
feat: add order by aggregate scalar on group by

### DIFF
--- a/libs/datamodel/core/src/common/preview_features.rs
+++ b/libs/datamodel/core/src/common/preview_features.rs
@@ -11,6 +11,7 @@ const CREATE_MANY: &str = "createMany";
 const ORDER_BY_RELATION: &str = "orderByRelation";
 const NAPI: &str = "napi";
 const SELECT_RELATION_COUNT: &str = "selectRelationCount";
+const ORDER_BY_AGGREGATE_GROUP: &str = "orderByAggregateGroup";
 
 // deprecated preview features
 const ATOMIC_NUMBER_OPERATIONS: &str = "atomicNumberOperations";
@@ -21,7 +22,13 @@ const UNCHECKED_SCALAR_INPUTS: &str = "uncheckedScalarInputs";
 
 pub const DATASOURCE_PREVIEW_FEATURES: &[&str] = &[];
 
-pub const GENERATOR_PREVIEW_FEATURES: &[&str] = &[SQL_SERVER, ORDER_BY_RELATION, NAPI, SELECT_RELATION_COUNT];
+pub const GENERATOR_PREVIEW_FEATURES: &[&str] = &[
+    SQL_SERVER,
+    ORDER_BY_RELATION,
+    NAPI,
+    SELECT_RELATION_COUNT,
+    ORDER_BY_AGGREGATE_GROUP,
+];
 
 pub const DEPRECATED_GENERATOR_PREVIEW_FEATURES: &[&str] = &[
     ATOMIC_NUMBER_OPERATIONS,

--- a/libs/feature-flags/src/lib.rs
+++ b/libs/feature-flags/src/lib.rs
@@ -56,7 +56,15 @@ macro_rules! flags {
 // `orderByRelation`: Allows ordering by to-one relation in the QE API.
 // `mongoDb`: Support for MongoDB.
 // `selectRelationCount`: Allows selecting `_count` on to-many relations in find queries.
-flags!(microsoftSqlServer, orderByRelation, napi, mongoDb, selectRelationCount);
+// `orderByAggregateGroup`: Allows ordering by aggregations of scalars in groupBy
+flags!(
+    microsoftSqlServer,
+    orderByRelation,
+    napi,
+    mongoDb,
+    selectRelationCount,
+    orderByAggregateGroup
+);
 
 /// Initializes the feature flags with given flags.
 /// Noop if already initialized.

--- a/libs/prisma-models/src/order_by.rs
+++ b/libs/prisma-models/src/order_by.rs
@@ -33,7 +33,7 @@ pub enum SortOrder {
 }
 
 impl SortOrder {
-    pub fn into_order(&self, reverse: bool) -> Order {
+    pub fn into_order(self, reverse: bool) -> Order {
         match (self, reverse) {
             (SortOrder::Ascending, false) => Order::Asc,
             (SortOrder::Descending, false) => Order::Desc,

--- a/libs/prisma-models/src/order_by.rs
+++ b/libs/prisma-models/src/order_by.rs
@@ -1,4 +1,5 @@
-use crate::{ModelRef, RelationFieldRef, ScalarFieldRef};
+use crate::{RelationFieldRef, ScalarFieldRef};
+use quaint::prelude::Order;
 use std::string::ToString;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -25,19 +26,30 @@ impl OrderBy {
     }
 }
 
-pub trait IntoOrderBy {
-    fn into_order_by(self, model: ModelRef) -> OrderBy;
-}
-
 #[derive(Clone, Copy, PartialEq, Debug, Eq, Hash)]
 pub enum SortOrder {
     Ascending,
     Descending,
 }
 
+impl SortOrder {
+    pub fn into_order(&self, reverse: bool) -> Order {
+        match (self, reverse) {
+            (SortOrder::Ascending, false) => Order::Asc,
+            (SortOrder::Descending, false) => Order::Desc,
+            (SortOrder::Ascending, true) => Order::Desc,
+            (SortOrder::Descending, true) => Order::Asc,
+        }
+    }
+}
+
 #[derive(Clone, Copy, PartialEq, Debug, Eq, Hash)]
 pub enum SortAggregation {
-    Count { _all: bool },
+    Count,
+    Avg,
+    Sum,
+    Min,
+    Max,
 }
 
 impl ToString for SortOrder {

--- a/query-engine/connector-test-kit/src/test/scala/queries/aggregation/GroupByQuerySpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/aggregation/GroupByQuerySpec.scala
@@ -272,6 +272,233 @@ class GroupByQuerySpec extends FlatSpec with Matchers with ApiSpecBase {
     result.toString should be("""{"data":{"groupByModel":[{"s":"group3","count":{"s":2},"sum":{"float":25},"min":{"int":5}}]}}""")
   }
 
+
+  "Using a group-by with ordering COUNT aggregation" should "work" in {
+    // Float, int, dec, s, id
+    create(1.1, 1, "11", "group1", Some("1"))
+    create(1.1, 2, "11", "group1", Some("2"))
+    create(1.1, 3, "3", "group2", Some("3"))
+    create(4.0, 3, "4", "group3", Some("4"))
+
+    var result = server.query(
+      s"""{
+         |  groupByModel(by: [float], orderBy: { _count: { float: asc } }) {
+         |    float
+         |    count {
+         |      float
+         |    }
+         |  }
+         |}""".stripMargin,
+      project
+    )
+
+    result.toString should be("""{"data":{"groupByModel":[{"float":4,"count":{"float":1}},{"float":1.1,"count":{"float":3}}]}}""")
+
+    result = server.query(
+      s"""{
+         |  groupByModel(by: [float], orderBy: { _count: { float: desc } }) {
+         |    float
+         |    count {
+         |      float
+         |    }
+         |  }
+         |}""".stripMargin,
+      project
+    )
+
+    result.toString should be("""{"data":{"groupByModel":[{"float":1.1,"count":{"float":3}},{"float":4,"count":{"float":1}}]}}""")
+  }
+
+  "Using a group-by with ordering SUM aggregation" should "work" in {
+    // Float, int, dec, s, id
+    create(1.1, 1, "11", "group1", Some("1"))
+    create(1.1, 2, "11", "group1", Some("2"))
+    create(1.1, 3, "3", "group2", Some("3"))
+    create(4.0, 3, "4", "group3", Some("4"))
+
+    var result = server.query(
+      s"""{
+         |  groupByModel(by: [float], orderBy: { _sum: { float: asc } }) {
+         |    float
+         |    sum {
+         |      float
+         |    }
+         |  }
+         |}""".stripMargin,
+      project
+    )
+
+    result.toString should be("""{"data":{"groupByModel":[{"float":1.1,"sum":{"float":3.3}},{"float":4,"sum":{"float":4}}]}}""")
+
+    result = server.query(
+      s"""{
+         |  groupByModel(by: [float], orderBy: { _sum: { float: desc } }) {
+         |    float
+         |    sum {
+         |      float
+         |    }
+         |  }
+         |}""".stripMargin,
+      project
+    )
+
+    result.toString should be("""{"data":{"groupByModel":[{"float":4,"sum":{"float":4}},{"float":1.1,"sum":{"float":3.3}}]}}""")
+  }
+
+  "Using a group-by with ordering AVG aggregation" should "work" in {
+    // Float, int, dec, s, id
+    create(1.1, 1, "11", "group1", Some("1"))
+    create(1.1, 2, "11", "group1", Some("2"))
+    create(1.1, 3, "3", "group2", Some("3"))
+    create(4.0, 3, "4", "group3", Some("4"))
+
+    var result = server.query(
+      s"""{
+         |  groupByModel(by: [float], orderBy: { _avg: { float: asc } }) {
+         |    float
+         |    avg {
+         |      float
+         |    }
+         |  }
+         |}""".stripMargin,
+      project
+    )
+
+    result.toString should be("""{"data":{"groupByModel":[{"float":1.1,"avg":{"float":1.1}},{"float":4,"avg":{"float":4}}]}}""")
+
+    result = server.query(
+      s"""{
+         |  groupByModel(by: [float], orderBy: { _avg: { float: desc } }) {
+         |    float
+         |    avg {
+         |      float
+         |    }
+         |  }
+         |}""".stripMargin,
+      project
+    )
+
+    result.toString should be("""{"data":{"groupByModel":[{"float":4,"avg":{"float":4}},{"float":1.1,"avg":{"float":1.1}}]}}""")
+  }
+
+  "Using a group-by with ordering MIN aggregation" should "work" in {
+    // Float, int, dec, s, id
+    create(1.1, 1, "11", "group1", Some("1"))
+    create(1.1, 2, "11", "group1", Some("2"))
+    create(1.1, 3, "3", "group2", Some("3"))
+    create(4.0, 3, "4", "group3", Some("4"))
+
+    var result = server.query(
+      s"""{
+         |  groupByModel(by: [float], orderBy: { _min: { float: asc } }) {
+         |    float
+         |    min {
+         |      float
+         |    }
+         |  }
+         |}""".stripMargin,
+      project
+    )
+
+    result.toString should be("""{"data":{"groupByModel":[{"float":1.1,"min":{"float":1.1}},{"float":4,"min":{"float":4}}]}}""")
+
+    result = server.query(
+      s"""{
+         |  groupByModel(by: [float], orderBy: { _min: { float: desc } }) {
+         |    float
+         |    min {
+         |      float
+         |    }
+         |  }
+         |}""".stripMargin,
+      project
+    )
+
+    result.toString should be("""{"data":{"groupByModel":[{"float":4,"min":{"float":4}},{"float":1.1,"min":{"float":1.1}}]}}""")
+  }
+
+  "Using a group-by with ordering MAX aggregation" should "work" in {
+    // Float, int, dec, s, id
+    create(1.1, 1, "11", "group1", Some("1"))
+    create(1.1, 2, "11", "group1", Some("2"))
+    create(1.1, 3, "3", "group2", Some("3"))
+    create(4.0, 3, "4", "group3", Some("4"))
+
+    var result = server.query(
+      s"""{
+         |  groupByModel(by: [float], orderBy: { _max: { float: asc } }) {
+         |    float
+         |    max {
+         |      float
+         |    }
+         |  }
+         |}""".stripMargin,
+      project
+    )
+
+    result.toString should be("""{"data":{"groupByModel":[{"float":1.1,"max":{"float":1.1}},{"float":4,"max":{"float":4}}]}}""")
+
+    result = server.query(
+      s"""{
+         |  groupByModel(by: [float], orderBy: { _max: { float: desc } }) {
+         |    float
+         |    max {
+         |      float
+         |    }
+         |  }
+         |}""".stripMargin,
+      project
+    )
+
+    result.toString should be("""{"data":{"groupByModel":[{"float":4,"max":{"float":4}},{"float":1.1,"max":{"float":1.1}}]}}""")
+  }
+
+
+  "Using a group-by with multiple ordering aggregation of different fields" should "work" in {
+    // Float, int, dec, s, id
+    create(1.1, 1, "11", "group1", Some("1"))
+    create(1.1, 1, "11", "group1", Some("2"))
+    create(1.1, 1, "3", "group2", Some("3"))
+    create(3.0, 3, "4", "group3", Some("5"))
+    create(4.0, 4, "4", "group3", Some("4"))
+
+    val result = server.query(
+      s"""{
+         |  groupByModel(by: [float, int], orderBy: [{ _count: { float: desc } }, { _sum: { int: asc } }]) {
+         |    float
+         |    count { float }
+         |    sum { int }
+         |  }
+         |}""".stripMargin,
+      project
+    )
+
+    result.toString should be("""{"data":{"groupByModel":[{"float":1.1,"count":{"float":3},"sum":{"int":3}},{"float":3.0,"count":{"float":1},"sum":{"int":3}},{"float":4.0,"count":{"float":1},"sum":{"int":4}}]}}""")
+  }
+
+  "Using a group-by with multiple ordering aggregation and having" should "work" in {
+    // Float, int, dec, s, id
+    create(1.1, 1, "11", "group1", Some("1"))
+    create(1.1, 1, "11", "group1", Some("2"))
+    create(1.1, 1, "3", "group2", Some("3"))
+    create(3.0, 3, "4", "group3", Some("5"))
+    create(4.0, 4, "4", "group3", Some("4"))
+
+    val result = server.query(
+      s"""{
+         |  groupByModel(by: [float, int], orderBy: [{ _count: { float: desc } }, { _sum: { int: asc } }], having: { float: { lt: 4 } }) {
+         |    float
+         |    count { float }
+         |    sum { int }
+         |  }
+         |}""".stripMargin,
+      project
+    )
+
+    result.toString should be("""{"data":{"groupByModel":[{"float":1.1,"count":{"float":3},"sum":{"int":3}},{"float":3.0,"count":{"float":1},"sum":{"int":3}}]}}""")
+  }
+
+
   /////// Error Cases
 
   "Using a groupBy without any by selection" should "error" in {

--- a/query-engine/connector-test-kit/src/test/scala/queries/aggregation/GroupByQuerySpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/aggregation/GroupByQuerySpec.scala
@@ -473,7 +473,7 @@ class GroupByQuerySpec extends FlatSpec with Matchers with ApiSpecBase {
       project
     )
 
-    result.toString should be("""{"data":{"groupByModel":[{"float":1.1,"count":{"float":3},"sum":{"int":3}},{"float":3.0,"count":{"float":1},"sum":{"int":3}},{"float":4.0,"count":{"float":1},"sum":{"int":4}}]}}""")
+    result.toString should be("""{"data":{"groupByModel":[{"float":1.1,"count":{"float":3},"sum":{"int":3}},{"float":3,"count":{"float":1},"sum":{"int":3}},{"float":4,"count":{"float":1},"sum":{"int":4}}]}}""")
   }
 
   "Using a group-by with multiple ordering aggregation and having" should "work" in {
@@ -495,7 +495,7 @@ class GroupByQuerySpec extends FlatSpec with Matchers with ApiSpecBase {
       project
     )
 
-    result.toString should be("""{"data":{"groupByModel":[{"float":1.1,"count":{"float":3},"sum":{"int":3}},{"float":3.0,"count":{"float":1},"sum":{"int":3}}]}}""")
+    result.toString should be("""{"data":{"groupByModel":[{"float":1.1,"count":{"float":3},"sum":{"int":3}},{"float":3,"count":{"float":1},"sum":{"int":3}}]}}""")
   }
 
 

--- a/query-engine/connector-test-kit/src/test/scala/queries/aggregation/GroupByQuerySpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/aggregation/GroupByQuerySpec.scala
@@ -498,6 +498,23 @@ class GroupByQuerySpec extends FlatSpec with Matchers with ApiSpecBase {
     result.toString should be("""{"data":{"groupByModel":[{"float":1.1,"count":{"float":3},"sum":{"int":3}},{"float":3,"count":{"float":1},"sum":{"int":3}}]}}""")
   }
 
+  "Using a group-by with order by aggregation without selecting the ordered field" should "work" in {
+    // Float, int, dec, s, id
+    create(1.1, 1, "11", "group1", Some("1"))
+    create(1.1, 1, "11", "group1", Some("2"))
+    create(1.1, 1, "3", "group2", Some("3"))
+
+    val result = server.query(
+      s"""{
+         |  groupByModel(by: [float], orderBy: { _count: { float: desc } }) {
+         |    sum { int }
+         |  }
+         |}""".stripMargin,
+      project
+    )
+
+    result.toString should be("""{"data":{"groupByModel":[{"sum":{"int":3}}]}}""")
+  }
 
   /////// Error Cases
 

--- a/query-engine/connectors/sql-query-connector/src/ordering.rs
+++ b/query-engine/connectors/sql-query-connector/src/ordering.rs
@@ -28,28 +28,28 @@ pub fn build(
     // The index is used to differentiate potentially separate relations to the same model.
     for (index, order_by) in query_arguments.order_by.iter().enumerate() {
         let (joins, order_column) = compute_joins(order_by, index, base_model);
-        let order_dir = Some(order_by.sort_order.into_order(needs_reversed_order));
+        let order = Some(order_by.sort_order.into_order(needs_reversed_order));
 
         if joins.is_empty() && order_by.sort_aggregation.is_some() {
             match order_by.sort_aggregation.unwrap() {
                 SortAggregation::Count => {
-                    order_definitions.push((count(order_column.clone()).into(), order_dir));
+                    order_definitions.push((count(order_column.clone()).into(), order));
                 }
                 SortAggregation::Avg => {
-                    order_definitions.push((avg(order_column.clone()).into(), order_dir));
+                    order_definitions.push((avg(order_column.clone()).into(), order));
                 }
                 SortAggregation::Sum => {
-                    order_definitions.push((sum(order_column.clone()).into(), order_dir));
+                    order_definitions.push((sum(order_column.clone()).into(), order));
                 }
                 SortAggregation::Min => {
-                    order_definitions.push((min(order_column.clone()).into(), order_dir));
+                    order_definitions.push((min(order_column.clone()).into(), order));
                 }
                 SortAggregation::Max => {
-                    order_definitions.push((max(order_column.clone()).into(), order_dir));
+                    order_definitions.push((max(order_column.clone()).into(), order));
                 }
             }
         } else {
-            order_definitions.push((order_column.clone().into(), order_dir));
+            order_definitions.push((order_column.clone().into(), order));
         }
 
         ordering_joins.push(OrderingJoins { joins, order_column });

--- a/query-engine/connectors/sql-query-connector/src/ordering.rs
+++ b/query-engine/connectors/sql-query-connector/src/ordering.rs
@@ -52,10 +52,7 @@ pub fn build(
             order_definitions.push((order_column.clone().into(), order_dir));
         }
 
-        ordering_joins.push(OrderingJoins {
-            joins,
-            order_column: order_column,
-        });
+        ordering_joins.push(OrderingJoins { joins, order_column });
     }
 
     (order_definitions, ordering_joins)

--- a/query-engine/core/src/query_graph_builder/extractors/query_arguments.rs
+++ b/query-engine/core/src/query_graph_builder/extractors/query_arguments.rs
@@ -101,16 +101,17 @@ fn process_order_object(
     match object.into_iter().next() {
         None => Ok(None),
         Some((field_name, field_value)) => {
-            let field = model.fields().find_from_all(&field_name).ok();
+            let sort_aggregation = extract_sort_aggregation(field_name.as_str());
 
-            if field.is_none() {
-                let sort_aggregation = extract_sort_aggregation(field_name.as_str())?;
+            if let Ok(sort_aggr) = sort_aggregation {
                 let object: ParsedInputMap = field_value.try_into()?;
 
-                return process_order_object(model, object, path, Some(sort_aggregation));
+                return process_order_object(model, object, path, Some(sort_aggr));
             }
 
-            match field.unwrap() {
+            let field = model.fields().find_from_all(&field_name)?;
+
+            match field {
                 Field::Relation(rf) if rf.is_list => {
                     path.push(rf.clone());
 

--- a/query-engine/core/src/query_graph_builder/extractors/query_arguments.rs
+++ b/query-engine/core/src/query_graph_builder/extractors/query_arguments.rs
@@ -77,12 +77,12 @@ fn extract_order_by(model: &ModelRef, value: ParsedInputValue) -> QueryGraphBuil
             .into_iter()
             .map(|list_value| {
                 let object: ParsedInputMap = list_value.try_into()?;
-                Ok(process_order_object(model, object, vec![])?)
+                Ok(process_order_object(model, object, vec![], None)?)
             })
             .collect::<QueryGraphBuilderResult<Vec<_>>>()
             .map(|results| results.into_iter().filter_map(identity).collect()),
 
-        ParsedInputValue::Map(map) => Ok(match process_order_object(model, map, vec![])? {
+        ParsedInputValue::Map(map) => Ok(match process_order_object(model, map, vec![], None)? {
             Some(order) => vec![order],
             None => vec![],
         }),
@@ -96,17 +96,28 @@ fn process_order_object(
     model: &ModelRef,
     object: ParsedInputMap,
     mut path: Vec<RelationFieldRef>,
+    parent_sort_aggregation: Option<SortAggregation>,
 ) -> QueryGraphBuilderResult<Option<OrderBy>> {
     match object.into_iter().next() {
         None => Ok(None),
         Some((field_name, field_value)) => {
-            let field = model.fields().find_from_all(&field_name)?;
-            match field {
+            let field = model.fields().find_from_all(&field_name).ok();
+
+            if field.is_none() {
+                let sort_aggregation = extract_sort_aggregation(field_name.as_str())?;
+                let object: ParsedInputMap = field_value.try_into()?;
+
+                return process_order_object(model, object, path, Some(sort_aggregation));
+            }
+
+            match field.unwrap() {
                 Field::Relation(rf) if rf.is_list => {
                     path.push(rf.clone());
 
                     let object: ParsedInputMap = field_value.try_into()?;
-                    let (sort_aggregation, sort_order) = extract_sort_aggregation(object)?;
+                    let (inner_field_name, inner_field_value) = object.into_iter().next().unwrap();
+                    let sort_aggregation = extract_sort_aggregation(inner_field_name.as_str())?;
+                    let sort_order = extract_sort_order(inner_field_value)?;
                     let ids: Vec<_> = rf.related_model().primary_identifier().scalar_fields().collect();
                     // FIXME: This is a hack to fulfil the requirement of the `OrderBy` struct to have a field to order by
                     // In the case of aggregations, at least for now, we use AGGR(*), meaning that this field won't ever be used
@@ -124,27 +135,34 @@ fn process_order_object(
                     path.push(rf.clone());
 
                     let object: ParsedInputMap = field_value.try_into()?;
-                    process_order_object(&rf.related_model(), object, path)
+                    process_order_object(&rf.related_model(), object, path, None)
                 }
                 Field::Scalar(sf) => {
                     let sort_order = extract_sort_order(field_value)?;
 
-                    Ok(Some(OrderBy::new(sf.clone(), path, sort_order, None)))
+                    Ok(Some(OrderBy::new(
+                        sf.clone(),
+                        path,
+                        sort_order,
+                        parent_sort_aggregation,
+                    )))
                 }
             }
         }
     }
 }
 
-fn extract_sort_aggregation(object: ParsedInputMap) -> QueryGraphBuilderResult<(SortAggregation, SortOrder)> {
-    let (field_name, field_value) = object.into_iter().next().unwrap();
-    let sort_order = extract_sort_order(field_value)?;
-    let sort_aggregation = match field_name.as_str() {
-        filters::COUNT => Some(SortAggregation::Count { _all: true }),
+fn extract_sort_aggregation(field_name: &str) -> QueryGraphBuilderResult<SortAggregation> {
+    let sort_aggregation = match field_name {
+        filters::COUNT | filters::UNDERSCORE_COUNT => SortAggregation::Count,
+        filters::UNDERSCORE_AVG => SortAggregation::Avg,
+        filters::UNDERSCORE_SUM => SortAggregation::Sum,
+        filters::UNDERSCORE_MIN => SortAggregation::Min,
+        filters::UNDERSCORE_MAX => SortAggregation::Max,
         _ => unreachable!("No aggregation operation could be found. This should not happen"),
     };
 
-    Ok((sort_aggregation.unwrap(), sort_order))
+    Ok(sort_aggregation)
 }
 
 fn extract_sort_order(field_value: ParsedInputValue) -> QueryGraphBuilderResult<SortOrder> {

--- a/query-engine/core/src/query_graph_builder/extractors/query_arguments.rs
+++ b/query-engine/core/src/query_graph_builder/extractors/query_arguments.rs
@@ -154,16 +154,16 @@ fn process_order_object(
 }
 
 fn extract_sort_aggregation(field_name: &str) -> QueryGraphBuilderResult<SortAggregation> {
-    let sort_aggregation = match field_name {
-        filters::COUNT | filters::UNDERSCORE_COUNT => SortAggregation::Count,
-        filters::UNDERSCORE_AVG => SortAggregation::Avg,
-        filters::UNDERSCORE_SUM => SortAggregation::Sum,
-        filters::UNDERSCORE_MIN => SortAggregation::Min,
-        filters::UNDERSCORE_MAX => SortAggregation::Max,
-        _ => unreachable!("No aggregation operation could be found. This should not happen"),
-    };
-
-    Ok(sort_aggregation)
+    match field_name {
+        filters::COUNT | filters::UNDERSCORE_COUNT => Ok(SortAggregation::Count),
+        filters::UNDERSCORE_AVG => Ok(SortAggregation::Avg),
+        filters::UNDERSCORE_SUM => Ok(SortAggregation::Sum),
+        filters::UNDERSCORE_MIN => Ok(SortAggregation::Min),
+        filters::UNDERSCORE_MAX => Ok(SortAggregation::Max),
+        _ => Err(QueryGraphBuilderError::InputError(
+            "No aggregation operation could be found. This should not happen".to_string(),
+        )),
+    }
 }
 
 fn extract_sort_order(field_value: ParsedInputValue) -> QueryGraphBuilderResult<SortOrder> {

--- a/query-engine/core/src/schema_builder/constants.rs
+++ b/query-engine/core/src/schema_builder/constants.rs
@@ -99,10 +99,15 @@ pub mod inputs {
 
         // aggregation filters
         pub const COUNT: &str = "count";
+        pub const UNDERSCORE_COUNT: &str = "_count";
         pub const AVG: &str = "avg";
+        pub const UNDERSCORE_AVG: &str = "_avg";
         pub const SUM: &str = "sum";
+        pub const UNDERSCORE_SUM: &str = "_sum";
         pub const MIN: &str = "min";
+        pub const UNDERSCORE_MIN: &str = "_min";
         pub const MAX: &str = "max";
+        pub const UNDERSCORE_MAX: &str = "_max";
     }
 
     pub mod ordering {

--- a/query-engine/core/src/schema_builder/input_types/arguments.rs
+++ b/query-engine/core/src/schema_builder/input_types/arguments.rs
@@ -118,7 +118,7 @@ pub(crate) fn many_records_arguments(
 
     let mut args = vec![
         where_argument(ctx, &model),
-        order_by_argument(ctx, &model, feature_flags::get().orderByRelation),
+        order_by_argument(ctx, &model, feature_flags::get().orderByRelation, false),
         input_field(args::CURSOR, unique_input_type, None).optional(),
         input_field(args::TAKE, InputType::int(), None).optional(),
         input_field(args::SKIP, InputType::int(), None).optional(),
@@ -139,8 +139,18 @@ pub(crate) fn many_records_arguments(
 }
 
 // Builds "orderBy" argument.
-pub(crate) fn order_by_argument(ctx: &mut BuilderContext, model: &ModelRef, include_relations: bool) -> InputField {
-    let order_object_type = InputType::object(order_by_objects::order_by_object_type(ctx, model, include_relations));
+pub(crate) fn order_by_argument(
+    ctx: &mut BuilderContext,
+    model: &ModelRef,
+    include_relations: bool,
+    include_scalar_aggregations: bool,
+) -> InputField {
+    let order_object_type = InputType::object(order_by_objects::order_by_object_type(
+        ctx,
+        model,
+        include_relations,
+        include_scalar_aggregations,
+    ));
 
     input_field(
         args::ORDER_BY,
@@ -155,7 +165,7 @@ pub(crate) fn group_by_arguments(ctx: &mut BuilderContext, model: &ModelRef) -> 
 
     vec![
         where_argument(ctx, &model),
-        order_by_argument(ctx, &model, false),
+        order_by_argument(ctx, &model, false, true),
         input_field(
             args::BY,
             vec![InputType::list(field_enum_type.clone()), field_enum_type],

--- a/query-engine/core/src/schema_builder/input_types/arguments.rs
+++ b/query-engine/core/src/schema_builder/input_types/arguments.rs
@@ -165,7 +165,7 @@ pub(crate) fn group_by_arguments(ctx: &mut BuilderContext, model: &ModelRef) -> 
 
     vec![
         where_argument(ctx, &model),
-        order_by_argument(ctx, &model, false, true),
+        order_by_argument(ctx, &model, false, feature_flags::get().orderByAggregateGroup),
         input_field(
             args::BY,
             vec![InputType::list(field_enum_type.clone()), field_enum_type],

--- a/query-engine/core/src/schema_builder/input_types/objects/order_by_objects.rs
+++ b/query-engine/core/src/schema_builder/input_types/objects/order_by_objects.rs
@@ -1,5 +1,6 @@
 use super::*;
 use constants::inputs::filters;
+use output_types::aggregation;
 
 /// Builds "<Model>OrderByInput" object types.
 #[tracing::instrument(skip(ctx, model, include_relations))]
@@ -7,17 +8,19 @@ pub(crate) fn order_by_object_type(
     ctx: &mut BuilderContext,
     model: &ModelRef,
     include_relations: bool,
+    include_scalar_aggregations: bool,
 ) -> InputObjectTypeWeakRef {
     let enum_type = Arc::new(string_enum_type(
         ordering::SORT_ORDER,
         vec![ordering::ASC.to_owned(), ordering::DESC.to_owned()],
     ));
-
-    let with_relation_ident = if include_relations { "WithRelation" } else { "" };
-    let ident = Identifier::new(
-        format!("{}OrderBy{}Input", model.name, with_relation_ident),
-        PRISMA_NAMESPACE,
-    );
+    let ident_suffix = match (include_relations, include_scalar_aggregations) {
+        (false, false) => "",
+        (true, false) => "WithRelation",
+        (false, true) => "WithAggregation",
+        (true, true) => unreachable!("Order by with relations and scalar aggregations is not supported yet"),
+    };
+    let ident = Identifier::new(format!("{}OrderBy{}Input", model.name, ident_suffix), PRISMA_NAMESPACE);
     return_cached_input!(ctx, &ident);
 
     let mut input_object = init_input_object_type(ident.clone());
@@ -26,20 +29,21 @@ pub(crate) fn order_by_object_type(
     let input_object = Arc::new(input_object);
     ctx.cache_input_type(ident, input_object.clone());
 
-    let fields = model
+    let mut fields = model
         .fields()
         .all
         .iter()
         .filter_map(|field| match field {
             ModelField::Relation(rf) if rf.is_list && include_relations => {
                 let related_model = rf.related_model();
-                let related_object_type = order_by_object_type_aggregate(ctx, &related_model, &enum_type);
+                let related_object_type = order_by_object_type_rel_aggregate(ctx, &related_model, &enum_type);
 
                 Some(input_field(rf.name.clone(), InputType::object(related_object_type), None).optional())
             }
             ModelField::Relation(rf) if include_relations => {
                 let related_model = rf.related_model();
-                let related_object_type = order_by_object_type(ctx, &related_model, include_relations);
+                let related_object_type =
+                    order_by_object_type(ctx, &related_model, include_relations, include_scalar_aggregations);
 
                 Some(input_field(rf.name.clone(), InputType::object(related_object_type), None).optional())
             }
@@ -50,16 +54,128 @@ pub(crate) fn order_by_object_type(
         })
         .collect();
 
+    if include_scalar_aggregations {
+        // Fields used in aggregations
+        let non_list_nor_json_fields = aggregation::collect_non_list_nor_json_fields(model);
+        let numeric_fields = aggregation::collect_numeric_fields(model);
+
+        append_opt(
+            &mut fields,
+            order_by_field_aggregate(
+                filters::UNDERSCORE_COUNT,
+                "Count",
+                ctx,
+                model,
+                &enum_type,
+                model.fields().scalar(),
+            ),
+        );
+        append_opt(
+            &mut fields,
+            order_by_field_aggregate(
+                filters::UNDERSCORE_AVG,
+                "Avg",
+                ctx,
+                model,
+                &enum_type,
+                numeric_fields.clone(),
+            ),
+        );
+        append_opt(
+            &mut fields,
+            order_by_field_aggregate(
+                filters::UNDERSCORE_MAX,
+                "Max",
+                ctx,
+                model,
+                &enum_type,
+                non_list_nor_json_fields.clone(),
+            ),
+        );
+        append_opt(
+            &mut fields,
+            order_by_field_aggregate(
+                filters::UNDERSCORE_MIN,
+                "Min",
+                ctx,
+                model,
+                &enum_type,
+                non_list_nor_json_fields,
+            ),
+        );
+        append_opt(
+            &mut fields,
+            order_by_field_aggregate(filters::UNDERSCORE_SUM, "Sum", ctx, model, &enum_type, numeric_fields),
+        );
+    }
+
     input_object.set_fields(fields);
     Arc::downgrade(&input_object)
 }
 
+fn order_by_field_aggregate(
+    name: &str,
+    suffix: &str,
+    ctx: &mut BuilderContext,
+    model: &ModelRef,
+    ordering_enum: &Arc<EnumType>,
+    scalar_fields: Vec<ScalarFieldRef>,
+) -> Option<InputField> {
+    if scalar_fields.is_empty() {
+        None
+    } else {
+        Some(
+            input_field(
+                name,
+                InputType::object(order_by_object_type_aggregate(
+                    suffix,
+                    ctx,
+                    model,
+                    ordering_enum,
+                    scalar_fields,
+                )),
+                None,
+            )
+            .optional(),
+        )
+    }
+}
+
 fn order_by_object_type_aggregate(
+    suffix: &str,
+    ctx: &mut BuilderContext,
+    model: &ModelRef,
+    ordering_enum: &Arc<EnumType>,
+    scalar_fields: Vec<ScalarFieldRef>,
+) -> InputObjectTypeWeakRef {
+    let ident = Identifier::new(
+        format!("{}{}OrderByAggregateInput", model.name, suffix),
+        PRISMA_NAMESPACE,
+    );
+
+    return_cached_input!(ctx, &ident);
+
+    let mut input_object = init_input_object_type(ident.clone());
+    input_object.require_exactly_one_field();
+
+    let input_object = Arc::new(input_object);
+    ctx.cache_input_type(ident, input_object.clone());
+
+    let fields = scalar_fields
+        .iter()
+        .map(|sf| input_field(sf.name.clone(), InputType::Enum(ordering_enum.clone()), None).optional())
+        .collect();
+
+    input_object.set_fields(fields);
+    Arc::downgrade(&input_object)
+}
+
+fn order_by_object_type_rel_aggregate(
     ctx: &mut BuilderContext,
     model: &ModelRef,
     ordering_enum: &Arc<EnumType>,
 ) -> InputObjectTypeWeakRef {
-    let ident = Identifier::new(format!("{}OrderByAggregateInput", model.name), PRISMA_NAMESPACE);
+    let ident = Identifier::new(format!("{}OrderByRelationAggregateInput", model.name), PRISMA_NAMESPACE);
 
     return_cached_input!(ctx, &ident);
 

--- a/query-engine/core/src/schema_builder/output_types/aggregation/mod.rs
+++ b/query-engine/core/src/schema_builder/output_types/aggregation/mod.rs
@@ -13,7 +13,7 @@ fn field_avg_output_type(ctx: &mut BuilderContext, field: &ScalarFieldRef) -> Ou
     }
 }
 
-fn collect_non_list_nor_json_fields(model: &ModelRef) -> Vec<ScalarFieldRef> {
+pub fn collect_non_list_nor_json_fields(model: &ModelRef) -> Vec<ScalarFieldRef> {
     model
         .fields()
         .scalar()
@@ -22,7 +22,7 @@ fn collect_non_list_nor_json_fields(model: &ModelRef) -> Vec<ScalarFieldRef> {
         .collect()
 }
 
-fn collect_numeric_fields(model: &ModelRef) -> Vec<ScalarFieldRef> {
+pub fn collect_numeric_fields(model: &ModelRef) -> Vec<ScalarFieldRef> {
     model
         .fields()
         .scalar()


### PR DESCRIPTION
## Overview

Implements https://github.com/prisma/prisma/issues/5464

**Feature flag**: `orderByAggregateGroup`

This enables ordering by count, avg, min, max, sum of scalar fields in `groupBy`.

From a query perspective, it's designed as followed:


```graphql
{
  groupByModel(orderBy: { _count|_sum|_avg|_min|_max: { scalar_field: asc|desc } }) {
    // ...
  }
}
```

## DMMF Changes

From a schema/DMMF perspective, this PR applies the following changes:

Given this datamodel:

```prisma
model User {
  id    Int      @id @default(autoincrement())
  name  String
  posts Post[]
}
```

```diff
type Query {
  groupByUser(
    where: UserWhereInput
-    orderBy: [UserOrderByInput]
+    orderBy: [UserOrderByWithAggregationInput]
    by: [UserScalarFieldEnum]!
    having: UserScalarWhereWithAggregatesInput
    take: Int
    skip: Int
  ): [UserGroupByOutputType]!
}

- input UserOrderByInput {
+ input UserOrderByWithAggregationInput { # BREAKING
  id: SortOrder
  name: SortOrder
+  _count: UserCountOrderByAggregateInput
+  _avg: UserAvgOrderByAggregateInput
+  _max: UserMaxOrderByAggregateInput
+  _min: UserMinOrderByAggregateInput
+  _sum: UserSumOrderByAggregateInput
}

+ input UserAvgOrderByAggregateInput {
+  id: SortOrder
+ }

+ input UserMaxOrderByAggregateInput {
+  id: SortOrder
+  name: SortOrder
+ }

+ input UserMinOrderByAggregateInput {
+  id: SortOrder
+  name: SortOrder
+ }

+ input UserSymOrderByAggregateInput {
+  id: SortOrder
+ }

input UserOrderByWithRelationInput {
  id: SortOrder
  name: SortOrder
-  posts: PostOrderByAggregateInput
+  posts: PostOrderByRelationAggregateInput # BREAKING
}
```


## TODO

- [x] Test