### PR TITLE
ci: Run tests via GH Actions

### DIFF
--- a/.github/workflows/introspection-engine.yml
+++ b/.github/workflows/introspection-engine.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        segment: [""]
+        segment: [""] # TODO: Use to split tests by database if desired
         
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/introspection-engine.yml
+++ b/.github/workflows/introspection-engine.yml
@@ -1,0 +1,60 @@
+name: Introspection Engine
+on:
+  push:
+
+jobs:
+
+  compile:
+    name: "Compile Introspection Engine tests"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.48.0
+          default: true
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: introspection-engine-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - run: timeout 40m cargo test --no-run
+        working-directory: introspection-engine/introspection-engine-tests
+
+  test:
+    name: "Test Introspection Engine - ${{ matrix.segment }}"
+    
+    strategy:
+      fail-fast: false
+      matrix:
+        segment: [""]
+        
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: "Start databases"
+        run: docker-compose up -d
+      
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.48.0
+          default: true
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: introspection-engine-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - run: cargo test ${{ matrix.segment }}
+        working-directory: introspection-engine/introspection-engine-tests
+        env:
+          CLICOLOR_FORCE: 1

--- a/.github/workflows/migration-engine.yml
+++ b/.github/workflows/migration-engine.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        database: [mssql_2017, mssql_2019, mysql_5_6, mysql, mysql_8, mysql_mariadb, postgres9, postgres10, postgres11, postgres12, postgres13, sqlite]
+        database: [mssql_2017, mssql_2019, mysql_5_6, mysql_5_7, mysql_8, mysql_mariadb, postgres9, postgres10, postgres11, postgres12, postgres13, sqlite]
         
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/migration-engine.yml
+++ b/.github/workflows/migration-engine.yml
@@ -38,8 +38,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: "Start database test-db-${{ matrix.database }}"
-        run: docker-compose up -d test-db-${{ matrix.database }}
+      - name: "Start databases"
+        run: docker-compose up -d
       
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/migration-engine.yml
+++ b/.github/workflows/migration-engine.yml
@@ -1,0 +1,60 @@
+name: Migration Engine
+on:
+  push:
+
+jobs:
+
+  compile:
+    name: "Compile Migration Engine tests"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.48.0
+          default: true
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: migration-engine-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - run: cargo test --no-run
+        working-directory: migration-engine/migration-engine-tests
+
+  test:
+    name: "Test Migration Engine - ${{ matrix.database }}"
+    
+    strategy:
+      fail-fast: false
+      matrix:
+        database: [mssql_2017, mssql_2019, mysql_5_6, mysql, mysql_8, mysql_mariadb, postgres9, postgres10, postgres11, postgres12, postgres13, sqlite]
+        
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: "Start databases"
+        run: docker-compose up -d
+      
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.48.0
+          default: true
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: migration-engine-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - run: timeout 40m cargo test ${{ matrix.database }}
+        working-directory: migration-engine/migration-engine-tests
+        env:
+          CLICOLOR_FORCE: 1

--- a/.github/workflows/migration-engine.yml
+++ b/.github/workflows/migration-engine.yml
@@ -38,8 +38,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: "Start databases"
-        run: docker-compose up -d
+      - name: "Start database test-db-${{ matrix.database }}"
+        run: docker-compose up -d test-db-${{ matrix.database }}
       
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/query-engine.yml
+++ b/.github/workflows/query-engine.yml
@@ -1,0 +1,35 @@
+name: Query Engine
+on:
+  push:
+
+jobs:
+
+  test:
+    name: "Test Query Engine - ${{ matrix.connector }}"
+    
+    strategy:
+      fail-fast: false
+      matrix:
+        connector: [postgresql9, postgresql10, postgresql11, postgresql12, postgresql13, pgbouncer, mysql, mysql56, mysql8, mariadb, mssql2017, mssql2019, sqlite]
+        
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: "Start databases"
+        run: docker-compose up -d 
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: query-engine-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          
+      - name: Build Engines on image
+        run: docker-compose run -e SQLITE_MAX_VARIABLE_NUMBER=250000 -e SQLITE_MAX_EXPR_DEPTH=10000 test-base cargo build --all-features --release --bin query-engine --bin migration-engine          
+      
+      - name: Run tests on image
+        run: docker-compose run -e TEST_CONNECTOR=${{ matrix.connector }} -e TEST_MODE=simple -w /root/build/query-engine/connector-test-kit test-base sbt test
+

--- a/.github/workflows/query-engine.yml
+++ b/.github/workflows/query-engine.yml
@@ -28,8 +28,8 @@ jobs:
           key: query-engine-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           
       - name: Build Engines on image
-        run: docker-compose run -e SQLITE_MAX_VARIABLE_NUMBER=250000 -e SQLITE_MAX_EXPR_DEPTH=10000 test-base cargo build --all-features --release --bin query-engine --bin migration-engine          
+        run: docker-compose run -e SQLITE_MAX_VARIABLE_NUMBER=250000 -e SQLITE_MAX_EXPR_DEPTH=10000 qe-test-base cargo build --all-features --release --bin query-engine --bin migration-engine          
       
       - name: Run tests on image
-        run: docker-compose run -e TEST_CONNECTOR=${{ matrix.connector }} -e TEST_MODE=simple -w /root/build/query-engine/connector-test-kit test-base sbt test
+        run: docker-compose run -e TEST_CONNECTOR=${{ matrix.connector }} -e TEST_MODE=simple -w /root/build/query-engine/connector-test-kit qe-test-base sbt test
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,22 +1,21 @@
 version: "3"
 services:
-
-  qe-test-base:
-    image: prismagraphql/build:test
+  pgbouncer:
+    image: brainsam/pgbouncer:latest
+    restart: always
     environment:
-      SERVER_ROOT: /root/build
-      COMMIT_SHA: "ci_test_binary"
-      RUST_BACKTRACE: "1"
-      IS_BUILDKITE: "1"
-      RUST_LOG_FORMAT: "devel"
-      LOG_LEVEL: "error"
-    volumes:
-      - .:/root/build
-    working_dir: /root/build/
+      DB_HOST: "postgres11"
+      DB_PORT: "5432"
+      DB_USER: "postgres"
+      DB_PASSWORD: "prisma"
+      POOL_MODE: "transaction"
+      MAX_CLIENT_CONN: "1000"
     networks:
       - databases
+    ports:
+      - "6432:6432"
 
-  test-db-postgres_9:
+  postgres9:
     image: postgres:9
     restart: always
     command: postgres -c 'max_connections=1000'
@@ -29,7 +28,7 @@ services:
       - databases
     tmpfs: /pgtmpfs9
 
-  test-db-postgres_10:
+  postgres10:
     image: postgres:10
     restart: always
     command: postgres -c 'max_connections=1000'
@@ -42,7 +41,7 @@ services:
       - databases
     tmpfs: /pgtmpfs10
 
-  test-db-postgres_11:
+  postgres11:
     image: postgres:11
     restart: always
     command: postgres -c 'max_connections=1000'
@@ -55,7 +54,7 @@ services:
       - databases
     tmpfs: /pgtmpfs11
 
-  test-db-postgres_12:
+  postgres12:
     image: postgres:12
     restart: always
     command: postgres -c 'max_connections=1000'
@@ -68,7 +67,7 @@ services:
       - databases
     tmpfs: /pgtmpfs12
 
-  test-db-postgres_13:
+  postgres13:
     image: postgres:13
     restart: always
     command: postgres -c 'max_connections=1000'
@@ -81,22 +80,7 @@ services:
       - databases
     tmpfs: /pgtmpfs12
 
-  test-db-pgbouncer:
-    image: brainsam/pgbouncer:latest
-    restart: always
-    environment:
-      DB_HOST: "test-db-postgres-11"
-      DB_PORT: "5432"
-      DB_USER: "postgres"
-      DB_PASSWORD: "prisma"
-      POOL_MODE: "transaction"
-      MAX_CLIENT_CONN: "1000"
-    networks:
-      - databases
-    ports:
-      - "6432:6432"
-      
-  test-db-mysql_5_6:
+  mysql-5-6:
     image: mysql:5.6.50
     command: mysqld
     restart: always
@@ -110,7 +94,7 @@ services:
       - databases
     tmpfs: /var/lib/mysql
 
-  test-db-mysql_5_7:
+  mysql-5-7:
     image: mysql:5.7.32
     command: mysqld
     restart: always
@@ -124,7 +108,7 @@ services:
       - databases
     tmpfs: /var/lib/mysql
 
-  test-db-mysql_8_0:
+  mysql-8-0:
     image: mysql:8.0.22
     command: mysqld
     restart: always
@@ -138,7 +122,7 @@ services:
       - databases
     tmpfs: /var/lib/mysql8
 
-  test-db-mariadb:
+  mariadb-10-0:
     image: mariadb:10
     restart: always
     environment:
@@ -151,7 +135,7 @@ services:
       - databases
     tmpfs: /var/lib/mariadb
 
-  test-db-mssql_2019:
+  mssql-2019:
     image: mcr.microsoft.com/mssql/server:2019-latest
     restart: always
     environment:
@@ -162,7 +146,7 @@ services:
     networks:
       - databases
 
-  test-db-mssql_2017:
+  mssql-2017:
     image: mcr.microsoft.com/mssql/server:2017-latest
     restart: always
     environment:
@@ -173,7 +157,7 @@ services:
     networks:
       - databases
 
-  test-db-mongo_4:
+  mongo4:
     image: mongo:4.4.3-bionic
     restart: always
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,22 @@
 version: "3"
 services:
-  pgbouncer:
-    image: brainsam/pgbouncer:latest
-    restart: always
+
+  qe-test-base:
+    image: prismagraphql/build:test
     environment:
-      DB_HOST: "postgres11"
-      DB_PORT: "5432"
-      DB_USER: "postgres"
-      DB_PASSWORD: "prisma"
-      POOL_MODE: "transaction"
-      MAX_CLIENT_CONN: "1000"
+      SERVER_ROOT: /root/build
+      COMMIT_SHA: "ci_test_binary"
+      RUST_BACKTRACE: "1"
+      IS_BUILDKITE: "1"
+      RUST_LOG_FORMAT: "devel"
+      LOG_LEVEL: "error"
+    volumes:
+      - .:/root/build
+    working_dir: /root/build/
     networks:
       - databases
-    ports:
-      - "6432:6432"
 
-  postgres9:
+  test-db-postgres-9:
     image: postgres:9
     restart: always
     command: postgres -c 'max_connections=1000'
@@ -28,7 +29,7 @@ services:
       - databases
     tmpfs: /pgtmpfs9
 
-  postgres10:
+  test-db-postgres-10:
     image: postgres:10
     restart: always
     command: postgres -c 'max_connections=1000'
@@ -41,7 +42,7 @@ services:
       - databases
     tmpfs: /pgtmpfs10
 
-  postgres11:
+  test-db-postgres-11:
     image: postgres:11
     restart: always
     command: postgres -c 'max_connections=1000'
@@ -54,7 +55,7 @@ services:
       - databases
     tmpfs: /pgtmpfs11
 
-  postgres12:
+  test-db-postgres-12:
     image: postgres:12
     restart: always
     command: postgres -c 'max_connections=1000'
@@ -67,7 +68,7 @@ services:
       - databases
     tmpfs: /pgtmpfs12
 
-  postgres13:
+  test-db-postgres-13:
     image: postgres:13
     restart: always
     command: postgres -c 'max_connections=1000'
@@ -79,8 +80,23 @@ services:
     networks:
       - databases
     tmpfs: /pgtmpfs12
+    
+  test-db-pgbouncer:
+    image: brainsam/pgbouncer:latest
+    restart: always
+    environment:
+      DB_HOST: "test-db-postgres-11"
+      DB_PORT: "5432"
+      DB_USER: "postgres"
+      DB_PASSWORD: "prisma"
+      POOL_MODE: "transaction"
+      MAX_CLIENT_CONN: "1000"
+    networks:
+      - databases
+    ports:
+      - "6432:6432"
 
-  mysql-5-6:
+  test-db-mysql-5-6:
     image: mysql:5.6.50
     command: mysqld
     restart: always
@@ -94,7 +110,7 @@ services:
       - databases
     tmpfs: /var/lib/mysql
 
-  mysql-5-7:
+  test-db-mysql-5-7:
     image: mysql:5.7.32
     command: mysqld
     restart: always
@@ -108,7 +124,7 @@ services:
       - databases
     tmpfs: /var/lib/mysql
 
-  mysql-8-0:
+  test-db-mysql-8-0:
     image: mysql:8.0.22
     command: mysqld
     restart: always
@@ -121,8 +137,8 @@ services:
     networks:
       - databases
     tmpfs: /var/lib/mysql8
-
-  mariadb-10-0:
+    
+  test-db-mariadb:
     image: mariadb:10
     restart: always
     environment:
@@ -135,7 +151,7 @@ services:
       - databases
     tmpfs: /var/lib/mariadb
 
-  mssql-2019:
+  test-db-mssql-2019:
     image: mcr.microsoft.com/mssql/server:2019-latest
     restart: always
     environment:
@@ -146,7 +162,7 @@ services:
     networks:
       - databases
 
-  mssql-2017:
+  test-db-mssql-2017:
     image: mcr.microsoft.com/mssql/server:2017-latest
     restart: always
     environment:
@@ -167,7 +183,7 @@ services:
       - "27017:27017"
     networks:
       - databases
-
+      
   jaeger:
     image: jaegertracing/all-in-one:latest
     restart: always
@@ -175,7 +191,7 @@ services:
       - "16686:16686" # the trace viewer (http)
     networks:
       - telemetry
-
+      
   otel-agent:
     image: otel/opentelemetry-collector-dev:latest
     command: ["--config=/etc/otel-agent-config.yaml"]
@@ -188,7 +204,7 @@ services:
       - jaeger
     networks:
       - telemetry
-
+      
 networks:
   databases:
   telemetry:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -138,7 +138,7 @@ services:
       - databases
     tmpfs: /var/lib/mysql8
 
-  test-db-mariadb-10-0:
+  test-db-mariadb:
     image: mariadb:10
     restart: always
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -137,7 +137,7 @@ services:
     networks:
       - databases
     tmpfs: /var/lib/mysql8
-    
+
   test-db-mariadb:
     image: mariadb:10
     restart: always
@@ -183,7 +183,7 @@ services:
       - "27017:27017"
     networks:
       - databases
-      
+
   jaeger:
     image: jaegertracing/all-in-one:latest
     restart: always
@@ -191,7 +191,7 @@ services:
       - "16686:16686" # the trace viewer (http)
     networks:
       - telemetry
-      
+
   otel-agent:
     image: otel/opentelemetry-collector-dev:latest
     command: ["--config=/etc/otel-agent-config.yaml"]
@@ -204,7 +204,7 @@ services:
       - jaeger
     networks:
       - telemetry
-      
+
 networks:
   databases:
   telemetry:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     networks:
       - databases
 
-  test-db-postgres-9:
+  test-db-postgres_9:
     image: postgres:9
     restart: always
     command: postgres -c 'max_connections=1000'
@@ -29,7 +29,7 @@ services:
       - databases
     tmpfs: /pgtmpfs9
 
-  test-db-postgres-10:
+  test-db-postgres_10:
     image: postgres:10
     restart: always
     command: postgres -c 'max_connections=1000'
@@ -42,7 +42,7 @@ services:
       - databases
     tmpfs: /pgtmpfs10
 
-  test-db-postgres-11:
+  test-db-postgres_11:
     image: postgres:11
     restart: always
     command: postgres -c 'max_connections=1000'
@@ -55,7 +55,7 @@ services:
       - databases
     tmpfs: /pgtmpfs11
 
-  test-db-postgres-12:
+  test-db-postgres_12:
     image: postgres:12
     restart: always
     command: postgres -c 'max_connections=1000'
@@ -68,7 +68,7 @@ services:
       - databases
     tmpfs: /pgtmpfs12
 
-  test-db-postgres-13:
+  test-db-postgres_13:
     image: postgres:13
     restart: always
     command: postgres -c 'max_connections=1000'
@@ -96,7 +96,7 @@ services:
     ports:
       - "6432:6432"
       
-  test-db-mysql-5-6:
+  test-db-mysql_5_6:
     image: mysql:5.6.50
     command: mysqld
     restart: always
@@ -110,7 +110,7 @@ services:
       - databases
     tmpfs: /var/lib/mysql
 
-  test-db-mysql-5-7:
+  test-db-mysql_5_7:
     image: mysql:5.7.32
     command: mysqld
     restart: always
@@ -124,7 +124,7 @@ services:
       - databases
     tmpfs: /var/lib/mysql
 
-  test-db-mysql-8-0:
+  test-db-mysql_8_0:
     image: mysql:8.0.22
     command: mysqld
     restart: always
@@ -151,7 +151,7 @@ services:
       - databases
     tmpfs: /var/lib/mariadb
 
-  test-db-mssql-2019:
+  test-db-mssql_2019:
     image: mcr.microsoft.com/mssql/server:2019-latest
     restart: always
     environment:
@@ -162,7 +162,7 @@ services:
     networks:
       - databases
 
-  test-db-mssql-2017:
+  test-db-mssql_2017:
     image: mcr.microsoft.com/mssql/server:2017-latest
     restart: always
     environment:
@@ -173,7 +173,7 @@ services:
     networks:
       - databases
 
-  mongo4:
+  test-db-mongo_4:
     image: mongo:4.4.3-bionic
     restart: always
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,22 +16,7 @@ services:
     networks:
       - databases
 
-  pgbouncer:
-    image: brainsam/pgbouncer:latest
-    restart: always
-    environment:
-      DB_HOST: "postgres11"
-      DB_PORT: "5432"
-      DB_USER: "postgres"
-      DB_PASSWORD: "prisma"
-      POOL_MODE: "transaction"
-      MAX_CLIENT_CONN: "1000"
-    networks:
-      - databases
-    ports:
-      - "6432:6432"
-
-  postgres9:
+  test-db-postgres-9:
     image: postgres:9
     restart: always
     command: postgres -c 'max_connections=1000'
@@ -44,7 +29,7 @@ services:
       - databases
     tmpfs: /pgtmpfs9
 
-  postgres10:
+  test-db-postgres-10:
     image: postgres:10
     restart: always
     command: postgres -c 'max_connections=1000'
@@ -57,7 +42,7 @@ services:
       - databases
     tmpfs: /pgtmpfs10
 
-  postgres11:
+  test-db-postgres-11:
     image: postgres:11
     restart: always
     command: postgres -c 'max_connections=1000'
@@ -70,7 +55,7 @@ services:
       - databases
     tmpfs: /pgtmpfs11
 
-  postgres12:
+  test-db-postgres-12:
     image: postgres:12
     restart: always
     command: postgres -c 'max_connections=1000'
@@ -83,7 +68,7 @@ services:
       - databases
     tmpfs: /pgtmpfs12
 
-  postgres13:
+  test-db-postgres-13:
     image: postgres:13
     restart: always
     command: postgres -c 'max_connections=1000'
@@ -96,7 +81,22 @@ services:
       - databases
     tmpfs: /pgtmpfs12
 
-  mysql-5-6:
+  test-db-pgbouncer:
+    image: brainsam/pgbouncer:latest
+    restart: always
+    environment:
+      DB_HOST: "test-db-postgres-11"
+      DB_PORT: "5432"
+      DB_USER: "postgres"
+      DB_PASSWORD: "prisma"
+      POOL_MODE: "transaction"
+      MAX_CLIENT_CONN: "1000"
+    networks:
+      - databases
+    ports:
+      - "6432:6432"
+      
+  test-db-mysql-5-6:
     image: mysql:5.6.50
     command: mysqld
     restart: always
@@ -110,7 +110,7 @@ services:
       - databases
     tmpfs: /var/lib/mysql
 
-  mysql-5-7:
+  test-db-mysql-5-7:
     image: mysql:5.7.32
     command: mysqld
     restart: always
@@ -124,7 +124,7 @@ services:
       - databases
     tmpfs: /var/lib/mysql
 
-  mysql-8-0:
+  test-db-mysql-8-0:
     image: mysql:8.0.22
     command: mysqld
     restart: always
@@ -138,7 +138,7 @@ services:
       - databases
     tmpfs: /var/lib/mysql8
 
-  mariadb-10-0:
+  test-db-mariadb:
     image: mariadb:10
     restart: always
     environment:
@@ -151,7 +151,7 @@ services:
       - databases
     tmpfs: /var/lib/mariadb
 
-  mssql-2019:
+  test-db-mssql-2019:
     image: mcr.microsoft.com/mssql/server:2019-latest
     restart: always
     environment:
@@ -162,7 +162,7 @@ services:
     networks:
       - databases
 
-  mssql-2017:
+  test-db-mssql-2017:
     image: mcr.microsoft.com/mssql/server:2017-latest
     restart: always
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -138,7 +138,7 @@ services:
       - databases
     tmpfs: /var/lib/mysql8
 
-  test-db-mariadb:
+  test-db-mariadb-10-0:
     image: mariadb:10
     restart: always
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,21 @@
 version: "3"
 services:
+
+  qe-test-base:
+    image: prismagraphql/build:test
+    environment:
+      SERVER_ROOT: /root/build
+      COMMIT_SHA: "ci_test_binary"
+      RUST_BACKTRACE: "1"
+      IS_BUILDKITE: "1"
+      RUST_LOG_FORMAT: "devel"
+      LOG_LEVEL: "error"
+    volumes:
+      - .:/root/build
+    working_dir: /root/build/
+    networks:
+      - databases
+
   pgbouncer:
     image: brainsam/pgbouncer:latest
     restart: always

--- a/libs/test-setup/src/lib.rs
+++ b/libs/test-setup/src/lib.rs
@@ -14,11 +14,8 @@ pub mod runtime;
 /// The built-in connectors database.
 pub mod connectors;
 
-use std::{borrow::Cow, collections::BTreeMap, str::FromStr};
-
 pub use crate::connectors::Features;
 use crate::connectors::Tags;
-use connection_string::JdbcString;
 use enumflags2::BitFlags;
 use once_cell::sync::Lazy;
 use quaint::{prelude::Queryable, single::Quaint};
@@ -61,7 +58,7 @@ test_api_constructors!(
     (mssql_2017, "sqlserver"),
     (mssql_2019, "sqlserver"),
     (mysql_5_6, "mysql"),
-    (mysql_5_7, "mysql"),
+    (mysql, "mysql"),
     (mysql_8, "mysql"),
     (mysql_mariadb, "mysql"),
     (postgres9, "postgresql"),
@@ -83,14 +80,31 @@ impl TestApiArgs {
 }
 
 mod urls {
+    use super::SCHEMA_NAME;
+
+    fn db_host_and_port_postgres_11() -> (&'static str, usize) {
+        match std::env::var("IS_BUILDKITE") {
+            Ok(_) => ("test-db-postgres-11", 5432),
+            Err(_) => ("127.0.0.1", 5433),
+        }
+    }
+
+    pub fn postgres11(db_name: &str) -> String {
+        let (host, port) = db_host_and_port_postgres_11();
+
+        format!(
+            "postgresql://postgres:prisma@{}:{}/{}?schema={}&statement_cache_size=0&socket_timeout=60",
+            host, port, db_name, SCHEMA_NAME
+        )
+    }
+
     pub use super::mariadb_url as mysql_mariadb;
     pub use super::mssql_2017_url as mssql_2017;
     pub use super::mssql_2019_url as mssql_2019;
     pub use super::mysql_5_6_url as mysql_5_6;
-    pub use super::mysql_5_7_url as mysql_5_7;
     pub use super::mysql_8_url as mysql_8;
+    pub use super::mysql_url as mysql;
     pub use super::postgres_10_url as postgres10;
-    pub use super::postgres_11_url as postgres11;
     pub use super::postgres_12_url as postgres12;
     pub use super::postgres_13_url as postgres13;
     pub use super::postgres_9_url as postgres9;
@@ -98,7 +112,7 @@ mod urls {
 }
 
 pub fn sqlite_test_url(db_name: &str) -> String {
-    std::env::var("SQLITE_TEST_URL").unwrap_or_else(|_| format!("file:{}", sqlite_test_file(db_name)))
+    format!("file:{}", sqlite_test_file(db_name))
 }
 
 pub fn sqlite_test_file(db_name: &str) -> String {
@@ -123,442 +137,202 @@ pub fn sqlite_test_file(db_name: &str) -> String {
     file_path.to_string_lossy().into_owned()
 }
 
-enum TestDb<'a> {
-    Schema(&'a str),
-    Database(&'a str),
-}
-
-fn url_from_env(env_var: &str, db: TestDb<'_>) -> Option<String> {
-    std::env::var(env_var).ok().map(|url| {
-        let mut url = Url::parse(&url).unwrap();
-
-        match db {
-            TestDb::Schema(schema) => {
-                let mut params: BTreeMap<String, String> =
-                    url.query_pairs().map(|(k, v)| (k.to_string(), v.to_string())).collect();
-
-                params.insert("schema".into(), schema.into());
-                url.query_pairs_mut().clear();
-
-                for (k, v) in params.into_iter() {
-                    url.query_pairs_mut().append_pair(&k, &v);
-                }
-            }
-            TestDb::Database(db) => {
-                url.set_path(db);
-            }
-        }
-
-        url.to_string()
-    })
-}
-
-fn jdbc_from_env(env_var: &str, schema: &str) -> Option<String> {
-    std::env::var(env_var).ok().and_then(|url| {
-        let mut conn_str = JdbcString::from_str(&url).ok()?;
-        conn_str.properties_mut().insert("schema".into(), schema.into());
-        Some(conn_str.to_string())
-    })
-}
-
 pub fn postgres_9_url(db_name: &str) -> String {
-    url_from_env("POSTGRES_9_TEST_URL", TestDb::Schema(db_name)).unwrap_or_else(|| {
-        let (host, port) = db_host_and_port_postgres_9();
+    let (host, port) = db_host_and_port_postgres_9();
 
-        format!(
-            "postgresql://postgres:prisma@{}:{}/{}?schema={}&statement_cache_size=0&socket_timeout=60",
-            host, port, db_name, SCHEMA_NAME
-        )
-    })
+    format!(
+        "postgresql://postgres:prisma@{}:{}/{}?schema={}&statement_cache_size=0&socket_timeout=60",
+        host, port, db_name, SCHEMA_NAME
+    )
 }
 
 pub fn pgbouncer_url(db_name: &str) -> String {
-    url_from_env("PGBOUNCER_TEST_URL", TestDb::Schema(db_name)).unwrap_or_else(|| {
-        let (host, port) = db_host_and_port_for_pgbouncer();
+    let (host, port) = db_host_and_port_for_pgbouncer();
 
-        format!(
-            "postgresql://postgres:prisma@{}:{}/{}?schema={}&pgbouncer=true&socket_timeout=60",
-            host, port, db_name, SCHEMA_NAME
-        )
-    })
+    format!(
+        "postgresql://postgres:prisma@{}:{}/{}?schema={}&pgbouncer=true&socket_timeout=60",
+        host, port, db_name, SCHEMA_NAME
+    )
 }
 
 pub fn postgres_10_url(db_name: &str) -> String {
-    url_from_env("POSTGRES_10_TEST_URL", TestDb::Schema(db_name)).unwrap_or_else(|| {
-        let (host, port) = db_host_and_port_postgres_10();
+    let (host, port) = db_host_and_port_postgres_10();
 
-        format!(
-            "postgresql://postgres:prisma@{}:{}/{}?schema={}&statement_cache_size=0&socket_timeout=60",
-            host, port, db_name, SCHEMA_NAME
-        )
-    })
-}
-
-pub fn postgres_11_url(db_name: &str) -> String {
-    url_from_env("POSTGRES_11_TEST_URL", TestDb::Schema(db_name)).unwrap_or_else(|| {
-        let (host, port) = db_host_and_port_postgres_11();
-
-        format!(
-            "postgresql://postgres:prisma@{}:{}/{}?schema={}&statement_cache_size=0&socket_timeout=60",
-            host, port, db_name, SCHEMA_NAME
-        )
-    })
+    format!(
+        "postgresql://postgres:prisma@{}:{}/{}?schema={}&statement_cache_size=0&socket_timeout=60",
+        host, port, db_name, SCHEMA_NAME
+    )
 }
 
 pub fn postgres_12_url(db_name: &str) -> String {
-    url_from_env("POSTGRES_12_TEST_URL", TestDb::Schema(db_name)).unwrap_or_else(|| {
-        let (host, port) = db_host_and_port_postgres_12();
+    let (host, port) = db_host_and_port_postgres_12();
 
-        format!(
-            "postgresql://postgres:prisma@{}:{}/{}?schema={}&statement_cache_size=0&socket_timeout=60",
-            host, port, db_name, SCHEMA_NAME
-        )
-    })
+    format!(
+        "postgresql://postgres:prisma@{}:{}/{}?schema={}&statement_cache_size=0&socket_timeout=60",
+        host, port, db_name, SCHEMA_NAME
+    )
 }
 
 pub fn postgres_13_url(db_name: &str) -> String {
-    url_from_env("POSTGRES_13_TEST_URL", TestDb::Schema(db_name)).unwrap_or_else(|| {
-        let (host, port) = db_host_and_port_postgres_13();
+    let (host, port) = db_host_and_port_postgres_13();
 
-        format!(
-            "postgresql://postgres:prisma@{}:{}/{}?schema={}&statement_cache_size=0&socket_timeout=60",
-            host, port, db_name, SCHEMA_NAME
-        )
-    })
+    format!(
+        "postgresql://postgres:prisma@{}:{}/{}?schema={}&statement_cache_size=0&socket_timeout=60",
+        host, port, db_name, SCHEMA_NAME
+    )
 }
 
-pub fn mysql_5_7_url(db_name: &str) -> String {
-    url_from_env("MYSQL_5_7_TEST_URL", TestDb::Database(db_name)).unwrap_or_else(|| {
-        let db_name = mysql_safe_identifier(db_name);
-        let (host, port) = db_host_and_port_mysql_5_7();
+pub fn mysql_url(db_name: &str) -> String {
+    let db_name = mysql_safe_identifier(db_name);
+    let (host, port) = db_host_and_port_mysql_5_7();
 
-        format!(
-            "mysql://root:prisma@{host}:{port}/{db_name}?connect_timeout=20&socket_timeout=60",
-            host = host,
-            port = port,
-            db_name = db_name,
-        )
-    })
+    format!(
+        "mysql://root:prisma@{host}:{port}/{db_name}?connect_timeout=20&socket_timeout=60",
+        host = host,
+        port = port,
+        db_name = db_name,
+    )
 }
 
 pub fn mysql_8_url(db_name: &str) -> String {
-    url_from_env("MYSQL_8_TEST_URL", TestDb::Database(db_name)).unwrap_or_else(|| {
-        let (host, port) = db_host_and_port_mysql_8_0();
+    let (host, port) = db_host_and_port_mysql_8_0();
 
-        // maximum length of identifiers on mysql
-        let db_name = mysql_safe_identifier(db_name);
+    // maximum length of identifiers on mysql
+    let db_name = mysql_safe_identifier(db_name);
 
-        format!(
-            "mysql://root:prisma@{host}:{port}{maybe_slash}{db_name}?connect_timeout=20&socket_timeout=60",
-            maybe_slash = if db_name.is_empty() { "" } else { "/" },
-            host = host,
-            port = port,
-            db_name = db_name,
-        )
-    })
+    format!(
+        "mysql://root:prisma@{host}:{port}{maybe_slash}{db_name}?connect_timeout=20&socket_timeout=60",
+        maybe_slash = if db_name.is_empty() { "" } else { "/" },
+        host = host,
+        port = port,
+        db_name = db_name,
+    )
 }
 
 pub fn mysql_5_6_url(db_name: &str) -> String {
-    url_from_env("MYSQL_5_6_TEST_URL", TestDb::Database(db_name)).unwrap_or_else(|| {
-        let (host, port) = db_host_and_port_mysql_5_6();
+    let (host, port) = db_host_and_port_mysql_5_6();
 
-        // maximum length of identifiers on mysql
-        let db_name = mysql_safe_identifier(db_name);
+    // maximum length of identifiers on mysql
+    let db_name = mysql_safe_identifier(db_name);
 
-        format!(
-            "mysql://root:prisma@{host}:{port}/{db_name}?connect_timeout=20&socket_timeout=60",
-            host = host,
-            port = port,
-            db_name = db_name,
-        )
-    })
+    format!(
+        "mysql://root:prisma@{host}:{port}/{db_name}?connect_timeout=20&socket_timeout=60",
+        host = host,
+        port = port,
+        db_name = db_name,
+    )
 }
 
 pub fn mariadb_url(db_name: &str) -> String {
-    url_from_env("MARIADB_TEST_URL", TestDb::Database(db_name)).unwrap_or_else(|| {
-        let (host, port) = db_host_and_port_mariadb();
+    let (host, port) = db_host_and_port_mariadb();
 
-        // maximum length of identifiers on mysql
-        let db_name = mysql_safe_identifier(db_name);
+    // maximum length of identifiers on mysql
+    let db_name = mysql_safe_identifier(db_name);
 
-        format!(
-            "mysql://root:prisma@{host}:{port}/{db_name}?connect_timeout=20&socket_timeout=60",
-            host = host,
-            port = port,
-            db_name = db_name,
-        )
-    })
+    format!(
+        "mysql://root:prisma@{host}:{port}/{db_name}?connect_timeout=20&socket_timeout=60",
+        host = host,
+        port = port,
+        db_name = db_name,
+    )
 }
 
 pub fn mssql_2017_url(schema_name: &str) -> String {
-    jdbc_from_env("MSSQL_2017_TEST_URL", schema_name).unwrap_or_else(|| {
-        let (host, port) = db_host_mssql_2017();
+    let (host, port) = db_host_mssql_2017();
 
-        format!(
-            "sqlserver://{host}:{port};database=master;schema={schema_name};user=SA;password=<YourStrong@Passw0rd>;trustServerCertificate=true;socket_timeout=60;isolationLevel=READ UNCOMMITTED",
-            schema_name = schema_name,
-            host = host,
-            port = port,
-        )
-    })
+    format!(
+        "sqlserver://{host}:{port};database=master;schema={schema_name};user=SA;password=<YourStrong@Passw0rd>;trustServerCertificate=true;socket_timeout=60;isolationLevel=READ UNCOMMITTED",
+        schema_name = schema_name,
+        host = host,
+        port = port,
+    )
 }
 
 pub fn mssql_2019_url(schema_name: &str) -> String {
-    jdbc_from_env("MSSQL_2019_TEST_URL", schema_name).unwrap_or_else(|| {
-        let (host, port) = db_host_and_port_mssql_2019();
+    let (host, port) = db_host_and_port_mssql_2019();
 
-        format!(
-            "sqlserver://{host}:{port};database=master;schema={schema_name};user=SA;password=<YourStrong@Passw0rd>;trustServerCertificate=true;socket_timeout=60;isolationLevel=READ UNCOMMITTED",
-            schema_name = schema_name,
-            host = host,
-            port = port,
-        )
-    })
+    format!(
+        "sqlserver://{host}:{port};database=master;schema={schema_name};user=SA;password=<YourStrong@Passw0rd>;trustServerCertificate=true;socket_timeout=60;isolationLevel=READ UNCOMMITTED",
+        schema_name = schema_name,
+        host = host,
+        port = port,
+    )
 }
 
-fn db_host_and_port_postgres_9() -> (Cow<'static, str>, usize) {
-    if let Some(var) = std::env::var("POSTGRES_9_TEST_URL")
-        .ok()
-        .and_then(|s| Url::parse(&s).ok())
-    {
-        let host = var
-            .host()
-            .map(|s| Cow::from(s.to_string()))
-            .unwrap_or_else(|| Cow::from("localhost"));
-
-        let port = var.port().unwrap_or(5432) as usize;
-
-        return (host, port);
-    }
-
+fn db_host_and_port_postgres_9() -> (&'static str, usize) {
     match std::env::var("IS_BUILDKITE") {
-        Ok(_) => ("test-db-postgres-9".into(), 5432),
-        Err(_) => ("127.0.0.1".into(), 5431),
+        Ok(_) => ("test-db-postgres-9", 5432),
+        Err(_) => ("127.0.0.1", 5431),
     }
 }
 
-fn db_host_and_port_postgres_10() -> (Cow<'static, str>, usize) {
-    if let Some(var) = std::env::var("POSTGRES_10_TEST_URL")
-        .ok()
-        .and_then(|s| Url::parse(&s).ok())
-    {
-        let host = var
-            .host()
-            .map(|s| Cow::from(s.to_string()))
-            .unwrap_or_else(|| Cow::from("localhost"));
-
-        let port = var.port().unwrap_or(5432) as usize;
-
-        return (host, port);
-    }
-
+fn db_host_and_port_postgres_10() -> (&'static str, usize) {
     match std::env::var("IS_BUILDKITE") {
-        Ok(_) => ("test-db-postgres-10".into(), 5432),
-        Err(_) => ("127.0.0.1".into(), 5432),
+        Ok(_) => ("test-db-postgres-10", 5432),
+        Err(_) => ("127.0.0.1", 5432),
     }
 }
 
-fn db_host_and_port_postgres_11() -> (Cow<'static, str>, usize) {
-    if let Some(var) = std::env::var("POSTGRES_11_TEST_URL")
-        .ok()
-        .and_then(|s| Url::parse(&s).ok())
-    {
-        let host = var
-            .host()
-            .map(|s| Cow::from(s.to_string()))
-            .unwrap_or_else(|| Cow::from("localhost"));
-
-        let port = var.port().unwrap_or(5432) as usize;
-
-        return (host, port);
-    }
-
+fn db_host_and_port_for_pgbouncer() -> (&'static str, usize) {
     match std::env::var("IS_BUILDKITE") {
-        Ok(_) => ("test-db-postgres-11".into(), 5432),
-        Err(_) => ("127.0.0.1".into(), 5433),
+        Ok(_) => ("test-db-pgbouncer", 6432),
+        Err(_) => ("127.0.0.1", 6432),
     }
 }
 
-fn db_host_and_port_for_pgbouncer() -> (Cow<'static, str>, usize) {
-    if let Some(var) = std::env::var("PGBOUNCER_TEST_URL")
-        .ok()
-        .and_then(|s| Url::parse(&s).ok())
-    {
-        let host = var
-            .host()
-            .map(|s| Cow::from(s.to_string()))
-            .unwrap_or_else(|| Cow::from("localhost"));
-
-        let port = var.port().unwrap_or(5432) as usize;
-
-        return (host, port);
-    }
-
+pub fn db_host_and_port_postgres_12() -> (&'static str, usize) {
     match std::env::var("IS_BUILDKITE") {
-        Ok(_) => ("test-db-pgbouncer".into(), 6432),
-        Err(_) => ("127.0.0.1".into(), 6432),
+        Ok(_) => ("test-db-postgres-12", 5432),
+        Err(_) => ("127.0.0.1", 5434),
     }
 }
 
-pub fn db_host_and_port_postgres_12() -> (Cow<'static, str>, usize) {
-    if let Some(var) = std::env::var("POSTGRES_12_TEST_URL")
-        .ok()
-        .and_then(|s| Url::parse(&s).ok())
-    {
-        let host = var
-            .host()
-            .map(|s| Cow::from(s.to_string()))
-            .unwrap_or_else(|| Cow::from("localhost"));
-
-        let port = var.port().unwrap_or(5432) as usize;
-
-        return (host, port);
-    }
-
+fn db_host_and_port_postgres_13() -> (&'static str, usize) {
     match std::env::var("IS_BUILDKITE") {
-        Ok(_) => ("test-db-postgres-12".into(), 5432),
-        Err(_) => ("127.0.0.1".into(), 5434),
+        Ok(_) => ("test-db-postgres-13", 5432),
+        Err(_) => ("127.0.0.1", 5435),
     }
 }
 
-fn db_host_and_port_postgres_13() -> (Cow<'static, str>, usize) {
-    if let Some(var) = std::env::var("POSTGRES_13_TEST_URL")
-        .ok()
-        .and_then(|s| Url::parse(&s).ok())
-    {
-        let host = var
-            .host()
-            .map(|s| Cow::from(s.to_string()))
-            .unwrap_or_else(|| Cow::from("localhost"));
-
-        let port = var.port().unwrap_or(5432) as usize;
-
-        return (host, port);
-    }
-
+pub fn db_host_and_port_mysql_8_0() -> (&'static str, usize) {
     match std::env::var("IS_BUILDKITE") {
-        Ok(_) => ("test-db-postgres-13".into(), 5432),
-        Err(_) => ("127.0.0.1".into(), 5435),
+        Ok(_) => ("test-db-mysql-8-0", 3306),
+        Err(_) => ("127.0.0.1", 3307),
     }
 }
 
-pub fn db_host_and_port_mysql_8_0() -> (Cow<'static, str>, usize) {
-    if let Some(var) = std::env::var("MYSQL_8_TEST_URL").ok().and_then(|s| Url::parse(&s).ok()) {
-        let host = var
-            .host()
-            .map(|s| Cow::from(s.to_string()))
-            .unwrap_or_else(|| Cow::from("localhost"));
-
-        let port = var.port().unwrap_or(3306) as usize;
-
-        return (host, port);
-    }
-
+fn db_host_and_port_mysql_5_6() -> (&'static str, usize) {
     match std::env::var("IS_BUILDKITE") {
-        Ok(_) => ("test-db-mysql-8-0".into(), 3306),
-        Err(_) => ("127.0.0.1".into(), 3307),
+        Ok(_) => ("test-db-mysql-5-6", 3306),
+        Err(_) => ("127.0.0.1", 3309),
     }
 }
 
-fn db_host_and_port_mysql_5_6() -> (Cow<'static, str>, usize) {
-    if let Some(var) = std::env::var("MYSQL_5_6_TEST_URL")
-        .ok()
-        .and_then(|s| Url::parse(&s).ok())
-    {
-        let host = var
-            .host()
-            .map(|s| Cow::from(s.to_string()))
-            .unwrap_or_else(|| Cow::from("localhost"));
-
-        let port = var.port().unwrap_or(3306) as usize;
-
-        return (host, port);
-    }
-
+pub fn db_host_and_port_mysql_5_7() -> (&'static str, usize) {
     match std::env::var("IS_BUILDKITE") {
-        Ok(_) => ("test-db-mysql-5-6".into(), 3306),
-        Err(_) => ("127.0.0.1".into(), 3309),
+        Ok(_) => ("test-db-mysql-5-7", 3306),
+        Err(_) => ("127.0.0.1", 3306),
     }
 }
 
-pub fn db_host_and_port_mysql_5_7() -> (Cow<'static, str>, usize) {
-    if let Some(var) = std::env::var("MYSQL_5_7_TEST_URL")
-        .ok()
-        .and_then(|s| Url::parse(&s).ok())
-    {
-        let host = var
-            .host()
-            .map(|s| Cow::from(s.to_string()))
-            .unwrap_or_else(|| Cow::from("localhost"));
-
-        let port = var.port().unwrap_or(3306) as usize;
-
-        return (host, port);
-    }
-
+fn db_host_and_port_mariadb() -> (&'static str, usize) {
     match std::env::var("IS_BUILDKITE") {
-        Ok(_) => ("test-db-mysql-5-7".into(), 3306),
-        Err(_) => ("127.0.0.1".into(), 3306),
+        Ok(_) => ("test-db-mariadb", 3306),
+        Err(_) => ("127.0.0.1", 3308),
     }
 }
 
-fn db_host_and_port_mariadb() -> (Cow<'static, str>, usize) {
-    if let Some(var) = std::env::var("MARIADB_TEST_URL").ok().and_then(|s| Url::parse(&s).ok()) {
-        let host = var
-            .host()
-            .map(|s| Cow::from(s.to_string()))
-            .unwrap_or_else(|| Cow::from("localhost"));
-
-        let port = var.port().unwrap_or(3306) as usize;
-
-        return (host, port);
-    }
-
+fn db_host_mssql_2017() -> (&'static str, usize) {
     match std::env::var("IS_BUILDKITE") {
-        Ok(_) => ("test-db-mariadb".into(), 3306),
-        Err(_) => ("127.0.0.1".into(), 3308),
+        Ok(_) => ("test-db-mssql-2017", 1433),
+        Err(_) => ("127.0.0.1", 1434),
     }
 }
 
-fn db_host_mssql_2017() -> (Cow<'static, str>, usize) {
-    if let Some(var) = std::env::var("MSSQL_2017_TEST_URL")
-        .ok()
-        .and_then(|s| JdbcString::from_str(&s).ok())
-    {
-        let host = var
-            .server_name()
-            .map(|s| Cow::from(s.to_string()))
-            .unwrap_or_else(|| Cow::from("localhost"));
-
-        let port = var.port().unwrap_or(1433) as usize;
-
-        return (host, port);
-    }
-
+pub fn db_host_and_port_mssql_2019() -> (&'static str, usize) {
     match std::env::var("IS_BUILDKITE") {
-        Ok(_) => ("test-db-mssql-2017".into(), 1433),
-        Err(_) => ("127.0.0.1".into(), 1434),
-    }
-}
-
-pub fn db_host_and_port_mssql_2019() -> (Cow<'static, str>, usize) {
-    if let Some(var) = std::env::var("MSSQL_2019_TEST_URL")
-        .ok()
-        .and_then(|s| JdbcString::from_str(&s).ok())
-    {
-        let host = var
-            .server_name()
-            .map(|s| Cow::from(s.to_string()))
-            .unwrap_or_else(|| Cow::from("localhost"));
-
-        let port = var.port().unwrap_or(1433) as usize;
-
-        return (host, port);
-    }
-
-    match std::env::var("IS_BUILDKITE") {
-        Ok(_) => ("test-db-mssql-2019".into(), 1433),
-        Err(_) => ("127.0.0.1".into(), 1433),
+        Ok(_) => ("test-db-mssql-2019", 1433),
+        Err(_) => ("127.0.0.1", 1433),
     }
 }
 

--- a/migration-engine/migration-engine-tests/tests/diagnose_migration_history/diagnose_migration_history_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/diagnose_migration_history/diagnose_migration_history_tests.rs
@@ -904,7 +904,7 @@ async fn shadow_database_creation_error_is_special_cased_postgres(api: &TestApi)
     Ok(())
 }
 
-#[test_each_connector(tags("mssql"))]
+#[test_each_connector(tags("mssql_2019"))]
 async fn shadow_database_creation_error_is_special_cased_mssql(api: &TestApi) -> TestResult {
     let directory = api.create_migrations_directory()?;
 


### PR DESCRIPTION
Run tests on GH Actions.

Open topics:
- IE is not split by connector yet
- QE and ME: Workflow starts _all_ databases each time instead of just the needed one(s). Changing that is not trivial, as ME and QE tests use different naming schemes (`mysql56` vs. `mysql_5_6`), and the container names in the docker-compose uses another one (`test-db-mysql-5-6`). Unifying these naming patterns will make this trivial.
- A few MSSQL tests (~~ME: `diagnose_migration_history::diagnose_migration_history_tests::shadow_database_creation_error_is_special_cased_mssql::mssql_2017`~~, QE: `writes.deadlocksAndTransactions.VeryManyMutationsSpec` on both mssql versions) seem to be failing on GH Actions (which I heard usually are "just" flaky on Buildkite)
- MongoDB test runs might not be reflected in the Matrix configuration of the workflows yet
- MariaDB container does not follow naming scheme yet, as QE tests expect a different database name
- QE test base container is using `BUILDKITE=1` which it most probably should not. Changing that might break a few more things and need fixes