### PR TITLE
Query CLR types for SQL Server

### DIFF
--- a/introspection-engine/introspection-engine-tests/tests/introspection_tests.rs
+++ b/introspection-engine/introspection-engine-tests/tests/introspection_tests.rs
@@ -5,6 +5,7 @@ mod errors;
 mod identify_version;
 mod lists;
 mod model_renames;
+mod mssql;
 mod native_types;
 mod postgres;
 mod re_introspection;

--- a/introspection-engine/introspection-engine-tests/tests/mssql/mod.rs
+++ b/introspection-engine/introspection-engine-tests/tests/mssql/mod.rs
@@ -1,0 +1,27 @@
+use indoc::indoc;
+use introspection_engine_tests::test_api::*;
+use test_macros::test_each_connector;
+
+#[test_each_connector(tags("mssql"))]
+async fn geometry_should_be_unsupported(api: &TestApi) -> crate::TestResult {
+    api.barrel()
+        .execute(move |migration| {
+            migration.create_table("A", move |t| {
+                t.inject_custom("id int identity primary key");
+                t.inject_custom("location geography");
+            });
+        })
+        .await?;
+
+    let result = api.introspect().await?;
+
+    let dm = indoc! {r#"
+        model A {
+          id       Int @id @default(autoincrement())
+          location Unsupported("geography")?
+        }
+    "#};
+
+    api.assert_eq_datamodels(&dm, &result);
+    Ok(())
+}

--- a/libs/sql-schema-describer/src/mssql.rs
+++ b/libs/sql-schema-describer/src/mssql.rs
@@ -232,22 +232,23 @@ impl SqlSchemaDescriber {
 
     async fn get_all_columns(&self, schema: &str) -> DescriberResult<HashMap<String, Vec<Column>>> {
         let sql = indoc! {r#"
-            SELECT c.name                                          AS column_name,
-                TYPE_NAME(c.system_type_id)                        AS data_type,
-                COLUMNPROPERTY(c.object_id, c.name, 'charmaxlen')  AS character_maximum_length,
-                OBJECT_DEFINITION(c.default_object_id)             AS column_default,
-                c.is_nullable                                      AS is_nullable,
-                COLUMNPROPERTY(c.object_id, c.name, 'IsIdentity')  AS is_identity,
-                OBJECT_NAME(c.object_id)                           AS table_name,
-                OBJECT_NAME(c.default_object_id)                   AS constraint_name,
+            SELECT c.name                                                       AS column_name,
+                typ.name                                                        AS data_type,
+                COLUMNPROPERTY(c.object_id, c.name, 'charmaxlen')               AS character_maximum_length,
+                OBJECT_DEFINITION(c.default_object_id)                          AS column_default,
+                c.is_nullable                                                   AS is_nullable,
+                COLUMNPROPERTY(c.object_id, c.name, 'IsIdentity')               AS is_identity,
+                OBJECT_NAME(c.object_id)                                        AS table_name,
+                OBJECT_NAME(c.default_object_id)                                AS constraint_name,
                 convert(tinyint, CASE
                     WHEN c.system_type_id IN (48, 52, 56, 59, 60, 62, 106, 108, 122, 127) THEN c.precision
-                    END)                                           AS numeric_precision,
+                    END) AS numeric_precision,
                 convert(int, CASE
                     WHEN c.system_type_id IN (40, 41, 42, 43, 58, 61) THEN NULL
                     ELSE ODBCSCALE(c.system_type_id, c.scale) END) AS numeric_scale
             FROM sys.columns c
                     INNER JOIN sys.tables t ON c.object_id = t.object_id
+                    INNER JOIN sys.types typ ON c.user_type_id = typ.user_type_id
             WHERE OBJECT_SCHEMA_NAME(c.object_id) = @P1
             AND t.is_ms_shipped = 0
             ORDER BY COLUMNPROPERTY(c.object_id, c.name, 'ordinal');


### PR DESCRIPTION
This fixes an issue where certain types have a `NULL` name when using the `TYPE_NAME` function. This version finds all types, including `geography` which causes trouble for some of our users.

Closes: https://github.com/prisma/prisma/issues/6269
Closes: https://github.com/prisma/prisma/issues/6176 