### PR TITLE
feat: enable pushing a list to a scalar list

### DIFF
--- a/query-engine/connector-test-kit/src/test/scala/writes/dataTypes/scalarLists/ScalarListsSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/dataTypes/scalarLists/ScalarListsSpec.scala
@@ -122,6 +122,34 @@ class ScalarListsSpec extends FlatSpec with Matchers with ApiSpecBase {
 
     res should be(
       s"""{"data":{"updateScalarModel":{"strings":["updated","now","future"],"ints":[14,15],"floats":[1.2345678,2],"decimals":["1.2345678","2"],"booleans":[false,false,true,true],"enums":["A"],"dateTimes":["2019-07-31T23:59:01.000Z","2019-07-31T23:59:01.000Z"],"bytes":["dGVzdA==","dGVzdA=="]}}}""".parseJson)
+
+    res = server.query(
+      s"""mutation {
+         |  updateScalarModel(where: { id: 1 }, data: {
+         |    strings:   { push: ["more", "items"] }
+         |    ints:      { push: [16, 17] }
+         |    floats:    { push: [3, 4] }
+         |    decimals:  { push: ["3", "4"] }
+         |    booleans:  { push: [false, true] }
+         |    enums:     { push: [B, A] }
+         |    dateTimes: { push: ["2019-07-31T23:59:01.000Z", "2019-07-31T23:59:01.000Z"] }
+         |    bytes:     { push: ["dGVzdA==", "dGVzdA=="] }
+         |  }) {
+         |    strings
+         |    ints
+         |    floats
+         |    decimals
+         |    booleans
+         |    enums
+         |    dateTimes
+         |    bytes
+         |  }
+         |}""",
+      project = project
+    )
+
+    res should be(
+      s"""{"data":{"updateScalarModel":{"strings":["updated","now","future","more","items"],"ints":[14,15,16,17],"floats":[1.2345678,2.0,3.0,4.0],"decimals":["1.2345678","2","3","4"],"booleans":[false,false,true,true,false,true],"enums":["A","B","A"],"dateTimes":["2019-07-31T23:59:01.000Z","2019-07-31T23:59:01.000Z","2019-07-31T23:59:01.000Z","2019-07-31T23:59:01.000Z"],"bytes":["dGVzdA==","dGVzdA==","dGVzdA==","dGVzdA=="]}}}""".parseJson)
   }
 
   "A Create Mutation" should "create and return items with list values with shorthand notation" in {
@@ -226,7 +254,18 @@ class ScalarListsSpec extends FlatSpec with Matchers with ApiSpecBase {
       project = project
     )
 
-    val res = server.query(
+    server.query(
+      s"""mutation {
+         |  createScalarModel(data: {
+         |    id: 2,
+         |  }) {
+         |    id
+         |  }
+         |}""",
+      project = project
+    )
+
+    var res = server.query(
       s"""mutation {
          |  updateScalarModel(where: { id: 1 }, data: {
          |    strings:   { push: "future" }
@@ -253,5 +292,32 @@ class ScalarListsSpec extends FlatSpec with Matchers with ApiSpecBase {
 
     res should be(
       s"""{"data":{"updateScalarModel":{"strings":["future"],"ints":[15],"floats":[2.0],"decimals":["2"],"booleans":[true],"enums":["A"],"dateTimes":["2019-07-31T23:59:01.000Z"],"bytes":["dGVzdA=="]}}}""".parseJson)
+
+    res = server.query(
+      s"""mutation {
+         |  updateScalarModel(where: { id: 2 }, data: {
+         |    strings:   { push: ["present", "future"] }
+         |    ints:      { push: [14, 15] }
+         |    floats:    { push: [1, 2] }
+         |    decimals:  { push: ["1", "2"] }
+         |    booleans:  { push: [false, true] }
+         |    enums:     { push: [A, B] }
+         |    dateTimes: { push: ["2019-07-31T23:59:01.000Z", "2019-07-31T23:59:02.000Z"] }
+         |    bytes:     { push: ["dGVzdA==", "dGVzdA=="] }
+         |  }) {
+         |    strings
+         |    ints
+         |    floats
+         |    decimals
+         |    booleans
+         |    enums
+         |    dateTimes
+         |    bytes
+         |  }
+         |}""",
+      project = project
+    )
+
+    res should be(s"""{"data":{"updateScalarModel":{"strings":["present","future"],"ints":[14,15],"floats":[1.0,2.0],"decimals":["1","2"],"booleans":[false,true],"enums":["A","B"],"dateTimes":["2019-07-31T23:59:01.000Z","2019-07-31T23:59:02.000Z"],"bytes":["dGVzdA==","dGVzdA=="]}}}""".parseJson)
   }
 }

--- a/query-engine/connectors/sql-query-connector/src/query_builder/write.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_builder/write.rs
@@ -101,9 +101,13 @@ pub fn update_many(model: &ModelRef, ids: &[&RecordProjection], args: WriteArgs)
                 WriteExpression::Value(rhs) => field.value(rhs).into(),
                 WriteExpression::Add(rhs) if field.is_list => {
                     let e: Expression = Column::from(name.clone()).into();
+                    let vals: Vec<_> = match rhs {
+                        PrismaValue::List(vals) => vals.into_iter().map(|val| field.value(val)).collect(),
+                        _ => vec![field.value(rhs)],
+                    };
 
                     // Postgres only
-                    e.compare_raw("||", Value::array(vec![field.value(rhs)])).into()
+                    e.compare_raw("||", Value::array(vals)).into()
                 }
                 WriteExpression::Add(rhs) => {
                     let e: Expression<'_> = Column::from(name.clone()).into();

--- a/query-engine/core/src/schema_builder/input_types/input_fields.rs
+++ b/query-engine/core/src/schema_builder/input_types/input_fields.rs
@@ -279,7 +279,10 @@ where
                 object_fields.push(
                     input_field(
                         operations::PUSH,
-                        map_scalar_input_type(ctx, &f.type_identifier, false),
+                        vec![
+                            map_scalar_input_type(ctx, &f.type_identifier, false),
+                            list_input_type.clone(),
+                        ],
                         None,
                     )
                     .optional(),


### PR DESCRIPTION
## Overview

Follow-up to #1753
Finishes https://github.com/prisma/prisma/issues/5078

This enables pushing a list of values to a scalar list.

Concretely, from a query perspective, this adds the following ability:

```graphql
{
  updateOneModel(where: { ... }, data: { strList: { push: ["moar", "items"] } })
}
```

It was previously only possible to push a single item with:

```graphql
{
  updateOneModel(where: { ... }, data: { strList: { push: "a single item" } })
}
```

From a schema/DMMF perspective, this PR changes the following types:


```diff
type ModelUpdatestrListInput {
   set: String[]
-  push: String
+  push: String | String[]
}
```