### PR TITLE
Simplify `Arguments` in schema parser

### DIFF
--- a/libs/datamodel/core/src/lib.rs
+++ b/libs/datamodel/core/src/lib.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::upper_case_acronyms)]
-
 //! This crate is responsible for parsing, rendering and formatting a Prisma Schema.
 //! A Prisma Schema consists out of two parts:
 //! 1. The `Datamodel` part refers to the model and enum definitions.
@@ -73,7 +71,11 @@
 //!</pre>
 //!
 
-#![allow(clippy::module_inception, clippy::suspicious_operation_groupings)]
+#![allow(
+    clippy::module_inception,
+    clippy::suspicious_operation_groupings,
+    clippy::upper_case_acronyms
+)]
 
 pub mod ast;
 pub mod common;
@@ -84,13 +86,12 @@ pub mod json;
 pub mod transform;
 pub mod walkers;
 
-use std::path::Path;
-
 pub use crate::dml::*;
 pub use configuration::*;
 
 use crate::ast::SchemaAst;
 use crate::diagnostics::{ValidatedConfiguration, ValidatedDatamodel, ValidatedDatasources};
+use std::path::Path;
 use transform::{
     ast_to_dml::{DatasourceLoader, GeneratorLoader, ValidationPipeline},
     dml_to_ast::{DatasourceSerializer, GeneratorSerializer, LowerDmlToAst},

--- a/libs/datamodel/core/src/transform/helpers/arguments.rs
+++ b/libs/datamodel/core/src/transform/helpers/arguments.rs
@@ -1,108 +1,81 @@
 use super::ValueValidator;
 use crate::ast;
 use crate::diagnostics::{DatamodelError, Diagnostics};
-use std::collections::HashSet;
+use std::collections::HashMap;
 
 /// Represents a list of arguments.
 #[derive(Debug)]
 pub struct Arguments<'a> {
-    arguments: &'a [ast::Argument],
-    used_arguments: HashSet<&'a str>,
+    args: HashMap<&'a str, &'a ast::Argument>, // the _remaining_ arguments
     span: ast::Span,
 }
 
 impl<'a> Arguments<'a> {
-    /// Creates a new instance, given a list of arguments.
-    pub fn new(arguments: &'a [ast::Argument], span: ast::Span) -> Arguments<'a> {
-        Arguments {
-            used_arguments: HashSet::new(),
-            arguments,
+    /// Creates a new instance for an attribute, checking for duplicate arguments in the process.
+    pub fn new(attribute: &'a ast::Attribute) -> Result<Arguments<'a>, Diagnostics> {
+        let arguments = &attribute.arguments;
+        let span = attribute.span;
+        let mut remaining_arguments = HashMap::with_capacity(arguments.len()); // validation will succeed more often than not
+        let mut errors = Diagnostics::new();
+        let mut unnamed_arguments = Vec::new();
+
+        for arg in arguments {
+            if let Some(existing_argument) = remaining_arguments.insert(arg.name.name.as_str(), arg) {
+                if arg.is_unnamed() {
+                    if unnamed_arguments.is_empty() {
+                        unnamed_arguments.push(existing_argument.value.render_to_string())
+                    }
+
+                    unnamed_arguments.push(arg.value.render_to_string())
+                } else {
+                    errors.push_error(DatamodelError::new_duplicate_argument_error(&arg.name.name, arg.span));
+                }
+            }
+        }
+
+        if !unnamed_arguments.is_empty() {
+            errors.push_error(DatamodelError::new_attribute_validation_error(
+                &format!("You provided multiple unnamed arguments. This is not possible. Did you forget the brackets? Did you mean `[{}]`?", unnamed_arguments.join(", ")),
+                attribute.name.name.as_str(),
+                span
+            ))
+        }
+
+        errors.to_result()?;
+
+        Ok(Arguments {
+            args: remaining_arguments,
             span,
-        }
+        })
     }
 
-    /// Checks if arguments occur twice and returns an appropriate error list.
-    pub fn check_for_duplicate_named_arguments(&self) -> Result<(), Diagnostics> {
-        let mut arg_names: HashSet<&'a str> = HashSet::new();
-        let mut errors = Diagnostics::new();
-
-        for arg in self.arguments {
-            if arg_names.contains::<&str>(&(&arg.name.name as &str)) {
-                errors.push_error(DatamodelError::new_duplicate_argument_error(&arg.name.name, arg.span));
-            }
-            if !arg.is_unnamed() {
-                arg_names.insert(&arg.name.name);
-            }
+    /// Call this at the end of validation. It will report errors for each argument that was not used by the validators.
+    pub(crate) fn check_for_unused_arguments(&self, errors: &mut Diagnostics) {
+        for arg in self.args.values() {
+            errors.push_error(DatamodelError::new_unused_argument_error(&arg.name.name, arg.span));
         }
-
-        errors.to_result()
-    }
-
-    pub fn check_for_multiple_unnamed_arguments(&self, attribute_name: &str) -> Result<(), Diagnostics> {
-        let mut unnamed_values: Vec<String> = Vec::new();
-        for arg in self.arguments {
-            if arg.is_unnamed() {
-                unnamed_values.push(arg.value.render_to_string());
-            }
-        }
-
-        if unnamed_values.len() > 1 {
-            Err(DatamodelError::new_attribute_validation_error(
-                &format!("You provided multiple unnamed arguments. This is not possible. Did you forget the brackets? Did you mean `[{}]`?", unnamed_values.join(", ")),
-                attribute_name,
-                self.span).into()
-            )
-        } else {
-            Ok(())
-        }
-    }
-
-    /// Checks if arguments were not accessed and raises the appropriate errors.
-    pub fn check_for_unused_arguments(&self) -> Result<(), Diagnostics> {
-        let mut errors = Diagnostics::new();
-
-        for arg in self.arguments {
-            if !self.used_arguments.contains::<&str>(&(&arg.name.name as &str)) {
-                errors.push_error(DatamodelError::new_unused_argument_error(&arg.name.name, arg.span));
-            }
-        }
-
-        errors.to_result()
     }
 
     /// Gets the span of all arguments wrapped by this instance.
-    pub fn span(&self) -> ast::Span {
+    pub(crate) fn span(&self) -> ast::Span {
         self.span
     }
 
     /// Gets the arg with the given name.
-    pub fn arg(&mut self, name: &str) -> Result<ValueValidator, DatamodelError> {
-        match self.arg_internal(name) {
-            None => Err(DatamodelError::new_argument_not_found_error(name, self.span)),
-            Some(arg) => Ok(ValueValidator::new(&arg.value)),
-        }
+    pub(crate) fn arg(&mut self, name: &str) -> Result<ValueValidator, DatamodelError> {
+        self.optional_arg(name)
+            .ok_or_else(|| DatamodelError::new_argument_not_found_error(name, self.span))
     }
 
-    pub fn optional_arg(&mut self, name: &str) -> Option<ValueValidator> {
-        let arg = self.arg_internal(name)?;
-
-        Some(ValueValidator::new(&arg.value))
-    }
-
-    /// Gets the full argument span for an argument, used to generate errors.
-    fn arg_internal(&mut self, name: &str) -> Option<&'a ast::Argument> {
-        let arg = self.arguments.iter().find(|arg| arg.name.name == name)?;
-
-        self.used_arguments.insert(arg.name.name.as_str());
-
-        Some(arg)
+    pub(crate) fn optional_arg(&mut self, name: &str) -> Option<ValueValidator> {
+        self.args.remove(name).map(|arg| ValueValidator::new(&arg.value))
     }
 
     /// Gets the arg with the given name, or if it is not found, the first unnamed argument.
     ///
     /// Use this to implement unnamed argument behavior.
     pub fn default_arg(&mut self, name: &str) -> Result<ValueValidator, DatamodelError> {
-        match (self.arg_internal(name), self.arg_internal("")) {
+        match (self.args.remove(name), self.args.remove("")) {
             (Some(arg), None) => Ok(ValueValidator::new(&arg.value)),
             (None, Some(arg)) => Ok(ValueValidator::new(&arg.value)),
             (Some(arg), Some(_)) => Err(DatamodelError::new_duplicate_default_argument_error(&name, arg.span)),


### PR DESCRIPTION
This is an opportunistic refactoring I made as I was trying to
understand the attribution validation code.

- Less code
- Fewer methods to call in consuming code
- Fewer allocations