### PR TITLE
Try to survive if the server closes the connection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3238,7 +3238,7 @@ dependencies = [
 [[package]]
 name = "quaint"
 version = "0.2.0-alpha.13"
-source = "git+https://github.com/prisma/quaint#f0bd031e2989651e110c1c12e64bd0133e99e41a"
+source = "git+https://github.com/prisma/quaint#8c4544130e1fe1cbc0f95ec3b21e616763774808"
 dependencies = [
  "async-trait",
  "base64 0.12.3",

--- a/libs/user-facing-errors/src/common.rs
+++ b/libs/user-facing-errors/src/common.rs
@@ -181,6 +181,10 @@ pub struct IncorrectNumberOfParameters {
     pub actual: usize,
 }
 
+#[derive(Debug, UserFacingError, Serialize)]
+#[user_facing(code = "P1017", message = "Server has closed the connection.")]
+pub struct ConnectionClosed;
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/libs/user-facing-errors/src/quaint.rs
+++ b/libs/user-facing-errors/src/quaint.rs
@@ -238,6 +238,8 @@ pub fn render_quaint_error(kind: &ErrorKind, connection_info: &ConnectionInfo) -
             }))
         }
 
+        (ErrorKind::ConnectionClosed, _) => Some(KnownError::new(common::ConnectionClosed)),
+
         _ => None,
     }
 }

--- a/query-engine/connectors/query-connector/src/error.rs
+++ b/query-engine/connectors/query-connector/src/error.rs
@@ -189,6 +189,9 @@ pub enum ErrorKind {
         actual
     )]
     IncorrectNumberOfParameters { expected: usize, actual: usize },
+
+    #[error("Server terminated the connection.")]
+    ConnectionClosed,
 }
 
 impl From<DomainError> for ConnectorError {


### PR DESCRIPTION
The engines counterpart for the Quaint change to mark closed connections dead, never using them again after a failure.

Adds a user-facing error for the closed connection. This error will be visible for the one query that didn't finish, letting the user make the decision to retry the query, or restart the app, depending on the use-case.

Quaint: https://github.com/prisma/quaint/pull/283

Closes: https://github.com/prisma/prisma/issues/5976
Closes: https://github.com/prisma/prisma/issues/5947
Closes: https://github.com/prisma/prisma/issues/5515
Closes: https://github.com/prisma/prisma/issues/6213
Closes: https://github.com/prisma/prisma/issues/6329
Closes: https://github.com/prisma/prisma/issues/6139
Closes: https://github.com/prisma/prisma/issues/5418