### PR TITLE
Fixes prisma/prisma#6042

### DIFF
--- a/libs/datamodel/core/src/transform/ast_to_dml/validate.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validate.rs
@@ -540,11 +540,11 @@ impl<'a> Validator<'a> {
                 .cloned()
                 .collect();
 
-            let at_least_one_underlying_field_is_required = rel_info
+            let at_least_one_underlying_field_is_optional = rel_info
                 .fields
                 .iter()
                 .filter_map(|base_field| model.find_scalar_field(&base_field))
-                .any(|f| f.is_required());
+                .any(|f| !f.is_required());
 
             let all_underlying_fields_are_optional = rel_info
                 .fields
@@ -570,10 +570,10 @@ impl<'a> Validator<'a> {
                     );
             }
 
-            if at_least_one_underlying_field_is_required && !field.is_required() {
+            if at_least_one_underlying_field_is_optional && field.is_required() {
                 errors.push_error(DatamodelError::new_validation_error(
                         &format!(
-                            "The relation field `{}` uses the scalar fields {}. At least one of those fields is required. Hence the relation field must be required as well.",
+                            "The relation field `{}` uses the scalar fields {}. At least one of those fields is optional. Hence the relation field must be optional as well.",
                             &field.name,
                             rel_info.fields.join(", ")
                         ),

--- a/libs/datamodel/core/tests/attributes/relations/relations_new.rs
+++ b/libs/datamodel/core/tests/attributes/relations/relations_new.rs
@@ -116,7 +116,7 @@ fn optional_relation_field_must_succeed_when_all_underlying_fields_are_optional(
 }
 
 #[test]
-fn optional_relation_field_must_error_when_one_underlying_field_is_required() {
+fn required_relation_field_must_error_when_one_underlying_field_is_optional() {
     let dml = r#"
     model User {
         id        Int     @id
@@ -133,12 +133,12 @@ fn optional_relation_field_must_error_when_one_underlying_field_is_required() {
         userFirstName String
         userLastName  String?
 
-        user          User?   @relation(fields: [userFirstName, userLastName], references: [firstName, lastName])
+        user          User    @relation(fields: [userFirstName, userLastName], references: [firstName, lastName])
     }
     "#;
 
     let errors = parse_error(dml);
-    errors.assert_is(DatamodelError::new_validation_error("The relation field `user` uses the scalar fields userFirstName, userLastName. At least one of those fields is required. Hence the relation field must be required as well.", Span::new(320, 426)));
+    errors.assert_is(DatamodelError::new_validation_error("The relation field `user` uses the scalar fields userFirstName, userLastName. At least one of those fields is optional. Hence the relation field must be optional as well.", Span::new(320, 426)));
 }
 
 #[test]


### PR DESCRIPTION
Allow optional relations with a composite foreign key even if one relation field is required and prevent required relations if at least one relation field is optional.

https://github.com/prisma/prisma/issues/6042