### PR TITLE
Handle more errors when trying to create a db

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3322,7 +3322,7 @@ dependencies = [
 [[package]]
 name = "quaint"
 version = "0.2.0-alpha.13"
-source = "git+https://github.com/prisma/quaint#8c4544130e1fe1cbc0f95ec3b21e616763774808"
+source = "git+https://github.com/prisma/quaint#8196f13800cc22d40c51a057aae10863099f17f5"
 dependencies = [
  "async-trait",
  "base64 0.12.3",

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/postgres.rs
@@ -9,8 +9,9 @@ use sql_schema_describer::{DescriberErrorKind, SqlSchema, SqlSchemaDescriberBack
 use std::collections::HashMap;
 use url::Url;
 use user_facing_errors::{
-    common::DatabaseDoesNotExist, introspection_engine::DatabaseSchemaInconsistent, migration_engine, KnownError,
-    UserFacingError,
+    common::{DatabaseAccessDenied, DatabaseDoesNotExist},
+    introspection_engine::DatabaseSchemaInconsistent,
+    migration_engine, KnownError, UserFacingError,
 };
 
 const ADVISORY_LOCK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
@@ -355,6 +356,7 @@ async fn create_postgres_admin_conn(mut url: Url) -> ConnectorResult<Connection>
             // If the database does not exist, try the next one.
             Err(err) => match &err.error_code() {
                 Some(DatabaseDoesNotExist::ERROR_CODE) => (),
+                Some(DatabaseAccessDenied::ERROR_CODE) => (),
                 _ => {
                     conn = Some(Err(err));
                     break;


### PR DESCRIPTION
We try to connect to some available postgres database while creating a new database. The order is `postgres`, `template1` and `defaultdb`. We try again, if the database does not exist, but crashed and burned if we didn't have access to the given database.

In case of the cloud version of timescaledb, we connect first to `postgres` which does not exist, then `template1` which gives us access denied. The third one would've be `defaultdb` that would work, but we already exited during `template1`.

Quaint: https://github.com/prisma/quaint/pull/284
Closes: https://github.com/prisma/prisma/issues/6277