### PR TITLE
Handle SQL Server type aliases on introspection

### DIFF
--- a/introspection-engine/introspection-engine-tests/tests/mssql/mod.rs
+++ b/introspection-engine/introspection-engine-tests/tests/mssql/mod.rs
@@ -1,5 +1,6 @@
 use indoc::indoc;
 use introspection_engine_tests::test_api::*;
+use quaint::prelude::Queryable;
 use test_macros::test_each_connector;
 
 #[test_each_connector(tags("mssql"))]
@@ -23,5 +24,32 @@ async fn geometry_should_be_unsupported(api: &TestApi) -> crate::TestResult {
     "#};
 
     api.assert_eq_datamodels(&dm, &result);
+
+    Ok(())
+}
+
+#[test_each_connector(tags("mssql"), log = "quaint=trace")]
+async fn user_defined_type_aliases_should_map_to_the_system_type(api: &TestApi) -> crate::TestResult {
+    let create_type = format!("CREATE TYPE [{}].[Name] FROM [nvarchar](50) NULL", api.schema_name());
+    api.database().raw_cmd(&create_type).await?;
+
+    let create_table = format!(
+        "CREATE TABLE [{schema_name}].[A] (id int identity primary key, name [{schema_name}].[Name])",
+        schema_name = api.schema_name()
+    );
+
+    api.database().raw_cmd(&create_table).await?;
+
+    let dm = indoc! {r#"
+        model A {
+          id       Int @id @default(autoincrement())
+          name     String? @db.NVarChar(50)
+        }
+    "#};
+
+    let result = api.introspect().await?;
+
+    api.assert_eq_datamodels(&dm, &result);
+
     Ok(())
 }

--- a/libs/sql-schema-describer/src/mssql.rs
+++ b/libs/sql-schema-describer/src/mssql.rs
@@ -234,7 +234,10 @@ impl SqlSchemaDescriber {
     async fn get_all_columns(&self, schema: &str) -> DescriberResult<HashMap<String, Vec<Column>>> {
         let sql = indoc! {r#"
             SELECT c.name                                                       AS column_name,
-                typ.name                                                        AS data_type,
+                CASE typ.is_assembly_type
+                        WHEN 1 THEN TYPE_NAME(c.user_type_id)
+                        ELSE TYPE_NAME(c.system_type_id)
+                END                                                             AS data_type,
                 COLUMNPROPERTY(c.object_id, c.name, 'charmaxlen')               AS character_maximum_length,
                 OBJECT_DEFINITION(c.default_object_id)                          AS column_default,
                 c.is_nullable                                                   AS is_nullable,


### PR DESCRIPTION
The previous change changed how we get type names, mapping the  `user_type_id` and taking its name. This fixed the case where the type didn't have any system type underneath, such as `geography`. Now, we can also define user types like this:

```sql
CREATE TYPE Name FROM NVARCHAR(50)
```

This would create a new type, that is actually just `NVARCHAR` underneath. Our previous change would map all these columns as of type `Name` in the schema, which rendered them unsupported (and is not what we want). Now we check is the type a CLR assembly type and only then we take the name from the user type, otherwise relying to the system type as we did before.