### PR TITLE
Remove connection strings from error messages

### DIFF
--- a/introspection-engine/connectors/introspection-connector/src/error.rs
+++ b/introspection-engine/connectors/introspection-connector/src/error.rs
@@ -19,13 +19,13 @@ impl ConnectorError {
         }
     }
 
-    pub fn url_parse_error(err: impl Display, url: &str) -> Self {
-        let details = user_facing_errors::quaint::invalid_url_description(url, &format!("{}", err));
+    pub fn url_parse_error(err: impl Display) -> Self {
+        let details = user_facing_errors::quaint::invalid_url_description(&err.to_string());
         let known = KnownError::new(InvalidDatabaseString { details });
 
         ConnectorError {
             user_facing_error: Some(known),
-            kind: ErrorKind::InvalidDatabaseUrl(format!("{} in `{}`)", err, url)),
+            kind: ErrorKind::InvalidDatabaseUrl(format!("{} in database URL", err)),
         }
     }
 

--- a/introspection-engine/connectors/sql-introspection-connector/src/lib.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/lib.rs
@@ -46,7 +46,7 @@ impl SqlIntrospectionConnector {
             .map_err(|error| {
                 ConnectionInfo::from_url(url)
                     .map(|connection_info| error.into_connector_error(&connection_info))
-                    .unwrap_or_else(|err| ConnectorError::url_parse_error(err, url))
+                    .unwrap_or_else(ConnectorError::url_parse_error)
             })?;
 
         tracing::debug!("SqlIntrospectionConnector initialized.");

--- a/introspection-engine/introspection-engine-tests/tests/errors/mod.rs
+++ b/introspection-engine/introspection-engine-tests/tests/errors/mod.rs
@@ -1,4 +1,4 @@
-use indoc::formatdoc;
+use indoc::indoc;
 use introspection_core::RpcImpl;
 use pretty_assertions::assert_eq;
 use serde_json::json;
@@ -24,21 +24,19 @@ async fn connection_string_problems_give_a_nice_error() {
 
         let details = match provider.0 {
             "sqlserver" => {
-                formatdoc!(
-                    "Error parsing connection string: Conversion error: invalid digit found in string in `{connection_string}`.
+                indoc!(
+                    "Error parsing connection string: Conversion error: invalid digit found in string in database URL.
                     Please refer to the documentation in https://www.prisma.io/docs/reference/database-reference/connection-urls
                     for constructing a correct connection string. In some cases, certain characters must be escaped.
                     Please check the string for any illegal characters.",
-                    connection_string = provider.1
                 ).replace('\n', " ")
             },
             _ => {
-                formatdoc!(
-                    "Error parsing connection string: invalid port number in `{connection_string}`.
+                indoc!(
+                    "Error parsing connection string: invalid port number in database URL.
                     Please refer to the documentation in https://www.prisma.io/docs/reference/database-reference/connection-urls
                     for constructing a correct connection string. In some cases, certain characters must be escaped.
                     Please check the string for any illegal characters.",
-                    connection_string = provider.1
                 ).replace('\n', " ")
             }
         };

--- a/libs/user-facing-errors/src/quaint.rs
+++ b/libs/user-facing-errors/src/quaint.rs
@@ -25,13 +25,13 @@ impl From<quaint::error::DatabaseConstraint> for crate::query_engine::DatabaseCo
     }
 }
 
-pub fn invalid_url_description(database_str: &str, error_details: &str) -> String {
+pub fn invalid_url_description(error_details: &str) -> String {
     let docs = r#"https://www.prisma.io/docs/reference/database-reference/connection-urls"#;
 
     let details = formatdoc! {r#"
-            {} in `{}`. Please refer to the documentation in {} for constructing a correct
+            {} in database URL. Please refer to the documentation in {} for constructing a correct
             connection string. In some cases, certain characters must be escaped. Please
-            check the string for any illegal characters."#, error_details, database_str, docs};
+            check the string for any illegal characters."#, error_details, docs};
 
     details.replace('\n', " ")
 }

--- a/migration-engine/cli/src/error_tests.rs
+++ b/migration-engine/cli/src/error_tests.rs
@@ -49,7 +49,7 @@ async fn bad_postgres_url_must_return_a_good_error() {
 
     let expected = json!({
         "is_panic": false,
-        "message": "Error parsing connection string: invalid port number in `postgresql://postgres:prisma@localhost:543`/mydb?schema=public`\n\n",
+        "message": "Error parsing connection string: invalid port number in database URL\n\n",
         "backtrace": null,
     });
 

--- a/migration-engine/connectors/migration-connector/src/error.rs
+++ b/migration-engine/connectors/migration-connector/src/error.rs
@@ -150,8 +150,8 @@ impl ConnectorError {
     }
 
     /// Construct an UrlParseError.
-    pub fn url_parse_error(err: impl Display, url: &str) -> Self {
-        Self::from_msg(format!("{} in `{}`", err, url))
+    pub fn url_parse_error(err: impl Display) -> Self {
+        Self::from_msg(format!("{} in database URL", err))
     }
 }
 

--- a/migration-engine/connectors/mongodb-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/mongodb-migration-connector/src/lib.rs
@@ -50,7 +50,7 @@ impl MongoDbMigrationConnector {
     }
 
     async fn create_client(database_str: &str) -> ConnectorResult<(Client, String)> {
-        let url = Url::parse(database_str).map_err(|err| ConnectorError::url_parse_error(err, database_str))?;
+        let url = Url::parse(database_str).map_err(ConnectorError::url_parse_error)?;
         let db_name = url.path().trim_start_matches('/').to_string();
 
         let client_options = ClientOptions::parse(database_str).await.into_connector_result()?;

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/mysql.rs
@@ -145,7 +145,7 @@ impl SqlFlavour for MysqlFlavour {
     }
 
     async fn create_database(&self, database_str: &str) -> ConnectorResult<String> {
-        let mut url = Url::parse(database_str).map_err(|err| ConnectorError::url_parse_error(err, database_str))?;
+        let mut url = Url::parse(database_str).map_err(ConnectorError::url_parse_error)?;
         url.set_path("/mysql");
 
         let conn = connect(&url.to_string()).await?;
@@ -253,7 +253,7 @@ impl SqlFlavour for MysqlFlavour {
     }
 
     async fn qe_setup(&self, database_str: &str) -> ConnectorResult<()> {
-        let mut url = Url::parse(database_str).map_err(|err| ConnectorError::url_parse_error(err, database_str))?;
+        let mut url = Url::parse(database_str).map_err(ConnectorError::url_parse_error)?;
         url.set_path("/mysql");
 
         let conn = connect(&url.to_string()).await?;

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/postgres.rs
@@ -116,7 +116,7 @@ impl SqlFlavour for PostgresFlavour {
 
     #[tracing::instrument(skip(database_str))]
     async fn create_database(&self, database_str: &str) -> ConnectorResult<String> {
-        let mut url = Url::parse(database_str).map_err(|err| ConnectorError::url_parse_error(err, database_str))?;
+        let mut url = Url::parse(database_str).map_err(ConnectorError::url_parse_error)?;
         let db_name = self.url.dbname();
 
         strip_schema_param_from_url(&mut url);
@@ -190,7 +190,7 @@ impl SqlFlavour for PostgresFlavour {
     }
 
     async fn drop_database(&self, database_str: &str) -> ConnectorResult<()> {
-        let mut url = Url::parse(database_str).map_err(|err| ConnectorError::url_parse_error(err, database_str))?;
+        let mut url = Url::parse(database_str).map_err(ConnectorError::url_parse_error)?;
         let db_name = url.path().trim_start_matches('/').to_owned();
         assert!(!db_name.is_empty(), "Database name should not be empty.");
 
@@ -238,7 +238,7 @@ impl SqlFlavour for PostgresFlavour {
     }
 
     async fn qe_setup(&self, database_str: &str) -> ConnectorResult<()> {
-        let mut url = Url::parse(database_str).map_err(|err| ConnectorError::url_parse_error(err, database_str))?;
+        let mut url = Url::parse(database_str).map_err(ConnectorError::url_parse_error)?;
 
         strip_schema_param_from_url(&mut url);
         let conn = create_postgres_admin_conn(url.clone()).await?;

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/sqlite.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/sqlite.rs
@@ -78,7 +78,7 @@ impl SqlFlavour for SqliteFlavour {
         let file_path = match ConnectionInfo::from_url(database_url) {
             Ok(ConnectionInfo::Sqlite { file_path, .. }) => file_path,
             Ok(_) => unreachable!(),
-            Err(err) => return Err(ConnectorError::url_parse_error(err, database_url)),
+            Err(err) => return Err(ConnectorError::url_parse_error(err)),
         };
 
         std::fs::remove_file(&file_path).map_err(|err| {

--- a/migration-engine/connectors/sql-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/lib.rs
@@ -56,16 +56,14 @@ impl SqlMigrationConnector {
 
     /// Create the database corresponding to the connection string, without initializing the connector.
     pub async fn create_database(database_str: &str) -> ConnectorResult<String> {
-        let connection_info =
-            ConnectionInfo::from_url(database_str).map_err(|err| ConnectorError::url_parse_error(err, database_str))?;
+        let connection_info = ConnectionInfo::from_url(database_str).map_err(ConnectorError::url_parse_error)?;
         let flavour = flavour::from_connection_info(&connection_info, BitFlags::empty());
         flavour.create_database(database_str).await
     }
 
     /// Drop the database corresponding to the connection string, without initializing the connector.
     pub async fn drop_database(database_str: &str) -> ConnectorResult<()> {
-        let connection_info =
-            ConnectionInfo::from_url(database_str).map_err(|err| ConnectorError::url_parse_error(err, database_str))?;
+        let connection_info = ConnectionInfo::from_url(database_str).map_err(ConnectorError::url_parse_error)?;
         let flavour = flavour::from_connection_info(&connection_info, BitFlags::empty());
 
         flavour.drop_database(database_str).await
@@ -73,8 +71,7 @@ impl SqlMigrationConnector {
 
     /// Set up the database for connector-test-kit, without initializing the connector.
     pub async fn qe_setup(database_str: &str) -> ConnectorResult<()> {
-        let connection_info =
-            ConnectionInfo::from_url(database_str).map_err(|err| ConnectorError::url_parse_error(err, database_str))?;
+        let connection_info = ConnectionInfo::from_url(database_str).map_err(ConnectorError::url_parse_error)?;
 
         let flavour = flavour::from_connection_info(&connection_info, BitFlags::empty());
 
@@ -217,7 +214,7 @@ impl MigrationConnector for SqlMigrationConnector {
 
 async fn connect(database_str: &str) -> ConnectorResult<Connection> {
     let connection_info = ConnectionInfo::from_url(database_str).map_err(|err| {
-        let details = user_facing_errors::quaint::invalid_url_description(database_str, &err.to_string());
+        let details = user_facing_errors::quaint::invalid_url_description(&err.to_string());
         KnownError::new(InvalidDatabaseString { details })
     })?;
 

--- a/migration-engine/core/src/lib.rs
+++ b/migration-engine/core/src/lib.rs
@@ -46,10 +46,10 @@ pub async fn migration_api(datamodel: &str) -> CoreResult<Box<dyn api::GenericAp
             let database_str = &source.url().value;
 
             let mut u = url::Url::parse(database_str).map_err(|err| {
-                let details = user_facing_errors::quaint::invalid_url_description(
-                    database_str,
-                    &format!("Error parsing connection string: {}", err),
-                );
+                let details = user_facing_errors::quaint::invalid_url_description(&format!(
+                    "Error parsing connection string: {}",
+                    err
+                ));
 
                 ConnectorError::from(KnownError::new(InvalidDatabaseString { details }))
             })?;

--- a/migration-engine/migration-engine-tests/tests/errors/error_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/errors/error_tests.rs
@@ -1,4 +1,4 @@
-use indoc::formatdoc;
+use indoc::{formatdoc, indoc};
 use migration_core::api::RpcApi;
 use migration_engine_tests::sql::*;
 use pretty_assertions::assert_eq;
@@ -452,21 +452,19 @@ async fn connection_string_problems_give_a_nice_error() {
 
         let details = match provider.0 {
             "sqlserver" => {
-                formatdoc!(
-                    "Error parsing connection string: Conversion error: invalid digit found in string in `{connection_string}`.
+                indoc!(
+                    "Error parsing connection string: Conversion error: invalid digit found in string in database URL.
                     Please refer to the documentation in https://www.prisma.io/docs/reference/database-reference/connection-urls
                     for constructing a correct connection string. In some cases, certain characters must be escaped.
                     Please check the string for any illegal characters.",
-                    connection_string = provider.1
                 ).replace('\n', " ")
             },
             _ => {
-                formatdoc!(
-                    "Error parsing connection string: invalid port number in `{connection_string}`.
+                indoc!(
+                    "Error parsing connection string: invalid port number in database URL.
                     Please refer to the documentation in https://www.prisma.io/docs/reference/database-reference/connection-urls
                     for constructing a correct connection string. In some cases, certain characters must be escaped.
                     Please check the string for any illegal characters.",
-                    connection_string = provider.1
                 ).replace('\n', " ")
             }
         };

--- a/query-engine/connectors/query-connector/src/error.rs
+++ b/query-engine/connectors/query-connector/src/error.rs
@@ -33,8 +33,8 @@ impl ConnectorError {
                     column: column.clone(),
                 }))
             }
-            ErrorKind::InvalidDatabaseUrl { details, url } => {
-                let details = user_facing_errors::quaint::invalid_url_description(url, details);
+            ErrorKind::InvalidDatabaseUrl { details, url: _ } => {
+                let details = user_facing_errors::quaint::invalid_url_description(details);
 
                 Some(KnownError::new(user_facing_errors::common::InvalidDatabaseString {
                     details,

--- a/query-engine/query-engine/src/tests/errors.rs
+++ b/query-engine/query-engine/src/tests/errors.rs
@@ -1,4 +1,4 @@
-use indoc::formatdoc;
+use indoc::{formatdoc, indoc};
 use serde_json::json;
 
 use crate::context::PrismaContext;
@@ -46,21 +46,19 @@ async fn connection_string_problems_give_a_nice_error() {
 
         let details = match provider.0 {
             "sqlserver" => {
-                formatdoc!(
-                    "Error parsing connection string: Conversion error: invalid digit found in string in `{connection_string}`.
+                indoc!(
+                    "Error parsing connection string: Conversion error: invalid digit found in string in database URL.
                     Please refer to the documentation in https://www.prisma.io/docs/reference/database-reference/connection-urls
                     for constructing a correct connection string. In some cases, certain characters must be escaped.
                     Please check the string for any illegal characters.",
-                    connection_string = provider.1
                 ).replace('\n', " ")
             },
             _ => {
-                formatdoc!(
-                    "Error parsing connection string: invalid port number in `{connection_string}`.
+                indoc!(
+                    "Error parsing connection string: invalid port number in database URL.
                     Please refer to the documentation in https://www.prisma.io/docs/reference/database-reference/connection-urls
                     for constructing a correct connection string. In some cases, certain characters must be escaped.
                     Please check the string for any illegal characters.",
-                    connection_string = provider.1
                 ).replace('\n', " ")
             }
         };


### PR DESCRIPTION
This can be a cause of credential leaks.