### PR TITLE
Improve user facing errors in ApplyMigrations

### DIFF
--- a/libs/sql-ddl/src/mysql.rs
+++ b/libs/sql-ddl/src/mysql.rs
@@ -94,12 +94,12 @@ impl<'a> Display for ForeignKey<'a> {
 
         if let Some(on_delete) = &self.on_delete {
             f.write_str(" ON DELETE ")?;
-            on_delete.fmt(f)?;
+            Display::fmt(on_delete, f)?;
         }
 
         if let Some(on_update) = &self.on_update {
             f.write_str(" ON UPDATE ")?;
-            on_update.fmt(f)?;
+            Display::fmt(&on_update, f)?;
         }
 
         Ok(())

--- a/libs/user-facing-errors/src/migration_engine.rs
+++ b/libs/user-facing-errors/src/migration_engine.rs
@@ -234,7 +234,7 @@ pub struct MigrationToMarkAppliedNotFound {
 #[derive(Debug, Serialize, UserFacingError)]
 #[user_facing(
     code = "P3018",
-    message = "A migration failed to apply.
+    message = "A migration failed to apply. New migrations can not be applied before the error is recovered from. Read more about how to resolve migration issues in a production database: https://pris.ly/d/migrate-resolve
 
 Migration name: {migration_name}
 

--- a/libs/user-facing-errors/src/migration_engine.rs
+++ b/libs/user-facing-errors/src/migration_engine.rs
@@ -231,6 +231,25 @@ pub struct MigrationToMarkAppliedNotFound {
     pub migration_name: String,
 }
 
+#[derive(Debug, Serialize, UserFacingError)]
+#[user_facing(
+    code = "P3018",
+    message = "A migration failed to apply.
+
+Migration name: {migration_name}
+
+Database error code: {database_error_code}
+
+Database error:
+{database_error}
+"
+)]
+pub struct ApplyMigrationError {
+    pub migration_name: String,
+    pub database_error_code: String,
+    pub database_error: String,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/migration-engine/connectors/migration-connector/src/database_migration_step_applier.rs
+++ b/migration-engine/connectors/migration-connector/src/database_migration_step_applier.rs
@@ -15,7 +15,7 @@ pub trait DatabaseMigrationStepApplier<T>: Send + Sync {
 
     /// Apply a migration script to the database. The migration persistence is
     /// managed by the core.
-    async fn apply_script(&self, script: &str) -> ConnectorResult<()>;
+    async fn apply_script(&self, migration_name: &str, script: &str) -> ConnectorResult<()>;
 }
 
 /// A helper struct to serialize a database migration with an additional `raw` field containing the

--- a/migration-engine/connectors/mongodb-migration-connector/src/mongodb_migration_step_applier.rs
+++ b/migration-engine/connectors/mongodb-migration-connector/src/mongodb_migration_step_applier.rs
@@ -42,7 +42,7 @@ impl DatabaseMigrationStepApplier<MongoDbMigration> for MongoDbMigrationConnecto
         todo!()
     }
 
-    async fn apply_script(&self, _script: &str) -> migration_connector::ConnectorResult<()> {
+    async fn apply_script(&self, _migration_name: &str, _script: &str) -> migration_connector::ConnectorResult<()> {
         todo!()
     }
 }

--- a/migration-engine/connectors/sql-migration-connector/src/connection_wrapper.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/connection_wrapper.rs
@@ -24,6 +24,14 @@ impl ConnectionError<'_> {
     pub(crate) fn kind(&self) -> &QuaintKind {
         self.quaint_error.kind()
     }
+
+    pub(crate) fn original_code(&self) -> Option<&str> {
+        self.quaint_error.original_code()
+    }
+
+    pub(crate) fn original_message(&self) -> Option<&str> {
+        self.quaint_error.original_message()
+    }
 }
 
 impl From<ConnectionError<'_>> for ConnectorError {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
@@ -4,10 +4,11 @@ use crate::{
     SqlFlavour, SqlMigrationConnector,
 };
 use migration_connector::{
-    ConnectorResult, DatabaseMigrationMarker, DatabaseMigrationStepApplier, DestructiveChangeDiagnostics,
-    PrettyDatabaseMigrationStep,
+    ConnectorError, ConnectorResult, DatabaseMigrationMarker, DatabaseMigrationStepApplier,
+    DestructiveChangeDiagnostics, PrettyDatabaseMigrationStep,
 };
 use sql_schema_describer::{walkers::SqlSchemaExt, SqlSchema};
+use user_facing_errors::migration_engine::ApplyMigrationError;
 
 #[async_trait::async_trait]
 impl DatabaseMigrationStepApplier<SqlMigration> for SqlMigrationConnector {
@@ -110,9 +111,19 @@ impl DatabaseMigrationStepApplier<SqlMigration> for SqlMigrationConnector {
         script
     }
 
-    async fn apply_script(&self, script: &str) -> ConnectorResult<()> {
+    async fn apply_script(&self, migration_name: &str, script: &str) -> ConnectorResult<()> {
         self.flavour.scan_migration_script(script);
-        Ok(self.conn().raw_cmd(script).await?)
+
+        self.conn().raw_cmd(script).await.map_err(|quaint_error| {
+            ConnectorError::user_facing_error(ApplyMigrationError {
+                migration_name: migration_name.to_owned(),
+                database_error_code: String::from(quaint_error.original_code().unwrap_or("none")),
+                database_error: quaint_error
+                    .original_message()
+                    .map(String::from)
+                    .unwrap_or_else(|| ConnectorError::from(quaint_error).to_string()),
+            })
+        })
     }
 }
 

--- a/migration-engine/core/src/commands/apply_migrations.rs
+++ b/migration-engine/core/src/commands/apply_migrations.rs
@@ -88,7 +88,10 @@ impl<'a> MigrationCommand for ApplyMigrationsCommand {
                 .record_migration_started(unapplied_migration.migration_name(), &script)
                 .await?;
 
-            match applier.apply_script(&script).await {
+            match applier
+                .apply_script(unapplied_migration.migration_name(), &script)
+                .await
+            {
                 Ok(()) => {
                     tracing::debug!("Successfully applied the script.");
                     migration_persistence.record_successful_step(&migration_id).await?;

--- a/migration-engine/core/src/commands/diagnose_migration_history.rs
+++ b/migration-engine/core/src/commands/diagnose_migration_history.rs
@@ -23,6 +23,7 @@ pub struct DiagnoseMigrationHistoryInput {
 pub struct DiagnoseMigrationHistoryOutput {
     /// Whether drift between the expected schema and the dev database could be
     /// detected. `None` if the dev database has the expected schema.
+    #[serde(skip)]
     pub drift: Option<DriftDiagnostic>,
     /// The current status of the migration history of the database relative to
     /// migrations directory. `None` if they are in sync and up to date.
@@ -37,6 +38,7 @@ pub struct DiagnoseMigrationHistoryOutput {
     /// An optional error encountered when applying a migration that is not
     /// applied in the main database to the shadow database. We do this to
     /// validate that unapplied migrations are at least minimally valid.
+    #[serde(skip)]
     pub error_in_unapplied_migration: Option<user_facing_errors::Error>,
     /// Is the migrations table initialized in the database.
     pub has_migrations_table: bool,

--- a/migration-engine/migration-engine-tests/src/test_api.rs
+++ b/migration-engine/migration-engine-tests/src/test_api.rs
@@ -160,7 +160,7 @@ impl TestApi {
         self.connection_info().sql_family()
     }
 
-    fn tags(&self) -> BitFlags<Tags> {
+    pub fn tags(&self) -> BitFlags<Tags> {
         self.args.connector_tags
     }
 

--- a/migration-engine/migration-engine-tests/tests/apply_migrations/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/apply_migrations/mod.rs
@@ -126,7 +126,7 @@ async fn migrations_should_fail_when_the_script_is_invalid(api: &TestApi) -> Tes
     {
         let expected_error_message = formatdoc!(
             r#"
-                A migration failed to apply.
+                A migration failed to apply. New migrations can not be applied before the error is recovered from. Read more about how to resolve migration issues in a production database: https://pris.ly/d/migrate-resolve
 
                 Migration name: {second_migration_name}
 


### PR DESCRIPTION
Errors now look like this:

```
                A migration failed to apply.

                Migration name: {migration_name}

                Database error code: {error_code}

                Database error:
                {message}

```

closes https://github.com/prisma/prisma/issues/6054

---

Also contains a second small commit:

Hide unused response fields in diagnoseMigrationHistory

The notion API docs will be updated accordingly. This is to leave us
flexibility in what we do in DevDiagnostic in the near future, and for
simplification's sake.