### PR TITLE
Improve Mac Incremental Compile Times

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,9 @@ members = [
   "libs/user-facing-errors",
 ]
 
+[profile.dev]
+split-debuginfo = "unpacked"
+
 [profile.dev.package.backtrace]
 opt-level = 3
 


### PR DESCRIPTION
Inspired by https://jakedeichert.com/blog/reducing-rust-incremental-compilation-times-on-macos-by-70-percent/
Can be removed once it becomes the default