### PR TITLE
Simplify away migration_core::CoreError

### DIFF
--- a/libs/datamodel/connectors/datamodel-connector/src/connector_error.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/connector_error.rs
@@ -1,11 +1,23 @@
 use dml::native_type_instance::NativeTypeInstance;
+use std::{error::Error as StdError, fmt::Display};
 use thiserror::Error;
 
-#[derive(Debug, Error, Clone)]
-#[error("{}", kind)]
+#[derive(Debug, Clone)]
 pub struct ConnectorError {
     /// The error information for internal use.
     pub kind: ErrorKind,
+}
+
+impl Display for ConnectorError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&self.kind, f)
+    }
+}
+
+impl StdError for ConnectorError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.kind.source()
+    }
 }
 
 pub struct ConnectorErrorFactory {

--- a/migration-engine/cli/src/commands/error.rs
+++ b/migration-engine/cli/src/commands/error.rs
@@ -1,5 +1,4 @@
 use migration_connector::ConnectorError;
-use migration_core::CoreError;
 use std::fmt::Display;
 use tracing_error::SpanTrace;
 use user_facing_errors::{
@@ -94,19 +93,6 @@ impl From<ConnectorError> for CliError {
                 error: err,
                 exit_code,
                 context,
-            },
-        }
-    }
-}
-
-impl From<CoreError> for CliError {
-    fn from(e: CoreError) -> Self {
-        match e {
-            CoreError::ConnectorError(e) => e.into(),
-            e => CliError::Unknown {
-                error: ConnectorError::from_source(e, "Generic error"),
-                context: SpanTrace::capture(),
-                exit_code: 255,
             },
         }
     }

--- a/migration-engine/cli/src/main.rs
+++ b/migration-engine/cli/src/main.rs
@@ -5,7 +5,7 @@ mod commands;
 mod error_tests;
 mod logger;
 
-use migration_core::{api::RpcApi, CoreError};
+use migration_core::api::RpcApi;
 use structopt::StructOpt;
 use user_facing_errors::{common::SchemaParserError, UserFacingError};
 
@@ -72,16 +72,15 @@ async fn start_engine(datamodel_location: &str) -> ! {
         // Block the thread and handle IO in async until EOF.
         Ok(api) => json_rpc_stdio::run(api.io_handler()).await.unwrap(),
         Err(err) => {
-            let (error, exit_code) = match &err {
-                CoreError::UserFacing(err)
-                    if err.as_known().map(|e| e.error_code) == Some(SchemaParserError::ERROR_CODE) =>
-                {
-                    (err.clone(), 1)
-                }
-                _ => (err.render_user_facing(), 250),
-            };
+            let user_facing_error = err.to_user_facing();
+            let exit_code =
+                if user_facing_error.as_known().map(|err| err.error_code) == Some(SchemaParserError::ERROR_CODE) {
+                    1
+                } else {
+                    250
+                };
 
-            serde_json::to_writer(std::io::stdout().lock(), &error).expect("failed to write to stdout");
+            serde_json::to_writer(std::io::stdout().lock(), &user_facing_error).expect("failed to write to stdout");
             std::process::exit(exit_code)
         }
     }

--- a/migration-engine/connectors/migration-connector/src/migrations_directory.rs
+++ b/migration-engine/connectors/migration-connector/src/migrations_directory.rs
@@ -79,7 +79,7 @@ provider = "{}""##,
 pub fn error_on_changed_provider(migrations_directory_path: &str, provider: &str) -> ConnectorResult<()> {
     match match_provider_in_lock_file(migrations_directory_path, provider) {
         None => Ok(()),
-        Some(Err(expected_provider)) => Err(ConnectorError::user_facing_error(ProviderSwitchedError {
+        Some(Err(expected_provider)) => Err(ConnectorError::user_facing(ProviderSwitchedError {
             provider: provider.into(),
             expected_provider,
         })),

--- a/migration-engine/connectors/sql-migration-connector/src/error.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/error.rs
@@ -14,6 +14,6 @@ pub(crate) struct SystemDatabase(pub(crate) String);
 
 impl From<SystemDatabase> for ConnectorError {
     fn from(err: SystemDatabase) -> ConnectorError {
-        ConnectorError::user_facing_error(MigrateSystemDatabase { database_name: err.0 })
+        ConnectorError::user_facing(MigrateSystemDatabase { database_name: err.0 })
     }
 }

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/mssql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/mssql.rs
@@ -165,7 +165,7 @@ impl SqlFlavour for MssqlFlavour {
 
     async fn drop_database(&self, _database_url: &str) -> ConnectorResult<()> {
         let features = vec!["microsoftSqlServer".into()];
-        return Err(ConnectorError::user_facing_error(
+        return Err(ConnectorError::user_facing(
             user_facing_errors::migration_engine::PreviewFeaturesBlocked { features },
         ));
     }

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/postgres.rs
@@ -101,7 +101,7 @@ impl SqlFlavour for PostgresFlavour {
         )
         .await
         .map_err(|_elapsed| {
-            ConnectorError::user_facing_error(user_facing_errors::common::DatabaseTimeout {
+            ConnectorError::user_facing(user_facing_errors::common::DatabaseTimeout {
                 database_host: connection.connection_info().host().to_owned(),
                 database_port: connection
                     .connection_info()
@@ -371,7 +371,7 @@ async fn create_postgres_admin_conn(mut url: Url) -> ConnectorResult<Connection>
     }
 
     let conn = conn.ok_or_else(|| {
-        ConnectorError::user_facing_error(migration_engine::DatabaseCreationFailed { database_error: "Prisma could not connect to a default database (`postgres` or `template1`), it cannot create the specified database.".to_owned() })
+        ConnectorError::user_facing(migration_engine::DatabaseCreationFailed { database_error: "Prisma could not connect to a default database (`postgres` or `template1`), it cannot create the specified database.".to_owned() })
     })??;
 
     Ok(conn)

--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
@@ -115,7 +115,7 @@ impl DatabaseMigrationStepApplier<SqlMigration> for SqlMigrationConnector {
         self.flavour.scan_migration_script(script);
 
         self.conn().raw_cmd(script).await.map_err(|quaint_error| {
-            ConnectorError::user_facing_error(ApplyMigrationError {
+            ConnectorError::user_facing(ApplyMigrationError {
                 migration_name: migration_name.to_owned(),
                 database_error_code: String::from(quaint_error.original_code().unwrap_or("none")),
                 database_error: quaint_error

--- a/migration-engine/connectors/sql-migration-connector/src/sql_migration_persistence.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_migration_persistence.rs
@@ -29,7 +29,7 @@ impl MigrationPersistence for SqlMigrationConnector {
                 .table_walkers()
                 .any(|t| !self.flavour().table_should_be_ignored(t.name()))
         {
-            return Err(ConnectorError::user_facing_error(
+            return Err(ConnectorError::user_facing(
                 user_facing_errors::migration_engine::DatabaseSchemaNotEmpty {
                     database_name: self.connection.connection_info().database_location(),
                 },

--- a/migration-engine/core/src/api/error_rendering.rs
+++ b/migration-engine/core/src/api/error_rendering.rs
@@ -3,7 +3,7 @@ use jsonrpc_core::types::Error as JsonRpcError;
 
 pub(super) fn render_jsonrpc_error(crate_error: CoreError) -> JsonRpcError {
     let error_rendering_result: Result<_, _> =
-        serde_json::to_value(&crate_error.render_user_facing()).map(|data| JsonRpcError {
+        serde_json::to_value(&crate_error.to_user_facing()).map(|data| JsonRpcError {
             // We separate the JSON-RPC error code (defined by the JSON-RPC spec) from the
             // prisma error code, which is located in `data`.
             code: jsonrpc_core::types::error::ErrorCode::ServerError(4466),

--- a/migration-engine/core/src/commands/apply_migrations.rs
+++ b/migration-engine/core/src/commands/apply_migrations.rs
@@ -105,7 +105,7 @@ impl<'a> MigrationCommand for ApplyMigrationsCommand {
 
                     migration_persistence.record_failed_step(&migration_id, &logs).await?;
 
-                    return Err(err.into());
+                    return Err(err);
                 }
             }
         }

--- a/migration-engine/core/src/commands/create_migration.rs
+++ b/migration-engine/core/src/commands/create_migration.rs
@@ -74,12 +74,12 @@ impl<'a> MigrationCommand for CreateMigrationCommand {
             &Path::new(&input.migrations_directory_path),
             &input.migration_name,
         )
-        .map_err(|_| CoreError::new_unknown("Failed to create a new migration directory.".into()))?;
+        .map_err(|_| CoreError::from_msg("Failed to create a new migration directory.".into()))?;
 
         directory
             .write_migration_script(&migration_script, C::DatabaseMigration::FILE_EXTENSION)
             .map_err(|err| {
-                CoreError::new_unknown(format!(
+                CoreError::from_msg(format!(
                     "Failed to write the migration script to `{:?}`\n{}",
                     directory.path(),
                     err,
@@ -88,7 +88,7 @@ impl<'a> MigrationCommand for CreateMigrationCommand {
 
         migration_connector::write_migration_lock_file(&input.migrations_directory_path, connector_type).map_err(
             |err| {
-                CoreError::new_unknown(format!(
+                CoreError::from_msg(format!(
                     "Failed to write the migration lock file to `{:?}`\n{}",
                     &input.migrations_directory_path, err
                 ))

--- a/migration-engine/core/src/commands/dev_diagnostic.rs
+++ b/migration-engine/core/src/commands/dev_diagnostic.rs
@@ -2,7 +2,7 @@ use super::{
     DiagnoseMigrationHistoryCommand, DiagnoseMigrationHistoryInput, DiagnoseMigrationHistoryOutput, DriftDiagnostic,
     HistoryDiagnostic, MigrationCommand,
 };
-use crate::{core_error::CoreResult, CoreError};
+use crate::core_error::CoreResult;
 use migration_connector::MigrationConnector;
 use serde::{Deserialize, Serialize};
 
@@ -57,11 +57,11 @@ impl<'a> MigrationCommand for DevDiagnosticCommand {
 
 fn check_for_broken_migrations(output: &DiagnoseMigrationHistoryOutput) -> CoreResult<()> {
     if let Some(DriftDiagnostic::MigrationFailedToApply { error }) = &output.drift {
-        return Err(CoreError::UserFacing(error.clone()));
+        return Err(error.clone());
     }
 
     if let Some(error) = &output.error_in_unapplied_migration {
-        return Err(CoreError::UserFacing(error.clone()));
+        return Err(error.clone());
     }
 
     Ok(())

--- a/migration-engine/core/src/commands/mark_migration_rolled_back.rs
+++ b/migration-engine/core/src/commands/mark_migration_rolled_back.rs
@@ -28,7 +28,7 @@ pub(crate) async fn mark_migration_rolled_back<
     connector.acquire_lock().await?;
 
     let all_migrations = persistence.list_migrations().await?.map_err(|_err| {
-        CoreError::new_unknown(
+        CoreError::from_msg(
             "Invariant violation: called markMigrationRolledBack on a database without migrations table.".into(),
         )
     })?;

--- a/migration-engine/core/src/commands/schema_push.rs
+++ b/migration-engine/core/src/commands/schema_push.rs
@@ -25,7 +25,7 @@ impl MigrationCommand for SchemaPushCommand {
         };
 
         if let Some(err) = connector.check_database_version_compatibility(&schema) {
-            return Err(ConnectorError::user_facing_error(err).into());
+            return Err(ConnectorError::user_facing(err));
         };
 
         let checks = checker.check(&database_migration).await?;

--- a/migration-engine/core/src/core_error.rs
+++ b/migration-engine/core/src/core_error.rs
@@ -1,69 +1,7 @@
-use migration_connector::{ConnectorError, ListMigrationsError};
-use std::{error::Error as StdError, fmt::Display};
-use user_facing_errors::{common::SchemaParserError, KnownError, UserFacingError};
+use migration_connector::ConnectorError;
 
 /// The result type for migration engine commands
 pub type CoreResult<T> = Result<T, CoreError>;
 
 /// The top-level error type for migration engine commands
-#[derive(Debug)]
-pub enum CoreError {
-    /// Errors from the connector.
-    ConnectorError(ConnectorError),
-
-    /// User facing errors
-    UserFacing(user_facing_errors::Error),
-}
-
-impl Display for CoreError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            CoreError::ConnectorError(err) => write!(f, "Connector error: {:#}", err),
-            CoreError::UserFacing(src) => f.write_str(src.message()),
-        }
-    }
-}
-
-impl StdError for CoreError {
-    fn source(&self) -> Option<&(dyn StdError + 'static)> {
-        match self {
-            CoreError::UserFacing(_) => None,
-            CoreError::ConnectorError(err) => Some(err),
-        }
-    }
-}
-
-impl CoreError {
-    /// Render to an `user_facing_error::Error`.
-    pub fn render_user_facing(self) -> user_facing_errors::Error {
-        match self {
-            CoreError::ConnectorError(err) => err.to_user_facing(),
-            CoreError::UserFacing(err) => err,
-        }
-    }
-
-    pub(crate) fn new_schema_parser_error(full_error: String) -> Self {
-        CoreError::user_facing(SchemaParserError { full_error })
-    }
-
-    pub(crate) fn new_unknown(message: String) -> Self {
-        CoreError::UserFacing(user_facing_errors::Error::new_non_panic_with_current_backtrace(message))
-    }
-
-    /// Construct a user facing CoreError
-    pub(crate) fn user_facing(error: impl UserFacingError) -> Self {
-        CoreError::UserFacing(KnownError::new(error).into())
-    }
-}
-
-impl From<ConnectorError> for CoreError {
-    fn from(err: ConnectorError) -> Self {
-        CoreError::ConnectorError(err)
-    }
-}
-
-impl From<ListMigrationsError> for CoreError {
-    fn from(err: ListMigrationsError) -> Self {
-        CoreError::new_unknown(err.to_string())
-    }
-}
+pub type CoreError = ConnectorError;

--- a/migration-engine/core/src/lib.rs
+++ b/migration-engine/core/src/lib.rs
@@ -33,7 +33,7 @@ pub async fn migration_api(datamodel: &str) -> CoreResult<Box<dyn api::GenericAp
     let source = config
         .datasources
         .first()
-        .ok_or_else(|| CoreError::new_unknown("There is no datasource in the schema.".into()))?;
+        .ok_or_else(|| CoreError::from_msg("There is no datasource in the schema.".into()))?;
 
     match &source.active_provider {
         #[cfg(feature = "sql")]
@@ -101,7 +101,7 @@ pub async fn create_database(schema: &str) -> CoreResult<String> {
     let source = config
         .datasources
         .first()
-        .ok_or_else(|| CoreError::new_unknown("There is no datasource in the schema.".into()))?;
+        .ok_or_else(|| CoreError::from_msg("There is no datasource in the schema.".into()))?;
 
     match &source.active_provider {
         provider
@@ -126,7 +126,7 @@ pub async fn drop_database(schema: &str) -> CoreResult<()> {
     let source = config
         .datasources
         .first()
-        .ok_or_else(|| CoreError::new_unknown("There is no datasource in the schema.".into()))?;
+        .ok_or_else(|| CoreError::from_msg("There is no datasource in the schema.".into()))?;
 
     match &source.active_provider {
         provider
@@ -152,7 +152,7 @@ pub async fn qe_setup(prisma_schema: &str) -> CoreResult<()> {
     let source = config
         .datasources
         .first()
-        .ok_or_else(|| CoreError::new_unknown("There is no datasource in the schema.".into()))?;
+        .ok_or_else(|| CoreError::from_msg("There is no datasource in the schema.".into()))?;
 
     let api: Box<dyn GenericApi> = match &source.active_provider {
         provider

--- a/migration-engine/migration-engine-tests/tests/apply_migrations/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/apply_migrations/mod.rs
@@ -119,7 +119,7 @@ async fn migrations_should_fail_when_the_script_is_invalid(api: &TestApi) -> Tes
         .send()
         .await
         .unwrap_err()
-        .render_user_facing()
+        .to_user_facing()
         .unwrap_known();
 
     // Assertions about the user facing error.
@@ -240,7 +240,7 @@ async fn migrations_should_fail_on_an_uninitialized_nonempty_database(api: &Test
         .send()
         .await
         .unwrap_err()
-        .render_user_facing()
+        .to_user_facing()
         .unwrap_known();
 
     assert_eq!(

--- a/migration-engine/migration-engine-tests/tests/diagnose_migration_history/diagnose_migration_history_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/diagnose_migration_history/diagnose_migration_history_tests.rs
@@ -570,7 +570,7 @@ async fn diagnose_migrations_history_reports_migrations_failing_to_apply_cleanly
 
     match drift {
         Some(DriftDiagnostic::MigrationFailedToApply { error }) => {
-            let known_error = error.unwrap_known();
+            let known_error = error.to_user_facing().unwrap_known();
             assert_eq!(
                 known_error.error_code,
                 user_facing_errors::migration_engine::MigrationDoesNotApplyCleanly::ERROR_CODE
@@ -663,8 +663,9 @@ async fn with_a_failed_migration(api: &TestApi) -> TestResult {
     assert!(has_migrations_table);
     assert_eq!(failed_migration_names, &[generated_migration_name.unwrap()]);
 
-    let error_in_unapplied_migration =
-        error_in_unapplied_migration.expect("No error in unapplied migrations, but we expected one.");
+    let error_in_unapplied_migration = error_in_unapplied_migration
+        .expect("No error in unapplied migrations, but we expected one.")
+        .to_user_facing();
 
     let message = error_in_unapplied_migration.message().to_owned();
 
@@ -740,8 +741,9 @@ async fn with_an_invalid_unapplied_migration_should_report_it(api: &TestApi) -> 
     );
     assert!(drift.is_none());
 
-    let error_in_unapplied_migration =
-        error_in_unapplied_migration.expect("No error in unapplied migrations, but we expected one.");
+    let error_in_unapplied_migration = error_in_unapplied_migration
+        .expect("No error in unapplied migrations, but we expected one.")
+        .to_user_facing();
 
     let message = error_in_unapplied_migration.message().to_owned();
 
@@ -847,7 +849,7 @@ async fn shadow_database_creation_error_is_special_cased_mysql(api: &TestApi) ->
         .await?;
 
     assert!(
-        matches!(output.drift, Some(DriftDiagnostic::MigrationFailedToApply { error }) if error.as_known().unwrap().error_code == ShadowDbCreationError::ERROR_CODE)
+        matches!(output.drift, Some(DriftDiagnostic::MigrationFailedToApply { error }) if error.to_user_facing().as_known().unwrap().error_code == ShadowDbCreationError::ERROR_CODE)
     );
 
     Ok(())
@@ -898,7 +900,7 @@ async fn shadow_database_creation_error_is_special_cased_postgres(api: &TestApi)
         .await?;
 
     assert!(
-        matches!(output.drift, Some(DriftDiagnostic::MigrationFailedToApply { error }) if error.as_known().unwrap().error_code == ShadowDbCreationError::ERROR_CODE)
+        matches!(output.drift, Some(DriftDiagnostic::MigrationFailedToApply { error }) if error.to_user_facing().as_known().unwrap().error_code == ShadowDbCreationError::ERROR_CODE)
     );
 
     Ok(())
@@ -971,7 +973,7 @@ async fn shadow_database_creation_error_is_special_cased_mssql(api: &TestApi) ->
         .await?;
 
     assert!(
-        matches!(output.drift, Some(DriftDiagnostic::MigrationFailedToApply { error }) if error.as_known().unwrap().error_code == ShadowDbCreationError::ERROR_CODE)
+        matches!(output.drift, Some(DriftDiagnostic::MigrationFailedToApply { error }) if error.to_user_facing().as_known().unwrap().error_code == ShadowDbCreationError::ERROR_CODE)
     );
 
     Ok(())
@@ -1017,7 +1019,7 @@ async fn empty_migration_directories_should_cause_known_errors(api: &TestApi) ->
         .send()
         .await
         .unwrap_err()
-        .render_user_facing()
+        .to_user_facing()
         .unwrap_known();
 
     assert_eq!(

--- a/migration-engine/migration-engine-tests/tests/errors/error_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/errors/error_tests.rs
@@ -28,7 +28,7 @@ async fn authentication_failure_must_return_a_known_error_on_postgres() {
     let user = url.username();
     let host = url.host().unwrap().to_string();
 
-    let json_error = serde_json::to_value(&error.render_user_facing()).unwrap();
+    let json_error = serde_json::to_value(&error.to_user_facing()).unwrap();
     let expected = json!({
         "is_panic": false,
         "message": format!("Authentication failed against database server at `{host}`, the provided database credentials for `postgres` are not valid.\n\nPlease make sure to provide valid database credentials for the database server at `{host}`.", host = host),
@@ -65,7 +65,7 @@ async fn authentication_failure_must_return_a_known_error_on_mysql() {
     let user = url.username();
     let host = url.host().unwrap().to_string();
 
-    let json_error = serde_json::to_value(&error.render_user_facing()).unwrap();
+    let json_error = serde_json::to_value(&error.to_user_facing()).unwrap();
     let expected = json!({
         "is_panic": false,
         "message": format!("Authentication failed against database server at `{host}`, the provided database credentials for `{user}` are not valid.\n\nPlease make sure to provide valid database credentials for the database server at `{host}`.", host = host, user = user),
@@ -102,7 +102,7 @@ async fn unreachable_database_must_return_a_proper_error_on_mysql() {
     let port = url.port().unwrap();
     let host = url.host().unwrap().to_string();
 
-    let json_error = serde_json::to_value(&error.render_user_facing()).unwrap();
+    let json_error = serde_json::to_value(&error.to_user_facing()).unwrap();
     let expected = json!({
         "is_panic": false,
         "message": format!("Can't reach database server at `{host}`:`{port}`\n\nPlease make sure your database server is running at `{host}`:`{port}`.", host = host, port = port),
@@ -139,7 +139,7 @@ async fn unreachable_database_must_return_a_proper_error_on_postgres() {
     let host = url.host().unwrap().to_string();
     let port = url.port().unwrap();
 
-    let json_error = serde_json::to_value(&error.render_user_facing()).unwrap();
+    let json_error = serde_json::to_value(&error.to_user_facing()).unwrap();
     let expected = json!({
         "is_panic": false,
         "message": format!("Can't reach database server at `{host}`:`{port}`\n\nPlease make sure your database server is running at `{host}`:`{port}`.", host = host, port = port),
@@ -174,7 +174,7 @@ async fn database_does_not_exist_must_return_a_proper_error() {
 
     let error = RpcApi::new(&dm).await.map(|_| ()).unwrap_err();
 
-    let json_error = serde_json::to_value(&error.render_user_facing()).unwrap();
+    let json_error = serde_json::to_value(&error.to_user_facing()).unwrap();
     let expected = json!({
         "is_panic": false,
         "message": format!("Database `{database_name}` does not exist on the database server at `{database_host}:{database_port}`.", database_name = database_name, database_host = url.host().unwrap(), database_port = url.port().unwrap()),
@@ -216,7 +216,7 @@ async fn database_access_denied_must_return_a_proper_error_in_rpc() {
     );
 
     let error = RpcApi::new(&dm).await.map(|_| ()).unwrap_err();
-    let json_error = serde_json::to_value(&error.render_user_facing()).unwrap();
+    let json_error = serde_json::to_value(&error.to_user_facing()).unwrap();
 
     let expected = json!({
         "is_panic": false,
@@ -246,7 +246,7 @@ async fn bad_datasource_url_and_provider_combinations_must_return_a_proper_error
 
     let error = RpcApi::new(&dm).await.map(drop).unwrap_err();
 
-    let json_error = serde_json::to_value(&error.render_user_facing()).unwrap();
+    let json_error = serde_json::to_value(&error.to_user_facing()).unwrap();
 
     let err_message: String = json_error["message"].as_str().unwrap().into();
 
@@ -286,7 +286,7 @@ async fn connections_to_system_databases_must_be_rejected(_api: &TestApi) -> Tes
         let name = if name == &"" { "mysql" } else { name };
 
         let error = RpcApi::new(&dm).await.map(drop).unwrap_err();
-        let json_error = serde_json::to_value(&error.render_user_facing()).unwrap();
+        let json_error = serde_json::to_value(&error.to_user_facing()).unwrap();
 
         let expected = json!({
             "is_panic": false,
@@ -312,7 +312,7 @@ async fn datamodel_parser_errors_must_return_a_known_error(api: &TestApi) {
         }
     "#;
 
-    let error = api.schema_push(bad_dm).send().await.unwrap_err().render_user_facing();
+    let error = api.schema_push(bad_dm).send().await.unwrap_err().to_user_facing();
 
     let expected_msg = "\u{1b}[1;91merror\u{1b}[0m: \u{1b}[1mType \"Post\" is neither a built-in type, nor refers to another model, custom type, or enum.\u{1b}[0m\n  \u{1b}[1;94m-->\u{1b}[0m  \u{1b}[4mschema.prisma:4\u{1b}[0m\n\u{1b}[1;94m   | \u{1b}[0m\n\u{1b}[1;94m 3 | \u{1b}[0m            id Float @id\n\u{1b}[1;94m 4 | \u{1b}[0m            post \u{1b}[1;91mPost[]\u{1b}[0m\n\u{1b}[1;94m   | \u{1b}[0m\n";
 
@@ -359,7 +359,7 @@ async fn unique_constraint_errors_in_migrations_must_return_a_known_error(api: &
         .send()
         .await
         .unwrap_err()
-        .render_user_facing();
+        .to_user_facing();
 
     let json_error = serde_json::to_value(&res).unwrap();
 
@@ -409,7 +409,7 @@ async fn json_fields_must_be_rejected(api: &TestApi) -> TestResult {
         .send()
         .await
         .unwrap_err()
-        .render_user_facing()
+        .to_user_facing()
         .unwrap_known();
 
     assert_eq!(result.error_code, "P1015");
@@ -448,7 +448,7 @@ async fn connection_string_problems_give_a_nice_error() {
 
         let error = RpcApi::new(&dm).await.map(|_| ()).unwrap_err();
 
-        let json_error = serde_json::to_value(&error.render_user_facing()).unwrap();
+        let json_error = serde_json::to_value(&error.to_user_facing()).unwrap();
 
         let details = match provider.0 {
             "sqlserver" => {

--- a/migration-engine/migration-engine-tests/tests/migrations/dev_diagnostic_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/dev_diagnostic_tests.rs
@@ -380,7 +380,7 @@ async fn dev_diagnostic_reports_migrations_failing_to_apply_cleanly(api: &TestAp
         .send()
         .await
         .unwrap_err()
-        .render_user_facing();
+        .to_user_facing();
 
     let known_err = err.as_known().unwrap();
 
@@ -495,7 +495,7 @@ async fn with_an_invalid_unapplied_migration_should_report_it(api: &TestApi) -> 
         .send()
         .await
         .unwrap_err()
-        .render_user_facing()
+        .to_user_facing()
         .unwrap_known();
 
     assert_eq!(err.error_code, MigrationDoesNotApplyCleanly::ERROR_CODE);
@@ -578,7 +578,7 @@ async fn dev_diagnostic_shadow_database_creation_error_is_special_cased_mysql(ap
         })
         .await
         .unwrap_err()
-        .render_user_facing()
+        .to_user_facing()
         .unwrap_known();
 
     assert!(err.message.starts_with("Prisma Migrate could not create the shadow database. Please make sure the database user has permission to create databases. More info: https://pris.ly/d/migrate-shadow."), "{:?}", err);
@@ -629,7 +629,7 @@ async fn dev_diagnostic_shadow_database_creation_error_is_special_cased_postgres
         })
         .await
         .unwrap_err()
-        .render_user_facing()
+        .to_user_facing()
         .unwrap_known();
 
     assert!(err.message.starts_with("Prisma Migrate could not create the shadow database. Please make sure the database user has permission to create databases. More info: https://pris.ly/d/migrate-shadow."));
@@ -703,7 +703,7 @@ async fn dev_diagnostic_shadow_database_creation_error_is_special_cased_postgres
 //         })
 //         .await
 //         .unwrap_err()
-//         .render_user_facing()
+//         .to_user_facing()
 //         .unwrap_known();
 
 //     assert_eq!(err.error_code, ShadowDbCreationError::ERROR_CODE);

--- a/migration-engine/migration-engine-tests/tests/migrations/mark_migration_applied_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/mark_migration_applied_tests.rs
@@ -170,7 +170,7 @@ async fn mark_migration_applied_when_the_migration_is_already_applied_errors(api
     assert_eq!(
         err.to_string(),
         format!(
-            "The migration `{}` is already recorded as applied in the database.",
+            "The migration `{}` is already recorded as applied in the database.\n",
             second_migration_name
         )
     );
@@ -346,7 +346,7 @@ async fn must_return_helpful_error_on_migration_not_found(api: &TestApi) -> Test
         .send()
         .await
         .unwrap_err()
-        .render_user_facing()
+        .to_user_facing()
         .unwrap_known();
 
     assert_eq!(err.error_code, MigrationToMarkAppliedNotFound::ERROR_CODE);

--- a/migration-engine/migration-engine-tests/tests/migrations/mark_migration_rolled_back_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/mark_migration_rolled_back_tests.rs
@@ -9,7 +9,7 @@ async fn mark_migration_rolled_back_on_an_empty_database_errors(api: &TestApi) -
 
     assert_eq!(
         err.to_string(),
-        "Invariant violation: called markMigrationRolledBack on a database without migrations table."
+        "Invariant violation: called markMigrationRolledBack on a database without migrations table.\n"
     );
 
     Ok(())
@@ -24,7 +24,7 @@ async fn mark_migration_rolled_back_on_a_database_with_migrations_table_errors(a
         .send()
         .await
         .unwrap_err()
-        .render_user_facing()
+        .to_user_facing()
         .unwrap_known();
 
     assert_eq!(
@@ -188,7 +188,7 @@ async fn mark_migration_rolled_back_with_a_successful_migration_errors(api: &Tes
     assert_eq!(
         err.to_string(),
         format!(
-            "Migration `{}` cannot be rolled back because it is not in a failed state.",
+            "Migration `{}` cannot be rolled back because it is not in a failed state.\n",
             second_migration_name
         )
     );

--- a/migration-engine/migration-engine-tests/tests/migrations/migrate_lock.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/migrate_lock.rs
@@ -51,7 +51,7 @@ async fn create_migration_with_new_provider_errors(api: TestApi) -> TestResult {
         .send()
         .await
         .unwrap_err()
-        .render_user_facing();
+        .to_user_facing();
 
     let err = err.as_known().unwrap();
 
@@ -117,7 +117,7 @@ async fn migration_lock_with_different_comment_shapes_work(api: TestApi) -> Test
             .send()
             .await
             .unwrap_err()
-            .render_user_facing();
+            .to_user_facing();
 
         let err = err.as_known().unwrap();
 


### PR DESCRIPTION
It is an error _reporting_ type, not an error handling type. It is not
functionally distinct from ConnectorError, so they should be the same
type.