### PR TITLE
Quick and dirty parameter hints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3362,7 +3362,7 @@ dependencies = [
 [[package]]
 name = "quaint"
 version = "0.2.0-alpha.13"
-source = "git+https://github.com/prisma/quaint#0e1c8ab7059b76baf5b2bfd5f0457c52b3bf1d4b"
+source = "git+https://github.com/prisma/quaint#19d62bb7d87590a18c9844620c87f2f38e972d7d"
 dependencies = [
  "async-trait",
  "base64 0.12.3",


### PR DESCRIPTION
SQL Server uses type information for `INSERT` queries with `OUTPUT` to counteract the restriction with `OUTPUT` when using triggers in the database. This creates a list variable that gathers the output data, and this variable is typed.

We originally just gave hints and our best effort for the type, only to find out that with native types, such as `decimal(26,0)`, this value would not fit to the default `decimal(32,16)` and would error out.

Same when returning `nvarchar(max)` and so on. Although these are not yet used in `OUTPUT`, but will be if we ever start using `RETURNING` inserts for more than just the identifiers.

Quaint: https://github.com/prisma/quaint/pull/288
Closes: https://github.com/prisma/prisma/issues/5950