### PR TITLE
CI: Test Introspection Engine against Vitess

### DIFF
--- a/.buildkite/engineer
+++ b/.buildkite/engineer
@@ -13,7 +13,7 @@ fi
 if ! type "engineer" > /dev/null; then
     # Setup Prisma engine build & test tool (engineer).
     set -e
-    curl --fail -sSL "https://prisma-engineer.s3-eu-west-1.amazonaws.com/vttest/latest/$OS/engineer.gz" --output engineer.gz
+    curl --fail -sSL "https://prisma-engineer.s3-eu-west-1.amazonaws.com/1.17/latest/$OS/engineer.gz" --output engineer.gz
     gzip -d engineer.gz
     chmod +x engineer
 

--- a/.buildkite/engineer
+++ b/.buildkite/engineer
@@ -13,7 +13,7 @@ fi
 if ! type "engineer" > /dev/null; then
     # Setup Prisma engine build & test tool (engineer).
     set -e
-    curl --fail -sSL "https://prisma-engineer.s3-eu-west-1.amazonaws.com/1.16/latest/$OS/engineer.gz" --output engineer.gz
+    curl --fail -sSL "https://prisma-engineer.s3-eu-west-1.amazonaws.com/vttest/latest/$OS/engineer.gz" --output engineer.gz
     gzip -d engineer.gz
     chmod +x engineer
 

--- a/.envrc
+++ b/.envrc
@@ -3,6 +3,7 @@ export RUST_LOG_FORMAT=devel
 export RUST_BACKTRACE=1
 export RUST_LOG=query_engine=debug,quaint=debug,query_core=trace,query_connector=debug,sql_query_connector=debug,prisma_models=debug,engineer=info,sql_introspection_connector=debug
 export LOG_QUERIES=y
+export SKIP_CONNECTORS="vitess_5_7,vitess_8_0"
 
 # Controls Scala test kit verbosity. Levels are trace, debug, info, error, warning
 export LOG_LEVEL=debug

--- a/.github/workflows/introspection-engine.yml
+++ b/.github/workflows/introspection-engine.yml
@@ -45,7 +45,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: introspection-engine-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: introspection-engine-${{ runner.os }}-${{ matrix.database}}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - run: cargo test ${{ matrix.database }}
         if: ${{ matrix.database != 'vitess_5_7' && matrix.database != 'vitess_8_0' }}

--- a/.github/workflows/introspection-engine.yml
+++ b/.github/workflows/introspection-engine.yml
@@ -26,6 +26,7 @@ jobs:
           - postgres13
           - sqlite
           - vitess_5_7
+          - vitess_8_0
 
     steps:
       - uses: actions/checkout@v2
@@ -47,13 +48,13 @@ jobs:
           key: introspection-engine-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - run: cargo test ${{ matrix.database }}
-        if: ${{ matrix.database != 'vitess_5_7' }}
+        if: ${{ matrix.database != 'vitess_5_7' && matrix.database != 'vitess_8_0' }}
         working-directory: introspection-engine/introspection-engine-tests
         env:
           CLICOLOR_FORCE: 1
 
       - run: cargo test ${{ matrix.database }} -- --test-threads=1
-        if: ${{ matrix.database == 'vitess_5_7' }}
+        if: ${{ matrix.database == 'vitess_5_7' || matrix.database == 'vitess_8_0' }}
         working-directory: introspection-engine/introspection-engine-tests
         env:
           CLICOLOR_FORCE: 1

--- a/.github/workflows/introspection-engine.yml
+++ b/.github/workflows/introspection-engine.yml
@@ -6,15 +6,33 @@ on:
   pull_request:
 jobs:
   test:
-    name: "Test on Linux"
+    name: "Test ${{ matrix.database }} on Linux"
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        database:
+          - mssql_2017
+          - mssql_2019
+          - mysql_5_6
+          - mysql_5_7
+          - mysql_8
+          - mysql_mariadb
+          - postgres9
+          - postgres10
+          - postgres11
+          - postgres12
+          - postgres13
+          - sqlite
+          - vitess_5_7
 
     steps:
       - uses: actions/checkout@v2
 
-      - name: "Start databases"
-        run: docker-compose up -d
-      
+      - name: "Start ${{ matrix.database }}"
+        run: make start-${{ matrix.database }}
+
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -28,7 +46,14 @@ jobs:
             target
           key: introspection-engine-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - run: cargo test ${{ matrix.segment }}
+      - run: cargo test ${{ matrix.database }}
+        if: ${{ matrix.database != 'vitess_5_7' }}
+        working-directory: introspection-engine/introspection-engine-tests
+        env:
+          CLICOLOR_FORCE: 1
+
+      - run: cargo test ${{ matrix.database }} -- --test-threads=1
+        if: ${{ matrix.database == 'vitess_5_7' }}
         working-directory: introspection-engine/introspection-engine-tests
         env:
           CLICOLOR_FORCE: 1

--- a/.github/workflows/migration-engine.yml
+++ b/.github/workflows/migration-engine.yml
@@ -45,11 +45,6 @@ jobs:
             target
           key: migration-engine-${{ runner.os }}-cargo-${{ matrix.database }}-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: "Wait for database to get healthy"
-        uses: juliangruber/sleep-action@v1
-        with:
-          time: 20s
-
       - run: timeout 40m cargo test ${{ matrix.database }}
         working-directory: migration-engine/migration-engine-tests
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3364,6 +3364,7 @@ dependencies = [
 [[package]]
 name = "quaint"
 version = "0.2.0-alpha.13"
+source = "git+https://github.com/prisma/quaint#19d62bb7d87590a18c9844620c87f2f38e972d7d"
 dependencies = [
  "async-trait",
  "base64 0.12.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1895,12 +1895,14 @@ dependencies = [
  "indoc",
  "introspection-connector",
  "introspection-core",
+ "migration-connector",
  "pretty_assertions",
  "quaint",
  "serde",
  "serde_json",
  "sql-datamodel-connector",
  "sql-introspection-connector",
+ "sql-migration-connector",
  "sql-schema-describer",
  "test-macros",
  "test-setup",
@@ -3362,7 +3364,6 @@ dependencies = [
 [[package]]
 name = "quaint"
 version = "0.2.0-alpha.13"
-source = "git+https://github.com/prisma/quaint#19d62bb7d87590a18c9844620c87f2f38e972d7d"
 dependencies = [
  "async-trait",
  "base64 0.12.3",

--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,9 @@ dev-mongodb: start-mongodb
 start-vitess_5_7:
 	docker-compose -f docker-compose.yml up -d --remove-orphans vitess-test-5_7 vitess-shadow-5_7
 
+start-vitess_8_0:
+	docker-compose -f docker-compose.yml up -d --remove-orphans vitess-test-8_0 vitess-shadow-8_0
+
 dev-down:
 	docker-compose -f docker-compose.yml down -v --remove-orphans
 

--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,9 @@ dev-mongodb: start-mongodb
 	echo 'mongodb' > current_connector
 	cp $(CONFIG_PATH)/mongodb4 $(CONFIG_FILE)
 
+start-vitess_5_7:
+	docker-compose -f docker-compose.yml up -d --remove-orphans vitess-test-5_7 vitess-shadow-5_7
+
 dev-down:
 	docker-compose -f docker-compose.yml down -v --remove-orphans
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -135,6 +135,58 @@ services:
       - databases
     tmpfs: /var/lib/mariadb
 
+  vitess-test-5_7:
+    image: vitess/vttestserver:mysql57
+    restart: always
+    ports:
+      - 33577:33577
+    environment:
+      PORT: 33574
+      KEYSPACES: "test"
+      NUM_SHARDS: "1"
+      MYSQL_BIND_HOST: "0.0.0.0"
+    networks:
+      - databases
+
+  vitess-test-8_0:
+    image: vitess/vttestserver:mysql80
+    restart: always
+    ports:
+      - 33807:33807
+    environment:
+      PORT: 33804
+      KEYSPACES: "test"
+      NUM_SHARDS: "1"
+      MYSQL_BIND_HOST: "0.0.0.0"
+    networks:
+      - databases
+
+  vitess-shadow-5_7:
+    image: vitess/vttestserver:mysql57
+    restart: always
+    ports:
+      - 33578:33577
+    environment:
+      PORT: 33574
+      KEYSPACES: "shadow"
+      NUM_SHARDS: "1"
+      MYSQL_BIND_HOST: "0.0.0.0"
+    networks:
+      - databases
+
+  vitess-shadow-8_0:
+    image: vitess/vttestserver:mysql80
+    restart: always
+    ports:
+      - 33808:33807
+    environment:
+      PORT: 33804
+      KEYSPACES: "shadow"
+      NUM_SHARDS: "1"
+      MYSQL_BIND_HOST: "0.0.0.0"
+    networks:
+      - databases
+
   mssql-2019:
     image: mcr.microsoft.com/mssql/server:2019-latest
     restart: always

--- a/introspection-engine/introspection-engine-tests/Cargo.toml
+++ b/introspection-engine/introspection-engine-tests/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2018"
 [dependencies]
 sql-datamodel-connector = { path = "../../libs/datamodel/connectors/sql-datamodel-connector" }
 sql-introspection-connector = { path = "../connectors/sql-introspection-connector" }
+migration-connector = { path = "../../migration-engine/connectors/migration-connector" }
+sql-migration-connector = { path = "../../migration-engine/connectors/sql-migration-connector" }
 introspection-connector = { path = "../connectors/introspection-connector" }
 introspection-core = { path = "../core" }
 datamodel-connector = { path = "../../libs/datamodel/connectors/datamodel-connector" }

--- a/introspection-engine/introspection-engine-tests/src/lib.rs
+++ b/introspection-engine/introspection-engine-tests/src/lib.rs
@@ -49,7 +49,7 @@ impl BarrelMigrationExecutor {
     where
         F: FnOnce(&mut Migration),
     {
-        let mut migration = if self.tags.contains(Tags::Vitess57) {
+        let mut migration = if self.tags.intersects(Tags::Vitess) {
             Migration::new()
         } else {
             Migration::new().schema(schema_name)

--- a/introspection-engine/introspection-engine-tests/src/test_api.rs
+++ b/introspection-engine/introspection-engine-tests/src/test_api.rs
@@ -35,7 +35,7 @@ impl TestApi {
 
         let connection_string = (args.url_fn)(db_name);
 
-        let database = if tags.contains(Tags::Vitess57) {
+        let database = if tags.intersects(Tags::Vitess) {
             let me = SqlMigrationConnector::new(&connection_string, BitFlags::empty(), None)
                 .await
                 .unwrap();
@@ -200,7 +200,7 @@ impl TestApi {
     }
 
     pub fn db_name(&self) -> &str {
-        if self.tags().contains(Tags::Vitess57) {
+        if self.tags().intersects(Tags::Vitess) {
             "test"
         } else {
             self.db_name

--- a/introspection-engine/introspection-engine-tests/tests/rpc_calls/list_databases_command_tests.rs
+++ b/introspection-engine/introspection-engine-tests/tests/rpc_calls/list_databases_command_tests.rs
@@ -2,7 +2,7 @@ use barrel::types;
 use introspection_engine_tests::{test_api::*, BarrelMigrationExecutor};
 use test_macros::test_each_connector;
 
-#[test_each_connector(tags("mysql"))]
+#[test_each_connector(tags("mysql"), ignore("vitess_5_7"))]
 async fn databases_for_mysql_should_work(api: &TestApi) -> crate::TestResult {
     setup(&api.barrel(), api.db_name()).await?;
 

--- a/introspection-engine/introspection-engine-tests/tests/rpc_calls/list_databases_command_tests.rs
+++ b/introspection-engine/introspection-engine-tests/tests/rpc_calls/list_databases_command_tests.rs
@@ -2,7 +2,7 @@ use barrel::types;
 use introspection_engine_tests::{test_api::*, BarrelMigrationExecutor};
 use test_macros::test_each_connector;
 
-#[test_each_connector(tags("mysql"), ignore("vitess_5_7"))]
+#[test_each_connector(tags("mysql"), ignore("vitess"))]
 async fn databases_for_mysql_should_work(api: &TestApi) -> crate::TestResult {
     setup(&api.barrel(), api.db_name()).await?;
 

--- a/libs/test-setup/src/connectors.rs
+++ b/libs/test-setup/src/connectors.rs
@@ -15,7 +15,7 @@ use once_cell::sync::Lazy;
 
 static SKIP_CONNECTORS: Lazy<HashSet<String>> = Lazy::new(|| {
     std::env::var("SKIP_CONNECTORS")
-        .map(|s| s.split(",").map(ToString::to_string).collect())
+        .map(|s| s.split(',').map(ToString::to_string).collect())
         .unwrap_or_else(|_| HashSet::new())
 });
 

--- a/libs/test-setup/src/connectors.rs
+++ b/libs/test-setup/src/connectors.rs
@@ -33,7 +33,8 @@ fn connector_names() -> Vec<(&'static str, BitFlags<Tags>)> {
         ("postgres13", Tags::Postgres.into()),
         ("mysql_mariadb", Tags::Mysql | Tags::Mariadb),
         ("sqlite", Tags::Sqlite.into()),
-        ("vitess_5_7", Tags::Mysql | Tags::Vitess57),
+        ("vitess_5_7", Tags::Vitess | Tags::Mysql | Tags::Vitess57),
+        ("vitess_8_0", Tags::Vitess | Tags::Mysql | Tags::Vitess80),
     ]
 }
 
@@ -61,6 +62,10 @@ fn vitess_5_7_capabilities() -> BitFlags<Capabilities> {
     Capabilities::Enums | Capabilities::Json
 }
 
+fn vitess_8_0_capabilities() -> BitFlags<Capabilities> {
+    Capabilities::Enums | Capabilities::Json
+}
+
 fn infer_capabilities(tags: BitFlags<Tags>) -> BitFlags<Capabilities> {
     if tags.intersects(Tags::Postgres) {
         return postgres_capabilities();
@@ -84,6 +89,10 @@ fn infer_capabilities(tags: BitFlags<Tags>) -> BitFlags<Capabilities> {
 
     if tags.intersects(Tags::Vitess57) {
         return vitess_5_7_capabilities();
+    }
+
+    if tags.intersects(Tags::Vitess80) {
+        return vitess_8_0_capabilities();
     }
 
     BitFlags::empty()

--- a/libs/test-setup/src/connectors/capabilities.rs
+++ b/libs/test-setup/src/connectors/capabilities.rs
@@ -7,6 +7,7 @@ pub enum Capabilities {
     ScalarLists = 0b0001,
     Enums = 0b0010,
     Json = 0b0100,
+    CreateDatabase = 0b1000,
 }
 
 #[derive(Debug)]
@@ -41,6 +42,7 @@ impl FromStr for Capabilities {
 
 /// All the capabilities, sorted by name.
 const CAPABILITY_NAMES: &[(&str, Capabilities)] = &[
+    ("create_db", Capabilities::CreateDatabase),
     ("enums", Capabilities::Enums),
     ("json", Capabilities::Json),
     ("scalar_lists", Capabilities::ScalarLists),

--- a/libs/test-setup/src/connectors/tags.rs
+++ b/libs/test-setup/src/connectors/tags.rs
@@ -17,6 +17,8 @@ pub enum Tags {
     Postgres12 = 0x200,
     Mssql = 0x400,
     Vitess57 = 0x800,
+    Vitess80 = 0x1000,
+    Vitess = 0x2000,
 }
 
 impl Tags {
@@ -61,6 +63,8 @@ static TAG_NAMES: Lazy<Vec<(&str, BitFlags<Tags>)>> = Lazy::new(|| {
         ("postgres_12", Tags::Postgres12.into()),
         ("sql", Tags::Mysql | Tags::Postgres | Tags::Sqlite | Tags::Mssql),
         ("sqlite", Tags::Sqlite.into()),
+        ("vitess", Tags::Vitess.into()),
         ("vitess_5_7", Tags::Vitess57.into()),
+        ("vitess_8_0", Tags::Vitess80.into()),
     ]
 });

--- a/libs/test-setup/src/connectors/tags.rs
+++ b/libs/test-setup/src/connectors/tags.rs
@@ -3,19 +3,20 @@ use once_cell::sync::Lazy;
 use std::error::Error as StdError;
 
 #[derive(BitFlags, Copy, Clone, Debug, PartialEq)]
-#[repr(u16)]
+#[repr(u32)]
 pub enum Tags {
-    Mysql = 0b0001,
-    Mariadb = 0b0010,
-    Postgres = 0b0100,
-    Sqlite = 0b1000,
-    Mysql8 = 0b00010000,
-    Mysql56 = 0b00100000,
-    Mysql57 = 0b10000000000,
-    Mssql2017 = 0b01000000,
-    Mssql2019 = 0b10000000,
-    Postgres12 = 0b100000000,
-    Mssql = 0b1000000000,
+    Mysql = 0x01,
+    Mariadb = 0x02,
+    Postgres = 0x04,
+    Sqlite = 0x08,
+    Mysql8 = 0x10,
+    Mysql56 = 0x20,
+    Mysql57 = 0x40,
+    Mssql2017 = 0x80,
+    Mssql2019 = 0x100,
+    Postgres12 = 0x200,
+    Mssql = 0x400,
+    Vitess57 = 0x800,
 }
 
 impl Tags {
@@ -60,5 +61,6 @@ static TAG_NAMES: Lazy<Vec<(&str, BitFlags<Tags>)>> = Lazy::new(|| {
         ("postgres_12", Tags::Postgres12.into()),
         ("sql", Tags::Mysql | Tags::Postgres | Tags::Sqlite | Tags::Mssql),
         ("sqlite", Tags::Sqlite.into()),
+        ("vitess_5_7", Tags::Vitess57.into()),
     ]
 });

--- a/libs/test-setup/src/lib.rs
+++ b/libs/test-setup/src/lib.rs
@@ -65,6 +65,7 @@ test_api_constructors!(
     (mysql_8, "mysql"),
     (mysql_mariadb, "mysql"),
     (vitess_5_7, "mysql"),
+    (vitess_8_0, "mysql"),
     (postgres9, "postgresql"),
     (postgres10, "postgresql"),
     (postgres11, "postgresql"),
@@ -97,6 +98,7 @@ mod urls {
     pub use super::postgres_9_url as postgres9;
     pub use super::sqlite_test_url as sqlite;
     pub use super::vitess_5_7_url as vitess_5_7;
+    pub use super::vitess_8_0_url as vitess_8_0;
 }
 
 pub fn sqlite_test_url(db_name: &str) -> String {
@@ -283,7 +285,22 @@ pub fn vitess_5_7_url(_: &str) -> String {
             let (host, port) = db_host_and_port_vitess_5_7();
 
             format!(
-                "mysql://root:prisma@{host}:{port}/test?connect_timeout=20&socket_timeout=60",
+                "mysql://root@{host}:{port}/test?connect_timeout=20&socket_timeout=60",
+                host = host,
+                port = port,
+            )
+        }
+    }
+}
+
+pub fn vitess_8_0_url(_: &str) -> String {
+    match std::env::var("VITESS_8_0_TEST_URL") {
+        Ok(url) => url,
+        Err(_) => {
+            let (host, port) = db_host_and_port_vitess_8_0();
+
+            format!(
+                "mysql://root@{host}:{port}/test?connect_timeout=20&socket_timeout=60",
                 host = host,
                 port = port,
             )
@@ -520,7 +537,7 @@ pub fn db_host_and_port_mysql_5_7() -> (Cow<'static, str>, usize) {
 }
 
 pub fn db_host_and_port_vitess_5_7() -> (Cow<'static, str>, usize) {
-    if let Some(var) = std::env::var("VITESXS_5_7_TEST_URL")
+    if let Some(var) = std::env::var("VITESS_5_7_TEST_URL")
         .ok()
         .and_then(|s| Url::parse(&s).ok())
     {
@@ -537,6 +554,27 @@ pub fn db_host_and_port_vitess_5_7() -> (Cow<'static, str>, usize) {
     match std::env::var("IS_BUILDKITE") {
         Ok(_) => ("test-db-vitess-5-7".into(), 33577),
         Err(_) => ("127.0.0.1".into(), 33577),
+    }
+}
+
+pub fn db_host_and_port_vitess_8_0() -> (Cow<'static, str>, usize) {
+    if let Some(var) = std::env::var("VITESS_8_0_TEST_URL")
+        .ok()
+        .and_then(|s| Url::parse(&s).ok())
+    {
+        let host = var
+            .host()
+            .map(|s| Cow::from(s.to_string()))
+            .unwrap_or_else(|| Cow::from("localhost"));
+
+        let port = var.port().unwrap_or(33807) as usize;
+
+        return (host, port);
+    }
+
+    match std::env::var("IS_BUILDKITE") {
+        Ok(_) => ("test-db-vitess-5-7".into(), 33807),
+        Err(_) => ("127.0.0.1".into(), 33807),
     }
 }
 

--- a/shell.nix
+++ b/shell.nix
@@ -13,6 +13,7 @@ mkShell {
     sbt
     sbt-extras
     jdk8
+    gcc
     openssl
     pkg-config
     clangStdenv


### PR DESCRIPTION
Part of: https://github.com/prisma/prisma-engines/issues/1851

The beginning of the CI test setup for Vitess. The first system: Introspection Engine. This introduces new test connectors: `vitess_5_7` and `vitess_8_0` with special setup of not creating or dropping databases, and to run the tests against vitess in single-threaded mode.

An update to Engineer was created to skip testing anything vitess-related on Buildkite, due to it testing all connectors in one go and the test run being multi-threaded. These tests run and should run only on GitHub Actions.