### PR TITLE
CI: Migration Engine tests on Vitess

### DIFF
--- a/.github/workflows/migration-engine.yml
+++ b/.github/workflows/migration-engine.yml
@@ -24,6 +24,8 @@ jobs:
           - postgres12
           - postgres13
           - sqlite
+          - vitess_5_7
+          - vitess_8_0
         
     runs-on: ubuntu-latest
     steps:
@@ -46,6 +48,13 @@ jobs:
           key: migration-engine-${{ runner.os }}-cargo-${{ matrix.database }}-${{ hashFiles('**/Cargo.lock') }}
 
       - run: timeout 40m cargo test ${{ matrix.database }}
+        if: ${{ matrix.database != 'vitess_5_7' && matrix.database != 'vitess_8_0' }}
+        working-directory: migration-engine/migration-engine-tests
+        env:
+          CLICOLOR_FORCE: 1
+
+      - run: cargo test ${{ matrix.database }} -- --test-threads=1
+        if: ${{ matrix.database == 'vitess_5_7' || matrix.database == 'vitess_8_0' }}
         working-directory: migration-engine/migration-engine-tests
         env:
           CLICOLOR_FORCE: 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -145,8 +145,6 @@ services:
       KEYSPACES: "test"
       NUM_SHARDS: "1"
       MYSQL_BIND_HOST: "0.0.0.0"
-    networks:
-      - databases
 
   vitess-test-8_0:
     image: vitess/vttestserver:mysql80
@@ -158,8 +156,6 @@ services:
       KEYSPACES: "test"
       NUM_SHARDS: "1"
       MYSQL_BIND_HOST: "0.0.0.0"
-    networks:
-      - databases
 
   vitess-shadow-5_7:
     image: vitess/vttestserver:mysql57
@@ -171,8 +167,6 @@ services:
       KEYSPACES: "shadow"
       NUM_SHARDS: "1"
       MYSQL_BIND_HOST: "0.0.0.0"
-    networks:
-      - databases
 
   vitess-shadow-8_0:
     image: vitess/vttestserver:mysql80
@@ -184,8 +178,6 @@ services:
       KEYSPACES: "shadow"
       NUM_SHARDS: "1"
       MYSQL_BIND_HOST: "0.0.0.0"
-    networks:
-      - databases
 
   mssql-2019:
     image: mcr.microsoft.com/mssql/server:2019-latest

--- a/introspection-engine/introspection-engine-tests/src/test_api.rs
+++ b/introspection-engine/introspection-engine-tests/src/test_api.rs
@@ -33,7 +33,7 @@ impl TestApi {
             args.test_function_name
         };
 
-        let connection_string = (args.url_fn)(db_name);
+        let (connection_string, _) = (args.url_fn)(db_name);
 
         let database = if tags.intersects(Tags::Vitess) {
             let me = SqlMigrationConnector::new(&connection_string, BitFlags::empty(), None)

--- a/libs/sql-schema-describer/tests/mssql/mod.rs
+++ b/libs/sql-schema-describer/tests/mssql/mod.rs
@@ -5,7 +5,7 @@ use tracing::debug;
 
 #[allow(dead_code)]
 pub async fn get_mssql_describer_for_schema(sql: &str, schema: &'static str) -> mssql::SqlSchemaDescriber {
-    let connection_string = mssql_2019_url(schema);
+    let (connection_string, _) = mssql_2019_url(schema);
     let conn = Quaint::new(&connection_string).await.unwrap();
 
     test_setup::connectors::mssql::reset_schema(&conn, schema)

--- a/libs/sql-schema-describer/tests/mssql_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/mssql_describer_tests.rs
@@ -12,7 +12,7 @@ use test_setup::mssql_2019_url;
 #[tokio::test]
 async fn udts_can_be_described() {
     let db_name = "udts_can_be_described";
-    let connection_string = mssql_2019_url(db_name);
+    let (connection_string, _) = mssql_2019_url(db_name);
     let conn = Quaint::new(&connection_string).await.unwrap();
 
     let types = &[
@@ -74,7 +74,7 @@ async fn udts_can_be_described() {
 async fn views_can_be_described() {
     let db_name = "views_can_be_described";
 
-    let connection_string = mssql_2019_url(db_name);
+    let (connection_string, _) = mssql_2019_url(db_name);
     let conn = Quaint::new(&connection_string).await.unwrap();
 
     test_setup::connectors::mssql::reset_schema(&conn, db_name)
@@ -542,7 +542,7 @@ async fn mssql_cross_schema_references_are_not_allowed() {
     let secondary = "mssql_foreign_key_on_delete_must_be_handled_B";
 
     for s in &[db_name, secondary] {
-        let connection_string = mssql_2019_url("master");
+        let (connection_string, _) = mssql_2019_url("master");
         let conn = Quaint::new(&connection_string).await.unwrap();
 
         test_setup::connectors::mssql::reset_schema(&conn, s).await.unwrap();

--- a/libs/sql-schema-describer/tests/mysql/mod.rs
+++ b/libs/sql-schema-describer/tests/mysql/mod.rs
@@ -10,7 +10,7 @@ use test_setup::mysql_5_7_url;
 pub async fn get_mysql_describer_for_schema(sql: &str, schema: &str) -> mysql::SqlSchemaDescriber {
     // Ensure the presence of an empty database.
 
-    let url = mysql_5_7_url(schema);
+    let (url, _) = mysql_5_7_url(schema);
     let conn = test_setup::create_mysql_database(&url.parse().unwrap()).await.unwrap();
 
     // Migrate the database we just created.

--- a/libs/sql-schema-describer/tests/mysql_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/mysql_describer_tests.rs
@@ -15,7 +15,7 @@ use test_setup::mysql_5_7_url;
 async fn views_can_be_described() {
     let db_name = "views_can_be_described";
 
-    let url = mysql_5_7_url(db_name);
+    let (url, _) = mysql_5_7_url(db_name);
     let conn = test_setup::create_mysql_database(&url.parse().unwrap()).await.unwrap();
 
     conn.raw_cmd(&format!("CREATE TABLE {}.a (a_id int)", db_name))

--- a/libs/sql-schema-describer/tests/test_api/mod.rs
+++ b/libs/sql-schema-describer/tests/test_api/mod.rs
@@ -44,7 +44,7 @@ impl TestApi {
             args.test_function_name
         };
 
-        let url = (args.url_fn)(db_name);
+        let (url, _) = (args.url_fn)(db_name);
 
         let conn = if tags.contains(Tags::Mysql) {
             create_mysql_database(&url.parse().unwrap()).await.unwrap()

--- a/migration-engine/cli/src/commands/tests.rs
+++ b/migration-engine/cli/src/commands/tests.rs
@@ -13,14 +13,14 @@ fn postgres_url(db: Option<&str>) -> String {
 }
 
 fn postgres_url_with_scheme(db: Option<&str>, scheme: &str) -> String {
-    let original_url = test_setup::postgres_10_url(db.unwrap_or("postgres"));
+    let (original_url, _) = test_setup::postgres_10_url(db.unwrap_or("postgres"));
     let mut parsed: url::Url = original_url.parse().unwrap();
     parsed.set_scheme(scheme).unwrap();
     parsed.to_string()
 }
 
 fn mysql_url(db: Option<&str>) -> String {
-    test_setup::mysql_5_7_url(db.unwrap_or(""))
+    test_setup::mysql_5_7_url(db.unwrap_or("")).0
 }
 
 #[tokio::test]
@@ -115,7 +115,6 @@ async fn test_create_psql_database() {
     // Drop the database
     {
         let url = postgres_url(None);
-
         let conn = Quaint::new(&url).await.unwrap();
 
         conn.raw_cmd("DROP DATABASE IF EXISTS \"this_should_exist\"")
@@ -124,7 +123,6 @@ async fn test_create_psql_database() {
     };
 
     let url = postgres_url(Some(db_name));
-
     let res = run(&["--datasource", &url, "create-database"]).await;
 
     assert_eq!(
@@ -150,7 +148,6 @@ async fn test_create_sqlite_database() {
     assert!(!sqlite_path.exists());
 
     let url = format!("file:{}", sqlite_path.to_string_lossy());
-
     let res = run(&["--datasource", &url, "create-database"]).await;
     let msg = res.as_ref().unwrap();
 

--- a/migration-engine/cli/src/error_tests.rs
+++ b/migration-engine/cli/src/error_tests.rs
@@ -6,9 +6,9 @@ use url::Url;
 #[tokio::test]
 async fn database_already_exists_must_return_a_proper_error() {
     let db_name = "database_already_exists_must_return_a_proper_error";
-    let url = postgres_10_url(db_name);
+    let (url, _) = postgres_10_url(db_name);
 
-    let conn = Quaint::new(&postgres_10_url("postgres")).await.unwrap();
+    let conn = Quaint::new(&postgres_10_url("postgres").0).await.unwrap();
     conn.execute_raw(
         "CREATE DATABASE \"database_already_exists_must_return_a_proper_error\"",
         &[],
@@ -59,7 +59,7 @@ async fn bad_postgres_url_must_return_a_good_error() {
 #[tokio::test]
 async fn database_access_denied_must_return_a_proper_error_in_cli() {
     let db_name = "dbaccessdeniedincli";
-    let url: Url = mysql_5_7_url(db_name).parse().unwrap();
+    let url: Url = mysql_5_7_url(db_name).0.parse().unwrap();
     let conn = create_mysql_database(&url).await.unwrap();
 
     conn.execute_raw("DROP USER IF EXISTS jeanmichel", &[]).await.unwrap();
@@ -99,7 +99,7 @@ async fn database_access_denied_must_return_a_proper_error_in_cli() {
 async fn tls_errors_must_be_mapped_in_the_cli() {
     let url = format!(
         "{}&sslmode=require&sslaccept=strict",
-        postgres_10_url("tls_errors_must_be_mapped_in_the_cli")
+        postgres_10_url("tls_errors_must_be_mapped_in_the_cli").0
     );
     let error = get_cli_error(&[
         "migration-engine",

--- a/migration-engine/connectors/sql-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/lib.rs
@@ -143,10 +143,12 @@ impl SqlMigrationConnector {
             steps,
         };
 
-        self.apply_migration(&migration).await?;
-
         if migration.before.table_walker("_prisma_migrations").is_some() {
-            self.flavour.drop_migrations_table(self.conn()).await?;
+            self.flavour.drop_migrations_table(connection).await?;
+        }
+
+        for step in self.render_steps_pretty(&migration)? {
+            connection.raw_cmd(&step.raw).await?;
         }
 
         Ok(())

--- a/migration-engine/migration-engine-tests/tests/apply_migrations/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/apply_migrations/mod.rs
@@ -137,6 +137,7 @@ async fn migrations_should_fail_when_the_script_is_invalid(api: &TestApi) -> Tes
                 "#,
             second_migration_name = second_migration_name,
             error_code = match api.tags() {
+                t if t.contains(Tags::Vitess) => 1105,
                 t if t.contains(Tags::Mysql) => 1064,
                 t if t.contains(Tags::Mssql) => 102,
                 t if t.contains(Tags::Postgres) => 42601,
@@ -144,6 +145,7 @@ async fn migrations_should_fail_when_the_script_is_invalid(api: &TestApi) -> Tes
                 _ => todo!(),
             },
             message = match api.tags() {
+                t if t.contains(Tags::Vitess) => "syntax error at position 10",
                 t if t.contains(Tags::Mariadb) => "You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near \'^.^)_n\' at line 1",
                 t if t.contains(Tags::Mysql) => "You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near \'^.^)_n\' at line 1",
                 t if t.contains(Tags::Mssql) => "Incorrect syntax near \'^\'.",
@@ -195,7 +197,7 @@ async fn migrations_should_not_reapply_modified_migrations(api: &TestApi) -> Tes
 
     api.apply_migrations(&migrations_directory).send().await?;
 
-    assertions.modify_migration(|script| script.push_str("/* this is just a harmless comment */"))?;
+    assertions.modify_migration(|script| *script = format!("/* this is just a harmless comment */\n{}", script))?;
 
     let dm2 = r#"
         model Cat {

--- a/migration-engine/migration-engine-tests/tests/diagnose_migration_history/diagnose_migration_history_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/diagnose_migration_history/diagnose_migration_history_tests.rs
@@ -576,7 +576,11 @@ async fn diagnose_migrations_history_reports_migrations_failing_to_apply_cleanly
                 user_facing_errors::migration_engine::MigrationDoesNotApplyCleanly::ERROR_CODE
             );
             assert_eq!(known_error.meta["migration_name"], initial_migration_name.as_str());
-            assert!(known_error.message.contains("yolo") || known_error.message.contains("YOLO"));
+            assert!(
+                known_error.message.contains("yolo")
+                    || known_error.message.contains("YOLO")
+                    || known_error.message.contains("(not available)")
+            );
         }
         _ => panic!("assertion failed"),
     }

--- a/migration-engine/migration-engine-tests/tests/initialization/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/initialization/mod.rs
@@ -5,7 +5,7 @@ use url::Url;
 
 #[tokio::test]
 async fn connecting_to_a_postgres_database_with_missing_schema_creates_it() {
-    let url_str = postgres_10_url("test_connecting_with_a_nonexisting_schema");
+    let url_str = postgres_10_url("test_connecting_with_a_nonexisting_schema").0;
     test_setup::create_postgres_database(&url_str.parse().unwrap())
         .await
         .unwrap();

--- a/migration-engine/migration-engine-tests/tests/migrations/advisory_locking.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/advisory_locking.rs
@@ -2,7 +2,8 @@ use migration_core::commands::{ApplyMigrationsInput, CreateMigrationInput};
 use migration_engine_tests::{multi_engine_test_api::*, TestResult};
 use test_macros::test_connectors;
 
-#[test_connectors]
+// Tom says: THIS IS OK TO IGNORE.
+#[test_connectors(ignore("vitess"))]
 async fn advisory_locking_works(api: TestApi) -> TestResult {
     api.initialize().await?;
 

--- a/migration-engine/migration-engine-tests/tests/migrations/defaults.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/defaults.rs
@@ -4,7 +4,7 @@ use test_macros::test_connectors;
 
 // MySQL 5.7 and MariaDB are skipped, because the datamodel parser gives us a
 // chrono DateTime, and we don't render that in the exact expected format.
-#[test_connectors(ignore("mysql_5_7", "mariadb"))]
+#[test_connectors(ignore("mysql_5_7", "mariadb", "vitess_5_7"))]
 async fn datetime_defaults_work(api: TestApi) -> TestResult {
     api.initialize().await?;
 

--- a/migration-engine/migration-engine-tests/tests/migrations/migrate_lock.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/migrate_lock.rs
@@ -43,7 +43,7 @@ async fn create_migration_with_new_provider_errors(api: TestApi) -> TestResult {
     "#;
 
     let sqlite_engine = api
-        .new_engine_with_connection_strings(&sqlite_test_url("migratelocktest"), None)
+        .new_engine_with_connection_strings(&sqlite_test_url("migratelocktest").0, None)
         .await?;
 
     let err = sqlite_engine

--- a/migration-engine/migration-engine-tests/tests/migrations/soft_resets.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/soft_resets.rs
@@ -243,7 +243,8 @@ async fn soft_resets_work_on_sql_server(api: TestApi) -> TestResult {
 }
 
 /// MySQL 5.6 doesn't have `DROP USER IF EXISTS`...
-#[test_connectors(tags("mysql"), ignore("mysql_5_6"))]
+/// Neither does Vitess
+#[test_connectors(tags("mysql"), ignore("mysql_5_6", "vitess"))]
 async fn soft_resets_work_on_mysql(api: TestApi) -> TestResult {
     let migrations_directory = api.create_migrations_directory()?;
     let mut url: url::Url = api.connection_string().parse()?;

--- a/query-engine/query-engine/src/tests/test_api.rs
+++ b/query-engine/query-engine/src/tests/test_api.rs
@@ -38,7 +38,7 @@ pub struct TestApi {
 impl TestApi {
     pub async fn new(args: TestApiArgs) -> Self {
         let tags = args.connector_tags;
-        let connection_string = (args.url_fn)(args.test_function_name);
+        let (connection_string, _) = (args.url_fn)(args.test_function_name);
 
         let migration_api = if tags.contains(Tags::Mysql) {
             mysql_migration_connector(&connection_string).await
@@ -128,7 +128,7 @@ pub(super) async fn postgres_migration_connector(url_str: &str) -> SqlMigrationC
 }
 
 pub(super) async fn sqlite_migration_connector(db_name: &str) -> SqlMigrationConnector {
-    SqlMigrationConnector::new(&sqlite_test_url(db_name), BitFlags::all(), None)
+    SqlMigrationConnector::new(&sqlite_test_url(db_name).0, BitFlags::all(), None)
         .await
         .unwrap()
 }


### PR DESCRIPTION
Part of: https://github.com/prisma/prisma-engines/issues/1851

The next step of the CI test setup for Vitess: Migration Engine. Tests run, again, against vitess in single-threaded mode, on GitHub Actions only and invisible on development environment without setting the `SKIP_CONNECTORS` environment variable to empty.