### PR TITLE
CI: Query Engine tests on Vitess

### DIFF
--- a/.github/workflows/query-engine.yml
+++ b/.github/workflows/query-engine.yml
@@ -89,6 +89,6 @@ jobs:
             target
           key: query-engine-rs-${{ runner.os }}-cargo-vitess-${{ matrix.version }}-${{ hashFiles('**/Cargo.lock') }}
 
-      - run: export WORKSPACE_ROOT=$(pwd) && timeout 40m cargo test --package query-engine-tests -- --test-threads=1
+      - run: export WORKSPACE_ROOT=$(pwd) && cargo test --package query-engine-tests -- --test-threads=1
         env:
           CLICOLOR_FORCE: 1

--- a/.github/workflows/query-engine.yml
+++ b/.github/workflows/query-engine.yml
@@ -5,7 +5,7 @@ on:
       - master
   pull_request:
 jobs:
-  test:
+  scala-vitess-tests:
     name: "Scala test suite: ${{ matrix.database }} on Linux"
     runs-on: ubuntu-latest
 
@@ -49,5 +49,46 @@ jobs:
 
       - run: export SERVER_ROOT=$(pwd) && cd query-engine/connector-test-kit && sbt test
         name: Run tests
+        env:
+          CLICOLOR_FORCE: 1
+
+  rust-vitess-tests:
+    name: "Rust test suite: Vitess ${{ matrix.database }} on Linux"
+
+    strategy:
+      fail-fast: false
+      matrix:
+        database:
+          - "vitess_5_7"
+          - "vitess_8_0"
+
+    env:
+      LOG_LEVEL: "info"
+      LOG_QUERIES: "y"
+      RUST_LOG_FORMAT: "devel"
+      RUST_BACKTRACE: 1
+      CLICOLOR_FORCE: 1
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: "Start ${{ matrix.database }}"
+        run: make dev-${{ matrix.database }}
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          default: true
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: query-engine-rs-${{ runner.os }}-cargo-vitess-${{ matrix.version }}-${{ hashFiles('**/Cargo.lock') }}
+
+      - run: timeout 40m cargo test --package query-engine-tests -- --test-threads=1
         env:
           CLICOLOR_FORCE: 1

--- a/.github/workflows/query-engine.yml
+++ b/.github/workflows/query-engine.yml
@@ -1,0 +1,53 @@
+name: Query Engine
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+jobs:
+  test:
+    name: "Scala test suite: ${{ matrix.database }} on Linux"
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        database:
+          - vitess_5_7
+          - vitess_8_0
+
+    env:
+      TEST_CONNECTOR: ${{ matrix.database }}
+      LOG_LEVEL: "info"
+      LOG_QUERIES: "y"
+      RUST_LOG_FORMAT: "devel"
+      RUST_BACKTRACE: 1
+      CLICOLOR_FORCE: 1
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: "Start ${{ matrix.database }}"
+        run: make start-${{ matrix.database }}
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          default: true
+
+      - uses: olafurpg/setup-scala@v10
+        with:
+          java-version: adopt@1.8
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: query-engine-${{ runner.os }}-${{ matrix.database}}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - run: export SERVER_ROOT=$(pwd) && cd query-engine/connector-test-kit && sbt test
+        name: Run tests
+        env:
+          CLICOLOR_FORCE: 1

--- a/.github/workflows/query-engine.yml
+++ b/.github/workflows/query-engine.yml
@@ -89,6 +89,6 @@ jobs:
             target
           key: query-engine-rs-${{ runner.os }}-cargo-vitess-${{ matrix.version }}-${{ hashFiles('**/Cargo.lock') }}
 
-      - run: timeout 40m cargo test --package query-engine-tests -- --test-threads=1
+      - run: export WORKSPACE_ROOT=$(pwd) && timeout 40m cargo test --package query-engine-tests -- --test-threads=1
         env:
           CLICOLOR_FORCE: 1

--- a/.github/workflows/query-engine.yml
+++ b/.github/workflows/query-engine.yml
@@ -53,7 +53,7 @@ jobs:
           CLICOLOR_FORCE: 1
 
   rust-vitess-tests:
-    name: "Rust test suite: Vitess ${{ matrix.database }} on Linux"
+    name: "Rust test suite: ${{ matrix.database }} on Linux"
 
     strategy:
       fail-fast: false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2288,6 +2288,7 @@ name = "migration-engine-cli"
 version = "0.1.0"
 dependencies = [
  "base64 0.13.0",
+ "enumflags2",
  "futures 0.3.13",
  "json-rpc-stdio",
  "migration-connector",
@@ -3569,6 +3570,7 @@ dependencies = [
  "datamodel",
  "datamodel-connector",
  "enum_dispatch",
+ "enumflags2",
  "indoc",
  "itertools 0.10.0",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3358,7 +3358,7 @@ dependencies = [
 [[package]]
 name = "quaint"
 version = "0.2.0-alpha.13"
-source = "git+https://github.com/prisma/quaint#19d62bb7d87590a18c9844620c87f2f38e972d7d"
+source = "git+https://github.com/prisma/quaint#32d028ffb5f7b22dc4ee20206a598ac8431ce0bf"
 dependencies = [
  "async-trait",
  "base64 0.12.3",

--- a/Makefile
+++ b/Makefile
@@ -120,8 +120,16 @@ dev-mongodb: start-mongodb
 start-vitess_5_7:
 	docker-compose -f docker-compose.yml up -d --remove-orphans vitess-test-5_7 vitess-shadow-5_7
 
+dev-vitess_5_7: start-vitess_5_7
+	echo 'vitess_5_7' > current_connector
+	cp $(CONFIG_PATH)/vitess_5_7 $(CONFIG_FILE)
+
 start-vitess_8_0:
 	docker-compose -f docker-compose.yml up -d --remove-orphans vitess-test-8_0 vitess-shadow-8_0
+
+dev-vitess_8_0: start-vitess_8_0
+	echo 'vitess_5_7' > current_connector
+	cp $(CONFIG_PATH)/vitess_8_0 $(CONFIG_FILE)
 
 dev-down:
 	docker-compose -f docker-compose.yml down -v --remove-orphans

--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ start-vitess_8_0:
 	docker-compose -f docker-compose.yml up -d --remove-orphans vitess-test-8_0 vitess-shadow-8_0
 
 dev-vitess_8_0: start-vitess_8_0
-	echo 'vitess_5_7' > current_connector
+	echo 'vitess_8_0' > current_connector
 	cp $(CONFIG_PATH)/vitess_8_0 $(CONFIG_FILE)
 
 dev-down:

--- a/migration-engine/cli/Cargo.toml
+++ b/migration-engine/cli/Cargo.toml
@@ -20,6 +20,7 @@ tokio = { version = "1.0", default-features = false, features = ["macros"] }
 tracing = "0.1"
 tracing-subscriber = "0.2"
 tracing-error = "0.1.2"
+enumflags2 = "0.6.0"
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/migration-engine/cli/src/commands.rs
+++ b/migration-engine/cli/src/commands.rs
@@ -3,9 +3,10 @@ pub(crate) mod error;
 #[cfg(test)]
 mod tests;
 
+use enumflags2::BitFlags;
 use error::CliError;
 use futures::FutureExt;
-use migration_core::migration_api;
+use migration_core::{migration_api, qe_setup::QueryEngineFlags};
 use structopt::StructOpt;
 use user_facing_errors::{
     common::{InvalidDatabaseString, SchemaParserError},
@@ -17,6 +18,8 @@ pub(crate) struct Cli {
     /// The connection string to the database
     #[structopt(long, short = "d", parse(try_from_str = parse_base64_string))]
     datasource: String,
+    #[structopt(long, short = "f", parse(try_from_str = parse_setup_flags), default_value = "Bitflags::empty")]
+    qe_test_setup_flags: BitFlags<QueryEngineFlags>,
     #[structopt(subcommand)]
     command: CliCommand,
 }
@@ -51,7 +54,7 @@ impl Cli {
             CliCommand::CanConnectToDatabase => connect_to_database(&self.datasource).await,
             CliCommand::DropDatabase => drop_database(&self.datasource).await,
             CliCommand::QeSetup => {
-                qe_setup(&self.datasource).await?;
+                qe_setup(&self.datasource, self.qe_test_setup_flags).await?;
                 Ok(String::new())
             }
         }
@@ -85,6 +88,19 @@ fn parse_base64_string(s: &str) -> Result<String, CliError> {
     }
 }
 
+fn parse_setup_flags(s: &str) -> Result<BitFlags<QueryEngineFlags>, CliError> {
+    let mut flags = BitFlags::empty();
+
+    for flag in s.split(',') {
+        match flag {
+            "database_creation_not_allowed" => flags.insert(QueryEngineFlags::DatabaseCreationNotAllowed),
+            flag => return Err(CliError::invalid_parameters(format!("Unknown flag: {}", flag))),
+        }
+    }
+
+    Ok(flags)
+}
+
 async fn connect_to_database(database_str: &str) -> Result<String, CliError> {
     let datamodel = datasource_from_database_str(database_str)?;
     migration_api(&datamodel).await?;
@@ -105,8 +121,8 @@ async fn drop_database(database_str: &str) -> Result<String, CliError> {
     Ok("The database was successfully dropped.".to_string())
 }
 
-async fn qe_setup(prisma_schema: &str) -> Result<(), CliError> {
-    migration_core::qe_setup(&prisma_schema).await?;
+async fn qe_setup(prisma_schema: &str, flags: BitFlags<QueryEngineFlags>) -> Result<(), CliError> {
+    migration_core::qe_setup::run(&prisma_schema, flags).await?;
 
     Ok(())
 }

--- a/migration-engine/cli/src/commands/error.rs
+++ b/migration-engine/cli/src/commands/error.rs
@@ -13,6 +13,10 @@ pub enum CliError {
         error: user_facing_errors::KnownError,
         exit_code: i32,
     },
+    InvalidParameters {
+        error: String,
+        exit_code: i32,
+    },
     Unknown {
         error: ConnectorError,
         context: SpanTrace,
@@ -24,6 +28,7 @@ impl Display for CliError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             CliError::Known { error, exit_code: _ } => write!(f, "Known error: {:?}", error),
+            CliError::InvalidParameters { error, .. } => write!(f, "Invalid parameters: {}", error),
             CliError::Unknown {
                 error,
                 context,
@@ -38,6 +43,14 @@ impl CliError {
         match self {
             CliError::Known { exit_code, .. } => *exit_code,
             CliError::Unknown { exit_code, .. } => *exit_code,
+            CliError::InvalidParameters { exit_code, .. } => *exit_code,
+        }
+    }
+
+    pub fn invalid_parameters<S: ToString>(error: S) -> Self {
+        Self::InvalidParameters {
+            error: error.to_string(),
+            exit_code: 255,
         }
     }
 

--- a/migration-engine/core/src/qe_setup.rs
+++ b/migration-engine/core/src/qe_setup.rs
@@ -1,0 +1,72 @@
+//! Query Engine test setup.
+
+use crate::api::GenericApi;
+use crate::commands::SchemaPushInput;
+use crate::core_error::{CoreError, CoreResult};
+#[cfg(feature = "mongodb")]
+use datamodel::common::provider_names::MONGODB_SOURCE_NAME;
+use datamodel::common::provider_names::{
+    MSSQL_SOURCE_NAME, MYSQL_SOURCE_NAME, POSTGRES_SOURCE_NAME, SQLITE_SOURCE_NAME,
+};
+use enumflags2::BitFlags;
+#[cfg(feature = "mongodb")]
+use mongodb_migration_connector::MongoDbMigrationConnector;
+use sql_migration_connector::SqlMigrationConnector;
+
+/// Flags from Query Engine to define the underlying database features.
+#[derive(Debug, Clone, Copy, BitFlags)]
+#[repr(u8)]
+pub enum QueryEngineFlags {
+    /// We cannot `CREATE` (or `DROP`) databases.
+    DatabaseCreationNotAllowed = 0x01,
+}
+
+/// Database setup for connector-test-kit.
+pub async fn run(prisma_schema: &str, flags: BitFlags<QueryEngineFlags>) -> CoreResult<()> {
+    let config = super::parse_configuration(prisma_schema)?;
+    let features = super::features::from_config(&config);
+
+    let source = config
+        .datasources
+        .first()
+        .ok_or_else(|| CoreError::from_msg("There is no datasource in the schema.".into()))?;
+
+    let api: Box<dyn GenericApi> = match &source.active_provider {
+        _ if flags.contains(QueryEngineFlags::DatabaseCreationNotAllowed) => {
+            let api = SqlMigrationConnector::new(&source.url().value, features, None).await?;
+            api.reset().await?;
+
+            Box::new(api)
+        }
+        provider
+            if [
+                MYSQL_SOURCE_NAME,
+                POSTGRES_SOURCE_NAME,
+                SQLITE_SOURCE_NAME,
+                MSSQL_SOURCE_NAME,
+            ]
+            .contains(&provider.as_str()) =>
+        {
+            // 1. creates schema & database
+            SqlMigrationConnector::qe_setup(&source.url().value).await?;
+            Box::new(SqlMigrationConnector::new(&source.url().value, features, None).await?)
+        }
+        #[cfg(feature = "mongodb")]
+        provider if provider == MONGODB_SOURCE_NAME => {
+            MongoDbMigrationConnector::qe_setup(&source.url().value).await?;
+            let connector = MongoDbMigrationConnector::new(&source.url().value, features).await?;
+            Box::new(connector)
+        }
+        x => unimplemented!("Connector {} is not supported yet", x),
+    };
+
+    // 2. create the database schema for given Prisma schema
+    let schema_push_input = SchemaPushInput {
+        schema: prisma_schema.to_string(),
+        assume_empty: true,
+        force: true,
+    };
+
+    api.schema_push(&schema_push_input).await?;
+    Ok(())
+}

--- a/migration-engine/migration-engine-tests/tests/migrations/advisory_locking.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/advisory_locking.rs
@@ -2,8 +2,7 @@ use migration_core::commands::{ApplyMigrationsInput, CreateMigrationInput};
 use migration_engine_tests::{multi_engine_test_api::*, TestResult};
 use test_macros::test_connectors;
 
-// Tom says: THIS IS OK TO IGNORE.
-#[test_connectors(ignore("vitess"))]
+#[test_connectors]
 async fn advisory_locking_works(api: TestApi) -> TestResult {
     api.initialize().await?;
 

--- a/query-engine/connector-test-kit-rs/query-tests-setup/Cargo.toml
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/Cargo.toml
@@ -28,6 +28,7 @@ tracing-subscriber = { version = "0.2", features = ["fmt"] }
 tracing-error = "0.1.2"
 colored = "2"
 indoc = "1.0"
+enumflags2 = "0.6"
 
 # Only this version is vetted, upgrade only after going through the code,
 # as this is a small crate with little user base.

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mod.rs
@@ -3,6 +3,7 @@ mod mysql;
 mod postgres;
 mod sql_server;
 mod sqlite;
+mod vitess;
 
 use datamodel_connector::ConnectorCapability;
 use enum_dispatch::enum_dispatch;
@@ -12,6 +13,7 @@ use postgres::*;
 use sql_server::*;
 use sqlite::*;
 use std::convert::TryFrom;
+use vitess::*;
 
 use crate::{datamodel_rendering::DatamodelRenderer, TestConfig, TestError};
 
@@ -50,6 +52,7 @@ pub enum ConnectorTag {
     MySql(MySqlConnectorTag),
     MongoDb(MongoDbConnectorTag),
     Sqlite(SqliteConnectorTag),
+    Vitess(VitessConnectorTag),
 }
 
 impl ConnectorTag {
@@ -114,6 +117,7 @@ impl TryFrom<(&str, Option<&str>)> for ConnectorTag {
             "postgres" => Self::Postgres(PostgresConnectorTag::new(version)?),
             "mysql" => Self::MySql(MySqlConnectorTag::new(version)?),
             "mongodb" => Self::MongoDb(MongoDbConnectorTag::new(version)?),
+            "vitess" => Self::Vitess(VitessConnectorTag::new(version)?),
             _ => return Err(TestError::parse_error(format!("Unknown connector tag `{}`", connector))),
         };
 

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/vitess.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/vitess.rs
@@ -73,7 +73,7 @@ impl VitessConnectorTag {
             },
             Self {
                 version: Some(VitessVersion::V8_0),
-                capabilities: capabilities.clone(),
+                capabilities,
             },
         ]
     }

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/vitess.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/vitess.rs
@@ -1,0 +1,117 @@
+use std::{fmt::Display, str::FromStr};
+
+use datamodel_connector::Connector;
+use sql_datamodel_connector::MySqlDatamodelConnector;
+
+use super::*;
+use crate::{SqlDatamodelRenderer, TestResult};
+
+#[derive(Debug, Default, Clone)]
+pub struct VitessConnectorTag {
+    capabilities: Vec<ConnectorCapability>,
+    version: Option<VitessVersion>,
+}
+
+impl ConnectorTagInterface for VitessConnectorTag {
+    fn datamodel_provider(&self) -> &'static str {
+        "mysql"
+    }
+
+    fn datamodel_renderer(&self) -> Box<dyn DatamodelRenderer> {
+        Box::new(SqlDatamodelRenderer::new())
+    }
+
+    fn connection_string(&self, _database: &str, _is_ci: bool) -> String {
+        dbg!(match self.version {
+            Some(VitessVersion::V5_7) => "mysql://root@localhost:33577/test?connection_limit=1".into(),
+            Some(VitessVersion::V8_0) => "mysql://root@localhost:33807/test?connection_limit=1".into(),
+            None => unreachable!("A versioned connector must have a concrete version to run."),
+        })
+    }
+
+    fn capabilities(&self) -> &[ConnectorCapability] {
+        &self.capabilities
+    }
+
+    fn as_parse_pair(&self) -> (String, Option<String>) {
+        let version = self.version.as_ref().map(ToString::to_string);
+        ("sqlite".to_owned(), version)
+    }
+
+    fn is_versioned(&self) -> bool {
+        true
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum VitessVersion {
+    V5_7,
+    V8_0,
+}
+
+impl VitessConnectorTag {
+    pub fn new(version: Option<&str>) -> TestResult<Self> {
+        let version = match version {
+            Some(v) => Some(v.parse()?),
+            None => None,
+        };
+
+        Ok(Self {
+            version,
+            capabilities: vitess_capabilities(),
+        })
+    }
+
+    /// Returns all versions of this connector.
+    pub fn all() -> Vec<Self> {
+        let capabilities = vitess_capabilities();
+
+        vec![
+            Self {
+                version: Some(VitessVersion::V5_7),
+                capabilities: capabilities.clone(),
+            },
+            Self {
+                version: Some(VitessVersion::V8_0),
+                capabilities: capabilities.clone(),
+            },
+        ]
+    }
+}
+
+impl PartialEq for VitessConnectorTag {
+    fn eq(&self, other: &Self) -> bool {
+        match (self.version, other.version) {
+            (None, None) | (Some(_), None) | (None, Some(_)) => true,
+            (Some(v1), Some(v2)) => v1 == v2,
+        }
+    }
+}
+
+impl FromStr for VitessVersion {
+    type Err = TestError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let version = match s {
+            "5.7" => Self::V5_7,
+            "8.0" => Self::V8_0,
+            _ => return Err(TestError::parse_error(format!("Unknown Vitess version `{}`", s))),
+        };
+
+        Ok(version)
+    }
+}
+
+impl Display for VitessVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::V5_7 => write!(f, "5.7"),
+            Self::V8_0 => write!(f, "8.0"),
+        }
+    }
+}
+
+fn vitess_capabilities() -> Vec<ConnectorCapability> {
+    let dm_connector = MySqlDatamodelConnector::new();
+    dm_connector.capabilities().clone()
+}

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/vitess.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/vitess.rs
@@ -22,11 +22,11 @@ impl ConnectorTagInterface for VitessConnectorTag {
     }
 
     fn connection_string(&self, _database: &str, _is_ci: bool) -> String {
-        dbg!(match self.version {
+        match self.version {
             Some(VitessVersion::V5_7) => "mysql://root@localhost:33577/test?connection_limit=1".into(),
             Some(VitessVersion::V8_0) => "mysql://root@localhost:33807/test?connection_limit=1".into(),
             None => unreachable!("A versioned connector must have a concrete version to run."),
-        })
+        }
     }
 
     fn capabilities(&self) -> &[ConnectorCapability] {

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/vitess.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/vitess.rs
@@ -35,7 +35,7 @@ impl ConnectorTagInterface for VitessConnectorTag {
 
     fn as_parse_pair(&self) -> (String, Option<String>) {
         let version = self.version.as_ref().map(ToString::to_string);
-        ("sqlite".to_owned(), version)
+        ("vitess".to_owned(), version)
     }
 
     fn is_versioned(&self) -> bool {

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/lib.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/lib.rs
@@ -16,6 +16,7 @@ pub use query_result::*;
 pub use runner::*;
 pub use templating::*;
 
+use enumflags2::BitFlags;
 use lazy_static::lazy_static;
 use tokio::runtime::Builder;
 
@@ -28,7 +29,7 @@ lazy_static! {
 
 /// Teardown & setup of everything as defined in the passed datamodel.
 pub async fn setup_project(datamodel: &str) -> TestResult<()> {
-    Ok(migration_core::qe_setup(datamodel).await?)
+    Ok(migration_core::qe_setup::run(datamodel, BitFlags::empty()).await?)
 }
 
 /// Helper method to allow a sync shell function to run the async test blocks.

--- a/query-engine/connector-test-kit-rs/test-configs/vitess_5_7
+++ b/query-engine/connector-test-kit-rs/test-configs/vitess_5_7
@@ -1,0 +1,5 @@
+{
+    "connector": "vitess",
+    "version": "5.7",
+    "runner": "direct"
+}

--- a/query-engine/connector-test-kit-rs/test-configs/vitess_8_0
+++ b/query-engine/connector-test-kit-rs/test-configs/vitess_8_0
@@ -1,0 +1,5 @@
+{
+    "connector": "vitess",
+    "version": "8.0",
+    "runner": "direct"
+}

--- a/query-engine/connector-test-kit/build.sbt
+++ b/query-engine/connector-test-kit/build.sbt
@@ -17,6 +17,9 @@ def allowParallelExecution(): Boolean = {
 
   connectorToTest match {
     case "pgbouncer" => false
+    case "vitess_5_7" => false
+    case "vitess_8_0" => false
+    case "vitess" => false
     case _ => true
   }
 }

--- a/query-engine/connector-test-kit/src/test/scala/binary/QueryEngine.scala
+++ b/query-engine/connector-test-kit/src/test/scala/binary/QueryEngine.scala
@@ -4,7 +4,7 @@ import org.scalatest.{FlatSpec, Matchers}
 import util._
 
 class QueryEngine extends FlatSpec with Matchers with ApiSpecBase {
-  "Setting a data source override via env" should "prevent env errors" in {
+  "Setting a data source override via env" should "prevent env errors" taggedAs (IgnoreVitess) in {
     val config = ConnectorConfig.instance
 
     val header = s"""

--- a/query-engine/connector-test-kit/src/test/scala/util/ConnectorAwareTest.scala
+++ b/query-engine/connector-test-kit/src/test/scala/util/ConnectorAwareTest.scala
@@ -25,9 +25,12 @@ object IgnoreSQLite extends Tag("ignore.sqlite") with AssociatedWithConnectorTag
 object IgnoreMsSql extends Tag("ignore.mssql") with AssociatedWithConnectorTags {
   override def tag = ConnectorTag.MsSqlConnectorTag
 }
+object IgnoreVitess extends Tag("ignore.vitess") with AssociatedWithConnectorTags {
+  override def tag = ConnectorTag.VitessConnectorTag
+}
 
 object IgnoreSet {
-  val ignoreConnectorTags = Set(IgnorePostgres, IgnoreMySql, IgnoreMySql56, IgnoreMongo, IgnoreSQLite, IgnoreMsSql)
+  val ignoreConnectorTags = Set(IgnorePostgres, IgnoreMySql, IgnoreMySql56, IgnoreMongo, IgnoreSQLite, IgnoreMsSql, IgnoreVitess)
 
   def byName(name: String): Option[AssociatedWithConnectorTags] = ignoreConnectorTags.find(_.name == name)
 }
@@ -49,6 +52,9 @@ object ConnectorTag extends Enum[ConnectorTag] {
   object PostgresConnectorTag extends RelationalConnectorTag
   object SQLiteConnectorTag   extends RelationalConnectorTag
   object MsSqlConnectorTag    extends RelationalConnectorTag
+  object VitessConnectorTag extends RelationalConnectorTag {
+    override def superTags() = Seq(MySqlConnectorTag)
+  }
 
   sealed trait DocumentConnectorTag extends ConnectorTag
 
@@ -65,6 +71,7 @@ trait ConnectorAwareTest extends SuiteMixin { self: Suite with ApiSpecBase =>
     case "mongodb"                 => ConnectorTag.MongoConnectorTag
     case "mysql56"                 => ConnectorTag.Mysql56ConnectorTag
     case "mysql"                   => ConnectorTag.MySqlConnectorTag
+    case "vitess"                  => ConnectorTag.VitessConnectorTag
     case "postgres" | "postgresql" => ConnectorTag.PostgresConnectorTag
     case "sqlite"                  => ConnectorTag.SQLiteConnectorTag
     case "sqlserver"               => ConnectorTag.MsSqlConnectorTag

--- a/query-engine/connector-test-kit/src/test/scala/util/ConnectorCapabilities.scala
+++ b/query-engine/connector-test-kit/src/test/scala/util/ConnectorCapabilities.scala
@@ -43,6 +43,7 @@ object ConnectorCapabilities {
   lazy val sqlite: ConnectorCapabilities   = ConnectorCapabilities(sqlShared)
   lazy val postgres: ConnectorCapabilities = ConnectorCapabilities(sqlShared + ScalarListsCapability + EnumCapability)
   lazy val mysql: ConnectorCapabilities    = ConnectorCapabilities(sqlShared + EnumCapability)
+  lazy val vitess: ConnectorCapabilities    = ConnectorCapabilities(sqlShared + EnumCapability)
   lazy val mssql: ConnectorCapabilities    = ConnectorCapabilities(sqlShared)
   lazy val mongo: ConnectorCapabilities    = ConnectorCapabilities(ScalarListsCapability)
 

--- a/query-engine/connector-test-kit/src/test/scala/util/ConnectorConfig.scala
+++ b/query-engine/connector-test-kit/src/test/scala/util/ConnectorConfig.scala
@@ -16,6 +16,7 @@ case class ConnectorConfig(
       case "postgresql" => ConnectorCapabilities.postgres
       case "mysql"      => ConnectorCapabilities.mysql
       case "mysql56"    => ConnectorCapabilities.mysql
+      case "vitess"     => ConnectorCapabilities.mysql
       case "sqlserver"  => ConnectorCapabilities.mssql
       case "mongodb"    => ConnectorCapabilities.mongo
     }
@@ -58,6 +59,9 @@ object ConnectorConfig {
       case "mysql8"  => ConnectorConfig("mysql", s"mysql://root:prisma@$mysql_8_0_Host:$mysql_8_0_Port/$$DB?connection_limit=1", "mysql8")
       case "mysql56" => ConnectorConfig("mysql56", s"mysql://root:prisma@$mysql_5_6_Host:$mysql_5_6_Port/$$DB?connection_limit=1", "mysql56")
       case "mariadb" => ConnectorConfig("mysql", s"mysql://root:prisma@$mariadb_Host:$mariadb_Port/$$DB?connection_limit=1", "mariadb")
+
+      case "vitess_5_7" => ConnectorConfig("vitess", s"mysql://root:prisma@127.0.0.1:33577/test?connection_limit=1", "vitess")
+      case "vitess_8_0" => ConnectorConfig("vitess", s"mysql://root:prisma@127.0.0.1:33807/test?connection_limit=1", "vitess")
 
       case "mssql2017" =>
         ConnectorConfig(

--- a/query-engine/connector-test-kit/src/test/scala/util/Project.scala
+++ b/query-engine/connector-test-kit/src/test/scala/util/Project.scala
@@ -19,9 +19,14 @@ case class Project(
   val dataSourceConfig: String = {
     val config = ConnectorConfig.instance
 
+    val provider = config.provider.stripSuffix("56") match {
+      case "vitess" => "mysql"
+      case provider => provider
+    }
+
     s"""
            |datasource test {
-           |  provider = "${config.provider.stripSuffix("56")}"
+           |  provider = "${provider}"
            |  url = "$dataSourceUrl"
            |}
     """.stripMargin

--- a/query-engine/connector-test-kit/src/test/scala/util/TestDatabase.scala
+++ b/query-engine/connector-test-kit/src/test/scala/util/TestDatabase.scala
@@ -3,6 +3,7 @@ package util
 case class TestDatabase() {
   def setup(project: Project): Unit = {
     val engine = MigrationEngine(project)
+
     engine.resetAndSetupDatabase()
   }
 
@@ -19,7 +20,14 @@ case class MigrationEngine(project: Project) {
 
   def resetAndSetupDatabase(): Unit = {
     import scala.sys.process._
-    val cmd = List(EnvVars.migrationEngineBinaryPath, "cli", "-d", project.fullDatamodelBase64Encoded, "qe-setup")
+    val config = ConnectorConfig.instance
+
+    val flags = config.provider match {
+      case "vitess" => "database_creation_not_allowed"
+      case _ => ""
+    }
+
+    val cmd = List(EnvVars.migrationEngineBinaryPath, "cli", "-f", flags, "-d", project.fullDatamodelBase64Encoded, "qe-setup")
 
     cmd.!
   }

--- a/query-engine/connector-test-kit/src/test/scala/util/TestServer.scala
+++ b/query-engine/connector-test-kit/src/test/scala/util/TestServer.scala
@@ -19,7 +19,7 @@ case class TestServer() extends PlayJsonExtensions with LogSupport {
       project: Project,
       dataContains: String = "",
       legacy: Boolean = true,
-      batchSize: Int = 500,
+      batchSize: Int = 5000,
   ): JsValue = {
     val result = queryBinary(
       request = createSingleQuery(query),

--- a/query-engine/connector-test-kit/src/test/scala/util/TestServer.scala
+++ b/query-engine/connector-test-kit/src/test/scala/util/TestServer.scala
@@ -19,7 +19,7 @@ case class TestServer() extends PlayJsonExtensions with LogSupport {
       project: Project,
       dataContains: String = "",
       legacy: Boolean = true,
-      batchSize: Int = 5000,
+      batchSize: Int = 500,
   ): JsValue = {
     val result = queryBinary(
       request = createSingleQuery(query),

--- a/query-engine/connector-test-kit/src/test/scala/writes/dataTypes/datetime/DateTimeSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/dataTypes/datetime/DateTimeSpec.scala
@@ -12,7 +12,10 @@ class DateTimeSpec extends FlatSpec with Matchers with ApiSpecBase {
        | born DateTime
        |}"""
   }
-  database.setup(project)
+
+  override def beforeEach(): Unit = {
+    database.setup(project)
+  }
 
   // FIXME: this panics the rust code. Let's fix that at some point.
   "Using a date before 1970" should "work" taggedAs IgnoreSQLite in {

--- a/query-engine/connector-test-kit/src/test/scala/writes/dataTypes/datetime/NonEmbeddedUpdatedAtShouldChangeSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/dataTypes/datetime/NonEmbeddedUpdatedAtShouldChangeSpec.scala
@@ -29,7 +29,9 @@ class NonEmbeddedUpdatedAtShouldChangeSpec extends FlatSpec with Matchers with A
       |"""
   }
 
-  database.setup(project)
+  override def beforeEach(): Unit = {
+    database.setup(project)
+  }
 
   "Updating a nested data item" should "change it's updatedAt value" in {
     val updatedAt = server

--- a/query-engine/connector-test-kit/src/test/scala/writes/deadlocksAndTransactions/VeryManyMutationsSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/deadlocksAndTransactions/VeryManyMutationsSpec.scala
@@ -8,6 +8,7 @@ import scala.concurrent.Future
 
 class VeryManyMutationsSpec extends FlatSpec with Matchers with ApiSpecBase with AwaitUtils {
 
+  override def doNotRunForConnectors: Set[ConnectorTag] = Set(ConnectorTag.VitessConnectorTag)
   override def runOnlyForCapabilities = Set(JoinRelationLinksCapability)
 
   //Postgres has a limit of 32678 parameters to a query
@@ -29,8 +30,7 @@ class VeryManyMutationsSpec extends FlatSpec with Matchers with ApiSpecBase with
   """
   }
 
-  override protected def beforeAll(): Unit = {
-    super.beforeAll()
+  override protected def beforeEach(): Unit = {
     database.setup(project)
 
     def createTop(int: Int): Unit = {

--- a/query-engine/connector-test-kit/src/test/scala/writes/ids/BringYourOwnIdSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/ids/BringYourOwnIdSpec.scala
@@ -6,7 +6,7 @@ import util._
 
 class BringYourOwnIdSpec extends FlatSpec with Matchers with ApiSpecBase with SchemaBaseV11 {
 
-  override def runOnlyForConnectors: Set[ConnectorTag] = Set(MySqlConnectorTag, PostgresConnectorTag, SQLiteConnectorTag)
+  override def runOnlyForConnectors: Set[ConnectorTag] = Set(VitessConnectorTag, MySqlConnectorTag, PostgresConnectorTag, SQLiteConnectorTag)
 
   "A Create Mutation" should "create and return item with own Id" in {
     schemaP1optToC1opt.test { dataModel =>
@@ -23,8 +23,9 @@ class BringYourOwnIdSpec extends FlatSpec with Matchers with ApiSpecBase with Sc
       res.toString should be(s"""{"data":{"createParent":{"p":"Parent","id":"Own Id"}}}""")
 
       val errorTarget = () match {
-        case _ if connectorTag == ConnectorTag.MySqlConnectorTag => "constraint: `PRIMARY`"
-        case _                                                   => "fields: (`id`)"
+        case _ if connectorTag == ConnectorTag.MySqlConnectorTag    => "constraint: `PRIMARY`"
+        case _ if connectorTag == ConnectorTag.VitessConnectorTag   => "(not available)"
+        case _                                                      => "fields: (`id`)"
       }
 
       server.queryThatMustFail(
@@ -101,8 +102,9 @@ class BringYourOwnIdSpec extends FlatSpec with Matchers with ApiSpecBase with Sc
       res.toString should be(s"""{"data":{"createParent":{"p":"Parent","id":"Own Id","childOpt":{"c":"Child","id":"Own Child Id"}}}}""")
 
       val constraintTarget = () match {
-        case _ if connectorTag == ConnectorTag.MySqlConnectorTag => "constraint: `PRIMARY`"
-        case _                                                   => "fields: (`id`)"
+        case _ if connectorTag == ConnectorTag.MySqlConnectorTag  => "constraint: `PRIMARY`"
+        case _ if connectorTag == ConnectorTag.VitessConnectorTag => "(not available)"
+        case _                                                    => "fields: (`id`)"
       }
 
       server.queryThatMustFail(

--- a/query-engine/connector-test-kit/src/test/scala/writes/topLevelMutations/CreateMutationSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/topLevelMutations/CreateMutationSpec.scala
@@ -7,6 +7,7 @@ import util._
 
 class CreateMutationSpec extends FlatSpec with Matchers with ApiSpecBase {
 
+  override def doNotRunForConnectors: Set[ConnectorTag] = Set(ConnectorTag.VitessConnectorTag)
   override def runOnlyForCapabilities = Set(EnumCapability)
 
   val schema =

--- a/query-engine/connector-test-kit/src/test/scala/writes/topLevelMutations/UpdateMutationSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/writes/topLevelMutations/UpdateMutationSpec.scala
@@ -5,6 +5,8 @@ import play.api.libs.json.Json
 import util._
 
 class UpdateMutationSpec extends FlatSpec with Matchers with ApiSpecBase {
+  override def doNotRunForConnectors: Set[ConnectorTag] = Set(ConnectorTag.VitessConnectorTag)
+
   "An updateOne mutation" should "update an item" taggedAs IgnoreSQLite in {
     val project = ProjectDsl.fromString {
       """

--- a/query-engine/connectors/sql-query-connector/src/database/operations/write.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/write.rs
@@ -46,11 +46,11 @@ pub async fn create_record(conn: &dyn QueryExt, model: &ModelRef, args: WriteArg
                 }
                 quaint::error::DatabaseConstraint::ForeignKey => {
                     let constraint = DatabaseConstraint::ForeignKey;
-                    return Err(SqlError::UniqueConstraintViolation { constraint });
+                    return Err(SqlError::NullConstraintViolation { constraint });
                 }
                 quaint::error::DatabaseConstraint::CannotParse => {
                     let constraint = DatabaseConstraint::CannotParse;
-                    return Err(SqlError::UniqueConstraintViolation { constraint });
+                    return Err(SqlError::NullConstraintViolation { constraint });
                 }
             },
             _ => return Err(SqlError::from(e)),

--- a/query-engine/connectors/sql-query-connector/src/query_builder/write.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_builder/write.rs
@@ -67,7 +67,8 @@ pub fn create_records(model: &ModelRef, args: Vec<WriteArgs>, skip_duplicates: b
         })
         .collect();
 
-    let insert = Insert::multi_into(model.as_table(), fields.as_columns());
+    let columns = fields.as_columns().map(|c| c.name.into_owned());
+    let insert = Insert::multi_into(model.as_table(), columns);
     let insert = values.into_iter().fold(insert, |stmt, values| stmt.values(values));
     let insert: Insert = insert.into();
 
@@ -155,10 +156,16 @@ pub fn create_relation_table_records(
     child_ids: &[RecordProjection],
 ) -> Query<'static> {
     let relation = field.relation();
-    let parent_columns: Vec<_> = field.related_field().m2m_columns();
-    let child_columns: Vec<_> = field.m2m_columns();
 
-    let columns: Vec<_> = parent_columns.into_iter().chain(child_columns).collect();
+    let parent_columns = field
+        .related_field()
+        .m2m_columns()
+        .into_iter()
+        .map(|c| c.name.into_owned());
+
+    let child_columns = field.m2m_columns().into_iter().map(|c| c.name.into_owned());
+
+    let columns: Vec<_> = parent_columns.chain(child_columns).collect();
     let insert = Insert::multi_into(relation.as_table(), columns);
 
     let insert: MultiRowInsert = child_ids.iter().fold(insert, |insert, child_id| {

--- a/query-engine/connectors/sql-query-connector/src/query_builder/write.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_builder/write.rs
@@ -67,8 +67,7 @@ pub fn create_records(model: &ModelRef, args: Vec<WriteArgs>, skip_duplicates: b
         })
         .collect();
 
-    let columns = fields.as_columns().map(|c| c.name.into_owned());
-    let insert = Insert::multi_into(model.as_table(), columns);
+    let insert = Insert::multi_into(model.as_table(), fields.as_columns());
     let insert = values.into_iter().fold(insert, |stmt, values| stmt.values(values));
     let insert: Insert = insert.into();
 
@@ -157,15 +156,10 @@ pub fn create_relation_table_records(
 ) -> Query<'static> {
     let relation = field.relation();
 
-    let parent_columns = field
-        .related_field()
-        .m2m_columns()
-        .into_iter()
-        .map(|c| c.name.into_owned());
+    let parent_columns: Vec<_> = field.related_field().m2m_columns();
+    let child_columns: Vec<_> = field.m2m_columns();
 
-    let child_columns = field.m2m_columns().into_iter().map(|c| c.name.into_owned());
-
-    let columns: Vec<_> = parent_columns.chain(child_columns).collect();
+    let columns: Vec<_> = parent_columns.into_iter().chain(child_columns).collect();
     let insert = Insert::multi_into(relation.as_table(), columns);
 
     let insert: MultiRowInsert = child_ids.iter().fold(insert, |insert, child_id| {


### PR DESCRIPTION
The last step of the CI test setup for Vitess: Query Engine. Tests run, again, against vitess in single-threaded mode, on GitHub Actions only.

Closes: https://github.com/prisma/prisma-engines/issues/1851
Closes: https://github.com/prisma/prisma/issues/5219
Closes: https://github.com/prisma/migrations-team/issues/203