### PR TITLE
Validate SQL Server parameters without crashing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4253,6 +4253,7 @@ dependencies = [
  "dml",
  "native-types",
  "once_cell",
+ "regex",
  "serde_json",
 ]
 

--- a/libs/datamodel/connectors/datamodel-connector/src/connector_error.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/connector_error.rs
@@ -90,6 +90,14 @@ impl ConnectorErrorFactory {
             connector_name: self.connector,
         }))
     }
+
+    pub fn native_type_invalid_param(self, expected: &str, got: &str) -> ConnectorError {
+        ConnectorError::from_kind(ErrorKind::InvalidArgumentError {
+            native_type: self.native_type,
+            expected: expected.into(),
+            got: got.into(),
+        })
+    }
 }
 
 impl ConnectorError {
@@ -254,6 +262,13 @@ pub enum ErrorKind {
         native_type: String,
         connector_name: String,
         message: String,
+    },
+
+    #[error("Invalid argument for type {}: {}. Allowed values: {}.", native_type, got, expected)]
+    InvalidArgumentError {
+        native_type: String,
+        expected: String,
+        got: String,
     },
 
     #[error("Error validating field '{}': {}", field, message)]

--- a/libs/datamodel/connectors/sql-datamodel-connector/Cargo.toml
+++ b/libs/datamodel/connectors/sql-datamodel-connector/Cargo.toml
@@ -12,3 +12,4 @@ dml = { path = "../dml" }
 native-types = { path = "../../../native-types" }
 serde_json = { version = "1.0", features = ["float_roundtrip"] }
 once_cell = "1.3"
+regex = "1"

--- a/libs/datamodel/core/tests/types/mssql_native_types.rs
+++ b/libs/datamodel/core/tests/types/mssql_native_types.rs
@@ -183,6 +183,50 @@ fn should_fail_on_incompatible_scalar_type_with_tiny_int() {
     ));
 }
 
+#[test]
+fn should_fail_on_bad_type_params() {
+    let dml = r#"
+        datasource db {
+          provider = "sqlserver"
+          url = "sqlserver://"
+        }
+
+        model Blog {
+            id     Int    @id
+            s      String @db.NVarChar(Ma)
+        }
+    "#;
+
+    let error = parse_error(dml);
+
+    error.assert_is(DatamodelError::new_connector_error(
+        "Invalid argument for type NVarChar: Ma. Allowed values: a number or `Max`.",
+        ast::Span::new(178, 193),
+    ));
+}
+
+#[test]
+fn should_fail_on_too_many_type_params() {
+    let dml = r#"
+        datasource db {
+          provider = "sqlserver"
+          url = "sqlserver://"
+        }
+
+        model Blog {
+            id     Int    @id
+            s      String @db.NVarChar(1, 2)
+        }
+    "#;
+
+    let error = parse_error(dml);
+
+    error.assert_is(DatamodelError::new_connector_error(
+        "Native type NVarChar takes 1 optional arguments, but received 2.",
+        ast::Span::new(178, 195),
+    ));
+}
+
 macro_rules! test_type {
     ($name:ident($(($input:expr, $output:expr)),+ $(,)?)) => {
         paste::item! {


### PR DESCRIPTION
This it not really the right place to do that. Most of the validation is handled through `NativeTypeConstructor`, which could hold a `Box<dyn Fn(&[String]) -> bool>`. Then again, the `NativeTypeConstructor` is `Serialize`, meaning a trait object is not possible in the constructor.

We need one place for managing all validations. This needs to change in the future.

Closes: https://github.com/prisma/prisma/issues/6842