### PR TITLE
Fix checksum formatting in ME

### DIFF
--- a/migration-engine/connectors/migration-connector/src/migrations_directory.rs
+++ b/migration-engine/connectors/migration-connector/src/migrations_directory.rs
@@ -5,7 +5,7 @@
 //! It also contains multiple subfolders, named after the migration id, and each containing:
 //! - A migration script
 
-use crate::{ConnectorError, ConnectorResult, FormatChecksum};
+use crate::{ConnectorError, ConnectorResult, FormatChecksum, CHECKSUM_STR_LEN};
 use sha2::{Digest, Sha256, Sha512};
 use std::{
     error::Error,
@@ -221,7 +221,19 @@ impl MigrationDirectory {
         hasher.update(&filesystem_script);
         let filesystem_script_checksum: [u8; 32] = hasher.finalize().into();
 
-        Ok(checksum_str == filesystem_script_checksum.format_checksum())
+        // Due to an omission in a previous version of the migration engine,
+        // some migrations tables will have old migrations with checksum strings
+        // that have not been zero-padded.
+        //
+        // Corresponding issue:
+        // https://github.com/prisma/prisma-engines/issues/1887
+        let filesystem_script_checksum_str = if !checksum_str.is_empty() && checksum_str.len() != CHECKSUM_STR_LEN {
+            filesystem_script_checksum.format_checksum_old()
+        } else {
+            filesystem_script_checksum.format_checksum()
+        };
+
+        Ok(checksum_str == filesystem_script_checksum_str)
     }
 
     /// Write the migration script to the directory.

--- a/migration-engine/migration-engine-tests/tests/migrations/migration_persistence_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/migration_persistence_tests.rs
@@ -23,7 +23,7 @@ async fn starting_a_migration_works(api: &TestApi) -> TestResult {
     assert_eq!(first_migration.id, id);
     assert_eq!(
         first_migration.checksum,
-        "e0c9674d3b332d71b8bc304aae5b7b8a8bb8ec72e772429fb20d8cc69a864"
+        "e0c9674d3b332d71b8bc304aae5b7b8a8bb8ec720e07072429fb20d8cc69a864"
     );
     assert_eq!(first_migration.finished_at, None);
     assert_eq!(first_migration.migration_name, "initial_migration");
@@ -61,7 +61,7 @@ async fn finishing_a_migration_works(api: &TestApi) -> TestResult {
     assert_eq!(first_migration.id, id);
     assert_eq!(
         first_migration.checksum,
-        "e0c9674d3b332d71b8bc304aae5b7b8a8bb8ec72e772429fb20d8cc69a864"
+        "e0c9674d3b332d71b8bc304aae5b7b8a8bb8ec720e07072429fb20d8cc69a864"
     );
     assert_eq!(first_migration.migration_name, "initial_migration");
     assert_eq!(first_migration.logs.as_deref(), None);
@@ -103,7 +103,7 @@ async fn updating_then_finishing_a_migration_works(api: &TestApi) -> TestResult 
     assert_eq!(first_migration.id, id);
     assert_eq!(
         first_migration.checksum,
-        "e0c9674d3b332d71b8bc304aae5b7b8a8bb8ec72e772429fb20d8cc69a864"
+        "e0c9674d3b332d71b8bc304aae5b7b8a8bb8ec720e07072429fb20d8cc69a864"
     );
     assert_eq!(first_migration.migration_name, "initial_migration");
     assert!(first_migration.logs.is_none());
@@ -155,7 +155,7 @@ async fn multiple_successive_migrations_work(api: &TestApi) -> TestResult {
         assert_eq!(first_migration.id, id_1);
         assert_eq!(
             first_migration.checksum,
-            "e0c9674d3b332d71b8bc304aae5b7b8a8bb8ec72e772429fb20d8cc69a864"
+            "e0c9674d3b332d71b8bc304aae5b7b8a8bb8ec720e07072429fb20d8cc69a864"
         );
         assert_eq!(first_migration.migration_name, "initial_migration");
         assert!(first_migration.logs.is_none());
@@ -179,7 +179,7 @@ async fn multiple_successive_migrations_work(api: &TestApi) -> TestResult {
         assert_eq!(second_migration.id, id_2);
         assert_eq!(
             second_migration.checksum,
-            "822db1ee793d76eaa1319eb2c453a7ec92ab6ec235268b4d27ac395c6c5a6ef"
+            "822db1ee793d76eaa1319eb2c453a7ec92ab6ec235268b4d27ac395c6c5a6e0f"
         );
         assert_eq!(second_migration.migration_name, "second_migration");
         assert!(second_migration.logs.is_none());


### PR DESCRIPTION
This is to align with other tools, for example the CLI shasum utility on
linux.

The old format is still recognized and accepted for compatibility with
existing migration tables.

closes https://github.com/prisma/prisma-engines/issues/1887