### PR TITLE
Fix MySQL drift with similar indexes

### DIFF
--- a/.github/workflows/migration-engine.yml
+++ b/.github/workflows/migration-engine.yml
@@ -54,7 +54,7 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: "1.51.0"
           default: true
 
       - uses: actions/cache@v2
@@ -118,7 +118,7 @@ jobs:
           - name: mariadb
             url: "mysql://root@localhost:3306?connect_timeout=20&socket_timeout=60"
         rust:
-          - stable
+          - "1.51.0"
         os:
           - windows-latest
 

--- a/.github/workflows/query-engine.yml
+++ b/.github/workflows/query-engine.yml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: "1.51.0"
           default: true
 
       - uses: olafurpg/setup-scala@v10
@@ -78,7 +78,7 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: "1.51.0"
           default: true
 
       - uses: actions/cache@v2

--- a/.github/workflows/query-engine.yml
+++ b/.github/workflows/query-engine.yml
@@ -87,7 +87,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: query-engine-rs-${{ runner.os }}-cargo-vitess-${{ matrix.version }}-${{ hashFiles('**/Cargo.lock') }}
+          key: query-engine-rust-${{ runner.os }}-cargo-vitess-${{ matrix.version }}-${{ hashFiles('**/Cargo.lock') }}
 
       - run: export WORKSPACE_ROOT=$(pwd) && cargo test --package query-engine-tests -- --test-threads=1
         env:

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/table.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/table.rs
@@ -81,7 +81,7 @@ impl<'schema> TableDiffer<'schema> {
             let number_of_identical_indexes = self
                 .previous_indexes()
                 .filter(|right| left.column_names() == right.column_names() && left.index_type() == right.index_type())
-                .fold(0, |acc, _| acc + 1);
+                .count();
 
             number_of_identical_indexes == 1
         });


### PR DESCRIPTION
If the index is pointing to a same column than another index, but they
have different names, we detected drift.

Closes: https://github.com/prisma/prisma/issues/6873