### PR TITLE
fix(error): Simplify P2024 message

### DIFF
--- a/libs/user-facing-errors/src/query_engine.rs
+++ b/libs/user-facing-errors/src/query_engine.rs
@@ -253,7 +253,7 @@ pub struct InconsistentColumnData {
 #[derive(Debug, UserFacingError, Serialize)]
 #[user_facing(
     code = "P2024",
-    message = "Timed out fetching a new connection from the pool. Please consider reducing the number of requests or increasing the `connection_limit` parameter (https://www.prisma.io/docs/concepts/components/prisma-client/connection-management#connection-pool). Current limit: {connection_limit}."
+    message = "Timed out fetching a new connection from the connection pool. (More info: https://www.prisma.io/docs/concepts/components/prisma-client/working-with-prismaclient/connection-pool, Current connection limit: {connection_limit})"
 )]
 pub struct PoolTimeout {
     pub connection_limit: u64,

--- a/libs/user-facing-errors/src/query_engine.rs
+++ b/libs/user-facing-errors/src/query_engine.rs
@@ -253,7 +253,7 @@ pub struct InconsistentColumnData {
 #[derive(Debug, UserFacingError, Serialize)]
 #[user_facing(
     code = "P2024",
-    message = "Timed out fetching a new connection from the connection pool. (More info: https://www.prisma.io/docs/concepts/components/prisma-client/working-with-prismaclient/connection-pool, Current connection limit: {connection_limit})"
+    message = "Timed out fetching a new connection from the connection pool. (More info: http://pris.ly/d/connection-pool, Current connection limit: {connection_limit})"
 )]
 pub struct PoolTimeout {
     pub connection_limit: u64,


### PR DESCRIPTION
- New docs page https://www.prisma.io/docs/concepts/components/prisma-client/working-with-prismaclient/connection-pool (pris.ly link http://pris.ly/d/connection-pool) is the better place to learn about the connection pool and explain the timeout error and so on. 
- Current message was considered misleading by some (e.g. https://github.com/prisma/prisma/issues/6898)