### PR TITLE
Replace O(n²) ops with O(n)/O(log n) in SQL table and column diffing

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/pair.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/pair.rs
@@ -3,7 +3,7 @@ use sql_schema_describer::{
     SqlSchema,
 };
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct Pair<T> {
     previous: T,
     next: T,
@@ -58,6 +58,10 @@ impl<T> Pair<T> {
 
     pub(crate) fn next(&self) -> &T {
         &self.next
+    }
+
+    pub(crate) fn next_mut(&mut self) -> &mut T {
+        &mut self.next
     }
 }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_migration.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_migration.rs
@@ -83,7 +83,7 @@ impl SqlMigrationStep {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct CreateTable {
     pub table_index: usize,
 }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_migration.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_migration.rs
@@ -195,7 +195,7 @@ pub(crate) struct DropForeignKey {
     pub constraint_name: String,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub(crate) struct CreateIndex {
     pub table_index: usize,
     pub index_index: usize,

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/differ_database.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/differ_database.rs
@@ -1,0 +1,126 @@
+use crate::{flavour::SqlFlavour, pair::Pair};
+use sql_schema_describer::{
+    walkers::{SqlSchemaExt, TableWalker},
+    SqlSchema,
+};
+use std::{
+    borrow::Cow,
+    collections::{BTreeMap, HashMap},
+    ops::Bound,
+};
+
+pub(crate) struct DifferDatabase<'a> {
+    schemas: Pair<&'a SqlSchema>,
+    /// Table name -> table indexes.
+    tables: HashMap<Cow<'a, str>, Pair<Option<usize>>>,
+    /// (table_idxs, column_name) -> column_idxs
+    columns: BTreeMap<(Pair<usize>, &'a str), Pair<Option<usize>>>,
+}
+
+impl<'a> DifferDatabase<'a> {
+    pub(crate) fn new(schemas: Pair<&'a SqlSchema>, flavour: &'a dyn SqlFlavour) -> Self {
+        let table_count_lb = std::cmp::max(schemas.previous().tables.len(), schemas.next().tables.len());
+        let mut tables = HashMap::with_capacity(table_count_lb);
+        let mut columns = BTreeMap::<(Pair<usize>, &'a str), Pair<Option<usize>>>::new();
+        let mut columns_cache = HashMap::new();
+        let table_is_ignored =
+            |table_name: &str| table_name == "_prisma_migrations" || flavour.table_should_be_ignored(&table_name);
+
+        for table in schemas
+            .previous()
+            .table_walkers()
+            .filter(|t| !table_is_ignored(t.name()))
+        {
+            let table_name = if flavour.lower_cases_table_names() {
+                table.name().to_ascii_lowercase().into()
+            } else {
+                Cow::Borrowed(table.name())
+            };
+            tables.insert(table_name, Pair::new(Some(table.table_index()), None));
+        }
+
+        for table in schemas.next().table_walkers().filter(|t| !table_is_ignored(t.name())) {
+            let table_name = if flavour.lower_cases_table_names() {
+                table.name().to_ascii_lowercase().into()
+            } else {
+                Cow::Borrowed(table.name())
+            };
+            let entry = tables.entry(table_name).or_default();
+            *entry.next_mut() = Some(table.table_index());
+
+            if let Some(table_pair) = entry.transpose() {
+                let tables = schemas.tables(&table_pair);
+
+                columns_cache.clear();
+
+                for column in tables.previous().columns() {
+                    columns_cache.insert(column.name(), Pair::new(Some(column.column_index()), None));
+                }
+
+                for column in tables.next().columns() {
+                    let entry = columns_cache.entry(column.name()).or_default();
+                    *entry.next_mut() = Some(column.column_index());
+                }
+
+                for (column_name, indexes) in &columns_cache {
+                    columns.insert((table_pair, column_name), *indexes);
+                }
+            }
+        }
+
+        DifferDatabase {
+            tables,
+            columns,
+            schemas,
+        }
+    }
+
+    pub(crate) fn column_pairs(&self, table: Pair<usize>) -> impl Iterator<Item = Pair<usize>> + '_ {
+        self.range_columns(table).filter_map(|(_k, v)| v.transpose())
+    }
+
+    pub(crate) fn created_columns(&self, table: Pair<usize>) -> impl Iterator<Item = usize> + '_ {
+        self.range_columns(table)
+            .filter(|(_k, v)| v.previous().is_none())
+            .filter_map(|(_k, v)| *v.next())
+    }
+
+    pub(crate) fn created_tables(&self) -> impl Iterator<Item = TableWalker<'a>> + '_ {
+        self.tables
+            .values()
+            .filter(|p| p.previous().is_none())
+            .filter_map(|p| *p.next())
+            .map(move |idx| self.schemas.next().table_walker_at(idx))
+    }
+
+    pub(crate) fn dropped_columns(&self, table: Pair<usize>) -> impl Iterator<Item = usize> + '_ {
+        self.range_columns(table)
+            .filter(|(_k, v)| v.next().is_none())
+            .filter_map(|(_k, v)| *v.previous())
+    }
+
+    pub(crate) fn dropped_tables(&self) -> impl Iterator<Item = TableWalker<'a>> + '_ {
+        self.tables
+            .values()
+            .filter(|p| p.next().is_none())
+            .filter_map(|p| *p.previous())
+            .map(move |idx| self.schemas.previous().table_walker_at(idx))
+    }
+
+    fn range_columns(
+        &self,
+        table: Pair<usize>,
+    ) -> impl Iterator<Item = (&(Pair<usize>, &'a str), &Pair<Option<usize>>)> {
+        self.columns
+            .range((Bound::Included(&(table, "")), Bound::Unbounded))
+            .take_while(move |((t, _), _)| *t == table)
+    }
+
+    /// An iterator over the tables that are present in both schemas.
+    pub(crate) fn table_pairs(&self) -> impl Iterator<Item = Pair<TableWalker<'a>>> + '_ {
+        self.tables
+            .values()
+            .filter_map(|p| p.transpose())
+            .map(move |idxs| self.schemas.tables(&idxs))
+    }
+}

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour.rs
@@ -54,6 +54,10 @@ pub(crate) trait SqlSchemaDifferFlavour {
         indexes.previous().name() != indexes.next().name()
     }
 
+    fn lower_cases_table_names(&self) -> bool {
+        false
+    }
+
     /// Evaluate indexes/constraints that need to be dropped and re-created based on other changes in the schema
     fn push_index_changes_for_column_changes(
         &self,

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/mysql.rs
@@ -73,6 +73,10 @@ impl SqlSchemaDifferFlavour for MysqlFlavour {
         }
     }
 
+    fn lower_cases_table_names(&self) -> bool {
+        self.lower_cases_table_names()
+    }
+
     fn should_create_indexes_from_created_tables(&self) -> bool {
         false
     }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/table.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/table.rs
@@ -1,44 +1,37 @@
-use super::column::ColumnDiffer;
+use super::{column::ColumnDiffer, differ_database::DifferDatabase};
 use crate::{flavour::SqlFlavour, pair::Pair};
 use sql_schema_describer::{
     walkers::{ColumnWalker, ForeignKeyWalker, IndexWalker, TableWalker},
     PrimaryKey,
 };
 
-pub(crate) struct TableDiffer<'a> {
+pub(crate) struct TableDiffer<'a, 'b> {
     pub(crate) flavour: &'a dyn SqlFlavour,
     pub(crate) tables: Pair<TableWalker<'a>>,
+    pub(crate) db: &'b DifferDatabase<'a>,
 }
 
-impl<'schema> TableDiffer<'schema> {
+impl<'schema, 'b> TableDiffer<'schema, 'b> {
     pub(crate) fn column_pairs<'a>(&'a self) -> impl Iterator<Item = ColumnDiffer<'schema>> + 'a {
-        self.previous_columns()
-            .filter_map(move |previous_column| {
-                self.next_columns()
-                    .find(|next_column| columns_match(&previous_column, next_column))
-                    .map(|next_column| (previous_column, next_column))
-            })
-            .map(move |(previous, next)| ColumnDiffer {
+        self.db
+            .column_pairs(self.tables.map(|t| t.table_index()))
+            .map(move |colidxs| ColumnDiffer {
                 flavour: self.flavour,
-                previous,
-                next,
+                previous: self.tables.previous().column_at(*colidxs.previous()),
+                next: self.tables.next().column_at(*colidxs.next()),
             })
     }
 
     pub(crate) fn dropped_columns<'a>(&'a self) -> impl Iterator<Item = ColumnWalker<'schema>> + 'a {
-        self.previous_columns().filter(move |previous_column| {
-            self.next_columns()
-                .find(|next_column| columns_match(previous_column, next_column))
-                .is_none()
-        })
+        self.db
+            .dropped_columns(self.tables.map(|t| t.table_index()))
+            .map(move |idx| self.tables.previous().column_at(idx))
     }
 
     pub(crate) fn added_columns<'a>(&'a self) -> impl Iterator<Item = ColumnWalker<'schema>> + 'a {
-        self.next_columns().filter(move |next_column| {
-            self.previous_columns()
-                .find(|previous_column| columns_match(previous_column, next_column))
-                .is_none()
-        })
+        self.db
+            .created_columns(self.tables.map(|t| t.table_index()))
+            .map(move |idx| self.tables.next().column_at(idx))
     }
 
     pub(crate) fn created_foreign_keys<'a>(&'a self) -> impl Iterator<Item = ForeignKeyWalker<'schema>> + 'a {
@@ -137,14 +130,6 @@ impl<'schema> TableDiffer<'schema> {
             .any(|columns| columns.all_changes().0.type_changed())
     }
 
-    fn previous_columns<'a>(&'a self) -> impl Iterator<Item = ColumnWalker<'schema>> + 'a {
-        self.previous().columns()
-    }
-
-    fn next_columns<'a>(&'a self) -> impl Iterator<Item = ColumnWalker<'schema>> + 'a {
-        self.next().columns()
-    }
-
     fn previous_foreign_keys<'a>(&'a self) -> impl Iterator<Item = ForeignKeyWalker<'schema>> + 'a {
         self.previous().foreign_keys()
     }
@@ -168,10 +153,6 @@ impl<'schema> TableDiffer<'schema> {
     pub(super) fn next(&self) -> &TableWalker<'schema> {
         self.tables.next()
     }
-}
-
-pub(crate) fn columns_match(a: &ColumnWalker<'_>, b: &ColumnWalker<'_>) -> bool {
-    a.name() == b.name()
 }
 
 /// Compare two SQL indexes and return whether they only differ by name.


### PR DESCRIPTION
This is increasingly a concern as we add new operations walking the
schema multiple times every time we add more diffing logic.