### PR TITLE
Resolve datasource URL env vars in getConfig

### DIFF
--- a/libs/datamodel/core/src/configuration/configuration.rs
+++ b/libs/datamodel/core/src/configuration/configuration.rs
@@ -27,4 +27,14 @@ impl Configuration {
             .iter()
             .flat_map(|generator| generator.preview_features.iter())
     }
+
+    pub fn resolve_datasource_urls_from_env(&mut self) -> Result<(), Diagnostics> {
+        for datasource in &mut self.datasources {
+            if datasource.url.from_env_var.is_some() && datasource.url.value.is_none() {
+                datasource.url.value = Some(datasource.load_url()?);
+            }
+        }
+
+        Ok(())
+    }
 }

--- a/libs/datamodel/core/src/configuration/env_vars.rs
+++ b/libs/datamodel/core/src/configuration/env_vars.rs
@@ -1,58 +1,37 @@
-use serde::{ser::SerializeStruct, Serialize};
+use serde::Serialize;
 
 /// Either an env var or a string literal.
-#[derive(Clone, Debug, PartialEq)]
-pub enum StringFromEnvVar {
+#[derive(Clone, Debug, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StringFromEnvVar {
     /// Contains the name of env var if the value was read from one.
-    FromEnvVar(String),
+    pub from_env_var: Option<String>,
     /// Contains the string literal, when it was directly in the parsed schema.
-    Literal(String),
-}
-
-impl Serialize for StringFromEnvVar {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let mut s = serializer.serialize_struct("StringFromEnvVar", 2)?;
-
-        match dbg!(self) {
-            StringFromEnvVar::FromEnvVar(var) => {
-                s.serialize_field("fromEnvVar", var)?;
-                s.serialize_field("value", &Option::<String>::None)?;
-            }
-            StringFromEnvVar::Literal(val) => {
-                s.serialize_field("fromEnvVar", &Option::<String>::None)?;
-                s.serialize_field("value", val)?;
-            }
-        }
-
-        s.end()
-    }
+    pub value: Option<String>,
 }
 
 impl StringFromEnvVar {
     pub fn new_from_env_var(env_var_name: String) -> StringFromEnvVar {
-        StringFromEnvVar::FromEnvVar(env_var_name)
+        StringFromEnvVar {
+            from_env_var: Some(env_var_name),
+            value: None,
+        }
     }
 
     pub fn new_literal(value: String) -> StringFromEnvVar {
-        StringFromEnvVar::Literal(value)
+        StringFromEnvVar {
+            from_env_var: None,
+            value: Some(value),
+        }
     }
 
     /// Returns the name of the env var, if env var.
     pub fn as_env_var(&self) -> Option<&str> {
-        match self {
-            StringFromEnvVar::FromEnvVar(var_name) => Some(var_name),
-            _ => None,
-        }
+        self.from_env_var.as_deref()
     }
 
     /// Returns the contents of the string literal, if applicable.
     pub fn as_literal(&self) -> Option<&str> {
-        match self {
-            StringFromEnvVar::Literal(value) => Some(value),
-            _ => None,
-        }
+        self.value.as_deref()
     }
 }

--- a/libs/datamodel/core/tests/config/sources.rs
+++ b/libs/datamodel/core/tests/config/sources.rs
@@ -324,7 +324,10 @@ fn must_succeed_if_env_var_is_missing_but_override_was_provided() {
     let data_source = config.datasources.first().unwrap();
 
     data_source.assert_name("ds");
-    data_source.assert_url(StringFromEnvVar::Literal(url.to_string()));
+    data_source.assert_url(StringFromEnvVar {
+        value: Some(url.to_string()),
+        from_env_var: None,
+    });
 }
 
 #[test]
@@ -344,7 +347,7 @@ fn must_succeed_if_env_var_exists_and_override_was_provided() {
     let data_source = config.datasources.first().unwrap();
 
     data_source.assert_name("ds");
-    data_source.assert_url(StringFromEnvVar::Literal(url.to_string()));
+    assert_eq!(data_source.url.value.as_deref(), Some(url));
 
     // make sure other tests that run afterwards are not run in a modified environment
     std::env::remove_var("DATABASE_URL");
@@ -366,7 +369,7 @@ fn must_succeed_with_overrides() {
     let data_source = config.datasources.first().unwrap();
 
     data_source.assert_name("ds");
-    data_source.assert_url(StringFromEnvVar::Literal(url.to_string()));
+    assert_eq!(data_source.url.value.as_deref(), Some(url));
 }
 
 #[test]

--- a/query-engine/query-engine-napi/src/engine.rs
+++ b/query-engine/query-engine-napi/src/engine.rs
@@ -133,6 +133,11 @@ impl QueryEngine {
             .validate_that_one_datasource_is_provided()
             .map_err(|errors| ApiError::conversion(errors, &datamodel))?;
 
+        config
+            .subject
+            .resolve_datasource_urls_from_env()
+            .map_err(|errors| ApiError::conversion(errors, &datamodel))?;
+
         let ast = datamodel::parse_datamodel(&datamodel)
             .map_err(|errors| ApiError::conversion(errors, &datamodel))?
             .subject;

--- a/query-engine/query-engine/src/cli.rs
+++ b/query-engine/query-engine/src/cli.rs
@@ -110,7 +110,8 @@ impl CliCommand {
         Ok(())
     }
 
-    fn get_config(config: ValidatedConfiguration) -> PrismaResult<()> {
+    fn get_config(mut config: ValidatedConfiguration) -> PrismaResult<()> {
+        config.subject.resolve_datasource_urls_from_env()?;
         let json = datamodel::json::mcf::config_to_mcf_json_value(&config);
         let serialized = serde_json::to_string(&json)?;
 


### PR DESCRIPTION
getConfig broke in https://github.com/prisma/prisma-engines/pull/1896
since the CLI expects the engine to resolve environment variables.

This PR moves StringFromEnvVar back to a struct, preserving for the CLI
which env var the value came from, and explicitly evaluates URLs in
getConfig.