### PR TITLE
Prevent using duplicate model names after renaming

### DIFF
--- a/introspection-engine/connectors/sql-introspection-connector/src/calculate_datamodel.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/calculate_datamodel.rs
@@ -5,11 +5,13 @@ use crate::prisma_1_defaults::*;
 use crate::re_introspection::enrich;
 use crate::sanitize_datamodel_names::sanitize_datamodel_names;
 use crate::version_checker::VersionChecker;
+use crate::SqlError;
 use crate::SqlIntrospectionResult;
 use datamodel::Datamodel;
 use introspection_connector::IntrospectionResult;
 use quaint::connector::SqlFamily;
 use sql_schema_describer::*;
+use std::collections::HashMap;
 use tracing::debug;
 
 /// Calculate a data model from a database schema.
@@ -28,6 +30,8 @@ pub fn calculate_datamodel(
 
     // our opinionation about valid names
     sanitize_datamodel_names(&mut data_model, family);
+
+    validate_duplicates(&data_model)?;
 
     // deduplicating relation field names
     deduplicate_relation_field_names(&mut data_model);
@@ -54,6 +58,35 @@ pub fn calculate_datamodel(
         version,
         warnings,
     })
+}
+
+// if after opionated renames we have duplicated names, e.g. a database with
+// tables `a` and `_a`, the tables in the data model (`a` and `a`) would
+// cause really weird errors
+fn validate_duplicates(data_model: &Datamodel) -> SqlIntrospectionResult<()> {
+    debug!("Validating duplicates");
+
+    let mut names: HashMap<&str, Option<&str>> = HashMap::new();
+
+    for model in data_model.models() {
+        if names.contains_key(model.name.as_str()) {
+            let db_name = match names.get(model.name.as_str()) {
+                Some(Some(db_name)) => db_name,
+                _ => model.database_name.as_deref().unwrap(),
+            };
+
+            let explanation = format!(
+                "Due to name sanitization, table `{}` was renamed to `{}` in the data model, being not a unique name anymore. Consider renaming one of the tables.",
+                db_name, model.name
+            );
+
+            return Err(SqlError::SchemaInconsistent { explanation });
+        } else {
+            names.insert(model.name.as_str(), model.database_name.as_deref());
+        }
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/introspection-engine/connectors/sql-introspection-connector/src/sanitize_datamodel_names.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/sanitize_datamodel_names.rs
@@ -18,6 +18,26 @@ pub fn sanitize_datamodel_names(datamodel: &mut Datamodel, family: &SqlFamily) {
     sanitize_enums(datamodel, &enum_renames);
 }
 
+// if after opionated renames we have duplicated names, e.g. a database with
+// tables `a` and `_a`, the tables in the data model (`a` and `a`) would
+// cause really weird errors
+pub fn sanitization_leads_to_duplicate_names(datamodel: &Datamodel) -> bool {
+    for model in datamodel.models() {
+        let sanitized = sanitize_string(&model.name);
+
+        let dups = datamodel
+            .models()
+            .filter(|m| sanitize_string(m.name()) == sanitized)
+            .count();
+
+        if dups > 1 {
+            return true;
+        }
+    }
+
+    false
+}
+
 // Todo: Sanitizing might need to be adjusted to also change the fields in the RelationInfo
 fn sanitize_models(datamodel: &mut Datamodel, family: &SqlFamily) -> HashMap<String, (String, Option<String>)> {
     let mut enum_renames = HashMap::new();

--- a/introspection-engine/introspection-engine-tests/tests/remapping_database_names/mod.rs
+++ b/introspection-engine/introspection-engine-tests/tests/remapping_database_names/mod.rs
@@ -6,6 +6,33 @@ use quaint::prelude::Queryable;
 use test_macros::test_connector;
 
 #[test_connector]
+async fn remapping_name_clashes_should_error(api: &TestApi) -> TestResult {
+    api.barrel()
+        .execute(|migration| {
+            migration.create_table("a", |t| {
+                t.add_column("id", types::primary());
+            });
+
+            migration.create_table("_a", |t| {
+                t.add_column("a_a", types::integer().nullable(false));
+                t.add_column("a_b", types::integer().nullable(false));
+                t.add_foreign_key(&["a_a"], "a", &["id"]);
+                t.add_foreign_key(&["a_b"], "a", &["id"]);
+            });
+        })
+        .await?;
+
+    let error_msg = format!("{}", api.introspect().await.unwrap_err());
+
+    assert_eq!(
+        "Could not introspect the database since the schema was inconsistent. Due to name sanitization, table `_a` was renamed to `a` in the data model, being not a unique name anymore. Consider renaming one of the tables.",
+        &error_msg,
+    );
+
+    Ok(())
+}
+
+#[test_connector]
 async fn remapping_fields_with_invalid_characters(api: &TestApi) -> TestResult {
     api.barrel()
         .execute(|migration| {


### PR DESCRIPTION
In a case where the database has tables, such as `_a` and `a`, our internal renaming will rename `_a` to `a`, rendering very tricky errors all over the place that are extra hard to debug.

Here we take a decision to not allow databases with "duplicates" such as this case, and ask the user to rename one of the tables before continuing.

Closes: https://github.com/prisma/prisma/issues/6861