### PR TITLE
Fix prisma/prisma#4602

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour.rs
@@ -25,6 +25,12 @@ pub(crate) trait SqlSchemaDifferFlavour {
         true
     }
 
+    /// Returns true only if the database can cope with an optional column
+    /// constrained by a foreign key being made NOT NULL.
+    fn can_cope_with_foreign_key_column_becoming_nonnullable(&self) -> bool {
+        true
+    }
+
     /// Return whether a column's type needs to be migrated, and how.
     fn column_type_change(&self, differ: &ColumnDiffer<'_>) -> Option<ColumnTypeChange> {
         if differ.previous.column_type_family() != differ.next.column_type_family() {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/mysql.rs
@@ -11,6 +11,10 @@ impl SqlSchemaDifferFlavour for MysqlFlavour {
         !self.is_mariadb() && !self.is_mysql_5_6()
     }
 
+    fn can_cope_with_foreign_key_column_becoming_nonnullable(&self) -> bool {
+        false
+    }
+
     fn column_type_change(&self, differ: &ColumnDiffer<'_>) -> Option<ColumnTypeChange> {
         // On MariaDB, JSON is an alias for LONGTEXT. https://mariadb.com/kb/en/json-data-type/
         if self.is_mariadb() {


### PR DESCRIPTION
MySQL cannot deal with nullable columns constrained by foreign keys
becoming NOT NULL. Solution: drop and recreate the foreign key.

Second commit is a small unrelated refactoring.

closes https://github.com/prisma/prisma/issues/4602