### PR TITLE
Improve timeout error diagnostics in ME

### DIFF
--- a/libs/user-facing-errors/src/common.rs
+++ b/libs/user-facing-errors/src/common.rs
@@ -44,6 +44,8 @@ The database server at `{database_host}`:`{database_port}` was reached but timed
 Please try again.
 
 Please make sure your database server is running at `{database_host}`:`{database_port}`.
+
+Context: {context}
 "
 )]
 pub struct DatabaseTimeout {
@@ -52,6 +54,9 @@ pub struct DatabaseTimeout {
 
     /// Database port
     pub database_port: String,
+
+    /// Extra context
+    pub context: String,
 }
 
 #[derive(Debug, UserFacingError, Serialize)]
@@ -83,10 +88,13 @@ pub enum DatabaseDoesNotExist {
 }
 
 #[derive(Debug, UserFacingError, Serialize)]
-#[user_facing(code = "P1008", message = "Operations timed out after `{time}`")]
+#[user_facing(code = "P1008", message = "Operations timed out after `{time}`. Context: {context}")]
 pub struct DatabaseOperationTimeout {
     /// Operation time in s or ms (if <1000ms)
     pub time: String,
+
+    /// Extra context
+    pub context: String,
 }
 
 #[derive(Debug, UserFacingError, Serialize)]

--- a/libs/user-facing-errors/src/quaint.rs
+++ b/libs/user-facing-errors/src/quaint.rs
@@ -160,7 +160,11 @@ pub fn render_quaint_error(kind: &ErrorKind, connection_info: &ConnectionInfo) -
                 None => String::from("N/A"),
             };
 
-            Some(KnownError::new(common::DatabaseOperationTimeout { time }))
+            Some(KnownError::new(common::DatabaseOperationTimeout {
+                time,
+                context: "Socket timeout (the database failed to respond to a query within the configured timeout — see https://pris.ly/d/mysql-connector for more details.)."
+                    .into(),
+            }))
         }
 
         (ErrorKind::SocketTimeout, ConnectionInfo::Postgres(url)) => {
@@ -169,7 +173,11 @@ pub fn render_quaint_error(kind: &ErrorKind, connection_info: &ConnectionInfo) -
                 None => String::from("N/A"),
             };
 
-            Some(KnownError::new(common::DatabaseOperationTimeout { time }))
+            Some(KnownError::new(common::DatabaseOperationTimeout {
+                time,
+                context: "Socket timeout (the database failed to respond to a query within the configured timeout — see https://pris.ly/d/mssql-connector for more details.)."
+                    .into(),
+            }))
         }
 
         (ErrorKind::SocketTimeout, ConnectionInfo::Mssql(url)) => {
@@ -178,7 +186,11 @@ pub fn render_quaint_error(kind: &ErrorKind, connection_info: &ConnectionInfo) -
                 None => String::from("N/A"),
             };
 
-            Some(KnownError::new(common::DatabaseOperationTimeout { time }))
+            Some(KnownError::new(common::DatabaseOperationTimeout {
+                time,
+                context: "Socket timeout (the database failed to respond to a query within the configured timeout — see https://pris.ly/d/postgres-connector for more details.)."
+                    .into(),
+            }))
         }
 
         (ErrorKind::PoolTimeout { max_open, .. }, _) => Some(KnownError::new(query_engine::PoolTimeout {

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/postgres.rs
@@ -103,6 +103,9 @@ impl SqlFlavour for PostgresFlavour {
                     .port()
                     .map(|port| port.to_string())
                     .unwrap_or_else(|| "<unknown>".into()),
+                context: format!(
+                    "Timed out trying to acquire a postgres advisory lock (SELECT pg_advisory_lock(72707369)). Elapsed: {}ms. See https://pris.ly/d/migrate-advisory-locking for details.", ADVISORY_LOCK_TIMEOUT.as_millis()
+                ),
             })
         })??;
 

--- a/migration-engine/migration-engine-tests/compile-bench.md
+++ b/migration-engine/migration-engine-tests/compile-bench.md
@@ -1,3 +1,3 @@
 | Command | Mean [s] | Min [s] | Max [s] | Relative |
 |:---|---:|---:|---:|---:|
-| `cargo build --tests` | 15.123 ± 0.224 | 14.878 | 15.534 | 1.00 |
+| `cargo build --tests` | 15.083 ± 0.061 | 15.002 | 15.194 | 1.00 |

--- a/migration-engine/migration-engine-tests/src/multi_engine_test_api.rs
+++ b/migration-engine/migration-engine-tests/src/multi_engine_test_api.rs
@@ -97,6 +97,11 @@ impl TestApi {
         tempfile::tempdir().unwrap()
     }
 
+    /// Render a valid datasource block, including database URL.
+    pub fn datasource_block(&self) -> String {
+        self.args.datasource_block(self.args.database_url())
+    }
+
     /// Returns true only when testing on MSSQL.
     pub fn is_mssql(&self) -> bool {
         self.tags().contains(Tags::Mssql)


### PR DESCRIPTION
MySQL cannot deal with nullable columns constrained by foreign keys
becoming NOT NULL. Solution: drop and recreate the foreign key.