### PR TITLE
Delete one of the two rustfmt.toml files

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,2 +1,0 @@
-edition = "2018"
-max_width = 120


### PR DESCRIPTION
We have both .rustfmt.toml and rustfmt.toml. They are identical. This
commit deletes .rustfmt.toml.

Rusfmt and rust-analyzer take both files into account, so tooling should
continue to work exactly the same. Let's see if this breaks anything.