### PR TITLE
Syncify ME enum tests

### DIFF
--- a/migration-engine/migration-engine-tests/tests/migrations/enums.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/enums.rs
@@ -1,4 +1,4 @@
-use migration_engine_tests::sql::*;
+use migration_engine_tests::multi_engine_test_api::*;
 
 const BASIC_ENUM_DM: &str = r#"
 model Cat {
@@ -13,19 +13,26 @@ enum CatMood {
 "#;
 
 #[test_connector(capabilities(Enums))]
-async fn an_enum_can_be_turned_into_a_model(api: &TestApi) -> TestResult {
-    api.schema_push(BASIC_ENUM_DM).send().await?.assert_green()?;
+fn an_enum_can_be_turned_into_a_model(api: TestApi) {
+    let engine = api.new_engine();
 
-    let enum_name = if api.lower_case_identifiers() {
+    engine
+        .schema_push(BASIC_ENUM_DM)
+        .send_sync()
+        .unwrap()
+        .assert_green()
+        .unwrap();
+
+    let enum_name = if api.lower_cases_table_names() {
         "cat_mood"
-    } else if api.sql_family().is_mysql() {
+    } else if api.is_mysql() {
         "Cat_mood"
     } else {
         "CatMood"
     };
 
     #[allow(clippy::redundant_closure)]
-    api.assert_schema().await?.assert_enum(enum_name, |enm| Ok(enm))?;
+    engine.assert_schema().assert_enum(enum_name, |enm| Ok(enm)).unwrap();
 
     let dm2 = r#"
         model Cat {
@@ -42,21 +49,23 @@ async fn an_enum_can_be_turned_into_a_model(api: &TestApi) -> TestResult {
         }
     "#;
 
-    api.schema_push(dm2).send().await?.assert_green()?;
+    engine.schema_push(dm2).send_sync().unwrap().assert_green().unwrap();
 
-    api.assert_schema()
-        .await?
+    engine
+        .assert_schema()
         .assert_table("Cat", |table| {
             table.assert_columns_count(2)?.assert_column("moodId", Ok)
-        })?
-        .assert_table("CatMood", |table| table.assert_column_count(3))?
-        .assert_has_no_enum("CatMood")?;
-
-    Ok(())
+        })
+        .unwrap()
+        .assert_table("CatMood", |table| table.assert_column_count(3))
+        .unwrap()
+        .assert_has_no_enum("CatMood")
+        .unwrap();
 }
 
 #[test_connector(capabilities(Enums))]
-async fn variants_can_be_added_to_an_existing_enum(api: &TestApi) -> TestResult {
+fn variants_can_be_added_to_an_existing_enum(api: TestApi) {
+    let engine = api.new_engine();
     let dm1 = r#"
         model Cat {
             id Int @id
@@ -68,19 +77,20 @@ async fn variants_can_be_added_to_an_existing_enum(api: &TestApi) -> TestResult 
         }
     "#;
 
-    api.schema_push(dm1).send().await?.assert_green()?;
+    engine.schema_push(dm1).send_sync().unwrap().assert_green().unwrap();
 
-    let enum_name = if api.lower_case_identifiers() {
+    let enum_name = if api.lower_cases_table_names() {
         "cat_mood"
-    } else if api.sql_family().is_mysql() {
+    } else if api.is_mysql() {
         "Cat_mood"
     } else {
         "CatMood"
     };
 
-    api.assert_schema()
-        .await?
-        .assert_enum(enum_name, |enm| enm.assert_values(&["HUNGRY"]))?;
+    engine
+        .assert_schema()
+        .assert_enum(enum_name, |enm| enm.assert_values(&["HUNGRY"]))
+        .unwrap();
 
     let dm2 = r#"
         model Cat {
@@ -95,17 +105,18 @@ async fn variants_can_be_added_to_an_existing_enum(api: &TestApi) -> TestResult 
         }
     "#;
 
-    api.schema_push(dm2).send().await?.assert_green()?;
+    engine.schema_push(dm2).send_sync().unwrap().assert_green().unwrap();
 
-    api.assert_schema()
-        .await?
-        .assert_enum(enum_name, |enm| enm.assert_values(&["HUNGRY", "HAPPY", "JOYJOY"]))?;
-
-    Ok(())
+    engine
+        .assert_schema()
+        .assert_enum(enum_name, |enm| enm.assert_values(&["HUNGRY", "HAPPY", "JOYJOY"]))
+        .unwrap();
 }
 
 #[test_connector(capabilities(Enums))]
-async fn variants_can_be_removed_from_an_existing_enum(api: &TestApi) -> TestResult {
+fn variants_can_be_removed_from_an_existing_enum(api: TestApi) {
+    let engine = api.new_engine();
+
     let dm1 = r#"
         model Cat {
             id Int @id
@@ -118,19 +129,20 @@ async fn variants_can_be_removed_from_an_existing_enum(api: &TestApi) -> TestRes
         }
     "#;
 
-    api.schema_push(dm1).send().await?.assert_green()?;
+    engine.schema_push(dm1).send_sync().unwrap().assert_green().unwrap();
 
-    let enum_name = if api.lower_case_identifiers() {
+    let enum_name = if api.lower_cases_table_names() {
         "cat_mood"
-    } else if api.sql_family().is_mysql() {
+    } else if api.is_mysql() {
         "Cat_mood"
     } else {
         "CatMood"
     };
 
-    api.assert_schema()
-        .await?
-        .assert_enum(enum_name, |enm| enm.assert_values(&["HAPPY", "HUNGRY"]))?;
+    engine
+        .assert_schema()
+        .assert_enum(enum_name, |enm| enm.assert_values(&["HAPPY", "HUNGRY"]))
+        .unwrap();
 
     let dm2 = r#"
         model Cat {
@@ -143,58 +155,64 @@ async fn variants_can_be_removed_from_an_existing_enum(api: &TestApi) -> TestRes
         }
     "#;
 
-    let warning = if api.sql_family().is_mysql() {
+    let warning = if api.is_mysql() {
         "The values [HAPPY] on the enum `Cat_mood` will be removed. If these variants are still used in the database, this will fail."
     } else {
         "The values [HAPPY] on the enum `CatMood` will be removed. If these variants are still used in the database, this will fail."
     };
 
-    api.schema_push(dm2)
+    engine
+        .schema_push(dm2)
         .force(true)
-        .send()
-        .await?
-        .assert_warnings(&[warning.into()])?
-        .assert_executable()?;
+        .send_sync()
+        .unwrap()
+        .assert_warnings(&[warning.into()])
+        .unwrap()
+        .assert_executable()
+        .unwrap();
 
-    api.assert_schema()
-        .await?
-        .assert_enum(enum_name, |enm| enm.assert_values(&["HUNGRY"]))?;
-
-    Ok(())
+    engine
+        .assert_schema()
+        .assert_enum(enum_name, |enm| enm.assert_values(&["HUNGRY"]))
+        .unwrap();
 }
 
 #[test_connector(capabilities(Enums))]
-async fn models_with_enum_values_can_be_dropped(api: &TestApi) -> TestResult {
-    api.schema_push(BASIC_ENUM_DM).send().await?.assert_green()?;
+fn models_with_enum_values_can_be_dropped(api: TestApi) {
+    let engine = api.new_engine();
+    engine
+        .schema_push(BASIC_ENUM_DM)
+        .send_sync()
+        .unwrap()
+        .assert_green()
+        .unwrap();
 
-    api.assert_schema().await?.assert_tables_count(1)?;
+    engine.assert_schema().assert_tables_count(1).unwrap();
 
-    api.insert("Cat")
-        .value("id", 1)
-        .value("mood", "HAPPY")
-        .result_raw()
-        .await?;
+    engine.insert("Cat").value("id", 1).value("mood", "HAPPY").result_raw();
 
-    let warn = if api.lower_case_identifiers() {
+    let warn = if api.lower_cases_table_names() {
         "You are about to drop the `cat` table, which is not empty (1 rows)."
     } else {
         "You are about to drop the `Cat` table, which is not empty (1 rows)."
     };
 
-    api.schema_push("")
+    engine
+        .schema_push("")
         .force(true)
-        .send()
-        .await?
-        .assert_executable()?
-        .assert_warnings(&[warn.into()])?;
+        .send_sync()
+        .unwrap()
+        .assert_executable()
+        .unwrap()
+        .assert_warnings(&[warn.into()])
+        .unwrap();
 
-    api.assert_schema().await?.assert_tables_count(0)?;
-
-    Ok(())
+    engine.assert_schema().assert_tables_count(0).unwrap();
 }
 
 #[test_connector(capabilities(Enums))]
-async fn enum_field_to_string_field_works(api: &TestApi) -> TestResult {
+fn enum_field_to_string_field_works(api: TestApi) {
+    let engine = api.new_engine();
     let dm1 = r#"
         model Cat {
             id Int @id
@@ -207,17 +225,16 @@ async fn enum_field_to_string_field_works(api: &TestApi) -> TestResult {
         }
     "#;
 
-    api.schema_push(dm1).send().await?.assert_green()?;
+    engine.schema_push(dm1).send_sync().unwrap().assert_green().unwrap();
 
-    api.assert_schema().await?.assert_table("Cat", |table| {
-        table.assert_column("mood", |col| col.assert_type_is_enum())
-    })?;
+    engine
+        .assert_schema()
+        .assert_table("Cat", |table| {
+            table.assert_column("mood", |col| col.assert_type_is_enum())
+        })
+        .unwrap();
 
-    api.insert("Cat")
-        .value("id", 1)
-        .value("mood", "HAPPY")
-        .result_raw()
-        .await?;
+    engine.insert("Cat").value("id", 1).value("mood", "HAPPY").result_raw();
 
     let dm2 = r#"
         model Cat {
@@ -226,17 +243,25 @@ async fn enum_field_to_string_field_works(api: &TestApi) -> TestResult {
         }
     "#;
 
-    api.schema_push(dm2).force(true).send().await?.assert_executable()?;
+    engine
+        .schema_push(dm2)
+        .force(true)
+        .send_sync()
+        .unwrap()
+        .assert_executable()
+        .unwrap();
 
-    api.assert_schema().await?.assert_table("Cat", |table| {
-        table.assert_column("mood", |col| col.assert_type_is_string())
-    })?;
-
-    Ok(())
+    engine
+        .assert_schema()
+        .assert_table("Cat", |table| {
+            table.assert_column("mood", |col| col.assert_type_is_string())
+        })
+        .unwrap();
 }
 
 #[test_connector(capabilities(Enums))]
-async fn string_field_to_enum_field_works(api: &TestApi) -> TestResult {
+fn string_field_to_enum_field_works(api: TestApi) {
+    let engine = api.new_engine();
     let dm1 = r#"
         model Cat {
             id      Int @id
@@ -244,17 +269,16 @@ async fn string_field_to_enum_field_works(api: &TestApi) -> TestResult {
         }
     "#;
 
-    api.schema_push(dm1).send().await?.assert_green()?;
+    engine.schema_push(dm1).send_sync().unwrap().assert_green().unwrap();
 
-    api.assert_schema().await?.assert_table("Cat", |table| {
-        table.assert_column("mood", |col| col.assert_type_is_string())
-    })?;
+    engine
+        .assert_schema()
+        .assert_table("Cat", |table| {
+            table.assert_column("mood", |col| col.assert_type_is_string())
+        })
+        .unwrap();
 
-    api.insert("Cat")
-        .value("id", 1)
-        .value("mood", "HAPPY")
-        .result_raw()
-        .await?;
+    engine.insert("Cat").value("id", 1).value("mood", "HAPPY").result_raw();
 
     let dm2 = r#"
         model Cat {
@@ -270,28 +294,34 @@ async fn string_field_to_enum_field_works(api: &TestApi) -> TestResult {
 
     let warn = if api.is_postgres() {
         "The `mood` column on the `Cat` table would be dropped and recreated. This will lead to data loss."
-    } else if api.lower_case_identifiers() {
+    } else if api.lower_cases_table_names() {
         "You are about to alter the column `mood` on the `cat` table, which contains 1 non-null values. The data in that column will be cast from `VarChar(191)` to `Enum(\"Cat_mood\")`."
     } else {
         "You are about to alter the column `mood` on the `Cat` table, which contains 1 non-null values. The data in that column will be cast from `VarChar(191)` to `Enum(\"Cat_mood\")`."
     };
 
-    api.schema_push(dm2)
+    engine
+        .schema_push(dm2)
         .force(true)
-        .send()
-        .await?
-        .assert_executable()?
-        .assert_warnings(&[warn.into()])?;
+        .send_sync()
+        .unwrap()
+        .assert_executable()
+        .unwrap()
+        .assert_warnings(&[warn.into()])
+        .unwrap();
 
-    api.assert_schema().await?.assert_table("Cat", |table| {
-        table.assert_column("mood", |col| col.assert_type_is_enum())
-    })?;
-
-    Ok(())
+    engine
+        .assert_schema()
+        .assert_table("Cat", |table| {
+            table.assert_column("mood", |col| col.assert_type_is_enum())
+        })
+        .unwrap();
 }
 
 #[test_connector(capabilities(Enums))]
-async fn enums_used_in_default_can_be_changed(api: &TestApi) -> TestResult {
+fn enums_used_in_default_can_be_changed(api: TestApi) {
+    let engine = api.new_engine();
+
     let dm1 = r#"
         model Panther {
             id Int @id
@@ -329,9 +359,9 @@ async fn enums_used_in_default_can_be_changed(api: &TestApi) -> TestResult {
         }
     "#;
 
-    api.schema_push(dm1).send().await?.assert_green()?;
+    engine.schema_push(dm1).send_sync().unwrap().assert_green().unwrap();
 
-    api.assert_schema().await?.assert_tables_count(5)?;
+    engine.assert_schema().assert_tables_count(5).unwrap();
 
     let dm2 = r#"
         model Panther {
@@ -372,31 +402,29 @@ async fn enums_used_in_default_can_be_changed(api: &TestApi) -> TestResult {
     "#;
 
     if api.is_postgres() {
-        api.schema_push(dm2)
+        engine.schema_push(dm2)
             .force(true)
-            .send()
-            .await?
-            .assert_executable()?
+            .send_sync()
+            .unwrap()
+            .assert_executable().unwrap()
             .assert_warnings(&["The values [HUNGRY] on the enum `CatMood` will be removed. If these variants are still used in the database, this will fail.".into()]
-            )?;
+            ).unwrap();
     } else {
-        api.schema_push(dm2)
+        engine.schema_push(dm2)
             .force(true)
-            .send()
-            .await?
-            .assert_executable()?
+            .send_sync().unwrap()
+            .assert_executable().unwrap()
             .assert_warnings(& ["The values [HUNGRY] on the enum `Panther_mood` will be removed. If these variants are still used in the database, this will fail.".into(),
                 "The values [HUNGRY] on the enum `Tiger_mood` will be removed. If these variants are still used in the database, this will fail.".into(),]
-            )?;
+            ).unwrap();
     };
 
-    api.assert_schema().await?.assert_tables_count(5)?;
-
-    Ok(())
+    engine.assert_schema().assert_tables_count(5).unwrap();
 }
 
 #[test_connector(capabilities(Enums))]
-async fn changing_all_values_of_enums_used_in_defaults_works(api: &TestApi) -> TestResult {
+fn changing_all_values_of_enums_used_in_defaults_works(api: TestApi) {
+    let api = api.new_engine();
     let dm1 = r#"
         model Cat {
             id Int @id
@@ -413,7 +441,7 @@ async fn changing_all_values_of_enums_used_in_defaults_works(api: &TestApi) -> T
         }
     "#;
 
-    api.schema_push(dm1).send().await?.assert_green()?;
+    api.schema_push(dm1).send_sync().unwrap().assert_green().unwrap();
 
     let dm2 = r#"
         model Cat {
@@ -433,11 +461,11 @@ async fn changing_all_values_of_enums_used_in_defaults_works(api: &TestApi) -> T
         }
     "#;
 
-    api.schema_push(dm2).force(true).send().await?;
+    api.schema_push(dm2).force(true).send_sync().unwrap();
 
-    api.assert_schema().await?.assert_table("Cat", |table| {
-        table.assert_column("eveningMood", |col| Ok(col.assert_enum_default("MEOWMEOW")))
-    })?;
-
-    Ok(())
+    api.assert_schema()
+        .assert_table("Cat", |table| {
+            table.assert_column("eveningMood", |col| Ok(col.assert_enum_default("MEOWMEOW")))
+        })
+        .unwrap();
 }


### PR DESCRIPTION
This branch was initially meant for a repro and fix for
https://github.com/prisma/prisma/issues/6458, but as you can see there,
that didn't work out. The diff is part of the progressive simplification
of ME tests.