### PR TITLE
Remove custom timeout logic from IE

### DIFF
--- a/introspection-engine/connectors/sql-introspection-connector/Cargo.toml
+++ b/introspection-engine/connectors/sql-introspection-connector/Cargo.toml
@@ -25,7 +25,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1.0", features = ["float_roundtrip"] }
 sql-schema-describer = { path = "../../../libs/sql-schema-describer" }
 thiserror = "1.0.9"
-tokio = { version = "1.0", features = ["rt-multi-thread", "time"] }
+tokio = { version = "1.0", features = ["rt-multi-thread"] }
 tracing = "0.1.10"
 tracing-futures = "0.2.0"
 user-facing-errors = { path = "../../../libs/user-facing-errors", features = ["sql"] }


### PR DESCRIPTION
We have a `connect_timeout` url parameter that is used by quaint, so we
do not need to have custom timeout logic in the introspection engine.

Closes https://github.com/prisma/prisma/issues/7036