### PR TITLE
Start #[track_caller] based simplifications in ME tests

### DIFF
--- a/migration-engine/migration-engine-tests/compile-bench.md
+++ b/migration-engine/migration-engine-tests/compile-bench.md
@@ -1,3 +1,3 @@
 | Command | Mean [s] | Min [s] | Max [s] | Relative |
 |:---|---:|---:|---:|---:|
-| `cargo build --tests` | 15.083 ± 0.061 | 15.002 | 15.194 | 1.00 |
+| `cargo build --tests` | 14.357 ± 0.185 | 14.194 | 14.710 | 1.00 |

--- a/migration-engine/migration-engine-tests/src/lib.rs
+++ b/migration-engine/migration-engine-tests/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod multi_engine_test_api;
 pub mod sql;
+pub mod sync_test_api;
 
 mod assertions;
 mod test_api;

--- a/migration-engine/migration-engine-tests/src/sync_test_api.rs
+++ b/migration-engine/migration-engine-tests/src/sync_test_api.rs
@@ -1,0 +1,172 @@
+use migration_connector::MigrationPersistence;
+use tempfile::TempDir;
+pub use test_macros::test_connector;
+pub use test_setup::{BitFlags, Capabilities, Tags};
+
+use crate::{
+    multi_engine_test_api::TestApi as RootTestApi, ApplyMigrations, CreateMigration, SchemaAssertion, SchemaPush,
+};
+use quaint::prelude::{Queryable, ResultSet};
+use sql_migration_connector::SqlMigrationConnector;
+use std::future::Future;
+use test_setup::TestApiArgs;
+
+pub struct TestApi {
+    root: RootTestApi,
+    connector: SqlMigrationConnector,
+}
+
+impl TestApi {
+    /// Initializer, called by the test macros.
+    pub fn new(args: TestApiArgs) -> Self {
+        let root = RootTestApi::new(args);
+        let connector = root.new_engine().connector;
+
+        TestApi { root, connector }
+    }
+
+    /// Plan an `applyMigrations` command
+    pub fn apply_migrations<'a>(&'a self, migrations_directory: &'a TempDir) -> ApplyMigrations<'a> {
+        ApplyMigrations::new_sync(&self.connector, migrations_directory, &self.root.rt)
+    }
+
+    pub fn connection_string(&self) -> &str {
+        self.root.connection_string()
+    }
+
+    /// Plan a `createMigration` command
+    pub fn create_migration<'a>(
+        &'a self,
+        name: &'a str,
+        schema: &'a str,
+        migrations_directory: &'a TempDir,
+    ) -> CreateMigration<'a> {
+        CreateMigration::new_sync(&self.connector, name, schema, migrations_directory, &self.root.rt)
+    }
+
+    /// Create a temporary directory to serve as a test migrations directory.
+    pub fn create_migrations_directory(&self) -> TempDir {
+        self.root.create_migrations_directory()
+    }
+
+    /// Returns true only when testing on MSSQL.
+    pub fn is_mssql(&self) -> bool {
+        self.root.is_mssql()
+    }
+
+    /// Returns true only when testing on MySQL.
+    pub fn is_mysql(&self) -> bool {
+        self.root.is_mysql()
+    }
+
+    /// Returns true only when testing on MariaDB.
+    pub fn is_mysql_mariadb(&self) -> bool {
+        self.root.is_mysql_mariadb()
+    }
+
+    /// Returns true only when testing on MySQL 5.6.
+    pub fn is_mysql_5_6(&self) -> bool {
+        self.root.is_mysql_5_6()
+    }
+
+    /// Returns true only when testing on MySQL 8.
+    pub fn is_mysql_8(&self) -> bool {
+        self.root.is_mysql_8()
+    }
+
+    /// Returns true only when testing on postgres.
+    pub fn is_postgres(&self) -> bool {
+        self.root.is_postgres()
+    }
+
+    /// Returns true only when testing on sqlite.
+    pub fn is_sqlite(&self) -> bool {
+        self.root.is_sqlite()
+    }
+
+    /// Returns true only when testing on vitess.
+    pub fn is_vitess(&self) -> bool {
+        self.root.is_vitess()
+    }
+
+    /// Insert test values
+    pub fn insert<'a>(&'a self, table_name: &'a str) -> SingleRowInsert<'a> {
+        SingleRowInsert {
+            insert: quaint::ast::Insert::single_into(self.render_table_name(table_name)),
+            api: self,
+        }
+    }
+
+    pub fn lower_cases_table_names(&self) -> bool {
+        self.root.lower_cases_table_names()
+    }
+
+    pub fn migration_persistence<'a>(&'a self) -> &(dyn MigrationPersistence + 'a) {
+        &self.connector
+    }
+
+    /// Assert facts about the database schema
+    pub fn assert_schema(&self) -> SchemaAssertion {
+        SchemaAssertion::new(
+            self.root.block_on(self.connector.describe_schema()).unwrap(),
+            self.root.args.tags(),
+        )
+    }
+
+    /// Block on a future
+    pub fn block_on<O, F: Future<Output = O>>(&self, f: F) -> O {
+        self.root.block_on(f)
+    }
+
+    /// Render a valid datasource block, including database URL.
+    pub fn datasource_block(&self) -> String {
+        self.root.args.datasource_block(self.root.args.database_url())
+    }
+
+    /// Same as quaint::Queryable::query()
+    pub fn query(&self, q: quaint::ast::Query<'_>) -> ResultSet {
+        self.root.block_on(self.connector.quaint().query(q)).unwrap()
+    }
+
+    /// Send a SQL command to the database, and expect it to succeed.
+    pub fn raw_cmd(&self, sql: &str) {
+        self.root.raw_cmd(sql)
+    }
+
+    /// Render a table name with the required prefixing for use with quaint query building.
+    pub fn render_table_name<'a>(&'a self, table_name: &'a str) -> quaint::ast::Table<'a> {
+        if self.root.is_sqlite() {
+            table_name.into()
+        } else {
+            (self.connector.quaint().connection_info().schema_name(), table_name).into()
+        }
+    }
+
+    /// Plan a `schemaPush` command
+    pub fn schema_push(&self, dm: impl Into<String>) -> SchemaPush<'_> {
+        SchemaPush::new_sync(&self.connector, dm.into(), &self.root.rt)
+    }
+
+    pub fn tags(&self) -> BitFlags<Tags> {
+        self.root.args.tags()
+    }
+}
+
+pub struct SingleRowInsert<'a> {
+    insert: quaint::ast::SingleRowInsert<'a>,
+    api: &'a TestApi,
+}
+
+impl<'a> SingleRowInsert<'a> {
+    /// Add a value to the row
+    pub fn value(mut self, name: &'a str, value: impl Into<quaint::ast::Expression<'a>>) -> Self {
+        self.insert = self.insert.value(name, value);
+
+        self
+    }
+
+    /// Execute the request and return the result set.
+    pub fn result_raw(self) -> quaint::connector::ResultSet {
+        self.api.query(self.insert.into())
+    }
+}

--- a/migration-engine/migration-engine-tests/src/test_api/create_migration.rs
+++ b/migration-engine/migration-engine-tests/src/test_api/create_migration.rs
@@ -1,5 +1,7 @@
 use anyhow::Context;
-use migration_core::{commands::CreateMigrationInput, commands::CreateMigrationOutput, CoreResult, GenericApi};
+use migration_core::{
+    commands::CreateMigrationInput, commands::CreateMigrationOutput, CoreError, CoreResult, GenericApi,
+};
 use pretty_assertions::assert_eq;
 use std::path::Path;
 use tempfile::TempDir;
@@ -63,8 +65,14 @@ impl<'a> CreateMigration<'a> {
         })
     }
 
-    pub fn send_sync(self) -> CoreResult<CreateMigrationAssertion<'a>> {
-        self.rt.unwrap().block_on(self.send())
+    #[track_caller]
+    pub fn send_sync(self) -> CreateMigrationAssertion<'a> {
+        self.rt.unwrap().block_on(self.send()).unwrap()
+    }
+
+    #[track_caller]
+    pub fn send_unwrap_err(self) -> CoreError {
+        self.rt.unwrap().block_on(self.send()).unwrap_err()
     }
 }
 
@@ -83,13 +91,15 @@ impl std::fmt::Debug for CreateMigrationAssertion<'_> {
 impl<'a> CreateMigrationAssertion<'a> {
     /// Assert that there are `expected_count` migrations in the migrations directory.
     #[tracing::instrument(skip(self))]
-    pub fn assert_migration_directories_count(self, expected_count: usize) -> AssertionResult<Self> {
+    #[track_caller]
+    pub fn assert_migration_directories_count(self, expected_count: usize) -> Self {
         let mut count = 0;
 
         for entry in std::fs::read_dir(self.migrations_directory.path())
-            .context("Counting directories in migrations directory.")?
+            .context("Counting directories in migrations directory.")
+            .unwrap()
         {
-            let entry = entry?;
+            let entry = entry.unwrap();
 
             if entry.path().file_name().and_then(|s| s.to_str()) == Some("migration_lock.toml") {
                 continue;
@@ -98,7 +108,7 @@ impl<'a> CreateMigrationAssertion<'a> {
             count += 1;
         }
 
-        anyhow::ensure!(
+        assert!(
             // the lock file is counted as an entry
             expected_count == count,
             "Assertion failed. Expected {expected} migrations in the migrations directory, found {actual}.",
@@ -106,7 +116,7 @@ impl<'a> CreateMigrationAssertion<'a> {
             actual = count
         );
 
-        Ok(self)
+        self
     }
 
     /// Assert that there is one migration with `name_matcher` contained in its name present in the migration directory.
@@ -147,7 +157,8 @@ impl<'a> CreateMigrationAssertion<'a> {
         &self.output
     }
 
-    pub fn modify_migration<F>(self, modify: F) -> AssertionResult<Self>
+    #[track_caller]
+    pub fn modify_migration<F>(self, modify: F) -> Self
     where
         F: FnOnce(&mut String),
     {
@@ -160,17 +171,19 @@ impl<'a> CreateMigrationAssertion<'a> {
             .join("migration.sql");
 
         let new_contents = {
-            let mut contents = std::fs::read_to_string(&migration_script_path).context("Reading migration script")?;
+            let mut contents = std::fs::read_to_string(&migration_script_path)
+                .context("Reading migration script")
+                .unwrap();
 
             modify(&mut contents);
 
             contents
         };
 
-        let mut file = std::fs::File::create(&migration_script_path)?;
-        write!(file, "{}", new_contents)?;
+        let mut file = std::fs::File::create(&migration_script_path).unwrap();
+        write!(file, "{}", new_contents).unwrap();
 
-        Ok(self)
+        self
     }
 
     pub fn into_output(self) -> CreateMigrationOutput {

--- a/migration-engine/migration-engine-tests/src/test_api/reset.rs
+++ b/migration-engine/migration-engine-tests/src/test_api/reset.rs
@@ -21,8 +21,10 @@ impl<'a> Reset<'a> {
         Ok(ResetAssertion { _api: self.api })
     }
 
-    pub fn send_sync(self) -> CoreResult<ResetAssertion<'a>> {
-        self.rt.unwrap().block_on(self.send())
+    /// Execute the command and expect it to succeed.
+    #[track_caller]
+    pub fn send_sync(self) -> ResetAssertion<'a> {
+        self.rt.unwrap().block_on(self.send()).unwrap()
     }
 }
 

--- a/migration-engine/migration-engine-tests/tests/create_migration/create_migration_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/create_migration/create_migration_tests.rs
@@ -17,7 +17,7 @@ async fn basic_create_migration_works(api: &TestApi) -> TestResult {
     api.create_migration("create-cats", dm, &dir)
         .send()
         .await?
-        .assert_migration_directories_count(1)?
+        .assert_migration_directories_count(1)
         .assert_migration("create-cats", |migration| {
             let expected_script = match api.sql_family() {
                 SqlFamily::Postgres => {
@@ -91,7 +91,7 @@ async fn creating_a_second_migration_should_have_the_previous_sql_schema_as_base
     api.create_migration("create-cats", dm1, &dir)
         .send()
         .await?
-        .assert_migration_directories_count(1)?;
+        .assert_migration_directories_count(1);
 
     let dm2 = r#"
         model Cat {
@@ -108,7 +108,7 @@ async fn creating_a_second_migration_should_have_the_previous_sql_schema_as_base
     api.create_migration("create-dogs", dm2, &dir)
         .send()
         .await?
-        .assert_migration_directories_count(2)?
+        .assert_migration_directories_count(2)
         .assert_migration("create-dogs", |migration| {
             let expected_script = match api.sql_family() {
                 SqlFamily::Postgres => {
@@ -209,12 +209,12 @@ async fn empty_migrations_should_not_be_created(api: &TestApi) -> TestResult {
     api.create_migration("create-cats", dm, &dir)
         .send()
         .await?
-        .assert_migration_directories_count(1)?;
+        .assert_migration_directories_count(1);
 
     api.create_migration("create-cats-again", dm, &dir)
         .send()
         .await?
-        .assert_migration_directories_count(1)?;
+        .assert_migration_directories_count(1);
 
     Ok(())
 }
@@ -233,7 +233,7 @@ async fn migration_name_length_is_validated(api: &TestApi) -> TestResult {
     api.create_migration("a-migration-with-a-name-that-is-way-too-long-a-migration-with-a-name-that-is-way-too-long-a-migration-with-a-name-that-is-way-too-long-a-migration-with-a-name-that-is-way-too-long", dm, &dir)
         .send()
         .await?
-        .assert_migration_directories_count(1)?;
+        .assert_migration_directories_count(1);
 
     Ok(())
 }
@@ -252,13 +252,13 @@ async fn empty_migrations_should_be_created_with_the_draft_option(api: &TestApi)
     api.create_migration("create-cats", dm, &dir)
         .send()
         .await?
-        .assert_migration_directories_count(1)?;
+        .assert_migration_directories_count(1);
 
     api.create_migration("create-cats-again", dm, &dir)
         .draft(true)
         .send()
         .await?
-        .assert_migration_directories_count(2)?
+        .assert_migration_directories_count(2)
         .assert_migration("create-cats-again", |migration| {
             migration.assert_contents("-- This is an empty migration.")
         })?;
@@ -282,7 +282,7 @@ async fn creating_a_migration_with_a_non_existent_migrations_directory_should_wo
     api.create_migration("create-cats", dm, &dir)
         .send()
         .await?
-        .assert_migration_directories_count(1)?;
+        .assert_migration_directories_count(1);
 
     Ok(())
 }
@@ -312,7 +312,7 @@ async fn create_enum_step_only_rendered_when_needed(api: &TestApi) -> TestResult
     api.create_migration("create-cats", dm, &dir)
         .send()
         .await?
-        .assert_migration_directories_count(1)?
+        .assert_migration_directories_count(1)
         .assert_migration("create-cats", |migration| {
             let expected_script = match api.sql_family() {
                 SqlFamily::Postgres => {
@@ -377,7 +377,7 @@ async fn create_enum_renders_correctly(api: &TestApi) -> TestResult {
     api.create_migration("create-cats", dm, &dir)
         .send()
         .await?
-        .assert_migration_directories_count(1)?
+        .assert_migration_directories_count(1)
         .assert_migration("create-cats", |migration| {
             let expected_script = match api.sql_family() {
                 SqlFamily::Postgres => {
@@ -424,7 +424,7 @@ async fn unsupported_type_renders_correctly(api: &TestApi) -> TestResult {
     api.create_migration("create-cats", dm, &dir)
         .send()
         .await?
-        .assert_migration_directories_count(1)?
+        .assert_migration_directories_count(1)
         .assert_migration("create-cats", |migration| {
             let expected_script = match api.sql_family() {
                 SqlFamily::Postgres => {
@@ -475,7 +475,7 @@ async fn no_additional_unique_created(api: &TestApi) -> TestResult {
     api.create_migration("create-cats", dm, &dir)
         .send()
         .await?
-        .assert_migration_directories_count(1)?
+        .assert_migration_directories_count(1)
         .assert_migration("create-cats", |migration| {
             let expected_script = match api.sql_family() {
                 SqlFamily::Postgres => {

--- a/migration-engine/migration-engine-tests/tests/diagnose_migration_history/diagnose_migration_history_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/diagnose_migration_history/diagnose_migration_history_tests.rs
@@ -49,7 +49,7 @@ async fn diagnose_migrations_history_after_two_migrations_happy_path(api: &TestA
     api.apply_migrations(&directory)
         .send()
         .await?
-        .assert_applied_migrations(&["initial", "second-migration"])?;
+        .assert_applied_migrations(&["initial", "second-migration"]);
 
     let output = api.diagnose_migration_history(&directory).send().await?.into_output();
 
@@ -74,7 +74,7 @@ async fn diagnose_migration_history_with_opt_in_to_shadow_database_calculates_dr
     api.apply_migrations(&directory)
         .send()
         .await?
-        .assert_applied_migrations(&["initial"])?;
+        .assert_applied_migrations(&["initial"]);
 
     let dm2 = r#"
         model Cat {
@@ -134,7 +134,7 @@ async fn diagnose_migration_history_without_opt_in_to_shadow_database_does_not_c
     api.apply_migrations(&directory)
         .send()
         .await?
-        .assert_applied_migrations(&["initial"])?;
+        .assert_applied_migrations(&["initial"]);
 
     let dm2 = r#"
         model Cat {
@@ -196,12 +196,12 @@ async fn diagnose_migration_history_calculates_drift_in_presence_of_failed_migra
         .await?
         .modify_migration(|migration| {
             migration.push_str("\nSELECT YOLO;");
-        })?;
+        });
 
     let err = api.apply_migrations(&directory).send().await.unwrap_err().to_string();
     assert!(err.contains("yolo") || err.contains("YOLO"), "{}", err);
 
-    migration_two.modify_migration(|migration| migration.truncate(migration.len() - "SELECT YOLO;".len()))?;
+    migration_two.modify_migration(|migration| migration.truncate(migration.len() - "SELECT YOLO;".len()));
 
     let DiagnoseMigrationHistoryOutput {
         drift,
@@ -258,7 +258,7 @@ async fn diagnose_migrations_history_can_detect_when_the_database_is_behind(api:
     api.apply_migrations(&directory)
         .send()
         .await?
-        .assert_applied_migrations(&["initial"])?;
+        .assert_applied_migrations(&["initial"]);
 
     let dm2 = r#"
         model Cat {
@@ -332,7 +332,7 @@ async fn diagnose_migrations_history_can_detect_when_the_folder_is_behind(api: &
     api.apply_migrations(&directory)
         .send()
         .await?
-        .assert_applied_migrations(&["initial", "second-migration"])?;
+        .assert_applied_migrations(&["initial", "second-migration"]);
 
     let second_migration_folder_path = directory.path().join(&name);
     std::fs::remove_dir_all(&second_migration_folder_path)?;
@@ -404,7 +404,7 @@ async fn diagnose_migrations_history_can_detect_when_history_diverges(api: &Test
     api.apply_migrations(&directory)
         .send()
         .await?
-        .assert_applied_migrations(&["1-initial", "2-second-migration"])?;
+        .assert_applied_migrations(&["1-initial", "2-second-migration"]);
 
     let second_migration_folder_path = directory.path().join(&deleted_migration_name);
     std::fs::remove_dir_all(&second_migration_folder_path)?;
@@ -422,7 +422,7 @@ async fn diagnose_migrations_history_can_detect_when_history_diverges(api: &Test
         .draft(true)
         .send()
         .await?
-        .assert_migration_directories_count(2)?
+        .assert_migration_directories_count(2)
         .into_output()
         .generated_migration_name
         .unwrap();
@@ -484,12 +484,12 @@ async fn diagnose_migrations_history_can_detect_edited_migrations(api: &TestApi)
     api.apply_migrations(&directory)
         .send()
         .await?
-        .assert_applied_migrations(&["initial", "second-migration"])?;
+        .assert_applied_migrations(&["initial", "second-migration"]);
 
     let initial_migration_name = initial_assertions
         .modify_migration(|script| {
             std::mem::swap(script, &mut format!("/* test */\n{}", script));
-        })?
+        })
         .into_output()
         .generated_migration_name
         .unwrap();
@@ -539,12 +539,12 @@ async fn diagnose_migrations_history_reports_migrations_failing_to_apply_cleanly
     api.apply_migrations(&directory)
         .send()
         .await?
-        .assert_applied_migrations(&["initial", "second-migration"])?;
+        .assert_applied_migrations(&["initial", "second-migration"]);
 
     let initial_migration_name = initial_assertions
         .modify_migration(|script| {
             script.push_str("SELECT YOLO;\n");
-        })?
+        })
         .into_output()
         .generated_migration_name
         .unwrap();
@@ -630,11 +630,11 @@ async fn with_a_failed_migration(api: &TestApi) -> TestResult {
         .create_migration("01-init", dm, &migrations_directory)
         .send()
         .await?
-        .assert_migration_directories_count(1)?
+        .assert_migration_directories_count(1)
         .modify_migration(|migration| {
             migration.clear();
             migration.push_str("CREATE_BROKEN");
-        })?
+        })
         .into_output();
 
     let err = api
@@ -703,7 +703,7 @@ async fn with_an_invalid_unapplied_migration_should_report_it(api: &TestApi) -> 
     api.apply_migrations(&directory)
         .send()
         .await?
-        .assert_applied_migrations(&["initial"])?;
+        .assert_applied_migrations(&["initial"]);
 
     let dm2 = r#"
         model Cat {
@@ -721,7 +721,7 @@ async fn with_an_invalid_unapplied_migration_should_report_it(api: &TestApi) -> 
         .await?
         .modify_migration(|script| {
             *script = "CREATE BROKEN".into();
-        })?
+        })
         .into_output();
 
     let DiagnoseMigrationHistoryOutput {
@@ -998,7 +998,7 @@ async fn empty_migration_directories_should_cause_known_errors(api: &TestApi) ->
     api.apply_migrations(&migrations_directory)
         .send()
         .await?
-        .assert_applied_migrations(&["01init"])?;
+        .assert_applied_migrations(&["01init"]);
 
     let dirname = output.generated_migration_name.unwrap();
     let dirpath = migrations_directory.path().join(dirname);
@@ -1053,7 +1053,7 @@ async fn indexes_on_same_columns_with_different_names_should_work(api: &TestApi)
     api.apply_migrations(&directory)
         .send()
         .await?
-        .assert_applied_migrations(&["initial"])?;
+        .assert_applied_migrations(&["initial"]);
 
     let output = api
         .diagnose_migration_history(&directory)
@@ -1082,7 +1082,7 @@ async fn default_dbgenerated_should_not_cause_drift(api: &TestApi) -> TestResult
     api.apply_migrations(&migrations_directory)
         .send()
         .await?
-        .assert_applied_migrations(&["01init"])?;
+        .assert_applied_migrations(&["01init"]);
 
     let output = api
         .diagnose_migration_history(&migrations_directory)
@@ -1112,7 +1112,7 @@ async fn default_uuid_should_not_cause_drift(api: &TestApi) -> TestResult {
     api.apply_migrations(&migrations_directory)
         .send()
         .await?
-        .assert_applied_migrations(&["01init"])?;
+        .assert_applied_migrations(&["01init"]);
 
     let output = api
         .diagnose_migration_history(&migrations_directory)

--- a/migration-engine/migration-engine-tests/tests/existing_data/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_data/mod.rs
@@ -372,7 +372,7 @@ async fn changing_a_column_from_optional_to_required_is_unexecutable(api: &TestA
     api.schema_push(dm2)
         .send()
         .await?
-        .assert_no_warning()?
+        .assert_no_warning()
         .assert_unexecutable(&[error])?;
 
     // The schema should not change because the migration should not run if there are warnings
@@ -811,8 +811,8 @@ async fn set_default_current_timestamp_on_existing_column_works(api: &TestApi) -
         .force(true)
         .send()
         .await?
-        .assert_executable()?
-        .assert_no_warning()?;
+        .assert_executable()
+        .assert_no_warning();
 
     api.assert_schema().await?.assert_table("User", |table| {
         table.assert_column("created_at", |column| column.assert_default(Some(DefaultValue::now())))
@@ -883,7 +883,7 @@ async fn primary_key_migrations_do_not_cause_data_loss(api: &TestApi) -> TestRes
         .force(true)
         .send()
         .await?
-        .assert_executable()?
+        .assert_executable()
         .assert_warnings(&[warn.into()])?;
 
     api.assert_schema().await?.assert_table("Dog", |table| {

--- a/migration-engine/migration-engine-tests/tests/existing_data/sql_unexecutable_migrations/added_required_field_to_table.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_data/sql_unexecutable_migrations/added_required_field_to_table.rs
@@ -31,7 +31,7 @@ async fn adding_a_required_field_to_an_existing_table_with_data_without_a_defaul
         .force(false)
         .send()
         .await?
-        .assert_no_warning()?
+        .assert_no_warning()
         .assert_unexecutable(&["Added the required column `age` to the `Test` table without a default value. There are 1 rows in this table, it is not possible to execute this step.".to_string()])?;
 
     let rows = api.select("Test").column("id").column("name").send().await?;
@@ -70,7 +70,7 @@ async fn adding_a_required_field_with_prisma_level_default_works(api: &TestApi) 
         .force(false)
         .send()
         .await?
-        .assert_no_warning()?
+        .assert_no_warning()
         .assert_unexecutable(&["The required column `name` was added to the `Test` table with a prisma-level default value. There are 1 rows in this table, it is not possible to execute this step. Please add this column as optional, then populate it before making it required.".into()])?;
 
     let rows = api.select("Test").column("id").column("age").send().await?;

--- a/migration-engine/migration-engine-tests/tests/existing_data/sql_unexecutable_migrations/made_optional_field_required.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_data/sql_unexecutable_migrations/made_optional_field_required.rs
@@ -36,7 +36,7 @@ async fn making_an_optional_field_required_with_data_without_a_default_is_unexec
     api.schema_push(dm2)
         .send()
         .await?
-        .assert_no_warning()?
+        .assert_no_warning()
         .assert_unexecutable(&[error])?;
 
     api.assert_schema()
@@ -160,7 +160,7 @@ async fn making_an_optional_field_required_with_data_with_a_default_is_unexecuta
         .send()
         .await?
         .assert_unexecutable(&[error])?
-        .assert_no_warning()?;
+        .assert_no_warning();
 
     api.assert_schema().await?.assert_equals(&initial_schema)?;
 

--- a/migration-engine/migration-engine-tests/tests/existing_data/type_migration_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_data/type_migration_tests.rs
@@ -191,7 +191,7 @@ async fn changing_an_int_array_column_to_scalar_is_not_possible(api: &TestApi) -
         .force(true)
         .send()
         .await?
-        .assert_no_warning()?
+        .assert_no_warning()
         .assert_unexecutable(&["Changed the type of `mainProtagonist` on the `Film` table. No cast exists, the column would be dropped and recreated, which cannot be done since the column is required and there is data in the table.".into()])?;
 
     api.assert_schema().await?.assert_table("Film", |table| {
@@ -235,7 +235,7 @@ async fn int_to_string_conversions_work(api: &TestApi) -> TestResult {
         .send()
         .await?
         .assert_green()?
-        .assert_has_executed_steps()?;
+        .assert_has_executed_steps();
 
     api.dump_table("Cat")
         .await?
@@ -271,7 +271,7 @@ async fn string_to_int_conversions_are_risky(api: &TestApi) -> TestResult {
                 .force(true)
                 .send()
                 .await?
-                .assert_no_warning()?
+                .assert_no_warning()
                 .assert_unexecutable(&["Changed the type of `tag` on the `Cat` table. No cast exists, the column would be dropped and recreated, which cannot be done since the column is required and there is data in the table.".into()])?;
         }
         // Executable, conditionally.
@@ -283,8 +283,8 @@ async fn string_to_int_conversions_are_risky(api: &TestApi) -> TestResult {
             .assert_warnings(&[
                 "You are about to alter the column `tag` on the `cat` table, which contains 1 non-null values. The data in that column will be cast from `VarChar(191)` to `Int`.".into()
             ])?
-            .assert_executable()?
-            .assert_has_executed_steps()?;
+            .assert_executable()
+            .assert_has_executed_steps();
 
             api.dump_table("Cat")
                 .await?
@@ -299,8 +299,8 @@ async fn string_to_int_conversions_are_risky(api: &TestApi) -> TestResult {
             .assert_warnings(&[
                 "You are about to alter the column `tag` on the `Cat` table, which contains 1 non-null values. The data in that column will be cast from `VarChar(191)` to `Int`.".into()
             ])?
-            .assert_executable()?
-            .assert_has_executed_steps()?;
+            .assert_executable()
+            .assert_has_executed_steps();
 
             api.dump_table("Cat")
                 .await?
@@ -314,8 +314,8 @@ async fn string_to_int_conversions_are_risky(api: &TestApi) -> TestResult {
             .assert_warnings(&[
                 "You are about to alter the column `tag` on the `Cat` table, which contains 1 non-null values. The data in that column will be cast from `NVarChar(1000)` to `Int`.".into()
             ])?
-            .assert_executable()?
-            .assert_has_executed_steps()?;
+            .assert_executable()
+            .assert_has_executed_steps();
 
             api.dump_table("Cat")
                 .await?
@@ -329,8 +329,8 @@ async fn string_to_int_conversions_are_risky(api: &TestApi) -> TestResult {
                 .assert_warnings(&[
                     "You are about to alter the column `tag` on the `Cat` table, which contains 1 non-null values. The data in that column will be cast from `String` to `Int`.".into()
                 ])?
-                .assert_executable()?
-                .assert_has_executed_steps()?;
+                .assert_executable()
+                .assert_has_executed_steps();
 
             api.dump_table("Cat")
                 .await?
@@ -373,8 +373,8 @@ async fn datetime_to_float_conversions_are_impossible(api: &TestApi) -> TestResu
             "The `birthday` column on the `Cat` table would be dropped and recreated. This will lead to data loss."
                 .into(),
         ])?
-        .assert_executable()?
-        .assert_no_steps()?;
+        .assert_executable()
+        .assert_no_steps();
 
     api.dump_table("Cat")
         .await?
@@ -388,8 +388,8 @@ async fn datetime_to_float_conversions_are_impossible(api: &TestApi) -> TestResu
             "The `birthday` column on the `Cat` table would be dropped and recreated. This will lead to data loss."
                 .into(),
         ])?
-        .assert_executable()?
-        .assert_has_executed_steps()?;
+        .assert_executable()
+        .assert_has_executed_steps();
 
     api.dump_table("Cat")
         .await?

--- a/migration-engine/migration-engine-tests/tests/existing_databases/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_databases/mod.rs
@@ -205,7 +205,7 @@ async fn creating_a_scalar_list_field_for_an_existing_table_must_work(api: &Test
         }
     "#;
 
-    api.schema_push(dm2).send().await?.assert_green()?.assert_no_steps()?;
+    api.schema_push(dm2).send().await?.assert_green()?.assert_no_steps();
     api.assert_schema().await?.assert_equals(&result.into_schema())?;
 
     Ok(())
@@ -246,7 +246,7 @@ async fn delete_a_field_for_a_non_existent_column_must_work(api: &TestApi) -> Te
         }
     "#;
 
-    api.schema_push(dm2).send().await?.assert_green()?.assert_no_steps()?;
+    api.schema_push(dm2).send().await?.assert_green()?.assert_no_steps();
     api.assert_schema().await?.assert_equals(&result.into_schema())?;
 
     Ok(())
@@ -410,7 +410,7 @@ async fn existing_enums_are_picked_up(api: &TestApi) -> TestResult {
         }
     "#;
 
-    api.schema_push(dm).send().await?.assert_green()?.assert_no_steps()?;
+    api.schema_push(dm).send().await?.assert_green()?.assert_no_steps();
 
     Ok(())
 }

--- a/migration-engine/migration-engine-tests/tests/list_migration_directories/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/list_migration_directories/mod.rs
@@ -28,7 +28,7 @@ async fn listing_a_single_migration_name_should_work(api: &TestApi) -> TestResul
     api.apply_migrations(&migrations_directory)
         .send()
         .await?
-        .assert_applied_migrations(&["init"])?;
+        .assert_applied_migrations(&["init"]);
 
     api.list_migration_directories(&migrations_directory)
         .send()

--- a/migration-engine/migration-engine-tests/tests/migration_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migration_tests.rs
@@ -68,7 +68,7 @@ async fn adding_a_scalar_field_must_work(api: &TestApi) -> TestResult {
     })?;
 
     // Check that the migration is idempotent.
-    api.schema_push(dm).send().await?.assert_green()?.assert_no_steps()?;
+    api.schema_push(dm).send().await?.assert_green()?.assert_no_steps();
 
     Ok(())
 }
@@ -104,7 +104,7 @@ async fn adding_an_enum_field_must_work(api: &TestApi) -> TestResult {
     })?;
 
     // Check that the migration is idempotent.
-    api.schema_push(dm).send().await?.assert_no_steps()?;
+    api.schema_push(dm).send().await?.assert_no_steps();
 
     Ok(())
 }
@@ -140,7 +140,7 @@ async fn adding_an_enum_field_must_work_with_native_types_off(api: &TestApi) -> 
     })?;
 
     // Check that the migration is idempotent.
-    api.schema_push(dm).send().await?.assert_no_steps()?;
+    api.schema_push(dm).send().await?.assert_no_steps();
 
     Ok(())
 }
@@ -172,7 +172,7 @@ async fn json_fields_can_be_created(api: &TestApi) -> TestResult {
         })
     })?;
 
-    api.schema_push(&dm).send().await?.assert_green()?.assert_no_steps()?;
+    api.schema_push(&dm).send().await?.assert_green()?.assert_no_steps();
 
     Ok(())
 }
@@ -328,7 +328,7 @@ async fn making_an_existing_id_field_autoincrement_works(api: &TestApi) -> TestR
     })?;
 
     // Check that the migration is idempotent.
-    api.schema_push(dm2).send().await?.assert_green()?.assert_no_steps()?;
+    api.schema_push(dm2).send().await?.assert_green()?.assert_no_steps();
 
     // MySQL cannot add autoincrement property to a column that already has data.
     if !api.sql_family().is_mysql() {
@@ -403,7 +403,7 @@ async fn removing_autoincrement_from_an_existing_field_works(api: &TestApi) -> T
         .send()
         .await?
         .assert_green()?
-        .assert_no_steps()?;
+        .assert_no_steps();
 
     assert_eq!(
         3,
@@ -472,7 +472,7 @@ async fn making_an_existing_id_field_autoincrement_works_with_indices(api: &Test
     })?;
 
     // Check that the migration is idempotent.
-    api.schema_push(dm2).send().await?.assert_green()?.assert_no_steps()?;
+    api.schema_push(dm2).send().await?.assert_green()?.assert_no_steps();
 
     assert_eq!(
         3,
@@ -586,7 +586,7 @@ async fn making_an_existing_id_field_autoincrement_works_with_foreign_keys(api: 
 
     // TODO: Why not empty?
     // Check that the migration is idempotent.
-    //api.schema_push(dm2).send().await?.assert_green()?.assert_no_steps()?;
+    //api.schema_push(dm2).send().await?.assert_green()?.assert_no_steps();
 
     assert_eq!(
         3,
@@ -1061,9 +1061,9 @@ async fn adding_unique_to_an_existing_field_must_work(api: &TestApi) -> TestResu
         .force(true)
         .send()
         .await?
-        .assert_executable()?
+        .assert_executable()
         .assert_warnings(&["A unique constraint covering the columns `[field]` on the table `A` will be added. If there are existing duplicate values, this will fail.".into()])?
-        .assert_has_executed_steps()?;
+        .assert_has_executed_steps();
 
     api.assert_schema().await?.assert_table("A", |table| {
         table
@@ -1306,7 +1306,7 @@ async fn escaped_string_defaults_are_not_arbitrarily_migrated(api: &TestApi) -> 
         .send()
         .await?
         .assert_green()?
-        .assert_no_steps()?;
+        .assert_no_steps();
 
     let sql_schema = api.assert_schema().await?.into_schema();
     let table = sql_schema.table_bang(&api.normalize_identifier("Fruit"));
@@ -1383,7 +1383,7 @@ async fn created_at_does_not_get_arbitrarily_migrated(api: &TestApi) -> TestResu
         }
     "#;
 
-    api.schema_push(dm2).send().await?.assert_green()?.assert_no_steps()?;
+    api.schema_push(dm2).send().await?.assert_green()?.assert_no_steps();
 
     Ok(())
 }
@@ -1994,7 +1994,7 @@ async fn migrating_a_unique_constraint_to_a_primary_key_works(api: &TestApi) -> 
         .force(true)
         .send()
         .await?
-        .assert_executable()?
+        .assert_executable()
         .assert_warnings(&["The primary key for the `model1` table will be changed. If it partially fails, the table could be left without primary key constraint.".into(), "You are about to drop the column `id` on the `model1` table, which still contains 1 non-null values.".into()])?;
 
     api.assert_schema().await?.assert_table("model1", |table| {
@@ -2216,7 +2216,7 @@ async fn a_model_can_be_removed(api: &TestApi) -> TestResult {
     api.apply_migrations(&directory)
         .send()
         .await?
-        .assert_applied_migrations(&["initial", "second-migration"])?;
+        .assert_applied_migrations(&["initial", "second-migration"]);
 
     let output = api.diagnose_migration_history(&directory).send().await?.into_output();
 
@@ -2250,7 +2250,7 @@ async fn a_default_can_be_dropped(api: &TestApi) -> TestResult {
     api.apply_migrations(&directory)
         .send()
         .await?
-        .assert_applied_migrations(&["initial", "second-migration"])?;
+        .assert_applied_migrations(&["initial", "second-migration"]);
 
     let output = api.diagnose_migration_history(&directory).send().await?.into_output();
 

--- a/migration-engine/migration-engine-tests/tests/migrations/defaults.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/defaults.rs
@@ -1,4 +1,4 @@
-use migration_engine_tests::multi_engine_test_api::*;
+use migration_engine_tests::sync_test_api::*;
 use sql_schema_describer::DefaultValue;
 use test_macros::test_connector;
 
@@ -6,8 +6,6 @@ use test_macros::test_connector;
 // chrono DateTime, and we don't render that in the exact expected format.
 #[test_connector(exclude(Mysql57, Mariadb))]
 fn datetime_defaults_work(api: TestApi) {
-    let engine = api.new_engine();
-
     let dm = r#"
         model Cat {
             id Int @id
@@ -15,7 +13,7 @@ fn datetime_defaults_work(api: TestApi) {
         }
     "#;
 
-    engine.schema_push(dm).send_sync().unwrap().assert_green().unwrap();
+    api.schema_push(dm).send_sync().assert_green().unwrap();
 
     let expected_default = if api.is_postgres() {
         DefaultValue::db_generated("'2018-01-27 08:00:00'::timestamp without time zone")
@@ -29,8 +27,7 @@ fn datetime_defaults_work(api: TestApi) {
         DefaultValue::db_generated("'2018-01-27 08:00:00 +00:00'")
     };
 
-    engine
-        .assert_schema()
+    api.assert_schema()
         .assert_table("Cat", |table| {
             table.assert_column("birthday", |col| col.assert_default(Some(expected_default)))
         })
@@ -39,18 +36,15 @@ fn datetime_defaults_work(api: TestApi) {
 
 #[test_connector(tags(Mariadb, Mysql8), exclude(Vitess))]
 fn function_expressions_as_dbgenerated_work(api: TestApi) {
-    let engine = api.new_engine();
-
     let dm = r#"
         model Cat {
             id String @id @default(dbgenerated("(LEFT(UUID(), 8))"))
         }
     "#;
 
-    engine.schema_push(dm).send_sync().unwrap().assert_green().unwrap();
+    api.schema_push(dm).send_sync().assert_green().unwrap();
 
-    engine
-        .assert_schema()
+    api.assert_schema()
         .assert_table("Cat", |table| {
             table.assert_column("id", |col| {
                 col.assert_default(Some(DefaultValue::db_generated("(left(uuid(),8))")))
@@ -61,18 +55,15 @@ fn function_expressions_as_dbgenerated_work(api: TestApi) {
 
 #[test_connector(tags(Postgres))]
 fn default_dbgenerated_with_type_definitions_should_work(api: TestApi) {
-    let engine = api.new_engine();
-
     let dm = r#"
         model A {
             id String @id @default(dbgenerated("(now())::TEXT"))
         }
     "#;
 
-    engine.schema_push(dm).send_sync().unwrap().assert_green().unwrap();
+    api.schema_push(dm).send_sync().assert_green().unwrap();
 
-    engine
-        .assert_schema()
+    api.assert_schema()
         .assert_table("A", |table| {
             table.assert_column("id", |col| {
                 col.assert_default(Some(DefaultValue::db_generated("(now())::text")))
@@ -83,18 +74,15 @@ fn default_dbgenerated_with_type_definitions_should_work(api: TestApi) {
 
 #[test_connector(tags(Postgres))]
 fn default_dbgenerated_should_work(api: TestApi) {
-    let engine = api.new_engine();
-
     let dm = r#"
         model A {
             id String @id @default(dbgenerated("(now())"))
         }
     "#;
 
-    engine.schema_push(dm).send_sync().unwrap().assert_green().unwrap();
+    api.schema_push(dm).send_sync().assert_green().unwrap();
 
-    engine
-        .assert_schema()
+    api.assert_schema()
         .assert_table("A", |table| {
             table.assert_column("id", |col| {
                 col.assert_default(Some(DefaultValue::db_generated("now()")))
@@ -105,8 +93,6 @@ fn default_dbgenerated_should_work(api: TestApi) {
 
 #[test_connector(tags(Postgres))]
 fn uuid_default(api: TestApi) {
-    let engine = api.new_engine();
-
     let dm = r#"
         model A {
             id   String @id @db.Uuid
@@ -114,10 +100,9 @@ fn uuid_default(api: TestApi) {
         }
     "#;
 
-    engine.schema_push(dm).send_sync().unwrap().assert_green().unwrap();
+    api.schema_push(dm).send_sync().assert_green().unwrap();
 
-    engine
-        .assert_schema()
+    api.assert_schema()
         .assert_table("A", |table| {
             table.assert_column("uuid", |col| {
                 col.assert_default(Some(DefaultValue::value("00000000-0000-0000-0016-000000000004")))

--- a/migration-engine/migration-engine-tests/tests/migrations/dev_diagnostic_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/dev_diagnostic_tests.rs
@@ -42,7 +42,7 @@ async fn dev_diagnostic_after_two_migrations_happy_path(api: &TestApi) -> TestRe
     api.apply_migrations(&directory)
         .send()
         .await?
-        .assert_applied_migrations(&["initial", "second-migration"])?;
+        .assert_applied_migrations(&["initial", "second-migration"]);
 
     let DevDiagnosticOutput { action } = api.dev_diagnostic(&directory).send().await?.into_output();
 
@@ -67,7 +67,7 @@ async fn dev_diagnostic_detects_drift(api: &TestApi) -> TestResult {
     api.apply_migrations(&directory)
         .send()
         .await?
-        .assert_applied_migrations(&["initial"])?;
+        .assert_applied_migrations(&["initial"]);
 
     let dm2 = r#"
         model Cat {
@@ -120,13 +120,13 @@ async fn dev_diagnostic_calculates_drift_in_presence_of_failed_migrations(api: &
         .await?
         .modify_migration(|migration| {
             migration.push_str("\nSELECT YOLO;");
-        })?;
+        });
 
     let err = api.apply_migrations(&directory).send().await.unwrap_err().to_string();
     assert!(err.contains("yolo") || err.contains("YOLO"), "{}", err);
 
     let migration_two =
-        migration_two.modify_migration(|migration| migration.truncate(migration.len() - "SELECT YOLO;".len()))?;
+        migration_two.modify_migration(|migration| migration.truncate(migration.len() - "SELECT YOLO;".len()));
 
     let DevDiagnosticOutput { action } = api.dev_diagnostic(&directory).send().await?.into_output();
 
@@ -158,7 +158,7 @@ async fn dev_diagnostic_returns_create_migration_when_the_database_is_behind(api
     api.apply_migrations(&directory)
         .send()
         .await?
-        .assert_applied_migrations(&["initial"])?;
+        .assert_applied_migrations(&["initial"]);
 
     let dm2 = r#"
         model Cat {
@@ -209,7 +209,7 @@ async fn dev_diagnostic_can_detect_when_the_migrations_directory_is_behind(api: 
     api.apply_migrations(&directory)
         .send()
         .await?
-        .assert_applied_migrations(&["initial", "second-migration"])?;
+        .assert_applied_migrations(&["initial", "second-migration"]);
 
     let second_migration_folder_path = directory.path().join(&name);
     std::fs::remove_dir_all(&second_migration_folder_path)?;
@@ -259,7 +259,7 @@ async fn dev_diagnostic_can_detect_when_history_diverges(api: &TestApi) -> TestR
     api.apply_migrations(&directory)
         .send()
         .await?
-        .assert_applied_migrations(&["1-initial", "2-second-migration"])?;
+        .assert_applied_migrations(&["1-initial", "2-second-migration"]);
 
     let second_migration_folder_path = directory.path().join(&deleted_migration_name);
     std::fs::remove_dir_all(&second_migration_folder_path)?;
@@ -276,7 +276,7 @@ async fn dev_diagnostic_can_detect_when_history_diverges(api: &TestApi) -> TestR
         .draft(true)
         .send()
         .await?
-        .assert_migration_directories_count(2)?;
+        .assert_migration_directories_count(2);
 
     let DevDiagnosticOutput { action } = api.dev_diagnostic(&directory).send().await?.into_output();
 
@@ -317,12 +317,12 @@ async fn dev_diagnostic_can_detect_edited_migrations(api: &TestApi) -> TestResul
     api.apply_migrations(&directory)
         .send()
         .await?
-        .assert_applied_migrations(&["initial", "second-migration"])?;
+        .assert_applied_migrations(&["initial", "second-migration"]);
 
     let initial_migration_name = initial_assertions
         .modify_migration(|script| {
             std::mem::swap(script, &mut format!("/* test */\n{}", script));
-        })?
+        })
         .into_output()
         .generated_migration_name
         .unwrap();
@@ -365,12 +365,12 @@ async fn dev_diagnostic_reports_migrations_failing_to_apply_cleanly(api: &TestAp
     api.apply_migrations(&directory)
         .send()
         .await?
-        .assert_applied_migrations(&["initial", "second-migration"])?;
+        .assert_applied_migrations(&["initial", "second-migration"]);
 
     let initial_migration_name = initial_assertions
         .modify_migration(|script| {
             script.push_str("SELECT YOLO;\n");
-        })?
+        })
         .into_output()
         .generated_migration_name
         .unwrap();
@@ -418,11 +418,11 @@ async fn with_a_failed_migration(api: &TestApi) -> TestResult {
         .create_migration("01-init", dm, &migrations_directory)
         .send()
         .await?
-        .assert_migration_directories_count(1)?
+        .assert_migration_directories_count(1)
         .modify_migration(|migration| {
             migration.clear();
             migration.push_str("CREATE_BROKEN");
-        })?
+        })
         .into_output();
 
     let err = api
@@ -469,7 +469,7 @@ async fn with_an_invalid_unapplied_migration_should_report_it(api: &TestApi) -> 
     api.apply_migrations(&directory)
         .send()
         .await?
-        .assert_applied_migrations(&["initial"])?;
+        .assert_applied_migrations(&["initial"]);
 
     let dm2 = r#"
         model catcat {
@@ -487,7 +487,7 @@ async fn with_an_invalid_unapplied_migration_should_report_it(api: &TestApi) -> 
         .await?
         .modify_migration(|script| {
             *script = "CREATE BROKEN".into();
-        })?
+        })
         .into_output();
 
     let err = api

--- a/migration-engine/migration-engine-tests/tests/migrations/foreign_keys.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/foreign_keys.rs
@@ -1,9 +1,7 @@
-use migration_engine_tests::multi_engine_test_api::*;
+use migration_engine_tests::sync_test_api::*;
 
 #[test_connector]
 fn foreign_keys_of_inline_one_to_one_relations_have_a_unique_constraint(api: TestApi) {
-    let engine = api.new_engine();
-
     let dm = r#"
         model Cat {
             id Int   @id
@@ -17,9 +15,8 @@ fn foreign_keys_of_inline_one_to_one_relations_have_a_unique_constraint(api: Tes
         }
     "#;
 
-    engine.schema_push(dm).send_sync().unwrap().assert_green().unwrap();
-    engine
-        .assert_schema()
+    api.schema_push(dm).send_sync().assert_green().unwrap();
+    api.assert_schema()
         .assert_table("Box", |t| {
             t.assert_indexes_count(1)
                 .unwrap()
@@ -32,8 +29,6 @@ fn foreign_keys_of_inline_one_to_one_relations_have_a_unique_constraint(api: Tes
 
 #[test_connector]
 fn foreign_keys_are_added_on_existing_tables(api: TestApi) -> TestResult {
-    let api = api.new_engine();
-
     let dm1 = r#"
         model User {
             id Int @id
@@ -45,7 +40,7 @@ fn foreign_keys_are_added_on_existing_tables(api: TestApi) -> TestResult {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().unwrap().assert_green().unwrap();
+    api.schema_push(dm1).send_sync().assert_green().unwrap();
 
     api.assert_schema()
         // There should be no foreign keys yet.
@@ -66,7 +61,7 @@ fn foreign_keys_are_added_on_existing_tables(api: TestApi) -> TestResult {
         }
     "#;
 
-    api.schema_push(dm2).send_sync().unwrap().assert_green().unwrap();
+    api.schema_push(dm2).send_sync().assert_green().unwrap();
 
     api.assert_schema()
         .assert_table("Account", |table| {
@@ -80,7 +75,6 @@ fn foreign_keys_are_added_on_existing_tables(api: TestApi) -> TestResult {
 
 #[test_connector]
 fn foreign_keys_can_be_added_on_existing_columns(api: TestApi) -> TestResult {
-    let api = api.new_engine();
     let dm1 = r#"
         model User {
             id Int @id
@@ -93,7 +87,7 @@ fn foreign_keys_can_be_added_on_existing_columns(api: TestApi) -> TestResult {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().unwrap().assert_green().unwrap();
+    api.schema_push(dm1).send_sync().assert_green().unwrap();
 
     api.assert_schema()
         // There should be no foreign keys yet.
@@ -114,7 +108,7 @@ fn foreign_keys_can_be_added_on_existing_columns(api: TestApi) -> TestResult {
         }
     "#;
 
-    api.schema_push(dm2).send_sync().unwrap().assert_green().unwrap();
+    api.schema_push(dm2).send_sync().assert_green().unwrap();
 
     api.assert_schema()
         .assert_table("Account", |table| {
@@ -128,7 +122,6 @@ fn foreign_keys_can_be_added_on_existing_columns(api: TestApi) -> TestResult {
 
 #[test_connector]
 fn foreign_keys_can_be_dropped_on_existing_columns(api: TestApi) {
-    let api = api.new_engine();
     let dm1 = r#"
         model User {
             id Int @id
@@ -143,7 +136,7 @@ fn foreign_keys_can_be_dropped_on_existing_columns(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().unwrap().assert_green().unwrap();
+    api.schema_push(dm1).send_sync().assert_green().unwrap();
 
     api.assert_schema()
         .assert_table("Account", |table| {
@@ -166,7 +159,7 @@ fn foreign_keys_can_be_dropped_on_existing_columns(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm2).send_sync().unwrap().assert_green().unwrap();
+    api.schema_push(dm2).send_sync().assert_green().unwrap();
 
     api.assert_schema()
         .assert_table("Account", |table| table.assert_foreign_keys_count(0))
@@ -175,7 +168,6 @@ fn foreign_keys_can_be_dropped_on_existing_columns(api: TestApi) {
 
 #[test_connector]
 fn changing_a_scalar_field_to_a_relation_field_must_work(api: TestApi) {
-    let api = api.new_engine();
     let dm1 = r#"
         model A {
             id Int @id
@@ -187,7 +179,7 @@ fn changing_a_scalar_field_to_a_relation_field_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().unwrap().assert_green().unwrap();
+    api.schema_push(dm1).send_sync().assert_green().unwrap();
     api.assert_schema()
         .assert_table("A", |t| {
             t.assert_column("b", |c| c.assert_type_is_string())?
@@ -212,11 +204,8 @@ fn changing_a_scalar_field_to_a_relation_field_must_work(api: TestApi) {
     api.schema_push(dm2)
         .force(true)
         .send_sync()
-        .unwrap()
         .assert_executable()
-        .unwrap()
-        .assert_has_executed_steps()
-        .unwrap();
+        .assert_has_executed_steps();
 
     api.assert_schema()
         .assert_table("A", |table| {
@@ -229,7 +218,6 @@ fn changing_a_scalar_field_to_a_relation_field_must_work(api: TestApi) {
 
 #[test_connector]
 fn changing_a_relation_field_to_a_scalar_field_must_work(api: TestApi) {
-    let api = api.new_engine();
     let dm1 = r#"
         model A {
             id Int @id
@@ -242,7 +230,7 @@ fn changing_a_relation_field_to_a_scalar_field_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().unwrap().assert_green().unwrap();
+    api.schema_push(dm1).send_sync().assert_green().unwrap();
 
     api.assert_schema()
         .assert_table("A", |table| {
@@ -267,7 +255,7 @@ fn changing_a_relation_field_to_a_scalar_field_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm2).send_sync().unwrap().assert_green().unwrap();
+    api.schema_push(dm2).send_sync().assert_green().unwrap();
 
     api.assert_schema()
         .assert_table("A", |table| {
@@ -280,8 +268,6 @@ fn changing_a_relation_field_to_a_scalar_field_must_work(api: TestApi) {
 
 #[test_connector]
 fn changing_a_foreign_key_constrained_column_from_nullable_to_required_and_back_works(api: TestApi) {
-    let api = api.new_engine();
-
     let dm = r#"
         model Student {
             id       String @id @default(cuid())
@@ -296,7 +282,7 @@ fn changing_a_foreign_key_constrained_column_from_nullable_to_required_and_back_
         }
     "#;
 
-    api.schema_push(dm).send_sync().unwrap().assert_green().unwrap();
+    api.schema_push(dm).send_sync().assert_green().unwrap();
 
     let dm2 = r#"
         model Student {
@@ -312,6 +298,6 @@ fn changing_a_foreign_key_constrained_column_from_nullable_to_required_and_back_
         }
     "#;
 
-    api.schema_push(dm2).send_sync().unwrap().assert_green().unwrap();
-    api.schema_push(dm).send_sync().unwrap().assert_green().unwrap();
+    api.schema_push(dm2).send_sync().assert_green().unwrap();
+    api.schema_push(dm).send_sync().assert_green().unwrap();
 }

--- a/migration-engine/migration-engine-tests/tests/migrations/indexes.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/indexes.rs
@@ -374,7 +374,7 @@ async fn index_updates_with_rename_must_work(api: &TestApi) -> TestResult {
         }
     "#;
 
-    api.schema_push(dm2).force(true).send().await?.assert_executable()?;
+    api.schema_push(dm2).force(true).send().await?.assert_executable();
 
     api.assert_schema().await?.assert_table("A", |t| {
         t.assert_indexes_count(1)?.assert_index_on_columns(&["field", "id"], Ok)
@@ -443,7 +443,7 @@ async fn indexes_with_an_automatically_truncated_name_are_idempotent(api: &TestA
             )
         })?;
 
-    api.schema_push(dm).send().await?.assert_green()?.assert_no_steps()?;
+    api.schema_push(dm).send().await?.assert_green()?.assert_no_steps();
 
     Ok(())
 }

--- a/migration-engine/migration-engine-tests/tests/migrations/json.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/json.rs
@@ -38,7 +38,7 @@ async fn database_level_json_defaults_can_be_defined(api: &TestApi) -> TestResul
     })?;
 
     // Check that the migration is idempotent.
-    api.schema_push(&dm).send().await?.assert_green()?.assert_no_steps()?;
+    api.schema_push(&dm).send().await?.assert_green()?.assert_no_steps();
 
     Ok(())
 }

--- a/migration-engine/migration-engine-tests/tests/migrations/mark_migration_applied_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/mark_migration_applied_tests.rs
@@ -226,7 +226,7 @@ async fn mark_migration_applied_when_the_migration_is_failed(api: &TestApi) -> T
             .modify_migration(|migration| {
                 migration.clear();
                 migration.push_str("\nSELECT YOLO;");
-            })?
+            })
             .into_output();
 
         output_second_migration.generated_migration_name.unwrap()
@@ -333,7 +333,7 @@ async fn must_return_helpful_error_on_migration_not_found(api: &TestApi) -> Test
         .create_migration("01init", BASE_DM, &migrations_directory)
         .send()
         .await?
-        .assert_migration_directories_count(1)?
+        .assert_migration_directories_count(1)
         .into_output();
 
     let migration_name = output.generated_migration_name.unwrap();

--- a/migration-engine/migration-engine-tests/tests/migrations/mark_migration_rolled_back_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/mark_migration_rolled_back_tests.rs
@@ -81,7 +81,7 @@ async fn mark_migration_rolled_back_with_a_failed_migration_works(api: &TestApi)
             .modify_migration(|migration| {
                 migration.clear();
                 migration.push_str("\nSELECT YOLO;");
-            })?
+            })
             .into_output();
 
         output_second_migration.generated_migration_name.unwrap()
@@ -244,7 +244,7 @@ async fn rolling_back_applying_again_then_rolling_back_again_should_error(api: &
             .modify_migration(|migration| {
                 migration.clear();
                 migration.push_str("\nSELECT YOLO;");
-            })?;
+            });
 
         (
             output_second_migration
@@ -274,7 +274,7 @@ async fn rolling_back_applying_again_then_rolling_back_again_should_error(api: &
     second_migration_assertions.modify_migration(|migration| {
         migration.clear();
         migration.push_str("SELECT 'YOLO'");
-    })?;
+    });
 
     // Reapply migration 2
     api.apply_migrations(&migrations_directory).send().await?;

--- a/migration-engine/migration-engine-tests/tests/migrations/migrate_lock.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/migrate_lock.rs
@@ -20,10 +20,7 @@ fn create_migration_with_new_provider_errors(api: TestApi) {
     let migrations_directory = api.create_migrations_directory();
     let engine = api.new_engine_with_connection_strings(api.connection_string(), None);
 
-    engine
-        .create_migration("01init", dm, &migrations_directory)
-        .send_sync()
-        .unwrap();
+    engine.create_migration("01init", dm, &migrations_directory).send_sync();
 
     let dm2 = r#"
         datasource db {
@@ -40,8 +37,7 @@ fn create_migration_with_new_provider_errors(api: TestApi) {
 
     let err = sqlite_engine
         .create_migration("02switchprovider", dm2, &migrations_directory)
-        .send_sync()
-        .unwrap_err()
+        .send_unwrap_err()
         .to_user_facing();
 
     let err = err.as_known().unwrap();
@@ -99,8 +95,7 @@ fn migration_lock_with_different_comment_shapes_work(api: TestApi) {
 
         let err = engine
             .create_migration("01init", dm, &migrations_directory)
-            .send_sync()
-            .unwrap_err()
+            .send_unwrap_err()
             .to_user_facing();
 
         let err = err.as_known().unwrap();

--- a/migration-engine/migration-engine-tests/tests/migrations/mssql.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/mssql.rs
@@ -40,7 +40,7 @@ async fn shared_default_constraints_are_ignored_issue_5423(api: &TestApi) -> Tes
         .send()
         .await?
         .assert_green()?
-        .assert_no_steps()?;
+        .assert_no_steps();
 
     Ok(())
 }

--- a/migration-engine/migration-engine-tests/tests/migrations/mysql.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/mysql.rs
@@ -41,7 +41,7 @@ async fn indexes_on_foreign_key_fields_are_not_created_twice(api: &TestApi) -> T
         .send()
         .await?
         .assert_green()?
-        .assert_no_steps()?;
+        .assert_no_steps();
 
     api.assert_schema().await?.assert_equals(&sql_schema)?;
 
@@ -70,7 +70,7 @@ async fn enum_creation_is_idempotent(api: &TestApi) -> TestResult {
 
     api.schema_push(dm1).send().await?.assert_green()?;
 
-    api.schema_push(dm1).send().await?.assert_green()?.assert_no_steps()?;
+    api.schema_push(dm1).send().await?.assert_green()?.assert_no_steps();
 
     Ok(())
 }
@@ -188,8 +188,8 @@ async fn arity_is_preserved_by_alter_enum(api: &TestApi) -> TestResult {
         .force(true)
         .send()
         .await?
-        .assert_executable()?
-        .assert_has_executed_steps()?;
+        .assert_executable()
+        .assert_has_executed_steps();
 
     api.assert_schema().await?.assert_table("A", |table| {
         table
@@ -287,7 +287,7 @@ async fn native_type_columns_can_be_created(api: &TestApi) -> TestResult {
     })?;
 
     // Check that the migration is idempotent
-    api.schema_push(dm).send().await?.assert_green()?.assert_no_steps()?;
+    api.schema_push(dm).send().await?.assert_green()?.assert_no_steps();
 
     Ok(())
 }

--- a/migration-engine/migration-engine-tests/tests/migrations/postgres.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/postgres.rs
@@ -88,11 +88,7 @@ async fn existing_postgis_tables_must_not_be_migrated(api: &TestApi) -> TestResu
 
     let schema = "";
 
-    api.schema_push(schema)
-        .send()
-        .await?
-        .assert_green()?
-        .assert_no_steps()?;
+    api.schema_push(schema).send().await?.assert_green()?.assert_no_steps();
 
     api.assert_schema()
         .await?
@@ -164,7 +160,7 @@ async fn native_type_columns_can_be_created(api: &TestApi) -> TestResult {
         )
     })?;
 
-    api.schema_push(dm).send().await?.assert_green()?.assert_no_steps()?;
+    api.schema_push(dm).send().await?.assert_green()?.assert_no_steps();
 
     Ok(())
 }
@@ -199,7 +195,7 @@ async fn uuids_do_not_generate_drift_issue_5282(api: &TestApi) -> TestResult {
         .send()
         .await?
         .assert_green()?
-        .assert_no_steps()?;
+        .assert_no_steps();
 
     Ok(())
 }

--- a/migration-engine/migration-engine-tests/tests/migrations/shadow_database_url_configuration.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/shadow_database_url_configuration.rs
@@ -32,8 +32,7 @@ fn shadow_db_url_can_be_configured_on_postgres(api: TestApi) {
 
             engine
                 .create_migration("01initcats", dm1, &migrations_directory)
-                .send_sync()
-                .unwrap();
+                .send_sync();
         }
 
         api.raw_cmd("DROP DATABASE IF EXISTS testshadowdb0001");
@@ -88,21 +87,16 @@ fn shadow_db_url_can_be_configured_on_postgres(api: TestApi) {
         engine
             .apply_migrations(&migrations_directory)
             .send_sync()
-            .unwrap()
-            .assert_applied_migrations(&["01initcats"])
-            .unwrap();
+            .assert_applied_migrations(&["01initcats"]);
 
         engine
             .create_migration("02addMeowFrequency", dm2, &migrations_directory)
-            .send_sync()
-            .unwrap();
+            .send_sync();
 
         engine
             .apply_migrations(&migrations_directory)
             .send_sync()
-            .unwrap()
-            .assert_applied_migrations(&["02addMeowFrequency"])
-            .unwrap();
+            .assert_applied_migrations(&["02addMeowFrequency"]);
 
         engine
             .assert_schema()

--- a/migration-engine/migration-engine-tests/tests/migrations/soft_resets.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/soft_resets.rs
@@ -20,8 +20,7 @@ fn soft_resets_work_on_postgres(api: TestApi) {
     {
         api.new_engine()
             .create_migration("01init", dm, &migrations_directory)
-            .send_sync()
-            .unwrap();
+            .send_sync();
 
         let create_user = r#"
             DROP USER IF EXISTS softresetstestuser;
@@ -56,16 +55,14 @@ fn soft_resets_work_on_postgres(api: TestApi) {
         engine
             .apply_migrations(&migrations_directory)
             .send_sync()
-            .unwrap()
-            .assert_applied_migrations(&["01init"])
-            .unwrap();
+            .assert_applied_migrations(&["01init"]);
 
         let add_view = format!(
             r#"CREATE VIEW "{0}"."catcat" AS SELECT * FROM "{0}"."Cat" LIMIT 2"#,
             engine.schema_name(),
         );
 
-        engine.raw_cmd(&add_view).unwrap();
+        engine.raw_cmd(&add_view);
 
         engine
             .assert_schema()
@@ -76,15 +73,13 @@ fn soft_resets_work_on_postgres(api: TestApi) {
             .assert_has_table("Cat")
             .unwrap();
 
-        engine.reset().send_sync().unwrap();
+        engine.reset().send_sync();
         engine.assert_schema().assert_tables_count(0).unwrap();
 
         engine
             .schema_push(dm)
             .send_sync()
-            .unwrap()
             .assert_has_executed_steps()
-            .unwrap()
             .assert_green()
             .unwrap();
 
@@ -95,7 +90,7 @@ fn soft_resets_work_on_postgres(api: TestApi) {
             .assert_has_table("Cat")
             .unwrap();
 
-        engine.reset().send_sync().unwrap();
+        engine.reset().send_sync();
         engine.assert_schema().assert_tables_count(0).unwrap();
     }
 }
@@ -118,8 +113,7 @@ fn soft_resets_work_on_sql_server(api: TestApi) {
     {
         api.new_engine()
             .create_migration("01init", dm, &migrations_directory)
-            .send_sync()
-            .unwrap();
+            .send_sync();
 
         let create_database = r#"
             IF(DB_ID(N'resetTest') IS NOT NULL)
@@ -177,32 +171,30 @@ fn soft_resets_work_on_sql_server(api: TestApi) {
         let engine = api.new_engine_with_connection_strings(&test_user_connection_string, None);
 
         let create_schema = format!("CREATE SCHEMA [{}];", engine.schema_name());
-        engine.raw_cmd(&create_schema).unwrap();
+        engine.raw_cmd(&create_schema);
 
         engine
             .apply_migrations(&migrations_directory)
             .send_sync()
-            .unwrap()
-            .assert_applied_migrations(&["01init"])
-            .unwrap();
+            .assert_applied_migrations(&["01init"]);
 
         let add_view = format!(
             r#"CREATE VIEW [{0}].[catcat] AS SELECT * FROM [{0}].[Cat]"#,
             engine.schema_name(),
         );
 
-        engine.raw_cmd(&add_view).unwrap();
+        engine.raw_cmd(&add_view);
 
         let add_type = format!(r#"CREATE TYPE [{0}].[Litter] FROM int"#, engine.schema_name(),);
 
-        engine.raw_cmd(&add_type).unwrap();
+        engine.raw_cmd(&add_type);
 
         let add_table_with_type = format!(
             r#"CREATE TABLE [{0}].specialLitter (id int primary key, litterAmount [{0}].Litter)"#,
             engine.schema_name()
         );
 
-        engine.raw_cmd(&add_table_with_type).unwrap();
+        engine.raw_cmd(&add_table_with_type);
 
         engine
             .assert_schema()
@@ -215,15 +207,13 @@ fn soft_resets_work_on_sql_server(api: TestApi) {
             .assert_has_table("Cat")
             .unwrap();
 
-        engine.reset().send_sync().unwrap();
+        engine.reset().send_sync();
         engine.assert_schema().assert_tables_count(0).unwrap();
 
         engine
             .schema_push(dm)
             .send_sync()
-            .unwrap()
             .assert_has_executed_steps()
-            .unwrap()
             .assert_green()
             .unwrap();
 
@@ -234,7 +224,7 @@ fn soft_resets_work_on_sql_server(api: TestApi) {
             .assert_has_table("Cat")
             .unwrap();
 
-        engine.reset().send_sync().unwrap();
+        engine.reset().send_sync();
         engine.assert_schema().assert_tables_count(0).unwrap();
     }
 }
@@ -257,17 +247,12 @@ fn soft_resets_work_on_mysql(api: TestApi) {
     {
         let engine = api.new_engine();
 
-        engine
-            .create_migration("01init", dm, &migrations_directory)
-            .send_sync()
-            .unwrap();
+        engine.create_migration("01init", dm, &migrations_directory).send_sync();
 
         engine
             .apply_migrations(&migrations_directory)
             .send_sync()
-            .unwrap()
-            .assert_applied_migrations(&["01init"])
-            .unwrap();
+            .assert_applied_migrations(&["01init"]);
 
         engine
             .assert_schema()
@@ -318,15 +303,13 @@ fn soft_resets_work_on_mysql(api: TestApi) {
     {
         let engine = api.new_engine_with_connection_strings(&test_user_connection_string, None);
 
-        engine.reset().send_sync().unwrap();
+        engine.reset().send_sync();
         engine.assert_schema().assert_tables_count(0).unwrap();
 
         engine
             .schema_push(dm)
             .send_sync()
-            .unwrap()
             .assert_has_executed_steps()
-            .unwrap()
             .assert_green()
             .unwrap();
 
@@ -337,7 +320,7 @@ fn soft_resets_work_on_mysql(api: TestApi) {
             .assert_has_table("Cat")
             .unwrap();
 
-        engine.reset().send_sync().unwrap();
+        engine.reset().send_sync();
         engine.assert_schema().assert_tables_count(0).unwrap();
     }
 }

--- a/migration-engine/migration-engine-tests/tests/migrations/sqlite.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/sqlite.rs
@@ -1,8 +1,8 @@
-use migration_engine_tests::sql::*;
+use migration_engine_tests::sync_test_api::*;
 use test_macros::test_connector;
 
 #[test_connector(tags(Sqlite))]
-async fn sqlite_must_recreate_indexes(api: &TestApi) -> TestResult {
+fn sqlite_must_recreate_indexes(api: TestApi) {
     // SQLite must go through a complicated migration procedure which requires dropping and recreating indexes. This test checks that.
     // We run them still against each connector.
     let dm1 = r#"
@@ -12,11 +12,13 @@ async fn sqlite_must_recreate_indexes(api: &TestApi) -> TestResult {
         }
     "#;
 
-    api.schema_push(dm1).send().await?.assert_green()?;
+    api.schema_push(dm1).send_sync().assert_green().unwrap();
 
-    api.assert_schema().await?.assert_table("A", |table| {
-        table.assert_index_on_columns(&["field"], |idx| idx.assert_is_unique())
-    })?;
+    api.assert_schema()
+        .assert_table("A", |table| {
+            table.assert_index_on_columns(&["field"], |idx| idx.assert_is_unique())
+        })
+        .unwrap();
 
     let dm2 = r#"
         model A {
@@ -26,17 +28,17 @@ async fn sqlite_must_recreate_indexes(api: &TestApi) -> TestResult {
         }
     "#;
 
-    api.schema_push(dm2).send().await?.assert_green()?;
+    api.schema_push(dm2).send_sync().assert_green().unwrap();
 
-    api.assert_schema().await?.assert_table("A", |table| {
-        table.assert_index_on_columns(&["field"], |idx| idx.assert_is_unique())
-    })?;
-
-    Ok(())
+    api.assert_schema()
+        .assert_table("A", |table| {
+            table.assert_index_on_columns(&["field"], |idx| idx.assert_is_unique())
+        })
+        .unwrap();
 }
 
 #[test_connector(tags(Sqlite))]
-async fn sqlite_must_recreate_multi_field_indexes(api: &TestApi) -> TestResult {
+fn sqlite_must_recreate_multi_field_indexes(api: TestApi) {
     // SQLite must go through a complicated migration procedure which requires dropping and recreating indexes. This test checks that.
     // We run them still against each connector.
     let dm1 = r#"
@@ -49,11 +51,13 @@ async fn sqlite_must_recreate_multi_field_indexes(api: &TestApi) -> TestResult {
         }
     "#;
 
-    api.schema_push(dm1).send().await?.assert_green()?;
+    api.schema_push(dm1).send_sync().assert_green().unwrap();
 
-    api.assert_schema().await?.assert_table("A", |table| {
-        table.assert_index_on_columns(&["field", "secondField"], |idx| idx.assert_is_unique())
-    })?;
+    api.assert_schema()
+        .assert_table("A", |table| {
+            table.assert_index_on_columns(&["field", "secondField"], |idx| idx.assert_is_unique())
+        })
+        .unwrap();
 
     let dm2 = r#"
         model A {
@@ -66,26 +70,28 @@ async fn sqlite_must_recreate_multi_field_indexes(api: &TestApi) -> TestResult {
         }
     "#;
 
-    api.schema_push(dm2).send().await?.assert_green()?;
+    api.schema_push(dm2).send_sync().assert_green().unwrap();
 
-    api.assert_schema().await?.assert_table("A", |table| {
-        table.assert_index_on_columns(&["field", "secondField"], |idx| idx.assert_is_unique())
-    })?;
-
-    Ok(())
+    api.assert_schema()
+        .assert_table("A", |table| {
+            table.assert_index_on_columns(&["field", "secondField"], |idx| idx.assert_is_unique())
+        })
+        .unwrap();
 }
 
 // This is necessary because of how INTEGER PRIMARY KEY works on SQLite. This has already caused problems.
 #[test_connector(tags(Sqlite))]
-async fn creating_a_model_with_a_non_autoincrement_id_column_is_idempotent(api: &TestApi) -> TestResult {
+fn creating_a_model_with_a_non_autoincrement_id_column_is_idempotent(api: TestApi) {
     let dm = r#"
         model Cat {
             id  Int @id
         }
     "#;
 
-    api.schema_push(dm).send().await?.assert_green()?;
-    api.schema_push(dm).send().await?.assert_green()?.assert_no_steps()?;
-
-    Ok(())
+    api.schema_push(dm).send_sync().assert_green().unwrap();
+    api.schema_push(dm)
+        .send_sync()
+        .assert_green()
+        .unwrap()
+        .assert_no_steps();
 }

--- a/migration-engine/migration-engine-tests/tests/migrations/squashing_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/squashing_tests.rs
@@ -147,7 +147,7 @@ async fn squashing_whole_migration_history_works(api: &TestApi) -> TestResult {
     api.apply_migrations(&directory)
         .send()
         .await?
-        .assert_applied_migrations(&[])?;
+        .assert_applied_migrations(&[]);
 
     let DiagnoseMigrationHistoryOutput {
         drift,
@@ -329,7 +329,7 @@ async fn squashing_migrations_history_at_the_start_works(api: &TestApi) -> TestR
     api.apply_migrations(&directory)
         .send()
         .await?
-        .assert_applied_migrations(&[])?;
+        .assert_applied_migrations(&[]);
 
     let DiagnoseMigrationHistoryOutput {
         drift,
@@ -488,7 +488,7 @@ async fn squashing_migrations_history_at_the_end_works(api: &TestApi) -> TestRes
     api.apply_migrations(&directory)
         .send()
         .await?
-        .assert_applied_migrations(&[])?;
+        .assert_applied_migrations(&[]);
 
     let DiagnoseMigrationHistoryOutput {
         drift,

--- a/migration-engine/migration-engine-tests/tests/migrations/types.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/types.rs
@@ -19,9 +19,9 @@ async fn bytes_columns_are_idempotent(api: &TestApi) -> TestResult {
         .send()
         .await?
         .assert_green()?
-        .assert_has_executed_steps()?;
+        .assert_has_executed_steps();
 
-    api.schema_push(&dm).send().await?.assert_green()?.assert_no_steps()?;
+    api.schema_push(&dm).send().await?.assert_green()?.assert_no_steps();
 
     Ok(())
 }
@@ -39,9 +39,9 @@ async fn float_columns_are_idempotent(api: &TestApi) -> TestResult {
         .send()
         .await?
         .assert_green()?
-        .assert_has_executed_steps()?;
+        .assert_has_executed_steps();
 
-    api.schema_push(dm).send().await?.assert_green()?.assert_no_steps()?;
+    api.schema_push(dm).send().await?.assert_green()?.assert_no_steps();
 
     Ok(())
 }
@@ -64,9 +64,9 @@ async fn decimal_columns_are_idempotent(api: &TestApi) -> TestResult {
         .send()
         .await?
         .assert_green()?
-        .assert_has_executed_steps()?;
+        .assert_has_executed_steps();
 
-    api.schema_push(&dm).send().await?.assert_green()?.assert_no_steps()?;
+    api.schema_push(&dm).send().await?.assert_green()?.assert_no_steps();
 
     Ok(())
 }
@@ -102,7 +102,7 @@ async fn float_to_decimal_works(api: &TestApi) -> TestResult {
         .send()
         .await?
         .assert_green()?
-        .assert_has_executed_steps()?;
+        .assert_has_executed_steps();
 
     api.assert_schema().await?.assert_table("Cat", |table| {
         table.assert_column("meowFrequency", |col| col.assert_type_family(ColumnTypeFamily::Decimal))
@@ -142,7 +142,7 @@ async fn decimal_to_float_works(api: &TestApi) -> TestResult {
         .send()
         .await?
         .assert_green()?
-        .assert_has_executed_steps()?;
+        .assert_has_executed_steps();
 
     api.assert_schema().await?.assert_table("Cat", |table| {
         table.assert_column("meowFrequency", |col| col.assert_type_family(ColumnTypeFamily::Float))
@@ -182,7 +182,7 @@ async fn bytes_to_string_works(api: &TestApi) -> TestResult {
         .send()
         .await?
         .assert_green()?
-        .assert_has_executed_steps()?;
+        .assert_has_executed_steps();
 
     api.assert_schema().await?.assert_table("Cat", |table| {
         table.assert_column("meowData", |col| col.assert_type_is_string())
@@ -222,7 +222,7 @@ async fn string_to_bytes_works(api: &TestApi) -> TestResult {
         .send()
         .await?
         .assert_green()?
-        .assert_has_executed_steps()?;
+        .assert_has_executed_steps();
 
     api.assert_schema().await?.assert_table("Cat", |table| {
         table.assert_column("meowData", |col| col.assert_type_is_string())
@@ -262,7 +262,7 @@ async fn decimal_to_decimal_array_works(api: &TestApi) -> TestResult {
         .send()
         .await?
         .assert_green()?
-        .assert_has_executed_steps()?;
+        .assert_has_executed_steps();
 
     api.assert_schema().await?.assert_table("Test", |table| {
         table.assert_column("decFloat", |col| col.assert_type_is_decimal()?.assert_is_list())
@@ -313,7 +313,7 @@ async fn bytes_to_bytes_array_works(api: &TestApi) -> TestResult {
         .send()
         .await?
         .assert_green()?
-        .assert_has_executed_steps()?;
+        .assert_has_executed_steps();
 
     api.assert_schema().await?.assert_table("Test", |table| {
         table.assert_column("bytesCol", |col| col.assert_type_is_bytes()?.assert_is_list())

--- a/migration-engine/migration-engine-tests/tests/native_types/common.rs
+++ b/migration-engine/migration-engine-tests/tests/native_types/common.rs
@@ -26,9 +26,9 @@ async fn typescript_starter_schema_is_idempotent_without_native_type_annotations
         .send()
         .await?
         .assert_green()?
-        .assert_has_executed_steps()?;
-    api.schema_push(&dm).send().await?.assert_green()?.assert_no_steps()?;
-    api.schema_push(&dm).send().await?.assert_green()?.assert_no_steps()?;
+        .assert_has_executed_steps();
+    api.schema_push(&dm).send().await?.assert_green()?.assert_no_steps();
+    api.schema_push(&dm).send().await?.assert_green()?.assert_no_steps();
 
     Ok(())
 }
@@ -58,9 +58,9 @@ async fn typescript_starter_schema_starting_without_native_types_is_idempotent(a
         .send()
         .await?
         .assert_green()?
-        .assert_has_executed_steps()?;
-    api.schema_push(dm).send().await?.assert_green()?.assert_no_steps()?;
-    api.schema_push(&dm2).send().await?.assert_green()?.assert_no_steps()?;
+        .assert_has_executed_steps();
+    api.schema_push(dm).send().await?.assert_green()?.assert_no_steps();
+    api.schema_push(&dm2).send().await?.assert_green()?.assert_no_steps();
 
     Ok(())
 }
@@ -76,7 +76,7 @@ async fn bigint_primary_keys_are_idempotent(api: &TestApi) -> TestResult {
     );
 
     api.schema_push(&dm1).send().await?.assert_green()?;
-    api.schema_push(dm1).send().await?.assert_green()?.assert_no_steps()?;
+    api.schema_push(dm1).send().await?.assert_green()?.assert_no_steps();
 
     let dm2 = api.native_types_datamodel(
         r#"
@@ -87,7 +87,7 @@ async fn bigint_primary_keys_are_idempotent(api: &TestApi) -> TestResult {
     );
 
     api.schema_push(&dm2).send().await?.assert_green()?;
-    api.schema_push(dm2).send().await?.assert_green()?.assert_no_steps()?;
+    api.schema_push(dm2).send().await?.assert_green()?.assert_no_steps();
 
     Ok(())
 }

--- a/migration-engine/migration-engine-tests/tests/native_types/mssql.rs
+++ b/migration-engine/migration-engine-tests/tests/native_types/mssql.rs
@@ -2145,19 +2145,19 @@ async fn typescript_starter_schema_with_native_types_is_idempotent(api: &TestApi
         .send()
         .await?
         .assert_green()?
-        .assert_has_executed_steps()?;
+        .assert_has_executed_steps();
     api.schema_push(&dm)
         .migration_id(Some("second"))
         .send()
         .await?
         .assert_green()?
-        .assert_no_steps()?;
+        .assert_no_steps();
     api.schema_push(&dm2)
         .migration_id(Some("third"))
         .send()
         .await?
         .assert_green()?
-        .assert_no_steps()?;
+        .assert_no_steps();
 
     Ok(())
 }
@@ -2210,26 +2210,26 @@ async fn typescript_starter_schema_with_different_native_types_is_idempotent(api
         .send()
         .await?
         .assert_green()?
-        .assert_has_executed_steps()?;
+        .assert_has_executed_steps();
     api.schema_push(&dm)
         .migration_id(Some("second"))
         .send()
         .await?
         .assert_green()?
-        .assert_no_steps()?;
+        .assert_no_steps();
 
     api.schema_push(&dm2)
         .migration_id(Some("third"))
         .send()
         .await?
         .assert_green()?
-        .assert_has_executed_steps()?;
+        .assert_has_executed_steps();
     api.schema_push(&dm2)
         .migration_id(Some("fourth"))
         .send()
         .await?
         .assert_green()?
-        .assert_no_steps()?;
+        .assert_no_steps();
 
     Ok(())
 }

--- a/migration-engine/migration-engine-tests/tests/native_types/mysql.rs
+++ b/migration-engine/migration-engine-tests/tests/native_types/mysql.rs
@@ -852,7 +852,7 @@ async fn risky_casts_with_existing_data_should_warn(api: &TestApi) -> TestResult
             .force(true)
             .send()
             .await?
-            .assert_executable()?
+            .assert_executable()
             .assert_warnings(&warnings)?;
 
         api.assert_schema().await?.assert_table("Test", |table| {
@@ -921,7 +921,7 @@ async fn impossible_casts_with_existing_data_should_warn(api: &TestApi) -> TestR
             .force(true)
             .send()
             .await?
-            .assert_executable()?
+            .assert_executable()
             .assert_warnings(&warnings)?;
 
         api.assert_schema().await?.assert_table("Test", |table| {
@@ -986,19 +986,19 @@ async fn typescript_starter_schema_with_native_types_is_idempotent(api: &TestApi
         .send()
         .await?
         .assert_green()?
-        .assert_has_executed_steps()?;
+        .assert_has_executed_steps();
     api.schema_push(&dm)
         .migration_id(Some("second"))
         .send()
         .await?
         .assert_green()?
-        .assert_no_steps()?;
+        .assert_no_steps();
     api.schema_push(&dm2)
         .migration_id(Some("third"))
         .send()
         .await?
         .assert_green()?
-        .assert_no_steps()?;
+        .assert_no_steps();
 
     Ok(())
 }
@@ -1051,26 +1051,26 @@ async fn typescript_starter_schema_with_differnt_native_types_is_idempotent(api:
         .send()
         .await?
         .assert_green()?
-        .assert_has_executed_steps()?;
+        .assert_has_executed_steps();
     api.schema_push(&dm)
         .migration_id(Some("second"))
         .send()
         .await?
         .assert_green()?
-        .assert_no_steps()?;
+        .assert_no_steps();
 
     api.schema_push(&dm2)
         .migration_id(Some("third"))
         .send()
         .await?
         .assert_green()?
-        .assert_has_executed_steps()?;
+        .assert_has_executed_steps();
     api.schema_push(&dm2)
         .migration_id(Some("third"))
         .send()
         .await?
         .assert_green()?
-        .assert_no_steps()?;
+        .assert_no_steps();
 
     Ok(())
 }

--- a/migration-engine/migration-engine-tests/tests/native_types/postgres.rs
+++ b/migration-engine/migration-engine-tests/tests/native_types/postgres.rs
@@ -1313,19 +1313,19 @@ async fn typescript_starter_schema_with_native_types_is_idempotent(api: &TestApi
         .send()
         .await?
         .assert_green()?
-        .assert_has_executed_steps()?;
+        .assert_has_executed_steps();
     api.schema_push(&dm)
         .migration_id(Some("second"))
         .send()
         .await?
         .assert_green()?
-        .assert_no_steps()?;
+        .assert_no_steps();
     api.schema_push(&dm2)
         .migration_id(Some("third"))
         .send()
         .await?
         .assert_green()?
-        .assert_no_steps()?;
+        .assert_no_steps();
 
     Ok(())
 }
@@ -1378,25 +1378,25 @@ async fn typescript_starter_schema_with_differnt_native_types_is_idempotent(api:
         .send()
         .await?
         .assert_green()?
-        .assert_has_executed_steps()?;
+        .assert_has_executed_steps();
     api.schema_push(&dm)
         .migration_id(Some("second"))
         .send()
         .await?
         .assert_green()?
-        .assert_no_steps()?;
+        .assert_no_steps();
     api.schema_push(&dm2)
         .migration_id(Some("third"))
         .send()
         .await?
         .assert_green()?
-        .assert_has_executed_steps()?;
+        .assert_has_executed_steps();
     api.schema_push(&dm2)
         .migration_id(Some("third"))
         .send()
         .await?
         .assert_green()?
-        .assert_no_steps()?;
+        .assert_no_steps();
 
     Ok(())
 }

--- a/migration-engine/migration-engine-tests/tests/schema_push/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/schema_push/mod.rs
@@ -21,7 +21,7 @@ async fn schema_push_happy_path(api: &TestApi) -> TestResult {
         .send()
         .await?
         .assert_green()?
-        .assert_has_executed_steps()?;
+        .assert_has_executed_steps();
 
     api.assert_schema()
         .await?
@@ -51,7 +51,7 @@ async fn schema_push_happy_path(api: &TestApi) -> TestResult {
         .send()
         .await?
         .assert_green()?
-        .assert_has_executed_steps()?;
+        .assert_has_executed_steps();
 
     api.assert_schema()
         .await?
@@ -73,7 +73,7 @@ async fn schema_push_warns_about_destructive_changes(api: &TestApi) -> TestResul
         .send()
         .await?
         .assert_green()?
-        .assert_has_executed_steps()?;
+        .assert_has_executed_steps();
 
     api.insert("Box")
         .value("id", 1)
@@ -95,15 +95,17 @@ async fn schema_push_warns_about_destructive_changes(api: &TestApi) -> TestResul
     api.schema_push(dm2)
         .send()
         .await?
-        .assert_warnings(&[expected_warning.as_str().into()])?
-        .assert_no_steps()?;
+        .assert_warnings(&[expected_warning.as_str().into()])
+        .unwrap()
+        .assert_no_steps();
 
     api.schema_push(dm2)
         .force(true)
         .send()
         .await?
-        .assert_warnings(&[expected_warning.as_str().into()])?
-        .assert_has_executed_steps()?;
+        .assert_warnings(&[expected_warning.as_str().into()])
+        .unwrap()
+        .assert_has_executed_steps();
 
     Ok(())
 }
@@ -114,7 +116,7 @@ async fn schema_push_with_an_unexecutable_migration_returns_a_message_and_aborts
         .send()
         .await?
         .assert_green()?
-        .assert_has_executed_steps()?;
+        .assert_has_executed_steps();
 
     api.insert("Box")
         .value("id", 1)
@@ -141,7 +143,7 @@ async fn schema_push_with_an_unexecutable_migration_returns_a_message_and_aborts
         .send()
         .await?
         .assert_unexecutable(&["Added the required column `volumeCm3` to the `Box` table without a default value. There are 1 rows in this table, it is not possible to execute this step.".into()])?
-        .assert_no_steps()?;
+        .assert_no_steps();
 
     Ok(())
 }


### PR DESCRIPTION
The main benefit is that we can avoid result handling, gaining in
terseness in compile time, while getting even better errors in tests.