### PR TITLE
Remove datasource url overrides from core datamodel parse API

### DIFF
--- a/libs/datamodel/core/src/configuration/configuration.rs
+++ b/libs/datamodel/core/src/configuration/configuration.rs
@@ -28,8 +28,13 @@ impl Configuration {
             .flat_map(|generator| generator.preview_features.iter())
     }
 
-    pub fn resolve_datasource_urls_from_env(&mut self) -> Result<(), Diagnostics> {
+    pub fn resolve_datasource_urls_from_env(&mut self, url_overrides: &[(String, String)]) -> Result<(), Diagnostics> {
         for datasource in &mut self.datasources {
+            if let Some((_, url)) = url_overrides.iter().find(|(name, _url)| name == &datasource.name) {
+                datasource.url.value = Some(url.clone());
+                datasource.url.from_env_var = None;
+            }
+
             if datasource.url.from_env_var.is_some() && datasource.url.value.is_none() {
                 datasource.url.value = Some(datasource.load_url()?);
             }

--- a/libs/datamodel/core/src/lib.rs
+++ b/libs/datamodel/core/src/lib.rs
@@ -119,7 +119,7 @@ fn parse_datamodel_internal(
     let mut diagnostics = diagnostics::Diagnostics::new();
     let ast = ast::parse_schema(datamodel_string)?;
 
-    let sources = load_sources(&ast, vec![])?;
+    let sources = load_sources(&ast)?;
     let generators = GeneratorLoader::load_generators_from_ast(&ast)?;
     let validator = ValidationPipeline::new(&sources.subject);
 
@@ -143,18 +143,10 @@ pub fn parse_schema_ast(datamodel_string: &str) -> Result<SchemaAst, diagnostics
 }
 
 /// Loads all configuration blocks from a datamodel using the built-in source definitions.
-pub fn parse_configuration(datamodel_string: &str) -> Result<ValidatedConfiguration, diagnostics::Diagnostics> {
-    parse_configuration_with_url_overrides(datamodel_string, Vec::new())
-}
-
-/// - `datasource_url_overrides`: the tuples consist of datasource name and url
-pub fn parse_configuration_with_url_overrides(
-    schema: &str,
-    datasource_url_overrides: Vec<(String, String)>,
-) -> Result<ValidatedConfiguration, diagnostics::Diagnostics> {
+pub fn parse_configuration(schema: &str) -> Result<ValidatedConfiguration, diagnostics::Diagnostics> {
     let mut warnings = Vec::new();
     let ast = ast::parse_schema(schema)?;
-    let mut validated_sources = load_sources(&ast, datasource_url_overrides)?;
+    let mut validated_sources = load_sources(&ast)?;
     let mut validated_generators = GeneratorLoader::load_generators_from_ast(&ast)?;
 
     warnings.append(&mut validated_generators.warnings);
@@ -169,12 +161,9 @@ pub fn parse_configuration_with_url_overrides(
     })
 }
 
-fn load_sources(
-    schema_ast: &SchemaAst,
-    datasource_url_overrides: Vec<(String, String)>,
-) -> Result<ValidatedDatasources, diagnostics::Diagnostics> {
+fn load_sources(schema_ast: &SchemaAst) -> Result<ValidatedDatasources, diagnostics::Diagnostics> {
     let source_loader = DatasourceLoader::new();
-    source_loader.load_datasources_from_ast(&schema_ast, datasource_url_overrides)
+    source_loader.load_datasources_from_ast(&schema_ast)
 }
 
 //

--- a/libs/datamodel/core/tests/common.rs
+++ b/libs/datamodel/core/tests/common.rs
@@ -395,23 +395,6 @@ pub fn parse_configuration(datamodel_string: &str) -> Configuration {
     }
 }
 
-pub fn parse_configuration_with_url_overrides(
-    datamodel_string: &str,
-    datasource_url_overrides: Vec<(String, String)>,
-) -> Configuration {
-    match datamodel::parse_configuration_with_url_overrides(datamodel_string, datasource_url_overrides) {
-        Ok(c) => c.subject,
-        Err(errs) => {
-            for err in errs.to_error_iter() {
-                err.pretty_print(&mut std::io::stderr().lock(), "", datamodel_string)
-                    .unwrap()
-            }
-
-            panic!("Configuration parsing failed. Please see error above.")
-        }
-    }
-}
-
 pub fn parse_with_diagnostics(datamodel_string: &str) -> ValidatedDatamodel {
     match datamodel::parse_datamodel(datamodel_string) {
         Ok(s) => s,

--- a/libs/datamodel/core/tests/config/sources.rs
+++ b/libs/datamodel/core/tests/config/sources.rs
@@ -320,7 +320,8 @@ fn must_succeed_if_env_var_is_missing_but_override_was_provided() {
 
     let url = "postgres://localhost";
     let overrides = vec![("ds".to_string(), url.to_string())];
-    let config = parse_configuration_with_url_overrides(schema, overrides);
+    let mut config = parse_configuration(schema);
+    config.resolve_datasource_urls_from_env(&overrides).unwrap();
     let data_source = config.datasources.first().unwrap();
 
     data_source.assert_name("ds");
@@ -343,7 +344,8 @@ fn must_succeed_if_env_var_exists_and_override_was_provided() {
 
     let url = "postgres://hostbar";
     let overrides = vec![("ds".to_string(), url.to_string())];
-    let config = parse_configuration_with_url_overrides(schema, overrides);
+    let mut config = parse_configuration(schema);
+    config.resolve_datasource_urls_from_env(&overrides).unwrap();
     let data_source = config.datasources.first().unwrap();
 
     data_source.assert_name("ds");
@@ -365,7 +367,9 @@ fn must_succeed_with_overrides() {
 
     let url = "postgres://hostbar";
     let overrides = vec![("ds".to_string(), url.to_string())];
-    let config = parse_configuration_with_url_overrides(schema, overrides);
+    let mut config = parse_configuration(schema);
+    config.resolve_datasource_urls_from_env(&overrides).unwrap();
+
     let data_source = config.datasources.first().unwrap();
 
     data_source.assert_name("ds");

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/direct.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/direct.rs
@@ -17,9 +17,7 @@ pub struct DirectRunner {
 #[async_trait::async_trait]
 impl RunnerInterface for DirectRunner {
     async fn load(datamodel: String, connector_tag: ConnectorTag) -> TestResult<Self> {
-        let config = datamodel::parse_configuration_with_url_overrides(&datamodel, vec![])
-            .unwrap()
-            .subject;
+        let config = datamodel::parse_configuration(&datamodel).unwrap().subject;
 
         let parsed_datamodel = datamodel::parse_datamodel(&datamodel).unwrap().subject;
         let internal_datamodel = DatamodelConverter::convert(&parsed_datamodel);

--- a/query-engine/query-engine-napi/src/engine.rs
+++ b/query-engine/query-engine-napi/src/engine.rs
@@ -125,8 +125,8 @@ impl QueryEngine {
         } = opts;
 
         let overrides: Vec<(_, _)> = datasource_overrides.into_iter().collect();
-        let mut config = datamodel::parse_configuration_with_url_overrides(&datamodel, overrides.clone())
-            .map_err(|errors| ApiError::conversion(errors, &datamodel))?;
+        let mut config =
+            datamodel::parse_configuration(&datamodel).map_err(|errors| ApiError::conversion(errors, &datamodel))?;
 
         config.subject = config
             .subject
@@ -135,7 +135,7 @@ impl QueryEngine {
 
         config
             .subject
-            .resolve_datasource_urls_from_env()
+            .resolve_datasource_urls_from_env(&overrides)
             .map_err(|errors| ApiError::conversion(errors, &datamodel))?;
 
         let ast = datamodel::parse_datamodel(&datamodel)
@@ -233,11 +233,8 @@ impl QueryEngine {
 
         match *inner {
             Inner::Connected(ref engine) => {
-                let config = datamodel::parse_configuration_with_url_overrides(
-                    &engine.datamodel.raw,
-                    engine.datamodel.datasource_overrides.clone(),
-                )
-                .map_err(|errors| ApiError::conversion(errors, &engine.datamodel.raw))?;
+                let config = datamodel::parse_configuration(&engine.datamodel.raw)
+                    .map_err(|errors| ApiError::conversion(errors, &engine.datamodel.raw))?;
 
                 let builder = EngineBuilder {
                     datamodel: engine.datamodel.clone(),

--- a/query-engine/query-engine/src/cli.rs
+++ b/query-engine/query-engine/src/cli.rs
@@ -116,7 +116,7 @@ impl CliCommand {
         let config = &mut req.config;
 
         if !req.ignore_env_var_errors {
-            config.subject.resolve_datasource_urls_from_env()?;
+            config.subject.resolve_datasource_urls_from_env(&[])?;
         }
 
         let json = datamodel::json::mcf::config_to_mcf_json_value(&config);

--- a/query-engine/query-engine/src/opt.rs
+++ b/query-engine/query-engine/src/opt.rs
@@ -143,12 +143,13 @@ impl PrismaOpt {
         let config_result = if ignore_env_errors {
             datamodel::parse_configuration(datamodel_str)
         } else {
-            datamodel::parse_configuration_with_url_overrides(datamodel_str, datasource_url_overrides).and_then(
-                |config| {
-                    config.subject.datasources[0].load_url()?;
-                    Ok(config)
-                },
-            )
+            datamodel::parse_configuration(datamodel_str).and_then(|mut config| {
+                config
+                    .subject
+                    .resolve_datasource_urls_from_env(&datasource_url_overrides)?;
+
+                Ok(config)
+            })
         };
         config_result.map_err(|errors| PrismaError::ConversionError(errors, datamodel_str.to_string()))
     }


### PR DESCRIPTION
As with env vars since
https://github.com/prisma/prisma-engines/pull/1896, this concern is
moved to a later point, when the datasource URL is actually needed.