### PR TITLE
Introduce a napi function: `version()`

### DIFF
--- a/query-engine/query-engine-napi/src/engine.rs
+++ b/query-engine/query-engine-napi/src/engine.rs
@@ -305,22 +305,6 @@ impl QueryEngine {
             }
         }
     }
-
-    /// Info about the runnings server.
-    pub async fn server_info(&self) -> crate::Result<ServerInfo> {
-        match *self.inner.read().await {
-            Inner::Connected(ref engine) => Ok(ServerInfo {
-                commit: env!("GIT_HASH").into(),
-                version: env!("CARGO_PKG_VERSION").into(),
-                primary_connector: Some(engine.executor().primary_connector().name()),
-            }),
-            Inner::Builder(_) => Ok(ServerInfo {
-                commit: env!("GIT_HASH").into(),
-                version: env!("CARGO_PKG_VERSION").into(),
-                primary_connector: None,
-            }),
-        }
-    }
 }
 
 pub fn set_panic_hook() {


### PR DESCRIPTION
Removes the `server_info` from the `QueryEngine` class in favor of a separate function `version`, returning the commit and cargo version.

Closes: https://github.com/prisma/prisma-engines/issues/1926