### PR TITLE
fix: coalesce to 0 order by rel count

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3369,7 +3369,7 @@ dependencies = [
 [[package]]
 name = "quaint"
 version = "0.2.0-alpha.13"
-source = "git+https://github.com/prisma/quaint#93fca2904bb9cffafe5e729b459a69fba720c095"
+source = "git+https://github.com/prisma/quaint#7d3e8d6a93bcf44546f2e46d8026bd7c98c8a13e"
 dependencies = [
  "async-trait",
  "base64 0.12.3",

--- a/query-engine/connector-test-kit/src/test/scala/queries/orderAndPagination/OrderByAggregationSpec.scala
+++ b/query-engine/connector-test-kit/src/test/scala/queries/orderAndPagination/OrderByAggregationSpec.scala
@@ -54,7 +54,7 @@ class OrderByAggregationSpec extends FlatSpec with Matchers with ApiSpecBase {
     )
 
     result.toString should be(
-      """{"data":{"findManyUser":[{"id":1,"posts":[{"title":"alice_post_1"}]},{"id":2,"posts":[{"title":"bob_post_1"},{"title":"bob_post_2"}]}]}}"""
+      """{"data":{"findManyUser":[{"id":3,"posts":[]},{"id":1,"posts":[{"title":"alice_post_1"}]},{"id":2,"posts":[{"title":"bob_post_1"},{"title":"bob_post_2"}]}]}}"""
     )
   }
 
@@ -75,7 +75,7 @@ class OrderByAggregationSpec extends FlatSpec with Matchers with ApiSpecBase {
     )
 
     result.toString should be(
-      """{"data":{"findManyUser":[{"id":2,"posts":[{"title":"bob_post_1"},{"title":"bob_post_2"}]},{"id":1,"posts":[{"title":"alice_post_1"}]}]}}"""
+      """{"data":{"findManyUser":[{"id":2,"posts":[{"title":"bob_post_1"},{"title":"bob_post_2"}]},{"id":1,"posts":[{"title":"alice_post_1"}]},{"id":3,"posts":[]}]}}"""
     )
   }
 
@@ -139,7 +139,7 @@ class OrderByAggregationSpec extends FlatSpec with Matchers with ApiSpecBase {
     )
 
     result.toString should be(
-      """{"data":{"findManyUser":[{"id":1,"name":"Alice","posts":[{"title":"alice_post_1"}]},{"id":2,"name":"Bob","posts":[{"title":"bob_post_1"},{"title":"bob_post_2"}]}]}}"""
+      """{"data":{"findManyUser":[{"id":3,"name":"Motongo","posts":[]},{"id":1,"name":"Alice","posts":[{"title":"alice_post_1"}]},{"id":2,"name":"Bob","posts":[{"title":"bob_post_1"},{"title":"bob_post_2"}]}]}}"""
     )
   }
 
@@ -161,7 +161,7 @@ class OrderByAggregationSpec extends FlatSpec with Matchers with ApiSpecBase {
     )
 
     result.toString should be(
-      """{"data":{"findManyUser":[{"id":2,"name":"Bob","posts":[{"title":"bob_post_1"},{"title":"bob_post_2"}]},{"id":1,"name":"Alice","posts":[{"title":"alice_post_1"}]}]}}"""
+      """{"data":{"findManyUser":[{"id":3,"name":"Motongo","posts":[]},{"id":2,"name":"Bob","posts":[{"title":"bob_post_1"},{"title":"bob_post_2"}]},{"id":1,"name":"Alice","posts":[{"title":"alice_post_1"}]}]}}"""
     )
   }
 
@@ -558,5 +558,6 @@ class OrderByAggregationSpec extends FlatSpec with Matchers with ApiSpecBase {
   private def createTestData(): Unit = {
     server.query("""mutation { createOneUser(data: { id: 1, name: "Alice", categories: { create: [{ id: 1, name: "Startup" }] }, posts: { create: { id: 1, title: "alice_post_1", categories: { create: [{ id: 2, name: "News" }, { id: 3, name: "Society" }] }} } }){ id }}""".stripMargin, project, legacy = false)
     server.query("""mutation { createOneUser(data: { id: 2, name: "Bob", categories: { create: [{ id: 4, name: "Computer Science" }, { id: 5, name: "Music" }] }, posts: { create: [{ id: 2, title: "bob_post_1", categories: { create: [{ id: 6, name: "Finance" }] } }, { id: 3, title: "bob_post_2", categories: { create: [{ id: 7, name: "History" }, { id: 8, name: "Gaming" }, { id: 9, name: "Hacking" }] } }] } }){ id }}""".stripMargin, project, legacy = false)
+    server.query("""mutation { createOneUser(data: { id: 3, name: "Motongo" }){ id }}""".stripMargin, project, legacy = false)
   }
 }


### PR DESCRIPTION
## Overview

Closes https://github.com/prisma/prisma/issues/6824

On an order by relation count, if no relation was present at all, ordered expression was `NULL`, thus messing the ordering.

We now always `COALESCE` the ordered expression to 0 so that if there's no relation, it'll preserve the ordering.