### PR TITLE
Improve parsing of Unsupported(...)

### DIFF
--- a/libs/datamodel/core/src/ast/field.rs
+++ b/libs/datamodel/core/src/ast/field.rs
@@ -1,9 +1,9 @@
-use super::*;
+use super::{Attribute, Comment, Identifier, Span, WithAttributes, WithDocumentation, WithIdentifier, WithSpan};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Field {
     /// The field's type.
-    pub field_type: Identifier,
+    pub field_type: FieldType,
     /// The name of the field.
     pub name: Identifier,
     /// The aritiy of the field.
@@ -51,4 +51,26 @@ pub enum FieldArity {
     Required,
     Optional,
     List,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum FieldType {
+    Supported(Identifier),
+    Unsupported(String, Span),
+}
+
+impl FieldType {
+    pub(crate) fn span(&self) -> Span {
+        match self {
+            FieldType::Supported(ident) => ident.span,
+            FieldType::Unsupported(_, span) => *span,
+        }
+    }
+
+    pub(crate) fn unwrap_supported(&self) -> &Identifier {
+        match self {
+            FieldType::Supported(ident) => ident,
+            FieldType::Unsupported(_, _) => panic!("Unsupported in unwrap_supported()"),
+        }
+    }
 }

--- a/libs/datamodel/core/src/ast/mod.rs
+++ b/libs/datamodel/core/src/ast/mod.rs
@@ -26,7 +26,7 @@ pub use argument::Argument;
 pub use attribute::Attribute;
 pub use comment::Comment;
 pub use expression::Expression;
-pub use field::{Field, FieldArity};
+pub use field::{Field, FieldArity, FieldType};
 pub use generator_config::GeneratorConfig;
 pub use identifier::Identifier;
 pub use model::Model;

--- a/libs/datamodel/core/src/ast/parser/datamodel.pest
+++ b/libs/datamodel/core/src/ast/parser/datamodel.pest
@@ -30,18 +30,15 @@ field_declaration = { doc_comment_and_new_line* ~ non_empty_identifier ~ LEGACY_
 // ######################################
 
 // Pest is greedy, order is very important here.
-field_type = { optional_unsupported_type | list_unsupported_type | unsupported_type | unsupported_optional_list_type | list_type | optional_type | legacy_required_type | legacy_list_type | base_type  }
+field_type = { unsupported_optional_list_type | list_type | optional_type | legacy_required_type | legacy_list_type | base_type  }
 
-//todo can these be merged?
-optional_unsupported_type = { "Unsupported(" ~ string_literal ~ ")" ~"?" }
-list_unsupported_type = { "Unsupported(" ~ string_literal ~ ")" ~"[]" }
 unsupported_type = { "Unsupported(" ~ string_literal ~ ")" }
-unsupported_optional_list_type = { non_empty_identifier ~ "[]" ~ "?" }
-list_type = { non_empty_identifier ~ "[]" }
-optional_type = { non_empty_identifier ~ "?" }
+base_type = { unsupported_type | non_empty_identifier } // Called base type to not conflict with type rust keyword
+unsupported_optional_list_type = { base_type ~ "[]" ~ "?" }
+list_type = { base_type ~ "[]" }
+optional_type = { base_type ~ "?" }
 legacy_required_type = { non_empty_identifier ~ "!" }
 legacy_list_type = { "[" ~ non_empty_identifier ~ "]" }
-base_type = { non_empty_identifier } // Called base type to not conflict with type rust keyword
 
 // ######################################
 // Type Alias

--- a/libs/datamodel/core/src/ast/parser/helpers.rs
+++ b/libs/datamodel/core/src/ast/parser/helpers.rs
@@ -3,7 +3,7 @@ use crate::ast::{Identifier, Span};
 
 pub type Token<'a> = pest::iterators::Pair<'a, Rule>;
 
-pub fn parsing_catch_all(token: &Token, kind: &str) {
+pub fn parsing_catch_all(token: &Token<'_>, kind: &str) {
     match token.as_rule() {
         Rule::comment | Rule::comment_and_new_line | Rule::comment_block | Rule::doc_comment_and_new_line => {}
         x => unreachable!(
@@ -32,11 +32,11 @@ impl ToIdentifier for pest::iterators::Pair<'_, Rule> {
 pub trait TokenExtensions {
     /// Gets the first child token that is relevant.
     /// Irrelevant Tokens are e.g. new lines which we do not want to match during parsing.
-    fn first_relevant_child(&self) -> Token;
+    fn first_relevant_child(&self) -> Token<'_>;
 
     /// Returns all child token of this Token that are relevant.
     /// Irrelevant Tokens are e.g. new lines which we do not want to match during parsing.
-    fn relevant_children(&self) -> Vec<Token>;
+    fn relevant_children(&self) -> Vec<Token<'_>>;
 }
 
 // this is not implemented for Token because auto completion does not work then
@@ -48,7 +48,7 @@ impl TokenExtensions for pest::iterators::Pair<'_, Rule> {
             .unwrap_or_else(|| panic!("Token `{}` had no children.", &self))
     }
 
-    fn relevant_children(&self) -> Vec<Token> {
+    fn relevant_children(&self) -> Vec<Token<'_>> {
         self.clone()
             .into_inner()
             .filter(|rule| {

--- a/libs/datamodel/core/src/ast/parser/parse_attribute.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_attribute.rs
@@ -5,7 +5,7 @@ use super::{
 };
 use crate::ast::*;
 
-pub fn parse_attribute(token: &Token) -> Attribute {
+pub fn parse_attribute(token: &Token<'_>) -> Attribute {
     let mut name: Option<Identifier> = None;
     let mut arguments: Vec<Argument> = vec![];
 
@@ -28,7 +28,7 @@ pub fn parse_attribute(token: &Token) -> Attribute {
     }
 }
 
-fn parse_attribute_args(token: &Token, arguments: &mut Vec<Argument>) {
+fn parse_attribute_args(token: &Token<'_>, arguments: &mut Vec<Argument>) {
     for current in token.relevant_children() {
         match current.as_rule() {
             // This is a named arg.
@@ -44,7 +44,7 @@ fn parse_attribute_args(token: &Token, arguments: &mut Vec<Argument>) {
     }
 }
 
-fn parse_attribute_arg(token: &Token) -> Argument {
+fn parse_attribute_arg(token: &Token<'_>) -> Argument {
     let mut name: Option<Identifier> = None;
     let mut argument: Option<Expression> = None;
 

--- a/libs/datamodel/core/src/ast/parser/parse_comments.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_comments.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use crate::ast::Comment;
 
-pub fn parse_comment_block(token: &Token) -> Option<Comment> {
+pub fn parse_comment_block(token: &Token<'_>) -> Option<Comment> {
     let mut comments: Vec<String> = Vec::new();
     for comment in token.clone().into_inner() {
         match comment.as_rule() {
@@ -23,7 +23,7 @@ pub fn parse_comment_block(token: &Token) -> Option<Comment> {
     }
 }
 
-pub fn parse_doc_comment(token: &Token) -> String {
+pub fn parse_doc_comment(token: &Token<'_>) -> String {
     let child = token.first_relevant_child();
     match child.as_rule() {
         Rule::doc_content => String::from(child.as_str().trim()),

--- a/libs/datamodel/core/src/ast/parser/parse_enum.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_enum.rs
@@ -8,7 +8,7 @@ use crate::ast::parser::helpers::TokenExtensions;
 use crate::ast::*;
 use crate::diagnostics::{DatamodelError, Diagnostics};
 
-pub fn parse_enum(token: &Token) -> Result<Enum, Diagnostics> {
+pub fn parse_enum(token: &Token<'_>) -> Result<Enum, Diagnostics> {
     let mut errors = Diagnostics::new();
     let mut name: Option<Identifier> = None;
     let mut attributes: Vec<Attribute> = vec![];
@@ -49,7 +49,7 @@ pub fn parse_enum(token: &Token) -> Result<Enum, Diagnostics> {
     }
 }
 
-fn parse_enum_value(enum_name: &str, token: &Token) -> Result<EnumValue, DatamodelError> {
+fn parse_enum_value(enum_name: &str, token: &Token<'_>) -> Result<EnumValue, DatamodelError> {
     let mut name: Option<Identifier> = None;
     let mut attributes: Vec<Attribute> = vec![];
     let mut comments: Vec<String> = vec![];

--- a/libs/datamodel/core/src/ast/parser/parse_expression.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_expression.rs
@@ -8,7 +8,7 @@ use super::helpers::{parsing_catch_all, Token, TokenExtensions};
 use super::Rule;
 use crate::ast::*;
 
-pub fn parse_expression(token: &Token) -> Expression {
+pub fn parse_expression(token: &Token<'_>) -> Expression {
     let first_child = token.first_relevant_child();
     let span = Span::from_pest(first_child.as_span());
     match first_child.as_rule() {
@@ -25,7 +25,7 @@ pub fn parse_expression(token: &Token) -> Expression {
     }
 }
 
-fn parse_function(token: &Token) -> Expression {
+fn parse_function(token: &Token<'_>) -> Expression {
     let mut name: Option<String> = None;
     let mut arguments: Vec<Expression> = vec![];
 
@@ -43,7 +43,7 @@ fn parse_function(token: &Token) -> Expression {
     }
 }
 
-fn parse_array(token: &Token) -> Expression {
+fn parse_array(token: &Token<'_>) -> Expression {
     let mut elements: Vec<Expression> = vec![];
 
     for current in token.relevant_children() {
@@ -56,7 +56,7 @@ fn parse_array(token: &Token) -> Expression {
     Expression::Array(elements, Span::from_pest(token.as_span()))
 }
 
-pub fn parse_arg_value(token: &Token) -> Expression {
+pub fn parse_arg_value(token: &Token<'_>) -> Expression {
     let current = token.first_relevant_child();
     match current.as_rule() {
         Rule::expression => parse_expression(&current),
@@ -64,7 +64,7 @@ pub fn parse_arg_value(token: &Token) -> Expression {
     }
 }
 
-fn parse_string_literal(token: &Token) -> String {
+fn parse_string_literal(token: &Token<'_>) -> String {
     let current = token.first_relevant_child();
     match current.as_rule() {
         Rule::string_content => unescape_string_literal(current.as_str()).into_owned(),

--- a/libs/datamodel/core/src/ast/parser/parse_field.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_field.rs
@@ -11,13 +11,13 @@ use crate::diagnostics::DatamodelError;
 pub fn parse_field(model_name: &str, token: &Token) -> Result<Field, DatamodelError> {
     let mut name: Option<Identifier> = None;
     let mut attributes: Vec<Attribute> = Vec::new();
-    let mut field_type: Option<((FieldArity, String), Span)> = None;
+    let mut field_type: Option<(FieldArity, FieldType)> = None;
     let mut comments: Vec<String> = Vec::new();
 
     for current in token.relevant_children() {
         match current.as_rule() {
             Rule::non_empty_identifier => name = Some(current.to_id()),
-            Rule::field_type => field_type = Some((parse_field_type(&current)?, Span::from_pest(current.as_span()))),
+            Rule::field_type => field_type = Some(parse_field_type(&current)?),
             Rule::LEGACY_COLON => {
                 return Err(DatamodelError::new_legacy_parser_error(
                     "Field declarations don't require a `:`.",
@@ -32,11 +32,8 @@ pub fn parse_field(model_name: &str, token: &Token) -> Result<Field, DatamodelEr
     }
 
     match (name, field_type) {
-        (Some(name), Some(((arity, field_type), field_type_span))) => Ok(Field {
-            field_type: Identifier {
-                name: field_type,
-                span: field_type_span,
-            },
+        (Some(name), Some((arity, field_type))) => Ok(Field {
+            field_type,
             name,
             arity,
             attributes,

--- a/libs/datamodel/core/src/ast/parser/parse_field.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_field.rs
@@ -8,7 +8,7 @@ use super::{
 use crate::ast::*;
 use crate::diagnostics::DatamodelError;
 
-pub fn parse_field(model_name: &str, token: &Token) -> Result<Field, DatamodelError> {
+pub fn parse_field(model_name: &str, token: &Token<'_>) -> Result<Field, DatamodelError> {
     let mut name: Option<Identifier> = None;
     let mut attributes: Vec<Attribute> = Vec::new();
     let mut field_type: Option<(FieldArity, FieldType)> = None;

--- a/libs/datamodel/core/src/ast/parser/parse_model.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_model.rs
@@ -8,7 +8,7 @@ use super::{
 use crate::ast::*;
 use crate::diagnostics::{DatamodelError, Diagnostics};
 
-pub fn parse_model(token: &Token) -> Result<Model, Diagnostics> {
+pub fn parse_model(token: &Token<'_>) -> Result<Model, Diagnostics> {
     let mut errors = Diagnostics::new();
     let mut name: Option<Identifier> = None;
     let mut attributes: Vec<Attribute> = vec![];

--- a/libs/datamodel/core/src/ast/parser/parse_schema.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_schema.rs
@@ -111,8 +111,6 @@ fn rule_to_string(rule: Rule) -> &'static str {
         Rule::attribute => "attribute",
         Rule::optional_type => "optional type",
         Rule::base_type => "type",
-        Rule::optional_unsupported_type => "optional unsupported type",
-        Rule::list_unsupported_type => "list unsupported type",
         Rule::unsupported_type => "unsupported type",
         Rule::list_type => "list type",
         Rule::field_type => "field type",

--- a/libs/datamodel/core/src/ast/parser/parse_source_and_generator.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_source_and_generator.rs
@@ -7,7 +7,7 @@ use super::{
 use crate::ast::*;
 use crate::diagnostics::{DatamodelError, Diagnostics};
 
-pub fn parse_source(token: &Token) -> Result<SourceConfig, Diagnostics> {
+pub fn parse_source(token: &Token<'_>) -> Result<SourceConfig, Diagnostics> {
     let mut errors = Diagnostics::new();
     let mut name: Option<Identifier> = None;
     let mut properties: Vec<Argument> = vec![];
@@ -42,7 +42,7 @@ pub fn parse_source(token: &Token) -> Result<SourceConfig, Diagnostics> {
     }
 }
 
-pub fn parse_generator(token: &Token) -> Result<GeneratorConfig, Diagnostics> {
+pub fn parse_generator(token: &Token<'_>) -> Result<GeneratorConfig, Diagnostics> {
     let mut errors = Diagnostics::new();
     let mut name: Option<Identifier> = None;
     let mut properties: Vec<Argument> = vec![];
@@ -78,7 +78,7 @@ pub fn parse_generator(token: &Token) -> Result<GeneratorConfig, Diagnostics> {
     }
 }
 
-fn parse_key_value(token: &Token) -> Argument {
+fn parse_key_value(token: &Token<'_>) -> Argument {
     let mut name: Option<Identifier> = None;
     let mut value: Option<Expression> = None;
 

--- a/libs/datamodel/core/src/ast/parser/parse_types.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_types.rs
@@ -4,20 +4,21 @@ use super::{
     parse_comments::parse_comment_block,
     Rule,
 };
+use crate::ast::parser::parse_expression::parse_expression;
 use crate::ast::*;
 use crate::diagnostics::DatamodelError;
 
 pub fn parse_type_alias(token: &Token) -> Field {
     let mut name: Option<Identifier> = None;
     let mut attributes: Vec<Attribute> = vec![];
-    let mut base_type: Option<(String, Span)> = None;
+    let mut base_type: Option<FieldType> = None;
     let mut comment: Option<Comment> = None;
 
     for current in token.relevant_children() {
         match current.as_rule() {
             Rule::TYPE_KEYWORD => {}
             Rule::non_empty_identifier => name = Some(current.to_id()),
-            Rule::base_type => base_type = Some((parse_base_type(&current), Span::from_pest(current.as_span()))),
+            Rule::base_type => base_type = Some(parse_base_type(&current)),
             Rule::attribute => attributes.push(parse_attribute(&current)),
             Rule::comment_block => comment = parse_comment_block(&current),
             _ => parsing_catch_all(&current, "custom type"),
@@ -25,11 +26,8 @@ pub fn parse_type_alias(token: &Token) -> Field {
     }
 
     match (name, base_type) {
-        (Some(name), Some((field_type, field_type_span))) => Field {
-            field_type: Identifier {
-                name: field_type,
-                span: field_type_span,
-            },
+        (Some(name), Some(field_type)) => Field {
+            field_type,
             name,
             arity: FieldArity::Required,
             attributes,
@@ -44,15 +42,12 @@ pub fn parse_type_alias(token: &Token) -> Field {
     }
 }
 
-pub fn parse_field_type(token: &Token) -> Result<(FieldArity, String), DatamodelError> {
+pub fn parse_field_type(token: &Token) -> Result<(FieldArity, FieldType), DatamodelError> {
     let current = token.first_relevant_child();
     match current.as_rule() {
-        Rule::optional_type => Ok((FieldArity::Optional, parse_base_type(&current))),
+        Rule::optional_type => Ok((FieldArity::Optional, parse_base_type(&current.first_relevant_child()))),
         Rule::base_type => Ok((FieldArity::Required, parse_base_type(&current))),
-        Rule::list_unsupported_type => Ok((FieldArity::List, current.as_str().into())),
-        Rule::optional_unsupported_type => Ok((FieldArity::Optional, current.as_str().into())),
-        Rule::unsupported_type => Ok((FieldArity::Required, current.as_str().into())),
-        Rule::list_type => Ok((FieldArity::List, parse_base_type(&current))),
+        Rule::list_type => Ok((FieldArity::List, parse_base_type(&current.first_relevant_child()))),
         Rule::legacy_required_type => Err(DatamodelError::new_legacy_parser_error(
             "Fields are required by default, `!` is no longer required.",
             Span::from_pest(current.as_span()),
@@ -69,10 +64,17 @@ pub fn parse_field_type(token: &Token) -> Result<(FieldArity, String), Datamodel
     }
 }
 
-fn parse_base_type(token: &Token) -> String {
+fn parse_base_type(token: &Token) -> FieldType {
     let current = token.first_relevant_child();
     match current.as_rule() {
-        Rule::non_empty_identifier => current.as_str().to_string(),
+        Rule::non_empty_identifier => FieldType::Supported(Identifier {
+            name: current.as_str().to_string(),
+            span: Span::from_pest(current.as_span()),
+        }),
+        Rule::unsupported_type => match parse_expression(&current) {
+            Expression::StringValue(lit, span) => FieldType::Unsupported(lit, span),
+            _ => unreachable!("Encountered impossible type during parsing: {:?}", current.tokens()),
+        },
         _ => unreachable!("Encountered impossible type during parsing: {:?}", current.tokens()),
     }
 }

--- a/libs/datamodel/core/src/ast/parser/parse_types.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_types.rs
@@ -8,7 +8,7 @@ use crate::ast::parser::parse_expression::parse_expression;
 use crate::ast::*;
 use crate::diagnostics::DatamodelError;
 
-pub fn parse_type_alias(token: &Token) -> Field {
+pub fn parse_type_alias(token: &Token<'_>) -> Field {
     let mut name: Option<Identifier> = None;
     let mut attributes: Vec<Attribute> = vec![];
     let mut base_type: Option<FieldType> = None;
@@ -42,7 +42,7 @@ pub fn parse_type_alias(token: &Token) -> Field {
     }
 }
 
-pub fn parse_field_type(token: &Token) -> Result<(FieldArity, FieldType), DatamodelError> {
+pub fn parse_field_type(token: &Token<'_>) -> Result<(FieldArity, FieldType), DatamodelError> {
     let current = token.first_relevant_child();
     match current.as_rule() {
         Rule::optional_type => Ok((FieldArity::Optional, parse_base_type(&current.first_relevant_child()))),
@@ -64,7 +64,7 @@ pub fn parse_field_type(token: &Token) -> Result<(FieldArity, FieldType), Datamo
     }
 }
 
-fn parse_base_type(token: &Token) -> FieldType {
+fn parse_base_type(token: &Token<'_>) -> FieldType {
     let current = token.first_relevant_child();
     match current.as_rule() {
         Rule::non_empty_identifier => FieldType::Supported(Identifier {

--- a/libs/datamodel/core/src/ast/reformat/reformatter.rs
+++ b/libs/datamodel/core/src/ast/reformat/reformatter.rs
@@ -165,7 +165,7 @@ impl<'a> Reformatter<'a> {
         target_string
     }
 
-    fn reformat_top(&self, target: &mut Renderer, token: &Token) {
+    fn reformat_top(&self, target: &mut Renderer<'_>, token: &Token<'_>) {
         let mut types_table = TableFormat::new();
         let mut types_mode = false;
         let mut seen_at_least_one_top_level_element = false;
@@ -232,7 +232,7 @@ impl<'a> Reformatter<'a> {
         target.write("");
     }
 
-    fn reformat_datasource(&self, target: &mut Renderer, token: &Token) {
+    fn reformat_datasource(&self, target: &mut Renderer<'_>, token: &Token<'_>) {
         self.reformat_block_element(
             "datasource",
             target,
@@ -244,7 +244,7 @@ impl<'a> Reformatter<'a> {
         );
     }
 
-    fn reformat_generator(&self, target: &mut Renderer, token: &Token) {
+    fn reformat_generator(&self, target: &mut Renderer<'_>, token: &Token<'_>) {
         self.reformat_block_element(
             "generator",
             target,
@@ -259,7 +259,7 @@ impl<'a> Reformatter<'a> {
         );
     }
 
-    fn reformat_key_value(target: &mut TableFormat, token: &Token) {
+    fn reformat_key_value(target: &mut TableFormat, token: &Token<'_>) {
         for current in token.clone().into_inner() {
             match current.as_rule() {
                 Rule::non_empty_identifier | Rule::maybe_empty_identifier => {
@@ -277,7 +277,7 @@ impl<'a> Reformatter<'a> {
         }
     }
 
-    fn reformat_model(&self, target: &mut Renderer, token: &Token) {
+    fn reformat_model(&self, target: &mut Renderer<'_>, token: &Token<'_>) {
         self.reformat_block_element_internal(
             "model",
             target,
@@ -309,9 +309,9 @@ impl<'a> Reformatter<'a> {
     fn reformat_block_element(
         &self,
         block_type: &'static str,
-        renderer: &'a mut Renderer,
-        token: &'a Token,
-        the_fn: Box<dyn Fn(&mut TableFormat, &mut Renderer, &Token, &str) + 'a>,
+        renderer: &'a mut Renderer<'_>,
+        token: &'a Token<'_>,
+        the_fn: Box<dyn Fn(&mut TableFormat, &mut Renderer<'_>, &Token<'_>, &str) + 'a>,
     ) {
         self.reformat_block_element_internal(block_type, renderer, token, the_fn, {
             // a no op
@@ -322,10 +322,10 @@ impl<'a> Reformatter<'a> {
     fn reformat_block_element_internal(
         &self,
         block_type: &'static str,
-        renderer: &'a mut Renderer,
-        token: &'a Token,
-        the_fn: Box<dyn Fn(&mut TableFormat, &mut Renderer, &Token, &str) + 'a>,
-        after_fn: Box<dyn Fn(&mut TableFormat, &mut Renderer, &str) + 'a>,
+        renderer: &'a mut Renderer<'_>,
+        token: &'a Token<'_>,
+        the_fn: Box<dyn Fn(&mut TableFormat, &mut Renderer<'_>, &Token<'_>, &str) + 'a>,
+        after_fn: Box<dyn Fn(&mut TableFormat, &mut Renderer<'_>, &str) + 'a>,
     ) {
         let mut table = TableFormat::new();
         let mut block_name = "";
@@ -412,7 +412,7 @@ impl<'a> Reformatter<'a> {
         renderer.maybe_end_line();
     }
 
-    fn reformat_enum(&self, target: &mut Renderer, token: &Token) {
+    fn reformat_enum(&self, target: &mut Renderer<'_>, token: &Token<'_>) {
         self.reformat_block_element(
             "enum",
             target,
@@ -432,7 +432,7 @@ impl<'a> Reformatter<'a> {
         );
     }
 
-    fn reformat_enum_entry(target: &mut TableFormat, token: &Token) {
+    fn reformat_enum_entry(target: &mut TableFormat, token: &Token<'_>) {
         for current in token.clone().into_inner() {
             match current.as_rule() {
                 Rule::non_empty_identifier => target.write(current.as_str()),
@@ -445,7 +445,7 @@ impl<'a> Reformatter<'a> {
         }
     }
 
-    fn extract_and_sort_attributes<'i>(token: &'i Token, is_field_attribute: bool) -> Vec<Pair<'i, Rule>> {
+    fn extract_and_sort_attributes<'i>(token: &'i Token<'_>, is_field_attribute: bool) -> Vec<Pair<'i, Rule>> {
         // get indices of attributes and store in separate Vector
         let mut attributes = Vec::new();
         for pair in token.clone().into_inner() {
@@ -467,7 +467,7 @@ impl<'a> Reformatter<'a> {
         attributes
     }
 
-    fn reformat_field(&self, target: &mut TableFormat, token: &Token, model_name: &str) {
+    fn reformat_field(&self, target: &mut TableFormat, token: &Token<'_>, model_name: &str) {
         let field_name = token
             .clone()
             .into_inner()
@@ -538,7 +538,7 @@ impl<'a> Reformatter<'a> {
         target.maybe_end_line();
     }
 
-    fn reformat_type_alias(target: &mut TableFormat, token: &Token) {
+    fn reformat_type_alias(target: &mut TableFormat, token: &Token<'_>) {
         let mut identifier = None;
 
         for current in token.clone().into_inner() {
@@ -567,7 +567,7 @@ impl<'a> Reformatter<'a> {
         target.maybe_end_line();
     }
 
-    fn reformat_field_type(token: &Token) -> String {
+    fn reformat_field_type(token: &Token<'_>) -> String {
         let mut builder = StringBuilder::new();
 
         for current in token.clone().into_inner() {
@@ -590,7 +590,7 @@ impl<'a> Reformatter<'a> {
         builder.to_string()
     }
 
-    fn get_identifier(token: Token) -> &str {
+    fn get_identifier(token: Token<'_>) -> &str {
         let ident_token = match token.as_rule() {
             Rule::base_type => token.as_str(),
             Rule::list_type
@@ -610,7 +610,7 @@ impl<'a> Reformatter<'a> {
 
     fn reformat_attribute(
         target: &mut dyn LineWriteable,
-        token: &Token,
+        token: &Token<'_>,
         owl: &str,
         missing_args: Vec<&MissingRelationAttributeArg>,
     ) {
@@ -644,7 +644,7 @@ impl<'a> Reformatter<'a> {
         }
     }
 
-    fn unpack_token_to_find_matching_rule(token: Token, rule: Rule) -> Token {
+    fn unpack_token_to_find_matching_rule(token: Token<'_>, rule: Rule) -> Token<'_> {
         if token.as_rule() == rule {
             token
         } else {
@@ -660,7 +660,7 @@ impl<'a> Reformatter<'a> {
 
     fn reformat_attribute_args(
         target: &mut dyn LineWriteable,
-        token: &Token,
+        token: &Token<'_>,
         missing_args: Vec<&MissingRelationAttributeArg>,
     ) {
         let mut builder = StringBuilder::new();
@@ -753,7 +753,7 @@ impl<'a> Reformatter<'a> {
     }
     //duplicated from renderer -.-
 
-    fn reformat_attribute_arg(target: &mut dyn LineWriteable, token: &Token) {
+    fn reformat_attribute_arg(target: &mut dyn LineWriteable, token: &Token<'_>) {
         for current in token.clone().into_inner() {
             match current.as_rule() {
                 Rule::argument_name => {
@@ -769,7 +769,7 @@ impl<'a> Reformatter<'a> {
         }
     }
 
-    fn reformat_arg_value(target: &mut dyn LineWriteable, token: &Token) {
+    fn reformat_arg_value(target: &mut dyn LineWriteable, token: &Token<'_>) {
         for current in token.clone().into_inner() {
             match current.as_rule() {
                 Rule::expression => Self::reformat_expression(target, &current),
@@ -782,7 +782,7 @@ impl<'a> Reformatter<'a> {
     }
 
     /// Parses an expression, given a Pest parser token.
-    fn reformat_expression(target: &mut dyn LineWriteable, token: &Token) {
+    fn reformat_expression(target: &mut dyn LineWriteable, token: &Token<'_>) {
         for current in token.clone().into_inner() {
             match current.as_rule() {
                 Rule::numeric_literal => target.write(current.as_str()),
@@ -799,7 +799,7 @@ impl<'a> Reformatter<'a> {
         }
     }
 
-    fn reformat_array_expression(target: &mut dyn LineWriteable, token: &Token) {
+    fn reformat_array_expression(target: &mut dyn LineWriteable, token: &Token<'_>) {
         target.write("[");
         let mut expr_count = 0;
 
@@ -822,7 +822,7 @@ impl<'a> Reformatter<'a> {
         target.write("]");
     }
 
-    fn reformat_function_expression(target: &mut dyn LineWriteable, token: &Token) {
+    fn reformat_function_expression(target: &mut dyn LineWriteable, token: &Token<'_>) {
         let mut has_seen_one_argument = false;
 
         for current in token.clone().into_inner() {
@@ -848,7 +848,7 @@ impl<'a> Reformatter<'a> {
         target.write(")");
     }
 
-    fn reformat_generic_token(target: &mut dyn LineWriteable, token: &Token) {
+    fn reformat_generic_token(target: &mut dyn LineWriteable, token: &Token<'_>) {
         //        println!("generic token: |{:?}|", token.as_str());
         match token.as_rule() {
             Rule::NEWLINE => target.end_line(),

--- a/libs/datamodel/core/src/ast/renderer/mod.rs
+++ b/libs/datamodel/core/src/ast/renderer/mod.rs
@@ -151,7 +151,7 @@ impl<'a> Renderer<'a> {
         target.write("type ");
         target.write(&field.name.name);
         target.write(&" = ");
-        target.write(&field.field_type.name);
+        Self::render_field_type(target, &field.field_type);
 
         // Attributes
         if !field.attributes.is_empty() {
@@ -280,7 +280,7 @@ impl<'a> Renderer<'a> {
         {
             let mut type_builder = StringBuilder::new();
 
-            type_builder.write(&field.field_type.name);
+            Self::render_field_type(&mut type_builder, &field.field_type);
             Self::render_field_arity(&mut type_builder, &field.arity);
 
             target.write(&type_builder.to_string());
@@ -318,6 +318,19 @@ impl<'a> Renderer<'a> {
             target.write("(");
             Self::render_arguments(target, &attribute.arguments);
             target.write(")");
+        }
+    }
+
+    pub fn render_field_type(target: &mut dyn LineWriteable, field_type: &ast::FieldType) {
+        match field_type {
+            ast::FieldType::Supported(ft) => {
+                target.write(&ft.name);
+            }
+            ast::FieldType::Unsupported(lit, _) => {
+                target.write("Unsupported(\"");
+                target.write(&lit);
+                target.write("\")");
+            }
         }
     }
 

--- a/libs/datamodel/core/src/ast/renderer/table.rs
+++ b/libs/datamodel/core/src/ast/renderer/table.rs
@@ -42,14 +42,14 @@ impl TableFormat {
         self.maybe_new_line = false;
     }
 
-    pub fn interleave_writer(&mut self) -> TableFormatInterleaveWrapper {
+    pub fn interleave_writer(&mut self) -> TableFormatInterleaveWrapper<'_> {
         TableFormatInterleaveWrapper {
             formatter: self,
             string_builder: StringBuilder::new(),
         }
     }
 
-    pub fn column_locked_writer_for(&mut self, index: usize) -> ColumnLockedWriter {
+    pub fn column_locked_writer_for(&mut self, index: usize) -> ColumnLockedWriter<'_> {
         ColumnLockedWriter {
             formatter: self,
             column: index,
@@ -58,7 +58,7 @@ impl TableFormat {
 
     // TODO: make a decision on whether we can remove this once i understand what this is
     #[allow(unused)]
-    fn column_locked_writer(&mut self) -> ColumnLockedWriter {
+    fn column_locked_writer(&mut self) -> ColumnLockedWriter<'_> {
         if self.table.is_empty() {
             self.start_new_line();
             self.write("");

--- a/libs/datamodel/core/src/ast/span.rs
+++ b/libs/datamodel/core/src/ast/span.rs
@@ -15,7 +15,7 @@ impl Span {
         Span { start: 0, end: 0 }
     }
     /// Creates a new ast::Span from a pest::Span.
-    pub fn from_pest(s: pest::Span) -> Span {
+    pub fn from_pest(s: pest::Span<'_>) -> Span {
         Span {
             start: s.start(),
             end: s.end(),
@@ -32,7 +32,7 @@ impl Span {
 }
 
 impl std::fmt::Display for Span {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "[{} - {}]", self.start, self.end)
     }
 }

--- a/libs/datamodel/core/src/diagnostics/collection.rs
+++ b/libs/datamodel/core/src/diagnostics/collection.rs
@@ -50,12 +50,12 @@ impl Diagnostics {
     }
 
     /// Creates an iterator over all errors in this collection.
-    pub fn to_error_iter(&self) -> std::slice::Iter<DatamodelError> {
+    pub fn to_error_iter(&self) -> std::slice::Iter<'_, DatamodelError> {
         self.errors.iter()
     }
 
     /// Creates an iterator over all warnings in this collection.
-    pub fn to_warning_iter(&self) -> std::slice::Iter<DatamodelWarning> {
+    pub fn to_warning_iter(&self) -> std::slice::Iter<'_, DatamodelWarning> {
         self.warnings.iter()
     }
 
@@ -94,7 +94,7 @@ impl Diagnostics {
 }
 
 impl std::fmt::Display for Diagnostics {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let msg: Vec<String> = self.errors.iter().map(|e| e.to_string()).collect();
         f.write_str(&msg.join("\n"))
     }

--- a/libs/datamodel/core/src/lib.rs
+++ b/libs/datamodel/core/src/lib.rs
@@ -76,6 +76,7 @@
     clippy::suspicious_operation_groupings,
     clippy::upper_case_acronyms
 )]
+#![deny(rust_2018_idioms, unsafe_code)]
 
 pub mod ast;
 pub mod common;

--- a/libs/datamodel/core/src/transform/ast_to_dml/standardise_formatting.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/standardise_formatting.rs
@@ -321,7 +321,7 @@ impl StandardiserForFormatting {
 
     fn underlying_fields_for_unique_criteria(
         &self,
-        unique_criteria: &dml::UniqueCriteria,
+        unique_criteria: &dml::UniqueCriteria<'_>,
         model_name: &str,
         field_arity: dml::FieldArity,
     ) -> Vec<ScalarField> {

--- a/libs/datamodel/core/src/transform/attributes/attribute_validator.rs
+++ b/libs/datamodel/core/src/transform/attributes/attribute_validator.rs
@@ -16,7 +16,7 @@ pub trait AttributeValidator<T> {
 
     /// Validates an attribute and applies the attribute
     /// to the given object.
-    fn validate_and_apply(&self, args: &mut Arguments, obj: &mut T) -> Result<(), DatamodelError>;
+    fn validate_and_apply(&self, args: &mut Arguments<'_>, obj: &mut T) -> Result<(), DatamodelError>;
 
     /// Serializes the given attribute's arguments for rendering.
     fn serialize(&self, obj: &T, datamodel: &dml::Datamodel) -> Vec<ast::Attribute>;

--- a/libs/datamodel/core/src/transform/attributes/default.rs
+++ b/libs/datamodel/core/src/transform/attributes/default.rs
@@ -14,7 +14,7 @@ impl AttributeValidator<dml::Field> for DefaultAttributeValidator {
         &"default"
     }
 
-    fn validate_and_apply(&self, args: &mut Arguments, field: &mut dml::Field) -> Result<(), DatamodelError> {
+    fn validate_and_apply(&self, args: &mut Arguments<'_>, field: &mut dml::Field) -> Result<(), DatamodelError> {
         if let dml::Field::RelationField(_) = field {
             return self.new_attribute_validation_error("Cannot set a default value on a relation field.", args.span());
         } else if let dml::Field::ScalarField(sf) = field {

--- a/libs/datamodel/core/src/transform/attributes/id.rs
+++ b/libs/datamodel/core/src/transform/attributes/id.rs
@@ -10,7 +10,7 @@ impl AttributeValidator<dml::Field> for IdAttributeValidator {
         &"id"
     }
 
-    fn validate_and_apply(&self, args: &mut Arguments, obj: &mut dml::Field) -> Result<(), DatamodelError> {
+    fn validate_and_apply(&self, args: &mut Arguments<'_>, obj: &mut dml::Field) -> Result<(), DatamodelError> {
         if let dml::Field::ScalarField(sf) = obj {
             sf.is_id = true;
             Ok(())
@@ -44,7 +44,7 @@ impl AttributeValidator<dml::Model> for ModelLevelIdAttributeValidator {
         "id"
     }
 
-    fn validate_and_apply(&self, args: &mut Arguments, obj: &mut dml::Model) -> Result<(), DatamodelError> {
+    fn validate_and_apply(&self, args: &mut Arguments<'_>, obj: &mut dml::Model) -> Result<(), DatamodelError> {
         let fields = args
             .default_arg("fields")?
             .as_array()

--- a/libs/datamodel/core/src/transform/attributes/ignore.rs
+++ b/libs/datamodel/core/src/transform/attributes/ignore.rs
@@ -14,7 +14,7 @@ impl AttributeValidator<dml::Model> for IgnoreAttributeValidator {
         ATTRIBUTE_NAME
     }
 
-    fn validate_and_apply(&self, args: &mut Arguments, obj: &mut dml::Model) -> Result<(), DatamodelError> {
+    fn validate_and_apply(&self, args: &mut Arguments<'_>, obj: &mut dml::Model) -> Result<(), DatamodelError> {
         if obj.fields().any(|f| f.is_ignored()) {
             return self.new_attribute_validation_error(
                 "Fields on an already ignored Model do not need an `@ignore` annotation.",
@@ -37,7 +37,7 @@ impl AttributeValidator<dml::Field> for IgnoreAttributeValidatorForField {
         ATTRIBUTE_NAME
     }
 
-    fn validate_and_apply(&self, args: &mut Arguments, obj: &mut dml::Field) -> Result<(), DatamodelError> {
+    fn validate_and_apply(&self, args: &mut Arguments<'_>, obj: &mut dml::Field) -> Result<(), DatamodelError> {
         match obj {
             ScalarField(sf) if matches!(sf.field_type, dml::FieldType::Unsupported(_)) => {
                 self.new_attribute_validation_error("Fields of type `Unsupported` cannot take an `@ignore` attribute. They are already treated as ignored by the client due to their type.", args.span())

--- a/libs/datamodel/core/src/transform/attributes/map.rs
+++ b/libs/datamodel/core/src/transform/attributes/map.rs
@@ -13,7 +13,7 @@ impl AttributeValidator<dml::Model> for MapAttributeValidator {
         ATTRIBUTE_NAME
     }
 
-    fn validate_and_apply(&self, args: &mut Arguments, obj: &mut dml::Model) -> Result<(), DatamodelError> {
+    fn validate_and_apply(&self, args: &mut Arguments<'_>, obj: &mut dml::Model) -> Result<(), DatamodelError> {
         internal_validate_and_apply(args, obj)
     }
 
@@ -28,7 +28,7 @@ impl AttributeValidator<dml::Field> for MapAttributeValidatorForField {
         ATTRIBUTE_NAME
     }
 
-    fn validate_and_apply(&self, args: &mut Arguments, obj: &mut dml::Field) -> Result<(), DatamodelError> {
+    fn validate_and_apply(&self, args: &mut Arguments<'_>, obj: &mut dml::Field) -> Result<(), DatamodelError> {
         if obj.is_relation() {
             return self.new_attribute_validation_error(
                 &format!(
@@ -51,7 +51,7 @@ impl AttributeValidator<dml::Enum> for MapAttributeValidator {
         ATTRIBUTE_NAME
     }
 
-    fn validate_and_apply(&self, args: &mut Arguments, obj: &mut dml::Enum) -> Result<(), DatamodelError> {
+    fn validate_and_apply(&self, args: &mut Arguments<'_>, obj: &mut dml::Enum) -> Result<(), DatamodelError> {
         internal_validate_and_apply(args, obj)
     }
 
@@ -65,7 +65,7 @@ impl AttributeValidator<dml::EnumValue> for MapAttributeValidator {
         ATTRIBUTE_NAME
     }
 
-    fn validate_and_apply(&self, args: &mut Arguments, obj: &mut dml::EnumValue) -> Result<(), DatamodelError> {
+    fn validate_and_apply(&self, args: &mut Arguments<'_>, obj: &mut dml::EnumValue) -> Result<(), DatamodelError> {
         internal_validate_and_apply(args, obj)
     }
 
@@ -74,7 +74,7 @@ impl AttributeValidator<dml::EnumValue> for MapAttributeValidator {
     }
 }
 
-fn internal_validate_and_apply(args: &mut Arguments, obj: &mut dyn WithDatabaseName) -> Result<(), DatamodelError> {
+fn internal_validate_and_apply(args: &mut Arguments<'_>, obj: &mut dyn WithDatabaseName) -> Result<(), DatamodelError> {
     let name_arg = args.default_arg("name")?;
     let db_name = name_arg.as_str().map_err(|err| {
         DatamodelError::new_attribute_validation_error(&format!("{}", err), ATTRIBUTE_NAME, err.span())

--- a/libs/datamodel/core/src/transform/attributes/relation.rs
+++ b/libs/datamodel/core/src/transform/attributes/relation.rs
@@ -11,7 +11,7 @@ impl AttributeValidator<dml::Field> for RelationAttributeValidator {
         &"relation"
     }
 
-    fn validate_and_apply(&self, args: &mut Arguments, field: &mut dml::Field) -> Result<(), DatamodelError> {
+    fn validate_and_apply(&self, args: &mut Arguments<'_>, field: &mut dml::Field) -> Result<(), DatamodelError> {
         if let dml::Field::RelationField(rf) = field {
             if let Ok(name_arg) = args.default_arg("name") {
                 let name = name_arg.as_str()?;

--- a/libs/datamodel/core/src/transform/attributes/unique_and_index.rs
+++ b/libs/datamodel/core/src/transform/attributes/unique_and_index.rs
@@ -13,7 +13,7 @@ impl AttributeValidator<dml::Field> for FieldLevelUniqueAttributeValidator {
         &"unique"
     }
 
-    fn validate_and_apply(&self, args: &mut Arguments, obj: &mut dml::Field) -> Result<(), DatamodelError> {
+    fn validate_and_apply(&self, args: &mut Arguments<'_>, obj: &mut dml::Field) -> Result<(), DatamodelError> {
         if let dml::Field::RelationField(rf) = obj {
             let suggestion = match rf.relation_info.fields.len().cmp(&1) {
                 Ordering::Equal => format!(
@@ -75,7 +75,7 @@ impl AttributeValidator<dml::Model> for ModelLevelUniqueAttributeValidator {
         true
     }
 
-    fn validate_and_apply(&self, args: &mut Arguments, obj: &mut dml::Model) -> Result<(), DatamodelError> {
+    fn validate_and_apply(&self, args: &mut Arguments<'_>, obj: &mut dml::Model) -> Result<(), DatamodelError> {
         let index_def = self.validate_index(args, obj, IndexType::Unique)?;
         obj.indices.push(index_def);
 
@@ -100,7 +100,7 @@ impl AttributeValidator<dml::Model> for ModelLevelIndexAttributeValidator {
         true
     }
 
-    fn validate_and_apply(&self, args: &mut Arguments, obj: &mut dml::Model) -> Result<(), DatamodelError> {
+    fn validate_and_apply(&self, args: &mut Arguments<'_>, obj: &mut dml::Model) -> Result<(), DatamodelError> {
         let index_def = self.validate_index(args, obj, IndexType::Normal)?;
         obj.indices.push(index_def);
 
@@ -116,7 +116,7 @@ impl AttributeValidator<dml::Model> for ModelLevelIndexAttributeValidator {
 trait IndexAttributeBase<T>: AttributeValidator<T> {
     fn validate_index(
         &self,
-        args: &mut Arguments,
+        args: &mut Arguments<'_>,
         obj: &mut dml::Model,
         index_type: IndexType,
     ) -> Result<IndexDefinition, DatamodelError> {

--- a/libs/datamodel/core/src/transform/attributes/updated_at.rs
+++ b/libs/datamodel/core/src/transform/attributes/updated_at.rs
@@ -10,7 +10,7 @@ impl AttributeValidator<dml::Field> for UpdatedAtAttributeValidator {
         &"updatedAt"
     }
 
-    fn validate_and_apply(&self, args: &mut Arguments, obj: &mut dml::Field) -> Result<(), DatamodelError> {
+    fn validate_and_apply(&self, args: &mut Arguments<'_>, obj: &mut dml::Field) -> Result<(), DatamodelError> {
         if let dml::Field::ScalarField(sf) = obj {
             if sf.field_type.scalar_type() == Some(dml::ScalarType::DateTime) {
                 if sf.arity == dml::FieldArity::List {

--- a/libs/datamodel/core/src/transform/dml_to_ast/lower.rs
+++ b/libs/datamodel/core/src/transform/dml_to_ast/lower.rs
@@ -100,15 +100,17 @@ impl<'a> LowerDmlToAst<'a> {
     }
 
     /// Internal: Lowers a field's type.
-    fn lower_type(&self, field_type: &dml::FieldType) -> ast::Identifier {
+    fn lower_type(&self, field_type: &dml::FieldType) -> ast::FieldType {
         match field_type {
-            dml::FieldType::Base(tpe, custom_type_name) => {
-                ast::Identifier::new(&custom_type_name.as_ref().unwrap_or(&tpe.to_string()))
+            dml::FieldType::Base(tpe, custom_type_name) => ast::FieldType::Supported(ast::Identifier::new(
+                &custom_type_name.as_ref().unwrap_or(&tpe.to_string()),
+            )),
+            dml::FieldType::Enum(tpe) => ast::FieldType::Supported(ast::Identifier::new(&tpe)),
+            dml::FieldType::Unsupported(tpe) => ast::FieldType::Unsupported(tpe.clone(), Span::empty()),
+            dml::FieldType::Relation(rel) => ast::FieldType::Supported(ast::Identifier::new(&rel.to)),
+            dml::FieldType::NativeType(prisma_tpe, _native_tpe) => {
+                ast::FieldType::Supported(ast::Identifier::new(&prisma_tpe.to_string()))
             }
-            dml::FieldType::Enum(tpe) => ast::Identifier::new(&tpe),
-            dml::FieldType::Unsupported(tpe) => ast::Identifier::new(&format!("Unsupported(\"{}\")", tpe)),
-            dml::FieldType::Relation(rel) => ast::Identifier::new(&rel.to),
-            dml::FieldType::NativeType(prisma_tpe, _native_tpe) => ast::Identifier::new(&prisma_tpe.to_string()),
         }
     }
 

--- a/libs/datamodel/core/tests/types/negative.rs
+++ b/libs/datamodel/core/tests/types/negative.rs
@@ -245,10 +245,10 @@ fn should_fail_on_native_type_in_unsupported_postgres() {
 
         model Blog {
             id              Int    @id
-            decimal         Unsupported("Decimal(10,2)") 
-            text            Unsupported("Text") 
-            unsupported     Unsupported("Some random stuff") 
-            unsupportes2    Unsupported("Some random (2,5) do something") 
+            decimal         Unsupported("Decimal(10,2)")
+            text            Unsupported("Text")
+            unsupported     Unsupported("Some random stuff")
+            unsupportes2    Unsupported("Some random (2,5) do something")
         }
     "#;
 
@@ -257,11 +257,11 @@ fn should_fail_on_native_type_in_unsupported_postgres() {
     error.assert_are(&[
         DatamodelError::new_validation_error(
         "The type `Unsupported(\"Decimal(10,2)\")` you specified in the type definition for the field `decimal` is supported as a native type by Prisma. Please use the native type notation `Decimal @pg.Decimal(10,2)` for full support.",
-        ast::Span::new(188, 216),
+        ast::Span::new(172, 217),
     ),
         DatamodelError::new_validation_error(
             "The type `Unsupported(\"Text\")` you specified in the type definition for the field `text` is supported as a native type by Prisma. Please use the native type notation `String @pg.Text` for full support.",
-            ast::Span::new(246, 265),
+            ast::Span::new(229, 265),
         )
     ]);
 }
@@ -276,8 +276,8 @@ fn should_fail_on_native_type_in_unsupported_mysql() {
 
         model Blog {
             id          Int    @id
-            text        Unsupported("Text") 
-            decimal     Unsupported("Float") 
+            text        Unsupported("Text")
+            decimal     Unsupported("Float")
         }
     "#;
 
@@ -286,11 +286,11 @@ fn should_fail_on_native_type_in_unsupported_mysql() {
     error.assert_are(&[
         DatamodelError::new_validation_error(
             "The type `Unsupported(\"Text\")` you specified in the type definition for the field `text` is supported as a native type by Prisma. Please use the native type notation `String @pg.Text` for full support.",
-            ast::Span::new(172, 191),
+            ast::Span::new(160, 192),
         ),
         DatamodelError::new_validation_error(
             "The type `Unsupported(\"Float\")` you specified in the type definition for the field `decimal` is supported as a native type by Prisma. Please use the native type notation `Float @pg.Float` for full support.",
-            ast::Span::new(217, 237),
+            ast::Span::new(204, 237),
         )
     ]);
 }
@@ -305,9 +305,9 @@ fn should_fail_on_native_type_in_unsupported_sqlserver() {
 
         model Blog {
             id          Int    @id
-            text        Unsupported("Text") 
-            decimal     Unsupported("Real") 
-            TEXT        Unsupported("TEXT") 
+            text        Unsupported("Text")
+            decimal     Unsupported("Real")
+            TEXT        Unsupported("TEXT")
         }
     "#;
 
@@ -316,11 +316,11 @@ fn should_fail_on_native_type_in_unsupported_sqlserver() {
     error.assert_are(&[
         DatamodelError::new_validation_error(
             "The type `Unsupported(\"Text\")` you specified in the type definition for the field `text` is supported as a native type by Prisma. Please use the native type notation `String @pg.Text` for full support.",
-            ast::Span::new(180, 199),
+            ast::Span::new(168, 200),
         ),
         DatamodelError::new_validation_error(
             "The type `Unsupported(\"Real\")` you specified in the type definition for the field `decimal` is supported as a native type by Prisma. Please use the native type notation `Float @pg.Real` for full support.",
-            ast::Span::new(225, 244),
+            ast::Span::new(212, 244),
         )
     ]);
 }

--- a/migration-engine/migration-engine-tests/tests/errors/error_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/errors/error_tests.rs
@@ -263,7 +263,7 @@ fn datamodel_parser_errors_must_return_a_known_error(api: TestApi) {
 
     let error = api.schema_push(bad_dm).send_unwrap_err().to_user_facing();
 
-    let expected_msg = "\u{1b}[1;91merror\u{1b}[0m: \u{1b}[1mType \"Post\" is neither a built-in type, nor refers to another model, custom type, or enum.\u{1b}[0m\n  \u{1b}[1;94m-->\u{1b}[0m  \u{1b}[4mschema.prisma:4\u{1b}[0m\n\u{1b}[1;94m   | \u{1b}[0m\n\u{1b}[1;94m 3 | \u{1b}[0m            id Float @id\n\u{1b}[1;94m 4 | \u{1b}[0m            post \u{1b}[1;91mPost[]\u{1b}[0m\n\u{1b}[1;94m   | \u{1b}[0m\n";
+    let expected_msg = "\u{1b}[1;91merror\u{1b}[0m: \u{1b}[1mType \"Post\" is neither a built-in type, nor refers to another model, custom type, or enum.\u{1b}[0m\n  \u{1b}[1;94m-->\u{1b}[0m  \u{1b}[4mschema.prisma:4\u{1b}[0m\n\u{1b}[1;94m   | \u{1b}[0m\n\u{1b}[1;94m 3 | \u{1b}[0m            id Float @id\n\u{1b}[1;94m 4 | \u{1b}[0m            post \u{1b}[1;91mPost\u{1b}[0m[]\n\u{1b}[1;94m   | \u{1b}[0m\n";
 
     let expected_error = user_facing_errors::Error::from(user_facing_errors::KnownError {
         error_code: "P1012",


### PR DESCRIPTION
Before: one identifier, containing "Unsupported(\"...\")" as a blob.
After: Parsed as "Unsupported(" + string literal + ")" in parser, with a
proper string literal in the AST, or an identifier (for supported types).

Also cleans up unsupported handling in lift_field.

Closed: https://github.com/prisma/prisma-engines/issues/1917