### PR TITLE
Make generator binaryTargets a StringFromEnvVar

### DIFF
--- a/libs/datamodel/core/src/configuration/generator.rs
+++ b/libs/datamodel/core/src/configuration/generator.rs
@@ -12,7 +12,7 @@ pub struct Generator {
     pub config: HashMap<String, String>,
 
     #[serde(default)]
-    pub binary_targets: Vec<String>,
+    pub binary_targets: Vec<StringFromEnvVar>,
 
     #[serde(default)]
     pub preview_features: Vec<PreviewFeature>,

--- a/libs/datamodel/core/src/transform/ast_to_dml/generator_loader.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/generator_loader.rs
@@ -88,7 +88,7 @@ impl GeneratorLoader {
         let mut properties: HashMap<String, String> = HashMap::new();
 
         let binary_targets = match args.get(BINARY_TARGETS_KEY) {
-            Some(x) => x.as_array().to_str_vec()?,
+            Some(x) => x.as_array().to_string_from_env_var_vec()?,
             None => Vec::new(),
         };
 

--- a/libs/datamodel/core/src/transform/dml_to_ast/generator_serializer.rs
+++ b/libs/datamodel/core/src/transform/dml_to_ast/generator_serializer.rs
@@ -1,4 +1,4 @@
-use crate::{ast, configuration::Generator};
+use crate::{ast, configuration::Generator, transform::dml_to_ast::lower_string_from_env_var};
 
 pub struct GeneratorSerializer {}
 
@@ -36,7 +36,7 @@ impl GeneratorSerializer {
         let platform_values: Vec<ast::Expression> = generator
             .binary_targets
             .iter()
-            .map(|p| ast::Expression::StringValue(p.to_string(), ast::Span::empty()))
+            .map(|p| lower_string_from_env_var("binaryTargets", p).value)
             .collect();
         if !platform_values.is_empty() {
             arguments.push(ast::Argument::new_array("binaryTargets", platform_values));

--- a/libs/datamodel/core/src/transform/helpers/mod.rs
+++ b/libs/datamodel/core/src/transform/helpers/mod.rs
@@ -2,5 +2,5 @@ mod arguments;
 mod env_function;
 mod value_validator;
 
-pub use arguments::Arguments;
-pub use value_validator::{ValueListValidator, ValueValidator};
+pub(crate) use arguments::Arguments;
+pub(crate) use value_validator::{ValueListValidator, ValueValidator};

--- a/libs/datamodel/core/src/transform/helpers/value_validator.rs
+++ b/libs/datamodel/core/src/transform/helpers/value_validator.rs
@@ -243,29 +243,22 @@ impl ValueValidator {
     }
 }
 
-pub trait ValueListValidator {
+pub(crate) trait ValueListValidator {
     fn to_str_vec(&self) -> Result<Vec<String>, DatamodelError>;
+    fn to_string_from_env_var_vec(&self) -> Result<Vec<StringFromEnvVar>, DatamodelError>;
     fn to_literal_vec(&self) -> Result<Vec<String>, DatamodelError>;
 }
 
 impl ValueListValidator for Vec<ValueValidator> {
+    fn to_string_from_env_var_vec(&self) -> Result<Vec<StringFromEnvVar>, DatamodelError> {
+        self.iter().map(|val| val.as_str_from_env()).collect()
+    }
+
     fn to_str_vec(&self) -> Result<Vec<String>, DatamodelError> {
-        let mut res: Vec<String> = Vec::new();
-
-        for val in self {
-            res.push(val.as_str()?.to_owned());
-        }
-
-        Ok(res)
+        self.iter().map(|val| Ok(val.as_str()?.to_owned())).collect()
     }
 
     fn to_literal_vec(&self) -> Result<Vec<String>, DatamodelError> {
-        let mut res: Vec<String> = Vec::new();
-
-        for val in self {
-            res.push(val.as_constant_literal()?);
-        }
-
-        Ok(res)
+        self.iter().map(|val| val.as_constant_literal()).collect()
     }
 }

--- a/libs/datamodel/core/tests/common.rs
+++ b/libs/datamodel/core/tests/common.rs
@@ -395,21 +395,6 @@ pub fn parse_configuration(datamodel_string: &str) -> Configuration {
     }
 }
 
-pub fn parse_with_diagnostics(datamodel_string: &str) -> ValidatedDatamodel {
-    match datamodel::parse_datamodel(datamodel_string) {
-        Ok(s) => s,
-        Err(errs) => {
-            for err in errs.to_error_iter() {
-                err.pretty_print(&mut std::io::stderr().lock(), "", datamodel_string)
-                    .unwrap();
-            }
-
-            panic!("Datamodel parsing failed. Please see error above.")
-        }
-    }
-}
-
-#[allow(dead_code)] // Not sure why the compiler thinks this is never used.
 pub fn parse_error(datamodel_string: &str) -> Diagnostics {
     match datamodel::parse_datamodel(datamodel_string) {
         Ok(_) => panic!("Expected an error when parsing schema."),

--- a/libs/datamodel/core/tests/config/generators.rs
+++ b/libs/datamodel/core/tests/config/generators.rs
@@ -1,8 +1,8 @@
-use crate::common::parse_configuration;
-use crate::common::ErrorAsserts;
+use crate::common::{parse_configuration, ErrorAsserts};
 use datamodel::common::preview_features::GENERATOR;
 use datamodel::diagnostics::DatamodelError;
 use itertools::Itertools;
+use pretty_assertions::assert_eq;
 
 #[test]
 fn serialize_generators_to_cmf() {
@@ -39,7 +39,7 @@ generator go {
         "value": "go"
     },
     "output": null,
-    "binaryTargets": ["a","b"],
+    "binaryTargets": [{ "value": "a", "fromEnvVar": null }, { "value": "b", "fromEnvVar": null }],
     "previewFeatures": [],
     "config": {}
   }
@@ -159,7 +159,7 @@ fn new_lines_in_generator_must_work() {
             "value": "go"
           },
           "output": null,
-          "binaryTargets": ["b","c"],
+          "binaryTargets": [{ "value": "b", "fromEnvVar": null }, { "value": "c", "fromEnvVar": null }],
           "previewFeatures": [],
           "config": {}
         }
@@ -212,10 +212,47 @@ fn nice_error_for_unknown_generator_preview_feature() {
 }
 
 #[test]
-fn retain_env_var_definitions_in_generator_block() {
-    std::env::set_var("PROVIDER", "postgres");
-    std::env::set_var("OUTPUT", "~/home/prisma/");
+fn binary_targets_from_env_var_should_work() {
+    let schema = r#"
+    datasource db {
+        provider = "mysql"
+        url      = env("DATABASE_URL")
+    }
 
+    generator client {
+        provider      = "prisma-client-js"
+        binaryTargets = env("BINARY_TARGETS")
+    }
+
+    model User {
+        id Int @id
+    }
+    "#;
+
+    let expected_dmmf = r#"[
+        {
+          "name": "client",
+          "provider": {
+            "fromEnvVar": null,
+            "value": "prisma-client-js"
+          },
+          "output": null,
+          "binaryTargets": [
+            {
+                "fromEnvVar": "BINARY_TARGETS",
+                "value": null
+            }
+          ],
+          "previewFeatures": [],
+          "config": {}
+        }
+      ]"#;
+
+    assert_mcf(schema, expected_dmmf);
+}
+
+#[test]
+fn retain_env_var_definitions_in_generator_block() {
     let schema1 = r#"
     generator js1 {
         provider = env("PROVIDER")

--- a/libs/datamodel/core/tests/mod.rs
+++ b/libs/datamodel/core/tests/mod.rs
@@ -1,13 +1,13 @@
 #![allow(clippy::module_inception)]
 
-pub mod attributes;
-pub mod base;
-pub mod capabilities;
-pub mod common;
-pub mod config;
-pub mod functions;
-pub mod parsing;
-pub mod reformat;
-pub mod render_to_dmmf;
-pub mod renderer;
-pub mod types;
+mod attributes;
+mod base;
+mod capabilities;
+mod common;
+mod config;
+mod functions;
+mod parsing;
+mod reformat;
+mod render_to_dmmf;
+mod renderer;
+mod types;

--- a/libs/datamodel/core/tests/reformat/reformat.rs
+++ b/libs/datamodel/core/tests/reformat/reformat.rs
@@ -1,6 +1,5 @@
 use indoc::indoc;
 use pretty_assertions::assert_eq;
-use std::str;
 
 #[test]
 fn must_add_new_line_to_end_of_schema() {
@@ -845,7 +844,7 @@ fn unsupported_is_allowed() {
 fn ignore_is_allowed() {
     let input = r#"model Post {
   id Int @id
-  @@ignore  
+  @@ignore
 }
 "#;
 


### PR DESCRIPTION
Fixes a regression documented in
https://github.com/prisma/prisma/issues/7295 : the generatorConfig was
_implicitly_ potentially from the environment. Since we do not resolve
env vars during parsing anymore, using the env function in binaryTargets
started returning errors from DMMF generation.

The solution is to make binaryTarget members first-class
`StringFromEnvVar`s. Note that this is a small breaking change in the
shape of the DMMF that needs to be coordinated with the Typescript code.

closes https://github.com/prisma/prisma/issues/7295