### PR TITLE
Allow setting the statement cache for MySQL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3390,7 +3390,7 @@ dependencies = [
 [[package]]
 name = "quaint"
 version = "0.2.0-alpha.13"
-source = "git+https://github.com/prisma/quaint#bbc9cd6390837bc5291f08089eb15c5588629246"
+source = "git+https://github.com/prisma/quaint#af530a52337a2fff4b05c8e9da3e8a5fab780736"
 dependencies = [
  "async-trait",
  "base64 0.12.3",


### PR DESCRIPTION
Uses the same param as PostgreSQL: `statement_cache_size`. If not set, defaults to 32 (mysql_async default). If set to 0, disables caching. First aid for ticket: https://github.com/prisma/prisma/issues/6872

Quaint: https://github.com/prisma/quaint/pull/296