### PR TITLE
Revert "Make generator binaryTargets a StringFromEnvVar"

### DIFF
--- a/libs/datamodel/core/src/configuration/generator.rs
+++ b/libs/datamodel/core/src/configuration/generator.rs
@@ -12,7 +12,7 @@ pub struct Generator {
     pub config: HashMap<String, String>,
 
     #[serde(default)]
-    pub binary_targets: Vec<StringFromEnvVar>,
+    pub binary_targets: Vec<String>,
 
     #[serde(default)]
     pub preview_features: Vec<PreviewFeature>,

--- a/libs/datamodel/core/src/transform/ast_to_dml/generator_loader.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/generator_loader.rs
@@ -88,7 +88,7 @@ impl GeneratorLoader {
         let mut properties: HashMap<String, String> = HashMap::new();
 
         let binary_targets = match args.get(BINARY_TARGETS_KEY) {
-            Some(x) => x.as_array().to_string_from_env_var_vec()?,
+            Some(x) => x.as_array().to_str_vec()?,
             None => Vec::new(),
         };
 

--- a/libs/datamodel/core/src/transform/dml_to_ast/generator_serializer.rs
+++ b/libs/datamodel/core/src/transform/dml_to_ast/generator_serializer.rs
@@ -1,4 +1,4 @@
-use crate::{ast, configuration::Generator, transform::dml_to_ast::lower_string_from_env_var};
+use crate::{ast, configuration::Generator};
 
 pub struct GeneratorSerializer {}
 
@@ -36,7 +36,7 @@ impl GeneratorSerializer {
         let platform_values: Vec<ast::Expression> = generator
             .binary_targets
             .iter()
-            .map(|p| lower_string_from_env_var("binaryTargets", p).value)
+            .map(|p| ast::Expression::StringValue(p.to_string(), ast::Span::empty()))
             .collect();
         if !platform_values.is_empty() {
             arguments.push(ast::Argument::new_array("binaryTargets", platform_values));

--- a/libs/datamodel/core/src/transform/helpers/mod.rs
+++ b/libs/datamodel/core/src/transform/helpers/mod.rs
@@ -2,5 +2,5 @@ mod arguments;
 mod env_function;
 mod value_validator;
 
-pub(crate) use arguments::Arguments;
-pub(crate) use value_validator::{ValueListValidator, ValueValidator};
+pub use arguments::Arguments;
+pub use value_validator::{ValueListValidator, ValueValidator};

--- a/libs/datamodel/core/src/transform/helpers/value_validator.rs
+++ b/libs/datamodel/core/src/transform/helpers/value_validator.rs
@@ -236,22 +236,29 @@ impl ValueValidator {
     }
 }
 
-pub(crate) trait ValueListValidator {
+pub trait ValueListValidator {
     fn to_str_vec(&self) -> Result<Vec<String>, DatamodelError>;
-    fn to_string_from_env_var_vec(&self) -> Result<Vec<StringFromEnvVar>, DatamodelError>;
     fn to_literal_vec(&self) -> Result<Vec<String>, DatamodelError>;
 }
 
 impl ValueListValidator for Vec<ValueValidator> {
-    fn to_string_from_env_var_vec(&self) -> Result<Vec<StringFromEnvVar>, DatamodelError> {
-        self.iter().map(|val| val.as_str_from_env()).collect()
-    }
-
     fn to_str_vec(&self) -> Result<Vec<String>, DatamodelError> {
-        self.iter().map(|val| Ok(val.as_str()?.to_owned())).collect()
+        let mut res: Vec<String> = Vec::new();
+
+        for val in self {
+            res.push(val.as_str()?.to_owned());
+        }
+
+        Ok(res)
     }
 
     fn to_literal_vec(&self) -> Result<Vec<String>, DatamodelError> {
-        self.iter().map(|val| val.as_constant_literal()).collect()
+        let mut res: Vec<String> = Vec::new();
+
+        for val in self {
+            res.push(val.as_constant_literal()?);
+        }
+
+        Ok(res)
     }
 }

--- a/libs/datamodel/core/tests/common.rs
+++ b/libs/datamodel/core/tests/common.rs
@@ -395,6 +395,21 @@ pub fn parse_configuration(datamodel_string: &str) -> Configuration {
     }
 }
 
+pub fn parse_with_diagnostics(datamodel_string: &str) -> ValidatedDatamodel {
+    match datamodel::parse_datamodel(datamodel_string) {
+        Ok(s) => s,
+        Err(errs) => {
+            for err in errs.to_error_iter() {
+                err.pretty_print(&mut std::io::stderr().lock(), "", datamodel_string)
+                    .unwrap();
+            }
+
+            panic!("Datamodel parsing failed. Please see error above.")
+        }
+    }
+}
+
+#[allow(dead_code)] // Not sure why the compiler thinks this is never used.
 pub fn parse_error(datamodel_string: &str) -> Diagnostics {
     match datamodel::parse_datamodel(datamodel_string) {
         Ok(_) => panic!("Expected an error when parsing schema."),

--- a/libs/datamodel/core/tests/config/generators.rs
+++ b/libs/datamodel/core/tests/config/generators.rs
@@ -1,8 +1,8 @@
-use crate::common::{parse_configuration, ErrorAsserts};
+use crate::common::parse_configuration;
+use crate::common::ErrorAsserts;
 use datamodel::common::preview_features::GENERATOR;
 use datamodel::diagnostics::DatamodelError;
 use itertools::Itertools;
-use pretty_assertions::assert_eq;
 
 #[test]
 fn serialize_generators_to_cmf() {
@@ -39,7 +39,7 @@ generator go {
         "value": "go"
     },
     "output": null,
-    "binaryTargets": [{ "value": "a", "fromEnvVar": null }, { "value": "b", "fromEnvVar": null }],
+    "binaryTargets": ["a","b"],
     "previewFeatures": [],
     "config": {}
   }
@@ -159,7 +159,7 @@ fn new_lines_in_generator_must_work() {
             "value": "go"
           },
           "output": null,
-          "binaryTargets": [{ "value": "b", "fromEnvVar": null }, { "value": "c", "fromEnvVar": null }],
+          "binaryTargets": ["b","c"],
           "previewFeatures": [],
           "config": {}
         }
@@ -212,47 +212,10 @@ fn nice_error_for_unknown_generator_preview_feature() {
 }
 
 #[test]
-fn binary_targets_from_env_var_should_work() {
-    let schema = r#"
-    datasource db {
-        provider = "mysql"
-        url      = env("DATABASE_URL")
-    }
-
-    generator client {
-        provider      = "prisma-client-js"
-        binaryTargets = env("BINARY_TARGETS")
-    }
-
-    model User {
-        id Int @id
-    }
-    "#;
-
-    let expected_dmmf = r#"[
-        {
-          "name": "client",
-          "provider": {
-            "fromEnvVar": null,
-            "value": "prisma-client-js"
-          },
-          "output": null,
-          "binaryTargets": [
-            {
-                "fromEnvVar": "BINARY_TARGETS",
-                "value": null
-            }
-          ],
-          "previewFeatures": [],
-          "config": {}
-        }
-      ]"#;
-
-    assert_mcf(schema, expected_dmmf);
-}
-
-#[test]
 fn retain_env_var_definitions_in_generator_block() {
+    std::env::set_var("PROVIDER", "postgres");
+    std::env::set_var("OUTPUT", "~/home/prisma/");
+
     let schema1 = r#"
     generator js1 {
         provider = env("PROVIDER")

--- a/libs/datamodel/core/tests/mod.rs
+++ b/libs/datamodel/core/tests/mod.rs
@@ -1,13 +1,13 @@
 #![allow(clippy::module_inception)]
 
-mod attributes;
-mod base;
-mod capabilities;
-mod common;
-mod config;
-mod functions;
-mod parsing;
-mod reformat;
-mod render_to_dmmf;
-mod renderer;
-mod types;
+pub mod attributes;
+pub mod base;
+pub mod capabilities;
+pub mod common;
+pub mod config;
+pub mod functions;
+pub mod parsing;
+pub mod reformat;
+pub mod render_to_dmmf;
+pub mod renderer;
+pub mod types;

--- a/libs/datamodel/core/tests/reformat/reformat.rs
+++ b/libs/datamodel/core/tests/reformat/reformat.rs
@@ -1,5 +1,6 @@
 use indoc::indoc;
 use pretty_assertions::assert_eq;
+use std::str;
 
 #[test]
 fn must_add_new_line_to_end_of_schema() {
@@ -844,7 +845,7 @@ fn unsupported_is_allowed() {
 fn ignore_is_allowed() {
     let input = r#"model Post {
   id Int @id
-  @@ignore
+  @@ignore  
 }
 "#;
 


### PR DESCRIPTION
This reverts commit 01dc787a95d8de76f4d832c352692e7fb2cab372.

TS side is a bit entangled, so we will fix this regression after
tomorrow's release.