### PR TITLE
Unescape string literals using pest instead of an ad-hoc regex

### DIFF
--- a/libs/datamodel/core/src/ast/parser/datamodel.pest
+++ b/libs/datamodel/core/src/ast/parser/datamodel.pest
@@ -130,11 +130,11 @@ numeric_literal = @{ ("-")? ~ ASCII_DIGIT+ ~("." ~ ASCII_DIGIT+)? }
 
 // String, with support for escaped stuff and interpolations.
 string_escaped_predefined = { "n" | "r" | "t" | "\\" | "0" | "\"" | "'" | SPACE_SEPARATOR | INTERPOLATION_START }
-string_escape     = { "\\" ~ string_escaped_predefined }
+string_escape = { "\\" ~ string_escaped_predefined }
 // This is only used to escape the parser. The string above is still treated as atomic.
 string_interpolate_escape = !{ (INTERPOLATION_START ~ expression ~ INTERPOLATION_END) }
 string_raw = { (!("\\" | "\"" | NEWLINE | INTERPOLATION_START ) ~ (ANY))+ }
-string_content = @{ (string_raw | string_escape | string_interpolate_escape)* }
+string_content = ${ (string_raw | string_escape | string_interpolate_escape)* }
 string_literal = { "\"" ~ string_content ~ "\"" }
 
 boolean_true  = { "true" }

--- a/libs/datamodel/core/tests/config/generators.rs
+++ b/libs/datamodel/core/tests/config/generators.rs
@@ -120,7 +120,7 @@ fn hidden_preview_features_setting_must_work() {
 fn back_slashes_in_providers_must_work() {
     let schema = r#"
         generator mygen {
-          provider = "../folder\ with\ space/my\ generator.js"
+          provider = "../folder\ with\\ space/my\ generator.js"
         }
     "#;
 
@@ -129,7 +129,7 @@ fn back_slashes_in_providers_must_work() {
           "name": "mygen",
           "provider":{
             "fromEnvVar": null,
-            "value": "../folder\\ with\\ space/my\\ generator.js"
+            "value": "../folder with\\ space/my generator.js"
           },
           "output": null,
           "binaryTargets": [],


### PR DESCRIPTION
String unescaping now takes advantage of the parser already having done
the work of figuring out where and what the escaped characters were,
instead of trying to emulate this later with a regular expression.