### PR TITLE
Drop several dependencies in datamodel parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,10 +997,8 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "serial_test",
  "sql-datamodel-connector",
  "thiserror",
- "tracing",
  "url 2.2.1",
 ]
 

--- a/libs/datamodel/core/Cargo.toml
+++ b/libs/datamodel/core/Cargo.toml
@@ -23,7 +23,6 @@ regex = "1.3.7"
 serde = { version = "1.0.90", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order", "float_roundtrip"] }
 thiserror = "1.0"
-tracing = "0.1"
 url = "2"
 lazy_static = "1.4"
 
@@ -31,9 +30,7 @@ lazy_static = "1.4"
 clap = "2.33"
 indoc = "1"
 native-types = { path = "../../native-types" }
-paste = "1.0"
 pretty_assertions = "0.6.1"
-serial_test = "*"
 
 [features]
 default = []

--- a/libs/datamodel/core/tests/config/sources.rs
+++ b/libs/datamodel/core/tests/config/sources.rs
@@ -1,10 +1,8 @@
 use crate::common::*;
 use datamodel::{ast::Span, common::preview_features::*, diagnostics::DatamodelError, StringFromEnvVar};
 use pretty_assertions::assert_eq;
-use serial_test::serial;
 
 #[test]
-#[serial]
 fn must_error_if_multiple_datasources_are_defined() {
     let schema = r#"
 datasource db1 {
@@ -31,7 +29,6 @@ datasource db2 {
 }
 
 #[test]
-#[serial]
 fn must_forbid_env_functions_in_provider_field() {
     let schema = r#"
         datasource ds {
@@ -39,8 +36,6 @@ fn must_forbid_env_functions_in_provider_field() {
             url = env("DB_URL")
         }
     "#;
-    std::env::set_var("DB_PROVIDER", "postgresql");
-    std::env::set_var("DB_URL", "https://localhost");
     let config = datamodel::parse_configuration(schema);
     assert!(config.is_err());
     let diagnostics = config.err().expect("This must error");
@@ -51,7 +46,6 @@ fn must_forbid_env_functions_in_provider_field() {
 }
 
 #[test]
-#[serial]
 fn must_forbid_env_functions_in_provider_field_even_if_missing() {
     let schema = r#"
         datasource ds {
@@ -59,9 +53,7 @@ fn must_forbid_env_functions_in_provider_field_even_if_missing() {
             url = env("DB_URL")
         }
     "#;
-    std::env::set_var("DB_URL", "https://localhost");
     let config = datamodel::parse_configuration(schema);
-    assert!(config.is_err());
     let diagnostics = config.err().expect("This must error");
     diagnostics.assert_is(DatamodelError::new_functional_evaluation_error(
         "A datasource must not use the env() function in the provider argument.",
@@ -107,13 +99,12 @@ fn must_error_for_empty_provider_arrays() {
 }
 
 #[test]
-#[serial]
 fn must_error_for_empty_urls_derived_from_env_vars() {
-    std::env::set_var("DB_URL", "  ");
+    std::env::set_var("DB_URL_EMPTY_0001", "  ");
     let schema = r#"
         datasource myds {
             provider = "sqlite"
-            url = env("DB_URL")
+            url = env("DB_URL_EMPTY_0001")
         }
     "#;
 
@@ -121,9 +112,9 @@ fn must_error_for_empty_urls_derived_from_env_vars() {
     let diagnostics = config.subject.datasources[0].load_url().unwrap_err();
 
     diagnostics.assert_is(DatamodelError::new_source_validation_error(
-        "You must provide a nonempty URL. The environment variable `DB_URL` resolved to an empty string.",
+        "You must provide a nonempty URL. The environment variable `DB_URL_EMPTY_0001` resolved to an empty string.",
         "myds",
-        Span::new(77, 90),
+        Span::new(77, 101),
     ));
 }
 
@@ -167,15 +158,14 @@ fn must_error_if_wrong_protocol_is_used_for_mysql_shadow_database_url() {
 }
 
 #[test]
-#[serial]
 fn must_not_error_for_empty_shadow_database_urls_derived_from_env_vars() {
-    std::env::set_var("DB_URL", "  ");
+    std::env::set_var("EMPTY_SHADOW_DB URL_0129", "  ");
 
     let schema = r#"
         datasource myds {
             provider = "postgres"
             url = "postgres://"
-            shadowDatabaseUrl = env("DB_URL")
+            shadowDatabaseUrl = env("EMPTY_SHADOW_DB URL_0129")
         }
     "#;
 
@@ -290,12 +280,11 @@ fn new_lines_in_source_must_work() {
 }
 
 #[test]
-#[serial]
 fn must_error_if_env_var_is_missing() {
     let schema = r#"
         datasource ds {
           provider = "postgresql"
-          url = env("DATABASE_URL")
+          url = env("MISSING_DATABASE_URL_0001")
         }
     "#;
 
@@ -303,18 +292,17 @@ fn must_error_if_env_var_is_missing() {
     let diagnostics = config.subject.datasources[0].load_url().unwrap_err();
 
     diagnostics.assert_is(DatamodelError::new_environment_functional_evaluation_error(
-        "DATABASE_URL".into(),
-        Span::new(75, 94),
+        "MISSING_DATABASE_URL_0001".into(),
+        Span::new(75, 107),
     ));
 }
 
 #[test]
-#[serial]
 fn must_succeed_if_env_var_is_missing_but_override_was_provided() {
     let schema = r#"
         datasource ds {
           provider = "postgresql"
-          url = env("DATABASE_URL")
+          url = env("MISSING_DATABASE_URL_0002")
         }
     "#;
 
@@ -332,7 +320,6 @@ fn must_succeed_if_env_var_is_missing_but_override_was_provided() {
 }
 
 #[test]
-#[serial]
 fn must_succeed_if_env_var_exists_and_override_was_provided() {
     let schema = r#"
         datasource ds {
@@ -411,7 +398,6 @@ fn fail_when_preview_features_are_declared() {
 }
 
 #[test]
-#[serial]
 fn fail_when_no_source_is_declared() {
     let invalid_datamodel: &str = r#"        "#;
     let res = parse_configuration(invalid_datamodel);


### PR DESCRIPTION
serial_test in particular isn't required anymore since we do not parse env vars in the regular datamodel parsing process