### PR TITLE
Include shadowDatabaseUrl in datamodel rendering

### DIFF
--- a/libs/datamodel/core/src/transform/dml_to_ast/datasource_serializer.rs
+++ b/libs/datamodel/core/src/transform/dml_to_ast/datasource_serializer.rs
@@ -5,7 +5,7 @@ pub struct DatasourceSerializer {}
 
 impl DatasourceSerializer {
     pub fn add_sources_to_ast(sources: &[Datasource], ast_datamodel: &mut ast::SchemaAst) {
-        let mut tops: Vec<ast::Top> = Vec::new();
+        let mut tops: Vec<ast::Top> = Vec::with_capacity(ast_datamodel.tops.len() + sources.len());
 
         for source in sources {
             tops.push(ast::Top::Source(Self::lower_datasource(&source)))
@@ -21,6 +21,12 @@ impl DatasourceSerializer {
         let mut arguments: Vec<ast::Argument> = vec![ast::Argument::new_string("provider", &source.active_provider)];
 
         arguments.push(super::lower_string_from_env_var("url", &source.url));
+        if let Some((shadow_database_url, _)) = &source.shadow_database_url {
+            arguments.push(super::lower_string_from_env_var(
+                "shadowDatabaseUrl",
+                shadow_database_url,
+            ))
+        }
 
         ast::SourceConfig {
             name: ast::Identifier::new(&source.name),

--- a/libs/datamodel/core/tests/renderer/configuration.rs
+++ b/libs/datamodel/core/tests/renderer/configuration.rs
@@ -1,0 +1,27 @@
+use datamodel::{parse_schema, render_datamodel_and_config_to_string};
+use indoc::indoc;
+
+#[test]
+fn shadow_database_url_round_trips() {
+    let schema_str = indoc!(
+        r#"
+        datasource myds {
+          provider          = "postgresql"
+          url               = "postgres://"
+          shadowDatabaseUrl = env("EMPTY_SHADOW_DB URL_0129")
+        }
+
+        model Cat {
+          id   Int    @id
+          name String
+        }
+        "#
+    );
+
+    let parsed = parse_schema(schema_str).unwrap();
+    let (ref config, ref datamodel) = parsed.subject;
+
+    let rendered = render_datamodel_and_config_to_string(datamodel, config);
+
+    assert_eq!(schema_str, rendered);
+}

--- a/libs/datamodel/core/tests/renderer/mod.rs
+++ b/libs/datamodel/core/tests/renderer/mod.rs
@@ -1,2 +1,3 @@
+pub mod configuration;
 pub mod literals;
 pub mod simplification;


### PR DESCRIPTION
It was previously not included in the lowering of the datamodel to an
AST (after introspection).

closes https://github.com/prisma/prisma/issues/7337