### PR TITLE
Make schema assertions panic in ME

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2300,7 +2300,6 @@ dependencies = [
 name = "migration-engine-tests"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "bigdecimal",
  "chrono",
  "connection-string",

--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
@@ -163,11 +163,14 @@ fn render_raw_sql(
 
             vec![renderer.render_add_foreign_key(&foreign_key)]
         }
-        SqlMigrationStep::DropForeignKey(drop_foreign_key) => {
+        SqlMigrationStep::DropForeignKey {
+            table_index,
+            foreign_key_index,
+        } => {
             let foreign_key = schemas
                 .previous()
-                .table_walker_at(drop_foreign_key.table_index)
-                .foreign_key_at(drop_foreign_key.foreign_key_index);
+                .table_walker_at(*table_index)
+                .foreign_key_at(*foreign_key_index);
 
             vec![renderer.render_drop_foreign_key(&foreign_key)]
         }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_migration.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_migration.rs
@@ -64,8 +64,8 @@ impl SqlMigration {
                 SqlMigrationStep::AlterEnum(alter_enum) => {
                     drift_items.insert((DriftType::ChangedEnum, *alter_enum.index.previous() as u32, idx));
                 }
-                SqlMigrationStep::DropForeignKey(dropfk) => {
-                    drift_items.insert((DriftType::ChangedTable, dropfk.table_index as u32, idx));
+                SqlMigrationStep::DropForeignKey { table_index, .. } => {
+                    drift_items.insert((DriftType::ChangedTable, *table_index as u32, idx));
                 }
                 SqlMigrationStep::DropIndex { table_index, .. } => {
                     drift_items.insert((DriftType::ChangedTable, *table_index as u32, idx));
@@ -152,7 +152,9 @@ impl SqlMigration {
                         out.push_str("`\n");
                     }
                 }
-                SqlMigrationStep::DropForeignKey(_) => {}
+                SqlMigrationStep::DropForeignKey { .. } => {
+                    todo!()
+                }
                 SqlMigrationStep::DropIndex {
                     table_index,
                     index_index,
@@ -311,7 +313,10 @@ pub(crate) enum SqlMigrationStep {
         enum_index: usize,
     },
     AlterEnum(AlterEnum),
-    DropForeignKey(DropForeignKey),
+    DropForeignKey {
+        table_index: usize,
+        foreign_key_index: usize,
+    },
     DropIndex {
         table_index: usize,
         index_index: usize,
@@ -378,7 +383,7 @@ impl SqlMigrationStep {
             SqlMigrationStep::CreateTable { .. } => "CreateTable",
             SqlMigrationStep::AlterTable(_) => "AlterTable",
             SqlMigrationStep::RedefineIndex { .. } => "RedefineIndex",
-            SqlMigrationStep::DropForeignKey(_) => "DropForeignKey",
+            SqlMigrationStep::DropForeignKey { .. } => "DropForeignKey",
             SqlMigrationStep::DropTable { .. } => "DropTable",
             SqlMigrationStep::RedefineTables { .. } => "RedefineTables",
             SqlMigrationStep::CreateIndex(_) => "CreateIndex",
@@ -476,14 +481,6 @@ pub(crate) enum ColumnTypeChange {
     RiskyCast,
     SafeCast,
     NotCastable,
-}
-
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub(crate) struct DropForeignKey {
-    pub table: String,
-    pub table_index: usize,
-    pub foreign_key_index: usize,
-    pub constraint_name: String,
 }
 
 #[derive(Debug, Eq, Ord, PartialEq, PartialOrd)]

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour.rs
@@ -81,6 +81,12 @@ pub(crate) trait SqlSchemaDifferFlavour {
         false
     }
 
+    /// Whether the foreign keys of dropped tables should be dropped before the table
+    /// is dropped.
+    fn should_drop_foreign_keys_from_dropped_tables(&self) -> bool {
+        true
+    }
+
     /// Whether to skip diffing JSON defaults.
     fn should_ignore_json_defaults(&self) -> bool {
         false

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/sqlite.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/sqlite.rs
@@ -39,6 +39,10 @@ impl SqlSchemaDifferFlavour for SqliteFlavour {
             .collect()
     }
 
+    fn should_drop_foreign_keys_from_dropped_tables(&self) -> bool {
+        false
+    }
+
     fn should_push_foreign_keys_from_created_tables(&self) -> bool {
         false
     }

--- a/migration-engine/migration-engine-tests/Cargo.toml
+++ b/migration-engine/migration-engine-tests/Cargo.toml
@@ -23,7 +23,6 @@ test-macros = { path = "../../libs/test-macros" }
 test-setup = { path = "../../libs/test-setup" }
 prisma-value = { path = "../../libs/prisma-value" }
 
-anyhow = "1.0"
 bigdecimal = "0.2"
 chrono = "0.4.15"
 enumflags2 = "0.7"

--- a/migration-engine/migration-engine-tests/src/assertions.rs
+++ b/migration-engine/migration-engine-tests/src/assertions.rs
@@ -7,10 +7,8 @@ use sql_schema_describer::{
 };
 use test_setup::{BitFlags, Tags};
 
-pub(crate) type AssertionResult<T> = Result<T, anyhow::Error>;
-
 pub trait SqlSchemaExt {
-    fn assert_table<'a>(&'a self, table_name: &str) -> AssertionResult<TableAssertion<'a>>;
+    fn assert_table<'a>(&'a self, table_name: &str) -> TableAssertion<'a>;
 }
 
 pub struct SchemaAssertion {
@@ -27,19 +25,18 @@ impl SchemaAssertion {
         self.schema
     }
 
-    pub fn assert_equals(self, other: &SqlSchema) -> AssertionResult<Self> {
+    pub fn assert_equals(self, other: &SqlSchema) -> Self {
         assert_eq!(&self.schema, other);
-
-        Ok(self)
+        self
     }
 
-    pub fn assert_ne(self, other: &SqlSchema) -> AssertionResult<Self> {
+    pub fn assert_ne(self, other: &SqlSchema) -> Self {
         assert_ne!(&self.schema, other);
-
-        Ok(self)
+        self
     }
 
-    fn find_table(&self, table_name: &str) -> anyhow::Result<&sql_schema_describer::Table> {
+    #[track_caller]
+    fn find_table(&self, table_name: &str) -> &sql_schema_describer::Table {
         match self.schema.tables.iter().find(|t| {
             if self.tags.contains(Tags::LowerCasesTableNames) {
                 t.name.eq_ignore_ascii_case(table_name)
@@ -47,44 +44,32 @@ impl SchemaAssertion {
                 t.name == table_name
             }
         }) {
-            Some(table) => Ok(table),
-            None => Err(anyhow::anyhow!(
+            Some(table) => table,
+            None => panic!(
                 "assert_has_table failed. Table {} not found. Tables in database: {:?}",
                 table_name,
                 self.schema.tables.iter().map(|table| &table.name).collect::<Vec<_>>()
-            )),
+            ),
         }
     }
 
-    pub fn assert_has_table(self, table_name: &str) -> AssertionResult<Self> {
-        self.find_table(table_name)?;
-        Ok(self)
-    }
-
-    pub fn assert_table<F>(self, table_name: &str, table_assertions: F) -> AssertionResult<Self>
-    where
-        F: for<'a> FnOnce(TableAssertion<'a>) -> AssertionResult<TableAssertion<'a>>,
-    {
-        let table = self.find_table(table_name)?;
-
-        table_assertions(TableAssertion::new(table, self.tags))?;
-
-        Ok(self)
-    }
-
     #[track_caller]
-    pub fn assert_table_bang<F>(self, table_name: &str, table_assertions: F) -> Self
-    where
-        F: for<'a> FnOnce(TableAssertion<'a>) -> AssertionResult<TableAssertion<'a>>,
-    {
-        let table = self.find_table(table_name).unwrap();
-
-        table_assertions(TableAssertion::new(table, self.tags)).unwrap();
-
+    pub fn assert_has_table(self, table_name: &str) -> Self {
+        self.find_table(table_name);
         self
     }
 
-    pub fn assert_has_no_enum(self, enum_name: &str) -> AssertionResult<Self> {
+    #[track_caller]
+    pub fn assert_table<F>(self, table_name: &str, table_assertions: F) -> Self
+    where
+        F: for<'a> FnOnce(TableAssertion<'a>) -> TableAssertion<'a>,
+    {
+        let table = self.find_table(table_name);
+        table_assertions(TableAssertion::new(table, self.tags));
+        self
+    }
+
+    pub fn assert_has_no_enum(self, enum_name: &str) -> Self {
         let has_matching_enum = self.schema.enums.iter().any(|enm| {
             if self.tags.contains(Tags::LowerCasesTableNames) {
                 enm.name.eq_ignore_ascii_case(enum_name)
@@ -94,24 +79,23 @@ impl SchemaAssertion {
         });
 
         if has_matching_enum {
-            anyhow::bail!("Expected no enum named {}, found one", enum_name);
+            panic!("Expected no enum named {}, found one", enum_name);
         }
 
-        Ok(self)
+        self
     }
 
-    pub fn assert_enum<F>(self, enum_name: &str, enum_assertions: F) -> AssertionResult<Self>
+    pub fn assert_enum<F>(self, enum_name: &str, enum_assertions: F) -> Self
     where
-        F: for<'a> FnOnce(EnumAssertion<'a>) -> AssertionResult<EnumAssertion<'a>>,
+        F: for<'a> FnOnce(EnumAssertion<'a>) -> EnumAssertion<'a>,
     {
-        let r#enum = self
-            .schema
-            .get_enum(enum_name)
-            .ok_or_else(|| anyhow::anyhow!("Assertion failed. Enum `{}` not found", enum_name))?;
+        let r#enum = match self.schema.get_enum(enum_name) {
+            Some(enm) => enm,
+            None => panic!("Assertion failed. Enum `{}` not found", enum_name),
+        };
 
-        enum_assertions(EnumAssertion(&r#enum))?;
-
-        Ok(self)
+        enum_assertions(EnumAssertion(&r#enum));
+        self
     }
 
     #[track_caller]
@@ -139,16 +123,15 @@ impl SchemaAssertion {
 pub struct EnumAssertion<'a>(&'a Enum);
 
 impl<'a> EnumAssertion<'a> {
-    pub fn assert_values(self, expected_values: &[&'static str]) -> AssertionResult<Self> {
-        anyhow::ensure!(
+    pub fn assert_values(self, expected_values: &[&'static str]) -> Self {
+        assert!(
             self.0.values == expected_values,
             "Assertion failed. The `{}` enum does not contain the expected variants.\nExpected:\n{:#?}\n\nFound:\n{:#?}\n",
             self.0.name,
             expected_values,
             self.0.values,
         );
-
-        Ok(self)
+        self
     }
 }
 
@@ -163,154 +146,136 @@ impl<'a> TableAssertion<'a> {
         Self { table, tags }
     }
 
-    pub fn assert_column_count(self, n: usize) -> AssertionResult<Self> {
+    pub fn assert_column_count(self, n: usize) -> Self {
         let columns_count = self.table.columns.len();
 
-        anyhow::ensure!(
+        assert!(
             columns_count == n,
-            anyhow::anyhow!(
-                "Assertion failed. Expected {n} columns, found {columns_count}. {columns:#?}",
-                n = n,
-                columns_count = columns_count,
-                columns = &self.table.columns,
-            )
+            "Assertion failed. Expected {n} columns, found {columns_count}. {columns:#?}",
+            n = n,
+            columns_count = columns_count,
+            columns = &self.table.columns,
         );
-
-        Ok(self)
+        self
     }
 
-    pub fn assert_foreign_keys_count(self, n: usize) -> AssertionResult<Self> {
+    pub fn assert_foreign_keys_count(self, n: usize) -> Self {
         let fk_count = self.table.foreign_keys.len();
-        anyhow::ensure!(
-            fk_count == n,
-            anyhow::anyhow!("Expected {} foreign keys, found {}.", n, fk_count)
-        );
-
-        Ok(self)
+        assert!(fk_count == n, "Expected {} foreign keys, found {}.", n, fk_count);
+        self
     }
 
-    pub fn assert_has_fk(self, fk: &ForeignKey) -> AssertionResult<Self> {
+    pub fn assert_has_fk(self, fk: &ForeignKey) -> Self {
         let matching_fk = self.table.foreign_keys.iter().any(|found| found == fk);
-
-        anyhow::ensure!(matching_fk, "Assertion failed. Could not find fk.");
-
-        Ok(self)
+        assert!(matching_fk, "Assertion failed. Could not find fk.");
+        self
     }
 
-    pub fn assert_fk_on_columns<F>(self, columns: &[&str], fk_assertions: F) -> AssertionResult<Self>
+    pub fn assert_fk_on_columns<F>(self, columns: &[&str], fk_assertions: F) -> Self
     where
-        F: FnOnce(ForeignKeyAssertion<'a>) -> AssertionResult<ForeignKeyAssertion<'a>>,
+        F: FnOnce(ForeignKeyAssertion<'a>) -> ForeignKeyAssertion<'a>,
     {
         if let Some(fk) = self.table.foreign_keys.iter().find(|fk| fk.columns == columns) {
-            fk_assertions(ForeignKeyAssertion::new(fk, self.tags))?;
+            fk_assertions(ForeignKeyAssertion::new(fk, self.tags));
         } else {
-            anyhow::bail!("Could not find foreign key on {}.{:?}", self.table.name, columns);
+            panic!("Could not find foreign key on {}.{:?}", self.table.name, columns);
         }
 
-        Ok(self)
+        self
     }
 
-    pub fn assert_does_not_have_column(self, column_name: &str) -> AssertionResult<Self> {
+    pub fn assert_does_not_have_column(self, column_name: &str) -> Self {
         if self.table.column(column_name).is_some() {
-            anyhow::bail!(
+            panic!(
                 "Assertion failed: found column `{}` on `{}`.",
-                column_name,
-                self.table.name
+                column_name, self.table.name
             );
         }
-
-        Ok(self)
+        self
     }
 
-    pub fn assert_has_column(self, column_name: &str) -> AssertionResult<Self> {
-        self.table.column(column_name).ok_or_else(|| {
-            anyhow::anyhow!(
+    #[track_caller]
+    pub fn assert_has_column(self, column_name: &str) -> Self {
+        match self.table.column(column_name) {
+            Some(_) => self,
+            None => panic!(
                 "Assertion failed: column {} not found. Existing columns: {:?}",
                 column_name,
                 self.table.columns.iter().map(|col| &col.name).collect::<Vec<_>>()
-            )
-        })?;
-
-        Ok(self)
+            ),
+        }
     }
 
-    pub fn assert_column<F>(self, column_name: &str, column_assertions: F) -> AssertionResult<Self>
+    pub fn assert_column<F>(self, column_name: &str, column_assertions: F) -> Self
     where
-        F: FnOnce(ColumnAssertion<'a>) -> AssertionResult<ColumnAssertion<'a>>,
+        F: FnOnce(ColumnAssertion<'a>) -> ColumnAssertion<'a>,
     {
-        let this = self.assert_has_column(column_name)?;
+        let this = self.assert_has_column(column_name);
         let column = this.table.column(column_name).unwrap();
 
-        column_assertions(ColumnAssertion::new(column, self.tags))?;
-
-        Ok(this)
+        column_assertions(ColumnAssertion::new(column, self.tags));
+        this
     }
 
-    pub fn assert_columns_count(self, count: usize) -> AssertionResult<Self> {
+    pub fn assert_columns_count(self, count: usize) -> Self {
         let actual_count = self.table.columns.len();
 
-        anyhow::ensure!(
+        assert!(
             actual_count == count,
             "Assertion failed: expected {} columns, found {}",
             count,
             actual_count,
         );
 
-        Ok(self)
+        self
     }
 
-    pub fn assert_has_no_pk(self) -> AssertionResult<Self> {
-        anyhow::ensure!(
+    pub fn assert_has_no_pk(self) -> Self {
+        assert!(
             self.table.primary_key.is_none(),
             "Assertion failed: expected no primary key on {}, but found one. ({:?})",
             self.table.name,
             self.table.primary_key
         );
 
-        Ok(self)
+        self
     }
 
-    pub fn assert_pk<F>(self, pk_assertions: F) -> AssertionResult<Self>
+    pub fn assert_pk<F>(self, pk_assertions: F) -> Self
     where
-        F: FnOnce(PrimaryKeyAssertion<'a>) -> AssertionResult<PrimaryKeyAssertion<'a>>,
+        F: FnOnce(PrimaryKeyAssertion<'a>) -> PrimaryKeyAssertion<'a>,
     {
-        let pk = self
-            .table
-            .primary_key
-            .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("Primary key not found on {}.", self.table.name))?;
-
-        pk_assertions(PrimaryKeyAssertion { pk, table: self.table })?;
-
-        Ok(self)
+        match self.table.primary_key.as_ref() {
+            Some(pk) => {
+                pk_assertions(PrimaryKeyAssertion { pk, table: self.table });
+                self
+            }
+            None => panic!("Primary key not found on {}.", self.table.name),
+        }
     }
 
-    pub fn assert_indexes_count(self, n: usize) -> AssertionResult<Self> {
+    pub fn assert_indexes_count(self, n: usize) -> Self {
         let idx_count = self.table.indices.len();
-        anyhow::ensure!(
-            idx_count == n,
-            anyhow::anyhow!("Expected {} indexes, found {}.", n, idx_count)
-        );
-
-        Ok(self)
+        assert!(idx_count == n, "Expected {} indexes, found {}.", n, idx_count);
+        self
     }
 
-    pub fn assert_index_on_columns<F>(self, columns: &[&str], index_assertions: F) -> AssertionResult<Self>
+    pub fn assert_index_on_columns<F>(self, columns: &[&str], index_assertions: F) -> Self
     where
-        F: FnOnce(IndexAssertion<'a>) -> AssertionResult<IndexAssertion<'a>>,
+        F: FnOnce(IndexAssertion<'a>) -> IndexAssertion<'a>,
     {
         if let Some(idx) = self.table.indices.iter().find(|idx| idx.columns == columns) {
-            index_assertions(IndexAssertion(idx))?;
+            index_assertions(IndexAssertion(idx));
         } else {
-            anyhow::bail!("Could not find index on {}.{:?}", self.table.name, columns);
+            panic!("Could not find index on {}.{:?}", self.table.name, columns);
         }
 
-        Ok(self)
+        self
     }
 
-    pub fn debug_print(self) -> AssertionResult<Self> {
+    pub fn debug_print(self) -> Self {
         println!("{:?}", self.table);
-        Ok(self)
+        self
     }
 }
 
@@ -324,43 +289,43 @@ impl<'a> ColumnAssertion<'a> {
         Self { column, tags }
     }
 
-    pub fn assert_auto_increments(self) -> AssertionResult<Self> {
-        anyhow::ensure!(
+    pub fn assert_auto_increments(self) -> Self {
+        assert!(
             self.column.auto_increment,
             "Assertion failed. Expected column `{}` to be auto-incrementing.",
             self.column.name,
         );
 
-        Ok(self)
+        self
     }
 
-    pub fn assert_no_auto_increment(self) -> AssertionResult<Self> {
-        anyhow::ensure!(
+    pub fn assert_no_auto_increment(self) -> Self {
+        assert!(
             !self.column.auto_increment,
             "Assertion failed. Expected column `{}` not to be auto-incrementing.",
             self.column.name,
         );
 
-        Ok(self)
+        self
     }
 
-    pub fn assert_default(self, expected: Option<DefaultValue>) -> AssertionResult<Self> {
+    pub fn assert_default(self, expected: Option<DefaultValue>) -> Self {
         let found = &self.column.default.as_ref().map(|d| d.kind());
 
-        anyhow::ensure!(
+        assert!(
             found == &expected.as_ref().map(|d| d.kind()),
             "Assertion failed. Expected default: {:?}, but found {:?}",
             expected,
             found
         );
 
-        Ok(self)
+        self
     }
 
-    pub fn assert_full_data_type(self, full_data_type: &str) -> AssertionResult<Self> {
+    pub fn assert_full_data_type(self, full_data_type: &str) -> Self {
         let found = &self.column.tpe.full_data_type;
 
-        anyhow::ensure!(
+        assert!(
             found == full_data_type,
             "Assertion failed: expected the full_data_type for the `{}` column to be `{}`, found `{}`",
             self.column.name,
@@ -368,53 +333,51 @@ impl<'a> ColumnAssertion<'a> {
             found
         );
 
-        Ok(self)
+        self
     }
 
-    pub fn assert_has_no_default(self) -> AssertionResult<Self> {
+    pub fn assert_has_no_default(self) -> Self {
         self.assert_default(None)
     }
 
-    pub fn assert_default_value(self, expected: &prisma_value::PrismaValue) -> AssertionResult<Self> {
+    pub fn assert_default_value(self, expected: &prisma_value::PrismaValue) -> Self {
         let found = &self.column.default;
 
         match found.as_ref().map(|d| d.kind()) {
-            Some(DefaultKind::Value(ref val)) => anyhow::ensure!(
+            Some(DefaultKind::Value(ref val)) => assert!(
                 val == expected,
                 "Assertion failed. Expected the default value for `{}` to be `{:?}`, got `{:?}`",
                 self.column.name,
                 expected,
                 val
             ),
-            other => anyhow::bail!(
+            other => panic!(
                 "Assertion failed. Expected default: {:?}, but found {:?}",
-                expected,
-                other
+                expected, other
             ),
         }
 
-        Ok(self)
+        self
     }
 
-    pub fn assert_dbgenerated(self, expected: &str) -> AssertionResult<Self> {
+    pub fn assert_dbgenerated(self, expected: &str) -> Self {
         let found = &self.column.default;
 
         match found.as_ref().map(|d| d.kind()) {
-            Some(DefaultKind::DbGenerated(val)) => anyhow::ensure!(
+            Some(DefaultKind::DbGenerated(val)) => assert!(
                 val == expected,
                 "Assertion failed. Expected the default value for `{}` to be dbgenerated with `{:?}`, got `{:?}`",
                 self.column.name,
                 expected,
                 val
             ),
-            other => anyhow::bail!(
+            other => panic!(
                 "Assertion failed. Expected default: {:?}, but found {:?}",
-                expected,
-                other
+                expected, other
             ),
         }
 
-        Ok(self)
+        self
     }
 
     pub fn assert_enum_default(self, expected: &str) -> Self {
@@ -425,9 +388,9 @@ impl<'a> ColumnAssertion<'a> {
         self
     }
 
-    pub fn assert_native_type(self, expected: &str, connector: &dyn Connector) -> AssertionResult<Self> {
+    pub fn assert_native_type(self, expected: &str, connector: &dyn Connector) -> Self {
         let found = connector.render_native_type(self.column.tpe.native_type.clone().unwrap());
-        anyhow::ensure!(
+        assert!(
             found == expected,
             "Assertion failed. Expected the column native type for `{}` to be `{:?}`, found `{:?}`",
             self.column.name,
@@ -435,10 +398,10 @@ impl<'a> ColumnAssertion<'a> {
             found,
         );
 
-        Ok(self)
+        self
     }
 
-    pub fn assert_type_family(self, expected: ColumnTypeFamily) -> AssertionResult<Self> {
+    pub fn assert_type_family(self, expected: ColumnTypeFamily) -> Self {
         let found = &self.column.tpe.family;
 
         let expected = match expected {
@@ -448,7 +411,7 @@ impl<'a> ColumnAssertion<'a> {
             _ => expected,
         };
 
-        anyhow::ensure!(
+        assert!(
             found == &expected,
             "Assertion failed. Expected the column type family for `{}` to be `{:?}`, found `{:?}`",
             self.column.name,
@@ -456,46 +419,46 @@ impl<'a> ColumnAssertion<'a> {
             found,
         );
 
-        Ok(self)
+        self
     }
 
-    pub fn assert_type_is_bigint(self) -> AssertionResult<Self> {
+    pub fn assert_type_is_bigint(self) -> Self {
         let found = &self.column.tpe.family;
 
-        anyhow::ensure!(
+        assert!(
             found == &sql_schema_describer::ColumnTypeFamily::BigInt,
             "Assertion failed. Expected a BigInt column, got {:?}.",
             found
         );
 
-        Ok(self)
+        self
     }
 
-    pub fn assert_type_is_bytes(self) -> AssertionResult<Self> {
+    pub fn assert_type_is_bytes(self) -> Self {
         let found = &self.column.tpe.family;
 
-        anyhow::ensure!(
+        assert!(
             found == &sql_schema_describer::ColumnTypeFamily::Binary,
             "Assertion failed. Expected a bytes column, got {:?}.",
             found
         );
 
-        Ok(self)
+        self
     }
 
-    pub fn assert_type_is_decimal(self) -> AssertionResult<Self> {
+    pub fn assert_type_is_decimal(self) -> Self {
         let found = &self.column.tpe.family;
 
-        anyhow::ensure!(
+        assert!(
             found == &sql_schema_describer::ColumnTypeFamily::Decimal,
             "Assertion failed. Expected a decimal column, got {:?}.",
             found
         );
 
-        Ok(self)
+        self
     }
 
-    pub fn assert_type_is_enum(self) -> AssertionResult<Self> {
+    pub fn assert_type_is_enum(self) -> Self {
         let found = &self.column.tpe.family;
 
         assert!(
@@ -504,64 +467,64 @@ impl<'a> ColumnAssertion<'a> {
             found
         );
 
-        Ok(self)
+        self
     }
 
-    pub fn assert_type_is_string(self) -> AssertionResult<Self> {
+    pub fn assert_type_is_string(self) -> Self {
         let found = &self.column.tpe.family;
 
-        anyhow::ensure!(
+        assert!(
             found == &sql_schema_describer::ColumnTypeFamily::String,
             "Assertion failed. Expected a string column, got {:?}.",
             found
         );
 
-        Ok(self)
+        self
     }
 
-    pub fn assert_type_is_int(self) -> AssertionResult<Self> {
+    pub fn assert_type_is_int(self) -> Self {
         let found = &self.column.tpe.family;
 
-        anyhow::ensure!(
+        assert!(
             found == &sql_schema_describer::ColumnTypeFamily::Int,
             "Assertion failed. Expected an integer column, got {:?}.",
             found
         );
 
-        Ok(self)
+        self
     }
 
-    pub fn assert_is_list(self) -> AssertionResult<Self> {
-        anyhow::ensure!(
+    pub fn assert_is_list(self) -> Self {
+        assert!(
             self.column.tpe.arity.is_list(),
             "Assertion failed. Expected column `{}` to be a list, got {:?}",
             self.column.name,
             self.column.tpe.arity,
         );
 
-        Ok(self)
+        self
     }
 
-    pub fn assert_is_nullable(self) -> AssertionResult<Self> {
-        anyhow::ensure!(
+    pub fn assert_is_nullable(self) -> Self {
+        assert!(
             self.column.tpe.arity.is_nullable(),
             "Assertion failed. Expected column `{}` to be nullable, got {:?}",
             self.column.name,
             self.column.tpe.arity,
         );
 
-        Ok(self)
+        self
     }
 
-    pub fn assert_is_required(self) -> AssertionResult<Self> {
-        anyhow::ensure!(
+    pub fn assert_is_required(self) -> Self {
+        assert!(
             self.column.tpe.arity.is_required(),
             "Assertion failed. Expected column `{}` to be NOT NULL, got {:?}",
             self.column.name,
             self.column.tpe.arity,
         );
 
-        Ok(self)
+        self
     }
 }
 
@@ -571,14 +534,14 @@ pub struct PrimaryKeyAssertion<'a> {
 }
 
 impl<'a> PrimaryKeyAssertion<'a> {
-    pub fn assert_columns(self, column_names: &[&str]) -> AssertionResult<Self> {
+    pub fn assert_columns(self, column_names: &[&str]) -> Self {
         assert_eq!(self.pk.columns, column_names);
 
-        Ok(self)
+        self
     }
 
-    pub fn assert_has_autoincrement(self) -> AssertionResult<Self> {
-        anyhow::ensure!(
+    pub fn assert_has_autoincrement(self) -> Self {
+        assert!(
             self.table
                 .columns
                 .iter()
@@ -586,11 +549,11 @@ impl<'a> PrimaryKeyAssertion<'a> {
             "Assertion failed: expected a sequence on the primary key, found none."
         );
 
-        Ok(self)
+        self
     }
 
-    pub fn assert_has_no_autoincrement(self) -> AssertionResult<Self> {
-        anyhow::ensure!(
+    pub fn assert_has_no_autoincrement(self) -> Self {
+        assert!(
             !self
                 .table
                 .columns
@@ -599,12 +562,12 @@ impl<'a> PrimaryKeyAssertion<'a> {
             "Assertion failed: expected no sequence on the primary key, but found one."
         );
 
-        Ok(self)
+        self
     }
 
-    pub fn debug_print(self) -> AssertionResult<Self> {
+    pub fn debug_print(self) -> Self {
         println!("{:?}", &self.pk);
-        Ok(self)
+        self
     }
 }
 
@@ -618,8 +581,8 @@ impl<'a> ForeignKeyAssertion<'a> {
         Self { fk, tags }
     }
 
-    pub fn assert_references(self, table: &str, columns: &[&str]) -> AssertionResult<Self> {
-        anyhow::ensure!(
+    pub fn assert_references(self, table: &str, columns: &[&str]) -> Self {
+        assert!(
             self.is_same_table_name(&self.fk.referenced_table, table) && self.fk.referenced_columns == columns,
             r#"Assertion failed. Expected reference to "{}" ({:?}). Found "{}" ({:?}) "#,
             table,
@@ -628,16 +591,16 @@ impl<'a> ForeignKeyAssertion<'a> {
             self.fk.referenced_columns,
         );
 
-        Ok(self)
+        self
     }
 
-    pub fn assert_cascades_on_delete(self) -> AssertionResult<Self> {
-        anyhow::ensure!(
+    pub fn assert_cascades_on_delete(self) -> Self {
+        assert!(
             self.fk.on_delete_action == ForeignKeyAction::Cascade,
             "Assertion failed: expected foreign key to cascade on delete."
         );
 
-        Ok(self)
+        self
     }
 
     fn is_same_table_name(&self, fst: &str, snd: &str) -> bool {
@@ -652,21 +615,21 @@ impl<'a> ForeignKeyAssertion<'a> {
 pub struct IndexAssertion<'a>(&'a Index);
 
 impl<'a> IndexAssertion<'a> {
-    pub fn assert_name(self, name: &str) -> AssertionResult<Self> {
+    pub fn assert_name(self, name: &str) -> Self {
         assert_eq!(self.0.name, name);
 
-        Ok(self)
+        self
     }
 
-    pub fn assert_is_unique(self) -> AssertionResult<Self> {
+    pub fn assert_is_unique(self) -> Self {
         assert_eq!(self.0.tpe, IndexType::Unique);
 
-        Ok(self)
+        self
     }
 
-    pub fn assert_is_not_unique(self) -> AssertionResult<Self> {
+    pub fn assert_is_not_unique(self) -> Self {
         assert_eq!(self.0.tpe, IndexType::Normal);
 
-        Ok(self)
+        self
     }
 }

--- a/migration-engine/migration-engine-tests/src/lib.rs
+++ b/migration-engine/migration-engine-tests/src/lib.rs
@@ -11,5 +11,3 @@ pub use assertions::*;
 pub use test_api::*;
 pub use test_macros::test_connector;
 pub use test_setup::*;
-
-pub type TestResult = anyhow::Result<()>;

--- a/migration-engine/migration-engine-tests/src/sql.rs
+++ b/migration-engine/migration-engine-tests/src/sql.rs
@@ -1,6 +1,6 @@
 mod quaint_result_set_ext;
 
-pub use super::{assertions::*, test_api::*, TestResult};
+pub use super::{assertions::*, test_api::*};
 pub use quaint::prelude::Queryable;
 pub use quaint_result_set_ext::*;
 pub use test_macros::test_connector;

--- a/migration-engine/migration-engine-tests/src/test_api/schema_push.rs
+++ b/migration-engine/migration-engine-tests/src/test_api/schema_push.rs
@@ -1,4 +1,3 @@
-use super::super::assertions::AssertionResult;
 use migration_core::{
     api::GenericApi,
     commands::{SchemaPushInput, SchemaPushOutput},
@@ -91,11 +90,6 @@ impl Debug for SchemaPushAssertion<'_> {
 }
 
 impl<'a> SchemaPushAssertion<'a> {
-    /// Asserts that the command produced no warning and no unexecutable migration message.
-    pub fn assert_green(self) -> AssertionResult<Self> {
-        Ok(self.assert_no_warning().assert_executable())
-    }
-
     /// Asserts that the command produced no warning and no unexecutable migration message.
     #[track_caller]
     pub fn assert_green_bang(self) -> Self {

--- a/migration-engine/migration-engine-tests/tests/apply_migrations/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/apply_migrations/mod.rs
@@ -147,19 +147,13 @@ fn migrations_should_fail_when_the_script_is_invalid(api: TestApi) {
 
     first
         .assert_migration_name("initial")
-        .unwrap()
         .assert_applied_steps_count(1)
-        .unwrap()
-        .assert_success()
-        .unwrap();
+        .assert_success();
 
     second
         .assert_migration_name("second-migration")
-        .unwrap()
         .assert_applied_steps_count(0)
-        .unwrap()
-        .assert_failed()
-        .unwrap();
+        .assert_failed();
 }
 
 #[test_connector]

--- a/migration-engine/migration-engine-tests/tests/existing_data/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_data/mod.rs
@@ -35,7 +35,7 @@ fn dropping_a_table_with_rows_should_warn(api: TestApi) {
 
     // The schema should not change because the migration should not run if there are warnings
     // and the force flag isn't passed.
-    api.assert_schema().assert_equals(&original_database_schema).unwrap();
+    api.assert_schema().assert_equals(&original_database_schema);
 }
 
 #[test_connector]
@@ -73,7 +73,7 @@ fn dropping_a_column_with_non_null_values_should_warn(api: TestApi) {
 
     // The schema should not change because the migration should not run if there are warnings
     // and the force flag isn't passed.
-    api.assert_schema().assert_equals(&original_database_schema).unwrap();
+    api.assert_schema().assert_equals(&original_database_schema);
 }
 
 #[test_connector]
@@ -104,7 +104,7 @@ fn altering_a_column_without_non_null_values_should_not_warn(api: TestApi) {
 
     api.schema_push(dm2).send_sync().assert_warnings(&[]);
 
-    api.assert_schema().assert_ne(&original_database_schema).unwrap();
+    api.assert_schema().assert_ne(&original_database_schema);
 }
 
 #[test_connector]
@@ -154,7 +154,7 @@ fn altering_a_column_with_non_null_values_should_warn(api: TestApi) {
 
     // The schema should not change because the migration should not run if there are warnings
     // and the force flag isn't passed.
-    api.assert_schema().assert_equals(&original_database_schema).unwrap();
+    api.assert_schema().assert_equals(&original_database_schema);
 
     assert_eq!(api.dump_table("Test").len(), 2);
 }
@@ -194,7 +194,7 @@ fn column_defaults_can_safely_be_changed(api: TestApi) {
 
             api.schema_push(dm1).force(true).send_sync();
 
-            api.assert_schema().assert_table_bang(model_name, |table| {
+            api.assert_schema().assert_table(model_name, |table| {
                 table.assert_column("name", |column| {
                     if let Some(first_default) = first_default.as_ref() {
                         column.assert_default_value(first_default)
@@ -275,7 +275,7 @@ fn column_defaults_can_safely_be_changed(api: TestApi) {
                 names.as_slice()
             );
 
-            api.assert_schema().assert_table_bang(model_name, |table| {
+            api.assert_schema().assert_table(model_name, |table| {
                 table.assert_column("name", |column| {
                     if let Some(second_default) = second_default.as_ref() {
                         column.assert_default_value(second_default)
@@ -315,7 +315,7 @@ fn changing_a_column_from_required_to_optional_should_work(api: TestApi) {
 
     api.schema_push(dm2).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_ne(&original_database_schema).unwrap();
+    api.assert_schema().assert_ne(&original_database_schema);
 
     // Check that no data was lost.
     {
@@ -368,7 +368,7 @@ fn changing_a_column_from_optional_to_required_is_unexecutable(api: TestApi) {
 
     // The schema should not change because the migration should not run if there are warnings
     // and the force flag isn't passed.
-    api.assert_schema().assert_equals(&original_database_schema).unwrap();
+    api.assert_schema().assert_equals(&original_database_schema);
 
     // Check that no data was lost.
     {
@@ -401,8 +401,8 @@ fn dropping_a_table_referenced_by_foreign_keys_must_work(api: TestApi) {
     api.schema_push(dm1).send_sync().assert_green_bang();
 
     api.assert_schema()
-        .assert_table_bang("Category", |table| table.assert_columns_count(2))
-        .assert_table_bang("Recipe", |table| {
+        .assert_table("Category", |table| table.assert_columns_count(2))
+        .assert_table("Recipe", |table| {
             table.assert_fk_on_columns(&["categoryId"], |fk| fk.assert_references("Category", &["id"]))
         });
 
@@ -428,7 +428,7 @@ fn dropping_a_table_referenced_by_foreign_keys_must_work(api: TestApi) {
 
     api.assert_schema()
         .assert_tables_count(1)
-        .assert_table_bang("Recipe", |table| table.assert_foreign_keys_count(0));
+        .assert_table("Recipe", |table| table.assert_foreign_keys_count(0));
 }
 
 #[test_connector]
@@ -506,8 +506,8 @@ fn altering_the_type_of_a_column_in_an_empty_table_should_not_warn(api: TestApi)
 
     api.schema_push(dm2).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("User", |table| {
-        table.assert_column("dogs", |col| col.assert_type_is_string()?.assert_is_required())
+    api.assert_schema().assert_table("User", |table| {
+        table.assert_column("dogs", |col| col.assert_type_is_string().assert_is_required())
     });
 }
 
@@ -533,8 +533,8 @@ fn making_a_column_required_in_an_empty_table_should_not_warn(api: TestApi) {
 
     api.schema_push(dm2).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("User", |table| {
-        table.assert_column("dogs", |col| col.assert_type_is_int()?.assert_is_required())
+    api.assert_schema().assert_table("User", |table| {
+        table.assert_column("dogs", |col| col.assert_type_is_int().assert_is_required())
     });
 }
 
@@ -630,17 +630,13 @@ fn enum_variants_can_be_added_without_data_loss(api: TestApi) {
                 .assert_enum(&api.normalize_identifier("Cat_mood"), |enm| {
                     enm.assert_values(&["HAPPY", "HUNGRY", "ABSOLUTELY_FABULOUS"])
                 })
-                .unwrap()
                 .assert_enum(&api.normalize_identifier("Human_mood"), |enm| {
                     enm.assert_values(&["HAPPY", "HUNGRY", "ABSOLUTELY_FABULOUS"])
-                })
-                .unwrap();
+                });
         } else {
-            api.assert_schema()
-                .assert_enum("Mood", |enm| {
-                    enm.assert_values(&["HAPPY", "HUNGRY", "ABSOLUTELY_FABULOUS"])
-                })
-                .unwrap();
+            api.assert_schema().assert_enum("Mood", |enm| {
+                enm.assert_values(&["HAPPY", "HUNGRY", "ABSOLUTELY_FABULOUS"])
+            });
         };
     }
 }
@@ -744,15 +740,12 @@ fn enum_variants_can_be_dropped_without_data_loss(api: TestApi) {
                 .assert_enum(&api.normalize_identifier("Cat_mood"), |enm| {
                     enm.assert_values(&["HAPPY", "HUNGRY"])
                 })
-                .unwrap()
                 .assert_enum(&api.normalize_identifier("Human_mood"), |enm| {
                     enm.assert_values(&["HAPPY", "HUNGRY"])
-                })
-                .unwrap();
+                });
         } else {
             api.assert_schema()
-                .assert_enum("Mood", |enm| enm.assert_values(&["HAPPY", "HUNGRY"]))
-                .unwrap();
+                .assert_enum("Mood", |enm| enm.assert_values(&["HAPPY", "HUNGRY"]));
         };
     }
 }
@@ -787,7 +780,7 @@ fn set_default_current_timestamp_on_existing_column_works(api: TestApi) {
         .assert_executable()
         .assert_no_warning();
 
-    api.assert_schema().assert_table_bang("User", |table| {
+    api.assert_schema().assert_table("User", |table| {
         table.assert_column("created_at", |column| column.assert_default(Some(DefaultValue::now())))
     });
 }
@@ -854,7 +847,7 @@ fn primary_key_migrations_do_not_cause_data_loss(api: TestApi) {
         .assert_executable()
         .assert_warnings(&[warn.into()]);
 
-    api.assert_schema().assert_table_bang("Dog", |table| {
+    api.assert_schema().assert_table("Dog", |table| {
         table.assert_pk(|pk| pk.assert_columns(&["name", "passportNumber"]))
     });
 
@@ -933,12 +926,10 @@ fn failing_enum_migrations_should_not_be_partially_applied(api: TestApi) {
 
         if api.is_mysql() {
             api.assert_schema()
-                .assert_enum("Cat_mood", |enm| enm.assert_values(&["HAPPY", "HUNGRY"]))
-                .unwrap();
+                .assert_enum("Cat_mood", |enm| enm.assert_values(&["HAPPY", "HUNGRY"]));
         } else {
             api.assert_schema()
-                .assert_enum("Mood", |enm| enm.assert_values(&["HAPPY", "HUNGRY"]))
-                .unwrap();
+                .assert_enum("Mood", |enm| enm.assert_values(&["HAPPY", "HUNGRY"]));
         };
     }
 }

--- a/migration-engine/migration-engine-tests/tests/existing_data/sql_unexecutable_migrations/added_required_field_to_table.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_data/sql_unexecutable_migrations/added_required_field_to_table.rs
@@ -120,5 +120,5 @@ fn adding_a_required_field_without_default_to_an_existing_table_without_data_wor
     api.schema_push(dm2).send_sync().assert_green_bang();
 
     api.assert_schema()
-        .assert_table_bang("Test", |table| table.assert_has_column("age"));
+        .assert_table("Test", |table| table.assert_has_column("age"));
 }

--- a/migration-engine/migration-engine-tests/tests/existing_data/sql_unexecutable_migrations/made_optional_field_required.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_data/sql_unexecutable_migrations/made_optional_field_required.rs
@@ -38,7 +38,7 @@ fn making_an_optional_field_required_with_data_without_a_default_is_unexecutable
         .assert_unexecutable(&[error]);
 
     api.assert_schema()
-        .assert_table_bang("Test", |table| table.assert_does_not_have_column("Int"));
+        .assert_table("Test", |table| table.assert_does_not_have_column("Int"));
 
     api.dump_table("Test")
         .assert_single_row(|row| row.assert_text_value("id", "abc").assert_text_value("name", "george"));
@@ -77,10 +77,10 @@ fn making_an_optional_field_required_with_data_with_a_default_works(api: TestApi
 
     api.schema_push(dm2).force(true).send_sync();
 
-    api.assert_schema().assert_table_bang("Test", |table| {
+    api.assert_schema().assert_table("Test", |table| {
         table.assert_column("age", |column| {
             column
-                .assert_is_required()?
+                .assert_is_required()
                 .assert_default(Some(DefaultValue::value(84)))
         })
     });
@@ -145,7 +145,7 @@ fn making_an_optional_field_required_with_data_with_a_default_is_unexecutable(ap
         .assert_unexecutable(&[error])
         .assert_no_warning();
 
-    api.assert_schema().assert_equals(&initial_schema).unwrap();
+    api.assert_schema().assert_equals(&initial_schema);
 
     let rows = api.dump_table("Test");
 
@@ -183,7 +183,7 @@ fn making_an_optional_field_required_on_an_empty_table_works(api: TestApi) {
     api.schema_push(dm2).send_sync().assert_green_bang();
 
     api.assert_schema()
-        .assert_table_bang("Test", |table| table.assert_does_not_have_column("Int"));
+        .assert_table("Test", |table| table.assert_does_not_have_column("Int"));
 
     assert!(api.dump_table("Test").is_empty());
 }

--- a/migration-engine/migration-engine-tests/tests/existing_data/sqlite_existing_data_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_data/sqlite_existing_data_tests.rs
@@ -29,10 +29,10 @@ fn changing_a_column_from_optional_to_required_with_a_default_is_safe(api: TestA
 
     api.schema_push(dm2).force(true).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("Test", |table| {
+    api.assert_schema().assert_table("Test", |table| {
         table.assert_column("age", |column| {
             column
-                .assert_default(Some(DefaultValue::value(30)))?
+                .assert_default(Some(DefaultValue::value(30)))
                 .assert_is_required()
         })
     });

--- a/migration-engine/migration-engine-tests/tests/existing_data/type_migration_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_data/type_migration_tests.rs
@@ -41,8 +41,8 @@ fn altering_the_type_of_a_column_in_a_non_empty_table_warns(api: TestApi) {
     api.dump_table("User")
         .assert_single_row(|row| row.assert_int_value("dogs", 7));
 
-    api.assert_schema().assert_table_bang("User", |table| {
-        table.assert_column("dogs", |col| col.assert_type_is_bigint()?.assert_is_required())
+    api.assert_schema().assert_table("User", |table| {
+        table.assert_column("dogs", |col| col.assert_type_is_bigint().assert_is_required())
     });
 }
 
@@ -74,7 +74,7 @@ fn migrating_a_required_column_from_int_to_string_should_cast(api: TestApi) {
 
     api.schema_push(dm2).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("Test", |table| {
+    api.assert_schema().assert_table("Test", |table| {
         table.assert_column("serialNumber", |col| col.assert_type_is_string())
     });
 
@@ -124,7 +124,7 @@ fn changing_a_string_array_column_to_scalar_is_fine(api: TestApi) {
 
     api.schema_push(&dm2).force(true).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("Film", |table| {
+    api.assert_schema().assert_table("Film", |table| {
         table.assert_column("mainProtagonist", |column| column.assert_is_required())
     });
 
@@ -176,7 +176,7 @@ fn changing_an_int_array_column_to_scalar_is_not_possible(api: TestApi) {
         .assert_no_warning()
         .assert_unexecutable(&["Changed the type of `mainProtagonist` on the `Film` table. No cast exists, the column would be dropped and recreated, which cannot be done since the column is required and there is data in the table.".into()]);
 
-    api.assert_schema().assert_table_bang("Film", |table| {
+    api.assert_schema().assert_table("Film", |table| {
         table.assert_column("mainProtagonist", |column| column.assert_is_list())
     });
 

--- a/migration-engine/migration-engine-tests/tests/migrations/defaults.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/defaults.rs
@@ -28,11 +28,9 @@ fn datetime_defaults_work(api: TestApi) {
         DefaultValue::db_generated("'2018-01-27 08:00:00 +00:00'")
     };
 
-    api.assert_schema()
-        .assert_table("Cat", |table| {
-            table.assert_column("birthday", |col| col.assert_default(Some(expected_default)))
-        })
-        .unwrap();
+    api.assert_schema().assert_table("Cat", |table| {
+        table.assert_column("birthday", |col| col.assert_default(Some(expected_default)))
+    });
 }
 
 #[test_connector(tags(Mariadb, Mysql8), exclude(Vitess))]
@@ -45,13 +43,11 @@ fn function_expressions_as_dbgenerated_work(api: TestApi) {
 
     api.schema_push(dm).send_sync().assert_green_bang();
 
-    api.assert_schema()
-        .assert_table("Cat", |table| {
-            table.assert_column("id", |col| {
-                col.assert_default(Some(DefaultValue::db_generated("(left(uuid(),8))")))
-            })
+    api.assert_schema().assert_table("Cat", |table| {
+        table.assert_column("id", |col| {
+            col.assert_default(Some(DefaultValue::db_generated("(left(uuid(),8))")))
         })
-        .unwrap();
+    });
 }
 
 #[test_connector(tags(Postgres))]
@@ -64,13 +60,11 @@ fn default_dbgenerated_with_type_definitions_should_work(api: TestApi) {
 
     api.schema_push(dm).send_sync().assert_green_bang();
 
-    api.assert_schema()
-        .assert_table("A", |table| {
-            table.assert_column("id", |col| {
-                col.assert_default(Some(DefaultValue::db_generated("(now())::text")))
-            })
+    api.assert_schema().assert_table("A", |table| {
+        table.assert_column("id", |col| {
+            col.assert_default(Some(DefaultValue::db_generated("(now())::text")))
         })
-        .unwrap();
+    });
 }
 
 #[test_connector(tags(Postgres))]
@@ -83,13 +77,11 @@ fn default_dbgenerated_should_work(api: TestApi) {
 
     api.schema_push(dm).send_sync().assert_green_bang();
 
-    api.assert_schema()
-        .assert_table("A", |table| {
-            table.assert_column("id", |col| {
-                col.assert_default(Some(DefaultValue::db_generated("now()")))
-            })
+    api.assert_schema().assert_table("A", |table| {
+        table.assert_column("id", |col| {
+            col.assert_default(Some(DefaultValue::db_generated("now()")))
         })
-        .unwrap();
+    });
 }
 
 #[test_connector(tags(Postgres))]
@@ -103,13 +95,11 @@ fn uuid_default(api: TestApi) {
 
     api.schema_push(dm).send_sync().assert_green_bang();
 
-    api.assert_schema()
-        .assert_table("A", |table| {
-            table.assert_column("uuid", |col| {
-                col.assert_default(Some(DefaultValue::value("00000000-0000-0000-0016-000000000004")))
-            })
+    api.assert_schema().assert_table("A", |table| {
+        table.assert_column("uuid", |col| {
+            col.assert_default(Some(DefaultValue::value("00000000-0000-0000-0016-000000000004")))
         })
-        .unwrap();
+    });
 }
 
 #[test_connector]
@@ -199,13 +189,11 @@ fn column_defaults_must_be_migrated(api: TestApi) {
 
     api.schema_push(dm1).send_sync().assert_green_bang();
 
-    api.assert_schema()
-        .assert_table("Fruit", |table| {
-            table.assert_column("name", |col| {
-                col.assert_default(Some(DefaultValue::value(PrismaValue::String("banana".to_string()))))
-            })
+    api.assert_schema().assert_table("Fruit", |table| {
+        table.assert_column("name", |col| {
+            col.assert_default(Some(DefaultValue::value(PrismaValue::String("banana".to_string()))))
         })
-        .unwrap();
+    });
 
     let dm2 = r#"
         model Fruit {
@@ -216,11 +204,9 @@ fn column_defaults_must_be_migrated(api: TestApi) {
 
     api.schema_push(dm2).send_sync().assert_green_bang();
 
-    api.assert_schema()
-        .assert_table("Fruit", |table| {
-            table.assert_column("name", |col| col.assert_default(Some(DefaultValue::value("mango"))))
-        })
-        .unwrap();
+    api.assert_schema().assert_table("Fruit", |table| {
+        table.assert_column("name", |col| col.assert_default(Some(DefaultValue::value("mango"))))
+    });
 }
 
 #[test_connector]
@@ -240,8 +226,7 @@ fn escaped_string_defaults_are_not_arbitrarily_migrated(api: TestApi) {
     api.schema_push(dm1)
         .migration_id(Some("first migration"))
         .send_sync()
-        .assert_green()
-        .unwrap();
+        .assert_green_bang();
 
     let insert = Insert::single_into(api.render_table_name("Fruit"))
         .value("id", "apple-id")
@@ -254,8 +239,7 @@ fn escaped_string_defaults_are_not_arbitrarily_migrated(api: TestApi) {
     api.schema_push(dm1)
         .migration_id(Some("second migration"))
         .send_sync()
-        .assert_green()
-        .unwrap()
+        .assert_green_bang()
         .assert_no_steps();
 
     let sql_schema = api.assert_schema().into_schema();

--- a/migration-engine/migration-engine-tests/tests/migrations/enums.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/enums.rs
@@ -29,22 +29,20 @@ fn adding_an_enum_field_must_work(api: TestApi) {
 
     api.schema_push(dm).send_sync().assert_green_bang();
 
-    api.assert_schema()
-        .assert_table("Test", |table| {
-            table.assert_columns_count(2)?.assert_column("enum", |c| {
-                if api.is_postgres() {
-                    c.assert_is_required()?
-                        .assert_type_family(ColumnTypeFamily::Enum("MyEnum".to_owned()))
-                } else if api.is_mysql() {
-                    c.assert_is_required()?.assert_type_family(ColumnTypeFamily::Enum(
-                        api.normalize_identifier("Test_enum").into_owned(),
-                    ))
-                } else {
-                    c.assert_is_required()?.assert_type_is_string()
-                }
-            })
+    api.assert_schema().assert_table("Test", |table| {
+        table.assert_columns_count(2).assert_column("enum", |c| {
+            if api.is_postgres() {
+                c.assert_is_required()
+                    .assert_type_family(ColumnTypeFamily::Enum("MyEnum".to_owned()))
+            } else if api.is_mysql() {
+                c.assert_is_required().assert_type_family(ColumnTypeFamily::Enum(
+                    api.normalize_identifier("Test_enum").into_owned(),
+                ))
+            } else {
+                c.assert_is_required().assert_type_is_string()
+            }
         })
-        .unwrap();
+    });
 
     // Check that the migration is idempotent.
     api.schema_push(dm).send_sync().assert_no_steps();
@@ -66,21 +64,19 @@ fn adding_an_enum_field_must_work_with_native_types_off(api: TestApi) {
 
     api.schema_push(dm).send_sync().assert_green_bang();
 
-    api.assert_schema()
-        .assert_table("Test", |table| {
-            table.assert_columns_count(2)?.assert_column("enum", |c| {
-                if api.is_postgres() {
-                    c.assert_is_required()?
-                        .assert_type_family(ColumnTypeFamily::Enum("MyEnum".to_owned()))
-                } else if api.is_mysql() {
-                    c.assert_is_required()?
-                        .assert_type_family(ColumnTypeFamily::Enum(api.normalize_identifier("Test_enum").into()))
-                } else {
-                    c.assert_is_required()?.assert_type_is_string()
-                }
-            })
+    api.assert_schema().assert_table("Test", |table| {
+        table.assert_columns_count(2).assert_column("enum", |c| {
+            if api.is_postgres() {
+                c.assert_is_required()
+                    .assert_type_family(ColumnTypeFamily::Enum("MyEnum".to_owned()))
+            } else if api.is_mysql() {
+                c.assert_is_required()
+                    .assert_type_family(ColumnTypeFamily::Enum(api.normalize_identifier("Test_enum").into()))
+            } else {
+                c.assert_is_required().assert_type_is_string()
+            }
         })
-        .unwrap();
+    });
 
     // Check that the migration is idempotent.
     api.schema_push(dm).send_sync().assert_no_steps();
@@ -99,7 +95,7 @@ fn an_enum_can_be_turned_into_a_model(api: TestApi) {
     };
 
     #[allow(clippy::redundant_closure)]
-    api.assert_schema().assert_enum(enum_name, |enm| Ok(enm)).unwrap();
+    api.assert_schema().assert_enum(enum_name, |enm| enm);
 
     let dm2 = r#"
         model Cat {
@@ -119,14 +115,9 @@ fn an_enum_can_be_turned_into_a_model(api: TestApi) {
     api.schema_push(dm2).send_sync().assert_green_bang();
 
     api.assert_schema()
-        .assert_table("Cat", |table| {
-            table.assert_columns_count(2)?.assert_column("moodId", Ok)
-        })
-        .unwrap()
+        .assert_table("Cat", |table| table.assert_columns_count(2).assert_has_column("moodId"))
         .assert_table("CatMood", |table| table.assert_column_count(3))
-        .unwrap()
-        .assert_has_no_enum("CatMood")
-        .unwrap();
+        .assert_has_no_enum("CatMood");
 }
 
 #[test_connector(capabilities(Enums))]
@@ -153,8 +144,7 @@ fn variants_can_be_added_to_an_existing_enum(api: TestApi) {
     };
 
     api.assert_schema()
-        .assert_enum(enum_name, |enm| enm.assert_values(&["HUNGRY"]))
-        .unwrap();
+        .assert_enum(enum_name, |enm| enm.assert_values(&["HUNGRY"]));
 
     let dm2 = r#"
         model Cat {
@@ -172,8 +162,7 @@ fn variants_can_be_added_to_an_existing_enum(api: TestApi) {
     api.schema_push(dm2).send_sync().assert_green_bang();
 
     api.assert_schema()
-        .assert_enum(enum_name, |enm| enm.assert_values(&["HUNGRY", "HAPPY", "JOYJOY"]))
-        .unwrap();
+        .assert_enum(enum_name, |enm| enm.assert_values(&["HUNGRY", "HAPPY", "JOYJOY"]));
 }
 
 #[test_connector(capabilities(Enums))]
@@ -201,8 +190,7 @@ fn variants_can_be_removed_from_an_existing_enum(api: TestApi) {
     };
 
     api.assert_schema()
-        .assert_enum(enum_name, |enm| enm.assert_values(&["HAPPY", "HUNGRY"]))
-        .unwrap();
+        .assert_enum(enum_name, |enm| enm.assert_values(&["HAPPY", "HUNGRY"]));
 
     let dm2 = r#"
         model Cat {
@@ -228,8 +216,7 @@ fn variants_can_be_removed_from_an_existing_enum(api: TestApi) {
         .assert_executable();
 
     api.assert_schema()
-        .assert_enum(enum_name, |enm| enm.assert_values(&["HUNGRY"]))
-        .unwrap();
+        .assert_enum(enum_name, |enm| enm.assert_values(&["HUNGRY"]));
 }
 
 #[test_connector(capabilities(Enums))]
@@ -271,11 +258,9 @@ fn enum_field_to_string_field_works(api: TestApi) {
 
     api.schema_push(dm1).send_sync().assert_green_bang();
 
-    api.assert_schema()
-        .assert_table("Cat", |table| {
-            table.assert_column("mood", |col| col.assert_type_is_enum())
-        })
-        .unwrap();
+    api.assert_schema().assert_table("Cat", |table| {
+        table.assert_column("mood", |col| col.assert_type_is_enum())
+    });
 
     api.insert("Cat").value("id", 1).value("mood", "HAPPY").result_raw();
 
@@ -288,11 +273,9 @@ fn enum_field_to_string_field_works(api: TestApi) {
 
     api.schema_push(dm2).force(true).send_sync().assert_executable();
 
-    api.assert_schema()
-        .assert_table("Cat", |table| {
-            table.assert_column("mood", |col| col.assert_type_is_string())
-        })
-        .unwrap();
+    api.assert_schema().assert_table("Cat", |table| {
+        table.assert_column("mood", |col| col.assert_type_is_string())
+    });
 }
 
 #[test_connector(capabilities(Enums))]
@@ -306,11 +289,9 @@ fn string_field_to_enum_field_works(api: TestApi) {
 
     api.schema_push(dm1).send_sync().assert_green_bang();
 
-    api.assert_schema()
-        .assert_table("Cat", |table| {
-            table.assert_column("mood", |col| col.assert_type_is_string())
-        })
-        .unwrap();
+    api.assert_schema().assert_table("Cat", |table| {
+        table.assert_column("mood", |col| col.assert_type_is_string())
+    });
 
     api.insert("Cat").value("id", 1).value("mood", "HAPPY").result_raw();
 
@@ -340,11 +321,9 @@ fn string_field_to_enum_field_works(api: TestApi) {
         .assert_executable()
         .assert_warnings(&[warn.into()]);
 
-    api.assert_schema()
-        .assert_table("Cat", |table| {
-            table.assert_column("mood", |col| col.assert_type_is_enum())
-        })
-        .unwrap();
+    api.assert_schema().assert_table("Cat", |table| {
+        table.assert_column("mood", |col| col.assert_type_is_enum())
+    });
 }
 
 #[test_connector(capabilities(Enums))]
@@ -488,11 +467,9 @@ fn changing_all_values_of_enums_used_in_defaults_works(api: TestApi) {
 
     api.schema_push(dm2).force(true).send_sync();
 
-    api.assert_schema()
-        .assert_table("Cat", |table| {
-            table.assert_column("eveningMood", |col| Ok(col.assert_enum_default("MEOWMEOW")))
-        })
-        .unwrap();
+    api.assert_schema().assert_table("Cat", |table| {
+        table.assert_column("eveningMood", |col| col.assert_enum_default("MEOWMEOW"))
+    });
 }
 
 #[test_connector(tags(Postgres))]

--- a/migration-engine/migration-engine-tests/tests/migrations/foreign_keys.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/foreign_keys.rs
@@ -16,12 +16,10 @@ fn foreign_keys_of_inline_one_to_one_relations_have_a_unique_constraint(api: Tes
     "#;
 
     api.schema_push(dm).send_sync().assert_green_bang();
-    api.assert_schema().assert_table_bang("Box", |t| {
-        t.assert_indexes_count(1)
-            .unwrap()
-            .assert_index_on_columns(&["cat_id"], |idx| {
-                idx.assert_is_unique().unwrap().assert_name("Box_cat_id_unique")
-            })
+    api.assert_schema().assert_table("Box", |t| {
+        t.assert_indexes_count(1).assert_index_on_columns(&["cat_id"], |idx| {
+            idx.assert_is_unique().assert_name("Box_cat_id_unique")
+        })
     });
 }
 
@@ -42,8 +40,7 @@ fn foreign_keys_are_added_on_existing_tables(api: TestApi) -> TestResult {
 
     api.assert_schema()
         // There should be no foreign keys yet.
-        .assert_table("Account", |table| table.assert_foreign_keys_count(0))
-        .unwrap();
+        .assert_table("Account", |table| table.assert_foreign_keys_count(0));
 
     let dm2 = r#"
         model User {
@@ -61,10 +58,9 @@ fn foreign_keys_are_added_on_existing_tables(api: TestApi) -> TestResult {
 
     api.schema_push(dm2).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("Account", |table| {
+    api.assert_schema().assert_table("Account", |table| {
         table
             .assert_foreign_keys_count(1)
-            .unwrap()
             .assert_fk_on_columns(&["user_email"], |fk| fk.assert_references("User", &["email"]))
     });
 }
@@ -87,8 +83,7 @@ fn foreign_keys_can_be_added_on_existing_columns(api: TestApi) -> TestResult {
 
     api.assert_schema()
         // There should be no foreign keys yet.
-        .assert_table("Account", |table| table.assert_foreign_keys_count(0))
-        .unwrap();
+        .assert_table("Account", |table| table.assert_foreign_keys_count(0));
 
     let dm2 = r#"
         model User {
@@ -106,10 +101,9 @@ fn foreign_keys_can_be_added_on_existing_columns(api: TestApi) -> TestResult {
 
     api.schema_push(dm2).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("Account", |table| {
+    api.assert_schema().assert_table("Account", |table| {
         table
             .assert_foreign_keys_count(1)
-            .unwrap()
             .assert_fk_on_columns(&["user_email"], |fk| fk.assert_references("User", &["email"]))
     });
 }
@@ -132,14 +126,11 @@ fn foreign_keys_can_be_dropped_on_existing_columns(api: TestApi) {
 
     api.schema_push(dm1).send_sync().assert_green_bang();
 
-    api.assert_schema()
-        .assert_table("Account", |table| {
-            table
-                .assert_foreign_keys_count(1)
-                .unwrap()
-                .assert_fk_on_columns(&["user_email"], |fk| fk.assert_references("User", &["email"]))
-        })
-        .unwrap();
+    api.assert_schema().assert_table("Account", |table| {
+        table
+            .assert_foreign_keys_count(1)
+            .assert_fk_on_columns(&["user_email"], |fk| fk.assert_references("User", &["email"]))
+    });
 
     let dm2 = r#"
         model User {
@@ -156,7 +147,7 @@ fn foreign_keys_can_be_dropped_on_existing_columns(api: TestApi) {
     api.schema_push(dm2).send_sync().assert_green_bang();
 
     api.assert_schema()
-        .assert_table_bang("Account", |table| table.assert_foreign_keys_count(0));
+        .assert_table("Account", |table| table.assert_foreign_keys_count(0));
 }
 
 #[test_connector]
@@ -173,13 +164,11 @@ fn changing_a_scalar_field_to_a_relation_field_must_work(api: TestApi) {
     "#;
 
     api.schema_push(dm1).send_sync().assert_green_bang();
-    api.assert_schema()
-        .assert_table("A", |t| {
-            t.assert_column("b", |c| c.assert_type_is_string())?
-                .assert_foreign_keys_count(0)?
-                .assert_indexes_count(0)
-        })
-        .unwrap();
+    api.assert_schema().assert_table("A", |t| {
+        t.assert_column("b", |c| c.assert_type_is_string())
+            .assert_foreign_keys_count(0)
+            .assert_indexes_count(0)
+    });
 
     let dm2 = r#"
         model A {
@@ -200,9 +189,9 @@ fn changing_a_scalar_field_to_a_relation_field_must_work(api: TestApi) {
         .assert_executable()
         .assert_has_executed_steps();
 
-    api.assert_schema().assert_table_bang("A", |table| {
+    api.assert_schema().assert_table("A", |table| {
         table
-            .assert_column("b", |col| col.assert_type_is_int())?
+            .assert_column("b", |col| col.assert_type_is_int())
             .assert_fk_on_columns(&["b"], |fk| fk.assert_references("B", &["id"]))
     });
 }
@@ -223,18 +212,14 @@ fn changing_a_relation_field_to_a_scalar_field_must_work(api: TestApi) {
 
     api.schema_push(dm1).send_sync().assert_green_bang();
 
-    api.assert_schema()
-        .assert_table("A", |table| {
-            table
-                .assert_column("b", |col| col.assert_type_is_int())
-                .unwrap()
-                .assert_foreign_keys_count(1)
-                .unwrap()
-                .assert_fk_on_columns(&["b"], |fk| {
-                    fk.assert_references("B", &["id"])?.assert_cascades_on_delete()
-                })
-        })
-        .unwrap();
+    api.assert_schema().assert_table("A", |table| {
+        table
+            .assert_column("b", |col| col.assert_type_is_int())
+            .assert_foreign_keys_count(1)
+            .assert_fk_on_columns(&["b"], |fk| {
+                fk.assert_references("B", &["id"]).assert_cascades_on_delete()
+            })
+    });
 
     let dm2 = r#"
         model A {
@@ -248,13 +233,11 @@ fn changing_a_relation_field_to_a_scalar_field_must_work(api: TestApi) {
 
     api.schema_push(dm2).send_sync().assert_green_bang();
 
-    api.assert_schema()
-        .assert_table("A", |table| {
-            table
-                .assert_column("b", |col| col.assert_type_is_string())?
-                .assert_foreign_keys_count(0)
-        })
-        .unwrap();
+    api.assert_schema().assert_table("A", |table| {
+        table
+            .assert_column("b", |col| col.assert_type_is_string())
+            .assert_foreign_keys_count(0)
+    });
 }
 
 #[test_connector]

--- a/migration-engine/migration-engine-tests/tests/migrations/indexes.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/indexes.rs
@@ -24,10 +24,10 @@ fn index_on_compound_relation_fields_must_work(api: TestApi) {
 
     api.schema_push(dm).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("Post", |table| {
+    api.assert_schema().assert_table("Post", |table| {
         table
-            .assert_has_column("authorName")?
-            .assert_has_column("authorEmail")?
+            .assert_has_column("authorName")
+            .assert_has_column("authorEmail")
             .assert_index_on_columns(&["authorEmail", "authorName"], |idx| idx.assert_name("testIndex"))
     });
 }
@@ -46,11 +46,11 @@ fn index_settings_must_be_migrated(api: TestApi) {
 
     api.schema_push(dm).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("Test", |table| {
+    api.assert_schema().assert_table("Test", |table| {
         table
-            .assert_indexes_count(1)?
+            .assert_indexes_count(1)
             .assert_index_on_columns(&["name", "followersCount"], |idx| {
-                idx.assert_is_not_unique()?.assert_name("nameAndFollowers")
+                idx.assert_is_not_unique().assert_name("nameAndFollowers")
             })
     });
 
@@ -69,11 +69,11 @@ fn index_settings_must_be_migrated(api: TestApi) {
         .send_sync()
         .assert_warnings(&["A unique constraint covering the columns `[name,followersCount]` on the table `Test` will be added. If there are existing duplicate values, this will fail.".into()]);
 
-    api.assert_schema().assert_table_bang("Test", |table| {
+    api.assert_schema().assert_table("Test", |table| {
         table
-            .assert_indexes_count(1)?
+            .assert_indexes_count(1)
             .assert_index_on_columns(&["name", "followersCount"], |idx| {
-                idx.assert_is_unique()?.assert_name("nameAndFollowers")
+                idx.assert_is_unique().assert_name("nameAndFollowers")
             })
     });
 }
@@ -99,7 +99,7 @@ fn unique_directive_on_required_one_to_one_relation_creates_one_index(api: TestA
     api.schema_push(dm).send_sync().assert_green_bang();
 
     api.assert_schema()
-        .assert_table_bang("Cat", |table| table.assert_indexes_count(1));
+        .assert_table("Cat", |table| table.assert_indexes_count(1));
 }
 
 // TODO: Enable SQL Server when cascading rules are in PSL.
@@ -118,13 +118,13 @@ fn one_to_many_self_relations_do_not_create_a_unique_index(api: TestApi) {
 
     if api.is_mysql() {
         // MySQL creates an index for the FK.
-        api.assert_schema().assert_table_bang("Location", |t| {
-            t.assert_indexes_count(1)?
+        api.assert_schema().assert_table("Location", |t| {
+            t.assert_indexes_count(1)
                 .assert_index_on_columns(&["parent"], |idx| idx.assert_is_not_unique())
         });
     } else {
         api.assert_schema()
-            .assert_table_bang("Location", |t| t.assert_indexes_count(0));
+            .assert_table("Location", |t| t.assert_indexes_count(0));
     }
 }
 
@@ -163,7 +163,7 @@ fn model_with_multiple_indexes_works(api: TestApi) {
 
     api.schema_push(dm).send_sync().assert_green_bang();
     api.assert_schema()
-        .assert_table_bang("Like", |table| table.assert_indexes_count(3));
+        .assert_table("Like", |table| table.assert_indexes_count(3));
 }
 
 #[test_connector]
@@ -180,7 +180,7 @@ fn removing_multi_field_unique_index_must_work(api: TestApi) {
 
     api.schema_push(dm1).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("A", |table| {
+    api.assert_schema().assert_table("A", |table| {
         table.assert_index_on_columns(&["field", "secondField"], |idx| idx.assert_is_unique())
     });
 
@@ -195,7 +195,7 @@ fn removing_multi_field_unique_index_must_work(api: TestApi) {
     api.schema_push(dm2).send_sync().assert_green_bang();
 
     api.assert_schema()
-        .assert_table_bang("A", |table| table.assert_indexes_count(0));
+        .assert_table("A", |table| table.assert_indexes_count(0));
 }
 
 #[test_connector]
@@ -213,13 +213,13 @@ fn index_renaming_must_work(api: TestApi) {
 
     api.schema_push(dm1).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("A", |table| {
+    api.assert_schema().assert_table("A", |table| {
         table
             .assert_index_on_columns(&["field", "secondField"], |idx| {
-                idx.assert_is_unique()?.assert_name("customName")
-            })?
+                idx.assert_is_unique().assert_name("customName")
+            })
             .assert_index_on_columns(&["secondField", "field"], |idx| {
-                idx.assert_is_not_unique()?.assert_name("customNameNonUnique")
+                idx.assert_is_not_unique().assert_name("customNameNonUnique")
             })
     });
 
@@ -236,14 +236,14 @@ fn index_renaming_must_work(api: TestApi) {
 
     api.schema_push(dm2).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("A", |table| {
+    api.assert_schema().assert_table("A", |table| {
         table
-            .assert_indexes_count(2)?
+            .assert_indexes_count(2)
             .assert_index_on_columns(&["field", "secondField"], |idx| {
-                idx.assert_is_unique()?.assert_name("customNameA")
-            })?
+                idx.assert_is_unique().assert_name("customNameA")
+            })
             .assert_index_on_columns(&["secondField", "field"], |idx| {
-                idx.assert_is_not_unique()?.assert_name("customNameNonUniqueA")
+                idx.assert_is_not_unique().assert_name("customNameNonUniqueA")
             })
     });
 }
@@ -261,7 +261,7 @@ fn index_renaming_must_work_when_renaming_to_default(api: TestApi) {
     "#;
 
     api.schema_push(dm1).send_sync().assert_green_bang();
-    api.assert_schema().assert_table_bang("A", |t| {
+    api.assert_schema().assert_table("A", |t| {
         t.assert_index_on_columns(&["field", "secondField"], |idx| idx.assert_is_unique())
     });
 
@@ -276,9 +276,9 @@ fn index_renaming_must_work_when_renaming_to_default(api: TestApi) {
     "#;
 
     api.schema_push(dm2).send_sync();
-    api.assert_schema().assert_table_bang("A", |t| {
+    api.assert_schema().assert_table("A", |t| {
         t.assert_index_on_columns(&["field", "secondField"], |idx| {
-            idx.assert_is_unique()?.assert_name("A.field_secondField_unique")
+            idx.assert_is_unique().assert_name("A.field_secondField_unique")
         })
     });
 }
@@ -297,9 +297,9 @@ fn index_renaming_must_work_when_renaming_to_custom(api: TestApi) {
 
     api.schema_push(dm1).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("A", |table| {
+    api.assert_schema().assert_table("A", |table| {
         table
-            .assert_indexes_count(1)?
+            .assert_indexes_count(1)
             .assert_index_on_columns(&["field", "secondField"], |idx| idx.assert_is_unique())
     });
 
@@ -315,11 +315,11 @@ fn index_renaming_must_work_when_renaming_to_custom(api: TestApi) {
 
     api.schema_push(dm2).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("A", |table| {
+    api.assert_schema().assert_table("A", |table| {
         table
-            .assert_indexes_count(1)?
+            .assert_indexes_count(1)
             .assert_index_on_columns(&["field", "secondField"], |idx| {
-                idx.assert_name("somethingCustom")?.assert_is_unique()
+                idx.assert_name("somethingCustom").assert_is_unique()
             })
     });
 }
@@ -337,7 +337,7 @@ fn index_updates_with_rename_must_work(api: TestApi) {
     "#;
 
     api.schema_push(dm1).send_sync().assert_green_bang();
-    api.assert_schema().assert_table_bang("A", |t| {
+    api.assert_schema().assert_table("A", |t| {
         t.assert_index_on_columns(&["field", "secondField"], |idx| idx.assert_is_unique())
     });
 
@@ -353,8 +353,9 @@ fn index_updates_with_rename_must_work(api: TestApi) {
 
     api.schema_push(dm2).force(true).send_sync().assert_executable();
 
-    api.assert_schema().assert_table_bang("A", |t| {
-        t.assert_indexes_count(1)?.assert_index_on_columns(&["field", "id"], Ok)
+    api.assert_schema().assert_table("A", |t| {
+        t.assert_indexes_count(1)
+            .assert_index_on_columns(&["field", "id"], |idx| idx)
     });
 }
 
@@ -371,9 +372,9 @@ fn dropping_a_model_with_a_multi_field_unique_index_must_work(api: TestApi) {
     "#;
 
     api.schema_push(dm1).send_sync().assert_green_bang();
-    api.assert_schema().assert_table_bang("A", |t| {
+    api.assert_schema().assert_table("A", |t| {
         t.assert_index_on_columns(&["field", "secondField"], |idx| {
-            idx.assert_name("customName")?.assert_is_unique()
+            idx.assert_name("customName").assert_is_unique()
         })
     });
 
@@ -395,25 +396,24 @@ fn indexes_with_an_automatically_truncated_name_are_idempotent(api: TestApi) {
 
     api.schema_push(dm).send_sync().assert_green_bang();
 
-    api.assert_schema()
-        .assert_table_bang("TestModelWithALongName", |table| {
-            table.assert_index_on_columns(
-                &[
-                    "looooooooooooongfield",
-                    "evenLongerFieldNameWth",
-                    "omgWhatEvenIsThatLongFieldName",
-                ],
-                |idx| {
-                    idx.assert_name(if api.is_mysql() {
-                        // The size limit of identifiers is 64 bytes on MySQL
-                        // and 63 on Postgres.
-                        "TestModelWithALongName.looooooooooooongfield_evenLongerFieldName"
-                    } else {
-                        "TestModelWithALongName.looooooooooooongfield_evenLongerFieldNam"
-                    })
-                },
-            )
-        });
+    api.assert_schema().assert_table("TestModelWithALongName", |table| {
+        table.assert_index_on_columns(
+            &[
+                "looooooooooooongfield",
+                "evenLongerFieldNameWth",
+                "omgWhatEvenIsThatLongFieldName",
+            ],
+            |idx| {
+                idx.assert_name(if api.is_mysql() {
+                    // The size limit of identifiers is 64 bytes on MySQL
+                    // and 63 on Postgres.
+                    "TestModelWithALongName.looooooooooooongfield_evenLongerFieldName"
+                } else {
+                    "TestModelWithALongName.looooooooooooongfield_evenLongerFieldNam"
+                })
+            },
+        )
+    });
 
     api.schema_push(dm).send_sync().assert_green_bang().assert_no_steps();
 }
@@ -444,7 +444,7 @@ fn new_index_with_same_name_as_index_from_dropped_table_works(api: TestApi) {
 
     api.schema_push(dm1).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("Cat", |table| {
+    api.assert_schema().assert_table("Cat", |table| {
         table.assert_column("ownerid", |col| col.assert_is_required())
     });
 
@@ -465,7 +465,7 @@ fn new_index_with_same_name_as_index_from_dropped_table_works(api: TestApi) {
 
     api.schema_push(dm2).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("Owner", |table| {
+    api.assert_schema().assert_table("Owner", |table| {
         table.assert_column("ownerid", |col| col.assert_is_required())
     });
 }
@@ -499,8 +499,8 @@ fn column_type_migrations_should_not_implicitly_drop_indexes(api: TestApi) {
 
     api.apply_migrations(&migrations_directory).send_sync();
 
-    api.assert_schema().assert_table_bang("Cat", |cat| {
-        cat.assert_indexes_count(1)?
+    api.assert_schema().assert_table("Cat", |cat| {
+        cat.assert_indexes_count(1)
             .assert_index_on_columns(&["name"], |idx| idx.assert_is_not_unique())
     });
 }
@@ -536,8 +536,8 @@ fn column_type_migrations_should_not_implicitly_drop_compound_indexes(api: TestA
 
     api.apply_migrations(&migrations_directory).send_sync();
 
-    api.assert_schema().assert_table_bang("Cat", |cat| {
-        cat.assert_indexes_count(1)?
+    api.assert_schema().assert_table("Cat", |cat| {
+        cat.assert_indexes_count(1)
             .assert_index_on_columns(&["name", "age"], |idx| idx.assert_is_not_unique())
     });
 }

--- a/migration-engine/migration-engine-tests/tests/migrations/json.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/json.rs
@@ -18,22 +18,18 @@ fn json_fields_can_be_created(api: TestApi) {
 
     api.schema_push(&dm).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("Test", |table| {
+    api.assert_schema().assert_table("Test", |table| {
         table.assert_column("javaScriptObjectNotation", |c| {
             if api.is_mariadb() {
                 // JSON is an alias for LONGTEXT on MariaDB - https://mariadb.com/kb/en/json-data-type/
-                c.assert_is_required()?.assert_type_family(ColumnTypeFamily::String)
+                c.assert_is_required().assert_type_family(ColumnTypeFamily::String)
             } else {
-                c.assert_is_required()?.assert_type_family(ColumnTypeFamily::Json)
+                c.assert_is_required().assert_type_family(ColumnTypeFamily::Json)
             }
         })
     });
 
-    api.schema_push(&dm)
-        .send_sync()
-        .assert_green()
-        .unwrap()
-        .assert_no_steps();
+    api.schema_push(&dm).send_sync().assert_green_bang().assert_no_steps();
 }
 
 #[test_connector(capabilities(Json), exclude(Mysql56))]
@@ -52,14 +48,14 @@ fn database_level_json_defaults_can_be_defined(api: TestApi) {
 
     api.schema_push(&dm).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("Dog", |table| {
+    api.assert_schema().assert_table("Dog", |table| {
         table.assert_column("favouriteThings", |column| {
             column
                 .assert_type_family(if api.is_mariadb() {
                     ColumnTypeFamily::String
                 } else {
                     ColumnTypeFamily::Json
-                })?
+                })
                 .assert_default(if api.is_postgres() {
                     Some(DefaultValue::value(PrismaValue::Json(
                         "[\"sticks\", \"chimken\", 100, \"dog park\"]".into(),

--- a/migration-engine/migration-engine-tests/tests/migrations/mariadb.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/mariadb.rs
@@ -25,11 +25,9 @@ fn foreign_keys_to_indexes_being_renamed_must_work(api: TestApi) {
         .assert_table("User", |table| {
             table.assert_index_on_columns(&["name"], |idx| idx.assert_name("idxname"))
         })
-        .unwrap()
         .assert_table("Post", |table| {
             table.assert_fk_on_columns(&["author"], |fk| fk.assert_references("User", &["name"]))
-        })
-        .unwrap();
+        });
 
     let insert_post = quaint_ast::Insert::single_into(api.render_table_name("Post"))
         .value("id", "the-post-id")
@@ -64,9 +62,7 @@ fn foreign_keys_to_indexes_being_renamed_must_work(api: TestApi) {
         .assert_table("User", |table| {
             table.assert_index_on_columns(&["name"], |idx| idx.assert_name("idxrenamed"))
         })
-        .unwrap()
         .assert_table("Post", |table| {
             table.assert_fk_on_columns(&["author"], |fk| fk.assert_references("User", &["name"]))
-        })
-        .unwrap();
+        });
 }

--- a/migration-engine/migration-engine-tests/tests/migrations/mark_migration_applied_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/mark_migration_applied_tests.rs
@@ -42,8 +42,7 @@ fn mark_migration_applied_on_an_empty_database_works(api: TestApi) {
 
     api.assert_schema()
         .assert_tables_count(1)
-        .assert_has_table("_prisma_migrations")
-        .unwrap();
+        .assert_has_table("_prisma_migrations");
 }
 
 #[test_connector]
@@ -104,9 +103,7 @@ fn mark_migration_applied_on_a_non_empty_database_works(api: TestApi) {
     api.assert_schema()
         .assert_tables_count(2)
         .assert_has_table("_prisma_migrations")
-        .unwrap()
-        .assert_has_table("Test")
-        .unwrap();
+        .assert_has_table("Test");
 }
 
 #[test_connector]
@@ -169,11 +166,8 @@ fn mark_migration_applied_when_the_migration_is_already_applied_errors(api: Test
     api.assert_schema()
         .assert_tables_count(3)
         .assert_has_table("_prisma_migrations")
-        .unwrap()
         .assert_has_table("Cat")
-        .unwrap()
-        .assert_has_table("Test")
-        .unwrap();
+        .assert_has_table("Test");
 }
 
 #[test_connector]
@@ -251,9 +245,7 @@ fn mark_migration_applied_when_the_migration_is_failed(api: TestApi) {
     api.assert_schema()
         .assert_tables_count(2)
         .assert_has_table("_prisma_migrations")
-        .unwrap()
-        .assert_has_table("Test")
-        .unwrap();
+        .assert_has_table("Test");
 }
 
 #[test_connector]
@@ -292,9 +284,7 @@ fn baselining_should_work(api: TestApi) {
     api.assert_schema()
         .assert_tables_count(2)
         .assert_has_table("_prisma_migrations")
-        .unwrap()
-        .assert_has_table("test")
-        .unwrap();
+        .assert_has_table("test");
 }
 
 #[test_connector]

--- a/migration-engine/migration-engine-tests/tests/migrations/mysql.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/mysql.rs
@@ -25,11 +25,11 @@ fn indexes_on_foreign_key_fields_are_not_created_twice(api: TestApi) {
 
     let sql_schema = api
         .assert_schema()
-        .assert_table_bang("Human", |table| {
+        .assert_table("Human", |table| {
             table
-                .assert_foreign_keys_count(1)?
-                .assert_fk_on_columns(&["catname"], |fk| fk.assert_references("Cat", &["name"]))?
-                .assert_indexes_count(1)?
+                .assert_foreign_keys_count(1)
+                .assert_fk_on_columns(&["catname"], |fk| fk.assert_references("Cat", &["name"]))
+                .assert_indexes_count(1)
                 .assert_index_on_columns(&["catname"], |idx| idx.assert_is_not_unique())
         })
         .into_schema();
@@ -41,7 +41,7 @@ fn indexes_on_foreign_key_fields_are_not_created_twice(api: TestApi) {
         .assert_green_bang()
         .assert_no_steps();
 
-    api.assert_schema().assert_equals(&sql_schema).unwrap();
+    api.assert_schema().assert_equals(&sql_schema);
 }
 
 // We have to test this because one enum on MySQL can map to multiple enums in the database.
@@ -106,9 +106,9 @@ fn arity_of_enum_columns_can_be_changed(api: TestApi) {
 
     api.schema_push(dm1).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("A", |table| {
+    api.assert_schema().assert_table("A", |table| {
         table
-            .assert_column("primaryColor", |col| col.assert_is_required())?
+            .assert_column("primaryColor", |col| col.assert_is_required())
             .assert_column("secondaryColor", |col| col.assert_is_nullable())
     });
 
@@ -128,9 +128,9 @@ fn arity_of_enum_columns_can_be_changed(api: TestApi) {
 
     api.schema_push(dm2).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("A", |table| {
+    api.assert_schema().assert_table("A", |table| {
         table
-            .assert_column("primaryColor", |col| col.assert_is_nullable())?
+            .assert_column("primaryColor", |col| col.assert_is_nullable())
             .assert_column("secondaryColor", |col| col.assert_is_required())
     });
 }
@@ -153,9 +153,9 @@ fn arity_is_preserved_by_alter_enum(api: TestApi) {
 
     api.schema_push(dm1).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("A", |table| {
+    api.assert_schema().assert_table("A", |table| {
         table
-            .assert_column("primaryColor", |col| col.assert_is_required())?
+            .assert_column("primaryColor", |col| col.assert_is_required())
             .assert_column("secondaryColor", |col| col.assert_is_nullable())
     });
 
@@ -179,9 +179,9 @@ fn arity_is_preserved_by_alter_enum(api: TestApi) {
         .assert_executable()
         .assert_has_executed_steps();
 
-    api.assert_schema().assert_table_bang("A", |table| {
+    api.assert_schema().assert_table("A", |table| {
         table
-            .assert_column("primaryColor", |col| col.assert_is_required())?
+            .assert_column("primaryColor", |col| col.assert_is_required())
             .assert_column("secondaryColor", |col| col.assert_is_nullable())
     });
 }
@@ -263,11 +263,11 @@ fn native_type_columns_can_be_created(api: TestApi) {
 
     api.schema_push(&dm).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("A", |table| {
+    api.assert_schema().assert_table("A", |table| {
         types.iter().fold(
-            Ok(table),
+            table,
             |table, (field_name, _prisma_type, _native_type, database_type)| {
-                table.and_then(|table| table.assert_column(field_name, |col| col.assert_full_data_type(database_type)))
+                table.assert_column(field_name, |col| col.assert_full_data_type(database_type))
             },
         )
     });

--- a/migration-engine/migration-engine-tests/tests/migrations/planetscale_mode.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/planetscale_mode.rs
@@ -39,9 +39,9 @@ fn schema_push_planetscale_mode_works(api: TestApi) {
     api.schema_push(dm).send_sync().assert_green_bang().assert_no_steps(); // idempotence
 
     api.assert_schema()
-        .assert_table_bang("Post", |table| table.assert_foreign_keys_count(0))
-        .assert_table_bang("User", |table| table.assert_foreign_keys_count(0))
-        .assert_table_bang("Comment", |table| table.assert_foreign_keys_count(0));
+        .assert_table("Post", |table| table.assert_foreign_keys_count(0))
+        .assert_table("User", |table| table.assert_foreign_keys_count(0))
+        .assert_table("Comment", |table| table.assert_foreign_keys_count(0));
 }
 
 #[test_connector]
@@ -104,7 +104,7 @@ fn create_migration_planetscale_mode_works(api: TestApi) {
     assert!(diagnostic.drift.is_none());
 
     api.assert_schema()
-        .assert_table_bang("Post", |table| table.assert_foreign_keys_count(0))
-        .assert_table_bang("User", |table| table.assert_foreign_keys_count(0))
-        .assert_table_bang("Comment", |table| table.assert_foreign_keys_count(0));
+        .assert_table("Post", |table| table.assert_foreign_keys_count(0))
+        .assert_table("User", |table| table.assert_foreign_keys_count(0))
+        .assert_table("Comment", |table| table.assert_foreign_keys_count(0));
 }

--- a/migration-engine/migration-engine-tests/tests/migrations/postgres.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/postgres.rs
@@ -20,8 +20,7 @@ fn enums_can_be_dropped_on_postgres(api: TestApi) {
 
     api.schema_push(dm1).send_sync().assert_green_bang();
     api.assert_schema()
-        .assert_enum("CatMood", |r#enum| r#enum.assert_values(&["ANGRY", "HUNGRY", "CUDDLY"]))
-        .unwrap();
+        .assert_enum("CatMood", |r#enum| r#enum.assert_values(&["ANGRY", "HUNGRY", "CUDDLY"]));
 
     let dm2 = r#"
         model Cat {
@@ -31,7 +30,7 @@ fn enums_can_be_dropped_on_postgres(api: TestApi) {
     "#;
 
     api.schema_push(dm2).send_sync().assert_green_bang();
-    api.assert_schema().assert_has_no_enum("CatMood").unwrap();
+    api.assert_schema().assert_has_no_enum("CatMood");
 }
 
 #[test_connector(capabilities(ScalarLists))]
@@ -56,11 +55,11 @@ fn adding_a_scalar_list_for_a_model_with_id_type_int_must_work(api: TestApi) {
 
     api.schema_push(dm1).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("A", |table| {
+    api.assert_schema().assert_table("A", |table| {
         table
-            .assert_column("strings", |col| col.assert_is_list()?.assert_type_is_string())?
+            .assert_column("strings", |col| col.assert_is_list().assert_type_is_string())
             .assert_column("enums", |col| {
-                col.assert_type_family(ColumnTypeFamily::Enum("Status".into()))?
+                col.assert_type_family(ColumnTypeFamily::Enum("Status".into()))
                     .assert_is_list()
             })
     });
@@ -78,9 +77,7 @@ fn existing_postgis_tables_must_not_be_migrated(api: TestApi) {
 
     api.assert_schema()
         .assert_has_table("spatial_ref_sys")
-        .unwrap()
-        .assert_has_table("Geometry_columns")
-        .unwrap();
+        .assert_has_table("Geometry_columns");
 
     let schema = "";
 
@@ -91,9 +88,7 @@ fn existing_postgis_tables_must_not_be_migrated(api: TestApi) {
 
     api.assert_schema()
         .assert_has_table("spatial_ref_sys")
-        .unwrap()
-        .assert_has_table("Geometry_columns")
-        .unwrap();
+        .assert_has_table("Geometry_columns");
 }
 
 #[test_connector(tags(Postgres))]
@@ -149,11 +144,11 @@ fn native_type_columns_can_be_created(api: TestApi) {
 
     api.schema_push(&dm).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("A", |table| {
+    api.assert_schema().assert_table("A", |table| {
         types.iter().fold(
-            Ok(table),
+            table,
             |table, (field_name, _prisma_type, _native_type, database_type)| {
-                table.and_then(|table| table.assert_column(field_name, |col| col.assert_full_data_type(database_type)))
+                table.assert_column(field_name, |col| col.assert_full_data_type(database_type))
             },
         )
     });

--- a/migration-engine/migration-engine-tests/tests/migrations/relations.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/relations.rs
@@ -16,16 +16,16 @@ fn adding_a_many_to_many_relation_must_result_in_a_prisma_style_relation_table(a
 
     api.schema_push(dm1).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("_AToB", |table| {
+    api.assert_schema().assert_table("_AToB", |table| {
         table
-            .assert_columns_count(2)?
-            .assert_column("A", |col| col.assert_type_is_int())?
-            .assert_column("B", |col| col.assert_type_is_string())?
+            .assert_columns_count(2)
+            .assert_column("A", |col| col.assert_type_is_int())
+            .assert_column("B", |col| col.assert_type_is_string())
             .assert_fk_on_columns(&["A"], |fk| {
-                fk.assert_references("A", &["id"])?.assert_cascades_on_delete()
-            })?
+                fk.assert_references("A", &["id"]).assert_cascades_on_delete()
+            })
             .assert_fk_on_columns(&["B"], |fk| {
-                fk.assert_references("B", &["id"])?.assert_cascades_on_delete()
+                fk.assert_references("B", &["id"]).assert_cascades_on_delete()
             })
     });
 }
@@ -45,13 +45,13 @@ fn adding_a_many_to_many_relation_with_custom_name_must_work(api: TestApi) {
 
     api.schema_push(dm1).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("_my_relation", |table| {
+    api.assert_schema().assert_table("_my_relation", |table| {
         table
-            .assert_columns_count(2)?
-            .assert_column("A", |col| col.assert_type_is_int())?
-            .assert_column("B", |col| col.assert_type_is_int())?
-            .assert_foreign_keys_count(2)?
-            .assert_fk_on_columns(&["A"], |fk| fk.assert_references("A", &["id"]))?
+            .assert_columns_count(2)
+            .assert_column("A", |col| col.assert_type_is_int())
+            .assert_column("B", |col| col.assert_type_is_int())
+            .assert_foreign_keys_count(2)
+            .assert_fk_on_columns(&["A"], |fk| fk.assert_references("A", &["id"]))
             .assert_fk_on_columns(&["B"], |fk| fk.assert_references("B", &["id"]))
     });
 }
@@ -79,13 +79,13 @@ fn adding_an_inline_relation_must_result_in_a_foreign_key_in_the_model_table(api
     "#;
 
     api.schema_push(dm1).send_sync().assert_green_bang();
-    api.assert_schema().assert_table_bang("A", |t| {
-        t.assert_column("bid", |c| c.assert_type_is_int()?.assert_is_required())?
-            .assert_column("cid", |c| c.assert_type_is_int()?.assert_is_nullable())?
-            .assert_foreign_keys_count(2)?
+    api.assert_schema().assert_table("A", |t| {
+        t.assert_column("bid", |c| c.assert_type_is_int().assert_is_required())
+            .assert_column("cid", |c| c.assert_type_is_int().assert_is_nullable())
+            .assert_foreign_keys_count(2)
             .assert_fk_on_columns(&["bid"], |fk| {
-                fk.assert_references("B", &["id"])?.assert_cascades_on_delete()
-            })?
+                fk.assert_references("B", &["id"]).assert_cascades_on_delete()
+            })
             .assert_fk_on_columns(&["cid"], |fk| fk.assert_references("C", &["id"]))
     });
 }
@@ -106,9 +106,9 @@ fn specifying_a_db_name_for_an_inline_relation_must_work(api: TestApi) {
     "#;
 
     api.schema_push(dm1).send_sync().assert_green_bang();
-    api.assert_schema().assert_table_bang("A", |t| {
-        t.assert_column("b_column", |c| c.assert_type_is_int())?
-            .assert_foreign_keys_count(1)?
+    api.assert_schema().assert_table("A", |t| {
+        t.assert_column("b_column", |c| c.assert_type_is_int())
+            .assert_foreign_keys_count(1)
             .assert_fk_on_columns(&["b_column"], |fk| fk.assert_references("B", &["id"]))
     });
 }
@@ -129,11 +129,11 @@ fn adding_an_inline_relation_to_a_model_with_an_exotic_id_type(api: TestApi) {
     "#;
 
     api.schema_push(dm1).send_sync().assert_green_bang();
-    api.assert_schema().assert_table_bang("A", |t| {
-        t.assert_column("b_id", |c| c.assert_type_is_string())?
-            .assert_foreign_keys_count(1)?
+    api.assert_schema().assert_table("A", |t| {
+        t.assert_column("b_id", |c| c.assert_type_is_string())
+            .assert_foreign_keys_count(1)
             .assert_fk_on_columns(&["b_id"], |fk| {
-                fk.assert_references("B", &["id"])?.assert_cascades_on_delete()
+                fk.assert_references("B", &["id"]).assert_cascades_on_delete()
             })
     });
 }
@@ -156,7 +156,7 @@ fn removing_an_inline_relation_must_work(api: TestApi) {
     api.schema_push(dm1).send_sync().assert_green_bang();
 
     api.assert_schema()
-        .assert_table_bang("A", |table| table.assert_has_column("b_id"));
+        .assert_table("A", |table| table.assert_has_column("b_id"));
 
     let dm2 = r#"
             model A {
@@ -170,10 +170,10 @@ fn removing_an_inline_relation_must_work(api: TestApi) {
 
     api.schema_push(dm2).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("A", |table| {
+    api.assert_schema().assert_table("A", |table| {
         table
-            .assert_foreign_keys_count(0)?
-            .assert_indexes_count(0)?
+            .assert_foreign_keys_count(0)
+            .assert_indexes_count(0)
             .assert_does_not_have_column("b")
     });
 }
@@ -200,10 +200,10 @@ fn compound_foreign_keys_should_work_in_correct_order(api: TestApi) {
 
     api.schema_push(dm1).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("A", |t| {
-        t.assert_foreign_keys_count(1)?
+    api.assert_schema().assert_table("A", |t| {
+        t.assert_foreign_keys_count(1)
             .assert_fk_on_columns(&["a", "b", "d"], |fk| {
-                fk.assert_cascades_on_delete()?
+                fk.assert_cascades_on_delete()
                     .assert_references("B", &["a_id", "b_id", "d_id"])
             })
     });
@@ -225,9 +225,9 @@ fn moving_an_inline_relation_to_the_other_side_must_work(api: TestApi) {
     "#;
 
     api.schema_push(dm1).send_sync().assert_green_bang();
-    api.assert_schema().assert_table_bang("A", |t| {
-        t.assert_foreign_keys_count(1)?.assert_fk_on_columns(&["b_id"], |fk| {
-            fk.assert_cascades_on_delete()?.assert_references("B", &["id"])
+    api.assert_schema().assert_table("A", |t| {
+        t.assert_foreign_keys_count(1).assert_fk_on_columns(&["b_id"], |fk| {
+            fk.assert_cascades_on_delete().assert_references("B", &["id"])
         })
     });
 
@@ -246,14 +246,14 @@ fn moving_an_inline_relation_to_the_other_side_must_work(api: TestApi) {
 
     api.schema_push(dm2).send_sync().assert_green_bang();
     api.assert_schema()
-        .assert_table_bang("B", |table| {
+        .assert_table("B", |table| {
             table
-                .assert_foreign_keys_count(1)?
+                .assert_foreign_keys_count(1)
                 .assert_fk_on_columns(&["a_id"], |fk| {
-                    fk.assert_references("A", &["id"])?.assert_cascades_on_delete()
+                    fk.assert_references("A", &["id"]).assert_cascades_on_delete()
                 })
         })
-        .assert_table_bang("A", |table| table.assert_foreign_keys_count(0)?.assert_indexes_count(0));
+        .assert_table("A", |table| table.assert_foreign_keys_count(0).assert_indexes_count(0));
 }
 
 #[test_connector]
@@ -273,8 +273,8 @@ fn relations_can_reference_arbitrary_unique_fields(api: TestApi) {
     "#;
 
     api.schema_push(dm).send_sync().assert_green_bang();
-    api.assert_schema().assert_table_bang("Account", |t| {
-        t.assert_foreign_keys_count(1)?
+    api.assert_schema().assert_table("Account", |t| {
+        t.assert_foreign_keys_count(1)
             .assert_fk_on_columns(&["uem"], |fk| fk.assert_references("User", &["email"]))
     });
 }
@@ -299,9 +299,9 @@ fn relations_can_reference_arbitrary_unique_fields_with_maps(api: TestApi) {
 
     api.schema_push(dm).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("Account", |table| {
+    api.assert_schema().assert_table("Account", |table| {
         table
-            .assert_foreign_keys_count(1)?
+            .assert_foreign_keys_count(1)
             .assert_fk_on_columns(&["user-id"], |fk| fk.assert_references("users", &["emergency-mail"]))
     });
 }
@@ -328,9 +328,9 @@ fn relations_can_reference_multiple_fields(api: TestApi) {
 
     api.schema_push(dm).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("Account", |table| {
+    api.assert_schema().assert_table("Account", |table| {
         table
-            .assert_foreign_keys_count(1)?
+            .assert_foreign_keys_count(1)
             .assert_fk_on_columns(&["usermail", "userage"], |fk| {
                 fk.assert_references("User", &["email", "age"])
             })
@@ -361,9 +361,9 @@ fn a_relation_with_mappings_on_both_sides_can_reference_multiple_fields(api: Tes
 
     api.schema_push(dm).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("Account", |table| {
+    api.assert_schema().assert_table("Account", |table| {
         table
-            .assert_foreign_keys_count(1)?
+            .assert_foreign_keys_count(1)
             .assert_fk_on_columns(&["emergency-mail-fk-1", "age-fk2"], |fk| {
                 fk.assert_references("users", &["emergency-mail", "birthdays-count"])
             })
@@ -393,9 +393,9 @@ fn relations_with_mappings_on_referenced_side_can_reference_multiple_fields(api:
 
     api.schema_push(dm).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("Account", |table| {
+    api.assert_schema().assert_table("Account", |table| {
         table
-            .assert_foreign_keys_count(1)?
+            .assert_foreign_keys_count(1)
             .assert_fk_on_columns(&["useremail", "userage"], |fk| {
                 fk.assert_references("users", &["emergency-mail", "birthdays-count"])
             })
@@ -425,9 +425,9 @@ fn relations_with_mappings_on_referencing_side_can_reference_multiple_fields(api
 
     api.schema_push(dm).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("Account", |table| {
+    api.assert_schema().assert_table("Account", |table| {
         table
-            .assert_foreign_keys_count(1)?
+            .assert_foreign_keys_count(1)
             .assert_fk_on_columns(&["emergency-mail-fk1", "age-fk2"], |fk| {
                 fk.assert_references("users", &["email", "age"])
             })

--- a/migration-engine/migration-engine-tests/tests/migrations/reset_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/reset_tests.rs
@@ -40,9 +40,7 @@ fn reset_then_apply_with_migrations_directory_works(api: TestApi) {
     api.assert_schema()
         .assert_tables_count(2)
         .assert_has_table("Cat")
-        .unwrap()
-        .assert_has_table("_prisma_migrations")
-        .unwrap();
+        .assert_has_table("_prisma_migrations");
 
     api.insert("Cat").value("id", 1).value("name", "Garfield").result_raw();
 
@@ -55,9 +53,7 @@ fn reset_then_apply_with_migrations_directory_works(api: TestApi) {
     api.assert_schema()
         .assert_tables_count(2)
         .assert_has_table("Cat")
-        .unwrap()
-        .assert_has_table("_prisma_migrations")
-        .unwrap();
+        .assert_has_table("_prisma_migrations");
 }
 
 #[test_connector]
@@ -76,9 +72,7 @@ fn reset_then_diagnostics_with_migrations_directory_works(api: TestApi) {
     api.assert_schema()
         .assert_tables_count(2)
         .assert_has_table("Cat")
-        .unwrap()
-        .assert_has_table("_prisma_migrations")
-        .unwrap();
+        .assert_has_table("_prisma_migrations");
 
     api.insert("Cat").value("id", 1).value("name", "Garfield").result_raw();
 
@@ -93,7 +87,5 @@ fn reset_then_diagnostics_with_migrations_directory_works(api: TestApi) {
     api.assert_schema()
         .assert_tables_count(2)
         .assert_has_table("Cat")
-        .unwrap()
-        .assert_has_table("_prisma_migrations")
-        .unwrap();
+        .assert_has_table("_prisma_migrations");
 }

--- a/migration-engine/migration-engine-tests/tests/migrations/shadow_database_url_configuration.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/shadow_database_url_configuration.rs
@@ -102,8 +102,7 @@ fn shadow_db_url_can_be_configured_on_postgres(api: TestApi) {
             .assert_schema()
             .assert_tables_count(2)
             .assert_has_table("_prisma_migrations")
-            .unwrap()
-            .assert_table_bang("Cat", |table| table.assert_has_column("meowFrequency"));
+            .assert_table("Cat", |table| table.assert_has_column("meowFrequency"));
     }
 }
 

--- a/migration-engine/migration-engine-tests/tests/migrations/soft_resets.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/soft_resets.rs
@@ -68,9 +68,7 @@ fn soft_resets_work_on_postgres(api: TestApi) {
             .assert_schema()
             .assert_tables_count(2)
             .assert_has_table("_prisma_migrations")
-            .unwrap()
-            .assert_has_table("Cat")
-            .unwrap();
+            .assert_has_table("Cat");
 
         engine.reset().send_sync();
         engine.assert_schema().assert_tables_count(0);
@@ -79,14 +77,9 @@ fn soft_resets_work_on_postgres(api: TestApi) {
             .schema_push(dm)
             .send_sync()
             .assert_has_executed_steps()
-            .assert_green()
-            .unwrap();
+            .assert_green_bang();
 
-        engine
-            .assert_schema()
-            .assert_tables_count(1)
-            .assert_has_table("Cat")
-            .unwrap();
+        engine.assert_schema().assert_tables_count(1).assert_has_table("Cat");
 
         engine.reset().send_sync();
         engine.assert_schema().assert_tables_count(0);
@@ -198,11 +191,8 @@ fn soft_resets_work_on_sql_server(api: TestApi) {
             .assert_schema()
             .assert_tables_count(3)
             .assert_has_table("_prisma_migrations")
-            .unwrap()
             .assert_has_table("specialLitter")
-            .unwrap()
-            .assert_has_table("Cat")
-            .unwrap();
+            .assert_has_table("Cat");
 
         engine.reset().send_sync();
         engine.assert_schema().assert_tables_count(0);
@@ -211,14 +201,9 @@ fn soft_resets_work_on_sql_server(api: TestApi) {
             .schema_push(dm)
             .send_sync()
             .assert_has_executed_steps()
-            .assert_green()
-            .unwrap();
+            .assert_green_bang();
 
-        engine
-            .assert_schema()
-            .assert_tables_count(1)
-            .assert_has_table("Cat")
-            .unwrap();
+        engine.assert_schema().assert_tables_count(1).assert_has_table("Cat");
 
         engine.reset().send_sync();
         engine.assert_schema().assert_tables_count(0);
@@ -254,9 +239,7 @@ fn soft_resets_work_on_mysql(api: TestApi) {
             .assert_schema()
             .assert_tables_count(2)
             .assert_has_table("_prisma_migrations")
-            .unwrap()
-            .assert_has_table("Cat")
-            .unwrap();
+            .assert_has_table("Cat");
     }
 
     {
@@ -305,14 +288,9 @@ fn soft_resets_work_on_mysql(api: TestApi) {
             .schema_push(dm)
             .send_sync()
             .assert_has_executed_steps()
-            .assert_green()
-            .unwrap();
+            .assert_green_bang();
 
-        engine
-            .assert_schema()
-            .assert_tables_count(1)
-            .assert_has_table("Cat")
-            .unwrap();
+        engine.assert_schema().assert_tables_count(1).assert_has_table("Cat");
 
         engine.reset().send_sync();
         engine.assert_schema().assert_tables_count(0);

--- a/migration-engine/migration-engine-tests/tests/migrations/sql.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/sql.rs
@@ -11,7 +11,7 @@ fn can_handle_reserved_sql_keywords_for_model_name(api: TestApi) {
 
     api.schema_push(dm1).send_sync().assert_green_bang();
     api.assert_schema()
-        .assert_table_bang("Group", |t| t.assert_column("field", |c| c.assert_type_is_string()));
+        .assert_table("Group", |t| t.assert_column("field", |c| c.assert_type_is_string()));
 
     let dm2 = r#"
         model Group {
@@ -22,7 +22,7 @@ fn can_handle_reserved_sql_keywords_for_model_name(api: TestApi) {
 
     api.schema_push(dm2).send_sync().assert_green_bang();
     api.assert_schema()
-        .assert_table_bang("Group", |t| t.assert_column("field", |c| c.assert_type_is_int()));
+        .assert_table("Group", |t| t.assert_column("field", |c| c.assert_type_is_int()));
 }
 
 #[test_connector]
@@ -36,7 +36,7 @@ fn can_handle_reserved_sql_keywords_for_field_name(api: TestApi) {
 
     api.schema_push(dm1).send_sync().assert_green_bang();
     api.assert_schema()
-        .assert_table_bang("Test", |t| t.assert_column("Group", |c| c.assert_type_is_string()));
+        .assert_table("Test", |t| t.assert_column("Group", |c| c.assert_type_is_string()));
 
     let dm2 = r#"
         model Test {
@@ -47,7 +47,7 @@ fn can_handle_reserved_sql_keywords_for_field_name(api: TestApi) {
 
     api.schema_push(dm2).send_sync().assert_green_bang();
     api.assert_schema()
-        .assert_table_bang("Test", |t| t.assert_column("Group", |c| c.assert_type_is_int()));
+        .assert_table("Test", |t| t.assert_column("Group", |c| c.assert_type_is_int()));
 }
 
 #[test_connector]
@@ -64,9 +64,9 @@ fn creating_tables_without_primary_key_must_work(api: TestApi) {
 
     api.schema_push(dm).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("Pair", |table| {
+    api.assert_schema().assert_table("Pair", |table| {
         table
-            .assert_has_no_pk()?
+            .assert_has_no_pk()
             .assert_index_on_columns(&["index", "name"], |idx| idx.assert_is_unique())
     });
 }
@@ -94,10 +94,10 @@ fn relations_to_models_without_a_primary_key_work(api: TestApi) {
     api.schema_push(dm).send_sync().assert_green_bang();
 
     api.assert_schema()
-        .assert_table_bang("Pair", |table| table.assert_has_no_pk())
-        .assert_table_bang("PairMetadata", |table| {
+        .assert_table("Pair", |table| table.assert_has_no_pk())
+        .assert_table("PairMetadata", |table| {
             table
-                .assert_pk(|pk| pk.assert_columns(&["id"]))?
+                .assert_pk(|pk| pk.assert_columns(&["id"]))
                 .assert_fk_on_columns(&["pairidx", "pairname"], |fk| {
                     fk.assert_references("Pair", &["index", "name"])
                 })
@@ -124,10 +124,10 @@ fn relations_to_models_with_no_pk_and_a_single_unique_required_field_work(api: T
     api.schema_push(dm).send_sync().assert_green_bang();
 
     api.assert_schema()
-        .assert_table_bang("Pair", |table| table.assert_has_no_pk())
-        .assert_table_bang("PairMetadata", |table| {
+        .assert_table("Pair", |table| table.assert_has_no_pk())
+        .assert_table("PairMetadata", |table| {
             table
-                .assert_pk(|pk| pk.assert_columns(&["id"]))?
+                .assert_pk(|pk| pk.assert_columns(&["id"]))
                 .assert_fk_on_columns(&["pweight"], |fk| fk.assert_references("Pair", &["weight"]))
         });
 }
@@ -155,12 +155,10 @@ fn enum_value_with_database_names_must_work(api: TestApi) {
         api.assert_schema()
             .assert_enum(&api.normalize_identifier("Cat_mood"), |enm| {
                 enm.assert_values(&["ANGRY", "hongry"])
-            })
-            .unwrap();
+            });
     } else {
         api.assert_schema()
-            .assert_enum("CatMood", |enm| enm.assert_values(&["ANGRY", "hongry"]))
-            .unwrap();
+            .assert_enum("CatMood", |enm| enm.assert_values(&["ANGRY", "hongry"]));
     }
 
     let dm = r##"
@@ -181,13 +179,11 @@ fn enum_value_with_database_names_must_work(api: TestApi) {
         api.assert_schema()
             .assert_enum(&api.normalize_identifier("Cat_mood"), |enm| {
                 enm.assert_values(&["ANGRY", "hongery"])
-            })
-            .unwrap();
+            });
     } else {
         api.schema_push(dm).force(true).send_sync().assert_warnings(&["The values [hongry] on the enum `CatMood` will be removed. If these variants are still used in the database, this will fail.".into()]);
         api.assert_schema()
-            .assert_enum("CatMood", |enm| enm.assert_values(&["ANGRY", "hongery"]))
-            .unwrap();
+            .assert_enum("CatMood", |enm| enm.assert_values(&["ANGRY", "hongery"]));
     }
 }
 
@@ -260,9 +256,9 @@ fn id_as_part_of_relation_must_work(api: TestApi) {
 
     api.schema_push(dm).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("Cat", |table| {
+    api.assert_schema().assert_table("Cat", |table| {
         table
-            .assert_pk(|pk| pk.assert_columns(&["nemesis_id"]))?
+            .assert_pk(|pk| pk.assert_columns(&["nemesis_id"]))
             .assert_fk_on_columns(&["nemesis_id"], |fk| fk.assert_references("Dog", &["id"]))
     });
 }
@@ -290,9 +286,9 @@ fn multi_field_id_as_part_of_relation_must_work(api: TestApi) {
 
     api.schema_push(dm).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("Cat", |table| {
+    api.assert_schema().assert_table("Cat", |table| {
         table
-            .assert_pk(|pk| pk.assert_columns(&["nemesis_name", "nemesis_weight"]))?
+            .assert_pk(|pk| pk.assert_columns(&["nemesis_name", "nemesis_weight"]))
             .assert_fk_on_columns(&["nemesis_name", "nemesis_weight"], |fk| {
                 fk.assert_references("Dog", &["name", "weight"])
             })
@@ -321,9 +317,9 @@ fn remapped_multi_field_id_as_part_of_relation_must_work(api: TestApi) {
 
     api.schema_push(dm).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("Cat", |table| {
+    api.assert_schema().assert_table("Cat", |table| {
         table
-            .assert_pk(|pk| pk.assert_columns(&["dogname", "dogweight"]))?
+            .assert_pk(|pk| pk.assert_columns(&["dogname", "dogweight"]))
             .assert_fk_on_columns(&["dogname", "dogweight"], |fk| {
                 fk.assert_references("Dog", &["name", "weight"])
             })
@@ -354,7 +350,7 @@ fn unique_constraints_on_composite_relation_fields(api: TestApi) {
 
     api.schema_push(dm).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("Parent", |table| {
+    api.assert_schema().assert_table("Parent", |table| {
         table.assert_index_on_columns(&["chiid", "chic"], |idx| idx.assert_is_unique())
     });
 }
@@ -383,7 +379,7 @@ fn indexes_on_composite_relation_fields(api: TestApi) {
 
     api.schema_push(dm).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("SpamList", |table| {
+    api.assert_schema().assert_table("SpamList", |table| {
         table.assert_index_on_columns(&["ufn", "uln"], |idx| idx.assert_is_not_unique())
     });
 }

--- a/migration-engine/migration-engine-tests/tests/migrations/sqlite.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/sqlite.rs
@@ -14,11 +14,9 @@ fn sqlite_must_recreate_indexes(api: TestApi) {
 
     api.schema_push(dm1).send_sync().assert_green_bang();
 
-    api.assert_schema()
-        .assert_table("A", |table| {
-            table.assert_index_on_columns(&["field"], |idx| idx.assert_is_unique())
-        })
-        .unwrap();
+    api.assert_schema().assert_table("A", |table| {
+        table.assert_index_on_columns(&["field"], |idx| idx.assert_is_unique())
+    });
 
     let dm2 = r#"
         model A {
@@ -30,11 +28,9 @@ fn sqlite_must_recreate_indexes(api: TestApi) {
 
     api.schema_push(dm2).send_sync().assert_green_bang();
 
-    api.assert_schema()
-        .assert_table("A", |table| {
-            table.assert_index_on_columns(&["field"], |idx| idx.assert_is_unique())
-        })
-        .unwrap();
+    api.assert_schema().assert_table("A", |table| {
+        table.assert_index_on_columns(&["field"], |idx| idx.assert_is_unique())
+    });
 }
 
 #[test_connector(tags(Sqlite))]
@@ -53,11 +49,9 @@ fn sqlite_must_recreate_multi_field_indexes(api: TestApi) {
 
     api.schema_push(dm1).send_sync().assert_green_bang();
 
-    api.assert_schema()
-        .assert_table("A", |table| {
-            table.assert_index_on_columns(&["field", "secondField"], |idx| idx.assert_is_unique())
-        })
-        .unwrap();
+    api.assert_schema().assert_table("A", |table| {
+        table.assert_index_on_columns(&["field", "secondField"], |idx| idx.assert_is_unique())
+    });
 
     let dm2 = r#"
         model A {
@@ -72,11 +66,9 @@ fn sqlite_must_recreate_multi_field_indexes(api: TestApi) {
 
     api.schema_push(dm2).send_sync().assert_green_bang();
 
-    api.assert_schema()
-        .assert_table("A", |table| {
-            table.assert_index_on_columns(&["field", "secondField"], |idx| idx.assert_is_unique())
-        })
-        .unwrap();
+    api.assert_schema().assert_table("A", |table| {
+        table.assert_index_on_columns(&["field", "secondField"], |idx| idx.assert_is_unique())
+    });
 }
 
 // This is necessary because of how INTEGER PRIMARY KEY works on SQLite. This has already caused problems.
@@ -89,9 +81,5 @@ fn creating_a_model_with_a_non_autoincrement_id_column_is_idempotent(api: TestAp
     "#;
 
     api.schema_push(dm).send_sync().assert_green_bang();
-    api.schema_push(dm)
-        .send_sync()
-        .assert_green()
-        .unwrap()
-        .assert_no_steps();
+    api.schema_push(dm).send_sync().assert_green_bang().assert_no_steps();
 }

--- a/migration-engine/migration-engine-tests/tests/migrations/squashing_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/squashing_tests.rs
@@ -169,7 +169,7 @@ fn squashing_whole_migration_history_works(api: TestApi) {
     assert!(has_migrations_table);
     assert!(error_in_unapplied_migration.is_none());
 
-    api.assert_schema().assert_equals(&initial_schema).unwrap();
+    api.assert_schema().assert_equals(&initial_schema);
 
     // The following does not work because we validate that migrations are failed before marking them as rolled back.
     //
@@ -250,7 +250,6 @@ fn squashing_migrations_history_at_the_start_works(api: TestApi) {
         .assert_schema()
         .assert_tables_count(3)
         .assert_has_table("Hyena")
-        .unwrap()
         .into_schema();
 
     // Squash the files, mark migration applied, assert the schema is the same.
@@ -345,7 +344,7 @@ fn squashing_migrations_history_at_the_start_works(api: TestApi) {
     assert!(has_migrations_table);
     assert!(error_in_unapplied_migration.is_none());
 
-    api.assert_schema().assert_equals(&initial_schema).unwrap();
+    api.assert_schema().assert_equals(&initial_schema);
 }
 
 #[test_connector]
@@ -403,7 +402,6 @@ fn squashing_migrations_history_at_the_end_works(api: TestApi) {
         .assert_schema()
         .assert_tables_count(3)
         .assert_has_table("Hyena")
-        .unwrap()
         .into_schema();
 
     // Squash the files, mark migration applied, assert the schema is the same.
@@ -498,5 +496,5 @@ fn squashing_migrations_history_at_the_end_works(api: TestApi) {
     assert!(has_migrations_table);
     assert!(error_in_unapplied_migration.is_none());
 
-    api.assert_schema().assert_equals(&initial_schema).unwrap();
+    api.assert_schema().assert_equals(&initial_schema);
 }

--- a/migration-engine/migration-engine-tests/tests/migrations/timeouts.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/timeouts.rs
@@ -36,5 +36,5 @@ fn migrations_can_last_more_than_a_minute_and_succeed(api: TestApi) {
         .send_sync()
         .assert_applied_migrations(&["01long_migration", "02short_migration"]);
 
-    api.assert_schema().assert_has_table("cat").unwrap();
+    api.assert_schema().assert_has_table("cat");
 }

--- a/migration-engine/migration-engine-tests/tests/migrations/types.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/types.rs
@@ -73,7 +73,7 @@ fn float_to_decimal_works(api: TestApi) {
 
     api.schema_push(dm1).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("Cat", |table| {
+    api.assert_schema().assert_table("Cat", |table| {
         table.assert_column("meowFrequency", |col| col.assert_type_family(ColumnTypeFamily::Float))
     });
 
@@ -94,7 +94,7 @@ fn float_to_decimal_works(api: TestApi) {
         .assert_green_bang()
         .assert_has_executed_steps();
 
-    api.assert_schema().assert_table_bang("Cat", |table| {
+    api.assert_schema().assert_table("Cat", |table| {
         table.assert_column("meowFrequency", |col| col.assert_type_family(ColumnTypeFamily::Decimal))
     });
 }
@@ -115,7 +115,7 @@ fn decimal_to_float_works(api: TestApi) {
 
     api.schema_push(&dm1).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("Cat", |table| {
+    api.assert_schema().assert_table("Cat", |table| {
         table.assert_column("meowFrequency", |col| col.assert_type_family(ColumnTypeFamily::Decimal))
     });
 
@@ -131,7 +131,7 @@ fn decimal_to_float_works(api: TestApi) {
         .assert_green_bang()
         .assert_has_executed_steps();
 
-    api.assert_schema().assert_table_bang("Cat", |table| {
+    api.assert_schema().assert_table("Cat", |table| {
         table.assert_column("meowFrequency", |col| col.assert_type_family(ColumnTypeFamily::Float))
     });
 }
@@ -152,7 +152,7 @@ fn bytes_to_string_works(api: TestApi) {
 
     api.schema_push(&dm1).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("Cat", |table| {
+    api.assert_schema().assert_table("Cat", |table| {
         table.assert_column("meowData", |col| col.assert_type_is_bytes())
     });
 
@@ -168,7 +168,7 @@ fn bytes_to_string_works(api: TestApi) {
         .assert_green_bang()
         .assert_has_executed_steps();
 
-    api.assert_schema().assert_table_bang("Cat", |table| {
+    api.assert_schema().assert_table("Cat", |table| {
         table.assert_column("meowData", |col| col.assert_type_is_string())
     });
 }
@@ -189,7 +189,7 @@ fn string_to_bytes_works(api: TestApi) {
 
     api.schema_push(&dm1).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("Cat", |table| {
+    api.assert_schema().assert_table("Cat", |table| {
         table.assert_column("meowData", |col| col.assert_type_is_bytes())
     });
 
@@ -205,7 +205,7 @@ fn string_to_bytes_works(api: TestApi) {
         .assert_green_bang()
         .assert_has_executed_steps();
 
-    api.assert_schema().assert_table_bang("Cat", |table| {
+    api.assert_schema().assert_table("Cat", |table| {
         table.assert_column("meowData", |col| col.assert_type_is_string())
     });
 }
@@ -221,8 +221,8 @@ fn decimal_to_decimal_array_works(api: TestApi) {
 
     api.schema_push(dm1).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("Test", |table| {
-        table.assert_column("decFloat", |col| col.assert_type_is_decimal()?.assert_is_required())
+    api.assert_schema().assert_table("Test", |table| {
+        table.assert_column("decFloat", |col| col.assert_type_is_decimal().assert_is_required())
     });
 
     let dm2 = format!(
@@ -242,14 +242,14 @@ fn decimal_to_decimal_array_works(api: TestApi) {
         .assert_green_bang()
         .assert_has_executed_steps();
 
-    api.assert_schema().assert_table_bang("Test", |table| {
-        table.assert_column("decFloat", |col| col.assert_type_is_decimal()?.assert_is_list())
+    api.assert_schema().assert_table("Test", |table| {
+        table.assert_column("decFloat", |col| col.assert_type_is_decimal().assert_is_list())
     });
 
     api.schema_push(dm1).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("Test", |table| {
-        table.assert_column("decFloat", |col| col.assert_type_is_decimal()?.assert_is_required())
+    api.assert_schema().assert_table("Test", |table| {
+        table.assert_column("decFloat", |col| col.assert_type_is_decimal().assert_is_required())
     });
 }
 
@@ -269,8 +269,8 @@ fn bytes_to_bytes_array_works(api: TestApi) {
 
     api.schema_push(&dm1).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("Test", |table| {
-        table.assert_column("bytesCol", |col| col.assert_type_is_bytes()?.assert_is_required())
+    api.assert_schema().assert_table("Test", |table| {
+        table.assert_column("bytesCol", |col| col.assert_type_is_bytes().assert_is_required())
     });
 
     let dm2 = format!(
@@ -290,13 +290,13 @@ fn bytes_to_bytes_array_works(api: TestApi) {
         .assert_green_bang()
         .assert_has_executed_steps();
 
-    api.assert_schema().assert_table_bang("Test", |table| {
-        table.assert_column("bytesCol", |col| col.assert_type_is_bytes()?.assert_is_list())
+    api.assert_schema().assert_table("Test", |table| {
+        table.assert_column("bytesCol", |col| col.assert_type_is_bytes().assert_is_list())
     });
 
     api.schema_push(&dm1).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("Test", |table| {
-        table.assert_column("bytesCol", |col| col.assert_type_is_bytes()?.assert_is_required())
+    api.assert_schema().assert_table("Test", |table| {
+        table.assert_column("bytesCol", |col| col.assert_type_is_bytes().assert_is_required())
     });
 }

--- a/migration-engine/migration-engine-tests/tests/migrations/unsupported_types.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/unsupported_types.rs
@@ -22,26 +22,26 @@ fn adding_an_unsupported_type_must_work(api: TestApi) {
 
     api.schema_push(dm).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("Post", |table| {
+    api.assert_schema().assert_table("Post", |table| {
         table
-            .assert_columns_count(2)?
+            .assert_columns_count(2)
             .assert_column("id", |c| {
-                c.assert_is_required()?.assert_type_family(ColumnTypeFamily::Int)
-            })?
+                c.assert_is_required().assert_type_family(ColumnTypeFamily::Int)
+            })
             .assert_column("user_ip", |c| {
-                c.assert_is_required()?
+                c.assert_is_required()
                     .assert_type_family(ColumnTypeFamily::Unsupported("cidr".to_string()))
             })
     });
 
-    api.assert_schema().assert_table_bang("User", |table| {
+    api.assert_schema().assert_table("User", |table| {
         table
-            .assert_columns_count(2)?
+            .assert_columns_count(2)
             .assert_column("id", |c| {
-                c.assert_is_required()?.assert_type_family(ColumnTypeFamily::Int)
-            })?
+                c.assert_is_required().assert_type_family(ColumnTypeFamily::Int)
+            })
             .assert_column("balance", |c| {
-                c.assert_is_required()?
+                c.assert_is_required()
                     .assert_type_family(ColumnTypeFamily::Unsupported("cidr".to_string()))
             })
     });
@@ -59,18 +59,18 @@ fn switching_an_unsupported_type_to_supported_must_work(api: TestApi) {
 
     api.schema_push(dm1).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("Post", |table| {
+    api.assert_schema().assert_table("Post", |table| {
         table
-            .assert_columns_count(3)?
+            .assert_columns_count(3)
             .assert_column("id", |c| {
-                c.assert_is_required()?.assert_type_family(ColumnTypeFamily::Int)
-            })?
+                c.assert_is_required().assert_type_family(ColumnTypeFamily::Int)
+            })
             .assert_column("user_home", |c| {
-                c.assert_is_required()?
+                c.assert_is_required()
                     .assert_type_family(ColumnTypeFamily::Unsupported("point".to_string()))
-            })?
+            })
             .assert_column("user_location", |c| {
-                c.assert_is_required()?
+                c.assert_is_required()
                     .assert_type_family(ColumnTypeFamily::Unsupported("point".to_string()))
             })
     });
@@ -85,17 +85,17 @@ fn switching_an_unsupported_type_to_supported_must_work(api: TestApi) {
 
     api.schema_push(dm2).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("Post", |table| {
+    api.assert_schema().assert_table("Post", |table| {
         table
-            .assert_columns_count(3)?
+            .assert_columns_count(3)
             .assert_column("id", |c| {
-                c.assert_is_required()?.assert_type_family(ColumnTypeFamily::Int)
-            })?
+                c.assert_is_required().assert_type_family(ColumnTypeFamily::Int)
+            })
             .assert_column("user_home", |c| {
-                c.assert_is_required()?.assert_type_family(ColumnTypeFamily::String)
-            })?
+                c.assert_is_required().assert_type_family(ColumnTypeFamily::String)
+            })
             .assert_column("user_location", |c| {
-                c.assert_is_required()?.assert_type_family(ColumnTypeFamily::String)
+                c.assert_is_required().assert_type_family(ColumnTypeFamily::String)
             })
     });
 }
@@ -105,7 +105,7 @@ fn adding_and_removing_properties_on_unsupported_should_work(api: TestApi) {
     let dm1 = r#"
         model Post {
             id               Int    @id @default(autoincrement())
-            user_ip     Unsupported("cidr")
+            user_ip         Unsupported("cidr")
         }
 
         model Blog {
@@ -118,37 +118,37 @@ fn adding_and_removing_properties_on_unsupported_should_work(api: TestApi) {
 
     api.schema_push(dm1).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("Post", |table| {
+    api.assert_schema().assert_table("Post", |table| {
         table
-            .assert_columns_count(2)?
+            .assert_columns_count(2)
             .assert_column("id", |c| {
-                c.assert_is_required()?.assert_type_family(ColumnTypeFamily::Int)
-            })?
+                c.assert_is_required().assert_type_family(ColumnTypeFamily::Int)
+            })
             .assert_column("user_ip", |c| {
-                c.assert_is_required()?
+                c.assert_is_required()
                     .assert_type_family(ColumnTypeFamily::Unsupported("cidr".to_string()))
             })
     });
 
-    api.assert_schema().assert_table_bang("Blog", |table| {
+    api.assert_schema().assert_table("Blog", |table| {
         table
-            .assert_columns_count(4)?
+            .assert_columns_count(4)
             .assert_column("id", |c| {
-                c.assert_is_required()?.assert_type_family(ColumnTypeFamily::Int)
-            })?
+                c.assert_is_required().assert_type_family(ColumnTypeFamily::Int)
+            })
             .assert_column("number", |c| {
-                c.assert_is_nullable()?
-                    .assert_type_family(ColumnTypeFamily::Int)?
+                c.assert_is_nullable()
+                    .assert_type_family(ColumnTypeFamily::Int)
                     .assert_default_value(&PrismaValue::Int(1))
-            })?
+            })
             .assert_column("bigger_number", |c| {
-                c.assert_is_nullable()?
-                    .assert_type_family(ColumnTypeFamily::Int)?
+                c.assert_is_nullable()
+                    .assert_type_family(ColumnTypeFamily::Int)
                     .assert_dbgenerated("sqrt((4)::double precision)")
-            })?
+            })
             .assert_column("point", |c| {
-                c.assert_is_nullable()?
-                    .assert_type_family(ColumnTypeFamily::Unsupported("point".to_string()))?
+                c.assert_is_nullable()
+                    .assert_type_family(ColumnTypeFamily::Unsupported("point".to_string()))
                     .assert_dbgenerated("point((0)::double precision, (0)::double precision)")
             })
     });
@@ -162,15 +162,15 @@ fn adding_and_removing_properties_on_unsupported_should_work(api: TestApi) {
 
     api.schema_push(dm2).force(true).send_sync().assert_warnings(&["A unique constraint covering the columns `[user_ip]` on the table `Post` will be added. If there are existing duplicate values, this will fail.".into()]);
 
-    api.assert_schema().assert_table_bang("Post", |table| {
+    api.assert_schema().assert_table("Post", |table| {
         table
-            .assert_columns_count(2)?
-            .assert_index_on_columns(&["user_ip"], |index| index.assert_is_unique())?
+            .assert_columns_count(2)
+            .assert_index_on_columns(&["user_ip"], |index| index.assert_is_unique())
             .assert_column("id", |c| {
-                c.assert_is_required()?.assert_type_family(ColumnTypeFamily::Int)
-            })?
+                c.assert_is_required().assert_type_family(ColumnTypeFamily::Int)
+            })
             .assert_column("user_ip", |c| {
-                c.assert_is_nullable()?
+                c.assert_is_nullable()
                     .assert_type_family(ColumnTypeFamily::Unsupported("cidr".to_string()))
             })
     });
@@ -184,15 +184,15 @@ fn adding_and_removing_properties_on_unsupported_should_work(api: TestApi) {
 
     api.schema_push(dm3).send_sync().assert_green_bang();
 
-    api.assert_schema().assert_table_bang("Post", |table| {
+    api.assert_schema().assert_table("Post", |table| {
         table
-            .assert_columns_count(2)?
+            .assert_columns_count(2)
             .assert_column("id", |c| {
-                c.assert_is_required()?.assert_type_family(ColumnTypeFamily::Int)
-            })?
+                c.assert_is_required().assert_type_family(ColumnTypeFamily::Int)
+            })
             .assert_column("user_ip", |c| {
-                c.assert_is_required()?
-                    .assert_type_family(ColumnTypeFamily::Unsupported("cidr".to_string()))?
+                c.assert_is_required()
+                    .assert_type_family(ColumnTypeFamily::Unsupported("cidr".to_string()))
                     .assert_dbgenerated("'10.1.2.3/32'::cidr")
             })
     });
@@ -217,7 +217,7 @@ fn using_unsupported_and_ignore_should_work(api: TestApi) {
         {}
 
         model UnsupportedModel {{
-            field Unsupported("{}")?
+            field Unsupported("{}")
             @@ignore
         }}
      "#,

--- a/migration-engine/migration-engine-tests/tests/native_types/mssql.rs
+++ b/migration-engine/migration-engine-tests/tests/native_types/mssql.rs
@@ -1921,9 +1921,9 @@ fn safe_casts_with_existing_data_should_work(api: TestApi) {
             let insert = Insert::single_into((api.connection_info().schema_name(), "A")).value("x", seed.clone());
             api.query(insert.into());
 
-            api.assert_schema().assert_table_bang("A", |table| {
-                table.assert_columns_count(2)?.assert_column("x", |c| {
-                    c.assert_is_required()?
+            api.assert_schema().assert_table("A", |table| {
+                table.assert_columns_count(2).assert_column("x", |c| {
+                    c.assert_is_required()
                         .assert_full_data_type(&with_params(from).to_lowercase())
                 })
             });
@@ -1946,9 +1946,9 @@ fn safe_casts_with_existing_data_should_work(api: TestApi) {
 
             api.schema_push(&dm2).send_sync().assert_green_bang();
 
-            api.assert_schema().assert_table_bang("A", |table| {
-                table.assert_columns_count(2)?.assert_column("x", |c| {
-                    c.assert_is_required()?
+            api.assert_schema().assert_table("A", |table| {
+                table.assert_columns_count(2).assert_column("x", |c| {
+                    c.assert_is_required()
                         .assert_full_data_type(&with_params(to).to_lowercase())
                 })
             });
@@ -1985,9 +1985,9 @@ fn risky_casts_with_existing_data_should_warn(api: TestApi) {
             let insert = Insert::single_into((api.connection_info().schema_name(), "A")).value("x", seed.clone());
             api.query(insert.into());
 
-            api.assert_schema().assert_table_bang("A", |table| {
-                table.assert_columns_count(2)?.assert_column("x", |c| {
-                    c.assert_is_required()?
+            api.assert_schema().assert_table("A", |table| {
+                table.assert_columns_count(2).assert_column("x", |c| {
+                    c.assert_is_required()
                         .assert_full_data_type(&with_params(from).to_lowercase())
                 })
             });
@@ -2016,9 +2016,9 @@ fn risky_casts_with_existing_data_should_warn(api: TestApi) {
 
             api.schema_push(&dm2).send_sync().assert_warnings(&[warning.into()]);
 
-            api.assert_schema().assert_table_bang("A", |table| {
-                table.assert_columns_count(2)?.assert_column("x", |c| {
-                    c.assert_is_required()?
+            api.assert_schema().assert_table("A", |table| {
+                table.assert_columns_count(2).assert_column("x", |c| {
+                    c.assert_is_required()
                         .assert_full_data_type(&with_params(from).to_lowercase())
                 })
             });
@@ -2058,9 +2058,9 @@ fn not_castable_with_existing_data_should_warn(api: TestApi) {
             let insert = Insert::single_into((api.connection_info().schema_name(), "A")).value("x", seed.clone());
             api.query(insert.into());
 
-            api.assert_schema().assert_table_bang("A", |table| {
-                table.assert_columns_count(2)?.assert_column("x", |c| {
-                    c.assert_is_required()?
+            api.assert_schema().assert_table("A", |table| {
+                table.assert_columns_count(2).assert_column("x", |c| {
+                    c.assert_is_required()
                         .assert_full_data_type(&with_params(from).to_lowercase())
                 })
             });
@@ -2085,9 +2085,9 @@ fn not_castable_with_existing_data_should_warn(api: TestApi) {
 
             api.schema_push(&dm2).send_sync().assert_unexecutable(&[warning.into()]);
 
-            api.assert_schema().assert_table_bang("A", |table| {
-                table.assert_columns_count(2)?.assert_column("x", |c| {
-                    c.assert_is_required()?
+            api.assert_schema().assert_table("A", |table| {
+                table.assert_columns_count(2).assert_column("x", |c| {
+                    c.assert_is_required()
                         .assert_full_data_type(&with_params(from).to_lowercase())
                 })
             });

--- a/migration-engine/migration-engine-tests/tests/native_types/mysql.rs
+++ b/migration-engine/migration-engine-tests/tests/native_types/mysql.rs
@@ -781,13 +781,11 @@ fn safe_casts_with_existing_data_should_work(api: TestApi) {
         tracing::info!("cast migration");
         api.schema_push(&dm2).send_sync().assert_green_bang();
 
-        api.assert_schema().assert_table_bang("Test", |table| {
+        api.assert_schema().assert_table("Test", |table| {
             to_types.iter().enumerate().fold(
                 table.assert_columns_count(to_types.len() + 1),
-                |result, (idx, to_type)| {
-                    result.and_then(|table| {
-                        table.assert_column(&colnames[idx], |col| col.assert_native_type(to_type, &connector))
-                    })
+                |table, (idx, to_type)| {
+                    table.assert_column(&colnames[idx], |col| col.assert_native_type(to_type, &connector))
                 },
             )
         });
@@ -849,11 +847,9 @@ fn risky_casts_with_existing_data_should_warn(api: TestApi) {
             .assert_executable()
             .assert_warnings(&warnings);
 
-        api.assert_schema().assert_table_bang("Test", |table| {
-            to_types.iter().enumerate().fold(Ok(table), |result, (idx, to_type)| {
-                result.and_then(|table| {
-                    table.assert_column(&colnames[idx], |col| col.assert_native_type(to_type, &connector))
-                })
+        api.assert_schema().assert_table("Test", |table| {
+            to_types.iter().enumerate().fold(table, |table, (idx, to_type)| {
+                table.assert_column(&colnames[idx], |col| col.assert_native_type(to_type, &connector))
             })
         });
 
@@ -914,11 +910,9 @@ fn impossible_casts_with_existing_data_should_warn(api: TestApi) {
             .assert_executable()
             .assert_warnings(&warnings);
 
-        api.assert_schema().assert_table_bang("Test", |table| {
-            to_types.iter().enumerate().fold(Ok(table), |result, (idx, to_type)| {
-                result.and_then(|table| {
-                    table.assert_column(&colnames[idx], |col| col.assert_native_type(to_type, &connector))
-                })
+        api.assert_schema().assert_table("Test", |table| {
+            to_types.iter().enumerate().fold(table, |table, (idx, to_type)| {
+                table.assert_column(&colnames[idx], |col| col.assert_native_type(to_type, &connector))
             })
         });
 

--- a/migration-engine/migration-engine-tests/tests/native_types/postgres.rs
+++ b/migration-engine/migration-engine-tests/tests/native_types/postgres.rs
@@ -830,13 +830,11 @@ fn safe_casts_with_existing_data_should_work(api: TestApi) {
         api.query(insert.into());
 
         // first assertions
-        api.assert_schema().assert_table_bang("A", |table| {
+        api.assert_schema().assert_table("A", |table| {
             previous_assertions.iter().fold(
                 table.assert_column_count(previous_assertions.len() + 1),
-                |acc, (column_name, expected)| {
-                    acc.and_then(|table| {
-                        table.assert_column(column_name, |c| c.assert_native_type(expected, &connector))
-                    })
+                |table, (column_name, expected)| {
+                    table.assert_column(column_name, |c| c.assert_native_type(expected, &connector))
                 },
             )
         });
@@ -857,12 +855,10 @@ fn safe_casts_with_existing_data_should_work(api: TestApi) {
         api.schema_push(&dm2).send_sync().assert_green_bang();
 
         // second assertions
-        api.assert_schema().assert_table_bang("A", |table| {
+        api.assert_schema().assert_table("A", |table| {
             next_assertions.iter().fold(
                 table.assert_column_count(next_assertions.len() + 1),
-                |acc, (name, expected)| {
-                    acc.and_then(|table| table.assert_column(name, |c| c.assert_native_type(expected, &connector)))
-                },
+                |table, (name, expected)| table.assert_column(name, |c| c.assert_native_type(expected, &connector)),
             )
         });
 
@@ -935,13 +931,11 @@ fn risky_casts_with_existing_data_should_warn(api: TestApi) {
 
         // first assertions
 
-        api.assert_schema().assert_table_bang("A", |table| {
+        api.assert_schema().assert_table("A", |table| {
             previous_assertions.iter().fold(
                 table.assert_column_count(previous_assertions.len() + 1),
-                |acc, (column_name, expected)| {
-                    acc.and_then(|table| {
-                        table.assert_column(column_name, |c| c.assert_native_type(expected, &connector))
-                    })
+                |table, (column_name, expected)| {
+                    table.assert_column(column_name, |c| c.assert_native_type(expected, &connector))
                 },
             )
         });
@@ -962,13 +956,11 @@ fn risky_casts_with_existing_data_should_warn(api: TestApi) {
         api.schema_push(&dm2).force(true).send_sync().assert_warnings(&warnings);
 
         //second assertions same as first
-        api.assert_schema().assert_table_bang("A", |table| {
+        api.assert_schema().assert_table("A", |table| {
             next_assertions.iter().fold(
                 table.assert_column_count(next_assertions.len() + 1),
-                |acc, (column_name, expected)| {
-                    acc.and_then(|table| {
-                        table.assert_column(column_name, |c| c.assert_native_type(expected, &connector))
-                    })
+                |table, (column_name, expected)| {
+                    table.assert_column(column_name, |c| c.assert_native_type(expected, &connector))
                 },
             )
         });
@@ -1044,13 +1036,11 @@ fn not_castable_with_existing_data_should_warn(api: TestApi) {
         api.query(insert.into());
 
         // first assertions
-        api.assert_schema().assert_table_bang("A", |table| {
+        api.assert_schema().assert_table("A", |table| {
             previous_assertions.iter().fold(
                 table.assert_column_count(previous_assertions.len() + 1),
-                |acc, (column_name, expected)| {
-                    acc.and_then(|table| {
-                        table.assert_column(column_name, |c| c.assert_native_type(expected, &connector))
-                    })
+                |table, (column_name, expected)| {
+                    table.assert_column(column_name, |c| c.assert_native_type(expected, &connector))
                 },
             )
         });
@@ -1073,13 +1063,11 @@ fn not_castable_with_existing_data_should_warn(api: TestApi) {
         api.schema_push(&dm2).send_sync().assert_warnings(&warnings);
 
         //second assertions same as first
-        api.assert_schema().assert_table_bang("A", |table| {
+        api.assert_schema().assert_table("A", |table| {
             previous_assertions.iter().fold(
                 table.assert_column_count(previous_assertions.len() + 1),
-                |acc, (column_name, expected)| {
-                    acc.and_then(|table| {
-                        table.assert_column(column_name, |c| c.assert_native_type(expected, &connector))
-                    })
+                |table, (column_name, expected)| {
+                    table.assert_column(column_name, |c| c.assert_native_type(expected, &connector))
                 },
             )
         });
@@ -1230,13 +1218,11 @@ fn safe_casts_from_array_with_existing_data_should_work(api: TestApi) {
         api.query(insert.into());
 
         // first assertions
-        api.assert_schema().assert_table_bang("A", |table| {
+        api.assert_schema().assert_table("A", |table| {
             previous_assertions.iter().fold(
                 table.assert_column_count(previous_assertions.len() + 1),
-                |acc, (column_name, expected)| {
-                    acc.and_then(|table| {
-                        table.assert_column(column_name, |c| c.assert_native_type(expected, &connector))
-                    })
+                |table, (column_name, expected)| {
+                    table.assert_column(column_name, |c| c.assert_native_type(expected, &connector))
                 },
             )
         });
@@ -1257,12 +1243,10 @@ fn safe_casts_from_array_with_existing_data_should_work(api: TestApi) {
         api.schema_push(&dm2).send_sync().assert_green_bang();
 
         //second assertions
-        api.assert_schema().assert_table_bang("A", |table| {
+        api.assert_schema().assert_table("A", |table| {
             next_assertions.iter().fold(
                 table.assert_column_count(next_assertions.len() + 1),
-                |acc, (name, expected)| {
-                    acc.and_then(|table| table.assert_column(name, |c| c.assert_native_type(expected, &connector)))
-                },
+                |table, (name, expected)| table.assert_column(name, |c| c.assert_native_type(expected, &connector)),
             )
         });
 

--- a/migration-engine/migration-engine-tests/tests/schema_push/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/schema_push/mod.rs
@@ -23,10 +23,10 @@ fn schema_push_happy_path(api: TestApi) {
         .assert_has_executed_steps();
 
     api.assert_schema()
-        .assert_table_bang("Cat", |table| {
+        .assert_table("Cat", |table| {
             table.assert_column("boxId", |col| col.assert_type_family(ColumnTypeFamily::Int))
         })
-        .assert_table_bang("Box", |table| {
+        .assert_table("Box", |table| {
             table.assert_column("material", |col| col.assert_type_family(ColumnTypeFamily::String))
         });
 
@@ -51,12 +51,12 @@ fn schema_push_happy_path(api: TestApi) {
         .assert_has_executed_steps();
 
     api.assert_schema()
-        .assert_table_bang("Cat", |table| {
+        .assert_table("Cat", |table| {
             table.assert_column("boxId", |col| col.assert_type_family(ColumnTypeFamily::Int))
         })
-        .assert_table_bang("Box", |table| {
+        .assert_table("Box", |table| {
             table
-                .assert_columns_count(3)?
+                .assert_columns_count(3)
                 .assert_column("texture", |col| col.assert_type_family(ColumnTypeFamily::String))
         });
 }


### PR DESCRIPTION
The diff speaks for itself. With #[track_caller], we now get better
diagnostics with less effort.