### PR TITLE
Fix human-readable drift rendering

### DIFF
--- a/migration-engine/migration-engine-tests/tests/migrations/drift_summary.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/drift_summary.rs
@@ -391,13 +391,13 @@ fn multiple_changed_tables_and_enums() {
             [*] Changed the `Cat` table
               [-] Removed column `color`
               [+] Added column `vaccinated`
-              [+] Added unique index on columns (weight)
 
             [*] Changed the `Dog` table
               [-] Dropped the primary key on columns (id)
               [-] Removed column `name`
               [+] Added column `weight`
-              [*] Altered column `isGoodDog` (ColumnChanges { changes: BitFlags<ColumnChange>(0b110, Arity | Default) })
+              [*] Altered column `isGoodDog` (arity changed, default changed)
+              [+] Added unique index on columns (weight)
         "#]],
     );
 }


### PR DESCRIPTION
- The index part of the sorting key was not working because some indexes
  are in the next schema. It is replaced by the item name.
- Use a more friendly representation for ColumnChanges instead of the
  Debug impl