### PR TITLE
Allow passing the env on Engine init

### DIFF
--- a/introspection-engine/core/src/rpc.rs
+++ b/introspection-engine/core/src/rpc.rs
@@ -69,7 +69,7 @@ impl RpcImpl {
             .datasources
             .first()
             .ok_or_else(|| Error::Generic("There is no datasource in the schema.".into()))?
-            .load_url()
+            .load_url(|key| std::env::var(key).ok())
             .map_err(|diagnostics| Error::DatamodelError(diagnostics.to_pretty_string("schema.prisma", schema)))?;
 
         Ok((

--- a/libs/datamodel/core/src/configuration/configuration.rs
+++ b/libs/datamodel/core/src/configuration/configuration.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use super::{Datasource, Generator};
 use crate::{
     common::preview_features::PreviewFeature,
@@ -38,23 +36,14 @@ impl Configuration {
             .flat_map(|generator| generator.preview_features.iter())
     }
 
-    pub fn resolve_datasource_urls_from_virtual_env(
-        &mut self,
-        env: &HashMap<String, String>,
-        url_overrides: &[(String, String)],
-    ) -> Result<(), Diagnostics> {
-        self.resolve(url_overrides, Some(env))
-    }
-
-    pub fn resolve_datasource_urls_from_env(&mut self, url_overrides: &[(String, String)]) -> Result<(), Diagnostics> {
-        self.resolve(url_overrides, None)
-    }
-
-    fn resolve(
+    pub fn resolve_datasource_urls_from_env<F>(
         &mut self,
         url_overrides: &[(String, String)],
-        env: Option<&HashMap<String, String>>,
-    ) -> Result<(), Diagnostics> {
+        env: F,
+    ) -> Result<(), Diagnostics>
+    where
+        F: Fn(&str) -> Option<String> + Copy,
+    {
         for datasource in &mut self.datasources {
             if let Some((_, url)) = url_overrides.iter().find(|(name, _url)| name == &datasource.name) {
                 datasource.url.value = Some(url.clone());
@@ -62,12 +51,7 @@ impl Configuration {
             }
 
             if datasource.url.from_env_var.is_some() && datasource.url.value.is_none() {
-                let url = match env {
-                    Some(env) => datasource.load_url_with_env(&env)?,
-                    None => datasource.load_url()?,
-                };
-
-                datasource.url.value = Some(url);
+                datasource.url.value = Some(datasource.load_url(env)?);
             }
         }
 

--- a/libs/datamodel/core/tests/config/sources.rs
+++ b/libs/datamodel/core/tests/config/sources.rs
@@ -309,7 +309,9 @@ fn must_succeed_if_env_var_is_missing_but_override_was_provided() {
     let url = "postgres://localhost";
     let overrides = vec![("ds".to_string(), url.to_string())];
     let mut config = parse_configuration(schema);
-    config.resolve_datasource_urls_from_env(&overrides, load_env_var).unwrap();
+    config
+        .resolve_datasource_urls_from_env(&overrides, load_env_var)
+        .unwrap();
     let data_source = config.datasources.first().unwrap();
 
     data_source.assert_name("ds");
@@ -332,7 +334,9 @@ fn must_succeed_if_env_var_exists_and_override_was_provided() {
     let url = "postgres://hostbar";
     let overrides = vec![("ds".to_string(), url.to_string())];
     let mut config = parse_configuration(schema);
-    config.resolve_datasource_urls_from_env(&overrides, load_env_var).unwrap();
+    config
+        .resolve_datasource_urls_from_env(&overrides, load_env_var)
+        .unwrap();
     let data_source = config.datasources.first().unwrap();
 
     data_source.assert_name("ds");
@@ -354,7 +358,9 @@ fn must_succeed_with_overrides() {
     let url = "postgres://hostbar";
     let overrides = &[("ds".to_string(), url.to_string())];
     let mut config = parse_configuration(schema);
-    config.resolve_datasource_urls_from_env(overrides, load_env_var).unwrap();
+    config
+        .resolve_datasource_urls_from_env(overrides, load_env_var)
+        .unwrap();
 
     let data_source = config.datasources.first().unwrap();
 

--- a/libs/datamodel/core/tests/config/sources.rs
+++ b/libs/datamodel/core/tests/config/sources.rs
@@ -71,7 +71,7 @@ fn must_error_for_empty_urls() {
     "#;
 
     let config = datamodel::parse_configuration(schema).unwrap();
-    let diagnostics = config.subject.datasources[0].load_url().unwrap_err();
+    let diagnostics = config.subject.datasources[0].load_url(load_env_var).unwrap_err();
 
     diagnostics.assert_is(DatamodelError::new_source_validation_error(
         "You must provide a nonempty URL",
@@ -109,7 +109,7 @@ fn must_error_for_empty_urls_derived_from_env_vars() {
     "#;
 
     let config = datamodel::parse_configuration(schema).unwrap();
-    let diagnostics = config.subject.datasources[0].load_url().unwrap_err();
+    let diagnostics = config.subject.datasources[0].load_url(load_env_var).unwrap_err();
 
     diagnostics.assert_is(DatamodelError::new_source_validation_error(
         "You must provide a nonempty URL. The environment variable `DB_URL_EMPTY_0001` resolved to an empty string.",
@@ -128,7 +128,7 @@ fn must_error_if_wrong_protocol_is_used_for_mysql() {
     "#;
 
     let config = datamodel::parse_configuration(schema).unwrap();
-    let diagnostics = config.subject.datasources[0].load_url().unwrap_err();
+    let diagnostics = config.subject.datasources[0].load_url(load_env_var).unwrap_err();
 
     diagnostics.assert_is(DatamodelError::new_source_validation_error(
         "the URL must start with the protocol `mysql://`.",
@@ -201,7 +201,7 @@ fn must_error_if_wrong_protocol_is_used_for_postgresql() {
     "#;
 
     let config = datamodel::parse_configuration(schema).unwrap();
-    let diagnostics = config.subject.datasources[0].load_url().unwrap_err();
+    let diagnostics = config.subject.datasources[0].load_url(load_env_var).unwrap_err();
 
     diagnostics.assert_is(DatamodelError::new_source_validation_error(
         "the URL must start with the protocol `postgresql://` or `postgres://`.",
@@ -240,7 +240,7 @@ fn must_error_if_wrong_protocol_is_used_for_sqlite() {
     "#;
 
     let config = datamodel::parse_configuration(schema).unwrap();
-    let diagnostics = config.subject.datasources[0].load_url().unwrap_err();
+    let diagnostics = config.subject.datasources[0].load_url(load_env_var).unwrap_err();
 
     diagnostics.assert_is(DatamodelError::new_source_validation_error(
         "the URL must start with the protocol `file:`.",
@@ -289,7 +289,7 @@ fn must_error_if_env_var_is_missing() {
     "#;
 
     let config = datamodel::parse_configuration(schema).unwrap();
-    let diagnostics = config.subject.datasources[0].load_url().unwrap_err();
+    let diagnostics = config.subject.datasources[0].load_url(load_env_var).unwrap_err();
 
     diagnostics.assert_is(DatamodelError::new_environment_functional_evaluation_error(
         "MISSING_DATABASE_URL_0001".into(),
@@ -309,7 +309,7 @@ fn must_succeed_if_env_var_is_missing_but_override_was_provided() {
     let url = "postgres://localhost";
     let overrides = vec![("ds".to_string(), url.to_string())];
     let mut config = parse_configuration(schema);
-    config.resolve_datasource_urls_from_env(&overrides).unwrap();
+    config.resolve_datasource_urls_from_env(&overrides, load_env_var).unwrap();
     let data_source = config.datasources.first().unwrap();
 
     data_source.assert_name("ds");
@@ -332,7 +332,7 @@ fn must_succeed_if_env_var_exists_and_override_was_provided() {
     let url = "postgres://hostbar";
     let overrides = vec![("ds".to_string(), url.to_string())];
     let mut config = parse_configuration(schema);
-    config.resolve_datasource_urls_from_env(&overrides).unwrap();
+    config.resolve_datasource_urls_from_env(&overrides, load_env_var).unwrap();
     let data_source = config.datasources.first().unwrap();
 
     data_source.assert_name("ds");
@@ -354,7 +354,7 @@ fn must_succeed_with_overrides() {
     let url = "postgres://hostbar";
     let overrides = &[("ds".to_string(), url.to_string())];
     let mut config = parse_configuration(schema);
-    config.resolve_datasource_urls_from_env(overrides).unwrap();
+    config.resolve_datasource_urls_from_env(overrides, load_env_var).unwrap();
 
     let data_source = config.datasources.first().unwrap();
 
@@ -496,4 +496,8 @@ fn assert_eq_json(a: &str, b: &str) {
     let json_b: serde_json::Value = serde_json::from_str(b).expect("The String b was not valid JSON.");
 
     assert_eq!(json_a, json_b);
+}
+
+fn load_env_var(key: &str) -> Option<String> {
+    std::env::var(key).ok()
 }

--- a/libs/datamodel/core/tests/parsing/literals.rs
+++ b/libs/datamodel/core/tests/parsing/literals.rs
@@ -4,6 +4,10 @@ use crate::common::parse;
 use indoc::indoc;
 use pretty_assertions::assert_eq;
 
+fn from_env(key: &str) -> Option<String> {
+    std::env::var(key).ok()
+}
+
 #[test]
 fn strings_with_quotes_are_unescaped() {
     let input = indoc!(
@@ -67,7 +71,7 @@ fn relative_sqlite_paths_can_be_modified() {
     );
 
     let config = datamodel::parse_configuration(schema).unwrap();
-    let url = config.subject.datasources[0].load_url_with_config_dir(Path::new("/path/to/prisma"));
+    let url = config.subject.datasources[0].load_url_with_config_dir(Path::new("/path/to/prisma"), from_env);
 
     assert_eq!("file:/path/to/prisma/dev.db", url.unwrap())
 }
@@ -83,7 +87,7 @@ fn absolute_sqlite_paths_are_not_modified() {
     );
 
     let config = datamodel::parse_configuration(schema).unwrap();
-    let url = config.subject.datasources[0].load_url_with_config_dir(Path::new("/path/to/prisma"));
+    let url = config.subject.datasources[0].load_url_with_config_dir(Path::new("/path/to/prisma"), from_env);
 
     assert_eq!("file:/foo/bar/dev.db", url.unwrap())
 }
@@ -99,7 +103,7 @@ fn postgres_relative_sslidentity_can_be_modified() {
     );
 
     let config = datamodel::parse_configuration(schema).unwrap();
-    let url = config.subject.datasources[0].load_url_with_config_dir(Path::new("/path/to/prisma"));
+    let url = config.subject.datasources[0].load_url_with_config_dir(Path::new("/path/to/prisma"), from_env);
 
     assert_eq!(
         "postgres://localhost:420/?foo=bar&sslidentity=%2Fpath%2Fto%2Fprisma%2Fwe%2Fare%2Fhere.key",
@@ -119,7 +123,7 @@ fn postgres_absolute_sslidentity_should_not_be_modified() {
 
     let config = datamodel::parse_configuration(schema).unwrap();
     let url = config.subject.datasources[0]
-        .load_url_with_config_dir(Path::new("/path/to/prisma"))
+        .load_url_with_config_dir(Path::new("/path/to/prisma"), from_env)
         .unwrap();
 
     assert_eq!(
@@ -140,7 +144,7 @@ fn mysql_relative_sslidentity_can_be_modified() {
 
     let config = datamodel::parse_configuration(schema).unwrap();
     let url = config.subject.datasources[0]
-        .load_url_with_config_dir(Path::new("/path/to/prisma"))
+        .load_url_with_config_dir(Path::new("/path/to/prisma"), from_env)
         .unwrap();
 
     assert_eq!(
@@ -161,7 +165,7 @@ fn mysql_absolute_sslidentity_should_not_be_modified() {
 
     let config = datamodel::parse_configuration(schema).unwrap();
     let url = config.subject.datasources[0]
-        .load_url_with_config_dir(Path::new("/path/to/prisma"))
+        .load_url_with_config_dir(Path::new("/path/to/prisma"), from_env)
         .unwrap();
 
     assert_eq!("mysql://localhost:420/?foo=bar&sslidentity=%2Fwe%2Fare%2Fhere.key", url)
@@ -179,7 +183,7 @@ fn postgres_relative_sslcert_can_be_modified() {
 
     let config = datamodel::parse_configuration(schema).unwrap();
     let url = config.subject.datasources[0]
-        .load_url_with_config_dir(Path::new("/path/to/prisma"))
+        .load_url_with_config_dir(Path::new("/path/to/prisma"), from_env)
         .unwrap();
 
     assert_eq!(
@@ -200,7 +204,7 @@ fn postgres_absolute_sslcert_should_not_be_modified() {
 
     let config = datamodel::parse_configuration(schema).unwrap();
     let url = config.subject.datasources[0]
-        .load_url_with_config_dir(Path::new("/path/to/prisma"))
+        .load_url_with_config_dir(Path::new("/path/to/prisma"), from_env)
         .unwrap();
 
     assert_eq!("postgres://localhost:420/?foo=bar&sslcert=%2Fwe%2Fare%2Fhere.crt", url)
@@ -218,7 +222,7 @@ fn mysql_relative_sslcert_can_be_modified() {
 
     let config = datamodel::parse_configuration(schema).unwrap();
     let url = config.subject.datasources[0]
-        .load_url_with_config_dir(Path::new("/path/to/prisma"))
+        .load_url_with_config_dir(Path::new("/path/to/prisma"), from_env)
         .unwrap();
 
     assert_eq!(
@@ -239,7 +243,7 @@ fn mysql_absolute_sslcert_should_not_be_modified() {
 
     let config = datamodel::parse_configuration(schema).unwrap();
     let url = config.subject.datasources[0]
-        .load_url_with_config_dir(Path::new("/path/to/prisma"))
+        .load_url_with_config_dir(Path::new("/path/to/prisma"), from_env)
         .unwrap();
 
     assert_eq!("mysql://localhost:420/?foo=bar&sslcert=%2Fwe%2Fare%2Fhere.crt", url)

--- a/migration-engine/connectors/sql-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/lib.rs
@@ -15,6 +15,8 @@ mod sql_renderer;
 mod sql_schema_calculator;
 mod sql_schema_differ;
 
+use std::env;
+
 use connection_wrapper::Connection;
 use datamodel::{walkers::walk_models, Configuration, Datamodel};
 use error::quaint_error_to_connector_error;
@@ -156,7 +158,8 @@ impl SqlMigrationConnector {
         from: (&Configuration, &Datamodel),
         to: (&Configuration, &Datamodel),
     ) -> SqlMigration {
-        let connection_info = ConnectionInfo::from_url(&from.0.datasources[0].load_url().unwrap()).unwrap();
+        let connection_info =
+            ConnectionInfo::from_url(&from.0.datasources[0].load_url(|key| env::var(key).ok()).unwrap()).unwrap();
         let flavour = flavour::from_connection_info(&connection_info);
         let from_sql = sql_schema_calculator::calculate_sql_schema(from, flavour.as_ref());
         let to_sql = sql_schema_calculator::calculate_sql_schema(to, flavour.as_ref());

--- a/migration-engine/core/src/lib.rs
+++ b/migration-engine/core/src/lib.rs
@@ -8,6 +8,8 @@ pub mod qe_setup;
 
 mod core_error;
 
+use std::env;
+
 pub use api::GenericApi;
 pub use commands::SchemaPushInput;
 pub use core_error::{CoreError, CoreResult};
@@ -120,7 +122,7 @@ fn parse_configuration(datamodel: &str) -> CoreResult<(Datasource, String, Optio
         .map_err(|err| CoreError::new_schema_parser_error(err.to_pretty_string("schema.prisma", datamodel)))?;
 
     let url = config.datasources[0]
-        .load_url()
+        .load_url(|key| env::var(key).ok())
         .map_err(|err| CoreError::new_schema_parser_error(err.to_pretty_string("schema.prisma", datamodel)))?;
 
     let shadow_database_url = config.datasources[0]

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/direct.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/direct.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{env, sync::Arc};
 
 use crate::{ConnectorTag, RunnerInterface, TestResult};
 use prisma_models::DatamodelConverter;
@@ -23,7 +23,7 @@ impl RunnerInterface for DirectRunner {
         let internal_datamodel = DatamodelConverter::convert(&parsed_datamodel);
         let data_source = config.datasources.first().expect("No valid data source found");
         let preview_features: Vec<_> = config.preview_features().cloned().collect();
-        let url = data_source.load_url().unwrap();
+        let url = data_source.load_url(|key| env::var(key).ok()).unwrap();
         let (db_name, executor) = exec_loader::load(&data_source, &preview_features, &url).await?;
         let internal_data_model = internal_datamodel.build(db_name);
 

--- a/query-engine/query-engine-napi/src/engine.rs
+++ b/query-engine/query-engine-napi/src/engine.rs
@@ -45,6 +45,7 @@ pub struct EngineBuilder {
     config: ValidatedConfiguration,
     logger: ChannelLogger,
     config_dir: PathBuf,
+    env: HashMap<String, String>,
 }
 
 /// Internal structure for querying and reconnecting with the engine.
@@ -54,6 +55,7 @@ pub struct ConnectedEngine {
     executor: crate::Executor,
     logger: ChannelLogger,
     config_dir: PathBuf,
+    env: HashMap<String, String>,
 }
 
 /// Returned from the `serverInfo` method in javascript.
@@ -128,7 +130,8 @@ impl QueryEngine {
                 .and_then(|mut config| {
                     config
                         .subject
-                        .resolve_datasource_urls_from_virtual_env(&env, &overrides)?;
+                        .resolve_datasource_urls_from_env(&overrides, |key| env.get(key).map(ToString::to_string))?;
+
                     Ok(config)
                 })
                 .map_err(|errors| ApiError::conversion(errors, &datamodel))?
@@ -160,6 +163,7 @@ impl QueryEngine {
             config,
             logger,
             config_dir,
+            env,
         };
 
         Ok(Self {
@@ -189,7 +193,9 @@ impl QueryEngine {
 
                         let preview_features: Vec<_> = builder.config.subject.preview_features().cloned().collect();
                         let url = data_source
-                            .load_url_with_config_dir(&builder.config_dir)
+                            .load_url_with_config_dir(&builder.config_dir, |key| {
+                                builder.env.get(key).map(ToString::to_string)
+                            })
                             .map_err(|err| crate::error::ApiError::Conversion(err, builder.datamodel.raw.clone()))?;
 
                         let (db_name, executor) = exec_loader::load(&data_source, &preview_features, &url).await?;
@@ -213,6 +219,7 @@ impl QueryEngine {
                             logger: builder.logger.clone(),
                             executor,
                             config_dir: builder.config_dir.clone(),
+                            env: builder.env.clone(),
                         })
                     })
                     .await?;
@@ -239,6 +246,7 @@ impl QueryEngine {
                     logger: engine.logger.clone(),
                     config,
                     config_dir: engine.config_dir.clone(),
+                    env: engine.env.clone(),
                 };
 
                 *inner = Inner::Builder(builder);

--- a/query-engine/query-engine-napi/src/engine.rs
+++ b/query-engine/query-engine-napi/src/engine.rs
@@ -88,6 +88,8 @@ pub struct ConstructorOptions {
     #[serde(default)]
     datasource_overrides: BTreeMap<String, String>,
     #[serde(default)]
+    env: HashMap<String, String>,
+    #[serde(default)]
     telemetry: TelemetryOptions,
     config_dir: PathBuf,
     #[serde(default)]
@@ -111,6 +113,7 @@ impl QueryEngine {
             log_level,
             log_queries,
             datasource_overrides,
+            env,
             telemetry,
             config_dir,
             ignore_env_var_errors,
@@ -123,7 +126,9 @@ impl QueryEngine {
         } else {
             datamodel::parse_configuration(&datamodel)
                 .and_then(|mut config| {
-                    config.subject.resolve_datasource_urls_from_env(&overrides)?;
+                    config
+                        .subject
+                        .resolve_datasource_urls_from_virtual_env(&env, &overrides)?;
                     Ok(config)
                 })
                 .map_err(|errors| ApiError::conversion(errors, &datamodel))?

--- a/query-engine/query-engine/src/cli.rs
+++ b/query-engine/query-engine/src/cli.rs
@@ -10,7 +10,7 @@ use datamodel_connector::ConnectorCapabilities;
 use prisma_models::DatamodelConverter;
 use query_core::{schema::QuerySchemaRef, schema_builder, BuildMode};
 use request_handlers::{dmmf, GraphQlHandler};
-use std::sync::Arc;
+use std::{sync::Arc, env};
 
 pub struct ExecuteRequest {
     legacy: bool,
@@ -116,7 +116,7 @@ impl CliCommand {
         let config = &mut req.config;
 
         if !req.ignore_env_var_errors {
-            config.subject.resolve_datasource_urls_from_env(&[])?;
+            config.subject.resolve_datasource_urls_from_env(&[], |key| env::var(key).ok())?;
         }
 
         let json = datamodel::json::mcf::config_to_mcf_json_value(&config);

--- a/query-engine/query-engine/src/cli.rs
+++ b/query-engine/query-engine/src/cli.rs
@@ -10,7 +10,7 @@ use datamodel_connector::ConnectorCapabilities;
 use prisma_models::DatamodelConverter;
 use query_core::{schema::QuerySchemaRef, schema_builder, BuildMode};
 use request_handlers::{dmmf, GraphQlHandler};
-use std::{sync::Arc, env};
+use std::{env, sync::Arc};
 
 pub struct ExecuteRequest {
     legacy: bool,
@@ -116,7 +116,9 @@ impl CliCommand {
         let config = &mut req.config;
 
         if !req.ignore_env_var_errors {
-            config.subject.resolve_datasource_urls_from_env(&[], |key| env::var(key).ok())?;
+            config
+                .subject
+                .resolve_datasource_urls_from_env(&[], |key| env::var(key).ok())?;
         }
 
         let json = datamodel::json::mcf::config_to_mcf_json_value(&config);

--- a/query-engine/query-engine/src/context.rs
+++ b/query-engine/query-engine/src/context.rs
@@ -2,7 +2,7 @@ use crate::{PrismaError, PrismaResult};
 use datamodel::{Configuration, Datamodel};
 use prisma_models::DatamodelConverter;
 use query_core::{exec_loader, schema::QuerySchemaRef, schema_builder, BuildMode, QueryExecutor};
-use std::{fmt, sync::Arc};
+use std::{env, fmt, sync::Arc};
 
 /// Prisma request context containing all immutable state of the process.
 /// There is usually only one context initialized per process.
@@ -55,7 +55,7 @@ impl PrismaContext {
             .first()
             .ok_or_else(|| PrismaError::ConfigurationError("No valid data source found".into()))?;
 
-        let url = data_source.load_url()?;
+        let url = data_source.load_url(|key| env::var(key).ok())?;
 
         // Load executor
 

--- a/query-engine/query-engine/src/opt.rs
+++ b/query-engine/query-engine/src/opt.rs
@@ -2,6 +2,7 @@ use crate::{error::PrismaError, PrismaResult};
 use datamodel::diagnostics::ValidatedConfiguration;
 use datamodel::Datamodel;
 use serde::Deserialize;
+use std::env;
 use std::{ffi::OsStr, fs::File, io::Read};
 use structopt::StructOpt;
 
@@ -150,7 +151,7 @@ impl PrismaOpt {
             datamodel::parse_configuration(datamodel_str).and_then(|mut config| {
                 config
                     .subject
-                    .resolve_datasource_urls_from_env(&datasource_url_overrides)?;
+                    .resolve_datasource_urls_from_env(&datasource_url_overrides, |key| env::var(key).ok())?;
 
                 Ok(config)
             })


### PR DESCRIPTION
Parameter `env` takes an object, that should reflect the system environment. E.g. `process.env` in node.

closes: https://github.com/prisma/prisma/issues/7522
closes: https://github.com/prisma/prisma/issues/7562