### PR TITLE
Remove DatabaseMigrationStepApplier::render_steps()

### DIFF
--- a/.github/workflows/migration-engine.yml
+++ b/.github/workflows/migration-engine.yml
@@ -83,6 +83,7 @@ jobs:
         env:
           CLICOLOR_FORCE: 1
           TEST_DATABASE_URL: ${{ matrix.database.url }}
+          RUST_LOG: debug
 
       - run: cargo test -p introspection-engine-tests -- --test-threads=1
         if: ${{ matrix.database.is_vitess }}
@@ -107,6 +108,7 @@ jobs:
           CLICOLOR_FORCE: 1
           TEST_DATABASE_URL: ${{ matrix.database.url }}
           TEST_SHADOW_DATABASE_URL: ${{ matrix.database.shadow_database_url }}
+          RUST_LOG: debug
 
   test-windows:
     strategy:

--- a/migration-engine/connectors/migration-connector/src/database_migration_step_applier.rs
+++ b/migration-engine/connectors/migration-connector/src/database_migration_step_applier.rs
@@ -7,9 +7,6 @@ pub trait DatabaseMigrationStepApplier: Send + Sync {
     /// Applies the migration to the database. Returns the number of executed steps.
     async fn apply_migration(&self, migration: &Migration) -> ConnectorResult<u32>;
 
-    /// Render steps for the CLI. Each step will contain the raw field.
-    fn render_steps(&self, migration: &Migration) -> Vec<String>;
-
     /// Render the migration to a runnable script.
     fn render_script(&self, migration: &Migration, diagnostics: &DestructiveChangeDiagnostics) -> String;
 

--- a/migration-engine/connectors/migration-connector/src/lib.rs
+++ b/migration-engine/connectors/migration-connector/src/lib.rs
@@ -74,7 +74,13 @@ pub trait MigrationConnector: Send + Sync + 'static {
     fn migration_file_extension(&self) -> &'static str;
 
     /// Return whether the migration is empty.
-    fn migration_is_empty(&self, migration: &Migration) -> bool;
+    fn migration_is_empty(&self, migration: &Migration) -> bool {
+        self.migration_len(migration) == 0
+    }
+
+    /// Return the number of steps in the migration.
+    /// Invariant: migration_is_empty() == true iff migration_len() == 0.
+    fn migration_len(&self, migration: &Migration) -> usize;
 
     /// See [MigrationPersistence](trait.MigrationPersistence.html).
     fn migration_persistence(&self) -> &dyn MigrationPersistence;

--- a/migration-engine/connectors/mongodb-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/mongodb-migration-connector/src/lib.rs
@@ -87,8 +87,8 @@ impl MigrationConnector for MongoDbMigrationConnector {
         "mongo"
     }
 
-    fn migration_is_empty(&self, migration: &Migration) -> bool {
-        migration.downcast_ref::<MongoDbMigration>().is_empty()
+    fn migration_len(&self, migration: &Migration) -> usize {
+        migration.downcast_ref::<MongoDbMigration>().steps.len()
     }
 
     fn migration_summary(&self, migration: &Migration) -> String {

--- a/migration-engine/connectors/mongodb-migration-connector/src/mongodb_migration.rs
+++ b/migration-engine/connectors/mongodb-migration-connector/src/mongodb_migration.rs
@@ -4,10 +4,6 @@ pub struct MongoDbMigration {
 }
 
 impl MongoDbMigration {
-    pub(crate) fn is_empty(&self) -> bool {
-        self.steps.is_empty()
-    }
-
     pub(crate) fn summary(&self) -> String {
         let mut out = String::with_capacity(self.steps.len() * 10);
 

--- a/migration-engine/connectors/mongodb-migration-connector/src/mongodb_migration_step_applier.rs
+++ b/migration-engine/connectors/mongodb-migration-connector/src/mongodb_migration_step_applier.rs
@@ -25,10 +25,6 @@ impl DatabaseMigrationStepApplier for MongoDbMigrationConnector {
         Ok(migration.steps.len() as u32)
     }
 
-    fn render_steps(&self, _migration: &Migration) -> Vec<String> {
-        todo!()
-    }
-
     fn render_script(&self, _migration: &Migration, _diagnostics: &DestructiveChangeDiagnostics) -> String {
         todo!()
     }

--- a/migration-engine/migration-engine-tests/src/test_api/evaluate_data_loss.rs
+++ b/migration-engine/migration-engine-tests/src/test_api/evaluate_data_loss.rs
@@ -63,10 +63,9 @@ impl<'a> EvaluateDataLossAssertion<'a> {
     #[track_caller]
     pub fn assert_steps_count(self, count: usize) -> Self {
         assert!(
-            self.output.migration_steps.len() == count,
-            "Assertion failed. Expected evaluateDataLoss to return {} steps, found {}.\n{:?}",
+            self.output.migration_steps == count,
+            "Assertion failed. Expected evaluateDataLoss to return {} steps, found {}",
             count,
-            self.output.migration_steps.len(),
             self.output.migration_steps,
         );
 

--- a/migration-engine/migration-engine-tests/tests/evaluate_data_loss/evaluate_data_loss_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/evaluate_data_loss/evaluate_data_loss_tests.rs
@@ -18,7 +18,7 @@ fn evaluate_data_loss_with_an_up_to_date_database_returns_no_step(api: TestApi) 
 
     let output = api.evaluate_data_loss(&directory, dm.into()).send().into_output();
     let expected_output = EvaluateDataLossOutput {
-        migration_steps: vec![],
+        migration_steps: 0,
         warnings: vec![],
         unexecutable_steps: vec![],
     };


### PR DESCRIPTION
This is a low-hanging fruit type of migration connector API
simplification.

- The difference from render_script() is not clear, making the API
  harder to understand.
- It is only used in evaluateDataLoss, and the only relevant information
  is whether it is empty. We now just return the length of the migration
  there.

Companion PR in the CLI: https://github.com/prisma/prisma/pull/7576