### PR TITLE
Make configuration parsing internally infallible

### DIFF
--- a/libs/datamodel/core/README.md
+++ b/libs/datamodel/core/README.md
@@ -54,12 +54,27 @@ The validated and standardised **Datamodel** structure is the primary output of 
 
 For a parsed, validated and standardised datamodel, the following guarantees hold:
 
-- Each referred model or enum does exist.
+- Each referenced model or enum does exist.
 - Each related field has a backwards related field on the related type with equal relation name. If the user did not specify any, a backwards field will be generated.
-- All relations are be named.
+- All relations are named.
 - All relations have a valid list of `to_fields` on the referencing side. An empty list indicates the back relation field. If the user does not give any `references` argument, the `to_fields` will point to the related types id fields.
 
 **These Guarantees do not hold if a datamodel is loaded from DMMF**
+
+## Error handling
+
+The datamodel parser strives to provide good error diagnostics to schema
+authors. As such, it has to be capable of dealing with partially broken input
+and keep validating. The validation process can however not proceed to the
+validating models in presence of a broken datasource, for example, because that
+would lead to a cascade of misleading errors. Like other parsers, we introduce
+*cutoff points* where validation will stop in the presence of errors.
+
+These are:
+
+- AST parsing stage. Syntax errors.
+- Configuration validation
+- Datamodel validation
 
 ## Usage
 

--- a/libs/datamodel/core/src/diagnostics/validated.rs
+++ b/libs/datamodel/core/src/diagnostics/validated.rs
@@ -1,7 +1,4 @@
-use crate::ast::reformat::MissingField;
-use crate::{common::preview_features::PreviewFeature, diagnostics::DatamodelWarning};
-use crate::{Configuration, Datamodel, Datasource, Generator};
-use std::collections::HashSet;
+use crate::{ast::reformat::MissingField, diagnostics::DatamodelWarning, Configuration, Datamodel};
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct Validated<T> {
@@ -11,17 +8,4 @@ pub struct Validated<T> {
 
 pub type ValidatedDatamodel = Validated<Datamodel>;
 pub type ValidatedConfiguration = Validated<Configuration>;
-pub type ValidatedDatasource = Validated<Datasource>;
-pub type ValidatedDatasources = Validated<Vec<Datasource>>;
-pub type ValidatedGenerator = Validated<Generator>;
-pub type ValidatedGenerators = Validated<Vec<Generator>>;
 pub type ValidatedMissingFields = Validated<Vec<MissingField>>;
-
-impl ValidatedGenerators {
-    pub(crate) fn preview_features(&self) -> HashSet<&PreviewFeature> {
-        self.subject
-            .iter()
-            .flat_map(|gen| gen.preview_features.iter())
-            .collect()
-    }
-}

--- a/libs/datamodel/core/src/lib.rs
+++ b/libs/datamodel/core/src/lib.rs
@@ -89,8 +89,9 @@ pub mod walkers;
 
 pub use crate::dml::*;
 pub use configuration::*;
+use diagnostics::Diagnostics;
 
-use crate::diagnostics::{Validated, ValidatedConfiguration, ValidatedDatamodel, ValidatedDatasources};
+use crate::diagnostics::{Validated, ValidatedConfiguration, ValidatedDatamodel};
 use crate::{ast::SchemaAst, common::preview_features::PreviewFeature};
 use std::collections::HashSet;
 use transform::{
@@ -138,13 +139,12 @@ fn parse_datamodel_internal(
     let mut diagnostics = diagnostics::Diagnostics::new();
     let ast = ast::parse_schema(datamodel_string)?;
 
-    let generators = GeneratorLoader::load_generators_from_ast(&ast)?;
-    let preview_features = generators.preview_features();
-    let sources = load_sources(&ast, &&preview_features)?;
-    let validator = ValidationPipeline::new(&sources.subject);
+    let generators = GeneratorLoader::load_generators_from_ast(&ast, &mut diagnostics);
+    let preview_features = preview_features(&generators);
+    let datasources = load_sources(&ast, &preview_features, &mut &mut diagnostics);
+    let validator = ValidationPipeline::new(&datasources);
 
-    diagnostics.append_warning_vec(sources.warnings);
-    diagnostics.append_warning_vec(generators.warnings);
+    diagnostics.to_result()?;
 
     match validator.validate(&ast, transform) {
         Ok(mut src) => {
@@ -152,8 +152,8 @@ fn parse_datamodel_internal(
             Ok(Validated {
                 subject: (
                     Configuration {
-                        generators: generators.subject,
-                        datasources: sources.subject,
+                        generators,
+                        datasources,
                     },
                     src.subject,
                 ),
@@ -173,30 +173,30 @@ pub fn parse_schema_ast(datamodel_string: &str) -> Result<SchemaAst, diagnostics
 
 /// Loads all configuration blocks from a datamodel using the built-in source definitions.
 pub fn parse_configuration(schema: &str) -> Result<ValidatedConfiguration, diagnostics::Diagnostics> {
-    let mut warnings = Vec::new();
     let ast = ast::parse_schema(schema)?;
-    let mut validated_generators = GeneratorLoader::load_generators_from_ast(&ast)?;
-    let preview_features = validated_generators.preview_features();
-    let mut validated_sources = load_sources(&ast, &preview_features)?;
+    let mut diagnostics = Diagnostics::default();
+    let generators = GeneratorLoader::load_generators_from_ast(&ast, &mut diagnostics);
+    let preview_features = preview_features(&generators);
+    let datasources = load_sources(&ast, &preview_features, &mut diagnostics);
 
-    warnings.append(&mut validated_generators.warnings);
-    warnings.append(&mut validated_sources.warnings);
+    diagnostics.to_result()?;
 
     Ok(ValidatedConfiguration {
         subject: Configuration {
-            datasources: validated_sources.subject,
-            generators: validated_generators.subject,
+            datasources,
+            generators,
         },
-        warnings,
+        warnings: diagnostics.warnings,
     })
 }
 
 fn load_sources(
     schema_ast: &SchemaAst,
     preview_features: &HashSet<&PreviewFeature>,
-) -> Result<ValidatedDatasources, diagnostics::Diagnostics> {
+    diagnostics: &mut Diagnostics,
+) -> Vec<Datasource> {
     let source_loader = DatasourceLoader::new();
-    source_loader.load_datasources_from_ast(&schema_ast, preview_features)
+    source_loader.load_datasources_from_ast(&schema_ast, preview_features, diagnostics)
 }
 
 //
@@ -259,4 +259,8 @@ fn render_datamodel_and_config_to(
 fn render_schema_ast_to(stream: &mut dyn std::fmt::Write, schema: &ast::SchemaAst, ident_width: usize) {
     let mut renderer = ast::Renderer::new(stream, ident_width);
     renderer.render(schema);
+}
+
+fn preview_features(generators: &[Generator]) -> HashSet<&PreviewFeature> {
+    generators.iter().flat_map(|gen| gen.preview_features.iter()).collect()
 }

--- a/libs/datamodel/core/src/transform/ast_to_dml/datasource_loader.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/datasource_loader.rs
@@ -8,7 +8,7 @@ use super::{
 };
 use crate::{
     ast::SourceConfig,
-    diagnostics::{DatamodelError, Diagnostics, ValidatedDatasource, ValidatedDatasources},
+    diagnostics::{DatamodelError, Diagnostics},
 };
 use crate::{ast::Span, common::preview_features::PreviewFeature, configuration::StringFromEnvVar};
 use crate::{
@@ -41,34 +41,13 @@ impl DatasourceLoader {
         &self,
         ast_schema: &ast::SchemaAst,
         preview_features: &HashSet<&PreviewFeature>,
-    ) -> Result<ValidatedDatasources, Diagnostics> {
-        let mut sources = vec![];
-        let mut diagnostics = Diagnostics::new();
+        diagnostics: &mut Diagnostics,
+    ) -> Vec<Datasource> {
+        let mut sources = Vec::new();
 
         for src in &ast_schema.sources() {
-            match self.lift_datasource(&src, preview_features) {
-                Ok(loaded_src) => {
-                    diagnostics.append_warning_vec(loaded_src.warnings);
-                    sources.push(loaded_src.subject)
-                }
-                // Lift error.
-                Err(err) => {
-                    for e in err.errors {
-                        match e {
-                            DatamodelError::ArgumentNotFound { argument_name, span } => {
-                                diagnostics.push_error(DatamodelError::new_source_argument_not_found_error(
-                                    argument_name.as_str(),
-                                    src.name.name.as_str(),
-                                    span,
-                                ));
-                            }
-                            _ => {
-                                diagnostics.push_error(e);
-                            }
-                        }
-                    }
-                    diagnostics.append_warning_vec(err.warnings)
-                }
+            if let Some(source) = self.lift_datasource(&src, preview_features, diagnostics) {
+                sources.push(source)
             }
         }
 
@@ -82,66 +61,79 @@ impl DatasourceLoader {
             }
         }
 
-        if diagnostics.has_errors() {
-            Err(diagnostics)
-        } else {
-            Ok(ValidatedDatasources {
-                subject: sources,
-                warnings: diagnostics.warnings,
-            })
-        }
+        sources
     }
 
     fn lift_datasource(
         &self,
         ast_source: &ast::SourceConfig,
         preview_features: &HashSet<&PreviewFeature>,
-    ) -> Result<ValidatedDatasource, Diagnostics> {
+        diagnostics: &mut Diagnostics,
+    ) -> Option<Datasource> {
         let source_name = &ast_source.name.name;
         let args: HashMap<_, _> = ast_source
             .properties
             .iter()
             .map(|arg| (arg.name.name.as_str(), ValueValidator::new(&arg.value)))
             .collect();
-        let diagnostics = Diagnostics::new();
 
-        let provider_arg = args
-            .get("provider")
-            .ok_or_else(|| DatamodelError::new_argument_not_found_error("provider", ast_source.span))?;
+        let provider_arg = match args.get("provider") {
+            Some(provider) => provider,
+            None => {
+                diagnostics.push_error(DatamodelError::new_source_argument_not_found_error(
+                    "provider",
+                    &ast_source.name.name,
+                    ast_source.span,
+                ));
+                return None;
+            }
+        };
 
         if provider_arg.is_from_env() {
-            return Err(diagnostics.merge_error(DatamodelError::new_functional_evaluation_error(
+            diagnostics.push_error(DatamodelError::new_functional_evaluation_error(
                 &"A datasource must not use the env() function in the provider argument.".to_string(),
                 ast_source.span,
-            )));
+            ));
+            return None;
         }
 
         let provider = match provider_arg.as_string_literal() {
             Some(("", _)) => {
-                return Err(diagnostics.merge_error(DatamodelError::new_source_validation_error(
+                diagnostics.push_error(DatamodelError::new_source_validation_error(
                     "The provider argument in a datasource must not be empty",
                     source_name,
                     provider_arg.span(),
-                )));
+                ));
+                return None;
             }
             None => {
-                return Err(diagnostics.merge_error(DatamodelError::new_source_validation_error(
+                diagnostics.push_error(DatamodelError::new_source_validation_error(
                     "The provider argument in a datasource must be a string literal",
                     source_name,
                     provider_arg.span(),
-                )));
+                ));
+                return None;
             }
             Some((provider, _)) => provider,
         };
 
-        let url_arg = args
-            .get(URL_KEY)
-            .ok_or_else(|| DatamodelError::new_argument_not_found_error(URL_KEY, ast_source.span))?;
+        let url_arg = match args.get(URL_KEY) {
+            Some(url_arg) => url_arg,
+            None => {
+                diagnostics.push_error(DatamodelError::new_source_argument_not_found_error(
+                    URL_KEY,
+                    &ast_source.name.name,
+                    ast_source.span,
+                ));
+                return None;
+            }
+        };
 
         let url = match url_arg.as_str_from_env() {
             Ok(str_from_env_var) => str_from_env_var,
             Err(err) => {
-                return Err(diagnostics.merge_error(err));
+                diagnostics.push_error(err);
+                return None;
             }
         };
 
@@ -158,39 +150,39 @@ impl DatasourceLoader {
                     Err(DatamodelError::EnvironmentFunctionalEvaluationError { .. }) => None,
 
                     Err(err) => {
-                        return Err(diagnostics.merge_error(err));
+                        diagnostics.push_error(err);
+                        None
                     }
                 }
             } else {
                 None
             };
 
-        preview_features_guardrail(&args)?;
+        preview_features_guardrail(&args, diagnostics);
 
         let documentation = ast_source.documentation.as_ref().map(|comment| comment.text.clone());
 
-        let datasource_provider = self.get_datasource_provider(&provider).ok_or_else(|| {
-            diagnostics
-                .clone()
-                .merge_error(DatamodelError::new_datasource_provider_not_known_error(
+        let datasource_provider = match self.get_datasource_provider(&provider) {
+            Some(provider) => provider,
+            None => {
+                diagnostics.push_error(DatamodelError::new_datasource_provider_not_known_error(
                     provider,
                     provider_arg.span(),
-                ))
-        })?;
+                ));
+                return None;
+            }
+        };
 
-        Ok(ValidatedDatasource {
-            subject: Datasource {
-                name: source_name.to_string(),
-                provider: provider.to_owned(),
-                active_provider: datasource_provider.canonical_name().to_owned(),
-                url,
-                url_span: url_arg.span(),
-                documentation,
-                active_connector: datasource_provider.connector(),
-                shadow_database_url,
-                planet_scale_mode: get_planet_scale_mode_arg(&args, preview_features, ast_source)?,
-            },
-            warnings: diagnostics.warnings,
+        Some(Datasource {
+            name: source_name.to_string(),
+            provider: provider.to_owned(),
+            active_provider: datasource_provider.canonical_name().to_owned(),
+            url,
+            url_span: url_arg.span(),
+            documentation,
+            active_connector: datasource_provider.connector(),
+            shadow_database_url,
+            planet_scale_mode: get_planet_scale_mode_arg(&args, preview_features, ast_source, diagnostics),
         })
     }
 
@@ -227,37 +219,51 @@ fn get_planet_scale_mode_arg(
     args: &HashMap<&str, ValueValidator>,
     preview_features: &HashSet<&PreviewFeature>,
     source: &SourceConfig,
-) -> Result<bool, DatamodelError> {
+    diagnostics: &mut Diagnostics,
+) -> bool {
     let arg = args.get("planetScaleMode");
 
     match arg {
-        None => Ok(false),
+        None => false,
         Some(value) => {
-            let mode_enabled = value.as_bool()?;
+            let mode_enabled = match value.as_bool() {
+                Ok(mode_enabled) => mode_enabled,
+                Err(err) => {
+                    diagnostics.push_error(err);
+                    false
+                }
+            };
 
             if mode_enabled && !preview_features.contains(&PreviewFeature::PlanetScaleMode) {
-                return Err(DatamodelError::new_source_validation_error(
+                diagnostics.push_error(DatamodelError::new_source_validation_error(
                     PLANET_SCALE_PREVIEW_FEATURE_ERR,
                     &source.name.name,
                     value.span(),
                 ));
+                return false;
             }
 
-            Ok(mode_enabled)
+            mode_enabled
         }
     }
 }
 
-fn preview_features_guardrail(args: &HashMap<&str, ValueValidator>) -> Result<(), DatamodelError> {
-    args.get(PREVIEW_FEATURES_KEY)
-        .map(|val| -> Result<_, _> { Ok((val.as_array().to_str_vec()?, val.span())) })
-        .transpose()?
-        .filter(|(feats, _span)| !feats.is_empty())
-        .map(|(_, span)| {
-            Err(DatamodelError::new_connector_error(
-        "Preview features are only supported in the generator block. Please move this field to the generator block.",
-        span,
-    ))
-        })
-        .unwrap_or(Ok(()))
+fn preview_features_guardrail(args: &HashMap<&str, ValueValidator>, diagnostics: &mut Diagnostics) {
+    let arg = args.get(PREVIEW_FEATURES_KEY);
+
+    if let Some(val) = arg {
+        match val.as_array().to_str_vec() {
+            Ok(features) => {
+                if features.is_empty() {
+                    return;
+                }
+
+                diagnostics.push_error(DatamodelError::new_connector_error(
+            "Preview features are only supported in the generator block. Please move this field to the generator block.",
+            val.span(),
+            ));
+            }
+            Err(err) => diagnostics.push_error(err),
+        }
+    }
 }

--- a/libs/datamodel/core/src/transform/ast_to_dml/generator_loader.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/generator_loader.rs
@@ -1,6 +1,6 @@
 use super::super::helpers::*;
 use crate::{
-    ast::{self, Span},
+    ast::{self, Span, WithSpan},
     common::preview_features::GENERATOR,
     configuration::Generator,
     diagnostics::*,
@@ -25,90 +25,81 @@ const FIRST_CLASS_PROPERTIES: &[&str] = &[
 pub struct GeneratorLoader {}
 
 impl GeneratorLoader {
-    pub fn load_generators_from_ast(ast_schema: &ast::SchemaAst) -> Result<ValidatedGenerators, Diagnostics> {
-        let mut generators: Vec<Generator> = vec![];
-        let mut diagnostics = Diagnostics::new();
+    pub fn load_generators_from_ast(ast_schema: &ast::SchemaAst, diagnostics: &mut Diagnostics) -> Vec<Generator> {
+        let mut generators: Vec<Generator> = Vec::new();
 
         for gen in &ast_schema.generators() {
-            match Self::lift_generator(&gen) {
-                Ok(loaded_gen) => {
-                    diagnostics.append_warning_vec(loaded_gen.warnings);
-                    generators.push(loaded_gen.subject)
-                }
-                // Lift error.
-                Err(err) => {
-                    for e in err.errors {
-                        match e {
-                            DatamodelError::ArgumentNotFound { argument_name, span } => {
-                                diagnostics.push_error(DatamodelError::new_generator_argument_not_found_error(
-                                    argument_name.as_str(),
-                                    gen.name.name.as_str(),
-                                    span,
-                                ));
-                            }
-                            _ => {
-                                diagnostics.push_error(e);
-                            }
-                        }
-                    }
-                    diagnostics.append_warning_vec(err.warnings)
-                }
+            if let Some(generator) = Self::lift_generator(&gen, diagnostics) {
+                generators.push(generator)
             }
         }
 
-        if diagnostics.has_errors() {
-            Err(diagnostics)
-        } else {
-            Ok(ValidatedGenerators {
-                subject: generators,
-                warnings: diagnostics.warnings,
-            })
-        }
+        generators
     }
 
-    fn lift_generator(ast_generator: &ast::GeneratorConfig) -> Result<ValidatedGenerator, Diagnostics> {
+    fn lift_generator(ast_generator: &ast::GeneratorConfig, diagnostics: &mut Diagnostics) -> Option<Generator> {
         let args: HashMap<_, _> = ast_generator
             .properties
             .iter()
             .map(|arg| (arg.name.name.as_str(), ValueValidator::new(&arg.value)))
             .collect();
-        let mut diagnostics = Diagnostics::new();
 
-        let provider = args
-            .get(PROVIDER_KEY)
-            .ok_or_else(|| DatamodelError::new_argument_not_found_error(PROVIDER_KEY, ast_generator.span))?
-            .as_str_from_env()?;
+        let provider = match args.get(PROVIDER_KEY) {
+            Some(val) => match val.as_str_from_env() {
+                Ok(val) => val,
+                Err(err) => {
+                    diagnostics.push_error(err);
+                    return None;
+                }
+            },
+            None => {
+                diagnostics.push_error(DatamodelError::new_generator_argument_not_found_error(
+                    PROVIDER_KEY,
+                    &ast_generator.name.name,
+                    *ast_generator.span(),
+                ));
+                return None;
+            }
+        };
 
-        let output = if let Some(arg) = args.get(OUTPUT_KEY) {
-            Some(arg.as_str_from_env()?)
-        } else {
-            None
+        let output = match args.get(OUTPUT_KEY).map(|v| v.as_str_from_env()) {
+            Some(Ok(val)) => Some(val),
+            Some(Err(err)) => {
+                diagnostics.push_error(err);
+                None
+            }
+            None => None,
         };
 
         let mut properties: HashMap<String, String> = HashMap::new();
 
-        let binary_targets = match args.get(BINARY_TARGETS_KEY) {
-            Some(x) => x.as_array().to_str_vec()?,
+        let binary_targets = match args.get(BINARY_TARGETS_KEY).map(|v| v.as_array().to_str_vec()) {
+            Some(Ok(val)) => val,
+            Some(Err(err)) => {
+                diagnostics.push_error(err);
+                Vec::new()
+            }
             None => Vec::new(),
         };
 
         // for compatibility reasons we still accept the old experimental key
         let preview_features_arg = args
             .get(PREVIEW_FEATURES_KEY)
-            .or_else(|| args.get(EXPERIMENTAL_FEATURES_KEY));
+            .or_else(|| args.get(EXPERIMENTAL_FEATURES_KEY))
+            .map(|v| (v.as_array().to_str_vec(), v.span()));
 
         let (raw_preview_features, span) = match preview_features_arg {
-            Some(x) => (x.as_array().to_str_vec()?, x.span()),
+            Some((Ok(arr), span)) => (arr, span),
+            Some((Err(err), span)) => {
+                diagnostics.push_error(err);
+                (Vec::new(), span)
+            }
             None => (Vec::new(), Span::empty()),
         };
 
         let preview_features = if !raw_preview_features.is_empty() {
             let (features, mut diag) = parse_and_validate_preview_features(raw_preview_features, &GENERATOR, span);
             diagnostics.append(&mut diag);
-
-            if diagnostics.has_errors() {
-                return Err(diagnostics);
-            }
 
             features
         } else {
@@ -124,17 +115,14 @@ impl GeneratorLoader {
             properties.insert(prop.name.name.clone(), prop.value.to_string());
         }
 
-        Ok(ValidatedGenerator {
-            subject: Generator {
-                name: ast_generator.name.name.clone(),
-                provider,
-                output,
-                binary_targets,
-                preview_features,
-                config: properties,
-                documentation: ast_generator.documentation.clone().map(|comment| comment.text),
-            },
-            warnings: diagnostics.warnings,
+        Some(Generator {
+            name: ast_generator.name.name.clone(),
+            provider,
+            output,
+            binary_targets,
+            preview_features,
+            config: properties,
+            documentation: ast_generator.documentation.clone().map(|comment| comment.text),
         })
     }
 }

--- a/migration-engine/migration-engine-tests/compile-bench.md
+++ b/migration-engine/migration-engine-tests/compile-bench.md
@@ -1,3 +1,3 @@
 | Command | Mean [s] | Min [s] | Max [s] | Relative |
 |:---|---:|---:|---:|---:|
-| `cargo build --tests` | 7.426 ± 0.088 | 7.288 | 7.573 | 1.00 |
+| `cargo build --tests` | 5.590 ± 0.073 | 5.491 | 5.713 | 1.00 |


### PR DESCRIPTION
From a code organization perspective, validation errors are not error
conditions for the parser. We do not want them to affect the control
flow, but on the contrary to accumulate them and continue working with
broken input as much as it makes sense. To go further than this, we will
have to separate validation from Datamodel instantiation, longer term.

Observation: the value validators returning results tends to produce
slightly verbose match statements all over the place, we might want to
look into that in the future.