### PR TITLE
Try using blocking logging

### DIFF
--- a/query-engine/query-engine-napi/src/logger/channel.rs
+++ b/query-engine/query-engine-napi/src/logger/channel.rs
@@ -43,8 +43,7 @@ where
         let js_object = Value::Object(object);
         let json_str = serde_json::to_string(&js_object).unwrap();
 
-        self.callback
-            .call(Ok(json_str), ThreadsafeFunctionCallMode::NonBlocking);
+        self.callback.call(Ok(json_str), ThreadsafeFunctionCallMode::Blocking);
     }
 
     fn enabled(&self, metadata: &tracing::Metadata<'_>, ctx: Context<'_, S>) -> bool {

--- a/query-engine/query-engine-napi/src/napi_generators/engine.rs
+++ b/query-engine/query-engine-napi/src/napi_generators/engine.rs
@@ -14,7 +14,7 @@ pub fn constructor(ctx: CallContext) -> napi::Result<JsUndefined> {
 
     let mut log_callback =
         ctx.env
-            .create_threadsafe_function(&callback, 10000, |mut ctx: ThreadSafeCallContext<String>| {
+            .create_threadsafe_function(&callback, 0, |mut ctx: ThreadSafeCallContext<String>| {
                 ctx.env.adjust_external_memory(ctx.value.len() as i64)?;
 
                 ctx.env


### PR DESCRIPTION
The callback queue is bounded. If it's full, the old behavior was to drop the log messages, causing the requests to be faster but tests flaky. Now we slow down the requests, but have more consistent test results.