### PR TITLE
Group parser state into `ParserDatabase`

### DIFF
--- a/libs/datamodel/core/src/transform/ast_to_dml/db.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db.rs
@@ -1,0 +1,31 @@
+mod names;
+
+use crate::{ast, diagnostics::Diagnostics};
+
+pub(crate) struct ParserDatabase<'a> {
+    ast: &'a ast::SchemaAst,
+    names: names::Names<'a>,
+}
+
+impl<'ast> ParserDatabase<'ast> {
+    pub(super) fn new(ast: &'ast ast::SchemaAst, diagnostics: &mut Diagnostics) -> Self {
+        let names = names::Names::new(ast, diagnostics);
+
+        ParserDatabase { ast, names }
+    }
+
+    pub(super) fn ast(&self) -> &'ast ast::SchemaAst {
+        self.ast
+    }
+
+    pub(crate) fn iter_enums(&self) -> impl Iterator<Item = (ast::TopId, &'ast ast::Enum)> + '_ {
+        self.names
+            .tops
+            .values()
+            .filter_map(move |topid| self.ast[*topid].as_enum().map(|enm| (*topid, enm)))
+    }
+
+    pub(super) fn get_enum(&self, name: &str) -> Option<&'ast ast::Enum> {
+        self.names.tops.get(name).and_then(|top_id| self.ast[*top_id].as_enum())
+    }
+}

--- a/libs/datamodel/core/src/transform/ast_to_dml/db/names.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/names.rs
@@ -18,14 +18,14 @@ use std::{
 /// - Datasources
 /// - Model fields for each model
 /// - Enum variants for each enum
-pub(crate) struct Names<'ast> {
+pub(super) struct Names<'ast> {
     /// Models, enums and type aliases
-    tops: HashMap<&'ast str, TopId>,
+    pub(super) tops: HashMap<&'ast str, TopId>,
     /// Generators have their own namespace.
-    generators: HashMap<&'ast str, TopId>,
+    pub(super) generators: HashMap<&'ast str, TopId>,
     /// Datasources have their own namespace.
-    datasources: HashMap<&'ast str, TopId>,
-    model_fields: BTreeMap<(TopId, &'ast str), FieldId>,
+    pub(super) datasources: HashMap<&'ast str, TopId>,
+    pub(super) model_fields: BTreeMap<(TopId, &'ast str), FieldId>,
 }
 
 impl<'ast> Names<'ast> {
@@ -89,16 +89,6 @@ impl<'ast> Names<'ast> {
         }
 
         names
-    }
-
-    pub(crate) fn get_enum(&self, name: &str, schema: &'ast ast::SchemaAst) -> Option<&'ast ast::Enum> {
-        self.tops.get(name).and_then(|top_id| schema[*top_id].as_enum())
-    }
-
-    pub(crate) fn iter_enums(&self, schema: &'ast SchemaAst) -> impl Iterator<Item = (TopId, &'ast ast::Enum)> + '_ {
-        self.tops
-            .values()
-            .filter_map(move |topid| schema[*topid].as_enum().map(|enm| (*topid, enm)))
     }
 }
 

--- a/libs/datamodel/core/src/transform/ast_to_dml/mod.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/mod.rs
@@ -4,16 +4,15 @@ mod builtin_datasource_providers;
 mod common;
 mod datasource_loader;
 mod datasource_provider;
+mod db;
 mod generator_loader;
 mod lift;
-mod names;
 mod standardise_formatting;
 mod standardise_parsing;
 mod validate;
 mod validation_pipeline;
 
 use lift::*;
-use names::Names;
 use standardise_formatting::*;
 use validate::*;
 


### PR DESCRIPTION
* Make Names private to ParserDb

We want multiple components, like `Names`, to build up information
during the validation process. `Names` was implemented as an isolated
struct that makes sense in concert with / augments a SchemaAst. I
experimented with a component for field type checking yesterday, and
noticed that code organization is not easily extensible. It is easier to
have the state live in a single place where, for example, the type
checking component can take advantage of name resolution component.

For prior art, see rust-analyzer's layered Salsa databases pattern.  All
state is available to the root database, and every layer has access to
the layers below (starting with source text):
https://github.com/rust-analyzer/rust-analyzer/blob/38ae18b7592f97a7058d97928307bccbd881a582/crates/ide_db/src/lib.rs#L45.

Additionally, bundling the components with a reference to the AST lets
us expose a simpler API to the validation code (there is no extra
urgument for the AST in every function).