### PR TITLE
Write a default impl for datamodel_connector::Connector

### DIFF
--- a/libs/datamodel/connectors/datamodel-connector/src/empty_connector.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/empty_connector.rs
@@ -1,0 +1,72 @@
+use crate::{connector_error::ConnectorError, Connector, ConnectorCapability};
+
+/// A [Connector](/trait.Connector.html) implementor meant to
+/// be used as a default when no datasource is defined.
+pub struct EmptyDatamodelConnector;
+
+impl Connector for EmptyDatamodelConnector {
+    fn name(&self) -> &str {
+        std::any::type_name::<EmptyDatamodelConnector>()
+    }
+
+    fn capabilities(&self) -> &[ConnectorCapability] {
+        &[]
+    }
+
+    fn validate_field(&self, _field: &dml::field::Field) -> Result<(), ConnectorError> {
+        Ok(())
+    }
+
+    fn validate_model(&self, _model: &dml::model::Model) -> Result<(), ConnectorError> {
+        Ok(())
+    }
+
+    fn available_native_type_constructors(&self) -> &[dml::native_type_constructor::NativeTypeConstructor] {
+        &[]
+    }
+
+    fn scalar_type_for_native_type(&self, _native_type: serde_json::Value) -> dml::scalars::ScalarType {
+        dml::scalars::ScalarType::String
+    }
+
+    fn default_native_type_for_scalar_type(&self, _scalar_type: &dml::scalars::ScalarType) -> serde_json::Value {
+        serde_json::Value::Null
+    }
+
+    fn native_type_is_default_for_scalar_type(
+        &self,
+        _native_type: serde_json::Value,
+        _scalar_type: &dml::scalars::ScalarType,
+    ) -> bool {
+        false
+    }
+
+    fn parse_native_type(
+        &self,
+        name: &str,
+        _args: Vec<String>,
+    ) -> Result<dml::native_type_instance::NativeTypeInstance, ConnectorError> {
+        Err(ConnectorError::new_native_type_parser_error(name))
+    }
+
+    fn introspect_native_type(
+        &self,
+        _native_type: serde_json::Value,
+    ) -> Result<dml::native_type_instance::NativeTypeInstance, ConnectorError> {
+        unreachable!("introspect_native_type on EmptyDatamodelConnector")
+    }
+
+    fn validate_url(&self, _url: &str) -> Result<(), String> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_datamodel_connector_as_dyn_connector() {
+        let _connector: &dyn Connector = &EmptyDatamodelConnector;
+    }
+}

--- a/libs/datamodel/connectors/datamodel-connector/src/lib.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/lib.rs
@@ -1,6 +1,10 @@
 pub mod connector_error;
 pub mod helper;
 
+mod empty_connector;
+
+pub use empty_connector::EmptyDatamodelConnector;
+
 use crate::connector_error::{ConnectorError, ConnectorErrorFactory, ErrorKind};
 use dml::{
     field::Field, model::Model, native_type_constructor::NativeTypeConstructor,
@@ -9,9 +13,9 @@ use dml::{
 use std::{borrow::Cow, collections::BTreeMap};
 
 pub trait Connector: Send + Sync {
-    fn name(&self) -> String;
+    fn name(&self) -> &str;
 
-    fn capabilities(&self) -> &Vec<ConnectorCapability>;
+    fn capabilities(&self) -> &[ConnectorCapability];
 
     fn has_capability(&self, capability: ConnectorCapability) -> bool {
         self.capabilities().contains(&capability)
@@ -134,14 +138,14 @@ pub trait Connector: Send + Sync {
 
     fn native_instance_error(&self, instance: NativeTypeInstance) -> ConnectorErrorFactory {
         ConnectorErrorFactory {
-            connector: self.name(),
+            connector: self.name().to_owned(),
             native_type: instance.render(),
         }
     }
 
     fn native_str_error(&self, native_str: &str) -> ConnectorErrorFactory {
         ConnectorErrorFactory {
-            connector: self.name(),
+            connector: self.name().to_owned(),
             native_type: native_str.to_string(),
         }
     }
@@ -149,7 +153,7 @@ pub trait Connector: Send + Sync {
     fn native_types_not_supported(&self) -> Result<NativeTypeInstance, ConnectorError> {
         Err(ConnectorError::from_kind(
             ErrorKind::ConnectorNotSupportedForNativeTypes {
-                connector_name: self.name(),
+                connector_name: self.name().to_owned(),
             },
         ))
     }

--- a/libs/datamodel/connectors/mongodb-datamodel-connector/src/lib.rs
+++ b/libs/datamodel/connectors/mongodb-datamodel-connector/src/lib.rs
@@ -49,11 +49,11 @@ impl Default for MongoDbDatamodelConnector {
 }
 
 impl Connector for MongoDbDatamodelConnector {
-    fn name(&self) -> String {
-        "MongoDB".to_owned()
+    fn name(&self) -> &str {
+        "MongoDB"
     }
 
-    fn capabilities(&self) -> &Vec<ConnectorCapability> {
+    fn capabilities(&self) -> &[ConnectorCapability] {
         &self.capabilities
     }
 

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/mssql_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/mssql_datamodel_connector.rs
@@ -134,11 +134,11 @@ const SCALAR_TYPE_DEFAULTS: &[(ScalarType, MsSqlType)] = &[
 ];
 
 impl Connector for MsSqlDatamodelConnector {
-    fn name(&self) -> String {
-        "SQL Server".to_string()
+    fn name(&self) -> &str {
+        "SQL Server"
     }
 
-    fn capabilities(&self) -> &Vec<ConnectorCapability> {
+    fn capabilities(&self) -> &[ConnectorCapability] {
         &self.capabilities
     }
 

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
@@ -169,11 +169,11 @@ const SCALAR_TYPE_DEFAULTS: &[(ScalarType, MySqlType)] = &[
 ];
 
 impl Connector for MySqlDatamodelConnector {
-    fn name(&self) -> String {
-        "MySQL".to_string()
+    fn name(&self) -> &str {
+        "MySQL"
     }
 
-    fn capabilities(&self) -> &Vec<ConnectorCapability> {
+    fn capabilities(&self) -> &[ConnectorCapability] {
         &self.capabilities
     }
 

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
@@ -140,11 +140,11 @@ const SCALAR_TYPE_DEFAULTS: &[(ScalarType, PostgresType)] = &[
 ];
 
 impl Connector for PostgresDatamodelConnector {
-    fn name(&self) -> String {
-        "Postgres".to_string()
+    fn name(&self) -> &str {
+        "Postgres"
     }
 
-    fn capabilities(&self) -> &Vec<ConnectorCapability> {
+    fn capabilities(&self) -> &[ConnectorCapability] {
         &self.capabilities
     }
 

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/sqlite_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/sqlite_datamodel_connector.rs
@@ -29,10 +29,10 @@ impl SqliteDatamodelConnector {
 }
 
 impl Connector for SqliteDatamodelConnector {
-    fn name(&self) -> String {
-        "sqlite".to_string()
+    fn name(&self) -> &str {
+        "sqlite"
     }
-    fn capabilities(&self) -> &Vec<ConnectorCapability> {
+    fn capabilities(&self) -> &[ConnectorCapability] {
         &self.capabilities
     }
 

--- a/libs/datamodel/core/src/configuration/datasource.rs
+++ b/libs/datamodel/core/src/configuration/datasource.rs
@@ -40,7 +40,7 @@ impl std::fmt::Debug for Datasource {
 
 impl Datasource {
     pub fn capabilities(&self) -> ConnectorCapabilities {
-        let capabilities = self.active_connector.capabilities().clone();
+        let capabilities = self.active_connector.capabilities().to_owned();
         ConnectorCapabilities::new(capabilities)
     }
 

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mongodb.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mongodb.rs
@@ -107,5 +107,5 @@ impl ToString for MongoDbVersion {
 
 fn mongo_capabilities() -> Vec<ConnectorCapability> {
     let dm_connector = MongoDbDatamodelConnector::default();
-    dm_connector.capabilities().clone()
+    dm_connector.capabilities().to_owned()
 }

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mysql.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mysql.rs
@@ -147,5 +147,5 @@ impl ToString for MySqlVersion {
 
 fn mysql_capabilities() -> Vec<ConnectorCapability> {
     let dm_connector = MySqlDatamodelConnector::new();
-    dm_connector.capabilities().clone()
+    dm_connector.capabilities().to_owned()
 }

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/postgres.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/postgres.rs
@@ -187,5 +187,5 @@ impl ToString for PostgresVersion {
 
 fn postgres_capabilities() -> Vec<ConnectorCapability> {
     let dm_connector = PostgresDatamodelConnector::new();
-    dm_connector.capabilities().clone()
+    dm_connector.capabilities().to_owned()
 }

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/sql_server.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/sql_server.rs
@@ -117,5 +117,5 @@ impl ToString for SqlServerVersion {
 
 fn sql_server_capabilities() -> Vec<ConnectorCapability> {
     let dm_connector = MsSqlDatamodelConnector::new();
-    dm_connector.capabilities().clone()
+    dm_connector.capabilities().to_owned()
 }

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/sqlite.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/sqlite.rs
@@ -55,5 +55,5 @@ impl SqliteConnectorTag {
 
 fn sqlite_capabilities() -> Vec<ConnectorCapability> {
     let dm_connector = SqliteDatamodelConnector::new();
-    dm_connector.capabilities().clone()
+    dm_connector.capabilities().to_owned()
 }

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/vitess.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/vitess.rs
@@ -113,5 +113,5 @@ impl Display for VitessVersion {
 
 fn vitess_capabilities() -> Vec<ConnectorCapability> {
     let dm_connector = MySqlDatamodelConnector::new();
-    dm_connector.capabilities().clone()
+    dm_connector.capabilities().to_owned()
 }


### PR DESCRIPTION
The idea is that this is the one to use when no datasoruce is defined in
the schema.