### PR TITLE
Implement type resolution in ParserDatabase

### DIFF
--- a/libs/datamodel/connectors/dml/src/scalars.rs
+++ b/libs/datamodel/connectors/dml/src/scalars.rs
@@ -1,6 +1,5 @@
-use std::str::FromStr;
-
 use serde::{Deserialize, Serialize};
+use std::str::FromStr;
 
 /// Prisma's builtin scalar types.
 #[derive(Debug, Copy, PartialEq, Clone, Serialize, Deserialize, Eq, Hash)]

--- a/libs/datamodel/core/src/ast/mod.rs
+++ b/libs/datamodel/core/src/ast/mod.rs
@@ -97,7 +97,7 @@ impl SchemaAst {
 
 /// An opaque identifier for a top-level item in a schema AST. Use the
 /// `schema[top_id]` syntax to resolve the id to an `ast::Top`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) struct TopId(u32);
 
 impl std::ops::Index<TopId> for SchemaAst {

--- a/libs/datamodel/core/src/ast/model.rs
+++ b/libs/datamodel/core/src/ast/model.rs
@@ -1,7 +1,14 @@
 use super::*;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) struct FieldId(u32);
+
+impl FieldId {
+    /// Used for range bounds when iterating over BTreeMaps.
+    pub(crate) const ZERO: FieldId = FieldId(0);
+    /// Used for range bounds when iterating over BTreeMaps.
+    pub(crate) const MAX: FieldId = FieldId(u32::MAX);
+}
 
 /// A model declaration.
 #[derive(Debug, Clone, PartialEq)]

--- a/libs/datamodel/core/src/ast/top.rs
+++ b/libs/datamodel/core/src/ast/top.rs
@@ -89,4 +89,9 @@ impl Top {
             _ => None,
         }
     }
+
+    #[track_caller]
+    pub fn unwrap_type_alias(&self) -> &Field {
+        self.as_type_alias().unwrap()
+    }
 }

--- a/libs/datamodel/core/src/transform/ast_to_dml/db.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db.rs
@@ -1,31 +1,151 @@
+#![allow(unused)]
+
 mod names;
+mod relations;
+mod types;
 
-use crate::{ast, diagnostics::Diagnostics};
+use self::relations::RelationField;
+use crate::{
+    ast::{self, FieldId, TopId},
+    diagnostics::{DatamodelError, Diagnostics},
+};
+use names::Names;
+use std::str::FromStr;
 
+/// Information gathered during schema validation. Each validation steps
+/// enriches the database with information that can be used in later steps.
 pub(crate) struct ParserDatabase<'a> {
     ast: &'a ast::SchemaAst,
-    names: names::Names<'a>,
+    names: Names<'a>,
+    types: types::Types,
+    relations: relations::Relations,
 }
 
 impl<'ast> ParserDatabase<'ast> {
-    pub(super) fn new(ast: &'ast ast::SchemaAst, diagnostics: &mut Diagnostics) -> Self {
-        let names = names::Names::new(ast, diagnostics);
+    pub(super) fn new(ast: &'ast ast::SchemaAst, diagnostics: &mut Diagnostics) -> Option<Self> {
+        let names = Names::new(ast, diagnostics);
 
-        ParserDatabase { ast, names }
+        if diagnostics.has_errors() {
+            return None;
+        }
+
+        let mut types = types::Types::default();
+        let mut relations = relations::Relations::default();
+
+        for (top_id, top) in ast.iter_tops() {
+            match top {
+                ast::Top::Type(type_alias) => {
+                    match field_type(type_alias, &names, ast) {
+                        Ok(FieldType::Scalar(scalar_field_type)) => {
+                            types.type_aliases.insert(top_id, scalar_field_type);
+                        }
+                        Ok(FieldType::Model(_)) => diagnostics.push_error(DatamodelError::new_validation_error(
+                            "Only scalar types can be used for defining custom types.",
+                            type_alias.field_type.span(),
+                        )),
+                        Err(supported) => diagnostics.push_error(DatamodelError::new_type_not_found_error(
+                            supported,
+                            type_alias.field_type.span(),
+                        )),
+                    };
+                }
+                ast::Top::Model(model) => {
+                    for (field_id, field) in model.iter_fields() {
+                        match field_type(field, &names, ast) {
+                            Ok(FieldType::Model(referenced_model)) => {
+                                relations
+                                    .relation_fields
+                                    .insert((top_id, field_id), relations::RelationField { referenced_model });
+                            }
+                            Ok(FieldType::Scalar(scalar_field_type)) => {
+                                types.scalar_fields.insert((top_id, field_id), scalar_field_type);
+                            }
+                            Err(supported) => diagnostics.push_error(DatamodelError::new_type_not_found_error(
+                                supported,
+                                field.field_type.span(),
+                            )),
+                        }
+                    }
+                }
+                ast::Top::Source(_) | ast::Top::Generator(_) | ast::Top::Enum(_) => (),
+            }
+        }
+
+        types.detect_alias_cycles(ast, diagnostics);
+
+        Some(ParserDatabase {
+            ast,
+            names,
+            types,
+            relations,
+        })
     }
 
     pub(super) fn ast(&self) -> &'ast ast::SchemaAst {
         self.ast
     }
 
-    pub(crate) fn iter_enums(&self) -> impl Iterator<Item = (ast::TopId, &'ast ast::Enum)> + '_ {
+    pub(crate) fn iter_enums(&self) -> impl Iterator<Item = (TopId, &'ast ast::Enum)> + '_ {
         self.names
             .tops
             .values()
             .filter_map(move |topid| self.ast[*topid].as_enum().map(|enm| (*topid, enm)))
     }
 
+    pub(crate) fn iter_model_relation_fields(
+        &self,
+        top_id: TopId,
+    ) -> impl Iterator<Item = (FieldId, &RelationField)> + '_ {
+        self.relations
+            .relation_fields
+            .range((top_id, FieldId::ZERO)..=(top_id, FieldId::MAX))
+            .map(|((_, field_id), rf)| (*field_id, rf))
+    }
+
+    pub(crate) fn iter_model_scalar_fields(
+        &self,
+        model_id: TopId,
+    ) -> impl Iterator<Item = (FieldId, &ScalarFieldType)> + '_ {
+        self.types
+            .scalar_fields
+            .range((model_id, FieldId::ZERO)..=(model_id, FieldId::MAX))
+            .map(|((_, field_id), scalar_type)| (*field_id, scalar_type))
+    }
+
     pub(super) fn get_enum(&self, name: &str) -> Option<&'ast ast::Enum> {
         self.names.tops.get(name).and_then(|top_id| self.ast[*top_id].as_enum())
+    }
+}
+
+#[derive(Debug)]
+enum FieldType {
+    Model(TopId),
+    Scalar(ScalarFieldType),
+}
+
+#[derive(Debug)]
+pub(crate) enum ScalarFieldType {
+    Enum(TopId),
+    BuiltInScalar,
+    Alias(TopId),
+    Unsupported,
+}
+
+fn field_type<'a>(field: &'a ast::Field, names: &Names<'_>, ast: &'a ast::SchemaAst) -> Result<FieldType, &'a str> {
+    let supported = match &field.field_type {
+        ast::FieldType::Supported(ident) => &ident.name,
+        ast::FieldType::Unsupported(_, _) => return Ok(FieldType::Scalar(ScalarFieldType::Unsupported)),
+    };
+
+    if dml::scalars::ScalarType::from_str(supported).is_ok() {
+        return Ok(FieldType::Scalar(ScalarFieldType::BuiltInScalar));
+    }
+
+    match names.tops.get(supported.as_str()).map(|id| (*id, &ast[*id])) {
+        Some((id, ast::Top::Model(_))) => Ok(FieldType::Model(id)),
+        Some((id, ast::Top::Enum(_))) => Ok(FieldType::Scalar(ScalarFieldType::Enum(id))),
+        Some((id, ast::Top::Type(_))) => Ok(FieldType::Scalar(ScalarFieldType::Alias(id))),
+        Some((_, ast::Top::Generator(_))) | Some((_, ast::Top::Source(_))) => unreachable!(),
+        None => Err(supported),
     }
 }

--- a/libs/datamodel/core/src/transform/ast_to_dml/db/relations.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/relations.rs
@@ -1,0 +1,13 @@
+use crate::ast::{FieldId, TopId};
+use std::collections::BTreeMap;
+
+#[derive(Default)]
+pub(super) struct Relations {
+    /// This contains only the relation fields actually present in the schema
+    /// source text.
+    pub(super) relation_fields: BTreeMap<(TopId, FieldId), RelationField>,
+}
+
+pub(crate) struct RelationField {
+    pub(super) referenced_model: TopId,
+}

--- a/libs/datamodel/core/src/transform/ast_to_dml/db/types.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/types.rs
@@ -1,0 +1,88 @@
+use super::ScalarFieldType;
+use crate::{
+    ast::{FieldId, SchemaAst, TopId},
+    diagnostics::{DatamodelError, Diagnostics},
+};
+use itertools::Itertools;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+
+type AnnotationId = u32;
+
+#[derive(Debug, Default)]
+pub(super) struct Types {
+    pub(super) type_aliases: BTreeMap<TopId, ScalarFieldType>,
+    pub(super) scalar_fields: BTreeMap<(TopId, FieldId), ScalarFieldType>,
+    annotations: Vec<ModelAnnotation>,
+    // Storage for annotation fields, i.e. the fields referenced in `@(@)index`,
+    // `@(@)unique` and `@(@)id`. The type should be understood as (model_id,
+    // annotation_id, order_key_in_annotation, field_id)
+    annotation_fields: BTreeSet<(TopId, AnnotationId, u16, FieldId)>,
+}
+
+impl Types {
+    /// Detect self-referencing type aliases (possibly indirectly).
+    pub(super) fn detect_alias_cycles(&self, ast: &SchemaAst, diagnostics: &mut Diagnostics) {
+        let mut path = Vec::new();
+        // We accumulate the errors here because we want to sort them at the end.
+        let mut errors: Vec<(TopId, DatamodelError)> = Vec::new();
+
+        for (top_id, ty) in &self.type_aliases {
+            let mut current = (*top_id, ty);
+            path.clear();
+
+            // Follow the chain.
+            while let ScalarFieldType::Alias(next_alias_id) = current.1 {
+                path.push(current.0);
+                let next_alias = ast[*next_alias_id].unwrap_type_alias();
+                // Detect a cycle where next type is also the root. In that
+                // case, we want to report an error.
+                if path.len() > 1 && &path[0] == next_alias_id {
+                    errors.push((
+                        *top_id,
+                        DatamodelError::new_validation_error(
+                            &format!(
+                                "Recursive type definitions are not allowed. Recursive path was: {} -> {}.",
+                                path.iter()
+                                    .map(|id| &ast[*id].unwrap_type_alias().name.name)
+                                    .join(" -> "),
+                                &next_alias.name.name,
+                            ),
+                            next_alias.field_type.span(),
+                        ),
+                    ));
+                    break;
+                }
+
+                // Detect a cycle anywhere else in the chain of native
+                // types. In that case, the error will be reported somewhere
+                // else, and we can just abort.
+                if path.contains(next_alias_id) {
+                    break;
+                }
+
+                match self.type_aliases.get(next_alias_id) {
+                    Some(next_alias_type) => {
+                        current = (*next_alias_id, next_alias_type);
+                    }
+                    // A missing alias at this point means that there was an
+                    // error resolving the type of the next alias. We should
+                    // stop validation here.
+                    None => break,
+                }
+            }
+        }
+
+        errors.sort_by_key(|(id, _err)| *id);
+        for (_, error) in errors {
+            diagnostics.push_error(error);
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum ModelAnnotation {
+    Id,
+    Index,
+    Unique,
+    Ignore,
+}

--- a/libs/datamodel/core/src/transform/ast_to_dml/lift.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/lift.rs
@@ -38,16 +38,15 @@ impl<'a> LiftAstToDml<'a> {
 
     pub fn lift(&self) -> Result<dml::Datamodel, Diagnostics> {
         let mut schema = dml::Datamodel::new();
-        let ast_schema = self.db.ast();
         let mut errors = Diagnostics::new();
 
-        for ast_obj in &ast_schema.tops {
+        for (_, ast_obj) in self.db.ast().iter_tops() {
             match ast_obj {
                 ast::Top::Enum(en) => match self.lift_enum(&en) {
                     Ok(en) => schema.add_enum(en),
                     Err(mut err) => errors.append(&mut err),
                 },
-                ast::Top::Model(ty) => match self.lift_model(&ty, ast_schema) {
+                ast::Top::Model(ty) => match self.lift_model(&ty) {
                     Ok(md) => schema.add_model(md),
                     Err(mut err) => errors.append(&mut err),
                 },
@@ -66,14 +65,14 @@ impl<'a> LiftAstToDml<'a> {
     }
 
     /// Internal: Validates a model AST node and lifts it to a DML model.
-    fn lift_model(&self, ast_model: &ast::Model, ast_schema: &ast::SchemaAst) -> Result<dml::Model, Diagnostics> {
+    fn lift_model(&self, ast_model: &ast::Model) -> Result<dml::Model, Diagnostics> {
         let mut model = dml::Model::new(ast_model.name.name.clone(), None);
         model.documentation = ast_model.documentation.clone().map(|comment| comment.text);
 
         let mut errors = Diagnostics::new();
 
         for ast_field in &ast_model.fields {
-            match self.lift_field(ast_field, ast_schema) {
+            match self.lift_field(ast_field) {
                 Ok(field) => model.add_field(field),
                 Err(mut err) => errors.append(&mut err),
             }
@@ -151,10 +150,10 @@ impl<'a> LiftAstToDml<'a> {
     }
 
     /// Internal: Lift a field AST node to a DML field.
-    fn lift_field(&self, ast_field: &ast::Field, ast_schema: &ast::SchemaAst) -> Result<dml::Field, Diagnostics> {
+    fn lift_field(&self, ast_field: &ast::Field) -> Result<dml::Field, Diagnostics> {
         let mut errors = Diagnostics::new();
         // If we cannot parse the field type, we exit right away.
-        let (field_type, extra_attributes) = self.lift_field_type(&ast_field, None, ast_schema, &mut Vec::new())?;
+        let (field_type, extra_attributes) = self.lift_field_type(&ast_field, None, &mut Vec::new())?;
 
         let mut field = match field_type {
             FieldType::Relation(info) => {
@@ -200,7 +199,6 @@ impl<'a> LiftAstToDml<'a> {
         &self,
         ast_field: &ast::Field,
         type_alias: Option<String>,
-        ast_schema: &ast::SchemaAst,
         checked_types: &mut Vec<String>,
     ) -> Result<(dml::FieldType, Vec<ast::Attribute>), DatamodelError> {
         let type_ident: &Identifier = match &ast_field.field_type {
@@ -334,19 +332,18 @@ impl<'a> LiftAstToDml<'a> {
             } else {
                 Ok((dml::FieldType::Base(scalar_type, type_alias), vec![]))
             }
-        } else if ast_schema.find_model(type_name).is_some() {
+        } else if self.db.ast().find_model(type_name).is_some() {
             Ok((dml::FieldType::Relation(dml::RelationInfo::new(type_name)), vec![]))
         } else if self.db.get_enum(type_name).is_some() {
             Ok((dml::FieldType::Enum(type_name.clone()), vec![]))
         } else {
-            self.resolve_custom_type(ast_field, ast_schema, checked_types)
+            self.resolve_custom_type(ast_field, checked_types)
         }
     }
 
     fn resolve_custom_type(
         &self,
         ast_field: &ast::Field,
-        ast_schema: &ast::SchemaAst,
         checked_types: &mut Vec<String>,
     ) -> Result<(dml::FieldType, Vec<ast::Attribute>), DatamodelError> {
         let field_type = ast_field.field_type.unwrap_supported();
@@ -364,10 +361,10 @@ impl<'a> LiftAstToDml<'a> {
             ));
         }
 
-        if let Some(custom_type) = ast_schema.find_type_alias(&type_name) {
+        if let Some(custom_type) = self.db.ast().find_type_alias(&type_name) {
             checked_types.push(custom_type.name.name.clone());
             let (field_type, mut attrs) =
-                self.lift_field_type(custom_type, Some(type_name.to_owned()), ast_schema, checked_types)?;
+                self.lift_field_type(custom_type, Some(type_name.to_owned()), checked_types)?;
 
             if let dml::FieldType::Relation(_) = field_type {
                 return Err(DatamodelError::new_validation_error(

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline.rs
@@ -42,10 +42,7 @@ impl<'a, 'b> ValidationPipeline<'a> {
         // Phase 1 is source block loading.
 
         // Phase 2: Name resolution.
-        let db = match ParserDatabase::new(ast_schema, &mut diagnostics) {
-            Some(db) => db,
-            None => return Err(diagnostics),
-        };
+        let db = ParserDatabase::new(ast_schema, &mut diagnostics);
 
         // Early return so that the validator does not have to deal with invalid schemas
         diagnostics.to_result()?;

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline.rs
@@ -42,12 +42,13 @@ impl<'a, 'b> ValidationPipeline<'a> {
         // Phase 1 is source block loading.
 
         // Phase 2: Name resolution.
-        let db = ParserDatabase::new(ast_schema, &mut diagnostics);
+        let db = match ParserDatabase::new(ast_schema, &mut diagnostics) {
+            Some(db) => db,
+            None => return Err(diagnostics),
+        };
 
         // Early return so that the validator does not have to deal with invalid schemas
-        if diagnostics.has_errors() {
-            return Err(diagnostics);
-        }
+        diagnostics.to_result()?;
 
         // Phase 3: Lift AST to DML.
         let lifter = LiftAstToDml::new(self.source, &db);

--- a/libs/datamodel/core/tests/common.rs
+++ b/libs/datamodel/core/tests/common.rs
@@ -5,6 +5,8 @@ use datamodel::{
 };
 use pretty_assertions::assert_eq;
 
+pub use expect_test::expect;
+
 pub trait DatasourceAsserts {
     fn assert_name(&self, name: &str) -> &Self;
     fn assert_url(&self, url: StringFromEnvVar) -> &Self;


### PR DESCRIPTION
We now know and validate ahead of lifting what field resolves to what
type, which fields are relation fields, how type aliases resolve, and
whether there are cycles in type alias definitions. This information is
efficient and convenient to query from the ParserDatabase.