### PR TITLE
Stop requiring ownership of the connection in SqlSchemaDescriber

### DIFF
--- a/introspection-engine/connectors/sql-introspection-connector/src/lib.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/lib.rs
@@ -17,57 +17,51 @@ pub use error::*;
 use introspection_connector::{
     ConnectorError, ConnectorResult, DatabaseMetadata, IntrospectionConnector, IntrospectionResult,
 };
-use quaint::prelude::ConnectionInfo;
+use quaint::{prelude::ConnectionInfo, single::Quaint};
+use schema_describer_loading::load_describer;
 use sql_schema_describer::{SqlSchema, SqlSchemaDescriberBackend};
-use std::{fmt, future::Future};
-use tracing_futures::Instrument;
+use std::future::Future;
 
 pub type SqlIntrospectionResult<T> = core::result::Result<T, SqlError>;
 
+#[derive(Debug)]
 pub struct SqlIntrospectionConnector {
-    connection_info: ConnectionInfo,
-    describer: Box<dyn SqlSchemaDescriberBackend>,
-}
-
-impl fmt::Debug for SqlIntrospectionConnector {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("SqlIntrospectionConnector")
-            .field("connection_info", &self.connection_info)
-            .field("describer", &"Box<dyn SqlSchemaDescriberBackend>")
-            .finish()
-    }
+    connection: Quaint,
 }
 
 impl SqlIntrospectionConnector {
     pub async fn new(url: &str) -> ConnectorResult<SqlIntrospectionConnector> {
-        let (describer, connection_info) = schema_describer_loading::load_describer(&url)
-            .instrument(tracing::debug_span!("Loading describer"))
-            .await
-            .map_err(|error| {
-                ConnectionInfo::from_url(url)
-                    .map(|connection_info| error.into_connector_error(&connection_info))
-                    .unwrap_or_else(ConnectorError::url_parse_error)
-            })?;
+        let connection = Quaint::new(&url).await.map_err(|error| {
+            ConnectionInfo::from_url(url)
+                .map(|connection_info| SqlError::from(error).into_connector_error(&connection_info))
+                .unwrap_or_else(ConnectorError::url_parse_error)
+        })?;
 
         tracing::debug!("SqlIntrospectionConnector initialized.");
 
-        Ok(SqlIntrospectionConnector {
-            connection_info,
-            describer,
-        })
+        Ok(SqlIntrospectionConnector { connection })
     }
 
     async fn catch<O>(&self, fut: impl Future<Output = Result<O, SqlError>>) -> ConnectorResult<O> {
-        fut.await
-            .map_err(|sql_introspection_error| sql_introspection_error.into_connector_error(&self.connection_info))
+        fut.await.map_err(|sql_introspection_error| {
+            sql_introspection_error.into_connector_error(&self.connection.connection_info())
+        })
+    }
+
+    async fn describer(&self) -> SqlIntrospectionResult<Box<dyn SqlSchemaDescriberBackend + '_>> {
+        load_describer(&self.connection, self.connection.connection_info()).await
     }
 
     async fn list_databases_internal(&self) -> SqlIntrospectionResult<Vec<String>> {
-        Ok(self.describer.list_databases().await?)
+        Ok(self.describer().await?.list_databases().await?)
     }
 
     async fn get_metadata_internal(&self) -> SqlIntrospectionResult<DatabaseMetadata> {
-        let sql_metadata = self.describer.get_metadata(self.connection_info.schema_name()).await?;
+        let sql_metadata = self
+            .describer()
+            .await?
+            .get_metadata(self.connection.connection_info().schema_name())
+            .await?;
         let db_metadate = DatabaseMetadata {
             table_count: sql_metadata.table_count,
             size_in_bytes: sql_metadata.size_in_bytes,
@@ -77,13 +71,18 @@ impl SqlIntrospectionConnector {
 
     /// Exported for tests
     pub async fn describe(&self) -> SqlIntrospectionResult<SqlSchema> {
-        Ok(self.describer.describe(self.connection_info.schema_name()).await?)
+        Ok(self
+            .describer()
+            .await?
+            .describe(self.connection.connection_info().schema_name())
+            .await?)
     }
 
     async fn version(&self) -> SqlIntrospectionResult<String> {
         Ok(self
-            .describer
-            .version(self.connection_info.schema_name())
+            .describer()
+            .await?
+            .version(self.connection.connection_info().schema_name())
             .await?
             .unwrap_or_else(|| "Database version information not available.".into()))
     }
@@ -115,10 +114,12 @@ impl IntrospectionConnector for SqlIntrospectionConnector {
     async fn introspect(&self, previous_data_model: &Datamodel) -> ConnectorResult<IntrospectionResult> {
         let sql_schema = self.catch(self.describe()).await?;
         tracing::debug!("SQL Schema Describer is done: {:?}", sql_schema);
-        let family = self.connection_info.sql_family();
+        let family = self.connection.connection_info().sql_family();
 
         let introspection_result = calculate_datamodel::calculate_datamodel(&sql_schema, &family, &previous_data_model)
-            .map_err(|sql_introspection_error| sql_introspection_error.into_connector_error(&self.connection_info))?;
+            .map_err(|sql_introspection_error| {
+                sql_introspection_error.into_connector_error(&self.connection.connection_info())
+            })?;
 
         tracing::debug!("Calculating datamodel is done: {:?}", introspection_result.data_model);
 

--- a/libs/sql-schema-describer/src/lib.rs
+++ b/libs/sql-schema-describer/src/lib.rs
@@ -24,7 +24,7 @@ mod parsers;
 
 /// A database description connector.
 #[async_trait::async_trait]
-pub trait SqlSchemaDescriberBackend: Send + Sync + 'static {
+pub trait SqlSchemaDescriberBackend: Send + Sync {
     /// List the database's schemas.
     async fn list_databases(&self) -> DescriberResult<Vec<String>>;
 

--- a/libs/sql-schema-describer/src/mssql.rs
+++ b/libs/sql-schema-describer/src/mssql.rs
@@ -7,9 +7,10 @@ use indoc::indoc;
 use native_types::{MsSqlType, MsSqlTypeParameter, NativeType};
 use once_cell::sync::Lazy;
 use prisma_value::PrismaValue;
-use quaint::{prelude::Queryable, single::Quaint};
+use quaint::prelude::Queryable;
 use regex::Regex;
 use std::{
+    any::type_name,
     borrow::Cow,
     collections::{BTreeMap, HashMap, HashSet},
     convert::TryInto,
@@ -60,13 +61,18 @@ static DEFAULT_DB_GEN: Lazy<Regex> = Lazy::new(|| Regex::new(r"\((.*)\)").unwrap
 /// ```
 static DEFAULT_SHARED_CONSTRAINT: Lazy<Regex> = Lazy::new(|| Regex::new(r"^CREATE DEFAULT (.*)").unwrap());
 
-#[derive(Debug)]
-pub struct SqlSchemaDescriber {
-    conn: Quaint,
+pub struct SqlSchemaDescriber<'a> {
+    conn: &'a dyn Queryable,
+}
+
+impl std::fmt::Debug for SqlSchemaDescriber<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct(type_name::<SqlSchemaDescriber>()).finish()
+    }
 }
 
 #[async_trait::async_trait]
-impl super::SqlSchemaDescriberBackend for SqlSchemaDescriber {
+impl super::SqlSchemaDescriberBackend for SqlSchemaDescriber<'_> {
     async fn list_databases(&self) -> DescriberResult<Vec<String>> {
         Ok(self.get_databases().await?)
     }
@@ -115,10 +121,10 @@ impl super::SqlSchemaDescriberBackend for SqlSchemaDescriber {
     }
 }
 
-impl Parser for SqlSchemaDescriber {}
+impl Parser for SqlSchemaDescriber<'_> {}
 
-impl SqlSchemaDescriber {
-    pub fn new(conn: Quaint) -> Self {
+impl<'a> SqlSchemaDescriber<'a> {
+    pub fn new(conn: &'a dyn Queryable) -> Self {
         Self { conn }
     }
 

--- a/libs/sql-schema-describer/src/sqlite.rs
+++ b/libs/sql-schema-describer/src/sqlite.rs
@@ -4,17 +4,22 @@ use crate::{
     ColumnTypeFamily, DefaultValue, DescriberResult, ForeignKey, ForeignKeyAction, Index, IndexType, Lazy, PrimaryKey,
     PrismaValue, Regex, SqlMetadata, SqlSchema, SqlSchemaDescriberBackend, Table, View,
 };
-use quaint::{ast::Value, prelude::Queryable, single::Quaint};
-use std::{borrow::Cow, collections::HashMap, convert::TryInto};
+use quaint::{ast::Value, prelude::Queryable};
+use std::{any::type_name, borrow::Cow, collections::HashMap, convert::TryInto, fmt::Debug};
 use tracing::trace;
 
-#[derive(Debug)]
-pub struct SqlSchemaDescriber {
-    conn: Quaint,
+pub struct SqlSchemaDescriber<'a> {
+    conn: &'a dyn Queryable,
+}
+
+impl Debug for SqlSchemaDescriber<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct(type_name::<SqlSchemaDescriber>()).finish()
+    }
 }
 
 #[async_trait::async_trait]
-impl SqlSchemaDescriberBackend for SqlSchemaDescriber {
+impl SqlSchemaDescriberBackend for SqlSchemaDescriber<'_> {
     async fn list_databases(&self) -> DescriberResult<Vec<String>> {
         Ok(self.get_databases().await?)
     }
@@ -80,11 +85,11 @@ impl SqlSchemaDescriberBackend for SqlSchemaDescriber {
     }
 }
 
-impl Parser for SqlSchemaDescriber {}
+impl Parser for SqlSchemaDescriber<'_> {}
 
-impl SqlSchemaDescriber {
+impl<'a> SqlSchemaDescriber<'a> {
     /// Constructor.
-    pub fn new(conn: Quaint) -> SqlSchemaDescriber {
+    pub fn new(conn: &'a dyn Queryable) -> SqlSchemaDescriber<'a> {
         SqlSchemaDescriber { conn }
     }
 

--- a/libs/sql-schema-describer/tests/describers/mssql_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/mssql_describer_tests.rs
@@ -82,7 +82,7 @@ fn views_can_be_described(api: TestApi) {
 
     api.raw_cmd(&create_view);
 
-    let inspector = SqlSchemaDescriber::new(conn.clone());
+    let inspector = SqlSchemaDescriber::new(conn);
     let result = api.block_on(inspector.describe(db_name)).unwrap();
     let view = result.get_view("ab").expect("couldn't get ab view").to_owned();
 

--- a/libs/sql-schema-describer/tests/describers/mysql_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/mysql_describer_tests.rs
@@ -1245,9 +1245,7 @@ fn constraints_from_other_databases_should_not_be_introspected(api: TestApi) {
     let full_sql = other_migration.make::<barrel::backend::MySql>();
     api.raw_cmd(&full_sql);
 
-    let schema = api
-        .block_on(api.describer().describe(&"other_schema"))
-        .expect("describing");
+    let schema = api.describe_with_schema(&"other_schema");
     let table = schema.table_bang("Post");
 
     let fks = &table.foreign_keys;

--- a/libs/sql-schema-describer/tests/describers/sqlite_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/sqlite_describer_tests.rs
@@ -5,12 +5,12 @@ use sql_schema_describer::*;
 
 pub const SCHEMA: &str = "DatabaseInspector-Test";
 
-pub async fn get_sqlite_describer(sql: &str) -> sqlite::SqlSchemaDescriber {
+async fn describe_sqlite(sql: &str) -> SqlSchema {
     let conn = Quaint::new_in_memory().unwrap();
 
     conn.raw_cmd(sql).await.unwrap();
 
-    sqlite::SqlSchemaDescriber::new(conn)
+    sqlite::SqlSchemaDescriber::new(&conn).describe(SCHEMA).await.unwrap()
 }
 
 #[tokio::test]
@@ -21,8 +21,7 @@ async fn views_can_be_described() {
         CREATE VIEW ab AS SELECT a_id FROM a UNION ALL SELECT b_id FROM b;
         "#;
 
-    let inspector = get_sqlite_describer(&full_sql).await;
-    let result = inspector.describe(SCHEMA).await.expect("describing");
+    let result = describe_sqlite(full_sql).await;
     let view = result.get_view("ab").expect("couldn't get ab view").to_owned();
 
     let expected_sql = "CREATE VIEW ab AS SELECT a_id FROM a UNION ALL SELECT b_id FROM b";
@@ -44,8 +43,7 @@ async fn sqlite_column_types_must_work() {
     });
 
     let full_sql = migration.make::<barrel::backend::Sqlite>();
-    let inspector = get_sqlite_describer(&full_sql).await;
-    let result = inspector.describe(SCHEMA).await.expect("describing");
+    let result = describe_sqlite(&full_sql).await;
     let table = result.get_table("User").expect("couldn't get User table");
     let expected_columns = vec![
         Column {
@@ -144,9 +142,7 @@ async fn sqlite_foreign_key_on_delete_must_be_handled() {
             city_set_default INTEGER REFERENCES City(id) ON DELETE SET DEFAULT,
             city_set_null INTEGER REFERENCES City(id) ON DELETE SET NULL
         )";
-    let inspector = get_sqlite_describer(&sql).await;
-
-    let schema = inspector.describe(SCHEMA).await.expect("describing");
+    let schema = describe_sqlite(&sql).await;
     let mut table = schema.get_table("User").expect("get User table").to_owned();
     table.foreign_keys.sort_unstable_by_key(|fk| fk.columns.clone());
 
@@ -288,8 +284,7 @@ async fn sqlite_text_primary_keys_must_be_inferred_on_table_and_not_as_separate_
     });
     let full_sql = migration.make::<barrel::backend::Sqlite>();
 
-    let inspector = get_sqlite_describer(&full_sql).await;
-    let result = inspector.describe(SCHEMA).await.expect("describing");
+    let result = describe_sqlite(&full_sql).await;
 
     let table = result.get_table("User").expect("couldn't get User table");
 

--- a/libs/sql-schema-describer/tests/test_api/mod.rs
+++ b/libs/sql-schema-describer/tests/test_api/mod.rs
@@ -61,30 +61,34 @@ impl TestApi {
     }
 
     pub(crate) fn describe(&self) -> SqlSchema {
-        self.rt.block_on(self.describer().describe(self.schema_name())).unwrap()
+        self.describe_with_schema(self.schema_name())
+    }
+
+    pub(crate) fn describe_with_schema(&self, schema: &str) -> SqlSchema {
+        self.rt
+            .block_on(self.describer(&self.database).describe(schema))
+            .unwrap()
     }
 
     pub(crate) fn describe_error(&self) -> DescriberError {
         self.rt
-            .block_on(self.describer().describe(self.schema_name()))
+            .block_on(self.describer(&self.database).describe(self.schema_name()))
             .unwrap_err()
     }
 
-    pub(crate) fn describer(&self) -> Box<dyn SqlSchemaDescriberBackend> {
-        let db = self.database.clone();
-
+    fn describer<'a>(&self, connection: &'a dyn Queryable) -> Box<dyn SqlSchemaDescriberBackend + 'a> {
         match self.sql_family() {
             SqlFamily::Postgres => Box::new(sql_schema_describer::postgres::SqlSchemaDescriber::new(
-                db,
+                connection,
                 if self.tags.contains(Tags::Cockroach) {
                     Circumstances::Cockroach.into()
                 } else {
                     Default::default()
                 },
             )),
-            SqlFamily::Sqlite => Box::new(sql_schema_describer::sqlite::SqlSchemaDescriber::new(db)),
-            SqlFamily::Mysql => Box::new(sql_schema_describer::mysql::SqlSchemaDescriber::new(db)),
-            SqlFamily::Mssql => Box::new(sql_schema_describer::mssql::SqlSchemaDescriber::new(db)),
+            SqlFamily::Sqlite => Box::new(sql_schema_describer::sqlite::SqlSchemaDescriber::new(connection)),
+            SqlFamily::Mysql => Box::new(sql_schema_describer::mysql::SqlSchemaDescriber::new(connection)),
+            SqlFamily::Mssql => Box::new(sql_schema_describer::mssql::SqlSchemaDescriber::new(connection)),
         }
     }
 

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/mssql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/mssql.rs
@@ -152,7 +152,7 @@ impl SqlFlavour for MssqlFlavour {
     }
 
     async fn describe_schema<'a>(&'a self, connection: &Connection) -> ConnectorResult<SqlSchema> {
-        sql_schema_describer::mssql::SqlSchemaDescriber::new(connection.quaint().clone())
+        sql_schema_describer::mssql::SqlSchemaDescriber::new(connection.quaint())
             .describe(connection.connection_info().schema_name())
             .await
             .map_err(|err| match err.into_kind() {

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/mysql.rs
@@ -181,7 +181,7 @@ impl SqlFlavour for MysqlFlavour {
     }
 
     async fn describe_schema<'a>(&'a self, connection: &Connection) -> ConnectorResult<SqlSchema> {
-        sql_schema_describer::mysql::SqlSchemaDescriber::new(connection.quaint().clone())
+        sql_schema_describer::mysql::SqlSchemaDescriber::new(connection.quaint())
             .describe(connection.connection_info().schema_name())
             .await
             .map_err(|err| match err.into_kind() {

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/postgres.rs
@@ -171,7 +171,7 @@ impl SqlFlavour for PostgresFlavour {
     }
 
     async fn describe_schema<'a>(&'a self, connection: &Connection) -> ConnectorResult<SqlSchema> {
-        sql_schema_describer::postgres::SqlSchemaDescriber::new(connection.quaint().clone(), Default::default())
+        sql_schema_describer::postgres::SqlSchemaDescriber::new(connection.quaint(), Default::default())
             .describe(connection.connection_info().schema_name())
             .await
             .map_err(|err| match err.into_kind() {

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/sqlite.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/sqlite.rs
@@ -59,7 +59,7 @@ impl SqlFlavour for SqliteFlavour {
     }
 
     async fn describe_schema<'a>(&'a self, connection: &Connection) -> ConnectorResult<SqlSchema> {
-        sql_schema_describer::sqlite::SqlSchemaDescriber::new(connection.quaint().clone())
+        sql_schema_describer::sqlite::SqlSchemaDescriber::new(connection.quaint())
             .describe(connection.connection_info().schema_name())
             .await
             .map_err(|err| match err.into_kind() {


### PR DESCRIPTION
This is relevant to
https://github.com/prisma/migrations-team/issues/244 since we need to
be more flexible on what sql-schema-describer accepts as a connection.
This moves us from a concrete, owned `Quaint` struct to any `&dyn
Queryable`.