### PR TITLE
Return better errors on postgres in ApplyMigrations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3334,7 +3334,7 @@ dependencies = [
 [[package]]
 name = "quaint"
 version = "0.2.0-alpha.13"
-source = "git+https://github.com/prisma/quaint#ed93633f6139f522d6d1ffe6c932d446180e7507"
+source = "git+https://github.com/prisma/quaint#9f5860e2e6ac1684dd75f4e15ec3caef9a040f98"
 dependencies = [
  "async-trait",
  "base64 0.12.3",

--- a/migration-engine/connectors/sql-migration-connector/Cargo.toml
+++ b/migration-engine/connectors/sql-migration-connector/Cargo.toml
@@ -40,4 +40,5 @@ features = [
     "postgresql",
     "mysql",
     "mssql",
+    "expose-drivers",
 ]

--- a/migration-engine/connectors/sql-migration-connector/src/connection_wrapper.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/connection_wrapper.rs
@@ -1,26 +1,34 @@
 use crate::error::quaint_error_to_connector_error;
 use migration_connector::ConnectorError;
 use quaint::{
+    connector::{PostgreSql, PostgresUrl},
     error::{Error as QuaintError, ErrorKind as QuaintKind},
     prelude::{ConnectionInfo, Query, Queryable, ResultSet},
     single::Quaint,
 };
+use std::sync::Arc;
 
 /// An internal helper for the SQL connector. It wraps a `Quaint` struct and
 /// exposes a similar API, with additional error handling to return
 /// `ConnectorResult`s.
 #[derive(Clone, Debug)]
-pub(crate) struct Connection(Quaint);
+pub(crate) struct Connection(ConnectionInner);
 
-#[derive(Debug)]
-pub(crate) struct ConnectionError<'a> {
-    quaint_error: QuaintError,
-    connection_info: &'a ConnectionInfo,
+#[derive(Clone, Debug)]
+enum ConnectionInner {
+    Postgres(Arc<(quaint::connector::PostgreSql, PostgresUrl)>),
+    Generic(Quaint),
 }
 
-type ConnectionResult<'a, T> = Result<T, ConnectionError<'a>>;
+#[derive(Debug)]
+pub(crate) struct ConnectionError {
+    quaint_error: QuaintError,
+    connection_info: ConnectionInfo,
+}
 
-impl ConnectionError<'_> {
+type ConnectionResult<T> = Result<T, ConnectionError>;
+
+impl ConnectionError {
     pub(crate) fn kind(&self) -> &QuaintKind {
         self.quaint_error.kind()
     }
@@ -34,23 +42,30 @@ impl ConnectionError<'_> {
     }
 }
 
-impl From<ConnectionError<'_>> for ConnectorError {
-    fn from(err: ConnectionError<'_>) -> Self {
-        quaint_error_to_connector_error(err.quaint_error, err.connection_info)
+impl From<ConnectionError> for ConnectorError {
+    fn from(err: ConnectionError) -> Self {
+        quaint_error_to_connector_error(err.quaint_error, &err.connection_info)
     }
 }
 
 impl Connection {
-    pub(crate) fn new(quaint: Quaint) -> Self {
-        Connection(quaint)
+    pub(crate) fn new_generic(quaint: Quaint) -> Self {
+        Connection(ConnectionInner::Generic(quaint))
     }
 
-    pub(crate) fn connection_info(&self) -> &ConnectionInfo {
-        self.0.connection_info()
+    pub(crate) fn new_postgres(conn: PostgreSql, url: PostgresUrl) -> Self {
+        Connection(ConnectionInner::Postgres(Arc::new((conn, url))))
     }
 
-    pub(crate) async fn execute(&self, query: impl Into<Query<'_>>) -> ConnectionResult<'_, u64> {
-        self.0
+    pub(crate) fn connection_info(&self) -> ConnectionInfo {
+        match &self.0 {
+            ConnectionInner::Postgres(pg) => ConnectionInfo::Postgres(pg.1.clone()),
+            ConnectionInner::Generic(q) => q.connection_info().clone(),
+        }
+    }
+
+    pub(crate) async fn execute(&self, query: impl Into<Query<'_>>) -> ConnectionResult<u64> {
+        self.queryable()
             .execute(query.into())
             .await
             .map_err(|quaint_error| ConnectionError {
@@ -59,12 +74,15 @@ impl Connection {
             })
     }
 
-    pub(crate) fn quaint(&self) -> &Quaint {
-        &self.0
+    pub(crate) fn queryable(&self) -> &dyn Queryable {
+        match &self.0 {
+            ConnectionInner::Postgres(pg) => &pg.0,
+            ConnectionInner::Generic(q) => q,
+        }
     }
 
-    pub(crate) async fn query(&self, query: impl Into<Query<'_>>) -> ConnectionResult<'_, ResultSet> {
-        self.0
+    pub(crate) async fn query(&self, query: impl Into<Query<'_>>) -> ConnectionResult<ResultSet> {
+        self.queryable()
             .query(query.into())
             .await
             .map_err(|quaint_error| ConnectionError {
@@ -73,8 +91,8 @@ impl Connection {
             })
     }
 
-    pub(crate) async fn query_raw(&self, sql: &str, params: &[quaint::Value<'_>]) -> ConnectionResult<'_, ResultSet> {
-        self.0
+    pub(crate) async fn query_raw(&self, sql: &str, params: &[quaint::Value<'_>]) -> ConnectionResult<ResultSet> {
+        self.queryable()
             .query_raw(sql, params)
             .await
             .map_err(|quaint_error| ConnectionError {
@@ -83,18 +101,31 @@ impl Connection {
             })
     }
 
-    pub(crate) async fn raw_cmd(&self, sql: &str) -> ConnectionResult<'_, ()> {
-        self.0.raw_cmd(sql).await.map_err(|quaint_error| ConnectionError {
-            quaint_error,
-            connection_info: self.connection_info(),
-        })
+    pub(crate) async fn raw_cmd(&self, sql: &str) -> ConnectionResult<()> {
+        self.queryable()
+            .raw_cmd(sql)
+            .await
+            .map_err(|quaint_error| ConnectionError {
+                quaint_error,
+                connection_info: self.connection_info(),
+            })
     }
 
-    pub(crate) async fn version(&self) -> ConnectionResult<'_, Option<String>> {
-        self.0.version().await.map_err(|quaint_error| ConnectionError {
-            quaint_error,
-            connection_info: self.connection_info(),
-        })
+    pub(crate) fn schema_name(&self) -> &str {
+        match &self.0 {
+            ConnectionInner::Postgres(pg) => pg.1.schema(),
+            ConnectionInner::Generic(quaint) => quaint.connection_info().schema_name(),
+        }
+    }
+
+    pub(crate) async fn version(&self) -> ConnectionResult<Option<String>> {
+        self.queryable()
+            .version()
+            .await
+            .map_err(|quaint_error| ConnectionError {
+                quaint_error,
+                connection_info: self.connection_info(),
+            })
     }
 
     /// Render a table name with the required prefixing for use with quaint query building.
@@ -102,7 +133,14 @@ impl Connection {
         if self.connection_info().sql_family().is_sqlite() {
             name.into()
         } else {
-            (self.connection_info().schema_name(), name).into()
+            (self.schema_name(), name).into()
+        }
+    }
+
+    pub(crate) fn unwrap_postgres(&self) -> &(PostgreSql, PostgresUrl) {
+        match &self.0 {
+            ConnectionInner::Postgres(inner) => inner,
+            other => panic!("{:?} in Connection::unwrap_postgres()", other),
         }
     }
 }

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/mssql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/mssql.rs
@@ -65,7 +65,7 @@ impl MssqlFlavour {
             let shadow_conninfo = conn.connection_info();
             let main_conninfo = main_connection.connection_info();
 
-            super::validate_connection_infos_do_not_match((shadow_conninfo, main_conninfo))?;
+            super::validate_connection_infos_do_not_match((&shadow_conninfo, &main_conninfo))?;
 
             if self.reset(&conn).await.is_err() {
                 connector.best_effort_reset(&conn).await?;
@@ -117,6 +117,15 @@ impl SqlFlavour for MssqlFlavour {
             .await?)
     }
 
+    async fn apply_migration_script(
+        &self,
+        migration_name: &str,
+        script: &str,
+        conn: &Connection,
+    ) -> ConnectorResult<()> {
+        super::generic_apply_migration_script(migration_name, script, conn).await
+    }
+
     fn migrations_table(&self) -> Table<'_> {
         (self.schema_name(), self.migrations_table_name()).into()
     }
@@ -159,12 +168,12 @@ impl SqlFlavour for MssqlFlavour {
     }
 
     async fn describe_schema<'a>(&'a self, connection: &Connection) -> ConnectorResult<SqlSchema> {
-        sql_schema_describer::mssql::SqlSchemaDescriber::new(connection.quaint())
+        sql_schema_describer::mssql::SqlSchemaDescriber::new(connection.queryable())
             .describe(connection.connection_info().schema_name())
             .await
             .map_err(|err| match err.into_kind() {
                 DescriberErrorKind::QuaintError(err) => {
-                    quaint_error_to_connector_error(err, connection.connection_info())
+                    quaint_error_to_connector_error(err, &connection.connection_info())
                 }
                 e @ DescriberErrorKind::CrossSchemaReference { .. } => {
                     let err = KnownError::new(DatabaseSchemaInconsistent {
@@ -196,7 +205,7 @@ impl SqlFlavour for MssqlFlavour {
     }
 
     async fn reset(&self, connection: &Connection) -> ConnectorResult<()> {
-        let schema_name = connection.connection_info().schema_name();
+        let schema_name = connection.schema_name();
 
         let drop_procedures = format!(
             r#"

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/mysql.rs
@@ -76,7 +76,7 @@ impl MysqlFlavour {
             let shadow_conninfo = conn.connection_info();
             let main_conninfo = main_connection.connection_info();
 
-            super::validate_connection_infos_do_not_match((shadow_conninfo, main_conninfo))?;
+            super::validate_connection_infos_do_not_match((&shadow_conninfo, &main_conninfo))?;
 
             tracing::info!(
                 "Connecting to user-provided shadow database at {}.{:?}",
@@ -117,6 +117,15 @@ impl SqlFlavour for MysqlFlavour {
         // https://dev.mysql.com/doc/refman/8.0/en/locking-functions.html
         let query = format!("SELECT GET_LOCK('prisma_migrate', {})", ADVISORY_LOCK_TIMEOUT.as_secs());
         Ok(connection.raw_cmd(&query).await?)
+    }
+
+    async fn apply_migration_script(
+        &self,
+        migration_name: &str,
+        script: &str,
+        conn: &Connection,
+    ) -> ConnectorResult<()> {
+        super::generic_apply_migration_script(migration_name, script, conn).await
     }
 
     fn check_database_version_compatibility(
@@ -184,12 +193,12 @@ impl SqlFlavour for MysqlFlavour {
     }
 
     async fn describe_schema<'a>(&'a self, connection: &Connection) -> ConnectorResult<SqlSchema> {
-        sql_schema_describer::mysql::SqlSchemaDescriber::new(connection.quaint())
+        sql_schema_describer::mysql::SqlSchemaDescriber::new(connection.queryable())
             .describe(connection.connection_info().schema_name())
             .await
             .map_err(|err| match err.into_kind() {
                 DescriberErrorKind::QuaintError(err) => {
-                    quaint_error_to_connector_error(err, connection.connection_info())
+                    quaint_error_to_connector_error(err, &connection.connection_info())
                 }
                 DescriberErrorKind::CrossSchemaReference { .. } => {
                     unreachable!("No schemas in MySQL")
@@ -199,7 +208,8 @@ impl SqlFlavour for MysqlFlavour {
 
     async fn drop_database(&self, database_url: &str) -> ConnectorResult<()> {
         let connection = connect(database_url).await?;
-        let db_name = connection.connection_info().dbname().unwrap();
+        let connection_info = connection.connection_info();
+        let db_name = connection_info.dbname().unwrap();
 
         connection.raw_cmd(&format!("DROP DATABASE `{}`", db_name)).await?;
 
@@ -223,7 +233,7 @@ impl SqlFlavour for MysqlFlavour {
             .unwrap()
         });
 
-        let db_name = connection.connection_info().schema_name();
+        let db_name = connection.schema_name();
 
         if MYSQL_SYSTEM_DATABASES.is_match(db_name) {
             return Err(SystemDatabase(db_name.to_owned()).into());
@@ -297,7 +307,8 @@ impl SqlFlavour for MysqlFlavour {
             ));
         }
 
-        let db_name = connection.connection_info().dbname().unwrap();
+        let connection_info = connection.connection_info();
+        let db_name = connection_info.dbname().unwrap();
 
         connection.raw_cmd(&format!("DROP DATABASE `{}`", db_name)).await?;
         connection.raw_cmd(&format!("CREATE DATABASE `{}`", db_name)).await?;

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/sqlite.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/sqlite.rs
@@ -25,6 +25,15 @@ impl SqlFlavour for SqliteFlavour {
         Ok(())
     }
 
+    async fn apply_migration_script(
+        &self,
+        migration_name: &str,
+        script: &str,
+        conn: &Connection,
+    ) -> ConnectorResult<()> {
+        super::generic_apply_migration_script(migration_name, script, conn).await
+    }
+
     async fn create_database(&self, database_str: &str) -> ConnectorResult<String> {
         let path = Path::new(&self.file_path);
 
@@ -62,12 +71,12 @@ impl SqlFlavour for SqliteFlavour {
     }
 
     async fn describe_schema<'a>(&'a self, connection: &Connection) -> ConnectorResult<SqlSchema> {
-        sql_schema_describer::sqlite::SqlSchemaDescriber::new(connection.quaint())
+        sql_schema_describer::sqlite::SqlSchemaDescriber::new(connection.queryable())
             .describe(connection.connection_info().schema_name())
             .await
             .map_err(|err| match err.into_kind() {
                 DescriberErrorKind::QuaintError(err) => {
-                    quaint_error_to_connector_error(err, connection.connection_info())
+                    quaint_error_to_connector_error(err, &connection.connection_info())
                 }
                 DescriberErrorKind::CrossSchemaReference { .. } => {
                     unreachable!("No schemas in SQLite")
@@ -106,7 +115,8 @@ impl SqlFlavour for SqliteFlavour {
     }
 
     async fn reset(&self, connection: &Connection) -> ConnectorResult<()> {
-        let file_path = connection.connection_info().file_path().unwrap();
+        let connection_info = connection.connection_info();
+        let file_path = connection_info.file_path().unwrap();
 
         connection.raw_cmd("PRAGMA main.locking_mode=NORMAL").await?;
         connection.raw_cmd("PRAGMA main.quick_check").await?;
@@ -135,7 +145,7 @@ impl SqlFlavour for SqliteFlavour {
                 },
             )
         })?;
-        let conn = Connection::new(quaint);
+        let conn = Connection::new_generic(quaint);
 
         for migration in migrations {
             let script = migration.read_migration_script()?;

--- a/migration-engine/migration-engine-tests/src/multi_engine_test_api.rs
+++ b/migration-engine/migration-engine-tests/src/multi_engine_test_api.rs
@@ -247,12 +247,12 @@ impl EngineTestApi<'_> {
 
     /// The schema name of the current connected database.
     pub fn schema_name(&self) -> &str {
-        self.connector.quaint().connection_info().schema_name()
+        self.connector.schema_name()
     }
 
     /// Execute a raw SQL command and expect it to succeed.
     #[track_caller]
     pub fn raw_cmd(&self, cmd: &str) {
-        self.rt.block_on(self.connector.quaint().raw_cmd(cmd)).unwrap()
+        self.rt.block_on(self.connector.queryable().raw_cmd(cmd)).unwrap()
     }
 }

--- a/migration-engine/migration-engine-tests/src/test_api.rs
+++ b/migration-engine/migration-engine-tests/src/test_api.rs
@@ -24,10 +24,7 @@ pub use schema_push::SchemaPush;
 use crate::assertions::SchemaAssertion;
 use migration_connector::{ConnectorError, MigrationRecord};
 use migration_core::GenericApi;
-use quaint::{
-    prelude::{ConnectionInfo, Queryable, SqlFamily},
-    single::Quaint,
-};
+use quaint::prelude::{ConnectionInfo, Queryable, SqlFamily};
 use sql_migration_connector::SqlMigrationConnector;
 use std::{borrow::Cow, fmt::Write as _};
 use tempfile::TempDir;
@@ -88,7 +85,7 @@ impl TestApi {
 
         if tags.contains(Tags::Mysql) {
             let val = api
-                .quaint()
+                .queryable()
                 .query_raw("SELECT @@lower_case_table_names", &[])
                 .await
                 .ok()
@@ -109,11 +106,11 @@ impl TestApi {
     }
 
     pub fn schema_name(&self) -> &str {
-        self.connection_info().schema_name()
+        self.api.schema_name()
     }
 
-    pub fn database(&self) -> &Quaint {
-        self.api.quaint()
+    pub fn database(&self) -> &dyn Queryable {
+        self.api.queryable()
     }
 
     pub fn is_sqlite(&self) -> bool {
@@ -148,8 +145,8 @@ impl TestApi {
         self.tags().contains(Tags::Postgres)
     }
 
-    pub fn connection_info(&self) -> &ConnectionInfo {
-        self.database().connection_info()
+    pub fn connection_info(&self) -> ConnectionInfo {
+        self.api.connection_info()
     }
 
     pub fn sql_family(&self) -> SqlFamily {
@@ -169,7 +166,7 @@ impl TestApi {
         if self.is_sqlite() {
             table_name.into()
         } else {
-            (self.connection_info().schema_name(), table_name).into()
+            (self.api.schema_name(), table_name).into()
         }
     }
 

--- a/migration-engine/migration-engine-tests/tests/apply_migrations/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/apply_migrations/mod.rs
@@ -125,14 +125,19 @@ fn migrations_should_fail_when_the_script_is_invalid(api: TestApi) {
                 t if t.contains(Tags::Mariadb) => "You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near \'^.^)_n\' at line 1",
                 t if t.contains(Tags::Mysql) => "You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near \'^.^)_n\' at line 1",
                 t if t.contains(Tags::Mssql) => "Incorrect syntax near \'^\'.",
-                t if t.contains(Tags::Postgres) => "db error: ERROR: syntax error at or near \"^\"",
+                t if t.contains(Tags::Postgres) => "ERROR: syntax error at or near \"^\"",
                 t if t.contains(Tags::Sqlite) => "unrecognized token: \"^\"",
                 _ => todo!(),
             },
         );
 
         assert_eq!(error.error_code, ApplyMigrationError::ERROR_CODE);
-        assert_eq!(error.message, expected_error_message);
+        assert!(
+            error.message.starts_with(&expected_error_message),
+            "Actual:\n{}\n\nExpected:\n{}",
+            error.message,
+            expected_error_message
+        );
     }
 
     let mut migrations = api

--- a/migration-engine/migration-engine-tests/tests/migration_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migration_tests.rs
@@ -10,7 +10,6 @@ mod native_types;
 mod schema_push;
 
 use migration_engine_tests::sql::*;
-use quaint::prelude::Queryable;
 use sql_schema_describer::*;
 use test_macros::test_connector;
 

--- a/migration-engine/migration-engine-tests/tests/migrations/mssql.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/mssql.rs
@@ -2,7 +2,7 @@ use migration_engine_tests::sync_test_api::*;
 
 #[test_connector(tags(Mssql))]
 fn shared_default_constraints_are_ignored_issue_5423(api: TestApi) {
-    let schema = api.connection_info().schema_name();
+    let schema = api.schema_name();
 
     api.raw_cmd(&format!("CREATE DEFAULT [{}].catcat AS 'musti'", schema));
 

--- a/migration-engine/migration-engine-tests/tests/migrations/shadow_database_url_configuration.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/shadow_database_url_configuration.rs
@@ -2,6 +2,7 @@ use expect_test::expect;
 use migration_engine_tests::multi_engine_test_api::*;
 use quaint::{prelude::Queryable, single::Quaint};
 use test_macros::test_connector;
+use user_facing_errors::UserFacingError;
 
 #[test_connector(tags(Postgres))]
 fn shadow_db_url_can_be_configured_on_postgres(api: TestApi) {
@@ -170,24 +171,14 @@ fn shadow_db_not_reachable_error_must_have_the_right_connection_info(api: TestAp
         .to_user_facing();
 
     let assertion = expect![[r#"
-        Error {
-            is_panic: false,
-            inner: Known(
-                KnownError {
-                    message: "Can\'t reach database server at `localhost`:`39824`\n\nPlease make sure your database server is running at `localhost`:`39824`.",
-                    meta: Object({
-                        "database_host": String(
-                            "localhost",
-                        ),
-                        "database_port": Number(
-                            39824,
-                        ),
-                    }),
-                    error_code: "P1001",
-                },
-            ),
-        }
-    "#]];
+        Can't reach database server at `localhost`:`39824`
 
-    assertion.assert_debug_eq(&err);
+        Please make sure your database server is running at `localhost`:`39824`."#]];
+
+    assertion.assert_eq(err.message());
+
+    assert_eq!(
+        err.unwrap_known().error_code,
+        user_facing_errors::common::DatabaseNotReachable::ERROR_CODE
+    );
 }

--- a/migration-engine/migration-engine-tests/tests/native_types/mssql.rs
+++ b/migration-engine/migration-engine-tests/tests/native_types/mssql.rs
@@ -1918,7 +1918,7 @@ fn safe_casts_with_existing_data_should_work(api: TestApi) {
 
             api.schema_push(&dm1).send_sync().assert_green_bang();
 
-            let insert = Insert::single_into((api.connection_info().schema_name(), "A")).value("x", seed.clone());
+            let insert = Insert::single_into((api.schema_name(), "A")).value("x", seed.clone());
             api.query(insert.into());
 
             api.assert_schema().assert_table("A", |table| {
@@ -1953,7 +1953,7 @@ fn safe_casts_with_existing_data_should_work(api: TestApi) {
                 })
             });
 
-            api.raw_cmd(&format!("DROP TABLE [{}].[A]", api.connection_info().schema_name()));
+            api.raw_cmd(&format!("DROP TABLE [{}].[A]", api.schema_name()));
         }
     }
 }
@@ -1982,7 +1982,7 @@ fn risky_casts_with_existing_data_should_warn(api: TestApi) {
 
             api.schema_push(&dm1).send_sync().assert_green_bang();
 
-            let insert = Insert::single_into((api.connection_info().schema_name(), "A")).value("x", seed.clone());
+            let insert = Insert::single_into((api.schema_name(), "A")).value("x", seed.clone());
             api.query(insert.into());
 
             api.assert_schema().assert_table("A", |table| {
@@ -2023,7 +2023,7 @@ fn risky_casts_with_existing_data_should_warn(api: TestApi) {
                 })
             });
 
-            api.raw_cmd(&format!("DROP TABLE [{}].[A]", api.connection_info().schema_name()));
+            api.raw_cmd(&format!("DROP TABLE [{}].[A]", api.schema_name()));
         }
     }
 }
@@ -2055,7 +2055,7 @@ fn not_castable_with_existing_data_should_warn(api: TestApi) {
 
             api.schema_push(&dm1).send_sync().assert_green_bang();
 
-            let insert = Insert::single_into((api.connection_info().schema_name(), "A")).value("x", seed.clone());
+            let insert = Insert::single_into((api.schema_name(), "A")).value("x", seed.clone());
             api.query(insert.into());
 
             api.assert_schema().assert_table("A", |table| {
@@ -2092,7 +2092,7 @@ fn not_castable_with_existing_data_should_warn(api: TestApi) {
                 })
             });
 
-            api.raw_cmd(&format!("DROP TABLE [{}].[A]", api.connection_info().schema_name()));
+            api.raw_cmd(&format!("DROP TABLE [{}].[A]", api.schema_name()));
         }
     }
 }

--- a/migration-engine/migration-engine-tests/tests/native_types/postgres.rs
+++ b/migration-engine/migration-engine-tests/tests/native_types/postgres.rs
@@ -780,7 +780,7 @@ fn safe_casts_with_existing_data_should_work(api: TestApi) {
 
         let mut previous_columns = "".to_string();
         let mut next_columns = "".to_string();
-        let mut insert = Insert::single_into((api.connection_info().schema_name(), "A"));
+        let mut insert = Insert::single_into((api.schema_name(), "A"));
         let mut previous_assertions = vec![];
         let mut next_assertions = vec![];
 
@@ -862,7 +862,7 @@ fn safe_casts_with_existing_data_should_work(api: TestApi) {
             )
         });
 
-        api.raw_cmd(&format!("DROP TABLE \"{}\".\"A\"", api.connection_info().schema_name()));
+        api.raw_cmd(&format!("DROP TABLE \"{}\".\"A\"", api.schema_name()));
     }
 }
 
@@ -874,7 +874,7 @@ fn risky_casts_with_existing_data_should_warn(api: TestApi) {
     for (from, seed, casts) in RISKY_CASTS.iter() {
         let mut previous_columns = "".to_string();
         let mut next_columns = "".to_string();
-        let mut insert = Insert::single_into((api.connection_info().schema_name(), "A"));
+        let mut insert = Insert::single_into((api.schema_name(), "A"));
         let mut previous_assertions = vec![];
         let mut next_assertions = vec![];
         let mut warnings = vec![];
@@ -965,7 +965,7 @@ fn risky_casts_with_existing_data_should_warn(api: TestApi) {
             )
         });
 
-        api.raw_cmd(&format!("DROP TABLE \"{}\".\"A\"", api.connection_info().schema_name()));
+        api.raw_cmd(&format!("DROP TABLE \"{}\".\"A\"", api.schema_name()));
     }
 }
 
@@ -978,7 +978,7 @@ fn not_castable_with_existing_data_should_warn(api: TestApi) {
     for (from, seed, casts) in NOT_CASTABLE.iter() {
         let mut previous_columns = "".to_string();
         let mut next_columns = "".to_string();
-        let mut insert = Insert::single_into((api.connection_info().schema_name(), "A"));
+        let mut insert = Insert::single_into((api.schema_name(), "A"));
         let mut previous_assertions = vec![];
         warnings.clear();
 
@@ -1072,7 +1072,7 @@ fn not_castable_with_existing_data_should_warn(api: TestApi) {
             )
         });
 
-        api.raw_cmd(&format!("DROP TABLE \"{}\".\"A\"", api.connection_info().schema_name()));
+        api.raw_cmd(&format!("DROP TABLE \"{}\".\"A\"", api.schema_name()));
     }
 }
 
@@ -1170,7 +1170,7 @@ fn safe_casts_from_array_with_existing_data_should_work(api: TestApi) {
     for (to, from) in SAFE_CASTS_NON_LIST_TO_STRING.iter() {
         let mut previous_columns = "".to_string();
         let mut next_columns = "".to_string();
-        let mut insert = Insert::single_into((api.connection_info().schema_name(), "A"));
+        let mut insert = Insert::single_into((api.schema_name(), "A"));
         let mut previous_assertions = vec![];
         let mut next_assertions = vec![];
 
@@ -1250,7 +1250,7 @@ fn safe_casts_from_array_with_existing_data_should_work(api: TestApi) {
             )
         });
 
-        api.raw_cmd(&format!("DROP TABLE \"{}\".\"A\"", api.connection_info().schema_name()));
+        api.raw_cmd(&format!("DROP TABLE \"{}\".\"A\"", api.schema_name()));
     }
 }
 

--- a/query-engine/query-engine/src/tests/test_api.rs
+++ b/query-engine/query-engine/src/tests/test_api.rs
@@ -81,8 +81,8 @@ impl TestApi {
         })
     }
 
-    pub fn connection_info(&self) -> &ConnectionInfo {
-        self.migration_api.quaint().connection_info()
+    pub fn connection_info(&self) -> ConnectionInfo {
+        self.migration_api.connection_info()
     }
 
     pub fn to_sql_string<'a>(&'a self, query: impl Into<Query<'a>>) -> quaint::Result<(String, Vec<Value>)> {
@@ -96,7 +96,7 @@ impl TestApi {
 
     pub fn table_name<'a>(&'a self, name: &'a str) -> quaint::ast::Table<'a> {
         match self.connection_info() {
-            ConnectionInfo::Mssql(url) => (url.schema(), name).into(),
+            ConnectionInfo::Mssql(_url) => (self.migration_api.schema_name(), name).into(),
             _ => name.into(),
         }
     }


### PR DESCRIPTION
A lot of this commit is about taking advantage of
prisma/quaint#301 to gain access to the
underlying database driver in sql-migration-connector.

Rebased and dependent on https://github.com/prisma/prisma-engines/pull/2025