### PR TITLE
ci: MacOS ARM64 (Apple Silicon) engines build

### DIFF
--- a/.github/workflows/build-apple-silicon.yml
+++ b/.github/workflows/build-apple-silicon.yml
@@ -64,3 +64,4 @@ jobs:
             ${{ github.workspace }}/target/aarch64-apple-darwin/release/prisma-fmt
             ${{ github.workspace }}/target/aarch64-apple-darwin/release/query-engine
             ${{ github.workspace }}/target/aarch64-apple-darwin/release/libquery_engine_napi.dylib
+

--- a/.github/workflows/build-apple-silicon.yml
+++ b/.github/workflows/build-apple-silicon.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: latest
+          toolchain: stable
           default: true
 
       - name: Install aarch64 toolchain

--- a/.github/workflows/build-apple-silicon.yml
+++ b/.github/workflows/build-apple-silicon.yml
@@ -61,7 +61,5 @@ jobs:
         with:
           name: binaries
           path: |
-            ${{ github.workspace }}/target/release/build/query-engine*
-            ${{ github.workspace }}/target/release/build/migration-engine-cli*
-            ${{ github.workspace }}/target/release/build/introspection-core*
-            ${{ github.workspace }}/target/release/build/prisma-fmt*
+            ${{ github.workspace }}/target/release/*
+

--- a/.github/workflows/build-apple-silicon.yml
+++ b/.github/workflows/build-apple-silicon.yml
@@ -11,7 +11,8 @@ jobs:
     env:
       SQLITE_MAX_VARIABLE_NUMBER: 250000
       SQLITE_MAX_EXPR_DEPTH: 10000
-    runs-on: macos-latest
+    runs-on: macos-11.0
+    
     steps:
       - name: Output link to real commit
         run: echo ${{ github.repository }}/commit/${{ github.event.inputs.commit }}

--- a/.github/workflows/build-apple-silicon.yml
+++ b/.github/workflows/build-apple-silicon.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.48.0
+          toolchain: latest
           default: true
 
       - name: Install aarch64 toolchain

--- a/.github/workflows/build-apple-silicon.yml
+++ b/.github/workflows/build-apple-silicon.yml
@@ -61,7 +61,5 @@ jobs:
         with:
           name: binaries
           path: |
-            ${{ github.workspace }}/target/release/*
-  
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
+            ${{ github.workspace }}/target/aarch64-apple-darwin/release/*
+

--- a/.github/workflows/build-apple-silicon.yml
+++ b/.github/workflows/build-apple-silicon.yml
@@ -4,7 +4,7 @@ on:
     inputs:
       commit:
         description: "Commit on the given branch to build"
-        required: true
+        required: false
 
 jobs:
   build:

--- a/.github/workflows/build-apple-silicon.yml
+++ b/.github/workflows/build-apple-silicon.yml
@@ -40,10 +40,13 @@ jobs:
 
       - run: xcodebuild -showsdks
       - run: ls /Library/Developer/CommandLineTools/SDKs/
-      
+      - run: sudo rm -Rf /Library/Developer/CommandLineTools/SDKs/*;
+
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: latest-stable
+
+      - run: ls /Library/Developer/CommandLineTools/SDKs/
 
       - run: | 
           SDKROOT=$(xcrun -sdk macosx11.1 --show-sdk-path)

--- a/.github/workflows/build-apple-silicon.yml
+++ b/.github/workflows/build-apple-silicon.yml
@@ -40,15 +40,16 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - run: xcodebuild -showsdks
-      - run: ls /Library/Developer/CommandLineTools/SDKs/
+
+      # Remove Xcode Command Line Tools so old version can not be used in build
       - run: sudo rm -Rf /Library/Developer/CommandLineTools/SDKs/*;
 
+      # Activate newest available Xcode
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: latest-stable
 
-      - run: ls /Library/Developer/CommandLineTools/SDKs/
-
+      # Build with fancy params via https://github.com/shepmaster/rust/blob/silicon/silicon/README.md
       - run: | 
           SDKROOT=$(xcrun -sdk macosx11.1 --show-sdk-path)
           MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.1 --show-sdk-platform-version)
@@ -56,9 +57,11 @@ jobs:
 
       - run: ls ${{ github.workspace }}/target/release/build/
       
-#      - uses: actions/upload-artifact@v2
-#        with:
-#          name: binaries
-#          path: |
-#            ${{ github.workspace }}/target/release/*.exe
-#            ${{ github.workspace }}/target/release/*.dll
+      - uses: actions/upload-artifact@v2
+        with:
+          name: binaries
+          path: |
+            ${{ github.workspace }}/target/release/build/query-engine*
+            ${{ github.workspace }}/target/release/build/migration-engine-cli*
+            ${{ github.workspace }}/target/release/build/introspection-core*
+            ${{ github.workspace }}/target/release/build/prisma-fmt*

--- a/.github/workflows/build-apple-silicon.yml
+++ b/.github/workflows/build-apple-silicon.yml
@@ -41,9 +41,9 @@ jobs:
       - run: xcodebuild -showsdks
       - run: ls /Library/Developer/CommandLineTools/SDKs/
       
-      - run: |
-          sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer
-          sudo xcodebuild -runFirstLaunch
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
 
       - run: | 
           SDKROOT=$(xcrun -sdk macosx11.1 --show-sdk-path)

--- a/.github/workflows/build-apple-silicon.yml
+++ b/.github/workflows/build-apple-silicon.yml
@@ -41,7 +41,7 @@ jobs:
 
       - run: xcodebuild -showsdks
 
-      # Remove Xcode Command Line Tools so old version can not be used in build
+      # Remove Xcode Command Line Tools so old version can not be used in build via https://github.com/prisma/prisma/issues/5245#issuecomment-864356168
       - run: sudo rm -Rf /Library/Developer/CommandLineTools/SDKs/*;
 
       # Activate newest available Xcode

--- a/.github/workflows/build-apple-silicon.yml
+++ b/.github/workflows/build-apple-silicon.yml
@@ -61,5 +61,9 @@ jobs:
         with:
           name: binaries
           path: |
-            ${{ github.workspace }}/target/aarch64-apple-darwin/release/*
+            ${{ github.workspace }}/target/aarch64-apple-darwin/release/introspection-engine
+            ${{ github.workspace }}/target/aarch64-apple-darwin/release/migration-engine
+            ${{ github.workspace }}/target/aarch64-apple-darwin/release/prisma-fmt
+            ${{ github.workspace }}/target/aarch64-apple-darwin/release/query-engine
+            ${{ github.workspace }}/target/aarch64-apple-darwin/release/libquery_engine_napi.dylib
 

--- a/.github/workflows/build-apple-silicon.yml
+++ b/.github/workflows/build-apple-silicon.yml
@@ -41,6 +41,10 @@ jobs:
       - run: xcodebuild -showsdks
       - run: ls /Library/Developer/CommandLineTools/SDKs/
       
+      - run: |
+          sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer
+          sudo xcodebuild -runFirstLaunch
+
       - run: | 
           SDKROOT=$(xcrun -sdk macosx11.1 --show-sdk-path)
           MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.1 --show-sdk-platform-version)

--- a/.github/workflows/build-apple-silicon.yml
+++ b/.github/workflows/build-apple-silicon.yml
@@ -39,8 +39,8 @@ jobs:
 #          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - run: xcodebuild -showsdks
-      - run: SDKROOT=$(xcrun -sdk macosx11.0 --show-sdk-path) \
-              MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.0 --show-sdk-platform-version) \
+      - run: SDKROOT=$(xcrun -sdk macosx11.1 --show-sdk-path) \
+              MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.1 --show-sdk-platform-version) \
               cargo build --target=aarch64-apple-darwin --release
 
       - run: ls ${{ github.workspace }}/target/release/

--- a/.github/workflows/build-apple-silicon.yml
+++ b/.github/workflows/build-apple-silicon.yml
@@ -62,4 +62,6 @@ jobs:
           name: binaries
           path: |
             ${{ github.workspace }}/target/release/*
-
+  
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/build-apple-silicon.yml
+++ b/.github/workflows/build-apple-silicon.yml
@@ -39,6 +39,7 @@ jobs:
 #          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - run: xcodebuild -showsdks
+      - run: ls /Library/Developer/CommandLineTools/SDKs/
       
       - run: | 
           SDKROOT=$(xcrun -sdk macosx11.1 --show-sdk-path)

--- a/.github/workflows/build-apple-silicon.yml
+++ b/.github/workflows/build-apple-silicon.yml
@@ -1,0 +1,52 @@
+on:
+  workflow_dispatch:
+    inputs:
+      commit:
+        description: "Commit on the given branch to build"
+        required: true
+
+jobs:
+  build:
+    name: "MacOS ARM64 (Apple Silicon) engines build on branch ${{ github.event.ref }} for commit ${{ github.event.inputs.commit }}"
+    env:
+      SQLITE_MAX_VARIABLE_NUMBER: 250000
+      SQLITE_MAX_EXPR_DEPTH: 10000
+    runs-on: macos-latest
+    steps:
+      - name: Output link to real commit
+        run: echo ${{ github.repository }}/commit/${{ github.event.inputs.commit }}
+
+      - name: Checkout ${{ github.event.inputs.commit }}
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.commit }}
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.48.0
+          default: true
+
+      - name: Install aarch64 toolchain
+        run: rustup target add aarch64-apple-darwin
+        
+#      - uses: actions/cache@v2
+#        with:
+#          path: |
+#            ~/.cargo/registry
+#            ~/.cargo/git
+#            target
+#          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --target=aarch64-apple-darwin --release
+
+      - run: ls ${{ github.workspace }}/target/release/
+      
+#      - uses: actions/upload-artifact@v2
+#        with:
+#          name: binaries
+#          path: |
+#            ${{ github.workspace }}/target/release/*.exe
+#            ${{ github.workspace }}/target/release/*.dll

--- a/.github/workflows/build-apple-silicon.yml
+++ b/.github/workflows/build-apple-silicon.yml
@@ -11,7 +11,7 @@ jobs:
     env:
       SQLITE_MAX_VARIABLE_NUMBER: 250000
       SQLITE_MAX_EXPR_DEPTH: 10000
-    runs-on: macos-11.0
+    runs-on: macos-latest
     
     steps:
       - name: Output link to real commit
@@ -38,9 +38,10 @@ jobs:
 #            target
 #          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
+      - run: xcodebuild -showsdks
       - run: SDKROOT=$(xcrun -sdk macosx11.0 --show-sdk-path) \
               MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.0 --show-sdk-platform-version) \
-              cargo build  --target=aarch64-apple-darwin --release
+              cargo build --target=aarch64-apple-darwin --release
 
       - run: ls ${{ github.workspace }}/target/release/
       

--- a/.github/workflows/build-apple-silicon.yml
+++ b/.github/workflows/build-apple-silicon.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    name: "MacOS ARM64 (Apple Silicon) engines build on branch ${{ github.event.ref }} for commit ${{ github.event.inputs.commit }}"
+    name: "MacOS ARM64 (Apple Silicon) engines build on branch ${{ github.event.ref }} (for commit ${{ github.event.inputs.commit }})"
     env:
       SQLITE_MAX_VARIABLE_NUMBER: 250000
       SQLITE_MAX_EXPR_DEPTH: 10000
@@ -31,13 +31,13 @@ jobs:
       - name: Install aarch64 toolchain
         run: rustup target add aarch64-apple-darwin
         
-#      - uses: actions/cache@v2
-#        with:
-#          path: |
-#            ~/.cargo/registry
-#            ~/.cargo/git
-#            target
-#          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - run: xcodebuild -showsdks
       - run: ls /Library/Developer/CommandLineTools/SDKs/

--- a/.github/workflows/build-apple-silicon.yml
+++ b/.github/workflows/build-apple-silicon.yml
@@ -37,10 +37,9 @@ jobs:
 #            target
 #          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --target=aarch64-apple-darwin --release
+      - run: SDKROOT=$(xcrun -sdk macosx11.0 --show-sdk-path) \
+              MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.0 --show-sdk-platform-version) \
+              cargo build  --target=aarch64-apple-darwin --release
 
       - run: ls ${{ github.workspace }}/target/release/
       

--- a/.github/workflows/build-apple-silicon.yml
+++ b/.github/workflows/build-apple-silicon.yml
@@ -54,8 +54,6 @@ jobs:
           SDKROOT=$(xcrun -sdk macosx11.1 --show-sdk-path)
           MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.1 --show-sdk-platform-version)
           cargo build --target=aarch64-apple-darwin --release
-
-      - run: ls ${{ github.workspace }}/target/release/build/
       
       - uses: actions/upload-artifact@v2
         with:
@@ -66,4 +64,3 @@ jobs:
             ${{ github.workspace }}/target/aarch64-apple-darwin/release/prisma-fmt
             ${{ github.workspace }}/target/aarch64-apple-darwin/release/query-engine
             ${{ github.workspace }}/target/aarch64-apple-darwin/release/libquery_engine_napi.dylib
-

--- a/.github/workflows/build-apple-silicon.yml
+++ b/.github/workflows/build-apple-silicon.yml
@@ -1,4 +1,5 @@
 on:
+  push:
   workflow_dispatch:
     inputs:
       commit:
@@ -53,7 +54,7 @@ jobs:
           MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.1 --show-sdk-platform-version)
           cargo build --target=aarch64-apple-darwin --release
 
-      - run: ls ${{ github.workspace }}/target/release/
+      - run: ls ${{ github.workspace }}/target/release/build/
       
 #      - uses: actions/upload-artifact@v2
 #        with:

--- a/.github/workflows/build-apple-silicon.yml
+++ b/.github/workflows/build-apple-silicon.yml
@@ -39,9 +39,11 @@ jobs:
 #          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - run: xcodebuild -showsdks
-      - run: SDKROOT=$(xcrun -sdk macosx11.1 --show-sdk-path) \
-              MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.1 --show-sdk-platform-version) \
-              cargo build --target=aarch64-apple-darwin --release
+      
+      - run: | 
+          SDKROOT=$(xcrun -sdk macosx11.1 --show-sdk-path)
+          MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.1 --show-sdk-platform-version)
+          cargo build --target=aarch64-apple-darwin --release
 
       - run: ls ${{ github.workspace }}/target/release/
       


### PR DESCRIPTION
This PR adds a GH Actions workflow for a "MacOS ARM64 (Apple Silicon) engines build". The workflow is modelled after the Windows one, so it can be triggered and used in the same way from `engineer`.