### PR TITLE
Collapse dml::FieldType::{Base, NativeType}

### DIFF
--- a/introspection-engine/connectors/sql-introspection-connector/src/calculate_datamodel.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/calculate_datamodel.rs
@@ -83,12 +83,12 @@ mod tests {
                     Field::ScalarField(ScalarField::new(
                         "optional",
                         FieldArity::Optional,
-                        FieldType::Base(ScalarType::Int, None),
+                        FieldType::Scalar(ScalarType::Int, None, None),
                     )),
                     Field::ScalarField(ScalarField {
                         name: "required".to_string(),
                         arity: FieldArity::Required,
-                        field_type: FieldType::Base(ScalarType::Int, None),
+                        field_type: FieldType::Scalar(ScalarType::Int, None, None),
                         database_name: None,
                         default_value: Some(DMLDefault::Expression(ValueGenerator::new_autoincrement())),
                         is_unique: false,
@@ -102,7 +102,7 @@ mod tests {
                     Field::ScalarField(ScalarField::new(
                         "list",
                         FieldArity::List,
-                        FieldType::Base(ScalarType::Int, None),
+                        FieldType::Scalar(ScalarType::Int, None, None),
                     )),
                 ],
                 is_generated: false,
@@ -170,13 +170,14 @@ mod tests {
                     fields: vec![Field::ScalarField(ScalarField {
                         name: "primary".to_string(),
                         arity: FieldArity::Required,
-                        field_type: FieldType::NativeType(
+                        field_type: FieldType::Scalar(
                             ScalarType::Int,
-                            NativeTypeInstance {
+                            None,
+                            Some(NativeTypeInstance {
                                 name: "Integer".into(),
                                 serialized_native_type: PostgresType::Integer.to_json(),
                                 args: Vec::new(),
-                            },
+                            }),
                         ),
                         database_name: None,
                         default_value: Some(DMLDefault::Expression(ValueGenerator::new_autoincrement())),
@@ -203,13 +204,14 @@ mod tests {
                     fields: vec![Field::ScalarField(ScalarField {
                         name: "primary".to_string(),
                         arity: FieldArity::Required,
-                        field_type: FieldType::NativeType(
+                        field_type: FieldType::Scalar(
                             ScalarType::Int,
-                            NativeTypeInstance {
+                            None,
+                            Some(NativeTypeInstance {
                                 name: "Integer".into(),
                                 serialized_native_type: PostgresType::Integer.to_json(),
                                 args: Vec::new(),
-                            },
+                            }),
                         ),
                         database_name: None,
                         default_value: None,
@@ -236,13 +238,14 @@ mod tests {
                     fields: vec![Field::ScalarField(ScalarField {
                         name: "primary".to_string(),
                         arity: FieldArity::Required,
-                        field_type: FieldType::NativeType(
+                        field_type: FieldType::Scalar(
                             ScalarType::Int,
-                            NativeTypeInstance {
+                            None,
+                            Some(NativeTypeInstance {
                                 name: "Integer".into(),
                                 serialized_native_type: PostgresType::Integer.to_json(),
                                 args: Vec::new(),
-                            },
+                            }),
                         ),
                         database_name: None,
                         default_value: Some(DMLDefault::Expression(ValueGenerator::new_autoincrement())),
@@ -356,12 +359,12 @@ mod tests {
                     Field::ScalarField(ScalarField::new(
                         "non_unique",
                         FieldArity::Optional,
-                        FieldType::Base(ScalarType::Int, None),
+                        FieldType::Scalar(ScalarType::Int, None, None),
                     )),
                     Field::ScalarField(ScalarField {
                         name: "unique".to_string(),
                         arity: FieldArity::Required,
-                        field_type: FieldType::Base(ScalarType::Int, None),
+                        field_type: FieldType::Scalar(ScalarType::Int, None, None),
                         database_name: None,
                         default_value: None,
                         is_unique: true,
@@ -432,13 +435,14 @@ mod tests {
                         Field::ScalarField(ScalarField {
                             name: "id".to_string(),
                             arity: FieldArity::Required,
-                            field_type: FieldType::NativeType(
+                            field_type: FieldType::Scalar(
                                 ScalarType::Int,
-                                NativeTypeInstance {
+                                None,
+                                Some(NativeTypeInstance {
                                     name: "Integer".into(),
                                     serialized_native_type: PostgresType::Integer.to_json(),
                                     args: Vec::new(),
-                                },
+                                }),
                             ),
                             database_name: None,
                             default_value: Some(DMLDefault::Expression(ValueGenerator::new_autoincrement())),
@@ -453,13 +457,14 @@ mod tests {
                         Field::ScalarField(ScalarField::new(
                             "name",
                             FieldArity::Required,
-                            FieldType::NativeType(
+                            FieldType::Scalar(
                                 ScalarType::String,
-                                NativeTypeInstance {
+                                None,
+                                Some(NativeTypeInstance {
                                     name: "Text".into(),
                                     args: Vec::new(),
                                     serialized_native_type: PostgresType::Text.to_json(),
-                                },
+                                }),
                             ),
                         )),
                         Field::RelationField(RelationField::new(
@@ -489,13 +494,14 @@ mod tests {
                         Field::ScalarField(ScalarField {
                             name: "id".to_string(),
                             arity: FieldArity::Required,
-                            field_type: FieldType::NativeType(
+                            field_type: FieldType::Scalar(
                                 ScalarType::Int,
-                                NativeTypeInstance {
+                                None,
+                                Some(NativeTypeInstance {
                                     name: "Integer".into(),
                                     serialized_native_type: PostgresType::Integer.to_json(),
                                     args: Vec::new(),
-                                },
+                                }),
                             ),
                             database_name: None,
                             default_value: Some(DMLDefault::Expression(ValueGenerator::new_autoincrement())),
@@ -510,13 +516,14 @@ mod tests {
                         Field::ScalarField(ScalarField {
                             name: "city_id".to_string(),
                             arity: FieldArity::Required,
-                            field_type: FieldType::NativeType(
+                            field_type: FieldType::Scalar(
                                 ScalarType::Int,
-                                NativeTypeInstance {
+                                None,
+                                Some(NativeTypeInstance {
                                     name: "Integer".into(),
                                     serialized_native_type: PostgresType::Integer.to_json(),
                                     args: Vec::new(),
-                                },
+                                }),
                             ),
                             database_name: Some("city-id".to_string()),
                             default_value: None,
@@ -530,13 +537,14 @@ mod tests {
                         }),
                         Field::ScalarField(ScalarField {
                             name: "city_name".to_string(),
-                            field_type: FieldType::NativeType(
+                            field_type: FieldType::Scalar(
                                 ScalarType::String,
-                                NativeTypeInstance {
+                                None,
+                                Some(NativeTypeInstance {
                                     name: "Text".into(),
                                     args: Vec::new(),
                                     serialized_native_type: PostgresType::Text.to_json(),
-                                },
+                                }),
                             ),
                             arity: FieldArity::Required,
                             database_name: Some("city-name".to_string()),
@@ -685,13 +693,14 @@ mod tests {
                     Field::ScalarField(ScalarField {
                         name: "id".to_string(),
                         arity: FieldArity::Required,
-                        field_type: FieldType::NativeType(
+                        field_type: FieldType::Scalar(
                             ScalarType::Int,
-                            NativeTypeInstance {
+                            None,
+                            Some(NativeTypeInstance {
                                 name: "Integer".into(),
                                 serialized_native_type: PostgresType::Integer.to_json(),
                                 args: Vec::new(),
-                            },
+                            }),
                         ),
                         database_name: None,
                         default_value: Some(DMLDefault::Expression(ValueGenerator::new_autoincrement())),
@@ -706,25 +715,27 @@ mod tests {
                     Field::ScalarField(ScalarField::new(
                         "name",
                         FieldArity::Required,
-                        FieldType::NativeType(
+                        FieldType::Scalar(
                             ScalarType::String,
-                            NativeTypeInstance {
+                            None,
+                            Some(NativeTypeInstance {
                                 name: "Text".into(),
                                 args: Vec::new(),
                                 serialized_native_type: PostgresType::Text.to_json(),
-                            },
+                            }),
                         ),
                     )),
                     Field::ScalarField(ScalarField::new(
                         "lastname",
                         FieldArity::Required,
-                        FieldType::NativeType(
+                        FieldType::Scalar(
                             ScalarType::String,
-                            NativeTypeInstance {
+                            None,
+                            Some(NativeTypeInstance {
                                 name: "Text".into(),
                                 args: Vec::new(),
                                 serialized_native_type: PostgresType::Text.to_json(),
-                            },
+                            }),
                         ),
                     )),
                 ],
@@ -816,13 +827,14 @@ mod tests {
                         Field::ScalarField(ScalarField {
                             name: "id".to_string(),
                             arity: FieldArity::Required,
-                            field_type: FieldType::NativeType(
+                            field_type: FieldType::Scalar(
                                 ScalarType::Int,
-                                NativeTypeInstance {
+                                None,
+                                Some(NativeTypeInstance {
                                     name: "Integer".into(),
                                     serialized_native_type: PostgresType::Integer.to_json(),
                                     args: Vec::new(),
-                                },
+                                }),
                             ),
                             database_name: None,
                             default_value: Some(DMLDefault::Expression(ValueGenerator::new_autoincrement())),
@@ -837,13 +849,14 @@ mod tests {
                         Field::ScalarField(ScalarField::new(
                             "name",
                             FieldArity::Required,
-                            FieldType::NativeType(
+                            FieldType::Scalar(
                                 ScalarType::String,
-                                NativeTypeInstance {
+                                None,
+                                Some(NativeTypeInstance {
                                     name: "Text".into(),
                                     args: Vec::new(),
                                     serialized_native_type: PostgresType::Text.to_json(),
-                                },
+                                }),
                             ),
                         )),
                         Field::RelationField(RelationField::new(
@@ -873,13 +886,14 @@ mod tests {
                         Field::ScalarField(ScalarField {
                             name: "id".to_string(),
                             arity: FieldArity::Required,
-                            field_type: FieldType::NativeType(
+                            field_type: FieldType::Scalar(
                                 ScalarType::Int,
-                                NativeTypeInstance {
+                                None,
+                                Some(NativeTypeInstance {
                                     name: "Integer".into(),
                                     serialized_native_type: PostgresType::Integer.to_json(),
                                     args: Vec::new(),
-                                },
+                                }),
                             ),
                             database_name: None,
                             default_value: Some(DMLDefault::Expression(ValueGenerator::new_autoincrement())),
@@ -894,13 +908,14 @@ mod tests {
                         Field::ScalarField(ScalarField::new(
                             "city_id",
                             FieldArity::Required,
-                            FieldType::NativeType(
+                            FieldType::Scalar(
                                 ScalarType::Int,
-                                NativeTypeInstance {
+                                None,
+                                Some(NativeTypeInstance {
                                     name: "Integer".into(),
                                     serialized_native_type: PostgresType::Integer.to_json(),
                                     args: Vec::new(),
-                                },
+                                }),
                             ),
                         )),
                         Field::RelationField(RelationField::new(

--- a/introspection-engine/connectors/sql-introspection-connector/src/introspection_helpers.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/introspection_helpers.rs
@@ -318,16 +318,16 @@ pub(crate) fn calculate_scalar_field_type_for_native_type(column: &Column) -> Fi
     let fdt = column.tpe.full_data_type.to_owned();
 
     match &column.tpe.family {
-        ColumnTypeFamily::Int => FieldType::Base(ScalarType::Int, None),
-        ColumnTypeFamily::BigInt => FieldType::Base(ScalarType::BigInt, None),
-        ColumnTypeFamily::Float => FieldType::Base(ScalarType::Float, None),
-        ColumnTypeFamily::Decimal => FieldType::Base(ScalarType::Decimal, None),
-        ColumnTypeFamily::Boolean => FieldType::Base(ScalarType::Boolean, None),
-        ColumnTypeFamily::String => FieldType::Base(ScalarType::String, None),
-        ColumnTypeFamily::DateTime => FieldType::Base(ScalarType::DateTime, None),
-        ColumnTypeFamily::Json => FieldType::Base(ScalarType::Json, None),
-        ColumnTypeFamily::Uuid => FieldType::Base(ScalarType::String, None),
-        ColumnTypeFamily::Binary => FieldType::Base(ScalarType::Bytes, None),
+        ColumnTypeFamily::Int => FieldType::Scalar(ScalarType::Int, None, None),
+        ColumnTypeFamily::BigInt => FieldType::Scalar(ScalarType::BigInt, None, None),
+        ColumnTypeFamily::Float => FieldType::Scalar(ScalarType::Float, None, None),
+        ColumnTypeFamily::Decimal => FieldType::Scalar(ScalarType::Decimal, None, None),
+        ColumnTypeFamily::Boolean => FieldType::Scalar(ScalarType::Boolean, None, None),
+        ColumnTypeFamily::String => FieldType::Scalar(ScalarType::String, None, None),
+        ColumnTypeFamily::DateTime => FieldType::Scalar(ScalarType::DateTime, None, None),
+        ColumnTypeFamily::Json => FieldType::Scalar(ScalarType::Json, None, None),
+        ColumnTypeFamily::Uuid => FieldType::Scalar(ScalarType::String, None, None),
+        ColumnTypeFamily::Binary => FieldType::Scalar(ScalarType::Bytes, None, None),
         ColumnTypeFamily::Enum(name) => FieldType::Enum(name.to_owned()),
         ColumnTypeFamily::Unsupported(_) => FieldType::Unsupported(fdt),
     }
@@ -346,11 +346,11 @@ pub(crate) fn calculate_scalar_field_type_with_native_types(column: &Column, fam
     };
 
     match scalar_type {
-        FieldType::Base(scal_type, _) => match &column.tpe.native_type {
+        FieldType::Scalar(scal_type, _, _) => match &column.tpe.native_type {
             None => scalar_type,
             Some(native_type) => {
                 let native_type_instance = connector.introspect_native_type(native_type.clone()).unwrap();
-                FieldType::NativeType(scal_type, native_type_instance)
+                FieldType::Scalar(scal_type, None, Some(native_type_instance))
             }
         },
         field_type => field_type,

--- a/libs/datamodel/connectors/mongodb-datamodel-connector/src/lib.rs
+++ b/libs/datamodel/connectors/mongodb-datamodel-connector/src/lib.rs
@@ -81,7 +81,7 @@ impl Connector for MongoDbDatamodelConnector {
         }
 
         // If the field is _not_ a native-type-annotated field and it has a `dbgenerated` defult, we error.
-        if !matches!(field.field_type(), FieldType::NativeType(_, _))
+        if !matches!(field.field_type(), FieldType::Scalar(_, _, Some(_)))
             && matches!(field.default_value(), Some(DefaultValue::Expression(expr)) if expr.is_dbgenerated())
         {
             let message = if field.is_id() {

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/mssql_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/mssql_datamodel_connector.rs
@@ -210,7 +210,7 @@ impl Connector for MsSqlDatamodelConnector {
 
     fn validate_field(&self, field: &Field) -> Result<(), ConnectorError> {
         match field.field_type() {
-            FieldType::NativeType(_, native_type) => {
+            FieldType::Scalar(_, _, Some(native_type)) => {
                 let r#type: MsSqlType = native_type.deserialize_native_type();
                 let error = self.native_instance_error(native_type);
 
@@ -258,7 +258,7 @@ impl Connector for MsSqlDatamodelConnector {
             let fields = index_definition.fields.iter().map(|f| model.find_field(f).unwrap());
 
             for field in fields {
-                if let FieldType::NativeType(_, native_type) = field.field_type() {
+                if let FieldType::Scalar(_, _, Some(native_type)) = field.field_type() {
                     let r#type: MsSqlType = native_type.deserialize_native_type();
                     let error = self.native_instance_error(native_type);
 
@@ -276,7 +276,7 @@ impl Connector for MsSqlDatamodelConnector {
         for id_field in model.id_fields.iter() {
             let field = model.find_field(id_field).unwrap();
 
-            if let FieldType::NativeType(_, native_type) = field.field_type() {
+            if let FieldType::Scalar(_, _, Some(native_type)) = field.field_type() {
                 let r#type: MsSqlType = native_type.deserialize_native_type();
 
                 if heap_allocated_types().contains(&r#type) {

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
@@ -248,7 +248,7 @@ impl Connector for MySqlDatamodelConnector {
 
     fn validate_field(&self, field: &Field) -> Result<(), ConnectorError> {
         match field.field_type() {
-            FieldType::NativeType(scalar_type, native_type_instance) => {
+            FieldType::Scalar(scalar_type, _, Some(native_type_instance)) => {
                 let native_type_name = native_type_instance.name.as_str();
                 let native_type: MySqlType = native_type_instance.deserialize_native_type();
                 let error = self.native_instance_error(native_type_instance.clone());
@@ -290,7 +290,7 @@ impl Connector for MySqlDatamodelConnector {
         for index_definition in model.indices.iter() {
             let fields = index_definition.fields.iter().map(|f| model.find_field(f).unwrap());
             for f in fields {
-                if let FieldType::NativeType(_, native_type) = f.field_type() {
+                if let FieldType::Scalar(_, _, Some(native_type)) = f.field_type() {
                     let native_type_name = native_type.name.as_str();
 
                     if NATIVE_TYPES_THAT_CAN_NOT_BE_USED_IN_KEY_SPECIFICATION.contains(&native_type_name) {
@@ -307,7 +307,7 @@ impl Connector for MySqlDatamodelConnector {
         }
         for id_field in model.id_fields.iter() {
             let field = model.find_field(id_field).unwrap();
-            if let FieldType::NativeType(_, native_type) = field.field_type() {
+            if let FieldType::Scalar(_, _, Some(native_type)) = field.field_type() {
                 let native_type_name = native_type.name.as_str();
                 if NATIVE_TYPES_THAT_CAN_NOT_BE_USED_IN_KEY_SPECIFICATION.contains(&native_type_name) {
                     return self

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
@@ -211,7 +211,7 @@ impl Connector for PostgresDatamodelConnector {
 
     fn validate_field(&self, field: &Field) -> Result<(), ConnectorError> {
         match field.field_type() {
-            FieldType::NativeType(_scalar_type, native_type_instance) => {
+            FieldType::Scalar(_scalar_type, _, Some(native_type_instance)) => {
                 let native_type: PostgresType = native_type_instance.deserialize_native_type();
                 let error = self.native_instance_error(native_type_instance);
 

--- a/libs/datamodel/core/src/json/dmmf/to_dmmf.rs
+++ b/libs/datamodel/core/src/json/dmmf/to_dmmf.rs
@@ -123,8 +123,7 @@ fn get_field_kind(field: &dml::Field) -> String {
     match field.field_type() {
         dml::FieldType::Relation(_) => String::from("object"),
         dml::FieldType::Enum(_) => String::from("enum"),
-        dml::FieldType::Base(_, _) => String::from("scalar"),
-        dml::FieldType::NativeType(_, _) => String::from("scalar"),
+        dml::FieldType::Scalar(_, _, _) => String::from("scalar"),
         dml::FieldType::Unsupported(_) => String::from("unsupported"),
     }
 }
@@ -172,8 +171,7 @@ fn get_field_type(field: &dml::Field) -> String {
         dml::FieldType::Relation(relation_info) => relation_info.to.clone(),
         dml::FieldType::Enum(t) => t.clone(),
         dml::FieldType::Unsupported(t) => t.clone(),
-        dml::FieldType::Base(t, _) => type_to_string(t),
-        dml::FieldType::NativeType(t, _) => type_to_string(t),
+        dml::FieldType::Scalar(t, _, _) => type_to_string(t),
     }
 }
 

--- a/libs/datamodel/core/src/transform/ast_to_dml/lift.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/lift.rs
@@ -324,15 +324,16 @@ impl<'a> LiftAstToDml<'a> {
                             &connector_error.to_string(),
                             type_specification.unwrap().span,
                         )),
-                        Ok(parsed_native_type) => {
-                            Ok((dml::FieldType::NativeType(scalar_type, parsed_native_type), vec![]))
-                        }
+                        Ok(parsed_native_type) => Ok((
+                            dml::FieldType::Scalar(scalar_type, None, Some(parsed_native_type)),
+                            vec![],
+                        )),
                     }
                 } else {
-                    Ok((dml::FieldType::Base(scalar_type, type_alias), vec![]))
+                    Ok((dml::FieldType::Scalar(scalar_type, type_alias, None), vec![]))
                 }
             } else {
-                Ok((dml::FieldType::Base(scalar_type, type_alias), vec![]))
+                Ok((dml::FieldType::Scalar(scalar_type, type_alias, None), vec![]))
             }
         } else if ast_schema.find_model(type_name).is_some() {
             Ok((dml::FieldType::Relation(dml::RelationInfo::new(type_name)), vec![]))

--- a/libs/datamodel/core/src/transform/attributes/default.rs
+++ b/libs/datamodel/core/src/transform/attributes/default.rs
@@ -23,14 +23,7 @@ impl AttributeValidator<dml::Field> for DefaultAttributeValidator {
                 return self.new_attribute_validation_error("Cannot set a default value on list field.", args.span());
             }
 
-            if let dml::FieldType::Base(scalar_type, _) = sf.field_type {
-                let dv = args
-                    .default_arg("value")?
-                    .as_default_value_for_scalar_type(scalar_type)
-                    .map_err(|e| self.wrap_in_attribute_validation_error(&e))?;
-
-                sf.default_value = Some(dv);
-            } else if let dml::FieldType::NativeType(scalar_type, _) = sf.field_type {
+            if let dml::FieldType::Scalar(scalar_type, _, _) = sf.field_type {
                 let dv = args
                     .default_arg("value")?
                     .as_default_value_for_scalar_type(scalar_type)

--- a/libs/datamodel/core/src/transform/dml_to_ast/lower.rs
+++ b/libs/datamodel/core/src/transform/dml_to_ast/lower.rs
@@ -102,15 +102,12 @@ impl<'a> LowerDmlToAst<'a> {
     /// Internal: Lowers a field's type.
     fn lower_type(&self, field_type: &dml::FieldType) -> ast::FieldType {
         match field_type {
-            dml::FieldType::Base(tpe, custom_type_name) => ast::FieldType::Supported(ast::Identifier::new(
+            dml::FieldType::Scalar(tpe, custom_type_name, _) => ast::FieldType::Supported(ast::Identifier::new(
                 &custom_type_name.as_ref().unwrap_or(&tpe.to_string()),
             )),
             dml::FieldType::Enum(tpe) => ast::FieldType::Supported(ast::Identifier::new(&tpe)),
             dml::FieldType::Unsupported(tpe) => ast::FieldType::Unsupported(tpe.clone(), Span::empty()),
             dml::FieldType::Relation(rel) => ast::FieldType::Supported(ast::Identifier::new(&rel.to)),
-            dml::FieldType::NativeType(prisma_tpe, _native_tpe) => {
-                ast::FieldType::Supported(ast::Identifier::new(&prisma_tpe.to_string()))
-            }
         }
     }
 

--- a/libs/datamodel/core/src/walkers.rs
+++ b/libs/datamodel/core/src/walkers.rs
@@ -175,8 +175,8 @@ impl<'a> ScalarFieldWalker<'a> {
                 datamodel: self.datamodel,
                 r#enum: self.datamodel.find_enum(name).unwrap(),
             }),
-            FieldType::Base(scalar_type, _) => TypeWalker::Base(*scalar_type),
-            FieldType::NativeType(scalar_type, native_type) => TypeWalker::NativeType(*scalar_type, native_type),
+            FieldType::Scalar(scalar_type, _, None) => TypeWalker::Base(*scalar_type),
+            FieldType::Scalar(scalar_type, _, Some(nt)) => TypeWalker::NativeType(*scalar_type, nt),
             FieldType::Unsupported(description) => TypeWalker::Unsupported(description.clone()),
             FieldType::Relation(_) => unreachable!("FieldType::Relation in ScalarFieldWalker"),
         }

--- a/libs/datamodel/core/tests/common.rs
+++ b/libs/datamodel/core/tests/common.rs
@@ -109,7 +109,7 @@ impl FieldAsserts for dml::ScalarField {
 
 impl ScalarFieldAsserts for dml::ScalarField {
     fn assert_base_type(&self, t: &ScalarType) -> &Self {
-        if let dml::FieldType::Base(base_type, _) = &self.field_type {
+        if let dml::FieldType::Scalar(base_type, _, None) = &self.field_type {
             assert_eq!(base_type, t);
         } else {
             panic!("Scalar expected, but found {:?}", self.field_type);
@@ -136,7 +136,7 @@ impl ScalarFieldAsserts for dml::ScalarField {
     }
 
     fn assert_native_type(&self) -> &NativeTypeInstance {
-        if let dml::FieldType::NativeType(_, t) = &self.field_type {
+        if let dml::FieldType::Scalar(_, _, Some(t)) = &self.field_type {
             &t
         } else {
             panic!("Native Type expected, but found {:?}", self.field_type);

--- a/libs/prisma-models/src/datamodel_converter.rs
+++ b/libs/prisma-models/src/datamodel_converter.rs
@@ -442,19 +442,8 @@ impl DatamodelFieldExtensions for dml::ScalarField {
         match &self.field_type {
             dml::FieldType::Enum(x) => TypeIdentifier::Enum(x.clone()),
             dml::FieldType::Relation(_) => TypeIdentifier::String, // Todo: Unused
-            dml::FieldType::Base(scalar, _) => match scalar {
-                dml::ScalarType::Boolean => TypeIdentifier::Boolean,
-                dml::ScalarType::DateTime => TypeIdentifier::DateTime,
-                dml::ScalarType::Float => TypeIdentifier::Float,
-                dml::ScalarType::Decimal => TypeIdentifier::Decimal,
-                dml::ScalarType::Int => TypeIdentifier::Int,
-                dml::ScalarType::String => TypeIdentifier::String,
-                dml::ScalarType::Json => TypeIdentifier::Json,
-                dml::ScalarType::Bytes => TypeIdentifier::Bytes,
-                dml::ScalarType::BigInt => TypeIdentifier::BigInt,
-            },
+            dml::FieldType::Scalar(scalar, _, _) => (*scalar).into(),
             dml::FieldType::Unsupported(_) => TypeIdentifier::Unsupported,
-            dml::FieldType::NativeType(scalar_type, _) => (*scalar_type).into(),
         }
     }
 
@@ -513,7 +502,7 @@ impl DatamodelFieldExtensions for dml::ScalarField {
 
     fn native_type(&self) -> Option<NativeTypeInstance> {
         match &self.field_type {
-            datamodel::FieldType::NativeType(_, nt) => Some(nt.clone()),
+            datamodel::FieldType::Scalar(_, _, nt) => nt.clone(),
             _ => None,
         }
     }


### PR DESCRIPTION
This has been the plan from the start of the native types
implementation. Since native types have been the default for a while, we
can now collapse the two variants.