### PR TITLE
Rename FieldType::as_base() to as_scalar()

### DIFF
--- a/libs/datamodel/connectors/dml/src/field.rs
+++ b/libs/datamodel/connectors/dml/src/field.rs
@@ -41,7 +41,7 @@ pub enum FieldType {
 }
 
 impl FieldType {
-    pub fn as_base(&self) -> Option<&ScalarType> {
+    pub fn as_scalar(&self) -> Option<&ScalarType> {
         match self {
             FieldType::Scalar(scalar_type, _, _) => Some(scalar_type),
             _ => None,

--- a/libs/datamodel/core/src/transform/ast_to_dml/validate.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validate.rs
@@ -646,14 +646,14 @@ impl<'a> Validator<'a> {
                         if let Some(connector) = self.source.map(|source| &source.active_connector) {
                             let base_native_type = base_field.field_type().as_native_type().map(|(scalar, native)| (*scalar, native.serialized_native_type.clone())).or_else(|| -> Option<_> {
                                 let field_type = base_field.field_type();
-                                let scalar_type = field_type.as_base()?;
+                                let scalar_type = field_type.as_scalar()?;
 
                                 Some((*scalar_type, connector.default_native_type_for_scalar_type(scalar_type)))
                             });
 
                             let referenced_native_type = referenced_field.field_type().as_native_type().map(|(scalar, native)| (*scalar, native.serialized_native_type.clone())).or_else(|| -> Option<_> {
                                 let field_type = referenced_field.field_type();
-                                let scalar_type = field_type.as_base()?;
+                                let scalar_type = field_type.as_scalar()?;
 
                                 Some((*scalar_type, connector.default_native_type_for_scalar_type(scalar_type)))
                             });

--- a/migration-engine/cli/src/logger.rs
+++ b/migration-engine/cli/src/logger.rs
@@ -18,10 +18,15 @@ pub(crate) fn init_logger() {
 }
 
 pub(crate) fn log_error_and_exit(error: ConnectorError) -> ! {
+    let message: &dyn std::fmt::Display = match error.known_error() {
+        Some(known_error) => &known_error.message,
+        _ => &error,
+    };
+
     tracing::error!(
         is_panic = false,
         error_code = error.error_code().unwrap_or(""),
-        message = %error,
+        message = %message,
     );
 
     std::process::exit(1)


### PR DESCRIPTION
This was an omission in https://github.com/prisma/prisma-engines/pull/2032