### PR TITLE
Simplify parse_schema.rs

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -7,7 +7,6 @@ on:
 jobs:
   build:
     name: "WebAssembly build ${{ github.event.ref }} for commit ${{ github.event.inputs.commit }}"
-    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.48.0
+          toolchain: stable
           default: true
 
       - uses: actions/cache@v2

--- a/libs/datamodel/core/src/ast/parser/parse_schema.rs
+++ b/libs/datamodel/core/src/ast/parser/parse_schema.rs
@@ -22,22 +22,10 @@ pub fn parse_schema(datamodel_string: &str) -> Result<SchemaAst, Diagnostics> {
             let mut top_level_definitions: Vec<Top> = vec![];
             for current in datamodel.relevant_children() {
                 match current.as_rule() {
-                    Rule::model_declaration => match parse_model(&current) {
-                        Ok(model) => top_level_definitions.push(Top::Model(model)),
-                        Err(mut err) => errors.append(&mut err),
-                    },
-                    Rule::enum_declaration => match parse_enum(&current) {
-                        Ok(enm) => top_level_definitions.push(Top::Enum(enm)),
-                        Err(mut err) => errors.append(&mut err),
-                    },
-                    Rule::source_block => match parse_source(&current) {
-                        Ok(source) => top_level_definitions.push(Top::Source(source)),
-                        Err(mut err) => errors.append(&mut err),
-                    },
-                    Rule::generator_block => match parse_generator(&current) {
-                        Ok(generator) => top_level_definitions.push(Top::Generator(generator)),
-                        Err(mut err) => errors.append(&mut err),
-                    },
+                    Rule::model_declaration => top_level_definitions.push(Top::Model(parse_model(&current, &mut errors))),
+                    Rule::enum_declaration => top_level_definitions.push(Top::Enum(parse_enum(&current, &mut errors))),
+                    Rule::source_block => top_level_definitions.push(Top::Source(parse_source(&current, &mut errors))),
+                    Rule::generator_block => top_level_definitions.push(Top::Generator(parse_generator(&current, &mut errors))),
                     Rule::type_alias => top_level_definitions.push(Top::Type(parse_type_alias(&current))),
                     Rule::comment_block => (),
                     Rule::EOI => {}

--- a/libs/datamodel/core/src/common/default_names.rs
+++ b/libs/datamodel/core/src/common/default_names.rs
@@ -1,7 +1,7 @@
-pub struct RelationNames {}
+pub struct RelationNames;
 
 impl RelationNames {
-    /// generates a name for relations that have not been explicitly named by a user
+    /// Generates a name for relations that have not been explicitly named by a user
     pub fn name_for_unambiguous_relation(from: &str, to: &str) -> String {
         if from < to {
             format!("{}To{}", from, to)
@@ -10,6 +10,7 @@ impl RelationNames {
         }
     }
 
+    /// Generates a name for relations that have not been explicitly named by a user
     pub fn name_for_ambiguous_relation(from: &str, to: &str, scalar_field: &str) -> String {
         if from < to {
             format!("{}_{}To{}", from, scalar_field, to)

--- a/libs/datamodel/core/src/diagnostics/collection.rs
+++ b/libs/datamodel/core/src/diagnostics/collection.rs
@@ -52,14 +52,10 @@ impl Diagnostics {
         self.warnings.iter()
     }
 
-    /// Appends all errors from another collection to this collection.
+    /// Appends all errors and warnings from another collection to this collection.
     pub fn append(&mut self, err_and_warn: &mut Diagnostics) {
         self.errors.append(&mut err_and_warn.errors);
         self.warnings.append(&mut err_and_warn.warnings)
-    }
-
-    pub fn append_error_vec(&mut self, mut errors: Vec<DatamodelError>) {
-        self.errors.append(&mut errors)
     }
 
     pub fn append_warning_vec(&mut self, mut warnings: Vec<DatamodelWarning>) {

--- a/libs/datamodel/core/src/transform/ast_to_dml/validate.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validate.rs
@@ -823,9 +823,11 @@ impl<'a> Validator<'a> {
                 ));
             }
 
-            if !fields_with_wrong_type.is_empty() && !errors.has_errors() {
+            if !errors.has_errors() {
                 // don't output too much errors
-                errors.append_error_vec(fields_with_wrong_type);
+                for err in fields_with_wrong_type {
+                    errors.push_error(err);
+                }
             }
         }
 


### PR DESCRIPTION
Align it with the general error handling pattern in datamodel/core.

This is the first of a series of PRs to align the main branch and https://github.com/prisma/prisma-engines/pull/1874 so it is easier to merge. Optimally, we also want to split the merge in smaller reviewable chunks.