### PR TITLE
Implement new datamodel connector components for constraint names

### DIFF
--- a/libs/datamodel/connectors/datamodel-connector/src/empty_connector.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/empty_connector.rs
@@ -20,6 +20,10 @@ impl Connector for EmptyDatamodelConnector {
         &[]
     }
 
+    fn constraint_name_length(&self) -> usize {
+        usize::MAX
+    }
+
     fn validate_field(&self, _field: &dml::field::Field) -> Result<(), ConnectorError> {
         Ok(())
     }

--- a/libs/datamodel/connectors/datamodel-connector/src/lib.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/lib.rs
@@ -18,11 +18,19 @@ pub trait Connector: Send + Sync {
 
     fn capabilities(&self) -> &[ConnectorCapability];
 
+    /// The maximum length of constraint names in bytes. Connectors without a
+    /// limit should return usize::MAX.
+    fn constraint_name_length(&self) -> usize;
+
     fn has_capability(&self, capability: ConnectorCapability) -> bool {
         self.capabilities().contains(&capability)
     }
 
     fn referential_actions(&self) -> BitFlags<ReferentialAction>;
+
+    fn supports_named_primary_keys(&self) -> bool {
+        self.has_capability(ConnectorCapability::NamedPrimaryKeys)
+    }
 
     fn supports_referential_action(&self, action: ReferentialAction) -> bool {
         self.referential_actions().contains(action)
@@ -188,6 +196,7 @@ pub enum ConnectorCapability {
     AutoIncrementNonIndexedAllowed,
     RelationFieldsInArbitraryOrder,
     ForeignKeys,
+    NamedPrimaryKeys,
 
     // start of Query Engine Capabilities
     InsensitiveFilters,

--- a/libs/datamodel/connectors/mongodb-datamodel-connector/src/lib.rs
+++ b/libs/datamodel/connectors/mongodb-datamodel-connector/src/lib.rs
@@ -63,6 +63,10 @@ impl Connector for MongoDbDatamodelConnector {
         &self.capabilities
     }
 
+    fn constraint_name_length(&self) -> usize {
+        127
+    }
+
     fn referential_actions(&self) -> BitFlags<ReferentialAction> {
         self.referential_actions
     }

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/mssql_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/mssql_datamodel_connector.rs
@@ -57,15 +57,16 @@ impl MsSqlDatamodelConnector {
         use ReferentialAction::*;
 
         let capabilities = vec![
+            ConnectorCapability::AutoIncrement,
             ConnectorCapability::AutoIncrementAllowedOnNonId,
             ConnectorCapability::AutoIncrementMultipleAllowed,
             ConnectorCapability::AutoIncrementNonIndexedAllowed,
-            ConnectorCapability::CreateMany,
-            ConnectorCapability::UpdateableId,
-            ConnectorCapability::MultipleIndexesWithSameName,
-            ConnectorCapability::AutoIncrement,
             ConnectorCapability::CompoundIds,
+            ConnectorCapability::CreateMany,
             ConnectorCapability::ForeignKeys,
+            ConnectorCapability::MultipleIndexesWithSameName,
+            ConnectorCapability::NamedPrimaryKeys,
+            ConnectorCapability::UpdateableId,
         ];
 
         let constructors: Vec<NativeTypeConstructor> = vec![
@@ -152,6 +153,10 @@ impl Connector for MsSqlDatamodelConnector {
 
     fn capabilities(&self) -> &[ConnectorCapability] {
         &self.capabilities
+    }
+
+    fn constraint_name_length(&self) -> usize {
+        128
     }
 
     fn referential_actions(&self) -> BitFlags<ReferentialAction> {

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
@@ -198,6 +198,10 @@ impl Connector for MySqlDatamodelConnector {
         &self.capabilities
     }
 
+    fn constraint_name_length(&self) -> usize {
+        64
+    }
+
     fn referential_actions(&self) -> BitFlags<ReferentialAction> {
         self.referential_actions
     }

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
@@ -160,6 +160,10 @@ impl Connector for PostgresDatamodelConnector {
         &self.capabilities
     }
 
+    fn constraint_name_length(&self) -> usize {
+        63
+    }
+
     fn referential_actions(&self) -> BitFlags<ReferentialAction> {
         self.referential_actions
     }

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/sqlite_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/sqlite_datamodel_connector.rs
@@ -44,6 +44,10 @@ impl Connector for SqliteDatamodelConnector {
         &self.capabilities
     }
 
+    fn constraint_name_length(&self) -> usize {
+        10000
+    }
+
     fn referential_actions(&self) -> BitFlags<ReferentialAction> {
         self.referential_actions
     }


### PR DESCRIPTION
Ported from https://github.com/prisma/prisma-engines/pull/1874 — trying to merge this progressively.