### PR TITLE
Introduce identifier types to sql_schema_describer

### DIFF
--- a/libs/sql-schema-describer/src/ids.rs
+++ b/libs/sql-schema-describer/src/ids.rs
@@ -1,0 +1,39 @@
+use crate::{Column, Enum, SqlSchema, Table};
+use std::ops::Index;
+
+/// The identifier for a table in a SqlSchema. Use it with the indexing syntax:
+/// `let table = schema[table_id];`
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct TableId(pub(crate) u32);
+
+impl Index<TableId> for SqlSchema {
+    type Output = Table;
+
+    fn index(&self, index: TableId) -> &Self::Output {
+        &self.tables[index.0 as usize]
+    }
+}
+
+/// The identifier for an enum in a SqlSchema.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct EnumId(pub(crate) u32);
+
+impl Index<EnumId> for SqlSchema {
+    type Output = Enum;
+
+    fn index(&self, index: EnumId) -> &Self::Output {
+        &self.enums[index.0 as usize]
+    }
+}
+
+/// The identifier for a column in a SqlSchema.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ColumnId(pub(crate) u32);
+
+impl Index<ColumnId> for Table {
+    type Output = Column;
+
+    fn index(&self, index: ColumnId) -> &Self::Output {
+        &self.columns[index.0 as usize]
+    }
+}

--- a/migration-engine/connectors/sql-migration-connector/src/pair.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/pair.rs
@@ -1,6 +1,6 @@
 use sql_schema_describer::{
     walkers::{ColumnWalker, EnumWalker, IndexWalker, SqlSchemaExt, TableWalker},
-    SqlSchema,
+    ColumnId, SqlSchema, TableId,
 };
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -82,19 +82,19 @@ impl<'a> Pair<&'a SqlSchema> {
         )
     }
 
-    pub(crate) fn tables(&self, table_indexes: &Pair<usize>) -> Pair<TableWalker<'a>> {
+    pub(crate) fn tables(&self, table_ids: &Pair<TableId>) -> Pair<TableWalker<'a>> {
         Pair::new(
-            self.previous().table_walker_at(*table_indexes.previous()),
-            self.next.table_walker_at(*table_indexes.next()),
+            self.previous().table_walker_at(*table_ids.previous()),
+            self.next.table_walker_at(*table_ids.next()),
         )
     }
 }
 
 impl<'a> Pair<TableWalker<'a>> {
-    pub(crate) fn columns(&self, column_indexes: &Pair<usize>) -> Pair<ColumnWalker<'a>> {
+    pub(crate) fn columns(&self, column_ids: &Pair<ColumnId>) -> Pair<ColumnWalker<'a>> {
         Pair::new(
-            self.previous().column_at(*column_indexes.previous()),
-            self.next().column_at(*column_indexes.next()),
+            self.previous().column_at(*column_ids.previous()),
+            self.next().column_at(*column_ids.next()),
         )
     }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
@@ -119,48 +119,47 @@ fn render_raw_sql(
         SqlMigrationStep::DropEnum { enum_index } => {
             renderer.render_drop_enum(&schemas.previous().enum_walker_at(*enum_index))
         }
-        SqlMigrationStep::CreateTable { table_index } => {
-            let table = schemas.next().table_walker_at(*table_index);
+        SqlMigrationStep::CreateTable { table_id } => {
+            let table = schemas.next().table_walker_at(*table_id);
 
             vec![renderer.render_create_table(&table)]
         }
-        SqlMigrationStep::DropTable { table_index } => {
-            renderer.render_drop_table(schemas.previous().table_walker_at(*table_index).name())
+        SqlMigrationStep::DropTable { table_id } => {
+            renderer.render_drop_table(schemas.previous().table_walker_at(*table_id).name())
         }
         SqlMigrationStep::RedefineIndex { table, index } => {
             renderer.render_drop_and_recreate_index(schemas.tables(table).indexes(index).as_ref())
         }
         SqlMigrationStep::AddForeignKey {
-            table_index,
+            table_id,
             foreign_key_index,
         } => {
             let foreign_key = schemas
                 .next()
-                .table_walker_at(*table_index)
+                .table_walker_at(*table_id)
                 .foreign_key_at(*foreign_key_index);
 
             vec![renderer.render_add_foreign_key(&foreign_key)]
         }
         SqlMigrationStep::DropForeignKey {
-            table_index,
+            table_id,
             foreign_key_index,
         } => {
             let foreign_key = schemas
                 .previous()
-                .table_walker_at(*table_index)
+                .table_walker_at(*table_id)
                 .foreign_key_at(*foreign_key_index);
 
             vec![renderer.render_drop_foreign_key(&foreign_key)]
         }
         SqlMigrationStep::AlterTable(alter_table) => renderer.render_alter_table(alter_table, &schemas),
         SqlMigrationStep::CreateIndex {
-            table_index: (_, table_index),
+            table_id: (_, table_id),
             index_index,
-        } => vec![renderer.render_create_index(&schemas.next().table_walker_at(*table_index).index_at(*index_index))],
-        SqlMigrationStep::DropIndex {
-            table_index,
-            index_index,
-        } => vec![renderer.render_drop_index(&schemas.previous().table_walker_at(*table_index).index_at(*index_index))],
+        } => vec![renderer.render_create_index(&schemas.next().table_walker_at(*table_id).index_at(*index_index))],
+        SqlMigrationStep::DropIndex { table_id, index_index } => {
+            vec![renderer.render_drop_index(&schemas.previous().table_walker_at(*table_id).index_at(*index_index))]
+        }
         SqlMigrationStep::AlterIndex { table, index } => {
             renderer.render_alter_index(schemas.tables(table).indexes(index).as_ref())
         }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/mssql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/mssql.rs
@@ -22,7 +22,7 @@ impl DestructiveChangeCheckerFlavour for MssqlFlavour {
         step_index: usize,
     ) {
         let AlterColumn {
-            column_index: _,
+            column_id: _,
             changes,
             type_change,
         } = alter_column;

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/mysql.rs
@@ -22,7 +22,7 @@ impl DestructiveChangeCheckerFlavour for MysqlFlavour {
         step_index: usize,
     ) {
         let AlterColumn {
-            column_index: _,
+            column_id: _,
             changes,
             type_change,
         } = alter_column;

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/postgres.rs
@@ -22,7 +22,7 @@ impl DestructiveChangeCheckerFlavour for PostgresFlavour {
         step_index: usize,
     ) {
         let AlterColumn {
-            column_index: _,
+            column_id: _,
             changes,
             type_change,
         } = alter_column;

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mssql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mssql_renderer.rs
@@ -92,7 +92,10 @@ impl SqlRenderer for MssqlFlavour {
     }
 
     fn render_alter_table(&self, alter_table: &AlterTable, schemas: &Pair<&SqlSchema>) -> Vec<String> {
-        let AlterTable { table_index, changes } = alter_table;
+        let AlterTable {
+            table_ids: table_index,
+            changes,
+        } = alter_table;
         let tables = schemas.tables(table_index);
 
         alter_table::create_statements(self, tables, changes)
@@ -228,7 +231,7 @@ impl SqlRenderer for MssqlFlavour {
         let mut result = vec!["BEGIN TRANSACTION".to_string()];
 
         for redefine_table in tables {
-            let tables = schemas.tables(&redefine_table.table_index);
+            let tables = schemas.tables(&redefine_table.table_ids);
             // This is a copy of our new modified table.
             let temporary_table_name = format!("_prisma_new_{}", &tables.next().name());
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
@@ -43,7 +43,10 @@ impl SqlRenderer for SqliteFlavour {
     }
 
     fn render_alter_table(&self, alter_table: &AlterTable, schemas: &Pair<&SqlSchema>) -> Vec<String> {
-        let AlterTable { changes, table_index } = alter_table;
+        let AlterTable {
+            changes,
+            table_ids: table_index,
+        } = alter_table;
 
         let tables = schemas.tables(table_index);
 
@@ -54,8 +57,8 @@ impl SqlRenderer for SqliteFlavour {
 
         for change in changes {
             match change {
-                TableChange::AddColumn { column_index } => {
-                    let column = tables.next().column_at(*column_index);
+                TableChange::AddColumn { column_id } => {
+                    let column = tables.next().column_at(*column_id);
                     let col_sql = render_column(&column);
 
                     statements.push(format!(
@@ -149,7 +152,7 @@ impl SqlRenderer for SqliteFlavour {
         let mut result = vec!["PRAGMA foreign_keys=OFF".to_string()];
 
         for redefine_table in tables {
-            let tables = schemas.tables(&redefine_table.table_index);
+            let tables = schemas.tables(&redefine_table.table_ids);
             let temporary_table_name = format!("new_{}", &tables.next().name());
 
             result.push(self.render_create_table_as(tables.next(), &temporary_table_name));
@@ -229,10 +232,10 @@ fn copy_current_table_into_new_table(
     let destination_columns = redefine_table
         .column_pairs
         .iter()
-        .map(|(column_indexes, _, _)| tables.next().column_at(*column_indexes.next()).name());
+        .map(|(column_ides, _, _)| tables.next().column_at(*column_ides.next()).name());
 
-    let source_columns = redefine_table.column_pairs.iter().map(|(column_indexes, changes, _)| {
-        let columns = tables.columns(column_indexes);
+    let source_columns = redefine_table.column_pairs.iter().map(|(column_ides, changes, _)| {
+        let columns = tables.columns(column_ides);
 
         let col_became_required_with_a_default =
             changes.arity_changed() && columns.next().arity().is_required() && columns.next().default().is_some();

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
@@ -6,7 +6,6 @@ mod sql_schema_differ_flavour;
 mod table;
 
 pub(crate) use column::{ColumnChange, ColumnChanges};
-use datamodel::common::preview_features::PreviewFeature;
 pub(crate) use sql_schema_differ_flavour::SqlSchemaDifferFlavour;
 
 use self::differ_database::DifferDatabase;
@@ -16,10 +15,11 @@ use crate::{
     SqlFlavour, SqlSchema,
 };
 use column::ColumnTypeChange;
+use datamodel::common::preview_features::PreviewFeature;
 use enums::EnumDiffer;
 use sql_schema_describer::{
     walkers::{EnumWalker, ForeignKeyWalker, SqlSchemaExt, TableWalker},
-    ColumnTypeFamily,
+    ColumnId, ColumnTypeFamily, TableId,
 };
 use std::collections::HashSet;
 use table::TableDiffer;
@@ -91,13 +91,13 @@ impl<'schema> SqlSchemaDiffer<'schema> {
     fn push_create_tables(&self, steps: &mut Vec<SqlMigrationStep>) {
         for table in self.created_tables() {
             steps.push(SqlMigrationStep::CreateTable {
-                table_index: table.table_index(),
+                table_id: table.table_id(),
             });
 
             if self.flavour.should_push_foreign_keys_from_created_tables() {
                 for fk in table.foreign_keys() {
                     steps.push(SqlMigrationStep::AddForeignKey {
-                        table_index: table.table_index(),
+                        table_id: table.table_id(),
                         foreign_key_index: fk.foreign_key_index(),
                     });
                 }
@@ -110,7 +110,7 @@ impl<'schema> SqlSchemaDiffer<'schema> {
     fn drop_tables(&self, steps: &mut Vec<SqlMigrationStep>) {
         for dropped_table in self.dropped_tables() {
             steps.push(SqlMigrationStep::DropTable {
-                table_index: dropped_table.table_index(),
+                table_id: dropped_table.table_id(),
             });
 
             if !self.flavour.should_drop_foreign_keys_from_dropped_tables() {
@@ -119,7 +119,7 @@ impl<'schema> SqlSchemaDiffer<'schema> {
 
             for fk in dropped_table.foreign_keys() {
                 steps.push(SqlMigrationStep::DropForeignKey {
-                    table_index: dropped_table.table_index(),
+                    table_id: dropped_table.table_id(),
                     foreign_key_index: fk.foreign_key_index(),
                 });
             }
@@ -134,14 +134,14 @@ impl<'schema> SqlSchemaDiffer<'schema> {
         for table in tables {
             for created_fk in table.created_foreign_keys() {
                 steps.push(SqlMigrationStep::AddForeignKey {
-                    table_index: created_fk.table().table_index(),
+                    table_id: created_fk.table().table_id(),
                     foreign_key_index: created_fk.foreign_key_index(),
                 })
             }
 
             for dropped_fk in table.dropped_foreign_keys() {
                 steps.push(SqlMigrationStep::DropForeignKey {
-                    table_index: table.previous().table_index(),
+                    table_id: table.previous().table_id(),
                     foreign_key_index: dropped_fk.foreign_key_index(),
                 })
             }
@@ -162,14 +162,14 @@ impl<'schema> SqlSchemaDiffer<'schema> {
             for column in table.column_pairs() {
                 self.flavour.push_index_changes_for_column_changes(
                     &table,
-                    column.as_pair().map(|c| c.column_index()),
+                    column.as_pair().map(|c| c.column_id()),
                     column.all_changes().0,
                     steps,
                 );
             }
 
             steps.push(SqlMigrationStep::AlterTable(AlterTable {
-                table_index: table.tables.map(|t| t.table_index()),
+                table_ids: table.tables.map(|t| t.table_id()),
                 changes,
             }));
         }
@@ -177,13 +177,13 @@ impl<'schema> SqlSchemaDiffer<'schema> {
 
     fn drop_columns<'a>(differ: &'a TableDiffer<'schema, 'a>) -> impl Iterator<Item = TableChange> + 'a {
         differ.dropped_columns().map(|column| TableChange::DropColumn {
-            column_index: column.column_index(),
+            column_id: column.column_id(),
         })
     }
 
     fn add_columns<'a>(differ: &'a TableDiffer<'schema, 'a>) -> impl Iterator<Item = TableChange> + 'a {
         differ.added_columns().map(move |column| TableChange::AddColumn {
-            column_index: column.column_index(),
+            column_id: column.column_id(),
         })
     }
 
@@ -197,24 +197,24 @@ impl<'schema> SqlSchemaDiffer<'schema> {
                     return None;
                 }
 
-                let column_index = Pair::new(column_differ.previous.column_index(), column_differ.next.column_index());
+                let column_id = Pair::new(column_differ.previous.column_id(), column_differ.next.column_id());
 
                 match type_change {
                     Some(ColumnTypeChange::NotCastable) => {
-                        Some(TableChange::DropAndRecreateColumn { column_index, changes })
+                        Some(TableChange::DropAndRecreateColumn { column_id, changes })
                     }
                     Some(ColumnTypeChange::RiskyCast) => Some(TableChange::AlterColumn(AlterColumn {
-                        column_index,
+                        column_id,
                         changes,
                         type_change: Some(crate::sql_migration::ColumnTypeChange::RiskyCast),
                     })),
                     Some(ColumnTypeChange::SafeCast) => Some(TableChange::AlterColumn(AlterColumn {
-                        column_index,
+                        column_id,
                         changes,
                         type_change: Some(crate::sql_migration::ColumnTypeChange::SafeCast),
                     })),
                     None => Some(TableChange::AlterColumn(AlterColumn {
-                        column_index,
+                        column_id,
                         changes,
                         type_change: None,
                     })),
@@ -223,8 +223,8 @@ impl<'schema> SqlSchemaDiffer<'schema> {
             .collect();
 
         alter_columns.sort_by_key(|alter_col| match alter_col {
-            TableChange::AlterColumn(alter_col) => alter_col.column_index,
-            TableChange::DropAndRecreateColumn { column_index, .. } => *column_index,
+            TableChange::AlterColumn(alter_col) => alter_col.column_id,
+            TableChange::DropAndRecreateColumn { column_id, .. } => *column_id,
             _ => unreachable!(),
         });
 
@@ -242,8 +242,8 @@ impl<'schema> SqlSchemaDiffer<'schema> {
         if differ.flavour.should_recreate_the_primary_key_on_column_recreate() {
             from_psl_change.or_else(|| {
                 let from_recreate = Self::alter_columns(differ).into_iter().any(|tc| match tc {
-                    TableChange::DropAndRecreateColumn { column_index, .. } => {
-                        let idx = *column_index.previous();
+                    TableChange::DropAndRecreateColumn { column_id, .. } => {
+                        let idx = *column_id.previous();
                         differ.previous().column_at(idx).is_part_of_primary_key()
                     }
                     _ => false,
@@ -268,8 +268,8 @@ impl<'schema> SqlSchemaDiffer<'schema> {
         if differ.flavour.should_recreate_the_primary_key_on_column_recreate() {
             from_psl_change.or_else(|| {
                 let from_recreate = Self::alter_columns(differ).into_iter().any(|tc| match tc {
-                    TableChange::DropAndRecreateColumn { column_index, .. } => {
-                        let idx = *column_index.previous();
+                    TableChange::DropAndRecreateColumn { column_id, .. } => {
+                        let idx = *column_id.previous();
                         differ.previous().column_at(idx).is_part_of_primary_key()
                     }
                     _ => false,
@@ -293,7 +293,7 @@ impl<'schema> SqlSchemaDiffer<'schema> {
                 .flat_map(|table| table.indexes())
                 .filter(|index| !self.flavour.should_skip_index_for_new_table(index))
                 .map(|index| SqlMigrationStep::CreateIndex {
-                    table_index: (None, index.table().table_index()),
+                    table_id: (None, index.table().table_id()),
                     index_index: index.index(),
                 });
 
@@ -306,26 +306,26 @@ impl<'schema> SqlSchemaDiffer<'schema> {
         {
             for index in tables.created_indexes() {
                 steps.push(SqlMigrationStep::CreateIndex {
-                    table_index: (Some(tables.previous().table_index()), tables.next().table_index()),
+                    table_id: (Some(tables.previous().table_id()), tables.next().table_id()),
                     index_index: index.index(),
                 })
             }
 
             if self.flavour.indexes_should_be_recreated_after_column_drop() {
-                let dropped_and_recreated_column_indexes_next: HashSet<usize> = tables
+                let dropped_and_recreated_column_ids_next: HashSet<ColumnId> = tables
                     .column_pairs()
                     .filter(|columns| matches!(columns.all_changes().1, Some(ColumnTypeChange::NotCastable)))
-                    .map(|col| col.as_pair().next().column_index())
+                    .map(|col| col.as_pair().next().column_id())
                     .collect();
 
                 for index in tables.index_pairs().filter(|index| {
                     index
                         .next()
                         .columns()
-                        .any(|col| dropped_and_recreated_column_indexes_next.contains(&col.column_index()))
+                        .any(|col| dropped_and_recreated_column_ids_next.contains(&col.column_id()))
                 }) {
                     steps.push(SqlMigrationStep::CreateIndex {
-                        table_index: (Some(tables.previous().table_index()), tables.next().table_index()),
+                        table_id: (Some(tables.previous().table_id()), tables.next().table_id()),
                         index_index: index.next().index(),
                     })
                 }
@@ -344,7 +344,7 @@ impl<'schema> SqlSchemaDiffer<'schema> {
                     continue;
                 }
 
-                drop_indexes.insert((index.table().table_index(), index.index()));
+                drop_indexes.insert((index.table().table_id(), index.index()));
             }
         }
 
@@ -353,16 +353,13 @@ impl<'schema> SqlSchemaDiffer<'schema> {
         if !tables_to_redefine.is_empty() && self.flavour.should_drop_indexes_from_dropped_tables() {
             for table in self.dropped_tables() {
                 for index in table.indexes() {
-                    drop_indexes.insert((index.table().table_index(), index.index()));
+                    drop_indexes.insert((index.table().table_id(), index.index()));
                 }
             }
         }
 
-        for (table_index, index_index) in drop_indexes.into_iter() {
-            steps.push(SqlMigrationStep::DropIndex {
-                table_index,
-                index_index,
-            })
+        for (table_id, index_index) in drop_indexes.into_iter() {
+            steps.push(SqlMigrationStep::DropIndex { table_id, index_index })
         }
     }
 
@@ -375,7 +372,7 @@ impl<'schema> SqlSchemaDiffer<'schema> {
                     .map(|columns| {
                         let (changes, type_change) = columns.all_changes();
                         (
-                            Pair::new(columns.previous.column_index(), columns.next.column_index()),
+                            Pair::new(columns.previous.column_id(), columns.next.column_id()),
                             changes,
                             type_change.map(|tc| match tc {
                                 ColumnTypeChange::SafeCast => sql_migration::ColumnTypeChange::SafeCast,
@@ -387,10 +384,10 @@ impl<'schema> SqlSchemaDiffer<'schema> {
                     .collect();
 
                 RedefineTable {
-                    table_index: differ.tables.as_ref().map(|t| t.table_index()),
+                    table_ids: differ.tables.as_ref().map(|t| t.table_id()),
                     dropped_primary_key: SqlSchemaDiffer::drop_primary_key(&differ).is_some(),
-                    added_columns: differ.added_columns().map(|col| col.column_index()).collect(),
-                    dropped_columns: differ.dropped_columns().map(|col| col.column_index()).collect(),
+                    added_columns: differ.added_columns().map(|col| col.column_id()).collect(),
+                    dropped_columns: differ.dropped_columns().map(|col| col.column_id()).collect(),
                     column_pairs,
                 }
             })
@@ -406,7 +403,7 @@ impl<'schema> SqlSchemaDiffer<'schema> {
         })
     }
 
-    fn alter_indexes(&self, tables_to_redefine: &HashSet<String>) -> Vec<Pair<(usize, usize)>> {
+    fn alter_indexes(&self, tables_to_redefine: &HashSet<String>) -> Vec<Pair<(TableId, usize)>> {
         let mut steps = Vec::new();
 
         for differ in self
@@ -417,7 +414,7 @@ impl<'schema> SqlSchemaDiffer<'schema> {
                 .index_pairs()
                 .filter(|pair| self.flavour.index_should_be_renamed(pair))
             {
-                steps.push(pair.as_ref().map(|i| (i.table().table_index(), i.index())));
+                steps.push(pair.as_ref().map(|i| (i.table().table_id(), i.index())));
             }
         }
 
@@ -427,13 +424,13 @@ impl<'schema> SqlSchemaDiffer<'schema> {
     fn created_tables(&self) -> impl Iterator<Item = TableWalker<'schema>> + '_ {
         self.db
             .created_tables()
-            .map(move |table_index| self.schemas.next().table_walker_at(table_index))
+            .map(move |table_id| self.schemas.next().table_walker_at(table_id))
     }
 
     fn dropped_tables(&self) -> impl Iterator<Item = TableWalker<'schema>> + '_ {
         self.db
             .dropped_tables()
-            .map(move |table_index| self.schemas.previous().table_walker_at(table_index))
+            .map(move |table_id| self.schemas.previous().table_walker_at(table_id))
     }
 
     fn enum_pairs(&self) -> impl Iterator<Item = EnumDiffer<'_>> {
@@ -476,7 +473,7 @@ fn push_previous_usages_as_defaults_in_altered_enums(differ: &SqlSchemaDiffer<'_
                 .columns()
                 .filter(|col| col.column_type_is_enum(enum_names.previous()) && col.default().is_some())
             {
-                previous_usages_as_default.push(((column.table().table_index(), column.column_index()), None));
+                previous_usages_as_default.push(((column.table().table_id(), column.column_id()), None));
             }
         }
 
@@ -485,7 +482,7 @@ fn push_previous_usages_as_defaults_in_altered_enums(differ: &SqlSchemaDiffer<'_
                 .dropped_columns()
                 .filter(|col| col.column_type_is_enum(enum_names.previous()) && col.default().is_some())
             {
-                previous_usages_as_default.push(((column.table().table_index(), column.column_index()), None));
+                previous_usages_as_default.push(((column.table().table_id(), column.column_id()), None));
             }
 
             for columns in tables.column_pairs().filter(|col| {
@@ -493,10 +490,10 @@ fn push_previous_usages_as_defaults_in_altered_enums(differ: &SqlSchemaDiffer<'_
             }) {
                 let next_usage_as_default = Some(&columns.next)
                     .filter(|col| col.column_type_is_enum(enum_names.next()) && col.default().is_some())
-                    .map(|col| (col.table().table_index(), col.column_index()));
+                    .map(|col| (col.table().table_id(), col.column_id()));
 
                 previous_usages_as_default.push((
-                    (columns.previous.table().table_index(), columns.previous.column_index()),
+                    (columns.previous.table().table_id(), columns.previous.column_id()),
                     next_usage_as_default,
                 ));
             }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour.rs
@@ -4,7 +4,7 @@ use crate::{
     sql_migration::{AlterEnum, SqlMigrationStep},
     sql_schema_differ,
 };
-use sql_schema_describer::walkers::IndexWalker;
+use sql_schema_describer::{walkers::IndexWalker, ColumnId};
 use std::collections::HashSet;
 
 mod mssql;
@@ -65,7 +65,7 @@ pub(crate) trait SqlSchemaDifferFlavour {
     fn push_index_changes_for_column_changes(
         &self,
         _table: &sql_schema_differ::TableDiffer<'_, '_>,
-        _column_index: Pair<usize>,
+        _column_index: Pair<ColumnId>,
         _column_changes: sql_schema_differ::ColumnChanges,
         _steps: &mut Vec<SqlMigrationStep>,
     ) {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/table.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/table.rs
@@ -14,7 +14,7 @@ pub(crate) struct TableDiffer<'a, 'b> {
 impl<'schema, 'b> TableDiffer<'schema, 'b> {
     pub(crate) fn column_pairs<'a>(&'a self) -> impl Iterator<Item = ColumnDiffer<'schema>> + 'a {
         self.db
-            .column_pairs(self.tables.map(|t| t.table_index()))
+            .column_pairs(self.tables.map(|t| t.table_id()))
             .map(move |colidxs| ColumnDiffer {
                 flavour: self.flavour,
                 previous: self.tables.previous().column_at(*colidxs.previous()),
@@ -24,13 +24,13 @@ impl<'schema, 'b> TableDiffer<'schema, 'b> {
 
     pub(crate) fn dropped_columns<'a>(&'a self) -> impl Iterator<Item = ColumnWalker<'schema>> + 'a {
         self.db
-            .dropped_columns(self.tables.map(|t| t.table_index()))
+            .dropped_columns(self.tables.map(|t| t.table_id()))
             .map(move |idx| self.tables.previous().column_at(idx))
     }
 
     pub(crate) fn added_columns<'a>(&'a self) -> impl Iterator<Item = ColumnWalker<'schema>> + 'a {
         self.db
-            .created_columns(self.tables.map(|t| t.table_index()))
+            .created_columns(self.tables.map(|t| t.table_id()))
             .map(move |idx| self.tables.next().column_at(idx))
     }
 


### PR DESCRIPTION
- They are more self-documenting than `usize`s and thus make the code more readable
- They are typed and will catch a bunch of possible errors
- They are half the size of a `usize` on 64 bit platforms
- They can be used to conveniently index into a SqlSchema without breaking encapsulation
- They are already a success in the datamodel parser
- They are pretty standard in large rust compiler implementations