### PR TITLE
Simplify user-facing-error-macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,36 +869,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
-dependencies = [
- "darling_core 0.10.2",
- "darling_macro 0.10.2",
-]
-
-[[package]]
-name = "darling"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06d4a9551359071d1890820e3571252b91229e0712e7c36b08940e603c5a8fc"
 dependencies = [
- "darling_core 0.12.2",
- "darling_macro 0.12.2",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.9.3",
- "syn",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -917,22 +893,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
-dependencies = [
- "darling_core 0.10.2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0220073ce504f12a70efc4e7cdaea9e9b1b324872e7ad96a208056d7a638b81"
 dependencies = [
- "darling_core 0.12.2",
+ "darling_core",
  "quote",
  "syn",
 ]
@@ -3528,7 +3493,7 @@ dependencies = [
 name = "query-test-macros"
 version = "0.1.0"
 dependencies = [
- "darling 0.12.2",
+ "darling",
  "itertools 0.10.0",
  "proc-macro2",
  "query-tests-setup",
@@ -4029,7 +3994,7 @@ version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48b35457e9d855d3dc05ef32a73e0df1e2c0fd72c38796a4ee909160c8eeec2"
 dependencies = [
- "darling 0.12.2",
+ "darling",
  "proc-macro2",
  "quote",
  "syn",
@@ -4423,12 +4388,6 @@ name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "strsim"
@@ -5204,11 +5163,8 @@ dependencies = [
 name = "user-facing-error-macros"
 version = "0.1.0"
 dependencies = [
- "darling 0.10.2",
- "once_cell",
  "proc-macro2",
  "quote",
- "regex",
  "syn",
 ]
 

--- a/libs/test-macros/src/lib.rs
+++ b/libs/test-macros/src/lib.rs
@@ -33,7 +33,7 @@ pub fn test_connector(attr: TokenStream, input: TokenStream) -> TokenStream {
         }
     }
 
-    // Then the function body
+    // Then the function item
     // We take advantage of the function body being the last token tree (surrounded by braces).
     let (sig, body): (Signature, proc_macro2::TokenStream) = {
         let sig_tokens = input

--- a/libs/user-facing-error-macros/Cargo.toml
+++ b/libs/user-facing-error-macros/Cargo.toml
@@ -10,9 +10,6 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
-darling = "0.10.1"
 syn = "1.0.5"
 quote = "1.0.2"
 proc-macro2 = "1.0.6"
-once_cell = "1.3"
-regex = "1.3.1"

--- a/libs/user-facing-error-macros/src/lib.rs
+++ b/libs/user-facing-error-macros/src/lib.rs
@@ -1,194 +1,113 @@
 extern crate proc_macro;
 
-use darling::{FromDeriveInput, FromVariant};
-use once_cell::sync::Lazy;
-use proc_macro::TokenStream;
-use proc_macro2::{Ident, Span};
-use quote::quote;
-use regex::Regex;
-use std::collections::BTreeSet;
-use syn::DeriveInput;
-
 #[proc_macro_derive(UserFacingError, attributes(user_facing))]
-pub fn derive_user_facing_error(input: TokenStream) -> TokenStream {
-    let input = syn::parse_macro_input!(input as DeriveInput);
+pub fn derive_user_facing_error(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = syn::parse_macro_input!(input as syn::DeriveInput);
 
-    match &input.data {
-        syn::Data::Struct(_data) => user_error_derive_on_struct(&input),
-        syn::Data::Enum(data) => user_error_derive_on_enum(&input, data),
-        _ => syn::Error::new_spanned(input, "derive works only on structs and enums")
-            .to_compile_error()
-            .into(),
-    }
-}
-
-fn user_error_derive_on_struct(input: &DeriveInput) -> TokenStream {
-    let input = match UserErrorDeriveInput::from_derive_input(input) {
-        Ok(input) => input,
-        Err(err) => return err.write_errors().into(),
+    let data = match &input.data {
+        syn::Data::Struct(data) => data,
+        _ => {
+            return syn::Error::new_spanned(input, "derive works only on structs")
+                .to_compile_error()
+                .into()
+        }
     };
 
-    let ident = &input.ident;
-    let error_code = input.code.as_str();
-    let message_template = input.message;
-    let template_variables = message_template_variables(message_template.value().as_str(), &message_template.span());
+    let UserErrorDeriveInput { ident, code, message } = match UserErrorDeriveInput::new(&input) {
+        Ok(input) => input,
+        Err(err) => return err.into_compile_error().into(),
+    };
 
-    let template_variables = template_variables.iter();
+    let template_variables: Box<dyn Iterator<Item = _>> = match &data.fields {
+        syn::Fields::Named(named) => Box::new(named.named.iter().map(|field| field.ident.as_ref().unwrap())),
+        syn::Fields::Unit => Box::new(std::iter::empty()),
+        syn::Fields::Unnamed(unnamed) => {
+            return syn::Error::new_spanned(unnamed, "The error fields must be named")
+                .to_compile_error()
+                .into()
+        }
+    };
 
-    let output = quote! {
+    proc_macro::TokenStream::from(quote::quote! {
         impl crate::UserFacingError for #ident {
-            const ERROR_CODE: &'static str = #error_code;
+            const ERROR_CODE: &'static str = #code;
 
             fn message(&self) -> String {
                 format!(
-                    #message_template,
+                    #message,
                     #(
                         #template_variables = self.#template_variables
                     ),*
                 )
             }
         }
-    };
-
-    output.into()
+    })
 }
 
-fn user_error_derive_on_enum(input: &DeriveInput, data: &syn::DataEnum) -> TokenStream {
-    let attributes = match UserErrorEnumDeriveInput::from_derive_input(input) {
-        Ok(attributes) => attributes,
-        Err(err) => return err.write_errors().into(),
-    };
+struct UserErrorDeriveInput<'a> {
+    /// The name of the struct.
+    ident: &'a syn::Ident,
+    /// The error code.
+    code: syn::LitStr,
+    /// The error message format string.
+    message: syn::LitStr,
+}
 
-    let ident = &attributes.ident;
-    let error_code = &attributes.code;
+impl<'a> UserErrorDeriveInput<'a> {
+    fn new(input: &'a syn::DeriveInput) -> Result<Self, syn::Error> {
+        let mut code = None;
+        let mut message = None;
 
-    let message_variants = data
-        .variants
-        .iter()
-        .map(|variant| enum_variant_match_branch(ident, variant));
+        for attr in &input.attrs {
+            if !attr
+                .path
+                .get_ident()
+                .map(|ident| ident == "user_facing")
+                .unwrap_or(false)
+            {
+                continue;
+            }
 
-    let output = quote! {
-        impl crate::UserFacingError for #ident {
-            const ERROR_CODE: &'static str = #error_code;
+            for namevalue in attr.parse_args_with(|stream: &'_ syn::parse::ParseBuffer| {
+                syn::punctuated::Punctuated::<syn::MetaNameValue, syn::Token![,]>::parse_terminated(stream)
+            })? {
+                let litstr = match namevalue.lit {
+                    syn::Lit::Str(litstr) => litstr,
+                    other => {
+                        return Err(syn::Error::new_spanned(
+                            other,
+                            "Expected attribute of the form `#[user_facing(code = \"...\", message = \"...\")]`",
+                        ))
+                    }
+                };
 
-            fn message(&self) -> String {
-                match self {
-                    #(#message_variants)*
+                match namevalue.path.get_ident() {
+                    Some(ident) if ident == "code" => {
+                        code = Some(litstr);
+                    }
+                    Some(ident) if ident == "message" => {
+                        message = Some(litstr);
+                    }
+                    other => {
+                        return Err(syn::Error::new_spanned(
+                            other,
+                            "Expected attribute of the form `#[user_facing(code = \"...\", message = \"...\")]`",
+                        ))
+                    }
                 }
             }
         }
-    };
 
-    output.into()
-}
-
-fn enum_variant_match_branch(enum_ident: &syn::Ident, variant: &syn::Variant) -> impl quote::ToTokens {
-    let parsed_variant = match UserErrorEnumVariantAttributes::from_variant(variant) {
-        Ok(parsed_variant) => parsed_variant,
-        Err(err) => return err.write_errors(),
-    };
-
-    let variant_ident = &parsed_variant.ident;
-    let message_template = parsed_variant.message.value().replace("${", "{");
-
-    let variant_field_names: Vec<&syn::Ident> = match &variant.fields {
-        syn::Fields::Named(fields) => fields
-            .named
-            .iter()
-            .map(|f| f.ident.as_ref().expect("expect identifier"))
-            .collect(),
-        tokens => {
-            return syn::Error::new_spanned(tokens, "Enum variant fields of user facing errors must be named.")
-                .to_compile_error()
+        match (message, code) {
+            (Some(message), Some(code)) => Ok(UserErrorDeriveInput {
+                ident: &input.ident,
+                message,
+                code,
+            }),
+            _ => Err(syn::Error::new_spanned(
+                input,
+                "Expected attribute of the form `#[user_facing(code = \"...\", message = \"...\")]`",
+            )),
         }
-    };
-
-    quote! {
-        #enum_ident::#variant_ident { #(#variant_field_names),* } => format!(
-            #message_template,
-            #(#variant_field_names = #variant_field_names),*
-        ),
-    }
-}
-
-#[derive(Debug, FromDeriveInput)]
-#[darling(attributes(user_facing))]
-struct UserErrorEnumDeriveInput {
-    /// The name of the enum.
-    ident: syn::Ident,
-    /// The error code.
-    code: String,
-}
-
-#[derive(Debug, FromVariant)]
-#[darling(attributes(user_facing))]
-struct UserErrorEnumVariantAttributes {
-    /// The name of the enum.
-    ident: syn::Ident,
-    /// The error message format string.
-    message: syn::LitStr,
-}
-
-#[derive(Debug, FromDeriveInput)]
-#[darling(attributes(user_facing))]
-struct UserErrorDeriveInput {
-    /// The name of the struct.
-    ident: syn::Ident,
-    /// The error code.
-    code: String,
-    /// The error message format string.
-    message: syn::LitStr,
-}
-
-/// See MESSAGE_VARIABLE_REGEX
-const MESSAGE_VARIABLE_REGEX_PATTERN: &str = r##"(?x)
-    \{  # an opening curly brace
-    (
-        [a-zA-Z0-9_]+  # any number of alphanumeric characters and underscores
-    )
-    }  # a closing curly brace
-"##;
-
-/// The regex for variables in message templates.
-static MESSAGE_VARIABLE_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(MESSAGE_VARIABLE_REGEX_PATTERN).unwrap());
-
-fn message_template_variables(template: &str, span: &Span) -> BTreeSet<Ident> {
-    let captures = MESSAGE_VARIABLE_REGEX.captures_iter(template);
-
-    captures
-        // The unwrap is safe because we know this regex has one capture group.
-        .map(|capture| capture.get(1).unwrap())
-        .map(|m| Ident::new(m.as_str(), *span))
-        .collect()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn new_span() -> proc_macro2::Span {
-        proc_macro2::Span::call_site()
-    }
-
-    fn assert_template_variables(template: &str, expected: &[&str]) {
-        let result: Vec<String> = message_template_variables(template, &new_span())
-            .iter()
-            .map(|ident| ident.to_string())
-            .collect();
-
-        assert_eq!(result, expected);
-    }
-
-    #[test]
-    fn message_template_variables_works() {
-        assert_template_variables("no variables", &[]);
-        assert_template_variables("${abc}_def", &["abc"]);
-        assert_template_variables("abc${_def}", &["_def"]);
-        assert_template_variables("some ${ code } sample", &[] as &[&str]);
-        assert_template_variables("positional parameter ${} ", &[] as &[&str]);
-        assert_template_variables(
-            "Message with ${multiple_variables} to ${substitute}",
-            &["multiple_variables", "substitute"],
-        );
     }
 }

--- a/libs/user-facing-errors/src/common.rs
+++ b/libs/user-facing-errors/src/common.rs
@@ -1,3 +1,4 @@
+use crate::UserFacingError;
 use serde::Serialize;
 use std::fmt::Display;
 use user_facing_error_macros::*;
@@ -59,32 +60,63 @@ pub struct DatabaseTimeout {
     pub context: String,
 }
 
-#[derive(Debug, UserFacingError, Serialize)]
+#[derive(Debug, Serialize)]
 #[serde(untagged)]
-#[user_facing(code = "P1003")]
 pub enum DatabaseDoesNotExist {
-    #[user_facing(message = "Database {database_file_name} does not exist at {database_file_path}")]
     Sqlite {
         database_file_name: String,
         database_file_path: String,
     },
-    #[user_facing(
-        message = "Database `{database_name}.{database_schema_name}` does not exist on the database server at `{database_host}:{database_port}`."
-    )]
     Postgres {
         database_name: String,
         database_schema_name: String,
         database_host: String,
         database_port: u16,
     },
-    #[user_facing(
-        message = "Database `{database_name}` does not exist on the database server at `{database_host}:{database_port}`."
-    )]
     Mysql {
         database_name: String,
         database_host: String,
         database_port: u16,
     },
+}
+
+impl UserFacingError for DatabaseDoesNotExist {
+    const ERROR_CODE: &'static str = "P1003";
+
+    fn message(&self) -> String {
+        match self {
+            DatabaseDoesNotExist::Sqlite {
+                database_file_name,
+                database_file_path,
+            } => format!(
+                "Database {database_file_name} does not exist at {database_file_path}",
+                database_file_name = database_file_name,
+                database_file_path = database_file_path
+            ),
+            DatabaseDoesNotExist::Postgres {
+                database_name,
+                database_schema_name,
+                database_host,
+                database_port,
+            } => format!(
+                "Database `{database_name}.{database_schema_name}` does not exist on the database server at `{database_host}:{database_port}`.",
+                database_name = database_name,
+                database_schema_name = database_schema_name,
+                database_host = database_host,
+                database_port = database_port,
+            ),
+            DatabaseDoesNotExist::Mysql {
+                database_name,
+                database_host,
+                database_port,
+            } => format!(
+                "Database `{database_name}` does not exist on the database server at `{database_host}:{database_port}`.",
+                database_name = database_name,
+                database_host = database_host,
+                database_port = database_port,
+            ),
+        }
+    }
 }
 
 #[derive(Debug, UserFacingError, Serialize)]


### PR DESCRIPTION
- Drop the enum derive. It is confusing and used for only one error.
- Drop the darling dependency. `syn` is more than ergonomic enough,
  darling isn't pulling its weight.
- Drop regex and once_cell dependencies, and only rely on the macro input.