### PR TITLE
Output more context before drift summaries

### DIFF
--- a/migration-engine/core/src/commands/dev_diagnostic.rs
+++ b/migration-engine/core/src/commands/dev_diagnostic.rs
@@ -75,8 +75,7 @@ fn check_for_reset_conditions(output: &DiagnoseMigrationHistoryOutput) -> Option
     }
 
     if let Some(DriftDiagnostic::DriftDetected { summary }) = &output.drift {
-        let mut reason =
-            "Drift detected: Your database schema is not in sync with your migration history.\n".to_owned();
+        let mut reason = DRIFT_DETECTED_MESSAGE.trim_start().to_owned();
         reason.push_str(summary);
         reset_reasons.push(reason);
     }
@@ -111,6 +110,14 @@ fn check_for_reset_conditions(output: &DiagnoseMigrationHistoryOutput) -> Option
         }
     }
 }
+
+const DRIFT_DETECTED_MESSAGE: &str = r#"
+Drift detected: Your database schema is not in sync with your migration history.
+
+The following is a summary of the differences between the expected database schema given your migrations files, and the actual schema of the database.
+
+It should be understood as the set of changes to get from the expected schema to the actual schema.
+"#;
 
 /// A suggested action for the CLI `migrate dev` command.
 #[derive(Debug, Serialize)]

--- a/migration-engine/migration-engine-tests/tests/migrations/dev_diagnostic_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/dev_diagnostic_tests.rs
@@ -480,6 +480,10 @@ fn drift_can_be_detected_without_migrations_table_dev(api: TestApi) {
     let expect = expect![[r#"
         Drift detected: Your database schema is not in sync with your migration history.
 
+        The following is a summary of the differences between the expected database schema given your migrations files, and the actual schema of the database.
+
+        It should be understood as the set of changes to get from the expected schema to the actual schema.
+
         [+] Added tables
           - cat
     "#]];


### PR DESCRIPTION
This is an attempt to address https://github.com/prisma/prisma/issues/7676

When `migrate dev` detects drift, this PR changes the text we introduce the drift summary with to something like:

```
Drift detected: Your database schema is not in sync with your migration history.

The following is a summary of the differences between the expected database schema given your migrations files, and the actual schema of the database.

It should be understood as the set of changes to get from the expected schema to the actual schema.

[+] Added tables
  - cat
```