### PR TITLE
Split TopId into more specific types

### DIFF
--- a/libs/datamodel/core/src/ast/top.rs
+++ b/libs/datamodel/core/src/ast/top.rs
@@ -89,9 +89,4 @@ impl Top {
             _ => None,
         }
     }
-
-    #[track_caller]
-    pub fn unwrap_type_alias(&self) -> &Field {
-        self.as_type_alias().unwrap()
-    }
 }

--- a/libs/datamodel/core/src/transform/ast_to_dml/db/relations.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/relations.rs
@@ -1,13 +1,13 @@
-use crate::ast::{FieldId, TopId};
+use crate::ast;
 use std::collections::BTreeMap;
 
 #[derive(Default)]
 pub(super) struct Relations {
     /// This contains only the relation fields actually present in the schema
     /// source text.
-    pub(super) relation_fields: BTreeMap<(TopId, FieldId), RelationField>,
+    pub(super) relation_fields: BTreeMap<(ast::ModelId, ast::FieldId), RelationField>,
 }
 
 pub(crate) struct RelationField {
-    pub(crate) referenced_model: TopId,
+    pub(crate) referenced_model: ast::ModelId,
 }


### PR DESCRIPTION
TopId is losing information we know when we instantiate it, about what kind of ast::Top we are dealing with. It now contains more specific ids, like a model id.

The main advantage is that whenever we need to look up a model by ID, we can write `schema_ast[model_id]` instead of `schema_ast[top_id].as_model().unwrap()`. The other important advantage is that it makes function signatures a lot more specific and self-documenting.

Squashed commits:
- (squash) Use the abstraction more
- (squash) Do it for aliases too