### PR TITLE
Make Arguments an implementation detail of db::Context

### DIFF
--- a/libs/datamodel/core/src/transform/ast_to_dml/db/attributes.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/attributes.rs
@@ -1,16 +1,13 @@
 use super::{
+    context::{Arguments, Context},
     names::MappedName,
     types::{IndexData, ModelData, RelationField, ScalarField},
-    Context,
 };
 use crate::{
     ast::{self, WithName},
     diagnostics::DatamodelError,
     dml,
-    transform::{
-        ast_to_dml::db::ScalarFieldType,
-        helpers::{Arguments, ValueValidator},
-    },
+    transform::{ast_to_dml::db::ScalarFieldType, helpers::ValueValidator},
 };
 use itertools::Itertools;
 use prisma_value::PrismaValue;

--- a/libs/datamodel/core/src/transform/ast_to_dml/db/context.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/context.rs
@@ -1,10 +1,12 @@
-pub(super) use attributes::Attributes;
+mod arguments;
+mod attributes;
+
+pub(super) use self::{arguments::Arguments, attributes::Attributes};
 
 use super::{ParserDatabase, ScalarFieldType};
 use crate::{
     ast,
     diagnostics::{DatamodelError, Diagnostics},
-    transform::helpers::Arguments,
 };
 use std::collections::HashSet;
 
@@ -123,81 +125,5 @@ impl<'ast> Context<'ast> {
         arguments.check_for_unused_arguments(&mut self.diagnostics);
 
         self.arguments = arguments;
-    }
-}
-
-mod attributes {
-    use super::*;
-
-    #[derive(Default)]
-    pub(crate) struct Attributes<'ast> {
-        attributes: Vec<&'ast ast::Attribute>,
-        unused_attributes: HashSet<usize>,
-    }
-
-    impl<'ast> Attributes<'ast> {
-        pub(super) fn set_attributes(&mut self, ast_attributes: &'ast [ast::Attribute]) {
-            self.attributes.clear();
-            self.unused_attributes.clear();
-            self.extend_attributes(ast_attributes)
-        }
-
-        pub(super) fn extend_attributes(&mut self, ast_attributes: &'ast [ast::Attribute]) {
-            self.unused_attributes
-                .extend(self.attributes.len()..(self.attributes.len() + ast_attributes.len()));
-            self.attributes.extend(ast_attributes.iter());
-        }
-
-        pub(super) fn unused_attributes(&self) -> impl Iterator<Item = &'ast ast::Attribute> + '_ {
-            self.unused_attributes.iter().map(move |idx| self.attributes[*idx])
-        }
-
-        /// Validate an _optional_ attribute that should occur only once.
-        pub(crate) fn visit_optional_single<'ctx>(
-            &mut self,
-            name: &str,
-            ctx: &'ctx mut Context<'ast>,
-            f: impl FnOnce(&mut Arguments<'ast>, &mut Context<'ast>),
-        ) {
-            let mut attrs = self.attributes.iter().enumerate().filter(|(_, a)| a.name.name == name);
-            let (first_idx, first) = match attrs.next() {
-                Some(first) => first,
-                None => return, // early return if absent: it's optional
-            };
-
-            if attrs.next().is_some() {
-                for (idx, attr) in self.attributes.iter().enumerate().filter(|(_, a)| a.name.name == name) {
-                    ctx.push_error(DatamodelError::new_duplicate_attribute_error(
-                        &attr.name.name,
-                        attr.span,
-                    ));
-                    assert!(self.unused_attributes.remove(&idx));
-                }
-
-                return;
-            }
-
-            assert!(self.unused_attributes.remove(&first_idx));
-
-            ctx.with_arguments(first, f);
-        }
-
-        /// Extract an attribute that can occur zero or more times. Example: @@index on models.
-        pub(crate) fn visit_repeated<'ctx>(
-            &mut self,
-            name: &'static str,
-            ctx: &'ctx mut Context<'ast>,
-            mut f: impl FnMut(&mut Arguments<'ast>, &mut Context<'ast>),
-        ) {
-            for (attr_idx, attr) in self
-                .attributes
-                .iter()
-                .enumerate()
-                .filter(|(_, attr)| attr.name.name == name)
-            {
-                ctx.with_arguments(attr, &mut f);
-                assert!(self.unused_attributes.remove(&attr_idx));
-            }
-        }
     }
 }

--- a/libs/datamodel/core/src/transform/ast_to_dml/db/context/arguments.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/context/arguments.rs
@@ -1,14 +1,24 @@
-use super::ValueValidator;
 use crate::ast::{self, Span};
 use crate::diagnostics::{DatamodelError, Diagnostics};
+use crate::transform::helpers::ValueValidator;
 use std::collections::HashMap;
 
 /// Represents a list of arguments.
 #[derive(Debug)]
-pub struct Arguments<'a> {
+pub(crate) struct Arguments<'a> {
     attribute_name: &'a str,
     args: HashMap<&'a str, &'a ast::Argument>, // the _remaining_ arguments
     span: ast::Span,
+}
+
+impl Default for Arguments<'_> {
+    fn default() -> Self {
+        Arguments {
+            attribute_name: "",
+            args: Default::default(),
+            span: Span::empty(),
+        }
+    }
 }
 
 impl<'a> Arguments<'a> {
@@ -81,15 +91,5 @@ impl<'a> Arguments<'a> {
 
     pub(crate) fn optional_default_arg(&mut self, name: &str) -> Option<ValueValidator<'a>> {
         self.default_arg(name).ok()
-    }
-}
-
-impl Default for Arguments<'_> {
-    fn default() -> Self {
-        Arguments {
-            attribute_name: "",
-            args: Default::default(),
-            span: Span::empty(),
-        }
     }
 }

--- a/libs/datamodel/core/src/transform/ast_to_dml/db/context/attributes.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/context/attributes.rs
@@ -1,0 +1,73 @@
+use super::*;
+
+#[derive(Default)]
+pub(crate) struct Attributes<'ast> {
+    attributes: Vec<&'ast ast::Attribute>,
+    unused_attributes: HashSet<usize>,
+}
+
+impl<'ast> Attributes<'ast> {
+    pub(super) fn set_attributes(&mut self, ast_attributes: &'ast [ast::Attribute]) {
+        self.attributes.clear();
+        self.unused_attributes.clear();
+        self.extend_attributes(ast_attributes)
+    }
+
+    pub(super) fn extend_attributes(&mut self, ast_attributes: &'ast [ast::Attribute]) {
+        self.unused_attributes
+            .extend(self.attributes.len()..(self.attributes.len() + ast_attributes.len()));
+        self.attributes.extend(ast_attributes.iter());
+    }
+
+    pub(super) fn unused_attributes(&self) -> impl Iterator<Item = &'ast ast::Attribute> + '_ {
+        self.unused_attributes.iter().map(move |idx| self.attributes[*idx])
+    }
+
+    /// Validate an _optional_ attribute that should occur only once.
+    pub(crate) fn visit_optional_single<'ctx>(
+        &mut self,
+        name: &str,
+        ctx: &'ctx mut Context<'ast>,
+        f: impl FnOnce(&mut Arguments<'ast>, &mut Context<'ast>),
+    ) {
+        let mut attrs = self.attributes.iter().enumerate().filter(|(_, a)| a.name.name == name);
+        let (first_idx, first) = match attrs.next() {
+            Some(first) => first,
+            None => return, // early return if absent: it's optional
+        };
+
+        if attrs.next().is_some() {
+            for (idx, attr) in self.attributes.iter().enumerate().filter(|(_, a)| a.name.name == name) {
+                ctx.push_error(DatamodelError::new_duplicate_attribute_error(
+                    &attr.name.name,
+                    attr.span,
+                ));
+                assert!(self.unused_attributes.remove(&idx));
+            }
+
+            return;
+        }
+
+        assert!(self.unused_attributes.remove(&first_idx));
+
+        ctx.with_arguments(first, f);
+    }
+
+    /// Extract an attribute that can occur zero or more times. Example: @@index on models.
+    pub(crate) fn visit_repeated<'ctx>(
+        &mut self,
+        name: &'static str,
+        ctx: &'ctx mut Context<'ast>,
+        mut f: impl FnMut(&mut Arguments<'ast>, &mut Context<'ast>),
+    ) {
+        for (attr_idx, attr) in self
+            .attributes
+            .iter()
+            .enumerate()
+            .filter(|(_, attr)| attr.name.name == name)
+        {
+            ctx.with_arguments(attr, &mut f);
+            assert!(self.unused_attributes.remove(&attr_idx));
+        }
+    }
+}

--- a/libs/datamodel/core/src/transform/helpers/mod.rs
+++ b/libs/datamodel/core/src/transform/helpers/mod.rs
@@ -1,6 +1,4 @@
-mod arguments;
 mod env_function;
 mod value_validator;
 
-pub(crate) use arguments::Arguments;
 pub(crate) use value_validator::{ValueListValidator, ValueValidator};


### PR DESCRIPTION
This is about moving existing code to private modules, nothing of substance.