### PR TITLE
Extend postgis ignore list to views on postgres

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/lib.rs
@@ -130,6 +130,7 @@ impl SqlMigrationConnector {
         // accidentally drop something we can't describe in the data model.
         let drop_views = source_schema
             .view_walkers()
+            .filter(|view| !self.flavour.view_should_be_ignored(view.name()))
             .map(|vw| vw.view_index())
             .map(DropView::new)
             .map(SqlMigrationStep::DropView);

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour.rs
@@ -121,4 +121,8 @@ pub(crate) trait SqlSchemaDifferFlavour {
     fn table_should_be_ignored(&self, _table_name: &str) -> bool {
         false
     }
+
+    fn view_should_be_ignored(&self, _view_name: &str) -> bool {
+        false
+    }
 }

--- a/migration-engine/migration-engine-tests/src/multi_engine_test_api.rs
+++ b/migration-engine/migration-engine-tests/src/multi_engine_test_api.rs
@@ -246,7 +246,7 @@ impl EngineTestApi<'_> {
 
     /// Plan a `schemaPush` command
     pub fn schema_push(&self, dm: impl Into<String>) -> SchemaPush<'_> {
-        SchemaPush::new_sync(&self.connector, dm.into(), self.rt)
+        SchemaPush::new(&self.connector, dm.into(), self.rt)
     }
 
     /// The schema name of the current connected database.

--- a/migration-engine/migration-engine-tests/src/sync_test_api.rs
+++ b/migration-engine/migration-engine-tests/src/sync_test_api.rs
@@ -218,7 +218,7 @@ impl TestApi {
 
     /// Plan a `schemaPush` command
     pub fn schema_push(&self, dm: impl Into<String>) -> SchemaPush<'_> {
-        SchemaPush::new_sync(&self.connector, dm.into(), &self.root.rt)
+        SchemaPush::new(&self.connector, dm.into(), &self.root.rt)
     }
 
     pub fn tags(&self) -> BitFlags<Tags> {

--- a/migration-engine/migration-engine-tests/tests/apply_migrations/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/apply_migrations/mod.rs
@@ -203,7 +203,7 @@ fn migrations_should_fail_on_an_uninitialized_nonempty_database(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 
     let directory = api.create_migrations_directory();
 

--- a/migration-engine/migration-engine-tests/tests/errors/error_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/errors/error_tests.rs
@@ -283,7 +283,7 @@ fn unique_constraint_errors_in_migrations_must_return_a_known_error(api: TestApi
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 
     let insert = Insert::multi_into(api.render_table_name("Fruit"), &["name"])
         .values(("banana",))

--- a/migration-engine/migration-engine-tests/tests/existing_data/sql_unexecutable_migrations/added_required_field_to_table.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_data/sql_unexecutable_migrations/added_required_field_to_table.rs
@@ -9,7 +9,7 @@ fn adding_a_required_field_to_an_existing_table_with_data_without_a_default_is_u
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     api.insert("Test")
         .value("id", "abc")
@@ -26,7 +26,7 @@ fn adding_a_required_field_to_an_existing_table_with_data_without_a_default_is_u
 
     api.schema_push(dm2)
         .force(false)
-        .send_sync()
+        .send()
         .assert_no_warning()
         .assert_unexecutable(&["Added the required column `age` to the `Test` table without a default value. There are 1 rows in this table, it is not possible to execute this step.".to_string()]);
 
@@ -43,7 +43,7 @@ fn adding_a_required_field_with_prisma_level_default_works(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     api.insert("Test").value("id", "abc").value("age", 100).result_raw();
 
@@ -57,7 +57,7 @@ fn adding_a_required_field_with_prisma_level_default_works(api: TestApi) {
 
     api.schema_push(dm2)
         .force(false)
-        .send_sync()
+        .send()
         .assert_no_warning()
         .assert_unexecutable(&["The required column `name` was added to the `Test` table with a prisma-level default value. There are 1 rows in this table, it is not possible to execute this step. Please add this column as optional, then populate it before making it required.".into()]);
 
@@ -74,7 +74,7 @@ fn adding_a_required_field_with_a_default_to_an_existing_table_works(api: TestAp
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     api.insert("Test")
         .value("id", "abc")
@@ -89,7 +89,7 @@ fn adding_a_required_field_with_a_default_to_an_existing_table_works(api: TestAp
         }
     "#;
 
-    api.schema_push(dm2).send_sync().assert_green_bang();
+    api.schema_push(dm2).send().assert_green_bang();
 
     api.dump_table("Test").assert_single_row(|row| {
         row.assert_text_value("id", "abc")
@@ -107,7 +107,7 @@ fn adding_a_required_field_without_default_to_an_existing_table_without_data_wor
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     let dm2 = r#"
         model Test {
@@ -117,7 +117,7 @@ fn adding_a_required_field_without_default_to_an_existing_table_without_data_wor
         }
     "#;
 
-    api.schema_push(dm2).send_sync().assert_green_bang();
+    api.schema_push(dm2).send().assert_green_bang();
 
     api.assert_schema()
         .assert_table("Test", |table| table.assert_has_column("age"));

--- a/migration-engine/migration-engine-tests/tests/existing_data/sql_unexecutable_migrations/added_unimplementable_unique_constraint.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_data/sql_unexecutable_migrations/added_unimplementable_unique_constraint.rs
@@ -9,7 +9,7 @@ fn adding_a_unique_constraint_should_warn(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     {
         api.insert("Test")
@@ -32,7 +32,7 @@ fn adding_a_unique_constraint_should_warn(api: TestApi) {
 
     api.schema_push(dm2)
         .force(false)
-        .send_sync()
+        .send()
         .assert_warnings(&["A unique constraint covering the columns `[name]` on the table `Test` will be added. If there are existing duplicate values, this will fail.".into()]);
 
     api.dump_table("Test")
@@ -60,7 +60,7 @@ fn dropping_enum_values_should_warn(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     {
         api.insert("Test")
@@ -89,7 +89,7 @@ fn dropping_enum_values_should_warn(api: TestApi) {
 
     api.schema_push(dm2)
         .force(false)
-        .send_sync()
+        .send()
         .assert_warnings(&["The values [george] on the enum `Test_name` will be removed. If these variants are still used in the database, this will fail.".into()]);
 
     api.dump_table("Test")
@@ -110,7 +110,7 @@ fn adding_a_unique_constraint_when_existing_data_respects_it_works(api: TestApi)
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     api.insert("Test")
         .value("id", "abc")
@@ -131,7 +131,7 @@ fn adding_a_unique_constraint_when_existing_data_respects_it_works(api: TestApi)
 
     api.schema_push(dm2)
         .force(true)
-        .send_sync()
+        .send()
         .assert_warnings(&["A unique constraint covering the columns `[name]` on the table `Test` will be added. If there are existing duplicate values, this will fail.".into()]);
 
     api.dump_table("Test")

--- a/migration-engine/migration-engine-tests/tests/existing_data/sql_unexecutable_migrations/made_optional_field_required.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_data/sql_unexecutable_migrations/made_optional_field_required.rs
@@ -12,7 +12,7 @@ fn making_an_optional_field_required_with_data_without_a_default_is_unexecutable
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     api.insert("Test")
         .value("id", "abc")
@@ -33,7 +33,7 @@ fn making_an_optional_field_required_with_data_without_a_default_is_unexecutable
     );
 
     api.schema_push(dm2)
-        .send_sync()
+        .send()
         .assert_no_warning()
         .assert_unexecutable(&[error]);
 
@@ -54,7 +54,7 @@ fn making_an_optional_field_required_with_data_with_a_default_works(api: TestApi
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     api.insert("Test")
         .value("id", "abc")
@@ -75,7 +75,7 @@ fn making_an_optional_field_required_with_data_with_a_default_works(api: TestApi
         }
     "#;
 
-    api.schema_push(dm2).force(true).send_sync();
+    api.schema_push(dm2).force(true).send();
 
     api.assert_schema().assert_table("Test", |table| {
         table.assert_column("age", |column| {
@@ -111,7 +111,7 @@ fn making_an_optional_field_required_with_data_with_a_default_is_unexecutable(ap
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     let initial_schema = api.assert_schema().into_schema();
 
@@ -141,7 +141,7 @@ fn making_an_optional_field_required_with_data_with_a_default_is_unexecutable(ap
 
     api.schema_push(dm2)
         .force(false)
-        .send_sync()
+        .send()
         .assert_unexecutable(&[error])
         .assert_no_warning();
 
@@ -170,7 +170,7 @@ fn making_an_optional_field_required_on_an_empty_table_works(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     let dm2 = r#"
         model Test {
@@ -180,7 +180,7 @@ fn making_an_optional_field_required_on_an_empty_table_works(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm2).send_sync().assert_green_bang();
+    api.schema_push(dm2).send().assert_green_bang();
 
     api.assert_schema()
         .assert_table("Test", |table| table.assert_does_not_have_column("Int"));

--- a/migration-engine/migration-engine-tests/tests/existing_data/sqlite_existing_data_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_data/sqlite_existing_data_tests.rs
@@ -11,7 +11,7 @@ fn changing_a_column_from_optional_to_required_with_a_default_is_safe(api: TestA
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 
     let insert = Insert::multi_into(api.render_table_name("Test"), &["id", "age"])
         .values(("a", 12))
@@ -27,7 +27,7 @@ fn changing_a_column_from_optional_to_required_with_a_default_is_safe(api: TestA
         }
     "#;
 
-    api.schema_push(dm2).force(true).send_sync().assert_green_bang();
+    api.schema_push(dm2).force(true).send().assert_green_bang();
 
     api.assert_schema().assert_table("Test", |table| {
         table.assert_column("age", |column| {

--- a/migration-engine/migration-engine-tests/tests/existing_data/type_migration_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_data/type_migration_tests.rs
@@ -11,7 +11,7 @@ fn altering_the_type_of_a_column_in_a_non_empty_table_warns(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     let insert = quaint::ast::Insert::single_into(api.render_table_name("User"))
         .value("id", "abc")
@@ -28,7 +28,7 @@ fn altering_the_type_of_a_column_in_a_non_empty_table_warns(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm2).send_sync().assert_warnings(&[
+    api.schema_push(dm2).send().assert_warnings(&[
         if api.is_postgres() {
             "You are about to alter the column `dogs` on the `User` table, which contains 1 non-null values. The data in that column will be cast from `BigInt` to `Integer`.".into()
         } else if api.lower_cases_table_names() {
@@ -55,7 +55,7 @@ fn migrating_a_required_column_from_int_to_string_should_cast(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     api.insert("Test")
         .value("id", "abcd")
@@ -72,7 +72,7 @@ fn migrating_a_required_column_from_int_to_string_should_cast(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm2).send_sync().assert_green_bang();
+    api.schema_push(dm2).send().assert_green_bang();
 
     api.assert_schema().assert_table("Test", |table| {
         table.assert_column("serialNumber", |col| col.assert_type_is_string())
@@ -100,7 +100,7 @@ fn changing_a_string_array_column_to_scalar_is_fine(api: TestApi) {
         datasource_block = datasource_block,
     );
 
-    api.schema_push(&dm1).send_sync().assert_green_bang();
+    api.schema_push(&dm1).send().assert_green_bang();
 
     api.insert("Film")
         .value("id", "film1")
@@ -122,7 +122,7 @@ fn changing_a_string_array_column_to_scalar_is_fine(api: TestApi) {
         datasource_block = datasource_block,
     );
 
-    api.schema_push(&dm2).force(true).send_sync().assert_green_bang();
+    api.schema_push(&dm2).force(true).send().assert_green_bang();
 
     api.assert_schema().assert_table("Film", |table| {
         table.assert_column("mainProtagonist", |column| column.assert_is_required())
@@ -151,7 +151,7 @@ fn changing_an_int_array_column_to_scalar_is_not_possible(api: TestApi) {
         datasource_block = datasource_block,
     );
 
-    api.schema_push(&dm1).send_sync().assert_green_bang();
+    api.schema_push(&dm1).send().assert_green_bang();
 
     api.insert("Film")
         .value("id", "film1")
@@ -172,7 +172,7 @@ fn changing_an_int_array_column_to_scalar_is_not_possible(api: TestApi) {
 
     api.schema_push(&dm2)
         .force(true)
-        .send_sync()
+        .send()
         .assert_no_warning()
         .assert_unexecutable(&["Changed the type of `mainProtagonist` on the `Film` table. No cast exists, the column would be dropped and recreated, which cannot be done since the column is required and there is data in the table.".into()]);
 
@@ -195,7 +195,7 @@ fn int_to_string_conversions_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     api.insert("Cat").value("tag", 20).result_raw();
 
@@ -207,7 +207,7 @@ fn int_to_string_conversions_work(api: TestApi) {
     "#;
 
     api.schema_push(dm2)
-        .send_sync()
+        .send()
         .assert_green_bang()
         .assert_has_executed_steps();
 
@@ -224,7 +224,7 @@ fn string_to_int_conversions_are_risky(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     api.insert("Cat").value("tag", "20").result_raw();
 
@@ -239,7 +239,7 @@ fn string_to_int_conversions_are_risky(api: TestApi) {
         // Not executable
         api.schema_push(dm2)
             .force(true)
-            .send_sync()
+            .send()
             .assert_no_warning()
             .assert_unexecutable(&["Changed the type of `tag` on the `Cat` table. No cast exists, the column would be dropped and recreated, which cannot be done since the column is required and there is data in the table.".into()]);
     } else if api.is_mysql() {
@@ -247,7 +247,7 @@ fn string_to_int_conversions_are_risky(api: TestApi) {
         if api.lower_cases_table_names() {
             api.schema_push(dm2)
             .force(true)
-            .send_sync()
+            .send()
             .assert_warnings(&[
                 "You are about to alter the column `tag` on the `cat` table, which contains 1 non-null values. The data in that column will be cast from `VarChar(191)` to `Int`.".into()
             ])
@@ -260,7 +260,7 @@ fn string_to_int_conversions_are_risky(api: TestApi) {
             // Executable, conditionally.
             api.schema_push(dm2)
                 .force(true)
-                .send_sync()
+                .send()
                 .assert_warnings(&[
                     "You are about to alter the column `tag` on the `Cat` table, which contains 1 non-null values. The data in that column will be cast from `VarChar(191)` to `Int`.".into()
                 ])
@@ -273,7 +273,7 @@ fn string_to_int_conversions_are_risky(api: TestApi) {
     } else if api.is_mssql() {
         api.schema_push(dm2)
         .force(true)
-        .send_sync()
+        .send()
         .assert_warnings(&[
             "You are about to alter the column `tag` on the `Cat` table, which contains 1 non-null values. The data in that column will be cast from `NVarChar(1000)` to `Int`.".into()
         ])
@@ -285,7 +285,7 @@ fn string_to_int_conversions_are_risky(api: TestApi) {
     } else if api.is_sqlite() {
         api.schema_push(dm2)
             .force(true)
-            .send_sync()
+            .send()
             .assert_warnings(&[
                 "You are about to alter the column `tag` on the `Cat` table, which contains 1 non-null values. The data in that column will be cast from `String` to `Int`.".into()
             ])
@@ -308,7 +308,7 @@ fn datetime_to_float_conversions_are_impossible(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     api.insert("Cat")
         .value("birthday", Value::datetime("2018-01-18T08:01:02Z".parse().unwrap()))
@@ -322,7 +322,7 @@ fn datetime_to_float_conversions_are_impossible(api: TestApi) {
     "#;
 
     api.schema_push(dm2)
-        .send_sync()
+        .send()
         .assert_warnings(&[
             "The `birthday` column on the `Cat` table would be dropped and recreated. This will lead to data loss."
                 .into(),
@@ -335,7 +335,7 @@ fn datetime_to_float_conversions_are_impossible(api: TestApi) {
 
     api.schema_push(dm2)
         .force(true)
-        .send_sync()
+        .send()
         .assert_warnings(&[
             "The `birthday` column on the `Cat` table would be dropped and recreated. This will lead to data loss."
                 .into(),

--- a/migration-engine/migration-engine-tests/tests/migrations/basic.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/basic.rs
@@ -10,7 +10,7 @@ fn adding_an_id_field_of_type_int_with_autoincrement_works(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm2).send_sync().assert_green_bang();
+    api.schema_push(dm2).send().assert_green_bang();
     api.assert_schema().assert_table("Test", |t| {
         t.assert_column("myId", |c| {
             if api.is_postgres() {
@@ -30,7 +30,7 @@ fn adding_multiple_optional_fields_to_an_existing_model_works(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     let dm2 = r#"
         model Cat {
@@ -40,7 +40,7 @@ fn adding_multiple_optional_fields_to_an_existing_model_works(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm2).send_sync().assert_green_bang();
+    api.schema_push(dm2).send().assert_green_bang();
 
     api.assert_schema().assert_table("Cat", |table| {
         table
@@ -109,7 +109,7 @@ fn adding_a_scalar_field_must_work(api: TestApi) {
         api.datasource_block(),
     );
 
-    api.schema_push(&dm).send_sync().assert_green_bang();
+    api.schema_push(&dm).send().assert_green_bang();
 
     api.assert_schema().assert_table("Test", |table| {
         table
@@ -141,7 +141,7 @@ fn adding_a_scalar_field_must_work(api: TestApi) {
     });
 
     // Check that the migration is idempotent.
-    api.schema_push(dm).send_sync().assert_green_bang().assert_no_steps();
+    api.schema_push(dm).send().assert_green_bang().assert_no_steps();
 }
 
 #[test_connector]
@@ -153,7 +153,7 @@ fn adding_an_optional_field_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm2).send_sync().assert_green_bang();
+    api.schema_push(dm2).send().assert_green_bang();
     api.assert_schema().assert_table("Test", |table| {
         table.assert_column("field", |column| column.assert_default(None).assert_is_nullable())
     });
@@ -167,7 +167,7 @@ fn adding_an_id_field_with_a_special_name_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm2).send_sync().assert_green_bang();
+    api.schema_push(dm2).send().assert_green_bang();
     api.assert_schema()
         .assert_table("Test", |table| table.assert_has_column("specialName"));
 }
@@ -181,7 +181,7 @@ fn adding_an_id_field_of_type_int_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm2).send_sync().assert_green_bang();
+    api.schema_push(dm2).send().assert_green_bang();
     api.assert_schema()
         .assert_table("Test", |t| t.assert_column("myId", |c| c.assert_no_auto_increment()));
 }
@@ -195,7 +195,7 @@ fn adding_an_id_field_of_type_int_must_work_for_sqlite(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm2).send_sync().assert_green_bang();
+    api.schema_push(dm2).send().assert_green_bang();
 
     api.assert_schema().assert_table("Test", |table| {
         table.assert_column("myId", |col| col.assert_auto_increments())
@@ -211,7 +211,7 @@ fn removing_a_scalar_field_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     api.assert_schema()
         .assert_table("Test", |table| table.assert_columns_count(2).assert_has_column("field"));
@@ -222,7 +222,7 @@ fn removing_a_scalar_field_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm2).send_sync().assert_green_bang();
+    api.schema_push(dm2).send().assert_green_bang();
 
     api.assert_schema()
         .assert_table("Test", |table| table.assert_column_count(1));
@@ -237,7 +237,7 @@ fn update_type_of_scalar_field_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     api.assert_schema().assert_table("Test", |table| {
         table.assert_column("field", |column| column.assert_type_is_string())
@@ -250,7 +250,7 @@ fn update_type_of_scalar_field_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm2).send_sync().assert_green_bang();
+    api.schema_push(dm2).send().assert_green_bang();
 
     api.assert_schema().assert_table("Test", |table| {
         table.assert_column("field", |column| column.assert_type_is_int())
@@ -266,7 +266,7 @@ fn updating_db_name_of_a_scalar_field_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
     api.assert_schema()
         .assert_table("A", |table| table.assert_has_column("name1"));
 
@@ -277,7 +277,7 @@ fn updating_db_name_of_a_scalar_field_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm2).send_sync().assert_green_bang();
+    api.schema_push(dm2).send().assert_green_bang();
     api.assert_schema().assert_table("A", |t| {
         t.assert_columns_count(2)
             .assert_has_column("id")
@@ -315,7 +315,7 @@ fn reordering_and_altering_models_at_the_same_time_works(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     let dm2 = r#"
         generator js {
@@ -345,7 +345,7 @@ fn reordering_and_altering_models_at_the_same_time_works(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm2).send_sync().assert_green_bang();
+    api.schema_push(dm2).send().assert_green_bang();
 }
 
 #[test_connector]
@@ -362,7 +362,7 @@ fn switching_databases_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     let dm2 = r#"
         datasource db {
@@ -378,7 +378,7 @@ fn switching_databases_must_work(api: TestApi) {
 
     api.schema_push(dm2)
         .migration_id(Some("mig2"))
-        .send_sync()
+        .send()
         .assert_green_bang();
 }
 
@@ -395,7 +395,7 @@ fn renaming_a_datasource_works(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     let dm2 = r#"
         datasource db2 {
@@ -410,7 +410,7 @@ fn renaming_a_datasource_works(api: TestApi) {
 
     api.schema_push(dm2)
         .migration_id(Some("mig02"))
-        .send_sync()
+        .send()
         .assert_green_bang()
         .assert_no_steps();
 }
@@ -426,7 +426,7 @@ fn simple_type_aliases_in_migrations_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 }
 
 #[test_connector]
@@ -441,7 +441,7 @@ fn created_at_does_not_get_arbitrarily_migrated(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
     api.assert_schema().assert_table("Fruit", |t| {
         t.assert_column("createdAt", |c| c.assert_default(Some(DefaultValue::now())))
     });
@@ -457,7 +457,7 @@ fn created_at_does_not_get_arbitrarily_migrated(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm2).send_sync().assert_green_bang().assert_no_steps();
+    api.schema_push(dm2).send().assert_green_bang().assert_no_steps();
 }
 
 #[test_connector]
@@ -471,7 +471,7 @@ fn basic_compound_primary_keys_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 
     api.assert_schema().assert_table("User", |table| {
         table.assert_pk(|pk| pk.assert_columns(&["lastName", "firstName"]))
@@ -489,7 +489,7 @@ fn compound_primary_keys_on_mapped_columns_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 
     api.assert_schema().assert_table("User", |table| {
         table.assert_pk(|pk| pk.assert_columns(&["first_name", "family_name"]))

--- a/migration-engine/migration-engine-tests/tests/migrations/defaults.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/defaults.rs
@@ -14,7 +14,7 @@ fn datetime_defaults_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 
     let expected_default = if api.is_postgres() {
         DefaultValue::db_generated("'2018-01-27 08:00:00'::timestamp without time zone")
@@ -41,7 +41,7 @@ fn function_expressions_as_dbgenerated_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 
     api.assert_schema().assert_table("Cat", |table| {
         table.assert_column("id", |col| {
@@ -58,7 +58,7 @@ fn default_dbgenerated_with_type_definitions_should_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 
     api.assert_schema().assert_table("A", |table| {
         table.assert_column("id", |col| {
@@ -75,7 +75,7 @@ fn default_dbgenerated_should_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 
     api.assert_schema().assert_table("A", |table| {
         table.assert_column("id", |col| {
@@ -93,7 +93,7 @@ fn uuid_default(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 
     api.assert_schema().assert_table("A", |table| {
         table.assert_column("uuid", |col| {
@@ -148,7 +148,7 @@ fn schemas_with_dbgenerated_work(api: TestApi) {
     }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 }
 
 #[test_connector(tags(Mysql8, Mariadb), exclude(Vitess))]
@@ -175,7 +175,7 @@ fn schemas_with_dbgenerated_expressions_work(api: TestApi) {
     }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 }
 
 #[test_connector]
@@ -187,7 +187,7 @@ fn column_defaults_must_be_migrated(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     api.assert_schema().assert_table("Fruit", |table| {
         table.assert_column("name", |col| {
@@ -202,7 +202,7 @@ fn column_defaults_must_be_migrated(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm2).send_sync().assert_green_bang();
+    api.schema_push(dm2).send().assert_green_bang();
 
     api.assert_schema().assert_table("Fruit", |table| {
         table.assert_column("name", |col| col.assert_default(Some(DefaultValue::value("mango"))))
@@ -225,7 +225,7 @@ fn escaped_string_defaults_are_not_arbitrarily_migrated(api: TestApi) {
 
     api.schema_push(dm1)
         .migration_id(Some("first migration"))
-        .send_sync()
+        .send()
         .assert_green_bang();
 
     let insert = Insert::single_into(api.render_table_name("Fruit"))
@@ -238,7 +238,7 @@ fn escaped_string_defaults_are_not_arbitrarily_migrated(api: TestApi) {
 
     api.schema_push(dm1)
         .migration_id(Some("second migration"))
-        .send_sync()
+        .send()
         .assert_green_bang()
         .assert_no_steps();
 

--- a/migration-engine/migration-engine-tests/tests/migrations/dev_diagnostic_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/dev_diagnostic_tests.rs
@@ -71,7 +71,7 @@ fn dev_diagnostic_detects_drift(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm2).send_sync();
+    api.schema_push(dm2).send();
 
     let DevDiagnosticOutput { action } = api.dev_diagnostic(&directory).send().into_output();
 

--- a/migration-engine/migration-engine-tests/tests/migrations/diagnose_migration_history_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/diagnose_migration_history_tests.rs
@@ -74,7 +74,7 @@ fn diagnose_migration_history_with_opt_in_to_shadow_database_calculates_drift(ap
         }
     "#;
 
-    api.schema_push(dm2).send_sync();
+    api.schema_push(dm2).send();
 
     let DiagnoseMigrationHistoryOutput {
         drift,
@@ -131,7 +131,7 @@ fn diagnose_migration_history_without_opt_in_to_shadow_database_does_not_calcula
         }
     "#;
 
-    api.schema_push(dm2).send_sync();
+    api.schema_push(dm2).send();
 
     let DiagnoseMigrationHistoryOutput {
         drift,

--- a/migration-engine/migration-engine-tests/tests/migrations/enums.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/enums.rs
@@ -27,7 +27,7 @@ fn adding_an_enum_field_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 
     api.assert_schema().assert_table("Test", |table| {
         table.assert_columns_count(2).assert_column("enum", |c| {
@@ -45,7 +45,7 @@ fn adding_an_enum_field_must_work(api: TestApi) {
     });
 
     // Check that the migration is idempotent.
-    api.schema_push(dm).send_sync().assert_no_steps();
+    api.schema_push(dm).send().assert_no_steps();
 }
 
 #[test_connector(capabilities(Enums))]
@@ -62,7 +62,7 @@ fn adding_an_enum_field_must_work_with_native_types_off(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 
     api.assert_schema().assert_table("Test", |table| {
         table.assert_columns_count(2).assert_column("enum", |c| {
@@ -79,12 +79,12 @@ fn adding_an_enum_field_must_work_with_native_types_off(api: TestApi) {
     });
 
     // Check that the migration is idempotent.
-    api.schema_push(dm).send_sync().assert_no_steps();
+    api.schema_push(dm).send().assert_no_steps();
 }
 
 #[test_connector(capabilities(Enums))]
 fn an_enum_can_be_turned_into_a_model(api: TestApi) {
-    api.schema_push(BASIC_ENUM_DM).send_sync().assert_green_bang();
+    api.schema_push(BASIC_ENUM_DM).send().assert_green_bang();
 
     let enum_name = if api.lower_cases_table_names() {
         "cat_mood"
@@ -112,7 +112,7 @@ fn an_enum_can_be_turned_into_a_model(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm2).send_sync().assert_green_bang();
+    api.schema_push(dm2).send().assert_green_bang();
 
     api.assert_schema()
         .assert_table("Cat", |table| table.assert_columns_count(2).assert_has_column("moodId"))
@@ -133,7 +133,7 @@ fn variants_can_be_added_to_an_existing_enum(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     let enum_name = if api.lower_cases_table_names() {
         "cat_mood"
@@ -159,7 +159,7 @@ fn variants_can_be_added_to_an_existing_enum(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm2).send_sync().assert_green_bang();
+    api.schema_push(dm2).send().assert_green_bang();
 
     api.assert_schema()
         .assert_enum(enum_name, |enm| enm.assert_values(&["HUNGRY", "HAPPY", "JOYJOY"]));
@@ -179,7 +179,7 @@ fn variants_can_be_removed_from_an_existing_enum(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     let enum_name = if api.lower_cases_table_names() {
         "cat_mood"
@@ -211,7 +211,7 @@ fn variants_can_be_removed_from_an_existing_enum(api: TestApi) {
 
     api.schema_push(dm2)
         .force(true)
-        .send_sync()
+        .send()
         .assert_warnings(&[warning.into()])
         .assert_executable();
 
@@ -221,7 +221,7 @@ fn variants_can_be_removed_from_an_existing_enum(api: TestApi) {
 
 #[test_connector(capabilities(Enums))]
 fn models_with_enum_values_can_be_dropped(api: TestApi) {
-    api.schema_push(BASIC_ENUM_DM).send_sync().assert_green_bang();
+    api.schema_push(BASIC_ENUM_DM).send().assert_green_bang();
 
     api.assert_schema().assert_tables_count(1);
 
@@ -235,7 +235,7 @@ fn models_with_enum_values_can_be_dropped(api: TestApi) {
 
     api.schema_push("")
         .force(true)
-        .send_sync()
+        .send()
         .assert_executable()
         .assert_warnings(&[warn.into()]);
 
@@ -256,7 +256,7 @@ fn enum_field_to_string_field_works(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     api.assert_schema().assert_table("Cat", |table| {
         table.assert_column("mood", |col| col.assert_type_is_enum())
@@ -271,7 +271,7 @@ fn enum_field_to_string_field_works(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm2).force(true).send_sync().assert_executable();
+    api.schema_push(dm2).force(true).send().assert_executable();
 
     api.assert_schema().assert_table("Cat", |table| {
         table.assert_column("mood", |col| col.assert_type_is_string())
@@ -287,7 +287,7 @@ fn string_field_to_enum_field_works(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     api.assert_schema().assert_table("Cat", |table| {
         table.assert_column("mood", |col| col.assert_type_is_string())
@@ -317,7 +317,7 @@ fn string_field_to_enum_field_works(api: TestApi) {
 
     api.schema_push(dm2)
         .force(true)
-        .send_sync()
+        .send()
         .assert_executable()
         .assert_warnings(&[warn.into()]);
 
@@ -365,7 +365,7 @@ fn enums_used_in_default_can_be_changed(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     api.assert_schema().assert_tables_count(5);
 
@@ -410,14 +410,14 @@ fn enums_used_in_default_can_be_changed(api: TestApi) {
     if api.is_postgres() {
         api.schema_push(dm2)
             .force(true)
-            .send_sync()
+            .send()
             .assert_executable()
             .assert_warnings(&["The values [HUNGRY] on the enum `CatMood` will be removed. If these variants are still used in the database, this will fail.".into()]
             );
     } else {
         api.schema_push(dm2)
             .force(true)
-            .send_sync()
+            .send()
             .assert_executable()
             .assert_warnings(& ["The values [HUNGRY] on the enum `Panther_mood` will be removed. If these variants are still used in the database, this will fail.".into(),
                 "The values [HUNGRY] on the enum `Tiger_mood` will be removed. If these variants are still used in the database, this will fail.".into(),]
@@ -445,7 +445,7 @@ fn changing_all_values_of_enums_used_in_defaults_works(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     let dm2 = r#"
         model Cat {
@@ -465,7 +465,7 @@ fn changing_all_values_of_enums_used_in_defaults_works(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm2).force(true).send_sync();
+    api.schema_push(dm2).force(true).send();
 
     api.assert_schema().assert_table("Cat", |table| {
         table.assert_column("eveningMood", |col| col.assert_enum_default("MEOWMEOW"))
@@ -499,5 +499,5 @@ fn existing_enums_are_picked_up(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang().assert_no_steps();
+    api.schema_push(dm).send().assert_green_bang().assert_no_steps();
 }

--- a/migration-engine/migration-engine-tests/tests/migrations/foreign_keys.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/foreign_keys.rs
@@ -16,7 +16,7 @@ fn foreign_keys_of_inline_one_to_one_relations_have_a_unique_constraint(api: Tes
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
     api.assert_schema().assert_table("Box", |t| {
         t.assert_indexes_count(1).assert_index_on_columns(&["cat_id"], |idx| {
             idx.assert_is_unique().assert_name("Box_cat_id_unique")
@@ -37,7 +37,7 @@ fn foreign_keys_are_added_on_existing_tables(api: TestApi) -> TestResult {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     api.assert_schema()
         // There should be no foreign keys yet.
@@ -57,7 +57,7 @@ fn foreign_keys_are_added_on_existing_tables(api: TestApi) -> TestResult {
         }
     "#;
 
-    api.schema_push(dm2).send_sync().assert_green_bang();
+    api.schema_push(dm2).send().assert_green_bang();
 
     api.assert_schema().assert_table("Account", |table| {
         table
@@ -80,7 +80,7 @@ fn foreign_keys_can_be_added_on_existing_columns(api: TestApi) -> TestResult {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     api.assert_schema()
         // There should be no foreign keys yet.
@@ -100,7 +100,7 @@ fn foreign_keys_can_be_added_on_existing_columns(api: TestApi) -> TestResult {
         }
     "#;
 
-    api.schema_push(dm2).send_sync().assert_green_bang();
+    api.schema_push(dm2).send().assert_green_bang();
 
     api.assert_schema().assert_table("Account", |table| {
         table
@@ -125,7 +125,7 @@ fn foreign_keys_can_be_dropped_on_existing_columns(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     api.assert_schema().assert_table("Account", |table| {
         table
@@ -145,7 +145,7 @@ fn foreign_keys_can_be_dropped_on_existing_columns(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm2).send_sync().assert_green_bang();
+    api.schema_push(dm2).send().assert_green_bang();
 
     api.assert_schema()
         .assert_table("Account", |table| table.assert_foreign_keys_count(0));
@@ -164,7 +164,7 @@ fn changing_a_scalar_field_to_a_relation_field_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
     api.assert_schema().assert_table("A", |t| {
         t.assert_column("b", |c| c.assert_type_is_string())
             .assert_foreign_keys_count(0)
@@ -186,7 +186,7 @@ fn changing_a_scalar_field_to_a_relation_field_must_work(api: TestApi) {
 
     api.schema_push(dm2)
         .force(true)
-        .send_sync()
+        .send()
         .assert_executable()
         .assert_has_executed_steps();
 
@@ -212,7 +212,7 @@ fn changing_a_relation_field_to_a_scalar_field_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     api.assert_schema().assert_table("A", |table| {
         table
@@ -234,7 +234,7 @@ fn changing_a_relation_field_to_a_scalar_field_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm2).send_sync().assert_green_bang();
+    api.schema_push(dm2).send().assert_green_bang();
 
     api.assert_schema().assert_table("A", |table| {
         table
@@ -259,7 +259,7 @@ fn changing_a_foreign_key_constrained_column_from_nullable_to_required_and_back_
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 
     let dm2 = r#"
         model Student {
@@ -275,8 +275,8 @@ fn changing_a_foreign_key_constrained_column_from_nullable_to_required_and_back_
         }
     "#;
 
-    api.schema_push(dm2).send_sync().assert_green_bang();
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm2).send().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 }
 
 // TODO: Enable SQL Server when cascading rules are in PSL.
@@ -295,7 +295,7 @@ fn changing_all_referenced_columns_of_foreign_key_works(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     let dm2 = r#"
         model Post {
@@ -310,5 +310,5 @@ fn changing_all_referenced_columns_of_foreign_key_works(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm2).send_sync().assert_green_bang();
+    api.schema_push(dm2).send().assert_green_bang();
 }

--- a/migration-engine/migration-engine-tests/tests/migrations/id.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/id.rs
@@ -15,7 +15,7 @@ fn changing_the_type_of_an_id_field_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     api.assert_schema().assert_table("A", |table| {
         table
@@ -37,7 +37,7 @@ fn changing_the_type_of_an_id_field_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm2).send_sync().assert_green_bang();
+    api.schema_push(dm2).send().assert_green_bang();
 
     api.assert_schema().assert_table("A", |table| {
         table
@@ -66,7 +66,7 @@ fn models_with_an_autoincrement_field_as_part_of_a_multi_field_id_can_be_created
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 
     api.assert_schema().assert_table("Todo", |table| {
         table
@@ -97,7 +97,7 @@ fn making_an_existing_id_field_autoincrement_works(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     api.assert_schema().assert_table("Post", |model| {
         model.assert_pk(|pk| pk.assert_columns(&["id"]).assert_has_no_autoincrement())
@@ -132,14 +132,14 @@ fn making_an_existing_id_field_autoincrement_works(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm2).send_sync().assert_green_bang();
+    api.schema_push(dm2).send().assert_green_bang();
 
     api.assert_schema().assert_table("Post", |model| {
         model.assert_pk(|pk| pk.assert_columns(&["id"]).assert_has_autoincrement())
     });
 
     // Check that the migration is idempotent.
-    api.schema_push(dm2).send_sync().assert_green_bang().assert_no_steps();
+    api.schema_push(dm2).send().assert_green_bang().assert_no_steps();
 
     // MySQL cannot add autoincrement property to a column that already has data.
     if !api.is_mysql() {
@@ -167,7 +167,7 @@ fn removing_autoincrement_from_an_existing_field_works(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     api.assert_schema().assert_table("Post", |model| {
         model.assert_pk(|pk| pk.assert_columns(&["id"]).assert_has_autoincrement())
@@ -196,7 +196,7 @@ fn removing_autoincrement_from_an_existing_field_works(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm2).send_sync().assert_green_bang();
+    api.schema_push(dm2).send().assert_green_bang();
 
     api.assert_schema().assert_table("Post", |model| {
         model.assert_pk(|pk| pk.assert_columns(&["id"]).assert_has_no_autoincrement())
@@ -205,7 +205,7 @@ fn removing_autoincrement_from_an_existing_field_works(api: TestApi) {
     // Check that the migration is idempotent.
     api.schema_push(dm2)
         .migration_id(Some("idempotency-check"))
-        .send_sync()
+        .send()
         .assert_green_bang()
         .assert_no_steps();
 
@@ -229,7 +229,7 @@ fn making_an_existing_id_field_autoincrement_works_with_indices(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     api.assert_schema().assert_table("Post", |model| {
         model
@@ -261,7 +261,7 @@ fn making_an_existing_id_field_autoincrement_works_with_indices(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm2).send_sync().assert_green_bang();
+    api.schema_push(dm2).send().assert_green_bang();
 
     api.assert_schema().assert_table("Post", |model| {
         model
@@ -270,7 +270,7 @@ fn making_an_existing_id_field_autoincrement_works_with_indices(api: TestApi) {
     });
 
     // Check that the migration is idempotent.
-    api.schema_push(dm2).send_sync().assert_green_bang().assert_no_steps();
+    api.schema_push(dm2).send().assert_green_bang().assert_no_steps();
 
     assert_eq!(
         3,
@@ -308,7 +308,7 @@ fn making_an_existing_id_field_autoincrement_works_with_foreign_keys(api: TestAp
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     api.assert_schema().assert_table("Post", |model| {
         model.assert_pk(|pk| pk.assert_columns(&["id"]).assert_has_no_autoincrement())
@@ -370,7 +370,7 @@ fn making_an_existing_id_field_autoincrement_works_with_foreign_keys(api: TestAp
         }
     "#;
 
-    api.schema_push(dm2).send_sync().assert_green_bang();
+    api.schema_push(dm2).send().assert_green_bang();
 
     api.assert_schema().assert_table("Post", |model| {
         model.assert_pk(|pk| pk.assert_columns(&["id"]).assert_has_autoincrement())
@@ -404,7 +404,7 @@ fn flipping_autoincrement_on_and_off_works(api: TestApi) {
     "#;
 
     for dm in [dm_with, dm_without].iter().cycle().take(5) {
-        api.schema_push(*dm).send_sync().assert_green_bang();
+        api.schema_push(*dm).send().assert_green_bang();
     }
 }
 
@@ -420,7 +420,7 @@ fn making_an_autoincrement_default_an_expression_then_autoincrement_again_works(
 
     api.schema_push(dm1)
         .migration_id(Some("apply_dm1"))
-        .send_sync()
+        .send()
         .assert_green_bang();
 
     api.assert_schema().assert_table("Post", |model| {
@@ -436,7 +436,7 @@ fn making_an_autoincrement_default_an_expression_then_autoincrement_again_works(
 
     api.schema_push(dm2)
         .migration_id(Some("apply_dm2"))
-        .send_sync()
+        .send()
         .assert_green_bang();
 
     api.assert_schema().assert_table("Post", |model| {
@@ -448,7 +448,7 @@ fn making_an_autoincrement_default_an_expression_then_autoincrement_again_works(
     // Now re-apply the sequence.
     api.schema_push(dm1)
         .migration_id(Some("apply_dm1_again"))
-        .send_sync()
+        .send()
         .assert_green_bang();
 
     api.assert_schema().assert_table("Post", |model| {
@@ -470,7 +470,7 @@ fn migrating_a_unique_constraint_to_a_primary_key_works(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 
     api.assert_schema().assert_table("model1", |table| {
         table
@@ -498,7 +498,7 @@ fn migrating_a_unique_constraint_to_a_primary_key_works(api: TestApi) {
 
     api.schema_push(dm2)
         .force(true)
-        .send_sync()
+        .send()
         .assert_executable()
         .assert_warnings(&["The primary key for the `model1` table will be changed. If it partially fails, the table could be left without primary key constraint.".into(), "You are about to drop the column `id` on the `model1` table, which still contains 1 non-null values.".into()]);
 

--- a/migration-engine/migration-engine-tests/tests/migrations/indexes.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/indexes.rs
@@ -22,7 +22,7 @@ fn index_on_compound_relation_fields_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 
     api.assert_schema().assert_table("Post", |table| {
         table
@@ -44,7 +44,7 @@ fn index_settings_must_be_migrated(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 
     api.assert_schema().assert_table("Test", |table| {
         table
@@ -66,7 +66,7 @@ fn index_settings_must_be_migrated(api: TestApi) {
 
     api.schema_push(dm2)
         .force(true)
-        .send_sync()
+        .send()
         .assert_warnings(&["A unique constraint covering the columns `[name,followersCount]` on the table `Test` will be added. If there are existing duplicate values, this will fail.".into()]);
 
     api.assert_schema().assert_table("Test", |table| {
@@ -96,7 +96,7 @@ fn unique_directive_on_required_one_to_one_relation_creates_one_index(api: TestA
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 
     api.assert_schema()
         .assert_table("Cat", |table| table.assert_indexes_count(1));
@@ -118,7 +118,7 @@ fn one_to_many_self_relations_do_not_create_a_unique_index(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 
     if api.is_mysql() {
         // MySQL creates an index for the FK.
@@ -165,7 +165,7 @@ fn model_with_multiple_indexes_works(api: TestApi) {
     }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
     api.assert_schema()
         .assert_table("Like", |table| table.assert_indexes_count(3));
 }
@@ -182,7 +182,7 @@ fn removing_multi_field_unique_index_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     api.assert_schema().assert_table("A", |table| {
         table.assert_index_on_columns(&["field", "secondField"], |idx| idx.assert_is_unique())
@@ -196,7 +196,7 @@ fn removing_multi_field_unique_index_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm2).send_sync().assert_green_bang();
+    api.schema_push(dm2).send().assert_green_bang();
 
     api.assert_schema()
         .assert_table("A", |table| table.assert_indexes_count(0));
@@ -215,7 +215,7 @@ fn index_renaming_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     api.assert_schema().assert_table("A", |table| {
         table
@@ -238,7 +238,7 @@ fn index_renaming_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm2).send_sync().assert_green_bang();
+    api.schema_push(dm2).send().assert_green_bang();
 
     api.assert_schema().assert_table("A", |table| {
         table
@@ -264,7 +264,7 @@ fn index_renaming_must_work_when_renaming_to_default(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
     api.assert_schema().assert_table("A", |t| {
         t.assert_index_on_columns(&["field", "secondField"], |idx| idx.assert_is_unique())
     });
@@ -279,7 +279,7 @@ fn index_renaming_must_work_when_renaming_to_default(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm2).send_sync();
+    api.schema_push(dm2).send();
     api.assert_schema().assert_table("A", |t| {
         t.assert_index_on_columns(&["field", "secondField"], |idx| {
             idx.assert_is_unique().assert_name("A.field_secondField_unique")
@@ -299,7 +299,7 @@ fn index_renaming_must_work_when_renaming_to_custom(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     api.assert_schema().assert_table("A", |table| {
         table
@@ -317,7 +317,7 @@ fn index_renaming_must_work_when_renaming_to_custom(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm2).send_sync().assert_green_bang();
+    api.schema_push(dm2).send().assert_green_bang();
 
     api.assert_schema().assert_table("A", |table| {
         table
@@ -340,7 +340,7 @@ fn index_updates_with_rename_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
     api.assert_schema().assert_table("A", |t| {
         t.assert_index_on_columns(&["field", "secondField"], |idx| idx.assert_is_unique())
     });
@@ -355,7 +355,7 @@ fn index_updates_with_rename_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm2).force(true).send_sync().assert_executable();
+    api.schema_push(dm2).force(true).send().assert_executable();
 
     api.assert_schema().assert_table("A", |t| {
         t.assert_indexes_count(1)
@@ -375,14 +375,14 @@ fn dropping_a_model_with_a_multi_field_unique_index_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
     api.assert_schema().assert_table("A", |t| {
         t.assert_index_on_columns(&["field", "secondField"], |idx| {
             idx.assert_name("customName").assert_is_unique()
         })
     });
 
-    api.schema_push("").send_sync().assert_green_bang();
+    api.schema_push("").send().assert_green_bang();
 }
 
 #[test_connector(tags(Postgres, Mysql))]
@@ -398,7 +398,7 @@ fn indexes_with_an_automatically_truncated_name_are_idempotent(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 
     api.assert_schema().assert_table("TestModelWithALongName", |table| {
         table.assert_index_on_columns(
@@ -419,7 +419,7 @@ fn indexes_with_an_automatically_truncated_name_are_idempotent(api: TestApi) {
         )
     });
 
-    api.schema_push(dm).send_sync().assert_green_bang().assert_no_steps();
+    api.schema_push(dm).send().assert_green_bang().assert_no_steps();
 }
 
 #[test_connector]
@@ -446,7 +446,7 @@ fn new_index_with_same_name_as_index_from_dropped_table_works(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     api.assert_schema().assert_table("Cat", |table| {
         table.assert_column("ownerid", |col| col.assert_is_required())
@@ -467,7 +467,7 @@ fn new_index_with_same_name_as_index_from_dropped_table_works(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm2).send_sync().assert_green_bang();
+    api.schema_push(dm2).send().assert_green_bang();
 
     api.assert_schema().assert_table("Owner", |table| {
         table.assert_column("ownerid", |col| col.assert_is_required())

--- a/migration-engine/migration-engine-tests/tests/migrations/json.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/json.rs
@@ -16,7 +16,7 @@ fn json_fields_can_be_created(api: TestApi) {
         api.datasource_block()
     );
 
-    api.schema_push(&dm).send_sync().assert_green_bang();
+    api.schema_push(&dm).send().assert_green_bang();
 
     api.assert_schema().assert_table("Test", |table| {
         table.assert_column("javaScriptObjectNotation", |c| {
@@ -29,7 +29,7 @@ fn json_fields_can_be_created(api: TestApi) {
         })
     });
 
-    api.schema_push(&dm).send_sync().assert_green_bang().assert_no_steps();
+    api.schema_push(&dm).send().assert_green_bang().assert_no_steps();
 }
 
 #[test_connector(capabilities(Json), exclude(Mysql56))]
@@ -46,7 +46,7 @@ fn database_level_json_defaults_can_be_defined(api: TestApi) {
         datasource = api.datasource_block()
     );
 
-    api.schema_push(&dm).send_sync().assert_green_bang();
+    api.schema_push(&dm).send().assert_green_bang();
 
     api.assert_schema().assert_table("Dog", |table| {
         table.assert_column("favouriteThings", |column| {
@@ -69,5 +69,5 @@ fn database_level_json_defaults_can_be_defined(api: TestApi) {
     });
 
     // Check that the migration is idempotent.
-    api.schema_push(&dm).send_sync().assert_green_bang().assert_no_steps();
+    api.schema_push(&dm).send().assert_green_bang().assert_no_steps();
 }

--- a/migration-engine/migration-engine-tests/tests/migrations/mariadb.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/mariadb.rs
@@ -19,7 +19,7 @@ fn foreign_keys_to_indexes_being_renamed_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     api.assert_schema()
         .assert_table("User", |table| {
@@ -56,7 +56,7 @@ fn foreign_keys_to_indexes_being_renamed_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm2).send_sync().assert_green_bang();
+    api.schema_push(dm2).send().assert_green_bang();
 
     api.assert_schema()
         .assert_table("User", |table| {

--- a/migration-engine/migration-engine-tests/tests/migrations/mark_migration_applied_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/mark_migration_applied_tests.rs
@@ -259,7 +259,7 @@ fn baselining_should_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync();
+    api.schema_push(dm1).send();
 
     // Create a first local migration that matches the db contents
     let baseline_migration_name = {

--- a/migration-engine/migration-engine-tests/tests/migrations/mssql.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/mssql.rs
@@ -29,7 +29,7 @@ fn shared_default_constraints_are_ignored_issue_5423(api: TestApi) {
 
     api.schema_push(dm)
         .migration_id(Some("first"))
-        .send_sync()
+        .send()
         .assert_green_bang()
         .assert_no_steps();
 }

--- a/migration-engine/migration-engine-tests/tests/migrations/mysql.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/mysql.rs
@@ -21,7 +21,7 @@ fn indexes_on_foreign_key_fields_are_not_created_twice(api: TestApi) {
         }
     "#;
 
-    api.schema_push(schema).send_sync();
+    api.schema_push(schema).send();
 
     let sql_schema = api
         .assert_schema()
@@ -37,7 +37,7 @@ fn indexes_on_foreign_key_fields_are_not_created_twice(api: TestApi) {
     // Test that after introspection, we do not migrate further.
     api.schema_push(schema)
         .force(true)
-        .send_sync()
+        .send()
         .assert_green_bang()
         .assert_no_steps();
 
@@ -64,8 +64,8 @@ fn enum_creation_is_idempotent(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
-    api.schema_push(dm1).send_sync().assert_green_bang().assert_no_steps();
+    api.schema_push(dm1).send().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang().assert_no_steps();
 }
 
 #[test_connector(tags(Mysql))]
@@ -85,7 +85,7 @@ fn enums_work_when_table_name_is_remapped(api: TestApi) {
     }
     "#;
 
-    api.schema_push(schema).send_sync().assert_green_bang();
+    api.schema_push(schema).send().assert_green_bang();
 }
 
 #[test_connector(tags(Mysql))]
@@ -104,7 +104,7 @@ fn arity_of_enum_columns_can_be_changed(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     api.assert_schema().assert_table("A", |table| {
         table
@@ -126,7 +126,7 @@ fn arity_of_enum_columns_can_be_changed(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm2).send_sync().assert_green_bang();
+    api.schema_push(dm2).send().assert_green_bang();
 
     api.assert_schema().assert_table("A", |table| {
         table
@@ -151,7 +151,7 @@ fn arity_is_preserved_by_alter_enum(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     api.assert_schema().assert_table("A", |table| {
         table
@@ -175,7 +175,7 @@ fn arity_is_preserved_by_alter_enum(api: TestApi) {
 
     api.schema_push(dm2)
         .force(true)
-        .send_sync()
+        .send()
         .assert_executable()
         .assert_has_executed_steps();
 
@@ -257,7 +257,7 @@ fn native_type_columns_can_be_created(api: TestApi) {
 
     dm.push_str("}\n");
 
-    api.schema_push(&dm).send_sync().assert_green_bang();
+    api.schema_push(&dm).send().assert_green_bang();
 
     api.assert_schema().assert_table("A", |table| {
         types.iter().fold(
@@ -269,7 +269,7 @@ fn native_type_columns_can_be_created(api: TestApi) {
     });
 
     // Check that the migration is idempotent
-    api.schema_push(dm).send_sync().assert_green_bang().assert_no_steps();
+    api.schema_push(dm).send().assert_green_bang().assert_no_steps();
 }
 
 #[test_connector(tags(Mysql))]

--- a/migration-engine/migration-engine-tests/tests/migrations/planetscale_mode.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/planetscale_mode.rs
@@ -35,8 +35,8 @@ fn schema_push_planetscale_mode_works(api: TestApi) {
         datasource = api.datasource_block_with(&[("planetScaleMode", "true")]),
     );
 
-    api.schema_push(&dm).send_sync().assert_green_bang();
-    api.schema_push(dm).send_sync().assert_green_bang().assert_no_steps(); // idempotence
+    api.schema_push(&dm).send().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang().assert_no_steps(); // idempotence
 
     api.assert_schema()
         .assert_table("Post", |table| table.assert_foreign_keys_count(0))

--- a/migration-engine/migration-engine-tests/tests/migrations/postgres.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/postgres.rs
@@ -88,6 +88,24 @@ fn existing_postgis_tables_must_not_be_migrated(api: TestApi) {
         .assert_has_table("Geometry_columns");
 }
 
+// Reference for the tables created by PostGIS: https://postgis.net/docs/manual-1.4/ch04.html#id418599
+#[test_connector(tags(Postgres))]
+fn existing_postgis_views_must_not_be_migrated(api: TestApi) {
+    let create_spatial_ref_sys_view = "CREATE VIEW \"spatial_ref_sys\" AS SELECT 1";
+    // The capitalized Geometry is intentional here, because we want the matching to be case-insensitive.
+    let create_geometry_columns_view = "CREATE VIEW \"Geometry_columns\" AS SELECT 1";
+
+    api.raw_cmd(create_spatial_ref_sys_view);
+    api.raw_cmd(create_geometry_columns_view);
+
+    let schema = "";
+
+    api.schema_push(schema)
+        .send_sync()
+        .assert_green_bang()
+        .assert_no_steps();
+}
+
 #[test_connector(tags(Postgres))]
 fn native_type_columns_can_be_created(api: TestApi) {
     let types = &[

--- a/migration-engine/migration-engine-tests/tests/migrations/postgres.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/postgres.rs
@@ -18,7 +18,7 @@ fn enums_can_be_dropped_on_postgres(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
     api.assert_schema()
         .assert_enum("CatMood", |r#enum| r#enum.assert_values(&["ANGRY", "HUNGRY", "CUDDLY"]));
 
@@ -29,7 +29,7 @@ fn enums_can_be_dropped_on_postgres(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm2).send_sync().assert_green_bang();
+    api.schema_push(dm2).send().assert_green_bang();
     api.assert_schema().assert_has_no_enum("CatMood");
 }
 
@@ -50,7 +50,7 @@ fn adding_a_scalar_list_for_a_model_with_id_type_int_must_work(api: TestApi) {
     "#,
     );
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     api.assert_schema().assert_table("A", |table| {
         table
@@ -78,10 +78,7 @@ fn existing_postgis_tables_must_not_be_migrated(api: TestApi) {
 
     let schema = "";
 
-    api.schema_push(schema)
-        .send_sync()
-        .assert_green_bang()
-        .assert_no_steps();
+    api.schema_push(schema).send().assert_green_bang().assert_no_steps();
 
     api.assert_schema()
         .assert_has_table("spatial_ref_sys")
@@ -100,10 +97,7 @@ fn existing_postgis_views_must_not_be_migrated(api: TestApi) {
 
     let schema = "";
 
-    api.schema_push(schema)
-        .send_sync()
-        .assert_green_bang()
-        .assert_no_steps();
+    api.schema_push(schema).send().assert_green_bang().assert_no_steps();
 }
 
 #[test_connector(tags(Postgres))]
@@ -153,7 +147,7 @@ fn native_type_columns_can_be_created(api: TestApi) {
 
     dm.push_str("}\n");
 
-    api.schema_push(&dm).send_sync().assert_green_bang();
+    api.schema_push(&dm).send().assert_green_bang();
 
     api.assert_schema().assert_table("A", |table| {
         types.iter().fold(
@@ -164,7 +158,7 @@ fn native_type_columns_can_be_created(api: TestApi) {
         )
     });
 
-    api.schema_push(dm).send_sync().assert_green_bang().assert_no_steps();
+    api.schema_push(dm).send().assert_green_bang().assert_no_steps();
 }
 
 #[test_connector(tags(Postgres))]
@@ -194,7 +188,7 @@ fn uuids_do_not_generate_drift_issue_5282(api: TestApi) {
 
     api.schema_push(&dm)
         .migration_id(Some("first"))
-        .send_sync()
+        .send()
         .assert_green_bang()
         .assert_no_steps();
 }
@@ -212,10 +206,10 @@ fn functions_with_schema_prefix_in_dbgenerated_are_idempotent(api: TestApi) {
     );
 
     api.schema_push(dm.clone())
-        .send_sync()
+        .send()
         .assert_green_bang()
         .assert_has_executed_steps();
-    api.schema_push(dm).send_sync().assert_green_bang().assert_no_steps();
+    api.schema_push(dm).send().assert_green_bang().assert_no_steps();
 }
 
 #[test_connector(tags(Postgres))]
@@ -354,13 +348,13 @@ fn citext_to_text_and_back_works(api: TestApi) {
     "#,
     );
 
-    api.schema_push(&dm1).send_sync().assert_green_bang();
+    api.schema_push(&dm1).send().assert_green_bang();
 
     api.raw_cmd("INSERT INTO \"User\" (name) VALUES ('myCat'), ('myDog'), ('yourDog');");
 
     // TEXT -> CITEXT
     api.schema_push(dm2)
-        .send_sync()
+        .send()
         .assert_green_bang()
         .assert_has_executed_steps();
 
@@ -370,7 +364,7 @@ fn citext_to_text_and_back_works(api: TestApi) {
 
     // CITEXT -> TEXT
     api.schema_push(&dm1)
-        .send_sync()
+        .send()
         .assert_green_bang()
         .assert_has_executed_steps();
 

--- a/migration-engine/migration-engine-tests/tests/migrations/relations.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/relations.rs
@@ -16,7 +16,7 @@ fn adding_a_many_to_many_relation_must_result_in_a_prisma_style_relation_table(a
         }
     "##;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     api.assert_schema().assert_table("_AToB", |table| {
         table
@@ -49,7 +49,7 @@ fn adding_a_many_to_many_relation_with_custom_name_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     api.assert_schema().assert_table("_my_relation", |table| {
         table
@@ -84,7 +84,7 @@ fn adding_an_inline_relation_must_result_in_a_foreign_key_in_the_model_table(api
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
     api.assert_schema().assert_table("A", |t| {
         t.assert_column("bid", |c| c.assert_type_is_int().assert_is_required())
             .assert_column("cid", |c| c.assert_type_is_int().assert_is_nullable())
@@ -113,7 +113,7 @@ fn specifying_a_db_name_for_an_inline_relation_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
     api.assert_schema().assert_table("A", |t| {
         t.assert_column("b_column", |c| c.assert_type_is_int())
             .assert_foreign_keys_count(1)
@@ -137,7 +137,7 @@ fn changing_the_type_of_a_field_referenced_by_a_fk_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     api.assert_schema().assert_table("A", |table| {
         table
@@ -159,7 +159,7 @@ fn changing_the_type_of_a_field_referenced_by_a_fk_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm2).send_sync().assert_green_bang();
+    api.schema_push(dm2).send().assert_green_bang();
 
     api.assert_schema().assert_table("A", |table| {
         table
@@ -183,7 +183,7 @@ fn adding_an_inline_relation_to_a_model_with_an_exotic_id_type(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
     api.assert_schema().assert_table("A", |t| {
         t.assert_column("b_id", |c| c.assert_type_is_string())
             .assert_foreign_keys_count(1)
@@ -210,7 +210,7 @@ fn removing_an_inline_relation_must_work(api: TestApi) {
             }
         "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     api.assert_schema()
         .assert_table("A", |table| table.assert_has_column("b_id"));
@@ -225,7 +225,7 @@ fn removing_an_inline_relation_must_work(api: TestApi) {
             }
         "#;
 
-    api.schema_push(dm2).send_sync().assert_green_bang();
+    api.schema_push(dm2).send().assert_green_bang();
 
     api.assert_schema().assert_table("A", |table| {
         table
@@ -255,7 +255,7 @@ fn compound_foreign_keys_should_work_in_correct_order(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     api.assert_schema().assert_table("A", |t| {
         t.assert_foreign_keys_count(1)
@@ -282,7 +282,7 @@ fn moving_an_inline_relation_to_the_other_side_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
     api.assert_schema().assert_table("A", |t| {
         t.assert_foreign_keys_count(1).assert_fk_on_columns(&["b_id"], |fk| {
             fk.assert_referential_action_on_delete(ForeignKeyAction::Cascade)
@@ -304,7 +304,7 @@ fn moving_an_inline_relation_to_the_other_side_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm2).send_sync().assert_green_bang();
+    api.schema_push(dm2).send().assert_green_bang();
     api.assert_schema()
         .assert_table("B", |table| {
             table
@@ -334,7 +334,7 @@ fn relations_can_reference_arbitrary_unique_fields(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
     api.assert_schema().assert_table("Account", |t| {
         t.assert_foreign_keys_count(1)
             .assert_fk_on_columns(&["uem"], |fk| fk.assert_references("User", &["email"]))
@@ -359,7 +359,7 @@ fn relations_can_reference_arbitrary_unique_fields_with_maps(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 
     api.assert_schema().assert_table("Account", |table| {
         table
@@ -388,7 +388,7 @@ fn relations_can_reference_multiple_fields(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 
     api.assert_schema().assert_table("Account", |table| {
         table
@@ -421,7 +421,7 @@ fn a_relation_with_mappings_on_both_sides_can_reference_multiple_fields(api: Tes
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 
     api.assert_schema().assert_table("Account", |table| {
         table
@@ -453,7 +453,7 @@ fn relations_with_mappings_on_referenced_side_can_reference_multiple_fields(api:
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 
     api.assert_schema().assert_table("Account", |table| {
         table
@@ -485,7 +485,7 @@ fn relations_with_mappings_on_referencing_side_can_reference_multiple_fields(api
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 
     api.assert_schema().assert_table("Account", |table| {
         table
@@ -526,7 +526,7 @@ fn on_delete_referential_actions_should_work(api: TestApi) {
             ra
         );
 
-        api.schema_push(&dm).send_sync().assert_green_bang();
+        api.schema_push(&dm).send().assert_green_bang();
 
         api.assert_schema().assert_table("B", |table| {
             table.assert_foreign_keys_count(1).assert_fk_on_columns(&["aId"], |fk| {
@@ -535,7 +535,7 @@ fn on_delete_referential_actions_should_work(api: TestApi) {
             })
         });
 
-        api.schema_push("").send_sync().assert_green_bang();
+        api.schema_push("").send().assert_green_bang();
     }
 }
 
@@ -561,7 +561,7 @@ fn on_delete_set_default_should_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 
     api.assert_schema().assert_table("B", |table| {
         table.assert_foreign_keys_count(1).assert_fk_on_columns(&["aId"], |fk| {
@@ -591,7 +591,7 @@ fn on_delete_restrict_should_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 
     api.assert_schema().assert_table("B", |table| {
         table.assert_foreign_keys_count(1).assert_fk_on_columns(&["aId"], |fk| {
@@ -631,7 +631,7 @@ fn on_update_referential_actions_should_work(api: TestApi) {
             ra
         );
 
-        api.schema_push(&dm).send_sync().assert_green_bang();
+        api.schema_push(&dm).send().assert_green_bang();
 
         api.assert_schema().assert_table("B", |table| {
             table.assert_foreign_keys_count(1).assert_fk_on_columns(&["aId"], |fk| {
@@ -664,7 +664,7 @@ fn on_update_set_default_should_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 
     api.assert_schema().assert_table("B", |table| {
         table.assert_foreign_keys_count(1).assert_fk_on_columns(&["aId"], |fk| {
@@ -694,7 +694,7 @@ fn on_update_restrict_should_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 
     api.assert_schema().assert_table("B", |table| {
         table.assert_foreign_keys_count(1).assert_fk_on_columns(&["aId"], |fk| {
@@ -724,7 +724,7 @@ fn on_delete_required_default_action(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 
     api.assert_schema().assert_table("B", |table| {
         table.assert_foreign_keys_count(1).assert_fk_on_columns(&["aId"], |fk| {
@@ -754,7 +754,7 @@ fn on_delete_required_default_action_with_no_restrict(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 
     api.assert_schema().assert_table("B", |table| {
         table.assert_foreign_keys_count(1).assert_fk_on_columns(&["aId"], |fk| {
@@ -784,7 +784,7 @@ fn on_delete_optional_default_action(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 
     api.assert_schema().assert_table("B", |table| {
         table.assert_foreign_keys_count(1).assert_fk_on_columns(&["aId"], |fk| {
@@ -817,7 +817,7 @@ fn on_delete_compound_optional_optional_default_action(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 
     api.assert_schema().assert_table("B", |table| {
         table
@@ -852,7 +852,7 @@ fn on_delete_compound_required_optional_default_action_with_restrict(api: TestAp
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 
     api.assert_schema().assert_table("B", |table| {
         table
@@ -887,7 +887,7 @@ fn on_delete_compound_required_optional_default_action_without_restrict(api: Tes
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 
     api.assert_schema().assert_table("B", |table| {
         table
@@ -919,7 +919,7 @@ fn on_update_optional_default_action(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 
     api.assert_schema().assert_table("B", |table| {
         table.assert_foreign_keys_count(1).assert_fk_on_columns(&["aId"], |fk| {
@@ -949,7 +949,7 @@ fn on_update_required_default_action(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 
     api.assert_schema().assert_table("B", |table| {
         table.assert_foreign_keys_count(1).assert_fk_on_columns(&["aId"], |fk| {
@@ -976,7 +976,7 @@ fn adding_mutual_references_on_existing_tables_works(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     let dm2 = r#"
         generator js {
@@ -1001,7 +1001,7 @@ fn adding_mutual_references_on_existing_tables_works(api: TestApi) {
         }
     "#;
 
-    let res = api.schema_push(dm2).force(true).send_sync();
+    let res = api.schema_push(dm2).force(true).send();
 
     if api.is_sqlite() {
         res.assert_green_bang();
@@ -1032,7 +1032,7 @@ fn migrations_with_many_to_many_related_models_must_not_recreate_indexes(api: Te
         }
     "#;
 
-    api.schema_push(dm_1).send_sync().assert_green_bang();
+    api.schema_push(dm_1).send().assert_green_bang();
     api.assert_schema().assert_table("_ProfileToSkill", |t| {
         t.assert_index_on_columns(&["A", "B"], |idx| idx.assert_is_unique())
     });
@@ -1057,7 +1057,7 @@ fn migrations_with_many_to_many_related_models_must_not_recreate_indexes(api: Te
         }
     "#;
 
-    api.schema_push(dm_2).send_sync();
+    api.schema_push(dm_2).send();
     api.assert_schema().assert_table("_ProfileToSkill", |table| {
         table.assert_index_on_columns(&["A", "B"], |idx| {
             idx.assert_is_unique().assert_name("_ProfileToSkill_AB_unique")
@@ -1081,7 +1081,7 @@ fn removing_a_relation_field_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm_1).send_sync().assert_green_bang();
+    api.schema_push(dm_1).send().assert_green_bang();
 
     api.assert_schema()
         .assert_table("User", |table| table.assert_has_column("address_name"));
@@ -1097,7 +1097,7 @@ fn removing_a_relation_field_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm_2).send_sync().assert_green_bang();
+    api.schema_push(dm_2).send().assert_green_bang();
 
     api.assert_schema()
         .assert_table("User", |table| table.assert_does_not_have_column("address_name"));
@@ -1123,7 +1123,7 @@ fn references_to_models_with_compound_primary_keys_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 
     api.assert_schema().assert_table("Pet", |table| {
         table
@@ -1166,7 +1166,7 @@ fn join_tables_between_models_with_compound_primary_keys_must_work(api: TestApi)
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 
     api.assert_schema().assert_table("HumanToCat", |table| {
         table
@@ -1218,7 +1218,7 @@ fn join_tables_between_models_with_mapped_compound_primary_keys_must_work(api: T
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 
     api.assert_schema().assert_table("HumanToCat", |table| {
         table

--- a/migration-engine/migration-engine-tests/tests/migrations/reset_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/reset_tests.rs
@@ -9,7 +9,7 @@ fn reset_works(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm).send_sync();
+    api.schema_push(dm).send();
 
     api.assert_schema().assert_tables_count(1);
 
@@ -19,7 +19,7 @@ fn reset_works(api: TestApi) {
 
     api.assert_schema().assert_tables_count(0);
 
-    api.schema_push(dm).send_sync();
+    api.schema_push(dm).send();
 
     api.assert_schema().assert_tables_count(1);
 }

--- a/migration-engine/migration-engine-tests/tests/migrations/soft_resets.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/soft_resets.rs
@@ -75,7 +75,7 @@ fn soft_resets_work_on_postgres(api: TestApi) {
 
         engine
             .schema_push(dm)
-            .send_sync()
+            .send()
             .assert_has_executed_steps()
             .assert_green_bang();
 
@@ -199,7 +199,7 @@ fn soft_resets_work_on_sql_server(api: TestApi) {
 
         engine
             .schema_push(dm)
-            .send_sync()
+            .send()
             .assert_has_executed_steps()
             .assert_green_bang();
 
@@ -286,7 +286,7 @@ fn soft_resets_work_on_mysql(api: TestApi) {
 
         engine
             .schema_push(dm)
-            .send_sync()
+            .send()
             .assert_has_executed_steps()
             .assert_green_bang();
 

--- a/migration-engine/migration-engine-tests/tests/migrations/sql.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/sql.rs
@@ -9,7 +9,7 @@ fn can_handle_reserved_sql_keywords_for_model_name(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
     api.assert_schema()
         .assert_table("Group", |t| t.assert_column("field", |c| c.assert_type_is_string()));
 
@@ -20,7 +20,7 @@ fn can_handle_reserved_sql_keywords_for_model_name(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm2).send_sync().assert_green_bang();
+    api.schema_push(dm2).send().assert_green_bang();
     api.assert_schema()
         .assert_table("Group", |t| t.assert_column("field", |c| c.assert_type_is_int()));
 }
@@ -34,7 +34,7 @@ fn can_handle_reserved_sql_keywords_for_field_name(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
     api.assert_schema()
         .assert_table("Test", |t| t.assert_column("Group", |c| c.assert_type_is_string()));
 
@@ -45,7 +45,7 @@ fn can_handle_reserved_sql_keywords_for_field_name(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm2).send_sync().assert_green_bang();
+    api.schema_push(dm2).send().assert_green_bang();
     api.assert_schema()
         .assert_table("Test", |t| t.assert_column("Group", |c| c.assert_type_is_int()));
 }
@@ -62,7 +62,7 @@ fn creating_tables_without_primary_key_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 
     api.assert_schema().assert_table("Pair", |table| {
         table
@@ -91,7 +91,7 @@ fn relations_to_models_without_a_primary_key_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 
     api.assert_schema()
         .assert_table("Pair", |table| table.assert_has_no_pk())
@@ -121,7 +121,7 @@ fn relations_to_models_with_no_pk_and_a_single_unique_required_field_work(api: T
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 
     api.assert_schema()
         .assert_table("Pair", |table| table.assert_has_no_pk())
@@ -145,7 +145,7 @@ fn reserved_sql_key_words_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 
     api.assert_schema().assert_table("Group", |table| {
         table.assert_fk_on_columns(&["parent_id"], |fk| fk.assert_references("Group", &["id"]))
@@ -168,7 +168,7 @@ fn enum_value_with_database_names_must_work(api: TestApi) {
 
     api.schema_push(dm)
         .migration_id(Some("initial"))
-        .send_sync()
+        .send()
         .assert_green_bang();
 
     if api.is_mysql() {
@@ -194,14 +194,14 @@ fn enum_value_with_database_names_must_work(api: TestApi) {
     "##;
 
     if api.is_mysql() {
-        api.schema_push(dm).force(true).send_sync().assert_warnings(&["The values [hongry] on the enum `Cat_mood` will be removed. If these variants are still used in the database, this will fail.".into()]);
+        api.schema_push(dm).force(true).send().assert_warnings(&["The values [hongry] on the enum `Cat_mood` will be removed. If these variants are still used in the database, this will fail.".into()]);
 
         api.assert_schema()
             .assert_enum(&api.normalize_identifier("Cat_mood"), |enm| {
                 enm.assert_values(&["ANGRY", "hongery"])
             });
     } else {
-        api.schema_push(dm).force(true).send_sync().assert_warnings(&["The values [hongry] on the enum `CatMood` will be removed. If these variants are still used in the database, this will fail.".into()]);
+        api.schema_push(dm).force(true).send().assert_warnings(&["The values [hongry] on the enum `CatMood` will be removed. If these variants are still used in the database, this will fail.".into()]);
         api.assert_schema()
             .assert_enum("CatMood", |enm| enm.assert_values(&["ANGRY", "hongery"]));
     }
@@ -224,7 +224,7 @@ fn enum_defaults_must_work(api: TestApi) {
 
     api.schema_push(dm)
         .migration_id(Some("initial"))
-        .send_sync()
+        .send()
         .assert_green_bang();
 
     let insert = quaint::ast::Insert::single_into(api.render_table_name("Cat")).value("id", "the-id");
@@ -274,7 +274,7 @@ fn id_as_part_of_relation_must_work(api: TestApi) {
         }
     "##;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 
     api.assert_schema().assert_table("Cat", |table| {
         table
@@ -304,7 +304,7 @@ fn multi_field_id_as_part_of_relation_must_work(api: TestApi) {
         }
     "##;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 
     api.assert_schema().assert_table("Cat", |table| {
         table
@@ -335,7 +335,7 @@ fn remapped_multi_field_id_as_part_of_relation_must_work(api: TestApi) {
         }
     "##;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 
     api.assert_schema().assert_table("Cat", |table| {
         table
@@ -368,7 +368,7 @@ fn unique_constraints_on_composite_relation_fields(api: TestApi) {
         }
     "##;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 
     api.assert_schema().assert_table("Parent", |table| {
         table.assert_index_on_columns(&["chiid", "chic"], |idx| idx.assert_is_unique())
@@ -397,7 +397,7 @@ fn indexes_on_composite_relation_fields(api: TestApi) {
         }
     "##;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 
     api.assert_schema().assert_table("SpamList", |table| {
         table.assert_index_on_columns(&["ufn", "uln"], |idx| idx.assert_is_not_unique())
@@ -438,9 +438,9 @@ fn dropping_mutually_referencing_tables_works(api: TestApi) {
     }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
     api.assert_schema().assert_tables_count(3);
 
-    api.schema_push("").send_sync().assert_green_bang();
+    api.schema_push("").send().assert_green_bang();
     api.assert_schema().assert_tables_count(0);
 }

--- a/migration-engine/migration-engine-tests/tests/migrations/sqlite.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/sqlite.rs
@@ -12,7 +12,7 @@ fn sqlite_must_recreate_indexes(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     api.assert_schema().assert_table("A", |table| {
         table.assert_index_on_columns(&["field"], |idx| idx.assert_is_unique())
@@ -26,7 +26,7 @@ fn sqlite_must_recreate_indexes(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm2).send_sync().assert_green_bang();
+    api.schema_push(dm2).send().assert_green_bang();
 
     api.assert_schema().assert_table("A", |table| {
         table.assert_index_on_columns(&["field"], |idx| idx.assert_is_unique())
@@ -47,7 +47,7 @@ fn sqlite_must_recreate_multi_field_indexes(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     api.assert_schema().assert_table("A", |table| {
         table.assert_index_on_columns(&["field", "secondField"], |idx| idx.assert_is_unique())
@@ -64,7 +64,7 @@ fn sqlite_must_recreate_multi_field_indexes(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm2).send_sync().assert_green_bang();
+    api.schema_push(dm2).send().assert_green_bang();
 
     api.assert_schema().assert_table("A", |table| {
         table.assert_index_on_columns(&["field", "secondField"], |idx| idx.assert_is_unique())
@@ -80,6 +80,6 @@ fn creating_a_model_with_a_non_autoincrement_id_column_is_idempotent(api: TestAp
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
-    api.schema_push(dm).send_sync().assert_green_bang().assert_no_steps();
+    api.schema_push(dm).send().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang().assert_no_steps();
 }

--- a/migration-engine/migration-engine-tests/tests/migrations/types.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/types.rs
@@ -17,11 +17,11 @@ fn bytes_columns_are_idempotent(api: TestApi) {
     );
 
     api.schema_push(&dm)
-        .send_sync()
+        .send()
         .assert_green_bang()
         .assert_has_executed_steps();
 
-    api.schema_push(&dm).send_sync().assert_green_bang().assert_no_steps();
+    api.schema_push(&dm).send().assert_green_bang().assert_no_steps();
 }
 
 #[test_connector]
@@ -34,11 +34,11 @@ fn float_columns_are_idempotent(api: TestApi) {
     "#;
 
     api.schema_push(dm)
-        .send_sync()
+        .send()
         .assert_green_bang()
         .assert_has_executed_steps();
 
-    api.schema_push(dm).send_sync().assert_green_bang().assert_no_steps();
+    api.schema_push(dm).send().assert_green_bang().assert_no_steps();
 }
 
 #[test_connector]
@@ -56,11 +56,11 @@ fn decimal_columns_are_idempotent(api: TestApi) {
     );
 
     api.schema_push(&dm)
-        .send_sync()
+        .send()
         .assert_green_bang()
         .assert_has_executed_steps();
 
-    api.schema_push(&dm).send_sync().assert_green_bang().assert_no_steps();
+    api.schema_push(&dm).send().assert_green_bang().assert_no_steps();
 }
 
 #[test_connector]
@@ -72,7 +72,7 @@ fn float_to_decimal_works(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     api.assert_schema().assert_table("Cat", |table| {
         table.assert_column("meowFrequency", |col| col.assert_type_family(ColumnTypeFamily::Float))
@@ -91,7 +91,7 @@ fn float_to_decimal_works(api: TestApi) {
     );
 
     api.schema_push(&dm2)
-        .send_sync()
+        .send()
         .assert_green_bang()
         .assert_has_executed_steps();
 
@@ -114,7 +114,7 @@ fn decimal_to_float_works(api: TestApi) {
         datasource = api.datasource_block()
     );
 
-    api.schema_push(&dm1).send_sync().assert_green_bang();
+    api.schema_push(&dm1).send().assert_green_bang();
 
     api.assert_schema().assert_table("Cat", |table| {
         table.assert_column("meowFrequency", |col| col.assert_type_family(ColumnTypeFamily::Decimal))
@@ -128,7 +128,7 @@ fn decimal_to_float_works(api: TestApi) {
     "#;
 
     api.schema_push(dm2)
-        .send_sync()
+        .send()
         .assert_green_bang()
         .assert_has_executed_steps();
 
@@ -151,7 +151,7 @@ fn bytes_to_string_works(api: TestApi) {
         datasource = api.datasource_block()
     );
 
-    api.schema_push(&dm1).send_sync().assert_green_bang();
+    api.schema_push(&dm1).send().assert_green_bang();
 
     api.assert_schema().assert_table("Cat", |table| {
         table.assert_column("meowData", |col| col.assert_type_is_bytes())
@@ -165,7 +165,7 @@ fn bytes_to_string_works(api: TestApi) {
     "#;
 
     api.schema_push(dm2)
-        .send_sync()
+        .send()
         .assert_green_bang()
         .assert_has_executed_steps();
 
@@ -188,7 +188,7 @@ fn string_to_bytes_works(api: TestApi) {
         datasource = api.datasource_block()
     );
 
-    api.schema_push(&dm1).send_sync().assert_green_bang();
+    api.schema_push(&dm1).send().assert_green_bang();
 
     api.assert_schema().assert_table("Cat", |table| {
         table.assert_column("meowData", |col| col.assert_type_is_bytes())
@@ -202,7 +202,7 @@ fn string_to_bytes_works(api: TestApi) {
     "#;
 
     api.schema_push(dm2)
-        .send_sync()
+        .send()
         .assert_green_bang()
         .assert_has_executed_steps();
 
@@ -220,7 +220,7 @@ fn decimal_to_decimal_array_works(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     api.assert_schema().assert_table("Test", |table| {
         table.assert_column("decFloat", |col| col.assert_type_is_decimal().assert_is_required())
@@ -239,7 +239,7 @@ fn decimal_to_decimal_array_works(api: TestApi) {
     );
 
     api.schema_push(dm2)
-        .send_sync()
+        .send()
         .assert_green_bang()
         .assert_has_executed_steps();
 
@@ -247,7 +247,7 @@ fn decimal_to_decimal_array_works(api: TestApi) {
         table.assert_column("decFloat", |col| col.assert_type_is_decimal().assert_is_list())
     });
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     api.assert_schema().assert_table("Test", |table| {
         table.assert_column("decFloat", |col| col.assert_type_is_decimal().assert_is_required())
@@ -268,7 +268,7 @@ fn bytes_to_bytes_array_works(api: TestApi) {
         datasource = api.datasource_block()
     );
 
-    api.schema_push(&dm1).send_sync().assert_green_bang();
+    api.schema_push(&dm1).send().assert_green_bang();
 
     api.assert_schema().assert_table("Test", |table| {
         table.assert_column("bytesCol", |col| col.assert_type_is_bytes().assert_is_required())
@@ -287,7 +287,7 @@ fn bytes_to_bytes_array_works(api: TestApi) {
     );
 
     api.schema_push(dm2)
-        .send_sync()
+        .send()
         .assert_green_bang()
         .assert_has_executed_steps();
 
@@ -295,7 +295,7 @@ fn bytes_to_bytes_array_works(api: TestApi) {
         table.assert_column("bytesCol", |col| col.assert_type_is_bytes().assert_is_list())
     });
 
-    api.schema_push(&dm1).send_sync().assert_green_bang();
+    api.schema_push(&dm1).send().assert_green_bang();
 
     api.assert_schema().assert_table("Test", |table| {
         table.assert_column("bytesCol", |col| col.assert_type_is_bytes().assert_is_required())
@@ -311,7 +311,7 @@ fn a_table_recreation_with_noncastable_columns_should_trigger_warnings(api: Test
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     // Removing autoincrement requires us to recreate the table.
     let dm2 = r#"
@@ -324,7 +324,7 @@ fn a_table_recreation_with_noncastable_columns_should_trigger_warnings(api: Test
     api.insert("Blog").value("title", "3.14").result_raw();
 
     api.schema_push(dm2)
-        .send_sync()
+        .send()
         .assert_warnings(&["You are about to alter the column `title` on the `Blog` table, which contains 1 non-null values. The data in that column will be cast from `String` to `Float`.".into()]);
 }
 
@@ -342,7 +342,7 @@ fn a_column_recreation_with_non_castable_type_change_should_trigger_warnings(api
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
     let insert = quaint::ast::Insert::single_into((api.schema_name(), "Blog"))
         .value("id", 1)
         .value("float", Value::double(7.5));
@@ -361,6 +361,6 @@ fn a_column_recreation_with_non_castable_type_change_should_trigger_warnings(api
     "#;
 
     api.schema_push(dm2)
-        .send_sync()
+        .send()
         .assert_unexecutable(&["Changed the type of `float` on the `Blog` table. No cast exists, the column would be dropped and recreated, which cannot be done since the column is required and there is data in the table.".into()]);
 }

--- a/migration-engine/migration-engine-tests/tests/migrations/unique.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/unique.rs
@@ -9,7 +9,7 @@ fn adding_a_new_unique_field_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     api.assert_schema().assert_table("A", |table| {
         table.assert_index_on_columns(&["field"], |index| index.assert_is_unique())
@@ -28,7 +28,7 @@ fn adding_new_fields_with_multi_column_unique_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
     api.assert_schema().assert_table("A", |t| {
         t.assert_index_on_columns(&["field", "secondField"], |idx| idx.assert_is_unique())
     });
@@ -43,7 +43,7 @@ fn unique_in_conjunction_with_custom_column_name_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
     api.assert_schema().assert_table("A", |t| {
         t.assert_index_on_columns(&["custom_field_name"], |idx| idx.assert_is_unique())
     });
@@ -61,7 +61,7 @@ fn multi_column_unique_in_conjunction_with_custom_column_name_must_work(api: Tes
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
     api.assert_schema().assert_table("A", |t| {
         t.assert_index_on_columns(&["custom_field_name", "second_custom_field_name"], |idx| {
             idx.assert_is_unique()
@@ -78,7 +78,7 @@ fn removing_an_existing_unique_field_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
     api.assert_schema().assert_table("A", |table| {
         table.assert_index_on_columns(&["field"], |idx| idx.assert_is_unique())
     });
@@ -89,7 +89,7 @@ fn removing_an_existing_unique_field_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm2).send_sync().assert_green_bang();
+    api.schema_push(dm2).send().assert_green_bang();
 
     api.assert_schema().assert_table("A", |t| {
         t.assert_indexes_count(0)
@@ -107,7 +107,7 @@ fn adding_unique_to_an_existing_field_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     api.assert_schema()
         .assert_table("A", |table| table.assert_indexes_count(0));
@@ -121,7 +121,7 @@ fn adding_unique_to_an_existing_field_must_work(api: TestApi) {
 
     api.schema_push(dm2)
         .force(true)
-        .send_sync()
+        .send()
         .assert_executable()
         .assert_warnings(&["A unique constraint covering the columns `[field]` on the table `A` will be added. If there are existing duplicate values, this will fail.".into()])
         .assert_has_executed_steps();
@@ -142,7 +142,7 @@ fn removing_unique_from_an_existing_field_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
     api.assert_schema().assert_table("A", |t| {
         t.assert_index_on_columns(&["field"], |idx| idx.assert_is_unique())
     });
@@ -154,6 +154,6 @@ fn removing_unique_from_an_existing_field_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm2).send_sync().assert_green_bang();
+    api.schema_push(dm2).send().assert_green_bang();
     api.assert_schema().assert_table("A", |t| t.assert_indexes_count(0));
 }

--- a/migration-engine/migration-engine-tests/tests/migrations/unsupported_types.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/unsupported_types.rs
@@ -20,7 +20,7 @@ fn adding_an_unsupported_type_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 
     api.assert_schema().assert_table("Post", |table| {
         table
@@ -57,7 +57,7 @@ fn switching_an_unsupported_type_to_supported_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     api.assert_schema().assert_table("Post", |table| {
         table
@@ -83,7 +83,7 @@ fn switching_an_unsupported_type_to_supported_must_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm2).send_sync().assert_green_bang();
+    api.schema_push(dm2).send().assert_green_bang();
 
     api.assert_schema().assert_table("Post", |table| {
         table
@@ -116,7 +116,7 @@ fn adding_and_removing_properties_on_unsupported_should_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm1).send_sync().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang();
 
     api.assert_schema().assert_table("Post", |table| {
         table
@@ -160,7 +160,7 @@ fn adding_and_removing_properties_on_unsupported_should_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm2).force(true).send_sync().assert_warnings(&["A unique constraint covering the columns `[user_ip]` on the table `Post` will be added. If there are existing duplicate values, this will fail.".into()]);
+    api.schema_push(dm2).force(true).send().assert_warnings(&["A unique constraint covering the columns `[user_ip]` on the table `Post` will be added. If there are existing duplicate values, this will fail.".into()]);
 
     api.assert_schema().assert_table("Post", |table| {
         table
@@ -182,7 +182,7 @@ fn adding_and_removing_properties_on_unsupported_should_work(api: TestApi) {
         }
     "#;
 
-    api.schema_push(dm3).send_sync().assert_green_bang();
+    api.schema_push(dm3).send().assert_green_bang();
 
     api.assert_schema().assert_table("Post", |table| {
         table
@@ -222,5 +222,5 @@ fn using_unsupported_and_ignore_should_work(api: TestApi) {
         unsupported_type
     ));
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 }

--- a/migration-engine/migration-engine-tests/tests/native_types/common.rs
+++ b/migration-engine/migration-engine-tests/tests/native_types/common.rs
@@ -23,11 +23,11 @@ fn typescript_starter_schema_is_idempotent_without_native_type_annotations(api: 
     );
 
     api.schema_push(&dm)
-        .send_sync()
+        .send()
         .assert_green_bang()
         .assert_has_executed_steps();
-    api.schema_push(&dm).send_sync().assert_green_bang().assert_no_steps();
-    api.schema_push(&dm).send_sync().assert_green_bang().assert_no_steps();
+    api.schema_push(&dm).send().assert_green_bang().assert_no_steps();
+    api.schema_push(&dm).send().assert_green_bang().assert_no_steps();
 }
 #[test_connector]
 fn typescript_starter_schema_starting_without_native_types_is_idempotent(api: TestApi) {
@@ -52,11 +52,11 @@ fn typescript_starter_schema_starting_without_native_types_is_idempotent(api: Te
     let dm2 = format!("{}\n{}", api.datasource_block(), dm);
 
     api.schema_push(dm)
-        .send_sync()
+        .send()
         .assert_green_bang()
         .assert_has_executed_steps();
-    api.schema_push(dm).send_sync().assert_green_bang().assert_no_steps();
-    api.schema_push(&dm2).send_sync().assert_green_bang().assert_no_steps();
+    api.schema_push(dm).send().assert_green_bang().assert_no_steps();
+    api.schema_push(&dm2).send().assert_green_bang().assert_no_steps();
 }
 
 #[test_connector(tags(Postgres, Mysql, Mssql))]
@@ -69,8 +69,8 @@ fn bigint_primary_keys_are_idempotent(api: TestApi) {
         "#,
     );
 
-    api.schema_push(&dm1).send_sync().assert_green_bang();
-    api.schema_push(dm1).send_sync().assert_green_bang().assert_no_steps();
+    api.schema_push(&dm1).send().assert_green_bang();
+    api.schema_push(dm1).send().assert_green_bang().assert_no_steps();
 
     let dm2 = api.datamodel_with_provider(
         r#"
@@ -80,6 +80,6 @@ fn bigint_primary_keys_are_idempotent(api: TestApi) {
         "#,
     );
 
-    api.schema_push(&dm2).send_sync().assert_green_bang();
-    api.schema_push(dm2).send_sync().assert_green_bang().assert_no_steps();
+    api.schema_push(&dm2).send().assert_green_bang();
+    api.schema_push(dm2).send().assert_green_bang().assert_no_steps();
 }

--- a/migration-engine/migration-engine-tests/tests/native_types/mssql.rs
+++ b/migration-engine/migration-engine-tests/tests/native_types/mssql.rs
@@ -1913,7 +1913,7 @@ fn safe_casts_with_existing_data_should_work(api: TestApi) {
                 from,
             ));
 
-            api.schema_push(&dm1).send_sync().assert_green_bang();
+            api.schema_push(&dm1).send().assert_green_bang();
 
             let insert = Insert::single_into((api.schema_name(), "A")).value("x", seed.clone());
             api.query(insert.into());
@@ -1938,7 +1938,7 @@ fn safe_casts_with_existing_data_should_work(api: TestApi) {
                 to,
             ));
 
-            api.schema_push(&dm2).send_sync().assert_green_bang();
+            api.schema_push(&dm2).send().assert_green_bang();
 
             api.assert_schema().assert_table("A", |table| {
                 table.assert_columns_count(2).assert_column("x", |c| {
@@ -1971,7 +1971,7 @@ fn risky_casts_with_existing_data_should_warn(api: TestApi) {
                 from,
             ));
 
-            api.schema_push(&dm1).send_sync().assert_green_bang();
+            api.schema_push(&dm1).send().assert_green_bang();
 
             let insert = Insert::single_into((api.schema_name(), "A")).value("x", seed.clone());
             api.query(insert.into());
@@ -2002,7 +2002,7 @@ fn risky_casts_with_existing_data_should_warn(api: TestApi) {
                 to,
             );
 
-            api.schema_push(&dm2).send_sync().assert_warnings(&[warning.into()]);
+            api.schema_push(&dm2).send().assert_warnings(&[warning.into()]);
 
             api.assert_schema().assert_table("A", |table| {
                 table.assert_columns_count(2).assert_column("x", |c| {
@@ -2038,7 +2038,7 @@ fn not_castable_with_existing_data_should_warn(api: TestApi) {
                 from,
             ));
 
-            api.schema_push(&dm1).send_sync().assert_green_bang();
+            api.schema_push(&dm1).send().assert_green_bang();
 
             let insert = Insert::single_into((api.schema_name(), "A")).value("x", seed.clone());
             api.query(insert.into());
@@ -2065,7 +2065,7 @@ fn not_castable_with_existing_data_should_warn(api: TestApi) {
 
             let warning = "Changed the type of `x` on the `A` table. No cast exists, the column would be dropped and recreated, which cannot be done since the column is required and there is data in the table.";
 
-            api.schema_push(&dm2).send_sync().assert_unexecutable(&[warning.into()]);
+            api.schema_push(&dm2).send().assert_unexecutable(&[warning.into()]);
 
             api.assert_schema().assert_table("A", |table| {
                 table.assert_columns_count(2).assert_column("x", |c| {
@@ -2123,17 +2123,17 @@ fn typescript_starter_schema_with_native_types_is_idempotent(api: TestApi) {
 
     api.schema_push(&dm)
         .migration_id(Some("first"))
-        .send_sync()
+        .send()
         .assert_green_bang()
         .assert_has_executed_steps();
     api.schema_push(&dm)
         .migration_id(Some("second"))
-        .send_sync()
+        .send()
         .assert_green_bang()
         .assert_no_steps();
     api.schema_push(&dm2)
         .migration_id(Some("third"))
-        .send_sync()
+        .send()
         .assert_green_bang()
         .assert_no_steps();
 }
@@ -2182,23 +2182,23 @@ fn typescript_starter_schema_with_different_native_types_is_idempotent(api: Test
 
     api.schema_push(&dm)
         .migration_id(Some("first"))
-        .send_sync()
+        .send()
         .assert_green_bang()
         .assert_has_executed_steps();
     api.schema_push(&dm)
         .migration_id(Some("second"))
-        .send_sync()
+        .send()
         .assert_green_bang()
         .assert_no_steps();
 
     api.schema_push(&dm2)
         .migration_id(Some("third"))
-        .send_sync()
+        .send()
         .assert_green_bang()
         .assert_has_executed_steps();
     api.schema_push(&dm2)
         .migration_id(Some("fourth"))
-        .send_sync()
+        .send()
         .assert_green_bang()
         .assert_no_steps();
 }

--- a/migration-engine/migration-engine-tests/tests/native_types/mysql.rs
+++ b/migration-engine/migration-engine-tests/tests/native_types/mysql.rs
@@ -774,12 +774,12 @@ fn safe_casts_with_existing_data_should_work(api: TestApi) {
             &colnames,
         );
 
-        api.schema_push(&dm1).send_sync().assert_green_bang();
+        api.schema_push(&dm1).send().assert_green_bang();
 
         api.query(insert.into());
 
         tracing::info!("cast migration");
-        api.schema_push(&dm2).send_sync().assert_green_bang();
+        api.schema_push(&dm2).send().assert_green_bang();
 
         api.assert_schema().assert_table("Test", |table| {
             to_types.iter().enumerate().fold(
@@ -835,7 +835,7 @@ fn risky_casts_with_existing_data_should_warn(api: TestApi) {
             ).into());
         }
 
-        api.schema_push(&dm1).send_sync().assert_green_bang();
+        api.schema_push(&dm1).send().assert_green_bang();
 
         api.query(insert.into());
 
@@ -843,7 +843,7 @@ fn risky_casts_with_existing_data_should_warn(api: TestApi) {
 
         api.schema_push(&dm2)
             .force(true)
-            .send_sync()
+            .send()
             .assert_executable()
             .assert_warnings(&warnings);
 
@@ -898,7 +898,7 @@ fn impossible_casts_with_existing_data_should_warn(api: TestApi) {
             ).into());
         }
 
-        api.schema_push(&dm1).send_sync().assert_green_bang();
+        api.schema_push(&dm1).send().assert_green_bang();
 
         api.query(insert.into());
 
@@ -906,7 +906,7 @@ fn impossible_casts_with_existing_data_should_warn(api: TestApi) {
 
         api.schema_push(&dm2)
             .force(true)
-            .send_sync()
+            .send()
             .assert_executable()
             .assert_warnings(&warnings);
 
@@ -965,17 +965,17 @@ fn typescript_starter_schema_with_native_types_is_idempotent(api: TestApi) {
 
     api.schema_push(&dm)
         .migration_id(Some("first"))
-        .send_sync()
+        .send()
         .assert_green_bang()
         .assert_has_executed_steps();
     api.schema_push(&dm)
         .migration_id(Some("second"))
-        .send_sync()
+        .send()
         .assert_green_bang()
         .assert_no_steps();
     api.schema_push(&dm2)
         .migration_id(Some("third"))
-        .send_sync()
+        .send()
         .assert_green_bang()
         .assert_no_steps();
 }
@@ -1024,23 +1024,23 @@ fn typescript_starter_schema_with_differnt_native_types_is_idempotent(api: TestA
 
     api.schema_push(&dm)
         .migration_id(Some("first"))
-        .send_sync()
+        .send()
         .assert_green_bang()
         .assert_has_executed_steps();
     api.schema_push(&dm)
         .migration_id(Some("second"))
-        .send_sync()
+        .send()
         .assert_green_bang()
         .assert_no_steps();
 
     api.schema_push(&dm2)
         .migration_id(Some("third"))
-        .send_sync()
+        .send()
         .assert_green_bang()
         .assert_has_executed_steps();
     api.schema_push(&dm2)
         .migration_id(Some("third"))
-        .send_sync()
+        .send()
         .assert_green_bang()
         .assert_no_steps();
 }

--- a/migration-engine/migration-engine-tests/tests/native_types/postgres.rs
+++ b/migration-engine/migration-engine-tests/tests/native_types/postgres.rs
@@ -821,7 +821,7 @@ fn safe_casts_with_existing_data_should_work(api: TestApi) {
 
         tracing::info!(dm = dm1.as_str());
 
-        api.schema_push(&dm1).send_sync().assert_green_bang();
+        api.schema_push(&dm1).send().assert_green_bang();
 
         // inserts
         api.query(insert.into());
@@ -846,7 +846,7 @@ fn safe_casts_with_existing_data_should_work(api: TestApi) {
             columns = next_columns
         ));
 
-        api.schema_push(&dm2).send_sync().assert_green_bang();
+        api.schema_push(&dm2).send().assert_green_bang();
 
         // second assertions
         api.assert_schema().assert_table("A", |table| {
@@ -914,7 +914,7 @@ fn risky_casts_with_existing_data_should_warn(api: TestApi) {
             columns = previous_columns,
         ));
 
-        api.schema_push(&dm1).send_sync().assert_green_bang();
+        api.schema_push(&dm1).send().assert_green_bang();
 
         // inserts
         api.query(insert.into());
@@ -940,7 +940,7 @@ fn risky_casts_with_existing_data_should_warn(api: TestApi) {
             columns = next_columns,
         ));
 
-        api.schema_push(&dm2).force(true).send_sync().assert_warnings(&warnings);
+        api.schema_push(&dm2).force(true).send().assert_warnings(&warnings);
 
         //second assertions same as first
         api.assert_schema().assert_table("A", |table| {
@@ -1013,7 +1013,7 @@ fn not_castable_with_existing_data_should_warn(api: TestApi) {
             columns = previous_columns,
         ));
 
-        api.schema_push(&dm1).send_sync().assert_green_bang();
+        api.schema_push(&dm1).send().assert_green_bang();
 
         // inserts
         api.query(insert.into());
@@ -1040,7 +1040,7 @@ fn not_castable_with_existing_data_should_warn(api: TestApi) {
 
         // todo we could force here and then check that the db really returns not castable
         // then we would again need to have separate calls per mapping
-        api.schema_push(&dm2).send_sync().assert_warnings(&warnings);
+        api.schema_push(&dm2).send().assert_warnings(&warnings);
 
         //second assertions same as first
         api.assert_schema().assert_table("A", |table| {
@@ -1188,7 +1188,7 @@ fn safe_casts_from_array_with_existing_data_should_work(api: TestApi) {
             columns = previous_columns,
         ));
 
-        api.schema_push(&dm1).send_sync().assert_green_bang();
+        api.schema_push(&dm1).send().assert_green_bang();
 
         // inserts
         api.query(insert.into());
@@ -1213,7 +1213,7 @@ fn safe_casts_from_array_with_existing_data_should_work(api: TestApi) {
             columns = next_columns,
         ));
 
-        api.schema_push(&dm2).send_sync().assert_green_bang();
+        api.schema_push(&dm2).send().assert_green_bang();
 
         //second assertions
         api.assert_schema().assert_table("A", |table| {
@@ -1271,17 +1271,17 @@ fn typescript_starter_schema_with_native_types_is_idempotent(api: TestApi) {
 
     api.schema_push(&dm)
         .migration_id(Some("first"))
-        .send_sync()
+        .send()
         .assert_green_bang()
         .assert_has_executed_steps();
     api.schema_push(&dm)
         .migration_id(Some("second"))
-        .send_sync()
+        .send()
         .assert_green_bang()
         .assert_no_steps();
     api.schema_push(&dm2)
         .migration_id(Some("third"))
-        .send_sync()
+        .send()
         .assert_green_bang()
         .assert_no_steps();
 }
@@ -1330,22 +1330,22 @@ fn typescript_starter_schema_with_differnt_native_types_is_idempotent(api: TestA
 
     api.schema_push(&dm)
         .migration_id(Some("first"))
-        .send_sync()
+        .send()
         .assert_green_bang()
         .assert_has_executed_steps();
     api.schema_push(&dm)
         .migration_id(Some("second"))
-        .send_sync()
+        .send()
         .assert_green_bang()
         .assert_no_steps();
     api.schema_push(&dm2)
         .migration_id(Some("third"))
-        .send_sync()
+        .send()
         .assert_green_bang()
         .assert_has_executed_steps();
     api.schema_push(&dm2)
         .migration_id(Some("fourth"))
-        .send_sync()
+        .send()
         .assert_green_bang()
         .assert_no_steps();
 }

--- a/migration-engine/migration-engine-tests/tests/schema_push/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/schema_push/mod.rs
@@ -18,7 +18,7 @@ model Box {
 #[test_connector]
 fn schema_push_happy_path(api: TestApi) {
     api.schema_push(SCHEMA)
-        .send_sync()
+        .send()
         .assert_green_bang()
         .assert_has_executed_steps();
 
@@ -46,7 +46,7 @@ fn schema_push_happy_path(api: TestApi) {
     "#;
 
     api.schema_push(dm2)
-        .send_sync()
+        .send()
         .assert_green_bang()
         .assert_has_executed_steps();
 
@@ -64,7 +64,7 @@ fn schema_push_happy_path(api: TestApi) {
 #[test_connector]
 fn schema_push_warns_about_destructive_changes(api: TestApi) {
     api.schema_push(SCHEMA)
-        .send_sync()
+        .send()
         .assert_green_bang()
         .assert_has_executed_steps();
 
@@ -85,13 +85,13 @@ fn schema_push_warns_about_destructive_changes(api: TestApi) {
     );
 
     api.schema_push(dm2)
-        .send_sync()
+        .send()
         .assert_warnings(&[expected_warning.as_str().into()])
         .assert_no_steps();
 
     api.schema_push(dm2)
         .force(true)
-        .send_sync()
+        .send()
         .assert_warnings(&[expected_warning.as_str().into()])
         .assert_has_executed_steps();
 }
@@ -99,7 +99,7 @@ fn schema_push_warns_about_destructive_changes(api: TestApi) {
 #[test_connector]
 fn schema_push_with_an_unexecutable_migration_returns_a_message_and_aborts(api: TestApi) {
     api.schema_push(SCHEMA)
-        .send_sync()
+        .send()
         .assert_green_bang()
         .assert_has_executed_steps();
 
@@ -124,7 +124,7 @@ fn schema_push_with_an_unexecutable_migration_returns_a_message_and_aborts(api: 
     "#;
 
     api.schema_push(dm2)
-        .send_sync()
+        .send()
         .assert_unexecutable(&["Added the required column `volumeCm3` to the `Box` table without a default value. There are 1 rows in this table, it is not possible to execute this step.".into()])
         .assert_no_steps();
 }
@@ -141,7 +141,7 @@ fn indexes_and_unique_constraints_on_the_same_field_do_not_collide(api: TestApi)
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 }
 
 #[test_connector]
@@ -157,5 +157,5 @@ fn multi_column_indexes_and_unique_constraints_on_the_same_fields_do_not_collide
         }
     "#;
 
-    api.schema_push(dm).send_sync().assert_green_bang();
+    api.schema_push(dm).send().assert_green_bang();
 }


### PR DESCRIPTION
spatial_ref_sys and geometry_columns used to be tables managed by
postgis, and in more recent versions they are views managed by postgis.
We make sure to ignore them in both cases.

closes https://github.com/prisma/prisma/issues/7764