### PR TITLE
Rollback failing SQL Server migration transactions

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
@@ -59,7 +59,7 @@ impl DatabaseMigrationStepApplier for SqlMigrationConnector {
 
         if let Some(begin) = self.flavour().render_begin_transaction() {
             script.push_str(begin);
-            script.push_str(";\n");
+            script.push('\n');
         }
 
         for step in &migration.steps {
@@ -89,8 +89,8 @@ impl DatabaseMigrationStepApplier for SqlMigrationConnector {
         }
 
         if let Some(commit) = self.flavour().render_commit_transaction() {
+            script.push('\n');
             script.push_str(commit);
-            script.push_str(";\n");
         }
 
         script

--- a/migration-engine/migration-engine-tests/src/commands/create_migration.rs
+++ b/migration-engine/migration-engine-tests/src/commands/create_migration.rs
@@ -190,6 +190,7 @@ pub struct MigrationAssertion<'a> {
 }
 
 impl MigrationAssertion<'_> {
+    #[track_caller]
     pub fn assert_contents(self, expected_contents: &str) -> Self {
         let migration_file_path = self.path.join("migration.sql");
         let contents: String = std::fs::read_to_string(&migration_file_path)

--- a/migration-engine/migration-engine-tests/tests/create_migration/create_migration_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/create_migration/create_migration_tests.rs
@@ -53,14 +53,29 @@ fn basic_create_migration_works(api: TestApi) {
             } else if api.is_mssql() {
                 indoc! {
                     r#"
+                        BEGIN TRY
+
                         BEGIN TRAN;
+
                         -- CreateTable
                         CREATE TABLE [basic_create_migration_works].[Cat] (
                             [id] INT NOT NULL,
                             [name] NVARCHAR(1000) NOT NULL,
                             CONSTRAINT [PK__Cat__id] PRIMARY KEY ([id])
                         );
+
                         COMMIT TRAN;
+
+                        END TRY
+                        BEGIN CATCH
+
+                        IF @@TRANCOUNT > 0
+                        BEGIN 
+                            ROLLBACK TRAN;
+                        END;
+                        THROW
+
+                        END CATCH
                         "#
                 }
             } else {
@@ -144,14 +159,29 @@ fn creating_a_second_migration_should_have_the_previous_sql_schema_as_baseline(a
                 else if api.is_mssql() {
                     indoc! {
                         r#"
+                        BEGIN TRY
+
                         BEGIN TRAN;
+
                         -- CreateTable
                         CREATE TABLE [creating_a_second_migration_should_have_the_previous_sql_schema_as_baseline].[Dog] (
                             [id] INT NOT NULL,
                             [name] NVARCHAR(1000) NOT NULL,
                             CONSTRAINT [PK__Dog__id] PRIMARY KEY ([id])
                         );
+
                         COMMIT TRAN;
+
+                        END TRY
+                        BEGIN CATCH
+
+                        IF @@TRANCOUNT > 0
+                        BEGIN 
+                            ROLLBACK TRAN;
+                        END;
+                        THROW
+
+                        END CATCH
                         "#
                     }
                 } else {

--- a/migration-engine/migration-engine-tests/tests/migrations/mssql.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/mssql.rs
@@ -33,3 +33,76 @@ fn shared_default_constraints_are_ignored_issue_5423(api: TestApi) {
         .assert_green_bang()
         .assert_no_steps();
 }
+
+#[test_connector(tags(Mssql))]
+fn mssql_apply_migrations_error_output(api: TestApi) {
+    let dm = "";
+    let migrations_directory = api.create_migrations_directory();
+
+    let migration = format!(
+        r#"
+        BEGIN TRY
+
+        BEGIN TRAN;
+        CREATE TABLE [{schema_name}].[Cat] ( id INT IDENTITY PRIMARY KEY );
+        DROP TABLE [{schema_name}].[Emu];
+        CREATE TABLE [{schema_name}].[Emu] (
+            size INTEGER
+        );
+        COMMIT TRAN;
+
+        END TRY
+
+        BEGIN CATCH
+
+        IF @@TRANCOUNT > 0
+        BEGIN 
+            ROLLBACK TRAN;
+        END;
+        THROW
+
+        END CATCH
+    "#,
+        schema_name = api.schema_name()
+    );
+
+    let migration_name = api
+        .create_migration("01init", dm, &migrations_directory)
+        .draft(true)
+        .send_sync()
+        .modify_migration(|contents| {
+            contents.clear();
+            contents.push_str(&migration);
+        })
+        .into_output()
+        .generated_migration_name
+        .unwrap();
+
+    let err = api
+        .apply_migrations(&migrations_directory)
+        .send_unwrap_err()
+        .to_string()
+        .replace(&migration_name, "<migration-name>");
+
+    let expectation = expect![[r#"
+        A migration failed to apply. New migrations can not be applied before the error is recovered from. Read more about how to resolve migration issues in a production database: https://pris.ly/d/migrate-resolve
+
+        Migration name: <migration-name>
+
+        Database error code: 3701
+
+        Database error:
+        Cannot drop the table 'mssql_apply_migrations_error_output.Emu', because it does not exist or you do not have permission.
+
+    "#]];
+
+    let first_segment = err
+        .split_terminator("DbError {")
+        .next()
+        .unwrap()
+        .split_terminator("   0: ")
+        .next()
+        .unwrap();
+
+    expectation.assert_eq(first_segment)
+}


### PR DESCRIPTION
This fixes sucking the error messages when a migration fails. So we must rollback by ourselves in the sql to get proper errors out.

Fixes: https://github.com/prisma/migrations-ci/commit/b92cf2f9b8082f0ed79b0e1279a319d227aacee8