### PR TITLE
Remove unused dependency in introspection-engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -726,12 +726,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
 
 [[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
 name = "cookie"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -963,18 +957,6 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "derive_more"
-version = "0.99.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f82b1b72f1263f214c0f823371768776c4f5841b942c9883aa8e5ec584fd0ba6"
-dependencies = [
- "convert_case",
  "proc-macro2",
  "quote",
  "syn",
@@ -1288,12 +1270,6 @@ checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
-
-[[package]]
-name = "futures"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f55667319111d593ba876406af7c409c0ebb44dc4be6132a783ccf163ea14c1"
@@ -1332,7 +1308,6 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
- "num_cpus",
 ]
 
 [[package]]
@@ -1394,7 +1369,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "feb5c238d27e2bf94ffdfd27b2c29e3df4a68c4193bb6427384259e2bf191967"
 dependencies = [
  "autocfg",
- "futures 0.1.31",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -1830,7 +1804,6 @@ dependencies = [
  "introspection-connector",
  "json-rpc-stdio",
  "jsonrpc-core",
- "jsonrpc-core-client",
  "jsonrpc-derive",
  "serde",
  "serde_derive",
@@ -1940,42 +1913,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonrpc-client-transports"
-version = "17.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b6c6ad01c7354d60de493148c30ac8a82b759e22ae678c8705e9b8e0c566a4"
-dependencies = [
- "derive_more",
- "futures 0.3.13",
- "jsonrpc-core",
- "jsonrpc-pubsub",
- "log",
- "serde",
- "serde_json",
- "url 1.7.2",
-]
-
-[[package]]
 name = "jsonrpc-core"
 version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07569945133257ff557eb37b015497104cea61a2c9edaf126c1cbd6e8332397f"
 dependencies = [
- "futures 0.3.13",
+ "futures",
  "log",
  "serde",
  "serde_derive",
  "serde_json",
-]
-
-[[package]]
-name = "jsonrpc-core-client"
-version = "17.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ac9d56dc729912796637c30f475bbf834594607b27740dfea6e5fa7ba40d1f1"
-dependencies = [
- "futures 0.3.13",
- "jsonrpc-client-transports",
 ]
 
 [[package]]
@@ -1988,21 +1935,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "jsonrpc-pubsub"
-version = "17.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c48dbebce7a9c88ab272a4db7d6478aa4c6d9596e6c086366e89efc4e9ed89e"
-dependencies = [
- "futures 0.3.13",
- "jsonrpc-core",
- "lazy_static",
- "log",
- "parking_lot 0.11.1",
- "rand 0.7.3",
- "serde",
 ]
 
 [[package]]
@@ -2441,7 +2373,7 @@ dependencies = [
  "chrono",
  "cuid",
  "datamodel",
- "futures 0.3.13",
+ "futures",
  "itertools 0.10.0",
  "mongodb",
  "native-types",
@@ -2734,7 +2666,7 @@ checksum = "514d24875c140ed269eecc2d1b56d7b71b573716922a763c317fb1b1b4b58f15"
 dependencies = [
  "async-std",
  "async-trait",
- "futures 0.3.13",
+ "futures",
  "js-sys",
  "lazy_static",
  "percent-encoding 2.1.0",
@@ -2750,7 +2682,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff889e68a02000126fa635a311abc329ce128c576b7dddc4cd3270f3c240afd0"
 dependencies = [
  "async-trait",
- "futures 0.3.13",
+ "futures",
  "opentelemetry",
  "prost 0.7.0",
  "thiserror",
@@ -3051,7 +2983,7 @@ name = "postgres-native-tls"
 version = "0.5.0"
 source = "git+https://github.com/pimeys/rust-postgres?branch=pgbouncer-mode#8a61d46905571ff2b530b204dfa7c56ccbace7f4"
 dependencies = [
- "futures 0.3.13",
+ "futures",
  "native-tls",
  "tokio",
  "tokio-native-tls",
@@ -3311,7 +3243,7 @@ dependencies = [
  "chrono",
  "connection-string",
  "either",
- "futures 0.3.13",
+ "futures",
  "hex",
  "libsqlite3-sys",
  "lru-cache",
@@ -3344,7 +3276,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
- "futures 0.3.13",
+ "futures",
  "itertools 0.10.0",
  "once_cell",
  "prisma-models",
@@ -3368,7 +3300,7 @@ dependencies = [
  "crossbeam-queue",
  "datamodel",
  "datamodel-connector",
- "futures 0.3.13",
+ "futures",
  "im",
  "indexmap",
  "itertools 0.10.0",
@@ -3403,7 +3335,7 @@ dependencies = [
  "connection-string",
  "datamodel",
  "datamodel-connector",
- "futures 0.3.13",
+ "futures",
  "graphql-parser",
  "indexmap",
  "indoc",
@@ -3697,7 +3629,7 @@ dependencies = [
  "connection-string",
  "datamodel",
  "datamodel-connector",
- "futures 0.3.13",
+ "futures",
  "graphql-parser",
  "indexmap",
  "itertools 0.10.0",
@@ -4266,7 +4198,7 @@ dependencies = [
  "chrono",
  "cuid",
  "datamodel",
- "futures 0.3.13",
+ "futures",
  "itertools 0.10.0",
  "prisma-models",
  "prisma-value",
@@ -4579,7 +4511,7 @@ dependencies = [
  "connection-string",
  "encoding",
  "enumflags2",
- "futures 0.3.13",
+ "futures",
  "futures-sink",
  "futures-util",
  "num-bigint",
@@ -4745,7 +4677,7 @@ dependencies = [
  "byteorder",
  "bytes 1.0.1",
  "fallible-iterator",
- "futures 0.3.13",
+ "futures",
  "log",
  "parking_lot 0.11.1",
  "percent-encoding 2.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,7 +260,7 @@ dependencies = [
  "async-std",
  "native-tls",
  "thiserror",
- "url 2.2.1",
+ "url",
 ]
 
 [[package]]
@@ -735,7 +735,7 @@ dependencies = [
  "base64 0.13.0",
  "hkdf",
  "hmac",
- "percent-encoding 2.1.0",
+ "percent-encoding",
  "rand 0.8.3",
  "sha2",
  "time 0.2.26",
@@ -948,7 +948,7 @@ dependencies = [
  "itertools 0.10.0",
  "serde_json",
  "thiserror",
- "url 2.2.1",
+ "url",
 ]
 
 [[package]]
@@ -1259,7 +1259,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
- "percent-encoding 2.1.0",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -1637,7 +1637,7 @@ dependencies = [
  "serde_json",
  "serde_qs",
  "serde_urlencoded",
- "url 2.2.1",
+ "url",
 ]
 
 [[package]]
@@ -1696,17 +1696,6 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
-name = "idna"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
-dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
-]
 
 [[package]]
 name = "idna"
@@ -2162,7 +2151,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-futures",
- "url 2.2.1",
+ "url",
  "user-facing-errors",
 ]
 
@@ -2185,7 +2174,7 @@ dependencies = [
  "tracing",
  "tracing-error",
  "tracing-subscriber",
- "url 2.2.1",
+ "url",
  "user-facing-errors",
 ]
 
@@ -2218,7 +2207,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-futures",
- "url 2.2.1",
+ "url",
  "user-facing-errors",
 ]
 
@@ -2297,7 +2286,7 @@ dependencies = [
  "md-5",
  "os_info",
  "pbkdf2",
- "percent-encoding 2.1.0",
+ "percent-encoding",
  "rand 0.8.3",
  "reqwest",
  "rustls",
@@ -2358,7 +2347,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-futures",
- "url 2.2.1",
+ "url",
  "user-facing-errors",
  "uuid",
 ]
@@ -2388,7 +2377,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-futures",
- "url 2.2.1",
+ "url",
  "user-facing-errors",
  "uuid",
 ]
@@ -2414,7 +2403,7 @@ dependencies = [
  "mysql_common",
  "native-tls",
  "pem",
- "percent-encoding 2.1.0",
+ "percent-encoding",
  "pin-project",
  "serde",
  "serde_json",
@@ -2423,7 +2412,7 @@ dependencies = [
  "tokio-native-tls",
  "tokio-util",
  "twox-hash",
- "url 2.2.1",
+ "url",
  "uuid",
 ]
 
@@ -2669,7 +2658,7 @@ dependencies = [
  "futures",
  "js-sys",
  "lazy_static",
- "percent-encoding 2.1.0",
+ "percent-encoding",
  "pin-project",
  "rand 0.8.3",
  "thiserror",
@@ -2702,7 +2691,7 @@ dependencies = [
  "openssl",
  "openssl-probe",
  "openssl-sys",
- "url 2.2.1",
+ "url",
 ]
 
 [[package]]
@@ -2793,7 +2782,7 @@ checksum = "9dfd153802fdbad158c1dfa2c5df806a86955ae6e07758af642a4faaa03310ff"
 dependencies = [
  "html-escape",
  "nom",
- "percent-encoding 2.1.0",
+ "percent-encoding",
  "thiserror",
 ]
 
@@ -2816,12 +2805,6 @@ dependencies = [
  "once_cell",
  "regex",
 ]
-
-[[package]]
-name = "percent-encoding"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 
 [[package]]
 name = "percent-encoding"
@@ -3253,7 +3236,7 @@ dependencies = [
  "native-tls",
  "num-bigint",
  "num_cpus",
- "percent-encoding 2.1.0",
+ "percent-encoding",
  "postgres-native-tls",
  "postgres-types",
  "rusqlite",
@@ -3265,7 +3248,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-core",
- "url 2.2.1",
+ "url",
  "uuid",
 ]
 
@@ -3318,7 +3301,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-futures",
- "url 1.7.2",
+ "url",
  "user-facing-errors",
  "uuid",
 ]
@@ -3371,7 +3354,7 @@ dependencies = [
  "tracing-futures",
  "tracing-opentelemetry",
  "tracing-subscriber",
- "url 2.2.1",
+ "url",
  "user-facing-errors",
 ]
 
@@ -3400,7 +3383,7 @@ dependencies = [
  "tracing-futures",
  "tracing-opentelemetry",
  "tracing-subscriber",
- "url 2.2.1",
+ "url",
  "user-facing-errors",
 ]
 
@@ -3641,7 +3624,7 @@ dependencies = [
  "test-setup",
  "thiserror",
  "tracing",
- "url 2.2.1",
+ "url",
  "user-facing-errors",
 ]
 
@@ -3665,7 +3648,7 @@ dependencies = [
  "lazy_static",
  "log",
  "mime",
- "percent-encoding 2.1.0",
+ "percent-encoding",
  "pin-project-lite 0.2.6",
  "rustls",
  "serde",
@@ -3673,7 +3656,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-rustls",
- "url 2.2.1",
+ "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -3897,7 +3880,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5af82de3c6549b001bec34961ff2d6a54339a87bab37ce901b693401f27de6cb"
 dependencies = [
  "data-encoding",
- "percent-encoding 2.1.0",
+ "percent-encoding",
  "serde",
  "thiserror",
 ]
@@ -4183,7 +4166,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-futures",
- "url 2.2.1",
+ "url",
  "user-facing-errors",
  "uuid",
 ]
@@ -4453,7 +4436,7 @@ dependencies = [
  "tracing",
  "tracing-error",
  "tracing-subscriber",
- "url 2.2.1",
+ "url",
 ]
 
 [[package]]
@@ -4680,7 +4663,7 @@ dependencies = [
  "futures",
  "log",
  "parking_lot 0.11.1",
- "percent-encoding 2.1.0",
+ "percent-encoding",
  "phf",
  "pin-project-lite 0.2.6",
  "postgres-protocol",
@@ -4752,7 +4735,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "percent-encoding 2.1.0",
+ "percent-encoding",
  "pin-project",
  "prost 0.7.0",
  "prost-derive 0.7.0",
@@ -4933,7 +4916,7 @@ dependencies = [
  "futures-channel",
  "futures-io",
  "futures-util",
- "idna 0.2.2",
+ "idna",
  "ipnet",
  "lazy_static",
  "log",
@@ -4942,7 +4925,7 @@ dependencies = [
  "thiserror",
  "tinyvec",
  "tokio",
- "url 2.2.1",
+ "url",
 ]
 
 [[package]]
@@ -5074,25 +5057,14 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
-dependencies = [
- "idna 0.1.5",
- "matches",
- "percent-encoding 1.0.1",
-]
-
-[[package]]
-name = "url"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b"
 dependencies = [
  "form_urlencoded",
- "idna 0.2.2",
+ "idna",
  "matches",
- "percent-encoding 2.1.0",
+ "percent-encoding",
  "serde",
 ]
 

--- a/introspection-engine/core/Cargo.toml
+++ b/introspection-engine/core/Cargo.toml
@@ -20,7 +20,6 @@ serde_derive = "1.0"
 async-trait = "0.1.17"
 jsonrpc-core = "17.0"
 jsonrpc-derive = "17.0"
-jsonrpc-core-client = "17.0"
 json-rpc-stdio = { path = "../../libs/json-rpc-stdio" }
 
 tracing = "0.1"

--- a/introspection-engine/core/src/rpc.rs
+++ b/introspection-engine/core/src/rpc.rs
@@ -12,7 +12,7 @@ type RpcError = jsonrpc_core::Error;
 type RpcResult<T> = Result<T, RpcError>;
 type RpcFutureResult<T> = BoxFuture<RpcResult<T>>;
 
-#[rpc]
+#[rpc(server)]
 pub trait Rpc {
     #[rpc(name = "listDatabases")]
     fn list_databases(&self, input: IntrospectionInput) -> RpcFutureResult<Vec<String>>;

--- a/query-engine/core/Cargo.toml
+++ b/query-engine/core/Cargo.toml
@@ -36,6 +36,6 @@ thiserror = "1.0"
 tokio = { version = "1.0" }
 tracing = { version = "0.1", features = ["attributes"] }
 tracing-futures = "0.2.4"
-url = "1"
+url = "2"
 user-facing-errors = { path = "../../libs/user-facing-errors" }
 uuid = "0.8"


### PR DESCRIPTION
This cascades to a bunch of transitive dependencies becoming
unnecessary.

Also de-duplicates `url` dependency in QE.