### PR TITLE
Move native types validation to ParserDatabase

### DIFF
--- a/.github/workflows/query-engine.yml
+++ b/.github/workflows/query-engine.yml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: "1.51.0"
+          toolchain: stable
           default: true
 
       - uses: olafurpg/setup-scala@v10
@@ -78,7 +78,7 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: "1.51.0"
+          toolchain: stable
           default: true
 
       - uses: actions/cache@v2

--- a/introspection-engine/introspection-engine-tests/tests/re_introspection/mod.rs
+++ b/introspection-engine/introspection-engine-tests/tests/re_introspection/mod.rs
@@ -1183,21 +1183,21 @@ async fn virtual_cuid_default(api: &TestApi) {
         .await
         .unwrap();
 
-    let input_dm = indoc! {r#"
-        datasource db {
-            provider = "postgres"
-            url = env("TEST_DATABASE_URL")
-        }
+    let input_dm = format!(
+        r#"
+        {datasource}
 
-        model User {
+        model User {{
             id        String    @id @default(cuid()) @db.VarChar(30)
             non_id    String    @default(cuid()) @db.VarChar(30)
-        }
+        }}
 
-        model User2 {
+        model User2 {{
             id        String    @id @default(uuid()) @db.VarChar(36)
-        }
-    "#};
+        }}
+        "#,
+        datasource = api.datasource_block()
+    );
 
     let final_dm = indoc! {r#"
         model User {
@@ -1214,7 +1214,7 @@ async fn virtual_cuid_default(api: &TestApi) {
         }
     "#};
 
-    api.assert_eq_datamodels(final_dm, &api.re_introspect(input_dm).await.unwrap());
+    api.assert_eq_datamodels(final_dm, &api.re_introspect(&input_dm).await.unwrap());
 }
 
 #[test_connector(tags(Postgres))]

--- a/libs/datamodel/core/src/transform/ast_to_dml/db.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db.rs
@@ -7,11 +7,11 @@ mod context;
 mod names;
 mod types;
 
-pub(crate) use types::ScalarFieldType;
+pub(crate) use types::{ScalarField, ScalarFieldType};
 
 use self::{
     context::Context,
-    types::{RelationField, ScalarField, Types},
+    types::{RelationField, Types},
 };
 use crate::{ast, diagnostics::Diagnostics, Datasource};
 use datamodel_connector::{Connector, EmptyDatamodelConnector};

--- a/libs/datamodel/core/src/transform/ast_to_dml/db/attributes.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/attributes.rs
@@ -1,3 +1,5 @@
+mod native_types;
+
 use super::{
     context::{Arguments, Context},
     types::{IndexData, ModelData, RelationField, ScalarField},
@@ -201,6 +203,13 @@ fn visit_scalar_field_attributes<'ast>(
          attributes.visit_optional_single("default", ctx, |args, ctx| {
             visit_field_default(args, scalar_field_data, model_id, field_id, ctx);
          });
+
+        if let ScalarFieldType::BuiltInScalar(scalar_type) = scalar_field_data.r#type {
+            // native type attributes
+            attributes.visit_datasource_scoped(ctx, |type_name, args, ctx| {
+                native_types::visit_native_type_attribute(type_name, args, scalar_type, scalar_field_data, ctx)
+            });
+        }
 
          // @unique
          attributes.visit_optional_single("unique", ctx, |args, ctx| {

--- a/libs/datamodel/core/src/transform/ast_to_dml/db/attributes/native_types.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/attributes/native_types.rs
@@ -1,0 +1,96 @@
+use crate::{
+    ast,
+    diagnostics::DatamodelError,
+    transform::{
+        ast_to_dml::db::{context::Context, types::ScalarField},
+        helpers::ValueValidator,
+    },
+};
+use datamodel_connector::connector_error::{ConnectorError, ErrorKind};
+use dml::scalars::ScalarType;
+use itertools::Itertools;
+
+pub(super) fn visit_native_type_attribute<'ast>(
+    type_name: &'ast str,
+    attr: &'ast ast::Attribute,
+    scalar_type: ScalarType,
+    scalar_field: &mut ScalarField<'ast>,
+    ctx: &mut Context<'ast>,
+) {
+    let args = &attr.arguments;
+    let diagnostics = &mut ctx.diagnostics;
+
+    // convert arguments to string if possible
+    let args: Vec<String> = args.iter().map(|arg| ValueValidator::new(&arg.value).raw()).collect();
+
+    let constructor = if let Some(cons) = ctx.db.active_connector().find_native_type_constructor(type_name) {
+        cons
+    } else {
+        diagnostics.push_error(DatamodelError::new_connector_error(
+            &ConnectorError::from_kind(ErrorKind::NativeTypeNameUnknown {
+                native_type: type_name.to_owned(),
+                connector_name: ctx
+                    .db
+                    .datasource()
+                    .map(|ds| ds.active_provider.clone())
+                    .unwrap_or_else(|| "Default".to_owned()),
+            })
+            .to_string(),
+            attr.span,
+        ));
+        return;
+    };
+
+    let number_of_args = args.len();
+
+    if number_of_args < constructor._number_of_args
+        || ((number_of_args > constructor._number_of_args) && constructor._number_of_optional_args == 0)
+    {
+        diagnostics.push_error(DatamodelError::new_argument_count_missmatch_error(
+            type_name,
+            constructor._number_of_args,
+            number_of_args,
+            attr.span,
+        ));
+        return;
+    }
+
+    if number_of_args > constructor._number_of_args + constructor._number_of_optional_args
+        && constructor._number_of_optional_args > 0
+    {
+        diagnostics.push_error(DatamodelError::new_connector_error(
+            &ConnectorError::from_kind(ErrorKind::OptionalArgumentCountMismatchError {
+                native_type: type_name.to_owned(),
+                optional_count: constructor._number_of_optional_args,
+                given_count: number_of_args,
+            })
+            .to_string(),
+            attr.span,
+        ));
+        return;
+    }
+
+    // check for compatibility with scalar type
+    if !constructor.prisma_types.contains(&scalar_type) {
+        diagnostics.push_error(DatamodelError::new_connector_error(
+            &ConnectorError::from_kind(ErrorKind::IncompatibleNativeType {
+                native_type: type_name.to_owned(),
+                field_type: scalar_type.to_string(),
+                expected_types: constructor.prisma_types.iter().map(|s| s.to_string()).join(" or "),
+            })
+            .to_string(),
+            attr.span,
+        ));
+        return;
+    }
+
+    if let Err(connector_error) = ctx.db.active_connector().parse_native_type(type_name, args.clone()) {
+        diagnostics.push_error(DatamodelError::new_connector_error(
+            &connector_error.to_string(),
+            attr.span,
+        ));
+        return;
+    };
+
+    scalar_field.native_type = Some((type_name, args))
+}

--- a/libs/datamodel/core/src/transform/ast_to_dml/db/context.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/context.rs
@@ -104,11 +104,6 @@ impl<'ast> Context<'ast> {
         f(&mut attributes, self);
 
         for attribute in attributes.unused_attributes() {
-            // Native types...
-            if attribute.name.name.contains('.') {
-                continue;
-            }
-
             self.push_error(DatamodelError::new_attribute_not_known_error(
                 &attribute.name.name,
                 attribute.name.span,

--- a/libs/datamodel/core/src/transform/ast_to_dml/db/context/attributes.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/context/attributes.rs
@@ -1,4 +1,5 @@
 use super::*;
+use datamodel_connector::connector_error::{ConnectorError, ErrorKind};
 
 #[derive(Default)]
 pub(crate) struct Attributes<'ast> {
@@ -69,5 +70,63 @@ impl<'ast> Attributes<'ast> {
             ctx.with_arguments(attr, &mut f);
             assert!(self.unused_attributes.remove(&attr_idx));
         }
+    }
+
+    /// Look for an optional attribute with a name of the form
+    /// "<datasource_name>.<attribute_name>", and call the passed-in function
+    /// with the attribute name and the arguments.
+    ///
+    /// Also note that native type arguments are treated differently from
+    /// arguments to other attributes: everywhere else, attributes are named,
+    /// with a default that can be first, but with native types, arguments are
+    /// purely positional.
+    pub(crate) fn visit_datasource_scoped<'ctx>(
+        &mut self,
+        ctx: &'ctx mut Context<'ast>,
+        f: impl FnOnce(&'ast str, &'ast ast::Attribute, &mut Context<'ast>),
+    ) {
+        let datasource = if let Some(ds) = ctx.db.datasource() { ds } else { return };
+
+        let attrs = self
+            .attributes
+            .iter()
+            .enumerate()
+            .filter(|(_, attr)| attr.name.name.contains('.'));
+        let mut native_type_attr = None;
+
+        // Extract the attribute, validating that:
+        //
+        // 1. All scoped attributes are scoped with the right datasource name
+        // 2. There are no duplicates
+        for (attr_idx, attr) in attrs {
+            assert!(self.unused_attributes.remove(&attr_idx));
+
+            match attr.name.name.split_once('.') {
+                None => unreachable!(),
+                Some((ds, attr_name)) if ds == datasource.name => {
+                    if native_type_attr.replace((attr, attr_name)).is_some() {
+                        ctx.push_error(DatamodelError::new_duplicate_attribute_error(&ds, attr.span));
+                    }
+                }
+                Some((bad_datasource, attr_name)) => {
+                    ctx.push_error(DatamodelError::new_connector_error(
+                        &ConnectorError::from_kind(ErrorKind::InvalidPrefixForNativeTypes {
+                            given_prefix: bad_datasource.to_owned(),
+                            expected_prefix: datasource.name.clone(),
+                            suggestion: [datasource.name.as_str(), attr_name].join("."),
+                        })
+                        .to_string(),
+                        attr.span,
+                    ));
+                }
+            }
+        }
+
+        let (attr, attr_name) = match native_type_attr {
+            Some(attr) => attr,
+            None => return, // early return if absent: it's optional
+        };
+
+        f(attr_name, attr, ctx);
     }
 }

--- a/libs/datamodel/core/src/transform/ast_to_dml/db/types.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/types.rs
@@ -75,6 +75,8 @@ pub(crate) struct ScalarField<'ast> {
     pub(crate) default: Option<dml::default_value::DefaultValue>,
     /// @map
     pub(super) mapped_name: Option<&'ast str>,
+    // Native type name and arguments
+    pub(crate) native_type: Option<(&'ast str, Vec<String>)>,
 }
 
 #[derive(Debug)]
@@ -160,6 +162,7 @@ fn visit_model<'ast>(model_id: ast::ModelId, ast_model: &'ast ast::Model, ctx: &
                     is_updated_at: false,
                     default: None,
                     mapped_name: None,
+                    native_type: None,
                 };
 
                 if matches!(scalar_field_type, ScalarFieldType::BuiltInScalar(t) if t.is_json())

--- a/libs/datamodel/core/src/transform/ast_to_dml/lift.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/lift.rs
@@ -225,8 +225,8 @@ impl<'a> LiftAstToDml<'a> {
             ),
             ScalarFieldType::Alias(top_id) => {
                 let alias = &self.db.ast()[*top_id];
-                let scalar_field_type = self.db.alias_scalar_field_type(&top_id).clone();
-                self.lift_scalar_field_type(alias, &scalar_field_type, scalar_field_data)
+                let scalar_field_type = self.db.alias_scalar_field_type(&top_id);
+                self.lift_scalar_field_type(alias, scalar_field_type, scalar_field_data)
             }
             ScalarFieldType::BuiltInScalar(scalar_type) => {
                 let native_type = scalar_field_data.native_type.as_ref().map(|(name, args)| {

--- a/migration-engine/migration-engine-tests/tests/migrations/defaults.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/defaults.rs
@@ -86,18 +86,22 @@ fn default_dbgenerated_should_work(api: TestApi) {
 
 #[test_connector(tags(Postgres))]
 fn uuid_default(api: TestApi) {
-    let dm = r#"
+    let dm = api.datamodel_with_provider(
+        r#"
         model A {
             id   String @id @db.Uuid
             uuid String @db.Uuid @default("00000000-0000-0000-0016-000000000004")
         }
-    "#;
+    "#,
+    );
 
     api.schema_push(dm).send().assert_green_bang();
 
     api.assert_schema().assert_table("A", |table| {
         table.assert_column("uuid", |col| {
-            col.assert_default(Some(DefaultValue::value("00000000-0000-0000-0016-000000000004")))
+            col.assert_default(Some(DefaultValue::db_generated(
+                "'00000000-0000-0000-0016-000000000004'::uuid",
+            )))
         })
     });
 }

--- a/migration-engine/migration-engine-tests/tests/migrations/diagnose_migration_history_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/diagnose_migration_history_tests.rs
@@ -1009,14 +1009,16 @@ fn default_dbgenerated_should_not_cause_drift(api: TestApi) {
 fn default_uuid_should_not_cause_drift(api: TestApi) {
     let migrations_directory = api.create_migrations_directory();
 
-    let dm = r#"
+    let dm = api.datamodel_with_provider(
+        r#"
         model A {
             id   String @id @db.Uuid
             uuid String @db.Uuid @default("00000000-0000-0000-0016-000000000004")
         }
-    "#;
+    "#,
+    );
 
-    api.create_migration("01init", dm, &migrations_directory).send_sync();
+    api.create_migration("01init", &dm, &migrations_directory).send_sync();
 
     api.apply_migrations(&migrations_directory)
         .send_sync()


### PR DESCRIPTION
The alterations are kept to a minimum for now, so we are sure we are
porting the same logic. A few small validation improvements are
included.