### PR TITLE
SQL Server: Detect referential action cycles

### DIFF
--- a/libs/datamodel/connectors/datamodel-connector/src/lib.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/lib.rs
@@ -234,6 +234,7 @@ capabilities!(
     RelationFieldsInArbitraryOrder,
     ForeignKeys,
     NamedPrimaryKeys,
+    ReferenceCycleDetection,
     // Start of query-engine-only Capabilities
     InsensitiveFilters,
     CreateMany,

--- a/libs/datamodel/connectors/dml/src/relation_info.rs
+++ b/libs/datamodel/connectors/dml/src/relation_info.rs
@@ -96,3 +96,10 @@ impl fmt::Display for ReferentialAction {
         }
     }
 }
+
+impl ReferentialAction {
+    // True, if the action modifies the related items.
+    pub fn triggers_modification(self) -> bool {
+        !matches!(self, Self::NoAction | Self::Restrict)
+    }
+}

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/mssql_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/mssql_datamodel_connector.rs
@@ -69,6 +69,7 @@ impl MsSqlDatamodelConnector {
             ConnectorCapability::UpdateableId,
             ConnectorCapability::AnyId,
             ConnectorCapability::QueryRaw,
+            ConnectorCapability::ReferenceCycleDetection,
         ];
 
         let constructors: Vec<NativeTypeConstructor> = vec![

--- a/libs/datamodel/core/src/lib.rs
+++ b/libs/datamodel/core/src/lib.rs
@@ -139,9 +139,10 @@ fn parse_datamodel_internal(
     let generators = GeneratorLoader::load_generators_from_ast(&ast, &mut diagnostics);
     let preview_features = preview_features(&generators);
     let datasources = load_sources(&ast, preview_features, &mut diagnostics);
-    let validator = ValidationPipeline::new(&datasources, preview_features);
 
     diagnostics.to_result()?;
+
+    let validator = ValidationPipeline::new(&datasources, preview_features);
 
     match validator.validate(&ast, transform) {
         Ok(mut src) => {

--- a/libs/datamodel/core/src/transform/ast_to_dml/validate.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validate.rs
@@ -466,15 +466,15 @@ impl<'a> Validator<'a> {
                     let msg = match (on_delete, on_update) {
                         (Some(on_delete), Some(on_update)) => {
                             format!(
-                                "{} Caused by default `onDelete` and `onUpdate` values: `{}` and `{}`.",
+                                "{} Implicit default `onDelete` and `onUpdate` values: `{}` and `{}`.",
                                 msg, on_delete, on_update
                             )
                         }
                         (Some(on_delete), None) => {
-                            format!("{} Caused by default `onDelete` value: `{}`.", msg, on_delete)
+                            format!("{} Implicit default `onDelete` value: `{}`.", msg, on_delete)
                         }
                         (None, Some(on_update)) => {
-                            format!("{} Caused by default `onUpdate` value: `{}`.", msg, on_update)
+                            format!("{} Implicit default `onUpdate` value: `{}`.", msg, on_update)
                         }
                         (None, None) => msg.to_string(),
                     };

--- a/libs/datamodel/core/src/transform/ast_to_dml/validate.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validate.rs
@@ -425,13 +425,25 @@ impl<'a> Validator<'a> {
                 .relation_info
                 .on_update
                 .or(related_field.relation_info.on_update)
-                .unwrap_or_else(|| field.default_on_update_action());
+                .unwrap_or_else(|| {
+                    if field.is_list() {
+                        related_field.default_on_update_action()
+                    } else {
+                        field.default_on_update_action()
+                    }
+                });
 
             let on_delete = field
                 .relation_info
                 .on_delete
                 .or(related_field.relation_info.on_delete)
-                .unwrap_or_else(|| field.default_on_delete_action());
+                .unwrap_or_else(|| {
+                    if field.is_list() {
+                        related_field.default_on_delete_action()
+                    } else {
+                        field.default_on_delete_action()
+                    }
+                });
 
             // a cycle has a meaning only if every relation in it triggers
             // modifications in the children

--- a/libs/datamodel/core/tests/attributes/relations/referential_actions.rs
+++ b/libs/datamodel/core/tests/attributes/relations/referential_actions.rs
@@ -434,3 +434,430 @@ fn on_update_without_preview_feature_should_error() {
         Span::new(127, 145),
     )]);
 }
+
+#[test]
+fn sql_server_cascading_on_delete_self_relations() {
+    let dml = indoc! {
+        r#"
+        datasource db {
+            provider = "sqlserver"
+            url = "sqlserver://"
+        }
+
+        generator client {
+            provider = "prisma-client-js"
+            previewFeatures = ["referentialActions", "microsoftSqlServer"]
+        }
+
+        model A {
+            id     Int  @id @default(autoincrement())
+            child  A?   @relation(name: "a_self_relation")
+            parent A?   @relation(name: "a_self_relation", fields: [aId], references: [id], onDelete: Cascade)
+            aId    Int?
+        }
+    "#};
+
+    let expect = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes.[0m
+          [1;94m-->[0m  [4mschema.prisma:13[0m
+        [1;94m   | [0m
+        [1;94m12 | [0m    id     Int  @id @default(autoincrement())
+        [1;94m13 | [0m    [1;91mchild  A?   @relation(name: "a_self_relation")[0m
+        [1;94m14 | [0m    parent A?   @relation(name: "a_self_relation", fields: [aId], references: [id], onDelete: Cascade)
+        [1;94m   | [0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes.[0m
+          [1;94m-->[0m  [4mschema.prisma:14[0m
+        [1;94m   | [0m
+        [1;94m13 | [0m    child  A?   @relation(name: "a_self_relation")
+        [1;94m14 | [0m    [1;91mparent A?   @relation(name: "a_self_relation", fields: [aId], references: [id], onDelete: Cascade)[0m
+        [1;94m15 | [0m    aId    Int?
+        [1;94m   | [0m
+    "#]];
+
+    expect.assert_eq(&datamodel::parse_schema(dml).map(drop).unwrap_err());
+}
+
+#[test]
+fn sql_server_cascading_on_update_self_relations() {
+    let dml = indoc! {
+        r#"
+        datasource db {
+            provider = "sqlserver"
+            url = "sqlserver://"
+        }
+
+        generator client {
+            provider = "prisma-client-js"
+            previewFeatures = ["referentialActions", "microsoftSqlServer"]
+        }
+
+        model A {
+            id     Int  @id @default(autoincrement())
+            child  A?   @relation(name: "a_self_relation")
+            parent A?   @relation(name: "a_self_relation", fields: [aId], references: [id], onUpdate: Cascade)
+            aId    Int?
+        }
+    "#};
+
+    let expect = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes.[0m
+          [1;94m-->[0m  [4mschema.prisma:13[0m
+        [1;94m   | [0m
+        [1;94m12 | [0m    id     Int  @id @default(autoincrement())
+        [1;94m13 | [0m    [1;91mchild  A?   @relation(name: "a_self_relation")[0m
+        [1;94m14 | [0m    parent A?   @relation(name: "a_self_relation", fields: [aId], references: [id], onUpdate: Cascade)
+        [1;94m   | [0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes.[0m
+          [1;94m-->[0m  [4mschema.prisma:14[0m
+        [1;94m   | [0m
+        [1;94m13 | [0m    child  A?   @relation(name: "a_self_relation")
+        [1;94m14 | [0m    [1;91mparent A?   @relation(name: "a_self_relation", fields: [aId], references: [id], onUpdate: Cascade)[0m
+        [1;94m15 | [0m    aId    Int?
+        [1;94m   | [0m
+    "#]];
+
+    expect.assert_eq(&datamodel::parse_schema(dml).map(drop).unwrap_err());
+}
+
+#[test]
+fn sql_server_null_setting_on_delete_self_relations() {
+    let dml = indoc! {
+        r#"
+        datasource db {
+            provider = "sqlserver"
+            url = "sqlserver://"
+        }
+
+        generator client {
+            provider = "prisma-client-js"
+            previewFeatures = ["referentialActions", "microsoftSqlServer"]
+        }
+
+        model A {
+            id     Int  @id @default(autoincrement())
+            child  A?   @relation(name: "a_self_relation")
+            parent A?   @relation(name: "a_self_relation", fields: [aId], references: [id], onDelete: SetNull)
+            aId    Int?
+        }
+    "#};
+
+    let expect = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes.[0m
+          [1;94m-->[0m  [4mschema.prisma:13[0m
+        [1;94m   | [0m
+        [1;94m12 | [0m    id     Int  @id @default(autoincrement())
+        [1;94m13 | [0m    [1;91mchild  A?   @relation(name: "a_self_relation")[0m
+        [1;94m14 | [0m    parent A?   @relation(name: "a_self_relation", fields: [aId], references: [id], onDelete: SetNull)
+        [1;94m   | [0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes.[0m
+          [1;94m-->[0m  [4mschema.prisma:14[0m
+        [1;94m   | [0m
+        [1;94m13 | [0m    child  A?   @relation(name: "a_self_relation")
+        [1;94m14 | [0m    [1;91mparent A?   @relation(name: "a_self_relation", fields: [aId], references: [id], onDelete: SetNull)[0m
+        [1;94m15 | [0m    aId    Int?
+        [1;94m   | [0m
+    "#]];
+
+    expect.assert_eq(&datamodel::parse_schema(dml).map(drop).unwrap_err());
+}
+
+#[test]
+fn sql_server_null_setting_on_update_self_relations() {
+    let dml = indoc! {
+        r#"
+        datasource db {
+            provider = "sqlserver"
+            url = "sqlserver://"
+        }
+
+        generator client {
+            provider = "prisma-client-js"
+            previewFeatures = ["referentialActions", "microsoftSqlServer"]
+        }
+
+        model A {
+            id     Int  @id @default(autoincrement())
+            child  A?   @relation(name: "a_self_relation")
+            parent A?   @relation(name: "a_self_relation", fields: [aId], references: [id], onUpdate: SetNull)
+            aId    Int?
+        }
+    "#};
+
+    let expect = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes.[0m
+          [1;94m-->[0m  [4mschema.prisma:13[0m
+        [1;94m   | [0m
+        [1;94m12 | [0m    id     Int  @id @default(autoincrement())
+        [1;94m13 | [0m    [1;91mchild  A?   @relation(name: "a_self_relation")[0m
+        [1;94m14 | [0m    parent A?   @relation(name: "a_self_relation", fields: [aId], references: [id], onUpdate: SetNull)
+        [1;94m   | [0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes.[0m
+          [1;94m-->[0m  [4mschema.prisma:14[0m
+        [1;94m   | [0m
+        [1;94m13 | [0m    child  A?   @relation(name: "a_self_relation")
+        [1;94m14 | [0m    [1;91mparent A?   @relation(name: "a_self_relation", fields: [aId], references: [id], onUpdate: SetNull)[0m
+        [1;94m15 | [0m    aId    Int?
+        [1;94m   | [0m
+    "#]];
+
+    expect.assert_eq(&datamodel::parse_schema(dml).map(drop).unwrap_err());
+}
+
+#[test]
+fn sql_server_default_setting_on_delete_self_relations() {
+    let dml = indoc! {
+        r#"
+        datasource db {
+            provider = "sqlserver"
+            url = "sqlserver://"
+        }
+
+        generator client {
+            provider = "prisma-client-js"
+            previewFeatures = ["referentialActions", "microsoftSqlServer"]
+        }
+
+        model A {
+            id     Int  @id @default(autoincrement())
+            child  A?   @relation(name: "a_self_relation")
+            parent A?   @relation(name: "a_self_relation", fields: [aId], references: [id], onDelete: SetDefault)
+            aId    Int?
+        }
+    "#};
+
+    let expect = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes.[0m
+          [1;94m-->[0m  [4mschema.prisma:13[0m
+        [1;94m   | [0m
+        [1;94m12 | [0m    id     Int  @id @default(autoincrement())
+        [1;94m13 | [0m    [1;91mchild  A?   @relation(name: "a_self_relation")[0m
+        [1;94m14 | [0m    parent A?   @relation(name: "a_self_relation", fields: [aId], references: [id], onDelete: SetDefault)
+        [1;94m   | [0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes.[0m
+          [1;94m-->[0m  [4mschema.prisma:14[0m
+        [1;94m   | [0m
+        [1;94m13 | [0m    child  A?   @relation(name: "a_self_relation")
+        [1;94m14 | [0m    [1;91mparent A?   @relation(name: "a_self_relation", fields: [aId], references: [id], onDelete: SetDefault)[0m
+        [1;94m15 | [0m    aId    Int?
+        [1;94m   | [0m
+    "#]];
+
+    expect.assert_eq(&datamodel::parse_schema(dml).map(drop).unwrap_err());
+}
+
+#[test]
+fn sql_server_default_setting_on_update_self_relations() {
+    let dml = indoc! {
+        r#"
+        datasource db {
+            provider = "sqlserver"
+            url = "sqlserver://"
+        }
+
+        generator client {
+            provider = "prisma-client-js"
+            previewFeatures = ["referentialActions", "microsoftSqlServer"]
+        }
+
+        model A {
+            id     Int  @id @default(autoincrement())
+            child  A?   @relation(name: "a_self_relation")
+            parent A?   @relation(name: "a_self_relation", fields: [aId], references: [id], onUpdate: SetDefault)
+            aId    Int?
+        }
+    "#};
+
+    let expect = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes.[0m
+          [1;94m-->[0m  [4mschema.prisma:13[0m
+        [1;94m   | [0m
+        [1;94m12 | [0m    id     Int  @id @default(autoincrement())
+        [1;94m13 | [0m    [1;91mchild  A?   @relation(name: "a_self_relation")[0m
+        [1;94m14 | [0m    parent A?   @relation(name: "a_self_relation", fields: [aId], references: [id], onUpdate: SetDefault)
+        [1;94m   | [0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes.[0m
+          [1;94m-->[0m  [4mschema.prisma:14[0m
+        [1;94m   | [0m
+        [1;94m13 | [0m    child  A?   @relation(name: "a_self_relation")
+        [1;94m14 | [0m    [1;91mparent A?   @relation(name: "a_self_relation", fields: [aId], references: [id], onUpdate: SetDefault)[0m
+        [1;94m15 | [0m    aId    Int?
+        [1;94m   | [0m
+    "#]];
+
+    expect.assert_eq(&datamodel::parse_schema(dml).map(drop).unwrap_err());
+}
+
+#[test]
+fn sql_server_cascading_cyclic_one_hop_relations() {
+    let dml = indoc! {
+        r#"
+        datasource db {
+            provider = "sqlserver"
+            url = "sqlserver://"
+        }
+
+        generator client {
+            provider = "prisma-client-js"
+            previewFeatures = ["referentialActions", "microsoftSqlServer"]
+        }
+
+        model A {
+            id     Int  @id @default(autoincrement())
+            b      B    @relation(name: "foo", fields: [bId], references: [id], onDelete: Cascade)
+            bId    Int
+            bs     B[]  @relation(name: "bar")
+        }
+
+        model B {
+            id     Int @id @default(autoincrement())
+            a      A   @relation(name: "bar", fields: [aId], references: [id], onUpdate: Cascade)
+            as     A[] @relation(name: "foo")
+            aId    Int
+        }
+    "#};
+
+    let expect = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@relation": Reference causes a cycle or multiple cascade paths. One of the @relation attributes in this cycle must have `onDelete` and `onUpdate` referential actions set to `NoAction`.[0m
+          [1;94m-->[0m  [4mschema.prisma:13[0m
+        [1;94m   | [0m
+        [1;94m12 | [0m    id     Int  @id @default(autoincrement())
+        [1;94m13 | [0m    [1;91mb      B    @relation(name: "foo", fields: [bId], references: [id], onDelete: Cascade)[0m
+        [1;94m14 | [0m    bId    Int
+        [1;94m   | [0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": Reference causes a cycle or multiple cascade paths. One of the @relation attributes in this cycle must have `onDelete` and `onUpdate` referential actions set to `NoAction`.[0m
+          [1;94m-->[0m  [4mschema.prisma:20[0m
+        [1;94m   | [0m
+        [1;94m19 | [0m    id     Int @id @default(autoincrement())
+        [1;94m20 | [0m    [1;91ma      A   @relation(name: "bar", fields: [aId], references: [id], onUpdate: Cascade)[0m
+        [1;94m21 | [0m    as     A[] @relation(name: "foo")
+        [1;94m   | [0m
+    "#]];
+
+    expect.assert_eq(&datamodel::parse_schema(dml).map(drop).unwrap_err());
+}
+
+#[test]
+fn sql_server_cascading_cyclic_hop_over_table_relations() {
+    let dml = indoc! {
+        r#"
+        datasource db {
+            provider = "sqlserver"
+            url = "sqlserver://"
+        }
+
+        generator client {
+            provider = "prisma-client-js"
+            previewFeatures = ["referentialActions", "microsoftSqlServer"]
+        }
+
+        model A {
+            id     Int  @id @default(autoincrement())
+            bId    Int
+            b      B    @relation(fields: [bId], references: [id])
+            cs     C[]
+        }
+
+        model B {
+            id     Int  @id @default(autoincrement())
+            as     A[]
+            cId    Int
+            c      C    @relation(fields: [cId], references: [id])
+        }
+
+        model C {
+            id     Int @id @default(autoincrement())
+            bs     B[]
+            aId    Int
+            a      A   @relation(fields: [aId], references: [id])
+        }
+    "#};
+
+    let expect = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@relation": Reference causes a cycle or multiple cascade paths. One of the @relation attributes in this cycle must have `onDelete` and `onUpdate` referential actions set to `NoAction`.[0m
+          [1;94m-->[0m  [4mschema.prisma:14[0m
+        [1;94m   | [0m
+        [1;94m13 | [0m    bId    Int
+        [1;94m14 | [0m    [1;91mb      B    @relation(fields: [bId], references: [id])[0m
+        [1;94m15 | [0m    cs     C[]
+        [1;94m   | [0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": Reference causes a cycle or multiple cascade paths. One of the @relation attributes in this cycle must have `onDelete` and `onUpdate` referential actions set to `NoAction`.[0m
+          [1;94m-->[0m  [4mschema.prisma:22[0m
+        [1;94m   | [0m
+        [1;94m21 | [0m    cId    Int
+        [1;94m22 | [0m    [1;91mc      C    @relation(fields: [cId], references: [id])[0m
+        [1;94m23 | [0m}
+        [1;94m   | [0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": Reference causes a cycle or multiple cascade paths. One of the @relation attributes in this cycle must have `onDelete` and `onUpdate` referential actions set to `NoAction`.[0m
+          [1;94m-->[0m  [4mschema.prisma:29[0m
+        [1;94m   | [0m
+        [1;94m28 | [0m    aId    Int
+        [1;94m29 | [0m    [1;91ma      A   @relation(fields: [aId], references: [id])[0m
+        [1;94m30 | [0m}
+        [1;94m   | [0m
+    "#]];
+
+    expect.assert_eq(&datamodel::parse_schema(dml).map(drop).unwrap_err());
+}
+
+#[test]
+fn sql_server_cascading_cyclic_crossing_path_relations() {
+    let dml = indoc! {
+        r#"
+        datasource db {
+            provider = "sqlserver"
+            url = "sqlserver://"
+        }
+
+        generator client {
+            provider = "prisma-client-js"
+            previewFeatures = ["referentialActions", "microsoftSqlServer"]
+        }
+
+        model A {
+            id     Int  @id @default(autoincrement())
+            bId    Int
+            b      B    @relation(fields: [bId], references: [id])
+            cs     C[]
+        }
+
+        model B {
+            id     Int  @id @default(autoincrement())
+            as     A[]
+            cs     C[]
+        }
+
+        model C {
+            id     Int  @id @default(autoincrement())
+            aId    Int
+            bId    Int
+            a      A    @relation(fields: [aId], references: [id])
+            b      B    @relation(fields: [bId], references: [id])
+        }
+    "#};
+
+    let expect = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@relation": Reference causes a cycle or multiple cascade paths. One of the @relation attributes in this cycle must have `onDelete` and `onUpdate` referential actions set to `NoAction`.[0m
+          [1;94m-->[0m  [4mschema.prisma:14[0m
+        [1;94m   | [0m
+        [1;94m13 | [0m    bId    Int
+        [1;94m14 | [0m    [1;91mb      B    @relation(fields: [bId], references: [id])[0m
+        [1;94m15 | [0m    cs     C[]
+        [1;94m   | [0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": Reference causes a cycle or multiple cascade paths. One of the @relation attributes in this cycle must have `onDelete` and `onUpdate` referential actions set to `NoAction`.[0m
+          [1;94m-->[0m  [4mschema.prisma:28[0m
+        [1;94m   | [0m
+        [1;94m27 | [0m    bId    Int
+        [1;94m28 | [0m    [1;91ma      A    @relation(fields: [aId], references: [id])[0m
+        [1;94m29 | [0m    b      B    @relation(fields: [bId], references: [id])
+        [1;94m   | [0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": Reference causes a cycle or multiple cascade paths. One of the @relation attributes in this cycle must have `onDelete` and `onUpdate` referential actions set to `NoAction`.[0m
+          [1;94m-->[0m  [4mschema.prisma:29[0m
+        [1;94m   | [0m
+        [1;94m28 | [0m    a      A    @relation(fields: [aId], references: [id])
+        [1;94m29 | [0m    [1;91mb      B    @relation(fields: [bId], references: [id])[0m
+        [1;94m30 | [0m}
+        [1;94m   | [0m
+    "#]];
+
+    expect.assert_eq(&datamodel::parse_schema(dml).map(drop).unwrap_err());
+}

--- a/libs/datamodel/core/tests/attributes/relations/referential_actions.rs
+++ b/libs/datamodel/core/tests/attributes/relations/referential_actions.rs
@@ -458,14 +458,14 @@ fn sql_server_cascading_on_delete_self_relations() {
     "#};
 
     let expect = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes. Caused by default `onDelete` and `onUpdate` values: `SetNull` and `Cascade`.[0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes. Implicit default `onDelete` and `onUpdate` values: `SetNull` and `Cascade`.[0m
           [1;94m-->[0m  [4mschema.prisma:13[0m
         [1;94m   | [0m
         [1;94m12 | [0m    id     Int  @id @default(autoincrement())
         [1;94m13 | [0m    [1;91mchild  A?   @relation(name: "a_self_relation")[0m
         [1;94m14 | [0m    parent A?   @relation(name: "a_self_relation", fields: [aId], references: [id], onDelete: Cascade)
         [1;94m   | [0m
-        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes. Caused by default `onUpdate` value: `Cascade`.[0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes. Implicit default `onUpdate` value: `Cascade`.[0m
           [1;94m-->[0m  [4mschema.prisma:14[0m
         [1;94m   | [0m
         [1;94m13 | [0m    child  A?   @relation(name: "a_self_relation")
@@ -500,14 +500,14 @@ fn sql_server_cascading_on_update_self_relations() {
     "#};
 
     let expect = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes. Caused by default `onDelete` and `onUpdate` values: `SetNull` and `Cascade`.[0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes. Implicit default `onDelete` and `onUpdate` values: `SetNull` and `Cascade`.[0m
           [1;94m-->[0m  [4mschema.prisma:13[0m
         [1;94m   | [0m
         [1;94m12 | [0m    id     Int  @id @default(autoincrement())
         [1;94m13 | [0m    [1;91mchild  A?   @relation(name: "a_self_relation")[0m
         [1;94m14 | [0m    parent A?   @relation(name: "a_self_relation", fields: [aId], references: [id], onUpdate: Cascade)
         [1;94m   | [0m
-        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes. Caused by default `onDelete` value: `SetNull`.[0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes. Implicit default `onDelete` value: `SetNull`.[0m
           [1;94m-->[0m  [4mschema.prisma:14[0m
         [1;94m   | [0m
         [1;94m13 | [0m    child  A?   @relation(name: "a_self_relation")
@@ -542,14 +542,14 @@ fn sql_server_null_setting_on_delete_self_relations() {
     "#};
 
     let expect = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes. Caused by default `onDelete` and `onUpdate` values: `SetNull` and `Cascade`.[0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes. Implicit default `onDelete` and `onUpdate` values: `SetNull` and `Cascade`.[0m
           [1;94m-->[0m  [4mschema.prisma:13[0m
         [1;94m   | [0m
         [1;94m12 | [0m    id     Int  @id @default(autoincrement())
         [1;94m13 | [0m    [1;91mchild  A?   @relation(name: "a_self_relation")[0m
         [1;94m14 | [0m    parent A?   @relation(name: "a_self_relation", fields: [aId], references: [id], onDelete: SetNull)
         [1;94m   | [0m
-        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes. Caused by default `onUpdate` value: `Cascade`.[0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes. Implicit default `onUpdate` value: `Cascade`.[0m
           [1;94m-->[0m  [4mschema.prisma:14[0m
         [1;94m   | [0m
         [1;94m13 | [0m    child  A?   @relation(name: "a_self_relation")
@@ -584,14 +584,14 @@ fn sql_server_null_setting_on_update_self_relations() {
     "#};
 
     let expect = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes. Caused by default `onDelete` and `onUpdate` values: `SetNull` and `Cascade`.[0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes. Implicit default `onDelete` and `onUpdate` values: `SetNull` and `Cascade`.[0m
           [1;94m-->[0m  [4mschema.prisma:13[0m
         [1;94m   | [0m
         [1;94m12 | [0m    id     Int  @id @default(autoincrement())
         [1;94m13 | [0m    [1;91mchild  A?   @relation(name: "a_self_relation")[0m
         [1;94m14 | [0m    parent A?   @relation(name: "a_self_relation", fields: [aId], references: [id], onUpdate: SetNull)
         [1;94m   | [0m
-        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes. Caused by default `onDelete` value: `SetNull`.[0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes. Implicit default `onDelete` value: `SetNull`.[0m
           [1;94m-->[0m  [4mschema.prisma:14[0m
         [1;94m   | [0m
         [1;94m13 | [0m    child  A?   @relation(name: "a_self_relation")
@@ -626,14 +626,14 @@ fn sql_server_default_setting_on_delete_self_relations() {
     "#};
 
     let expect = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes. Caused by default `onDelete` and `onUpdate` values: `SetNull` and `Cascade`.[0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes. Implicit default `onDelete` and `onUpdate` values: `SetNull` and `Cascade`.[0m
           [1;94m-->[0m  [4mschema.prisma:13[0m
         [1;94m   | [0m
         [1;94m12 | [0m    id     Int  @id @default(autoincrement())
         [1;94m13 | [0m    [1;91mchild  A?   @relation(name: "a_self_relation")[0m
         [1;94m14 | [0m    parent A?   @relation(name: "a_self_relation", fields: [aId], references: [id], onDelete: SetDefault)
         [1;94m   | [0m
-        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes. Caused by default `onUpdate` value: `Cascade`.[0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes. Implicit default `onUpdate` value: `Cascade`.[0m
           [1;94m-->[0m  [4mschema.prisma:14[0m
         [1;94m   | [0m
         [1;94m13 | [0m    child  A?   @relation(name: "a_self_relation")
@@ -668,14 +668,14 @@ fn sql_server_default_setting_on_update_self_relations() {
     "#};
 
     let expect = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes. Caused by default `onDelete` and `onUpdate` values: `SetNull` and `Cascade`.[0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes. Implicit default `onDelete` and `onUpdate` values: `SetNull` and `Cascade`.[0m
           [1;94m-->[0m  [4mschema.prisma:13[0m
         [1;94m   | [0m
         [1;94m12 | [0m    id     Int  @id @default(autoincrement())
         [1;94m13 | [0m    [1;91mchild  A?   @relation(name: "a_self_relation")[0m
         [1;94m14 | [0m    parent A?   @relation(name: "a_self_relation", fields: [aId], references: [id], onUpdate: SetDefault)
         [1;94m   | [0m
-        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes. Caused by default `onDelete` value: `SetNull`.[0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes. Implicit default `onDelete` value: `SetNull`.[0m
           [1;94m-->[0m  [4mschema.prisma:14[0m
         [1;94m   | [0m
         [1;94m13 | [0m    child  A?   @relation(name: "a_self_relation")
@@ -717,7 +717,7 @@ fn sql_server_cascading_cyclic_one_hop_relations() {
     "#};
 
     let expect = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@relation": Reference causes a cycle or multiple cascade paths. One of the @relation attributes in this cycle must have `onDelete` and `onUpdate` referential actions set to `NoAction`. Caused by default `onUpdate` value: `Cascade`.[0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": Reference causes a cycle or multiple cascade paths. One of the @relation attributes in this cycle must have `onDelete` and `onUpdate` referential actions set to `NoAction`. Implicit default `onUpdate` value: `Cascade`.[0m
           [1;94m-->[0m  [4mschema.prisma:13[0m
         [1;94m   | [0m
         [1;94m12 | [0m    id     Int  @id @default(autoincrement())
@@ -773,21 +773,21 @@ fn sql_server_cascading_cyclic_hop_over_table_relations() {
     "#};
 
     let expect = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@relation": Reference causes a cycle or multiple cascade paths. One of the @relation attributes in this cycle must have `onDelete` and `onUpdate` referential actions set to `NoAction`. Caused by default `onUpdate` value: `Cascade`.[0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": Reference causes a cycle or multiple cascade paths. One of the @relation attributes in this cycle must have `onDelete` and `onUpdate` referential actions set to `NoAction`. Implicit default `onUpdate` value: `Cascade`.[0m
           [1;94m-->[0m  [4mschema.prisma:14[0m
         [1;94m   | [0m
         [1;94m13 | [0m    bId    Int
         [1;94m14 | [0m    [1;91mb      B    @relation(fields: [bId], references: [id])[0m
         [1;94m15 | [0m    cs     C[]
         [1;94m   | [0m
-        [1;91merror[0m: [1mError parsing attribute "@relation": Reference causes a cycle or multiple cascade paths. One of the @relation attributes in this cycle must have `onDelete` and `onUpdate` referential actions set to `NoAction`. Caused by default `onUpdate` value: `Cascade`.[0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": Reference causes a cycle or multiple cascade paths. One of the @relation attributes in this cycle must have `onDelete` and `onUpdate` referential actions set to `NoAction`. Implicit default `onUpdate` value: `Cascade`.[0m
           [1;94m-->[0m  [4mschema.prisma:22[0m
         [1;94m   | [0m
         [1;94m21 | [0m    cId    Int
         [1;94m22 | [0m    [1;91mc      C    @relation(fields: [cId], references: [id])[0m
         [1;94m23 | [0m}
         [1;94m   | [0m
-        [1;91merror[0m: [1mError parsing attribute "@relation": Reference causes a cycle or multiple cascade paths. One of the @relation attributes in this cycle must have `onDelete` and `onUpdate` referential actions set to `NoAction`. Caused by default `onUpdate` value: `Cascade`.[0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": Reference causes a cycle or multiple cascade paths. One of the @relation attributes in this cycle must have `onDelete` and `onUpdate` referential actions set to `NoAction`. Implicit default `onUpdate` value: `Cascade`.[0m
           [1;94m-->[0m  [4mschema.prisma:29[0m
         [1;94m   | [0m
         [1;94m28 | [0m    aId    Int
@@ -836,21 +836,21 @@ fn sql_server_cascading_cyclic_hop_over_backrelation() {
     "#};
 
     let expect = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@relation": Reference causes a cycle or multiple cascade paths. One of the @relation attributes in this cycle must have `onDelete` and `onUpdate` referential actions set to `NoAction`. Caused by default `onUpdate` value: `Cascade`.[0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": Reference causes a cycle or multiple cascade paths. One of the @relation attributes in this cycle must have `onDelete` and `onUpdate` referential actions set to `NoAction`. Implicit default `onUpdate` value: `Cascade`.[0m
           [1;94m-->[0m  [4mschema.prisma:14[0m
         [1;94m   | [0m
         [1;94m13 | [0m    bId    Int
         [1;94m14 | [0m    [1;91mb      B    @relation(fields: [bId], references: [id])[0m
         [1;94m15 | [0m    cs     C[]
         [1;94m   | [0m
-        [1;91merror[0m: [1mError parsing attribute "@relation": Reference causes a cycle or multiple cascade paths. One of the @relation attributes in this cycle must have `onDelete` and `onUpdate` referential actions set to `NoAction`. Caused by default `onUpdate` value: `Cascade`.[0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": Reference causes a cycle or multiple cascade paths. One of the @relation attributes in this cycle must have `onDelete` and `onUpdate` referential actions set to `NoAction`. Implicit default `onUpdate` value: `Cascade`.[0m
           [1;94m-->[0m  [4mschema.prisma:28[0m
         [1;94m   | [0m
         [1;94m27 | [0m    bId    Int
         [1;94m28 | [0m    [1;91ma      A   @relation(fields: [aId], references: [id])[0m
         [1;94m29 | [0m    b      B   @relation(fields: [bId], references: [id])
         [1;94m   | [0m
-        [1;91merror[0m: [1mError parsing attribute "@relation": Reference causes a cycle or multiple cascade paths. One of the @relation attributes in this cycle must have `onDelete` and `onUpdate` referential actions set to `NoAction`. Caused by default `onUpdate` value: `Cascade`.[0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": Reference causes a cycle or multiple cascade paths. One of the @relation attributes in this cycle must have `onDelete` and `onUpdate` referential actions set to `NoAction`. Implicit default `onUpdate` value: `Cascade`.[0m
           [1;94m-->[0m  [4mschema.prisma:29[0m
         [1;94m   | [0m
         [1;94m28 | [0m    a      A   @relation(fields: [aId], references: [id])
@@ -899,21 +899,21 @@ fn sql_server_cascading_cyclic_crossing_path_relations() {
     "#};
 
     let expect = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@relation": Reference causes a cycle or multiple cascade paths. One of the @relation attributes in this cycle must have `onDelete` and `onUpdate` referential actions set to `NoAction`. Caused by default `onUpdate` value: `Cascade`.[0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": Reference causes a cycle or multiple cascade paths. One of the @relation attributes in this cycle must have `onDelete` and `onUpdate` referential actions set to `NoAction`. Implicit default `onUpdate` value: `Cascade`.[0m
           [1;94m-->[0m  [4mschema.prisma:14[0m
         [1;94m   | [0m
         [1;94m13 | [0m    bId    Int
         [1;94m14 | [0m    [1;91mb      B    @relation(fields: [bId], references: [id])[0m
         [1;94m15 | [0m    cs     C[]
         [1;94m   | [0m
-        [1;91merror[0m: [1mError parsing attribute "@relation": Reference causes a cycle or multiple cascade paths. One of the @relation attributes in this cycle must have `onDelete` and `onUpdate` referential actions set to `NoAction`. Caused by default `onUpdate` value: `Cascade`.[0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": Reference causes a cycle or multiple cascade paths. One of the @relation attributes in this cycle must have `onDelete` and `onUpdate` referential actions set to `NoAction`. Implicit default `onUpdate` value: `Cascade`.[0m
           [1;94m-->[0m  [4mschema.prisma:28[0m
         [1;94m   | [0m
         [1;94m27 | [0m    bId    Int
         [1;94m28 | [0m    [1;91ma      A    @relation(fields: [aId], references: [id])[0m
         [1;94m29 | [0m    b      B    @relation(fields: [bId], references: [id])
         [1;94m   | [0m
-        [1;91merror[0m: [1mError parsing attribute "@relation": Reference causes a cycle or multiple cascade paths. One of the @relation attributes in this cycle must have `onDelete` and `onUpdate` referential actions set to `NoAction`. Caused by default `onUpdate` value: `Cascade`.[0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": Reference causes a cycle or multiple cascade paths. One of the @relation attributes in this cycle must have `onDelete` and `onUpdate` referential actions set to `NoAction`. Implicit default `onUpdate` value: `Cascade`.[0m
           [1;94m-->[0m  [4mschema.prisma:29[0m
         [1;94m   | [0m
         [1;94m28 | [0m    a      A    @relation(fields: [aId], references: [id])

--- a/libs/datamodel/core/tests/attributes/relations/referential_actions.rs
+++ b/libs/datamodel/core/tests/attributes/relations/referential_actions.rs
@@ -458,14 +458,14 @@ fn sql_server_cascading_on_delete_self_relations() {
     "#};
 
     let expect = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes.[0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes. Caused by default `onDelete` and `onUpdate` values: `SetNull` and `Cascade`.[0m
           [1;94m-->[0m  [4mschema.prisma:13[0m
         [1;94m   | [0m
         [1;94m12 | [0m    id     Int  @id @default(autoincrement())
         [1;94m13 | [0m    [1;91mchild  A?   @relation(name: "a_self_relation")[0m
         [1;94m14 | [0m    parent A?   @relation(name: "a_self_relation", fields: [aId], references: [id], onDelete: Cascade)
         [1;94m   | [0m
-        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes.[0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes. Caused by default `onUpdate` value: `Cascade`.[0m
           [1;94m-->[0m  [4mschema.prisma:14[0m
         [1;94m   | [0m
         [1;94m13 | [0m    child  A?   @relation(name: "a_self_relation")
@@ -500,14 +500,14 @@ fn sql_server_cascading_on_update_self_relations() {
     "#};
 
     let expect = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes.[0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes. Caused by default `onDelete` and `onUpdate` values: `SetNull` and `Cascade`.[0m
           [1;94m-->[0m  [4mschema.prisma:13[0m
         [1;94m   | [0m
         [1;94m12 | [0m    id     Int  @id @default(autoincrement())
         [1;94m13 | [0m    [1;91mchild  A?   @relation(name: "a_self_relation")[0m
         [1;94m14 | [0m    parent A?   @relation(name: "a_self_relation", fields: [aId], references: [id], onUpdate: Cascade)
         [1;94m   | [0m
-        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes.[0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes. Caused by default `onDelete` value: `SetNull`.[0m
           [1;94m-->[0m  [4mschema.prisma:14[0m
         [1;94m   | [0m
         [1;94m13 | [0m    child  A?   @relation(name: "a_self_relation")
@@ -542,14 +542,14 @@ fn sql_server_null_setting_on_delete_self_relations() {
     "#};
 
     let expect = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes.[0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes. Caused by default `onDelete` and `onUpdate` values: `SetNull` and `Cascade`.[0m
           [1;94m-->[0m  [4mschema.prisma:13[0m
         [1;94m   | [0m
         [1;94m12 | [0m    id     Int  @id @default(autoincrement())
         [1;94m13 | [0m    [1;91mchild  A?   @relation(name: "a_self_relation")[0m
         [1;94m14 | [0m    parent A?   @relation(name: "a_self_relation", fields: [aId], references: [id], onDelete: SetNull)
         [1;94m   | [0m
-        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes.[0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes. Caused by default `onUpdate` value: `Cascade`.[0m
           [1;94m-->[0m  [4mschema.prisma:14[0m
         [1;94m   | [0m
         [1;94m13 | [0m    child  A?   @relation(name: "a_self_relation")
@@ -584,14 +584,14 @@ fn sql_server_null_setting_on_update_self_relations() {
     "#};
 
     let expect = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes.[0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes. Caused by default `onDelete` and `onUpdate` values: `SetNull` and `Cascade`.[0m
           [1;94m-->[0m  [4mschema.prisma:13[0m
         [1;94m   | [0m
         [1;94m12 | [0m    id     Int  @id @default(autoincrement())
         [1;94m13 | [0m    [1;91mchild  A?   @relation(name: "a_self_relation")[0m
         [1;94m14 | [0m    parent A?   @relation(name: "a_self_relation", fields: [aId], references: [id], onUpdate: SetNull)
         [1;94m   | [0m
-        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes.[0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes. Caused by default `onDelete` value: `SetNull`.[0m
           [1;94m-->[0m  [4mschema.prisma:14[0m
         [1;94m   | [0m
         [1;94m13 | [0m    child  A?   @relation(name: "a_self_relation")
@@ -626,14 +626,14 @@ fn sql_server_default_setting_on_delete_self_relations() {
     "#};
 
     let expect = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes.[0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes. Caused by default `onDelete` and `onUpdate` values: `SetNull` and `Cascade`.[0m
           [1;94m-->[0m  [4mschema.prisma:13[0m
         [1;94m   | [0m
         [1;94m12 | [0m    id     Int  @id @default(autoincrement())
         [1;94m13 | [0m    [1;91mchild  A?   @relation(name: "a_self_relation")[0m
         [1;94m14 | [0m    parent A?   @relation(name: "a_self_relation", fields: [aId], references: [id], onDelete: SetDefault)
         [1;94m   | [0m
-        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes.[0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes. Caused by default `onUpdate` value: `Cascade`.[0m
           [1;94m-->[0m  [4mschema.prisma:14[0m
         [1;94m   | [0m
         [1;94m13 | [0m    child  A?   @relation(name: "a_self_relation")
@@ -668,14 +668,14 @@ fn sql_server_default_setting_on_update_self_relations() {
     "#};
 
     let expect = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes.[0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes. Caused by default `onDelete` and `onUpdate` values: `SetNull` and `Cascade`.[0m
           [1;94m-->[0m  [4mschema.prisma:13[0m
         [1;94m   | [0m
         [1;94m12 | [0m    id     Int  @id @default(autoincrement())
         [1;94m13 | [0m    [1;91mchild  A?   @relation(name: "a_self_relation")[0m
         [1;94m14 | [0m    parent A?   @relation(name: "a_self_relation", fields: [aId], references: [id], onUpdate: SetDefault)
         [1;94m   | [0m
-        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes.[0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes. Caused by default `onDelete` value: `SetNull`.[0m
           [1;94m-->[0m  [4mschema.prisma:14[0m
         [1;94m   | [0m
         [1;94m13 | [0m    child  A?   @relation(name: "a_self_relation")
@@ -717,7 +717,7 @@ fn sql_server_cascading_cyclic_one_hop_relations() {
     "#};
 
     let expect = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@relation": Reference causes a cycle or multiple cascade paths. One of the @relation attributes in this cycle must have `onDelete` and `onUpdate` referential actions set to `NoAction`.[0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": Reference causes a cycle or multiple cascade paths. One of the @relation attributes in this cycle must have `onDelete` and `onUpdate` referential actions set to `NoAction`. Caused by default `onUpdate` value: `Cascade`.[0m
           [1;94m-->[0m  [4mschema.prisma:13[0m
         [1;94m   | [0m
         [1;94m12 | [0m    id     Int  @id @default(autoincrement())
@@ -773,21 +773,21 @@ fn sql_server_cascading_cyclic_hop_over_table_relations() {
     "#};
 
     let expect = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@relation": Reference causes a cycle or multiple cascade paths. One of the @relation attributes in this cycle must have `onDelete` and `onUpdate` referential actions set to `NoAction`.[0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": Reference causes a cycle or multiple cascade paths. One of the @relation attributes in this cycle must have `onDelete` and `onUpdate` referential actions set to `NoAction`. Caused by default `onUpdate` value: `Cascade`.[0m
           [1;94m-->[0m  [4mschema.prisma:14[0m
         [1;94m   | [0m
         [1;94m13 | [0m    bId    Int
         [1;94m14 | [0m    [1;91mb      B    @relation(fields: [bId], references: [id])[0m
         [1;94m15 | [0m    cs     C[]
         [1;94m   | [0m
-        [1;91merror[0m: [1mError parsing attribute "@relation": Reference causes a cycle or multiple cascade paths. One of the @relation attributes in this cycle must have `onDelete` and `onUpdate` referential actions set to `NoAction`.[0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": Reference causes a cycle or multiple cascade paths. One of the @relation attributes in this cycle must have `onDelete` and `onUpdate` referential actions set to `NoAction`. Caused by default `onUpdate` value: `Cascade`.[0m
           [1;94m-->[0m  [4mschema.prisma:22[0m
         [1;94m   | [0m
         [1;94m21 | [0m    cId    Int
         [1;94m22 | [0m    [1;91mc      C    @relation(fields: [cId], references: [id])[0m
         [1;94m23 | [0m}
         [1;94m   | [0m
-        [1;91merror[0m: [1mError parsing attribute "@relation": Reference causes a cycle or multiple cascade paths. One of the @relation attributes in this cycle must have `onDelete` and `onUpdate` referential actions set to `NoAction`.[0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": Reference causes a cycle or multiple cascade paths. One of the @relation attributes in this cycle must have `onDelete` and `onUpdate` referential actions set to `NoAction`. Caused by default `onUpdate` value: `Cascade`.[0m
           [1;94m-->[0m  [4mschema.prisma:29[0m
         [1;94m   | [0m
         [1;94m28 | [0m    aId    Int
@@ -836,21 +836,21 @@ fn sql_server_cascading_cyclic_crossing_path_relations() {
     "#};
 
     let expect = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@relation": Reference causes a cycle or multiple cascade paths. One of the @relation attributes in this cycle must have `onDelete` and `onUpdate` referential actions set to `NoAction`.[0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": Reference causes a cycle or multiple cascade paths. One of the @relation attributes in this cycle must have `onDelete` and `onUpdate` referential actions set to `NoAction`. Caused by default `onUpdate` value: `Cascade`.[0m
           [1;94m-->[0m  [4mschema.prisma:14[0m
         [1;94m   | [0m
         [1;94m13 | [0m    bId    Int
         [1;94m14 | [0m    [1;91mb      B    @relation(fields: [bId], references: [id])[0m
         [1;94m15 | [0m    cs     C[]
         [1;94m   | [0m
-        [1;91merror[0m: [1mError parsing attribute "@relation": Reference causes a cycle or multiple cascade paths. One of the @relation attributes in this cycle must have `onDelete` and `onUpdate` referential actions set to `NoAction`.[0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": Reference causes a cycle or multiple cascade paths. One of the @relation attributes in this cycle must have `onDelete` and `onUpdate` referential actions set to `NoAction`. Caused by default `onUpdate` value: `Cascade`.[0m
           [1;94m-->[0m  [4mschema.prisma:28[0m
         [1;94m   | [0m
         [1;94m27 | [0m    bId    Int
         [1;94m28 | [0m    [1;91ma      A    @relation(fields: [aId], references: [id])[0m
         [1;94m29 | [0m    b      B    @relation(fields: [bId], references: [id])
         [1;94m   | [0m
-        [1;91merror[0m: [1mError parsing attribute "@relation": Reference causes a cycle or multiple cascade paths. One of the @relation attributes in this cycle must have `onDelete` and `onUpdate` referential actions set to `NoAction`.[0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": Reference causes a cycle or multiple cascade paths. One of the @relation attributes in this cycle must have `onDelete` and `onUpdate` referential actions set to `NoAction`. Caused by default `onUpdate` value: `Cascade`.[0m
           [1;94m-->[0m  [4mschema.prisma:29[0m
         [1;94m   | [0m
         [1;94m28 | [0m    a      A    @relation(fields: [aId], references: [id])


### PR DESCRIPTION
Implementing an early detection of cascading cycles, allowing us to highlight the relations and to give a better error than what SQL Server is giving us.

Examples what we get here.

## Self-relation

A self-relation is a cycle, and a special case of the feature. We give a different message in these cases, where the user can solve the problem by adding `onDelete: NoAction, onUpdate: NoAction` to one of the sides.

```prisma
model A {
  id     Int  @id @default(autoincrement())
  child  A?   @relation(name: "a_self_relation")
  parent A?   @relation(name: "a_self_relation", fields: [aId], references: [id], onUpdate: SetDefault)
  aId    Int?
}
```
![2021-08-02_13-08-1627905355](https://user-images.githubusercontent.com/34967/127858178-6714eaea-331d-47df-a584-15a7bbc27a63.png)

## Cycle between two tables

If we refer a table that has a relation back to the original table, one of the relations needs to have `onDelete: NoAction, onUpdate: NoAction` set to solve the issue.

```prisma
model A {
  id     Int  @id @default(autoincrement())
  b      B    @relation(name: "foo", fields: [bId], references: [id], onDelete: Cascade)
  bId    Int
  bs     B[]  @relation(name: "bar")
}

model B {
  id     Int @id @default(autoincrement())
  a      A   @relation(name: "bar", fields: [aId], references: [id], onUpdate: Cascade)
  as     A[] @relation(name: "foo")
  aId    Int
}
```
![2021-08-02_13-08-1627905449](https://user-images.githubusercontent.com/34967/127858327-314bc9fe-be05-485d-9c28-f5b81e8fc971.png)

## Hop over one table

A cycle where we go over one table, and then back to table `A`.

```prisma
model A {
  id     Int  @id @default(autoincrement())
  bId    Int
  b      B    @relation(fields: [bId], references: [id])
  cs     C[]
}

model B {
  id     Int  @id @default(autoincrement())
  as     A[]
  cId    Int
  c      C    @relation(fields: [cId], references: [id])
}

model C {
  id     Int @id @default(autoincrement())
  bs     B[]
  aId    Int
  a      A   @relation(fields: [aId], references: [id])
}
```
![2021-08-02_14-08-1627907565](https://user-images.githubusercontent.com/34967/127862496-46291efb-691a-426c-9ab1-0ddc576136af.png)

## Multiple separate paths between two tables

The referential actions can be in any side of the relation to matter. Here we have a link between `A` and `B`, `C` and `B`, `C` and `A`.

```prisma
model A {
  id     Int  @id @default(autoincrement())
  bId    Int
  b      B    @relation(fields: [bId], references: [id])
  cs     C[]
}

model B {
  id     Int  @id @default(autoincrement())
  as     A[]
  cs     C[]
}

model C {
  id     Int  @id @default(autoincrement())
  aId    Int
  bId    Int
  a      A    @relation(fields: [aId], references: [id])
  b      B    @relation(fields: [bId], references: [id])
}
```
![2021-08-02_14-08-1627907670](https://user-images.githubusercontent.com/34967/127862680-784e7d6a-1e18-47db-9bf4-c9b2445a0aeb.png)

## Implicit values in errors

If referential actions are not written to the relations, but they have an effect to the cycle errors, we write them to the error message.

Closes: https://github.com/prisma/prisma/issues/4580
Closes: https://github.com/prisma/prisma/issues/5782