### PR TITLE
Fixing m2m skips from cycle detection

### DIFF
--- a/libs/datamodel/core/src/transform/ast_to_dml/validate.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validate.rs
@@ -416,7 +416,7 @@ impl<'a> Validator<'a> {
 
             // skip many-to-many
             if field.is_list() && related_field.is_list() {
-                return;
+                continue;
             }
 
             // we skipped many-to-many relations, so one of the sides either has


### PR DESCRIPTION
In this case, if any of the models had a many to many field, we just stopped the cycle checks at that point, leading to a wrong error.