### PR TITLE
Foreign keys should not be created twice

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
@@ -121,6 +121,11 @@ impl<'schema> SqlSchemaDiffer<'schema> {
         for table in tables {
             // Foreign keys
             for created_fk in table.created_foreign_keys() {
+                // these are already created when we redefine the other table
+                if self.tables_to_redefine.contains(created_fk.referenced_table().name()) {
+                    continue;
+                }
+
                 steps.push(SqlMigrationStep::AddForeignKey {
                     table_id: created_fk.table().table_id(),
                     foreign_key_index: created_fk.foreign_key_index(),

--- a/migration-engine/migration-engine-tests/tests/migrations/foreign_keys.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/foreign_keys.rs
@@ -279,8 +279,7 @@ fn changing_a_foreign_key_constrained_column_from_nullable_to_required_and_back_
     api.schema_push(dm).send().assert_green_bang();
 }
 
-// TODO: Enable SQL Server when cascading rules are in PSL.
-#[test_connector(exclude(Mssql))]
+#[test_connector]
 fn changing_all_referenced_columns_of_foreign_key_works(api: TestApi) {
     let dm1 = r#"
        model Post {


### PR DESCRIPTION
In a case where we need to recreate a table, if the table has a foreign key we have to change, this change could be run twice, leading to an error.

The fix checks if the created foreign key references a table that was redefined earlier, and skips the creation if needed.

Closes: https://github.com/prisma/prisma/issues/8539