### PR TITLE
CI: Enable More SQL Server Tests

### DIFF
--- a/migration-engine/migration-engine-tests/tests/migrations/sql.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/sql.rs
@@ -132,15 +132,19 @@ fn relations_to_models_with_no_pk_and_a_single_unique_required_field_work(api: T
         });
 }
 
-// TODO: Enable SQL Server when cascading rules are in PSL.
-#[test_connector(exclude(Mssql))]
-fn reserved_sql_key_words_must_work(api: TestApi) {
+#[test_connector]
+fn reserved_sql_keywords_must_work(api: TestApi) {
     // Group is a reserved keyword
     let dm = r#"
+        generator js {
+           provider        = "prisma-client-js"
+           previewFeatures = ["referentialActions"]
+        }
+
         model Group {
             id          String  @id @default(cuid())
             parent_id   String?
-            parent      Group? @relation(name: "ChildGroups", fields: [parent_id], references: id)
+            parent      Group? @relation(name: "ChildGroups", fields: [parent_id], references: id, onDelete: NoAction, onUpdate: NoAction)
             childGroups Group[] @relation(name: "ChildGroups")
         }
     "#;
@@ -404,15 +408,20 @@ fn indexes_on_composite_relation_fields(api: TestApi) {
     });
 }
 
-#[test_connector(exclude(Mssql))]
+#[test_connector]
 fn dropping_mutually_referencing_tables_works(api: TestApi) {
     let dm1 = r#"
+    generator js {
+        provider        = "prisma-client-js"
+        previewFeatures = ["referentialActions"]
+    }
+
     model A {
         id Int @id
         b_id Int
-        ab B @relation("AtoB", fields: [b_id], references: [id])
+        ab B @relation("AtoB", fields: [b_id], references: [id], onUpdate: NoAction)
         c_id Int
-        ac C @relation("AtoC", fields: [c_id], references: [id])
+        ac C @relation("AtoC", fields: [c_id], references: [id], onUpdate: NoAction)
         b  B[] @relation("BtoA")
         c  C[] @relation("CtoA")
     }
@@ -420,7 +429,7 @@ fn dropping_mutually_referencing_tables_works(api: TestApi) {
     model B {
         id Int @id
         a_id Int
-        ba A @relation("BtoA", fields: [a_id], references: [id])
+        ba A @relation("BtoA", fields: [a_id], references: [id], onUpdate: NoAction)
         c_id Int
         bc C @relation("BtoC", fields: [c_id], references: [id])
         a  A[] @relation("AtoB")
@@ -430,9 +439,9 @@ fn dropping_mutually_referencing_tables_works(api: TestApi) {
     model C {
         id Int @id
         a_id Int
-        ca A @relation("CtoA", fields: [a_id], references: [id])
+        ca A @relation("CtoA", fields: [a_id], references: [id], onUpdate: NoAction)
         b_id Int
-        cb B @relation("CtoB", fields: [b_id], references: [id])
+        cb B @relation("CtoB", fields: [b_id], references: [id], onUpdate: NoAction)
         b  B[] @relation("BtoC")
         a  A[] @relation("AtoC")
     }

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/one2one_regression.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/one2one_regression.rs
@@ -1,7 +1,7 @@
 use indoc::indoc;
 use query_engine_tests::*;
 
-#[test_suite(schema(schema), exclude(SqlServer))]
+#[test_suite(schema(schema))]
 mod one2one_regression {
     fn schema() -> String {
         let schema = indoc! {
@@ -10,7 +10,7 @@ mod one2one_regression {
                 #id(id, Int, @id)
                 name     String?
                 friendOf User?   @relation("Userfriend")
-                friend   User?   @relation("Userfriend", fields: [friendId], references: [id])
+                friend   User?   @relation("Userfriend", fields: [friendId], references: [id], onDelete: NoAction, onUpdate: NoAction)
                 friendId Int?
             }
             "#

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/self_relation.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/self_relation.rs
@@ -1,7 +1,7 @@
 use indoc::indoc;
 use query_engine_tests::*;
 
-#[test_suite(schema(schema), exclude(SqlServer))]
+#[test_suite(schema(schema))]
 mod self_relation_filters {
     use query_engine_tests::assert_error;
 
@@ -18,11 +18,11 @@ mod self_relation_filters {
                 title_id   String?
 
                 husband       Human? @relation(name: "Marriage")
-                wife          Human? @relation(name: "Marriage",  fields: [wife_id],   references: [id])
-                mother        Human? @relation(name: "Cuckoo",    fields: [mother_id], references: [id])
-                father        Human? @relation(name: "Offspring", fields: [father_id], references: [id])
-                singer        Human? @relation(name: "Team",      fields: [singer_id], references: [id])
-                title         Song?  @relation(                   fields: [title_id],  references: [id])
+                wife          Human? @relation(name: "Marriage",  fields: [wife_id],   references: [id], onDelete: NoAction, onUpdate: NoAction)
+                mother        Human? @relation(name: "Cuckoo",    fields: [mother_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
+                father        Human? @relation(name: "Offspring", fields: [father_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
+                singer        Human? @relation(name: "Team",      fields: [singer_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
+                title         Song?  @relation(                   fields: [title_id],  references: [id], onDelete: NoAction, onUpdate: NoAction)
 
                 daughters     Human[] @relation(name: "Offspring")
                 stepdaughters Human[] @relation(name: "Cuckoo")
@@ -44,7 +44,7 @@ mod self_relation_filters {
     }
 
     // Filter Queries along self relations should succeed with one level.
-    #[connector_test]
+    #[connector_test(exclude(SqlServer))]
     async fn l1_query(runner: &Runner) -> TestResult<()> {
         test_data(runner).await?;
 
@@ -63,7 +63,7 @@ mod self_relation_filters {
     }
 
     // Filter Queries along self relations should succeed with two levels.
-    #[connector_test]
+    #[connector_test(exclude(SqlServer))]
     async fn l2_query(runner: &Runner) -> TestResult<()> {
         test_data(runner).await?;
 
@@ -86,7 +86,7 @@ mod self_relation_filters {
     }
 
     // Filter Queries along OneToOne self relations should succeed with two levels.
-    #[connector_test]
+    #[connector_test(exclude(SqlServer))]
     async fn l2_one2one(runner: &Runner) -> TestResult<()> {
         test_data(runner).await?;
 
@@ -107,7 +107,7 @@ mod self_relation_filters {
     }
 
     // Filter Queries along OneToOne self relations should succeed with null filter.
-    #[connector_test]
+    #[connector_test(exclude(SqlServer))]
     async fn one2one_null(runner: &Runner) -> TestResult<()> {
         test_data(runner).await?;
 
@@ -126,7 +126,7 @@ mod self_relation_filters {
     }
 
     // Filter Queries along OneToOne self relations should succeed with {} filter.
-    #[connector_test]
+    #[connector_test(exclude(SqlServer))]
     async fn one2one_empty(runner: &Runner) -> TestResult<()> {
         test_data(runner).await?;
 
@@ -145,7 +145,7 @@ mod self_relation_filters {
     }
 
     // Filter Queries along OneToMany self relations should fail with null filter.
-    #[connector_test]
+    #[connector_test(exclude(SqlServer))]
     async fn one2one_null_fail(runner: &Runner) -> TestResult<()> {
         test_data(runner).await?;
 
@@ -167,7 +167,7 @@ mod self_relation_filters {
     }
 
     // Filter Queries along OneToMany self relations should succeed with empty filter (`{}`).
-    #[connector_test]
+    #[connector_test(exclude(SqlServer))]
     async fn one2many_empty(runner: &Runner) -> TestResult<()> {
         test_data(runner).await?;
 
@@ -186,7 +186,7 @@ mod self_relation_filters {
     }
 
     // Filter Queries along ManyToMany self relations should succeed with valid filter `some`.
-    #[connector_test]
+    #[connector_test(exclude(SqlServer))]
     async fn many2many_some(runner: &Runner) -> TestResult<()> {
         test_data(runner).await?;
 
@@ -208,7 +208,7 @@ mod self_relation_filters {
     }
 
     // Filter Queries along ManyToMany self relations should succeed with valid filter `none`.
-    #[connector_test]
+    #[connector_test(exclude(SqlServer))]
     async fn many2many_none(runner: &Runner) -> TestResult<()> {
         test_data(runner).await?;
 
@@ -227,7 +227,7 @@ mod self_relation_filters {
     }
 
     // Filter Queries along ManyToMany self relations should succeed with valid filter `every`.
-    #[connector_test]
+    #[connector_test(exclude(SqlServer))]
     async fn many2many_every(runner: &Runner) -> TestResult<()> {
         test_data(runner).await?;
 
@@ -246,7 +246,7 @@ mod self_relation_filters {
     }
 
     // Filter Queries along ManyToMany self relations should give an error with null.
-    #[connector_test]
+    #[connector_test(exclude(SqlServer))]
     async fn many2many_null_error(runner: &Runner) -> TestResult<()> {
         test_data(runner).await?;
 
@@ -269,7 +269,7 @@ mod self_relation_filters {
     }
 
     // Filter Queries along ManyToMany self relations should succeed with {} filter `some`.
-    #[connector_test]
+    #[connector_test(exclude(SqlServer))]
     async fn many2many_empty_some(runner: &Runner) -> TestResult<()> {
         test_data(runner).await?;
 
@@ -288,7 +288,7 @@ mod self_relation_filters {
     }
 
     // Filter Queries along ManyToMany self relations should succeed with {} filter `none`.
-    #[connector_test]
+    #[connector_test(exclude(SqlServer))]
     async fn many2many_empty_none(runner: &Runner) -> TestResult<()> {
         test_data(runner).await?;
 
@@ -308,7 +308,7 @@ mod self_relation_filters {
     }
 
     // Filter Queries along ManyToMany self relations should succeed with {} filter `every`.
-    #[connector_test]
+    #[connector_test(exclude(SqlServer))]
     async fn many2many_empty_every(runner: &Runner) -> TestResult<()> {
         test_data(runner).await?;
 
@@ -328,7 +328,7 @@ mod self_relation_filters {
     }
 
     // Filter Queries along ManyToOne self relations should succeed valid filter.
-    #[connector_test]
+    #[connector_test(exclude(SqlServer))]
     async fn many2one(runner: &Runner) -> TestResult<()> {
         test_data(runner).await?;
 
@@ -347,7 +347,7 @@ mod self_relation_filters {
     }
 
     // Filter Queries along ManyToOne self relations should succeed with {} filter.
-    #[connector_test]
+    #[connector_test(exclude(SqlServer))]
     async fn many2one_empty_filter(runner: &Runner) -> TestResult<()> {
         test_data(runner).await?;
 
@@ -366,7 +366,7 @@ mod self_relation_filters {
     }
 
     // Filter Queries along ManyToOne self relations should succeed with null filter.
-    #[connector_test]
+    #[connector_test(exclude(SqlServer))]
     async fn many2one_null_filter(runner: &Runner) -> TestResult<()> {
         test_data(runner).await?;
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/self_relation_regression.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/self_relation_regression.rs
@@ -1,7 +1,7 @@
 use indoc::indoc;
 use query_engine_tests::*;
 
-#[test_suite(schema(schema), exclude(SqlServer))]
+#[test_suite(schema(schema))]
 mod sr_regression {
     fn schema() -> String {
         let schema = indoc! {
@@ -11,7 +11,7 @@ mod sr_regression {
                 name      String
                 parent_id String?
 
-                parent   Category? @relation(name: "C", fields: [parent_id], references: [id])
+                parent   Category? @relation(name: "C", fields: [parent_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
                 opposite Category? @relation(name: "C")
             }
             "#

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent.rs
@@ -10,7 +10,7 @@ mod order_by_dependent {
             r#"model ModelA {
               #id(id, Int, @id)
               b_id Int?
-              b    ModelB? @relation(fields: [b_id], references: [id])
+              b    ModelB? @relation(fields: [b_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
               c    ModelC?
             }
 
@@ -76,7 +76,7 @@ mod order_by_dependent {
     }
 
     // "[Hops: 1] Ordering by related record field ascending with nulls" should "work"
-    #[connector_test(exclude(SqlServer))]
+    #[connector_test]
     async fn hop_1_related_record_asc_nulls(runner: &Runner) -> TestResult<()> {
         create_row(runner, 1, Some(1), Some(1), None).await?;
         create_row(runner, 2, Some(2), None, None).await?;
@@ -140,7 +140,7 @@ mod order_by_dependent {
     }
 
     // "[Hops: 2] Ordering by related record field ascending with nulls" should "work"
-    #[connector_test(exclude(SqlServer))]
+    #[connector_test]
     async fn hop_2_related_record_asc_null(runner: &Runner) -> TestResult<()> {
         // 1 record has the "full chain", one half, one none
         create_row(runner, 1, Some(1), Some(1), None).await?;
@@ -171,7 +171,7 @@ mod order_by_dependent {
     }
 
     // "[Circular] Ordering by related record field ascending" should "work"
-    #[connector_test(exclude(SqlServer))]
+    #[connector_test]
     async fn circular_related_record_asc(runner: &Runner) -> TestResult<()> {
         // Records form circles with their relations
         create_row(runner, 1, Some(1), Some(1), Some(1)).await?;
@@ -197,7 +197,7 @@ mod order_by_dependent {
     }
 
     // "[Circular] Ordering by related record field descending" should "work"
-    #[connector_test(exclude(SqlServer))]
+    #[connector_test]
     async fn circular_related_record_desc(runner: &Runner) -> TestResult<()> {
         // Records form circles with their relations
         create_row(runner, 1, Some(1), Some(1), Some(1)).await?;
@@ -290,7 +290,7 @@ mod order_by_dependent {
           #id(id, Int, @id)
 
           b1_id Int?
-          b1    ModelB? @relation(fields: [b1_id], references: [id], name: "1")
+          b1    ModelB? @relation(fields: [b1_id], references: [id], name: "1", onDelete: NoAction, onUpdate: NoAction)
 
           b2_id Int?
           b2    ModelB? @relation(fields: [b2_id], references: [id], name: "2")
@@ -307,7 +307,7 @@ mod order_by_dependent {
         schema.to_string()
     }
 
-    #[connector_test(schema(multiple_rel_same_model), exclude(SqlServer, MongoDb))] // Mongo is excluded due to CI issues (version drift?).
+    #[connector_test(schema(multiple_rel_same_model), exclude(MongoDb))] // Mongo is excluded due to CI issues (version drift?).
     async fn multiple_rel_same_model_order_by(runner: &Runner) -> TestResult<()> {
         // test data
         run_query!(

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent_pagination.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent_pagination.rs
@@ -10,7 +10,7 @@ mod order_by_dependent_pag {
             r#"model ModelA {
               #id(id, Int, @id)
               b_id Int?
-              b    ModelB? @relation(fields: [b_id], references: [id])
+              b    ModelB? @relation(fields: [b_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
               c    ModelC?
             }
 
@@ -34,6 +34,7 @@ mod order_by_dependent_pag {
     }
 
     // "[Hops: 1] Ordering by related record field ascending" should "work"
+    // TODO(julius): should enable for SQL Server when partial indices are in the PSL
     #[connector_test(exclude(SqlServer))]
     async fn hop_1_related_record_asc(runner: &Runner) -> TestResult<()> {
         create_row(runner, 1, Some(2), Some(3), None).await?;
@@ -55,6 +56,7 @@ mod order_by_dependent_pag {
     }
 
     // "[Hops: 1] Ordering by related record field descending" should "work"
+    // TODO(julius): should enable for SQL Server when partial indices are in the PSL
     #[connector_test(exclude(SqlServer))]
     async fn hop_1_related_record_desc(runner: &Runner) -> TestResult<()> {
         create_row(runner, 1, Some(2), Some(3), None).await?;
@@ -79,7 +81,7 @@ mod order_by_dependent_pag {
     // TODO(dom): Not working on mongo
     // TODO(dom): Query result: {"data":{"findManyModelA":[{"id":1,"b":{"id":1}},{"id":2,"b":{"id":2}}]}}
     // TODO(dom): is not part of the expected results: ["{\"data\":{\"findManyModelA\":[{\"id\":3,\"b\":null},{\"id\":1,\"b\":{\"id\":1}},{\"id\":2,\"b\":{\"id\":2}}]}}", "{\"data\":{\"findManyModelA\":[{\"id\":1,\"b\":{\"id\":1}},{\"id\":2,\"b\":{\"id\":2}},{\"id\":3,\"b\":null}]}}"]
-    #[connector_test(exclude(SqlServer, MongoDb))]
+    #[connector_test(exclude(MongoDb))]
     async fn hop_1_related_record_asc_nulls(runner: &Runner) -> TestResult<()> {
         // 1 record has the "full chain", one half, one none
         create_row(runner, 1, Some(1), Some(1), None).await?;
@@ -107,6 +109,7 @@ mod order_by_dependent_pag {
     }
 
     // "[Hops: 2] Ordering by related record field ascending" should "work"
+    // TODO(julius): should enable for SQL Server when partial indices are in the PSL
     #[connector_test(exclude(SqlServer))]
     async fn hop_2_related_record_asc(runner: &Runner) -> TestResult<()> {
         create_row(runner, 1, Some(2), Some(3), None).await?;
@@ -126,6 +129,7 @@ mod order_by_dependent_pag {
     }
 
     // "[Hops: 2] Ordering by related record field descending" should "work"
+    // TODO(julius): should enable for SQL Server when partial indices are in the PSL
     #[connector_test(exclude(SqlServer))]
     async fn hop_2_related_record_desc(runner: &Runner) -> TestResult<()> {
         create_row(runner, 1, Some(2), Some(3), None).await?;
@@ -148,7 +152,7 @@ mod order_by_dependent_pag {
     // TODO(dom): Not working on mongo
     // TODO(dom): Query result: {"data":{"findManyModelA":[{"id":1,"b":{"c":{"id":1}}}]}}
     // TODO(dom): is not part of the expected results: ["{\"data\":{\"findManyModelA\":[{\"id\":2,\"b\":{\"c\":null}},{\"id\":3,\"b\":null},{\"id\":1,\"b\":{\"c\":{\"id\":1}}}]}}", "{\"data\":{\"findManyModelA\":[{\"id\":3,\"b\":null},{\"id\":2,\"b\":{\"c\":null}},{\"id\":1,\"b\":{\"c\":{\"id\":1}}}]}}", "{\"data\":{\"findManyModelA\":[{\"id\":1,\"b\":{\"c\":{\"id\":1}}},{\"id\":2,\"b\":{\"c\":null}},{\"id\":3,\"b\":null}]}}"]
-    #[connector_test(exclude(SqlServer, MongoDb))]
+    #[connector_test(exclude(MongoDb))]
     async fn hop_2_related_record_asc_null(runner: &Runner) -> TestResult<()> {
         // 1 record has the "full chain", one half, one none
         create_row(runner, 1, Some(1), Some(1), None).await?;
@@ -179,7 +183,7 @@ mod order_by_dependent_pag {
     }
 
     // "[Circular] Ordering by related record field ascending" should "work"
-    #[connector_test(exclude(SqlServer))]
+    #[connector_test]
     async fn circular_related_record_asc(runner: &Runner) -> TestResult<()> {
         // Records form circles with their relations
         create_row(runner, 1, Some(1), Some(1), Some(1)).await?;
@@ -205,7 +209,7 @@ mod order_by_dependent_pag {
     }
 
     // "[Circular] Ordering by related record field descending" should "work"
-    #[connector_test(exclude(SqlServer))]
+    #[connector_test]
     async fn circular_related_record_desc(runner: &Runner) -> TestResult<()> {
         // Records form circles with their relations
         create_row(runner, 1, Some(1), Some(1), Some(1)).await?;
@@ -234,6 +238,7 @@ mod order_by_dependent_pag {
     // TODO(dom): Not working on mongo
     // TODO(dom): Query result {"data":{"findManyModelA":[{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}}]}}
     // TODO(dom): is not part of the expected results: ["{\"data\":{\"findManyModelA\":[{\"id\":3,\"b\":null},{\"id\":4,\"b\":null},{\"id\":1,\"b\":{\"c\":{\"a\":{\"id\":3}}}},{\"id\":2,\"b\":{\"c\":{\"a\":{\"id\":4}}}}]}}", "{\"data\":{\"findManyModelA\":[{\"id\":1,\"b\":{\"c\":{\"a\":{\"id\":3}}}},{\"id\":2,\"b\":{\"c\":{\"a\":{\"id\":4}}}},{\"id\":3,\"b\":null},{\"id\":4,\"b\":null}]}}"]
+    // TODO(julius): should enable for SQL Server when partial indices are in the PSL
     #[connector_test(exclude(SqlServer, MySql, MongoDb))]
     async fn circular_diff_related_record_asc(runner: &Runner) -> TestResult<()> {
         // Records form circles with their relations
@@ -265,6 +270,7 @@ mod order_by_dependent_pag {
     }
 
     // "[Circular with differing records] Ordering by related record field descending" should "work"
+    // TODO(julius): should enable for SQL Server when partial indices are in the PSL
     #[connector_test(exclude(SqlServer, MySql))]
     async fn circular_diff_related_record_desc(runner: &Runner) -> TestResult<()> {
         // Records form circles with their relations
@@ -301,7 +307,7 @@ mod order_by_dependent_pag {
           #id(id, Int, @id)
 
           b1_id Int?
-          b1    ModelB? @relation(fields: [b1_id], references: [id], name: "1")
+          b1    ModelB? @relation(fields: [b1_id], references: [id], name: "1", onDelete: NoAction, onUpdate: NoAction)
 
           b2_id Int?
           b2    ModelB? @relation(fields: [b2_id], references: [id], name: "2")
@@ -318,7 +324,7 @@ mod order_by_dependent_pag {
         schema.to_string()
     }
 
-    #[connector_test(schema(multiple_rel_same_model), exclude(SqlServer, MongoDb))] // Mongo is excluded due to CI issues (version drift?).
+    #[connector_test(schema(multiple_rel_same_model), exclude(MongoDb))] // Mongo is excluded due to CI issues (version drift?).
     async fn multiple_rel_same_model_order_by(runner: &Runner) -> TestResult<()> {
         // test data
         run_query!(

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/regressions/prisma_3078.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/regressions/prisma_3078.rs
@@ -12,8 +12,7 @@ use query_engine_tests::*;
 // /!\ rel_filter_1_m_a and rel_filter_1_m_z must always expect the same results
 // /!\ rel_filter_n_m_a and rel_filter_n_m_z must always expect the same results
 
-// TODO: Bring back SqlServer when cascading rules can be set!
-#[test_suite(exclude(SqlServer))]
+#[test_suite]
 mod prisma_3078 {
     use indoc::indoc;
     use query_engine_tests::run_query;
@@ -24,7 +23,7 @@ mod prisma_3078 {
               #id(id, Int, @id)
               name       String?
               field_b    User?    @relation("UserfriendOf")
-              field_a    User?    @relation("UserfriendOf", fields: [field_aId], references: [id])
+              field_a    User?    @relation("UserfriendOf", fields: [field_aId], references: [id], onDelete: NoAction, onUpdate: NoAction)
               field_aId  Int?
             }"#
         };
@@ -38,7 +37,7 @@ mod prisma_3078 {
             #id(id, Int, @id)
             name       String?
             field_b    User?    @relation("UserfriendOf")
-            field_z    User?    @relation("UserfriendOf", fields: [field_zId], references: [id])
+            field_z    User?    @relation("UserfriendOf", fields: [field_zId], references: [id], onDelete: NoAction, onUpdate: NoAction)
             field_zId  Int?
           }"#
         };
@@ -52,7 +51,7 @@ mod prisma_3078 {
               #id(id, Int, @id)
               name      String?
               field_b   User[]  @relation("UserfriendOf")
-              field_a   User?   @relation("UserfriendOf", fields: [field_aId], references: [id])
+              field_a   User?   @relation("UserfriendOf", fields: [field_aId], references: [id], onDelete: NoAction, onUpdate: NoAction)
               field_aId Int?
             }"#
         };
@@ -66,7 +65,7 @@ mod prisma_3078 {
             #id(id, Int, @id)
             name      String?
             field_b   User[]  @relation("UserfriendOf")
-            field_z   User?   @relation("UserfriendOf", fields: [field_zId], references: [id])
+            field_z   User?   @relation("UserfriendOf", fields: [field_zId], references: [id], onDelete: NoAction, onUpdate: NoAction)
             field_zId Int?
           }"#
         };
@@ -107,7 +106,7 @@ mod prisma_3078 {
     }
 
     // "A relation filter on a 1:1 self relation " should "work" (with field_a)
-    #[connector_test(schema(rel_filter_1_1_a))]
+    #[connector_test(schema(rel_filter_1_1_a), exclude(SqlServer))]
     async fn relation_filter_1_1_a(runner: &Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(runner, r#"mutation{createOneUser(data: { id: 1, name: "A", field_a:{ create:{ id: 10, name: "AA"}}}){
@@ -153,7 +152,7 @@ mod prisma_3078 {
     }
 
     // "A relation filter on a 1:1 self relation " should "work" (with field_z)
-    #[connector_test(schema(rel_filter_1_1_z))]
+    #[connector_test(schema(rel_filter_1_1_z), exclude(SqlServer))]
     async fn relation_filter_1_1_z(runner: &Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(runner, r#"mutation{createOneUser(data: { id: 1, name: "A", field_z:{ create:{ id: 10, name: "AA"}}}){

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/filters/update_many_rel_filter.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/filters/update_many_rel_filter.rs
@@ -35,7 +35,7 @@ mod update_many_rel_filter {
     }
 
     // "The updateMany Mutation" should "update the items matching the where relation filter"
-    #[connector_test(exclude(SqlServer))]
+    #[connector_test]
     async fn update_items_matching_where_rel_filter(runner: &Runner) -> TestResult<()> {
         create_row(runner, r#"{ id: 1, top: "top1"}"#).await?;
         create_row(runner, r#"{ id: 2, top: "top2"}"#).await?;
@@ -105,7 +105,7 @@ mod update_many_rel_filter {
     }
 
     // "The updateMany Mutation" should "work for deeply nested filters"
-    #[connector_test(exclude(SqlServer))]
+    #[connector_test]
     async fn works_with_deeply_nested_filters(runner: &Runner) -> TestResult<()> {
         create_row(runner, r#"{ id: 1, top: "top1"}"#).await?;
         create_row(runner, r#"{ id: 2, top: "top2"}"#).await?;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/relations/same_model_self_rel_without_back_rel.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/relations/same_model_self_rel_without_back_rel.rs
@@ -1,6 +1,6 @@
 use query_engine_tests::*;
 
-#[test_suite(schema(schema), exclude(SqlServer))]
+#[test_suite(schema(schema))]
 mod self_rel_no_back_rel {
     use indoc::indoc;
     use query_engine_tests::run_query;
@@ -64,7 +64,7 @@ mod self_rel_no_back_rel {
               identifier Int?    @unique
               relatedId  String?
 
-              related    Post?  @relation(name: "RelatedPosts", fields:[relatedId], references: [id])
+              related    Post?  @relation(name: "RelatedPosts", fields:[relatedId], references: [id], onDelete: NoAction, onUpdate: NoAction)
               parents    Post[] @relation(name: "RelatedPosts")
             }"#
         };


### PR DESCRIPTION
The remaining tests are mainly optional relations, where we can for now only have one null per column. We can enable those when we have the `allowNullValues: true` in the foreign keys/indices.

Closes: https://github.com/prisma/prisma/issues/8544