### PR TITLE
feat: support full-text search on Postgres

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3215,7 +3215,7 @@ dependencies = [
 [[package]]
 name = "quaint"
 version = "0.2.0-alpha.13"
-source = "git+https://github.com/prisma/quaint#4558687180140b610b78e66c57e2fbd7c8ea0e7f"
+source = "git+https://github.com/prisma/quaint#832dc4ae5ca8b1d82c81c20ce49625ef685774e7"
 dependencies = [
  "async-trait",
  "base64 0.12.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3215,7 +3215,7 @@ dependencies = [
 [[package]]
 name = "quaint"
 version = "0.2.0-alpha.13"
-source = "git+https://github.com/prisma/quaint#832dc4ae5ca8b1d82c81c20ce49625ef685774e7"
+source = "git+https://github.com/prisma/quaint#d23b824b70baa552e69eb954280664bee2082f29"
 dependencies = [
  "async-trait",
  "base64 0.12.3",

--- a/libs/datamodel/connectors/datamodel-connector/src/lib.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/lib.rs
@@ -254,6 +254,7 @@ capabilities!(
     CompoundIds,
     AnyId, // Any (or combination of) uniques and not only id fields can constitute an id for a model.
     QueryRaw,
+    FullTextSearchWithoutIndex
 );
 
 /// Contains all capabilities that the connector is able to serve.

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
@@ -75,6 +75,7 @@ impl PostgresDatamodelConnector {
             ConnectorCapability::NamedPrimaryKeys,
             ConnectorCapability::NamedForeignKeys,
             ConnectorCapability::ForeignKeys,
+            ConnectorCapability::FullTextSearchWithoutIndex,
         ];
 
         let small_int = NativeTypeConstructor::without_args(SMALL_INT_TYPE_NAME, vec![ScalarType::Int]);

--- a/libs/datamodel/core/src/common/preview_features.rs
+++ b/libs/datamodel/core/src/common/preview_features.rs
@@ -58,6 +58,7 @@ features!(
     ReferentialActions,
     InteractiveTransactions,
     NamedConstraints,
+    FullTextSearch
 );
 
 // Mapping of which active, deprecated and hidden
@@ -78,6 +79,7 @@ pub static GENERATOR: Lazy<FeatureMap> = Lazy::new(|| {
             MongoDb,
             InteractiveTransactions,
             NamedConstraints,
+            FullTextSearch,
         ])
         .with_deprecated(vec![
             AtomicNumberOperations,

--- a/libs/prisma-value/src/lib.rs
+++ b/libs/prisma-value/src/lib.rs
@@ -320,3 +320,14 @@ impl TryFrom<PrismaValue> for i64 {
         }
     }
 }
+
+impl TryFrom<PrismaValue> for String {
+    type Error = ConversionFailure;
+
+    fn try_from(pv: PrismaValue) -> PrismaValueResult<String> {
+        match pv {
+            PrismaValue::String(s) => Ok(s),
+            _ => Err(ConversionFailure::new("PrismaValue", "String")),
+        }
+    }
+}

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/mod.rs
@@ -16,6 +16,7 @@ pub mod one2one_regression;
 pub mod one_relation;
 pub mod ported_filters;
 pub mod relation_null;
+pub mod search_filter;
 pub mod self_relation;
 pub mod self_relation_regression;
 pub mod where_unique;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/search_filter.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/search_filter.rs
@@ -1,0 +1,123 @@
+use query_engine_tests::*;
+
+#[test_suite(schema(schema), capabilities(FullTextSearchWithoutIndex))]
+mod search_filter {
+    use indoc::indoc;
+    use query_engine_tests::run_query;
+
+    fn schema() -> String {
+        let schema = indoc! {
+            r#"model TestModel {
+              #id(id, Int, @id)
+              fieldA  String
+              fieldB  String
+              fieldC  String?
+            }"#
+        };
+
+        schema.to_owned()
+    }
+
+    #[connector_test]
+    async fn search_single_field(runner: &Runner) -> TestResult<()> {
+        create_test_data(runner).await?;
+
+        insta::assert_snapshot!(
+          run_query!(runner, r#"query { findManyTestModel(where: { fieldA: { search: "Chicken" } }) { fieldA } }"#),
+          @r###"{"data":{"findManyTestModel":[{"fieldA":"Chicken Masala"},{"fieldA":"Chicken Curry"}]}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn search_many_fields(runner: &Runner) -> TestResult<()> {
+        create_test_data(runner).await?;
+
+        insta::assert_snapshot!(
+          run_query!(runner, r#"query { findManyTestModel(where: {
+                  fieldA: { search: "Chicken" }
+                  fieldB: { search: "Chicken" }
+              }) { fieldA, fieldB }}
+        "#),
+          @r###"{"data":{"findManyTestModel":[{"fieldA":"Chicken Masala","fieldB":"Chicken, Rice, Masala Sauce"},{"fieldA":"Chicken Curry","fieldB":"Chicken, Curry"},{"fieldA":"Caesar Salad","fieldB":"Salad, Chicken, Caesar Sauce"}]}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn search_nullable_field(runner: &Runner) -> TestResult<()> {
+        create_test_data(runner).await?;
+
+        insta::assert_snapshot!(
+          run_query!(runner, r#"query { findManyTestModel(where: {
+                    fieldA: { search: "Chicken" }
+                    fieldC: { search: "Chicken" }
+                }) { fieldA, fieldC }}
+          "#),
+          @r###"{"data":{"findManyTestModel":[{"fieldA":"Caesar Salad","fieldC":"Chicken"}]}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn search_with_other_filters(runner: &Runner) -> TestResult<()> {
+        create_test_data(runner).await?;
+
+        insta::assert_snapshot!(
+          run_query!(runner, r#"query { findManyTestModel(where: {
+                    fieldA: { search: "Chicken", startsWith: "Chicken" },
+                    fieldB: { search: "Chicken" },
+                    id: { equals: 1 }
+                }) { fieldA, fieldB, fieldC }}
+          "#),
+          @r###"{"data":{"findManyTestModel":[{"fieldA":"Chicken Masala","fieldB":"Chicken, Rice, Masala Sauce","fieldC":null}]}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn ensure_filter_tree_shake_works(runner: &Runner) -> TestResult<()> {
+        create_test_data(runner).await?;
+
+        insta::assert_snapshot!(
+          run_query!(runner, r#"query { findManyTestModel(where: {
+                    AND: [
+                        { fieldA: { search: "Chicken", startsWith: "Chicken" } },
+                        { OR: [{ fieldB: { search: "Chicken" } }, { id: { equals: 3 } }] }
+                    ]
+                }) { id, fieldA, fieldB, fieldC }}
+          "#),
+          @r###"{"data":{"findManyTestModel":[{"id":1,"fieldA":"Chicken Masala","fieldB":"Chicken, Rice, Masala Sauce","fieldC":null},{"id":2,"fieldA":"Chicken Curry","fieldB":"Chicken, Curry","fieldC":null}]}}"###
+        );
+
+        Ok(())
+    }
+
+    async fn create_test_data(runner: &Runner) -> TestResult<()> {
+        create_row(
+            runner,
+            r#"{ id: 1, fieldA: "Chicken Masala", fieldB: "Chicken, Rice, Masala Sauce"}"#,
+        )
+        .await?;
+        create_row(runner, r#"{ id: 2, fieldA: "Chicken Curry", fieldB: "Chicken, Curry"}"#).await?;
+        create_row(
+            runner,
+            r#"{ id: 3, fieldA: "Caesar Salad", fieldB: "Salad, Chicken, Caesar Sauce", fieldC: "Chicken"}"#,
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    async fn create_row(runner: &Runner, data: &str) -> TestResult<()> {
+        runner
+            .query(format!("mutation {{ createOneTestModel(data: {}) {{ id }} }}", data))
+            .await?
+            .assert_success();
+        Ok(())
+    }
+}

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/search_filter.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/search_filter.rs
@@ -19,11 +19,11 @@ mod search_filter {
     }
 
     #[connector_test]
-    async fn search_single_field(runner: &Runner) -> TestResult<()> {
-        create_test_data(runner).await?;
+    async fn search_single_field(runner: Runner) -> TestResult<()> {
+        create_test_data(&runner).await?;
 
         insta::assert_snapshot!(
-          run_query!(runner, r#"query { findManyTestModel(where: { fieldA: { search: "Chicken" } }) { fieldA } }"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { fieldA: { search: "Chicken" } }) { fieldA } }"#),
           @r###"{"data":{"findManyTestModel":[{"fieldA":"Chicken Masala"},{"fieldA":"Chicken Curry"}]}}"###
         );
 
@@ -31,11 +31,11 @@ mod search_filter {
     }
 
     #[connector_test]
-    async fn search_many_fields(runner: &Runner) -> TestResult<()> {
-        create_test_data(runner).await?;
+    async fn search_many_fields(runner: Runner) -> TestResult<()> {
+        create_test_data(&runner).await?;
 
         insta::assert_snapshot!(
-          run_query!(runner, r#"query { findManyTestModel(where: {
+          run_query!(&runner, r#"query { findManyTestModel(where: {
                   fieldA: { search: "Chicken" }
                   fieldB: { search: "Chicken" }
               }) { fieldA, fieldB }}
@@ -47,11 +47,11 @@ mod search_filter {
     }
 
     #[connector_test]
-    async fn search_nullable_field(runner: &Runner) -> TestResult<()> {
-        create_test_data(runner).await?;
+    async fn search_nullable_field(runner: Runner) -> TestResult<()> {
+        create_test_data(&runner).await?;
 
         insta::assert_snapshot!(
-          run_query!(runner, r#"query { findManyTestModel(where: {
+          run_query!(&runner, r#"query { findManyTestModel(where: {
                     fieldA: { search: "Chicken" }
                     fieldC: { search: "Chicken" }
                 }) { fieldA, fieldC }}
@@ -63,11 +63,11 @@ mod search_filter {
     }
 
     #[connector_test]
-    async fn search_with_other_filters(runner: &Runner) -> TestResult<()> {
-        create_test_data(runner).await?;
+    async fn search_with_other_filters(runner: Runner) -> TestResult<()> {
+        create_test_data(&runner).await?;
 
         insta::assert_snapshot!(
-          run_query!(runner, r#"query { findManyTestModel(where: {
+          run_query!(&runner, r#"query { findManyTestModel(where: {
                     fieldA: { search: "Chicken", startsWith: "Chicken" },
                     fieldB: { search: "Chicken" },
                     id: { equals: 1 }
@@ -80,11 +80,11 @@ mod search_filter {
     }
 
     #[connector_test]
-    async fn ensure_filter_tree_shake_works(runner: &Runner) -> TestResult<()> {
-        create_test_data(runner).await?;
+    async fn ensure_filter_tree_shake_works(runner: Runner) -> TestResult<()> {
+        create_test_data(&runner).await?;
 
         insta::assert_snapshot!(
-          run_query!(runner, r#"query { findManyTestModel(where: {
+          run_query!(&runner, r#"query { findManyTestModel(where: {
                     AND: [
                         { fieldA: { search: "Chicken", startsWith: "Chicken" } },
                         { OR: [{ fieldB: { search: "Chicken" } }, { id: { equals: 3 } }] }

--- a/query-engine/connectors/mongodb-query-connector/src/filter.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/filter.rs
@@ -199,6 +199,8 @@ fn default_scalar_filter(field: &ScalarFieldRef, condition: ScalarCondition) -> 
             }
             _ => unimplemented!("Only equality JSON filtering is supported on MongoDB."),
         },
+        ScalarCondition::Search(_, _) => unimplemented!("Full-text search is not supported yet on MongoDB"),
+        ScalarCondition::NotSearch(_, _) => unimplemented!("Full-text search is not supported yet on MongoDB"),
     })
 }
 
@@ -242,6 +244,8 @@ fn insensitive_scalar_filter(field: &ScalarFieldRef, condition: ScalarCondition)
             doc! { "$nin": to_regex_list(field, "^", vals, "$", true)? }
         }
         ScalarCondition::JsonCompare(_) => unimplemented!("JSON filtering is not yet supported on MongoDB"),
+        ScalarCondition::Search(_, _) => todo!(),
+        ScalarCondition::NotSearch(_, _) => todo!(),
     })
 }
 

--- a/query-engine/connectors/mongodb-query-connector/src/filter.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/filter.rs
@@ -244,8 +244,8 @@ fn insensitive_scalar_filter(field: &ScalarFieldRef, condition: ScalarCondition)
             doc! { "$nin": to_regex_list(field, "^", vals, "$", true)? }
         }
         ScalarCondition::JsonCompare(_) => unimplemented!("JSON filtering is not yet supported on MongoDB"),
-        ScalarCondition::Search(_, _) => todo!(),
-        ScalarCondition::NotSearch(_, _) => todo!(),
+        ScalarCondition::Search(_, _) => unimplemented!("Full-text search is not supported yet on MongoDB"),
+        ScalarCondition::NotSearch(_, _) => unimplemented!("Full-text search is not supported yet on MongoDB"),
     })
 }
 

--- a/query-engine/connectors/mongodb-query-connector/src/filter.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/filter.rs
@@ -1,4 +1,4 @@
-use crate::{join::JoinStage, IntoBson};
+use crate::{error::MongoError, join::JoinStage, IntoBson};
 use connector_interface::{
     AggregationFilter, Filter, OneRelationIsNullFilter, QueryMode, RelationCondition, RelationFilter, ScalarCompare,
     ScalarCondition, ScalarFilter, ScalarListFilter, ScalarProjection,
@@ -206,22 +206,20 @@ fn default_scalar_filter(field: &ScalarFieldRef, condition: ScalarCondition) -> 
 
 /// Insensitive filters are only reachable with TypeIdentifier::String (or UUID, which is string as well for us).
 fn insensitive_scalar_filter(field: &ScalarFieldRef, condition: ScalarCondition) -> crate::Result<Document> {
-    Ok(match condition {
-        ScalarCondition::Equals(val) => doc! { "$regex": to_regex(field, "^", val, "$", true)? },
-        ScalarCondition::NotEquals(val) => {
-            doc! { "$not": { "$regex": to_regex(field, "^", val, "$", true)? }}
-        }
+    match condition {
+        ScalarCondition::Equals(val) => Ok(doc! { "$regex": to_regex(field, "^", val, "$", true)? }),
+        ScalarCondition::NotEquals(val) => Ok(doc! { "$not": { "$regex": to_regex(field, "^", val, "$", true)? }}),
 
-        ScalarCondition::Contains(val) => doc! { "$regex": to_regex(field, ".*", val, ".*", true)? },
-        ScalarCondition::NotContains(val) => doc! { "$not": { "$regex": to_regex(field, ".*", val, ".*", true)? }},
-        ScalarCondition::StartsWith(val) => doc! { "$regex": to_regex(field, "^", val, "", true)?  },
-        ScalarCondition::NotStartsWith(val) => doc! { "$not": { "$regex": to_regex(field, "^", val, "", true)? }},
-        ScalarCondition::EndsWith(val) => doc! { "$regex": to_regex(field, "", val, "$", true)? },
-        ScalarCondition::NotEndsWith(val) => doc! { "$not": { "$regex": to_regex(field, "", val, "$", true)? }},
-        ScalarCondition::LessThan(val) => doc! { "$lt": (field, val).into_bson()? },
-        ScalarCondition::LessThanOrEquals(val) => doc! { "$lte": (field, val).into_bson()? },
-        ScalarCondition::GreaterThan(val) => doc! { "$gt": (field, val).into_bson()? },
-        ScalarCondition::GreaterThanOrEquals(val) => doc! { "$gte": (field, val).into_bson()? },
+        ScalarCondition::Contains(val) => Ok(doc! { "$regex": to_regex(field, ".*", val, ".*", true)? }),
+        ScalarCondition::NotContains(val) => Ok(doc! { "$not": { "$regex": to_regex(field, ".*", val, ".*", true)? }}),
+        ScalarCondition::StartsWith(val) => Ok(doc! { "$regex": to_regex(field, "^", val, "", true)?  }),
+        ScalarCondition::NotStartsWith(val) => Ok(doc! { "$not": { "$regex": to_regex(field, "^", val, "", true)? }}),
+        ScalarCondition::EndsWith(val) => Ok(doc! { "$regex": to_regex(field, "", val, "$", true)? }),
+        ScalarCondition::NotEndsWith(val) => Ok(doc! { "$not": { "$regex": to_regex(field, "", val, "$", true)? }}),
+        ScalarCondition::LessThan(val) => Ok(doc! { "$lt": (field, val).into_bson()? }),
+        ScalarCondition::LessThanOrEquals(val) => Ok(doc! { "$lte": (field, val).into_bson()? }),
+        ScalarCondition::GreaterThan(val) => Ok(doc! { "$gt": (field, val).into_bson()? }),
+        ScalarCondition::GreaterThanOrEquals(val) => Ok(doc! { "$gte": (field, val).into_bson()? }),
         // Todo: The nested list unpack looks like a bug somewhere.
         //       Likely join code mistakenly repacks a list into a list of PrismaValue somewhere in the core.
         ScalarCondition::In(vals) => match vals.split_first() {
@@ -235,18 +233,19 @@ fn insensitive_scalar_filter(field: &ScalarFieldRef, condition: ScalarCondition)
                     }
                 }
 
-                doc! { "$in": bson_values }
+                Ok(doc! { "$in": bson_values })
             }
 
-            _ => doc! { "$in": to_regex_list(field, "^", vals, "$", true)? },
+            _ => Ok(doc! { "$in": to_regex_list(field, "^", vals, "$", true)? }),
         },
-        ScalarCondition::NotIn(vals) => {
-            doc! { "$nin": to_regex_list(field, "^", vals, "$", true)? }
-        }
-        ScalarCondition::JsonCompare(_) => unimplemented!("JSON filtering is not yet supported on MongoDB"),
-        ScalarCondition::Search(_, _) => unimplemented!("Full-text search is not supported yet on MongoDB"),
-        ScalarCondition::NotSearch(_, _) => unimplemented!("Full-text search is not supported yet on MongoDB"),
-    })
+        ScalarCondition::NotIn(vals) => Ok(doc! { "$nin": to_regex_list(field, "^", vals, "$", true)? }),
+        ScalarCondition::JsonCompare(_) => Err(MongoError::Unsupported(
+            "JSON filtering is not yet supported on MongoDB".to_string(),
+        )),
+        ScalarCondition::Search(_, _) | ScalarCondition::NotSearch(_, _) => Err(MongoError::Unsupported(
+            "Full-text search is not supported yet on MongoDB".to_string(),
+        )),
+    }
 }
 
 /// Filters available on list fields.

--- a/query-engine/connectors/query-connector/src/compare.rs
+++ b/query-engine/connectors/query-connector/src/compare.rs
@@ -58,6 +58,12 @@ pub trait ScalarCompare {
     fn greater_than_or_equals<T>(&self, val: T) -> Filter
     where
         T: Into<PrismaValue>;
+    fn search<T>(&self, val: T) -> Filter
+    where
+        T: Into<PrismaValue>;
+    fn not_search<T>(&self, val: T) -> Filter
+    where
+        T: Into<PrismaValue>;
 }
 
 /// Comparison methods for relational fields.

--- a/query-engine/connectors/query-connector/src/compare.rs
+++ b/query-engine/connectors/query-connector/src/compare.rs
@@ -58,9 +58,11 @@ pub trait ScalarCompare {
     fn greater_than_or_equals<T>(&self, val: T) -> Filter
     where
         T: Into<PrismaValue>;
+
     fn search<T>(&self, val: T) -> Filter
     where
         T: Into<PrismaValue>;
+
     fn not_search<T>(&self, val: T) -> Filter
     where
         T: Into<PrismaValue>;

--- a/query-engine/connectors/query-connector/src/filter/scalar.rs
+++ b/query-engine/connectors/query-connector/src/filter/scalar.rs
@@ -367,7 +367,7 @@ impl ScalarCompare for ScalarFieldRef {
     {
         Filter::from(ScalarFilter {
             projection: ScalarProjection::Single(Arc::clone(self)),
-            condition: ScalarCondition::Search(val.into(), vec![]),
+            condition: ScalarCondition::NotSearch(val.into(), vec![]),
             mode: QueryMode::Default,
         })
     }
@@ -559,7 +559,7 @@ impl ScalarCompare for ModelProjection {
     {
         Filter::from(ScalarFilter {
             projection: ScalarProjection::Compound(self.scalar_fields().collect()),
-            condition: ScalarCondition::Search(val.into(), vec![]),
+            condition: ScalarCondition::NotSearch(val.into(), vec![]),
             mode: QueryMode::Default,
         })
     }

--- a/query-engine/connectors/sql-query-connector/src/filter_conversion.rs
+++ b/query-engine/connectors/sql-query-connector/src/filter_conversion.rs
@@ -136,31 +136,63 @@ impl AliasedCondition for Filter {
 impl AliasedCondition for ScalarFilter {
     /// Conversion from a `ScalarFilter` to a query condition tree. Aliased when in a nested `SELECT`.
     fn aliased_cond(self, alias: Option<Alias>) -> ConditionTree<'static> {
-        match (alias, self.projection) {
-            (Some(alias), ScalarProjection::Single(field)) => {
-                let comparable: Expression = field.as_column().table(alias.to_string(None)).into();
-
-                convert_scalar_filter(comparable, self.condition, self.mode, &[field], false)
+        match self.condition {
+            ScalarCondition::Search(_, _) | ScalarCondition::NotSearch(_, _) => {
+                scalar_filter_aliased_cond_search(self, alias)
             }
-            (Some(alias), ScalarProjection::Compound(fields)) => {
-                let columns: Vec<Column<'static>> = fields
-                    .clone()
-                    .into_iter()
-                    .map(|field| field.as_column().table(alias.to_string(None)))
-                    .collect();
+            _ => scalar_filter_aliased_cond(self, alias),
+        }
+    }
+}
 
-                convert_scalar_filter(Row::from(columns).into(), self.condition, self.mode, &fields, false)
-            }
-            (None, ScalarProjection::Single(field)) => {
-                let comparable: Expression = field.as_column().into();
+fn scalar_filter_aliased_cond_search(sf: ScalarFilter, alias: Option<Alias>) -> ConditionTree<'static> {
+    let mut projections = match sf.condition.clone() {
+        ScalarCondition::Search(_, proj) => proj,
+        ScalarCondition::NotSearch(_, proj) => proj,
+        _ => unreachable!(),
+    };
 
-                convert_scalar_filter(comparable, self.condition, self.mode, &[field], false)
-            }
-            (None, ScalarProjection::Compound(fields)) => {
-                let columns: Vec<Column<'static>> = fields.clone().into_iter().map(|field| field.as_column()).collect();
+    projections.push(sf.projection);
 
-                convert_scalar_filter(Row::from(columns).into(), self.condition, self.mode, &fields, false)
-            }
+    let columns: Vec<Column> = projections
+        .into_iter()
+        .map(|p| match (p, alias) {
+            (ScalarProjection::Single(field), None) => field.as_column(),
+            (ScalarProjection::Single(field), Some(alias)) => field.as_column().table(alias.to_string(None)).into(),
+            (ScalarProjection::Compound(_), _) => unreachable!("Full-text search does not support compound fields"),
+        })
+        .collect();
+
+    let comparable: Expression = text_search(columns.as_slice()).into();
+
+    convert_scalar_filter(comparable, sf.condition, sf.mode, &[], false)
+}
+
+fn scalar_filter_aliased_cond(sf: ScalarFilter, alias: Option<Alias>) -> ConditionTree<'static> {
+    match (alias, sf.projection) {
+        (Some(alias), ScalarProjection::Single(field)) => {
+            let comparable: Expression = field.as_column().table(alias.to_string(None)).into();
+
+            convert_scalar_filter(comparable, sf.condition, sf.mode, &[field], false)
+        }
+        (Some(alias), ScalarProjection::Compound(fields)) => {
+            let columns: Vec<Column<'static>> = fields
+                .clone()
+                .into_iter()
+                .map(|field| field.as_column().table(alias.to_string(None)))
+                .collect();
+
+            convert_scalar_filter(Row::from(columns).into(), sf.condition, sf.mode, &fields, false)
+        }
+        (None, ScalarProjection::Single(field)) => {
+            let comparable: Expression = field.as_column().into();
+
+            convert_scalar_filter(comparable, sf.condition, sf.mode, &[field], false)
+        }
+        (None, ScalarProjection::Compound(fields)) => {
+            let columns: Vec<Column<'static>> = fields.clone().into_iter().map(|field| field.as_column()).collect();
+
+            convert_scalar_filter(Row::from(columns).into(), sf.condition, sf.mode, &fields, false)
         }
     }
 }
@@ -563,6 +595,11 @@ fn default_scalar_filter(
             _ => comparable.not_in_selection(convert_values(fields, values)),
         },
         ScalarCondition::JsonCompare(_) => unreachable!(),
+        ScalarCondition::Search(value, _) => comparable.matches(match value {
+            PrismaValue::String(s) => s,
+            _ => unreachable!(),
+        }),
+        ScalarCondition::NotSearch(_, _) => todo!(),
     };
 
     ConditionTree::single(condition)
@@ -662,6 +699,8 @@ fn insensitive_scalar_filter(
             }
         },
         ScalarCondition::JsonCompare(_) => unreachable!(),
+        ScalarCondition::Search(_, _) => todo!(),
+        ScalarCondition::NotSearch(_, _) => todo!(),
     };
 
     ConditionTree::single(condition)

--- a/query-engine/core/src/query_graph_builder/extractors/filters/flatten.rs
+++ b/query-engine/core/src/query_graph_builder/extractors/filters/flatten.rs
@@ -1,0 +1,44 @@
+use connector::Filter;
+
+pub fn flatten_filter(filter: Filter) -> Filter {
+    fn flatten_filters(filters: Vec<Filter>, parent: &Filter) -> Vec<Filter> {
+        let mut flattened: Vec<Filter> = vec![];
+
+        for f in filters {
+            match (f.clone(), parent) {
+                (Filter::And(and), Filter::And(_)) => {
+                    flattened.append(&mut flatten_filters(and, &f));
+                }
+                (Filter::And(and), _) => {
+                    flattened.push(Filter::And(flatten_filters(and, &f)));
+                }
+                (Filter::Or(or), Filter::Or(_)) => {
+                    flattened.append(&mut flatten_filters(or, &f));
+                }
+                (Filter::Or(or), _) => {
+                    flattened.push(Filter::Or(flatten_filters(or, &f)));
+                }
+                (Filter::Not(not), Filter::Not(_)) => {
+                    flattened.append(&mut flatten_filters(not, &f));
+                }
+                (Filter::Not(not), _) => {
+                    flattened.push(Filter::Not(flatten_filters(not, &f)));
+                }
+                _ => {
+                    flattened.push(f);
+                }
+            }
+        }
+
+        flattened
+    }
+
+    let parent = filter.clone();
+
+    match filter {
+        Filter::And(ands) => Filter::And(flatten_filters(ands, &parent)),
+        Filter::Or(ors) => Filter::Or(flatten_filters(ors, &parent)),
+        Filter::Not(nots) => Filter::Not(flatten_filters(nots, &parent)),
+        f => f,
+    }
+}

--- a/query-engine/core/src/query_graph_builder/extractors/filters/scalar.rs
+++ b/query-engine/core/src/query_graph_builder/extractors/filters/scalar.rs
@@ -242,6 +242,9 @@ fn parse_internal_scalar(
         filters::LOWER_THAN_OR_EQUAL => Ok(vec![field.less_than_or_equals(as_prisma_value(input)?)]),
         filters::GREATER_THAN_OR_EQUAL => Ok(vec![field.greater_than_or_equals(as_prisma_value(input)?)]),
 
+        filters::SEARCH if reverse => Ok(vec![field.search(as_prisma_value(input)?)]),
+        filters::SEARCH => Ok(vec![field.not_search(as_prisma_value(input)?)]),
+
         // List-specific filters
         filters::HAS => Ok(vec![field.contains_element(as_prisma_value(input)?)]),
         filters::HAS_EVERY => Ok(vec![field.contains_every_element(as_prisma_value_list(input)?)]),

--- a/query-engine/core/src/query_graph_builder/extractors/filters/scalar.rs
+++ b/query-engine/core/src/query_graph_builder/extractors/filters/scalar.rs
@@ -242,8 +242,8 @@ fn parse_internal_scalar(
         filters::LOWER_THAN_OR_EQUAL => Ok(vec![field.less_than_or_equals(as_prisma_value(input)?)]),
         filters::GREATER_THAN_OR_EQUAL => Ok(vec![field.greater_than_or_equals(as_prisma_value(input)?)]),
 
-        filters::SEARCH if reverse => Ok(vec![field.search(as_prisma_value(input)?)]),
-        filters::SEARCH => Ok(vec![field.not_search(as_prisma_value(input)?)]),
+        filters::SEARCH if reverse => Ok(vec![field.not_search(as_prisma_value(input)?)]),
+        filters::SEARCH => Ok(vec![field.search(as_prisma_value(input)?)]),
 
         // List-specific filters
         filters::HAS => Ok(vec![field.contains_element(as_prisma_value(input)?)]),

--- a/query-engine/core/src/schema_builder/constants.rs
+++ b/query-engine/core/src/schema_builder/constants.rs
@@ -58,6 +58,7 @@ pub mod filters {
     pub const CONTAINS: &str = "contains";
     pub const STARTS_WITH: &str = "startsWith";
     pub const ENDS_WITH: &str = "endsWith";
+    pub const SEARCH: &str = "search";
     pub const LOWER_THAN: &str = "lt";
     pub const LOWER_THAN_OR_EQUAL: &str = "lte";
     pub const GREATER_THAN: &str = "gt";

--- a/query-engine/core/src/schema_builder/mod.rs
+++ b/query-engine/core/src/schema_builder/mod.rs
@@ -40,7 +40,7 @@ mod utils;
 use crate::schema::*;
 use cache::TypeRefCache;
 use datamodel::common::preview_features::PreviewFeature;
-use datamodel_connector::ConnectorCapabilities;
+use datamodel_connector::{ConnectorCapabilities, ConnectorCapability};
 use prisma_models::{Field as ModelField, Index, InternalDataModelRef, ModelRef, RelationFieldRef, TypeIdentifier};
 use std::sync::Arc;
 
@@ -91,6 +91,10 @@ impl BuilderContext {
 
     pub fn has_feature(&self, feature: &PreviewFeature) -> bool {
         self.preview_features.contains(feature)
+    }
+
+    pub fn has_capability(&self, capability: ConnectorCapability) -> bool {
+        self.capabilities.contains(capability)
     }
 
     // Just here for convenience, will be removed soon.


### PR DESCRIPTION
## Overview

**Needs https://github.com/prisma/quaint/pull/306 to be reviewed/merged first**

- Adds a `search` filter on fields of type `String`

## Usage example

Given this datamodel

```prisma
model Recipe {
  id Int
  name String
  ingredients String
}
```

You can run the following query

```graphql
query {
  findManyRecipe(where: {
    name: { search: "Chicken" },
    ingredients: { search: "Chicken" }
  }) {
    id
    name
    ingredients
  }
}
```

This translate to the following Prisma Client call

```ts
const recipes = await prisma.recipe.findMany({
  where: {
    name: { search: "Chicken" },
    ingredients: { search: "Chicken" }
  }
});
```