### PR TITLE
Fix query parameter batching

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -4,6 +4,9 @@ export RUST_BACKTRACE=1
 export RUST_LOG=query_engine_tests=trace,query_engine=debug,query_core=trace,query_connector=debug,sql_query_connector=debug,prisma_models=debug,engineer=info,sql_introspection_connector=debug,tiberius=trace,quaint=debug
 export SKIP_CONNECTORS="vitess_5_7,vitess_8_0"
 
+# Logs SQL queries
+export LOG_QUERIES=1
+
 # Controls Scala test kit verbosity. Levels are trace, debug, info, error, warning
 export LOG_LEVEL=trace
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
@@ -1,1 +1,2 @@
+mod prisma_7434;
 mod prisma_8265;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_7434.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_7434.rs
@@ -1,0 +1,18 @@
+use query_engine_tests::*;
+
+#[test_suite(schema(autoinc_id), capabilities(CreateMany, AutoIncrement))]
+mod not_in_batching {
+    use query_engine_tests::Runner;
+
+    #[connector_test]
+    async fn nested_update_many_timestamps(runner: Runner) -> TestResult<()> {
+        runner.query(r#"mutation { createManyTestModel(data: [{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{}]) { count }}"#).await?.assert_success();
+
+        insta::assert_snapshot!(
+            run_query!(&runner, "query { findManyTestModel(where: { id: { notIn: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11] } }) { id }}"),
+            @r###"{"data":{"findManyTestModel":[{"id":11},{"id":12},{"id":13},{"id":14},{"id":15},{"id":16},{"id":17},{"id":18},{"id":19},{"id":20},{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":6},{"id":7},{"id":8},{"id":9},{"id":10},{"id":12},{"id":13},{"id":14},{"id":15},{"id":16},{"id":17},{"id":18},{"id":19},{"id":20}]}}"###
+        );
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Relevant issue: https://github.com/prisma/prisma/issues/7434

We have not decided on how to fix this yet, until now we only have a reliable reproduction and an understanding of the underlying issue.

Prisma currently splits filters that surpass a certain threshold into multiple queries and merges the results. There are default values for parameter limits per connector, as well as a `QUERY_BATCH_SIZE` env var. However, this splitting doesn't actually analyze the filters that it splits, causing any negative filter (e.g. `notIn`) to return _all_ data instead of the negated set.

The query engine should reject all queries that use negation filters if it surpasses the limit for connector.
