### PR TITLE
fix: relation count on self m2m

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/many_count_relation.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/many_count_relation.rs
@@ -219,8 +219,8 @@ mod many_count_rel {
             r#"model User {
               #id(id, Int, @id, @default(autoincrement()))
               name String
-              #m2m(followers, User[], Int, approved-followers)
-              #m2m(following, User[], Int, approved-followers)
+              #m2m(followers, User[], Int, followers)
+              #m2m(following, User[], Int, followers)
             }"#
         };
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/many_count_relation.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/many_count_relation.rs
@@ -214,6 +214,77 @@ mod many_count_rel {
 
         Ok(())
     }
+    fn m_n_self_rel() -> String {
+        let schema = indoc! {
+            r#"model User {
+              #id(id, Int, @id, @default(autoincrement()))
+              name String
+              #m2m(followers, User[], Int, approved-followers)
+              #m2m(following, User[], Int, approved-followers)
+            }"#
+        };
+
+        schema.to_owned()
+    }
+
+    // Regression test for https://github.com/prisma/prisma/issues/7807
+    #[connector_test(schema(m_n_self_rel))]
+    async fn count_m_n_self_rel(runner: Runner) -> TestResult<()> {
+        run_query!(
+            runner,
+            r#"mutation {
+          createOneUser(data: {
+            name: "Alice"
+            followers: { create: { name: "Bob"}},
+            following: { create: { name: "Justin"}},
+          }) {
+            id
+          }
+        }"#
+        );
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"query {
+            findManyUser {
+              name
+              following {
+                name
+              }
+              followers {
+                name
+              }
+              _count {
+                following
+                followers
+              }
+            }
+          }
+          "#),
+          @r###"{"data":{"findManyUser":[{"name":"Bob","following":[{"name":"Alice"}],"followers":[],"_count":{"following":1,"followers":0}},{"name":"Alice","following":[{"name":"Justin"}],"followers":[{"name":"Bob"}],"_count":{"following":1,"followers":1}},{"name":"Justin","following":[],"followers":[{"name":"Alice"}],"_count":{"following":0,"followers":1}}]}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"query {
+            findUniqueUser(where: { id: 1 }) {
+              name
+              following {
+                name
+              }
+              followers {
+                name
+              }
+              _count {
+                following
+                followers
+              }
+            }
+          }
+          "#),
+          @r###"{"data":{"findUniqueUser":{"name":"Alice","following":[{"name":"Justin"}],"followers":[{"name":"Bob"}],"_count":{"following":1,"followers":1}}}}"###
+        );
+
+        Ok(())
+    }
 
     fn schema_inmemory_process() -> String {
         let schema = indoc! {

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/many_count_relation.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/many_count_relation.rs
@@ -245,7 +245,7 @@ mod many_count_rel {
 
         insta::assert_snapshot!(
           run_query!(&runner, r#"query {
-            findManyUser {
+            findManyUser(orderBy: { name: asc }) {
               name
               following {
                 name
@@ -260,7 +260,7 @@ mod many_count_rel {
             }
           }
           "#),
-          @r###"{"data":{"findManyUser":[{"name":"Bob","following":[{"name":"Alice"}],"followers":[],"_count":{"following":1,"followers":0}},{"name":"Alice","following":[{"name":"Justin"}],"followers":[{"name":"Bob"}],"_count":{"following":1,"followers":1}},{"name":"Justin","following":[],"followers":[{"name":"Alice"}],"_count":{"following":0,"followers":1}}]}}"###
+          @r###"{"data":{"findManyUser":[{"name":"Alice","following":[{"name":"Justin"}],"followers":[{"name":"Bob"}],"_count":{"following":1,"followers":1}},{"name":"Bob","following":[{"name":"Alice"}],"followers":[],"_count":{"following":1,"followers":0}},{"name":"Justin","following":[],"followers":[{"name":"Alice"}],"_count":{"following":0,"followers":1}}]}}"###
         );
 
         insta::assert_snapshot!(

--- a/query-engine/connectors/sql-query-connector/src/join_utils.rs
+++ b/query-engine/connectors/sql-query-connector/src/join_utils.rs
@@ -97,38 +97,70 @@ fn compute_aggr_join_m2m(
     previous_join: Option<&AliasedJoin>,
 ) -> AliasedJoin {
     let relation_table = rf.as_table();
-    let a_ids = rf.model().primary_identifier();
-    let b_ids = rf.related_model().primary_identifier();
 
-    // + SELECT A.id FROM _AtoB
-    let query = Select::from_table(relation_table).columns(a_ids.as_columns());
+    let model_a = rf.model();
+    let model_a_alias = format!("{}_A", model_a.db_name());
+    let a_ids = rf.model().primary_identifier();
+    let a_columns: Vec<_> = a_ids.as_columns().map(|c| c.table(model_a_alias.clone())).collect();
+
+    let model_b = rf.related_model();
+    let model_b_alias = format!("{}_B", model_b.db_name());
+    let b_ids = rf.related_model().primary_identifier();
+    let b_columns: Vec<_> = b_ids.as_columns().map(|c| c.table(model_b_alias.clone())).collect();
+
+    // SQL statements below refers to three tables:
+    // A (left table): aliased as A_A
+    // B (right table): aliased as B_B
+    // _AtoB (join table): not aliased
+    // A & B are aliased to support m2m self relations, in which case we inner join twice on the same table
+    // If A & B are the "User" table, they'd be aliased to: User_A & User_B
+
+    // + SELECT A_A.id FROM _AtoB
+    let query = Select::from_table(relation_table).columns(a_columns.clone());
 
     let aggr_expr = match aggregation {
         AggregationType::Count { _all } => count(asterisk()),
     };
-    // SELECT A.id,
+    // SELECT A_A.id,
     // + COUNT(*) AS <AGGREGATOR_ALIAS>
     // FROM _AtoB
     let query = query.value(aggr_expr.alias(aggregator_alias.to_owned()));
 
-    let conditions_a: Vec<_> = a_ids
-        .as_columns()
+    let conditions_a: Vec<_> = a_columns
+        .clone()
+        .into_iter()
         .map(|c| c.equals(rf.related_field().m2m_columns()))
         .collect();
-    let conditions_b: Vec<_> = b_ids.as_columns().map(|c| c.equals(rf.m2m_columns())).collect();
+    let conditions_b: Vec<_> = b_columns
+        .clone()
+        .into_iter()
+        .map(|c| c.equals(rf.m2m_columns()))
+        .collect();
 
-    // SELECT A.id, COUNT(*) AS <AGGREGATOR_ALIAS> FROM _AtoB
-    // + INNER JOIN A ON A.id = _AtoB.A
-    // + INNER JOIN B ON B.id = _AtoB.B
+    // SELECT A_A.id, COUNT(*) AS <AGGREGATOR_ALIAS> FROM _AtoB
+    // + INNER JOIN A AS A_A ON A_A.id = _AtoB.A
+    // + INNER JOIN B AS B_B ON B_B.id = _AtoB.B
     let query = query
-        .inner_join(rf.model().as_table().on(ConditionTree::single(conditions_a)))
-        .inner_join(rf.related_model().as_table().on(ConditionTree::single(conditions_b)));
+        .inner_join(
+            model_a
+                .clone()
+                .as_table()
+                .alias(model_a_alias)
+                .on(ConditionTree::single(conditions_a)),
+        )
+        .inner_join(
+            model_b
+                .clone()
+                .as_table()
+                .alias(model_b_alias)
+                .on(ConditionTree::single(conditions_b)),
+        );
 
-    // SELECT A.id, COUNT(*) AS <AGGREGATOR_ALIAS> FROM _AtoB
-    // INNER JOIN A ON A.id = _AtoB.A
-    // INNER JOIN B ON B.id = _AtoB.B
-    // + GROUP BY A.id
-    let query = a_ids.as_columns().fold(query, |acc, f| acc.group_by(f.clone()));
+    // SELECT A_A.id, COUNT(*) AS <AGGREGATOR_ALIAS> FROM _AtoB
+    // INNER JOIN A AS A_A ON A_A.id = _AtoB.A
+    // INNER JOIN B AS B_B ON B_B.id = _AtoB.B
+    // + GROUP BY A_A.id
+    let query = a_columns.into_iter().fold(query, |acc, f| acc.group_by(f.clone()));
 
     let (left_fields, right_fields) = (a_ids.scalar_fields(), b_ids.scalar_fields());
     let pairs = left_fields.zip(right_fields);
@@ -145,11 +177,11 @@ fn compute_aggr_join_m2m(
         .collect::<Vec<_>>();
 
     // + LEFT JOIN (
-    //     SELECT A.id, COUNT(*) AS <AGGREGATOR_ALIAS> FROM _AtoB
-    //       INNER JOIN A ON (A.id = _AtoB.A)
-    //       INNER JOIN B ON (B.id = _AtoB.B)
+    //     SELECT A_A.id, COUNT(*) AS <AGGREGATOR_ALIAS> FROM _AtoB
+    //       INNER JOIN A AS A_A ON (A_A.id = _AtoB.A)
+    //       INNER JOIN B AS B_B ON (B_B.id = _AtoB.B)
     //     GROUP BY A.id
-    // + ) AS <ORDER_JOIN_PREFIX> ON (<A | previous_join_alias >.id = <ORDER_JOIN_PREFIX>.id)
+    // + ) AS <ORDER_JOIN_PREFIX> ON (<A | previous_join_alias>.id = <ORDER_JOIN_PREFIX>.id)
     let join = Table::from(query)
         .alias(join_alias.to_owned())
         .on(ConditionTree::single(on_conditions));

--- a/query-engine/connectors/sql-query-connector/src/join_utils.rs
+++ b/query-engine/connectors/sql-query-connector/src/join_utils.rs
@@ -143,14 +143,12 @@ fn compute_aggr_join_m2m(
     let query = query
         .inner_join(
             model_a
-                .clone()
                 .as_table()
                 .alias(model_a_alias)
                 .on(ConditionTree::single(conditions_a)),
         )
         .inner_join(
             model_b
-                .clone()
                 .as_table()
                 .alias(model_b_alias)
                 .on(ConditionTree::single(conditions_b)),


### PR DESCRIPTION
## Overview
Fixes https://github.com/prisma/prisma/issues/7807
Fixes https://github.com/prisma/prisma/issues/7893

As we perform inner joins on both sides in the case of an m2m, this PR adds aliases to the joins so that the same table is not referred to twice in the same block.

## Example

Given this datamodel:

```prisma
model User {
  id Int @id @default(autoincrement()))
  following User[] @relation(name: "approved-followers")
}
```

And the following query:

```graphql
query {
  findManyUser {
    id
    _count {
      following
    }
  }
}
```

Here's what the `LEFT JOIN` in charge of computing the count aggregation would look like before:

```sql
LEFT JOIN (
  SELECT
    "public"."User"."id",
    COUNT(*) AS "_aggr_count_following"
  FROM
    "public"."_approved-followers"
      INNER JOIN "public"."User" ON ("public"."User"."id" = ("public"."_approved-followers"."B"))
      INNER JOIN "public"."User" ON ("public"."User"."id" = ("public"."_approved-followers"."A"))
	GROUP BY "public"."User"."id"
) AS "aggr_selection_0_User" ON ("public"."User"."id" = "aggr_selection_0_User"."id")
```

And after (notice the aliases on the `INNER JOIN`s):

```sql
LEFT JOIN (
  SELECT
    User_A."id",
    COUNT(*) AS "_aggr_count_following"
  FROM
    "public"."_approved-followers"
      INNER JOIN "public"."User" AS User_A ON (User_A."id" = ("public"."_approved-followers"."B"))
      INNER JOIN "public"."User" AS User_B ON (User_B."id" = ("public"."_approved-followers"."A"))
	GROUP BY User_A."id"
) AS "aggr_selection_0_User" ON ("public"."User"."id" = "aggr_selection_0_User"."id")
```