### PR TITLE
fix: count & orderBy on one2m with multiple fks

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/many_count_relation.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/many_count_relation.rs
@@ -280,7 +280,7 @@ mod many_count_rel {
             model UserToObjective {
               user        User      @relation(fields: [userId], references: [id])
               userId      Int
-              objective   Objective @relation(name: "UserObjectives", fields: [objectiveId], references: [id])
+              objective   Objective @relation(name: "UserObjectives", fields: [objectiveId], references: [id], onDelete: NoAction, onUpdate: NoAction)
               objectiveId Int
               votes       Vote[]
             
@@ -291,7 +291,7 @@ mod many_count_rel {
               createdAt     DateTime        @default(now())
               user          User            @relation(fields: [userId], references: [id])
               userId        Int
-              userObjective UserToObjective @relation(fields: [objectiveId, followerId], references: [objectiveId, userId])
+              userObjective UserToObjective @relation(fields: [objectiveId, followerId], references: [userId, objectiveId], onDelete: NoAction, onUpdate: NoAction)
               objectiveId   Int
               followerId    Int
             


### PR DESCRIPTION
## Overview

Fixes https://github.com/prisma/prisma/issues/7299
Fixes https://github.com/prisma/prisma/issues/7331

This PR also fixes an `orderByRelation` issue (7331 above) which is using the `compute_one2m_join` function that I batched fixed in this PR as the root cause was exactly the same as the count aggregation one.

## Changes

`LEFT JOIN` in charge of computing the count aggregation changes from (pseudo-sql):

```sql
  LEFT JOIN (
      SELECT fk_1, fk_2, COUNT(*) FROM ... GROUP BY fk_1, fk_2
  ) AS aggr ON (
    fk_1 = "aggr"."fk1",
    fk_2 = "aggr"."fk2"
  )
```

to:

```sql
  LEFT JOIN (
      SELECT fk_1, fk_2, COUNT(*) FROM ... GROUP BY fk_1, fk_2
  ) AS aggr ON (
    fk_1 = "aggr"."fk1" AND
    fk_2 = "aggr"."fk2"
  )
```