### PR TITLE
fixed type_renderer.rs to assure that correct type is returned for Json

### DIFF
--- a/query-engine/request-handlers/src/graphql/schema_renderer/type_renderer.rs
+++ b/query-engine/request-handlers/src/graphql/schema_renderer/type_renderer.rs
@@ -48,7 +48,7 @@ impl<'a> GqlTypeRenderer<'a> {
                     ScalarType::Float => "Float",
                     ScalarType::Decimal => "Decimal",
                     ScalarType::DateTime => "DateTime",
-                    ScalarType::Json => "DateTime",
+                    ScalarType::Json => "Json",
                     ScalarType::UUID => "UUID",
                     ScalarType::JsonList => "Json",
                     ScalarType::Xml => "Xml",


### PR DESCRIPTION
Fixes [prima/prisma-engines#2148](https://github.com/prisma/prisma-engines/issues/2148).  Renderer now renders `Json` for JSON type instead of `DateTime`.