### PR TITLE
CI: Run clippy/format on GH Actions

### DIFF
--- a/.buildkite/engineer
+++ b/.buildkite/engineer
@@ -13,7 +13,7 @@ fi
 if ! type "engineer" > /dev/null; then
     # Setup Prisma engine build & test tool (engineer).
     set -e
-    curl --fail -sSL "https://prisma-engineer.s3-eu-west-1.amazonaws.com/lrts/latest/$OS/engineer.gz" --output engineer.gz
+    curl --fail -sSL "https://prisma-engineer.s3-eu-west-1.amazonaws.com/buh-bye-clippy/latest/$OS/engineer.gz" --output engineer.gz
     gzip -d engineer.gz
     chmod +x engineer
 

--- a/.buildkite/engineer
+++ b/.buildkite/engineer
@@ -13,7 +13,7 @@ fi
 if ! type "engineer" > /dev/null; then
     # Setup Prisma engine build & test tool (engineer).
     set -e
-    curl --fail -sSL "https://prisma-engineer.s3-eu-west-1.amazonaws.com/buh-bye-clippy/latest/$OS/engineer.gz" --output engineer.gz
+    curl --fail -sSL "https://prisma-engineer.s3-eu-west-1.amazonaws.com/1.21/latest/$OS/engineer.gz" --output engineer.gz
     gzip -d engineer.gz
     chmod +x engineer
 

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -7,8 +7,6 @@ on:
 jobs:
   clippy:
     runs-on: ubuntu-latest
-    env:
-      RUSTFLAGS: "-Dwarnings"
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -1,0 +1,36 @@
+name: Formatting
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+jobs:
+  clippy:
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: "-Dwarnings"
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+            toolchain: nightly
+            components: clippy
+            override: true
+      - uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-features
+
+  format:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: rustfmt
+          override: true
+      - uses: mbrobbel/rustfmt-check@master
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -16,6 +16,12 @@ jobs:
             toolchain: nightly
             components: clippy
             override: true
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-format-${{ matrix.rust }}-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -31,6 +37,12 @@ jobs:
           toolchain: stable
           components: rustfmt
           override: true
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-format-${{ matrix.rust }}-${{ hashFiles('**/Cargo.lock') }}
       - uses: mbrobbel/rustfmt-check@master
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-            toolchain: nightly
+            toolchain: stable
             components: clippy
             override: true
       - uses: actions/cache@v2

--- a/introspection-engine/connectors/sql-introspection-connector/src/re_introspection.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/re_introspection.rs
@@ -54,7 +54,7 @@ pub fn enrich(old_data_model: &Datamodel, new_data_model: &mut Datamodel, ctx: &
                     for index in &model.indices {
                         if let Some(old_index) = old_model.indices.iter().find(|old| old.db_name == index.db_name) {
                             if old_index.name.is_some() {
-                                let mf = ModelAndIndex::new(&model.name, &old_index.db_name.as_ref().unwrap());
+                                let mf = ModelAndIndex::new(&model.name, old_index.db_name.as_ref().unwrap());
                                 changed_index_names.push((mf, old_index.name.clone()))
                             }
                         }

--- a/libs/datamodel/core/src/transform/ast_to_dml/db/context/attributes.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/context/attributes.rs
@@ -105,7 +105,7 @@ impl<'ast> Attributes<'ast> {
                 None => unreachable!(),
                 Some((ds, attr_name)) if ds == datasource.name => {
                     if native_type_attr.replace((attr, attr_name)).is_some() {
-                        ctx.push_error(DatamodelError::new_duplicate_attribute_error(&ds, attr.span));
+                        ctx.push_error(DatamodelError::new_duplicate_attribute_error(ds, attr.span));
                     }
                 }
                 Some((bad_datasource, attr_name)) => {

--- a/libs/datamodel/core/src/transform/ast_to_dml/lift.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/lift.rs
@@ -87,7 +87,7 @@ impl<'a> LiftAstToDml<'a> {
         for (field_id, scalar_field_data) in self.db.iter_model_scalar_fields(model_id) {
             let ast_field = &ast_model[field_id];
             let arity = self.lift_field_arity(&ast_field.arity);
-            let field_type = self.lift_scalar_field_type(ast_field, &scalar_field_data.r#type, &scalar_field_data);
+            let field_type = self.lift_scalar_field_type(ast_field, &scalar_field_data.r#type, scalar_field_data);
 
             let mut field = dml::ScalarField::new(&ast_field.name.name, arity, field_type);
 
@@ -197,7 +197,7 @@ impl<'a> LiftAstToDml<'a> {
             }
             db::ScalarFieldType::Alias(top_id) => {
                 let alias = &self.db.ast()[*top_id];
-                let scalar_field_type = self.db.alias_scalar_field_type(&top_id);
+                let scalar_field_type = self.db.alias_scalar_field_type(top_id);
                 self.lift_scalar_field_type(alias, scalar_field_type, scalar_field_data)
             }
             db::ScalarFieldType::BuiltInScalar(scalar_type) => {

--- a/libs/datamodel/core/src/transform/ast_to_dml/validate.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validate.rs
@@ -54,7 +54,7 @@ impl<'a> Validator<'a> {
                         for field in model.fields() {
                             if let Some(err) = ConstraintNames::client_name_already_in_use(
                                 name,
-                                &field.name(),
+                                field.name(),
                                 &model.name,
                                 ast_model.span,
                                 "@@id",
@@ -72,7 +72,7 @@ impl<'a> Validator<'a> {
                         for field in model.fields() {
                             if let Some(err) = ConstraintNames::client_name_already_in_use(
                                 name,
-                                &field.name(),
+                                field.name(),
                                 &model.name,
                                 ast_model.span,
                                 "@@unique",
@@ -116,7 +116,7 @@ impl<'a> Validator<'a> {
         schema: &dml::Datamodel,
         diagnostics: &mut Diagnostics,
     ) {
-        let constraint_names = NamesValidator::new(&schema, self.preview_features, self.source);
+        let constraint_names = NamesValidator::new(schema, self.preview_features, self.source);
 
         for model in schema.models() {
             let ast_model = ast_schema.find_model(&model.name).expect(STATE_ERROR);
@@ -856,7 +856,7 @@ impl<'a> Validator<'a> {
                 }
 
                 if !field.is_list() && self.preview_features.contains(PreviewFeature::ReferentialActions) {
-                    self.detect_referential_action_cycles(&datamodel, &model, &field, field_span, &mut errors);
+                    self.detect_referential_action_cycles(datamodel, model, field, field_span, &mut errors);
                 }
             } else {
                 let message = format!(

--- a/libs/datamodel/core/src/transform/dml_to_ast/lower_field.rs
+++ b/libs/datamodel/core/src/transform/dml_to_ast/lower_field.rs
@@ -232,7 +232,7 @@ impl<'a> LowerDmlToAst<'a> {
 
     pub fn lower_default_value(dv: dml::DefaultValue) -> ast::Expression {
         match dv.kind() {
-            dml::DefaultKind::Single(v) => LowerDmlToAst::<'a>::lower_prisma_value(&v),
+            dml::DefaultKind::Single(v) => LowerDmlToAst::<'a>::lower_prisma_value(v),
             dml::DefaultKind::Expression(e) => {
                 let exprs = e.args().iter().map(LowerDmlToAst::<'a>::lower_prisma_value).collect();
                 ast::Expression::Function(e.name().to_string(), exprs, ast::Span::empty())

--- a/libs/prisma-models/src/datamodel_converter.rs
+++ b/libs/prisma-models/src/datamodel_converter.rs
@@ -63,7 +63,7 @@ impl<'a> DatamodelConverter<'a> {
                 is_embedded: model.is_embedded,
                 fields: self.convert_fields(model),
                 manifestation: model.database_name().map(|s| s.to_owned()),
-                primary_key: self.convert_pk(&model),
+                primary_key: self.convert_pk(model),
                 indexes: self.convert_indexes(model),
                 supports_create_operation: model.supports_create_operation(),
                 dml_model: model.clone(),

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mssql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mssql_renderer.rs
@@ -135,7 +135,7 @@ impl SqlRenderer for MssqlFlavour {
             IndexType::Normal => "",
         };
 
-        let index_name = self.quote(&index.name());
+        let index_name = self.quote(index.name());
         let table_reference = self.quote_with_schema(index.table().name()).to_string();
 
         let columns = index.columns().map(|c| self.quote(c.name()));
@@ -178,11 +178,7 @@ impl SqlRenderer for MssqlFlavour {
                 .map(|index| {
                     let columns = index.columns().map(|col| self.quote(col.name()));
 
-                    format!(
-                        "CONSTRAINT {} UNIQUE ({})",
-                        self.quote(&index.name()),
-                        columns.join(",")
-                    )
+                    format!("CONSTRAINT {} UNIQUE ({})", self.quote(index.name()), columns.join(","))
                 })
                 .join(",\n    ");
 


### PR DESCRIPTION
Reasons
- Takes forever to get any clippy warnings with the current configuration
- Let's move them to a separate github action, get rid of clippy on buildkite
- Build should cache crates so faster compile times
- Format automatically adds formatted code as a commit to a PR

Let's see if this is less annoying compared to waiting for 15 minutes for buildkite to get red, when you forgot one extra `&reference` to your code.