### PR TITLE
Differentiate failed migration error if in tx

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/flavour.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour.rs
@@ -141,6 +141,7 @@ async fn generic_apply_migration_script(migration_name: &str, script: &str, conn
                 .original_message()
                 .map(String::from)
                 .unwrap_or_else(|| ConnectorError::from(quaint_error).to_string()),
+            in_transaction: conn.connection_info().sql_family().is_mssql(),
         })
     })
 }

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/mysql.rs
@@ -196,6 +196,7 @@ impl SqlFlavour for MysqlFlavour {
                 migration_name: migration_name.to_owned(),
                 database_error_code: code.map(|c| c.to_string()).unwrap_or_else(|| String::from("none")),
                 database_error: error,
+                in_transaction: false,
             })
         };
 

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/postgres.rs
@@ -201,6 +201,7 @@ impl SqlFlavour for PostgresFlavour {
                     migration_name: migration_name.to_owned(),
                     database_error_code: database_error_code.unwrap_or("none").to_owned(),
                     database_error,
+                    in_transaction: false,
                 }))
             }
         }

--- a/migration-engine/migration-engine-tests/tests/apply_migrations/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/apply_migrations/mod.rs
@@ -112,15 +112,19 @@ fn migrations_should_fail_when_the_script_is_invalid(api: TestApi) {
     {
         let expected_error_message = formatdoc!(
             r#"
-                A migration failed to apply. New migrations cannot be applied before the error is recovered from. Read more about how to resolve migration issues in a production database: https://pris.ly/d/migrate-resolve
+                {description}
 
                 Migration name: {second_migration_name}
 
                 Database error code: {error_code}
 
                 Database error:
-                {message}
-                "#,
+                {message}"#,
+            description = if api.connection_info().sql_family().is_mssql() {
+                "A migration failed to apply and the migration transaction was rolled back. Mark the migration as rolled back, possibly edit the migration and then retry. Read more about how to resolve migration issues in a production database: https://pris.ly/d/migrate-resolve"
+            } else {
+                "A migration failed to apply. New migrations cannot be applied before the error is recovered from. Read more about how to resolve migration issues in a production database: https://pris.ly/d/migrate-resolve"
+            },
             second_migration_name = second_migration_name,
             error_code = match api.tags() {
                 t if t.contains(Tags::Vitess) => 1105,

--- a/migration-engine/migration-engine-tests/tests/migrations/mssql.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/mssql.rs
@@ -110,7 +110,7 @@ fn mssql_apply_migrations_error_output(api: TestApi) {
         .replace(&migration_name, "<migration-name>");
 
     let expectation = expect![[r#"
-        A migration failed to apply. New migrations cannot be applied before the error is recovered from. Read more about how to resolve migration issues in a production database: https://pris.ly/d/migrate-resolve
+        A migration failed to apply and the migration transaction was rolled back. Mark the migration as rolled back, possibly edit the migration and then retry. Read more about how to resolve migration issues in a production database: https://pris.ly/d/migrate-resolve
 
         Migration name: <migration-name>
 


### PR DESCRIPTION
If the migration is known to be run in a transaction, inform the user they only need to rollback and retry.

Closes: https://github.com/prisma/prisma/issues/8351