### PR TITLE
Fix M2M relationname inferrence

### DIFF
--- a/introspection-engine/connectors/sql-introspection-connector/src/introspection_helpers.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/introspection_helpers.rs
@@ -178,7 +178,7 @@ pub(crate) fn calculate_relation_field(
     schema: &SqlSchema,
     table: &Table,
     foreign_key: &ForeignKey,
-    m2m_table_names: &Vec<String>,
+    m2m_table_names: &[String],
 ) -> Result<RelationField, SqlError> {
     debug!("Handling foreign key  {:?}", foreign_key);
 
@@ -327,7 +327,7 @@ pub(crate) fn calculate_relation_name(
     schema: &SqlSchema,
     fk: &ForeignKey,
     table: &Table,
-    m2m_table_names: &Vec<String>,
+    m2m_table_names: &[String],
 ) -> Result<String, SqlError> {
     //this is not called for prisma many to many relations. for them the name is just the name of the join table.
     let referenced_model = &fk.referenced_table;

--- a/introspection-engine/connectors/sql-introspection-connector/src/introspection_helpers.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/introspection_helpers.rs
@@ -178,6 +178,7 @@ pub(crate) fn calculate_relation_field(
     schema: &SqlSchema,
     table: &Table,
     foreign_key: &ForeignKey,
+    m2m_table_names: &Vec<String>,
 ) -> Result<RelationField, SqlError> {
     debug!("Handling foreign key  {:?}", foreign_key);
 
@@ -190,7 +191,7 @@ pub(crate) fn calculate_relation_field(
     };
 
     let relation_info = RelationInfo {
-        name: calculate_relation_name(schema, foreign_key, table)?,
+        name: calculate_relation_name(schema, foreign_key, table, m2m_table_names)?,
         fk_name: foreign_key.constraint_name.clone(),
         fields: foreign_key.columns.clone(),
         to: foreign_key.referenced_table.clone(),
@@ -322,7 +323,12 @@ pub(crate) fn is_sequence(column: &Column, table: &Table) -> bool {
         .unwrap_or(false)
 }
 
-pub(crate) fn calculate_relation_name(schema: &SqlSchema, fk: &ForeignKey, table: &Table) -> Result<String, SqlError> {
+pub(crate) fn calculate_relation_name(
+    schema: &SqlSchema,
+    fk: &ForeignKey,
+    table: &Table,
+    m2m_table_names: &Vec<String>,
+) -> Result<String, SqlError> {
     //this is not called for prisma many to many relations. for them the name is just the name of the join table.
     let referenced_model = &fk.referenced_table;
     let model_with_fk = &table.name;
@@ -347,8 +353,14 @@ pub(crate) fn calculate_relation_name(schema: &SqlSchema, fk: &ForeignKey, table
                 .iter()
                 .any(|fk| &fk.referenced_table == model_with_fk);
 
-            let name = if fk_to_same_model.len() < 2 && !fk_from_other_model_to_this_exist {
-                RelationNames::name_for_unambiguous_relation(model_with_fk, referenced_model)
+            let unambiguous_name = RelationNames::name_for_unambiguous_relation(model_with_fk, referenced_model);
+
+            // this needs to know whether there are m2m relations and then use ambiguous name path
+            let name = if fk_to_same_model.len() < 2
+                && !fk_from_other_model_to_this_exist
+                && !m2m_table_names.contains(&unambiguous_name)
+            {
+                unambiguous_name
             } else {
                 RelationNames::name_for_ambiguous_relation(model_with_fk, referenced_model, &fk_column_name)
             };

--- a/introspection-engine/introspection-engine-tests/tests/relations/mod.rs
+++ b/introspection-engine/introspection-engine-tests/tests/relations/mod.rs
@@ -859,15 +859,15 @@ async fn one_to_many_relation_field_names_do_not_conflict_with_many_to_many_rela
             model Event {{
                 id                           Int    @id @default(autoincrement())
                 host_id                      Int
-                User_EventToUser             User   @relation(fields: [host_id], references: [id])
-                User_EventToUserManyToMany   User[] @relation("EventToUserManyToMany")
+                User_Event_host_idToUser     User   @relation("Event_host_idToUser", fields: [host_id], references: [id])
+                User_EventToUser             User[] @relation("EventToUser")
                 {extra_index}
             }}
 
             model User {{
                 id                           Int     @id @default(autoincrement())
-                Event_EventToUser            Event[]
-                Event_EventToUserManyToMany  Event[] @relation("EventToUserManyToMany")
+                Event_Event_host_idToUser    Event[] @relation("Event_host_idToUser")
+                Event_EventToUser            Event[] @relation("EventToUser")
             }}
         "#,
         extra_index = extra_index,


### PR DESCRIPTION
We cannot change the relationname for m2m relations since the QE derives the table name from that.

Fixes https://github.com/prisma/prisma/issues/7706