### PR TITLE
Validate ref action side in 1-1 relations

### DIFF
--- a/libs/datamodel/core/src/transform/ast_to_dml/validate.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validate.rs
@@ -583,9 +583,9 @@ impl<'a> Validator<'a> {
                     && (rel_info.on_delete.is_some() || rel_info.on_update.is_some())
                 {
                     let message = &format!(
-                            "The relation field `{}` on Model `{}` must not specify the `onDelete` or `onUpdate` argument in the {} attribute. You must only specify it on the opposite field `{}` on model `{}`, or in case of a many to many relation, in an explicit join table.",
-                            &field.name, &model.name, RELATION_ATTRIBUTE_NAME_WITH_AT, &related_field.name, &related_model.name
-                        );
+                        "The relation field `{}` on Model `{}` must not specify the `onDelete` or `onUpdate` argument in the {} attribute. You must only specify it on the opposite field `{}` on model `{}`, or in case of a many to many relation, in an explicit join table.",
+                        &field.name, &model.name, RELATION_ATTRIBUTE_NAME_WITH_AT, &related_field.name, &related_model.name
+                    );
 
                     errors.push_error(DatamodelError::new_attribute_validation_error(
                         message,
@@ -635,20 +635,35 @@ impl<'a> Validator<'a> {
                         ));
                     }
 
-                    if self.preview_features.contains(PreviewFeature::ReferentialActions)
-                        && (rel_info.on_delete.is_some() || rel_info.on_update.is_some())
-                        && (related_field_rel_info.on_delete.is_some() || related_field_rel_info.on_update.is_some())
-                    {
-                        let message = format!(
-                            "The relation fields `{}` on Model `{}` and `{}` on Model `{}` both provide the `onDelete` or `onUpdate` argument in the {} attribute. You have to provide it only on one of the two fields.",
-                            &field.name, &model.name, &related_field.name, &related_model.name, RELATION_ATTRIBUTE_NAME_WITH_AT
-                        );
+                    if self.preview_features.contains(PreviewFeature::ReferentialActions) {
+                        if (rel_info.on_delete.is_some() || rel_info.on_update.is_some())
+                            && (related_field_rel_info.on_delete.is_some()
+                                || related_field_rel_info.on_update.is_some())
+                        {
+                            let message = format!(
+                                "The relation fields `{}` on Model `{}` and `{}` on Model `{}` both provide the `onDelete` or `onUpdate` argument in the {} attribute. You have to provide it only on one of the two fields.",
+                                &field.name, &model.name, &related_field.name, &related_model.name, RELATION_ATTRIBUTE_NAME_WITH_AT
+                            );
 
-                        errors.push_error(DatamodelError::new_attribute_validation_error(
-                            &message,
-                            RELATION_ATTRIBUTE_NAME,
-                            field_span,
-                        ));
+                            errors.push_error(DatamodelError::new_attribute_validation_error(
+                                &message,
+                                RELATION_ATTRIBUTE_NAME,
+                                field_span,
+                            ));
+                        } else if rel_info.fields.is_empty()
+                            && (rel_info.on_delete.is_some() || rel_info.on_update.is_some())
+                        {
+                            let message = &format!(
+                                "The relation field `{}` on Model `{}` must not specify the `onDelete` or `onUpdate` argument in the {} attribute. You must only specify it on the opposite field `{}` on model `{}`.",
+                                &field.name, &model.name, RELATION_ATTRIBUTE_NAME_WITH_AT, &related_field.name, &related_model.name
+                            );
+
+                            errors.push_error(DatamodelError::new_attribute_validation_error(
+                                message,
+                                RELATION_ATTRIBUTE_NAME,
+                                field_span,
+                            ));
+                        }
                     }
 
                     if !rel_info.fields.is_empty() && !related_field_rel_info.fields.is_empty() {

--- a/libs/datamodel/core/tests/attributes/relations/referential_actions.rs
+++ b/libs/datamodel/core/tests/attributes/relations/referential_actions.rs
@@ -318,7 +318,7 @@ fn concrete_actions_should_not_work_on_planetscale() {
 }
 
 #[test]
-fn on_delete_cannot_be_defined_on_the_wrong_side() {
+fn on_delete_cannot_be_defined_on_the_wrong_side_1_n() {
     let dml = indoc! { r#"
         datasource db {
             provider = "mysql"
@@ -353,7 +353,7 @@ fn on_delete_cannot_be_defined_on_the_wrong_side() {
 }
 
 #[test]
-fn on_update_cannot_be_defined_on_the_wrong_side() {
+fn on_update_cannot_be_defined_on_the_wrong_side_1_n() {
     let dml = indoc! { r#"
         datasource db {
             provider = "mysql"
@@ -385,6 +385,74 @@ fn on_update_cannot_be_defined_on_the_wrong_side() {
         "relation",
         Span::new(193, 230),
     )]);
+}
+
+#[test]
+fn on_delete_cannot_be_defined_on_the_wrong_side_1_1() {
+    let dml = indoc! { r#"
+        datasource db {
+            provider = "mysql"
+            url = "mysql://"
+        }
+
+        generator client {
+            provider = "prisma-client-js"
+            previewFeatures = ["referentialActions"]
+        }
+
+        model Chicken {
+            id        Int      @id @default(autoincrement())
+            cock      Chicken? @relation(name: "a_self_relation", onDelete: NoAction)
+            hen       Chicken? @relation(name: "a_self_relation", fields: [chickenId], references: [id])
+            chickenId Int?
+        }
+    "#};
+
+    let expect = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@relation": The relation field `cock` on Model `Chicken` must not specify the `onDelete` or `onUpdate` argument in the @relation attribute. You must only specify it on the opposite field `hen` on model `Chicken`.[0m
+          [1;94m-->[0m  [4mschema.prisma:13[0m
+        [1;94m   | [0m
+        [1;94m12 | [0m    id        Int      @id @default(autoincrement())
+        [1;94m13 | [0m    [1;91mcock      Chicken? @relation(name: "a_self_relation", onDelete: NoAction)[0m
+        [1;94m14 | [0m    hen       Chicken? @relation(name: "a_self_relation", fields: [chickenId], references: [id])
+        [1;94m   | [0m
+    "#]];
+
+    expect.assert_eq(&datamodel::parse_schema(dml).map(drop).unwrap_err());
+}
+
+#[test]
+fn on_update_cannot_be_defined_on_the_wrong_side_1_1() {
+    let dml = indoc! { r#"
+        datasource db {
+            provider = "mysql"
+            url = "mysql://"
+        }
+
+        generator client {
+            provider = "prisma-client-js"
+            previewFeatures = ["referentialActions"]
+        }
+
+        model Chicken {
+            id        Int      @id @default(autoincrement())
+            cock      Chicken? @relation(name: "a_self_relation", onUpdate: NoAction)
+            hen       Chicken? @relation(name: "a_self_relation", fields: [chickenId], references: [id])
+            chickenId Int?
+        }
+    "#};
+
+    let expect = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@relation": The relation field `cock` on Model `Chicken` must not specify the `onDelete` or `onUpdate` argument in the @relation attribute. You must only specify it on the opposite field `hen` on model `Chicken`.[0m
+          [1;94m-->[0m  [4mschema.prisma:13[0m
+        [1;94m   | [0m
+        [1;94m12 | [0m    id        Int      @id @default(autoincrement())
+        [1;94m13 | [0m    [1;91mcock      Chicken? @relation(name: "a_self_relation", onUpdate: NoAction)[0m
+        [1;94m14 | [0m    hen       Chicken? @relation(name: "a_self_relation", fields: [chickenId], references: [id])
+        [1;94m   | [0m
+    "#]];
+
+    expect.assert_eq(&datamodel::parse_schema(dml).map(drop).unwrap_err());
 }
 
 #[test]


### PR DESCRIPTION
The actions should be defined from the side of `fields` and `references`.

Closes: https://github.com/prisma/prisma/issues/8764