### PR TITLE
Make clippy faster to never invalidate the crates cache

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -21,7 +21,7 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-          key: ${{ runner.os }}-format-${{ matrix.rust }}-${{ hashFiles('**/Cargo.lock') }}
+          key: clippy
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -35,11 +35,5 @@ jobs:
           toolchain: stable
           components: rustfmt
           override: true
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: ${{ runner.os }}-format-${{ matrix.rust }}-${{ hashFiles('**/Cargo.lock') }}
       - name: Check formatting
         run: cargo fmt -- --check


### PR DESCRIPTION
We should never need to recompile all dependencies, just our own code.