### PR TITLE
Node API: Convert CoreError correctly to a UFE.

### DIFF
--- a/query-engine/query-engine-node-api/src/error.rs
+++ b/query-engine/query-engine-node-api/src/error.rs
@@ -44,6 +44,7 @@ impl From<ApiError> for user_facing_errors::Error {
                     user_facing_errors::common::SchemaParserError { full_error },
                 ))
             }
+            ApiError::Core(error) => user_facing_errors::Error::from(error),
             other => user_facing_errors::Error::new_non_panic_with_current_backtrace(other.to_string()),
         }
     }


### PR DESCRIPTION
Part of: https://github.com/prisma/prisma/issues/8836