### PR TITLE
fix: json numeric filters (gt/gte/lt/lte)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3214,7 +3214,7 @@ dependencies = [
 [[package]]
 name = "quaint"
 version = "0.2.0-alpha.13"
-source = "git+https://github.com/prisma/quaint#d23b824b70baa552e69eb954280664bee2082f29"
+source = "git+https://github.com/prisma/quaint#9808b60d3e1296686651eb8e07fe9d1df82afe6f"
 dependencies = [
  "async-trait",
  "base64 0.12.3",

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/json_path.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/json_path.rs
@@ -1,8 +1,8 @@
 use query_engine_tests::*;
 
-#[test_suite(schema(schemas::json), capabilities(JsonFilteringJsonPath, JsonFilteringArrayPath))]
+#[test_suite(schema(schemas::json), only(Postgres, MySql(5.7, 8, "mariadb")))]
 mod json_path {
-    use query_engine_tests::ConnectorTag;
+    use query_engine_tests::{assert_error, run_query, ConnectorTag};
 
     #[connector_test]
     async fn no_path_without_filter(runner: Runner) -> TestResult<()> {
@@ -40,7 +40,7 @@ mod json_path {
         Ok(())
     }
 
-    #[connector_test(capabilities(JsonFilteringJsonPath), exclude(MySql(5.6)))]
+    #[connector_test(capabilities(JsonFilteringJsonPath), only(MySql(5.7), MySql(8)))]
     async fn extract_json_path(runner: Runner) -> TestResult<()> {
         create_row(&runner, 1, r#"{ \"a\": { \"b\": \"c\" } }"#, false).await?;
         create_row(&runner, 2, r#"{ \"a\": { \"b\": [1, 2, 3] } }"#, false).await?;
@@ -64,7 +64,8 @@ mod json_path {
         Ok(())
     }
 
-    #[connector_test]
+    // TODO: MariaDB is excluded because it produces different results than MySQL and Postgres
+    #[connector_test(only(Postgres, MySql(5.7, 8)))]
     async fn array_contains(runner: Runner) -> TestResult<()> {
         create_row(&runner, 1, r#"[1, 2, 3]"#, true).await?;
         create_row(&runner, 2, r#"[3, 4, 5]"#, true).await?;
@@ -100,7 +101,8 @@ mod json_path {
         Ok(())
     }
 
-    #[connector_test]
+    // TODO: MariaDB is excluded because it doesn't support array_starts_with yet
+    #[connector_test(only(Postgres, MySql(5.7, 8)))]
     async fn array_starts_with(runner: Runner) -> TestResult<()> {
         create_row(&runner, 1, r#"[1, 2, 3]"#, true).await?;
         create_row(&runner, 2, r#"[3, 4, 5]"#, true).await?;
@@ -136,7 +138,8 @@ mod json_path {
         Ok(())
     }
 
-    #[connector_test]
+    // TODO: MariaDB is excluded because array_ends_with doesn't work yet
+    #[connector_test(only(Postgres, MySql(5.7, 8)))]
     async fn array_ends_with(runner: Runner) -> TestResult<()> {
         create_row(&runner, 1, r#"[1, 2, 3]"#, true).await?;
         create_row(&runner, 2, r#"[3, 4, 5]"#, true).await?;
@@ -225,7 +228,8 @@ mod json_path {
         create_row(&runner, 3, r#"1"#, true).await?;
         create_row(&runner, 4, r#"2"#, true).await?;
         create_row(&runner, 5, r#"1.4"#, true).await?;
-        create_row(&runner, 6, r#"[\"foo\"]"#, true).await?;
+        create_row(&runner, 6, r#"100"#, true).await?;
+        create_row(&runner, 7, r#"[\"foo\"]"#, true).await?;
 
         insta::assert_snapshot!(
             run_query!(
@@ -248,7 +252,7 @@ mod json_path {
                 runner,
                 jsonq(&runner, r#"gt: "1" "#, None)
             ),
-            @r###"{"data":{"findManyTestModel":[{"json":"{\"a\":{\"b\":2}}"},{"json":"{\"a\":{\"b\":1.4}}"}]}}"###
+            @r###"{"data":{"findManyTestModel":[{"json":"{\"a\":{\"b\":2}}"},{"json":"{\"a\":{\"b\":1.4}}"},{"json":"{\"a\":{\"b\":100}}"}]}}"###
         );
 
         insta::assert_snapshot!(
@@ -256,13 +260,59 @@ mod json_path {
                 runner,
                 jsonq(&runner, r#"gte: "1" "#, None)
             ),
-            @r###"{"data":{"findManyTestModel":[{"json":"{\"a\":{\"b\":1}}"},{"json":"{\"a\":{\"b\":2}}"},{"json":"{\"a\":{\"b\":1.4}}"}]}}"###
+            @r###"{"data":{"findManyTestModel":[{"json":"{\"a\":{\"b\":1}}"},{"json":"{\"a\":{\"b\":2}}"},{"json":"{\"a\":{\"b\":1.4}}"},{"json":"{\"a\":{\"b\":100}}"}]}}"###
         );
 
         Ok(())
     }
 
     #[connector_test]
+    async fn lt_lte(runner: Runner) -> TestResult<()> {
+        create_row(&runner, 1, r#"\"foo\""#, true).await?;
+        create_row(&runner, 2, r#"\"bar\""#, true).await?;
+        create_row(&runner, 3, r#"1"#, true).await?;
+        create_row(&runner, 4, r#"2"#, true).await?;
+        create_row(&runner, 5, r#"1.4"#, true).await?;
+        create_row(&runner, 6, r#"100"#, true).await?;
+        create_row(&runner, 7, r#"[\"foo\"]"#, true).await?;
+
+        insta::assert_snapshot!(
+            run_query!(
+                runner,
+                jsonq(&runner, r#"lt: "\"f\"" "#, None)
+            ),
+            @r###"{"data":{"findManyTestModel":[{"json":"{\"a\":{\"b\":\"bar\"}}"}]}}"###
+        );
+
+        insta::assert_snapshot!(
+            run_query!(
+                runner,
+                jsonq(&runner, r#"lte: "\"foo\"" "#, None)
+            ),
+            @r###"{"data":{"findManyTestModel":[{"json":"{\"a\":{\"b\":\"foo\"}}"},{"json":"{\"a\":{\"b\":\"bar\"}}"}]}}"###
+        );
+
+        insta::assert_snapshot!(
+            run_query!(
+                runner,
+                jsonq(&runner, r#"lt: "100" "#, None)
+            ),
+            @r###"{"data":{"findManyTestModel":[{"json":"{\"a\":{\"b\":1}}"},{"json":"{\"a\":{\"b\":2}}"},{"json":"{\"a\":{\"b\":1.4}}"}]}}"###
+        );
+
+        insta::assert_snapshot!(
+            run_query!(
+                runner,
+                jsonq(&runner, r#"lte: "100" "#, None)
+            ),
+            @r###"{"data":{"findManyTestModel":[{"json":"{\"a\":{\"b\":1}}"},{"json":"{\"a\":{\"b\":2}}"},{"json":"{\"a\":{\"b\":1.4}}"},{"json":"{\"a\":{\"b\":100}}"}]}}"###
+        );
+
+        Ok(())
+    }
+
+    // TODO: MariaDB is excluded because array_starts_with doesn't work yet
+    #[connector_test(only(Postgres, MySql(5.7, 8)))]
     async fn multi_filtering(runner: Runner) -> TestResult<()> {
         create_row(&runner, 1, r#"[1, 2, 3]"#, true).await?;
         create_row(&runner, 2, r#"[3, 4, 5]"#, true).await?;

--- a/query-engine/connectors/sql-query-connector/src/filter_conversion.rs
+++ b/query-engine/connectors/sql-query-connector/src/filter_conversion.rs
@@ -508,19 +508,23 @@ fn convert_json_filter(
                 .and(expr_json.json_type_equals(JsonType::Array))
                 .into(),
         },
-        ScalarCondition::GreaterThan(value) => expr_string
+        ScalarCondition::GreaterThan(value) => expr_json
+            .clone()
             .greater_than(convert_value(&field, value.clone()))
             .and(filter_json_type(expr_json, value))
             .into(),
-        ScalarCondition::GreaterThanOrEquals(value) => expr_string
+        ScalarCondition::GreaterThanOrEquals(value) => expr_json
+            .clone()
             .greater_than_or_equals(convert_value(&field, value.clone()))
             .and(filter_json_type(expr_json, value))
             .into(),
-        ScalarCondition::LessThan(value) => expr_string
+        ScalarCondition::LessThan(value) => expr_json
+            .clone()
             .less_than(convert_value(&field, value.clone()))
             .and(filter_json_type(expr_json, value))
             .into(),
-        ScalarCondition::LessThanOrEquals(value) => expr_string
+        ScalarCondition::LessThanOrEquals(value) => expr_json
+            .clone()
             .less_than_or_equals(convert_value(&field, value.clone()))
             .and(filter_json_type(expr_json, value))
             .into(),


### PR DESCRIPTION
## Overview

- fixes https://github.com/prisma/prisma/issues/8224 (Postgres JSON numeric comparisons)
- fixes MySQL and MariaDB JSON numeric comparisons too (https://github.com/prisma/quaint/pull/310, https://github.com/prisma/quaint/pull/311, https://github.com/prisma/quaint/pull/315)
- have JSON filter tests actually run again

## Deeper dive

- On Postgres, we were applying ASCII comparison instead of numeric comparison
- On MySQL and MariaDB, we're doing the comparisons against the deserialized json values