### PR TITLE
Set renovate to do PRs outside office hours

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,5 +7,10 @@
   },
   "sbt": {
     "enabled": false
-  }
+  },
+  "schedule": [
+    "after 10pm every weekday",
+    "before 5am every weekday",
+    "every weekend"
+  ]
 }


### PR DESCRIPTION
So at least we don't have the whole CI under stress when we do releases and other important things.