### PR TITLE
(sql-migration-connector) Start isolating quaint imports...

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/connection_wrapper.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/connection_wrapper.rs
@@ -1,161 +1,35 @@
-use crate::error::quaint_error_to_connector_error;
+mod native;
+
+pub(crate) use native::*;
+
 use migration_connector::ConnectorError;
-use quaint::{
-    connector::{Mysql, MysqlUrl, PostgreSql, PostgresUrl},
-    error::{Error as QuaintError, ErrorKind as QuaintKind},
-    prelude::{ConnectionInfo, Query, Queryable, ResultSet},
-    single::Quaint,
-};
-use std::sync::Arc;
+use user_facing_errors::UserFacingError;
 
-/// An internal helper for the SQL connector. It wraps a `Quaint` struct and
-/// exposes a similar API, with additional error handling to return
-/// `ConnectorResult`s.
-#[derive(Clone, Debug)]
-pub(crate) struct Connection(ConnectionInner);
-
-#[derive(Clone, Debug)]
-enum ConnectionInner {
-    Postgres(Arc<(quaint::connector::PostgreSql, PostgresUrl)>),
-    Mysql(Arc<(quaint::connector::Mysql, MysqlUrl)>),
-    Generic(Quaint),
-}
+pub(crate) type SqlResult<T> = Result<T, SqlError>;
 
 #[derive(Debug)]
-pub(crate) struct ConnectionError {
-    quaint_error: QuaintError,
-    connection_info: ConnectionInfo,
+pub(crate) struct SqlError {
+    error_code: Option<String>,
+    /// The constructed ConnectorError for bubbling up.
+    connector_error: ConnectorError,
+    /// A byte offset in the query text.
+    src_position: Option<u32>,
+    /// 0-based index of the statement in the original query.
+    src_statement: Option<u32>,
 }
 
-type ConnectionResult<T> = Result<T, ConnectionError>;
-
-impl ConnectionError {
-    pub(crate) fn kind(&self) -> &QuaintKind {
-        self.quaint_error.kind()
+impl SqlError {
+    pub(crate) fn error_code(&self) -> Option<&str> {
+        self.error_code.as_deref()
     }
 
-    pub(crate) fn original_code(&self) -> Option<&str> {
-        self.quaint_error.original_code()
-    }
-
-    pub(crate) fn original_message(&self) -> Option<&str> {
-        self.quaint_error.original_message()
-    }
-}
-
-impl From<ConnectionError> for ConnectorError {
-    fn from(err: ConnectionError) -> Self {
-        quaint_error_to_connector_error(err.quaint_error, &err.connection_info)
+    pub(crate) fn is_user_facing_error<T: UserFacingError>(&self) -> bool {
+        self.connector_error.error_code() == Some(T::ERROR_CODE)
     }
 }
 
-impl Connection {
-    pub(crate) fn new_generic(quaint: Quaint) -> Self {
-        Connection(ConnectionInner::Generic(quaint))
-    }
-
-    pub(crate) fn new_postgres(conn: PostgreSql, url: PostgresUrl) -> Self {
-        Connection(ConnectionInner::Postgres(Arc::new((conn, url))))
-    }
-
-    pub(crate) fn new_mysql(conn: Mysql, url: MysqlUrl) -> Self {
-        Connection(ConnectionInner::Mysql(Arc::new((conn, url))))
-    }
-
-    pub(crate) fn connection_info(&self) -> ConnectionInfo {
-        match &self.0 {
-            ConnectionInner::Postgres(pg) => ConnectionInfo::Postgres(pg.1.clone()),
-            ConnectionInner::Mysql(my) => ConnectionInfo::Mysql(my.1.clone()),
-            ConnectionInner::Generic(q) => q.connection_info().clone(),
-        }
-    }
-
-    pub(crate) async fn execute(&self, query: impl Into<Query<'_>>) -> ConnectionResult<u64> {
-        self.queryable()
-            .execute(query.into())
-            .await
-            .map_err(|quaint_error| ConnectionError {
-                quaint_error,
-                connection_info: self.connection_info(),
-            })
-    }
-
-    pub(crate) fn queryable(&self) -> &dyn Queryable {
-        match &self.0 {
-            ConnectionInner::Postgres(pg) => &pg.0,
-            ConnectionInner::Mysql(my) => &my.0,
-            ConnectionInner::Generic(q) => q,
-        }
-    }
-
-    pub(crate) async fn query(&self, query: impl Into<Query<'_>>) -> ConnectionResult<ResultSet> {
-        self.queryable()
-            .query(query.into())
-            .await
-            .map_err(|quaint_error| ConnectionError {
-                quaint_error,
-                connection_info: self.connection_info(),
-            })
-    }
-
-    pub(crate) async fn query_raw(&self, sql: &str, params: &[quaint::Value<'_>]) -> ConnectionResult<ResultSet> {
-        self.queryable()
-            .query_raw(sql, params)
-            .await
-            .map_err(|quaint_error| ConnectionError {
-                quaint_error,
-                connection_info: self.connection_info(),
-            })
-    }
-
-    pub(crate) async fn raw_cmd(&self, sql: &str) -> ConnectionResult<()> {
-        self.queryable()
-            .raw_cmd(sql)
-            .await
-            .map_err(|quaint_error| ConnectionError {
-                quaint_error,
-                connection_info: self.connection_info(),
-            })
-    }
-
-    pub(crate) fn schema_name(&self) -> &str {
-        match &self.0 {
-            ConnectionInner::Postgres(pg) => pg.1.schema(),
-            ConnectionInner::Mysql(my) => my.1.dbname(),
-            ConnectionInner::Generic(quaint) => quaint.connection_info().schema_name(),
-        }
-    }
-
-    pub(crate) async fn version(&self) -> ConnectionResult<Option<String>> {
-        self.queryable()
-            .version()
-            .await
-            .map_err(|quaint_error| ConnectionError {
-                quaint_error,
-                connection_info: self.connection_info(),
-            })
-    }
-
-    /// Render a table name with the required prefixing for use with quaint query building.
-    pub(crate) fn table_name<'a>(&'a self, name: &'a str) -> quaint::ast::Table<'a> {
-        if self.connection_info().sql_family().is_sqlite() {
-            name.into()
-        } else {
-            (self.schema_name(), name).into()
-        }
-    }
-
-    pub(crate) fn unwrap_postgres(&self) -> &(PostgreSql, PostgresUrl) {
-        match &self.0 {
-            ConnectionInner::Postgres(inner) => inner,
-            other => panic!("{:?} in Connection::unwrap_postgres()", other),
-        }
-    }
-
-    pub(crate) fn unwrap_mysql(&self) -> &(Mysql, MysqlUrl) {
-        match &self.0 {
-            ConnectionInner::Mysql(inner) => &**inner,
-            other => panic!("{:?} in Connection::unwrap_mysql()", other),
-        }
+impl From<SqlError> for ConnectorError {
+    fn from(err: SqlError) -> Self {
+        err.connector_error
     }
 }

--- a/migration-engine/connectors/sql-migration-connector/src/connection_wrapper/native.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/connection_wrapper/native.rs
@@ -1,0 +1,210 @@
+use super::{SqlError, SqlResult};
+use migration_connector::{ConnectorError, ConnectorResult};
+use quaint::{
+    connector::{Mysql, MysqlUrl, PostgreSql, PostgresUrl},
+    error::{Error as QuaintError, ErrorKind as QuaintKind},
+    prelude::{ConnectionInfo, Query, Queryable, ResultSet},
+    single::Quaint,
+};
+use std::sync::Arc;
+use user_facing_errors::KnownError;
+
+pub(crate) async fn connect(connection_string: &str) -> ConnectorResult<Connection> {
+    let connection_info = ConnectionInfo::from_url(connection_string).map_err(|err| {
+        let details = user_facing_errors::quaint::invalid_connection_string_description(&err.to_string());
+        KnownError::new(user_facing_errors::common::InvalidConnectionString { details })
+    })?;
+
+    if let ConnectionInfo::Postgres(url) = &connection_info {
+        return quaint::connector::PostgreSql::new(url.clone())
+            .await
+            .map(|conn| Connection::new_postgres(conn, url.clone()))
+            .map_err(|err| quaint_error_to_connector_error(err, &connection_info));
+    }
+
+    if let ConnectionInfo::Mysql(url) = &connection_info {
+        return quaint::connector::Mysql::new(url.clone())
+            .await
+            .map(|conn| Connection::new_mysql(conn, url.clone()))
+            .map_err(|err| quaint_error_to_connector_error(err, &connection_info));
+    }
+
+    let connection = Quaint::new(connection_string)
+        .await
+        .map_err(|err| quaint_error_to_connector_error(err, &connection_info))?;
+
+    Ok(Connection::new_generic(connection))
+}
+
+pub(crate) fn quaint_error_to_connector_error(error: QuaintError, connection_info: &ConnectionInfo) -> ConnectorError {
+    match user_facing_errors::quaint::render_quaint_error(error.kind(), connection_info) {
+        Some(user_facing_error) => user_facing_error.into(),
+        None => ConnectorError::from_source(error, "Database error"),
+    }
+}
+
+/// An internal helper for the SQL connector. It wraps a `Quaint` struct and
+/// exposes a similar API, with additional error handling to return
+/// `ConnectorResult`s.
+#[derive(Clone, Debug)]
+pub(crate) struct Connection(ConnectionInner);
+
+#[derive(Clone, Debug)]
+enum ConnectionInner {
+    Postgres(Arc<(quaint::connector::PostgreSql, PostgresUrl)>),
+    Mysql(Arc<(quaint::connector::Mysql, MysqlUrl)>),
+    Generic(Quaint),
+}
+
+#[derive(Debug)]
+pub(crate) struct ConnectionError {
+    quaint_error: QuaintError,
+    connection_info: ConnectionInfo,
+}
+
+impl From<ConnectionError> for super::SqlError {
+    fn from(err: ConnectionError) -> Self {
+        let error_code = err.quaint_error.original_code().map(String::from);
+        super::SqlError {
+            connector_error: quaint_error_to_connector_error(err.quaint_error, &err.connection_info),
+            src_position: None,
+            src_statement: None,
+            error_code,
+        }
+    }
+}
+
+type ConnectionResult<T> = Result<T, ConnectionError>;
+
+impl ConnectionError {
+    pub(crate) fn kind(&self) -> &QuaintKind {
+        self.quaint_error.kind()
+    }
+
+    pub(crate) fn original_code(&self) -> Option<&str> {
+        self.quaint_error.original_code()
+    }
+
+    pub(crate) fn original_message(&self) -> Option<&str> {
+        self.quaint_error.original_message()
+    }
+}
+
+impl From<ConnectionError> for ConnectorError {
+    fn from(err: ConnectionError) -> Self {
+        quaint_error_to_connector_error(err.quaint_error, &err.connection_info)
+    }
+}
+
+impl Connection {
+    pub(crate) fn new_generic(quaint: Quaint) -> Self {
+        Connection(ConnectionInner::Generic(quaint))
+    }
+
+    pub(crate) fn new_postgres(conn: PostgreSql, url: PostgresUrl) -> Self {
+        Connection(ConnectionInner::Postgres(Arc::new((conn, url))))
+    }
+
+    pub(crate) fn new_mysql(conn: Mysql, url: MysqlUrl) -> Self {
+        Connection(ConnectionInner::Mysql(Arc::new((conn, url))))
+    }
+
+    pub(crate) fn connection_info(&self) -> ConnectionInfo {
+        match &self.0 {
+            ConnectionInner::Postgres(pg) => ConnectionInfo::Postgres(pg.1.clone()),
+            ConnectionInner::Mysql(my) => ConnectionInfo::Mysql(my.1.clone()),
+            ConnectionInner::Generic(q) => q.connection_info().clone(),
+        }
+    }
+
+    pub(crate) async fn execute(&self, query: impl Into<Query<'_>>) -> SqlResult<u64> {
+        self.queryable()
+            .execute(query.into())
+            .await
+            .map_err(|quaint_error| ConnectionError {
+                quaint_error,
+                connection_info: self.connection_info(),
+            })
+            .map_err(SqlError::from)
+    }
+
+    pub(crate) fn queryable(&self) -> &dyn Queryable {
+        match &self.0 {
+            ConnectionInner::Postgres(pg) => &pg.0,
+            ConnectionInner::Mysql(my) => &my.0,
+            ConnectionInner::Generic(q) => q,
+        }
+    }
+
+    pub(crate) async fn query(&self, query: impl Into<Query<'_>>) -> ConnectionResult<ResultSet> {
+        self.queryable()
+            .query(query.into())
+            .await
+            .map_err(|quaint_error| ConnectionError {
+                quaint_error,
+                connection_info: self.connection_info(),
+            })
+    }
+
+    pub(crate) async fn query_raw(&self, sql: &str, params: &[quaint::Value<'_>]) -> ConnectionResult<ResultSet> {
+        self.queryable()
+            .query_raw(sql, params)
+            .await
+            .map_err(|quaint_error| ConnectionError {
+                quaint_error,
+                connection_info: self.connection_info(),
+            })
+    }
+
+    pub(crate) async fn raw_cmd(&self, sql: &str) -> SqlResult<()> {
+        self.queryable()
+            .raw_cmd(sql)
+            .await
+            .map_err(|quaint_error| ConnectionError {
+                quaint_error,
+                connection_info: self.connection_info(),
+            })
+            .map_err(SqlError::from)
+    }
+
+    pub(crate) fn schema_name(&self) -> &str {
+        match &self.0 {
+            ConnectionInner::Postgres(pg) => pg.1.schema(),
+            ConnectionInner::Mysql(my) => my.1.dbname(),
+            ConnectionInner::Generic(quaint) => quaint.connection_info().schema_name(),
+        }
+    }
+
+    pub(crate) async fn version(&self) -> ConnectionResult<Option<String>> {
+        self.queryable()
+            .version()
+            .await
+            .map_err(|quaint_error| ConnectionError {
+                quaint_error,
+                connection_info: self.connection_info(),
+            })
+    }
+
+    /// Render a table name with the required prefixing for use with quaint query building.
+    pub(crate) fn table_name<'a>(&'a self, name: &'a str) -> quaint::ast::Table<'a> {
+        if self.connection_info().sql_family().is_sqlite() {
+            name.into()
+        } else {
+            (self.schema_name(), name).into()
+        }
+    }
+
+    pub(crate) fn unwrap_postgres(&self) -> &(PostgreSql, PostgresUrl) {
+        match &self.0 {
+            ConnectionInner::Postgres(inner) => inner,
+            other => panic!("{:?} in Connection::unwrap_postgres()", other),
+        }
+    }
+
+    pub(crate) fn unwrap_mysql(&self) -> &(Mysql, MysqlUrl) {
+        match &self.0 {
+            ConnectionInner::Mysql(inner) => &**inner,
+            other => panic!("{:?} in Connection::unwrap_mysql()", other),
+        }
+    }
+}

--- a/migration-engine/connectors/sql-migration-connector/src/error.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/error.rs
@@ -1,13 +1,5 @@
 use migration_connector::ConnectorError;
-use quaint::{error::Error as QuaintError, prelude::ConnectionInfo};
-use user_facing_errors::{migration_engine::MigrateSystemDatabase, quaint::render_quaint_error};
-
-pub(crate) fn quaint_error_to_connector_error(error: QuaintError, connection_info: &ConnectionInfo) -> ConnectorError {
-    match render_quaint_error(error.kind(), connection_info) {
-        Some(user_facing_error) => user_facing_error.into(),
-        None => ConnectorError::from_source(error, "Database error"),
-    }
-}
+use user_facing_errors::migration_engine::MigrateSystemDatabase;
 
 #[derive(Debug)]
 pub(crate) struct SystemDatabase(pub(crate) String);

--- a/migration-engine/connectors/sql-migration-connector/src/flavour.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour.rs
@@ -133,14 +133,11 @@ fn validate_connection_infos_do_not_match((previous, next): (&ConnectionInfo, &C
 }
 
 async fn generic_apply_migration_script(migration_name: &str, script: &str, conn: &Connection) -> ConnectorResult<()> {
-    conn.raw_cmd(script).await.map_err(|quaint_error| {
+    conn.raw_cmd(script).await.map_err(|sql_error| {
         ConnectorError::user_facing(ApplyMigrationError {
             migration_name: migration_name.to_owned(),
-            database_error_code: String::from(quaint_error.original_code().unwrap_or("none")),
-            database_error: quaint_error
-                .original_message()
-                .map(String::from)
-                .unwrap_or_else(|| ConnectorError::from(quaint_error).to_string()),
+            database_error_code: String::from(sql_error.error_code().unwrap_or("none")),
+            database_error: ConnectorError::from(sql_error).to_string(),
         })
     })
 }

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/mssql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/mssql.rs
@@ -1,5 +1,6 @@
 use crate::{
-    connect, connection_wrapper::Connection, error::quaint_error_to_connector_error, SqlFlavour, SqlMigrationConnector,
+    connection_wrapper::{connect, quaint_error_to_connector_error, Connection},
+    SqlFlavour, SqlMigrationConnector,
 };
 use connection_string::JdbcString;
 use datamodel::common::preview_features::PreviewFeature;

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/mysql.rs
@@ -1,8 +1,7 @@
 use super::SqlFlavour;
 use crate::{
-    connect,
-    connection_wrapper::Connection,
-    error::{quaint_error_to_connector_error, SystemDatabase},
+    connection_wrapper::{connect, quaint_error_to_connector_error, Connection},
+    error::SystemDatabase,
     SqlMigrationConnector,
 };
 use datamodel::{common::preview_features::PreviewFeature, walkers::walk_scalar_fields, Datamodel};
@@ -483,7 +482,7 @@ impl SqlFlavour for MysqlFlavour {
 #[enumflags2::bitflags]
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(u8)]
-pub enum Circumstances {
+pub(crate) enum Circumstances {
     LowerCasesTableNames,
     IsMysql56,
     IsMariadb,

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/sqlite.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/sqlite.rs
@@ -1,5 +1,6 @@
 use crate::{
-    connect, connection_wrapper::Connection, error::quaint_error_to_connector_error, flavour::SqlFlavour,
+    connection_wrapper::{connect, quaint_error_to_connector_error, Connection},
+    flavour::SqlFlavour,
     SqlMigrationConnector,
 };
 use datamodel::common::preview_features::PreviewFeature;

--- a/migration-engine/connectors/sql-migration-connector/src/sql_migration_persistence.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_migration_persistence.rs
@@ -2,7 +2,7 @@ use crate::SqlMigrationConnector;
 use migration_connector::{
     ConnectorError, ConnectorResult, MigrationPersistence, MigrationRecord, PersistenceNotInitializedError,
 };
-use quaint::{ast::*, error::ErrorKind as QuaintKind};
+use quaint::ast::*;
 use uuid::Uuid;
 
 #[async_trait::async_trait]
@@ -137,7 +137,10 @@ impl MigrationPersistence for SqlMigrationConnector {
 
         let rows = match self.conn().query(select).await {
             Ok(result) => result,
-            Err(err) if matches!(err.kind(), QuaintKind::TableDoesNotExist { .. }) => {
+            Err(err)
+                if err.is_user_facing_error::<user_facing_errors::query_engine::TableDoesNotExist>()
+                    || err.is_user_facing_error::<user_facing_errors::common::InvalidModel>() =>
+            {
                 return Ok(Err(PersistenceNotInitializedError))
             }
             err @ Err(_) => err?,

--- a/migration-engine/migration-engine-tests/tests/migrations/mssql.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/mssql.rs
@@ -117,17 +117,13 @@ fn mssql_apply_migrations_error_output(api: TestApi) {
         Database error code: 3701
 
         Database error:
-        Cannot drop the table 'mssql_apply_migrations_error_output.Emu', because it does not exist or you do not have permission.
-
-    "#]];
+        Cannot drop the table 'mssql_apply_migrations_error_output.Emu', because it does not exist or you do not have permission."#]];
 
     let first_segment = err
-        .split_terminator("DbError {")
-        .next()
-        .unwrap()
         .split_terminator("   0: ")
         .next()
-        .unwrap();
+        .unwrap()
+        .trim_end_matches(|c| c == '\n' || c == ' ');
 
     expectation.assert_eq(first_segment)
 }


### PR DESCRIPTION
...in connection_wrapper module. To isolate the surface coupled to our
database drivers. This should also disentangle error handling. At the
lower level, we use quaint, but we don't refer to it anymore once we
have a user facing error error code.