### PR TITLE
Move row/value counts in destructive change checker to flavours

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/connection_wrapper/native.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/connection_wrapper/native.rs
@@ -144,15 +144,6 @@ impl Connection {
             .map_err(|quaint_error| sql_error(quaint_error, &self.connection_info()))
     }
 
-    /// Render a table name with the required prefixing for use with quaint query building.
-    pub(crate) fn table_name<'a>(&'a self, name: &'a str) -> quaint::ast::Table<'a> {
-        if self.connection_info().sql_family().is_sqlite() {
-            name.into()
-        } else {
-            (self.schema_name(), name).into()
-        }
-    }
-
     pub(crate) fn unwrap_postgres(&self) -> &(PostgreSql, PostgresUrl) {
         match &self.0 {
             ConnectionInner::Postgres(inner) => inner,

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker.rs
@@ -279,7 +279,7 @@ impl SqlMigrationConnector {
     async fn check_impl(&self, migration: &SqlMigration) -> ConnectorResult<DestructiveChangeDiagnostics> {
         let plan = self.plan(migration);
 
-        plan.execute(self.conn()).await
+        plan.execute(self.flavour(), self.conn()).await
     }
 }
 
@@ -288,7 +288,7 @@ impl DestructiveChangeChecker for SqlMigrationConnector {
     async fn check(&self, migration: &Migration) -> ConnectorResult<DestructiveChangeDiagnostics> {
         let plan = self.plan(migration.downcast_ref());
 
-        plan.execute(self.conn()).await
+        plan.execute(self.flavour(), self.conn()).await
     }
 
     fn pure_check(&self, migration: &Migration) -> DestructiveChangeDiagnostics {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour.rs
@@ -3,12 +3,13 @@ mod mysql;
 mod postgres;
 mod sqlite;
 
+use super::DestructiveCheckPlan;
+use crate::{connection_wrapper::Connection, pair::Pair, sql_migration::AlterColumn, sql_schema_differ::ColumnChanges};
+use migration_connector::{ConnectorError, ConnectorResult};
 use sql_schema_describer::walkers::ColumnWalker;
 
-use super::DestructiveCheckPlan;
-use crate::{pair::Pair, sql_migration::AlterColumn, sql_schema_differ::ColumnChanges};
-
-/// Flavour-specific destructive change checks.
+/// Flavour-specific destructive change checks and queries.
+#[async_trait::async_trait]
 pub(crate) trait DestructiveChangeCheckerFlavour {
     /// Check for potential destructive or unexecutable alter column steps.
     fn check_alter_column(
@@ -27,4 +28,36 @@ pub(crate) trait DestructiveChangeCheckerFlavour {
         plan: &mut DestructiveCheckPlan,
         step_index: usize,
     );
+
+    async fn count_rows_in_table(&self, table_name: &str, conn: &Connection) -> ConnectorResult<i64>;
+
+    async fn count_values_in_column(&self, table_and_column: (&str, &str), conn: &Connection) -> ConnectorResult<i64>;
+}
+
+fn extract_table_rows_count(table_name: &str, result_set: quaint::prelude::ResultSet) -> ConnectorResult<i64> {
+    result_set
+        .first()
+        .ok_or_else(|| {
+            ConnectorError::from_msg(format!(
+                "No row was returned when checking for existing rows in the `{}` table.",
+                table_name
+            ))
+        })?
+        .at(0)
+        .and_then(|value| value.as_i64())
+        .ok_or_else(|| {
+            ConnectorError::from_msg(format!(
+                "No count was returned when checking for existing rows in the `{}` table.",
+                table_name
+            ))
+        })
+}
+
+fn extract_column_values_count(result_set: quaint::prelude::ResultSet) -> ConnectorResult<i64> {
+    result_set
+        .first()
+        .as_ref()
+        .and_then(|row| row.at(0))
+        .and_then(|count| count.as_i64())
+        .ok_or_else(|| ConnectorError::from_msg("Unexpected result set shape when checking dropped columns.".into()))
 }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/mssql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/mssql.rs
@@ -13,6 +13,7 @@ use datamodel_connector::Connector;
 use sql_datamodel_connector::SqlDatamodelConnectors;
 use sql_schema_describer::walkers::ColumnWalker;
 
+#[async_trait::async_trait]
 impl DestructiveChangeCheckerFlavour for MssqlFlavour {
     fn check_alter_column(
         &self,
@@ -118,5 +119,30 @@ impl DestructiveChangeCheckerFlavour for MssqlFlavour {
                 step_index,
             )
         }
+    }
+
+    async fn count_rows_in_table(
+        &self,
+        table_name: &str,
+        conn: &crate::connection_wrapper::Connection,
+    ) -> migration_connector::ConnectorResult<i64> {
+        let query = format!("SELECT COUNT(*) FROM [{}].[{}]", conn.schema_name(), table_name);
+        let result_set = conn.query_raw(&query, &[]).await?;
+        super::extract_table_rows_count(table_name, result_set)
+    }
+
+    async fn count_values_in_column(
+        &self,
+        (table, column): (&str, &str),
+        conn: &crate::connection_wrapper::Connection,
+    ) -> migration_connector::ConnectorResult<i64> {
+        let query = format!(
+            "SELECT COUNT(*) FROM [{}].[{}] WHERE [{}] IS NOT NULL",
+            conn.schema_name(),
+            table,
+            column
+        );
+        let result_set = conn.query_raw(&query, &[]).await?;
+        super::extract_column_values_count(result_set)
     }
 }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/mysql.rs
@@ -13,6 +13,7 @@ use datamodel_connector::Connector;
 use sql_datamodel_connector::SqlDatamodelConnectors;
 use sql_schema_describer::walkers::ColumnWalker;
 
+#[async_trait::async_trait]
 impl DestructiveChangeCheckerFlavour for MysqlFlavour {
     fn check_alter_column(
         &self,
@@ -127,6 +128,26 @@ impl DestructiveChangeCheckerFlavour for MysqlFlavour {
                 step_index,
             )
         }
+    }
+
+    async fn count_rows_in_table(
+        &self,
+        table_name: &str,
+        conn: &crate::connection_wrapper::Connection,
+    ) -> migration_connector::ConnectorResult<i64> {
+        let query = format!("SELECT COUNT(*) FROM `{}`", table_name);
+        let result_set = conn.query_raw(&query, &[]).await?;
+        super::extract_table_rows_count(table_name, result_set)
+    }
+
+    async fn count_values_in_column(
+        &self,
+        (table, column): (&str, &str),
+        conn: &crate::connection_wrapper::Connection,
+    ) -> migration_connector::ConnectorResult<i64> {
+        let query = format!("SELECT COUNT(*) FROM `{}` WHERE `{}` IS NOT NULL", table, column);
+        let result_set = conn.query_raw(&query, &[]).await?;
+        super::extract_column_values_count(result_set)
     }
 }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/postgres.rs
@@ -13,6 +13,7 @@ use datamodel_connector::Connector;
 use sql_datamodel_connector::SqlDatamodelConnectors;
 use sql_schema_describer::walkers::ColumnWalker;
 
+#[async_trait::async_trait]
 impl DestructiveChangeCheckerFlavour for PostgresFlavour {
     fn check_alter_column(
         &self,
@@ -123,5 +124,25 @@ impl DestructiveChangeCheckerFlavour for PostgresFlavour {
                 step_index,
             )
         }
+    }
+
+    async fn count_rows_in_table(
+        &self,
+        table_name: &str,
+        conn: &crate::connection_wrapper::Connection,
+    ) -> migration_connector::ConnectorResult<i64> {
+        let query = format!("SELECT COUNT(*) FROM \"{}\"", table_name);
+        let result_set = conn.query_raw(&query, &[]).await?;
+        super::extract_table_rows_count(table_name, result_set)
+    }
+
+    async fn count_values_in_column(
+        &self,
+        (table, column): (&str, &str),
+        conn: &crate::connection_wrapper::Connection,
+    ) -> migration_connector::ConnectorResult<i64> {
+        let query = format!("SELECT COUNT(*) FROM \"{}\" WHERE \"{}\" IS NOT NULL", table, column);
+        let result_set = conn.query_raw(&query, &[]).await?;
+        super::extract_column_values_count(result_set)
     }
 }


### PR DESCRIPTION
We are slowly isolating quaint types in the sql migration connector.