### PR TITLE
Make using system certs with MySQL easier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3225,7 +3225,7 @@ dependencies = [
 [[package]]
 name = "quaint"
 version = "0.2.0-alpha.13"
-source = "git+https://github.com/prisma/quaint#11e743d06921bc63b1fa81b0fb5be48dee6be9be"
+source = "git+https://github.com/prisma/quaint#c1ed9835d12e72e56dff548e36599c21f38f7282"
 dependencies = [
  "async-trait",
  "base64 0.12.3",


### PR DESCRIPTION
From now on, a TLS connection can be formed by just setting `sslaccept=strict|accept_invalid_certs`. If no other TLS related
parameter is set, it should just use the system certificates and connecting to a database with a valid certificate, such as PlanetScale will Just Work.

Closes: https://github.com/prisma/prisma/issues/8843
The actual changes: https://github.com/prisma/quaint/pull/312