### PR TITLE
Keep order of mutated keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3270,6 +3270,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "futures",
+ "indexmap",
  "itertools 0.10.0",
  "prisma-models",
  "prisma-value",

--- a/query-engine/connectors/query-connector/Cargo.toml
+++ b/query-engine/connectors/query-connector/Cargo.toml
@@ -17,3 +17,4 @@ serde_json = {version = "1.0", features = ["float_roundtrip"]}
 thiserror = "1.0"
 user-facing-errors = {path = "../../../libs/user-facing-errors"}
 uuid = "0.8"
+indexmap = "1.0"

--- a/query-engine/connectors/query-connector/src/write_args.rs
+++ b/query-engine/connectors/query-connector/src/write_args.rs
@@ -1,17 +1,13 @@
 use crate::error::{ConnectorError, ErrorKind};
 use chrono::Utc;
+use indexmap::{map::Keys, IndexMap};
 use prisma_models::{ModelProjection, ModelRef, PrismaValue, RecordProjection, ScalarFieldRef};
-use std::{
-    borrow::Borrow,
-    collections::{hash_map::Keys, HashMap},
-    convert::TryInto,
-    ops::Deref,
-};
+use std::{borrow::Borrow, convert::TryInto, ops::Deref};
 
 /// WriteArgs represent data to be written to an underlying data source.
 #[derive(Debug, PartialEq, Clone, Default)]
 pub struct WriteArgs {
-    pub args: HashMap<DatasourceFieldName, WriteExpression>,
+    pub args: IndexMap<DatasourceFieldName, WriteExpression>,
 }
 
 /// Wrapper struct to force a bit of a reflection whether or not the string passed
@@ -83,16 +79,16 @@ impl TryInto<PrismaValue> for WriteExpression {
     }
 }
 
-impl From<HashMap<DatasourceFieldName, PrismaValue>> for WriteArgs {
-    fn from(args: HashMap<DatasourceFieldName, PrismaValue>) -> Self {
+impl From<IndexMap<DatasourceFieldName, PrismaValue>> for WriteArgs {
+    fn from(args: IndexMap<DatasourceFieldName, PrismaValue>) -> Self {
         Self {
             args: args.into_iter().map(|(k, v)| (k, WriteExpression::Value(v))).collect(),
         }
     }
 }
 
-impl From<HashMap<DatasourceFieldName, WriteExpression>> for WriteArgs {
-    fn from(args: HashMap<DatasourceFieldName, WriteExpression>) -> Self {
+impl From<IndexMap<DatasourceFieldName, WriteExpression>> for WriteArgs {
+    fn from(args: IndexMap<DatasourceFieldName, WriteExpression>) -> Self {
         Self { args }
     }
 }
@@ -115,7 +111,7 @@ impl From<Vec<(DatasourceFieldName, WriteExpression)>> for WriteArgs {
 
 impl WriteArgs {
     pub fn new() -> Self {
-        Self { args: HashMap::new() }
+        Self { args: IndexMap::new() }
     }
 
     pub fn insert<T, V>(&mut self, key: T, arg: V)
@@ -228,7 +224,7 @@ pub fn merge_write_args(loaded_ids: Vec<RecordProjection>, incoming_args: WriteA
     }
 
     // Contains all positions that need to be updated with the given expression.
-    let positions: HashMap<usize, &WriteExpression> = loaded_ids
+    let positions: IndexMap<usize, &WriteExpression> = loaded_ids
         .first()
         .unwrap()
         .pairs


### PR DESCRIPTION
This change keeps the order of keys e.g. in an update statement. The old behaviour generated a randomized order in an `UPDATE`, causing the LRU in the connector getting countless of separate statements even though they all did the same thing.

Closes: https://github.com/prisma/prisma/issues/8870