### PR TITLE
Skip the callback unref

### DIFF
--- a/query-engine/query-engine-node-api/Cargo.toml
+++ b/query-engine/query-engine-node-api/Cargo.toml
@@ -19,7 +19,7 @@ user-facing-errors = { path = "../../libs/user-facing-errors" }
 datamodel = { path = "../../libs/datamodel/core" }
 sql-connector = { path = "../connectors/sql-query-connector", package = "sql-query-connector" }
 prisma-models = { path = "../prisma-models" }
-napi = { version = "1.7.3", default-features = false, features = ["napi4", "tokio_rt", "serde-json"] }
+napi = { version = "1.7.6", default-features = false, features = ["napi4", "tokio_rt", "serde-json"] }
 napi-derive = "1"
 thiserror = "1"
 connection-string = "0.1"

--- a/query-engine/query-engine-node-api/src/logger.rs
+++ b/query-engine/query-engine-node-api/src/logger.rs
@@ -13,7 +13,7 @@ use opentelemetry::{
 
 use opentelemetry_otlp::WithExportConfig;
 use registry::EventRegistry;
-use std::future::Future;
+use std::{future::Future, sync::Arc};
 use telemetry::WithTelemetry;
 use tracing_futures::WithSubscriber;
 use tracing_subscriber::{
@@ -37,7 +37,7 @@ pub struct ChannelLogger {
 
 impl ChannelLogger {
     /// Creates a new instance of a logger with the minimum log level.
-    pub fn new(level: &str, log_queries: bool, callback: ThreadsafeFunction<String>) -> Self {
+    pub fn new(level: &str, log_queries: bool, callback: Arc<ThreadsafeFunction<String>>) -> Self {
         let mut filter = EnvFilter::new(level);
 
         if log_queries {
@@ -54,7 +54,7 @@ impl ChannelLogger {
 
     /// Creates a new instance of a logger with the `trace` minimum level.
     /// Enables tracing events to OTLP endpoint.
-    pub fn new_with_telemetry(callback: ThreadsafeFunction<String>, endpoint: Option<String>) -> Self {
+    pub fn new_with_telemetry(callback: Arc<ThreadsafeFunction<String>>, endpoint: Option<String>) -> Self {
         let javascript_cb = EventChannel::new(callback, EnvFilter::new("trace"), true);
 
         global::set_text_map_propagator(TraceContextPropagator::new());

--- a/query-engine/query-engine-node-api/src/logger/channel.rs
+++ b/query-engine/query-engine-node-api/src/logger/channel.rs
@@ -8,13 +8,13 @@ use tracing_subscriber::{layer::Context, registry::LookupSpan, EnvFilter, Layer}
 
 #[derive(Clone)]
 pub struct EventChannel {
-    callback: ThreadsafeFunction<String>,
+    callback: Arc<ThreadsafeFunction<String>>,
     telemetry: bool,
     filter: Arc<EnvFilter>,
 }
 
 impl EventChannel {
-    pub fn new(callback: ThreadsafeFunction<String>, filter: EnvFilter, telemetry: bool) -> Self {
+    pub fn new(callback: Arc<ThreadsafeFunction<String>>, filter: EnvFilter, telemetry: bool) -> Self {
         Self {
             callback,
             telemetry,
@@ -43,7 +43,8 @@ where
         let js_object = Value::Object(object);
         let json_str = serde_json::to_string(&js_object).unwrap();
 
-        self.callback.call(Ok(json_str), ThreadsafeFunctionCallMode::Blocking);
+        self.callback
+            .call(Ok(json_str), ThreadsafeFunctionCallMode::NonBlocking);
     }
 
     fn enabled(&self, metadata: &tracing::Metadata<'_>, ctx: Context<'_, S>) -> bool {


### PR DESCRIPTION
Leave the callback function reference to the node env, so we empty it correctly on exit. This should fix https://github.com/prisma/prisma/issues/8989 together with a client change that sets `this.engine = undefined` when `$disconnect()` is called.