### PR TITLE
Deterministic foreign key introspection ordering

### DIFF
--- a/introspection-engine/introspection-engine-tests/tests/relations/mod.rs
+++ b/introspection-engine/introspection-engine-tests/tests/relations/mod.rs
@@ -7,6 +7,7 @@ use expect_test::expect;
 use indoc::formatdoc;
 use indoc::indoc;
 use introspection_engine_tests::test_api::*;
+use quaint::prelude::Queryable;
 use test_macros::test_connector;
 
 #[test_connector(exclude(Mssql, Mysql, Sqlite))]
@@ -795,6 +796,48 @@ async fn one_to_one_req_relation_with_custom_fk_name(api: &TestApi) -> TestResul
     "#]];
 
     expected.assert_eq(&api.introspect_dml().await?);
+
+    Ok(())
+}
+
+#[test_connector(tags(Mysql57))]
+async fn multiple_foreign_key_constraints_are_taken_always_in_the_same_order(api: &TestApi) -> TestResult {
+    let migration = indoc! {r#"
+        CREATE TABLE A
+        (
+            id  int primary key,
+            foo int not null
+        );
+
+        CREATE TABLE B
+        (
+            id int primary key
+        );
+
+        ALTER TABLE A ADD CONSTRAINT fk_1 FOREIGN KEY (foo) REFERENCES B(id) ON DELETE CASCADE ON UPDATE CASCADE;
+        ALTER TABLE A ADD CONSTRAINT fk_2 FOREIGN KEY (foo) REFERENCES B(id) ON DELETE RESTRICT ON UPDATE RESTRICT;       
+    "#};
+
+    api.database().raw_cmd(migration).await?;
+
+    let expected = expect![[r#"
+        model A {
+          id  Int @id
+          foo Int
+          B   B   @relation(fields: [foo], references: [id], onDelete: Cascade)
+
+          @@index([foo], map: "fk_2")
+        }
+
+        model B {
+          id Int @id
+          A  A[]
+        }
+    "#]];
+
+    for _ in 0..10 {
+        expected.assert_eq(&api.introspect_dml().await?);
+    }
 
     Ok(())
 }

--- a/libs/sql-schema-describer/src/mysql.rs
+++ b/libs/sql-schema-describer/src/mysql.rs
@@ -8,7 +8,7 @@ use quaint::{prelude::Queryable, Value};
 use serde_json::from_str;
 use std::{
     borrow::Cow,
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, HashSet},
 };
 use tracing::trace;
 
@@ -205,9 +205,9 @@ impl<'a> SqlSchemaDescriber<'a> {
     fn get_table(
         &self,
         name: &str,
-        columns: &mut HashMap<String, (Vec<Column>, Vec<Enum>)>,
-        indexes: &mut HashMap<String, (BTreeMap<String, Index>, Option<PrimaryKey>)>,
-        foreign_keys: &mut HashMap<String, Vec<ForeignKey>>,
+        columns: &mut BTreeMap<String, (Vec<Column>, Vec<Enum>)>,
+        indexes: &mut BTreeMap<String, (BTreeMap<String, Index>, Option<PrimaryKey>)>,
+        foreign_keys: &mut BTreeMap<String, Vec<ForeignKey>>,
     ) -> (Table, Vec<Enum>) {
         let (columns, enums) = columns.remove(name).unwrap_or((vec![], vec![]));
         let (indices, primary_key) = indexes.remove(name).unwrap_or_else(|| (BTreeMap::new(), None));
@@ -230,7 +230,7 @@ impl<'a> SqlSchemaDescriber<'a> {
         conn: &dyn Queryable,
         schema_name: &str,
         flavour: &Flavour,
-    ) -> DescriberResult<HashMap<String, (Vec<Column>, Vec<Enum>)>> {
+    ) -> DescriberResult<BTreeMap<String, (Vec<Column>, Vec<Enum>)>> {
         // We alias all the columns because MySQL column names are case-insensitive in queries, but the
         // information schema column names became upper-case in MySQL 8, causing the code fetching
         // the result values by column name below to fail.
@@ -252,7 +252,7 @@ impl<'a> SqlSchemaDescriber<'a> {
             ORDER BY ordinal_position
         ";
 
-        let mut map = HashMap::new();
+        let mut map = BTreeMap::new();
 
         let rows = conn.query_raw(sql, &[schema_name.into()]).await?;
 
@@ -415,8 +415,8 @@ impl<'a> SqlSchemaDescriber<'a> {
     async fn get_all_indexes(
         conn: &dyn Queryable,
         schema_name: &str,
-    ) -> DescriberResult<HashMap<String, (BTreeMap<String, Index>, Option<PrimaryKey>)>> {
-        let mut map = HashMap::new();
+    ) -> DescriberResult<BTreeMap<String, (BTreeMap<String, Index>, Option<PrimaryKey>)>> {
+        let mut map = BTreeMap::new();
         let mut indexes_with_expressions: HashSet<(String, String)> = HashSet::new();
         let mut indexes_with_partially_covered_columns: HashSet<(String, String)> = HashSet::new();
 
@@ -523,10 +523,10 @@ impl<'a> SqlSchemaDescriber<'a> {
     async fn get_foreign_keys(
         conn: &dyn Queryable,
         schema_name: &str,
-    ) -> DescriberResult<HashMap<String, Vec<ForeignKey>>> {
+    ) -> DescriberResult<BTreeMap<String, Vec<ForeignKey>>> {
         // Foreign keys covering multiple columns will return multiple rows, which we need to
         // merge.
-        let mut map: HashMap<String, HashMap<String, ForeignKey>> = HashMap::new();
+        let mut map: BTreeMap<String, BTreeMap<String, ForeignKey>> = BTreeMap::new();
 
         // XXX: Is constraint_name unique? Need a way to uniquely associate rows with foreign keys
         // One should think it's unique since it's used to join information_schema.key_column_usage


### PR DESCRIPTION
On MySQL it is possible to create multiple foreign keys to the same columns. In this change we describe them in an order that is deterministic, helping our CI to be a bit more sane.

Closes: https://github.com/prisma/prisma/issues/8975