### PR TITLE
Explicit refer/unref the log_callback in QueryEngine

### DIFF
--- a/query-engine/query-engine-node-api/Cargo.toml
+++ b/query-engine/query-engine-node-api/Cargo.toml
@@ -19,7 +19,7 @@ user-facing-errors = { path = "../../libs/user-facing-errors" }
 datamodel = { path = "../../libs/datamodel/core" }
 sql-connector = { path = "../connectors/sql-query-connector", package = "sql-query-connector" }
 prisma-models = { path = "../../libs/prisma-models" }
-napi = { version = "1.7.3", default-features = false, features = ["napi4", "tokio_rt", "serde-json"] }
+napi = { version = "1.7.6", default-features = false, features = ["napi4", "tokio_rt", "serde-json"] }
 napi-derive = "1"
 thiserror = "1"
 connection-string = "0.1"

--- a/query-engine/query-engine-node-api/src/engine.rs
+++ b/query-engine/query-engine-node-api/src/engine.rs
@@ -1,6 +1,6 @@
 use crate::{error::ApiError, logger::ChannelLogger};
 use datamodel::{diagnostics::ValidatedConfiguration, Datamodel};
-use napi::threadsafe_function::ThreadsafeFunction;
+use napi::{threadsafe_function::ThreadsafeFunction, Env};
 use opentelemetry::global;
 use prisma_models::DatamodelConverter;
 use query_core::{executor, schema_builder, BuildMode, QueryExecutor, QuerySchema, QuerySchemaRenderer, TxId};
@@ -21,6 +21,8 @@ use tracing_opentelemetry::OpenTelemetrySpanExt;
 #[derive(Clone)]
 pub struct QueryEngine {
     inner: Arc<RwLock<Inner>>,
+    // Store the `log_callback` here to perform `release` when disconnecting
+    log_callback: Arc<ThreadsafeFunction<String>>,
 }
 
 /// The state of the engine.
@@ -108,7 +110,7 @@ pub struct TelemetryOptions {
 
 impl QueryEngine {
     /// Parse a validated datamodel and configuration to allow connecting later on.
-    pub fn new(opts: ConstructorOptions, log_callback: ThreadsafeFunction<String>) -> crate::Result<Self> {
+    pub fn new(opts: ConstructorOptions, log_callback: Arc<ThreadsafeFunction<String>>) -> crate::Result<Self> {
         set_panic_hook();
 
         let ConstructorOptions {
@@ -154,9 +156,9 @@ impl QueryEngine {
         };
 
         let logger = if telemetry.enabled {
-            ChannelLogger::new_with_telemetry(log_callback, telemetry.endpoint)
+            ChannelLogger::new_with_telemetry(log_callback.clone(), telemetry.endpoint)
         } else {
-            ChannelLogger::new(&log_level, log_queries, log_callback)
+            ChannelLogger::new(&log_level, log_queries, log_callback.clone())
         };
 
         let builder = EngineBuilder {
@@ -169,7 +171,15 @@ impl QueryEngine {
 
         Ok(Self {
             inner: Arc::new(RwLock::new(Inner::Builder(builder))),
+            log_callback,
         })
+    }
+
+    pub fn ref_log_callback(&mut self, env: &Env) -> napi::Result<()> {
+        // It's safe to call `Arc::make_mut` here
+        // Because this function is called from the Node.js process, which is single thread
+        Arc::make_mut(&mut self.log_callback).refer(env)?;
+        Ok(())
     }
 
     /// Connect to the database, allow queries to be run.
@@ -231,6 +241,15 @@ impl QueryEngine {
             }
             Inner::Connected(_) => Err(ApiError::AlreadyConnected),
         }
+    }
+
+    // call this function before `connect`
+    // Or the `log_callback` will prevent the Node.js process to exit
+    pub fn unref_log_callback(&mut self, env: &Env) -> napi::Result<()> {
+        // It's safe to call `Arc::make_mut` here
+        // Because this function is called from the Node.js process, which is single thread
+        Arc::make_mut(&mut self.log_callback).unref(env)?;
+        Ok(())
     }
 
     /// Disconnect and drop the core. Can be reconnected later with `#connect`.

--- a/query-engine/query-engine-node-api/src/logger.rs
+++ b/query-engine/query-engine-node-api/src/logger.rs
@@ -37,7 +37,7 @@ pub struct ChannelLogger {
 
 impl ChannelLogger {
     /// Creates a new instance of a logger with the minimum log level.
-    pub fn new(level: &str, log_queries: bool, callback: ThreadsafeFunction<String>) -> Self {
+    pub fn new(level: &str, log_queries: bool, callback: Arc<ThreadsafeFunction<String>>) -> Self {
         let mut filter = EnvFilter::new(level);
 
         if log_queries {
@@ -57,7 +57,7 @@ impl ChannelLogger {
 
     /// Creates a new instance of a logger with the `trace` minimum level.
     /// Enables tracing events to OTLP endpoint.
-    pub fn new_with_telemetry(callback: ThreadsafeFunction<String>, endpoint: Option<String>) -> Self {
+    pub fn new_with_telemetry(callback: Arc<ThreadsafeFunction<String>>, endpoint: Option<String>) -> Self {
         let javascript_cb = EventChannel::new(callback, EnvFilter::new("trace"), true);
 
         global::set_text_map_propagator(TraceContextPropagator::new());

--- a/query-engine/query-engine-node-api/src/logger/channel.rs
+++ b/query-engine/query-engine-node-api/src/logger/channel.rs
@@ -8,13 +8,13 @@ use tracing_subscriber::{layer::Context, registry::LookupSpan, EnvFilter, Layer}
 
 #[derive(Clone)]
 pub struct EventChannel {
-    callback: ThreadsafeFunction<String>,
+    callback: Arc<ThreadsafeFunction<String>>,
     telemetry: bool,
     filter: Arc<EnvFilter>,
 }
 
 impl EventChannel {
-    pub fn new(callback: ThreadsafeFunction<String>, filter: EnvFilter, telemetry: bool) -> Self {
+    pub fn new(callback: Arc<ThreadsafeFunction<String>>, filter: EnvFilter, telemetry: bool) -> Self {
         Self {
             callback,
             telemetry,
@@ -43,7 +43,8 @@ where
         let js_object = Value::Object(object);
         let json_str = serde_json::to_string(&js_object).unwrap();
 
-        self.callback.call(Ok(json_str), ThreadsafeFunctionCallMode::Blocking);
+        self.callback
+            .call(Ok(json_str), ThreadsafeFunctionCallMode::NonBlocking);
     }
 
     fn enabled(&self, metadata: &tracing::Metadata<'_>, ctx: Context<'_, S>) -> bool {


### PR DESCRIPTION
After this pull request, the `log_callback` will not be `clone` while `QueryEngine` being cloned. And the ref count of the `log_callback` is always be `0` (initialized/disconnected) or `1` (connected). And Node.js process will not exit unless the `disconnect`  explicit called.