### PR TITLE
chore: remove deprecated aggregations

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/sum.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/sum.rs
@@ -8,8 +8,8 @@ mod aggregation_sum {
     #[connector_test(exclude(MongoDb))]
     async fn sum_no_records(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
-          run_query!(&runner, "query { aggregateTestModel { sum { int bInt float decimal } } }"),
-          @r###"{"data":{"aggregateTestModel":{"sum":{"int":null,"bInt":null,"float":null,"decimal":null}}}}"###
+          run_query!(&runner, "query { aggregateTestModel { _sum { int bInt float decimal } } }"),
+          @r###"{"data":{"aggregateTestModel":{"_sum":{"int":null,"bInt":null,"float":null,"decimal":null}}}}"###
         );
 
         Ok(())
@@ -24,9 +24,9 @@ mod aggregation_sum {
         insta::assert_snapshot!(
             run_query!(
                 runner,
-                "query { aggregateTestModel { sum { int bInt float decimal } } }"
+                "query { aggregateTestModel { _sum { int bInt float decimal } } }"
             ),
-            @r###"{"data":{"aggregateTestModel":{"sum":{"int":15,"bInt":"15","float":10.0,"decimal":"10"}}}}"###
+            @r###"{"data":{"aggregateTestModel":{"_sum":{"int":15,"bInt":"15","float":10.0,"decimal":"10"}}}}"###
         );
 
         Ok(())
@@ -41,33 +41,33 @@ mod aggregation_sum {
         create_row(&runner, r#"{ id: 4, float: 0.0, int: 1, decimal: "0.0", bInt: "1" }"#).await?;
 
         insta::assert_snapshot!(
-            run_query!(&runner, "query { aggregateTestModel(take: 2) { sum { int bInt float decimal } } }"),
-            @r###"{"data":{"aggregateTestModel":{"sum":{"int":15,"bInt":"15","float":10.0,"decimal":"10"}}}}"###
+            run_query!(&runner, "query { aggregateTestModel(take: 2) { _sum { int bInt float decimal } } }"),
+            @r###"{"data":{"aggregateTestModel":{"_sum":{"int":15,"bInt":"15","float":10.0,"decimal":"10"}}}}"###
         );
 
         insta::assert_snapshot!(
-            run_query!(&runner, "query { aggregateTestModel(take: 5) { sum { int bInt float decimal } } }"),
-            @r###"{"data":{"aggregateTestModel":{"sum":{"int":18,"bInt":"18","float":11.5,"decimal":"11.5"}}}}"###
+            run_query!(&runner, "query { aggregateTestModel(take: 5) { _sum { int bInt float decimal } } }"),
+            @r###"{"data":{"aggregateTestModel":{"_sum":{"int":18,"bInt":"18","float":11.5,"decimal":"11.5"}}}}"###
         );
 
         insta::assert_snapshot!(
-            run_query!(&runner, "query { aggregateTestModel(take: -5) { sum { int bInt float decimal } } }"),
-            @r###"{"data":{"aggregateTestModel":{"sum":{"int":18,"bInt":"18","float":11.5,"decimal":"11.5"}}}}"###
+            run_query!(&runner, "query { aggregateTestModel(take: -5) { _sum { int bInt float decimal } } }"),
+            @r###"{"data":{"aggregateTestModel":{"_sum":{"int":18,"bInt":"18","float":11.5,"decimal":"11.5"}}}}"###
         );
 
         insta::assert_snapshot!(
-            run_query!(&runner, r#"query { aggregateTestModel(where: { id: { gt: 2 }}) { sum { int bInt float decimal } } }"#),
-            @r###"{"data":{"aggregateTestModel":{"sum":{"int":3,"bInt":"3","float":1.5,"decimal":"1.5"}}}}"###
+            run_query!(&runner, r#"query { aggregateTestModel(where: { id: { gt: 2 }}) { _sum { int bInt float decimal } } }"#),
+            @r###"{"data":{"aggregateTestModel":{"_sum":{"int":3,"bInt":"3","float":1.5,"decimal":"1.5"}}}}"###
         );
 
         insta::assert_snapshot!(
-            run_query!(&runner, "query { aggregateTestModel(skip: 2) { sum { int bInt float decimal } } }"),
-            @r###"{"data":{"aggregateTestModel":{"sum":{"int":3,"bInt":"3","float":1.5,"decimal":"1.5"}}}}"###
+            run_query!(&runner, "query { aggregateTestModel(skip: 2) { _sum { int bInt float decimal } } }"),
+            @r###"{"data":{"aggregateTestModel":{"_sum":{"int":3,"bInt":"3","float":1.5,"decimal":"1.5"}}}}"###
         );
 
         insta::assert_snapshot!(
-            run_query!(&runner, r#"query { aggregateTestModel(cursor: { id: 3 }) { sum { int bInt float decimal } } }"#),
-            @r###"{"data":{"aggregateTestModel":{"sum":{"int":3,"bInt":"3","float":1.5,"decimal":"1.5"}}}}"###
+            run_query!(&runner, r#"query { aggregateTestModel(cursor: { id: 3 }) { _sum { int bInt float decimal } } }"#),
+            @r###"{"data":{"aggregateTestModel":{"_sum":{"int":3,"bInt":"3","float":1.5,"decimal":"1.5"}}}}"###
         );
 
         Ok(())

--- a/query-engine/core/src/query_graph_builder/extractors/filters/scalar.rs
+++ b/query-engine/core/src/query_graph_builder/extractors/filters/scalar.rs
@@ -258,13 +258,6 @@ fn parse_internal_scalar(
         aggregations::UNDERSCORE_MIN => aggregation_filter(field, input, reverse, Filter::min),
         aggregations::UNDERSCORE_MAX => aggregation_filter(field, input, reverse, Filter::max),
 
-        // Deprecated aggregation filters
-        aggregations::COUNT => aggregation_filter(field, input, reverse, Filter::count),
-        aggregations::AVG => aggregation_filter(field, input, reverse, Filter::average),
-        aggregations::SUM => aggregation_filter(field, input, reverse, Filter::sum),
-        aggregations::MIN => aggregation_filter(field, input, reverse, Filter::min),
-        aggregations::MAX => aggregation_filter(field, input, reverse, Filter::max),
-
         _ => {
             return Err(QueryGraphBuilderError::InputError(format!(
                 "{} is not a valid scalar filter operation",

--- a/query-engine/core/src/query_graph_builder/extractors/query_arguments.rs
+++ b/query-engine/core/src/query_graph_builder/extractors/query_arguments.rs
@@ -153,7 +153,7 @@ fn process_order_object(
 
 fn extract_sort_aggregation(field_name: &str) -> QueryGraphBuilderResult<SortAggregation> {
     match field_name {
-        aggregations::COUNT | aggregations::UNDERSCORE_COUNT => Ok(SortAggregation::Count),
+        aggregations::UNDERSCORE_COUNT => Ok(SortAggregation::Count),
         aggregations::UNDERSCORE_AVG => Ok(SortAggregation::Avg),
         aggregations::UNDERSCORE_SUM => Ok(SortAggregation::Sum),
         aggregations::UNDERSCORE_MIN => Ok(SortAggregation::Min),

--- a/query-engine/core/src/schema_builder/constants.rs
+++ b/query-engine/core/src/schema_builder/constants.rs
@@ -132,7 +132,4 @@ pub mod output_fields {
     pub const AFFECTED_COUNT: &str = "count";
 }
 
-pub mod deprecation {
-    pub const AGGR_DEPRECATION: &str =
-        "Aggregation keywords got unified to use underscore as prefix to prevent field clashes.";
-}
+pub mod deprecation {}

--- a/query-engine/core/src/schema_builder/input_types/field_filter_types.rs
+++ b/query-engine/core/src/schema_builder/input_types/field_filter_types.rs
@@ -1,5 +1,5 @@
 use super::*;
-use constants::{aggregations, deprecation, filters};
+use constants::{aggregations, filters};
 use datamodel_connector::ConnectorCapability;
 use prisma_models::{dml::DefaultValue, PrismaValue};
 
@@ -216,14 +216,6 @@ fn full_scalar_filter_type(
             list,
         ));
 
-        fields.push(
-            aggregate_filter_field(ctx, aggregations::COUNT, &TypeIdentifier::Int, nullable, list).deprecate(
-                deprecation::AGGR_DEPRECATION,
-                "2.23",
-                None,
-            ),
-        );
-
         if typ.is_numeric() {
             let avg_type = map_avg_type_ident(typ.clone());
             fields.push(aggregate_filter_field(
@@ -234,14 +226,6 @@ fn full_scalar_filter_type(
                 list,
             ));
 
-            fields.push(
-                aggregate_filter_field(ctx, aggregations::AVG, &avg_type, nullable, list).deprecate(
-                    deprecation::AGGR_DEPRECATION,
-                    "2.23",
-                    None,
-                ),
-            );
-
             fields.push(aggregate_filter_field(
                 ctx,
                 aggregations::UNDERSCORE_SUM,
@@ -249,14 +233,6 @@ fn full_scalar_filter_type(
                 nullable,
                 list,
             ));
-
-            fields.push(
-                aggregate_filter_field(ctx, aggregations::SUM, typ, nullable, list).deprecate(
-                    deprecation::AGGR_DEPRECATION,
-                    "2.23",
-                    None,
-                ),
-            );
         }
 
         if !list {
@@ -267,13 +243,6 @@ fn full_scalar_filter_type(
                 nullable,
                 list,
             ));
-            fields.push(
-                aggregate_filter_field(ctx, aggregations::MIN, typ, nullable, list).deprecate(
-                    deprecation::AGGR_DEPRECATION,
-                    "2.23",
-                    None,
-                ),
-            );
 
             fields.push(aggregate_filter_field(
                 ctx,
@@ -282,13 +251,6 @@ fn full_scalar_filter_type(
                 nullable,
                 list,
             ));
-            fields.push(
-                aggregate_filter_field(ctx, aggregations::MAX, typ, nullable, list).deprecate(
-                    deprecation::AGGR_DEPRECATION,
-                    "2.23",
-                    None,
-                ),
-            );
         }
     }
 

--- a/query-engine/core/src/schema_builder/input_types/objects/order_by_objects.rs
+++ b/query-engine/core/src/schema_builder/input_types/objects/order_by_objects.rs
@@ -1,5 +1,5 @@
 use super::*;
-use constants::{aggregations, deprecation, ordering};
+use constants::{aggregations, ordering};
 use output_types::aggregation;
 
 /// Builds "<Model>OrderByInput" object types.
@@ -192,17 +192,12 @@ fn order_by_object_type_rel_aggregate(
     let input_object = Arc::new(input_object);
     ctx.cache_input_type(ident, input_object.clone());
 
-    let fields = vec![
-        input_field(
-            aggregations::UNDERSCORE_COUNT,
-            InputType::Enum(ordering_enum.clone()),
-            None,
-        )
-        .optional(),
-        input_field(aggregations::COUNT, InputType::Enum(ordering_enum.clone()), None)
-            .deprecate(deprecation::AGGR_DEPRECATION, "2.23", None)
-            .optional(),
-    ];
+    let fields = vec![input_field(
+        aggregations::UNDERSCORE_COUNT,
+        InputType::Enum(ordering_enum.clone()),
+        None,
+    )
+    .optional()];
 
     input_object.set_fields(fields);
 

--- a/query-engine/core/src/schema_builder/output_types/aggregation/plain.rs
+++ b/query-engine/core/src/schema_builder/output_types/aggregation/plain.rs
@@ -1,4 +1,4 @@
-use crate::constants::{aggregations::*, deprecation::*};
+use crate::constants::aggregations::*;
 
 use super::*;
 use std::convert::identity;
@@ -36,23 +36,6 @@ pub(crate) fn aggregation_object_type(ctx: &mut BuilderContext, model: &ModelRef
         &mut object_fields,
         aggregation_field(
             ctx,
-            COUNT,
-            &model,
-            model.fields().scalar(),
-            |_, _| OutputType::int(),
-            |mut obj| {
-                obj.add_field(field("_all", vec![], OutputType::int(), None));
-                obj
-            },
-            true,
-        )
-        .map(|f| f.deprecate(AGGR_DEPRECATION, "2.23", None)),
-    );
-
-    append_opt(
-        &mut object_fields,
-        aggregation_field(
-            ctx,
             UNDERSCORE_AVG,
             &model,
             numeric_fields.clone(),
@@ -60,20 +43,6 @@ pub(crate) fn aggregation_object_type(ctx: &mut BuilderContext, model: &ModelRef
             identity,
             false,
         ),
-    );
-
-    append_opt(
-        &mut object_fields,
-        aggregation_field(
-            ctx,
-            AVG,
-            &model,
-            numeric_fields.clone(),
-            field_avg_output_type,
-            identity,
-            false,
-        )
-        .map(|f| f.deprecate(AGGR_DEPRECATION, "2.23", None)),
     );
 
     append_opt(
@@ -93,20 +62,6 @@ pub(crate) fn aggregation_object_type(ctx: &mut BuilderContext, model: &ModelRef
         &mut object_fields,
         aggregation_field(
             ctx,
-            SUM,
-            &model,
-            numeric_fields,
-            map_scalar_output_type_for_field,
-            identity,
-            false,
-        )
-        .map(|f| f.deprecate(AGGR_DEPRECATION, "2.23", None)),
-    );
-
-    append_opt(
-        &mut object_fields,
-        aggregation_field(
-            ctx,
             UNDERSCORE_MIN,
             &model,
             non_list_nor_json_fields.clone(),
@@ -120,20 +75,6 @@ pub(crate) fn aggregation_object_type(ctx: &mut BuilderContext, model: &ModelRef
         &mut object_fields,
         aggregation_field(
             ctx,
-            MIN,
-            &model,
-            non_list_nor_json_fields.clone(),
-            map_scalar_output_type_for_field,
-            identity,
-            false,
-        )
-        .map(|f| f.deprecate(AGGR_DEPRECATION, "2.23", None)),
-    );
-
-    append_opt(
-        &mut object_fields,
-        aggregation_field(
-            ctx,
             UNDERSCORE_MAX,
             &model,
             non_list_nor_json_fields.clone(),
@@ -141,20 +82,6 @@ pub(crate) fn aggregation_object_type(ctx: &mut BuilderContext, model: &ModelRef
             identity,
             false,
         ),
-    );
-
-    append_opt(
-        &mut object_fields,
-        aggregation_field(
-            ctx,
-            MAX,
-            &model,
-            non_list_nor_json_fields,
-            map_scalar_output_type_for_field,
-            identity,
-            false,
-        )
-        .map(|f| f.deprecate(AGGR_DEPRECATION, "2.23", None)),
     );
 
     object.set_fields(object_fields);


### PR DESCRIPTION
## Overview

BREAKING CHANGE: Remove deprecated `count`, `min`, `max`, `sum`, `avg` aggregations and `count` order by aggregate.

Their equivalent `_count`, `_min`, `_max`, `_sum` and `_avg` are still available.