### PR TITLE
fix: one2m relation count with duplicate children id

### DIFF
--- a/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
@@ -51,7 +51,7 @@ pub async fn m2m(
     // - there is no additional filter
     // - there is no aggregation selection
     // - the selection set is the child_link_id
-    let scalars =
+    let mut scalars =
         if query.args.do_nothing() && query.aggregation_selections.is_empty() && child_link_id == query.selected_fields
         {
             ManyRecords::from_projection(child_ids, &query.selected_fields).with_unique_records()
@@ -72,9 +72,6 @@ pub async fn m2m(
             )
             .await?
         };
-
-    let (mut scalars, aggregation_rows) =
-        read::extract_aggregation_rows_from_scalars(scalars.clone(), query.aggregation_selections.clone());
 
     // Child id to parent ids
     let mut id_map: HashMap<RecordProjection, Vec<RecordProjection>> = HashMap::new();
@@ -124,7 +121,11 @@ pub async fn m2m(
         }
     }
 
-    Ok((processor.apply(scalars), aggregation_rows))
+    let scalars = processor.apply(scalars);
+    let (scalars, aggregation_rows) =
+        read::extract_aggregation_rows_from_scalars(scalars, query.aggregation_selections.clone());
+
+    Ok((scalars, aggregation_rows))
 }
 
 // [DTODO] This is implemented in an inefficient fashion, e.g. too much Arc cloning going on.
@@ -200,7 +201,7 @@ pub async fn one2m(
     // - there is no additional filter
     // - there is no aggregation selection
     // - the selection set is the child_link_id
-    let scalars = if query_args.do_nothing() && aggr_selections.is_empty() && &child_link_id == selected_fields {
+    let mut scalars = if query_args.do_nothing() && aggr_selections.is_empty() && &child_link_id == selected_fields {
         ManyRecords::from_projection(uniq_projections, selected_fields).with_unique_records()
     } else {
         let filter = child_link_id.is_in(uniq_projections);
@@ -213,8 +214,6 @@ pub async fn one2m(
         tx.get_many_records(&parent_field.related_model(), args, selected_fields, &aggr_selections)
             .await?
     };
-
-    let (mut scalars, aggregation_rows) = read::extract_aggregation_rows_from_scalars(scalars.clone(), aggr_selections);
 
     // Inlining is done on the parent, this means that we need to write the primary parent ID
     // into the child records that we retrieved. The matching is done based on the parent link values.
@@ -262,5 +261,8 @@ pub async fn one2m(
         );
     }
 
-    Ok((processor.apply(scalars), aggregation_rows))
+    let mut scalars = processor.apply(scalars);
+    let (scalars, aggregation_rows) = read::extract_aggregation_rows_from_scalars(scalars, aggr_selections);
+
+    Ok((scalars, aggregation_rows))
 }

--- a/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
@@ -261,7 +261,7 @@ pub async fn one2m(
         );
     }
 
-    let mut scalars = processor.apply(scalars);
+    let scalars = processor.apply(scalars);
     let (scalars, aggregation_rows) = read::extract_aggregation_rows_from_scalars(scalars, aggr_selections);
 
     Ok((scalars, aggregation_rows))

--- a/query-engine/core/src/interpreter/query_interpreters/read.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/read.rs
@@ -37,7 +37,7 @@ fn read_one(tx: &mut dyn ConnectionLike, query: RecordQuery) -> BoxFuture<'_, In
             Some(record) => {
                 let scalars: ManyRecords = record.into();
                 let (scalars, aggregation_rows) =
-                    extract_aggregation_rows_from_scalars(scalars.clone(), query.aggregation_selections);
+                    extract_aggregation_rows_from_scalars(scalars, query.aggregation_selections);
                 let nested: Vec<QueryResult> = process_nested(tx, query.nested, Some(&scalars)).await?;
 
                 Ok(RecordSelection {
@@ -90,7 +90,7 @@ fn read_many(
                 .await?;
             let scalars = processor.apply(scalars);
             let (scalars, aggregation_rows) =
-                extract_aggregation_rows_from_scalars(scalars.clone(), query.aggregation_selections);
+                extract_aggregation_rows_from_scalars(scalars, query.aggregation_selections);
 
             (scalars, aggregation_rows)
         } else {
@@ -103,7 +103,7 @@ fn read_many(
                 )
                 .await?;
             let (scalars, aggregation_rows) =
-                extract_aggregation_rows_from_scalars(scalars.clone(), query.aggregation_selections);
+                extract_aggregation_rows_from_scalars(scalars, query.aggregation_selections);
             (scalars, aggregation_rows)
         };
 


### PR DESCRIPTION
## Overview

Fixes https://github.com/prisma/prisma/issues/8861

When fetching some one2m related records and there are duplicate children ids, we optimize the query so that we fetch the related record only once and then duplicate it as many times as there are children.

By doing the aggregation extraction too early, we were essentially extracting the aggregation results only once, although there might be N occurrences of that same related record.

Later on, this was causing a panic as there weren't as many aggregation results as there were record selections to serialize.

The issue is fixed by performing the aggregation result extraction _after_ we reconcile/duplicate the records and any kind of logic on the record selection (like in-memory pagination etc). Basically, as the last possible step.