### PR TITLE
New commands to the test-cli tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4409,6 +4409,7 @@ dependencies = [
  "datamodel",
  "enumflags2",
  "introspection-core",
+ "migration-connector",
  "migration-core",
  "serde_json",
  "structopt",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4406,6 +4406,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "colored",
+ "datamodel",
  "enumflags2",
  "introspection-core",
  "migration-core",

--- a/libs/test-cli/Cargo.toml
+++ b/libs/test-cli/Cargo.toml
@@ -12,7 +12,8 @@ colored = "2"
 structopt = "0.3.8"
 enumflags2 = "0.7"
 migration-core = { path = "../../migration-engine/core" }
-introspection-core = { path = "../../introspection-engine/core"}
+introspection-core = { path = "../../introspection-engine/core" }
+datamodel = { path = "../../libs/datamodel/core" }
 tokio = "1.0"
 serde_json = { version = "1.0", features = ["float_roundtrip"] }
 tracing = "0.1.15"

--- a/libs/test-cli/Cargo.toml
+++ b/libs/test-cli/Cargo.toml
@@ -12,6 +12,7 @@ colored = "2"
 structopt = "0.3.8"
 enumflags2 = "0.7"
 migration-core = { path = "../../migration-engine/core" }
+migration-connector = { path = "../../migration-engine/connectors/migration-connector" }
 introspection-core = { path = "../../introspection-engine/core" }
 datamodel = { path = "../../libs/datamodel/core" }
 tokio = "1.0"

--- a/migration-engine/core/src/api.rs
+++ b/migration-engine/core/src/api.rs
@@ -1,7 +1,7 @@
 //! The external facing programmatic API to the migration engine.
 
 use crate::{commands::*, CoreResult};
-use migration_connector::{migrations_directory, MigrationConnector};
+use migration_connector::{migrations_directory, DestructiveChangeDiagnostics, DiffTarget, MigrationConnector};
 use std::path::Path;
 use tracing_futures::Instrument;
 
@@ -56,6 +56,12 @@ pub trait GenericApi: Send + Sync + 'static {
 
     /// The command behind `prisma db push`.
     async fn schema_push(&self, input: &SchemaPushInput) -> CoreResult<SchemaPushOutput>;
+
+    /// Creates a migration between two targets.
+    async fn migration_diff(&self, schema: &str) -> CoreResult<String>;
+
+    /// Lists the DDL of the given schema against the database.
+    async fn migration_ddl(&self, schema: &str) -> CoreResult<String>;
 }
 
 #[async_trait::async_trait]
@@ -160,5 +166,34 @@ impl<C: MigrationConnector> GenericApi for C {
         schema_push(input, self)
             .instrument(tracing::info_span!("SchemaPush"))
             .await
+    }
+
+    async fn migration_diff(&self, schema: &str) -> CoreResult<String> {
+        let (configuration, datamodel) = crate::parse_schema(schema)?;
+
+        let migration = self
+            .diff(
+                DiffTarget::Database,
+                DiffTarget::Datamodel((&configuration, &datamodel)),
+            )
+            .await?;
+
+        Ok(self.migration_summary(&migration))
+    }
+
+    async fn migration_ddl(&self, schema: &str) -> CoreResult<String> {
+        let (configuration, datamodel) = crate::parse_schema(schema)?;
+        let applier = self.database_migration_step_applier();
+
+        let migration = self
+            .diff(
+                DiffTarget::Database,
+                DiffTarget::Datamodel((&configuration, &datamodel)),
+            )
+            .await?;
+
+        let script = applier.render_script(&migration, &DestructiveChangeDiagnostics::default());
+
+        Ok(script)
     }
 }

--- a/migration-engine/core/src/native/rpc.rs
+++ b/migration-engine/core/src/native/rpc.rs
@@ -48,6 +48,7 @@ pub async fn rpc_api(datamodel: &str) -> CoreResult<IoHandler> {
     Ok(io_handler)
 }
 
+#[allow(clippy::redundant_allocation)]
 async fn run_command(
     executor: Arc<Box<dyn GenericApi>>,
     cmd: &str,


### PR DESCRIPTION
Introducing five new commands to the test-cli command for day to day development use:

## Diffing

Command `migrate-diff` compares the given data model to the database it points to, printing out a list of changes or the DDL to modify the database.

```prisma
datasource db {
  provider = "postgres"
  url      = "postgres://postgres:prisma@localhost:5435/postgres"
}

model Album {
  id       Int     @id @default(autoincrement())
  tracks   Track[]
}

model Track {
  id      Int   @id @default(autoincrement())
  albumId Int
  album   Album @relation(fields: [albumId], references: [id], onDelete: Cascade, onUpdate: Cascade)
}
```

```bash
> cargo run --bin test-cli -- migrate-diff datamodel_v2.prisma

[+] Added tables
  - Album
  - Track

[*] Changed the `Track` table
  [+] Added foreign key on columns (albumId)
```

```bash
> cargo run --bin test-cli -- migrate-diff --output-type ddl datamodel_v2.prisma

-- CreateTable
CREATE TABLE "Album" (
    "id" SERIAL NOT NULL,

    CONSTRAINT "Album_pkey" PRIMARY KEY ("id")
);

-- CreateTable
CREATE TABLE "Track" (
    "id" SERIAL NOT NULL,
    "albumId" INTEGER NOT NULL,

    CONSTRAINT "Track_pkey" PRIMARY KEY ("id")
);

-- AddForeignKey
ALTER TABLE "Track" ADD CONSTRAINT "Track_albumId_fkey" FOREIGN KEY ("albumId") REFERENCES "Album"("id") ON DELETE CASCADE ON UPDATE CASCADE;
```

## Validation

Just a quick command to see if the given data model is valid, printing out errors if any.

```prisma
datasource db {
  provider = "postgres"
  url      = "postgres://postgres:prisma@localhost:5435/postgres"
}

model Album {
  id       Int     @id @default(autoincrement())
}

model Track {
  id      Int   @id @default(autoincrement())
  albumId Int
  album   Album @relation(fields: [albumId], references: [id], onDelete: Cascade, onUpdate: Cascade)
}
```

```bash
> cargo run --bin test-cli -- validate-datamodel datamodel_v2.prisma

Error: error: Error validating field `album` in model `Track`: The relation field `album` on Model `Track` is missing an opposite relation field on the model `Album`. Either run `prisma format` or add it manually.
  -->  schema.prisma:13
   | 
12 |   albumId Int
13 |   album   Album @relation(fields: [albumId], references: [id], onDelete: Cascade, onUpdate: Cascade)
14 | }
   | 
```

## Create migration

Creates a new migration directory + file, comparing the database and given data model.

```prisma
datasource db {
  provider = "postgres"
  url      = "postgres://postgres:prisma@localhost:5435/postgres"
}

model Album {
  id       Int     @id @default(autoincrement())
}
```

```bash
> cargo run --bin test-cli -- create-migration migrations datamodel_v2.prisma init
> ls -l migrations

drwxr-xr-x   - pimeys 10 Sep 17:25 -N  20210910152557_init
.rw-r--r-- 126 pimeys 10 Sep 17:25 -N  migration_lock.toml

> cat migrations/20210910152557_init/migration.sql 
-- CreateTable
CREATE TABLE "Album" (
    "id" SERIAL NOT NULL,

    CONSTRAINT "Album_pkey" PRIMARY KEY ("id")
);
```

```prisma
datasource db {
  provider = "postgres"
  url      = "postgres://postgres:prisma@localhost:5435/postgres"
}

model Album {
  id       Int     @id @default(autoincrement())
  tracks   Track[]
}

model Track {
  id      Int   @id @default(autoincrement())
  albumId Int
  album   Album @relation(fields: [albumId], references: [id], onDelete: Cascade, onUpdate: Cascade)
}
```

```bash
> cargo run --bin test-cli -- create-migration migrations datamodel_v2.prisma tracks
> ls -l migrations

drwxr-xr-x   - pimeys 10 Sep 17:25 -N  20210910152557_init
drwxr-xr-x   - pimeys 10 Sep 17:28 -N  20210910152805_tracks
.rw-r--r-- 126 pimeys 10 Sep 17:28 -N  migration_lock.toml

> cat migrations/20210910152805_tracks/migration.sql 
-- CreateTable
CREATE TABLE "Track" (
    "id" SERIAL NOT NULL,
    "albumId" INTEGER NOT NULL,

    CONSTRAINT "Track_pkey" PRIMARY KEY ("id")
);

-- AddForeignKey
ALTER TABLE "Track" ADD CONSTRAINT "Track_albumId_fkey" FOREIGN KEY ("albumId") REFERENCES "Album"("id") ON DELETE CASCADE ON UPDATE CASCADE;
```

## Apply migrations

Reads all migrations from the given directory, and applies all unapplied migrations to the database.

```bash
> cargo run --bin test-cli -- apply-migrations migrations/ datamodel_v2.prisma
```

## Reset database

Clears everything from the database defined in the data model.

```bash
> cargo run --bin test-cli -- reset-database datamodel_v2.prisma
```