### PR TITLE
Re-introspection without foreign keys

### DIFF
--- a/introspection-engine/connectors/introspection-connector/src/lib.rs
+++ b/introspection-engine/connectors/introspection-connector/src/lib.rs
@@ -84,3 +84,9 @@ pub struct IntrospectionContext {
     pub source: Datasource,
     pub preview_features: BitFlags<PreviewFeature>,
 }
+
+impl IntrospectionContext {
+    pub fn foreign_keys_enabled(&self) -> bool {
+        self.source.referential_integrity.uses_foreign_keys()
+    }
+}

--- a/introspection-engine/connectors/sql-introspection-connector/src/re_introspection.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/re_introspection.rs
@@ -1,12 +1,44 @@
 use crate::introspection_helpers::replace_field_names;
 use crate::{warnings::*, SqlFamilyTrait};
-use datamodel::{Datamodel, DefaultValue, FieldType, Ignorable, ValueGenerator};
+use datamodel::{Datamodel, DefaultValue, Field, FieldType, Ignorable, ValueGenerator, WithName};
 use introspection_connector::{IntrospectionContext, Warning};
 use prisma_value::PrismaValue;
 use std::cmp::Ordering::{self, Equal, Greater, Less};
+use std::collections::{HashMap, HashSet};
 
 pub fn enrich(old_data_model: &Datamodel, new_data_model: &mut Datamodel, ctx: &IntrospectionContext) -> Vec<Warning> {
     let mut warnings = vec![];
+
+    // Keep @relation attributes even if the database doesn't use foreign keys
+    if !ctx.foreign_keys_enabled() {
+        let models: HashSet<String> = new_data_model.models().map(|m| m.name().to_string()).collect();
+
+        for old_model in old_data_model.models() {
+            if let Some(new_model) = new_data_model.models_mut().find(|m| m.name == *old_model.name()) {
+                let mut ordering: HashMap<String, usize> = old_model
+                    .fields()
+                    .enumerate()
+                    .map(|(i, field)| (field.name().to_string(), i))
+                    .collect();
+
+                for (i, field) in new_model.fields().enumerate() {
+                    if !ordering.contains_key(field.name()) {
+                        ordering.insert(field.name().to_string(), i);
+                    }
+                }
+
+                for field in old_model.relation_fields() {
+                    if models.contains(&field.relation_info.to) {
+                        new_model.add_field(Field::RelationField(field.clone()));
+                    }
+                }
+
+                new_model
+                    .fields
+                    .sort_by_cached_key(|field| *ordering.get(field.name()).unwrap_or(&usize::MAX));
+            }
+        }
+    }
 
     //@@map on models
     let mut changed_model_names = vec![];

--- a/introspection-engine/connectors/sql-introspection-connector/src/re_introspection.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/re_introspection.rs
@@ -620,11 +620,7 @@ fn merge_relation_fields(old_data_model: &Datamodel, new_data_model: &mut Datamo
                 let mut fields = Vec::new();
 
                 for field in old_model.relation_fields() {
-                    if new_data_model
-                        .models()
-                        .find(|m| m.name == field.relation_info.to)
-                        .is_some()
-                    {
+                    if new_data_model.models().any(|m| m.name == field.relation_info.to) {
                         fields.push(Field::RelationField(field.clone()));
                     }
                 }

--- a/introspection-engine/introspection-engine-tests/tests/re_introspection/mod.rs
+++ b/introspection-engine/introspection-engine-tests/tests/re_introspection/mod.rs
@@ -1,6 +1,7 @@
 mod mssql;
 mod mysql;
 mod sqlite;
+mod vitess;
 
 use barrel::types;
 use expect_test::expect;

--- a/introspection-engine/introspection-engine-tests/tests/re_introspection/vitess.rs
+++ b/introspection-engine/introspection-engine-tests/tests/re_introspection/vitess.rs
@@ -1,0 +1,337 @@
+use expect_test::expect;
+use indoc::indoc;
+use introspection_engine_tests::test_api::*;
+use quaint::prelude::Queryable;
+use test_macros::test_connector;
+
+#[test_connector(tags(Vitess), preview_features("referentialIntegrity"))]
+async fn relations_are_not_removed(api: &TestApi) -> TestResult {
+    let dml = indoc! {r#"
+        CREATE TABLE `A` (
+            id INT AUTO_INCREMENT PRIMARY KEY
+        );
+
+        CREATE TABLE `B` (
+            id  INT AUTO_INCREMENT PRIMARY KEY,
+            aId INT NOT NULL
+        );
+    "#};
+
+    api.database().raw_cmd(dml).await?;
+
+    let input_dm = indoc! {r#"
+        model A {
+          id Int @id @default(autoincrement())
+          bs B[]
+        }
+
+        model B {
+          id  Int @id @default(autoincrement())
+          aId Int
+          a   A   @relation(fields: [aId], references: [id])
+        }
+    "#};
+
+    let expected = expect![[r#"
+        model A {
+          id Int @id @default(autoincrement())
+          bs B[]
+        }
+
+        model B {
+          id  Int @id @default(autoincrement())
+          aId Int
+          a   A   @relation(fields: [aId], references: [id])
+        }
+    "#]];
+
+    expected.assert_eq(&api.re_introspect_dml(input_dm).await?);
+
+    Ok(())
+}
+
+#[test_connector(tags(Vitess), preview_features("referentialIntegrity"))]
+async fn relations_field_order_is_kept(api: &TestApi) -> TestResult {
+    let dml = indoc! {r#"
+        CREATE TABLE `A` (
+            id INT AUTO_INCREMENT PRIMARY KEY
+        );
+
+        CREATE TABLE `B` (
+            id  INT AUTO_INCREMENT PRIMARY KEY,
+            aId INT NOT NULL
+        );
+    "#};
+
+    api.database().raw_cmd(dml).await?;
+
+    let input_dm = indoc! {r#"
+        model A {
+          bs B[]
+          id Int @id @default(autoincrement())
+        }
+
+        model B {
+          id  Int @id @default(autoincrement())
+          a   A   @relation(fields: [aId], references: [id])
+          aId Int
+        }
+    "#};
+
+    let expected = expect![[r#"
+        model A {
+          bs B[]
+          id Int @id @default(autoincrement())
+        }
+
+        model B {
+          id  Int @id @default(autoincrement())
+          a   A   @relation(fields: [aId], references: [id])
+          aId Int
+        }
+    "#]];
+
+    expected.assert_eq(&api.re_introspect_dml(input_dm).await?);
+
+    Ok(())
+}
+
+#[test_connector(tags(Vitess), preview_features("referentialIntegrity"))]
+async fn relations_field_order_is_kept_if_having_new_fields(api: &TestApi) -> TestResult {
+    let dml = indoc! {r#"
+        CREATE TABLE `A` (
+            new VARCHAR(255) NOT NULL, 
+            id INT AUTO_INCREMENT PRIMARY KEY
+        );
+
+        CREATE TABLE `B` (
+            id  INT AUTO_INCREMENT PRIMARY KEY,
+            aId INT NOT NULL
+        );
+    "#};
+
+    api.database().raw_cmd(dml).await?;
+
+    let input_dm = indoc! {r#"
+        model A {
+          bs B[]
+          id Int @id @default(autoincrement())
+        }
+
+        model B {
+          id  Int @id @default(autoincrement())
+          a   A   @relation(fields: [aId], references: [id])
+          aId Int
+        }
+    "#};
+
+    let expected = expect![[r#"
+        model A {
+          new String @db.VarChar(255)
+          bs  B[]
+          id  Int    @id @default(autoincrement())
+        }
+
+        model B {
+          id  Int @id @default(autoincrement())
+          a   A   @relation(fields: [aId], references: [id])
+          aId Int
+        }
+    "#]];
+
+    expected.assert_eq(&api.re_introspect_dml(input_dm).await?);
+
+    Ok(())
+}
+
+#[test_connector(tags(Vitess), preview_features("referentialIntegrity"))]
+async fn relations_field_order_is_kept_if_removing_fields(api: &TestApi) -> TestResult {
+    let dml = indoc! {r#"
+        CREATE TABLE `A` (
+            id INT AUTO_INCREMENT PRIMARY KEY
+        );
+
+        CREATE TABLE `B` (
+            id  INT AUTO_INCREMENT PRIMARY KEY,
+            aId INT NOT NULL
+        );
+    "#};
+
+    api.database().raw_cmd(dml).await?;
+
+    let input_dm = indoc! {r#"
+        model A {
+          new String
+          bs  B[]
+          id  Int    @id @default(autoincrement())
+        }
+
+        model B {
+          id  Int @id @default(autoincrement())
+          a   A   @relation(fields: [aId], references: [id])
+          aId Int
+        }
+    "#};
+
+    let expected = expect![[r#"
+        model A {
+          bs B[]
+          id Int @id @default(autoincrement())
+        }
+
+        model B {
+          id  Int @id @default(autoincrement())
+          a   A   @relation(fields: [aId], references: [id])
+          aId Int
+        }
+    "#]];
+
+    expected.assert_eq(&api.re_introspect_dml(input_dm).await?);
+
+    Ok(())
+}
+
+#[test_connector(tags(Vitess), preview_features("referentialIntegrity"))]
+async fn deleting_models_will_delete_relations(api: &TestApi) -> TestResult {
+    let dml = indoc! {r#"
+        CREATE TABLE `A` (
+            id INT AUTO_INCREMENT PRIMARY KEY
+        );
+
+        CREATE TABLE `B` (
+            id  INT AUTO_INCREMENT PRIMARY KEY,
+            aId INT NOT NULL
+        );
+    "#};
+
+    api.database().raw_cmd(dml).await?;
+
+    let input_dm = indoc! {r#"
+        model A {
+          id Int @id @default(autoincrement())
+          bs B[]
+          cs C[]
+        }
+
+        model B {
+          id  Int @id @default(autoincrement())
+          aId Int
+          a   A   @relation(fields: [aId], references: [id])
+        }
+
+        model C {
+          id  Int @id @default(autoincrement())
+          aId Int
+          a   A   @relation(fields: [aId], references: [id])
+        }
+    "#};
+
+    let expected = expect![[r#"
+        model A {
+          id Int @id @default(autoincrement())
+          bs B[]
+        }
+
+        model B {
+          id  Int @id @default(autoincrement())
+          aId Int
+          a   A   @relation(fields: [aId], references: [id])
+        }
+    "#]];
+
+    expected.assert_eq(&api.re_introspect_dml(input_dm).await?);
+
+    Ok(())
+}
+
+#[test_connector(tags(Vitess), preview_features("referentialIntegrity"))]
+async fn field_renames_keeps_the_relation_intact(api: &TestApi) -> TestResult {
+    let dml = indoc! {r#"
+        CREATE TABLE `A` (
+            id INT AUTO_INCREMENT PRIMARY KEY
+        );
+
+        CREATE TABLE `B` (
+            id  INT AUTO_INCREMENT PRIMARY KEY,
+            aId INT NOT NULL
+        );
+    "#};
+
+    api.database().raw_cmd(dml).await?;
+
+    let input_dm = indoc! {r#"
+        model A {
+          id Int @id @default(autoincrement())
+          bs B[]
+        }
+
+        model B {
+          id  Int @id @default(autoincrement())
+          xId Int
+          a   A   @relation(fields: [xId], references: [id])
+        }
+    "#};
+
+    let expected = expect![[r#"
+        model A {
+          id Int @id @default(autoincrement())
+          bs B[]
+        }
+
+        model B {
+          id  Int @id @default(autoincrement())
+          aId Int
+          a   A   @relation(fields: [xId], references: [id])
+        }
+    "#]];
+
+    expected.assert_eq(&api.re_introspect_dml(input_dm).await?);
+
+    Ok(())
+}
+
+#[test_connector(tags(Vitess), preview_features("referentialIntegrity"))]
+async fn referential_actions_are_kept_intact(api: &TestApi) -> TestResult {
+    let dml = indoc! {r#"
+        CREATE TABLE `A` (
+            id INT AUTO_INCREMENT PRIMARY KEY
+        );
+
+        CREATE TABLE `B` (
+            id  INT AUTO_INCREMENT PRIMARY KEY,
+            aId INT NOT NULL
+        );
+    "#};
+
+    api.database().raw_cmd(dml).await?;
+
+    let input_dm = indoc! {r#"
+        model A {
+          id Int @id @default(autoincrement())
+          bs B[]
+        }
+
+        model B {
+          id  Int @id @default(autoincrement())
+          aId Int
+          a   A   @relation(fields: [aId], references: [id], onDelete: SetNull, onUpdate: Restrict)
+        }
+    "#};
+
+    let expected = expect![[r#"
+        model A {
+          id Int @id @default(autoincrement())
+          bs B[]
+        }
+
+        model B {
+          id  Int @id @default(autoincrement())
+          aId Int
+          a   A   @relation(fields: [aId], references: [id], onDelete: SetNull, onUpdate: Restrict)
+        }
+    "#]];
+
+    expected.assert_eq(&api.re_introspect_dml(input_dm).await?);
+
+    Ok(())
+}

--- a/libs/datamodel/core/src/common/constraint_names.rs
+++ b/libs/datamodel/core/src/common/constraint_names.rs
@@ -128,6 +128,11 @@ impl ConstraintNames {
             .fields
             .iter()
             .map(|field_name| {
+                // We cannot unwrap here, due to us re-introspecting relations
+                // and if we're not using foreign keys, we might copy a relation
+                // that is not valid anymore. We still want to write that to the
+                // file and let user fix it, but if we unwrap here, we will
+                // panic.
                 model
                     .find_scalar_field(field_name)
                     .map(|field| field.final_database_name())

--- a/libs/datamodel/core/src/common/constraint_names.rs
+++ b/libs/datamodel/core/src/common/constraint_names.rs
@@ -127,7 +127,12 @@ impl ConstraintNames {
         let column_names: Vec<&str> = ri
             .fields
             .iter()
-            .map(|field_name| model.find_scalar_field(field_name).unwrap().final_database_name())
+            .map(|field_name| {
+                model
+                    .find_scalar_field(field_name)
+                    .map(|field| field.final_database_name())
+                    .unwrap_or(field_name)
+            })
             .collect();
 
         ri.fk_name.as_ref().unwrap()


### PR DESCRIPTION
This change makes re-introspection not overwrite `@relation` attributes, if `referentialIntegrity` is set to `"prisma"` and the database has no foreign keys defined.

Closes: https://github.com/prisma/prisma/issues/7293
Closes: https://github.com/prisma/prisma/issues/8108
Closes: https://github.com/prisma/prisma/issues/9147