### PR TITLE
Expose prisma-fmt as WASM module to JS

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -46,4 +46,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: -p prisma-fmt --release --target=wasm32-unknown-unknown
+          args: -p prisma-fmt --lib --release --target=wasm32-unknown-unknown

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3042,6 +3042,7 @@ dependencies = [
  "serde",
  "serde_json",
  "structopt",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -5141,9 +5142,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.72"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fe8f61dba8e5d645a4d8132dc7a0a66861ed5e1045d2c0ed940fab33bac0fbe"
+checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -5153,9 +5154,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.72"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046ceba58ff062da072c7cb4ba5b22a37f00a302483f7e2a6cdc18fedbdc1fd3"
+checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -5180,9 +5181,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.72"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef9aa01d36cda046f797c57959ff5f3c615c9cc63997a8d545831ec7976819b"
+checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5190,9 +5191,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.72"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96eb45c1b2ee33545a813a92dbb53856418bf7eb54ab34f7f7ff1448a5b3735d"
+checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5203,9 +5204,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.72"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7148f4696fb4960a346eaa60bbfb42a1ac4ebba21f750f75fc1375b098d5ffa"
+checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
 
 [[package]]
 name = "web-sys"

--- a/libs/datamodel/core/src/common/preview_features.rs
+++ b/libs/datamodel/core/src/common/preview_features.rs
@@ -96,9 +96,6 @@ pub static GENERATOR: Lazy<FeatureMap> = Lazy::new(|| {
         ])
 });
 
-/// Datasource preview features.
-pub static DATASOURCE: Lazy<FeatureMap> = Lazy::new(FeatureMap::default);
-
 #[derive(Debug, Default)]
 pub struct FeatureMap {
     /// Valid, visible features.

--- a/prisma-fmt/.gitignore
+++ b/prisma-fmt/.gitignore
@@ -1,0 +1,2 @@
+/wasm-target
+/js-target

--- a/prisma-fmt/.gitignore
+++ b/prisma-fmt/.gitignore
@@ -1,2 +1,2 @@
-/wasm-target
-/js-target
+node_modules
+/pkg/src

--- a/prisma-fmt/Cargo.toml
+++ b/prisma-fmt/Cargo.toml
@@ -4,11 +4,19 @@ version = "0.1.0"
 authors = ["Emanuel Joebstl <emanuel.joebstl@gmail.com>"]
 edition = "2018"
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 datamodel = { path = "../libs/datamodel/core" }
-structopt = "0.3"
-serde = { version = "1.0.90", features = ["derive"] }
 serde_json = { version = "1.0", features = ["float_roundtrip"] }
+serde = { version = "1.0.90", features = ["derive"] }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+structopt = "0.3"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = "0.2.77"
 
 [features]
 # sigh please don't ask :(

--- a/prisma-fmt/Cargo.toml
+++ b/prisma-fmt/Cargo.toml
@@ -17,3 +17,7 @@ structopt = "0.3"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2.77"
+
+[features]
+# sigh please don't ask :(
+vendored-openssl = []

--- a/prisma-fmt/Cargo.toml
+++ b/prisma-fmt/Cargo.toml
@@ -17,7 +17,3 @@ structopt = "0.3"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2.77"
-
-[features]
-# sigh please don't ask :(
-vendored-openssl = []

--- a/prisma-fmt/build_wasm.sh
+++ b/prisma-fmt/build_wasm.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+echo "Building WASM from source..."
+cargo build --lib --target=wasm32-unknown-unknown --target-dir=wasm-target
+echo "Building JS module from WASM..."
+wasm-bindgen --target=nodejs ./wasm-target/wasm32-unknown-unknown/debug/prisma_fmt.wasm --out-dir=js-target
+echo "ok"

--- a/prisma-fmt/build_wasm.sh
+++ b/prisma-fmt/build_wasm.sh
@@ -1,7 +1,16 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-echo "Building WASM from source..."
-cargo build --lib --target=wasm32-unknown-unknown --target-dir=wasm-target
-echo "Building JS module from WASM..."
-wasm-bindgen --target=nodejs ./wasm-target/wasm32-unknown-unknown/debug/prisma_fmt.wasm --out-dir=js-target
+set -euo pipefail
+
+export builddir=`mktemp -d`
+
+echo "Building the .wasm artifact..."
+cargo build --lib --target=wasm32-unknown-unknown --target-dir=$builddir --release
+
+echo "Installing wasm-bindgen-cli..."
+cargo install wasm-bindgen-cli --version=0.2.78
+
+echo "Building npm package"
+wasm-bindgen --target=nodejs $builddir/wasm32-unknown-unknown/release/prisma_fmt.wasm --out-dir=pkg/src/
+
 echo "ok"

--- a/prisma-fmt/index.js
+++ b/prisma-fmt/index.js
@@ -1,0 +1,15 @@
+const prismaFmt = require("./js-target/prisma_fmt");
+const fs = require("fs")
+
+const file = String(fs.readFileSync("schema.prisma"));
+
+console.log("formatted:")
+console.log(prismaFmt.format(file))
+console.log("linted:")
+console.log(prismaFmt.lint(file))
+console.log("native types:")
+console.log(prismaFmt.native_types(file))
+console.log("preview features:")
+console.log(prismaFmt.preview_features(file))
+console.log("referential actions")
+console.log(prismaFmt.referential_actions(file))

--- a/prisma-fmt/index.js
+++ b/prisma-fmt/index.js
@@ -1,4 +1,4 @@
-const prismaFmt = require("./js-target/prisma_fmt");
+const prismaFmt = require("./pkg/src/prisma_fmt");
 const fs = require("fs")
 
 const file = String(fs.readFileSync("schema.prisma"));

--- a/prisma-fmt/pkg/package.json
+++ b/prisma-fmt/pkg/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "prisma-fmt-wasm-experimental",
+  "version": "0.1.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/prisma/prisma-engines.git"
+  },
+  "author": "Tom Houle",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/prisma/prisma-engines/issues"
+  },
+  "homepage": "https://github.com/prisma/prisma-engines#readme"
+}

--- a/prisma-fmt/schema.prisma
+++ b/prisma-fmt/schema.prisma
@@ -1,0 +1,4 @@
+datasource db {
+    provider = "postgresql"
+    url = env("MEOW")
+}

--- a/prisma-fmt/src/actions.rs
+++ b/prisma-fmt/src/actions.rs
@@ -1,18 +1,10 @@
-use std::io::{self, Read};
-
-pub fn run() {
-    let mut datamodel_string = String::new();
-
-    io::stdin()
-        .read_to_string(&mut datamodel_string)
-        .expect("Unable to read from stdin.");
-
-    let datamodel_result = datamodel::parse_configuration(&datamodel_string);
+pub(crate) fn run(schema: &str) -> String {
+    let datamodel_result = datamodel::parse_configuration(&schema);
 
     match datamodel_result {
         Ok(validated_configuration) => {
             if validated_configuration.subject.datasources.len() != 1 {
-                print!("[]")
+                "[]".to_string()
             } else if let Some(datasource) = validated_configuration.subject.datasources.first() {
                 let available_referential_actions = datasource
                     .active_connector
@@ -21,13 +13,11 @@ pub fn run() {
                     .map(|act| format!("{:?}", act))
                     .collect::<Vec<_>>();
 
-                let json = serde_json::to_string(&available_referential_actions).expect("Failed to render JSON");
-
-                print!("{}", json)
+                serde_json::to_string(&available_referential_actions).expect("Failed to render JSON")
             } else {
-                print!("[]")
+                "[]".to_string()
             }
         }
-        _ => print!("[]"),
+        _ => "[]".to_owned(),
     }
 }

--- a/prisma-fmt/src/actions.rs
+++ b/prisma-fmt/src/actions.rs
@@ -1,5 +1,5 @@
 pub(crate) fn run(schema: &str) -> String {
-    let datamodel_result = datamodel::parse_configuration(&schema);
+    let datamodel_result = datamodel::parse_configuration(schema);
 
     match datamodel_result {
         Ok(validated_configuration) => {

--- a/prisma-fmt/src/lib.rs
+++ b/prisma-fmt/src/lib.rs
@@ -1,0 +1,36 @@
+mod actions;
+mod lint;
+mod native;
+mod preview;
+
+#[cfg(target_arch = "wasm32")]
+mod api {
+    use crate::*;
+    use datamodel::ast::reformat::Reformatter;
+    use wasm_bindgen::prelude::*;
+
+    #[wasm_bindgen]
+    pub fn format(schema: String) -> String {
+        Reformatter::new(&schema).reformat_to_string()
+    }
+
+    #[wasm_bindgen]
+    pub fn lint(schema: String) -> String {
+        lint::run(&schema)
+    }
+
+    #[wasm_bindgen]
+    pub fn native_types(schema: String) -> String {
+        native::run(&schema)
+    }
+
+    #[wasm_bindgen]
+    pub fn preview_features() -> String {
+        preview::run()
+    }
+
+    #[wasm_bindgen]
+    pub fn referential_actions(schema: String) -> String {
+        actions::run(&schema)
+    }
+}

--- a/prisma-fmt/src/lib.rs
+++ b/prisma-fmt/src/lib.rs
@@ -1,9 +1,10 @@
+#![cfg(target_arch = "wasm32")]
+
 mod actions;
 mod lint;
 mod native;
 mod preview;
 
-#[cfg(target_arch = "wasm32")]
 mod api {
     use crate::*;
     use datamodel::ast::reformat::Reformatter;

--- a/prisma-fmt/src/lint.rs
+++ b/prisma-fmt/src/lint.rs
@@ -1,15 +1,15 @@
-use crate::{LintOpts, MiniError};
 use datamodel::diagnostics::{DatamodelError, DatamodelWarning};
-use std::io::{self, Read};
 
-pub fn run(_opts: LintOpts) {
-    let mut datamodel_string = String::new();
+#[derive(serde::Serialize)]
+pub struct MiniError {
+    start: usize,
+    end: usize,
+    text: String,
+    is_warning: bool,
+}
 
-    io::stdin()
-        .read_to_string(&mut datamodel_string)
-        .expect("Unable to read from stdin.");
-
-    let datamodel_result = datamodel::parse_datamodel(&datamodel_string);
+pub(crate) fn run(schema: &str) -> String {
+    let datamodel_result = datamodel::parse_datamodel(&schema);
 
     match datamodel_result {
         Err(err) => {
@@ -37,7 +37,7 @@ pub fn run(_opts: LintOpts) {
 
             mini_errors.append(&mut mini_warnings);
 
-            print_diagnostics(mini_errors);
+            print_diagnostics(mini_errors)
         }
         Ok(validated_datamodel) => {
             let mini_warnings: Vec<MiniError> = validated_datamodel
@@ -51,13 +51,11 @@ pub fn run(_opts: LintOpts) {
                 })
                 .collect();
 
-            print_diagnostics(mini_warnings);
+            print_diagnostics(mini_warnings)
         }
     }
 }
 
-fn print_diagnostics(diagnostics: Vec<MiniError>) {
-    let json = serde_json::to_string(&diagnostics).expect("Failed to render JSON");
-
-    print!("{}", json)
+fn print_diagnostics(diagnostics: Vec<MiniError>) -> String {
+    serde_json::to_string(&diagnostics).expect("Failed to render JSON")
 }

--- a/prisma-fmt/src/lint.rs
+++ b/prisma-fmt/src/lint.rs
@@ -9,7 +9,7 @@ pub struct MiniError {
 }
 
 pub(crate) fn run(schema: &str) -> String {
-    let datamodel_result = datamodel::parse_datamodel(&schema);
+    let datamodel_result = datamodel::parse_datamodel(schema);
 
     match datamodel_result {
         Err(err) => {

--- a/prisma-fmt/src/native.rs
+++ b/prisma-fmt/src/native.rs
@@ -1,29 +1,15 @@
-use std::io::{self, Read};
+pub(crate) fn run(schema: &str) -> String {
+    let validated_configuration = match datamodel::parse_configuration(&schema) {
+        Ok(validated_configuration) => validated_configuration,
+        Err(_) => return "[]".to_owned(),
+    };
 
-pub fn run() {
-    let mut datamodel_string = String::new();
-
-    io::stdin()
-        .read_to_string(&mut datamodel_string)
-        .expect("Unable to read from stdin.");
-
-    let datamodel_result = datamodel::parse_configuration(&datamodel_string);
-
-    match datamodel_result {
-        Ok(validated_configuration) => {
-            if validated_configuration.subject.datasources.len() != 1 {
-                print!("[]")
-            } else if let Some(datasource) = validated_configuration.subject.datasources.first() {
-                let available_native_type_constructors =
-                    datasource.active_connector.available_native_type_constructors();
-
-                let json = serde_json::to_string(available_native_type_constructors).expect("Failed to render JSON");
-
-                print!("{}", json)
-            } else {
-                print!("[]")
-            }
-        }
-        _ => print!("[]"),
+    if validated_configuration.subject.datasources.len() != 1 {
+        return "[]".to_owned();
     }
+
+    let datasource = &validated_configuration.subject.datasources[0];
+    let available_native_type_constructors = datasource.active_connector.available_native_type_constructors();
+
+    serde_json::to_string(available_native_type_constructors).expect("Failed to render JSON")
 }

--- a/prisma-fmt/src/native.rs
+++ b/prisma-fmt/src/native.rs
@@ -1,5 +1,5 @@
 pub(crate) fn run(schema: &str) -> String {
-    let validated_configuration = match datamodel::parse_configuration(&schema) {
+    let validated_configuration = match datamodel::parse_configuration(schema) {
         Ok(validated_configuration) => validated_configuration,
         Err(_) => return "[]".to_owned(),
     };

--- a/prisma-fmt/src/preview.rs
+++ b/prisma-fmt/src/preview.rs
@@ -1,18 +1,5 @@
-use crate::PreviewFeaturesOpts;
-use datamodel::common::preview_features::{DATASOURCE, GENERATOR};
+use datamodel::common::preview_features::GENERATOR;
 
-pub fn run(opts: PreviewFeaturesOpts) {
-    let features = if opts.datasource_only {
-        DATASOURCE.active_features()
-    } else {
-        GENERATOR.active_features()
-    };
-
-    if features.is_empty() {
-        print!("[]")
-    } else {
-        let json = serde_json::to_string(&features).expect("Failed to render JSON");
-
-        print!("{}", json)
-    }
+pub fn run() -> String {
+    serde_json::to_string(&GENERATOR.active_features()).unwrap()
 }


### PR DESCRIPTION
This PR sets up the infrastructure for prisma-fmt as a wasm module beside the current binary, sharing the same implementation for the most part.

Automatic publication to npm of the wasm package is left to a separate PR.