### PR TITLE
More actions on prisma integrity, deny onUpdate

### DIFF
--- a/introspection-engine/introspection-engine-tests/tests/re_introspection/vitess.rs
+++ b/introspection-engine/introspection-engine-tests/tests/re_introspection/vitess.rs
@@ -405,7 +405,7 @@ async fn referential_actions_are_kept_intact(api: &TestApi) -> TestResult {
         model B {
           id  Int @id @default(autoincrement())
           aId Int
-          a   A   @relation(fields: [aId], references: [id], onDelete: SetNull, onUpdate: Restrict)
+          a   A   @relation(fields: [aId], references: [id], onDelete: SetNull)
         }
     "#};
 
@@ -418,7 +418,7 @@ async fn referential_actions_are_kept_intact(api: &TestApi) -> TestResult {
         model B {
           id  Int @id @default(autoincrement())
           aId Int
-          a   A   @relation(fields: [aId], references: [id], onDelete: SetNull, onUpdate: Restrict)
+          a   A   @relation(fields: [aId], references: [id], onDelete: SetNull)
         }
     "#]];
 

--- a/libs/datamodel/connectors/datamodel-connector/src/referential_integrity.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/referential_integrity.rs
@@ -28,7 +28,7 @@ impl ReferentialIntegrity {
         match self {
             Self::ForeignKeys => from_connector,
             // The emulated modes should be listed here.
-            Self::Prisma => Restrict | SetNull,
+            Self::Prisma => Restrict | SetNull | NoAction | Cascade,
         }
     }
 

--- a/libs/datamodel/connectors/dml/src/field.rs
+++ b/libs/datamodel/connectors/dml/src/field.rs
@@ -374,7 +374,7 @@ impl RelationField {
 
         match self.referential_arity {
             _ if !self.emulates_referential_actions.unwrap_or(false) => Cascade,
-            FieldArity::Required => Restrict,
+            FieldArity::Required => NoAction,
             _ => SetNull,
         }
     }

--- a/libs/datamodel/core/src/transform/ast_to_dml/db/attributes.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/attributes.rs
@@ -744,6 +744,8 @@ fn visit_relation<'ast>(
         }
     }
 
+    relation::validate_on_update_without_foreign_keys(model_id, field_id, relation_field, ctx);
+
     let fk_name = {
         let ast_model = &ctx.db.ast[model_id];
 

--- a/libs/datamodel/core/src/transform/ast_to_dml/db/attributes/relation.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/attributes/relation.rs
@@ -3,6 +3,7 @@ use crate::{
     diagnostics::DatamodelError,
     transform::ast_to_dml::db::{context::Context, types::RelationField},
 };
+use dml::relation_info::ReferentialAction;
 use itertools::Itertools;
 
 /// Validate that the arity of fields from `fields` is compatible with relation field arity.
@@ -38,4 +39,44 @@ pub(super) fn validate_relation_field_arity(
         ),
         ast_relation_field.span
     ));
+}
+
+/// Validates usage of `onUpdate` with the `referentialIntegrity` set to
+/// `prisma`.
+///
+/// This is temporary to the point until Query Engine supports `onUpdate`
+/// actions on emulations.
+pub(super) fn validate_on_update_without_foreign_keys(
+    model_id: ast::ModelId,
+    field_id: ast::FieldId,
+    relation_field: &RelationField<'_>,
+    ctx: &mut Context<'_>,
+) {
+    let referential_integrity = ctx
+        .db
+        .datasource()
+        .map(|ds| ds.referential_integrity())
+        .unwrap_or_default();
+
+    if referential_integrity.uses_foreign_keys() {
+        return;
+    }
+
+    if relation_field
+        .on_update
+        .map(|act| act != ReferentialAction::NoAction)
+        .unwrap_or(false)
+    {
+        let ast_model = &ctx.db.ast[model_id];
+        let ast_field = &ast_model[field_id];
+
+        let span = ast_field
+            .span_for_argument("relation", "onUpdate")
+            .unwrap_or(ast_field.span);
+
+        ctx.push_error(DatamodelError::new_validation_error(
+            "Referential actions other than `NoAction` will not work for `onUpdate` without foreign keys. Please follow the issue: https://github.com/prisma/prisma/issues/9014",
+            span
+        ));
+    }
 }

--- a/libs/datamodel/core/src/transform/ast_to_dml/validate.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validate.rs
@@ -10,7 +10,6 @@ use crate::{
     diagnostics::{DatamodelError, Diagnostics},
     dml,
 };
-use ::dml::relation_info::ReferentialAction;
 use datamodel_connector::ConnectorCapability;
 use names::NamesValidator;
 
@@ -506,29 +505,6 @@ impl<'a> Validator<'a> {
                         &message,
                         RELATION_ATTRIBUTE_NAME,
                         field_span,
-                    ));
-                }
-
-                let referential_integrity = self.source.map(|ds| ds.referential_integrity()).unwrap_or_default();
-
-                if !referential_integrity.uses_foreign_keys()
-                    && rel_info
-                        .on_update
-                        .map(|act| act != ReferentialAction::NoAction)
-                        .unwrap_or(false)
-                {
-                    let ast_field = ast_model.find_field_bang(&field.name);
-                    let message =
-                        "Referential actions other than `NoAction` will not work for `onUpdate` without foreign keys. Please follow the issue: https://github.com/prisma/prisma/issues/9014";
-
-                    let span = ast_field
-                        .span_for_argument("relation", "onUpdate")
-                        .unwrap_or(ast_field.span);
-
-                    errors.push_error(DatamodelError::new_attribute_validation_error(
-                        message,
-                        RELATION_ATTRIBUTE_NAME,
-                        span,
                     ));
                 }
 

--- a/libs/datamodel/core/src/transform/ast_to_dml/validate.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validate.rs
@@ -10,6 +10,7 @@ use crate::{
     diagnostics::{DatamodelError, Diagnostics},
     dml,
 };
+use ::dml::relation_info::ReferentialAction;
 use datamodel_connector::ConnectorCapability;
 use names::NamesValidator;
 
@@ -505,6 +506,29 @@ impl<'a> Validator<'a> {
                         &message,
                         RELATION_ATTRIBUTE_NAME,
                         field_span,
+                    ));
+                }
+
+                let referential_integrity = self.source.map(|ds| ds.referential_integrity()).unwrap_or_default();
+
+                if !referential_integrity.uses_foreign_keys()
+                    && rel_info
+                        .on_update
+                        .map(|act| act != ReferentialAction::NoAction)
+                        .unwrap_or(false)
+                {
+                    let ast_field = ast_model.find_field_bang(&field.name);
+                    let message =
+                        "Referential actions other than `NoAction` will not work for `onUpdate` without foreign keys. Please follow the issue: https://github.com/prisma/prisma/issues/9014";
+
+                    let span = ast_field
+                        .span_for_argument("relation", "onUpdate")
+                        .unwrap_or(ast_field.span);
+
+                    errors.push_error(DatamodelError::new_attribute_validation_error(
+                        message,
+                        RELATION_ATTRIBUTE_NAME,
+                        span,
                     ));
                 }
 

--- a/libs/datamodel/core/tests/attributes/relations/referential_actions.rs
+++ b/libs/datamodel/core/tests/attributes/relations/referential_actions.rs
@@ -1,7 +1,7 @@
 mod cycle_detection;
 
 use crate::{common::*, config::parse_config};
-use datamodel::ReferentialAction::*;
+use datamodel::ReferentialAction::{self, *};
 use datamodel_connector::ReferentialIntegrity;
 use indoc::{formatdoc, indoc};
 
@@ -63,7 +63,7 @@ fn on_update_actions() {
 
 #[test]
 fn actions_on_mongo() {
-    let actions = &[Restrict, SetNull];
+    let actions = &[Restrict, SetNull, Cascade, NoAction];
 
     for action in actions {
         let dml = formatdoc!(
@@ -81,7 +81,7 @@ fn actions_on_mongo() {
             model B {{
                 id Int @id @map("_id")
                 aId Int
-                a A @relation(fields: [aId], references: [id], onDelete: {action}, onUpdate: {action})
+                a A @relation(fields: [aId], references: [id], onDelete: {action})
             }}
         "#,
             action = action
@@ -90,14 +90,13 @@ fn actions_on_mongo() {
         parse(&dml)
             .assert_has_model("B")
             .assert_has_relation_field("a")
-            .assert_relation_delete_strategy(*action)
-            .assert_relation_update_strategy(*action);
+            .assert_relation_delete_strategy(*action);
     }
 }
 
 #[test]
-fn actions_on_prisma_referential_integrity() {
-    let actions = &[Restrict, SetNull];
+fn on_delete_actions_should_work_on_prisma_referential_integrity() {
+    let actions = &[Restrict, SetNull, Cascade, NoAction];
 
     for action in actions {
         let dml = formatdoc!(
@@ -121,7 +120,7 @@ fn actions_on_prisma_referential_integrity() {
             model B {{
                 id Int @id
                 aId Int
-                a A @relation(fields: [aId], references: [id], onDelete: {action}, onUpdate: {action})
+                a A @relation(fields: [aId], references: [id], onDelete: {action})
             }}
         "#,
             action = action
@@ -130,9 +129,78 @@ fn actions_on_prisma_referential_integrity() {
         parse(&dml)
             .assert_has_model("B")
             .assert_has_relation_field("a")
-            .assert_relation_delete_strategy(*action)
-            .assert_relation_update_strategy(*action);
+            .assert_relation_delete_strategy(*action);
     }
+}
+
+#[test]
+fn on_update_actions_should_not_work_on_prisma_referential_integrity() {
+    let dml = indoc! { r#"
+        datasource db {
+          provider = "mysql"
+          url = "mysql://"
+          referentialIntegrity = "prisma"
+        }
+
+        generator client {
+          provider = "prisma-client-js"
+          previewFeatures = ["referentialIntegrity"]
+        }
+
+        model A {
+          id Int @id
+          bs B[]
+        }
+
+        model B {
+          id Int @id
+          aId Int
+          a A @relation(fields: [aId], references: [id], onUpdate: Restrict)
+        }
+    "#};
+
+    let expect = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@relation": Referential actions other than `NoAction` will not work for `onUpdate` without foreign keys. Please follow the issue: https://github.com/prisma/prisma/issues/9014[0m
+          [1;94m-->[0m  [4mschema.prisma:20[0m
+        [1;94m   | [0m
+        [1;94m19 | [0m  aId Int
+        [1;94m20 | [0m  a A @relation(fields: [aId], references: [id], [1;91monUpdate: Restrict[0m)
+        [1;94m   | [0m
+    "#]];
+
+    expect.assert_eq(&datamodel::parse_schema(dml).map(drop).unwrap_err());
+}
+
+#[test]
+fn on_update_no_action_should_work_on_prisma_referential_integrity() {
+    let dml = indoc! { r#"
+        datasource db {
+          provider = "mysql"
+          url = "mysql://"
+          referentialIntegrity = "prisma"
+        }
+
+        generator client {
+          provider = "prisma-client-js"
+          previewFeatures = ["referentialIntegrity"]
+        }
+
+        model A {
+          id Int @id
+          bs B[]
+        }
+
+        model B {
+          id Int @id
+          aId Int
+          a A @relation(fields: [aId], references: [id], onUpdate: NoAction)
+        }
+    "#};
+
+    parse(&dml)
+        .assert_has_model("B")
+        .assert_has_relation_field("a")
+        .assert_relation_update_strategy(ReferentialAction::NoAction);
 }
 
 #[test]
@@ -391,88 +459,6 @@ fn actions_should_be_defined_only_from_one_side() {
 }
 
 #[test]
-fn cascade_action_should_not_work_on_prisma_level_referential_integrity() {
-    let dml = indoc!(
-        r#"
-            datasource db {
-                provider = "mysql"
-                referentialIntegrity = "prisma"
-                url = "mysql://root:prisma@localhost:3306/mydb"
-            }
-
-            generator client {
-                provider = "prisma-client-js"
-                previewFeatures = ["referentialIntegrity"]
-            }
-
-            model A {{
-                id Int @id @map("_id")
-                bs B[]
-            }
-
-            model B {
-                id Int @id @map("_id")
-                aId Int
-                a A @relation(fields: [aId], references: [id], onDelete: Cascade)
-            }
-        "#,
-    );
-
-    let expected = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@relation": Invalid referential action: `Cascade`. Allowed values: (`Restrict`, `SetNull`)[0m
-          [1;94m-->[0m  [4mschema.prisma:20[0m
-        [1;94m   | [0m
-        [1;94m19 | [0m    aId Int
-        [1;94m20 | [0m    [1;91ma A @relation(fields: [aId], references: [id], onDelete: Cascade)[0m
-        [1;94m21 | [0m}
-        [1;94m   | [0m
-    "#]];
-
-    expected.assert_eq(&datamodel::parse_schema(dml).map(drop).unwrap_err());
-}
-
-#[test]
-fn no_action_should_not_work_on_prisma_level_referential_integrity() {
-    let dml = indoc!(
-        r#"
-            datasource db {
-                provider = "mysql"
-                referentialIntegrity = "prisma"
-                url = "mysql://root:prisma@localhost:3306/mydb"
-            }
-
-            generator client {
-                provider = "prisma-client-js"
-                previewFeatures = ["referentialIntegrity"]
-            }
-
-            model A {{
-                id Int @id @map("_id")
-                bs B[]
-            }
-
-            model B {
-                id Int @id @map("_id")
-                aId Int
-                a A @relation(fields: [aId], references: [id], onDelete: NoAction)
-            }
-        "#,
-    );
-
-    let expected = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@relation": Invalid referential action: `NoAction`. Allowed values: (`Restrict`, `SetNull`)[0m
-          [1;94m-->[0m  [4mschema.prisma:20[0m
-        [1;94m   | [0m
-        [1;94m19 | [0m    aId Int
-        [1;94m20 | [0m    [1;91ma A @relation(fields: [aId], references: [id], onDelete: NoAction)[0m
-        [1;94m21 | [0m}
-        [1;94m   | [0m
-    "#]];
-
-    expected.assert_eq(&datamodel::parse_schema(dml).map(drop).unwrap_err());
-}
-
-#[test]
 fn set_default_action_should_not_work_on_prisma_level_referential_integrity() {
     let dml = indoc!(
         r#"
@@ -501,7 +487,7 @@ fn set_default_action_should_not_work_on_prisma_level_referential_integrity() {
     );
 
     let expected = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@relation": Invalid referential action: `SetDefault`. Allowed values: (`Restrict`, `SetNull`)[0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": Invalid referential action: `SetDefault`. Allowed values: (`Cascade`, `Restrict`, `NoAction`, `SetNull`)[0m
           [1;94m-->[0m  [4mschema.prisma:20[0m
         [1;94m   | [0m
         [1;94m19 | [0m    aId Int

--- a/libs/datamodel/core/tests/attributes/relations/referential_actions.rs
+++ b/libs/datamodel/core/tests/attributes/relations/referential_actions.rs
@@ -160,7 +160,7 @@ fn on_update_actions_should_not_work_on_prisma_referential_integrity() {
     "#};
 
     let expect = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@relation": Referential actions other than `NoAction` will not work for `onUpdate` without foreign keys. Please follow the issue: https://github.com/prisma/prisma/issues/9014[0m
+        [1;91merror[0m: [1mError validating: Referential actions other than `NoAction` will not work for `onUpdate` without foreign keys. Please follow the issue: https://github.com/prisma/prisma/issues/9014[0m
           [1;94m-->[0m  [4mschema.prisma:20[0m
         [1;94m   | [0m
         [1;94m19 | [0m  aId Int

--- a/migration-engine/migration-engine-tests/tests/migrations/basic/vitess.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/basic/vitess.rs
@@ -6,20 +6,20 @@ fn reordering_and_altering_models_at_the_same_time_works(api: TestApi) {
         model A {
             id Int @id
             name Int @unique
-            c C @relation(name: "atoc", fields: [name], references: [name], onUpdate: Restrict)
+            c C @relation(name: "atoc", fields: [name], references: [name], onDelete: Restrict)
             cs C[] @relation(name: "ctoa")
         }
 
         model B {
             id Int @id
             name Int @unique
-            c C @relation(name: "btoc", fields: [name], references: [name], onUpdate: Restrict)
+            c C @relation(name: "btoc", fields: [name], references: [name], onDelete: Restrict)
         }
 
         model C {
             id Int @id
             name Int @unique
-            a A @relation(name: "ctoa", fields: [name], references: [name], onUpdate: Restrict)
+            a A @relation(name: "ctoa", fields: [name], references: [name], onDelete: Restrict)
             as A[] @relation(name: "atoc")
             bs B[] @relation(name: "btoc")
         }
@@ -30,7 +30,7 @@ fn reordering_and_altering_models_at_the_same_time_works(api: TestApi) {
     let dm2 = r#"
         model C {
             id Int @id
-            a A @relation(name: "ctoa2", fields: [name], references: [name], onUpdate: Restrict)
+            a A @relation(name: "ctoa2", fields: [name], references: [name], onDelete: Restrict)
             name Int @unique
             bs B[] @relation(name: "btoc2")
             as A[] @relation(name: "atoc2")
@@ -39,12 +39,12 @@ fn reordering_and_altering_models_at_the_same_time_works(api: TestApi) {
         model A {
             id Int @id
             name Int @unique
-            c C @relation(name: "atoc2", fields: [name], references: [name], onUpdate: Restrict)
+            c C @relation(name: "atoc2", fields: [name], references: [name], onDelete: Restrict)
             cs C[] @relation(name: "ctoa2")
         }
 
         model B {
-            c C @relation(name: "btoc2", fields: [name], references: [name], onUpdate: Restrict)
+            c C @relation(name: "btoc2", fields: [name], references: [name], onDelete: Restrict)
             name Int @unique
             id Int @id
         }


### PR DESCRIPTION
onUpdate actions never worked as emulated, so we better allow only `NoAction` in the data model for `referentialIntegrity` of `prisma`. We also already have `NoAction` and `Cascade` for `onDelete` emulations, so we should allow them.

Closes: https://github.com/prisma/prisma/issues/9281