### PR TITLE
Make ConnectionInfo private in sql_migration_connector

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/lib.rs
@@ -90,16 +90,6 @@ impl SqlMigrationConnector {
     }
 
     /// Made public for tests.
-    pub fn connection_info(&self) -> ConnectionInfo {
-        self.connection.connection_info()
-    }
-
-    /// Made public for tests.
-    pub fn schema_name(&self) -> &str {
-        self.connection.schema_name()
-    }
-
-    /// Made public for tests.
     pub async fn describe_schema(&self) -> ConnectorResult<SqlSchema> {
         self.flavour.describe_schema(&self.connection).await
     }

--- a/migration-engine/core/src/native/qe_setup.rs
+++ b/migration-engine/core/src/native/qe_setup.rs
@@ -1,8 +1,10 @@
 //! Query Engine test setup.
 
 use crate::{api::GenericApi, commands::SchemaPushInput, core_error::CoreResult};
+#[cfg(feature = "mongodb")]
+use datamodel::common::provider_names::MONGODB_SOURCE_NAME;
 use datamodel::common::provider_names::{
-    MONGODB_SOURCE_NAME, MSSQL_SOURCE_NAME, MYSQL_SOURCE_NAME, POSTGRES_SOURCE_NAME, SQLITE_SOURCE_NAME,
+    MSSQL_SOURCE_NAME, MYSQL_SOURCE_NAME, POSTGRES_SOURCE_NAME, SQLITE_SOURCE_NAME,
 };
 #[cfg(feature = "mongodb")]
 use mongodb_migration_connector::MongoDbMigrationConnector;

--- a/migration-engine/migration-engine-tests/src/multi_engine_test_api.rs
+++ b/migration-engine/migration-engine-tests/src/multi_engine_test_api.rs
@@ -4,6 +4,7 @@
 //! multiple migration engines.
 
 use datamodel::common::preview_features::PreviewFeature;
+use quaint::prelude::ConnectionInfo;
 pub use test_macros::test_connector;
 pub use test_setup::sqlite_test_url;
 pub use test_setup::{BitFlags, Capabilities, Tags};
@@ -102,6 +103,11 @@ impl TestApi {
         &self.connection_string
     }
 
+    /// The ConnectionInfo based on the connection string
+    pub fn connection_info(&self) -> ConnectionInfo {
+        ConnectionInfo::from_url(self.connection_string()).unwrap()
+    }
+
     /// Create a temporary directory to serve as a test migrations directory.
     pub fn create_migrations_directory(&self) -> TempDir {
         tempfile::tempdir().unwrap()
@@ -181,6 +187,7 @@ impl TestApi {
 
         EngineTestApi {
             connector,
+            connection_info: ConnectionInfo::from_url(connection_string).unwrap(),
             tags: self.args.tags(),
             rt: &self.rt,
         }
@@ -244,6 +251,7 @@ impl TestApi {
 /// writing tests.
 pub struct EngineTestApi<'a> {
     pub(crate) connector: SqlMigrationConnector,
+    connection_info: ConnectionInfo,
     tags: BitFlags<Tags>,
     rt: &'a tokio::runtime::Runtime,
 }
@@ -291,7 +299,7 @@ impl EngineTestApi<'_> {
 
     /// The schema name of the current connected database.
     pub fn schema_name(&self) -> &str {
-        self.connector.schema_name()
+        self.connection_info.schema_name()
     }
 
     /// Execute a raw SQL command and expect it to succeed.

--- a/migration-engine/migration-engine-tests/src/test_api.rs
+++ b/migration-engine/migration-engine-tests/src/test_api.rs
@@ -43,11 +43,11 @@ impl TestApi {
     }
 
     pub fn connection_info(&self) -> ConnectionInfo {
-        self.connector.connection_info()
+        self.root.connection_info()
     }
 
-    pub fn schema_name(&self) -> &str {
-        self.connector.schema_name()
+    pub fn schema_name(&self) -> String {
+        self.connection_info().schema_name().to_owned()
     }
 
     /// Plan a `createMigration` command
@@ -229,7 +229,7 @@ impl TestApi {
         if self.root.is_sqlite() {
             table_name.into()
         } else {
-            (self.connector.schema_name(), table_name).into()
+            (self.connection_info().schema_name().to_owned(), table_name.to_owned()).into()
         }
     }
 

--- a/migration-engine/migration-engine-tests/tests/migrations/types.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/types.rs
@@ -293,7 +293,7 @@ fn a_column_recreation_with_non_castable_type_change_should_trigger_warnings(api
     "#;
 
     api.schema_push_w_datasource(dm1).send().assert_green();
-    let insert = quaint::ast::Insert::single_into((api.schema_name(), "Blog"))
+    let insert = quaint::ast::Insert::single_into((api.schema_name(), "Blog".to_owned()))
         .value("id", 1)
         .value("float", Value::double(7.5));
 

--- a/migration-engine/migration-engine-tests/tests/native_types/mssql.rs
+++ b/migration-engine/migration-engine-tests/tests/native_types/mssql.rs
@@ -1915,7 +1915,7 @@ fn safe_casts_with_existing_data_should_work(api: TestApi) {
 
             api.schema_push_w_datasource(dm1).send().assert_green();
 
-            let insert = Insert::single_into((api.schema_name(), "A")).value("x", seed.clone());
+            let insert = Insert::single_into((api.schema_name(), "A".to_owned())).value("x", seed.clone());
             api.query(insert.into());
 
             api.assert_schema().assert_table("A", |table| {
@@ -1973,7 +1973,7 @@ fn risky_casts_with_existing_data_should_warn(api: TestApi) {
 
             api.schema_push_w_datasource(dm1).send().assert_green();
 
-            let insert = Insert::single_into((api.schema_name(), "A")).value("x", seed.clone());
+            let insert = Insert::single_into((api.schema_name(), "A".to_owned())).value("x", seed.clone());
             api.query(insert.into());
 
             api.assert_schema().assert_table("A", |table| {
@@ -2042,7 +2042,7 @@ fn not_castable_with_existing_data_should_warn(api: TestApi) {
 
             api.schema_push_w_datasource(dm1).send().assert_green();
 
-            let insert = Insert::single_into((api.schema_name(), "A")).value("x", seed.clone());
+            let insert = Insert::single_into((api.schema_name(), "A".to_owned())).value("x", seed.clone());
             api.query(insert.into());
 
             api.assert_schema().assert_table("A", |table| {

--- a/migration-engine/migration-engine-tests/tests/native_types/postgres.rs
+++ b/migration-engine/migration-engine-tests/tests/native_types/postgres.rs
@@ -780,7 +780,7 @@ fn safe_casts_with_existing_data_should_work(api: TestApi) {
 
         let mut previous_columns = "".to_string();
         let mut next_columns = "".to_string();
-        let mut insert = Insert::single_into((api.schema_name(), "A"));
+        let mut insert = Insert::single_into((api.schema_name(), "A".to_owned()));
         let mut previous_assertions = vec![];
         let mut next_assertions = vec![];
 
@@ -867,7 +867,7 @@ fn risky_casts_with_existing_data_should_warn(api: TestApi) {
     for (from, seed, casts) in RISKY_CASTS.iter() {
         let mut previous_columns = "".to_string();
         let mut next_columns = "".to_string();
-        let mut insert = Insert::single_into((api.schema_name(), "A"));
+        let mut insert = Insert::single_into((api.schema_name(), "A".to_owned()));
         let mut previous_assertions = vec![];
         let mut next_assertions = vec![];
         let mut warnings = vec![];
@@ -967,7 +967,7 @@ fn not_castable_with_existing_data_should_warn(api: TestApi) {
     for (from, seed, casts) in NOT_CASTABLE.iter() {
         let mut previous_columns = "".to_string();
         let mut next_columns = "".to_string();
-        let mut insert = Insert::single_into((api.schema_name(), "A"));
+        let mut insert = Insert::single_into((api.schema_name(), "A".to_owned()));
         let mut previous_assertions = vec![];
         warnings.clear();
 
@@ -1152,7 +1152,7 @@ fn safe_casts_from_array_with_existing_data_should_work(api: TestApi) {
     for (to, from) in SAFE_CASTS_NON_LIST_TO_STRING.iter() {
         let mut previous_columns = "".to_string();
         let mut next_columns = "".to_string();
-        let mut insert = Insert::single_into((api.schema_name(), "A"));
+        let mut insert = Insert::single_into((api.schema_name(), "A".to_owned()));
         let mut previous_assertions = vec![];
         let mut next_assertions = vec![];
 


### PR DESCRIPTION
-> so we can make connections lazy in sql_migration_connector
-> so we can adapt the API for mongodb migrations