### PR TITLE
Compile and run all unit tests in CI

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,4 +1,4 @@
-name: PSL
+name: Unit tests
 on:
   push:
     branches:
@@ -6,7 +6,7 @@ on:
   pull_request:
 jobs:
   test:
-    name: "Test Datamodel"
+    name: Workspace unit tests
 
     strategy:
       fail-fast: false
@@ -28,6 +28,14 @@ jobs:
             target
           key: datamodel-cache
 
-      - run: cargo test -p datamodel -p dml -p datamodel-connector -p sql-datamodel-connector
+      - run: |
+            cargo test --workspace \
+                  --exclude=query-engine \
+                  --exclude=query-engine-tests \
+                  --exclude=migration-engine-tests \
+                  --exclude=migration-engine-tests \
+                  --exclude=migration-engine-cli \
+                  --exclude=sql-schema-describer \
+                  --exclude=introspection-engine-tests
         env:
           CLICOLOR_FORCE: 1


### PR DESCRIPTION
Instead of an allow-list of crates to test, use a deny-list of crates to
exclude. The test crates we exclude are those that need a database
connection to run.

We already had an example of forgotten crate that stopped compiling and
that did not make CI fail, this should prevent it.