### PR TITLE
Define global relation validations, port a few validation functions to the new setup

### DIFF
--- a/libs/datamodel/core/src/ast/field.rs
+++ b/libs/datamodel/core/src/ast/field.rs
@@ -31,6 +31,11 @@ impl Field {
             .map(|a| a.span)
             .next()
     }
+
+    /// The name of the field
+    pub fn name(&self) -> &str {
+        &self.name.name
+    }
 }
 
 impl WithIdentifier for Field {

--- a/libs/datamodel/core/src/transform/ast_to_dml/db.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db.rs
@@ -97,7 +97,7 @@ impl<'ast> ParserDatabase<'ast> {
         // Fourth step: global validations
         attributes::validate_index_names(&mut ctx);
         attributes::fill_in_default_constraint_names(&mut ctx);
-        attributes::validate_relation_attributes(&mut ctx);
+        attributes::validate_relations(&mut ctx);
 
         ctx.finish()
     }

--- a/libs/datamodel/core/src/transform/ast_to_dml/db.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db.rs
@@ -97,6 +97,7 @@ impl<'ast> ParserDatabase<'ast> {
         // Fourth step: global validations
         attributes::validate_index_names(&mut ctx);
         attributes::fill_in_default_constraint_names(&mut ctx);
+        attributes::validate_relation_attributes(&mut ctx);
 
         ctx.finish()
     }

--- a/libs/datamodel/core/src/transform/ast_to_dml/db/attributes.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/attributes.rs
@@ -159,6 +159,7 @@ pub(super) fn validate_relation_attributes(ctx: &mut Context<'_>) {
         let field = model.walk_relation_field(*field_id);
         let related_model = ctx.db.walk_model(relation_field.referenced_model);
 
+        relation::validate_relation_field_arity(model, field, relation_field, &mut errors);
         relation::validate_ignored_related_model(model, related_model, &relation_field, *field_id, &mut errors);
         relation::validate_on_update_without_foreign_keys(field, &relation_field, referential_integrity, &mut errors);
     }
@@ -702,8 +703,6 @@ fn visit_relation<'ast>(
 
         relation_field.fields = Some(fields);
     }
-
-    relation::validate_relation_field_arity(model_id, field_id, relation_field, ctx);
 
     if let Some(references) = args.optional_arg("references") {
         let references = match resolve_field_array(&references, args.span(), relation_field.referenced_model, ctx) {

--- a/libs/datamodel/core/src/transform/ast_to_dml/db/attributes.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/attributes.rs
@@ -145,7 +145,7 @@ pub(super) fn validate_index_names(ctx: &mut Context<'_>) {
     errors.into_iter().for_each(|err| ctx.push_error(err))
 }
 
-pub(super) fn validate_relation_attributes(ctx: &mut Context<'_>) {
+pub(super) fn validate_relations(ctx: &mut Context<'_>) {
     let mut errors: Vec<DatamodelError> = Vec::new();
 
     let referential_integrity = ctx

--- a/libs/datamodel/core/src/transform/ast_to_dml/db/attributes.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/attributes.rs
@@ -154,13 +154,12 @@ pub(super) fn validate_relations(ctx: &mut Context<'_>) {
         .map(|ds| ds.referential_integrity())
         .unwrap_or_default();
 
-    for ((model_id, field_id), relation_field) in ctx.db.types.relation_fields.iter() {
+    for ((model_id, field_id), _) in ctx.db.types.relation_fields.iter() {
         let model = ctx.db.walk_model(*model_id);
         let field = model.walk_relation_field(*field_id);
-        let related_model = ctx.db.walk_model(relation_field.referenced_model);
 
-        relation::validate_relation_field_arity(model, field, &mut errors);
-        relation::validate_ignored_related_model(model, related_model, field, &mut errors);
+        relation::validate_relation_field_arity(field, &mut errors);
+        relation::validate_ignored_related_model(field, &mut errors);
         relation::validate_on_update_without_foreign_keys(field, referential_integrity, &mut errors);
     }
 

--- a/libs/datamodel/core/src/transform/ast_to_dml/db/attributes/id.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/attributes/id.rs
@@ -1,6 +1,6 @@
 use super::{resolve_field_array, FieldResolutionError};
 use crate::{
-    ast::{self, WithName},
+    ast,
     common::constraint_names::ConstraintNames,
     diagnostics::DatamodelError,
     transform::ast_to_dml::db::{

--- a/libs/datamodel/core/src/transform/ast_to_dml/db/attributes/relation.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/attributes/relation.rs
@@ -1,8 +1,13 @@
 use crate::{
     ast,
     diagnostics::DatamodelError,
-    transform::ast_to_dml::db::{context::Context, types::RelationField},
+    transform::ast_to_dml::db::{
+        context::Context,
+        types::RelationField,
+        walkers::{ModelWalker, RelationFieldWalker},
+    },
 };
+use datamodel_connector::ReferentialIntegrity;
 use dml::relation_info::ReferentialAction;
 use itertools::Itertools;
 
@@ -47,17 +52,11 @@ pub(super) fn validate_relation_field_arity(
 /// This is temporary to the point until Query Engine supports `onUpdate`
 /// actions on emulations.
 pub(super) fn validate_on_update_without_foreign_keys(
-    model_id: ast::ModelId,
-    field_id: ast::FieldId,
+    field: RelationFieldWalker<'_, '_>,
     relation_field: &RelationField<'_>,
-    ctx: &mut Context<'_>,
+    referential_integrity: ReferentialIntegrity,
+    errors: &mut Vec<DatamodelError>,
 ) {
-    let referential_integrity = ctx
-        .db
-        .datasource()
-        .map(|ds| ds.referential_integrity())
-        .unwrap_or_default();
-
     if referential_integrity.uses_foreign_keys() {
         return;
     }
@@ -67,14 +66,13 @@ pub(super) fn validate_on_update_without_foreign_keys(
         .map(|act| act != ReferentialAction::NoAction)
         .unwrap_or(false)
     {
-        let ast_model = &ctx.db.ast[model_id];
-        let ast_field = &ast_model[field_id];
+        let ast_field = field.ast_field();
 
         let span = ast_field
             .span_for_argument("relation", "onUpdate")
             .unwrap_or(ast_field.span);
 
-        ctx.push_error(DatamodelError::new_validation_error(
+        errors.push(DatamodelError::new_validation_error(
             "Referential actions other than `NoAction` will not work for `onUpdate` without foreign keys. Please follow the issue: https://github.com/prisma/prisma/issues/9014",
             span
         ));
@@ -83,17 +81,15 @@ pub(super) fn validate_on_update_without_foreign_keys(
 
 /// Validates if the related model for the relation is ignored.
 pub(super) fn validate_ignored_related_model(
-    model_id: ast::ModelId,
-    field_id: ast::FieldId,
+    model: ModelWalker<'_, '_>,
+    related_model: ModelWalker<'_, '_>,
     relation_field: &RelationField<'_>,
-    ctx: &mut Context<'_>,
+    field_id: ast::FieldId,
+    errors: &mut Vec<DatamodelError>,
 ) {
-    let model = ctx.db.walk_model(model_id);
-    let related_model = ctx.db.walk_model(relation_field.referenced_model);
-
     if related_model.attributes().is_ignored && !relation_field.is_ignored && !model.attributes().is_ignored {
-        let ast_model = &ctx.db.ast[model_id];
-        let ast_related_model = &ctx.db.ast[relation_field.referenced_model];
+        let ast_model = model.ast_model();
+        let ast_related_model = related_model.ast_model();
         let ast_field = &ast_model[field_id];
 
         let message = format!(
@@ -101,7 +97,7 @@ pub(super) fn validate_ignored_related_model(
             ast_field.name(), ast_model.name(), ast_related_model.name()
         );
 
-        ctx.push_error(DatamodelError::new_attribute_validation_error(
+        errors.push(DatamodelError::new_attribute_validation_error(
             &message,
             "ignore",
             ast_field.span,

--- a/libs/datamodel/core/src/transform/ast_to_dml/db/walkers.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/walkers.rs
@@ -6,6 +6,7 @@ use crate::{ast, common::constraint_names::ConstraintNames};
 use std::borrow::Cow;
 
 impl<'ast> ParserDatabase<'ast> {
+    #[track_caller]
     pub(crate) fn walk_model(&self, model_id: ast::ModelId) -> ModelWalker<'ast, '_> {
         ModelWalker {
             model_id,

--- a/libs/datamodel/core/src/transform/ast_to_dml/lift.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/lift.rs
@@ -1,8 +1,4 @@
-use crate::{
-    ast::{self, WithName},
-    dml,
-    transform::ast_to_dml::db,
-};
+use crate::{ast, dml, transform::ast_to_dml::db};
 use std::collections::HashMap;
 
 /// Helper for lifting a datamodel.

--- a/libs/datamodel/core/src/transform/ast_to_dml/validate.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validate.rs
@@ -450,17 +450,6 @@ impl<'a> Validator<'a> {
             if let Some((_rel_field_idx, related_field)) = datamodel.find_related_field(field) {
                 let related_field_rel_info = &related_field.relation_info;
 
-                if related_model.is_ignored && !field.is_ignored && !model.is_ignored {
-                    let message = format!(
-                        "The relation field `{}` on Model `{}` must specify the `@ignore` attribute, because the model {} it is pointing to is marked ignored.",
-                        &field.name, &model.name, &related_model.name
-                    );
-
-                    errors.push_error(DatamodelError::new_attribute_validation_error(
-                        &message, "ignore", field_span,
-                    ));
-                }
-
                 // ONE TO MANY
                 if field.is_singular() && related_field.is_list() {
                     if rel_info.fields.is_empty() {


### PR DESCRIPTION
Small steps, but the first iteration on porting relation validations depending on everything being visited and populated already.