### PR TITLE
Fix problem with multiple columns in `IN` and `NOT IN` filters (#7072)

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
@@ -1,1 +1,2 @@
 mod prisma_8265;
+mod prisma_7072;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_7072.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_7072.rs
@@ -1,0 +1,79 @@
+use query_engine_tests::*;
+
+#[test_suite(schema(schema))]
+mod filter_in {
+    use indoc::indoc;
+    use query_engine_tests::assert_query;
+
+    fn schema() -> String {
+        let schema = indoc! {r#"
+            model Foo {
+                id		  String @id
+                version String
+                name	  String
+                bar		  Bar?
+            
+                @@unique([id, version])
+            }
+
+            model Bar {
+                id			String	@id
+                name		String
+                fooId		String
+                version String
+                foo			Foo	@relation(fields: [fooId, version], references: [id, version])
+            }
+        "#};
+
+        schema.to_owned()
+    }
+
+    #[connector_test]
+    async fn test_filter_in(runner: Runner) -> TestResult<()> {
+        runner
+            .query(
+                r#"
+            mutation {
+                createOneFoo(data: {
+                  id: "1"
+                  version: "a"
+                  name: "first foo"
+                  bar: {
+                    create: {
+                      id: "1"
+                      name: "first bar"
+                    }
+                  }
+                }) {
+                  id
+                }
+              }"#,
+            )
+            .await?
+            .assert_success();
+
+        runner
+            .query(
+                r#"
+            mutation {
+                createOneFoo(data: {
+                    id: "2"
+                    version: "a"
+                    name: "second foo"
+                }) {
+                    id
+                }
+            }"#,
+            )
+            .await?
+            .assert_success();
+
+        assert_query!(
+            runner,
+            "query { findManyFoo(where: { bar: { is: null } }) { id } }",
+            r#"{"data":{"findManyFoo":[{"id":"2"}]}}"#
+        );
+
+        Ok(())
+    }
+}

--- a/query-engine/connectors/sql-query-connector/src/filter_conversion.rs
+++ b/query-engine/connectors/sql-query-connector/src/filter_conversion.rs
@@ -357,8 +357,7 @@ impl AliasedCondition for OneRelationIsNullFilter {
 
             let id_columns: Vec<Column<'static>> = self
                 .field
-                .model()
-                .primary_identifier()
+                .linking_fields()
                 .as_columns()
                 .map(|c| c.opt_table(alias.clone()))
                 .collect();


### PR DESCRIPTION
Now we use `linking_fields` instead of `model().primary_identifier()` when linking subqueries in `IN` and `NOT IN` clauses.