### PR TITLE
(sql_migration_connector) Reduce the API surface of connection_wrapper

### DIFF
--- a/.test_database_urls/postgres_12
+++ b/.test_database_urls/postgres_12
@@ -1,2 +1,2 @@
 export TEST_DATABASE_URL="postgresql://postgres:prisma@localhost:5434"
-set -e TEST_SHADOW_DATABASE_URL
+unset SHADOW_DATABASE_URL

--- a/migration-engine/connectors/sql-migration-connector/src/flavour.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour.rs
@@ -74,9 +74,6 @@ pub(crate) trait SqlFlavour:
     /// Initialize the `_prisma_migrations` table.
     async fn create_migrations_table(&self, connection: &Connection) -> ConnectorResult<()>;
 
-    /// Describe the SQL schema.
-    async fn describe_schema<'a>(&'a self, conn: &Connection) -> ConnectorResult<SqlSchema>;
-
     /// Drop the database for the provided URL on the server.
     async fn drop_database(&self, database_url: &str) -> ConnectorResult<()>;
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_migration_persistence.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_migration_persistence.rs
@@ -54,7 +54,7 @@ impl MigrationPersistence for SqlMigrationConnector {
             .value("finished_at", now)
             .value("migration_name", migration_name);
 
-        conn.execute(insert).await?;
+        conn.query(insert).await?;
 
         Ok(id)
     }
@@ -66,7 +66,7 @@ impl MigrationPersistence for SqlMigrationConnector {
             .so_that(Column::from("id").equals(migration_id))
             .set("rolled_back_at", chrono::Utc::now());
 
-        conn.execute(update).await?;
+        conn.query(update).await?;
 
         Ok(())
     }
@@ -82,7 +82,7 @@ impl MigrationPersistence for SqlMigrationConnector {
             .value("started_at", now)
             .value("migration_name", migration_name);
 
-        conn.execute(insert).await?;
+        conn.query(insert).await?;
 
         Ok(id)
     }
@@ -97,7 +97,7 @@ impl MigrationPersistence for SqlMigrationConnector {
                 Expression::from(Column::from("applied_steps_count")) + Expression::from(1),
             );
 
-        self.conn().execute(update).await?;
+        self.conn().query(update).await?;
 
         Ok(())
     }
@@ -107,7 +107,7 @@ impl MigrationPersistence for SqlMigrationConnector {
             .so_that(Column::from("id").equals(id))
             .set("logs", logs);
 
-        self.conn().execute(update).await?;
+        self.conn().query(update).await?;
 
         Ok(())
     }
@@ -117,7 +117,7 @@ impl MigrationPersistence for SqlMigrationConnector {
             .so_that(Column::from("id").equals(id))
             .set("finished_at", chrono::Utc::now()); // TODO maybe use a database generated timestamp
 
-        self.conn().execute(update).await?;
+        self.conn().query(update).await?;
 
         Ok(())
     }

--- a/migration-engine/migration-engine-tests/src/multi_engine_test_api.rs
+++ b/migration-engine/migration-engine-tests/src/multi_engine_test_api.rs
@@ -305,6 +305,6 @@ impl EngineTestApi<'_> {
     /// Execute a raw SQL command and expect it to succeed.
     #[track_caller]
     pub fn raw_cmd(&self, cmd: &str) {
-        self.rt.block_on(self.connector.queryable().raw_cmd(cmd)).unwrap()
+        self.rt.block_on(self.connector.raw_cmd(cmd)).unwrap()
     }
 }

--- a/migration-engine/migration-engine-tests/src/test_api.rs
+++ b/migration-engine/migration-engine-tests/src/test_api.rs
@@ -207,21 +207,19 @@ impl TestApi {
     /// Like quaint::Queryable::query()
     #[track_caller]
     pub fn query(&self, q: quaint::ast::Query<'_>) -> ResultSet {
-        self.root.block_on(self.connector.queryable().query(q)).unwrap()
+        self.root.block_on(self.connector.query(q)).unwrap()
     }
 
     /// Like quaint::Queryable::query_raw()
     #[track_caller]
     pub fn query_raw(&self, q: &str, params: &[Value<'static>]) -> ResultSet {
-        self.root
-            .block_on(self.connector.queryable().query_raw(q, params))
-            .unwrap()
+        self.root.block_on(self.connector.query_raw(q, params)).unwrap()
     }
 
     /// Send a SQL command to the database, and expect it to succeed.
     #[track_caller]
     pub fn raw_cmd(&self, sql: &str) {
-        self.root.block_on(self.connector.queryable().raw_cmd(sql)).unwrap()
+        self.root.block_on(self.connector.raw_cmd(sql)).unwrap()
     }
 
     /// Render a table name with the required prefixing for use with quaint query building.


### PR DESCRIPTION
We want this to be a proper abstraction boundary, eventually.