### PR TITLE
Bail on invalid URL modification in node-api

### DIFF
--- a/libs/datamodel/connectors/datamodel-connector/src/lib.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/lib.rs
@@ -99,7 +99,10 @@ pub trait Connector: Send + Sync {
             }
         };
 
-        let mut url = url::Url::parse(url).unwrap();
+        let mut url = match url::Url::parse(url) {
+            Ok(url) => url,
+            Err(_) => return Cow::from(url), // bail
+        };
 
         let mut params: BTreeMap<String, String> =
             url.query_pairs().map(|(k, v)| (k.to_string(), v.to_string())).collect();


### PR DESCRIPTION
Connection string validation should happen somewhere else. We just avoid
crashing here for the handled error to show up.

closes https://github.com/prisma/prisma/issues/9308