### PR TITLE
Make migration connectors connect lazily

### DIFF
--- a/introspection-engine/introspection-engine-tests/src/test_api.rs
+++ b/introspection-engine/introspection-engine-tests/src/test_api.rs
@@ -40,9 +40,7 @@ impl TestApi {
             .collect();
 
         let (database, connection_string): (Quaint, String) = if tags.intersects(Tags::Vitess) {
-            let me = SqlMigrationConnector::new(connection_string, preview_features, None)
-                .await
-                .unwrap();
+            let me = SqlMigrationConnector::new(connection_string.to_owned(), preview_features, None).unwrap();
 
             me.reset().await.unwrap();
 

--- a/libs/sql-schema-describer/Cargo.toml
+++ b/libs/sql-schema-describer/Cargo.toml
@@ -5,8 +5,8 @@ name = "sql-schema-describer"
 version = "0.1.0"
 
 [dependencies]
-native-types = {path = "../native-types"}
-prisma-value = {path = "../prisma-value"}
+native-types = { path = "../native-types" }
+prisma-value = { path = "../prisma-value" }
 
 async-trait = "0.1.17"
 bigdecimal = "0.2"

--- a/migration-engine/cli/src/commands.rs
+++ b/migration-engine/cli/src/commands.rs
@@ -57,7 +57,8 @@ fn parse_base64_string(s: &str) -> Result<String, ConnectorError> {
 
 async fn connect_to_database(database_str: &str) -> Result<String, ConnectorError> {
     let datamodel = datasource_from_database_str(database_str)?;
-    migration_api(&datamodel).await?;
+    let api = migration_api(&datamodel).await?;
+    api.ensure_connection_validity().await?;
     Ok("Connection successful".to_owned())
 }
 

--- a/migration-engine/connectors/migration-connector/src/lib.rs
+++ b/migration-engine/connectors/migration-connector/src/lib.rs
@@ -53,6 +53,11 @@ pub trait MigrationConnector: Send + Sync + 'static {
     /// [DiffTarget](/enum.DiffTarget.html) for possible inputs.
     async fn diff(&self, from: DiffTarget<'_>, to: DiffTarget<'_>) -> ConnectorResult<Migration>;
 
+    /// Make sure the connection to the database is established and valid.
+    /// Connectors can choose to connect lazily, but this method should force
+    /// them to connect.
+    async fn ensure_connection_validity(&self) -> ConnectorResult<()>;
+
     /// The version of the underlying database.
     async fn version(&self) -> ConnectorResult<String>;
 

--- a/migration-engine/connectors/mongodb-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/mongodb-migration-connector/src/lib.rs
@@ -62,6 +62,10 @@ impl MigrationConnector for MongoDbMigrationConnector {
         "mongodb"
     }
 
+    async fn ensure_connection_validity(&self) -> ConnectorResult<()> {
+        Ok(())
+    }
+
     async fn version(&self) -> migration_connector::ConnectorResult<String> {
         Ok("4".to_owned())
     }

--- a/migration-engine/connectors/sql-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/lib.rs
@@ -25,10 +25,13 @@ use quaint::prelude::ConnectionInfo;
 use sql_migration::{DropUserDefinedType, DropView, SqlMigration, SqlMigrationStep};
 use sql_schema_describer::{walkers::SqlSchemaExt, ColumnId, SqlSchema, TableId};
 use std::env;
+use user_facing_errors::KnownError;
 
 /// The top-level SQL migration connector.
 pub struct SqlMigrationConnector {
-    connection: Connection,
+    connection: tokio::sync::OnceCell<ConnectorResult<Connection>>,
+    connection_string: String,
+    connection_info: ConnectionInfo,
     flavour: Box<dyn SqlFlavour + Send + Sync + 'static>,
     shadow_database_connection_string: Option<String>,
 }
@@ -40,13 +43,17 @@ impl SqlMigrationConnector {
         preview_features: BitFlags<PreviewFeature>,
         shadow_database_connection_string: Option<String>,
     ) -> ConnectorResult<Self> {
-        let connection = connect(connection_string).await?;
-        let flavour = flavour::from_connection_info(connection.connection_info(), preview_features);
+        let connection_info = ConnectionInfo::from_url(connection_string).map_err(|err| {
+            let details = user_facing_errors::quaint::invalid_connection_string_description(&err.to_string());
+            KnownError::new(user_facing_errors::common::InvalidConnectionString { details })
+        })?;
 
-        flavour.ensure_connection_validity(&connection).await?;
+        let flavour = flavour::from_connection_info(&connection_info, preview_features);
 
         Ok(Self {
-            connection,
+            connection_string: connection_string.to_owned(),
+            connection_info,
+            connection: tokio::sync::OnceCell::new(),
             flavour,
             shadow_database_connection_string,
         })
@@ -76,8 +83,18 @@ impl SqlMigrationConnector {
         flavour.qe_setup(database_str).await
     }
 
-    fn conn(&self) -> &Connection {
-        &self.connection
+    async fn conn(&self) -> ConnectorResult<&Connection> {
+        self.connection
+            .get_or_init(|| {
+                Box::pin(async {
+                    let connection = connect(&self.connection_string).await?;
+                    self.flavour.ensure_connection_validity(&connection).await?;
+                    Ok(connection)
+                })
+            })
+            .await
+            .as_ref()
+            .map_err(|err| err.clone())
     }
 
     fn flavour(&self) -> &(dyn SqlFlavour + Send + Sync) {
@@ -86,7 +103,7 @@ impl SqlMigrationConnector {
 
     /// Made public for tests.
     pub async fn describe_schema(&self) -> ConnectorResult<SqlSchema> {
-        self.connection.describe_schema().await
+        self.conn().await?.describe_schema().await
     }
 
     /// Try to reset the database to an empty state. This should only be used
@@ -178,17 +195,20 @@ impl SqlMigrationConnector {
         sql: &str,
         params: &[quaint::prelude::Value<'_>],
     ) -> ConnectorResult<quaint::prelude::ResultSet> {
-        Ok(self.connection.query_raw(sql, params).await?)
+        let conn = self.conn().await?;
+        Ok(conn.query_raw(sql, params).await?)
     }
 
     /// For tests
     pub async fn query(&self, query: impl Into<quaint::ast::Query<'_>>) -> ConnectorResult<quaint::prelude::ResultSet> {
-        Ok(self.connection.query(query).await?)
+        let conn = self.conn().await?;
+        Ok(conn.query(query).await?)
     }
 
     /// For tests
     pub async fn raw_cmd(&self, sql: &str) -> ConnectorResult<()> {
-        Ok(self.connection.raw_cmd(sql).await?)
+        let conn = self.conn().await?;
+        Ok(conn.raw_cmd(sql).await?)
     }
 
     /// Generate a name for a temporary (shadow) database, _if_ there is no user-configured shadow database url.
@@ -207,8 +227,9 @@ impl SqlMigrationConnector {
                 self.flavour.as_ref(),
             )),
             DiffTarget::Migrations(migrations) => {
+                let conn = self.conn().await?;
                 self.flavour()
-                    .sql_schema_from_migration_history(migrations, &self.connection, self)
+                    .sql_schema_from_migration_history(migrations, conn, self)
                     .await
             }
             DiffTarget::Database => self.describe_schema().await,
@@ -220,16 +241,22 @@ impl SqlMigrationConnector {
 #[async_trait::async_trait]
 impl MigrationConnector for SqlMigrationConnector {
     fn connector_type(&self) -> &'static str {
-        self.connection.connection_info().sql_family().as_str()
+        self.connection_info.sql_family().as_str()
     }
 
     async fn acquire_lock(&self) -> ConnectorResult<()> {
-        self.flavour().acquire_lock(self.conn()).await
+        let conn = self.conn().await?;
+        self.flavour().acquire_lock(conn).await
+    }
+
+    async fn ensure_connection_validity(&self) -> ConnectorResult<()> {
+        let conn = self.conn().await?;
+        self.flavour().ensure_connection_validity(conn).await
     }
 
     async fn version(&self) -> ConnectorResult<String> {
-        Ok(self
-            .connection
+        let conn = self.conn().await?;
+        Ok(conn
             .version()
             .await?
             .unwrap_or_else(|| "Database version information not available.".into()))
@@ -286,8 +313,9 @@ impl MigrationConnector for SqlMigrationConnector {
     }
 
     async fn reset(&self) -> ConnectorResult<()> {
-        if self.flavour.reset(self.conn()).await.is_err() {
-            self.best_effort_reset(self.conn()).await?;
+        let conn = self.conn().await?;
+        if self.flavour.reset(conn).await.is_err() {
+            self.best_effort_reset(conn).await?;
         }
 
         Ok(())
@@ -320,8 +348,9 @@ impl MigrationConnector for SqlMigrationConnector {
 
     #[tracing::instrument(skip(self, migrations))]
     async fn validate_migrations(&self, migrations: &[MigrationDirectory]) -> ConnectorResult<()> {
+        let conn = self.conn().await?;
         self.flavour()
-            .sql_schema_from_migration_history(migrations, self.conn(), self)
+            .sql_schema_from_migration_history(migrations, conn, self)
             .await?;
 
         Ok(())

--- a/migration-engine/connectors/sql-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/lib.rs
@@ -38,12 +38,12 @@ pub struct SqlMigrationConnector {
 
 impl SqlMigrationConnector {
     /// Construct and initialize the SQL migration connector.
-    pub async fn new(
-        connection_string: &str,
+    pub fn new(
+        connection_string: String,
         preview_features: BitFlags<PreviewFeature>,
         shadow_database_connection_string: Option<String>,
     ) -> ConnectorResult<Self> {
-        let connection_info = ConnectionInfo::from_url(connection_string).map_err(|err| {
+        let connection_info = ConnectionInfo::from_url(&connection_string).map_err(|err| {
             let details = user_facing_errors::quaint::invalid_connection_string_description(&err.to_string());
             KnownError::new(user_facing_errors::common::InvalidConnectionString { details })
         })?;
@@ -51,7 +51,7 @@ impl SqlMigrationConnector {
         let flavour = flavour::from_connection_info(&connection_info, preview_features);
 
         Ok(Self {
-            connection_string: connection_string.to_owned(),
+            connection_string,
             connection_info,
             connection: tokio::sync::OnceCell::new(),
             flavour,

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker.rs
@@ -274,21 +274,15 @@ impl SqlMigrationConnector {
 
         plan
     }
-
-    #[tracing::instrument(skip(self, migration), target = "SqlDestructiveChangeChecker::check")]
-    async fn check_impl(&self, migration: &SqlMigration) -> ConnectorResult<DestructiveChangeDiagnostics> {
-        let plan = self.plan(migration);
-
-        plan.execute(self.flavour(), self.conn()).await
-    }
 }
 
 #[async_trait::async_trait]
 impl DestructiveChangeChecker for SqlMigrationConnector {
     async fn check(&self, migration: &Migration) -> ConnectorResult<DestructiveChangeDiagnostics> {
         let plan = self.plan(migration.downcast_ref());
+        let conn = self.conn().await?;
 
-        plan.execute(self.flavour(), self.conn()).await
+        plan.execute(self.flavour(), conn).await
     }
 
     fn pure_check(&self, migration: &Migration) -> DestructiveChangeDiagnostics {

--- a/migration-engine/core/src/native.rs
+++ b/migration-engine/core/src/native.rs
@@ -56,13 +56,13 @@ pub async fn migration_api(datamodel: &str) -> CoreResult<Box<dyn api::GenericAp
                 u.query_pairs_mut().append_pair("statement_cache_size", "0");
             }
 
-            let connector = SqlMigrationConnector::new(u.as_str(), preview_features, shadow_database_url).await?;
+            let connector = SqlMigrationConnector::new(u.to_string(), preview_features, shadow_database_url)?;
 
             Ok(Box::new(connector))
         }
         #[cfg(feature = "sql")]
         MYSQL_SOURCE_NAME | SQLITE_SOURCE_NAME | MSSQL_SOURCE_NAME => {
-            let connector = SqlMigrationConnector::new(&url, preview_features, shadow_database_url).await?;
+            let connector = SqlMigrationConnector::new(url, preview_features, shadow_database_url)?;
 
             Ok(Box::new(connector))
         }

--- a/migration-engine/core/src/native/qe_setup.rs
+++ b/migration-engine/core/src/native/qe_setup.rs
@@ -26,7 +26,7 @@ pub async fn run(prisma_schema: &str) -> CoreResult<()> {
         {
             // 1. creates schema & database
             SqlMigrationConnector::qe_setup(&url).await?;
-            Box::new(SqlMigrationConnector::new(&url, preview_features, None).await?)
+            Box::new(SqlMigrationConnector::new(url, preview_features, None)?)
         }
         #[cfg(feature = "mongodb")]
         provider if provider == MONGODB_SOURCE_NAME => {

--- a/migration-engine/core/src/native/rpc.rs
+++ b/migration-engine/core/src/native/rpc.rs
@@ -36,6 +36,8 @@ pub async fn rpc_api(datamodel: &str) -> CoreResult<IoHandler> {
     let mut io_handler = IoHandler::default();
     let executor = Arc::new(crate::migration_api(datamodel).await?);
 
+    executor.ensure_connection_validity().await?;
+
     for cmd in AVAILABLE_COMMANDS {
         let executor = executor.clone();
         io_handler.add_method(cmd, move |params: Params| {

--- a/migration-engine/migration-engine-tests/src/test_api.rs
+++ b/migration-engine/migration-engine-tests/src/test_api.rs
@@ -5,7 +5,9 @@ pub use test_macros::test_connector;
 pub use test_setup::{BitFlags, Capabilities, Tags};
 
 use crate::{commands::*, multi_engine_test_api::TestApi as RootTestApi};
-use migration_connector::{DatabaseMigrationStepApplier, DiffTarget, MigrationConnector, MigrationPersistence};
+use migration_connector::{
+    ConnectorResult, DatabaseMigrationStepApplier, DiffTarget, MigrationConnector, MigrationPersistence,
+};
 use quaint::{
     prelude::{ConnectionInfo, ResultSet},
     Value,
@@ -44,6 +46,10 @@ impl TestApi {
 
     pub fn connection_info(&self) -> ConnectionInfo {
         self.root.connection_info()
+    }
+
+    pub fn ensure_connection_validity(&self) -> ConnectorResult<()> {
+        self.block_on(self.connector.ensure_connection_validity())
     }
 
     pub fn schema_name(&self) -> String {

--- a/migration-engine/migration-engine-tests/tests/errors/error_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/errors/error_tests.rs
@@ -339,13 +339,15 @@ fn unique_constraint_errors_in_migrations_must_return_a_known_error(api: TestApi
 }
 
 #[test_connector(tags(Mysql56))]
-fn json_fields_must_be_rejected(api: TestApi) {
+fn json_fields_must_be_rejected_on_mysql_5_6(api: TestApi) {
     let dm = r#"
         model Test {
             id Int @id
             j Json
         }
         "#;
+
+    api.ensure_connection_validity().unwrap();
 
     let result = api
         .schema_push_w_datasource(dm)

--- a/migration-engine/migration-engine-tests/tests/initialization/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/initialization/mod.rs
@@ -54,7 +54,8 @@ fn connecting_to_a_postgres_database_with_missing_schema_creates_it(api: TestApi
             url
         );
 
-        api.block_on(migration_api(&datamodel)).unwrap();
+        let me = api.block_on(migration_api(&datamodel)).unwrap();
+        api.block_on(me.ensure_connection_validity()).unwrap();
     }
 
     // Check that the "unexpected" schema now exists.

--- a/migration-engine/migration-engine-tests/tests/migrations/migrate_lock.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/migrate_lock.rs
@@ -18,7 +18,7 @@ fn create_migration_with_new_provider_errors(api: TestApi) {
     "#;
 
     let migrations_directory = api.create_migrations_directory();
-    let engine = api.new_engine_with_connection_strings(api.connection_string(), None);
+    let engine = api.new_engine_with_connection_strings(api.connection_string().to_owned(), None);
 
     engine.create_migration("01init", dm, &migrations_directory).send_sync();
 
@@ -33,7 +33,7 @@ fn create_migration_with_new_provider_errors(api: TestApi) {
         }
     "#;
 
-    let sqlite_engine = api.new_engine_with_connection_strings(&sqlite_test_url("migratelocktest"), None);
+    let sqlite_engine = api.new_engine_with_connection_strings(sqlite_test_url("migratelocktest"), None);
 
     let err = sqlite_engine
         .create_migration("02switchprovider", dm2, &migrations_directory)
@@ -83,7 +83,7 @@ fn migration_lock_with_different_comment_shapes_work(api: TestApi) {
 
     let migration_lock_path = migrations_directory.path().join("migration_lock.toml");
 
-    let engine = api.new_engine_with_connection_strings(api.connection_string(), None);
+    let engine = api.new_engine_with_connection_strings(api.connection_string().to_owned(), None);
 
     for contents in contents {
         let span = tracing::info_span!("Contents", contents = contents);

--- a/migration-engine/migration-engine-tests/tests/migrations/shadow_database_url_configuration.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/shadow_database_url_configuration.rs
@@ -84,7 +84,7 @@ fn shadow_db_url_can_be_configured_on_postgres(api: TestApi) {
 
     // Check that commands using the shadow database work.
     {
-        let engine = api.new_engine_with_connection_strings(&test_user_connection_string, Some(custom_shadow_db_url));
+        let engine = api.new_engine_with_connection_strings(test_user_connection_string, Some(custom_shadow_db_url));
 
         engine
             .apply_migrations(&migrations_directory)
@@ -121,8 +121,10 @@ fn shadow_db_url_must_not_match_main_url(api: TestApi) {
 
     // URLs match -> error
     {
-        let engine =
-            api.new_engine_with_connection_strings(api.connection_string(), Some(api.connection_string().to_owned()));
+        let engine = api.new_engine_with_connection_strings(
+            api.connection_string().to_owned(),
+            Some(api.connection_string().to_owned()),
+        );
 
         let err = engine
             .create_migration("01init", schema, &migrations_directory)
@@ -140,7 +142,7 @@ fn shadow_db_url_must_not_match_main_url(api: TestApi) {
         let mut url: url::Url = api.connection_string().parse().unwrap();
         url.set_path("/testshadowdb0002");
 
-        let engine = api.new_engine_with_connection_strings(api.connection_string(), Some(url.to_string()));
+        let engine = api.new_engine_with_connection_strings(api.connection_string().to_owned(), Some(url.to_string()));
 
         engine
             .create_migration("01init", schema, &migrations_directory)
@@ -163,7 +165,7 @@ fn shadow_db_not_reachable_error_must_have_the_right_connection_info(api: TestAp
     let mut url: url::Url = api.connection_string().parse().unwrap();
     url.set_port(Some(39824)).unwrap(); // let's assume no database is running on that port
 
-    let engine = api.new_engine_with_connection_strings(api.connection_string(), Some(url.to_string()));
+    let engine = api.new_engine_with_connection_strings(api.connection_string().to_owned(), Some(url.to_string()));
 
     let err = engine
         .create_migration("01init", schema, &migrations_directory)

--- a/migration-engine/migration-engine-tests/tests/migrations/soft_resets.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/soft_resets.rs
@@ -50,7 +50,7 @@ fn soft_resets_work_on_postgres(api: TestApi) {
 
     // Check that the soft reset works with migrations, then with schema push.
     {
-        let engine = api.new_engine_with_connection_strings(&test_user_connection_string, None);
+        let engine = api.new_engine_with_connection_strings(test_user_connection_string, None);
 
         engine
             .apply_migrations(&migrations_directory)
@@ -157,7 +157,7 @@ fn soft_resets_work_on_sql_server(api: TestApi) {
 
     // Check that the soft reset works with migrations, then with schema push.
     {
-        let engine = api.new_engine_with_connection_strings(&test_user_connection_string, None);
+        let engine = api.new_engine_with_connection_strings(test_user_connection_string, None);
 
         let create_schema = format!("CREATE SCHEMA [{}];", engine.schema_name());
         engine.raw_cmd(&create_schema);
@@ -273,7 +273,7 @@ fn soft_resets_work_on_mysql(api: TestApi) {
 
     // Check that the soft reset works with migrations, then with schema push.
     {
-        let engine = api.new_engine_with_connection_strings(&test_user_connection_string, None);
+        let engine = api.new_engine_with_connection_strings(test_user_connection_string, None);
 
         engine.reset().send_sync();
         engine.assert_schema().assert_tables_count(0);


### PR DESCRIPTION
The JSON-RPC API is still eager. The next step will be to make it lazy
too. That will enable:

- Unifying the API surface of the migration engine CLI: JSON-RPC only
- Better test harnesses
- Removing qe_setup in favour of MigrationConnector::diff(), which
  should speed up query engine tests a lot.

Additionally, this is pointing towards a clear future direction for the
sql-migration-connector, where all the state is held inside the
SqlFlavour.