### PR TITLE
feat: add "dataProxy" feature flag for client

### DIFF
--- a/libs/datamodel/core/src/common/preview_features.rs
+++ b/libs/datamodel/core/src/common/preview_features.rs
@@ -75,7 +75,7 @@ pub static GENERATOR: Lazy<FeatureMap> = Lazy::new(|| {
             MongoDb,
             InteractiveTransactions,
             FullTextSearch,
-            DataProxy
+            DataProxy,
         ])
         .with_deprecated(vec![
             AtomicNumberOperations,

--- a/libs/datamodel/core/src/common/preview_features.rs
+++ b/libs/datamodel/core/src/common/preview_features.rs
@@ -59,7 +59,8 @@ features!(
     ReferentialActions,
     InteractiveTransactions,
     NamedConstraints,
-    FullTextSearch
+    FullTextSearch,
+    DataProxy,
 );
 
 // Mapping of which active, deprecated and hidden
@@ -74,6 +75,7 @@ pub static GENERATOR: Lazy<FeatureMap> = Lazy::new(|| {
             MongoDb,
             InteractiveTransactions,
             FullTextSearch,
+            DataProxy
         ])
         .with_deprecated(vec![
             AtomicNumberOperations,

--- a/libs/datamodel/core/tests/config/generators.rs
+++ b/libs/datamodel/core/tests/config/generators.rs
@@ -257,7 +257,7 @@ fn nice_error_for_unknown_generator_preview_feature() {
         .unwrap_err();
 
     let expectation = expect![[r#"
-        [1;91merror[0m: [1mThe preview feature "foo" is not known. Expected one of: filterJson, referentialIntegrity, mongoDb, interactiveTransactions, fullTextSearch[0m
+        [1;91merror[0m: [1mThe preview feature "foo" is not known. Expected one of: filterJson, referentialIntegrity, mongoDb, interactiveTransactions, fullTextSearch, dataProxy[0m
           [1;94m-->[0m  [4mschema.prisma:3[0m
         [1;94m   | [0m
         [1;94m 2 | [0m  provider = "prisma-client-js"


### PR DESCRIPTION
## Overview

Add a preview flag "dataProxy" that's only used by the clients at the request of @millsp