### PR TITLE
Comment out [lib] section of prisma-fmt/Cargo.toml

### DIFF
--- a/.github/workflows/migration-engine.yml
+++ b/.github/workflows/migration-engine.yml
@@ -71,8 +71,8 @@ jobs:
             url: "postgresql://postgres:prisma@localhost:5434"
           - name: postgres13
             url: "postgresql://postgres:prisma@localhost:5435"
-          - name: cockroach
-            url: "postgresql://root@localhost:5436"
+          # - name: cockroach
+          #   url: "postgresql://root@localhost:5436"
             is_cockroach: true
           - name: sqlite
             url: sqlite

--- a/prisma-fmt/Cargo.toml
+++ b/prisma-fmt/Cargo.toml
@@ -4,8 +4,10 @@ version = "0.1.0"
 authors = ["Emanuel Joebstl <emanuel.joebstl@gmail.com>"]
 edition = "2018"
 
-[lib]
-crate-type = ["cdylib"]
+# crate-type for wasm builds.
+# Commented out because it fails binary builds on linux-musl (Alpine).
+# [lib]
+# crate-type = ["cdylib"]
 
 [dependencies]
 datamodel = { path = "../libs/datamodel/core" }


### PR DESCRIPTION
This is because builds are failing on linux-musl (Alpine), as dynamic
linking is just not supported. That section is for the wasm builds,
which are not in CI yet, so it should improve the situation.

The wasm build situation is less than ideal, I want to explore
alternatives, and in particular not building from prisma-engines.