### PR TITLE
chore(mongo): unexclude some `orderByRelation` tests

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent.rs
@@ -307,7 +307,7 @@ mod order_by_dependent {
         schema.to_string()
     }
 
-    #[connector_test(schema(multiple_rel_same_model))] // Mongo is excluded due to CI issues (version drift?).
+    #[connector_test(schema(multiple_rel_same_model))]
     async fn multiple_rel_same_model_order_by(runner: Runner) -> TestResult<()> {
         // test data
         run_query!(

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent.rs
@@ -307,7 +307,7 @@ mod order_by_dependent {
         schema.to_string()
     }
 
-    #[connector_test(schema(multiple_rel_same_model), exclude(MongoDb))] // Mongo is excluded due to CI issues (version drift?).
+    #[connector_test(schema(multiple_rel_same_model))] // Mongo is excluded due to CI issues (version drift?).
     async fn multiple_rel_same_model_order_by(runner: Runner) -> TestResult<()> {
         // test data
         run_query!(

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent_pagination.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent_pagination.rs
@@ -316,7 +316,7 @@ mod order_by_dependent_pag {
         schema.to_string()
     }
 
-    #[connector_test(schema(multiple_rel_same_model))] // Mongo is excluded due to CI issues (version drift?).
+    #[connector_test(schema(multiple_rel_same_model))]
     async fn multiple_rel_same_model_order_by(runner: Runner) -> TestResult<()> {
         // test data
         run_query!(

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent_pagination.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent_pagination.rs
@@ -316,7 +316,7 @@ mod order_by_dependent_pag {
         schema.to_string()
     }
 
-    #[connector_test(schema(multiple_rel_same_model), exclude(MongoDb))] // Mongo is excluded due to CI issues (version drift?).
+    #[connector_test(schema(multiple_rel_same_model))] // Mongo is excluded due to CI issues (version drift?).
     async fn multiple_rel_same_model_order_by(runner: Runner) -> TestResult<()> {
         // test data
         run_query!(


### PR DESCRIPTION
## Overview

Closes https://github.com/prisma/prisma/issues/9158

- Unexclude the last `orderByRelation` tests in CI for MongoDB