### PR TITLE
Incorporate `create_database()` and `drop_database()` into GenericApi

### DIFF
--- a/.test_database_urls/mysql_5_7
+++ b/.test_database_urls/mysql_5_7
@@ -1,2 +1,2 @@
 export TEST_DATABASE_URL="mysql://root:prisma@localhost:3306"
-set -e TEST_SHADOW_DATABASE_URL
+unset TEST_SHADOW_DATABASE_URL

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
@@ -167,7 +167,7 @@ impl Connector for PostgresDatamodelConnector {
 
     /// The maximum length of postgres identifiers, in bytes.
     ///
-    /// Reference: https://www.postgresql.org/docs/12/limits.html
+    /// Reference: <https://www.postgresql.org/docs/12/limits.html>
     fn constraint_name_length(&self) -> usize {
         63
     }

--- a/migration-engine/connectors/migration-connector/src/lib.rs
+++ b/migration-engine/connectors/migration-connector/src/lib.rs
@@ -49,9 +49,15 @@ pub trait MigrationConnector: Send + Sync + 'static {
     /// the connector name. The SQL connector for example can return "postgresql", "mysql" or "sqlite".
     fn connector_type(&self) -> &'static str;
 
+    /// Create the database referenced by Prisma schema that was used to initialize the connector.
+    async fn create_database(&self) -> ConnectorResult<String>;
+
     /// Create a migration by comparing two database schemas. See
     /// [DiffTarget](/enum.DiffTarget.html) for possible inputs.
     async fn diff(&self, from: DiffTarget<'_>, to: DiffTarget<'_>) -> ConnectorResult<Migration>;
+
+    /// Drop the database referenced by Prisma schema that was used to initialize the connector.
+    async fn drop_database(&self) -> ConnectorResult<()>;
 
     /// Make sure the connection to the database is established and valid.
     /// Connectors can choose to connect lazily, but this method should force

--- a/migration-engine/connectors/mongodb-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/mongodb-migration-connector/src/lib.rs
@@ -62,6 +62,10 @@ impl MigrationConnector for MongoDbMigrationConnector {
         "mongodb"
     }
 
+    async fn create_database(&self) -> ConnectorResult<String> {
+        todo!();
+    }
+
     async fn ensure_connection_validity(&self) -> ConnectorResult<()> {
         Ok(())
     }
@@ -85,6 +89,10 @@ impl MigrationConnector for MongoDbMigrationConnector {
             }
             _ => todo!(),
         }
+    }
+
+    async fn drop_database(&self) -> ConnectorResult<()> {
+        todo!();
     }
 
     fn migration_file_extension(&self) -> &'static str {

--- a/migration-engine/core/src/native.rs
+++ b/migration-engine/core/src/native.rs
@@ -68,47 +68,10 @@ pub async fn migration_api(datamodel: &str) -> CoreResult<Box<dyn api::GenericAp
         }
         #[cfg(feature = "mongodb")]
         MONGODB_SOURCE_NAME => Ok(Box::new(MongoDbMigrationConnector::new(&url).await?)),
-        x => unimplemented!("Connector {} is not supported yet", x),
-    }
-}
-
-/// Create the database referenced by the passed in Prisma schema.
-pub async fn create_database(schema: &str) -> CoreResult<String> {
-    let (source, url, _preview_features, _shadow_database_url) = parse_configuration(schema)?;
-
-    match &source.active_provider {
-        provider
-            if [
-                MYSQL_SOURCE_NAME,
-                POSTGRES_SOURCE_NAME,
-                SQLITE_SOURCE_NAME,
-                MSSQL_SOURCE_NAME,
-            ]
-            .contains(&provider.as_str()) =>
-        {
-            Ok(SqlMigrationConnector::create_database(&url).await?)
-        }
-        x => unimplemented!("Connector {} is not supported yet", x),
-    }
-}
-
-/// Drop the database referenced by the passed in Prisma schema.
-pub async fn drop_database(schema: &str) -> CoreResult<()> {
-    let (source, url, _preview_features, _shadow_database_url) = parse_configuration(schema)?;
-
-    match &source.active_provider {
-        provider
-            if [
-                MYSQL_SOURCE_NAME,
-                POSTGRES_SOURCE_NAME,
-                SQLITE_SOURCE_NAME,
-                MSSQL_SOURCE_NAME,
-            ]
-            .contains(&provider.as_str()) =>
-        {
-            Ok(SqlMigrationConnector::drop_database(&url).await?)
-        }
-        x => unimplemented!("Connector {} is not supported yet", x),
+        provider => Err(CoreError::from_msg(format!(
+            "`{}` is not a supported connector.",
+            provider
+        ))),
     }
 }
 


### PR DESCRIPTION
`create_database()` is the implementation behind `migration-engine
--create-database`, used by the Prisma CLI. 
From the very beginning of
the Rust migration engine until this commit, it was implemented as a
separate top-level free-standing function that does not go through the
migration engine JSON-RPC API.

The reason behind this was that the JSON-RPC API eagerly connected to
the database, which tends to not work well for `create_database()` for
obvious reasons.

The consequence was a larger top-level library API for the migration
engine, and a different way to call the migration engine for the Prisma
CLI. This is unnecessary complexity.

Here, we are starting to reap the benefits of
b5a631aa090a4e69da6f48d2b1bb459dbe317a4b by unifying the migration
engine API: for rust code, only `GenericApi`, and for the CLI, only
JSON-RPC. The previous API is kept as a shim on top of the new one.