### PR TITLE
MySQL: Explicitely make column `NULL` if optional

### DIFF
--- a/libs/sql-ddl/src/mysql.rs
+++ b/libs/sql-ddl/src/mysql.rs
@@ -150,6 +150,8 @@ impl Display for Column<'_> {
 
         if self.not_null {
             f.write_str(" NOT NULL")?;
+        } else {
+            f.write_str(" NULL")?;
         }
 
         if self.auto_increment {
@@ -344,7 +346,7 @@ mod tests {
         let expected = indoc!(
             r#"
             CREATE TABLE `Cat` (
-                `id` INTEGER AUTO_INCREMENT PRIMARY KEY
+                `id` INTEGER NULL AUTO_INCREMENT PRIMARY KEY
             ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci
             "#,
         )

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
@@ -318,7 +318,7 @@ fn render_mysql_modify(
         nullability = if next_column.arity().is_required() {
             " NOT NULL"
         } else {
-            ""
+            " NULL"
         },
         default = default,
         sequence = if next_column.is_autoincrement() {

--- a/migration-engine/migration-engine-tests/tests/migrations/basic.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/basic.rs
@@ -160,6 +160,21 @@ fn adding_an_optional_field_must_work(api: TestApi) {
     });
 }
 
+#[test_connector(tags(Mysql))]
+fn adding_an_optional_datetime_field_must_work(api: TestApi) {
+    let dm2 = r#"
+        model Test {
+            id String @id @default(cuid())
+            field DateTime? @db.Timestamp
+        }
+    "#;
+
+    api.schema_push_w_datasource(dm2).send().assert_green();
+    api.assert_schema().assert_table("Test", |table| {
+        table.assert_column("field", |column| column.assert_default(None).assert_is_nullable())
+    });
+}
+
 #[test_connector]
 fn adding_an_id_field_with_a_special_name_must_work(api: TestApi) {
     let dm2 = r#"


### PR DESCRIPTION
MariaDB is having a nice feature, that if you do not do this, and your column type is `TIMESTAMP`, it'll make it `NOT NULL` and set the default to be `0000-00-00 00:00:00.000`.

Closes: https://github.com/prisma/prisma/issues/9438