### PR TITLE
Raw SQL query with unnamed parameters

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/src/schemas/basic.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/src/schemas/basic.rs
@@ -176,3 +176,7 @@ pub fn autoinc_id() -> String {
 
     schema.to_owned()
 }
+
+pub fn empty() -> String {
+    "".to_owned()
+}

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
@@ -1,1 +1,2 @@
+mod prisma_6173;
 mod prisma_8265;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_6173.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_6173.rs
@@ -6,10 +6,10 @@ mod query_raw {
     // MariaDB is the only one supporting anon blocks
     #[connector_test(only(MySQL("mariadb")))]
     async fn mysql_call(runner: Runner) -> TestResult<()> {
-        // Create a simple table for the test
 
+        // Create a simple table for the test
         runner
-            .query(fmt_execute_raw("CREATE TABLE test (id INT PRIMARY KEY);", vec![]))
+            .query(fmt_execute_raw("CREATE TABLE test (id INT);", vec![]))
             .await?
             .assert_success();
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_6173.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_6173.rs
@@ -1,0 +1,3 @@
+fn raw_query() {
+
+}

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_6173.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_6173.rs
@@ -1,3 +1,31 @@
-fn raw_query() {
+use query_engine_tests::*;
 
+#[test_suite(schema(empty))]
+mod query_raw {
+
+    // MariaDB is the only one supporting anon blocks
+    #[connector_test(only(MySQL("mariadb")))]
+    async fn mysql_call(runner: Runner) -> TestResult<()> {
+        // Create a simple table for the test
+
+        runner
+            .query(fmt_execute_raw("CREATE TABLE test (id INT PRIMARY KEY);", vec![]))
+            .await?
+            .assert_success();
+
+        // fmt_execute_raw cannot run this query, doing it directly instead
+        runner
+            .query(indoc! {r#"
+            mutation {
+                queryRaw(
+                    query: "BEGIN NOT ATOMIC\n INSERT INTO test VALUES(FLOOR(RAND()*1000));\n SELECT * FROM test;\n END",
+                    parameters: "[]"
+                )
+            }
+            "#})
+            .await?
+            .assert_success();
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
 - In certain cases, raw query returns no column names in `ResultSet`
 - This breaks JSON result sets
 - This fixes https://github.com/prisma/prisma/issues/6173