### PR TITLE
Add a friendly panic message for missing pk col

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1047,6 +1047,7 @@ dependencies = [
  "chrono",
  "cuid",
  "enumflags2",
+ "indoc",
  "native-types",
  "prisma-value",
  "serde",

--- a/libs/datamodel/connectors/dml/Cargo.toml
+++ b/libs/datamodel/connectors/dml/Cargo.toml
@@ -15,6 +15,7 @@ serde = { version = "1.0.90", features = ["derive"] }
 serde_json = { version = "1.0", features = ["float_roundtrip"] }
 native-types = { path = "../../../native-types" }
 enumflags2 = "0.7"
+indoc = "1"
 
 [features]
 # Support for generating default UUID and CUID default values. This implies


### PR DESCRIPTION
We have these ever now and then on our error reporting. After digging and digging into these, the result is always `CANNOT REPRODUCE`. The next goal is to add a bit more info to the crash, and ask for the user to contact us, so we know a bit more about their environment.

One of the crashes is by looking into the schema from a user in a country that does not use English as their primary language. The database is MySQL 5.6 and might be using a setting that breaks our introspection.

Helps solving https://github.com/prisma/prisma/issues/9546