### PR TITLE
Exclude CockroachDB from certain FK checks Postgres allows

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_delete/set_default.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_delete/set_default.rs
@@ -84,8 +84,8 @@ mod one2one_req {
     }
 
     /// Deleting the parent with no default for SetDefault fails.
-    /// Only postgres allows setting no default for a SetDefault FK.
-    #[connector_test(schema(required_without_default), only(Postgres))]
+    /// Only postgres (except CockroachDB) allows setting no default for a SetDefault FK.
+    #[connector_test(schema(required_without_default), only(Postgres), exclude(Cockroach))]
     async fn delete_parent_fail(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(&runner, r#"mutation { createOneParent(data: { id: 1, child: { create: { id: 1 }}}) { id }}"#),
@@ -288,8 +288,8 @@ mod one2many_req {
     }
 
     /// Deleting the parent with no default for SetDefault fails.
-    /// Only postgres allows setting no default for a SetDefault FK.
-    #[connector_test(schema(required_without_default), only(Postgres))]
+    /// Only postgres (except CockroachDB) allows setting no default for a SetDefault FK.
+    #[connector_test(schema(required_without_default), only(Postgres), exclude(Cockroach))]
     async fn delete_parent_fail(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(&runner, r#"mutation { createOneParent(data: { id: 1, children: { create: { id: 1 }}}) { id }}"#),

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_delete/set_null.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_delete/set_null.rs
@@ -1,9 +1,9 @@
-//! Only Postgres allows SetNull on a non-nullable FK at all, rest fail during migration.
+//! Only Postgres (except CockroachDB) allows SetNull on a non-nullable FK at all, rest fail during migration.
 
 use indoc::indoc;
 use query_engine_tests::*;
 
-#[test_suite(suite = "setnull_onD_1to1_req", schema(required), only(Postgres))]
+#[test_suite(suite = "setnull_onD_1to1_req", schema(required), only(Postgres), exclude(Cockroach))]
 mod one2one_req {
     fn required() -> String {
         let schema = indoc! {
@@ -90,7 +90,7 @@ mod one2one_opt {
     }
 }
 
-#[test_suite(suite = "setnull_onD_1toM_req", schema(required), only(Postgres))]
+#[test_suite(suite = "setnull_onD_1toM_req", schema(required), only(Postgres), exclude(Cockroach))]
 mod one2many_req {
     fn required() -> String {
         let schema = indoc! {
@@ -110,7 +110,7 @@ mod one2many_req {
     }
 
     /// Deleting the parent must fail if a child is connected (because of null key violation).
-    #[connector_test]
+    #[connector_test(exclude(Cockroach))]
     async fn delete_parent_failure(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(&runner, r#"mutation { createOneParent(data: { id: 1, children: { create: { id: 1 }}}) { id }}"#),

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_update/set_default.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_update/set_default.rs
@@ -86,8 +86,8 @@ mod one2one_req {
     }
 
     /// Updating the parent with no default for SetDefault fails.
-    /// Only postgres allows setting no default for a SetDefault FK.
-    #[connector_test(schema(required_without_default), only(Postgres))]
+    /// Only postgres (except CockroachDB) allows setting no default for a SetDefault FK.
+    #[connector_test(schema(required_without_default), only(Postgres), exclude(Cockroach))]
     async fn update_parent_fail(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(&runner, r#"mutation { createOneParent(data: { id: 1, uniq: "1", child: { create: { id: 1 }}}) { id }}"#),
@@ -294,8 +294,8 @@ mod one2many_req {
     }
 
     /// Updating the parent with no default for SetDefault fails.
-    /// Only postgres allows setting no default for a SetDefault FK.
-    #[connector_test(schema(required_without_default), only(Postgres))]
+    /// Only postgres (except CockroachDB) allows setting no default for a SetDefault FK.
+    #[connector_test(schema(required_without_default), only(Postgres), exclude(Cockroach))]
     async fn update_parent_fail(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(&runner, r#"mutation { createOneParent(data: { id: 1, uniq: "1", children: { create: { id: 1 }}}) { id }}"#),

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_update/set_null.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_update/set_null.rs
@@ -1,9 +1,9 @@
-//! Only Postgres allows SetNull on a non-nullable FK at all, rest fail during migration.
+//! Only Postgres (except CockroachDB) allows SetNull on a non-nullable FK at all, rest fail during migration.
 
 use indoc::indoc;
 use query_engine_tests::*;
 
-#[test_suite(suite = "setnull_onU_1to1_req", schema(required), only(Postgres))]
+#[test_suite(suite = "setnull_onU_1to1_req", schema(required), only(Postgres), exclude(Cockroach))]
 mod one2one_req {
     fn required() -> String {
         let schema = indoc! {
@@ -92,7 +92,7 @@ mod one2one_opt {
     }
 }
 
-#[test_suite(suite = "setnull_onU_1toM_req", schema(required), only(Postgres))]
+#[test_suite(suite = "setnull_onU_1toM_req", schema(required), only(Postgres), exclude(Cockroach))]
 mod one2many_req {
     fn required() -> String {
         let schema = indoc! {

--- a/query-engine/connector-test-kit-rs/query-test-macros/src/args/connector_test.rs
+++ b/query-engine/connector-test-kit-rs/query-test-macros/src/args/connector_test.rs
@@ -28,7 +28,6 @@ pub struct ConnectorTestArgs {
 
 impl ConnectorTestArgs {
     pub fn validate(&self, on_module: bool) -> Result<(), darling::Error> {
-        validate_only_exclude(&self.only, &self.exclude, on_module)?;
         validate_suite(&self.suite, on_module)?;
 
         if self.schema.is_none() && !on_module {

--- a/query-engine/connector-test-kit-rs/query-test-macros/src/args/relation_link_test.rs
+++ b/query-engine/connector-test-kit-rs/query-test-macros/src/args/relation_link_test.rs
@@ -29,7 +29,6 @@ pub struct RelationLinkTestArgs {
 
 impl RelationLinkTestArgs {
     pub fn validate(&self, on_module: bool) -> Result<(), darling::Error> {
-        validate_only_exclude(&self.only, &self.exclude, on_module)?;
         validate_suite(&self.suite, on_module)?;
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-test-macros/src/args/utils.rs
+++ b/query-engine/connector-test-kit-rs/query-test-macros/src/args/utils.rs
@@ -1,20 +1,6 @@
 use super::*;
 use query_tests_setup::ConnectorTag;
 
-pub fn validate_only_exclude(
-    only: &OnlyConnectorTags,
-    exclude: &ExcludeConnectorTags,
-    on_module: bool,
-) -> Result<(), darling::Error> {
-    if !only.is_empty() && !exclude.is_empty() && !on_module {
-        return Err(darling::Error::custom(
-            "Only one of `only` and `exclude` can be specified for a connector test.",
-        ));
-    }
-
-    Ok(())
-}
-
 pub fn validate_suite(suite: &Option<String>, on_module: bool) -> Result<(), darling::Error> {
     if suite.is_none() && !on_module {
         return Err(darling::Error::custom(
@@ -27,6 +13,14 @@ pub fn validate_suite(suite: &Option<String>, on_module: bool) -> Result<(), dar
 
 pub fn connectors_to_test(only: &OnlyConnectorTags, exclude: &ExcludeConnectorTags) -> Vec<ConnectorTag> {
     if !only.is_empty() {
+        if !exclude.is_empty() {
+            return only
+                .tags()
+                .to_vec()
+                .into_iter()
+                .filter(|tag| !exclude.tags().contains(tag))
+                .collect();
+        }
         only.tags().to_vec()
     } else if !exclude.is_empty() {
         let all = ConnectorTag::all();


### PR DESCRIPTION
This also allows `only` and `exclude` in the query tests in the same
macro. We allow this in introspection tests and it is useful for CRDB
tests as well.