### PR TITLE
Add simple test mode

### DIFF
--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/schema_gen/schema_with_relation.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/schema_gen/schema_with_relation.rs
@@ -116,8 +116,7 @@ pub fn schema_with_relation(
         FULL_ID_OPTIONS.to_vec()
     };
 
-    // TODO: Remove if we're sure we don't ever wanna keep the simple mode
-    let simple = false;
+    let simple = std::env::var("SIMPLE_TEST_MODE").is_ok();
     let mut datamodels: Vec<DatamodelWithParams> = vec![];
     let mut required_capabilities: Vec<Vec<ConnectorCapability>> = vec![];
 
@@ -171,10 +170,10 @@ pub fn schema_with_relation(
                                     {parent_field}
                                     non_unique    String?
                                     {parent_id}
-                
+
                                     @@unique([p_1, p_2])
                                 }}
-                
+
                                 model Child {{
                                     c              String    @unique
                                     c_1            String
@@ -182,7 +181,7 @@ pub fn schema_with_relation(
                                     {child_field}
                                     non_unique     String?
                                     {child_id}
-                
+
                                     @@unique([c_1, c_2])
                                 }}
                             ",


### PR DESCRIPTION
Env var `SIMPLE_TEST_MODE=<anything>` will now reduce the relation link test matrix dramatically (resulting in ~7500 tests overall, down from ~18k). 