### PR TITLE
Move implicit unique indexes to the parser db

### DIFF
--- a/libs/datamodel/core/src/transform/ast_to_dml/db.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db.rs
@@ -4,6 +4,7 @@
 
 mod attributes;
 mod context;
+mod indexes;
 mod names;
 mod relations;
 mod types;
@@ -100,6 +101,9 @@ impl<'ast> ParserDatabase<'ast> {
 
         // Fifth step: relation inference
         relations::infer_relations(&mut ctx);
+
+        // Sixth step: infering implicit indices
+        indexes::infer_implicit_indexes(&mut ctx);
 
         ctx.finish()
     }

--- a/libs/datamodel/core/src/transform/ast_to_dml/db/attributes.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/attributes.rs
@@ -220,7 +220,7 @@ fn visit_scalar_field_attributes<'ast>(
             validate_db_name(ast_model, args, db_name, "@unique", ctx);
 
 
-            model_attributes.indexes.push((args.attribute(), IndexAttribute {
+            model_attributes.ast_indexes.push((args.attribute(), IndexAttribute {
                 is_unique: true,
                 fields: vec![field_id],
                 source_field: Some(field_id),
@@ -529,7 +529,7 @@ fn model_index<'ast>(
         (None, None) => None,
     };
 
-    data.indexes.push((args.attribute(), index_attribute));
+    data.ast_indexes.push((args.attribute(), index_attribute));
 }
 
 /// Validate @@unique on models.
@@ -584,7 +584,7 @@ fn model_unique<'ast>(
     index_attribute.name = name;
     index_attribute.db_name = db_name.map(Cow::from);
 
-    data.indexes.push((args.attribute(), index_attribute));
+    data.ast_indexes.push((args.attribute(), index_attribute));
 }
 
 fn common_index_validations<'ast>(

--- a/libs/datamodel/core/src/transform/ast_to_dml/db/indexes.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/indexes.rs
@@ -1,0 +1,71 @@
+use std::borrow::Cow;
+
+use crate::common::constraint_names::ConstraintNames;
+
+use super::{context::Context, types::IndexAttribute};
+
+/// Prisma forces a 1:1 relation to be unique from the defining side. If the
+/// field is not a primary key or already defined in a unique index, we add an
+/// implicit unique index to that field here.
+pub(super) fn infer_implicit_indexes(ctx: &mut Context<'_>) {
+    let mut indexes = Vec::new();
+
+    for relation in ctx.db.walk_explicit_relations() {
+        if !relation.relation_type().is_one_to_one() {
+            continue;
+        }
+
+        let model = relation.referencing_model();
+
+        if model
+            .explicit_indexes()
+            .filter(|index| index.is_unique())
+            .any(|index| index.contains_exactly_fields(relation.referencing_fields()))
+        {
+            continue;
+        }
+
+        if model
+            .primary_key()
+            .map(|pk| pk.contains_exactly_fields(relation.referencing_fields()))
+            .unwrap_or(false)
+        {
+            continue;
+        }
+
+        let column_names = relation
+            .referencing_fields()
+            .map(|f| f.final_database_name())
+            .collect::<Vec<_>>();
+
+        let db_name =
+            ConstraintNames::unique_index_name(model.final_database_name(), &column_names, ctx.db.active_connector());
+
+        let source_field = {
+            let mut fields = relation.referencing_fields();
+
+            if fields.len() == 1 {
+                fields.next().map(|f| f.field_id())
+            } else {
+                None
+            }
+        };
+
+        indexes.push((
+            model.model_id(),
+            IndexAttribute {
+                is_unique: true,
+                fields: relation.referencing_fields().map(|f| f.field_id()).collect(),
+                source_field,
+                name: None,
+                db_name: Some(Cow::from(db_name)),
+            },
+        ));
+    }
+
+    for (model_id, attributes) in indexes.into_iter() {
+        if let Some(model) = ctx.db.types.model_attributes.get_mut(&model_id) {
+            model.implicit_indexes.push(attributes);
+        }
+    }
+}

--- a/libs/datamodel/core/src/transform/ast_to_dml/db/types.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/types.rs
@@ -140,9 +140,9 @@ pub(crate) struct ModelAttributes<'ast> {
     pub(super) primary_key: Option<IdAttribute<'ast>>,
     /// @@ignore
     pub(crate) is_ignored: bool,
-    /// @@index and @(@)unique.
-    pub(super) indexes: Vec<(&'ast ast::Attribute, IndexAttribute<'ast>)>,
-    /// @(@)unique added explicitely to the datamodel by us.
+    /// @@index and @(@)unique explicitely written to the schema AST.
+    pub(super) ast_indexes: Vec<(&'ast ast::Attribute, IndexAttribute<'ast>)>,
+    /// @(@)unique added implicitely to the datamodel by us.
     pub(super) implicit_indexes: Vec<IndexAttribute<'static>>,
     /// @@map
     pub(crate) mapped_name: Option<&'ast str>,
@@ -156,7 +156,9 @@ impl ModelAttributes<'_> {
 
     /// Whether MySQL would consider the field indexed for autoincrement purposes.
     pub(super) fn field_is_indexed_for_autoincrement(&self, field_id: ast::FieldId) -> bool {
-        self.indexes.iter().any(|(_, idx)| idx.fields.get(0) == Some(&field_id))
+        self.ast_indexes
+            .iter()
+            .any(|(_, idx)| idx.fields.get(0) == Some(&field_id))
             || self
                 .primary_key
                 .as_ref()

--- a/libs/datamodel/core/src/transform/ast_to_dml/db/types.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/types.rs
@@ -4,6 +4,7 @@ use itertools::Itertools;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use std::{
+    borrow::Cow,
     collections::{BTreeMap, HashMap},
     str::FromStr,
 };
@@ -141,6 +142,8 @@ pub(crate) struct ModelAttributes<'ast> {
     pub(crate) is_ignored: bool,
     /// @@index and @(@)unique.
     pub(super) indexes: Vec<(&'ast ast::Attribute, IndexAttribute<'ast>)>,
+    /// @(@)unique added explicitely to the datamodel by us.
+    pub(super) implicit_indexes: Vec<IndexAttribute<'static>>,
     /// @@map
     pub(crate) mapped_name: Option<&'ast str>,
 }
@@ -168,7 +171,7 @@ pub(crate) struct IndexAttribute<'ast> {
     pub(crate) fields: Vec<ast::FieldId>,
     pub(crate) source_field: Option<ast::FieldId>,
     pub(crate) name: Option<&'ast str>,
-    pub(crate) db_name: Option<&'ast str>,
+    pub(crate) db_name: Option<Cow<'ast, str>>,
 }
 
 #[derive(Debug, Default)]

--- a/libs/datamodel/core/src/transform/ast_to_dml/db/walkers/index.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/walkers/index.rs
@@ -5,19 +5,21 @@ use crate::{
 };
 use std::borrow::Cow;
 
+use super::ScalarFieldWalker;
+
 #[allow(dead_code)]
 #[derive(Copy, Clone)]
 pub(crate) struct IndexWalker<'ast, 'db> {
     pub(crate) model_id: ast::ModelId,
-    pub(crate) index: &'ast ast::Attribute,
+    pub(crate) index: Option<&'ast ast::Attribute>,
     pub(crate) db: &'db ParserDatabase<'ast>,
     pub(crate) index_attribute: &'db IndexAttribute<'ast>,
 }
 
 impl<'ast, 'db> IndexWalker<'ast, 'db> {
     pub(crate) fn final_database_name(&self) -> Cow<'ast, str> {
-        if let Some(mapped_name) = &self.index_attribute.db_name {
-            return Cow::Borrowed(mapped_name);
+        if let Some(mapped_name) = self.index_attribute.db_name.as_ref() {
+            return mapped_name.clone(); // :( :( :(
         }
 
         let model = self.db.walk_model(self.model_id);
@@ -33,5 +35,28 @@ impl<'ast, 'db> IndexWalker<'ast, 'db> {
 
     pub(crate) fn attribute(&self) -> &'db IndexAttribute<'ast> {
         self.index_attribute
+    }
+
+    pub(crate) fn fields(&self) -> impl ExactSizeIterator<Item = ScalarFieldWalker<'ast, 'db>> + '_ {
+        self.index_attribute
+            .fields
+            .iter()
+            .map(move |field_id| ScalarFieldWalker {
+                model_id: self.model_id,
+                field_id: *field_id,
+                db: self.db,
+                scalar_field: &self.db.types.scalar_fields[&(self.model_id, *field_id)],
+            })
+    }
+
+    pub(crate) fn contains_exactly_fields(
+        &self,
+        fields: impl ExactSizeIterator<Item = ScalarFieldWalker<'ast, 'db>>,
+    ) -> bool {
+        self.index_attribute.fields.len() == fields.len() && self.fields().zip(fields).all(|(a, b)| a == b)
+    }
+
+    pub(crate) fn is_unique(&self) -> bool {
+        self.index_attribute.is_unique
     }
 }

--- a/libs/datamodel/core/src/transform/ast_to_dml/db/walkers/model.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/walkers/model.rs
@@ -56,7 +56,7 @@ impl<'ast, 'db> ModelWalker<'ast, 'db> {
     /// True if given fields are unique in the model.
     pub(crate) fn fields_are_unique(&self, fields: &[ast::FieldId]) -> bool {
         self.model_attributes
-            .indexes
+            .ast_indexes
             .iter()
             .any(|(_, idx)| idx.is_unique && idx.fields == fields)
     }
@@ -137,7 +137,7 @@ impl<'ast, 'db> ModelWalker<'ast, 'db> {
         let db = self.db;
 
         self.model_attributes
-            .indexes
+            .ast_indexes
             .iter()
             .map(move |(index, index_attribute)| IndexWalker {
                 model_id,

--- a/libs/datamodel/core/src/transform/ast_to_dml/db/walkers/model.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/walkers/model.rs
@@ -129,8 +129,10 @@ impl<'ast, 'db> ModelWalker<'ast, 'db> {
         from_pk.chain(from_indices)
     }
 
-    /// All indexes defined in the model.
-    pub(crate) fn indexes(&self) -> impl Iterator<Item = IndexWalker<'ast, 'db>> + 'db {
+    /// Iterate all the relation fields in the model in the order they were
+    /// defined. Note that these are only the fields that were actually written
+    /// in the schema.
+    pub(crate) fn explicit_indexes(&self) -> impl Iterator<Item = IndexWalker<'ast, 'db>> + 'db {
         let model_id = self.model_id;
         let db = self.db;
 
@@ -139,15 +141,30 @@ impl<'ast, 'db> ModelWalker<'ast, 'db> {
             .iter()
             .map(move |(index, index_attribute)| IndexWalker {
                 model_id,
-                index,
+                index: Some(index),
                 db,
                 index_attribute,
             })
     }
 
     /// Iterate all the relation fields in the model in the order they were
-    /// defined. Note that these are only the fields that were actually written
-    /// in the schema.
+    /// defined, followed by the implicit indexes.
+    pub(crate) fn indexes(&self) -> impl Iterator<Item = IndexWalker<'ast, 'db>> + '_ {
+        let implicit_indexes = self
+            .model_attributes
+            .implicit_indexes
+            .iter()
+            .map(move |index_attribute| IndexWalker {
+                model_id: self.model_id(),
+                index: None,
+                db: self.db,
+                index_attribute,
+            });
+
+        self.explicit_indexes().chain(implicit_indexes)
+    }
+
+    /// All (concrete) relation fields of the model.
     pub(crate) fn relation_fields(&self) -> impl Iterator<Item = RelationFieldWalker<'ast, 'db>> + 'db {
         let model_id = self.model_id;
         let db = self.db;

--- a/libs/datamodel/core/src/transform/ast_to_dml/db/walkers/relation.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/walkers/relation.rs
@@ -3,7 +3,10 @@ use dml::relation_info::ReferentialAction;
 
 use crate::{
     ast::{self, FieldArity},
-    transform::ast_to_dml::db::{relations::Relation, ParserDatabase},
+    transform::ast_to_dml::db::{
+        relations::{Relation, RelationType},
+        ParserDatabase,
+    },
 };
 
 use super::{ModelWalker, RelationFieldWalker, ScalarFieldWalker};
@@ -15,7 +18,6 @@ use super::{ModelWalker, RelationFieldWalker, ScalarFieldWalker};
 pub(crate) struct ExplicitRelationWalker<'ast, 'db> {
     pub(crate) side_a: (ast::ModelId, ast::FieldId),
     pub(crate) side_b: (ast::ModelId, ast::FieldId),
-    #[allow(dead_code)]
     pub(crate) relation: &'db Relation<'ast>,
     pub(crate) db: &'db ParserDatabase<'ast>,
 }
@@ -132,5 +134,10 @@ impl<'ast, 'db> ExplicitRelationWalker<'ast, 'db> {
     /// fields is required.
     pub(crate) fn referential_arity(&self) -> FieldArity {
         self.referencing_field().referential_arity()
+    }
+
+    /// 1:1, 1:n or m:n
+    pub(crate) fn relation_type(&self) -> RelationType {
+        self.relation.r#type()
     }
 }

--- a/libs/datamodel/core/src/transform/ast_to_dml/db/walkers/scalar_field.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/walkers/scalar_field.rs
@@ -13,6 +13,14 @@ pub(crate) struct ScalarFieldWalker<'ast, 'db> {
     pub(crate) scalar_field: &'db ScalarField<'ast>,
 }
 
+impl<'ast, 'db> PartialEq for ScalarFieldWalker<'ast, 'db> {
+    fn eq(&self, other: &Self) -> bool {
+        self.model_id == other.model_id && self.field_id == other.field_id
+    }
+}
+
+impl<'ast, 'db> Eq for ScalarFieldWalker<'ast, 'db> {}
+
 impl<'ast, 'db> ScalarFieldWalker<'ast, 'db> {
     #[allow(dead_code)] // we'll need this
     pub(crate) fn field_id(&self) -> ast::FieldId {
@@ -25,6 +33,10 @@ impl<'ast, 'db> ScalarFieldWalker<'ast, 'db> {
 
     pub(crate) fn name(&self) -> &'ast str {
         self.ast_field().name()
+    }
+
+    pub(crate) fn final_database_name(&self) -> &'ast str {
+        self.attributes().mapped_name.unwrap_or_else(|| self.name())
     }
 
     pub(crate) fn is_optional(&self) -> bool {

--- a/libs/datamodel/core/src/transform/ast_to_dml/standardise_parsing.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/standardise_parsing.rs
@@ -1,72 +1,11 @@
 use super::common::*;
-use crate::common::constraint_names::ConstraintNames;
-use crate::{dml, Datasource, Field, WithDatabaseName};
+use crate::{dml, Field};
 
 /// Helper for standardising a datamodel during parsing.
 ///
 /// This will add relation names, referential actions and M2M references contents
-pub fn standardise(schema: &mut dml::Datamodel, source: Option<&Datasource>) {
+pub fn standardise(schema: &mut dml::Datamodel) {
     set_relation_to_field_to_id_if_missing_for_m2m_relations(schema);
-    add_implicit_unique_constraints_for_1_to_1_relations(schema, source);
-}
-
-fn add_implicit_unique_constraints_for_1_to_1_relations(schema: &mut dml::Datamodel, source: Option<&Datasource>) {
-    let mut modifications = Vec::new();
-
-    for (model_id, model) in schema.models().enumerate() {
-        for field in model.fields() {
-            match field {
-                Field::RelationField(field) if field.is_singular() && !field.relation_info.fields.is_empty() => {
-                    if let Some(src) = source {
-                        let related_field_is_singular =
-                            matches!(schema.find_related_field(field), Some(rf) if rf.1.is_singular());
-
-                        let covered_by_index = model
-                            .indices
-                            .iter()
-                            .any(|index| index.fields == field.relation_info.fields && index.is_unique());
-
-                        let covered_by_pk =
-                            matches!( &model.primary_key, Some(pk) if pk.fields == field.relation_info.fields);
-
-                        if related_field_is_singular && !covered_by_pk && !covered_by_index {
-                            let column_names: Vec<&str> = field
-                                .relation_info
-                                .fields
-                                .iter()
-                                .map(|field_name| {
-                                    schema.models[model_id]
-                                        .find_field(field_name)
-                                        .unwrap()
-                                        .final_database_name()
-                                })
-                                .collect();
-
-                            let index = dml::IndexDefinition {
-                                name: None,
-                                db_name: Some(ConstraintNames::unique_index_name(
-                                    model.final_database_name(),
-                                    &column_names,
-                                    src.active_connector.as_ref(),
-                                )),
-                                fields: field.relation_info.fields.clone(),
-                                tpe: dml::IndexType::Unique,
-                                defined_on_field: field.relation_info.fields.len() == 1,
-                            };
-
-                            modifications.push((model_id, index));
-                        }
-                    }
-                }
-
-                _ => (),
-            }
-        }
-    }
-
-    for (model_id, index) in modifications {
-        schema.models[model_id].indices.push(index);
-    }
 }
 
 /// For M2M relations set the references to the @id fields of the foreign model.

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline.rs
@@ -57,19 +57,29 @@ impl<'a, 'b> ValidationPipeline<'a> {
         // Early return so that the validator does not have to deal with invalid schemas
         diagnostics.to_result()?;
 
-        // Phase 3: Lift AST to DML. This can't fail.
+        // Phase 3: Global validations after we have consistent data model.
+        validations::validate(&db, &mut diagnostics);
+        diagnostics.to_result()?;
+
+        // Phase 4: Lift AST to DML. This can't fail.
         let mut schema = LiftAstToDml::new(&db).lift();
 
-        // Phase 4: Validation
+        // From now on we do not operate on the internal ast anymore, but DML.
+        // Please try to avoid all new validations after this, if you can.
+
+        // Phase 5: Validation (deprecated, move stuff out from here if you can)
         self.validator.validate(db.ast(), &schema, &mut diagnostics);
 
         // Early return so that the standardiser does not have to deal with invalid schemas
         diagnostics.to_result()?;
 
-        // Phase 5: Consistency fixes. These don't fail and always run, during parsing AND formatting
+        // Phase 6: Consistency fixes. These don't fail and always run, during
+        // parsing AND formatting. (deprecated, move stuff out from here if you
+        // can)
         standardise_parsing::standardise(&mut schema);
 
-        // Transform phase: These only run during formatting.
+        // Transform phase: These only run during formatting. (double
+        // deprecated, please do not add anything here)
         if relation_transformation_enabled {
             if let Err(mut err) = self.standardiser_for_formatting.standardise(ast_schema, &mut schema) {
                 diagnostics.append(&mut err);
@@ -77,10 +87,6 @@ impl<'a, 'b> ValidationPipeline<'a> {
                 return Err(diagnostics);
             }
         }
-
-        // Phase 6: Global validations after we have consistent data model.
-        validations::validate(&db, &mut diagnostics);
-        diagnostics.to_result()?;
 
         // Phase 7: Post Standardisation Validation (deprecated, move stuff out from here if you can)
         self.validator

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline.rs
@@ -67,7 +67,7 @@ impl<'a, 'b> ValidationPipeline<'a> {
         diagnostics.to_result()?;
 
         // Phase 5: Consistency fixes. These don't fail and always run, during parsing AND formatting
-        standardise_parsing::standardise(&mut schema, self.source);
+        standardise_parsing::standardise(&mut schema);
 
         // Transform phase: These only run during formatting.
         if relation_transformation_enabled {

--- a/libs/datamodel/core/tests/reformat/reformat_implicit_relations.rs
+++ b/libs/datamodel/core/tests/reformat/reformat_implicit_relations.rs
@@ -1075,8 +1075,8 @@ fn should_not_get_confused_with_complicated_self_relations() {
     let expected = expect![[r#"
         model Human {
           id        Int  @id
-          husbandId Int?
-          fatherId  Int?
+          husbandId Int? @unique
+          fatherId  Int? @unique
           parentId  Int?
 
           wife    Human? @relation("Marrige")

--- a/libs/datamodel/core/tests/renderer/simplification.rs
+++ b/libs/datamodel/core/tests/renderer/simplification.rs
@@ -50,7 +50,7 @@ fn test_exclude_default_relation_names_from_rendering() {
     let expected = expect![[r#"
         model Todo {
           id     Int  @id
-          userId Int
+          userId Int  @unique
           user   User @relation(fields: [userId], references: [id])
         }
 


### PR DESCRIPTION
The trip continues. By doing this, I found a few data models that did not come out with correct indexes from the validator. Now they work too.