### PR TITLE
Allow duplicate field names if mapped correctly

### DIFF
--- a/libs/datamodel/core/src/transform/ast_to_dml/db/attributes/map.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/attributes/map.rs
@@ -73,11 +73,21 @@ pub(super) fn scalar_field<'ast>(
         if !ctx.db.types.scalar_fields.contains_key(&(model_id, *field_id)) {
             return;
         }
-        ctx.push_error(DatamodelError::new_duplicate_field_error(
-            &ast_model.name.name,
-            &ast_field.name.name,
-            ast_field.span,
-        ));
+
+        match ctx
+            .db
+            .types
+            .scalar_fields
+            .get(&(model_id, *field_id))
+            .and_then(|sf| sf.mapped_name)
+        {
+            Some(name) if name != mapped_name => return,
+            _ => ctx.push_error(DatamodelError::new_duplicate_field_error(
+                &ast_model.name.name,
+                &ast_field.name.name,
+                ast_field.span,
+            )),
+        }
     }
 }
 

--- a/libs/datamodel/core/tests/base/duplicates.rs
+++ b/libs/datamodel/core/tests/base/duplicates.rs
@@ -331,6 +331,19 @@ fn fail_on_duplicate_field_with_map() {
 }
 
 #[test]
+fn do_not_fail_on_duplicate_field_with_map_if_the_maps_differ() {
+    let dml = indoc! {r#"
+        model User {
+          id Int @id
+          firstName String @map("thirdName")
+          otherName String @map("firstName")
+        }
+    "#};
+
+    assert!(datamodel::parse_datamodel(dml).is_ok())
+}
+
+#[test]
 fn fail_on_duplicate_composite_type_field_with_map() {
     let dml = indoc! {r#"
         datasource db {


### PR DESCRIPTION
This doesn't validate:

```prisma
model A {
  id  Int @id
  foo Int
  bar Int @map("foo")
}
```

But this should:

```prisma
model A {
  id  Int @id
  foo Int @map("meow")
  bar Int @map("foo")
}
```

Closes: https://github.com/prisma/prisma/issues/9770