### PR TITLE
Detect cycles in composite types

### DIFF
--- a/libs/datamodel/core/src/ast/mod.rs
+++ b/libs/datamodel/core/src/ast/mod.rs
@@ -175,6 +175,13 @@ impl TopId {
             _ => None,
         }
     }
+
+    pub(crate) fn as_composite_type_id(&self) -> Option<CompositeTypeId> {
+        match self {
+            TopId::CompositeType(ctid) => Some(*ctid),
+            _ => None,
+        }
+    }
 }
 
 impl std::ops::Index<TopId> for SchemaAst {

--- a/libs/datamodel/core/src/transform/ast_to_dml/db/walkers.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/walkers.rs
@@ -37,6 +37,13 @@ impl<'ast> ParserDatabase<'ast> {
         CompositeTypeWalker { ctid, db: self }
     }
 
+    pub(crate) fn walk_composite_types(&self) -> impl Iterator<Item = CompositeTypeWalker<'ast, '_>> + '_ {
+        self.ast()
+            .iter_tops()
+            .filter_map(|(top_id, _)| top_id.as_composite_type_id())
+            .map(move |ctid| CompositeTypeWalker { ctid, db: self })
+    }
+
     /// Iterate all complete relations that are not many to many and are
     /// correctly defined from both sides.
     #[track_caller]

--- a/libs/datamodel/core/src/transform/ast_to_dml/db/walkers/composite_type.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/walkers/composite_type.rs
@@ -9,7 +9,17 @@ pub(crate) struct CompositeTypeWalker<'ast, 'db> {
     pub(super) db: &'db ParserDatabase<'ast>,
 }
 
+impl<'ast, 'db> PartialEq for CompositeTypeWalker<'ast, 'db> {
+    fn eq(&self, other: &Self) -> bool {
+        self.ctid == other.ctid
+    }
+}
+
 impl<'ast, 'db> CompositeTypeWalker<'ast, 'db> {
+    pub(crate) fn composite_type_id(self) -> ast::CompositeTypeId {
+        self.ctid
+    }
+
     pub(crate) fn name(self) -> &'ast str {
         &self.db.ast[self.ctid].name.name
     }
@@ -28,6 +38,7 @@ impl<'ast, 'db> CompositeTypeWalker<'ast, 'db> {
     }
 }
 
+#[derive(Clone, Copy)]
 pub(crate) struct CompositeTypeFieldWalker<'ast, 'db> {
     ctid: ast::CompositeTypeId,
     field_id: ast::FieldId,
@@ -36,23 +47,30 @@ pub(crate) struct CompositeTypeFieldWalker<'ast, 'db> {
 }
 
 impl<'ast, 'db> CompositeTypeFieldWalker<'ast, 'db> {
-    pub(crate) fn ast_field(&self) -> &'ast ast::Field {
+    pub(crate) fn ast_field(self) -> &'ast ast::Field {
         &self.db.ast[self.ctid][self.field_id]
     }
 
-    pub(crate) fn mapped_name(&self) -> Option<&'ast str> {
+    pub(crate) fn composite_type(self) -> CompositeTypeWalker<'ast, 'db> {
+        CompositeTypeWalker {
+            ctid: self.ctid,
+            db: self.db,
+        }
+    }
+
+    pub(crate) fn mapped_name(self) -> Option<&'ast str> {
         self.field.mapped_name
     }
 
-    pub(crate) fn name(&self) -> &'ast str {
+    pub(crate) fn name(self) -> &'ast str {
         &self.ast_field().name.name
     }
 
-    pub(crate) fn arity(&self) -> ast::FieldArity {
+    pub(crate) fn arity(self) -> ast::FieldArity {
         self.ast_field().arity
     }
 
-    pub(crate) fn r#type(&self) -> &'db ScalarFieldType {
+    pub(crate) fn r#type(self) -> &'db ScalarFieldType {
         &self.field.r#type
     }
 }


### PR DESCRIPTION
Adds a validation layer to prevent cycles with composite types. Examples of a cycle:

```prisma
type A {
  field A
}
```

Refers to itself, and it being required forces the user to set the field endlessly to the same type. Doesn't validate.

```prisma
type A {
  field B
}

type B {
  field A
}
```

Creating a type `A` requires a field of type `B` that requires a field of type `A`. Doesn't validate.

```prisma
type A {
  field A?
}

type B {
  field B[]
}
```

Both of these types can be having the field to be set either to null or to an empty list, that allows breaking the cycle. Both types are allowed.

```prisma
type A {
  field B?
  field C[]
}

type B {
  field A
}

type C {
  field A
}
```

The cycles are broken with an optional or a list field in one position of the cycle. These are all allowed.

Closes: https://github.com/prisma/prisma/issues/9782