### PR TITLE
Fix deserialization of introspection inputs

### DIFF
--- a/introspection-engine/core/src/rpc.rs
+++ b/introspection-engine/core/src/rpc.rs
@@ -175,7 +175,7 @@ impl RpcImpl {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(rename = "camelCase")]
+#[serde(rename_all = "camelCase")]
 pub struct IntrospectionInput {
     pub(crate) schema: String,
     #[serde(default = "default_false")]


### PR DESCRIPTION
`#[serde(rename_all = "camelCase")]` will serialize/deserialize the field names in camel case

`#[serde(rename = "camelCase")]` renames the model to camelCase in serialized data.

https://serde.rs/container-attrs.html