### PR TITLE
Change phrasing of mongo introspection comments

### DIFF
--- a/introspection-engine/connectors/mongodb-introspection-connector/src/sampler/statistics.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/src/sampler/statistics.rs
@@ -115,7 +115,7 @@ impl Statistics {
             let documentation = if percentages.has_type_variety() {
                 Some(format!(
                     "Multiple data types found: {} out of {} sampled entries",
-                    percentages, SAMPLE_SIZE
+                    percentages, field_count
                 ))
             } else {
                 None

--- a/introspection-engine/connectors/mongodb-introspection-connector/tests/dirty_data/mod.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/tests/dirty_data/mod.rs
@@ -38,7 +38,7 @@ fn mixing_types() {
     let expected = expect![[r#"
         model A {
           id    String @id @default(dbgenerated()) @map("_id") @db.ObjectId
-          /// Multiple data types found: String: 50%, Int32: 50% out of 1000 sampled entries
+          /// Multiple data types found: String: 50%, Int32: 50% out of 3 sampled entries
           first Int?
         }
     "#]];
@@ -68,7 +68,7 @@ fn mixing_types_with_the_same_base_type() {
     let expected = expect![[r#"
         model A {
           id    String    @id @default(dbgenerated()) @map("_id") @db.ObjectId
-          /// Multiple data types found: Date: 50%, Timestamp: 50% out of 1000 sampled entries
+          /// Multiple data types found: Date: 50%, Timestamp: 50% out of 3 sampled entries
           first DateTime?
         }
     "#]];
@@ -91,7 +91,7 @@ fn the_most_common_type_wins() {
     let expected = expect![[r#"
         model A {
           id    String @id @default(dbgenerated()) @map("_id") @db.ObjectId
-          /// Multiple data types found: String: 66.7%, Boolean: 33.3% out of 1000 sampled entries
+          /// Multiple data types found: String: 66.7%, Boolean: 33.3% out of 3 sampled entries
           first String
         }
     "#]];

--- a/introspection-engine/connectors/mongodb-introspection-connector/tests/types/composite.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/tests/types/composite.rs
@@ -48,7 +48,7 @@ fn dirty_data() {
 
     let expected = expect![[r#"
         type CatAddress {
-          /// Multiple data types found: String: 66.7%, Int32: 33.3% out of 1000 sampled entries
+          /// Multiple data types found: String: 66.7%, Int32: 33.3% out of 3 sampled entries
           number String
           street String
         }


### PR DESCRIPTION
Since there can be fewer than 1000 documents, the sample has up to 1000
entries.