### PR TITLE
Add special handling for mongodb+srv URLs in migration engine CLI

### DIFF
--- a/migration-engine/cli/src/commands.rs
+++ b/migration-engine/cli/src/commands.rs
@@ -70,6 +70,7 @@ fn datasource_from_database_str(database_str: &str) -> Result<String, ConnectorE
     let provider = match database_str.split(':').next() {
         Some("postgres") => "postgresql",
         Some("file") => "sqlite",
+        Some("mongodb+srv") => "mongodb",
         Some(other) => other,
         None => {
             return Err(ConnectorError::user_facing(InvalidConnectionString {


### PR DESCRIPTION
`datasource_from_database_str()` should not exist, there is no good reason
it does. It is a consequence of old tech debt in the typescript CLI.

There is no test because we would need a new mongo test setup for the
CLI, and we are in a rush (release day).