### PR TITLE
Explicitly build migration-engine-cli with mongodb feature

### DIFF
--- a/migration-engine/cli/Cargo.toml
+++ b/migration-engine/cli/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 migration-connector = { path = "../connectors/migration-connector" }
-migration-core = { path = "../core", features = ["sql"] }
+migration-core = { path = "../core", features = ["sql", "mongodb"] }
 user-facing-errors = { path = "../../libs/user-facing-errors" }
 
 backtrace = "0.3.59"


### PR DESCRIPTION
There are reports that osx builds are not including the mongodb
connector, which could have to do with different rust toolchain versions in the
build pipeline for linux and OSX, or different build methods (whole workspace vs
 individual binary `cargo build`, since that would affect feature resolution). This 
should be investigated.

The toolchain version would matter because we recently switched to the v2 of 
the cargo feature resolver.