### PR TITLE
Eliminate SchemaPushInput::assume_empty

### DIFF
--- a/libs/test-cli/src/main.rs
+++ b/libs/test-cli/src/main.rs
@@ -67,8 +67,6 @@ struct SchemaPush {
     schema_path: String,
     #[structopt(long)]
     force: bool,
-    #[structopt(long)]
-    recreate: bool,
 }
 
 #[derive(StructOpt, Debug)]
@@ -340,7 +338,6 @@ async fn schema_push(cmd: &SchemaPush) -> anyhow::Result<()> {
         .schema_push(&SchemaPushInput {
             schema,
             force: cmd.force,
-            assume_empty: cmd.recreate,
         })
         .await?;
 

--- a/migration-engine/core/src/commands/schema_push.rs
+++ b/migration-engine/core/src/commands/schema_push.rs
@@ -17,14 +17,11 @@ pub(crate) async fn schema_push(
         return Err(ConnectorError::user_facing(err));
     };
 
-    let from = if input.assume_empty {
-        DiffTarget::Empty
-    } else {
-        DiffTarget::Database
-    };
-
     let database_migration = connector
-        .diff(from, DiffTarget::Datamodel((&configuration, &datamodel)))
+        .diff(
+            DiffTarget::Database,
+            DiffTarget::Datamodel((&configuration, &datamodel)),
+        )
         .await?;
 
     let checks = checker.check(&database_migration).await?;
@@ -64,9 +61,6 @@ pub struct SchemaPushInput {
     pub schema: String,
     /// Push the schema ignoring destructive change warnings.
     pub force: bool,
-    /// Expect the schema to be empty, skipping describing the existing schema.
-    #[serde(default)]
-    pub assume_empty: bool,
 }
 
 /// Output of the `schemaPush` command.

--- a/migration-engine/migration-engine-tests/src/commands/schema_push.rs
+++ b/migration-engine/migration-engine-tests/src/commands/schema_push.rs
@@ -39,7 +39,6 @@ impl<'a> SchemaPush<'a> {
         let input = SchemaPushInput {
             schema: self.schema,
             force: self.force,
-            assume_empty: false,
         };
 
         let fut = self


### PR DESCRIPTION
It is part of the public API but was only ever necessary for the QE
setup. Since the QE setup can use `MigrationConnector::diff()` and
`MigrationConnector::apply_migration()`, it is not required anymore.