### PR TITLE
[skip ci] Support Mongo 4.2 in tests

### DIFF
--- a/.buildkite/engineer
+++ b/.buildkite/engineer
@@ -13,7 +13,7 @@ fi
 if ! type "engineer" > /dev/null; then
     # Setup Prisma engine build & test tool (engineer).
     set -e
-    curl --fail -sSL "https://prisma-engineer.s3-eu-west-1.amazonaws.com/1.28/latest/$OS/engineer.gz" --output engineer.gz
+    curl --fail -sSL "https://prisma-engineer.s3-eu-west-1.amazonaws.com/mongo44/latest/$OS/engineer.gz" --output engineer.gz
     gzip -d engineer.gz
     chmod +x engineer
 

--- a/.buildkite/engineer
+++ b/.buildkite/engineer
@@ -13,7 +13,7 @@ fi
 if ! type "engineer" > /dev/null; then
     # Setup Prisma engine build & test tool (engineer).
     set -e
-    curl --fail -sSL "https://prisma-engineer.s3-eu-west-1.amazonaws.com/mongo44/latest/$OS/engineer.gz" --output engineer.gz
+    curl --fail -sSL "https://prisma-engineer.s3-eu-west-1.amazonaws.com/1.29/latest/$OS/engineer.gz" --output engineer.gz
     gzip -d engineer.gz
     chmod +x engineer
 

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ buildkite-script-*
 datamodel_v2.prisma
 dev_datamodel.prisma
 target/
+.tmp/

--- a/.test_database_urls/mongodb_42
+++ b/.test_database_urls/mongodb_42
@@ -1,0 +1,2 @@
+export TEST_DATABASE_URL="mongodb://prisma:prisma@localhost:27016/"
+set -e TEST_SHADOW_DATABASE_URL

--- a/Makefile
+++ b/Makefile
@@ -150,14 +150,11 @@ dev-mssql2017: start-mssql_2017
 	echo 'mssql2017' > current_connector
 	cp $(CONFIG_PATH)/sqlserver2017 $(CONFIG_FILE)
 
-start-mongodb4-single:
+start-mongodb4:
 	docker-compose -f docker-compose.yml up -d --remove-orphans mongo4-single
 
 start-mongodb5-single:
 	docker-compose -f docker-compose.yml up -d --remove-orphans mongo5-single
-
-start-mongodb_4_2-single:
-	docker-compose -f docker-compose.yml up -d --remove-orphans mongo42-single
 
 start-mongodb_4_2:
 	docker-compose -f docker-compose.yml up -d --remove-orphans mongo42

--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ dev-mssql2017: start-mssql_2017
 	echo 'mssql2017' > current_connector
 	cp $(CONFIG_PATH)/sqlserver2017 $(CONFIG_FILE)
 
-start-mongodb4:
+start-mongodb4-single:
 	docker-compose -f docker-compose.yml up -d --remove-orphans mongo4-single
 
 start-mongodb5-single:

--- a/Makefile
+++ b/Makefile
@@ -156,16 +156,16 @@ start-mongodb4-single:
 start-mongodb5-single:
 	docker-compose -f docker-compose.yml up -d --remove-orphans mongo5-single
 
-start-mongodb42-single:
+start-mongodb_4_2-single:
 	docker-compose -f docker-compose.yml up -d --remove-orphans mongo42-single
 
-start-mongodb42:
+start-mongodb_4_2:
 	docker-compose -f docker-compose.yml up -d --remove-orphans mongo42
 
-start-mongodb44:
+start-mongodb_4_4:
 	docker-compose -f docker-compose.yml up -d --remove-orphans mongo44
 
-dev-mongodb44: start-mongodb44
+dev-mongodb_4_4: start-mongodb_4_4
 	echo 'mongodb' > current_connector
 	cp $(CONFIG_PATH)/mongodb44 $(CONFIG_FILE)
 
@@ -176,7 +176,7 @@ dev-mongodb5: start-mongodb5
 	echo 'mongodb' > current_connector
 	cp $(CONFIG_PATH)/mongodb5 $(CONFIG_FILE)
 
-dev-mongodb42: start-mongodb42
+dev-mongodb_4_2: start-mongodb_4_2
 	echo 'mongodb' > current_connector
 	cp $(CONFIG_PATH)/mongodb42 $(CONFIG_FILE)
 

--- a/Makefile
+++ b/Makefile
@@ -156,12 +156,18 @@ start-mongodb4-single:
 start-mongodb5-single:
 	docker-compose -f docker-compose.yml up -d --remove-orphans mongo5-single
 
-start-mongodb4:
-	docker-compose -f docker-compose.yml up -d --remove-orphans mongo4
+start-mongodb42-single:
+	docker-compose -f docker-compose.yml up -d --remove-orphans mongo42-single
 
-dev-mongodb4: start-mongodb4
+start-mongodb42:
+	docker-compose -f docker-compose.yml up -d --remove-orphans mongo42
+
+start-mongodb44:
+	docker-compose -f docker-compose.yml up -d --remove-orphans mongo44
+
+dev-mongodb44: start-mongodb44
 	echo 'mongodb' > current_connector
-	cp $(CONFIG_PATH)/mongodb4 $(CONFIG_FILE)
+	cp $(CONFIG_PATH)/mongodb44 $(CONFIG_FILE)
 
 start-mongodb5:
 	docker-compose -f docker-compose.yml up -d --remove-orphans mongo5
@@ -169,6 +175,10 @@ start-mongodb5:
 dev-mongodb5: start-mongodb5
 	echo 'mongodb' > current_connector
 	cp $(CONFIG_PATH)/mongodb5 $(CONFIG_FILE)
+
+dev-mongodb42: start-mongodb42
+	echo 'mongodb' > current_connector
+	cp $(CONFIG_PATH)/mongodb42 $(CONFIG_FILE)
 
 start-vitess_5_7:
 	docker-compose -f docker-compose.yml up -d --remove-orphans vitess-test-5_7 vitess-shadow-5_7

--- a/Makefile
+++ b/Makefile
@@ -169,10 +169,10 @@ dev-mongodb_4_4: start-mongodb_4_4
 	echo 'mongodb' > current_connector
 	cp $(CONFIG_PATH)/mongodb44 $(CONFIG_FILE)
 
-start-mongodb5:
+start-mongodb_5:
 	docker-compose -f docker-compose.yml up -d --remove-orphans mongo5
 
-dev-mongodb5: start-mongodb5
+dev-mongodb_5: start-mongodb_5
 	echo 'mongodb' > current_connector
 	cp $(CONFIG_PATH)/mongodb5 $(CONFIG_FILE)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -239,17 +239,6 @@ services:
     ports:
       - "27016:27016"
 
-  mongo42-single:
-    image: mongo:4.2
-    restart: always
-    environment:
-      MONGO_INITDB_ROOT_USERNAME: "prisma"
-      MONGO_INITDB_ROOT_PASSWORD: "prisma"
-    ports:
-      - "27016:27017"
-    networks:
-      - databases
-
   mongo44:
     image: prismagraphql/mongo-single-replica:4.4.3-bionic
     restart: always
@@ -261,7 +250,7 @@ services:
     networks:
       - databases
 
-  mongo44-single:
+  mongo4-single:
     image: mongo:4
     restart: always
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -227,7 +227,30 @@ services:
     networks:
       - databases
 
-  mongo4:
+  mongo42:
+    image: prismagraphql/mongo-single-replica:4.2.17-bionic
+    restart: always
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: "prisma"
+      MONGO_INITDB_ROOT_PASSWORD: "prisma"
+      MONGO_PORT: 27016
+    networks:
+      - databases
+    ports:
+      - "27016:27016"
+
+  mongo42-single:
+    image: mongo:4.2
+    restart: always
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: "prisma"
+      MONGO_INITDB_ROOT_PASSWORD: "prisma"
+    ports:
+      - "27016:27017"
+    networks:
+      - databases
+
+  mongo44:
     image: prismagraphql/mongo-single-replica:4.4.3-bionic
     restart: always
     environment:
@@ -238,7 +261,7 @@ services:
     networks:
       - databases
 
-  mongo4-single:
+  mongo44-single:
     image: mongo:4
     restart: always
     environment:

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mongodb.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mongodb.rs
@@ -22,7 +22,7 @@ impl ConnectorTagInterface for MongoDbConnectorTag {
     fn connection_string(&self, database: &str, is_ci: bool) -> String {
         match self.version {
             Some(MongoDbVersion::V4_2) if is_ci => format!(
-                "mongodb://prisma:prisma@test-db-mongodb-42:27016/{}?authSource=admin&retryWrites=true",
+                "mongodb://prisma:prisma@test-db-mongodb-4-2:27016/{}?authSource=admin&retryWrites=true",
                 database
             ),
             Some(MongoDbVersion::V4_2) => {
@@ -32,7 +32,7 @@ impl ConnectorTagInterface for MongoDbConnectorTag {
                 )
             }
             Some(MongoDbVersion::V4_4) if is_ci => format!(
-                "mongodb://prisma:prisma@test-db-mongodb-4:27017/{}?authSource=admin&retryWrites=true",
+                "mongodb://prisma:prisma@test-db-mongodb-4-4:27017/{}?authSource=admin&retryWrites=true",
                 database
             ),
             Some(MongoDbVersion::V4_4) => {

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mongodb.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mongodb.rs
@@ -21,11 +21,21 @@ impl ConnectorTagInterface for MongoDbConnectorTag {
 
     fn connection_string(&self, database: &str, is_ci: bool) -> String {
         match self.version {
-            Some(MongoDbVersion::V4) if is_ci => format!(
+            Some(MongoDbVersion::V4_2) if is_ci => format!(
+                "mongodb://prisma:prisma@test-db-mongodb-42:27016/{}?authSource=admin&retryWrites=true",
+                database
+            ),
+            Some(MongoDbVersion::V4_2) => {
+                format!(
+                    "mongodb://prisma:prisma@127.0.0.1:27016/{}?authSource=admin&retryWrites=true",
+                    database
+                )
+            }
+            Some(MongoDbVersion::V4_4) if is_ci => format!(
                 "mongodb://prisma:prisma@test-db-mongodb-4:27017/{}?authSource=admin&retryWrites=true",
                 database
             ),
-            Some(MongoDbVersion::V4) => {
+            Some(MongoDbVersion::V4_4) => {
                 format!(
                     "mongodb://prisma:prisma@127.0.0.1:27017/{}?authSource=admin&retryWrites=true",
                     database
@@ -65,7 +75,8 @@ impl ConnectorTagInterface for MongoDbConnectorTag {
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum MongoDbVersion {
-    V4,
+    V4_2,
+    V4_4,
     V5,
 }
 
@@ -86,7 +97,11 @@ impl MongoDbConnectorTag {
     pub fn all() -> Vec<Self> {
         vec![
             Self {
-                version: Some(MongoDbVersion::V4),
+                version: Some(MongoDbVersion::V4_2),
+                capabilities: mongo_capabilities(),
+            },
+            Self {
+                version: Some(MongoDbVersion::V4_4),
                 capabilities: mongo_capabilities(),
             },
             Self {
@@ -111,7 +126,8 @@ impl TryFrom<&str> for MongoDbVersion {
 
     fn try_from(s: &str) -> Result<Self, Self::Error> {
         let version = match s {
-            "4" => Self::V4,
+            "4.4" => Self::V4_4,
+            "4.2" => Self::V4_2,
             "5" => Self::V5,
             _ => return Err(TestError::parse_error(format!("Unknown MongoDB version `{}`", s))),
         };
@@ -123,7 +139,8 @@ impl TryFrom<&str> for MongoDbVersion {
 impl ToString for MongoDbVersion {
     fn to_string(&self) -> String {
         match self {
-            MongoDbVersion::V4 => "4",
+            MongoDbVersion::V4_4 => "4.4",
+            &MongoDbVersion::V4_2 => "4.2",
             MongoDbVersion::V5 => "5",
         }
         .to_owned()

--- a/query-engine/connector-test-kit-rs/test-configs/mongodb42
+++ b/query-engine/connector-test-kit-rs/test-configs/mongodb42
@@ -1,0 +1,5 @@
+{
+    "connector": "mongodb",
+    "version": "4.2",
+    "runner": "direct"
+}

--- a/query-engine/connector-test-kit-rs/test-configs/mongodb44
+++ b/query-engine/connector-test-kit-rs/test-configs/mongodb44
@@ -1,5 +1,5 @@
 {
     "connector": "mongodb",
-    "version": "4",
+    "version": "4.4",
     "runner": "direct"
 }


### PR DESCRIPTION
 - Mongo 4 is now 4.4
 - Mongo 4.2 is listed as capabilities
 - Make command `dev-mongo4` is now `dev-mongo_4_4`
 - Make command `dev-mongo_4_2` is available
 - Make command `dev-mongo5` is now `dev-mongo_5`
 - This is part of https://github.com/prisma/prisma/issues/9232
 - We still need support in Engineer for this
 - It depends on https://github.com/prisma/engine-images/pull/31