### PR TITLE
Allow inline many-to-many relations on MongoDB

### DIFF
--- a/libs/datamodel/core/src/transform/ast_to_dml/validate.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validate.rs
@@ -1,7 +1,9 @@
 #![allow(clippy::suspicious_operation_groupings)] // clippy is wrong there
 
 use crate::{
-    ast, configuration,
+    ast,
+    common::provider_names::MONGODB_SOURCE_NAME,
+    configuration,
     diagnostics::{DatamodelError, Diagnostics},
     dml,
 };
@@ -84,6 +86,16 @@ impl<'a> Validator<'a> {
         model: &dml::Model,
         errors: &mut Diagnostics,
     ) {
+        // see https://github.com/prisma/prisma/issues/10105
+        if self
+            .source
+            .as_ref()
+            .map(|source| source.provider == MONGODB_SOURCE_NAME)
+            .unwrap_or(false)
+        {
+            return;
+        }
+
         for field in model.relation_fields() {
             let ast_field = match ast_model.find_field(&field.name) {
                 Some(ast_field) => ast_field,

--- a/libs/datamodel/core/tests/attributes/relations/relations_positive.rs
+++ b/libs/datamodel/core/tests/attributes/relations/relations_positive.rs
@@ -482,3 +482,38 @@ fn one_to_one_optional() {
     schema.assert_has_model("A").assert_has_relation_field("b");
     schema.assert_has_model("B").assert_has_relation_field("a");
 }
+
+#[test]
+fn mongodb_inline_many_to_many_relations_are_allowed() {
+    let schema = indoc! {r#"
+    datasource db {
+      provider = "mongodb"
+      url = env("DB_URL")
+    }
+
+    generator js {
+      provider = "prisma-client-js"
+      previewFeatures = ["mongoDb"]
+    }
+
+    model A {
+        id  String  @id @map("_id") @db.ObjectId
+        gql String?
+
+        b_ids String[] @db.Array(ObjectId)
+        bs    B[]      @relation(fields: [b_ids])
+    }
+
+    model B {
+        id  String  @id @map("_id") @db.ObjectId
+        gql String?
+
+        a_ids String[] @db.Array(ObjectId)
+        as    A[]      @relation(fields: [a_ids])
+    }
+    "#};
+
+    let schema = parse(schema);
+    schema.assert_has_model("A").assert_has_relation_field("bs");
+    schema.assert_has_model("B").assert_has_relation_field("as");
+}

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/data_types/native_types/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/data_types/native_types/mod.rs
@@ -1,3 +1,4 @@
+mod mongodb;
 mod mysql;
 mod postgres;
 mod sql_server;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/data_types/native_types/mongodb.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/data_types/native_types/mongodb.rs
@@ -1,0 +1,54 @@
+use query_engine_tests::*;
+
+#[test_suite(only(MongoDb))]
+mod mongodb {
+    use indoc::indoc;
+
+    fn m2m() -> String {
+        let schema = indoc! {
+            r#"model A {
+                id  String  @id @default(dbgenerated()) @map("_id") @test.ObjectId
+                gql String?
+
+                b_ids String[]
+                bs    B[]      @relation(fields: [b_ids])
+            }
+
+            model B {
+                id  String  @id @default(dbgenerated()) @map("_id") @test.ObjectId
+                gql String?
+
+                a_ids String[] @test.Array(ObjectId)
+                as    A[]      @relation(fields: [a_ids])
+            }"#
+        };
+
+        schema.to_owned()
+    }
+
+    /// Makes sure that the m2m relation workaround is explicitly tested.
+    #[connector_test(schema(m2m))]
+    async fn m2m_syntax_workaround(runner: Runner) -> TestResult<()> {
+        insta::assert_snapshot!(
+            run_query!(
+                &runner,
+                r#"mutation {
+                    createOneA(
+                        data: {
+                            id: "507f1f77bcf86cd799439011",
+                            bs: {
+                                create:[ { id: "507f191e810c19729de860ea" } ]
+                            }
+                        }
+                    ) {
+                        id
+                        bs { id }
+                    }
+                }"#
+            ),
+            @r###"{"data":{"createOneA":{"id":"507f1f77bcf86cd799439011","bs":[{"id":"507f191e810c19729de860ea"}]}}}"###
+        );
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Inline means that the referencing field data is embedded in the model's
fields. Many-to-many relations are always implicit (with an implicit
relation tables), except in that case on MongoDB. There was previously
no test covering this pattern.

With this commit, we just stop checking that referencing and referenced
field types match on mongo. This is not the long-term solution: we
should instead define and support this new type of relations properly in
the datamodel parser.

addresses https://github.com/prisma/prisma/issues/10105