### PR TITLE
Make SQL Schema Describer to understand index length and direction

### DIFF
--- a/introspection-engine/connectors/sql-introspection-connector/src/calculate_datamodel_tests.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/calculate_datamodel_tests.rs
@@ -14,8 +14,8 @@ mod tests {
     use pretty_assertions::assert_eq;
     use sql_datamodel_connector::PostgresDatamodelConnector;
     use sql_schema_describer::{
-        Column, ColumnArity, ColumnType, ColumnTypeFamily, Enum, ForeignKey, ForeignKeyAction, Index, IndexType,
-        PrimaryKey, Sequence, SqlSchema, Table,
+        Column, ColumnArity, ColumnType, ColumnTypeFamily, Enum, ForeignKey, ForeignKeyAction, Index, IndexColumn,
+        IndexType, PrimaryKey, PrimaryKeyColumn, Sequence, SqlSchema, Table,
     };
 
     fn postgres_context() -> IntrospectionContext {
@@ -152,7 +152,7 @@ mod tests {
             ],
             indices: vec![],
             primary_key: Some(PrimaryKey {
-                columns: vec!["required".to_string()],
+                columns: vec![PrimaryKeyColumn::new("required")],
                 sequence: None,
                 constraint_name: None,
             }),
@@ -298,7 +298,7 @@ mod tests {
                 }],
                 indices: vec![],
                 primary_key: Some(PrimaryKey {
-                    columns: vec!["primary".to_string()],
+                    columns: vec![PrimaryKeyColumn::new("primary")],
                     sequence: None,
                     constraint_name: None,
                 }),
@@ -319,7 +319,7 @@ mod tests {
                 }],
                 indices: vec![],
                 primary_key: Some(PrimaryKey {
-                    columns: vec!["primary".to_string()],
+                    columns: vec![PrimaryKeyColumn::new("primary")],
                     sequence: None,
                     constraint_name: None,
                 }),
@@ -340,7 +340,7 @@ mod tests {
                 }],
                 indices: vec![],
                 primary_key: Some(PrimaryKey {
-                    columns: vec!["primary".to_string()],
+                    columns: vec![PrimaryKeyColumn::new("primary")],
                     sequence: Some(Sequence {
                         name: "sequence".to_string(),
                     }),
@@ -416,7 +416,7 @@ mod tests {
             ],
             indices: vec![Index {
                 name: "unique_unique".to_string(),
-                columns: vec!["unique".to_string()],
+                columns: vec![IndexColumn::new("unique")],
                 tpe: IndexType::Unique,
             }],
             primary_key: None,
@@ -628,7 +628,7 @@ mod tests {
                 ],
                 indices: vec![],
                 primary_key: Some(PrimaryKey {
-                    columns: vec!["id".to_string()],
+                    columns: vec![PrimaryKeyColumn::new("id")],
                     sequence: None,
                     constraint_name: None,
                 }),
@@ -673,7 +673,7 @@ mod tests {
                 ],
                 indices: vec![],
                 primary_key: Some(PrimaryKey {
-                    columns: vec!["id".to_string()],
+                    columns: vec![PrimaryKeyColumn::new("id")],
                     sequence: None,
                     constraint_name: None,
                 }),
@@ -810,11 +810,11 @@ mod tests {
             ],
             indices: vec![Index {
                 name: "name_last_name_unique".to_string(),
-                columns: vec!["name".to_string(), "lastname".to_string()],
+                columns: vec![IndexColumn::new("name"), IndexColumn::new("lastname")],
                 tpe: IndexType::Unique,
             }],
             primary_key: Some(PrimaryKey {
-                columns: vec!["id".to_string()],
+                columns: vec![PrimaryKeyColumn::new("id")],
                 sequence: None,
                 constraint_name: None,
             }),
@@ -999,7 +999,7 @@ mod tests {
                 ],
                 indices: vec![],
                 primary_key: Some(PrimaryKey {
-                    columns: vec!["id".to_string()],
+                    columns: vec![PrimaryKeyColumn::new("id")],
                     sequence: None,
                     constraint_name: None,
                 }),
@@ -1033,7 +1033,7 @@ mod tests {
                 ],
                 indices: vec![],
                 primary_key: Some(PrimaryKey {
-                    columns: vec!["id".to_string()],
+                    columns: vec![PrimaryKeyColumn::new("id")],
                     sequence: None,
                     constraint_name: None,
                 }),

--- a/introspection-engine/connectors/sql-introspection-connector/src/introspection.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/introspection.rs
@@ -65,7 +65,7 @@ pub fn introspect(
             model.primary_key = Some(PrimaryKeyDefinition {
                 name: None,
                 db_name: pk.constraint_name.clone(),
-                fields: pk.columns.clone(),
+                fields: pk.columns.iter().map(|c| c.name().to_string()).collect(),
                 defined_on_field: pk.columns.len() == 1,
             });
         }

--- a/introspection-engine/connectors/sql-introspection-connector/src/introspection.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/introspection.rs
@@ -58,16 +58,25 @@ pub fn introspect(
         }
 
         for index in &table.indices {
+            // TODO: enable with preview flag, when dml index extensions are done.
+            if index.columns.iter().any(|c| c.length.is_some()) {
+                continue;
+            }
+
             model.add_index(calculate_index(index));
         }
 
-        if let Some(pk) = &table.primary_key {
-            model.primary_key = Some(PrimaryKeyDefinition {
-                name: None,
-                db_name: pk.constraint_name.clone(),
-                fields: pk.columns.iter().map(|c| c.name().to_string()).collect(),
-                defined_on_field: pk.columns.len() == 1,
-            });
+        match &table.primary_key {
+            // TODO: enable with preview flag, when dml index extensions are done.
+            Some(pk) if pk.columns.iter().all(|c| c.length.is_none()) => {
+                model.primary_key = Some(PrimaryKeyDefinition {
+                    name: None,
+                    db_name: pk.constraint_name.clone(),
+                    fields: pk.columns.iter().map(|c| c.name().to_string()).collect(),
+                    defined_on_field: pk.columns.len() == 1,
+                });
+            }
+            _ => (),
         }
 
         version_check.always_has_created_at_updated_at(table, &model);

--- a/introspection-engine/connectors/sql-introspection-connector/src/introspection.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/introspection.rs
@@ -67,7 +67,6 @@ pub fn introspect(
         }
 
         match &table.primary_key {
-            // TODO: enable with preview flag, when dml index extensions are done.
             Some(pk) if pk.columns.iter().all(|c| c.length.is_none()) => {
                 model.primary_key = Some(PrimaryKeyDefinition {
                     name: None,

--- a/introspection-engine/connectors/sql-introspection-connector/src/introspection.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/introspection.rs
@@ -67,6 +67,7 @@ pub fn introspect(
         }
 
         match &table.primary_key {
+            // TODO: enable with preview flag, when dml index extensions are done.
             Some(pk) if pk.columns.iter().all(|c| c.length.is_none()) => {
                 model.primary_key = Some(PrimaryKeyDefinition {
                     name: None,

--- a/introspection-engine/connectors/sql-introspection-connector/src/introspection_helpers.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/introspection_helpers.rs
@@ -250,11 +250,7 @@ pub(crate) fn calculate_backrelation_field(
                     &relation_info.fields,
                 ) && i.is_unique()
             }) || columns_match(
-                &table
-                    .primary_key_columns()
-                    .into_iter()
-                    .map(|c| c.name)
-                    .collect::<Vec<_>>(),
+                &table.primary_key_columns().map(|c| c.name).collect::<Vec<_>>(),
                 &relation_info.fields,
             );
 

--- a/introspection-engine/connectors/sql-introspection-connector/src/introspection_helpers.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/introspection_helpers.rs
@@ -74,15 +74,16 @@ fn common_prisma_m_to_n_relation_conditions(table: &Table) -> bool {
         //UNIQUE INDEX [A,B]
         && table.indices.iter().any(|i| {
             i.columns.len() == 2
-                && is_a(&i.columns[0])
-                && is_b(&i.columns[1])
+                && is_a(i.columns[0].name())
+                && is_b(i.columns[1].name())
                 && i.is_unique()
         })
         //INDEX [B]
         && table
             .indices
             .iter()
-            .any(|i| i.columns.len() == 1 && is_b(&i.columns[0]) && i.tpe == IndexType::Normal)
+            .any(|i| i.columns.len() == 1 && is_b(i.columns[0].name()) && i.tpe == IndexType::Normal)
+
         // 2 FKs
         && table.foreign_keys.len() == 2
         // Lexicographically lower model referenced by A
@@ -135,7 +136,7 @@ pub(crate) fn calculate_index(index: &Index) -> IndexDefinition {
     IndexDefinition {
         name: None,
         db_name: Some(index.name.clone()),
-        fields: index.columns.clone(),
+        fields: index.columns.iter().map(|c| c.name().to_string()).collect(),
         tpe,
         defined_on_field: index.columns.len() == 1,
     }
@@ -243,11 +244,19 @@ pub(crate) fn calculate_backrelation_field(
             };
 
             // unique or id
-            let other_is_unique = table
-                .indices
-                .iter()
-                .any(|i| columns_match(&i.columns, &relation_info.fields) && i.is_unique())
-                || columns_match(&table.primary_key_columns(), &relation_info.fields);
+            let other_is_unique = table.indices.iter().any(|i| {
+                columns_match(
+                    &i.columns.iter().map(|c| c.name().to_string()).collect::<Vec<_>>(),
+                    &relation_info.fields,
+                ) && i.is_unique()
+            }) || columns_match(
+                &table
+                    .primary_key_columns()
+                    .into_iter()
+                    .map(|c| c.name)
+                    .collect::<Vec<_>>(),
+                &relation_info.fields,
+            );
 
             let arity = match relation_field.arity {
                 FieldArity::Required | FieldArity::Optional if other_is_unique => FieldArity::Optional,

--- a/introspection-engine/connectors/sql-introspection-connector/src/introspection_helpers.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/introspection_helpers.rs
@@ -250,7 +250,10 @@ pub(crate) fn calculate_backrelation_field(
                     &relation_info.fields,
                 ) && i.is_unique()
             }) || columns_match(
-                &table.primary_key_columns().map(|c| c.name).collect::<Vec<_>>(),
+                &table
+                    .primary_key_columns()
+                    .map(|c| c.name().to_string())
+                    .collect::<Vec<_>>(),
                 &relation_info.fields,
             );
 

--- a/introspection-engine/connectors/sql-introspection-connector/src/lib.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/lib.rs
@@ -71,7 +71,12 @@ impl SqlIntrospectionConnector {
     }
 
     async fn describer(&self) -> SqlIntrospectionResult<Box<dyn SqlSchemaDescriberBackend + '_>> {
-        load_describer(&self.connection, self.connection.connection_info()).await
+        load_describer(
+            &self.connection,
+            self.connection.connection_info(),
+            self.preview_features,
+        )
+        .await
     }
 
     async fn list_databases_internal(&self) -> SqlIntrospectionResult<Vec<String>> {

--- a/introspection-engine/connectors/sql-introspection-connector/src/schema_describer_loading.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/schema_describer_loading.rs
@@ -1,3 +1,5 @@
+use datamodel::common::preview_features::PreviewFeature;
+use enumflags2::BitFlags;
 use quaint::prelude::{ConnectionInfo, Queryable, SqlFamily};
 use sql_schema_describer::{postgres::Circumstances, SqlSchemaDescriberBackend};
 
@@ -5,6 +7,7 @@ use sql_schema_describer::{postgres::Circumstances, SqlSchemaDescriberBackend};
 pub async fn load_describer<'a>(
     connection: &'a dyn Queryable,
     connection_info: &ConnectionInfo,
+    preview_features: BitFlags<PreviewFeature>,
 ) -> Result<Box<dyn SqlSchemaDescriberBackend + 'a>, crate::SqlError> {
     let version = connection.version().await?;
 
@@ -19,10 +22,20 @@ pub async fn load_describer<'a>(
             Box::new(sql_schema_describer::postgres::SqlSchemaDescriber::new(
                 connection,
                 circumstances,
+                preview_features,
             )) as Box<dyn SqlSchemaDescriberBackend>
         }
-        SqlFamily::Mysql => Box::new(sql_schema_describer::mysql::SqlSchemaDescriber::new(connection)),
-        SqlFamily::Sqlite => Box::new(sql_schema_describer::sqlite::SqlSchemaDescriber::new(connection)),
-        SqlFamily::Mssql => Box::new(sql_schema_describer::mssql::SqlSchemaDescriber::new(connection)),
+        SqlFamily::Mysql => Box::new(sql_schema_describer::mysql::SqlSchemaDescriber::new(
+            connection,
+            preview_features,
+        )),
+        SqlFamily::Sqlite => Box::new(sql_schema_describer::sqlite::SqlSchemaDescriber::new(
+            connection,
+            preview_features,
+        )),
+        SqlFamily::Mssql => Box::new(sql_schema_describer::mssql::SqlSchemaDescriber::new(
+            connection,
+            preview_features,
+        )),
     })
 }

--- a/introspection-engine/connectors/sql-introspection-connector/src/schema_describer_loading.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/schema_describer_loading.rs
@@ -22,20 +22,10 @@ pub async fn load_describer<'a>(
             Box::new(sql_schema_describer::postgres::SqlSchemaDescriber::new(
                 connection,
                 circumstances,
-                preview_features,
             )) as Box<dyn SqlSchemaDescriberBackend>
         }
-        SqlFamily::Mysql => Box::new(sql_schema_describer::mysql::SqlSchemaDescriber::new(
-            connection,
-            preview_features,
-        )),
-        SqlFamily::Sqlite => Box::new(sql_schema_describer::sqlite::SqlSchemaDescriber::new(
-            connection,
-            preview_features,
-        )),
-        SqlFamily::Mssql => Box::new(sql_schema_describer::mssql::SqlSchemaDescriber::new(
-            connection,
-            preview_features,
-        )),
+        SqlFamily::Mysql => Box::new(sql_schema_describer::mysql::SqlSchemaDescriber::new(connection)),
+        SqlFamily::Sqlite => Box::new(sql_schema_describer::sqlite::SqlSchemaDescriber::new(connection)),
+        SqlFamily::Mssql => Box::new(sql_schema_describer::mssql::SqlSchemaDescriber::new(connection)),
     })
 }

--- a/introspection-engine/connectors/sql-introspection-connector/src/version_checker.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/version_checker.rs
@@ -125,7 +125,7 @@ impl VersionChecker {
         if !is_prisma_1_or_11_list_table(table) && !is_relay_table(table) {
             if let Some(PrimaryKey { columns, .. }) = &table.primary_key {
                 if columns.len() == 1 {
-                    let tpe = &table.column_bang(columns.first().unwrap()).tpe;
+                    let tpe = &table.column_bang(columns.first().unwrap().name()).tpe;
 
                     if self.sql_family == SqlFamily::Postgres {
                         if let Some(native_type) = &tpe.native_type {

--- a/introspection-engine/introspection-engine-tests/tests/rpc_calls/get_database_description.rs
+++ b/introspection-engine/introspection-engine-tests/tests/rpc_calls/get_database_description.rs
@@ -1,5 +1,6 @@
 use barrel::types;
-use introspection_engine_tests::{assert_eq_schema, test_api::*, BarrelMigrationExecutor};
+use expect_test::expect;
+use introspection_engine_tests::{test_api::*, BarrelMigrationExecutor};
 use test_macros::test_connector;
 
 async fn setup_blog(barrel: &BarrelMigrationExecutor) -> TestResult {
@@ -19,9 +20,57 @@ async fn setup_blog(barrel: &BarrelMigrationExecutor) -> TestResult {
 async fn database_description_for_mysql_should_work(api: &TestApi) -> TestResult {
     setup_blog(&api.barrel()).await?;
 
-    let expected = r#"{"tables":[{"name":"Blog","columns":[{"name":"id","tpe":{"full_data_type":"int(11)","family":"Int","arity":"Required","native_type":"Int"},"default":null,"auto_increment":true},{"name":"string","tpe":{"full_data_type":"text","family":"String","arity":"Required","native_type":"Text"},"default":null,"auto_increment":false}],"indices":[],"primary_key":{"columns":["id"],"sequence":null,"constraint_name":null},"foreign_keys":[]}],"enums":[],"sequences":[],"views":[],"procedures":[],"user_defined_types":[]}"#;
+    let expected = expect![[r#"
+        {
+          "tables": [
+            {
+              "name": "Blog",
+              "columns": [
+                {
+                  "name": "id",
+                  "tpe": {
+                    "full_data_type": "int(11)",
+                    "family": "Int",
+                    "arity": "Required",
+                    "native_type": "Int"
+                  },
+                  "default": null,
+                  "auto_increment": true
+                },
+                {
+                  "name": "string",
+                  "tpe": {
+                    "full_data_type": "text",
+                    "family": "String",
+                    "arity": "Required",
+                    "native_type": "Text"
+                  },
+                  "default": null,
+                  "auto_increment": false
+                }
+              ],
+              "indices": [],
+              "primary_key": {
+                "columns": [
+                  {
+                    "name": "id",
+                    "length": null
+                  }
+                ],
+                "sequence": null,
+                "constraint_name": null
+              },
+              "foreign_keys": []
+            }
+          ],
+          "enums": [],
+          "sequences": [],
+          "views": [],
+          "procedures": [],
+          "user_defined_types": []
+        }"#]];
 
-    assert_eq_schema!(expected, api.get_database_description().await?);
+    expected.assert_eq(&api.get_database_description().await?);
 
     Ok(())
 }
@@ -30,9 +79,57 @@ async fn database_description_for_mysql_should_work(api: &TestApi) -> TestResult
 async fn database_description_for_mysql_8_should_work(api: &TestApi) -> TestResult {
     setup_blog(&api.barrel()).await?;
 
-    let expected = r#"{"tables":[{"name":"Blog","columns":[{"name":"id","tpe":{"full_data_type":"int","family":"Int","arity":"Required","native_type":"Int"},"default":null,"auto_increment":true},{"name":"string","tpe":{"full_data_type":"text","family":"String","arity":"Required","native_type":"Text"},"default":null,"auto_increment":false}],"indices":[],"primary_key":{"columns":["id"],"sequence":null,"constraint_name":null},"foreign_keys":[]}],"enums":[],"sequences":[],"views":[],"procedures":[],"user_defined_types":[]}"#;
+    let expected = expect![[r#"
+        {
+          "tables": [
+            {
+              "name": "Blog",
+              "columns": [
+                {
+                  "name": "id",
+                  "tpe": {
+                    "full_data_type": "int",
+                    "family": "Int",
+                    "arity": "Required",
+                    "native_type": "Int"
+                  },
+                  "default": null,
+                  "auto_increment": true
+                },
+                {
+                  "name": "string",
+                  "tpe": {
+                    "full_data_type": "text",
+                    "family": "String",
+                    "arity": "Required",
+                    "native_type": "Text"
+                  },
+                  "default": null,
+                  "auto_increment": false
+                }
+              ],
+              "indices": [],
+              "primary_key": {
+                "columns": [
+                  {
+                    "name": "id",
+                    "length": null
+                  }
+                ],
+                "sequence": null,
+                "constraint_name": null
+              },
+              "foreign_keys": []
+            }
+          ],
+          "enums": [],
+          "sequences": [],
+          "views": [],
+          "procedures": [],
+          "user_defined_types": []
+        }"#]];
 
-    assert_eq_schema!(expected, api.get_database_description().await?);
+    expected.assert_eq(&api.get_database_description().await?);
 
     Ok(())
 }
@@ -41,9 +138,68 @@ async fn database_description_for_mysql_8_should_work(api: &TestApi) -> TestResu
 async fn database_description_for_postgres_should_work(api: &TestApi) -> TestResult {
     setup_blog(&api.barrel()).await?;
 
-    let expected = r#"{"tables":[{"name":"Blog","columns":[{"name":"id","tpe":{"full_data_type":"int4","family":"Int","arity":"Required","native_type":"Integer"},"default":{"kind":{"Sequence":"Blog_id_seq"},"constraint_name":null},"auto_increment":true},{"name":"string","tpe":{"full_data_type":"text","family":"String","arity":"Required","native_type":"Text"},"default":null,"auto_increment":false}],"indices":[],"primary_key":{"columns":["id"],"sequence":{"name":"Blog_id_seq"},"constraint_name":"Blog_pkey"},"foreign_keys":[]}],"enums":[],"sequences":[{"name":"Blog_id_seq"}],"views":[],"procedures":[],"user_defined_types":[]}"#;
+    let expected = expect![[r#"
+        {
+          "tables": [
+            {
+              "name": "Blog",
+              "columns": [
+                {
+                  "name": "id",
+                  "tpe": {
+                    "full_data_type": "int4",
+                    "family": "Int",
+                    "arity": "Required",
+                    "native_type": "Integer"
+                  },
+                  "default": {
+                    "kind": {
+                      "Sequence": "Blog_id_seq"
+                    },
+                    "constraint_name": null
+                  },
+                  "auto_increment": true
+                },
+                {
+                  "name": "string",
+                  "tpe": {
+                    "full_data_type": "text",
+                    "family": "String",
+                    "arity": "Required",
+                    "native_type": "Text"
+                  },
+                  "default": null,
+                  "auto_increment": false
+                }
+              ],
+              "indices": [],
+              "primary_key": {
+                "columns": [
+                  {
+                    "name": "id",
+                    "length": null
+                  }
+                ],
+                "sequence": {
+                  "name": "Blog_id_seq"
+                },
+                "constraint_name": "Blog_pkey"
+              },
+              "foreign_keys": []
+            }
+          ],
+          "enums": [],
+          "sequences": [
+            {
+              "name": "Blog_id_seq"
+            }
+          ],
+          "views": [],
+          "procedures": [],
+          "user_defined_types": []
+        }"#]];
 
-    assert_eq_schema!(expected, api.get_database_description().await?);
+    expected.assert_eq(&api.get_database_description().await?);
 
     Ok(())
 }
@@ -52,9 +208,57 @@ async fn database_description_for_postgres_should_work(api: &TestApi) -> TestRes
 async fn database_description_for_sqlite_should_work(api: &TestApi) -> TestResult {
     setup_blog(&api.barrel()).await?;
 
-    let expected = r#"{"tables":[{"name":"Blog","columns":[{"name":"id","tpe":{"full_data_type":"INTEGER","family":"Int","arity":"Required","native_type":null},"default":null,"auto_increment":true},{"name":"string","tpe":{"full_data_type":"TEXT","family":"String","arity":"Required","native_type":null},"default":null,"auto_increment":false}],"indices":[],"primary_key":{"columns":["id"],"sequence":null,"constraint_name":null},"foreign_keys":[]}],"enums":[],"sequences":[],"views":[],"procedures":[],"user_defined_types":[]}"#;
+    let expected = expect![[r#"
+        {
+          "tables": [
+            {
+              "name": "Blog",
+              "columns": [
+                {
+                  "name": "id",
+                  "tpe": {
+                    "full_data_type": "INTEGER",
+                    "family": "Int",
+                    "arity": "Required",
+                    "native_type": null
+                  },
+                  "default": null,
+                  "auto_increment": true
+                },
+                {
+                  "name": "string",
+                  "tpe": {
+                    "full_data_type": "TEXT",
+                    "family": "String",
+                    "arity": "Required",
+                    "native_type": null
+                  },
+                  "default": null,
+                  "auto_increment": false
+                }
+              ],
+              "indices": [],
+              "primary_key": {
+                "columns": [
+                  {
+                    "name": "id",
+                    "length": null
+                  }
+                ],
+                "sequence": null,
+                "constraint_name": null
+              },
+              "foreign_keys": []
+            }
+          ],
+          "enums": [],
+          "sequences": [],
+          "views": [],
+          "procedures": [],
+          "user_defined_types": []
+        }"#]];
 
-    assert_eq_schema!(expected, api.get_database_description().await?);
+    expected.assert_eq(&api.get_database_description().await?);
 
     Ok(())
 }

--- a/introspection-engine/introspection-engine-tests/tests/rpc_calls/get_database_description.rs
+++ b/introspection-engine/introspection-engine-tests/tests/rpc_calls/get_database_description.rs
@@ -113,7 +113,8 @@ async fn database_description_for_mysql_8_should_work(api: &TestApi) -> TestResu
                 "columns": [
                   {
                     "name": "id",
-                    "length": null
+                    "length": null,
+                    "sort_order": null
                   }
                 ],
                 "sequence": null,
@@ -177,7 +178,8 @@ async fn database_description_for_postgres_should_work(api: &TestApi) -> TestRes
                 "columns": [
                   {
                     "name": "id",
-                    "length": null
+                    "length": null,
+                    "sort_order": null
                   }
                 ],
                 "sequence": {
@@ -242,7 +244,8 @@ async fn database_description_for_sqlite_should_work(api: &TestApi) -> TestResul
                 "columns": [
                   {
                     "name": "id",
-                    "length": null
+                    "length": null,
+                    "sort_order": null
                   }
                 ],
                 "sequence": null,

--- a/introspection-engine/introspection-engine-tests/tests/rpc_calls/get_database_description.rs
+++ b/introspection-engine/introspection-engine-tests/tests/rpc_calls/get_database_description.rs
@@ -54,7 +54,8 @@ async fn database_description_for_mysql_should_work(api: &TestApi) -> TestResult
                 "columns": [
                   {
                     "name": "id",
-                    "length": null
+                    "length": null,
+                    "sort_order": null
                   }
                 ],
                 "sequence": null,

--- a/introspection-engine/introspection-engine-tests/tests/tables/mod.rs
+++ b/introspection-engine/introspection-engine-tests/tests/tables/mod.rs
@@ -798,16 +798,15 @@ async fn partial_indexes_should_be_ignored_on_mysql(api: &TestApi) -> TestResult
         })
         .await?;
 
-    let dm = indoc! {r##"
+    let expected = expect![[r#"
         model Blog {
-          id                Int     @id @default(autoincrement())
-          int_col           Int
-          blob_col          Bytes?  @db.MediumBlob
+          id       Int    @id @default(autoincrement())
+          int_col  Int
+          blob_col Bytes? @db.MediumBlob
         }
-    "##};
+    "#]];
 
-    let result = &api.introspect().await?;
-    api.assert_eq_datamodels(dm, result);
+    expected.assert_eq(&api.introspect_dml().await?);
 
     Ok(())
 }

--- a/introspection-engine/introspection-engine-tests/tests/tables/mod.rs
+++ b/introspection-engine/introspection-engine-tests/tests/tables/mod.rs
@@ -824,15 +824,14 @@ async fn expression_indexes_should_be_ignored_on_sqlite(api: &TestApi) -> TestRe
         })
         .await?;
 
-    let dm = indoc! {r##"
+    let expected = expect![[r#"
         model Blog {
-          id                Int     @id @default(autoincrement())
-          author            String
+          id     Int    @id @default(autoincrement())
+          author String
         }
-    "##};
+    "#]];
 
-    let result = &api.introspect().await?;
-    api.assert_eq_datamodels(dm, result);
+    expected.assert_eq(&api.introspect_dml().await?);
 
     Ok(())
 }

--- a/libs/sql-schema-describer/Cargo.toml
+++ b/libs/sql-schema-describer/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.1.0"
 [dependencies]
 native-types = { path = "../native-types" }
 prisma-value = { path = "../prisma-value" }
+datamodel = { path = "../datamodel/core" }
 
 async-trait = "0.1.17"
 bigdecimal = "0.2"

--- a/libs/sql-schema-describer/Cargo.toml
+++ b/libs/sql-schema-describer/Cargo.toml
@@ -7,7 +7,6 @@ version = "0.1.0"
 [dependencies]
 native-types = { path = "../native-types" }
 prisma-value = { path = "../prisma-value" }
-datamodel = { path = "../datamodel/core" }
 
 async-trait = "0.1.17"
 bigdecimal = "0.2"

--- a/libs/sql-schema-describer/src/lib.rs
+++ b/libs/sql-schema-describer/src/lib.rs
@@ -191,12 +191,12 @@ impl Table {
 
     pub fn is_part_of_primary_key(&self, column: &str) -> bool {
         match &self.primary_key {
-            Some(pk) => pk.columns.contains(&column.to_string()),
+            Some(pk) => pk.columns.iter().any(|c| c.name() == column),
             None => false,
         }
     }
 
-    pub fn primary_key_columns(&self) -> Vec<String> {
+    pub fn primary_key_columns(&self) -> Vec<PrimaryKeyColumn> {
         match &self.primary_key {
             Some(pk) => pk.columns.clone(),
             None => Vec::new(),
@@ -205,7 +205,7 @@ impl Table {
 
     pub fn is_column_unique(&self, column_name: &str) -> bool {
         self.indices.iter().any(|index| {
-            index.is_unique() && index.columns.len() == 1 && index.columns.contains(&column_name.to_owned())
+            index.is_unique() && index.columns.len() == 1 && index.columns.iter().any(|c| c.name() == column_name)
         })
     }
 
@@ -232,13 +232,40 @@ impl IndexType {
     }
 }
 
+/// The sort order of an index.
+#[derive(Serialize, Deserialize, PartialEq, Debug, Copy, Clone)]
+pub enum SQLSortOrder {
+    Asc,
+    Desc,
+}
+
+#[derive(Default, Serialize, Deserialize, PartialEq, Debug, Clone)]
+pub struct IndexColumn {
+    pub name: String,
+    pub sort_order: Option<SQLSortOrder>,
+    pub length: Option<u32>,
+}
+
+impl IndexColumn {
+    pub fn new(name: impl ToString) -> Self {
+        Self {
+            name: name.to_string(),
+            ..Default::default()
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
 /// An index of a table.
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct Index {
     /// Index name.
     pub name: String,
     /// Index columns.
-    pub columns: Vec<String>,
+    pub columns: Vec<IndexColumn>,
     /// Type of index.
     pub tpe: IndexType,
 }
@@ -246,6 +273,10 @@ pub struct Index {
 impl Index {
     pub fn is_unique(&self) -> bool {
         self.tpe == IndexType::Unique
+    }
+
+    pub fn column_names(&self) -> impl ExactSizeIterator<Item = &str> + '_ {
+        self.columns.iter().map(|c| c.name())
     }
 }
 
@@ -267,11 +298,30 @@ pub struct UserDefinedType {
     pub definition: Option<String>,
 }
 
+#[derive(Default, Serialize, Deserialize, PartialEq, Debug, Clone)]
+pub struct PrimaryKeyColumn {
+    pub name: String,
+    pub length: Option<u32>,
+}
+
+impl PrimaryKeyColumn {
+    pub fn new(name: impl ToString) -> Self {
+        Self {
+            name: name.to_string(),
+            ..Default::default()
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
 /// The primary key of a table.
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct PrimaryKey {
     /// Columns.
-    pub columns: Vec<String>,
+    pub columns: Vec<PrimaryKeyColumn>,
     /// The sequence optionally seeding this primary key.
     pub sequence: Option<Sequence>,
     /// The name of the primary key constraint, when available.
@@ -280,7 +330,11 @@ pub struct PrimaryKey {
 
 impl PrimaryKey {
     pub fn is_single_primary_key(&self, column: &str) -> bool {
-        self.columns.len() == 1 && self.columns.iter().any(|col| col == column)
+        self.columns.len() == 1 && self.columns.iter().any(|col| col.name() == column)
+    }
+
+    pub fn column_names(&self) -> impl ExactSizeIterator<Item = &str> + '_ {
+        self.columns.iter().map(|c| c.name())
     }
 }
 

--- a/libs/sql-schema-describer/src/lib.rs
+++ b/libs/sql-schema-describer/src/lib.rs
@@ -239,11 +239,18 @@ pub enum SQLSortOrder {
     Desc,
 }
 
-#[derive(Default, Serialize, Deserialize, PartialEq, Debug, Clone)]
+#[derive(Default, Serialize, Deserialize, Debug, Clone)]
 pub struct IndexColumn {
     pub name: String,
     pub sort_order: Option<SQLSortOrder>,
     pub length: Option<u32>,
+}
+
+// TODO: remove when GA for index types
+impl PartialEq for IndexColumn {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name
+    }
 }
 
 impl IndexColumn {
@@ -298,11 +305,18 @@ pub struct UserDefinedType {
     pub definition: Option<String>,
 }
 
-#[derive(Default, Serialize, Deserialize, PartialEq, Debug, Clone)]
+#[derive(Default, Serialize, Deserialize, Debug, Clone)]
 pub struct PrimaryKeyColumn {
     pub name: String,
     pub length: Option<u32>,
     pub sort_order: Option<SQLSortOrder>,
+}
+
+// TODO: remove when GA for index types
+impl PartialEq for PrimaryKeyColumn {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name
+    }
 }
 
 impl PrimaryKeyColumn {

--- a/libs/sql-schema-describer/src/lib.rs
+++ b/libs/sql-schema-describer/src/lib.rs
@@ -239,18 +239,11 @@ pub enum SQLSortOrder {
     Desc,
 }
 
-#[derive(Default, Serialize, Deserialize, Debug, Clone)]
+#[derive(Default, Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct IndexColumn {
     pub name: String,
     pub sort_order: Option<SQLSortOrder>,
     pub length: Option<u32>,
-}
-
-// TODO: remove when GA for index types
-impl PartialEq for IndexColumn {
-    fn eq(&self, other: &Self) -> bool {
-        self.name == other.name
-    }
 }
 
 impl IndexColumn {
@@ -263,6 +256,10 @@ impl IndexColumn {
 
     pub fn name(&self) -> &str {
         &self.name
+    }
+
+    pub fn set_sort_order(&mut self, sort_order: SQLSortOrder) {
+        self.sort_order = Some(sort_order);
     }
 }
 
@@ -305,18 +302,11 @@ pub struct UserDefinedType {
     pub definition: Option<String>,
 }
 
-#[derive(Default, Serialize, Deserialize, Debug, Clone)]
+#[derive(Default, Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct PrimaryKeyColumn {
     pub name: String,
     pub length: Option<u32>,
     pub sort_order: Option<SQLSortOrder>,
-}
-
-// TODO: remove when GA for index types
-impl PartialEq for PrimaryKeyColumn {
-    fn eq(&self, other: &Self) -> bool {
-        self.name == other.name
-    }
 }
 
 impl PrimaryKeyColumn {
@@ -329,6 +319,10 @@ impl PrimaryKeyColumn {
 
     pub fn name(&self) -> &str {
         &self.name
+    }
+
+    pub fn set_sort_order(&mut self, sort_order: SQLSortOrder) {
+        self.sort_order = Some(sort_order);
     }
 }
 

--- a/libs/sql-schema-describer/src/lib.rs
+++ b/libs/sql-schema-describer/src/lib.rs
@@ -196,10 +196,10 @@ impl Table {
         }
     }
 
-    pub fn primary_key_columns(&self) -> Vec<PrimaryKeyColumn> {
+    pub fn primary_key_columns<'a>(&'a self) -> impl Iterator<Item = &'a PrimaryKeyColumn> + 'a {
         match &self.primary_key {
-            Some(pk) => pk.columns.clone(),
-            None => Vec::new(),
+            Some(pk) => pk.columns.iter(),
+            None => [].iter(),
         }
     }
 
@@ -302,6 +302,7 @@ pub struct UserDefinedType {
 pub struct PrimaryKeyColumn {
     pub name: String,
     pub length: Option<u32>,
+    pub sort_order: Option<SQLSortOrder>,
 }
 
 impl PrimaryKeyColumn {

--- a/libs/sql-schema-describer/src/lib.rs
+++ b/libs/sql-schema-describer/src/lib.rs
@@ -110,6 +110,13 @@ impl SqlSchema {
             .map(|(table_index, table)| (TableId(table_index as u32), table))
     }
 
+    pub fn iter_tables_mut(&mut self) -> impl Iterator<Item = (TableId, &mut Table)> {
+        self.tables
+            .iter_mut()
+            .enumerate()
+            .map(|(table_index, table)| (TableId(table_index as u32), table))
+    }
+
     pub fn table(&self, name: &str) -> core::result::Result<&Table, String> {
         match self.tables.iter().find(|t| t.name == name) {
             Some(t) => Ok(t),

--- a/libs/sql-schema-describer/src/lib.rs
+++ b/libs/sql-schema-describer/src/lib.rs
@@ -196,7 +196,7 @@ impl Table {
         }
     }
 
-    pub fn primary_key_columns<'a>(&'a self) -> impl Iterator<Item = &'a PrimaryKeyColumn> + 'a {
+    pub fn primary_key_columns(&self) -> impl Iterator<Item = &PrimaryKeyColumn> + '_ {
         match &self.primary_key {
             Some(pk) => pk.columns.iter(),
             None => [].iter(),

--- a/libs/sql-schema-describer/src/mssql.rs
+++ b/libs/sql-schema-describer/src/mssql.rs
@@ -1,7 +1,7 @@
 use crate::{
     getters::Getter, parsers::Parser, Column, ColumnArity, ColumnType, ColumnTypeFamily, DefaultValue, DescriberError,
-    DescriberErrorKind, DescriberResult, ForeignKey, ForeignKeyAction, Index, IndexType, PrimaryKey, Procedure,
-    SqlMetadata, SqlSchema, Table, UserDefinedType, View,
+    DescriberErrorKind, DescriberResult, ForeignKey, ForeignKeyAction, Index, IndexColumn, IndexType, PrimaryKey,
+    PrimaryKeyColumn, Procedure, SqlMetadata, SqlSchema, Table, UserDefinedType, View,
 };
 use indoc::indoc;
 use native_types::{MsSqlType, MsSqlTypeParameter, NativeType};
@@ -433,10 +433,13 @@ impl<'a> SqlSchemaDescriber<'a> {
                         match primary_key {
                             Some(pk) => {
                                 if pk.columns.len() < (pos + 1) as usize {
-                                    pk.columns.resize((pos + 1) as usize, "".to_string());
+                                    pk.columns.resize((pos + 1) as usize, PrimaryKeyColumn::default());
                                 }
 
-                                pk.columns[pos as usize] = column_name;
+                                pk.columns[pos as usize] = PrimaryKeyColumn {
+                                    name: column_name,
+                                    length: None,
+                                };
 
                                 debug!(
                                     "The primary key has already been created, added column to it: {:?}",
@@ -447,7 +450,7 @@ impl<'a> SqlSchemaDescriber<'a> {
                                 debug!("Instantiating primary key");
 
                                 primary_key.replace(PrimaryKey {
-                                    columns: vec![column_name],
+                                    columns: vec![PrimaryKeyColumn::new(column_name)],
                                     sequence: None,
                                     constraint_name: Some(index_name),
                                 });
@@ -455,14 +458,14 @@ impl<'a> SqlSchemaDescriber<'a> {
                         };
                     } else if indexes_map.contains_key(&index_name) {
                         if let Some(index) = indexes_map.get_mut(&index_name) {
-                            index.columns.push(column_name);
+                            index.columns.push(IndexColumn::new(column_name));
                         }
                     } else {
                         indexes_map.insert(
                             index_name.clone(),
                             Index {
                                 name: index_name,
-                                columns: vec![column_name],
+                                columns: vec![IndexColumn::new(column_name)],
                                 tpe: match is_unique {
                                     true => IndexType::Unique,
                                     false => IndexType::Normal,

--- a/libs/sql-schema-describer/src/mssql.rs
+++ b/libs/sql-schema-describer/src/mssql.rs
@@ -3,6 +3,8 @@ use crate::{
     DescriberErrorKind, DescriberResult, ForeignKey, ForeignKeyAction, Index, IndexColumn, IndexType, PrimaryKey,
     PrimaryKeyColumn, Procedure, SQLSortOrder, SqlMetadata, SqlSchema, Table, UserDefinedType, View,
 };
+use datamodel::common::preview_features::PreviewFeature;
+use enumflags2::BitFlags;
 use indoc::indoc;
 use native_types::{MsSqlType, MsSqlTypeParameter, NativeType};
 use once_cell::sync::Lazy;
@@ -63,6 +65,7 @@ static DEFAULT_SHARED_CONSTRAINT: Lazy<Regex> = Lazy::new(|| Regex::new(r"^CREAT
 
 pub struct SqlSchemaDescriber<'a> {
     conn: &'a dyn Queryable,
+    preview_features: BitFlags<PreviewFeature>,
 }
 
 impl std::fmt::Debug for SqlSchemaDescriber<'_> {
@@ -124,8 +127,8 @@ impl super::SqlSchemaDescriberBackend for SqlSchemaDescriber<'_> {
 impl Parser for SqlSchemaDescriber<'_> {}
 
 impl<'a> SqlSchemaDescriber<'a> {
-    pub fn new(conn: &'a dyn Queryable) -> Self {
-        Self { conn }
+    pub fn new(conn: &'a dyn Queryable, preview_features: BitFlags<PreviewFeature>) -> Self {
+        Self { conn, preview_features }
     }
 
     #[tracing::instrument]
@@ -442,11 +445,10 @@ impl<'a> SqlSchemaDescriber<'a> {
                                     pk.columns.resize((pos + 1) as usize, PrimaryKeyColumn::default());
                                 }
 
-                                pk.columns[pos as usize] = PrimaryKeyColumn {
-                                    name: column_name,
-                                    sort_order: Some(sort_order),
-                                    length: None,
-                                };
+                                pk.columns[pos as usize] = PrimaryKeyColumn::new(column_name);
+                                if self.preview_features.contains(PreviewFeature::ExtendedIndexes) {
+                                    pk.columns[pos as usize].set_sort_order(sort_order);
+                                }
 
                                 debug!(
                                     "The primary key has already been created, added column to it: {:?}",
@@ -456,12 +458,14 @@ impl<'a> SqlSchemaDescriber<'a> {
                             None => {
                                 debug!("Instantiating primary key");
 
+                                let mut column = PrimaryKeyColumn::new(column_name);
+
+                                if self.preview_features.contains(PreviewFeature::ExtendedIndexes) {
+                                    column.set_sort_order(sort_order);
+                                }
+
                                 primary_key.replace(PrimaryKey {
-                                    columns: vec![PrimaryKeyColumn {
-                                        name: column_name.to_string(),
-                                        sort_order: Some(sort_order),
-                                        length: None,
-                                    }],
+                                    columns: vec![column],
                                     sequence: None,
                                     constraint_name: Some(index_name),
                                 });
@@ -469,24 +473,26 @@ impl<'a> SqlSchemaDescriber<'a> {
                         };
                     } else if indexes_map.contains_key(&index_name) {
                         if let Some(index) = indexes_map.get_mut(&index_name) {
-                            index.columns.push(IndexColumn {
-                                name: column_name,
-                                sort_order: Some(sort_order),
-                                length: None,
-                            });
+                            let mut column = IndexColumn::new(column_name);
+
+                            if self.preview_features.contains(PreviewFeature::ExtendedIndexes) {
+                                column.set_sort_order(sort_order);
+                            }
+
+                            index.columns.push(column);
                         }
                     } else {
-                        let columns = vec![IndexColumn {
-                            name: column_name,
-                            sort_order: Some(sort_order),
-                            length: None,
-                        }];
+                        let mut column = IndexColumn::new(column_name);
+
+                        if self.preview_features.contains(PreviewFeature::ExtendedIndexes) {
+                            column.set_sort_order(sort_order);
+                        }
 
                         indexes_map.insert(
                             index_name.clone(),
                             Index {
                                 name: index_name,
-                                columns,
+                                columns: vec![column],
                                 tpe: match is_unique {
                                     true => IndexType::Unique,
                                     false => IndexType::Normal,

--- a/libs/sql-schema-describer/src/mysql.rs
+++ b/libs/sql-schema-describer/src/mysql.rs
@@ -472,6 +472,7 @@ impl<'a> SqlSchemaDescriber<'a> {
 
                                 pk.columns[pos as usize] = PrimaryKeyColumn {
                                     name: column_name.to_string(),
+                                    sort_order: None,
                                     length,
                                 };
 
@@ -486,6 +487,7 @@ impl<'a> SqlSchemaDescriber<'a> {
                                 let column = PrimaryKeyColumn {
                                     name: column_name,
                                     length,
+                                    sort_order: None,
                                 };
 
                                 primary_key.replace(PrimaryKey {

--- a/libs/sql-schema-describer/src/mysql.rs
+++ b/libs/sql-schema-describer/src/mysql.rs
@@ -462,9 +462,9 @@ impl<'a> SqlSchemaDescriber<'a> {
                         match primary_key {
                             Some(pk) => {
                                 if pk.columns.len() < (pos + 1) as usize {
-                                    pk.columns.resize((pos + 1) as usize, "".to_string());
+                                    pk.columns.resize((pos + 1) as usize, PrimaryKeyColumn::default());
                                 }
-                                pk.columns[pos as usize] = column_name;
+                                pk.columns[pos as usize] = PrimaryKeyColumn::new(column_name);
                                 trace!(
                                     "The primary key has already been created, added column to it: {:?}",
                                     pk.columns
@@ -474,7 +474,7 @@ impl<'a> SqlSchemaDescriber<'a> {
                                 trace!("Instantiating primary key");
 
                                 primary_key.replace(PrimaryKey {
-                                    columns: vec![column_name],
+                                    columns: vec![PrimaryKeyColumn::new(column_name)],
                                     sequence: None,
                                     constraint_name: None,
                                 });
@@ -482,14 +482,14 @@ impl<'a> SqlSchemaDescriber<'a> {
                         };
                     } else if indexes_map.contains_key(&index_name) {
                         if let Some(index) = indexes_map.get_mut(&index_name) {
-                            index.columns.push(column_name);
+                            index.columns.push(IndexColumn::new(column_name));
                         }
                     } else {
                         indexes_map.insert(
                             index_name.clone(),
                             Index {
                                 name: index_name,
-                                columns: vec![column_name],
+                                columns: vec![IndexColumn::new(column_name)],
                                 tpe: match is_unique {
                                     true => IndexType::Unique,
                                     false => IndexType::Normal,

--- a/libs/sql-schema-describer/src/postgres.rs
+++ b/libs/sql-schema-describer/src/postgres.rs
@@ -2,6 +2,7 @@
 
 use super::*;
 use crate::{getters::Getter, parsers::Parser};
+use datamodel::common::preview_features::PreviewFeature;
 use enumflags2::BitFlags;
 use indoc::indoc;
 use native_types::{NativeType, PostgresType};
@@ -21,6 +22,7 @@ pub enum Circumstances {
 pub struct SqlSchemaDescriber<'a> {
     conn: &'a dyn Queryable,
     circumstances: BitFlags<Circumstances>,
+    preview_features: BitFlags<PreviewFeature>,
 }
 
 impl Debug for SqlSchemaDescriber<'_> {
@@ -130,8 +132,16 @@ impl Parser for SqlSchemaDescriber<'_> {
 
 impl<'a> SqlSchemaDescriber<'a> {
     /// Constructor.
-    pub fn new(conn: &'a dyn Queryable, circumstances: BitFlags<Circumstances>) -> SqlSchemaDescriber<'a> {
-        SqlSchemaDescriber { conn, circumstances }
+    pub fn new(
+        conn: &'a dyn Queryable,
+        circumstances: BitFlags<Circumstances>,
+        preview_features: BitFlags<PreviewFeature>,
+    ) -> SqlSchemaDescriber<'a> {
+        SqlSchemaDescriber {
+            conn,
+            circumstances,
+            preview_features,
+        }
     }
 
     fn is_cockroach(&self) -> bool {
@@ -647,11 +657,11 @@ impl<'a> SqlSchemaDescriber<'a> {
             } else {
                 let entry: &mut (Vec<Index>, _) = indexes_map.entry(table_name).or_insert_with(|| (Vec::new(), None));
 
-                let column = IndexColumn {
-                    name: column_name.to_string(),
-                    sort_order,
-                    length: None,
-                };
+                let mut column = IndexColumn::new(column_name);
+
+                if self.preview_features.contains(PreviewFeature::ExtendedIndexes) {
+                    column.sort_order = sort_order;
+                }
 
                 if let Some(existing_index) = entry.0.iter_mut().find(|idx| idx.name == name) {
                     existing_index.columns.push(column);

--- a/libs/sql-schema-describer/src/postgres.rs
+++ b/libs/sql-schema-describer/src/postgres.rs
@@ -2,7 +2,6 @@
 
 use super::*;
 use crate::{getters::Getter, parsers::Parser};
-use datamodel::common::preview_features::PreviewFeature;
 use enumflags2::BitFlags;
 use indoc::indoc;
 use native_types::{NativeType, PostgresType};
@@ -22,7 +21,6 @@ pub enum Circumstances {
 pub struct SqlSchemaDescriber<'a> {
     conn: &'a dyn Queryable,
     circumstances: BitFlags<Circumstances>,
-    preview_features: BitFlags<PreviewFeature>,
 }
 
 impl Debug for SqlSchemaDescriber<'_> {
@@ -132,16 +130,8 @@ impl Parser for SqlSchemaDescriber<'_> {
 
 impl<'a> SqlSchemaDescriber<'a> {
     /// Constructor.
-    pub fn new(
-        conn: &'a dyn Queryable,
-        circumstances: BitFlags<Circumstances>,
-        preview_features: BitFlags<PreviewFeature>,
-    ) -> SqlSchemaDescriber<'a> {
-        SqlSchemaDescriber {
-            conn,
-            circumstances,
-            preview_features,
-        }
+    pub fn new(conn: &'a dyn Queryable, circumstances: BitFlags<Circumstances>) -> SqlSchemaDescriber<'a> {
+        SqlSchemaDescriber { conn, circumstances }
     }
 
     fn is_cockroach(&self) -> bool {
@@ -658,10 +648,7 @@ impl<'a> SqlSchemaDescriber<'a> {
                 let entry: &mut (Vec<Index>, _) = indexes_map.entry(table_name).or_insert_with(|| (Vec::new(), None));
 
                 let mut column = IndexColumn::new(column_name);
-
-                if self.preview_features.contains(PreviewFeature::ExtendedIndexes) {
-                    column.sort_order = sort_order;
-                }
+                column.sort_order = sort_order;
 
                 if let Some(existing_index) = entry.0.iter_mut().find(|idx| idx.name == name) {
                     existing_index.columns.push(column);

--- a/libs/sql-schema-describer/src/sqlite.rs
+++ b/libs/sql-schema-describer/src/sqlite.rs
@@ -283,7 +283,7 @@ impl<'a> SqlSchemaDescriber<'a> {
             if pk_cols.len() == 1 {
                 let pk_col = &columns[0];
                 for col in cols.iter_mut() {
-                    if &col.name == pk_col.name() && &col.tpe.full_data_type.to_lowercase() == "integer" {
+                    if col.name == pk_col.name() && &col.tpe.full_data_type.to_lowercase() == "integer" {
                         trace!(
                             "Detected that the primary key column corresponds to rowid and \
                                  is auto incrementing"

--- a/libs/sql-schema-describer/src/sqlite.rs
+++ b/libs/sql-schema-describer/src/sqlite.rs
@@ -5,12 +5,15 @@ use crate::{
     PrimaryKey, PrimaryKeyColumn, PrismaValue, Regex, SQLSortOrder, SqlMetadata, SqlSchema, SqlSchemaDescriberBackend,
     Table, View,
 };
+use datamodel::common::preview_features::PreviewFeature;
+use enumflags2::BitFlags;
 use quaint::{ast::Value, prelude::Queryable};
 use std::{any::type_name, borrow::Cow, collections::BTreeMap, convert::TryInto, fmt::Debug};
 use tracing::trace;
 
 pub struct SqlSchemaDescriber<'a> {
     conn: &'a dyn Queryable,
+    preview_features: BitFlags<PreviewFeature>,
 }
 
 impl Debug for SqlSchemaDescriber<'_> {
@@ -91,8 +94,8 @@ impl Parser for SqlSchemaDescriber<'_> {}
 
 impl<'a> SqlSchemaDescriber<'a> {
     /// Constructor.
-    pub fn new(conn: &'a dyn Queryable) -> SqlSchemaDescriber<'a> {
-        SqlSchemaDescriber { conn }
+    pub fn new(conn: &'a dyn Queryable, preview_features: BitFlags<PreviewFeature>) -> SqlSchemaDescriber<'a> {
+        SqlSchemaDescriber { conn, preview_features }
     }
 
     #[tracing::instrument]
@@ -474,21 +477,23 @@ impl<'a> SqlSchemaDescriber<'a> {
                 }
             }
 
-            let sql = format!(r#"PRAGMA index_xinfo("{}");"#, name);
-            let result_set = self.conn.query_raw(&sql, &[]).await.expect("querying for index info");
-            trace!("Got index description results: {:?}", result_set);
+            if self.preview_features.contains(PreviewFeature::ExtendedIndexes) {
+                let sql = format!(r#"PRAGMA index_xinfo("{}");"#, name);
+                let result_set = self.conn.query_raw(&sql, &[]).await.expect("querying for index info");
+                trace!("Got index description results: {:?}", result_set);
 
-            for row in result_set.into_iter() {
-                //if the index is on a rowid or expression, the name of the column will be null, we ignore these for now
-                if row.get("name").and_then(|x| x.to_string()).is_some() {
-                    let pos = row.get("seqno").and_then(|x| x.as_i64()).expect("get seqno") as usize;
+                for row in result_set.into_iter() {
+                    //if the index is on a rowid or expression, the name of the column will be null, we ignore these for now
+                    if row.get("name").and_then(|x| x.to_string()).is_some() {
+                        let pos = row.get("seqno").and_then(|x| x.as_i64()).expect("get seqno") as usize;
 
-                    let sort_order = row.get("desc").and_then(|r| r.as_i64()).map(|v| match v {
-                        0 => SQLSortOrder::Asc,
-                        _ => SQLSortOrder::Desc,
-                    });
+                        let sort_order = row.get("desc").and_then(|r| r.as_i64()).map(|v| match v {
+                            0 => SQLSortOrder::Asc,
+                            _ => SQLSortOrder::Desc,
+                        });
 
-                    index.columns[pos].sort_order = sort_order;
+                        index.columns[pos].sort_order = sort_order;
+                    }
                 }
             }
 

--- a/libs/sql-schema-describer/src/sqlite.rs
+++ b/libs/sql-schema-describer/src/sqlite.rs
@@ -442,7 +442,9 @@ impl<'a> SqlSchemaDescriber<'a> {
             // Exclude partial indices
             .filter(|row| !row.get("partial").and_then(|partial| partial.as_bool()).unwrap());
 
-        'index_loop: for row in filtered_rows {
+        for row in filtered_rows {
+            let mut valid_index = true;
+
             let is_unique = row.get("unique").and_then(|x| x.as_bool()).expect("get unique");
             let name = row.get("name").and_then(|x| x.to_string()).expect("get name");
             let mut index = Index {
@@ -457,42 +459,42 @@ impl<'a> SqlSchemaDescriber<'a> {
             let sql = format!(r#"PRAGMA index_info("{}");"#, name);
             let result_set = self.conn.query_raw(&sql, &[]).await.expect("querying for index info");
             trace!("Got index description results: {:?}", result_set);
+
             for row in result_set.into_iter() {
                 //if the index is on a rowid or expression, the name of the column will be null, we ignore these for now
-                if let Some(name) = row.get("name").and_then(|x| x.to_string()) {
-                    let pos = row.get("seqno").and_then(|x| x.as_i64()).expect("get seqno") as usize;
-                    if index.columns.len() <= pos {
-                        index.columns.resize(pos + 1, IndexColumn::default());
+                match row.get("name").and_then(|x| x.to_string()) {
+                    Some(name) => {
+                        let pos = row.get("seqno").and_then(|x| x.as_i64()).expect("get seqno") as usize;
+                        if index.columns.len() <= pos {
+                            index.columns.resize(pos + 1, IndexColumn::default());
+                        }
+                        index.columns[pos] = IndexColumn::new(name);
                     }
-                    index.columns[pos] = IndexColumn::new(name);
+                    None => valid_index = false,
                 }
             }
 
             let sql = format!(r#"PRAGMA index_xinfo("{}");"#, name);
             let result_set = self.conn.query_raw(&sql, &[]).await.expect("querying for index info");
-
-            trace!("Got extra index description results: {:?}", result_set);
+            trace!("Got index description results: {:?}", result_set);
 
             for row in result_set.into_iter() {
                 //if the index is on a rowid or expression, the name of the column will be null, we ignore these for now
+                if row.get("name").and_then(|x| x.to_string()).is_some() {
+                    let pos = row.get("seqno").and_then(|x| x.as_i64()).expect("get seqno") as usize;
 
-                match row.get("name") {
-                    _ if index.columns.is_empty() => break 'index_loop,
-                    Some(quaint::Value::Text(Some(s))) if !s.is_empty() => {
-                        let pos = row.get("seqno").and_then(|x| x.as_i64()).expect("get seqno") as usize;
+                    let sort_order = row.get("desc").and_then(|r| r.as_i64()).map(|v| match v {
+                        0 => SQLSortOrder::Asc,
+                        _ => SQLSortOrder::Desc,
+                    });
 
-                        let sort_order = row.get("desc").and_then(|r| r.as_i64()).map(|v| match v {
-                            0 => SQLSortOrder::Asc,
-                            _ => SQLSortOrder::Desc,
-                        });
-
-                        index.columns[pos].sort_order = sort_order;
-                    }
-                    _ => (),
+                    index.columns[pos].sort_order = sort_order;
                 }
             }
 
-            indices.push(index)
+            if valid_index {
+                indices.push(index)
+            }
         }
 
         Ok(indices)

--- a/libs/sql-schema-describer/src/sqlite.rs
+++ b/libs/sql-schema-describer/src/sqlite.rs
@@ -477,7 +477,7 @@ impl<'a> SqlSchemaDescriber<'a> {
                 //if the index is on a rowid or expression, the name of the column will be null, we ignore these for now
 
                 match row.get("name") {
-                    _ if index.columns.len() == 0 => break 'index_loop,
+                    _ if index.columns.is_empty() => break 'index_loop,
                     Some(quaint::Value::Text(Some(s))) if !s.is_empty() => {
                         let pos = row.get("seqno").and_then(|x| x.as_i64()).expect("get seqno") as usize;
 

--- a/libs/sql-schema-describer/src/walkers.rs
+++ b/libs/sql-schema-describer/src/walkers.rs
@@ -413,13 +413,11 @@ impl<'a> TableWalker<'a> {
     }
 
     /// The names of the columns that are part of the primary key.
-    pub fn primary_key_column_names(&'a self) -> impl ExactSizeIterator<Item = &'a str> + 'a {
-        let fetch_name = |c: &'a PrimaryKeyColumn| c.name();
-
-        match self.table().primary_key.as_ref() {
-            Some(pk) => pk.columns.iter().map(fetch_name),
-            None => [].iter().map(fetch_name),
-        }
+    pub fn primary_key_column_names(&self) -> Option<Vec<String>> {
+        self.table()
+            .primary_key
+            .as_ref()
+            .map(|pk| pk.columns.iter().map(|c| c.name().to_string()).collect())
     }
 
     /// Reference to the underlying `Table` struct.

--- a/libs/sql-schema-describer/tests/describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describer_tests.rs
@@ -301,7 +301,11 @@ fn indices_must_work(api: TestApi) {
     assert_eq!(
         vec![Index {
             name: "count".to_string(),
-            columns: vec![IndexColumn::new("count")],
+            columns: vec![IndexColumn {
+                name: "count".into(),
+                sort_order: Some(SQLSortOrder::Asc),
+                length: None,
+            }],
             tpe: IndexType::Normal,
         }],
         user_table.indices

--- a/libs/sql-schema-describer/tests/describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describer_tests.rs
@@ -235,7 +235,7 @@ fn composite_primary_keys_must_work(api: TestApi) {
             columns: expected_columns,
             indices: vec![],
             primary_key: Some(PrimaryKey {
-                columns: vec!["id".to_string(), "name".to_string()],
+                columns: vec![PrimaryKeyColumn::new("id"), PrimaryKeyColumn::new("name")],
                 sequence: None,
                 constraint_name: match api.sql_family() {
                     SqlFamily::Postgres => Some("User_pkey".into()),
@@ -301,7 +301,7 @@ fn indices_must_work(api: TestApi) {
     assert_eq!(
         vec![Index {
             name: "count".to_string(),
-            columns: vec!["count".to_string()],
+            columns: vec![IndexColumn::new("count")],
             tpe: IndexType::Normal,
         }],
         user_table.indices
@@ -312,7 +312,7 @@ fn indices_must_work(api: TestApi) {
 
     let pk = user_table.primary_key.as_ref().unwrap();
 
-    assert_eq!(pk.columns, &["id"]);
+    assert_eq!(pk.columns, &[PrimaryKeyColumn::new("id")]);
     assert_eq!(pk_sequence, pk.sequence);
 
     match api.sql_family() {

--- a/libs/sql-schema-describer/tests/describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describer_tests.rs
@@ -228,6 +228,23 @@ fn composite_primary_keys_must_work(api: TestApi) {
     ];
     expected_columns.sort_unstable_by_key(|c| c.name.to_owned());
 
+    let columns = if api.sql_family().is_mssql() {
+        vec![
+            PrimaryKeyColumn {
+                name: "id".to_string(),
+                sort_order: Some(SQLSortOrder::Asc),
+                length: None,
+            },
+            PrimaryKeyColumn {
+                name: "name".to_string(),
+                sort_order: Some(SQLSortOrder::Asc),
+                length: None,
+            },
+        ]
+    } else {
+        vec![PrimaryKeyColumn::new("id"), PrimaryKeyColumn::new("name")]
+    };
+
     assert_eq!(
         table,
         &Table {
@@ -235,7 +252,7 @@ fn composite_primary_keys_must_work(api: TestApi) {
             columns: expected_columns,
             indices: vec![],
             primary_key: Some(PrimaryKey {
-                columns: vec![PrimaryKeyColumn::new("id"), PrimaryKeyColumn::new("name")],
+                columns,
                 sequence: None,
                 constraint_name: match api.sql_family() {
                     SqlFamily::Postgres => Some("User_pkey".into()),
@@ -316,7 +333,17 @@ fn indices_must_work(api: TestApi) {
 
     let pk = user_table.primary_key.as_ref().unwrap();
 
-    assert_eq!(pk.columns, &[PrimaryKeyColumn::new("id")]);
+    let pk_col = if api.sql_family().is_mssql() {
+        PrimaryKeyColumn {
+            name: "id".to_string(),
+            length: None,
+            sort_order: Some(SQLSortOrder::Asc),
+        }
+    } else {
+        PrimaryKeyColumn::new("id")
+    };
+
+    assert_eq!(pk.columns, &[pk_col]);
     assert_eq!(pk_sequence, pk.sequence);
 
     match api.sql_family() {

--- a/libs/sql-schema-describer/tests/describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describer_tests.rs
@@ -315,12 +315,18 @@ fn indices_must_work(api: TestApi) {
     assert_eq!("User", user_table.name);
     assert_eq!(expected_columns, user_table.columns);
 
+    let sort_order = if api.is_mysql() && !api.is_mysql_8() {
+        None
+    } else {
+        Some(SQLSortOrder::Asc)
+    };
+
     assert_eq!(
         vec![Index {
             name: "count".to_string(),
             columns: vec![IndexColumn {
                 name: "count".into(),
-                sort_order: Some(SQLSortOrder::Asc),
+                sort_order,
                 length: None,
             }],
             tpe: IndexType::Normal,

--- a/libs/sql-schema-describer/tests/describers/mssql_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/mssql_describer_tests.rs
@@ -83,7 +83,7 @@ fn views_can_be_described(api: TestApi) {
 
     api.raw_cmd(&create_view);
 
-    let inspector = SqlSchemaDescriber::new(conn);
+    let inspector = SqlSchemaDescriber::new(conn, BitFlags::all());
     let result = api.block_on(inspector.describe(db_name)).unwrap();
     let view = result.get_view("ab").expect("couldn't get ab view").to_owned();
 

--- a/libs/sql-schema-describer/tests/describers/mssql_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/mssql_describer_tests.rs
@@ -495,6 +495,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
             auto_increment: false,
         },
     ];
+
     expected_columns.sort_unstable_by_key(|c| c.name.to_owned());
 
     assert_eq!("User", &table.name);
@@ -504,7 +505,9 @@ fn all_mssql_column_types_must_work(api: TestApi) {
 
     let pk = table.primary_key.as_ref().unwrap();
 
-    assert_eq!(vec!["primary_col".to_string()], pk.columns);
+    let pk_columns = pk.columns.iter().map(|c| c.name()).collect::<Vec<_>>();
+    assert_eq!(vec!["primary_col"], pk_columns);
+
     assert_eq!(None, pk.sequence);
     assert!(pk
         .constraint_name
@@ -611,7 +614,7 @@ fn mssql_foreign_key_on_delete_must_be_handled(api: TestApi) {
             ],
             indices: vec![],
             primary_key: Some(PrimaryKey {
-                columns: vec!["id".to_string()],
+                columns: vec![PrimaryKeyColumn::new("id")],
                 sequence: None,
                 constraint_name: Some("PK__User".into()),
             }),
@@ -656,7 +659,7 @@ fn mssql_multi_field_indexes_must_be_inferred(api: TestApi) {
         table.indices,
         &[Index {
             name: "age_and_name_index".into(),
-            columns: vec!["name".to_owned(), "age".to_owned()],
+            columns: vec![IndexColumn::new("name"), IndexColumn::new("age")],
             tpe: IndexType::Unique
         }]
     );
@@ -692,7 +695,7 @@ fn mssql_join_table_unique_indexes_must_be_inferred(api: TestApi) {
         table.indices,
         &[Index {
             name: "cat_and_human_index".into(),
-            columns: vec!["cat".to_owned(), "human".to_owned()],
+            columns: vec![IndexColumn::new("cat"), IndexColumn::new("human")],
             tpe: IndexType::Unique,
         }]
     );

--- a/libs/sql-schema-describer/tests/describers/mssql_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/mssql_describer_tests.rs
@@ -614,7 +614,11 @@ fn mssql_foreign_key_on_delete_must_be_handled(api: TestApi) {
             ],
             indices: vec![],
             primary_key: Some(PrimaryKey {
-                columns: vec![PrimaryKeyColumn::new("id")],
+                columns: vec![PrimaryKeyColumn {
+                    name: "id".to_string(),
+                    sort_order: Some(SQLSortOrder::Asc),
+                    length: None
+                }],
                 sequence: None,
                 constraint_name: Some("PK__User".into()),
             }),
@@ -655,11 +659,24 @@ fn mssql_multi_field_indexes_must_be_inferred(api: TestApi) {
     let result = api.describe();
     let table = result.get_table("Employee").expect("couldn't get Employee table");
 
+    let columns = vec![
+        IndexColumn {
+            name: "name".to_string(),
+            sort_order: Some(SQLSortOrder::Asc),
+            length: None,
+        },
+        IndexColumn {
+            name: "age".to_string(),
+            sort_order: Some(SQLSortOrder::Asc),
+            length: None,
+        },
+    ];
+
     assert_eq!(
         table.indices,
         &[Index {
             name: "age_and_name_index".into(),
-            columns: vec![IndexColumn::new("name"), IndexColumn::new("age")],
+            columns,
             tpe: IndexType::Unique
         }]
     );
@@ -691,11 +708,24 @@ fn mssql_join_table_unique_indexes_must_be_inferred(api: TestApi) {
     let result = api.describe();
     let table = result.get_table("CatToHuman").expect("couldn't get CatToHuman table");
 
+    let columns = vec![
+        IndexColumn {
+            name: "cat".to_string(),
+            sort_order: Some(SQLSortOrder::Asc),
+            length: None,
+        },
+        IndexColumn {
+            name: "human".to_string(),
+            sort_order: Some(SQLSortOrder::Asc),
+            length: None,
+        },
+    ];
+
     assert_eq!(
         table.indices,
         &[Index {
             name: "cat_and_human_index".into(),
-            columns: vec![IndexColumn::new("cat"), IndexColumn::new("human")],
+            columns,
             tpe: IndexType::Unique,
         }]
     );

--- a/libs/sql-schema-describer/tests/describers/mssql_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/mssql_describer_tests.rs
@@ -1,5 +1,6 @@
 use crate::test_api::*;
 use barrel::{types, Migration};
+use indoc::formatdoc;
 use native_types::{MsSqlType, MsSqlTypeParameter::*, NativeType};
 use pretty_assertions::assert_eq;
 use sql_schema_describer::{mssql::SqlSchemaDescriber, *};
@@ -546,6 +547,63 @@ fn mssql_cross_schema_references_are_not_allowed(api: TestApi) {
         "Illegal cross schema reference from `mssql_cross_schema_references_are_not_allowed.User` to `mssql_foreign_key_on_delete_must_be_handled_B.City` in constraint `FK__city`. Foreign keys between database schemas are not supported in Prisma. Please follow the GitHub ticket: https://github.com/prisma/prisma/issues/1175".to_string(),
         format!("{}", err),
     );
+}
+
+#[test_connector(tags(Mssql))]
+fn primary_key_sort_order_desc_is_handled(api: TestApi) {
+    let sql = formatdoc! {r#"
+        CREATE TABLE [{}].[A]
+        (
+            a INT NOT NULL,
+            b INT NOT NULL,
+            CONSTRAINT [PK__a_b] PRIMARY KEY (a ASC, b DESC)
+        );
+    "#, api.schema_name()};
+
+    api.raw_cmd(&sql);
+
+    let schema = api.describe();
+    let table = schema.table_walkers().next().unwrap();
+
+    assert_eq!(2, table.primary_key_columns().len());
+
+    let columns = table.primary_key_columns().collect::<Vec<_>>();
+
+    assert_eq!("a", columns[0].as_column().name());
+    assert_eq!("b", columns[1].as_column().name());
+
+    assert_eq!(Some(SQLSortOrder::Asc), columns[0].sort_order());
+    assert_eq!(Some(SQLSortOrder::Desc), columns[1].sort_order());
+}
+
+#[test_connector(tags(Mssql))]
+fn index_sort_order_desc_is_handled(api: TestApi) {
+    let sql = formatdoc! {r#"
+        CREATE TABLE [{schema}].[A]
+        (
+            id INT PRIMARY KEY,
+            a INT NOT NULL,
+            b INT NOT NULL
+        );
+
+        CREATE INDEX [A_idx] ON [{schema}].[A] (a DESC, b ASC);
+    "#, schema = api.schema_name()};
+
+    api.raw_cmd(&sql);
+
+    let schema = api.describe();
+    let table = schema.table_walkers().next().unwrap();
+    let index = table.index_at(0);
+
+    assert_eq!(2, index.columns().len());
+
+    let columns = index.columns().collect::<Vec<_>>();
+
+    assert_eq!("a", columns[0].as_column().name());
+    assert_eq!("b", columns[1].as_column().name());
+
+    assert_eq!(Some(SQLSortOrder::Desc), columns[0].sort_order());
+    assert_eq!(Some(SQLSortOrder::Asc), columns[1].sort_order());
 }
 
 #[test_connector(tags(Mssql))]

--- a/libs/sql-schema-describer/tests/describers/mssql_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/mssql_describer_tests.rs
@@ -83,7 +83,7 @@ fn views_can_be_described(api: TestApi) {
 
     api.raw_cmd(&create_view);
 
-    let inspector = SqlSchemaDescriber::new(conn, BitFlags::all());
+    let inspector = SqlSchemaDescriber::new(conn);
     let result = api.block_on(inspector.describe(db_name)).unwrap();
     let view = result.get_view("ab").expect("couldn't get ab view").to_owned();
 

--- a/libs/sql-schema-describer/tests/describers/mysql_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/mysql_describer_tests.rs
@@ -584,7 +584,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
             columns: expected_columns,
             indices: vec![],
             primary_key: Some(PrimaryKey {
-                columns: vec!["primary_col".to_string()],
+                columns: vec![PrimaryKeyColumn::new("primary_col")],
                 sequence: None,
                 constraint_name: None,
             }),
@@ -1114,7 +1114,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
             columns: expected_columns,
             indices: vec![],
             primary_key: Some(PrimaryKey {
-                columns: vec!["primary_col".to_string()],
+                columns: vec![PrimaryKeyColumn::new("primary_col")],
                 sequence: None,
                 constraint_name: None,
             }),
@@ -1188,7 +1188,7 @@ fn mysql_multi_field_indexes_must_be_inferred(api: TestApi) {
         table.indices,
         &[Index {
             name: "age_and_name_index".into(),
-            columns: vec!["name".to_owned(), "age".to_owned()],
+            columns: vec![IndexColumn::new("name"), IndexColumn::new("age")],
             tpe: IndexType::Unique,
         }]
     );

--- a/libs/sql-schema-describer/tests/describers/mysql_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/mysql_describer_tests.rs
@@ -1184,11 +1184,24 @@ fn mysql_multi_field_indexes_must_be_inferred(api: TestApi) {
     let result = api.describe();
     let table = result.get_table("Employee").expect("couldn't get Employee table");
 
+    let columns = vec![
+        IndexColumn {
+            name: "name".into(),
+            sort_order: Some(SQLSortOrder::Asc),
+            length: None,
+        },
+        IndexColumn {
+            name: "age".into(),
+            sort_order: Some(SQLSortOrder::Asc),
+            length: None,
+        },
+    ];
+
     assert_eq!(
         table.indices,
         &[Index {
             name: "age_and_name_index".into(),
-            columns: vec![IndexColumn::new("name"), IndexColumn::new("age")],
+            columns,
             tpe: IndexType::Unique,
         }]
     );

--- a/libs/sql-schema-describer/tests/describers/postgres_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/postgres_describer_tests.rs
@@ -842,3 +842,61 @@ fn index_sort_order_is_handled(api: TestApi) {
     assert_eq!("a", columns[0].as_column().name());
     assert_eq!(Some(SQLSortOrder::Desc), columns[0].sort_order());
 }
+
+#[test_connector(tags(Postgres))]
+fn index_sort_order_composite_type_desc_desc_is_handled(api: TestApi) {
+    let sql = indoc! {r#"
+        CREATE TABLE A (
+            id INT PRIMARY KEY,
+            a  INT NOT NULL,
+            b  INT NOT NULL
+        );
+
+        CREATE INDEX foo ON A (a DESC, b DESC);
+    "#};
+
+    api.raw_cmd(sql);
+
+    let schema = api.describe();
+    let table = schema.table_walkers().next().unwrap();
+    let index = table.index_at(0);
+
+    let columns = index.columns().collect::<Vec<_>>();
+
+    assert_eq!(2, columns.len());
+
+    assert_eq!("a", columns[0].as_column().name());
+    assert_eq!("b", columns[1].as_column().name());
+
+    assert_eq!(Some(SQLSortOrder::Desc), columns[0].sort_order());
+    assert_eq!(Some(SQLSortOrder::Desc), columns[1].sort_order());
+}
+
+#[test_connector(tags(Postgres))]
+fn index_sort_order_composite_type_asc_desc_is_handled(api: TestApi) {
+    let sql = indoc! {r#"
+        CREATE TABLE A (
+            id INT PRIMARY KEY,
+            a  INT NOT NULL,
+            b  INT NOT NULL
+        );
+
+        CREATE INDEX foo ON A (a ASC, b DESC);
+    "#};
+
+    api.raw_cmd(sql);
+
+    let schema = api.describe();
+    let table = schema.table_walkers().next().unwrap();
+    let index = table.index_at(0);
+
+    let columns = index.columns().collect::<Vec<_>>();
+
+    assert_eq!(2, columns.len());
+
+    assert_eq!("a", columns[0].as_column().name());
+    assert_eq!("b", columns[1].as_column().name());
+
+    assert_eq!(Some(SQLSortOrder::Asc), columns[0].sort_order());
+    assert_eq!(Some(SQLSortOrder::Desc), columns[1].sort_order());
+}

--- a/libs/sql-schema-describer/tests/describers/postgres_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/postgres_describer_tests.rs
@@ -564,11 +564,11 @@ fn all_postgres_column_types_must_work(api: TestApi) {
             columns: expected_columns,
             indices: vec![Index {
                 name: "User_uuid_col_key".into(),
-                columns: vec!["uuid_col".into(),],
+                columns: vec![IndexColumn::new("uuid_col")],
                 tpe: IndexType::Unique,
             },],
             primary_key: Some(PrimaryKey {
-                columns: vec!["primary_col".into()],
+                columns: vec![PrimaryKeyColumn::new("primary_col")],
                 sequence: Some(Sequence {
                     name: "User_primary_col_seq".into(),
                 },),
@@ -703,13 +703,13 @@ fn postgres_multi_field_indexes_must_be_inferred_in_the_right_order(api: TestApi
     let table = schema.table_bang("indexes_test");
     let index = &table.indices[0];
 
-    assert_eq!(&index.columns, &["name", "age"]);
+    assert_eq!(&index.columns, &[IndexColumn::new("name"), IndexColumn::new("age")]);
     assert!(index.tpe.is_unique());
 
     let index = &table.indices[1];
 
     assert!(!index.tpe.is_unique());
-    assert_eq!(&index.columns, &["age", "name"]);
+    assert_eq!(&index.columns, &[IndexColumn::new("age"), IndexColumn::new("name")]);
 }
 
 #[test_connector(tags(Postgres))]

--- a/libs/sql-schema-describer/tests/describers/postgres_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/postgres_describer_tests.rs
@@ -564,7 +564,11 @@ fn all_postgres_column_types_must_work(api: TestApi) {
             columns: expected_columns,
             indices: vec![Index {
                 name: "User_uuid_col_key".into(),
-                columns: vec![IndexColumn::new("uuid_col")],
+                columns: vec![IndexColumn {
+                    name: "uuid_col".to_string(),
+                    sort_order: Some(SQLSortOrder::Asc),
+                    length: None,
+                }],
                 tpe: IndexType::Unique,
             },],
             primary_key: Some(PrimaryKey {
@@ -703,13 +707,41 @@ fn postgres_multi_field_indexes_must_be_inferred_in_the_right_order(api: TestApi
     let table = schema.table_bang("indexes_test");
     let index = &table.indices[0];
 
-    assert_eq!(&index.columns, &[IndexColumn::new("name"), IndexColumn::new("age")]);
+    assert_eq!(
+        &index.columns,
+        &[
+            IndexColumn {
+                name: "name".to_string(),
+                sort_order: Some(SQLSortOrder::Asc),
+                length: None
+            },
+            IndexColumn {
+                name: "age".to_string(),
+                sort_order: Some(SQLSortOrder::Asc),
+                length: None
+            },
+        ]
+    );
     assert!(index.tpe.is_unique());
 
     let index = &table.indices[1];
 
     assert!(!index.tpe.is_unique());
-    assert_eq!(&index.columns, &[IndexColumn::new("age"), IndexColumn::new("name")]);
+    assert_eq!(
+        &index.columns,
+        &[
+            IndexColumn {
+                name: "age".to_string(),
+                sort_order: Some(SQLSortOrder::Asc),
+                length: None
+            },
+            IndexColumn {
+                name: "name".to_string(),
+                sort_order: Some(SQLSortOrder::Asc),
+                length: None
+            },
+        ]
+    );
 }
 
 #[test_connector(tags(Postgres))]

--- a/libs/sql-schema-describer/tests/describers/sqlite_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/sqlite_describer_tests.rs
@@ -11,10 +11,7 @@ async fn describe_sqlite(sql: &str) -> SqlSchema {
 
     conn.raw_cmd(sql).await.unwrap();
 
-    sqlite::SqlSchemaDescriber::new(&conn, BitFlags::all())
-        .describe(SCHEMA)
-        .await
-        .unwrap()
+    sqlite::SqlSchemaDescriber::new(&conn).describe(SCHEMA).await.unwrap()
 }
 
 #[tokio::test]

--- a/libs/sql-schema-describer/tests/describers/sqlite_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/sqlite_describer_tests.rs
@@ -11,7 +11,10 @@ async fn describe_sqlite(sql: &str) -> SqlSchema {
 
     conn.raw_cmd(sql).await.unwrap();
 
-    sqlite::SqlSchemaDescriber::new(&conn).describe(SCHEMA).await.unwrap()
+    sqlite::SqlSchemaDescriber::new(&conn, BitFlags::all())
+        .describe(SCHEMA)
+        .await
+        .unwrap()
 }
 
 #[tokio::test]

--- a/libs/sql-schema-describer/tests/describers/sqlite_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/sqlite_describer_tests.rs
@@ -121,7 +121,7 @@ async fn sqlite_column_types_must_work() {
             columns: expected_columns,
             indices: vec![],
             primary_key: Some(PrimaryKey {
-                columns: vec!["primary_col".to_string()],
+                columns: vec![PrimaryKeyColumn::new("primary_col")],
                 sequence: None,
                 constraint_name: None,
             }),
@@ -220,7 +220,7 @@ async fn sqlite_foreign_key_on_delete_must_be_handled() {
             ],
             indices: vec![],
             primary_key: Some(PrimaryKey {
-                columns: vec!["id".to_string()],
+                columns: vec![PrimaryKeyColumn::new("id")],
                 sequence: None,
                 constraint_name: None,
             }),
@@ -293,7 +293,7 @@ async fn sqlite_text_primary_keys_must_be_inferred_on_table_and_not_as_separate_
     assert_eq!(
         table.primary_key.as_ref().unwrap(),
         &PrimaryKey {
-            columns: vec!["primary_col".to_owned()],
+            columns: vec![PrimaryKeyColumn::new("primary_col")],
             sequence: None,
             constraint_name: None,
         }

--- a/libs/sql-schema-describer/tests/test_api/mod.rs
+++ b/libs/sql-schema-describer/tests/test_api/mod.rs
@@ -80,10 +80,20 @@ impl TestApi {
                 } else {
                     Default::default()
                 },
+                BitFlags::all(),
             )),
-            SqlFamily::Sqlite => Box::new(sql_schema_describer::sqlite::SqlSchemaDescriber::new(connection)),
-            SqlFamily::Mysql => Box::new(sql_schema_describer::mysql::SqlSchemaDescriber::new(connection)),
-            SqlFamily::Mssql => Box::new(sql_schema_describer::mssql::SqlSchemaDescriber::new(connection)),
+            SqlFamily::Sqlite => Box::new(sql_schema_describer::sqlite::SqlSchemaDescriber::new(
+                connection,
+                BitFlags::all(),
+            )),
+            SqlFamily::Mysql => Box::new(sql_schema_describer::mysql::SqlSchemaDescriber::new(
+                connection,
+                BitFlags::all(),
+            )),
+            SqlFamily::Mssql => Box::new(sql_schema_describer::mssql::SqlSchemaDescriber::new(
+                connection,
+                BitFlags::all(),
+            )),
         }
     }
 

--- a/libs/sql-schema-describer/tests/test_api/mod.rs
+++ b/libs/sql-schema-describer/tests/test_api/mod.rs
@@ -80,20 +80,10 @@ impl TestApi {
                 } else {
                     Default::default()
                 },
-                BitFlags::all(),
             )),
-            SqlFamily::Sqlite => Box::new(sql_schema_describer::sqlite::SqlSchemaDescriber::new(
-                connection,
-                BitFlags::all(),
-            )),
-            SqlFamily::Mysql => Box::new(sql_schema_describer::mysql::SqlSchemaDescriber::new(
-                connection,
-                BitFlags::all(),
-            )),
-            SqlFamily::Mssql => Box::new(sql_schema_describer::mssql::SqlSchemaDescriber::new(
-                connection,
-                BitFlags::all(),
-            )),
+            SqlFamily::Sqlite => Box::new(sql_schema_describer::sqlite::SqlSchemaDescriber::new(connection)),
+            SqlFamily::Mysql => Box::new(sql_schema_describer::mysql::SqlSchemaDescriber::new(connection)),
+            SqlFamily::Mssql => Box::new(sql_schema_describer::mssql::SqlSchemaDescriber::new(connection)),
         }
     }
 

--- a/libs/sql-schema-describer/tests/test_api/mod.rs
+++ b/libs/sql-schema-describer/tests/test_api/mod.rs
@@ -116,6 +116,14 @@ impl TestApi {
         self.tags.contains(Tags::Mssql)
     }
 
+    pub(crate) fn is_mysql(&self) -> bool {
+        self.tags.contains(Tags::Mysql)
+    }
+
+    pub(crate) fn is_mysql_8(&self) -> bool {
+        self.tags.contains(Tags::Mysql8)
+    }
+
     pub(crate) fn schema_name(&self) -> &str {
         match self.sql_family() {
             // It is not possible to connect to a specific schema in MSSQL. The

--- a/libs/sql-schema-describer/tests/test_api/mod.rs
+++ b/libs/sql-schema-describer/tests/test_api/mod.rs
@@ -210,7 +210,16 @@ impl TableAssertion<'_> {
         columns: &[&str],
         assertions: impl for<'i> FnOnce(&'i IndexAssertion<'i>) -> &'i IndexAssertion<'i>,
     ) -> &Self {
-        let index = self.table.indexes().find(|idx| idx.column_names() == columns).unwrap();
+        let index = self
+            .table
+            .indexes()
+            .find(|i| {
+                let lengths_match = i.columns().len() == columns.len();
+                let columns_match = i.columns().zip(columns.iter()).all(|(a, b)| a.get().name() == *b);
+
+                lengths_match && columns_match
+            })
+            .unwrap();
 
         assertions(&IndexAssertion { index });
 
@@ -223,7 +232,17 @@ impl TableAssertion<'_> {
     }
 
     pub fn assert_pk_on_columns(&self, columns: &[&str]) -> &Self {
-        assert_eq!(self.table.primary_key().unwrap().columns, columns);
+        let pk_columns = self
+            .table
+            .primary_key()
+            .unwrap()
+            .columns
+            .iter()
+            .map(|c| c.name())
+            .collect::<Vec<_>>();
+
+        assert_eq!(pk_columns, columns);
+
         self
     }
 }

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/mssql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/mssql.rs
@@ -403,7 +403,7 @@ impl SqlFlavour for MssqlFlavour {
                         })?;
                 }
 
-                temp_database.describe_schema().await
+                temp_database.describe_schema(self.preview_features).await
             })()
             .await
         };

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/mysql.rs
@@ -452,7 +452,7 @@ impl SqlFlavour for MysqlFlavour {
                     })?;
             }
 
-            temp_database.describe_schema().await
+            temp_database.describe_schema(self.preview_features).await
         })()
         .await;
 

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/postgres.rs
@@ -389,7 +389,7 @@ impl SqlFlavour for PostgresFlavour {
 
                 // The connection to the shadow database is dropped at the end of
                 // the block.
-                shadow_database.describe_schema().await
+                shadow_database.describe_schema(self.preview_features).await
             }
         })()
         .await;

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/sqlite.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/sqlite.rs
@@ -154,7 +154,7 @@ impl SqlFlavour for SqliteFlavour {
                 })?;
         }
 
-        let sql_schema = conn.describe_schema().await?;
+        let sql_schema = conn.describe_schema(self.preview_features).await?;
 
         Ok(sql_schema)
     }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker.rs
@@ -250,7 +250,7 @@ impl SqlMigrationConnector {
                         plan.push_warning(
                             SqlMigrationWarningCheck::UniqueConstraintAddition {
                                 table: index.table().name().to_owned(),
-                                columns: index.columns().map(|col| col.name().to_owned()).collect(),
+                                columns: index.columns().map(|col| col.get().name().to_owned()).collect(),
                             },
                             step_index,
                         )

--- a/migration-engine/connectors/sql-migration-connector/src/sql_migration.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_migration.rs
@@ -289,17 +289,17 @@ impl SqlMigration {
                             }
                             TableChange::DropPrimaryKey => {
                                 out.push_str("  [-] Dropped the primary key on columns (");
-                                out.push_str(&tables.previous().primary_key_column_names().join(", "));
+                                out.push_str(&tables.previous().primary_key_column_names().unwrap().join(", "));
                                 out.push_str(")\n");
                             }
                             TableChange::RenamePrimaryKey => {
                                 out.push_str("  [*] Renamed the primary key on columns (");
-                                out.push_str(&tables.previous().primary_key_column_names().join(", "));
+                                out.push_str(&tables.previous().primary_key_column_names().unwrap().join(", "));
                                 out.push_str(")\n");
                             }
                             TableChange::AddPrimaryKey => {
                                 out.push_str("  [+] Added primary key on columns (");
-                                out.push_str(&tables.next().primary_key_column_names().join(", "));
+                                out.push_str(&tables.next().primary_key_column_names().unwrap().join(", "));
                                 out.push_str(")\n");
                             }
                         }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_migration.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_migration.rs
@@ -289,17 +289,17 @@ impl SqlMigration {
                             }
                             TableChange::DropPrimaryKey => {
                                 out.push_str("  [-] Dropped the primary key on columns (");
-                                out.push_str(&tables.previous().primary_key_column_names().unwrap().join(", "));
+                                out.push_str(&tables.previous().primary_key_column_names().join(", "));
                                 out.push_str(")\n");
                             }
                             TableChange::RenamePrimaryKey => {
                                 out.push_str("  [*] Renamed the primary key on columns (");
-                                out.push_str(&tables.previous().primary_key_column_names().unwrap().join(", "));
+                                out.push_str(&tables.previous().primary_key_column_names().join(", "));
                                 out.push_str(")\n");
                             }
                             TableChange::AddPrimaryKey => {
                                 out.push_str("  [+] Added primary key on columns (");
-                                out.push_str(&tables.next().primary_key_column_names().unwrap().join(", "));
+                                out.push_str(&tables.next().primary_key_column_names().join(", "));
                                 out.push_str(")\n");
                             }
                         }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mssql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mssql_renderer.rs
@@ -138,7 +138,7 @@ impl SqlRenderer for MssqlFlavour {
         let index_name = self.quote(index.name());
         let table_reference = self.quote_with_schema(index.table().name()).to_string();
 
-        let columns = index.columns().map(|c| self.quote(c.name()));
+        let columns = index.columns().map(|c| self.quote(c.get().name()));
 
         format!(
             "CREATE {index_type}INDEX {index_name} ON {table_reference}({columns})",
@@ -156,7 +156,7 @@ impl SqlRenderer for MssqlFlavour {
             .join(",\n    ");
 
         let primary_key = if let Some(pk) = table.primary_key() {
-            let column_names = pk.columns.iter().map(|col| self.quote(col)).join(",");
+            let column_names = pk.columns.iter().map(|col| self.quote(col.name())).join(",");
 
             format!(
                 ",\n    CONSTRAINT {} PRIMARY KEY ({})",
@@ -176,7 +176,7 @@ impl SqlRenderer for MssqlFlavour {
             let constraints = constraints
                 .iter()
                 .map(|index| {
-                    let columns = index.columns().map(|col| self.quote(col.name()));
+                    let columns = index.columns().map(|col| self.quote(col.get().name()));
 
                     format!("CONSTRAINT {} UNIQUE ({})", self.quote(index.name()), columns.join(","))
                 })

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mssql_renderer/alter_table.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mssql_renderer/alter_table.rs
@@ -170,11 +170,11 @@ impl<'a> AlterTableConstructor<'a> {
             .and_then(|pk| pk.constraint_name.as_ref())
             .expect("Missing constraint name in AddPrimaryKey on MSSQL");
 
-        let columns = self.tables.next().primary_key_column_names();
+        let columns = self.tables.next().primary_key_column_names().unwrap();
         let mut quoted_columns = Vec::with_capacity(columns.len());
 
         for colname in columns {
-            quoted_columns.push(format!("{}", self.renderer.quote(colname)));
+            quoted_columns.push(format!("{}", self.renderer.quote(&colname)));
         }
 
         self.add_constraints.insert(format!(

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mssql_renderer/alter_table.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mssql_renderer/alter_table.rs
@@ -170,7 +170,7 @@ impl<'a> AlterTableConstructor<'a> {
             .and_then(|pk| pk.constraint_name.as_ref())
             .expect("Missing constraint name in AddPrimaryKey on MSSQL");
 
-        let columns = self.tables.next().primary_key_column_names().unwrap();
+        let columns = self.tables.next().primary_key_column_names();
         let mut quoted_columns = Vec::with_capacity(columns.len());
 
         for colname in columns {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
@@ -118,6 +118,8 @@ impl SqlRenderer for MysqlFlavour {
                     tables
                         .next()
                         .primary_key_column_names()
+                        .iter()
+                        .flat_map(|c| c.iter())
                         .map(|colname| self.quote(colname))
                         .join(", ")
                 )),
@@ -204,7 +206,12 @@ impl SqlRenderer for MysqlFlavour {
                     columns: index.column_names().map(ToString::to_string).map(Cow::from).collect(),
                 })
                 .collect(),
-            primary_key: table.primary_key_column_names().map(|s| Cow::Borrowed(s)).collect(),
+            primary_key: table
+                .primary_key_column_names()
+                .unwrap_or_default()
+                .iter()
+                .map(|s| Cow::Borrowed(s.as_str()))
+                .collect(),
             default_character_set: Some("utf8mb4".into()),
             collate: Some("utf8mb4_unicode_ci".into()),
         }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
@@ -118,8 +118,6 @@ impl SqlRenderer for MysqlFlavour {
                     tables
                         .next()
                         .primary_key_column_names()
-                        .iter()
-                        .flat_map(|c| c.iter())
                         .map(|colname| self.quote(colname))
                         .join(", ")
                 )),
@@ -184,7 +182,7 @@ impl SqlRenderer for MysqlFlavour {
             index_name: index.name().into(),
             on: (
                 index.table().name().into(),
-                index.columns().map(|c| c.name().into()).collect(),
+                index.columns().map(|c| c.get().name().into()).collect(),
             ),
         }
         .to_string()
@@ -203,15 +201,10 @@ impl SqlRenderer for MysqlFlavour {
                         Some(Cow::Borrowed(index.name()))
                     },
                     unique: index.index_type().is_unique(),
-                    columns: index.column_names().iter().map(Cow::from).collect(),
+                    columns: index.column_names().map(ToString::to_string).map(Cow::from).collect(),
                 })
                 .collect(),
-            primary_key: table
-                .primary_key_column_names()
-                .unwrap_or_default()
-                .iter()
-                .map(|s| Cow::Borrowed(s.as_str()))
-                .collect(),
+            primary_key: table.primary_key_column_names().map(|s| Cow::Borrowed(s)).collect(),
             default_character_set: Some("utf8mb4".into()),
             collate: Some("utf8mb4_unicode_ci".into()),
         }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
@@ -285,6 +285,8 @@ impl SqlRenderer for PostgresFlavour {
                         tables
                             .next()
                             .primary_key_column_names()
+                            .unwrap()
+                            .iter()
                             .map(|colname| self.quote(colname))
                             .join(", ")
                     )

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
@@ -285,8 +285,6 @@ impl SqlRenderer for PostgresFlavour {
                         tables
                             .next()
                             .primary_key_column_names()
-                            .unwrap()
-                            .iter()
                             .map(|colname| self.quote(colname))
                             .join(", ")
                     )
@@ -358,7 +356,7 @@ impl SqlRenderer for PostgresFlavour {
             index_name: index.name().into(),
             is_unique: index.index_type().is_unique(),
             table_reference: index.table().name().into(),
-            columns: index.columns().map(|c| c.name().into()).collect(),
+            columns: index.columns().map(|c| c.get().name().into()).collect(),
         }
         .to_string()
     }
@@ -376,11 +374,7 @@ impl SqlRenderer for PostgresFlavour {
                 ",\n\n{}{}PRIMARY KEY ({})",
                 SQL_INDENTATION,
                 named_constraint,
-                pk.columns
-                    .as_slice()
-                    .iter()
-                    .map(|col| self.quote(col.as_ref()))
-                    .join(",")
+                pk.columns.as_slice().iter().map(|col| self.quote(col.name())).join(",")
             )
         } else {
             String::new()

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
@@ -128,7 +128,9 @@ impl SqlRenderer for SqliteFlavour {
         };
 
         if !table.columns().any(|col| col.is_single_primary_key()) {
-            create_table.primary_key = Some(table.primary_key_column_names().map(Cow::from).collect());
+            create_table.primary_key = table
+                .primary_key_column_names()
+                .map(|v| v.into_iter().map(|name| name.into()).collect());
         }
 
         create_table.to_string()

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
@@ -28,7 +28,7 @@ impl SqlRenderer for SqliteFlavour {
         };
         let index_name = self.quote(index.name());
         let table_reference = self.quote(index.table().name());
-        let columns = index.columns().map(|c| self.quote(c.name()));
+        let columns = index.columns().map(|c| self.quote(c.get().name()));
 
         let index_create = format!(
             "CREATE {index_type}INDEX {index_name} ON {table_reference}({columns})",
@@ -128,9 +128,7 @@ impl SqlRenderer for SqliteFlavour {
         };
 
         if !table.columns().any(|col| col.is_single_primary_key()) {
-            create_table.primary_key = table
-                .primary_key_column_names()
-                .map(|slice| slice.iter().map(|name| name.into()).collect());
+            create_table.primary_key = Some(table.primary_key_column_names().map(Cow::from).collect());
         }
 
         create_table.to_string()

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
@@ -49,7 +49,7 @@ fn calculate_model_tables<'a>(
             columns: pk
                 .fields
                 .iter()
-                .map(|field| model.find_scalar_field(field).unwrap().db_name().to_string())
+                .map(|field| sql::PrimaryKeyColumn::new(model.find_scalar_field(field).unwrap().db_name()))
                 .collect(),
             sequence: None,
             constraint_name: pk.db_name.clone(),
@@ -78,7 +78,7 @@ fn calculate_model_tables<'a>(
                     // The model index definition uses the model field names, but the SQL Index wants the column names.
                     columns: referenced_fields
                         .iter()
-                        .map(|field| field.db_name().to_owned())
+                        .map(|field| sql::IndexColumn::new(field.db_name()))
                         .collect(),
                     tpe: index_type,
                 }
@@ -159,12 +159,15 @@ fn calculate_relation_tables<'a>(
             let indexes = vec![
                 sql::Index {
                     name: format!("{}_AB_unique", &table_name),
-                    columns: vec![m2m.model_a_column().into(), m2m.model_b_column().into()],
+                    columns: vec![
+                        sql::IndexColumn::new(m2m.model_a_column()),
+                        sql::IndexColumn::new(m2m.model_b_column()),
+                    ],
                     tpe: sql::IndexType::Unique,
                 },
                 sql::Index {
                     name: format!("{}_B_index", &table_name),
-                    columns: vec![m2m.model_b_column().into()],
+                    columns: vec![sql::IndexColumn::new(m2m.model_b_column())],
                     tpe: sql::IndexType::Normal,
                 },
             ];

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
@@ -362,7 +362,7 @@ impl<'schema> SqlSchemaDiffer<'schema> {
                     index
                         .next()
                         .columns()
-                        .any(|col| dropped_and_recreated_column_ids_next.contains(&col.column_id()))
+                        .any(|col| dropped_and_recreated_column_ids_next.contains(&col.as_column().column_id()))
                 }) {
                     steps.push(SqlMigrationStep::CreateIndex {
                         table_id: (Some(tables.previous().table_id()), tables.next().table_id()),

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/index.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/index.rs
@@ -1,7 +1,10 @@
 use sql_schema_describer::walkers::{IndexWalker, TableWalker};
 
 pub(super) fn index_covers_fk(table: &TableWalker<'_>, index: &IndexWalker<'_>) -> bool {
-    table
-        .foreign_keys()
-        .any(|fk| fk.constrained_column_names() == index.column_names())
+    table.foreign_keys().any(|fk| {
+        let fk_cols = fk.constrained_column_names().iter();
+        let index_cols = index.column_names();
+
+        fk_cols.len() == index_cols.len() && fk_cols.zip(index_cols).all(|(a, b)| a == b)
+    })
 }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/mssql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/mssql.rs
@@ -76,7 +76,7 @@ impl SqlSchemaDifferFlavour for MssqlFlavour {
         for dropped_index in table.index_pairs().filter(|pair| {
             pair.previous()
                 .columns()
-                .any(|col| col.column_id() == *column_id.previous())
+                .any(|col| col.as_column().column_id() == *column_id.previous())
         }) {
             steps.push(SqlMigrationStep::DropIndex {
                 table_id: table.previous().table_id(),
@@ -84,10 +84,11 @@ impl SqlSchemaDifferFlavour for MssqlFlavour {
             })
         }
 
-        for created_index in table
-            .index_pairs()
-            .filter(|pair| pair.next().columns().any(|col| col.column_id() == *column_id.next()))
-        {
+        for created_index in table.index_pairs().filter(|pair| {
+            pair.next()
+                .columns()
+                .any(|col| col.as_column().column_id() == *column_id.next())
+        }) {
             steps.push(SqlMigrationStep::CreateIndex {
                 table_id: (None, table.next().table_id()),
                 index_index: created_index.next().index(),

--- a/migration-engine/migration-engine-tests/src/assertions.rs
+++ b/migration-engine/migration-engine-tests/src/assertions.rs
@@ -600,7 +600,7 @@ impl<'a> PrimaryKeyAssertion<'a> {
             self.table
                 .columns
                 .iter()
-                .any(|column| self.pk.column_names().any(|name| name == &column.name) && column.auto_increment),
+                .any(|column| self.pk.column_names().any(|name| name == column.name) && column.auto_increment),
             "Assertion failed: expected a sequence on the primary key, found none."
         );
 
@@ -613,7 +613,7 @@ impl<'a> PrimaryKeyAssertion<'a> {
                 .table
                 .columns
                 .iter()
-                .any(|column| self.pk.column_names().any(|c| c == &column.name) && column.auto_increment),
+                .any(|column| self.pk.column_names().any(|c| c == column.name) && column.auto_increment),
             "Assertion failed: expected no sequence on the primary key, but found one."
         );
 

--- a/migration-engine/migration-engine-tests/src/assertions.rs
+++ b/migration-engine/migration-engine-tests/src/assertions.rs
@@ -280,7 +280,12 @@ impl<'a> TableAssertion<'a> {
     where
         F: FnOnce(IndexAssertion<'a>) -> IndexAssertion<'a>,
     {
-        if let Some(idx) = self.table.indices.iter().find(|idx| idx.columns == columns) {
+        if let Some(idx) = self
+            .table
+            .indices
+            .iter()
+            .find(|idx| idx.column_names().collect::<Vec<_>>() == columns)
+        {
             index_assertions(IndexAssertion(idx));
         } else {
             panic!("Could not find index on {}.{:?}", self.table.name, columns);
@@ -585,7 +590,7 @@ pub struct PrimaryKeyAssertion<'a> {
 
 impl<'a> PrimaryKeyAssertion<'a> {
     pub fn assert_columns(self, column_names: &[&str]) -> Self {
-        assert_eq!(self.pk.columns, column_names);
+        assert_eq!(&self.pk.column_names().collect::<Vec<_>>(), column_names);
 
         self
     }
@@ -595,7 +600,7 @@ impl<'a> PrimaryKeyAssertion<'a> {
             self.table
                 .columns
                 .iter()
-                .any(|column| self.pk.columns.contains(&column.name) && column.auto_increment),
+                .any(|column| self.pk.column_names().any(|name| name == &column.name) && column.auto_increment),
             "Assertion failed: expected a sequence on the primary key, found none."
         );
 
@@ -608,7 +613,7 @@ impl<'a> PrimaryKeyAssertion<'a> {
                 .table
                 .columns
                 .iter()
-                .any(|column| self.pk.columns.contains(&column.name) && column.auto_increment),
+                .any(|column| self.pk.column_names().any(|c| c == &column.name) && column.auto_increment),
             "Assertion failed: expected no sequence on the primary key, but found one."
         );
 


### PR DESCRIPTION
Changes a few things in the describer public API:

- Primary key columns are now special structs, that can hold length and sort
  order information.
- Index columns are similar, with length and sort order.
- Needs the flag `extendedIndexes` set.

Part of: https://github.com/prisma/prisma/issues/9577