### PR TITLE
Automate publishing of cargo docs to GitHub pages

### DIFF
--- a/.github/workflows/cargo-doc.yml
+++ b/.github/workflows/cargo-doc.yml
@@ -1,0 +1,55 @@
+name: Generate cargo docs
+on:
+  workflow_dispatch:
+    inputs: # null
+  push:
+    branches:
+      - master
+jobs:
+  generate-cargo-docs:
+    name: "Generate cargo docs for the workspace"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ matrix.rust }}-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Generate docs
+        run: cargo doc --workspace
+
+      - name: Move docs to gh-pages branch
+        run: |
+          mkdir -p /tmp/cargo-doc-output
+          mv target/doc /tmp/cargo-doc-output/doc
+
+      - uses: actions/checkout@v2
+        with:
+          ref: gh-pages
+
+      - name: Replace old docs with new docs
+        run: |
+          rm -rf ./doc
+          mv /tmp/cargo-doc-output/doc doc
+
+      - name: Commit and push new docs
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: cargo docs for ${{ env.GITHUB_SHA }}
+          branch: gh-pages
+          commit_user_name: prisma-bot
+          commit_user_email: prismabots@gmail.com
+          commit_author: prisma-bot <prismabots@gmail.com>
+

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Query Engine](https://github.com/prisma/prisma-engines/actions/workflows/query-engine.yml/badge.svg)](https://github.com/prisma/prisma-engines/actions/workflows/query-engine.yml)
 [![Introspection Engine + Migration Engine + sql_schema_describer](https://github.com/prisma/prisma-engines/actions/workflows/migration-engine.yml/badge.svg)](https://github.com/prisma/prisma-engines/actions/workflows/migration-engine.yml)
+[![Cargo docs](https://github.com/prisma/prisma-engines/actions/workflows/cargo-doc.yml/badge.svg)](https://github.com/prisma/prisma-engines/actions/workflows/cargo-doc.yml)
 
 This repository contains a collection of engines that power the core stack for
 [Prisma](https://github.com/prisma/prisma), most prominently [Prisma
@@ -13,6 +14,11 @@ The engines and their respective binary crates are:
 - Migration engine: `migration-engine-cli`
 - Introspection engine: `introspection-engine`
 - Prisma Format: `prisma-fmt`
+
+## Documentation
+
+The [API docs (cargo doc)](https://prisma.github.io/prisma-engines/) are
+published on the repo GitHub pages.
 
 ## Building Prisma Engines
 

--- a/migration-engine/core/src/commands/apply_migrations.rs
+++ b/migration-engine/core/src/commands/apply_migrations.rs
@@ -23,9 +23,6 @@ pub struct ApplyMigrationsOutput {
     pub applied_migration_names: Vec<String>,
 }
 
-/// Read the contents of the migrations directory and the migrations table, and
-/// returns their relative statuses. At this stage, the migration engine only
-/// reads, it does not write to the dev database nor the migrations directory.
 pub(crate) async fn apply_migrations<C>(
     input: &ApplyMigrationsInput,
     connector: &C,


### PR DESCRIPTION
Pages published under https://prisma.github.io/prisma-engines/