### PR TITLE
Make datamodel providers' native type constructors constant

### DIFF
--- a/libs/datamodel/connectors/datamodel-connector/src/empty_connector.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/empty_connector.rs
@@ -27,7 +27,7 @@ impl Connector for EmptyDatamodelConnector {
         usize::MAX
     }
 
-    fn available_native_type_constructors(&self) -> &[dml::native_type_constructor::NativeTypeConstructor] {
+    fn available_native_type_constructors(&self) -> &'static [dml::native_type_constructor::NativeTypeConstructor] {
         &[]
     }
 

--- a/libs/datamodel/connectors/datamodel-connector/src/lib.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/lib.rs
@@ -67,8 +67,8 @@ pub trait Connector: Send + Sync {
     }
 
     /// Returns all available native type constructors available through this connector.
-    /// Powers the auto completion of the vs code plugin.
-    fn available_native_type_constructors(&self) -> &[NativeTypeConstructor];
+    /// Powers the auto completion of the VSCode plugin.
+    fn available_native_type_constructors(&self) -> &'static [NativeTypeConstructor];
 
     /// Returns the Scalar Type for the given native type
     fn scalar_type_for_native_type(&self, native_type: serde_json::Value) -> ScalarType;
@@ -83,7 +83,7 @@ pub trait Connector: Send + Sync {
     fn find_native_type_constructor(&self, name: &str) -> Option<&NativeTypeConstructor> {
         self.available_native_type_constructors()
             .iter()
-            .find(|constructor| constructor.name.as_str() == name)
+            .find(|constructor| constructor.name == name)
     }
 
     /// This function is used during Schema parsing to calculate the concrete native type.

--- a/libs/datamodel/connectors/dml/src/native_type_constructor.rs
+++ b/libs/datamodel/connectors/dml/src/native_type_constructor.rs
@@ -4,7 +4,7 @@ use super::scalars::ScalarType;
 #[derive(serde::Serialize)]
 pub struct NativeTypeConstructor {
     /// The name that is used in the Prisma schema when declaring the native type
-    pub name: String,
+    pub name: &'static str,
 
     /// The number of arguments that must be provided
     pub _number_of_args: usize,
@@ -13,35 +13,39 @@ pub struct NativeTypeConstructor {
     pub _number_of_optional_args: usize,
 
     /// The scalar types this native type is compatible with
-    pub prisma_types: Vec<ScalarType>,
+    pub prisma_types: &'static [ScalarType],
 }
 
 impl NativeTypeConstructor {
-    pub fn without_args(name: &str, prisma_types: Vec<ScalarType>) -> NativeTypeConstructor {
+    pub const fn without_args(name: &'static str, prisma_types: &'static [ScalarType]) -> NativeTypeConstructor {
         NativeTypeConstructor {
-            name: name.to_string(),
+            name,
             _number_of_args: 0,
             _number_of_optional_args: 0,
             prisma_types,
         }
     }
 
-    pub fn with_args(name: &str, number_of_args: usize, prisma_types: Vec<ScalarType>) -> NativeTypeConstructor {
+    pub const fn with_args(
+        name: &'static str,
+        number_of_args: usize,
+        prisma_types: &'static [ScalarType],
+    ) -> NativeTypeConstructor {
         NativeTypeConstructor {
-            name: name.to_string(),
+            name,
             _number_of_args: number_of_args,
             _number_of_optional_args: 0,
             prisma_types,
         }
     }
 
-    pub fn with_optional_args(
-        name: &str,
+    pub const fn with_optional_args(
+        name: &'static str,
         number_of_optional_args: usize,
-        prisma_types: Vec<ScalarType>,
+        prisma_types: &'static [ScalarType],
     ) -> NativeTypeConstructor {
         NativeTypeConstructor {
-            name: name.to_string(),
+            name,
             _number_of_args: 0,
             _number_of_optional_args: number_of_optional_args,
             prisma_types,

--- a/libs/datamodel/connectors/mongodb-datamodel-connector/src/lib.rs
+++ b/libs/datamodel/connectors/mongodb-datamodel-connector/src/lib.rs
@@ -5,8 +5,8 @@ use datamodel_connector::{
     Connector, ConnectorCapability, ReferentialIntegrity,
 };
 use dml::{
-    default_value::DefaultKind, field::FieldType, native_type_constructor::NativeTypeConstructor,
-    native_type_instance::NativeTypeInstance, relation_info::ReferentialAction, traits::WithDatabaseName,
+    default_value::DefaultKind, field::FieldType, native_type_instance::NativeTypeInstance,
+    relation_info::ReferentialAction, traits::WithDatabaseName,
 };
 use enumflags2::BitFlags;
 use mongodb_types::*;
@@ -17,7 +17,6 @@ type Result<T> = std::result::Result<T, ConnectorError>;
 
 pub struct MongoDbDatamodelConnector {
     capabilities: Vec<ConnectorCapability>,
-    native_types: Vec<NativeTypeConstructor>,
     referential_integrity: ReferentialIntegrity,
 }
 
@@ -34,11 +33,8 @@ impl MongoDbDatamodelConnector {
             ConnectorCapability::CompositeTypes,
         ];
 
-        let native_types = mongodb_types::available_types();
-
         Self {
             capabilities,
-            native_types,
             referential_integrity: ReferentialIntegrity::Prisma,
         }
     }
@@ -133,8 +129,8 @@ impl Connector for MongoDbDatamodelConnector {
         }
     }
 
-    fn available_native_type_constructors(&self) -> &[dml::native_type_constructor::NativeTypeConstructor] {
-        &self.native_types
+    fn available_native_type_constructors(&self) -> &'static [dml::native_type_constructor::NativeTypeConstructor] {
+        NATIVE_TYPE_CONSTRUCTORS
     }
 
     fn default_native_type_for_scalar_type(&self, scalar_type: &dml::scalars::ScalarType) -> serde_json::Value {

--- a/libs/datamodel/connectors/mongodb-datamodel-connector/src/mongodb_types.rs
+++ b/libs/datamodel/connectors/mongodb-datamodel-connector/src/mongodb_types.rs
@@ -42,21 +42,19 @@ pub(crate) fn default_for(scalar_type: &ScalarType) -> &MongoDbType {
         .unwrap_or_else(|| panic!("MongoDB native type mapping missing for '{:?}'", scalar_type))
 }
 
-pub(crate) fn available_types() -> Vec<NativeTypeConstructor> {
-    vec![
-        NativeTypeConstructor::without_args(STRING, vec![ScalarType::String]),
-        NativeTypeConstructor::without_args(DOUBLE, vec![ScalarType::Float]),
-        NativeTypeConstructor::without_args(LONG, vec![ScalarType::Int, ScalarType::BigInt]),
-        NativeTypeConstructor::without_args(INT, vec![ScalarType::Int]),
-        NativeTypeConstructor::without_args(BIN_DATA, vec![ScalarType::Bytes]),
-        NativeTypeConstructor::without_args(OBJECT_ID, vec![ScalarType::String, ScalarType::Bytes]),
-        NativeTypeConstructor::without_args(BOOL, vec![ScalarType::Boolean]),
-        NativeTypeConstructor::without_args(DATE, vec![ScalarType::DateTime]),
-        NativeTypeConstructor::without_args(TIMESTAMP, vec![ScalarType::DateTime]),
-        NativeTypeConstructor::without_args(DECIMAL, vec![ScalarType::Decimal]),
-        NativeTypeConstructor::with_args(ARRAY, 1, all_types()),
-    ]
-}
+pub(crate) const NATIVE_TYPE_CONSTRUCTORS: &[NativeTypeConstructor] = &[
+    NativeTypeConstructor::without_args(STRING, &[ScalarType::String]),
+    NativeTypeConstructor::without_args(DOUBLE, &[ScalarType::Float]),
+    NativeTypeConstructor::without_args(LONG, &[ScalarType::Int, ScalarType::BigInt]),
+    NativeTypeConstructor::without_args(INT, &[ScalarType::Int]),
+    NativeTypeConstructor::without_args(BIN_DATA, &[ScalarType::Bytes]),
+    NativeTypeConstructor::without_args(OBJECT_ID, &[ScalarType::String, ScalarType::Bytes]),
+    NativeTypeConstructor::without_args(BOOL, &[ScalarType::Boolean]),
+    NativeTypeConstructor::without_args(DATE, &[ScalarType::DateTime]),
+    NativeTypeConstructor::without_args(TIMESTAMP, &[ScalarType::DateTime]),
+    NativeTypeConstructor::without_args(DECIMAL, &[ScalarType::Decimal]),
+    NativeTypeConstructor::with_args(ARRAY, 1, all_types()),
+];
 
 pub(crate) fn mongo_type_from_input(name: &str, args: &[String]) -> crate::Result<MongoDbType> {
     let mongo_type = match name {
@@ -84,8 +82,8 @@ pub(crate) fn mongo_type_from_input(name: &str, args: &[String]) -> crate::Resul
     Ok(mongo_type)
 }
 
-fn all_types() -> Vec<ScalarType> {
-    vec![
+const fn all_types() -> &'static [ScalarType] {
+    &[
         ScalarType::Int,
         ScalarType::BigInt,
         ScalarType::Float,

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/mssql_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/mssql_datamodel_connector.rs
@@ -46,9 +46,39 @@ const IMAGE_TYPE_NAME: &str = "Image";
 const XML_TYPE_NAME: &str = "Xml";
 const UNIQUE_IDENTIFIER_TYPE_NAME: &str = "UniqueIdentifier";
 
+const NATIVE_TYPE_CONSTRUCTORS: &[NativeTypeConstructor] = &[
+    NativeTypeConstructor::without_args(TINY_INT_TYPE_NAME, &[ScalarType::Int]),
+    NativeTypeConstructor::without_args(SMALL_INT_TYPE_NAME, &[ScalarType::Int]),
+    NativeTypeConstructor::without_args(INT_TYPE_NAME, &[ScalarType::Int]),
+    NativeTypeConstructor::without_args(BIG_INT_TYPE_NAME, &[ScalarType::BigInt]),
+    NativeTypeConstructor::with_optional_args(DECIMAL_TYPE_NAME, 2, &[ScalarType::Decimal]),
+    NativeTypeConstructor::with_optional_args(NUMERIC_TYPE_NAME, 2, &[ScalarType::Decimal]),
+    NativeTypeConstructor::without_args(MONEY_TYPE_NAME, &[ScalarType::Float]),
+    NativeTypeConstructor::without_args(SMALL_MONEY_TYPE_NAME, &[ScalarType::Float]),
+    NativeTypeConstructor::without_args(BIT_TYPE_NAME, &[ScalarType::Boolean, ScalarType::Int]),
+    NativeTypeConstructor::with_optional_args(FLOAT_TYPE_NAME, 1, &[ScalarType::Float]),
+    NativeTypeConstructor::without_args(REAL_TYPE_NAME, &[ScalarType::Float]),
+    NativeTypeConstructor::without_args(DATE_TYPE_NAME, &[ScalarType::DateTime]),
+    NativeTypeConstructor::without_args(TIME_TYPE_NAME, &[ScalarType::DateTime]),
+    NativeTypeConstructor::without_args(DATETIME_TYPE_NAME, &[ScalarType::DateTime]),
+    NativeTypeConstructor::without_args(DATETIME2_TYPE_NAME, &[ScalarType::DateTime]),
+    NativeTypeConstructor::without_args(DATETIME_OFFSET_TYPE_NAME, &[ScalarType::DateTime]),
+    NativeTypeConstructor::without_args(SMALL_DATETIME_TYPE_NAME, &[ScalarType::DateTime]),
+    NativeTypeConstructor::with_optional_args(CHAR_TYPE_NAME, 1, &[ScalarType::String]),
+    NativeTypeConstructor::with_optional_args(NCHAR_TYPE_NAME, 1, &[ScalarType::String]),
+    NativeTypeConstructor::with_optional_args(VARCHAR_TYPE_NAME, 1, &[ScalarType::String]),
+    NativeTypeConstructor::without_args(TEXT_TYPE_NAME, &[ScalarType::String]),
+    NativeTypeConstructor::with_optional_args(NVARCHAR_TYPE_NAME, 1, &[ScalarType::String]),
+    NativeTypeConstructor::without_args(NTEXT_TYPE_NAME, &[ScalarType::String]),
+    NativeTypeConstructor::with_optional_args(BINARY_TYPE_NAME, 1, &[ScalarType::Bytes]),
+    NativeTypeConstructor::with_optional_args(VAR_BINARY_TYPE_NAME, 1, &[ScalarType::Bytes]),
+    NativeTypeConstructor::without_args(IMAGE_TYPE_NAME, &[ScalarType::Bytes]),
+    NativeTypeConstructor::without_args(XML_TYPE_NAME, &[ScalarType::String]),
+    NativeTypeConstructor::without_args(UNIQUE_IDENTIFIER_TYPE_NAME, &[ScalarType::String]),
+];
+
 pub struct MsSqlDatamodelConnector {
     capabilities: Vec<ConnectorCapability>,
-    constructors: Vec<NativeTypeConstructor>,
     referential_integrity: ReferentialIntegrity,
     constraint_violation_scopes: Vec<ConstraintScope>,
 }
@@ -75,40 +105,8 @@ impl MsSqlDatamodelConnector {
             capabilities.push(ConnectorCapability::ForeignKeys);
         }
 
-        let constructors: Vec<NativeTypeConstructor> = vec![
-            NativeTypeConstructor::without_args(TINY_INT_TYPE_NAME, vec![ScalarType::Int]),
-            NativeTypeConstructor::without_args(SMALL_INT_TYPE_NAME, vec![ScalarType::Int]),
-            NativeTypeConstructor::without_args(INT_TYPE_NAME, vec![ScalarType::Int]),
-            NativeTypeConstructor::without_args(BIG_INT_TYPE_NAME, vec![ScalarType::BigInt]),
-            NativeTypeConstructor::with_optional_args(DECIMAL_TYPE_NAME, 2, vec![ScalarType::Decimal]),
-            NativeTypeConstructor::with_optional_args(NUMERIC_TYPE_NAME, 2, vec![ScalarType::Decimal]),
-            NativeTypeConstructor::without_args(MONEY_TYPE_NAME, vec![ScalarType::Float]),
-            NativeTypeConstructor::without_args(SMALL_MONEY_TYPE_NAME, vec![ScalarType::Float]),
-            NativeTypeConstructor::without_args(BIT_TYPE_NAME, vec![ScalarType::Boolean, ScalarType::Int]),
-            NativeTypeConstructor::with_optional_args(FLOAT_TYPE_NAME, 1, vec![ScalarType::Float]),
-            NativeTypeConstructor::without_args(REAL_TYPE_NAME, vec![ScalarType::Float]),
-            NativeTypeConstructor::without_args(DATE_TYPE_NAME, vec![ScalarType::DateTime]),
-            NativeTypeConstructor::without_args(TIME_TYPE_NAME, vec![ScalarType::DateTime]),
-            NativeTypeConstructor::without_args(DATETIME_TYPE_NAME, vec![ScalarType::DateTime]),
-            NativeTypeConstructor::without_args(DATETIME2_TYPE_NAME, vec![ScalarType::DateTime]),
-            NativeTypeConstructor::without_args(DATETIME_OFFSET_TYPE_NAME, vec![ScalarType::DateTime]),
-            NativeTypeConstructor::without_args(SMALL_DATETIME_TYPE_NAME, vec![ScalarType::DateTime]),
-            NativeTypeConstructor::with_optional_args(CHAR_TYPE_NAME, 1, vec![ScalarType::String]),
-            NativeTypeConstructor::with_optional_args(NCHAR_TYPE_NAME, 1, vec![ScalarType::String]),
-            NativeTypeConstructor::with_optional_args(VARCHAR_TYPE_NAME, 1, vec![ScalarType::String]),
-            NativeTypeConstructor::without_args(TEXT_TYPE_NAME, vec![ScalarType::String]),
-            NativeTypeConstructor::with_optional_args(NVARCHAR_TYPE_NAME, 1, vec![ScalarType::String]),
-            NativeTypeConstructor::without_args(NTEXT_TYPE_NAME, vec![ScalarType::String]),
-            NativeTypeConstructor::with_optional_args(BINARY_TYPE_NAME, 1, vec![ScalarType::Bytes]),
-            NativeTypeConstructor::with_optional_args(VAR_BINARY_TYPE_NAME, 1, vec![ScalarType::Bytes]),
-            NativeTypeConstructor::without_args(IMAGE_TYPE_NAME, vec![ScalarType::Bytes]),
-            NativeTypeConstructor::without_args(XML_TYPE_NAME, vec![ScalarType::String]),
-            NativeTypeConstructor::without_args(UNIQUE_IDENTIFIER_TYPE_NAME, vec![ScalarType::String]),
-        ];
-
         MsSqlDatamodelConnector {
             capabilities,
-            constructors,
             referential_integrity,
             constraint_violation_scopes: vec![
                 ConstraintScope::GlobalPrimaryKeyForeignKeyDefault,
@@ -332,8 +330,8 @@ impl Connector for MsSqlDatamodelConnector {
         &self.constraint_violation_scopes
     }
 
-    fn available_native_type_constructors(&self) -> &[NativeTypeConstructor] {
-        &self.constructors
+    fn available_native_type_constructors(&self) -> &'static [NativeTypeConstructor] {
+        NATIVE_TYPE_CONSTRUCTORS
     }
 
     fn parse_native_type(&self, name: &str, args: Vec<String>) -> Result<NativeTypeInstance, ConnectorError> {
@@ -408,7 +406,7 @@ impl Connector for MsSqlDatamodelConnector {
         if let Some(constructor) = self.find_native_type_constructor(constructor_name) {
             let stringified_args = args.iter().map(|arg| arg.to_string()).collect();
             Ok(NativeTypeInstance::new(
-                constructor.name.as_str(),
+                constructor.name,
                 stringified_args,
                 &native_type,
             ))

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
@@ -58,9 +58,43 @@ const NATIVE_TYPES_THAT_CAN_NOT_BE_USED_IN_KEY_SPECIFICATION: &[&str] = &[
     LONG_BLOB_TYPE_NAME,
 ];
 
+const NATIVE_TYPE_CONSTRUCTORS: &[NativeTypeConstructor] = &[
+    NativeTypeConstructor::without_args(INT_TYPE_NAME, &[ScalarType::Int]),
+    NativeTypeConstructor::without_args(UNSIGNED_INT_TYPE_NAME, &[ScalarType::Int]),
+    NativeTypeConstructor::without_args(SMALL_INT_TYPE_NAME, &[ScalarType::Int]),
+    NativeTypeConstructor::without_args(UNSIGNED_SMALL_INT_TYPE_NAME, &[ScalarType::Int]),
+    NativeTypeConstructor::without_args(TINY_INT_TYPE_NAME, &[ScalarType::Boolean, ScalarType::Int]),
+    NativeTypeConstructor::without_args(UNSIGNED_TINY_INT_TYPE_NAME, &[ScalarType::Int]),
+    NativeTypeConstructor::without_args(MEDIUM_INT_TYPE_NAME, &[ScalarType::Int]),
+    NativeTypeConstructor::without_args(UNSIGNED_MEDIUM_INT_TYPE_NAME, &[ScalarType::Int]),
+    NativeTypeConstructor::without_args(BIG_INT_TYPE_NAME, &[ScalarType::BigInt]),
+    NativeTypeConstructor::without_args(UNSIGNED_BIG_INT_TYPE_NAME, &[ScalarType::BigInt]),
+    NativeTypeConstructor::with_optional_args(DECIMAL_TYPE_NAME, 2, &[ScalarType::Decimal]),
+    NativeTypeConstructor::without_args(FLOAT_TYPE_NAME, &[ScalarType::Float]),
+    NativeTypeConstructor::without_args(DOUBLE_TYPE_NAME, &[ScalarType::Float]),
+    NativeTypeConstructor::with_args(BIT_TYPE_NAME, 1, &[ScalarType::Boolean, ScalarType::Bytes]),
+    NativeTypeConstructor::with_args(CHAR_TYPE_NAME, 1, &[ScalarType::String]),
+    NativeTypeConstructor::with_args(VAR_CHAR_TYPE_NAME, 1, &[ScalarType::String]),
+    NativeTypeConstructor::with_args(BINARY_TYPE_NAME, 1, &[ScalarType::Bytes]),
+    NativeTypeConstructor::with_args(VAR_BINARY_TYPE_NAME, 1, &[ScalarType::Bytes]),
+    NativeTypeConstructor::without_args(TINY_BLOB_TYPE_NAME, &[ScalarType::Bytes]),
+    NativeTypeConstructor::without_args(BLOB_TYPE_NAME, &[ScalarType::Bytes]),
+    NativeTypeConstructor::without_args(MEDIUM_BLOB_TYPE_NAME, &[ScalarType::Bytes]),
+    NativeTypeConstructor::without_args(LONG_BLOB_TYPE_NAME, &[ScalarType::Bytes]),
+    NativeTypeConstructor::without_args(TINY_TEXT_TYPE_NAME, &[ScalarType::String]),
+    NativeTypeConstructor::without_args(TEXT_TYPE_NAME, &[ScalarType::String]),
+    NativeTypeConstructor::without_args(MEDIUM_TEXT_TYPE_NAME, &[ScalarType::String]),
+    NativeTypeConstructor::without_args(LONG_TEXT_TYPE_NAME, &[ScalarType::String]),
+    NativeTypeConstructor::without_args(DATE_TYPE_NAME, &[ScalarType::DateTime]),
+    NativeTypeConstructor::with_optional_args(TIME_TYPE_NAME, 1, &[ScalarType::DateTime]),
+    NativeTypeConstructor::with_optional_args(DATETIME_TYPE_NAME, 1, &[ScalarType::DateTime]),
+    NativeTypeConstructor::with_optional_args(TIMESTAMP_TYPE_NAME, 1, &[ScalarType::DateTime]),
+    NativeTypeConstructor::without_args(YEAR_TYPE_NAME, &[ScalarType::Int]),
+    NativeTypeConstructor::without_args(JSON_TYPE_NAME, &[ScalarType::Json]),
+];
+
 pub struct MySqlDatamodelConnector {
     capabilities: Vec<ConnectorCapability>,
-    constructors: Vec<NativeTypeConstructor>,
     referential_integrity: ReferentialIntegrity,
     constraint_violation_scopes: Vec<ConstraintScope>,
 }
@@ -91,81 +125,8 @@ impl MySqlDatamodelConnector {
             capabilities.push(ConnectorCapability::ForeignKeys);
         }
 
-        let int = NativeTypeConstructor::without_args(INT_TYPE_NAME, vec![ScalarType::Int]);
-        let unsigned_int = NativeTypeConstructor::without_args(UNSIGNED_INT_TYPE_NAME, vec![ScalarType::Int]);
-        let small_int = NativeTypeConstructor::without_args(SMALL_INT_TYPE_NAME, vec![ScalarType::Int]);
-        let unsigned_small_int =
-            NativeTypeConstructor::without_args(UNSIGNED_SMALL_INT_TYPE_NAME, vec![ScalarType::Int]);
-        let tiny_int =
-            NativeTypeConstructor::without_args(TINY_INT_TYPE_NAME, vec![ScalarType::Boolean, ScalarType::Int]);
-        let unsigned_tiny_int = NativeTypeConstructor::without_args(UNSIGNED_TINY_INT_TYPE_NAME, vec![ScalarType::Int]);
-        let medium_int = NativeTypeConstructor::without_args(MEDIUM_INT_TYPE_NAME, vec![ScalarType::Int]);
-        let unsigned_medium_int =
-            NativeTypeConstructor::without_args(UNSIGNED_MEDIUM_INT_TYPE_NAME, vec![ScalarType::Int]);
-        let big_int = NativeTypeConstructor::without_args(BIG_INT_TYPE_NAME, vec![ScalarType::BigInt]);
-        let unsigned_big_int =
-            NativeTypeConstructor::without_args(UNSIGNED_BIG_INT_TYPE_NAME, vec![ScalarType::BigInt]);
-        let decimal = NativeTypeConstructor::with_optional_args(DECIMAL_TYPE_NAME, 2, vec![ScalarType::Decimal]);
-        let float = NativeTypeConstructor::without_args(FLOAT_TYPE_NAME, vec![ScalarType::Float]);
-        let double = NativeTypeConstructor::without_args(DOUBLE_TYPE_NAME, vec![ScalarType::Float]);
-        let bit = NativeTypeConstructor::with_args(BIT_TYPE_NAME, 1, vec![ScalarType::Boolean, ScalarType::Bytes]);
-        let char = NativeTypeConstructor::with_args(CHAR_TYPE_NAME, 1, vec![ScalarType::String]);
-        let var_char = NativeTypeConstructor::with_args(VAR_CHAR_TYPE_NAME, 1, vec![ScalarType::String]);
-        let binary = NativeTypeConstructor::with_args(BINARY_TYPE_NAME, 1, vec![ScalarType::Bytes]);
-        let var_binary = NativeTypeConstructor::with_args(VAR_BINARY_TYPE_NAME, 1, vec![ScalarType::Bytes]);
-        let tiny_blob = NativeTypeConstructor::without_args(TINY_BLOB_TYPE_NAME, vec![ScalarType::Bytes]);
-        let blob = NativeTypeConstructor::without_args(BLOB_TYPE_NAME, vec![ScalarType::Bytes]);
-        let medium_blob = NativeTypeConstructor::without_args(MEDIUM_BLOB_TYPE_NAME, vec![ScalarType::Bytes]);
-        let long_blob = NativeTypeConstructor::without_args(LONG_BLOB_TYPE_NAME, vec![ScalarType::Bytes]);
-        let tiny_text = NativeTypeConstructor::without_args(TINY_TEXT_TYPE_NAME, vec![ScalarType::String]);
-        let text = NativeTypeConstructor::without_args(TEXT_TYPE_NAME, vec![ScalarType::String]);
-        let medium_text = NativeTypeConstructor::without_args(MEDIUM_TEXT_TYPE_NAME, vec![ScalarType::String]);
-        let long_text = NativeTypeConstructor::without_args(LONG_TEXT_TYPE_NAME, vec![ScalarType::String]);
-        let date = NativeTypeConstructor::without_args(DATE_TYPE_NAME, vec![ScalarType::DateTime]);
-        let time = NativeTypeConstructor::with_optional_args(TIME_TYPE_NAME, 1, vec![ScalarType::DateTime]);
-        let datetime = NativeTypeConstructor::with_optional_args(DATETIME_TYPE_NAME, 1, vec![ScalarType::DateTime]);
-        let timestamp = NativeTypeConstructor::with_optional_args(TIMESTAMP_TYPE_NAME, 1, vec![ScalarType::DateTime]);
-        let year = NativeTypeConstructor::without_args(YEAR_TYPE_NAME, vec![ScalarType::Int]);
-        let json = NativeTypeConstructor::without_args(JSON_TYPE_NAME, vec![ScalarType::Json]);
-
-        let constructors: Vec<NativeTypeConstructor> = vec![
-            int,
-            unsigned_int,
-            small_int,
-            unsigned_small_int,
-            tiny_int,
-            unsigned_tiny_int,
-            medium_int,
-            unsigned_medium_int,
-            big_int,
-            unsigned_big_int,
-            decimal,
-            float,
-            double,
-            bit,
-            char,
-            var_char,
-            binary,
-            var_binary,
-            tiny_blob,
-            blob,
-            medium_blob,
-            long_blob,
-            tiny_text,
-            text,
-            medium_text,
-            long_text,
-            date,
-            time,
-            datetime,
-            timestamp,
-            year,
-            json,
-        ];
-
         MySqlDatamodelConnector {
             capabilities,
-            constructors,
             referential_integrity,
             constraint_violation_scopes: vec![ConstraintScope::GlobalForeignKey, ConstraintScope::ModelKeyIndex],
         }
@@ -357,8 +318,8 @@ impl Connector for MySqlDatamodelConnector {
         &self.constraint_violation_scopes
     }
 
-    fn available_native_type_constructors(&self) -> &[NativeTypeConstructor] {
-        &self.constructors
+    fn available_native_type_constructors(&self) -> &'static [NativeTypeConstructor] {
+        NATIVE_TYPE_CONSTRUCTORS
     }
 
     fn parse_native_type(&self, name: &str, args: Vec<String>) -> Result<NativeTypeInstance, ConnectorError> {
@@ -448,7 +409,7 @@ impl Connector for MySqlDatamodelConnector {
         }
 
         if let Some(constructor) = self.find_native_type_constructor(constructor_name) {
-            Ok(NativeTypeInstance::new(constructor.name.as_str(), args, &native_type))
+            Ok(NativeTypeInstance::new(constructor.name, args, &native_type))
         } else {
             Err(self.native_str_error(constructor_name).native_type_name_unknown())
         }

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
@@ -41,9 +41,37 @@ const XML_TYPE_NAME: &str = "Xml";
 const JSON_TYPE_NAME: &str = "Json";
 const JSON_B_TYPE_NAME: &str = "JsonB";
 
+const NATIVE_TYPE_CONSTRUCTORS: &[NativeTypeConstructor] = &[
+    NativeTypeConstructor::without_args(SMALL_INT_TYPE_NAME, &[ScalarType::Int]),
+    NativeTypeConstructor::without_args(INTEGER_TYPE_NAME, &[ScalarType::Int]),
+    NativeTypeConstructor::without_args(BIG_INT_TYPE_NAME, &[ScalarType::BigInt]),
+    NativeTypeConstructor::with_optional_args(DECIMAL_TYPE_NAME, 2, &[ScalarType::Decimal]),
+    NativeTypeConstructor::without_args(MONEY_TYPE_NAME, &[ScalarType::Decimal]),
+    NativeTypeConstructor::without_args(INET_TYPE_NAME, &[ScalarType::String]),
+    NativeTypeConstructor::without_args(CITEXT_TYPE_NAME, &[ScalarType::String]),
+    NativeTypeConstructor::without_args(OID_TYPE_NAME, &[ScalarType::Int]),
+    NativeTypeConstructor::without_args(REAL_TYPE_NAME, &[ScalarType::Float]),
+    NativeTypeConstructor::without_args(DOUBLE_PRECISION_TYPE_NAME, &[ScalarType::Float]),
+    NativeTypeConstructor::with_optional_args(VARCHAR_TYPE_NAME, 1, &[ScalarType::String]),
+    NativeTypeConstructor::with_optional_args(CHAR_TYPE_NAME, 1, &[ScalarType::String]),
+    NativeTypeConstructor::without_args(TEXT_TYPE_NAME, &[ScalarType::String]),
+    NativeTypeConstructor::without_args(BYTE_A_TYPE_NAME, &[ScalarType::Bytes]),
+    NativeTypeConstructor::with_optional_args(TIMESTAMP_TYPE_NAME, 1, &[ScalarType::DateTime]),
+    NativeTypeConstructor::with_optional_args(TIMESTAMP_TZ_TYPE_NAME, 1, &[ScalarType::DateTime]),
+    NativeTypeConstructor::without_args(DATE_TYPE_NAME, &[ScalarType::DateTime]),
+    NativeTypeConstructor::with_optional_args(TIME_TYPE_NAME, 1, &[ScalarType::DateTime]),
+    NativeTypeConstructor::with_optional_args(TIME_TZ_TYPE_NAME, 1, &[ScalarType::DateTime]),
+    NativeTypeConstructor::without_args(BOOLEAN_TYPE_NAME, &[ScalarType::Boolean]),
+    NativeTypeConstructor::with_optional_args(BIT_TYPE_NAME, 1, &[ScalarType::String]),
+    NativeTypeConstructor::with_optional_args(VAR_BIT_TYPE_NAME, 1, &[ScalarType::String]),
+    NativeTypeConstructor::without_args(UUID_TYPE_NAME, &[ScalarType::String]),
+    NativeTypeConstructor::without_args(XML_TYPE_NAME, &[ScalarType::String]),
+    NativeTypeConstructor::without_args(JSON_TYPE_NAME, &[ScalarType::Json]),
+    NativeTypeConstructor::without_args(JSON_B_TYPE_NAME, &[ScalarType::Json]),
+];
+
 pub struct PostgresDatamodelConnector {
     capabilities: Vec<ConnectorCapability>,
-    constructors: Vec<NativeTypeConstructor>,
     referential_integrity: ReferentialIntegrity,
     constraint_violation_scopes: Vec<ConstraintScope>,
 }
@@ -80,66 +108,8 @@ impl PostgresDatamodelConnector {
             capabilities.push(ConnectorCapability::ForeignKeys);
         }
 
-        let small_int = NativeTypeConstructor::without_args(SMALL_INT_TYPE_NAME, vec![ScalarType::Int]);
-        let integer = NativeTypeConstructor::without_args(INTEGER_TYPE_NAME, vec![ScalarType::Int]);
-        let big_int = NativeTypeConstructor::without_args(BIG_INT_TYPE_NAME, vec![ScalarType::BigInt]);
-        let decimal = NativeTypeConstructor::with_optional_args(DECIMAL_TYPE_NAME, 2, vec![ScalarType::Decimal]);
-        let money = NativeTypeConstructor::without_args(MONEY_TYPE_NAME, vec![ScalarType::Decimal]);
-        let inet = NativeTypeConstructor::without_args(INET_TYPE_NAME, vec![ScalarType::String]);
-        let citext = NativeTypeConstructor::without_args(CITEXT_TYPE_NAME, vec![ScalarType::String]);
-        let oid = NativeTypeConstructor::without_args(OID_TYPE_NAME, vec![ScalarType::Int]);
-        let real = NativeTypeConstructor::without_args(REAL_TYPE_NAME, vec![ScalarType::Float]);
-        let double_precision = NativeTypeConstructor::without_args(DOUBLE_PRECISION_TYPE_NAME, vec![ScalarType::Float]);
-        let varchar = NativeTypeConstructor::with_optional_args(VARCHAR_TYPE_NAME, 1, vec![ScalarType::String]);
-        let char = NativeTypeConstructor::with_optional_args(CHAR_TYPE_NAME, 1, vec![ScalarType::String]);
-        let text = NativeTypeConstructor::without_args(TEXT_TYPE_NAME, vec![ScalarType::String]);
-        let byte_a = NativeTypeConstructor::without_args(BYTE_A_TYPE_NAME, vec![ScalarType::Bytes]);
-        let timestamp = NativeTypeConstructor::with_optional_args(TIMESTAMP_TYPE_NAME, 1, vec![ScalarType::DateTime]);
-        let timestamptz =
-            NativeTypeConstructor::with_optional_args(TIMESTAMP_TZ_TYPE_NAME, 1, vec![ScalarType::DateTime]);
-        let date = NativeTypeConstructor::without_args(DATE_TYPE_NAME, vec![ScalarType::DateTime]);
-        let time = NativeTypeConstructor::with_optional_args(TIME_TYPE_NAME, 1, vec![ScalarType::DateTime]);
-        let timetz = NativeTypeConstructor::with_optional_args(TIME_TZ_TYPE_NAME, 1, vec![ScalarType::DateTime]);
-        let boolean = NativeTypeConstructor::without_args(BOOLEAN_TYPE_NAME, vec![ScalarType::Boolean]);
-        let bit = NativeTypeConstructor::with_optional_args(BIT_TYPE_NAME, 1, vec![ScalarType::String]);
-        let varbit = NativeTypeConstructor::with_optional_args(VAR_BIT_TYPE_NAME, 1, vec![ScalarType::String]);
-        let uuid = NativeTypeConstructor::without_args(UUID_TYPE_NAME, vec![ScalarType::String]);
-        let xml = NativeTypeConstructor::without_args(XML_TYPE_NAME, vec![ScalarType::String]);
-        let json = NativeTypeConstructor::without_args(JSON_TYPE_NAME, vec![ScalarType::Json]);
-        let json_b = NativeTypeConstructor::without_args(JSON_B_TYPE_NAME, vec![ScalarType::Json]);
-
-        let constructors = vec![
-            small_int,
-            integer,
-            big_int,
-            decimal,
-            money,
-            inet,
-            citext,
-            oid,
-            real,
-            double_precision,
-            varchar,
-            char,
-            text,
-            byte_a,
-            timestamp,
-            timestamptz,
-            date,
-            time,
-            timetz,
-            boolean,
-            bit,
-            varbit,
-            uuid,
-            xml,
-            json,
-            json_b,
-        ];
-
         PostgresDatamodelConnector {
             capabilities,
-            constructors,
             referential_integrity,
             constraint_violation_scopes: vec![
                 ConstraintScope::GlobalPrimaryKeyKeyIndex,
@@ -295,8 +265,8 @@ impl Connector for PostgresDatamodelConnector {
         &self.constraint_violation_scopes
     }
 
-    fn available_native_type_constructors(&self) -> &[NativeTypeConstructor] {
-        &self.constructors
+    fn available_native_type_constructors(&self) -> &'static [NativeTypeConstructor] {
+        NATIVE_TYPE_CONSTRUCTORS
     }
 
     fn parse_native_type(&self, name: &str, args: Vec<String>) -> Result<NativeTypeInstance, ConnectorError> {
@@ -367,7 +337,7 @@ impl Connector for PostgresDatamodelConnector {
         };
 
         if let Some(constructor) = self.find_native_type_constructor(constructor_name) {
-            Ok(NativeTypeInstance::new(constructor.name.as_str(), args, &native_type))
+            Ok(NativeTypeInstance::new(constructor.name, args, &native_type))
         } else {
             Err(self.native_str_error(constructor_name).native_type_name_unknown())
         }

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/sqlite_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/sqlite_datamodel_connector.rs
@@ -9,10 +9,11 @@ use std::borrow::Cow;
 
 pub struct SqliteDatamodelConnector {
     capabilities: Vec<ConnectorCapability>,
-    constructors: Vec<NativeTypeConstructor>,
     referential_integrity: ReferentialIntegrity,
     constraint_violation_scopes: Vec<ConstraintScope>,
 }
+
+const NATIVE_TYPE_CONSTRUCTORS: &[NativeTypeConstructor] = &[];
 
 impl SqliteDatamodelConnector {
     pub fn new(referential_integrity: ReferentialIntegrity) -> SqliteDatamodelConnector {
@@ -29,11 +30,8 @@ impl SqliteDatamodelConnector {
             capabilities.push(ConnectorCapability::ForeignKeys);
         }
 
-        let constructors: Vec<NativeTypeConstructor> = vec![];
-
         SqliteDatamodelConnector {
             capabilities,
-            constructors,
             referential_integrity,
             constraint_violation_scopes: vec![ConstraintScope::GlobalKeyIndex],
         }
@@ -80,8 +78,8 @@ impl Connector for SqliteDatamodelConnector {
         &self.constraint_violation_scopes
     }
 
-    fn available_native_type_constructors(&self) -> &[NativeTypeConstructor] {
-        &self.constructors
+    fn available_native_type_constructors(&self) -> &'static [NativeTypeConstructor] {
+        NATIVE_TYPE_CONSTRUCTORS
     }
 
     fn parse_native_type(&self, _name: &str, _args: Vec<String>) -> Result<NativeTypeInstance, ConnectorError> {


### PR DESCRIPTION
The justification for this is not performance (although it will almost
certainly be better), but that we want to enforce that there is no
dynamic behaviour in datamodel connectors: for a given provider, the set
of available native types should always be the same. The 'static
lifetimes enforce that.

The next step should be capabilities and constraint violation scopes.