### PR TITLE
 Make constraint scopes const in datamodel connector 

### DIFF
--- a/libs/datamodel/connectors/datamodel-connector/src/lib.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/lib.rs
@@ -1,21 +1,21 @@
-use std::{borrow::Cow, collections::BTreeMap, str::FromStr};
-
-use enumflags2::BitFlags;
-
-use dml::{
-    field::Field, model::Model, native_type_constructor::NativeTypeConstructor,
-    native_type_instance::NativeTypeInstance, relation_info::ReferentialAction, scalars::ScalarType,
-};
-pub use empty_connector::EmptyDatamodelConnector;
-pub use referential_integrity::ReferentialIntegrity;
-
-use crate::connector_error::{ConnectorError, ConnectorErrorFactory, ErrorKind};
+#![deny(rust_2018_idioms, unsafe_code)]
 
 pub mod connector_error;
 pub mod helper;
 
 mod empty_connector;
 mod referential_integrity;
+
+pub use empty_connector::EmptyDatamodelConnector;
+pub use referential_integrity::ReferentialIntegrity;
+
+use crate::connector_error::{ConnectorError, ConnectorErrorFactory, ErrorKind};
+use dml::{
+    field::Field, model::Model, native_type_constructor::NativeTypeConstructor,
+    native_type_instance::NativeTypeInstance, relation_info::ReferentialAction, scalars::ScalarType,
+};
+use enumflags2::BitFlags;
+use std::{borrow::Cow, collections::BTreeMap, str::FromStr};
 
 pub trait Connector: Send + Sync {
     fn name(&self) -> &str;

--- a/libs/datamodel/connectors/datamodel-connector/src/lib.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/lib.rs
@@ -62,7 +62,7 @@ pub trait Connector: Send + Sync {
 
     /// The scopes in which a constraint name should be validated. If empty, doesn't check for name
     /// clashes in the validation phase.
-    fn constraint_violation_scopes(&self) -> &[ConstraintScope] {
+    fn constraint_violation_scopes(&self) -> &'static [ConstraintScope] {
         &[]
     }
 
@@ -87,7 +87,6 @@ pub trait Connector: Send + Sync {
     }
 
     /// This function is used during Schema parsing to calculate the concrete native type.
-    /// This powers the use of native types for QE + ME.
     fn parse_native_type(&self, name: &str, args: Vec<String>) -> Result<NativeTypeInstance, ConnectorError>;
 
     /// This function is used in ME for error messages
@@ -97,7 +96,6 @@ pub trait Connector: Send + Sync {
     }
 
     /// This function is used during introspection to turn an introspected native type into an instance that can be put into the Prisma schema.
-    /// powers IE
     fn introspect_native_type(&self, native_type: serde_json::Value) -> Result<NativeTypeInstance, ConnectorError>;
 
     fn set_config_dir<'a>(&self, config_dir: &std::path::Path, url: &'a str) -> Cow<'a, str> {

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/lib.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(rust_2018_idioms, unsafe_code)]
+
 mod mssql_datamodel_connector;
 mod mysql_datamodel_connector;
 mod postgres_datamodel_connector;

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/mssql_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/mssql_datamodel_connector.rs
@@ -77,10 +77,14 @@ const NATIVE_TYPE_CONSTRUCTORS: &[NativeTypeConstructor] = &[
     NativeTypeConstructor::without_args(UNIQUE_IDENTIFIER_TYPE_NAME, &[ScalarType::String]),
 ];
 
+const CONSTRAINT_SCOPES: &[ConstraintScope] = &[
+    ConstraintScope::GlobalPrimaryKeyForeignKeyDefault,
+    ConstraintScope::ModelPrimaryKeyKeyIndex,
+];
+
 pub struct MsSqlDatamodelConnector {
     capabilities: Vec<ConnectorCapability>,
     referential_integrity: ReferentialIntegrity,
-    constraint_violation_scopes: Vec<ConstraintScope>,
 }
 
 impl MsSqlDatamodelConnector {
@@ -108,10 +112,6 @@ impl MsSqlDatamodelConnector {
         MsSqlDatamodelConnector {
             capabilities,
             referential_integrity,
-            constraint_violation_scopes: vec![
-                ConstraintScope::GlobalPrimaryKeyForeignKeyDefault,
-                ConstraintScope::ModelPrimaryKeyKeyIndex,
-            ],
         }
     }
 
@@ -326,8 +326,8 @@ impl Connector for MsSqlDatamodelConnector {
         }
     }
 
-    fn constraint_violation_scopes(&self) -> &[ConstraintScope] {
-        &self.constraint_violation_scopes
+    fn constraint_violation_scopes(&self) -> &'static [ConstraintScope] {
+        CONSTRAINT_SCOPES
     }
 
     fn available_native_type_constructors(&self) -> &'static [NativeTypeConstructor] {

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
@@ -93,10 +93,11 @@ const NATIVE_TYPE_CONSTRUCTORS: &[NativeTypeConstructor] = &[
     NativeTypeConstructor::without_args(JSON_TYPE_NAME, &[ScalarType::Json]),
 ];
 
+const CONSTRAINT_SCOPES: &[ConstraintScope] = &[ConstraintScope::GlobalForeignKey, ConstraintScope::ModelKeyIndex];
+
 pub struct MySqlDatamodelConnector {
     capabilities: Vec<ConnectorCapability>,
     referential_integrity: ReferentialIntegrity,
-    constraint_violation_scopes: Vec<ConstraintScope>,
 }
 
 impl MySqlDatamodelConnector {
@@ -128,7 +129,6 @@ impl MySqlDatamodelConnector {
         MySqlDatamodelConnector {
             capabilities,
             referential_integrity,
-            constraint_violation_scopes: vec![ConstraintScope::GlobalForeignKey, ConstraintScope::ModelKeyIndex],
         }
     }
 }
@@ -314,8 +314,8 @@ impl Connector for MySqlDatamodelConnector {
         }
     }
 
-    fn constraint_violation_scopes(&self) -> &[ConstraintScope] {
-        &self.constraint_violation_scopes
+    fn constraint_violation_scopes(&self) -> &'static [ConstraintScope] {
+        CONSTRAINT_SCOPES
     }
 
     fn available_native_type_constructors(&self) -> &'static [NativeTypeConstructor] {

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
@@ -70,10 +70,14 @@ const NATIVE_TYPE_CONSTRUCTORS: &[NativeTypeConstructor] = &[
     NativeTypeConstructor::without_args(JSON_B_TYPE_NAME, &[ScalarType::Json]),
 ];
 
+const CONSTRAINT_SCOPES: &[ConstraintScope] = &[
+    ConstraintScope::GlobalPrimaryKeyKeyIndex,
+    ConstraintScope::ModelPrimaryKeyKeyIndexForeignKey,
+];
+
 pub struct PostgresDatamodelConnector {
     capabilities: Vec<ConnectorCapability>,
     referential_integrity: ReferentialIntegrity,
-    constraint_violation_scopes: Vec<ConstraintScope>,
 }
 
 //todo should this also contain the pretty printed output for SQL rendering?
@@ -111,10 +115,6 @@ impl PostgresDatamodelConnector {
         PostgresDatamodelConnector {
             capabilities,
             referential_integrity,
-            constraint_violation_scopes: vec![
-                ConstraintScope::GlobalPrimaryKeyKeyIndex,
-                ConstraintScope::ModelPrimaryKeyKeyIndexForeignKey,
-            ],
         }
     }
 }
@@ -261,8 +261,8 @@ impl Connector for PostgresDatamodelConnector {
         }
     }
 
-    fn constraint_violation_scopes(&self) -> &[ConstraintScope] {
-        &self.constraint_violation_scopes
+    fn constraint_violation_scopes(&self) -> &'static [ConstraintScope] {
+        CONSTRAINT_SCOPES
     }
 
     fn available_native_type_constructors(&self) -> &'static [NativeTypeConstructor] {

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/sqlite_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/sqlite_datamodel_connector.rs
@@ -10,10 +10,10 @@ use std::borrow::Cow;
 pub struct SqliteDatamodelConnector {
     capabilities: Vec<ConnectorCapability>,
     referential_integrity: ReferentialIntegrity,
-    constraint_violation_scopes: Vec<ConstraintScope>,
 }
 
 const NATIVE_TYPE_CONSTRUCTORS: &[NativeTypeConstructor] = &[];
+const CONSTRAINT_SCOPES: &[ConstraintScope] = &[ConstraintScope::GlobalKeyIndex];
 
 impl SqliteDatamodelConnector {
     pub fn new(referential_integrity: ReferentialIntegrity) -> SqliteDatamodelConnector {
@@ -33,7 +33,6 @@ impl SqliteDatamodelConnector {
         SqliteDatamodelConnector {
             capabilities,
             referential_integrity,
-            constraint_violation_scopes: vec![ConstraintScope::GlobalKeyIndex],
         }
     }
 }
@@ -74,8 +73,8 @@ impl Connector for SqliteDatamodelConnector {
         false
     }
 
-    fn constraint_violation_scopes(&self) -> &[ConstraintScope] {
-        &self.constraint_violation_scopes
+    fn constraint_violation_scopes(&self) -> &'static [ConstraintScope] {
+        CONSTRAINT_SCOPES
     }
 
     fn available_native_type_constructors(&self) -> &'static [NativeTypeConstructor] {


### PR DESCRIPTION
On the way to the cockroachdb datamodel connector. We do not want these to be dynamic: one connector has one notion of
constraint scopes. This just enforces it.