### PR TITLE
 Make capabilities const in datamodel connector 

### DIFF
--- a/.test_database_urls/mssql_2019
+++ b/.test_database_urls/mssql_2019
@@ -1,2 +1,2 @@
 export TEST_DATABASE_URL="sqlserver://localhost:1433;database=master;user=SA;password=<YourStrong@Passw0rd>;trustServerCertificate=true;socket_timeout=60;isolationLevel=READ UNCOMMITTED"
-set -e TEST_SHADOW_DATABASE_URL
+unset TEST_SHADOW_DATABASE_URL

--- a/introspection-engine/connectors/sql-introspection-connector/src/calculate_datamodel_tests.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/calculate_datamodel_tests.rs
@@ -6,13 +6,12 @@ mod tests {
         IndexDefinition, Model, NativeTypeInstance, PrimaryKeyDefinition, ReferentialAction, RelationField,
         RelationInfo, ScalarField, ScalarType, StringFromEnvVar, ValueGenerator,
     };
-    use datamodel_connector::ReferentialIntegrity;
     use enumflags2::BitFlags;
     use expect_test::expect;
     use introspection_connector::IntrospectionContext;
     use native_types::{NativeType, PostgresType};
     use pretty_assertions::assert_eq;
-    use sql_datamodel_connector::PostgresDatamodelConnector;
+    use sql_datamodel_connector::SqlDatamodelConnectors;
     use sql_schema_describer::{
         Column, ColumnArity, ColumnType, ColumnTypeFamily, Enum, ForeignKey, ForeignKeyAction, Index, IndexType,
         PrimaryKey, Sequence, SqlSchema, Table,
@@ -25,11 +24,10 @@ mod tests {
             url: StringFromEnvVar::new_literal("test".to_string()),
             url_span: Span::empty(),
             documentation: None,
-            active_connector: Box::new(PostgresDatamodelConnector::new(Default::default())),
+            active_connector: SqlDatamodelConnectors::POSTGRES,
             shadow_database_url: None,
             provider: "postgresql".to_string(),
             referential_integrity: None,
-            default_referential_integrity: ReferentialIntegrity::ForeignKeys,
         };
 
         IntrospectionContext {

--- a/libs/datamodel/connectors/datamodel-connector/src/empty_connector.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/empty_connector.rs
@@ -11,11 +11,11 @@ impl Connector for EmptyDatamodelConnector {
         std::any::type_name::<EmptyDatamodelConnector>()
     }
 
-    fn referential_actions(&self) -> BitFlags<ReferentialAction> {
+    fn referential_actions(&self, _referential_integrity: &crate::ReferentialIntegrity) -> BitFlags<ReferentialAction> {
         BitFlags::all()
     }
 
-    fn capabilities(&self) -> &[ConnectorCapability] {
+    fn capabilities(&self) -> &'static [ConnectorCapability] {
         &[
             ConnectorCapability::CompoundIds,
             ConnectorCapability::Enums,

--- a/libs/datamodel/connectors/datamodel-connector/src/lib.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/lib.rs
@@ -20,17 +20,32 @@ use std::{borrow::Cow, collections::BTreeMap, str::FromStr};
 pub trait Connector: Send + Sync {
     fn name(&self) -> &str;
 
-    fn capabilities(&self) -> &[ConnectorCapability];
+    fn capabilities(&self) -> &'static [ConnectorCapability];
 
     /// The maximum length of constraint names in bytes. Connectors without a
     /// limit should return usize::MAX.
     fn constraint_name_length(&self) -> usize;
 
+    // Referential integrity
+
+    /// The referential integrity modes that can be set through the referentialIntegrity datasource
+    /// argument.
+    fn allowed_referential_integrity_settings(&self) -> BitFlags<ReferentialIntegrity> {
+        use ReferentialIntegrity::*;
+
+        ForeignKeys | Prisma
+    }
+
+    /// The default referential integrity mode to assume for this connector.
+    fn default_referential_integrity(&self) -> ReferentialIntegrity {
+        ReferentialIntegrity::ForeignKeys
+    }
+
     fn has_capability(&self, capability: ConnectorCapability) -> bool {
         self.capabilities().contains(&capability)
     }
 
-    fn referential_actions(&self) -> BitFlags<ReferentialAction>;
+    fn referential_actions(&self, referential_integrity: &ReferentialIntegrity) -> BitFlags<ReferentialAction>;
 
     fn supports_composite_types(&self) -> bool {
         self.has_capability(ConnectorCapability::CompositeTypes)
@@ -48,12 +63,8 @@ pub trait Connector: Send + Sync {
         self.has_capability(ConnectorCapability::NamedDefaultValues)
     }
 
-    fn supports_referential_action(&self, action: ReferentialAction) -> bool {
-        self.referential_actions().contains(action)
-    }
-
-    fn emulates_referential_actions(&self) -> bool {
-        false
+    fn supports_referential_action(&self, integrity: &ReferentialIntegrity, action: ReferentialAction) -> bool {
+        self.referential_actions(integrity).contains(action)
     }
 
     fn validate_field(&self, _: &Field, _: &mut Vec<ConnectorError>) {}

--- a/libs/datamodel/connectors/datamodel-connector/src/referential_integrity.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/referential_integrity.rs
@@ -32,6 +32,10 @@ impl ReferentialIntegrity {
         }
     }
 
+    pub fn is_prisma(&self) -> bool {
+        matches!(self, ReferentialIntegrity::Prisma)
+    }
+
     /// True, if integrity is in database foreign keys
     pub fn uses_foreign_keys(&self) -> bool {
         matches!(self, Self::ForeignKeys)

--- a/libs/datamodel/connectors/mongodb-datamodel-connector/src/lib.rs
+++ b/libs/datamodel/connectors/mongodb-datamodel-connector/src/lib.rs
@@ -13,59 +13,36 @@ use mongodb_types::*;
 use native_types::MongoDbType;
 use std::result::Result as StdResult;
 
+const CAPABILITIES: &[ConnectorCapability] = &[
+    ConnectorCapability::RelationsOverNonUniqueCriteria,
+    ConnectorCapability::Json,
+    ConnectorCapability::Enums,
+    ConnectorCapability::RelationFieldsInArbitraryOrder,
+    ConnectorCapability::CreateMany,
+    ConnectorCapability::ScalarLists,
+    ConnectorCapability::InsensitiveFilters,
+    ConnectorCapability::CompositeTypes,
+];
+
 type Result<T> = std::result::Result<T, ConnectorError>;
 
-pub struct MongoDbDatamodelConnector {
-    capabilities: Vec<ConnectorCapability>,
-    referential_integrity: ReferentialIntegrity,
-}
-
-impl MongoDbDatamodelConnector {
-    pub fn new() -> Self {
-        let capabilities = vec![
-            ConnectorCapability::RelationsOverNonUniqueCriteria,
-            ConnectorCapability::Json,
-            ConnectorCapability::Enums,
-            ConnectorCapability::RelationFieldsInArbitraryOrder,
-            ConnectorCapability::CreateMany,
-            ConnectorCapability::ScalarLists,
-            ConnectorCapability::InsensitiveFilters,
-            ConnectorCapability::CompositeTypes,
-        ];
-
-        Self {
-            capabilities,
-            referential_integrity: ReferentialIntegrity::Prisma,
-        }
-    }
-}
-
-impl Default for MongoDbDatamodelConnector {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+pub struct MongoDbDatamodelConnector;
 
 impl Connector for MongoDbDatamodelConnector {
     fn name(&self) -> &str {
         "MongoDB"
     }
 
-    fn capabilities(&self) -> &[ConnectorCapability] {
-        &self.capabilities
+    fn capabilities(&self) -> &'static [ConnectorCapability] {
+        CAPABILITIES
     }
 
     fn constraint_name_length(&self) -> usize {
         127
     }
 
-    fn referential_actions(&self) -> BitFlags<ReferentialAction> {
-        self.referential_integrity
-            .allowed_referential_actions(BitFlags::empty())
-    }
-
-    fn emulates_referential_actions(&self) -> bool {
-        true
+    fn referential_actions(&self, referential_integrity: &ReferentialIntegrity) -> BitFlags<ReferentialAction> {
+        referential_integrity.allowed_referential_actions(BitFlags::empty())
     }
 
     fn validate_field(&self, field: &dml::field::Field, errors: &mut Vec<ConnectorError>) {
@@ -179,5 +156,13 @@ impl Connector for MongoDbDatamodelConnector {
         }
 
         Ok(())
+    }
+
+    fn default_referential_integrity(&self) -> ReferentialIntegrity {
+        ReferentialIntegrity::Prisma
+    }
+
+    fn allowed_referential_integrity_settings(&self) -> enumflags2::BitFlags<ReferentialIntegrity> {
+        ReferentialIntegrity::Prisma.into()
     }
 }

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/lib.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/lib.rs
@@ -5,29 +5,13 @@ mod mysql_datamodel_connector;
 mod postgres_datamodel_connector;
 mod sqlite_datamodel_connector;
 
-pub use mssql_datamodel_connector::MsSqlDatamodelConnector;
-pub use mysql_datamodel_connector::MySqlDatamodelConnector;
-pub use postgres_datamodel_connector::PostgresDatamodelConnector;
-pub use sqlite_datamodel_connector::SqliteDatamodelConnector;
+use datamodel_connector::Connector;
 
-use datamodel_connector::ReferentialIntegrity;
-
-pub struct SqlDatamodelConnectors {}
+pub struct SqlDatamodelConnectors;
 
 impl SqlDatamodelConnectors {
-    pub fn postgres(referential_integrity: ReferentialIntegrity) -> PostgresDatamodelConnector {
-        PostgresDatamodelConnector::new(referential_integrity)
-    }
-
-    pub fn mysql(referential_integrity: ReferentialIntegrity) -> MySqlDatamodelConnector {
-        MySqlDatamodelConnector::new(referential_integrity)
-    }
-
-    pub fn sqlite(referential_integrity: ReferentialIntegrity) -> SqliteDatamodelConnector {
-        SqliteDatamodelConnector::new(referential_integrity)
-    }
-
-    pub fn mssql(referential_integrity: ReferentialIntegrity) -> MsSqlDatamodelConnector {
-        MsSqlDatamodelConnector::new(referential_integrity)
-    }
+    pub const POSTGRES: &'static dyn Connector = &postgres_datamodel_connector::PostgresDatamodelConnector;
+    pub const MYSQL: &'static dyn Connector = &mysql_datamodel_connector::MySqlDatamodelConnector;
+    pub const SQLITE: &'static dyn Connector = &sqlite_datamodel_connector::SqliteDatamodelConnector;
+    pub const MSSQL: &'static dyn Connector = &mssql_datamodel_connector::MsSqlDatamodelConnector;
 }

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
@@ -93,45 +93,30 @@ const NATIVE_TYPE_CONSTRUCTORS: &[NativeTypeConstructor] = &[
     NativeTypeConstructor::without_args(JSON_TYPE_NAME, &[ScalarType::Json]),
 ];
 
+const CAPABILITIES: &[ConnectorCapability] = &[
+    ConnectorCapability::RelationsOverNonUniqueCriteria,
+    ConnectorCapability::Enums,
+    ConnectorCapability::Json,
+    ConnectorCapability::AutoIncrementAllowedOnNonId,
+    ConnectorCapability::RelationFieldsInArbitraryOrder,
+    ConnectorCapability::CreateMany,
+    ConnectorCapability::WritableAutoincField,
+    ConnectorCapability::CreateSkipDuplicates,
+    ConnectorCapability::UpdateableId,
+    ConnectorCapability::JsonFilteringJsonPath,
+    ConnectorCapability::CreateManyWriteableAutoIncId,
+    ConnectorCapability::AutoIncrement,
+    ConnectorCapability::CompoundIds,
+    ConnectorCapability::AnyId,
+    ConnectorCapability::QueryRaw,
+    ConnectorCapability::NamedForeignKeys,
+    ConnectorCapability::AdvancedJsonNullability,
+    ConnectorCapability::ForeignKeys,
+];
+
 const CONSTRAINT_SCOPES: &[ConstraintScope] = &[ConstraintScope::GlobalForeignKey, ConstraintScope::ModelKeyIndex];
 
-pub struct MySqlDatamodelConnector {
-    capabilities: Vec<ConnectorCapability>,
-    referential_integrity: ReferentialIntegrity,
-}
-
-impl MySqlDatamodelConnector {
-    pub fn new(referential_integrity: ReferentialIntegrity) -> MySqlDatamodelConnector {
-        let mut capabilities = vec![
-            ConnectorCapability::RelationsOverNonUniqueCriteria,
-            ConnectorCapability::Enums,
-            ConnectorCapability::Json,
-            ConnectorCapability::AutoIncrementAllowedOnNonId,
-            ConnectorCapability::RelationFieldsInArbitraryOrder,
-            ConnectorCapability::CreateMany,
-            ConnectorCapability::WritableAutoincField,
-            ConnectorCapability::CreateSkipDuplicates,
-            ConnectorCapability::UpdateableId,
-            ConnectorCapability::JsonFilteringJsonPath,
-            ConnectorCapability::CreateManyWriteableAutoIncId,
-            ConnectorCapability::AutoIncrement,
-            ConnectorCapability::CompoundIds,
-            ConnectorCapability::AnyId,
-            ConnectorCapability::QueryRaw,
-            ConnectorCapability::NamedForeignKeys,
-            ConnectorCapability::AdvancedJsonNullability,
-        ];
-
-        if referential_integrity.uses_foreign_keys() {
-            capabilities.push(ConnectorCapability::ForeignKeys);
-        }
-
-        MySqlDatamodelConnector {
-            capabilities,
-            referential_integrity,
-        }
-    }
-}
+pub struct MySqlDatamodelConnector;
 
 const SCALAR_TYPE_DEFAULTS: &[(ScalarType, MySqlType)] = &[
     (ScalarType::Int, MySqlType::Int),
@@ -150,23 +135,18 @@ impl Connector for MySqlDatamodelConnector {
         "MySQL"
     }
 
-    fn capabilities(&self) -> &[ConnectorCapability] {
-        &self.capabilities
+    fn capabilities(&self) -> &'static [ConnectorCapability] {
+        CAPABILITIES
     }
 
     fn constraint_name_length(&self) -> usize {
         64
     }
 
-    fn referential_actions(&self) -> BitFlags<ReferentialAction> {
+    fn referential_actions(&self, referential_integrity: &ReferentialIntegrity) -> BitFlags<ReferentialAction> {
         use ReferentialAction::*;
 
-        self.referential_integrity
-            .allowed_referential_actions(Restrict | Cascade | SetNull | NoAction | SetDefault)
-    }
-
-    fn emulates_referential_actions(&self) -> bool {
-        matches!(self.referential_integrity, ReferentialIntegrity::Prisma)
+        referential_integrity.allowed_referential_actions(Restrict | Cascade | SetNull | NoAction | SetDefault)
     }
 
     fn scalar_type_for_native_type(&self, native_type: serde_json::Value) -> ScalarType {

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
@@ -75,49 +75,33 @@ const CONSTRAINT_SCOPES: &[ConstraintScope] = &[
     ConstraintScope::ModelPrimaryKeyKeyIndexForeignKey,
 ];
 
-pub struct PostgresDatamodelConnector {
-    capabilities: Vec<ConnectorCapability>,
-    referential_integrity: ReferentialIntegrity,
-}
+const CAPABILITIES: &[ConnectorCapability] = &[
+    ConnectorCapability::AdvancedJsonNullability,
+    ConnectorCapability::AnyId,
+    ConnectorCapability::AutoIncrement,
+    ConnectorCapability::AutoIncrementAllowedOnNonId,
+    ConnectorCapability::AutoIncrementMultipleAllowed,
+    ConnectorCapability::AutoIncrementNonIndexedAllowed,
+    ConnectorCapability::CompoundIds,
+    ConnectorCapability::CreateMany,
+    ConnectorCapability::CreateManyWriteableAutoIncId,
+    ConnectorCapability::CreateSkipDuplicates,
+    ConnectorCapability::Enums,
+    ConnectorCapability::ForeignKeys,
+    ConnectorCapability::FullTextSearchWithoutIndex,
+    ConnectorCapability::InsensitiveFilters,
+    ConnectorCapability::Json,
+    ConnectorCapability::JsonFilteringArrayPath,
+    ConnectorCapability::NamedForeignKeys,
+    ConnectorCapability::NamedPrimaryKeys,
+    ConnectorCapability::QueryRaw,
+    ConnectorCapability::RelationFieldsInArbitraryOrder,
+    ConnectorCapability::ScalarLists,
+    ConnectorCapability::UpdateableId,
+    ConnectorCapability::WritableAutoincField,
+];
 
-//todo should this also contain the pretty printed output for SQL rendering?
-impl PostgresDatamodelConnector {
-    pub fn new(referential_integrity: ReferentialIntegrity) -> PostgresDatamodelConnector {
-        let mut capabilities = vec![
-            ConnectorCapability::ScalarLists,
-            ConnectorCapability::Enums,
-            ConnectorCapability::Json,
-            ConnectorCapability::AutoIncrementMultipleAllowed,
-            ConnectorCapability::AutoIncrementAllowedOnNonId,
-            ConnectorCapability::AutoIncrementNonIndexedAllowed,
-            ConnectorCapability::InsensitiveFilters,
-            ConnectorCapability::RelationFieldsInArbitraryOrder,
-            ConnectorCapability::CreateMany,
-            ConnectorCapability::WritableAutoincField,
-            ConnectorCapability::CreateSkipDuplicates,
-            ConnectorCapability::UpdateableId,
-            ConnectorCapability::JsonFilteringArrayPath,
-            ConnectorCapability::CreateManyWriteableAutoIncId,
-            ConnectorCapability::AutoIncrement,
-            ConnectorCapability::CompoundIds,
-            ConnectorCapability::AnyId,
-            ConnectorCapability::QueryRaw,
-            ConnectorCapability::NamedPrimaryKeys,
-            ConnectorCapability::NamedForeignKeys,
-            ConnectorCapability::FullTextSearchWithoutIndex,
-            ConnectorCapability::AdvancedJsonNullability,
-        ];
-
-        if referential_integrity.uses_foreign_keys() {
-            capabilities.push(ConnectorCapability::ForeignKeys);
-        }
-
-        PostgresDatamodelConnector {
-            capabilities,
-            referential_integrity,
-        }
-    }
-}
+pub struct PostgresDatamodelConnector;
 
 const SCALAR_TYPE_DEFAULTS: &[(ScalarType, PostgresType)] = &[
     (ScalarType::Int, PostgresType::Integer),
@@ -136,8 +120,8 @@ impl Connector for PostgresDatamodelConnector {
         "Postgres"
     }
 
-    fn capabilities(&self) -> &[ConnectorCapability] {
-        &self.capabilities
+    fn capabilities(&self) -> &'static [ConnectorCapability] {
+        CAPABILITIES
     }
 
     /// The maximum length of postgres identifiers, in bytes.
@@ -147,11 +131,10 @@ impl Connector for PostgresDatamodelConnector {
         63
     }
 
-    fn referential_actions(&self) -> BitFlags<ReferentialAction> {
+    fn referential_actions(&self, referential_integrity: &ReferentialIntegrity) -> BitFlags<ReferentialAction> {
         use ReferentialAction::*;
 
-        self.referential_integrity
-            .allowed_referential_actions(NoAction | Restrict | Cascade | SetNull | SetDefault)
+        referential_integrity.allowed_referential_actions(NoAction | Restrict | Cascade | SetNull | SetDefault)
     }
 
     fn scalar_type_for_native_type(&self, native_type: serde_json::Value) -> ScalarType {

--- a/libs/datamodel/core/src/configuration/datasource.rs
+++ b/libs/datamodel/core/src/configuration/datasource.rs
@@ -17,12 +17,11 @@ pub struct Datasource {
     pub url_span: Span,
     pub documentation: Option<String>,
     /// the connector of the active provider
-    pub active_connector: Box<dyn Connector>,
+    pub active_connector: &'static dyn Connector,
     /// An optional user-defined shadow database URL.
     pub shadow_database_url: Option<(StringFromEnvVar, Span)>,
     /// In which layer referential actions are handled.
     pub referential_integrity: Option<ReferentialIntegrity>,
-    pub default_referential_integrity: ReferentialIntegrity,
 }
 
 impl std::fmt::Debug for Datasource {
@@ -46,8 +45,11 @@ impl Datasource {
         ConnectorCapabilities::new(capabilities)
     }
 
+    /// The applicable referential integrity mode for this datasource.
+    #[allow(clippy::or_fun_call)] // not applicable in this case
     pub fn referential_integrity(&self) -> ReferentialIntegrity {
-        self.referential_integrity.unwrap_or(self.default_referential_integrity)
+        self.referential_integrity
+            .unwrap_or(self.active_connector.default_referential_integrity())
     }
 
     /// Load the database URL, validating it and resolving env vars in the

--- a/libs/datamodel/core/src/transform/ast_to_dml/builtin_datasource_providers.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/builtin_datasource_providers.rs
@@ -1,18 +1,10 @@
 use super::datasource_provider::DatasourceProvider;
 use crate::common::provider_names::*;
-use datamodel_connector::{Connector, ReferentialIntegrity};
+use datamodel_connector::Connector;
 use mongodb_datamodel_connector::MongoDbDatamodelConnector;
 use sql_datamodel_connector::SqlDatamodelConnectors;
 
-pub struct SqliteDatasourceProvider {
-    referential_integrity: ReferentialIntegrity,
-}
-
-impl SqliteDatasourceProvider {
-    pub fn new(referential_integrity: ReferentialIntegrity) -> Self {
-        Self { referential_integrity }
-    }
-}
+pub struct SqliteDatasourceProvider;
 
 impl DatasourceProvider for SqliteDatasourceProvider {
     fn is_provider(&self, provider: &str) -> bool {
@@ -23,20 +15,12 @@ impl DatasourceProvider for SqliteDatasourceProvider {
         SQLITE_SOURCE_NAME
     }
 
-    fn connector(&self) -> Box<dyn Connector> {
-        Box::new(SqlDatamodelConnectors::sqlite(self.referential_integrity))
+    fn connector(&self) -> &'static dyn Connector {
+        SqlDatamodelConnectors::SQLITE
     }
 }
 
-pub struct PostgresDatasourceProvider {
-    referential_integrity: ReferentialIntegrity,
-}
-
-impl PostgresDatasourceProvider {
-    pub fn new(referential_integrity: ReferentialIntegrity) -> Self {
-        Self { referential_integrity }
-    }
-}
+pub struct PostgresDatasourceProvider;
 
 impl DatasourceProvider for PostgresDatasourceProvider {
     fn is_provider(&self, provider: &str) -> bool {
@@ -47,20 +31,12 @@ impl DatasourceProvider for PostgresDatasourceProvider {
         POSTGRES_SOURCE_NAME
     }
 
-    fn connector(&self) -> Box<dyn Connector> {
-        Box::new(SqlDatamodelConnectors::postgres(self.referential_integrity))
+    fn connector(&self) -> &'static dyn Connector {
+        SqlDatamodelConnectors::POSTGRES
     }
 }
 
-pub struct MySqlDatasourceProvider {
-    referential_integrity: ReferentialIntegrity,
-}
-
-impl MySqlDatasourceProvider {
-    pub fn new(referential_integrity: ReferentialIntegrity) -> Self {
-        Self { referential_integrity }
-    }
-}
+pub struct MySqlDatasourceProvider;
 
 impl DatasourceProvider for MySqlDatasourceProvider {
     fn is_provider(&self, provider: &str) -> bool {
@@ -71,20 +47,12 @@ impl DatasourceProvider for MySqlDatasourceProvider {
         MYSQL_SOURCE_NAME
     }
 
-    fn connector(&self) -> Box<dyn Connector> {
-        Box::new(SqlDatamodelConnectors::mysql(self.referential_integrity))
+    fn connector(&self) -> &'static dyn Connector {
+        SqlDatamodelConnectors::MYSQL
     }
 }
 
-pub struct MsSqlDatasourceProvider {
-    referential_integrity: ReferentialIntegrity,
-}
-
-impl MsSqlDatasourceProvider {
-    pub fn new(referential_integrity: ReferentialIntegrity) -> Self {
-        Self { referential_integrity }
-    }
-}
+pub struct MsSqlDatasourceProvider;
 
 impl DatasourceProvider for MsSqlDatasourceProvider {
     fn is_provider(&self, provider: &str) -> bool {
@@ -95,17 +63,12 @@ impl DatasourceProvider for MsSqlDatasourceProvider {
         MSSQL_SOURCE_NAME
     }
 
-    fn connector(&self) -> Box<dyn Connector> {
-        Box::new(SqlDatamodelConnectors::mssql(self.referential_integrity))
+    fn connector(&self) -> &'static dyn Connector {
+        SqlDatamodelConnectors::MSSQL
     }
 }
 
-pub struct MongoDbDatasourceProvider {}
-impl MongoDbDatasourceProvider {
-    pub fn new() -> Self {
-        Self {}
-    }
-}
+pub struct MongoDbDatasourceProvider;
 
 impl DatasourceProvider for MongoDbDatasourceProvider {
     fn is_provider(&self, provider: &str) -> bool {
@@ -116,15 +79,7 @@ impl DatasourceProvider for MongoDbDatasourceProvider {
         MONGODB_SOURCE_NAME
     }
 
-    fn connector(&self) -> Box<dyn Connector> {
-        Box::new(MongoDbDatamodelConnector::new())
-    }
-
-    fn default_referential_integrity(&self) -> ReferentialIntegrity {
-        ReferentialIntegrity::Prisma
-    }
-
-    fn allowed_referential_integrity_settings(&self) -> enumflags2::BitFlags<ReferentialIntegrity> {
-        ReferentialIntegrity::Prisma.into()
+    fn connector(&self) -> &'static dyn Connector {
+        &MongoDbDatamodelConnector
     }
 }

--- a/libs/datamodel/core/src/transform/ast_to_dml/datasource_provider.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/datasource_provider.rs
@@ -1,5 +1,4 @@
-use datamodel_connector::{Connector, ReferentialIntegrity};
-use enumflags2::BitFlags;
+use datamodel_connector::Connector;
 
 pub trait DatasourceProvider {
     /// Passes the provider arg from the datasource. Must return true for all provider names it can handle.
@@ -7,15 +6,5 @@ pub trait DatasourceProvider {
 
     fn canonical_name(&self) -> &str;
 
-    fn connector(&self) -> Box<dyn Connector>;
-
-    fn allowed_referential_integrity_settings(&self) -> BitFlags<ReferentialIntegrity> {
-        use ReferentialIntegrity::*;
-
-        ForeignKeys | Prisma
-    }
-
-    fn default_referential_integrity(&self) -> ReferentialIntegrity {
-        ReferentialIntegrity::ForeignKeys
-    }
+    fn connector(&self) -> &'static dyn Connector;
 }

--- a/libs/datamodel/core/src/transform/ast_to_dml/db.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db.rs
@@ -18,7 +18,7 @@ pub(crate) use types::{RelationField, ScalarField, ScalarFieldType};
 use self::{context::Context, relations::Relations, types::Types};
 use crate::PreviewFeature;
 use crate::{ast, diagnostics::Diagnostics, Datasource};
-use datamodel_connector::{Connector, ConstraintScope, EmptyDatamodelConnector};
+use datamodel_connector::{Connector, ConstraintScope, EmptyDatamodelConnector, ReferentialIntegrity};
 use enumflags2::BitFlags;
 use names::Names;
 
@@ -135,6 +135,12 @@ impl<'ast> ParserDatabase<'ast> {
         self.datasource
     }
 
+    pub(crate) fn active_referential_integrity(&self) -> ReferentialIntegrity {
+        self.datasource()
+            .map(|ds| ds.referential_integrity())
+            .unwrap_or(ReferentialIntegrity::ForeignKeys)
+    }
+
     pub(crate) fn find_model_field(&self, model_id: ast::ModelId, field_name: &str) -> Option<ast::FieldId> {
         self.names.model_fields.get(&(model_id, field_name)).cloned()
     }
@@ -152,7 +158,7 @@ impl<'ast> ParserDatabase<'ast> {
 
     pub(super) fn active_connector(&self) -> &dyn Connector {
         self.datasource
-            .map(|datasource| datasource.active_connector.as_ref())
+            .map(|datasource| datasource.active_connector)
             .unwrap_or(&EmptyDatamodelConnector)
     }
 }

--- a/libs/datamodel/core/src/transform/ast_to_dml/db/walkers/relation.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/walkers/relation.rs
@@ -380,7 +380,11 @@ impl<'ast, 'db> CompleteInlineRelationWalker<'ast, 'db> {
         use ReferentialAction::*;
 
         self.referencing_field().attributes().on_delete.unwrap_or_else(|| {
-            let supports_restrict = self.db.active_connector().supports_referential_action(Restrict);
+            let referential_integrity = self.db.active_referential_integrity();
+            let supports_restrict = self
+                .db
+                .active_connector()
+                .supports_referential_action(&referential_integrity, Restrict);
 
             match self.referential_arity() {
                 ast::FieldArity::Required if supports_restrict => Restrict,

--- a/libs/datamodel/core/src/transform/ast_to_dml/lift.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/lift.rs
@@ -62,6 +62,7 @@ impl<'a> LiftAstToDml<'a> {
         field_ids_for_sorting: &mut HashMap<(&'a str, &'a str), ast::FieldId>,
     ) {
         let active_connector = self.db.active_connector();
+        let referential_integrity = self.db.active_referential_integrity();
         let common_dml_fields = |field: &mut dml::RelationField,
                                  attributes: &super::db::RelationField<'_>,
                                  relation_field: RelationFieldWalker<'_, '_>| {
@@ -73,9 +74,9 @@ impl<'a> LiftAstToDml<'a> {
             field.is_ignored = attributes.is_ignored;
             field.relation_info.fk_name = relation_field.final_foreign_key_name().map(|cow| cow.into_owned());
             field.supports_restrict_action(
-                active_connector.supports_referential_action(dml::ReferentialAction::Restrict),
+                active_connector.supports_referential_action(&referential_integrity, dml::ReferentialAction::Restrict),
             );
-            field.emulates_referential_actions(active_connector.emulates_referential_actions());
+            field.emulates_referential_actions(referential_integrity.is_prisma());
         };
 
         for relation in self.db.walk_relations() {

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations.rs
@@ -37,7 +37,7 @@ pub(super) fn validate(db: &ParserDatabase<'_>, diagnostics: &mut Diagnostics, r
             fields::validate_client_name(field.into(), &names, diagnostics);
 
             relation_fields::ignored_related_model(field, diagnostics);
-            relation_fields::referential_actions(field, connector, diagnostics);
+            relation_fields::referential_actions(field, db, diagnostics);
             relation_fields::on_update_without_foreign_keys(field, referential_integrity, diagnostics);
         }
 
@@ -53,8 +53,8 @@ pub(super) fn validate(db: &ParserDatabase<'_>, diagnostics: &mut Diagnostics, r
                 if let Some(relation) = relation.as_complete() {
                     relations::field_arity(relation, diagnostics);
                     relations::same_length_in_referencing_and_referenced(relation, diagnostics);
-                    relations::cycles(relation, connector, diagnostics);
-                    relations::multiple_cascading_paths(relation, connector, diagnostics);
+                    relations::cycles(relation, db, diagnostics);
+                    relations::multiple_cascading_paths(relation, db, diagnostics);
                     relations::has_a_unique_constraint_name(db, relation, diagnostics);
 
                     // These needs to run last to prevent error spam.

--- a/libs/datamodel/core/src/transform/dml_to_ast/lower_field.rs
+++ b/libs/datamodel/core/src/transform/dml_to_ast/lower_field.rs
@@ -126,7 +126,7 @@ impl<'a> LowerDmlToAst<'a> {
 
             let connector = self
                 .datasource
-                .map(|source| source.active_connector.as_ref())
+                .map(|source| source.active_connector)
                 .unwrap_or(&EmptyDatamodelConnector as &dyn Connector);
 
             let prisma_default = ConstraintNames::default_name(model.name(), field.name(), connector);

--- a/libs/datamodel/core/tests/attributes/id_positive.rs
+++ b/libs/datamodel/core/tests/attributes/id_positive.rs
@@ -30,22 +30,6 @@ fn int_id_with_default_autoincrement_should_have_strategy_auto() {
 }
 
 #[test]
-#[ignore] // bring back when we work on embeds
-fn id_should_also_work_on_embedded_types() {
-    let dml = indoc! {r#"
-        model Model {
-          id Int @id
-
-          @@embedded
-        }
-    "#};
-
-    let datamodel = parse(dml);
-    let user_model = datamodel.assert_has_model("Model");
-    user_model.assert_has_scalar_field("id").assert_is_id(user_model);
-}
-
-#[test]
 fn should_allow_string_ids_with_cuid() {
     let dml = indoc! {r#"
         model Model {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/mssql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/mssql.rs
@@ -9,7 +9,6 @@ use crate::{
     sql_migration::{AlterColumn, ColumnTypeChange},
     sql_schema_differ::ColumnChanges,
 };
-use datamodel_connector::Connector;
 use sql_datamodel_connector::SqlDatamodelConnectors;
 use sql_schema_describer::walkers::ColumnWalker;
 
@@ -47,7 +46,7 @@ impl DestructiveChangeCheckerFlavour for MssqlFlavour {
         match type_change {
             Some(ColumnTypeChange::SafeCast) | None => (),
             Some(ColumnTypeChange::RiskyCast) => {
-                let datamodel_connector = SqlDatamodelConnectors::mssql(Default::default());
+                let datamodel_connector = SqlDatamodelConnectors::MSSQL;
                 let previous_type = match &columns.previous().column_type().native_type {
                     Some(tpe) => datamodel_connector.render_native_type(tpe.clone()),
                     _ => format!("{:?}", columns.previous().column_type_family()),

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/mysql.rs
@@ -9,7 +9,6 @@ use crate::{
     sql_migration::{AlterColumn, ColumnTypeChange},
     sql_schema_differ::ColumnChanges,
 };
-use datamodel_connector::Connector;
 use sql_datamodel_connector::SqlDatamodelConnectors;
 use sql_schema_describer::walkers::ColumnWalker;
 
@@ -52,7 +51,7 @@ impl DestructiveChangeCheckerFlavour for MysqlFlavour {
             return;
         }
 
-        let datamodel_connector = SqlDatamodelConnectors::mysql(Default::default());
+        let datamodel_connector = SqlDatamodelConnectors::MYSQL;
 
         let previous_type = match &columns.previous().column_type().native_type {
             Some(tpe) => datamodel_connector.render_native_type(tpe.clone()),

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/postgres.rs
@@ -9,7 +9,6 @@ use crate::{
     sql_migration::{AlterColumn, ColumnTypeChange},
     sql_schema_differ::ColumnChanges,
 };
-use datamodel_connector::Connector;
 use sql_datamodel_connector::SqlDatamodelConnectors;
 use sql_schema_describer::walkers::ColumnWalker;
 
@@ -48,7 +47,7 @@ impl DestructiveChangeCheckerFlavour for PostgresFlavour {
             )
         }
 
-        let datamodel_connector = SqlDatamodelConnectors::postgres(Default::default());
+        let datamodel_connector = SqlDatamodelConnectors::POSTGRES;
         let previous_type = match &columns.previous().column_type().native_type {
             Some(tpe) => datamodel_connector.render_native_type(tpe.clone()),
             _ => format!("{:?}", columns.previous().column_type_family()),

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/mssql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/mssql.rs
@@ -4,13 +4,11 @@ use datamodel::{
     walkers::{ModelWalker, RelationFieldWalker},
     ScalarType,
 };
-use datamodel_connector::Connector;
 use sql_schema_describer::{self as sql, ForeignKeyAction};
 
 impl SqlSchemaCalculatorFlavour for MssqlFlavour {
     fn default_native_type_for_scalar_type(&self, scalar_type: &ScalarType) -> serde_json::Value {
-        sql_datamodel_connector::SqlDatamodelConnectors::mssql(Default::default())
-            .default_native_type_for_scalar_type(scalar_type)
+        sql_datamodel_connector::SqlDatamodelConnectors::MSSQL.default_native_type_for_scalar_type(scalar_type)
     }
 
     fn m2m_foreign_key_action(&self, model_a: &ModelWalker<'_>, model_b: &ModelWalker<'_>) -> ForeignKeyAction {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/mysql.rs
@@ -4,7 +4,6 @@ use datamodel::{
     walkers::{walk_scalar_fields, ScalarFieldWalker},
     Datamodel, ScalarType,
 };
-use datamodel_connector::Connector;
 use sql_schema_describer as sql;
 
 impl SqlSchemaCalculatorFlavour for MysqlFlavour {
@@ -33,8 +32,7 @@ impl SqlSchemaCalculatorFlavour for MysqlFlavour {
     }
 
     fn default_native_type_for_scalar_type(&self, scalar_type: &ScalarType) -> serde_json::Value {
-        sql_datamodel_connector::SqlDatamodelConnectors::mysql(Default::default())
-            .default_native_type_for_scalar_type(scalar_type)
+        sql_datamodel_connector::SqlDatamodelConnectors::MYSQL.default_native_type_for_scalar_type(scalar_type)
     }
 
     fn enum_column_type(&self, field: &ScalarFieldWalker<'_>, _db_name: &str) -> sql::ColumnType {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/postgres.rs
@@ -1,7 +1,6 @@
 use super::SqlSchemaCalculatorFlavour;
 use crate::flavour::PostgresFlavour;
 use datamodel::{walkers::ScalarFieldWalker, Datamodel, ScalarType, WithDatabaseName};
-use datamodel_connector::Connector;
 use sql_schema_describer::{self as sql};
 
 impl SqlSchemaCalculatorFlavour for PostgresFlavour {
@@ -16,8 +15,7 @@ impl SqlSchemaCalculatorFlavour for PostgresFlavour {
     }
 
     fn default_native_type_for_scalar_type(&self, scalar_type: &ScalarType) -> serde_json::Value {
-        sql_datamodel_connector::PostgresDatamodelConnector::new(Default::default())
-            .default_native_type_for_scalar_type(scalar_type)
+        sql_datamodel_connector::SqlDatamodelConnectors::POSTGRES.default_native_type_for_scalar_type(scalar_type)
     }
 
     fn enum_column_type(&self, field: &ScalarFieldWalker<'_>, db_name: &str) -> sql::ColumnType {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/sqlite.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/sqlite.rs
@@ -1,12 +1,10 @@
 use super::SqlSchemaCalculatorFlavour;
 use crate::flavour::SqliteFlavour;
 use datamodel::{walkers::ScalarFieldWalker, ScalarType};
-use datamodel_connector::Connector;
 
 impl SqlSchemaCalculatorFlavour for SqliteFlavour {
     fn default_native_type_for_scalar_type(&self, scalar_type: &ScalarType) -> serde_json::Value {
-        sql_datamodel_connector::SqlDatamodelConnectors::sqlite(Default::default())
-            .default_native_type_for_scalar_type(scalar_type)
+        sql_datamodel_connector::SqlDatamodelConnectors::SQLITE.default_native_type_for_scalar_type(scalar_type)
     }
 
     // Integer primary keys on SQLite are automatically assigned the rowid, which means they are automatically autoincrementing.

--- a/migration-engine/migration-engine-tests/tests/native_types/mysql.rs
+++ b/migration-engine/migration-engine-tests/tests/native_types/mysql.rs
@@ -748,7 +748,7 @@ fn filter_to_types(api: &TestApi, to_types: &'static [&'static str]) -> Cow<'sta
 
 #[test_connector(tags(Mysql))]
 fn safe_casts_with_existing_data_should_work(api: TestApi) {
-    let connector = sql_datamodel_connector::MySqlDatamodelConnector::new(Default::default());
+    let connector = sql_datamodel_connector::SqlDatamodelConnectors::MYSQL;
     let mut dm1 = String::with_capacity(256);
     let mut dm2 = String::with_capacity(256);
     let colnames = colnames_for_cases(SAFE_CASTS);
@@ -782,7 +782,7 @@ fn safe_casts_with_existing_data_should_work(api: TestApi) {
             to_types.iter().enumerate().fold(
                 table.assert_columns_count(to_types.len() + 1),
                 |table, (idx, to_type)| {
-                    table.assert_column(&colnames[idx], |col| col.assert_native_type(to_type, &connector))
+                    table.assert_column(&colnames[idx], |col| col.assert_native_type(to_type, connector))
                 },
             )
         });
@@ -793,7 +793,7 @@ fn safe_casts_with_existing_data_should_work(api: TestApi) {
 
 #[test_connector(tags(Mysql))]
 fn risky_casts_with_existing_data_should_warn(api: TestApi) {
-    let connector = sql_datamodel_connector::MySqlDatamodelConnector::new(Default::default());
+    let connector = sql_datamodel_connector::SqlDatamodelConnectors::MYSQL;
     let mut dm1 = String::with_capacity(256);
     let mut dm2 = String::with_capacity(256);
     let colnames = colnames_for_cases(RISKY_CASTS);
@@ -845,7 +845,7 @@ fn risky_casts_with_existing_data_should_warn(api: TestApi) {
 
         api.assert_schema().assert_table("Test", |table| {
             to_types.iter().enumerate().fold(table, |table, (idx, to_type)| {
-                table.assert_column(&colnames[idx], |col| col.assert_native_type(to_type, &connector))
+                table.assert_column(&colnames[idx], |col| col.assert_native_type(to_type, connector))
             })
         });
 
@@ -855,7 +855,7 @@ fn risky_casts_with_existing_data_should_warn(api: TestApi) {
 
 #[test_connector(tags(Mysql))]
 fn impossible_casts_with_existing_data_should_warn(api: TestApi) {
-    let connector = sql_datamodel_connector::MySqlDatamodelConnector::new(Default::default());
+    let connector = sql_datamodel_connector::SqlDatamodelConnectors::MYSQL;
     let mut dm1 = String::with_capacity(256);
     let mut dm2 = String::with_capacity(256);
     let colnames = colnames_for_cases(IMPOSSIBLE_CASTS);
@@ -907,7 +907,7 @@ fn impossible_casts_with_existing_data_should_warn(api: TestApi) {
 
         api.assert_schema().assert_table("Test", |table| {
             to_types.iter().enumerate().fold(table, |table, (idx, to_type)| {
-                table.assert_column(&colnames[idx], |col| col.assert_native_type(to_type, &connector))
+                table.assert_column(&colnames[idx], |col| col.assert_native_type(to_type, connector))
             })
         });
 

--- a/migration-engine/migration-engine-tests/tests/native_types/postgres.rs
+++ b/migration-engine/migration-engine-tests/tests/native_types/postgres.rs
@@ -772,7 +772,7 @@ fn prisma_type(native_type: &str) -> &str {
 
 #[test_connector(tags(Postgres))]
 fn safe_casts_with_existing_data_should_work(api: TestApi) {
-    let connector = SqlDatamodelConnectors::postgres(Default::default());
+    let connector = SqlDatamodelConnectors::POSTGRES;
 
     for (from, seed, casts) in SAFE_CASTS.iter() {
         let span = tracing::info_span!("SafeCasts", from = %from, to = ?casts, seed = ?seed);
@@ -831,7 +831,7 @@ fn safe_casts_with_existing_data_should_work(api: TestApi) {
             previous_assertions.iter().fold(
                 table.assert_column_count(previous_assertions.len() + 1),
                 |table, (column_name, expected)| {
-                    table.assert_column(column_name, |c| c.assert_native_type(expected, &connector))
+                    table.assert_column(column_name, |c| c.assert_native_type(expected, connector))
                 },
             )
         });
@@ -852,7 +852,7 @@ fn safe_casts_with_existing_data_should_work(api: TestApi) {
         api.assert_schema().assert_table("A", |table| {
             next_assertions.iter().fold(
                 table.assert_column_count(next_assertions.len() + 1),
-                |table, (name, expected)| table.assert_column(name, |c| c.assert_native_type(expected, &connector)),
+                |table, (name, expected)| table.assert_column(name, |c| c.assert_native_type(expected, connector)),
             )
         });
 
@@ -862,7 +862,7 @@ fn safe_casts_with_existing_data_should_work(api: TestApi) {
 
 #[test_connector(tags(Postgres))]
 fn risky_casts_with_existing_data_should_warn(api: TestApi) {
-    let connector = SqlDatamodelConnectors::postgres(Default::default());
+    let connector = SqlDatamodelConnectors::POSTGRES;
 
     for (from, seed, casts) in RISKY_CASTS.iter() {
         let mut previous_columns = "".to_string();
@@ -925,7 +925,7 @@ fn risky_casts_with_existing_data_should_warn(api: TestApi) {
             previous_assertions.iter().fold(
                 table.assert_column_count(previous_assertions.len() + 1),
                 |table, (column_name, expected)| {
-                    table.assert_column(column_name, |c| c.assert_native_type(expected, &connector))
+                    table.assert_column(column_name, |c| c.assert_native_type(expected, connector))
                 },
             )
         });
@@ -950,7 +950,7 @@ fn risky_casts_with_existing_data_should_warn(api: TestApi) {
             next_assertions.iter().fold(
                 table.assert_column_count(next_assertions.len() + 1),
                 |table, (column_name, expected)| {
-                    table.assert_column(column_name, |c| c.assert_native_type(expected, &connector))
+                    table.assert_column(column_name, |c| c.assert_native_type(expected, connector))
                 },
             )
         });
@@ -961,7 +961,7 @@ fn risky_casts_with_existing_data_should_warn(api: TestApi) {
 
 #[test_connector(tags(Postgres))]
 fn not_castable_with_existing_data_should_warn(api: TestApi) {
-    let connector = SqlDatamodelConnectors::postgres(Default::default());
+    let connector = SqlDatamodelConnectors::POSTGRES;
     let mut warnings = Vec::new();
 
     for (from, seed, casts) in NOT_CASTABLE.iter() {
@@ -1026,7 +1026,7 @@ fn not_castable_with_existing_data_should_warn(api: TestApi) {
             previous_assertions.iter().fold(
                 table.assert_column_count(previous_assertions.len() + 1),
                 |table, (column_name, expected)| {
-                    table.assert_column(column_name, |c| c.assert_native_type(expected, &connector))
+                    table.assert_column(column_name, |c| c.assert_native_type(expected, connector))
                 },
             )
         });
@@ -1050,7 +1050,7 @@ fn not_castable_with_existing_data_should_warn(api: TestApi) {
             previous_assertions.iter().fold(
                 table.assert_column_count(previous_assertions.len() + 1),
                 |table, (column_name, expected)| {
-                    table.assert_column(column_name, |c| c.assert_native_type(expected, &connector))
+                    table.assert_column(column_name, |c| c.assert_native_type(expected, connector))
                 },
             )
         });
@@ -1147,7 +1147,7 @@ static SAFE_CASTS_NON_LIST_TO_STRING: CastList = Lazy::new(|| {
 
 #[test_connector(tags(Postgres))]
 fn safe_casts_from_array_with_existing_data_should_work(api: TestApi) {
-    let connector = SqlDatamodelConnectors::postgres(Default::default());
+    let connector = SqlDatamodelConnectors::POSTGRES;
 
     for (to, from) in SAFE_CASTS_NON_LIST_TO_STRING.iter() {
         let mut previous_columns = "".to_string();
@@ -1201,7 +1201,7 @@ fn safe_casts_from_array_with_existing_data_should_work(api: TestApi) {
             previous_assertions.iter().fold(
                 table.assert_column_count(previous_assertions.len() + 1),
                 |table, (column_name, expected)| {
-                    table.assert_column(column_name, |c| c.assert_native_type(expected, &connector))
+                    table.assert_column(column_name, |c| c.assert_native_type(expected, connector))
                 },
             )
         });
@@ -1222,7 +1222,7 @@ fn safe_casts_from_array_with_existing_data_should_work(api: TestApi) {
         api.assert_schema().assert_table("A", |table| {
             next_assertions.iter().fold(
                 table.assert_column_count(next_assertions.len() + 1),
-                |table, (name, expected)| table.assert_column(name, |c| c.assert_native_type(expected, &connector)),
+                |table, (name, expected)| table.assert_column(name, |c| c.assert_native_type(expected, connector)),
             )
         });
 

--- a/prisma-fmt/src/actions.rs
+++ b/prisma-fmt/src/actions.rs
@@ -6,9 +6,10 @@ pub(crate) fn run(schema: &str) -> String {
             if validated_configuration.subject.datasources.len() != 1 {
                 "[]".to_string()
             } else if let Some(datasource) = validated_configuration.subject.datasources.first() {
+                let referential_integrity = datasource.referential_integrity();
                 let available_referential_actions = datasource
                     .active_connector
-                    .referential_actions()
+                    .referential_actions(&referential_integrity)
                     .iter()
                     .map(|act| format!("{:?}", act))
                     .collect::<Vec<_>>();

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mongodb.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mongodb.rs
@@ -148,6 +148,5 @@ impl ToString for MongoDbVersion {
 }
 
 fn mongo_capabilities() -> Vec<ConnectorCapability> {
-    let dm_connector = MongoDbDatamodelConnector::default();
-    dm_connector.capabilities().to_owned()
+    MongoDbDatamodelConnector.capabilities().to_owned()
 }

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mysql.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mysql.rs
@@ -1,5 +1,4 @@
-use datamodel_connector::Connector;
-use sql_datamodel_connector::MySqlDatamodelConnector;
+use sql_datamodel_connector::SqlDatamodelConnectors;
 
 use super::*;
 use crate::{datamodel_rendering::SqlDatamodelRenderer, TestError, TestResult};
@@ -141,6 +140,5 @@ impl ToString for MySqlVersion {
 }
 
 fn mysql_capabilities() -> Vec<ConnectorCapability> {
-    let dm_connector = MySqlDatamodelConnector::new(Default::default());
-    dm_connector.capabilities().to_owned()
+    SqlDatamodelConnectors::MYSQL.capabilities().to_owned()
 }

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/postgres.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/postgres.rs
@@ -1,9 +1,7 @@
-use datamodel_connector::{Connector, ReferentialIntegrity};
-use sql_datamodel_connector::PostgresDatamodelConnector;
-
-use crate::{datamodel_rendering::SqlDatamodelRenderer, TestError, TestResult};
+use sql_datamodel_connector::SqlDatamodelConnectors;
 
 use super::*;
+use crate::{datamodel_rendering::SqlDatamodelRenderer, TestError, TestResult};
 
 #[derive(Debug, Default, Clone)]
 pub struct PostgresConnectorTag {
@@ -196,6 +194,5 @@ impl ToString for PostgresVersion {
 }
 
 fn postgres_capabilities() -> Vec<ConnectorCapability> {
-    let dm_connector = PostgresDatamodelConnector::new(ReferentialIntegrity::default());
-    dm_connector.capabilities().to_owned()
+    SqlDatamodelConnectors::POSTGRES.capabilities().to_owned()
 }

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/sql_server.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/sql_server.rs
@@ -1,5 +1,4 @@
-use datamodel_connector::{Connector, ReferentialIntegrity};
-use sql_datamodel_connector::MsSqlDatamodelConnector;
+use sql_datamodel_connector::SqlDatamodelConnectors;
 
 use crate::{datamodel_rendering::SqlDatamodelRenderer, TestError, TestResult};
 
@@ -116,6 +115,5 @@ impl ToString for SqlServerVersion {
 }
 
 fn sql_server_capabilities() -> Vec<ConnectorCapability> {
-    let dm_connector = MsSqlDatamodelConnector::new(ReferentialIntegrity::default());
-    dm_connector.capabilities().to_owned()
+    SqlDatamodelConnectors::MSSQL.capabilities().to_owned()
 }

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/sqlite.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/sqlite.rs
@@ -1,5 +1,4 @@
-use datamodel_connector::{Connector, ReferentialIntegrity};
-use sql_datamodel_connector::SqliteDatamodelConnector;
+use sql_datamodel_connector::SqlDatamodelConnectors;
 
 use super::*;
 use crate::SqlDatamodelRenderer;
@@ -54,6 +53,5 @@ impl SqliteConnectorTag {
 }
 
 fn sqlite_capabilities() -> Vec<ConnectorCapability> {
-    let dm_connector = SqliteDatamodelConnector::new(ReferentialIntegrity::default());
-    dm_connector.capabilities().to_owned()
+    SqlDatamodelConnectors::SQLITE.capabilities().to_owned()
 }

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/vitess.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/vitess.rs
@@ -1,10 +1,7 @@
-use std::{fmt::Display, str::FromStr};
-
-use datamodel_connector::{Connector, ReferentialIntegrity};
-use sql_datamodel_connector::MySqlDatamodelConnector;
-
 use super::*;
 use crate::{SqlDatamodelRenderer, TestResult};
+use sql_datamodel_connector::SqlDatamodelConnectors;
+use std::{fmt::Display, str::FromStr};
 
 #[derive(Debug, Default, Clone)]
 pub struct VitessConnectorTag {
@@ -116,6 +113,5 @@ impl Display for VitessVersion {
 }
 
 fn vitess_capabilities() -> Vec<ConnectorCapability> {
-    let dm_connector = MySqlDatamodelConnector::new(ReferentialIntegrity::Prisma);
-    dm_connector.capabilities().to_owned()
+    SqlDatamodelConnectors::MYSQL.capabilities().to_owned()
 }


### PR DESCRIPTION
Similar to the two previous pull requests for constraint scopes and
native type constructors, the datamodel connector is used in parsing:
the parsing rules should be consistent. Making the capabilities const
prevents changing them at runtime, which wouldn't be desirable for
schema validation.

A connector should not dynamically change capabilities. Version
differences and settings based on the prisma schema do not belong in the
datamodel connector — at least not yet and not in a dynamic way.

The referentialIntegrity setting is now stored where it is defined: in the
datasource block.