### PR TITLE
Connector specific length/sort validations

### DIFF
--- a/introspection-engine/connectors/sql-introspection-connector/src/introspection.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/introspection.rs
@@ -66,17 +66,13 @@ pub fn introspect(
             model.add_index(calculate_index(index));
         }
 
-        match &table.primary_key {
-            // TODO: enable with preview flag, when dml index extensions are done.
-            Some(pk) if pk.columns.iter().all(|c| c.length.is_none()) => {
-                model.primary_key = Some(PrimaryKeyDefinition {
-                    name: None,
-                    db_name: pk.constraint_name.clone(),
-                    fields: pk.columns.iter().map(|c| c.name().to_string()).collect(),
-                    defined_on_field: pk.columns.len() == 1,
-                });
-            }
-            _ => (),
+        if let Some(pk) = &table.primary_key {
+            model.primary_key = Some(PrimaryKeyDefinition {
+                name: None,
+                db_name: pk.constraint_name.clone(),
+                fields: pk.columns.iter().map(|c| c.name().to_string()).collect(),
+                defined_on_field: pk.columns.len() == 1,
+            });
         }
 
         version_check.always_has_created_at_updated_at(table, &model);

--- a/libs/datamodel/connectors/datamodel-connector/src/lib.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/lib.rs
@@ -268,6 +268,8 @@ capabilities!(
     NamedForeignKeys,
     ReferenceCycleDetection,
     NamedDefaultValues,
+    IndexColumnLengthPrefixing,
+    PrimaryKeySortOrderDefinition,
     // Start of query-engine-only Capabilities
     InsensitiveFilters,
     CreateMany,

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/mssql_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/mssql_datamodel_connector.rs
@@ -99,6 +99,7 @@ const CAPABILITIES: &[ConnectorCapability] = &[
     ConnectorCapability::QueryRaw,
     ConnectorCapability::ReferenceCycleDetection,
     ConnectorCapability::UpdateableId,
+    ConnectorCapability::PrimaryKeySortOrderDefinition,
 ];
 
 pub struct MsSqlDatamodelConnector;
@@ -412,8 +413,10 @@ impl Connector for MsSqlDatamodelConnector {
     }
 }
 
-static HEAP_ALLOCATED: Lazy<Vec<MsSqlType>> = Lazy::new(|| {
-    vec![
+/// A collection of types stored outside of the row to the heap, having
+/// certain properties such as not allowed in keys or normal indices.
+pub fn heap_allocated_types() -> &'static [MsSqlType] {
+    &[
         Text,
         NText,
         Image,
@@ -422,12 +425,6 @@ static HEAP_ALLOCATED: Lazy<Vec<MsSqlType>> = Lazy::new(|| {
         VarChar(Some(Max)),
         NVarChar(Some(Max)),
     ]
-});
-
-/// A collection of types stored outside of the row to the heap, having
-/// certain properties such as not allowed in keys or normal indices.
-pub fn heap_allocated_types() -> &'static [MsSqlType] {
-    &*HEAP_ALLOCATED
 }
 
 fn arg_vec_for_type_param(type_param: Option<MsSqlTypeParameter>) -> Vec<String> {

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
@@ -112,6 +112,7 @@ const CAPABILITIES: &[ConnectorCapability] = &[
     ConnectorCapability::NamedForeignKeys,
     ConnectorCapability::AdvancedJsonNullability,
     ConnectorCapability::ForeignKeys,
+    ConnectorCapability::IndexColumnLengthPrefixing,
 ];
 
 const CONSTRAINT_SCOPES: &[ConstraintScope] = &[ConstraintScope::GlobalForeignKey, ConstraintScope::ModelKeyIndex];

--- a/libs/datamodel/core/src/ast/model.rs
+++ b/libs/datamodel/core/src/ast/model.rs
@@ -54,13 +54,18 @@ impl Model {
     }
 
     pub(crate) fn id_attribute(&self) -> &Attribute {
+        self.try_id_attribute().unwrap()
+    }
+
+    #[track_caller]
+    pub(crate) fn try_id_attribute(&self) -> Option<&Attribute> {
         let from_model = self.attributes().iter().find(|attr| attr.is_id());
 
         let mut from_field = self
             .iter_fields()
             .flat_map(|(_, field)| field.attributes().iter().find(|attr| attr.is_id()));
 
-        from_model.or_else(|| from_field.next()).unwrap()
+        from_model.or_else(|| from_field.next())
     }
 
     pub(crate) fn name(&self) -> &str {

--- a/libs/datamodel/core/src/transform/ast_to_dml/db/types.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/types.rs
@@ -88,6 +88,15 @@ pub(crate) enum ScalarFieldType {
     Unsupported,
 }
 
+impl ScalarFieldType {
+    pub(crate) fn as_builtin_scalar(self) -> Option<dml::scalars::ScalarType> {
+        match self {
+            ScalarFieldType::BuiltInScalar(s) => Some(s),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub(crate) struct ScalarField<'ast> {
     pub(crate) r#type: ScalarFieldType,

--- a/libs/datamodel/core/src/transform/ast_to_dml/db/walkers/index.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/walkers/index.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use std::borrow::Cow;
 
-use super::{ModelWalker, ScalarFieldWalker};
+use super::{ModelWalker, ScalarFieldAttributeWalker, ScalarFieldWalker};
 
 #[allow(dead_code)]
 #[derive(Copy, Clone)]
@@ -67,6 +67,21 @@ impl<'ast, 'db> IndexWalker<'ast, 'db> {
                 field_id: field_id.field_id,
                 db: self.db,
                 scalar_field: &self.db.types.scalar_fields[&(self.model_id, field_id.field_id)],
+            })
+    }
+
+    pub(crate) fn scalar_field_attributes(
+        self,
+    ) -> impl ExactSizeIterator<Item = ScalarFieldAttributeWalker<'ast, 'db>> + 'db {
+        self.attribute()
+            .fields
+            .iter()
+            .enumerate()
+            .map(move |(field_arg_id, _)| ScalarFieldAttributeWalker {
+                model_id: self.model_id,
+                fields: &self.attribute().fields,
+                db: self.db,
+                field_arg_id,
             })
     }
 

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations.rs
@@ -7,6 +7,7 @@ mod relations;
 
 use self::names::Names;
 use crate::{
+    ast,
     diagnostics::Diagnostics,
     transform::ast_to_dml::db::{walkers::RefinedRelationWalker, ParserDatabase},
 };
@@ -21,6 +22,20 @@ pub(super) fn validate(db: &ParserDatabase<'_>, diagnostics: &mut Diagnostics, r
         models::uses_sort_or_length_on_primary_without_preview_flag(db, model, diagnostics);
         models::primary_key_length_prefix_supported(db, model, diagnostics);
         models::primary_key_sort_order_supported(db, model, diagnostics);
+
+        if let Some(pk) = model.primary_key() {
+            for field_attribute in pk.scalar_field_attributes() {
+                // Type aliases will panic here... :(
+                let span = if pk.has_ast_attribute() {
+                    pk.ast_attribute().span
+                } else {
+                    ast::Span::empty()
+                };
+
+                let attribute = ("id", span);
+                fields::validate_length_used_with_correct_types(db, field_attribute, attribute, diagnostics);
+            }
+        }
 
         for field in model.scalar_fields() {
             fields::validate_client_name(field.into(), &names, diagnostics);
@@ -45,6 +60,16 @@ pub(super) fn validate(db: &ParserDatabase<'_>, diagnostics: &mut Diagnostics, r
             indexes::has_a_unique_constraint_name(db, index, diagnostics);
             indexes::uses_length_or_sort_without_preview_flag(db, index, diagnostics);
             indexes::field_length_prefix_supported(db, index, diagnostics);
+
+            for field_attribute in index.scalar_field_attributes() {
+                let span = index
+                    .ast_attribute()
+                    .map(|attr| attr.span)
+                    .unwrap_or_else(ast::Span::empty);
+
+                let attribute = (index.attribute_name(), span);
+                fields::validate_length_used_with_correct_types(db, field_attribute, attribute, diagnostics);
+            }
         }
     }
 

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations.rs
@@ -19,6 +19,8 @@ pub(super) fn validate(db: &ParserDatabase<'_>, diagnostics: &mut Diagnostics, r
         models::has_a_strict_unique_criteria(model, diagnostics);
         models::has_a_unique_primary_key_name(db, model, diagnostics);
         models::uses_sort_or_length_on_primary_without_preview_flag(db, model, diagnostics);
+        models::primary_key_length_prefix_supported(db, model, diagnostics);
+        models::primary_key_sort_order_supported(db, model, diagnostics);
 
         for field in model.scalar_fields() {
             fields::validate_client_name(field.into(), &names, diagnostics);
@@ -42,6 +44,7 @@ pub(super) fn validate(db: &ParserDatabase<'_>, diagnostics: &mut Diagnostics, r
         for index in model.indexes() {
             indexes::has_a_unique_constraint_name(db, index, diagnostics);
             indexes::uses_length_or_sort_without_preview_flag(db, index, diagnostics);
+            indexes::field_length_prefix_supported(db, index, diagnostics);
         }
     }
 

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/fields.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/fields.rs
@@ -1,8 +1,12 @@
+use datamodel_connector::ConnectorCapability;
+use dml::scalars::ScalarType;
+
 use super::names::{NameTaken, Names};
 use crate::{
+    ast,
     diagnostics::{DatamodelError, Diagnostics},
     transform::ast_to_dml::db::{
-        walkers::{FieldWalker, ScalarFieldWalker},
+        walkers::{FieldWalker, ScalarFieldAttributeWalker, ScalarFieldWalker},
         ConstraintName, ParserDatabase,
     },
 };
@@ -71,4 +75,36 @@ pub(crate) fn has_a_unique_default_constraint_name(
             &message, "default", span,
         ));
     }
+}
+
+pub(crate) fn validate_length_used_with_correct_types(
+    db: &ParserDatabase<'_>,
+    attr: ScalarFieldAttributeWalker<'_, '_>,
+    attribute: (&str, ast::Span),
+    diagnostics: &mut Diagnostics,
+) {
+    if !db
+        .active_connector()
+        .has_capability(ConnectorCapability::IndexColumnLengthPrefixing)
+    {
+        return;
+    }
+
+    if attr.length().is_none() {
+        return;
+    }
+
+    if let Some(r#type) = attr.as_scalar_field().attributes().r#type.as_builtin_scalar() {
+        if [ScalarType::String, ScalarType::Bytes].iter().any(|t| t == &r#type) {
+            return;
+        }
+    };
+
+    let message = "The length argument is only allowed with field types `String` or `Bytes`.";
+
+    diagnostics.push_error(DatamodelError::new_attribute_validation_error(
+        message,
+        attribute.0,
+        attribute.1,
+    ));
 }

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/fields.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/fields.rs
@@ -77,6 +77,7 @@ pub(crate) fn has_a_unique_default_constraint_name(
     }
 }
 
+/// The length prefix can be used with strings and byte columns.
 pub(crate) fn validate_length_used_with_correct_types(
     db: &ParserDatabase<'_>,
     attr: ScalarFieldAttributeWalker<'_, '_>,

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/indexes.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/indexes.rs
@@ -78,7 +78,7 @@ pub(crate) fn field_length_prefix_supported(
     }
 
     if index.scalar_field_attributes().any(|f| f.length().is_some()) {
-        let message = "The length argument is not supported with the current connector";
+        let message = "The length argument is not supported in an index definition with the current connector";
         let span = index.ast_attribute().map(|i| i.span).unwrap_or_else(Span::empty);
 
         diagnostics.push_error(DatamodelError::new_attribute_validation_error(

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/indexes.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/indexes.rs
@@ -46,12 +46,13 @@ pub(crate) fn uses_length_or_sort_without_preview_flag(
     index: IndexWalker<'_, '_>,
     diagnostics: &mut Diagnostics,
 ) {
-    if !db.preview_features.contains(PreviewFeature::ExtendedIndexes)
-        && index
-            .index_attribute
-            .fields
-            .iter()
-            .any(|f| f.sort_order.is_some() || f.length.is_some())
+    if db.preview_features.contains(PreviewFeature::ExtendedIndexes) {
+        return;
+    }
+
+    if index
+        .scalar_field_attributes()
+        .any(|f| f.sort_order().is_some() || f.length().is_some())
     {
         let message = "The sort and length arguments are not yet available.";
 
@@ -76,7 +77,7 @@ pub(crate) fn field_length_prefix_supported(
         return;
     }
 
-    if index.index_attribute.fields.iter().any(|f| f.length.is_some()) {
+    if index.scalar_field_attributes().any(|f| f.length().is_some()) {
         let message = "The length argument is not supported with the current connector";
         let span = index.ast_attribute().map(|i| i.span).unwrap_or_else(Span::empty);
 

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/models.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/models.rs
@@ -124,7 +124,7 @@ pub(crate) fn primary_key_length_prefix_supported(
 
     if let Some(pk) = model.primary_key() {
         if pk.scalar_field_attributes().any(|f| f.length().is_some()) {
-            let message = "The length argument is not supported with the current connector";
+            let message = "The length argument is not supported in the primary key with the current connector";
             let span = pk.ast_attribute().span;
 
             diagnostics.push_error(DatamodelError::new_attribute_validation_error(message, "id", span));
@@ -132,6 +132,7 @@ pub(crate) fn primary_key_length_prefix_supported(
     }
 }
 
+/// Not every database is allowing sort definition in the primary key.
 pub(crate) fn primary_key_sort_order_supported(
     db: &ParserDatabase<'_>,
     model: ModelWalker<'_, '_>,
@@ -146,7 +147,7 @@ pub(crate) fn primary_key_sort_order_supported(
 
     if let Some(pk) = model.primary_key() {
         if pk.scalar_field_attributes().any(|f| f.sort_order().is_some()) {
-            let message = "The sort argument is not supported with the current connector";
+            let message = "The sort argument is not supported in the primary key with the current connector";
             let span = pk.ast_attribute().span;
 
             diagnostics.push_error(DatamodelError::new_attribute_validation_error(message, "id", span));

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/models.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/models.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 
+use datamodel_connector::ConnectorCapability;
 use itertools::Itertools;
 
 use crate::{
@@ -89,16 +90,63 @@ pub(crate) fn uses_sort_or_length_on_primary_without_preview_flag(
     model: ModelWalker<'_, '_>,
     diagnostics: &mut Diagnostics,
 ) {
+    if db.preview_features.contains(PreviewFeature::ExtendedIndexes) {
+        return;
+    }
+
     if let Some(pk) = model.primary_key() {
-        if !db.preview_features.contains(PreviewFeature::ExtendedIndexes)
-            && pk
-                .attribute
-                .fields
-                .iter()
-                .any(|f| f.sort_order.is_some() || f.length.is_some())
+        if pk
+            .attribute
+            .fields
+            .iter()
+            .any(|f| f.sort_order.is_some() || f.length.is_some())
         {
             let message = "The sort and length args are not yet available";
+            let span = pk.ast_attribute().span;
 
+            diagnostics.push_error(DatamodelError::new_attribute_validation_error(message, "id", span));
+        }
+    }
+}
+
+/// The database must support the primary key length prefix for it to be allowed in the data model.
+pub(crate) fn primary_key_length_prefix_supported(
+    db: &ParserDatabase<'_>,
+    model: ModelWalker<'_, '_>,
+    diagnostics: &mut Diagnostics,
+) {
+    if db
+        .active_connector()
+        .has_capability(ConnectorCapability::IndexColumnLengthPrefixing)
+    {
+        return;
+    }
+
+    if let Some(pk) = model.primary_key() {
+        if pk.attribute.fields.iter().any(|f| f.length.is_some()) {
+            let message = "The length argument is not supported with the current connector";
+            let span = pk.ast_attribute().span;
+
+            diagnostics.push_error(DatamodelError::new_attribute_validation_error(message, "id", span));
+        }
+    }
+}
+
+pub(crate) fn primary_key_sort_order_supported(
+    db: &ParserDatabase<'_>,
+    model: ModelWalker<'_, '_>,
+    diagnostics: &mut Diagnostics,
+) {
+    if db
+        .active_connector()
+        .has_capability(ConnectorCapability::PrimaryKeySortOrderDefinition)
+    {
+        return;
+    }
+
+    if let Some(pk) = model.primary_key() {
+        if pk.attribute.fields.iter().any(|f| f.sort_order.is_some()) {
+            let message = "The sort argument is not supported with the current connector";
             let span = pk.ast_attribute().span;
 
             diagnostics.push_error(DatamodelError::new_attribute_validation_error(message, "id", span));

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/models.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/models.rs
@@ -123,7 +123,7 @@ pub(crate) fn primary_key_length_prefix_supported(
     }
 
     if let Some(pk) = model.primary_key() {
-        if pk.attribute.fields.iter().any(|f| f.length.is_some()) {
+        if pk.scalar_field_attributes().any(|f| f.length().is_some()) {
             let message = "The length argument is not supported with the current connector";
             let span = pk.ast_attribute().span;
 
@@ -145,7 +145,7 @@ pub(crate) fn primary_key_sort_order_supported(
     }
 
     if let Some(pk) = model.primary_key() {
-        if pk.attribute.fields.iter().any(|f| f.sort_order.is_some()) {
+        if pk.scalar_field_attributes().any(|f| f.sort_order().is_some()) {
             let message = "The sort argument is not supported with the current connector";
             let span = pk.ast_attribute().span;
 

--- a/libs/datamodel/core/tests/attributes/id_negative.rs
+++ b/libs/datamodel/core/tests/attributes/id_negative.rs
@@ -547,3 +547,343 @@ fn id_does_not_allow_sort_or_index_unless_extended_indexes_are_on() {
 
     expectation.assert_eq(&error)
 }
+
+#[test]
+fn mysql_does_not_allow_id_sort_argument() {
+    let dml = indoc! {r#"
+        model A {
+          id Int @id(sort: Desc)
+        }
+    "#};
+
+    let schema = with_header(dml, Provider::Mysql, &["extendedIndexes"]);
+    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@id": The sort argument is not supported with the current connector[0m
+          [1;94m-->[0m  [4mschema.prisma:12[0m
+        [1;94m   | [0m
+        [1;94m11 | [0mmodel A {
+        [1;94m12 | [0m  id Int @[1;91mid(sort: Desc)[0m
+        [1;94m   | [0m
+    "#]];
+
+    expectation.assert_eq(&error)
+}
+
+#[test]
+fn mysql_does_not_allow_compound_id_sort_argument() {
+    let dml = indoc! {r#"
+        model A {
+          a String @test.VarChar(255)
+          b String @test.VarChar(255)
+
+          @@id([a(sort: Asc), b(sort: Desc)])
+        }
+    "#};
+
+    let schema = with_header(dml, Provider::Mysql, &["extendedIndexes"]);
+    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@id": The sort argument is not supported with the current connector[0m
+          [1;94m-->[0m  [4mschema.prisma:15[0m
+        [1;94m   | [0m
+        [1;94m14 | [0m
+        [1;94m15 | [0m  @@[1;91mid([a(sort: Asc), b(sort: Desc)])[0m
+        [1;94m   | [0m
+    "#]];
+
+    expectation.assert_eq(&error)
+}
+
+#[test]
+fn postgresql_does_not_allow_id_sort_argument() {
+    let dml = indoc! {r#"
+        model A {
+          id Int @id(sort: Desc)
+        }
+    "#};
+
+    let schema = with_header(dml, Provider::Postgres, &["extendedIndexes"]);
+    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@id": The sort argument is not supported with the current connector[0m
+          [1;94m-->[0m  [4mschema.prisma:12[0m
+        [1;94m   | [0m
+        [1;94m11 | [0mmodel A {
+        [1;94m12 | [0m  id Int @[1;91mid(sort: Desc)[0m
+        [1;94m   | [0m
+    "#]];
+
+    expectation.assert_eq(&error)
+}
+
+#[test]
+fn postgresql_does_not_allow_compound_id_sort_argument() {
+    let dml = indoc! {r#"
+        model A {
+          a String @test.VarChar(255)
+          b String @test.VarChar(255)
+
+          @@id([a(sort: Asc), b(sort: Desc)])
+        }
+    "#};
+
+    let schema = with_header(dml, Provider::Postgres, &["extendedIndexes"]);
+    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@id": The sort argument is not supported with the current connector[0m
+          [1;94m-->[0m  [4mschema.prisma:15[0m
+        [1;94m   | [0m
+        [1;94m14 | [0m
+        [1;94m15 | [0m  @@[1;91mid([a(sort: Asc), b(sort: Desc)])[0m
+        [1;94m   | [0m
+    "#]];
+
+    expectation.assert_eq(&error)
+}
+
+#[test]
+fn sqlite_does_not_allow_id_sort_argument() {
+    let dml = indoc! {r#"
+        model A {
+          id Int @id(sort: Desc)
+        }
+    "#};
+
+    let schema = with_header(dml, Provider::Postgres, &["extendedIndexes"]);
+    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@id": The sort argument is not supported with the current connector[0m
+          [1;94m-->[0m  [4mschema.prisma:12[0m
+        [1;94m   | [0m
+        [1;94m11 | [0mmodel A {
+        [1;94m12 | [0m  id Int @[1;91mid(sort: Desc)[0m
+        [1;94m   | [0m
+    "#]];
+
+    expectation.assert_eq(&error)
+}
+
+#[test]
+fn mongodb_does_not_allow_id_sort_argument() {
+    let dml = indoc! {r#"
+        model A {
+          id String @id(sort: Desc) @map("_id") @test.ObjectId
+        }
+    "#};
+
+    let schema = with_header(dml, Provider::Mongo, &["extendedIndexes", "mongoDb"]);
+    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@id": The sort argument is not supported with the current connector[0m
+          [1;94m-->[0m  [4mschema.prisma:12[0m
+        [1;94m   | [0m
+        [1;94m11 | [0mmodel A {
+        [1;94m12 | [0m  id String @[1;91mid(sort: Desc)[0m @map("_id") @test.ObjectId
+        [1;94m   | [0m
+    "#]];
+
+    expectation.assert_eq(&error)
+}
+
+#[test]
+fn sqlite_does_not_allow_compound_id_sort_argument() {
+    let dml = indoc! {r#"
+        model A {
+          a String
+          b String
+
+          @@id([a(sort: Asc), b(sort: Desc)])
+        }
+    "#};
+
+    let schema = with_header(dml, Provider::Sqlite, &["extendedIndexes"]);
+    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@id": The sort argument is not supported with the current connector[0m
+          [1;94m-->[0m  [4mschema.prisma:15[0m
+        [1;94m   | [0m
+        [1;94m14 | [0m
+        [1;94m15 | [0m  @@[1;91mid([a(sort: Asc), b(sort: Desc)])[0m
+        [1;94m   | [0m
+    "#]];
+
+    expectation.assert_eq(&error)
+}
+
+#[test]
+fn postgresql_does_not_allow_id_length_prefix() {
+    let dml = indoc! {r#"
+        model A {
+          id String @id(length: 10)
+        }
+    "#};
+
+    let schema = with_header(dml, Provider::Postgres, &["extendedIndexes"]);
+    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@id": The length argument is not supported with the current connector[0m
+          [1;94m-->[0m  [4mschema.prisma:12[0m
+        [1;94m   | [0m
+        [1;94m11 | [0mmodel A {
+        [1;94m12 | [0m  id String @[1;91mid(length: 10)[0m
+        [1;94m   | [0m
+    "#]];
+
+    expectation.assert_eq(&error)
+}
+
+#[test]
+fn postgresql_does_not_allow_compound_id_length_prefix() {
+    let dml = indoc! {r#"
+        model A {
+          a String
+          b String
+
+          @@id([a(length: 10), b(length: 20)])
+        }
+    "#};
+
+    let schema = with_header(dml, Provider::Postgres, &["extendedIndexes"]);
+    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@id": The length argument is not supported with the current connector[0m
+          [1;94m-->[0m  [4mschema.prisma:15[0m
+        [1;94m   | [0m
+        [1;94m14 | [0m
+        [1;94m15 | [0m  @@[1;91mid([a(length: 10), b(length: 20)])[0m
+        [1;94m   | [0m
+    "#]];
+
+    expectation.assert_eq(&error)
+}
+
+#[test]
+fn sqlserver_does_not_allow_id_length_prefix() {
+    let dml = indoc! {r#"
+        model A {
+          id String @id(length: 10)
+        }
+    "#};
+
+    let schema = with_header(dml, Provider::SqlServer, &["extendedIndexes"]);
+    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@id": The length argument is not supported with the current connector[0m
+          [1;94m-->[0m  [4mschema.prisma:12[0m
+        [1;94m   | [0m
+        [1;94m11 | [0mmodel A {
+        [1;94m12 | [0m  id String @[1;91mid(length: 10)[0m
+        [1;94m   | [0m
+    "#]];
+
+    expectation.assert_eq(&error)
+}
+
+#[test]
+fn sqlserver_does_not_allow_compound_id_length_prefix() {
+    let dml = indoc! {r#"
+        model A {
+          a String
+          b String
+
+          @@id([a(length: 10), b(length: 20)])
+        }
+    "#};
+
+    let schema = with_header(dml, Provider::SqlServer, &["extendedIndexes"]);
+    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@id": The length argument is not supported with the current connector[0m
+          [1;94m-->[0m  [4mschema.prisma:15[0m
+        [1;94m   | [0m
+        [1;94m14 | [0m
+        [1;94m15 | [0m  @@[1;91mid([a(length: 10), b(length: 20)])[0m
+        [1;94m   | [0m
+    "#]];
+
+    expectation.assert_eq(&error)
+}
+
+#[test]
+fn sqlite_does_not_allow_id_length_prefix() {
+    let dml = indoc! {r#"
+        model A {
+          id String @id(length: 10)
+        }
+    "#};
+
+    let schema = with_header(dml, Provider::Sqlite, &["extendedIndexes"]);
+    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@id": The length argument is not supported with the current connector[0m
+          [1;94m-->[0m  [4mschema.prisma:12[0m
+        [1;94m   | [0m
+        [1;94m11 | [0mmodel A {
+        [1;94m12 | [0m  id String @[1;91mid(length: 10)[0m
+        [1;94m   | [0m
+    "#]];
+
+    expectation.assert_eq(&error)
+}
+
+#[test]
+fn mongodb_does_not_allow_id_length_prefix() {
+    let dml = indoc! {r#"
+        model A {
+          id String @id(length: 10) @map("_id") @test.ObjectId
+        }
+    "#};
+
+    let schema = with_header(dml, Provider::Mongo, &["extendedIndexes", "mongoDb"]);
+    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@id": The length argument is not supported with the current connector[0m
+          [1;94m-->[0m  [4mschema.prisma:12[0m
+        [1;94m   | [0m
+        [1;94m11 | [0mmodel A {
+        [1;94m12 | [0m  id String @[1;91mid(length: 10)[0m @map("_id") @test.ObjectId
+        [1;94m   | [0m
+    "#]];
+
+    expectation.assert_eq(&error)
+}
+
+#[test]
+fn sqlite_does_not_allow_compound_id_length_prefix() {
+    let dml = indoc! {r#"
+        model A {
+          a String
+          b String
+
+          @@id([a(length: 10), b(length: 20)])
+        }
+    "#};
+
+    let schema = with_header(dml, Provider::Sqlite, &["extendedIndexes"]);
+    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@id": The length argument is not supported with the current connector[0m
+          [1;94m-->[0m  [4mschema.prisma:15[0m
+        [1;94m   | [0m
+        [1;94m14 | [0m
+        [1;94m15 | [0m  @@[1;91mid([a(length: 10), b(length: 20)])[0m
+        [1;94m   | [0m
+    "#]];
+
+    expectation.assert_eq(&error)
+}

--- a/libs/datamodel/core/tests/attributes/id_negative.rs
+++ b/libs/datamodel/core/tests/attributes/id_negative.rs
@@ -887,3 +887,164 @@ fn sqlite_does_not_allow_compound_id_length_prefix() {
 
     expectation.assert_eq(&error)
 }
+
+#[test]
+fn length_argument_does_not_work_with_decimal() {
+    let dml = indoc! {r#"
+        model A {
+          id Decimal @id(length: 10)
+        }
+    "#};
+
+    let schema = with_header(dml, Provider::Mysql, &["extendedIndexes"]);
+    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@id": The length argument is only allowed with field types `String` or `Bytes`.[0m
+          [1;94m-->[0m  [4mschema.prisma:12[0m
+        [1;94m   | [0m
+        [1;94m11 | [0mmodel A {
+        [1;94m12 | [0m  id Decimal @[1;91mid(length: 10)[0m
+        [1;94m   | [0m
+    "#]];
+
+    expectation.assert_eq(&error)
+}
+
+#[test]
+fn length_argument_does_not_work_with_json() {
+    let dml = indoc! {r#"
+        model A {
+          id Json @id(length: 10)
+        }
+    "#};
+
+    let schema = with_header(dml, Provider::Mysql, &["extendedIndexes"]);
+    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@id": The length argument is only allowed with field types `String` or `Bytes`.[0m
+          [1;94m-->[0m  [4mschema.prisma:12[0m
+        [1;94m   | [0m
+        [1;94m11 | [0mmodel A {
+        [1;94m12 | [0m  id Json @[1;91mid(length: 10)[0m
+        [1;94m   | [0m
+    "#]];
+
+    expectation.assert_eq(&error)
+}
+
+#[test]
+fn length_argument_does_not_work_with_datetime() {
+    let dml = indoc! {r#"
+        model A {
+          id DateTime @id(length: 10)
+        }
+    "#};
+
+    let schema = with_header(dml, Provider::Mysql, &["extendedIndexes"]);
+    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@id": The length argument is only allowed with field types `String` or `Bytes`.[0m
+          [1;94m-->[0m  [4mschema.prisma:12[0m
+        [1;94m   | [0m
+        [1;94m11 | [0mmodel A {
+        [1;94m12 | [0m  id DateTime @[1;91mid(length: 10)[0m
+        [1;94m   | [0m
+    "#]];
+
+    expectation.assert_eq(&error)
+}
+
+#[test]
+fn length_argument_does_not_work_with_boolean() {
+    let dml = indoc! {r#"
+        model A {
+          id Boolean @id(length: 10)
+        }
+    "#};
+
+    let schema = with_header(dml, Provider::Mysql, &["extendedIndexes"]);
+    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@id": The length argument is only allowed with field types `String` or `Bytes`.[0m
+          [1;94m-->[0m  [4mschema.prisma:12[0m
+        [1;94m   | [0m
+        [1;94m11 | [0mmodel A {
+        [1;94m12 | [0m  id Boolean @[1;91mid(length: 10)[0m
+        [1;94m   | [0m
+    "#]];
+
+    expectation.assert_eq(&error)
+}
+
+#[test]
+fn length_argument_does_not_work_with_float() {
+    let dml = indoc! {r#"
+        model A {
+          id Float @id(length: 10)
+        }
+    "#};
+
+    let schema = with_header(dml, Provider::Mysql, &["extendedIndexes"]);
+    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@id": The length argument is only allowed with field types `String` or `Bytes`.[0m
+          [1;94m-->[0m  [4mschema.prisma:12[0m
+        [1;94m   | [0m
+        [1;94m11 | [0mmodel A {
+        [1;94m12 | [0m  id Float @[1;91mid(length: 10)[0m
+        [1;94m   | [0m
+    "#]];
+
+    expectation.assert_eq(&error)
+}
+
+#[test]
+fn length_argument_does_not_work_with_bigint() {
+    let dml = indoc! {r#"
+        model A {
+          id BigInt @id(length: 10)
+        }
+    "#};
+
+    let schema = with_header(dml, Provider::Mysql, &["extendedIndexes"]);
+    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@id": The length argument is only allowed with field types `String` or `Bytes`.[0m
+          [1;94m-->[0m  [4mschema.prisma:12[0m
+        [1;94m   | [0m
+        [1;94m11 | [0mmodel A {
+        [1;94m12 | [0m  id BigInt @[1;91mid(length: 10)[0m
+        [1;94m   | [0m
+    "#]];
+
+    expectation.assert_eq(&error)
+}
+
+#[test]
+fn length_argument_does_not_work_with_int() {
+    let dml = indoc! {r#"
+        model A {
+          id Int @id(length: 10)
+        }
+    "#};
+
+    let schema = with_header(dml, Provider::Mysql, &["extendedIndexes"]);
+    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@id": The length argument is only allowed with field types `String` or `Bytes`.[0m
+          [1;94m-->[0m  [4mschema.prisma:12[0m
+        [1;94m   | [0m
+        [1;94m11 | [0mmodel A {
+        [1;94m12 | [0m  id Int @[1;91mid(length: 10)[0m
+        [1;94m   | [0m
+    "#]];
+
+    expectation.assert_eq(&error)
+}

--- a/libs/datamodel/core/tests/attributes/id_negative.rs
+++ b/libs/datamodel/core/tests/attributes/id_negative.rs
@@ -560,7 +560,7 @@ fn mysql_does_not_allow_id_sort_argument() {
     let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
 
     let expectation = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@id": The sort argument is not supported with the current connector[0m
+        [1;91merror[0m: [1mError parsing attribute "@id": The sort argument is not supported in the primary key with the current connector[0m
           [1;94m-->[0m  [4mschema.prisma:12[0m
         [1;94m   | [0m
         [1;94m11 | [0mmodel A {
@@ -586,7 +586,7 @@ fn mysql_does_not_allow_compound_id_sort_argument() {
     let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
 
     let expectation = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@id": The sort argument is not supported with the current connector[0m
+        [1;91merror[0m: [1mError parsing attribute "@id": The sort argument is not supported in the primary key with the current connector[0m
           [1;94m-->[0m  [4mschema.prisma:15[0m
         [1;94m   | [0m
         [1;94m14 | [0m
@@ -609,7 +609,7 @@ fn postgresql_does_not_allow_id_sort_argument() {
     let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
 
     let expectation = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@id": The sort argument is not supported with the current connector[0m
+        [1;91merror[0m: [1mError parsing attribute "@id": The sort argument is not supported in the primary key with the current connector[0m
           [1;94m-->[0m  [4mschema.prisma:12[0m
         [1;94m   | [0m
         [1;94m11 | [0mmodel A {
@@ -635,7 +635,7 @@ fn postgresql_does_not_allow_compound_id_sort_argument() {
     let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
 
     let expectation = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@id": The sort argument is not supported with the current connector[0m
+        [1;91merror[0m: [1mError parsing attribute "@id": The sort argument is not supported in the primary key with the current connector[0m
           [1;94m-->[0m  [4mschema.prisma:15[0m
         [1;94m   | [0m
         [1;94m14 | [0m
@@ -658,7 +658,7 @@ fn sqlite_does_not_allow_id_sort_argument() {
     let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
 
     let expectation = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@id": The sort argument is not supported with the current connector[0m
+        [1;91merror[0m: [1mError parsing attribute "@id": The sort argument is not supported in the primary key with the current connector[0m
           [1;94m-->[0m  [4mschema.prisma:12[0m
         [1;94m   | [0m
         [1;94m11 | [0mmodel A {
@@ -681,7 +681,7 @@ fn mongodb_does_not_allow_id_sort_argument() {
     let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
 
     let expectation = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@id": The sort argument is not supported with the current connector[0m
+        [1;91merror[0m: [1mError parsing attribute "@id": The sort argument is not supported in the primary key with the current connector[0m
           [1;94m-->[0m  [4mschema.prisma:12[0m
         [1;94m   | [0m
         [1;94m11 | [0mmodel A {
@@ -707,7 +707,7 @@ fn sqlite_does_not_allow_compound_id_sort_argument() {
     let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
 
     let expectation = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@id": The sort argument is not supported with the current connector[0m
+        [1;91merror[0m: [1mError parsing attribute "@id": The sort argument is not supported in the primary key with the current connector[0m
           [1;94m-->[0m  [4mschema.prisma:15[0m
         [1;94m   | [0m
         [1;94m14 | [0m
@@ -730,7 +730,7 @@ fn postgresql_does_not_allow_id_length_prefix() {
     let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
 
     let expectation = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@id": The length argument is not supported with the current connector[0m
+        [1;91merror[0m: [1mError parsing attribute "@id": The length argument is not supported in the primary key with the current connector[0m
           [1;94m-->[0m  [4mschema.prisma:12[0m
         [1;94m   | [0m
         [1;94m11 | [0mmodel A {
@@ -756,7 +756,7 @@ fn postgresql_does_not_allow_compound_id_length_prefix() {
     let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
 
     let expectation = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@id": The length argument is not supported with the current connector[0m
+        [1;91merror[0m: [1mError parsing attribute "@id": The length argument is not supported in the primary key with the current connector[0m
           [1;94m-->[0m  [4mschema.prisma:15[0m
         [1;94m   | [0m
         [1;94m14 | [0m
@@ -779,7 +779,7 @@ fn sqlserver_does_not_allow_id_length_prefix() {
     let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
 
     let expectation = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@id": The length argument is not supported with the current connector[0m
+        [1;91merror[0m: [1mError parsing attribute "@id": The length argument is not supported in the primary key with the current connector[0m
           [1;94m-->[0m  [4mschema.prisma:12[0m
         [1;94m   | [0m
         [1;94m11 | [0mmodel A {
@@ -805,7 +805,7 @@ fn sqlserver_does_not_allow_compound_id_length_prefix() {
     let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
 
     let expectation = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@id": The length argument is not supported with the current connector[0m
+        [1;91merror[0m: [1mError parsing attribute "@id": The length argument is not supported in the primary key with the current connector[0m
           [1;94m-->[0m  [4mschema.prisma:15[0m
         [1;94m   | [0m
         [1;94m14 | [0m
@@ -828,7 +828,7 @@ fn sqlite_does_not_allow_id_length_prefix() {
     let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
 
     let expectation = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@id": The length argument is not supported with the current connector[0m
+        [1;91merror[0m: [1mError parsing attribute "@id": The length argument is not supported in the primary key with the current connector[0m
           [1;94m-->[0m  [4mschema.prisma:12[0m
         [1;94m   | [0m
         [1;94m11 | [0mmodel A {
@@ -851,7 +851,7 @@ fn mongodb_does_not_allow_id_length_prefix() {
     let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
 
     let expectation = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@id": The length argument is not supported with the current connector[0m
+        [1;91merror[0m: [1mError parsing attribute "@id": The length argument is not supported in the primary key with the current connector[0m
           [1;94m-->[0m  [4mschema.prisma:12[0m
         [1;94m   | [0m
         [1;94m11 | [0mmodel A {
@@ -877,7 +877,7 @@ fn sqlite_does_not_allow_compound_id_length_prefix() {
     let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
 
     let expectation = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@id": The length argument is not supported with the current connector[0m
+        [1;91merror[0m: [1mError parsing attribute "@id": The length argument is not supported in the primary key with the current connector[0m
           [1;94m-->[0m  [4mschema.prisma:15[0m
         [1;94m   | [0m
         [1;94m14 | [0m

--- a/libs/datamodel/core/tests/attributes/index_negative.rs
+++ b/libs/datamodel/core/tests/attributes/index_negative.rs
@@ -151,7 +151,7 @@ fn postgres_disallows_unique_length_prefix() {
     let error = datamodel::parse_schema(&dml).map(drop).unwrap_err();
 
     let expectation = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@unique": The length argument is not supported with the current connector[0m
+        [1;91merror[0m: [1mError parsing attribute "@unique": The length argument is not supported in an index definition with the current connector[0m
           [1;94m-->[0m  [4mschema.prisma:12[0m
         [1;94m   | [0m
         [1;94m11 | [0mmodel A {
@@ -176,7 +176,7 @@ fn postgres_disallows_compound_unique_length_prefix() {
     let error = datamodel::parse_schema(&dml).map(drop).unwrap_err();
 
     let expectation = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@unique": The length argument is not supported with the current connector[0m
+        [1;91merror[0m: [1mError parsing attribute "@unique": The length argument is not supported in an index definition with the current connector[0m
           [1;94m-->[0m  [4mschema.prisma:14[0m
         [1;94m   | [0m
         [1;94m13 | [0m  b String
@@ -202,7 +202,7 @@ fn postgres_disallows_index_length_prefix() {
     let error = datamodel::parse_schema(&dml).map(drop).unwrap_err();
 
     let expectation = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@index": The length argument is not supported with the current connector[0m
+        [1;91merror[0m: [1mError parsing attribute "@index": The length argument is not supported in an index definition with the current connector[0m
           [1;94m-->[0m  [4mschema.prisma:15[0m
         [1;94m   | [0m
         [1;94m14 | [0m
@@ -225,7 +225,7 @@ fn sqlserver_disallows_unique_length_prefix() {
     let error = datamodel::parse_schema(&dml).map(drop).unwrap_err();
 
     let expectation = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@unique": The length argument is not supported with the current connector[0m
+        [1;91merror[0m: [1mError parsing attribute "@unique": The length argument is not supported in an index definition with the current connector[0m
           [1;94m-->[0m  [4mschema.prisma:12[0m
         [1;94m   | [0m
         [1;94m11 | [0mmodel A {
@@ -250,7 +250,7 @@ fn sqlserver_disallows_compound_unique_length_prefix() {
     let error = datamodel::parse_schema(&dml).map(drop).unwrap_err();
 
     let expectation = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@unique": The length argument is not supported with the current connector[0m
+        [1;91merror[0m: [1mError parsing attribute "@unique": The length argument is not supported in an index definition with the current connector[0m
           [1;94m-->[0m  [4mschema.prisma:14[0m
         [1;94m   | [0m
         [1;94m13 | [0m  b String
@@ -276,7 +276,7 @@ fn sqlserver_disallows_index_length_prefix() {
     let error = datamodel::parse_schema(&dml).map(drop).unwrap_err();
 
     let expectation = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@index": The length argument is not supported with the current connector[0m
+        [1;91merror[0m: [1mError parsing attribute "@index": The length argument is not supported in an index definition with the current connector[0m
           [1;94m-->[0m  [4mschema.prisma:15[0m
         [1;94m   | [0m
         [1;94m14 | [0m
@@ -299,7 +299,7 @@ fn sqlite_disallows_unique_length_prefix() {
     let error = datamodel::parse_schema(&dml).map(drop).unwrap_err();
 
     let expectation = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@unique": The length argument is not supported with the current connector[0m
+        [1;91merror[0m: [1mError parsing attribute "@unique": The length argument is not supported in an index definition with the current connector[0m
           [1;94m-->[0m  [4mschema.prisma:12[0m
         [1;94m   | [0m
         [1;94m11 | [0mmodel A {
@@ -324,7 +324,7 @@ fn sqlite_disallows_compound_unique_length_prefix() {
     let error = datamodel::parse_schema(&dml).map(drop).unwrap_err();
 
     let expectation = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@unique": The length argument is not supported with the current connector[0m
+        [1;91merror[0m: [1mError parsing attribute "@unique": The length argument is not supported in an index definition with the current connector[0m
           [1;94m-->[0m  [4mschema.prisma:14[0m
         [1;94m   | [0m
         [1;94m13 | [0m  b String
@@ -350,7 +350,7 @@ fn sqlite_disallows_index_length_prefix() {
     let error = datamodel::parse_schema(&dml).map(drop).unwrap_err();
 
     let expectation = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@index": The length argument is not supported with the current connector[0m
+        [1;91merror[0m: [1mError parsing attribute "@index": The length argument is not supported in an index definition with the current connector[0m
           [1;94m-->[0m  [4mschema.prisma:15[0m
         [1;94m   | [0m
         [1;94m14 | [0m
@@ -374,7 +374,7 @@ fn mongodb_disallows_unique_length_prefix() {
     let error = datamodel::parse_schema(&dml).map(drop).unwrap_err();
 
     let expectation = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@unique": The length argument is not supported with the current connector[0m
+        [1;91merror[0m: [1mError parsing attribute "@unique": The length argument is not supported in an index definition with the current connector[0m
           [1;94m-->[0m  [4mschema.prisma:13[0m
         [1;94m   | [0m
         [1;94m12 | [0m  id String @id @map("_id") @test.ObjectId
@@ -400,7 +400,7 @@ fn mongodb_disallows_compound_unique_length_prefix() {
     let error = datamodel::parse_schema(&dml).map(drop).unwrap_err();
 
     let expectation = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@unique": The length argument is not supported with the current connector[0m
+        [1;91merror[0m: [1mError parsing attribute "@unique": The length argument is not supported in an index definition with the current connector[0m
           [1;94m-->[0m  [4mschema.prisma:15[0m
         [1;94m   | [0m
         [1;94m14 | [0m  b String
@@ -426,7 +426,7 @@ fn mongodb_disallows_index_length_prefix() {
     let error = datamodel::parse_schema(&dml).map(drop).unwrap_err();
 
     let expectation = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@index": The length argument is not supported with the current connector[0m
+        [1;91merror[0m: [1mError parsing attribute "@index": The length argument is not supported in an index definition with the current connector[0m
           [1;94m-->[0m  [4mschema.prisma:15[0m
         [1;94m   | [0m
         [1;94m14 | [0m

--- a/libs/datamodel/core/tests/attributes/index_negative.rs
+++ b/libs/datamodel/core/tests/attributes/index_negative.rs
@@ -138,3 +138,301 @@ fn index_does_not_accept_sort_or_length_without_extended_indexes() {
 
     expectation.assert_eq(&error)
 }
+
+#[test]
+fn postgres_disallows_unique_length_prefix() {
+    let dml = indoc! {r#"
+        model A {
+          id String @unique(length: 30) @test.VarChar(255)
+        }
+    "#};
+
+    let dml = with_header(dml, Provider::Postgres, &["extendedIndexes"]);
+    let error = datamodel::parse_schema(&dml).map(drop).unwrap_err();
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@unique": The length argument is not supported with the current connector[0m
+          [1;94m-->[0m  [4mschema.prisma:12[0m
+        [1;94m   | [0m
+        [1;94m11 | [0mmodel A {
+        [1;94m12 | [0m  id String @[1;91munique(length: 30)[0m @test.VarChar(255)
+        [1;94m   | [0m
+    "#]];
+
+    expectation.assert_eq(&error)
+}
+
+#[test]
+fn postgres_disallows_compound_unique_length_prefix() {
+    let dml = indoc! {r#"
+        model A {
+          a String
+          b String
+          @@unique([a(length: 10), b(length: 30)])
+        }
+    "#};
+
+    let dml = with_header(dml, Provider::Postgres, &["extendedIndexes"]);
+    let error = datamodel::parse_schema(&dml).map(drop).unwrap_err();
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@unique": The length argument is not supported with the current connector[0m
+          [1;94m-->[0m  [4mschema.prisma:14[0m
+        [1;94m   | [0m
+        [1;94m13 | [0m  b String
+        [1;94m14 | [0m  @@[1;91munique([a(length: 10), b(length: 30)])[0m
+        [1;94m   | [0m
+    "#]];
+
+    expectation.assert_eq(&error)
+}
+
+#[test]
+fn postgres_disallows_index_length_prefix() {
+    let dml = indoc! {r#"
+        model A {
+          id Int @id
+          a String
+
+          @@index([a(length: 10)])
+        }
+    "#};
+
+    let dml = with_header(dml, Provider::Postgres, &["extendedIndexes"]);
+    let error = datamodel::parse_schema(&dml).map(drop).unwrap_err();
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@index": The length argument is not supported with the current connector[0m
+          [1;94m-->[0m  [4mschema.prisma:15[0m
+        [1;94m   | [0m
+        [1;94m14 | [0m
+        [1;94m15 | [0m  @@[1;91mindex([a(length: 10)])[0m
+        [1;94m   | [0m
+    "#]];
+
+    expectation.assert_eq(&error)
+}
+
+#[test]
+fn sqlserver_disallows_unique_length_prefix() {
+    let dml = indoc! {r#"
+        model A {
+          id String @unique(length: 30) @test.VarChar(255)
+        }
+    "#};
+
+    let dml = with_header(dml, Provider::SqlServer, &["extendedIndexes"]);
+    let error = datamodel::parse_schema(&dml).map(drop).unwrap_err();
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@unique": The length argument is not supported with the current connector[0m
+          [1;94m-->[0m  [4mschema.prisma:12[0m
+        [1;94m   | [0m
+        [1;94m11 | [0mmodel A {
+        [1;94m12 | [0m  id String @[1;91munique(length: 30)[0m @test.VarChar(255)
+        [1;94m   | [0m
+    "#]];
+
+    expectation.assert_eq(&error)
+}
+
+#[test]
+fn sqlserver_disallows_compound_unique_length_prefix() {
+    let dml = indoc! {r#"
+        model A {
+          a String
+          b String
+          @@unique([a(length: 10), b(length: 30)])
+        }
+    "#};
+
+    let dml = with_header(dml, Provider::SqlServer, &["extendedIndexes"]);
+    let error = datamodel::parse_schema(&dml).map(drop).unwrap_err();
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@unique": The length argument is not supported with the current connector[0m
+          [1;94m-->[0m  [4mschema.prisma:14[0m
+        [1;94m   | [0m
+        [1;94m13 | [0m  b String
+        [1;94m14 | [0m  @@[1;91munique([a(length: 10), b(length: 30)])[0m
+        [1;94m   | [0m
+    "#]];
+
+    expectation.assert_eq(&error)
+}
+
+#[test]
+fn sqlserver_disallows_index_length_prefix() {
+    let dml = indoc! {r#"
+        model A {
+          id Int @id
+          a String
+
+          @@index([a(length: 10)])
+        }
+    "#};
+
+    let dml = with_header(dml, Provider::SqlServer, &["extendedIndexes"]);
+    let error = datamodel::parse_schema(&dml).map(drop).unwrap_err();
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@index": The length argument is not supported with the current connector[0m
+          [1;94m-->[0m  [4mschema.prisma:15[0m
+        [1;94m   | [0m
+        [1;94m14 | [0m
+        [1;94m15 | [0m  @@[1;91mindex([a(length: 10)])[0m
+        [1;94m   | [0m
+    "#]];
+
+    expectation.assert_eq(&error)
+}
+
+#[test]
+fn sqlite_disallows_unique_length_prefix() {
+    let dml = indoc! {r#"
+        model A {
+          id String @unique(length: 30)
+        }
+    "#};
+
+    let dml = with_header(dml, Provider::Sqlite, &["extendedIndexes"]);
+    let error = datamodel::parse_schema(&dml).map(drop).unwrap_err();
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@unique": The length argument is not supported with the current connector[0m
+          [1;94m-->[0m  [4mschema.prisma:12[0m
+        [1;94m   | [0m
+        [1;94m11 | [0mmodel A {
+        [1;94m12 | [0m  id String @[1;91munique(length: 30)[0m
+        [1;94m   | [0m
+    "#]];
+
+    expectation.assert_eq(&error)
+}
+
+#[test]
+fn sqlite_disallows_compound_unique_length_prefix() {
+    let dml = indoc! {r#"
+        model A {
+          a String
+          b String
+          @@unique([a(length: 10), b(length: 30)])
+        }
+    "#};
+
+    let dml = with_header(dml, Provider::Sqlite, &["extendedIndexes"]);
+    let error = datamodel::parse_schema(&dml).map(drop).unwrap_err();
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@unique": The length argument is not supported with the current connector[0m
+          [1;94m-->[0m  [4mschema.prisma:14[0m
+        [1;94m   | [0m
+        [1;94m13 | [0m  b String
+        [1;94m14 | [0m  @@[1;91munique([a(length: 10), b(length: 30)])[0m
+        [1;94m   | [0m
+    "#]];
+
+    expectation.assert_eq(&error)
+}
+
+#[test]
+fn sqlite_disallows_index_length_prefix() {
+    let dml = indoc! {r#"
+        model A {
+          id Int @id
+          a String
+
+          @@index([a(length: 10)])
+        }
+    "#};
+
+    let dml = with_header(dml, Provider::Sqlite, &["extendedIndexes"]);
+    let error = datamodel::parse_schema(&dml).map(drop).unwrap_err();
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@index": The length argument is not supported with the current connector[0m
+          [1;94m-->[0m  [4mschema.prisma:15[0m
+        [1;94m   | [0m
+        [1;94m14 | [0m
+        [1;94m15 | [0m  @@[1;91mindex([a(length: 10)])[0m
+        [1;94m   | [0m
+    "#]];
+
+    expectation.assert_eq(&error)
+}
+
+#[test]
+fn mongodb_disallows_unique_length_prefix() {
+    let dml = indoc! {r#"
+        model A {
+          id String @id @map("_id") @test.ObjectId
+          val String @unique(length: 30)
+        }
+    "#};
+
+    let dml = with_header(dml, Provider::Mongo, &["extendedIndexes", "mongoDb"]);
+    let error = datamodel::parse_schema(&dml).map(drop).unwrap_err();
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@unique": The length argument is not supported with the current connector[0m
+          [1;94m-->[0m  [4mschema.prisma:13[0m
+        [1;94m   | [0m
+        [1;94m12 | [0m  id String @id @map("_id") @test.ObjectId
+        [1;94m13 | [0m  val String @[1;91munique(length: 30)[0m
+        [1;94m   | [0m
+    "#]];
+
+    expectation.assert_eq(&error)
+}
+
+#[test]
+fn mongodb_disallows_compound_unique_length_prefix() {
+    let dml = indoc! {r#"
+        model A {
+          id String @id @map("_id") @test.ObjectId
+          a String
+          b String
+          @@unique([a(length: 10), b(length: 30)])
+        }
+    "#};
+
+    let dml = with_header(dml, Provider::Mongo, &["extendedIndexes", "mongoDb"]);
+    let error = datamodel::parse_schema(&dml).map(drop).unwrap_err();
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@unique": The length argument is not supported with the current connector[0m
+          [1;94m-->[0m  [4mschema.prisma:15[0m
+        [1;94m   | [0m
+        [1;94m14 | [0m  b String
+        [1;94m15 | [0m  @@[1;91munique([a(length: 10), b(length: 30)])[0m
+        [1;94m   | [0m
+    "#]];
+
+    expectation.assert_eq(&error)
+}
+
+#[test]
+fn mongodb_disallows_index_length_prefix() {
+    let dml = indoc! {r#"
+        model A {
+          id String @id @map("_id") @test.ObjectId
+          a String
+
+          @@index([a(length: 10)])
+        }
+    "#};
+
+    let dml = with_header(dml, Provider::Mongo, &["extendedIndexes", "mongoDb"]);
+    let error = datamodel::parse_schema(&dml).map(drop).unwrap_err();
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@index": The length argument is not supported with the current connector[0m
+          [1;94m-->[0m  [4mschema.prisma:15[0m
+        [1;94m   | [0m
+        [1;94m14 | [0m
+        [1;94m15 | [0m  @@[1;91mindex([a(length: 10)])[0m
+        [1;94m   | [0m
+    "#]];
+
+    expectation.assert_eq(&error)
+}

--- a/libs/datamodel/core/tests/attributes/index_negative.rs
+++ b/libs/datamodel/core/tests/attributes/index_negative.rs
@@ -436,3 +436,185 @@ fn mongodb_disallows_index_length_prefix() {
 
     expectation.assert_eq(&error)
 }
+
+#[test]
+fn length_argument_does_not_work_with_decimal() {
+    let dml = indoc! {r#"
+        model A {
+          id Int @id
+          a Decimal
+
+          @@index([a(length: 10)])
+        }
+    "#};
+
+    let schema = with_header(dml, Provider::Mysql, &["extendedIndexes"]);
+    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@index": The length argument is only allowed with field types `String` or `Bytes`.[0m
+          [1;94m-->[0m  [4mschema.prisma:15[0m
+        [1;94m   | [0m
+        [1;94m14 | [0m
+        [1;94m15 | [0m  @@[1;91mindex([a(length: 10)])[0m
+        [1;94m   | [0m
+    "#]];
+
+    expectation.assert_eq(&error)
+}
+
+#[test]
+fn length_argument_does_not_work_with_json() {
+    let dml = indoc! {r#"
+        model A {
+          id Int @id
+          a Json
+
+          @@index([a(length: 10)])
+        }
+    "#};
+
+    let schema = with_header(dml, Provider::Mysql, &["extendedIndexes"]);
+    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@index": The length argument is only allowed with field types `String` or `Bytes`.[0m
+          [1;94m-->[0m  [4mschema.prisma:15[0m
+        [1;94m   | [0m
+        [1;94m14 | [0m
+        [1;94m15 | [0m  @@[1;91mindex([a(length: 10)])[0m
+        [1;94m   | [0m
+    "#]];
+
+    expectation.assert_eq(&error)
+}
+
+#[test]
+fn length_argument_does_not_work_with_datetime() {
+    let dml = indoc! {r#"
+        model A {
+          id Int @id
+          a DateTime
+
+          @@index([a(length: 10)])
+        }
+    "#};
+
+    let schema = with_header(dml, Provider::Mysql, &["extendedIndexes"]);
+    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@index": The length argument is only allowed with field types `String` or `Bytes`.[0m
+          [1;94m-->[0m  [4mschema.prisma:15[0m
+        [1;94m   | [0m
+        [1;94m14 | [0m
+        [1;94m15 | [0m  @@[1;91mindex([a(length: 10)])[0m
+        [1;94m   | [0m
+    "#]];
+
+    expectation.assert_eq(&error)
+}
+
+#[test]
+fn length_argument_does_not_work_with_boolean() {
+    let dml = indoc! {r#"
+        model A {
+          id Int @id
+          a Boolean
+
+          @@index([a(length: 10)])
+        }
+    "#};
+
+    let schema = with_header(dml, Provider::Mysql, &["extendedIndexes"]);
+    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@index": The length argument is only allowed with field types `String` or `Bytes`.[0m
+          [1;94m-->[0m  [4mschema.prisma:15[0m
+        [1;94m   | [0m
+        [1;94m14 | [0m
+        [1;94m15 | [0m  @@[1;91mindex([a(length: 10)])[0m
+        [1;94m   | [0m
+    "#]];
+
+    expectation.assert_eq(&error)
+}
+
+#[test]
+fn length_argument_does_not_work_with_float() {
+    let dml = indoc! {r#"
+        model A {
+          id Int @id
+          a Float
+
+          @@index([a(length: 10)])
+        }
+    "#};
+
+    let schema = with_header(dml, Provider::Mysql, &["extendedIndexes"]);
+    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@index": The length argument is only allowed with field types `String` or `Bytes`.[0m
+          [1;94m-->[0m  [4mschema.prisma:15[0m
+        [1;94m   | [0m
+        [1;94m14 | [0m
+        [1;94m15 | [0m  @@[1;91mindex([a(length: 10)])[0m
+        [1;94m   | [0m
+    "#]];
+
+    expectation.assert_eq(&error)
+}
+
+#[test]
+fn length_argument_does_not_work_with_bigint() {
+    let dml = indoc! {r#"
+        model A {
+          id Int @id
+          a BigInt
+
+          @@index([a(length: 10)])
+        }
+    "#};
+
+    let schema = with_header(dml, Provider::Mysql, &["extendedIndexes"]);
+    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@index": The length argument is only allowed with field types `String` or `Bytes`.[0m
+          [1;94m-->[0m  [4mschema.prisma:15[0m
+        [1;94m   | [0m
+        [1;94m14 | [0m
+        [1;94m15 | [0m  @@[1;91mindex([a(length: 10)])[0m
+        [1;94m   | [0m
+    "#]];
+
+    expectation.assert_eq(&error)
+}
+
+#[test]
+fn length_argument_does_not_work_with_int() {
+    let dml = indoc! {r#"
+        model A {
+          id Int @id
+          a Int
+
+          @@index([a(length: 10)])
+        }
+    "#};
+
+    let schema = with_header(dml, Provider::Mysql, &["extendedIndexes"]);
+    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@index": The length argument is only allowed with field types `String` or `Bytes`.[0m
+          [1;94m-->[0m  [4mschema.prisma:15[0m
+        [1;94m   | [0m
+        [1;94m14 | [0m
+        [1;94m15 | [0m  @@[1;91mindex([a(length: 10)])[0m
+        [1;94m   | [0m
+    "#]];
+
+    expectation.assert_eq(&error)
+}

--- a/libs/datamodel/core/tests/attributes/mod.rs
+++ b/libs/datamodel/core/tests/attributes/mod.rs
@@ -33,7 +33,7 @@ pub enum Provider {
 
 fn with_header(dm: &str, provider: Provider, preview_features: &[&str]) -> String {
     let (provider, url) = match provider {
-        Provider::Mongo => ("mongo", "mongo"),
+        Provider::Mongo => ("mongodb", "mongo"),
         Provider::Postgres => ("postgres", "postgresql"),
         Provider::Sqlite => ("sqlite", "file"),
         Provider::Mysql => ("mysql", "mysql"),
@@ -52,13 +52,13 @@ fn with_header(dm: &str, provider: Provider, preview_features: &[&str]) -> Strin
     let header = formatdoc!(
         r#"
         datasource test {{
-                provider = "{}"
-                url = "{}://..."
+          provider = "{}"
+          url = "{}://..."
         }}
         
         generator client {{
-            provider = "prisma-client-js"
-            {}
+          provider = "prisma-client-js"
+          {}
         }}
         "#,
         provider,

--- a/migration-engine/connectors/sql-migration-connector/src/connection_wrapper/native.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/connection_wrapper/native.rs
@@ -215,21 +215,11 @@ impl Connection {
 
 fn filter_extended_index_capabilities(schema: &mut SqlSchema) {
     for (_, table) in schema.iter_tables_mut() {
-        let mut pk_removal = false;
-
         if let Some(ref mut pk) = &mut table.primary_key {
             for col in pk.columns.iter_mut() {
-                if col.length.is_some() {
-                    pk_removal = true;
-                }
-
                 col.length = None;
                 col.sort_order = None;
             }
-        }
-
-        if pk_removal {
-            table.primary_key = None;
         }
 
         let mut kept_indexes = Vec::new();


### PR DESCRIPTION
Validation of index sort and length parameters.

- Checks that if any of them can be used with the current connector in primary key, index or unique position
- On MySQL, the `length` can be only used with string and bytes types.

The missing validation is finding the length parameter boundaries based on the underlying type and its length. This will come when the native types work is complete in the data model, most probably before GA. Also you cannot (yet) use `TEXT` or `BLOB` fields as a primary key. It needs [this PR](https://github.com/prisma/prisma-engines/pull/2400) merged so we can validate the length parameter in dml.

Also adds back the buggy behavior of not filtering a primary key out from an introspected data model even if the key holds a length prefix in MySQL databases. This behavior will get corrected either with the preview feature enabled when the IE work is done, or in the next major Prisma version.

Part of: https://github.com/prisma/prisma/issues/9577