### PR TITLE
Implement Quaint UUIDError

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3252,7 +3252,7 @@ dependencies = [
 [[package]]
 name = "quaint"
 version = "0.2.0-alpha.13"
-source = "git+https://github.com/prisma/quaint#fd51e19b3418984440762b5aea58b9a782446554"
+source = "git+https://github.com/prisma/quaint#9d9e2064fe81af73f808f1b3e2d622e7870d3566"
 dependencies = [
  "async-trait",
  "base64 0.12.3",

--- a/query-engine/connectors/sql-query-connector/src/error.rs
+++ b/query-engine/connectors/sql-query-connector/src/error.rs
@@ -278,6 +278,7 @@ impl From<quaint::error::Error> for SqlError {
             e @ QuaintKind::ResultTypeMismatch { .. } => SqlError::QueryError(e.into()),
             e @ QuaintKind::LengthMismatch { .. } => SqlError::QueryError(e.into()),
             e @ QuaintKind::ValueOutOfRange { .. } => SqlError::QueryError(e.into()),
+            e @ QuaintKind::UUIDError(_) => SqlError::ConversionError(e.into()),
             e @ QuaintKind::DatabaseUrlIsInvalid { .. } => SqlError::ConnectionError(e),
             e @ QuaintKind::DatabaseDoesNotExist { .. } => SqlError::ConnectionError(e),
             e @ QuaintKind::AuthenticationFailed { .. } => SqlError::ConnectionError(e),


### PR DESCRIPTION
This implements a better UUID error for the user

```

  "errors": [
    {
      "error": "Error occurred during query execution:\nConnectorError(ConnectorError { user_facing_error: Some(KnownError { message: \"Inconsistent column data: Error creating UUID, invalid length: expected one of [36, 32], found 3\", meta: Object({\"message\": String(\"Error creating UUID, invalid length: expected one of [36, 32], found 3\")}), error_code: \"P2023\" }), kind: ConversionError(Error creating UUID, invalid length: expected one of [36, 32], found 3) })",
      "user_facing_error": {
        "is_panic": false,
        "message": "Inconsistent column data: Error creating UUID, invalid length: expected one of [36, 32], found 3",
        "meta": {
          "message": "Error creating UUID, invalid length: expected one of [36, 32], found 3"
        },
        "error_code": "P2023"
      }
    }
  ]
}
```


Fixes https://github.com/prisma/prisma/issues/4060