### PR TITLE
add connection pool timeout to pool timeout error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3252,7 +3252,7 @@ dependencies = [
 [[package]]
 name = "quaint"
 version = "0.2.0-alpha.13"
-source = "git+https://github.com/prisma/quaint#9d9e2064fe81af73f808f1b3e2d622e7870d3566"
+source = "git+https://github.com/prisma/quaint#05eb0acc841eeb88569d1538c35b66b5e4f83266"
 dependencies = [
  "async-trait",
  "base64 0.12.3",
@@ -3943,7 +3943,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0bccbcf40c8938196944a3da0e133e031a33f4d6b72db3bda3cc556e361905d"
 dependencies = [
  "lazy_static",
- "parking_lot 0.11.2",
+ "parking_lot 0.10.2",
  "serial_test_derive",
 ]
 
@@ -4968,7 +4968,7 @@ version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f559b464de2e2bdabcac6a210d12e9b5a5973c251e102c44c585c71d51bd78e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "rand 0.8.4",
  "static_assertions",
 ]

--- a/libs/user-facing-errors/src/quaint.rs
+++ b/libs/user-facing-errors/src/quaint.rs
@@ -200,8 +200,9 @@ pub fn render_quaint_error(kind: &ErrorKind, connection_info: &ConnectionInfo) -
             }))
         }
 
-        (ErrorKind::PoolTimeout { max_open, .. }, _) => Some(KnownError::new(query_engine::PoolTimeout {
+        (ErrorKind::PoolTimeout { max_open, timeout, .. }, _) => Some(KnownError::new(query_engine::PoolTimeout {
             connection_limit: *max_open,
+            timeout: *timeout,
         })),
 
         (ErrorKind::DatabaseUrlIsInvalid(details), _connection_info) => {

--- a/libs/user-facing-errors/src/query_engine.rs
+++ b/libs/user-facing-errors/src/query_engine.rs
@@ -253,10 +253,11 @@ pub struct InconsistentColumnData {
 #[derive(Debug, UserFacingError, Serialize)]
 #[user_facing(
     code = "P2024",
-    message = "Timed out fetching a new connection from the connection pool. (More info: http://pris.ly/d/connection-pool, Current connection limit: {connection_limit})"
+    message = "Timed out fetching a new connection from the connection pool. More info: http://pris.ly/d/connection-pool (Current connection pool timeout: {timeout}, connection limit: {connection_limit})"
 )]
 pub struct PoolTimeout {
     pub connection_limit: u64,
+    pub timeout: u64,
 }
 
 #[derive(Debug, UserFacingError, Serialize)]


### PR DESCRIPTION
Changes the error to:

```json
{
  "errors": [
    {
      "error": "Error in connector: Error creating a database connection. (Timed out fetching a connection from the pool (connection limit: 1, in use: 1, pool timeout 1))",
      "user_facing_error": {
        "is_panic": false,
        "message": "Timed out fetching a new connection from the connection pool. More info: http://pris.ly/d/connection-pool (Current connection pool timeout: 1, connection limit: 1)",
        "meta": {
          "connection_limit": 1,
          "timeout": 1
        },
        "error_code": "P2024"
      }
    }
  ]
}
```

Fixes https://github.com/prisma/prisma/issues/9662