### PR TITLE
Add cockroachdb provider to datamodel parser 

### DIFF
--- a/introspection-engine/introspection-engine-tests/src/test_api.rs
+++ b/introspection-engine/introspection-engine-tests/src/test_api.rs
@@ -243,13 +243,9 @@ impl TestApi {
     }
 
     pub fn configuration(&self) -> Configuration {
-        datamodel::parse_configuration(&format!(
-            "{}\n{}",
-            &self.datasource_block().to_string(),
-            &self.generator_block()
-        ))
-        .unwrap()
-        .subject
+        datamodel::parse_configuration(&format!("{}\n{}", &self.datasource_block(), &self.generator_block()))
+            .unwrap()
+            .subject
     }
 
     #[track_caller]

--- a/libs/datamodel/core/src/common/preview_features.rs
+++ b/libs/datamodel/core/src/common/preview_features.rs
@@ -62,6 +62,7 @@ features!(
     FullTextSearch,
     DataProxy,
     ExtendedIndexes,
+    Cockroachdb,
 );
 
 // Mapping of which active, deprecated and hidden
@@ -79,6 +80,7 @@ pub static GENERATOR: Lazy<FeatureMap> = Lazy::new(|| {
             DataProxy,
             ExtendedIndexes,
         ])
+        .with_hidden(vec![Cockroachdb])
         .with_deprecated(vec![
             AtomicNumberOperations,
             AggregateApi,

--- a/libs/datamodel/core/src/common/provider_names.rs
+++ b/libs/datamodel/core/src/common/provider_names.rs
@@ -1,4 +1,5 @@
 pub const SQLITE_SOURCE_NAME: &str = "sqlite";
+pub const COCKROACHDB_SOURCE_NAME: &str = "cockroachdb";
 pub const POSTGRES_SOURCE_NAME: &str = "postgresql";
 pub const POSTGRES_SOURCE_NAME_HEROKU: &str = "postgres";
 pub const MYSQL_SOURCE_NAME: &str = "mysql";

--- a/libs/datamodel/core/src/transform/ast_to_dml/builtin_datasource_providers.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/builtin_datasource_providers.rs
@@ -20,6 +20,22 @@ impl DatasourceProvider for SqliteDatasourceProvider {
     }
 }
 
+pub struct CockroachDbDatasourceProvider;
+
+impl DatasourceProvider for CockroachDbDatasourceProvider {
+    fn is_provider(&self, provider: &str) -> bool {
+        provider == COCKROACHDB_SOURCE_NAME
+    }
+
+    fn canonical_name(&self) -> &str {
+        COCKROACHDB_SOURCE_NAME
+    }
+
+    fn connector(&self) -> &'static dyn Connector {
+        SqlDatamodelConnectors::POSTGRES
+    }
+}
+
 pub struct PostgresDatasourceProvider;
 
 impl DatasourceProvider for PostgresDatasourceProvider {

--- a/libs/datamodel/core/src/transform/ast_to_dml/datasource_loader.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/datasource_loader.rs
@@ -1,8 +1,8 @@
 use super::{
     super::helpers::{ValueListValidator, ValueValidator},
     builtin_datasource_providers::{
-        MongoDbDatasourceProvider, MsSqlDatasourceProvider, MySqlDatasourceProvider, PostgresDatasourceProvider,
-        SqliteDatasourceProvider,
+        CockroachDbDatasourceProvider, MongoDbDatasourceProvider, MsSqlDatasourceProvider, MySqlDatasourceProvider,
+        PostgresDatasourceProvider, SqliteDatasourceProvider,
     },
     datasource_provider::DatasourceProvider,
 };
@@ -157,12 +157,13 @@ impl DatasourceLoader {
         let documentation = ast_source.documentation.as_ref().map(|comment| comment.text.clone());
         let referential_integrity = get_referential_integrity(&args, preview_features, ast_source, diagnostics);
 
-        let datasource_provider: Box<dyn DatasourceProvider> = match provider {
-            p if p == MYSQL_SOURCE_NAME => Box::new(MySqlDatasourceProvider),
-            p if p == POSTGRES_SOURCE_NAME || p == POSTGRES_SOURCE_NAME_HEROKU => Box::new(PostgresDatasourceProvider),
-            p if p == SQLITE_SOURCE_NAME => Box::new(SqliteDatasourceProvider),
-            p if p == MSSQL_SOURCE_NAME => Box::new(MsSqlDatasourceProvider),
-            p if p == MONGODB_SOURCE_NAME => Box::new(MongoDbDatasourceProvider),
+        let datasource_provider: &'static dyn DatasourceProvider = match provider {
+            p if p == MYSQL_SOURCE_NAME => &MySqlDatasourceProvider,
+            p if p == POSTGRES_SOURCE_NAME || p == POSTGRES_SOURCE_NAME_HEROKU => &PostgresDatasourceProvider,
+            p if p == SQLITE_SOURCE_NAME => &SqliteDatasourceProvider,
+            p if p == MSSQL_SOURCE_NAME => &MsSqlDatasourceProvider,
+            p if p == MONGODB_SOURCE_NAME => &MongoDbDatasourceProvider,
+            p if p == COCKROACHDB_SOURCE_NAME => &CockroachDbDatasourceProvider,
             _ => {
                 diagnostics.push_error(DatamodelError::new_datasource_provider_not_known_error(
                     provider,

--- a/libs/datamodel/core/src/transform/ast_to_dml/datasource_loader.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/datasource_loader.rs
@@ -163,7 +163,9 @@ impl DatasourceLoader {
             p if p == SQLITE_SOURCE_NAME => &SqliteDatasourceProvider,
             p if p == MSSQL_SOURCE_NAME => &MsSqlDatasourceProvider,
             p if p == MONGODB_SOURCE_NAME => &MongoDbDatasourceProvider,
-            p if p == COCKROACHDB_SOURCE_NAME => &CockroachDbDatasourceProvider,
+            p if p == COCKROACHDB_SOURCE_NAME && preview_features.contains(PreviewFeature::Cockroachdb) => {
+                &CockroachDbDatasourceProvider
+            }
             _ => {
                 diagnostics.push_error(DatamodelError::new_datasource_provider_not_known_error(
                     provider,

--- a/libs/datamodel/core/tests/capabilities/cockroachdb.rs
+++ b/libs/datamodel/core/tests/capabilities/cockroachdb.rs
@@ -1,0 +1,211 @@
+use crate::common::*;
+use indoc::indoc;
+
+#[test]
+fn enum_support() {
+    let dml = indoc! {r#"
+        datasource db {
+          provider = "cockroachdb"
+          url = "postgres://"
+        }
+
+        model Todo {
+          id     Int    @id
+          status Status
+        }
+
+        enum Status {
+          DONE
+          NOT_DONE
+        }
+    "#};
+
+    assert!(datamodel::parse_schema(dml).is_ok());
+}
+
+#[test]
+fn scalar_list_support() {
+    let dml = indoc! {r#"
+        datasource db {
+          provider = "cockroachdb"
+          url = "postgres://"
+        }
+
+        model Todo {
+          id     Int    @id
+          val    String[]
+        }
+    "#};
+
+    assert!(datamodel::parse_schema(dml).is_ok());
+}
+
+#[test]
+fn unique_index_names_support() {
+    let dml = indoc! {r#"
+        datasource db {
+          provider = "cockroachdb"
+          url = "postgres://"
+        }
+
+        model User {
+          id         Int @id
+          neighborId Int
+
+          @@index([id], name: "metaId")
+        }
+
+        model Post {
+          id Int @id
+          optionId Int
+
+          @@index([id], name: "metaId")
+        }
+    "#};
+
+    let error = datamodel::parse_schema(dml).map(drop).unwrap_err();
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@index": The given constraint name `metaId` has to be unique in the following namespace: global for primary key, indexes and unique constraints. Please provide a different name using the `map` argument.[0m
+          [1;94m-->[0m  [4mschema.prisma:10[0m
+        [1;94m   | [0m
+        [1;94m 9 | [0m
+        [1;94m10 | [0m  @@index([id], [1;91mname: "metaId"[0m)
+        [1;94m   | [0m
+        [1;91merror[0m: [1mError parsing attribute "@index": The given constraint name `metaId` has to be unique in the following namespace: global for primary key, indexes and unique constraints. Please provide a different name using the `map` argument.[0m
+          [1;94m-->[0m  [4mschema.prisma:17[0m
+        [1;94m   | [0m
+        [1;94m16 | [0m
+        [1;94m17 | [0m  @@index([id], [1;91mname: "metaId"[0m)
+        [1;94m   | [0m
+    "#]];
+
+    expectation.assert_eq(&error);
+}
+
+#[test]
+fn json_support() {
+    let dml = indoc! {r#"
+        datasource db {
+          provider = "cockroachdb"
+          url = "postgres://"
+        }
+
+        model User {
+          id   Int @id
+          data Json
+        }
+    "#};
+
+    assert!(datamodel::parse_schema(dml).is_ok());
+}
+
+#[test]
+fn non_unique_relation_criteria_support() {
+    let dml = indoc! {r#"
+        datasource db {
+          provider = "sqlite"
+          url = "file:test.db"
+        }
+
+        model Todo {
+          id           Int    @id
+          assigneeName String
+          assignee     User   @relation(fields: [assigneeName], references: [name])
+        }
+
+        model User {
+          id   Int    @id
+          name String
+          todos Todo[]
+        }
+    "#};
+
+    let error = datamodel::parse_schema(dml).map(drop).unwrap_err();
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError validating: The argument `references` must refer to a unique criteria in the related model `User`. But it is referencing the following fields that are not a unique criteria: name[0m
+          [1;94m-->[0m  [4mschema.prisma:9[0m
+        [1;94m   | [0m
+        [1;94m 8 | [0m  assigneeName String
+        [1;94m 9 | [0m  [1;91massignee     User   @relation(fields: [assigneeName], references: [name])[0m
+        [1;94m10 | [0m}
+        [1;94m   | [0m
+    "#]];
+
+    expectation.assert_eq(&error);
+}
+
+#[test]
+fn auto_increment_on_non_primary_column_support() {
+    let dml = indoc! {r#"
+        datasource db {
+          provider = "cockroachdb"
+          url = "postgres://"
+        }
+
+        model Todo {
+          id           Int    @id
+          non_primary  Int    @default(autoincrement()) @unique
+        }
+    "#};
+
+    assert!(datamodel::parse_schema(dml).is_ok());
+}
+
+#[test]
+fn key_order_enforcement_support() {
+    let dml = indoc! {r#"
+        datasource db {
+          provider = "cockroachdb"
+          url = "postgres://"
+        }
+
+        model  Todo {
+          id1  Int
+          id2  Int
+          cats Cat[]
+
+          @@id([id1, id2])
+        }
+
+        model Cat {
+          id    Int @id
+          todo1 Int
+          todo2 Int
+
+          rel Todo @relation(fields: [todo1, todo2], references: [id2, id1])
+        }
+    "#};
+
+    assert!(datamodel::parse_schema(dml).is_ok());
+}
+
+#[test]
+fn does_not_support_composite_types() {
+    let schema = r#"
+        datasource db {
+            provider = "cockroachdb"
+            url = "postgres://"
+        }
+
+        type Address {
+            street String
+        }
+    "#;
+
+    let err = datamodel::parse_schema(schema).unwrap_err();
+
+    let expected = expect![[r#"
+        [1;91merror[0m: [1mError validating: Composite types are not supported on Postgres.[0m
+          [1;94m-->[0m  [4mschema.prisma:7[0m
+        [1;94m   | [0m
+        [1;94m 6 | [0m
+        [1;94m 7 | [0m        [1;91mtype Address {[0m
+        [1;94m 8 | [0m            street String
+        [1;94m 9 | [0m        }
+        [1;94m   | [0m
+    "#]];
+
+    expected.assert_eq(&err);
+}

--- a/libs/datamodel/core/tests/capabilities/cockroachdb.rs
+++ b/libs/datamodel/core/tests/capabilities/cockroachdb.rs
@@ -9,6 +9,11 @@ fn enum_support() {
           url = "postgres://"
         }
 
+        generator js {
+            provider = "prisma-client-js"
+            previewFeatures = ["cockroachdb"]
+        }
+
         model Todo {
           id     Int    @id
           status Status
@@ -31,6 +36,11 @@ fn scalar_list_support() {
           url = "postgres://"
         }
 
+        generator js {
+            provider = "prisma-client-js"
+            previewFeatures = ["cockroachdb"]
+        }
+
         model Todo {
           id     Int    @id
           val    String[]
@@ -46,6 +56,11 @@ fn unique_index_names_support() {
         datasource db {
           provider = "cockroachdb"
           url = "postgres://"
+        }
+
+        generator js {
+            provider = "prisma-client-js"
+            previewFeatures = ["cockroachdb"]
         }
 
         model User {
@@ -67,16 +82,16 @@ fn unique_index_names_support() {
 
     let expectation = expect![[r#"
         [1;91merror[0m: [1mError parsing attribute "@index": The given constraint name `metaId` has to be unique in the following namespace: global for primary key, indexes and unique constraints. Please provide a different name using the `map` argument.[0m
-          [1;94m-->[0m  [4mschema.prisma:10[0m
+          [1;94m-->[0m  [4mschema.prisma:15[0m
         [1;94m   | [0m
-        [1;94m 9 | [0m
-        [1;94m10 | [0m  @@index([id], [1;91mname: "metaId"[0m)
+        [1;94m14 | [0m
+        [1;94m15 | [0m  @@index([id], [1;91mname: "metaId"[0m)
         [1;94m   | [0m
         [1;91merror[0m: [1mError parsing attribute "@index": The given constraint name `metaId` has to be unique in the following namespace: global for primary key, indexes and unique constraints. Please provide a different name using the `map` argument.[0m
-          [1;94m-->[0m  [4mschema.prisma:17[0m
+          [1;94m-->[0m  [4mschema.prisma:22[0m
         [1;94m   | [0m
-        [1;94m16 | [0m
-        [1;94m17 | [0m  @@index([id], [1;91mname: "metaId"[0m)
+        [1;94m21 | [0m
+        [1;94m22 | [0m  @@index([id], [1;91mname: "metaId"[0m)
         [1;94m   | [0m
     "#]];
 
@@ -89,6 +104,11 @@ fn json_support() {
         datasource db {
           provider = "cockroachdb"
           url = "postgres://"
+        }
+
+        generator js {
+            provider = "prisma-client-js"
+            previewFeatures = ["cockroachdb"]
         }
 
         model User {
@@ -108,6 +128,11 @@ fn non_unique_relation_criteria_support() {
           url = "file:test.db"
         }
 
+        generator js {
+            provider = "prisma-client-js"
+            previewFeatures = ["cockroachdb"]
+        }
+
         model Todo {
           id           Int    @id
           assigneeName String
@@ -125,11 +150,11 @@ fn non_unique_relation_criteria_support() {
 
     let expectation = expect![[r#"
         [1;91merror[0m: [1mError validating: The argument `references` must refer to a unique criteria in the related model `User`. But it is referencing the following fields that are not a unique criteria: name[0m
-          [1;94m-->[0m  [4mschema.prisma:9[0m
+          [1;94m-->[0m  [4mschema.prisma:14[0m
         [1;94m   | [0m
-        [1;94m 8 | [0m  assigneeName String
-        [1;94m 9 | [0m  [1;91massignee     User   @relation(fields: [assigneeName], references: [name])[0m
-        [1;94m10 | [0m}
+        [1;94m13 | [0m  assigneeName String
+        [1;94m14 | [0m  [1;91massignee     User   @relation(fields: [assigneeName], references: [name])[0m
+        [1;94m15 | [0m}
         [1;94m   | [0m
     "#]];
 
@@ -142,6 +167,11 @@ fn auto_increment_on_non_primary_column_support() {
         datasource db {
           provider = "cockroachdb"
           url = "postgres://"
+        }
+
+        generator js {
+            provider = "prisma-client-js"
+            previewFeatures = ["cockroachdb"]
         }
 
         model Todo {
@@ -159,6 +189,11 @@ fn key_order_enforcement_support() {
         datasource db {
           provider = "cockroachdb"
           url = "postgres://"
+        }
+
+        generator js {
+            provider = "prisma-client-js"
+            previewFeatures = ["cockroachdb"]
         }
 
         model  Todo {
@@ -189,6 +224,11 @@ fn does_not_support_composite_types() {
             url = "postgres://"
         }
 
+        generator js {
+            provider = "prisma-client-js"
+            previewFeatures = ["cockroachdb"]
+        }
+
         type Address {
             street String
         }
@@ -198,12 +238,12 @@ fn does_not_support_composite_types() {
 
     let expected = expect![[r#"
         [1;91merror[0m: [1mError validating: Composite types are not supported on Postgres.[0m
-          [1;94m-->[0m  [4mschema.prisma:7[0m
+          [1;94m-->[0m  [4mschema.prisma:12[0m
         [1;94m   | [0m
-        [1;94m 6 | [0m
-        [1;94m 7 | [0m        [1;91mtype Address {[0m
-        [1;94m 8 | [0m            street String
-        [1;94m 9 | [0m        }
+        [1;94m11 | [0m
+        [1;94m12 | [0m        [1;91mtype Address {[0m
+        [1;94m13 | [0m            street String
+        [1;94m14 | [0m        }
         [1;94m   | [0m
     "#]];
 

--- a/libs/datamodel/core/tests/capabilities/mod.rs
+++ b/libs/datamodel/core/tests/capabilities/mod.rs
@@ -1,3 +1,4 @@
+mod cockroachdb;
 mod mongodb;
 mod mysql;
 mod postgres;

--- a/libs/datamodel/core/tests/common/mod.rs
+++ b/libs/datamodel/core/tests/common/mod.rs
@@ -457,3 +457,10 @@ pub(crate) const MSSQL_SOURCE: &str = r#"
         url      = "sqlserver://localhost:1433"
     }
 "#;
+
+pub(crate) const COCKROACHDB_SOURCE: &str = r#"
+    datasource db {
+        provider = "cockroachdb"
+        url      = "postgresql://localhost:5432"
+    }
+"#;

--- a/libs/datamodel/core/tests/common/mod.rs
+++ b/libs/datamodel/core/tests/common/mod.rs
@@ -463,4 +463,9 @@ pub(crate) const COCKROACHDB_SOURCE: &str = r#"
         provider = "cockroachdb"
         url      = "postgresql://localhost:5432"
     }
+
+    generator js {
+        provider = "prisma-client-js"
+        previewFeatures = ["cockroachdb"]
+    }
 "#;

--- a/libs/datamodel/core/tests/types/cockroachdb_native_types.rs
+++ b/libs/datamodel/core/tests/types/cockroachdb_native_types.rs
@@ -26,7 +26,7 @@ fn xml_data_type_should_fail_on_index() {
             "Native type Xml cannot be unique in Postgres."
         };
 
-        test_native_types_compatibility(&dml, error_msg, POSTGRES_SOURCE);
+        test_native_types_compatibility(&dml, error_msg, COCKROACHDB_SOURCE);
     }
 }
 
@@ -40,7 +40,7 @@ fn should_fail_on_invalid_precision_for_decimal_type() {
     }
 
     let native_type = "Decimal(1001,3)";
-    test_native_types_without_attributes(native_type, "Decimal", &error_msg(native_type), POSTGRES_SOURCE);
+    test_native_types_without_attributes(native_type, "Decimal", &error_msg(native_type), COCKROACHDB_SOURCE);
 }
 
 #[test]
@@ -54,9 +54,9 @@ fn should_fail_on_invalid_precision_for_time_types() {
 
     for tpe in &["Timestamp", "Time"] {
         let native_type = &format!("{}(7)", tpe);
-        test_native_types_without_attributes(native_type, "DateTime", &error_msg(native_type), POSTGRES_SOURCE);
+        test_native_types_without_attributes(native_type, "DateTime", &error_msg(native_type), COCKROACHDB_SOURCE);
         let native_type = &format!("{}(-1)", tpe);
-        test_native_types_without_attributes(native_type, "DateTime", &error_msg(native_type), POSTGRES_SOURCE);
+        test_native_types_without_attributes(native_type, "DateTime", &error_msg(native_type), COCKROACHDB_SOURCE);
     }
 }
 
@@ -71,7 +71,7 @@ fn should_fail_on_argument_out_of_range_for_bit_data_types() {
 
     for tpe in &["Bit", "VarBit"] {
         let native_type = &format!("{}(0)", tpe);
-        test_native_types_without_attributes(native_type, "String", &error_msg(native_type), POSTGRES_SOURCE);
+        test_native_types_without_attributes(native_type, "String", &error_msg(native_type), COCKROACHDB_SOURCE);
     }
 }
 
@@ -108,7 +108,7 @@ fn xml_should_work_with_string_scalar_type() {
             dec String @db.Xml
         }}
     "#,
-        datasource = POSTGRES_SOURCE
+        datasource = COCKROACHDB_SOURCE
     );
 
     let datamodel = parse(&dml);

--- a/libs/datamodel/core/tests/types/mod.rs
+++ b/libs/datamodel/core/tests/types/mod.rs
@@ -1,3 +1,4 @@
+mod cockroachdb_native_types;
 mod composite_types;
 mod helper;
 mod mssql_native_types;

--- a/query-engine/core/src/executor/loader.rs
+++ b/query-engine/core/src/executor/loader.rs
@@ -5,7 +5,9 @@ use connector::Connector;
 use datamodel::{
     common::{
         preview_features::PreviewFeature,
-        provider_names::{MSSQL_SOURCE_NAME, MYSQL_SOURCE_NAME, POSTGRES_SOURCE_NAME, SQLITE_SOURCE_NAME},
+        provider_names::{
+            COCKROACHDB_SOURCE_NAME, MSSQL_SOURCE_NAME, MYSQL_SOURCE_NAME, POSTGRES_SOURCE_NAME, SQLITE_SOURCE_NAME,
+        },
     },
     Datasource,
 };
@@ -33,6 +35,7 @@ pub async fn load(
         MYSQL_SOURCE_NAME => mysql(source, url).await,
         POSTGRES_SOURCE_NAME => postgres(source, url).await,
         MSSQL_SOURCE_NAME => mssql(source, url).await,
+        COCKROACHDB_SOURCE_NAME => postgres(source, url).await,
 
         #[cfg(feature = "mongodb")]
         MONGODB_SOURCE_NAME => {


### PR DESCRIPTION
This is now accepted by the datamodel parser:

```
datasource db {
  provider = "cockroachdb"
  url = "postgres://"
}
```

The validation rules, native types, etc. are currently exactly the same
as postgres, but these will evolve in different directions.

closes prisma/prisma#10079

Squashed:
- Avoid unecessary boxing of datasource providers