### PR TITLE
Index sort and length parameter introspection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2352,6 +2352,7 @@ dependencies = [
  "convert_case",
  "datamodel",
  "datamodel-connector",
+ "enumflags2",
  "expect-test",
  "futures",
  "indoc",

--- a/introspection-engine/connectors/mongodb-introspection-connector/Cargo.toml
+++ b/introspection-engine/connectors/mongodb-introspection-connector/Cargo.toml
@@ -15,6 +15,7 @@ datamodel-connector = { path = "../../../libs/datamodel/connectors/datamodel-con
 introspection-connector = { path = "../introspection-connector" }
 user-facing-errors = { path = "../../../libs/user-facing-errors" }
 native-types = { path = "../../../libs/native-types" }
+enumflags2 = "0.7"
 url = "2"
 indoc = "1"
 futures = "0.3"

--- a/introspection-engine/connectors/mongodb-introspection-connector/src/lib.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/src/lib.rs
@@ -115,6 +115,6 @@ impl IntrospectionConnector for MongoDbIntrospectionConnector {
             return Err(error);
         }
 
-        Ok(sampler::sample(self.database(), ctx.composite_type_depth).await?)
+        Ok(sampler::sample(self.database(), ctx.composite_type_depth, ctx.preview_features).await?)
     }
 }

--- a/introspection-engine/connectors/mongodb-introspection-connector/src/sampler.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/src/sampler.rs
@@ -1,6 +1,8 @@
 mod field_type;
 mod statistics;
 
+use datamodel::common::preview_features::PreviewFeature;
+use enumflags2::BitFlags;
 use futures::TryStreamExt;
 use introspection_connector::{CompositeTypeDepth, IntrospectionResult, Version};
 use mongodb::{
@@ -20,9 +22,10 @@ use statistics::*;
 pub(super) async fn sample(
     database: Database,
     composite_type_depth: CompositeTypeDepth,
+    preview_features: BitFlags<PreviewFeature>,
 ) -> crate::Result<IntrospectionResult> {
     let collections = database.list_collection_names(None).await?;
-    let mut statistics = Statistics::new(composite_type_depth);
+    let mut statistics = Statistics::new(composite_type_depth, preview_features);
     let mut warnings = Vec::new();
 
     for collection_name in &collections {

--- a/introspection-engine/introspection-engine-tests/tests/tables/mod.rs
+++ b/introspection-engine/introspection-engine-tests/tests/tables/mod.rs
@@ -1,5 +1,7 @@
 mod mssql;
 mod mysql;
+mod postgres;
+mod sqlite;
 
 use barrel::{functions, types};
 use expect_test::expect;

--- a/introspection-engine/introspection-engine-tests/tests/tables/mysql.rs
+++ b/introspection-engine/introspection-engine-tests/tests/tables/mysql.rs
@@ -1,3 +1,4 @@
+use indoc::indoc;
 use introspection_engine_tests::test_api::*;
 
 #[test_connector(tags(Mysql))]
@@ -15,6 +16,167 @@ async fn a_table_with_non_id_autoincrement(api: &TestApi) -> TestResult {
         model Test {
           id       Int @id
           authorId Int @unique(map: "authorId") @default(autoincrement())
+        }
+    "#]];
+
+    expected.assert_eq(&api.introspect_dml().await?);
+
+    Ok(())
+}
+
+#[test_connector(tags(Mysql8), preview_features("extendedIndexes"))]
+async fn a_table_with_length_prefixed_primary_key(api: &TestApi) -> TestResult {
+    let setup = indoc! {r#"
+        CREATE TABLE `A` (
+            `id` TEXT NOT NULL,
+            CONSTRAINT A_id_pkey PRIMARY KEY (id(30))
+        )
+    "#};
+
+    api.raw_cmd(setup).await;
+
+    let expected = expect![[r#"
+        model A {
+          id String @id(length: 30) @db.Text
+        }
+    "#]];
+
+    expected.assert_eq(&api.introspect_dml().await?);
+
+    Ok(())
+}
+
+#[test_connector(tags(Mysql8), preview_features("extendedIndexes"))]
+async fn a_table_with_length_prefixed_unique(api: &TestApi) -> TestResult {
+    let setup = indoc! {r#"
+        CREATE TABLE `A` (
+            `id` INT  PRIMARY KEY,
+            `a`  TEXT NOT NULL,
+            CONSTRAINT A_a_key UNIQUE (a(30))
+        )
+    "#};
+
+    api.raw_cmd(setup).await;
+
+    let expected = expect![[r#"
+        model A {
+          id Int    @id
+          a  String @unique(length: 30) @db.Text
+        }
+    "#]];
+
+    expected.assert_eq(&api.introspect_dml().await?);
+
+    Ok(())
+}
+
+#[test_connector(tags(Mysql8), preview_features("extendedIndexes"))]
+async fn a_table_with_length_prefixed_compound_unique(api: &TestApi) -> TestResult {
+    let setup = indoc! {r#"
+        CREATE TABLE `A` (
+            `id` INT  PRIMARY KEY,
+            `a`  TEXT NOT NULL,
+            `b`  TEXT NOT NULL,
+            CONSTRAINT A_a_b_key UNIQUE (a(30), b(20))
+        )
+    "#};
+
+    api.raw_cmd(setup).await;
+
+    let expected = expect![[r#"
+        model A {
+          id Int    @id
+          a  String @db.Text
+          b  String @db.Text
+
+          @@unique([a(length: 30), b(length: 20)])
+        }
+    "#]];
+
+    expected.assert_eq(&api.introspect_dml().await?);
+
+    Ok(())
+}
+
+#[test_connector(tags(Mysql8), preview_features("extendedIndexes"))]
+async fn a_table_with_length_prefixed_index(api: &TestApi) -> TestResult {
+    let setup = indoc! {r#"
+        CREATE TABLE `A` (
+            `id` INT  PRIMARY KEY,
+            `a`  TEXT NOT NULL,
+            `b`  TEXT NOT NULL
+        );
+        
+        CREATE INDEX A_a_b_idx ON `A` (a(30), b(20));
+    "#};
+
+    api.raw_cmd(setup).await;
+
+    let expected = expect![[r#"
+        model A {
+          id Int    @id
+          a  String @db.Text
+          b  String @db.Text
+
+          @@index([a(length: 30), b(length: 20)])
+        }
+    "#]];
+
+    expected.assert_eq(&api.introspect_dml().await?);
+
+    Ok(())
+}
+
+#[test_connector(tags(Mysql8), preview_features("extendedIndexes"))]
+async fn a_table_with_descending_index(api: &TestApi) -> TestResult {
+    let setup = indoc! {r#"
+        CREATE TABLE `A` (
+            `id` INT  PRIMARY KEY,
+            `a`  INT NOT NULL,
+            `b`  INT NOT NULL
+        );
+        
+        CREATE INDEX A_a_b_idx ON `A` (a ASC, b DESC);
+    "#};
+
+    api.raw_cmd(setup).await;
+
+    let expected = expect![[r#"
+        model A {
+          id Int @id
+          a  Int
+          b  Int
+
+          @@index([a, b(sort: Desc)])
+        }
+    "#]];
+
+    expected.assert_eq(&api.introspect_dml().await?);
+
+    Ok(())
+}
+
+#[test_connector(tags(Mysql8), preview_features("extendedIndexes"))]
+async fn a_table_with_descending_unique(api: &TestApi) -> TestResult {
+    let setup = indoc! {r#"
+        CREATE TABLE `A` (
+            `id` INT  PRIMARY KEY,
+            `a`  INT NOT NULL,
+            `b`  INT NOT NULL
+        );
+        
+        CREATE UNIQUE INDEX A_a_b_key ON `A` (a ASC, b DESC);
+    "#};
+
+    api.raw_cmd(setup).await;
+
+    let expected = expect![[r#"
+        model A {
+          id Int @id
+          a  Int
+          b  Int
+
+          @@unique([a, b(sort: Desc)])
         }
     "#]];
 

--- a/introspection-engine/introspection-engine-tests/tests/tables/postgres.rs
+++ b/introspection-engine/introspection-engine-tests/tests/tables/postgres.rs
@@ -1,0 +1,88 @@
+use indoc::indoc;
+use introspection_engine_tests::test_api::*;
+
+#[test_connector(tags(Postgres), preview_features("extendedIndexes"))]
+async fn a_table_with_descending_unique(api: &TestApi) -> TestResult {
+    let setup = indoc! {r#"
+       CREATE TABLE "A" (
+           id INTEGER NOT NULL,
+           a  INTEGER NOT NULL,
+           CONSTRAINT A_pkey PRIMARY KEY (id)
+       );
+
+       CREATE UNIQUE INDEX "A_a_key" ON "A" (a DESC);
+   "#};
+
+    api.raw_cmd(setup).await;
+
+    let expectation = expect![[r#"
+        model A {
+          id Int @id(map: "a_pkey")
+          a  Int @unique(sort: Desc)
+        }
+    "#]];
+
+    expectation.assert_eq(&api.introspect_dml().await?);
+
+    Ok(())
+}
+
+#[test_connector(tags(Postgres), preview_features("extendedIndexes"))]
+async fn a_table_with_descending_compound_unique(api: &TestApi) -> TestResult {
+    let setup = indoc! {r#"
+       CREATE TABLE "A" (
+           id INTEGER NOT NULL,
+           a  INTEGER NOT NULL,
+           b  INTEGER NOT NULL,
+           CONSTRAINT A_pkey PRIMARY KEY (id)
+       );
+
+       CREATE UNIQUE INDEX "A_a_b_key" ON "A" (a ASC, b DESC);
+   "#};
+
+    api.raw_cmd(setup).await;
+
+    let expectation = expect![[r#"
+        model A {
+          id Int @id(map: "a_pkey")
+          a  Int
+          b  Int
+
+          @@unique([a, b(sort: Desc)])
+        }
+    "#]];
+
+    expectation.assert_eq(&api.introspect_dml().await?);
+
+    Ok(())
+}
+
+#[test_connector(tags(Postgres), preview_features("extendedIndexes"))]
+async fn a_table_with_descending_index(api: &TestApi) -> TestResult {
+    let setup = indoc! {r#"
+       CREATE TABLE "A" (
+           id INTEGER NOT NULL,
+           a  INTEGER NOT NULL,
+           b  INTEGER NOT NULL,
+           CONSTRAINT A_pkey PRIMARY KEY (id)
+       );
+
+       CREATE INDEX "A_a_b_idx" ON "A" (a ASC, b DESC);
+   "#};
+
+    api.raw_cmd(setup).await;
+
+    let expectation = expect![[r#"
+        model A {
+          id Int @id(map: "a_pkey")
+          a  Int
+          b  Int
+
+          @@index([a, b(sort: Desc)])
+        }
+    "#]];
+
+    expectation.assert_eq(&api.introspect_dml().await?);
+
+    Ok(())
+}

--- a/introspection-engine/introspection-engine-tests/tests/tables/sqlite.rs
+++ b/introspection-engine/introspection-engine-tests/tests/tables/sqlite.rs
@@ -1,0 +1,88 @@
+use indoc::indoc;
+use introspection_engine_tests::test_api::*;
+
+#[test_connector(tags(Sqlite), preview_features("extendedIndexes"))]
+async fn a_table_with_descending_unique(api: &TestApi) -> TestResult {
+    let setup = indoc! {r#"
+       CREATE TABLE "A" (
+           id INTEGER NOT NULL,
+           a  INTEGER NOT NULL,
+           CONSTRAINT A_pkey PRIMARY KEY (id)
+       );
+
+       CREATE UNIQUE INDEX "A_a_key" ON "A" (a DESC);
+   "#};
+
+    api.raw_cmd(setup).await;
+
+    let expectation = expect![[r#"
+        model A {
+          id Int @id @default(autoincrement())
+          a  Int @unique(sort: Desc)
+        }
+    "#]];
+
+    expectation.assert_eq(&api.introspect_dml().await?);
+
+    Ok(())
+}
+
+#[test_connector(tags(Sqlite), preview_features("extendedIndexes"))]
+async fn a_table_with_descending_compound_unique(api: &TestApi) -> TestResult {
+    let setup = indoc! {r#"
+       CREATE TABLE "A" (
+           id INTEGER NOT NULL,
+           a  INTEGER NOT NULL,
+           b  INTEGER NOT NULL,
+           CONSTRAINT A_pkey PRIMARY KEY (id)
+       );
+
+       CREATE UNIQUE INDEX "A_a_b_key" ON "A" (a ASC, b DESC);
+   "#};
+
+    api.raw_cmd(setup).await;
+
+    let expectation = expect![[r#"
+        model A {
+          id Int @id @default(autoincrement())
+          a  Int
+          b  Int
+
+          @@unique([a, b(sort: Desc)])
+        }
+    "#]];
+
+    expectation.assert_eq(&api.introspect_dml().await?);
+
+    Ok(())
+}
+
+#[test_connector(tags(Sqlite), preview_features("extendedIndexes"))]
+async fn a_table_with_descending_index(api: &TestApi) -> TestResult {
+    let setup = indoc! {r#"
+       CREATE TABLE "A" (
+           id INTEGER NOT NULL,
+           a  INTEGER NOT NULL,
+           b  INTEGER NOT NULL,
+           CONSTRAINT A_pkey PRIMARY KEY (id)
+       );
+
+       CREATE INDEX "A_a_b_idx" ON "A" (a ASC, b DESC);
+   "#};
+
+    api.raw_cmd(setup).await;
+
+    let expectation = expect![[r#"
+        model A {
+          id Int @id @default(autoincrement())
+          a  Int
+          b  Int
+
+          @@index([a, b(sort: Desc)])
+        }
+    "#]];
+
+    expectation.assert_eq(&api.introspect_dml().await?);
+
+    Ok(())
+}

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
@@ -256,12 +256,19 @@ impl Connector for MySqlDatamodelConnector {
             let fields = index_definition
                 .fields
                 .iter()
-                .map(|f| model.find_field(&f.name).unwrap());
-            for f in fields {
+                .map(|f| model.find_field(&f.name).unwrap())
+                .zip(index_definition.fields.iter());
+
+            for (f, definition) in fields {
                 if let FieldType::Scalar(_, _, Some(native_type)) = f.field_type() {
                     let native_type_name = native_type.name.as_str();
 
                     if NATIVE_TYPES_THAT_CAN_NOT_BE_USED_IN_KEY_SPECIFICATION.contains(&native_type_name) {
+                        // Length defined, so we allow the index.
+                        if definition.length.is_some() {
+                            continue;
+                        }
+
                         if index_definition.is_unique() {
                             errors.push(
                                 self.native_instance_error(native_type.clone())
@@ -283,9 +290,16 @@ impl Connector for MySqlDatamodelConnector {
         if let Some(pk) = &model.primary_key {
             for id_field in pk.fields.iter() {
                 let field = model.find_field(&id_field.name).unwrap();
+
                 if let FieldType::Scalar(_, _, Some(native_type)) = field.field_type() {
                     let native_type_name = native_type.name.as_str();
+
                     if NATIVE_TYPES_THAT_CAN_NOT_BE_USED_IN_KEY_SPECIFICATION.contains(&native_type_name) {
+                        // Length defined, so we allow the index.
+                        if id_field.length.is_some() {
+                            continue;
+                        }
+
                         errors.push(
                             self.native_instance_error(native_type.clone())
                                 .new_incompatible_native_type_with_id(),


### PR DESCRIPTION
Support for length and sort parameter introspection on Postgres/MySQL/SQL Server/SQLite and MongoDB (where allowed).

Part of: https://github.com/prisma/prisma/issues/9577