### PR TITLE
Add a public method returning the engine version in prisma-fmt

### DIFF
--- a/prisma-fmt/src/lib.rs
+++ b/prisma-fmt/src/lib.rs
@@ -23,3 +23,18 @@ pub fn preview_features() -> String {
 pub fn referential_actions(schema: String) -> String {
     actions::run(&schema)
 }
+
+pub fn version() -> String {
+    let git_hash = env!("GIT_HASH");
+    format!("wasm+{}", git_hash)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn version_works() {
+        assert_eq!(version().len(), 45) // 40 from the sha + 5 for "wasm+"
+    }
+}


### PR DESCRIPTION
Example: wasm+74cfec832ece9bbe6ec7392b68e34d4f1e210665

This is for https://github.com/prisma/prisma-fmt-wasm/

First part of the work for https://github.com/prisma/prisma-fmt-wasm/issues/3