### PR TITLE
Fix prisma/prisma#9537

### DIFF
--- a/.test_database_urls/mysql_8
+++ b/.test_database_urls/mysql_8
@@ -1,2 +1,2 @@
 export TEST_DATABASE_URL="mysql://root:prisma@localhost:3307"
-set -e TEST_SHADOW_DATABASE_URL
+unset TEST_SHADOW_DATABASE_URL

--- a/libs/sql-schema-describer/src/walkers.rs
+++ b/libs/sql-schema-describer/src/walkers.rs
@@ -238,51 +238,6 @@ impl<'a> fmt::Debug for TableWalker<'a> {
     }
 }
 
-/// A walker of a column in a primary key.
-#[derive(Clone, Copy)]
-pub struct PrimaryKeyColumnWalker<'a> {
-    schema: &'a SqlSchema,
-    primary_key_column_id: usize,
-    table_id: TableId,
-    column_id: ColumnId,
-}
-
-impl<'a> PrimaryKeyColumnWalker<'a> {
-    /// Conversion to a normal column walker.
-    pub fn as_column(self) -> ColumnWalker<'a> {
-        ColumnWalker {
-            schema: self.schema,
-            column_id: self.column_id,
-            table_id: self.table_id,
-        }
-    }
-
-    /// The length limit of the (text) column. Matters on MySQL only.
-    pub fn length(self) -> Option<u32> {
-        self.get().length
-    }
-
-    /// The BTree ordering. Matters on SQL Server only.
-    pub fn sort_order(self) -> Option<SQLSortOrder> {
-        self.get().sort_order
-    }
-
-    fn table(self) -> TableWalker<'a> {
-        TableWalker {
-            schema: self.schema,
-            table_id: self.table_id,
-        }
-    }
-
-    fn get(self) -> &'a PrimaryKeyColumn {
-        self.table()
-            .table()
-            .primary_key_columns()
-            .nth(self.primary_key_column_id)
-            .unwrap()
-    }
-}
-
 impl<'a> TableWalker<'a> {
     /// Create a TableWalker from a schema and a reference to one of its tables. This should stay private.
     pub(crate) fn new(schema: &'a SqlSchema, table_id: TableId) -> Self {
@@ -428,6 +383,51 @@ impl<'a> TableWalker<'a> {
     /// The index of the table in the schema.
     pub fn table_id(&self) -> TableId {
         self.table_id
+    }
+}
+
+/// A walker of a column in a primary key.
+#[derive(Clone, Copy)]
+pub struct PrimaryKeyColumnWalker<'a> {
+    schema: &'a SqlSchema,
+    primary_key_column_id: usize,
+    table_id: TableId,
+    column_id: ColumnId,
+}
+
+impl<'a> PrimaryKeyColumnWalker<'a> {
+    /// Conversion to a normal column walker.
+    pub fn as_column(self) -> ColumnWalker<'a> {
+        ColumnWalker {
+            schema: self.schema,
+            column_id: self.column_id,
+            table_id: self.table_id,
+        }
+    }
+
+    /// The length limit of the (text) column. Matters on MySQL only.
+    pub fn length(self) -> Option<u32> {
+        self.get().length
+    }
+
+    /// The BTree ordering. Matters on SQL Server only.
+    pub fn sort_order(self) -> Option<SQLSortOrder> {
+        self.get().sort_order
+    }
+
+    fn table(self) -> TableWalker<'a> {
+        TableWalker {
+            schema: self.schema,
+            table_id: self.table_id,
+        }
+    }
+
+    fn get(self) -> &'a PrimaryKeyColumn {
+        self.table()
+            .table()
+            .primary_key_columns()
+            .nth(self.primary_key_column_id)
+            .unwrap()
     }
 }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mssql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mssql_renderer.rs
@@ -246,24 +246,10 @@ impl SqlRenderer for MssqlFlavour {
                 .column_pairs
                 .iter()
                 .map(|(column_indexes, _, _)| tables.columns(column_indexes).next().name())
-                .map(|c| self.quote(c))
-                .map(|c| format!("{}", c))
+                .map(|c| self.quote(c).to_string())
                 .collect();
 
-            let keys = tables.previous().referencing_foreign_keys().filter(|prev| {
-                tables
-                    .next()
-                    .referencing_foreign_keys()
-                    .any(|next| prev.foreign_key() == next.foreign_key())
-            });
-
-            // We must drop foreign keys pointing to this table before removing
-            // any of the table constraints.
-            for fk in keys {
-                result.push(self.render_drop_foreign_key(&fk));
-            }
-
-            // Then the indices...
+            // Drop the indexes on the table.
             for index in tables.previous().indexes() {
                 result.push(self.render_drop_index(&index));
             }
@@ -322,12 +308,7 @@ impl SqlRenderer for MssqlFlavour {
             // Rename the temporary table with the name defined in the migration.
             result.push(self.render_rename_table(&temporary_table_name, tables.next().name()));
 
-            // Recreating all foreign keys pointing to this table
-            for fk in tables.next().referencing_foreign_keys() {
-                result.push(self.render_add_foreign_key(&fk));
-            }
-
-            // Then the indices...
+            // Recreate the indexes.
             for index in tables.next().indexes().filter(|i| !i.index_type().is_unique()) {
                 result.push(self.render_create_index(&index));
             }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/postgres.rs
@@ -428,7 +428,7 @@ fn push_alter_enum_previous_usages_as_default(differ: &SqlSchemaDiffer<'_>, alte
         }
     }
 
-    for tables in differ.table_pairs() {
+    for tables in differ.db.table_pairs() {
         for column in tables
             .dropped_columns()
             .filter(|col| col.column_type_is_enum(enum_names.previous()) && col.default().is_some())

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/table.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/table.rs
@@ -2,7 +2,7 @@ use super::{differ_database::DifferDatabase, foreign_keys_match};
 use crate::pair::Pair;
 use sql_schema_describer::{
     walkers::{ColumnWalker, ForeignKeyWalker, IndexWalker, TableWalker},
-    PrimaryKey,
+    PrimaryKey, TableId,
 };
 
 pub(crate) struct TableDiffer<'a, 'b> {
@@ -152,6 +152,10 @@ impl<'schema, 'b> TableDiffer<'schema, 'b> {
 
     pub(super) fn next(&self) -> &TableWalker<'schema> {
         self.tables.next()
+    }
+
+    pub(super) fn table_ids(&self) -> Pair<TableId> {
+        self.tables.map(|t| t.table_id())
     }
 }
 


### PR DESCRIPTION
The problem was that when redefining tables on mssql, we did not
consider what else might have happened to the foreign keys we drop and
recreate on _other_ tables because they reference the redefined table.

That lead to the foreign key being created twice when it was on a new
table referencing the redefined table.

We now do this in a more fine-grained way: in the differ, we only
consider foreign key pairs (present in both old and new schema), on
non-redefined tables, and avoid further foreign key operations being
issued for the same foreign key.

closes https://github.com/prisma/prisma/issues/9537