### PR TITLE
Delete SqlSchemaDiffer

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
@@ -15,426 +15,379 @@ use crate::{
     SqlFlavour, SqlSchema,
 };
 use column::ColumnTypeChange;
-use enums::EnumDiffer;
-use sql_schema_describer::{
-    walkers::{EnumWalker, ForeignKeyWalker, SqlSchemaExt, TableWalker},
-    ColumnId, TableId,
-};
+use sql_schema_describer::{walkers::ForeignKeyWalker, ColumnId, TableId};
 use std::collections::HashSet;
 use table::TableDiffer;
 
 pub(crate) fn calculate_steps(schemas: Pair<&SqlSchema>, flavour: &dyn SqlFlavour) -> Vec<SqlMigrationStep> {
-    let differ = SqlSchemaDiffer::new(schemas, flavour);
+    let db = DifferDatabase::new(schemas, flavour);
     let mut steps: Vec<SqlMigrationStep> = Vec::new();
 
-    differ.push_created_tables(&mut steps);
-    differ.push_dropped_tables(&mut steps);
-    differ.drop_indexes(&mut steps);
-    differ.push_create_indexes(&mut steps);
-    differ.push_altered_tables(&mut steps);
-    flavour.push_enum_steps(&differ, &mut steps);
-    differ.push_redefine_tables(&mut steps);
+    push_created_table_steps(&mut steps, &db);
+    push_dropped_table_steps(&mut steps, &db);
+    push_dropped_index_steps(&mut steps, &db);
+    push_created_index_steps(&mut steps, &db);
+    push_altered_table_steps(&mut steps, &db);
+    flavour.push_enum_steps(&mut steps, &db);
+    push_redefined_table_steps(&mut steps, &db);
 
     steps.sort();
 
     steps
 }
 
-pub(crate) struct SqlSchemaDiffer<'a> {
-    schemas: Pair<&'a SqlSchema>,
-    db: DifferDatabase<'a>,
-}
+fn push_created_table_steps(steps: &mut Vec<SqlMigrationStep>, db: &DifferDatabase<'_>) {
+    for table in db.created_tables() {
+        steps.push(SqlMigrationStep::CreateTable {
+            table_id: table.table_id(),
+        });
 
-impl<'schema> SqlSchemaDiffer<'schema> {
-    fn new(schemas: Pair<&'schema SqlSchema>, flavour: &'schema dyn SqlFlavour) -> Self {
-        let db = DifferDatabase::new(schemas, flavour);
-
-        Self { schemas, db }
-    }
-
-    fn push_created_tables(&self, steps: &mut Vec<SqlMigrationStep>) {
-        for table in self.created_tables() {
-            steps.push(SqlMigrationStep::CreateTable {
-                table_id: table.table_id(),
-            });
-
-            if self.db.flavour.should_push_foreign_keys_from_created_tables() {
-                for fk in table.foreign_keys() {
-                    steps.push(SqlMigrationStep::AddForeignKey {
-                        table_id: table.table_id(),
-                        foreign_key_index: fk.foreign_key_index(),
-                    });
-                }
-            }
-
-            if self.db.flavour.should_create_indexes_from_created_tables() {
-                let create_indexes_from_created_tables = table
-                    .indexes()
-                    .filter(|index| !self.db.flavour.should_skip_index_for_new_table(index))
-                    .map(|index| SqlMigrationStep::CreateIndex {
-                        table_id: (None, index.table().table_id()),
-                        index_index: index.index(),
-                    });
-
-                steps.extend(create_indexes_from_created_tables);
-            }
-        }
-    }
-
-    // We drop the foreign keys of dropped tables first, so we can drop tables in whatever order we
-    // please later.
-    fn push_dropped_tables(&self, steps: &mut Vec<SqlMigrationStep>) {
-        for dropped_table in self.dropped_tables() {
-            steps.push(SqlMigrationStep::DropTable {
-                table_id: dropped_table.table_id(),
-            });
-
-            if !self.db.flavour.should_drop_foreign_keys_from_dropped_tables() {
-                continue;
-            }
-
-            for fk in dropped_table.foreign_keys() {
-                steps.push(SqlMigrationStep::DropForeignKey {
-                    table_id: dropped_table.table_id(),
+        if db.flavour.should_push_foreign_keys_from_created_tables() {
+            for fk in table.foreign_keys() {
+                steps.push(SqlMigrationStep::AddForeignKey {
+                    table_id: table.table_id(),
                     foreign_key_index: fk.foreign_key_index(),
                 });
             }
         }
+
+        if db.flavour.should_create_indexes_from_created_tables() {
+            let create_indexes_from_created_tables = table
+                .indexes()
+                .filter(|index| !db.flavour.should_skip_index_for_new_table(index))
+                .map(|index| SqlMigrationStep::CreateIndex {
+                    table_id: (None, index.table().table_id()),
+                    index_index: index.index(),
+                });
+
+            steps.extend(create_indexes_from_created_tables);
+        }
     }
+}
 
-    fn push_altered_tables(&self, steps: &mut Vec<SqlMigrationStep>) {
-        let tables = self.db.non_redefined_table_pairs();
+// We drop the foreign keys of dropped tables first, so we can drop tables in whatever order we
+// please later.
+fn push_dropped_table_steps(steps: &mut Vec<SqlMigrationStep>, db: &DifferDatabase<'_>) {
+    for dropped_table in db.dropped_tables() {
+        steps.push(SqlMigrationStep::DropTable {
+            table_id: dropped_table.table_id(),
+        });
 
-        for table in tables {
-            for created_fk in table.created_foreign_keys() {
-                steps.push(SqlMigrationStep::AddForeignKey {
-                    table_id: created_fk.table().table_id(),
-                    foreign_key_index: created_fk.foreign_key_index(),
+        if !db.flavour.should_drop_foreign_keys_from_dropped_tables() {
+            continue;
+        }
+
+        for fk in dropped_table.foreign_keys() {
+            steps.push(SqlMigrationStep::DropForeignKey {
+                table_id: dropped_table.table_id(),
+                foreign_key_index: fk.foreign_key_index(),
+            });
+        }
+    }
+}
+
+fn push_altered_table_steps(steps: &mut Vec<SqlMigrationStep>, db: &DifferDatabase<'_>) {
+    for table in db.non_redefined_table_pairs() {
+        for created_fk in table.created_foreign_keys() {
+            steps.push(SqlMigrationStep::AddForeignKey {
+                table_id: created_fk.table().table_id(),
+                foreign_key_index: created_fk.foreign_key_index(),
+            })
+        }
+
+        for dropped_fk in table.dropped_foreign_keys() {
+            steps.push(SqlMigrationStep::DropForeignKey {
+                table_id: table.previous().table_id(),
+                foreign_key_index: dropped_fk.foreign_key_index(),
+            })
+        }
+
+        for fk in table.foreign_key_pairs() {
+            push_foreign_key_pair_changes(fk, steps, db)
+        }
+
+        // Indexes.
+        for i in table
+            .index_pairs()
+            .filter(|pair| db.flavour.index_should_be_renamed(pair))
+        {
+            let table: Pair<TableId> = table.tables.map(|t| t.table_id());
+            let index: Pair<usize> = i.map(|i| i.index());
+
+            let step = if db.flavour.can_rename_index() {
+                SqlMigrationStep::RenameIndex { table, index }
+            } else {
+                SqlMigrationStep::RedefineIndex { table, index }
+            };
+
+            steps.push(step);
+        }
+
+        // Order matters.
+        let mut changes = Vec::new();
+        if let Some(change) = dropped_primary_key(&table) {
+            changes.push(change)
+        }
+
+        if let Some(change) = renamed_primary_key(&table) {
+            changes.push(change);
+        }
+
+        dropped_columns(&table, &mut changes);
+        added_columns(&table, &mut changes);
+
+        for change in alter_columns(&table) {
+            changes.push(change)
+        }
+
+        if let Some(change) = added_primary_key(&table) {
+            changes.push(change)
+        }
+
+        if changes.is_empty() {
+            continue;
+        }
+
+        for column in table.column_pairs() {
+            let ids = column.map(|c| c.column_id());
+            db.flavour.push_index_changes_for_column_changes(
+                &table,
+                ids,
+                db.column_changes(table.tables.map(|t| t.table_id()), ids),
+                steps,
+            );
+        }
+
+        steps.push(SqlMigrationStep::AlterTable(AlterTable {
+            table_ids: table.tables.map(|t| t.table_id()),
+            changes,
+        }));
+    }
+}
+
+fn dropped_columns(differ: &TableDiffer<'_, '_>, changes: &mut Vec<TableChange>) {
+    for column in differ.dropped_columns() {
+        changes.push(TableChange::DropColumn {
+            column_id: column.column_id(),
+        })
+    }
+}
+
+fn added_columns(differ: &TableDiffer<'_, '_>, changes: &mut Vec<TableChange>) {
+    for column in differ.added_columns() {
+        changes.push(TableChange::AddColumn {
+            column_id: column.column_id(),
+        })
+    }
+}
+
+fn alter_columns(table_differ: &TableDiffer<'_, '_>) -> Vec<TableChange> {
+    let mut alter_columns: Vec<_> = table_differ
+        .column_pairs()
+        .filter_map(move |column_differ| {
+            let changes = table_differ.db.column_changes(
+                table_differ.tables.map(|t| t.table_id()),
+                column_differ.map(|col| col.column_id()),
+            );
+
+            if !changes.differs_in_something() {
+                return None;
+            }
+
+            let column_id = Pair::new(column_differ.previous.column_id(), column_differ.next.column_id());
+
+            match changes.type_change {
+                Some(ColumnTypeChange::NotCastable) => Some(TableChange::DropAndRecreateColumn { column_id, changes }),
+                Some(ColumnTypeChange::RiskyCast) => Some(TableChange::AlterColumn(AlterColumn {
+                    column_id,
+                    changes,
+                    type_change: Some(crate::sql_migration::ColumnTypeChange::RiskyCast),
+                })),
+                Some(ColumnTypeChange::SafeCast) => Some(TableChange::AlterColumn(AlterColumn {
+                    column_id,
+                    changes,
+                    type_change: Some(crate::sql_migration::ColumnTypeChange::SafeCast),
+                })),
+                None => Some(TableChange::AlterColumn(AlterColumn {
+                    column_id,
+                    changes,
+                    type_change: None,
+                })),
+            }
+        })
+        .collect();
+
+    alter_columns.sort_by_key(|alter_col| match alter_col {
+        TableChange::AlterColumn(alter_col) => alter_col.column_id,
+        TableChange::DropAndRecreateColumn { column_id, .. } => *column_id,
+        _ => unreachable!(),
+    });
+
+    alter_columns
+}
+
+fn added_primary_key(differ: &TableDiffer<'_, '_>) -> Option<TableChange> {
+    let from_psl_change = differ
+        .created_primary_key()
+        .filter(|pk| !pk.columns.is_empty())
+        .map(|_| TableChange::AddPrimaryKey);
+
+    if differ.db.flavour.should_recreate_the_primary_key_on_column_recreate() {
+        from_psl_change.or_else(|| {
+            let from_recreate = alter_columns(differ).into_iter().any(|tc| match tc {
+                TableChange::DropAndRecreateColumn { column_id, .. } => {
+                    let idx = *column_id.previous();
+                    differ.previous().column_at(idx).is_part_of_primary_key()
+                }
+                _ => false,
+            });
+
+            if from_recreate {
+                Some(TableChange::AddPrimaryKey)
+            } else {
+                None
+            }
+        })
+    } else {
+        from_psl_change
+    }
+}
+
+fn dropped_primary_key(differ: &TableDiffer<'_, '_>) -> Option<TableChange> {
+    let from_psl_change = differ.dropped_primary_key().map(|_pk| TableChange::DropPrimaryKey);
+
+    if differ.db.flavour.should_recreate_the_primary_key_on_column_recreate() {
+        from_psl_change.or_else(|| {
+            let from_recreate = alter_columns(differ).into_iter().any(|tc| match tc {
+                TableChange::DropAndRecreateColumn { column_id, .. } => {
+                    let idx = *column_id.previous();
+                    differ.previous().column_at(idx).is_part_of_primary_key()
+                }
+                _ => false,
+            });
+
+            if from_recreate {
+                Some(TableChange::DropPrimaryKey)
+            } else {
+                None
+            }
+        })
+    } else {
+        from_psl_change
+    }
+}
+
+fn renamed_primary_key(differ: &TableDiffer<'_, '_>) -> Option<TableChange> {
+    differ
+        .tables
+        .map(|pk| pk.primary_key().and_then(|pk| pk.constraint_name.as_ref()))
+        .transpose()
+        .filter(|names| names.previous != names.next)
+        .map(|_| TableChange::RenamePrimaryKey)
+}
+
+fn push_created_index_steps(steps: &mut Vec<SqlMigrationStep>, db: &DifferDatabase<'_>) {
+    for tables in db.non_redefined_table_pairs() {
+        for index in tables.created_indexes() {
+            steps.push(SqlMigrationStep::CreateIndex {
+                table_id: (Some(tables.previous().table_id()), tables.next().table_id()),
+                index_index: index.index(),
+            })
+        }
+
+        if db.flavour.indexes_should_be_recreated_after_column_drop() {
+            let dropped_and_recreated_column_ids_next: HashSet<ColumnId> = tables
+                .column_pairs()
+                .filter(|columns| {
+                    matches!(
+                        db.column_changes_for_walkers(*columns).type_change,
+                        Some(ColumnTypeChange::NotCastable)
+                    )
                 })
-            }
-
-            for dropped_fk in table.dropped_foreign_keys() {
-                steps.push(SqlMigrationStep::DropForeignKey {
-                    table_id: table.previous().table_id(),
-                    foreign_key_index: dropped_fk.foreign_key_index(),
-                })
-            }
-
-            for fk in table.foreign_key_pairs() {
-                push_foreign_key_pair_changes(&table, fk, steps, &self.db)
-            }
-
-            // Indexes.
-            for i in table
-                .index_pairs()
-                .filter(|pair| self.db.flavour.index_should_be_renamed(pair))
-            {
-                let table: Pair<TableId> = table.tables.map(|t| t.table_id());
-                let index: Pair<usize> = i.map(|i| i.index());
-
-                let step = if self.db.flavour.can_rename_index() {
-                    SqlMigrationStep::RenameIndex { table, index }
-                } else {
-                    SqlMigrationStep::RedefineIndex { table, index }
-                };
-
-                steps.push(step);
-            }
-
-            // Order matters.
-            let changes: Vec<TableChange> = SqlSchemaDiffer::drop_primary_key(&table)
-                .into_iter()
-                .chain(self.rename_primary_key(&table))
-                .chain(SqlSchemaDiffer::drop_columns(&table))
-                .chain(SqlSchemaDiffer::add_columns(&table))
-                .chain(SqlSchemaDiffer::alter_columns(&table).into_iter())
-                .chain(SqlSchemaDiffer::add_primary_key(&table))
+                .map(|col| col.next.column_id())
                 .collect();
 
-            if changes.is_empty() {
+            for index in tables.index_pairs().filter(|index| {
+                index
+                    .next()
+                    .columns()
+                    .any(|col| dropped_and_recreated_column_ids_next.contains(&col.as_column().column_id()))
+            }) {
+                steps.push(SqlMigrationStep::CreateIndex {
+                    table_id: (Some(tables.previous().table_id()), tables.next().table_id()),
+                    index_index: index.next().index(),
+                })
+            }
+        }
+    }
+}
+
+fn push_dropped_index_steps(steps: &mut Vec<SqlMigrationStep>, db: &DifferDatabase<'_>) {
+    let mut drop_indexes = HashSet::new();
+
+    for tables in db.non_redefined_table_pairs() {
+        for index in tables.dropped_indexes() {
+            // On MySQL, foreign keys automatically create indexes. These foreign-key-created
+            // indexes should only be dropped as part of the foreign key.
+            if db.flavour.should_skip_fk_indexes() && index::index_covers_fk(tables.previous(), &index) {
                 continue;
             }
 
-            for column in table.column_pairs() {
-                let ids = column.map(|c| c.column_id());
-                self.db.flavour.push_index_changes_for_column_changes(
-                    &table,
-                    ids,
-                    self.db.column_changes(table.tables.map(|t| t.table_id()), ids),
-                    steps,
-                );
-            }
-
-            steps.push(SqlMigrationStep::AlterTable(AlterTable {
-                table_ids: table.tables.map(|t| t.table_id()),
-                changes,
-            }));
+            drop_indexes.insert((index.table().table_id(), index.index()));
         }
     }
 
-    fn drop_columns<'a>(differ: &'a TableDiffer<'schema, 'a>) -> impl Iterator<Item = TableChange> + 'a {
-        differ.dropped_columns().map(|column| TableChange::DropColumn {
-            column_id: column.column_id(),
-        })
-    }
-
-    fn add_columns<'a>(differ: &'a TableDiffer<'schema, 'a>) -> impl Iterator<Item = TableChange> + 'a {
-        differ.added_columns().map(move |column| TableChange::AddColumn {
-            column_id: column.column_id(),
-        })
-    }
-
-    fn alter_columns(table_differ: &TableDiffer<'_, '_>) -> Vec<TableChange> {
-        let mut alter_columns: Vec<_> = table_differ
-            .column_pairs()
-            .filter_map(move |column_differ| {
-                let changes = table_differ.db.column_changes(
-                    table_differ.tables.map(|t| t.table_id()),
-                    column_differ.map(|col| col.column_id()),
-                );
-
-                if !changes.differs_in_something() {
-                    return None;
-                }
-
-                let column_id = Pair::new(column_differ.previous.column_id(), column_differ.next.column_id());
-
-                match changes.type_change {
-                    Some(ColumnTypeChange::NotCastable) => {
-                        Some(TableChange::DropAndRecreateColumn { column_id, changes })
-                    }
-                    Some(ColumnTypeChange::RiskyCast) => Some(TableChange::AlterColumn(AlterColumn {
-                        column_id,
-                        changes,
-                        type_change: Some(crate::sql_migration::ColumnTypeChange::RiskyCast),
-                    })),
-                    Some(ColumnTypeChange::SafeCast) => Some(TableChange::AlterColumn(AlterColumn {
-                        column_id,
-                        changes,
-                        type_change: Some(crate::sql_migration::ColumnTypeChange::SafeCast),
-                    })),
-                    None => Some(TableChange::AlterColumn(AlterColumn {
-                        column_id,
-                        changes,
-                        type_change: None,
-                    })),
-                }
-            })
-            .collect();
-
-        alter_columns.sort_by_key(|alter_col| match alter_col {
-            TableChange::AlterColumn(alter_col) => alter_col.column_id,
-            TableChange::DropAndRecreateColumn { column_id, .. } => *column_id,
-            _ => unreachable!(),
-        });
-
-        alter_columns
-    }
-
-    fn add_primary_key(differ: &TableDiffer<'_, '_>) -> Option<TableChange> {
-        let from_psl_change = differ
-            .created_primary_key()
-            .filter(|pk| !pk.columns.is_empty())
-            .map(|_| TableChange::AddPrimaryKey);
-
-        if differ.db.flavour.should_recreate_the_primary_key_on_column_recreate() {
-            from_psl_change.or_else(|| {
-                let from_recreate = Self::alter_columns(differ).into_iter().any(|tc| match tc {
-                    TableChange::DropAndRecreateColumn { column_id, .. } => {
-                        let idx = *column_id.previous();
-                        differ.previous().column_at(idx).is_part_of_primary_key()
-                    }
-                    _ => false,
-                });
-
-                if from_recreate {
-                    Some(TableChange::AddPrimaryKey)
-                } else {
-                    None
-                }
-            })
-        } else {
-            from_psl_change
-        }
-    }
-
-    fn drop_primary_key(differ: &TableDiffer<'_, '_>) -> Option<TableChange> {
-        let from_psl_change = differ.dropped_primary_key().map(|_pk| TableChange::DropPrimaryKey);
-
-        if differ.db.flavour.should_recreate_the_primary_key_on_column_recreate() {
-            from_psl_change.or_else(|| {
-                let from_recreate = Self::alter_columns(differ).into_iter().any(|tc| match tc {
-                    TableChange::DropAndRecreateColumn { column_id, .. } => {
-                        let idx = *column_id.previous();
-                        differ.previous().column_at(idx).is_part_of_primary_key()
-                    }
-                    _ => false,
-                });
-
-                if from_recreate {
-                    Some(TableChange::DropPrimaryKey)
-                } else {
-                    None
-                }
-            })
-        } else {
-            from_psl_change
-        }
-    }
-
-    fn rename_primary_key(&self, differ: &TableDiffer<'_, '_>) -> Option<TableChange> {
-        differ
-            .tables
-            .map(|pk| pk.primary_key().and_then(|pk| pk.constraint_name.as_ref()))
-            .transpose()
-            .filter(|names| names.previous != names.next)
-            .map(|_| TableChange::RenamePrimaryKey)
-    }
-
-    fn push_create_indexes(&self, steps: &mut Vec<SqlMigrationStep>) {
-        for tables in self.db.non_redefined_table_pairs() {
-            for index in tables.created_indexes() {
-                steps.push(SqlMigrationStep::CreateIndex {
-                    table_id: (Some(tables.previous().table_id()), tables.next().table_id()),
-                    index_index: index.index(),
-                })
-            }
-
-            if self.db.flavour.indexes_should_be_recreated_after_column_drop() {
-                let dropped_and_recreated_column_ids_next: HashSet<ColumnId> = tables
-                    .column_pairs()
-                    .filter(|columns| {
-                        matches!(
-                            self.db.column_changes_for_walkers(*columns).type_change,
-                            Some(ColumnTypeChange::NotCastable)
-                        )
-                    })
-                    .map(|col| col.next.column_id())
-                    .collect();
-
-                for index in tables.index_pairs().filter(|index| {
-                    index
-                        .next()
-                        .columns()
-                        .any(|col| dropped_and_recreated_column_ids_next.contains(&col.as_column().column_id()))
-                }) {
-                    steps.push(SqlMigrationStep::CreateIndex {
-                        table_id: (Some(tables.previous().table_id()), tables.next().table_id()),
-                        index_index: index.next().index(),
-                    })
-                }
-            }
-        }
-    }
-
-    fn drop_indexes(&self, steps: &mut Vec<SqlMigrationStep>) {
-        let mut drop_indexes = HashSet::new();
-
-        for tables in self.db.non_redefined_table_pairs() {
-            for index in tables.dropped_indexes() {
-                // On MySQL, foreign keys automatically create indexes. These foreign-key-created
-                // indexes should only be dropped as part of the foreign key.
-                if self.db.flavour.should_skip_fk_indexes() && index::index_covers_fk(tables.previous(), &index) {
-                    continue;
-                }
-
+    // On SQLite, we will recreate indexes in the RedefineTables step,
+    // because they are needed for implementing new foreign key constraints.
+    if !db.tables_to_redefine.is_empty() && db.flavour.should_drop_indexes_from_dropped_tables() {
+        for table in db.dropped_tables() {
+            for index in table.indexes() {
                 drop_indexes.insert((index.table().table_id(), index.index()));
             }
         }
-
-        // On SQLite, we will recreate indexes in the RedefineTables step,
-        // because they are needed for implementing new foreign key constraints.
-        if !self.db.tables_to_redefine.is_empty() && self.db.flavour.should_drop_indexes_from_dropped_tables() {
-            for table in self.dropped_tables() {
-                for index in table.indexes() {
-                    drop_indexes.insert((index.table().table_id(), index.index()));
-                }
-            }
-        }
-
-        for (table_id, index_index) in drop_indexes.into_iter() {
-            steps.push(SqlMigrationStep::DropIndex { table_id, index_index })
-        }
     }
 
-    fn push_redefine_tables(&self, steps: &mut Vec<SqlMigrationStep>) {
-        if self.db.tables_to_redefine.is_empty() {
-            return;
-        }
+    for (table_id, index_index) in drop_indexes.into_iter() {
+        steps.push(SqlMigrationStep::DropIndex { table_id, index_index })
+    }
+}
 
-        let tables_to_redefine = self
-            .db
-            .table_pairs()
-            .filter(|tables| self.db.tables_to_redefine.contains(&tables.table_ids()))
-            .map(|differ| {
-                let column_pairs = differ
-                    .column_pairs()
-                    .map(|columns| {
-                        let changes = self.db.column_changes_for_walkers(columns);
-                        (
-                            Pair::new(columns.previous.column_id(), columns.next.column_id()),
-                            changes,
-                            changes.type_change.map(|tc| match tc {
-                                ColumnTypeChange::SafeCast => sql_migration::ColumnTypeChange::SafeCast,
-                                ColumnTypeChange::RiskyCast => sql_migration::ColumnTypeChange::RiskyCast,
-                                ColumnTypeChange::NotCastable => sql_migration::ColumnTypeChange::NotCastable,
-                            }),
-                        )
-                    })
-                    .collect();
-
-                RedefineTable {
-                    table_ids: differ.tables.as_ref().map(|t| t.table_id()),
-                    dropped_primary_key: SqlSchemaDiffer::drop_primary_key(&differ).is_some(),
-                    added_columns: differ.added_columns().map(|col| col.column_id()).collect(),
-                    dropped_columns: differ.dropped_columns().map(|col| col.column_id()).collect(),
-                    column_pairs,
-                }
-            })
-            .collect();
-
-        steps.push(SqlMigrationStep::RedefineTables(tables_to_redefine))
+fn push_redefined_table_steps(steps: &mut Vec<SqlMigrationStep>, db: &DifferDatabase<'_>) {
+    if db.tables_to_redefine.is_empty() {
+        return;
     }
 
-    fn created_tables(&self) -> impl Iterator<Item = TableWalker<'schema>> + '_ {
-        self.db
-            .created_tables()
-            .map(move |table_id| self.schemas.next().table_walker_at(table_id))
-    }
-
-    fn dropped_tables(&self) -> impl Iterator<Item = TableWalker<'schema>> + '_ {
-        self.db
-            .dropped_tables()
-            .map(move |table_id| self.schemas.previous().table_walker_at(table_id))
-    }
-
-    fn enum_pairs(&self) -> impl Iterator<Item = EnumDiffer<'_>> {
-        self.previous_enums().filter_map(move |previous| {
-            self.next_enums()
-                .find(|next| enums_match(&previous, next))
-                .map(|next| EnumDiffer {
-                    enums: Pair::new(previous, next),
+    let tables_to_redefine = db
+        .table_pairs()
+        .filter(|tables| db.tables_to_redefine.contains(&tables.table_ids()))
+        .map(|differ| {
+            let column_pairs = differ
+                .column_pairs()
+                .map(|columns| {
+                    let changes = db.column_changes_for_walkers(columns);
+                    (
+                        Pair::new(columns.previous.column_id(), columns.next.column_id()),
+                        changes,
+                        changes.type_change.map(|tc| match tc {
+                            ColumnTypeChange::SafeCast => sql_migration::ColumnTypeChange::SafeCast,
+                            ColumnTypeChange::RiskyCast => sql_migration::ColumnTypeChange::RiskyCast,
+                            ColumnTypeChange::NotCastable => sql_migration::ColumnTypeChange::NotCastable,
+                        }),
+                    )
                 })
+                .collect();
+
+            RedefineTable {
+                table_ids: differ.tables.as_ref().map(|t| t.table_id()),
+                dropped_primary_key: dropped_primary_key(&differ).is_some(),
+                added_columns: differ.added_columns().map(|col| col.column_id()).collect(),
+                dropped_columns: differ.dropped_columns().map(|col| col.column_id()).collect(),
+                column_pairs,
+            }
         })
-    }
+        .collect();
 
-    fn created_enums<'a>(&'a self) -> impl Iterator<Item = EnumWalker<'schema>> + 'a {
-        self.next_enums()
-            .filter(move |next| !self.previous_enums().any(|previous| enums_match(&previous, next)))
-    }
-
-    fn dropped_enums<'a>(&'a self) -> impl Iterator<Item = EnumWalker<'schema>> + 'a {
-        self.previous_enums()
-            .filter(move |previous| !self.next_enums().any(|next| enums_match(previous, &next)))
-    }
-
-    fn previous_enums(&self) -> impl Iterator<Item = EnumWalker<'schema>> {
-        self.schemas.previous().enum_walkers()
-    }
-
-    fn next_enums(&self) -> impl Iterator<Item = EnumWalker<'schema>> {
-        self.schemas.next().enum_walkers()
-    }
+    steps.push(SqlMigrationStep::RedefineTables(tables_to_redefine))
 }
 
 /// Compare two foreign keys and return whether they should be considered
@@ -475,12 +428,7 @@ fn foreign_keys_match(fks: Pair<&ForeignKeyWalker<'_>>, db: &DifferDatabase<'_>)
         && same_on_update_action
 }
 
-fn enums_match(previous: &EnumWalker<'_>, next: &EnumWalker<'_>) -> bool {
-    previous.name() == next.name()
-}
-
 fn push_foreign_key_pair_changes(
-    table: &TableDiffer<'_, '_>,
     fk: Pair<ForeignKeyWalker<'_>>,
     steps: &mut Vec<SqlMigrationStep>,
     db: &DifferDatabase<'_>,
@@ -491,11 +439,11 @@ fn push_foreign_key_pair_changes(
         && !db.flavour.can_redefine_tables_with_inbound_foreign_keys()
     {
         steps.push(SqlMigrationStep::DropForeignKey {
-            table_id: table.previous().table_id(),
+            table_id: fk.previous().table().table_id(),
             foreign_key_index: fk.previous().foreign_key_index(),
         });
         steps.push(SqlMigrationStep::AddForeignKey {
-            table_id: table.next().table_id(),
+            table_id: fk.next().table().table_id(),
             foreign_key_index: fk.next().foreign_key_index(),
         });
         return;
@@ -513,16 +461,16 @@ fn push_foreign_key_pair_changes(
     {
         if db.flavour.can_rename_foreign_key() {
             steps.push(SqlMigrationStep::RenameForeignKey {
-                table_id: table.tables.map(|t| t.table_id()),
+                table_id: fk.map(|fk| fk.table().table_id()),
                 foreign_key_id: fk.map(|fk| fk.foreign_key_index()),
             })
         } else {
             steps.push(SqlMigrationStep::AddForeignKey {
-                table_id: table.next().table_id(),
+                table_id: fk.next().table().table_id(),
                 foreign_key_index: fk.next().foreign_key_index(),
             });
             steps.push(SqlMigrationStep::DropForeignKey {
-                table_id: table.previous().table_id(),
+                table_id: fk.previous().table().table_id(),
                 foreign_key_index: fk.previous().foreign_key_index(),
             })
         }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour.rs
@@ -1,4 +1,4 @@
-use super::{differ_database::DifferDatabase, ColumnTypeChange, SqlSchemaDiffer};
+use super::{differ_database::DifferDatabase, ColumnTypeChange};
 use crate::{pair::Pair, sql_migration::SqlMigrationStep, sql_schema_differ};
 use sql_schema_describer::{
     walkers::{ColumnWalker, IndexWalker},
@@ -42,7 +42,7 @@ pub(crate) trait SqlSchemaDifferFlavour {
     }
 
     /// Push enum-related steps.
-    fn push_enum_steps(&self, _differ: &SqlSchemaDiffer<'_>, _steps: &mut Vec<SqlMigrationStep>) {}
+    fn push_enum_steps(&self, _steps: &mut Vec<SqlMigrationStep>, _db: &DifferDatabase<'_>) {}
 
     /// Returns whether the underlying database implicitly drops indexes on dropped (and potentially recreated) columns.
     fn indexes_should_be_recreated_after_column_drop(&self) -> bool {


### PR DESCRIPTION
Not the differ implementation, but the concrete struct, since it does
not serve any purpose anymore. Most of its utility has been absorbed by
DifferDatabase.

We take this opportunity to make the naming of functions in the
sql_schema_differ module more uniform.