### PR TITLE
Remove the `version()` method of prisma-fmt wasm

### DIFF
--- a/prisma-fmt/src/lib.rs
+++ b/prisma-fmt/src/lib.rs
@@ -23,18 +23,3 @@ pub fn preview_features() -> String {
 pub fn referential_actions(schema: String) -> String {
     actions::run(&schema)
 }
-
-pub fn version() -> String {
-    let git_hash = env!("GIT_HASH");
-    format!("wasm+{}", git_hash)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn version_works() {
-        assert_eq!(version().len(), 45) // 40 from the sha + 5 for "wasm+"
-    }
-}


### PR DESCRIPTION
It doesn't work, because `env!("GIT_HASH")` gets resolved in the parent
project building the crate, so it doesn't actually give us the engine
commit hash. We'll use another solution on the prisma-fmt-wasm side.