### PR TITLE
Revert "MySQL Migrations should always render dbgenerated (#2353)"

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
@@ -27,14 +27,13 @@ impl MysqlFlavour {
             default: col
                 .default()
                 .filter(|default| {
-                    match (default.kind(), col.column_type_family()) {
-                        (DefaultKind::Sequence(_), _) => false,
-                        (DefaultKind::DbGenerated(_), _) => true,
-                        // We do not want to render JSON or binary defaults because
-                        // they are not supported by MySQL.
-                        (_, ColumnTypeFamily::Json | ColumnTypeFamily::Binary) => false,
-                        _ => true,
-                    }
+                    !matches!(default.kind(),  DefaultKind::Sequence(_))
+                    // We do not want to render JSON defaults because
+                    // they are not supported by MySQL.
+                    && !matches!(col.column_type_family(), ColumnTypeFamily::Json)
+                    // We do not want to render binary defaults because
+                    // they are not supported by MySQL.
+                    && !matches!(col.column_type_family(), ColumnTypeFamily::Binary)
                 })
                 .map(|default| render_default(col, default)),
             auto_increment: col.is_autoincrement(),
@@ -484,7 +483,7 @@ impl MysqlAlterColumn {
 
 fn render_default<'a>(column: &ColumnWalker<'a>, default: &'a DefaultValue) -> Cow<'a, str> {
     match default.kind() {
-        DefaultKind::DbGenerated(val) => format!("({})", val.as_str()).into(),
+        DefaultKind::DbGenerated(val) => val.as_str().into(),
         DefaultKind::Value(PrismaValue::String(val)) | DefaultKind::Value(PrismaValue::Enum(val)) => {
             Quoted::mysql_string(escape_string_literal(val)).to_string().into()
         }

--- a/migration-engine/migration-engine-tests/tests/schema_push/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/schema_push/mod.rs
@@ -1,5 +1,5 @@
 use migration_engine_tests::test_api::*;
-use sql_schema_describer::{ColumnTypeFamily, DefaultKind};
+use sql_schema_describer::ColumnTypeFamily;
 
 const SCHEMA: &str = r#"
 model Cat {
@@ -365,24 +365,4 @@ fn duplicate_constraint_names_across_models_work_on_mysql(api: TestApi) {
      "#;
 
     api.schema_push_w_datasource(plain_dm).send().assert_green();
-}
-
-#[test_connector(tags(Mysql8))]
-fn binary_uuid_default_value(api: TestApi) {
-    let dm = r#"
-      model Test {
-        id   Bytes  @id @default(dbgenerated("uuid_to_bin(uuid())")) @db.Binary(16)
-      }
-    "#;
-
-    api.schema_push_w_datasource(dm)
-        .send()
-        .assert_green()
-        .assert_has_executed_steps();
-
-    api.assert_schema().assert_table("Test", |table| {
-        table.assert_column("id", |col| {
-            col.assert_default_kind(Some(DefaultKind::DbGenerated("(uuid_to_bin(uuid()))".into())))
-        })
-    });
 }


### PR DESCRIPTION
Closes: https://github.com/prisma/prisma/issues/10275

@cprieto use parentheses in the PSL...