### PR TITLE
add error when batching and using an not in filter

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
@@ -1,3 +1,4 @@
 mod prisma_6173;
 mod prisma_7072;
+mod prisma_7434;
 mod prisma_8265;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_7434.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_7434.rs
@@ -12,7 +12,7 @@ mod not_in_batching {
             runner,
             "query { findManyTestModel(where: { id: { notIn: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11] } }) { id }}",
             2029,
-            "Your query cannot be split into multiple queries because the filter will cause incorrect results"
+            "Parameter limits for this database provider require this query to be split into multiple queries, but the negation filters used prevent the query from being split. Please reduce the used values in the query."
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_7434.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_7434.rs
@@ -1,0 +1,20 @@
+use query_engine_tests::*;
+
+#[test_suite(schema(autoinc_id), capabilities(CreateMany, AutoIncrement))]
+mod not_in_batching {
+    use query_engine_tests::Runner;
+
+    #[connector_test]
+    async fn not_in_batch_filter(runner: Runner) -> TestResult<()> {
+        runner.query(r#"mutation { createManyTestModel(data: [{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{}]) { count }}"#).await?.assert_success();
+
+        assert_error!(
+            runner,
+            "query { findManyTestModel(where: { id: { notIn: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11] } }) { id }}",
+            2029,
+            "Your query cannot be split into multiple queries because the filter will cause incorrect results"
+        );
+
+        Ok(())
+    }
+}

--- a/query-engine/connectors/query-connector/src/filter/mod.rs
+++ b/query-engine/connectors/query-connector/src/filter/mod.rs
@@ -76,6 +76,15 @@ impl Filter {
         }
     }
 
+    pub fn can_batch(&self) -> bool {
+        match self {
+            Self::Scalar(sf) => sf.can_batch(),
+            Self::And(filters) => filters.iter().all(|f| f.can_batch()),
+            Self::Or(filters) => filters.iter().all(|f| f.can_batch()),
+            _ => true,
+        }
+    }
+
     pub fn batched(self, chunk_size: usize) -> Vec<Filter> {
         fn split_longest(mut filters: Vec<Filter>, chunk_size: usize) -> (Option<ScalarFilter>, Vec<Filter>) {
             let mut longest: Option<ScalarFilter> = None;

--- a/query-engine/connectors/query-connector/src/filter/scalar.rs
+++ b/query-engine/connectors/query-connector/src/filter/scalar.rs
@@ -66,15 +66,15 @@ impl ScalarFilter {
     }
 
     pub fn can_batch(&self) -> bool {
-        match self.condition {
-            ScalarCondition::NotContains(_) => false,
-            ScalarCondition::NotEquals(_) => false,
-            ScalarCondition::NotIn(_) => false,
-            ScalarCondition::NotSearch(..) => false,
-            ScalarCondition::NotStartsWith(_) => false,
-            ScalarCondition::NotEndsWith(_) => false,
-            _ => true,
-        }
+        !matches!(
+            self.condition,
+            ScalarCondition::NotContains(_)
+                | ScalarCondition::NotEquals(_)
+                | ScalarCondition::NotIn(_)
+                | ScalarCondition::NotSearch(..)
+                | ScalarCondition::NotStartsWith(_)
+                | ScalarCondition::NotEndsWith(_)
+        )
     }
 
     /// If possible, converts the filter into multiple smaller filters.

--- a/query-engine/connectors/query-connector/src/filter/scalar.rs
+++ b/query-engine/connectors/query-connector/src/filter/scalar.rs
@@ -66,7 +66,15 @@ impl ScalarFilter {
     }
 
     pub fn can_batch(&self) -> bool {
-        !matches!(self.condition, ScalarCondition::NotIn(_))
+        match self.condition {
+            ScalarCondition::NotContains(_) => false,
+            ScalarCondition::NotEquals(_) => false,
+            ScalarCondition::NotIn(_) => false,
+            ScalarCondition::NotSearch(..) => false,
+            ScalarCondition::NotStartsWith(_) => false,
+            ScalarCondition::NotEndsWith(_) => false,
+            _ => true,
+        }
     }
 
     /// If possible, converts the filter into multiple smaller filters.

--- a/query-engine/connectors/query-connector/src/filter/scalar.rs
+++ b/query-engine/connectors/query-connector/src/filter/scalar.rs
@@ -65,6 +65,10 @@ impl ScalarFilter {
         self.len() > chunk_size
     }
 
+    pub fn can_batch(&self) -> bool {
+        !matches!(self.condition, ScalarCondition::NotIn(_))
+    }
+
     /// If possible, converts the filter into multiple smaller filters.
     pub fn batched(self, chunk_size: usize) -> Vec<ScalarFilter> {
         fn inner(mut list: PrismaListValue, chunk_size: usize) -> Vec<PrismaListValue> {

--- a/query-engine/connectors/query-connector/src/query_arguments.rs
+++ b/query-engine/connectors/query-connector/src/query_arguments.rs
@@ -153,6 +153,13 @@ impl QueryArguments {
         })
     }
 
+    pub fn has_unbatchable_filters(&self) -> bool {
+        match &self.filter {
+            None => false,
+            Some(filter) => !filter.can_batch(),
+        }
+    }
+
     pub fn should_batch(&self, chunk_size: usize) -> bool {
         self.filter
             .as_ref()

--- a/query-engine/connectors/sql-query-connector/src/database/operations/read.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/read.rs
@@ -94,7 +94,7 @@ pub async fn get_many_records(
 
             if query_arguments.has_unbatchable_filters() {
                 return Err(SqlError::QueryParameterLimitExceeded(
-                    "Your query cannot be split into multiple queries because the filter will cause incorrect results"
+                    "Parameter limits for this database provider require this query to be split into multiple queries, but the negation filters used prevent the query from being split. Please reduce the used values in the query."
                         .to_string(),
                 ));
             }

--- a/query-engine/connectors/sql-query-connector/src/database/operations/read.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/read.rs
@@ -92,6 +92,13 @@ pub async fn get_many_records(
                 ));
             }
 
+            if query_arguments.has_unbatchable_filters() {
+                return Err(SqlError::QueryParameterLimitExceeded(
+                    "Your query cannot be split into multiple queries because the filter will cause incorrect results"
+                        .to_string(),
+                ));
+            }
+
             // We don't need to order in the database due to us ordering in this function.
             let order = std::mem::take(&mut query_arguments.order_by);
 


### PR DESCRIPTION
Return an error if we get into a situation where we need to batch the query and we have a `not` filter. 

This fixes https://github.com/prisma/prisma/issues/7434