### PR TITLE
Delete ast::Model::try_id_attribute()

### DIFF
--- a/libs/datamodel/core/src/ast/model.rs
+++ b/libs/datamodel/core/src/ast/model.rs
@@ -53,21 +53,6 @@ impl Model {
         self.find_field(name).unwrap()
     }
 
-    pub(crate) fn id_attribute(&self) -> &Attribute {
-        self.try_id_attribute().unwrap()
-    }
-
-    #[track_caller]
-    pub(crate) fn try_id_attribute(&self) -> Option<&Attribute> {
-        let from_model = self.attributes().iter().find(|attr| attr.is_id());
-
-        let mut from_field = self
-            .iter_fields()
-            .flat_map(|(_, field)| field.attributes().iter().find(|attr| attr.is_id()));
-
-        from_model.or_else(|| from_field.next())
-    }
-
     pub(crate) fn name(&self) -> &str {
         &self.name.name
     }

--- a/libs/datamodel/core/src/transform/ast_to_dml/db/attributes/id.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/attributes/id.rs
@@ -100,6 +100,7 @@ pub(super) fn model<'ast>(
 
     model_data.primary_key = Some(IdAttribute {
         name,
+        source_attribute: args.attribute(),
         db_name,
         fields: resolved_fields,
         source_field: None,
@@ -150,6 +151,7 @@ pub(super) fn field<'ast>(
             model_attributes.primary_key = Some(IdAttribute {
                 name: None,
                 db_name,
+                source_attribute: args.attribute(),
                 fields: vec![FieldWithArgs {
                     field_id,
                     sort_order,

--- a/libs/datamodel/core/src/transform/ast_to_dml/db/types.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/types.rs
@@ -192,10 +192,11 @@ pub(crate) struct IndexAttribute<'ast> {
     pub(crate) db_name: Option<Cow<'ast, str>>,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub(crate) struct IdAttribute<'ast> {
     pub(crate) fields: Vec<FieldWithArgs>,
     pub(super) source_field: Option<FieldId>,
+    pub(super) source_attribute: &'ast ast::Attribute,
     pub(super) name: Option<&'ast str>,
     pub(super) db_name: Option<&'ast str>,
 }

--- a/libs/datamodel/core/src/transform/ast_to_dml/db/walkers/model/primary_key.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/walkers/model/primary_key.rs
@@ -21,15 +21,7 @@ pub(crate) struct PrimaryKeyWalker<'ast, 'db> {
 impl<'ast, 'db> PrimaryKeyWalker<'ast, 'db> {
     #[track_caller]
     pub(crate) fn ast_attribute(self) -> &'ast ast::Attribute {
-        self.ast_model().id_attribute()
-    }
-
-    pub(crate) fn has_ast_attribute(self) -> bool {
-        self.ast_model().try_id_attribute().is_some()
-    }
-
-    fn ast_model(&self) -> &'ast ast::Model {
-        &self.db.ast[self.model_id]
+        self.attribute.source_attribute
     }
 
     pub(crate) fn final_database_name(self) -> Option<Cow<'ast, str>> {

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations.rs
@@ -25,13 +25,7 @@ pub(super) fn validate(db: &ParserDatabase<'_>, diagnostics: &mut Diagnostics, r
 
         if let Some(pk) = model.primary_key() {
             for field_attribute in pk.scalar_field_attributes() {
-                // Type aliases will panic here... :(
-                let span = if pk.has_ast_attribute() {
-                    pk.ast_attribute().span
-                } else {
-                    ast::Span::empty()
-                };
-
+                let span = pk.ast_attribute().span;
                 let attribute = ("id", span);
                 fields::validate_length_used_with_correct_types(db, field_attribute, attribute, diagnostics);
             }


### PR DESCRIPTION
This is used during validation, where we have much better tools to track
the attribute.