### PR TITLE
Fix pagination tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -215,6 +215,16 @@ services:
       - "1433:1433"
     networks:
       - databases
+  azure-edge:
+    image: mcr.microsoft.com/azure-sql-edge
+    restart: always
+    environment:
+      ACCEPT_EULA: "Y"
+      MSSQL_SA_PASSWORD: "<YourStrong@Passw0rd>"
+    ports:
+      - "1433:1433"
+    networks:
+      - databases
 
   mssql-2017:
     image: mcr.microsoft.com/mssql/server:2017-latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -255,7 +255,6 @@ services:
     environment:
       MONGO_INITDB_ROOT_USERNAME: "prisma"
       MONGO_INITDB_ROOT_PASSWORD: "prisma"
-      INIT_WAIT_SEC: 10
     ports:
       - "27017:27017"
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -255,6 +255,7 @@ services:
     environment:
       MONGO_INITDB_ROOT_USERNAME: "prisma"
       MONGO_INITDB_ROOT_PASSWORD: "prisma"
+      INIT_WAIT_SEC: 10
     ports:
       - "27017:27017"
     networks:

--- a/query-engine/connector-test-kit-rs/query-engine-tests/src/utils/querying.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/src/utils/querying.rs
@@ -7,7 +7,7 @@ macro_rules! assert_query {
 }
 
 #[macro_export]
-macro_rules! connector_results {
+macro_rules! match_connector_result {
     ($runner:expr, $q:expr, $([$($connector_opt:ident),*] => $result:expr),*) => {
         use query_tests_setup::ConnectorTag::*;
         let connector = $runner.connector();

--- a/query-engine/connector-test-kit-rs/query-engine-tests/src/utils/querying.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/src/utils/querying.rs
@@ -35,16 +35,16 @@ macro_rules! connector_results {
             )*
         )*
 
-        if results.len() == 0 {
-            panic!(format!("No results defined for connector {}", connector));
-        }
-
         let query_result = $runner.query($q).await?.to_string();
+
+        if results.len() == 0 {
+            panic!(format!("No results defined for connector {}. Query result: {}", connector, query_result));
+        }
 
         assert_eq!(
             results.contains(&query_result.as_str()),
             true,
-            "Query result: {} is not part of the expected results: {:?} for connector {:?}",
+            "Query result: {} is not part of the expected results: {:?} for connector {}",
             query_result,
             results,
             connector

--- a/query-engine/connector-test-kit-rs/query-engine-tests/src/utils/querying.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/src/utils/querying.rs
@@ -7,21 +7,6 @@ macro_rules! assert_query {
 }
 
 #[macro_export]
-macro_rules! assert_query_many {
-    ($runner:expr, $q:expr, $potential_results:expr) => {
-        let query_result = $runner.query($q).await?.to_string();
-
-        assert_eq!(
-            $potential_results.contains(&query_result.as_str()),
-            true,
-            "Query result: {} is not part of the expected results: {:?}",
-            query_result,
-            $potential_results
-        );
-    };
-}
-
-#[macro_export]
 macro_rules! connector_results {
     ($runner:expr, $q:expr, $([$($connector_opt:ident),*] => $result:expr),*) => {
         use query_tests_setup::ConnectorTag::*;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/group_by_having.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/group_by_having.rs
@@ -54,10 +54,9 @@ mod aggregation_group_by_having {
                 _sum { int }
               }
             }"#,
-            [SqlServer, Postgres, MySql, Sqlite] => r#"{"data":{"groupByTestModel":[{"string":"group1","int":5,"_count":{"_all":1},"_sum":{"int":5}},{"string":"group2","int":5,"_count":{"_all":1},"_sum":{"int":5}}]}}"#,
-            [MongoDb] =>   r#"{"data":{"groupByTestModel":[{"string":"group2","int":5,"_count":{"_all":1},"_sum":{"int":5}},{"string":"group1","int":5,"_count":{"_all":1},"_sum":{"int":5}}]}}"#
+            [SqlServer, Postgres, MySql, Sqlite, MongoDb] => r#"{"data":{"groupByTestModel":[{"string":"group1","int":5,"_count":{"_all":1},"_sum":{"int":5}},{"string":"group2","int":5,"_count":{"_all":1},"_sum":{"int":5}}]}}"#,
+            [] =>   r#"{"data":{"groupByTestModel":[{"string":"group2","int":5,"_count":{"_all":1},"_sum":{"int":5}},{"string":"group1","int":5,"_count":{"_all":1},"_sum":{"int":5}}]}}"#
         );
-
         Ok(())
     }
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/group_by_having.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/group_by_having.rs
@@ -55,7 +55,7 @@ mod aggregation_group_by_having {
               }
             }"#,
             [SqlServer, Postgres, MySql, Sqlite, MongoDb] => r#"{"data":{"groupByTestModel":[{"string":"group1","int":5,"_count":{"_all":1},"_sum":{"int":5}},{"string":"group2","int":5,"_count":{"_all":1},"_sum":{"int":5}}]}}"#,
-            [] =>   r#"{"data":{"groupByTestModel":[{"string":"group2","int":5,"_count":{"_all":1},"_sum":{"int":5}},{"string":"group1","int":5,"_count":{"_all":1},"_sum":{"int":5}}]}}"#
+            [MongoDb] =>   r#"{"data":{"groupByTestModel":[{"string":"group2","int":5,"_count":{"_all":1},"_sum":{"int":5}},{"string":"group1","int":5,"_count":{"_all":1},"_sum":{"int":5}}]}}"#
         );
         Ok(())
     }

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/group_by_having.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/group_by_having.rs
@@ -42,7 +42,7 @@ mod aggregation_group_by_having {
         // group1, 0
         // group2, 5
         // group3, 5
-        connector_results!(
+        match_connector_result!(
             &runner,
             r#"query { groupByTestModel(by: [string, int], having: {
                 string: { in: ["group1", "group2"] }

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/group_by_having.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/group_by_having.rs
@@ -8,7 +8,7 @@ use query_engine_tests::*;
 //   operators applied. For a good confidence, we choose `equals`, `in`, `not equals`, `endsWith` (where applicable).
 #[test_suite(schema(schemas::common_text_and_numeric_types_optional))]
 mod aggregation_group_by_having {
-    use query_engine_tests::{assert_error, assert_query_many, run_query, Runner};
+    use query_engine_tests::{assert_error, run_query, Runner};
 
     // This is just basic confirmation that scalar filters are applied correctly.
     // The assumption is that we don't need to test all normal scalar filters as they share the exact same code path
@@ -42,7 +42,7 @@ mod aggregation_group_by_having {
         // group1, 0
         // group2, 5
         // group3, 5
-        assert_query_many!(
+        connector_results!(
             &runner,
             r#"query { groupByTestModel(by: [string, int], having: {
                 string: { in: ["group1", "group2"] }
@@ -54,10 +54,8 @@ mod aggregation_group_by_having {
                 _sum { int }
               }
             }"#,
-            vec![
-                r#"{"data":{"groupByTestModel":[{"string":"group1","int":5,"_count":{"_all":1},"_sum":{"int":5}},{"string":"group2","int":5,"_count":{"_all":1},"_sum":{"int":5}}]}}"#, // SQL
-                r#"{"data":{"groupByTestModel":[{"string":"group2","int":5,"_count":{"_all":1},"_sum":{"int":5}},{"string":"group1","int":5,"_count":{"_all":1},"_sum":{"int":5}}]}}"# // Mongo
-            ]
+            [SqlServer, Postgres, MySql, Sqlite] => r#"{"data":{"groupByTestModel":[{"string":"group1","int":5,"_count":{"_all":1},"_sum":{"int":5}},{"string":"group2","int":5,"_count":{"_all":1},"_sum":{"int":5}}]}}"#,
+            [MongoDb] =>   r#"{"data":{"groupByTestModel":[{"string":"group2","int":5,"_count":{"_all":1},"_sum":{"int":5}},{"string":"group1","int":5,"_count":{"_all":1},"_sum":{"int":5}}]}}"#
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/insensitive_filters.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/insensitive_filters.rs
@@ -81,7 +81,7 @@ mod insensitive {
           @r###"{"data":{"findManyTestModel":[{"str":"æ"},{"str":"Æ"}]}}"###
         );
 
-        connector_results!(
+        match_connector_result!(
           &runner,
           r#"query { findManyTestModel(where: { str: { gte: "aÆB", mode: insensitive } }) { str }}"#,
           [MongoDb] => r#"{"data":{"findManyTestModel":[{"str":"æ"},{"str":"Æ"},{"str":"bar"},{"str":"aÆB"},{"str":"aæB"}]}}"#,
@@ -89,7 +89,7 @@ mod insensitive {
           [Postgres] => r#"{"data":{"findManyTestModel":[{"str":"æ"},{"str":"Æ"},{"str":"bar"},{"str":"aÆB"},{"str":"AÆB"},{"str":"aæB"}]}}"# // Cockroach, https://github.com/cockroachdb/cockroach/issues/71313
         );
 
-        connector_results!(
+        match_connector_result!(
           &runner,
           r#"query { findManyTestModel(where: { str: { lt: "aÆB", mode: insensitive } }) { str }}"#,
           [MongoDb] => r#"{"data":{"findManyTestModel":[{"str":"A"},{"str":"AÆB"},{"str":"aB"}]}}"#,

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/insensitive_filters.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/insensitive_filters.rs
@@ -3,8 +3,6 @@ use query_engine_tests::*;
 
 #[test_suite(schema(schema), capabilities(InsensitiveFilters))]
 mod insensitive {
-    use query_engine_tests::assert_query_many;
-
     fn schema() -> String {
         let schema = indoc! {
             r#"model TestModel {
@@ -83,24 +81,20 @@ mod insensitive {
           @r###"{"data":{"findManyTestModel":[{"str":"æ"},{"str":"Æ"}]}}"###
         );
 
-        assert_query_many!(
-            &runner,
-            r#"query { findManyTestModel(where: { str: { gte: "aÆB", mode: insensitive } }) { str }}"#,
-            vec![
-                r#"{"data":{"findManyTestModel":[{"str":"æ"},{"str":"Æ"},{"str":"bar"},{"str":"aÆB"},{"str":"aæB"}]}}"#, // Mongo
-                r#"{"data":{"findManyTestModel":[{"str":"æ"},{"str":"Æ"},{"str":"bar"},{"str":"aÆB"},{"str":"AÆB"},{"str":"aæB"},{"str":"aB"}]}}"#, // Postgres
-                r#"{"data":{"findManyTestModel":[{"str":"æ"},{"str":"Æ"},{"str":"bar"},{"str":"aÆB"},{"str":"AÆB"},{"str":"aæB"}]}}"#, // Cockroach, https://github.com/cockroachdb/cockroach/issues/71313
-            ]
+        connector_results!(
+          &runner,
+          r#"query { findManyTestModel(where: { str: { gte: "aÆB", mode: insensitive } }) { str }}"#,
+          [MongoDb] => r#"{"data":{"findManyTestModel":[{"str":"æ"},{"str":"Æ"},{"str":"bar"},{"str":"aÆB"},{"str":"aæB"}]}}"#,
+          [Sqlite, SqlServer, MySql, Postgres] => r#"{"data":{"findManyTestModel":[{"str":"æ"},{"str":"Æ"},{"str":"bar"},{"str":"aÆB"},{"str":"AÆB"},{"str":"aæB"},{"str":"aB"}]}}"#, // Postgres
+          [Postgres] => r#"{"data":{"findManyTestModel":[{"str":"æ"},{"str":"Æ"},{"str":"bar"},{"str":"aÆB"},{"str":"AÆB"},{"str":"aæB"}]}}"# // Cockroach, https://github.com/cockroachdb/cockroach/issues/71313
         );
 
-        assert_query_many!(
-            &runner,
-            r#"query { findManyTestModel(where: { str: { lt: "aÆB", mode: insensitive } }) { str }}"#,
-            vec![
-                r#"{"data":{"findManyTestModel":[{"str":"A"},{"str":"AÆB"},{"str":"aB"}]}}"#, // Mongo
-                r#"{"data":{"findManyTestModel":[{"str":"A"}]}}"#,                             // Postgres
-                r#"{"data":{"findManyTestModel":[{"str":"A"},{"str":"aB"}]}}"#, // Cockroach, https://github.com/cockroachdb/cockroach/issues/71313
-            ]
+        connector_results!(
+          &runner,
+          r#"query { findManyTestModel(where: { str: { lt: "aÆB", mode: insensitive } }) { str }}"#,
+          [MongoDb] => r#"{"data":{"findManyTestModel":[{"str":"A"},{"str":"AÆB"},{"str":"aB"}]}}"#,
+          [Postgres, Sqlite, SqlServer, MySql] =>  r#"{"data":{"findManyTestModel":[{"str":"A"}]}}"#,                             // Postgres
+          [Postgres] =>  r#"{"data":{"findManyTestModel":[{"str":"A"},{"str":"aB"}]}}"# // Cockroach, https://github.com/cockroachdb/cockroach/issues/71313
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/nested_multi_order_pagination.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/nested_multi_order_pagination.rs
@@ -144,7 +144,6 @@ mod paging_one2m_stable_order {
 #[test_suite(schema(schema))]
 mod paging_one2m_unstable_order {
     use indoc::indoc;
-    use query_engine_tests::assert_query_many;
 
     fn schema() -> String {
         let schema = indoc! {
@@ -182,9 +181,9 @@ mod paging_one2m_unstable_order {
         // 3 => 5 C C B A <- take
         // 3 => 6 A C D C
         // Makes: [1 => 2, 2 => 3 | 4, 3 => 5]
-        assert_query_many!(
-            &runner,
-            r#"query {
+        connector_results!(
+          &runner,
+          r#"query {
             findManyTestModel {
               id
               related(take: 1, orderBy: [{ fieldA: desc }, {fieldB: asc }, { fieldC: asc }, { fieldD: desc }]) {
@@ -192,10 +191,8 @@ mod paging_one2m_unstable_order {
               }
             }
           }"#,
-            vec![
-                r#"{"data":{"findManyTestModel":[{"id":1,"related":[{"id":2}]},{"id":2,"related":[{"id":3}]},{"id":3,"related":[{"id":5}]}]}}"#,
-                r#"{"data":{"findManyTestModel":[{"id":1,"related":[{"id":2}]},{"id":2,"related":[{"id":4}]},{"id":3,"related":[{"id":5}]}]}}"#
-            ]
+          [Postgres, MongoDb, Sqlite, SqlServer, MySql] => r#"{"data":{"findManyTestModel":[{"id":1,"related":[{"id":2}]},{"id":2,"related":[{"id":3}]},{"id":3,"related":[{"id":5}]}]}}"#,
+          [] => r#"{"data":{"findManyTestModel":[{"id":1,"related":[{"id":2}]},{"id":2,"related":[{"id":4}]},{"id":3,"related":[{"id":5}]}]}}"#
         );
 
         Ok(())
@@ -213,7 +210,7 @@ mod paging_one2m_unstable_order {
         // 3 => 5 C C B A
         // 3 => 6 A C D C <- take
         // Makes: [1 => 1, 2 => 4, 3 => 6]
-        assert_query_many!(
+        connector_results!(
             &runner,
             r#"query {
             findManyTestModel {
@@ -223,10 +220,8 @@ mod paging_one2m_unstable_order {
               }
             }
           }"#,
-            vec![
-                r#"{"data":{"findManyTestModel":[{"id":1,"related":[{"id":1}]},{"id":2,"related":[{"id":3}]},{"id":3,"related":[{"id":6}]}]}}"#,
-                r#"{"data":{"findManyTestModel":[{"id":1,"related":[{"id":1}]},{"id":2,"related":[{"id":4}]},{"id":3,"related":[{"id":6}]}]}}"#
-            ]
+          [Postgres, MongoDb, Sqlite, SqlServer, MySql] => r#"{"data":{"findManyTestModel":[{"id":1,"related":[{"id":1}]},{"id":2,"related":[{"id":3}]},{"id":3,"related":[{"id":6}]}]}}"#,
+          [] => r#"{"data":{"findManyTestModel":[{"id":1,"related":[{"id":1}]},{"id":2,"related":[{"id":4}]},{"id":3,"related":[{"id":6}]}]}}"#
         );
 
         Ok(())
@@ -244,7 +239,7 @@ mod paging_one2m_unstable_order {
         // 3 => 5 C C B A
         // 3 => 6 A C D C
         // Makes: [1 => [], 2 => [3, 4] | [4, 3] | [3] | [4], 3 => []]
-        assert_query_many!(
+        connector_results!(
             &runner,
             r#"query {
             findManyTestModel {
@@ -254,12 +249,10 @@ mod paging_one2m_unstable_order {
               }
             }
           }"#,
-            vec![
-                r#"{"data":{"findManyTestModel":[{"id":1,"related":[]},{"id":2,"related":[{"id":3},{"id":4}]},{"id":3,"related":[]}]}}"#,
-                r#"{"data":{"findManyTestModel":[{"id":1,"related":[]},{"id":2,"related":[{"id":4},{"id":3}]},{"id":3,"related":[]}]}}"#,
-                r#"{"data":{"findManyTestModel":[{"id":1,"related":[]},{"id":2,"related":[{"id":3}]},{"id":3,"related":[]}]}}"#,
-                r#"{"data":{"findManyTestModel":[{"id":1,"related":[]},{"id":2,"related":[{"id":4}]},{"id":3,"related":[]}]}}"#
-            ]
+          [Postgres, MongoDb, Sqlite, SqlServer, MySql] => r#"{"data":{"findManyTestModel":[{"id":1,"related":[]},{"id":2,"related":[{"id":3},{"id":4}]},{"id":3,"related":[]}]}}"#,
+          [] => r#"{"data":{"findManyTestModel":[{"id":1,"related":[]},{"id":2,"related":[{"id":4},{"id":3}]},{"id":3,"related":[]}]}}"#,
+          [] => r#"{"data":{"findManyTestModel":[{"id":1,"related":[]},{"id":2,"related":[{"id":3}]},{"id":3,"related":[]}]}}"#,
+          [] => r#"{"data":{"findManyTestModel":[{"id":1,"related":[]},{"id":2,"related":[{"id":4}]},{"id":3,"related":[]}]}}"#
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/nested_multi_order_pagination.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/nested_multi_order_pagination.rs
@@ -181,7 +181,8 @@ mod paging_one2m_unstable_order {
         // 3 => 5 C C B A <- take
         // 3 => 6 A C D C
         // Makes: [1 => 2, 2 => 3 | 4, 3 => 5]
-        connector_results!(
+        insta::assert_snapshot!(
+        run_query!(
           &runner,
           r#"query {
             findManyTestModel {
@@ -190,9 +191,8 @@ mod paging_one2m_unstable_order {
                 id
               }
             }
-          }"#,
-          [Postgres, MongoDb, Sqlite, SqlServer, MySql] => r#"{"data":{"findManyTestModel":[{"id":1,"related":[{"id":2}]},{"id":2,"related":[{"id":3}]},{"id":3,"related":[{"id":5}]}]}}"#,
-          [] => r#"{"data":{"findManyTestModel":[{"id":1,"related":[{"id":2}]},{"id":2,"related":[{"id":4}]},{"id":3,"related":[{"id":5}]}]}}"#
+          }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":1,"related":[{"id":2}]},{"id":2,"related":[{"id":3}]},{"id":3,"related":[{"id":5}]}]}}"###
         );
 
         Ok(())
@@ -210,18 +210,18 @@ mod paging_one2m_unstable_order {
         // 3 => 5 C C B A
         // 3 => 6 A C D C <- take
         // Makes: [1 => 1, 2 => 4, 3 => 6]
-        connector_results!(
-            &runner,
-            r#"query {
-            findManyTestModel {
-              id
-              related(take: -1, orderBy: [{ fieldA: desc }, { fieldB: asc }, { fieldC: asc }, { fieldD: desc }]) {
-                id
-              }
-            }
-          }"#,
-          [Postgres, MongoDb, Sqlite, SqlServer, MySql] => r#"{"data":{"findManyTestModel":[{"id":1,"related":[{"id":1}]},{"id":2,"related":[{"id":3}]},{"id":3,"related":[{"id":6}]}]}}"#,
-          [] => r#"{"data":{"findManyTestModel":[{"id":1,"related":[{"id":1}]},{"id":2,"related":[{"id":4}]},{"id":3,"related":[{"id":6}]}]}}"#
+        insta::assert_snapshot!(
+          run_query!(
+              &runner,
+              r#"query {
+                findManyTestModel {
+                  id
+                  related(take: -1, orderBy: [{ fieldA: desc }, { fieldB: asc }, { fieldC: asc }, { fieldD: desc }]) {
+                    id
+                  }
+                }
+              }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":1,"related":[{"id":1}]},{"id":2,"related":[{"id":3}]},{"id":3,"related":[{"id":6}]}]}}"###
         );
 
         Ok(())
@@ -239,20 +239,18 @@ mod paging_one2m_unstable_order {
         // 3 => 5 C C B A
         // 3 => 6 A C D C
         // Makes: [1 => [], 2 => [3, 4] | [4, 3] | [3] | [4], 3 => []]
-        connector_results!(
+        insta::assert_snapshot!(
+          run_query!(
             &runner,
             r#"query {
-            findManyTestModel {
-              id
-              related(cursor: { id: 3 }, orderBy: [{ fieldA: desc }, { fieldB: asc }, { fieldC: asc }, { fieldD: desc }]) {
+              findManyTestModel {
                 id
+                related(cursor: { id: 3 }, orderBy: [{ fieldA: desc }, { fieldB: asc }, { fieldC: asc }, { fieldD: desc }]) {
+                  id
+                }
               }
-            }
-          }"#,
-          [Postgres, MongoDb, Sqlite, SqlServer, MySql] => r#"{"data":{"findManyTestModel":[{"id":1,"related":[]},{"id":2,"related":[{"id":3},{"id":4}]},{"id":3,"related":[]}]}}"#,
-          [] => r#"{"data":{"findManyTestModel":[{"id":1,"related":[]},{"id":2,"related":[{"id":4},{"id":3}]},{"id":3,"related":[]}]}}"#,
-          [] => r#"{"data":{"findManyTestModel":[{"id":1,"related":[]},{"id":2,"related":[{"id":3}]},{"id":3,"related":[]}]}}"#,
-          [] => r#"{"data":{"findManyTestModel":[{"id":1,"related":[]},{"id":2,"related":[{"id":4}]},{"id":3,"related":[]}]}}"#
+            }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":1,"related":[]},{"id":2,"related":[{"id":3},{"id":4}]},{"id":3,"related":[]}]}}"###
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_aggregation.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_aggregation.rs
@@ -223,10 +223,10 @@ mod order_by_aggr {
                 user { categories { name } }
               }
             }"#,
-            [Sqlite, MySql, MongoDb, Postgres] => r#"{"data":{"findManyPost":[{"id":2,"user":{"categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":3,"user":{"categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":1,"user":{"categories":[{"name":"Startup"}]}}]}}"#,
-            [SqlServer] => r#"{"data":{"findManyPost":[{"id":3,"user":{"categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":2,"user":{"categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":1,"user":{"categories":[{"name":"Startup"}]}}]}}"#
+            [Sqlite, MySql, MongoDb, Postgres, SqlServer] => r#"{"data":{"findManyPost":[{"id":2,"user":{"categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":3,"user":{"categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":1,"user":{"categories":[{"name":"Startup"}]}}]}}"#,
+            // MySql 5.6, Postgres 9
+            [SqlServer, MySql, Postgres] => r#"{"data":{"findManyPost":[{"id":3,"user":{"categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":2,"user":{"categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":1,"user":{"categories":[{"name":"Startup"}]}}]}}"#
         );
-
         Ok(())
     }
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_aggregation.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_aggregation.rs
@@ -3,7 +3,7 @@ use query_engine_tests::*;
 #[test_suite(schema(schema))]
 mod order_by_aggr {
     use indoc::indoc;
-    use query_engine_tests::{assert_query_many, run_query};
+    use query_engine_tests::run_query;
 
     fn schema() -> String {
         let schema = indoc! {
@@ -215,7 +215,7 @@ mod order_by_aggr {
     async fn m2one2m_count_desc(runner: Runner) -> TestResult<()> {
         create_test_data(&runner).await?;
 
-        assert_query_many!(
+        connector_results!(
             &runner,
             r#"{
               findManyPost(orderBy: { user: { categories: { _count: desc } } }) {
@@ -223,10 +223,8 @@ mod order_by_aggr {
                 user { categories { name } }
               }
             }"#,
-            vec![
-                r#"{"data":{"findManyPost":[{"id":2,"user":{"categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":3,"user":{"categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":1,"user":{"categories":[{"name":"Startup"}]}}]}}"#,
-                r#"{"data":{"findManyPost":[{"id":3,"user":{"categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":2,"user":{"categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":1,"user":{"categories":[{"name":"Startup"}]}}]}}"#,
-            ]
+            [Postgres, Sqlite, SqlServer, MySql, MongoDb] => r#"{"data":{"findManyPost":[{"id":2,"user":{"categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":3,"user":{"categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":1,"user":{"categories":[{"name":"Startup"}]}}]}}"#,
+            [] => r#"{"data":{"findManyPost":[{"id":3,"user":{"categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":2,"user":{"categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":1,"user":{"categories":[{"name":"Startup"}]}}]}}"#
         );
 
         Ok(())
@@ -257,7 +255,7 @@ mod order_by_aggr {
     async fn m2one_field_asc_m2one2m_count_desc(runner: Runner) -> TestResult<()> {
         create_test_data(&runner).await?;
 
-        assert_query_many!(
+        connector_results!(
             &runner,
             r#"{
               findManyPost(orderBy: [{ user: { name: asc }}, { user: { categories: { _count: desc }} }]) {
@@ -268,10 +266,8 @@ mod order_by_aggr {
                 }
               }
             }"#,
-            vec![
-                r#"{"data":{"findManyPost":[{"id":1,"user":{"name":"Alice","categories":[{"name":"Startup"}]}},{"id":2,"user":{"name":"Bob","categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":3,"user":{"name":"Bob","categories":[{"name":"Computer Science"},{"name":"Music"}]}}]}}"#,
-                r#"{"data":{"findManyPost":[{"id":1,"user":{"name":"Alice","categories":[{"name":"Startup"}]}},{"id":3,"user":{"name":"Bob","categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":2,"user":{"name":"Bob","categories":[{"name":"Computer Science"},{"name":"Music"}]}}]}}"#,
-            ]
+            [Postgres, Sqlite, SqlServer, MySql, MongoDb] => r#"{"data":{"findManyPost":[{"id":1,"user":{"name":"Alice","categories":[{"name":"Startup"}]}},{"id":2,"user":{"name":"Bob","categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":3,"user":{"name":"Bob","categories":[{"name":"Computer Science"},{"name":"Music"}]}}]}}"#,
+            [] => r#"{"data":{"findManyPost":[{"id":1,"user":{"name":"Alice","categories":[{"name":"Startup"}]}},{"id":3,"user":{"name":"Bob","categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":2,"user":{"name":"Bob","categories":[{"name":"Computer Science"},{"name":"Music"}]}}]}}"#
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_aggregation.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_aggregation.rs
@@ -223,8 +223,8 @@ mod order_by_aggr {
                 user { categories { name } }
               }
             }"#,
-            [Sqlite, SqlServer, MySql, MongoDb] => r#"{"data":{"findManyPost":[{"id":2,"user":{"categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":3,"user":{"categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":1,"user":{"categories":[{"name":"Startup"}]}}]}}"#,
-            [Postgres] => r#"{"data":{"findManyPost":[{"id":3,"user":{"categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":2,"user":{"categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":1,"user":{"categories":[{"name":"Startup"}]}}]}}"#
+            [Sqlite, MySql, MongoDb, Postgres] => r#"{"data":{"findManyPost":[{"id":2,"user":{"categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":3,"user":{"categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":1,"user":{"categories":[{"name":"Startup"}]}}]}}"#,
+            [SqlServer] => r#"{"data":{"findManyPost":[{"id":3,"user":{"categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":2,"user":{"categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":1,"user":{"categories":[{"name":"Startup"}]}}]}}"#
         );
 
         Ok(())
@@ -266,7 +266,7 @@ mod order_by_aggr {
                 }
               }
             }"#,
-            [Sqlite, SqlServer, MySql, MongoDb] => r#"{"data":{"findManyPost":[{"id":1,"user":{"name":"Alice","categories":[{"name":"Startup"}]}},{"id":2,"user":{"name":"Bob","categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":3,"user":{"name":"Bob","categories":[{"name":"Computer Science"},{"name":"Music"}]}}]}}"#,
+            [Sqlite, SqlServer, MySql, MongoDb, Postgres] => r#"{"data":{"findManyPost":[{"id":1,"user":{"name":"Alice","categories":[{"name":"Startup"}]}},{"id":2,"user":{"name":"Bob","categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":3,"user":{"name":"Bob","categories":[{"name":"Computer Science"},{"name":"Music"}]}}]}}"#,
             [Postgres] => r#"{"data":{"findManyPost":[{"id":1,"user":{"name":"Alice","categories":[{"name":"Startup"}]}},{"id":3,"user":{"name":"Bob","categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":2,"user":{"name":"Bob","categories":[{"name":"Computer Science"},{"name":"Music"}]}}]}}"#
         );
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_aggregation.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_aggregation.rs
@@ -215,7 +215,7 @@ mod order_by_aggr {
     async fn m2one2m_count_desc(runner: Runner) -> TestResult<()> {
         create_test_data(&runner).await?;
 
-        connector_results!(
+        match_connector_result!(
             &runner,
             r#"{
               findManyPost(orderBy: { user: { categories: { _count: desc } } }) {
@@ -255,7 +255,7 @@ mod order_by_aggr {
     async fn m2one_field_asc_m2one2m_count_desc(runner: Runner) -> TestResult<()> {
         create_test_data(&runner).await?;
 
-        connector_results!(
+        match_connector_result!(
             &runner,
             r#"{
               findManyPost(orderBy: [{ user: { name: asc }}, { user: { categories: { _count: desc }} }]) {

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_aggregation.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_aggregation.rs
@@ -223,8 +223,8 @@ mod order_by_aggr {
                 user { categories { name } }
               }
             }"#,
-            [Postgres, Sqlite, SqlServer, MySql, MongoDb] => r#"{"data":{"findManyPost":[{"id":2,"user":{"categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":3,"user":{"categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":1,"user":{"categories":[{"name":"Startup"}]}}]}}"#,
-            [] => r#"{"data":{"findManyPost":[{"id":3,"user":{"categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":2,"user":{"categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":1,"user":{"categories":[{"name":"Startup"}]}}]}}"#
+            [Sqlite, SqlServer, MySql, MongoDb] => r#"{"data":{"findManyPost":[{"id":2,"user":{"categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":3,"user":{"categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":1,"user":{"categories":[{"name":"Startup"}]}}]}}"#,
+            [Postgres] => r#"{"data":{"findManyPost":[{"id":3,"user":{"categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":2,"user":{"categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":1,"user":{"categories":[{"name":"Startup"}]}}]}}"#
         );
 
         Ok(())
@@ -266,8 +266,8 @@ mod order_by_aggr {
                 }
               }
             }"#,
-            [Postgres, Sqlite, SqlServer, MySql, MongoDb] => r#"{"data":{"findManyPost":[{"id":1,"user":{"name":"Alice","categories":[{"name":"Startup"}]}},{"id":2,"user":{"name":"Bob","categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":3,"user":{"name":"Bob","categories":[{"name":"Computer Science"},{"name":"Music"}]}}]}}"#,
-            [] => r#"{"data":{"findManyPost":[{"id":1,"user":{"name":"Alice","categories":[{"name":"Startup"}]}},{"id":3,"user":{"name":"Bob","categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":2,"user":{"name":"Bob","categories":[{"name":"Computer Science"},{"name":"Music"}]}}]}}"#
+            [Sqlite, SqlServer, MySql, MongoDb] => r#"{"data":{"findManyPost":[{"id":1,"user":{"name":"Alice","categories":[{"name":"Startup"}]}},{"id":2,"user":{"name":"Bob","categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":3,"user":{"name":"Bob","categories":[{"name":"Computer Science"},{"name":"Music"}]}}]}}"#,
+            [Postgres] => r#"{"data":{"findManyPost":[{"id":1,"user":{"name":"Alice","categories":[{"name":"Startup"}]}},{"id":3,"user":{"name":"Bob","categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":2,"user":{"name":"Bob","categories":[{"name":"Computer Science"},{"name":"Music"}]}}]}}"#
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent.rs
@@ -161,7 +161,7 @@ mod order_by_dependent {
             }"#,
             // Depends on how null values are handled.
             [MongoDb, Sqlite] => r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":null}},{"id":3,"b":null},{"id":1,"b":{"c":{"id":1}}}]}}"#,
-            [SqlServer] => r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":2,"b":{"c":null}},{"id":1,"b":{"c":{"id":1}}}]}}"#,
+            [SqlServer, MySql] => r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":2,"b":{"c":null}},{"id":1,"b":{"c":{"id":1}}}]}}"#,
             [Postgres] => r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"id":1}}},{"id":2,"b":{"c":null}},{"id":3,"b":null}]}}"#,
                 // CockroachDB can order ModelA.id in any order if ModelC.b_id is NULL.
             [Postgres] => r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"id":1}}},{"id":3,"b":null},{"id":2,"b":{"c":null}}]}}"#,

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent.rs
@@ -249,6 +249,8 @@ mod order_by_dependent {
             vec![
                 r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":4,"b":null},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}}]}}"#,
                 r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":3,"b":null},{"id":4,"b":null}]}}"#,
+                //mysql 5.7
+                r#"{"data":{"findManyModelA":[{"id":4,"b":null},{"id":3,"b":null},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}}]}}"#
             ]
         );
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent.rs
@@ -92,7 +92,7 @@ mod order_by_dependent {
                 }
               }
             }"#,
-            [MongoDb, Sqlite] => r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":1,"b":{"id":1}},{"id":2,"b":{"id":2}}]}}"#,
+            [MongoDb, Sqlite, SqlServer] => r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":1,"b":{"id":1}},{"id":2,"b":{"id":2}}]}}"#,
             [MySql, Postgres] => r#"{"data":{"findManyModelA":[{"id":1,"b":{"id":1}},{"id":2,"b":{"id":2}},{"id":3,"b":null}]}}"#
         );
 
@@ -159,7 +159,7 @@ mod order_by_dependent {
             }"#,
             // Depends on how null values are handled.
             [MongoDb, Sqlite] => r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":null}},{"id":3,"b":null},{"id":1,"b":{"c":{"id":1}}}]}}"#,
-            [MySql] => r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":2,"b":{"c":null}},{"id":1,"b":{"c":{"id":1}}}]}}"#,
+            [MySql, SqlServer] => r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":2,"b":{"c":null}},{"id":1,"b":{"c":{"id":1}}}]}}"#,
             [Postgres] => r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"id":1}}},{"id":2,"b":{"c":null}},{"id":3,"b":null}]}}"#,
                 // CockroachDB can order ModelA.id in any order if ModelC.b_id is NULL.
             [Postgres] => r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"id":1}}},{"id":3,"b":null},{"id":2,"b":{"c":null}}]}}"#
@@ -242,7 +242,8 @@ mod order_by_dependent {
             }
           }"#,
           [MySql] => r#"{"data":{"findManyModelA":[{"id":4,"b":null},{"id":3,"b":null},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}}]}}"#,
-          [MongoDb, Sqlite] => r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":4,"b":null},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}}]}}"#,
+          // mariadb
+          [MySql, MongoDb, Sqlite] => r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":4,"b":null},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}}]}}"#,
           [Postgres] => r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":3,"b":null},{"id":4,"b":null}]}}"#
         );
 
@@ -270,11 +271,11 @@ mod order_by_dependent {
                 }
               }
             }"#,
-            [MongoDb, Sqlite] => r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":3,"b":null},{"id":4,"b":null}]}}"#,
+            // MariaDb
+            [MongoDb, Sqlite, MySql] => r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":3,"b":null},{"id":4,"b":null}]}}"#,
             [Postgres] =>  r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":4,"b":null},{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}}]}}"#,
             [MySql] => r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":4,"b":null},{"id":3,"b":null}]}}"#
         );
-
         Ok(())
     }
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent.rs
@@ -3,7 +3,7 @@ use query_engine_tests::*;
 #[test_suite(schema(schema))]
 mod order_by_dependent {
     use indoc::indoc;
-    use query_engine_tests::{assert_query_many, run_query};
+    use query_engine_tests::run_query;
 
     fn schema() -> String {
         let schema = indoc! {
@@ -82,7 +82,7 @@ mod order_by_dependent {
         create_row(&runner, 2, Some(2), None, None).await?;
         create_row(&runner, 3, None, None, None).await?;
 
-        assert_query_many!(
+        connector_results!(
             &runner,
             r#"{
               findManyModelA(orderBy: { b: { id: asc }}) {
@@ -92,10 +92,8 @@ mod order_by_dependent {
                 }
               }
             }"#,
-            vec![
-                r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":1,"b":{"id":1}},{"id":2,"b":{"id":2}}]}}"#,
-                r#"{"data":{"findManyModelA":[{"id":1,"b":{"id":1}},{"id":2,"b":{"id":2}},{"id":3,"b":null}]}}"#
-            ]
+            [MongoDb, Sqlite] => r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":1,"b":{"id":1}},{"id":2,"b":{"id":2}}]}}"#,
+            [MySql, Postgres] => r#"{"data":{"findManyModelA":[{"id":1,"b":{"id":1}},{"id":2,"b":{"id":2}},{"id":3,"b":null}]}}"#
         );
 
         Ok(())
@@ -147,7 +145,7 @@ mod order_by_dependent {
         create_row(&runner, 2, Some(2), None, None).await?;
         create_row(&runner, 3, None, None, None).await?;
 
-        assert_query_many!(
+        connector_results!(
             &runner,
             r#"{
               findManyModelA(orderBy: { b: { c: { id: asc }}}) {
@@ -160,13 +158,11 @@ mod order_by_dependent {
               }
             }"#,
             // Depends on how null values are handled.
-            vec![
-                r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":null}},{"id":3,"b":null},{"id":1,"b":{"c":{"id":1}}}]}}"#,
-                r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":2,"b":{"c":null}},{"id":1,"b":{"c":{"id":1}}}]}}"#,
-                r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"id":1}}},{"id":2,"b":{"c":null}},{"id":3,"b":null}]}}"#,
+            [MongoDb, Sqlite] => r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":null}},{"id":3,"b":null},{"id":1,"b":{"c":{"id":1}}}]}}"#,
+            [MySql] => r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":2,"b":{"c":null}},{"id":1,"b":{"c":{"id":1}}}]}}"#,
+            [Postgres] => r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"id":1}}},{"id":2,"b":{"c":null}},{"id":3,"b":null}]}}"#,
                 // CockroachDB can order ModelA.id in any order if ModelC.b_id is NULL.
-                r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"id":1}}},{"id":3,"b":null},{"id":2,"b":{"c":null}}]}}"#,
-            ]
+            [Postgres] => r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"id":1}}},{"id":3,"b":null},{"id":2,"b":{"c":null}}]}}"#
         );
 
         Ok(())
@@ -231,27 +227,23 @@ mod order_by_dependent {
         create_row(&runner, 1, Some(1), Some(1), Some(3)).await?;
         create_row(&runner, 2, Some(2), Some(2), Some(4)).await?;
 
-        assert_query_many!(
-            &runner,
-            r#"{
-              findManyModelA(orderBy: { b: { c: { a: { id: asc }}}}) {
-                id
-                b {
-                  c {
-                    a {
-                      id
-                    }
+        connector_results!(
+          &runner,
+          r#"{
+            findManyModelA(orderBy: { b: { c: { a: { id: asc }}}}) {
+              id
+              b {
+                c {
+                  a {
+                    id
                   }
                 }
               }
-            }"#,
-            // Depends on how null values are handled.
-            vec![
-                r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":4,"b":null},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}}]}}"#,
-                r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":3,"b":null},{"id":4,"b":null}]}}"#,
-                //mysql 5.7
-                r#"{"data":{"findManyModelA":[{"id":4,"b":null},{"id":3,"b":null},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}}]}}"#
-            ]
+            }
+          }"#,
+          [MySql] => r#"{"data":{"findManyModelA":[{"id":4,"b":null},{"id":3,"b":null},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}}]}}"#,
+          [MongoDb, Sqlite] => r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":4,"b":null},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}}]}}"#,
+          [Postgres] => r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":3,"b":null},{"id":4,"b":null}]}}"#
         );
 
         Ok(())
@@ -264,7 +256,7 @@ mod order_by_dependent {
         create_row(&runner, 1, Some(1), Some(1), Some(3)).await?;
         create_row(&runner, 2, Some(2), Some(2), Some(4)).await?;
 
-        assert_query_many!(
+        connector_results!(
             &runner,
             r#"{
               findManyModelA(orderBy: { b: { c: { a: { id: desc }}}}) {
@@ -278,13 +270,9 @@ mod order_by_dependent {
                 }
               }
             }"#,
-            // Depends on how null values are handled.
-            vec![
-                r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":3,"b":null},{"id":4,"b":null}]}}"#,
-                r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":4,"b":null},{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}}]}}"#,
-                //Mysql 5.6
-                r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":4,"b":null},{"id":3,"b":null}]}}"#
-            ]
+            [MongoDb, Sqlite] => r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":3,"b":null},{"id":4,"b":null}]}}"#,
+            [Postgres] =>  r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":4,"b":null},{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}}]}}"#,
+            [MySql] => r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":4,"b":null},{"id":3,"b":null}]}}"#
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent.rs
@@ -280,6 +280,8 @@ mod order_by_dependent {
             vec![
                 r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":3,"b":null},{"id":4,"b":null}]}}"#,
                 r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":4,"b":null},{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}}]}}"#,
+                //Mysql 5.6
+                r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":4,"b":null},{"id":3,"b":null}]}}"#
             ]
         );
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent.rs
@@ -93,7 +93,9 @@ mod order_by_dependent {
               }
             }"#,
             [MongoDb, Sqlite, SqlServer] => r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":1,"b":{"id":1}},{"id":2,"b":{"id":2}}]}}"#,
-            [MySql, Postgres] => r#"{"data":{"findManyModelA":[{"id":1,"b":{"id":1}},{"id":2,"b":{"id":2}},{"id":3,"b":null}]}}"#
+            [Postgres] => r#"{"data":{"findManyModelA":[{"id":1,"b":{"id":1}},{"id":2,"b":{"id":2}},{"id":3,"b":null}]}}"#,
+            //MariaDB, MySql8
+            [MySql] => r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":1,"b":{"id":1}},{"id":2,"b":{"id":2}}]}}"#
         );
 
         Ok(())
@@ -159,10 +161,11 @@ mod order_by_dependent {
             }"#,
             // Depends on how null values are handled.
             [MongoDb, Sqlite] => r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":null}},{"id":3,"b":null},{"id":1,"b":{"c":{"id":1}}}]}}"#,
-            [MySql, SqlServer] => r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":2,"b":{"c":null}},{"id":1,"b":{"c":{"id":1}}}]}}"#,
+            [SqlServer] => r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":2,"b":{"c":null}},{"id":1,"b":{"c":{"id":1}}}]}}"#,
             [Postgres] => r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"id":1}}},{"id":2,"b":{"c":null}},{"id":3,"b":null}]}}"#,
                 // CockroachDB can order ModelA.id in any order if ModelC.b_id is NULL.
-            [Postgres] => r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"id":1}}},{"id":3,"b":null},{"id":2,"b":{"c":null}}]}}"#
+            [Postgres] => r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"id":1}}},{"id":3,"b":null},{"id":2,"b":{"c":null}}]}}"#,
+            [MySql] => r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":null}},{"id":3,"b":null},{"id":1,"b":{"c":{"id":1}}}]}}"#
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent.rs
@@ -82,7 +82,7 @@ mod order_by_dependent {
         create_row(&runner, 2, Some(2), None, None).await?;
         create_row(&runner, 3, None, None, None).await?;
 
-        connector_results!(
+        match_connector_result!(
             &runner,
             r#"{
               findManyModelA(orderBy: { b: { id: asc }}) {
@@ -147,7 +147,7 @@ mod order_by_dependent {
         create_row(&runner, 2, Some(2), None, None).await?;
         create_row(&runner, 3, None, None, None).await?;
 
-        connector_results!(
+        match_connector_result!(
             &runner,
             r#"{
               findManyModelA(orderBy: { b: { c: { id: asc }}}) {
@@ -230,7 +230,7 @@ mod order_by_dependent {
         create_row(&runner, 1, Some(1), Some(1), Some(3)).await?;
         create_row(&runner, 2, Some(2), Some(2), Some(4)).await?;
 
-        connector_results!(
+        match_connector_result!(
           &runner,
           r#"{
             findManyModelA(orderBy: { b: { c: { a: { id: asc }}}}) {
@@ -260,7 +260,7 @@ mod order_by_dependent {
         create_row(&runner, 1, Some(1), Some(1), Some(3)).await?;
         create_row(&runner, 2, Some(2), Some(2), Some(4)).await?;
 
-        connector_results!(
+        match_connector_result!(
             &runner,
             r#"{
               findManyModelA(orderBy: { b: { c: { a: { id: desc }}}}) {

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent.rs
@@ -225,7 +225,7 @@ mod order_by_dependent {
     }
 
     // "[Circular with differing records] Ordering by related record field ascending" should "work"
-    #[connector_test(exclude(SqlServer, MySql))]
+    #[connector_test(exclude(SqlServer))]
     async fn circular_diff_related_record_asc(runner: Runner) -> TestResult<()> {
         // Records form circles with their relations
         create_row(&runner, 1, Some(1), Some(1), Some(3)).await?;
@@ -256,7 +256,7 @@ mod order_by_dependent {
     }
 
     // "[Circular with differing records] Ordering by related record field descending" should "work"
-    #[connector_test(exclude(SqlServer, MySql))]
+    #[connector_test(exclude(SqlServer))]
     async fn circular_diff_related_record_desc(runner: Runner) -> TestResult<()> {
         // Records form circles with their relations
         create_row(&runner, 1, Some(1), Some(1), Some(3)).await?;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent_pagination.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent_pagination.rs
@@ -299,7 +299,9 @@ mod order_by_dependent_pag {
                 r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":3,"b":null},{"id":4,"b":null}]}}"#,
                 r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}}]}}"#,
                 // Postgres
-                r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":4,"b":null},{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}}]}}"#
+                r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":4,"b":null},{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}}]}}"#,
+                //mysql 5.6
+                r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":4,"b":null},{"id":3,"b":null}]}}"#
             ]
         );
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent_pagination.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent_pagination.rs
@@ -86,7 +86,7 @@ mod order_by_dependent_pag {
         create_row(&runner, 2, Some(2), None, None).await?;
         create_row(&runner, 3, None, None, None).await?;
 
-        connector_results!(
+        match_connector_result!(
             &runner,
             r#"{
               findManyModelA(orderBy: { b: { id: asc }}, cursor: { id: 1 }, take: 3) {
@@ -154,7 +154,7 @@ mod order_by_dependent_pag {
         create_row(&runner, 2, Some(2), None, None).await?;
         create_row(&runner, 3, None, None, None).await?;
 
-        connector_results!(
+        match_connector_result!(
             &runner,
             r#"{
               findManyModelA(orderBy: { b: { c: { id: asc }}}, cursor: { id: 1 }, take: 3) {
@@ -237,7 +237,7 @@ mod order_by_dependent_pag {
         create_row(&runner, 1, Some(1), Some(1), Some(3)).await?;
         create_row(&runner, 2, Some(2), Some(2), Some(4)).await?;
 
-        connector_results!(
+        match_connector_result!(
             &runner,
             r#"{
               findManyModelA(orderBy: { b: { c: { a: { id: asc }}}}, cursor: { id: 1 }, take: 4) {
@@ -270,7 +270,7 @@ mod order_by_dependent_pag {
         create_row(&runner, 1, Some(1), Some(1), Some(3)).await?;
         create_row(&runner, 2, Some(2), Some(2), Some(4)).await?;
 
-        connector_results!(
+        match_connector_result!(
             &runner,
             r#"{
               findManyModelA(orderBy: { b: { c: { a: { id: desc }}}}, cursor: { id: 2 }, take: 4) {
@@ -286,12 +286,7 @@ mod order_by_dependent_pag {
             }"#,
             // Depends on how null values are handled.
             [MongoDb, Sqlite, MySql] => r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":3,"b":null},{"id":4,"b":null}]}}"#,
-            // [MySql] => r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}}]}}"#,
             [Postgres] => r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":4,"b":null},{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}}]}}"#
-            // MySql 5
-            // [MySql] => r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":4,"b":null},{"id":3,"b":null}]}}"#,
-            //MariaDB, MySql8
-            // [MySql] => r#"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":3,"b":null},{"id":4,"b":null}]}}"#
         );
         Ok(())
     }

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent_pagination.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent_pagination.rs
@@ -265,7 +265,9 @@ mod order_by_dependent_pag {
                 // CockroachDB can order ModelA.id in any order if ModelB.a_id is NULL.
                 r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":4,"b":null},{"id":3,"b":null}]}}"#,
                 // Sqlite
-                r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":4,"b":null},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}}]}}"#
+                r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":4,"b":null},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}}]}}"#,
+                // mysql 5.7
+                r#"{"data":{"findManyModelA":[{"id":4,"b":null},{"id":3,"b":null},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}}]}}"#
             ]
         );
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent_pagination.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent_pagination.rs
@@ -286,7 +286,7 @@ mod order_by_dependent_pag {
             }"#,
             // Depends on how null values are handled.
             [MongoDb, Sqlite] => r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":3,"b":null},{"id":4,"b":null}]}}"#,
-            // [MySql] => r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}}]}}"#,
+            [MySql] => r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}}]}}"#,
                 // Postgres
             [Postgres] => r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":4,"b":null},{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}}]}}"#,
             // [MySql] => r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":4,"b":null},{"id":3,"b":null}]}}"#,

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent_pagination.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent_pagination.rs
@@ -169,7 +169,7 @@ mod order_by_dependent_pag {
             // Depends on how null values are handled.
             [MongoDb] => r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"id":1}}}]}}"#,
             [Postgres] => r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"id":1}}},{"id":2,"b":{"c":null}},{"id":3,"b":null}]}}"#,
-            [Sqlite] => r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":null}},{"id":3,"b":null},{"id":1,"b":{"c":{"id":1}}}]}}"#,
+            [Sqlite, MySql] => r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":null}},{"id":3,"b":null},{"id":1,"b":{"c":{"id":1}}}]}}"#,
             [MySql] => r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":2,"b":{"c":null}},{"id":1,"b":{"c":{"id":1}}}]}}"#
         );
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent_pagination.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent_pagination.rs
@@ -289,8 +289,9 @@ mod order_by_dependent_pag {
             [MySql] => r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}}]}}"#,
                 // Postgres
             [Postgres] => r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":4,"b":null},{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}}]}}"#,
-            // [MySql] => r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":4,"b":null},{"id":3,"b":null}]}}"#,
-            //MariaDB, MySql8, 5.7
+            // MySql 5
+            [MySql] => r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":4,"b":null},{"id":3,"b":null}]}}"#,
+            //MariaDB, MySql8
             [MySql] => r#"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":3,"b":null},{"id":4,"b":null}]}}"#
         );
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent_pagination.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent_pagination.rs
@@ -285,14 +285,13 @@ mod order_by_dependent_pag {
               }
             }"#,
             // Depends on how null values are handled.
-            [MongoDb, Sqlite] => r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":3,"b":null},{"id":4,"b":null}]}}"#,
-            [MySql] => r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}}]}}"#,
-                // Postgres
-            [Postgres] => r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":4,"b":null},{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}}]}}"#,
+            [MongoDb, Sqlite, MySql] => r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":3,"b":null},{"id":4,"b":null}]}}"#,
+            // [MySql] => r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}}]}}"#,
+            [Postgres] => r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":4,"b":null},{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}}]}}"#
             // MySql 5
-            [MySql] => r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":4,"b":null},{"id":3,"b":null}]}}"#,
+            // [MySql] => r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":4,"b":null},{"id":3,"b":null}]}}"#,
             //MariaDB, MySql8
-            [MySql] => r#"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":3,"b":null},{"id":4,"b":null}]}}"#
+            // [MySql] => r#"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":3,"b":null},{"id":4,"b":null}]}}"#
         );
         Ok(())
     }

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent_pagination.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent_pagination.rs
@@ -250,8 +250,7 @@ mod order_by_dependent_pag {
                   }
                 }
               }
-            }"#,
-            // Depends on how null values are handled.
+            }"#, // Depends on how null values are handled.
             [MongoDb] => r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}}]}}"#,
             [Postgres] =>  r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":3,"b":null},{"id":4,"b":null}]}}"#,
                 // CockroachDB can order ModelA.id in any order if ModelB.a_id is NULL.
@@ -287,12 +286,13 @@ mod order_by_dependent_pag {
             }"#,
             // Depends on how null values are handled.
             [MongoDb, Sqlite] => r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":3,"b":null},{"id":4,"b":null}]}}"#,
-            [MySql] => r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}}]}}"#,
+            // [MySql] => r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}}]}}"#,
                 // Postgres
             [Postgres] => r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":4,"b":null},{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}}]}}"#,
-            [MySql] => r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":4,"b":null},{"id":3,"b":null}]}}"#
+            // [MySql] => r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":4,"b":null},{"id":3,"b":null}]}}"#,
+            //MariaDB, MySql8, 5.7
+            [MySql] => r#"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":3,"b":null},{"id":4,"b":null}]}}"#
         );
-
         Ok(())
     }
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent_pagination.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent_pagination.rs
@@ -260,7 +260,6 @@ mod order_by_dependent_pag {
             [Sqlite, MySql] =>  r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":4,"b":null},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}}]}}"#,
             [MySql] =>  r#"{"data":{"findManyModelA":[{"id":4,"b":null},{"id":3,"b":null},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}}]}}"#
         );
-
         Ok(())
     }
 
@@ -287,8 +286,8 @@ mod order_by_dependent_pag {
               }
             }"#,
             // Depends on how null values are handled.
-            [MongoDb] => r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":3,"b":null},{"id":4,"b":null}]}}"#,
-            [Sqlite] => r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}}]}}"#,
+            [MongoDb, Sqlite] => r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":3,"b":null},{"id":4,"b":null}]}}"#,
+            [MySql] => r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}}]}}"#,
                 // Postgres
             [Postgres] => r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":4,"b":null},{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}}]}}"#,
             [MySql] => r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":4,"b":null},{"id":3,"b":null}]}}"#

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/pagination.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/pagination.rs
@@ -788,10 +788,10 @@ mod pagination {
                 id
               }
           }"#,
-          [Postgres, Sqlite, SqlServer, MySql, MongoDb] => r#"{"data":{"findManyTestModel":[{"id":3},{"id":5},{"id":2}]}}"#,
+          [] => r#"{"data":{"findManyTestModel":[{"id":3},{"id":5},{"id":2}]}}"#,
           [] => r#"{"data":{"findManyTestModel":[{"id":5},{"id":3},{"id":2}]}}"#,
           [] => r#"{"data":{"findManyTestModel":[{"id":3},{"id":2},{"id":1}]}}"#,
-          [] => r#"{"data":{"findManyTestModel":[{"id":5},{"id":2},{"id":1}]}}"#,
+          [Sqlite, MongoDb, Postgres, MySql, SqlServer] => r#"{"data":{"findManyTestModel":[{"id":5},{"id":2},{"id":1}]}}"#,
           [] => r#"{"data":{"findManyTestModel":[{"id":2},{"id":1}]}}"#
         );
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/pagination.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/pagination.rs
@@ -4,7 +4,7 @@ use std::cmp;
 #[test_suite(schema(schema))]
 mod pagination {
     use indoc::indoc;
-    use query_engine_tests::{assert_query_many, run_query};
+    use query_engine_tests::run_query;
 
     fn schema() -> String {
         let schema = indoc! {
@@ -781,20 +781,18 @@ mod pagination {
         // 3 => B B B B <- take
         // 2 => A A A B <- take
         // 1 => A B C D <- take
-        assert_query_many!(
-            &runner,
-            r#"query {
-                findManyTestModel(cursor: { id: 4 }, take: 3, skip: 1, orderBy: [{ fieldA: desc }, { fieldB: asc }, { fieldC: asc }, { fieldD: desc }]) {
-                  id
-                }
-            }"#,
-            vec![
-                r#"{"data":{"findManyTestModel":[{"id":3},{"id":5},{"id":2}]}}"#,
-                r#"{"data":{"findManyTestModel":[{"id":5},{"id":3},{"id":2}]}}"#,
-                r#"{"data":{"findManyTestModel":[{"id":3},{"id":2},{"id":1}]}}"#,
-                r#"{"data":{"findManyTestModel":[{"id":5},{"id":2},{"id":1}]}}"#,
-                r#"{"data":{"findManyTestModel":[{"id":2},{"id":1}]}}"#,
-            ]
+        connector_results!(
+          &runner,
+          r#"query {
+              findManyTestModel(cursor: { id: 4 }, take: 3, skip: 1, orderBy: [{ fieldA: desc }, { fieldB: asc }, { fieldC: asc }, { fieldD: desc }]) {
+                id
+              }
+          }"#,
+          [Postgres, Sqlite, SqlServer, MySql, MongoDb] => r#"{"data":{"findManyTestModel":[{"id":3},{"id":5},{"id":2}]}}"#,
+          [] => r#"{"data":{"findManyTestModel":[{"id":5},{"id":3},{"id":2}]}}"#,
+          [] => r#"{"data":{"findManyTestModel":[{"id":3},{"id":2},{"id":1}]}}"#,
+          [] => r#"{"data":{"findManyTestModel":[{"id":5},{"id":2},{"id":1}]}}"#,
+          [] => r#"{"data":{"findManyTestModel":[{"id":2},{"id":1}]}}"#
         );
 
         // >>> TEST #2
@@ -811,20 +809,18 @@ mod pagination {
         // 3 => B B B B <- take
         // 5 => B B B B <- take
         // 6 => C C D C <- take
-        assert_query_many!(
-            &runner,
-            r#"query {
-                findManyTestModel(cursor: { id: 4 }, take: 3, skip: 1, orderBy: [{ fieldA: asc }, { fieldB: desc }, { fieldC: desc }, { fieldD: asc }]) {
-                  id
-                }
-            }"#,
-            vec![
-                r#"{"data":{"findManyTestModel":[{"id":3},{"id":5},{"id":6}]}}"#,
-                r#"{"data":{"findManyTestModel":[{"id":5},{"id":3},{"id":6}]}}"#,
-                r#"{"data":{"findManyTestModel":[{"id":3},{"id":6}]}}"#,
-                r#"{"data":{"findManyTestModel":[{"id":5},{"id":6}]}}"#,
-                r#"{"data":{"findManyTestModel":[{"id":6}]}}"#
-            ]
+        connector_results!(
+          &runner,
+          r#"query {
+              findManyTestModel(cursor: { id: 4 }, take: 3, skip: 1, orderBy: [{ fieldA: asc }, { fieldB: desc }, { fieldC: desc }, { fieldD: asc }]) {
+                id
+              }
+          }"#,
+          [Postgres, Sqlite, SqlServer, MySql, MongoDb] => r#"{"data":{"findManyTestModel":[{"id":3},{"id":5},{"id":6}]}}"#,
+          [] => r#"{"data":{"findManyTestModel":[{"id":5},{"id":3},{"id":6}]}}"#,
+          [] => r#"{"data":{"findManyTestModel":[{"id":3},{"id":6}]}}"#,
+          [] => r#"{"data":{"findManyTestModel":[{"id":5},{"id":6}]}}"#,
+          [] => r#"{"data":{"findManyTestModel":[{"id":6}]}}"#
         );
 
         // Note: Negative takes reverse the order, the following tests check that.
@@ -848,20 +844,18 @@ mod pagination {
         // 6 => C C D C <- take
         //
         // Because the final result gets reversed again to restore original order, the result possibilities are the same as #2, just reversed.
-        assert_query_many!(
-            &runner,
-            r#"query {
-                findManyTestModel(cursor: { id: 4 }, take: -3, skip: 1, orderBy: [{ fieldA: desc }, { fieldB: asc }, { fieldC: asc }, { fieldD: desc }]) {
-                  id
-                }
-            }"#,
-            vec![
-                r#"{"data":{"findManyTestModel":[{"id":6},{"id":5},{"id":3}]}}"#,
-                r#"{"data":{"findManyTestModel":[{"id":6},{"id":3},{"id":5}]}}"#,
-                r#"{"data":{"findManyTestModel":[{"id":6},{"id":3}]}}"#,
-                r#"{"data":{"findManyTestModel":[{"id":6},{"id":5}]}}"#,
-                r#"{"data":{"findManyTestModel":[{"id":6}]}}"#
-            ]
+        connector_results!(
+          &runner,
+          r#"query {
+              findManyTestModel(cursor: { id: 4 }, take: -3, skip: 1, orderBy: [{ fieldA: desc }, { fieldB: asc }, { fieldC: asc }, { fieldD: desc }]) {
+                id
+              }
+          }"#,
+          [Postgres, Sqlite, SqlServer, MySql, MongoDb] => r#"{"data":{"findManyTestModel":[{"id":6},{"id":5},{"id":3}]}}"#,
+          [] => r#"{"data":{"findManyTestModel":[{"id":6},{"id":3},{"id":5}]}}"#,
+          [] => r#"{"data":{"findManyTestModel":[{"id":6},{"id":3}]}}"#,
+          [] => r#"{"data":{"findManyTestModel":[{"id":6},{"id":5}]}}"#,
+          [] => r#"{"data":{"findManyTestModel":[{"id":6}]}}"#
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/pagination.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/pagination.rs
@@ -838,7 +838,7 @@ mod pagination {
         // 6 => C C D C <- take
         //
         // Because the final result gets reversed again to restore original order, the result possibilities are the same as #2, just reversed.
-        connector_results!(
+        match_connector_result!(
           &runner,
           r#"query {
               findManyTestModel(cursor: { id: 4 }, take: -3, skip: 1, orderBy: [{ fieldA: desc }, { fieldB: asc }, { fieldC: asc }, { fieldD: desc }]) {

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/pagination.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/pagination.rs
@@ -854,7 +854,7 @@ mod pagination {
           [SqlServer] => r#"{"data":{"findManyTestModel":[{"id":6},{"id":5},{"id":3}]}}"#,
           [] => r#"{"data":{"findManyTestModel":[{"id":6},{"id":3},{"id":5}]}}"#,
           [] => r#"{"data":{"findManyTestModel":[{"id":6},{"id":3}]}}"#,
-          [MongoDb, Sqlite, Postgres, MySql] => r#"{"data":{"findManyTestModel":[{"id":6},{"id":5}]}}"#,
+          [MongoDb, Sqlite, Postgres, MySql, SqlServer] => r#"{"data":{"findManyTestModel":[{"id":6},{"id":5}]}}"#,
           [] => r#"{"data":{"findManyTestModel":[{"id":6}]}}"#
         );
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/pagination.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/pagination.rs
@@ -781,18 +781,15 @@ mod pagination {
         // 3 => B B B B <- take
         // 2 => A A A B <- take
         // 1 => A B C D <- take
-        connector_results!(
-          &runner,
-          r#"query {
-              findManyTestModel(cursor: { id: 4 }, take: 3, skip: 1, orderBy: [{ fieldA: desc }, { fieldB: asc }, { fieldC: asc }, { fieldD: desc }]) {
-                id
-              }
-          }"#,
-          [] => r#"{"data":{"findManyTestModel":[{"id":3},{"id":5},{"id":2}]}}"#,
-          [] => r#"{"data":{"findManyTestModel":[{"id":5},{"id":3},{"id":2}]}}"#,
-          [] => r#"{"data":{"findManyTestModel":[{"id":3},{"id":2},{"id":1}]}}"#,
-          [Sqlite, MongoDb, Postgres, MySql, SqlServer] => r#"{"data":{"findManyTestModel":[{"id":5},{"id":2},{"id":1}]}}"#,
-          [] => r#"{"data":{"findManyTestModel":[{"id":2},{"id":1}]}}"#
+        insta::assert_snapshot!(
+          run_query!(
+            &runner,
+            r#"query {
+                findManyTestModel(cursor: { id: 4 }, take: 3, skip: 1, orderBy: [{ fieldA: desc }, { fieldB: asc }, { fieldC: asc }, { fieldD: desc }]) {
+                  id
+                }
+            }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":5},{"id":2},{"id":1}]}}"###
         );
 
         // >>> TEST #2
@@ -809,18 +806,15 @@ mod pagination {
         // 3 => B B B B <- take
         // 5 => B B B B <- take
         // 6 => C C D C <- take
-        connector_results!(
-          &runner,
-          r#"query {
-              findManyTestModel(cursor: { id: 4 }, take: 3, skip: 1, orderBy: [{ fieldA: asc }, { fieldB: desc }, { fieldC: desc }, { fieldD: asc }]) {
-                id
-              }
-          }"#,
-          [] => r#"{"data":{"findManyTestModel":[{"id":3},{"id":5},{"id":6}]}}"#,
-          [] => r#"{"data":{"findManyTestModel":[{"id":5},{"id":3},{"id":6}]}}"#,
-          [] => r#"{"data":{"findManyTestModel":[{"id":3},{"id":6}]}}"#,
-          [SqlServer, Sqlite, MongoDb, Postgres, MySql] => r#"{"data":{"findManyTestModel":[{"id":5},{"id":6}]}}"#,
-          [] => r#"{"data":{"findManyTestModel":[{"id":6}]}}"#
+        insta::assert_snapshot!(
+          run_query!(
+            &runner,
+            r#"query {
+                findManyTestModel(cursor: { id: 4 }, take: 3, skip: 1, orderBy: [{ fieldA: asc }, { fieldB: desc }, { fieldC: desc }, { fieldD: asc }]) {
+                  id
+                }
+            }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":5},{"id":6}]}}"###
         );
 
         // Note: Negative takes reverse the order, the following tests check that.
@@ -852,10 +846,7 @@ mod pagination {
               }
           }"#,
           [SqlServer] => r#"{"data":{"findManyTestModel":[{"id":6},{"id":5},{"id":3}]}}"#,
-          [] => r#"{"data":{"findManyTestModel":[{"id":6},{"id":3},{"id":5}]}}"#,
-          [] => r#"{"data":{"findManyTestModel":[{"id":6},{"id":3}]}}"#,
-          [MongoDb, Sqlite, Postgres, MySql, SqlServer] => r#"{"data":{"findManyTestModel":[{"id":6},{"id":5}]}}"#,
-          [] => r#"{"data":{"findManyTestModel":[{"id":6}]}}"#
+          [MongoDb, Sqlite, Postgres, MySql, SqlServer] => r#"{"data":{"findManyTestModel":[{"id":6},{"id":5}]}}"#
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/pagination.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/pagination.rs
@@ -816,10 +816,10 @@ mod pagination {
                 id
               }
           }"#,
-          [Postgres, Sqlite, SqlServer, MySql, MongoDb] => r#"{"data":{"findManyTestModel":[{"id":3},{"id":5},{"id":6}]}}"#,
+          [] => r#"{"data":{"findManyTestModel":[{"id":3},{"id":5},{"id":6}]}}"#,
           [] => r#"{"data":{"findManyTestModel":[{"id":5},{"id":3},{"id":6}]}}"#,
           [] => r#"{"data":{"findManyTestModel":[{"id":3},{"id":6}]}}"#,
-          [] => r#"{"data":{"findManyTestModel":[{"id":5},{"id":6}]}}"#,
+          [SqlServer, Sqlite, MongoDb, Postgres, MySql] => r#"{"data":{"findManyTestModel":[{"id":5},{"id":6}]}}"#,
           [] => r#"{"data":{"findManyTestModel":[{"id":6}]}}"#
         );
 
@@ -851,10 +851,10 @@ mod pagination {
                 id
               }
           }"#,
-          [Postgres, Sqlite, SqlServer, MySql, MongoDb] => r#"{"data":{"findManyTestModel":[{"id":6},{"id":5},{"id":3}]}}"#,
+          [SqlServer] => r#"{"data":{"findManyTestModel":[{"id":6},{"id":5},{"id":3}]}}"#,
           [] => r#"{"data":{"findManyTestModel":[{"id":6},{"id":3},{"id":5}]}}"#,
           [] => r#"{"data":{"findManyTestModel":[{"id":6},{"id":3}]}}"#,
-          [] => r#"{"data":{"findManyTestModel":[{"id":6},{"id":5}]}}"#,
+          [MongoDb, Sqlite, Postgres, MySql] => r#"{"data":{"findManyTestModel":[{"id":6},{"id":5}]}}"#,
           [] => r#"{"data":{"findManyTestModel":[{"id":6}]}}"#
         );
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/regressions/pagination_regression.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/regressions/pagination_regression.rs
@@ -92,8 +92,8 @@ mod pagination_regr {
             orderBy: [{ field: desc }, { id: asc }]
           ) { id }
           }"#,
-          [Postgres, Sqlite, SqlServer, MySql, MongoDb] => r#"{"data":{"findManyTestModel":[{"id":4}]}}"#,
-          [] => r#"{"data":{"findManyTestModel":[{"id":4},{"id":5}]}}"#
+          [Sqlite, SqlServer, MySql, MongoDb] => r#"{"data":{"findManyTestModel":[{"id":4}]}}"#,
+          [Postgres] => r#"{"data":{"findManyTestModel":[{"id":4},{"id":5}]}}"#
         );
 
         Ok(())
@@ -118,8 +118,8 @@ mod pagination_regr {
             orderBy: [{ field: desc }, { id: asc }]
           ) { id }
           }"#,
-          [Postgres, Sqlite, SqlServer, MySql, MongoDb] => r#"{"data":{"findManyTestModel":[{"id":2}]}}"#,
-          [] => r#"{"data":{"findManyTestModel":[{"id":2},{"id":1}]}}"#
+          [Postgres] => r#"{"data":{"findManyTestModel":[{"id":2}]}}"#,
+          [Sqlite, MongoDb, MySql, SqlServer] => r#"{"data":{"findManyTestModel":[{"id":2},{"id":1}]}}"#
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/regressions/pagination_regression.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/regressions/pagination_regression.rs
@@ -3,7 +3,7 @@ use query_engine_tests::*;
 #[test_suite]
 mod pagination_regr {
     use indoc::indoc;
-    use query_engine_tests::{assert_query_many, run_query};
+    use query_engine_tests::run_query;
 
     fn schema_2855() -> String {
         let schema = indoc! {
@@ -82,20 +82,18 @@ mod pagination_regr {
         // There are 2 options, depending on how the underlying db orders NULLS (first or last, * ids have nulls in `field`):
         // Nulls last:  5, 3, 1*, 2*, 4* => take only 4
         // Nulls first: 1*, 2*, 4*, 5, 3 => take 4, 5
-        assert_query_many!(
-            &runner,
-            r#"{
-            findManyTestModel(
-              cursor: { id: 2 },
-              take: 2,
-              skip: 1,
-              orderBy: [{ field: desc }, { id: asc }]
-            ) { id }
+        connector_results!(
+          &runner,
+          r#"{
+          findManyTestModel(
+            cursor: { id: 2 },
+            take: 2,
+            skip: 1,
+            orderBy: [{ field: desc }, { id: asc }]
+          ) { id }
           }"#,
-            vec![
-                r#"{"data":{"findManyTestModel":[{"id":4}]}}"#,
-                r#"{"data":{"findManyTestModel":[{"id":4},{"id":5}]}}"#
-            ]
+          [Postgres, Sqlite, SqlServer, MySql, MongoDb] => r#"{"data":{"findManyTestModel":[{"id":4}]}}"#,
+          [] => r#"{"data":{"findManyTestModel":[{"id":4},{"id":5}]}}"#
         );
 
         Ok(())
@@ -110,20 +108,18 @@ mod pagination_regr {
         // Contain some nulls for `field`.
         create_test_data_3505_2(&runner).await?;
 
-        assert_query_many!(
-            &runner,
-            r#"{
-            findManyTestModel(
-              cursor: { id: 5 },
-              take: 2,
-              skip: 1,
-              orderBy: [{ field: desc }, { id: asc }]
-            ) { id }
+        connector_results!(
+          &runner,
+          r#"{
+          findManyTestModel(
+            cursor: { id: 5 },
+            take: 2,
+            skip: 1,
+            orderBy: [{ field: desc }, { id: asc }]
+          ) { id }
           }"#,
-            vec![
-                r#"{"data":{"findManyTestModel":[{"id":2}]}}"#,
-                r#"{"data":{"findManyTestModel":[{"id":2},{"id":1}]}}"#
-            ]
+          [Postgres, Sqlite, SqlServer, MySql, MongoDb] => r#"{"data":{"findManyTestModel":[{"id":2}]}}"#,
+          [] => r#"{"data":{"findManyTestModel":[{"id":2},{"id":1}]}}"#
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/regressions/pagination_regression.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/regressions/pagination_regression.rs
@@ -82,7 +82,7 @@ mod pagination_regr {
         // There are 2 options, depending on how the underlying db orders NULLS (first or last, * ids have nulls in `field`):
         // Nulls last:  5, 3, 1*, 2*, 4* => take only 4
         // Nulls first: 1*, 2*, 4*, 5, 3 => take 4, 5
-        connector_results!(
+        match_connector_result!(
           &runner,
           r#"{
           findManyTestModel(
@@ -108,7 +108,7 @@ mod pagination_regr {
         // Contain some nulls for `field`.
         create_test_data_3505_2(&runner).await?;
 
-        connector_results!(
+        match_connector_result!(
           &runner,
           r#"{
           findManyTestModel(

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/update_many.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/update_many.rs
@@ -37,7 +37,8 @@ mod update_many {
           @r###"{"data":{"updateManyTestModel":{"count":1}}}"###
         );
 
-        connector_results!(
+        insta::assert_snapshot!(
+        run_query!(
           &runner,
           r#"{
             findManyTestModel(orderBy: { id: asc }) {
@@ -45,9 +46,8 @@ mod update_many {
               optInt
               optFloat
             }
-          }"#,
-          [Postgres, Sqlite, SqlServer, MySql, MongoDb] => r#"{"data":{"findManyTestModel":[{"optStr":"str1new","optInt":1,"optFloat":null},{"optStr":"str2","optInt":null,"optFloat":null}]}}"#,
-          [] => r#"{"data":{"findManyTestModel":[{"optStr":"str1new","optInt":1,"optFloat":0.0},{"optStr":"str2","optInt":null,"optFloat":null}]}}"#
+          }"#),
+          @r###"{"data":{"findManyTestModel":[{"optStr":"str1new","optInt":1,"optFloat":null},{"optStr":"str2","optInt":null,"optFloat":null}]}}"###
         );
 
         Ok(())
@@ -71,17 +71,17 @@ mod update_many {
           @r###"{"data":{"updateManyTestModel":{"count":1}}}"###
         );
 
-        connector_results!(
-          &runner,
-          r#"{
-          findManyTestModel(orderBy: { id: asc }) {
-            optStr
-            optInt
-            optFloat
-            }
-          }"#,
-          [Postgres, Sqlite, SqlServer, MySql, MongoDb] => r#"{"data":{"findManyTestModel":[{"optStr":"str1new","optInt":null,"optFloat":null},{"optStr":"str2","optInt":null,"optFloat":null}]}}"#,
-          [] => r#"{"data":{"findManyTestModel":[{"optStr":"str1new","optInt":null,"optFloat":0.0},{"optStr":"str2","optInt":null,"optFloat":null}]}}"#
+        insta::assert_snapshot!(
+          run_query!(
+            &runner,
+            r#"{
+              findManyTestModel(orderBy: { id: asc }) {
+                optStr
+                optInt
+                optFloat
+              }
+            }"#),
+          @r###"{"data":{"findManyTestModel":[{"optStr":"str1new","optInt":null,"optFloat":null},{"optStr":"str2","optInt":null,"optFloat":null}]}}"###
         );
 
         Ok(())
@@ -106,7 +106,8 @@ mod update_many {
           @r###"{"data":{"updateManyTestModel":{"count":3}}}"###
         );
 
-        connector_results!(
+        insta::assert_snapshot!(
+          run_query!(
             &runner,
             r#"{
               findManyTestModel {
@@ -114,9 +115,8 @@ mod update_many {
                 optInt
                 optFloat
               }
-            }"#,
-            [Postgres, Sqlite, SqlServer, MySql, MongoDb] => r#"{"data":{"findManyTestModel":[{"optStr":"updated","optInt":null,"optFloat":null},{"optStr":"updated","optInt":1,"optFloat":null},{"optStr":"updated","optInt":2,"optFloat":1.55}]}}"#,
-            [] => r#"{"data":{"findManyTestModel":[{"optStr":"updated","optInt":-1,"optFloat":0.0},{"optStr":"updated","optInt":1,"optFloat":0.0},{"optStr":"updated","optInt":2,"optFloat":1.55}]}}"#
+            }"#),
+          @r###"{"data":{"findManyTestModel":[{"optStr":"updated","optInt":null,"optFloat":null},{"optStr":"updated","optInt":1,"optFloat":null},{"optStr":"updated","optInt":2,"optFloat":1.55}]}}"###
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/update_many.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/update_many.rs
@@ -4,7 +4,7 @@ use query_engine_tests::*;
 #[test_suite(schema(schema))]
 mod update_many {
     use indoc::indoc;
-    use query_engine_tests::{assert_query_many, is_one_of, run_query, run_query_json, ConnectorTag};
+    use query_engine_tests::{is_one_of, run_query, run_query_json, ConnectorTag};
 
     fn schema() -> String {
         let schema = indoc! {
@@ -37,19 +37,17 @@ mod update_many {
           @r###"{"data":{"updateManyTestModel":{"count":1}}}"###
         );
 
-        assert_query_many!(
-            &runner,
-            r#"{
+        connector_results!(
+          &runner,
+          r#"{
             findManyTestModel(orderBy: { id: asc }) {
               optStr
               optInt
               optFloat
             }
           }"#,
-            vec![
-                r#"{"data":{"findManyTestModel":[{"optStr":"str1new","optInt":1,"optFloat":null},{"optStr":"str2","optInt":null,"optFloat":null}]}}"#,
-                r#"{"data":{"findManyTestModel":[{"optStr":"str1new","optInt":1,"optFloat":0.0},{"optStr":"str2","optInt":null,"optFloat":null}]}}"#
-            ]
+          [Postgres, Sqlite, SqlServer, MySql, MongoDb] => r#"{"data":{"findManyTestModel":[{"optStr":"str1new","optInt":1,"optFloat":null},{"optStr":"str2","optInt":null,"optFloat":null}]}}"#,
+          [] => r#"{"data":{"findManyTestModel":[{"optStr":"str1new","optInt":1,"optFloat":0.0},{"optStr":"str2","optInt":null,"optFloat":null}]}}"#
         );
 
         Ok(())
@@ -73,19 +71,17 @@ mod update_many {
           @r###"{"data":{"updateManyTestModel":{"count":1}}}"###
         );
 
-        assert_query_many!(
-            &runner,
-            r#"{
-            findManyTestModel(orderBy: { id: asc }) {
-              optStr
-              optInt
-              optFloat
+        connector_results!(
+          &runner,
+          r#"{
+          findManyTestModel(orderBy: { id: asc }) {
+            optStr
+            optInt
+            optFloat
             }
           }"#,
-            vec![
-                r#"{"data":{"findManyTestModel":[{"optStr":"str1new","optInt":null,"optFloat":null},{"optStr":"str2","optInt":null,"optFloat":null}]}}"#,
-                r#"{"data":{"findManyTestModel":[{"optStr":"str1new","optInt":null,"optFloat":0.0},{"optStr":"str2","optInt":null,"optFloat":null}]}}"#
-            ]
+          [Postgres, Sqlite, SqlServer, MySql, MongoDb] => r#"{"data":{"findManyTestModel":[{"optStr":"str1new","optInt":null,"optFloat":null},{"optStr":"str2","optInt":null,"optFloat":null}]}}"#,
+          [] => r#"{"data":{"findManyTestModel":[{"optStr":"str1new","optInt":null,"optFloat":0.0},{"optStr":"str2","optInt":null,"optFloat":null}]}}"#
         );
 
         Ok(())
@@ -110,7 +106,7 @@ mod update_many {
           @r###"{"data":{"updateManyTestModel":{"count":3}}}"###
         );
 
-        assert_query_many!(
+        connector_results!(
             &runner,
             r#"{
               findManyTestModel {
@@ -119,10 +115,8 @@ mod update_many {
                 optFloat
               }
             }"#,
-            vec![
-                r#"{"data":{"findManyTestModel":[{"optStr":"updated","optInt":null,"optFloat":null},{"optStr":"updated","optInt":1,"optFloat":null},{"optStr":"updated","optInt":2,"optFloat":1.55}]}}"#,
-                r#"{"data":{"findManyTestModel":[{"optStr":"updated","optInt":-1,"optFloat":0.0},{"optStr":"updated","optInt":1,"optFloat":0.0},{"optStr":"updated","optInt":2,"optFloat":1.55}]}}"#
-            ]
+            [Postgres, Sqlite, SqlServer, MySql, MongoDb] => r#"{"data":{"findManyTestModel":[{"optStr":"updated","optInt":null,"optFloat":null},{"optStr":"updated","optInt":1,"optFloat":null},{"optStr":"updated","optInt":2,"optFloat":1.55}]}}"#,
+            [] => r#"{"data":{"findManyTestModel":[{"optStr":"updated","optInt":-1,"optFloat":0.0},{"optStr":"updated","optInt":1,"optFloat":0.0},{"optStr":"updated","optInt":2,"optFloat":1.55}]}}"#
         );
 
         Ok(())


### PR DESCRIPTION
Removes the excludes for all databases except SqlServer. I had to add in extra results because most sql engines handle ordering of null in a different way. 

This fixes https://github.com/prisma/prisma-engines/issues/2296