### PR TITLE
Hash index support on PostgreSQL

### DIFF
--- a/introspection-engine/connectors/mongodb-introspection-connector/src/sampler/statistics.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/src/sampler/statistics.rs
@@ -482,8 +482,9 @@ fn add_indices_to_models(
                 fields,
                 tpe,
                 defined_on_field,
-                name: None,
                 db_name,
+                name: None,
+                algorithm: None,
             });
         }
     }

--- a/introspection-engine/connectors/sql-introspection-connector/src/calculate_datamodel_tests.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/calculate_datamodel_tests.rs
@@ -393,6 +393,7 @@ mod tests {
                     fields: vec![IndexField::new("unique")],
                     tpe: dml::IndexType::Unique,
                     defined_on_field: true,
+                    algorithm: None,
                 }],
                 primary_key: None,
             }],
@@ -420,6 +421,7 @@ mod tests {
                 name: "unique_unique".to_string(),
                 columns: vec![IndexColumn::new("unique")],
                 tpe: IndexType::Unique,
+                algorithm: None,
             }],
             primary_key: None,
             foreign_keys: vec![],
@@ -761,6 +763,7 @@ mod tests {
                     fields: vec![IndexField::new("name"), IndexField::new("lastname")],
                     tpe: datamodel::dml::IndexType::Unique,
                     defined_on_field: false,
+                    algorithm: None,
                 }],
                 primary_key: Some(PrimaryKeyDefinition {
                     name: None,
@@ -814,6 +817,7 @@ mod tests {
                 name: "name_last_name_unique".to_string(),
                 columns: vec![IndexColumn::new("name"), IndexColumn::new("lastname")],
                 tpe: IndexType::Unique,
+                algorithm: None,
             }],
             primary_key: Some(PrimaryKey {
                 columns: vec![PrimaryKeyColumn::new("id")],

--- a/libs/datamodel/connectors/datamodel-connector/src/lib.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/lib.rs
@@ -270,6 +270,7 @@ capabilities!(
     NamedDefaultValues,
     IndexColumnLengthPrefixing,
     PrimaryKeySortOrderDefinition,
+    UsingHashIndex,
     // Start of query-engine-only Capabilities
     InsensitiveFilters,
     CreateMany,

--- a/libs/datamodel/connectors/dml/src/model.rs
+++ b/libs/datamodel/connectors/dml/src/model.rs
@@ -28,6 +28,18 @@ pub struct Model {
     pub is_ignored: bool,
 }
 
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum IndexAlgorithm {
+    BTree,
+    Hash,
+}
+
+impl Default for IndexAlgorithm {
+    fn default() -> Self {
+        Self::BTree
+    }
+}
+
 /// Represents an index defined via `@@index`, `@unique` or `@@unique`.
 #[derive(Debug, PartialEq, Clone)]
 pub struct IndexDefinition {
@@ -35,6 +47,7 @@ pub struct IndexDefinition {
     pub db_name: Option<String>,
     pub fields: Vec<IndexField>,
     pub tpe: IndexType,
+    pub algorithm: Option<IndexAlgorithm>,
     pub defined_on_field: bool,
 }
 

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
@@ -99,6 +99,7 @@ const CAPABILITIES: &[ConnectorCapability] = &[
     ConnectorCapability::ScalarLists,
     ConnectorCapability::UpdateableId,
     ConnectorCapability::WritableAutoincField,
+    ConnectorCapability::UsingHashIndex,
 ];
 
 pub struct PostgresDatamodelConnector;

--- a/libs/datamodel/core/src/transform/ast_to_dml/db.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db.rs
@@ -13,7 +13,7 @@ pub(crate) mod walkers;
 
 // We should strive to make these private and expose that data through walkers.
 pub(crate) use names::constraint_namespace::ConstraintName;
-pub(crate) use types::{RelationField, ScalarField, ScalarFieldType};
+pub(crate) use types::{IndexAlgorithm, RelationField, ScalarField, ScalarFieldType};
 
 use self::{context::Context, relations::Relations, types::Types};
 use crate::PreviewFeature;

--- a/libs/datamodel/core/src/transform/ast_to_dml/db/indexes.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/indexes.rs
@@ -75,8 +75,8 @@ pub(super) fn infer_implicit_indexes(ctx: &mut Context<'_>) {
                     })
                     .collect(),
                 source_field,
-                name: None,
                 db_name: Some(Cow::from(db_name)),
+                ..Default::default()
             },
         ));
     }

--- a/libs/datamodel/core/src/transform/ast_to_dml/db/types.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/types.rs
@@ -183,6 +183,18 @@ impl ModelAttributes<'_> {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+pub enum IndexAlgorithm {
+    BTree,
+    Hash,
+}
+
+impl Default for IndexAlgorithm {
+    fn default() -> Self {
+        Self::BTree
+    }
+}
+
 #[derive(Debug, Default)]
 pub(crate) struct IndexAttribute<'ast> {
     pub(crate) is_unique: bool,
@@ -190,6 +202,7 @@ pub(crate) struct IndexAttribute<'ast> {
     pub(crate) source_field: Option<ast::FieldId>,
     pub(crate) name: Option<&'ast str>,
     pub(crate) db_name: Option<Cow<'ast, str>>,
+    pub(crate) algorithm: Option<IndexAlgorithm>,
 }
 
 #[derive(Debug)]

--- a/libs/datamodel/core/src/transform/ast_to_dml/lift.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/lift.rs
@@ -1,6 +1,6 @@
 use crate::{
     ast, dml,
-    transform::ast_to_dml::db::{self, walkers::*},
+    transform::ast_to_dml::db::{self, walkers::*, IndexAlgorithm},
     IndexField, PrimaryKeyField,
 };
 use ::dml::composite_type::{CompositeType, CompositeTypeField, CompositeTypeFieldType};
@@ -316,6 +316,10 @@ impl<'a> LiftAstToDml<'a> {
                         true => dml::IndexType::Unique,
                         false => dml::IndexType::Normal,
                     },
+                    algorithm: idx.attribute().algorithm.map(|using| match using {
+                        IndexAlgorithm::BTree => dml::IndexAlgorithm::BTree,
+                        IndexAlgorithm::Hash => dml::IndexAlgorithm::Hash,
+                    }),
                     defined_on_field: idx.attribute().source_field.is_some(),
                 }
             })

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations.rs
@@ -54,6 +54,8 @@ pub(super) fn validate(db: &ParserDatabase<'_>, diagnostics: &mut Diagnostics, r
             indexes::has_a_unique_constraint_name(db, index, diagnostics);
             indexes::uses_length_or_sort_without_preview_flag(db, index, diagnostics);
             indexes::field_length_prefix_supported(db, index, diagnostics);
+            indexes::index_algorithm_preview_feature(db, index, diagnostics);
+            indexes::index_algorithm_is_supported(db, index, diagnostics);
 
             for field_attribute in index.scalar_field_attributes() {
                 let span = index

--- a/libs/datamodel/core/src/transform/dml_to_ast/lower_model_attributes.rs
+++ b/libs/datamodel/core/src/transform/dml_to_ast/lower_model_attributes.rs
@@ -1,3 +1,5 @@
+use ::dml::model::IndexAlgorithm;
+
 use crate::ast::{Argument, Attribute};
 use crate::common::constraint_names::ConstraintNames;
 use crate::common::preview_features::PreviewFeature;
@@ -71,6 +73,13 @@ impl<'a> LowerDmlToAst<'a> {
             .for_each(|index_def| {
                 let mut args = self.fields_argument(&index_def);
                 self.push_index_map_argument(model, index_def, &mut args);
+
+                if let Some(IndexAlgorithm::Hash) = index_def.algorithm {
+                    args.push(ast::Argument::new(
+                        "type",
+                        ast::Expression::ConstantValue("Hash".to_string(), Span::empty()),
+                    ));
+                };
 
                 attributes.push(ast::Attribute::new("index", args));
             });

--- a/libs/datamodel/core/tests/attributes/constraint_names_positive.rs
+++ b/libs/datamodel/core/tests/attributes/constraint_names_positive.rs
@@ -35,6 +35,7 @@ fn multiple_indexes_with_same_name_on_different_models_are_supported_by_mysql() 
         fields: vec![IndexField::new("id")],
         tpe: IndexType::Normal,
         defined_on_field: false,
+        algorithm: None,
     });
 
     post_model.assert_has_index(IndexDefinition {
@@ -43,6 +44,7 @@ fn multiple_indexes_with_same_name_on_different_models_are_supported_by_mysql() 
         fields: vec![IndexField::new("id")],
         tpe: IndexType::Normal,
         defined_on_field: false,
+        algorithm: None,
     });
 }
 
@@ -78,6 +80,7 @@ fn foreign_keys_and_indexes_with_same_name_on_same_table_are_not_supported_on_my
         fields: vec![IndexField::new("bId")],
         tpe: IndexType::Normal,
         defined_on_field: false,
+        algorithm: None,
     });
 }
 
@@ -115,6 +118,7 @@ fn multiple_indexes_with_same_name_on_different_models_are_supported_by_mssql() 
         fields: vec![IndexField::new("id")],
         tpe: IndexType::Normal,
         defined_on_field: false,
+        algorithm: None,
     });
 
     post_model.assert_has_index(IndexDefinition {
@@ -123,6 +127,7 @@ fn multiple_indexes_with_same_name_on_different_models_are_supported_by_mssql() 
         fields: vec![IndexField::new("id")],
         tpe: IndexType::Normal,
         defined_on_field: false,
+        algorithm: None,
     });
 }
 
@@ -162,6 +167,7 @@ fn multiple_constraints_with_same_name_in_different_namespaces_are_supported_by_
         fields: vec![IndexField::new("id")],
         tpe: IndexType::Normal,
         defined_on_field: false,
+        algorithm: None,
     });
 
     post_model.assert_has_index(IndexDefinition {
@@ -170,5 +176,6 @@ fn multiple_constraints_with_same_name_in_different_namespaces_are_supported_by_
         fields: vec![IndexField::new("id")],
         tpe: IndexType::Normal,
         defined_on_field: false,
+        algorithm: None,
     });
 }

--- a/libs/datamodel/core/tests/attributes/id_positive.rs
+++ b/libs/datamodel/core/tests/attributes/id_positive.rs
@@ -156,6 +156,7 @@ fn should_allow_unique_and_id_on_same_field() {
         fields: vec![IndexField::new("id")],
         tpe: IndexType::Unique,
         defined_on_field: true,
+        algorithm: None,
     });
 }
 

--- a/libs/datamodel/core/tests/attributes/relations/relations_positive.rs
+++ b/libs/datamodel/core/tests/attributes/relations/relations_positive.rs
@@ -401,6 +401,7 @@ fn implicit_unique_constraint_on_one_to_one() {
         fields: vec![IndexField::new("user_id")],
         tpe: IndexType::Unique,
         defined_on_field: true,
+        algorithm: None,
     });
 }
 
@@ -445,6 +446,7 @@ fn implicit_unique_constraint_on_compound_one_to_one() {
         fields: vec![IndexField::new("user_id_1"), IndexField::new("user_id_2")],
         tpe: IndexType::Unique,
         defined_on_field: false,
+        algorithm: None,
     });
 }
 

--- a/libs/datamodel/core/tests/attributes/unique_positive.rs
+++ b/libs/datamodel/core/tests/attributes/unique_positive.rs
@@ -22,6 +22,7 @@ fn basic_unique_index_must_work() {
         fields: vec![IndexField::new("firstName"), IndexField::new("lastName")],
         tpe: IndexType::Unique,
         defined_on_field: false,
+        algorithm: None,
     });
 }
 
@@ -100,6 +101,7 @@ fn the_name_argument_must_work() {
         fields: vec![IndexField::new("firstName"), IndexField::new("lastName")],
         tpe: IndexType::Unique,
         defined_on_field: false,
+        algorithm: None,
     });
 }
 
@@ -139,6 +141,7 @@ fn multiple_unique_must_work() {
                     },
                 ],
                 tpe: Unique,
+                algorithm: None,
                 defined_on_field: false,
             },
             IndexDefinition {
@@ -161,6 +164,7 @@ fn multiple_unique_must_work() {
                     },
                 ],
                 tpe: Unique,
+                algorithm: None,
                 defined_on_field: false,
             },
         ]
@@ -212,6 +216,7 @@ fn multi_field_unique_indexes_on_enum_fields_must_work() {
         fields: vec![IndexField::new("role")],
         tpe: IndexType::Unique,
         defined_on_field: false,
+        algorithm: None,
     });
 }
 
@@ -237,6 +242,7 @@ fn single_field_unique_indexes_on_enum_fields_must_work() {
         fields: vec![IndexField::new("role")],
         tpe: IndexType::Unique,
         defined_on_field: true,
+        algorithm: None,
     });
 }
 
@@ -279,6 +285,7 @@ fn named_multi_field_unique_must_work() {
         fields: vec![IndexField::new("a"), IndexField::new("b")],
         tpe: IndexType::Unique,
         defined_on_field: false,
+        algorithm: None,
     });
 }
 
@@ -304,6 +311,7 @@ fn mapped_multi_field_unique_must_work() {
         fields: vec![IndexField::new("a"), IndexField::new("b")],
         tpe: IndexType::Unique,
         defined_on_field: false,
+        algorithm: None,
     });
 }
 
@@ -331,6 +339,7 @@ fn mapped_singular_unique_must_work() {
         fields: vec![IndexField::new("a")],
         tpe: IndexType::Unique,
         defined_on_field: true,
+        algorithm: None,
     });
 
     let model2 = datamodel.assert_has_model("Model2");
@@ -340,6 +349,7 @@ fn mapped_singular_unique_must_work() {
         fields: vec![IndexField::new("a")],
         tpe: IndexType::Unique,
         defined_on_field: true,
+        algorithm: None,
     });
 }
 
@@ -365,6 +375,7 @@ fn named_and_mapped_multi_field_unique_must_work() {
         fields: vec![IndexField::new("a"), IndexField::new("b")],
         tpe: IndexType::Unique,
         defined_on_field: false,
+        algorithm: None,
     });
 }
 
@@ -390,6 +401,7 @@ fn implicit_names_must_work() {
         fields: vec![IndexField::new("a"), IndexField::new("b")],
         tpe: IndexType::Unique,
         defined_on_field: false,
+        algorithm: None,
     });
 
     model.assert_has_index(IndexDefinition {
@@ -398,6 +410,7 @@ fn implicit_names_must_work() {
         fields: vec![IndexField::new("a")],
         tpe: IndexType::Unique,
         defined_on_field: true,
+        algorithm: None,
     });
 }
 
@@ -423,6 +436,7 @@ fn defined_on_field_must_work() {
         fields: vec![IndexField::new("a")],
         tpe: IndexType::Unique,
         defined_on_field: true,
+        algorithm: None,
     });
 
     model.assert_has_index(IndexDefinition {
@@ -431,6 +445,7 @@ fn defined_on_field_must_work() {
         fields: vec![IndexField::new("b")],
         tpe: IndexType::Unique,
         defined_on_field: false,
+        algorithm: None,
     });
 }
 
@@ -454,5 +469,6 @@ fn mapping_unique_to_a_field_name_should_work() {
         fields: vec![IndexField::new("name"), IndexField::new("identification")],
         tpe: IndexType::Unique,
         defined_on_field: false,
+        algorithm: None,
     });
 }

--- a/libs/sql-schema-describer/src/lib.rs
+++ b/libs/sql-schema-describer/src/lib.rs
@@ -239,6 +239,27 @@ impl IndexType {
     }
 }
 
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Copy)]
+pub enum SQLIndexAlgorithm {
+    BTree,
+    Hash,
+}
+
+impl AsRef<str> for SQLIndexAlgorithm {
+    fn as_ref(&self) -> &str {
+        match self {
+            Self::BTree => "BTREE",
+            Self::Hash => "HASH",
+        }
+    }
+}
+
+impl fmt::Display for SQLIndexAlgorithm {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_ref())
+    }
+}
+
 /// The sort order of an index.
 #[derive(Serialize, Deserialize, PartialEq, Debug, Copy, Clone)]
 pub enum SQLSortOrder {
@@ -294,6 +315,8 @@ pub struct Index {
     pub columns: Vec<IndexColumn>,
     /// Type of index.
     pub tpe: IndexType,
+    /// BTree or Hash
+    pub algorithm: Option<SQLIndexAlgorithm>,
 }
 
 impl Index {

--- a/libs/sql-schema-describer/src/mssql.rs
+++ b/libs/sql-schema-describer/src/mssql.rs
@@ -483,6 +483,7 @@ impl<'a> SqlSchemaDescriber<'a> {
                                     true => IndexType::Unique,
                                     false => IndexType::Normal,
                                 },
+                                algorithm: None,
                             },
                         );
                     }

--- a/libs/sql-schema-describer/src/mysql.rs
+++ b/libs/sql-schema-describer/src/mysql.rs
@@ -515,6 +515,7 @@ impl<'a> SqlSchemaDescriber<'a> {
                                     true => IndexType::Unique,
                                     false => IndexType::Normal,
                                 },
+                                algorithm: None,
                             },
                         );
                     }

--- a/libs/sql-schema-describer/src/sqlite.rs
+++ b/libs/sql-schema-describer/src/sqlite.rs
@@ -454,6 +454,7 @@ impl<'a> SqlSchemaDescriber<'a> {
                     false => IndexType::Normal,
                 },
                 columns: vec![],
+                algorithm: None,
             };
 
             let sql = format!(r#"PRAGMA index_info("{}");"#, name);

--- a/libs/sql-schema-describer/src/walkers.rs
+++ b/libs/sql-schema-describer/src/walkers.rs
@@ -4,8 +4,8 @@
 
 use crate::{
     Column, ColumnArity, ColumnId, ColumnType, ColumnTypeFamily, DefaultValue, Enum, ForeignKey, ForeignKeyAction,
-    Index, IndexColumn, IndexType, PrimaryKey, PrimaryKeyColumn, SQLSortOrder, SqlSchema, Table, TableId,
-    UserDefinedType, View,
+    Index, IndexColumn, IndexType, PrimaryKey, PrimaryKeyColumn, SQLIndexAlgorithm, SQLSortOrder, SqlSchema, Table,
+    TableId, UserDefinedType, View,
 };
 use serde::de::DeserializeOwned;
 use std::fmt;
@@ -668,6 +668,11 @@ impl<'a> IndexWalker<'a> {
             table_id: self.table_id,
             schema: self.schema,
         }
+    }
+
+    /// The hash algorithm used in the index.
+    pub fn algorithm(&self) -> Option<SQLIndexAlgorithm> {
+        self.get().algorithm
     }
 }
 

--- a/libs/sql-schema-describer/tests/describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describer_tests.rs
@@ -305,6 +305,7 @@ fn indices_must_work(api: TestApi) {
             auto_increment: false,
         },
     ];
+
     let pk_sequence = match api.sql_family() {
         SqlFamily::Postgres => Some(Sequence {
             name: "User_id_seq".to_string(),
@@ -321,6 +322,12 @@ fn indices_must_work(api: TestApi) {
         Some(SQLSortOrder::Asc)
     };
 
+    let algorithm = if api.is_postgres() && !api.is_cockroach() {
+        Some(SQLIndexAlgorithm::BTree)
+    } else {
+        None
+    };
+
     assert_eq!(
         vec![Index {
             name: "count".to_string(),
@@ -330,6 +337,7 @@ fn indices_must_work(api: TestApi) {
                 length: None,
             }],
             tpe: IndexType::Normal,
+            algorithm
         }],
         user_table.indices
     );

--- a/libs/sql-schema-describer/tests/describers/mssql_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/mssql_describer_tests.rs
@@ -735,7 +735,8 @@ fn mssql_multi_field_indexes_must_be_inferred(api: TestApi) {
         &[Index {
             name: "age_and_name_index".into(),
             columns,
-            tpe: IndexType::Unique
+            tpe: IndexType::Unique,
+            algorithm: None,
         }]
     );
 }
@@ -785,6 +786,7 @@ fn mssql_join_table_unique_indexes_must_be_inferred(api: TestApi) {
             name: "cat_and_human_index".into(),
             columns,
             tpe: IndexType::Unique,
+            algorithm: None,
         }]
     );
 }

--- a/libs/sql-schema-describer/tests/describers/mysql_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/mysql_describer_tests.rs
@@ -1204,6 +1204,7 @@ fn mysql_multi_field_indexes_must_be_inferred(api: TestApi) {
             name: "age_and_name_index".into(),
             columns,
             tpe: IndexType::Unique,
+            algorithm: None,
         }]
     );
 }
@@ -1242,6 +1243,7 @@ fn old_mysql_multi_field_indexes_must_be_inferred(api: TestApi) {
             name: "age_and_name_index".into(),
             columns,
             tpe: IndexType::Unique,
+            algorithm: None,
         }]
     );
 }

--- a/libs/sql-schema-describer/tests/describers/postgres_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/postgres_describer_tests.rs
@@ -571,6 +571,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                     length: None,
                 }],
                 tpe: IndexType::Unique,
+                algorithm: Some(SQLIndexAlgorithm::BTree),
             },],
             primary_key: Some(PrimaryKey {
                 columns: vec![PrimaryKeyColumn::new("primary_col")],
@@ -686,7 +687,7 @@ fn postgres_sequences_must_work(api: TestApi) {
     assert_eq!(got_seq, &Sequence { name: "test".into() },);
 }
 
-#[test_connector(tags(Postgres))]
+#[test_connector(tags(Postgres), exclude(Cockroach))]
 fn postgres_multi_field_indexes_must_be_inferred_in_the_right_order(api: TestApi) {
     let schema = format!(
         r##"

--- a/libs/sql-schema-describer/tests/test_api/mod.rs
+++ b/libs/sql-schema-describer/tests/test_api/mod.rs
@@ -120,6 +120,14 @@ impl TestApi {
         self.tags.contains(Tags::Mysql)
     }
 
+    pub(crate) fn is_postgres(&self) -> bool {
+        self.tags.contains(Tags::Postgres)
+    }
+
+    pub(crate) fn is_cockroach(&self) -> bool {
+        self.tags.contains(Tags::Cockroach)
+    }
+
     pub(crate) fn is_mysql_8(&self) -> bool {
         self.tags.contains(Tags::Mysql8)
     }

--- a/migration-engine/connectors/sql-migration-connector/src/connection_wrapper/native.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/connection_wrapper/native.rs
@@ -235,6 +235,8 @@ fn filter_extended_index_capabilities(schema: &mut SqlSchema) {
                 col.sort_order = None;
             }
 
+            index.algorithm = None;
+
             if !remove_index {
                 kept_indexes.push(index);
             }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
@@ -14,7 +14,8 @@ use prisma_value::PrismaValue;
 use regex::Regex;
 use sql_ddl::{postgres as ddl, IndexColumn, SortOrder};
 use sql_schema_describer::{
-    walkers::*, ColumnArity, ColumnTypeFamily, DefaultKind, DefaultValue, ForeignKeyAction, SQLSortOrder, SqlSchema,
+    walkers::*, ColumnArity, ColumnTypeFamily, DefaultKind, DefaultValue, ForeignKeyAction, SQLIndexAlgorithm,
+    SQLSortOrder, SqlSchema,
 };
 use std::borrow::Cow;
 
@@ -358,6 +359,10 @@ impl SqlRenderer for PostgresFlavour {
             index_name: index.name().into(),
             is_unique: index.index_type().is_unique(),
             table_reference: index.table().name().into(),
+            using: index.algorithm().map(|algo| match algo {
+                SQLIndexAlgorithm::BTree => ddl::IndexAlgorithm::BTree,
+                SQLIndexAlgorithm::Hash => ddl::IndexAlgorithm::Hash,
+            }),
             columns: index
                 .columns()
                 .map(|c| IndexColumn {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
@@ -5,7 +5,7 @@ pub(super) use sql_schema_calculator_flavour::SqlSchemaCalculatorFlavour;
 use crate::flavour::SqlFlavour;
 use datamodel::{
     walkers::{walk_models, walk_relations, ModelWalker, ScalarFieldWalker, TypeWalker},
-    Configuration, Datamodel, DefaultValue, FieldArity, IndexDefinition, IndexType, ScalarType,
+    Configuration, Datamodel, DefaultValue, FieldArity, IndexAlgorithm, IndexDefinition, IndexType, ScalarType,
 };
 use prisma_value::PrismaValue;
 use sql_schema_describer::{self as sql, walkers::SqlSchemaExt, ColumnType};
@@ -89,11 +89,17 @@ fn calculate_model_tables<'a>(
                     IndexType::Normal => sql::IndexType::Normal,
                 };
 
+                let algorithm = index_definition.algorithm.map(|algo| match algo {
+                    IndexAlgorithm::BTree => sql::SQLIndexAlgorithm::BTree,
+                    IndexAlgorithm::Hash => sql::SQLIndexAlgorithm::Hash,
+                });
+
                 sql::Index {
                     name: index_definition.db_name.clone().unwrap(),
                     // The model index definition uses the model field names, but the SQL Index wants the column names.
                     columns,
                     tpe: index_type,
+                    algorithm,
                 }
             })
             .collect();
@@ -177,11 +183,13 @@ fn calculate_relation_tables<'a>(
                         sql::IndexColumn::new(m2m.model_b_column()),
                     ],
                     tpe: sql::IndexType::Unique,
+                    algorithm: None,
                 },
                 sql::Index {
                     name: format!("{}_B_index", &table_name),
                     columns: vec![sql::IndexColumn::new(m2m.model_b_column())],
                     tpe: sql::IndexType::Normal,
+                    algorithm: None,
                 },
             ];
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/table.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/table.rs
@@ -173,4 +173,5 @@ fn indexes_match(first: &IndexWalker<'_>, second: &IndexWalker<'_>) -> bool {
             names_match && lengths_match && orders_match
         })
         && first.index_type() == second.index_type()
+        && first.algorithm() == second.algorithm()
 }

--- a/migration-engine/migration-engine-tests/src/assertions.rs
+++ b/migration-engine/migration-engine-tests/src/assertions.rs
@@ -9,7 +9,7 @@ use pretty_assertions::assert_eq;
 use prisma_value::PrismaValue;
 use sql_schema_describer::{
     Column, ColumnTypeFamily, DefaultKind, DefaultValue, Enum, ForeignKey, ForeignKeyAction, Index, IndexType,
-    PrimaryKey, SQLSortOrder, SqlSchema, Table,
+    PrimaryKey, SQLIndexAlgorithm, SQLSortOrder, SqlSchema, Table,
 };
 use test_setup::{BitFlags, Tags};
 
@@ -750,6 +750,12 @@ impl<'a> IndexAssertion<'a> {
 
     pub fn assert_is_not_unique(self) -> Self {
         assert_eq!(self.0.tpe, IndexType::Normal);
+
+        self
+    }
+
+    pub fn assert_algorithm(self, algo: SQLIndexAlgorithm) -> Self {
+        assert_eq!(self.0.algorithm, Some(algo));
 
         self
     }


### PR DESCRIPTION
Allows defining indexes using `Hash` instead of `BTree` as the algorithm. Works only with `@@index` attribute, never with `@@unique`. Support only for PostgreSQL, due to MySQL and SQL Server supporting `Hash` only with their in-memory tables, and SQLite/Mongo having no support for `Hash`.
 
Part of: https://github.com/prisma/prisma/issues/10080