### PR TITLE
@@fulltext attribute for MySQL, AST/DML work

### DIFF
--- a/libs/datamodel/connectors/datamodel-connector/src/lib.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/lib.rs
@@ -271,6 +271,7 @@ capabilities!(
     IndexColumnLengthPrefixing,
     PrimaryKeySortOrderDefinition,
     UsingHashIndex,
+    FullTextIndex,
     // Start of query-engine-only Capabilities
     InsensitiveFilters,
     CreateMany,

--- a/libs/datamodel/connectors/dml/src/model.rs
+++ b/libs/datamodel/connectors/dml/src/model.rs
@@ -55,7 +55,12 @@ impl IndexDefinition {
     pub fn is_unique(&self) -> bool {
         matches!(self.tpe, IndexType::Unique)
     }
+
+    pub fn is_fulltext(&self) -> bool {
+        matches!(self.tpe, IndexType::Fulltext)
+    }
 }
+
 ///A field in an index that optionally defines a sort order and length limit.
 #[derive(Debug, PartialEq, Clone)]
 pub struct IndexField {
@@ -125,6 +130,7 @@ impl fmt::Display for PrimaryKeyField {
 pub enum IndexType {
     Unique,
     Normal,
+    Fulltext,
 }
 
 #[derive(Debug, PartialEq, Clone, Copy)]

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
@@ -113,6 +113,7 @@ const CAPABILITIES: &[ConnectorCapability] = &[
     ConnectorCapability::AdvancedJsonNullability,
     ConnectorCapability::ForeignKeys,
     ConnectorCapability::IndexColumnLengthPrefixing,
+    ConnectorCapability::FullTextIndex,
 ];
 
 const CONSTRAINT_SCOPES: &[ConstraintScope] = &[ConstraintScope::GlobalForeignKey, ConstraintScope::ModelKeyIndex];

--- a/libs/datamodel/core/src/ast/helper.rs
+++ b/libs/datamodel/core/src/ast/helper.rs
@@ -4,7 +4,7 @@ pub(crate) fn get_sort_index_of_attribute(is_field_attribute: bool, attribute_na
     let correct_order: &[&str] = if is_field_attribute {
         &["id", "unique", "default", "updatedAt", "map", "relation"]
     } else {
-        &["id", "unique", "index", "map"]
+        &["id", "unique", "index", "fulltext", "map"]
     };
 
     correct_order

--- a/libs/datamodel/core/src/common/preview_features.rs
+++ b/libs/datamodel/core/src/common/preview_features.rs
@@ -60,6 +60,7 @@ features!(
     InteractiveTransactions,
     NamedConstraints,
     FullTextSearch,
+    FullTextIndex,
     DataProxy,
     ExtendedIndexes,
     Cockroachdb,
@@ -77,6 +78,7 @@ pub static GENERATOR: Lazy<FeatureMap> = Lazy::new(|| {
             MongoDb,
             InteractiveTransactions,
             FullTextSearch,
+            FullTextIndex,
             DataProxy,
             ExtendedIndexes,
         ])

--- a/libs/datamodel/core/src/transform/ast_to_dml/db.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db.rs
@@ -13,7 +13,7 @@ pub(crate) mod walkers;
 
 // We should strive to make these private and expose that data through walkers.
 pub(crate) use names::constraint_namespace::ConstraintName;
-pub(crate) use types::{IndexAlgorithm, RelationField, ScalarField, ScalarFieldType};
+pub(crate) use types::{IndexAlgorithm, IndexType, RelationField, ScalarField, ScalarFieldType};
 
 use self::{context::Context, relations::Relations, types::Types};
 use crate::PreviewFeature;

--- a/libs/datamodel/core/src/transform/ast_to_dml/db/indexes.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/indexes.rs
@@ -2,7 +2,10 @@ use std::borrow::Cow;
 
 use crate::common::constraint_names::ConstraintNames;
 
-use super::{context::Context, types::IndexAttribute};
+use super::{
+    context::Context,
+    types::{IndexAttribute, IndexType},
+};
 use crate::transform::ast_to_dml::db::types::FieldWithArgs;
 
 /// Prisma forces a 1:1 relation to be unique from the defining side. If the
@@ -66,7 +69,7 @@ pub(super) fn infer_implicit_indexes(ctx: &mut Context<'_>) {
         indexes.push((
             model.model_id(),
             IndexAttribute {
-                is_unique: true,
+                r#type: IndexType::Unique,
                 fields: referencing_fields()
                     .map(|f| FieldWithArgs {
                         field_id: f.field_id(),

--- a/libs/datamodel/core/src/transform/ast_to_dml/db/types.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/types.rs
@@ -195,14 +195,37 @@ impl Default for IndexAlgorithm {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum IndexType {
+    Normal,
+    Unique,
+    Fulltext,
+}
+
+impl Default for IndexType {
+    fn default() -> Self {
+        Self::Normal
+    }
+}
+
 #[derive(Debug, Default)]
 pub(crate) struct IndexAttribute<'ast> {
-    pub(crate) is_unique: bool,
+    pub(crate) r#type: IndexType,
     pub(crate) fields: Vec<FieldWithArgs>,
     pub(crate) source_field: Option<ast::FieldId>,
     pub(crate) name: Option<&'ast str>,
     pub(crate) db_name: Option<Cow<'ast, str>>,
     pub(crate) algorithm: Option<IndexAlgorithm>,
+}
+
+impl<'ast> IndexAttribute<'ast> {
+    pub(crate) fn is_unique(&self) -> bool {
+        matches!(self.r#type, IndexType::Unique)
+    }
+
+    pub(crate) fn is_fulltext(&self) -> bool {
+        matches!(self.r#type, IndexType::Fulltext)
+    }
 }
 
 #[derive(Debug)]

--- a/libs/datamodel/core/src/transform/ast_to_dml/db/walkers/index.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/walkers/index.rs
@@ -35,7 +35,7 @@ impl<'ast, 'db> IndexWalker<'ast, 'db> {
             )
             .collect();
 
-        if self.index_attribute.is_unique {
+        if self.index_attribute.is_unique() {
             ConstraintNames::unique_index_name(model_db_name, &field_db_names, self.db.active_connector()).into()
         } else {
             ConstraintNames::non_unique_index_name(model_db_name, &field_db_names, self.db.active_connector()).into()
@@ -93,7 +93,7 @@ impl<'ast, 'db> IndexWalker<'ast, 'db> {
     }
 
     pub(crate) fn is_unique(self) -> bool {
-        self.index_attribute.is_unique
+        self.index_attribute.is_unique()
     }
 
     pub(crate) fn model(self) -> ModelWalker<'ast, 'db> {

--- a/libs/datamodel/core/src/transform/ast_to_dml/db/walkers/model.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/walkers/model.rs
@@ -66,7 +66,7 @@ impl<'ast, 'db> ModelWalker<'ast, 'db> {
         self.model_attributes
             .ast_indexes
             .iter()
-            .any(|(_, idx)| idx.is_unique && idx.fields.iter().map(|f| f.field_id).collect::<Vec<_>>() == fields)
+            .any(|(_, idx)| idx.is_unique() && idx.fields.iter().map(|f| f.field_id).collect::<Vec<_>>() == fields)
     }
 
     /// The name of the database table the model points to.
@@ -143,7 +143,7 @@ impl<'ast, 'db> ModelWalker<'ast, 'db> {
 
         let from_indices = self
             .indexes()
-            .filter(|walker| walker.attribute().is_unique)
+            .filter(|walker| walker.attribute().is_unique())
             .map(move |walker| UniqueCriteriaWalker {
                 model_id,
                 fields: &walker.attribute().fields,

--- a/libs/datamodel/core/src/transform/ast_to_dml/lift.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/lift.rs
@@ -294,32 +294,34 @@ impl<'a> LiftAstToDml<'a> {
             .map(|idx| {
                 assert!(idx.fields().len() != 0);
 
-                dml::IndexDefinition {
-                    name: idx.attribute().name.map(String::from),
-                    db_name: Some(idx.final_database_name().into_owned()),
-                    fields: idx
-                        .attribute()
-                        .fields
-                        .iter()
-                        .map(|field|
-                        //TODO(extended indexes) here it is ok to pass sort and length with out a preview flag
-                        // check since this is coming from the ast and the parsing would reject the args without
-                        // the flag set.
-                        // When we start using the extra args here could be a place to fill in the defaults. 
-                        IndexField {
+                let fields = idx
+                    .attribute()
+                    .fields
+                    .iter()
+                    .map(|field| IndexField {
                         name: self.db.ast()[model_id][field.field_id].name.name.clone(),
                         sort_order: field.sort_order,
                         length: field.length,
                     })
-                        .collect(),
-                    tpe: match idx.attribute().is_unique {
-                        true => dml::IndexType::Unique,
-                        false => dml::IndexType::Normal,
-                    },
-                    algorithm: idx.attribute().algorithm.map(|using| match using {
-                        IndexAlgorithm::BTree => dml::IndexAlgorithm::BTree,
-                        IndexAlgorithm::Hash => dml::IndexAlgorithm::Hash,
-                    }),
+                    .collect();
+
+                let tpe = match idx.attribute().r#type {
+                    db::IndexType::Unique => dml::IndexType::Unique,
+                    db::IndexType::Normal => dml::IndexType::Normal,
+                    db::IndexType::Fulltext => dml::IndexType::Fulltext,
+                };
+
+                let algorithm = idx.attribute().algorithm.map(|using| match using {
+                    IndexAlgorithm::BTree => dml::IndexAlgorithm::BTree,
+                    IndexAlgorithm::Hash => dml::IndexAlgorithm::Hash,
+                });
+
+                dml::IndexDefinition {
+                    name: idx.attribute().name.map(String::from),
+                    db_name: Some(idx.final_database_name().into_owned()),
+                    fields,
+                    tpe,
+                    algorithm,
                     defined_on_field: idx.attribute().source_field.is_some(),
                 }
             })

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations.rs
@@ -56,6 +56,9 @@ pub(super) fn validate(db: &ParserDatabase<'_>, diagnostics: &mut Diagnostics, r
             indexes::field_length_prefix_supported(db, index, diagnostics);
             indexes::index_algorithm_preview_feature(db, index, diagnostics);
             indexes::index_algorithm_is_supported(db, index, diagnostics);
+            indexes::fulltext_index_preview_feature_enabled(db, index, diagnostics);
+            indexes::fulltext_index_supported(db, index, diagnostics);
+            indexes::fulltext_columns_should_not_use_arguments(db, index, diagnostics);
 
             for field_attribute in index.scalar_field_attributes() {
                 let span = index

--- a/libs/datamodel/core/src/transform/dml_to_ast/lower_model_attributes.rs
+++ b/libs/datamodel/core/src/transform/dml_to_ast/lower_model_attributes.rs
@@ -84,6 +84,18 @@ impl<'a> LowerDmlToAst<'a> {
                 attributes.push(ast::Attribute::new("index", args));
             });
 
+        // @@fulltext
+        model
+            .indices
+            .iter()
+            .filter(|index| index.is_fulltext())
+            .for_each(|index_def| {
+                let mut args = self.fields_argument(&index_def);
+                self.push_index_map_argument(model, index_def, &mut args);
+
+                attributes.push(ast::Attribute::new("fulltext", args));
+            });
+
         // @@map
         <LowerDmlToAst<'a>>::push_model_index_map_arg(model, &mut attributes);
 

--- a/libs/datamodel/core/tests/attributes/index_positive.rs
+++ b/libs/datamodel/core/tests/attributes/index_positive.rs
@@ -415,6 +415,7 @@ fn sqlserver_allows_index_sort_order() {
 }
 
 #[test]
+<<<<<<< HEAD
 fn hash_index_works_on_postgres() {
     let dml = indoc! {r#"
         model A {
@@ -435,5 +436,51 @@ fn hash_index_works_on_postgres() {
         tpe: IndexType::Normal,
         defined_on_field: false,
         algorithm: Some(IndexAlgorithm::Hash),
+    });
+}
+
+#[test]
+fn mysql_fulltext_index() {
+    let dml = indoc! {r#"
+        model A {
+          id Int @id
+          a String
+          b String
+
+          @@fulltext([a, b])
+        }
+    "#};
+
+    let dml = with_header(dml, Provider::Mysql, &["fullTextIndex"]);
+
+    parse(&dml).assert_has_model("A").assert_has_index(IndexDefinition {
+        name: None,
+        db_name: Some("A_a_b_idx".to_string()),
+        fields: vec![IndexField::new("a"), IndexField::new("b")],
+        tpe: IndexType::Fulltext,
+        defined_on_field: false,
+    });
+}
+
+#[test]
+fn mysql_fulltext_index_map() {
+    let dml = indoc! {r#"
+        model A {
+          id Int @id
+          a String
+          b String
+
+          @@fulltext([a, b], map: "my_text_index")
+        }
+    "#};
+
+    let dml = with_header(dml, Provider::Mysql, &["fullTextIndex"]);
+
+    parse(&dml).assert_has_model("A").assert_has_index(IndexDefinition {
+        name: None,
+        db_name: Some("my_text_index".to_string()),
+        fields: vec![IndexField::new("a"), IndexField::new("b")],
+        tpe: IndexType::Fulltext,
+        defined_on_field: false,
     });
 }

--- a/libs/datamodel/core/tests/attributes/index_positive.rs
+++ b/libs/datamodel/core/tests/attributes/index_positive.rs
@@ -415,7 +415,6 @@ fn sqlserver_allows_index_sort_order() {
 }
 
 #[test]
-<<<<<<< HEAD
 fn hash_index_works_on_postgres() {
     let dml = indoc! {r#"
         model A {
@@ -458,6 +457,7 @@ fn mysql_fulltext_index() {
         db_name: Some("A_a_b_idx".to_string()),
         fields: vec![IndexField::new("a"), IndexField::new("b")],
         tpe: IndexType::Fulltext,
+        algorithm: None,
         defined_on_field: false,
     });
 }
@@ -481,6 +481,7 @@ fn mysql_fulltext_index_map() {
         db_name: Some("my_text_index".to_string()),
         fields: vec![IndexField::new("a"), IndexField::new("b")],
         tpe: IndexType::Fulltext,
+        algorithm: None,
         defined_on_field: false,
     });
 }

--- a/libs/datamodel/core/tests/config/generators.rs
+++ b/libs/datamodel/core/tests/config/generators.rs
@@ -257,7 +257,7 @@ fn nice_error_for_unknown_generator_preview_feature() {
         .unwrap_err();
 
     let expectation = expect![[r#"
-        [1;91merror[0m: [1mThe preview feature "foo" is not known. Expected one of: filterJson, referentialIntegrity, mongoDb, interactiveTransactions, fullTextSearch, dataProxy, extendedIndexes[0m
+        [1;91merror[0m: [1mThe preview feature "foo" is not known. Expected one of: filterJson, referentialIntegrity, mongoDb, interactiveTransactions, fullTextSearch, fullTextIndex, dataProxy, extendedIndexes[0m
           [1;94m-->[0m  [4mschema.prisma:3[0m
         [1;94m   | [0m
         [1;94m 2 | [0m  provider = "prisma-client-js"

--- a/libs/datamodel/core/tests/reformat/reformat.rs
+++ b/libs/datamodel/core/tests/reformat/reformat.rs
@@ -134,6 +134,7 @@ fn format_should_enforce_order_of_block_attributes() {
           yearOfBirth Int
           @@map("blog")
           @@index([yearOfBirth])
+          @@fulltext([firstName, lastName, codeName])
           @@unique([codeName, yearOfBirth])
           @@id([firstName, lastName])
         }
@@ -143,6 +144,7 @@ fn format_should_enforce_order_of_block_attributes() {
           name  String
           posts Post[]
           @@id([id])
+          @@fulltext([name])
           @@index([id, name])
           @@unique([name])
           @@map("blog")
@@ -159,6 +161,7 @@ fn format_should_enforce_order_of_block_attributes() {
           @@id([firstName, lastName])
           @@unique([codeName, yearOfBirth])
           @@index([yearOfBirth])
+          @@fulltext([firstName, lastName, codeName])
           @@map("blog")
         }
 
@@ -170,6 +173,7 @@ fn format_should_enforce_order_of_block_attributes() {
           @@id([id])
           @@unique([name])
           @@index([id, name])
+          @@fulltext([name])
           @@map("blog")
         }
     "#]];

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
@@ -87,6 +87,7 @@ fn calculate_model_tables<'a>(
                 let index_type = match index_definition.tpe {
                     IndexType::Unique => sql::IndexType::Unique,
                     IndexType::Normal => sql::IndexType::Normal,
+                    IndexType::Fulltext => todo!("Fulltext migration support"),
                 };
 
                 let algorithm = index_definition.algorithm.map(|algo| match algo {

--- a/query-engine/prisma-models/src/builders/internal_dm_builder.rs
+++ b/query-engine/prisma-models/src/builders/internal_dm_builder.rs
@@ -224,6 +224,8 @@ fn index_builders(model: &dml::Model) -> Vec<IndexBuilder> {
             typ: match i.tpe {
                 dml::IndexType::Unique => IndexType::Unique,
                 dml::IndexType::Normal => IndexType::Normal,
+                // TODO: When introducing the indexes in QE, change this.
+                dml::IndexType::Fulltext => IndexType::Normal,
             },
         })
         .collect()


### PR DESCRIPTION
Introduces a new attribute `@@fulltext` to define fulltext indexes. For now only supported on MySQL, allows `map` argument and not yet `sort` for the fields (should be added with mongo support.

The work includes AST parsing, DML field, AST validations and the reformatter. Will not do anything useful yet.

Part of: https://github.com/prisma/prisma/issues/10080