### PR TITLE
Port the validation about scalar types in relations to ParserDb

### DIFF
--- a/libs/datamodel/connectors/dml/src/field.rs
+++ b/libs/datamodel/connectors/dml/src/field.rs
@@ -62,13 +62,6 @@ impl FieldType {
         }
     }
 
-    pub fn is_compatible_with(&self, other: &FieldType) -> bool {
-        match (self, other) {
-            (Self::Scalar(a, _, nta), Self::Scalar(b, _, ntb)) => a == b && nta == ntb, // the name of the type alias is not important for the comparison
-            (a, b) => a == b,
-        }
-    }
-
     pub fn is_datetime(&self) -> bool {
         self.scalar_type().map(|st| st.is_datetime()).unwrap_or(false)
     }

--- a/libs/datamodel/core/src/transform/ast_to_dml/db/walkers/relation.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/walkers/relation.rs
@@ -84,6 +84,10 @@ impl<'ast, 'db> InlineRelationWalker<'ast, 'db> {
         &self.db.relations.relations_storage[self.relation_id]
     }
 
+    pub(crate) fn db(self) -> &'db ParserDatabase<'ast> {
+        self.db
+    }
+
     /// The relation is 1:1, having at most one record on both sides of the relation.
     pub(crate) fn is_one_to_one(self) -> bool {
         matches!(self.get().attributes, RelationAttributes::OneToOne(_))

--- a/libs/datamodel/core/src/transform/ast_to_dml/db/walkers/scalar_field.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/walkers/scalar_field.rs
@@ -2,13 +2,12 @@ use std::borrow::Cow;
 
 use dml::{default_value::DefaultValue, model::SortOrder};
 
+use super::ModelWalker;
 use crate::{
     ast,
     common::constraint_names::ConstraintNames,
     transform::ast_to_dml::db::{types::FieldWithArgs, ParserDatabase, ScalarField},
 };
-
-use super::ModelWalker;
 
 #[derive(Copy, Clone)]
 pub(crate) struct ScalarFieldWalker<'ast, 'db> {
@@ -52,7 +51,6 @@ impl<'ast, 'db> ScalarFieldWalker<'ast, 'db> {
         self.scalar_field
     }
 
-    #[allow(dead_code)] // we'll need this
     pub(crate) fn model(self) -> ModelWalker<'ast, 'db> {
         ModelWalker {
             model_id: self.model_id,

--- a/libs/datamodel/core/src/transform/ast_to_dml/validate.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validate.rs
@@ -1,9 +1,5 @@
-#![allow(clippy::suspicious_operation_groupings)] // clippy is wrong there
-
 use crate::{
-    ast,
-    common::provider_names::MONGODB_SOURCE_NAME,
-    configuration,
+    ast, configuration,
     diagnostics::{DatamodelError, Diagnostics},
     dml,
 };
@@ -17,7 +13,6 @@ pub struct Validator<'a> {
 
 /// State error message. Seeing this error means something went really wrong internally. It's the datamodel equivalent of a bluescreen.
 const STATE_ERROR: &str = "Failed lookup of model, field or optional property during internal processing. This means that the internal representation was mutated incorrectly.";
-const RELATION_ATTRIBUTE_NAME: &str = "relation";
 
 impl<'a> Validator<'a> {
     /// Creates a new instance, with all builtin attributes registered.
@@ -36,8 +31,6 @@ impl<'a> Validator<'a> {
             if let Err(ref mut the_errors) = self.validate_model_connector_specific(ast_model, model) {
                 diagnostics.append(the_errors)
             }
-
-            self.validate_referenced_fields_for_relation(schema, ast_model, model, diagnostics);
         }
     }
 
@@ -77,82 +70,5 @@ impl<'a> Validator<'a> {
         }
 
         diagnostics.to_result()
-    }
-
-    fn validate_referenced_fields_for_relation(
-        &self,
-        datamodel: &dml::Datamodel,
-        ast_model: &ast::Model,
-        model: &dml::Model,
-        errors: &mut Diagnostics,
-    ) {
-        // see https://github.com/prisma/prisma/issues/10105
-        if self
-            .source
-            .as_ref()
-            .map(|source| source.provider == MONGODB_SOURCE_NAME)
-            .unwrap_or(false)
-        {
-            return;
-        }
-
-        for field in model.relation_fields() {
-            let ast_field = match ast_model.find_field(&field.name) {
-                Some(ast_field) => ast_field,
-                None => continue, // skip relation fields created by reformatting
-            };
-
-            let rel_info = &field.relation_info;
-            let related_model = datamodel.find_model(&rel_info.to).expect(STATE_ERROR);
-
-            let fields_with_wrong_type = rel_info.fields.iter().zip(rel_info.references.iter())
-                    .filter_map(|(base_field, referenced_field)| {
-                        let base_field = model.find_field(base_field)?;
-                        let referenced_field = related_model.find_field(referenced_field)?;
-
-                        if base_field.field_type().is_compatible_with(&referenced_field.field_type()) {
-                            return None
-                        }
-
-                        // Try harder to see if the final type is not the same.
-                        // This check needs the connector, so it can't be in the dml
-                        // crate.
-                        if let Some(connector) = self.source.map(|source| &source.active_connector) {
-                            let base_native_type = base_field.field_type().as_native_type().map(|(scalar, native)| (*scalar, native.serialized_native_type.clone())).or_else(|| -> Option<_> {
-                                let field_type = base_field.field_type();
-                                let scalar_type = field_type.as_scalar()?;
-
-                                Some((*scalar_type, connector.default_native_type_for_scalar_type(scalar_type)))
-                            });
-
-                            let referenced_native_type = referenced_field.field_type().as_native_type().map(|(scalar, native)| (*scalar, native.serialized_native_type.clone())).or_else(|| -> Option<_> {
-                                let field_type = referenced_field.field_type();
-                                let scalar_type = field_type.as_scalar()?;
-
-                                Some((*scalar_type, connector.default_native_type_for_scalar_type(scalar_type)))
-                            });
-
-                            if base_native_type.is_some() && base_native_type == referenced_native_type {
-                                return None
-                            }
-                        }
-
-                        Some(DatamodelError::new_attribute_validation_error(
-                            &format!(
-                                "The type of the field `{}` in the model `{}` is not matching the type of the referenced field `{}` in model `{}`.",
-                                &base_field.name(),
-                                &model.name,
-                                &referenced_field.name(),
-                                &related_model.name
-                            ),
-                            RELATION_ATTRIBUTE_NAME,
-                            ast_field.span,
-                        ))
-                    });
-
-            for err in fields_with_wrong_type {
-                errors.push_error(err);
-            }
-        }
     }
 }

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations.rs
@@ -82,11 +82,11 @@ pub(super) fn validate(db: &ParserDatabase<'_>, diagnostics: &mut Diagnostics, r
                     relations::cycles(relation, db, diagnostics);
                     relations::multiple_cascading_paths(relation, db, diagnostics);
                     relations::has_a_unique_constraint_name(db, relation, diagnostics);
-
-                    // These needs to run last to prevent error spam.
                     relations::references_unique_fields(relation, connector, diagnostics);
                     relations::referencing_fields_in_correct_order(relation, connector, diagnostics);
                 }
+
+                relations::referencing_scalar_field_types(relation, diagnostics);
 
                 // Only run these when you are not formatting the data model. These validations
                 // test against broken relations that we could fix with a code action. The flag is


### PR DESCRIPTION
The native type part of the check is dropped for two reasons:

- It has false positives: see https://github.com/prisma/prisma/issues/5289
- It is underspecified and not tested