### PR TITLE
Port connector-specific field validation to the new system

### DIFF
--- a/libs/datamodel/connectors/datamodel-connector/src/lib.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/lib.rs
@@ -11,8 +11,8 @@ pub use referential_integrity::ReferentialIntegrity;
 
 use crate::connector_error::{ConnectorError, ConnectorErrorFactory, ErrorKind};
 use dml::{
-    field::Field, model::Model, native_type_constructor::NativeTypeConstructor,
-    native_type_instance::NativeTypeInstance, relation_info::ReferentialAction, scalars::ScalarType,
+    model::Model, native_type_constructor::NativeTypeConstructor, native_type_instance::NativeTypeInstance,
+    relation_info::ReferentialAction, scalars::ScalarType,
 };
 use enumflags2::BitFlags;
 use std::{borrow::Cow, collections::BTreeMap, str::FromStr};
@@ -67,7 +67,13 @@ pub trait Connector: Send + Sync {
         self.referential_actions(integrity).contains(action)
     }
 
-    fn validate_field(&self, _: &Field, _: &mut Vec<ConnectorError>) {}
+    fn validate_native_type_arguments(
+        &self,
+        _native_type: &NativeTypeInstance,
+        _scalar_type: &ScalarType,
+        _: &mut Vec<ConnectorError>,
+    ) {
+    }
 
     fn validate_model(&self, _: &Model, _: &mut Vec<ConnectorError>) {}
 
@@ -185,7 +191,7 @@ pub trait Connector: Send + Sync {
         self.has_capability(ConnectorCapability::RelationFieldsInArbitraryOrder)
     }
 
-    fn native_instance_error(&self, instance: NativeTypeInstance) -> ConnectorErrorFactory {
+    fn native_instance_error(&self, instance: &NativeTypeInstance) -> ConnectorErrorFactory {
         ConnectorErrorFactory {
             connector: self.name().to_owned(),
             native_type: instance.render(),

--- a/libs/datamodel/connectors/datamodel-connector/src/lib.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/lib.rs
@@ -67,6 +67,17 @@ pub trait Connector: Send + Sync {
         self.referential_actions(integrity).contains(action)
     }
 
+    fn validate_field_default(
+        &self,
+        _field_name: &str,
+        _scalar_type: &ScalarType,
+        _native_type: Option<&NativeTypeInstance>,
+        _default: Option<&dml::default_value::DefaultValue>,
+        _errors: &mut Vec<ConnectorError>,
+    ) {
+    }
+
+    /// Validate that the arguments passed to a native type attribute are valid.
     fn validate_native_type_arguments(
         &self,
         _native_type: &NativeTypeInstance,

--- a/libs/datamodel/connectors/mongodb-datamodel-connector/src/lib.rs
+++ b/libs/datamodel/connectors/mongodb-datamodel-connector/src/lib.rs
@@ -45,18 +45,6 @@ impl Connector for MongoDbDatamodelConnector {
         referential_integrity.allowed_referential_actions(BitFlags::empty())
     }
 
-    fn validate_field(&self, field: &dml::field::Field, errors: &mut Vec<ConnectorError>) {
-        // If the field is _not_ a native-type-annotated field and it has a `dbgenerated` default, we error.
-        if !matches!(field.field_type(), FieldType::Scalar(_, _, Some(_)))
-            && matches!(field.default_value().as_ref().map(|v| v.kind()), Some(DefaultKind::Expression(expr)) if expr.is_dbgenerated())
-        {
-            errors.push(ConnectorError::from_kind(ErrorKind::FieldValidationError {
-                field: field.name().to_owned(),
-                message: "MongoDB `@default(dbgenerated())` fields must have a native type annotation.".to_owned(),
-            }));
-        }
-    }
-
     fn validate_model(&self, model: &dml::model::Model, errors: &mut Vec<ConnectorError>) {
         if let Some(pk) = &model.primary_key {
             // no compound ids

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/mssql_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/mssql_datamodel_connector.rs
@@ -4,12 +4,8 @@ use datamodel_connector::{
     Connector, ConnectorCapability, ConstraintScope, ReferentialIntegrity,
 };
 use dml::{
-    field::{Field, FieldType},
-    model::Model,
-    native_type_constructor::NativeTypeConstructor,
-    native_type_instance::NativeTypeInstance,
-    relation_info::ReferentialAction,
-    scalars::ScalarType,
+    field::FieldType, model::Model, native_type_constructor::NativeTypeConstructor,
+    native_type_instance::NativeTypeInstance, relation_info::ReferentialAction, scalars::ScalarType,
 };
 use enumflags2::BitFlags;
 use native_types::{MsSqlType, MsSqlTypeParameter};
@@ -227,40 +223,43 @@ impl Connector for MsSqlDatamodelConnector {
         Cow::Borrowed(url)
     }
 
-    fn validate_field(&self, field: &Field, errors: &mut Vec<ConnectorError>) {
-        if let FieldType::Scalar(_, _, Some(native_type)) = field.field_type() {
-            let r#type: MsSqlType = native_type.deserialize_native_type();
-            let error = self.native_instance_error(native_type);
+    fn validate_native_type_arguments(
+        &self,
+        native_type: &NativeTypeInstance,
+        _scalar_type: &ScalarType,
+        errors: &mut Vec<ConnectorError>,
+    ) {
+        let r#type: MsSqlType = native_type.deserialize_native_type();
+        let error = self.native_instance_error(native_type);
 
-            match r#type {
-                Decimal(Some((precision, scale))) if scale > precision => {
-                    errors.push(error.new_scale_larger_than_precision_error());
-                }
-                Decimal(Some((prec, _))) if prec == 0 || prec > 38 => {
-                    errors.push(error.new_argument_m_out_of_range_error("Precision can range from 1 to 38."));
-                }
-                Decimal(Some((_, scale))) if scale > 38 => {
-                    errors.push(error.new_argument_m_out_of_range_error("Scale can range from 0 to 38."))
-                }
-                Float(Some(bits)) if bits == 0 || bits > 53 => {
-                    errors.push(error.new_argument_m_out_of_range_error("Bits can range from 1 to 53."))
-                }
-                NVarChar(Some(Number(p))) if p > 4000 => errors.push(error.new_argument_m_out_of_range_error(
-                    "Length can range from 1 to 4000. For larger sizes, use the `Max` variant.",
-                )),
-                VarChar(Some(Number(p))) | VarBinary(Some(Number(p))) if p > 8000 => {
-                    errors.push(error.new_argument_m_out_of_range_error(
-                        r#"Length can range from 1 to 8000. For larger sizes, use the `Max` variant."#,
-                    ))
-                }
-                NChar(Some(p)) if p > 4000 => {
-                    errors.push(error.new_argument_m_out_of_range_error("Length can range from 1 to 4000."))
-                }
-                Char(Some(p)) | Binary(Some(p)) if p > 8000 => {
-                    errors.push(error.new_argument_m_out_of_range_error("Length can range from 1 to 8000."))
-                }
-                _ => (),
+        match r#type {
+            Decimal(Some((precision, scale))) if scale > precision => {
+                errors.push(error.new_scale_larger_than_precision_error());
             }
+            Decimal(Some((prec, _))) if prec == 0 || prec > 38 => {
+                errors.push(error.new_argument_m_out_of_range_error("Precision can range from 1 to 38."));
+            }
+            Decimal(Some((_, scale))) if scale > 38 => {
+                errors.push(error.new_argument_m_out_of_range_error("Scale can range from 0 to 38."))
+            }
+            Float(Some(bits)) if bits == 0 || bits > 53 => {
+                errors.push(error.new_argument_m_out_of_range_error("Bits can range from 1 to 53."))
+            }
+            NVarChar(Some(Number(p))) if p > 4000 => errors.push(error.new_argument_m_out_of_range_error(
+                "Length can range from 1 to 4000. For larger sizes, use the `Max` variant.",
+            )),
+            VarChar(Some(Number(p))) | VarBinary(Some(Number(p))) if p > 8000 => {
+                errors.push(error.new_argument_m_out_of_range_error(
+                    r#"Length can range from 1 to 8000. For larger sizes, use the `Max` variant."#,
+                ))
+            }
+            NChar(Some(p)) if p > 4000 => {
+                errors.push(error.new_argument_m_out_of_range_error("Length can range from 1 to 4000."))
+            }
+            Char(Some(p)) | Binary(Some(p)) if p > 8000 => {
+                errors.push(error.new_argument_m_out_of_range_error("Length can range from 1 to 8000."))
+            }
+            _ => (),
         }
     }
 
@@ -274,7 +273,7 @@ impl Connector for MsSqlDatamodelConnector {
             for field in fields {
                 if let FieldType::Scalar(_, _, Some(native_type)) = field.field_type() {
                     let r#type: MsSqlType = native_type.deserialize_native_type();
-                    let error = self.native_instance_error(native_type);
+                    let error = self.native_instance_error(&native_type);
 
                     if heap_allocated_types().contains(&r#type) {
                         if index_definition.is_unique() {
@@ -298,7 +297,7 @@ impl Connector for MsSqlDatamodelConnector {
 
                         if heap_allocated_types().contains(&r#type) {
                             errors.push(
-                                self.native_instance_error(native_type)
+                                self.native_instance_error(&native_type)
                                     .new_incompatible_native_type_with_id(),
                             );
                             break;

--- a/libs/datamodel/core/src/transform/ast_to_dml/db/walkers/scalar_field.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/walkers/scalar_field.rs
@@ -115,6 +115,10 @@ impl<'ast, 'db> DefaultValueWalker<'ast, 'db> {
         })
     }
 
+    pub(crate) fn default(self) -> &'db DefaultValue {
+        self.default
+    }
+
     fn field(self) -> ScalarFieldWalker<'ast, 'db> {
         ScalarFieldWalker {
             model_id: self.model_id,

--- a/libs/datamodel/core/src/transform/ast_to_dml/db/walkers/scalar_field.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/walkers/scalar_field.rs
@@ -1,12 +1,12 @@
 use std::borrow::Cow;
 
-use dml::{default_value::DefaultValue, model::SortOrder};
+use dml::{default_value::DefaultValue, model::SortOrder, native_type_instance::NativeTypeInstance};
 
 use super::ModelWalker;
 use crate::{
     ast,
     common::constraint_names::ConstraintNames,
-    transform::ast_to_dml::db::{types::FieldWithArgs, ParserDatabase, ScalarField},
+    transform::ast_to_dml::db::{types::FieldWithArgs, ParserDatabase, ScalarField, ScalarFieldType},
 };
 
 #[derive(Copy, Clone)]
@@ -59,6 +59,15 @@ impl<'ast, 'db> ScalarFieldWalker<'ast, 'db> {
         }
     }
 
+    pub(crate) fn native_type_instance(self) -> Option<NativeTypeInstance> {
+        self.scalar_field.native_type.as_ref().map(|(name, args)| {
+            self.db
+                .active_connector()
+                .parse_native_type(name, args.clone())
+                .unwrap()
+        })
+    }
+
     pub(crate) fn is_unsupported(self) -> bool {
         matches!(self.ast_field().field_type, ast::FieldType::Unsupported(_, _))
     }
@@ -70,6 +79,18 @@ impl<'ast, 'db> ScalarFieldWalker<'ast, 'db> {
             db: self.db,
             default: d,
         })
+    }
+
+    pub(crate) fn scalar_type(self) -> Option<dml::scalars::ScalarType> {
+        let mut tpe = &self.scalar_field.r#type;
+
+        loop {
+            match tpe {
+                ScalarFieldType::BuiltInScalar(scalar) => return Some(*scalar),
+                ScalarFieldType::Alias(alias_id) => tpe = &self.db.types.type_aliases[alias_id],
+                _ => return None,
+            }
+        }
     }
 }
 

--- a/libs/datamodel/core/src/transform/ast_to_dml/validate.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validate.rs
@@ -24,35 +24,10 @@ impl<'a> Validator<'a> {
         for model in schema.models() {
             let ast_model = ast.find_model(&model.name).expect(STATE_ERROR);
 
-            if let Err(ref mut the_errors) = self.validate_field_connector_specific(ast_model, model) {
-                diagnostics.append(the_errors)
-            }
-
             if let Err(ref mut the_errors) = self.validate_model_connector_specific(ast_model, model) {
                 diagnostics.append(the_errors)
             }
         }
-    }
-
-    fn validate_field_connector_specific(&self, ast_model: &ast::Model, model: &dml::Model) -> Result<(), Diagnostics> {
-        let mut diagnostics = Diagnostics::new();
-
-        if let Some(source) = self.source {
-            let connector = &source.active_connector;
-            for field in model.fields.iter() {
-                let mut errors = Vec::new();
-                connector.validate_field(field, &mut errors);
-
-                for error in errors {
-                    diagnostics.push_error(DatamodelError::ConnectorError {
-                        message: error.to_string(),
-                        span: ast_model.find_field_bang(field.name()).span,
-                    });
-                }
-            }
-        }
-
-        diagnostics.to_result()
     }
 
     fn validate_model_connector_specific(&self, ast_model: &ast::Model, model: &dml::Model) -> Result<(), Diagnostics> {

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations.rs
@@ -35,6 +35,7 @@ pub(super) fn validate(db: &ParserDatabase<'_>, diagnostics: &mut Diagnostics, r
             fields::validate_client_name(field.into(), &names, diagnostics);
             fields::has_a_unique_default_constraint_name(db, field, diagnostics);
             fields::validate_native_type_arguments(field, diagnostics);
+            fields::validate_default(field, diagnostics);
         }
 
         for field in model.relation_fields() {

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations.rs
@@ -34,6 +34,7 @@ pub(super) fn validate(db: &ParserDatabase<'_>, diagnostics: &mut Diagnostics, r
         for field in model.scalar_fields() {
             fields::validate_client_name(field.into(), &names, diagnostics);
             fields::has_a_unique_default_constraint_name(db, field, diagnostics);
+            fields::validate_native_type_arguments(field, diagnostics);
         }
 
         for field in model.relation_fields() {

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/fields.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/fields.rs
@@ -127,3 +127,22 @@ pub(super) fn validate_native_type_arguments(field: ScalarFieldWalker<'_, '_>, d
         });
     }
 }
+
+pub(super) fn validate_default(field: ScalarFieldWalker<'_, '_>, diagnostics: &mut Diagnostics) {
+    let connector = field.db.active_connector();
+    let (scalar_type, native_type) = match (field.scalar_type(), field.native_type_instance()) {
+        (Some(scalar_type), native_type) => (scalar_type, native_type),
+        _ => return,
+    };
+    let default = field.default_value().map(|d| d.default());
+
+    let mut errors = Vec::new();
+    connector.validate_field_default(field.name(), &scalar_type, native_type.as_ref(), default, &mut errors);
+
+    for error in errors {
+        diagnostics.push_error(DatamodelError::ConnectorError {
+            message: error.to_string(),
+            span: field.ast_field().span,
+        });
+    }
+}


### PR DESCRIPTION
This is one of the two validations still holding the validation pipeline
simplification back.