### PR TITLE
experiment: Use mold by default in shell.nix

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -22,7 +22,13 @@ export LOG_LEVEL=trace
 # export TEST_CONNECTOR="postgres"
 # export TEST_CONNECTOR_VERSION="10"
 
+# Set up env vars and build inputs from shell.nix / flake.nix automatically for
+# nix users. If you don't use nix, you can safely ignore this.
 if command -v nix-shell &> /dev/null
 then
-    use nix
+    if nix flake metadata > /dev/null; then
+        use flake
+    else
+        use nix
+    fi
 fi

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1634851050,
-        "narHash": "sha256-N83GlSGPJJdcqhUxSCS/WwW5pksYf3VP1M13cDRTSVA=",
+        "lastModified": 1637014545,
+        "narHash": "sha256-26IZAc5yzlD9FlDT54io1oqG/bBoyka+FJk5guaX4x4=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c91f3de5adaf1de973b797ef7485e441a65b8935",
+        "rev": "bba5dcc8e0b20ab664967ad83d24d64cb64ec4f4",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1636443933,
-        "narHash": "sha256-ABJmNQdzFWWxaqkb0C0kd9f/MmUtmnQrxm9sZPhgm/s=",
+        "lastModified": 1637827954,
+        "narHash": "sha256-XyhUKkgU+aENGkVF4do2Sz42VOTiouiiUCRwxc66t2s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9e70e9f732fbb15872cb4ea11bd43c14328a0b69",
+        "rev": "7c4bbc7cd008fb3802e3b5ea44118ebfc013578d",
         "type": "github"
       },
       "original": {

--- a/shell.nix
+++ b/shell.nix
@@ -6,9 +6,6 @@ mkShell {
   LIBCLANG_PATH="${pkgs.llvmPackages.libclang}/lib";
   PROTOC="${pkgs.protobuf}/bin/protoc";
   PROTOC_INCLUDE="${pkgs.protobuf}/include";
-  shellHook = ''
-    cargo='mold -run cargo'
-  '';
   buildInputs = with pkgs; [
     mold # much faster linker
 

--- a/shell.nix
+++ b/shell.nix
@@ -6,8 +6,12 @@ mkShell {
   LIBCLANG_PATH="${pkgs.llvmPackages.libclang}/lib";
   PROTOC="${pkgs.protobuf}/bin/protoc";
   PROTOC_INCLUDE="${pkgs.protobuf}/include";
-  shellHook = '' '';
+  shellHook = ''
+    cargo='mold -run cargo'
+  '';
   buildInputs = with pkgs; [
+    mold # much faster linker
+
     gcc
     openssl
     pkg-config


### PR DESCRIPTION
[rui314/mold](https://github.com/rui314/mold)

The outcome is much shorter build times. The risk is bugs, since mold is
still rather young.

You can safely ignore this if you don't use nix.