### PR TITLE
Validate we don't use `sort` in a hash index

### DIFF
--- a/libs/datamodel/core/src/transform/ast_to_dml/db/types.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/db/types.rs
@@ -189,6 +189,12 @@ pub enum IndexAlgorithm {
     Hash,
 }
 
+impl IndexAlgorithm {
+    pub fn is_hash(self) -> bool {
+        matches!(self, Self::Hash)
+    }
+}
+
 impl Default for IndexAlgorithm {
     fn default() -> Self {
         Self::BTree

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations.rs
@@ -59,6 +59,7 @@ pub(super) fn validate(db: &ParserDatabase<'_>, diagnostics: &mut Diagnostics, r
             indexes::field_length_prefix_supported(db, index, diagnostics);
             indexes::index_algorithm_preview_feature(db, index, diagnostics);
             indexes::index_algorithm_is_supported(db, index, diagnostics);
+            indexes::hash_index_must_not_use_sort_param(db, index, diagnostics);
             indexes::fulltext_index_preview_feature_enabled(db, index, diagnostics);
             indexes::fulltext_index_supported(db, index, diagnostics);
             indexes::fulltext_columns_should_not_define_length(db, index, diagnostics);

--- a/libs/datamodel/core/tests/attributes/index_negative.rs
+++ b/libs/datamodel/core/tests/attributes/index_negative.rs
@@ -620,6 +620,32 @@ fn length_argument_does_not_work_with_int() {
 }
 
 #[test]
+fn hash_index_doesnt_allow_sorting() {
+    let dml = indoc! {r#"
+        model A {
+          id Int @id
+          a  Int
+
+          @@index([a(sort: Desc)], type: Hash)
+        }
+    "#};
+
+    let schema = with_header(dml, Provider::Postgres, &["extendedIndexes"]);
+    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@index": Hash type does not support sort option.[0m
+          [1;94m-->[0m  [4mschema.prisma:15[0m
+        [1;94m   | [0m
+        [1;94m14 | [0m
+        [1;94m15 | [0m  @@[1;91mindex([a(sort: Desc)], type: Hash)[0m
+        [1;94m   | [0m
+    "#]];
+
+    expectation.assert_eq(&error)
+}
+
+#[test]
 fn hash_index_doesnt_work_on_sqlserver() {
     let dml = indoc! {r#"
         model A {


### PR DESCRIPTION
We missed this in the original issue.