### PR TITLE
Allow empty previewFeatures arrays in datamodel

### DIFF
--- a/libs/datamodel/core/tests/config/generators.rs
+++ b/libs/datamodel/core/tests/config/generators.rs
@@ -382,3 +382,41 @@ fn env_in_preview_features_must_be_rejected() {
     expect_1.assert_eq(&datamodel::parse_schema(schema_1).map(drop).unwrap_err());
     expect_2.assert_eq(&datamodel::parse_schema(schema_2).map(drop).unwrap_err());
 }
+
+#[test]
+fn empty_preview_features_array_should_work() {
+    let schema = r#"
+        datasource db {
+            provider = "postgresql"
+            url = env("DBURL")
+        }
+
+        generator js {
+            provider = "prisma-client-js"
+            previewFeatures = []
+        }
+    "#;
+
+    let (config, _) = datamodel::parse_schema(schema).unwrap();
+
+    assert!(config.preview_features().is_empty());
+}
+
+#[test]
+fn empty_preview_features_array_with_empty_space_should_work() {
+    let schema = r#"
+        datasource db {
+            provider = "postgresql"
+            url = env("DBURL")
+        }
+
+        generator js {
+            provider = "prisma-client-js"
+            previewFeatures = [ ]
+        }
+    "#;
+
+    let (config, _) = datamodel::parse_schema(schema).unwrap();
+
+    assert!(config.preview_features().is_empty());
+}

--- a/libs/datamodel/core/tests/config/sources.rs
+++ b/libs/datamodel/core/tests/config/sources.rs
@@ -135,12 +135,11 @@ fn must_error_for_empty_provider_arrays() {
     let error = super::parse_config(dml).map(drop).unwrap_err();
 
     let expectation = expect![[r#"
-        [1;91merror[0m: [1mError validating: This line is not a valid definition within a datasource.[0m
+        [1;91merror[0m: [1mError validating datasource `myds`: The provider argument in a datasource must be a string literal[0m
           [1;94m-->[0m  [4mschema.prisma:2[0m
         [1;94m   | [0m
         [1;94m 1 | [0mdatasource myds {
-        [1;94m 2 | [0m  [1;91mprovider = [][0m
-        [1;94m 3 | [0m  url = "postgres://"
+        [1;94m 2 | [0m  provider = [1;91m[][0m
         [1;94m   | [0m
     "#]];
 

--- a/libs/datamodel/schema-ast/src/parser/datamodel.pest
+++ b/libs/datamodel/schema-ast/src/parser/datamodel.pest
@@ -121,7 +121,7 @@ BLOCK_LEVEL_CATCH_ALL = { !BLOCK_CLOSE ~ CATCH_ALL }
 // ######################################
 function = { non_empty_identifier ~ "(" ~ (expression ~ ("," ~ expression)*)? ~ ")" }
 field_with_args = {  non_empty_identifier ~ "(" ~ argument ~ ("," ~ argument)*  ~")"}
-array_expression = { "[" ~ expression ~ ( "," ~ expression )* ~ "]" }
+array_expression = { "[" ~ (expression ~ ( "," ~ expression )*)? ~ "]" }
 expression = { field_with_args | array_expression | function | numeric_literal | string_literal | boolean_literal | constant_literal }
 
 // ######################################


### PR DESCRIPTION
This schema:

```
generator js {
        provider = "prisma-client-js"
        previewFeatures = []
}
```

did not work before this commit, because the way our pest grammar deals
with comma separators in array expressions required at least one
expression in the array. Now the whole contents of the array are
optional in the grammar.