### PR TITLE
Query engine M1 local dev adjustments

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -17,6 +17,13 @@ export CLOSED_TX_CLEANUP=2 # Time in seconds when a closed interactive transacti
 ### QE test setup vars ###
 export LOG_LEVEL=trace
 
+# Mongo image requires additional wait time on arm arch for some reason.
+if uname -a | grep -q 'arm64'; then
+    export INIT_WAIT_SEC="10"
+else
+    export INIT_WAIT_SEC="2"
+fi
+
 # (Example env vars if you're not using the make commands, i.e. the config files, to set up tests)
 # export TEST_RUNNER="direct"
 # export TEST_CONNECTOR="postgres"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -244,6 +244,7 @@ services:
       MONGO_INITDB_ROOT_USERNAME: "prisma"
       MONGO_INITDB_ROOT_PASSWORD: "prisma"
       MONGO_PORT: 27016
+      INIT_WAIT_SEC: $INIT_WAIT_SEC
     networks:
       - databases
     ports:
@@ -267,6 +268,7 @@ services:
     environment:
       MONGO_INITDB_ROOT_USERNAME: "prisma"
       MONGO_INITDB_ROOT_PASSWORD: "prisma"
+      INIT_WAIT_SEC: $INIT_WAIT_SEC
     ports:
       - "27017:27017"
     networks:
@@ -279,6 +281,7 @@ services:
       MONGO_INITDB_ROOT_USERNAME: "prisma"
       MONGO_INITDB_ROOT_PASSWORD: "prisma"
       MONGO_PORT: 27018
+      INIT_WAIT_SEC: $INIT_WAIT_SEC
     ports:
       - "27018:27018"
     networks:
@@ -290,6 +293,7 @@ services:
     environment:
       MONGO_INITDB_ROOT_USERNAME: "prisma"
       MONGO_INITDB_ROOT_PASSWORD: "prisma"
+      INIT_WAIT_SEC: $INIT_WAIT_SEC
     ports:
       - "27018:27017"
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -255,6 +255,7 @@ services:
     environment:
       MONGO_INITDB_ROOT_USERNAME: "prisma"
       MONGO_INITDB_ROOT_PASSWORD: "prisma"
+      INIT_WAIT_SEC: $INIT_WAIT_SEC
     ports:
       - "27017:27017"
     networks:
@@ -306,9 +307,20 @@ services:
     networks:
       - databases
 
-  otel:
-    # Jaeger supports OTEL out of the box
-    image: jaegertracing/opentelemetry-all-in-one:latest
+  jaeger:
+    image: jaegertracing/all-in-one:latest
+    restart: always
+    ports:
+      - "16686:16686" # the trace viewer (http)
+    networks:
+      - telemetry
+
+  otel-agent:
+    image: otel/opentelemetry-collector-dev:latest
+    command: [ "--config=/etc/otel-agent-config.yaml" ]
+    restart: always
+    volumes:
+      - ./otel-agent-config.yaml:/etc/otel-agent-config.yaml
     ports:
       - 13133:13133 # health check port
       - 16686:16686 # UI viewer
@@ -316,3 +328,4 @@ services:
 
 networks:
   databases: null
+  telemetry: null


### PR DESCRIPTION
Mongo doesn't work out of the box on M1, this changes the init wait time so other platforms are unaffected and M1 waits a little more when booting the mongo images.