### PR TITLE
Extra error details for query engine errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5146,6 +5146,16 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
+ "serde_json",
+ "syn",
+ "user-facing-error-parsing",
+]
+
+[[package]]
+name = "user-facing-error-parsing"
+version = "0.1.0"
+dependencies = [
+ "quote",
  "syn",
 ]
 
@@ -5160,6 +5170,7 @@ dependencies = [
  "serde_json",
  "tracing",
  "user-facing-error-macros",
+ "user-facing-error-parsing",
 ]
 
 [[package]]

--- a/introspection-engine/connectors/mongodb-introspection-connector/tests/errors/mod.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/tests/errors/mod.rs
@@ -22,7 +22,14 @@ fn connection_string_problems_give_a_nice_error() {
           "meta": {
             "details": "invalid port number in database URL. Please refer to the documentation in https://www.prisma.io/docs/reference/database-reference/connection-urls for constructing a correct connection string. In some cases, certain characters must be escaped. Please check the string for any illegal characters."
           },
-          "error_code": "P1013"
+          "error_code": "P1013",
+          "error_details": {
+            "name": "InvalidConnectionString",
+            "code": "P1013",
+            "fields": {
+              "details": "invalid port number in database URL. Please refer to the documentation in https://www.prisma.io/docs/reference/database-reference/connection-urls for constructing a correct connection string. In some cases, certain characters must be escaped. Please check the string for any illegal characters."
+            }
+          }
         }"#]];
 
     expected.assert_eq(&json_error);
@@ -66,7 +73,14 @@ fn using_without_preview_feature_enabled() {
           "meta": {
             "message": "Preview feature not enabled: MongoDB introspection connector (experimental feature, needs to be enabled)"
           },
-          "error_code": "P1019"
+          "error_code": "P1019",
+          "error_details": {
+            "name": "UnsupportedFeatureError",
+            "code": "P1019",
+            "fields": {
+              "message": "Preview feature not enabled: MongoDB introspection connector (experimental feature, needs to be enabled)"
+            }
+          }
         }"#]];
 
     expected.assert_eq(&json_error);

--- a/introspection-engine/introspection-engine-tests/tests/errors/mod.rs
+++ b/introspection-engine/introspection-engine-tests/tests/errors/mod.rs
@@ -50,7 +50,14 @@ async fn connection_string_problems_give_a_nice_error() {
             "meta": {
                 "details": &details,
             },
-            "error_code": "P1013"
+            "error_code": "P1013",
+            "error_details": {
+                "name": "InvalidConnectionString",
+                "code": "P1013",
+                "fields": {
+                    "details": &details,
+                },
+            },
         });
 
         assert_eq!(expected, json_error);
@@ -86,6 +93,14 @@ async fn bad_connection_string_in_datamodel_returns_nice_error() {
                 "full_error": "\u{1b}[1;91merror\u{1b}[0m: \u{1b}[1mError validating datasource `db`: the URL must start with the protocol `postgresql://` or `postgres://`.\u{1b}[0m\n  \u{1b}[1;94m-->\u{1b}[0m  \u{1b}[4mschema.prisma:4\u{1b}[0m\n\u{1b}[1;94m   | \u{1b}[0m\n\u{1b}[1;94m 3 | \u{1b}[0m        provider = \"postgresql\"\n\u{1b}[1;94m 4 | \u{1b}[0m        url      = \u{1b}[1;91m\"sqlserver:/localhost:1433;database=prisma-demo;user=SA;password=Pr1sm4_Pr1sm4;trustServerCertificate=true;encrypt=true\"\u{1b}[0m\n\u{1b}[1;94m   | \u{1b}[0m\n",
             },
             "error_code": SchemaParserError::ERROR_CODE,
+            "error_details": {
+                "name": "SchemaParserError",
+                "code":
+                    "P1012",
+                "fields": {
+                    "full_error": "\u{1b}[1;91merror\u{1b}[0m: \u{1b}[1mError validating datasource `db`: the URL must start with the protocol `postgresql://` or `postgres://`.\u{1b}[0m\n  \u{1b}[1;94m-->\u{1b}[0m  \u{1b}[4mschema.prisma:4\u{1b}[0m\n\u{1b}[1;94m   | \u{1b}[0m\n\u{1b}[1;94m 3 | \u{1b}[0m        provider = \"postgresql\"\n\u{1b}[1;94m 4 | \u{1b}[0m        url      = \u{1b}[1;91m\"sqlserver:/localhost:1433;database=prisma-demo;user=SA;password=Pr1sm4_Pr1sm4;trustServerCertificate=true;encrypt=true\"\u{1b}[0m\n\u{1b}[1;94m   | \u{1b}[0m\n",
+                },
+            },
         }
     });
 

--- a/libs/user-facing-error-macros/Cargo.toml
+++ b/libs/user-facing-error-macros/Cargo.toml
@@ -13,3 +13,6 @@ proc-macro = true
 syn = "1.0.5"
 quote = "1.0.2"
 proc-macro2 = "1.0.6"
+serde_json = { version = "1.0", features = ["float_roundtrip"] }
+user-facing-error-parsing = { path = "../user-facing-error-parsing" }
+

--- a/libs/user-facing-error-macros/src/lib.rs
+++ b/libs/user-facing-error-macros/src/lib.rs
@@ -30,7 +30,7 @@ pub fn derive_user_facing_error(input: proc_macro::TokenStream) -> proc_macro::T
     };
 
     let fields = field_idents.iter().map(|field| {
-        let key = format!("{}", field);
+        let key = field.to_string();
         quote::quote! {
            error_fields.insert(#key.to_string(), serde_json::to_value(&self.#field).unwrap());
         }

--- a/libs/user-facing-error-macros/src/lib.rs
+++ b/libs/user-facing-error-macros/src/lib.rs
@@ -54,11 +54,11 @@ pub fn derive_user_facing_error(input: proc_macro::TokenStream) -> proc_macro::T
                     #fields
                 )*
 
-                return ErrorDetails {
+                ErrorDetails {
                     name: #error_name,
                     code: Self::ERROR_CODE,
                     fields: json!(error_fields)
-                };
+                }
             }
 
             fn message(&self) -> String {

--- a/libs/user-facing-error-parsing/Cargo.toml
+++ b/libs/user-facing-error-parsing/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "user-facing-error-parsing"
+version = "0.1.0"
+authors = ["Garren Smith <garren.smith@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+syn = "1.0.5"
+quote = "1.0.2"
+
+

--- a/libs/user-facing-error-parsing/src/lib.rs
+++ b/libs/user-facing-error-parsing/src/lib.rs
@@ -1,20 +1,20 @@
 extern crate proc_macro;
 use syn::{Attribute, ItemStruct};
 
-/* This parses the list of files, looks for all structs and generates a vector of error types:
-   pub fn error_list() -> Vec<UserErrorType> {
-        Vec::from([
-            UserErrorType {
-                name: "InputValueTooLong",
-                code: "P2000"
-            },
-            UserErrorType {
-                name: "RecordNotFound",
-                code: "P2001"
-            },
-        ])
-    }
-*/
+/// This parses the list of files, looks for all structs and generates a vector of error types:
+///   pub fn error_list() -> Vec<UserErrorType> {
+///        Vec::from([
+///             UserErrorType {
+///                 name: "InputValueTooLong",
+///                 code: "P2000"
+///             },
+///             UserErrorType {
+///                 name: "RecordNotFound",
+///                 code: "P2001"
+///             },
+///         ])
+///     }
+///
 pub fn parse_files(srcs: Vec<String>) -> String {
     let errors: Vec<_> = vec![];
 

--- a/libs/user-facing-error-parsing/src/lib.rs
+++ b/libs/user-facing-error-parsing/src/lib.rs
@@ -1,0 +1,133 @@
+extern crate proc_macro;
+use syn::{Attribute, ItemStruct};
+
+/* This parses the list of files, looks for all structs and generates a vector of error types:
+   pub fn error_list() -> Vec<UserErrorType> {
+        Vec::from([
+            UserErrorType {
+                name: "InputValueTooLong",
+                code: "P2000"
+            },
+            UserErrorType {
+                name: "RecordNotFound",
+                code: "P2001"
+            },
+        ])
+    }
+*/
+pub fn parse_files(srcs: Vec<String>) -> String {
+    let errors: Vec<_> = vec![];
+
+    let error_infos = srcs.iter().fold(errors, |mut errors, src| {
+        let file = syn::parse_file(src).expect("Unable to parse file");
+
+        file.items.iter().for_each(|i| {
+            if let syn::Item::Struct(struct_item) = i {
+                let (name, code) = create_name_and_code(struct_item.clone()).unwrap();
+                errors.push(quote::quote! {
+                    UserErrorType {
+                        name: #name,
+                        code: #code
+                    }
+                });
+            }
+        });
+
+        errors
+    });
+
+    let output_file = quote::quote! {
+
+        pub fn error_list() -> Vec<UserErrorType> {
+            Vec::from([
+                #(
+                    #error_infos
+                ),*
+            ])
+
+        }
+    };
+
+    output_file.to_string()
+}
+
+fn create_name_and_code(item_struct: ItemStruct) -> Result<(String, String), syn::Error> {
+    match UserErrorDeriveInput::parse_input_attr(&item_struct.attrs).unwrap() {
+        (Some(_message), Some(code)) => Ok((format!("{}", item_struct.ident), code.value())),
+        _ => Err(syn::Error::new_spanned(
+            item_struct,
+            "Expected attribute of the form `#[user_facing(code = \"...\", message = \"...\")]`",
+        )),
+    }
+}
+
+pub struct UserErrorDeriveInput<'a> {
+    /// The name of the struct.
+    pub ident: &'a syn::Ident,
+    /// The error code.
+    pub code: syn::LitStr,
+    /// The error message format string.
+    pub message: syn::LitStr,
+}
+
+impl<'a> UserErrorDeriveInput<'a> {
+    pub fn new(input: &'a syn::DeriveInput) -> Result<Self, syn::Error> {
+        match Self::parse_input_attr(&input.attrs)? {
+            (Some(message), Some(code)) => Ok(UserErrorDeriveInput {
+                ident: &input.ident,
+                message,
+                code,
+            }),
+            _ => Err(syn::Error::new_spanned(
+                input,
+                "Expected attribute of the form `#[user_facing(code = \"...\", message = \"...\")]`",
+            )),
+        }
+    }
+
+    fn parse_input_attr(attrs: &[Attribute]) -> Result<(Option<syn::LitStr>, Option<syn::LitStr>), syn::Error> {
+        let mut code = None;
+        let mut message = None;
+        for attr in attrs {
+            if !attr
+                .path
+                .get_ident()
+                .map(|ident| ident == "user_facing")
+                .unwrap_or(false)
+            {
+                continue;
+            }
+
+            for namevalue in attr.parse_args_with(|stream: &'_ syn::parse::ParseBuffer| {
+                syn::punctuated::Punctuated::<syn::MetaNameValue, syn::Token![,]>::parse_terminated(stream)
+            })? {
+                let litstr = match namevalue.lit {
+                    syn::Lit::Str(litstr) => litstr,
+                    other => {
+                        return Err(syn::Error::new_spanned(
+                            other,
+                            "Expected attribute of the form `#[user_facing(code = \"...\", message = \"...\")]`",
+                        ))
+                    }
+                };
+
+                match namevalue.path.get_ident() {
+                    Some(ident) if ident == "code" => {
+                        code = Some(litstr);
+                    }
+                    Some(ident) if ident == "message" => {
+                        message = Some(litstr);
+                    }
+                    other => {
+                        return Err(syn::Error::new_spanned(
+                            other,
+                            "Expected attribute of the form `#[user_facing(code = \"...\", message = \"...\")]`",
+                        ))
+                    }
+                }
+            }
+        }
+
+        Ok((message, code))
+    }
+}

--- a/libs/user-facing-error-parsing/src/lib.rs
+++ b/libs/user-facing-error-parsing/src/lib.rs
@@ -15,7 +15,7 @@ use syn::{Attribute, ItemStruct};
 ///         ])
 ///     }
 ///
-pub fn parse_files(srcs: Vec<String>) -> String {
+pub fn parse_files(srcs: &[String]) -> String {
     let errors: Vec<_> = vec![];
 
     let error_infos = srcs.iter().fold(errors, |mut errors, src| {
@@ -38,12 +38,12 @@ pub fn parse_files(srcs: Vec<String>) -> String {
 
     let output_file = quote::quote! {
 
-        pub fn error_list() -> Vec<UserErrorType> {
-            Vec::from([
+        pub fn error_list() -> &'static [UserErrorType] {
+            &[
                 #(
                     #error_infos
                 ),*
-            ])
+            ]
 
         }
     };

--- a/libs/user-facing-errors/Cargo.toml
+++ b/libs/user-facing-errors/Cargo.toml
@@ -22,3 +22,6 @@ optional = true
 [features]
 default = []
 sql = ["quaint"]
+
+[build-dependencies]
+user-facing-error-parsing = { path = "../user-facing-error-parsing" }

--- a/libs/user-facing-errors/build.rs
+++ b/libs/user-facing-errors/build.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 fn main() {
     let common = read_file("./src/common.rs");
     let query = read_file("./src/query_engine.rs");
-    let files = vec![common, query];
+    let files = &[common, query];
 
     // Read the files and generate a list of errors for our dmmf
     let error_src = user_facing_error_parsing::parse_files(files);

--- a/libs/user-facing-errors/build.rs
+++ b/libs/user-facing-errors/build.rs
@@ -1,0 +1,29 @@
+use std::env;
+use std::fs;
+use std::fs::File;
+use std::io::prelude::*;
+use std::path::Path;
+
+fn main() {
+    let common = read_file("./src/common.rs");
+    let query = read_file("./src/query_engine.rs");
+    let files = vec![common, query];
+
+    // Read the files and generate a list of errors for our dmmf
+    let error_src = user_facing_error_parsing::parse_files(files);
+
+    let out_dir = env::var_os("OUT_DIR").unwrap();
+    let dest_path = Path::new(&out_dir).join("user_error_list.rs");
+
+    fs::write(&dest_path, error_src).unwrap();
+
+    println!("cargo:rerun-if-changed=build.rs");
+}
+
+fn read_file(path: &str) -> String {
+    let mut file = File::open(path).expect("Unable to open file");
+    let mut src = String::new();
+    file.read_to_string(&mut src).expect("Unable to read file");
+
+    src
+}

--- a/libs/user-facing-errors/src/common.rs
+++ b/libs/user-facing-errors/src/common.rs
@@ -1,4 +1,4 @@
-use crate::UserFacingError;
+use crate::{ErrorDetails, UserFacingError};
 use serde::Serialize;
 use std::fmt::Display;
 use user_facing_error_macros::*;
@@ -88,6 +88,16 @@ pub enum DatabaseDoesNotExist {
 
 impl UserFacingError for DatabaseDoesNotExist {
     const ERROR_CODE: &'static str = "P1003";
+
+    fn error_details(&self) -> ErrorDetails {
+        use serde_json::json;
+
+        ErrorDetails {
+            name: "DatabaseDoesNotExist",
+            code: Self::ERROR_CODE,
+            fields: json!([]),
+        }
+    }
 
     fn message(&self) -> String {
         match self {

--- a/libs/user-facing-errors/src/introspection_engine.rs
+++ b/libs/user-facing-errors/src/introspection_engine.rs
@@ -1,3 +1,4 @@
+use crate::ErrorDetails;
 use serde::Serialize;
 use user_facing_error_macros::*;
 

--- a/libs/user-facing-errors/src/lib.rs
+++ b/libs/user-facing-errors/src/lib.rs
@@ -24,7 +24,7 @@ include!(concat!(env!("OUT_DIR"), "/user_error_list.rs"));
 // This isn't really needed but is added for clarity to make
 // what is happening a little more obvious. The error_list() is generated
 // in the build.rs.
-pub fn known_errors() -> Vec<UserErrorType> {
+pub fn known_errors() -> &'static [UserErrorType] {
     error_list()
 }
 

--- a/libs/user-facing-errors/src/migration_engine.rs
+++ b/libs/user-facing-errors/src/migration_engine.rs
@@ -1,3 +1,4 @@
+use crate::ErrorDetails;
 use serde::Serialize;
 use user_facing_error_macros::*;
 
@@ -62,12 +63,25 @@ pub struct MigrationDoesNotApplyCleanly {
 impl crate::UserFacingError for MigrationDoesNotApplyCleanly {
     const ERROR_CODE: &'static str = "P3006";
 
+    fn error_details(&self) -> ErrorDetails {
+        use serde_json::json;
+
+        ErrorDetails {
+            name: "MigrationDoesNotApplyCleanly",
+            code: Self::ERROR_CODE,
+            fields: json![{
+                "migration_name": self.migration_name
+            }],
+        }
+    }
+
     fn message(&self) -> String {
         let error_code = match &self.inner_error.inner {
             crate::ErrorType::Known(crate::KnownError {
                 message: _,
                 meta: _,
                 error_code,
+                error_details: _,
             }) => format!("Error code: {}\n", &error_code),
             crate::ErrorType::Unknown(_) => String::new(),
         };
@@ -88,6 +102,17 @@ pub struct PreviewFeaturesBlocked {
 
 impl crate::UserFacingError for PreviewFeaturesBlocked {
     const ERROR_CODE: &'static str = "P3007";
+
+    fn error_details(&self) -> ErrorDetails {
+        use serde_json::json;
+        let blocked: Vec<_> = self.features.iter().map(|s| format!("`{}`", s)).collect();
+
+        ErrorDetails {
+            name: "PreviewFeaturesBlocked",
+            code: Self::ERROR_CODE,
+            fields: json!([{ "blocked": blocked }]),
+        }
+    }
 
     fn message(&self) -> String {
         let blocked: Vec<_> = self.features.iter().map(|s| format!("`{}`", s)).collect();
@@ -161,12 +186,23 @@ pub struct ShadowDbCreationError {
 impl crate::UserFacingError for ShadowDbCreationError {
     const ERROR_CODE: &'static str = "P3014";
 
+    fn error_details(&self) -> ErrorDetails {
+        use serde_json::json;
+
+        ErrorDetails {
+            name: "ShadowDbCreationError",
+            code: Self::ERROR_CODE,
+            fields: json!([]),
+        }
+    }
+
     fn message(&self) -> String {
         let error_code = match &self.inner_error.inner {
             crate::ErrorType::Known(crate::KnownError {
                 message: _,
                 meta: _,
                 error_code,
+                error_details: _,
             }) => format!("Error code: {}\n", &error_code),
             crate::ErrorType::Unknown(_) => String::new(),
         };
@@ -196,12 +232,23 @@ pub struct SoftResetFailed {
 impl crate::UserFacingError for SoftResetFailed {
     const ERROR_CODE: &'static str = "P3016";
 
+    fn error_details(&self) -> ErrorDetails {
+        use serde_json::json;
+
+        ErrorDetails {
+            name: "SoftResetFailed",
+            code: Self::ERROR_CODE,
+            fields: json!([]),
+        }
+    }
+
     fn message(&self) -> String {
         let error_code = match &self.inner_error.inner {
             crate::ErrorType::Known(crate::KnownError {
                 message: _,
                 meta: _,
                 error_code,
+                error_details: _,
             }) => format!("Error code: {}\n", &error_code),
             crate::ErrorType::Unknown(_) => String::new(),
         };

--- a/migration-engine/migration-engine-tests/tests/errors/database_access_denied.rs
+++ b/migration-engine/migration-engine-tests/tests/errors/database_access_denied.rs
@@ -34,6 +34,14 @@ fn database_access_denied_must_return_a_proper_error_in_rpc(api: TestApi) {
             "database_name": "access_denied_test",
         },
         "error_code": "P1010",
+        "error_details": {
+            "name": "DatabaseAccessDenied",
+            "code": "P1010",
+            "fields": {
+                "database_user": "jeanyves",
+                "database_name": "access_denied_test"
+            }
+        }
     });
 
     assert_eq!(json_error, expected);

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/error.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/error.rs
@@ -1,0 +1,61 @@
+use query_engine_tests::*;
+
+#[test_suite(schema(schema))]
+mod errors {
+    use indoc::indoc;
+    use query_engine_tests::run_query;
+
+    fn schema() -> String {
+        let schema = indoc! {
+            r#"model Album {
+                    id Int @id @unique
+                    Title String
+                }
+            "#
+        };
+
+        schema.to_owned()
+    }
+
+    #[connector_test]
+    async fn errors_include_error_details(runner: Runner) -> TestResult<()> {
+        run_query!(
+            &runner,
+            r#"
+                mutation {
+                    createOneAlbum(data: {
+                        id: 1,
+                        Title: "I made an album"
+                    }) {
+                        id
+                    }
+                }
+            "#
+        );
+
+        let res = runner
+            .query(
+                r#"
+                mutation {
+                    createOneAlbum(data: {
+                        id: 1,
+                        Title: "I made an album"
+                    }) {
+                        id
+                    }
+                }
+            "#,
+            )
+            .await?;
+
+        let resp = res.to_string();
+        let errors: serde_json::Value = serde_json::from_str(&resp).unwrap();
+        let error = &errors["errors"][0];
+        let details = &error["user_facing_error"]["error_details"];
+
+        assert_eq!(details["name"], "UniqueKeyViolation");
+        assert_eq!(details["code"], "P2002");
+
+        Ok(())
+    }
+}

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/error.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/error.rs
@@ -8,7 +8,7 @@ mod errors {
     fn schema() -> String {
         let schema = indoc! {
             r#"model Album {
-                    id Int @id @unique
+                    #id(id, Int, @id, @unique)
                     Title String
                 }
             "#

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/mod.rs
@@ -1,6 +1,7 @@
 mod create_many;
 mod cursor;
 mod disconnect;
+mod error;
 mod interactive_tx;
 mod native_types;
 mod ref_actions;

--- a/query-engine/query-engine-node-api/src/error.rs
+++ b/query-engine/query-engine-node-api/src/error.rs
@@ -3,6 +3,9 @@ use query_connector::error::ConnectorError;
 use query_core::CoreError;
 use thiserror::Error;
 
+// TODO (garren): CoreError is quite large. Clippy recommends
+// that we should box it. This would be a future improvement to this
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Error)]
 pub enum ApiError {
     #[error("{}", _0)]

--- a/query-engine/query-engine/Cargo.toml
+++ b/query-engine/query-engine/Cargo.toml
@@ -53,6 +53,7 @@ user-facing-errors = {path = "../../libs/user-facing-errors"}
 
 [build-dependencies]
 rustc_version = "0.2.3"
+user-facing-errors = {path = "../../libs/user-facing-errors"}
 
 [dev-dependencies]
 anyhow = "1"

--- a/query-engine/request-handlers/src/dmmf/mod.rs
+++ b/query-engine/request-handlers/src/dmmf/mod.rs
@@ -13,7 +13,7 @@ pub struct DataModelMetaFormat {
     pub data_model: serde_json::Value,
     pub schema: DmmfSchema,
     pub mappings: DmmfOperationMappings,
-    pub errors: Vec<user_facing_errors::UserErrorType>,
+    pub errors: &'static [user_facing_errors::UserErrorType],
 }
 
 /// Model operations are serialized as an array of objects, each one

--- a/query-engine/request-handlers/src/dmmf/mod.rs
+++ b/query-engine/request-handlers/src/dmmf/mod.rs
@@ -13,6 +13,7 @@ pub struct DataModelMetaFormat {
     pub data_model: serde_json::Value,
     pub schema: DmmfSchema,
     pub mappings: DmmfOperationMappings,
+    pub errors: Vec<user_facing_errors::UserErrorType>,
 }
 
 /// Model operations are serialized as an array of objects, each one
@@ -91,10 +92,12 @@ impl Serialize for DmmfModelOperations {
 pub fn render_dmmf(dml: &datamodel::Datamodel, query_schema: QuerySchemaRef) -> DataModelMetaFormat {
     let (schema, mappings) = DmmfQuerySchemaRenderer::render(query_schema);
     let datamodel_json = datamodel::json::dmmf::render_to_dmmf_value(&dml);
+    let errors = user_facing_errors::known_errors();
 
     DataModelMetaFormat {
         data_model: datamodel_json,
         schema,
         mappings,
+        errors,
     }
 }


### PR DESCRIPTION
Adds a list of errors to the query engine dmmf.
Adds a new key in the json response for errors that contains
more error details. For example:

```json
    {
        "name": "UniqueKeyViolation",
        "code": "P2002",
        "fields": {
            "constraint": {
                "fields": ["email", "name"]
            }
        }
    }

```
Ticket for this https://github.com/prisma/prisma/issues/5040

A few things to note:

* I've split up the `user-facing-error-macro` into `user-facing-error-macro` and `user-facing-error-parsing`. I did this because you cannot export functions from a `proc-macro` crate. And I want to reuse the functions that create the UserError. 
* There is a build.rs file in the `user-facing-errrors`, it uses the `user-facing-error-parsing` library to read through all the error files and generate a list of errors that are added to the dmmf. 