### PR TITLE
Fix devel log output format

### DIFF
--- a/query-engine/query-engine/src/logger.rs
+++ b/query-engine/query-engine/src/logger.rs
@@ -77,7 +77,7 @@ impl<'a> Logger<'a> {
 
                     self.finalize(subscriber)
                 } else {
-                    let subscriber = FmtSubscriber::builder().with_env_filter(filter).compact().finish();
+                    let subscriber = FmtSubscriber::builder().with_env_filter(filter).finish();
                     self.finalize(subscriber)
                 }
             }


### PR DESCRIPTION
 - When updated to tracing-subscriber 0.3 the default text logging format is not as verbose as we expected
 - Apparently, the `compact` method (returning a `Compact` formatter) was not that compact before 0.3