### PR TITLE
support unsigned int type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3245,7 +3245,7 @@ dependencies = [
 [[package]]
 name = "quaint"
 version = "0.2.0-alpha.13"
-source = "git+https://github.com/prisma/quaint#05eb0acc841eeb88569d1538c35b66b5e4f83266"
+source = "git+https://github.com/serejkaaa512/quaint/?branch=feature/unsigned_int#b838af33a24d1ff5312b71e04e64c71e7ac52a1d"
 dependencies = [
  "async-trait",
  "base64 0.12.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,3 +48,6 @@ opt-level = 3
 codegen-units = 1
 opt-level = 'z' # Optimize for size.
 #strip="symbols"
+
+[patch."https://github.com/prisma/quaint"]
+quaint = {git = 'https://github.com/serejkaaa512/quaint/', branch = 'feature/unsigned_int' }

--- a/libs/prisma-value/src/sql_ext.rs
+++ b/libs/prisma-value/src/sql_ext.rs
@@ -11,6 +11,13 @@ impl<'a> TryFrom<Value<'a>> for PrismaValue {
         let val = match pv {
             Value::Integer(i) => i.map(PrismaValue::Int).unwrap_or(PrismaValue::Null),
 
+            Value::UnsignedInteger(Some(u)) => match i64::try_from(u) {
+                Ok(i) => PrismaValue::Int(i),
+                Err(_) => return Err(crate::ConversionFailure { from: "u64", to: "i64" }),
+            },
+
+            Value::UnsignedInteger(None) => PrismaValue::Null,
+
             Value::Float(Some(f)) => match f {
                 f if f.is_nan() => {
                     return Err(crate::ConversionFailure {


### PR DESCRIPTION
this work is based off the work in the quaint project https://github.com/prisma/quaint/pull/335
It is not ready to be merged until the quaint PR has been merged. 

At this stage we don't really support unsigned integers so we try and convert it to a signed int. An error is returned if that fails. 
