### PR TITLE
Trigger a warning if using type aliases

### DIFF
--- a/libs/datamodel/core/src/lib.rs
+++ b/libs/datamodel/core/src/lib.rs
@@ -138,7 +138,7 @@ fn parse_datamodel_internal(
     transform: bool,
 ) -> Result<Validated<(Configuration, Datamodel)>, diagnostics::Diagnostics> {
     let mut diagnostics = diagnostics::Diagnostics::new();
-    let ast = ast::parse_schema(datamodel_string)?;
+    let ast = ast::parse_schema(datamodel_string, &mut diagnostics);
 
     let generators = GeneratorLoader::load_generators_from_ast(&ast, &mut diagnostics);
     let preview_features = preview_features(&generators);
@@ -170,13 +170,21 @@ fn parse_datamodel_internal(
 }
 
 pub fn parse_schema_ast(datamodel_string: &str) -> Result<SchemaAst, diagnostics::Diagnostics> {
-    ast::parse_schema(datamodel_string)
+    let mut diagnostics = Diagnostics::default();
+    let schema = ast::parse_schema(datamodel_string, &mut diagnostics);
+
+    diagnostics.to_result()?;
+
+    Ok(schema)
 }
 
 /// Loads all configuration blocks from a datamodel using the built-in source definitions.
 pub fn parse_configuration(schema: &str) -> Result<ValidatedConfiguration, diagnostics::Diagnostics> {
-    let ast = ast::parse_schema(schema)?;
     let mut diagnostics = Diagnostics::default();
+    let ast = ast::parse_schema(schema, &mut diagnostics);
+
+    diagnostics.to_result()?;
+
     let generators = GeneratorLoader::load_generators_from_ast(&ast, &mut diagnostics);
     let preview_features = preview_features(&generators);
     let datasources = load_sources(&ast, preview_features, &mut diagnostics);

--- a/libs/datamodel/diagnostics/src/warning.rs
+++ b/libs/datamodel/diagnostics/src/warning.rs
@@ -9,6 +9,8 @@ use thiserror::Error;
 pub enum DatamodelWarning {
     #[error("Preview feature \"{}\" is deprecated. The functionality can be used without specifying it as a preview feature.", preview_feature)]
     DeprecatedPreviewFeature { preview_feature: String, span: Span },
+    #[error("Type aliases are an undocumented feature that is getting deprecated. Please chime in in the issue if you need it: https://github.com/prisma/prisma/issues/9939")]
+    DeprecatedTypeAlias { span: Span },
 }
 
 impl DatamodelWarning {
@@ -22,6 +24,7 @@ impl DatamodelWarning {
     pub fn span(&self) -> Span {
         match self {
             DatamodelWarning::DeprecatedPreviewFeature { span, .. } => *span,
+            DatamodelWarning::DeprecatedTypeAlias { span } => *span,
         }
     }
 


### PR DESCRIPTION
Warning is visible through `prisma-fmt`.

Closes: https://github.com/prisma/migrations-team/issues/275