### PR TITLE
chore(qe): stabilize test suite

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/src/utils/querying.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/src/utils/querying.rs
@@ -8,17 +8,17 @@ macro_rules! assert_query {
 
 #[macro_export]
 macro_rules! match_connector_result {
-    ($runner:expr, $q:expr, $([$($connector_opt:ident),*] => $result:expr),*) => {
-        use query_tests_setup::ConnectorTag::*;
-        let connector = $runner.connector();
-        let mut results: Vec<&str> = vec![];
-        $(
+    ($runner:expr, $q:expr, $( $($matcher:pat)|+ $( if $pred:expr )? => $result:expr ),*) => {
+        use query_tests_setup::*;
+        use query_tests_setup::ConnectorVersion::*;
+
+        let connector = $runner.connector_version();
+
+        let mut results = match connector {
             $(
-                if matches!(connector, $connector_opt(_)) {
-                    results.push($result);
-                }
-            )*
-        )*
+                $( $matcher )|+ $( if $pred )? => $result
+            ),*
+        };
 
         let query_result = $runner.query($q).await?.to_string();
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_delete/restrict.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_delete/restrict.rs
@@ -30,8 +30,8 @@ mod one2one_req {
           @r###"{"data":{"createOneParent":{"id":1}}}"###
         );
 
-        match runner.connector() {
-            ConnectorTag::MongoDb(_) => assert_error!(
+        match runner.connector_version() {
+            ConnectorVersion::MongoDb(_) => assert_error!(
                 runner,
                 "mutation { deleteOneParent(where: { id: 1 }) { id }}",
                 2014,
@@ -76,8 +76,8 @@ mod one2one_opt {
           @r###"{"data":{"createOneParent":{"id":1}}}"###
         );
 
-        match runner.connector() {
-            ConnectorTag::MongoDb(_) => assert_error!(
+        match runner.connector_version() {
+            ConnectorVersion::MongoDb(_) => assert_error!(
                 runner,
                 "mutation { deleteOneParent(where: { id: 1 }) { id }}",
                 2014,
@@ -148,8 +148,8 @@ mod one2many_req {
           @r###"{"data":{"createOneParent":{"id":1}}}"###
         );
 
-        match runner.connector() {
-            ConnectorTag::MongoDb(_) => assert_error!(
+        match runner.connector_version() {
+            ConnectorVersion::MongoDb(_) => assert_error!(
                 runner,
                 "mutation { deleteOneParent(where: { id: 1 }) { id }}",
                 2014,
@@ -220,8 +220,8 @@ mod one2many_opt {
           @r###"{"data":{"createOneParent":{"id":1}}}"###
         );
 
-        match runner.connector() {
-            ConnectorTag::MongoDb(_) => assert_error!(
+        match runner.connector_version() {
+            ConnectorVersion::MongoDb(_) => assert_error!(
                 runner,
                 "mutation { deleteOneParent(where: { id: 1 }) { id }}",
                 2014,

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_update/restrict.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_update/restrict.rs
@@ -33,8 +33,8 @@ mod one2one_req {
 
         let query = r#"mutation { updateOneParent(where: { id: 1 }, data: { uniq: "u1" }) { id }}"#;
 
-        match runner.connector() {
-            ConnectorTag::MongoDb(_) => assert_error!(
+        match runner.connector_version() {
+            ConnectorVersion::MongoDb(_) => assert_error!(
                 runner,
                 query,
                 2014,
@@ -61,8 +61,8 @@ mod one2one_req {
 
         let query = r#"mutation { updateManyParent(where: { id: 1 }, data: { uniq: "u1" }) { count }}"#;
 
-        match runner.connector() {
-            ConnectorTag::MongoDb(_) => assert_error!(
+        match runner.connector_version() {
+            ConnectorVersion::MongoDb(_) => assert_error!(
                 runner,
                 query,
                 2014,
@@ -89,8 +89,8 @@ mod one2one_req {
 
         let query = r#"mutation { upsertOneParent(where: { id: 1 }, update: { uniq: "u1" }, create: { id: 1, uniq: "1", child: { create: { id: 1 }} }) { id }}"#;
 
-        match runner.connector() {
-            ConnectorTag::MongoDb(_) => assert_error!(
+        match runner.connector_version() {
+            ConnectorVersion::MongoDb(_) => assert_error!(
                 runner,
                 query,
                 2014,
@@ -138,8 +138,8 @@ mod one2one_opt {
 
         let query = r#"mutation { updateOneParent(where: { id: 1 }, data: { uniq: "u1" }) { id }}"#;
 
-        match runner.connector() {
-            ConnectorTag::MongoDb(_) => assert_error!(
+        match runner.connector_version() {
+            ConnectorVersion::MongoDb(_) => assert_error!(
                 runner,
                 query,
                 2014,
@@ -166,8 +166,8 @@ mod one2one_opt {
 
         let query = r#"mutation { updateManyParent(where: { id: 1 }, data: { uniq: "u1" }) { count }}"#;
 
-        match runner.connector() {
-            ConnectorTag::MongoDb(_) => assert_error!(
+        match runner.connector_version() {
+            ConnectorVersion::MongoDb(_) => assert_error!(
                 runner,
                 query,
                 2014,
@@ -194,8 +194,8 @@ mod one2one_opt {
 
         let query = r#"mutation { upsertOneParent(where: { id: 1 }, update: { uniq: "u1" }, create: { id: 1, uniq: "1", child: { create: { id: 1 }} }) { id }}"#;
 
-        match runner.connector() {
-            ConnectorTag::MongoDb(_) => assert_error!(
+        match runner.connector_version() {
+            ConnectorVersion::MongoDb(_) => assert_error!(
                 runner,
                 query,
                 2014,
@@ -269,8 +269,8 @@ mod one2many_req {
 
         let query = r#"mutation { updateOneParent(where: { id: 1 }, data: { uniq: "u1" }) { id }}"#;
 
-        match runner.connector() {
-            ConnectorTag::MongoDb(_) => assert_error!(
+        match runner.connector_version() {
+            ConnectorVersion::MongoDb(_) => assert_error!(
                 runner,
                 query,
                 2014,
@@ -297,8 +297,8 @@ mod one2many_req {
 
         let query = r#"mutation { updateManyParent(where: { id: 1 }, data: { uniq: "u1" }) { count }}"#;
 
-        match runner.connector() {
-            ConnectorTag::MongoDb(_) => assert_error!(
+        match runner.connector_version() {
+            ConnectorVersion::MongoDb(_) => assert_error!(
                 runner,
                 query,
                 2014,
@@ -325,8 +325,8 @@ mod one2many_req {
 
         let query = r#"mutation { upsertOneParent(where: { id: 1 }, update: { uniq: "u1" }, create: { id: 1, uniq: "1", children: { create: { id: 1 }} }) { id }}"#;
 
-        match runner.connector() {
-            ConnectorTag::MongoDb(_) => assert_error!(
+        match runner.connector_version() {
+            ConnectorVersion::MongoDb(_) => assert_error!(
                 runner,
                 query,
                 2014,
@@ -400,8 +400,8 @@ mod one2many_opt {
 
         let query = r#"mutation { updateOneParent(where: { id: 1 }, data: { uniq: "u1" }) { id }}"#;
 
-        match runner.connector() {
-            ConnectorTag::MongoDb(_) => assert_error!(
+        match runner.connector_version() {
+            ConnectorVersion::MongoDb(_) => assert_error!(
                 runner,
                 query,
                 2014,
@@ -428,8 +428,8 @@ mod one2many_opt {
 
         let query = r#"mutation { updateManyParent(where: { id: 1 }, data: { uniq: "u1" }) { count }}"#;
 
-        match runner.connector() {
-            ConnectorTag::MongoDb(_) => assert_error!(
+        match runner.connector_version() {
+            ConnectorVersion::MongoDb(_) => assert_error!(
                 runner,
                 query,
                 2014,
@@ -456,8 +456,8 @@ mod one2many_opt {
 
         let query = r#"mutation { upsertOneParent(where: { id: 1 }, update: { uniq: "u1" }, create: { id: 1, uniq: "1", children: { create: { id: 1 }} }) { id }}"#;
 
-        match runner.connector() {
-            ConnectorTag::MongoDb(_) => assert_error!(
+        match runner.connector_version() {
+            ConnectorVersion::MongoDb(_) => assert_error!(
                 runner,
                 query,
                 2014,

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_update/set_null.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_update/set_null.rs
@@ -253,8 +253,8 @@ mod one2one_opt {
 
         let query = r#"mutation { updateOneA(where: { id: 1 }, data: { b_id: 2 }) { id } }"#;
 
-        match runner.connector() {
-          ConnectorTag::MongoDb(_) => assert_error!(
+        match runner.connector_version() {
+          ConnectorVersion::MongoDb(_) => assert_error!(
               runner,
               query,
               2014,
@@ -703,8 +703,8 @@ mod one2many_opt {
 
         let query = r#"mutation { updateOneA(where: { id: 1 }, data: { b_id: 2 }) { id } }"#;
 
-        match runner.connector() {
-        ConnectorTag::MongoDb(_) => assert_error!(
+        match runner.connector_version() {
+        ConnectorVersion::MongoDb(_) => assert_error!(
             runner,
             query,
             2014,

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/bytes_filter.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/bytes_filter.rs
@@ -3,7 +3,7 @@ use query_engine_tests::*;
 
 #[test_suite(schema(schemas::common_nullable_types))]
 mod bytes_filter_spec {
-    use query_engine_tests::run_query;
+    use query_engine_tests::{match_connector_result, run_query};
 
     #[connector_test]
     async fn basic_where(runner: Runner) -> TestResult<()> {
@@ -71,8 +71,9 @@ mod bytes_filter_spec {
         match_connector_result!(
             &runner,
             r#"query { findManyTestModel(where: { bytes: { not: { in: ["dGVzdA=="] }}}) { id }}"#,
-            [SqlServer, Postgres, MySql, Sqlite] => r#"{"data":{"findManyTestModel":[{"id":2}]}}"#,
-            [MongoDb] => r#"{"data":{"findManyTestModel":[{"id":2},{"id":3}]}}"# // Mongo selects `null` fields as well.
+            // Mongo selects `null` fields as well.
+            MongoDb(_) => vec![r#"{"data":{"findManyTestModel":[{"id":2},{"id":3}]}}"#],
+            _ => vec![r#"{"data":{"findManyTestModel":[{"id":2}]}}"#]
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/json_path.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/json_path.rs
@@ -195,9 +195,9 @@ mod json_path {
             ]
         );
 
-        match runner.connector() {
+        match runner.connector_version() {
             // MariaDB does not support finding arrays in arrays, unlike MySQL
-            ConnectorTag::MySql(mysql) if mysql.version() == Some(&MySqlVersion::MariaDb) => {
+            ConnectorVersion::MySql(Some(MySqlVersion::MariaDb)) => {
                 insta::assert_snapshot!(
                     run_query!(
                         runner,
@@ -667,10 +667,10 @@ mod json_path {
     }
 
     fn json_path(runner: &Runner) -> &'static str {
-        match runner.connector() {
-            ConnectorTag::Postgres(_) => r#"path: ["a", "b"]"#,
-            ConnectorTag::MySql(_) => r#"path: "$.a.b""#,
-            x => unreachable!("JSON filtering is not supported on {}", x),
+        match runner.connector_version() {
+            ConnectorVersion::Postgres(_) => r#"path: ["a", "b"]"#,
+            ConnectorVersion::MySql(_) => r#"path: "$.a.b""#,
+            x => unreachable!("JSON filtering is not supported on {:?}", x),
         }
     }
 }

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_aggregation.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_aggregation.rs
@@ -3,7 +3,7 @@ use query_engine_tests::*;
 #[test_suite(schema(schema))]
 mod order_by_aggr {
     use indoc::indoc;
-    use query_engine_tests::run_query;
+    use query_engine_tests::{match_connector_result, run_query};
 
     fn schema() -> String {
         let schema = indoc! {
@@ -223,9 +223,10 @@ mod order_by_aggr {
                 user { categories { name } }
               }
             }"#,
-            [Sqlite, MySql, MongoDb, Postgres, SqlServer] => r#"{"data":{"findManyPost":[{"id":2,"user":{"categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":3,"user":{"categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":1,"user":{"categories":[{"name":"Startup"}]}}]}}"#,
-            // MySql 5.6, Postgres 9
-            [SqlServer, MySql, Postgres] => r#"{"data":{"findManyPost":[{"id":3,"user":{"categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":2,"user":{"categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":1,"user":{"categories":[{"name":"Startup"}]}}]}}"#
+            _ => vec![
+              r#"{"data":{"findManyPost":[{"id":2,"user":{"categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":3,"user":{"categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":1,"user":{"categories":[{"name":"Startup"}]}}]}}"#,
+              r#"{"data":{"findManyPost":[{"id":3,"user":{"categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":2,"user":{"categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":1,"user":{"categories":[{"name":"Startup"}]}}]}}"#
+            ]
         );
         Ok(())
     }
@@ -266,8 +267,11 @@ mod order_by_aggr {
                 }
               }
             }"#,
-            [Sqlite, SqlServer, MySql, MongoDb, Postgres] => r#"{"data":{"findManyPost":[{"id":1,"user":{"name":"Alice","categories":[{"name":"Startup"}]}},{"id":2,"user":{"name":"Bob","categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":3,"user":{"name":"Bob","categories":[{"name":"Computer Science"},{"name":"Music"}]}}]}}"#,
-            [MySql, Postgres] => r#"{"data":{"findManyPost":[{"id":1,"user":{"name":"Alice","categories":[{"name":"Startup"}]}},{"id":3,"user":{"name":"Bob","categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":2,"user":{"name":"Bob","categories":[{"name":"Computer Science"},{"name":"Music"}]}}]}}"#
+            Postgres(_) | MySql(_) => vec![
+              r#"{"data":{"findManyPost":[{"id":1,"user":{"name":"Alice","categories":[{"name":"Startup"}]}},{"id":2,"user":{"name":"Bob","categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":3,"user":{"name":"Bob","categories":[{"name":"Computer Science"},{"name":"Music"}]}}]}}"#,
+              r#"{"data":{"findManyPost":[{"id":1,"user":{"name":"Alice","categories":[{"name":"Startup"}]}},{"id":3,"user":{"name":"Bob","categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":2,"user":{"name":"Bob","categories":[{"name":"Computer Science"},{"name":"Music"}]}}]}}"#
+            ],
+            _ => vec![r#"{"data":{"findManyPost":[{"id":1,"user":{"name":"Alice","categories":[{"name":"Startup"}]}},{"id":2,"user":{"name":"Bob","categories":[{"name":"Computer Science"},{"name":"Music"}]}},{"id":3,"user":{"name":"Bob","categories":[{"name":"Computer Science"},{"name":"Music"}]}}]}}"#]
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent.rs
@@ -245,7 +245,7 @@ mod order_by_dependent {
               }
             }
           }"#,
-          MySql(Some(MySqlVersion::MariaDb)) | MongoDb(_) | Sqlite => vec![r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":4,"b":null},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}}]}}"#],
+          MongoDb(_) | Sqlite => vec![r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":4,"b":null},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}}]}}"#],
           MySql(_) => vec![
             r#"{"data":{"findManyModelA":[{"id":4,"b":null},{"id":3,"b":null},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}}]}}"#,
             r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":4,"b":null},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}}]}}"#,
@@ -277,8 +277,7 @@ mod order_by_dependent {
                 }
               }
             }"#,
-            // MariaDb
-            MongoDb(_) | Sqlite | MySql(Some(MySqlVersion::MariaDb)) => vec![r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":3,"b":null},{"id":4,"b":null}]}}"#],
+            MongoDb(_) | Sqlite => vec![r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":3,"b":null},{"id":4,"b":null}]}}"#],
             MySql(_) => vec![
               r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":4,"b":null},{"id":3,"b":null}]}}"#,
               r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":3,"b":null},{"id":4,"b":null}]}}"#,

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent.rs
@@ -92,10 +92,8 @@ mod order_by_dependent {
                 }
               }
             }"#,
-            [MongoDb, Sqlite, SqlServer] => r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":1,"b":{"id":1}},{"id":2,"b":{"id":2}}]}}"#,
-            [Postgres] => r#"{"data":{"findManyModelA":[{"id":1,"b":{"id":1}},{"id":2,"b":{"id":2}},{"id":3,"b":null}]}}"#,
-            //MariaDB, MySql8
-            [MySql] => r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":1,"b":{"id":1}},{"id":2,"b":{"id":2}}]}}"#
+            Postgres(_) => r#"{"data":{"findManyModelA":[{"id":1,"b":{"id":1}},{"id":2,"b":{"id":2}},{"id":3,"b":null}]}}"#,
+            _ => r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":1,"b":{"id":1}},{"id":2,"b":{"id":2}}]}}"#
         );
 
         Ok(())
@@ -160,12 +158,15 @@ mod order_by_dependent {
               }
             }"#,
             // Depends on how null values are handled.
-            [MongoDb, Sqlite] => r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":null}},{"id":3,"b":null},{"id":1,"b":{"c":{"id":1}}}]}}"#,
-            [SqlServer, MySql] => r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":2,"b":{"c":null}},{"id":1,"b":{"c":{"id":1}}}]}}"#,
-            [Postgres] => r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"id":1}}},{"id":2,"b":{"c":null}},{"id":3,"b":null}]}}"#,
+            MongoDb(_) | Sqlite => vec![r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":null}},{"id":3,"b":null},{"id":1,"b":{"c":{"id":1}}}]}}"#],
+            SqlServer(_) => vec![r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":2,"b":{"c":null}},{"id":1,"b":{"c":{"id":1}}}]}}"#],
             // CockroachDB can order ModelA.id in any order if ModelC.b_id is NULL.
-            [Postgres] => r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"id":1}}},{"id":3,"b":null},{"id":2,"b":{"c":null}}]}}"#,
-            [MySql] => r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":null}},{"id":3,"b":null},{"id":1,"b":{"c":{"id":1}}}]}}"#
+            Postgres(Some(PostgresVersion::Cockroach)) => vec![r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"id":1}}},{"id":3,"b":null},{"id":2,"b":{"c":null}}]}}"#],
+            Postgres(_) => vec![r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"id":1}}},{"id":2,"b":{"c":null}},{"id":3,"b":null}]}}"#],
+            _ => vec![
+              r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":null}},{"id":3,"b":null},{"id":1,"b":{"c":{"id":1}}}]}}"#,
+              r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":2,"b":{"c":null}},{"id":1,"b":{"c":{"id":1}}}]}}"#
+            ]
         );
 
         Ok(())
@@ -244,10 +245,12 @@ mod order_by_dependent {
               }
             }
           }"#,
-          [MySql] => r#"{"data":{"findManyModelA":[{"id":4,"b":null},{"id":3,"b":null},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}}]}}"#,
-          // mariadb
-          [MySql, MongoDb, Sqlite] => r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":4,"b":null},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}}]}}"#,
-          [Postgres] => r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":3,"b":null},{"id":4,"b":null}]}}"#
+          MySql(Some(MySqlVersion::MariaDb)) | MongoDb(_) | Sqlite => vec![r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":4,"b":null},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}}]}}"#],
+          MySql(_) => vec![
+            r#"{"data":{"findManyModelA":[{"id":4,"b":null},{"id":3,"b":null},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}}]}}"#,
+            r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":4,"b":null},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}}]}}"#,
+          ],
+          _ => vec![r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":3,"b":null},{"id":4,"b":null}]}}"#]
         );
 
         Ok(())
@@ -275,9 +278,12 @@ mod order_by_dependent {
               }
             }"#,
             // MariaDb
-            [MongoDb, Sqlite, MySql] => r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":3,"b":null},{"id":4,"b":null}]}}"#,
-            [Postgres] =>  r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":4,"b":null},{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}}]}}"#,
-            [MySql] => r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":4,"b":null},{"id":3,"b":null}]}}"#
+            MongoDb(_) | Sqlite | MySql(Some(MySqlVersion::MariaDb)) => vec![r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":3,"b":null},{"id":4,"b":null}]}}"#],
+            MySql(_) => vec![
+              r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":4,"b":null},{"id":3,"b":null}]}}"#,
+              r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":3,"b":null},{"id":4,"b":null}]}}"#,
+            ],
+            _ =>  vec![r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":4,"b":null},{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}}]}}"#]
         );
         Ok(())
     }

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent_pagination.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent_pagination.rs
@@ -228,8 +228,8 @@ mod order_by_dependent_pag {
     }
 
     // "[Circular with differing records] Ordering by related record field ascending" should "work"
-    // TODO: Does not work on MySQL & SQLite. Figure out why?
     // TODO(julius): should enable for SQL Server when partial indices are in the PSL
+    // TODO(flavian): Does not work on MySQL & SQLite. Figure out why?
     #[connector_test(exclude(SqlServer, MySql, Sqlite))]
     async fn circular_diff_related_record_asc(runner: Runner) -> TestResult<()> {
         // Records form circles with their relations
@@ -261,7 +261,7 @@ mod order_by_dependent_pag {
 
     // "[Circular with differing records] Ordering by related record field descending" should "work"
     // TODO(julius): should enable for SQL Server when partial indices are in the PSL
-    // TODO(flavian): fix pagination issue
+    // TODO(flavian): fix pagination issue on Postgres
     #[connector_test(exclude(SqlServer, Postgres))]
     async fn circular_diff_related_record_desc(runner: Runner) -> TestResult<()> {
         // Records form circles with their relations

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent_pagination.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent_pagination.rs
@@ -260,7 +260,8 @@ mod order_by_dependent_pag {
 
     // "[Circular with differing records] Ordering by related record field descending" should "work"
     // TODO(julius): should enable for SQL Server when partial indices are in the PSL
-    #[connector_test(exclude(SqlServer))]
+    // TODO(flavian): fix pagination issue
+    #[connector_test(exclude(SqlServer, Postgres))]
     async fn circular_diff_related_record_desc(runner: Runner) -> TestResult<()> {
         // Records form circles with their relations
         create_row(&runner, 1, Some(1), Some(1), Some(3)).await?;
@@ -281,7 +282,6 @@ mod order_by_dependent_pag {
               }
             }"#,
             // Depends on how null values are handled.
-            MongoDb(_) => vec![r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}}]}}"#],
             _ => vec![
               r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":3,"b":null},{"id":4,"b":null}]}}"#,
               r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":4,"b":null},{"id":3,"b":null}]}}"#,

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent_pagination.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent_pagination.rs
@@ -252,6 +252,7 @@ mod order_by_dependent_pag {
             }"#,
             // Depends on how null values are handled.
             MongoDb(_) => vec![r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}}]}}"#],
+            Postgres(Some(PostgresVersion::Cockroack)) => vec![r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":4,"b":null},{"id":3,"b":null}]}}"#],
             _ => vec![r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":3,"b":null},{"id":4,"b":null}]}}"#]
         );
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent_pagination.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent_pagination.rs
@@ -252,7 +252,7 @@ mod order_by_dependent_pag {
             }"#,
             // Depends on how null values are handled.
             MongoDb(_) => vec![r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}}]}}"#],
-            Postgres(Some(PostgresVersion::Cockroack)) => vec![r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":4,"b":null},{"id":3,"b":null}]}}"#],
+            Postgres(Some(PostgresVersion::Cockroach)) => vec![r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":4,"b":null},{"id":3,"b":null}]}}"#],
             _ => vec![r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":3,"b":null},{"id":4,"b":null}]}}"#]
         );
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent_pagination.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent_pagination.rs
@@ -3,7 +3,7 @@ use query_engine_tests::*;
 #[test_suite(schema(schema))]
 mod order_by_dependent_pag {
     use indoc::indoc;
-    use query_engine_tests::run_query;
+    use query_engine_tests::{connector_test, match_connector_result, run_query};
 
     fn schema() -> String {
         let schema = indoc! {
@@ -79,7 +79,8 @@ mod order_by_dependent_pag {
 
     // "[Hops: 1] Ordering by related record field ascending with nulls" should "work"
     // TODO(julius): should enable for SQL Server when partial indices are in the PSL
-    #[connector_test(exclude(SqlServer))]
+    // TODO:(flavian): fix tests for sql dbs
+    #[connector_test(only(MongoDb, Postgres))]
     async fn hop_1_related_record_asc_nulls(runner: Runner) -> TestResult<()> {
         // 1 record has the "full chain", one half, one none
         create_row(&runner, 1, Some(1), Some(1), None).await?;
@@ -97,9 +98,8 @@ mod order_by_dependent_pag {
               }
             }"#,
             // Depends on how null values are handled.
-            [MongoDb] => r#"{"data":{"findManyModelA":[{"id":1,"b":{"id":1}},{"id":2,"b":{"id":2}}]}}"#,
-            [Postgres] =>  r#"{"data":{"findManyModelA":[{"id":1,"b":{"id":1}},{"id":2,"b":{"id":2}},{"id":3,"b":null}]}}"#,
-            [MySql, Sqlite] => r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":1,"b":{"id":1}},{"id":2,"b":{"id":2}}]}}"#
+            MongoDb(_) => vec![r#"{"data":{"findManyModelA":[{"id":1,"b":{"id":1}},{"id":2,"b":{"id":2}}]}}"#],
+            _ => vec![r#"{"data":{"findManyModelA":[{"id":1,"b":{"id":1}},{"id":2,"b":{"id":2}},{"id":3,"b":null}]}}"#]
         );
 
         Ok(())
@@ -147,7 +147,8 @@ mod order_by_dependent_pag {
 
     // "[Hops: 2] Ordering by related record field ascending with nulls" should "work"
     // TODO(garren): should enable for SQL Server when partial indices are in the PSL
-    #[connector_test(exclude(SqlServer))]
+    // TODO(flavian): sqlite and mysql don't work. Cursor is on 1, first result is 2 and 3.
+    #[connector_test(only(MongoDb, Postgres))]
     async fn hop_2_related_record_asc_null(runner: Runner) -> TestResult<()> {
         // 1 record has the "full chain", one half, one none
         create_row(&runner, 1, Some(1), Some(1), None).await?;
@@ -167,10 +168,8 @@ mod order_by_dependent_pag {
               }
             }"#,
             // Depends on how null values are handled.
-            [MongoDb] => r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"id":1}}}]}}"#,
-            [Postgres] => r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"id":1}}},{"id":2,"b":{"c":null}},{"id":3,"b":null}]}}"#,
-            [Sqlite, MySql] => r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":null}},{"id":3,"b":null},{"id":1,"b":{"c":{"id":1}}}]}}"#,
-            [MySql] => r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":2,"b":{"c":null}},{"id":1,"b":{"c":{"id":1}}}]}}"#
+            MongoDb(_) => vec![r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"id":1}}}]}}"#],
+            _ => vec![r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"id":1}}},{"id":2,"b":{"c":null}},{"id":3,"b":null}]}}"#]
         );
 
         Ok(())
@@ -231,7 +230,7 @@ mod order_by_dependent_pag {
     // "[Circular with differing records] Ordering by related record field ascending" should "work"
     // TODO: Does not work on MySQL & SQLite. Figure out why?
     // TODO(julius): should enable for SQL Server when partial indices are in the PSL
-    #[connector_test(exclude(SqlServer))]
+    #[connector_test(exclude(SqlServer, MySql, Sqlite))]
     async fn circular_diff_related_record_asc(runner: Runner) -> TestResult<()> {
         // Records form circles with their relations
         create_row(&runner, 1, Some(1), Some(1), Some(3)).await?;
@@ -250,15 +249,12 @@ mod order_by_dependent_pag {
                   }
                 }
               }
-            }"#, // Depends on how null values are handled.
-            [MongoDb] => r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}}]}}"#,
-            [Postgres] =>  r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":3,"b":null},{"id":4,"b":null}]}}"#,
-            // CockroachDB can order ModelA.id in any order if ModelB.a_id is NULL.
-            [Postgres] =>  r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":4,"b":null},{"id":3,"b":null}]}}"#,
-            // Mariadb
-            [Sqlite, MySql] =>  r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":4,"b":null},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}}]}}"#,
-            [MySql] =>  r#"{"data":{"findManyModelA":[{"id":4,"b":null},{"id":3,"b":null},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}}]}}"#
+            }"#,
+            // Depends on how null values are handled.
+            MongoDb(_) => vec![r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}}]}}"#],
+            _ => vec![r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":3,"b":null},{"id":4,"b":null}]}}"#]
         );
+
         Ok(())
     }
 
@@ -285,12 +281,13 @@ mod order_by_dependent_pag {
               }
             }"#,
             // Depends on how null values are handled.
-            [MongoDb, Sqlite, MySql, Postgres] => r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":3,"b":null},{"id":4,"b":null}]}}"#,
-            [MongoDb, Sqlite, MySql] => r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":4,"b":null},{"id":3,"b":null}]}}"#,
-            // Cockroach has a different ordering.
-            [Postgres] => r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":4,"b":null},{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}}]}}"#,
-            [Postgres] => r#"{"data":{"findManyModelA":[{"id":4,"b":null},{"id":3,"b":null},{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}}]}}"#
+            MongoDb(_) => vec![r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}}]}}"#],
+            _ => vec![
+              r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":3,"b":null},{"id":4,"b":null}]}}"#,
+              r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":4,"b":null},{"id":3,"b":null}]}}"#,
+            ]
         );
+
         Ok(())
     }
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/pagination.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/pagination.rs
@@ -845,8 +845,8 @@ mod pagination {
                 id
               }
           }"#,
-          [SqlServer] => r#"{"data":{"findManyTestModel":[{"id":6},{"id":5},{"id":3}]}}"#,
-          [MongoDb, Sqlite, Postgres, MySql, SqlServer] => r#"{"data":{"findManyTestModel":[{"id":6},{"id":5}]}}"#
+          SqlServer(_) => vec![r#"{"data":{"findManyTestModel":[{"id":6},{"id":5},{"id":3}]}}"#],
+          _ => vec![r#"{"data":{"findManyTestModel":[{"id":6},{"id":5}]}}"#]
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/pagination.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/pagination.rs
@@ -838,15 +838,15 @@ mod pagination {
         // 6 => C C D C <- take
         //
         // Because the final result gets reversed again to restore original order, the result possibilities are the same as #2, just reversed.
-        match_connector_result!(
-          &runner,
-          r#"query {
+        insta::assert_snapshot!(
+          run_query!(
+            &runner,
+            r#"query {
               findManyTestModel(cursor: { id: 4 }, take: -3, skip: 1, orderBy: [{ fieldA: desc }, { fieldB: asc }, { fieldC: asc }, { fieldD: desc }]) {
                 id
               }
-          }"#,
-          SqlServer(_) => vec![r#"{"data":{"findManyTestModel":[{"id":6},{"id":5},{"id":3}]}}"#],
-          _ => vec![r#"{"data":{"findManyTestModel":[{"id":6},{"id":5}]}}"#]
+            }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":6},{"id":5}]}}"###
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/regressions/pagination_regression.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/regressions/pagination_regression.rs
@@ -92,8 +92,8 @@ mod pagination_regr {
             orderBy: [{ field: desc }, { id: asc }]
           ) { id }
           }"#,
-          [Sqlite, SqlServer, MySql, MongoDb] => r#"{"data":{"findManyTestModel":[{"id":4}]}}"#,
-          [Postgres] => r#"{"data":{"findManyTestModel":[{"id":4},{"id":5}]}}"#
+          Postgres(_) => vec![r#"{"data":{"findManyTestModel":[{"id":4},{"id":5}]}}"#],
+          _ => vec![r#"{"data":{"findManyTestModel":[{"id":4}]}}"#]
         );
 
         Ok(())
@@ -118,8 +118,8 @@ mod pagination_regr {
             orderBy: [{ field: desc }, { id: asc }]
           ) { id }
           }"#,
-          [Postgres] => r#"{"data":{"findManyTestModel":[{"id":2}]}}"#,
-          [Sqlite, MongoDb, MySql, SqlServer] => r#"{"data":{"findManyTestModel":[{"id":2},{"id":1}]}}"#
+          Postgres(_) => vec![r#"{"data":{"findManyTestModel":[{"id":2}]}}"#],
+          _ => vec![r#"{"data":{"findManyTestModel":[{"id":2},{"id":1}]}}"#]
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/ids/byoid.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/ids/byoid.rs
@@ -54,9 +54,9 @@ mod byoid {
           @r###"{"data":{"createOneParent":{"p":"Parent","id":"Own Id"}}}"###
         );
 
-        let error_target = match runner.connector() {
-            query_engine_tests::ConnectorTag::MySql(_) => "constraint: `PRIMARY`",
-            query_engine_tests::ConnectorTag::Vitess(_) => "(not available)",
+        let error_target = match runner.connector_version() {
+            query_engine_tests::ConnectorVersion::MySql(_) => "constraint: `PRIMARY`",
+            query_engine_tests::ConnectorVersion::Vitess(_) => "(not available)",
             _ => "fields: (`id`)",
         };
 
@@ -82,9 +82,9 @@ mod byoid {
           @r###"{"data":{"createOneParent":{"p":"Parent","id":"Own Id"}}}"###
         );
 
-        let error_target = match runner.connector() {
-            query_engine_tests::ConnectorTag::MySql(_) => "constraint: `PRIMARY`",
-            query_engine_tests::ConnectorTag::Vitess(_) => "(not available)",
+        let error_target = match runner.connector_version() {
+            ConnectorVersion::MySql(_) => "constraint: `PRIMARY`",
+            ConnectorVersion::Vitess(_) => "(not available)",
             _ => "fields: (`id`)",
         };
 
@@ -140,9 +140,9 @@ mod byoid {
           @r###"{"data":{"createOneParent":{"p":"Parent","id":"Own Id","childOpt":{"c":"Child","id":"Own Child Id"}}}}"###
         );
 
-        let error_target = match runner.connector() {
-            query_engine_tests::ConnectorTag::MySql(_) => "constraint: `PRIMARY`",
-            query_engine_tests::ConnectorTag::Vitess(_) => "(not available)",
+        let error_target = match runner.connector_version() {
+            ConnectorVersion::MySql(_) => "constraint: `PRIMARY`",
+            ConnectorVersion::Vitess(_) => "(not available)",
             _ => "fields: (`id`)",
         };
 
@@ -168,9 +168,9 @@ mod byoid {
           @r###"{"data":{"createOneParent":{"p":"Parent","id":"Own Id","childOpt":{"c":"Child","id":"Own Child Id"}}}}"###
         );
 
-        let error_target = match runner.connector() {
-            query_engine_tests::ConnectorTag::MySql(_) => "constraint: `PRIMARY`",
-            query_engine_tests::ConnectorTag::Vitess(_) => "(not available)",
+        let error_target = match runner.connector_version() {
+            ConnectorVersion::MySql(_) => "constraint: `PRIMARY`",
+            ConnectorVersion::Vitess(_) => "(not available)",
             _ => "fields: (`id`)",
         };
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/insert_null_in_required_field.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/insert_null_in_required_field.rs
@@ -22,20 +22,10 @@ mod insert_null {
     async fn update_required_val_to_null(runner: Runner) -> TestResult<()> {
         create_row(&runner, r#"{ id: 1, b: "abc" key: "abc" }"#).await?;
 
-        let is_mysql_56 = match runner.connector() {
-            query_engine_tests::ConnectorTag::MySql(conn) => {
-                let (_, version) = conn.as_parse_pair();
-
-                if let Some(v) = version {
-                    v == "5.6"
-                } else {
-                    false
-                }
-            }
-            _ => false,
-        };
-
-        if !is_mysql_56 {
+        if !matches!(
+            runner.connector_version(),
+            ConnectorVersion::MySql(Some(MySqlVersion::V5_6))
+        ) {
             assert_error!(
               runner,
               r#"mutation {

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/update_many.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/update_many.rs
@@ -156,7 +156,7 @@ mod update_many {
         );
 
         // Todo: Mongo divisions are broken
-        if !matches!(runner.connector(), ConnectorTag::MongoDb(_)) {
+        if !matches!(runner.connector_version(), ConnectorVersion::MongoDb(_)) {
             // optInts before this op are now: null/0, 4, 6
             is_one_of!(
                 query_number_operation(&runner, "optInt", "divide", "3").await?,

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mod.rs
@@ -90,21 +90,6 @@ impl From<&ConnectorTag> for ConnectorVersion {
     }
 }
 
-impl fmt::Display for ConnectorVersion {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let printable = match self {
-            Self::SqlServer(_) => "SQL Server",
-            Self::Postgres(_) => "PostgreSQL",
-            Self::MySql(_) => "MySQL",
-            Self::MongoDb(_) => "MongoDB",
-            Self::Sqlite => "SQLite",
-            Self::Vitess(_) => "Vitess",
-        };
-
-        write!(f, "{}", printable)
-    }
-}
-
 impl fmt::Display for ConnectorTag {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let printable = match self {
@@ -114,6 +99,36 @@ impl fmt::Display for ConnectorTag {
             Self::MongoDb(_) => "MongoDB",
             Self::Sqlite(_) => "SQLite",
             Self::Vitess(_) => "Vitess",
+        };
+
+        write!(f, "{}", printable)
+    }
+}
+
+impl fmt::Display for ConnectorVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let printable = match self {
+            Self::SqlServer(v) => match v {
+                Some(v) => format!("SQL Server ({})", v.to_string()),
+                None => format!("SQL Server (unknown)"),
+            },
+            Self::Postgres(v) => match v {
+                Some(v) => format!("PostgreSQL ({})", v.to_string()),
+                None => format!("PostgreSQL (unknown)"),
+            },
+            Self::MySql(v) => match v {
+                Some(v) => format!("MySQL ({})", v.to_string()),
+                None => format!("MySQL (unknown)"),
+            },
+            Self::MongoDb(v) => match v {
+                Some(v) => format!("MongoDB ({})", v.to_string()),
+                None => format!("MongoDB (unknown)"),
+            },
+            Self::Sqlite => "SQLite".to_string(),
+            Self::Vitess(v) => match v {
+                Some(v) => format!("Vitess ({})", v.to_string()),
+                None => format!("Vitess (unknown)"),
+            },
         };
 
         write!(f, "{}", printable)

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mod.rs
@@ -7,13 +7,13 @@ mod vitess;
 
 use datamodel_connector::ConnectorCapability;
 use enum_dispatch::enum_dispatch;
-use mongodb::*;
+pub use mongodb::*;
 pub use mysql::*;
-use postgres::*;
-use sql_server::*;
-use sqlite::*;
+pub use postgres::*;
+pub use sql_server::*;
+pub use sqlite::*;
 use std::{convert::TryFrom, fmt};
-use vitess::*;
+pub use vitess::*;
 
 use crate::{datamodel_rendering::DatamodelRenderer, TestConfig, TestError};
 
@@ -67,15 +67,53 @@ pub enum ConnectorTag {
     Vitess(VitessConnectorTag),
 }
 
+#[derive(Debug, Clone)]
+pub enum ConnectorVersion {
+    SqlServer(Option<SqlServerVersion>),
+    Postgres(Option<PostgresVersion>),
+    MySql(Option<MySqlVersion>),
+    MongoDb(Option<MongoDbVersion>),
+    Sqlite,
+    Vitess(Option<VitessVersion>),
+}
+
+impl From<&ConnectorTag> for ConnectorVersion {
+    fn from(connector: &ConnectorTag) -> Self {
+        match connector {
+            ConnectorTag::SqlServer(c) => ConnectorVersion::SqlServer(c.version()),
+            ConnectorTag::Postgres(c) => ConnectorVersion::Postgres(c.version()),
+            ConnectorTag::MySql(c) => ConnectorVersion::MySql(c.version()),
+            ConnectorTag::MongoDb(c) => ConnectorVersion::MongoDb(c.version()),
+            ConnectorTag::Sqlite(_) => ConnectorVersion::Sqlite,
+            ConnectorTag::Vitess(c) => ConnectorVersion::Vitess(c.version()),
+        }
+    }
+}
+
+impl fmt::Display for ConnectorVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let printable = match self {
+            Self::SqlServer(_) => "SQL Server",
+            Self::Postgres(_) => "PostgreSQL",
+            Self::MySql(_) => "MySQL",
+            Self::MongoDb(_) => "MongoDB",
+            Self::Sqlite => "SQLite",
+            Self::Vitess(_) => "Vitess",
+        };
+
+        write!(f, "{}", printable)
+    }
+}
+
 impl fmt::Display for ConnectorTag {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let printable = match self {
-            ConnectorTag::SqlServer(_) => "SQL Server",
-            ConnectorTag::Postgres(_) => "PostgreSQL",
-            ConnectorTag::MySql(_) => "MySQL",
-            ConnectorTag::MongoDb(_) => "MongoDB",
-            ConnectorTag::Sqlite(_) => "SQLite",
-            ConnectorTag::Vitess(_) => "Vitess",
+            Self::SqlServer(_) => "SQL Server",
+            Self::Postgres(_) => "PostgreSQL",
+            Self::MySql(_) => "MySQL",
+            Self::MongoDb(_) => "MongoDB",
+            Self::Sqlite(_) => "SQLite",
+            Self::Vitess(_) => "Vitess",
         };
 
         write!(f, "{}", printable)

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mod.rs
@@ -110,24 +110,24 @@ impl fmt::Display for ConnectorVersion {
         let printable = match self {
             Self::SqlServer(v) => match v {
                 Some(v) => format!("SQL Server ({})", v.to_string()),
-                None => format!("SQL Server (unknown)"),
+                None => "SQL Server (unknown)".to_string(),
             },
             Self::Postgres(v) => match v {
                 Some(v) => format!("PostgreSQL ({})", v.to_string()),
-                None => format!("PostgreSQL (unknown)"),
+                None => "PostgreSQL (unknown)".to_string(),
             },
             Self::MySql(v) => match v {
                 Some(v) => format!("MySQL ({})", v.to_string()),
-                None => format!("MySQL (unknown)"),
+                None => "MySQL (unknown)".to_string(),
             },
             Self::MongoDb(v) => match v {
                 Some(v) => format!("MongoDB ({})", v.to_string()),
-                None => format!("MongoDB (unknown)"),
+                None => "MongoDB (unknown)".to_string(),
             },
             Self::Sqlite => "SQLite".to_string(),
             Self::Vitess(v) => match v {
                 Some(v) => format!("Vitess ({})", v.to_string()),
-                None => format!("Vitess (unknown)"),
+                None => "Vitess (unknown)".to_string(),
             },
         };
 

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mongodb.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mongodb.rs
@@ -107,6 +107,11 @@ impl MongoDbConnectorTag {
             },
         ]
     }
+
+    /// Get a reference to the mongo db connector tag's version.
+    pub fn version(&self) -> Option<MongoDbVersion> {
+        self.version
+    }
 }
 
 impl PartialEq for MongoDbConnectorTag {

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mysql.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mysql.rs
@@ -11,8 +11,8 @@ pub struct MySqlConnectorTag {
 
 impl MySqlConnectorTag {
     /// Get a reference to the MySQL connector tag's version.
-    pub fn version(&self) -> Option<&MySqlVersion> {
-        self.version.as_ref()
+    pub fn version(&self) -> Option<MySqlVersion> {
+        self.version
     }
 }
 

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/postgres.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/postgres.rs
@@ -154,6 +154,11 @@ impl PostgresConnectorTag {
             },
         ]
     }
+
+    /// Get a reference to the postgres connector tag's version.
+    pub fn version(&self) -> Option<PostgresVersion> {
+        self.version
+    }
 }
 
 impl PartialEq for PostgresConnectorTag {

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/sql_server.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/sql_server.rs
@@ -79,6 +79,11 @@ impl SqlServerConnectorTag {
             },
         ]
     }
+
+    /// Get a reference to the sql server connector tag's version.
+    pub fn version(&self) -> Option<SqlServerVersion> {
+        self.version
+    }
 }
 
 impl PartialEq for SqlServerConnectorTag {

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/vitess.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/vitess.rs
@@ -78,6 +78,11 @@ impl VitessConnectorTag {
             },
         ]
     }
+
+    /// Get a reference to the vitess connector tag's version.
+    pub fn version(&self) -> Option<VitessVersion> {
+        self.version
+    }
 }
 
 impl PartialEq for VitessConnectorTag {

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/direct.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/direct.rs
@@ -6,7 +6,7 @@ use std::{env, sync::Arc};
 
 pub(crate) type Executor = Box<dyn QueryExecutor + Send + Sync>;
 
-/// Direct engine runner.
+/// Direct engine runner.   
 pub struct DirectRunner {
     executor: Executor,
     query_schema: QuerySchemaRef,

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/mod.rs
@@ -7,7 +7,7 @@ pub use direct::*;
 pub use node_api::*;
 use query_core::{QueryExecutor, TxId};
 
-use crate::{ConnectorTag, QueryResult, TestError, TestResult};
+use crate::{ConnectorTag, ConnectorVersion, QueryResult, TestError, TestResult};
 use colored::*;
 
 #[async_trait::async_trait]
@@ -94,6 +94,14 @@ impl Runner {
     pub fn connector(&self) -> &ConnectorTag {
         match self {
             Runner::Direct(r) => r.connector(),
+            Runner::NodeApi(_) => todo!(),
+            Runner::Binary(_) => todo!(),
+        }
+    }
+
+    pub fn connector_version(&self) -> ConnectorVersion {
+        match self {
+            Runner::Direct(r) => ConnectorVersion::from(r.connector()),
             Runner::NodeApi(_) => todo!(),
             Runner::Binary(_) => todo!(),
         }


### PR DESCRIPTION
## Overview

- Add a new `ConnectorVersion` enum
- Refactor `match_connector_result` macro to use a simpler match statement
- Remove some unnecessary clutter in the match bodies
- Exclude some tests that had wrong assertions