### PR TITLE
Fix list_databases for SQLite on Windows in introspection-engine

### DIFF
--- a/libs/sql-schema-describer/src/sqlite.rs
+++ b/libs/sql-schema-describer/src/sqlite.rs
@@ -6,7 +6,7 @@ use crate::{
     Table, View,
 };
 use quaint::{ast::Value, prelude::Queryable};
-use std::{any::type_name, borrow::Cow, collections::BTreeMap, convert::TryInto, fmt::Debug};
+use std::{any::type_name, borrow::Cow, collections::BTreeMap, convert::TryInto, fmt::Debug, path::Path};
 use tracing::trace;
 
 pub struct SqlSchemaDescriber<'a> {
@@ -104,7 +104,11 @@ impl<'a> SqlSchemaDescriber<'a> {
             .map(|row| {
                 row.get("file")
                     .and_then(|x| x.to_string())
-                    .and_then(|x| x.split('/').last().map(|x| x.to_string()))
+                    .and_then(|x| {
+                        Path::new(&x)
+                            .file_name()
+                            .map(|name| name.to_string_lossy().into_owned())
+                    })
                     .expect("convert schema names")
             })
             .collect();


### PR DESCRIPTION
Use `std::path::Path::file_name` instead of manually splitting the database file path by `/`.

This fixes a `@prisma/sdk` test failing on Windows on TypeScript side:

```
FAIL src/__tests__/introspection/introspection.test.ts
  × introspection basic (39 ms)

  ● introspection basic

    expect(received).toMatchInlineSnapshot(snapshot)

    Snapshot name: `introspection basic 3`

    - Snapshot  - 1
    + Received  + 1

      Array [
    -   "blog.db",
    +   "D:\\a\\prisma\\prisma\\packages\\sdk\\src\\__tests__\\introspection\\blog.db",
      ]

      56 |   `)
      57 |   const databases = await engine.listDatabases(schema)
    > 58 |   expect(databases).toMatchInlineSnapshot(`
         |                     ^
      59 |     Array [
      60 |       "blog.db",
      61 |     ]

      at Object.<anonymous> (src/__tests__/introspection/introspection.test.ts:58:21)

 › 1 snapshot failed.
```

Ref: https://github.com/prisma/prisma/pull/10526