### PR TITLE
Allow broken links in prisma-models docs

### DIFF
--- a/query-engine/prisma-models/src/lib.rs
+++ b/query-engine/prisma-models/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(warnings)]
+#![allow(rustdoc::broken_intra_doc_links)]
 #![allow(clippy::from_over_into)]
 
 mod builders;


### PR DESCRIPTION
This is so the rustdocs action that publishes the docs for all of
engines works again. Example failed run: https://github.com/prisma/prisma-engines/runs/4434580223?check_suite_focus=true