### PR TITLE
fix(qe): order by + pagination tests on sql & sqlite

### DIFF
--- a/query-engine/connectors/query-connector/src/query_arguments.rs
+++ b/query-engine/connectors/query-connector/src/query_arguments.rs
@@ -138,6 +138,14 @@ impl QueryArguments {
             .iter()
             .any(|o| o.field.unique() && o.path.iter().all(|r| r.relation().is_one_to_one()));
 
+        let has_optional_relation = on_relation
+            .iter()
+            .any(|o| o.path.iter().any(|r| r.arity == dml::FieldArity::Optional));
+
+        if has_optional_relation {
+            return false;
+        }
+
         source_contains_unique || order_by_contains_unique_index || relations_contain_1to1_unique
     }
 


### PR DESCRIPTION
## Overview

Closes #2296

When performing order bys on optional relations, even though the cursor might be stable, `NULL`s can get themselves into the result because of the joins. This requires post-processing the result set in memory to pin the cursor. Concretely, it means leading `NULL`s should be truncated from the result in the following cases:
- On MySQL and SQLite, `NULL`s are put first by default on ASC.
- It is the opposite on Postgres. `NULL`s are put first on DESC

**Note**: We might want to discuss always putting `NULL`s last with `ORDER BY NULLS LAST` on all connectors that support it (known: pg, mysql, sqlite). This would ensure:
- Consistency across SQL connectors
- Always getting `NULL`s in the result sets, which might be valuable for the users