### PR TITLE
 Internalize ReferentialAction and ScalarType in ParserDatabase 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2836,6 +2836,7 @@ dependencies = [
  "chrono",
  "diagnostics",
  "dml",
+ "enumflags2",
  "schema-ast",
 ]
 

--- a/libs/datamodel/connectors/datamodel-connector/src/empty_connector.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/empty_connector.rs
@@ -1,5 +1,4 @@
-use crate::{connector_error::ConnectorError, Connector, ConnectorCapability};
-use dml::relation_info::ReferentialAction;
+use crate::{connector_error::ConnectorError, Connector, ConnectorCapability, ReferentialAction, ScalarType};
 use enumflags2::BitFlags;
 
 /// A [Connector](/trait.Connector.html) implementor meant to
@@ -27,22 +26,22 @@ impl Connector for EmptyDatamodelConnector {
         usize::MAX
     }
 
-    fn available_native_type_constructors(&self) -> &'static [dml::native_type_constructor::NativeTypeConstructor] {
+    fn available_native_type_constructors(&self) -> &'static [crate::native_type_constructor::NativeTypeConstructor] {
         &[]
     }
 
-    fn scalar_type_for_native_type(&self, _native_type: serde_json::Value) -> dml::scalars::ScalarType {
-        dml::scalars::ScalarType::String
+    fn scalar_type_for_native_type(&self, _native_type: serde_json::Value) -> ScalarType {
+        ScalarType::String
     }
 
-    fn default_native_type_for_scalar_type(&self, _scalar_type: &dml::scalars::ScalarType) -> serde_json::Value {
+    fn default_native_type_for_scalar_type(&self, _scalar_type: &ScalarType) -> serde_json::Value {
         serde_json::Value::Null
     }
 
     fn native_type_is_default_for_scalar_type(
         &self,
         _native_type: serde_json::Value,
-        _scalar_type: &dml::scalars::ScalarType,
+        _scalar_type: &ScalarType,
     ) -> bool {
         false
     }

--- a/libs/datamodel/connectors/datamodel-connector/src/lib.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/lib.rs
@@ -5,22 +5,22 @@ pub mod helper;
 pub mod walker_ext_traits;
 
 mod empty_connector;
+mod native_type_constructor;
 mod referential_integrity;
 
 pub use diagnostics::connector_error;
 pub use empty_connector::EmptyDatamodelConnector;
-pub use parser_database;
+pub use native_type_constructor::NativeTypeConstructor;
+pub use parser_database::{self, ReferentialAction, ScalarType};
 pub use referential_integrity::ReferentialIntegrity;
 
 use crate::connector_error::{ConnectorError, ConnectorErrorFactory, ErrorKind};
-use dml::{
-    native_type_constructor::NativeTypeConstructor, native_type_instance::NativeTypeInstance,
-    relation_info::ReferentialAction, scalars::ScalarType,
-};
+use dml::native_type_instance::NativeTypeInstance;
 use enumflags2::BitFlags;
 use std::{borrow::Cow, collections::BTreeMap, str::FromStr};
 
 pub trait Connector: Send + Sync {
+    /// The name of the connector. Can be used in error messages.
     fn name(&self) -> &str;
 
     fn capabilities(&self) -> &'static [ConnectorCapability];

--- a/libs/datamodel/connectors/datamodel-connector/src/native_type_constructor.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/native_type_constructor.rs
@@ -1,7 +1,6 @@
-use super::scalars::ScalarType;
+use crate::ScalarType;
 
-/// represents an available native type
-#[derive(serde::Serialize)]
+/// Represents an available native type.
 pub struct NativeTypeConstructor {
     /// The name that is used in the Prisma schema when declaring the native type
     pub name: &'static str,

--- a/libs/datamodel/connectors/datamodel-connector/src/referential_integrity.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/referential_integrity.rs
@@ -1,7 +1,6 @@
-use std::fmt;
-
-use dml::relation_info::ReferentialAction;
+use crate::ReferentialAction;
 use enumflags2::{bitflags, BitFlags};
+use std::fmt;
 
 /// Defines the part of the stack where referential actions are handled.
 #[bitflags]

--- a/libs/datamodel/connectors/dml/src/lib.rs
+++ b/libs/datamodel/connectors/dml/src/lib.rs
@@ -7,7 +7,6 @@ pub mod default_value;
 pub mod r#enum;
 pub mod field;
 pub mod model;
-pub mod native_type_constructor;
 pub mod native_type_instance;
 pub mod relation_info;
 pub mod scalars;

--- a/libs/datamodel/connectors/dml/src/relation_info.rs
+++ b/libs/datamodel/connectors/dml/src/relation_info.rs
@@ -86,10 +86,3 @@ impl fmt::Display for ReferentialAction {
         }
     }
 }
-
-impl ReferentialAction {
-    // True, if the action modifies the related items.
-    pub fn triggers_modification(self) -> bool {
-        !matches!(self, Self::NoAction | Self::Restrict)
-    }
-}

--- a/libs/datamodel/connectors/mongodb-datamodel-connector/src/lib.rs
+++ b/libs/datamodel/connectors/mongodb-datamodel-connector/src/lib.rs
@@ -2,12 +2,10 @@ mod mongodb_types;
 
 use datamodel_connector::{
     connector_error::{ConnectorError, ErrorKind},
-    parser_database, Connector, ConnectorCapability, ReferentialIntegrity,
+    parser_database, Connector, ConnectorCapability, NativeTypeConstructor, ReferentialAction, ReferentialIntegrity,
+    ScalarType,
 };
-use dml::{
-    default_value::DefaultKind, native_type_instance::NativeTypeInstance, relation_info::ReferentialAction,
-    scalars::ScalarType,
-};
+use dml::{default_value::DefaultKind, native_type_instance::NativeTypeInstance};
 use enumflags2::BitFlags;
 use mongodb_types::*;
 use native_types::MongoDbType;
@@ -115,20 +113,16 @@ impl Connector for MongoDbDatamodelConnector {
         }
     }
 
-    fn available_native_type_constructors(&self) -> &'static [dml::native_type_constructor::NativeTypeConstructor] {
+    fn available_native_type_constructors(&self) -> &'static [NativeTypeConstructor] {
         NATIVE_TYPE_CONSTRUCTORS
     }
 
-    fn default_native_type_for_scalar_type(&self, scalar_type: &dml::scalars::ScalarType) -> serde_json::Value {
+    fn default_native_type_for_scalar_type(&self, scalar_type: &ScalarType) -> serde_json::Value {
         let native_type = default_for(scalar_type);
         serde_json::to_value(native_type).expect("MongoDB native type to JSON failed")
     }
 
-    fn native_type_is_default_for_scalar_type(
-        &self,
-        native_type: serde_json::Value,
-        scalar_type: &dml::scalars::ScalarType,
-    ) -> bool {
+    fn native_type_is_default_for_scalar_type(&self, native_type: serde_json::Value, scalar_type: &ScalarType) -> bool {
         let default_native_type = default_for(scalar_type);
         let native_type: MongoDbType =
             serde_json::from_value(native_type).expect("MongoDB native type from JSON failed");
@@ -154,7 +148,7 @@ impl Connector for MongoDbDatamodelConnector {
         todo!()
     }
 
-    fn scalar_type_for_native_type(&self, _native_type: serde_json::Value) -> dml::scalars::ScalarType {
+    fn scalar_type_for_native_type(&self, _native_type: serde_json::Value) -> ScalarType {
         // Out of scope for MVP
         todo!()
     }

--- a/libs/datamodel/connectors/mongodb-datamodel-connector/src/mongodb_types.rs
+++ b/libs/datamodel/connectors/mongodb-datamodel-connector/src/mongodb_types.rs
@@ -1,5 +1,7 @@
-use datamodel_connector::connector_error::{ConnectorError, ErrorKind};
-use dml::{native_type_constructor::NativeTypeConstructor, scalars::ScalarType};
+use datamodel_connector::{
+    connector_error::{ConnectorError, ErrorKind},
+    NativeTypeConstructor, ScalarType,
+};
 use native_types::MongoDbType;
 use once_cell::sync::Lazy;
 use std::collections::HashMap;

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/cockroach_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/cockroach_datamodel_connector.rs
@@ -1,12 +1,10 @@
 use datamodel_connector::{
     connector_error::ConnectorError,
     helper::{arg_vec_from_opt, args_vec_from_opt, parse_one_opt_u32, parse_two_opt_u32},
-    parser_database, Connector, ConnectorCapability, ConstraintScope, ReferentialIntegrity,
+    parser_database, Connector, ConnectorCapability, ConstraintScope, NativeTypeConstructor, ReferentialAction,
+    ReferentialIntegrity, ScalarType,
 };
-use dml::{
-    native_type_constructor::NativeTypeConstructor, native_type_instance::NativeTypeInstance,
-    relation_info::ReferentialAction, scalars::ScalarType,
-};
+use dml::native_type_instance::NativeTypeInstance;
 use enumflags2::BitFlags;
 use native_types::CockroachType::{self, *};
 

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/mssql_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/mssql_datamodel_connector.rs
@@ -1,14 +1,11 @@
-use datamodel_connector::helper::{arg_vec_from_opt, args_vec_from_opt, parse_one_opt_u32, parse_two_opt_u32};
 use datamodel_connector::{
     connector_error::{ConnectorError, ErrorKind},
-    parser_database,
+    helper::{arg_vec_from_opt, args_vec_from_opt, parse_one_opt_u32, parse_two_opt_u32},
+    parser_database::{self, ScalarType},
     walker_ext_traits::*,
-    Connector, ConnectorCapability, ConstraintScope, ReferentialIntegrity,
+    Connector, ConnectorCapability, ConstraintScope, NativeTypeConstructor, ReferentialAction, ReferentialIntegrity,
 };
-use dml::{
-    native_type_constructor::NativeTypeConstructor, native_type_instance::NativeTypeInstance,
-    relation_info::ReferentialAction, scalars::ScalarType,
-};
+use dml::native_type_instance::NativeTypeInstance;
 use enumflags2::BitFlags;
 use native_types::{MsSqlType, MsSqlTypeParameter};
 use once_cell::sync::Lazy;

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
@@ -3,12 +3,10 @@ use datamodel_connector::{
     helper::{args_vec_from_opt, parse_one_opt_u32, parse_one_u32, parse_two_opt_u32},
     parser_database::walkers::ModelWalker,
     walker_ext_traits::*,
-    Connector, ConnectorCapability, ConstraintScope, ReferentialIntegrity,
+    Connector, ConnectorCapability, ConstraintScope, NativeTypeConstructor, ReferentialAction, ReferentialIntegrity,
+    ScalarType,
 };
-use dml::{
-    native_type_constructor::NativeTypeConstructor, native_type_instance::NativeTypeInstance,
-    relation_info::ReferentialAction, scalars::ScalarType,
-};
+use dml::native_type_instance::NativeTypeInstance;
 use enumflags2::BitFlags;
 use native_types::MySqlType::{self, *};
 
@@ -248,7 +246,7 @@ impl Connector for MySqlDatamodelConnector {
             VarChar(length) if length > 65535 => {
                 errors.push(error.new_argument_m_out_of_range_error("M can range from 0 to 65,535."))
             }
-            Bit(n) if n > 1 && scalar_type.is_boolean() => {
+            Bit(n) if n > 1 && matches!(scalar_type, ScalarType::Boolean) => {
                 errors.push(error.new_argument_m_out_of_range_error("only Bit(1) can be used as Boolean."))
             }
             _ => (),

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
@@ -3,12 +3,10 @@ use datamodel_connector::{
     helper::{arg_vec_from_opt, args_vec_from_opt, parse_one_opt_u32, parse_two_opt_u32},
     parser_database::walkers::ModelWalker,
     walker_ext_traits::*,
-    Connector, ConnectorCapability, ConstraintScope, ReferentialIntegrity,
+    Connector, ConnectorCapability, ConstraintScope, NativeTypeConstructor, ReferentialAction, ReferentialIntegrity,
+    ScalarType,
 };
-use dml::{
-    native_type_constructor::NativeTypeConstructor, native_type_instance::NativeTypeInstance,
-    relation_info::ReferentialAction, scalars::ScalarType,
-};
+use dml::native_type_instance::NativeTypeInstance;
 use enumflags2::BitFlags;
 use native_types::PostgresType::{self, *};
 

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/sqlite_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/sqlite_datamodel_connector.rs
@@ -1,9 +1,9 @@
 use datamodel_connector::ConstraintScope;
-use datamodel_connector::{connector_error::ConnectorError, Connector, ConnectorCapability, ReferentialIntegrity};
-use dml::{
-    native_type_constructor::NativeTypeConstructor, native_type_instance::NativeTypeInstance,
-    relation_info::ReferentialAction, scalars::ScalarType,
+use datamodel_connector::{
+    connector_error::ConnectorError, parser_database::ScalarType, Connector, ConnectorCapability,
+    NativeTypeConstructor, ReferentialAction, ReferentialIntegrity,
 };
+use dml::native_type_instance::NativeTypeInstance;
 use enumflags2::BitFlags;
 use std::borrow::Cow;
 

--- a/libs/datamodel/core/src/dml/mod.rs
+++ b/libs/datamodel/core/src/dml/mod.rs
@@ -3,7 +3,6 @@ pub use dml::datamodel::*;
 pub use dml::default_value::*;
 pub use dml::field::*;
 pub use dml::model::*;
-pub use dml::native_type_constructor::*;
 pub use dml::native_type_instance::*;
 pub use dml::r#enum::*;
 pub use dml::relation_info::*;

--- a/libs/datamodel/core/src/lib.rs
+++ b/libs/datamodel/core/src/lib.rs
@@ -84,6 +84,7 @@ mod transform;
 
 pub use crate::dml::*;
 pub use configuration::{Configuration, Datasource, Generator, StringFromEnvVar};
+pub use datamodel_connector;
 pub use diagnostics;
 pub use parser_database::is_reserved_type_name;
 

--- a/libs/datamodel/core/src/transform/ast_to_dml/lift.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/lift.rs
@@ -73,13 +73,18 @@ impl<'a> LiftAstToDml<'a> {
         let referential_integrity = self.referential_integrity;
         let common_dml_fields = |field: &mut dml::RelationField, relation_field: RelationFieldWalker<'_, '_>| {
             let ast_field = relation_field.ast_field();
-            field.relation_info.on_delete = relation_field.explicit_on_delete();
-            field.relation_info.on_update = relation_field.explicit_on_update();
+            field.relation_info.on_delete = relation_field
+                .explicit_on_delete()
+                .map(parser_database_referential_action_to_dml_referential_action);
+            field.relation_info.on_update = relation_field
+                .explicit_on_update()
+                .map(parser_database_referential_action_to_dml_referential_action);
             field.relation_info.name = relation_field.relation_name().to_string();
             field.documentation = ast_field.documentation.clone().map(|comment| comment.text);
             field.is_ignored = relation_field.is_ignored();
             field.supports_restrict_action(
-                active_connector.supports_referential_action(&referential_integrity, dml::ReferentialAction::Restrict),
+                active_connector
+                    .supports_referential_action(&referential_integrity, parser_database::ReferentialAction::Restrict),
             );
             field.emulates_referential_actions(referential_integrity.is_prisma());
         };
@@ -418,7 +423,11 @@ impl<'a> LiftAstToDml<'a> {
                 let native_type = scalar_field
                     .raw_native_type()
                     .map(|(_, name, args, _)| self.connector.parse_native_type(name, args.to_owned()).unwrap());
-                dml::FieldType::Scalar(scalar_type.to_owned(), None, native_type)
+                dml::FieldType::Scalar(
+                    parser_database_scalar_type_to_dml_scalar_type(*scalar_type),
+                    None,
+                    native_type,
+                )
             }
         }
     }
@@ -429,7 +438,7 @@ impl<'a> LiftAstToDml<'a> {
                 CompositeTypeFieldType::CompositeType(self.db.ast()[*ctid].name.name.to_owned())
             }
             db::ScalarFieldType::BuiltInScalar(scalar_type) => {
-                CompositeTypeFieldType::Scalar(scalar_type.to_owned(), None, None)
+                CompositeTypeFieldType::Scalar(parser_database_scalar_type_to_dml_scalar_type(*scalar_type), None, None)
             }
             db::ScalarFieldType::Alias(_) | db::ScalarFieldType::Enum(_) | db::ScalarFieldType::Unsupported => {
                 unreachable!()
@@ -443,4 +452,20 @@ fn parser_database_sort_order_to_dml_sort_order(sort_order: parser_database::Sor
         parser_database::SortOrder::Asc => dml::SortOrder::Asc,
         parser_database::SortOrder::Desc => dml::SortOrder::Desc,
     }
+}
+
+fn parser_database_referential_action_to_dml_referential_action(
+    ra: parser_database::ReferentialAction,
+) -> dml::ReferentialAction {
+    match ra {
+        parser_database::ReferentialAction::Cascade => dml::ReferentialAction::Cascade,
+        parser_database::ReferentialAction::SetNull => dml::ReferentialAction::SetNull,
+        parser_database::ReferentialAction::SetDefault => dml::ReferentialAction::SetDefault,
+        parser_database::ReferentialAction::Restrict => dml::ReferentialAction::Restrict,
+        parser_database::ReferentialAction::NoAction => dml::ReferentialAction::NoAction,
+    }
+}
+
+fn parser_database_scalar_type_to_dml_scalar_type(st: parser_database::ScalarType) -> dml::ScalarType {
+    st.as_str().parse().unwrap()
 }

--- a/libs/datamodel/core/src/transform/ast_to_dml/mod.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/mod.rs
@@ -8,5 +8,6 @@ mod validation_pipeline;
 
 pub(crate) use datasource_loader::DatasourceLoader;
 pub(crate) use generator_loader::GeneratorLoader;
+pub(crate) use lift::LiftAstToDml;
 pub(crate) use parser_database as db;
 pub(crate) use validation_pipeline::validate;

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline.rs
@@ -1,54 +1,63 @@
 mod context;
 mod validations;
 
-use super::{db::ParserDatabase, lift::LiftAstToDml};
-use crate::{
-    ast, common::preview_features::PreviewFeature, configuration, diagnostics::Diagnostics, ValidatedDatamodel,
-};
-use datamodel_connector::EmptyDatamodelConnector;
+use crate::{ast, common::preview_features::PreviewFeature, configuration, diagnostics::Diagnostics};
+use datamodel_connector::{Connector, EmptyDatamodelConnector, ReferentialIntegrity};
 use enumflags2::BitFlags;
+use parser_database::ParserDatabase;
 
-/// Validates an AST semantically and promotes it to a datamodel/schema.
+pub(crate) struct ValidateOutput<'ast> {
+    pub(crate) db: ParserDatabase<'ast>,
+    pub(crate) diagnostics: Diagnostics,
+    pub(crate) referential_integrity: ReferentialIntegrity,
+    pub(crate) connector: &'static dyn Connector,
+}
+
+/// Analyze and validate a schema AST.
 ///
 /// This will attempt to
 ///
 /// * Resolve all attributes
 /// * Resolve and check default values
 /// * Resolve and check all field types
+/// * ...
 /// * Validate the schema
-pub(crate) fn validate(
-    ast_schema: &ast::SchemaAst,
+pub(crate) fn validate<'ast>(
+    ast_schema: &'ast ast::SchemaAst,
     sources: &[configuration::Datasource],
     preview_features: BitFlags<PreviewFeature>,
+    diagnostics: Diagnostics,
     relation_transformation_enabled: bool,
-) -> Result<ValidatedDatamodel, Diagnostics> {
+) -> ValidateOutput<'ast> {
     let source = sources.first();
-    let diagnostics = Diagnostics::new();
     let connector = source.map(|s| s.active_connector).unwrap_or(&EmptyDatamodelConnector);
     let referential_integrity = source.map(|s| s.referential_integrity()).unwrap_or_default();
 
     // Make sense of the AST.
-    let (db, mut diagnostics) = ParserDatabase::new(ast_schema, diagnostics);
+    let (db, diagnostics) = ParserDatabase::new(ast_schema, diagnostics);
+
+    let mut output = ValidateOutput {
+        db,
+        diagnostics,
+        referential_integrity,
+        connector,
+    };
 
     // Early return so that the validator does not have to deal with invalid schemas
-    diagnostics.to_result()?;
+    if !output.diagnostics.errors().is_empty() {
+        return output;
+    }
 
     let mut context = context::Context {
-        db: &db,
+        db: &output.db,
         datasource: source,
         preview_features,
         connector,
         referential_integrity,
-        diagnostics: &mut diagnostics,
+        diagnostics: &mut output.diagnostics,
     };
 
     validations::validate(&mut context, relation_transformation_enabled);
-    diagnostics.to_result()?;
 
-    let schema = LiftAstToDml::new(&db, connector, referential_integrity).lift();
-
-    Ok(ValidatedDatamodel {
-        subject: schema,
-        warnings: diagnostics.warnings().to_owned(),
-    })
+    output
 }

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/relation_fields.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/relation_fields.rs
@@ -2,7 +2,10 @@ use crate::{
     ast,
     diagnostics::DatamodelError,
     transform::ast_to_dml::{
-        db::walkers::{ModelWalker, RelationFieldWalker, RelationName},
+        db::{
+            walkers::{ModelWalker, RelationFieldWalker, RelationName},
+            ReferentialAction,
+        },
         validation_pipeline::context::Context,
     },
 };
@@ -140,16 +143,17 @@ pub(super) fn ignored_related_model(field: RelationFieldWalker<'_, '_>, ctx: &mu
 pub(super) fn referential_actions(field: RelationFieldWalker<'_, '_>, ctx: &mut Context<'_>) {
     let connector = ctx.connector;
     let referential_integrity = ctx.referential_integrity;
-    let msg = |action| {
+    let msg = |action: ReferentialAction| {
         let allowed_values = connector
             .referential_actions(&referential_integrity)
             .iter()
-            .map(|f| format!("`{}`", f))
+            .map(|f| format!("`{}`", f.as_str()))
             .join(", ");
 
         format!(
             "Invalid referential action: `{}`. Allowed values: ({})",
-            action, allowed_values,
+            action.as_str(),
+            allowed_values,
         )
     };
 

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/relations.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/relations.rs
@@ -460,14 +460,16 @@ fn cascade_error_with_default_values(
         (Some(on_delete), Some(on_update)) => {
             format!(
                 "{} (Implicit default `onDelete`: `{}`, and `onUpdate`: `{}`)",
-                msg, on_delete, on_update
+                msg,
+                on_delete.as_str(),
+                on_update.as_str()
             )
         }
         (Some(on_delete), None) => {
-            format!("{} (Implicit default `onDelete`: `{}`)", msg, on_delete)
+            format!("{} (Implicit default `onDelete`: `{}`)", msg, on_delete.as_str())
         }
         (None, Some(on_update)) => {
-            format!("{} (Implicit default `onUpdate`: `{}`)", msg, on_update)
+            format!("{} (Implicit default `onUpdate`: `{}`)", msg, on_update.as_str())
         }
         (None, None) => msg.to_string(),
     };

--- a/libs/datamodel/core/src/transform/dml_to_ast/lower_field.rs
+++ b/libs/datamodel/core/src/transform/dml_to_ast/lower_field.rs
@@ -54,10 +54,10 @@ impl<'a> LowerDmlToAst<'a> {
         attributes: &mut Vec<Attribute>,
         datasource: &Datasource,
     ) {
-        if datasource
-            .active_connector
-            .native_type_is_default_for_scalar_type(native_type.serialized_native_type.clone(), scalar_type)
-        {
+        if datasource.active_connector.native_type_is_default_for_scalar_type(
+            native_type.serialized_native_type.clone(),
+            &dml_scalar_type_to_parser_database_scalar_type(*scalar_type),
+        ) {
             return;
         }
 
@@ -282,5 +282,19 @@ impl<'a> LowerDmlToAst<'a> {
             PrismaValue::Bytes(b) => ast::Expression::StringValue(prisma_value::encode_bytes(b), ast::Span::empty()),
             PrismaValue::Object(_) => unreachable!(), // There's no concept of object values in the PSL right now.
         }
+    }
+}
+
+fn dml_scalar_type_to_parser_database_scalar_type(st: dml::ScalarType) -> parser_database::ScalarType {
+    match st {
+        dml::ScalarType::Int => parser_database::ScalarType::Int,
+        dml::ScalarType::BigInt => parser_database::ScalarType::BigInt,
+        dml::ScalarType::Float => parser_database::ScalarType::Float,
+        dml::ScalarType::Boolean => parser_database::ScalarType::Boolean,
+        dml::ScalarType::String => parser_database::ScalarType::String,
+        dml::ScalarType::DateTime => parser_database::ScalarType::DateTime,
+        dml::ScalarType::Json => parser_database::ScalarType::Json,
+        dml::ScalarType::Bytes => parser_database::ScalarType::Bytes,
+        dml::ScalarType::Decimal => parser_database::ScalarType::Decimal,
     }
 }

--- a/libs/datamodel/diagnostics/src/connector_error.rs
+++ b/libs/datamodel/diagnostics/src/connector_error.rs
@@ -145,7 +145,7 @@ pub enum ErrorKind {
     )]
     IncompatibleNativeType {
         native_type: String,
-        field_type: String,
+        field_type: &'static str,
         expected_types: String,
     },
 

--- a/libs/datamodel/parser-database/Cargo.toml
+++ b/libs/datamodel/parser-database/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2021"
 diagnostics = { path = "../diagnostics" }
 schema-ast = { path = "../schema-ast" }
 
+enumflags2 = "0.7"
+
 # We should strive to depend less and less on dml, until the dependency can be removed.
 dml = { path = "../connectors/dml" }
 

--- a/libs/datamodel/parser-database/src/attributes.rs
+++ b/libs/datamodel/parser-database/src/attributes.rs
@@ -179,7 +179,7 @@ fn visit_scalar_field_attributes<'ast>(
 
         // @updatedAt
         attributes.visit_optional_single("updatedAt", ctx, |args, ctx| {
-            if !matches!(scalar_field_data.r#type, ScalarFieldType::BuiltInScalar(tpe) if tpe.is_datetime()) {
+            if !matches!(scalar_field_data.r#type, ScalarFieldType::BuiltInScalar(crate::ScalarType::DateTime)) {
                 ctx.push_error(args.new_attribute_validation_error(
                     "Fields that are marked with @updatedAt must be of type DateTime." ));
 

--- a/libs/datamodel/parser-database/src/lib.rs
+++ b/libs/datamodel/parser-database/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! ## Scope
 //!
-//! The ParserDatbase is tasked with gathering information about the schema. It is _connector
+//! The ParserDatabase is tasked with gathering information about the schema. It is _connector
 //! agnostic_: it gathers information and performs generic validations, leaving connector-specific
 //! validations to later phases in datamodel core.
 //!
@@ -33,6 +33,7 @@ mod types;
 mod value_validator;
 
 pub use names::is_reserved_type_name;
+pub use relations::ReferentialAction;
 pub use schema_ast::ast;
 pub use types::{IndexAlgorithm, IndexType, ScalarFieldType, ScalarType, SortOrder};
 pub use value_validator::{ValueListValidator, ValueValidator};

--- a/libs/datamodel/parser-database/src/relations.rs
+++ b/libs/datamodel/parser-database/src/relations.rs
@@ -2,6 +2,7 @@ use crate::{
     ast,
     {context::Context, types::RelationField},
 };
+use enumflags2::bitflags;
 use std::collections::BTreeSet;
 
 /// Detect relation types and construct relation objects to the database.
@@ -306,4 +307,52 @@ pub(super) fn ingest_relation<'ast, 'db>(
         evidence.model_id,
         relation_idx,
     ));
+}
+
+/// Describes what happens when related nodes are deleted.
+#[repr(u8)]
+#[bitflags]
+#[derive(Debug, Copy, PartialEq, Clone)]
+pub enum ReferentialAction {
+    /// Deletes record if dependent record is deleted. Updates relation scalar
+    /// fields if referenced scalar fields of the dependent record are updated.
+    /// Prevents operation (both updates and deletes) from succeeding if any
+    /// records are connected.
+    Cascade,
+    /// Prevents operation (both updates and deletes) from succeeding if any
+    /// records are connected. This behavior will always result in a runtime
+    /// error for required relations.
+    Restrict,
+    /// Behavior is database specific. Either defers throwing an integrity check
+    /// error until the end of the transaction or errors immediately. If
+    /// deferred, this makes it possible to temporarily violate integrity in a
+    /// transaction while making sure that subsequent operations in the
+    /// transaction restore integrity.
+    NoAction,
+    /// Sets relation scalar fields to null if the relation is deleted or
+    /// updated. This will always result in a runtime error if one or more of the
+    /// relation scalar fields are required.
+    SetNull,
+    /// Sets relation scalar fields to their default values on update or delete
+    /// of relation. Will always result in a runtime error if no defaults are
+    /// provided for any relation scalar fields.
+    SetDefault,
+}
+
+impl ReferentialAction {
+    /// True if the action modifies the related items.
+    pub fn triggers_modification(self) -> bool {
+        !matches!(self, Self::NoAction | Self::Restrict)
+    }
+
+    /// The string representation of the referential action in the schema.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ReferentialAction::Cascade => "Cascade",
+            ReferentialAction::Restrict => "Restrict",
+            ReferentialAction::NoAction => "NoAction",
+            ReferentialAction::SetNull => "SetNull",
+            ReferentialAction::SetDefault => "SetDefault",
+        }
+    }
 }

--- a/libs/datamodel/parser-database/src/value_validator.rs
+++ b/libs/datamodel/parser-database/src/value_validator.rs
@@ -2,16 +2,14 @@
 
 use crate::{
     ast::{self, Expression, Span},
-    types::SortOrder,
+    relations::ReferentialAction,
+    types::{ScalarType, SortOrder},
 };
 use chrono::{DateTime, FixedOffset};
 use diagnostics::DatamodelError;
 use dml::{
     default_value::{DefaultValue, ValueGenerator},
-    prisma_value,
-    relation_info::ReferentialAction,
-    scalars::ScalarType,
-    PrismaValue,
+    prisma_value, PrismaValue,
 };
 use std::error;
 
@@ -279,7 +277,7 @@ impl<'a> ValueValidator<'a> {
                 let generator = self.get_value_generator(name.to_owned(), prisma_args)?;
 
                 generator
-                    .check_compatibility_with_scalar_type(scalar_type)
+                    .check_compatibility_with_scalar_type(scalar_type.as_str().parse().unwrap())
                     .map_err(|err_msg| DatamodelError::new_functional_evaluation_error(&err_msg, self.span()))?;
 
                 Ok(DefaultValue::new_expression(generator))

--- a/libs/datamodel/parser-database/src/walkers/relation.rs
+++ b/libs/datamodel/parser-database/src/walkers/relation.rs
@@ -1,9 +1,4 @@
-use super::{ModelWalker, RelationFieldWalker, RelationName, ScalarFieldWalker};
-use crate::{
-    ast,
-    {relations::*, ParserDatabase, ScalarFieldType},
-};
-use dml::relation_info::ReferentialAction;
+use crate::{ast, relations::*, walkers::*, ParserDatabase, ScalarFieldType};
 
 /// A relation that has the minimal amount of information for us to create one. Useful for
 /// validation purposes. Holds all possible relation types.

--- a/libs/datamodel/parser-database/src/walkers/relation_field.rs
+++ b/libs/datamodel/parser-database/src/walkers/relation_field.rs
@@ -2,9 +2,8 @@ use crate::{
     ast::{self, FieldArity},
     types::RelationField,
     walkers::{ModelWalker, ScalarFieldWalker},
-    ParserDatabase,
+    ParserDatabase, ReferentialAction,
 };
-use dml::relation_info::ReferentialAction;
 use std::{
     borrow::Cow,
     fmt,

--- a/libs/datamodel/parser-database/src/walkers/scalar_field.rs
+++ b/libs/datamodel/parser-database/src/walkers/scalar_field.rs
@@ -1,6 +1,6 @@
 use crate::{
     ast,
-    types::{FieldWithArgs, ScalarField, SortOrder},
+    types::{FieldWithArgs, ScalarField, ScalarType, SortOrder},
     walkers::ModelWalker,
     ParserDatabase, ScalarFieldType,
 };
@@ -119,7 +119,7 @@ impl<'ast, 'db> ScalarFieldWalker<'ast, 'db> {
     }
 
     /// The type of the field in case it is a scalar type (not an enum, not a composite type).
-    pub fn scalar_type(self) -> Option<dml::scalars::ScalarType> {
+    pub fn scalar_type(self) -> Option<ScalarType> {
         let mut tpe = &self.scalar_field.r#type;
 
         loop {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
@@ -273,7 +273,10 @@ fn column_for_scalar_field(field: &ScalarFieldWalker<'_>, flavour: &dyn SqlFlavo
                 auto_increment: false,
             }
         }
-        TypeWalker::Base(scalar_type) => (scalar_type, flavour.default_native_type_for_scalar_type(&scalar_type)),
+        TypeWalker::Base(scalar_type) => (
+            scalar_type,
+            flavour.default_native_type_for_scalar_type(&scalar_type.into()),
+        ),
         TypeWalker::NativeType(scalar_type, instance) => (scalar_type, instance.serialized_native_type.clone()),
         TypeWalker::Unsupported(description) => {
             let default = field.default_value().and_then(db_generated).map(|mut default| {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour.rs
@@ -4,9 +4,10 @@ mod postgres;
 mod sqlite;
 
 use datamodel::{
+    datamodel_connector::ScalarType,
     walkers::ModelWalker,
     walkers::{RelationFieldWalker, ScalarFieldWalker},
-    Datamodel, FieldArity, ReferentialAction, ScalarType,
+    Datamodel, FieldArity, ReferentialAction,
 };
 use sql_schema_describer::{self as sql, ColumnArity, ColumnType, ColumnTypeFamily};
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/mssql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/mssql.rs
@@ -1,8 +1,8 @@
 use super::SqlSchemaCalculatorFlavour;
 use crate::flavour::MssqlFlavour;
 use datamodel::{
+    datamodel_connector::ScalarType,
     walkers::{ModelWalker, RelationFieldWalker},
-    ScalarType,
 };
 use sql_schema_describer::{self as sql, ForeignKeyAction};
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/mysql.rs
@@ -1,8 +1,9 @@
 use super::SqlSchemaCalculatorFlavour;
 use crate::flavour::MysqlFlavour;
 use datamodel::{
+    datamodel_connector::ScalarType,
     walkers::{walk_scalar_fields, ScalarFieldWalker},
-    Datamodel, ScalarType,
+    Datamodel,
 };
 use sql_schema_describer as sql;
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/postgres.rs
@@ -1,6 +1,6 @@
 use super::SqlSchemaCalculatorFlavour;
 use crate::flavour::PostgresFlavour;
-use datamodel::{walkers::ScalarFieldWalker, Datamodel, ScalarType, WithDatabaseName};
+use datamodel::{datamodel_connector::ScalarType, walkers::ScalarFieldWalker, Datamodel, WithDatabaseName};
 use sql_schema_describer::{self as sql};
 
 impl SqlSchemaCalculatorFlavour for PostgresFlavour {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/sqlite.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/sqlite.rs
@@ -1,6 +1,6 @@
 use super::SqlSchemaCalculatorFlavour;
 use crate::flavour::SqliteFlavour;
-use datamodel::{walkers::ScalarFieldWalker, ScalarType};
+use datamodel::{datamodel_connector::ScalarType, walkers::ScalarFieldWalker};
 
 impl SqlSchemaCalculatorFlavour for SqliteFlavour {
     fn default_native_type_for_scalar_type(&self, scalar_type: &ScalarType) -> serde_json::Value {

--- a/prisma-fmt/src/native.rs
+++ b/prisma-fmt/src/native.rs
@@ -1,3 +1,5 @@
+use datamodel::datamodel_connector::NativeTypeConstructor;
+
 pub(crate) fn run(schema: &str) -> String {
     let validated_configuration = match datamodel::parse_configuration(schema) {
         Ok(validated_configuration) => validated_configuration,
@@ -10,6 +12,33 @@ pub(crate) fn run(schema: &str) -> String {
 
     let datasource = &validated_configuration.subject.datasources[0];
     let available_native_type_constructors = datasource.active_connector.available_native_type_constructors();
+    let available_native_type_constructors: Vec<SerializableNativeTypeConstructor> =
+        available_native_type_constructors.iter().map(From::from).collect();
 
-    serde_json::to_string(available_native_type_constructors).expect("Failed to render JSON")
+    serde_json::to_string(&available_native_type_constructors).expect("Failed to render JSON")
+}
+
+#[derive(serde::Serialize)]
+struct SerializableNativeTypeConstructor {
+    pub name: &'static str,
+    pub _number_of_args: usize,
+    pub _number_of_optional_args: usize,
+    pub prisma_types: Vec<&'static str>,
+}
+
+impl From<&NativeTypeConstructor> for SerializableNativeTypeConstructor {
+    fn from(nt: &NativeTypeConstructor) -> Self {
+        let NativeTypeConstructor {
+            name,
+            _number_of_args,
+            _number_of_optional_args,
+            prisma_types,
+        } = nt;
+        SerializableNativeTypeConstructor {
+            name,
+            _number_of_args: *_number_of_args,
+            _number_of_optional_args: *_number_of_optional_args,
+            prisma_types: prisma_types.iter().map(|st| st.as_str()).collect(),
+        }
+    }
 }


### PR DESCRIPTION
The last dependency on dml is for default values. We'll tackle that in a
 principled way in an upcoming PR, then we can simplify the dependency
 graph of libs/datamodel even more.

---

### Context for review

This is a continuation of https://github.com/prisma/migrations-team/issues/294

For a long time (since the introduction of native types and datamodel connector), we've had a complicated situation with dependencies in libs/datamodel. We are moving towards having a an easy, linear dependency graph, with each step building on the previous ones. Roughly: `diagnostics` -> `schema-ast` -> `parser-database` -> `datamodel-connector` -> `datamodel` (core). (see the graph in https://github.com/prisma/migrations-team/issues/294). (`diagnostics` is just the crate defining datamodel errors, it does nothing by itself).

Currently, parser-database still depends on the `dml` crate, but that comes optionally after `datamodel` (core) in the new organization. We want `parser-database` to depend only on `diagnostics` and `schema-ast`. This PR removes all the internal dependencies on dml in `parser-database`, except for the last big chunk around default value handling, which is left to a separate PR.