### PR TITLE
Validate no `fields` or `references` on back-relation field...

### DIFF
--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations.rs
@@ -134,6 +134,7 @@ pub(super) fn validate(ctx: &mut Context<'_>, relation_transformation_enabled: b
                         // Run these validations last to prevent validation spam.
                         relations::one_to_one::fields_references_mixups(relation, ctx);
                         relations::one_to_one::back_relation_arity_is_optional(relation, ctx);
+                        relations::one_to_one::fields_and_references_on_wrong_side(relation, ctx);
                     } else {
                         relations::one_to_many::both_sides_are_defined(relation, ctx);
                         relations::one_to_many::fields_and_references_are_defined(relation, ctx);

--- a/libs/datamodel/parser-database/src/walkers/relation_field.rs
+++ b/libs/datamodel/parser-database/src/walkers/relation_field.rs
@@ -80,6 +80,11 @@ impl<'ast, 'db> RelationFieldWalker<'ast, 'db> {
         self.relation_field.is_ignored
     }
 
+    /// Is the field required? (not optional, not list)
+    pub fn is_required(self) -> bool {
+        self.ast_field().arity.is_required()
+    }
+
     /// The model containing the field.
     pub fn model(self) -> ModelWalker<'ast, 'db> {
         ModelWalker {


### PR DESCRIPTION
...on one-to-one required relations.

closes https://github.com/prisma/prisma-engines/issues/2501