### PR TITLE
ci: Run CockroachDB QE tests on GH Actions

### DIFF
--- a/.github/workflows/query-engine.yml
+++ b/.github/workflows/query-engine.yml
@@ -72,3 +72,4 @@ jobs:
         env:
           CLICOLOR_FORCE: 1
           SIMPLE_TEST_MODE: 1
+

--- a/.github/workflows/query-engine.yml
+++ b/.github/workflows/query-engine.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
   pull_request:
+
 jobs:
   rust-vitess-tests:
     name: "Rust test suite: ${{ matrix.database }} on Linux"
@@ -12,8 +13,9 @@ jobs:
       fail-fast: false
       matrix:
         database:
-          - "vitess_5_7"
-          - "vitess_8_0"
+          #- "vitess_5_7"
+          #- "vitess_8_0"
+          - "cockroach"
 
     env:
       LOG_LEVEL: "info"
@@ -22,7 +24,7 @@ jobs:
       RUST_BACKTRACE: 1
       CLICOLOR_FORCE: 1
 
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, buildjet-32vcpu-ubuntu-2004]
     steps:
       - uses: actions/checkout@v2
 
@@ -42,6 +44,7 @@ jobs:
       #       target
       #     key: query-engine-rust-${{ runner.os }}-cargo-vitess-${{ matrix.version }}-${{ hashFiles('**/Cargo.lock') }}
 
-      - run: export WORKSPACE_ROOT=$(pwd) && cargo test --package query-engine-tests -- --test-threads=1
+      - run: export WORKSPACE_ROOT=$(pwd) && cargo test --package query-engine-tests #-- --test-threads=1
         env:
           CLICOLOR_FORCE: 1
+          SIMPLE_TEST_MODE: 1

--- a/.github/workflows/query-engine.yml
+++ b/.github/workflows/query-engine.yml
@@ -5,6 +5,13 @@ on:
       - master
   pull_request:
 
+env:
+  LOG_LEVEL: "info"
+  LOG_QUERIES: "y"
+  RUST_LOG_FORMAT: "devel"
+  RUST_BACKTRACE: 1
+  CLICOLOR_FORCE: 1
+      
 jobs:
   rust-vitess-tests:
     name: "Rust test suite: ${{ matrix.database }} on Linux"
@@ -13,18 +20,10 @@ jobs:
       fail-fast: false
       matrix:
         database:
-          #- "vitess_5_7"
-          #- "vitess_8_0"
-          - "cockroach"
+          - "vitess_5_7"
+          - "vitess_8_0"
 
-    env:
-      LOG_LEVEL: "info"
-      LOG_QUERIES: "y"
-      RUST_LOG_FORMAT: "devel"
-      RUST_BACKTRACE: 1
-      CLICOLOR_FORCE: 1
-
-    runs-on: [self-hosted, buildjet-32vcpu-ubuntu-2004]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 
@@ -44,7 +43,32 @@ jobs:
       #       target
       #     key: query-engine-rust-${{ runner.os }}-cargo-vitess-${{ matrix.version }}-${{ hashFiles('**/Cargo.lock') }}
 
-      - run: export WORKSPACE_ROOT=$(pwd) && cargo test --package query-engine-tests #-- --test-threads=1
+      - run: export WORKSPACE_ROOT=$(pwd) && cargo test --package query-engine-tests -- --test-threads=1
+        env:
+          CLICOLOR_FORCE: 1
+
+  rust-cockroach-tests:
+    name: "Rust test suite: ${{ matrix.database }} on Linux"
+
+    strategy:
+      fail-fast: false
+      matrix:
+        database:
+          - "cockroach"
+
+    runs-on: [self-hosted, buildjet-32vcpu-ubuntu-2004]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: "Start ${{ matrix.database }}"
+        run: make dev-${{ matrix.database }}
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          default: true
+
+      - run: export WORKSPACE_ROOT=$(pwd) && cargo test --package query-engine-tests
         env:
           CLICOLOR_FORCE: 1
           SIMPLE_TEST_MODE: 1


### PR DESCRIPTION
Add a Cockroach GH Actions job that is visible to external contributors (vs. Buildkite which is not).