### PR TITLE
query-engine-tests: fix output to match CockroachDB's NULLS FIRST

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent.rs
@@ -160,8 +160,6 @@ mod order_by_dependent {
             // Depends on how null values are handled.
             MongoDb(_) | Sqlite => vec![r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":null}},{"id":3,"b":null},{"id":1,"b":{"c":{"id":1}}}]}}"#],
             SqlServer(_) => vec![r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":2,"b":{"c":null}},{"id":1,"b":{"c":{"id":1}}}]}}"#],
-            // CockroachDB can order ModelA.id in any order if ModelC.b_id is NULL.
-            CockroachDb => vec![r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"id":1}}},{"id":3,"b":null},{"id":2,"b":{"c":null}}]}}"#],
             Postgres(_) => vec![r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"id":1}}},{"id":2,"b":{"c":null}},{"id":3,"b":null}]}}"#],
             _ => vec![
               r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":null}},{"id":3,"b":null},{"id":1,"b":{"c":{"id":1}}}]}}"#,
@@ -246,7 +244,7 @@ mod order_by_dependent {
             }
           }"#,
           MongoDb(_) | Sqlite => vec![r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":4,"b":null},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}}]}}"#],
-          MySql(_) => vec![
+          MySql(_) | CockroachDb => vec![
             r#"{"data":{"findManyModelA":[{"id":4,"b":null},{"id":3,"b":null},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}}]}}"#,
             r#"{"data":{"findManyModelA":[{"id":3,"b":null},{"id":4,"b":null},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}}]}}"#,
           ],
@@ -278,7 +276,7 @@ mod order_by_dependent {
               }
             }"#,
             MongoDb(_) | Sqlite => vec![r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":3,"b":null},{"id":4,"b":null}]}}"#],
-            MySql(_) => vec![
+            MySql(_) | CockroachDb => vec![
               r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":4,"b":null},{"id":3,"b":null}]}}"#,
               r#"{"data":{"findManyModelA":[{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":3,"b":null},{"id":4,"b":null}]}}"#,
             ],

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent_pagination.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent_pagination.rs
@@ -97,7 +97,7 @@ mod order_by_dependent_pag {
               }
             }"#,
             // Depends on how null values are handled.
-            MongoDb(_) | Sqlite | MySql(_) => vec![r#"{"data":{"findManyModelA":[{"id":1,"b":{"id":1}},{"id":2,"b":{"id":2}}]}}"#],
+            MongoDb(_) | Sqlite | MySql(_) | CockroachDb => vec![r#"{"data":{"findManyModelA":[{"id":1,"b":{"id":1}},{"id":2,"b":{"id":2}}]}}"#],
             _ => vec![r#"{"data":{"findManyModelA":[{"id":1,"b":{"id":1}},{"id":2,"b":{"id":2}},{"id":3,"b":null}]}}"#]
         );
 
@@ -166,7 +166,7 @@ mod order_by_dependent_pag {
               }
             }"#,
             // Depends on how null values are handled.
-            MongoDb(_) | Sqlite | MySql(_) => vec![r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"id":1}}}]}}"#],
+            MongoDb(_) | Sqlite | MySql(_) | CockroachDb => vec![r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"id":1}}}]}}"#],
             _ => vec![r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"id":1}}},{"id":2,"b":{"c":null}},{"id":3,"b":null}]}}"#]
         );
 
@@ -248,8 +248,7 @@ mod order_by_dependent_pag {
               }
             }"#,
             // Depends on how null values are handled.
-            MongoDb(_) | MySql(_) | Sqlite => vec![r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}}]}}"#],
-            CockroachDb => vec![r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":4,"b":null},{"id":3,"b":null}]}}"#],
+            MongoDb(_) | MySql(_) | Sqlite | CockroachDb => vec![r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}}]}}"#],
             _ => vec![r#"{"data":{"findManyModelA":[{"id":1,"b":{"c":{"a":{"id":3}}}},{"id":2,"b":{"c":{"a":{"id":4}}}},{"id":3,"b":null},{"id":4,"b":null}]}}"#]
         );
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/regressions/pagination_regression.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/regressions/pagination_regression.rs
@@ -92,7 +92,7 @@ mod pagination_regr {
             orderBy: [{ field: desc }, { id: asc }]
           ) { id }
           }"#,
-          Postgres(_) | CockroachDb => vec![r#"{"data":{"findManyTestModel":[{"id":4},{"id":5}]}}"#],
+          Postgres(_) => vec![r#"{"data":{"findManyTestModel":[{"id":4},{"id":5}]}}"#],
           _ => vec![r#"{"data":{"findManyTestModel":[{"id":4}]}}"#]
         );
 
@@ -118,7 +118,7 @@ mod pagination_regr {
             orderBy: [{ field: desc }, { id: asc }]
           ) { id }
           }"#,
-          Postgres(_) | CockroachDb => vec![r#"{"data":{"findManyTestModel":[{"id":2}]}}"#],
+          Postgres(_) => vec![r#"{"data":{"findManyTestModel":[{"id":2}]}}"#],
           _ => vec![r#"{"data":{"findManyTestModel":[{"id":2},{"id":1}]}}"#]
         );
 


### PR DESCRIPTION
Mostly following MySQL path here as we behave mostly the same - NULLS
are ordered FIRST and can be in any order.

closes #2507