### PR TITLE
Implement default validations without reference to DML in parser-database

### DIFF
--- a/.test_database_urls/mysql_mariadb
+++ b/.test_database_urls/mysql_mariadb
@@ -1,2 +1,2 @@
 export TEST_DATABASE_URL="mysql://root:prisma@localhost:3308"
-set -e TEST_SHADOW_DATABASE_URL
+unset TEST_SHADOW_DATABASE_URL

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2834,10 +2834,7 @@ dependencies = [
 name = "parser-database"
 version = "0.1.0"
 dependencies = [
- "bigdecimal",
- "chrono",
  "diagnostics",
- "dml",
  "enumflags2",
  "schema-ast",
 ]

--- a/libs/datamodel/README.md
+++ b/libs/datamodel/README.md
@@ -1,0 +1,24 @@
+# Prisma Schema Language implementation
+
+This directory contains the crates responsible for parsing, validating and
+formatting Prisma schemas. The entrypoint and what should be considered public
+API is [core](./core).
+
+## Organization
+
+The crate graph is moving towards a completely linear dependency graph:
+
+[schema-ast](./schema-ast) →
+[parser-database](./parser-database) →
+[datamodel-connector](./connectors/datamodel-connector) →
+[core](./core)
+
+[dml](./connectors/dml) is a separate data structure that can optionally be
+produced ("lifted") by [core](./core).
+
+We are getting close, but this is currently aspirational, and still in flux:
+- [datamodel-connector](./connectors/datamodel-connector) still depends on
+[dml](./connectors/dml) 
+- AST reformatting still depends on dml
+- The reexports from other crates should be more principled.
+

--- a/libs/datamodel/connectors/datamodel-connector/src/lib.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/lib.rs
@@ -74,7 +74,7 @@ pub trait Connector: Send + Sync {
         &self,
         _field_name: &str,
         _scalar_type: &ScalarType,
-        _default: Option<&dml::default_value::DefaultValue>,
+        _default: Option<&dml::default_value::DefaultKind>,
         _errors: &mut Vec<ConnectorError>,
     ) {
     }
@@ -393,6 +393,22 @@ impl ConstraintScope {
                 model_name
             )),
         }
+    }
+}
+
+/// (temporary) bridge between dml::scalars::ScalarType and parser_database::ScalarType. Avoid
+/// relying on this if you can.
+pub fn convert_from_scalar_type(st: dml::scalars::ScalarType) -> ScalarType {
+    match st {
+        dml::scalars::ScalarType::Int => ScalarType::Int,
+        dml::scalars::ScalarType::BigInt => ScalarType::BigInt,
+        dml::scalars::ScalarType::Float => ScalarType::Float,
+        dml::scalars::ScalarType::Boolean => ScalarType::Boolean,
+        dml::scalars::ScalarType::String => ScalarType::String,
+        dml::scalars::ScalarType::DateTime => ScalarType::DateTime,
+        dml::scalars::ScalarType::Json => ScalarType::Json,
+        dml::scalars::ScalarType::Bytes => ScalarType::Bytes,
+        dml::scalars::ScalarType::Decimal => ScalarType::Decimal,
     }
 }
 

--- a/libs/datamodel/connectors/dml/src/default_value.rs
+++ b/libs/datamodel/connectors/dml/src/default_value.rs
@@ -159,7 +159,7 @@ impl ValueGenerator {
     }
 
     pub fn new_dbgenerated(description: String) -> Self {
-        if description.trim_matches(char::from(0)).is_empty() {
+        if description.trim_matches('\0').is_empty() {
             ValueGenerator::new("dbgenerated".to_owned(), Vec::new()).unwrap()
         } else {
             ValueGenerator::new("dbgenerated".to_owned(), vec![PrismaValue::String(description)]).unwrap()

--- a/libs/datamodel/core/Cargo.toml
+++ b/libs/datamodel/core/Cargo.toml
@@ -14,6 +14,7 @@ diagnostics = { path = "../diagnostics" }
 parser-database = { path = "../parser-database" }
 
 bigdecimal = "0.2"
+chrono = { version = "0.4.6", default_features = false }
 itertools = "0.10"
 once_cell = "1.3.1"
 pest = "2.1.3"

--- a/libs/datamodel/core/src/transform/ast_to_dml/lift.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/lift.rs
@@ -355,7 +355,7 @@ impl<'a> LiftAstToDml<'a> {
             field.is_updated_at = scalar_field.is_updated_at();
             field.database_name = scalar_field.mapped_name().map(String::from);
             field.default_value = scalar_field.default_value().map(|d| dml::DefaultValue {
-                kind: d.default().kind().clone(),
+                kind: d.dml_default_kind(),
                 db_name: Some(d.constraint_name(self.connector).into())
                     .filter(|_| self.connector.supports_named_default_values()),
             });

--- a/libs/datamodel/core/tests/attributes/default_positive.rs
+++ b/libs/datamodel/core/tests/attributes/default_positive.rs
@@ -15,6 +15,9 @@ fn should_set_default_for_all_scalar_types() {
         string String @default("String")
         boolean Boolean @default(false)
         dateTime DateTime @default("2019-06-17T14:20:57Z")
+        bytes    Bytes @default("aGVsbG8gd29ybGQ=")
+        json     Json  @default("{ \"a\": [\"b\"] }")
+        decimal  Decimal  @default("121.10299000124800000001")
     }
     "#;
 
@@ -44,6 +47,22 @@ fn should_set_default_for_all_scalar_types() {
         .assert_base_type(&ScalarType::DateTime)
         .assert_default_value(DefaultValue::new_single(PrismaValue::DateTime(
             DateTime::parse_from_rfc3339("2019-06-17T14:20:57Z").unwrap(),
+        )));
+    user_model
+        .assert_has_scalar_field("bytes")
+        .assert_base_type(&ScalarType::Bytes)
+        .assert_default_value(DefaultValue::new_single(PrismaValue::Bytes(b"hello world".to_vec())));
+    user_model
+        .assert_has_scalar_field("json")
+        .assert_base_type(&ScalarType::Json)
+        .assert_default_value(DefaultValue::new_single(PrismaValue::Json(
+            r#"{ "a": ["b"] }"#.to_owned(),
+        )));
+    user_model
+        .assert_has_scalar_field("decimal")
+        .assert_base_type(&ScalarType::Decimal)
+        .assert_default_value(DefaultValue::new_single(PrismaValue::Float(
+            r#"121.10299000124800000001"#.parse().unwrap(),
         )));
 }
 

--- a/libs/datamodel/parser-database/Cargo.toml
+++ b/libs/datamodel/parser-database/Cargo.toml
@@ -8,12 +8,3 @@ diagnostics = { path = "../diagnostics" }
 schema-ast = { path = "../schema-ast" }
 
 enumflags2 = "0.7"
-
-# We should strive to depend less and less on dml, until the dependency can be removed.
-dml = { path = "../connectors/dml" }
-
-# We should strive to remove the dependencies below.
-
-# For ValueValidator
-bigdecimal = "0.2"
-chrono = { version = "0.4.6", features = ["serde"] }

--- a/libs/datamodel/parser-database/src/attributes/default.rs
+++ b/libs/datamodel/parser-database/src/attributes/default.rs
@@ -1,0 +1,224 @@
+use crate::{
+    ast::{self, WithName},
+    context::{Arguments, Context},
+    types::{DefaultAttribute, ScalarField, ScalarFieldType, ScalarType},
+    DatamodelError,
+};
+
+/// @default on scalar fields
+pub(super) fn visit_field_default<'ast>(
+    args: &mut Arguments<'ast>,
+    field_data: &mut ScalarField<'ast>,
+    model_id: ast::ModelId,
+    field_id: ast::FieldId,
+    ctx: &mut Context<'ast>,
+) {
+    let value = match args.default_arg("value") {
+        Ok(value) => value,
+        Err(err) => return ctx.push_error(err),
+    };
+
+    let ast_model = &ctx.db.ast[model_id];
+    let ast_field = &ast_model[field_id];
+    if ast_field.arity.is_list() {
+        return ctx.push_error(args.new_attribute_validation_error("Cannot set a default value on list field."));
+    }
+
+    let mapped_name = default_attribute_mapped_name(args, ctx);
+    let default_attribute = args.attribute();
+
+    let mut accept = || {
+        let default_value = DefaultAttribute {
+            value: value.value,
+            mapped_name,
+            default_attribute,
+        };
+
+        field_data.default = Some(default_value);
+    };
+
+    // Resolve the default to a DefaultValue. We must loop in order to
+    // resolve type aliases.
+    let mut r#type = field_data.r#type;
+
+    loop {
+        match r#type {
+            ScalarFieldType::CompositeType(ctid) => {
+                let ct_name = ctx.db.walk_composite_type(ctid).name();
+                ctx.push_error(DatamodelError::new_composite_type_field_validation_error(
+                    "Defaults inside composite types are not supported",
+                    ct_name,
+                    &ast_field.name.name,
+                    args.span(),
+                ));
+            }
+            ScalarFieldType::Enum(enum_id) => {
+                match value.value {
+                    ast::Expression::ConstantValue(enum_value, _) | ast::Expression::BooleanValue(enum_value, _) => {
+                        if ctx.db.ast[enum_id].values.iter().any(|v| v.name() == enum_value) {
+                            accept()
+                        } else {
+                            ctx.push_error(args.new_attribute_validation_error(
+                                "The defined default value is not a valid value of the enum specified for the field.",
+                            ))
+                        }
+                    }
+                    ast::Expression::Function(funcname, funcargs, _) if funcname == FN_DBGENERATED => {
+                        validate_dbgenerated_args(funcargs, args, accept, ctx);
+                    }
+                    value => ctx.push_error(args.new_attribute_validation_error(&format!(
+                        "Expected a an enum value, but found `{bad_value}`.",
+                        bad_value = value
+                    ))),
+                };
+            }
+            ScalarFieldType::BuiltInScalar(scalar_type) => {
+                validate_builtin_scalar_type_default(scalar_type, value.value, mapped_name, accept, args, ctx)
+            }
+            ScalarFieldType::Alias(alias_id) => {
+                r#type = ctx.db.types.type_aliases[&alias_id];
+                continue;
+            }
+            ScalarFieldType::Unsupported => {
+                match value.value {
+                    ast::Expression::Function(funcname, funcargs, _)
+                        if funcname == FN_DBGENERATED
+                            && matches!(funcargs.as_slice(), [ast::Expression::StringValue(_, _)]) =>
+                    {
+                        accept()
+                    }
+                    _ => ctx.push_error(args.new_attribute_validation_error(
+                        "Only @default(dbgenerated()) can be used for Unsupported types.",
+                    )),
+                }
+            }
+        }
+
+        break;
+    }
+}
+
+fn validate_builtin_scalar_type_default(
+    scalar_type: ScalarType,
+    value: &ast::Expression,
+    mapped_name: Option<&str>,
+    mut accept: impl FnMut(),
+    args: &Arguments<'_>,
+    ctx: &mut Context<'_>,
+) {
+    match (scalar_type, value) {
+        (ScalarType::String, ast::Expression::StringValue(_, _))
+        | (ScalarType::Json, ast::Expression::StringValue(_, _))
+        | (ScalarType::Bytes, ast::Expression::StringValue(_, _))
+        | (ScalarType::Int, ast::Expression::NumericValue(_, _))
+        | (ScalarType::BigInt, ast::Expression::NumericValue(_, _))
+        | (ScalarType::Float, ast::Expression::NumericValue(_, _))
+        | (ScalarType::DateTime, ast::Expression::StringValue(_, _))
+        | (ScalarType::Decimal, ast::Expression::NumericValue(_, _))
+        | (ScalarType::Decimal, ast::Expression::StringValue(_, _))
+        | (ScalarType::Boolean, ast::Expression::BooleanValue(_, _)) => accept(),
+
+        // Functions
+        (_, ast::Expression::Function(funcname, _, _)) if funcname == FN_AUTOINCREMENT && mapped_name.is_some() => {
+            ctx.push_error(args.new_attribute_validation_error("Naming an autoincrement default value is not allowed."))
+        }
+        (ScalarType::Int, ast::Expression::Function(funcname, funcargs, _))
+        | (ScalarType::BigInt, ast::Expression::Function(funcname, funcargs, _))
+            if funcname == FN_AUTOINCREMENT =>
+        {
+            validate_empty_function_args(funcname, funcargs, args, accept, ctx)
+        }
+        (ScalarType::String, ast::Expression::Function(funcname, funcargs, _))
+            if funcname == FN_UUID || funcname == FN_CUID =>
+        {
+            validate_empty_function_args(funcname, funcargs, args, accept, ctx)
+        }
+        (ScalarType::DateTime, ast::Expression::Function(funcname, funcargs, _)) if funcname == FN_NOW => {
+            validate_empty_function_args(FN_NOW, funcargs, args, accept, ctx)
+        }
+
+        (_, ast::Expression::Function(funcname, funcargs, _)) if funcname == FN_DBGENERATED => {
+            validate_dbgenerated_args(funcargs, args, accept, ctx)
+        }
+
+        (_, ast::Expression::Function(funcname, _, _)) if !KNOWN_FUNCTIONS.contains(&funcname.as_str()) => {
+            ctx.push_error(args.new_attribute_validation_error(&format!(
+                            "The function `{funcname}` is not a known function. You can read about the available functions here: https://pris.ly/d/attribute-functions",
+                            funcname = funcname
+                        )));
+        }
+
+        // Invalid function default.
+        (scalar_type, ast::Expression::Function(funcname, _, _)) => {
+            ctx.push_error(args.new_attribute_validation_error(&format!(
+                "The function `{funcname}()` cannot be used on fields of type `{scalar_type}`.",
+                funcname = funcname,
+                scalar_type = scalar_type.as_str()
+            )));
+        }
+
+        // Invalid scalar default.
+        (scalar_type, value) => ctx.push_error(args.new_attribute_validation_error(&format!(
+            "Expected a {scalar_type} value, but found `{bad_value}`.",
+            scalar_type = scalar_type.as_str(),
+            bad_value = value
+        ))),
+    }
+}
+
+fn default_attribute_mapped_name<'ast>(args: &mut Arguments<'ast>, ctx: &mut Context<'ast>) -> Option<&'ast str> {
+    match args.optional_arg("map").map(|name| name.as_str()) {
+        Some(Ok("")) => {
+            ctx.push_error(args.new_attribute_validation_error("The `map` argument cannot be an empty string."));
+            None
+        }
+        Some(Ok(name)) => Some(name),
+        Some(Err(err)) => {
+            ctx.push_error(err);
+            None
+        }
+        None => None,
+    }
+}
+
+fn validate_empty_function_args(
+    fn_name: &str,
+    args: &[ast::Expression],
+    arguments: &Arguments<'_>,
+    mut accept: impl FnMut(),
+    ctx: &mut Context<'_>,
+) {
+    if args.is_empty() {
+        return accept();
+    }
+
+    ctx.push_error(arguments.new_attribute_validation_error(&format!(
+        "The `{fn_name}` function does not take any argument. Consider changing this default to `{fn_name}()`.",
+        fn_name = fn_name
+    )));
+}
+
+fn validate_dbgenerated_args(
+    args: &[ast::Expression],
+    arguments: &Arguments<'_>,
+    mut accept: impl FnMut(),
+    ctx: &mut Context<'_>,
+) {
+    match args {
+        [ast::Expression::StringValue(val, _)] if val.is_empty() => {
+            ctx.push_error(arguments.new_attribute_validation_error(
+                "dbgenerated() takes either no argument, or a single nonempty string argument.",
+            ));
+        }
+        [] | [ast::Expression::StringValue(_, _)] => accept(),
+        _ => ctx.push_error(arguments.new_attribute_validation_error("`dbgenerated()` takes a single String argument")), // let's not mention what we don't want to see.
+    }
+}
+
+const FN_AUTOINCREMENT: &str = "autoincrement";
+const FN_CUID: &str = "cuid";
+const FN_DBGENERATED: &str = "dbgenerated";
+const FN_NOW: &str = "now";
+const FN_UUID: &str = "uuid";
+
+const KNOWN_FUNCTIONS: &[&str] = &[FN_AUTOINCREMENT, FN_CUID, FN_DBGENERATED, FN_NOW, FN_UUID];

--- a/libs/datamodel/parser-database/src/context/arguments.rs
+++ b/libs/datamodel/parser-database/src/context/arguments.rs
@@ -67,11 +67,6 @@ impl<'a> Arguments<'a> {
         self.args.remove(name).map(|arg| ValueValidator::new(&arg.value))
     }
 
-    /// True if argument with the given key is defined.
-    pub(crate) fn has_arg(&self, name: &str) -> bool {
-        self.args.contains_key(name)
-    }
-
     /// Gets the arg with the given name, or if it is not found, the first unnamed argument.
     ///
     /// Use this to implement unnamed argument behavior.

--- a/libs/datamodel/parser-database/src/types.rs
+++ b/libs/datamodel/parser-database/src/types.rs
@@ -99,12 +99,18 @@ impl ScalarFieldType {
 }
 
 #[derive(Debug)]
+pub(crate) struct DefaultAttribute<'ast> {
+    pub(crate) mapped_name: Option<&'ast str>,
+    pub(crate) value: &'ast ast::Expression,
+    pub(crate) default_attribute: &'ast ast::Attribute,
+}
+
+#[derive(Debug)]
 pub(crate) struct ScalarField<'ast> {
     pub(crate) r#type: ScalarFieldType,
     pub(crate) is_ignored: bool,
     pub(crate) is_updated_at: bool,
-    pub(crate) default: Option<dml::default_value::DefaultValue>,
-    pub(crate) default_attribute: Option<&'ast ast::Attribute>,
+    pub(crate) default: Option<DefaultAttribute<'ast>>,
     /// @map
     pub(crate) mapped_name: Option<&'ast str>,
     /// Native type name and arguments
@@ -263,7 +269,6 @@ fn visit_model<'ast>(model_id: ast::ModelId, ast_model: &'ast ast::Model, ctx: &
                     is_ignored: false,
                     is_updated_at: false,
                     default: None,
-                    default_attribute: None,
                     mapped_name: None,
                     native_type: None,
                 };
@@ -596,22 +601,6 @@ impl ScalarType {
             "Bytes" => Some(ScalarType::Bytes),
             "Decimal" => Some(ScalarType::Decimal),
             _ => None,
-        }
-    }
-}
-
-impl From<dml::scalars::ScalarType> for ScalarType {
-    fn from(st: dml::scalars::ScalarType) -> ScalarType {
-        match st {
-            dml::scalars::ScalarType::Int => ScalarType::Int,
-            dml::scalars::ScalarType::BigInt => ScalarType::BigInt,
-            dml::scalars::ScalarType::Float => ScalarType::Float,
-            dml::scalars::ScalarType::Boolean => ScalarType::Boolean,
-            dml::scalars::ScalarType::String => ScalarType::String,
-            dml::scalars::ScalarType::DateTime => ScalarType::DateTime,
-            dml::scalars::ScalarType::Json => ScalarType::Json,
-            dml::scalars::ScalarType::Bytes => ScalarType::Bytes,
-            dml::scalars::ScalarType::Decimal => ScalarType::Decimal,
         }
     }
 }

--- a/libs/datamodel/schema-ast/src/ast/expression.rs
+++ b/libs/datamodel/schema-ast/src/ast/expression.rs
@@ -52,9 +52,16 @@ impl Expression {
         }
     }
 
-    pub fn extract_constant_value(&self) -> Option<(&str, Span)> {
+    pub fn as_constant_value(&self) -> Option<(&str, Span)> {
         match self {
             Expression::ConstantValue(s, span) => Some((s, *span)),
+            _ => None,
+        }
+    }
+
+    pub fn as_numeric_value(&self) -> Option<(&str, Span)> {
+        match self {
+            Expression::NumericValue(s, span) => Some((s, *span)),
             _ => None,
         }
     }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
@@ -691,7 +691,7 @@ fn render_default(default: &DefaultValue) -> Cow<'_, str> {
             out.push_str(&escape_string_literal(json_value));
             out.push('\'');
             Cow::Owned(out)
-        },
+        }
         DefaultKind::Value(val) => val.to_string().into(),
         DefaultKind::Sequence(_) => Default::default(),
     }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
@@ -678,13 +678,20 @@ enum PostgresAlterColumn {
 
 fn render_default(default: &DefaultValue) -> Cow<'_, str> {
     match default.kind() {
-        DefaultKind::DbGenerated(val) => val.as_str().into(),
+        DefaultKind::DbGenerated(val) => Cow::Borrowed(val.as_str()),
         DefaultKind::Value(PrismaValue::String(val)) | DefaultKind::Value(PrismaValue::Enum(val)) => {
             format!("E'{}'", escape_string_literal(val)).into()
         }
         DefaultKind::Value(PrismaValue::Bytes(b)) => Quoted::postgres_string(format_hex(b)).to_string().into(),
         DefaultKind::Now => "CURRENT_TIMESTAMP".into(),
         DefaultKind::Value(PrismaValue::DateTime(val)) => Quoted::postgres_string(val).to_string().into(),
+        DefaultKind::Value(PrismaValue::Json(json_value)) => {
+            let mut out = String::with_capacity(json_value.len() + 2);
+            out.push('\'');
+            out.push_str(&escape_string_literal(json_value));
+            out.push('\'');
+            Cow::Owned(out)
+        },
         DefaultKind::Value(val) => val.to_string().into(),
         DefaultKind::Sequence(_) => Default::default(),
     }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
@@ -275,7 +275,7 @@ fn column_for_scalar_field(field: &ScalarFieldWalker<'_>, flavour: &dyn SqlFlavo
         }
         TypeWalker::Base(scalar_type) => (
             scalar_type,
-            flavour.default_native_type_for_scalar_type(&scalar_type.into()),
+            flavour.default_native_type_for_scalar_type(&datamodel_connector::convert_from_scalar_type(scalar_type)),
         ),
         TypeWalker::NativeType(scalar_type, instance) => (scalar_type, instance.serialized_native_type.clone()),
         TypeWalker::Unsupported(description) => {


### PR DESCRIPTION
A few error messages changed for the better. Additionally, this lets us
simplify the dependency graph of libs/datamodel crates. parser-database
no longer depends on dml.

There are also a bunch of new `@default()` related tests (we didn't test boolean, json, bytes and decimal defaults in datamodel until this PR, for example).

This PR also introduces a `libs/datamodel/README.md` for documentation. See the second commit.

A smaller PR will follow with improvements for boolean defaults.