### PR TITLE
 Improve parsing and validation of boolean defaults 

### DIFF
--- a/libs/datamodel/connectors/datamodel-connector/src/walker_ext_traits.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/walker_ext_traits.rs
@@ -67,8 +67,11 @@ impl<'ast> DefaultValueExt<'ast> for DefaultValueWalker<'ast, '_> {
                 Some(ScalarType::Decimal) => DefaultKind::Single(PrismaValue::Float(num.parse().unwrap())),
                 other => unreachable!("{:?}", other),
             },
-            ast::Expression::BooleanValue(b, _) => DefaultKind::Single(PrismaValue::Boolean(b.parse().unwrap())),
-            ast::Expression::ConstantValue(v, _) => DefaultKind::Single(PrismaValue::Enum(v.to_owned())),
+            ast::Expression::ConstantValue(v, _) => match self.field().scalar_type() {
+                Some(ScalarType::Boolean) => DefaultKind::Single(PrismaValue::Boolean(v.parse().unwrap())),
+                None => DefaultKind::Single(PrismaValue::Enum(v.to_owned())),
+                other => unreachable!("{:?}", other),
+            },
             ast::Expression::StringValue(v, _) => match self.field().scalar_type() {
                 Some(ScalarType::DateTime) => DefaultKind::Single(PrismaValue::DateTime(v.parse().unwrap())),
                 Some(ScalarType::String) => DefaultKind::Single(PrismaValue::String(v.parse().unwrap())),

--- a/libs/datamodel/core/src/ast/reformat/reformatter.rs
+++ b/libs/datamodel/core/src/ast/reformat/reformatter.rs
@@ -777,7 +777,6 @@ impl<'a> Reformatter<'a> {
         match val {
             ast::Expression::Array(vals, _) => Self::render_expression_array(target, vals),
             ast::Expression::FieldWithArgs(ident, vals, _) => Self::render_constant_value_w_args(target, ident, vals),
-            ast::Expression::BooleanValue(val, _) => target.write(val),
             ast::Expression::ConstantValue(val, _) => target.write(val),
             ast::Expression::NumericValue(val, _) => target.write(val),
             ast::Expression::StringValue(val, _) => Self::render_str(target, val),
@@ -875,7 +874,6 @@ impl<'a> Reformatter<'a> {
             match current.as_rule() {
                 Rule::numeric_literal => target.write(current.as_str()),
                 Rule::string_literal => target.write(current.as_str()),
-                Rule::boolean_literal => target.write(current.as_str()),
                 Rule::constant_literal => target.write(current.as_str()),
                 Rule::function => Self::reformat_function_expression(target, &current),
                 Rule::array_expression => Self::reformat_array_expression(target, &current),

--- a/libs/datamodel/core/src/transform/ast_to_dml/generator_loader.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/generator_loader.rs
@@ -121,7 +121,6 @@ impl GeneratorLoader {
 
             let value = match &prop.value {
                 ast::Expression::NumericValue(val, _) => val.clone(),
-                ast::Expression::BooleanValue(val, _) => val.clone(),
                 ast::Expression::StringValue(val, _) => val.clone(),
                 ast::Expression::ConstantValue(val, _) => val.clone(),
                 ast::Expression::Function(_, _, _) => String::from("(function)"),

--- a/libs/datamodel/core/src/transform/dml_to_ast/lower_field.rs
+++ b/libs/datamodel/core/src/transform/dml_to_ast/lower_field.rs
@@ -263,8 +263,8 @@ impl<'a> LowerDmlToAst<'a> {
 
     pub fn lower_prisma_value(pv: &PrismaValue) -> ast::Expression {
         match pv {
-            PrismaValue::Boolean(true) => ast::Expression::BooleanValue(String::from("true"), ast::Span::empty()),
-            PrismaValue::Boolean(false) => ast::Expression::BooleanValue(String::from("false"), ast::Span::empty()),
+            PrismaValue::Boolean(true) => ast::Expression::ConstantValue(String::from("true"), ast::Span::empty()),
+            PrismaValue::Boolean(false) => ast::Expression::ConstantValue(String::from("false"), ast::Span::empty()),
             PrismaValue::String(value) => Self::lower_string(value),
             PrismaValue::Enum(value) => ast::Expression::ConstantValue(value.clone(), ast::Span::empty()),
             PrismaValue::DateTime(value) => Self::lower_string(value),

--- a/libs/datamodel/core/tests/attributes/default_negative.rs
+++ b/libs/datamodel/core/tests/attributes/default_negative.rs
@@ -817,11 +817,11 @@ fn boolean_defaults_must_be_true_or_false() {
     let error = datamodel::parse_schema(schema).map(drop).unwrap_err();
 
     let expected = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@default": Expected a Boolean value, but found `True`.[0m
+        [1;91merror[0m: [1mError parsing attribute "@default": A boolean literal must be `true` or `false`.[0m
           [1;94m-->[0m  [4mschema.prisma:4[0m
         [1;94m   | [0m
         [1;94m 3 | [0m            id Int @id
-        [1;94m 4 | [0m            isEdible Boolean @[1;91mdefault(True)[0m
+        [1;94m 4 | [0m            isEdible Boolean @default([1;91mTrue[0m)
         [1;94m   | [0m
     "#]];
 

--- a/libs/datamodel/core/tests/parsing/nice_errors.rs
+++ b/libs/datamodel/core/tests/parsing/nice_errors.rs
@@ -252,7 +252,7 @@ fn nice_error_in_case_of_bool_type_in_env_var() {
     let error = datamodel::parse_schema(source).map(drop).unwrap_err();
 
     let expectation = expect![[r#"
-        [1;91merror[0m: [1mExpected a String value, but received boolean value `true`.[0m
+        [1;91merror[0m: [1mExpected a String value, but received literal value `true`.[0m
           [1;94m-->[0m  [4mschema.prisma:3[0m
         [1;94m   | [0m
         [1;94m 2 | [0m  provider = "postgresql"

--- a/libs/datamodel/parser-database/src/value_validator.rs
+++ b/libs/datamodel/parser-database/src/value_validator.rs
@@ -89,7 +89,6 @@ impl<'a> ValueValidator<'a> {
     pub(crate) fn as_constant_literal(&self) -> Result<&'a str, DatamodelError> {
         match &self.value {
             ast::Expression::ConstantValue(value, _) => Ok(value),
-            ast::Expression::BooleanValue(value, _) => Ok(value),
             _ => Err(self.construct_type_mismatch_error("constant literal")),
         }
     }

--- a/libs/datamodel/schema-ast/src/ast/expression.rs
+++ b/libs/datamodel/schema-ast/src/ast/expression.rs
@@ -6,12 +6,10 @@ use std::fmt;
 pub enum Expression {
     /// Any numeric value e.g. floats or ints.
     NumericValue(String, Span),
-    /// Any boolean value.
-    BooleanValue(String, Span),
     /// Any string value.
     StringValue(String, Span),
     /// Any literal constant, basically a string which was not inside "...".
-    /// This is used for representing builtin enums.
+    /// This is used for representing builtin enums and boolean constants (true and false).
     ConstantValue(String, Span),
     /// A function with a name and arguments, which is evaluated at client side.
     Function(String, Vec<Expression>, Span),
@@ -24,10 +22,9 @@ pub enum Expression {
 impl fmt::Display for Expression {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Expression::NumericValue(val, _) => write!(f, "{}", val),
-            Expression::BooleanValue(val, _) => write!(f, "{}", val),
+            Expression::NumericValue(val, _) => fmt::Display::fmt(val, f),
             Expression::StringValue(val, _) => write!(f, "\"{}\"", val),
-            Expression::ConstantValue(val, _) => write!(f, "{}", val),
+            Expression::ConstantValue(val, _) => fmt::Display::fmt(val, f),
             Expression::Function(fun, args, _) => {
                 let args = args.iter().map(ToString::to_string).collect::<Vec<_>>().join(",");
                 write!(f, "{}({})", fun, args)
@@ -69,7 +66,6 @@ impl Expression {
     pub fn span(&self) -> Span {
         match &self {
             Self::NumericValue(_, span) => *span,
-            Self::BooleanValue(_, span) => *span,
             Self::StringValue(_, span) => *span,
             Self::ConstantValue(_, span) => *span,
             Self::Function(_, _, span) => *span,
@@ -89,7 +85,6 @@ impl Expression {
     pub fn describe_value_type(&self) -> &'static str {
         match self {
             Expression::NumericValue(_, _) => "numeric",
-            Expression::BooleanValue(_, _) => "boolean",
             Expression::StringValue(_, _) => "string",
             Expression::ConstantValue(_, _) => "literal",
             Expression::Function(_, _, _) => "functional",

--- a/libs/datamodel/schema-ast/src/parser/datamodel.pest
+++ b/libs/datamodel/schema-ast/src/parser/datamodel.pest
@@ -122,7 +122,7 @@ BLOCK_LEVEL_CATCH_ALL = { !BLOCK_CLOSE ~ CATCH_ALL }
 function = { non_empty_identifier ~ "(" ~ (expression ~ ("," ~ expression)*)? ~ ")" }
 field_with_args = {  non_empty_identifier ~ "(" ~ argument ~ ("," ~ argument)*  ~")"}
 array_expression = { "[" ~ (expression ~ ( "," ~ expression )*)? ~ "]" }
-expression = { field_with_args | array_expression | function | numeric_literal | string_literal | boolean_literal | constant_literal }
+expression = { field_with_args | array_expression | function | numeric_literal | string_literal | constant_literal }
 
 // ######################################
 // Literals / Values
@@ -140,9 +140,6 @@ string_raw = { (!("\\" | "\"" | NEWLINE | INTERPOLATION_START ) ~ (ANY))+ }
 string_content = ${ (string_raw | string_escape | string_interpolate_escape)* }
 string_literal = { "\"" ~ string_content ~ "\"" }
 
-boolean_true  = { "true" }
-boolean_false = { "false" }
-boolean_literal =  @{ boolean_true | boolean_false }
 constant_literal = @{ non_empty_identifier }
 
 // ######################################

--- a/libs/datamodel/schema-ast/src/parser/parse_expression.rs
+++ b/libs/datamodel/schema-ast/src/parser/parse_expression.rs
@@ -9,7 +9,6 @@ pub fn parse_expression(token: &Token<'_>) -> Expression {
     match first_child.as_rule() {
         Rule::numeric_literal => Expression::NumericValue(first_child.as_str().to_string(), span),
         Rule::string_literal => Expression::StringValue(parse_string_literal(&first_child), span),
-        Rule::boolean_literal => Expression::BooleanValue(first_child.as_str().to_string(), span),
         Rule::constant_literal => Expression::ConstantValue(first_child.as_str().to_string(), span),
         Rule::field_with_args => parse_field_with_args(&first_child),
         Rule::function => parse_function(&first_child),

--- a/libs/datamodel/schema-ast/src/parser/parse_schema.rs
+++ b/libs/datamodel/schema-ast/src/parser/parse_schema.rs
@@ -100,7 +100,6 @@ fn rule_to_string(rule: Rule) -> &'static str {
         Rule::maybe_empty_identifier => "alphanumeric identifier",
         Rule::numeric_literal => "numeric literal",
         Rule::string_literal => "string literal",
-        Rule::boolean_literal => "boolean literal",
         Rule::constant_literal => "literal",
         Rule::array_expression => "array",
         Rule::expression => "expression",
@@ -160,8 +159,6 @@ fn rule_to_string(rule: Rule) -> &'static str {
         Rule::string_interpolate_escape => "string interpolation",
         Rule::string_raw => "unescaped string",
         Rule::string_content => "string contents",
-        Rule::boolean_true => "boolean true",
-        Rule::boolean_false => "boolean false",
         Rule::doc_content => "documentation comment content",
     }
 }

--- a/libs/datamodel/schema-ast/src/renderer.rs
+++ b/libs/datamodel/schema-ast/src/renderer.rs
@@ -422,7 +422,6 @@ impl<'a> Renderer<'a> {
         match val {
             ast::Expression::Array(vals, _) => Self::render_expression_array(target, vals),
             ast::Expression::FieldWithArgs(ident, vals, _) => Self::render_field_with_args(target, ident, vals),
-            ast::Expression::BooleanValue(val, _) => target.write(val),
             ast::Expression::ConstantValue(val, _) => target.write(val),
             ast::Expression::NumericValue(val, _) => target.write(val),
             ast::Expression::StringValue(val, _) => Self::render_str(target, val),


### PR DESCRIPTION
- Remove the BooleanValue case of ast::Expression (and also in the pest
  grammar)

  At a syntax level, it is indistinguishable from a constant literal. It
  is a constant literal, and we had a bunch of hacky branches in
  validation code to deal with the fact that these two aren't different.
  Now, boolean constants are just constants.

- We validate in parser_database that the constant in @default on
  boolean fields is "true" or "false". That improves the error message
  in case we find something else.