### PR TITLE
feat(qe): emulate referential integrity on update

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/relations/emulate_ref_integrity.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/relations/emulate_ref_integrity.rs
@@ -1,0 +1,180 @@
+use query_engine_tests::*;
+
+#[test_suite(schema(schema), only(MongoDB, Vitess))]
+mod emulate_ref_integrity {
+    use indoc::indoc;
+    use query_engine_tests::{assert_error, run_query};
+
+    fn schema() -> String {
+        let schema = indoc! {
+            r#"model User {
+              #id(id, Int, @id)
+              uniq_1     Int
+              uniq_2     Int
+              comments Comment[]
+              post     Post?
+            
+              @@unique([uniq_1, uniq_2])
+            }
+            
+            model Post {
+              #id(id, Int, @id)
+              name       String?
+              authorId_1 Int
+              authorId_2 Int
+              author     User      @relation(fields: [authorId_1, authorId_2], references: [uniq_1, uniq_2], onUpdate: Cascade, onDelete: Cascade)
+              comment    Comment[]
+            }
+            
+            model Comment {
+              #id(id, Int, @id)
+              name          String?
+              writtenById_1 Int
+              writtenById_2 Int
+              writtenBy     User?   @relation(fields: [writtenById_1, writtenById_2], references: [uniq_1, uniq_2], onUpdate: Cascade, onDelete: Cascade)
+              post          Post    @relation(fields: [writtenById_1], references: [id], onUpdate: Cascade, onDelete: Cascade)
+            }"#
+        };
+
+        schema.to_owned()
+    }
+
+    // Updating foreign keys to a record that exist should work
+    #[connector_test]
+    async fn referenced_records_exist(runner: Runner) -> TestResult<()> {
+        create_row(
+            &runner,
+            r#"{
+              id: 1
+              uniq_1: 1
+              uniq_2: 1
+              post: { create: { id: 1 } }
+              comments: { create: [
+                { id: 1, post: { connect: { id: 1 } } },
+                { id: 2, post: { connect: { id: 1 } } }
+              ] }
+            }"#,
+        )
+        .await?;
+
+        create_row(
+            &runner,
+            r#"{
+                id: 2
+                uniq_1: 3
+                uniq_2: 1
+                post: { create: { id: 3 } }
+                comments: { create: [
+                  { id: 3, post: { connect: { id: 3 } } }
+                ]}
+            }"#,
+        )
+        .await?;
+
+        // Update works because there's an existing:
+        // - `User` with [uniq_1: 3, uniq_2: 1]
+        // - `Post` with id: 3
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"mutation { updateOneComment(where: { id: 1 }, data: { writtenById_1: 3 }) { id writtenBy { uniq_1 uniq_2 } } }"#),
+          @r###"{"data":{"updateOneComment":{"id":1,"writtenBy":{"uniq_1":3,"uniq_2":1}}}}"###
+        );
+
+        Ok(())
+    }
+
+    // Updating foreign keys to a record that does not exist should fail
+    #[connector_test]
+    async fn violates_required_relation(runner: Runner) -> TestResult<()> {
+        create_row(
+            &runner,
+            r#"{
+              id: 1
+              uniq_1: 1
+              uniq_2: 1
+              post: { create: { id: 1 } }
+              comments: { create: [
+                { id: 1, post: { connect: { id: 1 } } },
+                { id: 2, post: { connect: { id: 1 } } }
+              ] }
+            }"#,
+        )
+        .await?;
+
+        create_row(
+            &runner,
+            r#"{
+              id: 2
+              uniq_1: 3
+              uniq_2: 1
+              post: { create: { id: 2 } }
+              comments: { create: [
+                { id: 3, post: { connect: { id: 2 } } }
+              ]}
+            }"#,
+        )
+        .await?;
+
+        // Can fail on `Comment.writtenBy` or `Comment.post` since there is
+        // - no `User` with [uniq_1: 5, uniq_2: 1]
+        // - nor `Post` with `id: 5`
+        assert_error!(
+            runner,
+            r#"mutation { updateOneComment(where: { id: 1 }, data: { writtenById_1: 5 }) { id } }"#,
+            2014,
+            "The change you are trying to make would violate the required relation"
+        );
+
+        // Does _not_ fail on `Comment.writtenBy` but on `Comment.post` since there _is_ a `User` with [uniq_1: 3, uniq_2: 1]
+        // but no `Post` with `id: 3`
+        assert_error!(
+            runner,
+            r#"mutation { updateOneComment(where: { id: 1 }, data: { writtenById_1: 3 }) { id } }"#,
+            2014,
+            "The change you are trying to make would violate the required relation 'CommentToPost' between the `Comment` and `Post` models."
+        );
+
+        // Does _not_ fail on `Comment.post` since `Comment.writtenById_2` is not part of its fks
+        assert_error!(
+          runner,
+          r#"mutation { updateOneComment(where: { id: 1 }, data: { writtenById_2: 5 }) { id } }"#,
+          2014,
+          "The change you are trying to make would violate the required relation 'CommentToUser' between the `Comment` and `User` models."
+      );
+
+        Ok(())
+    }
+
+    // Updating foreign keys with anything else than `set` should not trigger emulation
+    #[connector_test]
+    async fn no_support_for_complex_updates(runner: Runner) -> TestResult<()> {
+        create_row(
+            &runner,
+            r#"{
+              id: 1
+              uniq_1: 1
+              uniq_2: 1
+              post: { create: { id: 1 } }
+              comments: { create: [
+                { id: 1, post: { connect: { id: 1 } } },
+                { id: 2, post: { connect: { id: 1 } } }
+              ] }
+            }"#,
+        )
+        .await?;
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"mutation { updateOneComment(where: { id: 1 }, data: { writtenById_1: { increment: 10 } }) { id writtenById_1 } }"#),
+          @r###"{"data":{"updateOneComment":{"id":1,"writtenById_1":11}}}"###
+        );
+
+        Ok(())
+    }
+
+    async fn create_row(runner: &Runner, data: &str) -> TestResult<()> {
+        runner
+            .query(format!("mutation {{ createOneUser(data: {}) {{ id }} }}", data))
+            .await?
+            .assert_success();
+        Ok(())
+    }
+}

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/relations/emulate_ref_integrity.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/relations/emulate_ref_integrity.rs
@@ -150,8 +150,8 @@ mod emulate_ref_integrity {
         );
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"{ findManyUser { id comments { id } } }"#),
-          @r###"{"data":{"findManyUser":[{"id":1,"comments":[]},{"id":2,"comments":[{"id":2},{"id":1},{"id":3}]}]}}"###
+          run_query!(&runner, r#"{ findManyUser { id comments(orderBy: { id: asc }) { id } } }"#),
+          @r###"{"data":{"findManyUser":[{"id":1,"comments":[]},{"id":2,"comments":[{"id":1},{"id":2},{"id":3}]}]}}"###
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/relations/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/relations/mod.rs
@@ -1,5 +1,6 @@
 mod compound_fks_mixed_requiredness;
 mod deeply_nested_self_rel;
+mod emulate_ref_integrity;
 mod optional_rel;
 mod rel_defaults;
 mod rel_design;

--- a/query-engine/connectors/query-connector/src/write_args.rs
+++ b/query-engine/connectors/query-connector/src/write_args.rs
@@ -59,6 +59,23 @@ pub enum WriteExpression {
     Divide(PrismaValue),
 }
 
+impl WriteExpression {
+    pub fn as_value(&self) -> Option<&PrismaValue> {
+        if let Self::Value(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    /// Returns `true` if the write expression is [`Value`].
+    ///
+    /// [`Value`]: WriteExpression::Value
+    pub fn is_value(&self) -> bool {
+        matches!(self, Self::Value(..))
+    }
+}
+
 impl From<PrismaValue> for WriteExpression {
     fn from(pv: PrismaValue) -> Self {
         WriteExpression::Value(pv)

--- a/query-engine/core/src/query_graph_builder/write/nested/update_nested.rs
+++ b/query-engine/core/src/query_graph_builder/write/nested/update_nested.rs
@@ -97,6 +97,13 @@ pub fn nested_update(
             ),
         )?;
 
+        utils::preserve_referential_integrity_on_update(
+            graph,
+            connector_ctx,
+            &child_model,
+            &find_child_records_node,
+            &update_node,
+        )?;
         utils::insert_emulated_on_update(
             graph,
             connector_ctx,

--- a/query-engine/core/src/query_graph_builder/write/update.rs
+++ b/query-engine/core/src/query_graph_builder/write/update.rs
@@ -37,6 +37,7 @@ pub fn update_record(
             filter,
         ));
 
+        utils::preserve_referential_integrity_on_update(graph, connector_ctx, &model, &read_parent_node, &update_node)?;
         utils::insert_emulated_on_update(graph, connector_ctx, &model, &read_parent_node, &update_node)?;
 
         graph.create_edge(

--- a/query-engine/core/src/query_graph_builder/write/update.rs
+++ b/query-engine/core/src/query_graph_builder/write/update.rs
@@ -112,6 +112,13 @@ pub fn update_many_records(
         ));
         let update_many_node = update_many_record_node(graph, connector_ctx, Filter::empty(), model.clone(), data_map)?;
 
+        utils::preserve_referential_integrity_on_update(
+            graph,
+            connector_ctx,
+            &model,
+            &pre_read_node,
+            &update_many_node,
+        )?;
         utils::insert_emulated_on_update(graph, connector_ctx, &model, &pre_read_node, &update_many_node)?;
 
         graph.create_edge(

--- a/query-engine/core/src/query_graph_builder/write/utils.rs
+++ b/query-engine/core/src/query_graph_builder/write/utils.rs
@@ -1021,7 +1021,7 @@ pub fn emulate_on_update_cascade(
 /// Inserts nodes in the graph (_before_ an update node) to preserve referential integrity when any foreign keys are about to be updated.
 /// Foreign keys need to reference an existing record. Before the update is performed, we check that the new set of foreign keys points to an actual record.
 /// If they don't, we abort the query and error out. In the case of optional relations, the check is skipped if any of the foreign keys are set to `NULL`.
-/// 
+///
 /// ```text
 ///    ┌ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─    
 ///         Parent (Read node)    │   
@@ -1052,7 +1052,7 @@ pub fn emulate_on_update_cascade(
 ///                  │               │
 ///                  ▼                
 ///       ┌ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─      │
-///               Update       │◀ ─ ─ 
+///               Update       │◀ ─ ─
 ///       └ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─       
 /// ```
 #[allow(clippy::mutable_key_type)]

--- a/query-engine/core/src/query_graph_builder/write/utils.rs
+++ b/query-engine/core/src/query_graph_builder/write/utils.rs
@@ -1047,6 +1047,10 @@ pub fn preserve_referential_integrity_on_update(
                 })
                 .collect();
 
+            if fks_to_be_updated.is_empty() {
+                return None;
+            }
+
             // We don't preserve referential integrity if any of the foreign keys were updated
             // with something else than a value. Division, multiplication, addition, etc ... isn't supported.
             let has_complex_fk_updates = fks_to_be_updated.values().any(|write_expr| !write_expr.is_value());

--- a/query-engine/prisma-models/src/field_selection.rs
+++ b/query-engine/prisma-models/src/field_selection.rs
@@ -245,6 +245,14 @@ impl From<Vec<Field>> for FieldSelection {
     }
 }
 
+impl From<Vec<ScalarFieldRef>> for FieldSelection {
+    fn from(fields: Vec<ScalarFieldRef>) -> Self {
+        Self {
+            selections: fields.into_iter().map(|sf| sf.into()).collect(),
+        }
+    }
+}
+
 impl From<ScalarFieldRef> for FieldSelection {
     fn from(field: ScalarFieldRef) -> Self {
         Self {

--- a/query-engine/prisma-models/src/field_selection.rs
+++ b/query-engine/prisma-models/src/field_selection.rs
@@ -245,10 +245,13 @@ impl From<Vec<Field>> for FieldSelection {
     }
 }
 
-impl From<Vec<ScalarFieldRef>> for FieldSelection {
-    fn from(fields: Vec<ScalarFieldRef>) -> Self {
+impl<T> From<Vec<T>> for FieldSelection
+where
+    T: Into<SelectedField>,
+{
+    fn from(fields: Vec<T>) -> Self {
         Self {
-            selections: fields.into_iter().map(|sf| sf.into()).collect(),
+            selections: fields.into_iter().map(Into::into).collect(),
         }
     }
 }


### PR DESCRIPTION
## Overview
Closes #2504

This PR ensure that, when the `refentialIntegrity` mode is set to `prisma` and one or more foreign keys are updated, we ensure that the new foreign keys points to an existing record which would otherwise break referential integrity. If the foreign keys do not point to an existing record, the operation is aborted and an error is raised.