### PR TITLE
Validate that the fields argument on indexes and @@id is not empty

### DIFF
--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations.rs
@@ -28,6 +28,7 @@ pub(super) fn validate(ctx: &mut Context<'_>, relation_transformation_enabled: b
         models::has_a_strict_unique_criteria(model, ctx);
         models::has_a_unique_primary_key_name(model, &names, ctx);
         models::uses_sort_or_length_on_primary_without_preview_flag(model, ctx);
+        models::id_has_fields(model, ctx);
         models::primary_key_connector_specific(model, ctx);
         models::primary_key_length_prefix_supported(model, ctx);
         models::primary_key_sort_order_supported(model, ctx);

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations.rs
@@ -68,6 +68,7 @@ pub(super) fn validate(ctx: &mut Context<'_>, relation_transformation_enabled: b
         }
 
         for index in model.indexes() {
+            indexes::has_fields(index, ctx);
             indexes::has_a_unique_constraint_name(index, &names, ctx);
             indexes::uses_length_or_sort_without_preview_flag(index, ctx);
             indexes::field_length_prefix_supported(index, ctx);

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/indexes.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/indexes.rs
@@ -9,6 +9,7 @@ use crate::{
     },
 };
 use datamodel_connector::{walker_ext_traits::*, ConnectorCapability};
+use schema_ast::ast::{WithName, WithSpan};
 
 /// Different databases validate index and unique constraint names in a certain namespace.
 /// Validates index and unique constraint names against the database requirements.
@@ -328,4 +329,20 @@ pub(super) fn has_valid_mapped_name(index: IndexWalker<'_, '_>, ctx: &mut Contex
     }
 }
 
-//TODO(extended indices) add db specific validations to sort and length
+pub(super) fn has_fields(index: IndexWalker<'_, '_>, ctx: &mut Context<'_>) {
+    if index.fields().len() > 0 {
+        return;
+    }
+
+    let attr = if let Some(attribute) = index.ast_attribute() {
+        attribute
+    } else {
+        return;
+    };
+
+    ctx.push_error(DatamodelError::new_attribute_validation_error(
+        "The list of fields in an index cannot be empty. Please specify at least one field.",
+        attr.name(),
+        *attr.span(),
+    ))
+}

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/models.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/models.rs
@@ -231,3 +231,17 @@ pub(super) fn connector_specific(model: ModelWalker<'_, '_>, ctx: &mut Context<'
         ));
     }
 }
+
+pub(super) fn id_has_fields(model: ModelWalker<'_, '_>, ctx: &mut Context<'_>) {
+    let id = if let Some(id) = model.primary_key() { id } else { return };
+
+    if id.fields().len() > 0 {
+        return;
+    }
+
+    ctx.push_error(DatamodelError::new_attribute_validation_error(
+        "The list of fields in an `@@id()` attribute cannot be empty. Please specify at least one field.",
+        "id",
+        id.ast_attribute().span,
+    ))
+}

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/relation_fields.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/relation_fields.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ast,
+    ast::{self, WithName},
     diagnostics::DatamodelError,
     transform::ast_to_dml::{
         db::{

--- a/libs/datamodel/core/tests/attributes/id_negative.rs
+++ b/libs/datamodel/core/tests/attributes/id_negative.rs
@@ -1094,3 +1094,36 @@ fn length_argument_does_not_work_with_int() {
 
     expectation.assert_eq(&error)
 }
+
+#[test]
+fn empty_fields_must_error() {
+    let schema = r#"
+        generator js {
+          provider        = "prisma-client-js"
+          previewFeatures = ["fullTextIndex", "extendedIndexes"]
+        }
+
+        datasource db {
+          provider = "mysql"
+          url      = env("DATABASE_URL")
+        }
+
+        model Fulltext {
+          number      Int    
+          name        String @db.VarChar(255)
+          @@id([])
+        }
+    "#;
+
+    let expected = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@id": The list of fields in an `@@id()` attribute cannot be empty. Please specify at least one field.[0m
+          [1;94m-->[0m  [4mschema.prisma:15[0m
+        [1;94m   | [0m
+        [1;94m14 | [0m          name        String @db.VarChar(255)
+        [1;94m15 | [0m          @@[1;91mid([])[0m
+        [1;94m   | [0m
+    "#]];
+
+    let error = datamodel::parse_schema(schema).map(drop).unwrap_err();
+    expected.assert_eq(&error);
+}

--- a/libs/datamodel/core/tests/reformat/reformat.rs
+++ b/libs/datamodel/core/tests/reformat/reformat.rs
@@ -1164,3 +1164,53 @@ fn reformatting_extended_indexes_works() {
     let result = Reformatter::new(input).reformat_to_string();
     expected.assert_eq(&result);
 }
+
+#[test]
+fn reformatting_with_empty_indexes() {
+    let schema = r#"
+        generator js {
+          provider        = "prisma-client-js"
+          previewFeatures = ["fullTextIndex", "extendedIndexes"]
+        }
+
+        datasource db {
+          provider = "mysql"
+          url      = env("DATABASE_URL")
+        }
+
+        model Fulltext {
+          id      Int    @id
+          title   String @db.VarChar(255)
+          content String @db.Text
+
+          @@fulltext(fields:[], map: "a")
+          @@index(fields: [ ], map: "b")
+          @@unique(fields: [])
+        }
+    "#;
+
+    let expected = expect![[r#"
+        generator js {
+          provider        = "prisma-client-js"
+          previewFeatures = ["fullTextIndex", "extendedIndexes"]
+        }
+
+        datasource db {
+          provider = "mysql"
+          url      = env("DATABASE_URL")
+        }
+
+        model Fulltext {
+          id      Int    @id
+          title   String @db.VarChar(255)
+          content String @db.Text
+
+          @@unique(fields: [])
+          @@index(fields: [], map: "b")
+          @@fulltext(fields: [], map: "a")
+        }
+    "#]];
+
+    let result = Reformatter::new(schema).reformat_to_string();
+    expected.assert_eq(&result);
+}

--- a/libs/datamodel/parser-database/src/context/arguments.rs
+++ b/libs/datamodel/parser-database/src/context/arguments.rs
@@ -1,4 +1,4 @@
-use crate::ast;
+use crate::ast::{self, WithName};
 use crate::ValueValidator;
 use crate::{DatamodelError, Diagnostics};
 use std::collections::HashMap;

--- a/libs/datamodel/schema-ast/src/ast/attribute.rs
+++ b/libs/datamodel/schema-ast/src/ast/attribute.rs
@@ -36,10 +36,6 @@ impl Attribute {
     pub fn span_for_argument(&self, argument: &str) -> Option<Span> {
         self.arguments.iter().find(|a| a.name.name == argument).map(|a| a.span)
     }
-
-    pub fn name(&self) -> &str {
-        &self.name.name
-    }
 }
 
 impl WithIdentifier for Attribute {


### PR DESCRIPTION
That covers @@index, @@unique and @@fulltext. This was never validated
before. It was a syntax error because the AST parser didn't understand
empty arrays, and it became a failed assertion when we fixed that first
problem. With this PR, we now have a regular validation.

closes https://github.com/prisma/language-tools/issues/995