### PR TITLE
Simplify datamodel-connector API

### DIFF
--- a/libs/datamodel/connectors/datamodel-connector/src/capabilities.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/capabilities.rs
@@ -1,0 +1,152 @@
+use std::{fmt, str::FromStr};
+
+/// Not all Databases are created equal. Hence connectors for our datasources support different capabilities.
+/// These are used during schema validation. E.g. if a connector does not support enums an error will be raised.
+macro_rules! capabilities {
+    ($( $variant:ident $(,)? ),*) => {
+        #[derive(Debug, Clone, Copy, PartialEq)]
+        pub enum ConnectorCapability {
+            $(
+                $variant,
+            )*
+        }
+
+        impl fmt::Display for ConnectorCapability {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                let name = match self {
+                    $(
+                        Self::$variant => stringify!($variant),
+                    )*
+                };
+
+                write!(f, "{}", name)
+            }
+        }
+
+        impl FromStr for ConnectorCapability {
+            type Err = String;
+
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                match s {
+                    $(
+                        stringify!($variant) => Ok(Self::$variant),
+                    )*
+                    _ => Err(format!("{} is not a known connector capability.", s)),
+                }
+            }
+        }
+    };
+}
+
+// Capabilities describe what functionality connectors are able to provide.
+// Some are used only by the query engine, some are used only by the datamodel parser.
+capabilities!(
+    // General capabilities, not specific to any part of Prisma.
+    ScalarLists,
+    RelationsOverNonUniqueCriteria,
+    Enums,
+    EnumArrayPush,
+    Json,
+    JsonLists,
+    AutoIncrement,
+    RelationFieldsInArbitraryOrder,
+    CompositeTypes,
+    //Start of ME/IE only capabilities
+    AutoIncrementAllowedOnNonId,
+    AutoIncrementMultipleAllowed,
+    AutoIncrementNonIndexedAllowed,
+    NamedPrimaryKeys,
+    NamedForeignKeys,
+    ReferenceCycleDetection,
+    NamedDefaultValues,
+    IndexColumnLengthPrefixing,
+    PrimaryKeySortOrderDefinition,
+    UsingHashIndex,
+    FullTextIndex,
+    SortOrderInFullTextIndex,
+    MultipleFullTextAttributesPerModel,
+    // Start of query-engine-only Capabilities
+    InsensitiveFilters,
+    CreateMany,
+    CreateManyWriteableAutoIncId,
+    WritableAutoincField,
+    CreateSkipDuplicates,
+    UpdateableId,
+    JsonFiltering,
+    JsonFilteringJsonPath,
+    JsonFilteringArrayPath,
+    JsonFilteringAlphanumeric,
+    CompoundIds,
+    AnyId, // Any (or combination of) uniques and not only id fields can constitute an id for a model.
+    QueryRaw,
+    FullTextSearchWithoutIndex,
+    AdvancedJsonNullability, // Database distinguishes between their null type and JSON null.
+);
+
+/// Contains all capabilities that the connector is able to serve.
+#[derive(Debug)]
+pub struct ConnectorCapabilities {
+    pub capabilities: Vec<ConnectorCapability>,
+}
+
+impl ConnectorCapabilities {
+    pub fn empty() -> Self {
+        Self { capabilities: vec![] }
+    }
+
+    pub fn new(capabilities: Vec<ConnectorCapability>) -> Self {
+        Self { capabilities }
+    }
+
+    pub fn contains(&self, capability: ConnectorCapability) -> bool {
+        self.capabilities.contains(&capability)
+    }
+
+    pub fn supports_any(&self, capabilities: &[ConnectorCapability]) -> bool {
+        self.capabilities
+            .iter()
+            .any(|connector_capability| capabilities.contains(connector_capability))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty_cap_does_not_contain() {
+        let cap = ConnectorCapabilities::empty();
+        assert!(!cap.supports_any(&[ConnectorCapability::JsonFilteringJsonPath]));
+    }
+
+    #[test]
+    fn test_cap_with_others_does_not_contain() {
+        let cap = ConnectorCapabilities::new(vec![
+            ConnectorCapability::PrimaryKeySortOrderDefinition,
+            ConnectorCapability::JsonFilteringArrayPath,
+        ]);
+        assert!(!cap.supports_any(&[ConnectorCapability::JsonFilteringJsonPath]));
+    }
+
+    #[test]
+    fn test_cap_with_others_does_contain() {
+        let cap = ConnectorCapabilities::new(vec![
+            ConnectorCapability::PrimaryKeySortOrderDefinition,
+            ConnectorCapability::JsonFilteringJsonPath,
+            ConnectorCapability::JsonFilteringArrayPath,
+        ]);
+        assert!(cap.supports_any(&[
+            ConnectorCapability::JsonFilteringJsonPath,
+            ConnectorCapability::JsonFilteringArrayPath,
+        ]));
+    }
+
+    #[test]
+    fn test_does_contain() {
+        let cap = ConnectorCapabilities::new(vec![
+            ConnectorCapability::PrimaryKeySortOrderDefinition,
+            ConnectorCapability::JsonFilteringArrayPath,
+        ]);
+        assert!(!cap.supports_any(&[ConnectorCapability::JsonFilteringJsonPath]));
+    }
+}

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/cockroach_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/cockroach_datamodel_connector.rs
@@ -1,8 +1,8 @@
 use datamodel_connector::{
     connector_error::ConnectorError,
     helper::{arg_vec_from_opt, args_vec_from_opt, parse_one_opt_u32, parse_two_opt_u32},
-    parser_database, Connector, ConnectorCapability, ConstraintScope, NativeTypeConstructor, ReferentialAction,
-    ReferentialIntegrity, ScalarType,
+    parser_database, Connector, ConnectorCapability, ConstraintScope, Diagnostics, NativeTypeConstructor,
+    ReferentialAction, ReferentialIntegrity, ScalarType,
 };
 use dml::native_type_instance::NativeTypeInstance;
 use enumflags2::BitFlags;
@@ -207,8 +207,7 @@ impl Connector for CockroachDatamodelConnector {
         }
     }
 
-    fn validate_model(&self, _model: parser_database::walkers::ModelWalker<'_, '_>, _errors: &mut Vec<ConnectorError>) {
-    }
+    fn validate_model(&self, _model: parser_database::walkers::ModelWalker<'_, '_>, _diagnostics: &mut Diagnostics) {}
 
     fn constraint_violation_scopes(&self) -> &'static [ConstraintScope] {
         CONSTRAINT_SCOPES

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/mssql_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/mssql_datamodel_connector.rs
@@ -3,7 +3,8 @@ use datamodel_connector::{
     helper::{arg_vec_from_opt, args_vec_from_opt, parse_one_opt_u32, parse_two_opt_u32},
     parser_database::{self, ScalarType},
     walker_ext_traits::*,
-    Connector, ConnectorCapability, ConstraintScope, NativeTypeConstructor, ReferentialAction, ReferentialIntegrity,
+    Connector, ConnectorCapability, ConstraintScope, Diagnostics, NativeTypeConstructor, ReferentialAction,
+    ReferentialIntegrity,
 };
 use dml::native_type_instance::NativeTypeInstance;
 use enumflags2::BitFlags;
@@ -261,7 +262,14 @@ impl Connector for MsSqlDatamodelConnector {
         }
     }
 
-    fn validate_model(&self, model: parser_database::walkers::ModelWalker<'_, '_>, errors: &mut Vec<ConnectorError>) {
+    fn validate_model(&self, model: parser_database::walkers::ModelWalker<'_, '_>, errors: &mut Diagnostics) {
+        let mut push_error = |err: ConnectorError| {
+            errors.push_error(datamodel_connector::DatamodelError::ConnectorError {
+                message: err.to_string(),
+                span: model.ast_model().span,
+            });
+        };
+
         for index in model.indexes() {
             for field in index.fields() {
                 if let Some(native_type) = field.native_type_instance(self) {
@@ -270,9 +278,9 @@ impl Connector for MsSqlDatamodelConnector {
 
                     if heap_allocated_types().contains(&r#type) {
                         if index.is_unique() {
-                            errors.push(error.new_incompatible_native_type_with_unique())
+                            push_error(error.new_incompatible_native_type_with_unique())
                         } else {
-                            errors.push(error.new_incompatible_native_type_with_index())
+                            push_error(error.new_incompatible_native_type_with_index())
                         };
                         break;
                     }
@@ -286,7 +294,7 @@ impl Connector for MsSqlDatamodelConnector {
                     let r#type: MsSqlType = native_type.deserialize_native_type();
 
                     if heap_allocated_types().contains(&r#type) {
-                        errors.push(
+                        push_error(
                             self.native_instance_error(&native_type)
                                 .new_incompatible_native_type_with_id(),
                         );
@@ -299,7 +307,7 @@ impl Connector for MsSqlDatamodelConnector {
                         message: String::from("Using Bytes type is not allowed in the model's id."),
                     };
 
-                    errors.push(ConnectorError { kind });
+                    push_error(ConnectorError { kind });
                     break;
                 }
             }

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
@@ -3,8 +3,8 @@ use datamodel_connector::{
     helper::{arg_vec_from_opt, args_vec_from_opt, parse_one_opt_u32, parse_two_opt_u32},
     parser_database::walkers::ModelWalker,
     walker_ext_traits::*,
-    Connector, ConnectorCapability, ConstraintScope, NativeTypeConstructor, ReferentialAction, ReferentialIntegrity,
-    ScalarType,
+    Connector, ConnectorCapability, ConstraintScope, Diagnostics, NativeTypeConstructor, ReferentialAction,
+    ReferentialIntegrity, ScalarType,
 };
 use dml::native_type_instance::NativeTypeInstance;
 use enumflags2::BitFlags;
@@ -223,7 +223,14 @@ impl Connector for PostgresDatamodelConnector {
         }
     }
 
-    fn validate_model(&self, model: ModelWalker<'_, '_>, errors: &mut Vec<ConnectorError>) {
+    fn validate_model(&self, model: ModelWalker<'_, '_>, errors: &mut Diagnostics) {
+        let mut push_error = |err: ConnectorError| {
+            errors.push_error(datamodel_connector::DatamodelError::ConnectorError {
+                message: err.to_string(),
+                span: model.ast_model().span,
+            });
+        };
+
         for index in model.indexes() {
             for field in index.fields() {
                 if let Some(native_type) = field.native_type_instance(self) {
@@ -232,9 +239,9 @@ impl Connector for PostgresDatamodelConnector {
 
                     if r#type == PostgresType::Xml {
                         if index.is_unique() {
-                            errors.push(error.new_incompatible_native_type_with_unique())
+                            push_error(error.new_incompatible_native_type_with_unique())
                         } else {
-                            errors.push(error.new_incompatible_native_type_with_index())
+                            push_error(error.new_incompatible_native_type_with_index())
                         };
 
                         break;

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/fields.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/fields.rs
@@ -323,27 +323,6 @@ pub(super) fn validate_default(field: ScalarFieldWalker<'_, '_>, ctx: &mut Conte
         }
         _ => (),
     }
-
-    // Connector-specific validations.
-
-    let mut errors = Vec::new();
-    let default = field.default_value().map(|d| d.dml_default_kind());
-
-    if field.raw_native_type().is_none() {
-        ctx.connector.validate_field_default_without_native_type(
-            field.name(),
-            &scalar_type,
-            default.as_ref(),
-            &mut errors,
-        );
-    }
-
-    for error in errors {
-        ctx.push_error(DatamodelError::ConnectorError {
-            message: error.to_string(),
-            span: field.ast_field().span,
-        });
-    }
 }
 
 pub(super) fn validate_scalar_field_connector_specific(field: ScalarFieldWalker<'_, '_>, ctx: &mut Context<'_>) {
@@ -354,10 +333,10 @@ pub(super) fn validate_scalar_field_connector_specific(field: ScalarFieldWalker<
         if !ctx.connector.supports_json() {
             ctx.push_error(DatamodelError::new_field_validation_error(
                 &format!(
-                "Field `{}` in model `{}` can't be of type Json. The current connector does not support the Json type.",
-                field.name(),
-                field.model().name(),
-            ),
+                    "Field `{}` in model `{}` can't be of type Json. The current connector does not support the Json type.",
+                    field.name(),
+                    field.model().name(),
+                ),
                 field.model().name(),
                 field.name(),
                 field.ast_field().span,

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/models.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/models.rs
@@ -221,15 +221,7 @@ pub(crate) fn primary_key_connector_specific(model: ModelWalker<'_, '_>, ctx: &m
 }
 
 pub(super) fn connector_specific(model: ModelWalker<'_, '_>, ctx: &mut Context<'_>) {
-    let mut errors = Vec::new();
-    ctx.connector.validate_model(model, &mut errors);
-
-    for error in errors {
-        ctx.push_error(DatamodelError::new_connector_error(
-            &error.to_string(),
-            model.ast_model().span,
-        ));
-    }
+    ctx.connector.validate_model(model, ctx.diagnostics)
 }
 
 pub(super) fn id_has_fields(model: ModelWalker<'_, '_>, ctx: &mut Context<'_>) {

--- a/libs/datamodel/parser-database/src/walkers/scalar_field.rs
+++ b/libs/datamodel/parser-database/src/walkers/scalar_field.rs
@@ -159,6 +159,11 @@ impl<'ast, 'db> DefaultValueWalker<'ast, 'db> {
         self.default.value
     }
 
+    /// Is this an `@default(dbgenerated())`?
+    pub fn is_dbgenerated(self) -> bool {
+        matches!(self.default.value, ast::Expression::Function(name, _, _) if name == "dbgenerated")
+    }
+
     /// The mapped name of the default value. Not applicable to all connectors. See crate docs for
     /// details on mapped names.
     ///


### PR DESCRIPTION
We can use Diagnostics and parser-database in there now.