### PR TITLE
feat: add full text index queries to mysql

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3258,7 +3258,6 @@ dependencies = [
 [[package]]
 name = "quaint"
 version = "0.2.0-alpha.13"
-source = "git+https://github.com/prisma/quaint#05eb0acc841eeb88569d1538c35b66b5e4f83266"
 dependencies = [
  "async-trait",
  "base64 0.12.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3258,6 +3258,7 @@ dependencies = [
 [[package]]
 name = "quaint"
 version = "0.2.0-alpha.13"
+source = "git+https://github.com/prisma/quaint#9c3eb65963a985da775deda1c8d4310040f24be1"
 dependencies = [
  "async-trait",
  "base64 0.12.3",
@@ -3967,7 +3968,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0bccbcf40c8938196944a3da0e133e031a33f4d6b72db3bda3cc556e361905d"
 dependencies = [
  "lazy_static",
- "parking_lot 0.11.2",
+ "parking_lot 0.10.2",
  "serial_test_derive",
 ]
 
@@ -5054,7 +5055,7 @@ version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f559b464de2e2bdabcac6a210d12e9b5a5973c251e102c44c585c71d51bd78e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "rand 0.8.4",
  "static_assertions",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,3 +50,6 @@ opt-level = 3
 codegen-units = 1
 opt-level = 'z' # Optimize for size.
 #strip="symbols"
+
+[patch."https://github.com/prisma/quaint"]
+quaint = {path = "../quaint"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,3 @@ opt-level = 3
 codegen-units = 1
 opt-level = 'z' # Optimize for size.
 #strip="symbols"
-
-[patch."https://github.com/prisma/quaint"]
-quaint = {path = "../quaint"}

--- a/libs/datamodel/connectors/datamodel-connector/src/capabilities.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/capabilities.rs
@@ -80,6 +80,7 @@ capabilities!(
     AnyId, // Any (or combination of) uniques and not only id fields can constitute an id for a model.
     QueryRaw,
     FullTextSearchWithoutIndex,
+    FullTextSearchWithIndex,
     AdvancedJsonNullability, // Database distinguishes between their null type and JSON null.
 );
 

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
@@ -111,6 +111,7 @@ const CAPABILITIES: &[ConnectorCapability] = &[
     ConnectorCapability::AdvancedJsonNullability,
     ConnectorCapability::IndexColumnLengthPrefixing,
     ConnectorCapability::FullTextIndex,
+    ConnectorCapability::FullTextSearchWithIndex,
     ConnectorCapability::MultipleFullTextAttributesPerModel,
 ];
 

--- a/libs/user-facing-errors/src/query_engine.rs
+++ b/libs/user-facing-errors/src/query_engine.rs
@@ -298,3 +298,10 @@ pub struct InteractiveTransactionError {
 pub struct QueryParameterLimitExceeded {
     pub message: String,
 }
+
+#[derive(Debug, UserFacingError, Serialize)]
+#[user_facing(
+    code = "P2030",
+    message = "Cannot find a FULLTEXT index to use for the search, try adding a @@fulltext([Columns...]) to your schema"
+)]
+pub struct MissingFullTextSearchIndex {}

--- a/libs/user-facing-errors/src/query_engine.rs
+++ b/libs/user-facing-errors/src/query_engine.rs
@@ -302,6 +302,6 @@ pub struct QueryParameterLimitExceeded {
 #[derive(Debug, UserFacingError, Serialize)]
 #[user_facing(
     code = "P2030",
-    message = "Cannot find a FULLTEXT index to use for the search, try adding a @@fulltext([Columns...]) to your schema"
+    message = "Cannot find a fulltext index to use for the search, try adding a @@fulltext([Fields...]) to your schema"
 )]
 pub struct MissingFullTextSearchIndex {}

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/search_filter.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/search_filter.rs
@@ -1,11 +1,138 @@
 use query_engine_tests::*;
 
-// CockroachDB does not support FullTextSearchWithoutIndex, despite having that capability
-// as it inherits PostgreSQL's capabilities.
-#[test_suite(schema(schema), capabilities(FullTextSearchWithoutIndex), exclude(CockroachDb))]
-mod search_filter {
+// create a set of common tests to use across connectors with full text indexes or without.
+
+async fn search_single_field(runner: Runner) -> TestResult<()> {
+    create_test_data(&runner).await?;
+
+    insta::assert_snapshot!(
+      run_query!(&runner, r#"query { findManyTestModel(where: { fieldA: { search: "Chicken" } }) { fieldA } }"#),
+      @r###"{"data":{"findManyTestModel":[{"fieldA":"Chicken Masala"},{"fieldA":"Chicken Curry"}]}}"###
+    );
+
+    Ok(())
+}
+
+async fn search_many_fields(runner: Runner) -> TestResult<()> {
+    create_test_data(&runner).await?;
+
+    insta::assert_snapshot!(
+      run_query!(&runner, r#"query { findManyTestModel(where: {
+              fieldA: { search: "Chicken" }
+              fieldB: { search: "Chicken" }
+          }) { fieldA, fieldB }}
+    "#),
+      @r###"{"data":{"findManyTestModel":[{"fieldA":"Chicken Masala","fieldB":"Chicken, Rice, Masala Sauce"},{"fieldA":"Chicken Curry","fieldB":"Chicken, Curry"},{"fieldA":"Caesar Salad","fieldB":"Salad, Chicken, Caesar Sauce"}]}}"###
+    );
+
+    Ok(())
+}
+
+async fn search_nullable_field(runner: Runner) -> TestResult<()> {
+    create_test_data(&runner).await?;
+
+    insta::assert_snapshot!(
+      run_query!(&runner, r#"query { findManyTestModel(where: {
+                fieldA: { search: "Chicken" }
+                fieldC: { search: "Chicken" }
+            }) { fieldA, fieldC }}
+      "#),
+      @r###"{"data":{"findManyTestModel":[{"fieldA":"Chicken Masala","fieldC":null},{"fieldA":"Chicken Curry","fieldC":null},{"fieldA":"Caesar Salad","fieldC":"Chicken"}]}}"###
+    );
+
+    Ok(())
+}
+
+async fn search_with_other_filters(runner: Runner) -> TestResult<()> {
+    create_test_data(&runner).await?;
+
+    insta::assert_snapshot!(
+      run_query!(&runner, r#"query { findManyTestModel(where: {
+                fieldA: { search: "Chicken", startsWith: "Chicken" },
+                fieldB: { search: "Chicken" },
+                id: { equals: 1 }
+            }) { fieldA, fieldB, fieldC }}
+      "#),
+      @r###"{"data":{"findManyTestModel":[{"fieldA":"Chicken Masala","fieldB":"Chicken, Rice, Masala Sauce","fieldC":null}]}}"###
+    );
+
+    Ok(())
+}
+
+async fn search_many_fields_not(runner: Runner) -> TestResult<()> {
+    create_test_data(&runner).await?;
+
+    insta::assert_snapshot!(
+      run_query!(&runner, r#"query { findManyTestModel(where: {
+                NOT: [{ fieldA: { search: "Chicken" } }, { fieldB: { search: "Carrot" } }]
+            }) { id, fieldA, fieldB }}
+      "#),
+      @r###"{"data":{"findManyTestModel":[{"id":3,"fieldA":"Caesar Salad","fieldB":"Salad, Chicken, Caesar Sauce"},{"id":4,"fieldA":"Beef Sandwich","fieldB":"Bread, Beef"}]}}"###
+    );
+
+    Ok(())
+}
+
+async fn ensure_filter_tree_shake_works(runner: Runner) -> TestResult<()> {
+    create_test_data(&runner).await?;
+
+    insta::assert_snapshot!(
+      run_query!(&runner, r#"query { findManyTestModel(where: {
+                AND: [
+                    { fieldA: { search: "Chicken", startsWith: "Chicken" } },
+                    { OR: [{ fieldB: { search: "Chicken" } }, { id: { equals: 3 } }] }
+                ]
+            }) { id, fieldA, fieldB, fieldC }}
+      "#),
+      @r###"{"data":{"findManyTestModel":[{"id":1,"fieldA":"Chicken Masala","fieldB":"Chicken, Rice, Masala Sauce","fieldC":null},{"id":2,"fieldA":"Chicken Curry","fieldB":"Chicken, Curry","fieldC":null}]}}"###
+    );
+
+    insta::assert_snapshot!(
+      run_query!(&runner, r#"query { findManyTestModel(where: {
+                  AND: [
+                    { NOT: [{ fieldA: { search: "Chicken" } }, { fieldB: { search: "Beef" } }] },
+                    { fieldA: { search: "Salad" } }
+                  ]
+              }) { id, fieldA, fieldB, fieldC }}
+        "#),
+      @r###"{"data":{"findManyTestModel":[{"id":3,"fieldA":"Caesar Salad","fieldB":"Salad, Chicken, Caesar Sauce","fieldC":"Chicken"}]}}"###
+    );
+
+    Ok(())
+}
+
+async fn create_test_data(runner: &Runner) -> TestResult<()> {
+    create_row(
+        runner,
+        r#"{ id: 1, fieldA: "Chicken Masala", fieldB: "Chicken, Rice, Masala Sauce"}"#,
+    )
+    .await?;
+    create_row(runner, r#"{ id: 2, fieldA: "Chicken Curry", fieldB: "Chicken, Curry"}"#).await?;
+    create_row(
+        runner,
+        r#"{ id: 3, fieldA: "Caesar Salad", fieldB: "Salad, Chicken, Caesar Sauce", fieldC: "Chicken"}"#,
+    )
+    .await?;
+    create_row(
+        runner,
+        r#"{ id: 4, fieldA: "Beef Sandwich", fieldB: "Bread, Beef", fieldC: "Beef"}"#,
+    )
+    .await?;
+
+    Ok(())
+}
+
+async fn create_row(runner: &Runner, data: &str) -> TestResult<()> {
+    runner
+        .query(format!("mutation {{ createOneTestModel(data: {}) {{ id }} }}", data))
+        .await?
+        .assert_success();
+    Ok(())
+}
+
+#[test_suite(schema(schema), capabilities(FullTextSearchWithoutIndex))]
+mod search_filter_without_index {
     use indoc::indoc;
-    use query_engine_tests::run_query;
 
     fn schema() -> String {
         let schema = indoc! {
@@ -22,135 +149,97 @@ mod search_filter {
 
     #[connector_test]
     async fn search_single_field(runner: Runner) -> TestResult<()> {
-        create_test_data(&runner).await?;
-
-        insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { fieldA: { search: "Chicken" } }) { fieldA } }"#),
-          @r###"{"data":{"findManyTestModel":[{"fieldA":"Chicken Masala"},{"fieldA":"Chicken Curry"}]}}"###
-        );
-
-        Ok(())
+        super::search_single_field(runner).await
     }
 
     #[connector_test]
     async fn search_many_fields(runner: Runner) -> TestResult<()> {
-        create_test_data(&runner).await?;
-
-        insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: {
-                  fieldA: { search: "Chicken" }
-                  fieldB: { search: "Chicken" }
-              }) { fieldA, fieldB }}
-        "#),
-          @r###"{"data":{"findManyTestModel":[{"fieldA":"Chicken Masala","fieldB":"Chicken, Rice, Masala Sauce"},{"fieldA":"Chicken Curry","fieldB":"Chicken, Curry"},{"fieldA":"Caesar Salad","fieldB":"Salad, Chicken, Caesar Sauce"}]}}"###
-        );
-
-        Ok(())
+        super::search_many_fields(runner).await
     }
 
     #[connector_test]
     async fn search_nullable_field(runner: Runner) -> TestResult<()> {
-        create_test_data(&runner).await?;
-
-        insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: {
-                    fieldA: { search: "Chicken" }
-                    fieldC: { search: "Chicken" }
-                }) { fieldA, fieldC }}
-          "#),
-          @r###"{"data":{"findManyTestModel":[{"fieldA":"Caesar Salad","fieldC":"Chicken"}]}}"###
-        );
-
-        Ok(())
+        super::search_nullable_field(runner).await
     }
 
     #[connector_test]
     async fn search_with_other_filters(runner: Runner) -> TestResult<()> {
-        create_test_data(&runner).await?;
-
-        insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: {
-                    fieldA: { search: "Chicken", startsWith: "Chicken" },
-                    fieldB: { search: "Chicken" },
-                    id: { equals: 1 }
-                }) { fieldA, fieldB, fieldC }}
-          "#),
-          @r###"{"data":{"findManyTestModel":[{"fieldA":"Chicken Masala","fieldB":"Chicken, Rice, Masala Sauce","fieldC":null}]}}"###
-        );
-
-        Ok(())
+        super::search_with_other_filters(runner).await
     }
 
     #[connector_test]
     async fn search_many_fields_not(runner: Runner) -> TestResult<()> {
-        create_test_data(&runner).await?;
-
-        insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: {
-                    NOT: [{ fieldA: { search: "Chicken" } }, { fieldB: { search: "Carrot" } }]
-                }) { id, fieldA, fieldB }}
-          "#),
-          @r###"{"data":{"findManyTestModel":[{"id":3,"fieldA":"Caesar Salad","fieldB":"Salad, Chicken, Caesar Sauce"},{"id":4,"fieldA":"Beef Sandwich","fieldB":"Bread, Beef"}]}}"###
-        );
-
-        Ok(())
+        super::search_many_fields_not(runner).await
     }
 
     #[connector_test]
     async fn ensure_filter_tree_shake_works(runner: Runner) -> TestResult<()> {
-        create_test_data(&runner).await?;
+        super::ensure_filter_tree_shake_works(runner).await
+    }
+}
 
-        insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: {
-                    AND: [
-                        { fieldA: { search: "Chicken", startsWith: "Chicken" } },
-                        { OR: [{ fieldB: { search: "Chicken" } }, { id: { equals: 3 } }] }
-                    ]
-                }) { id, fieldA, fieldB, fieldC }}
-          "#),
-          @r###"{"data":{"findManyTestModel":[{"id":1,"fieldA":"Chicken Masala","fieldB":"Chicken, Rice, Masala Sauce","fieldC":null},{"id":2,"fieldA":"Chicken Curry","fieldB":"Chicken, Curry","fieldC":null}]}}"###
-        );
+#[test_suite(schema(schema), capabilities(FullTextSearchWithIndex))]
+mod search_filter_with_index {
+    use indoc::indoc;
 
-        insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: {
-                      AND: [
-                        { NOT: [{ fieldA: { search: "Chicken" } }, { fieldB: { search: "Beef" } }] },
-                        { fieldA: { search: "Salad" } }
-                      ]
-                  }) { id, fieldA, fieldB, fieldC }}
-            "#),
-          @r###"{"data":{"findManyTestModel":[{"id":3,"fieldA":"Caesar Salad","fieldB":"Salad, Chicken, Caesar Sauce","fieldC":"Chicken"}]}}"###
-        );
+    fn schema() -> String {
+        let schema = indoc! {
+            r#"model TestModel {
+              #id(id, Int, @id)
+              fieldA  String
+              fieldB  String
+              fieldC  String?
+              @@fulltext([fieldA])
+              @@fulltext([fieldB])
+              @@fulltext([fieldA, fieldB])
+              @@fulltext([fieldA, fieldC])
+            }"#
+        };
 
-        Ok(())
+        schema.to_owned()
     }
 
-    async fn create_test_data(runner: &Runner) -> TestResult<()> {
-        create_row(
-            runner,
-            r#"{ id: 1, fieldA: "Chicken Masala", fieldB: "Chicken, Rice, Masala Sauce"}"#,
-        )
-        .await?;
-        create_row(runner, r#"{ id: 2, fieldA: "Chicken Curry", fieldB: "Chicken, Curry"}"#).await?;
-        create_row(
-            runner,
-            r#"{ id: 3, fieldA: "Caesar Salad", fieldB: "Salad, Chicken, Caesar Sauce", fieldC: "Chicken"}"#,
-        )
-        .await?;
-        create_row(
-            runner,
-            r#"{ id: 4, fieldA: "Beef Sandwich", fieldB: "Bread, Beef", fieldC: "Beef"}"#,
-        )
-        .await?;
-
-        Ok(())
+    #[connector_test]
+    async fn search_single_field(runner: Runner) -> TestResult<()> {
+        super::search_single_field(runner).await
     }
 
-    async fn create_row(runner: &Runner, data: &str) -> TestResult<()> {
-        runner
-            .query(format!("mutation {{ createOneTestModel(data: {}) {{ id }} }}", data))
-            .await?
-            .assert_success();
+    #[connector_test]
+    async fn search_many_fields(runner: Runner) -> TestResult<()> {
+        super::search_many_fields(runner).await
+    }
+
+    #[connector_test]
+    async fn search_nullable_field(runner: Runner) -> TestResult<()> {
+        super::search_nullable_field(runner).await
+    }
+
+    #[connector_test]
+    async fn search_with_other_filters(runner: Runner) -> TestResult<()> {
+        super::search_with_other_filters(runner).await
+    }
+
+    #[connector_test]
+    async fn search_many_fields_not(runner: Runner) -> TestResult<()> {
+        super::search_many_fields_not(runner).await
+    }
+
+    #[connector_test]
+    async fn ensure_filter_tree_shake_works(runner: Runner) -> TestResult<()> {
+        super::ensure_filter_tree_shake_works(runner).await
+    }
+
+    #[connector_test]
+    async fn throws_error_on_missing_index(runner: Runner) -> TestResult<()> {
+        super::create_test_data(&runner).await?;
+
+        assert_error!(
+            &runner,
+            "query { findManyTestModel(where: {fieldC: { search: \"Chicken\" }}) { id, fieldC }}",
+            2030,
+            "Cannot find a FULLTEXT index"
+        );
+
         Ok(())
     }
 }

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/search_filter.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/search_filter.rs
@@ -237,7 +237,7 @@ mod search_filter_with_index {
             &runner,
             "query { findManyTestModel(where: {fieldC: { search: \"Chicken\" }}) { id, fieldC }}",
             2030,
-            "Cannot find a FULLTEXT index"
+            "Cannot find a fulltext index"
         );
 
         Ok(())

--- a/query-engine/connectors/query-connector/src/error.rs
+++ b/query-engine/connectors/query-connector/src/error.rs
@@ -210,7 +210,7 @@ pub enum ErrorKind {
     #[error("The query parameter limit supported by your database is exceeded: {0}.")]
     QueryParameterLimitExceeded(String),
 
-    #[error("Cannot find a FULLTEXT index to use for the search")]
+    #[error("Cannot find a fulltext index to use for the search")]
     MissingFullTextSearchIndex,
 }
 

--- a/query-engine/connectors/query-connector/src/error.rs
+++ b/query-engine/connectors/query-connector/src/error.rs
@@ -82,6 +82,10 @@ impl ConnectorError {
                     message: message.clone(),
                 },
             )),
+
+            ErrorKind::MissingFullTextSearchIndex => Some(KnownError::new(
+                user_facing_errors::query_engine::MissingFullTextSearchIndex {},
+            )),
             _ => None,
         };
 
@@ -205,6 +209,9 @@ pub enum ErrorKind {
 
     #[error("The query parameter limit supported by your database is exceeded: {0}.")]
     QueryParameterLimitExceeded(String),
+
+    #[error("Cannot find a FULLTEXT index to use for the search")]
+    MissingFullTextSearchIndex,
 }
 
 impl From<DomainError> for ConnectorError {

--- a/query-engine/connectors/sql-query-connector/src/error.rs
+++ b/query-engine/connectors/sql-query-connector/src/error.rs
@@ -146,7 +146,7 @@ pub enum SqlError {
     #[error("Query parameter limit exceeded error: {0}.")]
     QueryParameterLimitExceeded(String),
 
-    #[error("Cannot find a FULLTEXT index to use for the search")]
+    #[error("Cannot find a fulltext index to use for the search")]
     MissingFullTextSearchIndex,
 }
 

--- a/query-engine/connectors/sql-query-connector/src/error.rs
+++ b/query-engine/connectors/sql-query-connector/src/error.rs
@@ -145,6 +145,9 @@ pub enum SqlError {
 
     #[error("Query parameter limit exceeded error: {0}.")]
     QueryParameterLimitExceeded(String),
+
+    #[error("Cannot find a FULLTEXT index to use for the search")]
+    MissingFullTextSearchIndex,
 }
 
 impl SqlError {
@@ -238,6 +241,7 @@ impl SqlError {
             SqlError::QueryParameterLimitExceeded(e) => {
                 ConnectorError::from_kind(ErrorKind::QueryParameterLimitExceeded(e))
             }
+            SqlError::MissingFullTextSearchIndex => ConnectorError::from_kind(ErrorKind::MissingFullTextSearchIndex),
         }
     }
 }
@@ -265,6 +269,8 @@ impl From<quaint::error::Error> for SqlError {
             QuaintKind::ForeignKeyConstraintViolation { constraint } => Self::ForeignKeyConstraintViolation {
                 constraint: constraint.into(),
             },
+
+            QuaintKind::MissingFullTextSearchIndex => Self::MissingFullTextSearchIndex,
 
             e @ QuaintKind::ConnectionError(_) => Self::ConnectionError(e),
             QuaintKind::ColumnReadFailure(e) => Self::ColumnReadFailure(e),

--- a/query-engine/core/src/schema_builder/input_types/arguments.rs
+++ b/query-engine/core/src/schema_builder/input_types/arguments.rs
@@ -115,14 +115,7 @@ pub(crate) fn many_records_arguments(
 
     let mut args = vec![
         where_argument(ctx, &model),
-        order_by_argument(
-            ctx,
-            &model,
-            true,
-            false,
-            ctx.has_feature(&PreviewFeature::FullTextSearch)
-                && ctx.has_capability(ConnectorCapability::FullTextSearchWithoutIndex),
-        ),
+        order_by_argument(ctx, &model, true, false, ctx.can_full_text_search()),
         input_field(args::CURSOR, unique_input_type, None).optional(),
         input_field(args::TAKE, InputType::int(), None).optional(),
         input_field(args::SKIP, InputType::int(), None).optional(),

--- a/query-engine/core/src/schema_builder/input_types/field_filter_types.rs
+++ b/query-engine/core/src/schema_builder/input_types/field_filter_types.rs
@@ -326,9 +326,7 @@ fn string_filters(ctx: &mut BuilderContext, mapped_type: InputType) -> impl Iter
         input_field(filters::ENDS_WITH, mapped_type.clone(), None).optional(),
     ];
 
-    if ctx.has_feature(&PreviewFeature::FullTextSearch)
-        && ctx.has_capability(ConnectorCapability::FullTextSearchWithoutIndex)
-    {
+    if ctx.can_full_text_search() {
         string_filters.push(input_field(filters::SEARCH, mapped_type, None).optional());
     }
 

--- a/query-engine/core/src/schema_builder/mod.rs
+++ b/query-engine/core/src/schema_builder/mod.rs
@@ -124,6 +124,12 @@ impl BuilderContext {
     pub fn cache_output_type(&mut self, ident: Identifier, typ: ObjectTypeStrongRef) {
         self.cache.output_types.insert(ident, typ);
     }
+
+    pub fn can_full_text_search(&self) -> bool {
+        self.has_feature(&PreviewFeature::FullTextSearch)
+            && (self.has_capability(ConnectorCapability::FullTextSearchWithoutIndex)
+                || self.has_capability(ConnectorCapability::FullTextSearchWithIndex))
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
This is part one of full text search support for MySql. This implements text search but does not implement the relevance queries yet. 

This also relies on https://github.com/prisma/quaint/pull/337/files being merged first. 

This is related to https://github.com/prisma/prisma/issues/10415