### PR TITLE
Parse and reject trailing commas in argument lists, improve prisma-fmt completion

### DIFF
--- a/libs/datamodel/core/tests/parsing/attributes.rs
+++ b/libs/datamodel/core/tests/parsing/attributes.rs
@@ -73,3 +73,51 @@ fn empty_enum_attribute_arguments_are_rejected_with_nice_error() {
 
     expected.assert_eq(&parse_schema(schema).map(|_| ()).unwrap_err());
 }
+
+#[test]
+fn trailing_commas_without_space_are_rejected_with_nice_error() {
+    let schema = r#"
+        enum Colour {
+            RED
+            GREEN
+            BLUE
+
+            @@map(name: "color",)
+        }
+    "#;
+
+    let expected = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@map": Trailing commas are not valid in attribute arguments, please remove the comma.[0m
+          [1;94m-->[0m  [4mschema.prisma:7[0m
+        [1;94m   | [0m
+        [1;94m 6 | [0m
+        [1;94m 7 | [0m            @@map(name: "color"[1;91m,[0m)
+        [1;94m   | [0m
+    "#]];
+
+    expected.assert_eq(&parse_schema(schema).map(|_| ()).unwrap_err());
+}
+
+#[test]
+fn trailing_commas_with_space_are_rejected_with_nice_error() {
+    let schema = r#"
+        enum Colour {
+            RED
+            GREEN
+            BLUE
+
+            @@map(name: "color", )
+        }
+    "#;
+
+    let expected = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@map": Trailing commas are not valid in attribute arguments, please remove the comma.[0m
+          [1;94m-->[0m  [4mschema.prisma:7[0m
+        [1;94m   | [0m
+        [1;94m 6 | [0m
+        [1;94m 7 | [0m            @@map(name: "color"[1;91m,[0m )
+        [1;94m   | [0m
+    "#]];
+
+    expected.assert_eq(&parse_schema(schema).map(|_| ()).unwrap_err());
+}

--- a/libs/datamodel/core/tests/types/composite_types.rs
+++ b/libs/datamodel/core/tests/types/composite_types.rs
@@ -182,6 +182,7 @@ fn composite_types_are_parsed_without_error() {
                                         },
                                         arguments: [],
                                         empty_arguments: [],
+                                        trailing_comma: None,
                                         span: Span {
                                             start: 175,
                                             end: 177,

--- a/libs/datamodel/parser-database/src/context/arguments.rs
+++ b/libs/datamodel/parser-database/src/context/arguments.rs
@@ -52,6 +52,14 @@ impl<'a> Arguments<'a> {
             ))
         }
 
+        if let Some(span) = attribute.trailing_comma {
+            errors.push_error(DatamodelError::new_attribute_validation_error(
+                "Trailing commas are not valid in attribute arguments, please remove the comma.",
+                attribute.name(),
+                span,
+            ))
+        }
+
         errors.to_result()
     }
 

--- a/libs/datamodel/schema-ast/src/ast/attribute.rs
+++ b/libs/datamodel/schema-ast/src/ast/attribute.rs
@@ -38,6 +38,13 @@ pub struct Attribute {
     ///                    ^^^^
     /// ```
     pub empty_arguments: Vec<EmptyArgument>,
+    /// The trailing comma at the end of the arguments list.
+    ///
+    /// ```ignore
+    /// @relation(fields: [a, b], references: [id, name], )
+    ///                                                 ^
+    /// ```
+    pub trailing_comma: Option<Span>,
     /// The AST span of the node.
     pub span: Span,
 }
@@ -50,6 +57,7 @@ impl Attribute {
             arguments,
             span: Span::empty(),
             empty_arguments: Vec::new(),
+            trailing_comma: None,
         }
     }
 

--- a/libs/datamodel/schema-ast/src/ast/find_at_position.rs
+++ b/libs/datamodel/schema-ast/src/ast/find_at_position.rs
@@ -101,10 +101,14 @@ impl<'ast> FieldPosition<'ast> {
                 spans.sort_by_key(|(_, span)| span.start);
                 let mut arg_name = None;
 
-                for (name, span) in spans {
+                for (name, _) in spans.iter().take_while(|(_, span)| span.start < position) {
+                    arg_name = Some(*name);
+                }
+
+                // If the cursor is after a trailing comma, we're not in an argument.
+                if let Some(span) = attr.trailing_comma {
                     if position > span.start {
-                        arg_name = Some(name);
-                        break;
+                        arg_name = None;
                     }
                 }
 

--- a/libs/datamodel/schema-ast/src/parser/datamodel.pest
+++ b/libs/datamodel/schema-ast/src/parser/datamodel.pest
@@ -72,13 +72,14 @@ attribute = { (attribute_name ~ attribute_arguments | attribute_name) }
 // This is a poor-mans version of name spacing. This is currently used for native types.
 attribute_name = @{ (maybe_empty_identifier ~ ".")? ~ maybe_empty_identifier }
 // If arguments are supplied there might multiple unnahmed arguments (see decimal native type).
-attribute_arguments = { "(" ~ (argument ~ ("," ~ argument)*)? ~ ")" }
+attribute_arguments = { "(" ~ (argument ~ ("," ~ argument)*)? ~ trailing_comma? ~ ")" }
 
 argument = _{ named_argument | empty_argument | argument_value }
 empty_argument = { argument_name ~ ":" }
 named_argument = { argument_name ~ ":" ~ argument_value }
 argument_name = { non_empty_identifier }
 argument_value = { expression }
+trailing_comma = @{ "," }
 
 // ######################################
 // Comments and Documentation Comments

--- a/libs/datamodel/schema-ast/src/parser/parse_attribute.rs
+++ b/libs/datamodel/schema-ast/src/parser/parse_attribute.rs
@@ -9,12 +9,15 @@ pub fn parse_attribute(token: &Token<'_>) -> Attribute {
     let mut name: Option<Identifier> = None;
     let mut arguments: Vec<Argument> = Vec::new();
     let mut empty_arguments = Vec::new();
+    let mut trailing_comma = None;
 
     for current in token.relevant_children() {
         match current.as_rule() {
             Rule::attribute => return parse_attribute(&current),
             Rule::attribute_name => name = Some(current.to_id()),
-            Rule::attribute_arguments => parse_attribute_args(&current, &mut arguments, &mut empty_arguments),
+            Rule::attribute_arguments => {
+                parse_attribute_args(&current, &mut arguments, &mut empty_arguments, &mut trailing_comma)
+            }
             _ => parsing_catch_all(&current, "attribute"),
         }
     }
@@ -25,6 +28,7 @@ pub fn parse_attribute(token: &Token<'_>) -> Attribute {
             arguments,
             empty_arguments,
             span: Span::from(token.as_span()),
+            trailing_comma,
         },
         _ => panic!("Encountered impossible type during parsing: {:?}", token.as_str()),
     }
@@ -34,6 +38,7 @@ pub(crate) fn parse_attribute_args(
     token: &Token<'_>,
     arguments: &mut Vec<Argument>,
     empty_arguments: &mut Vec<EmptyArgument>,
+    trailing_comma: &mut Option<Span>,
 ) {
     debug_assert_eq!(token.as_rule(), Rule::attribute_arguments);
     for current in token.relevant_children() {
@@ -54,6 +59,9 @@ pub(crate) fn parse_attribute_args(
                     .find(|tok| tok.as_rule() == Rule::argument_name)
                     .unwrap();
                 empty_arguments.push(EmptyArgument { name: name.to_id() })
+            }
+            Rule::trailing_comma => {
+                *trailing_comma = Some(current.as_span().into());
             }
             _ => parsing_catch_all(&current, "attribute arguments"),
         }

--- a/libs/datamodel/schema-ast/src/parser/parse_schema.rs
+++ b/libs/datamodel/schema-ast/src/parser/parse_schema.rs
@@ -129,6 +129,7 @@ fn rule_to_string(rule: Rule) -> &'static str {
         Rule::comment_and_new_line => "comment and new line",
         Rule::comment_block => "comment block",
         Rule::number => "number",
+        Rule::trailing_comma => "trailing comma",
 
         // Those are helpers, so we get better error messages:
         Rule::BLOCK_OPEN => "Start of block (\"{\")",

--- a/prisma-fmt/tests/text_document_completion/scenarios/argument_after_trailing_comma/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/argument_after_trailing_comma/result.json
@@ -1,0 +1,4 @@
+{
+  "isIncomplete": true,
+  "items": []
+}

--- a/prisma-fmt/tests/text_document_completion/scenarios/argument_after_trailing_comma/schema.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/argument_after_trailing_comma/schema.prisma
@@ -1,0 +1,19 @@
+datasource db {
+  provider = "sqlserver"
+  url      = env("DATABASE_URL")
+}
+
+model TestB {
+  id   Int    @id
+  name Int
+  Test Test[]
+}
+
+model Test {
+  id      Int   @id
+  bId     Int
+  // We should _not_ get any completion here, we're not in the onDelete argument.
+  b       TestB @relation(fields: [testBId], references: [id], onDelete: Casc, <|>)
+  testBId Int
+}
+

--- a/prisma-fmt/tests/text_document_completion/scenarios/default_map_end_of_args_list/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/default_map_end_of_args_list/result.json
@@ -1,0 +1,9 @@
+{
+  "isIncomplete": false,
+  "items": [
+    {
+      "label": "map: ",
+      "kind": 10
+    }
+  ]
+}

--- a/prisma-fmt/tests/text_document_completion/scenarios/default_map_end_of_args_list/schema.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/default_map_end_of_args_list/schema.prisma
@@ -1,0 +1,10 @@
+datasource db {
+  provider = "sqlserver"
+  url      = env("DATABASE_URL")
+}
+
+model Test {
+  id      Int   @id
+  dogId   Int   @default(1, <|>)
+}
+

--- a/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_end_of_args_list/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_end_of_args_list/result.json
@@ -1,0 +1,25 @@
+{
+  "isIncomplete": false,
+  "items": [
+    {
+      "label": "Cascade",
+      "kind": 21,
+      "documentation": "Delete the child records when the parent record is deleted."
+    },
+    {
+      "label": "NoAction",
+      "kind": 21,
+      "documentation": "Prevent deleting a parent record as long as it is referenced."
+    },
+    {
+      "label": "SetNull",
+      "kind": 21,
+      "documentation": "Set the referencing fields to NULL when the referenced record is deleted."
+    },
+    {
+      "label": "SetDefault",
+      "kind": 21,
+      "documentation": "Set the referencing field's value to the default when the referenced record is deleted."
+    }
+  ]
+}

--- a/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_end_of_args_list/schema.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_end_of_args_list/schema.prisma
@@ -1,0 +1,19 @@
+datasource db {
+  provider = "sqlserver"
+  url      = env("DATABASE_URL")
+}
+
+model TestB {
+  id   Int    @id
+  name Int
+  Test Test[]
+}
+
+model Test {
+  id      Int   @id
+  bId     Int
+  // The user started typing Casc
+  b       TestB @relation(fields: [testBId], references: [id], onDelete: <|>)
+  testBId Int
+}
+

--- a/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_middle_of_args_list/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_middle_of_args_list/result.json
@@ -1,0 +1,25 @@
+{
+  "isIncomplete": false,
+  "items": [
+    {
+      "label": "Cascade",
+      "kind": 21,
+      "documentation": "Delete the child records when the parent record is deleted."
+    },
+    {
+      "label": "NoAction",
+      "kind": 21,
+      "documentation": "Prevent deleting a parent record as long as it is referenced."
+    },
+    {
+      "label": "SetNull",
+      "kind": 21,
+      "documentation": "Set the referencing fields to NULL when the referenced record is deleted."
+    },
+    {
+      "label": "SetDefault",
+      "kind": 21,
+      "documentation": "Set the referencing field's value to the default when the referenced record is deleted."
+    }
+  ]
+}

--- a/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_middle_of_args_list/schema.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_middle_of_args_list/schema.prisma
@@ -1,0 +1,18 @@
+datasource db {
+  provider = "sqlserver"
+  url      = env("DATABASE_URL")
+}
+
+model TestB {
+  id   Int    @id
+  name Int
+  Test Test[]
+}
+
+model Test {
+  id      Int   @id
+  bId     Int
+  b       TestB @relation(fields: [testBId], onDelete: <|>, references: [id])
+  testBId Int
+}
+

--- a/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_with_trailing_comma/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_with_trailing_comma/result.json
@@ -1,0 +1,25 @@
+{
+  "isIncomplete": false,
+  "items": [
+    {
+      "label": "Cascade",
+      "kind": 21,
+      "documentation": "Delete the child records when the parent record is deleted."
+    },
+    {
+      "label": "NoAction",
+      "kind": 21,
+      "documentation": "Prevent deleting a parent record as long as it is referenced."
+    },
+    {
+      "label": "SetNull",
+      "kind": 21,
+      "documentation": "Set the referencing fields to NULL when the referenced record is deleted."
+    },
+    {
+      "label": "SetDefault",
+      "kind": 21,
+      "documentation": "Set the referencing field's value to the default when the referenced record is deleted."
+    }
+  ]
+}

--- a/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_with_trailing_comma/schema.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_with_trailing_comma/schema.prisma
@@ -1,0 +1,19 @@
+datasource db {
+  provider = "sqlserver"
+  url      = env("DATABASE_URL")
+}
+
+model TestB {
+  id   Int    @id
+  name Int
+  Test Test[]
+}
+
+model Test {
+  id      Int   @id
+  bId     Int
+  // The user started typing Casc
+  b       TestB @relation(fields: [testBId], references: [id], onDelete: <|>,)
+  testBId Int
+}
+

--- a/prisma-fmt/tests/text_document_completion/tests.rs
+++ b/prisma-fmt/tests/text_document_completion/tests.rs
@@ -12,9 +12,14 @@ macro_rules! scenarios {
 }
 
 scenarios! {
-  empty_schema
-  default_map_mssql
-  no_default_map_on_postgres
-  referential_actions_mssql
-  referential_actions_in_progress
+    argument_after_trailing_comma
+    default_map_end_of_args_list
+    default_map_mssql
+    empty_schema
+    no_default_map_on_postgres
+    referential_actions_end_of_args_list
+    referential_actions_in_progress
+    referential_actions_middle_of_args_list
+    referential_actions_mssql
+    referential_actions_with_trailing_comma
 }


### PR DESCRIPTION
This PR contains two commits that can be reviewed separately:

- The first one is about parsing and validating against trailing commas in attribute argument lists. See commit message for the reasoning and more details.
- The second one is about using that and other fixes to improve text_document_completion() in prisma-fmt