### PR TITLE
Update to latest quaint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3258,7 +3258,7 @@ dependencies = [
 [[package]]
 name = "quaint"
 version = "0.2.0-alpha.13"
-source = "git+https://github.com/prisma/quaint#9c3eb65963a985da775deda1c8d4310040f24be1"
+source = "git+https://github.com/prisma/quaint#c50ce7af91574e928c50ad057af50c8e73b6bffa"
 dependencies = [
  "async-trait",
  "base64 0.12.3",
@@ -5055,7 +5055,7 @@ version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f559b464de2e2bdabcac6a210d12e9b5a5973c251e102c44c585c71d51bd78e"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "rand 0.8.4",
  "static_assertions",
 ]


### PR DESCRIPTION
Updates to the latest quaint that supports the options argument
for the postgres connector
Quaint PR https://github.com/prisma/quaint/pull/339

Fixes https://github.com/prisma/prisma/issues/10805
