### PR TITLE
Let prisma_fmt::format() take parameters for tab size

### DIFF
--- a/prisma-fmt/src/lib.rs
+++ b/prisma-fmt/src/lib.rs
@@ -4,14 +4,17 @@ mod native;
 mod preview;
 mod text_document_completion;
 
+use log::*;
+
 /// The API is modelled on an LSP [completion
 /// request](https://github.com/microsoft/language-server-protocol/blob/gh-pages/_specifications/specification-3-16.md#textDocument_completion).
 /// Input and output are both JSON, the request being a `CompletionParams` object and the response
 /// being a `CompletionList` object.
-pub fn text_document_completion(schema: &str, params: String) -> String {
-    let params = if let Ok(params) = serde_json::from_str::<lsp_types::CompletionParams>(&params) {
+pub fn text_document_completion(schema: &str, params: &str) -> String {
+    let params = if let Ok(params) = serde_json::from_str::<lsp_types::CompletionParams>(params) {
         params
     } else {
+        warn!("Failed to parse params to text_document_completion() as CompletionParams.");
         return serde_json::to_string(&text_document_completion::empty_completion_list()).unwrap();
     };
 
@@ -20,9 +23,28 @@ pub fn text_document_completion(schema: &str, params: String) -> String {
     serde_json::to_string(&completion_list).unwrap()
 }
 
-pub fn format(schema: String) -> String {
+/// The two parameters are:
+/// - The Prisma schema to reformat, as a string.
+/// - An LSP
+/// [DocumentFormattingParams](https://github.com/microsoft/language-server-protocol/blob/gh-pages/_specifications/specification-3-16.md#textDocument_formatting) object, as JSON.
+///
+/// The function returns the formatted schema, as a string.
+///
+/// Of the DocumentFormattingParams, we only take into account tabSize, at the moment.
+pub fn format(schema: &str, params: &str) -> String {
     use datamodel::ast::reformat::Reformatter;
-    Reformatter::new(&schema).reformat_to_string()
+
+    let params: lsp_types::DocumentFormattingParams = match serde_json::from_str(params) {
+        Ok(params) => params,
+        Err(err) => {
+            warn!("Error parsing DocumentFormattingParams params: {}", err);
+            return schema.to_owned();
+        }
+    };
+
+    let mut out = Vec::with_capacity(schema.len() / 2);
+    Reformatter::new(schema).reformat_to(&mut out, params.options.tab_size as usize);
+    String::from_utf8_lossy(&out).into_owned()
 }
 
 pub fn lint(schema: String) -> String {

--- a/prisma-fmt/tests/text_document_completion/test_api.rs
+++ b/prisma-fmt/tests/text_document_completion/test_api.rs
@@ -32,7 +32,7 @@ pub(crate) fn test_scenario(scenario_name: &str) {
         context: None,
     };
 
-    let result = prisma_fmt::text_document_completion(&schema, serde_json::to_string_pretty(&params).unwrap());
+    let result = prisma_fmt::text_document_completion(&schema, &serde_json::to_string_pretty(&params).unwrap());
     // Prettify the JSON
     let result =
         serde_json::to_string_pretty(&serde_json::from_str::<lsp_types::CompletionList>(&result).unwrap()).unwrap();


### PR DESCRIPTION
The API is modelled on an LSP formatting request. The
DocumentFormattingParams contain, among other options, the tab size,
which we then pass to the reformatter. Note that this is a breaking API
change, so we'll have to pay attention to prisma-fmt-wasm, and probably
skip a (failed) release there.