### PR TITLE
Render empty preview feature lists

### DIFF
--- a/introspection-engine/introspection-engine-tests/tests/re_introspection/mod.rs
+++ b/introspection-engine/introspection-engine-tests/tests/re_introspection/mod.rs
@@ -1781,7 +1781,7 @@ async fn re_introspecting_custom_compound_id_names(api: &TestApi) -> TestResult 
 
              @@id([first, last], name: "compound", map: "User.something@invalid-and/weird")
          }
-         
+
          model User2 {
              first  Int
              last   Int
@@ -1798,7 +1798,7 @@ async fn re_introspecting_custom_compound_id_names(api: &TestApi) -> TestResult 
 
              @@id([first, last], name: "compound", map: "User.something@invalid-and/weird")
          }
-         
+
          model User2 {
              first  Int
              last   Int

--- a/libs/datamodel/core/src/lib.rs
+++ b/libs/datamodel/core/src/lib.rs
@@ -289,8 +289,5 @@ fn render_schema_ast_to(stream: &mut dyn std::fmt::Write, schema: &ast::SchemaAs
 }
 
 fn preview_features(generators: &[Generator]) -> BitFlags<PreviewFeature> {
-    generators
-        .iter()
-        .flat_map(|gen| gen.preview_features.iter().cloned())
-        .collect()
+    generators.iter().map(|gen| gen.preview_features()).collect()
 }

--- a/libs/datamodel/core/tests/config/generators.rs
+++ b/libs/datamodel/core/tests/config/generators.rs
@@ -1,3 +1,5 @@
+use datamodel::Datamodel;
+
 use crate::common::*;
 
 #[test]
@@ -419,4 +421,46 @@ fn empty_preview_features_array_with_empty_space_should_work() {
     let (config, _) = datamodel::parse_schema(schema).unwrap();
 
     assert!(config.preview_features().is_empty());
+}
+
+#[test]
+fn empty_preview_features_are_kept_when_rendering() {
+    let schema = indoc! {r#"
+       generator js1 {
+         provider = "a_cat"
+         previewFeatures = []
+       }
+    "#};
+
+    let config = parse_configuration(schema);
+    let rendered = datamodel::render_datamodel_and_config_to_string(&Datamodel::default(), &config);
+
+    let expected = expect![[r#"
+       generator js1 {
+         provider        = "a_cat"
+         previewFeatures = []
+       }
+    "#]];
+
+    expected.assert_eq(&rendered);
+}
+
+#[test]
+fn not_defining_preview_features_should_not_add_them_as_empty_when_rendering() {
+    let schema = indoc! {r#"
+       generator js1 {
+         provider = "a_cat"
+       }
+    "#};
+
+    let config = parse_configuration(schema);
+    let rendered = datamodel::render_datamodel_and_config_to_string(&Datamodel::default(), &config);
+
+    let expected = expect![[r#"
+       generator js1 {
+         provider = "a_cat"
+       }
+    "#]];
+
+    expected.assert_eq(&rendered);
 }


### PR DESCRIPTION
If the user has an empty list defined for preview features in their generator block, do not remove the parameter when re-introspecting.

Closes: https://github.com/prisma/prisma/issues/10460