### PR TITLE
Further simplify PSL pest grammar

### DIFF
--- a/libs/datamodel/core/src/ast/reformat/helpers.rs
+++ b/libs/datamodel/core/src/ast/reformat/helpers.rs
@@ -12,8 +12,7 @@ impl TokenExtensions for Token<'_> {
             self.as_rule(),
             Rule::model_declaration
                 | Rule::enum_declaration
-                | Rule::source_block
-                | Rule::generator_block
+                | Rule::config_block
                 | Rule::type_alias
                 | Rule::comment_block
         )

--- a/libs/datamodel/schema-ast/src/parser/datamodel.pest
+++ b/libs/datamodel/schema-ast/src/parser/datamodel.pest
@@ -109,8 +109,6 @@ BLOCK_CLOSE = { "}" }
 ENUM_KEYWORD = _{ "enum" }
 GENERATOR_KEYWORD = _{ "generator" }
 DATASOURCE_KEYWORD = _{ "datasource" }
-INTERPOLATION_START = _{ "${" }
-INTERPOLATION_END = _{ "}" }
 
 // rules that we want to handle explicitly
 MODEL_KEYWORD = { "model" }
@@ -134,31 +132,12 @@ number = @{ ASCII_DIGIT+ }
 
 numeric_literal = @{ ("-")? ~ ASCII_DIGIT+ ~("." ~ ASCII_DIGIT+)? }
 
-// String, with support for escaped stuff and interpolations.
-string_escaped_predefined = { "n" | "r" | "t" | "\\" | "0" | "\"" | "'" | SPACE_SEPARATOR | INTERPOLATION_START }
+// String literals with support for escaped characters.
+string_escaped_predefined = { "n" | "r" | "t" | "\\" | "0" | "\"" | "'" | SPACE_SEPARATOR }
 string_escape = { "\\" ~ string_escaped_predefined }
-// This is only used to escape the parser. The string above is still treated as atomic.
-string_interpolate_escape = !{ (INTERPOLATION_START ~ expression ~ INTERPOLATION_END) }
-string_raw = { (!("\\" | "\"" | NEWLINE | INTERPOLATION_START ) ~ (ANY))+ }
-string_content = ${ (string_raw | string_escape | string_interpolate_escape)* }
+// This is only used to escape in the parser. The string above is still treated as atomic.
+string_raw = { (!("\\" | "\"" | NEWLINE ) ~ ANY)+ }
+string_content = ${ (string_raw | string_escape )* }
 string_literal = { "\"" ~ string_content ~ "\"" }
 
 constant_literal = @{ non_empty_identifier }
-
-// ######################################
-// String Interpolation
-// Called separately, but falls back to expression.
-// ######################################
-// We can safely assume that our strings are stripped of their "s and
-// that strings do not contain new lines.
-
-// Greedy match escaped interpolation or any char. Do not match interpolation.
-string_any = @{ ANY }
-string_escaped_interpolation = @{ "\\"  ~ INTERPOLATION_START }
-// String is marked as compound atomic. We do not allow whitespace or similar.
-string_interpolated = ${ SOI ~ (
-                            // This is basically everything except an expression, using the escape trick from above.
-                            (!(INTERPOLATION_START) ~ ( string_escaped_interpolation | string_any))+ |
-                            // This is an expression. It's no more atomic.
-                            string_interpolate_escape
-                        )* ~ EOI }

--- a/libs/datamodel/schema-ast/src/parser/datamodel.pest
+++ b/libs/datamodel/schema-ast/src/parser/datamodel.pest
@@ -15,7 +15,7 @@
 // ######################################
 // Schema - the root of all rules
 // ######################################
-schema = { SOI ~ NEWLINE* ~ (model_declaration | enum_declaration | source_block | generator_block | type_alias | arbitrary_block | comment_block | NEWLINE | CATCH_ALL)* ~ EOI }
+schema = { SOI ~ NEWLINE* ~ (model_declaration | enum_declaration | config_block | type_alias | arbitrary_block | comment_block | NEWLINE | CATCH_ALL)* ~ EOI }
 
 // ######################################
 // Model and composite types
@@ -48,10 +48,9 @@ legacy_list_type = { "[" ~ non_empty_identifier ~ "]" }
 type_alias = { comment_block? ~ TYPE_KEYWORD ~ non_empty_identifier ~ "=" ~ (base_type ~ ( "@" ~ attribute )+ | base_type)  }
 
 // ######################################
-// Other kind of blocks
+// Configuration blocks
 // ######################################
-source_block = { comment_block? ~ DATASOURCE_KEYWORD ~ non_empty_identifier ~ BLOCK_OPEN ~ (key_value | doc_comment_and_new_line | comment_and_new_line | NEWLINE | BLOCK_LEVEL_CATCH_ALL)* ~ BLOCK_CLOSE }
-generator_block = { comment_block? ~ GENERATOR_KEYWORD ~ non_empty_identifier ~ BLOCK_OPEN ~ (key_value | doc_comment_and_new_line | comment_and_new_line | NEWLINE | BLOCK_LEVEL_CATCH_ALL)* ~ BLOCK_CLOSE }
+config_block = { comment_block? ~ (DATASOURCE_KEYWORD | GENERATOR_KEYWORD) ~ non_empty_identifier ~ BLOCK_OPEN ~ (key_value | doc_comment_and_new_line | comment_and_new_line | NEWLINE | BLOCK_LEVEL_CATCH_ALL)* ~ BLOCK_CLOSE }
 key_value = { non_empty_identifier ~ "=" ~ expression ~ NEWLINE }
 
 // a block definition without a keyword. Is not valid. Just acts as a catch for the parser to display a nice error.
@@ -107,12 +106,12 @@ BLOCK_CLOSE = { "}" }
 
 // those rules are silent because we don't want to handle the tokens
 ENUM_KEYWORD = _{ "enum" }
-GENERATOR_KEYWORD = _{ "generator" }
-DATASOURCE_KEYWORD = _{ "datasource" }
 
 // rules that we want to handle explicitly
 MODEL_KEYWORD = { "model" }
 TYPE_KEYWORD = { "type" }
+GENERATOR_KEYWORD = { "generator" }
+DATASOURCE_KEYWORD = { "datasource" }
 LEGACY_COLON = { ":" }
 
 CATCH_ALL = { (!NEWLINE ~ ANY)+ ~ NEWLINE? }

--- a/libs/datamodel/schema-ast/src/parser/parse_schema.rs
+++ b/libs/datamodel/schema-ast/src/parser/parse_schema.rs
@@ -3,7 +3,7 @@ use super::{
     parse_composite_type::parse_composite_type,
     parse_enum::parse_enum,
     parse_model::parse_model,
-    parse_source_and_generator::{parse_generator, parse_source},
+    parse_source_and_generator::parse_config_block,
     parse_types::parse_type_alias,
     PrismaDatamodelParser, Rule,
 };
@@ -36,8 +36,9 @@ pub fn parse_schema(datamodel_string: &str, diagnostics: &mut Diagnostics) -> Sc
 
                     },
                     Rule::enum_declaration => top_level_definitions.push(Top::Enum(parse_enum(&current, diagnostics))),
-                    Rule::source_block => top_level_definitions.push(Top::Source(parse_source(&current, diagnostics))),
-                    Rule::generator_block => top_level_definitions.push(Top::Generator(parse_generator(&current, diagnostics))),
+                    Rule::config_block => {
+                        top_level_definitions.push(parse_config_block(&current, diagnostics));
+                    },
                     Rule::type_alias => {
                         diagnostics.push_warning(DatamodelWarning::DeprecatedTypeAlias { span: current.as_span().into() });
                         top_level_definitions.push(Top::Type(parse_type_alias(&current)))


### PR DESCRIPTION
- Remove string interpolation grammar. It is not used and not planned.
- Deduplicate the grammar of datasource and generator blocks.

More details in commit messages.