### PR TITLE
SQLite: Treat nullable primary keys required

### DIFF
--- a/libs/sql-schema-describer/src/sqlite.rs
+++ b/libs/sql-schema-describer/src/sqlite.rs
@@ -252,12 +252,14 @@ impl<'a> SqlSchemaDescriber<'a> {
                 };
 
                 let pk_col = row.get("pk").and_then(|x| x.as_i64()).expect("primary key");
+
                 let col = Column {
                     name: row.get("name").and_then(|x| x.to_string()).expect("name"),
                     tpe,
                     default,
                     auto_increment: false,
                 };
+
                 if pk_col > 0 {
                     pk_cols.insert(pk_col, col.name.clone());
                 }
@@ -280,6 +282,7 @@ impl<'a> SqlSchemaDescriber<'a> {
         } else {
             let mut columns: Vec<PrimaryKeyColumn> = vec![];
             let mut col_idxs: Vec<&i64> = pk_cols.keys().collect();
+
             col_idxs.sort_unstable();
 
             for i in col_idxs {
@@ -296,6 +299,9 @@ impl<'a> SqlSchemaDescriber<'a> {
                                  is auto incrementing"
                         );
                         col.auto_increment = true;
+                        // It is impossible to write a null value to an
+                        // autoincrementing primary key column.
+                        col.tpe.arity = ColumnArity::Required;
                     }
                 }
             }

--- a/migration-engine/migration-engine-tests/tests/migrations/sqlite.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/sqlite.rs
@@ -82,3 +82,17 @@ fn creating_a_model_with_a_non_autoincrement_id_column_is_idempotent(api: TestAp
     api.schema_push_w_datasource(dm).send().assert_green();
     api.schema_push_w_datasource(dm).send().assert_green().assert_no_steps();
 }
+
+#[test_connector(tags(Sqlite))]
+fn treat_nullable_integer_primary_key_as_required(api: TestApi) {
+    let schema = r#"CREATE TABLE "a" ("id" INTEGER NULL, PRIMARY KEY("id"));"#;
+    api.raw_cmd(schema);
+
+    let dm = r#"
+        model a {
+          id Int @id @default(autoincrement())
+        }
+    "#;
+
+    api.schema_push_w_datasource(dm).send().assert_green().assert_no_steps();
+}


### PR DESCRIPTION
But only if they're autoincremented and of integer type. These values cannot be written as null, therefore we can decide them to be required and not causing any drift or broken migrations when we try to rewrite them as required in the following migration.

Also tested in this issue is what if we have a nullable primary key of some other type than integer. We introspect them as ignored tables, so the only bug we had here was in cases of nullable integer primary keys.

Closes: https://github.com/prisma/prisma/issues/9204