### PR TITLE
SQLite: treat `STRING` type as String

### DIFF
--- a/introspection-engine/introspection-engine-tests/tests/tables/sqlite.rs
+++ b/introspection-engine/introspection-engine-tests/tests/tables/sqlite.rs
@@ -1,6 +1,30 @@
 use indoc::indoc;
 use introspection_engine_tests::test_api::*;
 
+#[test_connector(tags(Sqlite))]
+async fn a_table_with_string_column(api: &TestApi) -> TestResult {
+    let setup = indoc! {r#"
+        CREATE TABLE "A" (
+           id INTEGER NOT NULL,
+           a  STRING  NOT NULL,
+           CONSTRAINT A_pkey PRIMARY KEY (id)
+        );
+    "#};
+
+    api.raw_cmd(setup).await;
+
+    let expectation = expect![[r#"
+        model A {
+          id Int    @id @default(autoincrement())
+          a  String
+        }
+    "#]];
+
+    expectation.assert_eq(&api.introspect_dml().await?);
+
+    Ok(())
+}
+
 #[test_connector(tags(Sqlite), preview_features("extendedIndexes"))]
 async fn a_table_with_descending_unique(api: &TestApi) -> TestResult {
     let setup = indoc! {r#"

--- a/libs/sql-schema-describer/src/sqlite.rs
+++ b/libs/sql-schema-describer/src/sqlite.rs
@@ -526,6 +526,7 @@ fn get_column_type(tpe: &str, arity: ColumnArity) -> ColumnType {
         "serial" => ColumnTypeFamily::Int,
         "boolean" => ColumnTypeFamily::Boolean,
         "text" => ColumnTypeFamily::String,
+        "string" => ColumnTypeFamily::String,
         s if s.contains("char") => ColumnTypeFamily::String,
         s if s.contains("numeric") => ColumnTypeFamily::Decimal,
         s if s.contains("decimal") => ColumnTypeFamily::Decimal,
@@ -544,6 +545,7 @@ fn get_column_type(tpe: &str, arity: ColumnArity) -> ColumnType {
         "int[]" => ColumnTypeFamily::Int,
         "integer[]" => ColumnTypeFamily::Int,
         "text[]" => ColumnTypeFamily::String,
+        "string[]" => ColumnTypeFamily::String,
         // NUMERIC type affinity
         data_type if data_type.starts_with("decimal") => ColumnTypeFamily::Decimal,
         data_type => ColumnTypeFamily::Unsupported(data_type.into()),


### PR DESCRIPTION
It's kind of stupid, but you can define a column as `STRING` and we should not treat that as unsupported.

Closes: https://github.com/prisma/prisma/issues/10347