### PR TITLE
prisma-fmt: Change the completion kind of referential actions

### DIFF
--- a/prisma-fmt/src/text_document_completion.rs
+++ b/prisma-fmt/src/text_document_completion.rs
@@ -103,7 +103,7 @@ fn push_ast_completions(
             for referential_action in connector.referential_actions(&referential_integrity).iter() {
                 items.push(CompletionItem {
                     label: referential_action.as_str().to_owned(),
-                    kind: Some(CompletionItemKind::CONSTANT),
+                    kind: Some(CompletionItemKind::ENUM),
                     detail: None, // what is the difference between detail and documentation?
                     documentation: Some(Documentation::String(referential_action.documentation().to_owned())),
                     ..Default::default()

--- a/prisma-fmt/tests/text_document_completion/scenarios/language_tools_relation_directive/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/language_tools_relation_directive/result.json
@@ -3,27 +3,27 @@
   "items": [
     {
       "label": "Cascade",
-      "kind": 21,
+      "kind": 13,
       "documentation": "Delete the child records when the parent record is deleted."
     },
     {
       "label": "Restrict",
-      "kind": 21,
+      "kind": 13,
       "documentation": "Prevent deleting a parent record as long as it is referenced."
     },
     {
       "label": "NoAction",
-      "kind": 21,
+      "kind": 13,
       "documentation": "Prevent deleting a parent record as long as it is referenced."
     },
     {
       "label": "SetNull",
-      "kind": 21,
+      "kind": 13,
       "documentation": "Set the referencing fields to NULL when the referenced record is deleted."
     },
     {
       "label": "SetDefault",
-      "kind": 21,
+      "kind": 13,
       "documentation": "Set the referencing field's value to the default when the referenced record is deleted."
     }
   ]

--- a/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_end_of_args_list/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_end_of_args_list/result.json
@@ -3,22 +3,22 @@
   "items": [
     {
       "label": "Cascade",
-      "kind": 21,
+      "kind": 13,
       "documentation": "Delete the child records when the parent record is deleted."
     },
     {
       "label": "NoAction",
-      "kind": 21,
+      "kind": 13,
       "documentation": "Prevent deleting a parent record as long as it is referenced."
     },
     {
       "label": "SetNull",
-      "kind": 21,
+      "kind": 13,
       "documentation": "Set the referencing fields to NULL when the referenced record is deleted."
     },
     {
       "label": "SetDefault",
-      "kind": 21,
+      "kind": 13,
       "documentation": "Set the referencing field's value to the default when the referenced record is deleted."
     }
   ]

--- a/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_in_progress/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_in_progress/result.json
@@ -3,22 +3,22 @@
   "items": [
     {
       "label": "Cascade",
-      "kind": 21,
+      "kind": 13,
       "documentation": "Delete the child records when the parent record is deleted."
     },
     {
       "label": "NoAction",
-      "kind": 21,
+      "kind": 13,
       "documentation": "Prevent deleting a parent record as long as it is referenced."
     },
     {
       "label": "SetNull",
-      "kind": 21,
+      "kind": 13,
       "documentation": "Set the referencing fields to NULL when the referenced record is deleted."
     },
     {
       "label": "SetDefault",
-      "kind": 21,
+      "kind": 13,
       "documentation": "Set the referencing field's value to the default when the referenced record is deleted."
     }
   ]

--- a/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_middle_of_args_list/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_middle_of_args_list/result.json
@@ -3,22 +3,22 @@
   "items": [
     {
       "label": "Cascade",
-      "kind": 21,
+      "kind": 13,
       "documentation": "Delete the child records when the parent record is deleted."
     },
     {
       "label": "NoAction",
-      "kind": 21,
+      "kind": 13,
       "documentation": "Prevent deleting a parent record as long as it is referenced."
     },
     {
       "label": "SetNull",
-      "kind": 21,
+      "kind": 13,
       "documentation": "Set the referencing fields to NULL when the referenced record is deleted."
     },
     {
       "label": "SetDefault",
-      "kind": 21,
+      "kind": 13,
       "documentation": "Set the referencing field's value to the default when the referenced record is deleted."
     }
   ]

--- a/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_mssql/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_mssql/result.json
@@ -3,22 +3,22 @@
   "items": [
     {
       "label": "Cascade",
-      "kind": 21,
+      "kind": 13,
       "documentation": "Delete the child records when the parent record is deleted."
     },
     {
       "label": "NoAction",
-      "kind": 21,
+      "kind": 13,
       "documentation": "Prevent deleting a parent record as long as it is referenced."
     },
     {
       "label": "SetNull",
-      "kind": 21,
+      "kind": 13,
       "documentation": "Set the referencing fields to NULL when the referenced record is deleted."
     },
     {
       "label": "SetDefault",
-      "kind": 21,
+      "kind": 13,
       "documentation": "Set the referencing field's value to the default when the referenced record is deleted."
     }
   ]

--- a/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_with_trailing_comma/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_with_trailing_comma/result.json
@@ -3,22 +3,22 @@
   "items": [
     {
       "label": "Cascade",
-      "kind": 21,
+      "kind": 13,
       "documentation": "Delete the child records when the parent record is deleted."
     },
     {
       "label": "NoAction",
-      "kind": 21,
+      "kind": 13,
       "documentation": "Prevent deleting a parent record as long as it is referenced."
     },
     {
       "label": "SetNull",
-      "kind": 21,
+      "kind": 13,
       "documentation": "Set the referencing fields to NULL when the referenced record is deleted."
     },
     {
       "label": "SetDefault",
-      "kind": 21,
+      "kind": 13,
       "documentation": "Set the referencing field's value to the default when the referenced record is deleted."
     }
   ]


### PR DESCRIPTION
That influences the icon of the completion item in the editor. This
commit aligns the completion kind of referential actions between
prisma-fmt-wasm and the TS language server.