### PR TITLE
Validate m2m relation fields do not contain referential actions

### DIFF
--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations.rs
@@ -148,6 +148,7 @@ pub(super) fn validate(ctx: &mut Context<'_>, relation_transformation_enabled: b
             }
             RefinedRelationWalker::ImplicitManyToMany(relation) => {
                 relations::many_to_many::validate_singular_id(relation, ctx);
+                relations::many_to_many::validate_no_referential_actions(relation, ctx);
             }
         }
     }

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/relations/many_to_many.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/relations/many_to_many.rs
@@ -37,3 +37,22 @@ pub(crate) fn validate_singular_id(relation: ImplicitManyToManyRelationWalker<'_
         }
     }
 }
+
+pub(crate) fn validate_no_referential_actions(
+    relation: ImplicitManyToManyRelationWalker<'_, '_>,
+    ctx: &mut Context<'_>,
+) {
+    let referential_action_spans = [relation.field_a(), relation.field_b()].into_iter().flat_map(|field| {
+        field
+            .explicit_on_delete_span()
+            .into_iter()
+            .chain(field.explicit_on_update_span().into_iter())
+    });
+
+    for span in referential_action_spans {
+        ctx.push_error(DatamodelError::new_validation_error(
+            "Referential actions on many-to-many relations are not supported".to_owned(),
+            span,
+        ));
+    }
+}

--- a/libs/datamodel/core/tests/attributes/relations/many_to_many_negative.rs
+++ b/libs/datamodel/core/tests/attributes/relations/many_to_many_negative.rs
@@ -1,0 +1,52 @@
+use expect_test::expect;
+
+#[test]
+fn many_to_many_relation_fields_with_referential_actions() {
+    let schema = r#"
+datasource db {
+  provider = "sqlite"
+  url      = "file:./dev.db"
+}
+
+model Track {
+  id        String     @id
+  title     String
+  playlists Playlist[] @relation(onDelete: Restrict, onUpdate: Restrict)
+}
+
+model Playlist {
+  id     String  @id
+  name   String
+  tracks Track[] @relation(onDelete: Restrict, onUpdate: Restrict)
+}
+    "#;
+
+    let expect = expect![[r#"
+        [1;91merror[0m: [1mError validating: Referential actions on many-to-many relations are not supported[0m
+          [1;94m-->[0m  [4mschema.prisma:16[0m
+        [1;94m   | [0m
+        [1;94m15 | [0m  name   String
+        [1;94m16 | [0m  tracks Track[] @relation(onDelete: [1;91mRestrict[0m, onUpdate: Restrict)
+        [1;94m   | [0m
+        [1;91merror[0m: [1mError validating: Referential actions on many-to-many relations are not supported[0m
+          [1;94m-->[0m  [4mschema.prisma:16[0m
+        [1;94m   | [0m
+        [1;94m15 | [0m  name   String
+        [1;94m16 | [0m  tracks Track[] @relation(onDelete: Restrict, onUpdate: [1;91mRestrict[0m)
+        [1;94m   | [0m
+        [1;91merror[0m: [1mError validating: Referential actions on many-to-many relations are not supported[0m
+          [1;94m-->[0m  [4mschema.prisma:10[0m
+        [1;94m   | [0m
+        [1;94m 9 | [0m  title     String
+        [1;94m10 | [0m  playlists Playlist[] @relation(onDelete: [1;91mRestrict[0m, onUpdate: Restrict)
+        [1;94m   | [0m
+        [1;91merror[0m: [1mError validating: Referential actions on many-to-many relations are not supported[0m
+          [1;94m-->[0m  [4mschema.prisma:10[0m
+        [1;94m   | [0m
+        [1;94m 9 | [0m  title     String
+        [1;94m10 | [0m  playlists Playlist[] @relation(onDelete: Restrict, onUpdate: [1;91mRestrict[0m)
+        [1;94m   | [0m
+    "#]];
+
+    expect.assert_eq(&datamodel::parse_schema(schema).map(drop).unwrap_err());
+}

--- a/libs/datamodel/core/tests/attributes/relations/mod.rs
+++ b/libs/datamodel/core/tests/attributes/relations/mod.rs
@@ -1,3 +1,4 @@
+mod many_to_many_negative;
 mod referential_actions;
 mod relations_negative;
 mod relations_new;

--- a/libs/datamodel/parser-database/src/attributes.rs
+++ b/libs/datamodel/parser-database/src/attributes.rs
@@ -684,7 +684,7 @@ fn visit_relation<'ast>(
     if let Some(on_delete) = args.optional_arg("onDelete") {
         match on_delete.as_referential_action() {
             Ok(action) => {
-                relation_field.on_delete = Some(action);
+                relation_field.on_delete = Some((action, on_delete.span()));
             }
             Err(err) => ctx.push_error(err),
         }
@@ -693,7 +693,7 @@ fn visit_relation<'ast>(
     if let Some(on_update) = args.optional_arg("onUpdate") {
         match on_update.as_referential_action() {
             Ok(action) => {
-                relation_field.on_update = Some(action);
+                relation_field.on_update = Some((action, on_update.span()));
             }
             Err(err) => ctx.push_error(err),
         }

--- a/libs/datamodel/parser-database/src/types.rs
+++ b/libs/datamodel/parser-database/src/types.rs
@@ -124,8 +124,8 @@ pub(crate) struct ScalarField<'ast> {
 #[derive(Debug)]
 pub(crate) struct RelationField<'ast> {
     pub(crate) referenced_model: ast::ModelId,
-    pub(crate) on_delete: Option<crate::ReferentialAction>,
-    pub(crate) on_update: Option<crate::ReferentialAction>,
+    pub(crate) on_delete: Option<(crate::ReferentialAction, ast::Span)>,
+    pub(crate) on_update: Option<(crate::ReferentialAction, ast::Span)>,
     /// The fields _explicitly present_ in the AST.
     pub(crate) fields: Option<Vec<ast::FieldId>>,
     /// The `references` fields _explicitly present_ in the AST.

--- a/libs/datamodel/parser-database/src/walkers/relation.rs
+++ b/libs/datamodel/parser-database/src/walkers/relation.rs
@@ -363,7 +363,11 @@ impl<'ast, 'db> CompleteInlineRelationWalker<'ast, 'db> {
     pub fn on_update(self) -> ReferentialAction {
         use ReferentialAction::*;
 
-        self.referencing_field().attributes().on_update.unwrap_or(Cascade)
+        self.referencing_field()
+            .attributes()
+            .on_update
+            .map(|(action, _)| action)
+            .unwrap_or(Cascade)
     }
 
     /// Prisma allows setting the relation field as optional, even if one of the

--- a/libs/datamodel/parser-database/src/walkers/relation_field.rs
+++ b/libs/datamodel/parser-database/src/walkers/relation_field.rs
@@ -61,12 +61,22 @@ impl<'ast, 'db> RelationFieldWalker<'ast, 'db> {
 
     /// The onDelete argument on the relation.
     pub fn explicit_on_delete(self) -> Option<ReferentialAction> {
-        self.attributes().on_delete
+        self.attributes().on_delete.map(|(action, _span)| action)
+    }
+
+    /// The onDelete argument on the relation.
+    pub fn explicit_on_delete_span(self) -> Option<ast::Span> {
+        self.attributes().on_delete.map(|(_action, span)| span)
     }
 
     /// The onUpdate argument on the relation.
     pub fn explicit_on_update(self) -> Option<ReferentialAction> {
-        self.attributes().on_update
+        self.attributes().on_update.map(|(action, _span)| action)
+    }
+
+    /// The onUpdate argument on the relation.
+    pub fn explicit_on_update_span(self) -> Option<ast::Span> {
+        self.attributes().on_update.map(|(_action, span)| span)
     }
 
     /// The relation name explicitly written in the schema source.


### PR DESCRIPTION
They are not supported and are no-ops, we should reject them.

relevant:  prisma/prisma#10861