### PR TITLE
Fix drift with missing sort order.

### DIFF
--- a/libs/sql-schema-describer/src/lib.rs
+++ b/libs/sql-schema-describer/src/lib.rs
@@ -269,6 +269,12 @@ pub enum SQLSortOrder {
     Desc,
 }
 
+impl Default for SQLSortOrder {
+    fn default() -> Self {
+        Self::Asc
+    }
+}
+
 impl AsRef<str> for SQLSortOrder {
     fn as_ref(&self) -> &str {
         match self {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/table.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/table.rs
@@ -168,7 +168,7 @@ fn indexes_match(first: &IndexWalker<'_>, second: &IndexWalker<'_>) -> bool {
         && left_cols.zip(right_cols).all(|(a, b)| {
             let names_match = a.as_column().name() == b.as_column().name();
             let lengths_match = a.length() == b.length();
-            let orders_match = a.sort_order() == b.sort_order();
+            let orders_match = a.sort_order().unwrap_or_default() == b.sort_order().unwrap_or_default();
 
             names_match && lengths_match && orders_match
         })


### PR DESCRIPTION
Sometimes the database gives us nothing, and sometimes `ASC` depending on its mood when sort order is not defined. We should compare `None` to be the same as `Some(Asc)` in these cases.

Closes: https://github.com/prisma/prisma/issues/10983
Hopefully helps with: https://github.com/prisma/prisma/issues/8687