### PR TITLE
text_document_completion: Make isIncomplete false by default

### DIFF
--- a/prisma-fmt/tests/text_document_completion/scenarios/argument_after_trailing_comma/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/argument_after_trailing_comma/result.json
@@ -1,4 +1,4 @@
 {
-  "isIncomplete": true,
+  "isIncomplete": false,
   "items": []
 }

--- a/prisma-fmt/tests/text_document_completion/scenarios/empty_schema/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/empty_schema/result.json
@@ -1,4 +1,4 @@
 {
-  "isIncomplete": true,
+  "isIncomplete": false,
   "items": []
 }

--- a/prisma-fmt/tests/text_document_completion/scenarios/language_tools_relation_directive/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/language_tools_relation_directive/result.json
@@ -4,27 +4,27 @@
     {
       "label": "Cascade",
       "kind": 13,
-      "documentation": "Delete the child records when the parent record is deleted."
+      "detail": "Delete the child records when the parent record is deleted."
     },
     {
       "label": "Restrict",
       "kind": 13,
-      "documentation": "Prevent deleting a parent record as long as it is referenced."
+      "detail": "Prevent deleting a parent record as long as it is referenced."
     },
     {
       "label": "NoAction",
       "kind": 13,
-      "documentation": "Prevent deleting a parent record as long as it is referenced."
+      "detail": "Prevent deleting a parent record as long as it is referenced."
     },
     {
       "label": "SetNull",
       "kind": 13,
-      "documentation": "Set the referencing fields to NULL when the referenced record is deleted."
+      "detail": "Set the referencing fields to NULL when the referenced record is deleted."
     },
     {
       "label": "SetDefault",
       "kind": 13,
-      "documentation": "Set the referencing field's value to the default when the referenced record is deleted."
+      "detail": "Set the referencing field's value to the default when the referenced record is deleted."
     }
   ]
 }

--- a/prisma-fmt/tests/text_document_completion/scenarios/no_default_map_on_postgres/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/no_default_map_on_postgres/result.json
@@ -1,4 +1,4 @@
 {
-  "isIncomplete": true,
+  "isIncomplete": false,
   "items": []
 }

--- a/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_end_of_args_list/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_end_of_args_list/result.json
@@ -4,22 +4,22 @@
     {
       "label": "Cascade",
       "kind": 13,
-      "documentation": "Delete the child records when the parent record is deleted."
+      "detail": "Delete the child records when the parent record is deleted."
     },
     {
       "label": "NoAction",
       "kind": 13,
-      "documentation": "Prevent deleting a parent record as long as it is referenced."
+      "detail": "Prevent deleting a parent record as long as it is referenced."
     },
     {
       "label": "SetNull",
       "kind": 13,
-      "documentation": "Set the referencing fields to NULL when the referenced record is deleted."
+      "detail": "Set the referencing fields to NULL when the referenced record is deleted."
     },
     {
       "label": "SetDefault",
       "kind": 13,
-      "documentation": "Set the referencing field's value to the default when the referenced record is deleted."
+      "detail": "Set the referencing field's value to the default when the referenced record is deleted."
     }
   ]
 }

--- a/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_in_progress/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_in_progress/result.json
@@ -4,22 +4,22 @@
     {
       "label": "Cascade",
       "kind": 13,
-      "documentation": "Delete the child records when the parent record is deleted."
+      "detail": "Delete the child records when the parent record is deleted."
     },
     {
       "label": "NoAction",
       "kind": 13,
-      "documentation": "Prevent deleting a parent record as long as it is referenced."
+      "detail": "Prevent deleting a parent record as long as it is referenced."
     },
     {
       "label": "SetNull",
       "kind": 13,
-      "documentation": "Set the referencing fields to NULL when the referenced record is deleted."
+      "detail": "Set the referencing fields to NULL when the referenced record is deleted."
     },
     {
       "label": "SetDefault",
       "kind": 13,
-      "documentation": "Set the referencing field's value to the default when the referenced record is deleted."
+      "detail": "Set the referencing field's value to the default when the referenced record is deleted."
     }
   ]
 }

--- a/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_middle_of_args_list/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_middle_of_args_list/result.json
@@ -4,22 +4,22 @@
     {
       "label": "Cascade",
       "kind": 13,
-      "documentation": "Delete the child records when the parent record is deleted."
+      "detail": "Delete the child records when the parent record is deleted."
     },
     {
       "label": "NoAction",
       "kind": 13,
-      "documentation": "Prevent deleting a parent record as long as it is referenced."
+      "detail": "Prevent deleting a parent record as long as it is referenced."
     },
     {
       "label": "SetNull",
       "kind": 13,
-      "documentation": "Set the referencing fields to NULL when the referenced record is deleted."
+      "detail": "Set the referencing fields to NULL when the referenced record is deleted."
     },
     {
       "label": "SetDefault",
       "kind": 13,
-      "documentation": "Set the referencing field's value to the default when the referenced record is deleted."
+      "detail": "Set the referencing field's value to the default when the referenced record is deleted."
     }
   ]
 }

--- a/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_mssql/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_mssql/result.json
@@ -4,22 +4,22 @@
     {
       "label": "Cascade",
       "kind": 13,
-      "documentation": "Delete the child records when the parent record is deleted."
+      "detail": "Delete the child records when the parent record is deleted."
     },
     {
       "label": "NoAction",
       "kind": 13,
-      "documentation": "Prevent deleting a parent record as long as it is referenced."
+      "detail": "Prevent deleting a parent record as long as it is referenced."
     },
     {
       "label": "SetNull",
       "kind": 13,
-      "documentation": "Set the referencing fields to NULL when the referenced record is deleted."
+      "detail": "Set the referencing fields to NULL when the referenced record is deleted."
     },
     {
       "label": "SetDefault",
       "kind": 13,
-      "documentation": "Set the referencing field's value to the default when the referenced record is deleted."
+      "detail": "Set the referencing field's value to the default when the referenced record is deleted."
     }
   ]
 }

--- a/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_with_trailing_comma/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_with_trailing_comma/result.json
@@ -4,22 +4,22 @@
     {
       "label": "Cascade",
       "kind": 13,
-      "documentation": "Delete the child records when the parent record is deleted."
+      "detail": "Delete the child records when the parent record is deleted."
     },
     {
       "label": "NoAction",
       "kind": 13,
-      "documentation": "Prevent deleting a parent record as long as it is referenced."
+      "detail": "Prevent deleting a parent record as long as it is referenced."
     },
     {
       "label": "SetNull",
       "kind": 13,
-      "documentation": "Set the referencing fields to NULL when the referenced record is deleted."
+      "detail": "Set the referencing fields to NULL when the referenced record is deleted."
     },
     {
       "label": "SetDefault",
       "kind": 13,
-      "documentation": "Set the referencing field's value to the default when the referenced record is deleted."
+      "detail": "Set the referencing field's value to the default when the referenced record is deleted."
     }
   ]
 }


### PR DESCRIPTION
The consequence is that the client will not ask for the completion again
_for the same position_, which is what we want.

reference: https://docs.microsoft.com/en-us/dotnet/api/microsoft.visualstudio.languageserver.protocol.completionlist.isincomplete?view=visualstudiosdk-2022