### PR TITLE
datamodel: Simplify reformatter

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1639566195,
-        "narHash": "sha256-ZnTBGSV6bTwopdDibmsBaAkedmTZC/rOgwQzOGcOD+s=",
+        "lastModified": 1641760999,
+        "narHash": "sha256-UhSV8Qe8TBrZksBZSYqwNsWFY7EgCJCJTlRxXJSL4Jg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3c52ea8c9216a0d5b7a7b4d74a9d2e858b06df5c",
+        "rev": "8928525bd8b8cdc1235a92a89b72cbbe5bd8a00d",
         "type": "github"
       },
       "original": {

--- a/libs/datamodel/core/src/transform/ast_to_dml/lift.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/lift.rs
@@ -297,8 +297,6 @@ impl<'a> LiftAstToDml<'a> {
         model.indices = walker
             .indexes()
             .map(|idx| {
-                assert!(idx.fields().len() != 0);
-
                 let fields = idx
                     .scalar_field_attributes()
                     .map(|field| IndexField {

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline.rs
@@ -27,7 +27,6 @@ pub(crate) fn validate<'ast>(
     sources: &[configuration::Datasource],
     preview_features: BitFlags<PreviewFeature>,
     diagnostics: Diagnostics,
-    relation_transformation_enabled: bool,
 ) -> ValidateOutput<'ast> {
     let source = sources.first();
     let connector = source.map(|s| s.active_connector).unwrap_or(&EmptyDatamodelConnector);
@@ -57,7 +56,7 @@ pub(crate) fn validate<'ast>(
         diagnostics: &mut output.diagnostics,
     };
 
-    validations::validate(&mut context, relation_transformation_enabled);
+    validations::validate(&mut context);
 
     output
 }

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations.rs
@@ -14,7 +14,7 @@ use crate::{ast, transform::ast_to_dml::db::walkers::RefinedRelationWalker};
 use diagnostics::DatamodelError;
 use names::Names;
 
-pub(super) fn validate(ctx: &mut Context<'_>, relation_transformation_enabled: bool) {
+pub(super) fn validate(ctx: &mut Context<'_>) {
     let db = ctx.db;
     let connector = ctx.connector;
 
@@ -125,25 +125,20 @@ pub(super) fn validate(ctx: &mut Context<'_>, relation_transformation_enabled: b
                 relations::referencing_scalar_field_types(relation, ctx);
                 relations::has_a_unique_constraint_name(&names, relation, ctx);
 
-                // Only run these when you are not formatting the data model. These validations
-                // test against broken relations that we could fix with a code action. The flag is
-                // set when prisma-fmt calls this code.
-                if !relation_transformation_enabled {
-                    if relation.is_one_to_one() {
-                        relations::one_to_one::both_sides_are_defined(relation, ctx);
-                        relations::one_to_one::fields_and_references_are_defined(relation, ctx);
-                        relations::one_to_one::fields_and_references_defined_on_one_side_only(relation, ctx);
-                        relations::one_to_one::referential_actions(relation, ctx);
+                if relation.is_one_to_one() {
+                    relations::one_to_one::both_sides_are_defined(relation, ctx);
+                    relations::one_to_one::fields_and_references_are_defined(relation, ctx);
+                    relations::one_to_one::fields_and_references_defined_on_one_side_only(relation, ctx);
+                    relations::one_to_one::referential_actions(relation, ctx);
 
-                        // Run these validations last to prevent validation spam.
-                        relations::one_to_one::fields_references_mixups(relation, ctx);
-                        relations::one_to_one::back_relation_arity_is_optional(relation, ctx);
-                        relations::one_to_one::fields_and_references_on_wrong_side(relation, ctx);
-                    } else {
-                        relations::one_to_many::both_sides_are_defined(relation, ctx);
-                        relations::one_to_many::fields_and_references_are_defined(relation, ctx);
-                        relations::one_to_many::referential_actions(relation, ctx);
-                    }
+                    // Run these validations last to prevent validation spam.
+                    relations::one_to_one::fields_references_mixups(relation, ctx);
+                    relations::one_to_one::back_relation_arity_is_optional(relation, ctx);
+                    relations::one_to_one::fields_and_references_on_wrong_side(relation, ctx);
+                } else {
+                    relations::one_to_many::both_sides_are_defined(relation, ctx);
+                    relations::one_to_many::fields_and_references_are_defined(relation, ctx);
+                    relations::one_to_many::referential_actions(relation, ctx);
                 }
             }
             RefinedRelationWalker::ImplicitManyToMany(relation) => {


### PR DESCRIPTION
- Lift without validating: we don't return errors, so we just have to
  make sure we can produce DML.
  - In the future, we want to push DML out of the picture and
    progressively move the relation fixing logic to code actions. In the
    meantime, the relation fixing could be done more safely and easily
    without lifting with the parser db.
  - Consequence: we can remove conditional validation tada
- Do not assume the reformatter can return errors. It can't, and it's
  not its role.