### PR TITLE
fix: add cockroachdb to active features

### DIFF
--- a/libs/datamodel/core/src/common/preview_features.rs
+++ b/libs/datamodel/core/src/common/preview_features.rs
@@ -81,8 +81,8 @@ pub static GENERATOR: Lazy<FeatureMap> = Lazy::new(|| {
             FullTextIndex,
             DataProxy,
             ExtendedIndexes,
+            Cockroachdb,
         ])
-        .with_hidden(vec![Cockroachdb])
         .with_deprecated(vec![
             AtomicNumberOperations,
             AggregateApi,

--- a/libs/datamodel/core/tests/config/generators.rs
+++ b/libs/datamodel/core/tests/config/generators.rs
@@ -259,7 +259,7 @@ fn nice_error_for_unknown_generator_preview_feature() {
         .unwrap_err();
 
     let expectation = expect![[r#"
-        [1;91merror[0m: [1mThe preview feature "foo" is not known. Expected one of: filterJson, referentialIntegrity, mongoDb, interactiveTransactions, fullTextSearch, fullTextIndex, dataProxy, extendedIndexes[0m
+        [1;91merror[0m: [1mThe preview feature "foo" is not known. Expected one of: filterJson, referentialIntegrity, mongoDb, interactiveTransactions, fullTextSearch, fullTextIndex, dataProxy, extendedIndexes, cockroachdb[0m
           [1;94m-->[0m  [4mschema.prisma:3[0m
         [1;94m   | [0m
         [1;94m 2 | [0m  provider = "prisma-client-js"


### PR DESCRIPTION
Adds cockroachdb to the list of active features. 

⚠️⚠️  Warning don't merge until after 3.8 release. ⚠️⚠️  

https://github.com/prisma/prisma/issues/10808