### PR TITLE
Walkers: rename final_database_name() methods

### DIFF
--- a/libs/datamodel/core/src/transform/ast_to_dml/lift.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/lift.rs
@@ -277,7 +277,7 @@ impl<'a> LiftAstToDml<'a> {
 
         model.primary_key = walker.primary_key().map(|pk| dml::PrimaryKeyDefinition {
             name: pk.name().map(String::from),
-            db_name: pk.final_database_name(self.connector).map(|c| c.into_owned()),
+            db_name: pk.constraint_name(self.connector).map(|c| c.into_owned()),
             fields: pk
                 .scalar_field_attributes()
                 .map(|field|
@@ -319,7 +319,7 @@ impl<'a> LiftAstToDml<'a> {
 
                 dml::IndexDefinition {
                     name: idx.name().map(String::from),
-                    db_name: Some(idx.final_database_name(self.connector).into_owned()),
+                    db_name: Some(idx.constraint_name(self.connector).into_owned()),
                     fields,
                     tpe,
                     algorithm,

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/constraint_namespace.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/constraint_namespace.rs
@@ -67,7 +67,7 @@ impl<'ast> ConstraintNamespace<'ast> {
         for index in db.walk_models().flat_map(|m| m.indexes()) {
             let counter = self
                 .global
-                .entry((scope, index.final_database_name(connector)))
+                .entry((scope, index.constraint_name(connector)))
                 .or_default();
             *counter += 1;
         }
@@ -98,7 +98,7 @@ impl<'ast> ConstraintNamespace<'ast> {
         scope: ConstraintScope,
     ) {
         for model in db.walk_models() {
-            if let Some(name) = model.primary_key().and_then(|k| k.final_database_name(connector)) {
+            if let Some(name) = model.primary_key().and_then(|k| k.constraint_name(connector)) {
                 let counter = self.global.entry((scope, name)).or_default();
                 *counter += 1;
             }
@@ -136,7 +136,7 @@ impl<'ast> ConstraintNamespace<'ast> {
             for index in model.indexes() {
                 let counter = self
                     .local
-                    .entry((model.model_id(), scope, index.final_database_name(connector)))
+                    .entry((model.model_id(), scope, index.constraint_name(connector)))
                     .or_default();
 
                 *counter += 1;
@@ -152,7 +152,7 @@ impl<'ast> ConstraintNamespace<'ast> {
         scope: ConstraintScope,
     ) {
         for model in db.walk_models() {
-            if let Some(name) = model.primary_key().and_then(|pk| pk.final_database_name(connector)) {
+            if let Some(name) = model.primary_key().and_then(|pk| pk.constraint_name(connector)) {
                 let counter = self.local.entry((model.model_id(), scope, name)).or_default();
                 *counter += 1;
             }

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/indexes.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/indexes.rs
@@ -18,7 +18,7 @@ pub(super) fn has_a_unique_constraint_name(
     names: &super::Names<'_>,
     ctx: &mut Context<'_>,
 ) {
-    let name = index.final_database_name(ctx.connector);
+    let name = index.constraint_name(ctx.connector);
     let model = index.model();
 
     for violation in names

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/models.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/models.rs
@@ -64,7 +64,7 @@ pub(super) fn has_a_unique_primary_key_name(
 ) {
     let (pk, name): (PrimaryKeyWalker<'_, '_>, Cow<'_, str>) = match model
         .primary_key()
-        .and_then(|pk| pk.final_database_name(ctx.connector).map(|name| (pk, name)))
+        .and_then(|pk| pk.constraint_name(ctx.connector).map(|name| (pk, name)))
     {
         Some((pk, name)) => (pk, name),
         None => return,

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/relation_fields.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/relation_fields.rs
@@ -187,7 +187,7 @@ pub(super) fn referential_actions(field: RelationFieldWalker<'_, '_>, ctx: &mut 
 }
 
 pub(super) fn map(field: RelationFieldWalker<'_, '_>, ctx: &mut Context<'_>) {
-    if field.foreign_key_name().is_none() {
+    if field.mapped_name().is_none() {
         return;
     }
 
@@ -209,12 +209,6 @@ pub(super) fn map(field: RelationFieldWalker<'_, '_>, ctx: &mut Context<'_>) {
         .iter()
         .find(|attr| attr.name() == "relation")
     {
-        validate_db_name(
-            field.model().name(),
-            relation_attr,
-            field.foreign_key_name(),
-            ctx,
-            false,
-        );
+        validate_db_name(field.model().name(), relation_attr, field.mapped_name(), ctx, false);
     }
 }

--- a/libs/datamodel/parser-database/src/attributes/id.rs
+++ b/libs/datamodel/parser-database/src/attributes/id.rs
@@ -74,21 +74,21 @@ pub(super) fn model<'ast>(
         ))
     }
 
-    let (name, db_name) = {
-        let db_name = primary_key_constraint_name(args, ctx);
+    let (name, mapped_name) = {
+        let mapped_name = primary_key_mapped_name(args, ctx);
         let name = super::get_name_argument(args, ctx);
 
         if let Some(name) = name {
             super::validate_client_name(args.span(), &ast_model.name.name, name, "@@id", ctx);
         }
 
-        (name, db_name)
+        (name, mapped_name)
     };
 
     model_data.primary_key = Some(IdAttribute {
         name,
         source_attribute: args.attribute(),
-        db_name,
+        mapped_name,
         fields: resolved_fields,
         source_field: None,
     });
@@ -107,7 +107,7 @@ pub(super) fn field<'ast>(
             ast_model.span,
         )),
         None => {
-            let db_name = primary_key_constraint_name(args, ctx);
+            let mapped_name = primary_key_mapped_name(args, ctx);
 
             let length = match args.optional_arg("length").map(|length| length.as_int()) {
                 Some(Ok(length)) => Some(length as u32),
@@ -137,7 +137,7 @@ pub(super) fn field<'ast>(
 
             model_attributes.primary_key = Some(IdAttribute {
                 name: None,
-                db_name,
+                mapped_name,
                 source_attribute: args.attribute(),
                 fields: vec![FieldWithArgs {
                     field_id,
@@ -180,8 +180,8 @@ pub(super) fn validate_id_field_arities(
     }
 }
 
-fn primary_key_constraint_name<'ast>(args: &mut Arguments<'ast>, ctx: &mut Context<'ast>) -> Option<&'ast str> {
-    let db_name = match args.optional_arg("map").map(|name| name.as_str()) {
+fn primary_key_mapped_name<'ast>(args: &mut Arguments<'ast>, ctx: &mut Context<'ast>) -> Option<&'ast str> {
+    let mapped_name = match args.optional_arg("map").map(|name| name.as_str()) {
         Some(Ok("")) => {
             ctx.push_error(args.new_attribute_validation_error("The `map` argument cannot be an empty string."));
             None
@@ -194,5 +194,5 @@ fn primary_key_constraint_name<'ast>(args: &mut Arguments<'ast>, ctx: &mut Conte
         None => None,
     };
 
-    db_name
+    mapped_name
 }

--- a/libs/datamodel/parser-database/src/indexes.rs
+++ b/libs/datamodel/parser-database/src/indexes.rs
@@ -66,7 +66,7 @@ pub(super) fn infer_implicit_indexes(ctx: &mut Context<'_>) {
                     })
                     .collect(),
                 source_field,
-                db_name: None,
+                mapped_name: None,
                 ..Default::default()
             },
         ));

--- a/libs/datamodel/parser-database/src/lib.rs
+++ b/libs/datamodel/parser-database/src/lib.rs
@@ -12,15 +12,18 @@
 //!
 //! Names:
 //!
+//! - _name_: the item name in the schema for datasources, generators, models, model fields,
+//!   composite types, composite type fields, enums and enum variants. The `name:` argument for
+//!   unique constraints, primary keys and relations.
 //! - _mapped name_: the name inside an `@map()` or `@@map()` attribute of a model, field, enum or
 //!   enum value. This is used to determine what the name of the Prisma schema item is in the
 //!   database.
 //! - _database name_: the name in the database, once both the name of the item and the mapped
 //!   name have been taken into account. The logic is always the same: if a mapped name is defined,
 //!   then the database name is the mapped name, otherwise it is the name of the item.
-//! - _foreign key name_: the name inside the `map: ...` argument inside an `@relation()`
-//!   attribute. This is taken as the database name of the constraint backing the relation, on the
-//!   connectors where that makes sense.
+//! - _constraint name_: indexes, primary keys and defaults can have a constraint name. It can be
+//!   defined with a `map:` argument or be a default, generated name if the `map:` argument is not
+//!   provided. These usually require a datamodel connector to be defined.
 
 pub mod walkers;
 

--- a/libs/datamodel/parser-database/src/types.rs
+++ b/libs/datamodel/parser-database/src/types.rs
@@ -133,8 +133,8 @@ pub(crate) struct RelationField<'ast> {
     /// The name _explicitly present_ in the AST.
     pub(crate) name: Option<&'ast str>,
     pub(crate) is_ignored: bool,
-    /// The fk_name _explicitly present_ in the AST through the map argument.
-    pub(crate) fk_name: Option<&'ast str>,
+    /// The foreign key name _explicitly present_ in the AST through the `@map` attribute.
+    pub(crate) mapped_name: Option<&'ast str>,
     pub(crate) relation_attribute: Option<&'ast ast::Attribute>,
 }
 
@@ -148,7 +148,7 @@ impl RelationField<'_> {
             references: None,
             name: None,
             is_ignored: false,
-            fk_name: None,
+            mapped_name: None,
             relation_attribute: None,
         }
     }
@@ -219,7 +219,7 @@ pub(crate) struct IndexAttribute<'ast> {
     pub(crate) fields: Vec<FieldWithArgs>,
     pub(crate) source_field: Option<ast::FieldId>,
     pub(crate) name: Option<&'ast str>,
-    pub(crate) db_name: Option<&'ast str>,
+    pub(crate) mapped_name: Option<&'ast str>,
     pub(crate) algorithm: Option<IndexAlgorithm>,
 }
 
@@ -239,7 +239,7 @@ pub(crate) struct IdAttribute<'ast> {
     pub(super) source_field: Option<ast::FieldId>,
     pub(super) source_attribute: &'ast ast::Attribute,
     pub(super) name: Option<&'ast str>,
-    pub(super) db_name: Option<&'ast str>,
+    pub(super) mapped_name: Option<&'ast str>,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/libs/datamodel/parser-database/src/walkers/index.rs
+++ b/libs/datamodel/parser-database/src/walkers/index.rs
@@ -22,7 +22,7 @@ impl<'ast, 'db> IndexWalker<'ast, 'db> {
     ///                      ^^^^^^^^^
     /// ```
     pub fn mapped_name(self) -> Option<&'ast str> {
-        self.index_attribute.db_name
+        self.index_attribute.mapped_name
     }
 
     /// The attribute name: `"unique"` for `@@unique`, `"fulltext"` for `@@fultext` and `"index"`

--- a/libs/datamodel/parser-database/src/walkers/model.rs
+++ b/libs/datamodel/parser-database/src/walkers/model.rs
@@ -90,7 +90,7 @@ impl<'ast, 'db> ModelWalker<'ast, 'db> {
 
     /// The name of the database table the model points to.
     #[allow(clippy::unnecessary_lazy_evaluations)] // respectfully disagree
-    pub fn final_database_name(self) -> &'ast str {
+    pub fn database_name(self) -> &'ast str {
         self.model_attributes
             .mapped_name
             .unwrap_or_else(|| &self.db.ast[self.model_id].name.name)
@@ -98,7 +98,7 @@ impl<'ast, 'db> ModelWalker<'ast, 'db> {
 
     /// Get the database names of the constrained scalar fields.
     #[allow(clippy::unnecessary_lazy_evaluations)] // respectfully disagree
-    pub fn get_field_db_names<'a>(&'a self, fields: &'a [ast::FieldId]) -> impl Iterator<Item = &'ast str> + 'a {
+    pub fn get_field_database_names<'a>(&'a self, fields: &'a [ast::FieldId]) -> impl Iterator<Item = &'ast str> + 'a {
         fields.iter().map(move |&field_id| {
             self.db.types.scalar_fields[&(self.model_id, field_id)]
                 .mapped_name

--- a/libs/datamodel/parser-database/src/walkers/model/primary_key.rs
+++ b/libs/datamodel/parser-database/src/walkers/model/primary_key.rs
@@ -26,7 +26,7 @@ impl<'ast, 'db> PrimaryKeyWalker<'ast, 'db> {
     ///                   ^^^^^^^^^
     /// ```
     pub fn mapped_name(self) -> Option<&'ast str> {
-        self.attribute.db_name
+        self.attribute.mapped_name
     }
 
     /// Is this an `@id` on a specific field, rather than on the model?

--- a/libs/datamodel/parser-database/src/walkers/relation.rs
+++ b/libs/datamodel/parser-database/src/walkers/relation.rs
@@ -204,8 +204,8 @@ impl<'ast, 'db> InlineRelationWalker<'ast, 'db> {
     }
 
     /// The contents of the `map: ...` argument of the `@relation` attribute.
-    pub fn foreign_key_name(self) -> Option<&'ast str> {
-        self.forward_relation_field().and_then(|field| field.foreign_key_name())
+    pub fn mapped_name(self) -> Option<&'ast str> {
+        self.forward_relation_field().and_then(|field| field.mapped_name())
     }
 
     /// The back relation field, or virtual relation field (on model B, the referenced model).

--- a/libs/datamodel/parser-database/src/walkers/relation_field.rs
+++ b/libs/datamodel/parser-database/src/walkers/relation_field.rs
@@ -41,8 +41,8 @@ impl<'ast, 'db> RelationFieldWalker<'ast, 'db> {
     }
 
     /// The foreign key name of the relation (`@relation(map: ...)`).
-    pub fn foreign_key_name(self) -> Option<&'ast str> {
-        self.attributes().fk_name
+    pub fn mapped_name(self) -> Option<&'ast str> {
+        self.attributes().mapped_name
     }
 
     /// The field name.

--- a/migration-engine/connectors/mongodb-migration-connector/src/schema_calculator.rs
+++ b/migration-engine/connectors/mongodb-migration-connector/src/schema_calculator.rs
@@ -11,10 +11,10 @@ pub(crate) fn calculate(datamodel: &ValidatedSchema<'_>) -> MongoSchema {
     let connector = mongodb_datamodel_connector::MongoDbDatamodelConnector;
 
     for model in datamodel.db.walk_models() {
-        let collection_id = schema.push_collection(model.final_database_name().to_owned());
+        let collection_id = schema.push_collection(model.database_name().to_owned());
 
         for index in model.indexes() {
-            let name = index.final_database_name(&connector);
+            let name = index.constraint_name(&connector);
             let fields = index
                 .scalar_field_attributes()
                 .map(|field| (field.as_scalar_field().database_name(), field.sort_order()))

--- a/migration-engine/connectors/sql-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/lib.rs
@@ -271,7 +271,7 @@ impl MigrationConnector for SqlMigrationConnector {
                         next_datamodel
                             .db
                             .walk_models()
-                            .find(|model| model.final_database_name() == table.name())
+                            .find(|model| model.database_name() == table.name())
                             .and_then(|model| model.scalar_fields().find(|sf| sf.name() == column.name()))
                             .filter(|field| {
                                 field

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
@@ -54,7 +54,7 @@ fn push_model_tables(ctx: &mut Context<'_>) {
                 .collect(),
             sequence: None,
             constraint_name: pk
-                .final_database_name(ctx.flavour.datamodel_connector())
+                .constraint_name(ctx.flavour.datamodel_connector())
                 .map(|c| c.into_owned()),
         });
 
@@ -85,9 +85,7 @@ fn push_model_tables(ctx: &mut Context<'_>) {
                 });
 
                 sql::Index {
-                    name: index
-                        .final_database_name(ctx.flavour.datamodel_connector())
-                        .into_owned(),
+                    name: index.constraint_name(ctx.flavour.datamodel_connector()).into_owned(),
                     // The model index definition uses the model field names, but the SQL Index wants the column names.
                     columns,
                     tpe: index_type,
@@ -97,7 +95,7 @@ fn push_model_tables(ctx: &mut Context<'_>) {
             .collect();
 
         let mut table = sql::Table {
-            name: model.final_database_name().to_owned(),
+            name: model.database_name().to_owned(),
             columns,
             indices,
             primary_key,
@@ -134,7 +132,7 @@ fn push_inline_relations(model: ModelWalker<'_, '_>, table: &mut sql::Table, ctx
         table.foreign_keys.push(sql::ForeignKey {
             constraint_name: Some(relation.constraint_name(ctx.flavour.datamodel_connector()).into_owned()),
             columns: fk_columns,
-            referenced_table: relation.referenced_model().final_database_name().to_owned(),
+            referenced_table: relation.referenced_model().database_name().to_owned(),
             referenced_columns: relation_field
                 .referenced_fields()
                 .expect("Expected references to be defined on relation field")
@@ -172,7 +170,7 @@ fn push_relation_tables(ctx: &mut Context<'_>) {
                 sql::ForeignKey {
                     constraint_name: None,
                     columns: vec![model_a_column.into()],
-                    referenced_table: model_a.final_database_name().into(),
+                    referenced_table: model_a.database_name().into(),
                     referenced_columns: vec![model_a_id.database_name().into()],
                     on_update_action: flavour.m2m_foreign_key_action(model_a, model_b),
                     on_delete_action: flavour.m2m_foreign_key_action(model_a, model_b),
@@ -180,7 +178,7 @@ fn push_relation_tables(ctx: &mut Context<'_>) {
                 sql::ForeignKey {
                     constraint_name: None,
                     columns: vec![model_b_column.into()],
-                    referenced_table: model_b.final_database_name().into(),
+                    referenced_table: model_b.database_name().into(),
                     referenced_columns: vec![model_b_id.database_name().into()],
                     on_update_action: flavour.m2m_foreign_key_action(model_a, model_b),
                     on_delete_action: flavour.m2m_foreign_key_action(model_a, model_b),

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/mysql.rs
@@ -19,7 +19,7 @@ impl SqlSchemaCalculatorFlavour for MysqlFlavour {
             let sql_enum = sql::Enum {
                 name: format!(
                     "{model_name}_{field_name}",
-                    model_name = field.model().final_database_name(),
+                    model_name = field.model().database_name(),
                     field_name = field.database_name()
                 ),
                 values: enum_tpe.values().map(|v| v.database_name().to_owned()).collect(),
@@ -39,11 +39,7 @@ impl SqlSchemaCalculatorFlavour for MysqlFlavour {
         let arity = super::super::column_arity(field.ast_field().arity);
 
         sql::ColumnType::pure(
-            sql::ColumnTypeFamily::Enum(format!(
-                "{}_{}",
-                field.model().final_database_name(),
-                field.database_name()
-            )),
+            sql::ColumnTypeFamily::Enum(format!("{}_{}", field.model().database_name(), field.database_name())),
             arity,
         )
     }

--- a/migration-engine/qe-setup/src/mongodb.rs
+++ b/migration-engine/qe-setup/src/mongodb.rs
@@ -23,7 +23,7 @@ pub(crate) async fn mongo_setup(schema: &str, url: &str) -> ConnectorResult<()> 
     for model in parsed_schema.db.walk_models() {
         client
             .database(&db_name)
-            .create_collection(model.final_database_name(), None)
+            .create_collection(model.database_name(), None)
             .await
             .unwrap();
     }


### PR DESCRIPTION
This is to align terminology on what is documented in parser_database
crate docs.

- For primary keys and indexes, final_database_name() is the constraint
  name (renamed to constraint_name()). It can be explicit from the
  schema, or a generated default.
- For models, final_database_name() is what is documented as database
  name in parser database, so it is renamed to database_name() to align
  with other walkers.

Additionally, we rename RelationFieldWalker::foreign_key_name() and
RelationWalker::foreign_key_name() to mapped_name() for consistency.
They also have a constraint_name() method in datamodel connector that
could be confused with foreign_key_name otherwise.

In the public API of datamodel (except DML) and parser database, the use
of the following terms should now be consistent: name, mapped name,
database name, constraint name.