### PR TITLE
Passing trace id from JS client to a database comment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -311,25 +311,13 @@ services:
     networks:
       - databases
 
-  jaeger:
-    image: jaegertracing/all-in-one:latest
-    restart: always
+  otel:
+    image: jaegertracing/opentelemetry-all-in-one:latest
     ports:
-      - "16686:16686" # the trace viewer (http)
-    networks:
-      - telemetry
-
-  otel-agent:
-    image: otel/opentelemetry-collector-dev:latest
-    command: [ "--config=/etc/otel-agent-config.yaml" ]
-    restart: always
-    volumes:
-      - ./otel-agent-config.yaml:/etc/otel-agent-config.yaml
-    ports:
-      - 13133:13133 # health check port
-      - 16686:16686 # UI viewer
-      - 4317:55680 # Otel endpoint
+      - 13133:13133
+      - 16686:16686
+      - 4317:55680
 
 networks:
   databases: null
-  telemetry: null
+

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/direct.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/direct.rs
@@ -45,7 +45,7 @@ impl RunnerInterface for DirectRunner {
         let handler = GraphQlHandler::new(&*self.executor, &self.query_schema);
         let query = GraphQlBody::Single(query.into());
 
-        Ok(handler.handle(query, self.current_tx_id.clone()).await.into())
+        Ok(handler.handle(query, self.current_tx_id.clone(), None).await.into())
     }
 
     async fn batch(&self, queries: Vec<String>, transaction: bool) -> TestResult<crate::QueryResult> {
@@ -55,7 +55,7 @@ impl RunnerInterface for DirectRunner {
             transaction,
         ));
 
-        Ok(handler.handle(query, self.current_tx_id.clone()).await.into())
+        Ok(handler.handle(query, self.current_tx_id.clone(), None).await.into())
     }
 
     fn connector(&self) -> &crate::ConnectorTag {

--- a/query-engine/connectors/mongodb-query-connector/src/interface/connection.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/interface/connection.rs
@@ -63,6 +63,7 @@ impl WriteOperations for MongoDbConnection {
         model: &ModelRef,
         record_filter: connector_interface::RecordFilter,
         args: WriteArgs,
+        _trace_id: Option<String>,
     ) -> connector_interface::Result<Vec<SelectionResult>> {
         catch(async move { write::update_records(&self.database, &mut self.session, model, record_filter, args).await })
             .await
@@ -72,6 +73,7 @@ impl WriteOperations for MongoDbConnection {
         &mut self,
         model: &ModelRef,
         record_filter: connector_interface::RecordFilter,
+        _trace_id: Option<String>,
     ) -> connector_interface::Result<usize> {
         catch(async move { write::delete_records(&self.database, &mut self.session, model, record_filter).await }).await
     }
@@ -123,6 +125,7 @@ impl ReadOperations for MongoDbConnection {
         filter: &connector_interface::Filter,
         selected_fields: &FieldSelection,
         aggr_selections: &[RelAggregationSelection],
+        _trace_id: Option<String>,
     ) -> connector_interface::Result<Option<SingleRecord>> {
         catch(async move {
             read::get_single_record(
@@ -144,6 +147,7 @@ impl ReadOperations for MongoDbConnection {
         query_arguments: connector_interface::QueryArguments,
         selected_fields: &FieldSelection,
         aggregation_selections: &[RelAggregationSelection],
+        _trace_id: Option<String>,
     ) -> connector_interface::Result<ManyRecords> {
         catch(async move {
             read::get_many_records(
@@ -163,6 +167,7 @@ impl ReadOperations for MongoDbConnection {
         &mut self,
         from_field: &RelationFieldRef,
         from_record_ids: &[SelectionResult],
+        _trace_id: Option<String>,
     ) -> connector_interface::Result<Vec<(SelectionResult, SelectionResult)>> {
         catch(async move {
             read::get_related_m2m_record_ids(&self.database, &mut self.session, from_field, from_record_ids).await
@@ -177,6 +182,7 @@ impl ReadOperations for MongoDbConnection {
         selections: Vec<connector_interface::AggregationSelection>,
         group_by: Vec<ScalarFieldRef>,
         having: Option<connector_interface::Filter>,
+        _trace_id: Option<String>,
     ) -> connector_interface::Result<Vec<connector_interface::AggregationRow>> {
         catch(async move {
             aggregate::aggregate(

--- a/query-engine/connectors/mongodb-query-connector/src/interface/connection.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/interface/connection.rs
@@ -42,6 +42,7 @@ impl WriteOperations for MongoDbConnection {
         &mut self,
         model: &ModelRef,
         args: WriteArgs,
+        _trace_id: Option<String>,
     ) -> connector_interface::Result<SelectionResult> {
         catch(async move { write::create_record(&self.database, &mut self.session, model, args).await }).await
     }
@@ -51,6 +52,7 @@ impl WriteOperations for MongoDbConnection {
         model: &ModelRef,
         args: Vec<WriteArgs>,
         skip_duplicates: bool,
+        _trace_id: Option<String>,
     ) -> connector_interface::Result<usize> {
         catch(
             async move { write::create_records(&self.database, &mut self.session, model, args, skip_duplicates).await },
@@ -93,6 +95,7 @@ impl WriteOperations for MongoDbConnection {
         field: &RelationFieldRef,
         parent_id: &SelectionResult,
         child_ids: &[SelectionResult],
+        _trace_id: Option<String>,
     ) -> connector_interface::Result<()> {
         catch(
             async move { write::m2m_disconnect(&self.database, &mut self.session, field, parent_id, child_ids).await },

--- a/query-engine/connectors/mongodb-query-connector/src/interface/transaction.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/interface/transaction.rs
@@ -65,6 +65,7 @@ impl<'conn> WriteOperations for MongoDbTransaction<'conn> {
         &mut self,
         model: &ModelRef,
         args: connector_interface::WriteArgs,
+        _trace_id: Option<String>,
     ) -> connector_interface::Result<SelectionResult> {
         catch(async move {
             write::create_record(&self.connection.database, &mut self.connection.session, model, args).await
@@ -77,6 +78,7 @@ impl<'conn> WriteOperations for MongoDbTransaction<'conn> {
         model: &ModelRef,
         args: Vec<connector_interface::WriteArgs>,
         skip_duplicates: bool,
+        _trace_id: Option<String>,
     ) -> connector_interface::Result<usize> {
         catch(async move {
             write::create_records(
@@ -153,6 +155,7 @@ impl<'conn> WriteOperations for MongoDbTransaction<'conn> {
         field: &RelationFieldRef,
         parent_id: &SelectionResult,
         child_ids: &[SelectionResult],
+        _trace_id: Option<String>,
     ) -> connector_interface::Result<()> {
         catch(async move {
             write::m2m_disconnect(

--- a/query-engine/connectors/mongodb-query-connector/src/interface/transaction.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/interface/transaction.rs
@@ -96,6 +96,7 @@ impl<'conn> WriteOperations for MongoDbTransaction<'conn> {
         model: &ModelRef,
         record_filter: connector_interface::RecordFilter,
         args: connector_interface::WriteArgs,
+        _trace_id: Option<String>,
     ) -> connector_interface::Result<Vec<SelectionResult>> {
         catch(async move {
             write::update_records(
@@ -114,6 +115,7 @@ impl<'conn> WriteOperations for MongoDbTransaction<'conn> {
         &mut self,
         model: &ModelRef,
         record_filter: connector_interface::RecordFilter,
+        _trace_id: Option<String>,
     ) -> connector_interface::Result<usize> {
         catch(async move {
             write::delete_records(
@@ -190,6 +192,7 @@ impl<'conn> ReadOperations for MongoDbTransaction<'conn> {
         filter: &connector_interface::Filter,
         selected_fields: &FieldSelection,
         aggr_selections: &[RelAggregationSelection],
+        _trace_id: Option<String>,
     ) -> connector_interface::Result<Option<SingleRecord>> {
         catch(async move {
             read::get_single_record(
@@ -211,6 +214,7 @@ impl<'conn> ReadOperations for MongoDbTransaction<'conn> {
         query_arguments: connector_interface::QueryArguments,
         selected_fields: &FieldSelection,
         aggregation_selections: &[RelAggregationSelection],
+        _trace_id: Option<String>,
     ) -> connector_interface::Result<ManyRecords> {
         catch(async move {
             read::get_many_records(
@@ -230,6 +234,7 @@ impl<'conn> ReadOperations for MongoDbTransaction<'conn> {
         &mut self,
         from_field: &RelationFieldRef,
         from_record_ids: &[SelectionResult],
+        _trace_id: Option<String>,
     ) -> connector_interface::Result<Vec<(SelectionResult, SelectionResult)>> {
         catch(async move {
             read::get_related_m2m_record_ids(
@@ -250,6 +255,7 @@ impl<'conn> ReadOperations for MongoDbTransaction<'conn> {
         selections: Vec<connector_interface::AggregationSelection>,
         group_by: Vec<ScalarFieldRef>,
         having: Option<connector_interface::Filter>,
+        _trace_id: Option<String>,
     ) -> connector_interface::Result<Vec<connector_interface::AggregationRow>> {
         catch(async move {
             aggregate::aggregate(

--- a/query-engine/connectors/query-connector/src/interface.rs
+++ b/query-engine/connectors/query-connector/src/interface.rs
@@ -273,7 +273,12 @@ pub trait ReadOperations {
 #[async_trait]
 pub trait WriteOperations {
     /// Insert a single record to the database.
-    async fn create_record(&mut self, model: &ModelRef, args: WriteArgs, trace_id: Option<String>) -> crate::Result<SelectionResult>;
+    async fn create_record(
+        &mut self,
+        model: &ModelRef,
+        args: WriteArgs,
+        trace_id: Option<String>,
+    ) -> crate::Result<SelectionResult>;
 
     /// Inserts many records at once into the database.
     async fn create_records(
@@ -295,7 +300,12 @@ pub trait WriteOperations {
     ) -> crate::Result<Vec<SelectionResult>>;
 
     /// Delete records in the `Model` with the given `Filter`.
-    async fn delete_records(&mut self, model: &ModelRef, record_filter: RecordFilter, trace_id: Option<String>,) -> crate::Result<usize>;
+    async fn delete_records(
+        &mut self,
+        model: &ModelRef,
+        record_filter: RecordFilter,
+        trace_id: Option<String>,
+    ) -> crate::Result<usize>;
 
     // We plan to remove the methods below in the future. We want emulate them with the ones above. Those should suffice.
 

--- a/query-engine/connectors/query-connector/src/interface.rs
+++ b/query-engine/connectors/query-connector/src/interface.rs
@@ -273,7 +273,7 @@ pub trait ReadOperations {
 #[async_trait]
 pub trait WriteOperations {
     /// Insert a single record to the database.
-    async fn create_record(&mut self, model: &ModelRef, args: WriteArgs) -> crate::Result<SelectionResult>;
+    async fn create_record(&mut self, model: &ModelRef, args: WriteArgs, trace_id: Option<String>) -> crate::Result<SelectionResult>;
 
     /// Inserts many records at once into the database.
     async fn create_records(
@@ -281,6 +281,7 @@ pub trait WriteOperations {
         model: &ModelRef,
         args: Vec<WriteArgs>,
         skip_duplicates: bool,
+        trace_id: Option<String>,
     ) -> crate::Result<usize>;
 
     /// Update records in the `Model` with the given `WriteArgs` filtered by the
@@ -312,6 +313,7 @@ pub trait WriteOperations {
         field: &RelationFieldRef,
         parent_id: &SelectionResult,
         child_ids: &[SelectionResult],
+        trace_id: Option<String>,
     ) -> crate::Result<()>;
 
     /// Execute the raw query in the database as-is. The `parameters` are

--- a/query-engine/connectors/query-connector/src/interface.rs
+++ b/query-engine/connectors/query-connector/src/interface.rs
@@ -222,6 +222,7 @@ pub trait ReadOperations {
         filter: &Filter,
         selected_fields: &FieldSelection,
         aggregation_selections: &[RelAggregationSelection],
+        trace_id: Option<String>,
     ) -> crate::Result<Option<SingleRecord>>;
 
     /// Gets multiple records from the database.
@@ -236,6 +237,7 @@ pub trait ReadOperations {
         query_arguments: QueryArguments,
         selected_fields: &FieldSelection,
         aggregation_selections: &[RelAggregationSelection],
+        trace_id: Option<String>,
     ) -> crate::Result<ManyRecords>;
 
     /// Retrieves pairs of IDs that belong together from a intermediate join
@@ -249,6 +251,7 @@ pub trait ReadOperations {
         &mut self,
         from_field: &RelationFieldRef,
         from_record_ids: &[SelectionResult],
+        trace_id: Option<String>,
     ) -> crate::Result<Vec<(SelectionResult, SelectionResult)>>;
 
     /// Aggregates records for a specific model based on the given selections.
@@ -263,6 +266,7 @@ pub trait ReadOperations {
         selections: Vec<AggregationSelection>,
         group_by: Vec<ScalarFieldRef>,
         having: Option<Filter>,
+        trace_id: Option<String>,
     ) -> crate::Result<Vec<AggregationRow>>;
 }
 
@@ -286,10 +290,11 @@ pub trait WriteOperations {
         model: &ModelRef,
         record_filter: RecordFilter,
         args: WriteArgs,
+        trace_id: Option<String>,
     ) -> crate::Result<Vec<SelectionResult>>;
 
     /// Delete records in the `Model` with the given `Filter`.
-    async fn delete_records(&mut self, model: &ModelRef, record_filter: RecordFilter) -> crate::Result<usize>;
+    async fn delete_records(&mut self, model: &ModelRef, record_filter: RecordFilter, trace_id: Option<String>,) -> crate::Result<usize>;
 
     // We plan to remove the methods below in the future. We want emulate them with the ones above. Those should suffice.
 

--- a/query-engine/connectors/sql-query-connector/src/database/connection.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/connection.rs
@@ -125,9 +125,9 @@ impl<C> WriteOperations for SqlConnection<C>
 where
     C: QueryExt + Send + Sync + 'static,
 {
-    async fn create_record(&mut self, model: &ModelRef, args: WriteArgs) -> connector::Result<SelectionResult> {
+    async fn create_record(&mut self, model: &ModelRef, args: WriteArgs, trace_id: Option<String>) -> connector::Result<SelectionResult> {
         catch(self.connection_info.clone(), async move {
-            write::create_record(&self.inner, model, args).await
+            write::create_record(&self.inner, model, args, trace_id).await
         })
         .await
     }
@@ -137,6 +137,7 @@ where
         model: &ModelRef,
         args: Vec<WriteArgs>,
         skip_duplicates: bool,
+        trace_id: Option<String>,
     ) -> connector::Result<usize> {
         catch(self.connection_info.clone(), async move {
             write::create_records(
@@ -145,6 +146,7 @@ where
                 model,
                 args,
                 skip_duplicates,
+                trace_id
             )
             .await
         })
@@ -188,9 +190,10 @@ where
         field: &RelationFieldRef,
         parent_id: &SelectionResult,
         child_ids: &[SelectionResult],
+        trace_id: Option<String>,
     ) -> connector::Result<()> {
         catch(self.connection_info.clone(), async move {
-            write::m2m_disconnect(&self.inner, field, parent_id, child_ids).await
+            write::m2m_disconnect(&self.inner, field, parent_id, child_ids, trace_id).await
         })
         .await
     }

--- a/query-engine/connectors/sql-query-connector/src/database/connection.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/connection.rs
@@ -64,7 +64,15 @@ where
     ) -> connector::Result<Option<SingleRecord>> {
         // [Composites] todo: FieldSelection -> ModelProjection conversion
         catch(self.connection_info.clone(), async move {
-            read::get_single_record(&self.inner, model, filter, &selected_fields.into(), aggr_selections, trace_id).await
+            read::get_single_record(
+                &self.inner,
+                model,
+                filter,
+                &selected_fields.into(),
+                aggr_selections,
+                trace_id,
+            )
+            .await
         })
         .await
     }
@@ -85,7 +93,7 @@ where
                 &selected_fields.into(),
                 aggr_selections,
                 SqlInfo::from(&self.connection_info),
-                trace_id
+                trace_id,
             )
             .await
         })
@@ -114,7 +122,16 @@ where
         trace_id: Option<String>,
     ) -> connector::Result<Vec<AggregationRow>> {
         catch(self.connection_info.clone(), async move {
-            read::aggregate(&self.inner, model, query_arguments, selections, group_by, having, trace_id).await
+            read::aggregate(
+                &self.inner,
+                model,
+                query_arguments,
+                selections,
+                group_by,
+                having,
+                trace_id,
+            )
+            .await
         })
         .await
     }
@@ -125,7 +142,12 @@ impl<C> WriteOperations for SqlConnection<C>
 where
     C: QueryExt + Send + Sync + 'static,
 {
-    async fn create_record(&mut self, model: &ModelRef, args: WriteArgs, trace_id: Option<String>) -> connector::Result<SelectionResult> {
+    async fn create_record(
+        &mut self,
+        model: &ModelRef,
+        args: WriteArgs,
+        trace_id: Option<String>,
+    ) -> connector::Result<SelectionResult> {
         catch(self.connection_info.clone(), async move {
             write::create_record(&self.inner, model, args, trace_id).await
         })
@@ -146,7 +168,7 @@ where
                 model,
                 args,
                 skip_duplicates,
-                trace_id
+                trace_id,
             )
             .await
         })
@@ -166,7 +188,12 @@ where
         .await
     }
 
-    async fn delete_records(&mut self, model: &ModelRef, record_filter: RecordFilter, trace_id: Option<String>) -> connector::Result<usize> {
+    async fn delete_records(
+        &mut self,
+        model: &ModelRef,
+        record_filter: RecordFilter,
+        trace_id: Option<String>,
+    ) -> connector::Result<usize> {
         catch(self.connection_info.clone(), async move {
             write::delete_records(&self.inner, model, record_filter, trace_id).await
         })

--- a/query-engine/connectors/sql-query-connector/src/database/connection.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/connection.rs
@@ -60,10 +60,11 @@ where
         filter: &Filter,
         selected_fields: &FieldSelection,
         aggr_selections: &[RelAggregationSelection],
+        trace_id: Option<String>,
     ) -> connector::Result<Option<SingleRecord>> {
         // [Composites] todo: FieldSelection -> ModelProjection conversion
         catch(self.connection_info.clone(), async move {
-            read::get_single_record(&self.inner, model, filter, &selected_fields.into(), aggr_selections).await
+            read::get_single_record(&self.inner, model, filter, &selected_fields.into(), aggr_selections, trace_id).await
         })
         .await
     }
@@ -74,6 +75,7 @@ where
         query_arguments: QueryArguments,
         selected_fields: &FieldSelection,
         aggr_selections: &[RelAggregationSelection],
+        trace_id: Option<String>,
     ) -> connector::Result<ManyRecords> {
         catch(self.connection_info.clone(), async move {
             read::get_many_records(
@@ -83,6 +85,7 @@ where
                 &selected_fields.into(),
                 aggr_selections,
                 SqlInfo::from(&self.connection_info),
+                trace_id
             )
             .await
         })
@@ -93,9 +96,10 @@ where
         &mut self,
         from_field: &RelationFieldRef,
         from_record_ids: &[SelectionResult],
+        trace_id: Option<String>,
     ) -> connector::Result<Vec<(SelectionResult, SelectionResult)>> {
         catch(self.connection_info.clone(), async move {
-            read::get_related_m2m_record_ids(&self.inner, from_field, from_record_ids).await
+            read::get_related_m2m_record_ids(&self.inner, from_field, from_record_ids, trace_id).await
         })
         .await
     }
@@ -107,9 +111,10 @@ where
         selections: Vec<AggregationSelection>,
         group_by: Vec<ScalarFieldRef>,
         having: Option<Filter>,
+        trace_id: Option<String>,
     ) -> connector::Result<Vec<AggregationRow>> {
         catch(self.connection_info.clone(), async move {
-            read::aggregate(&self.inner, model, query_arguments, selections, group_by, having).await
+            read::aggregate(&self.inner, model, query_arguments, selections, group_by, having, trace_id).await
         })
         .await
     }
@@ -151,16 +156,17 @@ where
         model: &ModelRef,
         record_filter: RecordFilter,
         args: WriteArgs,
+        trace_id: Option<String>,
     ) -> connector::Result<Vec<SelectionResult>> {
         catch(self.connection_info.clone(), async move {
-            write::update_records(&self.inner, model, record_filter, args).await
+            write::update_records(&self.inner, model, record_filter, args, trace_id).await
         })
         .await
     }
 
-    async fn delete_records(&mut self, model: &ModelRef, record_filter: RecordFilter) -> connector::Result<usize> {
+    async fn delete_records(&mut self, model: &ModelRef, record_filter: RecordFilter, trace_id: Option<String>) -> connector::Result<usize> {
         catch(self.connection_info.clone(), async move {
-            write::delete_records(&self.inner, model, record_filter).await
+            write::delete_records(&self.inner, model, record_filter, trace_id).await
         })
         .await
     }

--- a/query-engine/connectors/sql-query-connector/src/database/operations/read.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/read.rs
@@ -20,7 +20,13 @@ pub async fn get_single_record(
     aggr_selections: &[RelAggregationSelection],
     trace_id: Option<String>,
 ) -> crate::Result<Option<SingleRecord>> {
-    let query = read::get_records(model, selected_fields.as_columns(), aggr_selections, filter, trace_id.clone());
+    let query = read::get_records(
+        model,
+        selected_fields.as_columns(),
+        aggr_selections,
+        filter,
+        trace_id.clone(),
+    );
 
     let mut field_names: Vec<_> = selected_fields.db_names().collect();
     let mut aggr_field_names: Vec<_> = aggr_selections.iter().map(|aggr_sel| aggr_sel.db_alias()).collect();
@@ -108,7 +114,13 @@ pub async fn get_many_records(
             let mut futures = FuturesUnordered::new();
 
             for args in batches.into_iter() {
-                let query = read::get_records(model, selected_fields.as_columns(), aggr_selections, args, trace_id.clone());
+                let query = read::get_records(
+                    model,
+                    selected_fields.as_columns(),
+                    aggr_selections,
+                    args,
+                    trace_id.clone(),
+                );
 
                 futures.push(conn.filter(query.into(), meta.as_slice(), trace_id.clone()));
             }
@@ -124,7 +136,13 @@ pub async fn get_many_records(
             }
         }
         _ => {
-            let query = read::get_records(model, selected_fields.as_columns (), aggr_selections, query_arguments, trace_id.clone());
+            let query = read::get_records(
+                model,
+                selected_fields.as_columns(),
+                aggr_selections,
+                query_arguments,
+                trace_id.clone(),
+            );
 
             for item in conn.filter(query.into(), meta.as_slice(), trace_id).await?.into_iter() {
                 records.push(Record::from(item))

--- a/query-engine/connectors/sql-query-connector/src/database/operations/read.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/read.rs
@@ -18,6 +18,7 @@ pub async fn get_single_record(
     filter: &Filter,
     selected_fields: &ModelProjection,
     aggr_selections: &[RelAggregationSelection],
+    trace_id: Option<String>,
 ) -> crate::Result<Option<SingleRecord>> {
     let query = read::get_records(model, selected_fields.as_columns(), aggr_selections, filter);
 
@@ -36,7 +37,7 @@ pub async fn get_single_record(
 
     let meta = column_metadata::create(field_names.as_slice(), idents.as_slice());
 
-    let record = (match conn.find(query, meta.as_slice()).await {
+    let record = (match conn.find(query, meta.as_slice(), trace_id).await {
         Ok(result) => Ok(Some(result)),
         Err(_e @ SqlError::RecordNotFoundForWhere(_)) => Ok(None),
         Err(_e @ SqlError::RecordDoesNotExist) => Ok(None),
@@ -56,6 +57,7 @@ pub async fn get_many_records(
     selected_fields: &ModelProjection,
     aggr_selections: &[RelAggregationSelection],
     sql_info: SqlInfo,
+    trace_id: Option<String>,
 ) -> crate::Result<ManyRecords> {
     let reversed = query_arguments.needs_reversed_order();
 
@@ -108,7 +110,7 @@ pub async fn get_many_records(
             for args in batches.into_iter() {
                 let query = read::get_records(model, selected_fields.as_columns(), aggr_selections, args);
 
-                futures.push(conn.filter(query.into(), meta.as_slice()));
+                futures.push(conn.filter(query.into(), meta.as_slice(), trace_id.clone()));
             }
 
             while let Some(result) = futures.next().await {
@@ -124,7 +126,7 @@ pub async fn get_many_records(
         _ => {
             let query = read::get_records(model, selected_fields.as_columns(), aggr_selections, query_arguments);
 
-            for item in conn.filter(query.into(), meta.as_slice()).await?.into_iter() {
+            for item in conn.filter(query.into(), meta.as_slice(), trace_id.clone()).await?.into_iter() {
                 records.push(Record::from(item))
             }
         }
@@ -142,6 +144,7 @@ pub async fn get_related_m2m_record_ids(
     conn: &dyn QueryExt,
     from_field: &RelationFieldRef,
     from_record_ids: &[SelectionResult],
+    trace_id: Option<String>,
 ) -> crate::Result<Vec<(SelectionResult, SelectionResult)>> {
     let mut idents = vec![];
     idents.extend(ModelProjection::from(from_field.model().primary_identifier()).type_identifiers_with_arities());
@@ -178,7 +181,7 @@ pub async fn get_related_m2m_record_ids(
 
     // first parent id, then child id
     Ok(conn
-        .filter(select.into(), meta.as_slice())
+        .filter(select.into(), meta.as_slice(), trace_id)
         .await?
         .into_iter()
         .map(|row| {
@@ -214,11 +217,12 @@ pub async fn aggregate(
     selections: Vec<AggregationSelection>,
     group_by: Vec<ScalarFieldRef>,
     having: Option<Filter>,
+    trace_id: Option<String>,
 ) -> crate::Result<Vec<AggregationRow>> {
     if !group_by.is_empty() {
-        group_by_aggregate(conn, model, query_arguments, selections, group_by, having).await
+        group_by_aggregate(conn, model, query_arguments, selections, group_by, having, trace_id).await
     } else {
-        plain_aggregate(conn, model, query_arguments, selections)
+        plain_aggregate(conn, model, query_arguments, selections, trace_id)
             .await
             .map(|v| vec![v])
     }
@@ -230,6 +234,7 @@ async fn plain_aggregate(
     model: &ModelRef,
     query_arguments: QueryArguments,
     selections: Vec<AggregationSelection>,
+    trace_id: Option<String>,
 ) -> crate::Result<Vec<AggregationResult>> {
     let query = read::aggregate(model, &selections, query_arguments);
 
@@ -241,7 +246,7 @@ async fn plain_aggregate(
 
     let meta = column_metadata::create_anonymous(&idents);
 
-    let mut rows = conn.filter(query.into(), meta.as_slice()).await?;
+    let mut rows = conn.filter(query.into(), meta.as_slice(), trace_id).await?;
     let row = rows
         .pop()
         .expect("Expected exactly one return row for aggregation query.");
@@ -257,6 +262,7 @@ async fn group_by_aggregate(
     selections: Vec<AggregationSelection>,
     group_by: Vec<ScalarFieldRef>,
     having: Option<Filter>,
+    trace_id: Option<String>,
 ) -> crate::Result<Vec<AggregationRow>> {
     let query = read::group_by_aggregate(model, query_arguments, &selections, group_by, having);
 
@@ -267,7 +273,7 @@ async fn group_by_aggregate(
         .collect();
 
     let meta = column_metadata::create_anonymous(&idents);
-    let rows = conn.filter(query.into(), meta.as_slice()).await?;
+    let rows = conn.filter(query.into(), meta.as_slice(), trace_id).await?;
 
     Ok(rows
         .into_iter()

--- a/query-engine/connectors/sql-query-connector/src/database/operations/write.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/write.rs
@@ -11,8 +11,8 @@ use user_facing_errors::query_engine::DatabaseConstraint;
 /// Create a single record to the database defined in `conn`, resulting into a
 /// `RecordProjection` as an identifier pointing to the just-created record.
 #[tracing::instrument(skip(conn, model, args))]
-pub async fn create_record(conn: &dyn QueryExt, model: &ModelRef, args: WriteArgs) -> crate::Result<SelectionResult> {
-    let (insert, returned_id) = write::create_record(model, args);
+pub async fn create_record(conn: &dyn QueryExt, model: &ModelRef, args: WriteArgs, trace_id: Option<String>) -> crate::Result<SelectionResult> {
+    let (insert, returned_id) = write::create_record(model, args, trace_id);
 
     let result_set = match conn.insert(insert).await {
         Ok(id) => id,
@@ -81,6 +81,7 @@ pub async fn create_records(
     model: &ModelRef,
     args: Vec<WriteArgs>,
     skip_duplicates: bool,
+    trace_id: Option<String>,
 ) -> crate::Result<usize> {
     if args.is_empty() {
         return Ok(0);
@@ -105,9 +106,9 @@ pub async fn create_records(
 
     if affected_fields.is_empty() {
         // If no fields are to be inserted (everything is DEFAULT) we need to fall back to inserting default rows `args.len()` times.
-        create_many_empty(conn, model, args.len(), skip_duplicates).await
+        create_many_empty(conn, model, args.len(), skip_duplicates, trace_id).await
     } else {
-        create_many_nonempty(conn, sql_info, model, args, skip_duplicates, affected_fields).await
+        create_many_nonempty(conn, sql_info, model, args, skip_duplicates, affected_fields, trace_id).await
     }
 }
 
@@ -120,6 +121,7 @@ async fn create_many_nonempty(
     args: Vec<WriteArgs>,
     skip_duplicates: bool,
     affected_fields: HashSet<ScalarFieldRef>,
+    trace_id: Option<String>,
 ) -> crate::Result<usize> {
     let batches = if let Some(max_params) = sql_info.max_bind_values {
         // We need to split inserts if they are above a parameter threshold, as well as split based on number of rows.
@@ -193,7 +195,7 @@ async fn create_many_nonempty(
 
     let mut count = 0;
     for batch in partitioned_batches {
-        let stmt = write::create_records_nonempty(model, batch, skip_duplicates, &affected_fields);
+        let stmt = write::create_records_nonempty(model, batch, skip_duplicates, &affected_fields, trace_id.clone());
         count += conn.execute(stmt.into()).await?;
     }
 
@@ -206,8 +208,9 @@ async fn create_many_empty(
     model: &ModelRef,
     num_records: usize,
     skip_duplicates: bool,
+    trace_id: Option<String>,
 ) -> crate::Result<usize> {
-    let stmt = write::create_records_empty(model, skip_duplicates);
+    let stmt = write::create_records_empty(model, skip_duplicates, trace_id);
     let mut count = 0;
 
     for _ in 0..num_records {
@@ -228,7 +231,7 @@ pub async fn update_records(
     args: WriteArgs,
     trace_id: Option<String>,
 ) -> crate::Result<Vec<SelectionResult>> {
-    let ids = conn.filter_selectors(model, record_filter, trace_id).await?;
+    let ids = conn.filter_selectors(model, record_filter, trace_id.clone()).await?;
     let id_args = pick_args(&model.primary_identifier().into(), &args);
 
     if ids.is_empty() {
@@ -237,7 +240,7 @@ pub async fn update_records(
 
     let updates = {
         let ids: Vec<&SelectionResult> = ids.iter().map(|id| &*id).collect();
-        write::update_many(model, ids.as_slice(), args)?
+        write::update_many(model, ids.as_slice(), args, trace_id)?
     };
 
     for update in updates {
@@ -255,7 +258,7 @@ pub async fn delete_records(
     record_filter: RecordFilter,
     trace_id: Option<String>,
 ) -> crate::Result<usize> {
-    let ids = conn.filter_selectors(model, record_filter, trace_id).await?;
+    let ids = conn.filter_selectors(model, record_filter, trace_id.clone()).await?;
     let ids: Vec<&SelectionResult> = ids.iter().map(|id| &*id).collect();
     let count = ids.len();
 
@@ -263,7 +266,7 @@ pub async fn delete_records(
         return Ok(count);
     }
 
-    for delete in write::delete_many(model, ids.as_slice()) {
+    for delete in write::delete_many(model, ids.as_slice(), trace_id) {
         conn.query(delete).await?;
     }
 
@@ -293,8 +296,9 @@ pub async fn m2m_disconnect(
     field: &RelationFieldRef,
     parent_id: &SelectionResult,
     child_ids: &[SelectionResult],
+    trace_id: Option<String>,
 ) -> crate::Result<()> {
-    let query = write::delete_relation_table_records(field, parent_id, child_ids);
+    let query = write::delete_relation_table_records(field, parent_id, child_ids, trace_id);
     conn.delete(query).await?;
 
     Ok(())

--- a/query-engine/connectors/sql-query-connector/src/database/operations/write.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/write.rs
@@ -226,8 +226,9 @@ pub async fn update_records(
     model: &ModelRef,
     record_filter: RecordFilter,
     args: WriteArgs,
+    trace_id: Option<String>,
 ) -> crate::Result<Vec<SelectionResult>> {
-    let ids = conn.filter_selectors(model, record_filter).await?;
+    let ids = conn.filter_selectors(model, record_filter, trace_id).await?;
     let id_args = pick_args(&model.primary_identifier().into(), &args);
 
     if ids.is_empty() {
@@ -252,8 +253,9 @@ pub async fn delete_records(
     conn: &dyn QueryExt,
     model: &ModelRef,
     record_filter: RecordFilter,
+    trace_id: Option<String>,
 ) -> crate::Result<usize> {
-    let ids = conn.filter_selectors(model, record_filter).await?;
+    let ids = conn.filter_selectors(model, record_filter, trace_id).await?;
     let ids: Vec<&SelectionResult> = ids.iter().map(|id| &*id).collect();
     let count = ids.len();
 

--- a/query-engine/connectors/sql-query-connector/src/database/operations/write.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/write.rs
@@ -11,7 +11,12 @@ use user_facing_errors::query_engine::DatabaseConstraint;
 /// Create a single record to the database defined in `conn`, resulting into a
 /// `RecordProjection` as an identifier pointing to the just-created record.
 #[tracing::instrument(skip(conn, model, args))]
-pub async fn create_record(conn: &dyn QueryExt, model: &ModelRef, args: WriteArgs, trace_id: Option<String>) -> crate::Result<SelectionResult> {
+pub async fn create_record(
+    conn: &dyn QueryExt,
+    model: &ModelRef,
+    args: WriteArgs,
+    trace_id: Option<String>,
+) -> crate::Result<SelectionResult> {
     let (insert, returned_id) = write::create_record(model, args, trace_id);
 
     let result_set = match conn.insert(insert).await {

--- a/query-engine/connectors/sql-query-connector/src/database/transaction.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/transaction.rs
@@ -66,9 +66,10 @@ impl<'tx> ReadOperations for SqlConnectorTransaction<'tx> {
         filter: &Filter,
         selected_fields: &FieldSelection,
         aggr_selections: &[RelAggregationSelection],
+        trace_id: Option<String>,
     ) -> connector::Result<Option<SingleRecord>> {
         catch(self.connection_info.clone(), async move {
-            read::get_single_record(&self.inner, model, filter, &selected_fields.into(), aggr_selections).await
+            read::get_single_record(&self.inner, model, filter, &selected_fields.into(), aggr_selections, trace_id).await
         })
         .await
     }
@@ -79,6 +80,7 @@ impl<'tx> ReadOperations for SqlConnectorTransaction<'tx> {
         query_arguments: QueryArguments,
         selected_fields: &FieldSelection,
         aggr_selections: &[RelAggregationSelection],
+        trace_id: Option<String>,
     ) -> connector::Result<ManyRecords> {
         catch(self.connection_info.clone(), async move {
             read::get_many_records(
@@ -88,6 +90,7 @@ impl<'tx> ReadOperations for SqlConnectorTransaction<'tx> {
                 &selected_fields.into(),
                 aggr_selections,
                 SqlInfo::from(&self.connection_info),
+                trace_id
             )
             .await
         })
@@ -98,9 +101,10 @@ impl<'tx> ReadOperations for SqlConnectorTransaction<'tx> {
         &mut self,
         from_field: &RelationFieldRef,
         from_record_ids: &[SelectionResult],
+        trace_id: Option<String>,
     ) -> connector::Result<Vec<(SelectionResult, SelectionResult)>> {
         catch(self.connection_info.clone(), async move {
-            read::get_related_m2m_record_ids(&self.inner, from_field, from_record_ids).await
+            read::get_related_m2m_record_ids(&self.inner, from_field, from_record_ids, trace_id).await
         })
         .await
     }
@@ -112,9 +116,10 @@ impl<'tx> ReadOperations for SqlConnectorTransaction<'tx> {
         selections: Vec<AggregationSelection>,
         group_by: Vec<ScalarFieldRef>,
         having: Option<Filter>,
+        trace_id: Option<String>,
     ) -> connector::Result<Vec<AggregationRow>> {
         catch(self.connection_info.clone(), async move {
-            read::aggregate(&self.inner, model, query_arguments, selections, group_by, having).await
+            read::aggregate(&self.inner, model, query_arguments, selections, group_by, having, trace_id).await
         })
         .await
     }
@@ -153,16 +158,17 @@ impl<'tx> WriteOperations for SqlConnectorTransaction<'tx> {
         model: &ModelRef,
         record_filter: RecordFilter,
         args: WriteArgs,
+        trace_id: Option<String>,
     ) -> connector::Result<Vec<SelectionResult>> {
         catch(self.connection_info.clone(), async move {
-            write::update_records(&self.inner, model, record_filter, args).await
+            write::update_records(&self.inner, model, record_filter, args, trace_id).await
         })
         .await
     }
 
-    async fn delete_records(&mut self, model: &ModelRef, record_filter: RecordFilter) -> connector::Result<usize> {
+    async fn delete_records(&mut self, model: &ModelRef, record_filter: RecordFilter, trace_id: Option<String>,) -> connector::Result<usize> {
         catch(self.connection_info.clone(), async move {
-            write::delete_records(&self.inner, model, record_filter).await
+            write::delete_records(&self.inner, model, record_filter, trace_id).await
         })
         .await
     }

--- a/query-engine/connectors/sql-query-connector/src/database/transaction.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/transaction.rs
@@ -69,7 +69,15 @@ impl<'tx> ReadOperations for SqlConnectorTransaction<'tx> {
         trace_id: Option<String>,
     ) -> connector::Result<Option<SingleRecord>> {
         catch(self.connection_info.clone(), async move {
-            read::get_single_record(&self.inner, model, filter, &selected_fields.into(), aggr_selections, trace_id).await
+            read::get_single_record(
+                &self.inner,
+                model,
+                filter,
+                &selected_fields.into(),
+                aggr_selections,
+                trace_id,
+            )
+            .await
         })
         .await
     }
@@ -90,7 +98,7 @@ impl<'tx> ReadOperations for SqlConnectorTransaction<'tx> {
                 &selected_fields.into(),
                 aggr_selections,
                 SqlInfo::from(&self.connection_info),
-                trace_id
+                trace_id,
             )
             .await
         })
@@ -119,7 +127,16 @@ impl<'tx> ReadOperations for SqlConnectorTransaction<'tx> {
         trace_id: Option<String>,
     ) -> connector::Result<Vec<AggregationRow>> {
         catch(self.connection_info.clone(), async move {
-            read::aggregate(&self.inner, model, query_arguments, selections, group_by, having, trace_id).await
+            read::aggregate(
+                &self.inner,
+                model,
+                query_arguments,
+                selections,
+                group_by,
+                having,
+                trace_id,
+            )
+            .await
         })
         .await
     }
@@ -127,7 +144,12 @@ impl<'tx> ReadOperations for SqlConnectorTransaction<'tx> {
 
 #[async_trait]
 impl<'tx> WriteOperations for SqlConnectorTransaction<'tx> {
-    async fn create_record(&mut self, model: &ModelRef, args: WriteArgs, trace_id: Option<String>) -> connector::Result<SelectionResult> {
+    async fn create_record(
+        &mut self,
+        model: &ModelRef,
+        args: WriteArgs,
+        trace_id: Option<String>,
+    ) -> connector::Result<SelectionResult> {
         catch(self.connection_info.clone(), async move {
             write::create_record(&self.inner, model, args, trace_id).await
         })
@@ -148,7 +170,7 @@ impl<'tx> WriteOperations for SqlConnectorTransaction<'tx> {
                 model,
                 args,
                 skip_duplicates,
-                trace_id
+                trace_id,
             )
             .await
         })
@@ -168,7 +190,12 @@ impl<'tx> WriteOperations for SqlConnectorTransaction<'tx> {
         .await
     }
 
-    async fn delete_records(&mut self, model: &ModelRef, record_filter: RecordFilter, trace_id: Option<String>,) -> connector::Result<usize> {
+    async fn delete_records(
+        &mut self,
+        model: &ModelRef,
+        record_filter: RecordFilter,
+        trace_id: Option<String>,
+    ) -> connector::Result<usize> {
         catch(self.connection_info.clone(), async move {
             write::delete_records(&self.inner, model, record_filter, trace_id).await
         })

--- a/query-engine/connectors/sql-query-connector/src/database/transaction.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/transaction.rs
@@ -127,9 +127,9 @@ impl<'tx> ReadOperations for SqlConnectorTransaction<'tx> {
 
 #[async_trait]
 impl<'tx> WriteOperations for SqlConnectorTransaction<'tx> {
-    async fn create_record(&mut self, model: &ModelRef, args: WriteArgs) -> connector::Result<SelectionResult> {
+    async fn create_record(&mut self, model: &ModelRef, args: WriteArgs, trace_id: Option<String>) -> connector::Result<SelectionResult> {
         catch(self.connection_info.clone(), async move {
-            write::create_record(&self.inner, model, args).await
+            write::create_record(&self.inner, model, args, trace_id).await
         })
         .await
     }
@@ -139,6 +139,7 @@ impl<'tx> WriteOperations for SqlConnectorTransaction<'tx> {
         model: &ModelRef,
         args: Vec<WriteArgs>,
         skip_duplicates: bool,
+        trace_id: Option<String>,
     ) -> connector::Result<usize> {
         catch(self.connection_info.clone(), async move {
             write::create_records(
@@ -147,6 +148,7 @@ impl<'tx> WriteOperations for SqlConnectorTransaction<'tx> {
                 model,
                 args,
                 skip_duplicates,
+                trace_id
             )
             .await
         })
@@ -190,9 +192,10 @@ impl<'tx> WriteOperations for SqlConnectorTransaction<'tx> {
         field: &RelationFieldRef,
         parent_id: &SelectionResult,
         child_ids: &[SelectionResult],
+        trace_id: Option<String>,
     ) -> connector::Result<()> {
         catch(self.connection_info.clone(), async move {
-            write::m2m_disconnect(&self.inner, field, parent_id, child_ids).await
+            write::m2m_disconnect(&self.inner, field, parent_id, child_ids, trace_id).await
         })
         .await
     }

--- a/query-engine/connectors/sql-query-connector/src/query_builder/read.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_builder/read.rs
@@ -13,6 +13,7 @@ pub trait SelectDefinition {
         self,
         _: &ModelRef,
         aggr_selections: &[RelAggregationSelection],
+        trace_id: Option<String>,
     ) -> (Select<'static>, Vec<Expression<'static>>);
 }
 
@@ -21,9 +22,10 @@ impl SelectDefinition for Filter {
         self,
         model: &ModelRef,
         aggr_selections: &[RelAggregationSelection],
+        trace_id: Option<String>,
     ) -> (Select<'static>, Vec<Expression<'static>>) {
         let args = QueryArguments::from((model.clone(), self));
-        args.into_select(model, aggr_selections)
+        args.into_select(model, aggr_selections, trace_id)
     }
 }
 
@@ -32,13 +34,14 @@ impl SelectDefinition for &Filter {
         self,
         model: &ModelRef,
         aggr_selections: &[RelAggregationSelection],
+        trace_id: Option<String>,
     ) -> (Select<'static>, Vec<Expression<'static>>) {
-        self.clone().into_select(model, aggr_selections)
+        self.clone().into_select(model, aggr_selections, trace_id)
     }
 }
 
 impl SelectDefinition for Select<'static> {
-    fn into_select(self, _: &ModelRef, _: &[RelAggregationSelection]) -> (Select<'static>, Vec<Expression<'static>>) {
+    fn into_select(self, _: &ModelRef, _: &[RelAggregationSelection], _trace_id: Option<String>) -> (Select<'static>, Vec<Expression<'static>>) {
         (self, vec![])
     }
 }
@@ -49,6 +52,7 @@ impl SelectDefinition for QueryArguments {
         self,
         model: &ModelRef,
         aggr_selections: &[RelAggregationSelection],
+        trace_id: Option<String>,
     ) -> (Select<'static>, Vec<Expression<'static>>) {
         let order_by_definitions = ordering::build(&self, &model);
         let (table_opt, cursor_condition) = cursor_condition::build(&self, &model, &order_by_definitions);
@@ -83,7 +87,8 @@ impl SelectDefinition for QueryArguments {
         let select_ast = Select::from_table(joined_table)
             .so_that(conditions)
             .offset(skip as usize)
-            .append_trace(&Span::current());
+            .append_trace(&Span::current())
+            .add_trace_id(trace_id);
 
         let select_ast = if let Some(table) = table_opt {
             select_ast.and_from(table)
@@ -108,14 +113,15 @@ pub fn get_records<T>(
     columns: impl Iterator<Item = Column<'static>>,
     aggr_selections: &[RelAggregationSelection],
     query: T,
+    trace_id: Option<String>,
 ) -> Select<'static>
 where
     T: SelectDefinition,
 {
-    let (select, additional_selection_set) = query.into_select(model, aggr_selections);
+    let (select, additional_selection_set) = query.into_select(model, aggr_selections, trace_id.clone());
     let select = columns.fold(select, |acc, col| acc.column(col));
 
-    let select = select.append_trace(&Span::current());
+    let select = select.append_trace(&Span::current()).add_trace_id(trace_id);
 
     additional_selection_set
         .into_iter()
@@ -149,13 +155,13 @@ where
 /// Important note: Do not use the AsColumn trait here as we need to construct column references that are relative,
 /// not absolute - e.g. `SELECT "field" FROM (...)` NOT `SELECT "full"."path"."to"."field" FROM (...)`.
 #[tracing::instrument(skip(model, selections, args))]
-pub fn aggregate(model: &ModelRef, selections: &[AggregationSelection], args: QueryArguments) -> Select<'static> {
+pub fn aggregate(model: &ModelRef, selections: &[AggregationSelection], args: QueryArguments, trace_id: Option<String>) -> Select<'static> {
     let columns = extract_columns(model, &selections);
-    let sub_query = get_records(model, columns.into_iter(), &[], args);
+    let sub_query = get_records(model, columns.into_iter(), &[], args, trace_id.clone());
     let sub_table = Table::from(sub_query).alias("sub");
 
     selections.iter().fold(
-        Select::from_table(sub_table).append_trace(&Span::current()),
+        Select::from_table(sub_table).append_trace(&Span::current()).add_trace_id(trace_id),
         |select, next_op| match next_op {
             AggregationSelection::Field(field) => select.column(Column::from(field.db_name().to_owned())),
 
@@ -197,8 +203,9 @@ pub fn group_by_aggregate(
     selections: &[AggregationSelection],
     group_by: Vec<ScalarFieldRef>,
     having: Option<Filter>,
+    trace_id: Option<String>,
 ) -> Select<'static> {
-    let (base_query, _) = args.into_select(model, &[]);
+    let (base_query, _) = args.into_select(model, &[], trace_id.clone());
 
     let select_query = selections.iter().fold(base_query, |select, next_op| match next_op {
         AggregationSelection::Field(field) => select.column(field.as_column()),
@@ -234,7 +241,7 @@ pub fn group_by_aggregate(
 
     let grouped = group_by
         .into_iter()
-        .fold(select_query.append_trace(&Span::current()), |query, field| {
+        .fold(select_query.append_trace(&Span::current()).add_trace_id(trace_id), |query, field| {
             query.group_by(field.as_column())
         });
 

--- a/query-engine/connectors/sql-query-connector/src/query_builder/write.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_builder/write.rs
@@ -10,7 +10,7 @@ use tracing::Span;
 /// `INSERT` a new record to the database. Resulting an `INSERT` ast and an
 /// optional `RecordProjection` if available from the arguments or model.
 #[tracing::instrument(skip(model, args))]
-pub fn create_record(model: &ModelRef, mut args: WriteArgs) -> (Insert<'static>, Option<SelectionResult>) {
+pub fn create_record(model: &ModelRef, mut args: WriteArgs, trace_id: Option<String>) -> (Insert<'static>, Option<SelectionResult>) {
     let return_id = args.as_record_projection(model.primary_identifier().into());
 
     let fields: Vec<_> = model
@@ -35,7 +35,8 @@ pub fn create_record(model: &ModelRef, mut args: WriteArgs) -> (Insert<'static>,
     (
         Insert::from(insert)
             .returning(ModelProjection::from(model.primary_identifier()).as_columns())
-            .append_trace(&Span::current()),
+            .append_trace(&Span::current())
+            .add_trace_id(trace_id),
         return_id,
     )
 }
@@ -50,6 +51,7 @@ pub fn create_records_nonempty(
     args: Vec<WriteArgs>,
     skip_duplicates: bool,
     affected_fields: &HashSet<ScalarFieldRef>,
+    trace_id: Option<String>,
 ) -> Insert<'static> {
     // We need to bring all write args into a uniform shape.
     // The easiest way to do this is to take go over all fields of the batch and apply the following:
@@ -82,7 +84,7 @@ pub fn create_records_nonempty(
     let insert = Insert::multi_into(model.as_table(), columns);
     let insert = values.into_iter().fold(insert, |stmt, values| stmt.values(values));
     let insert: Insert = insert.into();
-    let insert = insert.append_trace(&Span::current());
+    let insert = insert.append_trace(&Span::current()).add_trace_id(trace_id);
 
     if skip_duplicates {
         insert.on_conflict(OnConflict::DoNothing)
@@ -93,9 +95,9 @@ pub fn create_records_nonempty(
 
 /// `INSERT` empty records statement.
 #[tracing::instrument(skip(model, skip_duplicates))]
-pub fn create_records_empty(model: &ModelRef, skip_duplicates: bool) -> Insert<'static> {
+pub fn create_records_empty(model: &ModelRef, skip_duplicates: bool, trace_id: Option<String>,) -> Insert<'static> {
     let insert: Insert<'static> = Insert::single_into(model.as_table()).into();
-    let insert = insert.append_trace(&Span::current());
+    let insert = insert.append_trace(&Span::current()).add_trace_id(trace_id);
 
     if skip_duplicates {
         insert.on_conflict(OnConflict::DoNothing)
@@ -105,7 +107,7 @@ pub fn create_records_empty(model: &ModelRef, skip_duplicates: bool) -> Insert<'
 }
 
 #[tracing::instrument(skip(model, ids, args))]
-pub fn update_many(model: &ModelRef, ids: &[&SelectionResult], args: WriteArgs) -> crate::Result<Vec<Query<'static>>> {
+pub fn update_many(model: &ModelRef, ids: &[&SelectionResult], args: WriteArgs, trace_id: Option<String>) -> crate::Result<Vec<Query<'static>>> {
     if args.args.is_empty() || ids.is_empty() {
         return Ok(Vec::new());
     }
@@ -159,7 +161,7 @@ pub fn update_many(model: &ModelRef, ids: &[&SelectionResult], args: WriteArgs) 
             acc.set(name, value)
         });
 
-    let query = query.append_trace(&Span::current());
+    let query = query.append_trace(&Span::current()).add_trace_id(trace_id);
     let columns: Vec<_> = ModelProjection::from(model.primary_identifier()).as_columns().collect();
     let result: Vec<Query> = super::chunked_conditions(&columns, ids, |conditions| query.clone().so_that(conditions));
 
@@ -167,13 +169,14 @@ pub fn update_many(model: &ModelRef, ids: &[&SelectionResult], args: WriteArgs) 
 }
 
 #[tracing::instrument(skip(model, ids))]
-pub fn delete_many(model: &ModelRef, ids: &[&SelectionResult]) -> Vec<Query<'static>> {
+pub fn delete_many(model: &ModelRef, ids: &[&SelectionResult], trace_id: Option<String>) -> Vec<Query<'static>> {
     let columns: Vec<_> = ModelProjection::from(model.primary_identifier()).as_columns().collect();
 
     super::chunked_conditions(&columns, ids, |conditions| {
         Delete::from_table(model.as_table())
             .so_that(conditions)
             .append_trace(&Span::current())
+            .add_trace_id(trace_id.clone())
     })
 }
 
@@ -207,6 +210,7 @@ pub fn delete_relation_table_records(
     parent_field: &RelationFieldRef,
     parent_id: &SelectionResult,
     child_ids: &[SelectionResult],
+    trace_id: Option<String>,
 ) -> Delete<'static> {
     let relation = parent_field.relation();
 
@@ -225,4 +229,5 @@ pub fn delete_relation_table_records(
     Delete::from_table(relation.as_table())
         .so_that(parent_id_criteria.and(child_id_criteria))
         .append_trace(&Span::current())
+        .add_trace_id(trace_id)
 }

--- a/query-engine/connectors/sql-query-connector/src/query_builder/write.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_builder/write.rs
@@ -10,7 +10,11 @@ use tracing::Span;
 /// `INSERT` a new record to the database. Resulting an `INSERT` ast and an
 /// optional `RecordProjection` if available from the arguments or model.
 #[tracing::instrument(skip(model, args))]
-pub fn create_record(model: &ModelRef, mut args: WriteArgs, trace_id: Option<String>) -> (Insert<'static>, Option<SelectionResult>) {
+pub fn create_record(
+    model: &ModelRef,
+    mut args: WriteArgs,
+    trace_id: Option<String>,
+) -> (Insert<'static>, Option<SelectionResult>) {
     let return_id = args.as_record_projection(model.primary_identifier().into());
 
     let fields: Vec<_> = model
@@ -95,7 +99,7 @@ pub fn create_records_nonempty(
 
 /// `INSERT` empty records statement.
 #[tracing::instrument(skip(model, skip_duplicates))]
-pub fn create_records_empty(model: &ModelRef, skip_duplicates: bool, trace_id: Option<String>,) -> Insert<'static> {
+pub fn create_records_empty(model: &ModelRef, skip_duplicates: bool, trace_id: Option<String>) -> Insert<'static> {
     let insert: Insert<'static> = Insert::single_into(model.as_table()).into();
     let insert = insert.append_trace(&Span::current()).add_trace_id(trace_id);
 
@@ -107,7 +111,12 @@ pub fn create_records_empty(model: &ModelRef, skip_duplicates: bool, trace_id: O
 }
 
 #[tracing::instrument(skip(model, ids, args))]
-pub fn update_many(model: &ModelRef, ids: &[&SelectionResult], args: WriteArgs, trace_id: Option<String>) -> crate::Result<Vec<Query<'static>>> {
+pub fn update_many(
+    model: &ModelRef,
+    ids: &[&SelectionResult],
+    args: WriteArgs,
+    trace_id: Option<String>,
+) -> crate::Result<Vec<Query<'static>>> {
     if args.args.is_empty() || ids.is_empty() {
         return Ok(Vec::new());
     }

--- a/query-engine/connectors/sql-query-connector/src/query_ext.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_ext.rs
@@ -142,6 +142,7 @@ pub trait QueryExt: Queryable + Send + Sync {
         let select = Select::from_table(model.as_table())
             .columns(id_cols)
             .append_trace(&Span::current())
+            .add_trace_id(trace_id.clone())
             .so_that(filter.aliased_cond(None));
 
         self.select_ids(select, model_id, trace_id).await

--- a/query-engine/connectors/sql-query-connector/src/sql_trace.rs
+++ b/query-engine/connectors/sql-query-connector/src/sql_trace.rs
@@ -13,6 +13,7 @@ pub fn trace_parent_to_string(context: &SpanContext) -> String {
 
 pub trait SqlTraceComment: Sized {
     fn append_trace(self, span: &Span) -> Self;
+    fn add_trace_id(self, trace_id: Option<String>) -> Self;
 }
 
 macro_rules! sql_trace {
@@ -25,6 +26,14 @@ macro_rules! sql_trace {
 
                 if otel_ctx.trace_flags() == TraceFlags::SAMPLED {
                     self.comment(trace_parent_to_string(otel_ctx))
+                } else {
+                    self
+                }
+            }
+            // Temporary method to pass the traceid in an operation
+            fn add_trace_id(self, trace_id: Option<String>) -> Self {
+                if let Some(traceparent) = trace_id {
+                    self.comment(format!("traceparent={}", traceparent))
                 } else {
                     self
                 }

--- a/query-engine/core/src/executor/interpreting_executor.rs
+++ b/query-engine/core/src/executor/interpreting_executor.rs
@@ -43,10 +43,11 @@ where
         graph: QueryGraph,
         serializer: IrSerializer,
         force_transactions: bool,
+        trace_id: Option<String>,
     ) -> crate::Result<ResponseData> {
         if force_transactions || graph.needs_transaction() {
             let mut tx = conn.start_transaction().await?;
-            let result = Self::execute_on(tx.as_connection_like(), graph, serializer).await;
+            let result = Self::execute_on(tx.as_connection_like(), graph, serializer, trace_id).await;
 
             if result.is_ok() {
                 tx.commit().await?;
@@ -56,7 +57,7 @@ where
 
             result
         } else {
-            Self::execute_on(conn.as_connection_like(), graph, serializer).await
+            Self::execute_on(conn.as_connection_like(), graph, serializer, trace_id).await
         }
     }
 
@@ -66,9 +67,10 @@ where
         conn: &mut dyn ConnectionLike,
         graph: QueryGraph,
         serializer: IrSerializer,
+        trace_id: Option<String>,
     ) -> crate::Result<ResponseData> {
         let interpreter = QueryInterpreter::new(conn);
-        let result = QueryPipeline::new(graph, interpreter, serializer).execute().await;
+        let result = QueryPipeline::new(graph, interpreter, serializer).execute(trace_id).await;
 
         result
     }
@@ -116,6 +118,7 @@ where
         tx_id: Option<TxId>,
         operation: Operation,
         query_schema: QuerySchemaRef,
+        trace_id: Option<String>,
     ) -> crate::Result<ResponseData> {
         // Parse, validate, and extract query graph from query document.
         let (query_graph, serializer) = QueryGraphBuilder::new(query_schema).build(operation)?;
@@ -125,10 +128,10 @@ where
             let mut c_tx = self.tx_cache.get_or_err(&tx_id)?;
             let otx = c_tx.as_open()?;
 
-            Self::execute_on(otx.tx.as_connection_like(), query_graph, serializer).await
+            Self::execute_on(otx.tx.as_connection_like(), query_graph, serializer, trace_id).await
         } else {
             let conn = self.connector.get_connection().await?;
-            Self::execute_self_contained(conn, query_graph, serializer, self.force_transactions).await
+            Self::execute_self_contained(conn, query_graph, serializer, self.force_transactions, trace_id).await
         }
     }
 
@@ -151,6 +154,7 @@ where
         operations: Vec<Operation>,
         transactional: bool,
         query_schema: QuerySchemaRef,
+        trace_id: Option<String>,
     ) -> crate::Result<Vec<crate::Result<ResponseData>>> {
         if let Some(tx_id) = tx_id {
             let queries = operations
@@ -165,7 +169,7 @@ where
             let tx = otx.as_connection_like();
 
             for (graph, serializer) in queries {
-                let result = Self::execute_on(tx, graph, serializer).await?;
+                let result = Self::execute_on(tx, graph, serializer, trace_id.clone()).await?;
                 results.push(Ok(result));
             }
 
@@ -181,7 +185,7 @@ where
             let mut results = Vec::with_capacity(queries.len());
 
             for (graph, serializer) in queries {
-                let result = Self::execute_on(tx.as_connection_like(), graph, serializer).await;
+                let result = Self::execute_on(tx.as_connection_like(), graph, serializer, trace_id.clone()).await;
 
                 if result.is_err() {
                     tx.rollback().await?;
@@ -205,6 +209,7 @@ where
                             graph,
                             serializer,
                             self.force_transactions,
+                            trace_id.clone()
                         )));
                     }
 

--- a/query-engine/core/src/executor/interpreting_executor.rs
+++ b/query-engine/core/src/executor/interpreting_executor.rs
@@ -70,7 +70,9 @@ where
         trace_id: Option<String>,
     ) -> crate::Result<ResponseData> {
         let interpreter = QueryInterpreter::new(conn);
-        let result = QueryPipeline::new(graph, interpreter, serializer).execute(trace_id).await;
+        let result = QueryPipeline::new(graph, interpreter, serializer)
+            .execute(trace_id)
+            .await;
 
         result
     }
@@ -209,7 +211,7 @@ where
                             graph,
                             serializer,
                             self.force_transactions,
-                            trace_id.clone()
+                            trace_id.clone(),
                         )));
                     }
 

--- a/query-engine/core/src/executor/mod.rs
+++ b/query-engine/core/src/executor/mod.rs
@@ -27,6 +27,7 @@ pub trait QueryExecutor: TransactionManager {
         tx_id: Option<TxId>,
         operation: Operation,
         query_schema: QuerySchemaRef,
+        trace_id: Option<String>,
     ) -> crate::Result<ResponseData>;
 
     /// Executes a collection of operations as either a fanout of individual operations (non-transactional), or in series (transactional).
@@ -41,6 +42,7 @@ pub trait QueryExecutor: TransactionManager {
         operations: Vec<Operation>,
         transactional: bool,
         query_schema: QuerySchemaRef,
+        trace_id: Option<String>,
     ) -> crate::Result<Vec<crate::Result<ResponseData>>>;
 
     fn primary_connector(&self) -> &(dyn Connector + Send + Sync);

--- a/query-engine/core/src/executor/pipeline.rs
+++ b/query-engine/core/src/executor/pipeline.rs
@@ -16,10 +16,11 @@ impl<'conn> QueryPipeline<'conn> {
         }
     }
 
-    pub async fn execute(mut self) -> crate::Result<ResponseData> {
+    #[tracing::instrument(skip(trace_id))]
+    pub async fn execute(mut self, trace_id: Option<String>) -> crate::Result<ResponseData> {
         let serializer = self.serializer;
         let expr = Expressionista::translate(self.graph)?;
-        let result = self.interpreter.interpret(expr, Env::default(), 0).await;
+        let result = self.interpreter.interpret(expr, Env::default(), 0, trace_id).await;
 
         trace!("{}", self.interpreter.log_output());
         serializer.serialize(result?)

--- a/query-engine/core/src/interpreter/interpreter.rs
+++ b/query-engine/core/src/interpreter/interpreter.rs
@@ -233,7 +233,7 @@ impl<'conn> QueryInterpreter<'conn> {
 
                     Query::Write(write) => {
                         self.log_line(level, || format!("WRITE {}", write));
-                        Ok(write::execute(self.conn, write).await.map(ExpressionResult::Query)?)
+                        Ok(write::execute(self.conn, write, trace_id).await.map(ExpressionResult::Query)?)
                     }
                 }
             }),

--- a/query-engine/core/src/interpreter/interpreter.rs
+++ b/query-engine/core/src/interpreter/interpreter.rs
@@ -170,12 +170,13 @@ impl<'conn> QueryInterpreter<'conn> {
         exp: Expression,
         env: Env,
         level: usize,
+        trace_id: Option<String>,
     ) -> BoxFuture<'_, InterpretationResult<ExpressionResult>> {
         match exp {
             Expression::Func { func } => {
                 let expr = func(env.clone());
 
-                Box::pin(async move { self.interpret(expr?, env, level).await })
+                Box::pin(async move { self.interpret(expr?, env, level, trace_id).await })
             }
 
             Expression::Sequence { seq } if seq.is_empty() => Box::pin(async { Ok(ExpressionResult::Empty) }),
@@ -187,7 +188,7 @@ impl<'conn> QueryInterpreter<'conn> {
                     let mut results = Vec::with_capacity(seq.len());
 
                     for expr in seq {
-                        results.push(self.interpret(expr, env.clone(), level + 1).await?);
+                        results.push(self.interpret(expr, env.clone(), level + 1, trace_id.clone()).await?);
                     }
 
                     // Last result gets returned
@@ -206,7 +207,7 @@ impl<'conn> QueryInterpreter<'conn> {
                     for binding in bindings {
                         self.log_line(level + 1, || format!("bind {} ", &binding.name));
 
-                        let result = self.interpret(binding.expr, env.clone(), level + 2).await?;
+                        let result = self.interpret(binding.expr, env.clone(), level + 2, trace_id.clone()).await?;
                         inner_env.insert(binding.name, result);
                     }
 
@@ -217,7 +218,7 @@ impl<'conn> QueryInterpreter<'conn> {
                         Expression::Sequence { seq: expressions }
                     };
 
-                    self.interpret(next_expression, inner_env, level + 1).await
+                    self.interpret(next_expression, inner_env, level + 1, trace_id).await
                 })
             }
 
@@ -225,7 +226,7 @@ impl<'conn> QueryInterpreter<'conn> {
                 match *query {
                     Query::Read(read) => {
                         self.log_line(level, || format!("READ {}", read));
-                        Ok(read::execute(self.conn, read, None)
+                        Ok(read::execute(self.conn, read, None, trace_id)
                             .await
                             .map(ExpressionResult::Query)?)
                     }
@@ -262,9 +263,9 @@ impl<'conn> QueryInterpreter<'conn> {
                 self.log_line(level, || "IF");
 
                 if func() {
-                    self.interpret(Expression::Sequence { seq: then }, env, level + 1).await
+                    self.interpret(Expression::Sequence { seq: then }, env, level + 1, trace_id).await
                 } else {
-                    self.interpret(Expression::Sequence { seq: elze }, env, level + 1).await
+                    self.interpret(Expression::Sequence { seq: elze }, env, level + 1, trace_id).await
                 }
             }),
 

--- a/query-engine/core/src/interpreter/interpreter.rs
+++ b/query-engine/core/src/interpreter/interpreter.rs
@@ -207,7 +207,9 @@ impl<'conn> QueryInterpreter<'conn> {
                     for binding in bindings {
                         self.log_line(level + 1, || format!("bind {} ", &binding.name));
 
-                        let result = self.interpret(binding.expr, env.clone(), level + 2, trace_id.clone()).await?;
+                        let result = self
+                            .interpret(binding.expr, env.clone(), level + 2, trace_id.clone())
+                            .await?;
                         inner_env.insert(binding.name, result);
                     }
 
@@ -233,7 +235,9 @@ impl<'conn> QueryInterpreter<'conn> {
 
                     Query::Write(write) => {
                         self.log_line(level, || format!("WRITE {}", write));
-                        Ok(write::execute(self.conn, write, trace_id).await.map(ExpressionResult::Query)?)
+                        Ok(write::execute(self.conn, write, trace_id)
+                            .await
+                            .map(ExpressionResult::Query)?)
                     }
                 }
             }),
@@ -263,9 +267,11 @@ impl<'conn> QueryInterpreter<'conn> {
                 self.log_line(level, || "IF");
 
                 if func() {
-                    self.interpret(Expression::Sequence { seq: then }, env, level + 1, trace_id).await
+                    self.interpret(Expression::Sequence { seq: then }, env, level + 1, trace_id)
+                        .await
                 } else {
-                    self.interpret(Expression::Sequence { seq: elze }, env, level + 1, trace_id).await
+                    self.interpret(Expression::Sequence { seq: elze }, env, level + 1, trace_id)
+                        .await
                 }
             }),
 

--- a/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
@@ -33,7 +33,9 @@ pub async fn m2m(
         return Ok((ManyRecords::empty(&query.selected_fields), None));
     }
 
-    let ids = tx.get_related_m2m_record_ids(&query.parent_field, &parent_ids, trace_id.clone()).await?;
+    let ids = tx
+        .get_related_m2m_record_ids(&query.parent_field, &parent_ids, trace_id.clone())
+        .await?;
     if ids.is_empty() {
         return Ok((ManyRecords::empty(&query.selected_fields), None));
     }
@@ -205,8 +207,14 @@ pub async fn one2m(
             Some(existing_filter) => Some(Filter::and(vec![existing_filter, filter])),
             None => Some(filter),
         };
-        tx.get_many_records(&parent_field.related_model(), args, selected_fields, &aggr_selections, trace_id)
-            .await?
+        tx.get_many_records(
+            &parent_field.related_model(),
+            args,
+            selected_fields,
+            &aggr_selections,
+            trace_id,
+        )
+        .await?
     };
 
     // Inlining is done on the parent, this means that we need to write the primary parent ID

--- a/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
@@ -13,6 +13,7 @@ pub async fn m2m(
     query: &RelatedRecordsQuery,
     parent_result: Option<&ManyRecords>,
     processor: InMemoryRecordProcessor,
+    trace_id: Option<String>,
 ) -> InterpretationResult<(ManyRecords, Option<Vec<RelAggregationRow>>)> {
     let parent_field = &query.parent_field;
     let child_link_id = parent_field.related_field().linking_fields();
@@ -32,7 +33,7 @@ pub async fn m2m(
         return Ok((ManyRecords::empty(&query.selected_fields), None));
     }
 
-    let ids = tx.get_related_m2m_record_ids(&query.parent_field, &parent_ids).await?;
+    let ids = tx.get_related_m2m_record_ids(&query.parent_field, &parent_ids, trace_id.clone()).await?;
     if ids.is_empty() {
         return Ok((ManyRecords::empty(&query.selected_fields), None));
     }
@@ -69,6 +70,7 @@ pub async fn m2m(
                 args,
                 &query.selected_fields,
                 &query.aggregation_selections,
+                trace_id.clone(),
             )
             .await?
         };
@@ -145,6 +147,7 @@ pub async fn one2m(
     selected_fields: &FieldSelection,
     aggr_selections: Vec<RelAggregationSelection>,
     processor: InMemoryRecordProcessor,
+    trace_id: Option<String>,
 ) -> InterpretationResult<(ManyRecords, Option<Vec<RelAggregationRow>>)> {
     let parent_model_id = parent_field.model().primary_identifier();
     let parent_link_id = parent_field.linking_fields();
@@ -202,7 +205,7 @@ pub async fn one2m(
             Some(existing_filter) => Some(Filter::and(vec![existing_filter, filter])),
             None => Some(filter),
         };
-        tx.get_many_records(&parent_field.related_model(), args, selected_fields, &aggr_selections)
+        tx.get_many_records(&parent_field.related_model(), args, selected_fields, &aggr_selections, trace_id)
             .await?
     };
 

--- a/query-engine/core/src/interpreter/query_interpreters/write.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/write.rs
@@ -6,7 +6,11 @@ use crate::{
 use connector::ConnectionLike;
 use prisma_value::PrismaValue;
 
-pub async fn execute(tx: &mut dyn ConnectionLike, write_query: WriteQuery, trace_id: Option<String>) -> InterpretationResult<QueryResult> {
+pub async fn execute(
+    tx: &mut dyn ConnectionLike,
+    write_query: WriteQuery,
+    trace_id: Option<String>,
+) -> InterpretationResult<QueryResult> {
     match write_query {
         WriteQuery::CreateRecord(q) => create_one(tx, q, trace_id).await,
         WriteQuery::CreateManyRecords(q) => create_many(tx, q, trace_id).await,
@@ -42,25 +46,41 @@ async fn execute_raw(
     Ok(QueryResult::Json(num))
 }
 
-async fn create_one(tx: &mut dyn ConnectionLike, q: CreateRecord, trace_id: Option<String>) -> InterpretationResult<QueryResult> {
+async fn create_one(
+    tx: &mut dyn ConnectionLike,
+    q: CreateRecord,
+    trace_id: Option<String>,
+) -> InterpretationResult<QueryResult> {
     let res = tx.create_record(&q.model, q.args, trace_id).await?;
 
     Ok(QueryResult::Id(Some(res)))
 }
 
-async fn create_many(tx: &mut dyn ConnectionLike, q: CreateManyRecords, trace_id: Option<String>) -> InterpretationResult<QueryResult> {
+async fn create_many(
+    tx: &mut dyn ConnectionLike,
+    q: CreateManyRecords,
+    trace_id: Option<String>,
+) -> InterpretationResult<QueryResult> {
     let affected_records = tx.create_records(&q.model, q.args, q.skip_duplicates, trace_id).await?;
 
     Ok(QueryResult::Count(affected_records))
 }
 
-async fn update_one(tx: &mut dyn ConnectionLike, q: UpdateRecord, trace_id: Option<String>) -> InterpretationResult<QueryResult> {
+async fn update_one(
+    tx: &mut dyn ConnectionLike,
+    q: UpdateRecord,
+    trace_id: Option<String>,
+) -> InterpretationResult<QueryResult> {
     let mut res = tx.update_records(&q.model, q.record_filter, q.args, trace_id).await?;
 
     Ok(QueryResult::Id(res.pop()))
 }
 
-async fn delete_one(tx: &mut dyn ConnectionLike, q: DeleteRecord, trace_id: Option<String>) -> InterpretationResult<QueryResult> {
+async fn delete_one(
+    tx: &mut dyn ConnectionLike,
+    q: DeleteRecord,
+    trace_id: Option<String>,
+) -> InterpretationResult<QueryResult> {
     // We need to ensure that we have a record finder, else we delete everything (conversion to empty filter).
     let filter = match q.record_filter {
         Some(f) => Ok(f),
@@ -75,13 +95,21 @@ async fn delete_one(tx: &mut dyn ConnectionLike, q: DeleteRecord, trace_id: Opti
     Ok(QueryResult::Count(res))
 }
 
-async fn update_many(tx: &mut dyn ConnectionLike, q: UpdateManyRecords, trace_id: Option<String>) -> InterpretationResult<QueryResult> {
+async fn update_many(
+    tx: &mut dyn ConnectionLike,
+    q: UpdateManyRecords,
+    trace_id: Option<String>,
+) -> InterpretationResult<QueryResult> {
     let res = tx.update_records(&q.model, q.record_filter, q.args, trace_id).await?;
 
     Ok(QueryResult::Count(res.len()))
 }
 
-async fn delete_many(tx: &mut dyn ConnectionLike, q: DeleteManyRecords, trace_id: Option<String>) -> InterpretationResult<QueryResult> {
+async fn delete_many(
+    tx: &mut dyn ConnectionLike,
+    q: DeleteManyRecords,
+    trace_id: Option<String>,
+) -> InterpretationResult<QueryResult> {
     let res = tx.delete_records(&q.model, q.record_filter, trace_id).await?;
 
     Ok(QueryResult::Count(res))
@@ -98,12 +126,16 @@ async fn connect(tx: &mut dyn ConnectionLike, q: ConnectRecords) -> Interpretati
     Ok(QueryResult::Unit)
 }
 
-async fn disconnect(tx: &mut dyn ConnectionLike, q: DisconnectRecords, trace_id: Option<String>) -> InterpretationResult<QueryResult> {
+async fn disconnect(
+    tx: &mut dyn ConnectionLike,
+    q: DisconnectRecords,
+    trace_id: Option<String>,
+) -> InterpretationResult<QueryResult> {
     tx.m2m_disconnect(
         &q.relation_field,
         &q.parent_id.expect("Expected parent record ID to be set for disconnect"),
         &q.child_ids,
-        trace_id
+        trace_id,
     )
     .await?;
 

--- a/query-engine/core/src/interpreter/query_interpreters/write.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/write.rs
@@ -6,16 +6,17 @@ use crate::{
 use connector::ConnectionLike;
 use prisma_value::PrismaValue;
 
-pub async fn execute(tx: &mut dyn ConnectionLike, write_query: WriteQuery) -> InterpretationResult<QueryResult> {
+pub async fn execute(tx: &mut dyn ConnectionLike, write_query: WriteQuery, trace_id: Option<String>) -> InterpretationResult<QueryResult> {
     match write_query {
         WriteQuery::CreateRecord(q) => create_one(tx, q).await,
         WriteQuery::CreateManyRecords(q) => create_many(tx, q).await,
-        WriteQuery::UpdateRecord(q) => update_one(tx, q).await,
-        WriteQuery::DeleteRecord(q) => delete_one(tx, q).await,
-        WriteQuery::UpdateManyRecords(q) => update_many(tx, q).await,
-        WriteQuery::DeleteManyRecords(q) => delete_many(tx, q).await,
+        WriteQuery::UpdateRecord(q) => update_one(tx, q, trace_id).await,
+        WriteQuery::DeleteRecord(q) => delete_one(tx, q, trace_id).await,
+        WriteQuery::UpdateManyRecords(q) => update_many(tx, q, trace_id).await,
+        WriteQuery::DeleteManyRecords(q) => delete_many(tx, q, trace_id).await,
         WriteQuery::ConnectRecords(q) => connect(tx, q).await,
         WriteQuery::DisconnectRecords(q) => disconnect(tx, q).await,
+        // TODO: Add trace id to raw
         WriteQuery::ExecuteRaw(rq) => execute_raw(tx, rq.query, rq.parameters).await,
         WriteQuery::QueryRaw(rq) => query_raw(tx, rq.query, rq.parameters).await,
     }
@@ -53,13 +54,13 @@ async fn create_many(tx: &mut dyn ConnectionLike, q: CreateManyRecords) -> Inter
     Ok(QueryResult::Count(affected_records))
 }
 
-async fn update_one(tx: &mut dyn ConnectionLike, q: UpdateRecord) -> InterpretationResult<QueryResult> {
-    let mut res = tx.update_records(&q.model, q.record_filter, q.args).await?;
+async fn update_one(tx: &mut dyn ConnectionLike, q: UpdateRecord, trace_id: Option<String>) -> InterpretationResult<QueryResult> {
+    let mut res = tx.update_records(&q.model, q.record_filter, q.args, trace_id).await?;
 
     Ok(QueryResult::Id(res.pop()))
 }
 
-async fn delete_one(tx: &mut dyn ConnectionLike, q: DeleteRecord) -> InterpretationResult<QueryResult> {
+async fn delete_one(tx: &mut dyn ConnectionLike, q: DeleteRecord, trace_id: Option<String>) -> InterpretationResult<QueryResult> {
     // We need to ensure that we have a record finder, else we delete everything (conversion to empty filter).
     let filter = match q.record_filter {
         Some(f) => Ok(f),
@@ -69,19 +70,19 @@ async fn delete_one(tx: &mut dyn ConnectionLike, q: DeleteRecord) -> Interpretat
         )),
     }?;
 
-    let res = tx.delete_records(&q.model, filter).await?;
+    let res = tx.delete_records(&q.model, filter, trace_id).await?;
 
     Ok(QueryResult::Count(res))
 }
 
-async fn update_many(tx: &mut dyn ConnectionLike, q: UpdateManyRecords) -> InterpretationResult<QueryResult> {
-    let res = tx.update_records(&q.model, q.record_filter, q.args).await?;
+async fn update_many(tx: &mut dyn ConnectionLike, q: UpdateManyRecords, trace_id: Option<String>) -> InterpretationResult<QueryResult> {
+    let res = tx.update_records(&q.model, q.record_filter, q.args, trace_id).await?;
 
     Ok(QueryResult::Count(res.len()))
 }
 
-async fn delete_many(tx: &mut dyn ConnectionLike, q: DeleteManyRecords) -> InterpretationResult<QueryResult> {
-    let res = tx.delete_records(&q.model, q.record_filter).await?;
+async fn delete_many(tx: &mut dyn ConnectionLike, q: DeleteManyRecords, trace_id: Option<String>) -> InterpretationResult<QueryResult> {
+    let res = tx.delete_records(&q.model, q.record_filter, trace_id).await?;
 
     Ok(QueryResult::Count(res))
 }

--- a/query-engine/query-engine-node-api/src/engine.rs
+++ b/query-engine/query-engine-node-api/src/engine.rs
@@ -269,9 +269,10 @@ impl QueryEngine {
                         let span = tracing::span!(Level::TRACE, "query");
 
                         span.set_parent(cx);
+                        let trace_id = trace.get("traceparent").map(String::from);
 
                         let handler = GraphQlHandler::new(engine.executor(), engine.query_schema());
-                        Ok(handler.handle(query, tx_id.map(TxId::from)).await)
+                        Ok(handler.handle(query, tx_id.map(TxId::from), trace_id).await)
                     })
                     .await
             }

--- a/query-engine/query-engine-node-api/src/engine.rs
+++ b/query-engine/query-engine-node-api/src/engine.rs
@@ -13,7 +13,7 @@ use std::{
     sync::Arc,
 };
 use tokio::sync::RwLock;
-use tracing::Level;
+use tracing::{Level, warn};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 /// The main engine, that can be cloned between threads when using JavaScript
@@ -100,6 +100,7 @@ pub struct ConstructorOptions {
 
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
 pub struct TelemetryOptions {
     enabled: bool,
     endpoint: Option<String>,
@@ -149,10 +150,12 @@ impl QueryEngine {
 
         let datamodel = EngineDatamodel { ast, raw: datamodel };
 
-        let logger = if telemetry.enabled {
-            ChannelLogger::new_with_telemetry(log_callback, telemetry.endpoint)
-        } else {
-            ChannelLogger::new(&log_level, log_queries, log_callback)
+        // OTEL is not ready (in our Node API code) to production
+        // it will require redoing the logging collector, ignoring it for now
+        let logger = ChannelLogger::new(&log_level, log_queries, log_callback);
+
+        if telemetry.enabled {
+            warn!("Telemetry is not ready for usage yet");
         };
 
         let builder = EngineBuilder {

--- a/query-engine/query-engine-node-api/src/engine.rs
+++ b/query-engine/query-engine-node-api/src/engine.rs
@@ -13,7 +13,7 @@ use std::{
     sync::Arc,
 };
 use tokio::sync::RwLock;
-use tracing::{Level, warn};
+use tracing::{warn, Level};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 /// The main engine, that can be cloned between threads when using JavaScript

--- a/query-engine/query-engine-node-api/src/logger.rs
+++ b/query-engine/query-engine-node-api/src/logger.rs
@@ -54,6 +54,7 @@ impl ChannelLogger {
 
     /// Creates a new instance of a logger with the `trace` minimum level.
     /// Enables tracing events to OTLP endpoint.
+    #[allow(dead_code)] // This is not ready for prime time yet!
     pub fn new_with_telemetry(callback: ThreadsafeFunction<String>, endpoint: Option<String>) -> Self {
         let javascript_cb = EventChannel::new(callback, EnvFilter::new("trace"), true);
 

--- a/query-engine/query-engine/src/cli.rs
+++ b/query-engine/query-engine/src/cli.rs
@@ -143,7 +143,7 @@ impl CliCommand {
         let cx = Arc::new(cx);
 
         let handler = GraphQlHandler::new(&*cx.executor, cx.query_schema());
-        let res = handler.handle(serde_json::from_str(&decoded_request)?, None).await;
+        let res = handler.handle(serde_json::from_str(&decoded_request)?, None, None).await;
         let res = serde_json::to_string(&res).unwrap();
 
         let encoded_response = base64::encode(&res);

--- a/query-engine/query-engine/src/cli.rs
+++ b/query-engine/query-engine/src/cli.rs
@@ -143,7 +143,9 @@ impl CliCommand {
         let cx = Arc::new(cx);
 
         let handler = GraphQlHandler::new(&*cx.executor, cx.query_schema());
-        let res = handler.handle(serde_json::from_str(&decoded_request)?, None, None).await;
+        let res = handler
+            .handle(serde_json::from_str(&decoded_request)?, None, None)
+            .await;
         let res = serde_json::to_string(&res).unwrap();
 
         let encoded_response = base64::encode(&res);

--- a/query-engine/query-engine/src/server/mod.rs
+++ b/query-engine/query-engine/src/server/mod.rs
@@ -122,7 +122,7 @@ async fn graphql_handler(mut req: Request<State>) -> tide::Result {
         let cx = req.state().cx.clone();
 
         let handler = GraphQlHandler::new(&*cx.executor, cx.query_schema());
-        let result = handler.handle(body, tx_id).await;
+        let result = handler.handle(body, tx_id, None).await;
 
         let mut res = Response::new(StatusCode::Ok);
         res.set_body(Body::from_json(&result)?);

--- a/query-engine/request-handlers/src/graphql/handler.rs
+++ b/query-engine/request-handlers/src/graphql/handler.rs
@@ -24,23 +24,23 @@ impl<'a> GraphQlHandler<'a> {
         Self { executor, query_schema }
     }
 
-    pub async fn handle(&self, body: GraphQlBody, tx_id: Option<TxId>) -> PrismaResponse {
+    pub async fn handle(&self, body: GraphQlBody, tx_id: Option<TxId>, trace_id: Option<String>) -> PrismaResponse {
         tracing::debug!("Incoming GraphQL query: {:?}", body);
 
         match body.into_doc() {
-            Ok(QueryDocument::Single(query)) => self.handle_single(query, tx_id).await,
+            Ok(QueryDocument::Single(query)) => self.handle_single(query, tx_id, trace_id).await,
             Ok(QueryDocument::Multi(batch)) => match batch.compact() {
-                BatchDocument::Multi(batch, transactional) => self.handle_batch(batch, transactional, tx_id).await,
-                BatchDocument::Compact(compacted) => self.handle_compacted(compacted, tx_id).await,
+                BatchDocument::Multi(batch, transactional) => self.handle_batch(batch, transactional, tx_id, trace_id).await,
+                BatchDocument::Compact(compacted) => self.handle_compacted(compacted, tx_id, trace_id).await,
             },
             Err(err) => PrismaResponse::Single(err.into()),
         }
     }
 
-    async fn handle_single(&self, query: Operation, tx_id: Option<TxId>) -> PrismaResponse {
+    async fn handle_single(&self, query: Operation, tx_id: Option<TxId>, trace_id: Option<String>) -> PrismaResponse {
         use user_facing_errors::Error;
 
-        let gql_response = match AssertUnwindSafe(self.handle_graphql(query, tx_id)).catch_unwind().await {
+        let gql_response = match AssertUnwindSafe(self.handle_graphql(query, tx_id, trace_id)).catch_unwind().await {
             Ok(Ok(response)) => response.into(),
             Ok(Err(err)) => err.into(),
             Err(err) => {
@@ -53,12 +53,12 @@ impl<'a> GraphQlHandler<'a> {
         PrismaResponse::Single(gql_response)
     }
 
-    async fn handle_batch(&self, queries: Vec<Operation>, transactional: bool, tx_id: Option<TxId>) -> PrismaResponse {
+    async fn handle_batch(&self, queries: Vec<Operation>, transactional: bool, tx_id: Option<TxId>, trace_id: Option<String>) -> PrismaResponse {
         use user_facing_errors::Error;
 
         match AssertUnwindSafe(
             self.executor
-                .execute_all(tx_id, queries, transactional, self.query_schema.clone()),
+                .execute_all(tx_id, queries, transactional, self.query_schema.clone(), trace_id),
         )
         .catch_unwind()
         .await
@@ -86,7 +86,7 @@ impl<'a> GraphQlHandler<'a> {
     }
 
     #[tracing::instrument(skip(self, document))]
-    async fn handle_compacted(&self, document: CompactedDocument, tx_id: Option<TxId>) -> PrismaResponse {
+    async fn handle_compacted(&self, document: CompactedDocument, tx_id: Option<TxId>, trace_id: Option<String>) -> PrismaResponse {
         use user_facing_errors::Error;
 
         let plural_name = document.plural_name();
@@ -95,7 +95,7 @@ impl<'a> GraphQlHandler<'a> {
         let arguments = document.arguments;
         let nested_selection = document.nested_selection;
 
-        match AssertUnwindSafe(self.handle_graphql(document.operation, tx_id))
+        match AssertUnwindSafe(self.handle_graphql(document.operation, tx_id, trace_id))
             .catch_unwind()
             .await
         {
@@ -153,7 +153,7 @@ impl<'a> GraphQlHandler<'a> {
         }
     }
 
-    async fn handle_graphql(&self, query_doc: Operation, tx_id: Option<TxId>) -> query_core::Result<ResponseData> {
-        self.executor.execute(tx_id, query_doc, self.query_schema.clone()).await
+    async fn handle_graphql(&self, query_doc: Operation, tx_id: Option<TxId>, trace_id: Option<String>) -> query_core::Result<ResponseData> {
+        self.executor.execute(tx_id, query_doc, self.query_schema.clone(), trace_id).await
     }
 }


### PR DESCRIPTION
Current tracing implementation in the Node API conflicts with the OpenTelemetry collector layer, this makes really difficult to collect tracing information for technical reasons (explanation is a little long, ask me if you want more details).

This is (hopefully) a temporary solution for https://github.com/prisma/prisma/issues/10004 and is required for https://github.com/prisma/prisma/issues/10310 until we have more time to reconstruct the logging support for the QE in the Node API, right now we just pass whatever we get from the client to the database as a database comment, for example:

```js
const path = require('path')
const fs = require('fs')

const { QueryEngine } = require(path.join(__dirname, 'query-engine.node'))

let query = fs.readFileSync('test.json', 'utf-8')

async function main() {
    let q = new QueryEngine({
        datamodel: fs.readFileSync(path.join(__dirname, 'test.prisma'), 'utf-8'),
        logLevel: 'info',
        telemetry: {
            enabled: false,
        },
        configDir: process.cwd(),
    }, err => console.log(err))

    let traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
    console.log(`original trace: ${traceparent}`)
    await q.connect({ enableRawQueries: true })
    let res = await q.query(query, `{"traceparent": "${traceparent}"}`)

    await new Promise(_ => setTimeout(_, 500))
    console.log(res)
}

main().then(console.log).catch(console.error)
```

would generate a SQL command like this one:

```sql
SELECT `prisma`.`User`.`id`, `prisma`.`User`.`name` FROM `prisma`.`User` WHERE `prisma`.`User`.`id` = 1 
/* traceparent=00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01 */
```