### PR TITLE
Introspect datetime defaults correctly on MySQL

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1641760999,
-        "narHash": "sha256-UhSV8Qe8TBrZksBZSYqwNsWFY7EgCJCJTlRxXJSL4Jg=",
+        "lastModified": 1642069818,
+        "narHash": "sha256-666w6j8wl/bojfgpp0k58/UJ5rbrdYFbI2RFT2BXbSQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8928525bd8b8cdc1235a92a89b72cbbe5bd8a00d",
+        "rev": "46821ea01c8f54d2a20f5a503809abfc605269d7",
         "type": "github"
       },
       "original": {

--- a/introspection-engine/introspection-engine-tests/tests/tables/mysql.rs
+++ b/introspection-engine/introspection-engine-tests/tests/tables/mysql.rs
@@ -282,7 +282,7 @@ async fn a_table_with_fulltext_index_without_preview_flag(api: &TestApi) -> Test
             `a`  VARCHAR(255) NOT NULL,
             `b`  TEXT         NOT NULL
         );
-        
+
         CREATE FULLTEXT INDEX A_a_b_idx ON `A` (a, b);
     "#};
 
@@ -295,6 +295,33 @@ async fn a_table_with_fulltext_index_without_preview_flag(api: &TestApi) -> Test
           b  String @db.Text
 
           @@index([a, b])
+        }
+    "#]];
+
+    expected.assert_eq(&api.introspect_dml().await?);
+
+    Ok(())
+}
+
+#[test_connector(tags(Mysql))]
+async fn date_time_defaults(api: &TestApi) -> TestResult {
+    let setup = indoc! {r#"
+        CREATE TABLE `A` (
+            id INT PRIMARY KEY auto_increment,
+            d1 DATE DEFAULT '2020-01-01',
+            d2 DATETIME DEFAULT '2038-01-19 03:14:08',
+            d3 TIME DEFAULT '16:20:00'
+        )
+    "#};
+
+    api.raw_cmd(setup).await;
+
+    let expected = expect![[r#"
+        model A {
+          id Int       @id @default(autoincrement())
+          d1 DateTime? @default(dbgenerated("'2020-01-01'")) @db.Date
+          d2 DateTime? @default(dbgenerated("'2038-01-19 03:14:08'")) @db.DateTime(0)
+          d3 DateTime? @default(dbgenerated("'16:20:00'")) @db.Time(0)
         }
     "#]];
 

--- a/migration-engine/migration-engine-tests/tests/migrations/defaults.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/defaults.rs
@@ -36,6 +36,34 @@ fn datetime_defaults_work(api: TestApi) {
     });
 }
 
+#[test_connector(tags(Mysql))]
+fn datetime_dbgenerated_defaults(api: TestApi) {
+    let dm = indoc::indoc! {r#"
+        model A {
+          id Int       @id @default(autoincrement())
+          d1 DateTime? @default(dbgenerated("'2020-01-01'")) @db.Date
+          d2 DateTime? @default(dbgenerated("'2038-01-19 03:14:08'")) @db.DateTime(0)
+          d3 DateTime? @default(dbgenerated("'16:20:00'")) @db.Time(0)
+        }
+    "#};
+
+    api.schema_push_w_datasource(dm).send().assert_green();
+
+    api.assert_schema().assert_table("A", |table| {
+        table.assert_column("d1", |col| {
+            col.assert_default(Some(DefaultValue::db_generated("'2020-01-01'")))
+        });
+
+        table.assert_column("d2", |col| {
+            col.assert_default(Some(DefaultValue::db_generated("'2038-01-19 03:14:08'")))
+        });
+
+        table.assert_column("d3", |col| {
+            col.assert_default(Some(DefaultValue::db_generated("'16:20:00'")))
+        })
+    });
+}
+
 #[test_connector(tags(Mariadb, Mysql8), exclude(Vitess))]
 fn function_expressions_as_dbgenerated_work(api: TestApi) {
     let dm = r#"


### PR DESCRIPTION
We have to surrond static datetime values in single quotes for them to work in the migration engine.

Closes: https://github.com/prisma/migrations-team/issues/312

For now we do NOT introspect the values as `@default` due to the Query Engine then enforcing a timezone for the values, making this an awfully breaking change. So what we do is we consistently introspect date, time and datetime values as `dbgenerated("'VALUE'")`.

Example:

```sql
CREATE TABLE `A` (
    id INT PRIMARY KEY auto_increment,
    d1 DATE DEFAULT '2020-01-01',
    d2 DATETIME DEFAULT '2038-01-19 03:14:08',
    d3 TIME DEFAULT '16:20:00'
)
```

Will introspect as

```prisma
model A {
  id Int       @id @default(autoincrement())
  d1 DateTime? @default(dbgenerated("'2020-01-01'")) @db.Date
  d2 DateTime? @default(dbgenerated("'2038-01-19 03:14:08'")) @db.DateTime(0)
  d3 DateTime? @default(dbgenerated("'16:20:00'")) @db.Time(0)
}
```