### PR TITLE
Handle Option when parsing float QueryValue to i64

### DIFF
--- a/query-engine/core/src/query_document/parser.rs
+++ b/query-engine/core/src/query_document/parser.rs
@@ -247,7 +247,13 @@ impl QueryDocumentParser {
             (QueryValue::Int(i), ScalarType::BigInt) => Ok(PrismaValue::BigInt(i)),
 
             (QueryValue::Float(f), ScalarType::Float) => Ok(PrismaValue::Float(f)),
-            (QueryValue::Float(f), ScalarType::Int) => Ok(PrismaValue::Int(f.to_i64().unwrap())),
+            (QueryValue::Float(f), ScalarType::Int) => Ok(PrismaValue::Int(f.to_i64().ok_or(QueryParserError {
+                path: parent_path.clone(),
+                error_kind: QueryParserErrorKind::ValueParseError(format!(
+                    "'{}' is not a valid integer",
+                    f
+                )),
+            })?)),
             (QueryValue::Float(d), ScalarType::Decimal) => Ok(PrismaValue::Float(d)),
 
             (QueryValue::Boolean(b), ScalarType::Boolean) => Ok(PrismaValue::Boolean(b)),


### PR DESCRIPTION
Replaces an `.unwrap` call with a `QueryParserError` in `QueryDocumentParser` when attempting to parse a `QueryValue::Float` given a `ScalarType::Int`.

##### Background

I've been running into https://github.com/prisma/prisma/issues/10586, and created a reproduction case here: https://github.com/dguenther/prisma-panic-demo

The most significant part of the issue is that all subsequent calls to the client after the initial error cause the client to throw the same error. I'm sure it'd be better to fix that underlying issue, but I decided to attempt to fix the problem for this particular case, or at least start a discussion about a better fix for this issue.

This is a pretty naive fix since I'm not too familiar with your codebase, so feel free to take over the PR or close it if this is a misguided change.