### PR TITLE
Support changing existing column index type.

### DIFF
--- a/libs/sql-ddl/src/mysql.rs
+++ b/libs/sql-ddl/src/mysql.rs
@@ -193,11 +193,11 @@ impl Display for CreateIndex<'_> {
             IndexType::Fulltext => f.write_str("FULLTEXT ")?,
         }
 
-        f.write_str("INDEX ")?;
+        f.write_str("INDEX `")?;
         f.write_str(&self.index_name)?;
-        f.write_str(" ON ")?;
+        f.write_str("` ON `")?;
         f.write_str(&self.on.0)?;
-        f.write_str("(")?;
+        f.write_str("`(")?;
 
         self.on
             .1

--- a/libs/sql-ddl/src/mysql.rs
+++ b/libs/sql-ddl/src/mysql.rs
@@ -178,20 +178,26 @@ impl Display for Column<'_> {
 
 #[derive(Debug, Default)]
 pub struct CreateIndex<'a> {
-    pub unique: bool,
+    pub r#type: IndexType,
     pub index_name: Cow<'a, str>,
     pub on: (Cow<'a, str>, Vec<IndexColumn<'a>>),
 }
 
 impl Display for CreateIndex<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "CREATE {maybe_unique}INDEX `{index_name}` ON `{table_name}`(",
-            maybe_unique = if self.unique { "UNIQUE " } else { "" },
-            index_name = self.index_name,
-            table_name = self.on.0,
-        )?;
+        f.write_str("CREATE ")?;
+
+        match self.r#type {
+            IndexType::Normal => (),
+            IndexType::Unique => f.write_str("UNIQUE ")?,
+            IndexType::Fulltext => f.write_str("FULLTEXT ")?,
+        }
+
+        f.write_str("INDEX ")?;
+        f.write_str(&self.index_name)?;
+        f.write_str(" ON ")?;
+        f.write_str(&self.on.0)?;
+        f.write_str("(")?;
 
         self.on
             .1
@@ -311,6 +317,12 @@ pub enum IndexType {
     Normal,
     Unique,
     Fulltext,
+}
+
+impl Default for IndexType {
+    fn default() -> Self {
+        Self::Normal
+    }
 }
 
 #[derive(Debug)]

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
@@ -190,7 +190,11 @@ impl SqlRenderer for MysqlFlavour {
 
     fn render_create_index(&self, index: &IndexWalker<'_>) -> String {
         ddl::CreateIndex {
-            unique: index.index_type().is_unique(),
+            r#type: match index.index_type() {
+                sql_schema_describer::IndexType::Unique => ddl::IndexType::Unique,
+                sql_schema_describer::IndexType::Normal => ddl::IndexType::Normal,
+                sql_schema_describer::IndexType::Fulltext => ddl::IndexType::Fulltext,
+            },
             index_name: index.name().into(),
             on: (
                 index.table().name().into(),

--- a/migration-engine/migration-engine-tests/src/assertions.rs
+++ b/migration-engine/migration-engine-tests/src/assertions.rs
@@ -270,6 +270,7 @@ impl<'a> TableAssertion<'a> {
         }
     }
 
+    #[track_caller]
     pub fn assert_indexes_count(self, n: usize) -> Self {
         let idx_count = self.table.indices.len();
         assert!(idx_count == n, "Expected {} indexes, found {}.", n, idx_count);

--- a/migration-engine/migration-engine-tests/src/assertions.rs
+++ b/migration-engine/migration-engine-tests/src/assertions.rs
@@ -751,6 +751,12 @@ impl<'a> IndexAssertion<'a> {
         self
     }
 
+    pub fn assert_is_normal(self) -> Self {
+        assert_eq!(self.0.tpe, IndexType::Normal);
+
+        self
+    }
+
     pub fn assert_is_unique(self) -> Self {
         assert_eq!(self.0.tpe, IndexType::Unique);
 

--- a/migration-engine/migration-engine-tests/tests/create_migration/create_migration_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/create_migration/create_migration_tests.rs
@@ -936,7 +936,7 @@ fn alter_constraint_name(api: TestApi) {
            @@unique([a, b], name: "compound", map:"CustomCompoundUnique")
            @@index([a], map: "CustomIndex")
          }}
-         
+
          model B {{
            a   String
            b   String

--- a/migration-engine/migration-engine-tests/tests/migrations/indexes.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/indexes.rs
@@ -1038,94 +1038,66 @@ fn do_not_overwrite_fulltext_index_without_preview_feature(api: TestApi) {
 
 #[test_connector(tags(Mysql), preview_features("fullTextIndex"))]
 fn adding_fulltext_index_to_an_existing_column(api: TestApi) {
-    let dm = formatdoc! {r#"
-        {}
-
-        generator client {{
-          provider = "prisma-client-js"
-          previewFeatures = ["fullTextIndex"]
-        }}
-
-        model A {{
+    let dm = indoc! {r#"
+        model A {
           id Int    @id
           a  String @db.Text
           b  String @db.Text
-        }}
-    "#, api.datasource_block()};
+        }
+    "#};
 
-    api.schema_push(&dm).send().assert_green();
+    api.schema_push(&api.datamodel_with_provider(dm)).send().assert_green();
 
     api.assert_schema()
         .assert_table("A", |table| table.assert_indexes_count(0));
 
-    let dm = formatdoc! {r#"
-        {}
-
-        generator client {{
-          provider = "prisma-client-js"
-          previewFeatures = ["fullTextIndex"]
-        }}
-
-        model A {{
+    let dm = indoc! {r#"
+        model A {
           id Int    @id
           a  String @db.Text
           b  String @db.Text
 
           @@fulltext([a, b])
-        }}
-    "#, api.datasource_block()};
+        }
+    "#};
 
-    api.schema_push(&dm).send().assert_green();
+    api.schema_push(&api.datamodel_with_provider(dm)).send().assert_green();
 
     api.assert_schema().assert_table("A", |table| {
         table.assert_index_on_columns(&["a", "b"], |index| index.assert_is_fulltext())
     });
 }
 
-#[test_connector(tags(Mysql), preview_features("fullTextIndex"))]
-fn changing_fulltext_index_to_a_normal_index(api: TestApi) {
-    let dm = formatdoc! {r#"
-        {}
-
-        generator client {{
-          provider = "prisma-client-js"
-          previewFeatures = ["fullTextIndex"]
-        }}
-
-        model A {{
+#[test_connector(tags(Mysql), exclude(Mysql56), preview_features("fullTextIndex"))]
+fn changing_normal_index_to_a_fulltext_index(api: TestApi) {
+    let dm = indoc! {r#"
+        model A {
           id Int    @id
           a  String @db.VarChar(255)
           b  String @db.VarChar(255)
 
           @@index([a, b])
-        }}
-    "#, api.datasource_block()};
+        }
+    "#};
 
-    api.schema_push(&dm).send().assert_green();
+    api.schema_push(&api.datamodel_with_provider(dm)).send().assert_green();
 
     api.assert_schema().assert_table("A", |table| {
         table.assert_indexes_count(1);
         table.assert_index_on_columns(&["a", "b"], |index| index.assert_is_normal())
     });
 
-    let dm = formatdoc! {r#"
-        {}
-
-        generator client {{
-          provider = "prisma-client-js"
-          previewFeatures = ["fullTextIndex"]
-        }}
-
-        model A {{
+    let dm = indoc! {r#"
+        model A {
           id Int    @id
           a  String @db.VarChar(255)
           b  String @db.VarChar(255)
 
           @@fulltext([a, b])
-        }}
-    "#, api.datasource_block()};
+        }
+    "#};
 
-    api.schema_push(&dm).send().assert_green();
+    api.schema_push(&api.datamodel_with_provider(dm)).send().assert_green();
 
     api.assert_schema().assert_table("A", |table| {
         table.assert_indexes_count(1);

--- a/migration-engine/migration-engine-tests/tests/migrations/indexes.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/indexes.rs
@@ -1035,3 +1035,100 @@ fn do_not_overwrite_fulltext_index_without_preview_feature(api: TestApi) {
 
     api.schema_push_w_datasource(dm).send().assert_no_steps();
 }
+
+#[test_connector(tags(Mysql), preview_features("fullTextIndex"))]
+fn adding_fulltext_index_to_an_existing_column(api: TestApi) {
+    let dm = formatdoc! {r#"
+        {}
+
+        generator client {{
+          provider = "prisma-client-js"
+          previewFeatures = ["fullTextIndex"]
+        }}
+
+        model A {{
+          id Int    @id
+          a  String @db.Text
+          b  String @db.Text
+        }}
+    "#, api.datasource_block()};
+
+    api.schema_push(&dm).send().assert_green();
+
+    api.assert_schema()
+        .assert_table("A", |table| table.assert_indexes_count(0));
+
+    let dm = formatdoc! {r#"
+        {}
+
+        generator client {{
+          provider = "prisma-client-js"
+          previewFeatures = ["fullTextIndex"]
+        }}
+
+        model A {{
+          id Int    @id
+          a  String @db.Text
+          b  String @db.Text
+
+          @@fulltext([a, b])
+        }}
+    "#, api.datasource_block()};
+
+    api.schema_push(&dm).send().assert_green();
+
+    api.assert_schema().assert_table("A", |table| {
+        table.assert_index_on_columns(&["a", "b"], |index| index.assert_is_fulltext())
+    });
+}
+
+#[test_connector(tags(Mysql), preview_features("fullTextIndex"))]
+fn changing_fulltext_index_to_a_normal_index(api: TestApi) {
+    let dm = formatdoc! {r#"
+        {}
+
+        generator client {{
+          provider = "prisma-client-js"
+          previewFeatures = ["fullTextIndex"]
+        }}
+
+        model A {{
+          id Int    @id
+          a  String @db.VarChar(255)
+          b  String @db.VarChar(255)
+
+          @@index([a, b])
+        }}
+    "#, api.datasource_block()};
+
+    api.schema_push(&dm).send().assert_green();
+
+    api.assert_schema().assert_table("A", |table| {
+        table.assert_indexes_count(1);
+        table.assert_index_on_columns(&["a", "b"], |index| index.assert_is_normal())
+    });
+
+    let dm = formatdoc! {r#"
+        {}
+
+        generator client {{
+          provider = "prisma-client-js"
+          previewFeatures = ["fullTextIndex"]
+        }}
+
+        model A {{
+          id Int    @id
+          a  String @db.VarChar(255)
+          b  String @db.VarChar(255)
+
+          @@fulltext([a, b])
+        }}
+    "#, api.datasource_block()};
+
+    api.schema_push(&dm).send().assert_green();
+
+    api.assert_schema().assert_table("A", |table| {
+        table.assert_indexes_count(1);
+        table.assert_index_on_columns(&["a", "b"], |index| index.assert_is_fulltext())
+    });
+}


### PR DESCRIPTION
From
```prisma
model A {
  id Int    @id
  c  String @db.VarChar(255)
}
```
to
```prisma
model A {
  id Int    @id
  c  String @db.VarChar(255)

  @@fulltext([c])
}
```
should work.

And from
```prisma
model A {
  id Int    @id
  c  String @db.VarChar(255)

  @@index([c])
}
```
to
```prisma
model A {
  id Int    @id
  c  String @db.VarChar(255)

  @@fulltext([c])
}
```
and back.

Closes: https://github.com/prisma/prisma/issues/11177