### PR TITLE
Downgrade MySQL on Windows to 8.0.27

### DIFF
--- a/.github/workflows/migration-engine.yml
+++ b/.github/workflows/migration-engine.yml
@@ -191,7 +191,7 @@ jobs:
       fail-fast: false
       matrix:
         db:
-          - name: mysql
+          - name: mysql@8.0.27
             url: "mysql://root@localhost:3306?connect_timeout=20&socket_timeout=60"
           - name: mariadb
             url: "mysql://root@localhost:3306?connect_timeout=20&socket_timeout=60"

--- a/migration-engine/migration-engine-tests/tests/create_migration/create_migration_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/create_migration/create_migration_tests.rs
@@ -898,8 +898,12 @@ fn create_constraint_name_tests_w_explicit_names(api: TestApi) {
         });
 }
 
-#[cfg_attr(not(target_os = "windows"), test_connector(exclude(Vitess)))]
+#[test_connector(exclude(Vitess))]
 fn alter_constraint_name(api: TestApi) {
+    if cfg!(target_os = "windows") {
+        return;
+    }
+
     let plain_dm = api.datamodel_with_provider(
         r#"
          model A {


### PR DESCRIPTION
Seems that 8.0.28 has a bug that breaks the CI run. Also 8.0.27 is the latest available dockerized version of MySQL.