### PR TITLE
Add doc = false to query-engine-node-api/Cargo.toml

### DIFF
--- a/query-engine/query-engine-node-api/Cargo.toml
+++ b/query-engine/query-engine-node-api/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Julius de Bruijn <bruijn@prisma.io>"]
 edition = "2021"
 
 [lib]
+doc = false
 crate-type = ["cdylib"]
 name = "query_engine"
 


### PR DESCRIPTION
This is preventing the docs for the whole workspace from being built.

![2022-01-21_12-01-42](https://user-images.githubusercontent.com/13155277/150521849-ccca8a8e-58a4-41c1-9de4-0cf05c235c82.png)

