### PR TITLE
feat(composite): support @default on create

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/src/schemas/composites.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/src/schemas/composites.rs
@@ -68,17 +68,17 @@ pub fn to_one_composites() -> String {
         }
 
         type A {
-            a_1 String @map("a1")
+            a_1 String @default("a_1 default") @map("a1")
             a_2 Int?
         }
 
         type B {
-            b_field String
-            c       C      @map("nested_c")
+            b_field String @default("b_field default")
+            c C @map("nested_c")
         }
 
         type C {
-            c_field String
+            c_field String @default("c_field default")
             b B?
         }
         "#
@@ -111,35 +111,6 @@ pub fn to_many_composites() -> String {
 
     schema.to_owned()
 }
-
-// pub fn to_one_composites() -> String {
-//     let schema = indoc! {
-//         r#"model TestModel {
-//             #id(id, Int, @id)
-//             field String?
-//             a     A       @map("nested_a")
-//             b     B?
-//         }
-
-//         type A {
-//             a_1 String @default("a_1 default") @map("a1")
-//             a_2 Int?   @map("a2")
-//         }
-
-//         type B {
-//             b_field String @default("b_field default")
-//             c C @map("nested_c")
-//         }
-
-//         type C {
-//             c_field String @default("c_field default")
-//             b B?
-//         }
-//         "#
-//     };
-
-//     schema.to_owned()
-// }
 
 // defaults
 // maps

--- a/query-engine/connector-test-kit-rs/query-engine-tests/src/schemas/composites.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/src/schemas/composites.rs
@@ -94,17 +94,22 @@ pub fn to_many_composites() -> String {
             #id(id, Int, @id)
             field String?
             a     A[]       @map("top_a")
+            c     C[]       @map("top_c")
         }
 
         type A {
-            a_1 String @map("a1")
+            a_1 String @default("a_1 default") @map("a1")
             a_2 Int?
             b B[]
         }
 
         type B {
-            b_field String
+            b_field String   @default("b_field default")
             a       A[]      @map("nested_a")
+        }
+
+        type C {
+          c_field String @default("c_field default")
         }
         "#
     };

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/composites/list.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/composites/list.rs
@@ -263,6 +263,30 @@ mod create {
           @r###"{"data":{"createOneTestModel":{"a":[{"a_1":"a_1 default","a_2":null,"b":[{"b_field":"b_field default"}]}]}}}"###
         );
 
+        // Using single-object shorthand syntax
+        insta::assert_snapshot!(
+          run_query!(runner, r#"mutation {
+              createOneTestModel(
+                data: {
+                  id: 2
+                  a: { set: [{
+                    a_2: null,
+                    b: {}
+                  }] }
+                  c: { set: [] }
+                }
+              ) {
+                a {
+                  a_1
+                  a_2
+                  b { b_field }
+                }
+              }
+            }
+            "#),
+          @r###"{"data":{"createOneTestModel":{"a":[{"a_1":"a_1 default","a_2":null,"b":[{"b_field":"b_field default"}]}]}}}"###
+        );
+
         Ok(())
     }
 
@@ -277,6 +301,30 @@ mod create {
                 a: [{
                   a_2: null,
                   b: [{}]
+                }]
+                c: []
+              }
+            ) {
+              a {
+                a_1
+                a_2
+                b { b_field }
+              }
+            }
+          }
+        "#),
+          @r###"{"data":{"createOneTestModel":{"a":[{"a_1":"a_1 default","a_2":null,"b":[{"b_field":"b_field default"}]}]}}}"###
+        );
+
+        // Using single-object shorthand syntax
+        insta::assert_snapshot!(
+          run_query!(runner, r#"mutation {
+            createOneTestModel(
+              data: {
+                id: 2
+                a: [{
+                  a_2: null,
+                  b: {}
                 }]
                 c: []
               }

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/composites/list.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/composites/list.rs
@@ -1,12 +1,9 @@
 use query_engine_tests::*;
 
-// [Composites] Flavian Todo
-// - Include defaults here as well (no need for separate tests, can be part of the normal tests here, see composites.rs for the commented out schema)
-// - Make tests below pass where they don't.
-// - Implement missing tests, suggestions:
-//     - Error cases: Check that parsing correctly errors no required fields missing etc.
 #[test_suite(schema(to_many_composites), only(MongoDb))]
 mod create {
+    use query_engine_tests::run_query;
+
     /// Using explicit `set` operators, create (deeply nested) composite lists.
     #[connector_test]
     async fn set_create(runner: Runner) -> TestResult<()> {
@@ -17,6 +14,7 @@ mod create {
               data: {
                 id: 1
                 a: { set: { a_1: "a1", a_2: null, b: { b_field: "b_field", a: [] } } }
+                c: { set: [] }
               }
             ) {
               a {
@@ -42,6 +40,7 @@ mod create {
               data: {
                 id: 2
                 a: { set: [{ a_1: "a1", a_2: null, b: { b_field: "b_field", a: [] } }] }
+                c: { set: [] }
               }
             ) {
               a {
@@ -86,6 +85,7 @@ mod create {
                           }
                         ]
                       }
+                      c: { set: [] }
                     }
                   ) {
                     a {
@@ -117,6 +117,7 @@ mod create {
                 data: {
                   id: 1
                   a: { a_1: "a1", a_2: null, b: { b_field: "b_field", a: [] } }
+                  c: []
                 }
               ) {
                 a {
@@ -142,6 +143,7 @@ mod create {
                 data: {
                   id: 2
                   a: [{ a_1: "a1", a_2: null, b: { b_field: "b_field", a: [] } }]
+                  c: []
                 }
               ) {
                 a {
@@ -184,6 +186,7 @@ mod create {
                               ]
                             }
                           ]
+                        c: []
                       }
                     ) {
                       a {
@@ -213,41 +216,99 @@ mod create {
             createOneTestModel(
               data: {
                 id: 1
-                a: { set: { a_1: "a1", a_2: null } }
-                b: { b_field: "b_field", c: { set: { c_field: "c_field" } } }
+                a: { set: { a_1: "a1", a_2: null, b: [{ b_field: "b1" }] } }
+                c: [{ c_field: "c1" }]
               }
             ) {
               a {
                 a_1
                 a_2
+                b { b_field }
               }
-              b {
-                b_field
-                c {
-                  c_field
-                  b {
-                    b_field
-                  }
-                }
+              c {
+                c_field
               }
             }
           }
           "#),
-          @r###""###
+          @r###"{"data":{"createOneTestModel":{"a":[{"a_1":"a1","a_2":null,"b":[{"b_field":"b1"}]}],"c":[{"c_field":"c1"}]}}}"###
         );
 
         Ok(())
     }
 
-    // Todo: Relies on defaults being there.
+    // Ensures default values are set when using an explicit set empty object
     #[connector_test]
     async fn explicit_set_empty_object(runner: Runner) -> TestResult<()> {
-        todo!()
+        insta::assert_snapshot!(
+          run_query!(runner, r#"mutation {
+              createOneTestModel(
+                data: {
+                  id: 1
+                  a: { set: [{
+                    a_2: null,
+                    b: [{}]
+                  }] }
+                  c: { set: [] }
+                }
+              ) {
+                a {
+                  a_1
+                  a_2
+                  b { b_field }
+                }
+              }
+            }
+            "#),
+          @r###"{"data":{"createOneTestModel":{"a":[{"a_1":"a_1 default","a_2":null,"b":[{"b_field":"b_field default"}]}]}}}"###
+        );
+
+        Ok(())
     }
 
-    // Todo: Relies on defaults being there.
+    // Ensures default values are set when using a shorthand empty object
     #[connector_test]
     async fn shorthand_set_empty_object(runner: Runner) -> TestResult<()> {
-        todo!()
+        insta::assert_snapshot!(
+          run_query!(runner, r#"mutation {
+            createOneTestModel(
+              data: {
+                id: 1
+                a: [{
+                  a_2: null,
+                  b: [{}]
+                }]
+                c: []
+              }
+            ) {
+              a {
+                a_1
+                a_2
+                b { b_field }
+              }
+            }
+          }
+        "#),
+          @r###"{"data":{"createOneTestModel":{"a":[{"a_1":"a_1 default","a_2":null,"b":[{"b_field":"b_field default"}]}]}}}"###
+        );
+
+        Ok(())
+    }
+
+    // Missing scalar lists are coerced to empty lists
+    #[connector_test]
+    async fn missing_lists_coerced_to_empty(runner: Runner) -> TestResult<()> {
+        insta::assert_snapshot!(
+          run_query!(runner, r#"mutation {
+          createOneTestModel(data: { id: 1 }) {
+            a { a_1 }
+            c { c_field }
+          }
+        }
+        "#),
+          @r###"{"data":{"createOneTestModel":{"a":[],"c":[]}}}"###
+        );
+
+        Ok(())
     }
 }

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/composites/single.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/composites/single.rs
@@ -174,64 +174,6 @@ mod create {
         Ok(())
     }
 
-    /// Using explicit `set` operator, create (deeply nested) composites.
-    #[connector_test(schema(to_many_composites))]
-    async fn set_create_to_many(runner: Runner) -> TestResult<()> {
-        insta::assert_snapshot!(
-          run_query!(runner, r#"mutation {
-                createOneTestModel(
-                  data: {
-                    id: 1
-                    a: { set: [{
-                      a_1: "a1",
-                      a_2: null,
-                      b: [{ b_field: "b_field" }]
-                    }] }
-                  }
-                ) {
-                  a {
-                    a_1
-                    a_2
-                    b { b_field }
-                  }
-                }
-              }
-              "#),
-          @r###"{"data":{"createOneTestModel":{"a":[{"a_1":"a1","a_2":null,"b":[{"b_field":"b_field"}]}]}}}"###
-        );
-
-        Ok(())
-    }
-
-    /// Using only shorthand syntax, create (deeply nested) composites.
-    #[connector_test(schema(to_many_composites))]
-    async fn shorthand_set_create_to_many(runner: Runner) -> TestResult<()> {
-        insta::assert_snapshot!(
-          run_query!(runner, r#"mutation {
-              createOneTestModel(
-                data: {
-                  id: 1
-                  a: [{
-                    a_1: "a1",
-                    a_2: null,
-                    b: [{ b_field: "b_field" }]
-                  }]
-                }
-              ) {
-                a {
-                  a_1
-                  a_2
-                  b { b_field }
-                }
-              }
-            }
-          "#),
-          @r###"{"data":{"createOneTestModel":{"a":[{"a_1":"a1","a_2":null,"b":[{"b_field":"b_field"}]}]}}}"###
-        );
-
-        Ok(())
-    }
-
     // Fails on both the envelope and the actual input type
     #[connector_test(schema(to_one_composites))]
     async fn error_when_missing_required_fields(runner: Runner) -> TestResult<()> {

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/composites/single.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/composites/single.rs
@@ -106,6 +106,7 @@ mod create {
         Ok(())
     }
 
+    // Ensures default values are set when using an explicit set empty object
     #[connector_test(schema(to_one_composites))]
     async fn explicit_set_empty_object_to_one(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
@@ -139,6 +140,7 @@ mod create {
         Ok(())
     }
 
+    // Ensures default values are set when using a shorthand empty object
     #[connector_test(schema(to_one_composites))]
     async fn shorthand_set_empty_object_to_one(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/composites/single.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/composites/single.rs
@@ -1,15 +1,12 @@
 use query_engine_tests::*;
 
-// [Composites] Flavian Todo
-// - Include defaults here as well (no need for separate tests, can be part of the normal tests here, see composites.rs for the commented out schema)
-// - Make tests below pass where they don't.
-// - Implement missing tests, suggestions:
-//     - Error cases: Check that parsing correctly errors no required fields missing etc.
-#[test_suite(schema(to_one_composites), only(MongoDb))]
+#[test_suite(only(MongoDb))]
 mod create {
+    use query_engine_tests::{assert_error, run_query};
+
     /// Using explicit `set` operator, create (deeply nested) composites.
-    #[connector_test]
-    async fn set_create(runner: Runner) -> TestResult<()> {
+    #[connector_test(schema(to_one_composites))]
+    async fn set_create_to_one(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(runner, r#"mutation {
             createOneTestModel(
@@ -42,8 +39,8 @@ mod create {
     }
 
     /// Using only shorthand syntax, create (deeply nested) composites.
-    #[connector_test]
-    async fn shorthand_set_create(runner: Runner) -> TestResult<()> {
+    #[connector_test(schema(to_one_composites))]
+    async fn shorthand_set_create_to_one(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(runner, r#"mutation {
             createOneTestModel(
@@ -76,8 +73,8 @@ mod create {
     }
 
     /// Using explicit `set` operators and shorthands mixed together, create (deeply nested) composites.
-    #[connector_test]
-    async fn mixed_set_create(runner: Runner) -> TestResult<()> {
+    #[connector_test(schema(to_one_composites))]
+    async fn mixed_set_create_to_one(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(runner, r#"mutation {
             createOneTestModel(
@@ -109,17 +106,15 @@ mod create {
         Ok(())
     }
 
-    // Todo: Relies on defaults being there.
-
-    #[connector_test]
-    async fn explicit_set_empty_object(runner: Runner) -> TestResult<()> {
+    #[connector_test(schema(to_one_composites))]
+    async fn explicit_set_empty_object_to_one(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(runner, r#"mutation {
           createOneTestModel(
             data: {
               id: 1
               a: { set: { a_1: "a1", a_2: null } }
-              b: { set: {} }
+              b: { set: { c: {} } }
             }
           ) {
             a {
@@ -138,22 +133,21 @@ mod create {
           }
         }
         "#),
-          @r###""###
+          @r###"{"data":{"createOneTestModel":{"a":{"a_1":"a1","a_2":null},"b":{"b_field":"b_field default","c":{"c_field":"c_field default","b":null}}}}}"###
         );
 
         Ok(())
     }
 
-    // Todo: Relies on defaults being there.
-    #[connector_test]
-    async fn shorthand_set_empty_object(runner: Runner) -> TestResult<()> {
+    #[connector_test(schema(to_one_composites))]
+    async fn shorthand_set_empty_object_to_one(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(runner, r#"mutation {
             createOneTestModel(
               data: {
                 id: 1
                 a: { set: { a_1: "a1", a_2: null } }
-                b: {}
+                b: { c: {} }
               }
             ) {
               a {
@@ -172,7 +166,107 @@ mod create {
             }
           }
           "#),
-          @r###""###
+          @r###"{"data":{"createOneTestModel":{"a":{"a_1":"a1","a_2":null},"b":{"b_field":"b_field default","c":{"c_field":"c_field default","b":null}}}}}"###
+        );
+
+        Ok(())
+    }
+
+    /// Using explicit `set` operator, create (deeply nested) composites.
+    #[connector_test(schema(to_many_composites))]
+    async fn set_create_to_many(runner: Runner) -> TestResult<()> {
+        insta::assert_snapshot!(
+          run_query!(runner, r#"mutation {
+                createOneTestModel(
+                  data: {
+                    id: 1
+                    a: { set: [{
+                      a_1: "a1",
+                      a_2: null,
+                      b: [{ b_field: "b_field" }]
+                    }] }
+                  }
+                ) {
+                  a {
+                    a_1
+                    a_2
+                    b { b_field }
+                  }
+                }
+              }
+              "#),
+          @r###"{"data":{"createOneTestModel":{"a":[{"a_1":"a1","a_2":null,"b":[{"b_field":"b_field"}]}]}}}"###
+        );
+
+        Ok(())
+    }
+
+    /// Using only shorthand syntax, create (deeply nested) composites.
+    #[connector_test(schema(to_many_composites))]
+    async fn shorthand_set_create_to_many(runner: Runner) -> TestResult<()> {
+        insta::assert_snapshot!(
+          run_query!(runner, r#"mutation {
+              createOneTestModel(
+                data: {
+                  id: 1
+                  a: [{
+                    a_1: "a1",
+                    a_2: null,
+                    b: [{ b_field: "b_field" }]
+                  }]
+                }
+              ) {
+                a {
+                  a_1
+                  a_2
+                  b { b_field }
+                }
+              }
+            }
+          "#),
+          @r###"{"data":{"createOneTestModel":{"a":[{"a_1":"a1","a_2":null,"b":[{"b_field":"b_field"}]}]}}}"###
+        );
+
+        Ok(())
+    }
+
+    // Fails on both the envelope and the actual input type
+    #[connector_test(schema(to_one_composites))]
+    async fn error_when_missing_required_fields(runner: Runner) -> TestResult<()> {
+        // Envelope type failure
+        assert_error!(
+          runner,
+          r#"mutation {
+            createOneTestModel(
+              data: {
+                id: 1
+                a: { set: { a_1: "a1", a_2: null } }
+                b: {}
+              }
+            ) {
+              id
+            }
+          }"#,
+          2009,
+          "Mutation.createOneTestModel.data.TestModelUncheckedCreateInput.b.BCreateEnvelopeInput`: Expected exactly one field to be present, got 0."
+        );
+
+        // Missing required field without default failure on field `B.c`
+        assert_error!(
+            runner,
+            r#"mutation {
+            createOneTestModel(
+              data: {
+                id: 1
+                a: { set: { a_1: "a1", a_2: null } }
+                b: {}
+              }
+            ) {
+              id
+            }
+          }"#,
+            2009,
+            "Mutation.createOneTestModel.data.TestModelCreateInput.b.BCreateInput.c`: A value is required but not set."
         );
 
         Ok(())

--- a/query-engine/core/src/query_graph_builder/write/write_args_parser.rs
+++ b/query-engine/core/src/query_graph_builder/write/write_args_parser.rs
@@ -112,9 +112,11 @@ impl WriteArgsParser {
 }
 
 fn is_composite_envelope(map: &ParsedInputMap) -> bool {
-    let (key, _) = map.iter().next().unwrap();
-
-    map.len() == 1 && key == operations::SET // [Composites] Flavian Todo
+    // [Composites] Flavian Todo
+    map.iter()
+        .next()
+        .map(|(key, _)| map.len() == 1 && key == operations::SET)
+        .unwrap_or(false)
 }
 
 fn parse_composite_envelope(envelope: ParsedInputMap) -> QueryGraphBuilderResult<WriteExpression> {

--- a/query-engine/core/src/schema_builder/input_types/fields/data_input_mapper/create.rs
+++ b/query-engine/core/src/schema_builder/input_types/fields/data_input_mapper/create.rs
@@ -155,7 +155,11 @@ fn composite_create_envelope_object_type(ctx: &mut BuilderContext, cf: &Composit
     let ident = Identifier::new(name, PRISMA_NAMESPACE);
     return_cached_input!(ctx, &ident);
 
-    let input_object = Arc::new(init_input_object_type(ident.clone()));
+    let mut input_object = init_input_object_type(ident.clone());
+    input_object.require_exactly_one_field();
+
+    let input_object = Arc::new(input_object);
+
     ctx.cache_input_type(ident, input_object.clone());
 
     let create_input = InputType::Object(composite_create_object_type(ctx, cf));


### PR DESCRIPTION
## Overview

Adds support for `@default` on `create` operation for composites