### PR TITLE
ME: Implement the dbExecute command

### DIFF
--- a/migration-engine/connectors/migration-connector/src/lib.rs
+++ b/migration-engine/connectors/migration-connector/src/lib.rs
@@ -75,6 +75,9 @@ pub trait MigrationConnector: Send + Sync + 'static {
     /// Create the database referenced by Prisma schema that was used to initialize the connector.
     async fn create_database(&self) -> ConnectorResult<String>;
 
+    /// Send a command to the database directly.
+    async fn db_execute(&self, url: &str, script: &str) -> ConnectorResult<()>;
+
     /// Create a migration by comparing two database schemas. See
     /// [DiffTarget](/enum.DiffTarget.html) for possible inputs.
     async fn diff(&self, from: DiffTarget<'_>, to: DiffTarget<'_>) -> ConnectorResult<Migration>;

--- a/migration-engine/connectors/mongodb-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/mongodb-migration-connector/src/lib.rs
@@ -68,6 +68,12 @@ impl MigrationConnector for MongoDbMigrationConnector {
         ))
     }
 
+    async fn db_execute(&self, _url: &str, _script: &str) -> ConnectorResult<()> {
+        Err(ConnectorError::from_msg(
+            "dbExecute is not supported on MongoDB".to_owned(),
+        ))
+    }
+
     async fn ensure_connection_validity(&self) -> ConnectorResult<()> {
         Ok(())
     }

--- a/migration-engine/connectors/sql-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/lib.rs
@@ -251,6 +251,15 @@ impl MigrationConnector for SqlMigrationConnector {
         self.flavour.create_database(&self.connection_string).await
     }
 
+    async fn db_execute(&self, url: &str, script: &str) -> ConnectorResult<()> {
+        if url == self.connection_string {
+            self.conn().await?.raw_cmd(script).await?;
+        } else {
+            connect(url).await?.raw_cmd(script).await?;
+        };
+        Ok(())
+    }
+
     async fn diff(&self, from: DiffTarget<'_>, to: DiffTarget<'_>) -> ConnectorResult<Migration> {
         let previous_schema = self.sql_schema_from_diff_target(&from).await?;
         let next_schema = self.sql_schema_from_diff_target(&to).await?;

--- a/migration-engine/core/src/rpc.rs
+++ b/migration-engine/core/src/rpc.rs
@@ -32,6 +32,7 @@ async fn run_command(
     match cmd {
         APPLY_MIGRATIONS => render(executor.apply_migrations(&params.parse()?).await),
         CREATE_MIGRATION => render(executor.create_migration(&params.parse()?).await),
+        DB_EXECUTE => render(executor.db_execute(&params.parse()?).await),
         DEV_DIAGNOSTIC => render(executor.dev_diagnostic(&params.parse()?).await),
         DEBUG_PANIC => render(executor.debug_panic().await),
         DIAGNOSE_MIGRATION_HISTORY => render(executor.diagnose_migration_history(&params.parse()?).await),

--- a/migration-engine/json-rpc-api-build/methods/dbExecute.toml
+++ b/migration-engine/json-rpc-api-build/methods/dbExecute.toml
@@ -1,26 +1,24 @@
-
 [methods.dbExecute]
 description = """
 Execute a database script directly on the specified live database.\n\nNote that this may not be
 defined on all connectors.
 """
-requestShape = "dbExecuteInput"
-responseShape = "dbExecuteOutput"
+requestShape = "DbExecuteParams"
+responseShape = "DbExecuteResult"
 
-[recordShapes.dbExecuteInput]
-fields.datasourceType.shape = "dbExecuteDatasourceType"
-fields.inputType.shape = "dbExecuteInputType"
+[recordShapes.DbExecuteParams]
+description = "The type of params accepted by dbExecute."
+fields.datasourceType.description = "The location of the live database to connect to."
+fields.datasourceType.shape = "DbExecuteDatasourceType"
+fields.script.description = "The input script."
+fields.script.shape = "string"
 
-[recordShapes.dbExecuteOutput]
+[recordShapes.DbExecuteResult]
+description = "The type of results returned by dbExecute."
 
-[enumShapes.dbExecuteDatasourceType]
+[enumShapes.DbExecuteDatasourceType]
 description = "The location of the live database to connect to in dbExecute."
-variants.schema.description = "Path to the Prisma schema to take the datasource URL from."
+variants.schema.description = "Path to the Prisma schema file to take the datasource URL from."
 variants.schema.shape = "string"
 variants.url.description = "The URL of the database to run the command on."
 variants.url.shape = "string"
-
-[enumShapes.dbExecuteInputType]
-description = "The input script for dbExecute."
-variants.filePath = { shape = "string" }
-variants.url = { shape = "string" }

--- a/migration-engine/migration-engine-tests/src/commands/reset.rs
+++ b/migration-engine/migration-engine-tests/src/commands/reset.rs
@@ -7,10 +7,6 @@ pub struct Reset<'a> {
 }
 
 impl<'a> Reset<'a> {
-    pub fn new(api: &'a dyn GenericApi) -> Self {
-        Reset { api, rt: None }
-    }
-
     pub fn new_sync(api: &'a dyn GenericApi, rt: &'a tokio::runtime::Runtime) -> Self {
         Reset { api, rt: Some(rt) }
     }

--- a/migration-engine/migration-engine-tests/src/test_api.rs
+++ b/migration-engine/migration-engine-tests/src/test_api.rs
@@ -1,5 +1,6 @@
 pub use crate::assertions::{MigrationsAssertions, ResultSetExt, SchemaAssertion};
 pub use expect_test::expect;
+pub use migration_core::json_rpc::types::{DbExecuteDatasourceType, DbExecuteParams};
 pub use test_macros::test_connector;
 pub use test_setup::{BitFlags, Capabilities, Tags};
 
@@ -51,6 +52,11 @@ impl TestApi {
 
     pub fn connection_info(&self) -> ConnectionInfo {
         self.root.connection_info()
+    }
+
+    pub fn db_execute(&self, params: &migration_core::json_rpc::types::DbExecuteParams) -> ConnectorResult<()> {
+        let api: &dyn migration_core::GenericApi = &self.connector;
+        self.block_on(api.db_execute(params))
     }
 
     pub fn ensure_connection_validity(&self) -> ConnectorResult<()> {

--- a/migration-engine/migration-engine-tests/tests/migrations/db_execute.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/db_execute.rs
@@ -1,0 +1,61 @@
+use migration_engine_tests::test_api::*;
+use quaint::prelude::Queryable;
+
+#[test_connector(tags(Sqlite))]
+fn db_execute_happy_path_with_literal_url(api: TestApi) {
+    let tmpdir = tempfile::TempDir::new().unwrap();
+    let url = format!("file:{}/db1.sqlite", tmpdir.path().to_string_lossy());
+    let script = r#"
+        CREATE TABLE "dogs" ( id INTEGER PRIMARY KEY, name TEXT );
+        INSERT INTO "dogs" ("name") VALUES ('snoopy'), ('marmaduke');
+    "#;
+
+    // Execute the command.
+    api.db_execute(&DbExecuteParams {
+        datasource_type: DbExecuteDatasourceType::Url(url.clone()),
+        script: script.to_owned(),
+    })
+    .unwrap();
+
+    // Check that the command was executed
+    let q = api.block_on(quaint::single::Quaint::new(&url)).unwrap();
+    let result = api.block_on(q.query_raw("SELECT name FROM dogs;", &[])).unwrap();
+    let mut rows = result.into_iter();
+    assert_eq!(rows.next().unwrap()[0].to_string().unwrap(), "snoopy");
+    assert_eq!(rows.next().unwrap()[0].to_string().unwrap(), "marmaduke");
+}
+
+#[test_connector(tags(Sqlite))]
+fn db_execute_happy_path_with_prisma_schema(api: TestApi) {
+    let tmpdir = tempfile::TempDir::new().unwrap();
+    let url = format!("file:{}/dbfromschema.sqlite", tmpdir.path().to_string_lossy());
+    let prisma_schema = format!(
+        r#"
+        datasource dbtest {{
+            url = "{}"
+            provider = "sqlite"
+        }}
+    "#,
+        url
+    );
+    let schema_path = tmpdir.path().join("schema.prisma");
+    std::fs::write(&schema_path, &prisma_schema).unwrap();
+    let script = r#"
+        CREATE TABLE "dogs" ( id INTEGER PRIMARY KEY, name TEXT );
+        INSERT INTO "dogs" ("name") VALUES ('snoopy'), ('marmaduke');
+    "#;
+
+    // Execute the command.
+    api.db_execute(&DbExecuteParams {
+        datasource_type: DbExecuteDatasourceType::Schema(schema_path.to_string_lossy().into_owned()),
+        script: script.to_owned(),
+    })
+    .unwrap();
+
+    // Check that the command was executed
+    let q = api.block_on(quaint::single::Quaint::new(&url)).unwrap();
+    let result = api.block_on(q.query_raw("SELECT name FROM dogs;", &[])).unwrap();
+    let mut rows = result.into_iter();
+    assert_eq!(rows.next().unwrap()[0].to_string().unwrap(), "snoopy");
+    assert_eq!(rows.next().unwrap()[0].to_string().unwrap(), "marmaduke");
+}

--- a/migration-engine/migration-engine-tests/tests/migrations/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/mod.rs
@@ -1,5 +1,6 @@
 mod advisory_locking;
 mod basic;
+mod db_execute;
 mod defaults;
 mod dev_diagnostic_tests;
 mod diagnose_migration_history_tests;


### PR DESCRIPTION
Note that this changes the previous API, because it was not
implementable (stdin from the migration engine is not the stdin from the
migrate CLI process). Also, dbExecuteOutputType was completely wrong.

Relevant issue: https://github.com/prisma/migrations-team/issues/313