### PR TITLE
Fix(query-engines): interactive transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,9 +30,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.15"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
 ]
@@ -593,16 +593,6 @@ dependencies = [
  "darling_core 0.13.0",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "dashmap"
-version = "4.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
-dependencies = [
- "cfg-if 1.0.0",
- "num_cpus",
 ]
 
 [[package]]
@@ -1676,9 +1666,9 @@ checksum = "7e6bcd6433cff03a4bfc3d9834d504467db1f1cf6d0ea765d37d330249ed629d"
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "metrics"
@@ -2114,9 +2104,9 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "6.2.1"
+version = "6.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c5c51b9083a3c620fa67a2a635d1ce7d95b897e957d6b28ff9a5da960a103a6"
+checksum = "e7413f999671bd4745a7b624bd370a569fb6bc574b23c83a3c5ed2e453f3d5e2"
 dependencies = [
  "bitvec",
  "funty",
@@ -2847,7 +2837,6 @@ dependencies = [
  "connection-string",
  "crossbeam-queue",
  "cuid",
- "dashmap",
  "datamodel",
  "datamodel-connector",
  "futures",
@@ -3136,9 +3125,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.6"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a26af418b574bd56588335b3a3659a65725d4e636eb1016c2f9e3b38c7cc759"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4091,11 +4080,10 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.12.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2c2416fdedca8443ae44b4527de1ea633af61d8f7169ffa6e72c5b53d24efcc"
+checksum = "fbbf1c778ec206785635ce8ad57fe52b3009ae9e0c9f574a728f3049d3e55838"
 dependencies = [
- "autocfg",
  "bytes",
  "libc",
  "memchr",
@@ -4121,9 +4109,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.4.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "154794c8f499c2619acd19e839294703e9e32e7630ef5f46ea80d4ef0fbee5eb"
+checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/direct.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/direct.rs
@@ -59,7 +59,10 @@ impl RunnerInterface for DirectRunner {
     }
 
     async fn start_tx(&self, max_acquisition_millis: u64, valid_for_millis: u64) -> TestResult<TxId> {
-        let id = self.executor.start_tx(max_acquisition_millis, valid_for_millis).await?;
+        let id = self
+            .executor
+            .start_tx(self.query_schema.clone(), max_acquisition_millis, valid_for_millis)
+            .await?;
         Ok(id)
     }
 

--- a/query-engine/connectors/query-connector/src/error.rs
+++ b/query-engine/connectors/query-connector/src/error.rs
@@ -86,6 +86,9 @@ impl ConnectorError {
             ErrorKind::MissingFullTextSearchIndex => Some(KnownError::new(
                 user_facing_errors::query_engine::MissingFullTextSearchIndex {},
             )),
+            ErrorKind::TransactionAborted { message } => Some(KnownError::new(
+                user_facing_errors::query_engine::InteractiveTransactionError { error: message.clone() },
+            )),
             _ => None,
         };
 

--- a/query-engine/core/Cargo.toml
+++ b/query-engine/core/Cargo.toml
@@ -40,5 +40,4 @@ url = "2"
 user-facing-errors = { path = "../../libs/user-facing-errors" }
 uuid = "0.8"
 cuid = { git = "https://github.com/prisma/cuid-rust" }
-dashmap = "4.0"
 pin-utils = "0.1"

--- a/query-engine/core/src/executor/interactive_tx.rs
+++ b/query-engine/core/src/executor/interactive_tx.rs
@@ -1,18 +1,51 @@
-use crate::CoreError;
+use super::pipeline::QueryPipeline;
+use crate::{CoreError, QueryGraphBuilder, QueryInterpreter, QuerySchemaRef, ResponseData};
 use connector::{Connection, ConnectionLike, Transaction};
-use dashmap::{mapref::one::RefMut, DashMap};
 use once_cell::sync::Lazy;
-use std::{fmt::Display, sync::Arc};
+use std::{collections::HashMap, fmt::Display, sync::Arc};
 use thiserror::Error;
 use tokio::{
-    task::{self, JoinHandle},
+    sync::{
+        mpsc::{channel, Receiver, Sender},
+        oneshot, RwLock,
+    },
+    task::JoinHandle,
     time::{self, Duration},
 };
+
+use crate::Operation;
+
+/*
+How Interactive Transactions work
+The Interactive Transactions (iTx) follow an actor model design. Where each iTx is created in its own process.
+When a prisma client requests to start a new transaction, the Transaction Manager spawns a new iTXServer. The iTxServer runs in its own
+process and waits for messages to arrive via its receive channel to process.
+The iTx Manager will also create an iTxClient and add it to hashmap managed by an RwLock. The iTx client is the only way to communicate
+with the iTxServer.
+
+Once the prisma client receives the iTx Id it can perform database operations using that iTx id. When an operation request is received by the
+TransactionManager, it looks for the client in the hashmap and passes the operation to the client. The iTx client sends a message to the
+iTx server and waits for a response. The iTxServer will then perform the operation and return the result. The iTxServer will perform one
+operation at a time. All other operations will sit in the message queue waiting to be processed.
+Once all the operations have been done, the prisma client can ask the Transaction Manager to commit or rollback the iTx.
+Again, the Transaction Manager will find the iTx Client, and tell it to commit or rollback. The iTx Client will send a message to
+the iTxServer to commit or rollback. The iTxServer will perform that, send the response back to the iTxClient
+and then the iTxServer will move into the cache eviction state. In this state, the connection is closed, and any messages it receives, the will
+will only reply with its last state. i.e committed, rollbacked or timeout.
+
+Once the eviction timeout is exceeded, the iTxServer will send a message to the TransactionManager to say that it is completed, and it will end.
+The TransactionManager will remove the iTxClient from the hashmap.
+
+During the time the iTxServer is active there is also a timer running and if that timeout is exceeded, the
+transaction is rolledback and the connection to the database is closed. The iTxServer will then move into the eviction state.
+*/
 
 pub static CACHE_EVICTION_SECS: Lazy<u64> = Lazy::new(|| match std::env::var("CLOSED_TX_CLEANUP") {
     Ok(size) => size.parse().unwrap_or(300),
     Err(_) => 300,
 });
+
+static CHANNEL_SIZE: usize = 100;
 
 #[derive(Debug, Error, PartialEq)]
 pub enum TransactionError {
@@ -27,6 +60,9 @@ pub enum TransactionError {
 
     #[error("Transaction already closed: {reason}.")]
     Closed { reason: String },
+
+    #[error("Unexpected response: {reason}.")]
+    Unknown { reason: String },
 }
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
@@ -50,6 +86,411 @@ where
 impl Display for TxId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
+    }
+}
+
+#[derive(Debug)]
+pub enum TxOpRequestMsg {
+    Commit,
+    Rollback,
+    Single(Operation, Option<String>),
+    Batch(Vec<Operation>, Option<String>),
+}
+
+pub struct TxOpRequest {
+    msg: TxOpRequestMsg,
+    respond_to: oneshot::Sender<TxOpResponse>,
+}
+
+impl Display for TxOpRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.msg {
+            TxOpRequestMsg::Commit => write!(f, "Commit"),
+            TxOpRequestMsg::Rollback => write!(f, "Rollback"),
+            TxOpRequestMsg::Single(..) => write!(f, "Single"),
+            TxOpRequestMsg::Batch(..) => write!(f, "Batch"),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum TxOpResponse {
+    Committed(crate::Result<()>),
+    RolledBack(crate::Result<()>),
+    Expired,
+    Single(crate::Result<ResponseData>),
+    Batch(crate::Result<Vec<crate::Result<ResponseData>>>),
+}
+
+impl Display for TxOpResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Committed(..) => write!(f, "Committed"),
+            Self::RolledBack(..) => write!(f, "RolledBack"),
+            Self::Expired => write!(f, "Expired"),
+            Self::Single(..) => write!(f, "Single"),
+            Self::Batch(..) => write!(f, "Single"),
+        }
+    }
+}
+
+pub struct ITXServer {
+    id: TxId,
+    pub cached_tx: CachedTx,
+    pub timeout: Duration,
+    receive: Receiver<TxOpRequest>,
+    query_schema: QuerySchemaRef,
+}
+
+impl ITXServer {
+    pub fn new(
+        id: TxId,
+        tx: CachedTx,
+        timeout: Duration,
+        receive: Receiver<TxOpRequest>,
+        query_schema: QuerySchemaRef,
+    ) -> Self {
+        Self {
+            id,
+            cached_tx: tx,
+            timeout,
+            receive,
+            query_schema,
+        }
+    }
+
+    pub async fn process_msg(&mut self, op: TxOpRequest) -> bool {
+        match op.msg {
+            TxOpRequestMsg::Single(ref operation, trace_id) => {
+                let result = self.execute_single(&operation, trace_id).await;
+                let _ = op.respond_to.send(TxOpResponse::Single(result));
+                false
+            }
+            TxOpRequestMsg::Batch(ref operations, trace_id) => {
+                let result = self.execute_batch(&operations, trace_id).await;
+                let _ = op.respond_to.send(TxOpResponse::Batch(result));
+                false
+            }
+            TxOpRequestMsg::Commit => {
+                let resp = self.commit().await;
+                let _ = op.respond_to.send(TxOpResponse::Committed(resp));
+                true
+            }
+            TxOpRequestMsg::Rollback => {
+                let resp = self.rollback(false).await;
+                let _ = op.respond_to.send(TxOpResponse::RolledBack(resp));
+                true
+            }
+        }
+    }
+
+    async fn execute_single(&mut self, operation: &Operation, trace_id: Option<String>) -> crate::Result<ResponseData> {
+        let conn = self.cached_tx.as_open()?;
+        let interpreter = QueryInterpreter::new(conn.as_connection_like());
+        let (query_graph, serializer) = QueryGraphBuilder::new(self.query_schema.clone()).build(operation.clone())?;
+
+        QueryPipeline::new(query_graph, interpreter, serializer)
+            .execute(trace_id)
+            .await
+    }
+
+    async fn execute_batch(
+        &mut self,
+        operations: &[Operation],
+        trace_id: Option<String>,
+    ) -> crate::Result<Vec<crate::Result<ResponseData>>> {
+        let conn = self.cached_tx.as_open()?;
+        let queries = operations
+            .iter()
+            .map(|operation| QueryGraphBuilder::new(self.query_schema.clone()).build(operation.clone()))
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+
+        let mut results = Vec::with_capacity(queries.len());
+
+        for (query_graph, serializer) in queries {
+            let interpreter = QueryInterpreter::new(conn.as_connection_like());
+            let result = QueryPipeline::new(query_graph, interpreter, serializer)
+                .execute(trace_id.clone())
+                .await?;
+            results.push(Ok(result));
+        }
+
+        Ok(results)
+    }
+
+    pub async fn commit(&mut self) -> crate::Result<()> {
+        if let CachedTx::Open(_) = self.cached_tx {
+            let open_tx = self.cached_tx.as_open()?;
+            debug!("[{}] committing.", self.id.to_string());
+            open_tx.tx.commit().await?;
+            self.cached_tx = CachedTx::Committed;
+        }
+
+        Ok(())
+    }
+
+    pub async fn rollback(&mut self, was_timeout: bool) -> crate::Result<()> {
+        debug!("[{}] {was_timeout} rolling back", self.name());
+        if let CachedTx::Open(_) = self.cached_tx {
+            let open_tx = self.cached_tx.as_open()?;
+            open_tx.tx.rollback().await?;
+            if was_timeout {
+                debug!("[{}] Expired Rolling back", self.id.to_string());
+                self.cached_tx = CachedTx::Expired;
+            } else {
+                self.cached_tx = CachedTx::RolledBack;
+                debug!("[{}] Rolling back", self.id.to_string());
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn name(&self) -> String {
+        format!("itx-{:?}", self.id.to_string())
+    }
+}
+
+pub struct ITXClient {
+    send: Sender<TxOpRequest>,
+    tx_id: TxId,
+}
+
+impl ITXClient {
+    async fn commit(&self) -> crate::Result<()> {
+        let msg = self.send_and_receive(TxOpRequestMsg::Commit).await?;
+
+        if let TxOpResponse::Committed(resp) = msg {
+            debug!("[{}] COMMITTED {:?}", self.tx_id, resp);
+            resp
+        } else {
+            Err(self.handle_error(msg).into())
+        }
+    }
+
+    async fn rollback(&self) -> crate::Result<()> {
+        let msg = self.send_and_receive(TxOpRequestMsg::Rollback).await?;
+
+        if let TxOpResponse::RolledBack(resp) = msg {
+            resp
+        } else {
+            Err(self.handle_error(msg).into())
+        }
+    }
+
+    async fn execute(&self, operation: Operation, trace_id: Option<String>) -> crate::Result<ResponseData> {
+        let msg_req = TxOpRequestMsg::Single(operation, trace_id);
+        let msg = self.send_and_receive(msg_req).await?;
+
+        if let TxOpResponse::Single(resp) = msg {
+            resp
+        } else {
+            Err(self.handle_error(msg).into())
+        }
+    }
+
+    async fn batch_execute(
+        &self,
+        operations: Vec<Operation>,
+        trace_id: Option<String>,
+    ) -> crate::Result<Vec<crate::Result<ResponseData>>> {
+        let msg_req = TxOpRequestMsg::Batch(operations, trace_id);
+
+        let msg = self.send_and_receive(msg_req).await?;
+
+        if let TxOpResponse::Batch(resp) = msg {
+            resp
+        } else {
+            Err(self.handle_error(msg).into())
+        }
+    }
+
+    async fn send_and_receive(&self, msg: TxOpRequestMsg) -> Result<TxOpResponse, crate::CoreError> {
+        let (rx, req) = self.create_rx_and_req(msg);
+        if let Err(err) = self.send.send(req).await {
+            debug!("channel send error {err}");
+            return Err(TransactionError::Closed {
+                reason: "Cound not perform operation".to_string(),
+            }
+            .into());
+        }
+
+        match rx.await {
+            Ok(resp) => Ok(resp),
+            Err(_err) => Err(TransactionError::Closed {
+                reason: "Cound not perform operation".to_string(),
+            }
+            .into()),
+        }
+    }
+
+    fn create_rx_and_req(&self, msg: TxOpRequestMsg) -> (oneshot::Receiver<TxOpResponse>, TxOpRequest) {
+        let (send, rx) = oneshot::channel::<TxOpResponse>();
+        let request = TxOpRequest { msg, respond_to: send };
+        (rx, request)
+    }
+
+    fn handle_error(&self, msg: TxOpResponse) -> TransactionError {
+        match msg {
+            TxOpResponse::Expired => {
+                let reason = "Transaction is no longer valid. Last state: 'Expired'".to_string();
+                TransactionError::Closed { reason }
+            }
+            TxOpResponse::Committed(..) => {
+                let reason = "Transaction is no longer valid. Last state: 'Committed'".to_string();
+                TransactionError::Closed { reason }
+            }
+            TxOpResponse::RolledBack(..) => {
+                let reason = "Transaction is no longer valid. Last state: 'RolledBack'".to_string();
+                TransactionError::Closed { reason }
+            }
+            other => {
+                error!("Unexpected iTx response, {}", other);
+                let reason = format!("response '{}'", other);
+                TransactionError::Closed { reason }
+            }
+        }
+    }
+}
+
+pub(crate) struct TransactionProcessManager {
+    pub clients: Arc<RwLock<HashMap<TxId, ITXClient>>>,
+    send_done: Sender<TxId>,
+}
+
+impl TransactionProcessManager {
+    pub fn new() -> Self {
+        let clients: Arc<RwLock<HashMap<TxId, ITXClient>>> = Arc::new(RwLock::new(HashMap::new()));
+
+        let (send_done, mut rx) = channel::<TxId>(CHANNEL_SIZE);
+        let c = clients.clone();
+        tokio::task::spawn(async move {
+            loop {
+                if let Some(id) = rx.recv().await {
+                    debug!("removing {} from client list", id);
+                    c.write().await.remove(&id);
+                }
+            }
+        });
+
+        Self { clients, send_done }
+    }
+
+    pub async fn create_tx(&self, query_schema: QuerySchemaRef, tx_id: TxId, value: OpenTx, timeout: Duration) {
+        let (tx_to_server, rx_from_client) = channel::<TxOpRequest>(CHANNEL_SIZE);
+
+        let client = ITXClient {
+            send: tx_to_server,
+            tx_id: tx_id.clone(),
+        };
+
+        self.clients.write().await.insert(tx_id.clone(), client);
+
+        let mut server = ITXServer::new(tx_id, CachedTx::Open(value), timeout, rx_from_client, query_schema);
+        let send_done = self.send_done.clone();
+
+        tokio::task::spawn(async move {
+            let sleep = time::sleep(timeout);
+            tokio::pin!(sleep);
+
+            loop {
+                tokio::select! {
+                    _ = &mut sleep => {
+                        debug!("[{}] operation timed out", server.id.to_string());
+                        let _ = server.rollback(true).await;
+                        break;
+                    }
+                    msg = server.receive.recv() => {
+                        if let Some(op) = msg {
+                            let finished = server.process_msg(op).await;
+
+                            if finished {
+                                break
+                            }
+                        }
+                    }
+                }
+            }
+
+            debug!("[{}] completed with {}", server.id.to_string(), server.cached_tx);
+            let eviction_sleep = time::sleep(Duration::from_secs(*CACHE_EVICTION_SECS));
+            tokio::pin!(eviction_sleep);
+
+            loop {
+                tokio::select! {
+                    _ = &mut eviction_sleep => {
+                        break;
+                    }
+                    msg = server.receive.recv() => {
+                        if let Some(op) = msg {
+                            let msg = match server.cached_tx {
+                                CachedTx::Committed => TxOpResponse::Committed(Ok(())),
+                                CachedTx::RolledBack => TxOpResponse::RolledBack(Ok(())),
+                                CachedTx::Expired => TxOpResponse::Expired,
+                                 _ => {
+                                     error!("[{}] unexpected state {}", server.id.to_string(), server.cached_tx);
+                                     let _ = server.rollback(true).await;
+                                     let msg = "The transaction was in an unexpected state and rolledback".to_string();
+                                     let err = Err(TransactionError::Unknown{ reason: msg }.into());
+                                     TxOpResponse::RolledBack(err)
+                                 }
+                                };
+
+                                // we ignore any errors when sending
+                                let _ = op.respond_to.send(msg);
+                            }
+                        }
+                }
+            }
+
+            let _ = send_done.send(server.id.clone()).await;
+            debug!("[{}] has stopped with {}", server.id.to_string(), server.cached_tx);
+        });
+    }
+
+    pub async fn execute(
+        &self,
+        tx_id: &TxId,
+        operation: Operation,
+        trace_id: Option<String>,
+    ) -> crate::Result<ResponseData> {
+        if let Some(client) = self.clients.read().await.get(tx_id) {
+            let resp = client.execute(operation, trace_id).await;
+            resp
+        } else {
+            Err(TransactionError::NotFound.into())
+        }
+    }
+
+    pub async fn batch_execute(
+        &self,
+        tx_id: &TxId,
+        operations: Vec<Operation>,
+        trace_id: Option<String>,
+    ) -> crate::Result<Vec<crate::Result<ResponseData>>> {
+        if let Some(client) = self.clients.read().await.get(tx_id) {
+            client.batch_execute(operations, trace_id).await
+        } else {
+            Err(TransactionError::NotFound.into())
+        }
+    }
+
+    pub async fn commit_tx(&self, tx_id: &TxId) -> crate::Result<()> {
+        if let Some(client) = self.clients.read().await.get(tx_id) {
+            client.commit().await?;
+            Ok(())
+        } else {
+            Err(TransactionError::NotFound.into())
+        }
+    }
+
+    pub async fn rollback_tx(&self, tx_id: &TxId) -> crate::Result<()> {
+        if let Some(client) = self.clients.read().await.get(tx_id) {
+            client.rollback().await?;
+            Ok(())
+        } else {
+            Err(TransactionError::NotFound.into())
+        }
     }
 }
 
@@ -96,50 +537,6 @@ impl CachedTx {
     }
 }
 
-#[derive(Default)]
-pub(crate) struct TransactionCache {
-    cache: Arc<DashMap<TxId, CachedTx>>,
-}
-
-impl TransactionCache {
-    pub async fn insert(&self, key: TxId, mut value: OpenTx, valid_for_millis: u64) {
-        let cache = Arc::clone(&self.cache);
-        let cache_key = key.clone();
-
-        let timer_handle = task::spawn(async move {
-            debug!("[{}] Valid for {} milliseconds", cache_key, valid_for_millis);
-            time::sleep(Duration::from_millis(valid_for_millis)).await;
-            debug!("[{}] Forced rollback triggered.", cache_key);
-
-            if let Some(ref mut c_tx) = cache.get_mut(&cache_key) {
-                if let CachedTx::Open(open_tx) = c_tx.value_mut() {
-                    debug!("[{}] Rolling back.", cache_key.to_string());
-                    open_tx.tx.rollback().await.unwrap();
-                    debug!("[{}] Expired.", cache_key.to_string());
-                }
-            }
-
-            cache.insert(cache_key.clone(), CachedTx::Expired);
-            schedule_cache_eviction(cache_key, cache, *CACHE_EVICTION_SECS);
-        });
-
-        value.expiration_timer = Some(timer_handle);
-        self.cache.insert(key, CachedTx::Open(value));
-    }
-
-    /// Get cache entry or error with not found.
-    pub fn get_or_err(&self, key: &TxId) -> crate::Result<RefMut<'_, TxId, CachedTx>> {
-        Ok(self.cache.get_mut(key).ok_or(TransactionError::NotFound)?)
-    }
-
-    /// Replaces the cache entry for the tx with the specified `CachedTx`.
-    /// After `CACHE_EVICTION_SECS`, the entry is removed completely.
-    pub fn finalize_tx(&self, key: TxId, with: CachedTx) {
-        self.cache.insert(key.clone(), with);
-        schedule_cache_eviction(key, Arc::clone(&self.cache), *CACHE_EVICTION_SECS)
-    }
-}
-
 pub struct OpenTx {
     pub conn: Box<dyn Connection>,
     pub tx: Box<dyn Transaction + 'static>,
@@ -167,13 +564,6 @@ impl OpenTx {
         Ok(c_tx)
     }
 
-    /// Cancels a running expiration timer, if any.
-    pub fn cancel_expiration_timer(&mut self) {
-        if let Some(timer) = self.expiration_timer.take() {
-            timer.abort();
-        }
-    }
-
     pub fn as_connection_like(&mut self) -> &mut dyn ConnectionLike {
         self.tx.as_mut().as_connection_like()
     }
@@ -183,18 +573,4 @@ impl Into<CachedTx> for OpenTx {
     fn into(self) -> CachedTx {
         CachedTx::Open(self)
     }
-}
-
-/// Fire-and-forget of a final cache key eviction task.
-fn schedule_cache_eviction(key: TxId, cache: Arc<DashMap<TxId, CachedTx>>, secs: u64) {
-    task::spawn(async move {
-        time::sleep(Duration::from_secs(secs)).await;
-        debug!("[{}] Evicting cache key.", key);
-
-        if cache.remove(&key).is_some() {
-            debug!("[{}] Evicted.", key);
-        } else {
-            debug!("[{}] Already gone.", key);
-        }
-    });
 }

--- a/query-engine/core/src/executor/interpreting_executor.rs
+++ b/query-engine/core/src/executor/interpreting_executor.rs
@@ -1,23 +1,23 @@
 use super::{
-    interactive_tx::{CachedTx, TransactionCache, TxId},
+    interactive_tx::{CachedTx, TxId},
     pipeline::QueryPipeline,
     QueryExecutor,
 };
 use crate::{
     IrSerializer, OpenTx, Operation, QueryGraph, QueryGraphBuilder, QueryInterpreter, QuerySchemaRef, ResponseData,
-    TransactionError, TransactionManager,
+    TransactionError, TransactionManager, TransactionProcessManager,
 };
 use async_trait::async_trait;
-use connector::{error::ErrorKind, Connection, ConnectionLike, Connector};
-use futures::{future, Future};
-use tokio::time;
+use connector::{Connection, ConnectionLike, Connector};
+use futures::future;
+use tokio::time::{self, Duration};
 
 /// Central query executor and main entry point into the query core.
 pub struct InterpretingExecutor<C> {
     /// The loaded connector
     connector: C,
 
-    tx_cache: TransactionCache,
+    itx_manager: TransactionProcessManager,
 
     /// Flag that forces individual operations to run in a transaction.
     /// Does _not_ force batches to use transactions.
@@ -31,8 +31,8 @@ where
     pub fn new(connector: C, force_transactions: bool) -> Self {
         InterpretingExecutor {
             connector,
-            tx_cache: TransactionCache::default(),
             force_transactions,
+            itx_manager: TransactionProcessManager::new(),
         }
     }
 
@@ -77,34 +77,14 @@ where
         result
     }
 
-    async fn finalize_tx<F>(&self, tx_id: TxId, final_state: CachedTx, finalizer: F) -> crate::Result<()>
-    where
-        F: Fn(&mut OpenTx) -> Box<dyn Future<Output = connector::Result<()>> + Unpin + Send + '_>,
-    {
-        // The references need to be dropped before finalization,
-        // or else the DashMap deadlocks with the finalization cleanup task.
-        let final_state = {
-            let mut tx = self.tx_cache.get_or_err(&tx_id)?;
-            let otx = tx.as_open()?;
-
-            // Some connectors hard-abort transactions after an error
-            // and refuse to execute any subsequent operation. Handle cleanup for those cases.
-            let state = if let Err(err) = finalizer(otx).await {
-                if let ErrorKind::TransactionAborted { message } = err.kind {
-                    debug!("[{}] Aborted with {}.", tx_id, message);
-                    CachedTx::Aborted
-                } else {
-                    return Err(err.into());
-                }
-            } else {
-                final_state
-            };
-
-            otx.cancel_expiration_timer();
-            state
+    async fn finalize_tx(&self, tx_id: TxId, final_state: CachedTx) -> crate::Result<()> {
+        match final_state {
+            CachedTx::Committed => self.itx_manager.commit_tx(&tx_id).await?,
+            CachedTx::RolledBack => self.itx_manager.rollback_tx(&tx_id).await?,
+            _ => panic!("SHOULD NOT GET HERE"),
         };
+        debug!("[{tx_id}] FINALIZE DONE {final_state}");
 
-        self.tx_cache.finalize_tx(tx_id, final_state);
         Ok(())
     }
 }
@@ -122,16 +102,11 @@ where
         query_schema: QuerySchemaRef,
         trace_id: Option<String>,
     ) -> crate::Result<ResponseData> {
-        // Parse, validate, and extract query graph from query document.
-        let (query_graph, serializer) = QueryGraphBuilder::new(query_schema).build(operation)?;
-
         // If a Tx id is provided, execute on that one. Else execute normally as a single operation.
         if let Some(tx_id) = tx_id {
-            let mut c_tx = self.tx_cache.get_or_err(&tx_id)?;
-            let otx = c_tx.as_open()?;
-
-            Self::execute_on(otx.tx.as_connection_like(), query_graph, serializer, trace_id).await
+            self.itx_manager.execute(&tx_id, operation, trace_id).await
         } else {
+            let (query_graph, serializer) = QueryGraphBuilder::new(query_schema).build(operation)?;
             let conn = self.connector.get_connection().await?;
             Self::execute_self_contained(conn, query_graph, serializer, self.force_transactions, trace_id).await
         }
@@ -159,23 +134,7 @@ where
         trace_id: Option<String>,
     ) -> crate::Result<Vec<crate::Result<ResponseData>>> {
         if let Some(tx_id) = tx_id {
-            let queries = operations
-                .into_iter()
-                .map(|op| QueryGraphBuilder::new(query_schema.clone()).build(op))
-                .collect::<std::result::Result<Vec<_>, _>>()?;
-
-            let mut c_tx = self.tx_cache.get_or_err(&tx_id)?;
-            let otx = c_tx.as_open()?;
-            let mut results = Vec::with_capacity(queries.len());
-
-            let tx = otx.as_connection_like();
-
-            for (graph, serializer) in queries {
-                let result = Self::execute_on(tx, graph, serializer, trace_id.clone()).await?;
-                results.push(Ok(result));
-            }
-
-            Ok(results)
+            self.itx_manager.batch_execute(&tx_id, operations, trace_id).await
         } else if transactional {
             let queries = operations
                 .into_iter()
@@ -240,12 +199,16 @@ impl<C> TransactionManager for InterpretingExecutor<C>
 where
     C: Connector + Send + Sync,
 {
-    async fn start_tx(&self, max_acquisition_millis: u64, valid_for_millis: u64) -> crate::Result<TxId> {
+    async fn start_tx(
+        &self,
+        query_schema: QuerySchemaRef,
+        max_acquisition_millis: u64,
+        valid_for_millis: u64,
+    ) -> crate::Result<TxId> {
         let id = TxId::default();
         debug!("[{}] Starting...", id);
-
         let conn = time::timeout(
-            time::Duration::from_millis(max_acquisition_millis),
+            Duration::from_millis(max_acquisition_millis),
             self.connector.get_connection(),
         )
         .await;
@@ -253,7 +216,14 @@ where
         let conn = conn.map_err(|_| TransactionError::AcquisitionTimeout)??;
         let c_tx = OpenTx::start(conn).await?;
 
-        self.tx_cache.insert(id.clone(), c_tx, valid_for_millis).await;
+        self.itx_manager
+            .create_tx(
+                query_schema.clone(),
+                id.clone(),
+                c_tx,
+                Duration::from_millis(valid_for_millis),
+            )
+            .await;
 
         debug!("[{}] Started.", id);
         Ok(id)
@@ -261,13 +231,11 @@ where
 
     async fn commit_tx(&self, tx_id: TxId) -> crate::Result<()> {
         debug!("[{}] Committing.", tx_id);
-        self.finalize_tx(tx_id, CachedTx::Committed, |otx| Box::new(otx.tx.commit()))
-            .await
+        self.finalize_tx(tx_id, CachedTx::Committed).await
     }
 
     async fn rollback_tx(&self, tx_id: TxId) -> crate::Result<()> {
         debug!("[{}] Rolling back.", tx_id);
-        self.finalize_tx(tx_id, CachedTx::RolledBack, |otx| Box::new(otx.tx.rollback()))
-            .await
+        self.finalize_tx(tx_id, CachedTx::RolledBack).await
     }
 }

--- a/query-engine/core/src/executor/interpreting_executor.rs
+++ b/query-engine/core/src/executor/interpreting_executor.rs
@@ -81,7 +81,7 @@ where
         match final_state {
             CachedTx::Committed => self.itx_manager.commit_tx(&tx_id).await?,
             CachedTx::RolledBack => self.itx_manager.rollback_tx(&tx_id).await?,
-            _ => panic!("SHOULD NOT GET HERE"),
+            _ => unreachable!(),
         };
         debug!("[{tx_id}] FINALIZE DONE {final_state}");
 

--- a/query-engine/core/src/executor/mod.rs
+++ b/query-engine/core/src/executor/mod.rs
@@ -55,7 +55,12 @@ pub trait TransactionManager {
     /// Expected to throw an error if no transaction could be opened for `max_acquisition_millis` milliseconds.
     /// The new transaction must only live for `valid_for_millis` milliseconds before it automatically rolls back.
     /// This rollback mechanism is an implementation detail of the trait implementer.
-    async fn start_tx(&self, max_acquisition_millis: u64, valid_for_millis: u64) -> crate::Result<TxId>;
+    async fn start_tx(
+        &self,
+        query_schema: QuerySchemaRef,
+        max_acquisition_millis: u64,
+        valid_for_millis: u64,
+    ) -> crate::Result<TxId>;
 
     /// Commits a transaction.
     async fn commit_tx(&self, tx_id: TxId) -> crate::Result<()>;

--- a/query-engine/query-engine-node-api/src/engine.rs
+++ b/query-engine/query-engine-node-api/src/engine.rs
@@ -295,7 +295,11 @@ impl QueryEngine {
 
                         span.set_parent(cx);
 
-                        match engine.executor().start_tx(input.max_wait, input.timeout).await {
+                        match engine
+                            .executor()
+                            .start_tx(engine.query_schema().clone(), input.max_wait, input.timeout)
+                            .await
+                        {
                             Ok(tx_id) => Ok(json!({ "id": tx_id.to_string() }).to_string()),
                             Err(err) => Ok(map_known_error(err)?),
                         }

--- a/query-engine/query-engine/Cargo.toml
+++ b/query-engine/query-engine/Cargo.toml
@@ -12,7 +12,7 @@ vendored-openssl = ["quaint/vendored-openssl"]
 
 [dependencies]
 futures = "0.3"
-tokio = { version = "1.0", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1.15", features = ["rt-multi-thread", "macros"] }
 anyhow = "1.0"
 async-trait = "0.1"
 base64 = "0.12"


### PR DESCRIPTION
This fixes the issue that the interactive transactions can deadlock and block the query-engine. Redesign the interactive transactions to work around an actor based model. 

## How it works.
Here is a diagram on how this works:
![This-3](https://user-images.githubusercontent.com/179458/151330103-ad7ccfe3-c311-49fa-8214-8caba94148ab.png)


*This is copy paste from the interactive_transactions.rs file*

The Interactive Transactions (iTx) follow an actor model design. Where each iTx is created in its own process.
When a prisma client requests to start a new transaction, the Transaction Manager spawns a new iTXServer. The iTxServer runs in its own
process and waits for messages to arrive via its receive channel to process.
The iTx Manager will also create an iTxClient and add it to hashmap managed by an RwLock. The iTx client is the only way to communicate
with the iTxServer.

Once the prisma client receives the iTx Id it can perform database operations using that iTx id. When an operation request is received by the
TransactionManager, it looks for the client in the hashmap and passes the operation to the client. The iTx client sends a message to the
iTx server and waits for a response. The iTxServer will then perform the operation and return the result. The iTxServer will perform one
operation at a time. All other operations will sit in the message queue waiting to be processed.
Once all the operations have been done, the prisma client can ask the Transaction Manager to commit or rollback the iTx.
Again, the Transaction Manager will find the iTx Client, and tell it to commit or rollback. The iTx Client will send a message to
the iTxServer to commit or rollback. The iTxServer will perform that, send the response back to the iTxClient
and then the iTxServer will move into the cache eviction state. In this state, the connection is closed, and any messages it receives, the will
will only reply with its last state. i.e committed, rollbacked or timeout.

Once the eviction timeout is exceeded, the iTxServer will send a message to the TransactionManager to say that it is completed, and it will end.
The TransactionManager will remove the iTxClient from the hashmap.

During the time the iTxServer is active there is also a timer running and if that timeout is exceeded, the
transaction is rolledback and the connection to the database is closed. The iTxServer will then move into the eviction state.

## Testing

I wrote [smash](https://github.com/garrensmith/smash) to help test this. It can run concurrent requests against the query-engine to check the behaviour. I've also added in a new client test https://github.com/prisma/prisma/pull/11382