### PR TITLE
Proof-of-concept owned parser-database

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1296,9 +1296,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -2389,6 +2389,7 @@ version = "0.1.0"
 dependencies = [
  "diagnostics",
  "enumflags2",
+ "indexmap",
  "schema-ast",
 ]
 

--- a/libs/datamodel/connectors/datamodel-connector/src/walker_ext_traits.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/walker_ext_traits.rs
@@ -88,12 +88,12 @@ impl<'ast> CompleteInlineRelationWalkerExt<'ast> for CompleteInlineRelationWalke
     }
 }
 
-pub trait InlineRelationWalkerExt<'ast> {
-    fn constraint_name(self, connector: &dyn Connector) -> Cow<'ast, str>;
+pub trait InlineRelationWalkerExt<'db> {
+    fn constraint_name(self, connector: &dyn Connector) -> Cow<'db, str>;
 }
 
-impl<'ast> InlineRelationWalkerExt<'ast> for InlineRelationWalker<'ast, '_> {
-    fn constraint_name(self, connector: &dyn Connector) -> Cow<'ast, str> {
+impl<'db> InlineRelationWalkerExt<'db> for InlineRelationWalker<'_, 'db> {
+    fn constraint_name(self, connector: &dyn Connector) -> Cow<'db, str> {
         self.mapped_name().map(Cow::Borrowed).unwrap_or_else(|| {
             let model_database_name = self.referencing_model().database_name();
             let field_names: Vec<&str> = match self.referencing_fields() {

--- a/libs/datamodel/connectors/datamodel-connector/src/walker_ext_traits.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/walker_ext_traits.rs
@@ -46,14 +46,14 @@ impl<'ast> DefaultValueExt<'ast> for DefaultValueWalker<'ast, '_> {
     }
 }
 
-pub trait PrimaryKeyWalkerExt<'ast> {
+pub trait PrimaryKeyWalkerExt<'db> {
     /// This will be None if and only if the connector does not support named primary keys. It can
     /// be a generated name or one explicitly set in the schema.
-    fn constraint_name(self, connector: &dyn Connector) -> Option<Cow<'ast, str>>;
+    fn constraint_name(self, connector: &dyn Connector) -> Option<Cow<'db, str>>;
 }
 
-impl<'ast> PrimaryKeyWalkerExt<'ast> for PrimaryKeyWalker<'ast, '_> {
-    fn constraint_name(self, connector: &dyn Connector) -> Option<Cow<'ast, str>> {
+impl<'db> PrimaryKeyWalkerExt<'db> for PrimaryKeyWalker<'_, 'db> {
+    fn constraint_name(self, connector: &dyn Connector) -> Option<Cow<'db, str>> {
         if !connector.supports_named_primary_keys() {
             return None;
         }

--- a/libs/datamodel/core/src/ast/reformat/reformatter.rs
+++ b/libs/datamodel/core/src/ast/reformat/reformatter.rs
@@ -18,7 +18,7 @@ pub struct Reformatter<'a> {
 impl<'a> Reformatter<'a> {
     pub fn new(input: &'a str) -> Self {
         let info = crate::parse_schema_ast(input)
-            .and_then(|ast| crate::parse_datamodel_for_formatter(&ast).map(|datamodel| (ast, datamodel)));
+            .and_then(|ast| crate::parse_datamodel_for_formatter(input, &ast).map(|datamodel| (ast, datamodel)));
         match info {
             Ok((schema_ast, (datamodel, mut datasources))) => {
                 let datasource = datasources.pop();

--- a/libs/datamodel/core/src/ast/reformat/reformatter.rs
+++ b/libs/datamodel/core/src/ast/reformat/reformatter.rs
@@ -18,7 +18,7 @@ pub struct Reformatter<'a> {
 impl<'a> Reformatter<'a> {
     pub fn new(input: &'a str) -> Self {
         let info = crate::parse_schema_ast(input)
-            .and_then(|ast| crate::parse_datamodel_for_formatter(input, &ast).map(|datamodel| (ast, datamodel)));
+            .and_then(|ast| crate::parse_datamodel_for_formatter(&ast).map(|datamodel| (ast, datamodel)));
         match info {
             Ok((schema_ast, (datamodel, mut datasources))) => {
                 let datasource = datasources.pop();

--- a/libs/datamodel/core/src/lib.rs
+++ b/libs/datamodel/core/src/lib.rs
@@ -132,7 +132,7 @@ pub fn parse_schema_parserdb<'ast>(src: &'ast str, ast: &'ast ast::SchemaAst) ->
         .to_result()
         .map_err(|err| err.to_pretty_string("schema.prisma", src))?;
 
-    let out = validate(src, ast, &datasources, preview_features, diagnostics);
+    let out = validate(ast, &datasources, preview_features, diagnostics);
 
     out.diagnostics
         .to_result()
@@ -156,10 +156,10 @@ pub fn parse_datamodel(datamodel_string: &str) -> Result<ValidatedDatamodel, dia
     })
 }
 
-fn parse_datamodel_for_formatter(src: &str, ast: &SchemaAst) -> Result<(Datamodel, Vec<Datasource>), Diagnostics> {
+fn parse_datamodel_for_formatter(ast: &SchemaAst) -> Result<(Datamodel, Vec<Datasource>), Diagnostics> {
     let mut diagnostics = diagnostics::Diagnostics::new();
     let datasources = load_sources(ast, Default::default(), &mut diagnostics);
-    let (db, diagnostics) = parser_database::ParserDatabase::new(src, ast, diagnostics);
+    let (db, diagnostics) = parser_database::ParserDatabase::new(ast, diagnostics);
     diagnostics.to_result()?;
     let (connector, referential_integrity) = datasources
         .get(0)
@@ -182,7 +182,7 @@ fn parse_datamodel_internal(
 
     diagnostics.to_result()?;
 
-    let out = validate(datamodel_string, &ast, &datasources, preview_features, diagnostics);
+    let out = validate(&ast, &datasources, preview_features, diagnostics);
 
     if !out.diagnostics.errors().is_empty() {
         return Err(out.diagnostics);

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline.rs
@@ -23,6 +23,7 @@ pub struct ValidateOutput<'ast> {
 /// * ...
 /// * Validate the schema
 pub(crate) fn validate<'ast>(
+    src: &'ast str,
     ast_schema: &'ast ast::SchemaAst,
     sources: &[configuration::Datasource],
     preview_features: BitFlags<PreviewFeature>,
@@ -33,7 +34,7 @@ pub(crate) fn validate<'ast>(
     let referential_integrity = source.map(|s| s.referential_integrity()).unwrap_or_default();
 
     // Make sense of the AST.
-    let (db, diagnostics) = ParserDatabase::new(ast_schema, diagnostics);
+    let (db, diagnostics) = ParserDatabase::new(src, ast_schema, diagnostics);
 
     let mut output = ValidateOutput {
         db,

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline.rs
@@ -23,7 +23,6 @@ pub struct ValidateOutput<'ast> {
 /// * ...
 /// * Validate the schema
 pub(crate) fn validate<'ast>(
-    src: &'ast str,
     ast_schema: &'ast ast::SchemaAst,
     sources: &[configuration::Datasource],
     preview_features: BitFlags<PreviewFeature>,
@@ -34,7 +33,7 @@ pub(crate) fn validate<'ast>(
     let referential_integrity = source.map(|s| s.referential_integrity()).unwrap_or_default();
 
     // Make sense of the AST.
-    let (db, diagnostics) = ParserDatabase::new(src, ast_schema, diagnostics);
+    let (db, diagnostics) = ParserDatabase::new(ast_schema, diagnostics);
 
     let mut output = ValidateOutput {
         db,

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/fields.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/fields.rs
@@ -21,7 +21,7 @@ use datamodel_connector::{
     ConnectorCapability,
 };
 
-pub(super) fn validate_client_name(field: FieldWalker<'_, '_>, names: &Names<'_>, ctx: &mut Context<'_>) {
+pub(super) fn validate_client_name(field: FieldWalker<'_, '_>, names: &Names<'_, '_>, ctx: &mut Context<'_>) {
     let model = field.model();
 
     for taken in names.name_taken(model.model_id(), field.name()).into_iter() {
@@ -61,7 +61,7 @@ pub(super) fn validate_client_name(field: FieldWalker<'_, '_>, names: &Names<'_>
 /// namespace. Validates the field default constraint against name clases.
 pub(super) fn has_a_unique_default_constraint_name(
     field: ScalarFieldWalker<'_, '_>,
-    names: &Names<'_>,
+    names: &Names<'_, '_>,
     ctx: &mut Context<'_>,
 ) {
     let name = match field.default_value().map(|w| w.constraint_name(ctx.connector)) {

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/indexes.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/indexes.rs
@@ -15,7 +15,7 @@ use schema_ast::ast::{WithName, WithSpan};
 /// Validates index and unique constraint names against the database requirements.
 pub(super) fn has_a_unique_constraint_name(
     index: IndexWalker<'_, '_>,
-    names: &super::Names<'_>,
+    names: &super::Names<'_, '_>,
     ctx: &mut Context<'_>,
 ) {
     let name = index.constraint_name(ctx.connector);
@@ -51,7 +51,7 @@ pub(super) fn has_a_unique_constraint_name(
 /// needs to be unique per model. It can be found on the primary key or unique indexes.
 pub(super) fn unique_index_has_a_unique_custom_name_per_model(
     index: IndexWalker<'_, '_>,
-    names: &super::Names<'_>,
+    names: &super::Names<'_, '_>,
     ctx: &mut Context<'_>,
 ) {
     let model = index.model();

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/models.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/models.rs
@@ -59,7 +59,7 @@ pub(super) fn has_a_strict_unique_criteria(model: ModelWalker<'_, '_>, ctx: &mut
 /// model's primary key against the database requirements.
 pub(super) fn has_a_unique_primary_key_name(
     model: ModelWalker<'_, '_>,
-    names: &super::Names<'_>,
+    names: &super::Names<'_, '_>,
     ctx: &mut Context<'_>,
 ) {
     let (pk, name): (PrimaryKeyWalker<'_, '_>, Cow<'_, str>) = match model
@@ -101,7 +101,7 @@ pub(super) fn has_a_unique_primary_key_name(
 /// needs to be unique per model. It can be found on the primary key or unique indexes.
 pub(super) fn has_a_unique_custom_primary_key_name_per_model(
     model: ModelWalker<'_, '_>,
-    names: &super::Names<'_>,
+    names: &super::Names<'_, '_>,
     ctx: &mut Context<'_>,
 ) {
     let pk = match model.primary_key() {

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/names.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/names.rs
@@ -1,12 +1,10 @@
-use datamodel_connector::Connector;
-
 use super::constraint_namespace::ConstraintNamespace;
-use std::collections::{HashMap, HashSet};
-
 use crate::{
     ast::{FieldId, ModelId},
     transform::ast_to_dml::db::{walkers::RelationName, ParserDatabase},
 };
+use datamodel_connector::Connector;
+use std::collections::{HashMap, HashSet};
 
 type RelationIdentifier<'ast> = (ModelId, ModelId, RelationName<'ast>);
 
@@ -17,17 +15,17 @@ pub(super) enum NameTaken {
     PrimaryKey,
 }
 
-pub(super) struct Names<'ast> {
-    pub(super) relation_names: HashMap<RelationIdentifier<'ast>, Vec<FieldId>>,
+pub(super) struct Names<'ast, 'db> {
+    pub(super) relation_names: HashMap<RelationIdentifier<'db>, Vec<FieldId>>,
     index_names: HashMap<ModelId, HashSet<&'ast str>>,
     unique_names: HashMap<ModelId, HashSet<&'ast str>>,
     primary_key_names: HashMap<ModelId, &'ast str>,
     pub(super) constraint_namespace: ConstraintNamespace<'ast>,
 }
 
-impl<'ast> Names<'ast> {
-    pub(super) fn new(db: &ParserDatabase<'ast>, connector: &dyn Connector) -> Self {
-        let mut relation_names: HashMap<RelationIdentifier<'ast>, Vec<FieldId>> = HashMap::new();
+impl<'ast, 'db> Names<'ast, 'db> {
+    pub(super) fn new(db: &'db ParserDatabase<'ast>, connector: &dyn Connector) -> Self {
+        let mut relation_names: HashMap<RelationIdentifier<'db>, Vec<FieldId>> = HashMap::new();
         let mut index_names: HashMap<ModelId, HashSet<&'ast str>> = HashMap::new();
         let mut unique_names: HashMap<ModelId, HashSet<&'ast str>> = HashMap::new();
         let mut primary_key_names: HashMap<ModelId, &'ast str> = HashMap::new();

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/names.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/names.rs
@@ -20,7 +20,7 @@ pub(super) struct Names<'ast, 'db> {
     index_names: HashMap<ModelId, HashSet<&'ast str>>,
     unique_names: HashMap<ModelId, HashSet<&'ast str>>,
     primary_key_names: HashMap<ModelId, &'ast str>,
-    pub(super) constraint_namespace: ConstraintNamespace<'ast>,
+    pub(super) constraint_namespace: ConstraintNamespace<'db>,
 }
 
 impl<'ast, 'db> Names<'ast, 'db> {
@@ -101,7 +101,7 @@ impl<'ast, 'db> Names<'ast, 'db> {
 
 /// Generate namespaces per database requirements, and add the names to it from the constraints
 /// part of the namespace.
-fn infer_namespaces<'ast>(db: &ParserDatabase<'ast>, connector: &dyn Connector) -> ConstraintNamespace<'ast> {
+fn infer_namespaces<'db>(db: &'db ParserDatabase<'_>, connector: &dyn Connector) -> ConstraintNamespace<'db> {
     use datamodel_connector::ConstraintScope;
 
     let mut namespaces = ConstraintNamespace::default();

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/relation_fields.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/relation_fields.rs
@@ -55,7 +55,7 @@ impl<'ast, 'db> fmt::Display for Fields<'ast, 'db> {
     }
 }
 
-pub(super) fn ambiguity(field: RelationFieldWalker<'_, '_>, names: &Names<'_>) -> Result<(), DatamodelError> {
+pub(super) fn ambiguity(field: RelationFieldWalker<'_, '_>, names: &Names<'_, '_>) -> Result<(), DatamodelError> {
     let model = field.model();
     let related_model = field.related_model();
 

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/relations.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/relations.rs
@@ -34,7 +34,7 @@ const STATE_ERROR: &str = "Failed lookup of model, field or optional property du
 /// Depending on the database, a constraint name might need to be unique in a certain namespace.
 /// Validates per database that we do not use a name that is already in use.
 pub(super) fn has_a_unique_constraint_name(
-    names: &super::Names<'_>,
+    names: &super::Names<'_, '_>,
     relation: InlineRelationWalker<'_, '_>,
     ctx: &mut Context<'_>,
 ) {

--- a/libs/datamodel/parser-database/Cargo.toml
+++ b/libs/datamodel/parser-database/Cargo.toml
@@ -8,3 +8,4 @@ diagnostics = { path = "../diagnostics" }
 schema-ast = { path = "../schema-ast" }
 
 enumflags2 = "0.7"
+indexmap = "1.8.0"

--- a/libs/datamodel/parser-database/src/ast_string.rs
+++ b/libs/datamodel/parser-database/src/ast_string.rs
@@ -1,0 +1,18 @@
+use schema_ast::ast;
+
+/// A maybe-allocated AST string.
+#[derive(Debug, Clone)]
+pub(crate) struct AstString {
+    pub(crate) span: ast::Span,
+    /// The unescaped string if applicable.
+    pub(crate) unescaped: Option<String>,
+}
+
+impl AstString {
+    pub(crate) fn from_literal(v: String, span: ast::Span) -> Self {
+        AstString {
+            span,
+            unescaped: Some(v),
+        }
+    }
+}

--- a/libs/datamodel/parser-database/src/ast_string.rs
+++ b/libs/datamodel/parser-database/src/ast_string.rs
@@ -1,18 +1,38 @@
+use indexmap::IndexSet;
 use schema_ast::ast;
+use std::ops::Index;
+
+#[derive(Default)]
+pub(crate) struct StringInterner {
+    store: IndexSet<String>,
+}
+
+#[derive(PartialEq, Debug, Clone, Copy, Hash, Eq, Ord, PartialOrd)]
+pub(crate) struct InternedString(usize);
+
+impl StringInterner {
+    pub(crate) fn intern(&mut self, s: &str) -> InternedString {
+        if let Some(idx) = self.store.get_index_of(s) {
+            InternedString(idx)
+        } else {
+            let (idx, _) = self.store.insert_full(s.to_owned());
+            InternedString(idx)
+        }
+    }
+}
+
+impl Index<InternedString> for StringInterner {
+    type Output = str;
+
+    fn index(&self, index: InternedString) -> &Self::Output {
+        &self.store[index.0]
+    }
+}
 
 /// A maybe-allocated AST string.
 #[derive(Debug, Clone)]
 pub(crate) struct AstString {
+    #[allow(unused)] // we will use it.
     pub(crate) span: ast::Span,
-    /// The unescaped string if applicable.
-    pub(crate) unescaped: Option<String>,
-}
-
-impl AstString {
-    pub(crate) fn from_literal(v: String, span: ast::Span) -> Self {
-        AstString {
-            span,
-            unescaped: Some(v),
-        }
-    }
+    pub(crate) value: InternedString,
 }

--- a/libs/datamodel/parser-database/src/attributes.rs
+++ b/libs/datamodel/parser-database/src/attributes.rs
@@ -33,7 +33,7 @@ fn resolve_composite_type_attributes<'ast>(
     ctx: &mut Context<'ast>,
 ) {
     for (field_id, field) in ct.iter_fields() {
-        let mut ctfield = ctx.db.types.composite_type_fields[&(ctid, field_id)].clone();
+        let mut ctfield = ctx.db.types.composite_type_fields.remove(&(ctid, field_id)).unwrap();
 
         ctx.visit_attributes(&field.attributes, |attributes, ctx| {
             // @map

--- a/libs/datamodel/parser-database/src/attributes/default.rs
+++ b/libs/datamodel/parser-database/src/attributes/default.rs
@@ -32,7 +32,7 @@ pub(super) fn visit_model_field_default<'ast>(
         let default_value = DefaultAttribute {
             value: value.value,
             mapped_name,
-            default_attribute,
+            default_attribute: default_attribute.0,
         };
 
         field_data.default = Some(default_value);
@@ -117,7 +117,7 @@ pub(super) fn visit_composite_field_default<'ast>(
         let default_value = DefaultAttribute {
             value: value.value,
             mapped_name: None,
-            default_attribute,
+            default_attribute: default_attribute.0,
         };
 
         field_data.default = Some(default_value);

--- a/libs/datamodel/parser-database/src/attributes/default.rs
+++ b/libs/datamodel/parser-database/src/attributes/default.rs
@@ -8,7 +8,7 @@ use crate::{
 /// @default on model scalar fields
 pub(super) fn visit_model_field_default<'ast>(
     args: &mut Arguments<'ast>,
-    field_data: &mut ScalarField<'ast>,
+    field_data: &mut ScalarField,
     model_id: ast::ModelId,
     field_id: ast::FieldId,
     ctx: &mut Context<'ast>,
@@ -88,7 +88,7 @@ pub(super) fn visit_model_field_default<'ast>(
 /// @default on composite type fields
 pub(super) fn visit_composite_field_default<'ast>(
     args: &mut Arguments<'ast>,
-    field_data: &mut CompositeTypeField<'ast>,
+    field_data: &mut CompositeTypeField,
     ct_id: ast::CompositeTypeId,
     field_id: ast::FieldId,
     ctx: &mut Context<'ast>,

--- a/libs/datamodel/parser-database/src/attributes/id.rs
+++ b/libs/datamodel/parser-database/src/attributes/id.rs
@@ -87,7 +87,7 @@ pub(super) fn model<'ast>(
 
     model_data.primary_key = Some(IdAttribute {
         name,
-        source_attribute: args.attribute(),
+        source_attribute: args.attribute().0,
         mapped_name,
         fields: resolved_fields,
         source_field: None,
@@ -138,7 +138,7 @@ pub(super) fn field<'ast>(
             model_attributes.primary_key = Some(IdAttribute {
                 name: None,
                 mapped_name,
-                source_attribute: args.attribute(),
+                source_attribute: args.attribute().0,
                 fields: vec![FieldWithArgs {
                     field_id,
                     sort_order,

--- a/libs/datamodel/parser-database/src/attributes/id.rs
+++ b/libs/datamodel/parser-database/src/attributes/id.rs
@@ -8,11 +8,11 @@ use crate::{
 };
 
 /// @@id on models
-pub(super) fn model<'ast>(
-    args: &mut Arguments<'ast>,
-    model_data: &mut ModelAttributes<'ast>,
+pub(super) fn model<'db>(
+    args: &mut Arguments<'db>,
+    model_data: &mut ModelAttributes,
     model_id: ast::ModelId,
-    ctx: &mut Context<'ast>,
+    ctx: &mut Context<'db>,
 ) {
     let fields = match args.default_arg("fields") {
         Ok(value) => value,
@@ -86,9 +86,9 @@ pub(super) fn model<'ast>(
     };
 
     model_data.primary_key = Some(IdAttribute {
-        name,
+        name: name.map(|name| ctx.db.interner.intern(name)),
         source_attribute: args.attribute().0,
-        mapped_name,
+        mapped_name: mapped_name.map(|mapped_name| ctx.db.interner.intern(mapped_name)),
         fields: resolved_fields,
         source_field: None,
     });
@@ -96,7 +96,7 @@ pub(super) fn model<'ast>(
 pub(super) fn field<'ast>(
     ast_model: &'ast ast::Model,
     field_id: ast::FieldId,
-    model_attributes: &mut ModelAttributes<'ast>,
+    model_attributes: &mut ModelAttributes,
     args: &mut Arguments<'ast>,
     ctx: &mut Context<'ast>,
 ) {
@@ -137,7 +137,7 @@ pub(super) fn field<'ast>(
 
             model_attributes.primary_key = Some(IdAttribute {
                 name: None,
-                mapped_name,
+                mapped_name: mapped_name.map(|n| ctx.db.interner.intern(n)),
                 source_attribute: args.attribute().0,
                 fields: vec![FieldWithArgs {
                     field_id,
@@ -152,7 +152,7 @@ pub(super) fn field<'ast>(
 
 pub(super) fn validate_id_field_arities(
     model_id: ast::ModelId,
-    model_attributes: &ModelAttributes<'_>,
+    model_attributes: &ModelAttributes,
     ctx: &mut Context<'_>,
 ) {
     if model_attributes.is_ignored {

--- a/libs/datamodel/parser-database/src/attributes/map.rs
+++ b/libs/datamodel/parser-database/src/attributes/map.rs
@@ -1,6 +1,6 @@
 use crate::{
     ast::{self, WithName},
-    context::{Arguments, Context},
+    context::{Arguments, AttributeContext, Context},
     types::{CompositeTypeField, ModelAttributes, ScalarField},
     DatamodelError,
 };
@@ -8,70 +8,72 @@ use crate::{
 pub(super) fn model(
     model_attributes: &mut ModelAttributes,
     model_id: ast::ModelId,
-    args: &mut Arguments<'_>,
-    ctx: &mut Context<'_>,
+    map: &mut AttributeContext<'_, '_>,
 ) {
-    let mapped_name = match visit_map_attribute(args, ctx) {
+    let mapped_name = match visit_map_attribute(map) {
         Some(name) => name,
         None => return,
     };
 
     model_attributes.mapped_name = Some(mapped_name);
 
-    if let Some(existing_model_id) = ctx.mapped_model_names.insert(mapped_name, model_id) {
-        let existing_model_name = ctx.db.ast[existing_model_id].name();
-        ctx.push_error(DatamodelError::new_duplicate_model_database_name_error(
-            mapped_name.to_owned(),
-            existing_model_name.to_owned(),
-            ctx.db.ast[model_id].span,
-        ));
+    if let Some(existing_model_id) = map.ctx.mapped_model_names.insert(mapped_name, model_id) {
+        let existing_model_name = map.ctx.db.ast[existing_model_id].name();
+        map.ctx
+            .push_error(DatamodelError::new_duplicate_model_database_name_error(
+                mapped_name.to_owned(),
+                existing_model_name.to_owned(),
+                map.ctx.db.ast[model_id].span,
+            ));
     }
 
-    if let Some(existing_model_id) = ctx.db.names.tops.get(mapped_name).and_then(|id| id.as_model_id()) {
-        let existing_model_name = ctx.db.ast[existing_model_id].name();
-        ctx.push_error(DatamodelError::new_duplicate_model_database_name_error(
-            mapped_name.to_owned(),
-            existing_model_name.to_owned(),
-            args.span(),
-        ));
+    if let Some(existing_model_id) = map.ctx.db.names.tops.get(mapped_name).and_then(|id| id.as_model_id()) {
+        let existing_model_name = map.ctx.db.ast[existing_model_id].name();
+        map.ctx
+            .push_error(DatamodelError::new_duplicate_model_database_name_error(
+                mapped_name.to_owned(),
+                existing_model_name.to_owned(),
+                map.span(),
+            ));
     }
 }
 
-pub(super) fn scalar_field<'ast>(
+pub(super) fn scalar_field(
     ast_model: &ast::Model,
     ast_field: &ast::Field,
     model_id: ast::ModelId,
     field_id: ast::FieldId,
     scalar_field_data: &mut ScalarField,
-    map_args: &mut Arguments<'ast>,
-    ctx: &mut Context<'ast>,
+    map: &mut AttributeContext<'_, '_>,
 ) {
-    let mapped_name = match visit_map_attribute(map_args, ctx) {
+    let mapped_name = match visit_map_attribute(map) {
         Some(name) => name,
         None => return,
     };
 
     scalar_field_data.mapped_name = Some(mapped_name);
 
-    if ctx
+    if map
+        .ctx
         .mapped_model_scalar_field_names
         .insert((model_id, mapped_name), field_id)
         .is_some()
     {
-        ctx.push_error(DatamodelError::new_duplicate_field_error(
+        map.ctx.push_error(DatamodelError::new_duplicate_field_error(
             ast_model.name(),
             &ast_field.name.name,
             ast_field.span,
         ));
     }
 
-    if let Some(field_id) = ctx.db.names.model_fields.get(&(model_id, mapped_name)) {
+    if let Some(field_id) = map.ctx.db.names.model_fields.get(&(model_id, mapped_name)) {
         // @map only conflicts with _scalar_ fields
-        if !ctx.db.types.scalar_fields.contains_key(&(model_id, *field_id)) {
+        if !map.ctx.db.types.scalar_fields.contains_key(&(model_id, *field_id)) {
             return;
         }
 
-        match ctx
+        match map
+            .ctx
             .db
             .types
             .scalar_fields
@@ -79,7 +81,7 @@ pub(super) fn scalar_field<'ast>(
             .and_then(|sf| sf.mapped_name)
         {
             Some(name) if name != mapped_name => {}
-            _ => ctx.push_error(DatamodelError::new_duplicate_field_error(
+            _ => map.ctx.push_error(DatamodelError::new_duplicate_field_error(
                 &ast_model.name.name,
                 &ast_field.name.name,
                 ast_field.span,
@@ -88,36 +90,42 @@ pub(super) fn scalar_field<'ast>(
     }
 }
 
-pub(super) fn composite_type_field<'ast>(
-    ct: &'ast ast::CompositeType,
-    ast_field: &'ast ast::Field,
+pub(super) fn composite_type_field(
+    ct: &ast::CompositeType,
+    ast_field: &ast::Field,
     ctid: ast::CompositeTypeId,
     field_id: ast::FieldId,
     field: &mut CompositeTypeField,
-    map_args: &mut Arguments<'ast>,
-    ctx: &mut Context<'ast>,
+    map: &mut AttributeContext<'_, '_>,
 ) {
-    let mapped_name = match visit_map_attribute(map_args, ctx) {
+    let mapped_name = match visit_map_attribute(map) {
         Some(name) => name,
         None => return,
     };
 
     field.mapped_name = Some(mapped_name);
 
-    if ctx
+    if map
+        .ctx
         .mapped_composite_type_names
         .insert((ctid, mapped_name), field_id)
         .is_some()
     {
-        ctx.push_error(DatamodelError::new_duplicate_field_error(
+        map.ctx.push_error(DatamodelError::new_duplicate_field_error(
             &ct.name.name,
             &ast_field.name.name,
             ast_field.span,
         ));
     }
 
-    if ctx.db.names.composite_type_fields.contains_key(&(ctid, mapped_name)) {
-        ctx.push_error(DatamodelError::new_duplicate_field_error(
+    if map
+        .ctx
+        .db
+        .names
+        .composite_type_fields
+        .contains_key(&(ctid, mapped_name))
+    {
+        map.ctx.push_error(DatamodelError::new_duplicate_field_error(
             &ct.name.name,
             &ast_field.name.name,
             ast_field.span,
@@ -125,11 +133,11 @@ pub(super) fn composite_type_field<'ast>(
     }
 }
 
-pub(super) fn visit_map_attribute<'ast>(map_args: &mut Arguments<'ast>, ctx: &mut Context<'ast>) -> Option<&'ast str> {
-    match map_args.default_arg("name").map(|value| value.as_str()) {
+pub(super) fn visit_map_attribute<'db>(map: &mut AttributeContext<'_, 'db>) -> Option<&'db str> {
+    match map.default_arg("name").map(|value| value.as_str()) {
         Ok(Ok(name)) => return Some(name),
-        Err(err) => ctx.push_error(err), // not flattened for error handing legacy reasons
-        Ok(Err(err)) => ctx.push_error(map_args.new_attribute_validation_error(&err.to_string())),
+        Err(err) => map.ctx.push_error(err), // not flattened for error handing legacy reasons
+        Ok(Err(err)) => map.ctx.push_error(map.new_attribute_validation_error(&err.to_string())),
     };
 
     None

--- a/libs/datamodel/parser-database/src/attributes/map.rs
+++ b/libs/datamodel/parser-database/src/attributes/map.rs
@@ -5,11 +5,11 @@ use crate::{
     DatamodelError,
 };
 
-pub(super) fn model<'ast>(
-    model_attributes: &mut ModelAttributes<'ast>,
+pub(super) fn model(
+    model_attributes: &mut ModelAttributes,
     model_id: ast::ModelId,
-    args: &mut Arguments<'ast>,
-    ctx: &mut Context<'ast>,
+    args: &mut Arguments<'_>,
+    ctx: &mut Context<'_>,
 ) {
     let mapped_name = match visit_map_attribute(args, ctx) {
         Some(name) => name,
@@ -42,7 +42,7 @@ pub(super) fn scalar_field<'ast>(
     ast_field: &ast::Field,
     model_id: ast::ModelId,
     field_id: ast::FieldId,
-    scalar_field_data: &mut ScalarField<'ast>,
+    scalar_field_data: &mut ScalarField,
     map_args: &mut Arguments<'ast>,
     ctx: &mut Context<'ast>,
 ) {
@@ -93,7 +93,7 @@ pub(super) fn composite_type_field<'ast>(
     ast_field: &'ast ast::Field,
     ctid: ast::CompositeTypeId,
     field_id: ast::FieldId,
-    field: &mut CompositeTypeField<'ast>,
+    field: &mut CompositeTypeField,
     map_args: &mut Arguments<'ast>,
     ctx: &mut Context<'ast>,
 ) {

--- a/libs/datamodel/parser-database/src/attributes/native_types.rs
+++ b/libs/datamodel/parser-database/src/attributes/native_types.rs
@@ -4,7 +4,7 @@ pub(super) fn visit_native_type_attribute<'ast>(
     datasource_name: &'ast str,
     type_name: &'ast str,
     attr: &'ast ast::Attribute,
-    scalar_field: &mut ScalarField<'ast>,
+    scalar_field: &mut ScalarField,
 ) {
     let args = &attr.arguments;
     let args: Vec<String> = args.arguments.iter().map(|arg| arg.value.to_string()).collect();

--- a/libs/datamodel/parser-database/src/context/attributes.rs
+++ b/libs/datamodel/parser-database/src/context/attributes.rs
@@ -2,25 +2,33 @@ use super::*;
 
 #[derive(Default)]
 pub(crate) struct Attributes<'ast> {
-    attributes: Vec<&'ast ast::Attribute>,
+    attributes: Vec<(&'ast ast::Attribute, ast::AttributeId)>,
     unused_attributes: HashSet<usize>,
 }
 
 impl<'ast> Attributes<'ast> {
-    pub(super) fn set_attributes(&mut self, ast_attributes: &'ast [ast::Attribute]) {
+    pub(super) fn set_attributes(
+        &mut self,
+        ast_attributes: impl ExactSizeIterator<Item = (&'ast ast::Attribute, ast::AttributeId)>,
+    ) {
         self.attributes.clear();
         self.unused_attributes.clear();
         self.extend_attributes(ast_attributes)
     }
 
-    pub(super) fn extend_attributes(&mut self, ast_attributes: &'ast [ast::Attribute]) {
+    pub(super) fn extend_attributes(
+        &mut self,
+        ast_attributes: impl ExactSizeIterator<Item = (&'ast ast::Attribute, ast::AttributeId)>,
+    ) {
         self.unused_attributes
             .extend(self.attributes.len()..(self.attributes.len() + ast_attributes.len()));
-        self.attributes.extend(ast_attributes.iter());
+        for attr in ast_attributes {
+            self.attributes.push(attr);
+        }
     }
 
     pub(super) fn unused_attributes(&self) -> impl Iterator<Item = &'ast ast::Attribute> + '_ {
-        self.unused_attributes.iter().map(move |idx| self.attributes[*idx])
+        self.unused_attributes.iter().map(move |idx| self.attributes[*idx].0)
     }
 
     /// Validate an _optional_ attribute that should occur only once.
@@ -30,14 +38,23 @@ impl<'ast> Attributes<'ast> {
         ctx: &'ctx mut Context<'ast>,
         f: impl FnOnce(&mut Arguments<'ast>, &mut Context<'ast>),
     ) {
-        let mut attrs = self.attributes.iter().enumerate().filter(|(_, a)| a.name.name == name);
+        let mut attrs = self
+            .attributes
+            .iter()
+            .enumerate()
+            .filter(|(_, (a, _))| a.name.name == name);
         let (first_idx, first) = match attrs.next() {
             Some(first) => first,
             None => return, // early return if absent: it's optional
         };
 
         if attrs.next().is_some() {
-            for (idx, attr) in self.attributes.iter().enumerate().filter(|(_, a)| a.name.name == name) {
+            for (idx, (attr, _attr_id)) in self
+                .attributes
+                .iter()
+                .enumerate()
+                .filter(|(_, (a, _))| a.name.name == name)
+            {
                 ctx.push_error(DatamodelError::new_duplicate_attribute_error(
                     &attr.name.name,
                     attr.span,
@@ -50,7 +67,7 @@ impl<'ast> Attributes<'ast> {
 
         assert!(self.unused_attributes.remove(&first_idx));
 
-        ctx.with_arguments(first, f);
+        ctx.with_arguments(first.0, first.1, f);
     }
 
     /// Extract an attribute that can occur zero or more times. Example: @@index on models.
@@ -60,13 +77,13 @@ impl<'ast> Attributes<'ast> {
         ctx: &'ctx mut Context<'ast>,
         mut f: impl FnMut(&mut Arguments<'ast>, &mut Context<'ast>),
     ) {
-        for (attr_idx, attr) in self
+        for (attr_idx, (attr, attr_id)) in self
             .attributes
             .iter()
             .enumerate()
-            .filter(|(_, attr)| attr.name.name == name)
+            .filter(|(_, (attr, _))| attr.name.name == name)
         {
-            ctx.with_arguments(attr, &mut f);
+            ctx.with_arguments(attr, *attr_id, &mut f);
             assert!(self.unused_attributes.remove(&attr_idx));
         }
     }
@@ -88,11 +105,11 @@ impl<'ast> Attributes<'ast> {
             .attributes
             .iter()
             .enumerate()
-            .filter(|(_, attr)| attr.name.name.contains('.'));
+            .filter(|(_, (attr, _))| attr.name.name.contains('.'));
         let mut native_type_attr = None;
 
         // Extract the attribute, validating that there are no duplicates.
-        for (attr_idx, attr) in attrs {
+        for (attr_idx, (attr, _)) in attrs {
             assert!(self.unused_attributes.remove(&attr_idx));
 
             match attr.name.name.split_once('.') {

--- a/libs/datamodel/parser-database/src/names.rs
+++ b/libs/datamodel/parser-database/src/names.rs
@@ -72,7 +72,7 @@ pub(super) fn resolve_names(ctx: &mut Context<'_>) {
 
                     if names
                         .model_fields
-                        .insert((model_id, &field.name.name), field_id)
+                        .insert((model_id, ctx.db.interner.intern(&field.name.name)), field_id)
                         .is_some()
                     {
                         ctx.push_error(DatamodelError::new_duplicate_field_error(
@@ -92,7 +92,7 @@ pub(super) fn resolve_names(ctx: &mut Context<'_>) {
                     // Check that there is no duplicate field on the composite type
                     if names
                         .composite_type_fields
-                        .insert((ctid, &field.name.name), field_id)
+                        .insert((ctid, ctx.db.interner.intern(&field.name.name)), field_id)
                         .is_some()
                     {
                         ctx.push_error(DatamodelError::new_composite_type_duplicate_field_error(

--- a/libs/datamodel/parser-database/src/relations.rs
+++ b/libs/datamodel/parser-database/src/relations.rs
@@ -180,19 +180,19 @@ impl Relation {
 }
 
 // Implementation detail for this module. Should stay private.
-pub(super) struct RelationEvidence<'ast, 'db> {
+struct RelationEvidence<'ast, 'db> {
     pub(super) ast_model: &'ast ast::Model,
     pub(super) model_id: ast::ModelId,
     pub(super) ast_field: &'ast ast::Field,
     pub(super) field_id: ast::FieldId,
     pub(super) is_self_relation: bool,
-    pub(super) relation_field: &'db RelationField<'ast>,
+    pub(super) relation_field: &'db RelationField,
     pub(super) opposite_model: &'ast ast::Model,
-    pub(super) opposite_relation_field: Option<(ast::FieldId, &'ast ast::Field, &'db RelationField<'ast>)>,
+    pub(super) opposite_relation_field: Option<(ast::FieldId, &'ast ast::Field, &'db RelationField)>,
 }
 
-pub(super) fn relation_evidence<'ast, 'db>(
-    ((model_id, field_id), relation_field): (&(ast::ModelId, ast::FieldId), &'db RelationField<'ast>),
+fn relation_evidence<'ast, 'db>(
+    ((model_id, field_id), relation_field): (&(ast::ModelId, ast::FieldId), &'db RelationField),
     ctx: &'db Context<'ast>,
 ) -> RelationEvidence<'ast, 'db> {
     let ast_model = &ctx.db.ast[*model_id];
@@ -200,7 +200,7 @@ pub(super) fn relation_evidence<'ast, 'db>(
     let opposite_model = &ctx.db.ast[relation_field.referenced_model];
     let is_self_relation = *model_id == relation_field.referenced_model;
     let relation_name = relation_field.name.as_ref().map(|s| ctx.db.resolve_str(s));
-    let opposite_relation_field: Option<(ast::FieldId, &ast::Field, &RelationField<'_>)> = ctx
+    let opposite_relation_field: Option<(ast::FieldId, &ast::Field, &RelationField)> = ctx
         .db
         .walk_model(relation_field.referenced_model)
         .relation_fields()
@@ -223,7 +223,7 @@ pub(super) fn relation_evidence<'ast, 'db>(
     }
 }
 
-pub(super) fn ingest_relation<'ast, 'db>(
+fn ingest_relation<'ast, 'db>(
     evidence: RelationEvidence<'ast, 'db>,
     relations: &mut Relations,
     ctx: &'db Context<'ast>,

--- a/libs/datamodel/parser-database/src/relations.rs
+++ b/libs/datamodel/parser-database/src/relations.rs
@@ -199,7 +199,7 @@ fn relation_evidence<'ast, 'db>(
     let ast_field = &ast_model[*field_id];
     let opposite_model = &ctx.db.ast[relation_field.referenced_model];
     let is_self_relation = *model_id == relation_field.referenced_model;
-    let relation_name = relation_field.name.as_ref().map(|s| ctx.db.resolve_str(s));
+    let relation_name = relation_field.name.as_ref().map(|s| &ctx.db.interner[s.value]);
     let opposite_relation_field: Option<(ast::FieldId, &ast::Field, &RelationField)> = ctx
         .db
         .walk_model(relation_field.referenced_model)

--- a/libs/datamodel/parser-database/src/relations.rs
+++ b/libs/datamodel/parser-database/src/relations.rs
@@ -180,21 +180,21 @@ impl Relation {
 }
 
 // Implementation detail for this module. Should stay private.
-struct RelationEvidence<'ast, 'db> {
-    pub(super) ast_model: &'ast ast::Model,
+struct RelationEvidence<'db> {
+    pub(super) ast_model: &'db ast::Model,
     pub(super) model_id: ast::ModelId,
-    pub(super) ast_field: &'ast ast::Field,
+    pub(super) ast_field: &'db ast::Field,
     pub(super) field_id: ast::FieldId,
     pub(super) is_self_relation: bool,
     pub(super) relation_field: &'db RelationField,
-    pub(super) opposite_model: &'ast ast::Model,
-    pub(super) opposite_relation_field: Option<(ast::FieldId, &'ast ast::Field, &'db RelationField)>,
+    pub(super) opposite_model: &'db ast::Model,
+    pub(super) opposite_relation_field: Option<(ast::FieldId, &'db ast::Field, &'db RelationField)>,
 }
 
-fn relation_evidence<'ast, 'db>(
-    ((model_id, field_id), relation_field): (&(ast::ModelId, ast::FieldId), &'db RelationField),
-    ctx: &'db Context<'ast>,
-) -> RelationEvidence<'ast, 'db> {
+fn relation_evidence<'db>(
+    ((model_id, field_id), relation_field): (&'db (ast::ModelId, ast::FieldId), &'db RelationField),
+    ctx: &'db Context<'db>,
+) -> RelationEvidence<'db> {
     let ast_model = &ctx.db.ast[*model_id];
     let ast_field = &ast_model[*field_id];
     let opposite_model = &ctx.db.ast[relation_field.referenced_model];
@@ -223,10 +223,10 @@ fn relation_evidence<'ast, 'db>(
     }
 }
 
-fn ingest_relation<'ast, 'db>(
-    evidence: RelationEvidence<'ast, 'db>,
+fn ingest_relation<'db>(
+    evidence: RelationEvidence<'db>,
     relations: &mut Relations,
-    ctx: &'db Context<'ast>,
+    ctx: &Context<'db>,
 ) {
     // In this function, we want to ingest the relation only once,
     // so if we know that we will create a relation for the opposite

--- a/libs/datamodel/parser-database/src/types.rs
+++ b/libs/datamodel/parser-database/src/types.rs
@@ -31,7 +31,7 @@ pub(super) struct Types<'ast> {
     pub(super) scalar_fields: BTreeMap<(ast::ModelId, ast::FieldId), ScalarField<'ast>>,
     /// This contains only the relation fields actually present in the schema
     /// source text.
-    pub(super) relation_fields: BTreeMap<(ast::ModelId, ast::FieldId), RelationField<'ast>>,
+    pub(super) relation_fields: BTreeMap<(ast::ModelId, ast::FieldId), RelationField>,
     pub(super) enum_attributes: HashMap<ast::EnumId, EnumAttributes<'ast>>,
     pub(super) model_attributes: HashMap<ast::ModelId, ModelAttributes<'ast>>,
 }
@@ -58,7 +58,7 @@ impl<'ast> Types<'ast> {
         &mut self,
         model_id: ast::ModelId,
         field_id: ast::FieldId,
-    ) -> Option<RelationField<'ast>> {
+    ) -> Option<RelationField> {
         self.relation_fields.remove(&(model_id, field_id))
     }
 }
@@ -125,7 +125,7 @@ pub(crate) struct ScalarField<'ast> {
 }
 
 #[derive(Debug)]
-pub(crate) struct RelationField<'ast> {
+pub(crate) struct RelationField {
     pub(crate) referenced_model: ast::ModelId,
     pub(crate) on_delete: Option<(crate::ReferentialAction, ast::Span)>,
     pub(crate) on_update: Option<(crate::ReferentialAction, ast::Span)>,
@@ -137,11 +137,11 @@ pub(crate) struct RelationField<'ast> {
     pub(crate) name: Option<AstString>,
     pub(crate) is_ignored: bool,
     /// The foreign key name _explicitly present_ in the AST through the `@map` attribute.
-    pub(crate) mapped_name: Option<&'ast str>,
-    pub(crate) relation_attribute: Option<&'ast ast::Attribute>,
+    pub(crate) mapped_name: Option<AstString>,
+    pub(crate) relation_attribute: Option<ast::AttributeId>,
 }
 
-impl RelationField<'_> {
+impl RelationField {
     fn new(referenced_model: ast::ModelId) -> Self {
         RelationField {
             referenced_model,

--- a/libs/datamodel/parser-database/src/types.rs
+++ b/libs/datamodel/parser-database/src/types.rs
@@ -61,7 +61,7 @@ impl<'ast> Types<'ast> {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(super) struct CompositeTypeField<'ast> {
     pub(super) r#type: ScalarFieldType,
     pub(super) mapped_name: Option<&'ast str>,
@@ -99,7 +99,7 @@ impl ScalarFieldType {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct DefaultAttribute<'ast> {
     pub(crate) mapped_name: Option<&'ast str>,
     pub(crate) value: &'ast ast::Expression,
@@ -243,7 +243,7 @@ pub(crate) struct IdAttribute<'ast> {
     pub(super) mapped_name: Option<&'ast str>,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug)]
 pub struct FieldWithArgs {
     pub(crate) field_id: ast::FieldId,
     pub(crate) sort_order: Option<SortOrder>,

--- a/libs/datamodel/parser-database/src/types.rs
+++ b/libs/datamodel/parser-database/src/types.rs
@@ -1,4 +1,6 @@
-use crate::{context::Context, walkers::CompositeTypeFieldWalker, walkers::CompositeTypeWalker, DatamodelError};
+use crate::{
+    context::Context, walkers::CompositeTypeFieldWalker, walkers::CompositeTypeWalker, AstString, DatamodelError,
+};
 use schema_ast::ast::{self, WithName};
 use std::{
     collections::{BTreeMap, HashMap},
@@ -132,7 +134,7 @@ pub(crate) struct RelationField<'ast> {
     /// The `references` fields _explicitly present_ in the AST.
     pub(crate) references: Option<Vec<ast::FieldId>>,
     /// The name _explicitly present_ in the AST.
-    pub(crate) name: Option<&'ast str>,
+    pub(crate) name: Option<AstString>,
     pub(crate) is_ignored: bool,
     /// The foreign key name _explicitly present_ in the AST through the `@map` attribute.
     pub(crate) mapped_name: Option<&'ast str>,

--- a/libs/datamodel/parser-database/src/value_validator.rs
+++ b/libs/datamodel/parser-database/src/value_validator.rs
@@ -59,6 +59,12 @@ impl<'a> ValueValidator<'a> {
             .ok_or_else(|| self.construct_type_mismatch_error("String"))
     }
 
+    /// Tries to convert the wrapped value to a Prisma String.
+    pub fn as_str_with_span(&self) -> Result<(&'a str, ast::Span), DatamodelError> {
+        self.as_string_literal()
+            .ok_or_else(|| self.construct_type_mismatch_error("String"))
+    }
+
     /// Returns true if this argument is derived from an env() function
     pub fn is_from_env(&self) -> bool {
         self.value.is_env_expression()

--- a/libs/datamodel/parser-database/src/walkers.rs
+++ b/libs/datamodel/parser-database/src/walkers.rs
@@ -28,14 +28,14 @@ use crate::{ast, ParserDatabase};
 
 /// A generic walker. Only walkers intantiated with a concrete ID type (`I`) are useful.
 #[derive(Clone, Copy)]
-pub struct Walker<'ast, 'db, I> {
-    db: &'db crate::ParserDatabase<'ast>,
+pub struct Walker<'db, I> {
+    db: &'db crate::ParserDatabase,
     id: I,
 }
 
-impl<'ast> ParserDatabase<'ast> {
+impl ParserDatabase {
     /// Walk all enums in the schema.
-    pub fn walk_enums(&self) -> impl Iterator<Item = EnumWalker<'ast, '_>> {
+    pub fn walk_enums(&self) -> impl Iterator<Item = EnumWalker<'_>> {
         self.ast()
             .iter_tops()
             .filter_map(|(top_id, _)| top_id.as_enum_id())
@@ -43,7 +43,7 @@ impl<'ast> ParserDatabase<'ast> {
     }
 
     /// Find a model by ID.
-    pub(crate) fn walk_model(&self, model_id: ast::ModelId) -> ModelWalker<'ast, '_> {
+    pub(crate) fn walk_model(&self, model_id: ast::ModelId) -> ModelWalker<'_> {
         ModelWalker {
             model_id,
             db: self,
@@ -52,12 +52,12 @@ impl<'ast> ParserDatabase<'ast> {
     }
 
     /// Find an enum by ID.
-    pub fn walk_enum(&self, enum_id: ast::EnumId) -> EnumWalker<'ast, '_> {
+    pub fn walk_enum(&self, enum_id: ast::EnumId) -> EnumWalker<'_> {
         Walker { db: self, id: enum_id }
     }
 
     /// Walk all the models in the schema.
-    pub fn walk_models(&self) -> impl Iterator<Item = ModelWalker<'ast, '_>> + '_ {
+    pub fn walk_models(&self) -> impl Iterator<Item = ModelWalker<'_>> + '_ {
         self.ast()
             .iter_tops()
             .filter_map(|(top_id, _)| top_id.as_model_id())
@@ -65,12 +65,12 @@ impl<'ast> ParserDatabase<'ast> {
     }
 
     /// Walk a specific composite type by ID.
-    pub fn walk_composite_type(&self, ctid: ast::CompositeTypeId) -> CompositeTypeWalker<'ast, '_> {
+    pub fn walk_composite_type(&self, ctid: ast::CompositeTypeId) -> CompositeTypeWalker<'_> {
         CompositeTypeWalker { ctid, db: self }
     }
 
     /// Walk all the composite types in the schema.
-    pub fn walk_composite_types(&self) -> impl Iterator<Item = CompositeTypeWalker<'ast, '_>> + '_ {
+    pub fn walk_composite_types(&self) -> impl Iterator<Item = CompositeTypeWalker<'_>> + '_ {
         self.ast()
             .iter_tops()
             .filter_map(|(top_id, _)| top_id.as_composite_type_id())
@@ -79,7 +79,7 @@ impl<'ast> ParserDatabase<'ast> {
 
     /// Walk all the relations in the schema. A relation may be defined by one or two fields; in
     /// both cases, it is still a single relation.
-    pub fn walk_relations(&self) -> impl Iterator<Item = RelationWalker<'ast, '_>> + '_ {
+    pub fn walk_relations(&self) -> impl Iterator<Item = RelationWalker<'_>> + '_ {
         self.relations.iter().map(move |relation_id| Walker {
             db: self,
             id: relation_id,
@@ -89,7 +89,7 @@ impl<'ast> ParserDatabase<'ast> {
     /// Iterate all complete relations that are not many to many and are
     /// correctly defined from both sides.
     #[track_caller]
-    pub fn walk_complete_inline_relations(&self) -> impl Iterator<Item = CompleteInlineRelationWalker<'ast, '_>> + '_ {
+    pub fn walk_complete_inline_relations(&self) -> impl Iterator<Item = CompleteInlineRelationWalker<'_>> + '_ {
         self.relations
             .iter_relations()
             .filter(|(_, _, relation)| !relation.is_many_to_many())

--- a/libs/datamodel/parser-database/src/walkers/composite_type.rs
+++ b/libs/datamodel/parser-database/src/walkers/composite_type.rs
@@ -19,35 +19,35 @@ use crate::{
 /// }
 /// ```
 #[derive(Copy, Clone)]
-pub struct CompositeTypeWalker<'ast, 'db> {
+pub struct CompositeTypeWalker<'db> {
     pub(super) ctid: ast::CompositeTypeId,
-    pub(super) db: &'db ParserDatabase<'ast>,
+    pub(super) db: &'db ParserDatabase,
 }
 
-impl<'ast, 'db> PartialEq for CompositeTypeWalker<'ast, 'db> {
+impl<'db> PartialEq for CompositeTypeWalker<'db> {
     fn eq(&self, other: &Self) -> bool {
         self.ctid == other.ctid
     }
 }
 
-impl<'ast, 'db> CompositeTypeWalker<'ast, 'db> {
+impl<'db> CompositeTypeWalker<'db> {
     /// The ID of the composite type node in the AST.
     pub fn composite_type_id(self) -> ast::CompositeTypeId {
         self.ctid
     }
 
     /// The composite type node in the AST.
-    pub fn ast_composite_type(self) -> &'ast ast::CompositeType {
+    pub fn ast_composite_type(self) -> &'db ast::CompositeType {
         &self.db.ast()[self.ctid]
     }
 
     /// The name of the composite type in the schema.
-    pub fn name(self) -> &'ast str {
+    pub fn name(self) -> &'db str {
         &self.db.ast[self.ctid].name.name
     }
 
     /// Iterator over all the fields of the composite type.
-    pub fn fields(self) -> impl Iterator<Item = CompositeTypeFieldWalker<'ast, 'db>> {
+    pub fn fields(self) -> impl Iterator<Item = CompositeTypeFieldWalker<'db>> {
         let db = self.db;
         db.types
             .composite_type_fields
@@ -63,21 +63,21 @@ impl<'ast, 'db> CompositeTypeWalker<'ast, 'db> {
 
 /// A field in a composite type.
 #[derive(Clone, Copy)]
-pub struct CompositeTypeFieldWalker<'ast, 'db> {
+pub struct CompositeTypeFieldWalker<'db> {
     ctid: ast::CompositeTypeId,
     field_id: ast::FieldId,
-    field: &'db types::CompositeTypeField<'ast>,
-    db: &'db ParserDatabase<'ast>,
+    field: &'db types::CompositeTypeField,
+    db: &'db ParserDatabase,
 }
 
-impl<'ast, 'db> CompositeTypeFieldWalker<'ast, 'db> {
+impl<'db> CompositeTypeFieldWalker<'db> {
     /// The AST node for the field.
-    pub fn ast_field(self) -> &'ast ast::Field {
+    pub fn ast_field(self) -> &'db ast::Field {
         &self.db.ast[self.ctid][self.field_id]
     }
 
     /// The composite type containing the field.
-    pub fn composite_type(self) -> CompositeTypeWalker<'ast, 'db> {
+    pub fn composite_type(self) -> CompositeTypeWalker<'db> {
         CompositeTypeWalker {
             ctid: self.ctid,
             db: self.db,
@@ -90,12 +90,12 @@ impl<'ast, 'db> CompositeTypeFieldWalker<'ast, 'db> {
     }
 
     /// The name contained in the `@map()` attribute of the field, if any.
-    pub fn mapped_name(self) -> Option<&'ast str> {
+    pub fn mapped_name(self) -> Option<&'db str> {
         self.field.mapped_name
     }
 
     /// The name of the field.
-    pub fn name(self) -> &'ast str {
+    pub fn name(self) -> &'db str {
         &self.ast_field().name.name
     }
 
@@ -110,7 +110,7 @@ impl<'ast, 'db> CompositeTypeFieldWalker<'ast, 'db> {
     }
 
     /// The `@default()` AST attribute on the field, if any.
-    pub fn default_attribute(self) -> Option<&'ast ast::Attribute> {
+    pub fn default_attribute(self) -> Option<&'db ast::Attribute> {
         self.field.default.as_ref().map(|d| d.default_attribute)
     }
 
@@ -120,7 +120,7 @@ impl<'ast, 'db> CompositeTypeFieldWalker<'ast, 'db> {
     /// score Int @default(0)
     ///                    ^
     /// ```
-    pub fn default_value(self) -> Option<&'ast ast::Expression> {
+    pub fn default_value(self) -> Option<&'db ast::Expression> {
         self.field.default.as_ref().map(|d| d.value)
     }
 
@@ -130,7 +130,7 @@ impl<'ast, 'db> CompositeTypeFieldWalker<'ast, 'db> {
     /// name String @default("george", map: "name_default_to_george")
     ///                                     ^^^^^^^^^^^^^^^^^^^^^^^^
     /// ```
-    pub fn default_mapped_name(self) -> Option<&'ast str> {
+    pub fn default_mapped_name(self) -> Option<&'db str> {
         self.field.default.as_ref().and_then(|d| d.mapped_name)
     }
 }

--- a/libs/datamodel/parser-database/src/walkers/enum.rs
+++ b/libs/datamodel/parser-database/src/walkers/enum.rs
@@ -1,23 +1,23 @@
 use crate::{ast, walkers::Walker};
 
 /// An `enum` declaration in the schema.
-pub type EnumWalker<'ast, 'db> = Walker<'ast, 'db, ast::EnumId>;
+pub type EnumWalker<'db> = Walker<'db, ast::EnumId>;
 /// One value in an `enum` declaration in the schema.
-pub type EnumValueWalker<'ast, 'db> = Walker<'ast, 'db, (ast::EnumId, usize)>;
+pub type EnumValueWalker<'db> = Walker<'db, (ast::EnumId, usize)>;
 
-impl<'ast, 'db> EnumWalker<'ast, 'db> {
+impl<'db> EnumWalker<'db> {
     /// The name of the enum.
-    pub fn name(self) -> &'ast str {
+    pub fn name(self) -> &'db str {
         &self.ast_enum().name.name
     }
 
     /// The AST node.
-    pub fn ast_enum(self) -> &'ast ast::Enum {
+    pub fn ast_enum(self) -> &'db ast::Enum {
         &self.db.ast()[self.id]
     }
 
     /// The database name of the enum.
-    pub fn database_name(self) -> &'ast str {
+    pub fn database_name(self) -> &'db str {
         self.mapped_name().unwrap_or_else(|| self.name())
     }
 
@@ -33,12 +33,14 @@ impl<'ast, 'db> EnumWalker<'ast, 'db> {
     ///           ^^^^^^^
     /// }
     /// ```
-    pub fn mapped_name(self) -> Option<&'ast str> {
-        self.db.types.enum_attributes[&self.id].mapped_name
+    pub fn mapped_name(self) -> Option<&'db str> {
+        self.db.types.enum_attributes[&self.id]
+            .mapped_name
+            .map(|interned| &self.db.interner[interned])
     }
 
     /// The values of the enum.
-    pub fn values(self) -> impl Iterator<Item = EnumValueWalker<'ast, 'db>> {
+    pub fn values(self) -> impl Iterator<Item = EnumValueWalker<'db>> {
         (0..self.ast_enum().values.len()).map(move |idx| Walker {
             db: self.db,
             id: (self.id, idx),
@@ -46,8 +48,8 @@ impl<'ast, 'db> EnumWalker<'ast, 'db> {
     }
 }
 
-impl<'ast, 'db> EnumValueWalker<'ast, 'db> {
-    fn r#enum(self) -> EnumWalker<'ast, 'db> {
+impl<'db> EnumValueWalker<'db> {
+    fn r#enum(self) -> EnumWalker<'db> {
         Walker {
             db: self.db,
             id: self.id.0,
@@ -55,7 +57,7 @@ impl<'ast, 'db> EnumValueWalker<'ast, 'db> {
     }
 
     /// The enum documentation
-    pub fn documentation(self) -> Option<&'ast str> {
+    pub fn documentation(self) -> Option<&'db str> {
         self.r#enum().ast_enum().values[self.id.1]
             .documentation
             .as_ref()
@@ -63,12 +65,12 @@ impl<'ast, 'db> EnumValueWalker<'ast, 'db> {
     }
 
     /// The name of the value.
-    pub fn name(self) -> &'ast str {
+    pub fn name(self) -> &'db str {
         &self.r#enum().ast_enum().values[self.id.1].name.name
     }
 
     /// The database name of the enum.
-    pub fn database_name(self) -> &'ast str {
+    pub fn database_name(self) -> &'db str {
         self.mapped_name().unwrap_or_else(|| self.name())
     }
 
@@ -82,10 +84,10 @@ impl<'ast, 'db> EnumValueWalker<'ast, 'db> {
     ///     BLUE @map("schmurf")
     /// }
     /// ```
-    pub fn mapped_name(self) -> Option<&'ast str> {
+    pub fn mapped_name(self) -> Option<&'db str> {
         self.db.types.enum_attributes[&self.id.0]
             .mapped_values
             .get(&(self.id.1 as u32))
-            .cloned()
+            .map(|interned| &self.db.interner[*interned])
     }
 }

--- a/libs/datamodel/parser-database/src/walkers/field.rs
+++ b/libs/datamodel/parser-database/src/walkers/field.rs
@@ -1,20 +1,20 @@
 use super::{ModelWalker, RelationFieldWalker, ScalarFieldWalker};
 
 #[derive(Copy, Clone)]
-enum InnerWalker<'ast, 'db> {
-    Scalar(ScalarFieldWalker<'ast, 'db>),
-    Relation(RelationFieldWalker<'ast, 'db>),
+enum InnerWalker<'db> {
+    Scalar(ScalarFieldWalker<'db>),
+    Relation(RelationFieldWalker<'db>),
 }
 
 /// A model field, scalar or relation.
 #[derive(Clone, Copy)]
-pub struct FieldWalker<'ast, 'db> {
-    inner: InnerWalker<'ast, 'db>,
+pub struct FieldWalker<'db> {
+    inner: InnerWalker<'db>,
 }
 
-impl<'ast, 'db> FieldWalker<'ast, 'db> {
+impl<'db> FieldWalker<'db> {
     /// The field name.
-    pub fn name(self) -> &'ast str {
+    pub fn name(self) -> &'db str {
         match self.inner {
             InnerWalker::Scalar(f) => f.name(),
             InnerWalker::Relation(f) => f.name(),
@@ -22,7 +22,7 @@ impl<'ast, 'db> FieldWalker<'ast, 'db> {
     }
 
     /// The model name.
-    pub fn model(self) -> ModelWalker<'ast, 'db> {
+    pub fn model(self) -> ModelWalker<'db> {
         match self.inner {
             InnerWalker::Scalar(f) => f.model(),
             InnerWalker::Relation(f) => f.model(),
@@ -30,16 +30,16 @@ impl<'ast, 'db> FieldWalker<'ast, 'db> {
     }
 }
 
-impl<'ast, 'db> From<ScalarFieldWalker<'ast, 'db>> for FieldWalker<'ast, 'db> {
-    fn from(w: ScalarFieldWalker<'ast, 'db>) -> Self {
+impl<'db> From<ScalarFieldWalker<'db>> for FieldWalker<'db> {
+    fn from(w: ScalarFieldWalker<'db>) -> Self {
         Self {
             inner: InnerWalker::Scalar(w),
         }
     }
 }
 
-impl<'ast, 'db> From<RelationFieldWalker<'ast, 'db>> for FieldWalker<'ast, 'db> {
-    fn from(w: RelationFieldWalker<'ast, 'db>) -> Self {
+impl<'db> From<RelationFieldWalker<'db>> for FieldWalker<'db> {
+    fn from(w: RelationFieldWalker<'db>) -> Self {
         Self {
             inner: InnerWalker::Relation(w),
         }

--- a/libs/datamodel/parser-database/src/walkers/index.rs
+++ b/libs/datamodel/parser-database/src/walkers/index.rs
@@ -7,21 +7,21 @@ use crate::{
 
 /// An index, unique or fulltext attribute.
 #[derive(Copy, Clone)]
-pub struct IndexWalker<'ast, 'db> {
+pub struct IndexWalker<'db> {
     pub(crate) model_id: ast::ModelId,
-    pub(crate) index: Option<&'ast ast::Attribute>,
-    pub(crate) db: &'db ParserDatabase<'ast>,
-    pub(crate) index_attribute: &'db IndexAttribute<'ast>,
+    pub(crate) index: Option<&'db ast::Attribute>,
+    pub(crate) db: &'db ParserDatabase,
+    pub(crate) index_attribute: &'db IndexAttribute,
 }
 
-impl<'ast, 'db> IndexWalker<'ast, 'db> {
+impl<'db> IndexWalker<'db> {
     /// The mapped name of the index.
     ///
     /// ```ignore
     /// @@index([a, b], map: "theName")
     ///                      ^^^^^^^^^
     /// ```
-    pub fn mapped_name(self) -> Option<&'ast str> {
+    pub fn mapped_name(self) -> Option<&'db str> {
         self.index_attribute.mapped_name
     }
 
@@ -46,7 +46,7 @@ impl<'ast, 'db> IndexWalker<'ast, 'db> {
     /// @@index([a, b], name: "theName")
     ///                      ^^^^^^^^^
     /// ```
-    pub fn name(self) -> Option<&'ast str> {
+    pub fn name(self) -> Option<&'db str> {
         self.index_attribute.name
     }
 
@@ -56,16 +56,16 @@ impl<'ast, 'db> IndexWalker<'ast, 'db> {
     }
 
     /// The AST node of the index/unique attribute.
-    pub fn ast_attribute(self) -> Option<&'ast ast::Attribute> {
+    pub fn ast_attribute(self) -> Option<&'db ast::Attribute> {
         self.index
     }
 
-    pub(crate) fn attribute(self) -> &'db IndexAttribute<'ast> {
+    pub(crate) fn attribute(self) -> &'db IndexAttribute {
         self.index_attribute
     }
 
     /// The scalar fields covered by the index.
-    pub fn fields(self) -> impl ExactSizeIterator<Item = ScalarFieldWalker<'ast, 'db>> + 'db {
+    pub fn fields(self) -> impl ExactSizeIterator<Item = ScalarFieldWalker<'db>> + 'db {
         self.index_attribute
             .fields
             .iter()
@@ -78,7 +78,7 @@ impl<'ast, 'db> IndexWalker<'ast, 'db> {
     }
 
     /// The scalar fields covered by the index, and their arguments.
-    pub fn scalar_field_attributes(self) -> impl ExactSizeIterator<Item = ScalarFieldAttributeWalker<'ast, 'db>> + 'db {
+    pub fn scalar_field_attributes(self) -> impl ExactSizeIterator<Item = ScalarFieldAttributeWalker<'db>> + 'db {
         self.attribute()
             .fields
             .iter()
@@ -91,10 +91,7 @@ impl<'ast, 'db> IndexWalker<'ast, 'db> {
             })
     }
 
-    pub(crate) fn contains_exactly_fields(
-        self,
-        fields: impl ExactSizeIterator<Item = ScalarFieldWalker<'ast, 'db>>,
-    ) -> bool {
+    pub(crate) fn contains_exactly_fields(self, fields: impl ExactSizeIterator<Item = ScalarFieldWalker<'db>>) -> bool {
         self.index_attribute.fields.len() == fields.len() && self.fields().zip(fields).all(|(a, b)| a == b)
     }
 
@@ -114,7 +111,7 @@ impl<'ast, 'db> IndexWalker<'ast, 'db> {
     }
 
     /// The model the index is defined on.
-    pub fn model(self) -> ModelWalker<'ast, 'db> {
+    pub fn model(self) -> ModelWalker<'db> {
         ModelWalker {
             model_id: self.model_id,
             db: self.db,

--- a/libs/datamodel/parser-database/src/walkers/model.rs
+++ b/libs/datamodel/parser-database/src/walkers/model.rs
@@ -17,29 +17,29 @@ use std::hash::{Hash, Hasher};
 
 /// A `model` declaration in the Prisma schema.
 #[derive(Copy, Clone, Debug)]
-pub struct ModelWalker<'ast, 'db> {
+pub struct ModelWalker<'db> {
     pub(super) model_id: ast::ModelId,
-    pub(super) db: &'db ParserDatabase<'ast>,
-    pub(super) model_attributes: &'db ModelAttributes<'ast>,
+    pub(super) db: &'db ParserDatabase,
+    pub(super) model_attributes: &'db ModelAttributes,
 }
 
-impl<'ast, 'db> PartialEq for ModelWalker<'ast, 'db> {
+impl<'db> PartialEq for ModelWalker<'db> {
     fn eq(&self, other: &Self) -> bool {
         self.model_id == other.model_id
     }
 }
 
-impl<'ast, 'db> Eq for ModelWalker<'ast, 'db> {}
+impl<'db> Eq for ModelWalker<'db> {}
 
-impl<'ast, 'db> Hash for ModelWalker<'ast, 'db> {
+impl<'db> Hash for ModelWalker<'db> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.model_id.hash(state);
     }
 }
 
-impl<'ast, 'db> ModelWalker<'ast, 'db> {
+impl<'db> ModelWalker<'db> {
     /// The name of the model.
-    pub fn name(self) -> &'ast str {
+    pub fn name(self) -> &'db str {
         self.ast_model().name()
     }
 
@@ -66,12 +66,12 @@ impl<'ast, 'db> ModelWalker<'ast, 'db> {
     }
 
     /// The AST node.
-    pub fn ast_model(self) -> &'ast ast::Model {
+    pub fn ast_model(self) -> &'db ast::Model {
         &self.db.ast[self.model_id]
     }
 
     /// The parsed attributes.
-    pub(crate) fn attributes(self) -> &'db ModelAttributes<'ast> {
+    pub(crate) fn attributes(self) -> &'db ModelAttributes {
         self.model_attributes
     }
 
@@ -117,7 +117,7 @@ impl<'ast, 'db> ModelWalker<'ast, 'db> {
     }
 
     /// The primary key of the model, if defined.
-    pub fn primary_key(self) -> Option<PrimaryKeyWalker<'ast, 'db>> {
+    pub fn primary_key(self) -> Option<PrimaryKeyWalker<'db>> {
         self.model_attributes.primary_key.as_ref().map(|pk| PrimaryKeyWalker {
             model_id: self.model_id,
             attribute: pk,
@@ -127,7 +127,7 @@ impl<'ast, 'db> ModelWalker<'ast, 'db> {
 
     /// Walk a scalar field by id.
     #[track_caller]
-    pub(crate) fn scalar_field(&self, field_id: ast::FieldId) -> ScalarFieldWalker<'ast, 'db> {
+    pub(crate) fn scalar_field(&self, field_id: ast::FieldId) -> ScalarFieldWalker<'db> {
         ScalarFieldWalker {
             model_id: self.model_id,
             field_id,
@@ -137,7 +137,7 @@ impl<'ast, 'db> ModelWalker<'ast, 'db> {
     }
 
     /// Iterate all the scalar fields in a given model in the order they were defined.
-    pub fn scalar_fields(self) -> impl Iterator<Item = ScalarFieldWalker<'ast, 'db>> + 'db {
+    pub fn scalar_fields(self) -> impl Iterator<Item = ScalarFieldWalker<'db>> + 'db {
         let db = self.db;
         db.types
             .scalar_fields
@@ -152,7 +152,7 @@ impl<'ast, 'db> ModelWalker<'ast, 'db> {
 
     /// All unique criterias of the model; consisting of the primary key and
     /// unique indexes, if set.
-    pub fn unique_criterias(self) -> impl Iterator<Item = UniqueCriteriaWalker<'ast, 'db>> + 'db {
+    pub fn unique_criterias(self) -> impl Iterator<Item = UniqueCriteriaWalker<'db>> + 'db {
         let model_id = self.model_id;
         let db = self.db;
 
@@ -181,7 +181,7 @@ impl<'ast, 'db> ModelWalker<'ast, 'db> {
     /// Iterate all the relation fields in the model in the order they were
     /// defined. Note that these are only the fields that were actually written
     /// in the schema.
-    pub(crate) fn explicit_indexes(self) -> impl Iterator<Item = IndexWalker<'ast, 'db>> + 'db {
+    pub(crate) fn explicit_indexes(self) -> impl Iterator<Item = IndexWalker<'db>> + 'db {
         let model_id = self.model_id;
         let db = self.db;
 
@@ -198,7 +198,7 @@ impl<'ast, 'db> ModelWalker<'ast, 'db> {
 
     /// Iterate all the indexes in the model in the order they were
     /// defined, followed by the implicit indexes.
-    pub fn indexes(self) -> impl Iterator<Item = IndexWalker<'ast, 'db>> + 'db {
+    pub fn indexes(self) -> impl Iterator<Item = IndexWalker<'db>> + 'db {
         let implicit_indexes = self
             .model_attributes
             .implicit_indexes
@@ -214,7 +214,7 @@ impl<'ast, 'db> ModelWalker<'ast, 'db> {
     }
 
     /// All (concrete) relation fields of the model.
-    pub fn relation_fields(self) -> impl Iterator<Item = RelationFieldWalker<'ast, 'db>> + 'db {
+    pub fn relation_fields(self) -> impl Iterator<Item = RelationFieldWalker<'db>> + 'db {
         let model_id = self.model_id;
         let db = self.db;
 
@@ -235,7 +235,7 @@ impl<'ast, 'db> ModelWalker<'ast, 'db> {
     /// ## Panics
     ///
     /// If the field does not exist.
-    pub fn relation_field(self, field_id: ast::FieldId) -> RelationFieldWalker<'ast, 'db> {
+    pub fn relation_field(self, field_id: ast::FieldId) -> RelationFieldWalker<'db> {
         RelationFieldWalker {
             model_id: self.model_id,
             field_id,
@@ -245,7 +245,7 @@ impl<'ast, 'db> ModelWalker<'ast, 'db> {
     }
 
     /// All relations that start from this model.
-    pub fn relations_from(self) -> impl Iterator<Item = RelationWalker<'ast, 'db>> + 'db {
+    pub fn relations_from(self) -> impl Iterator<Item = RelationWalker<'db>> + 'db {
         self.db
             .relations
             .from_model(self.model_id)
@@ -256,7 +256,7 @@ impl<'ast, 'db> ModelWalker<'ast, 'db> {
     }
 
     /// All relations that reference this model.
-    pub fn relations_to(self) -> impl Iterator<Item = RelationWalker<'ast, 'db>> + 'db {
+    pub fn relations_to(self) -> impl Iterator<Item = RelationWalker<'db>> + 'db {
         self.db
             .relations
             .to_model(self.model_id)
@@ -267,7 +267,7 @@ impl<'ast, 'db> ModelWalker<'ast, 'db> {
     }
 
     /// 1:n and 1:1 relations that start from this model.
-    pub fn inline_relations_from(self) -> impl Iterator<Item = InlineRelationWalker<'ast, 'db>> + 'db {
+    pub fn inline_relations_from(self) -> impl Iterator<Item = InlineRelationWalker<'db>> + 'db {
         self.relations_from().filter_map(|relation| match relation.refine() {
             super::RefinedRelationWalker::Inline(relation) => Some(relation),
             super::RefinedRelationWalker::ImplicitManyToMany(_) => None,
@@ -275,7 +275,7 @@ impl<'ast, 'db> ModelWalker<'ast, 'db> {
     }
 
     /// 1:n and 1:1 relations, starting from this model and having both sides defined.
-    pub fn complete_inline_relations_from(self) -> impl Iterator<Item = CompleteInlineRelationWalker<'ast, 'db>> + 'db {
+    pub fn complete_inline_relations_from(self) -> impl Iterator<Item = CompleteInlineRelationWalker<'db>> + 'db {
         self.inline_relations_from()
             .filter_map(|relation| relation.as_complete())
     }

--- a/libs/datamodel/parser-database/src/walkers/model/primary_key.rs
+++ b/libs/datamodel/parser-database/src/walkers/model/primary_key.rs
@@ -7,15 +7,15 @@ use crate::{
 
 /// An `@(@)id` attribute in the schema.
 #[derive(Copy, Clone)]
-pub struct PrimaryKeyWalker<'ast, 'db> {
+pub struct PrimaryKeyWalker<'db> {
     pub(crate) model_id: ast::ModelId,
-    pub(crate) attribute: &'db IdAttribute<'ast>,
-    pub(crate) db: &'db ParserDatabase<'ast>,
+    pub(crate) attribute: &'db IdAttribute,
+    pub(crate) db: &'db ParserDatabase,
 }
 
-impl<'ast, 'db> PrimaryKeyWalker<'ast, 'db> {
+impl<'db> PrimaryKeyWalker<'db> {
     /// The `@(@)id` AST node.
-    pub fn ast_attribute(self) -> &'ast ast::Attribute {
+    pub fn ast_attribute(self) -> &'db ast::Attribute {
         self.attribute.source_attribute
     }
 
@@ -25,8 +25,9 @@ impl<'ast, 'db> PrimaryKeyWalker<'ast, 'db> {
     /// @@id([a, b], map: "theName")
     ///                   ^^^^^^^^^
     /// ```
-    pub fn mapped_name(self) -> Option<&'ast str> {
-        self.attribute.mapped_name
+    pub fn mapped_name(self) -> Option<&'db str> {
+        let mapped_name = self.attribute.mapped_name?;
+        Some(&self.db.interner[mapped_name])
     }
 
     /// Is this an `@id` on a specific field, rather than on the model?
@@ -35,7 +36,7 @@ impl<'ast, 'db> PrimaryKeyWalker<'ast, 'db> {
     }
 
     /// The model the id is deined on.
-    pub fn model(self) -> ModelWalker<'ast, 'db> {
+    pub fn model(self) -> ModelWalker<'db> {
         ModelWalker {
             db: self.db,
             model_attributes: &self.db.types.model_attributes[&self.model_id],
@@ -49,12 +50,12 @@ impl<'ast, 'db> PrimaryKeyWalker<'ast, 'db> {
     /// @@id([a, b], name: "theName")
     ///                    ^^^^^^^^^
     /// ```
-    pub fn name(self) -> Option<&'ast str> {
-        self.attribute.name
+    pub fn name(self) -> Option<&'db str> {
+        self.attribute.name.map(|n| &self.db.interner[n])
     }
 
     /// The scalar fields constrained by the id.
-    pub fn fields(self) -> impl ExactSizeIterator<Item = ScalarFieldWalker<'ast, 'db>> + 'db {
+    pub fn fields(self) -> impl ExactSizeIterator<Item = ScalarFieldWalker<'db>> + 'db {
         self.attribute.fields.iter().map(move |field| ScalarFieldWalker {
             model_id: self.model_id,
             field_id: field.field_id,
@@ -64,7 +65,7 @@ impl<'ast, 'db> PrimaryKeyWalker<'ast, 'db> {
     }
 
     /// The scalar fields covered by the id, and their arguments.
-    pub fn scalar_field_attributes(self) -> impl ExactSizeIterator<Item = ScalarFieldAttributeWalker<'ast, 'db>> + 'db {
+    pub fn scalar_field_attributes(self) -> impl ExactSizeIterator<Item = ScalarFieldAttributeWalker<'db>> + 'db {
         self.attribute
             .fields
             .iter()
@@ -84,7 +85,7 @@ impl<'ast, 'db> PrimaryKeyWalker<'ast, 'db> {
     }
 
     /// Do the constrained fields match exactly these?
-    pub fn contains_exactly_fields(self, fields: impl ExactSizeIterator<Item = ScalarFieldWalker<'ast, 'db>>) -> bool {
+    pub fn contains_exactly_fields(self, fields: impl ExactSizeIterator<Item = ScalarFieldWalker<'db>>) -> bool {
         self.attribute.fields.len() == fields.len() && self.fields().zip(fields).all(|(a, b)| a == b)
     }
 }

--- a/libs/datamodel/parser-database/src/walkers/model/unique_criteria.rs
+++ b/libs/datamodel/parser-database/src/walkers/model/unique_criteria.rs
@@ -7,14 +7,14 @@ use crate::{
 /// Describes any unique criteria in a model. Can either be a primary
 /// key, or a unique index.
 #[derive(Copy, Clone)]
-pub struct UniqueCriteriaWalker<'ast, 'db> {
+pub struct UniqueCriteriaWalker<'db> {
     pub(crate) model_id: ast::ModelId,
     pub(crate) fields: &'db [FieldWithArgs],
-    pub(crate) db: &'db ParserDatabase<'ast>,
+    pub(crate) db: &'db ParserDatabase,
 }
 
-impl<'ast, 'db> UniqueCriteriaWalker<'ast, 'db> {
-    pub fn fields(self) -> impl ExactSizeIterator<Item = ScalarFieldWalker<'ast, 'db>> + 'db {
+impl<'db> UniqueCriteriaWalker<'db> {
+    pub fn fields(self) -> impl ExactSizeIterator<Item = ScalarFieldWalker<'db>> + 'db {
         self.fields.iter().map(move |field| ScalarFieldWalker {
             model_id: self.model_id,
             field_id: field.field_id,

--- a/libs/datamodel/parser-database/src/walkers/relation.rs
+++ b/libs/datamodel/parser-database/src/walkers/relation.rs
@@ -204,7 +204,7 @@ impl<'ast, 'db> InlineRelationWalker<'ast, 'db> {
     }
 
     /// The contents of the `map: ...` argument of the `@relation` attribute.
-    pub fn mapped_name(self) -> Option<&'ast str> {
+    pub fn mapped_name(self) -> Option<&'db str> {
         self.forward_relation_field().and_then(|field| field.mapped_name())
     }
 
@@ -365,11 +365,7 @@ impl<'ast, 'db> CompleteInlineRelationWalker<'ast, 'db> {
     pub fn on_update(self) -> ReferentialAction {
         use ReferentialAction::*;
 
-        self.referencing_field()
-            .attributes()
-            .on_update
-            .map(|(action, _)| action)
-            .unwrap_or(Cascade)
+        self.referencing_field().explicit_on_update().unwrap_or(Cascade)
     }
 
     /// Prisma allows setting the relation field as optional, even if one of the

--- a/libs/datamodel/parser-database/src/walkers/relation.rs
+++ b/libs/datamodel/parser-database/src/walkers/relation.rs
@@ -20,7 +20,7 @@ impl<'ast, 'db> RelationWalker<'ast, 'db> {
     }
 
     /// The relation attributes parsed from the AST.
-    fn get(self) -> &'db Relation<'ast> {
+    fn get(self) -> &'db Relation {
         &self.db.relations[self.id]
     }
 }
@@ -77,7 +77,7 @@ pub struct InlineRelationWalker<'ast, 'db>(RelationWalker<'ast, 'db>);
 
 impl<'ast, 'db> InlineRelationWalker<'ast, 'db> {
     /// Get the relation attributes defined in the AST.
-    fn get(self) -> &'db Relation<'ast> {
+    fn get(self) -> &'db Relation {
         &self.0.db.relations[self.0.id]
     }
 
@@ -223,10 +223,11 @@ impl<'ast, 'db> InlineRelationWalker<'ast, 'db> {
 
     /// The name of the relation. Either uses the `name` (or default) argument,
     /// or generates an implicit name.
-    pub fn relation_name(self) -> RelationName<'ast> {
+    pub fn relation_name(self) -> RelationName<'db> {
         self.get()
             .relation_name
-            .map(RelationName::Explicit)
+            .as_ref()
+            .map(|s| RelationName::Explicit(self.0.db.resolve_str(s)))
             .unwrap_or_else(|| RelationName::generated(self.referencing_model().name(), self.referenced_model().name()))
     }
 }
@@ -238,7 +239,7 @@ pub struct ImplicitManyToManyRelationWalker<'ast, 'db>(RelationWalker<'ast, 'db>
 
 impl<'ast, 'db> ImplicitManyToManyRelationWalker<'ast, 'db> {
     /// Gets the relation attributes from the AST.
-    fn get(&self) -> &'db Relation<'ast> {
+    fn get(&self) -> &'db Relation {
         &self.0.db.relations[self.0.id]
     }
 
@@ -269,7 +270,7 @@ impl<'ast, 'db> ImplicitManyToManyRelationWalker<'ast, 'db> {
     }
 
     /// The name of the relation.
-    pub fn relation_name(self) -> RelationName<'ast> {
+    pub fn relation_name(self) -> RelationName<'db> {
         self.field_a().relation_name()
     }
 }

--- a/libs/datamodel/parser-database/src/walkers/relation.rs
+++ b/libs/datamodel/parser-database/src/walkers/relation.rs
@@ -2,12 +2,12 @@ use crate::{ast, relations::*, walkers::*, ParserDatabase, ScalarFieldType};
 
 /// A relation that has the minimal amount of information for us to create one. Useful for
 /// validation purposes. Holds all possible relation types.
-pub type RelationWalker<'ast, 'db> = Walker<'ast, 'db, RelationId>;
+pub type RelationWalker<'db> = Walker<'db, RelationId>;
 
-impl<'ast, 'db> RelationWalker<'ast, 'db> {
+impl<'db> RelationWalker<'db> {
     /// Converts the walker to either an implicit many to many, or a inline relation walker
     /// gathering 1:1 and 1:n relations.
-    pub fn refine(self) -> RefinedRelationWalker<'ast, 'db> {
+    pub fn refine(self) -> RefinedRelationWalker<'db> {
         if self.get().is_many_to_many() {
             RefinedRelationWalker::ImplicitManyToMany(ImplicitManyToManyRelationWalker(self))
         } else {
@@ -26,16 +26,16 @@ impl<'ast, 'db> RelationWalker<'ast, 'db> {
 }
 
 /// Splits the relation to different types.
-pub enum RefinedRelationWalker<'ast, 'db> {
+pub enum RefinedRelationWalker<'db> {
     /// 1:1 and 1:n relations, where one side defines the relation arguments.
-    Inline(InlineRelationWalker<'ast, 'db>),
+    Inline(InlineRelationWalker<'db>),
     /// Implicit m:n relation. The arguments are inferred by Prisma.
-    ImplicitManyToMany(ImplicitManyToManyRelationWalker<'ast, 'db>),
+    ImplicitManyToMany(ImplicitManyToManyRelationWalker<'db>),
 }
 
-impl<'ast, 'db> RefinedRelationWalker<'ast, 'db> {
+impl<'db> RefinedRelationWalker<'db> {
     /// Try interpreting this relation as an inline (1:n or 1:1 — without join table) relation.
-    pub fn as_inline(&self) -> Option<InlineRelationWalker<'ast, 'db>> {
+    pub fn as_inline(&self) -> Option<InlineRelationWalker<'db>> {
         match self {
             RefinedRelationWalker::Inline(inline) => Some(*inline),
             _ => None,
@@ -43,7 +43,7 @@ impl<'ast, 'db> RefinedRelationWalker<'ast, 'db> {
     }
 
     /// Try interpreting this relation as an implicit many-to-many relation.
-    pub fn as_many_to_many(&self) -> Option<ImplicitManyToManyRelationWalker<'ast, 'db>> {
+    pub fn as_many_to_many(&self) -> Option<ImplicitManyToManyRelationWalker<'db>> {
         match self {
             RefinedRelationWalker::ImplicitManyToMany(m2m) => Some(*m2m),
             _ => None,
@@ -53,19 +53,19 @@ impl<'ast, 'db> RefinedRelationWalker<'ast, 'db> {
 
 /// A scalar inferred by loose/magic reformatting.
 #[allow(missing_docs)]
-pub struct InferredField<'ast, 'db> {
+pub struct InferredField<'db> {
     pub name: String,
     pub arity: ast::FieldArity,
     pub tpe: ScalarFieldType,
-    pub blueprint: ScalarFieldWalker<'ast, 'db>,
+    pub blueprint: ScalarFieldWalker<'db>,
 }
 
 /// The scalar fields on the concrete side of the relation.
-pub enum ReferencingFields<'ast, 'db> {
+pub enum ReferencingFields<'db> {
     /// Existing scalar fields
-    Concrete(Box<dyn ExactSizeIterator<Item = ScalarFieldWalker<'ast, 'db>> + 'db>),
+    Concrete(Box<dyn ExactSizeIterator<Item = ScalarFieldWalker<'db>> + 'db>),
     /// Inferred scalar fields
-    Inferred(Vec<InferredField<'ast, 'db>>),
+    Inferred(Vec<InferredField<'db>>),
     /// Error
     NA,
 }
@@ -73,9 +73,9 @@ pub enum ReferencingFields<'ast, 'db> {
 /// An explicitly defined 1:1 or 1:n relation. The walker has the referencing side defined, but
 /// might miss the back relation in the AST.
 #[derive(Copy, Clone)]
-pub struct InlineRelationWalker<'ast, 'db>(RelationWalker<'ast, 'db>);
+pub struct InlineRelationWalker<'db>(RelationWalker<'db>);
 
-impl<'ast, 'db> InlineRelationWalker<'ast, 'db> {
+impl<'db> InlineRelationWalker<'db> {
     /// Get the relation attributes defined in the AST.
     fn get(self) -> &'db Relation {
         &self.0.db.relations[self.0.id]
@@ -87,18 +87,18 @@ impl<'ast, 'db> InlineRelationWalker<'ast, 'db> {
     }
 
     /// The model which holds the relation arguments.
-    pub fn referencing_model(self) -> ModelWalker<'ast, 'db> {
+    pub fn referencing_model(self) -> ModelWalker<'db> {
         self.0.db.walk_model(self.get().model_a)
     }
 
     /// The model referenced and which hold the back-relation field.
-    pub fn referenced_model(self) -> ModelWalker<'ast, 'db> {
+    pub fn referenced_model(self) -> ModelWalker<'db> {
         self.0.db.walk_model(self.get().model_b)
     }
 
     /// If the relation is defined from both sides, convert to an explicit relation
     /// walker.
-    pub fn as_complete(self) -> Option<CompleteInlineRelationWalker<'ast, 'db>> {
+    pub fn as_complete(self) -> Option<CompleteInlineRelationWalker<'db>> {
         match (self.forward_relation_field(), self.back_relation_field()) {
             (Some(field_a), Some(field_b)) => {
                 let walker = CompleteInlineRelationWalker {
@@ -114,7 +114,7 @@ impl<'ast, 'db> InlineRelationWalker<'ast, 'db> {
     }
 
     /// Should only be used for lifting. The referencing fields (including possibly inferred ones).
-    pub fn referencing_fields(self) -> ReferencingFields<'ast, 'db> {
+    pub fn referencing_fields(self) -> ReferencingFields<'db> {
         self.forward_relation_field()
             .and_then(|rf| rf.fields())
             .map(|fields| ReferencingFields::Concrete(Box::new(fields)))
@@ -154,11 +154,11 @@ impl<'ast, 'db> InlineRelationWalker<'ast, 'db> {
     }
 
     /// Should only be used for lifting. The referenced fields. Inferred or specified.
-    pub fn referenced_fields(self) -> Box<dyn Iterator<Item = ScalarFieldWalker<'ast, 'db>> + 'db> {
+    pub fn referenced_fields(self) -> Box<dyn Iterator<Item = ScalarFieldWalker<'db>> + 'db> {
         self.forward_relation_field()
             .and_then(
-                |field: RelationFieldWalker<'ast, 'db>| -> Option<Box<dyn Iterator<Item = ScalarFieldWalker<'ast, 'db>>>> {
-                    field.referenced_fields().map(|fields| Box::new(fields) as Box<dyn Iterator<Item = ScalarFieldWalker<'ast, 'db>>>)
+                |field: RelationFieldWalker<'db>| -> Option<Box<dyn Iterator<Item = ScalarFieldWalker<'db>>>> {
+                    field.referenced_fields().map(|fields| Box::new(fields) as Box<dyn Iterator<Item = ScalarFieldWalker<'db>>>)
                 },
             )
             .unwrap_or_else(move || {
@@ -173,7 +173,7 @@ impl<'ast, 'db> InlineRelationWalker<'ast, 'db> {
     }
 
     /// The forward relation field (the relation field on model A, the referencing model).
-    pub fn forward_relation_field(self) -> Option<RelationFieldWalker<'ast, 'db>> {
+    pub fn forward_relation_field(self) -> Option<RelationFieldWalker<'db>> {
         let model = self.referencing_model();
         match self.get().attributes {
             RelationAttributes::OneToOne(OneToOneRelationFields::Forward(a))
@@ -209,7 +209,7 @@ impl<'ast, 'db> InlineRelationWalker<'ast, 'db> {
     }
 
     /// The back relation field, or virtual relation field (on model B, the referenced model).
-    pub fn back_relation_field(self) -> Option<RelationFieldWalker<'ast, 'db>> {
+    pub fn back_relation_field(self) -> Option<RelationFieldWalker<'db>> {
         let model = self.referenced_model();
         match self.get().attributes {
             RelationAttributes::OneToOne(OneToOneRelationFields::Both(_, b))
@@ -227,7 +227,7 @@ impl<'ast, 'db> InlineRelationWalker<'ast, 'db> {
         self.get()
             .relation_name
             .as_ref()
-            .map(|s| RelationName::Explicit(self.0.db.resolve_str(s)))
+            .map(|s| RelationName::Explicit(&self.0.db.interner[s.value]))
             .unwrap_or_else(|| RelationName::generated(self.referencing_model().name(), self.referenced_model().name()))
     }
 }
@@ -235,26 +235,26 @@ impl<'ast, 'db> InlineRelationWalker<'ast, 'db> {
 /// Describes an implicit m:n relation between two models. Neither side defines fields, attributes
 /// or referential actions, which are all inferred by Prisma.
 #[derive(Copy, Clone)]
-pub struct ImplicitManyToManyRelationWalker<'ast, 'db>(RelationWalker<'ast, 'db>);
+pub struct ImplicitManyToManyRelationWalker<'db>(RelationWalker<'db>);
 
-impl<'ast, 'db> ImplicitManyToManyRelationWalker<'ast, 'db> {
+impl<'db> ImplicitManyToManyRelationWalker<'db> {
     /// Gets the relation attributes from the AST.
     fn get(&self) -> &'db Relation {
         &self.0.db.relations[self.0.id]
     }
 
     /// The model which comes first in the alphabetical order.
-    pub fn model_a(self) -> ModelWalker<'ast, 'db> {
+    pub fn model_a(self) -> ModelWalker<'db> {
         self.0.db.walk_model(self.get().model_a)
     }
 
     /// The model which comes after model a in the alphabetical order.
-    pub fn model_b(self) -> ModelWalker<'ast, 'db> {
+    pub fn model_b(self) -> ModelWalker<'db> {
         self.0.db.walk_model(self.get().model_b)
     }
 
     /// The field that defines the relation in model a.
-    pub fn field_a(self) -> RelationFieldWalker<'ast, 'db> {
+    pub fn field_a(self) -> RelationFieldWalker<'db> {
         match self.get().attributes {
             RelationAttributes::ImplicitManyToMany { field_a, field_b: _ } => self.model_a().relation_field(field_a),
             _ => unreachable!(),
@@ -262,7 +262,7 @@ impl<'ast, 'db> ImplicitManyToManyRelationWalker<'ast, 'db> {
     }
 
     /// The field that defines the relation in model b.
-    pub fn field_b(self) -> RelationFieldWalker<'ast, 'db> {
+    pub fn field_b(self) -> RelationFieldWalker<'db> {
         match self.get().attributes {
             RelationAttributes::ImplicitManyToMany { field_a: _, field_b } => self.model_b().relation_field(field_b),
             _ => unreachable!(),
@@ -278,16 +278,16 @@ impl<'ast, 'db> ImplicitManyToManyRelationWalker<'ast, 'db> {
 /// Represents a relation that has fields and references defined in one of the
 /// relation fields. Includes 1:1 and 1:n relations that are defined from both sides.
 #[derive(Copy, Clone)]
-pub struct CompleteInlineRelationWalker<'ast, 'db> {
+pub struct CompleteInlineRelationWalker<'db> {
     pub(crate) side_a: (ast::ModelId, ast::FieldId),
     pub(crate) side_b: (ast::ModelId, ast::FieldId),
-    pub(crate) db: &'db ParserDatabase<'ast>,
+    pub(crate) db: &'db ParserDatabase,
 }
 
 #[allow(missing_docs)]
-impl<'ast, 'db> CompleteInlineRelationWalker<'ast, 'db> {
+impl<'db> CompleteInlineRelationWalker<'db> {
     /// The model that defines the relation fields and actions.
-    pub fn referencing_model(self) -> ModelWalker<'ast, 'db> {
+    pub fn referencing_model(self) -> ModelWalker<'db> {
         ModelWalker {
             model_id: self.side_a.0,
             db: self.db,
@@ -296,7 +296,7 @@ impl<'ast, 'db> CompleteInlineRelationWalker<'ast, 'db> {
     }
 
     /// The implicit relation side.
-    pub fn referenced_model(self) -> ModelWalker<'ast, 'db> {
+    pub fn referenced_model(self) -> ModelWalker<'db> {
         ModelWalker {
             model_id: self.side_b.0,
             db: self.db,
@@ -304,7 +304,7 @@ impl<'ast, 'db> CompleteInlineRelationWalker<'ast, 'db> {
         }
     }
 
-    pub fn referencing_field(self) -> RelationFieldWalker<'ast, 'db> {
+    pub fn referencing_field(self) -> RelationFieldWalker<'db> {
         RelationFieldWalker {
             model_id: self.side_a.0,
             field_id: self.side_a.1,
@@ -313,7 +313,7 @@ impl<'ast, 'db> CompleteInlineRelationWalker<'ast, 'db> {
         }
     }
 
-    pub fn referenced_field(self) -> RelationFieldWalker<'ast, 'db> {
+    pub fn referenced_field(self) -> RelationFieldWalker<'db> {
         RelationFieldWalker {
             model_id: self.side_b.0,
             field_id: self.side_b.1,
@@ -323,7 +323,7 @@ impl<'ast, 'db> CompleteInlineRelationWalker<'ast, 'db> {
     }
 
     /// The scalar fields defining the relation on the referenced model.
-    pub fn referenced_fields(self) -> impl ExactSizeIterator<Item = ScalarFieldWalker<'ast, 'db>> + 'db {
+    pub fn referenced_fields(self) -> impl ExactSizeIterator<Item = ScalarFieldWalker<'db>> + 'db {
         let f = move |field_id: &ast::FieldId| {
             let model_id = self.referenced_model().model_id;
 
@@ -342,7 +342,7 @@ impl<'ast, 'db> CompleteInlineRelationWalker<'ast, 'db> {
     }
 
     /// The scalar fields on the defining the relation on the referencing model.
-    pub fn referencing_fields(self) -> impl ExactSizeIterator<Item = ScalarFieldWalker<'ast, 'db>> + 'db {
+    pub fn referencing_fields(self) -> impl ExactSizeIterator<Item = ScalarFieldWalker<'db>> + 'db {
         let f = move |field_id: &ast::FieldId| {
             let model_id = self.referencing_model().model_id;
 

--- a/libs/datamodel/parser-database/src/walkers/relation_field.rs
+++ b/libs/datamodel/parser-database/src/walkers/relation_field.rs
@@ -80,8 +80,8 @@ impl<'ast, 'db> RelationFieldWalker<'ast, 'db> {
     }
 
     /// The relation name explicitly written in the schema source.
-    pub fn explicit_relation_name(self) -> Option<&'ast str> {
-        self.relation_field.name
+    pub fn explicit_relation_name(self) -> Option<&'db str> {
+        self.relation_field.name.as_ref().map(|s| self.db.resolve_str(s))
     }
 
     /// Is there an `@ignore` attribute on the field?
@@ -141,7 +141,7 @@ impl<'ast, 'db> RelationFieldWalker<'ast, 'db> {
 
     /// The name of the relation. Either uses the `name` (or default) argument,
     /// or generates an implicit name.
-    pub fn relation_name(self) -> RelationName<'ast> {
+    pub fn relation_name(self) -> RelationName<'db> {
         self.explicit_relation_name()
             .map(RelationName::Explicit)
             .unwrap_or_else(|| RelationName::generated(self.model().name(), self.related_model().name()))
@@ -270,7 +270,7 @@ impl<'ast> fmt::Display for RelationName<'ast> {
     }
 }
 
-impl<'ast> AsRef<str> for RelationName<'ast> {
+impl<'db> AsRef<str> for RelationName<'db> {
     fn as_ref(&self) -> &str {
         match self {
             RelationName::Explicit(s) => s,

--- a/libs/datamodel/parser-database/src/walkers/relation_field.rs
+++ b/libs/datamodel/parser-database/src/walkers/relation_field.rs
@@ -16,7 +16,7 @@ pub struct RelationFieldWalker<'ast, 'db> {
     pub(crate) model_id: ast::ModelId,
     pub(crate) field_id: ast::FieldId,
     pub(crate) db: &'db ParserDatabase<'ast>,
-    pub(crate) relation_field: &'db RelationField<'ast>,
+    pub(crate) relation_field: &'db RelationField,
 }
 
 impl<'ast, 'db> PartialEq for RelationFieldWalker<'ast, 'db> {
@@ -41,8 +41,8 @@ impl<'ast, 'db> RelationFieldWalker<'ast, 'db> {
     }
 
     /// The foreign key name of the relation (`@relation(map: ...)`).
-    pub fn mapped_name(self) -> Option<&'ast str> {
-        self.attributes().mapped_name
+    pub fn mapped_name(self) -> Option<&'db str> {
+        self.attributes().mapped_name.as_ref().map(|s| self.db.resolve_str(s))
     }
 
     /// The field name.
@@ -55,7 +55,7 @@ impl<'ast, 'db> RelationFieldWalker<'ast, 'db> {
         &self.db.ast[self.model_id][self.field_id]
     }
 
-    pub(crate) fn attributes(self) -> &'db RelationField<'ast> {
+    fn attributes(self) -> &'db RelationField {
         self.relation_field
     }
 
@@ -105,7 +105,9 @@ impl<'ast, 'db> RelationFieldWalker<'ast, 'db> {
 
     /// The `@relation` attribute in the field AST.
     pub fn relation_attribute(self) -> Option<&'ast ast::Attribute> {
-        self.attributes().relation_attribute
+        self.attributes()
+            .relation_attribute
+            .map(|attr_id| &self.db.ast[attr_id])
     }
 
     pub(crate) fn references_model(self, other: ast::ModelId) -> bool {

--- a/libs/datamodel/parser-database/src/walkers/scalar_field.rs
+++ b/libs/datamodel/parser-database/src/walkers/scalar_field.rs
@@ -8,44 +8,44 @@ use diagnostics::Span;
 
 /// A scalar field, as part of a model.
 #[derive(Debug, Copy, Clone)]
-pub struct ScalarFieldWalker<'ast, 'db> {
+pub struct ScalarFieldWalker<'db> {
     pub(crate) model_id: ast::ModelId,
     pub(crate) field_id: ast::FieldId,
-    pub(crate) db: &'db ParserDatabase<'ast>,
-    pub(crate) scalar_field: &'db ScalarField<'ast>,
+    pub(crate) db: &'db ParserDatabase,
+    pub(crate) scalar_field: &'db ScalarField,
 }
 
-impl<'ast, 'db> PartialEq for ScalarFieldWalker<'ast, 'db> {
+impl<'db> PartialEq for ScalarFieldWalker<'db> {
     fn eq(&self, other: &Self) -> bool {
         self.model_id == other.model_id && self.field_id == other.field_id
     }
 }
 
-impl<'ast, 'db> Eq for ScalarFieldWalker<'ast, 'db> {}
+impl<'db> Eq for ScalarFieldWalker<'db> {}
 
-impl<'ast, 'db> ScalarFieldWalker<'ast, 'db> {
+impl<'db> ScalarFieldWalker<'db> {
     /// The ID of the field node in the AST.
     pub fn field_id(self) -> ast::FieldId {
         self.field_id
     }
 
     /// The field node in the AST.
-    pub fn ast_field(self) -> &'ast ast::Field {
+    pub fn ast_field(self) -> &'db ast::Field {
         &self.db.ast[self.model_id][self.field_id]
     }
 
     /// The name of the field.
-    pub fn name(self) -> &'ast str {
+    pub fn name(self) -> &'db str {
         self.ast_field().name()
     }
 
     /// The `@default()` AST attribute on the field, if any.
-    pub fn default_attribute(self) -> Option<&'ast ast::Attribute> {
+    pub fn default_attribute(self) -> Option<&'db ast::Attribute> {
         self.scalar_field.default.as_ref().map(|d| d.default_attribute)
     }
 
     /// The final database name of the field. See crate docs for explanations on database names.
-    pub fn database_name(self) -> &'ast str {
+    pub fn database_name(self) -> &'db str {
         self.attributes().mapped_name.unwrap_or_else(|| self.name())
     }
 
@@ -72,12 +72,12 @@ impl<'ast, 'db> ScalarFieldWalker<'ast, 'db> {
         self.attributes().is_updated_at
     }
 
-    fn attributes(self) -> &'db ScalarField<'ast> {
+    fn attributes(self) -> &'db ScalarField {
         self.scalar_field
     }
 
     /// Is this field's type an enum? If yes, walk the enum.
-    pub fn field_type_as_enum(self) -> Option<EnumWalker<'ast, 'db>> {
+    pub fn field_type_as_enum(self) -> Option<EnumWalker<'db>> {
         match self.scalar_field_type() {
             ScalarFieldType::Enum(enum_id) => Some(Walker {
                 db: self.db,
@@ -88,12 +88,12 @@ impl<'ast, 'db> ScalarFieldWalker<'ast, 'db> {
     }
 
     /// The name in the `@map(<name>)` attribute.
-    pub fn mapped_name(self) -> Option<&'ast str> {
+    pub fn mapped_name(self) -> Option<&'db str> {
         self.attributes().mapped_name
     }
 
     /// The model that contains the field.
-    pub fn model(self) -> ModelWalker<'ast, 'db> {
+    pub fn model(self) -> ModelWalker<'db> {
         ModelWalker {
             model_id: self.model_id,
             db: self.db,
@@ -104,7 +104,7 @@ impl<'ast, 'db> ScalarFieldWalker<'ast, 'db> {
     /// (attribute scope, native type name, arguments, span)
     ///
     /// For example: `@db.Text` would translate to ("db", "Text", &[], <the span>)
-    pub fn raw_native_type(self) -> Option<(&'ast str, &'ast str, &'db [String], Span)> {
+    pub fn raw_native_type(self) -> Option<(&'db str, &'db str, &'db [String], Span)> {
         self.attributes()
             .native_type
             .as_ref()
@@ -117,7 +117,7 @@ impl<'ast, 'db> ScalarFieldWalker<'ast, 'db> {
     }
 
     /// The `@default()` attribute of the field, if any.
-    pub fn default_value(self) -> Option<DefaultValueWalker<'ast, 'db>> {
+    pub fn default_value(self) -> Option<DefaultValueWalker<'db>> {
         self.attributes().default.as_ref().map(|d| DefaultValueWalker {
             model_id: self.model_id,
             field_id: self.field_id,
@@ -155,16 +155,16 @@ impl<'ast, 'db> ScalarFieldWalker<'ast, 'db> {
 
 /// An `@default()` attribute on a field.
 #[derive(Clone, Copy)]
-pub struct DefaultValueWalker<'ast, 'db> {
+pub struct DefaultValueWalker<'db> {
     model_id: ast::ModelId,
     field_id: ast::FieldId,
-    db: &'db ParserDatabase<'ast>,
-    default: &'db DefaultAttribute<'ast>,
+    db: &'db ParserDatabase,
+    default: &'db DefaultAttribute,
 }
 
-impl<'ast, 'db> DefaultValueWalker<'ast, 'db> {
+impl<'db> DefaultValueWalker<'db> {
     /// The AST node of the attribute.
-    pub fn ast_attribute(self) -> &'ast ast::Attribute {
+    pub fn ast_attribute(self) -> &'db ast::Attribute {
         self.default.default_attribute
     }
 
@@ -174,7 +174,7 @@ impl<'ast, 'db> DefaultValueWalker<'ast, 'db> {
     /// score Int @default(0)
     ///                    ^
     /// ```
-    pub fn value(self) -> &'ast ast::Expression {
+    pub fn value(self) -> &'db ast::Expression {
         self.default.value
     }
 
@@ -210,7 +210,7 @@ impl<'ast, 'db> DefaultValueWalker<'ast, 'db> {
     /// name String @default("george", map: "name_default_to_george")
     ///                                     ^^^^^^^^^^^^^^^^^^^^^^^^
     /// ```
-    pub fn mapped_name(self) -> Option<&'ast str> {
+    pub fn mapped_name(self) -> Option<&'db str> {
         self.default.mapped_name
     }
 
@@ -220,7 +220,7 @@ impl<'ast, 'db> DefaultValueWalker<'ast, 'db> {
     /// name String @default("george")
     /// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     /// ```
-    pub fn field(self) -> ScalarFieldWalker<'ast, 'db> {
+    pub fn field(self) -> ScalarFieldWalker<'db> {
         ScalarFieldWalker {
             model_id: self.model_id,
             field_id: self.field_id,
@@ -232,14 +232,14 @@ impl<'ast, 'db> DefaultValueWalker<'ast, 'db> {
 
 /// A scalar field as referenced in a key specification (id, index or unique).
 #[derive(Copy, Clone)]
-pub struct ScalarFieldAttributeWalker<'ast, 'db> {
+pub struct ScalarFieldAttributeWalker<'db> {
     pub(crate) model_id: ast::ModelId,
     pub(crate) fields: &'db [FieldWithArgs],
-    pub(crate) db: &'db ParserDatabase<'ast>,
+    pub(crate) db: &'db ParserDatabase,
     pub(crate) field_arg_id: usize,
 }
 
-impl<'ast, 'db> ScalarFieldAttributeWalker<'ast, 'db> {
+impl<'db> ScalarFieldAttributeWalker<'db> {
     fn args(self) -> &'db FieldWithArgs {
         &self.fields[self.field_arg_id]
     }
@@ -267,7 +267,7 @@ impl<'ast, 'db> ScalarFieldAttributeWalker<'ast, 'db> {
     /// }
     ///
     /// ```
-    pub fn as_scalar_field(self) -> ScalarFieldWalker<'ast, 'db> {
+    pub fn as_scalar_field(self) -> ScalarFieldWalker<'db> {
         ScalarFieldWalker {
             model_id: self.model_id,
             field_id: self.args().field_id,

--- a/libs/datamodel/schema-ast/src/ast.rs
+++ b/libs/datamodel/schema-ast/src/ast.rs
@@ -15,7 +15,7 @@ mod top;
 mod traits;
 
 pub use argument::{Argument, ArgumentsList, EmptyArgument};
-pub use attribute::Attribute;
+pub use attribute::{Attribute, AttributeId};
 pub use comment::Comment;
 pub use composite_type::{CompositeType, CompositeTypeId};
 pub use config::ConfigBlockProperty;

--- a/libs/datamodel/schema-ast/src/ast/attribute.rs
+++ b/libs/datamodel/schema-ast/src/ast/attribute.rs
@@ -55,3 +55,41 @@ impl WithSpan for Attribute {
         &self.span
     }
 }
+
+/// An attribute (with @ or @@).
+#[derive(Debug, Clone, Copy)]
+pub enum AttributeId {
+    /// On a model
+    Model(super::ModelId, usize),
+    /// On a model field.
+    ModelField(super::ModelId, super::FieldId, usize),
+    /// Attributes in a type alias.
+    TypeAlias(super::AliasId, usize),
+    /// On a composite type field.
+    CompositeTypeField(super::CompositeTypeId, super::FieldId, usize),
+    /// On an enum
+    Enum(super::EnumId, usize),
+    /// On an enum value
+    EnumValue(super::EnumId, usize, usize),
+}
+
+impl std::ops::Index<AttributeId> for super::SchemaAst {
+    type Output = Attribute;
+
+    fn index(&self, index: AttributeId) -> &Self::Output {
+        match index {
+            AttributeId::ModelField(model_id, field_id, attribute_idx) => {
+                &self[model_id][field_id].attributes[attribute_idx]
+            }
+            AttributeId::TypeAlias(alias_id, attribute_idx) => &self[alias_id].attributes[attribute_idx],
+            AttributeId::CompositeTypeField(ctid, field_id, attribute_idx) => {
+                &self[ctid][field_id].attributes[attribute_idx]
+            }
+            AttributeId::Model(model_id, attribute_idx) => &self[model_id].attributes[attribute_idx],
+            AttributeId::Enum(enum_id, attribute_idx) => &self[enum_id].attributes[attribute_idx],
+            AttributeId::EnumValue(enum_id, enum_value_idx, attribute_idx) => {
+                &self[enum_id].values[enum_value_idx].attributes[attribute_idx]
+            }
+        }
+    }
+}

--- a/migration-engine/core/src/lib.rs
+++ b/migration-engine/core/src/lib.rs
@@ -36,7 +36,7 @@ fn parse_ast(schema: &str) -> CoreResult<SchemaAst> {
         .map_err(|err| CoreError::new_schema_parser_error(err.to_pretty_string("schema.prisma", schema)))
 }
 
-fn parse_schema<'ast>(schema: &str, ast: &'ast SchemaAst) -> CoreResult<ValidatedSchema<'ast>> {
+fn parse_schema<'a>(schema: &'a str, ast: &'a SchemaAst) -> CoreResult<ValidatedSchema<'a>> {
     datamodel::parse_schema_parserdb(schema, ast).map_err(CoreError::new_schema_parser_error)
 }
 


### PR DESCRIPTION
This commit does not convert _everything_, but shows how we can do it
without massive code changes.

The reasoning for AstString is that most strings we care about in the
parser are identifiers. These can't be escaped, so they can just be
stored as AST spans. For string _literals_ — between quotes — in the
PSL, escaping applies, so we need to normalize these. This will cause an
allocation. We use a regular allocated string for now, because there
aren't too many of these and they are copied at most a couple of times,
but since AstString is private, nothing prevents us from optimizing
further in the future if it becomes necessary.

Expected benefits:

- ParserDatabase<'ast> would become ParserDatabase
- Walker<'ast, 'db> would become Walker<'db>
- ParsedSchema<'ast> would become ParsedSchema
- The two-step parsing process where we have to parse the AST first,
  then the schema, turns into a one-step process.
- We can later transparently intern the allocated strings.