### PR TITLE
JSON-RPC equivalent of migration-engine-cli commands

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -36,11 +36,11 @@ jobs:
           command: build
           args: -p migration-connector --release --target=wasm32-unknown-unknown
 
-      - name: Build the migration-core crate
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: -p migration-core --release --target=wasm32-unknown-unknown --no-default-features
+      # - name: Build the migration-core crate
+      #   uses: actions-rs/cargo@v1
+      #   with:
+      #     command: build
+      #     args: -p migration-core --release --target=wasm32-unknown-unknown --no-default-features
 
       - name: Build the prisma-fmt crate
         uses: actions-rs/cargo@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,9 +108,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.51"
+version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44318e776df68115a881de9a8fd1b9e53368d7a4a5ce4cc48517da3393233a5e"
+checksum = "061a7acccaa286c011ddc30970520b98fa40e00c9d644633fb26b5fc63a265e3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -385,13 +385,13 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.14.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3993e6445baa160675931ec041a5e03ca84b9c6e32a056150d3aa2bdda0a1f45"
+checksum = "a28b32d32ca44b70c3e4acd7db1babf555fa026e385fb95f18028f88848b3c31"
 dependencies = [
  "encode_unicode",
- "lazy_static",
  "libc",
+ "once_cell",
  "terminal_size",
  "winapi",
 ]
@@ -444,12 +444,12 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.5",
+ "crossbeam-utils 0.8.6",
 ]
 
 [[package]]
@@ -476,9 +476,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+checksum = "cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120"
 dependencies = [
  "cfg-if 1.0.0",
  "lazy_static",
@@ -868,6 +868,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fastrand"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1088,9 +1097,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.9"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f072413d126e57991455e0a922b31e4c8ba7c2ffbebf6b78b4f8521397d65cd"
+checksum = "d9f1f717ddc7b2ba36df7e871fd88db79326551d3d6f1fc406fbfd28b582ff8e"
 dependencies = [
  "bytes",
  "fnv",
@@ -1199,13 +1208,13 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1323096b05d41827dadeaee54c9981958c0f94e670bc94ed80037d1a7b8b186b"
+checksum = "31f4c6746584866f0feabcc69893c5b51beef3831656a968ed7ae254cdc4fd03"
 dependencies = [
  "bytes",
  "fnv",
- "itoa",
+ "itoa 1.0.1",
 ]
 
 [[package]]
@@ -1246,7 +1255,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa",
+ "itoa 0.4.8",
  "pin-project-lite",
  "socket2 0.4.2",
  "tokio",
@@ -1317,17 +1326,16 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.8.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15226a375927344c78d39dc6b49e2d5562a5b0705e26a589093c6792e52eed8e"
+checksum = "da408b722765c64aad796c666b756aa1dda2a6c1b44f98797f2d8ea8f197746f"
 dependencies = [
  "console",
- "lazy_static",
+ "once_cell",
  "serde",
  "serde_json",
  "serde_yaml",
  "similar",
- "uuid",
 ]
 
 [[package]]
@@ -1436,6 +1444,12 @@ name = "itoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+
+[[package]]
+name = "itoa"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "js-sys"
@@ -1723,6 +1737,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sql-migration-connector",
+ "tokio",
  "tracing",
  "tracing-futures",
  "url",
@@ -1765,6 +1780,7 @@ dependencies = [
  "enumflags2",
  "expect-test",
  "indoc",
+ "jsonrpc-core",
  "migration-core",
  "once_cell",
  "pretty_assertions",
@@ -2769,12 +2785,14 @@ dependencies = [
 name = "qe-setup"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "connection-string",
  "datamodel",
  "enumflags2",
  "migration-core",
  "mongodb",
  "quaint",
+ "tempfile",
  "url",
 ]
 
@@ -3415,7 +3433,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
 dependencies = [
  "indexmap",
- "itoa",
+ "itoa 0.4.8",
  "ryu",
  "serde",
 ]
@@ -3473,7 +3491,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0bccbcf40c8938196944a3da0e133e031a33f4d6b72db3bda3cc556e361905d"
 dependencies = [
  "lazy_static",
- "parking_lot 0.10.2",
+ "parking_lot 0.11.2",
  "serial_test_derive",
 ]
 
@@ -3552,9 +3570,9 @@ dependencies = [
 
 [[package]]
 name = "similar"
-version = "1.3.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad1d488a557b235fc46dae55512ffbfc429d2482b08b4d9435ab07384ca8aec"
+checksum = "2e24979f63a11545f5f2c60141afe249d4f19f84581ea2138065e400941d83d3"
 
 [[package]]
 name = "siphasher"
@@ -3880,13 +3898,13 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
  "cfg-if 1.0.0",
+ "fastrand",
  "libc",
- "rand 0.8.4",
  "redox_syscall 0.2.10",
  "remove_dir_all",
  "winapi",
@@ -3907,6 +3925,7 @@ name = "test-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "colored",
  "datamodel",
  "enumflags2",
@@ -4047,7 +4066,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41effe7cfa8af36f439fac33861b66b049edc6f9a32331e2312660529c1c24ad"
 dependencies = [
- "itoa",
+ "itoa 0.4.8",
  "libc",
 ]
 
@@ -4111,9 +4130,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-io-timeout"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90c49f106be240de154571dd31fbe48acb10ba6c6dd6f6517ad603abffa42de9"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
 dependencies = [
  "pin-project-lite",
  "tokio",
@@ -4494,7 +4513,7 @@ version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f559b464de2e2bdabcac6a210d12e9b5a5973c251e102c44c585c71d51bd78e"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "rand 0.8.4",
  "static_assertions",
 ]
@@ -4758,9 +4777,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "4.2.2"
+version = "4.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea187a8ef279bc014ec368c27a920da2024d2a711109bfbe3440585d5cf27ad9"
+checksum = "2a5a7e487e921cf220206864a94a89b6c6905bfc19f1057fa26a4cb360e5c1d2"
 dependencies = [
  "either",
  "lazy_static",

--- a/libs/test-cli/Cargo.toml
+++ b/libs/test-cli/Cargo.toml
@@ -19,3 +19,4 @@ serde_json = { version = "1.0", features = ["float_roundtrip"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-error = "0.2"
+async-trait = "0.1.52"

--- a/libs/test-cli/src/diagnose_migration_history.rs
+++ b/libs/test-cli/src/diagnose_migration_history.rs
@@ -10,9 +10,9 @@ impl DiagnoseMigrationHistory {
         };
         let schema = crate::read_datamodel_from_file(&self.schema_path)?;
 
-        let engine = migration_core::migration_api(&schema)?;
+        let engine = migration_core::migration_api(Some(schema), None)?;
 
-        let output = engine.diagnose_migration_history(&input).await?;
+        let output = engine.diagnose_migration_history(input).await?;
 
         eprintln!("{:#?}", output);
 

--- a/migration-engine/cli/Cargo.toml
+++ b/migration-engine/cli/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dependencies]
 migration-connector = { path = "../connectors/migration-connector" }
-migration-core = { path = "../core", features = ["sql", "mongodb"] }
+migration-core = { path = "../core" }
 user-facing-errors = { path = "../../libs/user-facing-errors" }
 
 async-trait = "0.1.0"
@@ -28,11 +28,6 @@ connection-string = "0.1"
 
 [dev-dependencies.quaint]
 git = "https://github.com/prisma/quaint"
-
-[features]
-default = ["sql"]
-sql = ["migration-core/sql"]
-vendored-openssl = ["quaint/vendored-openssl"]
 
 [[bin]]
 name = "migration-engine"

--- a/migration-engine/connectors/migration-connector/src/lib.rs
+++ b/migration-engine/connectors/migration-connector/src/lib.rs
@@ -80,7 +80,7 @@ pub trait MigrationConnector: Send + Sync + 'static {
     async fn create_database(&self) -> ConnectorResult<String>;
 
     /// Send a command to the database directly.
-    async fn db_execute(&self, url: &str, script: &str) -> ConnectorResult<()>;
+    async fn db_execute(&self, url: String, script: String) -> ConnectorResult<()>;
 
     /// Create a migration by comparing two database schemas. See
     /// [DiffTarget](/enum.DiffTarget.html) for possible inputs.

--- a/migration-engine/connectors/mongodb-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/mongodb-migration-connector/src/lib.rs
@@ -95,7 +95,7 @@ impl MigrationConnector for MongoDbMigrationConnector {
         ))
     }
 
-    async fn db_execute(&self, _url: &str, _script: &str) -> ConnectorResult<()> {
+    async fn db_execute(&self, _url: String, _script: String) -> ConnectorResult<()> {
         Err(ConnectorError::from_msg(
             "dbExecute is not supported on MongoDB".to_owned(),
         ))

--- a/migration-engine/connectors/mongodb-migration-connector/src/migration_step_applier.rs
+++ b/migration-engine/connectors/mongodb-migration-connector/src/migration_step_applier.rs
@@ -65,7 +65,7 @@ impl DatabaseMigrationStepApplier for MongoDbMigrationConnector {
     }
 
     fn render_script(&self, _migration: &Migration, _diagnostics: &DestructiveChangeDiagnostics) -> String {
-        unreachable!()
+        panic!("rendering to a script is not supported on MongoDB");
     }
 
     async fn apply_script(&self, _migration_name: &str, _script: &str) -> ConnectorResult<()> {

--- a/migration-engine/connectors/sql-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/lib.rs
@@ -269,11 +269,11 @@ impl MigrationConnector for SqlMigrationConnector {
         self.flavour.create_database(&self.connection_string).await
     }
 
-    async fn db_execute(&self, url: &str, script: &str) -> ConnectorResult<()> {
+    async fn db_execute(&self, url: String, script: String) -> ConnectorResult<()> {
         if url == self.connection_string {
-            self.conn().await?.raw_cmd(script).await?;
+            self.conn().await?.raw_cmd(&script).await?;
         } else {
-            connect(url).await?.raw_cmd(script).await?;
+            connect(&url).await?.raw_cmd(&script).await?;
         };
         Ok(())
     }

--- a/migration-engine/core/Cargo.toml
+++ b/migration-engine/core/Cargo.toml
@@ -7,8 +7,8 @@ version = "0.1.0"
 [dependencies]
 datamodel = { path = "../../libs/datamodel/core" }
 migration-connector = { path = "../connectors/migration-connector" }
-mongodb-migration-connector = { path = "../connectors/mongodb-migration-connector", optional = true }
-sql-migration-connector = { path = "../connectors/sql-migration-connector", optional = true }
+mongodb-migration-connector = { path = "../connectors/mongodb-migration-connector" }
+sql-migration-connector = { path = "../connectors/sql-migration-connector" }
 user-facing-errors = { path = "../../libs/user-facing-errors" }
 
 async-trait = "0.1.17"
@@ -17,14 +17,10 @@ enumflags2 = "0.7.1"
 jsonrpc-core = "17.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["float_roundtrip"] }
+tokio = { version = "1.0", default_features = false }
 tracing = "0.1"
 tracing-futures = "0.2"
 url = "2.1.1"
 
 [build-dependencies]
 json-rpc-api-build = { path = "../json-rpc-api-build" }
-
-[features]
-default = ["sql"]
-mongodb = ["mongodb-migration-connector"]
-sql = ["sql-migration-connector"]

--- a/migration-engine/core/src/api.rs
+++ b/migration-engine/core/src/api.rs
@@ -1,18 +1,8 @@
 //! The external facing programmatic API to the migration engine.
 
-use crate::{
-    commands::*,
-    json_rpc::types::{
-        ApplyMigrationsInput, ApplyMigrationsOutput, CreateMigrationInput, CreateMigrationOutput,
-        DbExecuteDatasourceType, DbExecuteParams, DevDiagnosticInput, DevDiagnosticOutput, DiffParams, DiffResult,
-        EvaluateDataLossInput, EvaluateDataLossOutput, ListMigrationDirectoriesInput, ListMigrationDirectoriesOutput,
-        MarkMigrationAppliedInput, MarkMigrationAppliedOutput, MarkMigrationRolledBackInput,
-        MarkMigrationRolledBackOutput, SchemaContainer, SchemaPushInput, SchemaPushOutput, UrlContainer,
-    },
-    CoreResult,
-};
+use crate::{commands, json_rpc::types::*, CoreResult};
 use migration_connector::{migrations_directory, ConnectorError, MigrationConnector};
-use std::{path::Path, sync::Arc};
+use std::path::Path;
 use tracing_futures::Instrument;
 
 /// The programmatic, generic, fantastic migration engine API.
@@ -22,103 +12,95 @@ pub trait GenericApi: Send + Sync + 'static {
     async fn version(&self) -> CoreResult<String>;
 
     /// Apply all the unapplied migrations from the migrations folder.
-    async fn apply_migrations(&self, input: &ApplyMigrationsInput) -> CoreResult<ApplyMigrationsOutput>;
-
-    /// Access to the migration connector.
-    fn connector(&self) -> &dyn MigrationConnector;
+    async fn apply_migrations(&self, input: ApplyMigrationsInput) -> CoreResult<ApplyMigrationsOutput>;
 
     /// Create the database referenced by Prisma schema that was used to initialize the connector.
-    async fn create_database(&self) -> CoreResult<String>;
+    async fn create_database(&self, params: CreateDatabaseParams) -> CoreResult<CreateDatabaseResult>;
 
     /// Generate a new migration, based on the provided schema and existing migrations history.
-    async fn create_migration(&self, input: &CreateMigrationInput) -> CoreResult<CreateMigrationOutput>;
+    async fn create_migration(&self, input: CreateMigrationInput) -> CoreResult<CreateMigrationOutput>;
 
     /// Send a raw command to the database.
-    async fn db_execute(&self, params: &DbExecuteParams) -> CoreResult<()>;
+    async fn db_execute(&self, params: DbExecuteParams) -> CoreResult<()>;
 
     /// Debugging method that only panics, for CLI tests.
     async fn debug_panic(&self) -> CoreResult<()>;
 
     /// Tells the CLI what to do in `migrate dev`.
-    async fn dev_diagnostic(&self, input: &DevDiagnosticInput) -> CoreResult<DevDiagnosticOutput>;
+    async fn dev_diagnostic(&self, input: DevDiagnosticInput) -> CoreResult<DevDiagnosticOutput>;
 
     /// Create a migration between any two sources of database schemas.
-    async fn diff(&self, params: &DiffParams) -> CoreResult<DiffResult>;
+    async fn diff(&self, params: DiffParams) -> CoreResult<DiffResult>;
 
     /// Drop the database referenced by Prisma schema that was used to initialize the connector.
-    async fn drop_database(&self) -> CoreResult<()>;
+    async fn drop_database(&self, url: String) -> CoreResult<()>;
 
     /// Looks at the migrations folder and the database, and returns a bunch of useful information.
     async fn diagnose_migration_history(
         &self,
-        input: &DiagnoseMigrationHistoryInput,
-    ) -> CoreResult<DiagnoseMigrationHistoryOutput>;
+        input: commands::DiagnoseMigrationHistoryInput,
+    ) -> CoreResult<commands::DiagnoseMigrationHistoryOutput>;
 
     /// Make sure the connection to the database is established and valid.
     /// Connectors can choose to connect lazily, but this method should force
     /// them to connect.
-    async fn ensure_connection_validity(&self) -> CoreResult<()>;
+    async fn ensure_connection_validity(
+        &self,
+        params: EnsureConnectionValidityParams,
+    ) -> CoreResult<EnsureConnectionValidityResult>;
 
     /// Evaluate the consequences of running the next migration we would generate, given the current state of a Prisma schema.
-    async fn evaluate_data_loss(&self, input: &EvaluateDataLossInput) -> CoreResult<EvaluateDataLossOutput>;
+    async fn evaluate_data_loss(&self, input: EvaluateDataLossInput) -> CoreResult<EvaluateDataLossOutput>;
 
     /// List the migration directories.
     async fn list_migration_directories(
         &self,
-        input: &ListMigrationDirectoriesInput,
+        input: ListMigrationDirectoriesInput,
     ) -> CoreResult<ListMigrationDirectoriesOutput>;
 
     /// Mark a migration from the migrations folder as applied, without actually applying it.
-    async fn mark_migration_applied(&self, input: &MarkMigrationAppliedInput)
-        -> CoreResult<MarkMigrationAppliedOutput>;
+    async fn mark_migration_applied(&self, input: MarkMigrationAppliedInput) -> CoreResult<MarkMigrationAppliedOutput>;
 
     /// Mark a migration as rolled back.
     async fn mark_migration_rolled_back(
         &self,
-        input: &MarkMigrationRolledBackInput,
+        input: MarkMigrationRolledBackInput,
     ) -> CoreResult<MarkMigrationRolledBackOutput>;
 
     /// Reset a database to an empty state (no data, no schema).
     async fn reset(&self) -> CoreResult<()>;
 
     /// The command behind `prisma db push`.
-    async fn schema_push(&self, input: &SchemaPushInput) -> CoreResult<SchemaPushOutput>;
-
-    /// Set the `ConnectorHost` to use.
-    fn set_host(&mut self, host: Arc<dyn migration_connector::ConnectorHost>);
+    async fn schema_push(&self, input: SchemaPushInput) -> CoreResult<SchemaPushOutput>;
 }
 
 #[async_trait::async_trait]
 impl<C: MigrationConnector> GenericApi for C {
-    fn connector(&self) -> &dyn MigrationConnector {
-        self
-    }
-
     async fn version(&self) -> CoreResult<String> {
         Ok(self.version().await?)
     }
 
-    async fn apply_migrations(&self, input: &ApplyMigrationsInput) -> CoreResult<ApplyMigrationsOutput> {
-        apply_migrations(input, self)
+    async fn apply_migrations(&self, input: ApplyMigrationsInput) -> CoreResult<ApplyMigrationsOutput> {
+        commands::apply_migrations(input, self)
             .instrument(tracing::info_span!("ApplyMigrations"))
             .await
     }
 
-    async fn create_database(&self) -> CoreResult<String> {
-        MigrationConnector::create_database(self).await
+    async fn create_database(&self, _params: CreateDatabaseParams) -> CoreResult<CreateDatabaseResult> {
+        let database_name = MigrationConnector::create_database(self).await?;
+        Ok(CreateDatabaseResult { database_name })
     }
 
-    async fn create_migration(&self, input: &CreateMigrationInput) -> CoreResult<CreateMigrationOutput> {
-        create_migration(input, self)
-            .instrument(tracing::info_span!(
-                "CreateMigration",
-                migration_name = input.migration_name.as_str(),
-                draft = input.draft,
-            ))
-            .await
+    async fn create_migration(&self, input: CreateMigrationInput) -> CoreResult<CreateMigrationOutput> {
+        let span = tracing::info_span!(
+            "CreateMigration",
+            migration_name = input.migration_name.as_str(),
+            draft = input.draft,
+        );
+        commands::create_migration(input, self).instrument(span).await
     }
 
-    async fn db_execute(&self, params: &DbExecuteParams) -> CoreResult<()> {
+    async fn db_execute(&self, params: DbExecuteParams) -> CoreResult<()> {
         use std::io::Read;
 
         let url = match &params.datasource_type {
@@ -134,49 +116,53 @@ impl<C: MigrationConnector> GenericApi for C {
                 url
             }
         };
-        self.db_execute(&url, &params.script).await
+        self.db_execute(url, params.script).await
     }
 
     async fn debug_panic(&self) -> CoreResult<()> {
         panic!("This is the debugPanic artificial panic")
     }
 
-    async fn dev_diagnostic(&self, input: &DevDiagnosticInput) -> CoreResult<DevDiagnosticOutput> {
-        dev_diagnostic(input, self)
+    async fn dev_diagnostic(&self, input: DevDiagnosticInput) -> CoreResult<DevDiagnosticOutput> {
+        commands::dev_diagnostic(input, self)
             .instrument(tracing::info_span!("DevDiagnostic"))
             .await
     }
 
     async fn diagnose_migration_history(
         &self,
-        input: &DiagnoseMigrationHistoryInput,
-    ) -> CoreResult<DiagnoseMigrationHistoryOutput> {
-        diagnose_migration_history(input, self)
+        input: commands::DiagnoseMigrationHistoryInput,
+    ) -> CoreResult<commands::DiagnoseMigrationHistoryOutput> {
+        commands::diagnose_migration_history(input, self)
             .instrument(tracing::info_span!("DiagnoseMigrationHistory"))
             .await
     }
 
-    async fn diff(&self, params: &DiffParams) -> CoreResult<DiffResult> {
-        crate::commands::diff(params, self).await
+    async fn diff(&self, params: DiffParams) -> CoreResult<DiffResult> {
+        commands::diff(params, self.host().clone()).await
     }
 
-    async fn drop_database(&self) -> CoreResult<()> {
+    async fn drop_database(&self, _url: String) -> CoreResult<()> {
         MigrationConnector::drop_database(self).await
     }
 
-    async fn ensure_connection_validity(&self) -> CoreResult<()> {
-        MigrationConnector::ensure_connection_validity(self).await
+    async fn ensure_connection_validity(
+        &self,
+        _params: EnsureConnectionValidityParams,
+    ) -> CoreResult<EnsureConnectionValidityResult> {
+        MigrationConnector::ensure_connection_validity(self).await?;
+        Ok(EnsureConnectionValidityResult {})
     }
 
-    async fn evaluate_data_loss(&self, input: &EvaluateDataLossInput) -> CoreResult<EvaluateDataLossOutput> {
-        evaluate_data_loss(input, self)
+    async fn evaluate_data_loss(&self, input: EvaluateDataLossInput) -> CoreResult<EvaluateDataLossOutput> {
+        commands::evaluate_data_loss(input, self)
             .instrument(tracing::info_span!("EvaluateDataLoss"))
             .await
     }
 
     async fn list_migration_directories(
         &self,
-        input: &ListMigrationDirectoriesInput,
+        input: ListMigrationDirectoriesInput,
     ) -> CoreResult<ListMigrationDirectoriesOutput> {
         let migrations_from_filesystem =
             migrations_directory::list_migrations(Path::new(&input.migrations_directory_path))?;
@@ -189,28 +175,20 @@ impl<C: MigrationConnector> GenericApi for C {
         Ok(ListMigrationDirectoriesOutput { migrations })
     }
 
-    async fn mark_migration_applied(
-        &self,
-        input: &MarkMigrationAppliedInput,
-    ) -> CoreResult<MarkMigrationAppliedOutput> {
-        mark_migration_applied(input, self)
-            .instrument(tracing::info_span!(
-                "MarkMigrationApplied",
-                migration_name = input.migration_name.as_str()
-            ))
-            .await
+    async fn mark_migration_applied(&self, input: MarkMigrationAppliedInput) -> CoreResult<MarkMigrationAppliedOutput> {
+        let span = tracing::info_span!("MarkMigrationApplied", migration_name = input.migration_name.as_str());
+        commands::mark_migration_applied(input, self).instrument(span).await
     }
 
     async fn mark_migration_rolled_back(
         &self,
-        input: &MarkMigrationRolledBackInput,
+        input: MarkMigrationRolledBackInput,
     ) -> CoreResult<MarkMigrationRolledBackOutput> {
-        mark_migration_rolled_back(input, self)
-            .instrument(tracing::info_span!(
-                "MarkMigrationRolledBack",
-                migration_name = input.migration_name.as_str()
-            ))
-            .await
+        let span = tracing::info_span!(
+            "MarkMigrationRolledBack",
+            migration_name = input.migration_name.as_str()
+        );
+        commands::mark_migration_rolled_back(input, self).instrument(span).await
     }
 
     async fn reset(&self) -> CoreResult<()> {
@@ -221,13 +199,9 @@ impl<C: MigrationConnector> GenericApi for C {
             .await?)
     }
 
-    async fn schema_push(&self, input: &SchemaPushInput) -> CoreResult<SchemaPushOutput> {
-        schema_push(input, self)
+    async fn schema_push(&self, input: SchemaPushInput) -> CoreResult<SchemaPushOutput> {
+        commands::schema_push(input, self)
             .instrument(tracing::info_span!("SchemaPush"))
             .await
-    }
-
-    fn set_host(&mut self, host: Arc<dyn migration_connector::ConnectorHost>) {
-        MigrationConnector::set_host(self, host)
     }
 }

--- a/migration-engine/core/src/commands/apply_migrations.rs
+++ b/migration-engine/core/src/commands/apply_migrations.rs
@@ -1,18 +1,15 @@
 use crate::{json_rpc::types::*, CoreError, CoreResult};
 use migration_connector::{
     migrations_directory::{error_on_changed_provider, list_migrations, MigrationDirectory},
-    ConnectorError, MigrationRecord, PersistenceNotInitializedError,
+    ConnectorError, MigrationConnector, MigrationRecord, PersistenceNotInitializedError,
 };
 use std::{path::Path, time::Instant};
 use user_facing_errors::migration_engine::FoundFailedMigrations;
 
-pub(crate) async fn apply_migrations<C>(
-    input: &ApplyMigrationsInput,
-    connector: &C,
-) -> CoreResult<ApplyMigrationsOutput>
-where
-    C: migration_connector::MigrationConnector,
-{
+pub(crate) async fn apply_migrations(
+    input: ApplyMigrationsInput,
+    connector: &dyn MigrationConnector,
+) -> CoreResult<ApplyMigrationsOutput> {
     let start = Instant::now();
     let applier = connector.database_migration_step_applier();
     let migration_persistence = connector.migration_persistence();

--- a/migration-engine/core/src/commands/create_migration.rs
+++ b/migration-engine/core/src/commands/create_migration.rs
@@ -5,7 +5,7 @@ use user_facing_errors::migration_engine::MigrationNameTooLong;
 
 /// Create a new migration.
 pub async fn create_migration(
-    input: &CreateMigrationInput,
+    input: CreateMigrationInput,
     connector: &dyn MigrationConnector,
 ) -> CoreResult<CreateMigrationOutput> {
     let applier = connector.database_migration_step_applier();

--- a/migration-engine/core/src/commands/dev_diagnostic.rs
+++ b/migration-engine/core/src/commands/dev_diagnostic.rs
@@ -8,7 +8,7 @@ use migration_connector::{migrations_directory, ConnectorResult, MigrationConnec
 /// Method called at the beginning of `migrate dev` to decide the course of
 /// action based on the current state of the workspace.
 pub(crate) async fn dev_diagnostic(
-    input: &DevDiagnosticInput,
+    input: DevDiagnosticInput,
     connector: &dyn MigrationConnector,
 ) -> ConnectorResult<DevDiagnosticOutput> {
     migrations_directory::error_on_changed_provider(&input.migrations_directory_path, connector.connector_type())?;
@@ -18,7 +18,7 @@ pub(crate) async fn dev_diagnostic(
         opt_in_to_shadow_database: true,
     };
 
-    let diagnose_migration_history_output = diagnose_migration_history(&diagnose_input, connector).await?;
+    let diagnose_migration_history_output = diagnose_migration_history(diagnose_input, connector).await?;
 
     check_for_broken_migrations(&diagnose_migration_history_output)?;
 

--- a/migration-engine/core/src/commands/diagnose_migration_history.rs
+++ b/migration-engine/core/src/commands/diagnose_migration_history.rs
@@ -64,7 +64,7 @@ impl DiagnoseMigrationHistoryOutput {
 /// returns their relative statuses. At this stage, the migration engine only
 /// reads, it does not write to the dev database nor the migrations directory.
 pub(crate) async fn diagnose_migration_history(
-    input: &DiagnoseMigrationHistoryInput,
+    input: DiagnoseMigrationHistoryInput,
     connector: &dyn MigrationConnector,
 ) -> CoreResult<DiagnoseMigrationHistoryOutput> {
     let migration_persistence = connector.migration_persistence();

--- a/migration-engine/core/src/commands/diff.rs
+++ b/migration-engine/core/src/commands/diff.rs
@@ -2,20 +2,18 @@ use crate::{
     core_error::CoreResult,
     json_rpc::types::{DiffParams, DiffResult, DiffTarget, PathContainer, SchemaContainer, UrlContainer},
 };
-use migration_connector::{ConnectorError, DiffTarget as McDiff};
-use std::path::Path;
+use enumflags2::BitFlags;
+use migration_connector::{ConnectorError, ConnectorHost, DiffTarget as McDiff, MigrationConnector};
+use std::{path::Path, sync::Arc};
 
-pub(crate) async fn diff(
-    params: &DiffParams,
-    ambient_connector: &dyn migration_connector::MigrationConnector,
-) -> CoreResult<DiffResult> {
+pub(crate) async fn diff(params: DiffParams, host: Arc<dyn ConnectorHost>) -> CoreResult<DiffResult> {
     let mut from =
         json_rpc_diff_target_to_migration_connector_diff_target(&params.from, params.shadow_database_url.as_deref())?;
     let mut to =
         json_rpc_diff_target_to_migration_connector_diff_target(&params.to, params.shadow_database_url.as_deref())?;
 
     for connector in [from.connector.as_mut(), to.connector.as_mut()].into_iter().flatten() {
-        connector.set_host(ambient_connector.host().clone());
+        connector.set_host(host.clone());
     }
 
     // The `from` connector takes precedence, because if we think of diffs as migrations, `from` is
@@ -23,13 +21,11 @@ pub(crate) async fn diff(
     //
     // TODO: make sure the shadow_database_url param is _always_ taken into account.
     // TODO: make sure the connectors are the same in from and to.
-    let connector_from_targets = from
+    let connector = from
         .connector
         .as_ref()
         .or_else(|| to.connector.as_ref())
-        .map(|api| api.connector());
-
-    let connector = connector_from_targets.unwrap_or(ambient_connector); // fall back to the one the ME was initialized with
+        .ok_or_else(|| ConnectorError::from_msg("Could not determine the connector to use for diffing.".to_owned()))?;
 
     let migration: migration_connector::Migration = connector.diff(from.target, to.target).await?;
 
@@ -50,7 +46,7 @@ pub(crate) async fn diff(
 struct RefinedDiffTarget {
     target: McDiff<'static>,
     /// `None` in case the target is Empty.
-    connector: Option<Box<dyn crate::GenericApi>>,
+    connector: Option<Box<dyn MigrationConnector>>,
 }
 
 // -> CoreResult<(DiffTarget, Option<connector>)> ?
@@ -67,7 +63,7 @@ fn json_rpc_diff_target_to_migration_connector_diff_target(
             let schema_contents = std::fs::read_to_string(&schema)
                 .map_err(|err| ConnectorError::from_source(err, "Reading Prisma schema file."))?;
             let (_, url, _, _) = crate::parse_configuration(&schema_contents)?;
-            let api = crate::migration_api(&schema_contents)?;
+            let api = crate::schema_to_connector(&schema_contents)?;
             Ok(RefinedDiffTarget {
                 connector: Some(api),
                 target: McDiff::Database(url.into()),
@@ -77,15 +73,14 @@ fn json_rpc_diff_target_to_migration_connector_diff_target(
             let schema_contents = std::fs::read_to_string(&schema)
                 .map_err(|err| ConnectorError::from_source(err, "Reading Prisma schema file."))?;
             Ok(RefinedDiffTarget {
-                connector: Some(crate::migration_api(&schema_contents)?),
+                connector: Some(crate::schema_to_connector(&schema_contents)?),
                 target: McDiff::Datamodel(schema_contents.into()),
             })
         }
         DiffTarget::Url(UrlContainer { url }) => {
-            let schema_contents = crate::datasource_from_database_str(url)?;
-            let api = crate::migration_api(&schema_contents)?;
+            let connector = crate::connector_for_connection_string(url.clone(), None, BitFlags::empty())?;
             Ok(RefinedDiffTarget {
-                connector: Some(api),
+                connector: Some(connector),
                 target: McDiff::Database(url.to_owned().into()),
             })
         }
@@ -97,7 +92,7 @@ fn json_rpc_diff_target_to_migration_connector_diff_target(
                         .map(|sdurl| format!("shadowDatabaseUrl = \"{sdurl}\"", sdurl = sdurl.replace('\\', "\\\\")))
                         .unwrap_or_else(String::new);
 
-                    Some(crate::migration_api(&format!(
+                    Some(crate::schema_to_connector(&format!(
                         r#"
                             datasource db {{
                                 provider = "{provider}"
@@ -118,7 +113,7 @@ fn json_rpc_diff_target_to_migration_connector_diff_target(
                     "Could not determine the connector from the migrations directory (missing migrations_lock.toml)."
                         .to_owned(),
                 )),
-                _ => None,
+                _ => unreachable!("no provider, no shadow database url for migrations target"),
             };
             let directories = migration_connector::migrations_directory::list_migrations(Path::new(path))?;
             Ok(RefinedDiffTarget {

--- a/migration-engine/core/src/commands/evaluate_data_loss.rs
+++ b/migration-engine/core/src/commands/evaluate_data_loss.rs
@@ -7,7 +7,7 @@ use migration_connector::{migrations_directory::*, DiffTarget, MigrationConnecto
 /// At this stage, the engine does not create or mutate anything in the database
 /// nor in the migrations directory.
 pub(crate) async fn evaluate_data_loss(
-    input: &EvaluateDataLossInput,
+    input: EvaluateDataLossInput,
     connector: &dyn MigrationConnector,
 ) -> CoreResult<EvaluateDataLossOutput> {
     let checker = connector.destructive_change_checker();

--- a/migration-engine/core/src/commands/mark_migration_applied.rs
+++ b/migration-engine/core/src/commands/mark_migration_applied.rs
@@ -8,7 +8,7 @@ use user_facing_errors::migration_engine::{MigrationAlreadyApplied, MigrationToM
 
 /// Mark a migration as applied.
 pub async fn mark_migration_applied(
-    input: &MarkMigrationAppliedInput,
+    input: MarkMigrationAppliedInput,
     connector: &dyn MigrationConnector,
 ) -> CoreResult<MarkMigrationAppliedOutput> {
     let persistence = connector.migration_persistence();

--- a/migration-engine/core/src/commands/mark_migration_rolled_back.rs
+++ b/migration-engine/core/src/commands/mark_migration_rolled_back.rs
@@ -4,7 +4,7 @@ use user_facing_errors::migration_engine::{CannotRollBackSucceededMigration, Can
 
 /// Mark a migration as rolled back.
 pub(crate) async fn mark_migration_rolled_back(
-    input: &MarkMigrationRolledBackInput,
+    input: MarkMigrationRolledBackInput,
     connector: &dyn MigrationConnector,
 ) -> CoreResult<MarkMigrationRolledBackOutput> {
     let persistence = connector.migration_persistence();

--- a/migration-engine/core/src/commands/schema_push.rs
+++ b/migration-engine/core/src/commands/schema_push.rs
@@ -5,7 +5,7 @@ use migration_connector::{ConnectorError, DiffTarget, MigrationConnector};
 /// interacting with the migrations directory nor the migrations table.
 
 pub(crate) async fn schema_push(
-    input: &SchemaPushInput,
+    input: SchemaPushInput,
     connector: &dyn MigrationConnector,
 ) -> CoreResult<SchemaPushOutput> {
     let ast = crate::parse_ast(&input.schema)?;

--- a/migration-engine/core/src/lib.rs
+++ b/migration-engine/core/src/lib.rs
@@ -10,24 +10,26 @@ pub mod commands;
 mod api;
 mod core_error;
 mod rpc;
+mod state;
 
 pub use self::{api::GenericApi, core_error::*, rpc::rpc_api};
-
-pub use core_error::*;
 pub use migration_connector;
 
 use datamodel::{
     common::{
         preview_features::PreviewFeature,
-        provider_names::{MSSQL_SOURCE_NAME, MYSQL_SOURCE_NAME, POSTGRES_SOURCE_NAME, SQLITE_SOURCE_NAME},
+        provider_names::{
+            MONGODB_SOURCE_NAME, MSSQL_SOURCE_NAME, MYSQL_SOURCE_NAME, POSTGRES_SOURCE_NAME, SQLITE_SOURCE_NAME,
+        },
     },
     Datasource,
 };
+use datamodel::{schema_ast::ast::SchemaAst, ValidatedSchema};
 use enumflags2::BitFlags;
+use mongodb_migration_connector::MongoDbMigrationConnector;
+use sql_migration_connector::SqlMigrationConnector;
 use std::env;
 use user_facing_errors::{common::InvalidConnectionString, KnownError};
-
-use datamodel::{schema_ast::ast::SchemaAst, ValidatedSchema};
 
 fn parse_ast(schema: &str) -> CoreResult<SchemaAst> {
     datamodel::parse_schema_ast(schema)
@@ -38,62 +40,69 @@ fn parse_schema<'ast>(schema: &str, ast: &'ast SchemaAst) -> CoreResult<Validate
     datamodel::parse_schema_parserdb(schema, ast).map_err(CoreError::new_schema_parser_error)
 }
 
-#[cfg(feature = "mongodb")]
-use datamodel::common::provider_names::MONGODB_SOURCE_NAME;
-#[cfg(feature = "mongodb")]
-use mongodb_migration_connector::MongoDbMigrationConnector;
-#[cfg(feature = "sql")]
-use sql_migration_connector::SqlMigrationConnector;
+fn connector_for_connection_string(
+    connection_string: String,
+    shadow_database_connection_string: Option<String>,
+    preview_features: BitFlags<PreviewFeature>,
+) -> CoreResult<Box<dyn migration_connector::MigrationConnector>> {
+    match connection_string.split(':').next() {
+        Some("postgres") | Some("postgresql") => {
+            let url = disable_postgres_statement_cache(&connection_string)?;
+            let connector = SqlMigrationConnector::new(url, preview_features, shadow_database_connection_string)?;
+            Ok(Box::new(connector))
+        }
+        Some("file") | Some("mysql") | Some("sqlserver") => {
+            let connector =
+                SqlMigrationConnector::new(connection_string, preview_features, shadow_database_connection_string)?;
+            Ok(Box::new(connector))
+        }
+        Some("mongodb+srv") | Some("mongodb") => {
+            let connector = MongoDbMigrationConnector::new(connection_string, preview_features);
+            Ok(Box::new(connector))
+        }
+        Some(other) => Err(CoreError::url_parse_error(format!(
+            "`{other}` is not a known connection URL scheme. Prisma cannot determine the connector."
+        ))),
+        None => Err(CoreError::user_facing(InvalidConnectionString {
+            details: String::new(),
+        })),
+    }
+}
 
-/// Top-level constructor for the migration engine API.
-pub fn migration_api(datamodel: &str) -> CoreResult<Box<dyn api::GenericApi>> {
+/// Go from a schema to a connector
+fn schema_to_connector(datamodel: &str) -> CoreResult<Box<dyn migration_connector::MigrationConnector>> {
     let (source, url, preview_features, shadow_database_url) = parse_configuration(datamodel)?;
 
     match source.active_provider.as_str() {
-        #[cfg(feature = "sql")]
         POSTGRES_SOURCE_NAME => {
-            let mut u = url::Url::parse(&url).map_err(|err| {
-                let details = user_facing_errors::quaint::invalid_connection_string_description(&format!(
-                    "Error parsing connection string: {}",
-                    err
-                ));
-
-                CoreError::from(KnownError::new(InvalidConnectionString { details }))
-            })?;
-
-            let params: Vec<(String, String)> = u.query_pairs().map(|(k, v)| (k.to_string(), v.to_string())).collect();
-
-            u.query_pairs_mut().clear();
-
-            for (k, v) in params.into_iter() {
-                if k == "statement_cache_size" {
-                    u.query_pairs_mut().append_pair("statement_cache_size", "0");
-                } else {
-                    u.query_pairs_mut().append_pair(&k, &v);
-                }
-            }
-
-            if !u.query_pairs().any(|(k, _)| k == "statement_cache_size") {
-                u.query_pairs_mut().append_pair("statement_cache_size", "0");
-            }
-
-            let connector = SqlMigrationConnector::new(u.to_string(), preview_features, shadow_database_url)?;
-
+            let url = disable_postgres_statement_cache(&url)?;
+            let connector = SqlMigrationConnector::new(url, preview_features, shadow_database_url)?;
             Ok(Box::new(connector))
         }
-        #[cfg(feature = "sql")]
         MYSQL_SOURCE_NAME | SQLITE_SOURCE_NAME | MSSQL_SOURCE_NAME => {
             let connector = SqlMigrationConnector::new(url, preview_features, shadow_database_url)?;
-
             Ok(Box::new(connector))
         }
-        #[cfg(feature = "mongodb")]
         MONGODB_SOURCE_NAME => Ok(Box::new(MongoDbMigrationConnector::new(url, preview_features))),
         provider => Err(CoreError::from_msg(format!(
             "`{}` is not a supported connector.",
             provider
         ))),
     }
+}
+
+/// Top-level constructor for the migration engine API.
+pub fn migration_api(
+    datamodel: Option<String>,
+    host: Option<std::sync::Arc<dyn migration_connector::ConnectorHost>>,
+) -> CoreResult<Box<dyn api::GenericApi>> {
+    // Eagerly load the default schema, for validation errors.
+    if let Some(datamodel) = &datamodel {
+        parse_configuration(datamodel)?;
+    }
+
+    let state = state::EngineState::new(datamodel, host);
+    Ok(Box::new(state))
 }
 
 fn parse_configuration(datamodel: &str) -> CoreResult<(Datasource, String, BitFlags<PreviewFeature>, Option<String>)> {
@@ -120,34 +129,31 @@ fn parse_configuration(datamodel: &str) -> CoreResult<(Datasource, String, BitFl
     Ok((source, url, preview_features, shadow_database_url))
 }
 
-/// This is a hack. Please do not rely on this. It will disappear some day.
-pub fn datasource_from_database_str(database_str: &str) -> CoreResult<String> {
-    let provider = match database_str.split(':').next() {
-        Some("postgres") => "postgresql",
-        Some("file") => "sqlite",
-        Some("mongodb+srv") => "mongodb",
-        Some(other) => other,
-        None => {
-            return Err(CoreError::user_facing(InvalidConnectionString {
-                details: String::new(),
-            }))
+fn disable_postgres_statement_cache(url: &str) -> CoreResult<String> {
+    let mut u = url::Url::parse(url).map_err(|err| {
+        let details = user_facing_errors::quaint::invalid_connection_string_description(&format!(
+            "Error parsing connection string: {}",
+            err
+        ));
+
+        CoreError::from(KnownError::new(InvalidConnectionString { details }))
+    })?;
+
+    let params: Vec<(String, String)> = u.query_pairs().map(|(k, v)| (k.to_string(), v.to_string())).collect();
+
+    u.query_pairs_mut().clear();
+
+    for (k, v) in params.into_iter() {
+        if k == "statement_cache_size" {
+            u.query_pairs_mut().append_pair("statement_cache_size", "0");
+        } else {
+            u.query_pairs_mut().append_pair(&k, &v);
         }
-    };
+    }
 
-    let url = if provider == "sqlite" {
-        database_str.replace('\\', "\\\\")
-    } else {
-        database_str.to_owned()
-    };
+    if !u.query_pairs().any(|(k, _)| k == "statement_cache_size") {
+        u.query_pairs_mut().append_pair("statement_cache_size", "0");
+    }
 
-    let schema = format!(
-        r#"
-            datasource db {{
-                provider = "{provider}"
-                url = "{url}"
-            }}
-        "#,
-    );
-
-    Ok(schema)
+    Ok(u.to_string())
 }

--- a/migration-engine/core/src/state.rs
+++ b/migration-engine/core/src/state.rs
@@ -1,0 +1,278 @@
+//! A container to manage 0 or more migration connectors, based on request contents.
+//!
+//! Why: we must be able to use the migration engine without a valid schema or database connection
+//! for commands like createDatabase and diff.
+
+use crate::{api::GenericApi, commands, json_rpc::types::*, CoreResult};
+use enumflags2::BitFlag;
+use migration_connector::{ConnectorError, ConnectorHost, MigrationConnector};
+use std::{collections::HashMap, future::Future, path::Path, pin::Pin, sync::Arc};
+use tokio::sync::Mutex;
+use tracing_futures::Instrument;
+
+/// The container for the state of the migration engine. It can contain one or more connectors.
+pub(crate) struct EngineState {
+    initial_datamodel: Option<String>,
+    host: Arc<dyn ConnectorHost>,
+    // A map from either:
+    //
+    // - a connection string / url
+    // - a full schema
+    //
+    // To a MigrationConnector.
+    connectors: Mutex<HashMap<String, Box<dyn MigrationConnector>>>,
+}
+
+impl EngineState {
+    pub(crate) fn new(initial_datamodel: Option<String>, host: Option<Arc<dyn ConnectorHost>>) -> Self {
+        EngineState {
+            initial_datamodel,
+            host: host.unwrap_or_else(|| Arc::new(migration_connector::EmptyHost)),
+            connectors: Default::default(),
+        }
+    }
+
+    async fn with_connector_from_schema_path<O>(
+        &self,
+        path: &str,
+        f: impl for<'c> FnOnce(&'c dyn MigrationConnector) -> Pin<Box<dyn Future<Output = CoreResult<O>> + Send + 'c>>,
+    ) -> CoreResult<O> {
+        let schema = std::fs::read_to_string(path)
+            .map_err(|err| ConnectorError::from_source(err, "Falied to read Prisma schema."))?;
+        self.with_connector_for_schema(&schema, f).await
+    }
+
+    async fn with_connector_for_schema<O>(
+        &self,
+        schema: &str,
+        f: impl for<'c> FnOnce(&'c dyn MigrationConnector) -> Pin<Box<dyn Future<Output = CoreResult<O>> + Send + 'c>>,
+    ) -> CoreResult<O> {
+        let mut connectors = self.connectors.lock().await;
+
+        match connectors.get(schema) {
+            Some(connector) => f(connector.as_ref()).await,
+            None => {
+                let mut connector = crate::schema_to_connector(schema)?;
+                connector.set_host(self.host.clone());
+                let output = f(connector.as_ref()).await?;
+                connectors.insert(schema.to_owned(), connector);
+                Ok(output)
+            }
+        }
+    }
+
+    async fn with_connector_for_url<O>(
+        &self,
+        url: String,
+        f: impl for<'c> FnOnce(&'c dyn MigrationConnector) -> Pin<Box<dyn Future<Output = CoreResult<O>> + Send + 'c>>,
+    ) -> CoreResult<O> {
+        let mut connectors = self.connectors.lock().await;
+
+        match connectors.get(&url) {
+            Some(connector) => f(connector.as_ref()).await,
+            None => {
+                let mut connector = crate::connector_for_connection_string(url.clone(), None, BitFlag::empty())?;
+                connector.set_host(self.host.clone());
+                let output = f(connector.as_ref()).await?;
+                connectors.insert(url, connector);
+                Ok(output)
+            }
+        }
+    }
+
+    async fn with_connector_from_datasource_param<O>(
+        &self,
+        param: &DatasourceParam,
+        f: impl for<'c> FnOnce(&'c dyn MigrationConnector) -> Pin<Box<dyn Future<Output = CoreResult<O>> + Send + 'c>>,
+    ) -> CoreResult<O> {
+        match param {
+            DatasourceParam::ConnectionString(UrlContainer { url }) => {
+                self.with_connector_for_url(url.clone(), f).await
+            }
+            DatasourceParam::SchemaPath(PathContainer { path }) => self.with_connector_from_schema_path(path, f).await,
+            DatasourceParam::SchemaString(SchemaContainer { schema }) => {
+                self.with_connector_for_schema(schema, f).await
+            }
+        }
+    }
+
+    async fn with_default_connector<O>(
+        &self,
+        f: impl for<'c> FnOnce(&'c dyn MigrationConnector) -> Pin<Box<dyn Future<Output = CoreResult<O>> + Send + 'c>>,
+    ) -> CoreResult<O>
+    where
+        O: Sized + 'static,
+    {
+        let schema = if let Some(initial_datamodel) = &self.initial_datamodel {
+            initial_datamodel
+        } else {
+            return Err(ConnectorError::from_msg("Missing --datamodel".to_owned()));
+        };
+
+        self.with_connector_for_schema(schema, f).await
+    }
+}
+
+#[async_trait::async_trait]
+impl GenericApi for EngineState {
+    async fn version(&self) -> CoreResult<String> {
+        self.with_default_connector(move |connector| connector.version()).await
+    }
+
+    async fn apply_migrations(&self, input: ApplyMigrationsInput) -> CoreResult<ApplyMigrationsOutput> {
+        self.with_default_connector(move |connector| {
+            Box::pin(commands::apply_migrations(input, connector).instrument(tracing::info_span!("ApplyMigrations")))
+        })
+        .await
+    }
+
+    async fn create_database(&self, params: CreateDatabaseParams) -> CoreResult<CreateDatabaseResult> {
+        self.with_connector_from_datasource_param(&params.datasource, |connector| {
+            Box::pin(async move {
+                let database_name = MigrationConnector::create_database(connector).await?;
+                Ok(CreateDatabaseResult { database_name })
+            })
+        })
+        .await
+    }
+
+    async fn create_migration(&self, input: CreateMigrationInput) -> CoreResult<CreateMigrationOutput> {
+        self.with_default_connector(move |connector| {
+            let span = tracing::info_span!(
+                "CreateMigration",
+                migration_name = input.migration_name.as_str(),
+                draft = input.draft,
+            );
+            Box::pin(commands::create_migration(input, connector).instrument(span))
+        })
+        .await
+    }
+
+    async fn db_execute(&self, params: DbExecuteParams) -> CoreResult<()> {
+        use std::io::Read;
+
+        let url = match &params.datasource_type {
+            DbExecuteDatasourceType::Url(UrlContainer { url }) => url.to_owned(),
+            DbExecuteDatasourceType::Schema(SchemaContainer { schema: file_path }) => {
+                let mut schema_file = std::fs::File::open(&file_path)
+                    .map_err(|err| ConnectorError::from_source(err, "Opening Prisma schema file."))?;
+                let mut schema_string = String::new();
+                schema_file
+                    .read_to_string(&mut schema_string)
+                    .map_err(|err| ConnectorError::from_source(err, "Reading Prisma schema file."))?;
+                let (_, url, _, _) = crate::parse_configuration(&schema_string)?;
+                url
+            }
+        };
+
+        self.with_connector_for_url(url.clone(), move |connector| connector.db_execute(url, params.script))
+            .await
+    }
+
+    async fn debug_panic(&self) -> CoreResult<()> {
+        panic!("This is the debugPanic artificial panic")
+    }
+
+    async fn dev_diagnostic(&self, input: DevDiagnosticInput) -> CoreResult<DevDiagnosticOutput> {
+        self.with_default_connector(|connector| {
+            Box::pin(commands::dev_diagnostic(input, connector).instrument(tracing::info_span!("DevDiagnostic")))
+        })
+        .await
+    }
+
+    async fn diff(&self, params: DiffParams) -> CoreResult<DiffResult> {
+        crate::commands::diff(params, self.host.clone()).await
+    }
+
+    async fn drop_database(&self, url: String) -> CoreResult<()> {
+        self.with_connector_for_url(url, |connector| MigrationConnector::drop_database(connector))
+            .await
+    }
+
+    async fn diagnose_migration_history(
+        &self,
+        input: commands::DiagnoseMigrationHistoryInput,
+    ) -> CoreResult<commands::DiagnoseMigrationHistoryOutput> {
+        self.with_default_connector(|connector| {
+            Box::pin(
+                commands::diagnose_migration_history(input, connector)
+                    .instrument(tracing::info_span!("DiagnoseMigrationHistory")),
+            )
+        })
+        .await
+    }
+
+    async fn ensure_connection_validity(
+        &self,
+        params: EnsureConnectionValidityParams,
+    ) -> CoreResult<EnsureConnectionValidityResult> {
+        self.with_connector_from_datasource_param(&params.datasource, |connector| {
+            Box::pin(async move {
+                MigrationConnector::ensure_connection_validity(connector).await?;
+                Ok(EnsureConnectionValidityResult {})
+            })
+        })
+        .await
+    }
+
+    async fn evaluate_data_loss(&self, input: EvaluateDataLossInput) -> CoreResult<EvaluateDataLossOutput> {
+        self.with_default_connector(|connector| {
+            Box::pin(commands::evaluate_data_loss(input, connector).instrument(tracing::info_span!("EvaluateDataLoss")))
+        })
+        .await
+    }
+
+    async fn list_migration_directories(
+        &self,
+        input: ListMigrationDirectoriesInput,
+    ) -> CoreResult<ListMigrationDirectoriesOutput> {
+        let migrations_from_filesystem =
+            migration_connector::migrations_directory::list_migrations(Path::new(&input.migrations_directory_path))?;
+
+        let migrations = migrations_from_filesystem
+            .iter()
+            .map(|migration| migration.migration_name().to_string())
+            .collect();
+
+        Ok(ListMigrationDirectoriesOutput { migrations })
+    }
+
+    async fn mark_migration_applied(&self, input: MarkMigrationAppliedInput) -> CoreResult<MarkMigrationAppliedOutput> {
+        self.with_default_connector(move |connector| {
+            let span = tracing::info_span!("MarkMigrationApplied", migration_name = input.migration_name.as_str());
+            Box::pin(commands::mark_migration_applied(input, connector).instrument(span))
+        })
+        .await
+    }
+
+    async fn mark_migration_rolled_back(
+        &self,
+        input: MarkMigrationRolledBackInput,
+    ) -> CoreResult<MarkMigrationRolledBackOutput> {
+        self.with_default_connector(move |connector| {
+            let span = tracing::info_span!(
+                "MarkMigrationRolledBack",
+                migration_name = input.migration_name.as_str()
+            );
+            Box::pin(commands::mark_migration_rolled_back(input, connector).instrument(span))
+        })
+        .await
+    }
+
+    async fn reset(&self) -> CoreResult<()> {
+        tracing::debug!("Resetting the database.");
+
+        self.with_default_connector(move |connector| {
+            Box::pin(MigrationConnector::reset(connector).instrument(tracing::info_span!("Reset")))
+        })
+        .await?;
+        Ok(())
+    }
+
+    async fn schema_push(&self, input: SchemaPushInput) -> CoreResult<SchemaPushOutput> {
+        self.with_default_connector(move |connector| {
+            Box::pin(commands::schema_push(input, connector).instrument(tracing::info_span!("SchemaPush")))
+        })
+        .await
+    }
+}

--- a/migration-engine/json-rpc-api-build/methods/common.toml
+++ b/migration-engine/json-rpc-api-build/methods/common.toml
@@ -1,0 +1,17 @@
+# Common types
+
+[enumShapes.DatasourceParam]
+description = """
+The path to a live database taken as input. For flexibility, this can be the path to a Prisma
+schema file containing the datasource, or the whole Prisma schema as a string, or only the
+connection string. See variants.
+"""
+
+[enumShapes.DatasourceParam.variants.SchemaPath]
+shape = "PathContainer"
+
+[enumShapes.DatasourceParam.variants.SchemaString]
+shape = "SchemaContainer"
+
+[enumShapes.DatasourceParam.variants.ConnectionString]
+shape = "UrlContainer"

--- a/migration-engine/json-rpc-api-build/methods/createDatabase.toml
+++ b/migration-engine/json-rpc-api-build/methods/createDatabase.toml
@@ -1,0 +1,12 @@
+[methods.createDatabase]
+description = """
+Create the logical database from the Prisma schema.
+"""
+requestShape = "CreateDatabaseParams"
+responseShape = "CreateDatabaseResult"
+
+[recordShapes.CreateDatabaseParams]
+fields.datasource.shape = "DatasourceParam"
+
+[recordShapes.CreateDatabaseResult]
+fields.databaseName.shape = "string"

--- a/migration-engine/json-rpc-api-build/methods/dbExecute.toml
+++ b/migration-engine/json-rpc-api-build/methods/dbExecute.toml
@@ -25,7 +25,7 @@ fields.script.shape = "string"
 description = "The type of results returned by dbExecute."
 
 [enumShapes.DbExecuteDatasourceType]
-description = "The location of the live database to connect to in dbExecute."
+description = "The location of the live database to connect to."
 variants.schema.description = "Path to the Prisma schema file to take the datasource URL from."
 variants.schema.shape = "SchemaContainer"
 variants.url.description = "The URL of the database to run the command on."

--- a/migration-engine/json-rpc-api-build/methods/ensureConnectionValidity.toml
+++ b/migration-engine/json-rpc-api-build/methods/ensureConnectionValidity.toml
@@ -1,0 +1,12 @@
+[methods.ensureConnectionValidity]
+description = """
+Make sure the migration engine can connect to the database from the Prisma schema.
+"""
+requestShape = "EnsureConnectionValidityParams"
+responseShape = "EnsureConnectionValidityResult"
+
+[recordShapes.EnsureConnectionValidityParams]
+fields.datasource.shape = "DatasourceParam"
+
+[recordShapes.EnsureConnectionValidityResult]
+

--- a/migration-engine/json-rpc-api-build/src/rust_crate.rs
+++ b/migration-engine/json-rpc-api-build/src/rust_crate.rs
@@ -116,21 +116,21 @@ fn generate_types_rs(mut file: impl std::io::Write, api: &Api) -> CrateResult {
         for (variant_name, variant) in &variants.variants {
             if let Some(description) = &variant.description {
                 for line in description.lines() {
-                    writeln!(file, "    /// {}", line)?;
+                    writeln!(file, "/// {}", line)?;
                 }
+            }
 
-                let cc_variant_name = variant_name.to_camel_case();
+            let cc_variant_name = variant_name.to_camel_case();
 
-                if cc_variant_name.as_str() != variant_name {
-                    writeln!(file, "///\n/// JSON name: {}", variant_name)?;
-                    writeln!(file, "#[serde(rename = \"{}\")]", variant_name)?;
-                }
+            if cc_variant_name.as_str() != variant_name {
+                writeln!(file, "///\n/// JSON name: {}", variant_name)?;
+                writeln!(file, "#[serde(rename = \"{}\")]", variant_name)?;
+            }
 
-                if let Some(shape) = &variant.shape {
-                    writeln!(file, "    {}({}),", cc_variant_name, rustify_type_name(shape))?;
-                } else {
-                    writeln!(file, "    {},", cc_variant_name)?;
-                }
+            if let Some(shape) = &variant.shape {
+                writeln!(file, "    {}({}),", cc_variant_name, rustify_type_name(shape))?;
+            } else {
+                writeln!(file, "    {},", cc_variant_name)?;
             }
         }
 

--- a/migration-engine/migration-engine-tests/Cargo.toml
+++ b/migration-engine/migration-engine-tests/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 datamodel = { path = "../../libs/datamodel/core" }
 sql-datamodel-connector= { path = "../../libs/datamodel/connectors/sql-datamodel-connector" }
-migration-core = { path = "../core", features = ["sql", "mongodb"] }
+migration-core = { path = "../core" }
 sql-migration-connector = { path = "../connectors/sql-migration-connector" }
 sql-schema-describer = { path = "../../libs/sql-schema-describer" }
 user-facing-errors = { path = "../../libs/user-facing-errors" }
@@ -22,6 +22,7 @@ connection-string = "0.1.13"
 enumflags2 = "0.7"
 expect-test = "1.1.0"
 indoc = "1.0.3"
+jsonrpc-core = "17.0.0"
 once_cell = "1.8.0"
 pretty_assertions = "0.6"
 serde = "1"

--- a/migration-engine/migration-engine-tests/src/commands/apply_migrations.rs
+++ b/migration-engine/migration-engine-tests/src/commands/apply_migrations.rs
@@ -32,7 +32,7 @@ impl<'a> ApplyMigrations<'a> {
     pub async fn send(self) -> CoreResult<ApplyMigrationsAssertion<'a>> {
         let output = self
             .api
-            .apply_migrations(&ApplyMigrationsInput {
+            .apply_migrations(ApplyMigrationsInput {
                 migrations_directory_path: self.migrations_directory.path().to_str().unwrap().to_owned(),
             })
             .await?;

--- a/migration-engine/migration-engine-tests/src/commands/create_migration.rs
+++ b/migration-engine/migration-engine-tests/src/commands/create_migration.rs
@@ -45,7 +45,7 @@ impl<'a> CreateMigration<'a> {
     pub async fn send(self) -> CoreResult<CreateMigrationAssertion<'a>> {
         let output = self
             .api
-            .create_migration(&CreateMigrationInput {
+            .create_migration(CreateMigrationInput {
                 migrations_directory_path: self.migrations_directory.path().to_str().unwrap().to_owned(),
                 prisma_schema: self.schema.to_owned(),
                 draft: self.draft,

--- a/migration-engine/migration-engine-tests/src/commands/dev_diagnostic.rs
+++ b/migration-engine/migration-engine-tests/src/commands/dev_diagnostic.rs
@@ -22,7 +22,7 @@ impl<'a> DevDiagnostic<'a> {
     }
 
     fn send_impl(self) -> CoreResult<DevDiagnosticAssertions<'a>> {
-        let output = self.rt.block_on(self.api.dev_diagnostic(&DevDiagnosticInput {
+        let output = self.rt.block_on(self.api.dev_diagnostic(DevDiagnosticInput {
             migrations_directory_path: self.migrations_directory.path().to_str().unwrap().to_owned(),
         }))?;
 

--- a/migration-engine/migration-engine-tests/src/commands/diagnose_migration_history.rs
+++ b/migration-engine/migration-engine-tests/src/commands/diagnose_migration_history.rs
@@ -41,7 +41,7 @@ impl<'a> DiagnoseMigrationHistory<'a> {
     pub async fn send(self) -> CoreResult<DiagnoseMigrationHistoryAssertions<'a>> {
         let output = self
             .api
-            .diagnose_migration_history(&DiagnoseMigrationHistoryInput {
+            .diagnose_migration_history(DiagnoseMigrationHistoryInput {
                 migrations_directory_path: self.migrations_directory.path().to_str().unwrap().to_owned(),
                 opt_in_to_shadow_database: self.opt_in_to_shadow_database,
             })

--- a/migration-engine/migration-engine-tests/src/commands/evaluate_data_loss.rs
+++ b/migration-engine/migration-engine-tests/src/commands/evaluate_data_loss.rs
@@ -26,7 +26,7 @@ impl<'a> EvaluateDataLoss<'a> {
     }
 
     fn send_impl(self) -> CoreResult<EvaluateDataLossAssertion<'a>> {
-        let output = self.rt.block_on(self.api.evaluate_data_loss(&EvaluateDataLossInput {
+        let output = self.rt.block_on(self.api.evaluate_data_loss(EvaluateDataLossInput {
             migrations_directory_path: self.migrations_directory.path().to_str().unwrap().to_owned(),
             prisma_schema: self.prisma_schema,
         }))?;

--- a/migration-engine/migration-engine-tests/src/commands/list_migration_directories.rs
+++ b/migration-engine/migration-engine-tests/src/commands/list_migration_directories.rs
@@ -21,7 +21,7 @@ impl<'a> ListMigrationDirectories<'a> {
     pub fn send(self) -> ListMigrationDirectoriesAssertion<'a> {
         let output = self
             .rt
-            .block_on(self.api.list_migration_directories(&ListMigrationDirectoriesInput {
+            .block_on(self.api.list_migration_directories(ListMigrationDirectoriesInput {
                 migrations_directory_path: self.migrations_directory.path().to_str().unwrap().to_owned(),
             }))
             .unwrap();

--- a/migration-engine/migration-engine-tests/src/commands/mark_migration_applied.rs
+++ b/migration-engine/migration-engine-tests/src/commands/mark_migration_applied.rs
@@ -27,7 +27,7 @@ impl<'a> MarkMigrationApplied<'a> {
     pub fn send_impl(self) -> CoreResult<MarkMigrationAppliedAssertion<'a>> {
         let output = self
             .rt
-            .block_on(self.api.mark_migration_applied(&MarkMigrationAppliedInput {
+            .block_on(self.api.mark_migration_applied(MarkMigrationAppliedInput {
                 migrations_directory_path: self.migrations_directory.path().to_str().unwrap().to_owned(),
                 migration_name: self.migration_name,
             }))?;

--- a/migration-engine/migration-engine-tests/src/commands/mark_migration_rolled_back.rs
+++ b/migration-engine/migration-engine-tests/src/commands/mark_migration_rolled_back.rs
@@ -19,7 +19,7 @@ impl<'a> MarkMigrationRolledBack<'a> {
     fn send_impl(self) -> CoreResult<MarkMigrationRolledBackAssertion<'a>> {
         let output = self
             .rt
-            .block_on(self.api.mark_migration_rolled_back(&MarkMigrationRolledBackInput {
+            .block_on(self.api.mark_migration_rolled_back(MarkMigrationRolledBackInput {
                 migration_name: self.migration_name,
             }))?;
 

--- a/migration-engine/migration-engine-tests/src/commands/schema_push.rs
+++ b/migration-engine/migration-engine-tests/src/commands/schema_push.rs
@@ -40,7 +40,7 @@ impl<'a> SchemaPush<'a> {
 
         let fut = self
             .api
-            .schema_push(&input)
+            .schema_push(input)
             .instrument(tracing::info_span!("SchemaPush", migration_id = ?self.migration_id));
 
         let output = self.rt.block_on(fut)?;

--- a/migration-engine/migration-engine-tests/src/test_api.rs
+++ b/migration-engine/migration-engine-tests/src/test_api.rs
@@ -9,8 +9,7 @@ pub use test_setup::{BitFlags, Capabilities, Tags};
 use crate::{commands::*, multi_engine_test_api::TestApi as RootTestApi};
 use datamodel::common::preview_features::PreviewFeature;
 use migration_core::migration_connector::{
-    ConnectorHost, ConnectorResult, DatabaseMigrationStepApplier, DiffTarget, EmptyHost, MigrationConnector,
-    MigrationPersistence,
+    ConnectorHost, ConnectorResult, DatabaseMigrationStepApplier, DiffTarget, MigrationConnector, MigrationPersistence,
 };
 use quaint::{
     prelude::{ConnectionInfo, ResultSet},
@@ -21,15 +20,9 @@ use std::{
     borrow::Cow,
     fmt::{Display, Write},
     future::Future,
-    sync::Arc,
 };
 use tempfile::TempDir;
 use test_setup::{DatasourceBlock, TestApiArgs};
-
-/// For error testing.
-pub async fn rpc_api(schema: &str) -> ConnectorResult<()> {
-    migration_core::rpc_api(schema, Arc::new(EmptyHost)).await.map(drop)
-}
 
 #[derive(Debug, Default)]
 pub struct TestConnectorHost {
@@ -75,7 +68,7 @@ impl TestApi {
         self.root.connection_info()
     }
 
-    pub fn db_execute(&self, params: &migration_core::json_rpc::types::DbExecuteParams) -> ConnectorResult<()> {
+    pub fn db_execute(&self, params: migration_core::json_rpc::types::DbExecuteParams) -> ConnectorResult<()> {
         let api: &dyn migration_core::GenericApi = &self.connector;
         self.block_on(api.db_execute(params))
     }
@@ -112,7 +105,7 @@ impl TestApi {
         DiagnoseMigrationHistory::new_sync(&self.connector, migrations_directory, &self.root.rt)
     }
 
-    pub fn diff(&self, params: &DiffParams) -> ConnectorResult<DiffResult> {
+    pub fn diff(&self, params: DiffParams) -> ConnectorResult<DiffResult> {
         let api: &dyn migration_core::GenericApi = &self.connector;
         self.block_on(api.diff(params))
     }

--- a/migration-engine/migration-engine-tests/tests/migrations/advisory_locking.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/advisory_locking.rs
@@ -18,7 +18,7 @@ fn advisory_locking_works(api: TestApi) {
     );
 
     let output = api
-        .block_on(first_me.generic_api().create_migration(&CreateMigrationInput {
+        .block_on(first_me.generic_api().create_migration(CreateMigrationInput {
             migrations_directory_path: migrations_directory.path().to_string_lossy().into(),
             prisma_schema: dm,
             migration_name: "01initial".into(),

--- a/migration-engine/migration-engine-tests/tests/migrations/db_execute.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/db_execute.rs
@@ -32,7 +32,7 @@ fn db_execute_happy_path_with_literal_url(api: TestApi) {
     "#;
 
     // Execute the command.
-    api.db_execute(&DbExecuteParams {
+    api.db_execute(DbExecuteParams {
         datasource_type: DbExecuteDatasourceType::Url(UrlContainer { url: url.clone() }),
         script: script.to_owned(),
     })
@@ -67,7 +67,7 @@ fn db_execute_happy_path_with_prisma_schema(api: TestApi) {
     "#;
 
     // Execute the command.
-    api.db_execute(&DbExecuteParams {
+    api.db_execute(DbExecuteParams {
         datasource_type: DbExecuteDatasourceType::Schema(SchemaContainer {
             schema: schema_path.to_string_lossy().into_owned(),
         }),
@@ -93,7 +93,7 @@ fn mysql_incomplete_script_works(api: TestApi) {
     let url = api.connection_string().to_owned();
 
     // Execute the command.
-    api.db_execute(&DbExecuteParams {
+    api.db_execute(DbExecuteParams {
         datasource_type: DbExecuteDatasourceType::Url(UrlContainer { url: url.clone() }),
         script: script.to_owned(),
     })
@@ -114,7 +114,7 @@ fn db_execute_error_path(api: TestApi) {
     "#;
 
     // Execute the command.
-    let result = api.db_execute(&DbExecuteParams {
+    let result = api.db_execute(DbExecuteParams {
         datasource_type: DbExecuteDatasourceType::Url(UrlContainer {
             url: api.connection_string().to_owned(),
         }),

--- a/migration-engine/migration-engine-tests/tests/migrations/dev_diagnostic_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/dev_diagnostic_tests.rs
@@ -623,9 +623,9 @@ fn dev_diagnostic_shadow_database_creation_error_is_special_cased_mysql(api: Tes
 
     let err = api
         .block_on(async {
-            let migration_api = migration_api(&datamodel).unwrap();
+            let migration_api = migration_api(Some(datamodel), None).unwrap();
             migration_api
-                .dev_diagnostic(&DevDiagnosticInput {
+                .dev_diagnostic(DevDiagnosticInput {
                     migrations_directory_path: directory.path().as_os_str().to_string_lossy().into_owned(),
                 })
                 .await
@@ -671,10 +671,10 @@ fn dev_diagnostic_shadow_database_creation_error_is_special_cased_postgres(api: 
     );
 
     let err = api
-        .block_on(async {
-            let migration_api = migration_api(&datamodel).unwrap();
+        .block_on(async move {
+            let migration_api = migration_api(Some(datamodel), None).unwrap();
             migration_api
-                .dev_diagnostic(&DevDiagnosticInput {
+                .dev_diagnostic(DevDiagnosticInput {
                     migrations_directory_path: directory.path().as_os_str().to_string_lossy().into_owned(),
                 })
                 .await

--- a/migration-engine/migration-engine-tests/tests/migrations/diagnose_migration_history_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/diagnose_migration_history_tests.rs
@@ -808,15 +808,13 @@ fn shadow_database_creation_error_is_special_cased_mysql(api: TestApi) {
         dbport = api.connection_info().port().unwrap_or(3306),
     );
 
-    let migration_api = migration_api(&datamodel).unwrap();
+    let migration_api = migration_api(Some(datamodel), None).unwrap();
 
     let output = api
-        .block_on(
-            migration_api.diagnose_migration_history(&DiagnoseMigrationHistoryInput {
-                migrations_directory_path: directory.path().as_os_str().to_string_lossy().into_owned(),
-                opt_in_to_shadow_database: true,
-            }),
-        )
+        .block_on(migration_api.diagnose_migration_history(DiagnoseMigrationHistoryInput {
+            migrations_directory_path: directory.path().as_os_str().to_string_lossy().into_owned(),
+            opt_in_to_shadow_database: true,
+        }))
         .unwrap();
 
     assert!(
@@ -859,9 +857,9 @@ fn shadow_database_creation_error_is_special_cased_postgres(api: TestApi) {
 
     let output = api
         .block_on(async {
-            migration_api(&datamodel)
+            migration_api(Some(datamodel.clone()), None)
                 .unwrap()
-                .diagnose_migration_history(&DiagnoseMigrationHistoryInput {
+                .diagnose_migration_history(DiagnoseMigrationHistoryInput {
                     migrations_directory_path: directory.path().as_os_str().to_string_lossy().into_owned(),
                     opt_in_to_shadow_database: true,
                 })
@@ -918,7 +916,7 @@ fn shadow_database_creation_error_is_special_cased_mssql(api: TestApi) {
             panic!("Failed to connect to mssql more than five times.");
         }
 
-        let result = migration_api(&datamodel);
+        let result = migration_api(Some(datamodel.clone()), None);
 
         match result {
             Ok(api) => break api,
@@ -931,12 +929,10 @@ fn shadow_database_creation_error_is_special_cased_mssql(api: TestApi) {
     };
 
     let output = api
-        .block_on(
-            migration_api.diagnose_migration_history(&DiagnoseMigrationHistoryInput {
-                migrations_directory_path: directory.path().as_os_str().to_string_lossy().into_owned(),
-                opt_in_to_shadow_database: true,
-            }),
-        )
+        .block_on(migration_api.diagnose_migration_history(DiagnoseMigrationHistoryInput {
+            migrations_directory_path: directory.path().as_os_str().to_string_lossy().into_owned(),
+            opt_in_to_shadow_database: true,
+        }))
         .unwrap();
 
     assert!(

--- a/migration-engine/migration-engine-tests/tests/migrations/diff.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/diff.rs
@@ -47,7 +47,7 @@ fn diffing_postgres_schemas_when_initialized_on_sqlite(mut api: TestApi) {
 
     let to_file = write_file_to_tmp(to, &tempdir, "to");
 
-    api.diff(&DiffParams {
+    api.diff(DiffParams {
         from: DiffTarget::SchemaDatamodel(SchemaContainer {
             schema: from_file.to_string_lossy().into_owned(),
         }),
@@ -59,7 +59,7 @@ fn diffing_postgres_schemas_when_initialized_on_sqlite(mut api: TestApi) {
     })
     .unwrap();
 
-    api.diff(&DiffParams {
+    api.diff(DiffParams {
         from: DiffTarget::SchemaDatamodel(SchemaContainer {
             schema: from_file.to_string_lossy().into_owned(),
         }),
@@ -110,7 +110,7 @@ fn from_empty_to_migrations_directory(mut api: TestApi) {
         shadow_database_url: Some(api.connection_string().to_owned()),
     };
 
-    api.diff(&params).unwrap();
+    api.diff(params).unwrap();
 
     let expected_printed_messages = expect![[r#"
         [
@@ -149,7 +149,7 @@ fn from_empty_to_migrations_folder_without_shadow_db_url_must_error(mut api: Tes
         shadow_database_url: None, // TODO: ?
     };
 
-    let err = api.diff(&params).unwrap_err();
+    let err = api.diff(params).unwrap_err();
 
     let expected_error = expect![[r#"
         You must pass the --shadow-database-url if you want to diff a migrations directory.
@@ -195,7 +195,7 @@ fn from_schema_datamodel_to_url(mut api: TestApi) {
         to: DiffTarget::Url(UrlContainer { url: second_url }),
     };
 
-    api.diff(&input).unwrap();
+    api.diff(input).unwrap();
 
     let expected_printed_messages = expect![[r#"
         [
@@ -250,7 +250,7 @@ fn from_schema_datasource_to_url(mut api: TestApi) {
         to: DiffTarget::Url(UrlContainer { url: second_url }),
     };
 
-    api.diff(&input).unwrap();
+    api.diff(input).unwrap();
 
     let expected_printed_messages = expect![[r#"
         [
@@ -291,7 +291,7 @@ fn from_url_to_url(mut api: TestApi) {
         to: DiffTarget::Url(UrlContainer { url: second_url }),
     };
 
-    api.diff(&input).unwrap();
+    api.diff(input).unwrap();
 
     let expected_printed_messages = expect![[r#"
         [
@@ -352,7 +352,7 @@ fn diffing_mongo_schemas_works(mut api: TestApi) {
 
     let to_file = write_file_to_tmp(to, &tempdir, "to");
 
-    api.diff(&DiffParams {
+    api.diff(DiffParams {
         from: DiffTarget::SchemaDatamodel(SchemaContainer {
             schema: from_file.to_string_lossy().into_owned(),
         }),

--- a/migration-engine/migration-engine-tests/tests/migrations/jsonrpc.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/jsonrpc.rs
@@ -1,0 +1,59 @@
+use expect_test::expect;
+use std::sync::Arc;
+use test_macros::test_connector;
+use test_setup::*;
+
+struct TestApi {
+    _args: TestApiArgs,
+    api: jsonrpc_core::IoHandler,
+    rt: tokio::runtime::Runtime,
+}
+
+impl TestApi {
+    fn new(_args: TestApiArgs) -> Self {
+        let host = Arc::new(migration_core::migration_connector::EmptyHost);
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        TestApi {
+            _args,
+            api: migration_core::rpc_api(None, host),
+            rt,
+        }
+    }
+
+    fn send_request(&mut self, request: &str) -> Option<String> {
+        self.rt.block_on(self.api.handle_request(request))
+    }
+}
+
+#[test_connector(tags(Sqlite))]
+fn test_can_connect_to_database(mut api: TestApi) {
+    let tempdir = tempfile::tempdir().unwrap();
+    let url = format!(
+        "file:{}",
+        tempdir.path().join("test.sqlite").to_string_lossy().into_owned()
+    );
+    let request = r#"
+        {"jsonrpc":"2.0","id":1,"method":"ensureConnectionValidity","params":{"datasource":{"tag":"ConnectionString", "url": "theurl"}}}
+    "#.replace("theurl", &url);
+
+    let response = api.send_request(&request).unwrap();
+
+    let expected = expect![[r#"{"jsonrpc":"2.0","result":{},"id":1}"#]];
+
+    expected.assert_eq(&response);
+}
+
+#[test_connector(tags(Sqlite))]
+fn test_create_database(mut api: TestApi) {
+    let tempdir = tempfile::tempdir().unwrap();
+    let url = format!(
+        "file:{}",
+        tempdir.path().join("test.sqlite").to_string_lossy().into_owned()
+    );
+    let request = r#"
+        {"jsonrpc":"2.0","id":1,"method":"createDatabase","params":{"datasource":{"tag":"ConnectionString", "url": "theurl"}}}
+    "#.replace("theurl", &url);
+
+    let response = api.send_request(&request).unwrap();
+    assert!(response.starts_with(r#"{"jsonrpc":"2.0","result""#)); // success
+}

--- a/migration-engine/migration-engine-tests/tests/migrations/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/mod.rs
@@ -11,6 +11,7 @@ mod foreign_keys;
 mod id;
 mod indexes;
 mod json;
+mod jsonrpc;
 mod mariadb;
 mod mark_migration_applied_tests;
 mod mark_migration_rolled_back_tests;

--- a/migration-engine/qe-setup/Cargo.toml
+++ b/migration-engine/qe-setup/Cargo.toml
@@ -5,12 +5,14 @@ edition = "2021"
 
 [dependencies]
 datamodel = { path = "../../libs/datamodel/core" }
-migration-core = { path = "../core", features = ["sql"] }
+migration-core = { path = "../core" }
 
+async-trait = "0.1.52"
+connection-string = "*"
 enumflags2 = "*"
 mongodb = "2.1.0"
+tempfile = "3.3.0"
 url = "2"
-connection-string = "*"
 
 [dependencies.quaint]
 git = "https://github.com/prisma/quaint"

--- a/migration-engine/qe-setup/src/postgres.rs
+++ b/migration-engine/qe-setup/src/postgres.rs
@@ -1,4 +1,4 @@
-use migration_core::migration_connector::{ConnectorError, ConnectorResult, DiffTarget};
+use migration_core::migration_connector::{ConnectorError, ConnectorResult};
 use quaint::{prelude::*, single::Quaint};
 use std::collections::HashMap;
 use url::Url;
@@ -31,18 +31,7 @@ pub(crate) async fn postgres_setup(url: String, prisma_schema: &str) -> Connecto
     {
         //TODO: remove this once cockroachdb is supported in migrations
         let prisma_schema2 = prisma_schema.replace("provider = \"cockroachdb\"", "provider = \"postgres\"");
-        let api = migration_core::migration_api(&prisma_schema2)?;
-        // 2. create the database schema for given Prisma schema
-        let migration = api
-            .connector()
-            .diff(DiffTarget::Empty, DiffTarget::Datamodel(prisma_schema.into()))
-            .await
-            .unwrap();
-        api.connector()
-            .database_migration_step_applier()
-            .apply_migration(&migration)
-            .await
-            .unwrap();
+        crate::diff_and_apply(&prisma_schema2).await;
     };
 
     Ok(())


### PR DESCRIPTION
- New migration engine JSON-RPC commands: createDatabase and
  ensureConnectionValidity, that replace the corresponding
  migration-engine-cli commands. All input from the CLI can now go
  through JSON-RPC.
- The --datamodel parameter is no longer required to start the migration
  engine, just for the comments that required it previously.
- The migration engine no longer checks for connectivity on startup.
  This is a requirement for commands like diff and db execute to work
  without an existing valid schema with a valid connection string to a
  working database in prisma/schema.prisma.
- Make --datamodel param optional in migration engine
- CI: stop building migration-core on WASM
- me(refactor): Stop making up schema inside business logic

  We make up schemas when we only have a URL. This is obviously flawed and
  leads to bad error messages on invalid URLs. This commit has us stop
  doing that.
- Reimplement test-cli diff command