### PR TITLE
feat(composite): support nested update & set in updateOne

### DIFF
--- a/libs/prisma-value/src/lib.rs
+++ b/libs/prisma-value/src/lib.rs
@@ -231,6 +231,13 @@ impl PrismaValue {
     pub fn new_datetime(datetime: &str) -> PrismaValue {
         PrismaValue::DateTime(DateTime::parse_from_rfc3339(datetime).unwrap())
     }
+
+    pub fn as_boolean(&self) -> Option<&bool> {
+        match self {
+            PrismaValue::Boolean(bool) => Some(bool),
+            _ => None,
+        }
+    }
 }
 
 impl fmt::Display for PrismaValue {

--- a/query-engine/connector-test-kit-rs/query-engine-tests/src/schemas/composites.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/src/schemas/composites.rs
@@ -80,6 +80,7 @@ pub fn to_one_composites() -> String {
 
         type C {
             c_field String @default("c_field default")
+            c_opt   String?
             b B?
         }
         "#

--- a/query-engine/connector-test-kit-rs/query-engine-tests/src/schemas/composites.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/src/schemas/composites.rs
@@ -70,6 +70,7 @@ pub fn to_one_composites() -> String {
         type A {
             a_1 String @default("a_1 default") @map("a1")
             a_2 Int?
+            b   B @map("nested_b")
         }
 
         type B {

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/composites/list.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/composites/list.rs
@@ -445,7 +445,7 @@ mod update {
           runner,
           query,
           2009,
-          "`Mutation.updateOneTestModel.data.TestModelUpdateInput.a.AUpdateEnvelopeInput.set.ACreateInput.a_2`: Value types mismatch. Have: Object({\"update\": Object({\"increment\": Int(3)})}), want: Int"
+          "`Mutation.updateOneTestModel.data.TestModelUpdateInput.a.AListUpdateEnvelopeInput.set.ACreateInput.a_2`: Value types mismatch. Have: Object({\"update\": Object({\"increment\": Int(3)})}), want: Int"
         );
 
         // Ensure `update` cannot be used in the Unchecked type
@@ -453,7 +453,7 @@ mod update {
           runner,
           query,
           2009,
-          "`Mutation.updateOneTestModel.data.TestModelUncheckedUpdateInput.a.AUpdateEnvelopeInput.set.ACreateInput.a_2`: Value types mismatch. Have: Object({\"update\": Object({\"increment\": Int(3)})}), want: Int"
+          "`Mutation.updateOneTestModel.data.TestModelUncheckedUpdateInput.a.AListUpdateEnvelopeInput.set.ACreateInput.a_2`: Value types mismatch. Have: Object({\"update\": Object({\"increment\": Int(3)})}), want: Int"
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/composites/list.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/composites/list.rs
@@ -363,6 +363,9 @@ mod create {
 
 #[test_suite(schema(to_many_composites), only(MongoDb))]
 mod update {
+    use indoc::indoc;
+    use query_engine_tests::{assert_error, run_query};
+
     #[connector_test]
     async fn update_set_explicit(runner: Runner) -> TestResult<()> {
         create_test_data(&runner).await?;
@@ -454,6 +457,267 @@ mod update {
           query,
           2009,
           "`Mutation.updateOneTestModel.data.TestModelUncheckedUpdateInput.a.AListUpdateEnvelopeInput.set.ACreateInput.a_2`: Value types mismatch. Have: Object({\"update\": Object({\"increment\": Int(3)})}), want: Int"
+        );
+
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn update_push_explicit(runner: Runner) -> TestResult<()> {
+        create_test_data(&runner).await?;
+
+        // Test push with array & object syntax
+        insta::assert_snapshot!(
+          run_query!(runner, r#"mutation {
+            updateOneTestModel(
+              where: { id: 1 }
+              data: {
+                a: { push: [{ a_1: "new item", a_2: 1337, b: { b_field: "new item", a: [] } }] }
+                c: { push: { c_field: "new item" } }
+              }
+            ) {
+              a {
+                a_1
+                a_2
+                b {
+                  b_field
+                  a {
+                      a_1
+                  }
+                }
+              }
+              c { c_field }
+            }
+          }"#),
+          @r###"{"data":{"updateOneTestModel":{"a":[{"a_1":"a1","a_2":null,"b":[{"b_field":"b_field","a":[]}]},{"a_1":"new item","a_2":1337,"b":[{"b_field":"new item","a":[]}]}],"c":[{"c_field":"new item"}]}}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn update_push_explicit_with_default(runner: Runner) -> TestResult<()> {
+        create_test_data(&runner).await?;
+
+        // Tests push with array & object syntax
+        insta::assert_snapshot!(
+          run_query!(runner, r#"mutation {
+            updateOneTestModel(
+              where: { id: 1 }
+              data: {
+                a: { push: [{ b: { a: [{}] } }] }
+                c: { push: {} }
+              }
+            ) {
+              a {
+                a_1
+                a_2
+                b {
+                  b_field
+                  a {
+                      a_1
+                  }
+                }
+              }
+              c { c_field }
+            }
+          }"#),
+          @r###"{"data":{"updateOneTestModel":{"a":[{"a_1":"a1","a_2":null,"b":[{"b_field":"b_field","a":[]}]},{"a_1":"a_1 default","a_2":null,"b":[{"b_field":"b_field default","a":[{"a_1":"a_1 default"}]}]}],"c":[{"c_field":"c_field default"}]}}}"###
+        );
+
+        Ok(())
+    }
+
+    fn mixed_composites() -> String {
+        let schema = indoc! {
+            r#"model TestModel {
+              #id(id, Int, @id)
+              field String?
+              a     A       @map("top_a")
+          }
+  
+          type A {
+              a_1 String @default("a_1 default") @map("a1")
+              b B[]
+          }
+  
+          type B {
+              b_field String   @default("b_field default")
+          }"#
+        };
+
+        schema.to_owned()
+    }
+
+    #[connector_test(schema(mixed_composites))]
+    async fn update_push_explicit_nested(runner: Runner) -> TestResult<()> {
+        create_row(
+            &runner,
+            r#"{
+          id: 1
+          a: { a_1: "a1", b: [{ b_field: "b_field" }] }
+        }"#,
+        )
+        .await?;
+
+        // Test nested push (object syntax)
+        insta::assert_snapshot!(
+          run_query!(runner, r#"mutation {
+            updateOneTestModel(
+              where: { id: 1 }
+              data: {
+                a: { update: { b: { push: { b_field: "nested1" } } } }
+              }
+            ) {
+              a {
+                a_1
+                b {
+                  b_field
+                }
+              }
+            }
+          }"#),
+          @r###"{"data":{"updateOneTestModel":{"a":{"a_1":"a1","b":[{"b_field":"b_field"},{"b_field":"nested1"}]}}}}"###
+        );
+
+        // Test nested push with defaults (object syntax)
+        insta::assert_snapshot!(
+          run_query!(runner, r#"mutation {
+            updateOneTestModel(
+              where: { id: 1 }
+              data: {
+                a: { update: { b: { push: {} } } }
+              }
+            ) {
+              a {
+                a_1
+                b {
+                  b_field
+                }
+              }
+            }
+          }"#),
+          @r###"{"data":{"updateOneTestModel":{"a":{"a_1":"a1","b":[{"b_field":"b_field"},{"b_field":"nested1"},{"b_field":"b_field default"}]}}}}"###
+        );
+
+        // Test nested push (array syntax)
+        insta::assert_snapshot!(
+          run_query!(runner, r#"mutation {
+            updateOneTestModel(
+              where: { id: 1 }
+              data: {
+                a: { update: { b: { push: [{ b_field: "nested2" }, { b_field: "nested3" }] } } }
+              }
+            ) {
+              a {
+                a_1
+                b {
+                  b_field
+                }
+              }
+            }
+          }"#),
+          @r###"{"data":{"updateOneTestModel":{"a":{"a_1":"a1","b":[{"b_field":"b_field"},{"b_field":"nested1"},{"b_field":"b_field default"},{"b_field":"nested2"},{"b_field":"nested3"}]}}}}"###
+        );
+
+        // Test nested push with defaults (array syntax)
+        insta::assert_snapshot!(
+          run_query!(runner, r#"mutation {
+            updateOneTestModel(
+              where: { id: 1 }
+              data: {
+                a: { update: { b: { push: [{}] } } }
+              }
+            ) {
+              a {
+                a_1
+                b {
+                  b_field
+                }
+              }
+            }
+          }"#),
+          @r###"{"data":{"updateOneTestModel":{"a":{"a_1":"a1","b":[{"b_field":"b_field"},{"b_field":"nested1"},{"b_field":"b_field default"},{"b_field":"nested2"},{"b_field":"nested3"},{"b_field":"b_field default"}]}}}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test(schema(mixed_composites))]
+    async fn fails_push_on_non_list_field(runner: Runner) -> TestResult<()> {
+        create_row(
+            &runner,
+            r#"{
+              id: 1
+              a: { a_1: "a1", b: [{ b_field: "b_field" }] }
+            }"#,
+        )
+        .await?;
+
+        // No push on to-one composite
+        assert_error!(
+            runner,
+            r#"mutation {
+              updateOneTestModel(
+                where: { id: 1 }
+                data: { a: { push: {} } }
+              ) { id }
+            }"#,
+            2009,
+            "`Mutation.updateOneTestModel.data.TestModelUpdateInput.a.ACreateInput.push`: Field does not exist on enclosing type."
+        );
+
+        // No push on scalar
+        assert_error!(
+          runner,
+          r#"mutation {
+            updateOneTestModel(
+              where: { id: 1 }
+              data: { a: { update: { a_1: { push: {} } } } }
+            ) { id }
+          }"#,
+          2009,
+          "Mutation.updateOneTestModel.data.TestModelUpdateInput.a.AUpdateEnvelopeInput.update.AUpdateInput.a_1.StringFieldUpdateOperationsInput.push`: Field does not exist on enclosing type."
+        );
+
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn fails_unset_on_list_field(runner: Runner) -> TestResult<()> {
+        create_test_data(&runner).await?;
+
+        // No unset on list fields
+        assert_error!(
+            runner,
+            r#"mutation {
+              updateOneTestModel(
+                where: { id: 1 }
+                data: { a: { unset: true } }
+              ) { id }
+            }"#,
+            2009,
+            "`Mutation.updateOneTestModel.data.TestModelUncheckedUpdateInput.a.ACreateInput.unset`: Field does not exist on enclosing type."
+        );
+
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn fails_upsert_on_list_field(runner: Runner) -> TestResult<()> {
+        create_test_data(&runner).await?;
+
+        // No upsert on list fields
+        assert_error!(
+            runner,
+            r#"mutation {
+              updateOneTestModel(
+                where: { id: 1 }
+                data: { a: { upsert: {} } }
+              ) { id }
+            }"#,
+            2009,
+            "`Mutation.updateOneTestModel.data.TestModelUncheckedUpdateInput.a.ACreateInput.upsert`: Field does not exist on enclosing type."
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/composites/single.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/composites/single.rs
@@ -176,7 +176,7 @@ mod create {
 
     // Fails on both the envelope and the actual input type
     #[connector_test]
-    async fn error_when_missing_required_fields(runner: Runner) -> TestResult<()> {
+    async fn fails_when_missing_required_fields(runner: Runner) -> TestResult<()> {
         // Envelope type failure
         assert_error!(
           runner,
@@ -243,7 +243,7 @@ mod update {
           @r###"{"data":{"updateOneTestModel":{"a":{"a_1":"a_1 default","a_2":1337},"b":{"b_field":"b_field default","c":{"c_field":"updated"}}}}}"###
         );
 
-        // Nested empty object
+        // Nested empty object with defaults
         insta::assert_snapshot!(
           run_query!(&runner, r#"mutation { updateOneTestModel(
             where: { id: 1 },
@@ -277,7 +277,7 @@ mod update {
           @r###"{"data":{"updateOneTestModel":{"a":{"a_1":"a_1 default","a_2":1337},"b":{"b_field":"b_field default","c":{"c_field":"updated"}}}}}"###
         );
 
-        // Nested empty object
+        // Nested empty object with defaults
         insta::assert_snapshot!(
           run_query!(&runner, r#"mutation { updateOneTestModel(
             where: { id: 1 },
@@ -316,7 +316,7 @@ mod update {
         insta::assert_snapshot!(
           run_query!(&runner, r#"mutation { updateOneTestModel(
             where: { id: 1 },
-            data: { a: { update: { a_2: 1337 } } }
+            data: { a: { update: { a_2: { increment: 1335 } } } }
           ) { a { a_1 a_2 } b { b_field c { c_field } } } }"#),
           @r###"{"data":{"updateOneTestModel":{"a":{"a_1":"a1","a_2":1337},"b":{"b_field":"b1","c":{"c_field":"c1"}}}}}"###
         );
@@ -325,9 +325,12 @@ mod update {
         insta::assert_snapshot!(
           run_query!(&runner, r#"mutation { updateOneTestModel(
             where: { id: 1 },
-            data: { b: { update: { c: { update: { c_field: "updated" } } } } }
+            data: {
+              a: { update: { a_2: { decrement: 1 } } }
+              b: { update: { c: { update: { c_field: "updated" } } } }
+            }
           ) { a { a_1 a_2 } b { b_field c { c_field } } } }"#),
-          @r###"{"data":{"updateOneTestModel":{"a":{"a_1":"a1","a_2":1337},"b":{"b_field":"b1","c":{"c_field":"updated"}}}}}"###
+          @r###"{"data":{"updateOneTestModel":{"a":{"a_1":"a1","a_2":1336},"b":{"b_field":"b1","c":{"c_field":"updated"}}}}}"###
         );
 
         Ok(())
@@ -365,7 +368,7 @@ mod update {
             }
           }"#,
           2009,
-          "`Mutation.updateOneTestModel.data.TestModelUpdateInput.b.BUpdateEnvelopeInput.set.BSetUpdateInput.c.CCreateInput.update`: Field does not exist on enclosing type."
+          "`Mutation.updateOneTestModel.data.TestModelUpdateInput.b.BUpdateEnvelopeInput.set.BCreateInput.c.CCreateInput.update`: Field does not exist on enclosing type."
         );
 
         assert_error!(
@@ -381,14 +384,14 @@ mod update {
             }
           }"#,
           2009,
-          "`Mutation.updateOneTestModel.data.TestModelUpdateInput.b.BSetUpdateInput.c.CCreateInput.update`: Field does not exist on enclosing type."
+          "`Mutation.updateOneTestModel.data.TestModelUpdateInput.b.BCreateInput.c.CCreateInput.update`: Field does not exist on enclosing type."
         );
 
         Ok(())
     }
 
     #[connector_test]
-    async fn error_when_missing_required_fields(runner: Runner) -> TestResult<()> {
+    async fn fails_when_missing_required_fields(runner: Runner) -> TestResult<()> {
         // Envelope type failure
         assert_error!(
               runner,
@@ -422,7 +425,7 @@ mod update {
                 }
               }"#,
                 2009,
-                "`Mutation.updateOneTestModel.data.TestModelUpdateInput.b.BSetUpdateInput.c`: A value is required but not set."
+                "`Mutation.updateOneTestModel.data.TestModelUpdateInput.b.BCreateInput.c`: A value is required but not set."
             );
 
         // Missing required field on nested `update`

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/composites/single.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/composites/single.rs
@@ -1,12 +1,12 @@
 use query_engine_tests::*;
 
-#[test_suite(only(MongoDb))]
+#[test_suite(schema(to_one_composites), only(MongoDb))]
 mod create {
     use query_engine_tests::{assert_error, run_query};
 
     /// Using explicit `set` operator, create (deeply nested) composites.
-    #[connector_test(schema(to_one_composites))]
-    async fn set_create_to_one(runner: Runner) -> TestResult<()> {
+    #[connector_test]
+    async fn set_create(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(runner, r#"mutation {
             createOneTestModel(
@@ -39,8 +39,8 @@ mod create {
     }
 
     /// Using only shorthand syntax, create (deeply nested) composites.
-    #[connector_test(schema(to_one_composites))]
-    async fn shorthand_set_create_to_one(runner: Runner) -> TestResult<()> {
+    #[connector_test]
+    async fn shorthand_set_create(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(runner, r#"mutation {
             createOneTestModel(
@@ -73,8 +73,8 @@ mod create {
     }
 
     /// Using explicit `set` operators and shorthands mixed together, create (deeply nested) composites.
-    #[connector_test(schema(to_one_composites))]
-    async fn mixed_set_create_to_one(runner: Runner) -> TestResult<()> {
+    #[connector_test]
+    async fn mixed_set_create(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(runner, r#"mutation {
             createOneTestModel(
@@ -107,8 +107,8 @@ mod create {
     }
 
     // Ensures default values are set when using an explicit set empty object
-    #[connector_test(schema(to_one_composites))]
-    async fn explicit_set_empty_object_to_one(runner: Runner) -> TestResult<()> {
+    #[connector_test]
+    async fn explicit_set_empty_object(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(runner, r#"mutation {
           createOneTestModel(
@@ -141,8 +141,8 @@ mod create {
     }
 
     // Ensures default values are set when using a shorthand empty object
-    #[connector_test(schema(to_one_composites))]
-    async fn shorthand_set_empty_object_to_one(runner: Runner) -> TestResult<()> {
+    #[connector_test]
+    async fn shorthand_set_empty_object(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(runner, r#"mutation {
             createOneTestModel(
@@ -175,7 +175,7 @@ mod create {
     }
 
     // Fails on both the envelope and the actual input type
-    #[connector_test(schema(to_one_composites))]
+    #[connector_test]
     async fn error_when_missing_required_fields(runner: Runner) -> TestResult<()> {
         // Envelope type failure
         assert_error!(
@@ -213,6 +213,258 @@ mod create {
             "Mutation.createOneTestModel.data.TestModelCreateInput.b.BCreateInput.c`: A value is required but not set."
         );
 
+        Ok(())
+    }
+}
+
+#[test_suite(schema(to_one_composites), only(MongoDb))]
+mod update {
+    use query_engine_tests::{assert_error, run_query};
+
+    #[connector_test]
+    async fn update_set_envelope(runner: Runner) -> TestResult<()> {
+        create_test_data(&runner).await?;
+
+        // Top-level
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"mutation { updateOneTestModel(
+            where: { id: 1 },
+            data: { a: { set: { a_2: 1337 } } }
+          ) { a { a_1 a_2 } b { b_field c { c_field } } } }"#),
+          @r###"{"data":{"updateOneTestModel":{"a":{"a_1":"a_1 default","a_2":1337},"b":{"b_field":"b1","c":{"c_field":"c1"}}}}}"###
+        );
+
+        // Nested
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"mutation { updateOneTestModel(
+            where: { id: 1 },
+            data: { b: { set: { c: { c_field: "updated" } } } }
+          ) { a { a_1 a_2 } b { b_field c { c_field } } } }"#),
+          @r###"{"data":{"updateOneTestModel":{"a":{"a_1":"a_1 default","a_2":1337},"b":{"b_field":"b_field default","c":{"c_field":"updated"}}}}}"###
+        );
+
+        // Nested empty object
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"mutation { updateOneTestModel(
+            where: { id: 1 },
+            data: { b: { set: { c: {} } } }
+          ) { a { a_1 a_2 } b { b_field c { c_field } } } }"#),
+          @r###"{"data":{"updateOneTestModel":{"a":{"a_1":"a_1 default","a_2":1337},"b":{"b_field":"b_field default","c":{"c_field":"c_field default"}}}}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn update_set_shorthand(runner: Runner) -> TestResult<()> {
+        create_test_data(&runner).await?;
+
+        // Top-level
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"mutation { updateOneTestModel(
+            where: { id: 1 },
+            data: { a: { a_2: 1337 } }
+          ) { a { a_1 a_2 } b { b_field c { c_field } } } }"#),
+          @r###"{"data":{"updateOneTestModel":{"a":{"a_1":"a_1 default","a_2":1337},"b":{"b_field":"b1","c":{"c_field":"c1"}}}}}"###
+        );
+
+        // Nested
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"mutation { updateOneTestModel(
+            where: { id: 1 },
+            data: { b: { c: { c_field: "updated" } } }
+          ) { a { a_1 a_2 } b { b_field c { c_field } } } }"#),
+          @r###"{"data":{"updateOneTestModel":{"a":{"a_1":"a_1 default","a_2":1337},"b":{"b_field":"b_field default","c":{"c_field":"updated"}}}}}"###
+        );
+
+        // Nested empty object
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"mutation { updateOneTestModel(
+            where: { id: 1 },
+            data: { b: { c: {} } }
+          ) { a { a_1 a_2 } b { b_field c { c_field } } } }"#),
+          @r###"{"data":{"updateOneTestModel":{"a":{"a_1":"a_1 default","a_2":1337},"b":{"b_field":"b_field default","c":{"c_field":"c_field default"}}}}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn update_set_mixed(runner: Runner) -> TestResult<()> {
+        create_test_data(&runner).await?;
+
+        // Top-level
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"mutation { updateOneTestModel(
+            where: { id: 1 },
+            data: {
+              a: { set: { a_2: 1337 } },
+              b: { c: { c_field: "updated" } }
+            }
+          ) { a { a_1 a_2 } b { b_field c { c_field } } } }"#),
+          @r###"{"data":{"updateOneTestModel":{"a":{"a_1":"a_1 default","a_2":1337},"b":{"b_field":"b_field default","c":{"c_field":"updated"}}}}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn update_nested_envelope(runner: Runner) -> TestResult<()> {
+        create_test_data(&runner).await?;
+
+        // Top-level
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"mutation { updateOneTestModel(
+            where: { id: 1 },
+            data: { a: { update: { a_2: 1337 } } }
+          ) { a { a_1 a_2 } b { b_field c { c_field } } } }"#),
+          @r###"{"data":{"updateOneTestModel":{"a":{"a_1":"a1","a_2":1337},"b":{"b_field":"b1","c":{"c_field":"c1"}}}}}"###
+        );
+
+        // Nested
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"mutation { updateOneTestModel(
+            where: { id: 1 },
+            data: { b: { update: { c: { update: { c_field: "updated" } } } } }
+          ) { a { a_1 a_2 } b { b_field c { c_field } } } }"#),
+          @r###"{"data":{"updateOneTestModel":{"a":{"a_1":"a1","a_2":1337},"b":{"b_field":"b1","c":{"c_field":"updated"}}}}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn mixed_update_set(runner: Runner) -> TestResult<()> {
+        create_test_data(&runner).await?;
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"mutation { updateOneTestModel(
+            where: { id: 1 },
+            data: { b: { update: { c: {} } } }
+          ) { a { a_1 a_2 } b { b_field c { c_field } } } }"#),
+          @r###"{"data":{"updateOneTestModel":{"a":{"a_1":"a1","a_2":2},"b":{"b_field":"b1","c":{"c_field":"c_field default"}}}}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn fails_on_nested_update_after_a_set(runner: Runner) -> TestResult<()> {
+        create_test_data(&runner).await?;
+
+        assert_error!(
+          runner,
+          r#"mutation {
+            updateOneTestModel(
+              where: { id: 1 }
+              data: {
+                b: { set: { c: { update: { c_field: "updated" } } } }
+              }
+            ) {
+              id
+            }
+          }"#,
+          2009,
+          "`Mutation.updateOneTestModel.data.TestModelUpdateInput.b.BUpdateEnvelopeInput.set.BSetUpdateInput.c.CCreateInput.update`: Field does not exist on enclosing type."
+        );
+
+        assert_error!(
+          runner,
+          r#"mutation {
+            updateOneTestModel(
+              where: { id: 1 }
+              data: {
+                b: { c: { update: { c_field: "updated" } } }
+              }
+            ) {
+              id
+            }
+          }"#,
+          2009,
+          "`Mutation.updateOneTestModel.data.TestModelUpdateInput.b.BSetUpdateInput.c.CCreateInput.update`: Field does not exist on enclosing type."
+        );
+
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn error_when_missing_required_fields(runner: Runner) -> TestResult<()> {
+        // Envelope type failure
+        assert_error!(
+              runner,
+              r#"mutation {
+                updateOneTestModel(
+                  where: { id: 1 }
+                  data: {
+                    a: { set: { a_1: "a1", a_2: null } }
+                    b: {}
+                  }
+                ) {
+                  id
+                }
+              }"#,
+              2009,
+              "`Mutation.updateOneTestModel.data.TestModelUpdateInput.b.BUpdateEnvelopeInput`: Expected exactly one field to be present, got 0."
+            );
+
+        // Missing required field without default failure on field `B.c`
+        assert_error!(
+                runner,
+                r#"mutation {
+                updateOneTestModel(
+                  where: { id: 1 }
+                  data: {
+                    a: { set: { a_1: "a1", a_2: null } }
+                    b: {}
+                  }
+                ) {
+                  id
+                }
+              }"#,
+                2009,
+                "`Mutation.updateOneTestModel.data.TestModelUpdateInput.b.BSetUpdateInput.c`: A value is required but not set."
+            );
+
+        // Missing required field on nested `update`
+        assert_error!(
+              runner,
+              r#"mutation {
+              updateOneTestModel(
+                where: { id: 1 }
+                data: {
+                  a: { set: { a_1: "a1", a_2: null } }
+                  b: { update: {} }
+                }
+              ) {
+                id
+              }
+            }"#,
+              2009,
+              "`Mutation.updateOneTestModel.data.TestModelUpdateInput.b.BUpdateEnvelopeInput.update.BUpdateInput`: Expected a minimum of 1 fields to be present, got 0."
+          );
+
+        Ok(())
+    }
+
+    async fn create_test_data(runner: &Runner) -> TestResult<()> {
+        create_row(
+            runner,
+            r#"{
+          id: 1
+          a: { set: { a_1: "a1", a_2: 2 } }
+          b: { set: { b_field: "b1", c: { c_field: "c1" } } }
+        }"#,
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    async fn create_row(runner: &Runner, data: &str) -> TestResult<()> {
+        runner
+            .query(format!("mutation {{ createOneTestModel(data: {}) {{ id }} }}", data))
+            .await?
+            .assert_success();
         Ok(())
     }
 }

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/composites/single.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/composites/single.rs
@@ -12,13 +12,22 @@ mod create {
             createOneTestModel(
               data: {
                 id: 1
-                a: { set: { a_1: "a1", a_2: null } }
+                a: { set: { a_1: "a1", a_2: null, b: { b_field: "b_field", c: { c_field: "c_field" } } } }
                 b: { set: { b_field: "b_field", c: { c_field: "c_field" } } }
               }
             ) {
               a {
                 a_1
                 a_2
+                b {
+                  b_field
+                  c {
+                    c_field
+                    b {
+                      b_field
+                    }
+                  }
+                }
               }
               b {
                 b_field
@@ -32,7 +41,7 @@ mod create {
             }
           }
           "#),
-          @r###"{"data":{"createOneTestModel":{"a":{"a_1":"a1","a_2":null},"b":{"b_field":"b_field","c":{"c_field":"c_field","b":null}}}}}"###
+          @r###"{"data":{"createOneTestModel":{"a":{"a_1":"a1","a_2":null,"b":{"b_field":"b_field","c":{"c_field":"c_field","b":null}}},"b":{"b_field":"b_field","c":{"c_field":"c_field","b":null}}}}}"###
         );
 
         Ok(())
@@ -46,13 +55,22 @@ mod create {
             createOneTestModel(
               data: {
                 id: 1
-                a: { a_1: "a1", a_2: null }
+                a: { a_1: "a1", a_2: null, b: { b_field: "b_field", c: { c_field: "c_field" } } }
                 b: { b_field: "b_field", c: { c_field: "c_field" } }
               }
             ) {
               a {
                 a_1
                 a_2
+                b {
+                  b_field
+                  c {
+                    c_field
+                    b {
+                      b_field
+                    }
+                  }
+                }
               }
               b {
                 b_field
@@ -66,7 +84,7 @@ mod create {
             }
           }
           "#),
-          @r###"{"data":{"createOneTestModel":{"a":{"a_1":"a1","a_2":null},"b":{"b_field":"b_field","c":{"c_field":"c_field","b":null}}}}}"###
+          @r###"{"data":{"createOneTestModel":{"a":{"a_1":"a1","a_2":null,"b":{"b_field":"b_field","c":{"c_field":"c_field","b":null}}},"b":{"b_field":"b_field","c":{"c_field":"c_field","b":null}}}}}"###
         );
 
         Ok(())
@@ -80,13 +98,22 @@ mod create {
             createOneTestModel(
               data: {
                 id: 1
-                a: { set: { a_1: "a1", a_2: null } }
+                a: { set: { a_1: "a1", a_2: null, b: { b_field: "b_field", c: { c_field: "c_field" } } } }
                 b: { b_field: "b_field", c: { c_field: "c_field" } }
               }
             ) {
               a {
                 a_1
                 a_2
+                b {
+                  b_field
+                  c {
+                    c_field
+                    b {
+                      b_field
+                    }
+                  }
+                }
               }
               b {
                 b_field
@@ -100,7 +127,7 @@ mod create {
             }
           }
           "#),
-          @r###"{"data":{"createOneTestModel":{"a":{"a_1":"a1","a_2":null},"b":{"b_field":"b_field","c":{"c_field":"c_field","b":null}}}}}"###
+          @r###"{"data":{"createOneTestModel":{"a":{"a_1":"a1","a_2":null,"b":{"b_field":"b_field","c":{"c_field":"c_field","b":null}}},"b":{"b_field":"b_field","c":{"c_field":"c_field","b":null}}}}}"###
         );
 
         Ok(())
@@ -114,13 +141,22 @@ mod create {
           createOneTestModel(
             data: {
               id: 1
-              a: { set: { a_1: "a1", a_2: null } }
+              a: { set: { a_1: "a1", a_2: null, b: { c: {} } } }
               b: { set: { c: {} } }
             }
           ) {
             a {
               a_1
               a_2
+              b {
+                b_field
+                c {
+                  c_field
+                  b {
+                    b_field
+                  }
+                }
+              }
             }
             b {
               b_field
@@ -134,7 +170,7 @@ mod create {
           }
         }
         "#),
-          @r###"{"data":{"createOneTestModel":{"a":{"a_1":"a1","a_2":null},"b":{"b_field":"b_field default","c":{"c_field":"c_field default","b":null}}}}}"###
+          @r###"{"data":{"createOneTestModel":{"a":{"a_1":"a1","a_2":null,"b":{"b_field":"b_field default","c":{"c_field":"c_field default","b":null}}},"b":{"b_field":"b_field default","c":{"c_field":"c_field default","b":null}}}}}"###
         );
 
         Ok(())
@@ -148,13 +184,22 @@ mod create {
             createOneTestModel(
               data: {
                 id: 1
-                a: { set: { a_1: "a1", a_2: null } }
+                a: { a_1: "a1", a_2: null, b: { c: {} } }
                 b: { c: {} }
               }
             ) {
               a {
                 a_1
                 a_2
+                b {
+                  b_field
+                  c {
+                    c_field
+                    b {
+                      b_field
+                    }
+                  }
+                }
               }
               b {
                 b_field
@@ -168,7 +213,7 @@ mod create {
             }
           }
           "#),
-          @r###"{"data":{"createOneTestModel":{"a":{"a_1":"a1","a_2":null},"b":{"b_field":"b_field default","c":{"c_field":"c_field default","b":null}}}}}"###
+          @r###"{"data":{"createOneTestModel":{"a":{"a_1":"a1","a_2":null,"b":{"b_field":"b_field default","c":{"c_field":"c_field default","b":null}}},"b":{"b_field":"b_field default","c":{"c_field":"c_field default","b":null}}}}}"###
         );
 
         Ok(())
@@ -184,7 +229,7 @@ mod create {
             createOneTestModel(
               data: {
                 id: 1
-                a: { set: { a_1: "a1", a_2: null } }
+                a: { set: { a_1: "a1", a_2: null, b: { c: {} } } }
                 b: {}
               }
             ) {
@@ -202,7 +247,7 @@ mod create {
             createOneTestModel(
               data: {
                 id: 1
-                a: { set: { a_1: "a1", a_2: null } }
+                a: { set: { a_1: "a1", a_2: null, b: { c: {} } } }
                 b: {}
               }
             ) {
@@ -225,31 +270,52 @@ mod update {
     async fn update_set_envelope(runner: Runner) -> TestResult<()> {
         create_test_data(&runner).await?;
 
-        // Top-level
+        // Update set on required composite
         insta::assert_snapshot!(
           run_query!(&runner, r#"mutation { updateOneTestModel(
             where: { id: 1 },
-            data: { a: { set: { a_2: 1337 } } }
-          ) { a { a_1 a_2 } b { b_field c { c_field } } } }"#),
-          @r###"{"data":{"updateOneTestModel":{"a":{"a_1":"a_1 default","a_2":1337},"b":{"b_field":"b1","c":{"c_field":"c1"}}}}}"###
+            data: { a: { set: { a_1: "a_updated", a_2: 1337, b: { b_field: "b_updated", c: { c_field: "c_updated" } } } } }
+          ) {
+            a {
+              a_1 a_2
+              b { b_field c { c_field } }
+            }
+            b { b_field c { c_field } }
+          } }"#),
+          @r###"{"data":{"updateOneTestModel":{"a":{"a_1":"a_updated","a_2":1337,"b":{"b_field":"b_updated","c":{"c_field":"c_updated"}}},"b":{"b_field":"b1","c":{"c_field":"c1"}}}}}"###
         );
 
-        // Nested
+        // Update set on optional composite
         insta::assert_snapshot!(
           run_query!(&runner, r#"mutation { updateOneTestModel(
             where: { id: 1 },
             data: { b: { set: { c: { c_field: "updated" } } } }
-          ) { a { a_1 a_2 } b { b_field c { c_field } } } }"#),
-          @r###"{"data":{"updateOneTestModel":{"a":{"a_1":"a_1 default","a_2":1337},"b":{"b_field":"b_field default","c":{"c_field":"updated"}}}}}"###
+          ) {
+            a {
+              a_1 a_2
+              b { b_field c { c_field } }
+            }
+            b { b_field c { c_field } }
+          } }"#),
+          @r###"{"data":{"updateOneTestModel":{"a":{"a_1":"a_updated","a_2":1337,"b":{"b_field":"b_updated","c":{"c_field":"c_updated"}}},"b":{"b_field":"b_field default","c":{"c_field":"updated"}}}}}"###
         );
 
         // Nested empty object with defaults
         insta::assert_snapshot!(
           run_query!(&runner, r#"mutation { updateOneTestModel(
             where: { id: 1 },
-            data: { b: { set: { c: {} } } }
-          ) { a { a_1 a_2 } b { b_field c { c_field } } } }"#),
-          @r###"{"data":{"updateOneTestModel":{"a":{"a_1":"a_1 default","a_2":1337},"b":{"b_field":"b_field default","c":{"c_field":"c_field default"}}}}}"###
+            data: {
+              a: { set: { b: { c: {} } } }
+              b: { set: { c: {} } }
+            }
+          ) {
+            a {
+              a_1 a_2
+              b { b_field c { c_field } }
+            }
+            b { b_field c { c_field } }
+          } }"#),
+          @r###"{"data":{"updateOneTestModel":{"a":{"a_1":"a_1 default","a_2":null,"b":{"b_field":"b_field default","c":{"c_field":"c_field default"}}},"b":{"b_field":"b_field default","c":{"c_field":"c_field default"}}}}}"###
         );
 
         Ok(())
@@ -259,31 +325,52 @@ mod update {
     async fn update_set_shorthand(runner: Runner) -> TestResult<()> {
         create_test_data(&runner).await?;
 
-        // Top-level
+        // Update set on required composite
         insta::assert_snapshot!(
           run_query!(&runner, r#"mutation { updateOneTestModel(
             where: { id: 1 },
-            data: { a: { a_2: 1337 } }
-          ) { a { a_1 a_2 } b { b_field c { c_field } } } }"#),
-          @r###"{"data":{"updateOneTestModel":{"a":{"a_1":"a_1 default","a_2":1337},"b":{"b_field":"b1","c":{"c_field":"c1"}}}}}"###
+            data: { a: { a_1: "a_updated", a_2: 1337, b: { b_field: "b_updated", c: { c_field: "c_updated" } } } }
+          ) {
+            a {
+              a_1 a_2
+              b { b_field c { c_field } }
+            }
+            b { b_field c { c_field } }
+          } }"#),
+          @r###"{"data":{"updateOneTestModel":{"a":{"a_1":"a_updated","a_2":1337,"b":{"b_field":"b_updated","c":{"c_field":"c_updated"}}},"b":{"b_field":"b1","c":{"c_field":"c1"}}}}}"###
         );
 
-        // Nested
+        // Update set on optional composite
         insta::assert_snapshot!(
           run_query!(&runner, r#"mutation { updateOneTestModel(
             where: { id: 1 },
             data: { b: { c: { c_field: "updated" } } }
-          ) { a { a_1 a_2 } b { b_field c { c_field } } } }"#),
-          @r###"{"data":{"updateOneTestModel":{"a":{"a_1":"a_1 default","a_2":1337},"b":{"b_field":"b_field default","c":{"c_field":"updated"}}}}}"###
+          ) {
+            a {
+              a_1 a_2
+              b { b_field c { c_field } }
+            }
+            b { b_field c { c_field } }
+          } }"#),
+          @r###"{"data":{"updateOneTestModel":{"a":{"a_1":"a_updated","a_2":1337,"b":{"b_field":"b_updated","c":{"c_field":"c_updated"}}},"b":{"b_field":"b_field default","c":{"c_field":"updated"}}}}}"###
         );
 
         // Nested empty object with defaults
         insta::assert_snapshot!(
           run_query!(&runner, r#"mutation { updateOneTestModel(
             where: { id: 1 },
-            data: { b: { c: {} } }
-          ) { a { a_1 a_2 } b { b_field c { c_field } } } }"#),
-          @r###"{"data":{"updateOneTestModel":{"a":{"a_1":"a_1 default","a_2":1337},"b":{"b_field":"b_field default","c":{"c_field":"c_field default"}}}}}"###
+            data: {
+              a: { b: { c: {} } }
+              b: { c: {} }
+            }
+          ) {
+            a {
+              a_1 a_2
+              b { b_field c { c_field } }
+            }
+            b { b_field c { c_field } }
+          } }"#),
+          @r###"{"data":{"updateOneTestModel":{"a":{"a_1":"a_1 default","a_2":null,"b":{"b_field":"b_field default","c":{"c_field":"c_field default"}}},"b":{"b_field":"b_field default","c":{"c_field":"c_field default"}}}}}"###
         );
 
         Ok(())
@@ -298,11 +385,17 @@ mod update {
           run_query!(&runner, r#"mutation { updateOneTestModel(
             where: { id: 1 },
             data: {
-              a: { set: { a_2: 1337 } },
-              b: { c: { c_field: "updated" } }
+              a: { set: { a_2: 1337, b: { b_field: "b_updated", c: { c_field: "c_updated" } } } },
+              b: { c: { c_field: "c_updated" } }
             }
-          ) { a { a_1 a_2 } b { b_field c { c_field } } } }"#),
-          @r###"{"data":{"updateOneTestModel":{"a":{"a_1":"a_1 default","a_2":1337},"b":{"b_field":"b_field default","c":{"c_field":"updated"}}}}}"###
+          ) {
+            a {
+              a_1 a_2
+              b { b_field c { c_field } }
+            }
+            b { b_field c { c_field } }
+          } }"#),
+          @r###"{"data":{"updateOneTestModel":{"a":{"a_1":"a_1 default","a_2":1337,"b":{"b_field":"b_updated","c":{"c_field":"c_updated"}}},"b":{"b_field":"b_field default","c":{"c_field":"c_updated"}}}}}"###
         );
 
         Ok(())
@@ -316,9 +409,17 @@ mod update {
         insta::assert_snapshot!(
           run_query!(&runner, r#"mutation { updateOneTestModel(
             where: { id: 1 },
-            data: { a: { update: { a_2: { increment: 1335 } } } }
-          ) { a { a_1 a_2 } b { b_field c { c_field } } } }"#),
-          @r###"{"data":{"updateOneTestModel":{"a":{"a_1":"a1","a_2":1337},"b":{"b_field":"b1","c":{"c_field":"c1"}}}}}"###
+            data: { a: { update: {
+              a_2: { increment: 1335 },
+            }}}
+          ){
+            a {
+              a_1 a_2
+              b { b_field c { c_field } }
+            }
+            b { b_field c { c_field } }
+          } }"#),
+          @r###"{"data":{"updateOneTestModel":{"a":{"a_1":"a1","a_2":1337,"b":{"b_field":"b1","c":{"c_field":"c1"}}},"b":{"b_field":"b1","c":{"c_field":"c1"}}}}}"###
         );
 
         // Nested
@@ -326,11 +427,26 @@ mod update {
           run_query!(&runner, r#"mutation { updateOneTestModel(
             where: { id: 1 },
             data: {
-              a: { update: { a_2: { decrement: 1 } } }
-              b: { update: { c: { update: { c_field: "updated" } } } }
+              a: {
+                update: {
+                  a_2: { decrement: 1 }
+                  b: {
+                    update: {
+                      b_field: "b_updated"
+                      c: { update: { c_field: "c_updated" } }
+                    }
+                  }
+                }
+              }
             }
-          ) { a { a_1 a_2 } b { b_field c { c_field } } } }"#),
-          @r###"{"data":{"updateOneTestModel":{"a":{"a_1":"a1","a_2":1336},"b":{"b_field":"b1","c":{"c_field":"updated"}}}}}"###
+          ){
+            a {
+              a_1 a_2
+              b { b_field c { c_field } }
+            }
+            b { b_field c { c_field } }
+          } }"#),
+          @r###"{"data":{"updateOneTestModel":{"a":{"a_1":"a1","a_2":1336,"b":{"b_field":"b_updated","c":{"c_field":"c_updated"}}},"b":{"b_field":"b1","c":{"c_field":"c1"}}}}}"###
         );
 
         Ok(())
@@ -343,9 +459,20 @@ mod update {
         insta::assert_snapshot!(
           run_query!(&runner, r#"mutation { updateOneTestModel(
             where: { id: 1 },
-            data: { b: { update: { c: {} } } }
-          ) { a { a_1 a_2 } b { b_field c { c_field } } } }"#),
-          @r###"{"data":{"updateOneTestModel":{"a":{"a_1":"a1","a_2":2},"b":{"b_field":"b1","c":{"c_field":"c_field default"}}}}}"###
+            data: {
+              a: {
+                update: {
+                  b: { update: { c: {} } }
+                }
+              }
+            }
+          ) {
+            a {
+              a_1 a_2
+              b { b_field c { c_field } }
+            }
+          }}"#),
+          @r###"{"data":{"updateOneTestModel":{"a":{"a_1":"a1","a_2":2,"b":{"b_field":"b1","c":{"c_field":"c_field default"}}}}}}"###
         );
 
         Ok(())
@@ -368,7 +495,7 @@ mod update {
             }
           }"#,
           2009,
-          "`Mutation.updateOneTestModel.data.TestModelUpdateInput.b.BUpdateEnvelopeInput.set.BCreateInput.c.CCreateInput.update`: Field does not exist on enclosing type."
+          "`Mutation.updateOneTestModel.data.TestModelUpdateInput.b.BNullableUpdateEnvelopeInput.set.BCreateInput.c.CCreateInput.update`: Field does not exist on enclosing type."
         );
 
         assert_error!(
@@ -399,7 +526,6 @@ mod update {
                 updateOneTestModel(
                   where: { id: 1 }
                   data: {
-                    a: { set: { a_1: "a1", a_2: null } }
                     b: {}
                   }
                 ) {
@@ -407,7 +533,7 @@ mod update {
                 }
               }"#,
               2009,
-              "`Mutation.updateOneTestModel.data.TestModelUpdateInput.b.BUpdateEnvelopeInput`: Expected exactly one field to be present, got 0."
+              "`Mutation.updateOneTestModel.data.TestModelUpdateInput.b.BNullableUpdateEnvelopeInput`: Expected exactly one field to be present, got 0."
             );
 
         // Missing required field without default failure on field `B.c`
@@ -417,7 +543,6 @@ mod update {
                 updateOneTestModel(
                   where: { id: 1 }
                   data: {
-                    a: { set: { a_1: "a1", a_2: null } }
                     b: {}
                   }
                 ) {
@@ -428,23 +553,29 @@ mod update {
                 "`Mutation.updateOneTestModel.data.TestModelUpdateInput.b.BCreateInput.c`: A value is required but not set."
             );
 
-        // Missing required field on nested `update`
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn fails_update_on_optional_composite(runner: Runner) -> TestResult<()> {
+        create_test_data(&runner).await?;
+
+        // Invalid `update` on optional composite field
         assert_error!(
-              runner,
-              r#"mutation {
-              updateOneTestModel(
-                where: { id: 1 }
-                data: {
-                  a: { set: { a_1: "a1", a_2: null } }
-                  b: { update: {} }
-                }
-              ) {
-                id
-              }
-            }"#,
-              2009,
-              "`Mutation.updateOneTestModel.data.TestModelUpdateInput.b.BUpdateEnvelopeInput.update.BUpdateInput`: Expected a minimum of 1 fields to be present, got 0."
-          );
+          runner,
+          r#"mutation {
+          updateOneTestModel(
+            where: { id: 1 }
+            data: {
+              b: { update: { b_field: "b_updated" } }
+            }
+          ) {
+            id
+          }
+        }"#,
+          2009,
+          "`Mutation.updateOneTestModel.data.TestModelUpdateInput.b.BNullableUpdateEnvelopeInput.update`: Field does not exist on enclosing type."
+      );
 
         Ok(())
     }
@@ -454,7 +585,7 @@ mod update {
             runner,
             r#"{
           id: 1
-          a: { set: { a_1: "a1", a_2: 2 } }
+          a: { set: { a_1: "a1", a_2: 2, b: { b_field: "b1", c: { c_field: "c1" } } } }
           b: { set: { b_field: "b1", c: { c_field: "c1" } } }
         }"#,
         )

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/composites/single.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/composites/single.rs
@@ -479,6 +479,301 @@ mod update {
     }
 
     #[connector_test]
+    async fn update_unset_explicit(runner: Runner) -> TestResult<()> {
+        create_row(
+            &runner,
+            r#"{
+          id: 1
+          a: { b: { c: { b: { c: {}} } } }
+          b: { c: {} }
+        }"#,
+        )
+        .await?;
+
+        // Nested composite
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"mutation { updateOneTestModel(
+            where: { id: 1 },
+            data: { a: { update: { b: { update: { c: { update: { b: { unset: true } } } } } } } }
+          ) {
+            a {
+              a_1 a_2
+              b { c { b { b_field } } }
+            }
+          }}"#),
+          @r###"{"data":{"updateOneTestModel":{"a":{"a_1":"a_1 default","a_2":null,"b":{"c":{"b":null}}}}}}"###
+        );
+
+        // Top-level composite
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"mutation { updateOneTestModel(
+            where: { id: 1 },
+            data: { b: { unset: true } }
+          ) {
+            a {
+              a_1 a_2
+              b { c { b { b_field } } }
+            }
+            b {
+              b_field
+            }
+          }}"#),
+          @r###"{"data":{"updateOneTestModel":{"a":{"a_1":"a_1 default","a_2":null,"b":{"c":{"b":null}}},"b":null}}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn update_unset_false_is_noop(runner: Runner) -> TestResult<()> {
+        create_test_data(&runner).await?;
+
+        // Top-level composite
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"mutation { updateOneTestModel(
+            where: { id: 1 },
+            data: { b: { unset: false } }
+          ) {
+            b {
+              b_field
+            }
+          }}"#),
+          @r###"{"data":{"updateOneTestModel":{"b":{"b_field":"b1"}}}}"###
+        );
+
+        Ok(())
+    }
+
+    // Ensures unset is only available on optional field of type composite
+    #[connector_test]
+    async fn ensure_unset_unavailable_on_fields(runner: Runner) -> TestResult<()> {
+        create_test_data(&runner).await?;
+
+        assert_error!(
+            runner,
+            r#"mutation { updateOneTestModel(
+              where: { id: 1 },
+              data: { field: { unset: true } }
+            ) { id }}"#,
+            2009,
+            "Mutation.updateOneTestModel.data.TestModelUpdateInput.field.NullableStringFieldUpdateOperationsInput.unset`: Field does not exist on enclosing type"
+        );
+
+        assert_error!(
+          runner,
+          r#"mutation { updateOneTestModel(
+            where: { id: 1 },
+            data: { a: { update: { a_1: { unset: true } } } }
+          ) { id }}"#,
+          2009,
+          "`Mutation.updateOneTestModel.data.TestModelUncheckedUpdateInput.a.AUpdateEnvelopeInput.update.AUpdateInput.a_1.StringFieldUpdateOperationsInput.unset`: Field does not exist on enclosing type."
+        );
+
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn update_upsert_explicit(runner: Runner) -> TestResult<()> {
+        create_row(
+            &runner,
+            r#"{
+              id: 1
+              a: { set: { a_1: "a1", a_2: 2, b: { c: {} } } }
+            }"#,
+        )
+        .await?;
+
+        let nested_query = r#"mutation { updateOneTestModel(
+          where: { id: 1 },
+          data: {
+            a: { update: { b: { update: { c: { update: { b: {
+              upsert: {
+                set: { b_field: "new", c: { c_field: "new" } },
+                update: {
+                  b_field: "updated",
+                  c: {
+                    update: {
+                      c_field: "updated"
+                      b: {
+                        upsert: {
+                          set: { b_field: "new", c: { c_field: "new" } },
+                          update: {
+                            b_field: "updated",
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            } } } } } } }
+          }
+        ) {
+          a {
+            a_1 a_2
+            b {
+              b_field
+              c {
+                c_field
+                b {
+                  b_field
+                  c {
+                    c_field
+                    b { b_field }
+                  }
+                }
+              }
+            }
+          }
+        }}"#;
+
+        // Nested composite - upsert set
+        insta::assert_snapshot!(
+          run_query!(&runner, nested_query),
+          @r###"{"data":{"updateOneTestModel":{"a":{"a_1":"a1","a_2":2,"b":{"b_field":"b_field default","c":{"c_field":"c_field default","b":{"b_field":"new","c":{"c_field":"new","b":{"b_field":"new"}}}}}}}}}"###
+        );
+
+        // Nested composite - upsert update
+        insta::assert_snapshot!(
+          run_query!(&runner, nested_query),
+          @r###"{"data":{"updateOneTestModel":{"a":{"a_1":"a1","a_2":2,"b":{"b_field":"b_field default","c":{"c_field":"c_field default","b":{"b_field":"updated","c":{"c_field":"updated","b":{"b_field":"updated"}}}}}}}}}"###
+        );
+
+        let top_level_query = r#"mutation { updateOneTestModel(
+          where: { id: 1 },
+          data: { b: { upsert: {
+            set: { b_field: "new", c: { c_field: "new" } },
+            update: { b_field: "updated", c: { c_field: "updated" } }
+          } } }
+        ) { a { a_1 a_2 } b { b_field c { c_field } } } }"#;
+
+        // Top-level composite
+        insta::assert_snapshot!(
+          run_query!(&runner, top_level_query),
+          @r###"{"data":{"updateOneTestModel":{"a":{"a_1":"a1","a_2":2},"b":{"b_field":"new","c":{"c_field":"new"}}}}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(&runner, top_level_query),
+          @r###"{"data":{"updateOneTestModel":{"a":{"a_1":"a1","a_2":2},"b":{"b_field":"updated","c":{"c_field":"updated"}}}}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn mixed_upsert_update_set_unset(runner: Runner) -> TestResult<()> {
+        create_row(
+            &runner,
+            r#"{
+              id: 1
+              a: { set: { a_1: "a1", a_2: 2, b: { c: {} } } }
+            }"#,
+        )
+        .await?;
+
+        let query = r#"mutation {
+          updateOneTestModel(
+            where: { id: 1 }
+            data: {
+              a: {
+                update: {
+                  a_1: { set: "a.a_1.updated" }
+                  a_2: { increment: 1335 }
+                  b: {
+                    update: {
+                      b_field: "a.b.b_field.updated"
+                      c: {
+                        update: {
+                          c_field: "a.b.c.c_field.updated"
+                          b: {
+                            upsert: {
+                              set: { b_field: "a.b.c.b.b_field.new", c: { c_field: "a.b.c.b.c.c_field.new", b: { c: {} } } }
+                              update: {
+                                b_field: { set: "a.b.c.b.b_field.updated" }
+                                c: { update: { b: { unset: true } } }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          ) {
+            a {
+              a_1
+              a_2
+              b {
+                b_field
+                c {
+                  c_field
+                  b {
+                    b_field
+                    c {
+                      c_field
+                      b {
+                        b_field
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        "#;
+
+        insta::assert_snapshot!(
+          run_query!(&runner, query),
+          @r###"{"data":{"updateOneTestModel":{"a":{"a_1":"a.a_1.updated","a_2":1337,"b":{"b_field":"a.b.b_field.updated","c":{"c_field":"a.b.c.c_field.updated","b":{"b_field":"a.b.c.b.b_field.new","c":{"c_field":"a.b.c.b.c.c_field.new","b":{"b_field":"b_field default"}}}}}}}}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(&runner, query),
+          @r###"{"data":{"updateOneTestModel":{"a":{"a_1":"a.a_1.updated","a_2":2672,"b":{"b_field":"a.b.b_field.updated","c":{"c_field":"a.b.c.c_field.updated","b":{"b_field":"a.b.c.b.b_field.updated","c":{"c_field":"a.b.c.b.c.c_field.new","b":null}}}}}}}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn fails_unset_on_required_field(runner: Runner) -> TestResult<()> {
+        create_test_data(&runner).await?;
+
+        assert_error!(
+            runner,
+            r#"mutation { updateOneTestModel(
+              where: { id: 1 },
+              data: { a: { unset: true } }
+            ) { id }}"#,
+            2009,
+            "`Mutation.updateOneTestModel.data.TestModelUpdateInput.a.AUpdateEnvelopeInput.unset`: Field does not exist on enclosing type."
+        );
+
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn fails_upsert_on_required_field(runner: Runner) -> TestResult<()> {
+        create_test_data(&runner).await?;
+
+        assert_error!(
+            runner,
+            r#"mutation { updateOneTestModel(
+              where: { id: 1 },
+              data: { a: { upsert: { set: {}, update: {} } } }
+            ) { id }}"#,
+            2009,
+            "`Mutation.updateOneTestModel.data.TestModelUpdateInput.a.AUpdateEnvelopeInput.upsert`: Field does not exist on enclosing type."
+        );
+
+        Ok(())
+    }
+
+    #[connector_test]
     async fn fails_on_nested_update_after_a_set(runner: Runner) -> TestResult<()> {
         create_test_data(&runner).await?;
 
@@ -518,7 +813,7 @@ mod update {
     }
 
     #[connector_test]
-    async fn fails_when_missing_required_fields(runner: Runner) -> TestResult<()> {
+    async fn fails_set_when_missing_required_fields(runner: Runner) -> TestResult<()> {
         // Envelope type failure
         assert_error!(
               runner,

--- a/query-engine/connectors/mongodb-query-connector/src/root_queries/mod.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/root_queries/mod.rs
@@ -1,6 +1,7 @@
 //! Top level queries to satisfy the connector interface operations.
 pub mod aggregate;
 pub mod read;
+mod update_utils;
 pub mod write;
 
 use crate::{output_meta::OutputMetaMapping, value::value_from_bson};

--- a/query-engine/connectors/mongodb-query-connector/src/root_queries/mod.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/root_queries/mod.rs
@@ -1,8 +1,9 @@
 //! Top level queries to satisfy the connector interface operations.
 pub mod aggregate;
 pub mod read;
-mod update_utils;
 pub mod write;
+
+mod update_utils;
 
 use crate::{output_meta::OutputMetaMapping, value::value_from_bson};
 use mongodb::bson::Bson;

--- a/query-engine/connectors/mongodb-query-connector/src/root_queries/update_utils.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/root_queries/update_utils.rs
@@ -1,0 +1,127 @@
+use super::*;
+use crate::IntoBson;
+use connector_interface::{DatasourceFieldName, NestedWrite, WriteExpression};
+use itertools::Itertools;
+use mongodb::bson::{doc, Document};
+use prisma_models::PrismaValue;
+
+pub fn render_update_docs(
+    write_expr: WriteExpression,
+    field: &Field,
+    field_name: &str,
+) -> crate::Result<Vec<Document>> {
+    if let WriteExpression::NestedWrite(nested_write) = write_expr {
+        let docs = unfold_nested_write(field, nested_write, &mut vec![field.db_name().to_owned()])
+            .into_iter()
+            // TODO: figure out why we can't flat_map here
+            // TODO: the trait `FromIterator<Vec<mongodb::bson::Document>>` is not implemented for `std::result::Result<Vec<mongodb::bson::Document>, MongoError>`
+            .map(|(write_expr, field, field_name)| render_update_docs(write_expr, field, &field_name))
+            .collect::<crate::Result<Vec<_>>>()?;
+
+        return Ok(docs.into_iter().flatten().collect_vec());
+    };
+
+    let dollar_field_name = format!("${}", field.db_name());
+
+    let doc = match write_expr {
+        WriteExpression::Add(rhs) if field.is_list() => match rhs {
+            PrismaValue::List(vals) => {
+                let vals = vals
+                    .into_iter()
+                    .map(|val| (field, val).into_bson())
+                    .collect::<crate::Result<Vec<_>>>()?
+                    .into_iter()
+                    .map(|bson| {
+                        // Strip the list from the BSON values. [Todo] This is unfortunately necessary right now due to how the
+                        // conversion is set up with native types, we should clean that up at some point (move from traits to fns?).
+                        if let Bson::Array(mut inner) = bson {
+                            inner.pop().unwrap()
+                        } else {
+                            bson
+                        }
+                    })
+                    .collect();
+
+                let bson_array = Bson::Array(vals);
+
+                doc! {
+                    "$set": { field_name: {
+                        "$ifNull": [
+                            { "$concatArrays": [dollar_field_name, bson_array.clone()] },
+                            bson_array
+                        ]
+                    } }
+                }
+            }
+            val => {
+                let bson_val = match (field, val).into_bson()? {
+                    bson @ Bson::Array(_) => bson,
+                    bson => Bson::Array(vec![bson]),
+                };
+
+                doc! {
+                    "$set": {
+                        field_name: {
+                            "$ifNull": [
+                                { "$concatArrays": [dollar_field_name, bson_val.clone()] },
+                                bson_val
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        // We use $literal to enable the set of empty object, which is otherwise considered a syntax error
+        WriteExpression::Value(rhs) => doc! {
+            "$set": { field_name: { "$literal": (field, rhs).into_bson()? } }
+        },
+        WriteExpression::Add(rhs) => doc! {
+            "$set": { field_name: { "$add": [dollar_field_name, (field, rhs).into_bson()?] } }
+        },
+        WriteExpression::Substract(rhs) => doc! {
+            "$set": { field_name: { "$subtract": [dollar_field_name, (field, rhs).into_bson()?] } }
+        },
+        WriteExpression::Multiply(rhs) => doc! {
+            "$set": { field_name: { "$multiply": [dollar_field_name, (field, rhs).into_bson()?] } }
+        },
+        WriteExpression::Divide(rhs) => doc! {
+            "$set": { field_name: { "$divide": [dollar_field_name, (field, rhs).into_bson()?] } }
+        },
+        WriteExpression::NestedWrite(_) => unreachable!(),
+        WriteExpression::Field(_) => unimplemented!(),
+    };
+
+    Ok(vec![doc])
+}
+
+fn unfold_nested_write<'a>(
+    field: &'a Field,
+    nested_write: NestedWrite,
+    path: &mut Vec<String>,
+) -> Vec<(WriteExpression, &'a Field, String)> {
+    let mut nested_writes: Vec<(WriteExpression, &'a Field, String)> = vec![];
+
+    for (DatasourceFieldName(db_name), write) in nested_write.writes {
+        let nested_field = field
+            .as_composite()
+            .unwrap()
+            .typ
+            .find_field_by_db_name(&db_name)
+            .unwrap();
+
+        match write {
+            WriteExpression::NestedWrite(nested_write) => {
+                let mut path = path.clone();
+                path.push(db_name);
+
+                nested_writes.extend(unfold_nested_write(nested_field, nested_write, &mut path));
+            }
+            _ => {
+                path.push(db_name);
+                nested_writes.push((write, nested_field, path.join(".").to_owned()));
+            }
+        }
+    }
+
+    nested_writes
+}

--- a/query-engine/connectors/mongodb-query-connector/src/root_queries/update_utils.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/root_queries/update_utils.rs
@@ -21,7 +21,7 @@ pub fn render_update_docs(
         return Ok(docs.into_iter().flatten().collect_vec());
     };
 
-    let dollar_field_name = format!("${}", field.db_name());
+    let dollar_field_name = format!("${}", field_name);
 
     let doc = match write_expr {
         WriteExpression::Add(rhs) if field.is_list() => match rhs {

--- a/query-engine/connectors/mongodb-query-connector/src/root_queries/update_utils.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/root_queries/update_utils.rs
@@ -11,7 +11,7 @@ pub fn render_update_docs(
     field_name: &str,
 ) -> crate::Result<Vec<Document>> {
     if let WriteExpression::NestedWrite(nested_write) = write_expr {
-        let docs = unfold_nested_write(field, nested_write, &mut vec![field.db_name().to_owned()])
+        let docs = unfold_nested_write(field, nested_write, vec![field.db_name().to_owned()])
             .into_iter()
             // TODO: figure out why we can't flat_map here
             // TODO: the trait `FromIterator<Vec<mongodb::bson::Document>>` is not implemented for `std::result::Result<Vec<mongodb::bson::Document>, MongoError>`
@@ -97,7 +97,7 @@ pub fn render_update_docs(
 fn unfold_nested_write<'a>(
     field: &'a Field,
     nested_write: NestedWrite,
-    path: &mut Vec<String>,
+    path: Vec<String>,
 ) -> Vec<(WriteExpression, &'a Field, String)> {
     let mut nested_writes: Vec<(WriteExpression, &'a Field, String)> = vec![];
 
@@ -108,13 +108,13 @@ fn unfold_nested_write<'a>(
             .typ
             .find_field_by_db_name(&db_name)
             .unwrap();
+        let mut path = path.clone();
 
         match write {
             WriteExpression::NestedWrite(nested_write) => {
-                let mut path = path.clone();
                 path.push(db_name);
 
-                nested_writes.extend(unfold_nested_write(nested_field, nested_write, &mut path));
+                nested_writes.extend(unfold_nested_write(nested_field, nested_write, path));
             }
             _ => {
                 path.push(db_name);

--- a/query-engine/connectors/mongodb-query-connector/src/root_queries/update_utils.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/root_queries/update_utils.rs
@@ -1,127 +1,353 @@
 use super::*;
-use crate::IntoBson;
-use connector_interface::{DatasourceFieldName, NestedWrite, WriteExpression};
+use crate::{BsonTransform, IntoBson};
+use connector_interface::{CompositeWriteOperation, FieldPath, ScalarWriteOperation, WriteOperation};
 use itertools::Itertools;
 use mongodb::bson::{doc, Document};
 use prisma_models::PrismaValue;
 
-pub fn render_update_docs(
-    write_expr: WriteExpression,
-    field: &Field,
-    field_name: &str,
-) -> crate::Result<Vec<Document>> {
-    if let WriteExpression::NestedWrite(nested_write) = write_expr {
-        let docs = unfold_nested_write(field, nested_write, vec![field.db_name().to_owned()])
-            .into_iter()
-            // TODO: figure out why we can't flat_map here
-            // TODO: the trait `FromIterator<Vec<mongodb::bson::Document>>` is not implemented for `std::result::Result<Vec<mongodb::bson::Document>, MongoError>`
-            .map(|(write_expr, field, field_name)| render_update_docs(write_expr, field, &field_name))
-            .collect::<crate::Result<Vec<_>>>()?;
-
-        return Ok(docs.into_iter().flatten().collect_vec());
-    };
-
-    let dollar_field_name = format!("${}", field_name);
-
-    let doc = match write_expr {
-        WriteExpression::Add(rhs) if field.is_list() => match rhs {
-            PrismaValue::List(vals) => {
-                let vals = vals
-                    .into_iter()
-                    .map(|val| (field, val).into_bson())
-                    .collect::<crate::Result<Vec<_>>>()?
-                    .into_iter()
-                    .map(|bson| {
-                        // Strip the list from the BSON values. [Todo] This is unfortunately necessary right now due to how the
-                        // conversion is set up with native types, we should clean that up at some point (move from traits to fns?).
-                        if let Bson::Array(mut inner) = bson {
-                            inner.pop().unwrap()
-                        } else {
-                            bson
-                        }
-                    })
-                    .collect();
-
-                let bson_array = Bson::Array(vals);
-
-                doc! {
-                    "$set": { field_name: {
-                        "$ifNull": [
-                            { "$concatArrays": [dollar_field_name, bson_array.clone()] },
-                            bson_array
-                        ]
-                    } }
-                }
-            }
-            val => {
-                let bson_val = match (field, val).into_bson()? {
-                    bson @ Bson::Array(_) => bson,
-                    bson => Bson::Array(vec![bson]),
-                };
-
-                doc! {
-                    "$set": {
-                        field_name: {
-                            "$ifNull": [
-                                { "$concatArrays": [dollar_field_name, bson_val.clone()] },
-                                bson_val
-                            ]
-                        }
-                    }
-                }
-            }
-        },
-        // We use $literal to enable the set of empty object, which is otherwise considered a syntax error
-        WriteExpression::Value(rhs) => doc! {
-            "$set": { field_name: { "$literal": (field, rhs).into_bson()? } }
-        },
-        WriteExpression::Add(rhs) => doc! {
-            "$set": { field_name: { "$add": [dollar_field_name, (field, rhs).into_bson()?] } }
-        },
-        WriteExpression::Substract(rhs) => doc! {
-            "$set": { field_name: { "$subtract": [dollar_field_name, (field, rhs).into_bson()?] } }
-        },
-        WriteExpression::Multiply(rhs) => doc! {
-            "$set": { field_name: { "$multiply": [dollar_field_name, (field, rhs).into_bson()?] } }
-        },
-        WriteExpression::Divide(rhs) => doc! {
-            "$set": { field_name: { "$divide": [dollar_field_name, (field, rhs).into_bson()?] } }
-        },
-        WriteExpression::NestedWrite(_) => unreachable!(),
-        WriteExpression::Field(_) => unimplemented!(),
-    };
-
-    Ok(vec![doc])
+pub(crate) trait IntoUpdateDocumentExtension {
+    fn into_update_docs(self) -> crate::Result<Vec<Document>>;
 }
 
-fn unfold_nested_write<'a>(
-    field: &'a Field,
-    nested_write: NestedWrite,
-    path: Vec<String>,
-) -> Vec<(WriteExpression, &'a Field, String)> {
-    let mut nested_writes: Vec<(WriteExpression, &'a Field, String)> = vec![];
+impl IntoUpdateDocumentExtension for Vec<UpdateExpression> {
+    fn into_update_docs(self) -> crate::Result<Vec<Document>> {
+        self.into_iter()
+            .map(|op| op.into_bson()?.into_document())
+            .collect::<crate::Result<Vec<_>>>()
+    }
+}
 
-    for (DatasourceFieldName(db_name), write) in nested_write.writes {
-        let nested_field = field
-            .as_composite()
-            .unwrap()
-            .typ
-            .find_field_by_db_name(&db_name)
-            .unwrap();
-        let mut path = path.clone();
+pub(crate) trait IntoUpdateOperationExtension {
+    fn into_update_ops(self, field: &Field, path: FieldPath) -> crate::Result<Vec<UpdateExpression>>;
+}
 
-        match write {
-            WriteExpression::NestedWrite(nested_write) => {
-                path.push(db_name);
-
-                nested_writes.extend(unfold_nested_write(nested_field, nested_write, path));
-            }
-            _ => {
-                path.push(db_name);
-                nested_writes.push((write, nested_field, path.join(".").to_owned()));
-            }
+impl IntoUpdateOperationExtension for WriteOperation {
+    fn into_update_ops(self, field: &Field, path: FieldPath) -> crate::Result<Vec<UpdateExpression>> {
+        match self {
+            WriteOperation::Scalar(op) => op.into_update_ops(field, path),
+            WriteOperation::Composite(op) => op.into_update_ops(field, path),
         }
     }
+}
 
-    nested_writes
+impl IntoUpdateOperationExtension for ScalarWriteOperation {
+    fn into_update_ops(self, field: &Field, field_path: FieldPath) -> crate::Result<Vec<UpdateExpression>> {
+        let dollar_field_path = field_path.dollar_path();
+
+        let doc = match self {
+            ScalarWriteOperation::Add(rhs) if field.is_list() => render_push_update_doc(rhs, field, field_path)?,
+            // We use $literal to enable the set of empty object, which is otherwise considered a syntax error
+            ScalarWriteOperation::Set(rhs) => {
+                UpdateExpression::set(field_path, doc! { "$literal": (field, rhs).into_bson()? })
+            }
+            ScalarWriteOperation::Add(rhs) => UpdateExpression::set(
+                field_path,
+                doc! { "$add": [dollar_field_path, (field, rhs).into_bson()?] },
+            ),
+            ScalarWriteOperation::Substract(rhs) => UpdateExpression::set(
+                field_path,
+                doc! { "$subtract": [dollar_field_path, (field, rhs).into_bson()?] },
+            ),
+            ScalarWriteOperation::Multiply(rhs) => UpdateExpression::set(
+                field_path,
+                doc! { "$multiply": [dollar_field_path, (field, rhs).into_bson()?] },
+            ),
+            ScalarWriteOperation::Divide(rhs) => UpdateExpression::set(
+                field_path,
+                doc! { "$divide": [dollar_field_path, (field, rhs).into_bson()?] },
+            ),
+            ScalarWriteOperation::Field(_) => unimplemented!(),
+        };
+
+        Ok(vec![doc])
+    }
+}
+
+impl IntoUpdateOperationExtension for CompositeWriteOperation {
+    fn into_update_ops(self, field: &Field, path: FieldPath) -> crate::Result<Vec<UpdateExpression>> {
+        let dollar_field_path = path.dollar_path();
+
+        let docs = match self {
+            // We use $literal to enable the set of empty object, which is otherwise considered a syntax error
+            CompositeWriteOperation::Set(rhs) => {
+                vec![UpdateExpression::set(
+                    path,
+                    doc! { "$literal": (field, rhs).into_bson()? },
+                )]
+            }
+            CompositeWriteOperation::Update(nested_write) => {
+                let mut update_docs = vec![];
+
+                for (write_op, field, field_path) in nested_write.unfold(field, path) {
+                    dbg!(&field_path);
+                    update_docs.extend(write_op.into_update_ops(field, field_path)?);
+                }
+
+                update_docs
+            }
+            CompositeWriteOperation::Unset(should_unset) => {
+                let mut ops = Vec::with_capacity(1);
+
+                if should_unset {
+                    ops.push(UpdateExpression::set(path, Bson::String("$$REMOVE".to_owned())))
+                }
+
+                ops
+            }
+            CompositeWriteOperation::Push(rhs) => {
+                vec![render_push_update_doc(rhs, field, path)?]
+            }
+            CompositeWriteOperation::Upsert { set, update } => {
+                let should_set_id = format!("__prisma_should_set__{}", &path.identifier());
+                let should_set_ref_id = format!("${}", &should_set_id);
+
+                let set_docs = (*set)
+                    .into_update_ops(field, path.clone())?
+                    .into_iter()
+                    .map(|op| {
+                        let set = op.try_into_set().unwrap();
+                        let cond = doc! { "$eq": [&should_set_ref_id, true] };
+
+                        // Maps a Set expression to be executed _only_ if the field should be set and not updated. eg:
+                        // From: { $set: { {field_path}: {some_expression} } }
+                        // To:   { $set: { $cond: { if: {cond}, then: {some_expression}, else: "${field_path}"  } } }
+                        // where {cond} is the expression is the `cond` variable above
+                        UpdateExpression::set_upsert(
+                            set.field_path().clone(),
+                            UpdateExpression::if_then_else(
+                                cond,
+                                set.expression().clone(),
+                                Bson::String(set.field_path().dollar_path()),
+                            ),
+                        )
+                    })
+                    .collect_vec();
+                let update_docs = (*update)
+                    .into_update_ops(field, path)?
+                    .into_iter()
+                    .map(|op| match op {
+                        UpdateExpression::Set(set) => {
+                            // Because nested `upsert`s can be part of `update` operations,
+                            // Both `CompositeWriteOperation::Upsert { set }` and `CompositeWriteOperation::Upsert { set }` operations can be found in an `upsert.update`
+                            // Consequently, we need to know what type of Set expression we're dealing with to set the appropriate conditions.
+                            let cond = if set.is_upsert_set {
+                                doc! { "$eq": [&should_set_ref_id, true] }
+                            } else {
+                                doc! { "$eq": [&should_set_ref_id, false] }
+                            };
+
+                            // Maps a Set expression to be executed _only_ if the field should be set _or_ updated. eg:
+                            // From: { $set: { {field_path}: {some_expression} } }
+                            // To:   { $set: { $cond: { if: {cond}, then: {some_expression}, else: "${field_path}"  } } }
+                            // where {cond} is the expression is the `cond` variable above
+                            UpdateExpression::set(
+                                set.field_path().clone(),
+                                UpdateExpression::if_then_else(
+                                    cond,
+                                    set.expression().clone(),
+                                    Bson::String(set.field_path().dollar_path()),
+                                ),
+                            )
+                        }
+                        x => x,
+                    })
+                    .collect_vec();
+                let mut docs: Vec<UpdateExpression> = vec![];
+
+                // Adds a `__should_set__{field_path}` field that states whether a field needs to be `set` or `updated`
+                // `__should_set__` is true when {field_path} is null or absent
+                docs.push(
+                    doc! { "$addFields": {
+                        &should_set_id: {
+                            "$eq": [{ "$ifNull": [dollar_field_path, true] }, true]
+                        }
+                    }}
+                    .into(),
+                );
+                docs.extend(set_docs);
+                docs.extend(update_docs);
+                // Unsets the `__should_set__{field_path}` field
+                docs.push(doc! { "$unset": Bson::from(should_set_id) }.into());
+
+                docs
+            }
+        };
+
+        Ok(docs)
+    }
+}
+
+fn render_push_update_doc(rhs: PrismaValue, field: &Field, field_path: FieldPath) -> crate::Result<UpdateExpression> {
+    let dollar_field_path = field_path.dollar_path();
+
+    let doc = match rhs {
+        PrismaValue::List(vals) => {
+            let vals = vals
+                .into_iter()
+                .map(|val| (field, val).into_bson())
+                .collect::<crate::Result<Vec<_>>>()?
+                .into_iter()
+                .map(|bson| {
+                    // Strip the list from the BSON values. [Todo] This is unfortunately necessary right now due to how the
+                    // conversion is set up with native types, we should clean that up at some point (move from traits to fns?).
+                    if let Bson::Array(mut inner) = bson {
+                        inner.pop().unwrap()
+                    } else {
+                        bson
+                    }
+                })
+                .collect();
+
+            let bson_array = Bson::Array(vals);
+
+            UpdateExpression::set(
+                field_path,
+                doc! {
+                    "$ifNull": [
+                        { "$concatArrays": [dollar_field_path, bson_array.clone()] },
+                        bson_array
+                    ]
+                },
+            )
+        }
+        val => {
+            let bson_val = match (field, val).into_bson()? {
+                bson @ Bson::Array(_) => bson,
+                bson => Bson::Array(vec![bson]),
+            };
+
+            UpdateExpression::set(
+                field_path,
+                doc! {
+                    "$ifNull": [
+                        { "$concatArrays": [dollar_field_path, bson_val.clone()] },
+                        bson_val
+                    ]
+                },
+            )
+        }
+    };
+
+    Ok(doc)
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum UpdateExpression {
+    Set(Set),
+    IfThenElse(IfThenElse),
+    Generic(Bson),
+}
+
+impl IntoBson for UpdateExpression {
+    fn into_bson(self) -> crate::Result<Bson> {
+        let bson: Bson = match self {
+            UpdateExpression::Set(set) => {
+                doc! { "$set": { set.field_path.path(): (*set.expression).into_bson()? } }.into()
+            }
+            UpdateExpression::IfThenElse(if_then_else) => doc! {
+                "$cond": {
+                    "if": (*if_then_else.cond).into_bson()?,
+                    "then": (*if_then_else.then).into_bson()?,
+                    "else": (*if_then_else.els).into_bson()?
+                }
+
+            }
+            .into(),
+            UpdateExpression::Generic(bson) => bson,
+        };
+
+        Ok(bson)
+    }
+}
+
+impl From<Bson> for UpdateExpression {
+    fn from(bson: Bson) -> Self {
+        Self::Generic(bson)
+    }
+}
+
+impl From<Document> for UpdateExpression {
+    fn from(doc: Document) -> Self {
+        Self::Generic(doc.into())
+    }
+}
+
+impl From<Set> for UpdateExpression {
+    fn from(set: Set) -> Self {
+        Self::Set(set)
+    }
+}
+
+impl From<IfThenElse> for UpdateExpression {
+    fn from(if_then_else: IfThenElse) -> Self {
+        Self::IfThenElse(if_then_else)
+    }
+}
+
+impl UpdateExpression {
+    pub fn set(field_path: FieldPath, operation: impl Into<UpdateExpression>) -> Self {
+        Self::Set(Set {
+            field_path,
+            expression: Box::new(operation.into()),
+            is_upsert_set: false,
+        })
+    }
+
+    /// Create a set expression specifically for an `upsert.set` operation
+    pub fn set_upsert(field_path: FieldPath, operation: impl Into<UpdateExpression>) -> Self {
+        Self::Set(Set {
+            field_path,
+            expression: Box::new(operation.into()),
+            is_upsert_set: true,
+        })
+    }
+
+    pub fn if_then_else(
+        cond: impl Into<UpdateExpression>,
+        then: impl Into<UpdateExpression>,
+        els: impl Into<UpdateExpression>,
+    ) -> Self {
+        Self::IfThenElse(IfThenElse {
+            cond: Box::new(cond.into()),
+            then: Box::new(then.into()),
+            els: Box::new(els.into()),
+        })
+    }
+
+    fn try_into_set(self) -> Option<Set> {
+        if let Self::Set(set) = self {
+            Some(set)
+        } else {
+            None
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct Set {
+    /// The field path to which this set expression should be applied
+    pub field_path: FieldPath,
+    /// The inner expression that should be set
+    pub expression: Box<UpdateExpression>,
+    /// Is the expression the `set` part of an `upsert`
+    pub is_upsert_set: bool,
+}
+
+impl Set {
+    /// Get a reference to the set's field path.
+    fn field_path(&self) -> &FieldPath {
+        &self.field_path
+    }
+
+    /// Get a reference to the set's expression.
+    fn expression(&self) -> &UpdateExpression {
+        self.expression.as_ref()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct IfThenElse {
+    pub cond: Box<UpdateExpression>,
+    pub then: Box<UpdateExpression>,
+    pub els: Box<UpdateExpression>,
 }

--- a/query-engine/connectors/mongodb-query-connector/src/root_queries/write.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/root_queries/write.rs
@@ -6,6 +6,7 @@ use crate::{
     IntoBson,
 };
 use connector_interface::*;
+use itertools::Itertools;
 use mongodb::{
     bson::{doc, Document},
     error::ErrorKind,
@@ -112,7 +113,7 @@ pub async fn update_records<'conn>(
     session: &mut ClientSession,
     model: &ModelRef,
     record_filter: RecordFilter,
-    args: WriteArgs,
+    mut args: WriteArgs,
 ) -> crate::Result<Vec<SelectionResult>> {
     let coll = database.collection::<Document>(model.db_name());
 
@@ -139,86 +140,23 @@ pub async fn update_records<'conn>(
     }
 
     let filter = doc! { id_field.db_name(): { "$in": ids.clone() } };
-    let fields = model.fields().scalar();
+    let fields: Vec<_> = model
+        .fields()
+        .all
+        .iter()
+        .filter_map(|field| {
+            args.take_field_value(field.db_name())
+                .map(|write_expr| (field.clone(), write_expr))
+        })
+        .collect();
+
     let mut update_docs: Vec<Document> = vec![];
 
-    for (field_name, write_expr) in args.args {
-        let DatasourceFieldName(name) = field_name;
-
-        // Todo: This is inefficient.
-        let field = fields.iter().find(|f| f.db_name() == name).unwrap();
+    for (field, write_expr) in fields {
         let field_name = field.db_name();
-        let dollar_field_name = format!("${}", field.db_name());
+        let docs = render_update_docs(write_expr, &field, field_name)?;
 
-        let doc = match write_expr {
-            WriteExpression::Add(rhs) if field.is_list() => match rhs {
-                PrismaValue::List(vals) => {
-                    let vals = vals
-                        .into_iter()
-                        .map(|val| (field, val).into_bson())
-                        .collect::<crate::Result<Vec<_>>>()?
-                        .into_iter()
-                        .map(|bson| {
-                            // Strip the list from the BSON values. [Todo] This is unfortunately necessary right now due to how the
-                            // conversion is set up with native types, we should clean that up at some point (move from traits to fns?).
-                            if let Bson::Array(mut inner) = bson {
-                                inner.pop().unwrap()
-                            } else {
-                                bson
-                            }
-                        })
-                        .collect();
-
-                    let bson_array = Bson::Array(vals);
-
-                    doc! {
-                        "$set": { field_name: {
-                            "$ifNull": [
-                                { "$concatArrays": [dollar_field_name, bson_array.clone()] },
-                                bson_array
-                            ]
-                        } }
-                    }
-                }
-                val => {
-                    let bson_val = match (field, val).into_bson()? {
-                        bson @ Bson::Array(_) => bson,
-                        bson => Bson::Array(vec![bson]),
-                    };
-
-                    doc! {
-                        "$set": {
-                            field_name: {
-                                "$ifNull": [
-                                    { "$concatArrays": [dollar_field_name, bson_val.clone()] },
-                                    bson_val
-                                ]
-                            }
-                        }
-                    }
-                }
-            },
-            WriteExpression::CompositeWrite(_) => unimplemented!(),
-            // We use $literal to enable the set of empty object, which is otherwise considered a syntax error
-            WriteExpression::Value(rhs) => doc! {
-                "$set": { field_name: { "$literal": (field, rhs).into_bson()? } }
-            },
-            WriteExpression::Add(rhs) => doc! {
-                "$set": { field_name: { "$add": [dollar_field_name, (field, rhs).into_bson()?] } }
-            },
-            WriteExpression::Substract(rhs) => doc! {
-                "$set": { field_name: { "$subtract": [dollar_field_name, (field, rhs).into_bson()?] } }
-            },
-            WriteExpression::Multiply(rhs) => doc! {
-                "$set": { field_name: { "$multiply": [dollar_field_name, (field, rhs).into_bson()?] } }
-            },
-            WriteExpression::Divide(rhs) => doc! {
-                "$set": { field_name: { "$divide": [dollar_field_name, (field, rhs).into_bson()?] } }
-            },
-            WriteExpression::Field(_) => unimplemented!(),
-        };
-
-        update_docs.push(doc);
+        update_docs.extend(docs);
     }
 
     if !update_docs.is_empty() {
@@ -237,6 +175,124 @@ pub async fn update_records<'conn>(
         .collect::<crate::Result<Vec<_>>>()?;
 
     Ok(ids)
+}
+
+fn render_update_docs(write_expr: WriteExpression, field: &Field, field_name: &str) -> crate::Result<Vec<Document>> {
+    if let WriteExpression::NestedWrite(nested_write) = write_expr {
+        let docs = unfold_nested_write(field, nested_write, &mut vec![field.db_name().to_owned()])
+            .into_iter()
+            // TODO: figure out why we can't flat_map here
+            // TODO: the trait `FromIterator<Vec<mongodb::bson::Document>>` is not implemented for `std::result::Result<Vec<mongodb::bson::Document>, MongoError>`
+            .map(|(write_expr, field, field_name)| render_update_docs(write_expr, field, &field_name))
+            .collect::<crate::Result<Vec<_>>>()?;
+
+        return Ok(docs.into_iter().flatten().collect_vec());
+    };
+
+    let dollar_field_name = format!("${}", field.db_name());
+
+    let doc = match write_expr {
+        WriteExpression::Add(rhs) if field.is_list() => match rhs {
+            PrismaValue::List(vals) => {
+                let vals = vals
+                    .into_iter()
+                    .map(|val| (field, val).into_bson())
+                    .collect::<crate::Result<Vec<_>>>()?
+                    .into_iter()
+                    .map(|bson| {
+                        // Strip the list from the BSON values. [Todo] This is unfortunately necessary right now due to how the
+                        // conversion is set up with native types, we should clean that up at some point (move from traits to fns?).
+                        if let Bson::Array(mut inner) = bson {
+                            inner.pop().unwrap()
+                        } else {
+                            bson
+                        }
+                    })
+                    .collect();
+
+                let bson_array = Bson::Array(vals);
+
+                doc! {
+                    "$set": { field_name: {
+                        "$ifNull": [
+                            { "$concatArrays": [dollar_field_name, bson_array.clone()] },
+                            bson_array
+                        ]
+                    } }
+                }
+            }
+            val => {
+                let bson_val = match (field, val).into_bson()? {
+                    bson @ Bson::Array(_) => bson,
+                    bson => Bson::Array(vec![bson]),
+                };
+
+                doc! {
+                    "$set": {
+                        field_name: {
+                            "$ifNull": [
+                                { "$concatArrays": [dollar_field_name, bson_val.clone()] },
+                                bson_val
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        // We use $literal to enable the set of empty object, which is otherwise considered a syntax error
+        WriteExpression::Value(rhs) => doc! {
+            "$set": { field_name: { "$literal": (field, rhs).into_bson()? } }
+        },
+        WriteExpression::Add(rhs) => doc! {
+            "$set": { field_name: { "$add": [dollar_field_name, (field, rhs).into_bson()?] } }
+        },
+        WriteExpression::Substract(rhs) => doc! {
+            "$set": { field_name: { "$subtract": [dollar_field_name, (field, rhs).into_bson()?] } }
+        },
+        WriteExpression::Multiply(rhs) => doc! {
+            "$set": { field_name: { "$multiply": [dollar_field_name, (field, rhs).into_bson()?] } }
+        },
+        WriteExpression::Divide(rhs) => doc! {
+            "$set": { field_name: { "$divide": [dollar_field_name, (field, rhs).into_bson()?] } }
+        },
+        WriteExpression::NestedWrite(_) => unreachable!(),
+        WriteExpression::Field(_) => unimplemented!(),
+    };
+
+    Ok(vec![doc])
+}
+
+fn unfold_nested_write<'a>(
+    field: &'a Field,
+    nested_write: NestedWrite,
+    path: &mut Vec<String>,
+) -> Vec<(WriteExpression, &'a Field, String)> {
+    let mut res: Vec<(WriteExpression, &'a Field, String)> = vec![];
+
+    for (DatasourceFieldName(db_name), write) in nested_write.writes {
+        let nested_field = field
+            .as_composite()
+            .unwrap()
+            .typ
+            .find_field_by_db_name(&db_name)
+            .unwrap();
+
+        match write {
+            WriteExpression::NestedWrite(nested_write) => {
+                let mut path = path.clone();
+
+                path.push(db_name);
+
+                res.extend(unfold_nested_write(nested_field, nested_write, &mut path));
+            }
+            _ => {
+                path.push(db_name);
+                res.push((write, nested_field, path.join(".").to_owned()));
+            }
+        }
+    }
+
+    res
 }
 
 pub async fn delete_records<'conn>(

--- a/query-engine/connectors/mongodb-query-connector/src/root_queries/write.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/root_queries/write.rs
@@ -6,7 +6,6 @@ use crate::{
     IntoBson,
 };
 use connector_interface::*;
-use itertools::Itertools;
 use mongodb::{
     bson::{doc, Document},
     error::ErrorKind,
@@ -154,7 +153,7 @@ pub async fn update_records<'conn>(
 
     for (field, write_expr) in fields {
         let field_name = field.db_name();
-        let docs = render_update_docs(write_expr, &field, field_name)?;
+        let docs = update_utils::render_update_docs(write_expr, &field, field_name)?;
 
         update_docs.extend(docs);
     }
@@ -175,124 +174,6 @@ pub async fn update_records<'conn>(
         .collect::<crate::Result<Vec<_>>>()?;
 
     Ok(ids)
-}
-
-fn render_update_docs(write_expr: WriteExpression, field: &Field, field_name: &str) -> crate::Result<Vec<Document>> {
-    if let WriteExpression::NestedWrite(nested_write) = write_expr {
-        let docs = unfold_nested_write(field, nested_write, &mut vec![field.db_name().to_owned()])
-            .into_iter()
-            // TODO: figure out why we can't flat_map here
-            // TODO: the trait `FromIterator<Vec<mongodb::bson::Document>>` is not implemented for `std::result::Result<Vec<mongodb::bson::Document>, MongoError>`
-            .map(|(write_expr, field, field_name)| render_update_docs(write_expr, field, &field_name))
-            .collect::<crate::Result<Vec<_>>>()?;
-
-        return Ok(docs.into_iter().flatten().collect_vec());
-    };
-
-    let dollar_field_name = format!("${}", field.db_name());
-
-    let doc = match write_expr {
-        WriteExpression::Add(rhs) if field.is_list() => match rhs {
-            PrismaValue::List(vals) => {
-                let vals = vals
-                    .into_iter()
-                    .map(|val| (field, val).into_bson())
-                    .collect::<crate::Result<Vec<_>>>()?
-                    .into_iter()
-                    .map(|bson| {
-                        // Strip the list from the BSON values. [Todo] This is unfortunately necessary right now due to how the
-                        // conversion is set up with native types, we should clean that up at some point (move from traits to fns?).
-                        if let Bson::Array(mut inner) = bson {
-                            inner.pop().unwrap()
-                        } else {
-                            bson
-                        }
-                    })
-                    .collect();
-
-                let bson_array = Bson::Array(vals);
-
-                doc! {
-                    "$set": { field_name: {
-                        "$ifNull": [
-                            { "$concatArrays": [dollar_field_name, bson_array.clone()] },
-                            bson_array
-                        ]
-                    } }
-                }
-            }
-            val => {
-                let bson_val = match (field, val).into_bson()? {
-                    bson @ Bson::Array(_) => bson,
-                    bson => Bson::Array(vec![bson]),
-                };
-
-                doc! {
-                    "$set": {
-                        field_name: {
-                            "$ifNull": [
-                                { "$concatArrays": [dollar_field_name, bson_val.clone()] },
-                                bson_val
-                            ]
-                        }
-                    }
-                }
-            }
-        },
-        // We use $literal to enable the set of empty object, which is otherwise considered a syntax error
-        WriteExpression::Value(rhs) => doc! {
-            "$set": { field_name: { "$literal": (field, rhs).into_bson()? } }
-        },
-        WriteExpression::Add(rhs) => doc! {
-            "$set": { field_name: { "$add": [dollar_field_name, (field, rhs).into_bson()?] } }
-        },
-        WriteExpression::Substract(rhs) => doc! {
-            "$set": { field_name: { "$subtract": [dollar_field_name, (field, rhs).into_bson()?] } }
-        },
-        WriteExpression::Multiply(rhs) => doc! {
-            "$set": { field_name: { "$multiply": [dollar_field_name, (field, rhs).into_bson()?] } }
-        },
-        WriteExpression::Divide(rhs) => doc! {
-            "$set": { field_name: { "$divide": [dollar_field_name, (field, rhs).into_bson()?] } }
-        },
-        WriteExpression::NestedWrite(_) => unreachable!(),
-        WriteExpression::Field(_) => unimplemented!(),
-    };
-
-    Ok(vec![doc])
-}
-
-fn unfold_nested_write<'a>(
-    field: &'a Field,
-    nested_write: NestedWrite,
-    path: &mut Vec<String>,
-) -> Vec<(WriteExpression, &'a Field, String)> {
-    let mut res: Vec<(WriteExpression, &'a Field, String)> = vec![];
-
-    for (DatasourceFieldName(db_name), write) in nested_write.writes {
-        let nested_field = field
-            .as_composite()
-            .unwrap()
-            .typ
-            .find_field_by_db_name(&db_name)
-            .unwrap();
-
-        match write {
-            WriteExpression::NestedWrite(nested_write) => {
-                let mut path = path.clone();
-
-                path.push(db_name);
-
-                res.extend(unfold_nested_write(nested_field, nested_write, &mut path));
-            }
-            _ => {
-                path.push(db_name);
-                res.push((write, nested_field, path.join(".").to_owned()));
-            }
-        }
-    }
-
-    res
 }
 
 pub async fn delete_records<'conn>(

--- a/query-engine/connectors/query-connector/src/write_args.rs
+++ b/query-engine/connectors/query-connector/src/write_args.rs
@@ -49,8 +49,8 @@ pub enum WriteExpression {
     /// Reference to another field on the same model (unused at the moment).
     Field(DatasourceFieldName),
 
-    ///
-    CompositeWrite(CompositeWrite),
+    /// Represents nested writes for composites
+    NestedWrite(NestedWrite),
 
     /// Write plain value to field.
     Value(PrismaValue),
@@ -69,9 +69,8 @@ pub enum WriteExpression {
 }
 
 #[derive(Debug, PartialEq, Clone)]
-pub struct CompositeWrite {
-    field_name: DatasourceFieldName,
-    writes: Vec<WriteExpression>,
+pub struct NestedWrite {
+    pub writes: Vec<(DatasourceFieldName, WriteExpression)>,
 }
 
 impl From<PrismaValue> for WriteExpression {
@@ -262,6 +261,6 @@ pub fn apply_expression(val: PrismaValue, expr: WriteExpression) -> PrismaValue 
         WriteExpression::Substract(rhs) => val - rhs,
         WriteExpression::Multiply(rhs) => val * rhs,
         WriteExpression::Divide(rhs) => val / rhs,
-        WriteExpression::CompositeWrite(_) => unimplemented!(),
+        WriteExpression::NestedWrite(_) => unimplemented!(),
     }
 }

--- a/query-engine/connectors/query-connector/src/write_args.rs
+++ b/query-engine/connectors/query-connector/src/write_args.rs
@@ -1,13 +1,15 @@
 use crate::error::{ConnectorError, ErrorKind};
 use chrono::Utc;
 use indexmap::{map::Keys, IndexMap};
-use prisma_models::{CompositeFieldRef, ModelProjection, ModelRef, PrismaValue, ScalarFieldRef, SelectionResult};
+use prisma_models::{
+    CompositeFieldRef, Field, ModelProjection, ModelRef, PrismaValue, ScalarFieldRef, SelectedField, SelectionResult,
+};
 use std::{borrow::Borrow, convert::TryInto, ops::Deref};
 
 /// WriteArgs represent data to be written to an underlying data source.
 #[derive(Debug, PartialEq, Clone, Default)]
 pub struct WriteArgs {
-    pub args: IndexMap<DatasourceFieldName, WriteExpression>,
+    pub args: IndexMap<DatasourceFieldName, WriteOperation>,
 }
 
 /// Wrapper struct to force a bit of a reflection whether or not the string passed
@@ -45,15 +47,95 @@ impl From<&CompositeFieldRef> for DatasourceFieldName {
 /// A WriteExpression allows to express more complex operations on how the data is written,
 /// like field or inter-field arithmetic.
 #[derive(Debug, PartialEq, Clone)]
-pub enum WriteExpression {
+pub enum WriteOperation {
+    Scalar(ScalarWriteOperation),
+    Composite(CompositeWriteOperation),
+}
+
+impl WriteOperation {
+    pub fn scalar_set(pv: PrismaValue) -> Self {
+        Self::Scalar(ScalarWriteOperation::Set(pv))
+    }
+
+    pub fn scalar_add(pv: PrismaValue) -> Self {
+        Self::Scalar(ScalarWriteOperation::Add(pv))
+    }
+
+    pub fn scalar_substract(pv: PrismaValue) -> Self {
+        Self::Scalar(ScalarWriteOperation::Substract(pv))
+    }
+
+    pub fn scalar_multiply(pv: PrismaValue) -> Self {
+        Self::Scalar(ScalarWriteOperation::Multiply(pv))
+    }
+
+    pub fn scalar_divide(pv: PrismaValue) -> Self {
+        Self::Scalar(ScalarWriteOperation::Divide(pv))
+    }
+
+    pub fn composite_set(pv: PrismaValue) -> Self {
+        Self::Composite(CompositeWriteOperation::Set(pv))
+    }
+
+    pub fn composite_unset(should_unset: bool) -> Self {
+        Self::Composite(CompositeWriteOperation::Unset(should_unset))
+    }
+
+    pub fn composite_update(writes: Vec<(DatasourceFieldName, WriteOperation)>) -> Self {
+        Self::Composite(CompositeWriteOperation::Update(NestedWrite { writes }))
+    }
+
+    pub fn composite_push(pv: PrismaValue) -> Self {
+        Self::Composite(CompositeWriteOperation::Push(pv))
+    }
+
+    pub fn composite_upsert(set: CompositeWriteOperation, update: CompositeWriteOperation) -> Self {
+        Self::Composite(CompositeWriteOperation::Upsert {
+            set: Box::new(set),
+            update: Box::new(update),
+        })
+    }
+
+    pub fn as_scalar(&self) -> Option<&ScalarWriteOperation> {
+        if let Self::Scalar(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    pub fn as_composite(&self) -> Option<&CompositeWriteOperation> {
+        if let Self::Composite(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    pub fn try_into_scalar(self) -> Option<ScalarWriteOperation> {
+        if let Self::Scalar(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    pub fn try_into_composite(self) -> Option<CompositeWriteOperation> {
+        if let Self::Composite(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum ScalarWriteOperation {
     /// Reference to another field on the same model (unused at the moment).
     Field(DatasourceFieldName),
 
-    /// Represents nested writes for composites
-    NestedWrite(NestedWrite),
-
     /// Write plain value to field.
-    Value(PrismaValue),
+    Set(PrismaValue),
 
     /// Add value to field.
     Add(PrismaValue),
@@ -69,22 +151,130 @@ pub enum WriteExpression {
 }
 
 #[derive(Debug, PartialEq, Clone)]
-pub struct NestedWrite {
-    pub writes: Vec<(DatasourceFieldName, WriteExpression)>,
+pub enum CompositeWriteOperation {
+    Set(PrismaValue),
+    Push(PrismaValue),
+    Unset(bool),
+    Update(NestedWrite),
+    Upsert {
+        set: Box<CompositeWriteOperation>,
+        update: Box<CompositeWriteOperation>,
+    },
 }
 
-impl From<PrismaValue> for WriteExpression {
-    fn from(pv: PrismaValue) -> Self {
-        WriteExpression::Value(pv)
+#[derive(Debug, PartialEq, Clone)]
+pub struct NestedWrite {
+    pub writes: Vec<(DatasourceFieldName, WriteOperation)>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct FieldPath {
+    path: Vec<String>,
+}
+
+impl FieldPath {
+    pub fn new_from_segment(field: &Field) -> Self {
+        let mut path = Self::default();
+        path.add_segment(field);
+
+        path
+    }
+
+    pub fn add_segment(&mut self, field: &Field) {
+        self.path.push(field.db_name().to_owned());
+    }
+
+    pub fn path(&self) -> String {
+        self.path.join(".")
+    }
+
+    pub fn dollar_path(&self) -> String {
+        format!("${}", self.path())
+    }
+
+    pub fn identifier(&self) -> String {
+        self.path.join("_")
     }
 }
 
-impl TryInto<PrismaValue> for WriteExpression {
+impl NestedWrite {
+    /// Unfolds nested writes into a flat list of `WriteOperation`s.
+    ///
+    /// Given the following `NestedWrite`:
+    /// ```text
+    /// Vec [(
+    ///       "field_a",
+    ///       WriteOperation::Composite(Update(Vec[("field_b", WriteOperation::Composite(Set("3")))]))
+    ///     )]
+    /// ```
+    /// `unfold` will roughly return:
+    /// ```text
+    /// Vec[(Set("3"), Field("field_b"), "field_a.field_b")]
+    /// ```
+    /// where:
+    ///  - `Set("3")` is the write operation to execute
+    ///  - `Field("field_b")` is the field on which to execute the write operation
+    /// - `"field_a.field_b"` is the path for MongoDB to access the nested field
+    pub fn unfold(self, field: &Field, field_path: FieldPath) -> Vec<(WriteOperation, &Field, FieldPath)> {
+        self.unfold_internal(field, field_path)
+    }
+
+    fn unfold_internal(self, field: &'_ Field, field_path: FieldPath) -> Vec<(WriteOperation, &'_ Field, FieldPath)> {
+        let mut nested_writes: Vec<(WriteOperation, &Field, FieldPath)> = vec![];
+
+        for (DatasourceFieldName(db_name), write) in self.writes {
+            let nested_field = field
+                .as_composite()
+                .unwrap()
+                .typ
+                .find_field_by_db_name(&db_name)
+                .unwrap();
+            let mut new_path = field_path.clone();
+
+            new_path.add_segment(nested_field);
+
+            match write {
+                WriteOperation::Composite(CompositeWriteOperation::Update(nested_write)) => {
+                    nested_writes.extend(nested_write.unfold_internal(nested_field, new_path));
+                }
+                _ => {
+                    nested_writes.push((write, nested_field, new_path));
+                }
+            }
+        }
+
+        nested_writes
+    }
+}
+
+impl From<(&ScalarFieldRef, PrismaValue)> for WriteOperation {
+    fn from((_, pv): (&ScalarFieldRef, PrismaValue)) -> Self {
+        WriteOperation::scalar_set(pv)
+    }
+}
+
+impl From<(&CompositeFieldRef, PrismaValue)> for WriteOperation {
+    fn from((_, pv): (&CompositeFieldRef, PrismaValue)) -> Self {
+        WriteOperation::composite_set(pv)
+    }
+}
+
+impl From<(&SelectedField, PrismaValue)> for WriteOperation {
+    fn from((selection, pv): (&SelectedField, PrismaValue)) -> Self {
+        match selection {
+            SelectedField::Scalar(sf) => (sf, pv).into(),
+            SelectedField::Composite(cs) => (&cs.field, pv).into(),
+        }
+    }
+}
+
+impl TryInto<PrismaValue> for WriteOperation {
     type Error = ConnectorError;
 
     fn try_into(self) -> Result<PrismaValue, Self::Error> {
         match self {
-            WriteExpression::Value(pv) => Ok(pv),
+            WriteOperation::Scalar(ScalarWriteOperation::Set(pv)) => Ok(pv),
+            WriteOperation::Composite(CompositeWriteOperation::Set(pv)) => Ok(pv),
             x => Err(ConnectorError::from_kind(ErrorKind::InternalConversionError(format!(
                 "Unable to convert write expression {:?} into prisma value.",
                 x
@@ -93,30 +283,14 @@ impl TryInto<PrismaValue> for WriteExpression {
     }
 }
 
-impl From<IndexMap<DatasourceFieldName, PrismaValue>> for WriteArgs {
-    fn from(args: IndexMap<DatasourceFieldName, PrismaValue>) -> Self {
-        Self {
-            args: args.into_iter().map(|(k, v)| (k, WriteExpression::Value(v))).collect(),
-        }
-    }
-}
-
-impl From<IndexMap<DatasourceFieldName, WriteExpression>> for WriteArgs {
-    fn from(args: IndexMap<DatasourceFieldName, WriteExpression>) -> Self {
+impl From<IndexMap<DatasourceFieldName, WriteOperation>> for WriteArgs {
+    fn from(args: IndexMap<DatasourceFieldName, WriteOperation>) -> Self {
         Self { args }
     }
 }
 
-impl From<Vec<(DatasourceFieldName, PrismaValue)>> for WriteArgs {
-    fn from(pairs: Vec<(DatasourceFieldName, PrismaValue)>) -> Self {
-        Self {
-            args: pairs.into_iter().map(|(k, v)| (k, WriteExpression::Value(v))).collect(),
-        }
-    }
-}
-
-impl From<Vec<(DatasourceFieldName, WriteExpression)>> for WriteArgs {
-    fn from(pairs: Vec<(DatasourceFieldName, WriteExpression)>) -> Self {
+impl From<Vec<(DatasourceFieldName, WriteOperation)>> for WriteArgs {
+    fn from(pairs: Vec<(DatasourceFieldName, WriteOperation)>) -> Self {
         Self {
             args: pairs.into_iter().collect(),
         }
@@ -131,7 +305,7 @@ impl WriteArgs {
     pub fn insert<T, V>(&mut self, key: T, arg: V)
     where
         T: Into<DatasourceFieldName>,
-        V: Into<WriteExpression>,
+        V: Into<WriteOperation>,
     {
         self.args.insert(key.into(), arg.into());
     }
@@ -140,15 +314,15 @@ impl WriteArgs {
         self.args.contains_key(field)
     }
 
-    pub fn get_field_value(&self, field: &str) -> Option<&WriteExpression> {
+    pub fn get_field_value(&self, field: &str) -> Option<&WriteOperation> {
         self.args.get(field)
     }
 
-    pub fn take_field_value(&mut self, field: &str) -> Option<WriteExpression> {
+    pub fn take_field_value(&mut self, field: &str) -> Option<WriteOperation> {
         self.args.remove(field)
     }
 
-    pub fn keys(&self) -> Keys<DatasourceFieldName, WriteExpression> {
+    pub fn keys(&self) -> Keys<DatasourceFieldName, WriteOperation> {
         self.args.keys()
     }
 
@@ -166,7 +340,7 @@ impl WriteArgs {
 
         if let Some(f) = updated_at_field {
             if self.args.get(f.db_name()).is_none() {
-                self.args.insert(f.into(), now.into());
+                self.args.insert(f.into(), WriteOperation::scalar_set(now));
             }
         }
     }
@@ -175,8 +349,9 @@ impl WriteArgs {
         if !self.args.is_empty() {
             if let Some(field) = model.fields().updated_at() {
                 if self.args.get(field.db_name()).is_none() {
-                    self.args
-                        .insert(field.into(), PrismaValue::DateTime(Utc::now().into()).into());
+                    let now = PrismaValue::DateTime(Utc::now().into());
+
+                    self.args.insert(field.into(), WriteOperation::scalar_set(now));
                 }
             }
         }
@@ -231,7 +406,7 @@ pub fn merge_write_args(loaded_ids: Vec<SelectionResult>, incoming_args: WriteAr
     }
 
     // Contains all positions that need to be updated with the given expression.
-    let positions: IndexMap<usize, &WriteExpression> = loaded_ids
+    let positions: IndexMap<usize, &WriteOperation> = loaded_ids
         .first()
         .unwrap()
         .pairs
@@ -243,9 +418,10 @@ pub fn merge_write_args(loaded_ids: Vec<SelectionResult>, incoming_args: WriteAr
     loaded_ids
         .into_iter()
         .map(|mut id| {
-            for (position, expr) in positions.iter() {
+            for (position, write_op) in positions.iter() {
                 let current_val = id.pairs[position.to_owned()].1.clone();
-                id.pairs[position.to_owned()].1 = apply_expression(current_val, (*expr).clone());
+                id.pairs[position.to_owned()].1 =
+                    apply_expression(current_val, (*write_op.as_scalar().unwrap()).clone());
             }
 
             id
@@ -253,14 +429,13 @@ pub fn merge_write_args(loaded_ids: Vec<SelectionResult>, incoming_args: WriteAr
         .collect()
 }
 
-pub fn apply_expression(val: PrismaValue, expr: WriteExpression) -> PrismaValue {
-    match expr {
-        WriteExpression::Field(_) => unimplemented!(),
-        WriteExpression::Value(pv) => pv,
-        WriteExpression::Add(rhs) => val + rhs,
-        WriteExpression::Substract(rhs) => val - rhs,
-        WriteExpression::Multiply(rhs) => val * rhs,
-        WriteExpression::Divide(rhs) => val / rhs,
-        WriteExpression::NestedWrite(_) => unimplemented!(),
+pub fn apply_expression(val: PrismaValue, scalar_write: ScalarWriteOperation) -> PrismaValue {
+    match scalar_write {
+        ScalarWriteOperation::Field(_) => unimplemented!(),
+        ScalarWriteOperation::Set(pv) => pv,
+        ScalarWriteOperation::Add(rhs) => val + rhs,
+        ScalarWriteOperation::Substract(rhs) => val - rhs,
+        ScalarWriteOperation::Multiply(rhs) => val * rhs,
+        ScalarWriteOperation::Divide(rhs) => val / rhs,
     }
 }

--- a/query-engine/connectors/sql-query-connector/src/query_builder/write.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_builder/write.rs
@@ -1,6 +1,6 @@
 use crate::model_extensions::*;
 use crate::sql_trace::SqlTraceComment;
-use connector_interface::{DatasourceFieldName, WriteArgs, WriteExpression};
+use connector_interface::{DatasourceFieldName, ScalarWriteOperation, WriteArgs};
 use itertools::Itertools;
 use prisma_models::*;
 use quaint::ast::*;
@@ -68,8 +68,8 @@ pub fn create_records_nonempty(
             for field in affected_fields.iter() {
                 let value = arg.take_field_value(field.db_name());
                 match value {
-                    Some(expr) => {
-                        let value: PrismaValue = expr
+                    Some(write_op) => {
+                        let value: PrismaValue = write_op
                             .try_into()
                             .expect("Create calls can only use PrismaValue write expressions (right now).");
 
@@ -133,10 +133,10 @@ pub fn update_many(
                 .find(|f| f.db_name() == name)
                 .expect("Expected field to be valid");
 
-            let value: Expression = match val {
-                WriteExpression::Field(_) => unimplemented!(),
-                WriteExpression::Value(rhs) => field.value(rhs).into(),
-                WriteExpression::Add(rhs) if field.is_list() => {
+            let value: Expression = match val.try_into_scalar().unwrap() {
+                ScalarWriteOperation::Field(_) => unimplemented!(),
+                ScalarWriteOperation::Set(rhs) => field.value(rhs).into(),
+                ScalarWriteOperation::Add(rhs) if field.is_list() => {
                     let e: Expression = Column::from(name.clone()).into();
                     let vals: Vec<_> = match rhs {
                         PrismaValue::List(vals) => vals.into_iter().map(|val| field.value(val)).collect(),
@@ -146,27 +146,25 @@ pub fn update_many(
                     // Postgres only
                     e.compare_raw("||", Value::array(vals)).into()
                 }
-                WriteExpression::Add(rhs) => {
+                ScalarWriteOperation::Add(rhs) => {
                     let e: Expression<'_> = Column::from(name.clone()).into();
                     e + field.value(rhs).into()
                 }
 
-                WriteExpression::Substract(rhs) => {
+                ScalarWriteOperation::Substract(rhs) => {
                     let e: Expression<'_> = Column::from(name.clone()).into();
                     e - field.value(rhs).into()
                 }
 
-                WriteExpression::Multiply(rhs) => {
+                ScalarWriteOperation::Multiply(rhs) => {
                     let e: Expression<'_> = Column::from(name.clone()).into();
                     e * field.value(rhs).into()
                 }
 
-                WriteExpression::Divide(rhs) => {
+                ScalarWriteOperation::Divide(rhs) => {
                     let e: Expression<'_> = Column::from(name.clone()).into();
                     e / field.value(rhs).into()
                 }
-
-                WriteExpression::NestedWrite(_) => unreachable!("SQL Connectors do not support composite writes."),
             };
 
             acc.set(name, value)

--- a/query-engine/connectors/sql-query-connector/src/query_builder/write.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_builder/write.rs
@@ -166,7 +166,7 @@ pub fn update_many(
                     e / field.value(rhs).into()
                 }
 
-                WriteExpression::CompositeWrite(_) => unreachable!("SQL Connectors do not support composite writes."),
+                WriteExpression::NestedWrite(_) => unreachable!("SQL Connectors do not support composite writes."),
             };
 
             acc.set(name, value)

--- a/query-engine/core/src/query_ast/write.rs
+++ b/query-engine/core/src/query_ast/write.rs
@@ -31,7 +31,10 @@ impl WriteQuery {
         };
 
         for (selected_field, value) in result {
-            args.insert(DatasourceFieldName(selected_field.db_name().to_owned()), value)
+            args.insert(
+                DatasourceFieldName(selected_field.db_name().to_owned()),
+                (&selected_field, value),
+            )
         }
 
         args.update_datetimes(model);
@@ -136,7 +139,10 @@ impl CreateManyRecords {
     pub fn inject_result_into_all(&mut self, result: SelectionResult) {
         for (selected_field, value) in result {
             for args in self.args.iter_mut() {
-                args.insert(DatasourceFieldName(selected_field.db_name().to_owned()), value.clone())
+                args.insert(
+                    DatasourceFieldName(selected_field.db_name().to_owned()),
+                    (&selected_field, value.clone()),
+                )
             }
         }
     }

--- a/query-engine/core/src/query_graph_builder/write/write_args_parser.rs
+++ b/query-engine/core/src/query_graph_builder/write/write_args_parser.rs
@@ -4,8 +4,10 @@ use crate::{
     query_document::{ParsedInputMap, ParsedInputValue},
     ObjectTag,
 };
-use connector::{WriteArgs, WriteExpression};
-use prisma_models::{Field, ModelRef, PrismaValue, RelationFieldRef, TypeIdentifier};
+use connector::{DatasourceFieldName, NestedWrite, WriteArgs, WriteExpression};
+use prisma_models::{
+    CompositeFieldRef, Field, ModelRef, PrismaValue, RelationFieldRef, ScalarFieldRef, TypeIdentifier,
+};
 use std::{convert::TryInto, sync::Arc};
 
 #[derive(Default, Debug)]
@@ -25,49 +27,13 @@ impl WriteArgsParser {
                 let field = model.fields().find_from_all(&k).unwrap();
 
                 match field {
-                    Field::Scalar(sf) if sf.is_list() => match v {
-                        ParsedInputValue::List(_) => {
-                            let set_value: PrismaValue = v.try_into()?;
+                    Field::Scalar(sf) if sf.is_list() => {
+                        let expr = parse_scalar_list(v)?;
 
-                            args.args.insert(sf, set_value);
-                        }
-                        ParsedInputValue::Map(map) => {
-                            let expr = extract_scalar_list_ops(map)?;
-
-                            args.args.insert(sf, expr)
-                        }
-                        _ => unreachable!(),
-                    },
-
+                        args.args.insert(sf, expr);
+                    }
                     Field::Scalar(sf) => {
-                        let expr: WriteExpression = match v {
-                            ParsedInputValue::Single(PrismaValue::Enum(e))
-                                if sf.type_identifier == TypeIdentifier::Json =>
-                            {
-                                let val = match e.as_str() {
-                                    json_null::DB_NULL => PrismaValue::Null,
-                                    json_null::JSON_NULL => PrismaValue::Json("null".to_owned()),
-                                    _ => unreachable!(), // Validation guarantees correct enum values.
-                                };
-
-                                val.into()
-                            }
-                            ParsedInputValue::Single(v) => v.into(),
-                            ParsedInputValue::Map(map) => {
-                                let (operation, value) = map.into_iter().next().unwrap();
-                                let value: PrismaValue = value.try_into()?;
-
-                                match operation.as_str() {
-                                    operations::SET => WriteExpression::Value(value),
-                                    operations::INCREMENT => WriteExpression::Add(value),
-                                    operations::DECREMENT => WriteExpression::Substract(value),
-                                    operations::MULTIPLY => WriteExpression::Multiply(value),
-                                    operations::DIVIDE => WriteExpression::Divide(value),
-                                    _ => unreachable!("Invalid update operation"),
-                                }
-                            }
-                            _ => unreachable!(),
-                        };
+                        let expr: WriteExpression = parse_scalar(sf, v)?;
 
                         args.args.insert(sf, expr)
                     }
@@ -78,29 +44,7 @@ impl WriteArgsParser {
                     },
 
                     Field::Composite(cf) => {
-                        let expr: WriteExpression = match v {
-                            // Null-set operation.
-                            ParsedInputValue::Single(PrismaValue::Null) => WriteExpression::Value(PrismaValue::Null),
-
-                            // Set list shorthand operation (can only be objects).
-                            ParsedInputValue::List(_) => {
-                                let list: PrismaValue = v.try_into()?;
-                                WriteExpression::Value(list)
-                            }
-
-                            // One of:
-                            // - Single object set shorthand.
-                            // - Operation envelope with further actions nested.
-                            ParsedInputValue::Map(map) => {
-                                if is_composite_envelope(&map) {
-                                    parse_composite_envelope(map)?
-                                } else {
-                                    WriteExpression::Value(ParsedInputValue::Map(map).try_into()?)
-                                }
-                            }
-
-                            _ => unreachable!(),
-                        };
+                        let expr = parse_composite_writes(cf, v, &mut vec![])?;
 
                         args.args.insert(cf, expr)
                     }
@@ -116,16 +60,131 @@ fn is_composite_envelope(map: &ParsedInputMap) -> bool {
     matches!(map.tag, Some(ObjectTag::CompositeEnvelope))
 }
 
-fn parse_composite_envelope(envelope: ParsedInputMap) -> QueryGraphBuilderResult<WriteExpression> {
+fn parse_scalar(sf: &ScalarFieldRef, v: ParsedInputValue) -> Result<WriteExpression, QueryGraphBuilderError> {
+    match v {
+        ParsedInputValue::Single(PrismaValue::Enum(e)) if sf.type_identifier == TypeIdentifier::Json => {
+            let val = match e.as_str() {
+                json_null::DB_NULL => PrismaValue::Null,
+                json_null::JSON_NULL => PrismaValue::Json("null".to_owned()),
+                _ => unreachable!(), // Validation guarantees correct enum values.
+            };
+
+            Ok(val.into())
+        }
+        ParsedInputValue::Single(v) => Ok(v.into()),
+        ParsedInputValue::Map(map) => {
+            let (operation, value) = map.into_iter().next().unwrap();
+            let value: PrismaValue = value.try_into()?;
+
+            let expr = match operation.as_str() {
+                operations::SET => WriteExpression::Value(value),
+                operations::INCREMENT => WriteExpression::Add(value),
+                operations::DECREMENT => WriteExpression::Substract(value),
+                operations::MULTIPLY => WriteExpression::Multiply(value),
+                operations::DIVIDE => WriteExpression::Divide(value),
+                _ => unreachable!("Invalid update operation"),
+            };
+
+            Ok(expr)
+        }
+        _ => unreachable!(),
+    }
+}
+
+fn parse_scalar_list(v: ParsedInputValue) -> QueryGraphBuilderResult<WriteExpression> {
+    match v {
+        ParsedInputValue::List(_) => {
+            let set_value: PrismaValue = v.try_into()?;
+
+            Ok(WriteExpression::Value(set_value))
+        }
+        ParsedInputValue::Map(map) => extract_scalar_list_ops(map),
+        _ => unreachable!(),
+    }
+}
+
+fn parse_composite_writes(
+    cf: &CompositeFieldRef,
+    v: ParsedInputValue,
+    path: &mut Vec<DatasourceFieldName>,
+) -> QueryGraphBuilderResult<WriteExpression> {
+    match v {
+        // Null-set operation.
+        ParsedInputValue::Single(PrismaValue::Null) => Ok(WriteExpression::Value(PrismaValue::Null)),
+
+        // Set list shorthand operation (can only be objects).
+        ParsedInputValue::List(_) => {
+            let list: PrismaValue = v.try_into()?;
+
+            Ok(WriteExpression::Value(list))
+        }
+
+        // One of:
+        // - Operation envelope with further actions nested.
+        // - Single object set shorthand.
+        ParsedInputValue::Map(map) => {
+            if is_composite_envelope(&map) {
+                parse_composite_envelope(cf, map, path)
+            } else {
+                Ok(WriteExpression::Value(ParsedInputValue::Map(map).try_into()?))
+            }
+        }
+        _ => unreachable!(),
+    }
+}
+
+// TODO: This is _NOT_ a good heuristic.
+fn is_composite_envelope(map: &ParsedInputMap) -> bool {
+    let envelope_keys = [operations::SET, operations::UPDATE];
+
+    map.iter().any(|(k, _)| envelope_keys.contains(&k.as_str()))
+}
+
+fn parse_composite_envelope(
+    cf: &CompositeFieldRef,
+    envelope: ParsedInputMap,
+    path: &mut Vec<DatasourceFieldName>,
+) -> QueryGraphBuilderResult<WriteExpression> {
     let (op, value) = envelope.into_iter().next().unwrap();
 
     let expr = match op.as_str() {
         // Everything in a set operation can only be plain values, no more nested operations.
         operations::SET => WriteExpression::Value(value.try_into()?),
+        operations::UPDATE => parse_composite_updates(cf, value.try_into()?, path)?,
+        // operations::PUSH => WriteExpression::Add(value.try_into()?),
         _ => unimplemented!(),
     };
 
     Ok(expr)
+}
+
+fn parse_composite_updates(
+    cf: &CompositeFieldRef,
+    map: ParsedInputMap,
+    path: &mut Vec<DatasourceFieldName>,
+) -> QueryGraphBuilderResult<WriteExpression> {
+    let mut writes = vec![];
+
+    for (k, v) in map {
+        let field = cf.typ.find_field(&k).unwrap();
+
+        let field_name: DatasourceFieldName = match field {
+            Field::Scalar(sf) => sf.into(),
+            Field::Composite(cf) => cf.into(),
+            _ => unreachable!(),
+        };
+
+        let expr = match field {
+            Field::Scalar(sf) if sf.is_list() => parse_scalar_list(v),
+            Field::Scalar(sf) => parse_scalar(&sf, v),
+            Field::Composite(cf) => parse_composite_writes(&cf, v, &mut path.clone()),
+            _ => unreachable!(),
+        }?;
+
+        writes.push((field_name, expr));
+    }
+
+    Ok(WriteExpression::NestedWrite(NestedWrite { writes }))
 }
 
 fn extract_scalar_list_ops(map: ParsedInputMap) -> QueryGraphBuilderResult<WriteExpression> {

--- a/query-engine/core/src/query_graph_builder/write/write_args_parser.rs
+++ b/query-engine/core/src/query_graph_builder/write/write_args_parser.rs
@@ -133,13 +133,6 @@ fn parse_composite_writes(
     }
 }
 
-// TODO: This is _NOT_ a good heuristic.
-fn is_composite_envelope(map: &ParsedInputMap) -> bool {
-    let envelope_keys = [operations::SET, operations::UPDATE];
-
-    map.iter().any(|(k, _)| envelope_keys.contains(&k.as_str()))
-}
-
 fn parse_composite_envelope(
     cf: &CompositeFieldRef,
     envelope: ParsedInputMap,

--- a/query-engine/core/src/query_graph_builder/write/write_args_parser.rs
+++ b/query-engine/core/src/query_graph_builder/write/write_args_parser.rs
@@ -4,7 +4,7 @@ use crate::{
     query_document::{ParsedInputMap, ParsedInputValue},
     ObjectTag,
 };
-use connector::{DatasourceFieldName, NestedWrite, WriteArgs, WriteExpression};
+use connector::{DatasourceFieldName, WriteArgs, WriteOperation};
 use prisma_models::{
     CompositeFieldRef, Field, ModelRef, PrismaValue, RelationFieldRef, ScalarFieldRef, TypeIdentifier,
 };
@@ -28,14 +28,14 @@ impl WriteArgsParser {
 
                 match field {
                     Field::Scalar(sf) if sf.is_list() => {
-                        let expr = parse_scalar_list(v)?;
+                        let write_op = parse_scalar_list(v)?;
 
-                        args.args.insert(sf, expr);
+                        args.args.insert(sf, write_op);
                     }
                     Field::Scalar(sf) => {
-                        let expr: WriteExpression = parse_scalar(sf, v)?;
+                        let write_op: WriteOperation = parse_scalar(sf, v)?;
 
-                        args.args.insert(sf, expr)
+                        args.args.insert(sf, write_op)
                     }
 
                     Field::Relation(ref rf) => match v {
@@ -44,9 +44,9 @@ impl WriteArgsParser {
                     },
 
                     Field::Composite(cf) => {
-                        let expr = parse_composite_writes(cf, v, &mut vec![])?;
+                        let write_op = parse_composite_writes(cf, v, &mut vec![])?;
 
-                        args.args.insert(cf, expr)
+                        args.args.insert(cf, write_op)
                     }
                 };
 
@@ -60,7 +60,7 @@ fn is_composite_envelope(map: &ParsedInputMap) -> bool {
     matches!(map.tag, Some(ObjectTag::CompositeEnvelope))
 }
 
-fn parse_scalar(sf: &ScalarFieldRef, v: ParsedInputValue) -> Result<WriteExpression, QueryGraphBuilderError> {
+fn parse_scalar(sf: &ScalarFieldRef, v: ParsedInputValue) -> Result<WriteOperation, QueryGraphBuilderError> {
     match v {
         ParsedInputValue::Single(PrismaValue::Enum(e)) if sf.type_identifier == TypeIdentifier::Json => {
             let val = match e.as_str() {
@@ -69,34 +69,34 @@ fn parse_scalar(sf: &ScalarFieldRef, v: ParsedInputValue) -> Result<WriteExpress
                 _ => unreachable!(), // Validation guarantees correct enum values.
             };
 
-            Ok(val.into())
+            Ok(WriteOperation::scalar_set(val))
         }
-        ParsedInputValue::Single(v) => Ok(v.into()),
+        ParsedInputValue::Single(v) => Ok(WriteOperation::scalar_set(v)),
         ParsedInputValue::Map(map) => {
             let (operation, value) = map.into_iter().next().unwrap();
             let value: PrismaValue = value.try_into()?;
 
-            let expr = match operation.as_str() {
-                operations::SET => WriteExpression::Value(value),
-                operations::INCREMENT => WriteExpression::Add(value),
-                operations::DECREMENT => WriteExpression::Substract(value),
-                operations::MULTIPLY => WriteExpression::Multiply(value),
-                operations::DIVIDE => WriteExpression::Divide(value),
+            let write_op = match operation.as_str() {
+                operations::SET => WriteOperation::scalar_set(value),
+                operations::INCREMENT => WriteOperation::scalar_add(value),
+                operations::DECREMENT => WriteOperation::scalar_substract(value),
+                operations::MULTIPLY => WriteOperation::scalar_multiply(value),
+                operations::DIVIDE => WriteOperation::scalar_divide(value),
                 _ => unreachable!("Invalid update operation"),
             };
 
-            Ok(expr)
+            Ok(write_op)
         }
         _ => unreachable!(),
     }
 }
 
-fn parse_scalar_list(v: ParsedInputValue) -> QueryGraphBuilderResult<WriteExpression> {
+fn parse_scalar_list(v: ParsedInputValue) -> QueryGraphBuilderResult<WriteOperation> {
     match v {
         ParsedInputValue::List(_) => {
             let set_value: PrismaValue = v.try_into()?;
 
-            Ok(WriteExpression::Value(set_value))
+            Ok(WriteOperation::scalar_set(set_value))
         }
         ParsedInputValue::Map(map) => extract_scalar_list_ops(map),
         _ => unreachable!(),
@@ -107,16 +107,16 @@ fn parse_composite_writes(
     cf: &CompositeFieldRef,
     v: ParsedInputValue,
     path: &mut Vec<DatasourceFieldName>,
-) -> QueryGraphBuilderResult<WriteExpression> {
+) -> QueryGraphBuilderResult<WriteOperation> {
     match v {
         // Null-set operation.
-        ParsedInputValue::Single(PrismaValue::Null) => Ok(WriteExpression::Value(PrismaValue::Null)),
+        ParsedInputValue::Single(PrismaValue::Null) => Ok(WriteOperation::composite_set(PrismaValue::Null)),
 
         // Set list shorthand operation (can only be objects).
         ParsedInputValue::List(_) => {
             let list: PrismaValue = v.try_into()?;
 
-            Ok(WriteExpression::Value(list))
+            Ok(WriteOperation::composite_set(list))
         }
 
         // One of:
@@ -126,7 +126,9 @@ fn parse_composite_writes(
             if is_composite_envelope(&map) {
                 parse_composite_envelope(cf, map, path)
             } else {
-                Ok(WriteExpression::Value(ParsedInputValue::Map(map).try_into()?))
+                let pv: PrismaValue = ParsedInputValue::Map(map).try_into()?;
+
+                Ok(WriteOperation::composite_set(pv))
             }
         }
         _ => unreachable!(),
@@ -137,25 +139,46 @@ fn parse_composite_envelope(
     cf: &CompositeFieldRef,
     envelope: ParsedInputMap,
     path: &mut Vec<DatasourceFieldName>,
-) -> QueryGraphBuilderResult<WriteExpression> {
+) -> QueryGraphBuilderResult<WriteOperation> {
     let (op, value) = envelope.into_iter().next().unwrap();
 
-    let expr = match op.as_str() {
+    let write_op = match op.as_str() {
         // Everything in a set operation can only be plain values, no more nested operations.
-        operations::SET => WriteExpression::Value(value.try_into()?),
+        operations::SET => WriteOperation::composite_set(value.try_into()?),
+        operations::PUSH => WriteOperation::composite_push(value.try_into()?),
+        operations::UNSET => parse_composite_unset(value.try_into()?),
         operations::UPDATE => parse_composite_updates(cf, value.try_into()?, path)?,
-        // operations::PUSH => WriteExpression::Add(value.try_into()?),
+        operations::UPSERT => parse_composite_upsert(cf, value.try_into()?, path)?,
         _ => unimplemented!(),
     };
 
-    Ok(expr)
+    Ok(write_op)
+}
+
+fn parse_composite_upsert(
+    cf: &CompositeFieldRef,
+    mut value: ParsedInputMap,
+    path: &mut Vec<DatasourceFieldName>,
+) -> QueryGraphBuilderResult<WriteOperation> {
+    let set = value.remove(operations::SET).unwrap();
+    let set = parse_composite_writes(cf, set, path)?.try_into_composite().unwrap();
+    let update: ParsedInputMap = value.remove(operations::UPDATE).unwrap().try_into()?;
+    let update = parse_composite_updates(cf, update, path)?.try_into_composite().unwrap();
+
+    Ok(WriteOperation::composite_upsert(set, update))
+}
+
+fn parse_composite_unset(pv: PrismaValue) -> WriteOperation {
+    let should_unset = pv.as_boolean().unwrap();
+
+    WriteOperation::composite_unset(*should_unset)
 }
 
 fn parse_composite_updates(
     cf: &CompositeFieldRef,
     map: ParsedInputMap,
     path: &mut Vec<DatasourceFieldName>,
-) -> QueryGraphBuilderResult<WriteExpression> {
+) -> QueryGraphBuilderResult<WriteOperation> {
     let mut writes = vec![];
 
     for (k, v) in map {
@@ -167,25 +190,26 @@ fn parse_composite_updates(
             _ => unreachable!(),
         };
 
-        let expr = match field {
+        let write_op = match field {
             Field::Scalar(sf) if sf.is_list() => parse_scalar_list(v),
             Field::Scalar(sf) => parse_scalar(&sf, v),
             Field::Composite(cf) => parse_composite_writes(&cf, v, &mut path.clone()),
             _ => unreachable!(),
         }?;
 
-        writes.push((field_name, expr));
+        writes.push((field_name, write_op));
     }
 
-    Ok(WriteExpression::NestedWrite(NestedWrite { writes }))
+    Ok(WriteOperation::composite_update(writes))
 }
 
-fn extract_scalar_list_ops(map: ParsedInputMap) -> QueryGraphBuilderResult<WriteExpression> {
+fn extract_scalar_list_ops(map: ParsedInputMap) -> QueryGraphBuilderResult<WriteOperation> {
     let (operation, value) = map.into_iter().next().unwrap();
+    let pv: PrismaValue = value.try_into()?;
 
     match operation.as_str() {
-        operations::SET => Ok(WriteExpression::Value(value.try_into()?)),
-        operations::PUSH => Ok(WriteExpression::Add(value.try_into()?)),
+        operations::SET => Ok(WriteOperation::scalar_set(pv)),
+        operations::PUSH => Ok(WriteOperation::scalar_add(pv)),
         _ => unreachable!("Invalid scalar list operation"),
     }
 }

--- a/query-engine/core/src/schema/input_types.rs
+++ b/query-engine/core/src/schema/input_types.rs
@@ -110,6 +110,12 @@ impl InputField {
         self
     }
 
+    /// Sets the field as optional (not required to be present on the input).
+    pub fn required(mut self) -> Self {
+        self.is_required = true;
+        self
+    }
+
     /// Sets the field as optional if the condition is true.
     pub fn optional_if(self, condition: bool) -> Self {
         if condition {

--- a/query-engine/core/src/schema_builder/constants.rs
+++ b/query-engine/core/src/schema_builder/constants.rs
@@ -44,6 +44,7 @@ pub mod operations {
 
     // scalar lists and composites
     pub const PUSH: &str = "push";
+    pub const UNSET: &str = "unset";
 
     // numbers
     pub const INCREMENT: &str = "increment";

--- a/query-engine/core/src/schema_builder/input_types/fields/data_input_mapper/create.rs
+++ b/query-engine/core/src/schema_builder/input_types/fields/data_input_mapper/create.rs
@@ -126,7 +126,7 @@ impl DataInputFieldMapper for CreateDataInputFieldMapper {
         // If the composite field in _not_ on a model, then it's nested and we're skipping the create envelope for now.
         // (This allows us to simplify the parsing code for now.)
         let mut input_types = if cf.container().as_model().is_some() {
-            vec![shorthand_type.clone(), envelope_type]
+            vec![envelope_type, shorthand_type.clone()]
         } else {
             vec![shorthand_type.clone()]
         };

--- a/query-engine/core/src/schema_builder/input_types/fields/data_input_mapper/create.rs
+++ b/query-engine/core/src/schema_builder/input_types/fields/data_input_mapper/create.rs
@@ -179,7 +179,7 @@ fn composite_create_envelope_object_type(ctx: &mut BuilderContext, cf: &Composit
     Arc::downgrade(&input_object)
 }
 
-fn composite_create_object_type(ctx: &mut BuilderContext, cf: &CompositeFieldRef) -> InputObjectTypeWeakRef {
+pub(crate) fn composite_create_object_type(ctx: &mut BuilderContext, cf: &CompositeFieldRef) -> InputObjectTypeWeakRef {
     // It's called "Create" input because it's used across multiple create-type operations, not only "set".
     let name = format!("{}CreateInput", cf.typ.name);
 

--- a/query-engine/core/src/schema_builder/input_types/fields/data_input_mapper/update.rs
+++ b/query-engine/core/src/schema_builder/input_types/fields/data_input_mapper/update.rs
@@ -233,7 +233,7 @@ fn composite_update_envelope_object_type(ctx: &mut BuilderContext, cf: &Composit
 }
 
 fn composite_unset_update_input_field(cf: &CompositeFieldRef) -> Option<InputField> {
-    if cf.is_required() {
+    if cf.is_required() || cf.is_list() {
         return None;
     }
 

--- a/query-engine/core/src/schema_builder/input_types/fields/data_input_mapper/update.rs
+++ b/query-engine/core/src/schema_builder/input_types/fields/data_input_mapper/update.rs
@@ -232,6 +232,7 @@ fn composite_update_envelope_object_type(ctx: &mut BuilderContext, cf: &Composit
 
     let mut input_object = init_input_object_type(ident.clone());
     input_object.require_exactly_one_field();
+    input_object.set_tag(ObjectTag::CompositeEnvelope);
 
     let input_object = Arc::new(input_object);
     ctx.cache_input_type(ident, input_object.clone());

--- a/query-engine/prisma-models/src/field/composite.rs
+++ b/query-engine/prisma-models/src/field/composite.rs
@@ -27,6 +27,10 @@ impl CompositeField {
         matches!(self.arity, FieldArity::Required)
     }
 
+    pub fn is_optional(&self) -> bool {
+        matches!(self.arity, FieldArity::Optional)
+    }
+
     pub fn db_name(&self) -> &str {
         self.db_name.as_deref().unwrap_or_else(|| self.name.as_str())
     }

--- a/query-engine/prisma-models/src/field/mod.rs
+++ b/query-engine/prisma-models/src/field/mod.rs
@@ -37,11 +37,15 @@ impl Field {
     }
 
     pub fn is_scalar(&self) -> bool {
-        match self {
-            Field::Scalar(_) => true,
-            Field::Relation(_) => false,
-            Field::Composite(_) => false,
-        }
+        matches!(self, Self::Scalar(_))
+    }
+
+    pub fn is_relation(&self) -> bool {
+        matches!(self, Self::Relation(..))
+    }
+
+    pub fn is_composite(&self) -> bool {
+        matches!(self, Self::Composite(_))
     }
 
     pub fn is_id(&self) -> bool {

--- a/query-engine/prisma-models/src/field/mod.rs
+++ b/query-engine/prisma-models/src/field/mod.rs
@@ -106,6 +106,14 @@ impl Field {
             Field::Composite(field) => FieldWeak::Composite(Arc::downgrade(field)),
         }
     }
+
+    pub fn as_composite(&self) -> Option<&CompositeFieldRef> {
+        if let Self::Composite(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/query-engine/prisma-models/src/field/scalar.rs
+++ b/query-engine/prisma-models/src/field/scalar.rs
@@ -64,6 +64,10 @@ impl ScalarField {
     pub fn is_numeric(&self) -> bool {
         self.type_identifier.is_numeric()
     }
+
+    pub fn container(&self) -> &ParentContainer {
+        &self.container
+    }
 }
 
 impl Debug for ScalarField {

--- a/query-engine/prisma-models/src/parent_container.rs
+++ b/query-engine/prisma-models/src/parent_container.rs
@@ -66,6 +66,14 @@ impl ParentContainer {
                 .cloned(),
         }
     }
+
+    pub fn is_composite(&self) -> bool {
+        matches!(self, Self::CompositeType(..))
+    }
+
+    pub fn is_model(&self) -> bool {
+        matches!(self, Self::Model(..))
+    }
 }
 
 impl From<&ModelRef> for ParentContainer {

--- a/query-engine/prisma-models/src/parent_container.rs
+++ b/query-engine/prisma-models/src/parent_container.rs
@@ -32,7 +32,7 @@ impl ParentContainer {
         }
     }
 
-    fn as_composite(&self) -> Option<CompositeTypeRef> {
+    pub fn as_composite(&self) -> Option<CompositeTypeRef> {
         match self {
             ParentContainer::Model(_) => None,
             ParentContainer::CompositeType(ct) => ct.upgrade(),


### PR DESCRIPTION
## Overview

- Adds support for `set` & `update` on `updateOne` operation.

## Example

```prisma
model Test {
    id Int @id
    to_one ToOne
}

type ToOne {
    field Int
    nested_to_one NestedToOne
}

type NestedToOne {
  field String
}
```

```graphql
mutation {
  updateOneTest(
    where: { id: 1 }      
      data: {
        to_one: { update: { field: 1 }}
  # or: to_one: { update: { field: { set|increment|decrement|...: 1 } } }
  # or: to_one: { update: { nested_to_one: { update: { field: "test" } } } }
  # or: to_one: { update: { nested_to_one: { set: { field: "test" } } } }
  # or: to_one: { update: { nested_to_one: { field: "test" } } }
      }
  ) { id }
}
```