### PR TITLE
Skip advisory locking on Cockroachdb

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/postgres.rs
@@ -94,6 +94,12 @@ impl PostgresFlavour {
 #[async_trait::async_trait]
 impl SqlFlavour for PostgresFlavour {
     async fn acquire_lock(&self, connection: &Connection) -> ConnectorResult<()> {
+        // They are not supporting advisory locking:
+        // https://github.com/cockroachdb/cockroach/issues/13546
+        if connection.is_cockroachdb().await? {
+            return Ok(());
+        }
+
         // https://www.postgresql.org/docs/current/explicit-locking.html#ADVISORY-LOCKS
 
         // 72707369 is a unique number we chose to identify Migrate. It does not

--- a/migration-engine/migration-engine-tests/tests/migrations/advisory_locking.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/advisory_locking.rs
@@ -3,7 +3,7 @@ use migration_engine_tests::multi_engine_test_api::*;
 use std::sync::Arc;
 use test_macros::test_connector;
 
-#[test_connector]
+#[test_connector(exclude(CockroachDb))]
 fn advisory_locking_works(api: TestApi) {
     let first_me = api.new_engine();
     let migrations_directory = Arc::new(api.create_migrations_directory());


### PR DESCRIPTION
Not supported:

https://github.com/cockroachdb/cockroach/issues/13546

Part of: https://github.com/prisma/prisma/issues/4702