### PR TITLE
mecli: Fix buildkite build by adding a no-op cargo feature

### DIFF
--- a/migration-engine/cli/Cargo.toml
+++ b/migration-engine/cli/Cargo.toml
@@ -32,3 +32,6 @@ git = "https://github.com/prisma/quaint"
 [[bin]]
 name = "migration-engine"
 path = "src/main.rs"
+
+[features]
+vendored-openssl = []


### PR DESCRIPTION
https://buildkite.com/prisma/release-prisma-engines/builds/1942#9203c9c0-3e92-4eac-bb7d-0d23c73e61ec

This was removed in the previous commits, but it is apparently
necessary.