### PR TITLE
Make MigrationConnector::render_script() fallible

### DIFF
--- a/migration-engine/connectors/migration-connector/src/database_migration_step_applier.rs
+++ b/migration-engine/connectors/migration-connector/src/database_migration_step_applier.rs
@@ -7,7 +7,14 @@ pub trait DatabaseMigrationStepApplier: Send + Sync {
     async fn apply_migration(&self, migration: &Migration) -> ConnectorResult<u32>;
 
     /// Render the migration to a runnable script.
-    fn render_script(&self, migration: &Migration, diagnostics: &DestructiveChangeDiagnostics) -> String;
+    ///
+    /// This should always return with `Ok` in normal circumstances. The result is currently only
+    /// used to signal when the connector does not support rendering to a script.
+    fn render_script(
+        &self,
+        migration: &Migration,
+        diagnostics: &DestructiveChangeDiagnostics,
+    ) -> ConnectorResult<String>;
 
     /// Apply a migration script to the database. The migration persistence is
     /// managed by the core.

--- a/migration-engine/connectors/mongodb-migration-connector/src/migration_step_applier.rs
+++ b/migration-engine/connectors/mongodb-migration-connector/src/migration_step_applier.rs
@@ -4,7 +4,8 @@ use crate::{
     MongoDbMigrationConnector,
 };
 use migration_connector::{
-    ConnectorResult, DatabaseMigrationStepApplier, DestructiveChangeDiagnostics, Migration, MigrationConnector,
+    ConnectorError, ConnectorResult, DatabaseMigrationStepApplier, DestructiveChangeDiagnostics, Migration,
+    MigrationConnector,
 };
 use mongodb::bson::{self, Bson, Document};
 
@@ -64,8 +65,14 @@ impl DatabaseMigrationStepApplier for MongoDbMigrationConnector {
         Ok(migration.steps.len() as u32)
     }
 
-    fn render_script(&self, _migration: &Migration, _diagnostics: &DestructiveChangeDiagnostics) -> String {
-        panic!("rendering to a script is not supported on MongoDB");
+    fn render_script(
+        &self,
+        _migration: &Migration,
+        _diagnostics: &DestructiveChangeDiagnostics,
+    ) -> ConnectorResult<String> {
+        Err(ConnectorError::from_msg(
+            "Rendering to a script is not supported on MongoDB.".to_owned(),
+        ))
     }
 
     async fn apply_script(&self, _migration_name: &str, _script: &str) -> ConnectorResult<()> {

--- a/migration-engine/connectors/sql-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/lib.rs
@@ -141,7 +141,7 @@ impl SqlMigrationConnector {
             return Ok(());
         }
 
-        let migration = self.render_script(&Migration::new(migration), &DestructiveChangeDiagnostics::default());
+        let migration = self.render_script(&Migration::new(migration), &DestructiveChangeDiagnostics::default())?;
         connection.raw_cmd(&migration).await?;
 
         Ok(())

--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
@@ -25,10 +25,14 @@ impl DatabaseMigrationStepApplier for SqlMigrationConnector {
         Ok(migration.steps.len() as u32)
     }
 
-    fn render_script(&self, migration: &Migration, diagnostics: &DestructiveChangeDiagnostics) -> String {
+    fn render_script(
+        &self,
+        migration: &Migration,
+        diagnostics: &DestructiveChangeDiagnostics,
+    ) -> ConnectorResult<String> {
         let migration: &SqlMigration = migration.downcast_ref();
         if migration.steps.is_empty() {
-            return "-- This is an empty migration.".to_string();
+            return Ok("-- This is an empty migration.".to_owned());
         }
 
         let mut script = String::with_capacity(40 * migration.steps.len());
@@ -94,7 +98,7 @@ impl DatabaseMigrationStepApplier for SqlMigrationConnector {
             script.push_str(commit);
         }
 
-        script
+        Ok(script)
     }
 
     #[tracing::instrument(skip(self, script))]

--- a/migration-engine/core/src/commands/create_migration.rs
+++ b/migration-engine/core/src/commands/create_migration.rs
@@ -39,7 +39,7 @@ pub async fn create_migration(
 
     let destructive_change_diagnostics = checker.pure_check(&migration);
 
-    let migration_script = applier.render_script(&migration, &destructive_change_diagnostics);
+    let migration_script = applier.render_script(&migration, &destructive_change_diagnostics)?;
 
     // Write the migration script to a file.
     let directory = create_migration_directory(Path::new(&input.migrations_directory_path), &input.migration_name)

--- a/migration-engine/core/src/commands/diff.rs
+++ b/migration-engine/core/src/commands/diff.rs
@@ -33,7 +33,7 @@ pub(crate) async fn diff(params: DiffParams, host: Arc<dyn ConnectorHost>) -> Co
         let script_string = connector.database_migration_step_applier().render_script(
             &migration,
             &migration_connector::DestructiveChangeDiagnostics::default(),
-        );
+        )?;
         connector.host().print(&script_string).await?;
     } else {
         let summary = connector.migration_summary(&migration);

--- a/migration-engine/migration-engine-tests/src/test_api.rs
+++ b/migration-engine/migration-engine-tests/src/test_api.rs
@@ -234,7 +234,7 @@ impl TestApi {
     /// Generate a migration script using `MigrationConnector::diff()`.
     pub fn connector_diff(&self, from: DiffTarget<'_>, to: DiffTarget<'_>) -> String {
         let migration = self.block_on(self.connector.diff(from, to)).unwrap();
-        self.connector.render_script(&migration, &Default::default())
+        self.connector.render_script(&migration, &Default::default()).unwrap()
     }
 
     pub fn normalize_identifier<'a>(&self, identifier: &'a str) -> Cow<'a, str> {


### PR DESCRIPTION
This is so we can return a clean error instead of panicking on migrate
diff --script on mongodb. This commit also does and tests that.