### PR TITLE
Drop&recreate columns on type change for CDB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,9 +30,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.18"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
 dependencies = [
  "memchr",
 ]
@@ -1316,9 +1316,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da408b722765c64aad796c666b756aa1dda2a6c1b44f98797f2d8ea8f197746f"
+checksum = "f4c0c443f6dceb3a1cb7607c87501aa91e4b9c976044f725c2a74ca2152c91a4"
 dependencies = [
  "console",
  "once_cell",
@@ -1680,9 +1680,9 @@ checksum = "7e6bcd6433cff03a4bfc3d9834d504467db1f1cf6d0ea765d37d330249ed629d"
 
 [[package]]
 name = "memchr"
-version = "2.4.1"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "metrics"
@@ -2120,9 +2120,9 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "6.1.2"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7413f999671bd4745a7b624bd370a569fb6bc574b23c83a3c5ed2e453f3d5e2"
+checksum = "9c5c51b9083a3c620fa67a2a635d1ce7d95b897e957d6b28ff9a5da960a103a6"
 dependencies = [
  "bitvec",
  "funty",
@@ -3143,9 +3143,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "2a26af418b574bd56588335b3a3659a65725d4e636eb1016c2f9e3b38c7cc759"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/libs/sql-ddl/src/postgres.rs
+++ b/libs/sql-ddl/src/postgres.rs
@@ -117,8 +117,11 @@ impl Display for DropIndex<'_> {
 /// ```
 /// # use sql_ddl::postgres::DropTable;
 ///
-/// let drop_table = DropTable { table_name: "Cat".into() };
+/// let drop_table = DropTable { table_name: "Cat".into(), cascade: false };
 /// assert_eq!(drop_table.to_string(), r#"DROP TABLE "Cat""#);
+///
+/// let drop_table = DropTable { table_name: "Cat".into(), cascade: true };
+/// assert_eq!(drop_table.to_string(), r#"DROP TABLE "Cat" CASCADE"#);
 /// ```
 #[derive(Debug)]
 pub struct DropTable<'a> {

--- a/libs/sql-ddl/src/postgres.rs
+++ b/libs/sql-ddl/src/postgres.rs
@@ -124,12 +124,19 @@ impl Display for DropIndex<'_> {
 pub struct DropTable<'a> {
     /// The name of the table to be dropped.
     pub table_name: PostgresIdentifier<'a>,
+    pub cascade: bool,
 }
 
 impl Display for DropTable<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("DROP TABLE ")?;
-        Display::fmt(&self.table_name, f)
+        Display::fmt(&self.table_name, f)?;
+
+        if self.cascade {
+            f.write_str(" CASCADE")?;
+        }
+
+        Ok(())
     }
 }
 

--- a/migration-engine/migration-engine-tests/tests/apply_migrations/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/apply_migrations/mod.rs
@@ -1,4 +1,4 @@
-use indoc::formatdoc;
+use indoc::{formatdoc, indoc};
 use migration_engine_tests::test_api::*;
 use pretty_assertions::assert_eq;
 use user_facing_errors::{migration_engine::ApplyMigrationError, UserFacingError};
@@ -131,6 +131,13 @@ fn migrations_should_fail_when_the_script_is_invalid(api: TestApi) {
                 _ => todo!(),
             },
             message = match api.tags() {
+                t if t.contains(Tags::CockroachDb) => indoc! {r#"
+                    ERROR: at or near "^": syntax error
+                    DETAIL: source SQL:
+                    SELECT (^.^)_n
+                            ^
+                    HINT: try \h SELECT
+                "#},
                 t if t.contains(Tags::Vitess) => "syntax error at position 10",
                 t if t.contains(Tags::Mariadb) => "You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near \'^.^)_n\' at line 1",
                 t if t.contains(Tags::Mysql) => "You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near \'^.^)_n\' at line 1",

--- a/migration-engine/migration-engine-tests/tests/create_migration/create_migration_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/create_migration/create_migration_tests.rs
@@ -1005,6 +1005,29 @@ fn alter_constraint_name(api: TestApi) {
                     END CATCH
                  "#
                  }
+            } else if api.is_cockroach() {
+                indoc! {r#"
+                    -- AlterTable
+                    ALTER TABLE "A" RENAME CONSTRAINT "A_pkey" TO "CustomId";
+
+                    -- AlterTable
+                    ALTER TABLE "B" RENAME CONSTRAINT "B_pkey" TO "CustomCompoundId";
+
+                    -- RenameForeignKey
+                    ALTER TABLE "B" RENAME CONSTRAINT "B_aId_fkey" TO "CustomFK";
+
+                    -- RenameIndex
+                    ALTER INDEX "A_a_idx" RENAME TO "CustomIndex";
+
+                    -- RenameIndex
+                    ALTER INDEX "A_a_b_key" RENAME TO "CustomCompoundUnique";
+
+                    -- RenameIndex
+                    ALTER INDEX "A_name_key" RENAME TO "CustomUnique";
+
+                    -- RenameIndex
+                    ALTER INDEX "B_a_b_idx" RENAME TO "AnotherCustomIndex";
+                "#}
             } else if api.is_postgres() {
                 indoc! {
                      r#"


### PR DESCRIPTION
Also, if dropping the ID, we must recreate the table. Lots of tests are now working, but asserting a wrong error code and having more warnings due to more harsh migrations happening underneath.

Fixing these in future PRs.

Part of https://github.com/prisma/prisma/issues/4702