### PR TITLE
Use `auto()` instead of `dbgenerated()` on MongoDB

### DIFF
--- a/introspection-engine/connectors/mongodb-introspection-connector/src/sampler/statistics.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/src/sampler/statistics.rs
@@ -373,9 +373,7 @@ fn new_model(model_name: &str) -> Model {
         let mut sf = ScalarField::new("id", datamodel::FieldArity::Required, field_type);
 
         sf.set_database_name(Some("_id".to_string()));
-        sf.set_default_value(DefaultValue::new_expression(
-            ValueGenerator::new("dbgenerated".to_owned(), Vec::new()).unwrap(),
-        ));
+        sf.set_default_value(DefaultValue::new_expression(ValueGenerator::new_auto()));
 
         sf
     });

--- a/introspection-engine/connectors/mongodb-introspection-connector/tests/basic/mod.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/tests/basic/mod.rs
@@ -11,7 +11,7 @@ fn empty_collection() {
 
     let expected = expect![[r#"
         model A {
-          id String @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id String @id @default(auto()) @map("_id") @db.ObjectId
         }
     "#]];
 
@@ -38,12 +38,12 @@ fn multiple_collections_with_data() {
 
     let expected = expect![[r#"
         model A {
-          id    String @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id    String @id @default(auto()) @map("_id") @db.ObjectId
           first String
         }
 
         model B {
-          id     String @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id     String @id @default(auto()) @map("_id") @db.ObjectId
           second String
         }
     "#]];

--- a/introspection-engine/connectors/mongodb-introspection-connector/tests/dirty_data/mod.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/tests/dirty_data/mod.rs
@@ -15,7 +15,7 @@ fn explicit_id_field() {
 
     let expected = expect![[r#"
         model A {
-          id  String @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id  String @id @default(auto()) @map("_id") @db.ObjectId
           id_ Int    @map("id")
         }
     "#]];
@@ -37,7 +37,7 @@ fn mixing_types() {
 
     let expected = expect![[r#"
         model A {
-          id    String @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id    String @id @default(auto()) @map("_id") @db.ObjectId
           /// Multiple data types found: String: 50%, Int32: 50% out of 3 sampled entries
           first Int?
         }
@@ -67,7 +67,7 @@ fn mixing_types_with_the_same_base_type() {
 
     let expected = expect![[r#"
         model A {
-          id    String    @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id    String    @id @default(auto()) @map("_id") @db.ObjectId
           /// Multiple data types found: Date: 50%, Timestamp: 50% out of 3 sampled entries
           first DateTime?
         }
@@ -90,7 +90,7 @@ fn the_most_common_type_wins() {
 
     let expected = expect![[r#"
         model A {
-          id    String @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id    String @id @default(auto()) @map("_id") @db.ObjectId
           /// Multiple data types found: String: 66.7%, Boolean: 33.3% out of 3 sampled entries
           first String
         }

--- a/introspection-engine/connectors/mongodb-introspection-connector/tests/index/mod.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/tests/index/mod.rs
@@ -30,7 +30,7 @@ fn single_column_normal_index() {
 
     let expected = expect![[r#"
         model A {
-          id   String @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id   String @id @default(auto()) @map("_id") @db.ObjectId
           age  Int
           name String
 
@@ -67,7 +67,7 @@ fn single_column_descending_index_no_preview_enabled() {
 
     let expected = expect![[r#"
         model A {
-          id   String @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id   String @id @default(auto()) @map("_id") @db.ObjectId
           age  Int
           name String
 
@@ -101,7 +101,7 @@ fn single_column_descending_index() {
 
     let expected = expect![[r#"
         model A {
-          id   String @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id   String @id @default(auto()) @map("_id") @db.ObjectId
           age  Int
           name String
 
@@ -135,7 +135,7 @@ fn single_column_fulltext_index() {
 
     let expected = expect![[r#"
         model A {
-          id   String @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id   String @id @default(auto()) @map("_id") @db.ObjectId
           age  Int
           name String
 
@@ -169,7 +169,7 @@ fn multi_column_fulltext_index() {
 
     let expected = expect![[r#"
         model A {
-          id    String @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id    String @id @default(auto()) @map("_id") @db.ObjectId
           age   Int
           name  String
           title String
@@ -204,7 +204,7 @@ fn multi_column_fulltext_index_with_desc_in_end() {
 
     let expected = expect![[r#"
         model A {
-          id    String @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id    String @id @default(auto()) @map("_id") @db.ObjectId
           age   Int
           name  String
           title String
@@ -239,7 +239,7 @@ fn multi_column_fulltext_index_with_desc_in_beginning() {
 
     let expected = expect![[r#"
         model A {
-          id    String @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id    String @id @default(auto()) @map("_id") @db.ObjectId
           age   Int
           name  String
           title String
@@ -274,7 +274,7 @@ fn multi_column_fulltext_index_with_asc_in_end() {
 
     let expected = expect![[r#"
         model A {
-          id    String @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id    String @id @default(auto()) @map("_id") @db.ObjectId
           age   Int
           name  String
           title String
@@ -309,7 +309,7 @@ fn multi_column_fulltext_index_with_asc_in_beginning() {
 
     let expected = expect![[r#"
         model A {
-          id    String @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id    String @id @default(auto()) @map("_id") @db.ObjectId
           age   Int
           name  String
           title String
@@ -348,7 +348,7 @@ fn multi_column_fulltext_index_with_asc_in_beginning_desc_in_end() {
 
     let expected = expect![[r#"
         model A {
-          id     String @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id     String @id @default(auto()) @map("_id") @db.ObjectId
           age    Int
           name   String
           title  String
@@ -387,7 +387,7 @@ fn fultext_index_without_preview_flag() {
 
     let expected = expect![[r#"
         model A {
-          id   String @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id   String @id @default(auto()) @map("_id") @db.ObjectId
           age  Int
           name String
         }
@@ -419,7 +419,7 @@ fn index_pointing_to_a_renamed_field() {
 
     let expected = expect![[r#"
         model A {
-          id   String @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id   String @id @default(auto()) @map("_id") @db.ObjectId
           age  Int    @map("_age")
           name String
 
@@ -456,7 +456,7 @@ fn single_column_normal_index_default_name() {
 
     let expected = expect![[r#"
         model A {
-          id   String @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id   String @id @default(auto()) @map("_id") @db.ObjectId
           age  Int
           name String
 
@@ -493,7 +493,7 @@ fn multi_column_normal_index_no_preview() {
 
     let expected = expect![[r#"
         model A {
-          id   String @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id   String @id @default(auto()) @map("_id") @db.ObjectId
           age  Int
           name String
 
@@ -527,7 +527,7 @@ fn multi_column_normal_index() {
 
     let expected = expect![[r#"
         model A {
-          id   String @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id   String @id @default(auto()) @map("_id") @db.ObjectId
           age  Int
           name String
 
@@ -561,7 +561,7 @@ fn single_column_unique_index() {
 
     let expected = expect![[r#"
         model A {
-          id   String @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id   String @id @default(auto()) @map("_id") @db.ObjectId
           age  Int    @unique(map: "age_1")
           name String
         }
@@ -596,7 +596,7 @@ fn single_column_unique_index_default_name() {
 
     let expected = expect![[r#"
         model A {
-          id   String @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id   String @id @default(auto()) @map("_id") @db.ObjectId
           age  Int    @unique
           name String
         }
@@ -631,7 +631,7 @@ fn multi_column_unique_index_no_preview() {
 
     let expected = expect![[r#"
         model A {
-          id   String @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id   String @id @default(auto()) @map("_id") @db.ObjectId
           age  Int
           name String
 
@@ -665,7 +665,7 @@ fn multi_column_unique_index() {
 
     let expected = expect![[r#"
         model A {
-          id   String @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id   String @id @default(auto()) @map("_id") @db.ObjectId
           age  Int
           name String
 
@@ -699,7 +699,7 @@ fn unsupported_types_in_a_unique_index() {
 
     let expected = expect![[r#"
         model A {
-          id   String                        @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id   String                        @id @default(auto()) @map("_id") @db.ObjectId
           data Unsupported("JavaScriptCode") @unique(map: "data_1")
         }
     "#]];
@@ -730,7 +730,7 @@ fn unsupported_types_in_an_index() {
 
     let expected = expect![[r#"
         model A {
-          id   String                        @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id   String                        @id @default(auto()) @map("_id") @db.ObjectId
           data Unsupported("JavaScriptCode")
 
           @@index([data], map: "data_1")
@@ -770,7 +770,7 @@ fn partial_indices_should_be_ignored() {
 
     let expected = expect![[r#"
         model A {
-          id   String @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id   String @id @default(auto()) @map("_id") @db.ObjectId
           age  Int
           name String
         }
@@ -802,7 +802,7 @@ fn skip_index_pointing_to_non_existing_field() {
 
     let expected = expect![[r#"
         model A {
-          id   String @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id   String @id @default(auto()) @map("_id") @db.ObjectId
           name String
         }
     "#]];

--- a/introspection-engine/connectors/mongodb-introspection-connector/tests/model_renames/mod.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/tests/model_renames/mod.rs
@@ -16,7 +16,7 @@ fn a_model_with_reserved_name() {
     let expected = expect![[r#"
         /// This model has been renamed to 'RenamedPrismaClient' during introspection, because the original name 'PrismaClient' is reserved.
         model RenamedPrismaClient {
-          id   String @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id   String @id @default(auto()) @map("_id") @db.ObjectId
           data Int
 
           @@map("PrismaClient")
@@ -40,7 +40,7 @@ fn reserved_names_case_sensitivity() {
 
     let expected = expect![[r#"
         model prismalclient {
-          id   String @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id   String @id @default(auto()) @map("_id") @db.ObjectId
           data Int
         }
     "#]];

--- a/introspection-engine/connectors/mongodb-introspection-connector/tests/remapping_names/mod.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/tests/remapping_names/mod.rs
@@ -28,7 +28,7 @@ fn remapping_fields_with_invalid_characters() {
 
     let expected = expect![[r#"
         model A {
-          id  String @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id  String @id @default(auto()) @map("_id") @db.ObjectId
           d   Int    @map("(d")
           e   Int    @map(")e")
           b   Int    @map("*b")
@@ -55,13 +55,13 @@ fn remapping_models_with_invalid_characters() {
 
     let expected = expect![[r#"
         model A {
-          id String @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id String @id @default(auto()) @map("_id") @db.ObjectId
 
           @@map("?A")
         }
 
         model A_b_c {
-          id String @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id String @id @default(auto()) @map("_id") @db.ObjectId
 
           @@map("A b c")
         }

--- a/introspection-engine/connectors/mongodb-introspection-connector/tests/types/composite.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/tests/types/composite.rs
@@ -23,7 +23,7 @@ fn singular() {
         }
 
         model Cat {
-          id      String     @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id      String     @id @default(auto()) @map("_id") @db.ObjectId
           address CatAddress
           name    String
         }
@@ -54,7 +54,7 @@ fn dirty_data() {
         }
 
         model Cat {
-          id      String     @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id      String     @id @default(auto()) @map("_id") @db.ObjectId
           address CatAddress
           name    String
         }
@@ -84,7 +84,7 @@ fn array() {
         }
 
         model Blog {
-          id    String      @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id    String      @id @default(auto()) @map("_id") @db.ObjectId
           posts BlogPosts[]
           title String
         }
@@ -108,7 +108,7 @@ fn deep_array() {
 
     let expected = expect![[r#"
         model Blog {
-          id    String @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id    String @id @default(auto()) @map("_id") @db.ObjectId
           posts Json[]
           title String
         }
@@ -147,7 +147,7 @@ fn nullability() {
         }
 
         model Model {
-          id     String       @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id     String       @id @default(auto()) @map("_id") @db.ObjectId
           first  ModelFirst
           second ModelSecond?
           third  ModelThird?
@@ -176,7 +176,7 @@ fn unsupported() {
         }
 
         model FrontendEngineerWritesBackendCode {
-          id       String                                @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id       String                                @id @default(auto()) @map("_id") @db.ObjectId
           data     FrontendEngineerWritesBackendCodeData
           dataType String
         }
@@ -200,7 +200,7 @@ fn underscores_in_names() {
         }
 
         model Cat {
-          id           String         @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id           String         @id @default(auto()) @map("_id") @db.ObjectId
           home_address CatHomeAddress
           name         String
         }
@@ -219,7 +219,7 @@ fn depth_none() {
 
     let expected = expect![[r#"
         model Cat {
-          id           String @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id           String @id @default(auto()) @map("_id") @db.ObjectId
           home_address Json
           name         String
         }
@@ -238,7 +238,7 @@ fn depth_none_level_1_array() {
 
     let expected = expect![[r#"
         model Cat {
-          id           String @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id           String @id @default(auto()) @map("_id") @db.ObjectId
           home_address Json[]
           name         String
         }
@@ -262,7 +262,7 @@ fn depth_1_level_1() {
         }
 
         model Cat {
-          id           String         @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id           String         @id @default(auto()) @map("_id") @db.ObjectId
           home_address CatHomeAddress
           name         String
         }
@@ -289,7 +289,7 @@ fn depth_1_level_2() {
         }
 
         model Cat {
-          id           String         @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id           String         @id @default(auto()) @map("_id") @db.ObjectId
           home_address CatHomeAddress
           name         String
         }
@@ -316,7 +316,7 @@ fn depth_1_level_2_array() {
         }
 
         model Cat {
-          id           String           @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id           String           @id @default(auto()) @map("_id") @db.ObjectId
           home_address CatHomeAddress[]
           name         String
         }
@@ -347,7 +347,7 @@ fn depth_2_level_2_array() {
         }
 
         model Cat {
-          id           String           @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id           String           @id @default(auto()) @map("_id") @db.ObjectId
           home_address CatHomeAddress[]
           name         String
         }
@@ -375,13 +375,13 @@ fn name_clashes() {
         }
 
         model Cat {
-          id      String      @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id      String      @id @default(auto()) @map("_id") @db.ObjectId
           address CatAddress_
           name    String
         }
 
         model CatAddress {
-          id     String  @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id     String  @id @default(auto()) @map("_id") @db.ObjectId
           knock  Boolean
           number Int
           street String

--- a/introspection-engine/connectors/mongodb-introspection-connector/tests/types/mod.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/tests/types/mod.rs
@@ -22,7 +22,7 @@ fn string() {
 
     let expected = expect![[r#"
         model A {
-          id     String  @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id     String  @id @default(auto()) @map("_id") @db.ObjectId
           first  String
           second String?
           third  String?
@@ -51,7 +51,7 @@ fn double() {
 
     let expected = expect![[r#"
         model A {
-          id     String @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id     String @id @default(auto()) @map("_id") @db.ObjectId
           first  Float
           second Float?
           third  Float?
@@ -80,7 +80,7 @@ fn bool() {
 
     let expected = expect![[r#"
         model A {
-          id     String   @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id     String   @id @default(auto()) @map("_id") @db.ObjectId
           first  Boolean
           second Boolean?
           third  Boolean?
@@ -109,7 +109,7 @@ fn int() {
 
     let expected = expect![[r#"
         model A {
-          id     String @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id     String @id @default(auto()) @map("_id") @db.ObjectId
           first  Int
           second Int?
           third  Int?
@@ -138,7 +138,7 @@ fn bigint() {
 
     let expected = expect![[r#"
         model A {
-          id     String  @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id     String  @id @default(auto()) @map("_id") @db.ObjectId
           first  BigInt
           second BigInt?
           third  BigInt?
@@ -178,7 +178,7 @@ fn timestamp() {
 
     let expected = expect![[r#"
         model A {
-          id     String    @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id     String    @id @default(auto()) @map("_id") @db.ObjectId
           first  DateTime
           second DateTime?
           third  DateTime?
@@ -223,7 +223,7 @@ fn binary() {
 
     let expected = expect![[r#"
         model A {
-          id     String @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id     String @id @default(auto()) @map("_id") @db.ObjectId
           first  Bytes
           second Bytes?
           third  Bytes?
@@ -263,7 +263,7 @@ fn object_id() {
 
     let expected = expect![[r#"
         model A {
-          id     String  @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id     String  @id @default(auto()) @map("_id") @db.ObjectId
           first  String  @db.ObjectId
           second String? @db.ObjectId
           third  String? @db.ObjectId
@@ -303,7 +303,7 @@ fn date() {
 
     let expected = expect![[r#"
         model A {
-          id     String    @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id     String    @id @default(auto()) @map("_id") @db.ObjectId
           first  DateTime  @db.Date
           second DateTime? @db.Date
           third  DateTime? @db.Date
@@ -343,7 +343,7 @@ fn decimal() {
 
     let expected = expect![[r#"
         model A {
-          id     String   @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id     String   @id @default(auto()) @map("_id") @db.ObjectId
           first  Decimal
           second Decimal?
           third  Decimal?
@@ -383,7 +383,7 @@ fn array() {
 
     let expected = expect![[r#"
         model A {
-          id     String @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id     String @id @default(auto()) @map("_id") @db.ObjectId
           first  Int[]
           second Int[]
           third  Int[]
@@ -409,7 +409,7 @@ fn empty_arrays() {
 
     let expected = expect![[r#"
         model A {
-          id   String                  @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id   String                  @id @default(auto()) @map("_id") @db.ObjectId
           data Unsupported("Unknown")?
         }
     "#]];

--- a/libs/datamodel/connectors/datamodel-connector/src/capabilities.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/capabilities.rs
@@ -51,6 +51,7 @@ capabilities!(
     AutoIncrement,
     RelationFieldsInArbitraryOrder,
     CompositeTypes,
+    DefaultValueAuto,
     //Start of ME/IE only capabilities
     AutoIncrementAllowedOnNonId,
     AutoIncrementMultipleAllowed,

--- a/libs/datamodel/connectors/dml/src/default_value.rs
+++ b/libs/datamodel/connectors/dml/src/default_value.rs
@@ -155,6 +155,10 @@ impl ValueGenerator {
         }
     }
 
+    pub fn new_auto() -> Self {
+        ValueGenerator::new("auto".to_owned(), Vec::new()).unwrap()
+    }
+
     pub fn new_now() -> Self {
         ValueGenerator::new("now".to_owned(), vec![]).unwrap()
     }
@@ -220,6 +224,7 @@ pub enum ValueGeneratorFn {
     Now,
     Autoincrement,
     DbGenerated,
+    Auto,
 }
 
 impl ValueGeneratorFn {
@@ -230,6 +235,7 @@ impl ValueGeneratorFn {
             "now" => Ok(Self::Now),
             "autoincrement" => Ok(Self::Autoincrement),
             "dbgenerated" => Ok(Self::DbGenerated),
+            "auto" => Ok(Self::Auto),
             _ => Err(format!("The function {} is not a known function.", name)),
         }
     }
@@ -242,6 +248,7 @@ impl ValueGeneratorFn {
             Self::Now => Some(Self::generate_now()),
             Self::Autoincrement => None,
             Self::DbGenerated => None,
+            Self::Auto => None,
         }
     }
 
@@ -254,6 +261,7 @@ impl ValueGeneratorFn {
             (Self::Autoincrement, ScalarType::Int) => true,
             (Self::Autoincrement, ScalarType::BigInt) => true,
             (Self::DbGenerated, _) => true,
+            (Self::Auto, _) => true,
             _ => false,
         }
     }

--- a/libs/datamodel/core/src/transform/ast_to_dml/lift.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/lift.rs
@@ -502,6 +502,9 @@ fn dml_default_kind(default_value: &ast::Expression, scalar_type: Option<ScalarT
                     .unwrap_or_else(String::new),
             ))
         }
+        ast::Expression::Function(funcname, _, _) if funcname == "auto" => {
+            DefaultKind::Expression(ValueGenerator::new_auto())
+        }
         ast::Expression::Function(funcname, _args, _) if funcname == "autoincrement" => {
             DefaultKind::Expression(ValueGenerator::new_autoincrement())
         }

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/composite_types.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/composite_types.rs
@@ -1,7 +1,7 @@
 use super::default_value;
 use crate::transform::ast_to_dml::{db::walkers::CompositeTypeWalker, validation_pipeline::context::Context};
 use diagnostics::DatamodelError;
-use parser_database::{ast::Expression, walkers::CompositeTypeFieldWalker};
+use parser_database::walkers::CompositeTypeFieldWalker;
 
 pub(crate) fn composite_types_support(composite_type: CompositeTypeWalker<'_, '_>, ctx: &mut Context<'_>) {
     if ctx.connector.supports_composite_types() {
@@ -25,17 +25,6 @@ pub(super) fn validate_default_value(field: CompositeTypeFieldWalker<'_, '_>, ct
             "default",
             default_attribute.unwrap().span,
         ));
-    }
-
-    match default_value {
-        Some(Expression::Function(name, _, span)) if name == "auto" => {
-            ctx.push_error(DatamodelError::new_attribute_validation_error(
-                "The `auto()` function is not allowed in a composite type.",
-                "default",
-                *span,
-            ));
-        }
-        _ => (),
     }
 
     let scalar_type = field.r#type().as_builtin_scalar();

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/default_value.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/default_value.rs
@@ -8,6 +8,7 @@ use crate::{
 };
 use std::str::FromStr;
 
+/// Function `auto()` works for now only with MongoDB.
 pub(super) fn validate_auto_param(default_value: Option<&ast::Expression>, ctx: &mut Context<'_>) {
     if ctx.connector.has_capability(ConnectorCapability::DefaultValueAuto) {
         return;

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/default_value.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/default_value.rs
@@ -1,9 +1,34 @@
+use datamodel_connector::ConnectorCapability;
+use parser_database::ast::Expression;
+
 use crate::{
     ast,
     diagnostics::DatamodelError,
     transform::ast_to_dml::{db::ScalarType, validation_pipeline::context::Context},
 };
 use std::str::FromStr;
+
+pub(super) fn validate_auto_param(default_value: Option<&ast::Expression>, ctx: &mut Context<'_>) {
+    if ctx.connector.has_capability(ConnectorCapability::DefaultValueAuto) {
+        return;
+    }
+
+    let expression = match default_value {
+        Some(default_value) => default_value,
+        None => return,
+    };
+
+    match expression {
+        Expression::Function(name, _, span) if name == "auto" => {
+            let message = "The current connector does not support the `auto()` function.";
+
+            ctx.push_error(DatamodelError::new_attribute_validation_error(
+                message, "default", *span,
+            ));
+        }
+        _ => (),
+    }
+}
 
 /// Validates the @default attribute of a scalar field
 pub(super) fn validate_default_value(

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/fields.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/fields.rs
@@ -251,6 +251,7 @@ pub(super) fn validate_default_value(field: ScalarFieldWalker<'_, '_>, ctx: &mut
     let scalar_type = field.scalar_type();
 
     default_value::validate_default_value(default_value, scalar_type, ctx);
+    default_value::validate_auto_param(default_value, ctx);
 }
 
 pub(super) fn validate_scalar_field_connector_specific(field: ScalarFieldWalker<'_, '_>, ctx: &mut Context<'_>) {

--- a/libs/datamodel/core/tests/attributes/default_negative.rs
+++ b/libs/datamodel/core/tests/attributes/default_negative.rs
@@ -741,18 +741,24 @@ fn must_error_on_auto_default_on_mongodb_composite() {
         }
 
         type Meow {
-            id String @default(auto())
+            id String @default(auto()) @db.ObjectId
         }
     "#;
 
     let error = datamodel::parse_schema(schema).map(drop).unwrap_err();
 
     let expected = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@default": The function `auto()` cannot be used on fields of type `String`.[0m
+        [1;91merror[0m: [1mError parsing attribute "@default": The function `auto()` is not a supported on composite fields.[0m
           [1;94m-->[0m  [4mschema.prisma:18[0m
         [1;94m   | [0m
         [1;94m17 | [0m        type Meow {
-        [1;94m18 | [0m            id String @[1;91mdefault(auto())[0m
+        [1;94m18 | [0m            id String @[1;91mdefault(auto())[0m @db.ObjectId
+        [1;94m   | [0m
+        [1;91merror[0m: [1mAttribute not known: "@db.ObjectId".[0m
+          [1;94m-->[0m  [4mschema.prisma:18[0m
+        [1;94m   | [0m
+        [1;94m17 | [0m        type Meow {
+        [1;94m18 | [0m            id String @default(auto()) @[1;91mdb.ObjectId[0m
         [1;94m   | [0m
     "#]];
 

--- a/libs/datamodel/core/tests/attributes/default_negative.rs
+++ b/libs/datamodel/core/tests/attributes/default_negative.rs
@@ -655,7 +655,7 @@ fn default_on_composite_type_field_errors() {
 }
 
 #[test]
-fn must_error_on_dbgenerated_default_on_non_native_type_on_mongodb() {
+fn must_error_on_auto_default_on_non_native_type_on_mongodb() {
     let schema = r#"
         datasource db {
             provider = "mongodb"
@@ -669,18 +669,296 @@ fn must_error_on_dbgenerated_default_on_non_native_type_on_mongodb() {
 
         model User {
             id Int @id @map("_id")
-            nickname String @default(dbgenerated())
+            nickname String @default(auto())
         }
     "#;
 
     let error = datamodel::parse_schema(schema).map(drop).unwrap_err();
 
     let expected = expect![[r#"
-        [1;91merror[0m: [1mError validating field 'nickname': MongoDB `@default(dbgenerated())` fields must have a native type annotation.[0m
+        [1;91merror[0m: [1mError validating field 'nickname': MongoDB `@default(auto())` fields must have `ObjectId` native type and use the `@id` attribute.[0m
           [1;94m-->[0m  [4mschema.prisma:14[0m
         [1;94m   | [0m
         [1;94m13 | [0m            id Int @id @map("_id")
-        [1;94m14 | [0m            [1;91mnickname String @default(dbgenerated())[0m
+        [1;94m14 | [0m            [1;91mnickname String @default(auto())[0m
+        [1;94m15 | [0m        }
+        [1;94m   | [0m
+    "#]];
+
+    expected.assert_eq(&error)
+}
+
+#[test]
+fn must_error_on_auto_default_on_non_object_id_on_mongodb() {
+    let schema = r#"
+        datasource db {
+            provider = "mongodb"
+            url = "mongodb://"
+        }
+
+        generator client {
+            provider = "prisma-client-js"
+            previewFeatures = ["mongoDb"]
+        }
+
+        model User {
+            id Int @id @map("_id") @default(auto()) @db.Int
+            nickname String
+        }
+    "#;
+
+    let error = datamodel::parse_schema(schema).map(drop).unwrap_err();
+
+    let expected = expect![[r#"
+        [1;91merror[0m: [1mError validating field 'id': MongoDB `@default(auto())` fields must have `ObjectId` native type and use the `@id` attribute.[0m
+          [1;94m-->[0m  [4mschema.prisma:13[0m
+        [1;94m   | [0m
+        [1;94m12 | [0m        model User {
+        [1;94m13 | [0m            [1;91mid Int @id @map("_id") @default(auto()) @db.Int[0m
+        [1;94m14 | [0m            nickname String
+        [1;94m   | [0m
+    "#]];
+
+    expected.assert_eq(&error)
+}
+
+#[test]
+fn must_error_on_auto_default_on_mongodb_composite() {
+    let schema = r#"
+        datasource db {
+            provider = "mongodb"
+            url = "mongodb://"
+        }
+
+        generator client {
+            provider = "prisma-client-js"
+            previewFeatures = ["mongoDb"]
+        }
+
+        model User {
+            id   String @id @map("_id") @default(auto()) @db.ObjectId
+            meow Meow
+        }
+
+        type Meow {
+            id String @default(auto())
+        }
+    "#;
+
+    let error = datamodel::parse_schema(schema).map(drop).unwrap_err();
+
+    let expected = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@default": The function `auto()` cannot be used on fields of type `String`.[0m
+          [1;94m-->[0m  [4mschema.prisma:18[0m
+        [1;94m   | [0m
+        [1;94m17 | [0m        type Meow {
+        [1;94m18 | [0m            id String @[1;91mdefault(auto())[0m
+        [1;94m   | [0m
+    "#]];
+
+    expected.assert_eq(&error)
+}
+
+#[test]
+fn must_error_on_dbgenerated_default_on_mongodb() {
+    let schema = r#"
+        datasource db {
+            provider = "mongodb"
+            url = "mongodb://"
+        }
+
+        generator client {
+            provider = "prisma-client-js"
+            previewFeatures = ["mongoDb"]
+        }
+
+        model User {
+            id String @id @map("_id") @default(dbgenerated()) @db.ObjectId
+        }
+    "#;
+
+    let error = datamodel::parse_schema(schema).map(drop).unwrap_err();
+
+    let expected = expect![[r#"
+        [1;91merror[0m: [1mError validating field 'id': The `dbgenerated()` function is not allowed with MongoDB. Please use `auto()` instead.[0m
+          [1;94m-->[0m  [4mschema.prisma:13[0m
+        [1;94m   | [0m
+        [1;94m12 | [0m        model User {
+        [1;94m13 | [0m            [1;91mid String @id @map("_id") @default(dbgenerated()) @db.ObjectId[0m
+        [1;94m14 | [0m        }
+        [1;94m   | [0m
+    "#]];
+
+    expected.assert_eq(&error)
+}
+
+#[test]
+fn must_error_with_auto_params_on_mongodb() {
+    let schema = r#"
+        datasource db {
+            provider = "mongodb"
+            url = "mongodb://"
+        }
+
+        generator client {
+            provider = "prisma-client-js"
+            previewFeatures = ["mongoDb"]
+        }
+
+        model User {
+            id String @id @map("_id") @default(auto("meow")) @db.ObjectId
+        }
+    "#;
+
+    let error = datamodel::parse_schema(schema).map(drop).unwrap_err();
+
+    let expected = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@default": `auto()` takes no arguments[0m
+          [1;94m-->[0m  [4mschema.prisma:13[0m
+        [1;94m   | [0m
+        [1;94m12 | [0m        model User {
+        [1;94m13 | [0m            id String @id @map("_id") @[1;91mdefault(auto("meow"))[0m @db.ObjectId
+        [1;94m   | [0m
+    "#]];
+
+    expected.assert_eq(&error)
+}
+
+#[test]
+fn must_error_if_using_auto_with_postgres() {
+    let schema = r#"
+        datasource db {
+            provider = "postgres"
+            url = "postgres://"
+        }
+
+        model User {
+            id String @id @default(auto())
+        }
+    "#;
+
+    let error = datamodel::parse_schema(schema).map(drop).unwrap_err();
+
+    let expected = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@default": The current connector does not support the `auto()` function.[0m
+          [1;94m-->[0m  [4mschema.prisma:8[0m
+        [1;94m   | [0m
+        [1;94m 7 | [0m        model User {
+        [1;94m 8 | [0m            id String @id @default([1;91mauto()[0m)
+        [1;94m   | [0m
+    "#]];
+
+    expected.assert_eq(&error)
+}
+
+#[test]
+fn must_error_if_using_auto_with_mysql() {
+    let schema = r#"
+        datasource db {
+            provider = "mysql"
+            url = "mysql://"
+        }
+
+        model User {
+            id String @id @default(auto())
+        }
+    "#;
+
+    let error = datamodel::parse_schema(schema).map(drop).unwrap_err();
+
+    let expected = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@default": The current connector does not support the `auto()` function.[0m
+          [1;94m-->[0m  [4mschema.prisma:8[0m
+        [1;94m   | [0m
+        [1;94m 7 | [0m        model User {
+        [1;94m 8 | [0m            id String @id @default([1;91mauto()[0m)
+        [1;94m   | [0m
+    "#]];
+
+    expected.assert_eq(&error)
+}
+
+#[test]
+fn must_error_if_using_auto_with_sql_server() {
+    let schema = r#"
+        datasource db {
+            provider = "sqlserver"
+            url = "sqlserver://"
+        }
+
+        model User {
+            id String @id @default(auto())
+        }
+    "#;
+
+    let error = datamodel::parse_schema(schema).map(drop).unwrap_err();
+
+    let expected = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@default": The current connector does not support the `auto()` function.[0m
+          [1;94m-->[0m  [4mschema.prisma:8[0m
+        [1;94m   | [0m
+        [1;94m 7 | [0m        model User {
+        [1;94m 8 | [0m            id String @id @default([1;91mauto()[0m)
+        [1;94m   | [0m
+    "#]];
+
+    expected.assert_eq(&error)
+}
+
+#[test]
+fn must_error_if_using_auto_with_sqlite() {
+    let schema = r#"
+        datasource db {
+            provider = "sqlite"
+            url = "file:dev.db"
+        }
+
+        model User {
+            id String @id @default(auto())
+        }
+    "#;
+
+    let error = datamodel::parse_schema(schema).map(drop).unwrap_err();
+
+    let expected = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@default": The current connector does not support the `auto()` function.[0m
+          [1;94m-->[0m  [4mschema.prisma:8[0m
+        [1;94m   | [0m
+        [1;94m 7 | [0m        model User {
+        [1;94m 8 | [0m            id String @id @default([1;91mauto()[0m)
+        [1;94m   | [0m
+    "#]];
+
+    expected.assert_eq(&error)
+}
+
+#[test]
+fn must_error_on_auto_default_on_non_id_on_mongodb() {
+    let schema = r#"
+        datasource db {
+            provider = "mongodb"
+            url = "mongodb://"
+        }
+
+        generator client {
+            provider = "prisma-client-js"
+            previewFeatures = ["mongoDb"]
+        }
+
+        model User {
+            id Int @id @map("_id")
+            nickname String @default(auto()) @db.ObjectId
+        }
+    "#;
+
+    let error = datamodel::parse_schema(schema).map(drop).unwrap_err();
+
+    let expected = expect![[r#"
+        [1;91merror[0m: [1mError validating field 'nickname': MongoDB `@default(auto())` fields must have `ObjectId` native type and use the `@id` attribute.[0m
+          [1;94m-->[0m  [4mschema.prisma:14[0m
+        [1;94m   | [0m
+        [1;94m13 | [0m            id Int @id @map("_id")
+        [1;94m14 | [0m            [1;91mnickname String @default(auto()) @db.ObjectId[0m
         [1;94m15 | [0m        }
         [1;94m   | [0m
     "#]];

--- a/libs/datamodel/core/tests/reformat/reformat.rs
+++ b/libs/datamodel/core/tests/reformat/reformat.rs
@@ -1229,7 +1229,7 @@ fn test_composite_types_in_models() {
         }
 
         model A {
-          id String @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id String @id @default(auto()) @map("_id") @db.ObjectId
           b  B
           c  C[]
         }
@@ -1257,7 +1257,7 @@ fn test_composite_types_in_models() {
         }
 
         model A {
-          id String @id @default(dbgenerated()) @map("_id") @db.ObjectId
+          id String @id @default(auto()) @map("_id") @db.ObjectId
           b  B
           c  C[]
         }

--- a/libs/datamodel/parser-database/src/attributes/default.rs
+++ b/libs/datamodel/parser-database/src/attributes/default.rs
@@ -192,6 +192,10 @@ fn validate_model_builtin_scalar_type_default(
             validate_empty_function_args(FN_NOW, &funcargs.arguments, args, accept, ctx)
         }
 
+        (_, ast::Expression::Function(funcname, funcargs, _)) if funcname == FN_AUTO => {
+            validate_auto_args(&funcargs.arguments, args, accept, ctx)
+        }
+
         (_, ast::Expression::Function(funcname, funcargs, _)) if funcname == FN_DBGENERATED => {
             validate_dbgenerated_args(&funcargs.arguments, args, accept, ctx)
         }
@@ -368,6 +372,19 @@ fn validate_empty_function_args(
     )));
 }
 
+fn validate_auto_args(
+    args: &[ast::Argument],
+    arguments: &Arguments<'_>,
+    mut accept: impl FnMut(),
+    ctx: &mut Context<'_>,
+) {
+    if !args.is_empty() {
+        ctx.push_error(arguments.new_attribute_validation_error("`auto()` takes no arguments"));
+    } else {
+        accept()
+    }
+}
+
 fn validate_dbgenerated_args(
     args: &[ast::Argument],
     arguments: &Arguments<'_>,
@@ -399,5 +416,6 @@ const FN_CUID: &str = "cuid";
 const FN_DBGENERATED: &str = "dbgenerated";
 const FN_NOW: &str = "now";
 const FN_UUID: &str = "uuid";
+const FN_AUTO: &str = "auto";
 
-const KNOWN_FUNCTIONS: &[&str] = &[FN_AUTOINCREMENT, FN_CUID, FN_DBGENERATED, FN_NOW, FN_UUID];
+const KNOWN_FUNCTIONS: &[&str] = &[FN_AUTOINCREMENT, FN_CUID, FN_DBGENERATED, FN_NOW, FN_UUID, FN_AUTO];

--- a/libs/datamodel/parser-database/src/attributes/default.rs
+++ b/libs/datamodel/parser-database/src/attributes/default.rs
@@ -247,7 +247,7 @@ fn validate_composite_builtin_scalar_type_default(
             validate_empty_function_args(FN_NOW, &funcargs.arguments, args, accept, ctx)
         }
         (_, ast::Expression::Function(funcname, _, _))
-            if funcname == FN_DBGENERATED || funcname == FN_AUTOINCREMENT =>
+            if funcname == FN_DBGENERATED || funcname == FN_AUTOINCREMENT || funcname == FN_AUTO =>
         {
             ctx.push_error(args.new_attribute_validation_error(&format!(
                 "The function `{funcname}()` is not a supported on composite fields.",

--- a/libs/datamodel/parser-database/src/walkers/scalar_field.rs
+++ b/libs/datamodel/parser-database/src/walkers/scalar_field.rs
@@ -193,6 +193,11 @@ impl<'ast, 'db> DefaultValueWalker<'ast, 'db> {
         matches!(self.default.value, ast::Expression::Function(name, _, _) if name == "dbgenerated")
     }
 
+    /// Is this an `@default(auto())`?
+    pub fn is_auto(self) -> bool {
+        matches!(self.default.value, ast::Expression::Function(name, _, _) if name == "auto")
+    }
+
     /// Is this an `@default(now())`?
     pub fn is_now(self) -> bool {
         matches!(self.default.value, ast::Expression::Function(name, _, _) if name == "now")

--- a/libs/datamodel/schema-ast/src/parser/parse_model.rs
+++ b/libs/datamodel/schema-ast/src/parser/parse_model.rs
@@ -10,8 +10,8 @@ use diagnostics::{DatamodelError, Diagnostics};
 
 pub(crate) fn parse_model(token: &Token<'_>, diagnostics: &mut Diagnostics) -> Model {
     let mut name: Option<Identifier> = None;
-    let mut attributes: Vec<Attribute> = vec![];
-    let mut fields: Vec<Field> = vec![];
+    let mut attributes: Vec<Attribute> = Vec::new();
+    let mut fields: Vec<Field> = Vec::new();
     let mut comment: Option<Comment> = None;
 
     for current in token.relevant_children() {

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/data_types/native_types/mongodb.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/data_types/native_types/mongodb.rs
@@ -60,7 +60,7 @@ mod mongodb {
     fn m2m() -> String {
         let schema = indoc! {
             r#"model A {
-                id  String  @id @default(dbgenerated()) @map("_id") @test.ObjectId
+                id  String  @id @default(auto()) @map("_id") @test.ObjectId
                 gql String?
 
                 b_ids String[]
@@ -68,7 +68,7 @@ mod mongodb {
             }
 
             model B {
-                id  String  @id @default(dbgenerated()) @map("_id") @test.ObjectId
+                id  String  @id @default(auto()) @map("_id") @test.ObjectId
                 gql String?
 
                 a_ids String[] @test.Array(ObjectId)
@@ -109,7 +109,7 @@ mod mongodb {
         let schema = indoc! {
             r#"
             model A {
-                id  String  @id @default(dbgenerated()) @map("_id") @test.ObjectId
+                id  String  @id @default(auto()) @map("_id") @test.ObjectId
                 list_field String[] @test.Array(ObjectId)
             }
             "#

--- a/query-engine/example_schemas/generic_mongo4.prisma
+++ b/query-engine/example_schemas/generic_mongo4.prisma
@@ -1,35 +1,35 @@
 datasource db {
-    provider = "mongodb"
-    url      = "mongodb://prisma:prisma@127.0.0.1:27017/testdb2?authSource=admin"
+  provider = "mongodb"
+  url      = "mongodb://prisma:prisma@127.0.0.1:27017/testdb2?authSource=admin"
 }
 
 generator js {
-    previewFeatures = ["mongodb", "interactiveTransactions"]
-    provider        = "prisma-client-js"
+  previewFeatures = ["mongodb", "interactiveTransactions"]
+  provider        = "prisma-client-js"
 }
 
 model A {
-    id  String  @id @default(dbgenerated()) @map("_id") @db.ObjectId
-    gql String?
-    bs  B[]
+  id  String  @id @default(auto()) @map("_id") @db.ObjectId
+  gql String?
+  bs  B[]
 }
 
 model B {
-    id  String  @id @default(dbgenerated()) @map("_id") @db.ObjectId
-    gql String?
+  id  String  @id @default(auto()) @map("_id") @db.ObjectId
+  gql String?
 
-    a_id String @db.ObjectId
-    a    A      @relation(fields: [a_id], references: [id])
+  a_id String @db.ObjectId
+  a    A      @relation(fields: [a_id], references: [id])
 
-    cs C[]
+  cs C[]
 }
 
 model C {
-    id  String  @id @default(dbgenerated()) @map("_id") @db.ObjectId
-    gql String?
+  id  String  @id @default(auto()) @map("_id") @db.ObjectId
+  gql String?
 
-    b_id String @db.ObjectId
-    b    B      @relation(fields: [b_id], references: [id])
+  b_id String @db.ObjectId
+  b    B      @relation(fields: [b_id], references: [id])
 
-    bId String?
+  bId String?
 }


### PR DESCRIPTION
The datamodel id column should have `auto()` instead of `dbgenerated()` to mark automatically generated ID value. This comes with a few validations:

- `auto()` must only be used in an id field
- the field type must be `ObjectId`
- `auto()` cannot take any parameters
- `dbgenerated()` is now not allowed with MongoDB
- no `auto()` in composite types

Closes: https://github.com/prisma/prisma/issues/11552