### PR TITLE
feat(composite): unset, push, upsert for updateOne

### DIFF
--- a/libs/prisma-value/src/lib.rs
+++ b/libs/prisma-value/src/lib.rs
@@ -231,6 +231,13 @@ impl PrismaValue {
     pub fn new_datetime(datetime: &str) -> PrismaValue {
         PrismaValue::DateTime(DateTime::parse_from_rfc3339(datetime).unwrap())
     }
+
+    pub fn as_boolean(&self) -> Option<&bool> {
+        match self {
+            PrismaValue::Boolean(bool) => Some(bool),
+            _ => None,
+        }
+    }
 }
 
 impl fmt::Display for PrismaValue {

--- a/query-engine/connector-test-kit-rs/query-engine-tests/src/schemas/composites.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/src/schemas/composites.rs
@@ -80,6 +80,7 @@ pub fn to_one_composites() -> String {
 
         type C {
             c_field String @default("c_field default")
+            c_opt   String?
             b B?
         }
         "#

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/composites/list.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/composites/list.rs
@@ -654,7 +654,7 @@ mod update {
         )
         .await?;
 
-        // No push on required composite
+        // No push on to-one composite
         assert_error!(
             runner,
             r#"mutation {

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/composites/single.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/composites/single.rs
@@ -518,7 +518,7 @@ mod update {
     #[connector_test]
     async fn ensure_unset_unavailable_on_fields(runner: Runner) -> TestResult<()> {
         create_test_data(&runner).await?;
-    
+
         assert_error!(
             runner,
             r#"mutation { updateOneTestModel(
@@ -538,7 +538,7 @@ mod update {
           2009,
           "`Mutation.updateOneTestModel.data.TestModelUncheckedUpdateInput.a.AUpdateEnvelopeInput.update.AUpdateInput.a_1.StringFieldUpdateOperationsInput.unset`: Field does not exist on enclosing type."
         );
-    
+
         Ok(())
     }
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/composites/single.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/composites/single.rs
@@ -525,7 +525,7 @@ mod update {
     }
 
     #[connector_test]
-    async fn update_unset_false_idempotent(runner: Runner) -> TestResult<()> {
+    async fn update_unset_false_is_noop(runner: Runner) -> TestResult<()> {
         create_test_data(&runner).await?;
 
         // Top-level composite

--- a/query-engine/connectors/mongodb-query-connector/src/root_queries/update_utils.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/root_queries/update_utils.rs
@@ -108,7 +108,16 @@ impl IntoUpdateDocumentExtension for CompositeWriteOperation {
 
                 update_docs
             }
-            CompositeWriteOperation::Unset => todo!(),
+            CompositeWriteOperation::Unset(should_unset) => {
+                let mut docs = Vec::with_capacity(1);
+
+                if should_unset {
+                    docs.push(doc! { "$unset": field_name })
+                }
+
+                docs
+            }
+            CompositeWriteOperation::Push(_) => todo!(),
         };
 
         Ok(docs)

--- a/query-engine/connectors/mongodb-query-connector/src/root_queries/update_utils.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/root_queries/update_utils.rs
@@ -1,46 +1,61 @@
 use super::*;
-use crate::IntoBson;
-use connector_interface::{CompositeWriteOperation, ScalarWriteOperation, WriteOperation};
+use crate::{BsonTransform, IntoBson};
+use connector_interface::{CompositeWriteOperation, FieldPath, ScalarWriteOperation, WriteOperation};
+use itertools::Itertools;
 use mongodb::bson::{doc, Document};
 use prisma_models::PrismaValue;
 
-pub trait IntoUpdateDocumentExtension {
-    fn into_update_docs(self, field: &Field, field_path: &str) -> crate::Result<Vec<Document>>;
+pub(crate) trait IntoUpdateDocumentExtension {
+    fn into_update_docs(self) -> crate::Result<Vec<Document>>;
 }
 
-impl IntoUpdateDocumentExtension for WriteOperation {
-    fn into_update_docs(self, field: &Field, field_path: &str) -> crate::Result<Vec<Document>> {
+impl IntoUpdateDocumentExtension for Vec<UpdateExpression> {
+    fn into_update_docs(self) -> crate::Result<Vec<Document>> {
+        self.into_iter()
+            .map(|op| op.into_bson()?.into_document())
+            .collect::<crate::Result<Vec<_>>>()
+    }
+}
+
+pub(crate) trait IntoUpdateOperationExtension {
+    fn into_update_ops(self, field: &Field, path: FieldPath) -> crate::Result<Vec<UpdateExpression>>;
+}
+
+impl IntoUpdateOperationExtension for WriteOperation {
+    fn into_update_ops(self, field: &Field, path: FieldPath) -> crate::Result<Vec<UpdateExpression>> {
         match self {
-            WriteOperation::Scalar(op) => op.into_update_docs(field, field_path),
-            WriteOperation::Composite(op) => op.into_update_docs(field, field_path),
+            WriteOperation::Scalar(op) => op.into_update_ops(field, path),
+            WriteOperation::Composite(op) => op.into_update_ops(field, path),
         }
     }
 }
 
-impl IntoUpdateDocumentExtension for ScalarWriteOperation {
-    fn into_update_docs(self, field: &Field, field_path: &str) -> crate::Result<Vec<Document>> {
-        let dollar_field_path = format!("${}", field_path);
+impl IntoUpdateOperationExtension for ScalarWriteOperation {
+    fn into_update_ops(self, field: &Field, field_path: FieldPath) -> crate::Result<Vec<UpdateExpression>> {
+        let dollar_field_path = field_path.dollar_path();
 
         let doc = match self {
-            ScalarWriteOperation::Add(rhs) if field.is_list() => {
-                render_push_update_doc(rhs, field, field_path, &dollar_field_path)?
-            }
+            ScalarWriteOperation::Add(rhs) if field.is_list() => render_push_update_doc(rhs, field, field_path)?,
             // We use $literal to enable the set of empty object, which is otherwise considered a syntax error
-            ScalarWriteOperation::Set(rhs) => doc! {
-                "$set": { field_path: { "$literal": (field, rhs).into_bson()? } }
-            },
-            ScalarWriteOperation::Add(rhs) => doc! {
-                "$set": { field_path: { "$add": [dollar_field_path, (field, rhs).into_bson()?] } }
-            },
-            ScalarWriteOperation::Substract(rhs) => doc! {
-                "$set": { field_path: { "$subtract": [dollar_field_path, (field, rhs).into_bson()?] } }
-            },
-            ScalarWriteOperation::Multiply(rhs) => doc! {
-                "$set": { field_path: { "$multiply": [dollar_field_path, (field, rhs).into_bson()?] } }
-            },
-            ScalarWriteOperation::Divide(rhs) => doc! {
-                "$set": { field_path: { "$divide": [dollar_field_path, (field, rhs).into_bson()?] } }
-            },
+            ScalarWriteOperation::Set(rhs) => {
+                UpdateExpression::set(field_path, doc! { "$literal": (field, rhs).into_bson()? })
+            }
+            ScalarWriteOperation::Add(rhs) => UpdateExpression::set(
+                field_path,
+                doc! { "$add": [dollar_field_path, (field, rhs).into_bson()?] },
+            ),
+            ScalarWriteOperation::Substract(rhs) => UpdateExpression::set(
+                field_path,
+                doc! { "$subtract": [dollar_field_path, (field, rhs).into_bson()?] },
+            ),
+            ScalarWriteOperation::Multiply(rhs) => UpdateExpression::set(
+                field_path,
+                doc! { "$multiply": [dollar_field_path, (field, rhs).into_bson()?] },
+            ),
+            ScalarWriteOperation::Divide(rhs) => UpdateExpression::set(
+                field_path,
+                doc! { "$divide": [dollar_field_path, (field, rhs).into_bson()?] },
+            ),
             ScalarWriteOperation::Field(_) => unimplemented!(),
         };
 
@@ -48,35 +63,113 @@ impl IntoUpdateDocumentExtension for ScalarWriteOperation {
     }
 }
 
-impl IntoUpdateDocumentExtension for CompositeWriteOperation {
-    fn into_update_docs(self, field: &Field, field_path: &str) -> crate::Result<Vec<Document>> {
-        let dollar_field_path = format!("${}", field_path);
+impl IntoUpdateOperationExtension for CompositeWriteOperation {
+    fn into_update_ops(self, field: &Field, path: FieldPath) -> crate::Result<Vec<UpdateExpression>> {
+        let dollar_field_path = path.dollar_path();
 
         let docs = match self {
             // We use $literal to enable the set of empty object, which is otherwise considered a syntax error
-            CompositeWriteOperation::Set(rhs) => vec![doc! {
-                "$set": { field_path: { "$literal": (field, rhs).into_bson()? } }
-            }],
+            CompositeWriteOperation::Set(rhs) => {
+                vec![UpdateExpression::set(
+                    path,
+                    doc! { "$literal": (field, rhs).into_bson()? },
+                )]
+            }
             CompositeWriteOperation::Update(nested_write) => {
                 let mut update_docs = vec![];
 
-                for (write_op, field, field_path) in nested_write.unfold(field) {
-                    update_docs.extend(write_op.into_update_docs(field, &field_path)?);
+                for (write_op, field, field_path) in nested_write.unfold(field, path) {
+                    dbg!(&field_path);
+                    update_docs.extend(write_op.into_update_ops(field, field_path)?);
                 }
 
                 update_docs
             }
             CompositeWriteOperation::Unset(should_unset) => {
-                let mut docs = Vec::with_capacity(1);
+                let mut ops = Vec::with_capacity(1);
 
                 if should_unset {
-                    docs.push(doc! { "$unset": field_path })
+                    ops.push(UpdateExpression::set(path, Bson::String("$$REMOVE".to_owned())))
                 }
 
-                docs
+                ops
             }
             CompositeWriteOperation::Push(rhs) => {
-                vec![render_push_update_doc(rhs, field, field_path, &dollar_field_path)?]
+                vec![render_push_update_doc(rhs, field, path)?]
+            }
+            CompositeWriteOperation::Upsert { set, update } => {
+                let should_set_id = format!("__prisma_should_set__{}", &path.identifier());
+                let should_set_ref_id = format!("${}", &should_set_id);
+
+                let set_docs = (*set)
+                    .into_update_ops(field, path.clone())?
+                    .into_iter()
+                    .map(|op| {
+                        let set = op.try_into_set().unwrap();
+                        let cond = doc! { "$eq": [&should_set_ref_id, true] };
+
+                        // Maps a Set expression to be executed _only_ if the field should be set and not updated. eg:
+                        // From: { $set: { {field_path}: {some_expression} } }
+                        // To:   { $set: { $cond: { if: {cond}, then: {some_expression}, else: "${field_path}"  } } }
+                        // where {cond} is the expression is the `cond` variable above
+                        UpdateExpression::set_upsert(
+                            set.field_path().clone(),
+                            UpdateExpression::if_then_else(
+                                cond,
+                                set.expression().clone(),
+                                Bson::String(set.field_path().dollar_path()),
+                            ),
+                        )
+                    })
+                    .collect_vec();
+                let update_docs = (*update)
+                    .into_update_ops(field, path)?
+                    .into_iter()
+                    .map(|op| match op {
+                        UpdateExpression::Set(set) => {
+                            // Because nested `upsert`s can be part of `update` operations,
+                            // Both `CompositeWriteOperation::Upsert { set }` and `CompositeWriteOperation::Upsert { set }` operations can be found in an `upsert.update`
+                            // Consequently, we need to know what type of Set expression we're dealing with to set the appropriate conditions.
+                            let cond = if set.is_upsert_set {
+                                doc! { "$eq": [&should_set_ref_id, true] }
+                            } else {
+                                doc! { "$eq": [&should_set_ref_id, false] }
+                            };
+
+                            // Maps a Set expression to be executed _only_ if the field should be set _or_ updated. eg:
+                            // From: { $set: { {field_path}: {some_expression} } }
+                            // To:   { $set: { $cond: { if: {cond}, then: {some_expression}, else: "${field_path}"  } } }
+                            // where {cond} is the expression is the `cond` variable above
+                            UpdateExpression::set(
+                                set.field_path().clone(),
+                                UpdateExpression::if_then_else(
+                                    cond,
+                                    set.expression().clone(),
+                                    Bson::String(set.field_path().dollar_path()),
+                                ),
+                            )
+                        }
+                        x => x,
+                    })
+                    .collect_vec();
+                let mut docs: Vec<UpdateExpression> = vec![];
+
+                // Adds a `__should_set__{field_path}` field that states whether a field needs to be `set` or `updated`
+                // `__should_set__` is true when {field_path} is null or absent
+                docs.push(
+                    doc! { "$addFields": {
+                        &should_set_id: {
+                            "$eq": [{ "$ifNull": [dollar_field_path, true] }, true]
+                        }
+                    }}
+                    .into(),
+                );
+                docs.extend(set_docs);
+                docs.extend(update_docs);
+                // Unsets the `__should_set__{field_path}` field
+                docs.push(doc! { "$unset": Bson::from(should_set_id) }.into());
+
+                docs
             }
         };
 
@@ -84,12 +177,9 @@ impl IntoUpdateDocumentExtension for CompositeWriteOperation {
     }
 }
 
-fn render_push_update_doc(
-    rhs: PrismaValue,
-    field: &Field,
-    field_name: &str,
-    dollar_field_name: &str,
-) -> crate::Result<Document> {
+fn render_push_update_doc(rhs: PrismaValue, field: &Field, field_path: FieldPath) -> crate::Result<UpdateExpression> {
+    let dollar_field_path = field_path.dollar_path();
+
     let doc = match rhs {
         PrismaValue::List(vals) => {
             let vals = vals
@@ -110,14 +200,15 @@ fn render_push_update_doc(
 
             let bson_array = Bson::Array(vals);
 
-            doc! {
-                "$set": { field_name: {
+            UpdateExpression::set(
+                field_path,
+                doc! {
                     "$ifNull": [
-                        { "$concatArrays": [dollar_field_name, bson_array.clone()] },
+                        { "$concatArrays": [dollar_field_path, bson_array.clone()] },
                         bson_array
                     ]
-                } }
-            }
+                },
+            )
         }
         val => {
             let bson_val = match (field, val).into_bson()? {
@@ -125,18 +216,138 @@ fn render_push_update_doc(
                 bson => Bson::Array(vec![bson]),
             };
 
-            doc! {
-                "$set": {
-                    field_name: {
-                        "$ifNull": [
-                            { "$concatArrays": [dollar_field_name, bson_val.clone()] },
-                            bson_val
-                        ]
-                    }
-                }
-            }
+            UpdateExpression::set(
+                field_path,
+                doc! {
+                    "$ifNull": [
+                        { "$concatArrays": [dollar_field_path, bson_val.clone()] },
+                        bson_val
+                    ]
+                },
+            )
         }
     };
 
     Ok(doc)
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum UpdateExpression {
+    Set(Set),
+    IfThenElse(IfThenElse),
+    Generic(Bson),
+}
+
+impl IntoBson for UpdateExpression {
+    fn into_bson(self) -> crate::Result<Bson> {
+        let bson: Bson = match self {
+            UpdateExpression::Set(set) => {
+                doc! { "$set": { set.field_path.path(): (*set.expression).into_bson()? } }.into()
+            }
+            UpdateExpression::IfThenElse(if_then_else) => doc! {
+                "$cond": {
+                    "if": (*if_then_else.cond).into_bson()?,
+                    "then": (*if_then_else.then).into_bson()?,
+                    "else": (*if_then_else.els).into_bson()?
+                }
+
+            }
+            .into(),
+            UpdateExpression::Generic(bson) => bson,
+        };
+
+        Ok(bson)
+    }
+}
+
+impl From<Bson> for UpdateExpression {
+    fn from(bson: Bson) -> Self {
+        Self::Generic(bson)
+    }
+}
+
+impl From<Document> for UpdateExpression {
+    fn from(doc: Document) -> Self {
+        Self::Generic(doc.into())
+    }
+}
+
+impl From<Set> for UpdateExpression {
+    fn from(set: Set) -> Self {
+        Self::Set(set)
+    }
+}
+
+impl From<IfThenElse> for UpdateExpression {
+    fn from(if_then_else: IfThenElse) -> Self {
+        Self::IfThenElse(if_then_else)
+    }
+}
+
+impl UpdateExpression {
+    pub fn set(field_path: FieldPath, operation: impl Into<UpdateExpression>) -> Self {
+        Self::Set(Set {
+            field_path,
+            expression: Box::new(operation.into()),
+            is_upsert_set: false,
+        })
+    }
+
+    /// Create a set expression specifically for an `upsert.set` operation
+    pub fn set_upsert(field_path: FieldPath, operation: impl Into<UpdateExpression>) -> Self {
+        Self::Set(Set {
+            field_path,
+            expression: Box::new(operation.into()),
+            is_upsert_set: true,
+        })
+    }
+
+    pub fn if_then_else(
+        cond: impl Into<UpdateExpression>,
+        then: impl Into<UpdateExpression>,
+        els: impl Into<UpdateExpression>,
+    ) -> Self {
+        Self::IfThenElse(IfThenElse {
+            cond: Box::new(cond.into()),
+            then: Box::new(then.into()),
+            els: Box::new(els.into()),
+        })
+    }
+
+    fn try_into_set(self) -> Option<Set> {
+        if let Self::Set(set) = self {
+            Some(set)
+        } else {
+            None
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct Set {
+    /// The field path to which this set expression should be applied
+    pub field_path: FieldPath,
+    /// The inner expression that should be set
+    pub expression: Box<UpdateExpression>,
+    /// Is the expression the `set` part of an `upsert`
+    pub is_upsert_set: bool,
+}
+
+impl Set {
+    /// Get a reference to the set's field path.
+    fn field_path(&self) -> &FieldPath {
+        &self.field_path
+    }
+
+    /// Get a reference to the set's expression.
+    fn expression(&self) -> &UpdateExpression {
+        self.expression.as_ref()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct IfThenElse {
+    pub cond: Box<UpdateExpression>,
+    pub then: Box<UpdateExpression>,
+    pub els: Box<UpdateExpression>,
 }

--- a/query-engine/connectors/mongodb-query-connector/src/root_queries/write.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/root_queries/write.rs
@@ -14,7 +14,7 @@ use mongodb::{
 };
 use prisma_models::{ModelRef, PrismaValue, SelectionResult};
 use std::convert::TryInto;
-use update_utils::IntoUpdateDocumentExtension;
+use update_utils::{IntoUpdateDocumentExtension, IntoUpdateOperationExtension};
 
 /// Create a single record to the database resulting in a
 /// `RecordProjection` as an identifier pointing to the just-created document.
@@ -153,10 +153,10 @@ pub async fn update_records<'conn>(
     let mut update_docs: Vec<Document> = vec![];
 
     for (field, write_op) in fields {
-        let field_name = field.db_name();
-        let docs = write_op.into_update_docs(&field, field_name)?;
+        let field_path = FieldPath::new_from_segment(&field);
+        let update_ops = write_op.into_update_ops(&field, field_path)?.into_update_docs()?;
 
-        update_docs.extend(docs);
+        update_docs.extend(update_ops);
     }
 
     if !update_docs.is_empty() {

--- a/query-engine/connectors/query-connector/src/write_args.rs
+++ b/query-engine/connectors/query-connector/src/write_args.rs
@@ -85,6 +85,10 @@ impl WriteOperation {
         Self::Composite(CompositeWriteOperation::Update(NestedWrite { writes }))
     }
 
+    pub fn composite_push(pv: PrismaValue) -> Self {
+        Self::Composite(CompositeWriteOperation::Push(pv))
+    }
+
     pub fn as_scalar(&self) -> Option<&ScalarWriteOperation> {
         if let Self::Scalar(v) = self {
             Some(v)
@@ -142,6 +146,7 @@ pub enum ScalarWriteOperation {
 #[derive(Debug, PartialEq, Clone)]
 pub enum CompositeWriteOperation {
     Set(PrismaValue),
+    Push(PrismaValue),
     Unset(bool),
     Update(NestedWrite),
 }

--- a/query-engine/connectors/query-connector/src/write_args.rs
+++ b/query-engine/connectors/query-connector/src/write_args.rs
@@ -77,6 +77,10 @@ impl WriteOperation {
         Self::Composite(CompositeWriteOperation::Set(pv))
     }
 
+    pub fn composite_unset(should_unset: bool) -> Self {
+        Self::Composite(CompositeWriteOperation::Unset(should_unset))
+    }
+
     pub fn composite_update(writes: Vec<(DatasourceFieldName, WriteOperation)>) -> Self {
         Self::Composite(CompositeWriteOperation::Update(NestedWrite { writes }))
     }
@@ -138,7 +142,7 @@ pub enum ScalarWriteOperation {
 #[derive(Debug, PartialEq, Clone)]
 pub enum CompositeWriteOperation {
     Set(PrismaValue),
-    Unset,
+    Unset(bool),
     Update(NestedWrite),
 }
 

--- a/query-engine/connectors/query-connector/src/write_args.rs
+++ b/query-engine/connectors/query-connector/src/write_args.rs
@@ -89,6 +89,13 @@ impl WriteOperation {
         Self::Composite(CompositeWriteOperation::Push(pv))
     }
 
+    pub fn composite_upsert(set: CompositeWriteOperation, update: CompositeWriteOperation) -> Self {
+        Self::Composite(CompositeWriteOperation::Upsert {
+            set: Box::new(set),
+            update: Box::new(update),
+        })
+    }
+
     pub fn as_scalar(&self) -> Option<&ScalarWriteOperation> {
         if let Self::Scalar(v) = self {
             Some(v)
@@ -105,19 +112,19 @@ impl WriteOperation {
         }
     }
 
-    pub fn try_into_scalar(self) -> Result<ScalarWriteOperation, Self> {
+    pub fn try_into_scalar(self) -> Option<ScalarWriteOperation> {
         if let Self::Scalar(v) = self {
-            Ok(v)
+            Some(v)
         } else {
-            Err(self)
+            None
         }
     }
 
-    pub fn try_into_composite(self) -> Result<CompositeWriteOperation, Self> {
+    pub fn try_into_composite(self) -> Option<CompositeWriteOperation> {
         if let Self::Composite(v) = self {
-            Ok(v)
+            Some(v)
         } else {
-            Err(self)
+            None
         }
     }
 }
@@ -149,11 +156,45 @@ pub enum CompositeWriteOperation {
     Push(PrismaValue),
     Unset(bool),
     Update(NestedWrite),
+    Upsert {
+        set: Box<CompositeWriteOperation>,
+        update: Box<CompositeWriteOperation>,
+    },
 }
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct NestedWrite {
     pub writes: Vec<(DatasourceFieldName, WriteOperation)>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct FieldPath {
+    path: Vec<String>,
+}
+
+impl FieldPath {
+    pub fn new_from_segment(field: &Field) -> Self {
+        let mut path = Self::default();
+        path.add_segment(field);
+
+        path
+    }
+
+    pub fn add_segment(&mut self, field: &Field) {
+        self.path.push(field.db_name().to_owned());
+    }
+
+    pub fn path(&self) -> String {
+        self.path.join(".")
+    }
+
+    pub fn dollar_path(&self) -> String {
+        format!("${}", self.path())
+    }
+
+    pub fn identifier(&self) -> String {
+        self.path.join("_")
+    }
 }
 
 impl NestedWrite {
@@ -174,12 +215,12 @@ impl NestedWrite {
     ///  - `Set("3")` is the write operation to execute
     ///  - `Field("field_b")` is the field on which to execute the write operation
     /// - `"field_a.field_b"` is the path for MongoDB to access the nested field
-    pub fn unfold(self, field: &Field) -> Vec<(WriteOperation, &Field, String)> {
-        self.unfold_internal(field, vec![field.db_name().to_owned()])
+    pub fn unfold(self, field: &Field, field_path: FieldPath) -> Vec<(WriteOperation, &Field, FieldPath)> {
+        self.unfold_internal(field, field_path)
     }
 
-    fn unfold_internal(self, field: &'_ Field, path: Vec<String>) -> Vec<(WriteOperation, &'_ Field, String)> {
-        let mut nested_writes: Vec<(WriteOperation, &Field, String)> = vec![];
+    fn unfold_internal(self, field: &'_ Field, field_path: FieldPath) -> Vec<(WriteOperation, &'_ Field, FieldPath)> {
+        let mut nested_writes: Vec<(WriteOperation, &Field, FieldPath)> = vec![];
 
         for (DatasourceFieldName(db_name), write) in self.writes {
             let nested_field = field
@@ -188,17 +229,16 @@ impl NestedWrite {
                 .typ
                 .find_field_by_db_name(&db_name)
                 .unwrap();
-            let mut path = path.clone();
+            let mut new_path = field_path.clone();
+
+            new_path.add_segment(nested_field);
 
             match write {
                 WriteOperation::Composite(CompositeWriteOperation::Update(nested_write)) => {
-                    path.push(db_name);
-
-                    nested_writes.extend(nested_write.unfold_internal(nested_field, path));
+                    nested_writes.extend(nested_write.unfold_internal(nested_field, new_path));
                 }
                 _ => {
-                    path.push(db_name);
-                    nested_writes.push((write, nested_field, path.join(".").to_owned()));
+                    nested_writes.push((write, nested_field, new_path));
                 }
             }
         }

--- a/query-engine/core/src/query_graph_builder/write/write_args_parser.rs
+++ b/query-engine/core/src/query_graph_builder/write/write_args_parser.rs
@@ -147,7 +147,7 @@ fn parse_composite_envelope(
         // Everything in a set operation can only be plain values, no more nested operations.
         operations::SET => WriteOperation::composite_set(value.try_into()?),
         operations::UNSET => parse_composite_unset(value.try_into()?),
-        // operations::PUSH => WriteOperation::composite_push(value.try_into()?),
+        operations::PUSH => WriteOperation::composite_push(value.try_into()?),
         operations::UPDATE => parse_composite_updates(cf, value.try_into()?, path)?,
         _ => unimplemented!(),
     };

--- a/query-engine/core/src/query_graph_builder/write/write_args_parser.rs
+++ b/query-engine/core/src/query_graph_builder/write/write_args_parser.rs
@@ -82,7 +82,6 @@ fn parse_scalar(sf: &ScalarFieldRef, v: ParsedInputValue) -> Result<WriteOperati
                 operations::DECREMENT => WriteOperation::scalar_substract(value),
                 operations::MULTIPLY => WriteOperation::scalar_multiply(value),
                 operations::DIVIDE => WriteOperation::scalar_divide(value),
-                operations::UNSET if sf.container().is_composite() => parse_composite_unset(value),
                 _ => unreachable!("Invalid update operation"),
             };
 
@@ -146,13 +145,27 @@ fn parse_composite_envelope(
     let write_op = match op.as_str() {
         // Everything in a set operation can only be plain values, no more nested operations.
         operations::SET => WriteOperation::composite_set(value.try_into()?),
-        operations::UNSET => parse_composite_unset(value.try_into()?),
         operations::PUSH => WriteOperation::composite_push(value.try_into()?),
+        operations::UNSET => parse_composite_unset(value.try_into()?),
         operations::UPDATE => parse_composite_updates(cf, value.try_into()?, path)?,
+        operations::UPSERT => parse_composite_upsert(cf, value.try_into()?, path)?,
         _ => unimplemented!(),
     };
 
     Ok(write_op)
+}
+
+fn parse_composite_upsert(
+    cf: &CompositeFieldRef,
+    mut value: ParsedInputMap,
+    path: &mut Vec<DatasourceFieldName>,
+) -> QueryGraphBuilderResult<WriteOperation> {
+    let set = value.remove(operations::SET).unwrap();
+    let set = parse_composite_writes(cf, set, path)?.try_into_composite().unwrap();
+    let update: ParsedInputMap = value.remove(operations::UPDATE).unwrap().try_into()?;
+    let update = parse_composite_updates(cf, update, path)?.try_into_composite().unwrap();
+
+    Ok(WriteOperation::composite_upsert(set, update))
 }
 
 fn parse_composite_unset(pv: PrismaValue) -> WriteOperation {

--- a/query-engine/core/src/schema/input_types.rs
+++ b/query-engine/core/src/schema/input_types.rs
@@ -110,6 +110,12 @@ impl InputField {
         self
     }
 
+    /// Sets the field as optional (not required to be present on the input).
+    pub fn required(mut self) -> Self {
+        self.is_required = true;
+        self
+    }
+
     /// Sets the field as optional if the condition is true.
     pub fn optional_if(self, condition: bool) -> Self {
         if condition {

--- a/query-engine/core/src/schema_builder/input_types/fields/data_input_mapper/update.rs
+++ b/query-engine/core/src/schema_builder/input_types/fields/data_input_mapper/update.rs
@@ -305,7 +305,6 @@ fn composite_push_update_input_field(ctx: &mut BuilderContext, cf: &CompositeFie
 }
 
 /// Builds the `upsert` input object type. Should only be used in the envelope type.
-// TODO: remove upsert from update child object
 fn composite_upsert_object_type(ctx: &mut BuilderContext, cf: &CompositeFieldRef) -> InputObjectTypeWeakRef {
     let name = format!("{}UpsertInput", cf.typ.name);
 

--- a/query-engine/core/src/schema_builder/input_types/fields/data_input_mapper/update.rs
+++ b/query-engine/core/src/schema_builder/input_types/fields/data_input_mapper/update.rs
@@ -167,14 +167,9 @@ fn update_operations_object_type(
 ) -> InputObjectTypeWeakRef {
     // Different names are required to construct and cache different objects.
     // - "Nullable" affects the `set` operation (`set` is nullable)
-    // - "NullableComposite" affects the `set` & `unset` operation (`unset` only present when the container is a composite)
-    let null_composite = match (sf.is_required(), sf.container()) {
-        (false, ParentContainer::CompositeType(_)) => "NullableComposite",
-        (false, _) => "Nullable",
-        _ => "",
-    };
+    let nullable = if !sf.is_required() { "Nullable" } else { "" };
     let ident = Identifier::new(
-        format!("{}{}FieldUpdateOperationsInput", null_composite, prefix),
+        format!("{}{}FieldUpdateOperationsInput", nullable, prefix),
         PRISMA_NAMESPACE,
     );
     return_cached_input!(ctx, &ident);
@@ -189,11 +184,6 @@ fn update_operations_object_type(
     let mut fields = vec![input_field(operations::SET, typ.clone(), None)
         .optional()
         .nullable_if(!sf.is_required())];
-
-    // Adds the "unset" field for scalars within composite types
-    if sf.container().is_composite() {
-        append_opt(&mut fields, unset_update_input_field(sf.is_required(), sf.is_list()));
-    }
 
     if with_number_operators {
         fields.push(input_field(operations::INCREMENT, typ.clone(), None).optional());
@@ -240,7 +230,8 @@ fn composite_update_envelope_object_type(ctx: &mut BuilderContext, cf: &Composit
 
     append_opt(&mut fields, composite_update_input_field(ctx, cf));
     append_opt(&mut fields, composite_push_update_input_field(ctx, cf));
-    append_opt(&mut fields, unset_update_input_field(cf.is_required(), cf.is_list()));
+    append_opt(&mut fields, composite_unset_update_input_field(cf));
+    append_opt(&mut fields, composite_upsert_update_input_field(ctx, cf));
 
     input_object.set_fields(fields);
 
@@ -273,7 +264,7 @@ fn composite_update_input_field(ctx: &mut BuilderContext, cf: &CompositeFieldRef
     if cf.is_required() {
         let update_object_type = composite_update_object_type(ctx, cf);
 
-        Some(input_field(operations::UPDATE, InputType::Object(update_object_type.clone()), None).optional())
+        Some(input_field(operations::UPDATE, InputType::Object(update_object_type), None).optional())
     } else {
         None
     }
@@ -308,6 +299,43 @@ fn composite_push_update_input_field(ctx: &mut BuilderContext, cf: &CompositeFie
         let input_types = vec![set_object_type.clone(), InputType::list(set_object_type)];
 
         Some(input_field(operations::PUSH, input_types, None).optional())
+    } else {
+        None
+    }
+}
+
+/// Builds the `upsert` input object type. Should only be used in the envelope type.
+// TODO: remove upsert from update child object
+fn composite_upsert_object_type(ctx: &mut BuilderContext, cf: &CompositeFieldRef) -> InputObjectTypeWeakRef {
+    let name = format!("{}UpsertInput", cf.typ.name);
+
+    let ident = Identifier::new(name, PRISMA_NAMESPACE);
+    return_cached_input!(ctx, &ident);
+
+    let mut input_object = init_input_object_type(ident.clone());
+    input_object.set_tag(ObjectTag::CompositeEnvelope);
+
+    let input_object = Arc::new(input_object);
+
+    ctx.cache_input_type(ident, input_object.clone());
+
+    let update_object_type = composite_update_object_type(ctx, cf);
+    let update_field = input_field(operations::UPDATE, InputType::Object(update_object_type), None);
+    let set_field = composite_set_update_input_field(ctx, cf).required();
+
+    let fields = vec![set_field, update_field];
+
+    input_object.set_fields(fields);
+
+    Arc::downgrade(&input_object)
+}
+
+// Builds an `upsert` input field. Should only be used in the envelope type.
+fn composite_upsert_update_input_field(ctx: &mut BuilderContext, cf: &CompositeFieldRef) -> Option<InputField> {
+    if cf.is_optional() {
+        let upsert_object_type = InputType::Object(composite_upsert_object_type(ctx, cf));
+
+        Some(input_field(operations::UPSERT, upsert_object_type, None).optional())
     } else {
         None
     }

--- a/query-engine/prisma-models/src/field/mod.rs
+++ b/query-engine/prisma-models/src/field/mod.rs
@@ -37,11 +37,15 @@ impl Field {
     }
 
     pub fn is_scalar(&self) -> bool {
-        match self {
-            Field::Scalar(_) => true,
-            Field::Relation(_) => false,
-            Field::Composite(_) => false,
-        }
+        matches!(self, Self::Scalar(_))
+    }
+
+    pub fn is_relation(&self) -> bool {
+        matches!(self, Self::Relation(..))
+    }
+
+    pub fn is_composite(&self) -> bool {
+        matches!(self, Self::Composite(_))
     }
 
     pub fn is_id(&self) -> bool {

--- a/query-engine/prisma-models/src/field/scalar.rs
+++ b/query-engine/prisma-models/src/field/scalar.rs
@@ -64,6 +64,10 @@ impl ScalarField {
     pub fn is_numeric(&self) -> bool {
         self.type_identifier.is_numeric()
     }
+
+    pub fn container(&self) -> &ParentContainer {
+        &self.container
+    }
 }
 
 impl Debug for ScalarField {

--- a/query-engine/prisma-models/src/parent_container.rs
+++ b/query-engine/prisma-models/src/parent_container.rs
@@ -66,6 +66,14 @@ impl ParentContainer {
                 .cloned(),
         }
     }
+
+    pub fn is_composite(&self) -> bool {
+        matches!(self, Self::CompositeType(..))
+    }
+
+    pub fn is_model(&self) -> bool {
+        matches!(self, Self::Model(..))
+    }
 }
 
 impl From<&ModelRef> for ParentContainer {


### PR DESCRIPTION
## Overview

- Adds `unset`, `push` and `upsert` nested operations for `updateOne` on composite types