### PR TITLE
Commenting out wonky fields in Mongo introspection

### DIFF
--- a/introspection-engine/connectors/mongodb-introspection-connector/src/sampler/statistics.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/src/sampler/statistics.rs
@@ -25,13 +25,14 @@ use std::{
 pub(super) const SAMPLE_SIZE: i32 = 1000;
 
 static RESERVED_NAMES: &[&str] = &["PrismaClient"];
+static COMMENTED_OUT_FIELD: &str = "This field was commented out because of an invalid name. Please provide a valid one that matches [a-zA-Z][a-zA-Z0-9_]*";
 
 /// Statistical data from a MongoDB database for determining a Prisma data
 /// model.
 #[derive(Default)]
 pub(super) struct Statistics<'a> {
-    /// (model_name, field_name) -> type percentages
-    fields: BTreeMap<(Name, String), FieldSampler>,
+    /// (container_name, field_name) -> type percentages
+    samples: BTreeMap<(Name, String), FieldSampler>,
     /// model_name -> document count
     models: HashMap<Name, usize>,
     /// model_name -> indices
@@ -68,100 +69,7 @@ impl<'a> Statistics<'a> {
     pub(super) fn into_datamodel(self, warnings: &mut Vec<Warning>) -> Datamodel {
         let mut data_model = Datamodel::new();
         let mut indices = self.indices;
-        let mut unsupported = Vec::new();
-        let mut undecided_types = Vec::new();
-
-        let mut models: BTreeMap<String, Model> = self
-            .models
-            .iter()
-            .flat_map(|(name, _)| name.as_model_name())
-            .map(|model_name| (model_name.to_string(), new_model(model_name)))
-            .collect();
-
-        let mut types: BTreeMap<String, CompositeType> = self
-            .models
-            .iter()
-            .flat_map(|(name, _)| name.as_type_name())
-            .map(|type_name| (type_name.to_string(), new_composite_type(type_name)))
-            .collect();
-
-        for ((name, field_name), sampler) in self.fields.into_iter() {
-            let doc_count = *self.models.get(&name).unwrap_or(&0);
-            let field_count = sampler.counter;
-
-            let percentages = sampler.percentages();
-
-            let field_type = match percentages.find_most_common() {
-                Some(field_type) => field_type.to_owned(),
-                None => FieldType::Unsupported("Unknown"),
-            };
-
-            if let FieldType::Unsupported(r#type) = field_type {
-                unsupported.push((name.clone(), field_name.to_string(), r#type));
-            }
-
-            if percentages.data.len() > 1 {
-                undecided_types.push((name.clone(), field_name.to_string(), field_type.to_string()));
-            }
-
-            let arity = if field_type.is_array() {
-                datamodel::FieldArity::List
-            } else if doc_count > field_count || sampler.nullable {
-                datamodel::FieldArity::Optional
-            } else {
-                datamodel::FieldArity::Required
-            };
-
-            let documentation = if percentages.has_type_variety() {
-                Some(format!(
-                    "Multiple data types found: {} out of {} sampled entries",
-                    percentages, field_count
-                ))
-            } else {
-                None
-            };
-
-            let (sanitized_name, database_name) = match sanitize_string(&field_name) {
-                Some(sanitized) => (sanitized, Some(field_name)),
-                None if field_name == "id" => ("id_".to_string(), Some(field_name)),
-                None => (field_name, None),
-            };
-
-            match name {
-                Name::Model(model_name) => {
-                    let model = models.get_mut(&model_name).unwrap();
-
-                    if database_name.as_deref() == Some("_id") {
-                        continue;
-                    }
-
-                    model.fields.push(Field::ScalarField(ScalarField {
-                        name: sanitized_name,
-                        field_type: field_type.into(),
-                        arity,
-                        database_name,
-                        default_value: None,
-                        documentation,
-                        is_generated: false,
-                        is_updated_at: false,
-                        is_commented_out: false,
-                        is_ignored: false,
-                    }));
-                }
-                Name::CompositeType(type_name) => {
-                    let r#type = types.get_mut(&type_name).unwrap();
-
-                    r#type.fields.push(CompositeTypeField {
-                        name: sanitized_name,
-                        r#type: field_type.into(),
-                        arity,
-                        documentation,
-                        database_name,
-                        default_value: None,
-                    });
-                }
-            }
-        }
+        let (mut models, types) = populate_fields(&self.models, self.samples, warnings);
 
         add_indices_to_models(&mut models, &mut indices);
 
@@ -173,17 +81,13 @@ impl<'a> Statistics<'a> {
             data_model.composite_types.push(composite_type);
         }
 
-        if !unsupported.is_empty() {
-            warnings.push(crate::warnings::unsupported_type(&unsupported));
-        }
-
-        if !undecided_types.is_empty() {
-            warnings.push(crate::warnings::undecided_field_type(&undecided_types));
-        }
-
         data_model
     }
 
+    /// Creates a new name for a composite type with the following rules:
+    ///
+    /// - if model is foo and field is bar, the type is FooBar
+    /// - if a model already exists with the name, we'll use FooBar_
     fn composite_type_name(&self, model: &str, field: &str) -> Name {
         let name = Name::Model(format!("{}_{}", model, field).to_case(Case::Pascal));
 
@@ -196,6 +100,7 @@ impl<'a> Statistics<'a> {
         Name::CompositeType(name)
     }
 
+    /// Tracking the usage of types and names in a composite type.
     fn track_composite_type_fields(
         &mut self,
         model: &str,
@@ -207,6 +112,10 @@ impl<'a> Statistics<'a> {
         self.track_document_types(name, document, depth);
     }
 
+    /// If a document has a nested document, we'll introspect it as a composite
+    /// type until a certain depth. The depth can be given by user, and if we
+    /// reach enough nesting the following composite types are introspected as
+    /// `Json`.
     fn find_and_track_composite_types(
         &mut self,
         model: &str,
@@ -265,10 +174,12 @@ impl<'a> Statistics<'a> {
                 None
             };
 
-            let sampler = self.fields.entry((name.clone(), field.to_string())).or_default();
+            let sampler = self.samples.entry((name.clone(), field.to_string())).or_default();
             sampler.counter += 1;
 
             match FieldType::from_bson(val, compound_name) {
+                // We cannot have arrays of arrays, so multi-dimensional arrays
+                // are introspected as `Json[]`.
                 Some(_) if found_composite && array_layers > 1 => {
                     let counter = sampler
                         .types
@@ -276,10 +187,13 @@ impl<'a> Statistics<'a> {
                         .or_default();
                     *counter += 1;
                 }
+                // Counting the types.
                 Some(field_type) => {
                     let counter = sampler.types.entry(field_type).or_default();
                     *counter += 1;
                 }
+                // If the value is null, the field must be optional and we
+                // cannot detect the type.
                 None => {
                     sampler.nullable = true;
                 }
@@ -296,6 +210,7 @@ pub struct FieldSampler {
 }
 
 impl FieldSampler {
+    /// Counting the percentages of different types per field.
     fn percentages(&self) -> FieldPercentages {
         let total = self.types.iter().fold(0, |acc, (_, count)| acc + count);
         let mut data = BTreeMap::new();
@@ -400,6 +315,137 @@ fn new_model(model_name: &str) -> Model {
         documentation,
         ..Default::default()
     }
+}
+
+/// Read all samples from the data, returning models and composite types.
+///
+/// ## Input
+///
+/// - Samples, counting how many documents altogether there was in the model or
+///   in how many documents we had data for the composite type.
+/// - Fields counts from model or type and field name combination to statistics
+///   of different types seen in the data.
+fn populate_fields(
+    samples: &HashMap<Name, usize>,
+    fields: BTreeMap<(Name, String), FieldSampler>,
+    warnings: &mut Vec<Warning>,
+) -> (BTreeMap<String, Model>, BTreeMap<String, CompositeType>) {
+    let mut models: BTreeMap<String, Model> = samples
+        .iter()
+        .flat_map(|(name, _)| name.as_model_name())
+        .map(|model_name| (model_name.to_string(), new_model(model_name)))
+        .collect();
+
+    let mut types: BTreeMap<String, CompositeType> = samples
+        .iter()
+        .flat_map(|(name, _)| name.as_type_name())
+        .map(|type_name| (type_name.to_string(), new_composite_type(type_name)))
+        .collect();
+
+    let mut unsupported = Vec::new();
+    let mut undecided_types = Vec::new();
+
+    for ((container, field_name), sampler) in fields.into_iter() {
+        let doc_count = *samples.get(&container).unwrap_or(&0);
+        let field_count = sampler.counter;
+
+        let percentages = sampler.percentages();
+
+        let field_type = match percentages.find_most_common() {
+            Some(field_type) => field_type.to_owned(),
+            None => FieldType::Unsupported("Unknown"),
+        };
+
+        if let FieldType::Unsupported(r#type) = field_type {
+            unsupported.push((container.clone(), field_name.to_string(), r#type));
+        }
+
+        if percentages.data.len() > 1 {
+            undecided_types.push((container.clone(), field_name.to_string(), field_type.to_string()));
+        }
+
+        let arity = if field_type.is_array() {
+            datamodel::FieldArity::List
+        } else if doc_count > field_count || sampler.nullable {
+            datamodel::FieldArity::Optional
+        } else {
+            datamodel::FieldArity::Required
+        };
+
+        let mut documentation = if percentages.has_type_variety() {
+            Some(format!(
+                "Multiple data types found: {} out of {} sampled entries",
+                percentages, field_count
+            ))
+        } else {
+            None
+        };
+
+        let (name, database_name, is_commented_out) = match sanitize_string(&field_name) {
+            Some(sanitized) if sanitized.is_empty() => {
+                match documentation.as_mut() {
+                    Some(ref mut existing) => {
+                        existing.push('\n');
+                        existing.push_str(COMMENTED_OUT_FIELD);
+                    }
+                    None => {
+                        documentation = Some(COMMENTED_OUT_FIELD.to_string());
+                    }
+                };
+
+                (field_name.clone(), Some(field_name), true)
+            }
+            Some(sanitized) => (sanitized, Some(field_name), false),
+            None if field_name == "id" => ("id_".to_string(), Some(field_name), false),
+            None => (field_name, None, false),
+        };
+
+        match container {
+            Name::Model(model_name) => {
+                let model = models.get_mut(&model_name).unwrap();
+
+                if database_name.as_deref() == Some("_id") {
+                    continue;
+                }
+
+                model.fields.push(Field::ScalarField(ScalarField {
+                    name,
+                    field_type: field_type.into(),
+                    arity,
+                    database_name,
+                    default_value: None,
+                    documentation,
+                    is_generated: false,
+                    is_updated_at: false,
+                    is_commented_out,
+                    is_ignored: false,
+                }));
+            }
+            Name::CompositeType(type_name) => {
+                let r#type = types.get_mut(&type_name).unwrap();
+
+                r#type.fields.push(CompositeTypeField {
+                    name,
+                    r#type: field_type.into(),
+                    default_value: None,
+                    arity,
+                    documentation,
+                    database_name,
+                    is_commented_out,
+                });
+            }
+        }
+    }
+
+    if !unsupported.is_empty() {
+        warnings.push(crate::warnings::unsupported_type(&unsupported));
+    }
+
+    if !undecided_types.is_empty() {
+        warnings.push(crate::warnings::undecided_field_type(&undecided_types));
+    }
+
+    (models, types)
 }
 
 fn add_indices_to_models(models: &mut BTreeMap<String, Model>, indices: &mut BTreeMap<String, Vec<IndexWalker<'_>>>) {

--- a/introspection-engine/connectors/mongodb-introspection-connector/src/sampler/statistics.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/src/sampler/statistics.rs
@@ -344,6 +344,7 @@ fn populate_fields(
 
     let mut unsupported = Vec::new();
     let mut undecided_types = Vec::new();
+    let mut fields_with_empty_names = Vec::new();
 
     for ((container, field_name), sampler) in fields.into_iter() {
         let doc_count = *samples.get(&container).unwrap_or(&0);
@@ -392,6 +393,8 @@ fn populate_fields(
                         documentation = Some(COMMENTED_OUT_FIELD.to_string());
                     }
                 };
+
+                fields_with_empty_names.push((container.clone(), field_name.clone()));
 
                 (field_name.clone(), Some(field_name), true)
             }
@@ -443,6 +446,10 @@ fn populate_fields(
 
     if !undecided_types.is_empty() {
         warnings.push(crate::warnings::undecided_field_type(&undecided_types));
+    }
+
+    if !fields_with_empty_names.is_empty() {
+        warnings.push(crate::warnings::fields_with_empty_names(&fields_with_empty_names));
     }
 
     (models, types)

--- a/introspection-engine/connectors/mongodb-introspection-connector/src/warnings.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/src/warnings.rs
@@ -1,3 +1,4 @@
+use crate::sampler::Name;
 use introspection_connector::Warning;
 use serde_json::json;
 
@@ -51,6 +52,30 @@ pub(crate) fn undecided_field_type(affected: &[(Name, String, String)]) -> Warni
     Warning {
         code: 101,
         message: "The following fields had data stored in multiple types. The most common type was chosen. If loading data with a type that does not match the one in the data model, the client will crash. Please see the issue: https://github.com/prisma/prisma/issues/9654".into(),
+        affected,
+    }
+}
+
+pub(crate) fn fields_with_empty_names(fields_with_empty_names: &[(Name, String)]) -> Warning {
+    let affected = serde_json::Value::Array({
+        fields_with_empty_names
+            .iter()
+            .map(|(container, field)| match container {
+                Name::Model(name) => json!({
+                    "model": name,
+                    "field": field
+                }),
+                Name::CompositeType(name) => json!({
+                    "type": name,
+                    "field": field
+                }),
+            })
+            .collect()
+    });
+
+    Warning {
+        code: 4,
+        message: "These enum values were commented out because their names are currently not supported by Prisma. Please provide valid ones that match [a-zA-Z][a-zA-Z0-9_]* using the `@map` attribute.".into(),
         affected,
     }
 }

--- a/introspection-engine/connectors/mongodb-introspection-connector/src/warnings.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/src/warnings.rs
@@ -1,4 +1,3 @@
-use crate::sampler::Name;
 use introspection_connector::Warning;
 use serde_json::json;
 

--- a/introspection-engine/connectors/mongodb-introspection-connector/tests/dirty_data/mod.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/tests/dirty_data/mod.rs
@@ -29,7 +29,7 @@ fn mixing_types() {
     let res = introspect(|db| async move {
         db.create_collection("A", None).await?;
         let collection = db.collection("A");
-        let docs = vec![doc! {"first": "Musti"}, doc! {"first": 1}, doc! {"first": null}];
+        let docs = vec![doc! {"first": "Musti"}, doc! {"first": 1i32}, doc! {"first": null}];
 
         collection.insert_many(docs, None).await.unwrap();
 
@@ -48,7 +48,7 @@ fn mixing_types() {
 
     res.assert_warning("The following fields had data stored in multiple types. The most common type was chosen. If loading data with a type that does not match the one in the data model, the client will crash. Please see the issue: https://github.com/prisma/prisma/issues/9654");
 
-    res.assert_affected(json!([{
+    res.assert_warning_affected(&json!([{
         "model": "A",
         "field": "first",
         "tpe": "Int32",
@@ -82,7 +82,7 @@ fn mixing_types_with_the_same_base_type() {
 
     expected.assert_eq(res.datamodel());
 
-    res.assert_affected(json!([{
+    res.assert_warning_affected(&json!([{
         "model": "A",
         "field": "first",
         "tpe": "Timestamp",
@@ -111,7 +111,7 @@ fn the_most_common_type_wins() {
 
     expected.assert_eq(res.datamodel());
 
-    res.assert_affected(json!([{
+    res.assert_warning_affected(&json!([{
         "model": "A",
         "field": "first",
         "tpe": "String",

--- a/introspection-engine/connectors/mongodb-introspection-connector/tests/remapping_names/mod.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/tests/remapping_names/mod.rs
@@ -1,5 +1,6 @@
 use crate::test_api::*;
 use mongodb::bson::doc;
+use serde_json::json;
 
 #[test]
 fn remapping_fields_with_invalid_characters() {
@@ -100,6 +101,13 @@ fn remapping_composite_fields_with_numbers() {
     "#]];
 
     expected.assert_eq(res.datamodel());
+
+    res.assert_warning("These enum values were commented out because their names are currently not supported by Prisma. Please provide valid ones that match [a-zA-Z][a-zA-Z0-9_]* using the `@map` attribute.");
+
+    res.assert_warning_affected(&json!([{
+        "type": "OuterInner",
+        "field": "1",
+    }]));
 }
 
 #[test]
@@ -126,6 +134,13 @@ fn remapping_model_fields_with_numbers() {
     "#]];
 
     expected.assert_eq(res.datamodel());
+
+    res.assert_warning("These enum values were commented out because their names are currently not supported by Prisma. Please provide valid ones that match [a-zA-Z][a-zA-Z0-9_]* using the `@map` attribute.");
+
+    res.assert_warning_affected(&json!([{
+        "model": "Outer",
+        "field": "1",
+    }]));
 }
 
 #[test]

--- a/introspection-engine/connectors/mongodb-introspection-connector/tests/test_api/mod.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/tests/test_api/mod.rs
@@ -43,9 +43,9 @@ impl TestResult {
     }
 
     #[track_caller]
-    pub fn assert_affected(&self, affected: serde_json::Value) {
+    pub fn assert_warning_affected(&self, affected: &serde_json::Value) {
         dbg!(&self.warnings);
-        assert_eq!(self.warnings[0].affected, affected)
+        assert!(&self.warnings[0].affected == affected);
     }
 }
 

--- a/introspection-engine/connectors/mongodb-introspection-connector/tests/types/composite.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/tests/types/composite.rs
@@ -38,7 +38,7 @@ fn singular() {
 fn dirty_data() {
     let res = introspect(|db| async move {
         let docs = vec![
-            doc! { "name": "Musti", "address": { "street": "Meowstrasse", "number": 123 }},
+            doc! { "name": "Musti", "address": { "street": "Meowstrasse", "number": 123i32 }},
             doc! { "name": "Naukio", "address": { "street": "Meowstrasse", "number": "123" }},
             doc! { "name": "Bob", "address": { "street": "Kantstrasse", "number": "123" }},
         ];
@@ -64,7 +64,7 @@ fn dirty_data() {
 
     expected.assert_eq(res.datamodel());
 
-    res.assert_affected(json!([{
+    res.assert_warning_affected(&json!([{
         "compositeType": "CatAddress",
         "field": "number",
         "tpe": "String",

--- a/libs/datamodel/connectors/dml/src/composite_type.rs
+++ b/libs/datamodel/connectors/dml/src/composite_type.rs
@@ -24,6 +24,9 @@ pub struct CompositeTypeField {
 
     /// The default value of this field
     pub default_value: Option<DefaultValue>,
+
+    /// Should we comment this field out.
+    pub is_commented_out: bool,
 }
 
 impl CompositeType {

--- a/libs/datamodel/connectors/dml/src/field.rs
+++ b/libs/datamodel/connectors/dml/src/field.rs
@@ -581,6 +581,7 @@ impl WithName for CompositeField {
     fn name(&self) -> &String {
         &self.name
     }
+
     fn set_name(&mut self, name: &str) {
         self.name = String::from(name)
     }

--- a/libs/datamodel/core/src/transform/ast_to_dml/lift.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/lift.rs
@@ -255,6 +255,7 @@ impl<'a> LiftAstToDml<'a> {
                     kind: dml_default_kind(value, field.r#type().as_builtin_scalar()),
                     db_name: None,
                 }),
+                is_commented_out: field.ast_field().is_commented_out,
             };
 
             fields.push(field);

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations.rs
@@ -24,8 +24,12 @@ pub(super) fn validate(ctx: &mut Context<'_>) {
     for composite_type in db.walk_composite_types() {
         composite_types::composite_types_support(composite_type, ctx);
 
-        for field in composite_type.fields() {
-            composite_types::validate_default_value(field, ctx);
+        if !ctx.diagnostics.has_errors() {
+            composite_types::more_than_one_field(composite_type, ctx);
+
+            for field in composite_type.fields() {
+                composite_types::validate_default_value(field, ctx);
+            }
         }
     }
 

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/composite_types.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/composite_types.rs
@@ -3,6 +3,7 @@ use crate::transform::ast_to_dml::{db::walkers::CompositeTypeWalker, validation_
 use diagnostics::DatamodelError;
 use parser_database::walkers::CompositeTypeFieldWalker;
 
+/// Does the connector support composite types.
 pub(crate) fn composite_types_support(composite_type: CompositeTypeWalker<'_, '_>, ctx: &mut Context<'_>) {
     if ctx.connector.supports_composite_types() {
         return;
@@ -10,6 +11,20 @@ pub(crate) fn composite_types_support(composite_type: CompositeTypeWalker<'_, '_
 
     ctx.push_error(DatamodelError::new_validation_error(
         format!("Composite types are not supported on {}.", ctx.connector.name()),
+        composite_type.ast_composite_type().span,
+    ));
+}
+
+/// A composite type must have at least one visible field.
+pub(crate) fn more_than_one_field(composite_type: CompositeTypeWalker<'_, '_>, ctx: &mut Context<'_>) {
+    let num_of_fields = composite_type.fields().filter(|f| f.is_visible()).count();
+
+    if num_of_fields > 0 {
+        return;
+    }
+
+    ctx.push_error(DatamodelError::new_validation_error(
+        String::from("A type must have at least one field defined."),
         composite_type.ast_composite_type().span,
     ));
 }

--- a/libs/datamodel/core/src/transform/dml_to_ast/lower.rs
+++ b/libs/datamodel/core/src/transform/dml_to_ast/lower.rs
@@ -126,7 +126,7 @@ impl<'a> LowerDmlToAst<'a> {
                     .as_ref()
                     .map(|text| ast::Comment { text: text.to_owned() }),
                 span: ast::Span::empty(),
-                is_commented_out: false,
+                is_commented_out: field.is_commented_out,
             });
         }
 

--- a/libs/datamodel/core/tests/types/composite_types.rs
+++ b/libs/datamodel/core/tests/types/composite_types.rs
@@ -553,6 +553,32 @@ fn composite_types_are_parsed_without_error() {
 }
 
 #[test]
+fn composite_types_must_have_at_least_one_visible_field() {
+    let schema = indoc! {r#"
+        type Address {
+          // name String?
+        }
+    "#};
+
+    let datamodel = with_header(schema, Provider::Mongo, &["mongoDb"]);
+
+    let expected = expect![[r#"
+        [1;91merror[0m: [1mError validating: A type must have at least one field defined.[0m
+          [1;94m-->[0m  [4mschema.prisma:11[0m
+        [1;94m   | [0m
+        [1;94m10 | [0m
+        [1;94m11 | [0m[1;91mtype Address {[0m
+        [1;94m12 | [0m  // name String?
+        [1;94m13 | [0m}
+        [1;94m   | [0m
+    "#]];
+
+    let error = datamodel::parse_schema(&datamodel).map(drop).unwrap_err();
+
+    expected.assert_eq(&error);
+}
+
+#[test]
 fn composite_types_cannot_have_block_attributes() {
     let datamodel = r#"
         type Address {

--- a/libs/datamodel/core/tests/types/composite_types.rs
+++ b/libs/datamodel/core/tests/types/composite_types.rs
@@ -4,7 +4,7 @@ use indoc::indoc;
 
 use crate::{
     common::{CompositeTypeAsserts, DatamodelAsserts},
-    with_header,
+    with_header, Provider,
 };
 
 #[test]

--- a/libs/datamodel/core/tests/types/composite_types.rs
+++ b/libs/datamodel/core/tests/types/composite_types.rs
@@ -521,6 +521,7 @@ fn composite_types_are_parsed_without_error() {
                             database_name: None,
                             documentation: None,
                             default_value: None,
+                            is_commented_out: false,
                         },
                         CompositeTypeField {
                             name: "street",
@@ -541,6 +542,7 @@ fn composite_types_are_parsed_without_error() {
                             database_name: None,
                             documentation: None,
                             default_value: None,
+                            is_commented_out: false,
                         },
                     ],
                 },

--- a/libs/datamodel/parser-database/src/walkers/composite_type.rs
+++ b/libs/datamodel/parser-database/src/walkers/composite_type.rs
@@ -125,6 +125,11 @@ impl<'ast, 'db> CompositeTypeFieldWalker<'ast, 'db> {
             .map(move |(datasource_name, name, args, span)| (*datasource_name, *name, args.as_slice(), *span))
     }
 
+    /// Can the client use the field.
+    pub fn is_visible(self) -> bool {
+        !self.ast_field().is_commented_out
+    }
+
     /// The value expression in the `@default` attribute.
     ///
     /// ```ignore


### PR DESCRIPTION
In a case where a model or a type has a field we cannot represent in Prisma, and we cannot rename to anything, we give up commenting the field out and asking the user to rename it manually.

Also prevents using a datamodel with a composite type that has no fields.

Closes: https://github.com/prisma/prisma/issues/11390