### PR TITLE
Try not to panic if we have no index options or a name.

### DIFF
--- a/libs/mongodb-schema-describer/src/lib.rs
+++ b/libs/mongodb-schema-describer/src/lib.rs
@@ -32,8 +32,12 @@ pub async fn describe(client: &mongodb::Client, db_name: &str) -> mongodb::error
         let mut indexes_cursor = collection.list_indexes(None).await?;
 
         while let Some(index) = indexes_cursor.try_next().await? {
-            let options = index.options.unwrap();
-            let name = options.name.unwrap();
+            let options = index.options.unwrap_or_default();
+
+            let name = match options.name {
+                Some(name) => name,
+                None => continue,
+            };
 
             let r#type = match (options.unique, options.text_index_version.as_ref()) {
                 (Some(_), _) => IndexType::Unique,


### PR DESCRIPTION
We skip indices with no name. We introspect them as `@@index` if no options are defined.

Closes: https://github.com/prisma/prisma/issues/11300