### PR TITLE
fix(mongo): keep parsing @db.Array but validate

### DIFF
--- a/libs/datamodel/connectors/mongodb-datamodel-connector/src/lib.rs
+++ b/libs/datamodel/connectors/mongodb-datamodel-connector/src/lib.rs
@@ -82,21 +82,24 @@ impl MongoDbDatamodelConnector {
             None => return,
         };
 
-        if type_name == type_names::ARRAY {
-            let arg = args.get(0).unwrap();
-
-            errors.push_error(datamodel_connector::DatamodelError::ConnectorError {
-                message: ConnectorError::from_kind(ErrorKind::FieldValidationError {
-                    field: field.name().to_owned(),
-                    message: format!(
-                        "Native type `{ds_name}.{}` is deprecated. Please use `{ds_name}.{arg}` instead.",
-                        type_names::ARRAY
-                    ),
-                })
-                .to_string(),
-                span,
-            });
+        if type_name != type_names::ARRAY {
+            return;
         }
+
+        // `db.Array` expects exactly 1 argument, which is validated before this code path.
+        let arg = args.get(0).unwrap();
+
+        errors.push_error(datamodel_connector::DatamodelError::ConnectorError {
+            message: ConnectorError::from_kind(ErrorKind::FieldValidationError {
+                field: field.name().to_owned(),
+                message: format!(
+                    "Native type `{ds_name}.{}` is deprecated. Please use `{ds_name}.{arg}` instead.",
+                    type_names::ARRAY
+                ),
+            })
+            .to_string(),
+            span,
+        });
     }
 }
 

--- a/libs/datamodel/connectors/mongodb-datamodel-connector/src/lib.rs
+++ b/libs/datamodel/connectors/mongodb-datamodel-connector/src/lib.rs
@@ -75,6 +75,29 @@ impl MongoDbDatamodelConnector {
             span: field.ast_field().span,
         });
     }
+
+    fn validate_array_native_type(field: ScalarFieldWalker<'_, '_>, errors: &mut datamodel_connector::Diagnostics) {
+        let (ds_name, type_name, args, span) = match field.raw_native_type() {
+            Some(nt) => nt,
+            None => return,
+        };
+
+        if type_name == type_names::ARRAY {
+            let arg = args.get(0).unwrap();
+
+            errors.push_error(datamodel_connector::DatamodelError::ConnectorError {
+                message: ConnectorError::from_kind(ErrorKind::FieldValidationError {
+                    field: field.name().to_owned(),
+                    message: format!(
+                        "Native type `{ds_name}.{}` is deprecated. Please use `{ds_name}.{arg}` instead.",
+                        type_names::ARRAY
+                    ),
+                })
+                .to_string(),
+                span,
+            });
+        }
+    }
 }
 
 impl Connector for MongoDbDatamodelConnector {
@@ -98,6 +121,7 @@ impl Connector for MongoDbDatamodelConnector {
         for field in model.scalar_fields() {
             Self::validate_auto(field, errors);
             Self::validate_dbgenerated(field, errors);
+            Self::validate_array_native_type(field, errors);
         }
 
         let mut push_error = |err: ConnectorError| {
@@ -172,7 +196,7 @@ impl Connector for MongoDbDatamodelConnector {
     }
 
     fn parse_native_type(&self, name: &str, args: Vec<String>) -> Result<NativeTypeInstance> {
-        let mongo_type = mongo_type_from_input(name)?;
+        let mongo_type = mongo_type_from_input(name, &args)?;
 
         Ok(NativeTypeInstance::new(name, args, mongo_type.to_json()))
     }

--- a/libs/datamodel/core/tests/types/mod.rs
+++ b/libs/datamodel/core/tests/types/mod.rs
@@ -1,6 +1,7 @@
 mod cockroachdb_native_types;
 mod composite_types;
 mod helper;
+mod mongodb_native_types;
 mod mssql_native_types;
 mod mysql_native_types;
 mod negative;

--- a/libs/datamodel/core/tests/types/mongodb_native_types.rs
+++ b/libs/datamodel/core/tests/types/mongodb_native_types.rs
@@ -1,0 +1,29 @@
+use crate::common::*;
+
+#[test]
+fn array_native_type_should_fail() {
+    let dml = r#"
+        datasource db {
+          provider = "mongodb"
+          url      = "mongodb://"
+        }
+
+        model Blog {
+            id     Int   @id @map("_id")
+            post_ids String[] @db.Array(ObjectId)
+        }
+    "#;
+
+    let error = datamodel::parse_schema(dml).map(drop).unwrap_err();
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError validating field 'post_ids': Native type `db.Array` is deprecated. Please use `db.ObjectId` instead.[0m
+          [1;94m-->[0m  [4mschema.prisma:9[0m
+        [1;94m   | [0m
+        [1;94m 8 | [0m            id     Int   @id @map("_id")
+        [1;94m 9 | [0m            post_ids String[] @[1;91mdb.Array(ObjectId)[0m
+        [1;94m   | [0m
+    "#]];
+
+    expectation.assert_eq(&error)
+}

--- a/libs/native-types/src/mongodb.rs
+++ b/libs/native-types/src/mongodb.rs
@@ -8,6 +8,7 @@ use serde_json::Value;
 pub enum MongoDbType {
     String,
     Double,
+    Array(Box<MongoDbType>),
     BinData,
     ObjectId,
     Bool,


### PR DESCRIPTION
## Overview

Partial revert of: #2650.

- `@db.Array` remains parsed but is validated with a suggestion to switch to the new syntax (`@db.Array(String)` -> `@db.String`)

Implements one more TODO of: https://github.com/prisma/prisma/issues/11226