### PR TITLE
Differentiate models/composite types in warnings

### DIFF
--- a/introspection-engine/connectors/mongodb-introspection-connector/src/sampler.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/src/sampler.rs
@@ -9,6 +9,7 @@ use mongodb::{
     Database,
 };
 use mongodb_schema_describer::MongoSchema;
+pub(crate) use statistics::Name;
 use statistics::*;
 
 /// From the given database, lists all collections as models, and samples

--- a/introspection-engine/connectors/mongodb-introspection-connector/src/sampler/statistics.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/src/sampler/statistics.rs
@@ -97,11 +97,11 @@ impl<'a> Statistics<'a> {
             };
 
             if let FieldType::Unsupported(r#type) = field_type {
-                unsupported.push((name.to_string(), field_name.to_string(), r#type));
+                unsupported.push((name.clone(), field_name.to_string(), r#type));
             }
 
             if percentages.data.len() > 1 {
-                undecided_types.push((name.to_string(), field_name.to_string(), field_type.to_string()));
+                undecided_types.push((name.clone(), field_name.to_string(), field_type.to_string()));
             }
 
             let arity = if field_type.is_array() {

--- a/introspection-engine/connectors/mongodb-introspection-connector/src/warnings.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/src/warnings.rs
@@ -1,16 +1,23 @@
 use introspection_connector::Warning;
 use serde_json::json;
 
-pub(crate) fn unsupported_type(affected: &[(String, String, &str)]) -> Warning {
+use crate::sampler::Name;
+
+pub(crate) fn unsupported_type(affected: &[(Name, String, &str)]) -> Warning {
     let affected = serde_json::Value::Array({
         affected
             .iter()
-            .map(|(model, field, tpe)| {
-                json!({
-                    "model": model,
+            .map(|(name, field, tpe)| match name {
+                Name::Model(name) => json!({
+                    "model": name,
                     "field": field,
                     "tpe": tpe
-                })
+                }),
+                Name::CompositeType(name) => json!({
+                    "compositeType": name,
+                    "field": field,
+                    "tpe": tpe
+                }),
             })
             .collect()
     });
@@ -22,16 +29,21 @@ pub(crate) fn unsupported_type(affected: &[(String, String, &str)]) -> Warning {
     }
 }
 
-pub(crate) fn undecided_field_type(affected: &[(String, String, String)]) -> Warning {
+pub(crate) fn undecided_field_type(affected: &[(Name, String, String)]) -> Warning {
     let affected = serde_json::Value::Array({
         affected
             .iter()
-            .map(|(model, field, tpe)| {
-                json!({
-                    "model": model,
+            .map(|(name, field, tpe)| match name {
+                Name::Model(name) => json!({
+                    "model": name,
                     "field": field,
                     "tpe": tpe
-                })
+                }),
+                Name::CompositeType(name) => json!({
+                    "compositeType": name,
+                    "field": field,
+                    "tpe": tpe
+                }),
             })
             .collect()
     });
@@ -39,6 +51,6 @@ pub(crate) fn undecided_field_type(affected: &[(String, String, String)]) -> War
     Warning {
         code: 101,
         message: "The following fields had data stored in multiple types. The most common type was chosen. If loading data with a type that does not match the one in the data model, the client will crash. Please see the issue: https://github.com/prisma/prisma/issues/9654".into(),
-        affected: json![{"name": affected}],
+        affected,
     }
 }

--- a/introspection-engine/connectors/mongodb-introspection-connector/tests/dirty_data/mod.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/tests/dirty_data/mod.rs
@@ -1,5 +1,6 @@
 use crate::test_api::*;
 use mongodb::bson::{doc, Bson, DateTime, Timestamp};
+use serde_json::json;
 
 #[test]
 fn explicit_id_field() {
@@ -46,6 +47,12 @@ fn mixing_types() {
     expected.assert_eq(res.datamodel());
 
     res.assert_warning("The following fields had data stored in multiple types. The most common type was chosen. If loading data with a type that does not match the one in the data model, the client will crash. Please see the issue: https://github.com/prisma/prisma/issues/9654");
+
+    res.assert_affected(json!([{
+        "model": "A",
+        "field": "first",
+        "tpe": "Int32",
+    }]));
 }
 
 #[test]
@@ -74,6 +81,12 @@ fn mixing_types_with_the_same_base_type() {
     "#]];
 
     expected.assert_eq(res.datamodel());
+
+    res.assert_affected(json!([{
+        "model": "A",
+        "field": "first",
+        "tpe": "Timestamp",
+    }]));
 }
 
 #[test]
@@ -97,4 +110,10 @@ fn the_most_common_type_wins() {
     "#]];
 
     expected.assert_eq(res.datamodel());
+
+    res.assert_affected(json!([{
+        "model": "A",
+        "field": "first",
+        "tpe": "String",
+    }]));
 }

--- a/introspection-engine/connectors/mongodb-introspection-connector/tests/test_api/mod.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/tests/test_api/mod.rs
@@ -41,6 +41,12 @@ impl TestResult {
         dbg!(&self.warnings);
         assert!(self.warnings.iter().any(|w| w.message == warning))
     }
+
+    #[track_caller]
+    pub fn assert_affected(&self, affected: serde_json::Value) {
+        dbg!(&self.warnings);
+        assert_eq!(self.warnings[0].affected, affected)
+    }
 }
 
 pub(super) fn introspect_features<F, U>(

--- a/introspection-engine/connectors/mongodb-introspection-connector/tests/types/composite.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/tests/types/composite.rs
@@ -2,6 +2,7 @@ use crate::test_api::*;
 use crate::types::ObjectId;
 use introspection_connector::CompositeTypeDepth;
 use mongodb::bson::{doc, Bson};
+use serde_json::json;
 
 #[test]
 fn singular() {
@@ -62,6 +63,12 @@ fn dirty_data() {
     "#]];
 
     expected.assert_eq(res.datamodel());
+
+    res.assert_affected(json!([{
+        "compositeType": "CatAddress",
+        "field": "number",
+        "tpe": "String",
+    }]));
 }
 
 #[test]


### PR DESCRIPTION
Part of: https://github.com/prisma/prisma/issues/11179