### PR TITLE
Fix mapped name collision on composites

### DIFF
--- a/libs/datamodel/parser-database/src/walkers/composite_type.rs
+++ b/libs/datamodel/parser-database/src/walkers/composite_type.rs
@@ -47,6 +47,18 @@ impl<'ast, 'db> CompositeTypeWalker<'ast, 'db> {
         &self.db.ast[self.ctid].name.name
     }
 
+    /// Get the field with the given ID.
+    pub fn field(self, field_id: ast::FieldId) -> CompositeTypeFieldWalker<'ast, 'db> {
+        let field = &self.db.types.composite_type_fields[&(self.ctid, field_id)];
+
+        CompositeTypeFieldWalker {
+            ctid: self.ctid,
+            field_id,
+            field,
+            db: self.db,
+        }
+    }
+
     /// Iterator over all the fields of the composite type.
     pub fn fields(self) -> impl Iterator<Item = CompositeTypeFieldWalker<'ast, 'db>> {
         let db = self.db;


### PR DESCRIPTION
We correctly validate that:

```prisma
type Foo {
  id Int
  id_ Int @map("id")
}
```

returns an error. But if the type was defined as:

```prisma
type Foo {
  id Int @map("foo")
  id_ Int @map("id")
}
```

we still gave a validation error. The latter should be allowed with this patch.

Closes: https://github.com/prisma/prisma/issues/11625