### PR TITLE
mongo: Multiple ID types introspection

### DIFF
--- a/introspection-engine/connectors/mongodb-introspection-connector/tests/basic/mod.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/tests/basic/mod.rs
@@ -19,6 +19,24 @@ fn empty_collection() {
 }
 
 #[test]
+fn integer_id() {
+    let res = introspect(|db| async move {
+        let collection = db.collection("A");
+        collection.insert_one(doc! { "_id": 12345 }, None).await.unwrap();
+
+        Ok(())
+    });
+
+    let expected = expect![[r#"
+        model A {
+          id Int @id @map("_id")
+        }
+    "#]];
+
+    expected.assert_eq(res.datamodel());
+}
+
+#[test]
 fn multiple_collections_with_data() {
     let res = introspect(|db| async move {
         db.create_collection("A", None).await?;


### PR DESCRIPTION
A mongodb collection id type can be anything. So we apply certain rules here:

- If a field exists with a name `_id`, that will be our id
- If the type of the most prominent field is `ObjectId`, we'll add `auto()` default value to it.
- If the prominent type is not `ObjectId`, no `auto()`
- If we have mixed types in the field, warn the user.

Closes: https://github.com/prisma/prisma/issues/11623