### PR TITLE
A no-op `createDatabase` for MongoDB

### DIFF
--- a/migration-engine/connectors/mongodb-migration-connector/src/client_wrapper.rs
+++ b/migration-engine/connectors/mongodb-migration-connector/src/client_wrapper.rs
@@ -63,6 +63,10 @@ impl Client {
             .await
             .map_err(mongo_error_to_connector_error)
     }
+
+    pub(crate) fn db_name(&self) -> &str {
+        &self.db_name
+    }
 }
 
 pub(crate) fn mongo_error_to_connector_error(mongo_error: MongoError) -> ConnectorError {

--- a/migration-engine/connectors/mongodb-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/mongodb-migration-connector/src/lib.rs
@@ -90,9 +90,9 @@ impl MigrationConnector for MongoDbMigrationConnector {
     }
 
     async fn create_database(&self) -> ConnectorResult<String> {
-        Err(ConnectorError::from_msg(
-            "create_database() is not supported on mongodb: databases are created automatically when used.".to_owned(),
-        ))
+        let name = self.client().await?.db_name();
+        tracing::warn!("MongoDB database will be created on first use.");
+        Ok(name.into())
     }
 
     async fn db_execute(&self, _url: String, _script: String) -> ConnectorResult<()> {


### PR DESCRIPTION
We can't really create databases on MongoDB. They get created automatically on first use, but throwing here is different what we do on other databases. This is a no-op call that will send a warning through the logger.

Will this break something in the CLI and are you able to display this warning @Jolg42?

Closes: https://github.com/prisma/prisma/issues/8582