### PR TITLE
ci: For PRs stop running GitHub Actions if not needed

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -4,6 +4,13 @@ on:
     branches:
       - main
   pull_request:
+    paths-ignore:
+      - '.buildkite/**'
+      - '*.md'
+      - 'LICENSE'
+      - 'CODEOWNERS'
+      - 'renovate.json'
+
 jobs:
   build:
     name: "WebAssembly build ${{ github.event.ref }} for commit ${{ github.event.inputs.commit }}"

--- a/.github/workflows/cargo-doc.yml
+++ b/.github/workflows/cargo-doc.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      
 jobs:
   generate-cargo-docs:
     name: "Generate cargo docs for the workspace"

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -4,6 +4,13 @@ on:
     branches:
       - main
   pull_request:
+    paths-ignore:
+      - '.buildkite/**'
+      - '*.md'
+      - 'LICENSE'
+      - 'CODEOWNERS'
+      - 'renovate.json'
+
 jobs:
   clippy:
     runs-on: ubuntu-latest

--- a/.github/workflows/migration-engine.yml
+++ b/.github/workflows/migration-engine.yml
@@ -4,6 +4,13 @@ on:
     branches:
       - main
   pull_request:
+    paths-ignore:
+      - '.buildkite/**'
+      - '*.md'
+      - 'LICENSE'
+      - 'CODEOWNERS'
+      - 'renovate.json'
+
 jobs:
   test-mongodb-introspection-and-migration-connector:
     name: "Test ${{ matrix.database.name }} on Linux"

--- a/.github/workflows/query-engine.yml
+++ b/.github/workflows/query-engine.yml
@@ -4,6 +4,13 @@ on:
     branches:
       - main
   pull_request:
+    paths-ignore:
+      - '.buildkite/**'
+      - '*.md'
+      - 'LICENSE'
+      - 'CODEOWNERS'
+      - 'renovate.json'
+
 jobs:
   rust-vitess-tests:
     name: "Rust test suite: ${{ matrix.database }} on Linux"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -4,6 +4,13 @@ on:
     branches:
       - main
   pull_request:
+    paths-ignore:
+      - '.buildkite/**'
+      - '*.md'
+      - 'LICENSE'
+      - 'CODEOWNERS'
+      - 'renovate.json'
+      
 jobs:
   test:
     name: Workspace unit tests


### PR DESCRIPTION
Context:
We sometimes do PRs about files that do not affect the build, like `.md` files

Example:
https://github.com/prisma/prisma-engines/pull/2664

This only modifies the PR behavior of GitHub Actions which means when merged to main all tests will run (we could also skip there, like we do in prisma/prisma but thought you would prefer scoping this to the pull request)

So after this PR any change done in these files:
```
      - '.buildkite/**'
      - '*.md'
      - 'LICENSE'
      - 'CODEOWNERS'
      - 'renovate.json'
```

Won't trigger the GitHub Actions that define this list of files to skip.

Benefits:
- Less resources used (so less queuing)
- Potentially less flaky test(s) that could block a PR