### PR TITLE
ME/JSON-RPC Make `print` notification a request

### DIFF
--- a/migration-engine/cli/src/main.rs
+++ b/migration-engine/cli/src/main.rs
@@ -65,6 +65,7 @@ fn set_panic_hook() {
             location,
             message
         );
+        std::process::exit(101);
     }));
 }
 

--- a/migration-engine/cli/src/main.rs
+++ b/migration-engine/cli/src/main.rs
@@ -82,10 +82,12 @@ impl migration_connector::ConnectorHost for JsonRpcHost {
 
         let notification = serde_json::json!({ "content": text });
 
-        self.client
-            .notify("print".to_owned(), notification)
+        let _: std::collections::HashMap<(), ()> = self
+            .client
+            .call("print".to_owned(), notification)
             .await
-            .map_err(|err| ConnectorError::from_source(err, "JSON-RPC error"))
+            .map_err(|err| ConnectorError::from_source(err, "JSON-RPC error"))?;
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Also fix a bug in yet unused json-rpc-stdio code: the select loop was
waiting on request completion, which was preventing engine -> cli
request cycles from being handled.