### PR TITLE
Different error on m2m errors depending on preview flags

### DIFF
--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/relations/many_to_many/embedded.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/relations/many_to_many/embedded.rs
@@ -1,4 +1,7 @@
-use crate::{diagnostics::DatamodelError, transform::ast_to_dml::validation_pipeline::context::Context};
+use crate::{
+    common::preview_features::PreviewFeature, diagnostics::DatamodelError,
+    transform::ast_to_dml::validation_pipeline::context::Context,
+};
 use datamodel_connector::ConnectorCapability;
 use parser_database::walkers::TwoWayEmbeddedManyToManyRelationWalker;
 
@@ -15,10 +18,14 @@ pub(crate) fn supports_embedded_relations(relation: TwoWayEmbeddedManyToManyRela
         .into_iter()
         .map(|r| r.ast_field().span);
 
-    let msg = format!(
-        "Embedded many-to-many relations are not supported on {}. https://pris.ly/d/many-to-many-relations",
-        ctx.connector.name()
-    );
+    let msg = if ctx.preview_features.contains(PreviewFeature::MongoDb) {
+        format!(
+            "Embedded many-to-many relations are not supported on {}. Please use the syntax defined in https://pris.ly/d/relational-database-many-to-many",
+            ctx.connector.name()
+        )
+    } else {
+        String::from("An implicit many-to-many relation should not define `fields` argument.")
+    };
 
     for span in spans {
         ctx.push_error(DatamodelError::new_validation_error(msg.clone(), span));

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/relations/many_to_many/implicit.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/relations/many_to_many/implicit.rs
@@ -69,7 +69,7 @@ pub(crate) fn supports_implicit_relations(relation: ImplicitManyToManyRelationWa
         .map(|r| r.ast_field().span);
 
     let msg = format!(
-        "Implicit many-to-many relations are not supported on {}. https://pris.ly/d/many-to-many-relations",
+        "Implicit many-to-many relations are not supported on {}. Please use the syntax defined in https://pris.ly/d/document-database-many-to-many",
         ctx.connector.name()
     );
 

--- a/libs/datamodel/core/tests/attributes/relations/many_to_many_negative.rs
+++ b/libs/datamodel/core/tests/attributes/relations/many_to_many_negative.rs
@@ -118,14 +118,14 @@ fn embedded_many_to_many_relation_fields_with_referential_actions_postgres() {
     "#};
 
     let expect = expect![[r#"
-        [1;91merror[0m: [1mError validating: Embedded many-to-many relations are not supported on Postgres. https://pris.ly/d/many-to-many-relations[0m
+        [1;91merror[0m: [1mError validating: An implicit many-to-many relation should not define `fields` argument.[0m
           [1;94m-->[0m  [4mschema.prisma:14[0m
         [1;94m   | [0m
         [1;94m13 | [0m  b_ids Int[]
         [1;94m14 | [0m  [1;91mbs    B[]   @relation(fields: [b_ids], references: [id], onDelete: Restrict, onUpdate: Restrict)[0m
         [1;94m15 | [0m}
         [1;94m   | [0m
-        [1;91merror[0m: [1mError validating: Embedded many-to-many relations are not supported on Postgres. https://pris.ly/d/many-to-many-relations[0m
+        [1;91merror[0m: [1mError validating: An implicit many-to-many relation should not define `fields` argument.[0m
           [1;94m-->[0m  [4mschema.prisma:20[0m
         [1;94m   | [0m
         [1;94m19 | [0m  a_ids Int[]
@@ -242,14 +242,14 @@ fn embedded_many_to_many_must_define_references_on_both_sides_postgres() {
     "#};
 
     let expect = expect![[r#"
-        [1;91merror[0m: [1mError validating: Embedded many-to-many relations are not supported on Postgres. https://pris.ly/d/many-to-many-relations[0m
+        [1;91merror[0m: [1mError validating: An implicit many-to-many relation should not define `fields` argument.[0m
           [1;94m-->[0m  [4mschema.prisma:14[0m
         [1;94m   | [0m
         [1;94m13 | [0m  b_ids Int[]
         [1;94m14 | [0m  [1;91mbs    B[]   @relation(fields: [b_ids], references: [id])[0m
         [1;94m15 | [0m}
         [1;94m   | [0m
-        [1;91merror[0m: [1mError validating: Embedded many-to-many relations are not supported on Postgres. https://pris.ly/d/many-to-many-relations[0m
+        [1;91merror[0m: [1mError validating: An implicit many-to-many relation should not define `fields` argument.[0m
           [1;94m-->[0m  [4mschema.prisma:20[0m
         [1;94m   | [0m
         [1;94m19 | [0m  a_ids Int[]
@@ -276,14 +276,14 @@ fn embedded_many_to_many_must_define_references_on_both_sides_postgres() {
     "#};
 
     let expect = expect![[r#"
-        [1;91merror[0m: [1mError validating: Embedded many-to-many relations are not supported on Postgres. https://pris.ly/d/many-to-many-relations[0m
+        [1;91merror[0m: [1mError validating: An implicit many-to-many relation should not define `fields` argument.[0m
           [1;94m-->[0m  [4mschema.prisma:14[0m
         [1;94m   | [0m
         [1;94m13 | [0m  b_ids Int[]
         [1;94m14 | [0m  [1;91mbs    B[]   @relation(fields: [b_ids])[0m
         [1;94m15 | [0m}
         [1;94m   | [0m
-        [1;91merror[0m: [1mError validating: Embedded many-to-many relations are not supported on Postgres. https://pris.ly/d/many-to-many-relations[0m
+        [1;91merror[0m: [1mError validating: An implicit many-to-many relation should not define `fields` argument.[0m
           [1;94m-->[0m  [4mschema.prisma:20[0m
         [1;94m   | [0m
         [1;94m19 | [0m  a_ids Int[]
@@ -310,14 +310,14 @@ fn embedded_many_to_many_must_define_references_on_both_sides_postgres() {
     "#};
 
     let expect = expect![[r#"
-        [1;91merror[0m: [1mError validating: Embedded many-to-many relations are not supported on Postgres. https://pris.ly/d/many-to-many-relations[0m
+        [1;91merror[0m: [1mError validating: An implicit many-to-many relation should not define `fields` argument.[0m
           [1;94m-->[0m  [4mschema.prisma:14[0m
         [1;94m   | [0m
         [1;94m13 | [0m  b_ids Int[]
         [1;94m14 | [0m  [1;91mbs    B[]   @relation(fields: [b_ids])[0m
         [1;94m15 | [0m}
         [1;94m   | [0m
-        [1;91merror[0m: [1mError validating: Embedded many-to-many relations are not supported on Postgres. https://pris.ly/d/many-to-many-relations[0m
+        [1;91merror[0m: [1mError validating: An implicit many-to-many relation should not define `fields` argument.[0m
           [1;94m-->[0m  [4mschema.prisma:20[0m
         [1;94m   | [0m
         [1;94m19 | [0m  a_ids Int[]
@@ -402,14 +402,14 @@ fn embedded_many_to_many_must_define_fields_on_both_sides_postgres() {
     "#};
 
     let expect = expect![[r#"
-        [1;91merror[0m: [1mError validating: Embedded many-to-many relations are not supported on Postgres. https://pris.ly/d/many-to-many-relations[0m
+        [1;91merror[0m: [1mError validating: An implicit many-to-many relation should not define `fields` argument.[0m
           [1;94m-->[0m  [4mschema.prisma:14[0m
         [1;94m   | [0m
         [1;94m13 | [0m  b_ids Int[]
         [1;94m14 | [0m  [1;91mbs    B[]   @relation(fields: [b_ids], references: [id])[0m
         [1;94m15 | [0m}
         [1;94m   | [0m
-        [1;91merror[0m: [1mError validating: Embedded many-to-many relations are not supported on Postgres. https://pris.ly/d/many-to-many-relations[0m
+        [1;91merror[0m: [1mError validating: An implicit many-to-many relation should not define `fields` argument.[0m
           [1;94m-->[0m  [4mschema.prisma:20[0m
         [1;94m   | [0m
         [1;94m19 | [0m  a_ids Int[]
@@ -436,14 +436,14 @@ fn embedded_many_to_many_must_define_fields_on_both_sides_postgres() {
     "#};
 
     let expect = expect![[r#"
-        [1;91merror[0m: [1mError validating: Embedded many-to-many relations are not supported on Postgres. https://pris.ly/d/many-to-many-relations[0m
+        [1;91merror[0m: [1mError validating: An implicit many-to-many relation should not define `fields` argument.[0m
           [1;94m-->[0m  [4mschema.prisma:14[0m
         [1;94m   | [0m
         [1;94m13 | [0m  b_ids Int[]
         [1;94m14 | [0m  [1;91mbs    B[]   @relation(references: [id])[0m
         [1;94m15 | [0m}
         [1;94m   | [0m
-        [1;91merror[0m: [1mError validating: Embedded many-to-many relations are not supported on Postgres. https://pris.ly/d/many-to-many-relations[0m
+        [1;91merror[0m: [1mError validating: An implicit many-to-many relation should not define `fields` argument.[0m
           [1;94m-->[0m  [4mschema.prisma:20[0m
         [1;94m   | [0m
         [1;94m19 | [0m  a_ids Int[]
@@ -473,14 +473,14 @@ fn embedded_many_to_many_relations_do_not_work_on_postgresql() {
     "#};
 
     let expect = expect![[r#"
-        [1;91merror[0m: [1mError validating: Embedded many-to-many relations are not supported on Postgres. https://pris.ly/d/many-to-many-relations[0m
+        [1;91merror[0m: [1mError validating: An implicit many-to-many relation should not define `fields` argument.[0m
           [1;94m-->[0m  [4mschema.prisma:14[0m
         [1;94m   | [0m
         [1;94m13 | [0m  b_ids Int[]
         [1;94m14 | [0m  [1;91mbs    B[]      @relation(fields: [b_ids], references: [id])[0m
         [1;94m15 | [0m}
         [1;94m   | [0m
-        [1;91merror[0m: [1mError validating: Embedded many-to-many relations are not supported on Postgres. https://pris.ly/d/many-to-many-relations[0m
+        [1;91merror[0m: [1mError validating: An implicit many-to-many relation should not define `fields` argument.[0m
           [1;94m-->[0m  [4mschema.prisma:20[0m
         [1;94m   | [0m
         [1;94m19 | [0m  a_ids Int[]
@@ -490,6 +490,43 @@ fn embedded_many_to_many_relations_do_not_work_on_postgresql() {
     "#]];
 
     let dml = with_header(dml, Provider::Postgres, &[]);
+    expect.assert_eq(&datamodel::parse_schema(&dml).map(drop).unwrap_err());
+}
+
+#[test]
+fn embedded_many_to_many_relations_do_not_work_on_postgresql_with_mongo_preview_flag() {
+    let dml = indoc! {r#"
+        model A {
+          id    Int      @id
+          b_ids Int[]
+          bs    B[]      @relation(fields: [b_ids], references: [id])
+        }
+
+        model B {
+          id    Int      @id
+          a_ids Int[]
+          as    A[]      @relation(fields: [a_ids], references: [id])
+        }
+    "#};
+
+    let expect = expect![[r#"
+        [1;91merror[0m: [1mError validating: Embedded many-to-many relations are not supported on Postgres. Please use the syntax defined in https://pris.ly/d/relational-database-many-to-many[0m
+          [1;94m-->[0m  [4mschema.prisma:14[0m
+        [1;94m   | [0m
+        [1;94m13 | [0m  b_ids Int[]
+        [1;94m14 | [0m  [1;91mbs    B[]      @relation(fields: [b_ids], references: [id])[0m
+        [1;94m15 | [0m}
+        [1;94m   | [0m
+        [1;91merror[0m: [1mError validating: Embedded many-to-many relations are not supported on Postgres. Please use the syntax defined in https://pris.ly/d/relational-database-many-to-many[0m
+          [1;94m-->[0m  [4mschema.prisma:20[0m
+        [1;94m   | [0m
+        [1;94m19 | [0m  a_ids Int[]
+        [1;94m20 | [0m  [1;91mas    A[]      @relation(fields: [a_ids], references: [id])[0m
+        [1;94m21 | [0m}
+        [1;94m   | [0m
+    "#]];
+
+    let dml = with_header(dml, Provider::Postgres, &["mongoDb"]);
     expect.assert_eq(&datamodel::parse_schema(&dml).map(drop).unwrap_err());
 }
 
@@ -549,14 +586,14 @@ fn embedded_many_to_many_relations_must_refer_an_id_from_both_sides_postgres() {
     "#};
 
     let expect = expect![[r#"
-        [1;91merror[0m: [1mError validating: Embedded many-to-many relations are not supported on Postgres. https://pris.ly/d/many-to-many-relations[0m
+        [1;91merror[0m: [1mError validating: An implicit many-to-many relation should not define `fields` argument.[0m
           [1;94m-->[0m  [4mschema.prisma:15[0m
         [1;94m   | [0m
         [1;94m14 | [0m  b_ids Int[]
         [1;94m15 | [0m  [1;91mbs    B[]   @relation(fields: [b_ids], references: [u2])[0m
         [1;94m16 | [0m}
         [1;94m   | [0m
-        [1;91merror[0m: [1mError validating: Embedded many-to-many relations are not supported on Postgres. https://pris.ly/d/many-to-many-relations[0m
+        [1;91merror[0m: [1mError validating: An implicit many-to-many relation should not define `fields` argument.[0m
           [1;94m-->[0m  [4mschema.prisma:22[0m
         [1;94m   | [0m
         [1;94m21 | [0m  a_ids Int[]
@@ -584,14 +621,14 @@ fn implicit_many_to_many_relations_do_not_work_on_mongo() {
     "#};
 
     let expect = expect![[r#"
-        [1;91merror[0m: [1mError validating: Implicit many-to-many relations are not supported on MongoDB. https://pris.ly/d/many-to-many-relations[0m
+        [1;91merror[0m: [1mError validating: Implicit many-to-many relations are not supported on MongoDB. Please use the syntax defined in https://pris.ly/d/document-database-many-to-many[0m
           [1;94m-->[0m  [4mschema.prisma:13[0m
         [1;94m   | [0m
         [1;94m12 | [0m  id    Int @id @map("_id")
         [1;94m13 | [0m  [1;91mbs    B[] @relation("foo")[0m
         [1;94m14 | [0m}
         [1;94m   | [0m
-        [1;91merror[0m: [1mError validating: Implicit many-to-many relations are not supported on MongoDB. https://pris.ly/d/many-to-many-relations[0m
+        [1;91merror[0m: [1mError validating: Implicit many-to-many relations are not supported on MongoDB. Please use the syntax defined in https://pris.ly/d/document-database-many-to-many[0m
           [1;94m-->[0m  [4mschema.prisma:18[0m
         [1;94m   | [0m
         [1;94m17 | [0m  id    Int @id @map("_id")
@@ -650,14 +687,14 @@ fn embedded_many_to_many_fields_must_be_an_array_of_correct_type_postgres() {
     "#};
 
     let expect = expect![[r#"
-        [1;91merror[0m: [1mError validating: Embedded many-to-many relations are not supported on Postgres. https://pris.ly/d/many-to-many-relations[0m
+        [1;91merror[0m: [1mError validating: An implicit many-to-many relation should not define `fields` argument.[0m
           [1;94m-->[0m  [4mschema.prisma:14[0m
         [1;94m   | [0m
         [1;94m13 | [0m  b_ids Int[]
         [1;94m14 | [0m  [1;91mbs    B[]   @relation(fields: [b_ids], references: [id])[0m
         [1;94m15 | [0m}
         [1;94m   | [0m
-        [1;91merror[0m: [1mError validating: Embedded many-to-many relations are not supported on Postgres. https://pris.ly/d/many-to-many-relations[0m
+        [1;91merror[0m: [1mError validating: An implicit many-to-many relation should not define `fields` argument.[0m
           [1;94m-->[0m  [4mschema.prisma:20[0m
         [1;94m   | [0m
         [1;94m19 | [0m  a_ids Int[]
@@ -716,14 +753,14 @@ fn embedded_many_to_many_fields_must_be_an_array_of_correct_native_type_postgres
     "#};
 
     let expect = expect![[r#"
-        [1;91merror[0m: [1mError validating: Embedded many-to-many relations are not supported on Postgres. https://pris.ly/d/many-to-many-relations[0m
+        [1;91merror[0m: [1mError validating: An implicit many-to-many relation should not define `fields` argument.[0m
           [1;94m-->[0m  [4mschema.prisma:14[0m
         [1;94m   | [0m
         [1;94m13 | [0m  b_ids String[] @test.VarChar(255)
         [1;94m14 | [0m  [1;91mbs    B[]      @relation(fields: [b_ids], references: [id])[0m
         [1;94m15 | [0m}
         [1;94m   | [0m
-        [1;91merror[0m: [1mError validating: Embedded many-to-many relations are not supported on Postgres. https://pris.ly/d/many-to-many-relations[0m
+        [1;91merror[0m: [1mError validating: An implicit many-to-many relation should not define `fields` argument.[0m
           [1;94m-->[0m  [4mschema.prisma:20[0m
         [1;94m   | [0m
         [1;94m19 | [0m  a_ids String[] @test.VarChar(255)
@@ -753,14 +790,14 @@ fn embedded_many_to_many_fields_must_be_an_array_postgres() {
     "#};
 
     let expect = expect![[r#"
-        [1;91merror[0m: [1mError validating: Embedded many-to-many relations are not supported on Postgres. https://pris.ly/d/many-to-many-relations[0m
+        [1;91merror[0m: [1mError validating: An implicit many-to-many relation should not define `fields` argument.[0m
           [1;94m-->[0m  [4mschema.prisma:14[0m
         [1;94m   | [0m
         [1;94m13 | [0m  b_ids String
         [1;94m14 | [0m  [1;91mbs    B[]    @relation(fields: [b_ids], references: [id])[0m
         [1;94m15 | [0m}
         [1;94m   | [0m
-        [1;91merror[0m: [1mError validating: Embedded many-to-many relations are not supported on Postgres. https://pris.ly/d/many-to-many-relations[0m
+        [1;91merror[0m: [1mError validating: An implicit many-to-many relation should not define `fields` argument.[0m
           [1;94m-->[0m  [4mschema.prisma:20[0m
         [1;94m   | [0m
         [1;94m19 | [0m  a_ids Int[]


### PR DESCRIPTION
If having `mongoDb` enabled, defining `fields` to a m:n relation on other
databases triggers a different error than without.