### PR TITLE
Remove empty composite types on introspection

### DIFF
--- a/introspection-engine/connectors/mongodb-introspection-connector/src/warnings.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/src/warnings.rs
@@ -65,7 +65,7 @@ pub(crate) fn fields_with_empty_names(fields_with_empty_names: &[(Name, String)]
                     "field": field
                 }),
                 Name::CompositeType(name) => json!({
-                    "type": name,
+                    "compositeType": name,
                     "field": field
                 }),
             })
@@ -99,6 +99,30 @@ pub(crate) fn fields_with_unknown_types(unknown_types: &[(Name, String)]) -> War
     Warning {
         code: 103,
         message: "Could not determine the types for the following fields.".into(),
+        affected,
+    }
+}
+
+pub(crate) fn fields_pointing_to_an_empty_type(fields_with_an_empty_type: &[(Name, String)]) -> Warning {
+    let affected = serde_json::Value::Array({
+        fields_with_an_empty_type
+            .iter()
+            .map(|(container, field)| match container {
+                Name::Model(name) => json!({
+                    "model": name,
+                    "field": field
+                }),
+                Name::CompositeType(name) => json!({
+                    "compositeType": name,
+                    "field": field
+                }),
+            })
+            .collect()
+    });
+
+    Warning {
+        code: 102,
+        message: "The following fields point to nested objects without any data.".into(),
         affected,
     }
 }

--- a/introspection-engine/connectors/mongodb-introspection-connector/tests/remapping_names/mod.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/tests/remapping_names/mod.rs
@@ -105,7 +105,7 @@ fn remapping_composite_fields_with_numbers() {
     res.assert_warning("These enum values were commented out because their names are currently not supported by Prisma. Please provide valid ones that match [a-zA-Z][a-zA-Z0-9_]* using the `@map` attribute.");
 
     res.assert_warning_affected(&json!([{
-        "type": "OuterInner",
+        "compositeType": "OuterInner",
         "field": "1",
     }]));
 }

--- a/introspection-engine/connectors/mongodb-introspection-connector/tests/test_api/mod.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/tests/test_api/mod.rs
@@ -43,6 +43,12 @@ impl TestResult {
     }
 
     #[track_caller]
+    pub fn assert_no_warnings(&self) {
+        dbg!(&self.warnings);
+        assert!(self.warnings.is_empty())
+    }
+
+    #[track_caller]
     pub fn assert_warning_affected(&self, affected: &serde_json::Value) {
         dbg!(&self.warnings);
         assert!(&self.warnings[0].affected == affected);

--- a/libs/datamodel/connectors/dml/src/field.rs
+++ b/libs/datamodel/connectors/dml/src/field.rs
@@ -70,6 +70,10 @@ impl FieldType {
         self.scalar_type().map(|st| st.is_string()).unwrap_or(false)
     }
 
+    pub fn is_composite(&self) -> bool {
+        matches!(self, Self::CompositeType(_))
+    }
+
     pub fn is_enum(&self, name: &str) -> bool {
         matches!(self, Self::Enum(this) if this == name)
     }

--- a/libs/datamodel/connectors/dml/src/field.rs
+++ b/libs/datamodel/connectors/dml/src/field.rs
@@ -123,6 +123,13 @@ impl Field {
         }
     }
 
+    pub fn as_scalar_field_mut(&mut self) -> Option<&mut ScalarField> {
+        match self {
+            Field::ScalarField(sf) => Some(sf),
+            _ => None,
+        }
+    }
+
     pub fn is_relation(&self) -> bool {
         matches!(self, Field::RelationField(_))
     }


### PR DESCRIPTION
On MongoDB, if all we see in nested objects is an empty object, we cannot determine any fields which would result in an empty type. Instead we should introspect these as `Json` and warn the user.

Closes: https://github.com/prisma/prisma/issues/11809
Closes: https://github.com/prisma/migrations-team/issues/320