### PR TITLE
MongoDb should introspect deep arrays as Json

### DIFF
--- a/introspection-engine/connectors/mongodb-introspection-connector/src/sampler/statistics.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/src/sampler/statistics.rs
@@ -196,11 +196,8 @@ impl<'a> Statistics<'a> {
             match FieldType::from_bson(val, compound_name) {
                 // We cannot have arrays of arrays, so multi-dimensional arrays
                 // are introspected as `Json[]`.
-                Some(_) if found_composite && array_layers > 1 => {
-                    let counter = sampler
-                        .types
-                        .entry(FieldType::Array(Box::new(FieldType::Json)))
-                        .or_default();
+                Some(_) if array_layers > 1 => {
+                    let counter = sampler.types.entry(FieldType::Json).or_default();
                     *counter += 1;
                 }
                 // Counting the types.

--- a/introspection-engine/connectors/mongodb-introspection-connector/src/sampler/statistics.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/src/sampler/statistics.rs
@@ -195,7 +195,7 @@ impl<'a> Statistics<'a> {
 
             match FieldType::from_bson(val, compound_name) {
                 // We cannot have arrays of arrays, so multi-dimensional arrays
-                // are introspected as `Json[]`.
+                // are introspected as `Json`.
                 Some(_) if array_layers > 1 => {
                     let counter = sampler.types.entry(FieldType::Json).or_default();
                     *counter += 1;

--- a/introspection-engine/connectors/mongodb-introspection-connector/tests/types/composite.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/tests/types/composite.rs
@@ -117,7 +117,7 @@ fn deep_array() {
     let expected = expect![[r#"
         model Blog {
           id    String @id @default(auto()) @map("_id") @db.ObjectId
-          posts Json[]
+          posts Json
           title String
         }
     "#]];

--- a/introspection-engine/connectors/mongodb-introspection-connector/tests/types/mod.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/tests/types/mod.rs
@@ -395,6 +395,31 @@ fn array() {
 }
 
 #[test]
+fn deep_array() {
+    let res = introspect(|db| async move {
+        db.create_collection("A", None).await?;
+        let collection = db.collection("A");
+
+        let docs = vec![doc! {
+            "first": Bson::Array(vec![Bson::Array(vec![Bson::Int32(1)])]),
+        }];
+
+        collection.insert_many(docs, None).await.unwrap();
+
+        Ok(())
+    });
+
+    let expected = expect![[r#"
+        model A {
+          id    String @id @default(auto()) @map("_id") @db.ObjectId
+          first Json
+        }
+    "#]];
+
+    expected.assert_eq(res.datamodel());
+}
+
+#[test]
 fn empty_arrays() {
     let res = introspect(|db| async move {
         db.create_collection("A", None).await?;


### PR DESCRIPTION
In cases where we have data such as `[[[1]]]`, we cannot represent that as an
array in Prisma. Json works.

Closes: https://github.com/prisma/prisma/issues/11912