### PR TITLE
Avoid false-positive diffs in mongo tests on windows

### DIFF
--- a/migration-engine/connectors/mongodb-migration-connector/tests/migrations/test_api.rs
+++ b/migration-engine/connectors/mongodb-migration-connector/tests/migrations/test_api.rs
@@ -154,13 +154,16 @@ pub(crate) fn test_scenario(scenario_name: &str) {
         State { collections }
     };
 
-    let expected_result = {
+    let mut expected_result = {
         path.clear();
         write!(path, "{}/{}/result", SCENARIOS_PATH, scenario_name).unwrap();
         std::fs::read_to_string(&path).unwrap()
     };
 
-    // let state: State = serde_json::from_str(state).unwrap();
+    if cfg!(target_os = "windows") {
+        expected_result.retain(|c| c != '\r');
+    }
+
     RT.block_on(async move {
         let parsed_schema = datamodel::parse_schema_parserdb(&schema).unwrap();
         let (db_name, connector) = new_connector(parsed_schema.configuration.preview_features());


### PR DESCRIPTION
Because of line endings.