### PR TITLE
Make DatamodelError enum private

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1638122382,
-        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1642130244,
-        "narHash": "sha256-/5FhZkZFQCRQIRFosUQW1zmDrsNHVOJIB/+XgRPHiPU=",
+        "lastModified": 1645013224,
+        "narHash": "sha256-b7OEC8vwzJv3rsz9pwnTX2LQDkeOWz2DbKypkVvNHXc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bc59ba15b64d0a0ee1d1764f18b4f3480d2c3e5a",
+        "rev": "b66b39216b1fef2d8c33cc7a5c72d8da80b79970",
         "type": "github"
       },
       "original": {
@@ -32,7 +32,31 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1645409726,
+        "narHash": "sha256-rji0+Ii6WpBB8VCPh3siV/MFfaSiksNbDHOE1DHcHCA=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "d12fa61b3991d332d3b18ccb20a27d5e473f876e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,12 +1,18 @@
 {
   inputs = {
     flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-utils.follows = "flake-utils";
+    };
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
+  outputs = { self, nixpkgs, rust-overlay, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system:
       let
-        pkgs = import nixpkgs { inherit system; };
+        overlays = [ (import rust-overlay) ];
+        pkgs = import nixpkgs { inherit system overlays; };
         shell = import ./shell.nix { inherit pkgs; };
       in
       {

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/mssql_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/mssql_datamodel_connector.rs
@@ -264,10 +264,10 @@ impl Connector for MsSqlDatamodelConnector {
 
     fn validate_model(&self, model: parser_database::walkers::ModelWalker<'_>, errors: &mut Diagnostics) {
         let mut push_error = |err: ConnectorError| {
-            errors.push_error(datamodel_connector::DatamodelError::ConnectorError {
-                message: err.to_string(),
-                span: model.ast_model().span,
-            });
+            errors.push_error(datamodel_connector::DatamodelError::new_connector_error(
+                &err.to_string(),
+                model.ast_model().span,
+            ));
         };
 
         for index in model.indexes() {

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
@@ -260,10 +260,10 @@ impl Connector for MySqlDatamodelConnector {
 
     fn validate_model(&self, model: ModelWalker<'_>, errors: &mut Diagnostics) {
         let mut push_error = |err: ConnectorError| {
-            errors.push_error(datamodel_connector::DatamodelError::ConnectorError {
-                message: err.to_string(),
-                span: model.ast_model().span,
-            });
+            errors.push_error(datamodel_connector::DatamodelError::new_connector_error(
+                &err.to_string(),
+                model.ast_model().span,
+            ));
         };
 
         for index in model.indexes() {

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
@@ -229,10 +229,10 @@ impl Connector for PostgresDatamodelConnector {
 
     fn validate_model(&self, model: ModelWalker<'_>, errors: &mut Diagnostics) {
         let mut push_error = |err: ConnectorError| {
-            errors.push_error(datamodel_connector::DatamodelError::ConnectorError {
-                message: err.to_string(),
-                span: model.ast_model().span,
-            });
+            errors.push_error(datamodel_connector::DatamodelError::new_connector_error(
+                &err.to_string(),
+                model.ast_model().span,
+            ));
         };
 
         for index in model.indexes() {

--- a/libs/datamodel/core/src/transform/ast_to_dml/datasource_loader.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/datasource_loader.rs
@@ -136,10 +136,6 @@ impl DatasourceLoader {
                     Ok(shadow_database_url) => Some(shadow_database_url)
                         .filter(|s| !s.as_literal().map(|lit| lit.is_empty()).unwrap_or(false))
                         .map(|url| (url, shadow_database_url_arg.span())),
-
-                    // We intentionally ignore the shadow database URL if it is defined in an env var that is missing.
-                    Err(DatamodelError::EnvironmentFunctionalEvaluationError { .. }) => None,
-
                     Err(err) => {
                         diagnostics.push_error(err);
                         None

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/fields.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/fields.rs
@@ -216,10 +216,10 @@ pub(super) fn validate_native_type_arguments(field: ScalarFieldWalker<'_>, ctx: 
                 .validate_native_type_arguments(&native_type, &scalar_type, &mut errors);
 
             for error in errors {
-                ctx.push_error(DatamodelError::ConnectorError {
-                    message: error.to_string(),
-                    span: field.ast_field().span,
-                });
+                ctx.push_error(DatamodelError::new_connector_error(
+                    &error.to_string(),
+                    field.ast_field().span,
+                ));
             }
         }
         Err(connector_error) => {

--- a/libs/datamodel/diagnostics/src/error.rs
+++ b/libs/datamodel/diagnostics/src/error.rs
@@ -1,6 +1,22 @@
 use crate::helper::pretty_print;
 use crate::Span;
+use std::fmt;
 use thiserror::Error;
+
+#[derive(Debug, Error, Clone, PartialEq)]
+pub struct DatamodelError(DatamodelErrorKind);
+
+impl fmt::Display for DatamodelError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl From<DatamodelErrorKind> for DatamodelError {
+    fn from(kind: DatamodelErrorKind) -> Self {
+        DatamodelError(kind)
+    }
+}
 
 /// Enum for different errors which can happen during parsing or validation.
 ///
@@ -9,7 +25,7 @@ use thiserror::Error;
 // Line breaks make the declarations very hard to read.
 #[derive(Debug, Error, Clone, PartialEq)]
 #[rustfmt::skip]
-pub enum DatamodelError {
+enum DatamodelErrorKind {
   #[error("Argument \"{}\" is missing.", argument_name)]
   ArgumentNotFound { argument_name: String, span: Span },
 
@@ -131,18 +147,20 @@ pub enum DatamodelError {
 
 impl DatamodelError {
     pub fn new_literal_parser_error(literal_type: &str, raw_value: &str, span: Span) -> DatamodelError {
-        DatamodelError::LiteralParseError {
+        DatamodelErrorKind::LiteralParseError {
             literal_type: String::from(literal_type),
             raw_value: String::from(raw_value),
             span,
         }
+        .into()
     }
 
     pub fn new_argument_not_found_error(argument_name: &str, span: Span) -> DatamodelError {
-        DatamodelError::ArgumentNotFound {
+        DatamodelErrorKind::ArgumentNotFound {
             argument_name: String::from(argument_name),
             span,
         }
+        .into()
     }
 
     pub fn new_argument_count_missmatch_error(
@@ -151,12 +169,13 @@ impl DatamodelError {
         given_count: usize,
         span: Span,
     ) -> DatamodelError {
-        DatamodelError::ArgumentCountMissmatch {
+        DatamodelErrorKind::ArgumentCountMissmatch {
             function_name: String::from(function_name),
             required_count,
             given_count,
             span,
         }
+        .into()
     }
 
     pub fn new_attribute_argument_not_found_error(
@@ -164,19 +183,21 @@ impl DatamodelError {
         attribute_name: &str,
         span: Span,
     ) -> DatamodelError {
-        DatamodelError::AttributeArgumentNotFound {
+        DatamodelErrorKind::AttributeArgumentNotFound {
             argument_name: String::from(argument_name),
             attribute_name: String::from(attribute_name),
             span,
         }
+        .into()
     }
 
     pub fn new_source_argument_not_found_error(argument_name: &str, source_name: &str, span: Span) -> DatamodelError {
-        DatamodelError::SourceArgumentNotFound {
+        DatamodelErrorKind::SourceArgumentNotFound {
             argument_name: String::from(argument_name),
             source_name: String::from(source_name),
             span,
         }
+        .into()
     }
 
     pub fn new_generator_argument_not_found_error(
@@ -184,33 +205,37 @@ impl DatamodelError {
         generator_name: &str,
         span: Span,
     ) -> DatamodelError {
-        DatamodelError::GeneratorArgumentNotFound {
+        DatamodelErrorKind::GeneratorArgumentNotFound {
             argument_name: String::from(argument_name),
             generator_name: String::from(generator_name),
             span,
         }
+        .into()
     }
 
     pub fn new_attribute_validation_error(message: &str, attribute_name: &str, span: Span) -> DatamodelError {
-        DatamodelError::AttributeValidationError {
+        DatamodelErrorKind::AttributeValidationError {
             message: String::from(message),
             attribute_name: String::from(attribute_name),
             span,
         }
+        .into()
     }
 
     pub fn new_duplicate_attribute_error(attribute_name: &str, span: Span) -> DatamodelError {
-        DatamodelError::DuplicateAttributeError {
+        DatamodelErrorKind::DuplicateAttributeError {
             attribute_name: String::from(attribute_name),
             span,
         }
+        .into()
     }
 
     pub fn new_reserved_scalar_type_error(type_name: &str, span: Span) -> DatamodelError {
-        DatamodelError::ReservedScalarTypeError {
+        DatamodelErrorKind::ReservedScalarTypeError {
             type_name: String::from(type_name),
             span,
         }
+        .into()
     }
 
     pub fn new_duplicate_model_database_name_error(
@@ -218,91 +243,102 @@ impl DatamodelError {
         existing_model_name: String,
         span: Span,
     ) -> DatamodelError {
-        DatamodelError::DuplicateModelDatabaseNameError {
+        DatamodelErrorKind::DuplicateModelDatabaseNameError {
             model_database_name,
             existing_model_name,
             span,
         }
+        .into()
     }
 
     pub fn new_duplicate_top_error(name: &str, top_type: &str, existing_top_type: &str, span: Span) -> DatamodelError {
-        DatamodelError::DuplicateTopError {
+        DatamodelErrorKind::DuplicateTopError {
             name: String::from(name),
             top_type: String::from(top_type),
             existing_top_type: String::from(existing_top_type),
             span,
         }
+        .into()
     }
 
     pub fn new_duplicate_config_key_error(conf_block_name: &str, key_name: &str, span: Span) -> DatamodelError {
-        DatamodelError::DuplicateConfigKeyError {
+        DatamodelErrorKind::DuplicateConfigKeyError {
             conf_block_name: String::from(conf_block_name),
             key_name: String::from(key_name),
             span,
         }
+        .into()
     }
 
     pub fn new_duplicate_argument_error(arg_name: &str, span: Span) -> DatamodelError {
-        DatamodelError::DuplicateArgumentError {
+        DatamodelErrorKind::DuplicateArgumentError {
             arg_name: String::from(arg_name),
             span,
         }
+        .into()
     }
 
     pub fn new_unused_argument_error(arg_name: &str, span: Span) -> DatamodelError {
-        DatamodelError::UnusedArgumentError {
+        DatamodelErrorKind::UnusedArgumentError {
             arg_name: String::from(arg_name),
             span,
         }
+        .into()
     }
 
     pub fn new_duplicate_default_argument_error(arg_name: &str, span: Span) -> DatamodelError {
-        DatamodelError::DuplicateDefaultArgumentError {
+        DatamodelErrorKind::DuplicateDefaultArgumentError {
             arg_name: String::from(arg_name),
             span,
         }
+        .into()
     }
 
     pub fn new_duplicate_enum_value_error(enum_name: &str, value_name: &str, span: Span) -> DatamodelError {
-        DatamodelError::DuplicateEnumValueError {
+        DatamodelErrorKind::DuplicateEnumValueError {
             enum_name: String::from(enum_name),
             value_name: String::from(value_name),
             span,
         }
+        .into()
     }
 
     pub fn new_composite_type_duplicate_field_error(type_name: &str, field_name: &str, span: Span) -> DatamodelError {
-        DatamodelError::DuplicateFieldError {
+        DatamodelErrorKind::DuplicateFieldError {
             container_type: "composite type",
             model_name: String::from(type_name),
             field_name: String::from(field_name),
             span,
         }
+        .into()
     }
 
     pub fn new_duplicate_field_error(model_name: &str, field_name: &str, span: Span) -> DatamodelError {
-        DatamodelError::DuplicateFieldError {
+        DatamodelErrorKind::DuplicateFieldError {
             container_type: "model",
             model_name: String::from(model_name),
             field_name: String::from(field_name),
             span,
         }
+        .into()
     }
 
     pub fn new_scalar_list_fields_are_not_supported(model_name: &str, field_name: &str, span: Span) -> DatamodelError {
-        DatamodelError::ScalarListFieldsAreNotSupported {
+        DatamodelErrorKind::ScalarListFieldsAreNotSupported {
             model_name: String::from(model_name),
             field_name: String::from(field_name),
             span,
         }
+        .into()
     }
 
     pub fn new_model_validation_error(message: &str, model_name: &str, span: Span) -> DatamodelError {
-        DatamodelError::ModelValidationError {
+        DatamodelErrorKind::ModelValidationError {
             message: String::from(message),
             model_name: String::from(model_name),
             span,
         }
+        .into()
     }
 
     pub fn new_composite_type_validation_error(
@@ -310,19 +346,21 @@ impl DatamodelError {
         composite_type_name: String,
         span: Span,
     ) -> DatamodelError {
-        DatamodelError::CompositeTypeValidationError {
+        DatamodelErrorKind::CompositeTypeValidationError {
             message,
             composite_type_name,
             span,
         }
+        .into()
     }
 
     pub fn new_enum_validation_error(message: String, enum_name: String, span: Span) -> DatamodelError {
-        DatamodelError::EnumValidationError {
+        DatamodelErrorKind::EnumValidationError {
             message,
             enum_name,
             span,
         }
+        .into()
     }
 
     pub fn new_composite_type_field_validation_error(
@@ -331,110 +369,122 @@ impl DatamodelError {
         field: &str,
         span: Span,
     ) -> DatamodelError {
-        DatamodelError::FieldValidationError {
+        DatamodelErrorKind::FieldValidationError {
             message: message.to_owned(),
             container_name: composite_type_name.to_owned(),
             container_type: "composite type",
             field: field.to_owned(),
             span,
         }
+        .into()
     }
 
     pub fn new_field_validation_error(message: &str, model: &str, field: &str, span: Span) -> DatamodelError {
-        DatamodelError::FieldValidationError {
+        DatamodelErrorKind::FieldValidationError {
             message: message.to_owned(),
             container_name: model.to_owned(),
             container_type: "model",
             field: field.to_owned(),
             span,
         }
+        .into()
     }
 
     pub fn new_source_validation_error(message: &str, source: &str, span: Span) -> DatamodelError {
-        DatamodelError::SourceValidationError {
+        DatamodelErrorKind::SourceValidationError {
             message: message.to_owned(),
             datasource: source.to_owned(),
             span,
         }
+        .into()
     }
 
     pub fn new_validation_error(message: String, span: Span) -> DatamodelError {
-        DatamodelError::ValidationError { message, span }
+        DatamodelErrorKind::ValidationError { message, span }.into()
     }
 
     pub fn new_legacy_parser_error(message: &str, span: Span) -> DatamodelError {
-        DatamodelError::LegacyParserError {
+        DatamodelErrorKind::LegacyParserError {
             message: String::from(message),
             span,
         }
+        .into()
     }
 
     pub fn new_connector_error(message: &str, span: Span) -> DatamodelError {
-        DatamodelError::ConnectorError {
+        DatamodelErrorKind::ConnectorError {
             message: String::from(message),
             span,
         }
+        .into()
     }
 
     pub fn new_parser_error(expected_str: String, span: Span) -> DatamodelError {
-        DatamodelError::ParserError { expected_str, span }
+        DatamodelErrorKind::ParserError { expected_str, span }.into()
     }
 
     pub fn new_functional_evaluation_error(message: &str, span: Span) -> DatamodelError {
-        DatamodelError::FunctionalEvaluationError {
+        DatamodelErrorKind::FunctionalEvaluationError {
             message: String::from(message),
             span,
         }
+        .into()
     }
 
     pub fn new_environment_functional_evaluation_error(var_name: String, span: Span) -> DatamodelError {
-        DatamodelError::EnvironmentFunctionalEvaluationError { var_name, span }
+        DatamodelErrorKind::EnvironmentFunctionalEvaluationError { var_name, span }.into()
     }
 
     pub fn new_type_not_found_error(type_name: &str, span: Span) -> DatamodelError {
-        DatamodelError::TypeNotFoundError {
+        DatamodelErrorKind::TypeNotFoundError {
             type_name: String::from(type_name),
             span,
         }
+        .into()
     }
 
     pub fn new_scalar_type_not_found_error(type_name: &str, span: Span) -> DatamodelError {
-        DatamodelError::ScalarTypeNotFoundError {
+        DatamodelErrorKind::ScalarTypeNotFoundError {
             type_name: String::from(type_name),
             span,
         }
+        .into()
     }
 
     pub fn new_attribute_not_known_error(attribute_name: &str, span: Span) -> DatamodelError {
-        DatamodelError::AttributeNotKnownError {
+        DatamodelErrorKind::AttributeNotKnownError {
             attribute_name: String::from(attribute_name),
             span,
         }
+        .into()
     }
 
     pub fn new_property_not_known_error(property_name: &str, span: Span) -> DatamodelError {
-        DatamodelError::PropertyNotKnownError {
+        DatamodelErrorKind::PropertyNotKnownError {
             property_name: String::from(property_name),
             span,
         }
+        .into()
     }
 
     pub fn new_function_not_known_error(function_name: &str, span: Span) -> DatamodelError {
-        DatamodelError::FunctionNotKnownError {
+        DatamodelErrorKind::FunctionNotKnownError {
             function_name: String::from(function_name),
             span,
         }
+        .into()
     }
 
     pub fn new_datasource_provider_not_known_error(provider: &str, span: Span) -> DatamodelError {
-        DatamodelError::DatasourceProviderNotKnownError {
+        DatamodelErrorKind::DatasourceProviderNotKnownError {
             provider: String::from(provider),
             span,
         }
+        .into()
     }
 
     pub fn new_shadow_database_is_same_as_main_url_error(source_name: String, span: Span) -> DatamodelError {
-        DatamodelError::ShadowDatabaseUrlIsSameAsMainUrl { source_name, span }
+        DatamodelErrorKind::ShadowDatabaseUrlIsSameAsMainUrl { source_name, span }.into()
     }
 
     pub fn new_preview_feature_not_known_error(
@@ -442,72 +492,75 @@ impl DatamodelError {
         expected_preview_features: String,
         span: Span,
     ) -> DatamodelError {
-        DatamodelError::PreviewFeatureNotKnownError {
+        DatamodelErrorKind::PreviewFeatureNotKnownError {
             preview_feature: String::from(preview_feature),
             expected_preview_features,
             span,
         }
+        .into()
     }
 
     pub fn new_value_parser_error(expected_type: &str, parser_error: &str, raw: &str, span: Span) -> DatamodelError {
-        DatamodelError::ValueParserError {
+        DatamodelErrorKind::ValueParserError {
             expected_type: String::from(expected_type),
             parser_error: String::from(parser_error),
             raw: String::from(raw),
             span,
         }
+        .into()
     }
 
     pub fn new_type_mismatch_error(expected_type: &str, received_type: &str, raw: &str, span: Span) -> DatamodelError {
-        DatamodelError::TypeMismatchError {
+        DatamodelErrorKind::TypeMismatchError {
             expected_type: String::from(expected_type),
             received_type: String::from(received_type),
             raw: String::from(raw),
             span,
         }
+        .into()
     }
 
     pub fn span(&self) -> Span {
-        match self {
-            DatamodelError::ArgumentNotFound { span, .. } => *span,
-            DatamodelError::AttributeArgumentNotFound { span, .. } => *span,
-            DatamodelError::ArgumentCountMissmatch { span, .. } => *span,
-            DatamodelError::SourceArgumentNotFound { span, .. } => *span,
-            DatamodelError::GeneratorArgumentNotFound { span, .. } => *span,
-            DatamodelError::AttributeValidationError { span, .. } => *span,
-            DatamodelError::AttributeNotKnownError { span, .. } => *span,
-            DatamodelError::ReservedScalarTypeError { span, .. } => *span,
-            DatamodelError::FunctionNotKnownError { span, .. } => *span,
-            DatamodelError::PropertyNotKnownError { span, .. } => *span,
-            DatamodelError::DatasourceProviderNotKnownError { span, .. } => *span,
-            DatamodelError::LiteralParseError { span, .. } => *span,
-            DatamodelError::TypeNotFoundError { span, .. } => *span,
-            DatamodelError::ScalarTypeNotFoundError { span, .. } => *span,
-            DatamodelError::ParserError { span, .. } => *span,
-            DatamodelError::FunctionalEvaluationError { span, .. } => *span,
-            DatamodelError::EnvironmentFunctionalEvaluationError { span, .. } => *span,
-            DatamodelError::TypeMismatchError { span, .. } => *span,
-            DatamodelError::ValueParserError { span, .. } => *span,
-            DatamodelError::ValidationError { span, .. } => *span,
-            DatamodelError::LegacyParserError { span, .. } => *span,
-            DatamodelError::ModelValidationError { span, .. } => *span,
-            DatamodelError::DuplicateAttributeError { span, .. } => *span,
-            DatamodelError::DuplicateConfigKeyError { span, .. } => *span,
-            DatamodelError::DuplicateTopError { span, .. } => *span,
-            DatamodelError::DuplicateFieldError { span, .. } => *span,
-            DatamodelError::DuplicateEnumValueError { span, .. } => *span,
-            DatamodelError::DuplicateArgumentError { span, .. } => *span,
-            DatamodelError::DuplicateModelDatabaseNameError { span, .. } => *span,
-            DatamodelError::DuplicateDefaultArgumentError { span, .. } => *span,
-            DatamodelError::UnusedArgumentError { span, .. } => *span,
-            DatamodelError::ScalarListFieldsAreNotSupported { span, .. } => *span,
-            DatamodelError::FieldValidationError { span, .. } => *span,
-            DatamodelError::SourceValidationError { span, .. } => *span,
-            DatamodelError::EnumValidationError { span, .. } => *span,
-            DatamodelError::ConnectorError { span, .. } => *span,
-            DatamodelError::PreviewFeatureNotKnownError { span, .. } => *span,
-            DatamodelError::ShadowDatabaseUrlIsSameAsMainUrl { span, .. } => *span,
-            DatamodelError::CompositeTypeValidationError { span, .. } => *span,
+        match &self.0 {
+            DatamodelErrorKind::ArgumentNotFound { span, .. } => *span,
+            DatamodelErrorKind::AttributeArgumentNotFound { span, .. } => *span,
+            DatamodelErrorKind::ArgumentCountMissmatch { span, .. } => *span,
+            DatamodelErrorKind::SourceArgumentNotFound { span, .. } => *span,
+            DatamodelErrorKind::GeneratorArgumentNotFound { span, .. } => *span,
+            DatamodelErrorKind::AttributeValidationError { span, .. } => *span,
+            DatamodelErrorKind::AttributeNotKnownError { span, .. } => *span,
+            DatamodelErrorKind::ReservedScalarTypeError { span, .. } => *span,
+            DatamodelErrorKind::FunctionNotKnownError { span, .. } => *span,
+            DatamodelErrorKind::DatasourceProviderNotKnownError { span, .. } => *span,
+            DatamodelErrorKind::LiteralParseError { span, .. } => *span,
+            DatamodelErrorKind::TypeNotFoundError { span, .. } => *span,
+            DatamodelErrorKind::ScalarTypeNotFoundError { span, .. } => *span,
+            DatamodelErrorKind::ParserError { span, .. } => *span,
+            DatamodelErrorKind::FunctionalEvaluationError { span, .. } => *span,
+            DatamodelErrorKind::EnvironmentFunctionalEvaluationError { span, .. } => *span,
+            DatamodelErrorKind::TypeMismatchError { span, .. } => *span,
+            DatamodelErrorKind::ValueParserError { span, .. } => *span,
+            DatamodelErrorKind::ValidationError { span, .. } => *span,
+            DatamodelErrorKind::LegacyParserError { span, .. } => *span,
+            DatamodelErrorKind::ModelValidationError { span, .. } => *span,
+            DatamodelErrorKind::DuplicateAttributeError { span, .. } => *span,
+            DatamodelErrorKind::DuplicateConfigKeyError { span, .. } => *span,
+            DatamodelErrorKind::DuplicateTopError { span, .. } => *span,
+            DatamodelErrorKind::DuplicateFieldError { span, .. } => *span,
+            DatamodelErrorKind::DuplicateEnumValueError { span, .. } => *span,
+            DatamodelErrorKind::DuplicateArgumentError { span, .. } => *span,
+            DatamodelErrorKind::DuplicateModelDatabaseNameError { span, .. } => *span,
+            DatamodelErrorKind::DuplicateDefaultArgumentError { span, .. } => *span,
+            DatamodelErrorKind::UnusedArgumentError { span, .. } => *span,
+            DatamodelErrorKind::ScalarListFieldsAreNotSupported { span, .. } => *span,
+            DatamodelErrorKind::FieldValidationError { span, .. } => *span,
+            DatamodelErrorKind::SourceValidationError { span, .. } => *span,
+            DatamodelErrorKind::EnumValidationError { span, .. } => *span,
+            DatamodelErrorKind::ConnectorError { span, .. } => *span,
+            DatamodelErrorKind::PreviewFeatureNotKnownError { span, .. } => *span,
+            DatamodelErrorKind::ShadowDatabaseUrlIsSameAsMainUrl { span, .. } => *span,
+            DatamodelErrorKind::CompositeTypeValidationError { span, .. } => *span,
+            DatamodelErrorKind::PropertyNotKnownError { span, .. } => *span,
         }
     }
 

--- a/libs/datamodel/parser-database/src/attributes.rs
+++ b/libs/datamodel/parser-database/src/attributes.rs
@@ -584,11 +584,7 @@ fn common_index_validations(index_data: &mut IndexAttribute, model_id: ast::Mode
                         unresolvable_fields.join(", "),
                     );
                     let model_name = ctx.ast[model_id].name();
-                    DatamodelError::ModelValidationError {
-                        message: String::from(message),
-                        model_name: String::from(model_name),
-                        span: current_attribute.span,
-                    }
+                    DatamodelError::new_model_validation_error(message, model_name, current_attribute.span)
                 });
             }
 

--- a/libs/datamodel/parser-database/src/value_validator.rs
+++ b/libs/datamodel/parser-database/src/value_validator.rs
@@ -127,10 +127,7 @@ impl<'a> ValueValidator<'a> {
                 Some(("Asc", _)) => Ok(Some(SortOrder::Asc)),
                 Some(("Desc", _)) => Ok(Some(SortOrder::Desc)),
                 None => Ok(None),
-                _ => Err(DatamodelError::ParserError {
-                    expected_str: "Asc, Desc".to_owned(),
-                    span: arg.span,
-                }),
+                _ => Err(DatamodelError::new_parser_error("Asc, Desc".to_owned(), arg.span)),
             })
             .transpose()?
             .flatten();
@@ -139,14 +136,10 @@ impl<'a> ValueValidator<'a> {
             .iter()
             .find(|arg| arg.name.as_ref().map(|n| n.name.as_str()) == Some("length"))
             .map(|arg| match &arg.value {
-                Expression::NumericValue(s, _) => s.parse::<u32>().map_err(|_| DatamodelError::ParserError {
-                    expected_str: "valid integer".to_string(),
-                    span: arg.span,
-                }),
-                _ => Err(DatamodelError::ParserError {
-                    expected_str: "valid integer".to_string(),
-                    span: arg.span,
-                }),
+                Expression::NumericValue(s, _) => s
+                    .parse::<u32>()
+                    .map_err(|_| DatamodelError::new_parser_error("valid integer".to_owned(), arg.span)),
+                _ => Err(DatamodelError::new_parser_error("valid integer".to_owned(), arg.span)),
             })
             .transpose()?;
 
@@ -164,11 +157,11 @@ impl<'a> ValueValidator<'a> {
             s => {
                 let message = format!("Invalid referential action: `{}`", s);
 
-                Err(DatamodelError::AttributeValidationError {
-                    message,
-                    attribute_name: String::from("relation"),
-                    span: self.span(),
-                })
+                Err(DatamodelError::new_attribute_validation_error(
+                    &message,
+                    "relation",
+                    self.span(),
+                ))
             }
         }
     }

--- a/shell.nix
+++ b/shell.nix
@@ -23,5 +23,7 @@ mkShell {
     llvmPackages.libclang
     kerberos
     protobuf
+
+    rust-bin.stable.latest.default
   ];
 }


### PR DESCRIPTION
Diagnostics are error reporting types, not error handling types.

- Reacting to a specific datamodel error is an antipattern because it is
  non-obvious control flow when reading the code where the error is
  emitted. As a principle, we should always have all the context we need
  to make the decision to emit an error or not at the error creation
  site.
- Collapsing the enum to a more compact data structure will let us stuff
  more helpful information into the error, improve code readability and
  efficiency. See ConnectorError in the migration engine.
- Exhaustive matching on datamodel error cases has no real use case.