### PR TITLE
Order by composite fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3196,6 +3196,7 @@ dependencies = [
  "im",
  "indexmap",
  "itertools",
+ "lazy_static",
  "mongodb-client",
  "mongodb-query-connector",
  "once_cell",

--- a/migration-engine/migration-engine-tests/tests/migrations/diff.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/diff.rs
@@ -176,7 +176,7 @@ fn from_schema_datamodel_to_url(mut api: TestApi) {
             moos Boolean
         }
     "#;
-    let schema_path = write_file_to_tmp(&first_schema, &tempdir, "schema.prisma");
+    let schema_path = write_file_to_tmp(first_schema, &tempdir, "schema.prisma");
     let second_url = format!("file:{}/second_db.sqlite", base_dir_str);
 
     api.block_on(async {

--- a/query-engine/connector-test-kit-rs/query-engine-tests/src/schemas/composites.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/src/schemas/composites.rs
@@ -95,23 +95,25 @@ pub fn to_many_composites() -> String {
         r#"model TestModel {
             #id(id, Int, @id)
             field String?
-            a     A[]       @map("top_a")
-            c     C[]       @map("top_c")
+            to_many_as CompositeA[] @map("top_a")
+            to_one_b   CompositeB?
         }
 
-        type A {
+        type CompositeA {
             a_1 String @default("a_1 default") @map("a1")
             a_2 Int?
-            b B[]
         }
 
-        type B {
-            b_field String   @default("b_field default")
-            a       A[]      @map("nested_a")
+        type CompositeB {
+            b_field      Int?         @default(10)
+            b_to_many_cs CompositeC[]
         }
 
-        type C {
-          c_field String @default("c_field default")
+        type CompositeC {
+          c_field Int @default(10)
+
+          // Mostly here to test ordering multiple nested selection sets.
+          c_to_many_as CompositeA[]
         }
         "#
     };

--- a/query-engine/connector-test-kit-rs/query-engine-tests/src/schemas/composites.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/src/schemas/composites.rs
@@ -118,3 +118,49 @@ pub fn to_many_composites() -> String {
 
     schema.to_owned()
 }
+
+/// Composites and relations mixed.
+pub fn mixed_composites() -> String {
+    let schema = indoc! {
+        r#"model TestModel {
+            #id(id, Int, @id)
+            field        String?
+            to_one_com   CompositeA?  @map("to_one_composite")
+            to_many_com  CompositeB[] @map("to_many_composite")
+
+            to_one_rel_id Int?
+            to_one_rel RelatedModel? @relation(name: "ToOne", fields: [to_one_rel_id], references: [id])
+
+            to_many_rel RelatedModel[] @relation(name: "ToMany")
+        }
+
+        type CompositeA {
+            a_1 String @default("a_1 default") @map("a1")
+            a_2 Int?
+            other_composites CompositeB[]
+        }
+
+        type CompositeB {
+            b_field        String      @default("b_field default")
+            to_other_com   CompositeC? @map("nested_c")
+        }
+
+        type CompositeC {
+          c_field String @default("c_field default")
+        }
+
+        model RelatedModel {
+            #id(id, Int, @id)
+
+            to_one_com   CompositeA?  @map("to_one_composite")
+            to_many_com  CompositeB[] @map("to_many_composite")
+
+            test_model TestModel? @relation(name: "ToOne")
+            many_test_model TestModel[] @relation(name: "ToMany")
+        }
+
+        "#
+    };
+
+    schema.to_owned()
+}

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/mod.rs
@@ -2,6 +2,7 @@ mod nested_multi_order_pagination;
 mod nested_pagination;
 mod order_by;
 mod order_by_aggregation;
+mod order_by_composite;
 mod order_by_dependent;
 mod order_by_dependent_pagination;
 mod order_by_mutation;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_composite.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_composite.rs
@@ -1,0 +1,222 @@
+use indoc::indoc;
+use query_engine_tests::*;
+
+#[test_suite(schema(to_one_composites), only(MongoDb))]
+mod to_one {
+    /// Order a model based on a single to-one composite hop.
+    #[connector_test]
+    async fn model_basic_ordering_single(runner: Runner) -> TestResult<()> {
+        create_test_data(&runner).await?;
+
+        // Required, ASC
+        insta::assert_snapshot!(
+            run_query!(runner, r#"{ findManyTestModel(orderBy: { a: { a_1: asc } }) { id } }"#),
+            @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5}]}}"###
+        );
+
+        // Required, DESC
+        insta::assert_snapshot!(
+            run_query!(runner, r#"{ findManyTestModel(orderBy: { a: { a_1: desc } }) { id } }"#),
+            @r###"{"data":{"findManyTestModel":[{"id":5},{"id":4},{"id":3},{"id":2},{"id":1}]}}"###
+        );
+
+        // Optional, ASC (nulls appear first)
+        insta::assert_snapshot!(
+            run_query!(runner, r#"{ findManyTestModel(orderBy: { b: { b_field: asc } }) { id b { b_field } } }"#),
+            @r###"{"data":{"findManyTestModel":[{"id":4,"b":null},{"id":5,"b":null},{"id":1,"b":{"b_field":"1_b_field"}},{"id":2,"b":{"b_field":"2_b_field"}},{"id":3,"b":{"b_field":"3_b_field"}}]}}"###
+        );
+
+        // Optional, DESC (nulls appear last)
+        insta::assert_snapshot!(
+            run_query!(runner, r#"{ findManyTestModel(orderBy: { b: { b_field: desc } }) { id b { b_field } } }"#),
+            @r###"{"data":{"findManyTestModel":[{"id":3,"b":{"b_field":"3_b_field"}},{"id":2,"b":{"b_field":"2_b_field"}},{"id":1,"b":{"b_field":"1_b_field"}},{"id":4,"b":null},{"id":5,"b":null}]}}"###
+        );
+
+        Ok(())
+    }
+
+    /// Order a model based on multiple to-one composite hops.
+    #[connector_test]
+    async fn model_basic_ordering_multiple(runner: Runner) -> TestResult<()> {
+        create_test_data(&runner).await?;
+
+        // Required, ASC (nulls first)
+        insta::assert_snapshot!(
+            run_query!(runner, r#"{ findManyTestModel(orderBy: { b: { c: { c_field: asc }} }) { id } }"#),
+            @r###"{"data":{"findManyTestModel":[{"id":4},{"id":5},{"id":1},{"id":2},{"id":3}]}}"###
+        );
+
+        // Required, DESC (nulls last)
+        insta::assert_snapshot!(
+            run_query!(runner, r#"{ findManyTestModel(orderBy: { b: { c: { c_field: desc }} }) { id } }"#),
+            @r###"{"data":{"findManyTestModel":[{"id":3},{"id":2},{"id":1},{"id":4},{"id":5}]}}"###
+        );
+
+        Ok(())
+    }
+
+    /// Order a model based on different orderings at once.
+    #[connector_test]
+    async fn model_multi_ordering(runner: Runner) -> TestResult<()> {
+        create_multi_order_test_data(&runner).await?;
+
+        insta::assert_snapshot!(
+            run_query!(runner, r#"
+            { findManyTestModel(
+                orderBy: [
+                    { a: { a_1: asc } },
+                    { a: { a_2: desc } }
+                ]) { id } }"#),
+            @r###"{"data":{"findManyTestModel":[{"id":2},{"id":1},{"id":3},{"id":4},{"id":5}]}}"###
+        );
+
+        insta::assert_snapshot!(
+            run_query!(runner, r#"
+            { findManyTestModel(
+                orderBy: [
+                    { b: { b_field: asc } },
+                    { a: { a_1: desc } }
+                ]) { id } }"#),
+            @r###"{"data":{"findManyTestModel":[{"id":5},{"id":4},{"id":1},{"id":3},{"id":2}]}}"###
+        );
+
+        Ok(())
+    }
+
+    #[rustfmt::skip]
+    async fn create_test_data(runner: &Runner) -> TestResult<()> {
+        // All data set (except model and last hop to prevent endless circles).
+        create_row(runner, r#"{ id: 1, a: { a_1: "1_a_1", a_2: 1 }, b: { b_field: "1_b_field", c: { c_field: "1_c_field" } } }"#,).await?;
+        create_row(runner, r#"{ id: 2, a: { a_1: "2_a_1", a_2: 2 }, b: { b_field: "2_b_field", c: { c_field: "2_c_field" } } }"#,).await?;
+        create_row(runner, r#"{ id: 3, a: { a_1: "3_a_1", a_2: 3 }, b: { b_field: "3_b_field", c: { c_field: "3_c_field" } } }"#).await?;
+
+        // All optional data is explicitly null.
+        create_row(runner, r#"{ id: 4, a: { a_1: "4_a_1", a_2: null }, b: null }"#).await?;
+
+        // All optional data is not set.
+        create_row(runner, r#"{ id: 5, a: { a_1: "5_a_1" } }"#).await?;
+
+        Ok(())
+    }
+
+    /// Test data for ordering by multiple requires some duplicates in the first ordering keys to be useful.
+    #[rustfmt::skip]
+    async fn create_multi_order_test_data(runner: &Runner) -> TestResult<()> {
+        create_row(runner, r#"{ id: 1, a: { a_1: "a1", a_2: 1 }, b: { b_field: "b1", c: { c_field: "1_c_field" } } }"#,).await?;
+        create_row(runner, r#"{ id: 2, a: { a_1: "a1", a_2: 2 }, b: { b_field: "b2", c: { c_field: "2_c_field" } } }"#,).await?;
+        create_row(runner, r#"{ id: 3, a: { a_1: "a2", a_2: 2 }, b: { b_field: "b2", c: { c_field: "3_c_field" } } }"#).await?;
+        create_row(runner, r#"{ id: 4, a: { a_1: "a3", a_2: null }, b: null }"#).await?;
+        create_row(runner, r#"{ id: 5, a: { a_1: "a4" } }"#).await?;
+
+        Ok(())
+    }
+}
+
+#[test_suite(schema(mixed_composites), only(MongoDb))]
+mod mixed {
+
+    /// Order a model based on composites over a relation.
+    #[connector_test]
+    async fn composite_over_rel_ordering(runner: Runner) -> TestResult<()> {
+        create_test_data(&runner).await?;
+
+        insta::assert_snapshot!(
+            run_query!(runner, r#"
+            { findManyTestModel(orderBy: { to_one_rel: { to_one_com: { a_1: asc } } }) { id } }"#),
+            @r###"{"data":{"findManyTestModel":[{"id":2},{"id":1}]}}"###
+        );
+
+        Ok(())
+    }
+
+    async fn create_test_data(runner: &Runner) -> TestResult<()> {
+        // All data set
+        create_row(
+            runner,
+            r#"
+            {
+                id: 1,
+                to_one_com: {
+                    a_1: "a1",
+                    a_2: 1,
+                    other_composites: [
+                        { b_field: "b1", to_other_com: { c_field: "1_c_field" } }
+                    ]
+                },
+                to_many_com: [
+                    { b_field: "b3", to_other_com: { c_field: "3_c_field" } },
+                    { b_field: "b4", to_other_com: { c_field: "4_c_field" } }
+                ]
+                to_one_rel: {
+                    create: {
+                        id: 1,
+                        to_one_com: {
+                            a_1: "2",
+                            a_2: 2,
+                            other_composites: [
+                                { b_field: "b4", to_other_com: { c_field: "5_c_field" } },
+                                { b_field: "b5", to_other_com: { c_field: "6_c_field" } }
+                            ]
+                        },
+                        to_many_com: [
+                            { b_field: "b6", to_other_com: { c_field: "7_c_field" } },
+                            { b_field: "b7", to_other_com: { c_field: "8_c_field" } }
+                        ]
+                    }
+                }
+            }
+            "#,
+        )
+        .await?;
+
+        create_row(
+            runner,
+            r#"
+            {
+                id: 2,
+                to_one_com: {
+                    a_1: "a1",
+                    a_2: 1,
+                    other_composites: [
+                        { b_field: "b1", to_other_com: { c_field: "1_c_field" } },
+                        { b_field: "b2", to_other_com: { c_field: "2_c_field" } }
+                    ]
+                },
+                to_many_com: [
+                    { b_field: "b3", to_other_com: { c_field: "3_c_field" } },
+                    { b_field: "b4", to_other_com: { c_field: "4_c_field" } }
+                ]
+                to_one_rel: {
+                    create: {
+                        id: 2,
+                        to_one_com: {
+                            a_1: "1",
+                            a_2: 2,
+                            other_composites: [
+                                { b_field: "b4", to_other_com: { c_field: "5_c_field" } },
+                                { b_field: "b5", to_other_com: { c_field: "6_c_field" } }
+                            ]
+                        },
+                        to_many_com: [
+                            { b_field: "b6", to_other_com: { c_field: "7_c_field" } },
+                            { b_field: "b7", to_other_com: { c_field: "8_c_field" } }
+                        ]
+                    }
+                }
+            }
+            "#,
+        )
+        .await?;
+
+        Ok(())
+    }
+}
+
+async fn create_row(runner: &Runner, data: &str) -> TestResult<()> {
+    runner
+        .query(format!("mutation {{ createOneTestModel(data: {}) {{ id }} }}", data))
+        .await?
+        .assert_success();
+
+    Ok(())
+}

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_composite.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_composite.rs
@@ -148,18 +148,19 @@ mod to_many {
     }
 
     /// Order a model based on to-many reached over to-one composite hops.
+    /// This test also catches that to-many composites stay queryable together an aggregate order by.
     #[connector_test]
     async fn model_basic_to_many_ordering_multiple_hops(runner: Runner) -> TestResult<()> {
         create_test_data(&runner).await?;
 
         insta::assert_snapshot!(
-            run_query!(runner, r#"{ findManyTestModel(orderBy: { to_one_b: { b_to_many_cs: { _count: asc }} }) { id } }"#),
-            @r###"{"data":{"findManyTestModel":[{"id":3},{"id":4},{"id":2},{"id":1}]}}"###
+            run_query!(runner, r#"{ findManyTestModel(orderBy: { to_one_b: { b_to_many_cs: { _count: asc }} }) { id to_one_b { b_field } } }"#),
+            @r###"{"data":{"findManyTestModel":[{"id":3,"to_one_b":{"b_field":10}},{"id":4,"to_one_b":null},{"id":2,"to_one_b":{"b_field":10}},{"id":1,"to_one_b":{"b_field":10}}]}}"###
         );
 
         insta::assert_snapshot!(
-            run_query!(runner, r#"{ findManyTestModel(orderBy: { to_one_b: { b_to_many_cs: { _count: desc }} }) { id } }"#),
-            @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":3},{"id":4}]}}"###
+            run_query!(runner, r#"{ findManyTestModel(orderBy: { to_one_b: { b_to_many_cs: { _count: desc }} }) { id to_one_b { b_field } } }"#),
+            @r###"{"data":{"findManyTestModel":[{"id":1,"to_one_b":{"b_field":10}},{"id":2,"to_one_b":{"b_field":10}},{"id":3,"to_one_b":{"b_field":10}},{"id":4,"to_one_b":null}]}}"###
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_composite.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_composite.rs
@@ -112,101 +112,328 @@ mod to_one {
     }
 }
 
-#[test_suite(schema(mixed_composites), only(MongoDb))]
+#[test_suite(only(MongoDb))]
 mod mixed {
+    fn over_to_one_relation() -> String {
+        let schema = indoc! {
+            r#"model TestModel {
+              #id(id, Int, @id)
+
+              to_one_rel_id Int?
+              to_one_rel RelatedModel? @relation(name: "ToOne", fields: [to_one_rel_id], references: [id])
+            }
+
+            model RelatedModel {
+                #id(id, Int, @id)
+
+                to_one_a   CompositeA?  @map("to_one_composite")
+                to_many_bs CompositeB[] @map("to_many_composite")
+
+                test_model TestModel? @relation(name: "ToOne")
+            }
+
+            type CompositeA {
+                a_1 String @default("a_1 default") @map("a1")
+                a_2 Int?
+                a_to_many_bs CompositeB[]
+            }
+
+            type CompositeB {
+                b_field    Int         @default(10)
+                b_to_one_c CompositeC? @map("nested_c")
+            }
+
+            type CompositeC {
+              c_field String @default("c_field default")
+            }
+            "#
+        };
+
+        schema.to_owned()
+    }
+
+    // a_to_many_bs: [
+    //     { b_field: 50, b_to_one_c: { c_field: "c_field_1" } },
+    //     { b_field: 5, b_to_one_c: { c_field: "c_field_2" } }
+    // ]
+    // to_many_com: [
+    //     { b_field: 100, b_to_one_c: { c_field: "c_field_3" } },
+    //     { b_field: 10, b_to_one_c: { c_field: "c_field_1" } }
+    // ]
+
+    async fn over_to_one_relation_test_data(runner: &Runner) -> TestResult<()> {
+        create_row(
+            runner,
+            r#"{ id: 1, to_one_rel: { create: { id: 1, to_one_a: { a_1: "2", a_2: 1 }}}}"#,
+        )
+        .await?;
+
+        create_row(
+            runner,
+            r#"{ id: 2, to_one_rel: { create: { id: 2, to_one_a: { a_1: "1", a_2: 2 }}}}"#,
+        )
+        .await?;
+
+        create_row(
+            runner,
+            r#"{ id: 3, to_one_rel: { create: { id: 3, to_one_a: { a_1: "2", a_2: 5 }}}}"#,
+        )
+        .await?;
+
+        create_row(
+            runner,
+            r#"{ id: 4, to_one_rel: { create: { id: 4, to_one_a: { a_1: "2", a_2: null }}}}"#,
+        )
+        .await?;
+
+        create_row(
+            runner,
+            r#"{ id: 5, to_one_rel: { create: { id: 5, to_one_a: { a_1: "2" }}}}"#,
+        )
+        .await?;
+
+        create_row(runner, r#"{ id: 6 }"#).await?;
+        create_row(runner, r#"{ id: 7 }"#).await?;
+
+        Ok(())
+    }
 
     /// Order a model based on composites over a relation.
-    #[connector_test]
+    #[connector_test(schema(over_to_one_relation))]
     async fn composite_over_rel_ordering(runner: Runner) -> TestResult<()> {
-        create_test_data(&runner).await?;
+        over_to_one_relation_test_data(&runner).await?;
 
+        // Single orderBy ASC.
+        // Result is:
+        // - Null relations first: (6, 7)
+        // - Rows with data next ASC: (2, 1, 3, 4, 5)
         insta::assert_snapshot!(
-            run_query!(runner, r#"
-            { findManyTestModel(orderBy: { to_one_rel: { to_one_com: { a_1: asc } } }) { id } }"#),
-            @r###"{"data":{"findManyTestModel":[{"id":2},{"id":1}]}}"###
+            run_query!(runner, r#"{ findManyTestModel(orderBy: { to_one_rel: { to_one_a: { a_1: asc } } }) { id } }"#),
+            @r###"{"data":{"findManyTestModel":[{"id":6},{"id":7},{"id":2},{"id":1},{"id":3},{"id":4},{"id":5}]}}"###
+        );
+
+        // Single orderBy DESC.
+        // Result is:
+        // - Rows with data first ASC: (1, 3, 4, 5, 2)
+        // - Null relations next: (6, 7)
+        insta::assert_snapshot!(
+            run_query!(runner, r#"{ findManyTestModel(orderBy: { to_one_rel: { to_one_a: { a_1: desc } } }) { id } }"#),
+            @r###"{"data":{"findManyTestModel":[{"id":1},{"id":3},{"id":4},{"id":5},{"id":2},{"id":6},{"id":7}]}}"###
+        );
+
+        // Single orderBy over nullable ASC.
+        // Result is:
+        // - Null values first: (4, 5)
+        // - Null relations next: (6, 7)
+        // - Rows with data next ASC: (1, 2, 3)
+        insta::assert_snapshot!(
+            run_query!(runner, r#"{ findManyTestModel(orderBy: { to_one_rel: { to_one_a: { a_2: asc } } }) { id } }"#),
+            @r###"{"data":{"findManyTestModel":[{"id":4},{"id":5},{"id":6},{"id":7},{"id":1},{"id":2},{"id":3}]}}"###
+        );
+
+        // Single orderBy over nullable DESC.
+        // Result is:
+        // - Rows with data first DESC: (3, 2, 1)
+        // - Null relations next: (6, 7)
+        // - Null values next: (4, 5)
+        insta::assert_snapshot!(
+            run_query!(runner, r#"{ findManyTestModel(orderBy: { to_one_rel: { to_one_a: { a_2: desc } } }) { id } }"#),
+            @r###"{"data":{"findManyTestModel":[{"id":3},{"id":2},{"id":1},{"id":4},{"id":5},{"id":6},{"id":7}]}}"###
         );
 
         Ok(())
     }
 
-    async fn create_test_data(runner: &Runner) -> TestResult<()> {
-        // All data set
+    fn over_to_many_relation() -> String {
+        let schema = indoc! {
+            r#"model TestModel {
+              #id(id, Int, @id)
+              to_many_rel RelatedModel[]
+            }
+
+            model RelatedModel {
+                #id(id, Int, @id)
+
+                to_one_a   CompositeA?  @map("to_one_composite")
+                to_many_bs CompositeB[] @map("to_many_composite")
+
+                test_model_id Int
+                test_model    TestModel @relation(fields: [test_model_id], references: [id])
+            }
+
+            type CompositeA {
+                a_1 String @default("a_1 default") @map("a1")
+                a_2 Int?
+                a_to_many_bs CompositeB[]
+            }
+
+            type CompositeB {
+                b_field    Int         @default(10)
+                b_to_one_c CompositeC? @map("nested_c")
+            }
+
+            type CompositeC {
+              c_field String @default("c_field default")
+            }
+            "#
+        };
+
+        schema.to_owned()
+    }
+
+    async fn over_to_many_relation_test_data(runner: &Runner) -> TestResult<()> {
         create_row(
             runner,
-            r#"
-            {
-                id: 1,
-                to_one_com: {
-                    a_1: "a1",
-                    a_2: 1,
-                    other_composites: [
-                        { b_field: "b1", to_other_com: { c_field: "1_c_field" } }
-                    ]
-                },
-                to_many_com: [
-                    { b_field: "b3", to_other_com: { c_field: "3_c_field" } },
-                    { b_field: "b4", to_other_com: { c_field: "4_c_field" } }
+            r#"{ id: 1, to_many_rel: {
+                create: [
+                    { id: 1, to_one_a: { a_1: "1", a_2: 1 }},
+                    { id: 2, to_one_a: { a_1: "1", a_2: 2 }},
+                    { id: 3, to_one_a: { a_1: "2", a_2: 3 }}
                 ]
-                to_one_rel: {
-                    create: {
-                        id: 1,
-                        to_one_com: {
-                            a_1: "2",
-                            a_2: 2,
-                            other_composites: [
-                                { b_field: "b4", to_other_com: { c_field: "5_c_field" } },
-                                { b_field: "b5", to_other_com: { c_field: "6_c_field" } }
-                            ]
-                        },
-                        to_many_com: [
-                            { b_field: "b6", to_other_com: { c_field: "7_c_field" } },
-                            { b_field: "b7", to_other_com: { c_field: "8_c_field" } }
-                        ]
-                    }
-                }
             }
-            "#,
+        }"#,
         )
         .await?;
 
         create_row(
             runner,
-            r#"
-            {
-                id: 2,
-                to_one_com: {
-                    a_1: "a1",
-                    a_2: 1,
-                    other_composites: [
-                        { b_field: "b1", to_other_com: { c_field: "1_c_field" } },
-                        { b_field: "b2", to_other_com: { c_field: "2_c_field" } }
-                    ]
-                },
-                to_many_com: [
-                    { b_field: "b3", to_other_com: { c_field: "3_c_field" } },
-                    { b_field: "b4", to_other_com: { c_field: "4_c_field" } }
+            r#"{ id: 2, to_many_rel: {
+                create: [
+                    { id: 4, to_one_a: { a_1: "2", a_2: 2 }},
+                    { id: 5, to_one_a: { a_1: "3", a_2: 2 }},
+                    { id: 6, to_one_a: { a_1: "1", a_2: 2 }}
                 ]
-                to_one_rel: {
-                    create: {
-                        id: 2,
-                        to_one_com: {
-                            a_1: "1",
-                            a_2: 2,
-                            other_composites: [
-                                { b_field: "b4", to_other_com: { c_field: "5_c_field" } },
-                                { b_field: "b5", to_other_com: { c_field: "6_c_field" } }
-                            ]
-                        },
-                        to_many_com: [
-                            { b_field: "b6", to_other_com: { c_field: "7_c_field" } },
-                            { b_field: "b7", to_other_com: { c_field: "8_c_field" } }
-                        ]
-                    }
-                }
             }
-            "#,
+        }"#,
         )
         .await?;
+
+        create_row(
+            runner,
+            r#"{ id: 3, to_many_rel: {
+                create: []
+            }
+        }"#,
+        )
+        .await?;
+
+        create_row(
+            runner,
+            r#"{ id: 4, to_many_rel: {
+                create: [{ id: 7 }, { id: 8, to_one_a: null }]
+            }
+        }"#,
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    #[connector_test(schema(over_to_many_relation))]
+    // Order a related model on a to-one composite.
+    async fn order_related_by_to_one_composite(runner: Runner) -> TestResult<()> {
+        over_to_many_relation_test_data(&runner).await?;
+
+        insta::assert_snapshot!(
+            run_query!(runner, r#"
+              {
+                findManyTestModel {
+                  id
+                  to_many_rel(orderBy: { to_one_a: { a_1: asc } }) {
+                    id
+                    to_one_a {
+                      a_1
+                    }
+                  }
+                }
+              }
+            "#),
+            @r###"{"data":{"findManyTestModel":[{"id":1,"to_many_rel":[{"id":1,"to_one_a":{"a_1":"1"}},{"id":2,"to_one_a":{"a_1":"1"}},{"id":3,"to_one_a":{"a_1":"2"}}]},{"id":2,"to_many_rel":[{"id":6,"to_one_a":{"a_1":"1"}},{"id":4,"to_one_a":{"a_1":"2"}},{"id":5,"to_one_a":{"a_1":"3"}}]},{"id":3,"to_many_rel":[]},{"id":4,"to_many_rel":[{"id":7,"to_one_a":null},{"id":8,"to_one_a":null}]}]}}"###
+        );
+
+        insta::assert_snapshot!(
+            run_query!(runner, r#"
+              {
+                findManyTestModel {
+                  id
+                  to_many_rel(orderBy: { to_one_a: { a_1: desc } }) {
+                    id
+                    to_one_a {
+                      a_1
+                    }
+                  }
+                }
+              }
+            "#),
+            @r###"{"data":{"findManyTestModel":[{"id":1,"to_many_rel":[{"id":3,"to_one_a":{"a_1":"2"}},{"id":1,"to_one_a":{"a_1":"1"}},{"id":2,"to_one_a":{"a_1":"1"}}]},{"id":2,"to_many_rel":[{"id":5,"to_one_a":{"a_1":"3"}},{"id":4,"to_one_a":{"a_1":"2"}},{"id":6,"to_one_a":{"a_1":"1"}}]},{"id":3,"to_many_rel":[]},{"id":4,"to_many_rel":[{"id":7,"to_one_a":null},{"id":8,"to_one_a":null}]}]}}"###
+        );
+
+        Ok(())
+    }
+}
+
+#[test_suite(schema(to_many_composites), only(MongoDb))]
+mod to_many {
+    // Order a composite selection by a single orderBy.
+    // todo: Doesn't work yet at all, needs more in-depth code changes.
+    //#[connector_test]
+    // async fn simple_composite_selection_ordering(runner: Runner) -> TestResult<()> {
+    //     create_test_data(&runner).await?;
+
+    //     insta::assert_snapshot!(
+    //         run_query!(runner, r#"
+    //         { findManyTestModel { id to_many_as(orderBy: { a_1: asc }) { a_1 a_2 } } }"#),
+    //         @r###"{"data":{"findManyTestModel":[{"id":2},{"id":1},{"id":3},{"id":4},{"id":5}]}}"###
+    //     );
+
+    //     Ok(())
+    // }
+
+    async fn create_test_data(runner: &Runner) -> TestResult<()> {
+        create_row(
+            runner,
+            r#"{
+                id: 1,
+                to_many_as: [
+                    { a_1: "1", a_2: 5 },
+                    { a_1: "2", a_2: 2 }
+                ],
+                to_one_b: {
+                    b_to_many_cs: [
+                        { c_field: 1, c_to_many_as: [{ a_1: "1", a_2: 1 }, { a_1: "2", a_2: 2 }] },
+                        { c_field: 2, c_to_many_as: [{ a_1: "3", a_2: 3 }, { a_1: "4", a_2: 4 }] },
+                        { c_field: 3, c_to_many_as: [{ a_1: "5", a_2: 5 }, { a_1: "6", a_2: 6 }] }
+                    ]
+                }
+            }"#,
+        )
+        .await?;
+
+        create_row(
+            runner,
+            r#"{
+                id: 2,
+                to_many_as: [
+                    { a_1: "10", a_2: 50 },
+                    { a_1: "20", a_2: 20 }
+                ],
+                to_one_b: {
+                    b_to_many_cs: [
+                        { c_field: 10, c_to_many_as: [{ a_1: "10", a_2: 10 }, { a_1: "20", a_2: 20 }] },
+                        { c_field: 20, c_to_many_as: [{ a_1: "30", a_2: 30 }, { a_1: "40", a_2: 40 }] },
+                    ]
+                }
+            }"#,
+        )
+        .await?;
+
+        // more with optionals
+
+        // b_to_many_cs: [
+        //                 { b_field: 1 },
+        //                 { b_field: 2 },
+        //                 { b_field: 3 }
+        //             ]
 
         Ok(())
     }

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_composite.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_composite.rs
@@ -86,15 +86,15 @@ mod to_one {
     #[rustfmt::skip]
     async fn create_test_data(runner: &Runner) -> TestResult<()> {
         // All data set (except model and last hop to prevent endless circles).
-        create_row(runner, r#"{ id: 1, a: { a_1: "1_a_1", a_2: 1 }, b: { b_field: "1_b_field", c: { c_field: "1_c_field" } } }"#,).await?;
-        create_row(runner, r#"{ id: 2, a: { a_1: "2_a_1", a_2: 2 }, b: { b_field: "2_b_field", c: { c_field: "2_c_field" } } }"#,).await?;
-        create_row(runner, r#"{ id: 3, a: { a_1: "3_a_1", a_2: 3 }, b: { b_field: "3_b_field", c: { c_field: "3_c_field" } } }"#).await?;
+        create_row(runner, r#"{ id: 1, a: { a_1: "1_a_1", a_2: 1, b: { c:{} } }, b: { b_field: "1_b_field", c: { c_field: "1_c_field" } } }"#,).await?;
+        create_row(runner, r#"{ id: 2, a: { a_1: "2_a_1", a_2: 2, b: { c:{} } }, b: { b_field: "2_b_field", c: { c_field: "2_c_field" } } }"#,).await?;
+        create_row(runner, r#"{ id: 3, a: { a_1: "3_a_1", a_2: 3, b: { c:{} } }, b: { b_field: "3_b_field", c: { c_field: "3_c_field" } } }"#).await?;
 
         // All optional data is explicitly null.
-        create_row(runner, r#"{ id: 4, a: { a_1: "4_a_1", a_2: null }, b: null }"#).await?;
+        create_row(runner, r#"{ id: 4, a: { a_1: "4_a_1", a_2: null, b: { c:{} } }, b: null }"#).await?;
 
         // All optional data is not set.
-        create_row(runner, r#"{ id: 5, a: { a_1: "5_a_1" } }"#).await?;
+        create_row(runner, r#"{ id: 5, a: { a_1: "5_a_1", b: { c:{} } } }"#).await?;
 
         Ok(())
     }
@@ -102,11 +102,11 @@ mod to_one {
     /// Test data for ordering by multiple requires some duplicates in the first ordering keys to be useful.
     #[rustfmt::skip]
     async fn create_multi_order_test_data(runner: &Runner) -> TestResult<()> {
-        create_row(runner, r#"{ id: 1, a: { a_1: "a1", a_2: 1 }, b: { b_field: "b1", c: { c_field: "1_c_field" } } }"#,).await?;
-        create_row(runner, r#"{ id: 2, a: { a_1: "a1", a_2: 2 }, b: { b_field: "b2", c: { c_field: "2_c_field" } } }"#,).await?;
-        create_row(runner, r#"{ id: 3, a: { a_1: "a2", a_2: 2 }, b: { b_field: "b2", c: { c_field: "3_c_field" } } }"#).await?;
-        create_row(runner, r#"{ id: 4, a: { a_1: "a3", a_2: null }, b: null }"#).await?;
-        create_row(runner, r#"{ id: 5, a: { a_1: "a4" } }"#).await?;
+        create_row(runner, r#"{ id: 1, a: { a_1: "a1", a_2: 1, b: { c:{} } }, b: { b_field: "b1", c: { c_field: "1_c_field" } } }"#,).await?;
+        create_row(runner, r#"{ id: 2, a: { a_1: "a1", a_2: 2, b: { c:{} } }, b: { b_field: "b2", c: { c_field: "2_c_field" } } }"#,).await?;
+        create_row(runner, r#"{ id: 3, a: { a_1: "a2", a_2: 2, b: { c:{} } }, b: { b_field: "b2", c: { c_field: "3_c_field" } } }"#).await?;
+        create_row(runner, r#"{ id: 4, a: { a_1: "a3", a_2: null, b: { c:{} } }, b: null }"#).await?;
+        create_row(runner, r#"{ id: 5, a: { a_1: "a4", b: { c:{} } } }"#).await?;
 
         Ok(())
     }
@@ -148,7 +148,7 @@ mod to_many {
     }
 
     /// Order a model based on to-many reached over to-one composite hops.
-    /// This test also catches that to-many composites stay queryable together an aggregate order by.
+    /// This test also catches that to-many composites stay queryable together with aggregate order by.
     #[connector_test]
     async fn model_basic_to_many_ordering_multiple_hops(runner: Runner) -> TestResult<()> {
         create_test_data(&runner).await?;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/composites/list.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/composites/list.rs
@@ -13,24 +13,17 @@ mod create {
             createOneTestModel(
               data: {
                 id: 1
-                a: { set: { a_1: "a1", a_2: null, b: { b_field: "b_field", a: [] } } }
-                c: { set: [] }
+                to_many_as: { set: { a_1: "a1", a_2: null } }
               }
             ) {
-              a {
+              to_many_as {
                 a_1
                 a_2
-                b {
-                  b_field
-                  a {
-                      a_1
-                  }
-                }
               }
             }
           }
           "#),
-          @r###"{"data":{"createOneTestModel":{"a":[{"a_1":"a1","a_2":null,"b":[{"b_field":"b_field","a":[]}]}]}}}"###
+          @r###"{"data":{"createOneTestModel":{"to_many_as":[{"a_1":"a1","a_2":null}]}}}"###
         );
 
         // Full: set + list wrapper
@@ -39,24 +32,17 @@ mod create {
             createOneTestModel(
               data: {
                 id: 2
-                a: { set: [{ a_1: "a1", a_2: null, b: { b_field: "b_field", a: [] } }] }
-                c: { set: [] }
+                to_many_as: { set: [{ a_1: "a1", a_2: null }] }
               }
             ) {
-              a {
+              to_many_as {
                 a_1
                 a_2
-                b {
-                  b_field
-                  a {
-                      a_1
-                  }
-                }
               }
             }
           }
         "#),
-          @r###"{"data":{"createOneTestModel":{"a":[{"a_1":"a1","a_2":null,"b":[{"b_field":"b_field","a":[]}]}]}}}"###
+          @r###"{"data":{"createOneTestModel":{"to_many_as":[{"a_1":"a1","a_2":null}]}}}"###
         );
 
         // Many items at once
@@ -65,43 +51,32 @@ mod create {
                   createOneTestModel(
                     data: {
                       id: 3
-                      a: {
+                      to_many_as: {
                         set: [
                           {
-                            a_1: "a1"
-                            a_2: 2
-                            b: [
-                                { b_field: "b_field", a: [] },
-                                { b_field: "b_field", a: [] }
-                            ]
+                            a_1: "1"
+                            a_2: 1
                           },
                           {
-                            a_1: "a1"
+                            a_1: "2"
                             a_2: 2
-                            b: [
-                                { b_field: "b_field", a: [] },
-                                { b_field: "b_field", a: [] }
-                            ]
+                          },
+                          {
+                            a_1: "3"
+                            a_2: 3
                           }
                         ]
                       }
-                      c: { set: [] }
                     }
                   ) {
-                    a {
+                    to_many_as {
                       a_1
                       a_2
-                      b {
-                        b_field
-                        a {
-                            a_1
-                        }
-                      }
                     }
                   }
                 }
               "#),
-          @r###"{"data":{"createOneTestModel":{"a":[{"a_1":"a1","a_2":2,"b":[{"b_field":"b_field","a":[]},{"b_field":"b_field","a":[]}]},{"a_1":"a1","a_2":2,"b":[{"b_field":"b_field","a":[]},{"b_field":"b_field","a":[]}]}]}}}"###
+          @r###"{"data":{"createOneTestModel":{"to_many_as":[{"a_1":"1","a_2":1},{"a_1":"2","a_2":2},{"a_1":"3","a_2":3}]}}}"###
         );
 
         Ok(())
@@ -116,24 +91,24 @@ mod create {
               createOneTestModel(
                 data: {
                   id: 1
-                  a: { a_1: "a1", a_2: null, b: { b_field: "b_field", a: [] } }
-                  c: []
+                  to_many_as: { a_1: "a1", a_2: null }
+                  to_one_b: { b_to_many_cs: { c_field: 15 } }
                 }
               ) {
-                a {
+                to_many_as {
                   a_1
                   a_2
-                  b {
-                    b_field
-                    a {
-                        a_1
-                    }
+                }
+                to_one_b {
+                  b_field
+                  b_to_many_cs {
+                    c_field
                   }
                 }
               }
             }
             "#),
-          @r###"{"data":{"createOneTestModel":{"a":[{"a_1":"a1","a_2":null,"b":[{"b_field":"b_field","a":[]}]}]}}}"###
+          @r###"{"data":{"createOneTestModel":{"to_many_as":[{"a_1":"a1","a_2":null}],"to_one_b":{"b_field":10,"b_to_many_cs":[{"c_field":15}]}}}}"###
         );
 
         // Shorthand with explicit list wrapper.
@@ -142,67 +117,65 @@ mod create {
               createOneTestModel(
                 data: {
                   id: 2
-                  a: [{ a_1: "a1", a_2: null, b: { b_field: "b_field", a: [] } }]
-                  c: []
+                  to_many_as: [{ a_1: "a1", a_2: null }]
+                  to_one_b: { b_to_many_cs: [{ c_field: 15 }] }
                 }
               ) {
-                a {
+                to_many_as {
                   a_1
                   a_2
-                  b {
-                    b_field
-                    a {
-                        a_1
-                    }
+                }
+                to_one_b {
+                  b_field
+                  b_to_many_cs {
+                    c_field
                   }
                 }
               }
             }
-          "#),
-          @r###"{"data":{"createOneTestModel":{"a":[{"a_1":"a1","a_2":null,"b":[{"b_field":"b_field","a":[]}]}]}}}"###
+            "#),
+          @r###"{"data":{"createOneTestModel":{"to_many_as":[{"a_1":"a1","a_2":null}],"to_one_b":{"b_field":10,"b_to_many_cs":[{"c_field":15}]}}}}"###
         );
 
         // Many items at once
         insta::assert_snapshot!(
           run_query!(runner, r#"mutation {
-                    createOneTestModel(
-                      data: {
-                        id: 3
-                        a: [
-                            {
-                              a_1: "a1"
-                              a_2: 2
-                              b: [
-                                  { b_field: "b_field", a: [] },
-                                  { b_field: "b_field", a: [] }
-                              ]
-                            },
-                            {
-                              a_1: "a1"
-                              a_2: 2
-                              b: [
-                                  { b_field: "b_field", a: [] },
-                                  { b_field: "b_field", a: [] }
-                              ]
-                            }
-                          ]
-                        c: []
+              createOneTestModel(
+                data: {
+                  id: 3
+                  to_many_as: [
+                      {
+                        a_1: "a1"
+                        a_2: 1
+                      },
+                      {
+                        a_1: "a2"
+                        a_2: 2
                       }
-                    ) {
-                      a {
-                        a_1
-                        a_2
-                        b {
-                          b_field
-                          a {
-                              a_1
-                          }
-                        }
-                      }
-                    }
+                    ]
+                  to_one_b: {
+                    b_to_many_cs: [
+                      { c_field: 1 },
+                      { c_field: 2 },
+                      { c_field: 3 },
+                      { c_field: 4 },
+                    ]
                   }
-                "#),
-          @r###"{"data":{"createOneTestModel":{"a":[{"a_1":"a1","a_2":2,"b":[{"b_field":"b_field","a":[]},{"b_field":"b_field","a":[]}]},{"a_1":"a1","a_2":2,"b":[{"b_field":"b_field","a":[]},{"b_field":"b_field","a":[]}]}]}}}"###
+                }
+              ) {
+                to_many_as {
+                  a_1
+                  a_2
+                }
+                to_one_b {
+                  b_to_many_cs {
+                    c_field
+                  }
+                }
+              }
+            }
+          "#),
+          @r###"{"data":{"createOneTestModel":{"to_many_as":[{"a_1":"a1","a_2":1},{"a_1":"a2","a_2":2}],"to_one_b":{"b_to_many_cs":[{"c_field":1},{"c_field":2},{"c_field":3},{"c_field":4}]}}}}"###
         );
 
         Ok(())
@@ -216,22 +189,21 @@ mod create {
             createOneTestModel(
               data: {
                 id: 1
-                a: { set: { a_1: "a1", a_2: null, b: [{ b_field: "b1" }] } }
-                c: [{ c_field: "c1" }]
+                to_many_as: { set: { a_1: "a1", a_2: null } }
+                to_one_b: { b_field: 5 }
               }
             ) {
-              a {
+              to_many_as {
                 a_1
                 a_2
-                b { b_field }
               }
-              c {
-                c_field
+              to_one_b {
+                b_field
               }
             }
           }
           "#),
-          @r###"{"data":{"createOneTestModel":{"a":[{"a_1":"a1","a_2":null,"b":[{"b_field":"b1"}]}],"c":[{"c_field":"c1"}]}}}"###
+          @r###"{"data":{"createOneTestModel":{"to_many_as":[{"a_1":"a1","a_2":null}],"to_one_b":{"b_field":5}}}}"###
         );
 
         Ok(())
@@ -245,22 +217,19 @@ mod create {
               createOneTestModel(
                 data: {
                   id: 1
-                  a: { set: [{
+                  to_many_as: { set: [{
                     a_2: null,
-                    b: [{}]
                   }] }
-                  c: { set: [] }
                 }
               ) {
-                a {
+                to_many_as {
                   a_1
                   a_2
-                  b { b_field }
                 }
               }
             }
             "#),
-          @r###"{"data":{"createOneTestModel":{"a":[{"a_1":"a_1 default","a_2":null,"b":[{"b_field":"b_field default"}]}]}}}"###
+          @r###"{"data":{"createOneTestModel":{"to_many_as":[{"a_1":"a_1 default","a_2":null}]}}}"###
         );
 
         // Using single-object shorthand syntax
@@ -269,22 +238,19 @@ mod create {
               createOneTestModel(
                 data: {
                   id: 2
-                  a: { set: [{
+                  to_many_as: { set: {
                     a_2: null,
-                    b: {}
-                  }] }
-                  c: { set: [] }
+                  } }
                 }
               ) {
-                a {
+                to_many_as {
                   a_1
                   a_2
-                  b { b_field }
                 }
               }
             }
             "#),
-          @r###"{"data":{"createOneTestModel":{"a":[{"a_1":"a_1 default","a_2":null,"b":[{"b_field":"b_field default"}]}]}}}"###
+          @r###"{"data":{"createOneTestModel":{"to_many_as":[{"a_1":"a_1 default","a_2":null}]}}}"###
         );
 
         Ok(())
@@ -298,22 +264,25 @@ mod create {
             createOneTestModel(
               data: {
                 id: 1
-                a: [{
+                to_many_as: [{
                   a_2: null,
-                  b: [{}]
                 }]
-                c: []
+                to_one_b: { b_to_many_cs: [{}] }
               }
             ) {
-              a {
+              to_many_as {
                 a_1
                 a_2
-                b { b_field }
+              }
+              to_one_b {
+                b_to_many_cs {
+                  c_field
+                }
               }
             }
           }
         "#),
-          @r###"{"data":{"createOneTestModel":{"a":[{"a_1":"a_1 default","a_2":null,"b":[{"b_field":"b_field default"}]}]}}}"###
+          @r###"{"data":{"createOneTestModel":{"to_many_as":[{"a_1":"a_1 default","a_2":null}],"to_one_b":{"b_to_many_cs":[{"c_field":10}]}}}}"###
         );
 
         // Using single-object shorthand syntax
@@ -322,22 +291,25 @@ mod create {
             createOneTestModel(
               data: {
                 id: 2
-                a: [{
+                to_many_as: [{
                   a_2: null,
-                  b: {}
                 }]
-                c: []
+                to_one_b: { b_to_many_cs: {} }
               }
             ) {
-              a {
+              to_many_as {
                 a_1
                 a_2
-                b { b_field }
+              }
+              to_one_b {
+                b_to_many_cs {
+                  c_field
+                }
               }
             }
           }
         "#),
-          @r###"{"data":{"createOneTestModel":{"a":[{"a_1":"a_1 default","a_2":null,"b":[{"b_field":"b_field default"}]}]}}}"###
+          @r###"{"data":{"createOneTestModel":{"to_many_as":[{"a_1":"a_1 default","a_2":null}],"to_one_b":{"b_to_many_cs":[{"c_field":10}]}}}}"###
         );
 
         Ok(())
@@ -349,12 +321,12 @@ mod create {
         insta::assert_snapshot!(
           run_query!(runner, r#"mutation {
           createOneTestModel(data: { id: 1 }) {
-            a { a_1 }
-            c { c_field }
+            to_many_as { a_1 }
+            to_one_b { b_field }
           }
         }
         "#),
-          @r###"{"data":{"createOneTestModel":{"a":[],"c":[]}}}"###
+          @r###"{"data":{"createOneTestModel":{"to_many_as":[],"to_one_b":null}}}"###
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/composites/list.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/composites/list.rs
@@ -347,24 +347,21 @@ mod update {
             updateOneTestModel(
               where: { id: 1 }
               data: {
-                a: { set: [{ a_1: "updated", a_2: 1337, b: { b_field: "updated", a: [{}] } }] }
-                c: { set: [{ c_field: "updated" }] }
+                to_many_as: { set: [{ a_1: "updated", a_2: 1337 }] }
+                to_one_b: { set: { b_field: 999, b_to_many_cs: [{ c_field: 666 }] } }
               }
             ) {
-              a {
+              to_many_as {
                 a_1
                 a_2
-                b {
-                  b_field
-                  a {
-                      a_1
-                  }
-                }
               }
-              c { c_field }
+              to_one_b {
+                b_field
+                b_to_many_cs { c_field }
+              }
             }
           }"#),
-          @r###"{"data":{"updateOneTestModel":{"a":[{"a_1":"updated","a_2":1337,"b":[{"b_field":"updated","a":[{"a_1":"a_1 default"}]}]}],"c":[{"c_field":"updated"}]}}}"###
+          @r###"{"data":{"updateOneTestModel":{"to_many_as":[{"a_1":"updated","a_2":1337}],"to_one_b":{"b_field":999,"b_to_many_cs":[{"c_field":666}]}}}}"###
         );
 
         Ok(())
@@ -379,24 +376,21 @@ mod update {
             updateOneTestModel(
               where: { id: 1 }
               data: {
-                a: [{ a_1: "updated", a_2: 1337, b: { b_field: "updated", a: [{}] } }]
-                c: [{ c_field: "updated" }]
+                to_many_as: [{ a_1: "updated", a_2: 1337 }]
+                to_one_b: { b_field: 999, b_to_many_cs: [{ c_field: 666 }] }
               }
             ) {
-              a {
+              to_many_as {
                 a_1
                 a_2
-                b {
-                  b_field
-                  a {
-                      a_1
-                  }
-                }
               }
-              c { c_field }
+              to_one_b {
+                b_field
+                b_to_many_cs { c_field }
+              }
             }
           }"#),
-          @r###"{"data":{"updateOneTestModel":{"a":[{"a_1":"updated","a_2":1337,"b":[{"b_field":"updated","a":[{"a_1":"a_1 default"}]}]}],"c":[{"c_field":"updated"}]}}}"###
+          @r###"{"data":{"updateOneTestModel":{"to_many_as":[{"a_1":"updated","a_2":1337}],"to_one_b":{"b_field":999,"b_to_many_cs":[{"c_field":666}]}}}}"###
         );
 
         Ok(())
@@ -410,7 +404,7 @@ mod update {
           updateOneTestModel(
             where: { id: 1 }
             data: {
-              a: { set: [{ a_1: "updated", a_2: { update: { increment: 3 } }, b: [] }] }
+              to_many_as: { set: [{ a_1: "updated", a_2: { update: { increment: 3 } }, b: [] }] }
             }
           ) { id }
         }"#;
@@ -420,7 +414,7 @@ mod update {
           runner,
           query,
           2009,
-          "`Mutation.updateOneTestModel.data.TestModelUpdateInput.a.AListUpdateEnvelopeInput.set.ACreateInput.a_2`: Value types mismatch. Have: Object({\"update\": Object({\"increment\": Int(3)})}), want: Int"
+          "`Mutation.updateOneTestModel.data.TestModelUpdateInput.to_many_as.CompositeAListUpdateEnvelopeInput.set.CompositeACreateInput.a_2`: Value types mismatch. Have: Object({\"update\": Object({\"increment\": Int(3)})}), want: Int"
         );
 
         // Ensure `update` cannot be used in the Unchecked type
@@ -428,7 +422,7 @@ mod update {
           runner,
           query,
           2009,
-          "`Mutation.updateOneTestModel.data.TestModelUncheckedUpdateInput.a.AListUpdateEnvelopeInput.set.ACreateInput.a_2`: Value types mismatch. Have: Object({\"update\": Object({\"increment\": Int(3)})}), want: Int"
+          "`Mutation.updateOneTestModel.data.TestModelUpdateInput.to_many_as.CompositeAListUpdateEnvelopeInput.set.CompositeACreateInput.a_2`: Value types mismatch. Have: Object({\"update\": Object({\"increment\": Int(3)})}), want: Int"
         );
 
         Ok(())
@@ -444,24 +438,26 @@ mod update {
             updateOneTestModel(
               where: { id: 1 }
               data: {
-                a: { push: [{ a_1: "new item", a_2: 1337, b: { b_field: "new item", a: [] } }] }
-                c: { push: { c_field: "new item" } }
+                to_many_as: { push: [{ a_1: "new item", a_2: 1337 }] }
+                to_one_b: { upsert: {
+                  set: {}
+                  update: { b_to_many_cs: { push: { c_field: 111 } } }
+                } }
               }
             ) {
-              a {
+              to_many_as {
                 a_1
                 a_2
-                b {
-                  b_field
-                  a {
-                      a_1
-                  }
+              }
+              to_one_b {
+                b_to_many_cs {
+                  c_field
                 }
               }
-              c { c_field }
             }
-          }"#),
-          @r###"{"data":{"updateOneTestModel":{"a":[{"a_1":"a1","a_2":null,"b":[{"b_field":"b_field","a":[]}]},{"a_1":"new item","a_2":1337,"b":[{"b_field":"new item","a":[]}]}],"c":[{"c_field":"new item"}]}}}"###
+          }
+          "#),
+          @r###"{"data":{"updateOneTestModel":{"to_many_as":[{"a_1":"a1","a_2":null},{"a_1":"new item","a_2":1337}],"to_one_b":{"b_to_many_cs":[{"c_field":111}]}}}}"###
         );
 
         Ok(())
@@ -477,24 +473,21 @@ mod update {
             updateOneTestModel(
               where: { id: 1 }
               data: {
-                a: { push: [{ b: { a: [{}] } }] }
-                c: { push: {} }
+                to_many_as: { push: [{}] }
+                to_one_b: { upsert: {
+                  set: {}
+                  update: { b_to_many_cs: { push: {}} }
+                }}
               }
             ) {
-              a {
+              to_many_as {
                 a_1
                 a_2
-                b {
-                  b_field
-                  a {
-                      a_1
-                  }
-                }
               }
-              c { c_field }
+              to_one_b { b_to_many_cs { c_field } }
             }
           }"#),
-          @r###"{"data":{"updateOneTestModel":{"a":[{"a_1":"a1","a_2":null,"b":[{"b_field":"b_field","a":[]}]},{"a_1":"a_1 default","a_2":null,"b":[{"b_field":"b_field default","a":[{"a_1":"a_1 default"}]}]}],"c":[{"c_field":"c_field default"}]}}}"###
+          @r###"{"data":{"updateOneTestModel":{"to_many_as":[{"a_1":"a1","a_2":null},{"a_1":"a_1 default","a_2":null}],"to_one_b":{"b_to_many_cs":[{"c_field":10}]}}}}"###
         );
 
         Ok(())
@@ -507,12 +500,12 @@ mod update {
               field String?
               a     A       @map("top_a")
           }
-  
+
           type A {
               a_1 String @default("a_1 default") @map("a1")
               b B[]
           }
-  
+
           type B {
               b_field String   @default("b_field default")
           }"#
@@ -665,11 +658,11 @@ mod update {
             r#"mutation {
               updateOneTestModel(
                 where: { id: 1 }
-                data: { a: { unset: true } }
+                data: { to_many_as: { unset: true } }
               ) { id }
             }"#,
             2009,
-            "`Mutation.updateOneTestModel.data.TestModelUncheckedUpdateInput.a.ACreateInput.unset`: Field does not exist on enclosing type."
+            "`Mutation.updateOneTestModel.data.TestModelUncheckedUpdateInput.to_many_as.CompositeACreateInput.unset`: Field does not exist on enclosing type."
         );
 
         Ok(())
@@ -685,11 +678,11 @@ mod update {
             r#"mutation {
               updateOneTestModel(
                 where: { id: 1 }
-                data: { a: { upsert: {} } }
+                data: { to_many_as: { upsert: {} } }
               ) { id }
             }"#,
             2009,
-            "`Mutation.updateOneTestModel.data.TestModelUncheckedUpdateInput.a.ACreateInput.upsert`: Field does not exist on enclosing type."
+            "`Mutation.updateOneTestModel.data.TestModelUncheckedUpdateInput.to_many_as.CompositeACreateInput.upsert`: Field does not exist on enclosing type."
         );
 
         Ok(())
@@ -700,8 +693,8 @@ mod update {
             runner,
             r#"{
                    id: 1
-                   a: [{ a_1: "a1", a_2: null, b: { b_field: "b_field", a: [] } }]
-                   c: []
+                   to_many_as: [{ a_1: "a1", a_2: null }]
+                   to_one_b: {}
                  }"#,
         )
         .await?;

--- a/query-engine/connectors/mongodb-query-connector/src/orderby.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/orderby.rs
@@ -51,10 +51,9 @@ impl OrderByData {
 
             // We fold from right to left because the right hand side needs to be always contained
             // in the left hand side here (JoinStage<A, JoinStage<B, JoinStage<C>>>).
-            stages.reverse();
-
             let mut folded_stages = stages
                 .into_iter()
+                .rev()
                 .fold1(|right, mut left| {
                     left.push_nested(right);
                     left
@@ -72,7 +71,7 @@ impl OrderByData {
     }
 
     fn compute_prefix(index: usize, order_by: &OrderBy) -> Option<OrderByPrefix> {
-        match dbg!(order_by.path()) {
+        match order_by.path() {
             Some(path) => {
                 let mut parts = path
                     .iter()

--- a/query-engine/connectors/mongodb-query-connector/src/orderby.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/orderby.rs
@@ -39,7 +39,7 @@ impl OrderByData {
             }
         } else {
             let prefix = prefix.unwrap(); // Safe because relation hops always produce a prefix.
-            let mut stages = order_by
+            let stages = order_by
                 .path()
                 .unwrap() // Safe because relation hops always have a path.
                 .iter()

--- a/query-engine/connectors/mongodb-query-connector/src/orderby.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/orderby.rs
@@ -72,7 +72,7 @@ impl OrderByData {
     }
 
     fn compute_prefix(index: usize, order_by: &OrderBy) -> Option<OrderByPrefix> {
-        match order_by.path() {
+        match dbg!(order_by.path()) {
             Some(path) => {
                 let mut parts = path
                     .iter()

--- a/query-engine/connectors/mongodb-query-connector/src/query_builder/read_query_builder.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/query_builder/read_query_builder.rs
@@ -267,8 +267,8 @@ impl MongoReadQueryBuilder {
 
         let mut unwinds: Vec<Document> = vec![];
 
-        for nested_stage in joins {
-            let (join, unwind) = nested_stage.build();
+        for join_stage in joins {
+            let (join, unwind) = join_stage.build();
 
             if let Some(u) = unwind {
                 unwinds.push(u);

--- a/query-engine/connectors/query-connector/src/query_arguments.rs
+++ b/query-engine/connectors/query-connector/src/query_arguments.rs
@@ -74,8 +74,7 @@ impl QueryArguments {
         self.cursor.is_some()
             && self.order_by.iter().any(|o| match o {
                 OrderBy::Scalar(o) => !o.field.is_required(),
-                OrderBy::Aggregation(_) => false,
-                OrderBy::Relevance(_) => false,
+                _ => false,
             })
     }
 
@@ -115,8 +114,7 @@ impl QueryArguments {
             .iter()
             .filter_map(|o| match o {
                 OrderBy::Scalar(o) => Some(o),
-                OrderBy::Aggregation(_) => None,
-                OrderBy::Relevance(_) => None,
+                _ => None,
             })
             .collect();
 
@@ -164,8 +162,7 @@ impl QueryArguments {
     pub fn has_unbatchable_ordering(&self) -> bool {
         self.order_by.iter().any(|o| match o {
             OrderBy::Scalar(_) => false,
-            OrderBy::Aggregation(_) => true,
-            OrderBy::Relevance(_) => true,
+            _ => true,
         })
     }
 

--- a/query-engine/connectors/query-connector/src/query_arguments.rs
+++ b/query-engine/connectors/query-connector/src/query_arguments.rs
@@ -160,10 +160,7 @@ impl QueryArguments {
     }
 
     pub fn has_unbatchable_ordering(&self) -> bool {
-        self.order_by.iter().any(|o| match o {
-            OrderBy::Scalar(_) => false,
-            _ => true,
-        })
+        self.order_by.iter().any(|o| !matches!(o, OrderBy::Scalar(_)))
     }
 
     pub fn has_unbatchable_filters(&self) -> bool {

--- a/query-engine/connectors/sql-query-connector/src/cursor_condition.rs
+++ b/query-engine/connectors/sql-query-connector/src/cursor_condition.rs
@@ -363,7 +363,7 @@ fn cursor_order_def_scalar(
     order_by_def: &OrderByDefinition,
     index: usize,
 ) -> CursorOrderDefinition {
-    // If there are any ordering hop, this finds the foreign key fields for the _last_ hop (we look for the last one because the ordering is done the last one).
+    // If there are any ordering hops, this finds the foreign key fields for the _last_ hop (we look for the last one because the ordering is done the last one).
     // These fk fields are needed to check whether they are nullable
     // cf: part #2 of the SQL query above, when a field is nullable.
     let fks = foreign_keys_from_order_path(&order_by.path, &order_by_def.joins);
@@ -438,7 +438,14 @@ fn cursor_order_def_aggregation_rel(
     // Without these aliases, selecting from the <ORDER_TABLE_ALIAS> cmp table would result in ambiguous field name
     let cmp_column_alias = format!(
         "aggr_{}_{}",
-        order_by.path.iter().map(|rf| rf.model().name.to_owned()).join("_"),
+        order_by
+            .path
+            .iter()
+            .map(|hop| match hop {
+                OrderByHop::Relation(rf) => rf.model().name.to_owned(),
+                OrderByHop::Composite(_) => unreachable!("SQL connectors don't have composite support."),
+            })
+            .join("_"),
         index
     );
 
@@ -480,58 +487,60 @@ fn cursor_order_def_relevance(
     }
 }
 
-fn foreign_keys_from_order_path(
-    path: &[RelationFieldRef],
-    joins: &[AliasedJoin],
-) -> Option<Vec<CursorOrderForeignKey>> {
+fn foreign_keys_from_order_path(path: &[OrderByHop], joins: &[AliasedJoin]) -> Option<Vec<CursorOrderForeignKey>> {
     let (before_last_hop, last_hop) = take_last_two_elem(&path);
 
-    last_hop.map(|rf| {
-        rf.relation_info
-            .fields
-            .iter()
-            .map(|fk_name| {
-                let fk_field = rf.model().fields().find_from_scalar(fk_name).unwrap();
+    last_hop.map(|hop| {
+        match hop {
+            OrderByHop::Relation(rf) => {
+                rf.relation_info
+                    .fields
+                    .iter()
+                    .map(|fk_name| {
+                        let fk_field = rf.model().fields().find_from_scalar(fk_name).unwrap();
 
-                // If there are _more than one_ hop, we need to refer to the fk fields using the
-                // join alias of the hop _before_ the last hop. eg:
-                //
-                // ```sql
-                // SELECT ...
-                // FROM
-                //  "public"."ModelA"
-                //   LEFT JOIN "public"."ModelB" AS "orderby_0_ModelB" ON (
-                //     "public"."ModelA"."b_id" = "orderby_0_ModelB"."id"
-                //   )
-                //   LEFT JOIN "public"."ModelC" AS "orderby_0_ModelC" ON (
-                //     "orderby_0_ModelB"."c_id" = "orderby_0_ModelC"."id"
-                //   )
-                // WHERE
-                // ( ... OR <before_last_join_alias>.<foreign_key_db_name> IS NULL )
-                // ```
-                // In the example above, <before_last_join_alias> == "orderby_0_ModelB"
-                //                          <foreign_key_db_name> == "c_id"
-                match before_last_hop {
-                    Some(_) => {
-                        let (before_last_join, _) = take_last_two_elem(joins);
-                        let before_last_join =
-                            before_last_join.expect("There should be an equal amount of order by hops and joins");
+                        // If there are _more than one_ hop, we need to refer to the fk fields using the
+                        // join alias of the hop _before_ the last hop. eg:
+                        //
+                        // ```sql
+                        // SELECT ...
+                        // FROM
+                        //  "public"."ModelA"
+                        //   LEFT JOIN "public"."ModelB" AS "orderby_0_ModelB" ON (
+                        //     "public"."ModelA"."b_id" = "orderby_0_ModelB"."id"
+                        //   )
+                        //   LEFT JOIN "public"."ModelC" AS "orderby_0_ModelC" ON (
+                        //     "orderby_0_ModelB"."c_id" = "orderby_0_ModelC"."id"
+                        //   )
+                        // WHERE
+                        // ( ... OR <before_last_join_alias>.<foreign_key_db_name> IS NULL )
+                        // ```
+                        // In the example above, <before_last_join_alias> == "orderby_0_ModelB"
+                        //                          <foreign_key_db_name> == "c_id"
+                        match before_last_hop {
+                            Some(_) => {
+                                let (before_last_join, _) = take_last_two_elem(joins);
+                                let before_last_join = before_last_join
+                                    .expect("There should be an equal amount of order by hops and joins");
 
-                        CursorOrderForeignKey {
-                            field: fk_field,
-                            alias: Some(before_last_join.alias.to_owned()),
+                                CursorOrderForeignKey {
+                                    field: fk_field,
+                                    alias: Some(before_last_join.alias.to_owned()),
+                                }
+                            }
+                            None => {
+                                // If there is not more than one hop, then there's no need to alias the fk field
+                                CursorOrderForeignKey {
+                                    field: fk_field,
+                                    alias: None,
+                                }
+                            }
                         }
-                    }
-                    None => {
-                        // If there is not more than one hop, then there's no need to alias the fk field
-                        CursorOrderForeignKey {
-                            field: fk_field,
-                            alias: None,
-                        }
-                    }
-                }
-            })
-            .collect_vec()
+                    })
+                    .collect_vec()
+            }
+            OrderByHop::Composite(_) => unreachable!("SQL connectors don't have composite support."),
+        }
     })
 }
 

--- a/query-engine/connectors/sql-query-connector/src/ordering.rs
+++ b/query-engine/connectors/sql-query-connector/src/ordering.rs
@@ -128,7 +128,7 @@ pub fn compute_joins_aggregation(
 
     let mut joins = rest_hops
         .iter()
-        .map(|rf| compute_one2m_join(base_model, rf, join_prefix.as_str()))
+        .map(|hop| compute_one2m_join(base_model, hop.into_relation_hop().unwrap(), join_prefix.as_str()))
         .collect_vec();
 
     let aggregation_type = match order_by.sort_aggregation {
@@ -138,7 +138,7 @@ pub fn compute_joins_aggregation(
 
     // We perform the aggregation on the last join
     let last_aggr_join = compute_aggr_join(
-        last_hop,
+        last_hop.into_relation_hop().unwrap(),
         aggregation_type,
         ORDER_AGGREGATOR_ALIAS,
         join_prefix.as_str(),
@@ -163,8 +163,9 @@ pub fn compute_joins_scalar(
     let joins = order_by
         .path
         .iter()
-        .map(|rf| compute_one2m_join(base_model, rf, join_prefix.as_str()))
+        .map(|hop| compute_one2m_join(base_model, hop.into_relation_hop().unwrap(), join_prefix.as_str()))
         .collect_vec();
+
     // This is the final column identifier to be used for the scalar field to order by.
     // - If we order by a scalar field on the base model, we simply use the model's scalar field. eg:
     //   `{modelTable}.{field}`

--- a/query-engine/connectors/sql-query-connector/src/ordering.rs
+++ b/query-engine/connectors/sql-query-connector/src/ordering.rs
@@ -126,6 +126,7 @@ pub fn compute_joins_aggregation(
         .split_last()
         .expect("An order by relation aggregation has to have at least one hop");
 
+    // Unwraps are safe because the SQL connector doesn't yet support any other type of orderBy hop but the relation hop.
     let mut joins = rest_hops
         .iter()
         .map(|hop| compute_one2m_join(base_model, hop.into_relation_hop().unwrap(), join_prefix.as_str()))

--- a/query-engine/connectors/sql-query-connector/src/ordering.rs
+++ b/query-engine/connectors/sql-query-connector/src/ordering.rs
@@ -125,6 +125,7 @@ pub fn compute_joins_aggregation(
         .path
         .split_last()
         .expect("An order by relation aggregation has to have at least one hop");
+
     let mut joins = rest_hops
         .iter()
         .map(|rf| compute_one2m_join(base_model, rf, join_prefix.as_str()))
@@ -134,6 +135,7 @@ pub fn compute_joins_aggregation(
         SortAggregation::Count => AggregationType::Count,
         _ => unreachable!("Order by relation aggregation other than count are not supported"),
     };
+
     // We perform the aggregation on the last join
     let last_aggr_join = compute_aggr_join(
         last_hop,
@@ -142,6 +144,7 @@ pub fn compute_joins_aggregation(
         join_prefix.as_str(),
         joins.last(),
     );
+
     // This is the final column identifier to be used for the scalar field to order by.
     // `{last_join_alias}.{ORDER_AGGREGATOR_ALIAS}`
     let order_by_column = Column::from((last_aggr_join.alias.to_owned(), ORDER_AGGREGATOR_ALIAS.to_owned()));

--- a/query-engine/connectors/sql-query-connector/src/ordering.rs
+++ b/query-engine/connectors/sql-query-connector/src/ordering.rs
@@ -32,10 +32,10 @@ pub fn build(
         .enumerate()
         .map(|(index, order_by)| match order_by {
             OrderBy::Scalar(order_by) => build_order_scalar(order_by, base_model, needs_reversed_order, index),
-            OrderBy::Aggregation(order_by) if order_by.is_scalar_aggregation() => {
-                build_order_aggr_scalar(order_by, needs_reversed_order)
+            OrderBy::ScalarAggregation(order_by) => build_order_aggr_scalar(order_by, needs_reversed_order),
+            OrderBy::ToManyAggregation(order_by) => {
+                build_order_aggr_rel(order_by, base_model, needs_reversed_order, index)
             }
-            OrderBy::Aggregation(order_by) => build_order_aggr_rel(order_by, base_model, needs_reversed_order, index),
             OrderBy::Relevance(order_by) => build_order_relevance(order_by, needs_reversed_order),
         })
         .collect_vec()
@@ -71,9 +71,9 @@ fn build_order_relevance(order_by: &OrderByRelevance, needs_reversed_order: bool
     }
 }
 
-fn build_order_aggr_scalar(order_by: &OrderByAggregation, needs_reversed_order: bool) -> OrderByDefinition {
+fn build_order_aggr_scalar(order_by: &OrderByScalarAggregation, needs_reversed_order: bool) -> OrderByDefinition {
     let order: Option<Order> = Some(order_by.sort_order.into_order(needs_reversed_order));
-    let order_column = order_by.field.as_ref().unwrap().as_column();
+    let order_column = order_by.field.as_column();
     let order_definition: OrderDefinition = match order_by.sort_aggregation {
         SortAggregation::Count => (count(order_column.clone()).into(), order),
         SortAggregation::Avg => (avg(order_column.clone()).into(), order),
@@ -90,7 +90,7 @@ fn build_order_aggr_scalar(order_by: &OrderByAggregation, needs_reversed_order: 
 }
 
 fn build_order_aggr_rel(
-    order_by: &OrderByAggregation,
+    order_by: &OrderByToManyAggregation,
     base_model: &ModelRef,
     needs_reversed_order: bool,
     index: usize,
@@ -116,7 +116,7 @@ fn build_order_aggr_rel(
 }
 
 pub fn compute_joins_aggregation(
-    order_by: &OrderByAggregation,
+    order_by: &OrderByToManyAggregation,
     order_by_index: usize,
     base_model: &ModelRef,
 ) -> (Vec<AliasedJoin>, Column<'static>) {

--- a/query-engine/core/Cargo.toml
+++ b/query-engine/core/Cargo.toml
@@ -42,3 +42,4 @@ user-facing-errors = { path = "../../libs/user-facing-errors" }
 uuid = "0.8"
 cuid = { git = "https://github.com/prisma/cuid-rust" }
 pin-utils = "0.1"
+lazy_static = "1.4"

--- a/query-engine/core/src/query_graph_builder/extractors/query_arguments.rs
+++ b/query-engine/core/src/query_graph_builder/extractors/query_arguments.rs
@@ -122,7 +122,7 @@ fn process_order_object(
                         .expect("To-many relation orderBy must be an aggregation ordering.");
 
                     let sort_order = extract_sort_order(inner_field_value)?;
-                    Ok(Some(OrderBy::aggregation(None, path, sort_order, sort_aggregation)))
+                    Ok(Some(OrderBy::to_many_aggregation(path, sort_order, sort_aggregation)))
                 }
 
                 Field::Relation(rf) => {
@@ -137,8 +137,8 @@ fn process_order_object(
 
                     if let Some(sort_aggr) = parent_sort_aggregation {
                         // If the parent is a sort aggregation then this scalar is part of that one.
-                        Ok(Some(OrderBy::aggregation(
-                            Some(sf.clone()),
+                        Ok(Some(OrderBy::scalar_aggregation(
+                            sf.clone(),
                             vec![],
                             sort_order,
                             sort_aggr,
@@ -158,7 +158,7 @@ fn process_order_object(
                         .expect("To-many composite orderBy must be an aggregation ordering.");
 
                     let sort_order = extract_sort_order(inner_field_value)?;
-                    Ok(Some(OrderBy::aggregation(None, path, sort_order, sort_aggregation)))
+                    Ok(Some(OrderBy::to_many_aggregation(path, sort_order, sort_aggregation)))
                 }
 
                 Field::Composite(cf) => {

--- a/query-engine/core/src/query_graph_builder/extractors/query_arguments.rs
+++ b/query-engine/core/src/query_graph_builder/extractors/query_arguments.rs
@@ -34,7 +34,7 @@ pub fn extract_query_args(arguments: Vec<ParsedArgument>, model: &ModelRef) -> Q
                     }),
 
                     args::ORDER_BY => Ok(QueryArguments {
-                        order_by: extract_order_by(model, arg.value)?,
+                        order_by: extract_order_by(&model.into(), arg.value)?,
                         ..res
                     }),
 
@@ -66,18 +66,18 @@ pub fn extract_query_args(arguments: Vec<ParsedArgument>, model: &ModelRef) -> Q
 }
 
 /// Extracts order by conditions in order of appearance.
-fn extract_order_by(model: &ModelRef, value: ParsedInputValue) -> QueryGraphBuilderResult<Vec<OrderBy>> {
+fn extract_order_by(container: &ParentContainer, value: ParsedInputValue) -> QueryGraphBuilderResult<Vec<OrderBy>> {
     match value {
         ParsedInputValue::List(list) => list
             .into_iter()
             .map(|list_value| {
                 let object: ParsedInputMap = list_value.try_into()?;
-                Ok(process_order_object(model, object, vec![], None)?)
+                Ok(process_order_object(container, object, vec![], None)?)
             })
             .collect::<QueryGraphBuilderResult<Vec<_>>>()
             .map(|results| results.into_iter().flatten().collect()),
 
-        ParsedInputValue::Map(map) => Ok(match process_order_object(model, map, vec![], None)? {
+        ParsedInputValue::Map(map) => Ok(match process_order_object(container, map, vec![], None)? {
             Some(order) => vec![order],
             None => vec![],
         }),
@@ -86,11 +86,10 @@ fn extract_order_by(model: &ModelRef, value: ParsedInputValue) -> QueryGraphBuil
     }
 }
 
-#[tracing::instrument(skip(model, object, path))]
 fn process_order_object(
-    model: &ModelRef,
+    container: &ParentContainer,
     object: ParsedInputMap,
-    mut path: Vec<RelationFieldRef>,
+    mut path: Vec<OrderByHop>,
     parent_sort_aggregation: Option<SortAggregation>,
 ) -> QueryGraphBuilderResult<Option<OrderBy>> {
     match object.into_iter().next() {
@@ -99,40 +98,45 @@ fn process_order_object(
             if field_name.as_str() == ordering::UNDERSCORE_RELEVANCE {
                 let object: ParsedInputMap = field_value.try_into()?;
 
-                return extract_order_by_relevance(model, object);
+                return extract_order_by_relevance(container, object);
             }
 
-            if let Ok(sort_aggr) = extract_sort_aggregation(field_name.as_str()) {
+            if let Some(sort_aggr) = extract_sort_aggregation(field_name.as_str()) {
                 let object: ParsedInputMap = field_value.try_into()?;
 
-                return process_order_object(model, object, path, Some(sort_aggr));
+                return process_order_object(container, object, path, Some(sort_aggr));
             }
 
-            let field = model.fields().find_from_all(&field_name)?;
+            let field = container
+                .find_field(&field_name)
+                .expect("Fields must be valid after validation passed.");
 
             match field {
                 Field::Relation(rf) if rf.is_list() => {
                     let object: ParsedInputMap = field_value.try_into()?;
 
-                    path.push(rf.clone());
+                    path.push(rf.into());
 
                     let (inner_field_name, inner_field_value) = object.into_iter().next().unwrap();
-                    let sort_aggregation = extract_sort_aggregation(inner_field_name.as_str())?;
-                    let sort_order = extract_sort_order(inner_field_value)?;
+                    let sort_aggregation = extract_sort_aggregation(inner_field_name.as_str())
+                        .expect("To-many relation orderBy must be an aggregation ordering.");
 
+                    let sort_order = extract_sort_order(inner_field_value)?;
                     Ok(Some(OrderBy::aggregation(None, path, sort_order, sort_aggregation)))
                 }
+
                 Field::Relation(rf) => {
                     let object: ParsedInputMap = field_value.try_into()?;
+                    path.push((&rf).into());
 
-                    path.push(rf.clone());
-
-                    process_order_object(&rf.related_model(), object, path, None)
+                    process_order_object(&rf.related_model().into(), object, path, None)
                 }
+
                 Field::Scalar(sf) => {
                     let sort_order = extract_sort_order(field_value)?;
 
                     if let Some(sort_aggr) = parent_sort_aggregation {
+                        // If the parent is a sort aggregation then this scalar is part of that one.
                         Ok(Some(OrderBy::aggregation(
                             Some(sf.clone()),
                             vec![],
@@ -143,13 +147,35 @@ fn process_order_object(
                         Ok(Some(OrderBy::scalar(sf.clone(), path, sort_order)))
                     }
                 }
-                Field::Composite(_) => Ok(None), // [Composites] todo
+
+                Field::Composite(cf) if cf.is_list() => {
+                    let object: ParsedInputMap = field_value.try_into()?;
+
+                    path.push(cf.into());
+
+                    let (inner_field_name, inner_field_value) = object.into_iter().next().unwrap();
+                    let sort_aggregation = extract_sort_aggregation(inner_field_name.as_str())
+                        .expect("To-many composite orderBy must be an aggregation ordering.");
+
+                    let sort_order = extract_sort_order(inner_field_value)?;
+                    Ok(Some(OrderBy::aggregation(None, path, sort_order, sort_aggregation)))
+                }
+
+                Field::Composite(cf) => {
+                    let object: ParsedInputMap = field_value.try_into()?;
+                    path.push((&cf).into());
+
+                    process_order_object(&cf.typ.clone().into(), object, path, None)
+                }
             }
         }
     }
 }
 
-fn extract_order_by_relevance(model: &ModelRef, object: ParsedInputMap) -> QueryGraphBuilderResult<Option<OrderBy>> {
+fn extract_order_by_relevance(
+    container: &ParentContainer,
+    object: ParsedInputMap,
+) -> QueryGraphBuilderResult<Option<OrderBy>> {
     let sort_order = extract_sort_order(object.get(ordering::SORT).unwrap().clone())?;
     let search: PrismaValue = object.get(ordering::SEARCH).unwrap().clone().try_into()?;
     let search = search.into_string().unwrap();
@@ -168,22 +194,26 @@ fn extract_order_by_relevance(model: &ModelRef, object: ParsedInputMap) -> Query
     let fields = fields
         .into_iter()
         .map(|pv| pv.into_string().unwrap())
-        .map(|field_name| model.fields().find_from_scalar(&field_name))
+        .map(|field_name| match container.find_field(&field_name) {
+            Some(Field::Scalar(sf)) => Ok(sf),
+            _ => Err(QueryGraphBuilderError::InputError(format!(
+                "Invalid order-by reference input: Field {} is not a valid scalar field.",
+                field_name
+            ))),
+        })
         .collect::<Result<Vec<ScalarFieldRef>, _>>()?;
 
     Ok(Some(OrderBy::relevance(fields, search, sort_order)))
 }
 
-fn extract_sort_aggregation(field_name: &str) -> QueryGraphBuilderResult<SortAggregation> {
+fn extract_sort_aggregation(field_name: &str) -> Option<SortAggregation> {
     match field_name {
-        aggregations::UNDERSCORE_COUNT => Ok(SortAggregation::Count),
-        aggregations::UNDERSCORE_AVG => Ok(SortAggregation::Avg),
-        aggregations::UNDERSCORE_SUM => Ok(SortAggregation::Sum),
-        aggregations::UNDERSCORE_MIN => Ok(SortAggregation::Min),
-        aggregations::UNDERSCORE_MAX => Ok(SortAggregation::Max),
-        _ => Err(QueryGraphBuilderError::InputError(
-            "No aggregation operation could be found. This should not happen".to_string(),
-        )),
+        aggregations::UNDERSCORE_COUNT => Some(SortAggregation::Count),
+        aggregations::UNDERSCORE_AVG => Some(SortAggregation::Avg),
+        aggregations::UNDERSCORE_SUM => Some(SortAggregation::Sum),
+        aggregations::UNDERSCORE_MIN => Some(SortAggregation::Min),
+        aggregations::UNDERSCORE_MAX => Some(SortAggregation::Max),
+        _ => None,
     }
 }
 

--- a/query-engine/core/src/schema_builder/input_types/fields/arguments.rs
+++ b/query-engine/core/src/schema_builder/input_types/fields/arguments.rs
@@ -2,6 +2,7 @@ use super::*;
 use constants::args;
 use datamodel_connector::ConnectorCapability;
 use objects::*;
+use prisma_models::prelude::ParentContainer;
 
 /// Builds "where" argument.
 pub(crate) fn where_argument(ctx: &mut BuilderContext, model: &ModelRef) -> InputField {
@@ -116,7 +117,7 @@ pub(crate) fn many_records_arguments(
 
     let mut args = vec![
         where_argument(ctx, &model),
-        order_by_argument(ctx, &model, true, false, ctx.can_full_text_search()),
+        order_by_argument(ctx, &model.into(), true, false, ctx.can_full_text_search()),
         input_field(args::CURSOR, unique_input_type, None).optional(),
         input_field(args::TAKE, InputType::int(), None).optional(),
         input_field(args::SKIP, InputType::int(), None).optional(),
@@ -139,14 +140,14 @@ pub(crate) fn many_records_arguments(
 // Builds "orderBy" argument.
 pub(crate) fn order_by_argument(
     ctx: &mut BuilderContext,
-    model: &ModelRef,
+    container: &ParentContainer,
     include_relations: bool,
     include_scalar_aggregations: bool,
     include_full_text_search: bool,
 ) -> InputField {
     let order_object_type = InputType::object(order_by_objects::order_by_object_type(
         ctx,
-        model,
+        container,
         include_relations,
         include_scalar_aggregations,
         include_full_text_search,
@@ -165,7 +166,7 @@ pub(crate) fn group_by_arguments(ctx: &mut BuilderContext, model: &ModelRef) -> 
 
     vec![
         where_argument(ctx, &model),
-        order_by_argument(ctx, &model, false, true, false),
+        order_by_argument(ctx, &model.into(), false, true, false),
         input_field(
             args::BY,
             vec![InputType::list(field_enum_type.clone()), field_enum_type],

--- a/query-engine/core/src/schema_builder/input_types/fields/arguments.rs
+++ b/query-engine/core/src/schema_builder/input_types/fields/arguments.rs
@@ -1,8 +1,10 @@
+use crate::schema_builder::input_types::objects::order_by_objects::OrderByOptions;
+
 use super::*;
 use constants::args;
 use datamodel_connector::ConnectorCapability;
 use objects::*;
-use prisma_models::prelude::ParentContainer;
+use prisma_models::{prelude::ParentContainer, CompositeFieldRef};
 
 /// Builds "where" argument.
 pub(crate) fn where_argument(ctx: &mut BuilderContext, model: &ModelRef) -> InputField {
@@ -98,26 +100,40 @@ pub(crate) fn delete_many_arguments(ctx: &mut BuilderContext, model: &ModelRef) 
 }
 
 /// Builds "many records where" arguments based on the given model and field.
-pub(crate) fn many_records_field_arguments(ctx: &mut BuilderContext, field: &ModelField) -> Vec<InputField> {
+pub(crate) fn many_records_output_field_arguments(ctx: &mut BuilderContext, field: &ModelField) -> Vec<InputField> {
     match field {
         ModelField::Scalar(_) => vec![],
-        ModelField::Relation(rf) if rf.is_list() => many_records_arguments(ctx, &rf.related_model(), true),
-        ModelField::Relation(rf) if !rf.is_list() => vec![],
-        _ => vec![], // [Composites] todo
+
+        // To-many relation.
+        ModelField::Relation(rf) if rf.is_list() => relation_selection_arguments(ctx, &rf.related_model(), true),
+
+        // To-one relation.
+        ModelField::Relation(_) => vec![],
+
+        // To-many composite.
+        ModelField::Composite(cf) if cf.is_list() => composite_selection_arguments(ctx, cf),
+
+        // To-one composite.
+        ModelField::Composite(_) => vec![],
     }
 }
 
-/// Builds "many records where" arguments solely based on the given model.
-pub(crate) fn many_records_arguments(
+/// Builds "many records where" arguments for to-many relation selection sets.
+pub(crate) fn relation_selection_arguments(
     ctx: &mut BuilderContext,
     model: &ModelRef,
     include_distinct: bool,
 ) -> Vec<InputField> {
     let unique_input_type = InputType::object(filter_objects::where_unique_object_type(ctx, model));
+    let order_by_options = OrderByOptions {
+        include_relations: true,
+        include_scalar_aggregations: false,
+        include_full_text_search: ctx.can_full_text_search(),
+    };
 
     let mut args = vec![
         where_argument(ctx, &model),
-        order_by_argument(ctx, &model.into(), true, false, ctx.can_full_text_search()),
+        order_by_argument(ctx, &model.into(), &order_by_options),
         input_field(args::CURSOR, unique_input_type, None).optional(),
         input_field(args::TAKE, InputType::int(), None).optional(),
         input_field(args::SKIP, InputType::int(), None).optional(),
@@ -137,21 +153,24 @@ pub(crate) fn many_records_arguments(
     args
 }
 
+/// Builds "many composite where" arguments for to-many composite selection sets.
+pub(crate) fn composite_selection_arguments(ctx: &mut BuilderContext, cf: &CompositeFieldRef) -> Vec<InputField> {
+    let args = vec![order_by_argument(
+        ctx,
+        &(&cf.typ).into(),
+        &OrderByOptions::new().with_aggregates(),
+    )];
+
+    args
+}
+
 // Builds "orderBy" argument.
 pub(crate) fn order_by_argument(
     ctx: &mut BuilderContext,
     container: &ParentContainer,
-    include_relations: bool,
-    include_scalar_aggregations: bool,
-    include_full_text_search: bool,
+    options: &OrderByOptions,
 ) -> InputField {
-    let order_object_type = InputType::object(order_by_objects::order_by_object_type(
-        ctx,
-        container,
-        include_relations,
-        include_scalar_aggregations,
-        include_full_text_search,
-    ));
+    let order_object_type = InputType::object(order_by_objects::order_by_object_type(ctx, container, options));
 
     input_field(
         args::ORDER_BY,
@@ -166,7 +185,7 @@ pub(crate) fn group_by_arguments(ctx: &mut BuilderContext, model: &ModelRef) -> 
 
     vec![
         where_argument(ctx, &model),
-        order_by_argument(ctx, &model.into(), false, true, false),
+        order_by_argument(ctx, &model.into(), &OrderByOptions::new().with_aggregates()),
         input_field(
             args::BY,
             vec![InputType::list(field_enum_type.clone()), field_enum_type],

--- a/query-engine/core/src/schema_builder/input_types/fields/arguments.rs
+++ b/query-engine/core/src/schema_builder/input_types/fields/arguments.rs
@@ -154,14 +154,10 @@ pub(crate) fn relation_selection_arguments(
 }
 
 /// Builds "many composite where" arguments for to-many composite selection sets.
-pub(crate) fn composite_selection_arguments(ctx: &mut BuilderContext, cf: &CompositeFieldRef) -> Vec<InputField> {
-    let args = vec![order_by_argument(
-        ctx,
-        &(&cf.typ).into(),
-        &OrderByOptions::new().with_aggregates(),
-    )];
+pub(crate) fn composite_selection_arguments(_ctx: &mut BuilderContext, _cf: &CompositeFieldRef) -> Vec<InputField> {
+    //vec![order_by_argument(ctx, &(&cf.typ).into(), &OrderByOptions::new())]
 
-    args
+    vec![]
 }
 
 // Builds "orderBy" argument.

--- a/query-engine/core/src/schema_builder/input_types/objects/order_by_objects.rs
+++ b/query-engine/core/src/schema_builder/input_types/objects/order_by_objects.rs
@@ -166,8 +166,7 @@ fn orderby_field_mapper(field: &ModelField, ctx: &mut BuilderContext, options: &
         }
 
         ModelField::Composite(cf) => {
-            let composite_order_object_type =
-                order_by_object_type(ctx, &(&cf.typ).into(), &OrderByOptions::new().with_aggregates());
+            let composite_order_object_type = order_by_object_type(ctx, &(&cf.typ).into(), &OrderByOptions::new());
 
             Some(input_field(cf.name.clone(), InputType::object(composite_order_object_type), None).optional())
         }

--- a/query-engine/core/src/schema_builder/input_types/objects/order_by_objects.rs
+++ b/query-engine/core/src/schema_builder/input_types/objects/order_by_objects.rs
@@ -1,28 +1,37 @@
 use super::*;
 use constants::{aggregations, ordering};
 use itertools::Itertools;
+use lazy_static::lazy_static;
 use output_types::aggregation;
+use prisma_models::prelude::ParentContainer;
 
-/// Builds "<Model>OrderByInput" object types.
-#[tracing::instrument(skip(ctx, model, include_relations))]
+lazy_static! {
+    static ref SORT_ORDER_ENUM: Arc<EnumType> = Arc::new(string_enum_type(
+        ordering::SORT_ORDER,
+        vec![ordering::ASC.to_owned(), ordering::DESC.to_owned()],
+    ));
+}
+
+/// Builds "<Container>OrderBy<Suffixes>Input" object types.
 pub(crate) fn order_by_object_type(
     ctx: &mut BuilderContext,
-    model: &ModelRef,
+    container: &ParentContainer,
+    // model: &ModelRef,
     include_relations: bool,
     include_scalar_aggregations: bool,
     include_full_text_search: bool,
 ) -> InputObjectTypeWeakRef {
-    let enum_type = Arc::new(string_enum_type(
-        ordering::SORT_ORDER,
-        vec![ordering::ASC.to_owned(), ordering::DESC.to_owned()],
-    ));
     let ident_suffix = match (include_relations, include_scalar_aggregations, include_full_text_search) {
         (true, false, false) => "WithRelation",
         (false, true, false) => "WithAggregation",
         (true, false, true) => "WithRelationAndSearchRelevance",
-        _ => unreachable!("Invalid combination of parameters"),
+        _ => "",
     };
-    let ident = Identifier::new(format!("{}OrderBy{}Input", model.name, ident_suffix), PRISMA_NAMESPACE);
+
+    let ident = Identifier::new(
+        format!("{}OrderBy{}Input", container.name(), ident_suffix),
+        PRISMA_NAMESPACE,
+    );
     return_cached_input!(ctx, &ident);
 
     let mut input_object = init_input_object_type(ident.clone());
@@ -31,112 +40,142 @@ pub(crate) fn order_by_object_type(
     let input_object = Arc::new(input_object);
     ctx.cache_input_type(ident, input_object.clone());
 
-    let mut fields = model
+    // Basic orderBy fields.
+    let mut fields: Vec<_> = container
         .fields()
-        .all
         .iter()
-        .filter_map(|field| match field {
-            ModelField::Relation(rf) if rf.is_list() && include_relations => {
-                let related_model = rf.related_model();
-                let related_object_type = order_by_object_type_rel_aggregate(ctx, &related_model, &enum_type);
-
-                Some(input_field(rf.name.clone(), InputType::object(related_object_type), None).optional())
-            }
-            ModelField::Relation(rf) if include_relations => {
-                let related_model = rf.related_model();
-                let related_object_type = order_by_object_type(
-                    ctx,
-                    &related_model,
-                    include_relations,
-                    include_scalar_aggregations,
-                    include_full_text_search,
-                );
-
-                Some(input_field(rf.name.clone(), InputType::object(related_object_type), None).optional())
-            }
-            ModelField::Scalar(sf) => {
-                Some(input_field(sf.name.clone(), InputType::Enum(enum_type.clone()), None).optional())
-            }
-            _ => None,
+        .filter_map(|field| {
+            orderby_field_mapper(
+                field,
+                ctx,
+                include_relations,
+                include_scalar_aggregations,
+                include_full_text_search,
+            )
         })
         .collect();
 
     if include_scalar_aggregations {
-        // Fields used in aggregations
-        let non_list_nor_json_fields = aggregation::collect_non_list_nor_json_fields(model);
-        let numeric_fields = aggregation::collect_numeric_fields(model);
-
-        append_opt(
-            &mut fields,
-            order_by_field_aggregate(
-                aggregations::UNDERSCORE_COUNT,
-                "Count",
-                ctx,
-                model,
-                &enum_type,
-                model.fields().scalar(),
-            ),
-        );
-        append_opt(
-            &mut fields,
-            order_by_field_aggregate(
-                aggregations::UNDERSCORE_AVG,
-                "Avg",
-                ctx,
-                model,
-                &enum_type,
-                numeric_fields.clone(),
-            ),
-        );
-        append_opt(
-            &mut fields,
-            order_by_field_aggregate(
-                aggregations::UNDERSCORE_MAX,
-                "Max",
-                ctx,
-                model,
-                &enum_type,
-                non_list_nor_json_fields.clone(),
-            ),
-        );
-        append_opt(
-            &mut fields,
-            order_by_field_aggregate(
-                aggregations::UNDERSCORE_MIN,
-                "Min",
-                ctx,
-                model,
-                &enum_type,
-                non_list_nor_json_fields,
-            ),
-        );
-        append_opt(
-            &mut fields,
-            order_by_field_aggregate(
-                aggregations::UNDERSCORE_SUM,
-                "Sum",
-                ctx,
-                model,
-                &enum_type,
-                numeric_fields,
-            ),
-        );
+        // orderBy Fields for aggregation orderings.
+        fields.extend(compute_scalar_aggregation_fields(ctx, container));
     }
 
     if include_full_text_search {
-        append_opt(&mut fields, order_by_field_text_search(ctx, model, &enum_type))
+        // orderBy Fields for full text searches.
+        append_opt(
+            &mut fields,
+            order_by_field_text_search(ctx, container, &SORT_ORDER_ENUM),
+        )
     }
 
     input_object.set_fields(fields);
     Arc::downgrade(&input_object)
 }
 
+fn compute_scalar_aggregation_fields(ctx: &mut BuilderContext, container: &ParentContainer) -> Vec<InputField> {
+    let non_list_nor_json_fields = aggregation::collect_non_list_nor_json_fields(container);
+    let numeric_fields = aggregation::collect_numeric_fields(container);
+    let scalar_fields = container
+        .fields()
+        .into_iter()
+        .flat_map(ModelField::into_scalar)
+        .collect::<Vec<ScalarFieldRef>>();
+
+    let mut fields = vec![];
+
+    fields.push(order_by_field_aggregate(
+        aggregations::UNDERSCORE_COUNT,
+        "Count",
+        ctx,
+        container,
+        scalar_fields,
+    ));
+
+    fields.push(order_by_field_aggregate(
+        aggregations::UNDERSCORE_AVG,
+        "Avg",
+        ctx,
+        container,
+        numeric_fields.clone(),
+    ));
+
+    fields.push(order_by_field_aggregate(
+        aggregations::UNDERSCORE_MAX,
+        "Max",
+        ctx,
+        container,
+        non_list_nor_json_fields.clone(),
+    ));
+
+    fields.push(order_by_field_aggregate(
+        aggregations::UNDERSCORE_MIN,
+        "Min",
+        ctx,
+        container,
+        non_list_nor_json_fields,
+    ));
+
+    fields.push(order_by_field_aggregate(
+        aggregations::UNDERSCORE_SUM,
+        "Sum",
+        ctx,
+        container,
+        numeric_fields,
+    ));
+
+    fields.into_iter().flatten().collect()
+}
+
+fn orderby_field_mapper(
+    field: &ModelField,
+    ctx: &mut BuilderContext,
+    include_relations: bool,
+    include_scalar_aggregations: bool,
+    include_full_text_search: bool,
+) -> Option<InputField> {
+    match field {
+        // To-many relation field.
+        ModelField::Relation(rf) if rf.is_list() && include_relations => {
+            let related_model = rf.related_model();
+            let related_object_type = order_by_object_type_rel_aggregate(ctx, &related_model, &SORT_ORDER_ENUM);
+
+            Some(input_field(rf.name.clone(), InputType::object(related_object_type), None).optional())
+        }
+
+        // To-one relation field.
+        ModelField::Relation(rf) if include_relations => {
+            let related_model = rf.related_model();
+            let related_object_type = order_by_object_type(
+                ctx,
+                &related_model.into(),
+                include_relations,
+                include_scalar_aggregations,
+                include_full_text_search,
+            );
+
+            Some(input_field(rf.name.clone(), InputType::object(related_object_type), None).optional())
+        }
+
+        // Scalar field.
+        ModelField::Scalar(sf) => {
+            Some(input_field(sf.name.clone(), InputType::Enum(SORT_ORDER_ENUM.clone()), None).optional())
+        }
+
+        // Composite field.
+        ModelField::Composite(cf) => {
+            let composite_order_object_type = order_by_object_type(ctx, &(&cf.typ).into(), false, true, false);
+            Some(input_field(cf.name.clone(), InputType::object(composite_order_object_type), None).optional())
+        }
+
+        _ => None,
+    }
+}
+
 fn order_by_field_aggregate(
     name: &str,
     suffix: &str,
     ctx: &mut BuilderContext,
-    model: &ModelRef,
-    ordering_enum: &Arc<EnumType>,
+    container: &ParentContainer,
     scalar_fields: Vec<ScalarFieldRef>,
 ) -> Option<InputField> {
     if scalar_fields.is_empty() {
@@ -145,13 +184,7 @@ fn order_by_field_aggregate(
         Some(
             input_field(
                 name,
-                InputType::object(order_by_object_type_aggregate(
-                    suffix,
-                    ctx,
-                    model,
-                    ordering_enum,
-                    scalar_fields,
-                )),
+                InputType::object(order_by_object_type_aggregate(suffix, ctx, container, scalar_fields)),
                 None,
             )
             .optional(),
@@ -162,12 +195,11 @@ fn order_by_field_aggregate(
 fn order_by_object_type_aggregate(
     suffix: &str,
     ctx: &mut BuilderContext,
-    model: &ModelRef,
-    ordering_enum: &Arc<EnumType>,
+    container: &ParentContainer,
     scalar_fields: Vec<ScalarFieldRef>,
 ) -> InputObjectTypeWeakRef {
     let ident = Identifier::new(
-        format!("{}{}OrderByAggregateInput", model.name, suffix),
+        format!("{}{}OrderByAggregateInput", container.name(), suffix),
         PRISMA_NAMESPACE,
     );
 
@@ -181,7 +213,7 @@ fn order_by_object_type_aggregate(
 
     let fields = scalar_fields
         .iter()
-        .map(|sf| input_field(sf.name.clone(), InputType::Enum(ordering_enum.clone()), None).optional())
+        .map(|sf| input_field(sf.name.clone(), InputType::Enum(SORT_ORDER_ENUM.clone()), None).optional())
         .collect();
 
     input_object.set_fields(fields);
@@ -217,14 +249,16 @@ fn order_by_object_type_rel_aggregate(
 
 fn order_by_field_text_search(
     ctx: &mut BuilderContext,
-    model: &ModelRef,
+    container: &ParentContainer,
     enum_type: &Arc<EnumType>,
 ) -> Option<InputField> {
-    let scalar_fields: Vec<_> = model
+    let scalar_fields: Vec<_> = container
         .fields()
-        .scalar()
         .into_iter()
-        .filter(|sf| sf.type_identifier == TypeIdentifier::String)
+        .filter_map(|field| match field {
+            ModelField::Scalar(sf) if sf.type_identifier == TypeIdentifier::String => Some(sf),
+            _ => None,
+        })
         .collect();
 
     if scalar_fields.is_empty() {
@@ -233,7 +267,12 @@ fn order_by_field_text_search(
         Some(
             input_field(
                 ordering::UNDERSCORE_RELEVANCE,
-                InputType::object(order_by_object_type_text_search(ctx, model, scalar_fields, &enum_type)),
+                InputType::object(order_by_object_type_text_search(
+                    ctx,
+                    container,
+                    scalar_fields,
+                    &enum_type,
+                )),
                 None,
             )
             .optional(),
@@ -243,11 +282,11 @@ fn order_by_field_text_search(
 
 fn order_by_object_type_text_search(
     ctx: &mut BuilderContext,
-    model: &ModelRef,
+    container: &ParentContainer,
     scalar_fields: Vec<ScalarFieldRef>,
     order_enum_type: &Arc<EnumType>,
 ) -> InputObjectTypeWeakRef {
-    let ident = Identifier::new(format!("{}OrderByRelevanceInput", model.name), PRISMA_NAMESPACE);
+    let ident = Identifier::new(format!("{}OrderByRelevanceInput", container.name()), PRISMA_NAMESPACE);
 
     return_cached_input!(ctx, &ident);
 
@@ -255,7 +294,7 @@ fn order_by_object_type_text_search(
     ctx.cache_input_type(ident, input_object.clone());
 
     let fields_enum_type = InputType::enum_type(Arc::new(string_enum_type(
-        format!("{}OrderByRelevanceFieldEnum", model.name),
+        format!("{}OrderByRelevanceFieldEnum", container.name()),
         scalar_fields.iter().map(|sf| sf.name.clone()).collect_vec(),
     )));
     let mut fields = vec![];

--- a/query-engine/core/src/schema_builder/input_types/objects/order_by_objects.rs
+++ b/query-engine/core/src/schema_builder/input_types/objects/order_by_objects.rs
@@ -65,7 +65,11 @@ pub(crate) fn order_by_object_type(
     let mut fields: Vec<_> = container
         .fields()
         .iter()
-        .filter_map(|field| orderby_field_mapper(field, ctx, options))
+        .filter_map(|field| match field {
+            // We exclude composites if we're in aggregations land (groupBy).
+            ModelField::Composite(_) if options.include_scalar_aggregations => None,
+            _ => orderby_field_mapper(field, ctx, options),
+        })
         .collect();
 
     if options.include_scalar_aggregations {

--- a/query-engine/core/src/schema_builder/output_types/aggregation/group_by.rs
+++ b/query-engine/core/src/schema_builder/output_types/aggregation/group_by.rs
@@ -14,11 +14,11 @@ pub(crate) fn group_by_output_object_type(ctx: &mut BuilderContext, model: &Mode
     let object = Arc::new(ObjectType::new(ident.clone(), Some(ModelRef::clone(model))));
 
     // Model fields that can be grouped by value.
-    let mut object_fields = scalar_fields(ctx, model);
+    let mut object_fields = scalar_output_fields(ctx, model);
 
     // Fields used in aggregations
-    let non_list_nor_json_fields = collect_non_list_nor_json_fields(model);
-    let numeric_fields = collect_numeric_fields(model);
+    let non_list_nor_json_fields = collect_non_list_nor_json_fields(&model.into());
+    let numeric_fields = collect_numeric_fields(&model.into());
 
     // Count is available on all fields.
     append_opt(
@@ -95,7 +95,7 @@ pub(crate) fn group_by_output_object_type(ctx: &mut BuilderContext, model: &Mode
     ObjectTypeStrongRef::downgrade(&object)
 }
 
-fn scalar_fields(ctx: &mut BuilderContext, model: &ModelRef) -> Vec<OutputField> {
+fn scalar_output_fields(ctx: &mut BuilderContext, model: &ModelRef) -> Vec<OutputField> {
     let fields = model.fields().scalar();
 
     fields

--- a/query-engine/core/src/schema_builder/output_types/aggregation/mod.rs
+++ b/query-engine/core/src/schema_builder/output_types/aggregation/mod.rs
@@ -1,5 +1,5 @@
 use super::*;
-use prisma_models::ScalarFieldRef;
+use prisma_models::{prelude::ParentContainer, ScalarFieldRef};
 
 pub(crate) mod group_by;
 pub(crate) mod plain;
@@ -12,21 +12,25 @@ fn field_avg_output_type(ctx: &mut BuilderContext, field: &ScalarFieldRef) -> Ou
     }
 }
 
-pub fn collect_non_list_nor_json_fields(model: &ModelRef) -> Vec<ScalarFieldRef> {
-    model
+pub fn collect_non_list_nor_json_fields(container: &ParentContainer) -> Vec<ScalarFieldRef> {
+    container
         .fields()
-        .scalar()
         .into_iter()
-        .filter(|f| !f.is_list() && f.type_identifier != TypeIdentifier::Json)
+        .filter_map(|field| match field {
+            ModelField::Scalar(sf) if !sf.is_list() && sf.type_identifier != TypeIdentifier::Json => Some(sf),
+            _ => None,
+        })
         .collect()
 }
 
-pub fn collect_numeric_fields(model: &ModelRef) -> Vec<ScalarFieldRef> {
-    model
+pub fn collect_numeric_fields(container: &ParentContainer) -> Vec<ScalarFieldRef> {
+    container
         .fields()
-        .scalar()
         .into_iter()
-        .filter(|field| field.is_numeric())
+        .filter_map(|field| match field {
+            ModelField::Scalar(sf) if sf.is_numeric() => Some(sf),
+            _ => None,
+        })
         .collect()
 }
 

--- a/query-engine/core/src/schema_builder/output_types/aggregation/plain.rs
+++ b/query-engine/core/src/schema_builder/output_types/aggregation/plain.rs
@@ -12,8 +12,8 @@ pub(crate) fn aggregation_object_type(ctx: &mut BuilderContext, model: &ModelRef
     let object = ObjectTypeStrongRef::new(ObjectType::new(ident.clone(), Some(ModelRef::clone(model))));
     let mut object_fields = vec![];
 
-    let non_list_nor_json_fields = collect_non_list_nor_json_fields(model);
-    let numeric_fields = collect_numeric_fields(model);
+    let non_list_nor_json_fields = collect_non_list_nor_json_fields(&model.into());
+    let numeric_fields = collect_numeric_fields(&model.into());
 
     // Count is available on all fields.
     append_opt(

--- a/query-engine/core/src/schema_builder/output_types/field.rs
+++ b/query-engine/core/src/schema_builder/output_types/field.rs
@@ -2,10 +2,10 @@ use super::*;
 use input_types::fields::arguments;
 use prisma_models::{CompositeFieldRef, ScalarFieldRef};
 
-pub(crate) fn map_field(ctx: &mut BuilderContext, model_field: &ModelField) -> OutputField {
+pub(crate) fn map_output_field(ctx: &mut BuilderContext, model_field: &ModelField) -> OutputField {
     field(
         model_field.name(),
-        arguments::many_records_field_arguments(ctx, &model_field),
+        arguments::many_records_output_field_arguments(ctx, &model_field),
         map_field_output_type(ctx, &model_field),
         None,
     )

--- a/query-engine/core/src/schema_builder/output_types/objects/composite.rs
+++ b/query-engine/core/src/schema_builder/output_types/objects/composite.rs
@@ -37,5 +37,9 @@ pub(crate) fn map_type(ctx: &mut BuilderContext, ct: &CompositeTypeRef) -> Objec
 /// Computes composite output type fields.
 /// Requires an initialized cache.
 fn compute_composite_object_type_fields(ctx: &mut BuilderContext, composite: &CompositeTypeRef) -> Vec<OutputField> {
-    composite.fields().iter().map(|f| field::map_field(ctx, f)).collect()
+    composite
+        .fields()
+        .iter()
+        .map(|f| field::map_output_field(ctx, f))
+        .collect()
 }

--- a/query-engine/core/src/schema_builder/output_types/objects/model.rs
+++ b/query-engine/core/src/schema_builder/output_types/objects/model.rs
@@ -55,5 +55,10 @@ pub(crate) fn map_type(ctx: &mut BuilderContext, model: &ModelRef) -> ObjectType
 /// Computes model output type fields.
 /// Requires an initialized cache.
 fn compute_model_object_type_fields(ctx: &mut BuilderContext, model: &ModelRef) -> Vec<OutputField> {
-    model.fields().all.iter().map(|f| field::map_field(ctx, f)).collect()
+    model
+        .fields()
+        .all
+        .iter()
+        .map(|f| field::map_output_field(ctx, f))
+        .collect()
 }

--- a/query-engine/core/src/schema_builder/output_types/query_type.rs
+++ b/query-engine/core/src/schema_builder/output_types/query_type.rs
@@ -55,7 +55,7 @@ fn find_unique_field(ctx: &mut BuilderContext, model: &ModelRef) -> Option<Outpu
 
 /// Builds a find first item field for given model.
 fn find_first_field(ctx: &mut BuilderContext, model: &ModelRef) -> OutputField {
-    let args = arguments::many_records_arguments(ctx, &model, true);
+    let args = arguments::relation_selection_arguments(ctx, &model, true);
     let field_name = format!("findFirst{}", model.name);
 
     field(
@@ -72,7 +72,7 @@ fn find_first_field(ctx: &mut BuilderContext, model: &ModelRef) -> OutputField {
 
 /// Builds a "multiple" query arity items field (e.g. "users", "posts", ...) for given model.
 fn all_items_field(ctx: &mut BuilderContext, model: &ModelRef) -> OutputField {
-    let args = arguments::many_records_arguments(ctx, &model, true);
+    let args = arguments::relation_selection_arguments(ctx, &model, true);
     let field_name = ctx.pluralize_internal(camel_case(pluralize(&model.name)), format!("findMany{}", model.name));
     let object_type = objects::model::map_type(ctx, &model);
 
@@ -91,7 +91,7 @@ fn all_items_field(ctx: &mut BuilderContext, model: &ModelRef) -> OutputField {
 fn plain_aggregation_field(ctx: &mut BuilderContext, model: &ModelRef) -> OutputField {
     field(
         format!("aggregate{}", model.name),
-        arguments::many_records_arguments(ctx, &model, false),
+        arguments::relation_selection_arguments(ctx, &model, false),
         OutputType::object(aggregation::plain::aggregation_object_type(ctx, &model)),
         Some(QueryInfo {
             model: Some(Arc::clone(&model)),

--- a/query-engine/prisma-models/src/field/mod.rs
+++ b/query-engine/prisma-models/src/field/mod.rs
@@ -50,7 +50,7 @@ impl Field {
 
     pub fn into_scalar(self) -> Option<ScalarFieldRef> {
         match self {
-            Field::Scalar(sf) => Some(sf.clone()),
+            Field::Scalar(sf) => Some(sf),
             _ => None,
         }
     }

--- a/query-engine/prisma-models/src/field/mod.rs
+++ b/query-engine/prisma-models/src/field/mod.rs
@@ -48,6 +48,13 @@ impl Field {
         matches!(self, Self::Composite(_))
     }
 
+    pub fn into_scalar(self) -> Option<ScalarFieldRef> {
+        match self {
+            Field::Scalar(sf) => Some(sf.clone()),
+            _ => None,
+        }
+    }
+
     pub fn is_id(&self) -> bool {
         match self {
             Field::Scalar(sf) => sf.is_id,

--- a/query-engine/prisma-models/src/order_by.rs
+++ b/query-engine/prisma-models/src/order_by.rs
@@ -71,30 +71,6 @@ impl OrderBy {
         }
     }
 
-    // /// Returns only relation hops from the orderBy path.
-    // pub fn relation_path(&self) -> Vec<OrderByHop> {
-    //     self.path()
-    //         .into_iter()
-    //         .filter(|hop| matches!(hop, OrderByHop::Relation(_)))
-    //         .collect()
-    // }
-
-    // pub fn has_middle_to_one_relation_path(&self) -> bool {
-    //     let path = self.path();
-    //     let len = path.len();
-
-    //     if len < 2 {
-    //         false
-    //     } else {
-    //         path.get(len - 2)
-    //             .map(|hop| match hop {
-    //                 OrderByHop::Relation(rf) => !rf.is_list(),
-    //                 OrderByHop::Composite(_) => unreachable!("Found non-relation hop in relation-only list."),
-    //             })
-    //             .unwrap_or(false)
-    //     }
-    // }
-
     pub fn scalar(field: ScalarFieldRef, path: Vec<OrderByHop>, sort_order: SortOrder) -> Self {
         Self::Scalar(OrderByScalar {
             field,

--- a/query-engine/prisma-models/src/order_by.rs
+++ b/query-engine/prisma-models/src/order_by.rs
@@ -37,12 +37,12 @@ pub enum OrderBy {
 }
 
 impl OrderBy {
-    pub fn path(&self) -> Vec<OrderByHop> {
+    pub fn path(&self) -> Option<&[OrderByHop]> {
         match self {
-            OrderBy::Scalar(o) => o.path.clone(),
-            OrderBy::ScalarAggregation(o) => o.path.clone(),
-            OrderBy::ToManyAggregation(o) => o.path.clone(),
-            OrderBy::Relevance(_) => vec![],
+            OrderBy::Scalar(o) => Some(&o.path),
+            OrderBy::ScalarAggregation(o) => Some(&o.path),
+            OrderBy::ToManyAggregation(o) => Some(&o.path),
+            OrderBy::Relevance(_) => None,
         }
     }
 
@@ -64,29 +64,36 @@ impl OrderBy {
         }
     }
 
-    /// Returns only relation hops from the orderBy path.
-    pub fn relation_path(&self) -> Vec<OrderByHop> {
-        self.path()
-            .into_iter()
-            .filter(|hop| matches!(hop, OrderByHop::Relation(_)))
-            .collect()
-    }
-
-    pub fn has_middle_to_one_relation_path(&self) -> bool {
-        let path = self.path();
-        let len = path.len();
-
-        if len < 2 {
-            false
-        } else {
-            path.get(len - 2)
-                .map(|hop| match hop {
-                    OrderByHop::Relation(rf) => !rf.is_list(),
-                    OrderByHop::Composite(_) => unreachable!("Found non-relation hop in relation-only list."),
-                })
-                .unwrap_or(false)
+    pub fn contains_relation_hops(&self) -> bool {
+        match self.path() {
+            Some(path) => path.iter().any(|hop| matches!(hop, &OrderByHop::Relation(_))),
+            None => false,
         }
     }
+
+    // /// Returns only relation hops from the orderBy path.
+    // pub fn relation_path(&self) -> Vec<OrderByHop> {
+    //     self.path()
+    //         .into_iter()
+    //         .filter(|hop| matches!(hop, OrderByHop::Relation(_)))
+    //         .collect()
+    // }
+
+    // pub fn has_middle_to_one_relation_path(&self) -> bool {
+    //     let path = self.path();
+    //     let len = path.len();
+
+    //     if len < 2 {
+    //         false
+    //     } else {
+    //         path.get(len - 2)
+    //             .map(|hop| match hop {
+    //                 OrderByHop::Relation(rf) => !rf.is_list(),
+    //                 OrderByHop::Composite(_) => unreachable!("Found non-relation hop in relation-only list."),
+    //             })
+    //             .unwrap_or(false)
+    //     }
+    // }
 
     pub fn scalar(field: ScalarFieldRef, path: Vec<OrderByHop>, sort_order: SortOrder) -> Self {
         Self::Scalar(OrderByScalar {

--- a/query-engine/prisma-models/src/parent_container.rs
+++ b/query-engine/prisma-models/src/parent_container.rs
@@ -46,6 +46,13 @@ impl ParentContainer {
         }
     }
 
+    pub fn fields(&self) -> Vec<Field> {
+        match self {
+            ParentContainer::Model(model) => model.upgrade().unwrap().fields().all.clone(),
+            ParentContainer::CompositeType(composite) => composite.upgrade().unwrap().fields().to_vec(),
+        }
+    }
+
     pub fn find_field(&self, prisma_name: &str) -> Option<Field> {
         // Unwraps are safe: This can never fail, the models and composites are always available in memory.
         match self {
@@ -82,9 +89,21 @@ impl From<&ModelRef> for ParentContainer {
     }
 }
 
+impl From<ModelRef> for ParentContainer {
+    fn from(model: ModelRef) -> Self {
+        Self::Model(Arc::downgrade(&model))
+    }
+}
+
 impl From<ModelWeakRef> for ParentContainer {
     fn from(model: ModelWeakRef) -> Self {
         Self::Model(model)
+    }
+}
+
+impl From<CompositeTypeRef> for ParentContainer {
+    fn from(composite: CompositeTypeRef) -> Self {
+        Self::CompositeType(Arc::downgrade(&composite))
     }
 }
 

--- a/query-engine/prisma-models/src/record.rs
+++ b/query-engine/prisma-models/src/record.rs
@@ -71,8 +71,9 @@ impl ManyRecords {
                         SortOrder::Descending => b.values[index].cmp(&a.values[index]),
                     }
                 }
-                OrderBy::Aggregation(_) => todo!(),
-                OrderBy::Relevance(_) => todo!(),
+                OrderBy::ScalarAggregation(_) => unimplemented!(),
+                OrderBy::ToManyAggregation(_) => unimplemented!(),
+                OrderBy::Relevance(_) => unimplemented!(),
             });
 
             orderings


### PR DESCRIPTION
### Overview
Expands `orderBy` capabilities to include ordering by composite fields.

- Over to-one composites:
```graphql
query { findManyTestModel(orderBy: { to_one_composite: { field: asc } }) { id } }
```

- Over a to-many composite aggregation (count):
```graphql
query { findManyTestModel(orderBy: { to_many_composite: { _count: asc } }) { id } }
```

- Over to-one relation: Order by to-one or to-many composite (aggregation):
```graphql
query { findManyTestModel(orderBy: { to_one_rel: { to_one_composite: { field: asc } } }) { id } }
```

- Ordering a to-many relation by their composite fields:
```graphql
query {
    findManyTestModel {
        id
        to_many_relation(orderBy: { to_one_composite: { field: asc } }) {
            id
            to_one_composite {
                field
            }
        }
    }
}
```

### What is not included
- Order by to-many composite selection:
```graphql
query {
  findManyModels {
  	to_many_composites(orderBy: { field: asc }) {
      field
    }
  }
}
```

- Order by scalar aggregation for `groupBy`.
```graphql
query {
  groupByModel(by: [field], orderBy: { to_many_composite: { field: asc} }) {
    _sum {
      field
    }
  }
}

```