### PR TITLE
fix(me): CockroachDB migrations, a new connector is like a box of chocolate

### DIFF
--- a/.github/workflows/migration-engine.yml
+++ b/.github/workflows/migration-engine.yml
@@ -136,14 +136,15 @@ jobs:
           TEST_DATABASE_URL: ${{ matrix.database.url }}
 
       - run: cargo test -p migration-engine-tests
-        if: ${{ !matrix.database.is_cockroach && !matrix.database.single_threaded }}
+        if: ${{ !matrix.database.single_threaded }}
+        continue-on-error: ${{ matrix.database.is_cockroach || false }}
         env:
           CLICOLOR_FORCE: 1
           TEST_DATABASE_URL: ${{ matrix.database.url }}
           RUST_LOG: debug
 
       - run: cargo test -p migration-engine-cli
-        if: ${{ !matrix.database.is_cockroach && !matrix.database.single_threaded }}
+        if: ${{ !matrix.database.single_threaded }}
         env:
           CLICOLOR_FORCE: 1
           TEST_DATABASE_URL: ${{ matrix.database.url }}

--- a/migration-engine/cli/tests/cli_tests.rs
+++ b/migration-engine/cli/tests/cli_tests.rs
@@ -310,7 +310,7 @@ fn basic_jsonrpc_roundtrip_works(_api: TestApi) {
         let mut response = String::new();
         stdout.read_line(&mut response).unwrap();
 
-        assert!(response.contains("PostgreSQL"));
+        assert!(response.contains("PostgreSQL") || response.contains("CockroachDB"));
     }
 
     process.kill().unwrap();

--- a/migration-engine/connectors/sql-migration-connector/src/apply_migration.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/apply_migration.rs
@@ -166,6 +166,7 @@ fn render_raw_sql(
         SqlMigrationStep::CreateIndex {
             table_id: (_, table_id),
             index_index,
+            from_drop_and_recreate: _,
         } => vec![renderer.render_create_index(&schemas.next().table_walker_at(*table_id).index_at(*index_index))],
         SqlMigrationStep::DropIndex { table_id, index_index } => {
             vec![renderer.render_drop_index(&schemas.previous().table_walker_at(*table_id).index_at(*index_index))]

--- a/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_database_step_applier.rs
@@ -163,6 +163,7 @@ fn render_raw_sql(
         SqlMigrationStep::CreateIndex {
             table_id: (_, table_id),
             index_index,
+            from_drop_and_recreate: _,
         } => vec![renderer.render_create_index(&schemas.next().table_walker_at(*table_id).index_at(*index_index))],
         SqlMigrationStep::DropIndex { table_id, index_index } => {
             vec![renderer.render_drop_index(&schemas.previous().table_walker_at(*table_id).index_at(*index_index))]

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker.rs
@@ -243,6 +243,7 @@ impl SqlMigrationConnector {
                 SqlMigrationStep::CreateIndex {
                     table_id: (Some(_), table_id),
                     index_index,
+                    from_drop_and_recreate: false,
                 } => {
                     let index = schemas.next().table_walker_at(*table_id).index_at(*index_index);
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_migration.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_migration.rs
@@ -281,12 +281,8 @@ impl SqlMigration {
                             }
                             TableChange::DropAndRecreateColumn { column_id, changes } => {
                                 out.push_str("  [*] Column `");
-                                write!(
-                                    out,
-                                    "{}` would be dropped and recreated",
-                                    tables.next().column_at(*column_id.next()).name(),
-                                )
-                                .unwrap();
+                                out.push_str(tables.next().column_at(*column_id.next()).name());
+                                out.push_str("` would be dropped and recreated ");
                                 render_column_changes(tables.columns(column_id), changes, &mut out);
                                 out.push('\n');
                             }
@@ -338,6 +334,7 @@ impl SqlMigration {
                 SqlMigrationStep::CreateIndex {
                     table_id: (_, table_id),
                     index_index,
+                    from_drop_and_recreate: _,
                 } => {
                     let index = self.schemas().next().table_walker_at(*table_id).index_at(*index_index);
 
@@ -458,6 +455,7 @@ pub(crate) enum SqlMigrationStep {
     CreateIndex {
         table_id: (Option<TableId>, TableId),
         index_index: usize,
+        from_drop_and_recreate: bool,
     },
     RenameForeignKey {
         table_id: Pair<TableId>,

--- a/migration-engine/connectors/sql-migration-connector/src/sql_migration_persistence.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_migration_persistence.rs
@@ -14,9 +14,7 @@ impl MigrationPersistence for SqlMigrationConnector {
     }
 
     async fn initialize(&mut self) -> ConnectorResult<()> {
-        dbg!("here");
         let schema = self.flavour.describe_schema().await?;
-        dbg!("here");
 
         if schema
             .tables

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
@@ -59,6 +59,7 @@ fn push_created_table_steps(steps: &mut Vec<SqlMigrationStep>, db: &DifferDataba
                 .map(|index| SqlMigrationStep::CreateIndex {
                     table_id: (None, index.table().table_id()),
                     index_index: index.index(),
+                    from_drop_and_recreate: false,
                 });
 
             steps.extend(create_indexes_from_created_tables);
@@ -297,6 +298,7 @@ fn push_created_index_steps(steps: &mut Vec<SqlMigrationStep>, db: &DifferDataba
             steps.push(SqlMigrationStep::CreateIndex {
                 table_id: (Some(tables.previous().table_id()), tables.next().table_id()),
                 index_index: index.index(),
+                from_drop_and_recreate: false,
             })
         }
 
@@ -321,6 +323,7 @@ fn push_created_index_steps(steps: &mut Vec<SqlMigrationStep>, db: &DifferDataba
                 steps.push(SqlMigrationStep::CreateIndex {
                     table_id: (Some(tables.previous().table_id()), tables.next().table_id()),
                     index_index: index.next().index(),
+                    from_drop_and_recreate: true,
                 })
             }
         }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/mssql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/mssql.rs
@@ -91,6 +91,7 @@ impl SqlSchemaDifferFlavour for MssqlFlavour {
             steps.push(SqlMigrationStep::CreateIndex {
                 table_id: (None, table.next().table_id()),
                 index_index: created_index.next().index(),
+                from_drop_and_recreate: false,
             })
         }
     }

--- a/migration-engine/migration-engine-tests/tests/migrations/diff.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/diff.rs
@@ -75,7 +75,7 @@ fn diffing_postgres_schemas_when_initialized_on_sqlite(mut api: TestApi) {
     let expected_printed_messages = expect![[r#"
         [
             "-- AlterTable\nALTER TABLE \"TestModel\" DROP COLUMN \"names\",\nADD COLUMN     \"names\" TEXT[];\n\n-- CreateTable\nCREATE TABLE \"TestModel2\" (\n    \"id\" SERIAL NOT NULL,\n\n    CONSTRAINT \"TestModel2_pkey\" PRIMARY KEY (\"id\")\n);\n",
-            "\n[+] Added tables\n  - TestModel2\n\n[*] Changed the `TestModel` table\n  [*] Column `names` would be dropped and recreated(changed from Required to List, type changed)\n",
+            "\n[+] Added tables\n  - TestModel2\n\n[*] Changed the `TestModel` table\n  [*] Column `names` would be dropped and recreated (changed from Required to List, type changed)\n",
         ]
     "#]];
 


### PR DESCRIPTION
First batch of fixes.

- It brings the number of failing tests in migration-engine-tests from 55 to 35.
- We now test cockroachdb migrations in CI (and accept failures, until we're done)
- migration-engine-cli test suite fully passing and validated in CI on CRDB

See individual commits and their messages for details.

https://github.com/prisma/prisma/issues/4702