### PR TITLE
fix(me): Revert unintended change of SqlMigrationConnector::connector_type()

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/flavour/mssql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/mssql.rs
@@ -121,7 +121,7 @@ impl SqlFlavour for MssqlFlavour {
     }
 
     fn connector_type(&self) -> &'static str {
-        "sqlserver"
+        "mssql"
     }
 
     fn create_database(&mut self) -> BoxFuture<'_, ConnectorResult<String>> {


### PR DESCRIPTION

This was overlooked in the ME refactoring, we used to have
`SqlFamily::to_str()` there, and that returns "mssql". It's important
because that's what we write in migration_lock.toml.