### PR TITLE
Remove workaround for cockroachdb tests in qe-setup

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/common.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/common.rs
@@ -114,3 +114,51 @@ where
         out
     }
 }
+
+#[derive(Default)]
+pub(super) struct StepRenderer {
+    stmts: Vec<String>,
+}
+
+impl StepRenderer {
+    pub(super) fn render_statement(&mut self, f: &mut dyn FnMut(&mut StatementRenderer)) {
+        let mut stmt_renderer = Default::default();
+        f(&mut stmt_renderer);
+        self.stmts.push(stmt_renderer.statement);
+    }
+}
+
+#[derive(Default)]
+pub(super) struct StatementRenderer {
+    statement: String,
+}
+
+impl StatementRenderer {
+    pub(super) fn join<I, T>(&mut self, separator: &str, iter: I)
+    where
+        I: Iterator<Item = T>,
+        T: std::fmt::Display,
+    {
+        let mut iter = iter.peekable();
+        while let Some(item) = iter.next() {
+            self.push_display(&item);
+            if iter.peek().is_some() {
+                self.push_str(separator)
+            }
+        }
+    }
+
+    pub(super) fn push_str(&mut self, s: &str) {
+        self.statement.push_str(s)
+    }
+
+    pub(super) fn push_display(&mut self, d: &dyn std::fmt::Display) {
+        std::fmt::Write::write_fmt(&mut self.statement, format_args!("{}", d)).unwrap();
+    }
+}
+
+pub(super) fn render_step(f: &mut dyn FnMut(&mut StepRenderer)) -> Vec<String> {
+    let mut renderer = Default::default();
+    f(&mut renderer);
+    renderer.stmts
+}

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mssql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mssql_renderer.rs
@@ -1,9 +1,6 @@
 mod alter_table;
 
-use super::{
-    common::{self, render_referential_action},
-    IteratorJoin, Quoted, SqlRenderer,
-};
+use super::{common::*, IteratorJoin, Quoted, SqlRenderer};
 use crate::{
     flavour::MssqlFlavour,
     pair::Pair,
@@ -47,7 +44,7 @@ impl MssqlFlavour {
         let column_name = self.quote(column.name());
 
         let r#type = render_column_type(column);
-        let nullability = common::render_nullability(column);
+        let nullability = render_nullability(column);
 
         let default = if column.is_autoincrement() {
             Cow::Borrowed(" IDENTITY(1,1)")
@@ -517,7 +514,7 @@ fn render_default(default: &DefaultValue) -> Cow<'_, str> {
         DefaultKind::Value(PrismaValue::String(val)) | DefaultKind::Value(PrismaValue::Enum(val)) => {
             Quoted::mssql_string(escape_string_literal(val)).to_string().into()
         }
-        DefaultKind::Value(PrismaValue::Bytes(b)) => format!("0x{}", common::format_hex(b)).into(),
+        DefaultKind::Value(PrismaValue::Bytes(b)) => format!("0x{}", format_hex(b)).into(),
         DefaultKind::Now => "CURRENT_TIMESTAMP".into(),
         DefaultKind::Value(PrismaValue::DateTime(val)) => Quoted::mssql_string(val).to_string().into(),
         DefaultKind::Value(PrismaValue::Boolean(val)) => Cow::from(if *val { "1" } else { "0" }),

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
@@ -1,4 +1,4 @@
-use super::{common::Quoted, IteratorJoin, SqlRenderer};
+use super::{common::*, IteratorJoin, SqlRenderer};
 use crate::{
     flavour::MysqlFlavour,
     pair::Pair,
@@ -88,14 +88,17 @@ impl SqlRenderer for MysqlFlavour {
     }
 
     fn render_rename_index(&self, indexes: Pair<&IndexWalker<'_>>) -> Vec<String> {
-        vec![ddl::AlterTable {
-            table_name: indexes.previous().table().name().into(),
-            changes: vec![sql_ddl::mysql::AlterTableClause::RenameIndex {
-                previous_name: indexes.previous().name().into(),
-                next_name: indexes.next().name().into(),
-            }],
-        }
-        .to_string()]
+        render_step(&mut |step| {
+            step.render_statement(&mut |stmt| {
+                stmt.push_display(&ddl::AlterTable {
+                    table_name: indexes.previous().table().name().into(),
+                    changes: vec![sql_ddl::mysql::AlterTableClause::RenameIndex {
+                        previous_name: indexes.previous().name().into(),
+                        next_name: indexes.next().name().into(),
+                    }],
+                })
+            })
+        })
     }
 
     fn render_alter_table(&self, alter_table: &AlterTable, schemas: &Pair<&SqlSchema>) -> Vec<String> {
@@ -295,10 +298,13 @@ impl SqlRenderer for MysqlFlavour {
     }
 
     fn render_drop_table(&self, table_name: &str) -> Vec<String> {
-        vec![sql_ddl::mysql::DropTable {
-            table_name: table_name.into(),
-        }
-        .to_string()]
+        render_step(&mut |step| {
+            step.render_statement(&mut |stmt| {
+                stmt.push_display(&sql_ddl::mysql::DropTable {
+                    table_name: table_name.into(),
+                })
+            })
+        })
     }
 
     fn render_redefine_tables(&self, _names: &[RedefineTable], _schemas: &Pair<&SqlSchema>) -> Vec<String> {

--- a/migration-engine/qe-setup/src/postgres.rs
+++ b/migration-engine/qe-setup/src/postgres.rs
@@ -28,12 +28,8 @@ pub(crate) async fn postgres_setup(url: String, prisma_schema: &str) -> Connecto
             .await
             .map_err(|e| ConnectorError::from_source(e, ""))?;
     }
-    {
-        //TODO: remove this once cockroachdb is supported in migrations
-        let prisma_schema2 = prisma_schema.replace("provider = \"cockroachdb\"", "provider = \"postgres\"");
-        crate::diff_and_apply(&prisma_schema2).await;
-    };
 
+    crate::diff_and_apply(prisma_schema).await;
     Ok(())
 }
 


### PR DESCRIPTION
The second commit is independent refactoring in sql-migration-connector.