### PR TITLE
Validate an index is defined only once with the same fields in Mongo

### DIFF
--- a/libs/datamodel/connectors/datamodel-connector/src/capabilities.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/capabilities.rs
@@ -68,6 +68,7 @@ capabilities!(
     FullTextIndex,
     SortOrderInFullTextIndex,
     MultipleFullTextAttributesPerModel,
+    DuplicateIndexDefinitionsToSameFields,
     // Start of query-engine-only Capabilities
     InsensitiveFilters,
     CreateMany,

--- a/libs/datamodel/connectors/datamodel-connector/src/empty_connector.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/empty_connector.rs
@@ -23,6 +23,7 @@ impl Connector for EmptyDatamodelConnector {
             ConnectorCapability::Enums,
             ConnectorCapability::Json,
             ConnectorCapability::ImplicitManyToManyRelation,
+            ConnectorCapability::DuplicateIndexDefinitionsToSameFields,
         ]
     }
 

--- a/libs/datamodel/connectors/mongodb-datamodel-connector/src/lib.rs
+++ b/libs/datamodel/connectors/mongodb-datamodel-connector/src/lib.rs
@@ -3,8 +3,8 @@ mod mongodb_types;
 use datamodel_connector::{
     connector_error::{ConnectorError, ErrorKind},
     parser_database::{ast::Expression, walkers::*},
-    Connector, ConnectorCapability, DatamodelError, Diagnostics, NativeTypeConstructor, NativeTypeInstance,
-    ReferentialAction, ReferentialIntegrity, ScalarType,
+    Connector, ConnectorCapability, ConstraintScope, DatamodelError, Diagnostics, NativeTypeConstructor,
+    NativeTypeInstance, ReferentialAction, ReferentialIntegrity, ScalarType,
 };
 use enumflags2::BitFlags;
 use mongodb_types::*;
@@ -110,6 +110,10 @@ impl Connector for MongoDbDatamodelConnector {
 
     fn max_identifier_length(&self) -> usize {
         127
+    }
+
+    fn constraint_violation_scopes(&self) -> &'static [ConstraintScope] {
+        &[ConstraintScope::ModelKeyIndex]
     }
 
     fn referential_actions(&self, referential_integrity: &ReferentialIntegrity) -> BitFlags<ReferentialAction> {

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/cockroach_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/cockroach_datamodel_connector.rs
@@ -87,6 +87,7 @@ const CAPABILITIES: &[ConnectorCapability] = &[
     ConnectorCapability::UpdateableId,
     ConnectorCapability::WritableAutoincField,
     ConnectorCapability::ImplicitManyToManyRelation,
+    ConnectorCapability::DuplicateIndexDefinitionsToSameFields,
 ];
 
 const SCALAR_TYPE_DEFAULTS: &[(ScalarType, CockroachType)] = &[

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/mssql_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/mssql_datamodel_connector.rs
@@ -95,6 +95,7 @@ const CAPABILITIES: &[ConnectorCapability] = &[
     ConnectorCapability::UpdateableId,
     ConnectorCapability::PrimaryKeySortOrderDefinition,
     ConnectorCapability::ImplicitManyToManyRelation,
+    ConnectorCapability::DuplicateIndexDefinitionsToSameFields,
 ];
 
 pub struct MsSqlDatamodelConnector;

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
@@ -116,6 +116,7 @@ const CAPABILITIES: &[ConnectorCapability] = &[
     ConnectorCapability::FullTextSearchWithIndex,
     ConnectorCapability::MultipleFullTextAttributesPerModel,
     ConnectorCapability::ImplicitManyToManyRelation,
+    ConnectorCapability::DuplicateIndexDefinitionsToSameFields,
 ];
 
 const CONSTRAINT_SCOPES: &[ConstraintScope] = &[ConstraintScope::GlobalForeignKey, ConstraintScope::ModelKeyIndex];

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
@@ -101,6 +101,7 @@ const CAPABILITIES: &[ConnectorCapability] = &[
     ConnectorCapability::WritableAutoincField,
     ConnectorCapability::UsingHashIndex,
     ConnectorCapability::ImplicitManyToManyRelation,
+    ConnectorCapability::DuplicateIndexDefinitionsToSameFields,
 ];
 
 pub struct PostgresDatamodelConnector;

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/sqlite_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/sqlite_datamodel_connector.rs
@@ -16,6 +16,7 @@ const CAPABILITIES: &[ConnectorCapability] = &[
     ConnectorCapability::RelationFieldsInArbitraryOrder,
     ConnectorCapability::UpdateableId,
     ConnectorCapability::ImplicitManyToManyRelation,
+    ConnectorCapability::DuplicateIndexDefinitionsToSameFields,
 ];
 
 pub struct SqliteDatamodelConnector;

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations.rs
@@ -94,6 +94,7 @@ pub(super) fn validate(ctx: &mut Context<'_>) {
             indexes::fulltext_column_sort_is_supported(index, ctx);
             indexes::fulltext_text_columns_should_be_bundled_together(index, ctx);
             indexes::has_valid_mapped_name(index, ctx);
+            indexes::is_not_defined_multiple_times_to_same_fields(index, ctx);
 
             for field_attribute in index.scalar_field_attributes() {
                 let span = index

--- a/libs/datamodel/parser-database/src/types.rs
+++ b/libs/datamodel/parser-database/src/types.rs
@@ -454,7 +454,7 @@ fn field_type<'db>(field: &'db ast::Field, ctx: &mut Context<'db>) -> Result<Fie
 }
 
 /// The sort order of an index.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum SortOrder {
     /// ASCending
     Asc,


### PR DESCRIPTION
Mongo doesn't allow following index definition:

```prisma
model A {
  id Int @id
  field Int

  @@index([field], map: "1")
  @@index([field], map: "2")
}
```

The following schema push would error in the database. We should validate them when validating the data model.

Applies to unique and fulltext too.

Closes: https://github.com/prisma/prisma/issues/11911