### PR TITLE
Delete diagnostics::ConnectorError

### DIFF
--- a/introspection-engine/connectors/sql-introspection-connector/src/introspection_helpers.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/introspection_helpers.rs
@@ -438,11 +438,7 @@ pub(crate) fn calculate_scalar_field_type_with_native_types(column: &Column, ctx
         FieldType::Scalar(scal_type, _, _) => match &column.tpe.native_type {
             None => scalar_type,
             Some(native_type) => {
-                let native_type_instance = ctx
-                    .source
-                    .active_connector
-                    .introspect_native_type(native_type.clone())
-                    .unwrap();
+                let native_type_instance = ctx.source.active_connector.introspect_native_type(native_type.clone());
                 FieldType::Scalar(
                     scal_type,
                     None,

--- a/libs/datamodel/connectors/datamodel-connector/src/empty_connector.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/empty_connector.rs
@@ -1,6 +1,5 @@
-use crate::{
-    connector_error::ConnectorError, Connector, ConnectorCapability, NativeTypeInstance, ReferentialAction, ScalarType,
-};
+use crate::{Connector, ConnectorCapability, NativeTypeInstance, ReferentialAction, ScalarType};
+use diagnostics::{DatamodelError, Span};
 use enumflags2::BitFlags;
 
 /// A [Connector](/trait.Connector.html) implementor meant to
@@ -51,11 +50,11 @@ impl Connector for EmptyDatamodelConnector {
         false
     }
 
-    fn parse_native_type(&self, name: &str, _args: Vec<String>) -> Result<NativeTypeInstance, ConnectorError> {
-        Err(ConnectorError::new_native_type_parser_error(name))
+    fn parse_native_type(&self, name: &str, _: Vec<String>, span: Span) -> Result<NativeTypeInstance, DatamodelError> {
+        Err(DatamodelError::new_native_type_parser_error(name, span))
     }
 
-    fn introspect_native_type(&self, _native_type: serde_json::Value) -> Result<NativeTypeInstance, ConnectorError> {
+    fn introspect_native_type(&self, _native_type: serde_json::Value) -> Result<NativeTypeInstance, DatamodelError> {
         unreachable!("introspect_native_type on EmptyDatamodelConnector")
     }
 

--- a/libs/datamodel/connectors/datamodel-connector/src/empty_connector.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/empty_connector.rs
@@ -54,7 +54,7 @@ impl Connector for EmptyDatamodelConnector {
         Err(DatamodelError::new_native_type_parser_error(name, span))
     }
 
-    fn introspect_native_type(&self, _native_type: serde_json::Value) -> Result<NativeTypeInstance, DatamodelError> {
+    fn introspect_native_type(&self, _native_type: serde_json::Value) -> NativeTypeInstance {
         unreachable!("introspect_native_type on EmptyDatamodelConnector")
     }
 

--- a/libs/datamodel/connectors/datamodel-connector/src/lib.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/lib.rs
@@ -132,8 +132,9 @@ pub trait Connector: Send + Sync {
         span: Span,
     ) -> Result<NativeTypeInstance, DatamodelError>;
 
-    /// This function is used during introspection to turn an introspected native type into an instance that can be put into the Prisma schema.
-    fn introspect_native_type(&self, native_type: serde_json::Value) -> Result<NativeTypeInstance, DatamodelError>;
+    /// This function is used during introspection to turn an introspected native type into an
+    /// instance that can be inserted into dml.
+    fn introspect_native_type(&self, native_type: serde_json::Value) -> NativeTypeInstance;
 
     fn set_config_dir<'a>(&self, config_dir: &std::path::Path, url: &'a str) -> Cow<'a, str> {
         let set_root = |path: &str| {

--- a/libs/datamodel/connectors/datamodel-connector/src/lib.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/lib.rs
@@ -20,13 +20,12 @@ pub use self::{
     capabilities::{ConnectorCapabilities, ConnectorCapability},
     native_type_instance::NativeTypeInstance,
 };
-pub use diagnostics::{connector_error, DatamodelError, Diagnostics};
+pub use diagnostics::{ConnectorErrorFactory, DatamodelError, Diagnostics, Span};
 pub use empty_connector::EmptyDatamodelConnector;
 pub use native_type_constructor::NativeTypeConstructor;
 pub use parser_database::{self, ReferentialAction, ScalarType};
 pub use referential_integrity::ReferentialIntegrity;
 
-use crate::connector_error::{ConnectorError, ConnectorErrorFactory, ErrorKind};
 use enumflags2::BitFlags;
 use std::{borrow::Cow, collections::BTreeMap};
 
@@ -92,7 +91,8 @@ pub trait Connector: Send + Sync {
         &self,
         _native_type: &NativeTypeInstance,
         _scalar_type: &ScalarType,
-        _: &mut Vec<ConnectorError>,
+        _span: Span,
+        _: &mut Diagnostics,
     ) {
     }
 
@@ -125,10 +125,15 @@ pub trait Connector: Send + Sync {
     }
 
     /// This function is used during Schema parsing to calculate the concrete native type.
-    fn parse_native_type(&self, name: &str, args: Vec<String>) -> Result<NativeTypeInstance, ConnectorError>;
+    fn parse_native_type(
+        &self,
+        name: &str,
+        args: Vec<String>,
+        span: Span,
+    ) -> Result<NativeTypeInstance, DatamodelError>;
 
     /// This function is used during introspection to turn an introspected native type into an instance that can be put into the Prisma schema.
-    fn introspect_native_type(&self, native_type: serde_json::Value) -> Result<NativeTypeInstance, ConnectorError>;
+    fn introspect_native_type(&self, native_type: serde_json::Value) -> Result<NativeTypeInstance, DatamodelError>;
 
     fn set_config_dir<'a>(&self, config_dir: &std::path::Path, url: &'a str) -> Cow<'a, str> {
         let set_root = |path: &str| {
@@ -211,25 +216,7 @@ pub trait Connector: Send + Sync {
     }
 
     fn native_instance_error(&self, instance: &NativeTypeInstance) -> ConnectorErrorFactory {
-        ConnectorErrorFactory {
-            connector: self.name().to_owned(),
-            native_type: instance.to_string(),
-        }
-    }
-
-    fn native_str_error(&self, native_str: &str) -> ConnectorErrorFactory {
-        ConnectorErrorFactory {
-            connector: self.name().to_owned(),
-            native_type: native_str.to_string(),
-        }
-    }
-
-    fn native_types_not_supported(&self) -> Result<NativeTypeInstance, ConnectorError> {
-        Err(ConnectorError::from_kind(
-            ErrorKind::ConnectorNotSupportedForNativeTypes {
-                connector_name: self.name().to_owned(),
-            },
-        ))
+        ConnectorErrorFactory::new(instance.to_string(), self.name().to_owned())
     }
 
     fn validate_url(&self, url: &str) -> Result<(), String>;

--- a/libs/datamodel/connectors/datamodel-connector/src/native_type_constructor.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/native_type_constructor.rs
@@ -6,10 +6,10 @@ pub struct NativeTypeConstructor {
     pub name: &'static str,
 
     /// The number of arguments that must be provided
-    pub _number_of_args: usize,
+    pub number_of_args: usize,
 
     /// The number of optional arguments
-    pub _number_of_optional_args: usize,
+    pub number_of_optional_args: usize,
 
     /// The scalar types this native type is compatible with
     pub prisma_types: &'static [ScalarType],
@@ -19,8 +19,8 @@ impl NativeTypeConstructor {
     pub const fn without_args(name: &'static str, prisma_types: &'static [ScalarType]) -> NativeTypeConstructor {
         NativeTypeConstructor {
             name,
-            _number_of_args: 0,
-            _number_of_optional_args: 0,
+            number_of_args: 0,
+            number_of_optional_args: 0,
             prisma_types,
         }
     }
@@ -32,8 +32,8 @@ impl NativeTypeConstructor {
     ) -> NativeTypeConstructor {
         NativeTypeConstructor {
             name,
-            _number_of_args: number_of_args,
-            _number_of_optional_args: 0,
+            number_of_args,
+            number_of_optional_args: 0,
             prisma_types,
         }
     }
@@ -45,8 +45,8 @@ impl NativeTypeConstructor {
     ) -> NativeTypeConstructor {
         NativeTypeConstructor {
             name,
-            _number_of_args: 0,
-            _number_of_optional_args: number_of_optional_args,
+            number_of_args: 0,
+            number_of_optional_args,
             prisma_types,
         }
     }

--- a/libs/datamodel/connectors/datamodel-connector/src/walker_ext_traits.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/walker_ext_traits.rs
@@ -120,8 +120,11 @@ pub trait ScalarFieldWalkerExt {
 
 impl ScalarFieldWalkerExt for ScalarFieldWalker<'_> {
     fn native_type_instance(&self, connector: &dyn Connector) -> Option<NativeTypeInstance> {
-        self.raw_native_type()
-            .and_then(|(_, name, args, _)| connector.parse_native_type(name, args.to_owned()).ok())
+        self.raw_native_type().and_then(|(_, name, args, _)| {
+            connector
+                .parse_native_type(name, args.to_owned(), self.ast_field().span)
+                .ok()
+        })
     }
 }
 

--- a/libs/datamodel/connectors/mongodb-datamodel-connector/src/lib.rs
+++ b/libs/datamodel/connectors/mongodb-datamodel-connector/src/lib.rs
@@ -1,10 +1,9 @@
 mod mongodb_types;
 
 use datamodel_connector::{
-    connector_error::{ConnectorError, ErrorKind},
     parser_database::{ast::Expression, walkers::*},
     Connector, ConnectorCapability, ConstraintScope, DatamodelError, Diagnostics, NativeTypeConstructor,
-    NativeTypeInstance, ReferentialAction, ReferentialIntegrity, ScalarType,
+    NativeTypeInstance, ReferentialAction, ReferentialIntegrity, ScalarType, Span,
 };
 use enumflags2::BitFlags;
 use mongodb_types::*;
@@ -29,7 +28,7 @@ const CAPABILITIES: &[ConnectorCapability] = &[
     ConnectorCapability::TwoWayEmbeddedManyToManyRelation,
 ];
 
-type Result<T> = std::result::Result<T, ConnectorError>;
+type Result<T> = std::result::Result<T, DatamodelError>;
 
 pub struct MongoDbDatamodelConnector;
 
@@ -40,13 +39,13 @@ impl MongoDbDatamodelConnector {
         }
 
         let mut bail = || {
-            let err = ConnectorError::from_kind(ErrorKind::FieldValidationError {
-                field: field.name().to_owned(),
-                message:
-                    "MongoDB `@default(auto())` fields must have `ObjectId` native type and use the `@id` attribute."
-                        .to_owned(),
-            });
-            errors.push_error(DatamodelError::new_connector_error(err, field.ast_field().span))
+            let err = DatamodelError::new_field_validation_error(
+                "MongoDB `@default(auto())` fields must have `ObjectId` native type and use the `@id` attribute.",
+                field.model().name(),
+                field.name(),
+                field.ast_field().span,
+            );
+            errors.push_error(err);
         };
 
         let model = field.model();
@@ -65,12 +64,13 @@ impl MongoDbDatamodelConnector {
             return;
         }
 
-        let err = ConnectorError::from_kind(ErrorKind::FieldValidationError {
-            field: field.name().to_owned(),
-            message: "The `dbgenerated()` function is not allowed with MongoDB. Please use `auto()` instead."
-                .to_owned(),
-        });
-        errors.push_error(DatamodelError::new_connector_error(err, field.ast_field().span));
+        let err = DatamodelError::new_field_validation_error(
+            "The `dbgenerated()` function is not allowed with MongoDB. Please use `auto()` instead.",
+            field.model().name(),
+            field.name(),
+            field.ast_field().span,
+        );
+        errors.push_error(err);
     }
 
     fn validate_array_native_type(field: ScalarFieldWalker<'_>, errors: &mut Diagnostics) {
@@ -86,14 +86,13 @@ impl MongoDbDatamodelConnector {
         // `db.Array` expects exactly 1 argument, which is validated before this code path.
         let arg = args.get(0).unwrap();
 
-        errors.push_error(DatamodelError::new_connector_error(
-            ConnectorError::from_kind(ErrorKind::FieldValidationError {
-                field: field.name().to_owned(),
-                message: format!(
-                    "Native type `{ds_name}.{}` is deprecated. Please use `{ds_name}.{arg}` instead.",
-                    type_names::ARRAY
-                ),
-            }),
+        errors.push_error(DatamodelError::new_field_validation_error(
+            &format!(
+                "Native type `{ds_name}.{}` is deprecated. Please use `{ds_name}.{arg}` instead.",
+                type_names::ARRAY
+            ),
+            field.model().name(),
+            field.name(),
             span,
         ));
     }
@@ -127,16 +126,13 @@ impl Connector for MongoDbDatamodelConnector {
             Self::validate_array_native_type(field, errors);
         }
 
-        let mut push_error = |err: ConnectorError| {
-            errors.push_error(DatamodelError::new_connector_error(err, model.ast_model().span));
-        };
-
         if let Some(pk) = model.primary_key() {
             // no compound ids
             if pk.fields().len() > 1 {
-                push_error(ConnectorError::from_kind(ErrorKind::InvalidModelError {
-                    message: "MongoDB models require exactly one identity field annotated with @id".to_owned(),
-                }));
+                errors.push_error(DatamodelError::new_invalid_model_error(
+                    "MongoDB models require exactly one identity field annotated with @id",
+                    model.ast_model().span,
+                ));
             }
 
             // singular id
@@ -146,35 +142,43 @@ impl Connector for MongoDbDatamodelConnector {
             if field.name() != "_id" {
                 match field.mapped_name() {
                     Some("_id") => (),
-                    Some(mapped_name) => push_error(ConnectorError::from_kind(ErrorKind::FieldValidationError {
-                        field: field.name().to_owned(),
-                        message: format!(
+                    Some(mapped_name) => errors.push_error(DatamodelError::new_field_validation_error(
+                        &format!(
                             "MongoDB model IDs must have a @map(\"_id\") annotation, found @map(\"{}\").",
                             mapped_name
                         ),
-                    })),
-                    None => push_error(ConnectorError::from_kind(ErrorKind::FieldValidationError {
-                        field: field.name().to_owned(),
-                        message: "MongoDB model IDs must have a @map(\"_id\") annotations.".to_owned(),
-                    })),
+                        field.model().name(),
+                        field.name(),
+                        field.ast_field().span,
+                    )),
+                    None => errors.push_error(DatamodelError::new_field_validation_error(
+                        "MongoDB model IDs must have a @map(\"_id\") annotations.",
+                        field.model().name(),
+                        field.name(),
+                        field.ast_field().span,
+                    )),
                 };
             }
 
             if field.raw_native_type().is_none()
                 && matches!(field.default_value().map(|v| v.value()), Some(Expression::Function(fn_name,_,_)) if fn_name == "dbgenerated")
             {
-                push_error(ConnectorError::from_kind(ErrorKind::FieldValidationError {
-                    field: field.name().to_owned(),
-                    message: format!(
+                errors.push_error(DatamodelError::new_field_validation_error(
+                    &format!(
                         "MongoDB `@default(dbgenerated())` IDs must have an `ObjectID` native type annotation. `{}` is an ID field, so you probably want `ObjectId` as your native type.",
                         field.name()
-                    ),
-                }));
+                        ),
+                        field.model().name(),
+                        field.name(),
+                        field.ast_field().span,
+
+                ));
             }
         } else {
-            push_error(ConnectorError::from_kind(ErrorKind::InvalidModelError {
-                message: "MongoDB models require exactly one identity field annotated with @id".to_owned(),
-            }))
+            errors.push_error(DatamodelError::new_invalid_model_error(
+                "MongoDB models require exactly one identity field annotated with @id",
+                model.ast_model().span,
+            ));
         }
     }
 
@@ -195,8 +199,8 @@ impl Connector for MongoDbDatamodelConnector {
         &native_type == default_native_type
     }
 
-    fn parse_native_type(&self, name: &str, args: Vec<String>) -> Result<NativeTypeInstance> {
-        let mongo_type = mongo_type_from_input(name, &args)?;
+    fn parse_native_type(&self, name: &str, args: Vec<String>, span: Span) -> Result<NativeTypeInstance> {
+        let mongo_type = mongo_type_from_input(name, &args, span)?;
 
         Ok(NativeTypeInstance::new(name, args, mongo_type.to_json()))
     }

--- a/libs/datamodel/connectors/mongodb-datamodel-connector/src/lib.rs
+++ b/libs/datamodel/connectors/mongodb-datamodel-connector/src/lib.rs
@@ -205,7 +205,7 @@ impl Connector for MongoDbDatamodelConnector {
         Ok(NativeTypeInstance::new(name, args, mongo_type.to_json()))
     }
 
-    fn introspect_native_type(&self, _native_type: serde_json::Value) -> Result<NativeTypeInstance> {
+    fn introspect_native_type(&self, _native_type: serde_json::Value) -> NativeTypeInstance {
         // Out of scope for MVP
         todo!()
     }

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/cockroach_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/cockroach_datamodel_connector.rs
@@ -264,7 +264,7 @@ impl Connector for CockroachDatamodelConnector {
         Ok(NativeTypeInstance::new(name, cloned_args, native_type.to_json()))
     }
 
-    fn introspect_native_type(&self, native_type: serde_json::Value) -> Result<NativeTypeInstance, DatamodelError> {
+    fn introspect_native_type(&self, native_type: serde_json::Value) -> NativeTypeInstance {
         let native_type: CockroachType = serde_json::from_value(native_type).unwrap();
         let (constructor_name, args) = match native_type {
             SmallInt => (SMALL_INT_TYPE_NAME, vec![]),
@@ -294,7 +294,7 @@ impl Connector for CockroachDatamodelConnector {
         };
 
         if let Some(constructor) = self.find_native_type_constructor(constructor_name) {
-            Ok(NativeTypeInstance::new(constructor.name, args, native_type.to_json()))
+            NativeTypeInstance::new(constructor.name, args, native_type.to_json())
         } else {
             unreachable!()
         }

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/mssql_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/mssql_datamodel_connector.rs
@@ -364,7 +364,7 @@ impl Connector for MsSqlDatamodelConnector {
         Ok(NativeTypeInstance::new(name, cloned_args, native_type.to_json()))
     }
 
-    fn introspect_native_type(&self, native_type: serde_json::Value) -> Result<NativeTypeInstance, DatamodelError> {
+    fn introspect_native_type(&self, native_type: serde_json::Value) -> NativeTypeInstance {
         let native_type: MsSqlType = serde_json::from_value(native_type).unwrap();
 
         let (constructor_name, args) = match native_type {
@@ -399,11 +399,7 @@ impl Connector for MsSqlDatamodelConnector {
 
         if let Some(constructor) = self.find_native_type_constructor(constructor_name) {
             let stringified_args = args.iter().map(|arg| arg.to_string()).collect();
-            Ok(NativeTypeInstance::new(
-                constructor.name,
-                stringified_args,
-                native_type.to_json(),
-            ))
+            NativeTypeInstance::new(constructor.name, stringified_args, native_type.to_json())
         } else {
             unreachable!()
         }

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
@@ -371,7 +371,7 @@ impl Connector for MySqlDatamodelConnector {
         Ok(NativeTypeInstance::new(name, cloned_args, native_type.to_json()))
     }
 
-    fn introspect_native_type(&self, native_type: serde_json::Value) -> Result<NativeTypeInstance, DatamodelError> {
+    fn introspect_native_type(&self, native_type: serde_json::Value) -> NativeTypeInstance {
         let native_type: MySqlType = serde_json::from_value(native_type).unwrap();
         let (constructor_name, args) = match native_type {
             Int => (INT_TYPE_NAME, vec![]),
@@ -416,7 +416,7 @@ impl Connector for MySqlDatamodelConnector {
         }
 
         if let Some(constructor) = self.find_native_type_constructor(constructor_name) {
-            Ok(NativeTypeInstance::new(constructor.name, args, native_type.to_json()))
+            NativeTypeInstance::new(constructor.name, args, native_type.to_json())
         } else {
             unreachable!()
         }

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
@@ -1,10 +1,9 @@
 use datamodel_connector::{
-    connector_error::ConnectorError,
     helper::{args_vec_from_opt, parse_one_opt_u32, parse_one_u32, parse_two_opt_u32},
     parser_database::walkers::ModelWalker,
     walker_ext_traits::*,
     Connector, ConnectorCapability, ConstraintScope, DatamodelError, Diagnostics, NativeTypeConstructor,
-    NativeTypeInstance, ReferentialAction, ReferentialIntegrity, ScalarType,
+    NativeTypeInstance, ReferentialAction, ReferentialIntegrity, ScalarType, Span,
 };
 use enumflags2::BitFlags;
 use native_types::{
@@ -227,7 +226,8 @@ impl Connector for MySqlDatamodelConnector {
         &self,
         native_type_instance: &NativeTypeInstance,
         scalar_type: &ScalarType,
-        errors: &mut Vec<ConnectorError>,
+        span: Span,
+        errors: &mut Diagnostics,
     ) {
         let native_type: MySqlType =
             serde_json::from_value(native_type_instance.serialized_native_type.clone()).unwrap();
@@ -235,34 +235,32 @@ impl Connector for MySqlDatamodelConnector {
 
         match native_type {
             Decimal(Some((precision, scale))) if scale > precision => {
-                errors.push(error.new_scale_larger_than_precision_error())
+                errors.push_error(error.new_scale_larger_than_precision_error(span))
             }
             Decimal(Some((precision, _))) if precision > 65 => {
-                errors.push(error.new_argument_m_out_of_range_error("Precision can range from 1 to 65."))
+                errors.push_error(error.new_argument_m_out_of_range_error("Precision can range from 1 to 65.", span))
             }
             Decimal(Some((_, scale))) if scale > 30 => {
-                errors.push(error.new_argument_m_out_of_range_error("Scale can range from 0 to 30."))
+                errors.push_error(error.new_argument_m_out_of_range_error("Scale can range from 0 to 30.", span))
             }
             Bit(length) if length == 0 || length > 64 => {
-                errors.push(error.new_argument_m_out_of_range_error("M can range from 1 to 64."))
+                errors.push_error(error.new_argument_m_out_of_range_error("M can range from 1 to 64.", span))
             }
             Char(length) if length > 255 => {
-                errors.push(error.new_argument_m_out_of_range_error("M can range from 0 to 255."))
+                errors.push_error(error.new_argument_m_out_of_range_error("M can range from 0 to 255.", span))
             }
             VarChar(length) if length > 65535 => {
-                errors.push(error.new_argument_m_out_of_range_error("M can range from 0 to 65,535."))
+                errors.push_error(error.new_argument_m_out_of_range_error("M can range from 0 to 65,535.", span))
             }
             Bit(n) if n > 1 && matches!(scalar_type, ScalarType::Boolean) => {
-                errors.push(error.new_argument_m_out_of_range_error("only Bit(1) can be used as Boolean."))
+                errors.push_error(error.new_argument_m_out_of_range_error("only Bit(1) can be used as Boolean.", span))
             }
             _ => (),
         }
     }
 
     fn validate_model(&self, model: ModelWalker<'_>, errors: &mut Diagnostics) {
-        let mut push_error = |err: ConnectorError| {
-            errors.push_error(DatamodelError::new_connector_error(err, model.ast_model().span));
-        };
+        let span = model.ast_model().span;
 
         for index in model.indexes() {
             for field in index.scalar_field_attributes() {
@@ -278,14 +276,14 @@ impl Connector for MySqlDatamodelConnector {
                         }
 
                         if index.is_unique() {
-                            push_error(
+                            errors.push_error(
                                 self.native_instance_error(&native_type)
-                                    .new_incompatible_native_type_with_unique(" If you are using the `extendedIndexes` preview feature you can add a `length` argument to allow this."),
+                                    .new_incompatible_native_type_with_unique(" If you are using the `extendedIndexes` preview feature you can add a `length` argument to allow this.", span),
                             )
                         } else {
-                            push_error(
+                            errors.push_error(
                                 self.native_instance_error(&native_type)
-                                    .new_incompatible_native_type_with_index(" If you are using the `extendedIndexes` preview feature you can add a `length` argument to allow this."),
+                                    .new_incompatible_native_type_with_index(" If you are using the `extendedIndexes` preview feature you can add a `length` argument to allow this.", span),
                             )
                         };
 
@@ -306,9 +304,9 @@ impl Connector for MySqlDatamodelConnector {
                             continue;
                         }
 
-                        push_error(
+                        errors.push_error(
                             self.native_instance_error(&native_type_instance)
-                                .new_incompatible_native_type_with_id(" If you are using the `extendedIndexes` preview feature you can add a `length` argument to allow this."),
+                                .new_incompatible_native_type_with_id(" If you are using the `extendedIndexes` preview feature you can add a `length` argument to allow this.", span),
                         );
 
                         break;
@@ -326,7 +324,12 @@ impl Connector for MySqlDatamodelConnector {
         NATIVE_TYPE_CONSTRUCTORS
     }
 
-    fn parse_native_type(&self, name: &str, args: Vec<String>) -> Result<NativeTypeInstance, ConnectorError> {
+    fn parse_native_type(
+        &self,
+        name: &str,
+        args: Vec<String>,
+        span: Span,
+    ) -> Result<NativeTypeInstance, DatamodelError> {
         let cloned_args = args.clone();
 
         let native_type = match name {
@@ -340,14 +343,14 @@ impl Connector for MySqlDatamodelConnector {
             UNSIGNED_MEDIUM_INT_TYPE_NAME => UnsignedMediumInt,
             BIG_INT_TYPE_NAME => BigInt,
             UNSIGNED_BIG_INT_TYPE_NAME => UnsignedBigInt,
-            DECIMAL_TYPE_NAME => Decimal(parse_two_opt_u32(args, DECIMAL_TYPE_NAME)?),
+            DECIMAL_TYPE_NAME => Decimal(parse_two_opt_u32(args, DECIMAL_TYPE_NAME, span)?),
             FLOAT_TYPE_NAME => Float,
             DOUBLE_TYPE_NAME => Double,
-            BIT_TYPE_NAME => Bit(parse_one_u32(args, BIT_TYPE_NAME)?),
-            CHAR_TYPE_NAME => Char(parse_one_u32(args, CHAR_TYPE_NAME)?),
-            VAR_CHAR_TYPE_NAME => VarChar(parse_one_u32(args, VAR_CHAR_TYPE_NAME)?),
-            BINARY_TYPE_NAME => Binary(parse_one_u32(args, BINARY_TYPE_NAME)?),
-            VAR_BINARY_TYPE_NAME => VarBinary(parse_one_u32(args, VAR_BINARY_TYPE_NAME)?),
+            BIT_TYPE_NAME => Bit(parse_one_u32(args, BIT_TYPE_NAME, span)?),
+            CHAR_TYPE_NAME => Char(parse_one_u32(args, CHAR_TYPE_NAME, span)?),
+            VAR_CHAR_TYPE_NAME => VarChar(parse_one_u32(args, VAR_CHAR_TYPE_NAME, span)?),
+            BINARY_TYPE_NAME => Binary(parse_one_u32(args, BINARY_TYPE_NAME, span)?),
+            VAR_BINARY_TYPE_NAME => VarBinary(parse_one_u32(args, VAR_BINARY_TYPE_NAME, span)?),
             TINY_BLOB_TYPE_NAME => TinyBlob,
             BLOB_TYPE_NAME => Blob,
             MEDIUM_BLOB_TYPE_NAME => MediumBlob,
@@ -357,18 +360,18 @@ impl Connector for MySqlDatamodelConnector {
             MEDIUM_TEXT_TYPE_NAME => MediumText,
             LONG_TEXT_TYPE_NAME => LongText,
             DATE_TYPE_NAME => Date,
-            TIME_TYPE_NAME => Time(parse_one_opt_u32(args, TIME_TYPE_NAME)?),
-            DATETIME_TYPE_NAME => DateTime(parse_one_opt_u32(args, DATETIME_TYPE_NAME)?),
-            TIMESTAMP_TYPE_NAME => Timestamp(parse_one_opt_u32(args, TIMESTAMP_TYPE_NAME)?),
+            TIME_TYPE_NAME => Time(parse_one_opt_u32(args, TIME_TYPE_NAME, span)?),
+            DATETIME_TYPE_NAME => DateTime(parse_one_opt_u32(args, DATETIME_TYPE_NAME, span)?),
+            TIMESTAMP_TYPE_NAME => Timestamp(parse_one_opt_u32(args, TIMESTAMP_TYPE_NAME, span)?),
             YEAR_TYPE_NAME => Year,
             JSON_TYPE_NAME => Json,
-            _ => return Err(ConnectorError::new_native_type_parser_error(name)),
+            _ => return Err(DatamodelError::new_native_type_parser_error(name, span)),
         };
 
         Ok(NativeTypeInstance::new(name, cloned_args, native_type.to_json()))
     }
 
-    fn introspect_native_type(&self, native_type: serde_json::Value) -> Result<NativeTypeInstance, ConnectorError> {
+    fn introspect_native_type(&self, native_type: serde_json::Value) -> Result<NativeTypeInstance, DatamodelError> {
         let native_type: MySqlType = serde_json::from_value(native_type).unwrap();
         let (constructor_name, args) = match native_type {
             Int => (INT_TYPE_NAME, vec![]),
@@ -415,7 +418,7 @@ impl Connector for MySqlDatamodelConnector {
         if let Some(constructor) = self.find_native_type_constructor(constructor_name) {
             Ok(NativeTypeInstance::new(constructor.name, args, native_type.to_json()))
         } else {
-            Err(self.native_str_error(constructor_name).native_type_name_unknown())
+            unreachable!()
         }
     }
 

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
@@ -303,7 +303,7 @@ impl Connector for PostgresDatamodelConnector {
         Ok(NativeTypeInstance::new(name, cloned_args, native_type.to_json()))
     }
 
-    fn introspect_native_type(&self, native_type: serde_json::Value) -> Result<NativeTypeInstance, DatamodelError> {
+    fn introspect_native_type(&self, native_type: serde_json::Value) -> NativeTypeInstance {
         let native_type: PostgresType = serde_json::from_value(native_type).unwrap();
         let (constructor_name, args) = match native_type {
             SmallInt => (SMALL_INT_TYPE_NAME, vec![]),
@@ -335,7 +335,7 @@ impl Connector for PostgresDatamodelConnector {
         };
 
         if let Some(constructor) = self.find_native_type_constructor(constructor_name) {
-            Ok(NativeTypeInstance::new(constructor.name, args, native_type.to_json()))
+            NativeTypeInstance::new(constructor.name, args, native_type.to_json())
         } else {
             unreachable!()
         }

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
@@ -1,10 +1,9 @@
 use datamodel_connector::{
-    connector_error::ConnectorError,
     helper::{arg_vec_from_opt, args_vec_from_opt, parse_one_opt_u32, parse_two_opt_u32},
     parser_database::walkers::ModelWalker,
     walker_ext_traits::*,
     Connector, ConnectorCapability, ConstraintScope, DatamodelError, Diagnostics, NativeTypeConstructor,
-    NativeTypeInstance, ReferentialAction, ReferentialIntegrity, ScalarType,
+    NativeTypeInstance, ReferentialAction, ReferentialIntegrity, ScalarType, Span,
 };
 use enumflags2::BitFlags;
 use native_types::{
@@ -205,7 +204,8 @@ impl Connector for PostgresDatamodelConnector {
         &self,
         native_type_instance: &NativeTypeInstance,
         _scalar_type: &ScalarType,
-        errors: &mut Vec<ConnectorError>,
+        span: Span,
+        errors: &mut Diagnostics,
     ) {
         let native_type: PostgresType =
             serde_json::from_value(native_type_instance.serialized_native_type.clone()).unwrap();
@@ -213,38 +213,38 @@ impl Connector for PostgresDatamodelConnector {
 
         match native_type {
             Decimal(Some((precision, scale))) if scale > precision => {
-                errors.push(error.new_scale_larger_than_precision_error())
+                errors.push_error(error.new_scale_larger_than_precision_error(span))
             }
-            Decimal(Some((prec, _))) if prec > 1000 || prec == 0 => errors.push(
-                error.new_argument_m_out_of_range_error("Precision must be positive with a maximum value of 1000."),
-            ),
+            Decimal(Some((prec, _))) if prec > 1000 || prec == 0 => {
+                errors.push_error(error.new_argument_m_out_of_range_error(
+                    "Precision must be positive with a maximum value of 1000.",
+                    span,
+                ))
+            }
             Bit(Some(0)) | VarBit(Some(0)) => {
-                errors.push(error.new_argument_m_out_of_range_error("M must be a positive integer."))
+                errors.push_error(error.new_argument_m_out_of_range_error("M must be a positive integer.", span))
             }
             Timestamp(Some(p)) | Timestamptz(Some(p)) | Time(Some(p)) | Timetz(Some(p)) if p > 6 => {
-                errors.push(error.new_argument_m_out_of_range_error("M can range from 0 to 6."))
+                errors.push_error(error.new_argument_m_out_of_range_error("M can range from 0 to 6.", span))
             }
             _ => (),
         }
     }
 
     fn validate_model(&self, model: ModelWalker<'_>, errors: &mut Diagnostics) {
-        let mut push_error = |err: ConnectorError| {
-            errors.push_error(DatamodelError::new_connector_error(err, model.ast_model().span));
-        };
-
         for index in model.indexes() {
             for field in index.fields() {
                 if let Some(native_type) = field.native_type_instance(self) {
+                    let span = field.ast_field().span;
                     let r#type: PostgresType =
                         serde_json::from_value(native_type.serialized_native_type.clone()).unwrap();
                     let error = self.native_instance_error(&native_type);
 
                     if r#type == PostgresType::Xml {
                         if index.is_unique() {
-                            push_error(error.new_incompatible_native_type_with_unique(""))
+                            errors.push_error(error.new_incompatible_native_type_with_unique("", span))
                         } else {
-                            push_error(error.new_incompatible_native_type_with_index(""))
+                            errors.push_error(error.new_incompatible_native_type_with_index("", span))
                         };
 
                         break;
@@ -262,43 +262,48 @@ impl Connector for PostgresDatamodelConnector {
         NATIVE_TYPE_CONSTRUCTORS
     }
 
-    fn parse_native_type(&self, name: &str, args: Vec<String>) -> Result<NativeTypeInstance, ConnectorError> {
+    fn parse_native_type(
+        &self,
+        name: &str,
+        args: Vec<String>,
+        span: Span,
+    ) -> Result<NativeTypeInstance, DatamodelError> {
         let cloned_args = args.clone();
 
         let native_type = match name {
             SMALL_INT_TYPE_NAME => SmallInt,
             INTEGER_TYPE_NAME => Integer,
             BIG_INT_TYPE_NAME => BigInt,
-            DECIMAL_TYPE_NAME => Decimal(parse_two_opt_u32(args, DECIMAL_TYPE_NAME)?),
+            DECIMAL_TYPE_NAME => Decimal(parse_two_opt_u32(args, DECIMAL_TYPE_NAME, span)?),
             INET_TYPE_NAME => Inet,
             MONEY_TYPE_NAME => Money,
             CITEXT_TYPE_NAME => Citext,
             OID_TYPE_NAME => Oid,
             REAL_TYPE_NAME => Real,
             DOUBLE_PRECISION_TYPE_NAME => DoublePrecision,
-            VARCHAR_TYPE_NAME => VarChar(parse_one_opt_u32(args, VARCHAR_TYPE_NAME)?),
-            CHAR_TYPE_NAME => Char(parse_one_opt_u32(args, CHAR_TYPE_NAME)?),
+            VARCHAR_TYPE_NAME => VarChar(parse_one_opt_u32(args, VARCHAR_TYPE_NAME, span)?),
+            CHAR_TYPE_NAME => Char(parse_one_opt_u32(args, CHAR_TYPE_NAME, span)?),
             TEXT_TYPE_NAME => Text,
             BYTE_A_TYPE_NAME => ByteA,
-            TIMESTAMP_TYPE_NAME => Timestamp(parse_one_opt_u32(args, TIMESTAMP_TYPE_NAME)?),
-            TIMESTAMP_TZ_TYPE_NAME => Timestamptz(parse_one_opt_u32(args, TIMESTAMP_TZ_TYPE_NAME)?),
+            TIMESTAMP_TYPE_NAME => Timestamp(parse_one_opt_u32(args, TIMESTAMP_TYPE_NAME, span)?),
+            TIMESTAMP_TZ_TYPE_NAME => Timestamptz(parse_one_opt_u32(args, TIMESTAMP_TZ_TYPE_NAME, span)?),
             DATE_TYPE_NAME => Date,
-            TIME_TYPE_NAME => Time(parse_one_opt_u32(args, TIME_TYPE_NAME)?),
-            TIME_TZ_TYPE_NAME => Timetz(parse_one_opt_u32(args, TIME_TZ_TYPE_NAME)?),
+            TIME_TYPE_NAME => Time(parse_one_opt_u32(args, TIME_TYPE_NAME, span)?),
+            TIME_TZ_TYPE_NAME => Timetz(parse_one_opt_u32(args, TIME_TZ_TYPE_NAME, span)?),
             BOOLEAN_TYPE_NAME => Boolean,
-            BIT_TYPE_NAME => Bit(parse_one_opt_u32(args, BIT_TYPE_NAME)?),
-            VAR_BIT_TYPE_NAME => VarBit(parse_one_opt_u32(args, VAR_BIT_TYPE_NAME)?),
+            BIT_TYPE_NAME => Bit(parse_one_opt_u32(args, BIT_TYPE_NAME, span)?),
+            VAR_BIT_TYPE_NAME => VarBit(parse_one_opt_u32(args, VAR_BIT_TYPE_NAME, span)?),
             UUID_TYPE_NAME => Uuid,
             XML_TYPE_NAME => Xml,
             JSON_TYPE_NAME => Json,
             JSON_B_TYPE_NAME => JsonB,
-            _ => return Err(ConnectorError::new_native_type_parser_error(name)),
+            _ => return Err(DatamodelError::new_native_type_parser_error(name, span)),
         };
 
         Ok(NativeTypeInstance::new(name, cloned_args, native_type.to_json()))
     }
 
-    fn introspect_native_type(&self, native_type: serde_json::Value) -> Result<NativeTypeInstance, ConnectorError> {
+    fn introspect_native_type(&self, native_type: serde_json::Value) -> Result<NativeTypeInstance, DatamodelError> {
         let native_type: PostgresType = serde_json::from_value(native_type).unwrap();
         let (constructor_name, args) = match native_type {
             SmallInt => (SMALL_INT_TYPE_NAME, vec![]),
@@ -332,7 +337,7 @@ impl Connector for PostgresDatamodelConnector {
         if let Some(constructor) = self.find_native_type_constructor(constructor_name) {
             Ok(NativeTypeInstance::new(constructor.name, args, native_type.to_json()))
         } else {
-            Err(self.native_str_error(constructor_name).native_type_name_unknown())
+            unreachable!()
         }
     }
 

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/sqlite_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/sqlite_datamodel_connector.rs
@@ -1,8 +1,8 @@
-use datamodel_connector::ConstraintScope;
 use datamodel_connector::{
-    connector_error::ConnectorError, parser_database::ScalarType, Connector, ConnectorCapability,
-    NativeTypeConstructor, NativeTypeInstance, ReferentialAction, ReferentialIntegrity,
+    parser_database::ScalarType, Connector, ConnectorCapability, NativeTypeConstructor, NativeTypeInstance,
+    ReferentialAction, ReferentialIntegrity,
 };
+use datamodel_connector::{ConstraintScope, DatamodelError, Span};
 use enumflags2::BitFlags;
 use std::borrow::Cow;
 
@@ -64,12 +64,20 @@ impl Connector for SqliteDatamodelConnector {
         NATIVE_TYPE_CONSTRUCTORS
     }
 
-    fn parse_native_type(&self, _name: &str, _args: Vec<String>) -> Result<NativeTypeInstance, ConnectorError> {
-        self.native_types_not_supported()
+    fn parse_native_type(
+        &self,
+        _name: &str,
+        _args: Vec<String>,
+        span: Span,
+    ) -> Result<NativeTypeInstance, DatamodelError> {
+        Err(DatamodelError::new_native_types_not_supported(
+            self.name().to_owned(),
+            span,
+        ))
     }
 
-    fn introspect_native_type(&self, _native_type: serde_json::Value) -> Result<NativeTypeInstance, ConnectorError> {
-        self.native_types_not_supported()
+    fn introspect_native_type(&self, _native_type: serde_json::Value) -> Result<NativeTypeInstance, DatamodelError> {
+        unreachable!("unreachable introspect_native_type() on sqlite")
     }
 
     fn set_config_dir<'a>(&self, config_dir: &std::path::Path, url: &'a str) -> Cow<'a, str> {

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/sqlite_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/sqlite_datamodel_connector.rs
@@ -76,7 +76,7 @@ impl Connector for SqliteDatamodelConnector {
         ))
     }
 
-    fn introspect_native_type(&self, _native_type: serde_json::Value) -> Result<NativeTypeInstance, DatamodelError> {
+    fn introspect_native_type(&self, _native_type: serde_json::Value) -> NativeTypeInstance {
         unreachable!("unreachable introspect_native_type() on sqlite")
     }
 

--- a/libs/datamodel/core/src/transform/ast_to_dml/lift.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/lift.rs
@@ -478,9 +478,11 @@ impl<'a> LiftAstToDml<'a> {
                 self.lift_scalar_field_type(alias, scalar_field_type, scalar_field)
             }
             db::ScalarFieldType::BuiltInScalar(scalar_type) => {
-                let native_type = scalar_field
-                    .raw_native_type()
-                    .map(|(_, name, args, _)| self.connector.parse_native_type(name, args.to_owned()).unwrap());
+                let native_type = scalar_field.raw_native_type().map(|(_, name, args, _)| {
+                    self.connector
+                        .parse_native_type(name, args.to_owned(), scalar_field.ast_field().span)
+                        .unwrap()
+                });
                 dml::FieldType::Scalar(
                     parser_database_scalar_type_to_dml_scalar_type(*scalar_type),
                     None,
@@ -500,9 +502,11 @@ impl<'a> LiftAstToDml<'a> {
                 CompositeTypeFieldType::CompositeType(self.db.ast()[*ctid].name.name.to_owned())
             }
             db::ScalarFieldType::BuiltInScalar(scalar_type) => {
-                let native_type = composite_type_field
-                    .raw_native_type()
-                    .map(|(_, name, args, _)| self.connector.parse_native_type(name, args.to_owned()).unwrap());
+                let native_type = composite_type_field.raw_native_type().map(|(_, name, args, _)| {
+                    self.connector
+                        .parse_native_type(name, args.to_owned(), composite_type_field.ast_field().span)
+                        .unwrap()
+                });
 
                 CompositeTypeFieldType::Scalar(
                     parser_database_scalar_type_to_dml_scalar_type(*scalar_type),

--- a/libs/datamodel/core/tests/attributes/default_negative.rs
+++ b/libs/datamodel/core/tests/attributes/default_negative.rs
@@ -676,7 +676,7 @@ fn must_error_on_auto_default_on_non_native_type_on_mongodb() {
     let error = datamodel::parse_schema(schema).map(drop).unwrap_err();
 
     let expected = expect![[r#"
-        [1;91merror[0m: [1mError validating field 'nickname': MongoDB `@default(auto())` fields must have `ObjectId` native type and use the `@id` attribute.[0m
+        [1;91merror[0m: [1mError validating field `nickname` in model `User`: MongoDB `@default(auto())` fields must have `ObjectId` native type and use the `@id` attribute.[0m
           [1;94m-->[0m  [4mschema.prisma:14[0m
         [1;94m   | [0m
         [1;94m13 | [0m            id Int @id @map("_id")
@@ -710,7 +710,7 @@ fn must_error_on_auto_default_on_non_object_id_on_mongodb() {
     let error = datamodel::parse_schema(schema).map(drop).unwrap_err();
 
     let expected = expect![[r#"
-        [1;91merror[0m: [1mError validating field 'id': MongoDB `@default(auto())` fields must have `ObjectId` native type and use the `@id` attribute.[0m
+        [1;91merror[0m: [1mError validating field `id` in model `User`: MongoDB `@default(auto())` fields must have `ObjectId` native type and use the `@id` attribute.[0m
           [1;94m-->[0m  [4mschema.prisma:13[0m
         [1;94m   | [0m
         [1;94m12 | [0m        model User {
@@ -780,7 +780,7 @@ fn must_error_on_dbgenerated_default_on_mongodb() {
     let error = datamodel::parse_schema(schema).map(drop).unwrap_err();
 
     let expected = expect![[r#"
-        [1;91merror[0m: [1mError validating field 'id': The `dbgenerated()` function is not allowed with MongoDB. Please use `auto()` instead.[0m
+        [1;91merror[0m: [1mError validating field `id` in model `User`: The `dbgenerated()` function is not allowed with MongoDB. Please use `auto()` instead.[0m
           [1;94m-->[0m  [4mschema.prisma:13[0m
         [1;94m   | [0m
         [1;94m12 | [0m        model User {
@@ -954,7 +954,7 @@ fn must_error_on_auto_default_on_non_id_on_mongodb() {
     let error = datamodel::parse_schema(schema).map(drop).unwrap_err();
 
     let expected = expect![[r#"
-        [1;91merror[0m: [1mError validating field 'nickname': MongoDB `@default(auto())` fields must have `ObjectId` native type and use the `@id` attribute.[0m
+        [1;91merror[0m: [1mError validating field `nickname` in model `User`: MongoDB `@default(auto())` fields must have `ObjectId` native type and use the `@id` attribute.[0m
           [1;94m-->[0m  [4mschema.prisma:14[0m
         [1;94m   | [0m
         [1;94m13 | [0m            id Int @id @map("_id")

--- a/libs/datamodel/core/tests/attributes/id_negative.rs
+++ b/libs/datamodel/core/tests/attributes/id_negative.rs
@@ -455,7 +455,7 @@ fn bytes_should_not_be_allowed_as_id_on_sql_server() {
 
     let error = datamodel::parse_schema(dml).map(drop).unwrap_err();
     let expected = expect![[r#"
-        [1;91merror[0m: [1mInvalid model: Using Bytes type is not allowed in the model's id..[0m
+        [1;91merror[0m: [1mInvalid model: Using Bytes type is not allowed in the model's id.[0m
           [1;94m-->[0m  [4mschema.prisma:10[0m
         [1;94m   | [0m
         [1;94m 9 | [0m

--- a/libs/datamodel/core/tests/common/mod.rs
+++ b/libs/datamodel/core/tests/common/mod.rs
@@ -498,6 +498,11 @@ pub(crate) fn parse_configuration(datamodel_string: &str) -> Configuration {
     }
 }
 
+pub(crate) fn expect_error(schema: &str, expectation: &expect_test::Expect) {
+    let err = parse_and_render_error(schema);
+    expectation.assert_eq(&err)
+}
+
 pub(crate) fn parse_and_render_error(schema: &str) -> String {
     parse_error(schema).to_pretty_string("schema.prisma", schema)
 }

--- a/libs/datamodel/core/tests/types/cockroachdb_native_types.rs
+++ b/libs/datamodel/core/tests/types/cockroachdb_native_types.rs
@@ -1,5 +1,4 @@
 use crate::{common::*, types::helper::test_native_types_without_attributes};
-use datamodel::{ast, diagnostics::DatamodelError};
 
 #[test]
 fn should_fail_on_invalid_precision_for_decimal_type() {
@@ -65,10 +64,13 @@ fn should_fail_on_native_type_decimal_when_scale_is_bigger_than_precision() {
         }
     "#;
 
-    let error = parse_error(dml);
-
-    error.assert_is(DatamodelError::new(
-        "The scale must not be larger than the precision for the Decimal(2,4) native type in CockroachDB.".into(),
-        ast::Span::new(299, 329),
-    ));
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mThe scale must not be larger than the precision for the Decimal(2,4) native type in CockroachDB.[0m
+          [1;94m-->[0m  [4mschema.prisma:14[0m
+        [1;94m   | [0m
+        [1;94m13 | [0m            id     Int   @id
+        [1;94m14 | [0m            dec Decimal @[1;91mdb.Decimal(2, 4)[0m
+        [1;94m   | [0m
+    "#]];
+    expect_error(dml, &expectation);
 }

--- a/libs/datamodel/core/tests/types/mongodb_native_types.rs
+++ b/libs/datamodel/core/tests/types/mongodb_native_types.rs
@@ -17,7 +17,7 @@ fn array_native_type_should_fail() {
     let error = datamodel::parse_schema(dml).map(drop).unwrap_err();
 
     let expectation = expect![[r#"
-        [1;91merror[0m: [1mError validating field 'post_ids': Native type `db.Array` is deprecated. Please use `db.ObjectId` instead.[0m
+        [1;91merror[0m: [1mError validating field `post_ids` in model `Blog`: Native type `db.Array` is deprecated. Please use `db.ObjectId` instead.[0m
           [1;94m-->[0m  [4mschema.prisma:9[0m
         [1;94m   | [0m
         [1;94m 8 | [0m            id     Int   @id @map("_id")

--- a/libs/datamodel/core/tests/types/mssql_native_types.rs
+++ b/libs/datamodel/core/tests/types/mssql_native_types.rs
@@ -107,13 +107,15 @@ fn should_fail_on_native_type_decimal_when_scale_is_bigger_than_precision() {
         }
     "#
     );
-
-    let error = parse_error(dml);
-
-    error.assert_is(DatamodelError::new(
-        "The scale must not be larger than the precision for the Decimal(2,4) native type in SQL Server.".into(),
-        ast::Span::new(113, 142),
-    ));
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mThe scale must not be larger than the precision for the Decimal(2,4) native type in SQL Server.[0m
+          [1;94m-->[0m  [4mschema.prisma:8[0m
+        [1;94m   | [0m
+        [1;94m 7 | [0m    id  Int     @id
+        [1;94m 8 | [0m    dec Decimal @[1;91mdb.Decimal(2,4)[0m
+        [1;94m   | [0m
+    "#]];
+    expect_error(dml, &expectation);
 }
 
 #[test]

--- a/libs/datamodel/core/tests/types/mysql_native_types.rs
+++ b/libs/datamodel/core/tests/types/mysql_native_types.rs
@@ -252,13 +252,15 @@ fn should_fail_on_native_type_decimal_when_scale_is_bigger_than_precision() {
         }
         "#
     );
-
-    let error = parse_error(dml);
-
-    error.assert_is(DatamodelError::new(
-        "The scale must not be larger than the precision for the Decimal(2,4) native type in MySQL.".into(),
-        ast::Span::new(101, 131),
-    ));
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mThe scale must not be larger than the precision for the Decimal(2,4) native type in MySQL.[0m
+          [1;94m-->[0m  [4mschema.prisma:8[0m
+        [1;94m   | [0m
+        [1;94m 7 | [0m    id     Int  @id
+        [1;94m 8 | [0m    dec Decimal @[1;91mdb.Decimal(2, 4)[0m
+        [1;94m   | [0m
+    "#]];
+    expect_error(dml, &expectation);
 }
 
 #[test]

--- a/libs/datamodel/core/tests/types/negative.rs
+++ b/libs/datamodel/core/tests/types/negative.rs
@@ -58,7 +58,6 @@ fn should_fail_on_endless_recursive_type_def() {
     }
     "#;
 
-    let error = datamodel::parse_schema(dml).map(drop).unwrap_err();
     let expectation = expect![[r#"
         [1;91merror[0m: [1mError validating: Recursive type definitions are not allowed. Recursive path was: MyString -> ID -> MyStringWithDefault -> MyString.[0m
           [1;94m-->[0m  [4mschema.prisma:2[0m
@@ -79,8 +78,7 @@ fn should_fail_on_endless_recursive_type_def() {
         [1;94m 4 | [0m    type ID = [1;91mMyStringWithDefault[0m
         [1;94m   | [0m
     "#]];
-
-    expectation.assert_eq(&error);
+    expect_error(dml, &expectation);
 }
 
 #[test]
@@ -245,12 +243,15 @@ fn should_fail_on_native_type_with_invalid_arguments() {
         }
     "#;
 
-    let error = parse_error(dml);
-
-    error.assert_is(DatamodelError::new(
-        "Expected a numeric value, but failed while parsing \"a\": invalid digit found in string.".into(),
-        ast::Span::new(178, 191),
-    ));
+    let expected = expect![[r#"
+        [1;91merror[0m: [1mExpected a numeric value, but failed while parsing "a": invalid digit found in string.[0m
+          [1;94m-->[0m  [4mschema.prisma:9[0m
+        [1;94m   | [0m
+        [1;94m 8 | [0m            id     Int    @id
+        [1;94m 9 | [0m            foobar String @[1;91mpg.VarChar(a)[0m
+        [1;94m   | [0m
+    "#]];
+    expect_error(dml, &expected)
 }
 
 #[test]

--- a/libs/datamodel/core/tests/types/postgres_native_types.rs
+++ b/libs/datamodel/core/tests/types/postgres_native_types.rs
@@ -2,7 +2,6 @@ use crate::{
     common::*,
     types::helper::{test_native_types_compatibility, test_native_types_without_attributes},
 };
-use datamodel::{ast, diagnostics::DatamodelError};
 use native_types::PostgresType;
 
 #[test]
@@ -89,12 +88,15 @@ fn should_fail_on_native_type_decimal_when_scale_is_bigger_than_precision() {
         }
     "#;
 
-    let error = parse_error(dml);
-
-    error.assert_is(DatamodelError::new(
-        "The scale must not be larger than the precision for the Decimal(2,4) native type in Postgres.".into(),
-        ast::Span::new(167, 197),
-    ));
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mThe scale must not be larger than the precision for the Decimal(2,4) native type in Postgres.[0m
+          [1;94m-->[0m  [4mschema.prisma:9[0m
+        [1;94m   | [0m
+        [1;94m 8 | [0m            id     Int   @id
+        [1;94m 9 | [0m            dec Decimal @[1;91mdb.Decimal(2, 4)[0m
+        [1;94m   | [0m
+    "#]];
+    expect_error(dml, &expectation);
 }
 
 #[test]

--- a/libs/datamodel/diagnostics/src/connector_error.rs
+++ b/libs/datamodel/diagnostics/src/connector_error.rs
@@ -1,21 +1,9 @@
-use std::fmt::Display;
+use crate::{DatamodelError, Span};
 use thiserror::Error;
 
-#[derive(Debug, Clone)]
-pub struct ConnectorError {
-    /// The error information for internal use.
-    kind: ErrorKind,
-}
-
-impl Display for ConnectorError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        Display::fmt(&self.kind, f)
-    }
-}
-
 pub struct ConnectorErrorFactory {
-    pub native_type: String,
-    pub connector: String,
+    native_type: String,
+    connector: String,
 }
 
 impl ConnectorErrorFactory {
@@ -23,160 +11,101 @@ impl ConnectorErrorFactory {
         ConnectorErrorFactory { native_type, connector }
     }
 
-    pub fn new_scale_larger_than_precision_error(self) -> ConnectorError {
-        ConnectorError::from_kind(ErrorKind::ScaleLargerThanPrecisionError {
-            native_type: self.native_type,
-            connector_name: self.connector,
-        })
+    pub fn new_scale_larger_than_precision_error(self, span: Span) -> DatamodelError {
+        DatamodelError::new(
+            ErrorKind::ScaleLargerThanPrecisionError {
+                native_type: self.native_type,
+                connector_name: self.connector,
+            }
+            .to_string()
+            .into(),
+            span,
+        )
     }
 
-    pub fn new_incompatible_native_type_with_index(self, message: &str) -> ConnectorError {
-        ConnectorError::from_kind(ErrorKind::IncompatibleNativeTypeWithIndexAttribute {
-            native_type: self.native_type,
-            connector_name: self.connector,
-            message: String::from(message),
-        })
+    pub fn new_incompatible_native_type_with_index(self, message: &str, span: Span) -> DatamodelError {
+        DatamodelError::new(
+            ErrorKind::IncompatibleNativeTypeWithIndexAttribute {
+                native_type: self.native_type,
+                connector_name: self.connector,
+                message: String::from(message),
+            }
+            .to_string()
+            .into(),
+            span,
+        )
     }
 
-    pub fn new_incompatible_native_type_with_unique(self, message: &str) -> ConnectorError {
-        ConnectorError::from_kind(ErrorKind::IncompatibleNativeTypeWithUniqueAttribute {
-            native_type: self.native_type,
-            connector_name: self.connector,
-            message: String::from(message),
-        })
+    pub fn new_incompatible_native_type_with_unique(self, message: &str, span: Span) -> DatamodelError {
+        DatamodelError::new(
+            ErrorKind::IncompatibleNativeTypeWithUniqueAttribute {
+                native_type: self.native_type,
+                connector_name: self.connector,
+                message: String::from(message),
+            }
+            .to_string()
+            .into(),
+            span,
+        )
     }
 
-    pub fn new_incompatible_native_type_with_id(self, message: &str) -> ConnectorError {
-        ConnectorError::from_kind(ErrorKind::IncompatibleNativeTypeWithIdAttribute {
-            native_type: self.native_type,
-            connector_name: self.connector,
-            message: String::from(message),
-        })
+    pub fn new_incompatible_native_type_with_id(self, message: &str, span: Span) -> DatamodelError {
+        DatamodelError::new(
+            ErrorKind::IncompatibleNativeTypeWithIdAttribute {
+                native_type: self.native_type,
+                connector_name: self.connector,
+                message: String::from(message),
+            }
+            .to_string()
+            .into(),
+            span,
+        )
     }
 
-    pub fn new_incompatible_sequential_type_with_static_default_value_error(self) -> ConnectorError {
-        ConnectorError::from_kind(ErrorKind::IncompatibleSequentialTypeWithStaticDefaultValue {
-            native_type: self.native_type,
-            connector_name: self.connector,
-        })
+    pub fn new_incompatible_sequential_type_with_static_default_value_error(self, span: Span) -> DatamodelError {
+        DatamodelError::new(
+            ErrorKind::IncompatibleSequentialTypeWithStaticDefaultValue {
+                native_type: self.native_type,
+                connector_name: self.connector,
+            }
+            .to_string()
+            .into(),
+            span,
+        )
     }
 
-    pub fn new_argument_m_out_of_range_error(self, message: &str) -> ConnectorError {
-        ConnectorError::from_kind(ErrorKind::ArgumentOutOfRangeError {
-            native_type: self.native_type,
-            connector_name: self.connector,
-            message: String::from(message),
-        })
+    pub fn new_argument_m_out_of_range_error(self, message: &str, span: Span) -> DatamodelError {
+        DatamodelError::new(
+            ErrorKind::ArgumentOutOfRangeError {
+                native_type: self.native_type,
+                connector_name: self.connector,
+                message: String::from(message),
+            }
+            .to_string()
+            .into(),
+            span,
+        )
     }
 
-    pub fn native_type_name_unknown(self) -> ConnectorError {
-        ConnectorError::from_kind(ErrorKind::NativeTypeNameUnknown {
-            native_type: self.native_type,
-            connector_name: self.connector,
-        })
-    }
-
-    pub fn native_type_invalid_param(self, expected: &str, got: &str) -> ConnectorError {
-        ConnectorError::from_kind(ErrorKind::InvalidArgumentError {
-            native_type: self.native_type,
-            expected: expected.into(),
-            got: got.into(),
-        })
-    }
-}
-
-impl ConnectorError {
-    pub fn from_kind(kind: ErrorKind) -> Self {
-        ConnectorError { kind }
-    }
-
-    pub fn new_argument_count_mismatch_error(
-        native_type: &str,
-        required_count: usize,
-        given_count: usize,
-    ) -> ConnectorError {
-        ConnectorError::from_kind(ErrorKind::ArgumentCountMisMatchError {
-            native_type: String::from(native_type),
-            required_count,
-            given_count,
-        })
-    }
-
-    pub fn new_value_parser_error(expected_type: &str, parser_error: &str, raw: &str) -> ConnectorError {
-        ConnectorError::from_kind(ErrorKind::ValueParserError {
-            expected_type: String::from(expected_type),
-            parser_error: String::from(parser_error),
-            raw: String::from(raw),
-        })
-    }
-
-    pub fn new_native_type_parser_error(native_type: &str) -> ConnectorError {
-        ConnectorError::from_kind(ErrorKind::InvalidNativeType {
-            native_type: String::from(native_type),
-        })
+    pub fn native_type_name_unknown(self, span: Span) -> DatamodelError {
+        DatamodelError::new(
+            ErrorKind::NativeTypeNameUnknown {
+                native_type: self.native_type,
+                connector_name: self.connector,
+            }
+            .to_string()
+            .into(),
+            span,
+        )
     }
 }
 
-#[derive(Debug, Error, Clone)]
-pub enum ErrorKind {
-    #[error("Native types are not supported with {} connector", connector_name)]
-    ConnectorNotSupportedForNativeTypes { connector_name: String },
-
-    #[error(
-        "The prefix {} is invalid. It must be equal to the name of an existing datasource e.g. {}. Did you mean to use {}?",
-        given_prefix,
-        expected_prefix,
-        suggestion
-    )]
-    InvalidPrefixForNativeTypes {
-        given_prefix: String,
-        expected_prefix: String,
-        suggestion: String,
-    },
-
-    #[error(
-        "Native type {} is not compatible with declared field type {}, expected field type {}.",
-        native_type,
-        field_type,
-        expected_types
-    )]
-    IncompatibleNativeType {
-        native_type: String,
-        field_type: &'static str,
-        expected_types: String,
-    },
-
-    #[error("Attribute @{} is defined twice.", attribute_name)]
-    DuplicateAttributeError { attribute_name: String },
-
+#[derive(Debug, Error)]
+enum ErrorKind {
     #[error("Native type {} is not supported for {} connector.", native_type, connector_name)]
     NativeTypeNameUnknown {
         native_type: String,
         connector_name: String,
-    },
-
-    #[error(
-        "Native type {} takes {} arguments, but received {}.",
-        native_type,
-        required_count,
-        given_count
-    )]
-    ArgumentCountMisMatchError {
-        native_type: String,
-        required_count: usize,
-        given_count: usize,
-    },
-
-    #[error(
-        "Native type {} takes {} optional arguments, but received {}.",
-        native_type,
-        optional_count,
-        given_count
-    )]
-    OptionalArgumentCountMismatchError {
-        native_type: String,
-        optional_count: usize,
-        given_count: usize,
     },
 
     #[error("Native type {} cannot be unique in {}.{}", native_type, connector_name, message)]
@@ -211,18 +140,6 @@ pub enum ErrorKind {
     },
 
     #[error(
-        "Expected a {} value, but failed while parsing \"{}\": {}.",
-        expected_type,
-        raw,
-        parser_error
-    )]
-    ValueParserError {
-        expected_type: String,
-        parser_error: String,
-        raw: String,
-    },
-
-    #[error(
         "The scale must not be larger than the precision for the {} native type in {}.",
         native_type,
         connector_name
@@ -253,20 +170,4 @@ pub enum ErrorKind {
         connector_name: String,
         message: String,
     },
-
-    #[error("Invalid argument for type {}: {}. Allowed values: {}.", native_type, got, expected)]
-    InvalidArgumentError {
-        native_type: String,
-        expected: String,
-        got: String,
-    },
-
-    #[error("Error validating field '{}': {}", field, message)]
-    FieldValidationError { field: String, message: String },
-
-    #[error("Invalid Native type {}.", native_type)]
-    InvalidNativeType { native_type: String },
-
-    #[error("Invalid model: {}.", message)]
-    InvalidModelError { message: String },
 }

--- a/libs/datamodel/diagnostics/src/lib.rs
+++ b/libs/datamodel/diagnostics/src/lib.rs
@@ -1,14 +1,14 @@
-pub mod connector_error;
-
 mod collection;
+mod connector_error;
 mod error;
 mod helper;
 mod span;
 mod validated;
 mod warning;
 
-pub use collection::*;
+pub use collection::Diagnostics;
+pub use connector_error::ConnectorErrorFactory;
 pub use error::DatamodelError;
 pub use span::Span;
-pub use validated::*;
+pub use validated::Validated;
 pub use warning::DatamodelWarning;

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour.rs
@@ -40,7 +40,7 @@ fn display_column_type(
     connector: &dyn datamodel::datamodel_connector::Connector,
 ) -> String {
     match &column.column_type().native_type {
-        Some(tpe) => connector.introspect_native_type(tpe.clone()).unwrap().to_string(),
+        Some(tpe) => connector.introspect_native_type(tpe.clone()).to_string(),
         _ => format!("{:?}", column.column_type_family()),
     }
 }

--- a/migration-engine/migration-engine-tests/src/assertions.rs
+++ b/migration-engine/migration-engine-tests/src/assertions.rs
@@ -463,7 +463,6 @@ impl<'a> ColumnAssertion<'a> {
     pub fn assert_native_type(self, expected: &str, connector: &dyn Connector) -> Self {
         let found = connector
             .introspect_native_type(self.column.tpe.native_type.clone().unwrap())
-            .unwrap()
             .to_string();
         assert!(
             found == expected,

--- a/prisma-fmt/src/native.rs
+++ b/prisma-fmt/src/native.rs
@@ -30,14 +30,14 @@ impl From<&NativeTypeConstructor> for SerializableNativeTypeConstructor {
     fn from(nt: &NativeTypeConstructor) -> Self {
         let NativeTypeConstructor {
             name,
-            _number_of_args,
-            _number_of_optional_args,
+            number_of_args,
+            number_of_optional_args,
             prisma_types,
         } = nt;
         SerializableNativeTypeConstructor {
             name,
-            _number_of_args: *_number_of_args,
-            _number_of_optional_args: *_number_of_optional_args,
+            _number_of_args: *number_of_args,
+            _number_of_optional_args: *number_of_optional_args,
             prisma_types: prisma_types.iter().map(|st| st.as_str()).collect(),
         }
     }


### PR DESCRIPTION
This type was part of datamodel connector a long time ago, and meant to
fulfill the need for a type of errors that couldn't depend on AST
information, that would be grafted on after the fact in datamodel core.
Now that we have ParserDatabase, this is pure accidental complexity
anymore, we know where we are in the AST.

This commit deletes ConnectorError and replaces it with regular
datamodel errors. It makes validation code both in datamodel-connector
and in the core more straightforward.