### PR TITLE
me: Implement --exit-code param

### DIFF
--- a/libs/test-cli/src/main.rs
+++ b/libs/test-cli/src/main.rs
@@ -441,6 +441,7 @@ async fn migrate_diff(cmd: &MigrateDiff) -> anyhow::Result<()> {
     };
 
     let input = DiffParams {
+        exit_code: None,
         from,
         script: cmd.script,
         shadow_database_url: None, // TODO

--- a/migration-engine/core/src/commands/diff.rs
+++ b/migration-engine/core/src/commands/diff.rs
@@ -52,7 +52,13 @@ pub async fn diff(params: DiffParams, host: Arc<dyn ConnectorHost>) -> CoreResul
         connector.host().print(&summary).await?;
     }
 
-    Ok(DiffResult { exit_code: 0 })
+    let exit_code = if params.exit_code == Some(true) && !connector.migration_is_empty(&migration) {
+        2
+    } else {
+        0
+    };
+
+    Ok(DiffResult { exit_code })
 }
 
 // `None` in case the target is empty

--- a/migration-engine/json-rpc-api-build/methods/diff.toml
+++ b/migration-engine/json-rpc-api-build/methods/diff.toml
@@ -65,6 +65,16 @@ executable script, pass the `"script": true` param.
 """
 shape = "bool"
 
+[recordShapes.diffParams.fields.exitCode]
+description = """
+Whether the --exit-code param was passed.
+
+If this is set, the engine will return exitCode = 2 in the diffResult in case the diff is
+non-empty. Other than this, it does not change the behaviour of the command.
+"""
+isNullable = true
+shape = "bool"
+
 [recordShapes.diffResult]
 description = "The result type for the `diff` method."
 

--- a/migration-engine/json-rpc-api-build/src/lib.rs
+++ b/migration-engine/json-rpc-api-build/src/lib.rs
@@ -133,7 +133,6 @@ struct RecordShape {
     description: Option<String>,
     #[serde(default)]
     fields: BTreeMap<String, RecordField>,
-    #[allow(dead_code)]
     example: Option<String>,
 }
 

--- a/migration-engine/json-rpc-api-build/src/rust_crate.rs
+++ b/migration-engine/json-rpc-api-build/src/rust_crate.rs
@@ -72,6 +72,15 @@ fn generate_types_rs(mut file: impl std::io::Write, api: &Api) -> CrateResult {
             }
         }
 
+        if let Some(example) = &record_type.example {
+            file.write_all(b"/// ### Example\n///\n/// ```ignore")?;
+            for line in example.lines() {
+                file.write_all(b"\n/// ")?;
+                file.write_all(line.as_bytes())?;
+            }
+            file.write_all(b"\n/// ```\n")?;
+        }
+
         writeln!(
             file,
             "#[derive(Serialize, Deserialize, Debug)]\npub struct {} {{",
@@ -106,7 +115,9 @@ fn generate_types_rs(mut file: impl std::io::Write, api: &Api) -> CrateResult {
             for line in description.lines() {
                 writeln!(file, "/// {}", line)?;
             }
+
         }
+
         writeln!(
             file,
             "#[derive(Serialize, Deserialize, Debug)]\n#[serde(tag = \"tag\")]\npub enum {} {{",

--- a/migration-engine/json-rpc-api-build/src/rust_crate.rs
+++ b/migration-engine/json-rpc-api-build/src/rust_crate.rs
@@ -115,7 +115,6 @@ fn generate_types_rs(mut file: impl std::io::Write, api: &Api) -> CrateResult {
             for line in description.lines() {
                 writeln!(file, "/// {}", line)?;
             }
-
         }
 
         writeln!(

--- a/migration-engine/migration-engine-tests/tests/migrations/drift_summary.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/drift_summary.rs
@@ -7,6 +7,7 @@ fn check(from: &str, to: &str, expectation: Expect) {
     let from_schema = write_file_to_tmp(from, &tmpdir, "from.prisma");
     let to_schema = write_file_to_tmp(to, &tmpdir, "to.prisma");
     let params = DiffParams {
+        exit_code: None,
         from: migration_core::json_rpc::types::DiffTarget::SchemaDatamodel(SchemaContainer {
             schema: from_schema.to_str().unwrap().to_owned(),
         }),

--- a/migration-engine/qe-setup/src/lib.rs
+++ b/migration-engine/qe-setup/src/lib.rs
@@ -127,6 +127,7 @@ async fn diff_and_apply(schema: &str) {
 
     // 2. create the database schema for given Prisma schema
     api.diff(DiffParams {
+        exit_code: None,
         from: DiffTarget::Empty,
         to: DiffTarget::SchemaDatamodel(SchemaContainer {
             schema: schema_file_path.to_string_lossy().into(),


### PR DESCRIPTION
The `diff` RPC method now takes an optional `exitCode` boolean param. If
it is set to true, the `exitCode` field in the `DiffResult` returned by
the method will be set to 0 if there is no detected diff (the schemas
are in sync), and 2 otherwise.

Issue: prisma/prisma#11566