### PR TITLE
Remove the Clone bound on SqlSchema

### DIFF
--- a/libs/sql-schema-describer/src/lib.rs
+++ b/libs/sql-schema-describer/src/lib.rs
@@ -46,7 +46,7 @@ pub struct SqlMetadata {
 }
 
 /// The result of describing a database schema.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Default)]
 pub struct SqlSchema {
     /// The schema's tables.
     pub tables: Vec<Table>,
@@ -158,7 +158,7 @@ impl SqlSchema {
 }
 
 /// A table found in a schema.
-#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
 pub struct Table {
     /// The table's name.
     pub name: String,
@@ -405,7 +405,7 @@ impl PrimaryKey {
 }
 
 /// A column of a table.
-#[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
 pub struct Column {
     /// Column name.
     pub name: String,
@@ -424,7 +424,7 @@ impl Column {
 }
 
 /// The type of a column.
-#[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
 pub struct ColumnType {
     /// The full SQL data type, the sql string necessary to recreate the column, drawn directly from the db, used when there is no native type.
     pub full_data_type: String,
@@ -457,7 +457,7 @@ impl ColumnType {
 }
 
 /// Enumeration of column type families.
-#[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
 // TODO: this name feels weird.
 pub enum ColumnTypeFamily {
     /// Integer types.
@@ -524,7 +524,7 @@ impl ColumnTypeFamily {
 }
 
 /// A column's arity.
-#[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
 pub enum ColumnArity {
     /// Required column.
     Required,

--- a/libs/sql-schema-describer/src/mysql.rs
+++ b/libs/sql-schema-describer/src/mysql.rs
@@ -790,23 +790,22 @@ impl<'a> SqlSchemaDescriber<'a> {
             _ => (ColumnTypeFamily::Unsupported(full_data_type.into()), None),
         };
 
+        let enm = match &family {
+            ColumnTypeFamily::Enum(name) => Some(Enum {
+                name: name.clone(),
+                values: Self::extract_enum_values(&full_data_type),
+            }),
+            _ => None,
+        };
+
         let tpe = ColumnType {
             full_data_type: full_data_type.to_owned(),
-            family: family.clone(),
+            family,
             arity,
             native_type: native_type.map(|x| x.to_json()),
         };
 
-        match &family {
-            ColumnTypeFamily::Enum(name) => (
-                tpe,
-                Some(Enum {
-                    name: name.clone(),
-                    values: Self::extract_enum_values(&full_data_type),
-                }),
-            ),
-            _ => (tpe, None),
-        }
+        (tpe, enm)
     }
 
     fn extract_precision(input: &str) -> Option<u32> {

--- a/libs/sql-schema-describer/tests/describers/mysql_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/mysql_describer_tests.rs
@@ -99,8 +99,8 @@ fn all_mysql_column_types_must_work(api: TestApi) {
 
     let full_sql = migration.make::<barrel::backend::MySql>();
     api.raw_cmd(&full_sql);
-    let result = api.describe();
-    let mut table = result.get_table("User").expect("couldn't get User table").to_owned();
+    let mut result = api.describe();
+    let table = result.tables.iter_mut().find(|t| t.name == "User").unwrap();
     // Ensure columns are sorted as expected when comparing
     table.columns.sort_unstable_by_key(|c| c.name.to_owned());
     let mut expected_columns = vec![
@@ -580,7 +580,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
 
     assert_eq!(
         table,
-        Table {
+        &Table {
             name: "User".to_string(),
             columns: expected_columns,
             indices: vec![],
@@ -641,8 +641,8 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
 
     let full_sql = migration.make::<barrel::backend::MySql>();
     api.raw_cmd(&full_sql);
-    let result = api.describe();
-    let mut table = result.get_table("User").expect("couldn't get User table").to_owned();
+    let mut result = api.describe();
+    let table = result.tables.iter_mut().find(|t| t.name == "User").unwrap();
     // Ensure columns are sorted as expected when comparing
     table.columns.sort_unstable_by_key(|c| c.name.to_owned());
     let mut expected_columns = vec![
@@ -1110,7 +1110,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
 
     assert_eq!(
         table,
-        Table {
+        &Table {
             name: "User".to_string(),
             columns: expected_columns,
             indices: vec![],

--- a/libs/sql-schema-describer/tests/describers/postgres_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/postgres_describer_tests.rs
@@ -77,10 +77,10 @@ fn all_postgres_column_types_must_work(api: TestApi) {
 
     let full_sql = migration.make::<barrel::backend::Pg>();
     api.raw_cmd(&full_sql);
-    let result = api.describe();
-    let mut table = result.get_table("User").expect("couldn't get User table").to_owned();
+    let mut result = api.describe();
+    let table = result.tables.iter_mut().find(|t| t.name == "User").unwrap();
     // Ensure columns are sorted as expected when comparing
-    table.columns.sort_unstable_by_key(|c| c.name.to_owned());
+    table.columns.sort_unstable_by(|a, b| a.name.cmp(&b.name));
     let mut expected_columns = vec![
         Column {
             name: "array_bin_col".into(),
@@ -560,7 +560,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
 
     assert_eq!(
         table,
-        Table {
+        &Table {
             name: "User".into(),
             columns: expected_columns,
             indices: vec![Index {

--- a/libs/sql-schema-describer/tests/describers/sqlite_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/sqlite_describer_tests.rs
@@ -143,13 +143,13 @@ async fn sqlite_foreign_key_on_delete_must_be_handled() {
             city_set_default INTEGER REFERENCES City(id) ON DELETE SET DEFAULT,
             city_set_null INTEGER REFERENCES City(id) ON DELETE SET NULL
         )";
-    let schema = describe_sqlite(sql).await;
-    let mut table = schema.get_table("User").expect("get User table").to_owned();
+    let mut schema = describe_sqlite(sql).await;
+    let table = schema.tables.iter_mut().find(|t| t.name == "User").unwrap();
     table.foreign_keys.sort_unstable_by_key(|fk| fk.columns.clone());
 
     assert_eq!(
         table,
-        Table {
+        &Table {
             name: "User".to_string(),
             columns: vec![
                 Column {


### PR DESCRIPTION
- It is not used.
- Using it would be very expensive. Rc<SqlSchema> or Arc<SqlSchema> are
  a much better solution if you need sharing.
- It prevents us from progressively changing the native types mechanism.