### PR TITLE
datamodel: Export dml from a single module

### DIFF
--- a/introspection-engine/connectors/introspection-connector/src/lib.rs
+++ b/introspection-engine/connectors/introspection-connector/src/lib.rs
@@ -2,7 +2,7 @@ mod error;
 
 use core::fmt;
 use datamodel::common::preview_features::PreviewFeature;
-use datamodel::{Datamodel, Datasource};
+use datamodel::{dml::Datamodel, Datasource};
 use enumflags2::BitFlags;
 pub use error::{ConnectorError, ErrorKind};
 use serde::*;

--- a/introspection-engine/connectors/mongodb-introspection-connector/src/lib.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/src/lib.rs
@@ -2,10 +2,10 @@ mod error;
 mod sampler;
 mod warnings;
 
-use enumflags2::BitFlags;
 pub use error::*;
 
-use datamodel::{common::preview_features::PreviewFeature, Datamodel};
+use datamodel::{common::preview_features::PreviewFeature, dml::Datamodel};
+use enumflags2::BitFlags;
 use futures::TryStreamExt;
 use indoc::formatdoc;
 use introspection_connector::{

--- a/introspection-engine/connectors/mongodb-introspection-connector/src/sampler/field_type.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/src/sampler/field_type.rs
@@ -1,4 +1,4 @@
-use datamodel::{NativeTypeInstance, ScalarType};
+use datamodel::dml::{self, NativeTypeInstance, ScalarType};
 use mongodb::bson::Bson;
 use native_types::MongoDbType;
 use std::fmt;
@@ -84,60 +84,60 @@ impl fmt::Display for FieldType {
     }
 }
 
-impl From<FieldType> for datamodel::CompositeTypeFieldType {
+impl From<FieldType> for dml::CompositeTypeFieldType {
     fn from(r#type: FieldType) -> Self {
         match r#type {
-            FieldType::String => datamodel::CompositeTypeFieldType::Scalar(ScalarType::String, None, None),
-            FieldType::Double => datamodel::CompositeTypeFieldType::Scalar(ScalarType::Float, None, None),
-            FieldType::BinData => datamodel::CompositeTypeFieldType::Scalar(ScalarType::Bytes, None, None),
-            FieldType::ObjectId => datamodel::CompositeTypeFieldType::Scalar(
+            FieldType::String => dml::CompositeTypeFieldType::Scalar(ScalarType::String, None, None),
+            FieldType::Double => dml::CompositeTypeFieldType::Scalar(ScalarType::Float, None, None),
+            FieldType::BinData => dml::CompositeTypeFieldType::Scalar(ScalarType::Bytes, None, None),
+            FieldType::ObjectId => dml::CompositeTypeFieldType::Scalar(
                 ScalarType::String,
                 None,
                 Some(NativeTypeInstance::new("ObjectId", Vec::new(), &MongoDbType::ObjectId)),
             ),
-            FieldType::Bool => datamodel::CompositeTypeFieldType::Scalar(ScalarType::Boolean, None, None),
-            FieldType::Date => datamodel::CompositeTypeFieldType::Scalar(
+            FieldType::Bool => dml::CompositeTypeFieldType::Scalar(ScalarType::Boolean, None, None),
+            FieldType::Date => dml::CompositeTypeFieldType::Scalar(
                 ScalarType::DateTime,
                 None,
                 Some(NativeTypeInstance::new("Date", Vec::new(), &MongoDbType::Date)),
             ),
-            FieldType::Int32 => datamodel::CompositeTypeFieldType::Scalar(ScalarType::Int, None, None),
-            FieldType::Timestamp => datamodel::CompositeTypeFieldType::Scalar(ScalarType::DateTime, None, None),
-            FieldType::Int64 => datamodel::CompositeTypeFieldType::Scalar(ScalarType::BigInt, None, None),
-            FieldType::Decimal => datamodel::CompositeTypeFieldType::Scalar(ScalarType::Decimal, None, None),
-            FieldType::Json => datamodel::CompositeTypeFieldType::Scalar(ScalarType::Json, None, None),
-            FieldType::Document(name) => datamodel::CompositeTypeFieldType::CompositeType(name),
-            FieldType::Array(r#type) => datamodel::CompositeTypeFieldType::from(*r#type),
-            FieldType::Unsupported(name) => datamodel::CompositeTypeFieldType::Unsupported(name.to_string()),
+            FieldType::Int32 => dml::CompositeTypeFieldType::Scalar(ScalarType::Int, None, None),
+            FieldType::Timestamp => dml::CompositeTypeFieldType::Scalar(ScalarType::DateTime, None, None),
+            FieldType::Int64 => dml::CompositeTypeFieldType::Scalar(ScalarType::BigInt, None, None),
+            FieldType::Decimal => dml::CompositeTypeFieldType::Scalar(ScalarType::Decimal, None, None),
+            FieldType::Json => dml::CompositeTypeFieldType::Scalar(ScalarType::Json, None, None),
+            FieldType::Document(name) => dml::CompositeTypeFieldType::CompositeType(name),
+            FieldType::Array(r#type) => dml::CompositeTypeFieldType::from(*r#type),
+            FieldType::Unsupported(name) => dml::CompositeTypeFieldType::Unsupported(name.to_string()),
         }
     }
 }
 
-impl From<FieldType> for datamodel::FieldType {
+impl From<FieldType> for dml::FieldType {
     fn from(r#type: FieldType) -> Self {
         match r#type {
-            FieldType::String => datamodel::FieldType::Scalar(ScalarType::String, None, None),
-            FieldType::Double => datamodel::FieldType::Scalar(ScalarType::Float, None, None),
-            FieldType::BinData => datamodel::FieldType::Scalar(ScalarType::Bytes, None, None),
-            FieldType::ObjectId => datamodel::FieldType::Scalar(
+            FieldType::String => dml::FieldType::Scalar(ScalarType::String, None, None),
+            FieldType::Double => dml::FieldType::Scalar(ScalarType::Float, None, None),
+            FieldType::BinData => dml::FieldType::Scalar(ScalarType::Bytes, None, None),
+            FieldType::ObjectId => dml::FieldType::Scalar(
                 ScalarType::String,
                 None,
                 Some(NativeTypeInstance::new("ObjectId", Vec::new(), &MongoDbType::ObjectId)),
             ),
-            FieldType::Bool => datamodel::FieldType::Scalar(ScalarType::Boolean, None, None),
-            FieldType::Date => datamodel::FieldType::Scalar(
+            FieldType::Bool => dml::FieldType::Scalar(ScalarType::Boolean, None, None),
+            FieldType::Date => dml::FieldType::Scalar(
                 ScalarType::DateTime,
                 None,
                 Some(NativeTypeInstance::new("Date", Vec::new(), &MongoDbType::Date)),
             ),
-            FieldType::Int32 => datamodel::FieldType::Scalar(ScalarType::Int, None, None),
-            FieldType::Timestamp => datamodel::FieldType::Scalar(ScalarType::DateTime, None, None),
-            FieldType::Int64 => datamodel::FieldType::Scalar(ScalarType::BigInt, None, None),
-            FieldType::Decimal => datamodel::FieldType::Scalar(ScalarType::Decimal, None, None),
-            FieldType::Json => datamodel::FieldType::Scalar(ScalarType::Json, None, None),
-            FieldType::Document(name) => datamodel::FieldType::CompositeType(name),
-            FieldType::Array(r#type) => datamodel::FieldType::from(*r#type),
-            FieldType::Unsupported(type_name) => datamodel::FieldType::Unsupported(type_name.to_string()),
+            FieldType::Int32 => dml::FieldType::Scalar(ScalarType::Int, None, None),
+            FieldType::Timestamp => dml::FieldType::Scalar(ScalarType::DateTime, None, None),
+            FieldType::Int64 => dml::FieldType::Scalar(ScalarType::BigInt, None, None),
+            FieldType::Decimal => dml::FieldType::Scalar(ScalarType::Decimal, None, None),
+            FieldType::Json => dml::FieldType::Scalar(ScalarType::Json, None, None),
+            FieldType::Document(name) => dml::FieldType::CompositeType(name),
+            FieldType::Array(r#type) => dml::FieldType::from(*r#type),
+            FieldType::Unsupported(type_name) => dml::FieldType::Unsupported(type_name.to_string()),
         }
     }
 }

--- a/introspection-engine/connectors/mongodb-introspection-connector/tests/errors/mod.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/tests/errors/mod.rs
@@ -1,5 +1,5 @@
 use crate::test_api::*;
-use datamodel::Datamodel;
+use datamodel::dml::Datamodel;
 use introspection_connector::{IntrospectionConnector, IntrospectionContext};
 use mongodb_introspection_connector::MongoDbIntrospectionConnector;
 use url::Url;

--- a/introspection-engine/connectors/sql-introspection-connector/src/calculate_datamodel.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/calculate_datamodel.rs
@@ -5,7 +5,7 @@ use crate::sanitize_datamodel_names::{sanitization_leads_to_duplicate_names, san
 use crate::version_checker::VersionChecker;
 use crate::SqlIntrospectionResult;
 use crate::{commenting_out_guardrails::commenting_out_guardrails, introspection::introspect};
-use datamodel::Datamodel;
+use datamodel::dml::Datamodel;
 use introspection_connector::{IntrospectionContext, IntrospectionResult};
 use sql_schema_describer::*;
 use tracing::debug;

--- a/introspection-engine/connectors/sql-introspection-connector/src/calculate_datamodel_tests.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/calculate_datamodel_tests.rs
@@ -2,9 +2,13 @@
 mod tests {
     use crate::calculate_datamodel::calculate_datamodel;
     use datamodel::{
-        ast::Span, dml, Datamodel, Datasource, DefaultValue as DMLDefault, Field, FieldArity, FieldType,
-        IndexDefinition, IndexField, Model, NativeTypeInstance, PrimaryKeyDefinition, PrimaryKeyField,
-        ReferentialAction, RelationField, RelationInfo, ScalarField, ScalarType, StringFromEnvVar, ValueGenerator,
+        ast::Span,
+        dml::{
+            self, Datamodel, DefaultValue as DMLDefault, Field, FieldArity, FieldType, IndexDefinition, IndexField,
+            Model, NativeTypeInstance, PrimaryKeyDefinition, PrimaryKeyField, ReferentialAction, RelationField,
+            RelationInfo, ScalarField, ScalarType, ValueGenerator,
+        },
+        Datasource, StringFromEnvVar,
     };
     use enumflags2::BitFlags;
     use expect_test::expect;

--- a/introspection-engine/connectors/sql-introspection-connector/src/commenting_out_guardrails.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/commenting_out_guardrails.rs
@@ -4,7 +4,7 @@ use crate::warnings::{
     ModelAndFieldAndType,
 };
 use crate::SqlFamilyTrait;
-use datamodel::{Datamodel, FieldType};
+use datamodel::dml::{Datamodel, FieldType};
 use introspection_connector::{IntrospectionContext, Warning};
 
 pub fn commenting_out_guardrails(datamodel: &mut Datamodel, ctx: &IntrospectionContext) -> Vec<Warning> {

--- a/introspection-engine/connectors/sql-introspection-connector/src/introspection.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/introspection.rs
@@ -5,11 +5,10 @@ use crate::introspection_helpers::{
 };
 use crate::version_checker::VersionChecker;
 
-use crate::SqlError;
-use crate::{Dedup, SqlFamilyTrait};
+use crate::{Dedup, SqlError, SqlFamilyTrait};
 use datamodel::{
-    common::preview_features::PreviewFeature, dml, Datamodel, Field, Model, PrimaryKeyDefinition, PrimaryKeyField,
-    RelationField, SortOrder,
+    common::preview_features::PreviewFeature,
+    dml::{self, Datamodel, Field, Model, PrimaryKeyDefinition, PrimaryKeyField, RelationField, SortOrder},
 };
 use introspection_connector::IntrospectionContext;
 use sql_schema_describer::{SQLSortOrder, SqlSchema, Table};

--- a/introspection-engine/connectors/sql-introspection-connector/src/introspection_helpers.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/introspection_helpers.rs
@@ -1,10 +1,12 @@
 use crate::Dedup;
 use crate::SqlError;
-use datamodel::IndexAlgorithm;
 use datamodel::{
-    common::preview_features::PreviewFeature, common::RelationNames, Datamodel, DefaultValue as DMLDef, FieldArity,
-    FieldType, IndexDefinition, IndexField, Model, PrimaryKeyField, ReferentialAction, RelationField, RelationInfo,
-    ScalarField, ScalarType, SortOrder, ValueGenerator as VG,
+    common::{preview_features::PreviewFeature, RelationNames},
+    dml::{
+        Datamodel, DefaultValue as DMLDef, FieldArity, FieldType, IndexAlgorithm, IndexDefinition, IndexField, Model,
+        PrimaryKeyField, ReferentialAction, RelationField, RelationInfo, ScalarField, ScalarType, SortOrder,
+        ValueGenerator as VG,
+    },
 };
 use introspection_connector::IntrospectionContext;
 use sql_schema_describer::SQLIndexAlgorithm;

--- a/introspection-engine/connectors/sql-introspection-connector/src/lib.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::vec_init_then_push)]
 
 pub mod calculate_datamodel; // only exported to be able to unit test it
+
 mod calculate_datamodel_tests;
 mod commenting_out_guardrails;
 mod error;
@@ -13,10 +14,10 @@ mod schema_describer_loading;
 mod version_checker;
 mod warnings;
 
-use datamodel::common::preview_features::PreviewFeature;
-use datamodel::Datamodel;
-use enumflags2::BitFlags;
 pub use error::*;
+
+use datamodel::{common::preview_features::PreviewFeature, dml::Datamodel};
+use enumflags2::BitFlags;
 use introspection_connector::{
     ConnectorError, ConnectorResult, DatabaseMetadata, ErrorKind, IntrospectionConnector, IntrospectionContext,
     IntrospectionResult,

--- a/introspection-engine/connectors/sql-introspection-connector/src/prisma_1_defaults.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/prisma_1_defaults.rs
@@ -1,6 +1,6 @@
 use crate::warnings::{warning_default_cuid_warning, warning_default_uuid_warning, ModelAndField};
 use crate::SqlFamilyTrait;
-use datamodel::{dml, Datamodel, ValueGenerator};
+use datamodel::dml::{self, Datamodel, ValueGenerator};
 use introspection_connector::{IntrospectionContext, Version, Warning};
 use native_types::{MySqlType, PostgresType};
 use sql_schema_describer::SqlSchema;

--- a/introspection-engine/connectors/sql-introspection-connector/src/re_introspection.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/re_introspection.rs
@@ -2,7 +2,7 @@ use crate::introspection_helpers::{
     replace_index_field_names, replace_pk_field_names, replace_relation_info_field_names,
 };
 use crate::{warnings::*, SqlFamilyTrait};
-use datamodel::{Datamodel, DefaultValue, Field, FieldType, Ignorable, ValueGenerator, WithName};
+use datamodel::dml::{Datamodel, DefaultValue, Field, FieldType, Ignorable, ValueGenerator, WithName};
 use introspection_connector::{IntrospectionContext, Warning};
 use prisma_value::PrismaValue;
 use std::cmp::Ordering::{self, Equal, Greater, Less};

--- a/introspection-engine/connectors/sql-introspection-connector/src/sanitize_datamodel_names.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/sanitize_datamodel_names.rs
@@ -1,7 +1,10 @@
 use crate::SqlFamilyTrait;
 use datamodel::{
-    is_reserved_type_name, Datamodel, DefaultKind, DefaultValue, Field, FieldType, IndexField, Model, PrimaryKeyField,
-    ValueGenerator, WithDatabaseName, WithName,
+    dml::{
+        Datamodel, DefaultKind, DefaultValue, Field, FieldType, IndexField, Model, PrimaryKeyField, ValueGenerator,
+        WithDatabaseName, WithName,
+    },
+    is_reserved_type_name,
 };
 use introspection_connector::IntrospectionContext;
 use once_cell::sync::Lazy;

--- a/introspection-engine/connectors/sql-introspection-connector/src/version_checker.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/version_checker.rs
@@ -3,7 +3,7 @@ use crate::introspection_helpers::{
     is_prisma_1_point_1_or_2_join_table, is_relay_table,
 };
 use crate::SqlFamilyTrait;
-use datamodel::{Datamodel, Model};
+use datamodel::dml::{Datamodel, Model};
 use introspection_connector::{IntrospectionContext, Version, Warning};
 use native_types::{MySqlType, PostgresType};
 use quaint::connector::SqlFamily;

--- a/introspection-engine/core/src/rpc.rs
+++ b/introspection-engine/core/src/rpc.rs
@@ -1,5 +1,5 @@
 use crate::error::Error;
-use datamodel::{Configuration, Datamodel};
+use datamodel::{dml::Datamodel, Configuration};
 use introspection_connector::{
     CompositeTypeDepth, ConnectorResult, DatabaseMetadata, IntrospectionConnector, IntrospectionContext,
     IntrospectionResultOutput,

--- a/introspection-engine/introspection-engine-tests/src/test_api.rs
+++ b/introspection-engine/introspection-engine-tests/src/test_api.rs
@@ -5,7 +5,7 @@ pub use test_setup::{BitFlags, Capabilities, Tags};
 
 use crate::{BarrelMigrationExecutor, Result};
 use datamodel::common::preview_features::PreviewFeature;
-use datamodel::{Configuration, Datamodel};
+use datamodel::{dml::Datamodel, Configuration};
 use introspection_connector::{
     CompositeTypeDepth, ConnectorResult, DatabaseMetadata, IntrospectionConnector, IntrospectionContext,
     IntrospectionResult, Version,

--- a/libs/datamodel/core/src/ast/reformat/reformatter.rs
+++ b/libs/datamodel/core/src/ast/reformat/reformatter.rs
@@ -1,5 +1,5 @@
 use super::helpers::*;
-use crate::{Datamodel, Datasource};
+use crate::{dml::Datamodel, Datasource};
 use enumflags2::BitFlags;
 use pest::{iterators::Pair, Parser};
 use schema_ast::{

--- a/libs/datamodel/core/src/dml/mod.rs
+++ b/libs/datamodel/core/src/dml/mod.rs
@@ -4,12 +4,11 @@ pub use dml::default_value::*;
 pub use dml::field::*;
 pub use dml::model::*;
 pub use dml::native_type_instance::*;
+pub use dml::prisma_value::{self, PrismaValue};
 pub use dml::r#enum::*;
 pub use dml::relation_info::*;
 pub use dml::scalars::*;
 pub use dml::traits::*;
-
-pub use dml::PrismaValue;
 
 /// Find the model mapping to the passed in database name.
 pub fn find_model_by_db_name<'a>(datamodel: &'a Datamodel, db_name: &str) -> Option<&'a Model> {

--- a/libs/datamodel/core/src/transform/ast_to_dml/lift.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/lift.rs
@@ -1,7 +1,7 @@
 use crate::{
-    ast, dml,
+    ast,
+    dml::{self, IndexField, PrimaryKeyField},
     transform::ast_to_dml::db::{self, walkers::*, IndexAlgorithm},
-    IndexField, PrimaryKeyField,
 };
 use ::dml::composite_type::{CompositeType, CompositeTypeField, CompositeTypeFieldType};
 use datamodel_connector::{walker_ext_traits::*, Connector, ReferentialIntegrity, ScalarType};

--- a/libs/datamodel/core/src/transform/dml_to_ast/lower.rs
+++ b/libs/datamodel/core/src/transform/dml_to_ast/lower.rs
@@ -1,5 +1,9 @@
-use crate::common::preview_features::PreviewFeature;
-use crate::{ast, dml, Datasource, IndexField, PrimaryKeyField, SortOrder};
+use crate::{
+    ast,
+    common::preview_features::PreviewFeature,
+    dml::{self, IndexField, PrimaryKeyField, SortOrder},
+    Datasource,
+};
 use enumflags2::BitFlags;
 
 pub struct LowerDmlToAst<'a> {

--- a/libs/datamodel/core/src/transform/dml_to_ast/lower_field.rs
+++ b/libs/datamodel/core/src/transform/dml_to_ast/lower_field.rs
@@ -1,9 +1,9 @@
 use crate::{
     ast::{self, Attribute, Span},
     common::{constraint_names::ConstraintNames, preview_features::PreviewFeature, RelationNames},
-    dml,
+    dml::{self, Field, Ignorable, SortOrder},
     transform::dml_to_ast::LowerDmlToAst,
-    Datasource, Field, Ignorable, SortOrder,
+    Datasource,
 };
 use ::dml::{prisma_value, traits::WithName, PrismaValue};
 use datamodel_connector::{Connector, EmptyDatamodelConnector};

--- a/libs/datamodel/core/src/transform/dml_to_ast/lower_model_attributes.rs
+++ b/libs/datamodel/core/src/transform/dml_to_ast/lower_model_attributes.rs
@@ -3,7 +3,7 @@ use crate::common::preview_features::PreviewFeature;
 use crate::transform::dml_to_ast::LowerDmlToAst;
 use crate::{
     ast::{self, Span},
-    dml, Ignorable, IndexDefinition, IndexType, Model, SortOrder, WithDatabaseName,
+    dml::{self, Ignorable, IndexDefinition, IndexType, Model, SortOrder, WithDatabaseName},
 };
 use ::dml::model::IndexAlgorithm;
 

--- a/libs/datamodel/core/tests/attributes/builtin_attributes.rs
+++ b/libs/datamodel/core/tests/attributes/builtin_attributes.rs
@@ -1,5 +1,4 @@
 use crate::common::*;
-use datamodel::ScalarType;
 
 #[test]
 fn unique_attribute() {

--- a/libs/datamodel/core/tests/attributes/constraint_names.rs
+++ b/libs/datamodel/core/tests/attributes/constraint_names.rs
@@ -1,6 +1,5 @@
 use crate::common::*;
 use datamodel::render_datamodel_to_with_preview_flags;
-use indoc::indoc;
 
 #[test]
 fn constraint_names() {

--- a/libs/datamodel/core/tests/attributes/constraint_names_negative.rs
+++ b/libs/datamodel/core/tests/attributes/constraint_names_negative.rs
@@ -1,5 +1,4 @@
-use crate::common::*;
-use crate::{with_header, Provider};
+use crate::{common::*, with_header, Provider};
 
 const SQL_SERVER: &str = r#"datasource sqlserver {
                                          provider = "sqlserver"

--- a/libs/datamodel/core/tests/attributes/constraint_names_positive.rs
+++ b/libs/datamodel/core/tests/attributes/constraint_names_positive.rs
@@ -1,5 +1,4 @@
-use crate::common::{parse, DatamodelAsserts, ModelAsserts};
-use datamodel::{IndexDefinition, IndexField, IndexType};
+use crate::common::*;
 
 #[test]
 fn multiple_indexes_with_same_name_on_different_models_are_supported_by_mysql() {

--- a/libs/datamodel/core/tests/attributes/default_composite_positive.rs
+++ b/libs/datamodel/core/tests/attributes/default_composite_positive.rs
@@ -1,8 +1,6 @@
 use crate::common::*;
 use bigdecimal::{BigDecimal, FromPrimitive};
 use chrono::DateTime;
-use datamodel::{DefaultValue, ScalarType};
-use dml::prisma_value::PrismaValue;
 
 #[test]
 fn should_set_default_for_all_scalar_types() {

--- a/libs/datamodel/core/tests/attributes/default_positive.rs
+++ b/libs/datamodel/core/tests/attributes/default_positive.rs
@@ -1,9 +1,6 @@
 use crate::common::*;
 use bigdecimal::{BigDecimal, FromPrimitive};
 use chrono::DateTime;
-use datamodel::{DefaultValue, ScalarType, ValueGenerator};
-use dml::prisma_value::PrismaValue;
-use indoc::indoc;
 
 #[test]
 fn should_set_default_for_all_scalar_types() {

--- a/libs/datamodel/core/tests/attributes/id_negative.rs
+++ b/libs/datamodel/core/tests/attributes/id_negative.rs
@@ -1,6 +1,4 @@
-use crate::common::*;
-use crate::{with_header, Provider};
-use indoc::indoc;
+use crate::{common::*, with_header, Provider};
 
 #[test]
 fn id_should_error_if_the_field_is_not_required() {

--- a/libs/datamodel/core/tests/attributes/id_positive.rs
+++ b/libs/datamodel/core/tests/attributes/id_positive.rs
@@ -1,7 +1,4 @@
-use crate::common::*;
-use crate::{with_header, Provider};
-use datamodel::dml::*;
-use dml::prisma_value::PrismaValue;
+use crate::{common::*, with_header, Provider};
 
 #[test]
 fn int_id_without_default_should_have_strategy_none() {

--- a/libs/datamodel/core/tests/attributes/ignore_negative.rs
+++ b/libs/datamodel/core/tests/attributes/ignore_negative.rs
@@ -1,5 +1,4 @@
 use crate::common::*;
-use indoc::indoc;
 
 #[test]
 fn disallow_ignore_missing_from_model_without_fields() {

--- a/libs/datamodel/core/tests/attributes/index_negative.rs
+++ b/libs/datamodel/core/tests/attributes/index_negative.rs
@@ -1,5 +1,4 @@
-use crate::common::*;
-use crate::{with_header, Provider};
+use crate::{common::*, with_header, Provider};
 
 #[test]
 fn indexes_on_relation_fields_must_error() {

--- a/libs/datamodel/core/tests/attributes/index_positive.rs
+++ b/libs/datamodel/core/tests/attributes/index_positive.rs
@@ -1,6 +1,5 @@
-use crate::common::*;
-use crate::{with_header, Provider};
-use datamodel::{render_datamodel_to_string, IndexAlgorithm, IndexDefinition, IndexField, IndexType, SortOrder};
+use crate::{common::*, with_header, Provider};
+use datamodel::render_datamodel_to_string;
 
 #[test]
 fn basic_index_must_work() {

--- a/libs/datamodel/core/tests/attributes/map_negative.rs
+++ b/libs/datamodel/core/tests/attributes/map_negative.rs
@@ -1,5 +1,4 @@
 use crate::common::*;
-use indoc::indoc;
 
 #[test]
 fn map_must_error_for_relation_fields() {

--- a/libs/datamodel/core/tests/attributes/relations/many_to_many_negative.rs
+++ b/libs/datamodel/core/tests/attributes/relations/many_to_many_negative.rs
@@ -1,7 +1,4 @@
-use expect_test::expect;
-use indoc::indoc;
-
-use crate::{with_header, Provider};
+use crate::{common::*, with_header, Provider};
 
 #[test]
 fn implicit_many_to_many_relation_fields_with_referential_actions() {

--- a/libs/datamodel/core/tests/attributes/relations/referential_actions.rs
+++ b/libs/datamodel/core/tests/attributes/relations/referential_actions.rs
@@ -1,9 +1,8 @@
 mod cycle_detection;
 
 use crate::{common::*, config::parse_config};
-use datamodel::ReferentialAction::{self, *};
+use datamodel::dml::ReferentialAction::{self, *};
 use datamodel_connector::ReferentialIntegrity;
-use indoc::{formatdoc, indoc};
 
 #[test]
 fn on_delete_actions() {

--- a/libs/datamodel/core/tests/attributes/relations/referential_actions/cycle_detection.rs
+++ b/libs/datamodel/core/tests/attributes/relations/referential_actions/cycle_detection.rs
@@ -1,5 +1,4 @@
 use crate::common::*;
-use indoc::indoc;
 
 #[test]
 fn cascading_on_delete_self_relations() {

--- a/libs/datamodel/core/tests/attributes/relations/relations_negative.rs
+++ b/libs/datamodel/core/tests/attributes/relations/relations_negative.rs
@@ -1,6 +1,4 @@
-use crate::common::*;
-use crate::{with_header, Provider};
-use indoc::indoc;
+use crate::{common::*, with_header, Provider};
 
 #[test]
 fn fail_if_ambiguous_relation_fields_do_not_specify_a_name() {

--- a/libs/datamodel/core/tests/attributes/relations/relations_new.rs
+++ b/libs/datamodel/core/tests/attributes/relations/relations_new.rs
@@ -1,6 +1,4 @@
 use crate::common::*;
-use datamodel::dml;
-use indoc::indoc;
 
 #[test]
 fn relation_happy_path() {

--- a/libs/datamodel/core/tests/attributes/relations/relations_positive.rs
+++ b/libs/datamodel/core/tests/attributes/relations/relations_positive.rs
@@ -1,7 +1,5 @@
-use crate::common::*;
-use crate::{with_header, Provider};
-use datamodel::{dml, render_datamodel_to_string, IndexDefinition, IndexField, IndexType, ScalarType};
-use indoc::indoc;
+use crate::{common::*, with_header, Provider};
+use datamodel::render_datamodel_to_string;
 
 #[test]
 fn must_add_referenced_fields_on_both_sides_for_many_to_many_relations() {

--- a/libs/datamodel/core/tests/attributes/unique_negative.rs
+++ b/libs/datamodel/core/tests/attributes/unique_negative.rs
@@ -1,5 +1,4 @@
-use crate::common::*;
-use crate::{with_header, Provider};
+use crate::{common::*, with_header, Provider};
 
 #[test]
 fn must_error_on_model_without_unique_criteria() {

--- a/libs/datamodel/core/tests/attributes/unique_positive.rs
+++ b/libs/datamodel/core/tests/attributes/unique_positive.rs
@@ -1,6 +1,5 @@
-use crate::common::*;
-use crate::{with_header, Provider};
-use datamodel::{render_datamodel_to_string, IndexDefinition, IndexField, IndexType};
+use crate::{common::*, with_header, Provider};
+use datamodel::render_datamodel_to_string;
 
 #[test]
 fn basic_unique_index_must_work() {

--- a/libs/datamodel/core/tests/attributes/updated_at_positive.rs
+++ b/libs/datamodel/core/tests/attributes/updated_at_positive.rs
@@ -1,5 +1,4 @@
 use crate::common::*;
-use datamodel::ScalarType;
 
 #[test]
 fn should_apply_updated_at_attribute() {

--- a/libs/datamodel/core/tests/base/base_types.rs
+++ b/libs/datamodel/core/tests/base/base_types.rs
@@ -1,6 +1,4 @@
-use crate::common::*;
-use crate::{with_header, Provider};
-use datamodel::{dml, ScalarType};
+use crate::{common::*, with_header, Provider};
 
 #[test]
 fn parse_scalar_types() {

--- a/libs/datamodel/core/tests/base/basic.rs
+++ b/libs/datamodel/core/tests/base/basic.rs
@@ -1,5 +1,4 @@
 use crate::common::*;
-use datamodel::ScalarType;
 use diagnostics::{DatamodelWarning, Span};
 
 #[test]

--- a/libs/datamodel/core/tests/base/comments.rs
+++ b/libs/datamodel/core/tests/base/comments.rs
@@ -1,5 +1,4 @@
 use crate::common::*;
-use datamodel::ScalarType;
 
 #[test]
 fn comments_must_work_in_models() {

--- a/libs/datamodel/core/tests/base/unsupported_type.rs
+++ b/libs/datamodel/core/tests/base/unsupported_type.rs
@@ -1,7 +1,4 @@
 use crate::common::*;
-use datamodel::ValueGenerator;
-use dml::default_value::DefaultValue;
-use dml::field::FieldArity;
 
 #[test]
 fn parse_unsupported_types() {

--- a/libs/datamodel/core/tests/common/mod.rs
+++ b/libs/datamodel/core/tests/common/mod.rs
@@ -1,13 +1,9 @@
-use datamodel::{
-    diagnostics::*,
-    dml::{self, ScalarType},
-    Configuration, Datamodel, IndexDefinition, Model, NativeTypeInstance, PrimaryKeyDefinition, StringFromEnvVar,
-};
-use pretty_assertions::assert_eq;
+pub use datamodel::{dml, dml::*};
+pub use expect_test::expect;
+pub use indoc::{formatdoc, indoc};
 
-pub(crate) use expect_test::expect;
-pub(crate) use indoc::formatdoc;
-pub(crate) use indoc::indoc;
+use datamodel::{diagnostics::*, Configuration, StringFromEnvVar};
+use pretty_assertions::assert_eq;
 
 pub(crate) trait DatasourceAsserts {
     fn assert_name(&self, name: &str) -> &Self;

--- a/libs/datamodel/core/tests/config/generators.rs
+++ b/libs/datamodel/core/tests/config/generators.rs
@@ -1,6 +1,5 @@
-use datamodel::Datamodel;
-
 use crate::common::*;
+use datamodel::dml::Datamodel;
 
 #[test]
 fn serialize_generators_to_cmf() {

--- a/libs/datamodel/core/tests/functions/server_side_functions.rs
+++ b/libs/datamodel/core/tests/functions/server_side_functions.rs
@@ -1,5 +1,5 @@
 use crate::common::*;
-use datamodel::{DefaultValue, ScalarType, ValueGenerator};
+use datamodel::dml::{DefaultValue, ScalarType, ValueGenerator};
 
 #[test]
 fn correctly_handle_server_side_now_function() {

--- a/libs/datamodel/core/tests/functions/string_interpolation.rs
+++ b/libs/datamodel/core/tests/functions/string_interpolation.rs
@@ -1,6 +1,5 @@
 use crate::common::*;
-use ::dml::prisma_value::PrismaValue;
-use datamodel::{dml, ScalarType};
+use datamodel::dml::{self, PrismaValue, ScalarType};
 
 #[test]
 fn should_not_remove_whitespace() {

--- a/libs/datamodel/core/tests/renderer/literals.rs
+++ b/libs/datamodel/core/tests/renderer/literals.rs
@@ -1,5 +1,4 @@
-use datamodel::DefaultValue;
-use dml::prisma_value::PrismaValue;
+use datamodel::dml::{DefaultValue, PrismaValue};
 use indoc::indoc;
 use pretty_assertions::assert_eq;
 

--- a/libs/datamodel/core/tests/types/positive.rs
+++ b/libs/datamodel/core/tests/types/positive.rs
@@ -1,7 +1,6 @@
 use crate::common::*;
 use bigdecimal::{BigDecimal, FromPrimitive};
-use datamodel::{dml::ScalarType, DefaultValue, ValueGenerator};
-use dml::prisma_value::PrismaValue;
+use datamodel::dml::{DefaultValue, PrismaValue, ScalarType, ValueGenerator};
 use native_types::{MySqlType, PostgresType};
 
 #[test]

--- a/libs/datamodel/dmmf/src/to_dmmf.rs
+++ b/libs/datamodel/dmmf/src/to_dmmf.rs
@@ -1,9 +1,6 @@
 use crate::{Datamodel, Enum, EnumValue, Field, Function, Model, PrimaryKey, UniqueIndex};
 use bigdecimal::ToPrimitive;
-use datamodel::{
-    dml::{self, CompositeTypeFieldType, FieldType, Ignorable, ScalarType},
-    PrismaValue,
-};
+use datamodel::dml::{self, CompositeTypeFieldType, FieldType, Ignorable, PrismaValue, ScalarType};
 
 pub fn render_to_dmmf(schema: &dml::Datamodel) -> String {
     let dmmf = schema_to_dmmf(schema);
@@ -212,7 +209,7 @@ fn prisma_value_to_serde(value: &PrismaValue) -> serde_json::Value {
         PrismaValue::Json(val) => serde_json::Value::String(val.to_string()),
         PrismaValue::Xml(val) => serde_json::Value::String(val.to_string()),
         PrismaValue::List(value_vec) => serde_json::Value::Array(value_vec.iter().map(prisma_value_to_serde).collect()),
-        PrismaValue::Bytes(b) => serde_json::Value::String(datamodel::prisma_value::encode_bytes(b)),
+        PrismaValue::Bytes(b) => serde_json::Value::String(dml::prisma_value::encode_bytes(b)),
         PrismaValue::Object(pairs) => {
             let mut map = serde_json::Map::with_capacity(pairs.len());
             pairs.iter().for_each(|(key, value)| {

--- a/libs/datamodel/dmmf/tests/common/mod.rs
+++ b/libs/datamodel/dmmf/tests/common/mod.rs
@@ -1,4 +1,4 @@
-use datamodel::{Configuration, Datamodel};
+use datamodel::{dml::Datamodel, Configuration};
 
 pub(crate) use expect_test::expect;
 

--- a/libs/datamodel/dmmf/tests/render_to_dmmf/parser_renderer_dml.rs
+++ b/libs/datamodel/dmmf/tests/render_to_dmmf/parser_renderer_dml.rs
@@ -1,5 +1,5 @@
 use crate::common::*;
-use datamodel::Datamodel;
+use datamodel::dml::Datamodel;
 use indoc::indoc;
 use pretty_assertions::assert_eq;
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mssql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mssql_renderer.rs
@@ -6,7 +6,7 @@ use crate::{
     pair::Pair,
     sql_migration::{AlterEnum, AlterTable, RedefineTable},
 };
-use datamodel::PrismaValue;
+use datamodel::dml::PrismaValue;
 use indoc::{formatdoc, indoc};
 use native_types::{MsSqlType, MsSqlTypeParameter};
 use sql_schema_describer::{

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
@@ -5,7 +5,7 @@ use crate::{
     sql_migration::{AlterColumn, AlterEnum, AlterTable, RedefineTable, TableChange},
     sql_schema_differ::ColumnChanges,
 };
-use datamodel::PrismaValue;
+use datamodel::dml::PrismaValue;
 use native_types::MySqlType;
 use once_cell::sync::Lazy;
 use regex::Regex;

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
@@ -5,7 +5,7 @@ use crate::{
     sql_migration::{AlterColumn, AlterEnum, AlterTable, RedefineTable, TableChange},
     sql_schema_differ::{ColumnChange, ColumnChanges},
 };
-use datamodel::PrismaValue;
+use datamodel::dml::PrismaValue;
 use native_types::PostgresType;
 use once_cell::sync::Lazy;
 use regex::Regex;

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
@@ -4,7 +4,7 @@ use crate::{
     pair::Pair,
     sql_migration::{AlterEnum, AlterTable, RedefineTable, TableChange},
 };
-use datamodel::PrismaValue;
+use datamodel::dml::PrismaValue;
 use indoc::formatdoc;
 use once_cell::sync::Lazy;
 use regex::Regex;

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
@@ -5,7 +5,7 @@ pub(super) use sql_schema_calculator_flavour::SqlSchemaCalculatorFlavour;
 use crate::{flavour::SqlFlavour, SqlDatabaseSchema};
 use datamodel::{
     datamodel_connector::{walker_ext_traits::*, ReferentialAction, ScalarType},
-    dml::PrismaValue,
+    dml::{prisma_value, PrismaValue},
     parser_database::{
         walkers::{ModelWalker, ScalarFieldWalker},
         IndexAlgorithm, IndexType, ScalarFieldType, SortOrder,
@@ -366,7 +366,7 @@ fn column_for_builtin_scalar_type(
                             val.parse().unwrap(),
                         )))),
                         ScalarType::Bytes => Some(sql::DefaultValue::new(sql::DefaultKind::Value(PrismaValue::Bytes(
-                            datamodel::prisma_value::decode_bytes(val).unwrap(),
+                            prisma_value::decode_bytes(val).unwrap(),
                         )))),
                         ScalarType::Decimal => Some(sql::DefaultValue::new(sql::DefaultKind::Value(
                             PrismaValue::Float(val.parse().unwrap()),

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/column.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/column.rs
@@ -1,5 +1,5 @@
 use crate::{flavour::SqlFlavour, pair::Pair};
-use datamodel::PrismaValue;
+use datamodel::dml::PrismaValue;
 use enumflags2::BitFlags;
 use sql_schema_describer::{walkers::ColumnWalker, DefaultKind};
 

--- a/migration-engine/migration-engine-tests/tests/migrations/relations.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/relations.rs
@@ -1,7 +1,7 @@
 mod cockroachdb;
 mod vitess;
 
-use datamodel::ReferentialAction;
+use datamodel::dml::ReferentialAction;
 use migration_engine_tests::test_api::*;
 use sql_schema_describer::{ColumnTypeFamily, ForeignKeyAction};
 

--- a/query-engine/connectors/mongodb-query-connector/src/output_meta.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/output_meta.rs
@@ -1,5 +1,5 @@
 use connector_interface::{AggregationSelection, RelAggregationSelection};
-use datamodel::FieldArity;
+use datamodel::dml::FieldArity;
 use indexmap::IndexMap;
 use prisma_models::{FieldSelection, PrismaValue, ScalarFieldRef, SelectedField, TypeIdentifier};
 
@@ -94,7 +94,7 @@ pub fn from_scalar_field(field: &ScalarFieldRef) -> OutputMeta {
 
     // Only add a possible default return if the field is required.
     let default = field.default_value.clone().and_then(|dv| match dv.into_kind() {
-        datamodel::DefaultKind::Single(pv) if field.is_required() => Some(pv),
+        datamodel::dml::DefaultKind::Single(pv) if field.is_required() => Some(pv),
         _ => None,
     });
 

--- a/query-engine/connectors/mongodb-query-connector/src/root_queries/raw.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/root_queries/raw.rs
@@ -1,5 +1,5 @@
 use crate::{error::MongoError, vacuum_cursor, BsonTransform};
-use datamodel::PrismaValue;
+use datamodel::dml::PrismaValue;
 use itertools::Itertools;
 use mongodb::{
     bson::{from_bson, Bson, Document},

--- a/query-engine/connectors/sql-query-connector/src/column_metadata.rs
+++ b/query-engine/connectors/sql-query-connector/src/column_metadata.rs
@@ -1,4 +1,4 @@
-use datamodel::FieldArity;
+use datamodel::dml::FieldArity;
 use prisma_models::TypeIdentifier;
 
 /// Helps dealing with column value conversion and possible error resolution.

--- a/query-engine/connectors/sql-query-connector/src/row.rs
+++ b/query-engine/connectors/sql-query-connector/src/row.rs
@@ -2,7 +2,7 @@ use crate::{column_metadata::ColumnMetadata, error::SqlError};
 use bigdecimal::{BigDecimal, FromPrimitive};
 use chrono::{DateTime, NaiveDate, Utc};
 use connector_interface::{coerce_null_to_zero_value, AggregationResult, AggregationSelection};
-use datamodel::FieldArity;
+use datamodel::dml::FieldArity;
 use prisma_models::{PrismaValue, Record, TypeIdentifier};
 use quaint::{
     ast::{Expression, Value},

--- a/query-engine/core/src/query_graph_builder/write/utils.rs
+++ b/query-engine/core/src/query_graph_builder/write/utils.rs
@@ -4,7 +4,7 @@ use crate::{
     ConnectorContext, ParsedInputValue, QueryGraphBuilderError, QueryGraphBuilderResult,
 };
 use connector::{DatasourceFieldName, Filter, RecordFilter, WriteArgs, WriteOperation};
-use datamodel::ReferentialAction;
+use datamodel::dml::ReferentialAction;
 use indexmap::IndexMap;
 use prisma_models::{FieldSelection, ModelRef, PrismaValue, RelationFieldRef, SelectionResult};
 use std::sync::Arc;

--- a/query-engine/prisma-models/src/builders/field_builders/composite_field_builder.rs
+++ b/query-engine/prisma-models/src/builders/field_builders/composite_field_builder.rs
@@ -1,5 +1,5 @@
 use crate::{parent_container::ParentContainer, CompositeField, CompositeFieldRef, CompositeTypeRef};
-use datamodel::{DefaultValue, FieldArity};
+use datamodel::dml::{DefaultValue, FieldArity};
 use std::{fmt::Debug, sync::Arc};
 
 #[derive(Debug)]

--- a/query-engine/prisma-models/src/builders/field_builders/relation_field_builder.rs
+++ b/query-engine/prisma-models/src/builders/field_builders/relation_field_builder.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use datamodel::{FieldArity, ReferentialAction, RelationInfo};
+use dml::{FieldArity, ReferentialAction, RelationInfo};
 use once_cell::sync::OnceCell;
 use std::{fmt::Debug, sync::Arc};
 

--- a/query-engine/prisma-models/src/builders/field_builders/scalar_field_builder.rs
+++ b/query-engine/prisma-models/src/builders/field_builders/scalar_field_builder.rs
@@ -1,5 +1,5 @@
 use crate::{parent_container::ParentContainer, prelude::*, InternalEnum};
-use datamodel::{DefaultValue, FieldArity, NativeTypeInstance};
+use dml::{DefaultValue, FieldArity, NativeTypeInstance};
 use once_cell::sync::OnceCell;
 use std::{fmt::Debug, sync::Arc};
 

--- a/query-engine/prisma-models/src/builders/internal_dm_builder.rs
+++ b/query-engine/prisma-models/src/builders/internal_dm_builder.rs
@@ -8,7 +8,7 @@ use crate::{
     IndexType, InlineRelation, InternalDataModel, InternalDataModelRef, InternalEnum, InternalEnumValue,
     RelationLinkManifestation, RelationSide, RelationTable, TypeIdentifier,
 };
-use datamodel::{dml, CompositeTypeFieldType, Datamodel, Ignorable, WithDatabaseName};
+use datamodel::dml::{self, CompositeTypeFieldType, Datamodel, Ignorable, WithDatabaseName};
 use itertools::Itertools;
 use once_cell::sync::OnceCell;
 use std::sync::Arc;

--- a/query-engine/prisma-models/src/builders/model_builder.rs
+++ b/query-engine/prisma-models/src/builders/model_builder.rs
@@ -11,7 +11,7 @@ pub struct ModelBuilder {
     pub primary_key: Option<PrimaryKeyBuilder>,
     pub indexes: Vec<IndexBuilder>,
     pub supports_create_operation: bool,
-    pub dml_model: datamodel::Model,
+    pub dml_model: datamodel::dml::Model,
 }
 
 impl ModelBuilder {

--- a/query-engine/prisma-models/src/extensions.rs
+++ b/query-engine/prisma-models/src/extensions.rs
@@ -1,6 +1,5 @@
-use datamodel::{dml, Ignorable, NativeTypeInstance};
-
 use crate::{InternalEnum, InternalEnumValue, TypeIdentifier};
+use datamodel::dml::{self, Ignorable, NativeTypeInstance};
 
 pub trait ModelConverterUtilities {
     // A model is supported if it has at least one indexed/unique field or compound index that's supported.
@@ -126,7 +125,7 @@ impl DatamodelFieldExtensions for dml::ScalarField {
 
     fn native_type(&self) -> Option<NativeTypeInstance> {
         match &self.field_type {
-            datamodel::FieldType::Scalar(_, _, nt) => nt.clone(),
+            dml::FieldType::Scalar(_, _, nt) => nt.clone(),
             _ => None,
         }
     }
@@ -135,18 +134,18 @@ impl DatamodelFieldExtensions for dml::ScalarField {
 impl DatamodelFieldExtensions for dml::CompositeTypeField {
     fn type_identifier(&self) -> TypeIdentifier {
         match &self.r#type {
-            datamodel::CompositeTypeFieldType::CompositeType(_) => {
+            dml::CompositeTypeFieldType::CompositeType(_) => {
                 unreachable!("Composite fields should not use type identifiers")
             }
-            datamodel::CompositeTypeFieldType::Scalar(scalar, _, _) => (*scalar).into(),
-            datamodel::CompositeTypeFieldType::Enum(e) => TypeIdentifier::Enum(e.clone()),
-            datamodel::CompositeTypeFieldType::Unsupported(_) => TypeIdentifier::Unsupported,
+            dml::CompositeTypeFieldType::Scalar(scalar, _, _) => (*scalar).into(),
+            dml::CompositeTypeFieldType::Enum(e) => TypeIdentifier::Enum(e.clone()),
+            dml::CompositeTypeFieldType::Unsupported(_) => TypeIdentifier::Unsupported,
         }
     }
 
     fn internal_enum(&self, datamodel: &dml::Datamodel) -> Option<InternalEnum> {
         match self.r#type {
-            datamodel::CompositeTypeFieldType::Enum(ref enum_name) => {
+            dml::CompositeTypeFieldType::Enum(ref enum_name) => {
                 datamodel.enums().find(|e| e.name == *enum_name).map(|e| InternalEnum {
                     name: e.name.clone(),
                     values: e.values().map(|v| self.internal_enum_value(v)).collect(),
@@ -165,7 +164,7 @@ impl DatamodelFieldExtensions for dml::CompositeTypeField {
 
     fn native_type(&self) -> Option<NativeTypeInstance> {
         match &self.r#type {
-            datamodel::CompositeTypeFieldType::Scalar(_, _, nt) => nt.clone(),
+            dml::CompositeTypeFieldType::Scalar(_, _, nt) => nt.clone(),
             _ => None,
         }
     }

--- a/query-engine/prisma-models/src/field/composite.rs
+++ b/query-engine/prisma-models/src/field/composite.rs
@@ -1,5 +1,5 @@
 use crate::{parent_container::ParentContainer, CompositeTypeRef};
-use datamodel::FieldArity;
+use datamodel::dml::FieldArity;
 use std::{
     fmt::Debug,
     hash::{Hash, Hasher},

--- a/query-engine/prisma-models/src/field/mod.rs
+++ b/query-engine/prisma-models/src/field/mod.rs
@@ -7,7 +7,7 @@ pub use relation::*;
 pub use scalar::*;
 
 // use crate::prelude::*;
-use datamodel::ScalarType;
+use datamodel::dml::ScalarType;
 use std::{hash::Hash, sync::Arc};
 
 use crate::ModelRef;

--- a/query-engine/prisma-models/src/field/relation.rs
+++ b/query-engine/prisma-models/src/field/relation.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use datamodel::{FieldArity, ReferentialAction, RelationInfo};
+use dml::{FieldArity, ReferentialAction, RelationInfo};
 use once_cell::sync::OnceCell;
 use std::{
     fmt::Debug,

--- a/query-engine/prisma-models/src/field/scalar.rs
+++ b/query-engine/prisma-models/src/field/scalar.rs
@@ -1,5 +1,5 @@
 use crate::{parent_container::ParentContainer, prelude::*, InternalEnum};
-use datamodel::{DefaultValue, FieldArity, NativeTypeInstance};
+use dml::{DefaultValue, FieldArity, NativeTypeInstance};
 use once_cell::sync::OnceCell;
 use std::{
     fmt::Debug,

--- a/query-engine/prisma-models/src/model.rs
+++ b/query-engine/prisma-models/src/model.rs
@@ -15,7 +15,7 @@ pub struct Model {
     pub(crate) fields: OnceCell<Fields>,
     pub(crate) indexes: OnceCell<Vec<Index>>,
     pub(crate) primary_identifier: OnceCell<FieldSelection>,
-    pub(crate) dml_model: datamodel::Model,
+    pub(crate) dml_model: dml::Model,
 
     pub internal_data_model: InternalDataModelWeakRef,
     pub supports_create_operation: bool,

--- a/query-engine/prisma-models/src/relation.rs
+++ b/query-engine/prisma-models/src/relation.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use datamodel::ReferentialAction;
+use dml::ReferentialAction;
 use once_cell::sync::OnceCell;
 use std::{
     fmt::Debug,

--- a/query-engine/query-engine-node-api/src/engine.rs
+++ b/query-engine/query-engine-node-api/src/engine.rs
@@ -1,5 +1,5 @@
 use crate::{error::ApiError, logger::CallbackLayer};
-use datamodel::{Datamodel, ValidatedConfiguration};
+use datamodel::{dml::Datamodel, ValidatedConfiguration};
 use napi::threadsafe_function::ThreadsafeFunction;
 use opentelemetry::global;
 use prisma_models::InternalDataModelBuilder;

--- a/query-engine/query-engine/src/cli.rs
+++ b/query-engine/query-engine/src/cli.rs
@@ -4,7 +4,7 @@ use crate::{
     PrismaResult,
 };
 use datamodel::ValidatedConfiguration;
-use datamodel::{Configuration, Datamodel};
+use datamodel::{dml::Datamodel, Configuration};
 use datamodel_connector::ConnectorCapabilities;
 use prisma_models::InternalDataModelBuilder;
 use query_core::{schema::QuerySchemaRef, schema_builder, BuildMode};

--- a/query-engine/query-engine/src/context.rs
+++ b/query-engine/query-engine/src/context.rs
@@ -1,5 +1,5 @@
 use crate::{PrismaError, PrismaResult};
-use datamodel::{Configuration, Datamodel};
+use datamodel::{dml::Datamodel, Configuration};
 use prisma_models::InternalDataModelBuilder;
 use query_core::{executor, schema::QuerySchemaRef, schema_builder, BuildMode, QueryExecutor};
 use std::{env, fmt, sync::Arc};

--- a/query-engine/query-engine/src/opt.rs
+++ b/query-engine/query-engine/src/opt.rs
@@ -1,5 +1,5 @@
 use crate::{error::PrismaError, PrismaResult};
-use datamodel::Datamodel;
+use datamodel::dml::Datamodel;
 use datamodel::ValidatedConfiguration;
 use serde::Deserialize;
 use std::env;

--- a/query-engine/request-handlers/src/dmmf/mod.rs
+++ b/query-engine/request-handlers/src/dmmf/mod.rs
@@ -88,7 +88,7 @@ impl Serialize for DmmfModelOperations {
     }
 }
 
-pub fn render_dmmf(dml: &datamodel::Datamodel, query_schema: QuerySchemaRef) -> DataModelMetaFormat {
+pub fn render_dmmf(dml: &datamodel::dml::Datamodel, query_schema: QuerySchemaRef) -> DataModelMetaFormat {
     let (schema, mappings) = DmmfQuerySchemaRenderer::render(query_schema);
     let datamodel_json = dmmf_crate::render_to_dmmf_value(&dml);
 


### PR DESCRIPTION
All crates outside of libs/datamodel depend on datamodel/core, it is the
public API of the datamodel functionality.

The situation before this commit is that datamodel core reexports dml
types from both the `dml` module and at its top level, making the
top-level API surface very large.

This commit makes it export the types of the dml data structure only
from the dml module, which makes code across engines more uniform and
predictable.