### PR TITLE
me: Make migrations not depend on default_int_size param

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/postgres.rs
@@ -31,7 +31,6 @@ const ADVISORY_LOCK_TIMEOUT: std::time::Duration = std::time::Duration::from_sec
 /// https://www.cockroachlabs.com/docs/stable/experimental-features.html
 const COCKROACHDB_PRELUDE: &str = r#"
 SET enable_experimental_alter_column_type_general = true;
-SET default_int_size = 4;
 SET serial_normalization = 'sql_sequence';
 "#;
 

--- a/migration-engine/migration-engine-tests/tests/migrations/diff.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/diff.rs
@@ -84,7 +84,7 @@ fn diffing_postgres_schemas_when_initialized_on_sqlite(mut api: TestApi) {
     expected_printed_messages.assert_debug_eq(&host.printed_messages.lock().unwrap());
 }
 
-#[test_connector(tags(Postgres))]
+#[test_connector(tags(Postgres), exclude(CockroachDb))]
 fn from_empty_to_migrations_directory(mut api: TestApi) {
     let base_dir = tempfile::TempDir::new().unwrap();
     let first_migration_directory_path = base_dir.path().join("01firstmigration");


### PR DESCRIPTION
We use the cockroach-specific `INT4` to avoid integer sizing
ambiguities. For the complete solution, we will have to deal with the
different type of autoincrementing primary keys, because two out of the three
that exist force INT8.

Addresses the default_int_size part of https://github.com/prisma/prisma/issues/12113