### PR TITLE
Mongo logging

### DIFF
--- a/query-engine/connectors/mongodb-query-connector/src/lib.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/lib.rs
@@ -11,6 +11,7 @@ mod projection;
 mod query_builder;
 mod root_queries;
 mod value;
+mod logger;
 
 use error::MongoError;
 use mongodb::{

--- a/query-engine/connectors/mongodb-query-connector/src/lib.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/lib.rs
@@ -5,13 +5,13 @@ mod error;
 mod filter;
 mod interface;
 mod join;
+mod logger;
 mod orderby;
 mod output_meta;
 mod projection;
 mod query_builder;
 mod root_queries;
 mod value;
-mod logger;
 
 use error::MongoError;
 use mongodb::{

--- a/query-engine/connectors/mongodb-query-connector/src/logger.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/logger.rs
@@ -49,7 +49,11 @@ fn fmt_query(buffer: &mut String, coll_name: &str, query: &MongoReadQuery) -> st
 }
 
 fn fmt_opts(buffer: &mut String, opts: &FindOptions, depth: usize) -> std::fmt::Result {
-    writeln!(buffer, "{{")?;
+    if cfg!(debug_assertions) {
+        writeln!(buffer, "{{")?;
+    } else {
+        write!(buffer, "{{")?;
+    }
 
     if let Some(skip) = opts.skip {
         write_indented!(buffer, depth, "skip: {},\n", skip);
@@ -62,29 +66,51 @@ fn fmt_opts(buffer: &mut String, opts: &FindOptions, depth: usize) -> std::fmt::
     if let Some(ref sort) = opts.sort {
         write_indented!(buffer, depth, "sort: ",);
         fmt_doc(buffer, sort, depth + 1)?;
-        writeln!(buffer, ",")?;
+
+        if cfg!(debug_assertions) {
+            writeln!(buffer, ",")?;
+        } else {
+            write!(buffer, ",")?;
+        }
     }
 
     if let Some(ref projection) = opts.projection {
         write_indented!(buffer, depth, "projection: ",);
         fmt_doc(buffer, projection, depth + 1)?;
-        writeln!(buffer)?;
+
+        if cfg!(debug_assertions) {
+            writeln!(buffer)?;
+        }
     }
 
     write!(buffer, "}}")
 }
 
+#[cfg(debug_assertions)]
 fn indent(depth: usize) -> String {
     " ".repeat(4 * depth)
 }
 
+#[cfg(not(debug_assertions))]
+fn indent(_: usize) -> String {
+    String::from(" ")
+}
+
 fn fmt_doc(buffer: &mut String, doc: &Document, depth: usize) -> std::fmt::Result {
-    writeln!(buffer, "{{")?;
+    if cfg!(debug_assertions) {
+        writeln!(buffer, "{{")?;
+    } else {
+        write!(buffer, "{{")?;
+    }
 
     for (key, value) in doc {
         write_indented!(buffer, depth, "{}: ", key);
         fmt_val(buffer, value, depth)?;
-        writeln!(buffer, ",")?;
+        if cfg!(debug_assertions) {
+            writeln!(buffer, ",")?;
+        } else {
+            write!(buffer, ",")?;
+        }
     }
 
     write_indented!(buffer, usize::max(depth - 1, 0), "}}",);
@@ -92,12 +118,20 @@ fn fmt_doc(buffer: &mut String, doc: &Document, depth: usize) -> std::fmt::Resul
 }
 
 fn fmt_list(buffer: &mut String, list: &[Bson], depth: usize) -> std::fmt::Result {
-    writeln!(buffer, "[")?;
+    if cfg!(debug_assertions) {
+        writeln!(buffer, "[")?;
+    } else {
+        write!(buffer, "[")?;
+    }
 
     for item in list {
         write_indented!(buffer, depth, "",);
         fmt_val(buffer, item, depth)?;
-        writeln!(buffer, ",")?;
+        if cfg!(debug_assertions) {
+            writeln!(buffer, ",")?;
+        } else {
+            write!(buffer, ",")?;
+        }
     }
 
     write_indented!(buffer, usize::max(depth - 1, 0), "]",);

--- a/query-engine/connectors/mongodb-query-connector/src/logger.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/logger.rs
@@ -176,7 +176,7 @@ pub(crate) fn log_insert_one(coll: &str, doc: &Document) {
     debug!(target: "mongodb_query_connector::query", query = buffer.as_str(), item_type = "query", is_query = true);
 }
 
-pub(crate) fn log_update_many_vec(coll: &str, filter: &Document, docs: &Vec<Document>) {    
+pub(crate) fn log_update_many_vec(coll: &str, filter: &Document, docs: &Vec<Document>) {
     let mut buffer = String::new();
 
     write!(&mut buffer, "db.{}.updateMany(", coll).unwrap();
@@ -187,7 +187,7 @@ pub(crate) fn log_update_many_vec(coll: &str, filter: &Document, docs: &Vec<Docu
     } else {
         write!(&mut buffer, ", [").unwrap();
     }
-    
+
     for doc in docs {
         fmt_doc(&mut buffer, doc, 1).unwrap();
     }
@@ -201,7 +201,7 @@ pub(crate) fn log_update_many(coll: &str, filter: &Document, doc: &Document) {
 
     write!(&mut buffer, "db.{}.updateMany(", coll).unwrap();
     fmt_doc(&mut buffer, filter, 1).unwrap();
-    
+
     if cfg!(debug_assertions) {
         writeln!(&mut buffer, ", ").unwrap();
     } else {
@@ -217,13 +217,13 @@ pub(crate) fn log_update_one(coll: &str, filter: &Document, doc: &Document) {
 
     write!(&mut buffer, "db.{}.updateOne(", coll).unwrap();
     fmt_doc(&mut buffer, filter, 1).unwrap();
-    
+
     if cfg!(debug_assertions) {
         writeln!(&mut buffer, ", ").unwrap();
     } else {
         write!(&mut buffer, ", ").unwrap();
     }
-    
+
     fmt_doc(&mut buffer, doc, 1).unwrap();
 
     write!(&mut buffer, ")").unwrap();

--- a/query-engine/connectors/mongodb-query-connector/src/logger.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/logger.rs
@@ -176,7 +176,7 @@ pub(crate) fn log_insert_one(coll: &str, doc: &Document) {
     debug!(target: "mongodb_query_connector::query", query = buffer.as_str(), item_type = "query", is_query = true);
 }
 
-pub(crate) fn log_update_many_vec(coll: &str, filter: &Document, docs: &Vec<Document>) {
+pub(crate) fn log_update_many_vec(coll: &str, filter: &Document, docs: &[Document]) {
     let mut buffer = String::new();
 
     write!(&mut buffer, "db.{}.updateMany(", coll).unwrap();
@@ -241,7 +241,7 @@ pub(crate) fn log_delete_many(coll: &str, filter: &Document) {
     debug!(target: "mongodb_query_connector::query", query = buffer.as_str(), item_type = "query", is_query = true);
 }
 
-pub(crate) fn log_insert_many(coll: &str, docs: &Vec<Document>, ordered: bool) {
+pub(crate) fn log_insert_many(coll: &str, docs: &[Document], ordered: bool) {
     let mut buffer = String::new();
 
     write!(&mut buffer, "db.{}.insertMany(", coll).unwrap();

--- a/query-engine/connectors/mongodb-query-connector/src/logger.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/logger.rs
@@ -191,6 +191,7 @@ pub(crate) fn log_update_many_vec(coll: &str, filter: &Document, docs: &[Documen
     for doc in docs {
         fmt_doc(&mut buffer, doc, 1).unwrap();
     }
+    
     write!(&mut buffer, "])").unwrap();
 
     debug!(target: "mongodb_query_connector::query", query = buffer.as_str(), item_type = "query", is_query = true);
@@ -225,7 +226,6 @@ pub(crate) fn log_update_one(coll: &str, filter: &Document, doc: &Document) {
     }
 
     fmt_doc(&mut buffer, doc, 1).unwrap();
-
     write!(&mut buffer, ")").unwrap();
 
     debug!(target: "mongodb_query_connector::query", query = buffer.as_str(), item_type = "query", is_query = true);
@@ -245,9 +245,11 @@ pub(crate) fn log_insert_many(coll: &str, docs: &[Document], ordered: bool) {
     let mut buffer = String::new();
 
     write!(&mut buffer, "db.{}.insertMany(", coll).unwrap();
+
     for doc in docs {
         fmt_doc(&mut buffer, doc, 1).unwrap();
     }
+    
     write!(&mut buffer, "], ").unwrap();
     write!(&mut buffer, r#"{{ "ordered": {} }}"#, ordered).unwrap();
 

--- a/query-engine/connectors/mongodb-query-connector/src/logger.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/logger.rs
@@ -191,7 +191,7 @@ pub(crate) fn log_update_many_vec(coll: &str, filter: &Document, docs: &[Documen
     for doc in docs {
         fmt_doc(&mut buffer, doc, 1).unwrap();
     }
-    
+
     write!(&mut buffer, "])").unwrap();
 
     debug!(target: "mongodb_query_connector::query", query = buffer.as_str(), item_type = "query", is_query = true);
@@ -249,7 +249,7 @@ pub(crate) fn log_insert_many(coll: &str, docs: &[Document], ordered: bool) {
     for doc in docs {
         fmt_doc(&mut buffer, doc, 1).unwrap();
     }
-    
+
     write!(&mut buffer, "], ").unwrap();
     write!(&mut buffer, r#"{{ "ordered": {} }}"#, ordered).unwrap();
 

--- a/query-engine/connectors/mongodb-query-connector/src/query_builder/mod.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/query_builder/mod.rs
@@ -1,4 +1,3 @@
-mod logger;
 mod read_query_builder;
 
 pub use read_query_builder::*;

--- a/query-engine/connectors/mongodb-query-connector/src/query_builder/read_query_builder.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/query_builder/read_query_builder.rs
@@ -2,8 +2,9 @@ use crate::{
     cursor::{CursorBuilder, CursorData},
     filter::convert_filter,
     join::JoinStage,
+    logger::log_read_query as log_query,
     orderby::OrderByBuilder,
-    vacuum_cursor, BsonTransform, IntoBson, logger::log_read_query as log_query,
+    vacuum_cursor, BsonTransform, IntoBson,
 };
 use connector_interface::{AggregationSelection, Filter, QueryArguments, RelAggregationSelection};
 use itertools::Itertools;

--- a/query-engine/connectors/mongodb-query-connector/src/query_builder/read_query_builder.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/query_builder/read_query_builder.rs
@@ -1,10 +1,9 @@
-use super::logger::*;
 use crate::{
     cursor::{CursorBuilder, CursorData},
     filter::convert_filter,
     join::JoinStage,
     orderby::OrderByBuilder,
-    vacuum_cursor, BsonTransform, IntoBson,
+    vacuum_cursor, BsonTransform, IntoBson, logger::log_read_query as log_query,
 };
 use connector_interface::{AggregationSelection, Filter, QueryArguments, RelAggregationSelection};
 use itertools::Itertools;

--- a/query-engine/connectors/mongodb-query-connector/src/root_queries/write.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/root_queries/write.rs
@@ -16,7 +16,6 @@ use mongodb::{
 };
 use prisma_models::{ModelRef, PrismaValue, SelectionResult};
 use std::{collections::HashMap, convert::TryInto};
-use std::fmt::Write;
 use update_utils::{IntoUpdateDocumentExtension, IntoUpdateOperationExtension};
 
 /// Create a single record to the database resulting in a

--- a/query-engine/connectors/mongodb-query-connector/src/root_queries/write.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/root_queries/write.rs
@@ -1,10 +1,10 @@
 use super::*;
 use crate::{
     filter::{convert_filter, MongoFilter},
-    output_meta,
+    logger, output_meta,
     query_builder::MongoReadQueryBuilder,
     root_queries::raw::{MongoCommand, MongoOperation},
-    IntoBson, logger
+    IntoBson,
 };
 
 use connector_interface::*;

--- a/query-engine/query-engine-node-api/src/logger.rs
+++ b/query-engine/query-engine-node-api/src/logger.rs
@@ -19,14 +19,17 @@ pub(crate) fn create_log_dispatch(
     log_level: LevelFilter,
     log_callback: ThreadsafeFunction<String>,
 ) -> Dispatch {
+    // is a sql query?
+    let is_sql_query = filter_fn(|meta| {
+        meta.target() == "quaint::connector::metrics" && meta.fields().iter().any(|f| f.name() == "query")
+    });
+    // is a mongodb query?
+    let is_mongo_query = filter_fn(|meta| meta.target() == "mongodb_query_connector::query");
+
     // We need to filter the messages to send to our callback logging mechanism
     let filters = if log_queries {
         // Filter trace query events (for query log) or based in the defined log level
-        filter_fn(|meta| {
-            meta.target() == "quaint::connector::metrics" && meta.fields().iter().any(|f| f.name() == "query")
-        })
-        .or(log_level)
-        .boxed()
+        is_sql_query.or(is_mongo_query).or(log_level).boxed()
     } else {
         // Filter based in the defined log level
         log_level.boxed()


### PR DESCRIPTION
Support for query logging for MongoDB queries, we use the same format used by the Mongo Shell and Mongoose, so the query could be executed directly in the Mongo shell. A few important things need to be noted:

 - In `DEBUG` builds, the queries would be indented for easy reading
 - In `RELEASE` builds, the queries are plain, without indentation or car returns

This works exactly like the existing SQL query logging but a few details are not included:

 - Query execution time (maybe in a near future)
 - Query parameters (we don't use it)

When we retake logging this would be an area where things could be heavily simplified using spans for query logging. Another important improvement would be using a logging macro instead of the current functions.

This closes https://github.com/prisma/prisma/issues/11419