### PR TITLE
MongoDB: Map undecided types as Json

### DIFF
--- a/introspection-engine/connectors/mongodb-introspection-connector/src/sampler/statistics.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/src/sampler/statistics.rs
@@ -378,6 +378,7 @@ fn populate_fields(
         let most_common_type = percentages.find_most_common();
 
         let field_type = match &most_common_type {
+            Some(_) if percentages.has_type_variety() => FieldType::Json,
             Some(field_type) => field_type.to_owned(),
             None => FieldType::Json,
         };

--- a/introspection-engine/connectors/mongodb-introspection-connector/src/warnings.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/src/warnings.rs
@@ -50,7 +50,7 @@ pub(crate) fn undecided_field_type(affected: &[(Name, String, String)]) -> Warni
 
     Warning {
         code: 101,
-        message: "The following fields had data stored in multiple types. The most common type was chosen. If loading data with a type that does not match the one in the data model, the client will crash. Please see the issue: https://github.com/prisma/prisma/issues/9654".into(),
+        message: "The following fields had data stored in multiple types. Either use Json or normalize data to the wanted type.".into(),
         affected,
     }
 }

--- a/introspection-engine/connectors/mongodb-introspection-connector/tests/remapping_names/mod.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/tests/remapping_names/mod.rs
@@ -161,7 +161,7 @@ fn remapping_model_fields_with_numbers_dirty() {
           id   String @id @default(auto()) @map("_id") @db.ObjectId
           // Multiple data types found: String: 50%, Int32: 50% out of 2 sampled entries
           // This field was commented out because of an invalid name. Please provide a valid one that matches [a-zA-Z][a-zA-Z0-9_]*
-          // 1 Int    @map("1")
+          // 1 Json   @map("1")
         }
     "#]];
 

--- a/introspection-engine/connectors/mongodb-introspection-connector/tests/types/composite.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/tests/types/composite.rs
@@ -51,7 +51,7 @@ fn dirty_data() {
     let expected = expect![[r#"
         type CatAddress {
           /// Multiple data types found: String: 66.7%, Int32: 33.3% out of 3 sampled entries
-          number String
+          number Json
           street String
         }
 
@@ -67,7 +67,7 @@ fn dirty_data() {
     res.assert_warning_affected(&json!([{
         "compositeType": "CatAddress",
         "field": "number",
-        "tpe": "String",
+        "tpe": "Document",
     }]));
 }
 


### PR DESCRIPTION
If the field has more than one type in the sampled data, instead of choosing the most common type, we'll use Json and change the warning a bit.

Closes: https://github.com/prisma/schema-team/issues/338