### PR TITLE
Fix `gte` comparisson in filters for MongoDb

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
@@ -1,3 +1,4 @@
+mod prisma_10098;
 mod prisma_6173;
 mod prisma_7010;
 mod prisma_7072;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_10098.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_10098.rs
@@ -1,0 +1,39 @@
+use query_engine_tests::*;
+
+#[test_suite(schema(schema))]
+mod mongodb {
+    use indoc::indoc;
+
+    fn schema() -> String {
+        let schema = indoc! {
+            r#"
+            model Course {
+                id String @id @default(auto()) @map("_id") @test.ObjectId
+                rating Float @default(3.5)
+            }
+            "#
+        };
+        schema.to_owned()
+    }
+
+    #[connector_test]
+    async fn gte_works_with_floating_numbers(runner: Runner) -> TestResult<()> {
+        runner
+            .query(r#"mutation { createOneCourse(data: {}) { id } }"#)
+            .await?
+            .assert_success();
+
+        assert_query!(
+            runner,
+            r#"query {
+            aggregateCourse(where: {
+              rating: {
+                gte: 3.5
+              }
+            }) { _count {id} }}"#,
+            r#"{"data":{"aggregateCourse":{"_count":{"id":1}}}}"#
+        );
+
+        Ok(())
+    }
+}

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_10098.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_10098.rs
@@ -1,6 +1,6 @@
 use query_engine_tests::*;
 
-#[test_suite(schema(schema))]
+#[test_suite(schema(schema), only(MongoDb))]
 mod mongodb {
     use indoc::indoc;
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_10098.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_10098.rs
@@ -36,4 +36,25 @@ mod mongodb {
 
         Ok(())
     }
+
+    #[connector_test]
+    async fn lte_works_with_floating_numbers(runner: Runner) -> TestResult<()> {
+        runner
+            .query(r#"mutation { createOneCourse(data: {}) { id } }"#)
+            .await?
+            .assert_success();
+
+        assert_query!(
+            runner,
+            r#"query {
+            aggregateCourse(where: {
+              rating: {
+                lte: 3.5
+              }
+            }) { _count {id} }}"#,
+            r#"{"data":{"aggregateCourse":{"_count":{"id":1}}}}"#
+        );
+
+        Ok(())
+    }
 }

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/nested_atomic_number_ops.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/nested_atomic_number_ops.rs
@@ -392,9 +392,6 @@ mod atomic_number_ops {
         Ok(())
     }
 
-    // TODO(mongo, precision): Suffers from precision issues on Float
-    // These precision issues should be gone once the floating point fixes effort is done
-    // Note: These precision issues are created within Prisma's MongoDB connector, not within MongoDB.
     #[connector_test(schema(schema_3), only(MongoDb))]
     async fn nested_update_float_ops_mongo(runner: Runner) -> TestResult<()> {
         create_test_model(&runner, 1, None, None).await?;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/nested_atomic_number_ops.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/nested_atomic_number_ops.rs
@@ -417,7 +417,7 @@ mod atomic_number_ops {
         );
         insta::assert_snapshot!(
           query_nested_number_ops(&runner, 2, "optFloat", "decrement", "4.6").await?,
-          @r###"{"optFloat":5.500000000000001}"###
+          @r###"{"optFloat":5.5}"###
         );
 
         // Multiply

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/nested_atomic_number_ops.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/nested_atomic_number_ops.rs
@@ -437,17 +437,17 @@ mod atomic_number_ops {
         );
         insta::assert_snapshot!(
           query_nested_number_ops(&runner, 2, "optFloat", "divide", "2").await?,
-          @r###"{"optFloat":5.500000000000001}"###
+          @r###"{"optFloat":5.5}"###
         );
 
         // Set
         insta::assert_snapshot!(
           query_nested_number_ops(&runner, 1, "optFloat", "set", "5.1").await?,
-          @r###"{"optFloat":5.100000000000001}"###
+          @r###"{"optFloat":5.1}"###
         );
         insta::assert_snapshot!(
           query_nested_number_ops(&runner, 2, "optFloat", "set", "5.1").await?,
-          @r###"{"optFloat":5.100000000000001}"###
+          @r###"{"optFloat":5.1}"###
         );
 
         // Set null

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/update.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/update.rs
@@ -526,17 +526,17 @@ mod update {
         );
         insta::assert_snapshot!(
           query_number_operation(&runner, "2", "optFloat", "divide", "2").await?,
-          @r###"{"data":{"updateOneTestModel":{"optFloat":5.500000000000001}}}"###
+          @r###"{"data":{"updateOneTestModel":{"optFloat":5.5}}}"###
         );
 
         // Set
         insta::assert_snapshot!(
           query_number_operation(&runner, "1", "optFloat", "set", "5.1").await?,
-          @r###"{"data":{"updateOneTestModel":{"optFloat":5.100000000000001}}}"###
+          @r###"{"data":{"updateOneTestModel":{"optFloat":5.1}}}"###
         );
         insta::assert_snapshot!(
           query_number_operation(&runner, "2", "optFloat", "set", "5.1").await?,
-          @r###"{"data":{"updateOneTestModel":{"optFloat":5.100000000000001}}}"###
+          @r###"{"data":{"updateOneTestModel":{"optFloat":5.1}}}"###
         );
 
         // Set null

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/update.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/update.rs
@@ -481,9 +481,6 @@ mod update {
         Ok(())
     }
 
-    // TODO(mongo, precision): Suffers from precision issues on Float
-    // These precision issues should be gone once the floating point fixes effort is done
-    // Note: These precision issues are created within Prisma's MongoDB connector, not within MongoDB.
     #[connector_test(schema(schema_6), only(MongoDb))]
     async fn update_apply_number_ops_for_float_mongo(runner: Runner) -> TestResult<()> {
         create_row(&runner, r#"{ id: 1 }"#).await?;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/update.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/update.rs
@@ -506,7 +506,7 @@ mod update {
         );
         insta::assert_snapshot!(
           query_number_operation(&runner, "2", "optFloat", "decrement", "4.6").await?,
-          @r###"{"data":{"updateOneTestModel":{"optFloat":5.500000000000001}}}"###
+          @r###"{"data":{"updateOneTestModel":{"optFloat":5.5}}}"###
         );
 
         // Multiply

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/upsert.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/upsert.rs
@@ -631,7 +631,7 @@ mod upsert {
         );
         insta::assert_snapshot!(
           query_number_operation(&runner, "2", "optFloat", "decrement", "4.6").await?,
-          @r###"{"data":{"upsertOneTestModel":{"optFloat":5.500000000000001}}}"###
+          @r###"{"data":{"upsertOneTestModel":{"optFloat":5.5}}}"###
         );
 
         // Multiply
@@ -651,17 +651,17 @@ mod upsert {
         );
         insta::assert_snapshot!(
           query_number_operation(&runner, "2", "optFloat", "divide", "2").await?,
-          @r###"{"data":{"upsertOneTestModel":{"optFloat":5.500000000000001}}}"###
+          @r###"{"data":{"upsertOneTestModel":{"optFloat":5.5}}}"###
         );
 
         // Set
         insta::assert_snapshot!(
           query_number_operation(&runner, "1", "optFloat", "set", "5.1").await?,
-          @r###"{"data":{"upsertOneTestModel":{"optFloat":5.100000000000001}}}"###
+          @r###"{"data":{"upsertOneTestModel":{"optFloat":5.1}}}"###
         );
         insta::assert_snapshot!(
           query_number_operation(&runner, "2", "optFloat", "set", "5.1").await?,
-          @r###"{"data":{"upsertOneTestModel":{"optFloat":5.100000000000001}}}"###
+          @r###"{"data":{"upsertOneTestModel":{"optFloat":5.1}}}"###
         );
 
         // Set null

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/upsert.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/upsert.rs
@@ -606,9 +606,6 @@ mod upsert {
         Ok(())
     }
 
-    // TODO(mongo, precision): Suffers from precision issues on Float
-    // These precision issues should be gone once the floating point fixes effort is done
-    // Note: These precision issues are created within Prisma's MongoDB connector, not within MongoDB.
     #[connector_test(schema(schema_number), only(MongoDb))]
     async fn upsert_apply_number_ops_for_float_mongo(runner: Runner) -> TestResult<()> {
         create_row(&runner, r#"{ id: 1 }"#).await?;

--- a/query-engine/connectors/mongodb-query-connector/src/value.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/value.rs
@@ -205,7 +205,15 @@ impl IntoBson for (&TypeIdentifier, PrismaValue) {
             (TypeIdentifier::BigInt, PrismaValue::Float(dec)) => Bson::Int64(dec.to_i64().convert(expl::MONGO_I64)?),
 
             // Float
-            (TypeIdentifier::Float, PrismaValue::Float(dec)) => Bson::Double(dec.to_f64().convert(expl::MONGO_DOUBLE)?),
+            (TypeIdentifier::Float, PrismaValue::Float(dec)) => {
+                // We don't have native support for float numbers (yet)
+                // so we need to do this, see https://docs.rs/bigdecimal/latest/bigdecimal/index.html
+                let dec_str = dec.to_string();
+                let f64_val = dec_str.parse::<f64>().ok();
+                let converted = f64_val.convert(expl::MONGO_DOUBLE)?;
+
+                Bson::Double(converted)
+            }
             (TypeIdentifier::Float, PrismaValue::Int(i)) => Bson::Double(i.to_f64().convert(expl::MONGO_DOUBLE)?),
             (TypeIdentifier::Float, PrismaValue::BigInt(i)) => Bson::Double(i.to_f64().convert(expl::MONGO_DOUBLE)?),
 


### PR DESCRIPTION
 - This closes https://github.com/prisma/prisma/issues/10098
