### PR TITLE
refactor: rewrite filters into boolean expressions + isSet + unset for scalars

### DIFF
--- a/libs/datamodel/connectors/datamodel-connector/src/capabilities.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/capabilities.rs
@@ -86,6 +86,7 @@ capabilities!(
     FullTextSearchWithoutIndex,
     FullTextSearchWithIndex,
     AdvancedJsonNullability, // Database distinguishes between their null type and JSON null.
+    UndefinedType,           // Database distinguishes `null` and `undefined`
 );
 
 /// Contains all capabilities that the connector is able to serve.

--- a/libs/datamodel/connectors/mongodb-datamodel-connector/src/lib.rs
+++ b/libs/datamodel/connectors/mongodb-datamodel-connector/src/lib.rs
@@ -26,6 +26,7 @@ const CAPABILITIES: &[ConnectorCapability] = &[
     ConnectorCapability::MongoDbQueryRaw,
     ConnectorCapability::DefaultValueAuto,
     ConnectorCapability::TwoWayEmbeddedManyToManyRelation,
+    ConnectorCapability::UndefinedType,
 ];
 
 type Result<T> = std::result::Result<T, DatamodelError>;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/src/schemas/composites.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/src/schemas/composites.rs
@@ -134,22 +134,24 @@ pub fn mixed_composites() -> String {
             to_many_com  CompositeB[] @map("to_many_composite")
 
             to_one_rel_id Int?
-            to_one_rel RelatedModel? @relation(name: "ToOne", fields: [to_one_rel_id], references: [id])
+            to_one_rel    RelatedModel? @relation(name: "ToOne", fields: [to_one_rel_id], references: [id])
 
             #m2m(to_many_rel, RelatedModel[], id, Int, ToMany)
         }
 
         type CompositeA {
-            a_1 String @default("a_1 default") @map("a1")
-            a_2 Int?
+            a_1              String       @default("a_1 default") @map("a1")
+            a_2              Int?
+            a_to_other_com   CompositeC?
             other_composites CompositeB[]
-            scalar_list  String[]
+            scalar_list      String[]
         }
 
         type CompositeB {
-            b_field      String      @default("b_field default")
-            to_other_com CompositeC? @map("nested_c")
-            scalar_list  String[]
+            b_field       String       @default("b_field default")
+            to_other_com  CompositeC?  @map("nested_c")
+            to_other_coms CompositeC[]
+            scalar_list   String[]
         }
 
         type CompositeC {

--- a/query-engine/connector-test-kit-rs/query-engine-tests/src/schemas/composites.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/src/schemas/composites.rs
@@ -136,22 +136,25 @@ pub fn mixed_composites() -> String {
             to_one_rel_id Int?
             to_one_rel RelatedModel? @relation(name: "ToOne", fields: [to_one_rel_id], references: [id])
 
-            to_many_rel RelatedModel[] @relation(name: "ToMany")
+            #m2m(to_many_rel, RelatedModel[], id, Int, ToMany)
         }
 
         type CompositeA {
             a_1 String @default("a_1 default") @map("a1")
             a_2 Int?
             other_composites CompositeB[]
+            scalar_list  String[]
         }
 
         type CompositeB {
-            b_field        String      @default("b_field default")
-            to_other_com   CompositeC? @map("nested_c")
+            b_field      String      @default("b_field default")
+            to_other_com CompositeC? @map("nested_c")
+            scalar_list  String[]
         }
 
         type CompositeC {
-          c_field String @default("c_field default")
+          c_field     String @default("c_field default")
+          scalar_list String[]
         }
 
         model RelatedModel {
@@ -161,7 +164,7 @@ pub fn mixed_composites() -> String {
             to_many_com  CompositeB[] @map("to_many_composite")
 
             test_model TestModel? @relation(name: "ToOne")
-            many_test_model TestModel[] @relation(name: "ToMany")
+            #m2m(many_test_model, TestModel[], id, Int, ToMany)
         }
 
         "#

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/group_by_having.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/group_by_having.rs
@@ -342,25 +342,24 @@ mod aggregation_group_by_having {
             @r###"{"data":{"groupByTestModel":[{"string":"group1","_min":{"float":0.0,"int":0,"decimal":"0"}},{"string":"group2","_min":{"float":0.0,"int":0,"decimal":"0"}}]}}"###
         );
 
-        match_connector_result!(
-            runner,
-            r#"query { groupByTestModel(by: [string], orderBy: { string: asc }, having: {
-              float: { _min: { not: { equals: 0 }}}
-              int: { _min: { not: { equals: 0 }}}
-              decimal: { _min: { not: { equals: "0" }}}
-            }) {
-              string
-              _min {
-                float
-                int
-                decimal
+        insta::assert_snapshot!(
+          run_query!(
+              &runner,
+              r#"query { groupByTestModel(by: [string], orderBy: { string: asc }, having: {
+                float: { _min: { not: { equals: 0 }}}
+                int: { _min: { not: { equals: 0 }}}
+                decimal: { _min: { not: { equals: "0" }}}
+              }) {
+                string
+                _min {
+                  float
+                  int
+                  decimal
+                }
               }
-            }
-          }"#,
-          // Since MongoDB doesn't have the concept of `NULL` `not equals 10` includes `null` records
-          // The result _is_ empty on SQL though
-          MongoDb(_) => vec![r#"{"data":{"groupByTestModel":[{"string":"group3","_min":{"float":null,"int":null,"decimal":null}}]}}"#],
-          _ => vec![r#"{"data":{"groupByTestModel":[]}}"#]
+            }"#
+          ),
+          @r###"{"data":{"groupByTestModel":[]}}"###
         );
 
         // Group 1 and 2 returned
@@ -429,25 +428,24 @@ mod aggregation_group_by_having {
             @r###"{"data":{"groupByTestModel":[{"string":"group1","_max":{"float":10.0,"int":10,"decimal":"10"}},{"string":"group2","_max":{"float":10.0,"int":10,"decimal":"10"}}]}}"###
         );
 
-        match_connector_result!(
-            runner,
-            r#"query { groupByTestModel(by: [string], orderBy: { string: asc }, having: {
-              float: { _max: { not: { equals: 10 }}}
-              int: { _max: { not: { equals: 10 }}}
-              decimal: { _max: { not: { equals: "10" }}}
-            }) {
-              string
-              _max {
-                float
-                int
-                decimal
+        insta::assert_snapshot!(
+          run_query!(
+              &runner,
+              r#"query { groupByTestModel(by: [string], orderBy: { string: asc }, having: {
+                float: { _max: { not: { equals: 10 }}}
+                int: { _max: { not: { equals: 10 }}}
+                decimal: { _max: { not: { equals: "10" }}}
+              }) {
+                string
+                _max {
+                  float
+                  int
+                  decimal
+                }
               }
-            }
-          }"#,
-          // Since MongoDB doesn't have the concept of `NULL` `not equals 10` includes `null` records
-          // The result _is_ empty on SQL though
-          MongoDb(_) => vec![r#"{"data":{"groupByTestModel":[{"string":"group3","_max":{"float":null,"int":null,"decimal":null}}]}}"#],
-          _ => vec![r#"{"data":{"groupByTestModel":[]}}"#]
+            }"#
+          ),
+          @r###"{"data":{"groupByTestModel":[]}}"###
         );
 
         // Group 1 and 2 returned

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/group_by_having.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/group_by_having.rs
@@ -342,24 +342,24 @@ mod aggregation_group_by_having {
             @r###"{"data":{"groupByTestModel":[{"string":"group1","_min":{"float":0.0,"int":0,"decimal":"0"}},{"string":"group2","_min":{"float":0.0,"int":0,"decimal":"0"}}]}}"###
         );
 
-        insta::assert_snapshot!(
-          run_query!(
-              &runner,
-              r#"query { groupByTestModel(by: [string], orderBy: { string: asc }, having: {
-                float: { _min: { not: { equals: 0 }}}
-                int: { _min: { not: { equals: 0 }}}
-                decimal: { _min: { not: { equals: "0" }}}
-              }) {
-                string
-                _min {
-                  float
-                  int
-                  decimal
-                }
-              }
-            }"#
-          ),
-          @r###"{"data":{"groupByTestModel":[]}}"###
+        match_connector_result!(
+          &runner,
+          r#"query { groupByTestModel(by: [string], orderBy: { string: asc }, having: {
+            float: { _min: { not: { equals: 0 }}}
+            int: { _min: { not: { equals: 0 }}}
+            decimal: { _min: { not: { equals: "0" }}}
+          }) {
+            string
+            _min {
+              float
+              int
+              decimal
+            }
+          }
+        }"#,
+          // MongoDB returns null for aggregations on undefined fields, so it's included
+          MongoDb(_) => vec![r#"{"data":{"groupByTestModel":[{"string":"group3","_min":{"float":null,"int":null,"decimal":null}}]}}"#],
+          _ => vec![r#"{"data":{"groupByTestModel":[]}}"#]
         );
 
         // Group 1 and 2 returned
@@ -428,24 +428,24 @@ mod aggregation_group_by_having {
             @r###"{"data":{"groupByTestModel":[{"string":"group1","_max":{"float":10.0,"int":10,"decimal":"10"}},{"string":"group2","_max":{"float":10.0,"int":10,"decimal":"10"}}]}}"###
         );
 
-        insta::assert_snapshot!(
-          run_query!(
-              &runner,
-              r#"query { groupByTestModel(by: [string], orderBy: { string: asc }, having: {
-                float: { _max: { not: { equals: 10 }}}
-                int: { _max: { not: { equals: 10 }}}
-                decimal: { _max: { not: { equals: "10" }}}
-              }) {
-                string
-                _max {
-                  float
-                  int
-                  decimal
-                }
-              }
-            }"#
-          ),
-          @r###"{"data":{"groupByTestModel":[]}}"###
+        match_connector_result!(
+          &runner,
+          r#"query { groupByTestModel(by: [string], orderBy: { string: asc }, having: {
+            float: { _max: { not: { equals: 10 }}}
+            int: { _max: { not: { equals: 10 }}}
+            decimal: { _max: { not: { equals: "10" }}}
+          }) {
+            string
+            _max {
+              float
+              int
+              decimal
+            }
+          }
+        }"#,
+          // MongoDB returns null for aggregations on undefined fields, so it's included
+          MongoDb(_) => vec![r#"{"data":{"groupByTestModel":[{"string":"group3","_max":{"float":null,"int":null,"decimal":null}}]}}"#],
+          _ => vec![r#"{"data":{"groupByTestModel":[]}}"#]
         );
 
         // Group 1 and 2 returned

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/bigint_filter.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/bigint_filter.rs
@@ -36,9 +36,12 @@ mod bigint_filter_spec {
           @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
         );
 
-        insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { bInt: null }) { id }}"#),
-          @r###"{"data":{"findManyTestModel":[{"id":3}]}}"###
+        match_connector_result!(
+          &runner,
+          r#"query { findManyTestModel(where: { bInt: null }) { id }}"#,
+          // MongoDB excludes undefined fields
+          MongoDb(_) => vec![r#"{"data":{"findManyTestModel":[]}}"#],
+          _ => vec![r#"{"data":{"findManyTestModel":[{"id":3}]}}"#]
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/bytes_filter.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/bytes_filter.rs
@@ -68,12 +68,9 @@ mod bytes_filter_spec {
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
-        match_connector_result!(
-            &runner,
-            r#"query { findManyTestModel(where: { bytes: { not: { in: ["dGVzdA=="] }}}) { id }}"#,
-            // Mongo selects `null` fields as well.
-            MongoDb(_) => vec![r#"{"data":{"findManyTestModel":[{"id":2},{"id":3}]}}"#],
-            _ => vec![r#"{"data":{"findManyTestModel":[{"id":2}]}}"#]
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"query { findManyTestModel(where: { bytes: { not: { in: ["dGVzdA=="] }}}) { id }}"#),
+          @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/bytes_filter.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/bytes_filter.rs
@@ -36,9 +36,12 @@ mod bytes_filter_spec {
           @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
         );
 
-        insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { bytes: null }) { id }}"#),
-          @r###"{"data":{"findManyTestModel":[{"id":3}]}}"###
+        match_connector_result!(
+          &runner,
+          r#"query { findManyTestModel(where: { bytes: null }) { id }}"#,
+          // MongoDB excludes undefined fields
+          MongoDb(_) => vec![r#"{"data":{"findManyTestModel":[]}}"#],
+          _ => vec![r#"{"data":{"findManyTestModel":[{"id":3}]}}"#]
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/bytes_filter.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/bytes_filter.rs
@@ -3,7 +3,7 @@ use query_engine_tests::*;
 
 #[test_suite(schema(schemas::common_nullable_types))]
 mod bytes_filter_spec {
-    use query_engine_tests::{match_connector_result, run_query};
+    use query_engine_tests::run_query;
 
     #[connector_test]
     async fn basic_where(runner: Runner) -> TestResult<()> {

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/combination.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/combination.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 #[test_suite(schema(to_many_composites), only(MongoDb))]
-mod combination {
+mod composite_combination {
     // Over to-one to to-many (both composites)
     #[connector_test]
     async fn com_to_one_2_to_many(runner: Runner) -> TestResult<()> {
@@ -24,6 +24,643 @@ mod combination {
               }
           }"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":4},{"id":6},{"id":8},{"id":9},{"id":10},{"id":11}]}}"###
+        );
+
+        Ok(())
+    }
+}
+
+#[test_suite(schema(mixed_composites), only(MongoDb))]
+mod relation_combination {
+    // Over to-one relation to a to-one composite
+    #[connector_test]
+    async fn over_to_one_rel_to_one(runner: Runner) -> TestResult<()> {
+        create_relation_combination_test_data(&runner).await?;
+
+        insta::assert_snapshot!(
+          run_query!(runner, r#"{
+              findManyTestModel(where: {
+                  to_one_rel: {
+                      is: {
+                          to_one_com: {
+                              is: {
+                                  a_1: { contains: "test" }
+                              }
+                          }
+                      }
+                  }
+              }) {
+                  id
+              }
+          }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(runner, r#"{
+                findManyTestModel(where: {
+                    to_one_rel: {
+                        isNot: {
+                            to_one_com: {
+                                is: {
+                                    a_1: { contains: "test" }
+                                }
+                            }
+                        }
+                    }
+                }) {
+                    id
+                }
+            }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":2},{"id":3},{"id":4},{"id":5},{"id":6}]}}"###
+        );
+
+        // Todo: This doesn't return null or undefined values - is this okay?
+        insta::assert_snapshot!(
+          run_query!(runner, r#"{
+                  findManyTestModel(where: {
+                      to_one_rel: {
+                          is: {
+                              to_one_com: {
+                                  isNot: {
+                                      a_1: { contains: "test" }
+                                  }
+                              }
+                          }
+                      }
+                  }) {
+                      id
+                  }
+              }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":2},{"id":3}]}}"###
+        );
+
+        // Todo: This doesn't return undefined values - inconsistent with relations, also problematic with no way of checking for `isSet` or similar.
+        insta::assert_snapshot!(
+          run_query!(runner, r#"{
+                findManyTestModel(where: {
+                    to_one_rel: {
+                        is: {
+                            to_one_com: {
+                                is: null
+                            }
+                        }
+                    }
+                }) {
+                    id
+                }
+            }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":4}]}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(runner, r#"{
+                  findManyTestModel(where: {
+                      to_one_rel: {
+                          isNot: {
+                              to_one_com: {
+                                  is: null
+                              }
+                          }
+                      }
+                  }) {
+                      id
+                  }
+              }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":3},{"id":5},{"id":6}]}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(runner, r#"{
+                    findManyTestModel(where: {
+                        to_one_rel: {
+                            is: {
+                                to_one_com: {
+                                    isNot: null
+                                }
+                            }
+                        }
+                    }) {
+                        id
+                    }
+                }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":3},{"id":5},{"id":6}]}}"###
+        );
+
+        Ok(())
+    }
+
+    // Over to-one relation to a to-one composite, multiple conditions
+    #[connector_test]
+    async fn over_to_one_rel_to_one_multiple(runner: Runner) -> TestResult<()> {
+        create_relation_combination_test_data(&runner).await?;
+
+        // Implicit AND
+        insta::assert_snapshot!(
+          run_query!(runner, r#"{
+              findManyTestModel(where: {
+                  to_one_rel: {
+                      is: {
+                          to_one_com: {
+                              is: {
+                                  a_1: { contains: "hello" }
+                                  a_2: { lt: 0 }
+                              }
+                          }
+                      }
+                  }
+              }) {
+                  id
+              }
+          }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
+        );
+
+        // OR
+        insta::assert_snapshot!(
+          run_query!(runner, r#"{
+                findManyTestModel(where: {
+                    to_one_rel: {
+                        is: {
+                            to_one_com: {
+                                is: {
+                                    OR: [
+                                        { a_1: { contains: "test" } },
+                                        { a_2: { lt: 0 } }
+                                    ]
+
+                                }
+                            }
+                        }
+                    }
+                }) {
+                    id
+                }
+            }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
+        );
+
+        // NOT
+        insta::assert_snapshot!(
+          run_query!(runner, r#"{
+                  findManyTestModel(where: {
+                      to_one_rel: {
+                          is: {
+                              to_one_com: {
+                                  is: {
+                                      NOT: [
+                                          { a_1: { contains: "test" } },
+                                          { a_2: { gt: 0 } }
+                                      ]
+                                  }
+                              }
+                          }
+                      }
+                  }) {
+                      id
+                  }
+              }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":2},{"id":3}]}}"###
+        );
+
+        Ok(())
+    }
+
+    // Over to-one relation to a to-one composite, multiple conditions
+    #[connector_test]
+    async fn over_to_one_rel_to_one_logical_cond(runner: Runner) -> TestResult<()> {
+        create_relation_combination_test_data(&runner).await?;
+
+        // Implicit AND
+        insta::assert_snapshot!(
+          run_query!(runner, r#"{
+              findManyTestModel(where: {
+                  to_one_rel: {
+                      is: {
+                          to_one_com: {
+                              is: {
+                                  a_1: { contains: "hello" }
+                                  a_2: { lt: 0 }
+                              }
+                          }
+                      }
+                  }
+              }) {
+                  id
+              }
+          }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
+        );
+
+        // OR
+        insta::assert_snapshot!(
+          run_query!(runner, r#"{
+                findManyTestModel(where: {
+                    to_one_rel: {
+                        is: {
+                            to_one_com: {
+                                is: {
+                                    OR: [
+                                        { a_1: { contains: "test" } },
+                                        { a_2: { lt: 0 } }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                }) {
+                    id
+                }
+            }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
+        );
+
+        // NOT
+        insta::assert_snapshot!(
+          run_query!(runner, r#"{
+                  findManyTestModel(where: {
+                      to_one_rel: {
+                          is: {
+                              to_one_com: {
+                                  is: {
+                                      NOT: [
+                                          { a_1: { contains: "test" } },
+                                          { a_2: { gt: 0 } }
+                                      ]
+                                  }
+                              }
+                          }
+                      }
+                  }) {
+                      id
+                  }
+              }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":2},{"id":3}]}}"###
+        );
+
+        Ok(())
+    }
+
+    // Over to-one relation to a to-many composite
+    #[connector_test]
+    async fn over_to_one_rel_to_many(runner: Runner) -> TestResult<()> {
+        create_relation_combination_test_data(&runner).await?;
+
+        // Equals
+        insta::assert_snapshot!(
+          run_query!(runner, r#"{
+                findManyTestModel(where: {
+                    to_one_rel: {
+                        is: {
+                            to_many_com: [ { b_field: "fof" }, { b_field: "ofo" } ]
+                        }
+                    }
+                }) {
+                    id
+                }
+            }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":3}]}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(runner, r#"{
+                  findManyTestModel(where: {
+                      to_one_rel: {
+                          isNot: {
+                              to_many_com: [ { b_field: "fof" }, { b_field: "ofo" } ]
+                          }
+                      }
+                  }) {
+                      id
+                  }
+              }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":4},{"id":5},{"id":6}]}}"###
+        );
+
+        // Every
+        // For empty lists: Since no element is contained, the list automatically passes the condition.
+        insta::assert_snapshot!(
+          run_query!(runner, r#"{
+              findManyTestModel(where: {
+                  to_one_rel: {
+                      is: {
+                          to_many_com: {
+                              every: {
+                                  b_field: { contains: "oo" }
+                              }
+                          }
+                      }
+                  }
+              }) {
+                  id
+              }
+          }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":4},{"id":5}]}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(runner, r#"{
+                findManyTestModel(where: {
+                    to_one_rel: {
+                        isNot: {
+                            to_many_com: {
+                                every: {
+                                    b_field: { contains: "oo" }
+                                }
+                            }
+                        }
+                    }
+                }) {
+                    id
+                }
+            }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":2},{"id":3},{"id":6}]}}"###
+        );
+
+        // None
+        insta::assert_snapshot!(
+          run_query!(runner, r#"{
+                findManyTestModel(where: {
+                    to_one_rel: {
+                        is: {
+                            to_many_com: {
+                                none: {
+                                    b_field: { contains: "oo" }
+                                }
+                            }
+                        }
+                    }
+                }) {
+                    id
+                }
+            }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":3},{"id":4},{"id":5}]}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(runner, r#"{
+                  findManyTestModel(where: {
+                      to_one_rel: {
+                          isNot: {
+                              to_many_com: {
+                                  none: {
+                                      b_field: { contains: "oo" }
+                                  }
+                              }
+                          }
+                      }
+                  }) {
+                      id
+                  }
+              }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":6}]}}"###
+        );
+
+        // Some
+        insta::assert_snapshot!(
+          run_query!(runner, r#"{
+                    findManyTestModel(where: {
+                        to_one_rel: {
+                            is: {
+                                to_many_com: {
+                                    some: {
+                                        b_field: { contains: "fof" }
+                                    }
+                                }
+                            }
+                        }
+                    }) {
+                        id
+                    }
+                }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":3}]}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(runner, r#"{
+                      findManyTestModel(where: {
+                          to_one_rel: {
+                              isNot: {
+                                  to_many_com: {
+                                      some: {
+                                          b_field: { contains: "fof" }
+                                      }
+                                  }
+                              }
+                          }
+                      }) {
+                          id
+                      }
+                  }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":4},{"id":5},{"id":6}]}}"###
+        );
+
+        Ok(())
+    }
+
+    // Scalar lists over to-one relation and to-one composite.
+    #[connector_test]
+    async fn scalar_lists_to_one_to_one(runner: Runner) -> TestResult<()> {
+        create_relation_combination_test_data(&runner).await?;
+
+        // Todo (to-clarify): This considers null and undefined scalar lists as empty.
+        insta::assert_snapshot!(
+          run_query!(runner, r#"{
+              findManyTestModel(where: {
+                  to_one_rel: {
+                      is: {
+                          to_one_com: {
+                              is: {
+                                  scalar_list: {
+                                      isEmpty: true
+                                  }
+                              }
+                          }
+                      }
+                  }
+              }) {
+                  id
+              }
+          }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":3},{"id":4},{"id":5}]}}"###
+        );
+
+        // Undefined lists are NOT considered.
+        insta::assert_snapshot!(
+          run_query!(runner, r#"{
+                findManyTestModel(where: {
+                    to_one_rel: {
+                        is: {
+                            to_one_com: {
+                                is: {
+                                    scalar_list: {
+                                        isEmpty: false
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }) {
+                    id
+                }
+            }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
+        );
+
+        // This DOES consider undefined due to how the query must be build with the not condition.
+        insta::assert_snapshot!(
+          run_query!(runner, r#"{
+                findManyTestModel(where: {
+                    to_one_rel: {
+                        isNot: {
+                            to_one_com: {
+                                is: {
+                                    scalar_list: {
+                                        isEmpty: true
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }) {
+                    id
+                }
+            }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":6}]}}"###
+        );
+
+        Ok(())
+    }
+
+    // Scalar lists over to-one relation and to-many composite.
+    #[connector_test]
+    async fn scalar_lists_to_one_to_many(runner: Runner) -> TestResult<()> {
+        create_relation_combination_test_data(&runner).await?;
+
+        insta::assert_snapshot!(
+          run_query!(runner, r#"{
+              findManyTestModel(where: {
+                  to_one_rel: {
+                      is: {
+                        to_many_com: {
+                              every: {
+                                  scalar_list: {
+                                      has: "hello"
+                                  }
+                              }
+                          }
+                      }
+                  }
+              }) {
+                  id
+              }
+          }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":2},{"id":4},{"id":5}]}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(runner, r#"{
+                findManyTestModel(where: {
+                    to_one_rel: {
+                        isNot: {
+                          to_many_com: {
+                                every: {
+                                    scalar_list: {
+                                        has: "hello"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }) {
+                    id
+                }
+            }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":2},{"id":4},{"id":5}]}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(runner, r#"{
+                findManyTestModel(where: {
+                    to_one_rel: {
+                        is: {
+                          to_many_com: {
+                                none: {
+                                    scalar_list: {
+                                        has: "hello"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }) {
+                    id
+                }
+            }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":2},{"id":4},{"id":5}]}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(runner, r#"{
+                  findManyTestModel(where: {
+                      to_one_rel: {
+                          isNot: {
+                            to_many_com: {
+                                  none: {
+                                      scalar_list: {
+                                          has: "hello"
+                                      }
+                                  }
+                              }
+                          }
+                      }
+                  }) {
+                      id
+                  }
+              }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":2},{"id":4},{"id":5}]}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(runner, r#"{
+                findManyTestModel(where: {
+                    to_one_rel: {
+                        is: {
+                          to_many_com: {
+                                some: {
+                                    scalar_list: {
+                                        has: "world"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }) {
+                    id
+                }
+            }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":2},{"id":4},{"id":5}]}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(runner, r#"{
+                  findManyTestModel(where: {
+                      to_one_rel: {
+                          isNot: {
+                            to_many_com: {
+                                  some: {
+                                      scalar_list: {
+                                          has: "world"
+                                      }
+                                  }
+                              }
+                          }
+                      }
+                  }) {
+                      id
+                  }
+              }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":2},{"id":4},{"id":5}]}}"###
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/combination/composite.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/combination/composite.rs
@@ -1,0 +1,31 @@
+use super::*;
+
+#[test_suite(schema(to_many_composites), only(MongoDb))]
+mod composite_combination {
+    // Over to-one to to-many (both composites)
+    #[connector_test]
+    async fn com_to_one_2_to_many(runner: Runner) -> TestResult<()> {
+        create_combination_test_data(&runner).await?;
+
+        insta::assert_snapshot!(
+          run_query!(runner, r#"{
+              findManyTestModel(where: {
+                  to_one_b: {
+                      is: {
+                          b_to_many_cs: {
+                              every: {
+                                  c_field: { gt: 0 }
+                              }
+                          }
+                      }
+                  }
+              }) {
+                  id
+              }
+          }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":4},{"id":6},{"id":8},{"id":9},{"id":10},{"id":11}]}}"###
+        );
+
+        Ok(())
+    }
+}

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/combination/composite.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/combination/composite.rs
@@ -23,7 +23,7 @@ mod composite_combination {
                   id
               }
           }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":4},{"id":6},{"id":8},{"id":9},{"id":10},{"id":11}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":4},{"id":6}]}}"###
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/combination/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/combination/mod.rs
@@ -1,0 +1,6 @@
+mod composite;
+mod to_many_relation;
+mod to_one_relation;
+
+use super::*;
+use query_engine_tests::*;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/combination/to_many_relation.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/combination/to_many_relation.rs
@@ -1,0 +1,258 @@
+//! A lot of those tests are fairly basic - the test matrix is complicated as it is, so these tests strive to cover
+//! the API surface expected to be hit most (complexity with little hops) and makes sure that more complex hop combinations
+//! do not immediately produce syntax errors / invalid queries.
+
+use super::*;
+
+// [x] To-many-rel -> to-one-com (every, some, none, equals)
+// [ ] To-many-rel -> to-one-com -> to-one-com
+// [ ] To-many-rel -> to-one-com -> to-many-com
+// [ ] To-many-rel -> to-one-com -> scalar list
+//
+// [ ] To-many-rel -> to-many-com
+// [ ] To-many-rel -> to-many-com -> to-one-com
+// [ ] To-many-rel -> to-many-com -> to-many-com
+// [ ] To-many-rel -> to-many-com -> scalar list
+#[test_suite(schema(mixed_composites), only(MongoDb))]
+mod to_many_rel {
+    // To-many-rel -> to-one-com
+    // Every
+    #[connector_test]
+    async fn to_to_one_com_basic_every(runner: Runner) -> TestResult<()> {
+        create_relation_combination_test_data(&runner).await?;
+
+        insta::assert_snapshot!(
+          run_query!(runner, r#"{
+              findManyTestModel(where: {
+                  to_many_rel: {
+                      every: {
+                          to_one_com: {
+                              is: {
+                                  a_1: {
+                                    equals: "test"
+                                    mode: insensitive
+                                  }
+                              }
+                          }
+                      }
+                  }
+              }) {
+                  id
+              }
+          }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":3},{"id":6}]}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(runner, r#"{
+                findManyTestModel(where: {
+                    to_many_rel: {
+                        every: {
+                            to_one_com: {
+                                isNot: {
+                                    a_1: {
+                                      equals: "test"
+                                      mode: insensitive
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }) {
+                    id
+                }
+            }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":4},{"id":5},{"id":6}]}}"###
+        );
+
+        // Explanation:
+        // - ID 4 has explicit null values for to_one_com
+        // - ID 6 has undefined to_many_rel, which automatically fulfills the condition. (Todo: But should it?)
+        insta::assert_snapshot!(
+          run_query!(runner, r#"{
+                findManyTestModel(where: {
+                    to_many_rel: {
+                        every: {
+                            to_one_com: {
+                                is: null
+                            }
+                        }
+                    }
+                }) {
+                    id
+                }
+              }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":4},{"id":6}]}}"###
+        );
+
+        // All arrays but 4 (which has explicit nulls) automatically fulfill this condition.
+        insta::assert_snapshot!(
+          run_query!(runner, r#"{
+                  findManyTestModel(where: {
+                      to_many_rel: {
+                          every: {
+                              to_one_com: {
+                                  isNot: null
+                              }
+                          }
+                      }
+                  }) {
+                      id
+                  }
+                }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":3},{"id":5},{"id":6}]}}"###
+        );
+
+        Ok(())
+    }
+
+    // To-many-rel -> to-one-com
+    // Some
+    #[connector_test]
+    async fn to_to_one_com_basic_some(runner: Runner) -> TestResult<()> {
+        create_relation_combination_test_data(&runner).await?;
+
+        insta::assert_snapshot!(
+          run_query!(runner, r#"{
+              findManyTestModel(where: {
+                  to_many_rel: {
+                      some: {
+                          to_one_com: {
+                              is: {
+                                  a_1: {
+                                    equals: "test"
+                                  }
+                              }
+                          }
+                      }
+                  }
+              }) {
+                  id
+              }
+          }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":3}]}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(runner, r#"{
+                findManyTestModel(where: {
+                    to_many_rel: {
+                        some: {
+                            to_one_com: {
+                                isNot: {
+                                    a_1: {
+                                      equals: "test"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }) {
+                    id
+                }
+            }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":3}]}}"###
+        );
+
+        Ok(())
+    }
+
+    // To-many-rel -> to-one-com
+    // None
+    #[connector_test]
+    async fn to_to_one_com_basic_none(runner: Runner) -> TestResult<()> {
+        create_relation_combination_test_data(&runner).await?;
+
+        insta::assert_snapshot!(
+          run_query!(runner, r#"{
+              findManyTestModel(where: {
+                  to_many_rel: {
+                      none: {
+                          to_one_com: {
+                              equals: {
+                                  a_1: {
+                                    equals: "test"
+                                  }
+                              }
+                          }
+                      }
+                  }
+              }) {
+                  id
+              }
+          }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":2},{"id":4},{"id":5},{"id":6}]}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(runner, r#"{
+                findManyTestModel(where: {
+                    to_many_rel: {
+                        none: {
+                            to_one_com: {
+                                isNot: {
+                                    a_1: {
+                                      equals: "test"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }) {
+                    id
+                }
+            }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":4},{"id":5},{"id":6}]}}"###
+        );
+
+        Ok(())
+    }
+
+    // To-many-rel -> to-one-com
+    // None
+    #[connector_test]
+    async fn to_to_one_com_scalar_list(runner: Runner) -> TestResult<()> {
+        create_relation_combination_test_data(&runner).await?;
+
+        // todo: this considers undefined, I'm not sure it should (same with the second test).
+        insta::assert_snapshot!(
+          run_query!(runner, r#"{
+              findManyTestModel(where: {
+                  to_many_rel: {
+                      every: {
+                          to_one_com: {
+                              is: {
+                                  scalar_list: { has: "foo" }
+                              }
+                          }
+                      }
+                  }
+              }) {
+                  id
+              }
+          }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":2},{"id":6}]}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(runner, r#"{
+                findManyTestModel(where: {
+                    to_many_rel: {
+                        every: {
+                            to_one_com: {
+                                isNot: {
+                                    scalar_list: { has: "foo" }
+                                }
+                            }
+                        }
+                    }
+                }) {
+                    id
+                }
+            }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":6}]}"###
+        );
+
+        Ok(())
+    }
+}

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/combination/to_many_relation.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/combination/to_many_relation.rs
@@ -169,10 +169,8 @@ mod to_many_rel {
                   to_many_rel: {
                       none: {
                           to_one_com: {
-                              equals: {
-                                  a_1: {
-                                    equals: "test"
-                                  }
+                              is: {
+                                  a_1: "test"
                               }
                           }
                       }
@@ -250,7 +248,7 @@ mod to_many_rel {
                     id
                 }
             }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":6}]}"###
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":6}]}}"###
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/combination/to_many_relation.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/combination/to_many_relation.rs
@@ -100,7 +100,7 @@ mod to_many_rel {
                       id
                   }
                 }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":3},{"id":5},{"id":6}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":3},{"id":6}]}}"###
         );
 
         Ok(())
@@ -179,7 +179,7 @@ mod to_many_rel {
                   id
               }
           }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":2},{"id":4},{"id":5},{"id":6}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":2},{"id":6}]}}"###
         );
 
         insta::assert_snapshot!(
@@ -200,7 +200,7 @@ mod to_many_rel {
                     id
                 }
             }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":4},{"id":5},{"id":6}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":6}]}}"###
         );
 
         Ok(())
@@ -321,7 +321,7 @@ mod to_many_rel {
                   id
               }
           }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":3},{"id":4},{"id":5},{"id":6}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":3},{"id":6}]}}"###
         );
 
         // The `every` prevents any match with actual values.
@@ -368,7 +368,7 @@ mod to_many_rel {
                   id
               }
           }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":3},{"id":4},{"id":5},{"id":6}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":3},{"id":4},{"id":6}]}}"###
         );
 
         insta::assert_snapshot!(
@@ -387,7 +387,7 @@ mod to_many_rel {
                     id
                 }
             }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":4},{"id":5},{"id":6}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":4},{"id":6}]}}"###
         );
 
         insta::assert_snapshot!(
@@ -500,7 +500,7 @@ mod to_many_rel {
                   id
               }
           }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":2},{"id":4},{"id":5},{"id":6}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":2},{"id":4},{"id":6}]}}"###
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/combination/to_many_relation.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/combination/to_many_relation.rs
@@ -425,9 +425,11 @@ mod to_many_rel {
                           to_many_com: {
                               some: {
                                 to_other_com: {
-                                    c_field: {
-                                        equals: "test",
-                                        mode: insensitive
+                                    is: {
+                                        c_field: {
+                                            equals: "test",
+                                            mode: insensitive
+                                        }
                                     }
                                 }
                               }
@@ -438,7 +440,7 @@ mod to_many_rel {
                   id
               }
           }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":2},{"id":3},{"id":6}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":2},{"id":6}]}}"###
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/combination/to_one_relation.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/combination/to_one_relation.rs
@@ -55,7 +55,7 @@ mod to_one_rel {
                     id
                 }
             }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":2},{"id":3},{"id":4},{"id":5},{"id":6}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":2},{"id":3}]}}"###
         );
 
         // Todo: This doesn't return null or undefined values - is this okay?
@@ -110,7 +110,7 @@ mod to_one_rel {
                       id
                   }
               }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":3},{"id":5},{"id":6}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":3}]}}"###
         );
 
         insta::assert_snapshot!(
@@ -127,7 +127,7 @@ mod to_one_rel {
                         id
                     }
                 }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":3},{"id":5}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":3}]}}"###
         );
 
         Ok(())
@@ -354,7 +354,7 @@ mod to_one_rel {
                     id
                 }
             }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":4},{"id":5},{"id":6}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         Ok(())
@@ -454,7 +454,7 @@ mod to_one_rel {
                     id
                 }
             }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":4},{"id":5}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
         );
 
         Ok(())
@@ -516,7 +516,7 @@ mod to_one_rel {
                       id
                   }
               }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":4},{"id":5},{"id":6}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":4}]}}"###
         );
 
         // Every
@@ -537,7 +537,7 @@ mod to_one_rel {
                   id
               }
           }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":4},{"id":5}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":4}]}}"###
         );
 
         insta::assert_snapshot!(
@@ -556,7 +556,7 @@ mod to_one_rel {
                     id
                 }
             }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":2},{"id":3},{"id":6}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":2},{"id":3}]}}"###
         );
 
         // None
@@ -576,7 +576,7 @@ mod to_one_rel {
                     id
                 }
             }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":3},{"id":4},{"id":5}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":3},{"id":4}]}}"###
         );
 
         insta::assert_snapshot!(
@@ -595,7 +595,7 @@ mod to_one_rel {
                       id
                   }
               }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":6}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         // Some
@@ -634,7 +634,7 @@ mod to_one_rel {
                           id
                       }
                   }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":4},{"id":5},{"id":6}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":4}]}}"###
         );
 
         Ok(())
@@ -664,7 +664,7 @@ mod to_one_rel {
                   id
               }
           }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":2},{"id":4},{"id":5}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":2},{"id":4}]}}"###
         );
 
         insta::assert_snapshot!(
@@ -685,7 +685,7 @@ mod to_one_rel {
                     id
                 }
             }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":3},{"id":6}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
         );
 
         insta::assert_snapshot!(
@@ -706,7 +706,7 @@ mod to_one_rel {
                     id
                 }
             }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":3},{"id":4},{"id":5}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":4}]}}"###
         );
 
         insta::assert_snapshot!(
@@ -727,7 +727,7 @@ mod to_one_rel {
                       id
                   }
               }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":2},{"id":6}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
         insta::assert_snapshot!(
@@ -769,7 +769,7 @@ mod to_one_rel {
                       id
                   }
               }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":3},{"id":4},{"id":5},{"id":6}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":4}]}}"###
         );
 
         Ok(())
@@ -796,7 +796,7 @@ mod to_one_rel {
                   id
               }
           }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":3},{"id":4},{"id":5}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":3},{"id":4}]}}"###
         );
 
         insta::assert_snapshot!(
@@ -815,7 +815,7 @@ mod to_one_rel {
                     id
                 }
             }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":6}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         Ok(())
@@ -842,7 +842,7 @@ mod to_one_rel {
                   id
               }
           }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":4},{"id":5}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":4}]}}"###
         );
 
         insta::assert_snapshot!(
@@ -861,7 +861,7 @@ mod to_one_rel {
                     id
                 }
             }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":6}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/combination/to_one_relation.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/combination/to_one_relation.rs
@@ -127,7 +127,7 @@ mod to_one_rel {
                         id
                     }
                 }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":3},{"id":5},{"id":6}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":3},{"id":5}]}}"###
         );
 
         Ok(())
@@ -292,7 +292,6 @@ mod to_one_rel {
     async fn to_to_one_scalar_list(runner: Runner) -> TestResult<()> {
         create_relation_combination_test_data(&runner).await?;
 
-        // Todo (to-clarify): This considers null and undefined scalar lists as empty.
         insta::assert_snapshot!(
           run_query!(runner, r#"{
               findManyTestModel(where: {
@@ -311,7 +310,7 @@ mod to_one_rel {
                   id
               }
           }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":3},{"id":4},{"id":5}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":3}]}}"###
         );
 
         // Undefined lists are NOT considered.
@@ -355,7 +354,7 @@ mod to_one_rel {
                     id
                 }
             }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":6}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":4},{"id":5},{"id":6}]}}"###
         );
 
         Ok(())
@@ -473,7 +472,18 @@ mod to_one_rel {
                 findManyTestModel(where: {
                     to_one_rel: {
                         is: {
-                            to_many_com: [ { b_field: "fof" }, { b_field: "ofo" } ]
+                            to_many_com: [
+                                    {
+                                        b_field: "fof",
+                                        to_other_com: { c_field: "test" },
+                                        to_other_coms: [ { c_field: "nope" } ]
+                                    },
+                                    {
+                                        b_field: "ofo",
+                                        to_other_com: { c_field: "Test" },
+                                        to_other_coms: [ { c_field: "test" } ]
+                                    }
+                                ]
                         }
                     }
                 }) {
@@ -488,7 +498,18 @@ mod to_one_rel {
                   findManyTestModel(where: {
                       to_one_rel: {
                           isNot: {
-                              to_many_com: [ { b_field: "fof" }, { b_field: "ofo" } ]
+                              to_many_com: [
+                                    {
+                                        b_field: "fof",
+                                        to_other_com: { c_field: "test" },
+                                        to_other_coms: [ { c_field: "nope" } ]
+                                    },
+                                    {
+                                        b_field: "ofo",
+                                        to_other_com: { c_field: "Test" },
+                                        to_other_coms: [ { c_field: "test" } ]
+                                    }
+                                ]
                           }
                       }
                   }) {
@@ -664,7 +685,7 @@ mod to_one_rel {
                     id
                 }
             }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":2},{"id":4},{"id":5}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":3},{"id":6}]}}"###
         );
 
         insta::assert_snapshot!(
@@ -685,7 +706,7 @@ mod to_one_rel {
                     id
                 }
             }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":2},{"id":4},{"id":5}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":3},{"id":4},{"id":5}]}}"###
         );
 
         insta::assert_snapshot!(
@@ -706,7 +727,7 @@ mod to_one_rel {
                       id
                   }
               }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":2},{"id":4},{"id":5}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":2},{"id":6}]}}"###
         );
 
         insta::assert_snapshot!(
@@ -727,7 +748,7 @@ mod to_one_rel {
                     id
                 }
             }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":2},{"id":4},{"id":5}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
         insta::assert_snapshot!(
@@ -748,7 +769,7 @@ mod to_one_rel {
                       id
                   }
               }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":2},{"id":4},{"id":5}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":3},{"id":4},{"id":5},{"id":6}]}}"###
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/equals.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/equals.rs
@@ -45,7 +45,7 @@ mod to_many {
                         id
                     }
                 }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":6},{"id":7},{"id":8},{"id":9}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":6},{"id":7}]}}"###
         );
 
         // Implicit
@@ -61,7 +61,7 @@ mod to_many {
                           id
                       }
                   }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":6},{"id":7},{"id":8},{"id":9}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":6},{"id":7}]}}"###
         );
 
         Ok(())
@@ -186,7 +186,7 @@ mod to_many {
                       id
                   }
               }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":8},{"id":9}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5}]}}"###
         );
 
         // Implicit
@@ -202,7 +202,7 @@ mod to_many {
                         id
                     }
                 }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":8},{"id":9}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5}]}}"###
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/every.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/every.rs
@@ -18,7 +18,7 @@ mod every {
                   id
               }
           }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":6},{"id":7},{"id":8},{"id":9}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":6},{"id":7}]}}"###
         );
 
         Ok(())
@@ -38,7 +38,7 @@ mod every {
                   id
               }
           }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":6},{"id":7},{"id":8},{"id":9}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":6},{"id":7}]}}"###
         );
 
         insta::assert_snapshot!(
@@ -68,7 +68,7 @@ mod every {
                 id
               }
             }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":6},{"id":7},{"id":8},{"id":9}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":6},{"id":7}]}}"###
         );
 
         // `OR` with empty filter returns is a falsey condition, so no records fulfill the condition by default.
@@ -80,7 +80,7 @@ mod every {
               id
             }
           }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":6},{"id":7},{"id":8},{"id":9}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":6},{"id":7}]}}"###
         );
 
         insta::assert_snapshot!(
@@ -89,7 +89,7 @@ mod every {
                 id
               }
             }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":6},{"id":7},{"id":8},{"id":9}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":6},{"id":7}]}}"###
         );
 
         // `NOT` with empty filter returns is a truthy condition, so all record fulfill the condition by default.
@@ -99,7 +99,7 @@ mod every {
                 id
               }
             }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":6},{"id":7},{"id":8},{"id":9}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":6},{"id":7}]}}"###
         );
 
         Ok(())
@@ -123,7 +123,7 @@ mod every {
                   id
                 }
             }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":6},{"id":7},{"id":8},{"id":9}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":6},{"id":7}]}}"###
         );
 
         // Explicit AND
@@ -142,7 +142,7 @@ mod every {
                     id
                   }
               }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":6},{"id":7},{"id":8},{"id":9}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":6},{"id":7}]}}"###
         );
 
         Ok(())
@@ -164,7 +164,7 @@ mod every {
                     id
                 }
             }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":2},{"id":4},{"id":5},{"id":6},{"id":7},{"id":8},{"id":9}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":2},{"id":4},{"id":5},{"id":6},{"id":7}]}}"###
         );
 
         Ok(())
@@ -195,7 +195,7 @@ mod every {
                     id
                 }
             }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":6},{"id":7},{"id":8},{"id":9},{"id":10}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":6},{"id":7},{"id":10}]}}"###
         );
 
         Ok(())
@@ -220,7 +220,7 @@ mod every {
                     id
                 }
             }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":5},{"id":6},{"id":7},{"id":8},{"id":9}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":5},{"id":6},{"id":7}]}}"###
         );
 
         Ok(())
@@ -246,7 +246,7 @@ mod every {
                     id
                 }
             }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":4},{"id":5},{"id":6},{"id":7},{"id":8},{"id":9}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":4},{"id":5},{"id":6},{"id":7}]}}"###
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/is_empty.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/is_empty.rs
@@ -2,6 +2,8 @@ use super::*;
 
 #[test_suite(schema(to_many_composites), only(MongoDB))]
 mod is_empty {
+    use query_engine_tests::run_query;
+
     #[connector_test]
     async fn basic_empty_check(runner: Runner) -> TestResult<()> {
         create_to_many_test_data(&runner).await?;
@@ -29,7 +31,7 @@ mod is_empty {
                       id
                   }
               }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":8},{"id":9}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5}]}}"###
         );
 
         Ok(())
@@ -53,7 +55,7 @@ mod is_empty {
                     id
                 }
             }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":8},{"id":9}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5}]}}"###
         );
 
         insta::assert_snapshot!(
@@ -123,7 +125,7 @@ mod is_empty {
                       id
                   }
               }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":6},{"id":7},{"id":8},{"id":9}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":6},{"id":7}]}}"###
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/is_set.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/is_set.rs
@@ -251,6 +251,18 @@ mod is_set_to_one {
         Ok(())
     }
 
+    #[connector_test]
+    async fn fails_on_required(runner: Runner) -> TestResult<()> {
+        assert_error!(
+            runner,
+            r#"{ findManyTestModel(where: { a: { isSet: true } }) { id } }"#,
+            2009,
+            "Query.findManyTestModel.where.TestModelWhereInput.a.ACompositeFilter.isSet"
+        );
+
+        Ok(())
+    }
+
     async fn create_row(runner: &Runner, data: &str) -> TestResult<()> {
         runner
             .query(format!("mutation {{ createOneTestModel(data: {}) {{ id }} }}", data))
@@ -505,6 +517,18 @@ mod is_set_scalar {
             }
           ) { id } }"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn fails_on_required(runner: Runner) -> TestResult<()> {
+        assert_error!(
+            runner,
+            r#"{ findManyTestModel(where: { id: { isSet: true } }) { id } }"#,
+            2009,
+            "Query.findManyTestModel.where.TestModelWhereInput.id.IntFilter.isSet`: Field does not exist on enclosing type"
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/is_set.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/is_set.rs
@@ -1,0 +1,650 @@
+use super::*;
+
+#[test_suite(schema(to_one_composites), only(MongoDb))]
+mod is_set_to_one {
+
+    #[connector_test]
+    async fn basic(runner: Runner) -> TestResult<()> {
+        create_to_one_test_data(&runner).await?;
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{ findManyTestModel(where: { b: { isSet: false } }) { id } }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":3},{"id":4}]}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{ findManyTestModel(where: { b: { isSet: true } }) { id } }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":5},{"id":6}]}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn negation(runner: Runner) -> TestResult<()> {
+        create_to_one_test_data(&runner).await?;
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{ findManyTestModel(where: { NOT: { b: { isSet: false } } }) { id } }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":5},{"id":6}]}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{ findManyTestModel(where: { NOT: { b: { isSet: true } } }) { id } }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":3},{"id":4}]}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn with_null_check(runner: Runner) -> TestResult<()> {
+        create_to_one_test_data(&runner).await?;
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{
+            findManyTestModel(
+              where: { AND: [
+                { b: { isSet: true } },
+                { b: { isNot: null } },
+              ]}
+            ) { id }
+          }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{
+            findManyTestModel(
+              where: { AND: [
+                { b: { isSet: true } },
+                { b: { is: null } },
+              ]}
+            ) { id }
+          }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":5},{"id":6}]}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{
+            findManyTestModel(
+              where: { AND: [
+                { b: { isSet: false } },
+                { b: { isNot: null } },
+              ]}
+            ) { id }
+          }"#),
+          @r###"{"data":{"findManyTestModel":[]}}"###
+        );
+
+        // Field cannot be `undefined` and `null` at the same time
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{
+            findManyTestModel(
+              where: { AND: [
+                { b: { isSet: false } },
+                { b: { is: null } },
+              ]}
+            ) { id }
+          }"#),
+          @r###"{"data":{"findManyTestModel":[]}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn negation_with_null_check(runner: Runner) -> TestResult<()> {
+        create_to_one_test_data(&runner).await?;
+
+        // Field cannot be `undefined` and `null` at the same time
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{
+            findManyTestModel(
+              where: { NOT: [
+                { b: { isSet: true } },
+                { b: { isNot: null } },
+              ]}
+            ) { id }
+          }"#),
+          @r###"{"data":{"findManyTestModel":[]}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{
+            findManyTestModel(
+              where: { NOT: [
+                { b: { isSet: true } },
+                { b: { is: null } },
+              ]}
+            ) { id }
+          }"#),
+          @r###"{"data":{"findManyTestModel":[]}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{
+            findManyTestModel(
+              where: { NOT: [
+                { b: { isSet: false } },
+                { b: { isNot: null } },
+              ]}
+            ) { id }
+          }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":5},{"id":6}]}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{
+            findManyTestModel(
+              where: { NOT: [
+                { b: { isSet: false } },
+                { b: { is: null } },
+              ]}
+            ) { id }
+          }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn with_equality_check(runner: Runner) -> TestResult<()> {
+        create_to_one_test_data(&runner).await?;
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{ findManyTestModel(
+            where: {
+              AND: [
+                { b: { isSet: true } },
+                { b: { is: { b_field: "b_1" } } },
+              ]
+            }
+          ) { id } }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
+        );
+
+        // `b: null` is excluded because `isNot: { b_field: "b_1"}` checks that `b.b_field` is _not_ `undefined`
+        // and `null.b_field` == undefined
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{ findManyTestModel(
+            where: {
+              AND: [
+                { b: { isSet: true } },
+                { b: { isNot: { b_field: "b_1" } } },
+              ]
+            }
+          ) { id } }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
+        );
+
+        // Field cannot be `undefined` and something else at the same time
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{ findManyTestModel(
+            where: {
+              AND: [
+                { b: { isSet: false } },
+                { b: { is: { b_field: "b_1" } } },
+              ]
+            }
+          ) { id } }"#),
+          @r###"{"data":{"findManyTestModel":[]}}"###
+        );
+
+        // Field cannot be `undefined` and something else at the same time
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{ findManyTestModel(
+            where: {
+              AND: [
+                { b: { isSet: false } },
+                { b: { isNot: { b_field: "b_1" } } },
+              ]
+            }
+          ) { id } }"#),
+          @r###"{"data":{"findManyTestModel":[]}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn silly_logical_combinations(runner: Runner) -> TestResult<()> {
+        create_to_one_test_data(&runner).await?;
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{ findManyTestModel(
+            where: {
+              OR: [
+                { b: { isSet: false } },
+                { b: { isSet: true } },
+              ]
+            }
+          ) { id } }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":6}]}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{ findManyTestModel(
+            where: {
+              AND: [
+                { b: { isSet: false } },
+                { b: { isSet: true } },
+              ]
+            }
+          ) { id } }"#),
+          @r###"{"data":{"findManyTestModel":[]}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{ findManyTestModel(
+            where: {
+              NOT: [
+                { b: { isSet: false } },
+                { b: { isSet: true } },
+              ]
+            }
+          ) { id } }"#),
+          @r###"{"data":{"findManyTestModel":[]}}"###
+        );
+
+        Ok(())
+    }
+
+    async fn create_row(runner: &Runner, data: &str) -> TestResult<()> {
+        runner
+            .query(format!("mutation {{ createOneTestModel(data: {}) {{ id }} }}", data))
+            .await?
+            .assert_success();
+        Ok(())
+    }
+}
+
+#[test_suite(schema(to_one_composites), only(MongoDb))]
+mod is_set_scalar {
+
+    #[connector_test]
+    async fn basic(runner: Runner) -> TestResult<()> {
+        create_to_one_test_data(&runner).await?;
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{ findManyTestModel(where: { field: { isSet: false } }) { id } }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":3},{"id":4}]}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{ findManyTestModel(where: { field: { isSet: true } }) { id } }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":5},{"id":6}]}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn negation(runner: Runner) -> TestResult<()> {
+        create_to_one_test_data(&runner).await?;
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{ findManyTestModel(where: { NOT: { field: { isSet: false } } }) { id } }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":5},{"id":6}]}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{ findManyTestModel(where: { NOT: { field: { isSet: true } } }) { id } }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":3},{"id":4}]}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn with_null_check(runner: Runner) -> TestResult<()> {
+        create_to_one_test_data(&runner).await?;
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{
+            findManyTestModel(
+              where: { AND: [
+                { field: { isSet: true } },
+                { field: { not: null } },
+              ]}
+            ) { id }
+          }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{
+            findManyTestModel(
+              where: { AND: [
+                { field: { isSet: true } },
+                { field: { equals: null } },
+              ]}
+            ) { id }
+          }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":5},{"id":6}]}}"###
+        );
+
+        // Field cannot be `undefined` and have a value at the same time
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{
+            findManyTestModel(
+              where: { AND: [
+                { field: { isSet: false } },
+                { field: { not: null } },
+              ]}
+            ) { id }
+          }"#),
+          @r###"{"data":{"findManyTestModel":[]}}"###
+        );
+
+        // Field cannot be `undefined` and `null` at the same time
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{
+            findManyTestModel(
+              where: { AND: [
+                { field: { isSet: false } },
+                { field: { equals: null } },
+              ]}
+            ) { id }
+          }"#),
+          @r###"{"data":{"findManyTestModel":[]}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn negation_with_null_check(runner: Runner) -> TestResult<()> {
+        create_to_one_test_data(&runner).await?;
+
+        // Field cannot be `undefined` and `null` at the same time
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{
+            findManyTestModel(
+              where: { NOT: [
+                { field: { isSet: true } },
+                { field: { not: null } },
+              ]}
+            ) { id }
+          }"#),
+          @r###"{"data":{"findManyTestModel":[]}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{
+            findManyTestModel(
+              where: { NOT: [
+                { field: { isSet: true } },
+                { field: { equals: null } },
+              ]}
+            ) { id }
+          }"#),
+          @r###"{"data":{"findManyTestModel":[]}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{
+            findManyTestModel(
+              where: { NOT: [
+                { field: { isSet: false } },
+                { field: { not: null } },
+              ]}
+            ) { id }
+          }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":5},{"id":6}]}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{
+            findManyTestModel(
+              where: { NOT: [
+                { field: { isSet: false } },
+                { field: { equals: null } },
+              ]}
+            ) { id }
+          }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn with_equality_check(runner: Runner) -> TestResult<()> {
+        create_to_one_test_data(&runner).await?;
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{ findManyTestModel(
+            where: {
+              AND: [
+                { field: { isSet: true } },
+                { field: { equals: "1" } },
+              ]
+            }
+          ) { id } }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{ findManyTestModel(
+            where: {
+              AND: [
+                { field: { isSet: true } },
+                { field: { not: "1" } },
+              ]
+            }
+          ) { id } }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":2},{"id":5},{"id":6}]}}"###
+        );
+
+        // Field cannot be `undefined` and something else at the same time
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{ findManyTestModel(
+            where: {
+              AND: [
+                { field: { isSet: false } },
+                { field: { equals: "1" } },
+              ]
+            }
+          ) { id } }"#),
+          @r###"{"data":{"findManyTestModel":[]}}"###
+        );
+
+        // Field cannot be `undefined` and something else at the same time
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{ findManyTestModel(
+            where: {
+              AND: [
+                { field: { isSet: false } },
+                { field: { not: "1" } },
+              ]
+            }
+          ) { id } }"#),
+          @r###"{"data":{"findManyTestModel":[]}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn silly_logical_combinations(runner: Runner) -> TestResult<()> {
+        create_to_one_test_data(&runner).await?;
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{ findManyTestModel(
+            where: {
+              OR: [
+                { field: { isSet: false } },
+                { field: { isSet: true } },
+              ]
+            }
+          ) { id } }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":6}]}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{ findManyTestModel(
+            where: {
+              AND: [
+                { field: { isSet: false } },
+                { field: { isSet: true } },
+              ]
+            }
+          ) { id } }"#),
+          @r###"{"data":{"findManyTestModel":[]}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{ findManyTestModel(
+            where: {
+              NOT: [
+                { field: { isSet: false } },
+                { field: { isSet: true } },
+              ]
+            }
+          ) { id } }"#),
+          @r###"{"data":{"findManyTestModel":[]}}"###
+        );
+
+        Ok(())
+    }
+}
+
+#[test_suite(schema(to_many_composites), only(MongoDb))]
+mod is_set_to_many {
+
+    #[connector_test]
+    async fn basic(runner: Runner) -> TestResult<()> {
+        create_to_many_test_data(&runner).await?;
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{ findManyTestModel(where: { to_many_as: { isSet: false } }) { id } }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":8},{"id":9}]}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{ findManyTestModel(where: { to_many_as: { isSet: true } }) { id } }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":6},{"id":7}]}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn negation(runner: Runner) -> TestResult<()> {
+        create_to_many_test_data(&runner).await?;
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{ findManyTestModel(where: { NOT: { to_many_as: { isSet: false } } }) { id } }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":6},{"id":7}]}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{ findManyTestModel(where: { NOT: { to_many_as: { isSet: true } } }) { id } }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":8},{"id":9}]}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn with_equality_check(runner: Runner) -> TestResult<()> {
+        create_to_many_test_data(&runner).await?;
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{ findManyTestModel(
+            where: {
+              AND: [
+                { to_many_as: { isSet: true } },
+                { to_many_as: { some: { a_1: { contains: "oo" } } } },
+              ]
+            }
+          ) { id } }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":3}]}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{ findManyTestModel(
+            where: {
+              AND: [
+                { to_many_as: { isSet: true } },
+                { to_many_as: { none: { a_1: { contains: "oo" } } } },
+              ]
+            }
+          ) { id } }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":2},{"id":4},{"id":5},{"id":6},{"id":7}]}}"###
+        );
+
+        // Field cannot be `undefined` and something else at the same time
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{ findManyTestModel(
+            where: {
+              AND: [
+                { to_many_as: { isSet: false } },
+                { to_many_as: { equals: [] } },
+              ]
+            }
+          ) { id } }"#),
+          @r###"{"data":{"findManyTestModel":[]}}"###
+        );
+
+        // Field cannot be `undefined` and something else at the same time
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{ findManyTestModel(
+            where: {
+              AND: [
+                { to_many_as: { isSet: false } },
+                { to_many_as: { some: { a_1: { contains: "oo" } } } },
+              ]
+            }
+          ) { id } }"#),
+          @r###"{"data":{"findManyTestModel":[]}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn silly_logical_combinations(runner: Runner) -> TestResult<()> {
+        create_to_many_test_data(&runner).await?;
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{ findManyTestModel(
+            where: {
+              OR: [
+                { to_many_as: { isSet: false } },
+                { to_many_as: { isSet: true } },
+              ]
+            }
+          ) { id } }"#),
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":6},{"id":7},{"id":8},{"id":9}]}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{ findManyTestModel(
+            where: {
+              AND: [
+                { to_many_as: { isSet: false } },
+                { to_many_as: { isSet: true } },
+              ]
+            }
+          ) { id } }"#),
+          @r###"{"data":{"findManyTestModel":[]}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{ findManyTestModel(
+            where: {
+              NOT: [
+                { to_many_as: { isSet: false } },
+                { to_many_as: { isSet: true } },
+              ]
+            }
+          ) { id } }"#),
+          @r###"{"data":{"findManyTestModel":[]}}"###
+        );
+
+        Ok(())
+    }
+}

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/mod.rs
@@ -3,6 +3,7 @@ pub mod equals;
 pub mod every;
 pub mod is;
 pub mod is_empty;
+pub mod is_set;
 pub mod none;
 pub mod some;
 
@@ -94,16 +95,16 @@ async fn create_to_many_nested_test_data(runner: &Runner) -> TestResult<()> {
 #[rustfmt::skip]
 async fn create_to_one_test_data(runner: &Runner) -> TestResult<()> {
     // A few with full data
-    create_row(runner, r#"{ id: 1, a: { a_1: "foo1", a_2: 1, b: { b_field: "b_nested_1", c: {} }}, b: { b_field: "b_1", c: {} } }"#).await?;
-    create_row(runner, r#"{ id: 2, a: { a_1: "foo2", a_2: 2, b: { b_field: "b_nested_2", c: {} }}, b: { b_field: "b_2", c: {} } }"#).await?;
+    create_row(runner, r#"{ id: 1, field: "1", a: { a_1: "foo1", a_2: 1, b: { b_field: "b_nested_1", c: {} }}, b: { b_field: "b_1", c: {} } }"#).await?;
+    create_row(runner, r#"{ id: 2, field: "2", a: { a_1: "foo2", a_2: 2, b: { b_field: "b_nested_2", c: {} }}, b: { b_field: "b_2", c: {} } }"#).await?;
 
     // Optional root `b` (undefined)
     create_row(runner, r#"{ id: 3, a: { a_1: "test", a_2: 10,  b: { b_field: "test", c: {} }} }"#).await?;
     create_row(runner, r#"{ id: 4, a: { a_1: "ofo",  a_2: -100, b: { b_field: "test", c: {} }} }"#).await?;
 
     // Explicit `null` root `b`
-    create_row(runner, r#"{ id: 5, a: { a_1: "nope", a_2: 99,  b: { b_field: "bar", c: {} }}, b: null }"#).await?;
-    create_row(runner, r#"{ id: 6, a: { a_1: "epon", a_2: -1,  b: { b_field: "rab", c: {} }}, b: null }"#).await?;
+    create_row(runner, r#"{ id: 5, field: null, a: { a_1: "nope", a_2: 99,  b: { b_field: "bar", c: {} }}, b: null }"#).await?;
+    create_row(runner, r#"{ id: 6, field: null, a: { a_1: "epon", a_2: -1,  b: { b_field: "rab", c: {} }}, b: null }"#).await?;
 
 
     Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/mod.rs
@@ -175,13 +175,11 @@ async fn create_relation_combination_test_data(runner: &Runner) -> TestResult<()
                     {
                         b_field: "foo",
                         scalar_list: [],
-                        to_other_com: { c_field: "a" },
                         to_other_coms: []
                     },
                     {
                         b_field: "oof",
                         scalar_list: ["123"],
-                        to_other_com: { c_field: "b" },
                         to_other_coms: [ { c_field: "foo" } ]
                     }
                 ]
@@ -195,14 +193,25 @@ async fn create_relation_combination_test_data(runner: &Runner) -> TestResult<()
                         a_1: "test",
                         a_2: 10,
                         scalar_list: [],
+                        a_to_other_com: { c_field: "salad" },
                         other_composites: [
                             { b_field: "foo" },
                             { b_field: "oof" }
                         ]
                     }
                     to_many_com: [
-                        { b_field: "ayaya" },
-                        { b_field: "ofo" }
+                        {
+                            b_field: "ayaya",
+                            scalar_list: ["test", "tset"],
+                            to_other_com: { c_field: "oida" },
+                            to_other_coms: []
+                        },
+                        {
+                            b_field: "ofo",
+                            scalar_list: ["bar"],
+                            to_other_com: { c_field: "nope" },
+                            to_other_coms: []
+                        }
                     ]
                 },
                 {
@@ -211,14 +220,25 @@ async fn create_relation_combination_test_data(runner: &Runner) -> TestResult<()
                         a_1: "Test",
                         a_2: -10,
                         scalar_list: [],
+                        a_to_other_com: { c_field: "wurst salad" },
                         other_composites: [
                             { b_field: "foo" },
                             { b_field: "oof" }
                         ]
                     }
                     to_many_com: [
-                        { b_field: "ding" },
-                        { b_field: "dong" }
+                        {
+                            b_field: "ding",
+                            scalar_list: ["hello", "world"],
+                            to_other_com: { c_field: "fof" },
+                            to_other_coms: [{ c_field: "test" }, { c_field: "oof" }]
+                        },
+                        {
+                            b_field: "dong",
+                            scalar_list: ["foo", "bar"],
+                            to_other_com: { c_field: "foo" },
+                            to_other_coms: [{ c_field: "Test" }, { c_field: "ofo" }]
+                        }
                     ]
                 }
             ]
@@ -264,11 +284,22 @@ async fn create_relation_combination_test_data(runner: &Runner) -> TestResult<()
                         a_1: "tset",
                         a_2: 123,
                         scalar_list: ["foo", "oof"],
+                        a_to_other_com: { c_field: "test" },
                         other_composites: [ { b_field: "foo" }, { b_field: "test" } ]
                     }
                     to_many_com: [
-                        { b_field: "ayaya" },
-                        { b_field: "ofo" }
+                        {
+                            b_field: "foo",
+                            scalar_list: ["foo", "bar"],
+                            to_other_com: { c_field: "test" },
+                            to_other_coms: [{ c_field: "ofofoo" }, { c_field: "foo?" }]
+                        },
+                        {
+                            b_field: "ofo",
+                            scalar_list: ["foo"],
+                            to_other_com: { c_field: "Test" },
+                            to_other_coms: [{ c_field: "Test" }]
+                        }
                     ]
                 },
                 {
@@ -276,6 +307,7 @@ async fn create_relation_combination_test_data(runner: &Runner) -> TestResult<()
                     to_one_com: {
                         a_1: "Test",
                         a_2: -10,
+                        a_to_other_com: { c_field: "foo" },
                         scalar_list: ["foo", "bar", "baz"],
                         other_composites: [
                             { b_field: "foo" },
@@ -283,8 +315,18 @@ async fn create_relation_combination_test_data(runner: &Runner) -> TestResult<()
                         ]
                     }
                     to_many_com: [
-                        { b_field: "ding" },
-                        { b_field: "dong" }
+                        {
+                            b_field: "ding",
+                            scalar_list: ["test", "foo"],
+                            to_other_com: { c_field: "foo" },
+                            to_other_coms: [{ c_field: "bar" }, { c_field: "foo!" }]
+                        },
+                        {
+                            b_field: "dong",
+                            scalar_list: ["foo", "bar"],
+                            to_other_com: { c_field: "test" },
+                            to_other_coms: [{ c_field: "test" }, { c_field: "Test" }]
+                        }
                     ]
                 }
             ]
@@ -329,14 +371,24 @@ async fn create_relation_combination_test_data(runner: &Runner) -> TestResult<()
                         a_1: "test",
                         a_2: 11,
                         scalar_list: [],
+                        a_to_other_com: { c_field: "1" },
                         other_composites: [
-                            { b_field: "fo" },
-                            { b_field: "of" }
+                            { b_field: "foo" },
+                            { b_field: "oof" }
                         ]
                     }
                     to_many_com: [
-                        { b_field: "ayaya" },
-                        { b_field: "ofo" }
+                        {
+                            b_field: "oof",
+                            scalar_list: ["test", "bar"],
+                            to_other_com: { c_field: "FOO" },
+                            to_other_coms: [{ c_field: "test" }]
+                        },
+                        {
+                            b_field: "foof",
+                            scalar_list: ["wurst"],
+                            to_other_com: { c_field: "OOF" },
+                            to_other_coms: [] }
                     ]
                 },
                 {
@@ -345,14 +397,24 @@ async fn create_relation_combination_test_data(runner: &Runner) -> TestResult<()
                         a_1: "Test",
                         a_2: -10,
                         scalar_list: ["foo"],
+                        a_to_other_com: { c_field: "2" },
                         other_composites: [
                             { b_field: "foof" },
                             { b_field: "ofoo" }
                         ]
                     }
                     to_many_com: [
-                        { b_field: "ding" },
-                        { b_field: "dong" }
+                        {
+                            b_field: "dood",
+                            scalar_list: ["foo"],
+                            to_other_com: { c_field: "foo" },
+                            to_other_coms: [{ c_field: "woo" }, { c_field: "sah" }]  },
+                        {
+                            b_field: "doot",
+                            scalar_list: ["dood"],
+                            to_other_com: { c_field: "oof" },
+                            to_other_coms: [{ c_field: "test" }, { c_field: "TEST" }]
+                        }
                     ]
                 }
             ]

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/mod.rs
@@ -161,21 +161,65 @@ async fn create_relation_combination_test_data(runner: &Runner) -> TestResult<()
         to_one_rel: {
             create: {
                 id: 1
-                to_one_com: { a_1: "test", a_2: 10, scalar_list: ["a", "b", "c"], other_composites: [ { b_field: "foo", scalar_list: ["1", "2"], }, { b_field: "oof", scalar_list: ["1"] } ] }
-                to_many_com: [ { b_field: "foo", scalar_list: [], }, { b_field: "oof", scalar_list: ["123"], } ]
+                to_one_com: {
+                    a_1: "test",
+                    a_2: 10,
+                    scalar_list: ["a", "b", "c"],
+                    a_to_other_com: { c_field: "foo" },
+                    other_composites: [
+                        { b_field: "foo", scalar_list: ["1", "2"], to_other_com: { c_field: "test" } },
+                        { b_field: "oof", scalar_list: ["1"],      to_other_com: { c_field: "Test" } }
+                    ]
+                }
+                to_many_com: [
+                    {
+                        b_field: "foo",
+                        scalar_list: [],
+                        to_other_com: { c_field: "a" },
+                        to_other_coms: []
+                    },
+                    {
+                        b_field: "oof",
+                        scalar_list: ["123"],
+                        to_other_com: { c_field: "b" },
+                        to_other_coms: [ { c_field: "foo" } ]
+                    }
+                ]
             }
         }
         to_many_rel: {
             create: [
                 {
                     id: 2
-                    to_one_com: { a_1: "test", a_2: 10, other_composites: [ { b_field: "foo" }, { b_field: "oof" } ] }
-                    to_many_com: [ { b_field: "ayaya" }, { b_field: "ofo" } ]
+                    to_one_com: {
+                        a_1: "test",
+                        a_2: 10,
+                        scalar_list: [],
+                        other_composites: [
+                            { b_field: "foo" },
+                            { b_field: "oof" }
+                        ]
+                    }
+                    to_many_com: [
+                        { b_field: "ayaya" },
+                        { b_field: "ofo" }
+                    ]
                 },
                 {
                     id: 3
-                    to_one_com: { a_1: "Test", a_2: -10, other_composites: [ { b_field: "foo" }, { b_field: "oof" } ] }
-                    to_many_com: [ { b_field: "ding" }, { b_field: "dong" } ]
+                    to_one_com: {
+                        a_1: "Test",
+                        a_2: -10,
+                        scalar_list: [],
+                        other_composites: [
+                            { b_field: "foo" },
+                            { b_field: "oof" }
+                        ]
+                    }
+                    to_many_com: [
+                        { b_field: "ding" },
+                        { b_field: "dong" }
+                    ]
                 }
             ]
         }
@@ -186,21 +230,62 @@ async fn create_relation_combination_test_data(runner: &Runner) -> TestResult<()
         to_one_rel: {
             create: {
                 id: 4
-                to_one_com: { a_1: "hello world", a_2: -5, scalar_list: ["a", "b"], other_composites: [ { b_field: "shardbearer malenia", scalar_list: [] }, { b_field: "is", scalar_list: [] }, { b_field: "overtuned", scalar_list: [] } ] }
-                to_many_com: [ { b_field: "test", scalar_list: ["hello"] }, { b_field: "oof", scalar_list: ["hello", "world"] } ]
+                to_one_com: {
+                    a_1: "hello world",
+                    a_2: -5,
+                    scalar_list: ["a", "b"],
+                    a_to_other_com: { c_field: "oof" },
+                    other_composites: [
+                        { b_field: "Shardbearer malenia", scalar_list: [], to_other_com: { c_field: "test" } },
+                        { b_field: "is", scalar_list: [], to_other_com: { c_field: "foo" } },
+                        { b_field: "overtuned", scalar_list: [], to_other_com: { c_field: "oof" } }
+                    ]
+                }
+                to_many_com: [
+                    {
+                        b_field: "test",
+                        scalar_list: ["hello"],
+                        to_other_com: { c_field: "test" },
+                        to_other_coms: [ { c_field: "oof" } ] },
+                    {
+                        b_field: "oof",
+                        scalar_list: ["hello", "world"],
+                        to_other_com: { c_field: "foo" },
+                        to_other_coms: [ { c_field: "foof" } ]
+                    }
+                ]
             }
         }
         to_many_rel: {
             create: [
                 {
                     id: 5
-                    to_one_com: { a_1: "tset", a_2: 123, other_composites: [ { b_field: "foo" }, { b_field: "test" } ] }
-                    to_many_com: [ { b_field: "ayaya" }, { b_field: "ofo" } ]
+                    to_one_com: {
+                        a_1: "tset",
+                        a_2: 123,
+                        scalar_list: ["foo", "oof"],
+                        other_composites: [ { b_field: "foo" }, { b_field: "test" } ]
+                    }
+                    to_many_com: [
+                        { b_field: "ayaya" },
+                        { b_field: "ofo" }
+                    ]
                 },
                 {
                     id: 6
-                    to_one_com: { a_1: "Test", a_2: -10, other_composites: [ { b_field: "foo" }, { b_field: "oof" } ] }
-                    to_many_com: [ { b_field: "ding" }, { b_field: "dong" } ]
+                    to_one_com: {
+                        a_1: "Test",
+                        a_2: -10,
+                        scalar_list: ["foo", "bar", "baz"],
+                        other_composites: [
+                            { b_field: "foo" },
+                            { b_field: "oof" }
+                        ]
+                    }
+                    to_many_com: [
+                        { b_field: "ding" },
+                        { b_field: "dong" }
+                    ]
                 }
             ]
         }
@@ -211,21 +296,64 @@ async fn create_relation_combination_test_data(runner: &Runner) -> TestResult<()
         to_one_rel: {
             create: {
                 id: 7
-                to_one_com: { a_1: "world", a_2: 0, scalar_list: [], other_composites: [ { b_field: "shardbearer mogh", scalar_list: ["a"] }, { b_field: "is", scalar_list: ["b"] }, { b_field: "perfect", scalar_list: ["c"] } ] }
-                to_many_com: [ { b_field: "fof" }, { b_field: "ofo" } ]
+                to_one_com: {
+                    a_1: "world",
+                    a_2: 0,
+                    scalar_list: [],
+                    a_to_other_com: { c_field: "ofo", scalar_list: [] },
+                    other_composites: [
+                        { b_field: "shardbearer mogh", to_other_com: { c_field: "test" }  },
+                        { b_field: "is", scalar_list: ["b"], to_other_com: { c_field: "Test" }  },
+                        { b_field: "perfect", scalar_list: ["c"], to_other_com: { c_field: "nope" }  }
+                    ]
+                }
+                to_many_com: [
+                    {
+                        b_field: "fof",
+                        to_other_com: { c_field: "test" },
+                        to_other_coms: [ { c_field: "nope" } ]
+                    },
+                    {
+                        b_field: "ofo",
+                        to_other_com: { c_field: "Test" },
+                        to_other_coms: [ { c_field: "test" } ]
+                    }
+                ]
             }
         }
         to_many_rel: {
             create: [
                 {
                     id: 8
-                    to_one_com: { a_1: "test", a_2: 11, other_composites: [ { b_field: "fo" }, { b_field: "of" } ] }
-                    to_many_com: [ { b_field: "ayaya" }, { b_field: "ofo" } ]
+                    to_one_com: {
+                        a_1: "test",
+                        a_2: 11,
+                        scalar_list: [],
+                        other_composites: [
+                            { b_field: "fo" },
+                            { b_field: "of" }
+                        ]
+                    }
+                    to_many_com: [
+                        { b_field: "ayaya" },
+                        { b_field: "ofo" }
+                    ]
                 },
                 {
                     id: 9
-                    to_one_com: { a_1: "Test", a_2: -10, other_composites: [ { b_field: "foof" }, { b_field: "ofoo" } ] }
-                    to_many_com: [ { b_field: "ding" }, { b_field: "dong" } ]
+                    to_one_com: {
+                        a_1: "Test",
+                        a_2: -10,
+                        scalar_list: ["foo"],
+                        other_composites: [
+                            { b_field: "foof" },
+                            { b_field: "ofoo" }
+                        ]
+                    }
+                    to_many_com: [
+                        { b_field: "ding" },
+                        { b_field: "dong" }
+                    ]
                 }
             ]
         }

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/mod.rs
@@ -109,7 +109,7 @@ async fn create_to_one_test_data(runner: &Runner) -> TestResult<()> {
     Ok(())
 }
 
-/// Basic to-many test data.
+/// Composite combination test data.
 #[rustfmt::skip]
 async fn create_combination_test_data(runner: &Runner) -> TestResult<()> {
     // A few with full data
@@ -148,6 +148,140 @@ async fn create_combination_test_data(runner: &Runner) -> TestResult<()> {
     // A few with no list and no b - this will cause undefined fields!
     create_row(runner, r#"{ id: 10 }"#).await?;
     create_row(runner, r#"{ id: 11 }"#).await?;
+
+    Ok(())
+}
+
+/// Composite/Relation combination test data.
+#[rustfmt::skip]
+async fn create_relation_combination_test_data(runner: &Runner) -> TestResult<()> {
+    // A few with full data
+    create_row(runner, r#"{
+        id: 1,
+        to_one_rel: {
+            create: {
+                id: 1
+                to_one_com: { a_1: "test", a_2: 10, scalar_list: ["a", "b", "c"], other_composites: [ { b_field: "foo", scalar_list: ["1", "2"], }, { b_field: "oof", scalar_list: ["1"] } ] }
+                to_many_com: [ { b_field: "foo", scalar_list: [], }, { b_field: "oof", scalar_list: ["123"], } ]
+            }
+        }
+        to_many_rel: {
+            create: [
+                {
+                    id: 2
+                    to_one_com: { a_1: "test", a_2: 10, other_composites: [ { b_field: "foo" }, { b_field: "oof" } ] }
+                    to_many_com: [ { b_field: "ayaya" }, { b_field: "ofo" } ]
+                },
+                {
+                    id: 3
+                    to_one_com: { a_1: "Test", a_2: -10, other_composites: [ { b_field: "foo" }, { b_field: "oof" } ] }
+                    to_many_com: [ { b_field: "ding" }, { b_field: "dong" } ]
+                }
+            ]
+        }
+    }"#).await?;
+
+    create_row(runner, r#"{
+        id: 2,
+        to_one_rel: {
+            create: {
+                id: 4
+                to_one_com: { a_1: "hello world", a_2: -5, scalar_list: ["a", "b"], other_composites: [ { b_field: "shardbearer malenia", scalar_list: [] }, { b_field: "is", scalar_list: [] }, { b_field: "overtuned", scalar_list: [] } ] }
+                to_many_com: [ { b_field: "test", scalar_list: ["hello"] }, { b_field: "oof", scalar_list: ["hello", "world"] } ]
+            }
+        }
+        to_many_rel: {
+            create: [
+                {
+                    id: 5
+                    to_one_com: { a_1: "tset", a_2: 123, other_composites: [ { b_field: "foo" }, { b_field: "test" } ] }
+                    to_many_com: [ { b_field: "ayaya" }, { b_field: "ofo" } ]
+                },
+                {
+                    id: 6
+                    to_one_com: { a_1: "Test", a_2: -10, other_composites: [ { b_field: "foo" }, { b_field: "oof" } ] }
+                    to_many_com: [ { b_field: "ding" }, { b_field: "dong" } ]
+                }
+            ]
+        }
+    }"#).await?;
+
+    create_row(runner, r#"{
+        id: 3,
+        to_one_rel: {
+            create: {
+                id: 7
+                to_one_com: { a_1: "world", a_2: 0, scalar_list: [], other_composites: [ { b_field: "shardbearer mogh", scalar_list: ["a"] }, { b_field: "is", scalar_list: ["b"] }, { b_field: "perfect", scalar_list: ["c"] } ] }
+                to_many_com: [ { b_field: "fof" }, { b_field: "ofo" } ]
+            }
+        }
+        to_many_rel: {
+            create: [
+                {
+                    id: 8
+                    to_one_com: { a_1: "test", a_2: 11, other_composites: [ { b_field: "fo" }, { b_field: "of" } ] }
+                    to_many_com: [ { b_field: "ayaya" }, { b_field: "ofo" } ]
+                },
+                {
+                    id: 9
+                    to_one_com: { a_1: "Test", a_2: -10, other_composites: [ { b_field: "foof" }, { b_field: "ofoo" } ] }
+                    to_many_com: [ { b_field: "ding" }, { b_field: "dong" } ]
+                }
+            ]
+        }
+    }"#).await?;
+
+    // One with empty / null composites
+    create_row(runner, r#"{
+        id: 4,
+        to_one_rel: {
+            create: {
+                id: 10
+                to_one_com: null
+                to_many_com: []
+            }
+        }
+        to_many_rel: {
+            create: [
+                {
+                    id: 11
+                    to_one_com: null
+                    to_many_com: []
+                },
+                {
+                    id: 12
+                    to_one_com: null
+                    to_many_com: []
+                }
+            ]
+        }
+    }"#).await?;
+
+    // One with undefined composites
+    create_row(runner, r#"{
+        id: 5,
+        to_one_rel: {
+            create: {
+                id: 13
+            }
+        }
+        to_many_rel: {
+            create: [
+                {
+                    id: 14
+                },
+                {
+                    id: 15
+                }
+            ]
+        }
+    }"#).await?;
+
+
+    // One with no related records
+    create_row(runner, r#"{
+        id: 6,
+    }"#).await?;
 
     Ok(())
 }

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/none.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/none.rs
@@ -18,7 +18,7 @@ mod none {
                   id
               }
           }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":5},{"id":6},{"id":7},{"id":8},{"id":9}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":5},{"id":6},{"id":7}]}}"###
         );
 
         Ok(())
@@ -38,7 +38,7 @@ mod none {
                   id
               }
           }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":6},{"id":7},{"id":8},{"id":9}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":6},{"id":7}]}}"###
         );
 
         insta::assert_snapshot!(
@@ -68,7 +68,7 @@ mod none {
                 id
               }
             }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":6},{"id":7},{"id":8},{"id":9}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":6},{"id":7}]}}"###
         );
 
         // `OR` with empty filter returns is a falsey condition, so no records fulfill the condition by default.
@@ -79,7 +79,7 @@ mod none {
               id
             }
           }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":6},{"id":7},{"id":8},{"id":9}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":6},{"id":7}]}}"###
         );
 
         // All records do not fulfill this condition, so it returns all records.
@@ -89,7 +89,7 @@ mod none {
                 id
               }
             }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":6},{"id":7},{"id":8},{"id":9}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":6},{"id":7}]}}"###
         );
 
         // `NOT` with empty filter returns is a truthy condition, so all record fulfill the condition by default.
@@ -100,7 +100,7 @@ mod none {
                 id
               }
             }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":6},{"id":7},{"id":8},{"id":9}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":6},{"id":7}]}}"###
         );
 
         Ok(())
@@ -124,7 +124,7 @@ mod none {
                   id
                 }
             }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":4},{"id":5},{"id":6},{"id":7},{"id":8},{"id":9}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":4},{"id":5},{"id":6},{"id":7}]}}"###
         );
 
         // Explicit AND
@@ -143,7 +143,7 @@ mod none {
                     id
                   }
               }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":4},{"id":5},{"id":6},{"id":7},{"id":8},{"id":9}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":4},{"id":5},{"id":6},{"id":7}]}}"###
         );
 
         Ok(())
@@ -165,7 +165,7 @@ mod none {
                     id
                 }
             }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":3},{"id":6},{"id":7},{"id":8},{"id":9}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":3},{"id":6},{"id":7}]}}"###
         );
 
         Ok(())
@@ -196,7 +196,7 @@ mod none {
                     id
                 }
             }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":5},{"id":6},{"id":7},{"id":8},{"id":9}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":5},{"id":6},{"id":7}]}}"###
         );
 
         Ok(())
@@ -222,7 +222,7 @@ mod none {
                     id
                 }
             }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":6},{"id":7},{"id":8},{"id":9}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":6},{"id":7}]}}"###
         );
 
         Ok(())
@@ -248,7 +248,7 @@ mod none {
                     id
                 }
             }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":4},{"id":5},{"id":6},{"id":7},{"id":8},{"id":9}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":4},{"id":5},{"id":6},{"id":7}]}}"###
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/some.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/some.rs
@@ -51,7 +51,7 @@ mod some {
                       id
                   }
               }"#),
-          @r###"{"data":{"findManyTestModel":[{"id":6},{"id":7},{"id":8},{"id":9}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"id":6},{"id":7}]}}"###
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/decimal_filter.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/decimal_filter.rs
@@ -36,9 +36,12 @@ mod decimal_filter_spec {
           @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
         );
 
-        insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { decimal: null }) { id }}"#),
-          @r###"{"data":{"findManyTestModel":[{"id":3}]}}"###
+        match_connector_result!(
+          &runner,
+          r#"query { findManyTestModel(where: { decimal: null }) { id }}"#,
+          // MongoDB excludes undefined fields
+          MongoDb(_) => vec![r#"{"data":{"findManyTestModel":[]}}"#],
+          _ => vec![r#"{"data":{"findManyTestModel":[{"id":3}]}}"#]
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/list_filters.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/list_filters.rs
@@ -420,6 +420,17 @@ mod enum_lists {
             .await?
             .assert_success();
 
+        runner
+            .query(indoc! { r#"
+              mutation {
+                createOneTestModel(data: {
+                  id: 3,
+                }) { id }
+            }
+            "#})
+            .await?
+            .assert_success();
+
         Ok(())
     }
 }

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/composites/list.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/composites/list.rs
@@ -1018,6 +1018,7 @@ mod update {
 
         type CompositeC {
           c_field        Int         @map("c_int") @default(0)
+          c_opt_field    Int?        @map("c_opt_int") @default(0)
           c_to_one_d_opt CompositeD? @map("to_one_d")
           c_to_one_e_opt CompositeE? @map("to_one_e")
         }
@@ -1173,6 +1174,7 @@ mod update {
                         b_to_one_c: {
                           update: {
                             c_field: 1,
+                            c_opt_field: { unset: true }
                             c_to_one_d_opt: { unset: true },
                             c_to_one_e_opt: { unset: true },
                           }
@@ -1190,6 +1192,7 @@ mod update {
                   b_field
                   b_to_one_c {
                     c_field
+                    c_opt_field
                     c_to_one_d_opt { d_field }
                     c_to_one_e_opt { e_field }
                   }
@@ -1197,7 +1200,7 @@ mod update {
               }
             }
           }"#),
-          @r###"{"data":{"updateOneTestModel":{"id":1,"to_many_as":[{"a_field":1,"a_to_one_b":{"b_field":1,"b_to_one_c":{"c_field":1,"c_to_one_d_opt":null,"c_to_one_e_opt":null}}}]}}}"###
+          @r###"{"data":{"updateOneTestModel":{"id":1,"to_many_as":[{"a_field":1,"a_to_one_b":{"b_field":1,"b_to_one_c":{"c_field":1,"c_opt_field":null,"c_to_one_d_opt":null,"c_to_one_e_opt":null}}}]}}}"###
         );
 
         // (nested multiple unsets without any other updates) within updateMany
@@ -1212,6 +1215,7 @@ mod update {
                       update: {
                         b_to_one_c: {
                           update: {
+                            c_opt_field: { unset: true }
                             c_to_one_d_opt: { unset: true },
                             c_to_one_e_opt: { unset: true },
                           }
@@ -1229,6 +1233,7 @@ mod update {
                   b_field
                   b_to_one_c {
                     c_field
+                    c_opt_field
                     c_to_one_d_opt { d_field }
                     c_to_one_e_opt { e_field }
                   }
@@ -1236,7 +1241,7 @@ mod update {
               }
             }
           }"#),
-          @r###"{"data":{"updateOneTestModel":{"id":2,"to_many_as":[{"a_field":0,"a_to_one_b":{"b_field":0,"b_to_one_c":{"c_field":1,"c_to_one_d_opt":null,"c_to_one_e_opt":null}}}]}}}"###
+          @r###"{"data":{"updateOneTestModel":{"id":2,"to_many_as":[{"a_field":0,"a_to_one_b":{"b_field":0,"b_to_one_c":{"c_field":1,"c_opt_field":null,"c_to_one_d_opt":null,"c_to_one_e_opt":null}}}]}}}"###
         );
 
         // (nested multiple unsets + scalar updates) within upsert within updateMany
@@ -1256,6 +1261,7 @@ mod update {
                             set: { c_field: 0 },
                             update: {
                               c_field: 2,
+                              c_opt_field: { unset: true }
                               c_to_one_d_opt: { unset: true },
                               c_to_one_e_opt: { unset: true },
                             }
@@ -1274,6 +1280,7 @@ mod update {
                   b_field
                   b_to_one_c_opt {
                     c_field
+                    c_opt_field
                     c_to_one_d_opt { d_field }
                     c_to_one_e_opt { e_field }
                   }
@@ -1281,7 +1288,7 @@ mod update {
               }
             }
           }"#),
-          @r###"{"data":{"updateOneTestModel":{"id":1,"to_many_as":[{"a_field":2,"a_to_one_b":{"b_field":2,"b_to_one_c_opt":{"c_field":2,"c_to_one_d_opt":null,"c_to_one_e_opt":null}}}]}}}"###
+          @r###"{"data":{"updateOneTestModel":{"id":1,"to_many_as":[{"a_field":2,"a_to_one_b":{"b_field":2,"b_to_one_c_opt":{"c_field":2,"c_opt_field":null,"c_to_one_d_opt":null,"c_to_one_e_opt":null}}}]}}}"###
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/composites/single.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/composites/single.rs
@@ -484,7 +484,8 @@ mod update {
             &runner,
             r#"{
           id: 1
-          a: { b: { c: { b: { c: {}} } } }
+          field: "1",
+          a: { b: { c: { c_opt: "nested_1", b: { c: {}} } } }
           b: { c: {} }
         }"#,
         )
@@ -521,6 +522,52 @@ mod update {
           @r###"{"data":{"updateOneTestModel":{"a":{"a_1":"a_1 default","a_2":null,"b":{"c":{"b":null}}},"b":null}}}"###
         );
 
+        // Nested scalar
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"mutation {
+            updateOneTestModel(
+              where: { id: 1 }
+              data: {
+                a: {
+                  update: { b: { update: { c: { update: { c_opt: { unset: true } } } } } }
+                }
+              }
+            ) {
+              a {
+                a_1
+                a_2
+                b {
+                  c {
+                    c_opt
+                  }
+                }
+              }
+            }
+          }
+          "#),
+          @r###"{"data":{"updateOneTestModel":{"a":{"a_1":"a_1 default","a_2":null,"b":{"c":{"c_opt":null}}}}}}"###
+        );
+
+        // Top-level scalar
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"mutation {
+            updateOneTestModel(where: { id: 1 }, data: { field: { unset: true } }) {
+              field
+              a {
+                a_1
+                a_2
+                b {
+                  c {
+                    c_opt
+                  }
+                }
+              }
+            }
+          }
+          "#),
+          @r###"{"data":{"updateOneTestModel":{"field":null,"a":{"a_1":"a_1 default","a_2":null,"b":{"c":{"c_opt":null}}}}}}"###
+        );
+
         Ok(())
     }
 
@@ -541,10 +588,23 @@ mod update {
           @r###"{"data":{"updateOneTestModel":{"b":{"b_field":"b1"}}}}"###
         );
 
+        // Optional scalar
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"mutation { updateOneTestModel(
+            where: { id: 1 },
+            data: { a: { update: { a_2: { unset: false } } } }
+          ) {
+            a {
+              a_2
+            }
+          }}"#),
+          @r###"{"data":{"updateOneTestModel":{"b":{"b_field":"b1"}}}}"###
+        );
+
         Ok(())
     }
 
-    // Ensures unset is only available on optional field of type composite
+    // Ensures unset is only available on optional scalars/to-one composite
     #[connector_test]
     async fn ensure_unset_unavailable_on_fields(runner: Runner) -> TestResult<()> {
         create_test_data(&runner).await?;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/composites/single.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/composites/single.rs
@@ -598,7 +598,7 @@ mod update {
               a_2
             }
           }}"#),
-          @r###"{"data":{"updateOneTestModel":{"b":{"b_field":"b1"}}}}"###
+          @r###"{"data":{"updateOneTestModel":{"a":{"a_2":2}}}}"###
         );
 
         Ok(())
@@ -608,16 +608,6 @@ mod update {
     #[connector_test]
     async fn ensure_unset_unavailable_on_fields(runner: Runner) -> TestResult<()> {
         create_test_data(&runner).await?;
-
-        assert_error!(
-            runner,
-            r#"mutation { updateOneTestModel(
-              where: { id: 1 },
-              data: { field: { unset: true } }
-            ) { id }}"#,
-            2009,
-            "Mutation.updateOneTestModel.data.TestModelUpdateInput.field.NullableStringFieldUpdateOperationsInput.unset`: Field does not exist on enclosing type"
-        );
 
         assert_error!(
           runner,

--- a/query-engine/connectors/mongodb-query-connector/src/cursor.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/cursor.rs
@@ -50,8 +50,9 @@ impl CursorBuilder {
 
         for (field, value) in cursor {
             let bson = (&field, value).into_bson()?;
+            let field_name = format!("${}", field.db_name());
 
-            cursor_filters.push(doc! { field.db_name(): { "$eq": bson }});
+            cursor_filters.push(doc! { "$eq": [field_name, bson]});
         }
 
         let cursor_filter = doc! { "$and": cursor_filters };
@@ -181,7 +182,7 @@ fn map_orderby_condition(order_data: &OrderByData, reverse: bool, include_eq: bo
 
     // order_expr
 
-    doc! { "$expr": order_doc }
+    order_doc
 }
 
 fn map_equality_condition(order_data: &OrderByData) -> Document {
@@ -207,6 +208,6 @@ fn map_equality_condition(order_data: &OrderByData) -> Document {
     // } else {
 
     // Todo: Verify this actually does everything we want already.
-    doc! { "$expr": { "$eq": [format!("${}", &order_field_reference), format!("$${}", &order_field_reference)] } }
+    doc! { "$eq": [format!("${}", &order_field_reference), format!("$${}", &order_field_reference)] }
     // }
 }

--- a/query-engine/connectors/mongodb-query-connector/src/filter.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/filter.rs
@@ -1,10 +1,9 @@
 use crate::{error::MongoError, join::JoinStage, IntoBson};
 use connector_interface::{
-    AggregationFilter, CompositeCondition, CompositeFilter, Filter, OneRelationIsNullFilter, QueryMode,
-    RelationCondition, RelationFilter, ScalarCompare, ScalarCondition, ScalarFilter, ScalarListFilter,
-    ScalarProjection,
+    AggregationFilter, CompositeCondition, CompositeFilter, Filter, OneRelationIsNullFilter, QueryMode, RelationFilter,
+    ScalarCompare, ScalarCondition, ScalarFilter, ScalarListFilter, ScalarProjection,
 };
-use mongodb::bson::{doc, Bson, Document, Regex};
+use mongodb::bson::{doc, Bson, Document};
 use prisma_models::{CompositeFieldRef, PrismaValue, ScalarFieldRef};
 
 #[derive(Debug)]
@@ -41,28 +40,27 @@ pub(crate) struct MongoRelationFilter {
 pub(crate) fn convert_filter(
     filter: Filter,
     invert: bool,
-    is_having_filter: bool,
     prefix: impl Into<FilterPrefix>,
 ) -> crate::Result<MongoFilter> {
     let prefix = prefix.into();
     let filter = fold_compounds(filter);
 
     let filter_pair = match filter {
-        Filter::And(filters) if invert => coerce_empty(false, "$or", filters, invert, is_having_filter, prefix)?,
-        Filter::And(filters) => coerce_empty(true, "$and", filters, invert, is_having_filter, prefix)?,
+        Filter::And(filters) if invert => coerce_empty(false, "$or", filters, invert, prefix)?,
+        Filter::And(filters) => coerce_empty(true, "$and", filters, invert, prefix)?,
 
-        Filter::Or(filters) if invert => coerce_empty(true, "$and", filters, invert, is_having_filter, prefix)?,
-        Filter::Or(filters) => coerce_empty(false, "$or", filters, invert, is_having_filter, prefix)?,
+        Filter::Or(filters) if invert => coerce_empty(true, "$and", filters, invert, prefix)?,
+        Filter::Or(filters) => coerce_empty(false, "$or", filters, invert, prefix)?,
 
-        Filter::Not(filters) if invert => coerce_empty(false, "$or", filters, !invert, is_having_filter, prefix)?,
-        Filter::Not(filters) => coerce_empty(true, "$and", filters, !invert, is_having_filter, prefix)?,
+        Filter::Not(filters) if invert => coerce_empty(false, "$or", filters, !invert, prefix)?,
+        Filter::Not(filters) => coerce_empty(true, "$and", filters, !invert, prefix)?,
 
-        Filter::Scalar(sf) => scalar_filter(sf, invert, true, is_having_filter, prefix)?,
+        Filter::Scalar(sf) => scalar_filter(sf, invert, prefix)?,
         Filter::Empty => MongoFilter::Scalar(doc! {}),
         Filter::ScalarList(slf) => scalar_list_filter(slf, invert, prefix)?,
-        Filter::OneRelationIsNull(filter) => one_is_null(filter, invert),
+        Filter::OneRelationIsNull(filter) => one_is_null(filter, invert, prefix),
         Filter::Relation(rfilter) => relation_filter(rfilter, invert, prefix)?,
-        Filter::Aggregation(filter) => aggregation_filter(filter, invert, prefix)?,
+        Filter::Aggregation(filter) => aggregation_filter(filter, invert)?,
         Filter::Composite(filter) => composite_filter(filter, invert, prefix)?,
         Filter::BoolFilter(_) => unimplemented!("MongoDB boolean filter."),
     };
@@ -102,22 +100,17 @@ fn coerce_empty(
     operation: &str,
     filters: Vec<Filter>,
     invert: bool,
-    is_having_filter: bool,
     prefix: FilterPrefix,
 ) -> crate::Result<MongoFilter> {
     if filters.is_empty() {
         // We need to create a truthy or falsey expression for empty filter queries, e.g. AND / OR / NOT.
         // We abuse the fact that we can create an always failing or succeeding condition with logical `and` and `or` operators,
         // for example "a field exists or doesn't exist" is always true, "a field exists and doesn't exist" is always false.
-        let doc = if truthy {
-            doc! { "$or": [ { "__prisma_marker": { "$exists": 1 }}, { "__prisma_marker": { "$exists": 0 }} ] }
-        } else {
-            doc! { "$and": [ { "__prisma_marker": { "$exists": 1 }}, { "__prisma_marker": { "$exists": 0 }} ] }
-        };
+        let stub_condition = render_stub_condition(truthy);
 
-        Ok(MongoFilter::Scalar(doc))
+        Ok(MongoFilter::Scalar(stub_condition))
     } else {
-        fold_filters(operation, filters, invert, is_having_filter, prefix)
+        fold_filters(operation, filters, invert, prefix)
     }
 }
 
@@ -125,12 +118,11 @@ fn fold_filters(
     operation: &str,
     filters: Vec<Filter>,
     invert: bool,
-    is_having_filter: bool,
     prefix: FilterPrefix,
 ) -> crate::Result<MongoFilter> {
     let filters = filters
         .into_iter()
-        .map(|f| Ok(convert_filter(f, invert, is_having_filter, prefix.clone())?.render()))
+        .map(|f| Ok(convert_filter(f, invert, prefix.clone())?.render()))
         .collect::<crate::Result<Vec<_>>>()?;
 
     let (filters, joins) = fold_nested(filters);
@@ -148,13 +140,7 @@ fn fold_nested(nested: Vec<(Document, Vec<JoinStage>)>) -> (Vec<Document>, Vec<J
     })
 }
 
-fn scalar_filter(
-    filter: ScalarFilter,
-    invert: bool,
-    include_field_wrapper: bool,
-    is_having_filter: bool,
-    prefix: FilterPrefix,
-) -> crate::Result<MongoFilter> {
+fn scalar_filter(filter: ScalarFilter, invert: bool, prefix: FilterPrefix) -> crate::Result<MongoFilter> {
     let field = match filter.projection {
         connector_interface::ScalarProjection::Single(sf) => sf,
         connector_interface::ScalarProjection::Compound(mut c) if c.len() == 1 => c.pop().unwrap(),
@@ -166,43 +152,43 @@ fn scalar_filter(
     };
 
     let filter = match filter.mode {
-        QueryMode::Default => default_scalar_filter(&field, filter.condition.invert(invert))?,
-        QueryMode::Insensitive => insensitive_scalar_filter(&field, filter.condition.invert(invert))?,
+        QueryMode::Default => default_scalar_filter(&field, prefix, filter.condition.invert(invert))?,
+        QueryMode::Insensitive => insensitive_scalar_filter(&field, prefix, filter.condition.invert(invert))?,
     };
 
-    // Explanation: Having filters can only appear in group by queries.
-    // All group by fields go into the _id key of the result document.
-    // As it is the only point where the flat scalars are contained for the group,
-    // we need to refer to the object.
-    let field_name = match is_having_filter {
-        true => format!("_id.{}", field.db_name()),
-        false => field.db_name().to_string(),
-    };
-
-    let field_name = prefix.render_with(field_name);
-
-    if include_field_wrapper {
-        Ok(MongoFilter::Scalar(doc! { field_name: filter }))
-    } else {
-        Ok(MongoFilter::Scalar(filter))
-    }
+    Ok(MongoFilter::Scalar(filter))
 }
 
 // Note contains / startsWith / endsWith are only applicable to String types in the schema.
-fn default_scalar_filter(field: &ScalarFieldRef, condition: ScalarCondition) -> crate::Result<Document> {
-    Ok(match condition {
-        ScalarCondition::Equals(val) => doc! { "$eq": (field, val).into_bson()? },
-        ScalarCondition::NotEquals(val) => doc! { "$ne": (field, val).into_bson()? },
-        ScalarCondition::Contains(val) => doc! { "$regex": to_regex(field, ".*", val, ".*", false)? },
-        ScalarCondition::NotContains(val) => doc! { "$not": { "$regex": to_regex(field, ".*", val, ".*", false)? }},
-        ScalarCondition::StartsWith(val) => doc! { "$regex": to_regex(field, "^", val, "", false)? },
-        ScalarCondition::NotStartsWith(val) => doc! { "$not": { "$regex": to_regex(field, "^", val, "", false)? }},
-        ScalarCondition::EndsWith(val) => doc! { "$regex": to_regex(field, "", val, "$", false)? },
-        ScalarCondition::NotEndsWith(val) => doc! { "$not": { "$regex": to_regex(field, "", val, "$", false)? }},
-        ScalarCondition::LessThan(val) => doc! { "$lt": (field, val).into_bson()? },
-        ScalarCondition::LessThanOrEquals(val) => doc! { "$lte": (field, val).into_bson()? },
-        ScalarCondition::GreaterThan(val) => doc! { "$gt": (field, val).into_bson()? },
-        ScalarCondition::GreaterThanOrEquals(val) => doc! { "$gte": (field, val).into_bson()? },
+fn default_scalar_filter(
+    field: &ScalarFieldRef,
+    prefix: FilterPrefix,
+    condition: ScalarCondition,
+) -> crate::Result<Document> {
+    let field_name = prefix.render_with(field.db_name().to_owned());
+    let should_include_null = is_equal_condition(&condition);
+
+    let cond = match condition {
+        ScalarCondition::Equals(val) => doc! { "$eq": [coerce_as_null(&field_name), (field, val).into_bson()?] },
+        ScalarCondition::NotEquals(val) => {
+            doc! { "$ne": [&field_name, (field, val).into_bson()?] }
+        }
+        ScalarCondition::Contains(val) => regex_match(&field_name, field, ".*", val, ".*", false)?,
+        ScalarCondition::NotContains(val) => {
+            doc! { "$not": regex_match(&field_name, field, ".*", val, ".*", false)? }
+        }
+        ScalarCondition::StartsWith(val) => regex_match(&field_name, field, "^", val, "", false)?,
+        ScalarCondition::NotStartsWith(val) => {
+            doc! { "$not": regex_match(&field_name, field, "^", val, "", false)? }
+        }
+        ScalarCondition::EndsWith(val) => regex_match(&field_name, field, "", val, "$", false)?,
+        ScalarCondition::NotEndsWith(val) => {
+            doc! { "$not": regex_match(&field_name, field, "", val, "$", false)? }
+        }
+        ScalarCondition::LessThan(val) => doc! { "$lt": [&field_name, (field, val).into_bson()?] },
+        ScalarCondition::LessThanOrEquals(val) => doc! { "$lte": [&field_name, (field, val).into_bson()?] },
+        ScalarCondition::GreaterThan(val) => doc! { "$gt": [&field_name, (field, val).into_bson()?] },
+        ScalarCondition::GreaterThanOrEquals(val) => doc! { "$gte": [&field_name, (field, val).into_bson()?] },
         // Todo: The nested list unpack looks like a bug somewhere.
         //       Likely join code mistakenly repacks a list into a list of PrismaValue somewhere in the core.
         ScalarCondition::In(vals) => match vals.split_first() {
@@ -221,64 +207,105 @@ fn default_scalar_filter(field: &ScalarFieldRef, condition: ScalarCondition) -> 
                     }
                 }
 
-                doc! { "$in": bson_values }
+                doc! { "$in": [&field_name, bson_values] }
             }
-            _ => doc! { "$in": (field, PrismaValue::List(vals)).into_bson()? },
+            _ => doc! { "$in": [&field_name, (field, PrismaValue::List(vals)).into_bson()?] },
         },
         ScalarCondition::NotIn(vals) => {
-            doc! { "$nin": vals.into_iter().map(|val| (field, val).into_bson()).collect::<crate::Result<Vec<_>>>()? }
+            let bson_values = vals
+                .into_iter()
+                .map(|val| (field, val).into_bson())
+                .collect::<crate::Result<Vec<_>>>()?;
+
+            doc! { "$not": { "$in": [&field_name, bson_values] } }
         }
         ScalarCondition::JsonCompare(jc) => match *jc.condition {
             ScalarCondition::Equals(value) => {
                 let bson = (field, value).into_bson()?;
-                doc! { "$eq": bson }
+
+                doc! { "$eq": [&field_name, bson] }
             }
             ScalarCondition::NotEquals(value) => {
                 let bson = (field, value).into_bson()?;
-                doc! { "$ne": bson }
+
+                doc! { "$ne": [&field_name, bson] }
             }
             _ => unimplemented!("Only equality JSON filtering is supported on MongoDB."),
         },
         ScalarCondition::Search(_, _) => unimplemented!("Full-text search is not supported yet on MongoDB"),
         ScalarCondition::NotSearch(_, _) => unimplemented!("Full-text search is not supported yet on MongoDB"),
-    })
+    };
+
+    let cond = if should_include_null {
+        cond
+    } else {
+        doc! { "$and": [cond, { "$ne": [coerce_as_null(&field_name), null] }] }
+    };
+
+    Ok(cond)
 }
 
 /// Insensitive filters are only reachable with TypeIdentifier::String (or UUID, which is string as well for us).
-fn insensitive_scalar_filter(field: &ScalarFieldRef, condition: ScalarCondition) -> crate::Result<Document> {
-    match condition {
-        ScalarCondition::Equals(val) => Ok(doc! { "$regex": to_regex(field, "^", val, "$", true)? }),
-        ScalarCondition::NotEquals(val) => Ok(doc! { "$not": { "$regex": to_regex(field, "^", val, "$", true)? }}),
+fn insensitive_scalar_filter(
+    field: &ScalarFieldRef,
+    prefix: FilterPrefix,
+    condition: ScalarCondition,
+) -> crate::Result<Document> {
+    let field_name = prefix.render_with(field.db_name().to_owned());
 
-        ScalarCondition::Contains(val) => Ok(doc! { "$regex": to_regex(field, ".*", val, ".*", true)? }),
-        ScalarCondition::NotContains(val) => Ok(doc! { "$not": { "$regex": to_regex(field, ".*", val, ".*", true)? }}),
-        ScalarCondition::StartsWith(val) => Ok(doc! { "$regex": to_regex(field, "^", val, "", true)?  }),
-        ScalarCondition::NotStartsWith(val) => Ok(doc! { "$not": { "$regex": to_regex(field, "^", val, "", true)? }}),
-        ScalarCondition::EndsWith(val) => Ok(doc! { "$regex": to_regex(field, "", val, "$", true)? }),
-        ScalarCondition::NotEndsWith(val) => Ok(doc! { "$not": { "$regex": to_regex(field, "", val, "$", true)? }}),
-        ScalarCondition::LessThan(val) => Ok(doc! { "$lt": (field, val).into_bson()? }),
-        ScalarCondition::LessThanOrEquals(val) => Ok(doc! { "$lte": (field, val).into_bson()? }),
-        ScalarCondition::GreaterThan(val) => Ok(doc! { "$gt": (field, val).into_bson()? }),
-        ScalarCondition::GreaterThanOrEquals(val) => Ok(doc! { "$gte": (field, val).into_bson()? }),
+    match condition {
+        ScalarCondition::Equals(val) => regex_match(&field_name, field, "^", val, "$", true),
+        ScalarCondition::NotEquals(val) => Ok(doc! { "$not": regex_match(&field_name, field, "^", val, "$", true)? }),
+
+        ScalarCondition::Contains(val) => regex_match(&field_name, field, ".*", val, ".*", true),
+        ScalarCondition::NotContains(val) => {
+            Ok(doc! { "$not": regex_match(&field_name, field, ".*", val, ".*", true)?})
+        }
+        ScalarCondition::StartsWith(val) => regex_match(&field_name, field, "^", val, "", true),
+        ScalarCondition::NotStartsWith(val) => {
+            Ok(doc! { "$not": regex_match(&field_name, field, "^", val, "", true)? })
+        }
+        ScalarCondition::EndsWith(val) => regex_match(&field_name, field, "", val, "$", true),
+        ScalarCondition::NotEndsWith(val) => Ok(doc! { "$not": regex_match(&field_name, field, "", val, "$", true)? }),
+        ScalarCondition::LessThan(val) => Ok(doc! { "$lt": [&field_name, (field, val).into_bson()?] }),
+        ScalarCondition::LessThanOrEquals(val) => Ok(doc! { "$lte": [&field_name, (field, val).into_bson()?] }),
+        ScalarCondition::GreaterThan(val) => Ok(doc! { "$gt": [&field_name, (field, val).into_bson()?] }),
+        ScalarCondition::GreaterThanOrEquals(val) => Ok(doc! { "$gte": [&field_name, (field, val).into_bson()?] }),
         // Todo: The nested list unpack looks like a bug somewhere.
-        //       Likely join code mistakenly repacks a list into a list of PrismaValue somewhere in the core.
+        // Likely join code mistakenly repacks a list into a list of PrismaValue somewhere in the core.
         ScalarCondition::In(vals) => match vals.split_first() {
             // List is list of lists, we need to flatten.
             Some((PrismaValue::List(_), _)) => {
-                let mut bson_values = Vec::with_capacity(vals.len());
+                let mut matches = Vec::with_capacity(vals.len());
 
                 for pv in vals {
                     if let PrismaValue::List(inner) = pv {
-                        bson_values.extend(to_regex_list(field, "^", inner, "$", true)?)
+                        for val in inner {
+                            matches.push(regex_match(&field_name, field, "^", val, "$", true)?)
+                        }
                     }
                 }
 
-                Ok(doc! { "$in": bson_values })
+                Ok(doc! { "$or": matches })
             }
 
-            _ => Ok(doc! { "$in": to_regex_list(field, "^", vals, "$", true)? }),
+            _ => {
+                let matches = vals
+                    .into_iter()
+                    .map(|val| regex_match(&field_name, field, "^", val, "$", true))
+                    .collect::<crate::Result<Vec<_>>>()?;
+
+                Ok(doc! { "$or": matches })
+            }
         },
-        ScalarCondition::NotIn(vals) => Ok(doc! { "$nin": to_regex_list(field, "^", vals, "$", true)? }),
+        ScalarCondition::NotIn(vals) => {
+            let matches = vals
+                .into_iter()
+                .map(|val| regex_match(&field_name, field, "^", val, "$", true).map(|doc| doc! { "$not": doc }))
+                .collect::<crate::Result<Vec<_>>>()?;
+
+            Ok(doc! { "$and": matches })
+        }
         ScalarCondition::JsonCompare(_) => Err(MongoError::Unsupported(
             "JSON filtering is not yet supported on MongoDB".to_string(),
         )),
@@ -291,64 +318,104 @@ fn insensitive_scalar_filter(field: &ScalarFieldRef, condition: ScalarCondition)
 /// Filters available on list fields.
 fn scalar_list_filter(filter: ScalarListFilter, invert: bool, prefix: FilterPrefix) -> crate::Result<MongoFilter> {
     let field = filter.field;
-    let prefixed = prefix.render_with(field.db_name().into());
+    let field_name = prefix.render_with(field.db_name().into());
 
     // Of course Mongo needs special filters for the inverted case, everything else would be too easy.
     let filter_doc = if invert {
         match filter.condition {
             // "Contains element" -> "Does not contain element"
             connector_interface::ScalarListCondition::Contains(val) => {
-                doc! { prefixed: { "$elemMatch": { "$not": { "$eq": (&field, val).into_bson()? }}}}
+                doc! { "$not": { "$in": [(&field, val).into_bson()?, field_name] } }
             }
 
             // "Contains all elements" -> "Does not contain any of the elements"
             connector_interface::ScalarListCondition::ContainsEvery(vals) => {
-                doc! { prefixed: { "$nin": (&field, PrismaValue::List(vals)).into_bson()? }}
+                let ins = vals
+                    .into_iter()
+                    .map(|val| {
+                        (&field, val)
+                            .into_bson()
+                            .map(|bson_val| doc! { "$not": { "$in": [bson_val, coerce_as_array(&field_name)] } })
+                    })
+                    .collect::<crate::Result<Vec<_>>>()?;
+
+                doc! {
+                    "$and": ins
+                }
             }
 
             // "Contains some of the elements" -> "Does not contain some of the elements"
             connector_interface::ScalarListCondition::ContainsSome(vals) => {
-                doc! { prefixed: { "$elemMatch": { "$not": { "$in": (&field, PrismaValue::List(vals)).into_bson()? }}}}
+                let ins = vals
+                    .into_iter()
+                    .map(|val| {
+                        (&field, val)
+                            .into_bson()
+                            .map(|bson_val| doc! { "$not": { "$in": [bson_val, coerce_as_array(&field_name)] } })
+                    })
+                    .collect::<crate::Result<Vec<_>>>()?;
+
+                doc! {
+                    "$or": ins
+                }
             }
 
             // Empty -> not empty and vice versa
-            connector_interface::ScalarListCondition::IsEmpty(check_for_empty) => {
-                if check_for_empty && !invert {
-                    doc! { prefixed: { "$size": 0 }}
+            connector_interface::ScalarListCondition::IsEmpty(should_be_empty) => {
+                if should_be_empty && !invert {
+                    doc! { "$eq": [render_size(&field_name, true), 0] }
                 } else {
-                    doc! { prefixed: { "$not": { "$size": 0 }}}
+                    doc! { "$gt": [render_size(&field_name, true), 0] }
                 }
             }
         }
     } else {
         match filter.condition {
             connector_interface::ScalarListCondition::Contains(val) => {
-                doc! { prefixed: (&field, val).into_bson()? }
+                doc! { "$in": [(&field, val).into_bson()?, field_name] }
             }
 
             connector_interface::ScalarListCondition::ContainsEvery(vals) if vals.is_empty() => {
                 // Empty hasEvery: Return all records.
-                doc! { "_id": { "$exists": 1 }}
+                render_stub_condition(true)
             }
 
             connector_interface::ScalarListCondition::ContainsEvery(vals) => {
-                doc! { prefixed: { "$all": (&field, PrismaValue::List(vals)).into_bson()? }}
+                let ins = vals
+                    .into_iter()
+                    .map(|val| {
+                        (&field, val)
+                            .into_bson()
+                            .map(|bson_val| doc! { "$in": [bson_val, coerce_as_array(&field_name)] })
+                    })
+                    .collect::<crate::Result<Vec<_>>>()?;
+
+                doc! { "$and": ins }
             }
 
             connector_interface::ScalarListCondition::ContainsSome(vals) if vals.is_empty() => {
                 // Empty hasSome: Return no records.
-                doc! { "_id": { "$exists": 0 }}
+                render_stub_condition(false)
             }
 
             connector_interface::ScalarListCondition::ContainsSome(vals) => {
-                doc! { "$or": vals.into_iter().map(|val| Ok(doc! { prefixed.clone(): (&field, val).into_bson()? }) ).collect::<crate::Result<Vec<_>>>()?}
+                let ins = vals
+                    .into_iter()
+                    .map(|val| {
+                        (&field, val)
+                            .into_bson()
+                            .map(|bson_val| doc! { "$in": [bson_val, coerce_as_array(&field_name)] })
+                    })
+                    .collect::<crate::Result<Vec<_>>>()?;
+
+                doc! { "$or": ins }
             }
 
-            connector_interface::ScalarListCondition::IsEmpty(empty) => {
-                if empty {
-                    doc! { prefixed: { "$size": 0 }}
+            connector_interface::ScalarListCondition::IsEmpty(should_be_empty) => {
+                if should_be_empty {
+                    doc! { "$eq": [render_size(&field_name, true), 0] }
                 } else {
-                    doc! { prefixed: { "$not": { "$size": 0 }}}
+                    doc! { "$gt": [render_size(&field_name, true), 0] }
                 }
             }
         }
@@ -358,15 +425,15 @@ fn scalar_list_filter(filter: ScalarListFilter, invert: bool, prefix: FilterPref
 }
 
 // Can be optimized by checking inlined fields on the left side instead of always joining.
-fn one_is_null(filter: OneRelationIsNullFilter, invert: bool) -> MongoFilter {
+fn one_is_null(filter: OneRelationIsNullFilter, invert: bool, prefix: FilterPrefix) -> MongoFilter {
     let rf = filter.field;
-    let relation_name = &rf.relation().name;
+    let field_name = prefix.render_with(rf.relation().name.to_owned());
     let join_stage = JoinStage::new(rf);
 
     let filter_doc = if invert {
-        doc! { relation_name: { "$not": { "$size": 0 }}}
+        doc! { "$gt": [render_size(&field_name, false), 0] }
     } else {
-        doc! { relation_name: { "$size": 0 }}
+        doc! { "$eq": [render_size(&field_name, false), 0] }
     };
 
     MongoFilter::relation(filter_doc, vec![join_stage])
@@ -376,194 +443,336 @@ fn one_is_null(filter: OneRelationIsNullFilter, invert: bool) -> MongoFilter {
 fn relation_filter(filter: RelationFilter, invert: bool, prefix: FilterPrefix) -> crate::Result<MongoFilter> {
     let from_field = filter.field;
     let relation_name = &from_field.relation().name;
+    let field_name = prefix.clone().render_with(relation_name.to_owned());
     let nested_filter = *filter.nested_filter;
-
     // Tmp condition check while mongo is getting fully tested.
-    let is_empty = matches!(nested_filter, Filter::Empty);
-
-    // EveryRelatedRecord requires an inherent invert for Mongo.
-    let (nested_filter, nested_joins) = convert_filter(
-        nested_filter,
-        matches!(&filter.condition, RelationCondition::EveryRelatedRecord),
-        false,
-        prefix,
-    )?
-    .render();
+    let is_empty_filter = matches!(nested_filter, Filter::Empty);
 
     let mut join_stage = JoinStage::new(from_field);
-    join_stage.extend_nested(nested_joins);
 
     let filter_doc = match filter.condition {
         connector_interface::RelationCondition::EveryRelatedRecord => {
-            if is_empty {
-                doc! { "$not": { "$all": [{ "$elemMatch": { "_id": { "$exists": 0 }} }] }}
-            } else {
-                doc! { "$not": { "$all": [{ "$elemMatch": nested_filter }] }}
-            }
+            let (every, nested_joins) = render_every(&field_name, nested_filter, false)?;
+
+            join_stage.extend_nested(nested_joins);
+
+            every
         }
         connector_interface::RelationCondition::AtLeastOneRelatedRecord => {
-            doc! { "$elemMatch": nested_filter }
+            let (some, nested_joins) = render_some(&field_name, nested_filter, false)?;
+
+            join_stage.extend_nested(nested_joins);
+
+            some
         }
         connector_interface::RelationCondition::NoRelatedRecord => {
-            if is_empty {
-                doc! { "$size": 0 }
+            if is_empty_filter {
+                // Doesn't need coercing the array since joins always returns arrays
+                doc! { "$eq": [render_size(&field_name, false), 0] }
             } else {
-                doc! { "$not": { "$all": [{ "$elemMatch": nested_filter }] }}
+                let (none, nested_joins) = render_none(&field_name, nested_filter, false)?;
+
+                join_stage.extend_nested(nested_joins);
+
+                none
             }
         }
         connector_interface::RelationCondition::ToOneRelatedRecord => {
-            doc! { "$all": [{ "$elemMatch": nested_filter }]}
+            // To-ones are coerced to single-element arrays via the join.
+            // We render an "every" expression on that array to ensure that the predicate is matched.
+            let (every, nested_joins) = render_every(&field_name, nested_filter, false)?;
+
+            join_stage.extend_nested(nested_joins);
+
+            doc! {
+                "$and": [
+                    every,
+                    // Additionally, we ensure that the array has a single element.
+                    // It doesn't need to be coerced to an empty array since the join guarantees it will exist
+                    { "$eq": [render_size(&field_name, false), 1] }
+                ]
+            }
         }
     };
 
     if invert {
-        Ok(MongoFilter::relation(
-            doc! { relation_name: { "$not": filter_doc }},
-            vec![join_stage],
-        ))
+        Ok(MongoFilter::relation(doc! { "$not": filter_doc }, vec![join_stage]))
     } else {
-        Ok(MongoFilter::relation(
-            doc! { relation_name: filter_doc },
-            vec![join_stage],
-        ))
+        Ok(MongoFilter::relation(filter_doc, vec![join_stage]))
     }
 }
 
-fn aggregation_filter(filter: AggregationFilter, invert: bool, prefix: FilterPrefix) -> crate::Result<MongoFilter> {
+fn aggregation_filter(filter: AggregationFilter, invert: bool) -> crate::Result<MongoFilter> {
     match filter {
-        AggregationFilter::Count(filter) => aggregate_conditions("count", *filter, invert, prefix),
-        AggregationFilter::Average(filter) => aggregate_conditions("avg", *filter, invert, prefix),
-        AggregationFilter::Sum(filter) => aggregate_conditions("sum", *filter, invert, prefix),
-        AggregationFilter::Min(filter) => aggregate_conditions("min", *filter, invert, prefix),
-        AggregationFilter::Max(filter) => aggregate_conditions("max", *filter, invert, prefix),
+        AggregationFilter::Count(filter) => aggregate_conditions("count", *filter, invert),
+        AggregationFilter::Average(filter) => aggregate_conditions("avg", *filter, invert),
+        AggregationFilter::Sum(filter) => aggregate_conditions("sum", *filter, invert),
+        AggregationFilter::Min(filter) => aggregate_conditions("min", *filter, invert),
+        AggregationFilter::Max(filter) => aggregate_conditions("max", *filter, invert),
     }
 }
 
-fn aggregate_conditions(op: &str, filter: Filter, invert: bool, prefix: FilterPrefix) -> crate::Result<MongoFilter> {
+fn aggregate_conditions(op: &str, filter: Filter, invert: bool) -> crate::Result<MongoFilter> {
     let sf = match filter {
         Filter::Scalar(sf) => sf,
         _ => unimplemented!(),
     };
 
     let field = match &sf.projection {
-        ScalarProjection::Compound(_) => {
-            unimplemented!("Compound aggregate projections are unsupported.")
-        }
-
-        ScalarProjection::Single(field) => field.clone(),
+        ScalarProjection::Single(field) => field,
+        _ => unreachable!(),
     };
 
-    let (filter, _) = scalar_filter(sf, invert, false, false, prefix)?.render();
+    let mut prefix = FilterPrefix::from(format!("{}_{}", op, field.db_name()));
+    // An aggregation filter can only refer to its aggregated field, which is already the "target".
+    // Therefore, we make sure the additional target in `scalar_filter` won't be rendered.
+    prefix.ignore_target(true);
 
-    Ok(MongoFilter::Scalar(
-        doc! { format!("{}_{}", op, field.db_name()): filter },
-    ))
-}
+    let (filter, _) = scalar_filter(sf, invert, prefix)?.render();
 
-fn to_regex_list(
-    field: &ScalarFieldRef,
-    prefix: &str,
-    vals: Vec<PrismaValue>,
-    suffix: &str,
-    insensitive: bool,
-) -> crate::Result<Vec<Bson>> {
-    vals.into_iter()
-        .map(|val| to_regex(field, prefix, val, suffix, insensitive))
-        .collect::<crate::Result<Vec<_>>>()
-}
-
-fn to_regex(
-    field: &ScalarFieldRef,
-    prefix: &str,
-    val: PrismaValue,
-    suffix: &str,
-    insensitive: bool,
-) -> crate::Result<Bson> {
-    let options = if insensitive { "i" } else { "" }.to_owned();
-
-    Ok(Bson::RegularExpression(Regex {
-        pattern: format!(
-            "{}{}{}",
-            prefix,
-            (field, val)
-                .into_bson()?
-                .as_str()
-                .expect("Only reachable with String types."),
-            suffix
-        ),
-        options,
-    }))
+    Ok(MongoFilter::Scalar(filter))
 }
 
 fn composite_filter(filter: CompositeFilter, invert: bool, prefix: FilterPrefix) -> crate::Result<MongoFilter> {
     let field = filter.field;
+    let composite_name = field.db_name();
+    let field_name = prefix.clone().render_with(composite_name.to_string());
 
     let filter_doc = match *filter.condition {
         CompositeCondition::Every(filter) => {
-            let is_empty = matches!(filter, Filter::Empty);
+            // let is_empty = matches!(filter, Filter::Empty);
+            let (every, _) = render_every(&field_name, filter, true)?;
 
-            // `Every` filter requires inherent invert because of how the filters are implemented on Mongo.
-            let (nested_filter, _) = convert_filter(filter, true, false, FilterPrefix::default())?.render();
-
-            if is_empty {
-                doc! { "$not": { "$all": [{ "$elemMatch": { "__prisma_truthy_marker": { "$exists": 1 }} }] }}
-            } else {
-                doc! { "$not": { "$all": [{ "$elemMatch": nested_filter }] }}
-            }
+            every
         }
 
         CompositeCondition::Some(filter) => {
-            let (nested_filter, _) = convert_filter(filter, false, false, FilterPrefix::default())?.render();
-            doc! { "$elemMatch": nested_filter }
+            let (some, _) = render_some(&field_name, filter, true)?;
+
+            some
         }
 
         CompositeCondition::None(filter) => {
-            let (nested_filter, _) = convert_filter(filter, false, false, FilterPrefix::default())?.render();
+            let (none, _) = render_none(&field_name, filter, true)?;
 
-            doc! { "$not": { "$all": [{ "$elemMatch": nested_filter }] }}
+            none
         }
 
         CompositeCondition::Equals(value) => {
-            doc! { "$eq": (&field, value).into_bson()? }
+            doc! { "$eq": [&field_name, (&field, value).into_bson()?] }
         }
 
         CompositeCondition::Empty(should_be_empty) => {
-            if should_be_empty {
-                doc! { "$size": 0 }
+            let empty_doc = if should_be_empty {
+                doc! { "$eq": [render_size(&field_name, true), 0] }
             } else {
-                doc! { "$not": { "$size": 0 }}
+                doc! { "$gt": [render_size(&field_name, true), 0] }
+            };
+
+            if invert {
+                doc! {
+                    "$or": [
+                        empty_doc,
+                        doc! { "$eq": [coerce_as_null(&field_name), null] }
+                    ]
+                }
+            } else {
+                doc! {
+                    "$and": [
+                        empty_doc,
+                        doc! { "$ne": [coerce_as_null(&field_name), null] }
+                    ]
+                }
             }
         }
 
         CompositeCondition::Is(filter) => {
-            let (nested_filter, _) =
-                convert_filter(filter, invert, false, prefix.append_cloned(field.db_name()))?.render();
+            let (nested_filter, _) = convert_filter(filter, invert, prefix.append_cloned(field.db_name()))?.render();
 
             return Ok(MongoFilter::Composite(nested_filter));
         }
 
         CompositeCondition::IsNot(filter) => {
-            let (nested_filter, _) =
-                convert_filter(filter, !invert, false, prefix.append_cloned(field.db_name()))?.render();
+            let (nested_filter, _) = convert_filter(filter, !invert, prefix.append_cloned(field.db_name()))?.render();
 
             return Ok(MongoFilter::Composite(nested_filter));
         }
     };
 
-    let field_filter_name = prefix.render_with(field.db_name().into());
-
     if invert {
-        Ok(MongoFilter::Composite(
-            doc! { field_filter_name: { "$not": filter_doc }},
-        ))
+        Ok(MongoFilter::Composite(doc! { "$not": filter_doc }))
     } else {
-        Ok(MongoFilter::Composite(doc! { field_filter_name: filter_doc }))
+        Ok(MongoFilter::Composite(filter_doc))
     }
 }
 
-#[derive(Clone, Default)]
+/// Renders a `$regexMatch` expression
+fn regex_match(
+    field_name: &str,
+    field: &ScalarFieldRef,
+    prefix: &str,
+    val: PrismaValue,
+    suffix: &str,
+    insensitive: bool,
+) -> crate::Result<Document> {
+    let options = if insensitive { "i" } else { "" }.to_owned();
+    let pattern = format!(
+        "{}{}{}",
+        prefix,
+        (field, val)
+            .into_bson()?
+            .as_str()
+            .expect("Only reachable with String types."),
+        suffix
+    );
+
+    Ok(doc! {
+        "$regexMatch": {
+            "input": field_name,
+            "regex": pattern,
+            "options": options
+        }
+    })
+}
+
+/// Renders a `$size` expression to compute the length of an array.
+/// If `coerce_array` is true, the array will be coerced to an empty array in case it's `null` or `undefined`.
+fn render_size(field_name: &str, coerce_array: bool) -> Document {
+    if coerce_array {
+        doc! { "$size": coerce_as_array(field_name) }
+    } else {
+        doc! { "$size": field_name }
+    }
+}
+
+/// Coerces a field to an empty array if it's `null` or `undefined`.
+/// Renders an `$ifNull` expression.
+fn coerce_as_array(field_name: &str) -> Document {
+    doc! { "$ifNull": [field_name, []] }
+}
+
+/// Coerces a field to `null` if it's `null` or `undefined`.
+/// Used to convert `undefined` fields to `null`.
+/// Renders an `$ifNull` expression.
+fn coerce_as_null(field_name: &str) -> Document {
+    doc! { "$ifNull": [field_name, null] }
+}
+
+/// Renders an expression that computes whether _some_ of the elements of an array matches the `Filter`.
+/// If `coerce_array` is true, the array will be coerced to an empty array in case it's `null` or `undefined`.
+fn render_some(field_name: &str, filter: Filter, coerce_array: bool) -> crate::Result<(Document, Vec<JoinStage>)> {
+    let input = if coerce_array {
+        Bson::from(coerce_as_array(field_name))
+    } else {
+        Bson::from(field_name)
+    };
+
+    // Nested filters needs to be prefixed with `$$elem` so that they refer to the "elem" alias defined in the $filter operator below.
+    let prefix = FilterPrefix::from("$elem");
+    let (nested_filter, nested_joins) = convert_filter(filter, false, prefix)?.render();
+
+    let doc = doc! {
+      "$gt": [
+        {
+          "$size": {
+            "$filter": {
+              "input": input,
+              "as": "elem",
+              "cond": nested_filter
+            }
+          }
+        },
+        0
+      ]
+    };
+
+    Ok((doc, nested_joins))
+}
+
+/// Renders an expression that computes whether _all_ of the elements of an array matches the `Filter`.
+/// If `coerce_array` is true, the array will be coerced to an empty array in case it's `null` or `undefined`.
+fn render_every(field_name: &str, filter: Filter, coerce_array: bool) -> crate::Result<(Document, Vec<JoinStage>)> {
+    let input = if coerce_array {
+        Bson::from(coerce_as_array(field_name))
+    } else {
+        Bson::from(field_name)
+    };
+
+    // Nested filters needs to be prefixed with `$$elem` so that they refer to the "elem" alias defined in the $filter operator below.
+    let prefix = FilterPrefix::from("$elem");
+    let (nested_filter, nested_joins) = convert_filter(filter, false, prefix)?.render();
+
+    let doc = doc! {
+      "$eq": [
+        {
+          "$size": {
+            "$filter": {
+              "input": input,
+              "as": "elem",
+              "cond": nested_filter,
+            }
+          }
+        },
+        render_size(field_name, true)
+      ]
+    };
+
+    Ok((doc, nested_joins))
+}
+
+/// Renders an expression that computes whether _none_ of the elements of an array matches the `Filter`.
+/// If `coerce_array` is true, the array will be coerced to an empty array in case it's `null` or `undefined`.
+fn render_none(field_name: &str, filter: Filter, coerce_array: bool) -> crate::Result<(Document, Vec<JoinStage>)> {
+    let input = if coerce_array {
+        Bson::from(coerce_as_array(field_name))
+    } else {
+        Bson::from(field_name)
+    };
+
+    // Nested filters needs to be prefixed with `$$elem` so that they refer to the "elem" alias defined in the $filter operator below.
+    let prefix = FilterPrefix::from("$elem");
+    let (nested_filter, nested_joins) = convert_filter(filter, false, prefix)?.render();
+
+    let doc = doc! {
+      "$eq": [
+        {
+          "$size": {
+            "$filter": {
+              "input": input,
+              "as": "elem",
+              "cond": nested_filter
+            }
+          }
+        },
+        0
+      ]
+    };
+
+    Ok((doc, nested_joins))
+}
+
+/// Renders a stub condition that's either true or false
+fn render_stub_condition(truthy: bool) -> Document {
+    doc! { "$and": truthy }
+}
+
+/// Checks whether a scalar condition is an `Equals`
+fn is_equal_condition(condition: &ScalarCondition) -> bool {
+    let is_equal = matches!(condition, ScalarCondition::Equals(_));
+
+    let is_json_equal = match condition {
+        ScalarCondition::JsonCompare(json_cond) => matches!(*json_cond.condition, ScalarCondition::Equals(_)),
+        _ => false,
+    };
+
+    is_equal || is_json_equal
+}
+
+#[derive(Debug, Clone, Default)]
 pub(crate) struct FilterPrefix {
     parts: Vec<String>,
+    /// Whether the `target` should be rendered by the `render_with` method
+    ignore_target: bool,
 }
 
 impl FilterPrefix {
@@ -582,11 +791,20 @@ impl FilterPrefix {
     }
 
     pub fn render_with(self, target: String) -> String {
-        if self.parts.is_empty() {
-            target
-        } else {
-            format!("{}.{}", self.render(), target)
+        if self.ignore_target {
+            return format!("${}", self.render());
         }
+
+        if self.parts.is_empty() {
+            format!("${}", target)
+        } else {
+            format!("${}.{}", self.render(), target)
+        }
+    }
+
+    /// Sets whether the target should be rendered by the `render_with` method
+    pub fn ignore_target(&mut self, ignore_target: bool) {
+        self.ignore_target = ignore_target;
     }
 }
 
@@ -594,12 +812,25 @@ impl From<&CompositeFieldRef> for FilterPrefix {
     fn from(cf: &CompositeFieldRef) -> Self {
         Self {
             parts: vec![cf.db_name().to_owned()],
+            ignore_target: false,
         }
     }
 }
 
 impl From<String> for FilterPrefix {
     fn from(alias: String) -> Self {
-        Self { parts: vec![alias] }
+        Self {
+            parts: vec![alias],
+            ignore_target: false,
+        }
+    }
+}
+
+impl From<&str> for FilterPrefix {
+    fn from(alias: &str) -> Self {
+        Self {
+            parts: vec![alias.to_owned()],
+            ignore_target: false,
+        }
     }
 }

--- a/query-engine/connectors/mongodb-query-connector/src/filter.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/filter.rs
@@ -443,7 +443,7 @@ fn one_is_null(filter: OneRelationIsNullFilter, invert: bool, prefix: FilterPref
 fn relation_filter(filter: RelationFilter, invert: bool, prefix: FilterPrefix) -> crate::Result<MongoFilter> {
     let from_field = filter.field;
     let relation_name = &from_field.relation().name;
-    let field_name = prefix.clone().render_with(relation_name.to_owned());
+    let field_name = prefix.render_with(relation_name.to_owned());
     let nested_filter = *filter.nested_filter;
     // Tmp condition check while mongo is getting fully tested.
     let is_empty_filter = matches!(nested_filter, Filter::Empty);

--- a/query-engine/connectors/mongodb-query-connector/src/filter.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/filter.rs
@@ -42,26 +42,43 @@ pub(crate) fn convert_filter(
     invert: bool,
     prefix: impl Into<FilterPrefix>,
 ) -> crate::Result<MongoFilter> {
+    convert_filter_internal(filter, invert, false, prefix)
+}
+
+fn convert_filter_internal(
+    filter: Filter,
+    invert: bool,
+    invert_undefined_exclusion: bool,
+    prefix: impl Into<FilterPrefix>,
+) -> crate::Result<MongoFilter> {
+    dbg!(&filter);
+
     let prefix = prefix.into();
     let filter = fold_compounds(filter);
 
     let filter_pair = match filter {
-        Filter::And(filters) if invert => coerce_empty(false, "$or", filters, invert, prefix)?,
-        Filter::And(filters) => coerce_empty(true, "$and", filters, invert, prefix)?,
+        Filter::And(filters) if invert => {
+            coerce_empty(false, "$or", filters, invert, invert_undefined_exclusion, prefix)?
+        }
+        Filter::And(filters) => coerce_empty(true, "$and", filters, invert, invert_undefined_exclusion, prefix)?,
 
-        Filter::Or(filters) if invert => coerce_empty(true, "$and", filters, invert, prefix)?,
-        Filter::Or(filters) => coerce_empty(false, "$or", filters, invert, prefix)?,
+        Filter::Or(filters) if invert => {
+            coerce_empty(true, "$and", filters, invert, invert_undefined_exclusion, prefix)?
+        }
+        Filter::Or(filters) => coerce_empty(false, "$or", filters, invert, invert_undefined_exclusion, prefix)?,
 
-        Filter::Not(filters) if invert => coerce_empty(false, "$or", filters, !invert, prefix)?,
-        Filter::Not(filters) => coerce_empty(true, "$and", filters, !invert, prefix)?,
+        Filter::Not(filters) if invert => {
+            coerce_empty(false, "$or", filters, !invert, invert_undefined_exclusion, prefix)?
+        }
+        Filter::Not(filters) => coerce_empty(true, "$and", filters, !invert, invert_undefined_exclusion, prefix)?,
 
-        Filter::Scalar(sf) => scalar_filter(sf, invert, prefix)?,
+        Filter::Scalar(sf) => scalar_filter(sf, invert, invert_undefined_exclusion, prefix)?,
         Filter::Empty => MongoFilter::Scalar(doc! {}),
-        Filter::ScalarList(slf) => scalar_list_filter(slf, invert, prefix)?,
+        Filter::ScalarList(slf) => scalar_list_filter(slf, invert, invert_undefined_exclusion, prefix)?,
         Filter::OneRelationIsNull(filter) => one_is_null(filter, invert, prefix),
-        Filter::Relation(rfilter) => relation_filter(rfilter, invert, prefix)?,
-        Filter::Aggregation(filter) => aggregation_filter(filter, invert)?,
-        Filter::Composite(filter) => composite_filter(filter, invert, prefix)?,
+        Filter::Relation(rfilter) => relation_filter(rfilter.invert(invert), prefix)?,
+        Filter::Aggregation(filter) => aggregation_filter(filter, invert, invert_undefined_exclusion)?,
+        Filter::Composite(filter) => composite_filter(filter, invert, invert_undefined_exclusion, prefix)?,
         Filter::BoolFilter(_) => unimplemented!("MongoDB boolean filter."),
     };
 
@@ -100,6 +117,7 @@ fn coerce_empty(
     operation: &str,
     filters: Vec<Filter>,
     invert: bool,
+    invert_undefined_exclusion: bool,
     prefix: FilterPrefix,
 ) -> crate::Result<MongoFilter> {
     if filters.is_empty() {
@@ -110,7 +128,7 @@ fn coerce_empty(
 
         Ok(MongoFilter::Scalar(stub_condition))
     } else {
-        fold_filters(operation, filters, invert, prefix)
+        fold_filters(operation, filters, invert, invert_undefined_exclusion, prefix)
     }
 }
 
@@ -118,11 +136,12 @@ fn fold_filters(
     operation: &str,
     filters: Vec<Filter>,
     invert: bool,
+    invert_undefined_exclusion: bool,
     prefix: FilterPrefix,
 ) -> crate::Result<MongoFilter> {
     let filters = filters
         .into_iter()
-        .map(|f| Ok(convert_filter(f, invert, prefix.clone())?.render()))
+        .map(|f| Ok(convert_filter_internal(f, invert, invert_undefined_exclusion, prefix.clone())?.render()))
         .collect::<crate::Result<Vec<_>>>()?;
 
     let (filters, joins) = fold_nested(filters);
@@ -140,7 +159,12 @@ fn fold_nested(nested: Vec<(Document, Vec<JoinStage>)>) -> (Vec<Document>, Vec<J
     })
 }
 
-fn scalar_filter(filter: ScalarFilter, invert: bool, prefix: FilterPrefix) -> crate::Result<MongoFilter> {
+fn scalar_filter(
+    filter: ScalarFilter,
+    invert: bool,
+    invert_undefined_exclusion: bool,
+    prefix: FilterPrefix,
+) -> crate::Result<MongoFilter> {
     let field = match filter.projection {
         connector_interface::ScalarProjection::Single(sf) => sf,
         connector_interface::ScalarProjection::Compound(mut c) if c.len() == 1 => c.pop().unwrap(),
@@ -152,7 +176,12 @@ fn scalar_filter(filter: ScalarFilter, invert: bool, prefix: FilterPrefix) -> cr
     };
 
     let filter = match filter.mode {
-        QueryMode::Default => default_scalar_filter(&field, prefix, filter.condition.invert(invert))?,
+        QueryMode::Default => default_scalar_filter(
+            &field,
+            prefix,
+            filter.condition.invert(invert),
+            invert_undefined_exclusion,
+        )?,
         QueryMode::Insensitive => insensitive_scalar_filter(&field, prefix, filter.condition.invert(invert))?,
     };
 
@@ -164,12 +193,13 @@ fn default_scalar_filter(
     field: &ScalarFieldRef,
     prefix: FilterPrefix,
     condition: ScalarCondition,
+    invert_undefined_exclusion: bool,
 ) -> crate::Result<Document> {
     let field_name = prefix.render_with(field.db_name().to_owned());
-    let should_include_null = is_equal_condition(&condition);
+    let is_set_cond = matches!(&condition, ScalarCondition::IsSet(_));
 
-    let cond = match condition {
-        ScalarCondition::Equals(val) => doc! { "$eq": [coerce_as_null(&field_name), (field, val).into_bson()?] },
+    let filter_doc = match condition {
+        ScalarCondition::Equals(val) => doc! { "$eq": [&field_name, (field, val).into_bson()?] },
         ScalarCondition::NotEquals(val) => {
             doc! { "$ne": [&field_name, (field, val).into_bson()?] }
         }
@@ -232,14 +262,15 @@ fn default_scalar_filter(
             }
             _ => unimplemented!("Only equality JSON filtering is supported on MongoDB."),
         },
+        ScalarCondition::IsSet(is_set) => render_is_set(&field_name, is_set),
         ScalarCondition::Search(_, _) => unimplemented!("Full-text search is not supported yet on MongoDB"),
         ScalarCondition::NotSearch(_, _) => unimplemented!("Full-text search is not supported yet on MongoDB"),
     };
 
-    let cond = if should_include_null {
-        cond
+    let cond = if !is_set_cond {
+        exclude_undefineds(&field_name, invert_undefined_exclusion, filter_doc)
     } else {
-        doc! { "$and": [cond, { "$ne": [coerce_as_null(&field_name), null] }] }
+        filter_doc
     };
 
     Ok(cond)
@@ -306,6 +337,7 @@ fn insensitive_scalar_filter(
 
             Ok(doc! { "$and": matches })
         }
+        ScalarCondition::IsSet(is_set) => Ok(render_is_set(&field_name, is_set)),
         ScalarCondition::JsonCompare(_) => Err(MongoError::Unsupported(
             "JSON filtering is not yet supported on MongoDB".to_string(),
         )),
@@ -316,7 +348,12 @@ fn insensitive_scalar_filter(
 }
 
 /// Filters available on list fields.
-fn scalar_list_filter(filter: ScalarListFilter, invert: bool, prefix: FilterPrefix) -> crate::Result<MongoFilter> {
+fn scalar_list_filter(
+    filter: ScalarListFilter,
+    invert: bool,
+    invert_undefined_exclusion: bool,
+    prefix: FilterPrefix,
+) -> crate::Result<MongoFilter> {
     let field = filter.field;
     let field_name = prefix.render_with(field.db_name().into());
 
@@ -421,13 +458,7 @@ fn scalar_list_filter(filter: ScalarListFilter, invert: bool, prefix: FilterPref
         }
     };
 
-    let filter_doc = doc! {
-        "$and": [
-            filter_doc,
-            // Always ignore undefined scalar lists
-            { "$ne": [coerce_as_null(&field_name), null] }
-        ]
-    };
+    let filter_doc = exclude_undefineds(&field_name, invert_undefined_exclusion, filter_doc);
 
     Ok(MongoFilter::Scalar(filter_doc))
 }
@@ -448,11 +479,11 @@ fn one_is_null(filter: OneRelationIsNullFilter, invert: bool, prefix: FilterPref
 }
 
 /// Builds a Mongo relation filter depth-first.
-fn relation_filter(filter: RelationFilter, invert: bool, prefix: FilterPrefix) -> crate::Result<MongoFilter> {
+fn relation_filter(filter: RelationFilter, prefix: FilterPrefix) -> crate::Result<MongoFilter> {
     let from_field = filter.field;
-    let relation_name = &from_field.relation().name;
-    let field_name = prefix.render_with(relation_name.to_owned());
     let nested_filter = *filter.nested_filter;
+    let is_to_one = !from_field.is_list();
+    let field_name = prefix.render_with(from_field.relation().name.to_owned());
     // Tmp condition check while mongo is getting fully tested.
     let is_empty_filter = matches!(nested_filter, Filter::Empty);
 
@@ -460,25 +491,46 @@ fn relation_filter(filter: RelationFilter, invert: bool, prefix: FilterPrefix) -
 
     let filter_doc = match filter.condition {
         connector_interface::RelationCondition::EveryRelatedRecord => {
-            let (every, nested_joins) = render_every(&field_name, nested_filter, false)?;
+            let (every, nested_joins) = render_every(&field_name, nested_filter, false, false)?;
 
             join_stage.extend_nested(nested_joins);
 
             every
         }
         connector_interface::RelationCondition::AtLeastOneRelatedRecord => {
-            let (some, nested_joins) = render_some(&field_name, nested_filter, false)?;
+            let (some, nested_joins) = render_some(&field_name, nested_filter, false, false)?;
 
             join_stage.extend_nested(nested_joins);
 
             some
         }
-        connector_interface::RelationCondition::NoRelatedRecord => {
+        connector_interface::RelationCondition::NoRelatedRecord if is_to_one => {
             if is_empty_filter {
-                // Doesn't need coercing the array since joins always returns arrays
+                // Doesn't need coercing the array since joins always return arrays
                 doc! { "$eq": [render_size(&field_name, false), 0] }
             } else {
-                let (none, nested_joins) = render_none(&field_name, nested_filter, false)?;
+                let (none, nested_joins) = render_none(&field_name, nested_filter, true, false)?;
+
+                join_stage.extend_nested(nested_joins);
+
+                // If the relation is a to-one, ensure the array is of size 1
+                // This filters out undefined to-one relations
+                doc! {
+                    "$and": [
+                        none,
+                        // Additionally, we ensure that the array has a single element.
+                        // It doesn't need to be coerced to an empty array since the join guarantees it will exist
+                        { "$eq": [render_size(&field_name, false), 1] }
+                    ]
+                }
+            }
+        }
+        connector_interface::RelationCondition::NoRelatedRecord => {
+            if is_empty_filter {
+                // Doesn't need coercing the array since joins always return arrays
+                doc! { "$eq": [render_size(&field_name, false), 0] }
+            } else {
+                let (none, nested_joins) = render_none(&field_name, nested_filter, true, false)?;
 
                 join_stage.extend_nested(nested_joins);
 
@@ -488,7 +540,7 @@ fn relation_filter(filter: RelationFilter, invert: bool, prefix: FilterPrefix) -
         connector_interface::RelationCondition::ToOneRelatedRecord => {
             // To-ones are coerced to single-element arrays via the join.
             // We render an "every" expression on that array to ensure that the predicate is matched.
-            let (every, nested_joins) = render_every(&field_name, nested_filter, false)?;
+            let (every, nested_joins) = render_every(&field_name, nested_filter, false, false)?;
 
             join_stage.extend_nested(nested_joins);
 
@@ -503,24 +555,29 @@ fn relation_filter(filter: RelationFilter, invert: bool, prefix: FilterPrefix) -
         }
     };
 
-    if invert {
-        Ok(MongoFilter::relation(doc! { "$not": filter_doc }, vec![join_stage]))
-    } else {
-        Ok(MongoFilter::relation(filter_doc, vec![join_stage]))
-    }
+    Ok(MongoFilter::relation(filter_doc, vec![join_stage]))
 }
 
-fn aggregation_filter(filter: AggregationFilter, invert: bool) -> crate::Result<MongoFilter> {
+fn aggregation_filter(
+    filter: AggregationFilter,
+    invert: bool,
+    invert_undefined_exclusion: bool,
+) -> crate::Result<MongoFilter> {
     match filter {
-        AggregationFilter::Count(filter) => aggregate_conditions("count", *filter, invert),
-        AggregationFilter::Average(filter) => aggregate_conditions("avg", *filter, invert),
-        AggregationFilter::Sum(filter) => aggregate_conditions("sum", *filter, invert),
-        AggregationFilter::Min(filter) => aggregate_conditions("min", *filter, invert),
-        AggregationFilter::Max(filter) => aggregate_conditions("max", *filter, invert),
+        AggregationFilter::Count(filter) => aggregate_conditions("count", *filter, invert, invert_undefined_exclusion),
+        AggregationFilter::Average(filter) => aggregate_conditions("avg", *filter, invert, invert_undefined_exclusion),
+        AggregationFilter::Sum(filter) => aggregate_conditions("sum", *filter, invert, invert_undefined_exclusion),
+        AggregationFilter::Min(filter) => aggregate_conditions("min", *filter, invert, invert_undefined_exclusion),
+        AggregationFilter::Max(filter) => aggregate_conditions("max", *filter, invert, invert_undefined_exclusion),
     }
 }
 
-fn aggregate_conditions(op: &str, filter: Filter, invert: bool) -> crate::Result<MongoFilter> {
+fn aggregate_conditions(
+    op: &str,
+    filter: Filter,
+    invert: bool,
+    invert_undefined_exclusion: bool,
+) -> crate::Result<MongoFilter> {
     let sf = match filter {
         Filter::Scalar(sf) => sf,
         _ => unimplemented!(),
@@ -536,32 +593,38 @@ fn aggregate_conditions(op: &str, filter: Filter, invert: bool) -> crate::Result
     // Therefore, we make sure the additional target in `scalar_filter` won't be rendered.
     prefix.ignore_target(true);
 
-    let (filter, _) = scalar_filter(sf, invert, prefix)?.render();
+    let (filter, _) = scalar_filter(sf, invert, invert_undefined_exclusion, prefix)?.render();
 
     Ok(MongoFilter::Scalar(filter))
 }
 
-fn composite_filter(filter: CompositeFilter, invert: bool, prefix: FilterPrefix) -> crate::Result<MongoFilter> {
+fn composite_filter(
+    filter: CompositeFilter,
+    invert: bool,
+    invert_undefined_exclusion: bool,
+    prefix: FilterPrefix,
+) -> crate::Result<MongoFilter> {
     let field = filter.field;
     let composite_name = field.db_name();
     let field_name = prefix.clone().render_with(composite_name.to_string());
+    let is_set_cond = matches!(*filter.condition, CompositeCondition::IsSet(_));
 
     let filter_doc = match *filter.condition {
         CompositeCondition::Every(filter) => {
             // let is_empty = matches!(filter, Filter::Empty);
-            let (every, _) = render_every(&field_name, filter, true)?;
+            let (every, _) = render_every(&field_name, filter, invert_undefined_exclusion, true)?;
 
             every
         }
 
         CompositeCondition::Some(filter) => {
-            let (some, _) = render_some(&field_name, filter, true)?;
+            let (some, _) = render_some(&field_name, filter, invert_undefined_exclusion, true)?;
 
             some
         }
 
         CompositeCondition::None(filter) => {
-            let (none, _) = render_none(&field_name, filter, true)?;
+            let (none, _) = render_none(&field_name, filter, !invert_undefined_exclusion, true)?;
 
             none
         }
@@ -594,27 +657,48 @@ fn composite_filter(filter: CompositeFilter, invert: bool, prefix: FilterPrefix)
             }
         }
 
+        CompositeCondition::IsSet(is_set) => render_is_set(&field_name, is_set),
         CompositeCondition::Is(filter) => {
-            let (nested_filter, _) = convert_filter(filter, invert, prefix.append_cloned(field.db_name()))?.render();
+            let (nested_filter, _) = convert_filter_internal(
+                filter,
+                invert,
+                invert_undefined_exclusion,
+                prefix.append_cloned(field.db_name()),
+            )?
+            .render();
 
             return Ok(MongoFilter::Composite(nested_filter));
         }
 
         CompositeCondition::IsNot(filter) => {
-            let (nested_filter, _) = convert_filter(filter, !invert, prefix.append_cloned(field.db_name()))?.render();
+            let (nested_filter, _) = convert_filter_internal(
+                filter,
+                !invert,
+                invert_undefined_exclusion,
+                prefix.append_cloned(field.db_name()),
+            )?
+            .render();
 
             return Ok(MongoFilter::Composite(nested_filter));
         }
     };
 
-    if invert {
-        Ok(MongoFilter::Composite(doc! { "$not": filter_doc }))
+    let filter_doc = if invert {
+        doc! { "$not": filter_doc }
     } else {
-        Ok(MongoFilter::Composite(filter_doc))
-    }
+        filter_doc
+    };
+
+    let filter_doc = if !is_set_cond {
+        exclude_undefineds(&field_name, invert_undefined_exclusion, filter_doc)
+    } else {
+        filter_doc
+    };
+
+    Ok(MongoFilter::Composite(filter_doc))
 }
 
-/// Renders a `$regexMatch` expression
+/// Renders a `$regexMatch` expression.
 fn regex_match(
     field_name: &str,
     field: &ScalarFieldRef,
@@ -668,7 +752,12 @@ fn coerce_as_null(field_name: &str) -> Document {
 
 /// Renders an expression that computes whether _some_ of the elements of an array matches the `Filter`.
 /// If `coerce_array` is true, the array will be coerced to an empty array in case it's `null` or `undefined`.
-fn render_some(field_name: &str, filter: Filter, coerce_array: bool) -> crate::Result<(Document, Vec<JoinStage>)> {
+fn render_some(
+    field_name: &str,
+    filter: Filter,
+    invert_undefined_exclusion: bool,
+    coerce_array: bool,
+) -> crate::Result<(Document, Vec<JoinStage>)> {
     let input = if coerce_array {
         Bson::from(coerce_as_array(field_name))
     } else {
@@ -677,7 +766,8 @@ fn render_some(field_name: &str, filter: Filter, coerce_array: bool) -> crate::R
 
     // Nested filters needs to be prefixed with `$$elem` so that they refer to the "elem" alias defined in the $filter operator below.
     let prefix = FilterPrefix::from("$elem");
-    let (nested_filter, nested_joins) = convert_filter(filter, false, prefix)?.render();
+    let (nested_filter, nested_joins) =
+        convert_filter_internal(filter, false, invert_undefined_exclusion, prefix)?.render();
 
     let doc = doc! {
       "$gt": [
@@ -699,7 +789,12 @@ fn render_some(field_name: &str, filter: Filter, coerce_array: bool) -> crate::R
 
 /// Renders an expression that computes whether _all_ of the elements of an array matches the `Filter`.
 /// If `coerce_array` is true, the array will be coerced to an empty array in case it's `null` or `undefined`.
-fn render_every(field_name: &str, filter: Filter, coerce_array: bool) -> crate::Result<(Document, Vec<JoinStage>)> {
+fn render_every(
+    field_name: &str,
+    filter: Filter,
+    invert_undefined_exclusion: bool,
+    coerce_array: bool,
+) -> crate::Result<(Document, Vec<JoinStage>)> {
     let input = if coerce_array {
         Bson::from(coerce_as_array(field_name))
     } else {
@@ -708,7 +803,8 @@ fn render_every(field_name: &str, filter: Filter, coerce_array: bool) -> crate::
 
     // Nested filters needs to be prefixed with `$$elem` so that they refer to the "elem" alias defined in the $filter operator below.
     let prefix = FilterPrefix::from("$elem");
-    let (nested_filter, nested_joins) = convert_filter(filter, false, prefix)?.render();
+    let (nested_filter, nested_joins) =
+        convert_filter_internal(filter, false, invert_undefined_exclusion, prefix)?.render();
 
     let doc = doc! {
       "$eq": [
@@ -730,7 +826,12 @@ fn render_every(field_name: &str, filter: Filter, coerce_array: bool) -> crate::
 
 /// Renders an expression that computes whether _none_ of the elements of an array matches the `Filter`.
 /// If `coerce_array` is true, the array will be coerced to an empty array in case it's `null` or `undefined`.
-fn render_none(field_name: &str, filter: Filter, coerce_array: bool) -> crate::Result<(Document, Vec<JoinStage>)> {
+fn render_none(
+    field_name: &str,
+    filter: Filter,
+    invert_undefined_exclusion: bool,
+    coerce_array: bool,
+) -> crate::Result<(Document, Vec<JoinStage>)> {
     let input = if coerce_array {
         Bson::from(coerce_as_array(field_name))
     } else {
@@ -739,7 +840,8 @@ fn render_none(field_name: &str, filter: Filter, coerce_array: bool) -> crate::R
 
     // Nested filters needs to be prefixed with `$$elem` so that they refer to the "elem" alias defined in the $filter operator below.
     let prefix = FilterPrefix::from("$elem");
-    let (nested_filter, nested_joins) = convert_filter(filter, false, prefix)?.render();
+    let (nested_filter, nested_joins) =
+        convert_filter_internal(filter, false, invert_undefined_exclusion, prefix)?.render();
 
     let doc = doc! {
       "$eq": [
@@ -764,16 +866,34 @@ fn render_stub_condition(truthy: bool) -> Document {
     doc! { "$and": truthy }
 }
 
-/// Checks whether a scalar condition is an `Equals`
-fn is_equal_condition(condition: &ScalarCondition) -> bool {
-    let is_equal = matches!(condition, ScalarCondition::Equals(_));
+fn render_is_set(field_name: &str, is_set: bool) -> Document {
+    if is_set {
+        // To check whether a field is undefined, we need to coerce it to `null` first.
+        // This is why we _also_ need to check whether the field is equal to null
+        doc! {
+            "$or": [
+                { "$ne": [coerce_as_null(field_name), null] },
+                { "$eq": [field_name, null] }
+              ]
+        }
+    } else {
+        doc! {
+            "$and": [
+                { "$eq": [coerce_as_null(&field_name), null] },
+                { "$ne": [&field_name, null] }
+              ]
+        }
+    }
+}
 
-    let is_json_equal = match condition {
-        ScalarCondition::JsonCompare(json_cond) => matches!(*json_cond.condition, ScalarCondition::Equals(_)),
-        _ => false,
-    };
+fn exclude_undefineds(field_name: &str, invert: bool, filter: Document) -> Document {
+    let is_set_filter = render_is_set(field_name, !invert);
 
-    is_equal || is_json_equal
+    if invert {
+        doc! { "$or": [filter, is_set_filter] }
+    } else {
+        doc! { "$and": [filter, is_set_filter] }
+    }
 }
 
 #[derive(Debug, Clone, Default)]

--- a/query-engine/connectors/mongodb-query-connector/src/filter.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/filter.rs
@@ -51,8 +51,6 @@ fn convert_filter_internal(
     invert_undefined_exclusion: bool,
     prefix: impl Into<FilterPrefix>,
 ) -> crate::Result<MongoFilter> {
-    dbg!(&filter);
-
     let prefix = prefix.into();
     let filter = fold_compounds(filter);
 

--- a/query-engine/connectors/mongodb-query-connector/src/root_queries/update/into_expression.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/root_queries/update/into_expression.rs
@@ -96,7 +96,7 @@ impl IntoUpdateExpression for UpdateMany {
         // A reference to that alias
         let ref_elem_alias = format!("$${}", &elem_alias);
 
-        let (filter_doc, _) = filter::convert_filter(self.filter.clone(), true, false, elem_alias.clone())?.render();
+        let (filter_doc, _) = filter::convert_filter(self.filter.clone(), false, format!("${}", &elem_alias))?.render();
 
         // Builds a `$mergeObjects` operation to perform updates on each element of the to-many embeds.
         // The `FieldPath` used for the `$mergeObjects` is the alias constructed above, since we'll merge against

--- a/query-engine/connectors/mongodb-query-connector/src/root_queries/update/into_operation.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/root_queries/update/into_operation.rs
@@ -100,7 +100,7 @@ impl IntoUpdateOperation for CompositeWriteOperation {
             }
             CompositeWriteOperation::DeleteMany { filter } => {
                 let elem_alias = format!("{}_item", path.identifier());
-                let (filter_doc, _) = filter::convert_filter(filter, true, false, elem_alias.clone())?.render();
+                let (filter_doc, _) = filter::convert_filter(filter, true, format!("${}", &elem_alias))?.render();
 
                 let filter = doc! {
                     "$filter": {

--- a/query-engine/connectors/mongodb-query-connector/src/root_queries/update/into_operation.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/root_queries/update/into_operation.rs
@@ -23,31 +23,43 @@ impl IntoUpdateOperation for ScalarWriteOperation {
         let dollar_field_path = field_path.dollar_path(true);
 
         let doc = match self {
-            ScalarWriteOperation::Add(rhs) if field.is_list() => render_push_update_doc(rhs, field, field_path)?,
+            ScalarWriteOperation::Add(rhs) if field.is_list() => Some(render_push_update_doc(rhs, field, field_path)?),
             // We use $literal to enable the set of empty object, which is otherwise considered a syntax error
-            ScalarWriteOperation::Set(rhs) => {
-                UpdateOperation::generic(field_path, doc! { "$literal": (field, rhs).into_bson()? })
-            }
-            ScalarWriteOperation::Add(rhs) => UpdateOperation::generic(
+            ScalarWriteOperation::Set(rhs) => Some(UpdateOperation::generic(
+                field_path,
+                doc! { "$literal": (field, rhs).into_bson()? },
+            )),
+            ScalarWriteOperation::Add(rhs) => Some(UpdateOperation::generic(
                 field_path,
                 doc! { "$add": [dollar_field_path, (field, rhs).into_bson()?] },
-            ),
-            ScalarWriteOperation::Substract(rhs) => UpdateOperation::generic(
+            )),
+            ScalarWriteOperation::Substract(rhs) => Some(UpdateOperation::generic(
                 field_path,
                 doc! { "$subtract": [dollar_field_path, (field, rhs).into_bson()?] },
-            ),
-            ScalarWriteOperation::Multiply(rhs) => UpdateOperation::generic(
+            )),
+            ScalarWriteOperation::Multiply(rhs) => Some(UpdateOperation::generic(
                 field_path,
                 doc! { "$multiply": [dollar_field_path, (field, rhs).into_bson()?] },
-            ),
-            ScalarWriteOperation::Divide(rhs) => UpdateOperation::generic(
+            )),
+            ScalarWriteOperation::Divide(rhs) => Some(UpdateOperation::generic(
                 field_path,
                 doc! { "$divide": [dollar_field_path, (field, rhs).into_bson()?] },
-            ),
+            )),
+            ScalarWriteOperation::Unset(should_unset) => {
+                if should_unset {
+                    Some(UpdateOperation::unset(field_path))
+                } else {
+                    None
+                }
+            }
             ScalarWriteOperation::Field(_) => unimplemented!(),
         };
 
-        Ok(vec![doc])
+        if let Some(doc) = doc {
+            Ok(vec![doc])
+        } else {
+            Ok(vec![])
+        }
     }
 }
 

--- a/query-engine/connectors/mongodb-query-connector/src/root_queries/write.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/root_queries/write.rs
@@ -151,7 +151,7 @@ pub async fn update_records<'conn>(
             })
             .collect::<crate::Result<Vec<_>>>()?
     } else {
-        let filter = convert_filter(record_filter.filter, false, false, FilterPrefix::default())?;
+        let filter = convert_filter(record_filter.filter, false, FilterPrefix::default())?;
         find_ids(coll.clone(), session, model, filter).await?
     };
 
@@ -219,7 +219,7 @@ pub async fn delete_records<'conn>(
             })
             .collect::<crate::Result<Vec<_>>>()?
     } else {
-        let filter = convert_filter(record_filter.filter, false, false, FilterPrefix::default())?;
+        let filter = convert_filter(record_filter.filter, false, FilterPrefix::default())?;
         find_ids(coll.clone(), session, model, filter).await?
     };
 

--- a/query-engine/connectors/query-connector/src/compare.rs
+++ b/query-engine/connectors/query-connector/src/compare.rs
@@ -66,6 +66,8 @@ pub trait ScalarCompare {
     fn not_search<T>(&self, val: T) -> Filter
     where
         T: Into<PrismaValue>;
+
+    fn is_set(&self, val: bool) -> Filter;
 }
 
 /// Comparison methods for relational fields.
@@ -180,6 +182,8 @@ pub trait CompositeCompare {
         T: Into<Filter>;
 
     fn is_empty(&self, b: bool) -> Filter;
+
+    fn is_set(&self, b: bool) -> Filter;
 
     fn equals(&self, val: PrismaValue) -> Filter;
 }

--- a/query-engine/connectors/query-connector/src/filter/composite.rs
+++ b/query-engine/connectors/query-connector/src/filter/composite.rs
@@ -36,6 +36,9 @@ pub enum CompositeCondition {
 
     /// To-one composite only - the composite must not fulfill the filter.
     IsNot(Filter),
+
+    /// Checks whether or not the composite field exists (is `undefined` or not)
+    IsSet(bool),
 }
 
 impl CompositeCompare for CompositeFieldRef {
@@ -98,6 +101,14 @@ impl CompositeCompare for CompositeFieldRef {
         CompositeFilter {
             field: self.clone(),
             condition: Box::new(CompositeCondition::Empty(b)),
+        }
+        .into()
+    }
+
+    fn is_set(&self, b: bool) -> Filter {
+        CompositeFilter {
+            field: self.clone(),
+            condition: Box::new(CompositeCondition::IsSet(b)),
         }
         .into()
     }

--- a/query-engine/connectors/query-connector/src/write_args.rs
+++ b/query-engine/connectors/query-connector/src/write_args.rs
@@ -60,6 +60,10 @@ impl WriteOperation {
         Self::Scalar(ScalarWriteOperation::Set(pv))
     }
 
+    pub fn scalar_unset(should_unset: bool) -> Self {
+        Self::Scalar(ScalarWriteOperation::Unset(should_unset))
+    }
+
     pub fn scalar_add(pv: PrismaValue) -> Self {
         Self::Scalar(ScalarWriteOperation::Add(pv))
     }
@@ -150,6 +154,9 @@ pub enum ScalarWriteOperation {
 
     /// Write plain value to field.
     Set(PrismaValue),
+
+    /// Unsets a field (only for MongoDB for now)
+    Unset(bool),
 
     /// Add value to field.
     Add(PrismaValue),
@@ -499,5 +506,6 @@ pub fn apply_expression(val: PrismaValue, scalar_write: ScalarWriteOperation) ->
         ScalarWriteOperation::Substract(rhs) => val - rhs,
         ScalarWriteOperation::Multiply(rhs) => val * rhs,
         ScalarWriteOperation::Divide(rhs) => val / rhs,
+        ScalarWriteOperation::Unset(_) => unimplemented!(),
     }
 }

--- a/query-engine/connectors/sql-query-connector/src/filter_conversion.rs
+++ b/query-engine/connectors/sql-query-connector/src/filter_conversion.rs
@@ -610,6 +610,7 @@ fn default_scalar_filter(
             comparable.not_matches(query)
         }
         ScalarCondition::JsonCompare(_) => unreachable!(),
+        ScalarCondition::IsSet(_) => unreachable!(),
     };
 
     ConditionTree::single(condition)
@@ -723,6 +724,7 @@ fn insensitive_scalar_filter(
             comparable.not_matches(query)
         }
         ScalarCondition::JsonCompare(_) => unreachable!(),
+        ScalarCondition::IsSet(_) => unreachable!(),
     };
 
     ConditionTree::single(condition)

--- a/query-engine/connectors/sql-query-connector/src/query_builder/write.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_builder/write.rs
@@ -156,6 +156,8 @@ pub fn update_many(
                     let e: Expression<'_> = Column::from(name.clone()).into();
                     e / field.value(rhs).into()
                 }
+
+                ScalarWriteOperation::Unset(_) => unreachable!("Unset is not supported on SQL connectors"),
             };
 
             acc.set(name, value)

--- a/query-engine/core/src/query_graph_builder/extractors/filters/composite.rs
+++ b/query-engine/core/src/query_graph_builder/extractors/filters/composite.rs
@@ -16,6 +16,7 @@ pub fn parse(input_map: ParsedInputMap, field: &CompositeFieldRef, _reverse: boo
         match (filter_key.as_ref(), value) {
             // Common composite filters.
             (filters::EQUALS, input) => Ok(field.equals(input.try_into()?)),
+            (filters::IS_SET, input) => Ok(field.is_set(input.try_into()?)),
 
             // To-many composite filters.
             (filters::EVERY, input) => Ok(field.every(extract_filter(input.try_into()?, &field.typ)?)),
@@ -23,7 +24,7 @@ pub fn parse(input_map: ParsedInputMap, field: &CompositeFieldRef, _reverse: boo
             (filters::NONE, input) => Ok(field.none(extract_filter(input.try_into()?, &field.typ)?)),
             (filters::IS_EMPTY, input) => Ok(field.is_empty(input.try_into()?)),
 
-            // // To-one composite filters
+            // To-one composite filters
             (filters::IS, ParsedInputValue::Single(PrismaValue::Null)) => Ok(field.equals(PrismaValue::Null)),
             (filters::IS, input) => Ok(field.is(extract_filter(input.try_into()?, &field.typ)?)),
 

--- a/query-engine/core/src/query_graph_builder/extractors/filters/scalar.rs
+++ b/query-engine/core/src/query_graph_builder/extractors/filters/scalar.rs
@@ -328,6 +328,13 @@ fn parse_internal_scalar(
         filters::SEARCH if reverse => Ok(vec![field.not_search(as_prisma_value(input)?)]),
         filters::SEARCH => Ok(vec![field.search(as_prisma_value(input)?)]),
 
+        filters::IS_SET if reverse => {
+            let is_set: bool = input.try_into()?;
+
+            Ok(vec![field.is_set(!is_set)])
+        }
+        filters::IS_SET => Ok(vec![field.is_set(input.try_into()?)]),
+
         // List-specific filters
         filters::HAS => Ok(vec![field.contains_element(as_prisma_value(input)?)]),
         filters::HAS_EVERY => Ok(vec![field.contains_every_element(as_prisma_value_list(input)?)]),

--- a/query-engine/core/src/query_graph_builder/write/write_args_parser.rs
+++ b/query-engine/core/src/query_graph_builder/write/write_args_parser.rs
@@ -78,6 +78,7 @@ fn parse_scalar(sf: &ScalarFieldRef, v: ParsedInputValue) -> Result<WriteOperati
 
             let write_op = match operation.as_str() {
                 operations::SET => WriteOperation::scalar_set(value),
+                operations::UNSET => WriteOperation::scalar_unset(*value.as_boolean().unwrap()),
                 operations::INCREMENT => WriteOperation::scalar_add(value),
                 operations::DECREMENT => WriteOperation::scalar_substract(value),
                 operations::MULTIPLY => WriteOperation::scalar_multiply(value),

--- a/query-engine/core/src/schema_builder/constants.rs
+++ b/query-engine/core/src/schema_builder/constants.rs
@@ -61,6 +61,7 @@ pub mod filters {
     pub const GREATER_THAN_OR_EQUAL: &str = "gte";
     pub const IN: &str = "in";
     pub const SEARCH: &str = "search";
+    pub const IS_SET: &str = "isSet";
 
     // legacy filter
     pub const NOT_IN: &str = "notIn";

--- a/query-engine/core/src/schema_builder/input_types/fields/data_input_mapper/update.rs
+++ b/query-engine/core/src/schema_builder/input_types/fields/data_input_mapper/update.rs
@@ -193,6 +193,10 @@ fn update_operations_object_type(
         fields.push(input_field(operations::DIVIDE, typ, None).optional());
     }
 
+    if ctx.has_capability(ConnectorCapability::UndefinedType) && !sf.is_required() {
+        fields.push(input_field(operations::UNSET, InputType::boolean(), None).optional());
+    }
+
     obj.set_fields(fields);
 
     Arc::downgrade(&obj)

--- a/query-engine/core/src/schema_builder/input_types/fields/field_filter_types.rs
+++ b/query-engine/core/src/schema_builder/input_types/fields/field_filter_types.rs
@@ -121,7 +121,11 @@ fn to_one_composite_filter_shorthand_types(ctx: &mut BuilderContext, cf: &Compos
 
 #[tracing::instrument(skip(ctx, cf))]
 fn to_one_composite_filter_object(ctx: &mut BuilderContext, cf: &CompositeFieldRef) -> InputObjectTypeWeakRef {
-    let ident = Identifier::new(format!("{}CompositeFilter", capitalize(&cf.typ.name)), PRISMA_NAMESPACE);
+    let nullable = if cf.is_optional() { "Nullable" } else { "" };
+    let ident = Identifier::new(
+        format!("{}{}CompositeFilter", capitalize(&cf.typ.name), nullable),
+        PRISMA_NAMESPACE,
+    );
     return_cached_input!(ctx, &ident);
 
     let mut object = init_input_object_type(ident.clone());
@@ -135,7 +139,7 @@ fn to_one_composite_filter_object(ctx: &mut BuilderContext, cf: &CompositeFieldR
     let composite_where_object = filter_objects::where_object_type(ctx, &cf.typ);
     let composite_equals_object = filter_objects::composite_equality_object(ctx, cf);
 
-    let fields = vec![
+    let mut fields = vec![
         input_field(filters::EQUALS, InputType::object(composite_equals_object), None)
             .optional()
             .nullable_if(!cf.is_required()),
@@ -146,6 +150,10 @@ fn to_one_composite_filter_object(ctx: &mut BuilderContext, cf: &CompositeFieldR
             .optional()
             .nullable_if(!cf.is_required()),
     ];
+
+    if ctx.has_capability(ConnectorCapability::UndefinedType) && cf.is_optional() {
+        fields.push(is_set_input_field());
+    }
 
     object.set_fields(fields);
     Arc::downgrade(&object)
@@ -169,7 +177,7 @@ fn to_many_composite_filter_object(ctx: &mut BuilderContext, cf: &CompositeField
     let composite_where_object = filter_objects::where_object_type(ctx, &cf.typ);
     let composite_equals_object = filter_objects::composite_equality_object(ctx, cf);
 
-    let fields = vec![
+    let mut fields = vec![
         input_field(
             filters::EQUALS,
             InputType::list(InputType::object(composite_equals_object)),
@@ -181,6 +189,11 @@ fn to_many_composite_filter_object(ctx: &mut BuilderContext, cf: &CompositeField
         input_field(filters::NONE, InputType::object(composite_where_object), None).optional(),
         input_field(filters::IS_EMPTY, InputType::boolean(), None).optional(),
     ];
+
+    // TODO: Remove from required lists once we have optional lists
+    if ctx.has_capability(ConnectorCapability::UndefinedType) {
+        fields.push(is_set_input_field());
+    }
 
     object.set_fields(fields);
     Arc::downgrade(&object)
@@ -346,8 +359,16 @@ fn full_scalar_filter_type(
         }
     }
 
+    if ctx.has_capability(ConnectorCapability::UndefinedType) && !list {
+        fields.push(is_set_input_field());
+    }
+
     object.set_fields(fields);
     Arc::downgrade(&object)
+}
+
+fn is_set_input_field() -> InputField {
+    input_field(filters::IS_SET, InputType::boolean(), None).optional()
 }
 
 fn equality_filters(mapped_type: InputType, nullable: bool) -> impl Iterator<Item = InputField> {

--- a/query-engine/core/src/schema_builder/input_types/fields/field_filter_types.rs
+++ b/query-engine/core/src/schema_builder/input_types/fields/field_filter_types.rs
@@ -359,7 +359,7 @@ fn full_scalar_filter_type(
         }
     }
 
-    if ctx.has_capability(ConnectorCapability::UndefinedType) && !list {
+    if ctx.has_capability(ConnectorCapability::UndefinedType) && (list || nullable) {
         fields.push(is_set_input_field());
     }
 


### PR DESCRIPTION
## Overview

fixes https://github.com/prisma/prisma/issues/12362

Rewrites filters from the MQL syntax to boolean expressions