### PR TITLE
fix(mongo): better error mapping

### DIFF
--- a/query-engine/connectors/mongodb-query-connector/src/error.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/error.rs
@@ -17,6 +17,7 @@ pub enum MongoError {
     #[error("Failed to convert '{}' to '{}'.", from, to)]
     ConversionError { from: String, to: String },
 
+    // Unhandled conversion error. Mostly used for `#[non-exhaustive]` flagged Mongo errors.
     #[error("Unhandled conversion error: {0}.")]
     UnhandledConversionError(anyhow::Error),
 

--- a/query-engine/connectors/mongodb-query-connector/src/error.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/error.rs
@@ -17,9 +17,8 @@ pub enum MongoError {
     #[error("Failed to convert '{}' to '{}'.", from, to)]
     ConversionError { from: String, to: String },
 
-    /// Unhandled behavior error.
-    #[error("Unhandled behavior: {0}.")]
-    UnhandledError(String),
+    #[error("Unhandled conversion error: {0}.")]
+    UnhandledConversionError(anyhow::Error),
 
     /// ObjectID specific conversion error.
     #[error("Malformed ObjectID: {0}.")]
@@ -61,7 +60,7 @@ impl MongoError {
     pub fn into_connector_error(self) -> ConnectorError {
         match self {
             MongoError::Unsupported(feature) => ConnectorError::from_kind(ErrorKind::UnsupportedFeature(feature)),
-            MongoError::UnhandledError(reason) => ConnectorError::from_kind(ErrorKind::RawApiError(reason)),
+            MongoError::UnhandledConversionError(err) => ConnectorError::from_kind(ErrorKind::ConversionError(err)),
             MongoError::UuidError(err) => ConnectorError::from_kind(ErrorKind::ConversionError(err.into())),
             MongoError::JsonError(err) => ConnectorError::from_kind(ErrorKind::ConversionError(err.into())),
             MongoError::BsonDeserializationError(err) => {
@@ -211,7 +210,7 @@ impl From<extjson::de::Error> for MongoError {
                 to: "BSON".to_string(),
             },
             // Needed because `extjson::de::Error` is flagged as #[non_exhaustive]
-            err => MongoError::UnhandledError(format!("{:?}", err)),
+            err => MongoError::UnhandledConversionError(err.into()),
         }
     }
 }

--- a/query-engine/connectors/mongodb-query-connector/src/root_queries/raw.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/root_queries/raw.rs
@@ -35,8 +35,7 @@ impl MongoCommand {
             (Some("findRaw"), Some(m)) => Self::find(m, inputs),
             (Some("aggregateRaw"), Some(m)) => Self::aggregate(m, inputs),
             (Some("runCommandRaw"), _) => Self::raw(inputs),
-            // This is more of an internal guard in case new raw queries are added. It shouldn't happen
-            (_, _) => Err(MongoError::UnhandledError("Unexpected MongoDB raw query".to_string())),
+            _ => unreachable!("Unexpected MongoDB raw query"),
         }
     }
 


### PR DESCRIPTION
## Overview

We used to map `MongoError::UnhandledError` to a `ConnectorError::RawApiError` (because the `UnhandledError` can presently only happen in the raw API). This might lead to future ambigous/wrong mapping depending on where it's used.

This PR renames `UnhandledError` to `UnhandledConversionError` and maps that to a `ConnectorError::ConversionError`.