### PR TITLE
MDB: Do not allow invalid characters in mapped field names

### DIFF
--- a/libs/datamodel/connectors/mongodb-datamodel-connector/src/lib.rs
+++ b/libs/datamodel/connectors/mongodb-datamodel-connector/src/lib.rs
@@ -65,6 +65,7 @@ impl Connector for MongoDbDatamodelConnector {
             validations::auto_attribute_must_be_an_id(field, errors);
             validations::dbgenerated_attribute_is_not_allowed(field, errors);
             validations::disallow_array_native_types(field, errors);
+            validations::field_name_uses_valid_characters(field, errors);
         }
 
         for index in model.indexes() {

--- a/libs/datamodel/connectors/mongodb-datamodel-connector/src/validations.rs
+++ b/libs/datamodel/connectors/mongodb-datamodel-connector/src/validations.rs
@@ -189,3 +189,29 @@ pub(crate) fn unique_cannot_be_defined_to_id_field(index: IndexWalker<'_>, error
         *attr.span(),
     ));
 }
+
+/// A field name cannot contain the `.` character and it cannot start with `$`.
+pub(crate) fn field_name_uses_valid_characters(field: ScalarFieldWalker<'_>, errors: &mut Diagnostics) {
+    let name = match field.mapped_name() {
+        Some(name) => name,
+        None => return,
+    };
+
+    let span = field.ast_field().span_for_attribute("map").unwrap();
+
+    if name.starts_with('$') {
+        errors.push_error(DatamodelError::new_attribute_validation_error(
+            "The field name cannot start with a `$` character",
+            "map",
+            span,
+        ));
+    }
+
+    if name.contains('.') {
+        errors.push_error(DatamodelError::new_attribute_validation_error(
+            "The field name cannot contain a `.` character",
+            "map",
+            span,
+        ));
+    }
+}

--- a/libs/datamodel/core/tests/attributes/map_negative.rs
+++ b/libs/datamodel/core/tests/attributes/map_negative.rs
@@ -1,4 +1,4 @@
-use crate::common::*;
+use crate::{common::*, with_header, Provider};
 
 #[test]
 fn map_must_error_for_relation_fields() {
@@ -22,6 +22,54 @@ fn map_must_error_for_relation_fields() {
         [1;94m   | [0m
         [1;94m 3 | [0m  fooId Int
         [1;94m 4 | [0m  relationField  Foo @relation(fields: [fooId], references: [id]) @[1;91mmap("custom_name")[0m
+        [1;94m   | [0m
+    "#]];
+
+    expectation.assert_eq(&error)
+}
+
+#[test]
+fn mongodb_field_mapping_cannot_start_with_a_dollar_sign() {
+    let dml = indoc! {r#"
+        model Foo {
+          id    Int    @id @map("_id")
+          field String @map("$field")
+        }
+    "#};
+
+    let schema = with_header(dml, Provider::Mongo, &["mongoDb"]);
+    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@map": The field name cannot start with a `$` character[0m
+          [1;94m-->[0m  [4mschema.prisma:13[0m
+        [1;94m   | [0m
+        [1;94m12 | [0m  id    Int    @id @map("_id")
+        [1;94m13 | [0m  field String @[1;91mmap("$field")[0m
+        [1;94m   | [0m
+    "#]];
+
+    expectation.assert_eq(&error)
+}
+
+#[test]
+fn mongodb_field_mapping_cannot_contain_periods() {
+    let dml = indoc! {r#"
+        model Foo {
+          id    Int    @id @map("_id")
+          field String @map("field.schwield")
+        }
+    "#};
+
+    let schema = with_header(dml, Provider::Mongo, &["mongoDb"]);
+    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@map": The field name cannot contain a `.` character[0m
+          [1;94m-->[0m  [4mschema.prisma:13[0m
+        [1;94m   | [0m
+        [1;94m12 | [0m  id    Int    @id @map("_id")
+        [1;94m13 | [0m  field String @[1;91mmap("field.schwield")[0m
         [1;94m   | [0m
     "#]];
 


### PR DESCRIPTION
Reference documentation: https://jira.mongodb.org/browse/SERVER-3229

Closes: https://github.com/prisma/prisma/issues/12410