### PR TITLE
Skip serializing falsy values to DMMF

### DIFF
--- a/libs/datamodel/dmmf/src/lib.rs
+++ b/libs/datamodel/dmmf/src/lib.rs
@@ -66,9 +66,8 @@ pub struct Model {
     pub name: String,
     pub db_name: Option<String>,
     pub fields: Vec<Field>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "is_false_or_none")]
     pub is_generated: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub documentation: Option<String>,
     pub primary_key: Option<PrimaryKey>,
     pub unique_fields: Vec<Vec<String>>,

--- a/libs/datamodel/dmmf/src/lib.rs
+++ b/libs/datamodel/dmmf/src/lib.rs
@@ -3,14 +3,14 @@ pub use to_dmmf::render_to_dmmf;
 pub use to_dmmf::render_to_dmmf_value;
 
 fn is_false(val: &bool) -> bool {
-    *val == false
+    !(*val)
 }
 
 fn is_false_or_none(val: &Option<bool>) -> bool {
-    return match val {
-        Some(p) => is_false(&p),
+    match val {
+        Some(p) => is_false(p),
         None => true,
-    };
+    }
 }
 
 

--- a/libs/datamodel/dmmf/src/lib.rs
+++ b/libs/datamodel/dmmf/src/lib.rs
@@ -33,6 +33,7 @@ pub struct Field {
     pub is_read_only: bool,
     #[serde(rename = "type")]
     pub field_type: String,
+    #[serde(skip_serializing_if = "is_false")]
     pub has_default_value: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default: Option<serde_json::Value>,

--- a/libs/datamodel/dmmf/src/lib.rs
+++ b/libs/datamodel/dmmf/src/lib.rs
@@ -2,6 +2,18 @@ mod to_dmmf;
 pub use to_dmmf::render_to_dmmf;
 pub use to_dmmf::render_to_dmmf_value;
 
+fn is_false(val: &bool) -> bool {
+    *val == false
+}
+
+fn is_false_or_none(val: &Option<bool>) -> bool {
+    return match val {
+        Some(p) => is_false(&p),
+        None => true,
+    };
+}
+
+
 // This is a simple JSON serialization using Serde.
 // The JSON format follows the DMMF spec.
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
@@ -9,10 +21,15 @@ pub use to_dmmf::render_to_dmmf_value;
 pub struct Field {
     pub name: String,
     pub kind: String,
+    #[serde(skip_serializing_if = "is_false")]
     pub is_list: bool,
+    #[serde(skip_serializing_if = "is_false")]
     pub is_required: bool,
+    #[serde(skip_serializing_if = "is_false")]
     pub is_unique: bool,
+    #[serde(skip_serializing_if = "is_false")]
     pub is_id: bool,
+    #[serde(skip_serializing_if = "is_false")]
     pub is_read_only: bool,
     #[serde(rename = "type")]
     pub field_type: String,
@@ -27,9 +44,9 @@ pub struct Field {
     pub relation_to_fields: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub relation_on_delete: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "is_false_or_none")]
     pub is_generated: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "is_false_or_none")]
     pub is_updated_at: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub documentation: Option<String>,

--- a/libs/datamodel/dmmf/tests/render_to_dmmf/files/functions.json
+++ b/libs/datamodel/dmmf/tests/render_to_dmmf/files/functions.json
@@ -8,49 +8,32 @@
         {
           "name": "id",
           "kind": "scalar",
-          "isList": false,
           "isRequired": true,
-          "isUnique": false,
           "isId": true,
-          "isReadOnly": false,
-          "type": "Int",
-          "hasDefaultValue": false,
-          "isGenerated": false,
-          "isUpdatedAt": false
+          "type": "Int"
         },
         {
           "name": "createdAt",
           "kind": "scalar",
-          "isList": false,
           "isRequired": true,
-          "isUnique": false,
-          "isId": false,
-          "isReadOnly": false,
           "type": "DateTime",
           "hasDefaultValue": true,
           "default": {
             "name": "now",
             "args": []
-          },
-          "isGenerated": false,
-          "isUpdatedAt": false
+          }
         },
         {
           "name": "someId",
           "kind": "scalar",
-          "isList": false,
           "isRequired": true,
           "isUnique": true,
-          "isId": false,
-          "isReadOnly": false,
           "type": "String",
           "hasDefaultValue": true,
           "default": {
             "name": "cuid",
             "args": []
-          },
-          "isGenerated": false,
-          "isUpdatedAt": false
+          }
         }
       ],
       "isGenerated": false,

--- a/libs/datamodel/dmmf/tests/render_to_dmmf/files/general.json
+++ b/libs/datamodel/dmmf/tests/render_to_dmmf/files/general.json
@@ -27,86 +27,45 @@
         {
           "name": "id",
           "kind": "scalar",
-          "isList": false,
           "isRequired": true,
-          "isUnique": false,
           "isId": true,
-          "isReadOnly": false,
-          "type": "Int",
-          "hasDefaultValue": false,
-          "isGenerated": false,
-          "isUpdatedAt": false
+          "type": "Int"
         },
         {
           "name": "createdAt",
           "kind": "scalar",
-          "isList": false,
           "isRequired": true,
-          "isUnique": false,
-          "isId": false,
-          "isReadOnly": false,
-          "type": "DateTime",
-          "hasDefaultValue": false,
-          "isGenerated": false,
-          "isUpdatedAt": false
+          "type": "DateTime"
         },
         {
           "name": "email",
           "kind": "scalar",
-          "isList": false,
           "isRequired": true,
           "isUnique": true,
-          "isId": false,
-          "isReadOnly": false,
-          "type": "String",
-          "hasDefaultValue": false,
-          "isGenerated": false,
-          "isUpdatedAt": false
+          "type": "String"
         },
         {
           "name": "name",
           "kind": "scalar",
-          "isList": false,
-          "isRequired": false,
-          "isUnique": false,
-          "isId": false,
-          "isReadOnly": false,
-          "type": "String",
-          "hasDefaultValue": false,
-          "isGenerated": false,
-          "isUpdatedAt": false
+          "type": "String"
         },
         {
           "name": "posts",
           "kind": "object",
           "isList": true,
           "isRequired": true,
-          "isUnique": false,
-          "isId": false,
-          "isReadOnly": false,
           "type": "Post",
-          "hasDefaultValue": false,
           "relationName": "author",
           "relationFromFields": [],
-          "relationToFields": [],
-          "isGenerated": false,
-          "isUpdatedAt": false
+          "relationToFields": []
         },
         {
           "name": "profile",
           "kind": "object",
-          "isList": false,
-          "isRequired": false,
-          "isUnique": false,
-          "isId": false,
-          "isReadOnly": false,
           "type": "Profile",
-          "hasDefaultValue": false,
           "relationName": "ProfileToUser",
           "relationFromFields": [],
-          "relationToFields": [],
-          "isGenerated": false,
-          "isUpdatedAt": false
+          "relationToFields": []
         }
       ],
       "isGenerated": false,
@@ -121,61 +80,32 @@
         {
           "name": "id",
           "kind": "scalar",
-          "isList": false,
           "isRequired": true,
-          "isUnique": false,
           "isId": true,
-          "isReadOnly": false,
-          "type": "Int",
-          "hasDefaultValue": false,
-          "isGenerated": false,
-          "isUpdatedAt": false
+          "type": "Int"
         },
         {
           "name": "userId",
           "kind": "scalar",
-          "isList": false,
           "isRequired": true,
           "isUnique": true,
-          "isId": false,
           "isReadOnly": true,
-          "type": "Int",
-          "hasDefaultValue": false,
-          "isGenerated": false,
-          "isUpdatedAt": false
+          "type": "Int"
         },
         {
           "name": "user",
           "kind": "object",
-          "isList": false,
           "isRequired": true,
-          "isUnique": false,
-          "isId": false,
-          "isReadOnly": false,
           "type": "User",
-          "hasDefaultValue": false,
           "relationName": "ProfileToUser",
-          "relationFromFields": [
-            "userId"
-          ],
-          "relationToFields": [
-            "id"
-          ],
-          "isGenerated": false,
-          "isUpdatedAt": false
+          "relationFromFields": ["userId"],
+          "relationToFields": ["id"]
         },
         {
           "name": "bio",
           "kind": "scalar",
-          "isList": false,
           "isRequired": true,
-          "isUnique": false,
-          "isId": false,
-          "isReadOnly": false,
-          "type": "String",
-          "hasDefaultValue": false,
-          "isGenerated": false,
-          "isUpdatedAt": false
+          "type": "String"
         }
       ],
       "isGenerated": false,
@@ -190,141 +120,76 @@
         {
           "name": "id",
           "kind": "scalar",
-          "isList": false,
           "isRequired": true,
-          "isUnique": false,
-          "isId": false,
-          "isReadOnly": false,
-          "type": "Int",
-          "hasDefaultValue": false,
-          "isGenerated": false,
-          "isUpdatedAt": false
+          "type": "Int"
         },
         {
           "name": "createdAt",
           "kind": "scalar",
-          "isList": false,
           "isRequired": true,
-          "isUnique": false,
-          "isId": false,
-          "isReadOnly": false,
-          "type": "DateTime",
-          "hasDefaultValue": false,
-          "isGenerated": false,
-          "isUpdatedAt": false
+          "type": "DateTime"
         },
         {
           "name": "updatedAt",
           "kind": "scalar",
-          "isList": false,
           "isRequired": true,
-          "isUnique": false,
-          "isId": false,
-          "isReadOnly": false,
-          "type": "DateTime",
-          "hasDefaultValue": false,
-          "isGenerated": false,
-          "isUpdatedAt": false
+          "type": "DateTime"
         },
         {
           "name": "title",
           "kind": "scalar",
-          "isList": false,
           "isRequired": true,
-          "isUnique": false,
-          "isId": false,
-          "isReadOnly": false,
           "type": "String",
           "hasDefaultValue": true,
-          "default": "Default-Title",
-          "isGenerated": false,
-          "isUpdatedAt": false
+          "default": "Default-Title"
         },
         {
           "name": "wasLiked",
           "kind": "scalar",
-          "isList": false,
           "isRequired": true,
-          "isUnique": false,
-          "isId": false,
-          "isReadOnly": false,
           "type": "Boolean",
           "hasDefaultValue": true,
-          "default": false,
-          "isGenerated": false,
-          "isUpdatedAt": false
+          "default": false
         },
         {
           "name": "published",
           "kind": "scalar",
-          "isList": false,
           "isRequired": true,
-          "isUnique": false,
-          "isId": false,
-          "isReadOnly": false,
           "type": "Boolean",
           "hasDefaultValue": true,
-          "default": false,
-          "isGenerated": false,
-          "isUpdatedAt": false
+          "default": false
         },
         {
           "name": "authorId",
           "kind": "scalar",
-          "isList": false,
           "isRequired": true,
-          "isUnique": false,
-          "isId": false,
           "isReadOnly": true,
-          "type": "Int",
-          "hasDefaultValue": false,
-          "isGenerated": false,
-          "isUpdatedAt": false
+          "type": "Int"
         },
         {
           "name": "author",
           "kind": "object",
-          "isList": false,
           "isRequired": true,
-          "isUnique": false,
-          "isId": false,
-          "isReadOnly": false,
           "type": "User",
-          "hasDefaultValue": false,
           "relationName": "author",
-          "relationFromFields": [
-            "authorId"
-          ],
-          "relationToFields": [
-            "id"
-          ],
-          "isGenerated": false,
-          "isUpdatedAt": false
+          "relationFromFields": ["authorId"],
+          "relationToFields": ["id"]
         },
         {
           "name": "categories",
           "kind": "object",
           "isList": true,
           "isRequired": true,
-          "isUnique": false,
-          "isId": false,
-          "isReadOnly": false,
           "type": "PostToCategory",
-          "hasDefaultValue": false,
           "relationName": "PostToPostToCategory",
           "relationFromFields": [],
-          "relationToFields": [],
-          "isGenerated": false,
-          "isUpdatedAt": false
+          "relationToFields": []
         }
       ],
       "isGenerated": false,
       "primaryKey": {
         "name": null,
-        "fields": [
-          "title",
-          "createdAt"
-        ]
+        "fields": ["title", "createdAt"]
       },
       "uniqueFields": [],
       "uniqueIndexes": []
@@ -336,57 +201,31 @@
         {
           "name": "id",
           "kind": "scalar",
-          "isList": false,
           "isRequired": true,
-          "isUnique": false,
           "isId": true,
-          "isReadOnly": false,
-          "type": "Int",
-          "hasDefaultValue": false,
-          "isGenerated": false,
-          "isUpdatedAt": false
+          "type": "Int"
         },
         {
           "name": "name",
           "kind": "scalar",
-          "isList": false,
           "isRequired": true,
-          "isUnique": false,
-          "isId": false,
-          "isReadOnly": false,
-          "type": "String",
-          "hasDefaultValue": false,
-          "isGenerated": false,
-          "isUpdatedAt": false
+          "type": "String"
         },
         {
           "name": "posts",
           "kind": "object",
           "isList": true,
           "isRequired": true,
-          "isUnique": false,
-          "isId": false,
-          "isReadOnly": false,
           "type": "PostToCategory",
-          "hasDefaultValue": false,
           "relationName": "CategoryToPostToCategory",
           "relationFromFields": [],
-          "relationToFields": [],
-          "isGenerated": false,
-          "isUpdatedAt": false
+          "relationToFields": []
         },
         {
           "name": "cat",
           "kind": "enum",
-          "isList": false,
           "isRequired": true,
-          "isUnique": false,
-          "isId": false,
-          "isReadOnly": false,
-          "type": "CategoryEnum",
-          "hasDefaultValue": false,
-          "isGenerated": false,
-          "isUpdatedAt": false
+          "type": "CategoryEnum"
         }
       ],
       "isGenerated": false,
@@ -401,113 +240,57 @@
         {
           "name": "id",
           "kind": "scalar",
-          "isList": false,
           "isRequired": true,
-          "isUnique": false,
           "isId": true,
-          "isReadOnly": false,
-          "type": "Int",
-          "hasDefaultValue": false,
-          "isGenerated": false,
-          "isUpdatedAt": false
+          "type": "Int"
         },
         {
           "name": "postTitle",
           "kind": "scalar",
-          "isList": false,
           "isRequired": true,
-          "isUnique": false,
-          "isId": false,
           "isReadOnly": true,
-          "type": "String",
-          "hasDefaultValue": false,
-          "isGenerated": false,
-          "isUpdatedAt": false
+          "type": "String"
         },
         {
           "name": "postCreatedAt",
           "kind": "scalar",
-          "isList": false,
           "isRequired": true,
-          "isUnique": false,
-          "isId": false,
           "isReadOnly": true,
-          "type": "DateTime",
-          "hasDefaultValue": false,
-          "isGenerated": false,
-          "isUpdatedAt": false
+          "type": "DateTime"
         },
         {
           "name": "categoryId",
           "kind": "scalar",
-          "isList": false,
           "isRequired": true,
-          "isUnique": false,
-          "isId": false,
           "isReadOnly": true,
-          "type": "Int",
-          "hasDefaultValue": false,
-          "isGenerated": false,
-          "isUpdatedAt": false
+          "type": "Int"
         },
         {
           "name": "post",
           "kind": "object",
-          "isList": false,
           "isRequired": true,
-          "isUnique": false,
-          "isId": false,
-          "isReadOnly": false,
           "type": "Post",
-          "hasDefaultValue": false,
           "relationName": "PostToPostToCategory",
-          "relationFromFields": [
-            "postTitle",
-            "postCreatedAt"
-          ],
-          "relationToFields": [
-            "title",
-            "createdAt"
-          ],
-          "isGenerated": false,
-          "isUpdatedAt": false
+          "relationFromFields": ["postTitle", "postCreatedAt"],
+          "relationToFields": ["title", "createdAt"]
         },
         {
           "name": "category",
           "kind": "object",
-          "isList": false,
           "isRequired": true,
-          "isUnique": false,
-          "isId": false,
-          "isReadOnly": false,
           "type": "Category",
-          "hasDefaultValue": false,
           "relationName": "CategoryToPostToCategory",
-          "relationFromFields": [
-            "categoryId"
-          ],
-          "relationToFields": [
-            "id"
-          ],
-          "isGenerated": false,
-          "isUpdatedAt": false
+          "relationFromFields": ["categoryId"],
+          "relationToFields": ["id"]
         }
       ],
       "isGenerated": false,
       "primaryKey": null,
-      "uniqueFields": [
-        [
-          "postTitle",
-          "categoryId"
-        ]
-      ],
+      "uniqueFields": [["postTitle", "categoryId"]],
       "uniqueIndexes": [
         {
           "name": null,
-          "fields": [
-            "postTitle",
-            "categoryId"
-          ]
+          "fields": ["postTitle", "categoryId"]
         }
       ]
     },
@@ -518,48 +301,26 @@
         {
           "name": "id",
           "kind": "scalar",
-          "isList": false,
           "isRequired": true,
-          "isUnique": false,
           "isId": true,
-          "isReadOnly": false,
-          "type": "Int",
-          "hasDefaultValue": false,
-          "isGenerated": false,
-          "isUpdatedAt": false
+          "type": "Int"
         },
         {
           "name": "bId",
           "kind": "scalar",
-          "isList": false,
           "isRequired": true,
           "isUnique": true,
-          "isId": false,
           "isReadOnly": true,
-          "type": "Int",
-          "hasDefaultValue": false,
-          "isGenerated": false,
-          "isUpdatedAt": false
+          "type": "Int"
         },
         {
           "name": "b",
           "kind": "object",
-          "isList": false,
           "isRequired": true,
-          "isUnique": false,
-          "isId": false,
-          "isReadOnly": false,
           "type": "B",
-          "hasDefaultValue": false,
           "relationName": "AToB",
-          "relationFromFields": [
-            "bId"
-          ],
-          "relationToFields": [
-            "id"
-          ],
-          "isGenerated": false,
-          "isUpdatedAt": false
+          "relationFromFields": ["bId"],
+          "relationToFields": ["id"]
         }
       ],
       "isGenerated": false,
@@ -574,31 +335,17 @@
         {
           "name": "id",
           "kind": "scalar",
-          "isList": false,
           "isRequired": true,
-          "isUnique": false,
           "isId": true,
-          "isReadOnly": false,
-          "type": "Int",
-          "hasDefaultValue": false,
-          "isGenerated": false,
-          "isUpdatedAt": false
+          "type": "Int"
         },
         {
           "name": "a",
           "kind": "object",
-          "isList": false,
-          "isRequired": false,
-          "isUnique": false,
-          "isId": false,
-          "isReadOnly": false,
           "type": "A",
-          "hasDefaultValue": false,
           "relationName": "AToB",
           "relationFromFields": [],
-          "relationToFields": [],
-          "isGenerated": false,
-          "isUpdatedAt": false
+          "relationToFields": []
         }
       ],
       "isGenerated": false,
@@ -613,77 +360,38 @@
         {
           "name": "a",
           "kind": "scalar",
-          "isList": false,
           "isRequired": true,
-          "isUnique": false,
-          "isId": false,
-          "isReadOnly": false,
-          "type": "Int",
-          "hasDefaultValue": false,
-          "isGenerated": false,
-          "isUpdatedAt": false
+          "type": "Int"
         },
         {
           "name": "b",
           "kind": "scalar",
-          "isList": false,
           "isRequired": true,
-          "isUnique": false,
-          "isId": false,
-          "isReadOnly": false,
-          "type": "Int",
-          "hasDefaultValue": false,
-          "isGenerated": false,
-          "isUpdatedAt": false
+          "type": "Int"
         },
         {
           "name": "c",
           "kind": "scalar",
-          "isList": false,
           "isRequired": true,
-          "isUnique": false,
-          "isId": false,
-          "isReadOnly": false,
-          "type": "Int",
-          "hasDefaultValue": false,
-          "isGenerated": false,
-          "isUpdatedAt": false
+          "type": "Int"
         },
         {
           "name": "d",
           "kind": "scalar",
-          "isList": false,
           "isRequired": true,
-          "isUnique": false,
-          "isId": false,
-          "isReadOnly": false,
-          "type": "Int",
-          "hasDefaultValue": false,
-          "isGenerated": false,
-          "isUpdatedAt": false
+          "type": "Int"
         }
       ],
       "isGenerated": false,
       "primaryKey": {
         "name": "MyPrimary",
-        "fields": [
-          "a",
-          "b"
-        ]
+        "fields": ["a", "b"]
       },
-      "uniqueFields": [
-        [
-          "c",
-          "d"
-        ]
-      ],
+      "uniqueFields": [["c", "d"]],
       "uniqueIndexes": [
         {
           "name": "MyUnique",
-          "fields": [
-            "c",
-            "d"
-          ]
+          "fields": ["c", "d"]
         }
       ]
     },
@@ -694,28 +402,16 @@
         {
           "name": "a",
           "kind": "scalar",
-          "isList": false,
           "isRequired": true,
-          "isUnique": false,
           "isId": true,
-          "isReadOnly": false,
-          "type": "Int",
-          "hasDefaultValue": false,
-          "isGenerated": false,
-          "isUpdatedAt": false
+          "type": "Int"
         },
         {
           "name": "b",
           "kind": "scalar",
-          "isList": false,
           "isRequired": true,
           "isUnique": true,
-          "isId": false,
-          "isReadOnly": false,
-          "type": "Int",
-          "hasDefaultValue": false,
-          "isGenerated": false,
-          "isUpdatedAt": false
+          "type": "Int"
         }
       ],
       "isGenerated": false,

--- a/libs/datamodel/dmmf/tests/render_to_dmmf/files/ignore.json
+++ b/libs/datamodel/dmmf/tests/render_to_dmmf/files/ignore.json
@@ -8,38 +8,26 @@
         {
           "name": "id",
           "kind": "scalar",
-          "isList": false,
           "isRequired": true,
-          "isUnique": false,
           "isId": true,
-          "isReadOnly": false,
           "type": "Int",
           "hasDefaultValue": true,
           "default": {
             "name": "autoincrement",
             "args": []
-          },
-          "isGenerated": false,
-          "isUpdatedAt": false
+          }
         },
         {
           "name": "ip",
           "kind": "scalar",
-          "isList": false,
           "isRequired": true,
           "isUnique": true,
-          "isId": false,
-          "isReadOnly": false,
           "type": "Int",
           "hasDefaultValue": true,
           "default": {
             "name": "dbgenerated",
-            "args": [
-              "sqrt(4)"
-            ]
-          },
-          "isGenerated": false,
-          "isUpdatedAt": false
+            "args": ["sqrt(4)"]
+          }
         }
       ],
       "isGenerated": false,

--- a/libs/datamodel/dmmf/tests/render_to_dmmf/files/source_with_comments.json
+++ b/libs/datamodel/dmmf/tests/render_to_dmmf/files/source_with_comments.json
@@ -8,28 +8,14 @@
         {
           "name": "id",
           "kind": "scalar",
-          "isList": false,
           "isRequired": true,
-          "isUnique": false,
           "isId": true,
-          "isReadOnly": false,
-          "type": "Int",
-          "hasDefaultValue": false,
-          "isGenerated": false,
-          "isUpdatedAt": false
+          "type": "Int"
         },
         {
           "name": "name",
           "kind": "scalar",
-          "isList": false,
-          "isRequired": false,
-          "isUnique": false,
-          "isId": false,
-          "isReadOnly": false,
           "type": "String",
-          "hasDefaultValue": false,
-          "isGenerated": false,
-          "isUpdatedAt": false,
           "documentation": "Name of the author."
         }
       ],

--- a/libs/datamodel/dmmf/tests/render_to_dmmf/files/source_with_generator.json
+++ b/libs/datamodel/dmmf/tests/render_to_dmmf/files/source_with_generator.json
@@ -8,28 +8,14 @@
         {
           "name": "id",
           "kind": "scalar",
-          "isList": false,
           "isRequired": true,
-          "isUnique": false,
           "isId": true,
-          "isReadOnly": false,
-          "type": "Int",
-          "hasDefaultValue": false,
-          "isGenerated": false,
-          "isUpdatedAt": false
+          "type": "Int"
         },
         {
           "name": "name",
           "kind": "scalar",
-          "isList": false,
-          "isRequired": false,
-          "isUnique": false,
-          "isId": false,
-          "isReadOnly": false,
-          "type": "String",
-          "hasDefaultValue": false,
-          "isGenerated": false,
-          "isUpdatedAt": false
+          "type": "String"
         }
       ],
       "isGenerated": false,

--- a/libs/datamodel/dmmf/tests/render_to_dmmf/files/without_relation_name.json
+++ b/libs/datamodel/dmmf/tests/render_to_dmmf/files/without_relation_name.json
@@ -8,31 +8,19 @@
         {
           "name": "id",
           "kind": "scalar",
-          "isList": false,
           "isRequired": true,
-          "isUnique": false,
           "isId": true,
-          "isReadOnly": false,
-          "type": "Int",
-          "hasDefaultValue": false,
-          "isGenerated": false,
-          "isUpdatedAt": false
+          "type": "Int"
         },
         {
           "name": "posts",
           "kind": "object",
           "isList": true,
           "isRequired": true,
-          "isUnique": false,
-          "isId": false,
-          "isReadOnly": false,
           "type": "Post",
-          "hasDefaultValue": false,
           "relationName": "PostToUser",
           "relationFromFields": [],
-          "relationToFields": [],
-          "isGenerated": false,
-          "isUpdatedAt": false
+          "relationToFields": []
         }
       ],
       "isGenerated": false,
@@ -47,48 +35,25 @@
         {
           "name": "id",
           "kind": "scalar",
-          "isList": false,
           "isRequired": true,
-          "isUnique": false,
           "isId": true,
-          "isReadOnly": false,
-          "type": "Int",
-          "hasDefaultValue": false,
-          "isGenerated": false,
-          "isUpdatedAt": false
+          "type": "Int"
         },
         {
           "name": "userId",
           "kind": "scalar",
-          "isList": false,
           "isRequired": true,
-          "isUnique": false,
-          "isId": false,
           "isReadOnly": true,
-          "type": "Int",
-          "hasDefaultValue": false,
-          "isGenerated": false,
-          "isUpdatedAt": false
+          "type": "Int"
         },
         {
           "name": "user",
           "kind": "object",
-          "isList": false,
           "isRequired": true,
-          "isUnique": false,
-          "isId": false,
-          "isReadOnly": false,
           "type": "User",
-          "hasDefaultValue": false,
           "relationName": "PostToUser",
-          "relationFromFields": [
-            "userId"
-          ],
-          "relationToFields": [
-            "id"
-          ],
-          "isGenerated": false,
-          "isUpdatedAt": false
+          "relationFromFields": ["userId"],
+          "relationToFields": ["id"]
         }
       ],
       "isGenerated": false,

--- a/query-engine/request-handlers/src/dmmf/schema/ast.rs
+++ b/query-engine/request-handlers/src/dmmf/schema/ast.rs
@@ -2,6 +2,10 @@ use indexmap::IndexMap;
 use query_core::Deprecation;
 use serde::{Deserialize, Serialize};
 
+fn is_false(val: &bool) -> bool {
+    !(*val)
+}
+
 #[derive(Debug, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct DmmfSchema {
@@ -15,6 +19,7 @@ pub struct DmmfSchema {
 pub struct DmmfOutputField {
     pub name: String,
     pub args: Vec<DmmfInputField>,
+    #[serde(skip_serializing_if = "is_false")]
     pub is_nullable: bool,
     pub output_type: DmmfTypeReference,
 
@@ -48,7 +53,9 @@ pub struct DmmfOutputType {
 #[serde(rename_all = "camelCase")]
 pub struct DmmfInputField {
     pub name: String,
+    #[serde(skip_serializing_if = "is_false")]
     pub is_required: bool,
+    #[serde(skip_serializing_if = "is_false")]
     pub is_nullable: bool,
     pub input_types: Vec<DmmfTypeReference>,
 
@@ -65,6 +72,7 @@ pub struct DmmfTypeReference {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub namespace: Option<String>,
     pub location: TypeLocation,
+    #[serde(skip_serializing_if = "is_false")]
     pub is_list: bool,
 }
 


### PR DESCRIPTION
## Motivation

Shrink the size of DMMF JSON by making implicit what is currently explicit. Assume non-present values are false.

See: https://github.com/prisma/prisma/issues/10724#issuecomment-1073741619 

c.f. https://github.com/prisma/prisma/pull/12454