### PR TITLE
MySQL: Do not introspect things we cannot see

### DIFF
--- a/introspection-engine/introspection-engine-tests/Cargo.toml
+++ b/introspection-engine/introspection-engine-tests/Cargo.toml
@@ -26,6 +26,7 @@ serde_json = { version = "1.0", features = ["float_roundtrip"] }
 tracing = "0.1"
 indoc = "1"
 expect-test = "1.1.0"
+url = "2"
 
 [dependencies.barrel]
 git = "https://github.com/prisma/barrel.git"

--- a/introspection-engine/introspection-engine-tests/src/test_api.rs
+++ b/introspection-engine/introspection-engine-tests/src/test_api.rs
@@ -93,6 +93,10 @@ impl TestApi {
         }
     }
 
+    pub fn connection_string(&self) -> &str {
+        &self.connection_string
+    }
+
     pub async fn list_databases(&self) -> Result<Vec<String>> {
         Ok(self.api.list_databases().await?)
     }

--- a/migration-engine/migration-engine-tests/tests/migrations/soft_resets.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/soft_resets.rs
@@ -235,7 +235,7 @@ fn soft_resets_work_on_mysql(api: TestApi) {
             r#"
             DROP USER IF EXISTS 'softresetstestuser'@'%';
             CREATE USER 'softresetstestuser'@'%' IDENTIFIED BY '1234batman';
-            GRANT USAGE, CREATE ON TABLE `{0}`.* TO 'softresetstestuser'@'%';
+            GRANT SELECT, USAGE, CREATE ON TABLE `{0}`.* TO 'softresetstestuser'@'%';
             GRANT DROP ON TABLE `{0}`.`Cat` TO 'softresetstestuser'@'%';
             GRANT DROP ON TABLE `{0}`.`_prisma_migrations` TO 'softresetstestuser'@'%';
             FLUSH PRIVILEGES;


### PR DESCRIPTION
If the user doesn't have `SELECT` grant, you can list table names and indices,
but the table columns will return nothing. If this is the case, we should not
add tables or indices to the datamodel, because it's an inconsistent state that
leads to panics.

This fixes the so called `STATE ERROR BOOP` issue.

Closes: https://github.com/prisma/prisma/issues/12259
Closes: https://github.com/prisma/prisma/issues/10454
Closes: https://github.com/prisma/prisma/issues/10577
Closes: https://github.com/prisma/prisma/issues/12033
Closes: https://github.com/prisma/prisma/issues/9546
Closes: https://github.com/prisma/prisma/issues/9791
Closes: https://github.com/prisma/prisma/issues/12261 