### PR TITLE
fix(mongo): don't panic when counting empty result

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/count.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/count.rs
@@ -72,6 +72,16 @@ mod aggregation_count {
         Ok(())
     }
 
+    #[connector_test]
+    async fn count_empty_result(runner: Runner) -> TestResult<()> {
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{ aggregateTestModel { _count { _all string int } } }"#),
+          @r###"{"data":{"aggregateTestModel":{"_count":{"_all":0,"string":0,"int":0}}}}"###
+        );
+
+        Ok(())
+    }
+
     async fn create_row(runner: &Runner, data: &str) -> TestResult<()> {
         runner
             .query(format!("mutation {{ createOneTestModel(data: {}) {{ id }} }}", data))

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/count.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/count.rs
@@ -79,6 +79,11 @@ mod aggregation_count {
           @r###"{"data":{"aggregateTestModel":{"_count":{"_all":0,"string":0,"int":0}}}}"###
         );
 
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{ aggregateTestModel { _count { string _all int } } }"#),
+          @r###"{"data":{"aggregateTestModel":{"_count":{"string":0,"_all":0,"int":0}}}}"###
+        );
+
         Ok(())
     }
 

--- a/query-engine/connectors/mongodb-query-connector/src/root_queries/aggregate.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/root_queries/aggregate.rs
@@ -41,10 +41,10 @@ fn empty_aggregation(selections: Vec<AggregationSelection>) -> Vec<AggregationRo
             AggregationSelection::Count { all, fields } => {
                 if *all {
                     row.push(AggregationResult::Count(None, PrismaValue::Int(0)));
-                } else {
-                    for field in fields {
-                        row.push(AggregationResult::Count(Some(field.clone()), PrismaValue::Int(0)));
-                    }
+                }
+
+                for field in fields {
+                    row.push(AggregationResult::Count(Some(field.clone()), PrismaValue::Int(0)));
                 }
             }
             AggregationSelection::Average(fields) => {


### PR DESCRIPTION
## Overview

fixes https://github.com/prisma/prisma-engines/issues/2800

When `_all` was selected, none of the other aggregation result were pushed (because of the if/else).
Therefore, the serialization layer couldn't find some result for some of the selected aggregations.