### PR TITLE
Add debug-panic command to prisma-fmt

### DIFF
--- a/prisma-fmt/src/main.rs
+++ b/prisma-fmt/src/main.rs
@@ -39,10 +39,13 @@ pub enum FmtOpts {
     ReferentialActions,
     /// Specifies preview features mode
     PreviewFeatures,
+    /// Artificially panic (for testing the CLI)
+    DebugPanic,
 }
 
 fn main() {
     match FmtOpts::from_args() {
+        FmtOpts::DebugPanic => panic!("This is the debugPanic artificial panic"),
         FmtOpts::Lint => plug(lint::run),
         FmtOpts::Format(opts) => format::run(opts),
         FmtOpts::NativeTypes => plug(native::run),


### PR DESCRIPTION
Same as basically everywhere else (ME, IE, prisma-fmt-wasm)

![2022-03-28_09-03-58](https://user-images.githubusercontent.com/13155277/160350732-86ad5bbe-e553-41fa-8a01-876c1b670d10.png)
