### PR TITLE
fix(qe) itx deadlocks on SELECT FOR UPDATE

### DIFF
--- a/query-engine/core/src/interactive_transactions/actors.rs
+++ b/query-engine/core/src/interactive_transactions/actors.rs
@@ -149,6 +149,7 @@ impl ITXServer {
     }
 }
 
+#[derive(Clone)]
 pub struct ITXClient {
     send: Sender<TxOpRequest>,
     tx_id: TxId,


### PR DESCRIPTION
Interactive transactions can deadlock when a transaction contains a SELECT .. FOR UPDATE.
A SELECT ... FOR UPDATE causes that row to be locked and all other transactions will wait for
it to be unlocked before continuing.

To detail how this causes a deadlock. Consider a simplified example with 3 transactions starting immediately with the first query for each tx being a SELECT ... FOR UPDATE.
Tx1 will be created, an ITX Client will be added to the RwLock for it and it will start to execute its operations.
Tx2 will start up. Tx2 will try to perform a SELECT ... FOR UPDATE and then will block on that query until Tx1 completes.
Tx3 will try to start up. It will spawn an ITXServer and create an ITXClient that will then need to be added to the list of clients. It will need a write lock on our RwLock. It will sit waiting for that.
At this point Tx1 will finish its transaction and will want to COMMIT. To Commit it will need to take a new read lock on the RwLock containing all ITXClients. Because there are already a Read and Write locks waiting in the queue to access the ITXClient list, it has to wait. And since it cannot commit, it cannot release the SELECT ... FOR UPDATE lock for that row. So all transactions are now completely deadlocked.

The fix for this is to reduce the time we hold a read lock of an ITXClient. Previously we held the RWLock for the whole time an ITX operation was run. We don't need to do that. We get the ITXClient from the list, clone it, because all we actually need for an operation is the `send` channel to the ITXServer.

This cleans up our code and fixes the deadlock.

**NOTE** It was really hard to write a test for this in the query engine tests. I've written a test in the Prisma Client https://github.com/prisma/prisma/pull/12563 to demonstrate this is fixed. 