### PR TITLE
fix(mongo): having filter w/o selection should work

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/group_by_having.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/group_by_having.rs
@@ -346,6 +346,8 @@ mod aggr_group_by_having {
           }"#),
           @r###"{"data":{"groupByTestModel":[{"string":"group1","_count":{"string":2}}]}}"###
         );
+
+        Ok(())
     }
 
     async fn having_without_aggr_sel(runner: Runner) -> TestResult<()> {

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/group_by_having.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/group_by_having.rs
@@ -351,17 +351,17 @@ mod aggr_group_by_having {
     async fn having_without_aggr_sel(runner: Runner) -> TestResult<()> {
         create_row(
             &runner,
-            r#"{ id: 1, float: 10, int: 10, decimal: "10", string: "group1" }"#,
+            r#"{ id: 1, float: 10, int: 10, string: "group1" }"#,
         )
         .await?;
         create_row(
             &runner,
-            r#"{ id: 2, float: 0, int: 0, decimal: "0", string: "group1" }"#,
+            r#"{ id: 2, float: 0, int: 0, string: "group1" }"#,
         )
         .await?;
         create_row(
             &runner,
-            r#"{ id: 3, float: 10, int: 10, decimal: "10", string: "group2" }"#,
+            r#"{ id: 3, float: 10, int: 10, string: "group2" }"#,
         )
         .await?;
         create_row(&runner, r#"{ id: 4, string: "group2" }"#).await?;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/group_by_having.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/group_by_having.rs
@@ -376,12 +376,10 @@ mod aggr_group_by_having {
               having: { int: { _max: { gt: 1 } } }
             ) { string }
           }"#,
-          // Result order is not deterministic on MongoDB
-          MongoDb(_) => vec![
+          _ => vec![
             r#"{"data":{"groupByTestModel":[{"string":"group1"},{"string":"group2"}]}}"#,
             r#"{"data":{"groupByTestModel":[{"string":"group2"},{"string":"group1"}]}}"#,
-          ],
-          _ => vec![r#"{"data":{"groupByTestModel":[{"string":"group2"},{"string":"group1"}]}}"#]
+          ]
         );
 
         match_connector_result!(
@@ -394,12 +392,10 @@ mod aggr_group_by_having {
               }
             ) { string }
           }"#,
-          // Result order is not deterministic on MongoDB
-          MongoDb(_) => vec![
+          _ => vec![
             r#"{"data":{"groupByTestModel":[{"string":"group1"},{"string":"group2"}]}}"#,
             r#"{"data":{"groupByTestModel":[{"string":"group2"},{"string":"group1"}]}}"#,
-          ],
-          _ => vec![r#"{"data":{"groupByTestModel":[{"string":"group2"},{"string":"group1"}]}}"#]
+          ]
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/group_by_having.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/group_by_having.rs
@@ -7,7 +7,7 @@ use query_engine_tests::*;
 // - We don't need to check every single filter operation, as it's ultimately the same code path just with different
 //   operators applied. For a good confidence, we choose `equals`, `in`, `not equals`, `endsWith` (where applicable).
 #[test_suite(schema(schemas::common_text_and_numeric_types_optional))]
-mod aggregation_group_by_having {
+mod aggr_group_by_having {
     use query_engine_tests::{assert_error, match_connector_result, run_query, Runner};
 
     // This is just basic confirmation that scalar filters are applied correctly.
@@ -345,6 +345,61 @@ mod aggregation_group_by_having {
             ) { string _count { string } }
           }"#),
           @r###"{"data":{"groupByTestModel":[{"string":"group1","_count":{"string":2}}]}}"###
+        );
+    }
+
+    async fn having_without_aggr_sel(runner: Runner) -> TestResult<()> {
+        create_row(
+            &runner,
+            r#"{ id: 1, float: 10, int: 10, decimal: "10", string: "group1" }"#,
+        )
+        .await?;
+        create_row(
+            &runner,
+            r#"{ id: 2, float: 0, int: 0, decimal: "0", string: "group1" }"#,
+        )
+        .await?;
+        create_row(
+            &runner,
+            r#"{ id: 3, float: 10, int: 10, decimal: "10", string: "group2" }"#,
+        )
+        .await?;
+        create_row(&runner, r#"{ id: 4, string: "group2" }"#).await?;
+        create_row(&runner, r#"{ id: 5, string: "group3" }"#).await?;
+        create_row(&runner, r#"{ id: 6, string: "group3" }"#).await?;
+
+        match_connector_result!(
+          &runner,
+          r#"{
+            groupByTestModel(
+              by: [string],
+              having: { int: { _max: { gt: 1 } } }
+            ) { string }
+          }"#,
+          // Result order is not deterministic on MongoDB
+          MongoDb(_) => vec![
+            r#"{"data":{"groupByTestModel":[{"string":"group1"},{"string":"group2"}]}}"#,
+            r#"{"data":{"groupByTestModel":[{"string":"group2"},{"string":"group1"}]}}"#,
+          ],
+          _ => vec![r#"{"data":{"groupByTestModel":[{"string":"group2"},{"string":"group1"}]}}"#]
+        );
+
+        match_connector_result!(
+          &runner,
+          r#"{
+            groupByTestModel(
+              by: [string]
+              having: {
+                AND: [{ int: { _max: { gt: 1 } } }, { decimal: { _sum: { gt: 1 } } }]
+              }
+            ) { string }
+          }"#,
+          // Result order is not deterministic on MongoDB
+          MongoDb(_) => vec![
+            r#"{"data":{"groupByTestModel":[{"string":"group1"},{"string":"group2"}]}}"#,
+            r#"{"data":{"groupByTestModel":[{"string":"group2"},{"string":"group1"}]}}"#,
+          ],
+          _ => vec![r#"{"data":{"groupByTestModel":[{"string":"group2"},{"string":"group1"}]}}"#]
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/group_by_having.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/group_by_having.rs
@@ -349,21 +349,9 @@ mod aggr_group_by_having {
     }
 
     async fn having_without_aggr_sel(runner: Runner) -> TestResult<()> {
-        create_row(
-            &runner,
-            r#"{ id: 1, float: 10, int: 10, string: "group1" }"#,
-        )
-        .await?;
-        create_row(
-            &runner,
-            r#"{ id: 2, float: 0, int: 0, string: "group1" }"#,
-        )
-        .await?;
-        create_row(
-            &runner,
-            r#"{ id: 3, float: 10, int: 10, string: "group2" }"#,
-        )
-        .await?;
+        create_row(&runner, r#"{ id: 1, float: 10, int: 10, string: "group1" }"#).await?;
+        create_row(&runner, r#"{ id: 2, float: 0, int: 0, string: "group1" }"#).await?;
+        create_row(&runner, r#"{ id: 3, float: 10, int: 10, string: "group2" }"#).await?;
         create_row(&runner, r#"{ id: 4, string: "group2" }"#).await?;
         create_row(&runner, r#"{ id: 5, string: "group3" }"#).await?;
         create_row(&runner, r#"{ id: 6, string: "group3" }"#).await?;

--- a/query-engine/connectors/mongodb-query-connector/src/query_builder/group_by_builder.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/query_builder/group_by_builder.rs
@@ -46,7 +46,7 @@ impl GroupByBuilder {
         let mut project_stage = doc! {};
 
         if self.count_all {
-            group_stage.insert("count_all", doc! { "$sum": Bson::Int32(1) });
+            group_stage.insert("count_all", doc! { "$sum": 1 });
             project_stage.extend(projection_doc("count_all"));
         }
 
@@ -98,7 +98,7 @@ impl GroupByBuilder {
         }
     }
 
-    /// Derives some `AggregationSelection` into some aggregated groupings.
+    /// Derives aggregated groupings from an `AggregationSelection`.
     pub fn with_selections(&mut self, selections: &[AggregationSelection]) {
         for selection in selections {
             match selection {
@@ -126,7 +126,9 @@ impl GroupByBuilder {
         }
     }
 
-    /// Derives a having `Filter` into some aggregated groupings so the filter can be matched against something.
+    /// Derives aggregated groupings from a having `Filter`.
+    /// Required because the filter needs to match against a grouping,
+    /// which is not present if no aggregation selection is made but an aggregation filter is used.
     pub fn with_having_filter(&mut self, having: &Filter) {
         let mut unfold_filters = |filters: &Vec<Filter>| {
             for filter in filters {
@@ -213,5 +215,5 @@ fn count_field_pair(field: &ScalarFieldRef) -> (String, Bson) {
 /// Produces a document that projects a field.
 /// Important: Only valid for non-count aggregations.
 fn projection_doc(key: &str) -> Document {
-    doc! { key: Bson::Int32(1) }
+    doc! { key: 1 }
 }

--- a/query-engine/connectors/mongodb-query-connector/src/query_builder/group_by_builder.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/query_builder/group_by_builder.rs
@@ -1,0 +1,217 @@
+use connector_interface::{AggregationSelection, Filter, ScalarProjection};
+use mongodb::bson::{doc, Bson, Document};
+use prisma_models::ScalarFieldRef;
+use std::collections::HashSet;
+
+/// Represents a `$group` aggregation stage.
+/// Groupings can be generated either from some `AggregationSelection` or a having `Filter`.
+#[derive(Debug, Default)]
+pub struct GroupByBuilder {
+    /// A set of all aggregated fields.
+    aggregations: HashSet<(ScalarFieldRef, AggregationType)>,
+    /// Whether we need to group by count(*).
+    count_all: bool,
+}
+
+/// A generic aggregation type that abstracts selections & filter aggregations.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+enum AggregationType {
+    Count,
+    Min,
+    Max,
+    Sum,
+    Average,
+}
+
+impl GroupByBuilder {
+    pub fn new() -> Self {
+        Self { ..Default::default() }
+    }
+
+    pub fn render(&self, by_fields: Vec<ScalarFieldRef>) -> (Document, Option<Document>) {
+        let grouping = if by_fields.is_empty() {
+            Bson::Null // Null => group over the entire collection.
+        } else {
+            let mut group_doc = Document::new();
+
+            for field in by_fields {
+                group_doc.insert(field.db_name(), format!("${}", field.db_name()));
+            }
+
+            group_doc.into()
+        };
+
+        let mut group_stage = doc! { "_id": grouping };
+        // Needed for field-count aggregations
+        let mut project_stage = doc! {};
+
+        if self.count_all {
+            group_stage.insert("count_all", doc! { "$sum": Bson::Int32(1) });
+            project_stage.extend(projection_doc("count_all"));
+        }
+
+        for (sf, aggr_type) in &self.aggregations {
+            match aggr_type {
+                AggregationType::Count => {
+                    // MongoDB requires a different construct for counting on fields.
+                    // First, we push them into an array and then, in a separate project stage,
+                    // we count the number of items in the array.
+                    let push_pair = aggregation_pair("push", sf);
+                    let (count_key, count_val) = count_field_pair(sf);
+
+                    project_stage.insert(&count_key, doc! { "$sum": format!("${}", &count_key) });
+
+                    group_stage.insert(push_pair.0, push_pair.1);
+                    group_stage.insert(count_key, count_val);
+                }
+                AggregationType::Min => {
+                    let (k, v) = aggregation_pair("min", sf);
+
+                    project_stage.extend(projection_doc(&k));
+                    group_stage.insert(k, v);
+                }
+                AggregationType::Max => {
+                    let (k, v) = aggregation_pair("max", sf);
+
+                    project_stage.extend(projection_doc(&k));
+                    group_stage.insert(k, v);
+                }
+                AggregationType::Sum => {
+                    let (k, v) = aggregation_pair("sum", sf);
+
+                    project_stage.extend(projection_doc(&k));
+                    group_stage.insert(k, v);
+                }
+                AggregationType::Average => {
+                    let (k, v) = aggregation_pair("avg", sf);
+
+                    project_stage.extend(projection_doc(&k));
+                    group_stage.insert(k, v);
+                }
+            }
+        }
+
+        if self.requires_projection() {
+            (group_stage, Some(project_stage))
+        } else {
+            (group_stage, None)
+        }
+    }
+
+    /// Derives some `AggregationSelection` into some aggregated groupings.
+    pub fn with_selections(&mut self, selections: &[AggregationSelection]) {
+        for selection in selections {
+            match selection {
+                AggregationSelection::Count { all, fields } => {
+                    if *all {
+                        self.count_all = true;
+                    }
+
+                    self.insert_groupings(fields, AggregationType::Count);
+                }
+                AggregationSelection::Average(fields) => {
+                    self.insert_groupings(fields, AggregationType::Average);
+                }
+                AggregationSelection::Sum(fields) => {
+                    self.insert_groupings(fields, AggregationType::Sum);
+                }
+                AggregationSelection::Min(fields) => {
+                    self.insert_groupings(fields, AggregationType::Min);
+                }
+                AggregationSelection::Max(fields) => {
+                    self.insert_groupings(fields, AggregationType::Max);
+                }
+                AggregationSelection::Field(_) => (),
+            }
+        }
+    }
+
+    /// Derives a having `Filter` into some aggregated groupings so the filter can be matched against something.
+    pub fn with_having_filter(&mut self, having: &Filter) {
+        let mut unfold_filters = |filters: &Vec<Filter>| {
+            for filter in filters {
+                self.with_having_filter(filter);
+            }
+        };
+
+        match having {
+            Filter::And(filters) => {
+                unfold_filters(filters);
+            }
+            Filter::Or(filters) => {
+                unfold_filters(filters);
+            }
+            Filter::Not(filters) => {
+                unfold_filters(filters);
+            }
+            Filter::Aggregation(aggregation) => match aggregation {
+                connector_interface::AggregationFilter::Count(filter) => {
+                    self.insert_from_filter(filter.as_ref(), AggregationType::Count);
+                }
+                connector_interface::AggregationFilter::Average(filter) => {
+                    self.insert_from_filter(filter.as_ref(), AggregationType::Average);
+                }
+                connector_interface::AggregationFilter::Sum(filter) => {
+                    self.insert_from_filter(filter.as_ref(), AggregationType::Sum);
+                }
+                connector_interface::AggregationFilter::Min(filter) => {
+                    self.insert_from_filter(filter.as_ref(), AggregationType::Min);
+                }
+                connector_interface::AggregationFilter::Max(filter) => {
+                    self.insert_from_filter(filter.as_ref(), AggregationType::Max);
+                }
+            },
+            _ => (),
+        }
+    }
+
+    fn requires_projection(&self) -> bool {
+        self.aggregations
+            .iter()
+            .any(|(_, aggr_type)| matches!(aggr_type, AggregationType::Count))
+    }
+
+    fn insert_from_filter(&mut self, filter: &Filter, aggregation_type: AggregationType) {
+        let scalar_filter = filter.as_scalar().unwrap();
+        let field = match &scalar_filter.projection {
+            ScalarProjection::Single(sf) => sf,
+            _ => unreachable!(),
+        };
+
+        self.insert_grouping(field, &aggregation_type);
+    }
+
+    fn insert_groupings(&mut self, fields: &[ScalarFieldRef], aggregation_type: AggregationType) {
+        for field in fields {
+            self.insert_grouping(field, &aggregation_type)
+        }
+    }
+
+    fn insert_grouping(&mut self, field: &ScalarFieldRef, aggregation_type: &AggregationType) {
+        self.aggregations.insert((field.clone(), aggregation_type.clone()));
+    }
+}
+
+/// Produces pair like `("sum_fieldName", { "$sum": "$fieldName" })`.
+/// Important: Only valid for non-count aggregations.
+fn aggregation_pair(op: &str, field: &ScalarFieldRef) -> (String, Bson) {
+    (
+        format!("{}_{}", op, field.db_name()),
+        doc! { format!("${}", op): format!("${}", field.db_name()) }.into(),
+    )
+}
+
+/// Produces pair like `("count_fieldName", { "$sum": "$fieldName" })`.
+/// Important: Only valid for field-level count aggregations.
+fn count_field_pair(field: &ScalarFieldRef) -> (String, Bson) {
+    (
+        format!("count_{}", field.db_name()),
+        doc! { "$push": { "$cond": { "if": format!("${}", field.db_name()), "then": 1, "else": 0 }}}.into(),
+    )
+}
+
+/// Produces a document that projects a field.
+/// Important: Only valid for non-count aggregations.
+fn projection_doc(key: &str) -> Document {
+    doc! { key: Bson::Int32(1) }
+}

--- a/query-engine/connectors/mongodb-query-connector/src/query_builder/mod.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/query_builder/mod.rs
@@ -1,3 +1,4 @@
+mod group_by_builder;
 mod read_query_builder;
 
 pub use read_query_builder::*;

--- a/query-engine/connectors/mongodb-query-connector/src/root_queries/aggregate.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/root_queries/aggregate.rs
@@ -14,9 +14,9 @@ pub async fn aggregate<'conn>(
 ) -> crate::Result<Vec<AggregationRow>> {
     let is_group_by = !group_by.is_empty();
     let coll = database.collection(&model.db_name());
+
     let query = MongoReadQueryBuilder::from_args(query_arguments)?
-        .with_groupings(group_by, &selections)
-        .with_having(having)?
+        .with_groupings(group_by, &selections, having)?
         .build()?;
 
     let docs = query.execute(coll, session).await?;

--- a/query-engine/connectors/query-connector/src/filter/mod.rs
+++ b/query-engine/connectors/query-connector/src/filter/mod.rs
@@ -173,6 +173,14 @@ impl Filter {
     pub fn max(condition: Filter) -> Self {
         Self::Aggregation(AggregationFilter::Max(Box::new(condition)))
     }
+
+    pub fn as_scalar(&self) -> Option<&ScalarFilter> {
+        if let Self::Scalar(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
 }
 
 impl From<ScalarFilter> for Filter {


### PR DESCRIPTION
## Overview

fixes https://github.com/prisma/prisma-engines/issues/2768

Prior to this PR, the `$group` aggregation stage needed for having filters to work was only rendered from aggregation selections. This meant that without aggregation selections, a `having` filter would match against undefined values.

This changes by also deriving having filters to some MongoDB groupings. The main logic is shared with aggregation selections.