### PR TITLE
Specify ownership of libs/datamodel in CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,6 +2,7 @@
 
 /introspection-engine @prisma/schema-team
 
+/libs/datamodel @prisma/schema-team
 /libs/json-rpc-stdio @prisma/schema-team
 /libs/sql-ddl @prisma/schema-team
 /libs/sql-schema-describer @prisma/schema-team


### PR DESCRIPTION
This has been formalized internally, let's reflect this in the repo configuration.