### PR TITLE
reformatting: Fix spacing between attributes in edge cases

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -46,11 +46,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1648434893,
-        "narHash": "sha256-rTpgRsgIeCYY4e4Qj+gMT1H80E0f7ITNyseOaPSiyrM=",
+        "lastModified": 1649385338,
+        "narHash": "sha256-N6CgWq5bXN49OM6A4GmbjwsISxeYLIS3W89XJiqYyik=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "d477108aefccc46e4b7acc8008f03d4e823da7b0",
+        "rev": "f7d4a3aabee883bfa4d8987a19446ca8f25df81f",
         "type": "github"
       },
       "original": {

--- a/introspection-engine/connectors/sql-introspection-connector/src/lib.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::vec_init_then_push)]
+#![allow(clippy::ptr_arg)] // remove after https://github.com/rust-lang/rust-clippy/issues/8482 is fixed and shipped
 
 pub mod calculate_datamodel; // only exported to be able to unit test it
 

--- a/libs/datamodel/core/tests/reformat/reformat.rs
+++ b/libs/datamodel/core/tests/reformat/reformat.rs
@@ -1334,3 +1334,77 @@ fn composite_type_native_types_roundtrip() {
 
     expected.assert_eq(&reformat(schema));
 }
+
+#[test]
+fn added_missing_at_unique_attribute_with_existing_native_type() {
+    let schema = r#"
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = "mongodb"
+}
+
+datasource db {
+  provider = "mongodb"
+  url      = "m...ty"
+}
+
+model Foo {
+  id       String   @id @default(auto()) @map("_id") @db.ObjectId
+  name     String   @unique
+  json     Json
+  bar      Bar
+  bars     Bar[]
+  baz      Baz      @relation(fields: [bazId], references: [id])
+  bazId    String   @db.ObjectId
+  list     String[]
+  jsonList Json[]
+}
+
+type Bar {
+  label  String
+  number Int
+}
+
+model Baz {
+  id  String @id @default(auto()) @map("_id") @db.ObjectId
+  foo Foo?
+}
+
+    "#;
+
+    let expected = expect![[r#"
+        generator client {
+          provider        = "prisma-client-js"
+          previewFeatures = "mongodb"
+        }
+
+        datasource db {
+          provider = "mongodb"
+          url      = "m...ty"
+        }
+
+        model Foo {
+          id       String   @id @default(auto()) @map("_id") @db.ObjectId
+          name     String   @unique
+          json     Json
+          bar      Bar
+          bars     Bar[]
+          baz      Baz      @relation(fields: [bazId], references: [id])
+          bazId    String   @db.ObjectId @unique
+          list     String[]
+          jsonList Json[]
+        }
+
+        type Bar {
+          label  String
+          number Int
+        }
+
+        model Baz {
+          id  String @id @default(auto()) @map("_id") @db.ObjectId
+          foo Foo?
+        }
+    "#]];
+
+    expected.assert_eq(&reformat(schema));
+}

--- a/libs/datamodel/parser-database/src/relations.rs
+++ b/libs/datamodel/parser-database/src/relations.rs
@@ -95,6 +95,7 @@ impl Relations {
 
     /// Iterator over relations where the provided model is model A, or the forward side of the
     /// relation.
+    #[allow(clippy::wrong_self_convention)] // this is the name we want
     pub(crate) fn from_model(&self, model_a_id: ast::ModelId) -> impl Iterator<Item = RelationId> + '_ {
         self.forward
             .range((model_a_id, ast::ModelId::ZERO, RelationId::MIN)..(model_a_id, ast::ModelId::MAX, RelationId::MAX))

--- a/libs/datamodel/schema-ast/src/renderer.rs
+++ b/libs/datamodel/schema-ast/src/renderer.rs
@@ -467,7 +467,6 @@ impl<'a> Renderer<'a> {
 impl<'a> LineWriteable for Renderer<'a> {
     fn write(&mut self, param: &str) {
         self.is_new = false;
-        // TODO: Proper result handling.
         if self.new_line > 0 || self.maybe_new_line > 0 {
             for _i in 0..std::cmp::max(self.new_line, self.maybe_new_line) {
                 self.stream.write_char('\n').expect("Writer error.");

--- a/libs/datamodel/schema-ast/src/renderer/table.rs
+++ b/libs/datamodel/schema-ast/src/renderer/table.rs
@@ -84,7 +84,7 @@ impl TableFormat {
                 if row[index].is_empty() {
                     row[index] = String::from(text);
                 } else {
-                    row[index] = format!("{}{}", &row[index], text);
+                    row[index].push_str(text);
                 }
             }
             Row::Interleaved(_) => panic!("Cannot append to col in interleaved mode"),

--- a/libs/prisma-inflector/src/inflector.rs
+++ b/libs/prisma-inflector/src/inflector.rs
@@ -125,12 +125,7 @@ impl Inflector {
         // Rules are all 1-byte characters, so we can use slices.
         if first_singular == first_plural {
             vec![Rule::regex(
-                Regex::new(&format!(
-                    "(?i)({}){}$",
-                    first_singular.to_owned(),
-                    singular[1..].to_owned()
-                ))
-                .unwrap(),
+                Regex::new(&format!("(?i)({}){}$", first_singular, singular[1..].to_owned())).unwrap(),
                 format!("${{1}}{}", plural[1..].to_owned()),
             )]
         } else {

--- a/migration-engine/connectors/sql-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/lib.rs
@@ -3,6 +3,7 @@
 #![deny(rust_2018_idioms, unsafe_code, missing_docs)]
 #![allow(clippy::trivial_regex)] // these will grow
 #![allow(clippy::redundant_closure)] // too eager, sometimes wrong
+#![allow(clippy::ptr_arg)] // remove after https://github.com/rust-lang/rust-clippy/issues/8482 is fixed and shipped
 
 mod apply_migration;
 mod connection_wrapper;

--- a/query-engine/connectors/mongodb-query-connector/src/query_builder/read_query_builder.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/query_builder/read_query_builder.rs
@@ -54,7 +54,7 @@ impl PipelineQuery {
             .aggregate_with_session(self.stages, opts, with_session)
             .await?;
 
-        Ok(vacuum_cursor(cursor, with_session).await?)
+        vacuum_cursor(cursor, with_session).await
     }
 }
 
@@ -73,7 +73,7 @@ impl FindQuery {
             .find_with_session(self.filter, self.options, with_session)
             .await?;
 
-        Ok(vacuum_cursor(cursor, with_session).await?)
+        vacuum_cursor(cursor, with_session).await
     }
 }
 


### PR DESCRIPTION
In 1:1 relations, the reformatter can add `@unique` attributes. If they
come after a native type attribute, the reformatter failed to add
adequate spacing between the attributes, resulting in valid but odd
looking schemas. This commit fixes that problem.

These schemas are also not idempotent, because of interactions between
attribute sorting and missing attributes addition. Issue:
https://github.com/prisma/prisma/issues/12726

closes https://github.com/prisma/prisma/issues/12596