### PR TITLE
migrate-diff: error on non-existing sqlite database

### DIFF
--- a/libs/datamodel/core/src/transform/dml_to_ast/generator_serializer.rs
+++ b/libs/datamodel/core/src/transform/dml_to_ast/generator_serializer.rs
@@ -24,7 +24,7 @@ impl GeneratorSerializer {
             properties.push(super::lower_string_from_env_var("output", output));
         }
 
-        if let Some(ref features) = dbg!(&generator.preview_features) {
+        if let Some(ref features) = &generator.preview_features {
             let features: Vec<ast::Expression> = features
                 .iter()
                 .map(|f| ast::Expression::StringValue(f.to_string(), ast::Span::empty()))

--- a/libs/user-facing-errors/src/quaint.rs
+++ b/libs/user-facing-errors/src/quaint.rs
@@ -38,14 +38,8 @@ pub fn invalid_connection_string_description(error_details: &str) -> String {
 
 pub fn render_quaint_error(kind: &ErrorKind, connection_info: &ConnectionInfo) -> Option<KnownError> {
     match (kind, connection_info) {
-        (ErrorKind::DatabaseDoesNotExist { .. }, ConnectionInfo::Sqlite { file_path, .. }) => {
-            Some(KnownError::new(common::DatabaseDoesNotExist::Sqlite {
-                database_file_path: file_path.clone(),
-                database_file_name: std::path::Path::new(file_path)
-                    .file_name()
-                    .map(|osstr| osstr.to_string_lossy().into_owned())
-                    .unwrap_or_else(|| file_path.clone()),
-            }))
+        (ErrorKind::DatabaseDoesNotExist { .. }, ConnectionInfo::Sqlite { .. }) => {
+            unreachable!(); // quaint implicitly creates sqlite databases
         }
 
         (ErrorKind::DatabaseDoesNotExist { db_name }, ConnectionInfo::Postgres(url)) => {

--- a/migration-engine/cli/tests/cli_tests.rs
+++ b/migration-engine/cli/tests/cli_tests.rs
@@ -131,7 +131,6 @@ fn test_create_database(api: TestApi) {
     assert!(output.status.success(), "{:#?}", output);
 
     let output = api.run(&["--datasource", &connection_string, "create-database"]);
-    dbg!(&output);
     assert!(output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("Database 'test_create_database\' was successfully created."));

--- a/migration-engine/core/src/commands/diff.rs
+++ b/migration-engine/core/src/commands/diff.rs
@@ -81,6 +81,7 @@ async fn json_rpc_diff_target_to_connector(
             let schema_contents = read_prisma_schema_from_path(schema)?;
             let schema_dir = std::path::Path::new(schema).parent();
             let mut connector = crate::schema_to_connector(&schema_contents, schema_dir)?;
+            connector.ensure_connection_validity().await?;
             let schema = connector
                 .database_schema_from_diff_target(McDiff::Database, None)
                 .await?;
@@ -96,6 +97,7 @@ async fn json_rpc_diff_target_to_connector(
         }
         DiffTarget::Url(UrlContainer { url }) => {
             let mut connector = crate::connector_for_connection_string(url.clone(), None, BitFlags::empty())?;
+            connector.ensure_connection_validity().await?;
             let schema = connector
                 .database_schema_from_diff_target(McDiff::Database, None)
                 .await?;

--- a/migration-engine/migration-engine-tests/tests/migrations/jsonrpc.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/jsonrpc.rs
@@ -28,10 +28,9 @@ impl TestApi {
 #[test_connector(tags(Sqlite))]
 fn test_can_connect_to_database(mut api: TestApi) {
     let tempdir = tempfile::tempdir().unwrap();
-    let url = format!(
-        "file:{}",
-        tempdir.path().join("test.sqlite").to_string_lossy().into_owned()
-    );
+    let sqlite_schema_path = tempdir.path().join("test.sqlite");
+    std::fs::File::create(&sqlite_schema_path).unwrap();
+    let url = format!("file:{}", sqlite_schema_path.to_string_lossy().into_owned());
     let request = r#"
         {"jsonrpc":"2.0","id":1,"method":"ensureConnectionValidity","params":{"datasource":{"tag":"ConnectionString", "url": "theurl"}}}
     "#.replace("theurl", &url);


### PR DESCRIPTION
The default behaviour of the sqlite driver is to implicitly create the
database when we connect to it.

Given that

- db push has a database creation step
- implicit database creation is otherwise unexpected
- there is a stub of this for some commands in the TS code already
- we have more than enough time to QA changes we make today

This commit changes the sql migration connector so that whenever we
connect to a sqlite database, we return a P1003 (DatabaseDoesNotExist)
error if there is no file at the expected path.

closes prisma/prisma#12226