### PR TITLE
Bump Engineer to 1.37

### DIFF
--- a/.buildkite/engineer
+++ b/.buildkite/engineer
@@ -13,7 +13,7 @@ fi
 if ! type "engineer" > /dev/null; then
     # Setup Prisma engine build & test tool (engineer).
     set -e
-    curl --fail -sSL "https://prisma-engineer.s3-eu-west-1.amazonaws.com/1.36/latest/$OS/engineer.gz" --output engineer.gz
+    curl --fail -sSL "https://prisma-engineer.s3-eu-west-1.amazonaws.com/1.37/latest/$OS/engineer.gz" --output engineer.gz
     gzip -d engineer.gz
     chmod +x engineer
 


### PR DESCRIPTION
Adds useful output of the docker image digest at the beginning of the "Running commands" step: 
<img width="908" alt="image" src="https://user-images.githubusercontent.com/183673/163247809-b1b8edcb-0f43-47e6-9fc1-98ce7e299447.png">

Thanks @dpetrick 