### PR TITLE
ci: Fix CockroachDB connection string in migration-engine.yml

### DIFF
--- a/.github/workflows/migration-engine.yml
+++ b/.github/workflows/migration-engine.yml
@@ -88,7 +88,7 @@ jobs:
           - name: postgres14
             url: "postgresql://postgres:prisma@localhost:5437"
           - name: cockroach
-            url: "postgresql://root@localhost:26257"
+            url: "postgresql://prisma@localhost:26257"
           - name: sqlite
             url: sqlite
           - name: vitess_5_7


### PR DESCRIPTION
CockroachDB was using `root` that also works, but using `prisma` is better as that will only work when our [custom configuration](https://github.com/prisma/engine-images/blob/7ad194d787239fdb71d47c33cf464810c1c282f2/cockroach/prisma_init.sql) could be applied and is in use.