### PR TITLE
feat(qe): artificial panics for Query Engine

### DIFF
--- a/query-engine/query-engine/src/opt.rs
+++ b/query-engine/query-engine/src/opt.rs
@@ -23,15 +23,27 @@ pub struct ExecuteRequestInput {
 
 #[derive(Debug, Clone, StructOpt)]
 #[structopt(rename_all = "camelCase")]
+pub struct DmmfInput {
+    /// Artificially panic (for testing the CLI)
+    #[structopt(long)]
+    pub trigger_panic: bool,
+}
+
+#[derive(Debug, Clone, StructOpt)]
+#[structopt(rename_all = "camelCase")]
 pub struct GetConfigInput {
     #[structopt(long)]
     pub ignore_env_var_errors: bool,
+
+    /// Artificially panic (for testing the CLI)
+    #[structopt(long)]
+    pub trigger_panic: bool,
 }
 
 #[derive(Debug, StructOpt, Clone)]
 pub enum CliOpt {
     /// Output the DMMF from the loaded data model.
-    Dmmf,
+    Dmmf(DmmfInput),
     /// Get the configuration from the given data model.
     GetConfig(GetConfigInput),
     /// Executes one request and then terminates.


### PR DESCRIPTION
- Added support for `query-engine cli dmmf --triggerPanic`
- Added support for `query-engine cli get-config --triggerPanic`
- Closes https://github.com/prisma/prisma/issues/12494

TL/DR: before proceeding forward with the WASM-ification of part of the Rust codebase to be used in Prisma CLI, we need to make sure that the Rust's panics are properly captured and reported to our internal monitoring systems. Thus, we need to add ways of triggering artificial panics in Rust, and add tests in the TypeScript codebase to ensure those panics are properly handled.

Please see the [internal discussion](https://prisma-company.slack.com/archives/C02FNFLDUS3/p1650383326542629), and [these](https://github.com/prisma/prisma/issues/12495) [two](https://github.com/prisma/prisma/issues/12494) issues.