### PR TITLE
fix(me): Use CockroachType for native types on crdb

### DIFF
--- a/libs/sql-schema-describer/src/postgres.rs
+++ b/libs/sql-schema-describer/src/postgres.rs
@@ -4,7 +4,7 @@ use super::*;
 use crate::{getters::Getter, parsers::Parser};
 use enumflags2::BitFlags;
 use indoc::indoc;
-use native_types::{NativeType, PostgresType};
+use native_types::{CockroachType, NativeType, PostgresType};
 use quaint::{connector::ResultRow, prelude::Queryable};
 use regex::Regex;
 use serde_json::from_str;
@@ -321,7 +321,11 @@ impl<'a> SqlSchemaDescriber<'a> {
             };
 
             let data_type = col.get_expect_string("data_type");
-            let tpe = get_column_type(&col, enums);
+            let tpe = if self.is_cockroach() {
+                get_column_type_cockroachdb(&col, enums)
+            } else {
+                get_column_type_postgresql(&col, enums)
+            };
             let default = Self::get_default_value(&col, &data_type, &tpe, sequences, schema);
 
             let auto_increment = is_identity
@@ -838,7 +842,7 @@ impl<'a> SqlSchemaDescriber<'a> {
     }
 }
 
-fn get_column_type(row: &ResultRow, enums: &[Enum]) -> ColumnType {
+fn get_column_type_postgresql(row: &ResultRow, enums: &[Enum]) -> ColumnType {
     use ColumnTypeFamily::*;
     let data_type = row.get_expect_string("data_type");
     let full_data_type = row.get_expect_string("full_data_type");
@@ -905,6 +909,90 @@ fn get_column_type(row: &ResultRow, enums: &[Enum]) -> ColumnType {
         "tsvector" | "_tsvector" => unsupported_type(),
         "txid_snapshot" | "_txid_snapshot" => unsupported_type(),
         "inet" | "_inet" => (String, Some(PostgresType::Inet)),
+        //geometric
+        "box" | "_box" => unsupported_type(),
+        "circle" | "_circle" => unsupported_type(),
+        "line" | "_line" => unsupported_type(),
+        "lseg" | "_lseg" => unsupported_type(),
+        "path" | "_path" => unsupported_type(),
+        "polygon" | "_polygon" => unsupported_type(),
+        name if enum_exists(name) => (Enum(name.to_owned()), None),
+        _ => unsupported_type(),
+    };
+
+    ColumnType {
+        full_data_type,
+        family,
+        arity,
+        native_type: native_type.map(|x| x.to_json()),
+    }
+}
+
+// Separate from get_column_type_postgresql because of native types.
+fn get_column_type_cockroachdb(row: &ResultRow, enums: &[Enum]) -> ColumnType {
+    use ColumnTypeFamily::*;
+    let data_type = row.get_expect_string("data_type");
+    let full_data_type = row.get_expect_string("full_data_type");
+    let is_required = match row.get_expect_string("is_nullable").to_lowercase().as_ref() {
+        "no" => true,
+        "yes" => false,
+        x => panic!("unrecognized is_nullable variant '{}'", x),
+    };
+
+    let arity = match matches!(data_type.as_str(), "ARRAY") {
+        true => ColumnArity::List,
+        false if is_required => ColumnArity::Required,
+        false => ColumnArity::Nullable,
+    };
+
+    let precision = SqlSchemaDescriber::get_precision(row);
+    let unsupported_type = || (Unsupported(full_data_type.clone()), None);
+    let enum_exists = |name| enums.iter().any(|e| e.name == name);
+
+    let (family, native_type) = match full_data_type.as_str() {
+        name if data_type == "USER-DEFINED" && enum_exists(name) => (Enum(name.to_owned()), None),
+        name if data_type == "ARRAY" && name.starts_with('_') && enum_exists(name.trim_start_matches('_')) => {
+            (Enum(name.trim_start_matches('_').to_owned()), None)
+        }
+        "int2" | "_int2" => (Int, Some(CockroachType::SmallInt)),
+        "int4" | "_int4" => (Int, Some(CockroachType::Integer)),
+        "int8" | "_int8" => (BigInt, Some(CockroachType::BigInt)),
+        "oid" | "_oid" => (Int, Some(CockroachType::Oid)),
+        "float4" | "_float4" => (Float, Some(CockroachType::Real)),
+        "float8" | "_float8" => (Float, Some(CockroachType::DoublePrecision)),
+        "bool" | "_bool" => (Boolean, Some(CockroachType::Boolean)),
+        "text" | "_text" => (String, Some(CockroachType::Text)),
+        "citext" | "_citext" => (String, Some(CockroachType::Citext)),
+        "varchar" | "_varchar" => (String, Some(CockroachType::VarChar(precision.character_maximum_length))),
+        "bpchar" | "_bpchar" => (String, Some(CockroachType::Char(precision.character_maximum_length))),
+        // https://www.cockroachlabs.com/docs/stable/string.html
+        "char" | "_char" => (String, Some(CockroachType::Char(None))),
+        "date" | "_date" => (DateTime, Some(CockroachType::Date)),
+        "bytea" | "_bytea" => (Binary, Some(CockroachType::ByteA)),
+        "jsonb" | "_jsonb" => (Json, Some(CockroachType::JsonB)),
+        "uuid" | "_uuid" => (Uuid, Some(CockroachType::Uuid)),
+        // bit and varbit should be binary, but are currently mapped to strings.
+        "bit" | "_bit" => (String, Some(CockroachType::Bit(precision.character_maximum_length))),
+        "varbit" | "_varbit" => (String, Some(CockroachType::VarBit(precision.character_maximum_length))),
+        "numeric" | "_numeric" => (
+            Decimal,
+            Some(CockroachType::Decimal(
+                match (precision.numeric_precision, precision.numeric_scale) {
+                    (None, None) => None,
+                    (Some(prec), Some(scale)) => Some((prec, scale)),
+                    _ => None,
+                },
+            )),
+        ),
+        "pg_lsn" | "_pg_lsn" => unsupported_type(),
+        "time" | "_time" => (DateTime, Some(CockroachType::Time(precision.time_precision))),
+        "timetz" | "_timetz" => (DateTime, Some(CockroachType::Timetz(precision.time_precision))),
+        "timestamp" | "_timestamp" => (DateTime, Some(CockroachType::Timestamp(precision.time_precision))),
+        "timestamptz" | "_timestamptz" => (DateTime, Some(CockroachType::Timestamptz(precision.time_precision))),
+        "tsquery" | "_tsquery" => unsupported_type(),
+        "tsvector" | "_tsvector" => unsupported_type(),
+        "txid_snapshot" | "_txid_snapshot" => unsupported_type(),
+        "inet" | "_inet" => (String, Some(CockroachType::Inet)),
         //geometric
         "box" | "_box" => unsupported_type(),
         "circle" | "_circle" => unsupported_type(),

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/postgres.rs
@@ -5,7 +5,7 @@ use crate::{
     sql_migration::{AlterEnum, SqlMigrationStep},
     sql_schema_differ::{column::ColumnTypeChange, differ_database::DifferDatabase},
 };
-use native_types::PostgresType;
+use native_types::{CockroachType, PostgresType};
 use once_cell::sync::Lazy;
 use regex::RegexSet;
 use sql_schema_describer::walkers::{ColumnWalker, IndexWalker};
@@ -78,11 +78,6 @@ impl SqlSchemaDifferFlavour for PostgresFlavour {
     }
 
     fn column_type_change(&self, columns: Pair<ColumnWalker<'_>>) -> Option<ColumnTypeChange> {
-        use ColumnTypeChange::*;
-
-        let from_list_to_scalar = columns.previous.arity().is_list() && !columns.next.arity().is_list();
-        let from_scalar_to_list = !columns.previous.arity().is_list() && columns.next.arity().is_list();
-
         // Handle the enum cases first.
         match columns.map(|col| col.column_type_family().as_enum()).as_tuple() {
             (Some(previous_enum), Some(next_enum)) if previous_enum == next_enum => return None,
@@ -91,28 +86,10 @@ impl SqlSchemaDifferFlavour for PostgresFlavour {
             (None, None) => (),
         };
 
-        let previous_type: Option<PostgresType> = columns.previous.column_native_type();
-        let next_type: Option<PostgresType> = columns.next.column_native_type();
-
-        match (previous_type, next_type) {
-            (_, Some(PostgresType::Text)) if from_list_to_scalar => Some(SafeCast),
-            (_, Some(PostgresType::VarChar(None))) if from_list_to_scalar => Some(SafeCast),
-            (_, Some(PostgresType::VarChar(_))) if from_list_to_scalar => Some(RiskyCast),
-            (_, Some(PostgresType::Char(_))) if from_list_to_scalar => Some(RiskyCast),
-            (_, _) if from_scalar_to_list || from_list_to_scalar => Some(NotCastable),
-            (Some(previous), Some(next)) if self.is_cockroachdb() => {
-                cockroach_native_type_change_riskyness(previous, next, columns)
-            }
-            (Some(previous), Some(next)) => postgres_native_type_change_riskyness(previous, next),
-            // Unsupported types will have None as Native type
-            (None, Some(_)) => Some(RiskyCast),
-            (Some(_), None) => Some(RiskyCast),
-            (None, None)
-                if columns.previous.column_type().full_data_type == columns.previous.column_type().full_data_type =>
-            {
-                None
-            }
-            (None, None) => Some(RiskyCast),
+        if self.is_cockroachdb() {
+            cockroach_column_type_change(columns)
+        } else {
+            postgres_column_type_change(columns)
         }
     }
 
@@ -141,10 +118,37 @@ impl SqlSchemaDifferFlavour for PostgresFlavour {
     }
 }
 
+fn cockroach_column_type_change(columns: Pair<ColumnWalker<'_>>) -> Option<ColumnTypeChange> {
+    use ColumnTypeChange::*;
+
+    let previous_type: Option<CockroachType> = columns.previous.column_native_type();
+    let next_type: Option<CockroachType> = columns.next.column_native_type();
+    let from_list_to_scalar = columns.previous.arity().is_list() && !columns.next.arity().is_list();
+    let from_scalar_to_list = !columns.previous.arity().is_list() && columns.next.arity().is_list();
+
+    match (previous_type, next_type) {
+        (_, Some(CockroachType::Text)) if from_list_to_scalar => Some(SafeCast),
+        (_, Some(CockroachType::VarChar(None))) if from_list_to_scalar => Some(SafeCast),
+        (_, Some(CockroachType::VarChar(_))) if from_list_to_scalar => Some(RiskyCast),
+        (_, Some(CockroachType::Char(_))) if from_list_to_scalar => Some(RiskyCast),
+        (_, _) if from_scalar_to_list || from_list_to_scalar => Some(NotCastable),
+        (Some(previous), Some(next)) => cockroach_native_type_change_riskyness(previous, next, columns),
+        // Unsupported types will have None as Native type
+        (None, Some(_)) => Some(RiskyCast),
+        (Some(_), None) => Some(RiskyCast),
+        (None, None)
+            if columns.previous.column_type().full_data_type == columns.previous.column_type().full_data_type =>
+        {
+            None
+        }
+        (None, None) => Some(RiskyCast),
+    }
+}
+
 // https://go.crdb.dev/issue-v/49329/v22.1
 fn cockroach_native_type_change_riskyness(
-    previous: PostgresType,
-    next: PostgresType,
+    previous: CockroachType,
+    next: CockroachType,
     columns: Pair<ColumnWalker<'_>>,
 ) -> Option<ColumnTypeChange> {
     let covered_by_index = columns
@@ -153,19 +157,45 @@ fn cockroach_native_type_change_riskyness(
         == (&true, &true);
 
     match (previous, next) {
-        (PostgresType::Integer, PostgresType::Text) if !covered_by_index => Some(ColumnTypeChange::SafeCast),
-        (PostgresType::BigInt, PostgresType::Integer) if !covered_by_index => Some(ColumnTypeChange::RiskyCast),
+        (CockroachType::Integer, CockroachType::Text) if !covered_by_index => Some(ColumnTypeChange::SafeCast),
+        (CockroachType::BigInt, CockroachType::Integer) if !covered_by_index => Some(ColumnTypeChange::RiskyCast),
         (previous, next) if previous == next => None,
         // Timestamp default precisions
-        (PostgresType::Time(None), PostgresType::Time(Some(6)))
-        | (PostgresType::Time(Some(6)), PostgresType::Time(None))
-        | (PostgresType::Timetz(None), PostgresType::Timetz(Some(6)))
-        | (PostgresType::Timetz(Some(6)), PostgresType::Timetz(None))
-        | (PostgresType::Timestamptz(None), PostgresType::Timestamptz(Some(6)))
-        | (PostgresType::Timestamptz(Some(6)), PostgresType::Timestamptz(None))
-        | (PostgresType::Timestamp(None), PostgresType::Timestamp(Some(6)))
-        | (PostgresType::Timestamp(Some(6)), PostgresType::Timestamp(None)) => None,
+        (CockroachType::Time(None), CockroachType::Time(Some(6)))
+        | (CockroachType::Time(Some(6)), CockroachType::Time(None))
+        | (CockroachType::Timetz(None), CockroachType::Timetz(Some(6)))
+        | (CockroachType::Timetz(Some(6)), CockroachType::Timetz(None))
+        | (CockroachType::Timestamptz(None), CockroachType::Timestamptz(Some(6)))
+        | (CockroachType::Timestamptz(Some(6)), CockroachType::Timestamptz(None))
+        | (CockroachType::Timestamp(None), CockroachType::Timestamp(Some(6)))
+        | (CockroachType::Timestamp(Some(6)), CockroachType::Timestamp(None)) => None,
         _ => Some(ColumnTypeChange::NotCastable),
+    }
+}
+
+fn postgres_column_type_change(columns: Pair<ColumnWalker<'_>>) -> Option<ColumnTypeChange> {
+    use ColumnTypeChange::*;
+    let previous_type: Option<PostgresType> = columns.previous.column_native_type();
+    let next_type: Option<PostgresType> = columns.next.column_native_type();
+    let from_list_to_scalar = columns.previous.arity().is_list() && !columns.next.arity().is_list();
+    let from_scalar_to_list = !columns.previous.arity().is_list() && columns.next.arity().is_list();
+
+    match (previous_type, next_type) {
+        (_, Some(PostgresType::Text)) if from_list_to_scalar => Some(SafeCast),
+        (_, Some(PostgresType::VarChar(None))) if from_list_to_scalar => Some(SafeCast),
+        (_, Some(PostgresType::VarChar(_))) if from_list_to_scalar => Some(RiskyCast),
+        (_, Some(PostgresType::Char(_))) if from_list_to_scalar => Some(RiskyCast),
+        (_, _) if from_scalar_to_list || from_list_to_scalar => Some(NotCastable),
+        (Some(previous), Some(next)) => postgres_native_type_change_riskyness(previous, next),
+        // Unsupported types will have None as Native type
+        (None, Some(_)) => Some(RiskyCast),
+        (Some(_), None) => Some(RiskyCast),
+        (None, None)
+            if columns.previous.column_type().full_data_type == columns.previous.column_type().full_data_type =>
+        {
+            None
+        }
+        (None, None) => Some(RiskyCast),
     }
 }
 


### PR DESCRIPTION
Until now, we used PostgresType, which works because postgres types are
a superset of the cockroach types at the moment, but that is going to
change.