### PR TITLE
refactor(sql-schema-describer): take sequences pg-only

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4140,6 +4140,7 @@ dependencies = [
  "barrel",
  "bigdecimal 0.2.2",
  "enumflags2",
+ "expect-test",
  "indoc",
  "native-types",
  "once_cell",

--- a/introspection-engine/connectors/sql-introspection-connector/src/calculate_datamodel_tests.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/calculate_datamodel_tests.rs
@@ -17,7 +17,7 @@ mod tests {
     use pretty_assertions::assert_eq;
     use sql_schema_describer::{
         Column, ColumnArity, ColumnType, ColumnTypeFamily, Enum, ForeignKey, ForeignKeyAction, Index, IndexColumn,
-        IndexType, PrimaryKey, PrimaryKeyColumn, Sequence, SqlSchema, Table,
+        IndexType, PrimaryKey, PrimaryKeyColumn, SqlSchema, Table,
     };
 
     fn postgres_context() -> IntrospectionContext {
@@ -159,7 +159,6 @@ mod tests {
             indices: vec![],
             primary_key: Some(PrimaryKey {
                 columns: vec![PrimaryKeyColumn::new("required")],
-                sequence: None,
                 constraint_name: None,
             }),
             foreign_keys: vec![],
@@ -308,7 +307,6 @@ mod tests {
                 indices: vec![],
                 primary_key: Some(PrimaryKey {
                     columns: vec![PrimaryKeyColumn::new("primary")],
-                    sequence: None,
                     constraint_name: None,
                 }),
                 foreign_keys: vec![],
@@ -329,7 +327,6 @@ mod tests {
                 indices: vec![],
                 primary_key: Some(PrimaryKey {
                     columns: vec![PrimaryKeyColumn::new("primary")],
-                    sequence: None,
                     constraint_name: None,
                 }),
                 foreign_keys: vec![],
@@ -350,9 +347,6 @@ mod tests {
                 indices: vec![],
                 primary_key: Some(PrimaryKey {
                     columns: vec![PrimaryKeyColumn::new("primary")],
-                    sequence: Some(Sequence {
-                        name: "sequence".to_string(),
-                    }),
                     constraint_name: None,
                 }),
                 foreign_keys: vec![],
@@ -643,7 +637,6 @@ mod tests {
                 indices: vec![],
                 primary_key: Some(PrimaryKey {
                     columns: vec![PrimaryKeyColumn::new("id")],
-                    sequence: None,
                     constraint_name: None,
                 }),
                 foreign_keys: vec![],
@@ -688,7 +681,6 @@ mod tests {
                 indices: vec![],
                 primary_key: Some(PrimaryKey {
                     columns: vec![PrimaryKeyColumn::new("id")],
-                    sequence: None,
                     constraint_name: None,
                 }),
                 foreign_keys: vec![ForeignKey {
@@ -833,7 +825,6 @@ mod tests {
             }],
             primary_key: Some(PrimaryKey {
                 columns: vec![PrimaryKeyColumn::new("id")],
-                sequence: None,
                 constraint_name: None,
             }),
             foreign_keys: vec![],
@@ -1020,7 +1011,6 @@ mod tests {
                 indices: vec![],
                 primary_key: Some(PrimaryKey {
                     columns: vec![PrimaryKeyColumn::new("id")],
-                    sequence: None,
                     constraint_name: None,
                 }),
                 foreign_keys: vec![],
@@ -1054,7 +1044,6 @@ mod tests {
                 indices: vec![],
                 primary_key: Some(PrimaryKey {
                     columns: vec![PrimaryKeyColumn::new("id")],
-                    sequence: None,
                     constraint_name: None,
                 }),
                 foreign_keys: vec![ForeignKey {

--- a/introspection-engine/connectors/sql-introspection-connector/src/introspection_helpers.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/introspection_helpers.rs
@@ -144,12 +144,12 @@ pub(crate) fn calculate_index(index: sql::walkers::IndexWalker<'_>, ctx: &Intros
 
     let using = if ctx.preview_features.contains(PreviewFeature::ExtendedIndexes) {
         index.algorithm().map(|algo| match algo {
-            sql::SQLIndexAlgorithm::BTree => IndexAlgorithm::BTree,
-            sql::SQLIndexAlgorithm::Hash => IndexAlgorithm::Hash,
-            sql::SQLIndexAlgorithm::Gist => IndexAlgorithm::Gist,
-            sql::SQLIndexAlgorithm::Gin => IndexAlgorithm::Gin,
-            sql::SQLIndexAlgorithm::SpGist => IndexAlgorithm::SpGist,
-            sql::SQLIndexAlgorithm::Brin => IndexAlgorithm::Brin,
+            sql::SqlIndexAlgorithm::BTree => IndexAlgorithm::BTree,
+            sql::SqlIndexAlgorithm::Hash => IndexAlgorithm::Hash,
+            sql::SqlIndexAlgorithm::Gist => IndexAlgorithm::Gist,
+            sql::SqlIndexAlgorithm::Gin => IndexAlgorithm::Gin,
+            sql::SqlIndexAlgorithm::SpGist => IndexAlgorithm::SpGist,
+            sql::SqlIndexAlgorithm::Brin => IndexAlgorithm::Brin,
         })
     } else {
         None
@@ -376,7 +376,7 @@ pub(crate) fn is_sequence(column: &sql::Column, table: &sql::Table) -> bool {
     table
         .primary_key
         .as_ref()
-        .map(|pk| pk.is_single_primary_key(&column.name) && pk.sequence.is_some())
+        .map(|pk| pk.is_single_primary_key(&column.name) && matches!(&column.default, Some(d) if d.is_sequence()))
         .unwrap_or(false)
 }
 
@@ -386,7 +386,7 @@ pub(crate) fn calculate_relation_name(
     table: &Table,
     m2m_table_names: &[String],
 ) -> Result<String, SqlError> {
-    //this is not called for prisma many to many relations. for them the name is just the name of the join table.
+    // This is not called for prisma many to many relations. For them the name is just the name of the join table.
     let referenced_model = &fk.referenced_table;
     let model_with_fk = &table.name;
     let fk_column_name = fk.columns.join("_");
@@ -579,62 +579,64 @@ fn get_opclass(
 
     match &opclass.kind {
         _ if opclass.is_default => None,
-        sql::SQLOperatorClassKind::InetOps => Some(OperatorClass::InetOps),
-        sql::SQLOperatorClassKind::JsonbOps => Some(OperatorClass::JsonbOps),
-        sql::SQLOperatorClassKind::JsonbPathOps => Some(OperatorClass::JsonbPathOps),
-        sql::SQLOperatorClassKind::ArrayOps => Some(OperatorClass::ArrayOps),
-        sql::SQLOperatorClassKind::TextOps => Some(OperatorClass::TextOps),
-        sql::SQLOperatorClassKind::BitMinMaxOps => Some(OperatorClass::BitMinMaxOps),
-        sql::SQLOperatorClassKind::VarBitMinMaxOps => Some(OperatorClass::VarBitMinMaxOps),
-        sql::SQLOperatorClassKind::BpcharBloomOps => Some(OperatorClass::BpcharBloomOps),
-        sql::SQLOperatorClassKind::BpcharMinMaxOps => Some(OperatorClass::BpcharMinMaxOps),
-        sql::SQLOperatorClassKind::ByteaBloomOps => Some(OperatorClass::ByteaBloomOps),
-        sql::SQLOperatorClassKind::ByteaMinMaxOps => Some(OperatorClass::ByteaMinMaxOps),
-        sql::SQLOperatorClassKind::DateBloomOps => Some(OperatorClass::DateBloomOps),
-        sql::SQLOperatorClassKind::DateMinMaxOps => Some(OperatorClass::DateMinMaxOps),
-        sql::SQLOperatorClassKind::DateMinMaxMultiOps => Some(OperatorClass::DateMinMaxMultiOps),
-        sql::SQLOperatorClassKind::Float4BloomOps => Some(OperatorClass::Float4BloomOps),
-        sql::SQLOperatorClassKind::Float4MinMaxOps => Some(OperatorClass::Float4MinMaxOps),
-        sql::SQLOperatorClassKind::Float4MinMaxMultiOps => Some(OperatorClass::Float4MinMaxMultiOps),
-        sql::SQLOperatorClassKind::Float8BloomOps => Some(OperatorClass::Float8BloomOps),
-        sql::SQLOperatorClassKind::Float8MinMaxOps => Some(OperatorClass::Float8MinMaxOps),
-        sql::SQLOperatorClassKind::Float8MinMaxMultiOps => Some(OperatorClass::Float8MinMaxMultiOps),
-        sql::SQLOperatorClassKind::InetInclusionOps => Some(OperatorClass::InetInclusionOps),
-        sql::SQLOperatorClassKind::InetBloomOps => Some(OperatorClass::InetBloomOps),
-        sql::SQLOperatorClassKind::InetMinMaxOps => Some(OperatorClass::InetMinMaxOps),
-        sql::SQLOperatorClassKind::InetMinMaxMultiOps => Some(OperatorClass::InetMinMaxMultiOps),
-        sql::SQLOperatorClassKind::Int2BloomOps => Some(OperatorClass::Int2BloomOps),
-        sql::SQLOperatorClassKind::Int2MinMaxOps => Some(OperatorClass::Int2MinMaxOps),
-        sql::SQLOperatorClassKind::Int2MinMaxMultiOps => Some(OperatorClass::Int2MinMaxMultiOps),
-        sql::SQLOperatorClassKind::Int4BloomOps => Some(OperatorClass::Int4BloomOps),
-        sql::SQLOperatorClassKind::Int4MinMaxOps => Some(OperatorClass::Int4MinMaxOps),
-        sql::SQLOperatorClassKind::Int4MinMaxMultiOps => Some(OperatorClass::Int4MinMaxMultiOps),
-        sql::SQLOperatorClassKind::Int8BloomOps => Some(OperatorClass::Int8BloomOps),
-        sql::SQLOperatorClassKind::Int8MinMaxOps => Some(OperatorClass::Int8MinMaxOps),
-        sql::SQLOperatorClassKind::Int8MinMaxMultiOps => Some(OperatorClass::Int8MinMaxMultiOps),
-        sql::SQLOperatorClassKind::NumericBloomOps => Some(OperatorClass::NumericBloomOps),
-        sql::SQLOperatorClassKind::NumericMinMaxOps => Some(OperatorClass::NumericMinMaxOps),
-        sql::SQLOperatorClassKind::NumericMinMaxMultiOps => Some(OperatorClass::NumericMinMaxMultiOps),
-        sql::SQLOperatorClassKind::OidBloomOps => Some(OperatorClass::OidBloomOps),
-        sql::SQLOperatorClassKind::OidMinMaxOps => Some(OperatorClass::OidMinMaxOps),
-        sql::SQLOperatorClassKind::OidMinMaxMultiOps => Some(OperatorClass::OidMinMaxMultiOps),
-        sql::SQLOperatorClassKind::TextBloomOps => Some(OperatorClass::TextBloomOps),
-        sql::SQLOperatorClassKind::TextMinMaxOps => Some(OperatorClass::TextMinMaxOps),
-        sql::SQLOperatorClassKind::TimestampBloomOps => Some(OperatorClass::TimestampBloomOps),
-        sql::SQLOperatorClassKind::TimestampMinMaxOps => Some(OperatorClass::TimestampMinMaxOps),
-        sql::SQLOperatorClassKind::TimestampMinMaxMultiOps => Some(OperatorClass::TimestampMinMaxMultiOps),
-        sql::SQLOperatorClassKind::TimestampTzBloomOps => Some(OperatorClass::TimestampTzBloomOps),
-        sql::SQLOperatorClassKind::TimestampTzMinMaxOps => Some(OperatorClass::TimestampTzMinMaxOps),
-        sql::SQLOperatorClassKind::TimestampTzMinMaxMultiOps => Some(OperatorClass::TimestampTzMinMaxMultiOps),
-        sql::SQLOperatorClassKind::TimeBloomOps => Some(OperatorClass::TimeBloomOps),
-        sql::SQLOperatorClassKind::TimeMinMaxOps => Some(OperatorClass::TimeMinMaxOps),
-        sql::SQLOperatorClassKind::TimeMinMaxMultiOps => Some(OperatorClass::TimeMinMaxMultiOps),
-        sql::SQLOperatorClassKind::TimeTzBloomOps => Some(OperatorClass::TimeTzBloomOps),
-        sql::SQLOperatorClassKind::TimeTzMinMaxOps => Some(OperatorClass::TimeTzMinMaxOps),
-        sql::SQLOperatorClassKind::TimeTzMinMaxMultiOps => Some(OperatorClass::TimeTzMinMaxMultiOps),
-        sql::SQLOperatorClassKind::UuidBloomOps => Some(OperatorClass::UuidBloomOps),
-        sql::SQLOperatorClassKind::UuidMinMaxOps => Some(OperatorClass::UuidMinMaxOps),
-        sql::SQLOperatorClassKind::UuidMinMaxMultiOps => Some(OperatorClass::UuidMinMaxMultiOps),
-        sql::SQLOperatorClassKind::Raw(c) => Some(OperatorClass::Raw(c.to_string().into())),
+        sql::postgres::SQLOperatorClassKind::InetOps => Some(OperatorClass::InetOps),
+        sql::postgres::SQLOperatorClassKind::JsonbOps => Some(OperatorClass::JsonbOps),
+        sql::postgres::SQLOperatorClassKind::JsonbPathOps => Some(OperatorClass::JsonbPathOps),
+        sql::postgres::SQLOperatorClassKind::ArrayOps => Some(OperatorClass::ArrayOps),
+        sql::postgres::SQLOperatorClassKind::TextOps => Some(OperatorClass::TextOps),
+        sql::postgres::SQLOperatorClassKind::BitMinMaxOps => Some(OperatorClass::BitMinMaxOps),
+        sql::postgres::SQLOperatorClassKind::VarBitMinMaxOps => Some(OperatorClass::VarBitMinMaxOps),
+        sql::postgres::SQLOperatorClassKind::BpcharBloomOps => Some(OperatorClass::BpcharBloomOps),
+        sql::postgres::SQLOperatorClassKind::BpcharMinMaxOps => Some(OperatorClass::BpcharMinMaxOps),
+        sql::postgres::SQLOperatorClassKind::ByteaBloomOps => Some(OperatorClass::ByteaBloomOps),
+        sql::postgres::SQLOperatorClassKind::ByteaMinMaxOps => Some(OperatorClass::ByteaMinMaxOps),
+        sql::postgres::SQLOperatorClassKind::DateBloomOps => Some(OperatorClass::DateBloomOps),
+        sql::postgres::SQLOperatorClassKind::DateMinMaxOps => Some(OperatorClass::DateMinMaxOps),
+        sql::postgres::SQLOperatorClassKind::DateMinMaxMultiOps => Some(OperatorClass::DateMinMaxMultiOps),
+        sql::postgres::SQLOperatorClassKind::Float4BloomOps => Some(OperatorClass::Float4BloomOps),
+        sql::postgres::SQLOperatorClassKind::Float4MinMaxOps => Some(OperatorClass::Float4MinMaxOps),
+        sql::postgres::SQLOperatorClassKind::Float4MinMaxMultiOps => Some(OperatorClass::Float4MinMaxMultiOps),
+        sql::postgres::SQLOperatorClassKind::Float8BloomOps => Some(OperatorClass::Float8BloomOps),
+        sql::postgres::SQLOperatorClassKind::Float8MinMaxOps => Some(OperatorClass::Float8MinMaxOps),
+        sql::postgres::SQLOperatorClassKind::Float8MinMaxMultiOps => Some(OperatorClass::Float8MinMaxMultiOps),
+        sql::postgres::SQLOperatorClassKind::InetInclusionOps => Some(OperatorClass::InetInclusionOps),
+        sql::postgres::SQLOperatorClassKind::InetBloomOps => Some(OperatorClass::InetBloomOps),
+        sql::postgres::SQLOperatorClassKind::InetMinMaxOps => Some(OperatorClass::InetMinMaxOps),
+        sql::postgres::SQLOperatorClassKind::InetMinMaxMultiOps => Some(OperatorClass::InetMinMaxMultiOps),
+        sql::postgres::SQLOperatorClassKind::Int2BloomOps => Some(OperatorClass::Int2BloomOps),
+        sql::postgres::SQLOperatorClassKind::Int2MinMaxOps => Some(OperatorClass::Int2MinMaxOps),
+        sql::postgres::SQLOperatorClassKind::Int2MinMaxMultiOps => Some(OperatorClass::Int2MinMaxMultiOps),
+        sql::postgres::SQLOperatorClassKind::Int4BloomOps => Some(OperatorClass::Int4BloomOps),
+        sql::postgres::SQLOperatorClassKind::Int4MinMaxOps => Some(OperatorClass::Int4MinMaxOps),
+        sql::postgres::SQLOperatorClassKind::Int4MinMaxMultiOps => Some(OperatorClass::Int4MinMaxMultiOps),
+        sql::postgres::SQLOperatorClassKind::Int8BloomOps => Some(OperatorClass::Int8BloomOps),
+        sql::postgres::SQLOperatorClassKind::Int8MinMaxOps => Some(OperatorClass::Int8MinMaxOps),
+        sql::postgres::SQLOperatorClassKind::Int8MinMaxMultiOps => Some(OperatorClass::Int8MinMaxMultiOps),
+        sql::postgres::SQLOperatorClassKind::NumericBloomOps => Some(OperatorClass::NumericBloomOps),
+        sql::postgres::SQLOperatorClassKind::NumericMinMaxOps => Some(OperatorClass::NumericMinMaxOps),
+        sql::postgres::SQLOperatorClassKind::NumericMinMaxMultiOps => Some(OperatorClass::NumericMinMaxMultiOps),
+        sql::postgres::SQLOperatorClassKind::OidBloomOps => Some(OperatorClass::OidBloomOps),
+        sql::postgres::SQLOperatorClassKind::OidMinMaxOps => Some(OperatorClass::OidMinMaxOps),
+        sql::postgres::SQLOperatorClassKind::OidMinMaxMultiOps => Some(OperatorClass::OidMinMaxMultiOps),
+        sql::postgres::SQLOperatorClassKind::TextBloomOps => Some(OperatorClass::TextBloomOps),
+        sql::postgres::SQLOperatorClassKind::TextMinMaxOps => Some(OperatorClass::TextMinMaxOps),
+        sql::postgres::SQLOperatorClassKind::TimestampBloomOps => Some(OperatorClass::TimestampBloomOps),
+        sql::postgres::SQLOperatorClassKind::TimestampMinMaxOps => Some(OperatorClass::TimestampMinMaxOps),
+        sql::postgres::SQLOperatorClassKind::TimestampMinMaxMultiOps => Some(OperatorClass::TimestampMinMaxMultiOps),
+        sql::postgres::SQLOperatorClassKind::TimestampTzBloomOps => Some(OperatorClass::TimestampTzBloomOps),
+        sql::postgres::SQLOperatorClassKind::TimestampTzMinMaxOps => Some(OperatorClass::TimestampTzMinMaxOps),
+        sql::postgres::SQLOperatorClassKind::TimestampTzMinMaxMultiOps => {
+            Some(OperatorClass::TimestampTzMinMaxMultiOps)
+        }
+        sql::postgres::SQLOperatorClassKind::TimeBloomOps => Some(OperatorClass::TimeBloomOps),
+        sql::postgres::SQLOperatorClassKind::TimeMinMaxOps => Some(OperatorClass::TimeMinMaxOps),
+        sql::postgres::SQLOperatorClassKind::TimeMinMaxMultiOps => Some(OperatorClass::TimeMinMaxMultiOps),
+        sql::postgres::SQLOperatorClassKind::TimeTzBloomOps => Some(OperatorClass::TimeTzBloomOps),
+        sql::postgres::SQLOperatorClassKind::TimeTzMinMaxOps => Some(OperatorClass::TimeTzMinMaxOps),
+        sql::postgres::SQLOperatorClassKind::TimeTzMinMaxMultiOps => Some(OperatorClass::TimeTzMinMaxMultiOps),
+        sql::postgres::SQLOperatorClassKind::UuidBloomOps => Some(OperatorClass::UuidBloomOps),
+        sql::postgres::SQLOperatorClassKind::UuidMinMaxOps => Some(OperatorClass::UuidMinMaxOps),
+        sql::postgres::SQLOperatorClassKind::UuidMinMaxMultiOps => Some(OperatorClass::UuidMinMaxMultiOps),
+        sql::postgres::SQLOperatorClassKind::Raw(c) => Some(OperatorClass::Raw(c.to_string().into())),
     }
 }

--- a/introspection-engine/introspection-engine-tests/tests/rpc_calls/get_database_description.rs
+++ b/introspection-engine/introspection-engine-tests/tests/rpc_calls/get_database_description.rs
@@ -58,14 +58,12 @@ async fn database_description_for_mysql_should_work(api: &TestApi) -> TestResult
                     "sort_order": null
                   }
                 ],
-                "sequence": null,
                 "constraint_name": null
               },
               "foreign_keys": []
             }
           ],
           "enums": [],
-          "sequences": [],
           "views": [],
           "procedures": [],
           "user_defined_types": [],
@@ -119,14 +117,12 @@ async fn database_description_for_mysql_8_should_work(api: &TestApi) -> TestResu
                     "sort_order": null
                   }
                 ],
-                "sequence": null,
                 "constraint_name": null
               },
               "foreign_keys": []
             }
           ],
           "enums": [],
-          "sequences": [],
           "views": [],
           "procedures": [],
           "user_defined_types": [],
@@ -185,20 +181,12 @@ async fn database_description_for_postgres_should_work(api: &TestApi) -> TestRes
                     "sort_order": null
                   }
                 ],
-                "sequence": {
-                  "name": "Blog_id_seq"
-                },
                 "constraint_name": "Blog_pkey"
               },
               "foreign_keys": []
             }
           ],
           "enums": [],
-          "sequences": [
-            {
-              "name": "Blog_id_seq"
-            }
-          ],
           "views": [],
           "procedures": [],
           "user_defined_types": [],
@@ -252,14 +240,12 @@ async fn database_description_for_sqlite_should_work(api: &TestApi) -> TestResul
                     "sort_order": null
                   }
                 ],
-                "sequence": null,
                 "constraint_name": null
               },
               "foreign_keys": []
             }
           ],
           "enums": [],
-          "sequences": [],
           "views": [],
           "procedures": [],
           "user_defined_types": [],

--- a/libs/datamodel/connectors/datamodel-connector/src/lib.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/lib.rs
@@ -23,11 +23,11 @@ pub use self::{
 pub use diagnostics::{ConnectorErrorFactory, DatamodelError, Diagnostics, Span};
 pub use empty_connector::EmptyDatamodelConnector;
 pub use native_type_constructor::NativeTypeConstructor;
-use parser_database::IndexAlgorithm;
 pub use parser_database::{self, ReferentialAction, ScalarType};
 pub use referential_integrity::ReferentialIntegrity;
 
 use enumflags2::BitFlags;
+use parser_database::IndexAlgorithm;
 use std::{borrow::Cow, collections::BTreeMap};
 
 /// The datamodel connector API.
@@ -224,11 +224,11 @@ pub trait Connector: Send + Sync {
         self.has_capability(ConnectorCapability::DecimalType)
     }
 
-    fn supported_index_types(&self) -> &'static [IndexAlgorithm] {
-        &[IndexAlgorithm::BTree]
+    fn supported_index_types(&self) -> BitFlags<IndexAlgorithm> {
+        IndexAlgorithm::BTree.into()
     }
 
-    fn supports_index_type(&self, algo: &IndexAlgorithm) -> bool {
+    fn supports_index_type(&self, algo: IndexAlgorithm) -> bool {
         self.supported_index_types().contains(algo)
     }
 

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
@@ -104,15 +104,6 @@ const CAPABILITIES: &[ConnectorCapability] = &[
     ConnectorCapability::DecimalType,
 ];
 
-const INDEX_TYPES: &[IndexAlgorithm] = &[
-    IndexAlgorithm::BTree,
-    IndexAlgorithm::Gist,
-    IndexAlgorithm::Hash,
-    IndexAlgorithm::Gin,
-    IndexAlgorithm::SpGist,
-    IndexAlgorithm::Brin,
-];
-
 pub struct PostgresDatamodelConnector;
 
 const SCALAR_TYPE_DEFAULTS: &[(ScalarType, PostgresType)] = &[
@@ -257,8 +248,14 @@ impl Connector for PostgresDatamodelConnector {
         NATIVE_TYPE_CONSTRUCTORS
     }
 
-    fn supported_index_types(&self) -> &'static [IndexAlgorithm] {
-        INDEX_TYPES
+    fn supported_index_types(&self) -> BitFlags<IndexAlgorithm> {
+        BitFlags::empty()
+            | IndexAlgorithm::BTree
+            | IndexAlgorithm::Gist
+            | IndexAlgorithm::Hash
+            | IndexAlgorithm::Gin
+            | IndexAlgorithm::SpGist
+            | IndexAlgorithm::Brin
     }
 
     fn parse_native_type(

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/indexes.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/indexes.rs
@@ -460,7 +460,7 @@ pub(crate) fn index_algorithm_is_supported(index: IndexWalker<'_>, ctx: &mut Con
         None => return,
     };
 
-    if ctx.connector.supports_index_type(&algo) {
+    if ctx.connector.supports_index_type(algo) {
         return;
     }
 

--- a/libs/datamodel/parser-database/src/types.rs
+++ b/libs/datamodel/parser-database/src/types.rs
@@ -1,5 +1,6 @@
 use crate::{context::Context, interner::StringId, walkers::IndexFieldWalker, DatamodelError};
 use either::Either;
+use enumflags2::bitflags;
 use schema_ast::ast::{self, WithName};
 use std::{
     collections::{BTreeMap, HashMap},
@@ -233,7 +234,9 @@ pub(crate) struct ModelAttributes {
 /// @@index([a, b], type: Hash)
 ///                 ^^^^^^^^^^
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[bitflags]
+#[repr(u8)]
+#[derive(Debug, Clone, Copy)]
 pub enum IndexAlgorithm {
     /// Binary tree index (the default in most databases)
     BTree,

--- a/libs/native-types/src/postgres.rs
+++ b/libs/native-types/src/postgres.rs
@@ -1,5 +1,3 @@
-use std::fmt;
-
 use serde::*;
 use serde_json::Value;
 
@@ -31,39 +29,6 @@ pub enum PostgresType {
     Xml,
     Json,
     JsonB,
-}
-
-impl fmt::Display for PostgresType {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            PostgresType::SmallInt => f.write_str("SmallInt"),
-            PostgresType::Integer => f.write_str("Integer"),
-            PostgresType::BigInt => f.write_str("BigInt"),
-            PostgresType::Decimal(_) => f.write_str("Decimal"),
-            PostgresType::Money => f.write_str("Money"),
-            PostgresType::Inet => f.write_str("Inet"),
-            PostgresType::Oid => f.write_str("Oid"),
-            PostgresType::Citext => f.write_str("Citext"),
-            PostgresType::Real => f.write_str("Real"),
-            PostgresType::DoublePrecision => f.write_str("DoublePrecision"),
-            PostgresType::VarChar(_) => f.write_str("VarChar"),
-            PostgresType::Char(_) => f.write_str("Char"),
-            PostgresType::Text => f.write_str("Text"),
-            PostgresType::ByteA => f.write_str("ByteA"),
-            PostgresType::Timestamp(_) => f.write_str("Timestamp"),
-            PostgresType::Timestamptz(_) => f.write_str("Timestamptz"),
-            PostgresType::Date => f.write_str("Date"),
-            PostgresType::Time(_) => f.write_str("Time"),
-            PostgresType::Timetz(_) => f.write_str("Timetz"),
-            PostgresType::Boolean => f.write_str("Boolean"),
-            PostgresType::Bit(_) => f.write_str("Bit"),
-            PostgresType::VarBit(_) => f.write_str("VarBit"),
-            PostgresType::Uuid => f.write_str("Uuid"),
-            PostgresType::Xml => f.write_str("Xml"),
-            PostgresType::Json => f.write_str("Json"),
-            PostgresType::JsonB => f.write_str("JsonB"),
-        }
-    }
 }
 
 impl super::NativeType for PostgresType {

--- a/libs/sql-schema-describer/Cargo.toml
+++ b/libs/sql-schema-describer/Cargo.toml
@@ -33,6 +33,7 @@ features = [
 
 [dev-dependencies]
 barrel = { git = "https://github.com/prisma/barrel.git", features = ["sqlite3", "mysql", "pg", "mssql"], branch = "mssql-support" }
+expect-test = "1.2.2"
 pretty_assertions = "0.6"
 test-macros = { path = "../test-macros" }
 test-setup = { path = "../test-setup" }

--- a/libs/sql-schema-describer/src/mssql.rs
+++ b/libs/sql-schema-describer/src/mssql.rs
@@ -480,7 +480,6 @@ impl<'a> SqlSchemaDescriber<'a> {
 
                         table.primary_key.replace(PrimaryKey {
                             columns: vec![column],
-                            sequence: None,
                             constraint_name: Some(index_name),
                         });
                     }

--- a/libs/sql-schema-describer/src/mysql.rs
+++ b/libs/sql-schema-describer/src/mysql.rs
@@ -528,7 +528,6 @@ impl<'a> SqlSchemaDescriber<'a> {
 
                                 primary_key.replace(PrimaryKey {
                                     columns: vec![column],
-                                    sequence: None,
                                     constraint_name: None,
                                 });
                             }

--- a/libs/sql-schema-describer/src/sqlite.rs
+++ b/libs/sql-schema-describer/src/sqlite.rs
@@ -303,7 +303,6 @@ impl<'a> SqlSchemaDescriber<'a> {
             trace!("Determined that table has primary key with columns {:?}", columns);
             Some(PrimaryKey {
                 columns,
-                sequence: None,
                 constraint_name: None,
             })
         };

--- a/libs/sql-schema-describer/src/walkers.rs
+++ b/libs/sql-schema-describer/src/walkers.rs
@@ -4,8 +4,8 @@
 
 use crate::{
     Column, ColumnArity, ColumnId, ColumnType, ColumnTypeFamily, DefaultValue, Enum, ForeignKey, ForeignKeyAction,
-    Index, IndexColumn, IndexFieldId, IndexId, IndexType, PrimaryKey, PrimaryKeyColumn, SQLIndexAlgorithm,
-    SQLSortOrder, SqlSchema, Table, TableId, UserDefinedType, View,
+    Index, IndexColumn, IndexFieldId, IndexId, IndexType, PrimaryKey, PrimaryKeyColumn, SQLSortOrder,
+    SqlIndexAlgorithm, SqlSchema, Table, TableId, UserDefinedType, View,
 };
 use serde::de::DeserializeOwned;
 use std::fmt;
@@ -698,7 +698,7 @@ impl<'a> IndexWalker<'a> {
     }
 
     /// The hash algorithm used in the index.
-    pub fn algorithm(&self) -> Option<SQLIndexAlgorithm> {
+    pub fn algorithm(&self) -> Option<SqlIndexAlgorithm> {
         self.get().algorithm
     }
 }

--- a/libs/sql-schema-describer/tests/describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describer_tests.rs
@@ -255,7 +255,6 @@ fn composite_primary_keys_must_work(api: TestApi) {
             indices: vec![],
             primary_key: Some(PrimaryKey {
                 columns,
-                sequence: None,
                 constraint_name: match api.sql_family() {
                     SqlFamily::Postgres => Some("User_pkey".into()),
                     SqlFamily::Mssql => Some("PK_User".into()),
@@ -308,18 +307,11 @@ fn indices_must_work(api: TestApi) {
         },
     ];
 
-    let pk_sequence = match api.sql_family() {
-        SqlFamily::Postgres => Some(Sequence {
-            name: "User_id_seq".to_string(),
-        }),
-        _ => None,
-    };
-
     assert_eq!("User", user_table.name);
     assert_eq!(expected_columns, user_table.columns);
 
     let algorithm = if api.is_postgres() && !api.is_cockroach() {
-        Some(SQLIndexAlgorithm::BTree)
+        Some(SqlIndexAlgorithm::BTree)
     } else {
         None
     };
@@ -354,7 +346,6 @@ fn indices_must_work(api: TestApi) {
     };
 
     assert_eq!(pk.columns, &[pk_col]);
-    assert_eq!(pk_sequence, pk.sequence);
 
     match api.sql_family() {
         SqlFamily::Postgres => assert_eq!(Some("User_pkey"), pk.constraint_name.as_deref()),

--- a/libs/sql-schema-describer/tests/describers/mssql_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/mssql_describer_tests.rs
@@ -509,7 +509,6 @@ fn all_mssql_column_types_must_work(api: TestApi) {
     let pk_columns = pk.columns.iter().map(|c| c.name()).collect::<Vec<_>>();
     assert_eq!(vec!["primary_col"], pk_columns);
 
-    assert_eq!(None, pk.sequence);
     assert!(pk
         .constraint_name
         .as_ref()
@@ -677,9 +676,7 @@ fn mssql_foreign_key_on_delete_must_be_handled(api: TestApi) {
                     sort_order: Some(SQLSortOrder::Asc),
                     length: None
                 }],
-                sequence: None,
                 constraint_name: Some("PK__User".into()),
-                // clustered: Some(true),
             }),
             foreign_keys: vec![
                 ForeignKey {
@@ -738,7 +735,6 @@ fn mssql_multi_field_indexes_must_be_inferred(api: TestApi) {
             columns,
             tpe: IndexType::Unique,
             algorithm: None,
-            // clustered: Some(false),
         }]
     );
 }

--- a/libs/sql-schema-describer/tests/describers/mysql_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/mysql_describer_tests.rs
@@ -586,7 +586,6 @@ fn all_mysql_column_types_must_work(api: TestApi) {
             indices: vec![],
             primary_key: Some(PrimaryKey {
                 columns: vec![PrimaryKeyColumn::new("primary_col")],
-                sequence: None,
                 constraint_name: None,
             }),
             foreign_keys: vec![],
@@ -1116,7 +1115,6 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
             indices: vec![],
             primary_key: Some(PrimaryKey {
                 columns: vec![PrimaryKeyColumn::new("primary_col")],
-                sequence: None,
                 constraint_name: None,
             }),
             foreign_keys: vec![],

--- a/libs/sql-schema-describer/tests/describers/sqlite_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/sqlite_describer_tests.rs
@@ -123,7 +123,6 @@ async fn sqlite_column_types_must_work() {
             indices: vec![],
             primary_key: Some(PrimaryKey {
                 columns: vec![PrimaryKeyColumn::new("primary_col")],
-                sequence: None,
                 constraint_name: None,
             }),
             foreign_keys: vec![],
@@ -222,7 +221,6 @@ async fn sqlite_foreign_key_on_delete_must_be_handled() {
             indices: vec![],
             primary_key: Some(PrimaryKey {
                 columns: vec![PrimaryKeyColumn::new("id")],
-                sequence: None,
                 constraint_name: None,
             }),
             foreign_keys: vec![
@@ -295,7 +293,6 @@ async fn sqlite_text_primary_keys_must_be_inferred_on_table_and_not_as_separate_
         table.primary_key.as_ref().unwrap(),
         &PrimaryKey {
             columns: vec![PrimaryKeyColumn::new("primary_col")],
-            sequence: None,
             constraint_name: None,
         }
     );

--- a/libs/sql-schema-describer/tests/test_api/mod.rs
+++ b/libs/sql-schema-describer/tests/test_api/mod.rs
@@ -1,3 +1,4 @@
+pub use expect_test::expect;
 pub use quaint::{prelude::Queryable, single::Quaint};
 pub use test_macros::test_connector;
 pub use test_setup::{BitFlags, Capabilities, Tags};

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
@@ -12,7 +12,7 @@ use regex::Regex;
 use sql_ddl::{postgres as ddl, IndexColumn, SortOrder};
 use sql_schema_describer::{
     postgres::PostgresSchemaExt, walkers::*, ColumnArity, ColumnTypeFamily, DefaultKind, DefaultValue,
-    ForeignKeyAction, SQLIndexAlgorithm, SQLSortOrder, SqlSchema,
+    ForeignKeyAction, SQLSortOrder, SqlIndexAlgorithm, SqlSchema,
 };
 use std::borrow::Cow;
 
@@ -257,13 +257,12 @@ impl SqlRenderer for PostgresFlavour {
             is_unique: index.index_type().is_unique(),
             table_reference: index.table().name().into(),
             using: index.algorithm().map(|algo| match algo {
-                //todo we should think about not rendering this if it is the db default anyways
-                SQLIndexAlgorithm::BTree => ddl::IndexAlgorithm::BTree,
-                SQLIndexAlgorithm::Hash => ddl::IndexAlgorithm::Hash,
-                SQLIndexAlgorithm::Gist => ddl::IndexAlgorithm::Gist,
-                SQLIndexAlgorithm::Gin => ddl::IndexAlgorithm::Gin,
-                SQLIndexAlgorithm::SpGist => ddl::IndexAlgorithm::SpGist,
-                SQLIndexAlgorithm::Brin => ddl::IndexAlgorithm::Brin,
+                SqlIndexAlgorithm::BTree => ddl::IndexAlgorithm::BTree,
+                SqlIndexAlgorithm::Hash => ddl::IndexAlgorithm::Hash,
+                SqlIndexAlgorithm::Gist => ddl::IndexAlgorithm::Gist,
+                SqlIndexAlgorithm::Gin => ddl::IndexAlgorithm::Gin,
+                SqlIndexAlgorithm::SpGist => ddl::IndexAlgorithm::SpGist,
+                SqlIndexAlgorithm::Brin => ddl::IndexAlgorithm::Brin,
             }),
             columns: index
                 .columns()

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
@@ -54,7 +54,6 @@ fn push_model_tables(ctx: &mut Context<'_>) {
                     }),
                 })
                 .collect(),
-            sequence: None,
             constraint_name: pk
                 .constraint_name(ctx.flavour.datamodel_connector())
                 .map(|c| c.into_owned()),
@@ -82,12 +81,12 @@ fn push_model_tables(ctx: &mut Context<'_>) {
                 };
 
                 let algorithm = index.algorithm().map(|algo| match algo {
-                    IndexAlgorithm::BTree => sql::SQLIndexAlgorithm::BTree,
-                    IndexAlgorithm::Hash => sql::SQLIndexAlgorithm::Hash,
-                    IndexAlgorithm::Gist => sql::SQLIndexAlgorithm::Gist,
-                    IndexAlgorithm::Gin => sql::SQLIndexAlgorithm::Gin,
-                    IndexAlgorithm::SpGist => sql::SQLIndexAlgorithm::SpGist,
-                    IndexAlgorithm::Brin => sql::SQLIndexAlgorithm::Brin,
+                    IndexAlgorithm::BTree => sql::SqlIndexAlgorithm::BTree,
+                    IndexAlgorithm::Hash => sql::SqlIndexAlgorithm::Hash,
+                    IndexAlgorithm::Gist => sql::SqlIndexAlgorithm::Gist,
+                    IndexAlgorithm::Gin => sql::SqlIndexAlgorithm::Gin,
+                    IndexAlgorithm::SpGist => sql::SqlIndexAlgorithm::SpGist,
+                    IndexAlgorithm::Brin => sql::SqlIndexAlgorithm::Brin,
                 });
 
                 sql::Index {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/postgres.rs
@@ -48,13 +48,13 @@ impl SqlSchemaCalculatorFlavour for PostgresFlavour {
 
                         let opclass = match opclass.get() {
                             Either::Left(class) => convert_opclass(class, index.algorithm()),
-                            Either::Right(s) => sql::SQLOperatorClass {
-                                kind: sql::SQLOperatorClassKind::Raw(s.to_string()),
+                            Either::Right(s) => sql::postgres::SQLOperatorClass {
+                                kind: sql::postgres::SQLOperatorClassKind::Raw(s.to_string()),
                                 is_default: false,
                             },
                         };
 
-                        data.opclasses.insert(field_id, opclass);
+                        data.opclasses.push((field_id, opclass));
                     }
                 }
             }
@@ -64,230 +64,230 @@ impl SqlSchemaCalculatorFlavour for PostgresFlavour {
     }
 }
 
-fn convert_opclass(opclass: OperatorClass, algo: Option<IndexAlgorithm>) -> sql::SQLOperatorClass {
+fn convert_opclass(opclass: OperatorClass, algo: Option<IndexAlgorithm>) -> sql::postgres::SQLOperatorClass {
     match opclass {
-        OperatorClass::InetOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::InetOps,
+        OperatorClass::InetOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::InetOps,
             is_default: algo.map(|a| a.is_spgist()).unwrap_or(false),
         },
-        OperatorClass::JsonbOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::JsonbOps,
+        OperatorClass::JsonbOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::JsonbOps,
             is_default: true,
         },
-        OperatorClass::JsonbPathOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::JsonbPathOps,
+        OperatorClass::JsonbPathOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::JsonbPathOps,
             is_default: false,
         },
-        OperatorClass::ArrayOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::ArrayOps,
+        OperatorClass::ArrayOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::ArrayOps,
             is_default: true,
         },
-        OperatorClass::TextOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::TextOps,
+        OperatorClass::TextOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::TextOps,
             is_default: true,
         },
-        OperatorClass::BitMinMaxOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::BitMinMaxOps,
+        OperatorClass::BitMinMaxOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::BitMinMaxOps,
             is_default: true,
         },
-        OperatorClass::VarBitMinMaxOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::VarBitMinMaxOps,
+        OperatorClass::VarBitMinMaxOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::VarBitMinMaxOps,
             is_default: true,
         },
-        OperatorClass::BpcharBloomOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::BpcharBloomOps,
+        OperatorClass::BpcharBloomOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::BpcharBloomOps,
             is_default: false,
         },
-        OperatorClass::BpcharMinMaxOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::BpcharMinMaxOps,
+        OperatorClass::BpcharMinMaxOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::BpcharMinMaxOps,
             is_default: true,
         },
-        OperatorClass::ByteaBloomOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::ByteaBloomOps,
+        OperatorClass::ByteaBloomOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::ByteaBloomOps,
             is_default: false,
         },
-        OperatorClass::ByteaMinMaxOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::ByteaMinMaxOps,
+        OperatorClass::ByteaMinMaxOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::ByteaMinMaxOps,
             is_default: true,
         },
-        OperatorClass::DateBloomOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::DateBloomOps,
+        OperatorClass::DateBloomOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::DateBloomOps,
             is_default: false,
         },
-        OperatorClass::DateMinMaxOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::DateMinMaxOps,
+        OperatorClass::DateMinMaxOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::DateMinMaxOps,
             is_default: true,
         },
-        OperatorClass::DateMinMaxMultiOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::DateMinMaxMultiOps,
+        OperatorClass::DateMinMaxMultiOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::DateMinMaxMultiOps,
             is_default: false,
         },
-        OperatorClass::Float4BloomOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::Float4BloomOps,
+        OperatorClass::Float4BloomOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::Float4BloomOps,
             is_default: false,
         },
-        OperatorClass::Float4MinMaxOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::Float4MinMaxOps,
+        OperatorClass::Float4MinMaxOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::Float4MinMaxOps,
             is_default: true,
         },
-        OperatorClass::Float4MinMaxMultiOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::Float4MinMaxMultiOps,
+        OperatorClass::Float4MinMaxMultiOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::Float4MinMaxMultiOps,
             is_default: false,
         },
-        OperatorClass::Float8BloomOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::Float8BloomOps,
+        OperatorClass::Float8BloomOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::Float8BloomOps,
             is_default: false,
         },
-        OperatorClass::Float8MinMaxOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::Float8MinMaxOps,
+        OperatorClass::Float8MinMaxOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::Float8MinMaxOps,
             is_default: true,
         },
-        OperatorClass::Float8MinMaxMultiOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::Float8MinMaxMultiOps,
+        OperatorClass::Float8MinMaxMultiOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::Float8MinMaxMultiOps,
             is_default: false,
         },
-        OperatorClass::InetInclusionOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::InetInclusionOps,
+        OperatorClass::InetInclusionOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::InetInclusionOps,
             is_default: true,
         },
-        OperatorClass::InetBloomOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::InetBloomOps,
+        OperatorClass::InetBloomOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::InetBloomOps,
             is_default: false,
         },
-        OperatorClass::InetMinMaxOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::InetMinMaxOps,
+        OperatorClass::InetMinMaxOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::InetMinMaxOps,
             is_default: true,
         },
-        OperatorClass::InetMinMaxMultiOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::InetMinMaxMultiOps,
+        OperatorClass::InetMinMaxMultiOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::InetMinMaxMultiOps,
             is_default: false,
         },
-        OperatorClass::Int2BloomOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::Int2BloomOps,
+        OperatorClass::Int2BloomOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::Int2BloomOps,
             is_default: false,
         },
-        OperatorClass::Int2MinMaxOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::Int2MinMaxOps,
+        OperatorClass::Int2MinMaxOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::Int2MinMaxOps,
             is_default: true,
         },
-        OperatorClass::Int2MinMaxMultiOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::Int2MinMaxMultiOps,
+        OperatorClass::Int2MinMaxMultiOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::Int2MinMaxMultiOps,
             is_default: false,
         },
-        OperatorClass::Int4BloomOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::Int4BloomOps,
+        OperatorClass::Int4BloomOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::Int4BloomOps,
             is_default: false,
         },
-        OperatorClass::Int4MinMaxOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::Int4MinMaxOps,
+        OperatorClass::Int4MinMaxOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::Int4MinMaxOps,
             is_default: true,
         },
-        OperatorClass::Int4MinMaxMultiOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::Int4MinMaxMultiOps,
+        OperatorClass::Int4MinMaxMultiOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::Int4MinMaxMultiOps,
             is_default: false,
         },
-        OperatorClass::Int8BloomOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::Int8BloomOps,
+        OperatorClass::Int8BloomOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::Int8BloomOps,
             is_default: false,
         },
-        OperatorClass::Int8MinMaxOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::Int8MinMaxOps,
+        OperatorClass::Int8MinMaxOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::Int8MinMaxOps,
             is_default: true,
         },
-        OperatorClass::Int8MinMaxMultiOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::Int8MinMaxMultiOps,
+        OperatorClass::Int8MinMaxMultiOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::Int8MinMaxMultiOps,
             is_default: false,
         },
-        OperatorClass::NumericBloomOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::NumericBloomOps,
+        OperatorClass::NumericBloomOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::NumericBloomOps,
             is_default: false,
         },
-        OperatorClass::NumericMinMaxOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::NumericMinMaxOps,
+        OperatorClass::NumericMinMaxOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::NumericMinMaxOps,
             is_default: true,
         },
-        OperatorClass::NumericMinMaxMultiOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::NumericMinMaxMultiOps,
+        OperatorClass::NumericMinMaxMultiOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::NumericMinMaxMultiOps,
             is_default: false,
         },
-        OperatorClass::OidBloomOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::OidBloomOps,
+        OperatorClass::OidBloomOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::OidBloomOps,
             is_default: false,
         },
-        OperatorClass::OidMinMaxOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::OidMinMaxOps,
+        OperatorClass::OidMinMaxOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::OidMinMaxOps,
             is_default: true,
         },
-        OperatorClass::OidMinMaxMultiOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::OidMinMaxMultiOps,
+        OperatorClass::OidMinMaxMultiOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::OidMinMaxMultiOps,
             is_default: false,
         },
-        OperatorClass::TextBloomOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::TextBloomOps,
+        OperatorClass::TextBloomOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::TextBloomOps,
             is_default: false,
         },
-        OperatorClass::TextMinMaxOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::TextMinMaxOps,
+        OperatorClass::TextMinMaxOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::TextMinMaxOps,
             is_default: true,
         },
-        OperatorClass::TimestampBloomOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::TimestampBloomOps,
+        OperatorClass::TimestampBloomOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::TimestampBloomOps,
             is_default: false,
         },
-        OperatorClass::TimestampMinMaxOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::TimestampMinMaxOps,
+        OperatorClass::TimestampMinMaxOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::TimestampMinMaxOps,
             is_default: true,
         },
-        OperatorClass::TimestampMinMaxMultiOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::TimestampMinMaxMultiOps,
+        OperatorClass::TimestampMinMaxMultiOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::TimestampMinMaxMultiOps,
             is_default: false,
         },
-        OperatorClass::TimestampTzBloomOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::TimestampTzBloomOps,
+        OperatorClass::TimestampTzBloomOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::TimestampTzBloomOps,
             is_default: false,
         },
-        OperatorClass::TimestampTzMinMaxOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::TimestampTzMinMaxOps,
+        OperatorClass::TimestampTzMinMaxOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::TimestampTzMinMaxOps,
             is_default: true,
         },
-        OperatorClass::TimestampTzMinMaxMultiOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::TimestampTzMinMaxMultiOps,
+        OperatorClass::TimestampTzMinMaxMultiOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::TimestampTzMinMaxMultiOps,
             is_default: false,
         },
-        OperatorClass::TimeBloomOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::TimeBloomOps,
+        OperatorClass::TimeBloomOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::TimeBloomOps,
             is_default: false,
         },
-        OperatorClass::TimeMinMaxOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::TimeMinMaxOps,
+        OperatorClass::TimeMinMaxOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::TimeMinMaxOps,
             is_default: true,
         },
-        OperatorClass::TimeMinMaxMultiOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::TimeMinMaxMultiOps,
+        OperatorClass::TimeMinMaxMultiOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::TimeMinMaxMultiOps,
             is_default: false,
         },
-        OperatorClass::TimeTzBloomOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::TimeTzBloomOps,
+        OperatorClass::TimeTzBloomOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::TimeTzBloomOps,
             is_default: false,
         },
-        OperatorClass::TimeTzMinMaxOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::TimeTzMinMaxOps,
+        OperatorClass::TimeTzMinMaxOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::TimeTzMinMaxOps,
             is_default: true,
         },
-        OperatorClass::TimeTzMinMaxMultiOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::TimeTzMinMaxMultiOps,
+        OperatorClass::TimeTzMinMaxMultiOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::TimeTzMinMaxMultiOps,
             is_default: false,
         },
-        OperatorClass::UuidBloomOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::UuidBloomOps,
+        OperatorClass::UuidBloomOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::UuidBloomOps,
             is_default: false,
         },
-        OperatorClass::UuidMinMaxOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::UuidMinMaxOps,
+        OperatorClass::UuidMinMaxOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::UuidMinMaxOps,
             is_default: true,
         },
-        OperatorClass::UuidMinMaxMultiOps => sql::SQLOperatorClass {
-            kind: sql::SQLOperatorClassKind::UuidMinMaxMultiOps,
+        OperatorClass::UuidMinMaxMultiOps => sql::postgres::SQLOperatorClass {
+            kind: sql::postgres::SQLOperatorClassKind::UuidMinMaxMultiOps,
             is_default: false,
         },
     }

--- a/migration-engine/migration-engine-tests/src/assertions.rs
+++ b/migration-engine/migration-engine-tests/src/assertions.rs
@@ -9,8 +9,8 @@ use pretty_assertions::assert_eq;
 use prisma_value::PrismaValue;
 use sql::{postgres::PostgresSchemaExt, IndexFieldId};
 use sql_schema_describer::{
-    self as sql, Column, ColumnTypeFamily, DefaultKind, DefaultValue, Enum, ForeignKey, ForeignKeyAction, Index,
-    IndexType, PrimaryKey, SQLIndexAlgorithm, SQLOperatorClassKind, SQLSortOrder, SqlSchema, Table,
+    self as sql, postgres::SQLOperatorClassKind, Column, ColumnTypeFamily, DefaultKind, DefaultValue, Enum, ForeignKey,
+    ForeignKeyAction, Index, IndexType, PrimaryKey, SQLSortOrder, SqlIndexAlgorithm, SqlSchema, Table,
 };
 use test_setup::{BitFlags, Tags};
 
@@ -860,7 +860,7 @@ impl<'a> IndexAssertion<'a> {
         self
     }
 
-    pub fn assert_algorithm(self, algo: SQLIndexAlgorithm) -> Self {
+    pub fn assert_algorithm(self, algo: SqlIndexAlgorithm) -> Self {
         assert_eq!(self.index.algorithm, Some(algo));
 
         self

--- a/migration-engine/migration-engine-tests/tests/migrations/indexes/postgres.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/indexes/postgres.rs
@@ -4,7 +4,7 @@ mod gist;
 mod spgist;
 
 use migration_engine_tests::test_api::*;
-use sql_schema_describer::SQLIndexAlgorithm;
+use sql_schema_describer::SqlIndexAlgorithm;
 
 #[test_connector(tags(Postgres), exclude(CockroachDb), preview_features("extendedIndexes"))]
 fn hash_index(api: TestApi) {
@@ -21,7 +21,7 @@ fn hash_index(api: TestApi) {
 
     api.assert_schema().assert_table("A", |table| {
         table.assert_index_on_columns(&["a"], |index| {
-            index.assert_is_not_unique().assert_algorithm(SQLIndexAlgorithm::Hash)
+            index.assert_is_not_unique().assert_algorithm(SqlIndexAlgorithm::Hash)
         })
     });
 

--- a/migration-engine/migration-engine-tests/tests/migrations/indexes/postgres/brin.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/indexes/postgres/brin.rs
@@ -1,5 +1,5 @@
 use migration_engine_tests::test_api::*;
-use sql_schema_describer::{SQLIndexAlgorithm, SQLOperatorClassKind};
+use sql_schema_describer::{postgres::SQLOperatorClassKind, SqlIndexAlgorithm};
 
 #[test_connector(tags(Postgres), exclude(CockroachDb))]
 fn brin_preview_disabled(api: TestApi) {
@@ -39,7 +39,7 @@ fn brin_change_from_btree(api: TestApi) {
     api.assert_schema().assert_table("A", |table| {
         table
             .assert_has_column("data")
-            .assert_index_on_columns(&["data"], |idx| idx.assert_algorithm(SQLIndexAlgorithm::BTree))
+            .assert_index_on_columns(&["data"], |idx| idx.assert_algorithm(SqlIndexAlgorithm::BTree))
     });
 
     let dm = r#"
@@ -56,7 +56,7 @@ fn brin_change_from_btree(api: TestApi) {
     api.assert_schema().assert_table("A", |table| {
         table
             .assert_has_column("data")
-            .assert_index_on_columns(&["data"], |idx| idx.assert_algorithm(SQLIndexAlgorithm::Brin))
+            .assert_index_on_columns(&["data"], |idx| idx.assert_algorithm(SqlIndexAlgorithm::Brin))
     });
 }
 
@@ -77,7 +77,7 @@ fn brin_bit_minmax_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::BitMinMaxOps))
             })
     });
@@ -102,7 +102,7 @@ fn brin_bit_minmax_ops_default(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::BitMinMaxOps))
             })
     });
@@ -127,7 +127,7 @@ fn brin_varbit_minmax_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::VarBitMinMaxOps))
             })
     });
@@ -152,7 +152,7 @@ fn brin_varbit_minmax_ops_default(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::VarBitMinMaxOps))
             })
     });
@@ -177,7 +177,7 @@ fn brin_bpchar_minmax_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::BpcharMinMaxOps))
             })
     });
@@ -202,7 +202,7 @@ fn brin_bpchar_minmax_ops_default(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::BpcharMinMaxOps))
             })
     });
@@ -227,7 +227,7 @@ fn brin_bpchar_bloom_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::BpcharBloomOps))
             })
     });
@@ -252,7 +252,7 @@ fn brin_bytea_minmax_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::ByteaMinMaxOps))
             })
     });
@@ -277,7 +277,7 @@ fn brin_bytea_minmax_ops_default(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::ByteaMinMaxOps))
             })
     });
@@ -302,7 +302,7 @@ fn brin_bytea_bloom_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::ByteaBloomOps))
             })
     });
@@ -327,7 +327,7 @@ fn brin_date_minmax_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::DateMinMaxOps))
             })
     });
@@ -352,7 +352,7 @@ fn brin_date_minmax_ops_default(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::DateMinMaxOps))
             })
     });
@@ -377,7 +377,7 @@ fn brin_date_bloom_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::DateBloomOps))
             })
     });
@@ -402,7 +402,7 @@ fn brin_date_minmax_multi_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| {
                         attrs.assert_ops(SQLOperatorClassKind::DateMinMaxMultiOps)
                     })
@@ -429,7 +429,7 @@ fn brin_real_minmax_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::Float4MinMaxOps))
             })
     });
@@ -454,7 +454,7 @@ fn brin_real_minmax_ops_default(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::Float4MinMaxOps))
             })
     });
@@ -479,7 +479,7 @@ fn brin_real_bloom_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::Float4BloomOps))
             })
     });
@@ -504,7 +504,7 @@ fn brin_real_minmax_multi_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| {
                         attrs.assert_ops(SQLOperatorClassKind::Float4MinMaxMultiOps)
                     })
@@ -531,7 +531,7 @@ fn brin_double_minmax_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::Float8MinMaxOps))
             })
     });
@@ -556,7 +556,7 @@ fn brin_double_minmax_ops_default(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::Float8MinMaxOps))
             })
     });
@@ -581,7 +581,7 @@ fn brin_double_bloom_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::Float8BloomOps))
             })
     });
@@ -606,7 +606,7 @@ fn brin_double_minmax_multi_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| {
                         attrs.assert_ops(SQLOperatorClassKind::Float8MinMaxMultiOps)
                     })
@@ -633,7 +633,7 @@ fn brin_inet_minmax_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::InetMinMaxOps))
             })
     });
@@ -658,7 +658,7 @@ fn brin_inet_inclusion_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::InetInclusionOps))
             })
     });
@@ -683,7 +683,7 @@ fn brin_inet_inclusion_ops_default(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::InetInclusionOps))
             })
     });
@@ -708,7 +708,7 @@ fn brin_inet_bloom_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::InetBloomOps))
             })
     });
@@ -733,7 +733,7 @@ fn brin_inet_minmax_multi_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| {
                         attrs.assert_ops(SQLOperatorClassKind::InetMinMaxMultiOps)
                     })
@@ -760,7 +760,7 @@ fn brin_int2_minmax_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::Int2MinMaxOps))
             })
     });
@@ -785,7 +785,7 @@ fn brin_int2_minmax_ops_default(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::Int2MinMaxOps))
             })
     });
@@ -810,7 +810,7 @@ fn brin_int2_bloom_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::Int2BloomOps))
             })
     });
@@ -835,7 +835,7 @@ fn brin_int2_minmax_multi_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| {
                         attrs.assert_ops(SQLOperatorClassKind::Int2MinMaxMultiOps)
                     })
@@ -862,7 +862,7 @@ fn brin_int4_minmax_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::Int4MinMaxOps))
             })
     });
@@ -887,7 +887,7 @@ fn brin_int4_minmax_ops_default(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::Int4MinMaxOps))
             })
     });
@@ -912,7 +912,7 @@ fn brin_int4_bloom_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::Int4BloomOps))
             })
     });
@@ -937,7 +937,7 @@ fn brin_int4_minmax_multi_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| {
                         attrs.assert_ops(SQLOperatorClassKind::Int4MinMaxMultiOps)
                     })
@@ -964,7 +964,7 @@ fn brin_int8_minmax_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::Int8MinMaxOps))
             })
     });
@@ -989,7 +989,7 @@ fn brin_int8_minmax_ops_default(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::Int8MinMaxOps))
             })
     });
@@ -1014,7 +1014,7 @@ fn brin_int8_bloom_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::Int8BloomOps))
             })
     });
@@ -1039,7 +1039,7 @@ fn brin_int8_minmax_multi_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| {
                         attrs.assert_ops(SQLOperatorClassKind::Int8MinMaxMultiOps)
                     })
@@ -1066,7 +1066,7 @@ fn brin_numeric_minmax_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::NumericMinMaxOps))
             })
     });
@@ -1091,7 +1091,7 @@ fn brin_numeric_minmax_ops_default(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::NumericMinMaxOps))
             })
     });
@@ -1116,7 +1116,7 @@ fn brin_numeric_bloom_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::NumericBloomOps))
             })
     });
@@ -1141,7 +1141,7 @@ fn brin_numeric_minmax_multi_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| {
                         attrs.assert_ops(SQLOperatorClassKind::NumericMinMaxMultiOps)
                     })
@@ -1168,7 +1168,7 @@ fn brin_oid_minmax_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::OidMinMaxOps))
             })
     });
@@ -1193,7 +1193,7 @@ fn brin_oid_minmax_ops_default(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::OidMinMaxOps))
             })
     });
@@ -1218,7 +1218,7 @@ fn brin_oid_bloom_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::OidBloomOps))
             })
     });
@@ -1243,7 +1243,7 @@ fn brin_oid_minmax_multi_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| {
                         attrs.assert_ops(SQLOperatorClassKind::OidMinMaxMultiOps)
                     })
@@ -1270,7 +1270,7 @@ fn brin_text_minmax_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::TextMinMaxOps))
             })
     });
@@ -1295,7 +1295,7 @@ fn brin_text_minmax_ops_varchar(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::TextMinMaxOps))
             })
     });
@@ -1320,7 +1320,7 @@ fn brin_text_minmax_ops_default(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::TextMinMaxOps))
             })
     });
@@ -1345,7 +1345,7 @@ fn brin_text_minmax_ops_default_varchar(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::TextMinMaxOps))
             })
     });
@@ -1370,7 +1370,7 @@ fn brin_text_bloom_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::TextBloomOps))
             })
     });
@@ -1395,7 +1395,7 @@ fn brin_text_bloom_ops_varchar(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::TextBloomOps))
             })
     });
@@ -1420,7 +1420,7 @@ fn brin_timestamp_minmax_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| {
                         attrs.assert_ops(SQLOperatorClassKind::TimestampMinMaxOps)
                     })
@@ -1447,7 +1447,7 @@ fn brin_timestamp_minmax_ops_default(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| {
                         attrs.assert_ops(SQLOperatorClassKind::TimestampMinMaxOps)
                     })
@@ -1474,7 +1474,7 @@ fn brin_timestamp_bloom_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| {
                         attrs.assert_ops(SQLOperatorClassKind::TimestampBloomOps)
                     })
@@ -1501,7 +1501,7 @@ fn brin_timestamp_minmax_multi_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| {
                         attrs.assert_ops(SQLOperatorClassKind::TimestampMinMaxMultiOps)
                     })
@@ -1528,7 +1528,7 @@ fn brin_timestamptz_minmax_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| {
                         attrs.assert_ops(SQLOperatorClassKind::TimestampTzMinMaxOps)
                     })
@@ -1555,7 +1555,7 @@ fn brin_timestamptz_minmax_ops_default(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| {
                         attrs.assert_ops(SQLOperatorClassKind::TimestampTzMinMaxOps)
                     })
@@ -1582,7 +1582,7 @@ fn brin_timestamptz_bloom_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| {
                         attrs.assert_ops(SQLOperatorClassKind::TimestampTzBloomOps)
                     })
@@ -1609,7 +1609,7 @@ fn brin_timestamptz_minmax_multi_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| {
                         attrs.assert_ops(SQLOperatorClassKind::TimestampTzMinMaxMultiOps)
                     })
@@ -1636,7 +1636,7 @@ fn brin_time_minmax_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::TimeMinMaxOps))
             })
     });
@@ -1661,7 +1661,7 @@ fn brin_time_minmax_ops_default(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::TimeMinMaxOps))
             })
     });
@@ -1686,7 +1686,7 @@ fn brin_time_bloom_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::TimeBloomOps))
             })
     });
@@ -1711,7 +1711,7 @@ fn brin_time_minmax_multi_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| {
                         attrs.assert_ops(SQLOperatorClassKind::TimeMinMaxMultiOps)
                     })
@@ -1738,7 +1738,7 @@ fn brin_timetz_minmax_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::TimeTzMinMaxOps))
             })
     });
@@ -1763,7 +1763,7 @@ fn brin_timetz_minmax_ops_default(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::TimeTzMinMaxOps))
             })
     });
@@ -1788,7 +1788,7 @@ fn brin_timetz_bloom_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::TimeTzBloomOps))
             })
     });
@@ -1813,7 +1813,7 @@ fn brin_timetz_minmax_multi_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| {
                         attrs.assert_ops(SQLOperatorClassKind::TimeTzMinMaxMultiOps)
                     })
@@ -1840,7 +1840,7 @@ fn brin_uuid_minmax_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::UuidMinMaxOps))
             })
     });
@@ -1865,7 +1865,7 @@ fn brin_uuid_minmax_ops_default(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::UuidMinMaxOps))
             })
     });
@@ -1890,7 +1890,7 @@ fn brin_uuid_bloom_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::UuidBloomOps))
             })
     });
@@ -1915,7 +1915,7 @@ fn brin_uuid_minmax_multi_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Brin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Brin)
                     .assert_column("data", |attrs| {
                         attrs.assert_ops(SQLOperatorClassKind::UuidMinMaxMultiOps)
                     })

--- a/migration-engine/migration-engine-tests/tests/migrations/indexes/postgres/gin.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/indexes/postgres/gin.rs
@@ -1,5 +1,5 @@
 use migration_engine_tests::test_api::*;
-use sql_schema_describer::{SQLIndexAlgorithm, SQLOperatorClassKind};
+use sql_schema_describer::{postgres::SQLOperatorClassKind, SqlIndexAlgorithm};
 
 #[test_connector(tags(Postgres), exclude(CockroachDb))]
 fn gin_preview_disabled(api: TestApi) {
@@ -38,7 +38,7 @@ fn gin_change_from_btree(api: TestApi) {
     api.assert_schema().assert_table("A", |table| {
         table
             .assert_has_column("data")
-            .assert_index_on_columns(&["data"], |idx| idx.assert_algorithm(SQLIndexAlgorithm::BTree))
+            .assert_index_on_columns(&["data"], |idx| idx.assert_algorithm(SqlIndexAlgorithm::BTree))
     });
 
     let dm = r#"
@@ -55,7 +55,7 @@ fn gin_change_from_btree(api: TestApi) {
     api.assert_schema().assert_table("A", |table| {
         table
             .assert_has_column("data")
-            .assert_index_on_columns(&["data"], |idx| idx.assert_algorithm(SQLIndexAlgorithm::Gin))
+            .assert_index_on_columns(&["data"], |idx| idx.assert_algorithm(SqlIndexAlgorithm::Gin))
     });
 }
 
@@ -76,7 +76,7 @@ fn gin_array_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Gin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Gin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::ArrayOps))
             })
     });
@@ -101,7 +101,7 @@ fn gin_array_ops_default(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Gin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Gin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::ArrayOps))
             })
     });
@@ -126,7 +126,7 @@ fn gin_jsonb_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Gin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Gin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::JsonbOps))
             })
     });
@@ -151,7 +151,7 @@ fn gin_jsonb_ops_default(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Gin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Gin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::JsonbOps))
             })
     });
@@ -176,7 +176,7 @@ fn gin_jsonb_path_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Gin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Gin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::JsonbPathOps))
             })
     });
@@ -212,7 +212,7 @@ fn from_jsonb_ops_to_jsonb_path_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Gin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Gin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::JsonbPathOps))
             })
     });
@@ -236,7 +236,7 @@ fn compound_index_with_different_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data", "sata"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Gin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Gin)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::JsonbOps))
                     .assert_column("sata", |attrs| attrs.assert_ops(SQLOperatorClassKind::ArrayOps))
             })
@@ -260,7 +260,7 @@ fn gin_raw_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Gin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Gin)
                     .assert_column("data", |attrs| {
                         attrs.assert_ops(SQLOperatorClassKind::raw("tsvector_ops"))
                     })
@@ -287,7 +287,7 @@ fn gin_raw_ops_default(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Gin)
+                idx.assert_algorithm(SqlIndexAlgorithm::Gin)
                     .assert_column("data", |attrs| {
                         attrs.assert_ops(SQLOperatorClassKind::raw("tsvector_ops"))
                     })

--- a/migration-engine/migration-engine-tests/tests/migrations/indexes/postgres/gist.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/indexes/postgres/gist.rs
@@ -1,5 +1,5 @@
 use migration_engine_tests::test_api::*;
-use sql_schema_describer::{SQLIndexAlgorithm, SQLOperatorClassKind};
+use sql_schema_describer::{postgres::SQLOperatorClassKind, SqlIndexAlgorithm};
 
 #[test_connector(tags(Postgres), exclude(CockroachDb))]
 fn gist_preview_disabled(api: TestApi) {
@@ -38,7 +38,7 @@ fn gist_change_from_btree(api: TestApi) {
     api.assert_schema().assert_table("A", |table| {
         table
             .assert_has_column("data")
-            .assert_index_on_columns(&["data"], |idx| idx.assert_algorithm(SQLIndexAlgorithm::BTree))
+            .assert_index_on_columns(&["data"], |idx| idx.assert_algorithm(SqlIndexAlgorithm::BTree))
     });
 
     let dm = r#"
@@ -55,7 +55,7 @@ fn gist_change_from_btree(api: TestApi) {
     api.assert_schema().assert_table("A", |table| {
         table
             .assert_has_column("data")
-            .assert_index_on_columns(&["data"], |idx| idx.assert_algorithm(SQLIndexAlgorithm::Gist))
+            .assert_index_on_columns(&["data"], |idx| idx.assert_algorithm(SqlIndexAlgorithm::Gist))
     });
 }
 
@@ -76,7 +76,7 @@ fn gist_inet_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Gist)
+                idx.assert_algorithm(SqlIndexAlgorithm::Gist)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::InetOps))
             })
     });
@@ -101,7 +101,7 @@ fn gist_raw_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Gist)
+                idx.assert_algorithm(SqlIndexAlgorithm::Gist)
                     .assert_column("data", |attrs| {
                         attrs.assert_ops(SQLOperatorClassKind::raw("tsvector_ops"))
                     })
@@ -128,7 +128,7 @@ fn gist_unsupported_no_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::Gist)
+                idx.assert_algorithm(SqlIndexAlgorithm::Gist)
                     .assert_column("data", |attrs| {
                         attrs.assert_ops(SQLOperatorClassKind::raw("tsvector_ops"))
                     })

--- a/migration-engine/migration-engine-tests/tests/migrations/indexes/postgres/spgist.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/indexes/postgres/spgist.rs
@@ -1,5 +1,5 @@
 use migration_engine_tests::test_api::*;
-use sql_schema_describer::{SQLIndexAlgorithm, SQLOperatorClassKind};
+use sql_schema_describer::{postgres::SQLOperatorClassKind, SqlIndexAlgorithm};
 
 #[test_connector(tags(Postgres), exclude(CockroachDb, Postgres9))]
 fn spgist_preview_disabled(api: TestApi) {
@@ -38,7 +38,7 @@ fn spgist_change_from_btree(api: TestApi) {
     api.assert_schema().assert_table("A", |table| {
         table
             .assert_has_column("data")
-            .assert_index_on_columns(&["data"], |idx| idx.assert_algorithm(SQLIndexAlgorithm::BTree))
+            .assert_index_on_columns(&["data"], |idx| idx.assert_algorithm(SqlIndexAlgorithm::BTree))
     });
 
     let dm = r#"
@@ -55,7 +55,7 @@ fn spgist_change_from_btree(api: TestApi) {
     api.assert_schema().assert_table("A", |table| {
         table
             .assert_has_column("data")
-            .assert_index_on_columns(&["data"], |idx| idx.assert_algorithm(SQLIndexAlgorithm::Gist))
+            .assert_index_on_columns(&["data"], |idx| idx.assert_algorithm(SqlIndexAlgorithm::Gist))
     });
 }
 
@@ -76,7 +76,7 @@ fn spgist_inet_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::SpGist)
+                idx.assert_algorithm(SqlIndexAlgorithm::SpGist)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::InetOps))
             })
     });
@@ -101,7 +101,7 @@ fn spgist_inet_ops_default(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::SpGist)
+                idx.assert_algorithm(SqlIndexAlgorithm::SpGist)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::InetOps))
             })
     });
@@ -126,7 +126,7 @@ fn spgist_text_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::SpGist)
+                idx.assert_algorithm(SqlIndexAlgorithm::SpGist)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::TextOps))
             })
     });
@@ -151,7 +151,7 @@ fn spgist_text_ops_default(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::SpGist)
+                idx.assert_algorithm(SqlIndexAlgorithm::SpGist)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::TextOps))
             })
     });
@@ -176,7 +176,7 @@ fn spgist_text_ops_varchar(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::SpGist)
+                idx.assert_algorithm(SqlIndexAlgorithm::SpGist)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::TextOps))
             })
     });
@@ -201,7 +201,7 @@ fn spgist_text_ops_varchar_default(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::SpGist)
+                idx.assert_algorithm(SqlIndexAlgorithm::SpGist)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::TextOps))
             })
     });
@@ -226,7 +226,7 @@ fn spgist_raw_ops(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::SpGist)
+                idx.assert_algorithm(SqlIndexAlgorithm::SpGist)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::raw("box_ops")))
             })
     });
@@ -251,7 +251,7 @@ fn spgist_raw_ops_default(api: TestApi) {
         table
             .assert_has_column("data")
             .assert_index_on_columns(&["data"], |idx| {
-                idx.assert_algorithm(SQLIndexAlgorithm::SpGist)
+                idx.assert_algorithm(SqlIndexAlgorithm::SpGist)
                     .assert_column("data", |attrs| attrs.assert_ops(SQLOperatorClassKind::raw("box_ops")))
             })
     });


### PR DESCRIPTION
This commit uses the ConnectorData abstraction introduced in
https://github.com/prisma/prisma-engines/pull/2861 to clean up the
representation of sequences in sql-schema-describer, in preparation for
the CockroachDB sequences work.

Two main items:

- Take sequences private to the postgres sql schema describer

  Other supported connectors either do not have the concept of sequence
  present on postgresql. Taking sequences postgres-only buys us more
  compact representation with less redundant information, both on other
  connectors (they have no sequence-related data anymore), and on
  postgres (we don't have to worry about sequences being optional: they
  exist).

- Delete the PrimaryKey.sequence field

  It introduces significant amounts of logic, but it is purely
  redundant: sequence defaults are regular defaults, on postgres. The
  same information is already present in the column defaults of the
  primary key column(s). Removing that field buys us more simplicity and
  consistency. No tests needed adjusting after that.

We expect this to simplify the cockroachdb sequence work by a lot.

See the links below for some documentation on sequences:

- https://www.postgresql.org/docs/current/sql-createsequence.html
- http://www.neilconway.org/docs/sequences/