### PR TITLE
feat(qe): add debug panic to cli

### DIFF
--- a/query-engine/query-engine/src/cli.rs
+++ b/query-engine/query-engine/src/cli.rs
@@ -32,7 +32,7 @@ pub struct GetConfigRequest {
 }
 
 pub struct DebugPanicRequest {
-    message: Option<String>
+    message: Option<String>,
 }
 
 pub enum CliCommand {
@@ -79,7 +79,7 @@ impl CliCommand {
                     config: opts.configuration(false)?.subject,
                 }))),
                 CliOpt::DebugPanic(input) => Ok(Some(CliCommand::DebugPanic(DebugPanicRequest {
-                    message: input.message.clone()
+                    message: input.message.clone(),
                 }))),
             },
         }
@@ -96,7 +96,7 @@ impl CliCommand {
                 } else {
                     panic!("query-engine debug panic");
                 }
-            },
+            }
         }
     }
 

--- a/query-engine/query-engine/src/cli.rs
+++ b/query-engine/query-engine/src/cli.rs
@@ -31,10 +31,15 @@ pub struct GetConfigRequest {
     ignore_env_var_errors: bool,
 }
 
+pub struct DebugPanicRequest {
+    message: Option<String>
+}
+
 pub enum CliCommand {
     Dmmf(DmmfRequest),
     GetConfig(GetConfigRequest),
     ExecuteRequest(ExecuteRequest),
+    DebugPanic(DebugPanicRequest),
 }
 
 impl CliCommand {
@@ -73,6 +78,9 @@ impl CliCommand {
                     datamodel: opts.datamodel()?,
                     config: opts.configuration(false)?.subject,
                 }))),
+                CliOpt::DebugPanic(input) => Ok(Some(CliCommand::DebugPanic(DebugPanicRequest {
+                    message: input.message.clone()
+                }))),
             },
         }
     }
@@ -82,6 +90,13 @@ impl CliCommand {
             CliCommand::Dmmf(request) => Self::dmmf(request).await,
             CliCommand::GetConfig(input) => Self::get_config(input),
             CliCommand::ExecuteRequest(request) => Self::execute_request(request).await,
+            CliCommand::DebugPanic(request) => {
+                if let Some(message) = request.message {
+                    panic!("{}", message);
+                } else {
+                    panic!("query-engine debug panic");
+                }
+            },
         }
     }
 

--- a/query-engine/query-engine/src/opt.rs
+++ b/query-engine/query-engine/src/opt.rs
@@ -28,6 +28,13 @@ pub struct GetConfigInput {
     pub ignore_env_var_errors: bool,
 }
 
+#[derive(Debug, Clone, StructOpt)]
+#[structopt(rename_all = "camelCase")]
+pub struct DebugPanicInput {
+    #[structopt(long)]
+    pub message: Option<String>,
+}
+
 #[derive(Debug, StructOpt, Clone)]
 pub enum CliOpt {
     /// Output the DMMF from the loaded data model.
@@ -36,6 +43,8 @@ pub enum CliOpt {
     GetConfig(GetConfigInput),
     /// Executes one request and then terminates.
     ExecuteRequest(ExecuteRequestInput),
+    /// Artificially panic (for testing the CLI) with an optional message.
+    DebugPanic(DebugPanicInput),
 }
 
 #[derive(Debug, StructOpt, Clone)]


### PR DESCRIPTION
Added support for `query-engine cli debug-panic --message [optional-message]`.

Deprecates https://github.com/prisma/prisma-engines/pull/2852.
Addresses [this comment](https://github.com/prisma/prisma-engines/pull/2852#issuecomment-1103958143).
Contributes to https://github.com/prisma/prisma/issues/12494.