### PR TITLE
feat(qe): customized debug panic message in node api

### DIFF
--- a/query-engine/query-engine-node-api/src/functions.rs
+++ b/query-engine/query-engine-node-api/src/functions.rs
@@ -96,8 +96,9 @@ pub fn get_config(js_env: Env, options: JsUnknown) -> napi::Result<JsUnknown> {
 }
 
 #[napi]
-pub fn debug_panic() -> napi::Result<()> {
-    let user_facing = user_facing_errors::Error::from_panic_payload(Box::new("Debug panic"));
+pub fn debug_panic(panic_message: Option<String>) -> napi::Result<()> {
+    let user_facing =
+        user_facing_errors::Error::from_panic_payload(Box::new(panic_message.unwrap_or_else(|| "query-engine-node-api debug panic".to_string())));
     let message = serde_json::to_string(&user_facing).unwrap();
 
     Err(napi::Error::from_reason(message))


### PR DESCRIPTION
Added support for custom panic messages in `query-engine-node-api`'s `debug_panic` function.

Deprecates https://github.com/prisma/prisma-engines/pull/2852.
Contributes to https://github.com/prisma/prisma/issues/12494.