### PR TITLE
Fix regression for introspection of crdb dbs with postgres provider

### DIFF
--- a/introspection-engine/introspection-engine-tests/src/test_api.rs
+++ b/introspection-engine/introspection-engine-tests/src/test_api.rs
@@ -22,7 +22,7 @@ use test_setup::{sqlite_test_url, DatasourceBlock, TestApiArgs};
 use tracing::Instrument;
 
 pub struct TestApi {
-    api: SqlIntrospectionConnector,
+    pub api: SqlIntrospectionConnector,
     database: Quaint,
     args: TestApiArgs,
     connection_string: String,

--- a/introspection-engine/introspection-engine-tests/tests/cockroachdb/mod.rs
+++ b/introspection-engine/introspection-engine-tests/tests/cockroachdb/mod.rs
@@ -1,0 +1,43 @@
+use datamodel::parse_configuration;
+use introspection_connector::{CompositeTypeDepth, IntrospectionConnector, IntrospectionContext};
+use introspection_engine_tests::test_api::*;
+
+#[test_connector(tags(CockroachDb))]
+async fn introspecting_cockroach_db_with_postgres_provider(api: TestApi) {
+    let setup = r#"
+        CREATE TABLE "myTable" (
+            id   INTEGER PRIMARY KEY,
+            name STRING
+       );
+    "#;
+
+    let schema = format!(
+        r#"
+        datasource mypg {{
+            provider = "postgresql"
+            url = "{}"
+        }}
+
+    "#,
+        api.connection_string()
+    );
+
+    api.raw_cmd(setup).await;
+
+    let ctx = IntrospectionContext {
+        preview_features: Default::default(),
+        source: parse_configuration(&schema)
+            .unwrap()
+            .subject
+            .datasources
+            .into_iter()
+            .next()
+            .unwrap(),
+        composite_type_depth: CompositeTypeDepth::Infinite,
+    };
+
+    api.api
+        .introspect(&datamodel::parse_datamodel(&schema).unwrap().subject, ctx)
+        .await
+        .unwrap();
+}

--- a/introspection-engine/introspection-engine-tests/tests/introspection_tests.rs
+++ b/introspection-engine/introspection-engine-tests/tests/introspection_tests.rs
@@ -1,4 +1,5 @@
 mod add_prisma1_defaults;
+mod cockroachdb;
 mod commenting_out;
 mod enums;
 mod errors;

--- a/libs/sql-schema-describer/src/postgres.rs
+++ b/libs/sql-schema-describer/src/postgres.rs
@@ -16,6 +16,7 @@ use tracing::trace;
 #[repr(u8)]
 pub enum Circumstances {
     Cockroach,
+    CockroachWithPostgresNativeTypes, // TODO: this is a temporary workaround
 }
 
 pub struct SqlSchemaDescriber<'a> {
@@ -321,7 +322,11 @@ impl<'a> SqlSchemaDescriber<'a> {
             };
 
             let data_type = col.get_expect_string("data_type");
-            let tpe = if self.is_cockroach() {
+            let tpe = if self.is_cockroach()
+                && !self
+                    .circumstances
+                    .contains(Circumstances::CockroachWithPostgresNativeTypes)
+            {
                 get_column_type_cockroachdb(&col, enums)
             } else {
                 get_column_type_postgresql(&col, enums)


### PR DESCRIPTION
The incompatibility we introduced is that the native type definitions
now diverge. Introspection would instruct the sql-schema-describer to
introspect with cockroach settings, which is necessary for the process
to work, but then expect postgres types out of the introspected schema
(since it is using the postgres datamodel connector).

The proposed solution is to add a directive to the postgres sql schema
describer to allow introspecting with cockroach settings, but use
postgres native types.

The parts of the introspection engine touched by this PR have not
received love in a very long time, and this commit makes them worse. We
will want to come back to this to improve the interface and state
management at the top level of the introspection engine.