### PR TITLE
Reimplement Oid native type on cockroachdb

### DIFF
--- a/libs/datamodel/connectors/sql-datamodel-connector/src/cockroach_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/cockroach_datamodel_connector.rs
@@ -19,6 +19,7 @@ const INT2_TYPE_NAME: &str = "Int2";
 const INT4_TYPE_NAME: &str = "Int4";
 const INT8_TYPE_NAME: &str = "Int8";
 const JSON_B_TYPE_NAME: &str = "JsonB";
+const OID_TYPE_NAME: &str = "Oid";
 const SINGLE_CHAR_TYPE_NAME: &str = "SingleChar";
 const STRING_TYPE_NAME: &str = "String";
 const TIMESTAMP_TYPE_NAME: &str = "Timestamp";
@@ -50,6 +51,7 @@ const NATIVE_TYPE_CONSTRUCTORS: &[NativeTypeConstructor] = &[
     NativeTypeConstructor::without_args(INT4_TYPE_NAME, &[ScalarType::Int]),
     NativeTypeConstructor::without_args(INT8_TYPE_NAME, &[ScalarType::BigInt]),
     NativeTypeConstructor::without_args(JSON_B_TYPE_NAME, &[ScalarType::Json]),
+    NativeTypeConstructor::without_args(OID_TYPE_NAME, &[ScalarType::Int]),
     NativeTypeConstructor::without_args(SINGLE_CHAR_TYPE_NAME, &[ScalarType::String]),
     NativeTypeConstructor::without_args(UUID_TYPE_NAME, &[ScalarType::String]),
 ];
@@ -135,6 +137,7 @@ impl Connector for CockroachDatamodelConnector {
             // Int
             CockroachType::Int2 => ScalarType::Int,
             CockroachType::Int4 => ScalarType::Int,
+            CockroachType::Oid => ScalarType::Int,
             // BigInt
             CockroachType::Int8 => ScalarType::BigInt,
             // Float
@@ -248,6 +251,7 @@ impl Connector for CockroachDatamodelConnector {
             BOOL_TYPE_NAME => CockroachType::Bool,
             DATE_TYPE_NAME => CockroachType::Date,
             JSON_B_TYPE_NAME => CockroachType::JsonB,
+            OID_TYPE_NAME => CockroachType::Oid,
             TIME_TYPE_NAME => CockroachType::Time(parse_one_opt_u32(args, TIME_TYPE_NAME, span)?),
             TIME_TZ_TYPE_NAME => CockroachType::Timetz(parse_one_opt_u32(args, TIME_TZ_TYPE_NAME, span)?),
             UUID_TYPE_NAME => CockroachType::Uuid,
@@ -264,6 +268,7 @@ impl Connector for CockroachDatamodelConnector {
             CockroachType::Int2 => (INT2_TYPE_NAME, vec![]),
             CockroachType::Int4 => (INT4_TYPE_NAME, vec![]),
             CockroachType::Int8 => (INT8_TYPE_NAME, vec![]),
+            CockroachType::Oid => (OID_TYPE_NAME, vec![]),
             CockroachType::Decimal(x) => (DECIMAL_TYPE_NAME, args_vec_from_opt(x)),
             CockroachType::Float4 => (FLOAT4_TYPE_NAME, vec![]),
             CockroachType::Float8 => (FLOAT8_TYPE_NAME, vec![]),

--- a/libs/datamodel/core/tests/types/cockroachdb_native_types.rs
+++ b/libs/datamodel/core/tests/types/cockroachdb_native_types.rs
@@ -103,6 +103,7 @@ fn cockroach_specific_native_types_are_valid() {
         int4col     Int      @db.Int4
         int8col     BigInt   @db.Int8
         jsonbcol    Json     @db.JsonB
+        oidcol      Int      @db.Oid
         scharcol    String   @db.SingleChar
         stringcol1  String   @db.String
         stringcol2  String   @db.String(40)

--- a/libs/native-types/src/cockroach.rs
+++ b/libs/native-types/src/cockroach.rs
@@ -15,6 +15,7 @@ pub enum CockroachType {
     Int4,
     Int8,
     JsonB,
+    Oid,
     SingleChar,
     String(Option<u32>),
     Time(Option<u32>),

--- a/libs/sql-schema-describer/src/postgres.rs
+++ b/libs/sql-schema-describer/src/postgres.rs
@@ -987,6 +987,7 @@ fn get_column_type_cockroachdb(row: &ResultRow, enums: &[Enum]) -> ColumnType {
             )),
         ),
         "pg_lsn" | "_pg_lsn" => unsupported_type(),
+        "oid" | "_oid" => (Int, Some(CockroachType::Oid)),
         "time" | "_time" => (DateTime, Some(CockroachType::Time(precision.time_precision))),
         "timetz" | "_timetz" => (DateTime, Some(CockroachType::Timetz(precision.time_precision))),
         "timestamp" | "_timestamp" => (DateTime, Some(CockroachType::Timestamp(precision.time_precision))),

--- a/libs/sql-schema-describer/tests/describers/postgres_describer_tests/cockroach_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/postgres_describer_tests/cockroach_describer_tests.rs
@@ -47,6 +47,7 @@ fn all_cockroach_column_types_must_work(api: TestApi) {
             float_col FLOAT,
             int_col INT,
             numeric_col NUMERIC,
+            oid_col OID,
             smallint_col SMALLINT,
             smallserial_col SMALLSERIAL,
             serial_col SERIAL,
@@ -160,6 +161,10 @@ fn all_cockroach_column_types_must_work(api: TestApi) {
         .assert_column("char_col", |c| {
             c.assert_full_data_type("bpchar")
                 .assert_column_type_family(ColumnTypeFamily::String)
+        })
+        .assert_column("oid_col", |c| {
+            c.assert_full_data_type("oid")
+                .assert_column_type_family(ColumnTypeFamily::Int)
         })
         .assert_column("time_col", |c| {
             c.assert_full_data_type("time")

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
@@ -489,15 +489,16 @@ fn render_column_type_cockroachdb(col: &ColumnWalker<'_>) -> Cow<'static, str> {
 
     let tpe: Cow<'_, str> = match native_type {
         CockroachType::Inet => "INET".into(),
-        CockroachType::Int2 if is_autoincrement => "SMALLSERIAL".into(),
+        CockroachType::Int2 if is_autoincrement => "SERIAL2".into(),
         CockroachType::Int2 => "INT2".into(),
         CockroachType::Int4 if is_autoincrement => "SERIAL4".into(),
         CockroachType::Int4 => "INT4".into(),
-        CockroachType::Int8 if is_autoincrement => "BIGSERIAL".into(),
-        CockroachType::Int8 => "BIGINT".into(),
+        CockroachType::Int8 if is_autoincrement => "SERIAL8".into(),
+        CockroachType::Int8 => "INT8".into(),
+        CockroachType::Oid => "OID".into(),
         CockroachType::Decimal(precision) => format!("DECIMAL{}", render_decimal_args(precision)).into(),
-        CockroachType::Float4 => "REAL".into(),
-        CockroachType::Float8 => "DOUBLE PRECISION".into(),
+        CockroachType::Float4 => "FLOAT4".into(),
+        CockroachType::Float8 => "FLOAT8".into(),
         CockroachType::String(length) => format!("STRING{}", render_optional_args(length)).into(),
 
         // https://www.cockroachlabs.com/docs/stable/string.html
@@ -510,7 +511,7 @@ fn render_column_type_cockroachdb(col: &ColumnWalker<'_>) -> Cow<'static, str> {
         CockroachType::Timestamptz(precision) => format!("TIMESTAMPTZ{}", render_optional_args(precision)).into(),
         CockroachType::Time(precision) => format!("TIME{}", render_optional_args(precision)).into(),
         CockroachType::Timetz(precision) => format!("TIMETZ{}", render_optional_args(precision)).into(),
-        CockroachType::Bool => "BOOLEAN".into(),
+        CockroachType::Bool => "BOOL".into(),
         CockroachType::Bit(length) => format!("BIT{}", render_optional_args(length)).into(),
         CockroachType::VarBit(length) => format!("VARBIT{}", render_optional_args(length)).into(),
         CockroachType::Uuid => "UUID".into(),

--- a/migration-engine/migration-engine-tests/tests/migrations/cockroachdb.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/cockroachdb.rs
@@ -110,6 +110,7 @@ fn native_type_columns_can_be_created(api: TestApi) {
         ("smallint", "Int", "Int2", "int2"),
         ("int", "Int", "Int4", "int4"),
         ("bigint", "BigInt", "Int8", "int8"),
+        ("oid", "Int", "Oid", "oid"),
         ("decimal", "Decimal", "Decimal(4, 2)", "numeric"),
         ("decimaldefault", "Decimal", "Decimal", "numeric"),
         ("float4col", "Float", "Float4", "float4"),


### PR DESCRIPTION
It is not documented, but it exists.

Additionally, use the more idiomatic type names for some types in
postgres_renderer.rs

closes https://github.com/prisma/prisma/issues/13003