### PR TITLE
fix: emulated cascade one2one different id name

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_delete/cascade.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_delete/cascade.rs
@@ -89,31 +89,39 @@ mod one2one_opt {
 
     fn diff_id_name() -> String {
         let schema = indoc! {
-            r#"model User {
+            r#"model Parent {
             #id(id, Int, @id)
-            name          String?
-            profile       Profile?
+            uniq    Int? @unique
+            child   Child?
           }
           
-          model Profile {
-            #id(profileId, Int, @id)
-            user      User     @relation(fields: [profileId], references: [id], onDelete: Cascade)
+          model Child {
+            #id(childId, Int, @id)
+            childUniq       Int?
+            parent           Parent? @relation(fields: [childUniq], references: [uniq], onDelete: Cascade)
           }"#
         };
 
         schema.to_owned()
     }
 
+    /// Deleting the parent deletes child as well.
+    /// Checks that it works even with different parent/child primary identifier names.
     #[connector_test(schema(diff_id_name))]
     async fn delete_parent_diff_id_name(runner: Runner) -> TestResult<()> {
         run_query!(
             &runner,
-            r#"mutation { createOneUser(data: { id: 1, name: "Bob", profile: { create: {} } }) { id } }"#
+            r#"mutation { createOneParent(data: { id: 1, uniq: 1, child: { create: { childId: 1 } } }) { id } }"#
         );
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"mutation { deleteOneUser(where: { id: 1 }) { id } }"#),
-          @r###"{"data":{"deleteOneUser":{"id":1}}}"###
+          run_query!(&runner, r#"mutation { deleteOneParent(where: { id: 1 }) { id } }"#),
+          @r###"{"data":{"deleteOneParent":{"id":1}}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{ findManyChild { childUniq } }"#),
+          @r###"{"data":{"findManyChild":[]}}"###
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_delete/restrict.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_delete/restrict.rs
@@ -119,6 +119,41 @@ mod one2one_opt {
 
         Ok(())
     }
+
+    fn diff_id_name() -> String {
+        let schema = indoc! {
+            r#"model Parent {
+            #id(id, Int, @id)
+            uniq    Int? @unique
+            child   Child?
+          }
+          
+          model Child {
+            #id(childId, Int, @id)
+            childUniq       Int?
+            parent           Parent? @relation(fields: [childUniq], references: [uniq], onDelete: Restrict)
+          }"#
+        };
+
+        schema.to_owned()
+    }
+
+    /// Deleting the parent succeeds if no child is connected.
+    /// Checks that it works even with different parent/child primary identifier names.
+    #[connector_test(schema(diff_id_name))]
+    async fn delete_parent_diff_id_name(runner: Runner) -> TestResult<()> {
+        run_query!(
+            &runner,
+            r#"mutation { createOneParent(data: { id: 1, uniq: 1 }) { id } }"#
+        );
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"mutation { deleteOneParent(where: { id: 1 }) { id } }"#),
+          @r###"{"data":{"deleteOneParent":{"id":1}}}"###
+        );
+
+        Ok(())
+    }
 }
 
 #[test_suite(suite = "restrict_onD_1toM_req", schema(required), exclude(SqlServer))]

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_update/cascade.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_update/cascade.rs
@@ -83,7 +83,7 @@ mod one2one_req {
         // Checks that it work when no FK is updated
         insta::assert_snapshot!(
           run_query!(runner, r#"mutation { upsertOneParent(where: { id: 1 }, update: { name: "Bob" }, create: { id: 1, uniq: 1 }) { name uniq } }"#),
-          @r###"{"data":{"upsertOneParent":{"uniq":4}}}"###
+          @r###"{"data":{"upsertOneParent":{"name":"Bob","uniq":4}}}"###
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_update/set_null.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_update/set_null.rs
@@ -356,6 +356,51 @@ mod one2one_opt {
 
         Ok(())
     }
+
+    fn diff_id_name() -> String {
+        let schema = indoc! {
+            r#"model Parent {
+            #id(id, Int, @id)
+            uniq    Int? @unique
+            child   Child?
+          }
+          
+          model Child {
+            #id(childId, Int, @id)
+            childUniq       Int?
+            parent           Parent? @relation(fields: [childUniq], references: [uniq], onUpdate: SetNull)
+          }"#
+        };
+
+        schema.to_owned()
+    }
+
+    // Updating the parent updates the child FK as well.
+    // Checks that it works even with different parent/child primary identifier names.
+    #[connector_test(schema(diff_id_name))]
+    async fn update_parent_diff_id_name(runner: Runner) -> TestResult<()> {
+        run_query!(
+            &runner,
+            r#"mutation { createOneParent(data: { id: 1, uniq: 1, child: { create: { childId: 1 } } }) { id } }"#
+        );
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"mutation {
+            updateOneParent(
+              where: { id: 1 }
+              data: { uniq: 2 }
+            ) {
+              id
+              uniq
+              child { childId childUniq }
+            }
+          }
+          "#),
+          @r###"{"data":{"updateOneParent":{"id":1,"uniq":2,"child":null}}}"###
+        );
+
+        Ok(())
+    }
 }
 
 #[test_suite(

--- a/query-engine/core/src/query_graph/formatters.rs
+++ b/query-engine/core/src/query_graph/formatters.rs
@@ -101,7 +101,10 @@ impl Display for QueryGraphDependency {
                 write!(
                     f,
                     "ProjectedDataDependency ({:?})",
-                    selection.prisma_names().collect::<Vec<_>>()
+                    selection
+                        .selections()
+                        .map(|f| format!("{}.{}", f.container().name(), f.prisma_name()))
+                        .collect::<Vec<_>>()
                 )
             }
             Self::Then => write!(f, "Then"),

--- a/query-engine/core/src/query_graph_builder/write/utils.rs
+++ b/query-engine/core/src/query_graph_builder/write/utils.rs
@@ -960,7 +960,7 @@ pub fn emulate_on_update_cascade(
 ) -> QueryGraphBuilderResult<()> {
     let dependent_model = relation_field.model();
     let parent_relation_field = relation_field.related_field();
-    let child_model_identifier = relation_field.related_model().primary_identifier();
+    let child_linking_fields = parent_relation_field.related_field().linking_fields();
     let (parent_pks, child_fks) = if relation_field.is_inlined_on_enclosing_model() {
         (relation_field.referenced_fields(), relation_field.scalar_fields())
     } else {
@@ -1006,7 +1006,7 @@ pub fn emulate_on_update_cascade(
         &dependent_records_node,
         &update_dependents_node,
         QueryGraphDependency::ProjectedDataDependency(
-            child_model_identifier.clone(),
+            child_linking_fields,
             Box::new(move |mut update_dependents_node, dependent_ids| {
                 if let Node::Query(Query::Write(WriteQuery::UpdateManyRecords(ref mut dmr))) = update_dependents_node {
                     dmr.record_filter = dependent_ids.into();

--- a/query-engine/core/src/query_graph_builder/write/utils.rs
+++ b/query-engine/core/src/query_graph_builder/write/utils.rs
@@ -448,7 +448,7 @@ pub fn emulate_on_delete_cascade(
 ) -> QueryGraphBuilderResult<()> {
     let dependent_model = relation_field.model();
     let parent_relation_field = relation_field.related_field();
-    let child_linking_fields = parent_relation_field.related_field().linking_fields();
+    let child_model_identifier = parent_relation_field.related_model().primary_identifier();
 
     // Records that need to be deleted for the cascade.
     let dependent_records_node =
@@ -473,7 +473,7 @@ pub fn emulate_on_delete_cascade(
         &dependent_records_node,
         &delete_dependents_node,
         QueryGraphDependency::ProjectedDataDependency(
-            child_linking_fields,
+            child_model_identifier,
             Box::new(move |mut delete_dependents_node, dependent_ids| {
                 if let Node::Query(Query::Write(WriteQuery::DeleteManyRecords(ref mut dmr))) = delete_dependents_node {
                     dmr.record_filter = dependent_ids.into();
@@ -540,7 +540,7 @@ pub fn emulate_on_delete_set_null(
 ) -> QueryGraphBuilderResult<()> {
     let dependent_model = relation_field.model();
     let parent_relation_field = relation_field.related_field();
-    let child_model_identifier = relation_field.related_model().primary_identifier().clone();
+    let child_model_identifier = parent_relation_field.related_model().primary_identifier();
     let child_fks = if relation_field.is_inlined_on_enclosing_model() {
         relation_field.scalar_fields()
     } else {
@@ -655,7 +655,7 @@ pub fn emulate_on_update_set_null(
 ) -> QueryGraphBuilderResult<()> {
     let dependent_model = relation_field.model();
     let parent_relation_field = relation_field.related_field();
-    let child_model_identifier = relation_field.related_model().primary_identifier().clone();
+    let child_model_identifier = parent_relation_field.related_model().primary_identifier();
 
     // Only the nullable fks should be updated to null
     let (parent_pks, child_fks) = if relation_field.is_inlined_on_enclosing_model() {
@@ -960,7 +960,7 @@ pub fn emulate_on_update_cascade(
 ) -> QueryGraphBuilderResult<()> {
     let dependent_model = relation_field.model();
     let parent_relation_field = relation_field.related_field();
-    let child_linking_fields = parent_relation_field.related_field().linking_fields();
+    let child_model_identifier = parent_relation_field.related_model().primary_identifier();
     let (parent_pks, child_fks) = if relation_field.is_inlined_on_enclosing_model() {
         (relation_field.referenced_fields(), relation_field.scalar_fields())
     } else {
@@ -970,12 +970,10 @@ pub fn emulate_on_update_cascade(
         )
     };
 
-    // Records that need to be updated for the cascade.
-    let dependent_records_node =
-        insert_find_children_by_parent_node(graph, parent_node, &parent_relation_field, Filter::empty())?;
-
     // Unwraps are safe as in this stage, no node content can be replaced.
     let parent_update_args = extract_update_args(graph.node_content(child_node).unwrap());
+
+    // Computes update arguments for child based on parent update arguments
     let child_update_args: Vec<_> = parent_pks
         .into_iter()
         .zip(child_fks)
@@ -985,6 +983,15 @@ pub fn emulate_on_update_cascade(
                 .map(|value| (DatasourceFieldName::from(&child_fk), value.clone()))
         })
         .collect();
+
+    // If nothing was found to be updated for the child, stop here
+    if child_update_args.is_empty() {
+        return Ok(());
+    }
+
+    // Records that need to be updated for the cascade.
+    let dependent_records_node =
+        insert_find_children_by_parent_node(graph, parent_node, &parent_relation_field, Filter::empty())?;
 
     let update_query = WriteQuery::UpdateManyRecords(UpdateManyRecords {
         model: dependent_model.clone(),
@@ -1006,7 +1013,7 @@ pub fn emulate_on_update_cascade(
         &dependent_records_node,
         &update_dependents_node,
         QueryGraphDependency::ProjectedDataDependency(
-            child_linking_fields,
+            child_model_identifier,
             Box::new(move |mut update_dependents_node, dependent_ids| {
                 if let Node::Query(Query::Write(WriteQuery::UpdateManyRecords(ref mut dmr))) = update_dependents_node {
                     dmr.record_filter = dependent_ids.into();

--- a/query-engine/core/src/query_graph_builder/write/utils.rs
+++ b/query-engine/core/src/query_graph_builder/write/utils.rs
@@ -448,7 +448,7 @@ pub fn emulate_on_delete_cascade(
 ) -> QueryGraphBuilderResult<()> {
     let dependent_model = relation_field.model();
     let parent_relation_field = relation_field.related_field();
-    let child_model_identifier = relation_field.related_model().primary_identifier();
+    let child_linking_fields = parent_relation_field.related_field().linking_fields();
 
     // Records that need to be deleted for the cascade.
     let dependent_records_node =
@@ -473,7 +473,7 @@ pub fn emulate_on_delete_cascade(
         &dependent_records_node,
         &delete_dependents_node,
         QueryGraphDependency::ProjectedDataDependency(
-            child_model_identifier.clone(),
+            child_linking_fields,
             Box::new(move |mut delete_dependents_node, dependent_ids| {
                 if let Node::Query(Query::Write(WriteQuery::DeleteManyRecords(ref mut dmr))) = delete_dependents_node {
                     dmr.record_filter = dependent_ids.into();

--- a/query-engine/prisma-models/src/field/scalar.rs
+++ b/query-engine/prisma-models/src/field/scalar.rs
@@ -83,7 +83,7 @@ impl Debug for ScalarField {
             .field("arity", &self.arity)
             .field("db_name", &self.db_name)
             .field("default_value", &self.default_value)
-            .field("model", &"#ModelWeakRef#")
+            .field("model", &self.container().name())
             .field("is_unique", &self.is_unique)
             .field("read_only", &self.read_only)
             .finish()

--- a/query-engine/prisma-models/src/field_selection.rs
+++ b/query-engine/prisma-models/src/field_selection.rs
@@ -1,7 +1,8 @@
 use std::fmt::Display;
 
 use crate::{
-    CompositeFieldRef, DomainError, Field, PrismaValueExtensions, RelationField, ScalarFieldRef, SelectionResult,
+    parent_container::ParentContainer, CompositeFieldRef, DomainError, Field, PrismaValueExtensions, RelationField,
+    ScalarFieldRef, SelectionResult,
 };
 use itertools::Itertools;
 use prisma_value::PrismaValue;
@@ -168,6 +169,13 @@ impl SelectedField {
         match self {
             SelectedField::Composite(ref cs) => Some(cs),
             _ => None,
+        }
+    }
+
+    pub fn container(&self) -> &ParentContainer {
+        match self {
+            SelectedField::Scalar(sf) => sf.container(),
+            SelectedField::Composite(cs) => cs.field.container(),
         }
     }
 


### PR DESCRIPTION
## Overview

Fixes https://github.com/prisma/prisma/issues/10758
Fixes https://github.com/prisma/prisma/issues/11792

- **fix**: Emulated cascade for `onDelete` & `onUpdate` had a wrong data dependency which triggered a reload node which resulted in a faulty query.
- **improvement**: Optimized `onUpdate: Cascade` by not adding any nodes to the graph if no FKs are updated on the parent (this was already done on other RAs but not on `Cascade` for some reason. Must've missed it when I implemented the emulations.)
- **improvement**: Slightly improved debugging logs