### PR TITLE
chore(prisma-value): delete unnecessary dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3030,7 +3030,6 @@ dependencies = [
  "once_cell",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "uuid",
 ]

--- a/libs/prisma-value/Cargo.toml
+++ b/libs/prisma-value/Cargo.toml
@@ -13,7 +13,6 @@ chrono = { version = "0.4", features = ["serde"] }
 once_cell = "1.3"
 regex = "1.2"
 bigdecimal = "0.2"
-serde = "1.0"
-serde_derive = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["float_roundtrip"] }
 uuid = { version = "0.8", features = ["serde"] }

--- a/libs/prisma-value/src/lib.rs
+++ b/libs/prisma-value/src/lib.rs
@@ -5,8 +5,7 @@ mod error;
 use bigdecimal::{BigDecimal, FromPrimitive, ToPrimitive};
 use chrono::prelude::*;
 use serde::de::Unexpected;
-use serde::{ser::Serializer, Deserializer, Serialize as SerializeTrait};
-use serde_derive::{Deserialize, Serialize};
+use serde::{ser::Serializer, Deserialize, Deserializer, Serialize};
 use std::{convert::TryFrom, fmt, str::FromStr};
 use uuid::Uuid;
 


### PR DESCRIPTION
serde-derive is included in serde through the `derive` Cargo feature.