### PR TITLE
Keep index order in re-introspection

### DIFF
--- a/introspection-engine/connectors/sql-introspection-connector/src/re_introspection.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/re_introspection.rs
@@ -303,16 +303,21 @@ fn merge_changed_scalar_key_names(
     let mut changed_scalar_field_names = vec![];
 
     for model in new_data_model.models() {
-        if let Some(old_model) = &old_data_model.find_model(&model.name) {
-            for field in model.scalar_fields() {
-                if let Some(old_field) =
-                    old_model.find_scalar_field_db_name(field.database_name.as_ref().unwrap_or(&field.name))
-                {
-                    if model.find_scalar_field(&old_field.name).is_none() {
-                        let mf = ModelAndField::new(&model.name, &field.name);
-                        changed_scalar_field_names.push((mf, old_field.name.clone()))
-                    }
-                }
+        let old_model = match old_data_model.find_model(&model.name) {
+            Some(old_model) => old_model,
+            None => continue,
+        };
+
+        for field in model.scalar_fields() {
+            let old_field =
+                match old_model.find_scalar_field_db_name(field.database_name.as_ref().unwrap_or(&field.name)) {
+                    Some(old_field) => old_field,
+                    None => continue,
+                };
+
+            if model.find_scalar_field(&old_field.name).is_none() {
+                let mf = ModelAndField::new(&model.name, &field.name);
+                changed_scalar_field_names.push((mf, old_field.name.clone()))
             }
         }
     }
@@ -337,6 +342,7 @@ fn merge_changed_scalar_key_names(
         for index in &mut model.indices {
             replace_index_field_names(&mut index.fields, &changed_field_name.0.field, &changed_field_name.1);
         }
+
         for field in model.relation_fields_mut() {
             replace_relation_info_field_names(
                 &mut field.relation_info.fields,
@@ -349,8 +355,10 @@ fn merge_changed_scalar_key_names(
     // change RelationInfo.references
     for changed_field_name in &changed_scalar_field_names {
         let fields_to_be_changed = new_data_model.find_relation_fields_for_model(&changed_field_name.0.model);
+
         for f in fields_to_be_changed {
             let field = new_data_model.find_relation_field_mut(&f.0, &f.1);
+
             replace_relation_info_field_names(
                 &mut field.relation_info.references,
                 &changed_field_name.0.field,
@@ -373,30 +381,33 @@ fn merge_changed_relation_field_names(old_data_model: &Datamodel, new_data_model
     let mut changed_relation_field_names = vec![];
 
     for new_model in new_data_model.models() {
+        let old_model = match old_data_model.find_model(&new_model.name) {
+            Some(old_model) => old_model,
+            None => continue,
+        };
+
         for new_field in new_model.relation_fields() {
-            if let Some(old_model) = old_data_model.find_model(&new_model.name) {
-                for old_field in old_model.relation_fields() {
-                    let (_, old_related_field) = &old_data_model.find_related_field_bang(old_field);
-                    let is_many_to_many = old_field.is_list() && old_related_field.is_list();
-                    let is_self_relation = old_field.relation_info.to == old_related_field.relation_info.to;
+            for old_field in old_model.relation_fields() {
+                let (_, old_related_field) = &old_data_model.find_related_field_bang(old_field);
+                let is_many_to_many = old_field.is_list() && old_related_field.is_list();
+                let is_self_relation = old_field.relation_info.to == old_related_field.relation_info.to;
 
-                    let (_, related_field) = &new_data_model.find_related_field_bang(new_field);
+                let (_, related_field) = &new_data_model.find_related_field_bang(new_field);
 
-                    //the relationinfos of both sides need to be compared since the relationinfo of the
-                    // non-fk side does not contain enough information to uniquely identify the correct relationfield
-                    let relation_info_partial_eq = old_field.relation_info == new_field.relation_info
-                        && old_related_field.relation_info == related_field.relation_info;
+                //the relationinfos of both sides need to be compared since the relationinfo of the
+                // non-fk side does not contain enough information to uniquely identify the correct relationfield
+                let relation_info_partial_eq = old_field.relation_info == new_field.relation_info
+                    && old_related_field.relation_info == related_field.relation_info;
 
-                    let mf = ModelAndField::new(&new_model.name, &new_field.name);
+                let mf = ModelAndField::new(&new_model.name, &new_field.name);
 
-                    if relation_info_partial_eq
-                        && (!is_many_to_many
+                if relation_info_partial_eq
+                    && (!is_many_to_many
                                 //For many to many the relation infos always look the same, here we have to look at the relation name,
                                 //which translates to the join table name. But in case of self relations we cannot correctly infer the old name
                                 || (old_field.relation_info.name == new_field.relation_info.name && !is_self_relation))
-                    {
-                        changed_relation_field_names.push((mf.clone(), old_field.name.clone()));
-                    }
+                {
+                    changed_relation_field_names.push((mf.clone(), old_field.name.clone()));
                 }
             }
         }
@@ -419,24 +430,30 @@ fn merge_changed_relation_names(old_data_model: &Datamodel, new_data_model: &mut
     let mut changed_relation_names = vec![];
 
     for model in new_data_model.models() {
+        let old_model = match old_data_model.find_model(model.name()) {
+            Some(old_model) => old_model,
+            None => continue,
+        };
+
         for field in model.relation_fields() {
-            if let Some(old_model) = old_data_model.find_model(&model.name) {
-                for old_field in old_model.relation_fields() {
-                    let (_, related_field) = &new_data_model.find_related_field_bang(field);
-                    let (_, old_related_field) = &old_data_model.find_related_field_bang(old_field);
-                    //the relationinfos of both sides need to be compared since the relationinfo of the
-                    // non-fk side does not contain enough information to uniquely identify the correct relationfield
+            let (_, related_field) = &new_data_model.find_related_field_bang(field);
 
-                    let relation_info_partial_eq = old_field.relation_info == field.relation_info
-                        && old_related_field.relation_info == related_field.relation_info;
-                    let many_to_many = old_field.is_list() && old_related_field.is_list();
+            for old_field in old_model.relation_fields() {
+                let (_, old_related_field) = &old_data_model.find_related_field_bang(old_field);
 
-                    if relation_info_partial_eq && !many_to_many {
-                        let mf = ModelAndField::new(&model.name, &field.name);
-                        let other_mf = ModelAndField::new(&field.relation_info.to, &related_field.name);
-                        changed_relation_names.push((mf, old_field.relation_info.name.clone()));
-                        changed_relation_names.push((other_mf, old_field.relation_info.name.clone()))
-                    }
+                // the relationinfos of both sides need to be compared since the relationinfo of the
+                // non-fk side does not contain enough information to uniquely identify the correct relationfield
+                let relation_info_partial_eq = old_field.relation_info == field.relation_info
+                    && old_related_field.relation_info == related_field.relation_info;
+
+                let many_to_many = old_field.is_list() && old_related_field.is_list();
+
+                if relation_info_partial_eq && !many_to_many {
+                    let mf = ModelAndField::new(&model.name, &field.name);
+                    let other_mf = ModelAndField::new(&field.relation_info.to, &related_field.name);
+
+                    changed_relation_names.push((mf, old_field.relation_info.name.clone()));
+                    changed_relation_names.push((other_mf, old_field.relation_info.name.clone()))
                 }
             }
         }
@@ -464,6 +481,7 @@ fn merge_changed_enum_names(old_data_model: &Datamodel, new_data_model: &mut Dat
     for changed_enum_name in &changed_enum_names {
         let enm = new_data_model.find_enum_mut(&changed_enum_name.0.enm);
         enm.name = changed_enum_name.1.clone();
+
         if enm.database_name.is_none() {
             enm.database_name = Some(changed_enum_name.0.enm.clone());
         }
@@ -489,24 +507,31 @@ fn merge_changed_enum_values(old_data_model: &Datamodel, new_data_model: &mut Da
     let mut changed_enum_values = vec![];
 
     for enm in new_data_model.enums() {
-        if let Some(old_enum) = old_data_model.find_enum(&enm.name) {
-            for value in enm.values() {
-                if let Some(old_value) =
-                    old_enum.find_value_db_name(value.database_name.as_ref().unwrap_or(&value.name.to_owned()))
-                {
-                    if enm.find_value(&old_value.name).is_none() {
-                        let ev = EnumAndValue::new(&enm.name, &value.name);
-                        changed_enum_values.push((ev, old_value.name.clone()))
-                    }
-                }
+        let old_enum = match old_data_model.find_enum(&enm.name) {
+            Some(old_enum) => old_enum,
+            None => continue,
+        };
+
+        for value in enm.values() {
+            let old_value =
+                match old_enum.find_value_db_name(value.database_name.as_ref().unwrap_or(&value.name.to_owned())) {
+                    Some(old_value) => old_value,
+                    None => continue,
+                };
+
+            if enm.find_value(&old_value.name).is_none() {
+                let ev = EnumAndValue::new(&enm.name, &value.name);
+                changed_enum_values.push((ev, old_value.name.clone()))
             }
         }
     }
 
     for changed_enum_value in &changed_enum_values {
         let enm = new_data_model.find_enum_mut(&changed_enum_value.0.enm);
+
         let value = enm.find_value_mut(&changed_enum_value.0.value);
         value.name = changed_enum_value.1.clone();
+
         if value.database_name.is_none() {
             value.database_name = Some(changed_enum_value.0.value.clone());
         }
@@ -545,26 +570,41 @@ fn merge_mysql_enum_names(old_data_model: &Datamodel, new_data_model: &mut Datam
 
     if ctx.sql_family().is_mysql() {
         for enm in new_data_model.enums() {
-            if let Some((model_name, field_name)) = &new_data_model.find_enum_fields(&enm.name).first() {
-                if let Some(old_model) = old_data_model.find_model(model_name) {
-                    if let Some(old_field) = old_model.find_field(field_name) {
-                        if let FieldType::Enum(old_enum_name) = old_field.field_type() {
-                            let old_enum = old_data_model.find_enum(&old_enum_name).unwrap();
-                            if enm.values == old_enum.values
-                                && old_enum_name != enm.name
-                                && !changed_mysql_enum_names
-                                    .iter()
-                                    .any(|x: &(String, String, ModelAndField)| x.1 == old_enum_name)
-                            {
-                                changed_mysql_enum_names.push((
-                                    enm.name.clone(),
-                                    old_enum.name.clone(),
-                                    ModelAndField::new(model_name, field_name),
-                                ))
-                            }
-                        }
-                    }
-                }
+            let enum_fields = new_data_model.find_enum_fields(&enm.name);
+
+            let (model_name, field_name) = match enum_fields.first() {
+                Some((model_name, field_name)) => (model_name, field_name),
+                None => continue,
+            };
+
+            let old_model = match old_data_model.find_model(model_name) {
+                Some(old_model) => old_model,
+                None => continue,
+            };
+
+            let old_field = match old_model.find_field(field_name) {
+                Some(old_field) => old_field,
+                None => continue,
+            };
+
+            let old_enum_name = match old_field.field_type() {
+                FieldType::Enum(old_enum_name) => old_enum_name,
+                _ => continue,
+            };
+
+            let old_enum = old_data_model.find_enum(&old_enum_name).unwrap();
+
+            if enm.values == old_enum.values
+                && old_enum_name != enm.name
+                && !changed_mysql_enum_names
+                    .iter()
+                    .any(|x: &(String, String, ModelAndField)| x.1 == old_enum_name)
+            {
+                changed_mysql_enum_names.push((
+                    enm.name.clone(),
+                    old_enum.name.clone(),
+                    ModelAndField::new(model_name, field_name),
+                ))
             }
         }
 
@@ -593,22 +633,28 @@ fn merge_prisma_level_defaults(
 
     for model in new_data_model.models() {
         for field in model.scalar_fields() {
-            if let Some(old_model) = old_data_model.find_model(&model.name) {
-                if let Some(old_field) = old_model.find_scalar_field(&field.name) {
-                    if field.default_value.is_none() && field.field_type.is_string() {
-                        if old_field.default_value == Some(DefaultValue::new_expression(ValueGenerator::new_cuid())) {
-                            re_introspected_prisma_level_cuids.push(ModelAndField::new(&model.name, &field.name));
-                        }
+            let old_model = match old_data_model.find_model(&model.name) {
+                Some(old_model) => old_model,
+                None => continue,
+            };
 
-                        if old_field.default_value == Some(DefaultValue::new_expression(ValueGenerator::new_uuid())) {
-                            re_introspected_prisma_level_uuids.push(ModelAndField::new(&model.name, &field.name));
-                        }
-                    }
+            let old_field = match old_model.find_scalar_field(&field.name) {
+                Some(mike) => mike, // oldfield
+                None => continue,
+            };
 
-                    if field.field_type.is_datetime() && old_field.is_updated_at {
-                        re_introspected_updated_at.push(ModelAndField::new(&model.name, &field.name));
-                    }
+            if field.default_value.is_none() && field.field_type.is_string() {
+                if old_field.default_value == Some(DefaultValue::new_expression(ValueGenerator::new_cuid())) {
+                    re_introspected_prisma_level_cuids.push(ModelAndField::new(&model.name, &field.name));
                 }
+
+                if old_field.default_value == Some(DefaultValue::new_expression(ValueGenerator::new_uuid())) {
+                    re_introspected_prisma_level_uuids.push(ModelAndField::new(&model.name, &field.name));
+                }
+            }
+
+            if field.field_type.is_datetime() && old_field.is_updated_at {
+                re_introspected_updated_at.push(ModelAndField::new(&model.name, &field.name));
             }
         }
     }
@@ -651,17 +697,23 @@ fn merge_ignores(old_data_model: &Datamodel, new_data_model: &mut Datamodel, war
     let mut re_introspected_field_ignores = vec![];
 
     for model in new_data_model.models() {
-        if let Some(old_model) = old_data_model.find_model(&model.name) {
-            if old_model.is_ignored {
-                re_introspected_model_ignores.push(Model::new(&model.name));
-            }
+        let old_model = match old_data_model.find_model(&model.name) {
+            Some(old_model) => old_model,
+            None => continue,
+        };
 
-            for field in model.scalar_fields() {
-                if let Some(old_field) = old_model.find_scalar_field(&field.name) {
-                    if old_field.is_ignored {
-                        re_introspected_field_ignores.push(ModelAndField::new(&model.name, &field.name));
-                    }
-                }
+        if old_model.is_ignored {
+            re_introspected_model_ignores.push(Model::new(&model.name));
+        }
+
+        for field in model.scalar_fields() {
+            let old_field = match old_model.find_scalar_field(&field.name) {
+                Some(old_field) => old_field,
+                None => continue,
+            };
+
+            if old_field.is_ignored {
+                re_introspected_field_ignores.push(ModelAndField::new(&model.name, &field.name));
             }
         }
     }
@@ -688,19 +740,26 @@ fn merge_comments(old_data_model: &Datamodel, new_data_model: &mut Datamodel) {
     let mut re_introspected_field_comments = vec![];
 
     for model in new_data_model.models() {
+        let old_model = match old_data_model.find_model(&model.name) {
+            Some(old_model) => old_model,
+            None => continue,
+        };
+
+        if old_model.documentation.is_some() {
+            re_introspected_model_comments.push((Model::new(&model.name), &old_model.documentation))
+        }
+
         for field in &model.fields {
-            if let Some(old_model) = old_data_model.find_model(&model.name) {
-                if old_model.documentation.is_some() {
-                    re_introspected_model_comments.push((Model::new(&model.name), &old_model.documentation))
-                }
-                if let Some(old_field) = old_model.find_field(field.name()) {
-                    if old_field.documentation().is_some() {
-                        re_introspected_field_comments.push((
-                            ModelAndField::new(&model.name, field.name()),
-                            old_field.documentation().map(|s| s.to_string()),
-                        ))
-                    }
-                }
+            let old_field = match old_model.find_field(field.name()) {
+                Some(old_field) => old_field,
+                None => continue,
+            };
+
+            if old_field.documentation().is_some() {
+                re_introspected_field_comments.push((
+                    ModelAndField::new(&model.name, field.name()),
+                    old_field.documentation().map(|s| s.to_string()),
+                ))
             }
         }
     }
@@ -720,18 +779,25 @@ fn merge_comments(old_data_model: &Datamodel, new_data_model: &mut Datamodel) {
 
     for enm in new_data_model.enums() {
         for value in &enm.values {
-            if let Some(old_enum) = old_data_model.find_enum(&enm.name) {
-                if old_enum.documentation.is_some() {
-                    re_introspected_enum_comments.push((Enum::new(&enm.name), &old_enum.documentation))
-                }
-                if let Some(old_value) = old_enum.find_value(&value.name) {
-                    if old_value.documentation.is_some() {
-                        re_introspected_enum_value_comments.push((
-                            EnumAndValue::new(&enm.name, &value.name),
-                            old_value.documentation.clone(),
-                        ))
-                    }
-                }
+            let old_enum = match old_data_model.find_enum(&enm.name) {
+                Some(old_enum) => old_enum,
+                None => continue,
+            };
+
+            if old_enum.documentation.is_some() {
+                re_introspected_enum_comments.push((Enum::new(&enm.name), &old_enum.documentation))
+            }
+
+            let old_value = match old_enum.find_value(&value.name) {
+                Some(old_value) => old_value,
+                None => continue,
+            };
+
+            if old_value.documentation.is_some() {
+                re_introspected_enum_value_comments.push((
+                    EnumAndValue::new(&enm.name, &value.name),
+                    old_value.documentation.clone(),
+                ))
             }
         }
     }


### PR DESCRIPTION
This way things like the newly added new index types, that change the SQL ordering, will not cause crazy changes to existing Prisma data models.

Addresses: https://prisma-company.slack.com/archives/C02FNFLDUS3/p1651574110037009