### PR TITLE
Remove Prisma 1 legacy colons in reformat

### DIFF
--- a/libs/datamodel/core/src/reformat.rs
+++ b/libs/datamodel/core/src/reformat.rs
@@ -774,6 +774,15 @@ impl<'a> Reformatter<'a> {
                 comment(target, token.as_str())
             }
             Rule::WHITESPACE => {} // we are very opinionated about whitespace and hence ignore user input
+            // This is Prisma 1 thing, we should not render them. Example:
+            //
+            // ```no_run
+            // model Site {
+            //   name: String
+            //   htmlTitle: String
+            // }
+            // ```
+            Rule::LEGACY_COLON => {}
             Rule::CATCH_ALL | Rule::BLOCK_LEVEL_CATCH_ALL => {
                 target.write(token.as_str());
             }

--- a/libs/datamodel/core/tests/reformat/reformat.rs
+++ b/libs/datamodel/core/tests/reformat/reformat.rs
@@ -1408,3 +1408,22 @@ model Baz {
 
     expected.assert_eq(&reformat(schema));
 }
+
+#[test]
+fn removes_legacy_colon_from_fields() {
+    let input = indoc! {r#"
+        model Site {
+          name: String
+          htmlTitle: String
+        }
+    "#};
+
+    let expected = expect![[r#"
+        model Site {
+          name      String
+          htmlTitle String
+        }
+    "#]];
+
+    expected.assert_eq(&reformat(input));
+}


### PR DESCRIPTION
Do not panic.

Fixes https://github.com/prisma/prisma/issues/9302