### PR TITLE
feat: better query raw error on unsupported column

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3167,7 +3167,7 @@ dependencies = [
 [[package]]
 name = "quaint"
 version = "0.2.0-alpha.13"
-source = "git+https://github.com/prisma/quaint#c7dc33f9aecf8b359757af396b14f1567cf1598e"
+source = "git+https://github.com/prisma/quaint#3b94e4d0d0ffd226bd4517b673d18cb3960ecf10"
 dependencies = [
  "async-trait",
  "base64 0.12.3",

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/raw/sql/errors.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/raw/sql/errors.rs
@@ -1,0 +1,36 @@
+use indoc::indoc;
+use query_engine_tests::*;
+
+#[test_suite(schema(schema), only(Postgres))]
+mod raw_errors {
+    fn schema() -> String {
+        let schema = indoc! {
+            r#"model TestModel {
+              #id(id, Int, @id)
+              point Unsupported("point")
+            }"#
+        };
+
+        schema.to_owned()
+    }
+
+    #[connector_test]
+    async fn unsupported_columns(runner: Runner) -> TestResult<()> {
+        run_query!(
+            &runner,
+            fmt_execute_raw(
+                r#"INSERT INTO "TestModel" ("id", "point") VALUES (1, Point(1,2));"#,
+                vec![],
+            )
+        );
+
+        assert_error!(
+            runner,
+            fmt_query_raw(r#"SELECT * FROM "TestModel";"#, vec![]),
+            2010,
+            "Failed to deserialize column of type 'point'. If you're using $queryRaw and this column is explicitly marked as `Unsupported` in your datamodel, try casting this column to any supported Prisma type such as `String`."
+        );
+
+        Ok(())
+    }
+}

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/raw/sql/errors.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/raw/sql/errors.rs
@@ -28,7 +28,7 @@ mod raw_errors {
             runner,
             fmt_query_raw(r#"SELECT * FROM "TestModel";"#, vec![]),
             2010,
-            "Failed to deserialize column of type 'point'. If you're using $queryRaw and this column is explicitly marked as `Unsupported` in your datamodel, try casting this column to any supported Prisma type such as `String`."
+            "Failed to deserialize column of type 'point'. If you're using $queryRaw and this column is explicitly marked as `Unsupported` in your Prisma schema, try casting this column to any supported Prisma type such as `String`."
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/raw/sql/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/raw/sql/mod.rs
@@ -1,2 +1,3 @@
+mod errors;
 mod input_coercion;
 mod typed_output;

--- a/query-engine/connectors/sql-query-connector/src/error.rs
+++ b/query-engine/connectors/sql-query-connector/src/error.rs
@@ -29,7 +29,7 @@ impl From<RawError> for SqlError {
             RawError::UnsupportedColumnType { column_type } => Self::RawError {
                 code: String::from("N/A"),
                 message: format!(
-                    r#"Failed to deserialize column of type '{}'. If you're using $queryRaw and this column is explicitely marked as `Unsupported` in your datamodel, try casting this column to any supported Prisma type such as `String`."#,
+                    r#"Failed to deserialize column of type '{}'. If you're using $queryRaw and this column is explicitly marked as `Unsupported` in your Prisma schema, try casting this column to any supported Prisma type such as `String`."#,
                     column_type
                 ),
             },

--- a/query-engine/connectors/sql-query-connector/src/error.rs
+++ b/query-engine/connectors/sql-query-connector/src/error.rs
@@ -15,6 +15,9 @@ pub enum RawError {
         code: Option<String>,
         message: Option<String>,
     },
+    UnsupportedColumnType {
+        column_type: String,
+    },
 }
 
 impl From<RawError> for SqlError {
@@ -23,6 +26,13 @@ impl From<RawError> for SqlError {
             RawError::IncorrectNumberOfParameters { expected, actual } => {
                 Self::IncorrectNumberOfParameters { expected, actual }
             }
+            RawError::UnsupportedColumnType { column_type } => Self::RawError {
+                code: String::from("N/A"),
+                message: format!(
+                    r#"Failed to deserialize column of type '{}'. If you're using $queryRaw and this column is explicitely marked as `Unsupported` in your datamodel, try casting this column to any supported Prisma type such as `String`."#,
+                    column_type
+                ),
+            },
             RawError::ConnectionClosed => Self::ConnectionClosed,
             RawError::Database { code, message } => Self::RawError {
                 code: code.unwrap_or_else(|| String::from("N/A")),
@@ -42,6 +52,9 @@ impl From<quaint::error::Error> for RawError {
                 }
             }
             quaint::error::ErrorKind::ConnectionClosed => Self::ConnectionClosed,
+            quaint::error::ErrorKind::UnsupportedColumnType { column_type } => Self::UnsupportedColumnType {
+                column_type: column_type.to_owned(),
+            },
             _ => Self::Database {
                 code: e.original_code().map(ToString::to_string),
                 message: e.original_message().map(ToString::to_string),
@@ -269,13 +282,13 @@ impl From<quaint::error::Error> for SqlError {
             QuaintKind::ForeignKeyConstraintViolation { constraint } => Self::ForeignKeyConstraintViolation {
                 constraint: constraint.into(),
             },
-
             QuaintKind::MissingFullTextSearchIndex => Self::MissingFullTextSearchIndex,
             e @ QuaintKind::ConnectionError(_) => Self::ConnectionError(e),
             QuaintKind::ColumnReadFailure(e) => Self::ColumnReadFailure(e),
             QuaintKind::ColumnNotFound { column } => SqlError::ColumnDoesNotExist(format!("{}", column)),
             QuaintKind::TableDoesNotExist { table } => SqlError::TableDoesNotExist(format!("{}", table)),
             QuaintKind::ConnectionClosed => SqlError::ConnectionClosed,
+            e @ QuaintKind::UnsupportedColumnType { .. } => SqlError::ConversionError(e.into()),
             e @ QuaintKind::TransactionAlreadyClosed(_) => SqlError::TransactionAlreadyClosed(format!("{}", e)),
             e @ QuaintKind::IncorrectNumberOfParameters { .. } => SqlError::QueryError(e.into()),
             e @ QuaintKind::ConversionError(_) => SqlError::ConversionError(e.into()),


### PR DESCRIPTION
## Overview

Depends on https://github.com/prisma/quaint/pull/359

Related to a bunch of queryRaw issues where folks raw query Unsupported columns (eg: https://github.com/prisma/prisma/issues/12344), leading to the following unhelpful error:

```
error deserializing column 7: cannot convert between the Rust type core::option::Option::alloc::string::String and the Postgres type tsvector
```

This PR provides a much more helpful error which will hopefully reduce the amount of issues we receive about that topic.

## TODO

- [x] ⚠️ Update quaint before merging