### PR TITLE
fix: allow nulls in postgres scalar lists

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1973,18 +1973,24 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.12.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b70227ece8711a1aa2f99655efd795d0cff297a5b9fe39645a93aacf6ad39d"
+checksum = "2e52eb6380b6d2a10eb3434aec0885374490f5b82c8aaf5cd487a183c98be834"
 dependencies = [
- "metrics-core",
+ "ahash",
+ "metrics-macros",
 ]
 
 [[package]]
-name = "metrics-core"
-version = "0.5.2"
+name = "metrics-macros"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c064b3a1ff41f4bf6c91185c8a0caeccf8a8a27e9d0f92cc54cf3dbec812f48"
+checksum = "49e30813093f757be5cf21e50389a24dc7dbb22c49f23b7e8f51d69b508a5ffa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "migration-connector"
@@ -2133,7 +2139,7 @@ dependencies = [
 [[package]]
 name = "mobc"
 version = "0.7.3"
-source = "git+https://github.com/prisma/mobc?tag=1.0.0#75c68f1054b30e4aa22180c95eca1ccad96868cc"
+source = "git+https://github.com/prisma/mobc?tag=1.0.1#5a674b9e514b6985760b5bf4c8c478697b470893"
 dependencies = [
  "async-trait",
  "futures-channel",
@@ -2141,6 +2147,7 @@ dependencies = [
  "futures-timer",
  "futures-util",
  "log",
+ "metrics",
  "thiserror",
  "tokio",
 ]
@@ -3167,7 +3174,7 @@ dependencies = [
 [[package]]
 name = "quaint"
 version = "0.2.0-alpha.13"
-source = "git+https://github.com/prisma/quaint#3b94e4d0d0ffd226bd4517b673d18cb3960ecf10"
+source = "git+https://github.com/prisma/quaint#2fbc3fcfe654cf54f43ea11103ab44ac138dd18e"
 dependencies = [
  "async-trait",
  "base64 0.12.3",
@@ -4940,7 +4947,7 @@ version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f559b464de2e2bdabcac6a210d12e9b5a5973c251e102c44c585c71d51bd78e"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "rand 0.8.4",
  "static_assertions",
 ]

--- a/query-engine/connector-test-kit-rs/query-engine-tests/src/utils/raw.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/src/utils/raw.rs
@@ -33,6 +33,7 @@ pub enum RawParam {
     Decimal(String),
     Array(Vec<RawParam>),
     Primitive(serde_json::Value),
+    Null,
 }
 
 impl RawParam {
@@ -96,6 +97,7 @@ impl From<RawParam> for serde_json::Value {
                 serde_json::Value::Array(json_values)
             }
             RawParam::Primitive(v) => v,
+            RawParam::Null => serde_json::Value::Null,
         }
     }
 }

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/raw/sql/errors.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/raw/sql/errors.rs
@@ -33,4 +33,19 @@ mod raw_errors {
 
         Ok(())
     }
+
+    #[connector_test(schema(common_nullable_types))]
+    async fn list_param_for_scalar_column_should_not_panic(runner: Runner) -> TestResult<()> {
+        assert_error!(
+            runner,
+            fmt_execute_raw(
+                r#"INSERT INTO "TestModel" ("id") VALUES ($1);"#,
+                vec![RawParam::array(vec![1])],
+            ),
+            2010,
+            "error serializing parameter 0: Conversion failed: Couldn't serialize value `Some([Int64(Some(1))])` into a `int4`. Value is a list but `int4` is not."
+        );
+
+        Ok(())
+    }
 }

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/raw/sql/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/raw/sql/mod.rs
@@ -1,3 +1,4 @@
 mod errors;
 mod input_coercion;
+mod null_list;
 mod typed_output;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/raw/sql/null_list.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/raw/sql/null_list.rs
@@ -1,0 +1,268 @@
+use indoc::indoc;
+use query_engine_tests::*;
+
+#[test_suite(only(Postgres))]
+mod null_list {
+    use query_engine_tests::{fmt_query_raw, run_query, run_query_pretty};
+
+    #[connector_test(schema(common_list_types))]
+    async fn null_scalar_lists(runner: Runner) -> TestResult<()> {
+        run_query!(
+            &runner,
+            fmt_execute_raw(
+                r#"INSERT INTO "TestModel" ("id", "string", "int", "bInt", "float", "bytes", "bool", "dt") VALUES ($1, $2, $3, $4, $5, $6, $7, $8);"#,
+                vec![
+                    RawParam::from(1),
+                    RawParam::array(vec![RawParam::from("hello"), RawParam::Null]),
+                    RawParam::array(vec![RawParam::from(1337), RawParam::Null]),
+                    RawParam::array(vec![RawParam::bigint(133737), RawParam::Null]),
+                    RawParam::array(vec![RawParam::from(13.37), RawParam::Null]),
+                    RawParam::array(vec![RawParam::bytes(&[1, 2, 3]), RawParam::Null]),
+                    RawParam::array(vec![RawParam::from(true), RawParam::Null]),
+                    RawParam::array(vec![
+                        RawParam::try_datetime("1900-10-10T01:10:10.001Z")?,
+                        RawParam::Null
+                    ]),
+                ],
+            )
+        );
+
+        insta::assert_snapshot!(
+          run_query_pretty!(&runner, fmt_query_raw(r#"SELECT * FROM "TestModel";"#, vec![])),
+          @r###"
+        {
+          "data": {
+            "queryRaw": [
+              {
+                "id": {
+                  "prisma__type": "int",
+                  "prisma__value": 1
+                },
+                "string": {
+                  "prisma__type": "array",
+                  "prisma__value": [
+                    {
+                      "prisma__type": "string",
+                      "prisma__value": "hello"
+                    },
+                    {
+                      "prisma__type": "null",
+                      "prisma__value": null
+                    }
+                  ]
+                },
+                "int": {
+                  "prisma__type": "array",
+                  "prisma__value": [
+                    {
+                      "prisma__type": "int",
+                      "prisma__value": 1337
+                    },
+                    {
+                      "prisma__type": "null",
+                      "prisma__value": null
+                    }
+                  ]
+                },
+                "bInt": {
+                  "prisma__type": "array",
+                  "prisma__value": [
+                    {
+                      "prisma__type": "bigint",
+                      "prisma__value": "133737"
+                    },
+                    {
+                      "prisma__type": "null",
+                      "prisma__value": null
+                    }
+                  ]
+                },
+                "float": {
+                  "prisma__type": "array",
+                  "prisma__value": [
+                    {
+                      "prisma__type": "double",
+                      "prisma__value": 13.37
+                    },
+                    {
+                      "prisma__type": "null",
+                      "prisma__value": null
+                    }
+                  ]
+                },
+                "bytes": {
+                  "prisma__type": "array",
+                  "prisma__value": [
+                    {
+                      "prisma__type": "bytes",
+                      "prisma__value": "AQID"
+                    },
+                    {
+                      "prisma__type": "null",
+                      "prisma__value": null
+                    }
+                  ]
+                },
+                "bool": {
+                  "prisma__type": "array",
+                  "prisma__value": [
+                    {
+                      "prisma__type": "bool",
+                      "prisma__value": true
+                    },
+                    {
+                      "prisma__type": "null",
+                      "prisma__value": null
+                    }
+                  ]
+                },
+                "dt": {
+                  "prisma__type": "array",
+                  "prisma__value": [
+                    {
+                      "prisma__type": "datetime",
+                      "prisma__value": "1900-10-10T01:10:10.001+00:00"
+                    },
+                    {
+                      "prisma__type": "null",
+                      "prisma__value": null
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+        "###
+        );
+
+        Ok(())
+    }
+
+    fn native_list_types() -> String {
+        let schema = indoc! {
+            r#"model TestModel {
+                #id(id, Int, @id)
+                uuid  String[] @test.Uuid
+                bit   String[] @test.Bit(1)
+                inet  String[] @test.Inet
+                oid   Int[]    @test.Oid
+            }"#
+        };
+
+        schema.to_owned()
+    }
+
+    #[connector_test(schema(native_list_types))]
+    async fn null_native_type_lists(runner: Runner) -> TestResult<()> {
+        run_query!(
+            &runner,
+            fmt_execute_raw(
+                r#"INSERT INTO "TestModel" ("id", "uuid", "bit", "inet", "oid") VALUES ($1, $2, $3, $4, $5);"#,
+                vec![
+                    RawParam::from(1),
+                    RawParam::array(vec![
+                        RawParam::from("936DA01F-9ABD-4D9D-80C7-02AF85C822A8"),
+                        RawParam::Null
+                    ]),
+                    RawParam::array(vec![RawParam::from("1"), RawParam::Null]),
+                    RawParam::array(vec![RawParam::from("127.0.0.1"), RawParam::Null]),
+                    RawParam::array(vec![RawParam::from(123), RawParam::Null]),
+                ],
+            )
+        );
+
+        insta::assert_snapshot!(
+          run_query_pretty!(&runner, fmt_query_raw(r#"SELECT * FROM "TestModel";"#, vec![])),
+          @r###"
+        {
+          "data": {
+            "queryRaw": [
+              {
+                "id": {
+                  "prisma__type": "int",
+                  "prisma__value": 1
+                },
+                "uuid": {
+                  "prisma__type": "array",
+                  "prisma__value": [
+                    {
+                      "prisma__type": "uuid",
+                      "prisma__value": "936da01f-9abd-4d9d-80c7-02af85c822a8"
+                    },
+                    {
+                      "prisma__type": "null",
+                      "prisma__value": null
+                    }
+                  ]
+                },
+                "bit": {
+                  "prisma__type": "array",
+                  "prisma__value": [
+                    {
+                      "prisma__type": "string",
+                      "prisma__value": "1"
+                    },
+                    {
+                      "prisma__type": "null",
+                      "prisma__value": null
+                    }
+                  ]
+                },
+                "inet": {
+                  "prisma__type": "array",
+                  "prisma__value": [
+                    {
+                      "prisma__type": "string",
+                      "prisma__value": "127.0.0.1"
+                    },
+                    {
+                      "prisma__type": "null",
+                      "prisma__value": null
+                    }
+                  ]
+                },
+                "oid": {
+                  "prisma__type": "array",
+                  "prisma__value": [
+                    {
+                      "prisma__type": "bigint",
+                      "prisma__value": "123"
+                    },
+                    {
+                      "prisma__type": "null",
+                      "prisma__value": null
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+        "###
+        );
+
+        Ok(())
+    }
+
+    // Regression test for https://github.com/prisma/prisma/issues/11339
+    #[connector_test(schema(common_nullable_types))]
+    async fn prisma_11339(runner: Runner) -> TestResult<()> {
+        run_query!(
+            &runner,
+            "mutation {
+                createManyTestModel(data: [
+                    { id: 1, int: 1 },
+                    { id: 2 }
+                ]) { count }
+            }"
+        );
+
+        insta::assert_snapshot!(
+            run_query!(&runner, fmt_query_raw(r#"SELECT ARRAY_AGG(int) FROM "TestModel";"#, vec![])),
+            @r###"{"data":{"queryRaw":[{"array_agg":{"prisma__type":"array","prisma__value":[{"prisma__type":"int","prisma__value":1},{"prisma__type":"null","prisma__value":null}]}}]}}"###
+        );
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Overview

follow-up PR to https://github.com/prisma/quaint/pull/361

fixes https://github.com/prisma/prisma/issues/11339
- Quaint wasn't able to deserialize scalar lists containing NULLs. This was the root cause for `ARRAY_AGG` to fail in the issue that this PR closes.

fixes https://github.com/prisma/prisma/issues/12641
fixes https://github.com/prisma/prisma/issues/10224
- `tokio-postgres` was panicking when attempting to serialize an array for a scalar that's not of type list. It now throws a proper recoverable error