### PR TITLE
Adds metrics to Query Engine

### DIFF
--- a/.buildkite/engineer
+++ b/.buildkite/engineer
@@ -13,7 +13,7 @@ fi
 if ! type "engineer" > /dev/null; then
     # Setup Prisma engine build & test tool (engineer).
     set -e
-    curl --fail -sSL "https://prisma-engineer.s3-eu-west-1.amazonaws.com/1.39/latest/$OS/engineer.gz" --output engineer.gz
+    curl --fail -sSL "https://prisma-engineer.s3-eu-west-1.amazonaws.com/1.40/latest/$OS/engineer.gz" --output engineer.gz
     gzip -d engineer.gz
     chmod +x engineer
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,6 +131,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-shim"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67cd4b51d303cf3501c301e8125df442128d3c6d7c69f71b27833d253de47e77"
+dependencies = [
+ "crossbeam-utils 0.8.6",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -916,6 +925,12 @@ name = "encoding_index_tests"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
+
+[[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "enum-as-inner"
@@ -1889,6 +1904,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1982,6 +2006,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "metrics-exporter-prometheus"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b93b470b04c005178058e18ac8bb2eb3fda562cf87af5ea05ba8d44190d458c"
+dependencies = [
+ "hyper",
+ "indexmap",
+ "ipnet",
+ "metrics",
+ "metrics-util",
+ "parking_lot 0.11.2",
+ "quanta",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "metrics-macros"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1990,6 +2032,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65a9e83b833e1d2e07010a386b197c13aa199bbd0fca5cf69bfa147972db890a"
+dependencies = [
+ "aho-corasick",
+ "atomic-shim",
+ "crossbeam-epoch",
+ "crossbeam-utils 0.8.6",
+ "hashbrown",
+ "indexmap",
+ "metrics",
+ "num_cpus",
+ "ordered-float",
+ "parking_lot 0.11.2",
+ "quanta",
+ "radix_trie",
+ "sketches-ddsketch",
 ]
 
 [[package]]
@@ -2046,7 +2109,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-error",
- "tracing-subscriber 0.3.9",
+ "tracing-subscriber 0.3.11",
  "url",
  "user-facing-errors",
 ]
@@ -2137,7 +2200,7 @@ dependencies = [
 [[package]]
 name = "mobc"
 version = "0.7.3"
-source = "git+https://github.com/prisma/mobc?tag=1.0.2#2d20f6da12a8bae6093b3749706725194130a586"
+source = "git+https://github.com/prisma/mobc?tag=1.0.3#1d67f7cf416b0e555ec830d7e02f0fa563f44b15"
 dependencies = [
  "async-trait",
  "futures-channel",
@@ -2281,6 +2344,8 @@ dependencies = [
  "futures",
  "indexmap",
  "itertools",
+ "metrics",
+ "metrics-util",
  "mongodb",
  "mongodb-client",
  "native-types",
@@ -2473,6 +2538,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2653,6 +2727,15 @@ dependencies = [
  "tokio",
  "tonic 0.5.2",
  "tonic-build",
+]
+
+[[package]]
+name = "ordered-float"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -3170,7 +3253,7 @@ dependencies = [
 [[package]]
 name = "quaint"
 version = "0.2.0-alpha.13"
-source = "git+https://github.com/prisma/quaint#a97e758b28d82b429998ea5bbf335b77d8379f7b"
+source = "git+https://github.com/prisma/quaint#a916d18f1b4fa49d8cdd013d8df9a453c818df3f"
 dependencies = [
  "async-trait",
  "base64 0.12.3",
@@ -3208,6 +3291,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20afe714292d5e879d8b12740aa223c6a88f118af41870e8b6196e39a02238a8"
+dependencies = [
+ "crossbeam-utils 0.8.6",
+ "libc",
+ "mach",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.10.2+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "query-connector"
 version = "0.1.0"
 dependencies = [
@@ -3239,14 +3338,19 @@ dependencies = [
  "cuid",
  "datamodel",
  "datamodel-connector",
+ "expect-test",
  "futures",
  "im",
  "indexmap",
  "itertools",
  "lazy_static",
+ "metrics",
+ "metrics-exporter-prometheus",
+ "metrics-util",
  "mongodb-client",
  "mongodb-query-connector",
  "once_cell",
+ "parking_lot 0.12.0",
  "petgraph 0.4.13",
  "pin-utils",
  "prisma-inflector",
@@ -3262,6 +3366,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-futures",
+ "tracing-subscriber 0.3.11",
  "url",
  "user-facing-errors",
  "uuid",
@@ -3306,7 +3411,7 @@ dependencies = [
  "tracing",
  "tracing-futures",
  "tracing-opentelemetry",
- "tracing-subscriber 0.3.9",
+ "tracing-subscriber 0.3.11",
  "url",
  "user-facing-errors",
 ]
@@ -3335,7 +3440,7 @@ dependencies = [
  "tracing",
  "tracing-futures",
  "tracing-opentelemetry",
- "tracing-subscriber 0.3.9",
+ "tracing-subscriber 0.3.11",
  "url",
  "user-facing-errors",
 ]
@@ -3406,7 +3511,7 @@ dependencies = [
  "tracing",
  "tracing-error",
  "tracing-futures",
- "tracing-subscriber 0.3.9",
+ "tracing-subscriber 0.3.11",
  "user-facing-errors",
 ]
 
@@ -3430,6 +3535,16 @@ name = "radium"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
 
 [[package]]
 name = "rand"
@@ -3510,6 +3625,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
  "rand_core 0.6.3",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "10.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "738bc47119e3eeccc7e94c4a506901aea5e7b4944ecd0829cbebf4af04ceda12"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -4073,6 +4197,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sketches-ddsketch"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a77a8fd93886010f05e7ea0720e569d6d16c65329dbe3ec033bbbccccb017b"
+
+[[package]]
 name = "slab"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4388,7 +4518,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-error",
- "tracing-subscriber 0.3.9",
+ "tracing-subscriber 0.3.11",
 ]
 
 [[package]]
@@ -4411,7 +4541,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-error",
- "tracing-subscriber 0.3.9",
+ "tracing-subscriber 0.3.11",
  "url",
 ]
 
@@ -4805,7 +4935,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e"
 dependencies = [
  "tracing",
- "tracing-subscriber 0.3.9",
+ "tracing-subscriber 0.3.11",
 ]
 
 [[package]]
@@ -4839,7 +4969,7 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-subscriber 0.3.9",
+ "tracing-subscriber 0.3.11",
 ]
 
 [[package]]
@@ -4876,9 +5006,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.9"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e0ab7bdc962035a87fba73f3acca9b8a8d0034c2e6f60b84aeaaddddc155dce"
+checksum = "4bc28f93baff38037f64e6f43d34cfa1605f27a49c34e8a04c5e78b0babf2596"
 dependencies = [
  "ansi_term 0.12.1",
  "lazy_static",

--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ validate:
 	cargo run --bin test-cli -- validate-datamodel dev_datamodel.prisma
 
 qe:
-	cargo run --bin query-engine -- --enable-playground --enable-raw-queries
+	cargo run --bin query-engine -- --enable-playground --enable-raw-queries --enable-metrics
 
 qe-dmmf:
 	cargo run --bin query-engine -- cli dmmf > dmmf.json

--- a/libs/datamodel/core/src/common/preview_features.rs
+++ b/libs/datamodel/core/src/common/preview_features.rs
@@ -64,7 +64,8 @@ features!(
     ExtendedIndexes,
     Cockroachdb,
     Tracing,
-    ImprovedQueryRaw
+    ImprovedQueryRaw,
+    Metrics
 );
 
 // Mapping of which active, deprecated and hidden
@@ -81,6 +82,7 @@ pub const GENERATOR: FeatureMap = FeatureMap::new()
         ExtendedIndexes,
         Tracing,
         ImprovedQueryRaw,
+        Metrics,
     ])
     .with_deprecated(&[
         AtomicNumberOperations,

--- a/libs/datamodel/core/tests/config/generators.rs
+++ b/libs/datamodel/core/tests/config/generators.rs
@@ -258,7 +258,7 @@ fn nice_error_for_unknown_generator_preview_feature() {
         .unwrap_err();
 
     let expectation = expect![[r#"
-        [1;91merror[0m: [1mThe preview feature "foo" is not known. Expected one of: filterJson, referentialIntegrity, interactiveTransactions, fullTextSearch, fullTextIndex, extendedIndexes, tracing, improvedQueryRaw[0m
+        [1;91merror[0m: [1mThe preview feature "foo" is not known. Expected one of: filterJson, referentialIntegrity, interactiveTransactions, fullTextSearch, fullTextIndex, extendedIndexes, tracing, improvedQueryRaw, metrics[0m
           [1;94m-->[0m  [4mschema.prisma:3[0m
         [1;94m   | [0m
         [1;94m 2 | [0m  provider = "prisma-client-js"

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/metrics.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/metrics.rs
@@ -1,0 +1,95 @@
+use query_engine_tests::test_suite;
+
+#[test_suite(schema(generic))]
+mod metrics {
+    use query_engine_tests::ConnectorVersion::{MongoDb, SqlServer, Sqlite};
+    use query_engine_tests::*;
+    use serde_json::Value;
+
+    #[connector_test]
+    async fn metrics_are_recorded(runner: Runner) -> TestResult<()> {
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"mutation { createOneTestModel(data: { id: 1 }) { id }}"#),
+          @r###"{"data":{"createOneTestModel":{"id":1}}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"mutation { updateOneTestModel(where: { id: 1 }, data: { field: "updated" }) { field } }"#),
+          @r###"{"data":{"updateOneTestModel":{"field":"updated"}}}"###
+        );
+
+        let json = runner.get_metrics().to_json(Default::default());
+        // We cannot assert the full response it will be slightly different per database
+        let total_queries = get_counter(&json, "query_total_queries");
+        let total_operations = get_counter(&json, "query_total_operations");
+
+        match runner.connector_version() {
+            Sqlite => assert_eq!(total_queries, 9),
+            SqlServer(_) => assert_eq!(total_queries, 15),
+            MongoDb(_) => assert_eq!(total_queries, 5),
+            _ => assert_eq!(total_queries, 11),
+        }
+        assert_eq!(total_operations, 2);
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn metrics_tx_do_not_go_negative(mut runner: Runner) -> TestResult<()> {
+        let tx_id = runner.start_tx(5000, 5000).await?;
+        runner.set_active_tx(tx_id.clone());
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"mutation { createOneTestModel(data: { id: 1 }) { id }}"#),
+          @r###"{"data":{"createOneTestModel":{"id":1}}}"###
+        );
+
+        let _ = runner.commit_tx(tx_id.clone()).await?;
+        let _ = runner.commit_tx(tx_id.clone()).await?;
+        let _ = runner.commit_tx(tx_id.clone()).await?;
+        let _ = runner.commit_tx(tx_id).await?;
+
+        let json = runner.get_metrics().to_json(Default::default());
+        let active_transactions = get_gauge(&json, "query_active_transactions");
+        assert_eq!(active_transactions, 0.0);
+
+        let tx_id = runner.start_tx(5000, 5000).await?;
+        runner.set_active_tx(tx_id.clone());
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"mutation { createOneTestModel(data: { id: 2 }) { id }}"#),
+          @r###"{"data":{"createOneTestModel":{"id":2}}}"###
+        );
+
+        let _ = runner.rollback_tx(tx_id.clone()).await?;
+        let _ = runner.rollback_tx(tx_id.clone()).await?;
+        let _ = runner.rollback_tx(tx_id.clone()).await?;
+        let _ = runner.rollback_tx(tx_id.clone()).await?;
+
+        let json = runner.get_metrics().to_json(Default::default());
+        let active_transactions = get_gauge(&json, "query_active_transactions");
+        assert_eq!(active_transactions, 0.0);
+        Ok(())
+    }
+
+    fn get_counter(json: &Value, name: &str) -> u64 {
+        let metric_value = get_metric_value(json, "counters", name);
+        metric_value.as_u64().unwrap()
+    }
+
+    fn get_gauge(json: &Value, name: &str) -> f64 {
+        let metric_value = get_metric_value(json, "gauges", name);
+        metric_value.as_f64().unwrap()
+    }
+
+    fn get_metric_value(json: &Value, metric_type: &str, name: &str) -> serde_json::Value {
+        let metrics = json.get(metric_type).unwrap().as_array().unwrap();
+        let metric = metrics
+            .iter()
+            .find(|metric| metric.get("key").unwrap().as_str() == Some(name))
+            .unwrap()
+            .as_object()
+            .unwrap();
+
+        metric.get("value").unwrap().clone()
+    }
+}

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/mod.rs
@@ -2,6 +2,7 @@ mod create_many;
 mod cursor;
 mod disconnect;
 mod interactive_tx;
+mod metrics;
 mod native_types;
 mod ref_actions;
 mod regressions;

--- a/query-engine/connector-test-kit-rs/query-test-macros/src/connector_test.rs
+++ b/query-engine/connector-test-kit-rs/query-test-macros/src/connector_test.rs
@@ -90,6 +90,8 @@ pub fn connector_test_impl(attr: TokenStream, input: TokenStream) -> TokenStream
                 let template = #handler();
                 let datamodel = query_tests_setup::render_test_datamodel(config, #test_database, template, #excluded_features);
                 let connector = config.test_connector_tag().unwrap();
+                let metrics = query_tests_setup::setup_metrics();
+                let metrics_for_subscriber = metrics.clone();
 
                 query_tests_setup::run_with_tokio(async move {
                     tracing::debug!("Used datamodel:\n {}", datamodel.yellow());
@@ -97,12 +99,12 @@ pub fn connector_test_impl(attr: TokenStream, input: TokenStream) -> TokenStream
                     query_tests_setup::setup_project(&datamodel).await.unwrap();
 
                     let requires_teardown = connector.requires_teardown();
-                    let runner = Runner::load(config.runner(), datamodel.clone(), connector).await.unwrap();
+                    let runner = Runner::load(config.runner(), datamodel.clone(), connector, metrics).await.unwrap();
 
                     #runner_fn_ident(runner).await.unwrap();
 
                     if requires_teardown { query_tests_setup::teardown_project(&datamodel).await.unwrap(); }
-                }.with_subscriber(test_tracing_subscriber(std::env::var("LOG_LEVEL").unwrap_or("info".to_string()))));
+                }.with_subscriber(test_tracing_subscriber(std::env::var("LOG_LEVEL").unwrap_or("info".to_string()), metrics_for_subscriber)));
             }
         }
 

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/binary.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/binary.rs
@@ -1,6 +1,6 @@
 use crate::{ConnectorTag, RunnerInterface, TestResult, TxResult};
 use hyper::{Body, Method, Request, Response};
-use query_core::TxId;
+use query_core::{MetricRegistry, TxId};
 use query_engine::opt::PrismaOpt;
 use query_engine::server::{routes, setup, State};
 use request_handlers::{GQLBatchResponse, GQLError, GQLResponse, GraphQlBody, MultiQuery, PrismaResponse};
@@ -13,9 +13,9 @@ pub struct BinaryRunner {
 
 #[async_trait::async_trait]
 impl RunnerInterface for BinaryRunner {
-    async fn load(datamodel: String, connector_tag: ConnectorTag) -> TestResult<Self> {
+    async fn load(datamodel: String, connector_tag: ConnectorTag, metrics: MetricRegistry) -> TestResult<Self> {
         let opts = PrismaOpt::from_list(&["binary", "--enable-raw-queries", "--datamodel", &datamodel]);
-        let state = setup(&opts).await.unwrap();
+        let state = setup(&opts, metrics).await.unwrap();
 
         Ok(BinaryRunner {
             state,
@@ -161,6 +161,10 @@ impl RunnerInterface for BinaryRunner {
 
     fn clear_active_tx(&mut self) {
         self.current_tx_id = None;
+    }
+
+    fn get_metrics(&self) -> MetricRegistry {
+        self.state.get_metrics()
     }
 }
 

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/mod.rs
@@ -5,7 +5,7 @@ mod node_api;
 pub use binary::*;
 pub use direct::*;
 pub use node_api::*;
-use query_core::TxId;
+use query_core::{MetricRegistry, TxId};
 
 use crate::{ConnectorTag, ConnectorVersion, QueryResult, TestError, TestResult};
 use colored::*;
@@ -15,7 +15,7 @@ pub type TxResult = Result<(), user_facing_errors::Error>;
 #[async_trait::async_trait]
 pub trait RunnerInterface: Sized {
     /// Initializes the runner.
-    async fn load(datamodel: String, connector_tag: ConnectorTag) -> TestResult<Self>;
+    async fn load(datamodel: String, connector_tag: ConnectorTag, metrics: MetricRegistry) -> TestResult<Self>;
 
     /// Queries the engine.
     async fn query(&self, query: String) -> TestResult<QueryResult>;
@@ -40,6 +40,8 @@ pub trait RunnerInterface: Sized {
 
     /// Clears ITX ID for queries.
     fn clear_active_tx(&mut self);
+
+    fn get_metrics(&self) -> MetricRegistry;
 }
 
 pub enum Runner {
@@ -54,11 +56,16 @@ pub enum Runner {
 }
 
 impl Runner {
-    pub async fn load(ident: &str, datamodel: String, connector_tag: ConnectorTag) -> TestResult<Self> {
+    pub async fn load(
+        ident: &str,
+        datamodel: String,
+        connector_tag: ConnectorTag,
+        metrics: MetricRegistry,
+    ) -> TestResult<Self> {
         match ident {
-            "direct" => Self::direct(datamodel, connector_tag).await,
+            "direct" => Self::direct(datamodel, connector_tag, metrics).await,
             "node-api" => Ok(Self::NodeApi(NodeApiRunner {})),
-            "binary" => Self::binary(datamodel, connector_tag).await,
+            "binary" => Self::binary(datamodel, connector_tag, metrics).await,
             unknown => Err(TestError::parse_error(format!("Unknown test runner '{}'", unknown))),
         }
     }
@@ -117,14 +124,14 @@ impl Runner {
         }
     }
 
-    async fn direct(datamodel: String, connector_tag: ConnectorTag) -> TestResult<Self> {
-        let runner = DirectRunner::load(datamodel, connector_tag).await?;
+    async fn direct(datamodel: String, connector_tag: ConnectorTag, metrics: MetricRegistry) -> TestResult<Self> {
+        let runner = DirectRunner::load(datamodel, connector_tag, metrics).await?;
 
         Ok(Self::Direct(runner))
     }
 
-    async fn binary(datamodel: String, connector_tag: ConnectorTag) -> TestResult<Self> {
-        let runner = BinaryRunner::load(datamodel, connector_tag).await?;
+    async fn binary(datamodel: String, connector_tag: ConnectorTag, metrics: MetricRegistry) -> TestResult<Self> {
+        let runner = BinaryRunner::load(datamodel, connector_tag, metrics).await?;
 
         Ok(Self::Binary(runner))
     }
@@ -158,6 +165,14 @@ impl Runner {
             Runner::Direct(r) => r.clear_active_tx(),
             Runner::NodeApi(_) => todo!(),
             Runner::Binary(r) => r.clear_active_tx(),
+        }
+    }
+
+    pub fn get_metrics(&self) -> MetricRegistry {
+        match self {
+            Runner::Direct(r) => r.get_metrics(),
+            Runner::NodeApi(_) => todo!(),
+            Runner::Binary(r) => r.get_metrics(),
         }
     }
 }

--- a/query-engine/connectors/mongodb-query-connector/Cargo.toml
+++ b/query-engine/connectors/mongodb-query-connector/Cargo.toml
@@ -20,6 +20,8 @@ tracing = "0.1"
 tracing-futures = "0.2"
 uuid = "0.8"
 indexmap = "1.7"
+metrics = "0.18"
+metrics-util = "0.12.1"
 
 [dependencies.prisma-models]
 path = "../../prisma-models"

--- a/query-engine/connectors/mongodb-query-connector/src/query_builder/read_query_builder.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/query_builder/read_query_builder.rs
@@ -1,4 +1,5 @@
 use super::group_by_builder::*;
+use crate::root_queries::metrics;
 use crate::{
     cursor::{CursorBuilder, CursorData},
     filter::{convert_filter, FilterPrefix},
@@ -50,9 +51,7 @@ impl PipelineQuery {
         with_session: &mut ClientSession,
     ) -> crate::Result<Vec<Document>> {
         let opts = AggregateOptions::builder().allow_disk_use(true).build();
-        let cursor = on_collection
-            .aggregate_with_session(self.stages, opts, with_session)
-            .await?;
+        let cursor = metrics(|| on_collection.aggregate_with_session(self.stages, opts, with_session)).await?;
 
         vacuum_cursor(cursor, with_session).await
     }
@@ -69,9 +68,7 @@ impl FindQuery {
         on_collection: Collection<Document>,
         with_session: &mut ClientSession,
     ) -> crate::Result<Vec<Document>> {
-        let cursor = on_collection
-            .find_with_session(self.filter, self.options, with_session)
-            .await?;
+        let cursor = metrics(|| on_collection.find_with_session(self.filter, self.options, with_session)).await?;
 
         vacuum_cursor(cursor, with_session).await
     }

--- a/query-engine/connectors/mongodb-query-connector/src/root_queries/mod.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/root_queries/mod.rs
@@ -9,9 +9,12 @@ mod update;
 use crate::{
     error::DecorateErrorWithFieldInformationExtension, output_meta::OutputMetaMapping, value::value_from_bson,
 };
+use futures::Future;
+use metrics::{histogram, increment_counter};
 use mongodb::bson::Bson;
 use mongodb::bson::Document;
 use prisma_models::*;
+use std::time::Instant;
 
 /// Transforms a document to a `Record`, fields ordered as defined in `fields`.
 fn document_to_record(mut doc: Document, fields: &[String], meta_mapping: &OutputMetaMapping) -> crate::Result<Record> {
@@ -37,4 +40,18 @@ fn pick_singular_id(model: &ModelRef) -> ScalarFieldRef {
         .into_iter()
         .next()
         .unwrap()
+}
+
+pub(crate) async fn metrics<'a, F, T, U>(f: F) -> mongodb::error::Result<T>
+where
+    F: FnOnce() -> U + 'a,
+    U: Future<Output = mongodb::error::Result<T>>,
+{
+    let start = Instant::now();
+    let res = f().await;
+
+    histogram!("query_total_elapsed_time_ms", start.elapsed());
+    increment_counter!("query_total_queries");
+
+    res
 }

--- a/query-engine/connectors/mongodb-query-connector/src/root_queries/read.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/root_queries/read.rs
@@ -117,7 +117,7 @@ pub async fn get_related_m2m_record_ids<'conn>(
         .projection(doc! { id_field.db_name(): 1, relation_ids_field_name: 1 })
         .build();
 
-    let cursor = coll.find_with_session(filter, Some(find_options), session).await?;
+    let cursor = metrics(|| coll.find_with_session(filter, Some(find_options), session)).await?;
     let docs = vacuum_cursor(cursor, session).await?;
     let parent_id_meta = output_meta::from_scalar_field(&id_field);
     let id_holder_field = model.fields().find_from_scalar(relation_ids_field_name).unwrap();

--- a/query-engine/core/Cargo.toml
+++ b/query-engine/core/Cargo.toml
@@ -37,6 +37,7 @@ thiserror = "1.0"
 tokio = { version = "1.8" }
 tracing = { version = "0.1", features = ["attributes"] }
 tracing-futures = "0.2"
+tracing-subscriber = "0.3.11"
 url = "2"
 user-facing-errors = { path = "../../libs/user-facing-errors" }
 uuid = "0.8"
@@ -45,3 +46,10 @@ pin-utils = "0.1"
 lazy_static = "1.4"
 schema = { path = "../schema" }
 schema-builder = { path = "../schema-builder" }
+metrics = "0.18"
+metrics-util = "0.12.1"
+metrics-exporter-prometheus = "0.9.0"
+parking_lot = "0.12"
+
+[dev-dependencies]
+expect-test = "1"

--- a/query-engine/core/src/lib.rs
+++ b/query-engine/core/src/lib.rs
@@ -24,6 +24,7 @@ pub mod error;
 pub mod executor;
 pub mod interactive_transactions;
 pub mod interpreter;
+pub mod metrics;
 pub mod query_ast;
 pub mod query_document;
 pub mod query_graph;
@@ -31,6 +32,7 @@ pub mod query_graph_builder;
 pub mod response_ir;
 pub mod result_ast;
 
+pub use crate::metrics::*;
 pub use error::*;
 pub use executor::*;
 pub use interactive_transactions::*;

--- a/query-engine/core/src/metrics/common.rs
+++ b/query-engine/core/src/metrics/common.rs
@@ -1,0 +1,117 @@
+use std::collections::HashMap;
+
+use metrics::{Key, Label};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+pub(crate) struct KeyLabels {
+    name: String,
+    labels: HashMap<String, String>,
+}
+
+#[derive(Debug)]
+pub(crate) enum MetricType {
+    Counter,
+    Gauge,
+    Histogram, // Histograms are cumulative
+    Description,
+}
+
+#[derive(Debug)]
+pub(crate) enum MetricAction {
+    Increment(u64),
+    Absolute(u64),
+    GaugeSet(f64),
+    GaugeInc(f64),
+    GaugeDec(f64),
+    HistRecord(f64),
+    Description(String),
+}
+
+#[derive(Serialize, Clone)]
+pub(crate) struct Histogram {
+    pub buckets: Vec<(f64, u64)>,
+    pub sum: f64,
+    pub count: u64,
+}
+
+#[derive(Serialize, Clone)]
+#[serde(untagged)]
+pub(crate) enum MetricValue {
+    Counter(u64),
+    Gauge(f64),
+    Histogram(Histogram),
+}
+
+#[derive(Serialize, Clone)]
+pub(crate) struct Metric {
+    pub key: String,
+    pub labels: HashMap<String, String>,
+    pub value: MetricValue,
+    pub description: String,
+}
+
+impl Metric {
+    pub fn new(key: Key, description: String, value: MetricValue, global_labels: HashMap<String, String>) -> Self {
+        let (name, labels) = key.into_parts();
+
+        let mut labels_map: HashMap<String, String> = labels
+            .into_iter()
+            .map(|label| (label.key().to_string(), label.value().to_string()))
+            .collect();
+
+        labels_map.extend(global_labels);
+
+        Self {
+            key: name.as_str().to_string(),
+            value,
+            description,
+            labels: labels_map,
+        }
+    }
+}
+
+// The idea of this snapshot is take from
+// https://github.com/metrics-rs/metrics/blob/558a3f93a4bb3958379ae6227c613a222aa813b5/metrics-exporter-prometheus/src/common.rs#L79
+#[derive(Serialize)]
+pub(crate) struct Snapshot {
+    pub counters: Vec<Metric>,
+    pub gauges: Vec<Metric>,
+    pub histograms: Vec<Metric>,
+}
+
+impl From<Key> for KeyLabels {
+    fn from(key: Key) -> Self {
+        let mut kl = KeyLabels {
+            name: key.name().to_string(),
+            labels: Default::default(),
+        };
+
+        kl.labels
+            .extend(key.labels().map(|l| (l.key().to_string(), l.value().to_string())));
+
+        kl
+    }
+}
+
+impl From<KeyLabels> for Key {
+    fn from(kl: KeyLabels) -> Self {
+        let labels: Vec<Label> = kl
+            .labels
+            .into_iter()
+            .map(|(key, value)| Label::from(&(key, value)))
+            .collect();
+
+        Key::from_parts(kl.name, labels)
+    }
+}
+
+impl From<metrics_util::Histogram> for Histogram {
+    fn from(histogram: metrics_util::Histogram) -> Histogram {
+        Histogram {
+            buckets: histogram.buckets(),
+            sum: histogram.sum(),
+            count: histogram.count(),
+        }
+    }
+}

--- a/query-engine/core/src/metrics/formatters.rs
+++ b/query-engine/core/src/metrics/formatters.rs
@@ -1,0 +1,152 @@
+use super::common::{Histogram, Metric, MetricValue, Snapshot};
+use metrics_exporter_prometheus::formatting::{
+    sanitize_description, sanitize_label_key, sanitize_label_value, write_help_line, write_metric_line, write_type_line,
+};
+use serde_json::Value;
+use std::collections::HashMap;
+
+fn create_label_string(labels: &HashMap<String, String>) -> Vec<String> {
+    let mut label_string = labels
+        .iter()
+        .map(|(k, v)| format!("{}=\"{}\"", sanitize_label_key(k), sanitize_label_value(v)))
+        .collect::<Vec<String>>();
+
+    // This sort isn't strictly needed but adds a predictable set order of labels which makes testing easier but
+    // should also be better for our users
+    label_string.sort();
+    label_string
+}
+
+pub(crate) fn metrics_to_json(snapshot: Snapshot) -> Value {
+    let Snapshot {
+        counters,
+        histograms,
+        gauges,
+    } = snapshot;
+
+    // For json output we convert the histogram where a value is only recorded in a single bucket
+    let mut normalised_histograms = Vec::new();
+
+    for histogram in histograms {
+        if let MetricValue::Histogram(histogram_value) = histogram.value {
+            let mut prev = 0;
+            let buckets = histogram_value
+                .buckets
+                .iter()
+                .cloned()
+                .map(|(le, count)| {
+                    let new_count = count - prev;
+                    prev = count;
+                    (le, new_count)
+                })
+                .collect();
+
+            let new_histogram = Histogram {
+                buckets,
+                sum: histogram_value.sum,
+                count: histogram_value.count,
+            };
+
+            normalised_histograms.push(Metric {
+                key: histogram.key.clone(),
+                labels: histogram.labels.clone(),
+                description: histogram.description.clone(),
+                value: MetricValue::Histogram(new_histogram),
+            });
+        }
+    }
+
+    let snapshot = Snapshot {
+        counters,
+        histograms: normalised_histograms,
+        gauges,
+    };
+
+    serde_json::to_value(snapshot).unwrap()
+}
+
+pub(crate) fn metrics_to_prometheus(snapshot: Snapshot) -> String {
+    let Snapshot {
+        counters,
+        histograms,
+        gauges,
+    } = snapshot;
+
+    let mut output = String::new();
+
+    for counter in counters {
+        let desc = sanitize_description(counter.description.as_str());
+        write_help_line(&mut output, counter.key.as_str(), desc.as_str());
+
+        write_type_line(&mut output, counter.key.as_str(), "counter");
+        let labels = create_label_string(&counter.labels);
+
+        if let MetricValue::Counter(value) = counter.value {
+            write_metric_line::<&str, u64>(&mut output, &counter.key.as_str(), None, &labels, None, value);
+        }
+        output.push('\n');
+    }
+
+    for gauge in gauges {
+        let desc = sanitize_description(gauge.description.as_str());
+        write_help_line(&mut output, gauge.key.as_str(), desc.as_str());
+
+        write_type_line(&mut output, gauge.key.as_str(), "gauge");
+        let labels = create_label_string(&gauge.labels);
+
+        if let MetricValue::Gauge(value) = gauge.value {
+            write_metric_line::<&str, f64>(&mut output, &gauge.key.as_str(), None, &labels, None, value);
+        }
+        output.push('\n');
+    }
+
+    for histogram in histograms {
+        let desc = sanitize_description(histogram.description.as_str());
+        write_help_line(&mut output, histogram.key.as_str(), desc.as_str());
+
+        write_type_line(&mut output, histogram.key.as_str(), "histogram");
+        let labels = create_label_string(&histogram.labels);
+
+        if let MetricValue::Histogram(histogram_values) = histogram.value {
+            for (le, count) in histogram_values.buckets {
+                write_metric_line(
+                    &mut output,
+                    histogram.key.as_str(),
+                    Some("bucket"),
+                    &labels,
+                    Some(("le", le)),
+                    count,
+                );
+            }
+
+            write_metric_line(
+                &mut output,
+                histogram.key.as_str(),
+                Some("bucket"),
+                &labels,
+                Some(("le", "+Inf")),
+                histogram_values.count,
+            );
+            write_metric_line::<&str, f64>(
+                &mut output,
+                histogram.key.as_str(),
+                Some("sum"),
+                &labels,
+                None,
+                histogram_values.sum,
+            );
+            write_metric_line::<&str, u64>(
+                &mut output,
+                histogram.key.as_str(),
+                Some("count"),
+                &labels,
+                None,
+                histogram_values.count,
+            );
+        }
+
+        output.push('\n');
+    }
+
+    output
+}

--- a/query-engine/core/src/metrics/mod.rs
+++ b/query-engine/core/src/metrics/mod.rs
@@ -1,0 +1,513 @@
+//! Query Engine Metrics
+//! This crate is responsible for capturing and recording metrics in the Query Engine.
+//! Metrics is broken into two parts, `MetricsRecorder` and `MetricsRegistry`, and uses our tracing framework to communicate.
+//! An example best explains this system.
+//! When the engine boots up, the `MetricRegistry` is added to our tracing as a layer and The MetricRecorder is
+//! set as the global metric recorder. When a metric value is recorded `gauge_increment!("my_gauge", 1.0)` is called.
+//! The Metric Recorder is called with `register_gauge` and returns a `MetricHandle`. The `MetricHandle` will convert
+//! ``gauge_increment!("my_gauge", 1.0)` into a `trace!` message.
+//!
+//! The trace message is received by the `MetricRegistry` and converted into a `MetricVisitor` with all the information required
+//! to record the metric and the value. The MetricVisitor is then processed and the metric value added to the `Registry`.
+//!
+//! To view the recorded metrics we create a `Snapshot` of our metrics and then return it in `json` format.
+//! A few things to note:
+//! * We have an `ACCEPT_LIST` and those are the only metrics we capture. We don't want to accidentally record other metrics
+//!   recorded by external libraries that could leak more information than we want to expose.
+//! * The Histogram we use is a Cumulative Histogram. Meaning that a value is added to each bucket that the sample is smaller than.
+//!   This seems to be the way Prometheus expects it
+//! * At the moment, with the Histogram we only support one type of bucket which is a bucket for timings in milliseconds.
+//!
+
+const METRIC_TARGET: &str = "qe_metrics";
+const METRIC_COUNTER: &str = "counter";
+const METRIC_GAUGE: &str = "gauge";
+const METRIC_HISTOGRAM: &str = "histogram";
+const METRIC_DESCRIPTION: &str = "description";
+
+mod common;
+mod formatters;
+mod recorder;
+mod registry;
+
+use metrics::{absolute_counter, describe_counter, describe_gauge, describe_histogram, gauge};
+use recorder::*;
+pub use registry::MetricRegistry;
+
+// At the moment the histogram is only used for timings. So the bounds are hard coded here
+// The buckets are for ms
+pub(crate) const HISTOGRAM_BOUNDS: [f64; 10] = [0.0, 1.0, 5.0, 10.0, 50.0, 100.0, 500.0, 1000.0, 5000.0, 50000.0];
+// We need a list of acceptable metrics we want to expose, we don't want to accidentally expose metrics
+// that a different library have or unintended information
+const ACCEPT_LIST: &[&str] = &[
+    "pool_active_connections",
+    "pool_idle_connections",
+    "pool_wait_count",
+    "pool_wait_duration_ms",
+    "query_total_elapsed_time+ms",
+    "query_total_queries",
+    "query_active_transactions",
+    "query_total_operations",
+    "query_operation_total_elapsed_time_ms",
+];
+
+pub fn setup() {
+    set_recorder();
+    describe_metrics();
+}
+
+// Describe all metric here so that every time for create
+// a new metric registry for a Query Instance the descriptions
+// will be in place
+fn describe_metrics() {
+    describe_gauge!("pool_active_connections", "The number of active connections in use");
+
+    describe_gauge!(
+        "pool_idle_connections",
+        "The number of connections that are not being used"
+    );
+
+    describe_gauge!("pool_wait_count", "The number of workers waiting for a connection");
+    describe_gauge!("query_active_transactions", "The number of active transactions");
+
+    gauge!("pool_active_connections", 0.0);
+    gauge!("pool_idle_connections", 0.0);
+    gauge!("pool_wait_count", 0.0);
+    gauge!("query_active_transactions", 0.0);
+
+    describe_histogram!(
+        "pool_wait_duration_ms",
+        "The wait time for a worker to get a connection."
+    );
+    describe_histogram!(
+        "query_total_elapsed_time_ms",
+        "The execution time for all database queries executed."
+    );
+
+    describe_histogram!(
+        "query_operation_total_elapsed_time_ms",
+        "The execution time for all operations."
+    );
+
+    describe_counter!("query_total_queries", "The total number of queries executed");
+    describe_counter!("query_total_operations", "The total number of operations executed");
+
+    absolute_counter!("query_total_queries", 0);
+    absolute_counter!("query_total_operations", 0);
+}
+fn set_recorder() {
+    let recorder = MetricRecorder::default();
+    metrics::set_boxed_recorder(Box::new(recorder)).unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use metrics::{
+        absolute_counter, decrement_gauge, describe_counter, describe_gauge, describe_histogram, gauge, histogram,
+        increment_counter, increment_gauge, register_counter, register_gauge, register_histogram,
+    };
+    use serde_json::json;
+    use std::collections::HashMap;
+    use std::time::Duration;
+    use tracing::instrument::WithSubscriber;
+    use tracing::Dispatch;
+    use tracing_subscriber::layer::SubscriberExt;
+
+    use once_cell::sync::Lazy;
+    use tokio::runtime::Runtime;
+
+    static RT: Lazy<Runtime> = Lazy::new(|| {
+        set_recorder();
+        Runtime::new().unwrap()
+    });
+
+    const TESTING_ACCEPT_LIST: &[&str] = &[
+        "test_counter",
+        "another_counter",
+        "test_gauge",
+        "another_gauge",
+        "test_histogram",
+        "counter_1",
+        "counter_2",
+        "gauge_1",
+        "gauge_2",
+        "histogram_1",
+        "histogram_2",
+        "test.counter",
+    ];
+
+    #[test]
+    fn test_counters() {
+        RT.block_on(async {
+            let metrics = MetricRegistry::new_with_accept_list(TESTING_ACCEPT_LIST.to_vec());
+            let dispatch = Dispatch::new(tracing_subscriber::Registry::default().with(metrics.clone()));
+            async {
+                let counter1 = register_counter!("test_counter");
+                counter1.increment(1);
+                increment_counter!("test_counter");
+                increment_counter!("test_counter");
+
+                increment_counter!("another_counter");
+
+                let val = metrics.counter_value("test_counter").unwrap();
+                assert_eq!(val, 3);
+
+                let val2 = metrics.counter_value("another_counter").unwrap();
+                assert_eq!(val2, 1);
+
+                absolute_counter!("test_counter", 5);
+                let val3 = metrics.counter_value("test_counter").unwrap();
+                assert_eq!(val3, 5);
+            }
+            .with_subscriber(dispatch)
+            .await;
+        });
+    }
+
+    #[test]
+    fn test_gauges() {
+        RT.block_on(async {
+            let metrics = MetricRegistry::new_with_accept_list(TESTING_ACCEPT_LIST.to_vec());
+            let dispatch = Dispatch::new(tracing_subscriber::Registry::default().with(metrics.clone()));
+            async {
+                let gauge1 = register_gauge!("test_gauge");
+                gauge1.increment(1.0);
+                increment_gauge!("test_gauge", 1.0);
+                increment_gauge!("test_gauge", 1.0);
+                increment_gauge!("another_gauge", 1.0);
+
+                let val = metrics.gauge_value("test_gauge").unwrap();
+                assert_eq!(val, 3.0);
+
+                let val2 = metrics.gauge_value("another_gauge").unwrap();
+                assert_eq!(val2, 1.0);
+
+                assert_eq!(None, metrics.counter_value("test_gauge"));
+
+                gauge!("test_gauge", 5.0);
+                let val3 = metrics.gauge_value("test_gauge").unwrap();
+                assert_eq!(val3, 5.0);
+
+                decrement_gauge!("test_gauge", 2.0);
+                let val4 = metrics.gauge_value("test_gauge").unwrap();
+                assert_eq!(val4, 3.0);
+            }
+            .with_subscriber(dispatch)
+            .await;
+        });
+    }
+
+    #[test]
+    fn test_no_panic_and_ignore_other_traces() {
+        RT.block_on(async {
+            let metrics = MetricRegistry::new_with_accept_list(TESTING_ACCEPT_LIST.to_vec());
+            let dispatch = Dispatch::new(tracing_subscriber::Registry::default().with(metrics.clone()));
+            async {
+                trace!("a fake trace");
+
+                increment_gauge!("test_gauge", 1.0);
+                increment_counter!("test_counter");
+
+                trace!("another fake trace");
+
+                assert_eq!(1.0, metrics.gauge_value("test_gauge").unwrap());
+                assert_eq!(1, metrics.counter_value("test_counter").unwrap());
+            }
+            .with_subscriber(dispatch)
+            .await;
+        });
+    }
+
+    #[test]
+    fn test_ignore_non_accepted_metrics() {
+        RT.block_on(async {
+            let metrics = MetricRegistry::new_with_accept_list(TESTING_ACCEPT_LIST.to_vec());
+            let dispatch = Dispatch::new(tracing_subscriber::Registry::default().with(metrics.clone()));
+            async {
+                increment_gauge!("not_accepted", 1.0);
+                increment_gauge!("test_gauge", 1.0);
+
+                assert_eq!(1.0, metrics.gauge_value("test_gauge").unwrap());
+                assert_eq!(None, metrics.gauge_value("not_accepted"));
+            }
+            .with_subscriber(dispatch)
+            .await;
+        });
+    }
+
+    #[test]
+    fn test_histograms() {
+        RT.block_on(async {
+            let metrics = MetricRegistry::new_with_accept_list(TESTING_ACCEPT_LIST.to_vec());
+            let dispatch = Dispatch::new(tracing_subscriber::Registry::default().with(metrics.clone()));
+            async {
+                let hist = register_histogram!("test_histogram");
+                hist.record(Duration::from_millis(9));
+
+                histogram!("test_histogram", Duration::from_millis(100));
+                histogram!("test_histogram", Duration::from_millis(1));
+
+                histogram!("test_histogram", Duration::from_millis(1999));
+                histogram!("test_histogram", Duration::from_millis(3999));
+                histogram!("test_histogram", Duration::from_millis(610));
+
+                let hist = metrics.histogram_values("test_histogram").unwrap();
+                let expected: Vec<(f64, u64)> = Vec::from([
+                    (0.0, 0),
+                    (1.0, 1),
+                    (5.0, 1),
+                    (10.0, 2),
+                    (50.0, 2),
+                    (100.0, 3),
+                    (500.0, 3),
+                    (1000.0, 4),
+                    (5000.0, 6),
+                    (50000.0, 6),
+                ]);
+
+                assert_eq!(hist.buckets(), expected);
+            }
+            .with_subscriber(dispatch)
+            .await;
+        });
+    }
+
+    #[test]
+    fn test_set_and_read_descriptions() {
+        RT.block_on(async {
+            let metrics = MetricRegistry::new_with_accept_list(TESTING_ACCEPT_LIST.to_vec());
+            let dispatch = Dispatch::new(tracing_subscriber::Registry::default().with(metrics.clone()));
+            async {
+                describe_counter!("test_counter", "This is a counter");
+
+                let descriptions = metrics.get_descriptions();
+                let description = descriptions.get("test_counter").unwrap();
+
+                assert_eq!("This is a counter", description);
+
+                describe_gauge!("test_gauge", "This is a gauge");
+
+                let descriptions = metrics.get_descriptions();
+                let description = descriptions.get("test_gauge").unwrap();
+
+                assert_eq!("This is a gauge", description);
+
+                describe_histogram!("test_histogram", "This is a hist");
+
+                let descriptions = metrics.get_descriptions();
+                let description = descriptions.get("test_histogram").unwrap();
+                assert_eq!("This is a hist", description);
+            }
+            .with_subscriber(dispatch)
+            .await;
+        });
+    }
+
+    #[test]
+    fn test_to_json() {
+        RT.block_on(async {
+            let metrics = MetricRegistry::new_with_accept_list(TESTING_ACCEPT_LIST.to_vec());
+            let dispatch = Dispatch::new(tracing_subscriber::Registry::default().with(metrics.clone()));
+            async {
+                let empty = json!({
+                    "counters": [],
+                    "gauges": [],
+                    "histograms": []
+                });
+
+                assert_eq!(metrics.to_json(Default::default()), empty);
+
+                absolute_counter!("counter_1", 4, "label" => "one");
+                let _ = describe_counter!("counter_2", "this is a description for counter 2");
+                absolute_counter!("counter_2", 2, "label" => "one", "another_label" => "two");
+
+                describe_gauge!("gauge_1", "a description for gauge 1");
+                gauge!("gauge_1", 7.0);
+                gauge!("gauge_2", 3.0, "label" => "three");
+
+                describe_histogram!("histogram_1", "a description for histogram");
+                let hist = register_histogram!("histogram_1", "label" => "one", "hist_two" => "two");
+                hist.record(Duration::from_millis(9));
+
+                histogram!("histogram_2", Duration::from_millis(9));
+                histogram!("histogram_2", Duration::from_millis(1000));
+                histogram!("histogram_2", Duration::from_millis(40));
+
+                let json = metrics.to_json(Default::default());
+                let expected = json!({
+                    "counters":[{
+                        "key":"counter_1",
+                        "labels":{"label":"one"},
+                        "value":4,
+                        "description":""
+                    },{
+                        "key":"counter_2",
+                        "labels":{"label":"one","another_label":"two"},
+                        "value":2,
+                        "description":"this is a description for counter 2"
+                    }],
+                    "gauges":[{
+                        "key":"gauge_1",
+                        "labels":{},
+                        "value":7.0,
+                        "description":"a description for gauge 1"
+                    },{
+                        "key":"gauge_2",
+                        "labels":{"label":"three"},
+                        "value":3.0,
+                        "description":""
+                    }],
+                    "histograms":[{
+                        "key":"histogram_1",
+                        "labels":{"label":"one","hist_two":"two"},
+                        "value":{
+                            "buckets": [[0.0,0],[1.0,0],[5.0,0],[10.0,1],[50.0,0],[100.0,0],[500.0,0],[1000.0,0],[5000.0,0],[50000.0,0]],
+                            "sum":9.0,
+                            "count":1
+                        },
+                        "description":"a description for histogram"},{
+                            "key":"histogram_2",
+                            "labels":{},
+                            "value":{
+                                "buckets":[[0.0,0],[1.0,0],[5.0,0],[10.0,1],[50.0,1],[100.0,0],[500.0,0],[1000.0,1],[5000.0,0],[50000.0,0]],
+                                "sum":1049.0,
+                                "count":3
+                            },
+                            "description":""
+                        }]
+                    });
+
+                assert_eq!(json, expected);
+            }
+            .with_subscriber(dispatch)
+            .await;
+        });
+    }
+
+    #[test]
+    fn test_global_and_metric_labels() {
+        RT.block_on(async {
+            let metrics = MetricRegistry::new_with_accept_list(TESTING_ACCEPT_LIST.to_vec());
+            let dispatch = Dispatch::new(tracing_subscriber::Registry::default().with(metrics.clone()));
+            async {
+                let hist = register_histogram!("test_histogram", "label" => "one", "two" => "another");
+                hist.record(Duration::from_millis(9));
+
+                absolute_counter!("counter_1", 1);
+
+                let mut global_labels: HashMap<String, String> = HashMap::new();
+                global_labels.insert("global_one".to_string(), "one".to_string());
+                global_labels.insert("global_two".to_string(), "two".to_string());
+
+                let json = metrics.to_json(global_labels);
+
+                let expected = json!({
+                    "counters":[{
+                        "key":"counter_1",
+                        "labels":{"global_one":"one","global_two":"two"},
+                        "value":1,
+                        "description":""
+                    }],
+                    "gauges":[],
+                    "histograms":[{
+                        "key":"test_histogram",
+                        "labels":{"label":"one","two":"another","global_one":"one","global_two":"two"},
+                        "value":{
+                            "buckets": [[0.0,0],[1.0,0],[5.0,0],[10.0,1],[50.0,0],[100.0,0],[500.0,0],[1000.0,0],[5000.0,0],[50000.0,0]],
+                            "sum": 9.0,
+                            "count": 1
+                        },
+                        "description":""
+                    }]
+                });
+                assert_eq!(expected, json);
+            }
+            .with_subscriber(dispatch)
+            .await;
+        });
+    }
+
+    #[test]
+    fn test_prometheus_format() {
+        RT.block_on(async {
+            let metrics = MetricRegistry::new_with_accept_list(TESTING_ACCEPT_LIST.to_vec());
+            let dispatch = Dispatch::new(tracing_subscriber::Registry::default().with(metrics.clone()));
+            async {
+                absolute_counter!("counter_1", 4, "label" => "one");
+                let _ = describe_counter!("counter_2", "this is a description for counter 2");
+                absolute_counter!("counter_2", 2, "label" => "one", "another_label" => "two");
+
+                describe_gauge!("gauge_1", "a description for gauge 1");
+                gauge!("gauge_1", 7.0);
+                gauge!("gauge_2", 3.0, "label" => "three");
+
+                describe_histogram!("histogram_1", "a description for histogram");
+                let hist = register_histogram!("histogram_1", "label" => "one", "hist_two" => "two");
+                hist.record(Duration::from_millis(9));
+
+                histogram!("histogram_2", Duration::from_millis(1000));
+
+                let mut global_labels: HashMap<String, String> = HashMap::new();
+                global_labels.insert("global_two".to_string(), "two".to_string());
+                global_labels.insert("global_one".to_string(), "one".to_string());
+
+                let prometheus = metrics.to_prometheus(global_labels);
+                let snapshot = expect_test::expect![[r##"
+                    # HELP counter_1 
+                    # TYPE counter_1 counter
+                    counter_1{global_one="one",global_two="two",label="one"} 4
+
+                    # HELP counter_2 this is a description for counter 2
+                    # TYPE counter_2 counter
+                    counter_2{another_label="two",global_one="one",global_two="two",label="one"} 2
+
+                    # HELP gauge_1 a description for gauge 1
+                    # TYPE gauge_1 gauge
+                    gauge_1{global_one="one",global_two="two"} 7
+
+                    # HELP gauge_2 
+                    # TYPE gauge_2 gauge
+                    gauge_2{global_one="one",global_two="two",label="three"} 3
+
+                    # HELP histogram_1 a description for histogram
+                    # TYPE histogram_1 histogram
+                    histogram_1_bucket{global_one="one",global_two="two",hist_two="two",label="one",le="0"} 0
+                    histogram_1_bucket{global_one="one",global_two="two",hist_two="two",label="one",le="1"} 0
+                    histogram_1_bucket{global_one="one",global_two="two",hist_two="two",label="one",le="5"} 0
+                    histogram_1_bucket{global_one="one",global_two="two",hist_two="two",label="one",le="10"} 1
+                    histogram_1_bucket{global_one="one",global_two="two",hist_two="two",label="one",le="50"} 1
+                    histogram_1_bucket{global_one="one",global_two="two",hist_two="two",label="one",le="100"} 1
+                    histogram_1_bucket{global_one="one",global_two="two",hist_two="two",label="one",le="500"} 1
+                    histogram_1_bucket{global_one="one",global_two="two",hist_two="two",label="one",le="1000"} 1
+                    histogram_1_bucket{global_one="one",global_two="two",hist_two="two",label="one",le="5000"} 1
+                    histogram_1_bucket{global_one="one",global_two="two",hist_two="two",label="one",le="50000"} 1
+                    histogram_1_bucket{global_one="one",global_two="two",hist_two="two",label="one",le="+Inf"} 1
+                    histogram_1_sum{global_one="one",global_two="two",hist_two="two",label="one"} 9
+                    histogram_1_count{global_one="one",global_two="two",hist_two="two",label="one"} 1
+
+                    # HELP histogram_2 
+                    # TYPE histogram_2 histogram
+                    histogram_2_bucket{global_one="one",global_two="two",le="0"} 0
+                    histogram_2_bucket{global_one="one",global_two="two",le="1"} 0
+                    histogram_2_bucket{global_one="one",global_two="two",le="5"} 0
+                    histogram_2_bucket{global_one="one",global_two="two",le="10"} 0
+                    histogram_2_bucket{global_one="one",global_two="two",le="50"} 0
+                    histogram_2_bucket{global_one="one",global_two="two",le="100"} 0
+                    histogram_2_bucket{global_one="one",global_two="two",le="500"} 0
+                    histogram_2_bucket{global_one="one",global_two="two",le="1000"} 1
+                    histogram_2_bucket{global_one="one",global_two="two",le="5000"} 1
+                    histogram_2_bucket{global_one="one",global_two="two",le="50000"} 1
+                    histogram_2_bucket{global_one="one",global_two="two",le="+Inf"} 1
+                    histogram_2_sum{global_one="one",global_two="two"} 1000
+                    histogram_2_count{global_one="one",global_two="two"} 1
+
+                "##]];
+
+                snapshot.assert_eq(&prometheus);
+            }
+            .with_subscriber(dispatch)
+            .await;
+        });
+    }
+}

--- a/query-engine/core/src/metrics/recorder.rs
+++ b/query-engine/core/src/metrics/recorder.rs
@@ -1,0 +1,121 @@
+use std::sync::Arc;
+
+use metrics::KeyName;
+use metrics::{Counter, CounterFn, Gauge, GaugeFn, Histogram, HistogramFn, Key, Recorder, Unit};
+
+use super::common::KeyLabels;
+use super::{METRIC_COUNTER, METRIC_DESCRIPTION, METRIC_GAUGE, METRIC_HISTOGRAM, METRIC_TARGET};
+
+#[derive(Default)]
+pub(crate) struct MetricRecorder;
+
+impl MetricRecorder {
+    fn register_description(&self, name: &str, description: &str) {
+        trace!(
+            target: METRIC_TARGET,
+            name = name,
+            metric_type = METRIC_DESCRIPTION,
+            description = description
+        );
+    }
+}
+
+impl Recorder for MetricRecorder {
+    fn describe_counter(&self, key_name: KeyName, _unit: Option<Unit>, description: &'static str) {
+        self.register_description(key_name.as_str(), description);
+    }
+
+    fn describe_gauge(&self, key_name: KeyName, _unit: Option<Unit>, description: &'static str) {
+        self.register_description(key_name.as_str(), description);
+    }
+
+    fn describe_histogram(&self, key_name: KeyName, _unit: Option<Unit>, description: &'static str) {
+        self.register_description(key_name.as_str(), description);
+    }
+
+    fn register_counter(&self, key: &Key) -> Counter {
+        Counter::from_arc(Arc::new(MetricHandle(key.clone())))
+    }
+
+    fn register_gauge(&self, key: &Key) -> Gauge {
+        Gauge::from_arc(Arc::new(MetricHandle(key.clone())))
+    }
+
+    fn register_histogram(&self, key: &Key) -> Histogram {
+        Histogram::from_arc(Arc::new(MetricHandle(key.clone())))
+    }
+}
+
+pub(crate) struct MetricHandle(Key);
+
+impl CounterFn for MetricHandle {
+    fn increment(&self, value: u64) {
+        let keylabels: KeyLabels = self.0.clone().into();
+        let json_string = serde_json::to_string(&keylabels).unwrap();
+        trace!(
+            target: METRIC_TARGET,
+            key_labels = json_string.as_str(),
+            metric_type = METRIC_COUNTER,
+            increment = value,
+        );
+    }
+
+    fn absolute(&self, value: u64) {
+        let keylabels: KeyLabels = self.0.clone().into();
+        let json_string = serde_json::to_string(&keylabels).unwrap();
+        trace!(
+            target: METRIC_TARGET,
+            key_labels = json_string.as_str(),
+            metric_type = METRIC_COUNTER,
+            absolute = value,
+        );
+    }
+}
+
+impl GaugeFn for MetricHandle {
+    fn increment(&self, value: f64) {
+        let keylabels: KeyLabels = self.0.clone().into();
+        let json_string = serde_json::to_string(&keylabels).unwrap();
+        trace!(
+            target: METRIC_TARGET,
+            key_labels = json_string.as_str(),
+            metric_type = METRIC_GAUGE,
+            gauge_inc = value,
+        );
+    }
+
+    fn decrement(&self, value: f64) {
+        let keylabels: KeyLabels = self.0.clone().into();
+        let json_string = serde_json::to_string(&keylabels).unwrap();
+        trace!(
+            target: METRIC_TARGET,
+            key_labels = json_string.as_str(),
+            metric_type = METRIC_GAUGE,
+            gauge_dec = value,
+        );
+    }
+
+    fn set(&self, value: f64) {
+        let keylabels: KeyLabels = self.0.clone().into();
+        let json_string = serde_json::to_string(&keylabels).unwrap();
+        trace!(
+            target: METRIC_TARGET,
+            key_labels = json_string.as_str(),
+            metric_type = METRIC_GAUGE,
+            gauge_set = value,
+        );
+    }
+}
+
+impl HistogramFn for MetricHandle {
+    fn record(&self, value: f64) {
+        let keylabels: KeyLabels = self.0.clone().into();
+        let json_string = serde_json::to_string(&keylabels).unwrap();
+        trace!(
+            target: METRIC_TARGET,
+            key_labels = json_string.as_str(),
+            metric_type = METRIC_HISTOGRAM,
+            hist_record = value,
+        );
+    }
+}

--- a/query-engine/core/src/metrics/registry.rs
+++ b/query-engine/core/src/metrics/registry.rs
@@ -1,0 +1,308 @@
+use super::formatters::metrics_to_json;
+use super::{
+    common::{KeyLabels, Metric, MetricAction, MetricType, MetricValue, Snapshot},
+    formatters::metrics_to_prometheus,
+};
+use super::{
+    ACCEPT_LIST, HISTOGRAM_BOUNDS, METRIC_COUNTER, METRIC_DESCRIPTION, METRIC_GAUGE, METRIC_HISTOGRAM, METRIC_TARGET,
+};
+use metrics::{CounterFn, GaugeFn, HistogramFn, Key};
+use metrics_util::{
+    registry::{GenerationalAtomicStorage, GenerationalStorage, Registry},
+    Histogram as HistogramUtil,
+};
+use parking_lot::RwLock;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use tracing::{
+    field::{Field, Visit},
+    Subscriber,
+};
+use tracing_subscriber::Layer;
+
+struct Inner {
+    descriptions: RwLock<HashMap<String, String>>,
+    register: Registry<Key, GenerationalAtomicStorage>,
+    accept_list: Vec<&'static str>,
+}
+
+impl Inner {
+    fn new(accept_list: Vec<&'static str>) -> Self {
+        Self {
+            descriptions: RwLock::new(HashMap::new()),
+            register: Registry::new(GenerationalStorage::atomic()),
+            accept_list,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct MetricRegistry {
+    inner: Arc<Inner>,
+}
+
+impl fmt::Debug for MetricRegistry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Metric Registry")
+    }
+}
+
+impl Default for MetricRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MetricRegistry {
+    pub fn new() -> Self {
+        Self::new_with_accept_list(ACCEPT_LIST.to_vec())
+    }
+
+    // for internal and testing usage only
+    pub(crate) fn new_with_accept_list(accept_list: Vec<&'static str>) -> Self {
+        MetricRegistry {
+            inner: Arc::new(Inner::new(accept_list)),
+        }
+    }
+
+    fn record(&self, metric: &MetricVisitor) {
+        match metric.metric_type {
+            MetricType::Counter => self.handle_counter(metric),
+            MetricType::Gauge => self.handle_gauge(metric),
+            MetricType::Histogram => self.handle_histogram(metric),
+            MetricType::Description => self.handle_description(metric),
+        }
+    }
+
+    fn handle_description(&self, metric: &MetricVisitor) {
+        if let MetricAction::Description(description) = &metric.action {
+            let mut descriptions = self.inner.descriptions.write();
+            //TODO: Sanitize string
+            descriptions
+                .entry(metric.name.name().to_string())
+                .or_insert(description.to_string());
+        }
+    }
+
+    fn handle_counter(&self, metric: &MetricVisitor) {
+        self.inner
+            .register
+            .get_or_create_counter(&metric.name, |c| match metric.action {
+                MetricAction::Increment(val) => CounterFn::increment(c, val),
+                MetricAction::Absolute(val) => CounterFn::absolute(c, val),
+                _ => (),
+            });
+    }
+
+    fn handle_gauge(&self, metric: &MetricVisitor) {
+        self.inner
+            .register
+            .get_or_create_gauge(&metric.name, |c| match metric.action {
+                MetricAction::GaugeInc(val) => GaugeFn::increment(c, val as f64),
+                MetricAction::GaugeSet(val) => GaugeFn::set(c, val as f64),
+                MetricAction::GaugeDec(val) => GaugeFn::decrement(c, val as f64),
+                _ => (),
+            });
+    }
+
+    fn handle_histogram(&self, metric: &MetricVisitor) {
+        self.inner.register.get_or_create_histogram(&metric.name, |c| {
+            if let MetricAction::HistRecord(val) = metric.action {
+                // We multiply by 1000 here because the value is converted into seconds when doing:
+                // histogram!("my_histogram", duration.elapsed());
+                // and we want it in ms
+                HistogramFn::record(c, val * 1000.0)
+            }
+        });
+    }
+
+    pub fn counter_value(&self, name: &'static str) -> Option<u64> {
+        let key = Key::from_name(name);
+        let counters = self.inner.register.get_counter_handles();
+        let counter = counters.get(&key)?;
+        Some(counter.get_inner().load(Ordering::Acquire))
+    }
+
+    pub fn gauge_value(&self, name: &'static str) -> Option<f64> {
+        let key = Key::from_name(name);
+        let gauges = self.inner.register.get_gauge_handles();
+        let gauge = gauges.get(&key)?;
+        let val = f64::from_bits(gauge.get_inner().load(Ordering::Acquire));
+        Some(val)
+    }
+
+    pub fn histogram_values(&self, name: &'static str) -> Option<HistogramUtil> {
+        let mut histogram = HistogramUtil::new(&HISTOGRAM_BOUNDS)?;
+        let key = Key::from_name(name);
+        let histograms = self.inner.register.get_histogram_handles();
+        let samples = histograms.get(&key)?;
+
+        samples.get_inner().data_with(|s| {
+            histogram.record_many(s);
+        });
+        Some(histogram)
+    }
+
+    pub fn get_descriptions(&self) -> HashMap<String, String> {
+        let descriptions = self.inner.descriptions.read();
+        descriptions.clone()
+    }
+
+    fn get_snapshot(&self, global_labels: HashMap<String, String>) -> Snapshot {
+        let counter_handles = self.inner.register.get_counter_handles();
+        let gauge_handles = self.inner.register.get_gauge_handles();
+        let histogram_handles = self.inner.register.get_histogram_handles();
+        let descriptions = self.get_descriptions();
+
+        let mut counters: Vec<Metric> = counter_handles
+            .into_iter()
+            .map(|(key, counter)| {
+                let key_name = key.name();
+                let value = counter.get_inner().load(Ordering::Acquire);
+                let description = descriptions.get(key_name).cloned().unwrap_or_default();
+                Metric::new(key, description, MetricValue::Counter(value), global_labels.clone())
+            })
+            .collect();
+
+        let mut gauges: Vec<Metric> = gauge_handles
+            .into_iter()
+            .map(|(key, gauge)| {
+                let key_name = key.name();
+                let description = descriptions.get(key_name).cloned().unwrap_or_default();
+                let value = f64::from_bits(gauge.get_inner().load(Ordering::Acquire));
+                Metric::new(key, description, MetricValue::Gauge(value), global_labels.clone())
+            })
+            .collect();
+
+        let mut histograms: Vec<Metric> = histogram_handles
+            .into_iter()
+            .map(|(key, samples)| {
+                let mut histogram = HistogramUtil::new(&HISTOGRAM_BOUNDS).unwrap();
+                samples.get_inner().data_with(|s| {
+                    histogram.record_many(s);
+                });
+
+                let key_name = key.name();
+                let description = descriptions.get(key_name).cloned().unwrap_or_default();
+                Metric::new(
+                    key,
+                    description,
+                    MetricValue::Histogram(histogram.into()),
+                    global_labels.clone(),
+                )
+            })
+            .collect();
+
+        // Sort them so that they are in ordered by key name
+        counters.sort_by(|a, b| a.key.cmp(&b.key));
+        gauges.sort_by(|a, b| a.key.cmp(&b.key));
+        histograms.sort_by(|a, b| a.key.cmp(&b.key));
+
+        Snapshot {
+            counters,
+            gauges,
+            histograms,
+        }
+    }
+
+    pub fn to_json(&self, global_labels: HashMap<String, String>) -> Value {
+        let metrics = self.get_snapshot(global_labels);
+        metrics_to_json(metrics)
+    }
+
+    pub fn to_prometheus(&self, global_labels: HashMap<String, String>) -> String {
+        let metrics = self.get_snapshot(global_labels);
+        metrics_to_prometheus(metrics)
+    }
+
+    fn is_accepted_metric(&self, visitor: &MetricVisitor) -> bool {
+        let name = visitor.name.name();
+        if self.inner.accept_list.contains(&name) {
+            return true;
+        }
+
+        false
+    }
+}
+
+#[derive(Debug)]
+struct MetricVisitor {
+    metric_type: MetricType,
+    action: MetricAction,
+    name: Key,
+}
+
+impl MetricVisitor {
+    pub fn new() -> Self {
+        Self {
+            metric_type: MetricType::Description,
+            action: MetricAction::Absolute(0),
+            name: Key::from_name(""),
+        }
+    }
+}
+
+impl Visit for MetricVisitor {
+    fn record_debug(&mut self, _field: &Field, _value: &dyn std::fmt::Debug) {}
+
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        match field.name() {
+            "gauge_inc" => self.action = MetricAction::GaugeInc(value),
+            "gauge_dec" => self.action = MetricAction::GaugeDec(value),
+            "gauge_set" => self.action = MetricAction::GaugeSet(value),
+            "hist_record" => self.action = MetricAction::HistRecord(value),
+            _ => (),
+        }
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        match field.name() {
+            "increment" => self.action = MetricAction::Increment(value as u64),
+            "absolute" => self.action = MetricAction::Absolute(value as u64),
+            _ => (),
+        }
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        match field.name() {
+            "increment" => self.action = MetricAction::Increment(value),
+            "absolute" => self.action = MetricAction::Absolute(value),
+            _ => (),
+        }
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        match (field.name(), value) {
+            ("metric_type", METRIC_COUNTER) => self.metric_type = MetricType::Counter,
+            ("metric_type", METRIC_GAUGE) => self.metric_type = MetricType::Gauge,
+            ("metric_type", METRIC_HISTOGRAM) => self.metric_type = MetricType::Histogram,
+            ("metric_type", METRIC_DESCRIPTION) => self.metric_type = MetricType::Description,
+            ("name", _) => self.name = Key::from_name(value.to_string()),
+            ("key_labels", _) => {
+                let key_labels: KeyLabels = serde_json::from_str(value).unwrap();
+                self.name = key_labels.into();
+            }
+            (METRIC_DESCRIPTION, _) => self.action = MetricAction::Description(value.to_string()),
+            _ => (),
+        }
+    }
+}
+
+// A tracing layer for receiving metric trace events and storing them in the registry.
+impl<S: Subscriber> Layer<S> for MetricRegistry {
+    fn on_event(&self, event: &tracing::Event<'_>, _ctx: tracing_subscriber::layer::Context<'_, S>) {
+        if event.metadata().target() != METRIC_TARGET {
+            return;
+        }
+
+        let mut visitor = MetricVisitor::new();
+        event.record(&mut visitor);
+
+        if self.is_accepted_metric(&visitor) {
+            self.record(&visitor);
+        }
+    }
+}

--- a/query-engine/query-engine/src/context.rs
+++ b/query-engine/query-engine/src/context.rs
@@ -1,7 +1,7 @@
 use crate::{PrismaError, PrismaResult};
 use datamodel::{dml::Datamodel, Configuration};
 use prisma_models::InternalDataModelBuilder;
-use query_core::{executor, schema::QuerySchemaRef, schema_builder, QueryExecutor};
+use query_core::{executor, schema::QuerySchemaRef, schema_builder, MetricRegistry, QueryExecutor};
 use std::{env, fmt, sync::Arc};
 
 /// Prisma request context containing all immutable state of the process.
@@ -11,6 +11,7 @@ pub struct PrismaContext {
     query_schema: QuerySchemaRef,
     /// DML-based v2 datamodel.
     dm: Datamodel,
+    pub metrics: MetricRegistry,
     /// Central query executor.
     pub executor: Box<dyn QueryExecutor + Send + Sync + 'static>,
 }
@@ -26,6 +27,7 @@ pub struct ContextBuilder {
     enable_raw_queries: bool,
     datamodel: Datamodel,
     config: Configuration,
+    metrics: Option<MetricRegistry>,
 }
 
 impl ContextBuilder {
@@ -39,14 +41,32 @@ impl ContextBuilder {
         self
     }
 
+    pub fn set_metrics(mut self, metrics: MetricRegistry) -> Self {
+        self.metrics = Some(metrics);
+        self
+    }
+
     pub async fn build(self) -> PrismaResult<PrismaContext> {
-        PrismaContext::new(self.config, self.datamodel, self.enable_raw_queries).await
+        PrismaContext::new(
+            self.config,
+            self.datamodel,
+            self.legacy,
+            self.enable_raw_queries,
+            self.metrics.unwrap(),
+        )
+        .await
     }
 }
 
 impl PrismaContext {
     /// Initializes a new Prisma context.
-    async fn new(config: Configuration, dm: Datamodel, enable_raw_queries: bool) -> PrismaResult<Self> {
+    async fn new(
+        config: Configuration,
+        dm: Datamodel,
+        _legacy: bool,
+        enable_raw_queries: bool,
+        metrics: MetricRegistry,
+    ) -> PrismaResult<Self> {
         // We only support one data source at the moment, so take the first one (default not exposed yet).
         let data_source = config
             .datasources
@@ -75,6 +95,7 @@ impl PrismaContext {
             query_schema,
             dm,
             executor,
+            metrics,
         };
 
         context.verify_connection().await?;
@@ -93,6 +114,7 @@ impl PrismaContext {
             enable_raw_queries: false,
             datamodel,
             config,
+            metrics: None,
         }
     }
 

--- a/query-engine/query-engine/src/logger.rs
+++ b/query-engine/query-engine/src/logger.rs
@@ -4,8 +4,9 @@ use opentelemetry::{
     KeyValue,
 };
 use opentelemetry_otlp::WithExportConfig;
+use query_core::MetricRegistry;
 use tracing::{dispatcher::SetGlobalDefaultError, subscriber};
-use tracing_subscriber::{layer::SubscriberExt, registry::LookupSpan, EnvFilter, FmtSubscriber};
+use tracing_subscriber::{layer::SubscriberExt, registry::LookupSpan, EnvFilter, FmtSubscriber, Layer};
 
 use crate::LogFormat;
 
@@ -19,6 +20,7 @@ pub struct Logger<'a> {
     enable_telemetry: bool,
     log_queries: bool,
     telemetry_endpoint: Option<&'a str>,
+    metrics: Option<MetricRegistry>,
 }
 
 impl<'a> Logger<'a> {
@@ -30,6 +32,7 @@ impl<'a> Logger<'a> {
             enable_telemetry: false,
             log_queries: false,
             telemetry_endpoint: None,
+            metrics: None,
         }
     }
 
@@ -51,6 +54,10 @@ impl<'a> Logger<'a> {
     /// Sets a custom telemetry endpoint (default: http://localhost:4317)
     pub fn telemetry_endpoint(&mut self, endpoint: &'a str) {
         self.telemetry_endpoint = Some(endpoint);
+    }
+
+    pub fn enable_metrics(&mut self, metrics: MetricRegistry) {
+        self.metrics = Some(metrics);
     }
 
     /// Install logger as a global. Can be called only once per application
@@ -80,14 +87,19 @@ impl<'a> Logger<'a> {
         match self.log_format {
             LogFormat::Text => {
                 if self.enable_telemetry {
+                    // Leaving this the old way since this will be removed with the new tracing work
                     let subscriber = FmtSubscriber::builder()
                         .with_env_filter(filter.add_directive("trace".parse().unwrap()))
                         .finish();
 
                     self.finalize(subscriber)
                 } else {
-                    let subscriber = FmtSubscriber::builder().with_env_filter(filter).finish();
-                    self.finalize(subscriber)
+                    let fmt_layer = tracing_subscriber::fmt::layer().with_filter(filter);
+
+                    let subscriber = tracing_subscriber::registry().with(fmt_layer).with(self.metrics);
+                    subscriber::set_global_default(subscriber)?;
+
+                    Ok(())
                 }
             }
             LogFormat::Json => {
@@ -126,7 +138,6 @@ impl<'a> Logger<'a> {
             Ok(())
         } else {
             subscriber::set_global_default(subscriber)?;
-
             Ok(())
         }
     }

--- a/query-engine/query-engine/src/main.rs
+++ b/query-engine/query-engine/src/main.rs
@@ -3,6 +3,7 @@
 #[macro_use]
 extern crate tracing;
 
+use query_core::{metrics, MetricRegistry};
 use query_engine::cli::CliCommand;
 use query_engine::error::PrismaError;
 use query_engine::logger::Logger;
@@ -25,19 +26,26 @@ async fn main() -> Result<(), AnyError> {
     async fn main() -> Result<(), PrismaError> {
         let opts = PrismaOpt::from_args();
 
+        let metrics = MetricRegistry::new();
+
         let mut logger = Logger::new("query-engine-http");
         logger.log_format(opts.log_format());
         logger.log_queries(opts.log_queries());
         logger.enable_telemetry(opts.open_telemetry);
         logger.telemetry_endpoint(&opts.open_telemetry_endpoint);
+        logger.enable_metrics(metrics.clone());
 
         logger.install().unwrap();
+
+        if opts.enable_metrics {
+            metrics::setup();
+        }
 
         match CliCommand::from_opt(&opts)? {
             Some(cmd) => cmd.execute().await?,
             None => {
                 set_panic_hook(opts.log_format());
-                server::listen(opts).await?;
+                server::listen(opts, metrics).await?;
             }
         }
 

--- a/query-engine/query-engine/src/opt.rs
+++ b/query-engine/query-engine/src/opt.rs
@@ -92,6 +92,10 @@ pub struct PrismaOpt {
     #[structopt(long = "debug", short = "d")]
     pub enable_debug_mode: bool,
 
+    /// Enables the metrics endpoints
+    #[structopt(long, short = "m")]
+    pub enable_metrics: bool,
+
     /// Enable query logging [env: LOG_QUERIES=y]
     #[structopt(long, short = "o")]
     pub log_queries: bool,

--- a/query-engine/query-engine/src/tests/dmmf.rs
+++ b/query-engine/query-engine/src/tests/dmmf.rs
@@ -103,6 +103,7 @@ fn test_dmmf_cli_command(schema: &str) -> PrismaResult<()> {
         enable_debug_mode: false,
         enable_raw_queries: false,
         enable_playground: false,
+        enable_metrics: true,
         legacy: false,
         log_format: None,
         log_queries: true,


### PR DESCRIPTION
This is the first PR and adds metrics to the Engine. This PR only exposes the metrics via the binary/http server. 
```
curl HTTP://localhost:4466/metrics 
```
Will return the metrics in Prometheus format

```
curl HTTP://localhost:4466/metrics?format=json
```
Will return the metrics in json format

This PR excludes the following that will be added in a future PR:
1. node-api integration
2. MongoDB

**note:** I don't want to merge this until we have done 3.14 release. 

## Metrics
Most the actual metrics are in mobc https://github.com/prisma/mobc/blob/main/src/metrics_utils.rs and quaint https://github.com/prisma/quaint/pull/363

## Testing:

You can test using a schema file and js file like this:
```prisma

generator js {
  provider        = "prisma-client-js"
  previewFeatures = ["metrics"]
}

model Post {
    id        Int     @id @default(autoincrement())
    title     String
    content   String?
    published Boolean @default(false)
    author    User?   @relation(fields: [authorId], references: [id])
    authorId  Int?
}

model User {
    id    Int     @id @default(autoincrement())
    email String  @unique
    name  String?
    posts Post[]
}
```

```typescript
import { PrismaClient } from "@prisma/client";
import { inspect } from 'util';
import axios from "axios";

const prisma = new PrismaClient({
  log: ["info", "error", "query", "warn"],
  __internal: {
    engine: {
      endpoint: "http://127.0.0.1:4466",
    },
  },
} as any);

let main = async () => {
  const createdUser = await prisma.user.upsert({
    where: {
      email: "hello@gmail.com",
    },
    create: {
      email: "hello@gmail.com",
      name: "user-1",
    },
    update: {
      id: 1,
    },
  });

  console.log(createdUser);

  let res = await axios.get("http://127.0.0.1:4466/metrics?format=json");

  console.log("JSON - metrics", inspect(res.data, false, null, true))

  let res2 = await axios.get("http://127.0.0.1:4466/metrics");
  console.log("Prometheus - metrics", inspect(res2.data, false, null, true))

};

main()
  .then(() => console.log("done"))
  .catch((err) => console.error(err));

setInterval(async () => {
  main()
}, 1000);
```

### Prometheus
You can test with this Prometheus like this:
config file:
```yaml
scrape_configs:
  - job_name: 'prometheus'
    scrape_interval: 1s

    static_configs:
      - targets: ['host.docker.internal:4466']
        labels:
          service: 'prisma-metrics'
          group: 'production'
```

```
docker run -p 9090:9090 -v \"$(pwd)/prometheus\":/prometheus-data prom/prometheus --config.file=/prometheus-data/prometheus.yml
```

### Examples of what you should see are

<img width="1664" alt="Screenshot 2022-05-09 at 14 12 38" src="https://user-images.githubusercontent.com/179458/167407425-0a28184b-6460-4031-8492-2fd9bafd3ed1.png">

<img width="1663" alt="Screenshot 2022-05-09 at 14 14 12" src="https://user-images.githubusercontent.com/179458/167407717-20b5c652-c44f-4f84-a600-09da8d1e9dad.png">

