### PR TITLE
fix: compound index clashing with field name

### DIFF
--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations.rs
@@ -45,6 +45,7 @@ pub(super) fn validate(ctx: &mut Context<'_>) {
         models::has_a_unique_custom_primary_key_name_per_model(model, &names, ctx);
         models::uses_sort_or_length_on_primary_without_preview_flag(model, ctx);
         models::id_has_fields(model, ctx);
+        models::id_client_name_does_not_clash_with_field(model, ctx);
         models::primary_key_connector_specific(model, ctx);
         models::primary_key_length_prefix_supported(model, ctx);
         models::primary_key_sort_order_supported(model, ctx);
@@ -91,6 +92,7 @@ pub(super) fn validate(ctx: &mut Context<'_>) {
         for index in model.indexes() {
             indexes::has_fields(index, ctx);
             indexes::has_a_unique_constraint_name(index, &names, ctx);
+            indexes::unique_client_name_does_not_clash_with_field(index, ctx);
             indexes::unique_index_has_a_unique_custom_name_per_model(index, &names, ctx);
             indexes::uses_length_or_sort_without_preview_flag(index, ctx);
             indexes::field_length_prefix_supported(index, ctx);

--- a/libs/datamodel/core/tests/attributes/field_name_clash.rs
+++ b/libs/datamodel/core/tests/attributes/field_name_clash.rs
@@ -1,0 +1,135 @@
+use crate::{with_header, Provider};
+use expect_test::expect;
+use indoc::indoc;
+
+#[test]
+fn naming_a_scalar_field_same_as_generated_id_name_should_error() {
+    let dml = with_header(
+        indoc! {r#"
+        model User {
+          a           Int
+          b           Int
+          a_b         Int
+
+          @@id([a, b])
+        }
+    "#},
+        Provider::Postgres,
+        &[],
+    );
+
+    let error = datamodel::parse_schema(&dml).map(drop).unwrap_err();
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError validating model "User": The field `a_b` clashes with the `@@id` attribute's name. Please resolve the conflict by providing a custom id name: `@@id([...], name: "custom_name")`[0m
+          [1;94m-->[0m  [4mschema.prisma:16[0m
+        [1;94m   | [0m
+        [1;94m15 | [0m
+        [1;94m16 | [0m  @@[1;91mid([a, b])[0m
+        [1;94m   | [0m
+    "#]];
+
+    expectation.assert_eq(&error)
+}
+
+#[test]
+fn naming_a_field_same_as_generated_uniq_name_should_error() {
+    let dml = with_header(
+        indoc! {r#"
+        model User {
+          a           Int
+          b           Int
+          a_b         Int
+
+          @@unique([a, b])
+        }
+    "#},
+        Provider::Postgres,
+        &[],
+    );
+
+    let error = datamodel::parse_schema(&dml).map(drop).unwrap_err();
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError validating model "User": The field `a_b` clashes with the `@@unique` name. Please resolve the conflict by providing a custom id name: `@@unique([...], name: "custom_name")`[0m
+          [1;94m-->[0m  [4mschema.prisma:16[0m
+        [1;94m   | [0m
+        [1;94m15 | [0m
+        [1;94m16 | [0m  @@[1;91munique([a, b])[0m
+        [1;94m   | [0m
+    "#]];
+
+    expectation.assert_eq(&error)
+}
+
+#[test]
+fn naming_a_field_same_as_explicit_uniq_name_should_error() {
+    let dml = with_header(
+        indoc! {r#"
+        model User {
+          a           Int
+          b           Int
+          moo         Int
+
+          @@unique([a, b], name: "moo")
+        }
+    "#},
+        Provider::Postgres,
+        &[],
+    );
+
+    let error = datamodel::parse_schema(&dml).map(drop).unwrap_err();
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError validating model "User": The custom name `moo` specified for the `@@unique` attribute is already used as a name for a field. Please choose a different name.[0m
+          [1;94m-->[0m  [4mschema.prisma:11[0m
+        [1;94m   | [0m
+        [1;94m10 | [0m
+        [1;94m11 | [0m[1;91mmodel User {[0m
+        [1;94m12 | [0m  a           Int
+        [1;94m13 | [0m  b           Int
+        [1;94m14 | [0m  moo         Int
+        [1;94m15 | [0m
+        [1;94m16 | [0m  @@unique([a, b], name: "moo")
+        [1;94m17 | [0m}
+        [1;94m   | [0m
+    "#]];
+
+    expectation.assert_eq(&error)
+}
+
+#[test]
+fn naming_a_field_same_as_explicit_id_name_should_error() {
+    let dml = with_header(
+        indoc! {r#"
+        model User {
+          a           Int
+          b           Int
+          moo         Int
+
+          @@id([a, b], name: "moo")
+        }
+    "#},
+        Provider::Postgres,
+        &[],
+    );
+
+    let error = datamodel::parse_schema(&dml).map(drop).unwrap_err();
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError validating model "User": The custom name `moo` specified for the `@@id` attribute is already used as a name for a field. Please choose a different name.[0m
+          [1;94m-->[0m  [4mschema.prisma:11[0m
+        [1;94m   | [0m
+        [1;94m10 | [0m
+        [1;94m11 | [0m[1;91mmodel User {[0m
+        [1;94m12 | [0m  a           Int
+        [1;94m13 | [0m  b           Int
+        [1;94m14 | [0m  moo         Int
+        [1;94m15 | [0m
+        [1;94m16 | [0m  @@id([a, b], name: "moo")
+        [1;94m17 | [0m}
+        [1;94m   | [0m
+    "#]];
+
+    expectation.assert_eq(&error)
+}

--- a/libs/datamodel/core/tests/attributes/mod.rs
+++ b/libs/datamodel/core/tests/attributes/mod.rs
@@ -9,6 +9,7 @@ mod default_composite_negative;
 mod default_composite_positive;
 mod default_negative;
 mod default_positive;
+mod field_name_clash;
 mod id_negative;
 mod id_positive;
 mod ignore_negative;


### PR DESCRIPTION
This is a reimplementation of
https://github.com/prisma/prisma-engines/pull/2593 because it has gone
stale. The approach taken here is simpler, it rests on the assumption
that we only need to validate the client names in one place, and that
their scope is statically determined (unlike constraint names).

Additional difference: non-unique indexes are not validated because they
do not end up in the client API, so the names cannot clash.

closes https://github.com/prisma/prisma/issues/10456