### PR TITLE
me: never validate that the db is not cockroach when provider = postgres

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/postgres.rs
@@ -609,20 +609,17 @@ where
 
                     let version = schema_exists_result.get(0).and_then(|row| row.at(1)).and_then(|v| v.to_string());
 
-                    let cockroach_preview_enabled = params
-                        .connector_params
-                        .preview_features
-                        .contains(PreviewFeature::Cockroachdb);
-
                     match version {
                         Some(version) => {
                             let db_is_cockroach = version.contains("CockroachDB");
 
-                            if db_is_cockroach && !provider_is_cockroachdb && cockroach_preview_enabled {
-                                let msg = "You are trying to connect to a CockroachDB database, but the provider in your Prisma schema is `postgresql`. Please change it to `cockroachdb`.";
+                            // We will want to validate this in the future: https://github.com/prisma/prisma/issues/13222
+                            // if db_is_cockroach && !provider_is_cockroachdb  {
+                            //     let msg = "You are trying to connect to a CockroachDB database, but the provider in your Prisma schema is `postgresql`. Please change it to `cockroachdb`.";
 
-                                return Err(ConnectorError::from_msg(msg.to_owned()));
-                            } else if !db_is_cockroach && provider_is_cockroachdb {
+                            //     return Err(ConnectorError::from_msg(msg.to_owned()));
+
+                            if !db_is_cockroach && provider_is_cockroachdb {
                                 let msg = "You are trying to connect to a PostgreSQL database, but the provider in your Prisma schema is `cockroachdb`. Please change it to `postgresql`.";
 
                                 return Err(ConnectorError::from_msg(msg.to_owned()));

--- a/migration-engine/migration-engine-tests/tests/migrations/cockroachdb.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/cockroachdb.rs
@@ -426,36 +426,38 @@ fn typescript_starter_schema_with_native_types_is_idempotent(api: TestApi) {
         .assert_no_steps();
 }
 
-#[test_connector(tags(CockroachDb))]
-fn connecting_to_a_cockroachdb_database_with_the_postgresql_connector_fails(_api: TestApi) {
-    let dm = r#"
-        datasource crdb {
-            provider = "postgresql"
-            url = env("TEST_DATABASE_URL")
-        }
+// We will want to validate this in the future: https://github.com/prisma/prisma/issues/13222
+//
+// #[test_connector(tags(CockroachDb))]
+// fn connecting_to_a_cockroachdb_database_with_the_postgresql_connector_fails(_api: TestApi) {
+//     let dm = r#"
+//         datasource crdb {
+//             provider = "postgresql"
+//             url = env("TEST_DATABASE_URL")
+//         }
 
-        generator js {
-            provider = "prisma-client-js"
-            previewFeatures = ["cockroachdb"]
-        }
-    "#;
+//         generator js {
+//             provider = "prisma-client-js"
+//             previewFeatures = ["cockroachdb"]
+//         }
+//     "#;
 
-    let engine = migration_core::migration_api(None, None).unwrap();
-    let err = tok(
-        engine.ensure_connection_validity(migration_core::json_rpc::types::EnsureConnectionValidityParams {
-            datasource: migration_core::json_rpc::types::DatasourceParam::SchemaString(SchemaContainer {
-                schema: dm.to_owned(),
-            }),
-        }),
-    )
-    .unwrap_err()
-    .to_string();
+//     let engine = migration_core::migration_api(None, None).unwrap();
+//     let err = tok(
+//         engine.ensure_connection_validity(migration_core::json_rpc::types::EnsureConnectionValidityParams {
+//             datasource: migration_core::json_rpc::types::DatasourceParam::SchemaString(SchemaContainer {
+//                 schema: dm.to_owned(),
+//             }),
+//         }),
+//     )
+//     .unwrap_err()
+//     .to_string();
 
-    let expected_error = expect![[r#"
-        You are trying to connect to a CockroachDB database, but the provider in your Prisma schema is `postgresql`. Please change it to `cockroachdb`.
-    "#]];
-    expected_error.assert_eq(&err);
-}
+//     let expected_error = expect![[r#"
+//         You are trying to connect to a CockroachDB database, but the provider in your Prisma schema is `postgresql`. Please change it to `cockroachdb`.
+//     "#]];
+//     expected_error.assert_eq(&err);
+// }
 
 #[test_connector(tags(CockroachDb))]
 fn connecting_to_a_cockroachdb_database_with_the_postgresql_connector_without_preview_says_nothing(_api: TestApi) {


### PR DESCRIPTION
Rationale in the issue in the comment.