### PR TITLE
Remove extra tracing messages from the QueryEngine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2412,9 +2412,9 @@ dependencies = [
 
 [[package]]
 name = "napi-build"
-version = "1.2.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd4419172727423cf30351406c54f6cc1b354a2cfb4f1dba3e6cd07f6d5522b"
+checksum = "d6bba07d993e9865e6000062849a7644194be1b08c81968e7f02efd00e2dd49b"
 
 [[package]]
 name = "napi-derive"
@@ -3326,7 +3326,6 @@ dependencies = [
  "napi-build",
  "napi-derive",
  "opentelemetry",
- "opentelemetry-otlp",
  "prisma-models",
  "query-connector",
  "query-core",
@@ -3956,7 +3955,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0bccbcf40c8938196944a3da0e133e031a33f4d6b72db3bda3cc556e361905d"
 dependencies = [
  "lazy_static",
- "parking_lot 0.10.2",
+ "parking_lot 0.11.2",
  "serial_test_derive",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2412,9 +2412,9 @@ dependencies = [
 
 [[package]]
 name = "napi-build"
-version = "2.0.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bba07d993e9865e6000062849a7644194be1b08c81968e7f02efd00e2dd49b"
+checksum = "ebd4419172727423cf30351406c54f6cc1b354a2cfb4f1dba3e6cd07f6d5522b"
 
 [[package]]
 name = "napi-derive"

--- a/libs/sql-schema-describer/src/mssql.rs
+++ b/libs/sql-schema-describer/src/mssql.rs
@@ -114,7 +114,6 @@ impl super::SqlSchemaDescriberBackend for SqlSchemaDescriber<'_> {
         })
     }
 
-    #[tracing::instrument]
     async fn describe(&self, schema: &str) -> DescriberResult<SqlSchema> {
         let mut tables = self.get_table_names(schema).await?;
         let table_ids = tables
@@ -151,7 +150,6 @@ impl super::SqlSchemaDescriberBackend for SqlSchemaDescriber<'_> {
         })
     }
 
-    #[tracing::instrument]
     async fn version(&self, _schema: &str) -> DescriberResult<Option<String>> {
         Ok(self.conn.version().await?)
     }
@@ -164,7 +162,6 @@ impl<'a> SqlSchemaDescriber<'a> {
         Self { conn }
     }
 
-    #[tracing::instrument]
     async fn get_databases(&self) -> DescriberResult<Vec<String>> {
         let sql = "SELECT name FROM sys.schemas";
         let rows = self.conn.query_raw(sql, &[]).await?;
@@ -176,7 +173,6 @@ impl<'a> SqlSchemaDescriber<'a> {
         Ok(names)
     }
 
-    #[tracing::instrument]
     async fn get_procedures(&self, schema: &str) -> DescriberResult<Vec<Procedure>> {
         let sql = r#"
             SELECT name, OBJECT_DEFINITION(object_id) AS definition
@@ -199,7 +195,6 @@ impl<'a> SqlSchemaDescriber<'a> {
         Ok(procedures)
     }
 
-    #[tracing::instrument]
     async fn get_table_names(&self, schema: &str) -> DescriberResult<Vec<Table>> {
         let select = r#"
             SELECT t.name AS table_name
@@ -226,7 +221,6 @@ impl<'a> SqlSchemaDescriber<'a> {
         Ok(names)
     }
 
-    #[tracing::instrument]
     async fn get_size(&self, schema: &str) -> DescriberResult<usize> {
         let sql = indoc! {r#"
             SELECT
@@ -525,7 +519,6 @@ impl<'a> SqlSchemaDescriber<'a> {
         Ok(())
     }
 
-    #[tracing::instrument]
     async fn get_views(&self, schema: &str) -> DescriberResult<Vec<View>> {
         let sql = indoc! {r#"
             SELECT name AS view_name, OBJECT_DEFINITION(object_id) AS view_sql

--- a/libs/sql-schema-describer/src/postgres.rs
+++ b/libs/sql-schema-describer/src/postgres.rs
@@ -508,7 +508,6 @@ impl<'a> super::SqlSchemaDescriberBackend for SqlSchemaDescriber<'a> {
         })
     }
 
-    #[tracing::instrument]
     async fn version(&self, _schema: &str) -> crate::DescriberResult<Option<String>> {
         Ok(self.conn.version().await?)
     }
@@ -541,7 +540,6 @@ impl<'a> SqlSchemaDescriber<'a> {
         self.circumstances.contains(Circumstances::Cockroach)
     }
 
-    #[tracing::instrument]
     async fn get_databases(&self) -> DescriberResult<Vec<String>> {
         let sql = "select schema_name from information_schema.schemata;";
         let rows = self.conn.query_raw(sql, &[]).await?;
@@ -555,7 +553,6 @@ impl<'a> SqlSchemaDescriber<'a> {
         Ok(names)
     }
 
-    #[tracing::instrument]
     async fn get_procedures(&self, schema: &str) -> DescriberResult<Vec<Procedure>> {
         if self.is_cockroach() {
             return Ok(Vec::new());
@@ -585,7 +582,6 @@ impl<'a> SqlSchemaDescriber<'a> {
         Ok(procedures)
     }
 
-    #[tracing::instrument]
     async fn get_table_names(&self, schema: &str) -> DescriberResult<Vec<String>> {
         let sql = "
             SELECT table_name as table_name FROM information_schema.tables
@@ -604,7 +600,6 @@ impl<'a> SqlSchemaDescriber<'a> {
         Ok(names)
     }
 
-    #[tracing::instrument]
     async fn get_size(&self, schema: &str) -> DescriberResult<usize> {
         if self.circumstances.contains(Circumstances::Cockroach) {
             return Ok(0); // TODO
@@ -643,7 +638,6 @@ impl<'a> SqlSchemaDescriber<'a> {
         }
     }
 
-    #[tracing::instrument]
     async fn get_views(&self, schema: &str) -> DescriberResult<Vec<View>> {
         let sql = indoc! {r#"
             SELECT viewname AS view_name, definition AS view_sql
@@ -1187,7 +1181,6 @@ impl<'a> SqlSchemaDescriber<'a> {
         Ok(())
     }
 
-    #[tracing::instrument]
     async fn get_enums(&self, schema: &str) -> DescriberResult<Vec<Enum>> {
         let sql = "
             SELECT t.typname as name, e.enumlabel as value

--- a/libs/sql-schema-describer/src/sqlite.rs
+++ b/libs/sql-schema-describer/src/sqlite.rs
@@ -137,7 +137,7 @@ impl<'a> SqlSchemaDescriber<'a> {
         Ok(size.try_into().unwrap())
     }
 
-    async fn get_table(&self, schema: &str, name: &str) -> DescriberResult<Table> {
+    async fn get_table(&self, _schema: &str, name: &str) -> DescriberResult<Table> {
         let (columns, primary_key) = self.get_columns(name).await?;
         let foreign_keys = self.get_foreign_keys(name).await?;
         let indices = self.get_indices(name).await?;

--- a/libs/sql-schema-describer/src/sqlite.rs
+++ b/libs/sql-schema-describer/src/sqlite.rs
@@ -35,7 +35,6 @@ impl SqlSchemaDescriberBackend for SqlSchemaDescriber<'_> {
         })
     }
 
-    #[tracing::instrument]
     async fn describe(&self, schema: &str) -> DescriberResult<SqlSchema> {
         let table_names: Vec<String> = self.get_table_names(schema).await?;
 
@@ -75,7 +74,6 @@ impl SqlSchemaDescriberBackend for SqlSchemaDescriber<'_> {
         })
     }
 
-    #[tracing::instrument]
     async fn version(&self, _schema: &str) -> DescriberResult<Option<String>> {
         Ok(self.conn.version().await?)
     }
@@ -89,7 +87,6 @@ impl<'a> SqlSchemaDescriber<'a> {
         SqlSchemaDescriber { conn }
     }
 
-    #[tracing::instrument]
     async fn get_databases(&self) -> DescriberResult<Vec<String>> {
         let sql = "PRAGMA database_list;";
         let rows = self.conn.query_raw(sql, &[]).await?;
@@ -129,7 +126,6 @@ impl<'a> SqlSchemaDescriber<'a> {
         Ok(names)
     }
 
-    #[tracing::instrument]
     async fn get_size(&self) -> DescriberResult<usize> {
         let sql = r#"SELECT page_count * page_size as size FROM pragma_page_count(), pragma_page_size();"#;
         let result = self.conn.query_raw(sql, &[]).await?;
@@ -141,7 +137,6 @@ impl<'a> SqlSchemaDescriber<'a> {
         Ok(size.try_into().unwrap())
     }
 
-    #[tracing::instrument]
     async fn get_table(&self, schema: &str, name: &str) -> DescriberResult<Table> {
         let (columns, primary_key) = self.get_columns(name).await?;
         let foreign_keys = self.get_foreign_keys(name).await?;
@@ -156,7 +151,6 @@ impl<'a> SqlSchemaDescriber<'a> {
         })
     }
 
-    #[tracing::instrument]
     async fn get_views(&self) -> DescriberResult<Vec<View>> {
         let sql = "SELECT name AS view_name, sql AS view_sql FROM sqlite_master WHERE type = 'view'";
         let result_set = self.conn.query_raw(sql, &[]).await?;
@@ -172,7 +166,6 @@ impl<'a> SqlSchemaDescriber<'a> {
         Ok(views)
     }
 
-    #[tracing::instrument]
     async fn get_columns(&self, table: &str) -> DescriberResult<(Vec<Column>, Option<PrimaryKey>)> {
         let sql = format!(r#"PRAGMA table_info ("{}")"#, table);
         let result_set = self.conn.query_raw(&sql, &[]).await?;

--- a/migration-engine/connectors/migration-connector/src/migrations_directory.rs
+++ b/migration-engine/connectors/migration-connector/src/migrations_directory.rs
@@ -51,7 +51,6 @@ pub fn create_migration_directory(
 }
 
 /// Write the migration_lock file to the directory.
-#[tracing::instrument]
 pub fn write_migration_lock_file(migrations_directory_path: &str, provider: &str) -> std::io::Result<()> {
     let directory_path = Path::new(migrations_directory_path);
     let mut file_path = directory_path.join(MIGRATION_LOCK_FILENAME);
@@ -74,7 +73,6 @@ provider = "{}""##,
 }
 
 /// Error if the provider in the schema does not match the one in the schema_lock.toml
-#[tracing::instrument]
 pub fn error_on_changed_provider(migrations_directory_path: &str, provider: &str) -> ConnectorResult<()> {
     match match_provider_in_lock_file(migrations_directory_path, provider) {
         None => Ok(()),
@@ -87,7 +85,6 @@ pub fn error_on_changed_provider(migrations_directory_path: &str, provider: &str
 }
 
 /// Check whether provider matches. `None` means there was no migration_lock.toml file.
-#[tracing::instrument]
 fn match_provider_in_lock_file(migrations_directory_path: &str, provider: &str) -> Option<Result<(), String>> {
     read_provider_from_lock_file(migrations_directory_path).map(|found_provider| {
         if found_provider == provider {
@@ -208,14 +205,12 @@ impl MigrationDirectory {
     }
 
     /// Check whether the checksum of the migration script matches the provided one.
-    #[tracing::instrument]
     pub fn matches_checksum(&self, checksum_str: &str) -> Result<bool, ReadMigrationScriptError> {
         let filesystem_script = self.read_migration_script()?;
         Ok(checksum::script_matches_checksum(&filesystem_script, checksum_str))
     }
 
     /// Write the migration script to the directory.
-    #[tracing::instrument]
     pub fn write_migration_script(&self, script: &str, extension: &str) -> std::io::Result<()> {
         let mut path = self.path.join(MIGRATION_SCRIPT_FILENAME);
 
@@ -230,7 +225,6 @@ impl MigrationDirectory {
     }
 
     /// Read the migration script to a string.
-    #[tracing::instrument]
     pub fn read_migration_script(&self) -> Result<String, ReadMigrationScriptError> {
         let path = self.path.join("migration.sql"); // todo why is it hardcoded here?
         std::fs::read_to_string(&path).map_err(|ioerr| ReadMigrationScriptError::new(ioerr, &path))

--- a/query-engine/connectors/mongodb-query-connector/src/root_queries/write.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/root_queries/write.rs
@@ -375,7 +375,6 @@ pub async fn execute_raw<'conn>(
 }
 
 /// Execute a plain MongoDB query, returning the answer as a JSON `Value`.
-#[tracing::instrument(skip(database, session, model, inputs, query_type))]
 pub async fn query_raw<'conn>(
     database: &Database,
     session: &mut ClientSession,

--- a/query-engine/connectors/sql-query-connector/src/cursor_condition.rs
+++ b/query-engine/connectors/sql-query-connector/src/cursor_condition.rs
@@ -118,7 +118,6 @@ struct CursorOrderForeignKey {
 ///     OR `ModelA`.`modelB_id` IS NULL -- >>> Additional check for the nullable foreign key
 ///   )
 /// ```
-#[tracing::instrument(name = "build_cursor_condition", skip(query_arguments, model, order_by_defs))]
 pub fn build(
     query_arguments: &QueryArguments,
     model: &ModelRef,

--- a/query-engine/connectors/sql-query-connector/src/database/connection.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/connection.rs
@@ -40,7 +40,6 @@ impl<C> Connection for SqlConnection<C>
 where
     C: QueryExt + TransactionCapable + Send + Sync + 'static,
 {
-    #[tracing::instrument(skip(self))]
     async fn start_transaction<'a>(&'a mut self) -> connector::Result<Box<dyn Transaction + 'a>> {
         let fut_tx = self.inner.start_transaction();
         let connection_info = &self.connection_info;

--- a/query-engine/connectors/sql-query-connector/src/database/mssql.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/mssql.rs
@@ -59,7 +59,6 @@ impl FromSource for Mssql {
 
 #[async_trait]
 impl Connector for Mssql {
-    #[tracing::instrument(skip(self))]
     async fn get_connection<'a>(&'a self) -> connector::Result<Box<dyn Connection + Send + Sync + 'static>> {
         super::catch(self.connection_info.clone(), async move {
             let conn = self.pool.check_out().await.map_err(SqlError::from)?;

--- a/query-engine/connectors/sql-query-connector/src/database/mysql.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/mysql.rs
@@ -59,7 +59,6 @@ impl FromSource for Mysql {
 
 #[async_trait]
 impl Connector for Mysql {
-    #[tracing::instrument(skip(self))]
     async fn get_connection<'a>(&'a self) -> connector::Result<Box<dyn Connection + Send + Sync + 'static>> {
         super::catch(self.connection_info.clone(), async move {
             let conn = self.pool.check_out().await.map_err(SqlError::from)?;

--- a/query-engine/connectors/sql-query-connector/src/database/operations/read.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/read.rs
@@ -11,7 +11,6 @@ use futures::stream::{FuturesUnordered, StreamExt};
 use prisma_models::*;
 use quaint::ast::*;
 
-#[tracing::instrument(skip(conn, model, filter, selected_fields))]
 pub async fn get_single_record(
     conn: &dyn QueryExt,
     model: &ModelRef,
@@ -55,7 +54,6 @@ pub async fn get_single_record(
     Ok(record)
 }
 
-#[tracing::instrument(skip(conn, model, query_arguments, selected_fields, aggr_selections, sql_info))]
 pub async fn get_many_records(
     conn: &dyn QueryExt,
     model: &ModelRef,
@@ -157,7 +155,6 @@ pub async fn get_many_records(
     Ok(records)
 }
 
-#[tracing::instrument(skip(conn, from_field, from_record_ids))]
 pub async fn get_related_m2m_record_ids(
     conn: &dyn QueryExt,
     from_field: &RelationFieldRef,
@@ -227,7 +224,6 @@ pub async fn get_related_m2m_record_ids(
         .collect())
 }
 
-#[tracing::instrument(skip(conn, model, query_arguments, selections, group_by, having))]
 pub async fn aggregate(
     conn: &dyn QueryExt,
     model: &ModelRef,
@@ -246,7 +242,6 @@ pub async fn aggregate(
     }
 }
 
-#[tracing::instrument(skip(conn, model, query_arguments, selections))]
 async fn plain_aggregate(
     conn: &dyn QueryExt,
     model: &ModelRef,
@@ -272,7 +267,6 @@ async fn plain_aggregate(
     Ok(row.into_aggregation_results(&selections))
 }
 
-#[tracing::instrument(skip(conn, model, query_arguments, selections, group_by, having))]
 async fn group_by_aggregate(
     conn: &dyn QueryExt,
     model: &ModelRef,

--- a/query-engine/connectors/sql-query-connector/src/database/operations/write.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/write.rs
@@ -61,7 +61,6 @@ async fn generate_id(
 
 /// Create a single record to the database defined in `conn`, resulting into a
 /// `RecordProjection` as an identifier pointing to the just-created record.
-#[tracing::instrument(skip(conn, model, args))]
 pub async fn create_record(
     conn: &dyn QueryExt,
     sql_family: &SqlFamily,
@@ -153,7 +152,6 @@ pub async fn create_record(
     }
 }
 
-#[tracing::instrument(skip(conn, sql_info, model, args, skip_duplicates))]
 pub async fn create_records(
     conn: &dyn QueryExt,
     sql_info: SqlInfo,
@@ -302,7 +300,6 @@ async fn create_many_empty(
 /// Update multiple records in a database defined in `conn` and the records
 /// defined in `args`, resulting the identifiers that were modified in the
 /// operation.
-#[tracing::instrument(skip(conn, model, record_filter, args))]
 pub async fn update_records(
     conn: &dyn QueryExt,
     model: &ModelRef,
@@ -330,7 +327,6 @@ pub async fn update_records(
 }
 
 /// Delete multiple records in `conn`, defined in the `Filter`. Result is the number of items deleted.
-#[tracing::instrument(skip(conn, model, record_filter))]
 pub async fn delete_records(
     conn: &dyn QueryExt,
     model: &ModelRef,
@@ -354,7 +350,6 @@ pub async fn delete_records(
 
 /// Connect relations defined in `child_ids` to a parent defined in `parent_id`.
 /// The relation information is in the `RelationFieldRef`.
-#[tracing::instrument(skip(conn, field, parent_id, child_ids))]
 pub async fn m2m_connect(
     conn: &dyn QueryExt,
     field: &RelationFieldRef,
@@ -369,7 +364,6 @@ pub async fn m2m_connect(
 
 /// Disconnect relations defined in `child_ids` to a parent defined in `parent_id`.
 /// The relation information is in the `RelationFieldRef`.
-#[tracing::instrument(skip(conn, field, parent_id, child_ids))]
 pub async fn m2m_disconnect(
     conn: &dyn QueryExt,
     field: &RelationFieldRef,
@@ -385,7 +379,6 @@ pub async fn m2m_disconnect(
 
 /// Execute a plain SQL query with the given parameters, returning the number of
 /// affected rows.
-#[tracing::instrument(skip(conn, inputs))]
 pub async fn execute_raw(
     conn: &dyn QueryExt,
     features: &[PreviewFeature],
@@ -398,7 +391,6 @@ pub async fn execute_raw(
 
 /// Execute a plain SQL query with the given parameters, returning the answer as
 /// a JSON `Value`.
-#[tracing::instrument(skip(conn, sql_info, features, inputs))]
 pub async fn query_raw(
     conn: &dyn QueryExt,
     sql_info: SqlInfo,

--- a/query-engine/connectors/sql-query-connector/src/database/postgresql.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/postgresql.rs
@@ -57,7 +57,6 @@ impl FromSource for PostgreSql {
 
 #[async_trait]
 impl Connector for PostgreSql {
-    #[tracing::instrument(skip(self))]
     async fn get_connection<'a>(&'a self) -> connector_interface::Result<Box<dyn Connection + Send + Sync + 'static>> {
         super::catch(self.connection_info.clone(), async move {
             let conn = self.pool.check_out().await.map_err(SqlError::from)?;

--- a/query-engine/connectors/sql-query-connector/src/database/sqlite.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/sqlite.rs
@@ -81,7 +81,6 @@ fn invalid_file_path_error(file_path: &str, connection_info: &ConnectionInfo) ->
 
 #[async_trait]
 impl Connector for Sqlite {
-    #[tracing::instrument(skip(self))]
     async fn get_connection<'a>(&'a self) -> connector::Result<Box<dyn Connection + Send + Sync + 'static>> {
         super::catch(self.connection_info().clone(), async move {
             let conn = self.pool.check_out().await.map_err(SqlError::from)?;

--- a/query-engine/connectors/sql-query-connector/src/database/transaction.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/transaction.rs
@@ -40,7 +40,6 @@ impl<'tx> ConnectionLike for SqlConnectorTransaction<'tx> {}
 
 #[async_trait]
 impl<'tx> Transaction for SqlConnectorTransaction<'tx> {
-    #[tracing::instrument(skip(self))]
     async fn commit(&mut self) -> connector::Result<()> {
         catch(self.connection_info.clone(), async move {
             Ok(self.inner.commit().await.map_err(SqlError::from)?)
@@ -48,7 +47,6 @@ impl<'tx> Transaction for SqlConnectorTransaction<'tx> {
         .await
     }
 
-    #[tracing::instrument(skip(self))]
     async fn rollback(&mut self) -> connector::Result<()> {
         catch(self.connection_info.clone(), async move {
             let res = self.inner.rollback().await.map_err(SqlError::from);

--- a/query-engine/connectors/sql-query-connector/src/filter_conversion.rs
+++ b/query-engine/connectors/sql-query-connector/src/filter_conversion.rs
@@ -76,7 +76,6 @@ trait AliasedSelect {
 
 impl AliasedCondition for Filter {
     /// Conversion from a `Filter` to a query condition tree. Aliased when in a nested `SELECT`.
-    #[tracing::instrument(skip(self, alias))]
     fn aliased_cond(self, alias: Option<Alias>) -> ConditionTree<'static> {
         match self {
             Filter::And(mut filters) => match filters.len() {

--- a/query-engine/connectors/sql-query-connector/src/ordering.rs
+++ b/query-engine/connectors/sql-query-connector/src/ordering.rs
@@ -18,7 +18,6 @@ pub struct OrderByDefinition {
 }
 
 /// Builds all expressions for an `ORDER BY` clause based on the query arguments.
-#[tracing::instrument(skip(query_arguments, base_model))]
 pub fn build(
     query_arguments: &QueryArguments,
     base_model: &ModelRef, // The model the ordering will start from

--- a/query-engine/connectors/sql-query-connector/src/query_builder/mod.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_builder/mod.rs
@@ -10,7 +10,6 @@ use quaint::ast::{Column, Comparable, ConditionTree, Query, Row, Values};
 
 const PARAMETER_LIMIT: usize = 2000;
 
-#[tracing::instrument(skip(columns, records, f))]
 pub(super) fn chunked_conditions<F, Q>(
     columns: &[Column<'static>],
     records: &[&SelectionResult],
@@ -29,7 +28,6 @@ where
         .collect()
 }
 
-#[tracing::instrument(skip(columns, results))]
 pub(super) fn conditions<'a>(
     columns: &'a [Column<'static>],
     results: impl IntoIterator<Item = &'a SelectionResult>,

--- a/query-engine/connectors/sql-query-connector/src/query_builder/read.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_builder/read.rs
@@ -52,7 +52,6 @@ impl SelectDefinition for Select<'static> {
 }
 
 impl SelectDefinition for QueryArguments {
-    #[tracing::instrument(skip(self, model, aggr_selections))]
     fn into_select(
         self,
         model: &ModelRef,
@@ -112,7 +111,6 @@ impl SelectDefinition for QueryArguments {
     }
 }
 
-#[tracing::instrument(skip(model, columns, aggr_selections, query))]
 pub fn get_records<T>(
     model: &ModelRef,
     columns: impl Iterator<Item = Column<'static>>,
@@ -159,7 +157,6 @@ where
 /// ```
 /// Important note: Do not use the AsColumn trait here as we need to construct column references that are relative,
 /// not absolute - e.g. `SELECT "field" FROM (...)` NOT `SELECT "full"."path"."to"."field" FROM (...)`.
-#[tracing::instrument(skip(model, selections, args))]
 pub fn aggregate(
     model: &ModelRef,
     selections: &[AggregationSelection],
@@ -208,7 +205,6 @@ pub fn aggregate(
     )
 }
 
-#[tracing::instrument(skip(model, args, selections, group_by, having))]
 pub fn group_by_aggregate(
     model: &ModelRef,
     args: QueryArguments,
@@ -262,7 +258,6 @@ pub fn group_by_aggregate(
     }
 }
 
-#[tracing::instrument(skip(model, selections))]
 fn extract_columns(model: &ModelRef, selections: &[AggregationSelection]) -> Vec<Column<'static>> {
     let fields: Vec<_> = selections
         .iter()

--- a/query-engine/connectors/sql-query-connector/src/query_builder/write.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_builder/write.rs
@@ -9,7 +9,6 @@ use tracing::Span;
 
 /// `INSERT` a new record to the database. Resulting an `INSERT` ast and an
 /// optional `RecordProjection` if available from the arguments or model.
-#[tracing::instrument(skip(model, args))]
 pub fn create_record(model: &ModelRef, mut args: WriteArgs, trace_id: Option<String>) -> Insert<'static> {
     let fields: Vec<_> = model
         .fields()
@@ -39,7 +38,6 @@ pub fn create_record(model: &ModelRef, mut args: WriteArgs, trace_id: Option<Str
 /// `INSERT` new records into the database based on the given write arguments,
 /// where each `WriteArg` in the Vec is one row.
 /// Requires `affected_fields` to be non-empty to produce valid SQL.
-#[tracing::instrument(skip(model, args, skip_duplicates))]
 #[allow(clippy::mutable_key_type)]
 pub fn create_records_nonempty(
     model: &ModelRef,
@@ -89,7 +87,6 @@ pub fn create_records_nonempty(
 }
 
 /// `INSERT` empty records statement.
-#[tracing::instrument(skip(model, skip_duplicates))]
 pub fn create_records_empty(model: &ModelRef, skip_duplicates: bool, trace_id: Option<String>) -> Insert<'static> {
     let insert: Insert<'static> = Insert::single_into(model.as_table()).into();
     let insert = insert.append_trace(&Span::current()).add_trace_id(trace_id);
@@ -101,7 +98,6 @@ pub fn create_records_empty(model: &ModelRef, skip_duplicates: bool, trace_id: O
     }
 }
 
-#[tracing::instrument(skip(model, ids, args))]
 pub fn update_many(
     model: &ModelRef,
     ids: &[&SelectionResult],
@@ -170,7 +166,6 @@ pub fn update_many(
     Ok(result)
 }
 
-#[tracing::instrument(skip(model, ids))]
 pub fn delete_many(model: &ModelRef, ids: &[&SelectionResult], trace_id: Option<String>) -> Vec<Query<'static>> {
     let columns: Vec<_> = ModelProjection::from(model.primary_identifier()).as_columns().collect();
 
@@ -182,7 +177,6 @@ pub fn delete_many(model: &ModelRef, ids: &[&SelectionResult], trace_id: Option<
     })
 }
 
-#[tracing::instrument(skip(field, parent_id, child_ids))]
 pub fn create_relation_table_records(
     field: &RelationFieldRef,
     parent_id: &SelectionResult,
@@ -207,7 +201,6 @@ pub fn create_relation_table_records(
     insert.build().on_conflict(OnConflict::DoNothing).into()
 }
 
-#[tracing::instrument(skip(parent_field, parent_id, child_ids))]
 pub fn delete_relation_table_records(
     parent_field: &RelationFieldRef,
     parent_id: &SelectionResult,

--- a/query-engine/connectors/sql-query-connector/src/query_ext.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_ext.rs
@@ -33,7 +33,6 @@ impl QueryExt for PooledConnection {}
 #[async_trait]
 pub trait QueryExt: Queryable + Send + Sync {
     /// Filter and map the resulting types with the given identifiers.
-    #[tracing::instrument(skip(self, q, idents))]
     async fn filter(
         &self,
         q: Query<'_>,
@@ -70,7 +69,6 @@ pub trait QueryExt: Queryable + Send + Sync {
 
     /// Execute a singular SQL query in the database, returning an arbitrary
     /// JSON `Value` as a result.
-    #[tracing::instrument(skip(self, sql_info, features, inputs))]
     async fn raw_json<'a>(
         &'a self,
         sql_info: SqlInfo,
@@ -115,7 +113,6 @@ pub trait QueryExt: Queryable + Send + Sync {
 
     /// Execute a singular SQL query in the database, returning the number of
     /// affected rows.
-    #[tracing::instrument(skip(self, inputs))]
     async fn raw_count<'a>(
         &'a self,
         mut inputs: HashMap<String, PrismaValue>,
@@ -139,7 +136,6 @@ pub trait QueryExt: Queryable + Send + Sync {
     }
 
     /// Select one row from the database.
-    #[tracing::instrument(skip(self, q, meta))]
     async fn find(
         &self,
         q: Select<'_>,
@@ -155,7 +151,6 @@ pub trait QueryExt: Queryable + Send + Sync {
 
     /// Process the record filter and either return directly with precomputed values,
     /// or fetch IDs from the database.
-    #[tracing::instrument(skip(self, model, record_filter))]
     async fn filter_selectors(
         &self,
         model: &ModelRef,
@@ -170,7 +165,6 @@ pub trait QueryExt: Queryable + Send + Sync {
     }
 
     /// Read the all columns as a (primary) identifier.
-    #[tracing::instrument(skip(self, model, filter))]
     async fn filter_ids(
         &self,
         model: &ModelRef,
@@ -189,7 +183,6 @@ pub trait QueryExt: Queryable + Send + Sync {
         self.select_ids(select, model_id, trace_id).await
     }
 
-    #[tracing::instrument(skip(self, select, model_id))]
     async fn select_ids(
         &self,
         select: Select<'_>,

--- a/query-engine/connectors/sql-query-connector/src/row.rs
+++ b/query-engine/connectors/sql-query-connector/src/row.rs
@@ -18,7 +18,6 @@ pub struct SqlRow {
 }
 
 impl SqlRow {
-    #[tracing::instrument(skip(self, selections))]
     pub fn into_aggregation_results(self, selections: &[AggregationSelection]) -> Vec<AggregationResult> {
         let mut values = self.values;
         values.reverse();
@@ -89,7 +88,6 @@ pub trait ToSqlRow {
 }
 
 impl ToSqlRow for ResultRow {
-    #[tracing::instrument(skip(self, meta))]
     fn to_sql_row(self, meta: &[ColumnMetadata<'_>]) -> crate::Result<SqlRow> {
         let mut row = SqlRow::default();
         let row_width = meta.len();
@@ -124,7 +122,6 @@ impl ToSqlRow for ResultRow {
     }
 }
 
-#[tracing::instrument(skip(p_value, meta))]
 pub fn row_value_to_prisma_value(p_value: Value, meta: ColumnMetadata<'_>) -> Result<PrismaValue, SqlError> {
     let create_error = |value: &Value| {
         let message = match meta.name() {

--- a/query-engine/core/src/executor/execute_operation.rs
+++ b/query-engine/core/src/executor/execute_operation.rs
@@ -92,7 +92,6 @@ pub async fn execute_many_self_contained<C: Connector + Send + Sync>(
 }
 
 /// Execute the operation as a self-contained operation, if necessary wrapped in a transaction.
-#[tracing::instrument(skip(conn, graph, serializer, force_transactions))]
 async fn execute_self_contained(
     mut conn: Box<dyn Connection>,
     graph: QueryGraph,

--- a/query-engine/core/src/executor/interpreting_executor.rs
+++ b/query-engine/core/src/executor/interpreting_executor.rs
@@ -73,7 +73,6 @@ where
     /// A failing operation does not fail the batch, instead, an error is returned alongside other responses.
     /// Note that individual operations executed in non-transactional mode can still be transactions in themselves
     /// if the query (e.g. a write op) requires it.
-    #[tracing::instrument(skip(self, operations, query_schema))]
     async fn execute_all(
         &self,
         tx_id: Option<TxId>,

--- a/query-engine/core/src/executor/loader.rs
+++ b/query-engine/core/src/executor/loader.rs
@@ -25,7 +25,6 @@ use mongodb_connector::MongoDb;
 const DEFAULT_SQLITE_DB_NAME: &str = "main";
 
 /// Loads a query executor based on the parsed Prisma schema (datasource).
-#[tracing::instrument(name = "exec_loader", skip(source))]
 pub async fn load(
     source: &Datasource,
     features: &[PreviewFeature],

--- a/query-engine/core/src/interactive_transactions/actors.rs
+++ b/query-engine/core/src/interactive_transactions/actors.rs
@@ -87,7 +87,6 @@ impl ITXServer {
         let _ = op.respond_to.send(msg);
     }
 
-    #[tracing::instrument(skip(self, operation))]
     async fn execute_single(&mut self, operation: &Operation, trace_id: Option<String>) -> crate::Result<ResponseData> {
         let conn = self.cached_tx.as_open()?;
         execute_single_operation(
@@ -99,7 +98,6 @@ impl ITXServer {
         .await
     }
 
-    #[tracing::instrument(skip(self, operations))]
     async fn execute_batch(
         &mut self,
         operations: &[Operation],

--- a/query-engine/core/src/interpreter/expressionista.rs
+++ b/query-engine/core/src/interpreter/expressionista.rs
@@ -16,7 +16,6 @@ struct IfNodeAcc {
 }
 
 impl Expressionista {
-    #[tracing::instrument(skip(graph))]
     pub fn translate(mut graph: QueryGraph) -> InterpretationResult<Expression> {
         graph
             .root_nodes()
@@ -26,7 +25,6 @@ impl Expressionista {
             .map(|res| Expression::Sequence { seq: res })
     }
 
-    #[tracing::instrument(skip(graph, node, parent_edges))]
     fn build_expression(
         graph: &mut QueryGraph,
         node: &NodeRef,
@@ -43,7 +41,6 @@ impl Expressionista {
         }
     }
 
-    #[tracing::instrument(skip(graph, node, parent_edges))]
     fn build_query_expression(
         graph: &mut QueryGraph,
         node: &NodeRef,
@@ -89,7 +86,6 @@ impl Expressionista {
         }
     }
 
-    #[tracing::instrument(skip(graph, child_pairs))]
     fn process_children(
         graph: &mut QueryGraph,
         mut child_pairs: Vec<(EdgeRef, NodeRef)>,
@@ -135,7 +131,6 @@ impl Expressionista {
         Ok(expressions)
     }
 
-    #[tracing::instrument(skip(graph, node, parent_edges))]
     fn build_empty_expression(
         graph: &mut QueryGraph,
         node: &NodeRef,
@@ -153,7 +148,6 @@ impl Expressionista {
         Self::transform_node(graph, parent_edges, Node::Empty, into_expr)
     }
 
-    #[tracing::instrument(skip(graph, node, parent_edges))]
     fn build_computation_expression(
         graph: &mut QueryGraph,
         node: &NodeRef,
@@ -206,7 +200,6 @@ impl Expressionista {
         }
     }
 
-    #[tracing::instrument(skip(graph, node, parent_edges))]
     fn build_flow_expression(
         graph: &mut QueryGraph,
         node: &NodeRef,
@@ -221,7 +214,6 @@ impl Expressionista {
         }
     }
 
-    #[tracing::instrument(skip(graph, node, parent_edges))]
     fn translate_if_node(
         graph: &mut QueryGraph,
         node: &NodeRef,
@@ -288,7 +280,6 @@ impl Expressionista {
         Self::transform_node(graph, parent_edges, node, into_expr)
     }
 
-    #[tracing::instrument(skip(graph, node, parent_edges))]
     fn translate_return_node(
         graph: &mut QueryGraph,
         node: &NodeRef,
@@ -331,7 +322,6 @@ impl Expressionista {
 
     /// Runs transformer functions (e.g. `ParentIdsFn`) via `Expression::Func` if necessary, or if none present,
     /// builds an expression directly. `into_expr` does the final expression building based on the node coming in.
-    #[tracing::instrument(skip(graph, parent_edges, node, into_expr))]
     fn transform_node(
         graph: &mut QueryGraph,
         parent_edges: Vec<EdgeRef>,
@@ -390,7 +380,6 @@ impl Expressionista {
     }
 
     /// Collects all edge dependencies that perform a node transformation based on the parent.
-    #[tracing::instrument(skip(graph, parent_edges))]
     fn collect_parent_transformers(
         graph: &mut QueryGraph,
         parent_edges: Vec<EdgeRef>,
@@ -411,7 +400,6 @@ impl Expressionista {
             .collect()
     }
 
-    #[tracing::instrument(skip(graph, result_subgraphs))]
     fn fold_result_scopes(
         graph: &mut QueryGraph,
         result_subgraphs: Vec<(EdgeRef, NodeRef)>,

--- a/query-engine/core/src/interpreter/formatters.rs
+++ b/query-engine/core/src/interpreter/formatters.rs
@@ -1,7 +1,6 @@
 use super::Expression;
 use crate::Query;
 
-#[tracing::instrument(skip(expr, indent))]
 pub fn format_expression(expr: &Expression, indent: usize) -> String {
     match expr {
         Expression::Sequence { seq } => seq

--- a/query-engine/core/src/interpreter/interpreter.rs
+++ b/query-engine/core/src/interpreter/interpreter.rs
@@ -44,7 +44,6 @@ pub struct DiffResult {
 impl ExpressionResult {
     /// Attempts to transform this `ExpressionResult` into a vector of `SelectionResult`s corresponding to the passed desired selection shape.
     /// A vector is returned as some expression results return more than one result row at once.
-    #[tracing::instrument(skip(self, field_selection))]
     pub fn as_selection_results(&self, field_selection: &FieldSelection) -> InterpretationResult<Vec<SelectionResult>> {
         let converted = match self {
             Self::Query(ref result) => match result {
@@ -91,7 +90,6 @@ impl ExpressionResult {
         })
     }
 
-    #[tracing::instrument(skip(self))]
     pub fn as_query_result(&self) -> InterpretationResult<&QueryResult> {
         let converted = match self {
             Self::Query(ref q) => Some(q),
@@ -103,7 +101,6 @@ impl ExpressionResult {
         })
     }
 
-    #[tracing::instrument(skip(self))]
     pub fn as_diff_result(&self) -> InterpretationResult<&DiffResult> {
         let converted = match self {
             Self::Computation(ComputationResult::Diff(ref d)) => Some(d),
@@ -164,7 +161,6 @@ impl<'conn> QueryInterpreter<'conn> {
         Self { conn, log }
     }
 
-    #[tracing::instrument(skip(self, exp, env, level))]
     pub fn interpret(
         &mut self,
         exp: Expression,
@@ -282,7 +278,6 @@ impl<'conn> QueryInterpreter<'conn> {
         }
     }
 
-    #[tracing::instrument(skip(self))]
     pub fn log_output(&self) -> String {
         let mut output = String::with_capacity(self.log.len() * 30);
 

--- a/query-engine/core/src/interpreter/query_interpreters/inmemory_record_processor.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/inmemory_record_processor.rs
@@ -20,7 +20,6 @@ impl Deref for InMemoryRecordProcessor {
 impl InMemoryRecordProcessor {
     /// Creates a new processor from the given query args.
     /// The original args will be modified to prevent db level processing.
-    #[tracing::instrument(skip(args))]
     pub fn new_from_query_args(args: &mut QueryArguments) -> Self {
         let processor = Self { args: args.clone() };
 
@@ -41,7 +40,6 @@ impl InMemoryRecordProcessor {
         self.take.map(|t| t < 0).unwrap_or(false)
     }
 
-    #[tracing::instrument(skip(self, records))]
     pub fn apply(&self, mut records: ManyRecords) -> ManyRecords {
         if self.needs_reversed_order() {
             records.reverse();

--- a/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
@@ -7,7 +7,6 @@ use prisma_models::{FieldSelection, ManyRecords, Record, RelationFieldRef, Selec
 use prisma_value::PrismaValue;
 use std::collections::HashMap;
 
-#[tracing::instrument(skip(tx, query, parent_result, processor))]
 pub async fn m2m(
     tx: &mut dyn ConnectionLike,
     query: &RelatedRecordsQuery,
@@ -130,15 +129,6 @@ pub async fn m2m(
 }
 
 // [DTODO] This is implemented in an inefficient fashion, e.g. too much Arc cloning going on.
-#[tracing::instrument(skip(
-    tx,
-    parent_field,
-    parent_selections,
-    parent_result,
-    query_args,
-    selected_fields,
-    processor
-))]
 #[allow(clippy::too_many_arguments)]
 pub async fn one2m(
     tx: &mut dyn ConnectionLike,

--- a/query-engine/core/src/interpreter/query_interpreters/read.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/read.rs
@@ -25,7 +25,6 @@ pub fn execute<'conn>(
 }
 
 /// Queries a single record.
-#[tracing::instrument(skip(tx, query, trace_id))]
 fn read_one(
     tx: &mut dyn ConnectionLike,
     query: RecordQuery,

--- a/query-engine/core/src/query_ast/write.rs
+++ b/query-engine/core/src/query_ast/write.rs
@@ -20,7 +20,6 @@ pub enum WriteQuery {
 
 impl WriteQuery {
     /// Takes a SelectionResult and writes its contents into the write arguments of the underlying query.
-    #[tracing::instrument(skip(self, result))]
     pub fn inject_result_into_args(&mut self, result: SelectionResult) {
         let model = self.model();
         let args = match self {
@@ -40,7 +39,6 @@ impl WriteQuery {
         args.update_datetimes(model);
     }
 
-    #[tracing::instrument(skip(self, field_selection))]
     pub fn returns(&self, field_selection: &FieldSelection) -> bool {
         let returns_id = &self.model().primary_identifier() == field_selection;
 
@@ -61,7 +59,6 @@ impl WriteQuery {
         }
     }
 
-    #[tracing::instrument(skip(self))]
     pub fn model(&self) -> ModelRef {
         match self {
             Self::CreateRecord(q) => Arc::clone(&q.model),
@@ -135,7 +132,6 @@ pub struct CreateManyRecords {
 }
 
 impl CreateManyRecords {
-    #[tracing::instrument(skip(self, result))]
     pub fn inject_result_into_all(&mut self, result: SelectionResult) {
         for (selected_field, value) in result {
             for args in self.args.iter_mut() {

--- a/query-engine/core/src/query_document/mod.rs
+++ b/query-engine/core/src/query_document/mod.rs
@@ -107,7 +107,6 @@ impl CompactedDocument {
 
 /// Here be the dragons. Ay caramba!
 impl From<Vec<Operation>> for CompactedDocument {
-    #[tracing::instrument(name = "find_one_optimization", skip(ops))]
     fn from(ops: Vec<Operation>) -> Self {
         // Unpack all read queries (an enum) into a collection of selections.
         // We already took care earlier that all operations here must be reads.

--- a/query-engine/core/src/query_document/parser.rs
+++ b/query-engine/core/src/query_document/parser.rs
@@ -17,7 +17,6 @@ impl QueryDocumentParser {
     /// In contrast, nullable and optional types on an input object are separate concepts.
     /// The above is the reason we don't need to check nullability here, as it is done by the output
     /// validation in the serialization step.
-    #[tracing::instrument(skip(parent_path, selections, schema_object))]
     pub fn parse_object(
         parent_path: QueryPath,
         selections: &[Selection],
@@ -82,7 +81,6 @@ impl QueryDocumentParser {
     }
 
     /// Parses and validates selection arguments against a schema defined field.
-    #[tracing::instrument(skip(parent_path, schema_field, given_arguments))]
     pub fn parse_arguments(
         parent_path: QueryPath,
         schema_field: &OutputFieldRef,
@@ -141,7 +139,6 @@ impl QueryDocumentParser {
 
     /// Parses and validates a QueryValue against possible input types.
     /// Matching is done in order of definition on the input type. First matching type wins.
-    #[tracing::instrument(skip(parent_path, value, possible_input_types))]
     pub fn parse_input_value(
         parent_path: QueryPath,
         value: QueryValue,
@@ -218,7 +215,6 @@ impl QueryDocumentParser {
     }
 
     /// Attempts to parse given query value into a concrete PrismaValue based on given scalar type.
-    #[tracing::instrument(skip(parent_path, value))]
     pub fn parse_scalar(
         parent_path: &QueryPath,
         value: QueryValue,
@@ -263,7 +259,6 @@ impl QueryDocumentParser {
         }
     }
 
-    #[tracing::instrument(skip(path, s))]
     pub fn parse_datetime(path: &QueryPath, s: &str) -> QueryParserResult<DateTime<FixedOffset>> {
         DateTime::parse_from_rfc3339(s).map_err(|err| QueryParserError {
             path: path.clone(),
@@ -274,7 +269,6 @@ impl QueryDocumentParser {
         })
     }
 
-    #[tracing::instrument(skip(path, s))]
     pub fn parse_bytes(path: &QueryPath, s: String) -> QueryParserResult<PrismaValue> {
         prisma_value::decode_bytes(&s)
             .map(PrismaValue::Bytes)
@@ -287,7 +281,6 @@ impl QueryDocumentParser {
             })
     }
 
-    #[tracing::instrument(skip(path, s))]
     pub fn parse_decimal(path: &QueryPath, s: String) -> QueryParserResult<PrismaValue> {
         BigDecimal::from_str(&s)
             .map(PrismaValue::Float)
@@ -297,7 +290,6 @@ impl QueryDocumentParser {
             })
     }
 
-    #[tracing::instrument(skip(path, s))]
     pub fn parse_bigint(path: &QueryPath, s: String) -> QueryParserResult<PrismaValue> {
         s.parse::<i64>().map(PrismaValue::BigInt).map_err(|_| QueryParserError {
             path: path.clone(),
@@ -306,7 +298,6 @@ impl QueryDocumentParser {
     }
 
     // [DTODO] This is likely incorrect or at least using the wrong abstractions.
-    #[tracing::instrument(skip(path, s))]
     pub fn parse_json_list(path: &QueryPath, s: &str) -> QueryParserResult<PrismaValue> {
         let json = Self::parse_json(path, s)?;
 
@@ -329,7 +320,6 @@ impl QueryDocumentParser {
         Ok(PrismaValue::List(prisma_values))
     }
 
-    #[tracing::instrument(skip(path, s))]
     pub fn parse_json(path: &QueryPath, s: &str) -> QueryParserResult<serde_json::Value> {
         serde_json::from_str(s).map_err(|err| QueryParserError {
             path: path.clone(),
@@ -337,7 +327,6 @@ impl QueryDocumentParser {
         })
     }
 
-    #[tracing::instrument(skip(path, s))]
     pub fn parse_uuid(path: &QueryPath, s: &str) -> QueryParserResult<Uuid> {
         Uuid::parse_str(s).map_err(|err| QueryParserError {
             path: path.clone(),
@@ -345,7 +334,6 @@ impl QueryDocumentParser {
         })
     }
 
-    #[tracing::instrument(skip(path, values, value_type))]
     pub fn parse_list(
         path: &QueryPath,
         values: Vec<QueryValue>,
@@ -357,7 +345,6 @@ impl QueryDocumentParser {
             .collect::<QueryParserResult<Vec<ParsedInputValue>>>()
     }
 
-    #[tracing::instrument(skip(path, val, typ))]
     pub fn parse_enum(path: &QueryPath, val: QueryValue, typ: &EnumTypeRef) -> QueryParserResult<ParsedInputValue> {
         let raw = match val {
             QueryValue::Enum(s) => s,
@@ -402,7 +389,6 @@ impl QueryDocumentParser {
     }
 
     /// Parses and validates an input object recursively.
-    #[tracing::instrument(skip(parent_path, object, schema_object))]
     pub fn parse_input_object(
         parent_path: QueryPath,
         object: IndexMap<String, QueryValue>,

--- a/query-engine/core/src/query_graph/formatters.rs
+++ b/query-engine/core/src/query_graph/formatters.rs
@@ -1,7 +1,6 @@
 use super::*;
 use std::fmt::{self, Display};
 
-#[tracing::instrument(name = "debug_query_graph", skip(graph))]
 pub fn format(graph: &QueryGraph) -> String {
     format!(
         "---- Query Graph ----\nResult Nodes: {}\nMarked Nodes: {}\nRoot Nodes: {}\n\n{}\n----------------------",

--- a/query-engine/core/src/query_graph/mod.rs
+++ b/query-engine/core/src/query_graph/mod.rs
@@ -215,7 +215,6 @@ impl QueryGraph {
         Ok(graph)
     }
 
-    #[tracing::instrument(skip(self))]
     pub fn finalize(&mut self) -> QueryGraphResult<()> {
         if !self.finalized {
             self.swap_marked()?;
@@ -518,7 +517,6 @@ impl QueryGraph {
     ///                                                                                                         └───┘
     /// ```
     /// [DTODO] put if flow exception illustration here.
-    #[tracing::instrument(skip(self))]
     fn swap_marked(&mut self) -> QueryGraphResult<()> {
         if !self.marked_node_pairs.is_empty() {
             trace!("[Graph][Swap] Before shape: {}", self);
@@ -615,7 +613,6 @@ impl QueryGraph {
     ///         sibling   │                                ─ ─ ─ ─ ─ ─ ┘
     ///      └ ─ ─ ─ ─ ─ ─
     /// ```
-    #[tracing::instrument(skip(self))]
     fn normalize_if_nodes(&mut self) -> QueryGraphResult<()> {
         for node_ix in self.graph.node_indices() {
             let node = NodeRef { node_ix };
@@ -658,7 +655,6 @@ impl QueryGraph {
     /// This ensures that children nodes of return nodes have the proper data dependencies at their disposal.
     /// In case the parent nodes of return nodes do not have a field selection that fullfils the new dependency,
     /// a reload node will be inserted in between the parent and the return node by the `insert_reloads` method.
-    #[tracing::instrument(skip(self))]
     fn ensure_return_nodes_have_parent_dependency(&mut self) -> QueryGraphResult<()> {
         let return_nodes: Vec<NodeRef> = self
             .graph
@@ -770,7 +766,6 @@ impl QueryGraph {
     ///
     /// The `Reload` node is always a "find many" query.
     /// Unwraps are safe because we're operating on the unprocessed state of the graph (`Expressionista` changes that).
-    #[tracing::instrument(skip(self))]
     fn insert_reloads(&mut self) -> QueryGraphResult<()> {
         let reloads: Vec<(NodeRef, ModelRef, Vec<FieldSelection>)> = self
             .graph

--- a/query-engine/core/src/query_graph_builder/builder.rs
+++ b/query-engine/core/src/query_graph_builder/builder.rs
@@ -19,7 +19,6 @@ impl QueryGraphBuilder {
     }
 
     /// Maps an operation to a query.
-    #[tracing::instrument(skip(self, operation))]
     pub fn build(self, operation: Operation) -> QueryGraphBuilderResult<(QueryGraph, IrSerializer)> {
         match operation {
             Operation::Read(selection) => self.build_internal(selection, &self.query_schema.query()),
@@ -27,7 +26,6 @@ impl QueryGraphBuilder {
         }
     }
 
-    #[tracing::instrument(skip(self, selection, root_object))]
     fn build_internal(
         &self,
         selection: Selection,
@@ -52,7 +50,6 @@ impl QueryGraphBuilder {
         }
     }
 
-    #[tracing::instrument(skip(self, field_pair))]
     #[rustfmt::skip]
     fn dispatch_build(&self, field_pair: FieldPair) -> QueryGraphBuilderResult<QueryGraph> {
         let query_info = field_pair.schema_field.query_info.as_ref().unwrap();

--- a/query-engine/core/src/query_graph_builder/extractors/filters/mod.rs
+++ b/query-engine/core/src/query_graph_builder/extractors/filters/mod.rs
@@ -21,7 +21,6 @@ use schema_builder::constants::filters;
 use std::{collections::HashMap, convert::TryInto, str::FromStr};
 
 /// Extracts a filter for a unique selector, i.e. a filter that selects exactly one record.
-#[tracing::instrument(skip(value_map, model))]
 pub fn extract_unique_filter(value_map: ParsedInputMap, model: &ModelRef) -> QueryGraphBuilderResult<Filter> {
     let filters = value_map
         .into_iter()

--- a/query-engine/core/src/query_graph_builder/extractors/filters/relation.rs
+++ b/query-engine/core/src/query_graph_builder/extractors/filters/relation.rs
@@ -5,7 +5,6 @@ use prisma_models::RelationFieldRef;
 use schema_builder::constants::filters;
 use std::convert::TryInto;
 
-#[tracing::instrument(name = "parse_relation_field", skip(filter_key, field, input))]
 pub fn parse(filter_key: &str, field: &RelationFieldRef, input: ParsedInputValue) -> QueryGraphBuilderResult<Filter> {
     let value: Option<ParsedInputMap> = input.try_into()?;
 

--- a/query-engine/core/src/query_graph_builder/extractors/filters/scalar.rs
+++ b/query-engine/core/src/query_graph_builder/extractors/filters/scalar.rs
@@ -4,7 +4,6 @@ use prisma_models::{PrismaValue, ScalarFieldRef, TypeIdentifier};
 use schema_builder::constants::{aggregations, filters, json_null};
 use std::convert::TryInto;
 
-#[tracing::instrument(name = "parse_scalar_field", skip(input_map, reverse))]
 pub fn parse(
     mut input_map: ParsedInputMap,
     field: &ScalarFieldRef,

--- a/query-engine/core/src/query_graph_builder/extractors/query_arguments.rs
+++ b/query-engine/core/src/query_graph_builder/extractors/query_arguments.rs
@@ -11,7 +11,6 @@ use std::convert::TryInto;
 /// Expects the caller to know that it is structurally guaranteed that query arguments can be extracted,
 /// e.g. that the query schema guarantees that required fields are present.
 /// Errors occur if conversions fail.
-#[tracing::instrument(skip(arguments, model))]
 pub fn extract_query_args(arguments: Vec<ParsedArgument>, model: &ModelRef) -> QueryGraphBuilderResult<QueryArguments> {
     let query_args = arguments.into_iter().fold(
         Ok(QueryArguments::new(model.clone())),

--- a/query-engine/core/src/query_graph_builder/read/aggregations/aggregate.rs
+++ b/query-engine/core/src/query_graph_builder/read/aggregations/aggregate.rs
@@ -2,7 +2,6 @@ use super::*;
 use crate::{query_document::ParsedField, AggregateRecordsQuery};
 use prisma_models::ModelRef;
 
-#[tracing::instrument(skip(field, model))]
 pub fn aggregate(field: ParsedField, model: ModelRef) -> QueryGraphBuilderResult<ReadQuery> {
     let name = field.name;
     let alias = field.alias;

--- a/query-engine/core/src/query_graph_builder/read/aggregations/group_by.rs
+++ b/query-engine/core/src/query_graph_builder/read/aggregations/group_by.rs
@@ -6,7 +6,6 @@ use connector::Filter;
 use prisma_models::{ModelRef, OrderBy, ScalarFieldRef};
 use schema_builder::constants::args;
 
-#[tracing::instrument(skip(field, model))]
 pub fn group_by(mut field: ParsedField, model: ModelRef) -> QueryGraphBuilderResult<ReadQuery> {
     let name = field.name;
     let alias = field.alias;

--- a/query-engine/core/src/query_graph_builder/read/aggregations/mod.rs
+++ b/query-engine/core/src/query_graph_builder/read/aggregations/mod.rs
@@ -15,7 +15,6 @@ use schema_builder::constants::aggregations::*;
 
 /// Resolves the given field as a aggregation query.
 #[allow(clippy::unnecessary_wraps)]
-#[tracing::instrument(skip(field, model))]
 fn resolve_query(
     field: FieldPair,
     model: &ModelRef,

--- a/query-engine/core/src/query_graph_builder/read/first.rs
+++ b/query-engine/core/src/query_graph_builder/read/first.rs
@@ -3,7 +3,6 @@ use prisma_models::ModelRef;
 use super::*;
 use crate::ParsedField;
 
-#[tracing::instrument(skip(field, model))]
 pub fn find_first(field: ParsedField, model: ModelRef) -> QueryGraphBuilderResult<ReadQuery> {
     let mut many_query = many::find_many(field, model)?;
 

--- a/query-engine/core/src/query_graph_builder/read/many.rs
+++ b/query-engine/core/src/query_graph_builder/read/many.rs
@@ -2,7 +2,6 @@ use super::*;
 use crate::{query_document::ParsedField, ManyRecordsQuery, ReadQuery};
 use prisma_models::ModelRef;
 
-#[tracing::instrument(skip(field, model))]
 pub fn find_many(field: ParsedField, model: ModelRef) -> QueryGraphBuilderResult<ReadQuery> {
     let args = extractors::extract_query_args(field.arguments, &model)?;
     let name = field.name;

--- a/query-engine/core/src/query_graph_builder/read/one.rs
+++ b/query-engine/core/src/query_graph_builder/read/one.rs
@@ -5,7 +5,6 @@ use schema_builder::constants::args;
 use std::convert::TryInto;
 
 /// Builds a read query from a parsed incoming read query field.
-#[tracing::instrument(skip(field, model))]
 pub fn find_unique(mut field: ParsedField, model: ModelRef) -> QueryGraphBuilderResult<ReadQuery> {
     let filter = match field.arguments.lookup(args::WHERE) {
         Some(where_arg) => {

--- a/query-engine/core/src/query_graph_builder/read/related.rs
+++ b/query-engine/core/src/query_graph_builder/read/related.rs
@@ -2,7 +2,6 @@ use super::*;
 use crate::{query_document::ParsedField, ReadQuery, RelatedRecordsQuery};
 use prisma_models::{ModelRef, RelationFieldRef};
 
-#[tracing::instrument(skip(field, parent, model))]
 pub fn find_related(
     field: ParsedField,
     parent: RelationFieldRef,

--- a/query-engine/core/src/query_graph_builder/write/connect.rs
+++ b/query-engine/core/src/query_graph_builder/write/connect.rs
@@ -34,7 +34,6 @@ use std::sync::Arc;
 /// └─▶│     Connect     │
 ///    └─────────────────┘
 /// ```
-#[tracing::instrument(skip(graph, parent_node, child_node, parent_relation_field, expected_connects))]
 pub fn connect_records_node(
     graph: &mut QueryGraph,
     parent_node: &NodeRef,

--- a/query-engine/core/src/query_graph_builder/write/create.rs
+++ b/query-engine/core/src/query_graph_builder/write/create.rs
@@ -12,7 +12,6 @@ use std::{convert::TryInto, sync::Arc};
 use write_args_parser::*;
 
 /// Creates a create record query and adds it to the query graph, together with it's nested queries and companion read query.
-#[tracing::instrument(skip(graph, model, field))]
 pub fn create_record(
     graph: &mut QueryGraph,
     connector_ctx: &ConnectorContext,
@@ -59,7 +58,6 @@ pub fn create_record(
 }
 
 /// Creates a create record query and adds it to the query graph, together with it's nested queries and companion read query.
-#[tracing::instrument(skip(graph, model, field))]
 pub fn create_many_records(
     graph: &mut QueryGraph,
     _connector_ctx: &ConnectorContext,
@@ -99,7 +97,6 @@ pub fn create_many_records(
     Ok(())
 }
 
-#[tracing::instrument(skip(graph, model, data_map))]
 pub fn create_record_node(
     graph: &mut QueryGraph,
     connector_ctx: &ConnectorContext,

--- a/query-engine/core/src/query_graph_builder/write/delete.rs
+++ b/query-engine/core/src/query_graph_builder/write/delete.rs
@@ -11,7 +11,6 @@ use schema_builder::constants::args;
 use std::{convert::TryInto, sync::Arc};
 
 /// Creates a top level delete record query and adds it to the query graph.
-#[tracing::instrument(skip(graph, model, field))]
 pub fn delete_record(
     graph: &mut QueryGraph,
     connector_ctx: &ConnectorContext,
@@ -58,7 +57,6 @@ pub fn delete_record(
 }
 
 /// Creates a top level delete many records query and adds it to the query graph.
-#[tracing::instrument(skip(graph, model, field))]
 pub fn delete_many_records(
     graph: &mut QueryGraph,
     connector_ctx: &ConnectorContext,

--- a/query-engine/core/src/query_graph_builder/write/disconnect.rs
+++ b/query-engine/core/src/query_graph_builder/write/disconnect.rs
@@ -33,7 +33,6 @@ use std::sync::Arc;
 /// └─▶│   Disconnect    │
 ///    └─────────────────┘
 /// ```
-#[tracing::instrument(skip(graph, parent_node, child_node, parent_relation_field))]
 pub fn disconnect_records_node(
     graph: &mut QueryGraph,
     parent_node: &NodeRef,

--- a/query-engine/core/src/query_graph_builder/write/nested/connect_nested.rs
+++ b/query-engine/core/src/query_graph_builder/write/nested/connect_nested.rs
@@ -14,7 +14,6 @@ use std::sync::Arc;
 ///
 /// The resulting graph can take multiple forms, based on the relation type to the parent model.
 /// Information on the graph shapes can be found on the individual handlers.
-#[tracing::instrument(skip(graph, parent_node, parent_relation_field, value, child_model))]
 pub fn nested_connect(
     graph: &mut QueryGraph,
     parent_node: NodeRef,
@@ -74,7 +73,6 @@ pub fn nested_connect(
 /// └─▶│     Connect     │
 ///    └─────────────────┘
 /// ```
-#[tracing::instrument(skip(graph, parent_node, parent_relation_field, filter, child_model))]
 fn handle_many_to_many(
     graph: &mut QueryGraph,
     parent_node: NodeRef,
@@ -153,7 +151,6 @@ fn handle_many_to_many(
 ///
 /// We do not need to do relation requirement checks because the many side of the relation can't be required,
 /// and if the one side is required it's automatically satisfied because the record to connect has to exist.
-#[tracing::instrument(skip(graph, parent_node, parent_relation_field, child_filter, child_model))]
 fn handle_one_to_many(
     graph: &mut QueryGraph,
     parent_node: NodeRef,
@@ -338,7 +335,6 @@ fn handle_one_to_many(
 /// ... because we just updated the relation.
 ///
 /// This is why we need to have an extra update at the end if it's inlined on the parent and a non-create.
-#[tracing::instrument(skip(graph, parent_node, parent_relation_field, filter, child_model))]
 fn handle_one_to_one(
     graph: &mut QueryGraph,
     parent_node: NodeRef,

--- a/query-engine/core/src/query_graph_builder/write/nested/connect_or_create_nested.rs
+++ b/query-engine/core/src/query_graph_builder/write/nested/connect_or_create_nested.rs
@@ -13,7 +13,6 @@ use std::{convert::TryInto, sync::Arc};
 ///
 /// The resulting graph can take multiple forms, based on the relation type to the parent model.
 /// Information on the graph shapes can be found on the individual handlers.
-#[tracing::instrument(skip(graph, parent_node, parent_relation_field, value, child_model))]
 pub fn nested_connect_or_create(
     graph: &mut QueryGraph,
     connector_ctx: &ConnectorContext,
@@ -89,7 +88,6 @@ pub fn nested_connect_or_create(
 ///                          │     Connect     │◀─┘
 ///                          └─────────────────┘
 /// ```
-#[tracing::instrument(skip(graph, parent_node, parent_relation_field, values, child_model))]
 fn handle_many_to_many(
     graph: &mut QueryGraph,
     connector_ctx: &ConnectorContext,
@@ -147,7 +145,6 @@ fn handle_many_to_many(
 }
 
 /// Dispatcher for one-to-many relations.
-#[tracing::instrument(skip(graph, parent_node, parent_relation_field, values, child_model))]
 fn handle_one_to_many(
     graph: &mut QueryGraph,
     connector_ctx: &ConnectorContext,
@@ -178,7 +175,6 @@ fn handle_one_to_many(
 }
 
 /// Dispatcher for one-to-one relations.
-#[tracing::instrument(skip(graph, parent_node, parent_relation_field, values, child_model))]
 fn handle_one_to_one(
     graph: &mut QueryGraph,
     connector_ctx: &ConnectorContext,
@@ -250,7 +246,6 @@ fn handle_one_to_one(
 /// └─▶│  Update Child   │   │  Create Child   │◀─┘
 ///    └─────────────────┘   └─────────────────┘
 /// ```
-#[tracing::instrument(skip(graph, parent_node, parent_relation_field, values, child_model))]
 fn one_to_many_inlined_child(
     graph: &mut QueryGraph,
     connector_ctx: &ConnectorContext,
@@ -392,7 +387,6 @@ fn one_to_many_inlined_child(
 ///    ┌ ─ ─ ─ ─ ─ ─ ─ ─ ┐
 ///          Result
 ///    └ ─ ─ ─ ─ ─ ─ ─ ─ ┘
-#[tracing::instrument(skip(graph, parent_node, parent_relation_field, values, child_model))]
 fn one_to_many_inlined_parent(
     graph: &mut QueryGraph,
     connector_ctx: &ConnectorContext,
@@ -564,7 +558,6 @@ fn one_to_many_inlined_parent(
 ///
 /// Important note: We can't inject directly from the if node into the parent if the parent is a non-create, because we need to perform a check in between,
 /// and updating the record with the injection beforehand prevents that check. Instead, we need an additional update.
-#[tracing::instrument(skip(graph, parent_node, parent_relation_field, filter, create_data, child_model))]
 fn one_to_one_inlined_parent(
     graph: &mut QueryGraph,
     connector_ctx: &ConnectorContext,
@@ -784,7 +777,6 @@ fn one_to_one_inlined_parent(
 /// ```
 /// Note that two versions of this graph can be build: the create and non-create case,
 /// but they're never build at the same time (denoted by the dashed boxes).
-#[tracing::instrument(skip(graph, parent_node, parent_relation_field, filter, create_data, child_model))]
 fn one_to_one_inlined_child(
     graph: &mut QueryGraph,
     connector_ctx: &ConnectorContext,

--- a/query-engine/core/src/query_graph_builder/write/nested/create_nested.rs
+++ b/query-engine/core/src/query_graph_builder/write/nested/create_nested.rs
@@ -61,7 +61,6 @@ pub fn nested_create(
 /// └─▶│  Connect   │   │  Connect   │◀─┘
 ///    └────────────┘   └────────────┘
 /// ```
-#[tracing::instrument]
 #[tracing::instrument(skip(graph, parent_node, parent_relation_field, create_nodes))]
 fn handle_many_to_many(
     graph: &mut QueryGraph,

--- a/query-engine/core/src/query_graph_builder/write/nested/create_nested.rs
+++ b/query-engine/core/src/query_graph_builder/write/nested/create_nested.rs
@@ -13,7 +13,6 @@ use std::{convert::TryInto, sync::Arc};
 /// Handles nested create one cases.
 /// The resulting graph can take multiple forms, based on the relation type to the parent model.
 /// Information on the graph shapes can be found on the individual handlers.
-#[tracing::instrument(skip(graph, parent_node, parent_relation_field, value, child_model))]
 pub fn nested_create(
     graph: &mut QueryGraph,
     connector_ctx: &ConnectorContext,
@@ -61,7 +60,6 @@ pub fn nested_create(
 /// └─▶│  Connect   │   │  Connect   │◀─┘
 ///    └────────────┘   └────────────┘
 /// ```
-#[tracing::instrument(skip(graph, parent_node, parent_relation_field, create_nodes))]
 fn handle_many_to_many(
     graph: &mut QueryGraph,
     parent_node: NodeRef,
@@ -129,7 +127,6 @@ fn handle_many_to_many(
 /// │Create Child│  │Create Child│      Result   │
 /// └────────────┘  └────────────┘  └ ─ ─ ─ ─ ─ ─
 /// ```
-#[tracing::instrument(skip(graph, parent_node, parent_relation_field, create_nodes))]
 fn handle_one_to_many(
     graph: &mut QueryGraph,
     parent_node: NodeRef,
@@ -286,7 +283,6 @@ fn handle_one_to_many(
 /// ... because we just updated the relation.
 ///
 /// For these reasons, we need to have an extra update at the end if it's inlined on the parent and a non-create.
-#[tracing::instrument(skip(graph, parent_node, parent_relation_field, create_nodes))]
 fn handle_one_to_one(
     graph: &mut QueryGraph,
     parent_node: NodeRef,
@@ -425,7 +421,6 @@ fn handle_one_to_one(
     Ok(())
 }
 
-#[tracing::instrument(skip(graph, parent_node, parent_relation_field, value, child_model))]
 pub fn nested_create_many(
     graph: &mut QueryGraph,
     parent_node: NodeRef,

--- a/query-engine/core/src/query_graph_builder/write/nested/delete_nested.rs
+++ b/query-engine/core/src/query_graph_builder/write/nested/delete_nested.rs
@@ -20,7 +20,6 @@ use std::{convert::TryInto, sync::Arc};
 /// - If the relation is inlined but not in the parent, we can directly generate a delete on the record with the parent ID.
 ///
 /// We always need to make sure that the records are connected before deletion.
-#[tracing::instrument(skip(graph, parent_node, parent_relation_field, value, child_model))]
 pub fn nested_delete(
     graph: &mut QueryGraph,
     connector_ctx: &ConnectorContext,
@@ -137,7 +136,6 @@ pub fn nested_delete(
     Ok(())
 }
 
-#[tracing::instrument(skip(graph, parent, parent_relation_field, value, child_model))]
 pub fn nested_delete_many(
     graph: &mut QueryGraph,
     connector_ctx: &ConnectorContext,

--- a/query-engine/core/src/query_graph_builder/write/nested/disconnect_nested.rs
+++ b/query-engine/core/src/query_graph_builder/write/nested/disconnect_nested.rs
@@ -12,7 +12,6 @@ use std::convert::TryInto;
 ///
 /// The resulting graph can take multiple forms, based on the relation type to the parent model.
 /// Information on the graph shapes can be found on the individual handlers.
-#[tracing::instrument(skip(graph, parent_node, parent_relation_field, value, child_model))]
 pub fn nested_disconnect(
     graph: &mut QueryGraph,
     parent_node: NodeRef,
@@ -99,7 +98,6 @@ pub fn nested_disconnect(
 /// └─▶│   Disconnect    │
 ///    └─────────────────┘
 /// ```
-#[tracing::instrument(skip(graph, parent_node, parent_relation_field, filter))]
 fn handle_many_to_many(
     graph: &mut QueryGraph,
     parent_node: &NodeRef,
@@ -145,7 +143,6 @@ fn handle_many_to_many(
 /// Assumes that both `Parent` and `Child` return the necessary IDs.
 ///
 /// Todo pretty sure it's better do redo this code with separate handlers.
-#[tracing::instrument(skip(graph, parent_node, parent_relation_field, filter))]
 fn handle_one_to_x(
     graph: &mut QueryGraph,
     parent_node: &NodeRef,

--- a/query-engine/core/src/query_graph_builder/write/nested/mod.rs
+++ b/query-engine/core/src/query_graph_builder/write/nested/mod.rs
@@ -24,7 +24,6 @@ use set_nested::*;
 use update_nested::*;
 use upsert_nested::*;
 
-#[tracing::instrument(skip(graph, parent, parent_relation_field, data_map))]
 #[rustfmt::skip]
 pub fn connect_nested_query(
     graph: &mut QueryGraph,

--- a/query-engine/core/src/query_graph_builder/write/nested/set_nested.rs
+++ b/query-engine/core/src/query_graph_builder/write/nested/set_nested.rs
@@ -11,7 +11,6 @@ use std::sync::Arc;
 /// Handles nested set cases.
 /// The resulting graph can take multiple forms, based on the relation type to the parent model.
 /// Information on the graph shapes can be found on the individual handlers.
-#[tracing::instrument(skip(graph, parent_node, parent_relation_field, value, child_model))]
 pub fn nested_set(
     graph: &mut QueryGraph,
     parent_node: &NodeRef,
@@ -83,7 +82,6 @@ pub fn nested_set(
 ///
 /// Connects only happen if the query specifies at least one record to be connected.
 /// If none are specified, set effectively acts as a "disconnect all".
-#[tracing::instrument(skip(graph, parent_node, parent_relation_field, filter))]
 fn handle_many_to_many(
     graph: &mut QueryGraph,
     parent_node: &NodeRef,
@@ -208,7 +206,6 @@ fn handle_many_to_many(
 /// └─┴─▶│   ("connect")   │     │ ("disconnect")  │◀─┘
 ///      └─────────────────┘     └─────────────────┘
 /// ```
-#[tracing::instrument(skip(graph, parent_node, parent_relation_field, filter))]
 fn handle_one_to_many(
     graph: &mut QueryGraph,
     parent_node: &NodeRef,

--- a/query-engine/core/src/query_graph_builder/write/nested/update_nested.rs
+++ b/query-engine/core/src/query_graph_builder/write/nested/update_nested.rs
@@ -37,7 +37,6 @@ use std::{convert::TryInto, sync::Arc};
 /// └─▶│   Update   │
 ///    └────────────┘
 /// ```
-#[tracing::instrument(skip(graph, parent, parent_relation_field, value, child_model))]
 pub fn nested_update(
     graph: &mut QueryGraph,
     connector_ctx: &ConnectorContext,
@@ -109,7 +108,6 @@ pub fn nested_update(
     Ok(())
 }
 
-#[tracing::instrument(skip(graph, parent, parent_relation_field, value, child_model))]
 pub fn nested_update_many(
     graph: &mut QueryGraph,
     connector_ctx: &ConnectorContext,

--- a/query-engine/core/src/query_graph_builder/write/nested/upsert_nested.rs
+++ b/query-engine/core/src/query_graph_builder/write/nested/upsert_nested.rs
@@ -93,7 +93,6 @@ use std::{convert::TryInto, sync::Arc};
 ///    └─────────────────┘
 /// ```
 /// Todo split this mess up and clean up the code.
-#[tracing::instrument(skip(graph, parent_node, parent_relation_field, value))]
 pub fn nested_upsert(
     graph: &mut QueryGraph,
     connector_ctx: &ConnectorContext,

--- a/query-engine/core/src/query_graph_builder/write/raw.rs
+++ b/query-engine/core/src/query_graph_builder/write/raw.rs
@@ -4,7 +4,6 @@ use prisma_models::ModelRef;
 use prisma_value::PrismaValue;
 use std::{collections::HashMap, convert::TryInto};
 
-#[tracing::instrument(skip(graph, field))]
 pub fn execute_raw(graph: &mut QueryGraph, field: ParsedField) -> QueryGraphBuilderResult<()> {
     let raw_query = Query::Write(WriteQuery::ExecuteRaw(raw_query(None, None, field)?));
 
@@ -12,7 +11,6 @@ pub fn execute_raw(graph: &mut QueryGraph, field: ParsedField) -> QueryGraphBuil
     Ok(())
 }
 
-#[tracing::instrument(skip(graph, field))]
 pub fn query_raw(
     graph: &mut QueryGraph,
     model: Option<ModelRef>,

--- a/query-engine/core/src/query_graph_builder/write/update.rs
+++ b/query-engine/core/src/query_graph_builder/write/update.rs
@@ -12,7 +12,6 @@ use schema_builder::constants::args;
 use std::{convert::TryInto, sync::Arc};
 
 /// Creates an update record query and adds it to the query graph, together with it's nested queries and companion read query.
-#[tracing::instrument(skip(graph, model, field))]
 pub fn update_record(
     graph: &mut QueryGraph,
     connector_ctx: &ConnectorContext,
@@ -84,7 +83,6 @@ pub fn update_record(
 }
 
 /// Creates an update many record query and adds it to the query graph.
-#[tracing::instrument(skip(graph, model, field))]
 pub fn update_many_records(
     graph: &mut QueryGraph,
     connector_ctx: &ConnectorContext,
@@ -135,7 +133,6 @@ pub fn update_many_records(
 }
 
 /// Creates an update record query node and adds it to the query graph.
-#[tracing::instrument(skip(graph, filter, model, data_map))]
 pub fn update_record_node<T: Clone>(
     graph: &mut QueryGraph,
     connector_ctx: &ConnectorContext,
@@ -169,7 +166,6 @@ where
 }
 
 /// Creates an update many record query node and adds it to the query graph.
-#[tracing::instrument(skip(graph, connector_ctx, filter, model, data_map))]
 pub fn update_many_record_node<T>(
     graph: &mut QueryGraph,
     connector_ctx: &ConnectorContext,

--- a/query-engine/core/src/query_graph_builder/write/upsert.rs
+++ b/query-engine/core/src/query_graph_builder/write/upsert.rs
@@ -52,7 +52,6 @@ use std::{convert::TryInto, sync::Arc};
 ///  │   Read Parent   │
 ///  └─────────────────┘
 /// ```
-#[tracing::instrument(skip(graph, model, field))]
 pub fn upsert_record(
     graph: &mut QueryGraph,
     connector_ctx: &ConnectorContext,

--- a/query-engine/core/src/query_graph_builder/write/utils.rs
+++ b/query-engine/core/src/query_graph_builder/write/utils.rs
@@ -86,7 +86,6 @@ fn get_selected_fields(model: &ModelRef, selection: FieldSelection) -> FieldSele
 /// - `parent_node` needs to return a blog ID during execution.
 /// - `parent_relation_field` is the field on the `Blog` model, e.g. `posts`.
 /// - `filter` narrows down posts, e.g. posts where their titles start with a given string.
-#[tracing::instrument(skip(graph, parent_node, parent_relation_field, filter))]
 pub fn insert_find_children_by_parent_node<T>(
     graph: &mut QueryGraph,
     parent_node: &NodeRef,
@@ -192,7 +191,6 @@ where
 /// the relation is also inlined on that models side, so we put that check into the if flow.
 ///
 /// Returns a `NodeRef` to the "Read Related" node in the graph illustrated above.
-#[tracing::instrument(skip(graph, parent_node, parent_relation_field))]
 pub fn insert_existing_1to1_related_model_checks(
     graph: &mut QueryGraph,
     parent_node: &NodeRef,
@@ -308,7 +306,6 @@ pub fn insert_existing_1to1_related_model_checks(
 ///               │                                                         │                                        │
 ///               └─────────────────────────────────────────────────────────┴────────────────────────────────────────┘
 /// ```
-#[tracing::instrument(skip(graph, model_to_delete, parent_node, child_node))]
 pub fn insert_emulated_on_delete(
     graph: &mut QueryGraph,
     connector_ctx: &ConnectorContext,
@@ -819,7 +816,6 @@ pub fn emulate_on_update_set_null(
 ///               │                                                         │                                        │
 ///               └─────────────────────────────────────────────────────────┴────────────────────────────────────────┘
 /// ```
-#[tracing::instrument(skip(graph, model_to_update, parent_node, child_node))]
 pub fn insert_emulated_on_update_with_intermediary_node(
     graph: &mut QueryGraph,
     connector_ctx: &ConnectorContext,
@@ -868,7 +864,6 @@ pub fn insert_emulated_on_update_with_intermediary_node(
     Ok(Some(join_node))
 }
 
-#[tracing::instrument(skip(graph, model_to_update, parent_node, child_node))]
 pub fn insert_emulated_on_update(
     graph: &mut QueryGraph,
     connector_ctx: &ConnectorContext,

--- a/query-engine/core/src/query_graph_builder/write/write_args_parser.rs
+++ b/query-engine/core/src/query_graph_builder/write/write_args_parser.rs
@@ -17,7 +17,6 @@ pub struct WriteArgsParser {
 impl WriteArgsParser {
     /// Creates a new set of WriteArgsParser. Expects the parsed input map from the respective data key, not the enclosing map.
     /// E.g.: { data: { THIS MAP } } from the `data` argument of a write query.
-    #[tracing::instrument(name = "write_args_parser_from", skip(model, data_map))]
     pub fn from(model: &ModelRef, data_map: ParsedInputMap) -> QueryGraphBuilderResult<Self> {
         data_map.into_iter().try_fold(
             WriteArgsParser::default(),

--- a/query-engine/core/src/response_ir/internal.rs
+++ b/query-engine/core/src/response_ir/internal.rs
@@ -33,7 +33,6 @@ type UncheckedItemsWithParents = IndexMap<Option<SelectionResult>, Vec<Item>>;
 /// // todo more here
 ///
 /// Returns a map of pairs of (parent ID, response)
-#[tracing::instrument(skip(result, field, is_list))]
 pub fn serialize_internal(
     result: QueryResult,
     field: &OutputFieldRef,
@@ -59,7 +58,6 @@ pub fn serialize_internal(
     }
 }
 
-#[tracing::instrument(skip(output_field, record_aggregations))]
 fn serialize_aggregations(
     output_field: &OutputFieldRef,
     record_aggregations: RecordAggregations,
@@ -214,7 +212,6 @@ fn coerce_non_numeric(value: PrismaValue, output: &OutputType) -> PrismaValue {
     }
 }
 
-#[tracing::instrument(skip(record_selection, field, typ, is_list))]
 fn serialize_record_selection(
     record_selection: RecordSelection,
     field: &OutputFieldRef,
@@ -280,7 +277,6 @@ fn serialize_record_selection(
 /// Serializes the given result into objects of given type.
 /// Doesn't validate the shape of the result set ("unchecked" result).
 /// Returns a vector of serialized objects (as Item::Map), grouped into a map by parent, if present.
-#[tracing::instrument(skip(result, typ))]
 fn serialize_objects(
     mut result: RecordSelection,
     typ: ObjectTypeStrongRef,
@@ -379,7 +375,6 @@ fn serialize_objects(
 }
 
 /// Unwraps are safe due to query validation.
-#[tracing::instrument(skip(record_id, items_with_parent, into, enclosing_type))]
 fn write_nested_items(
     record_id: &Option<SelectionResult>,
     items_with_parent: &mut HashMap<String, CheckedItemsWithParents>,
@@ -413,7 +408,6 @@ fn write_nested_items(
 }
 
 /// Processes nested results into a more ergonomic structure of { <nested field name> -> { parent ID -> item (list, map, ...) } }.
-#[tracing::instrument(skip(nested, enclosing_type))]
 fn process_nested_results(
     nested: Vec<QueryResult>,
     enclosing_type: &ObjectTypeStrongRef,

--- a/query-engine/core/src/response_ir/ir_serializer.rs
+++ b/query-engine/core/src/response_ir/ir_serializer.rs
@@ -15,7 +15,6 @@ pub struct IrSerializer {
 }
 
 impl IrSerializer {
-    #[tracing::instrument(skip(self, result))]
     pub fn serialize(&self, result: ExpressionResult) -> crate::Result<ResponseData> {
         match result {
             ExpressionResult::Query(QueryResult::Json(json)) => {

--- a/query-engine/query-engine-node-api/Cargo.toml
+++ b/query-engine/query-engine-node-api/Cargo.toml
@@ -37,9 +37,8 @@ tracing-futures = "0.2"
 tracing-opentelemetry = "0.16"
 datamodel-connector = { path = "../../libs/datamodel/connectors/datamodel-connector" }
 opentelemetry = { version = "0.16" }
-opentelemetry-otlp = { version = "0.9", features = ["tls", "tls-roots"] }
 
 tokio = { version = "1", features = ["sync"] }
 
 [build-dependencies]
-napi-build = "1"
+napi-build = "2"

--- a/query-engine/query-engine-node-api/Cargo.toml
+++ b/query-engine/query-engine-node-api/Cargo.toml
@@ -41,4 +41,4 @@ opentelemetry = { version = "0.16" }
 tokio = { version = "1", features = ["sync"] }
 
 [build-dependencies]
-napi-build = "2"
+napi-build = "1"

--- a/query-engine/query-engine-node-api/src/logger.rs
+++ b/query-engine/query-engine-node-api/src/logger.rs
@@ -1,13 +1,5 @@
 use core::fmt;
 use napi::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
-use napi::Result;
-use opentelemetry::global;
-use opentelemetry::sdk::propagation::TraceContextPropagator;
-use opentelemetry::{
-    sdk::{trace::Config, Resource},
-    KeyValue,
-};
-use opentelemetry_otlp::WithExportConfig;
 use serde_json::Value;
 use std::collections::BTreeMap;
 use tokio::sync::RwLock;
@@ -24,10 +16,6 @@ use tracing_subscriber::{
 };
 
 pub(crate) struct Logger {
-    // We need the original parameters in case we move to tracing
-    log_queries: bool,
-    log_level: LevelFilter,
-    log_callback: ThreadsafeFunction<String>,
     __dispatcher: RwLock<Dispatch>,
 }
 
@@ -52,59 +40,8 @@ impl Logger {
         let layer = CallbackLayer::new(log_callback.clone()).with_filter(filters);
 
         Self {
-            log_queries,
-            log_level,
-            log_callback,
             __dispatcher: RwLock::new(Dispatch::new(Registry::default().with(layer))),
         }
-    }
-
-    /// Sets the Logger to use telemetry
-    pub async fn enable_telemetry(&self, endpoint: Option<String>, name: Option<String>) -> Result<()> {
-        global::set_text_map_propagator(TraceContextPropagator::new());
-
-        let name = name.unwrap_or_else(|| String::from("prisma-query-engine"));
-
-        let resource = Resource::new(vec![KeyValue::new("service.name", name)]);
-        let config = Config::default().with_resource(resource);
-
-        let builder = opentelemetry_otlp::new_pipeline().tracing().with_trace_config(config);
-
-        let mut exporter = opentelemetry_otlp::new_exporter().tonic();
-
-        if let Some(endpoint) = endpoint {
-            exporter = exporter.with_endpoint(endpoint);
-        }
-
-        let builder = builder.with_exporter(exporter);
-        let tracer = builder.install_simple().unwrap();
-
-        let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
-
-        let is_sql_query = filter_fn(|meta| {
-            meta.target() == "quaint::connector::metrics" && meta.fields().iter().any(|f| f.name() == "query")
-        });
-        // is a mongodb query?
-        let is_mongo_query = filter_fn(|meta| meta.target() == "mongodb_query_connector::query");
-
-        // We need to filter the messages to send to our callback logging mechanism
-        let filters = if self.log_queries {
-            // Filter trace query events (for query log) or based in the defined log level
-            is_sql_query.or(is_mongo_query).or(self.log_level).boxed()
-        } else {
-            // Filter based in the defined log level
-            self.log_level.boxed()
-        };
-
-        let layer = CallbackLayer::new(self.log_callback.clone()).with_filter(filters);
-
-        let registry = Registry::default().with(telemetry).with(layer);
-
-        // Assign a new dispatcher now with the telemetry layer assigned
-        let mut dispatcher = self.__dispatcher.write().await;
-        *dispatcher = Dispatch::new(registry);
-
-        Ok(())
     }
 
     /// Returns a tracing dispatcher

--- a/query-engine/query-engine-node-api/src/logger.rs
+++ b/query-engine/query-engine-node-api/src/logger.rs
@@ -37,7 +37,7 @@ impl Logger {
             log_level.boxed()
         };
 
-        let layer = CallbackLayer::new(log_callback.clone()).with_filter(filters);
+        let layer = CallbackLayer::new(log_callback).with_filter(filters);
 
         Self {
             __dispatcher: RwLock::new(Dispatch::new(Registry::default().with(layer))),

--- a/query-engine/query-engine-node-api/src/logger.rs
+++ b/query-engine/query-engine-node-api/src/logger.rs
@@ -2,7 +2,6 @@ use core::fmt;
 use napi::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
 use serde_json::Value;
 use std::collections::BTreeMap;
-use tokio::sync::RwLock;
 use tracing::{
     field::{Field, Visit},
     level_filters::LevelFilter,
@@ -16,7 +15,7 @@ use tracing_subscriber::{
 };
 
 pub(crate) struct Logger {
-    __dispatcher: RwLock<Dispatch>,
+    __dispatcher: Dispatch,
 }
 
 impl Logger {
@@ -40,13 +39,13 @@ impl Logger {
         let layer = CallbackLayer::new(log_callback).with_filter(filters);
 
         Self {
-            __dispatcher: RwLock::new(Dispatch::new(Registry::default().with(layer))),
+            __dispatcher: Dispatch::new(Registry::default().with(layer)),
         }
     }
 
     /// Returns a tracing dispatcher
     pub async fn dispatcher(&self) -> Dispatch {
-        self.__dispatcher.read().await.clone()
+        self.__dispatcher.clone()
     }
 }
 

--- a/query-engine/query-engine-node-api/src/logger.rs
+++ b/query-engine/query-engine-node-api/src/logger.rs
@@ -39,12 +39,12 @@ impl Logger {
         let layer = CallbackLayer::new(log_callback).with_filter(filters);
 
         Self {
-            __dispatcher: Dispatch::new(Registry::default().with(layer)),
+            dispatcher: Dispatch::new(Registry::default().with(layer)),
         }
     }
 
     pub async fn dispatcher(&self) -> Dispatch {
-        self.__dispatcher.clone()
+        self.dispatcher.clone()
     }
 }
 

--- a/query-engine/query-engine-node-api/src/logger.rs
+++ b/query-engine/query-engine-node-api/src/logger.rs
@@ -15,7 +15,7 @@ use tracing_subscriber::{
 };
 
 pub(crate) struct Logger {
-    __dispatcher: Dispatch,
+    dispatcher: Dispatch,
 }
 
 impl Logger {
@@ -43,7 +43,6 @@ impl Logger {
         }
     }
 
-    /// Returns a tracing dispatcher
     pub async fn dispatcher(&self) -> Dispatch {
         self.__dispatcher.clone()
     }

--- a/query-engine/query-engine/src/server/mod.rs
+++ b/query-engine/query-engine/src/server/mod.rs
@@ -66,7 +66,6 @@ pub async fn setup(opts: &PrismaOpt) -> PrismaResult<State> {
 }
 
 /// Starts up the graphql query engine server
-#[tracing::instrument(skip(opts))]
 pub async fn listen(opts: PrismaOpt) -> PrismaResult<()> {
     let state = setup(&opts).await?;
 

--- a/query-engine/request-handlers/src/graphql/handler.rs
+++ b/query-engine/request-handlers/src/graphql/handler.rs
@@ -99,7 +99,6 @@ impl<'a> GraphQlHandler<'a> {
         }
     }
 
-    #[tracing::instrument(skip(self, document))]
     async fn handle_compacted(
         &self,
         document: CompactedDocument,

--- a/query-engine/request-handlers/src/graphql/protocol_adapter.rs
+++ b/query-engine/request-handlers/src/graphql/protocol_adapter.rs
@@ -23,7 +23,6 @@ use query_core::query_document::*;
 pub struct GraphQLProtocolAdapter;
 
 impl GraphQLProtocolAdapter {
-    #[tracing::instrument(name = "graphql_to_query_document", skip(gql_doc, operation))]
     pub fn convert(gql_doc: Document<String>, operation: Option<String>) -> crate::Result<Operation> {
         let mut operations: Vec<Operation> = match operation {
             Some(ref op) => gql_doc

--- a/query-engine/request-handlers/src/graphql/schema_renderer/object_renderer.rs
+++ b/query-engine/request-handlers/src/graphql/schema_renderer/object_renderer.rs
@@ -7,7 +7,6 @@ pub enum GqlObjectRenderer {
 }
 
 impl Renderer for GqlObjectRenderer {
-    #[tracing::instrument(name = "render_graphql_object", skip(self, ctx))]
     fn render(&self, ctx: &mut RenderContext) -> String {
         match &self {
             GqlObjectRenderer::Input(input) => self.render_input_object(input, ctx),


### PR DESCRIPTION
- Extra trace messages (or redundant) used for poor man profile are removed.
- OLTP tracing instrumentation macros removed
- This closes https://github.com/prisma/prisma-engines/issues/2910
- Binary size reduced by approx 3.5M in macOS
- Same instrumentation will return in a different way probably in the future