### PR TITLE
refactor(me): stop using async_trait in migration connectors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1996,7 +1996,6 @@ dependencies = [
 name = "migration-connector"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "chrono",
  "datamodel",
  "enumflags2",
@@ -2056,7 +2055,6 @@ dependencies = [
 name = "migration-engine-tests"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "bigdecimal 0.2.2",
  "chrono",
  "connection-string",
@@ -2253,7 +2251,6 @@ dependencies = [
 name = "mongodb-migration-connector"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "datamodel",
  "dissimilar",
  "enumflags2",
@@ -3159,7 +3156,6 @@ dependencies = [
 name = "qe-setup"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "connection-string",
  "datamodel",
  "enumflags2",
@@ -4167,7 +4163,6 @@ dependencies = [
 name = "sql-migration-connector"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "chrono",
  "connection-string",
  "datamodel",

--- a/migration-engine/cli/Cargo.toml
+++ b/migration-engine/cli/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "migration-engine-cli"
 version = "0.1.0"
-authors = ["Tom Houlé <tom@tomhoule.com>"]
 edition = "2021"
 
 [dependencies]

--- a/migration-engine/connectors/migration-connector/Cargo.toml
+++ b/migration-engine/connectors/migration-connector/Cargo.toml
@@ -1,14 +1,12 @@
 [package]
 name = "migration-connector"
 version = "0.1.0"
-authors = ["Marcus Böhm <boehm@prisma.io>"]
 edition = "2021"
 
 [dependencies]
 datamodel = { path = "../../../libs/datamodel/core", default_features = false }
 user-facing-errors = { path = "../../../libs/user-facing-errors" }
 
-async-trait = "0.1.17"
 chrono = "0.4"
 enumflags2 = "0.7"
 sha2 = "0.9.1"

--- a/migration-engine/connectors/migration-connector/src/migration_persistence.rs
+++ b/migration-engine/connectors/migration-connector/src/migration_persistence.rs
@@ -1,13 +1,12 @@
-use crate::{checksum, ConnectorError, ConnectorResult};
+use crate::{checksum, BoxFuture, ConnectorError, ConnectorResult};
 
 /// A timestamp.
 pub type Timestamp = chrono::DateTime<chrono::Utc>;
 
 /// Management of imperative migrations state in the database.
-#[async_trait::async_trait]
 pub trait MigrationPersistence: Send + Sync {
     /// Initialize the migration persistence without checking the database first.
-    async fn baseline_initialize(&mut self) -> ConnectorResult<()>;
+    fn baseline_initialize(&mut self) -> BoxFuture<'_, ConnectorResult<()>>;
 
     /// This method is responsible for checking whether the migrations
     /// persistence is initialized.
@@ -15,7 +14,7 @@ pub trait MigrationPersistence: Send + Sync {
     /// If the migration persistence is not present in the target database,
     /// check whether the database schema is empty. If it is, initialize the
     /// migration persistence. If not, return a DatabaseSchemaNotEmpty error.
-    async fn initialize(&mut self) -> ConnectorResult<()>;
+    fn initialize(&mut self) -> BoxFuture<'_, ConnectorResult<()>>;
 
     /// Implementation in the connector for the core's MarkMigrationApplied
     /// command. See the docs there. Note that the started_at and finished_at
@@ -23,28 +22,44 @@ pub trait MigrationPersistence: Send + Sync {
     ///
     /// Connectors should implement mark_migration_applied_impl to avoid doing
     /// the checksuming themselves.
-    async fn mark_migration_applied(&mut self, migration_name: &str, script: &str) -> ConnectorResult<String> {
-        self.mark_migration_applied_impl(migration_name, &checksum::render_checksum(script))
-            .await
+    fn mark_migration_applied<'a>(
+        &'a mut self,
+        migration_name: &'a str,
+        script: &'a str,
+    ) -> BoxFuture<'a, ConnectorResult<String>> {
+        Box::pin(async move {
+            self.mark_migration_applied_impl(migration_name, &checksum::render_checksum(script))
+                .await
+        })
     }
 
     /// Implementation in the connector for the core's MarkMigrationApplied
     /// command. See the docs there. Note that the started_at and finished_at
     /// for the migration should be the same.
-    async fn mark_migration_applied_impl(&mut self, migration_name: &str, checksum: &str) -> ConnectorResult<String>;
+    fn mark_migration_applied_impl<'a>(
+        &'a mut self,
+        migration_name: &'a str,
+        checksum: &'a str,
+    ) -> BoxFuture<'a, ConnectorResult<String>>;
 
     /// Mark the failed instances of the migration in the persistence as rolled
     /// back, so they will be ignored by the engine in the future.
-    async fn mark_migration_rolled_back_by_id(&mut self, migration_id: &str) -> ConnectorResult<()>;
+    fn mark_migration_rolled_back_by_id<'a>(&'a mut self, migration_id: &'a str) -> BoxFuture<'a, ConnectorResult<()>>;
 
     /// Record that a migration is about to be applied. Returns the unique
     /// identifier for the migration.
     ///
     /// This is a default method that computes the checksum. Implementors should
     /// implement record_migration_started_impl.
-    async fn record_migration_started(&mut self, migration_name: &str, script: &str) -> ConnectorResult<String> {
-        self.record_migration_started_impl(migration_name, &checksum::render_checksum(script))
-            .await
+    fn record_migration_started<'a>(
+        &'a mut self,
+        migration_name: &'a str,
+        script: &'a str,
+    ) -> BoxFuture<'a, ConnectorResult<String>> {
+        Box::pin(async move {
+            self.record_migration_started_impl(migration_name, &checksum::render_checksum(script))
+                .await
+        })
     }
 
     /// Record that a migration is about to be applied. Returns the unique
@@ -52,25 +67,29 @@ pub trait MigrationPersistence: Send + Sync {
     ///
     /// This is an implementation detail, consumers should use
     /// `record_migration_started()` instead.
-    async fn record_migration_started_impl(&mut self, migration_name: &str, checksum: &str) -> ConnectorResult<String>;
+    fn record_migration_started_impl<'a>(
+        &'a mut self,
+        migration_name: &'a str,
+        checksum: &'a str,
+    ) -> BoxFuture<'a, ConnectorResult<String>>;
 
     /// Increase the applied_steps_count counter.
-    async fn record_successful_step(&mut self, id: &str) -> ConnectorResult<()>;
+    fn record_successful_step<'a>(&'a mut self, id: &'a str) -> BoxFuture<'a, ConnectorResult<()>>;
 
     /// Report logs for a failed migration step. We assume the next steps in the
     /// migration will not be applied, and the error reported.
-    async fn record_failed_step(&mut self, id: &str, logs: &str) -> ConnectorResult<()>;
+    fn record_failed_step<'a>(&'a mut self, id: &'a str, logs: &'a str) -> BoxFuture<'a, ConnectorResult<()>>;
 
     /// Record that the migration completed *successfully*. This means
     /// populating the `finished_at` field in the migration record.
-    async fn record_migration_finished(&mut self, id: &str) -> ConnectorResult<()>;
+    fn record_migration_finished<'a>(&'a mut self, id: &'a str) -> BoxFuture<'a, ConnectorResult<()>>;
 
     /// List all applied migrations, ordered by `started_at`. This should fail
     /// with a PersistenceNotInitializedError when the migration persistence is
     /// not initialized.
-    async fn list_migrations(
+    fn list_migrations(
         &mut self,
-    ) -> ConnectorResult<Result<Vec<MigrationRecord>, PersistenceNotInitializedError>>;
+    ) -> BoxFuture<'_, ConnectorResult<Result<Vec<MigrationRecord>, PersistenceNotInitializedError>>>;
 }
 
 /// Error returned when the persistence is not initialized.

--- a/migration-engine/connectors/mongodb-migration-connector/Cargo.toml
+++ b/migration-engine/connectors/mongodb-migration-connector/Cargo.toml
@@ -4,19 +4,18 @@ name = "mongodb-migration-connector"
 version = "0.1.0"
 
 [dependencies]
-datamodel = { path = "../../../libs/datamodel/core" }
+datamodel = { path = "../../../libs/datamodel/core", default_features = false }
 mongodb-client = { path = "../../../libs/mongodb-client" }
 mongodb-datamodel-connector = { path = "../../../libs/datamodel/connectors/mongodb-datamodel-connector" }
 mongodb-schema-describer = { path = "../../../libs/mongodb-schema-describer" }
 migration-connector = { path = "../migration-connector" }
 
-async-trait = "0.1.17"
+enumflags2 = "0.7"
 futures = "0.3"
 mongodb = "2.1.0"
 serde_json = "1"
 tokio = { version = "1.0", features = ["parking_lot"] }
 tracing = "0.1"
-enumflags2 = "0.7"
 
 [dev-dependencies]
 dissimilar = "1.0.3"

--- a/migration-engine/connectors/mongodb-migration-connector/src/migration_persistence.rs
+++ b/migration-engine/connectors/mongodb-migration-connector/src/migration_persistence.rs
@@ -1,56 +1,59 @@
 use crate::MongoDbMigrationConnector;
-use migration_connector::MigrationPersistence;
+use migration_connector::{BoxFuture, ConnectorResult, MigrationPersistence};
 
-#[async_trait::async_trait]
 impl MigrationPersistence for MongoDbMigrationConnector {
-    async fn baseline_initialize(&mut self) -> migration_connector::ConnectorResult<()> {
-        Err(crate::unsupported_command_error())
+    fn baseline_initialize(&mut self) -> migration_connector::BoxFuture<'_, ConnectorResult<()>> {
+        unsupported_command_error()
     }
 
-    async fn initialize(&mut self) -> migration_connector::ConnectorResult<()> {
-        Err(crate::unsupported_command_error())
+    fn initialize(&mut self) -> BoxFuture<'_, ConnectorResult<()>> {
+        unsupported_command_error()
     }
 
-    async fn mark_migration_applied_impl(
+    fn mark_migration_applied_impl(
         &mut self,
         _migration_name: &str,
         _checksum: &str,
-    ) -> migration_connector::ConnectorResult<String> {
-        Err(crate::unsupported_command_error())
+    ) -> BoxFuture<'_, ConnectorResult<String>> {
+        unsupported_command_error()
     }
 
-    async fn mark_migration_rolled_back_by_id(
-        &mut self,
-        _migration_id: &str,
-    ) -> migration_connector::ConnectorResult<()> {
-        Err(crate::unsupported_command_error())
+    fn mark_migration_rolled_back_by_id(&mut self, _migration_id: &str) -> BoxFuture<'_, ConnectorResult<()>> {
+        unsupported_command_error()
     }
 
-    async fn record_migration_started_impl(
+    fn record_migration_started_impl(
         &mut self,
         _migration_name: &str,
         _checksum: &str,
-    ) -> migration_connector::ConnectorResult<String> {
-        Err(crate::unsupported_command_error())
+    ) -> BoxFuture<'_, ConnectorResult<String>> {
+        unsupported_command_error()
     }
 
-    async fn record_successful_step(&mut self, _id: &str) -> migration_connector::ConnectorResult<()> {
-        Err(crate::unsupported_command_error())
+    fn record_successful_step(&mut self, _id: &str) -> BoxFuture<'_, ConnectorResult<()>> {
+        unsupported_command_error()
     }
 
-    async fn record_failed_step(&mut self, _id: &str, _logs: &str) -> migration_connector::ConnectorResult<()> {
-        Err(crate::unsupported_command_error())
+    fn record_failed_step(&mut self, _id: &str, _logs: &str) -> BoxFuture<'_, ConnectorResult<()>> {
+        unsupported_command_error()
     }
 
-    async fn record_migration_finished(&mut self, _id: &str) -> migration_connector::ConnectorResult<()> {
-        Err(crate::unsupported_command_error())
+    fn record_migration_finished(&mut self, _id: &str) -> BoxFuture<'_, ConnectorResult<()>> {
+        unsupported_command_error()
     }
 
-    async fn list_migrations(
+    fn list_migrations(
         &mut self,
-    ) -> migration_connector::ConnectorResult<
-        Result<Vec<migration_connector::MigrationRecord>, migration_connector::PersistenceNotInitializedError>,
+    ) -> BoxFuture<
+        '_,
+        ConnectorResult<
+            Result<Vec<migration_connector::MigrationRecord>, migration_connector::PersistenceNotInitializedError>,
+        >,
     > {
-        Err(crate::unsupported_command_error())
+        unsupported_command_error()
     }
+}
+
+fn unsupported_command_error<T: Send + Sync + 'static>() -> BoxFuture<'static, ConnectorResult<T>> {
+    Box::pin(std::future::ready(Err(crate::unsupported_command_error())))
 }

--- a/migration-engine/connectors/sql-migration-connector/Cargo.toml
+++ b/migration-engine/connectors/sql-migration-connector/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Marcus Böhm <boehm@prisma.io>"]
 edition = "2021"
 name = "sql-migration-connector"
 version = "0.1.0"
@@ -13,7 +12,6 @@ sql-schema-describer = { path = "../../../libs/sql-schema-describer" }
 sql-ddl = { path = "../../../libs/sql-ddl" }
 user-facing-errors = { path = "../../../libs/user-facing-errors", features = ["sql"] }
 
-async-trait = "0.1.17"
 chrono = { version = "0.4" }
 connection-string = "0.1.10"
 enumflags2 = "0.7.1"

--- a/migration-engine/connectors/sql-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/lib.rs
@@ -134,7 +134,6 @@ impl SqlMigrationConnector {
     }
 }
 
-#[async_trait::async_trait]
 impl MigrationConnector for SqlMigrationConnector {
     fn set_host(&mut self, host: Arc<dyn migration_connector::ConnectorHost>) {
         self.host = host;

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour.rs
@@ -5,11 +5,10 @@ mod sqlite;
 
 use super::DestructiveCheckPlan;
 use crate::{pair::Pair, sql_migration::AlterColumn, sql_schema_differ::ColumnChanges};
-use migration_connector::{ConnectorError, ConnectorResult};
+use migration_connector::{BoxFuture, ConnectorError, ConnectorResult};
 use sql_schema_describer::walkers::ColumnWalker;
 
 /// Flavour-specific destructive change checks and queries.
-#[async_trait::async_trait]
 pub(crate) trait DestructiveChangeCheckerFlavour {
     /// Check for potential destructive or unexecutable alter column steps.
     fn check_alter_column(
@@ -29,9 +28,12 @@ pub(crate) trait DestructiveChangeCheckerFlavour {
         step_index: usize,
     );
 
-    async fn count_rows_in_table(&mut self, table_name: &str) -> ConnectorResult<i64>;
+    fn count_rows_in_table<'a>(&'a mut self, table_name: &'a str) -> BoxFuture<'a, ConnectorResult<i64>>;
 
-    async fn count_values_in_column(&mut self, table_and_column: (&str, &str)) -> ConnectorResult<i64>;
+    fn count_values_in_column<'a>(
+        &'a mut self,
+        table_and_column: (&'a str, &'a str),
+    ) -> BoxFuture<'a, ConnectorResult<i64>>;
 }
 
 /// Display a column type for warnings/errors.

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/mssql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/mssql.rs
@@ -9,9 +9,9 @@ use crate::{
     sql_migration::{AlterColumn, ColumnTypeChange},
     sql_schema_differ::ColumnChanges,
 };
+use migration_connector::{BoxFuture, ConnectorResult};
 use sql_schema_describer::walkers::ColumnWalker;
 
-#[async_trait::async_trait]
 impl DestructiveChangeCheckerFlavour for MssqlFlavour {
     fn check_alter_column(
         &self,
@@ -111,27 +111,31 @@ impl DestructiveChangeCheckerFlavour for MssqlFlavour {
         }
     }
 
-    async fn count_rows_in_table(&mut self, table_name: &str) -> migration_connector::ConnectorResult<i64> {
-        let query = {
-            let schema_name = self.schema_name();
-            format!("SELECT COUNT(*) FROM [{}].[{}]", schema_name, table_name)
-        };
-        let result_set = self.query_raw(&query, &[]).await?;
-        super::extract_table_rows_count(table_name, result_set)
+    fn count_rows_in_table<'a>(&'a mut self, table_name: &'a str) -> BoxFuture<'a, ConnectorResult<i64>> {
+        Box::pin(async move {
+            let query = {
+                let schema_name = self.schema_name();
+                format!("SELECT COUNT(*) FROM [{}].[{}]", schema_name, table_name)
+            };
+            let result_set = self.query_raw(&query, &[]).await?;
+            super::extract_table_rows_count(table_name, result_set)
+        })
     }
 
-    async fn count_values_in_column(
-        &mut self,
-        (table, column): (&str, &str),
-    ) -> migration_connector::ConnectorResult<i64> {
-        let query = {
-            let schema_name = self.schema_name();
-            format!(
-                "SELECT COUNT(*) FROM [{}].[{}] WHERE [{}] IS NOT NULL",
-                schema_name, table, column
-            )
-        };
-        let result_set = self.query_raw(&query, &[]).await?;
-        super::extract_column_values_count(result_set)
+    fn count_values_in_column<'a>(
+        &'a mut self,
+        (table, column): (&'a str, &'a str),
+    ) -> BoxFuture<'a, ConnectorResult<i64>> {
+        Box::pin(async move {
+            let query = {
+                let schema_name = self.schema_name();
+                format!(
+                    "SELECT COUNT(*) FROM [{}].[{}] WHERE [{}] IS NOT NULL",
+                    schema_name, table, column
+                )
+            };
+            let result_set = self.query_raw(&query, &[]).await?;
+            super::extract_column_values_count(result_set)
+        })
     }
 }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/mysql.rs
@@ -9,9 +9,9 @@ use crate::{
     sql_migration::{AlterColumn, ColumnTypeChange},
     sql_schema_differ::ColumnChanges,
 };
+use migration_connector::{BoxFuture, ConnectorResult};
 use sql_schema_describer::walkers::ColumnWalker;
 
-#[async_trait::async_trait]
 impl DestructiveChangeCheckerFlavour for MysqlFlavour {
     fn check_alter_column(
         &self,
@@ -120,19 +120,23 @@ impl DestructiveChangeCheckerFlavour for MysqlFlavour {
         }
     }
 
-    async fn count_rows_in_table(&mut self, table_name: &str) -> migration_connector::ConnectorResult<i64> {
-        let query = format!("SELECT COUNT(*) FROM `{}`", table_name);
-        let result_set = self.query_raw(&query, &[]).await?;
-        super::extract_table_rows_count(table_name, result_set)
+    fn count_rows_in_table<'a>(&'a mut self, table_name: &'a str) -> BoxFuture<'a, ConnectorResult<i64>> {
+        Box::pin(async move {
+            let query = format!("SELECT COUNT(*) FROM `{}`", table_name);
+            let result_set = self.query_raw(&query, &[]).await?;
+            super::extract_table_rows_count(table_name, result_set)
+        })
     }
 
-    async fn count_values_in_column(
-        &mut self,
-        (table, column): (&str, &str),
-    ) -> migration_connector::ConnectorResult<i64> {
-        let query = format!("SELECT COUNT(*) FROM `{}` WHERE `{}` IS NOT NULL", table, column);
-        let result_set = self.query_raw(&query, &[]).await?;
-        super::extract_column_values_count(result_set)
+    fn count_values_in_column<'a>(
+        &'a mut self,
+        (table, column): (&'a str, &'a str),
+    ) -> BoxFuture<'a, ConnectorResult<i64>> {
+        Box::pin(async move {
+            let query = format!("SELECT COUNT(*) FROM `{}` WHERE `{}` IS NOT NULL", table, column);
+            let result_set = self.query_raw(&query, &[]).await?;
+            super::extract_column_values_count(result_set)
+        })
     }
 }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/sqlite.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/sqlite.rs
@@ -9,9 +9,9 @@ use crate::{
     sql_migration::{AlterColumn, ColumnTypeChange},
     sql_schema_differ::ColumnChanges,
 };
+use migration_connector::{BoxFuture, ConnectorResult};
 use sql_schema_describer::{walkers::ColumnWalker, ColumnArity};
 
-#[async_trait::async_trait]
 impl DestructiveChangeCheckerFlavour for SqliteFlavour {
     fn check_alter_column(
         &self,
@@ -75,18 +75,22 @@ impl DestructiveChangeCheckerFlavour for SqliteFlavour {
         unreachable!("check_drop_and_recreate_column on SQLite");
     }
 
-    async fn count_rows_in_table(&mut self, table_name: &str) -> migration_connector::ConnectorResult<i64> {
-        let query = format!("SELECT COUNT(*) FROM \"{}\"", table_name);
-        let result_set = self.query_raw(&query, &[]).await?;
-        super::extract_table_rows_count(table_name, result_set)
+    fn count_rows_in_table<'a>(&'a mut self, table_name: &'a str) -> BoxFuture<'a, ConnectorResult<i64>> {
+        Box::pin(async move {
+            let query = format!("SELECT COUNT(*) FROM \"{}\"", table_name);
+            let result_set = self.query_raw(&query, &[]).await?;
+            super::extract_table_rows_count(table_name, result_set)
+        })
     }
 
-    async fn count_values_in_column(
-        &mut self,
-        (table, column): (&str, &str),
-    ) -> migration_connector::ConnectorResult<i64> {
-        let query = format!("SELECT COUNT(*) FROM \"{}\" WHERE \"{}\" IS NOT NULL", table, column);
-        let result_set = self.query_raw(&query, &[]).await?;
-        super::extract_column_values_count(result_set)
+    fn count_values_in_column<'a>(
+        &'a mut self,
+        (table, column): (&'a str, &'a str),
+    ) -> BoxFuture<'a, ConnectorResult<i64>> {
+        Box::pin(async move {
+            let query = format!("SELECT COUNT(*) FROM \"{}\" WHERE \"{}\" IS NOT NULL", table, column);
+            let result_set = self.query_raw(&query, &[]).await?;
+            super::extract_column_values_count(result_set)
+        })
     }
 }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_migration_persistence.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_migration_persistence.rs
@@ -1,87 +1,100 @@
 use crate::SqlMigrationConnector;
 use migration_connector::{
-    ConnectorError, ConnectorResult, MigrationPersistence, MigrationRecord, PersistenceNotInitializedError,
+    BoxFuture, ConnectorError, ConnectorResult, MigrationPersistence, MigrationRecord, PersistenceNotInitializedError,
 };
 use quaint::ast::*;
 use uuid::Uuid;
 
-#[async_trait::async_trait]
 impl MigrationPersistence for SqlMigrationConnector {
-    async fn baseline_initialize(&mut self) -> ConnectorResult<()> {
-        self.flavour.create_migrations_table().await?;
-
-        Ok(())
+    fn baseline_initialize(&mut self) -> BoxFuture<'_, ConnectorResult<()>> {
+        self.flavour.create_migrations_table()
     }
 
-    async fn initialize(&mut self) -> ConnectorResult<()> {
-        let schema = self.flavour.describe_schema().await?;
+    fn initialize(&mut self) -> BoxFuture<'_, ConnectorResult<()>> {
+        Box::pin(async move {
+            let schema = self.flavour.describe_schema().await?;
 
-        if schema
-            .tables
-            .iter()
-            .any(|table| table.name == self.flavour().migrations_table_name())
-        {
-            return Ok(());
-        }
+            if schema
+                .tables
+                .iter()
+                .any(|table| table.name == self.flavour().migrations_table_name())
+            {
+                return Ok(());
+            }
 
-        if !schema.is_empty()
-            && schema
-                .table_walkers()
-                .any(|t| !self.flavour().table_should_be_ignored(t.name()))
-        {
-            return Err(ConnectorError::user_facing(
-                user_facing_errors::migration_engine::DatabaseSchemaNotEmpty,
-            ));
-        }
+            if !schema.is_empty()
+                && schema
+                    .table_walkers()
+                    .any(|t| !self.flavour().table_should_be_ignored(t.name()))
+            {
+                return Err(ConnectorError::user_facing(
+                    user_facing_errors::migration_engine::DatabaseSchemaNotEmpty,
+                ));
+            }
 
-        self.flavour.create_migrations_table().await?;
+            self.flavour.create_migrations_table().await?;
 
-        Ok(())
+            Ok(())
+        })
     }
 
-    async fn mark_migration_applied_impl(&mut self, migration_name: &str, checksum: &str) -> ConnectorResult<String> {
-        let id = Uuid::new_v4().to_string();
-        let now = chrono::Utc::now();
+    fn mark_migration_applied_impl<'a>(
+        &'a mut self,
+        migration_name: &'a str,
+        checksum: &'a str,
+    ) -> BoxFuture<'a, ConnectorResult<String>> {
+        Box::pin(async move {
+            let id = Uuid::new_v4().to_string();
+            let now = chrono::Utc::now();
 
-        let insert = Insert::single_into(self.flavour().migrations_table())
-            .value("id", id.as_str())
-            .value("checksum", checksum)
-            .value("logs", "")
-            .value("started_at", now)
-            .value("finished_at", now)
-            .value("migration_name", migration_name);
+            let insert = Insert::single_into(self.flavour().migrations_table())
+                .value("id", id.as_str())
+                .value("checksum", checksum)
+                .value("logs", "")
+                .value("started_at", now)
+                .value("finished_at", now)
+                .value("migration_name", migration_name);
 
-        self.flavour.query(insert.into()).await?;
+            self.flavour.query(insert.into()).await?;
 
-        Ok(id)
+            Ok(id)
+        })
     }
 
-    async fn mark_migration_rolled_back_by_id(&mut self, migration_id: &str) -> ConnectorResult<()> {
+    fn mark_migration_rolled_back_by_id<'a>(&'a mut self, migration_id: &'a str) -> BoxFuture<'a, ConnectorResult<()>> {
         let update = Update::table(self.flavour().migrations_table())
             .so_that(Column::from("id").equals(migration_id))
             .set("rolled_back_at", chrono::Utc::now());
 
-        self.flavour.query(update.into()).await?;
+        Box::pin(async move {
+            self.flavour.query(update.into()).await?;
 
-        Ok(())
+            Ok(())
+        })
     }
 
-    async fn record_migration_started_impl(&mut self, migration_name: &str, checksum: &str) -> ConnectorResult<String> {
-        let id = Uuid::new_v4().to_string();
-        let now = chrono::Utc::now();
+    fn record_migration_started_impl<'a>(
+        &'a mut self,
+        migration_name: &'a str,
+        checksum: &'a str,
+    ) -> BoxFuture<'a, ConnectorResult<String>> {
+        Box::pin(async move {
+            let id = Uuid::new_v4().to_string();
+            let now = chrono::Utc::now();
 
-        let insert = Insert::single_into(self.flavour().migrations_table())
-            .value("id", id.as_str())
-            .value("checksum", checksum)
-            .value("started_at", now)
-            .value("migration_name", migration_name);
+            let insert = Insert::single_into(self.flavour().migrations_table())
+                .value("id", id.as_str())
+                .value("checksum", checksum)
+                .value("started_at", now)
+                .value("migration_name", migration_name);
 
-        self.flavour.query(insert.into()).await?;
+            self.flavour.query(insert.into()).await?;
 
-        Ok(id)
+            Ok(id)
+        })
     }
 
-    async fn record_successful_step(&mut self, id: &str) -> ConnectorResult<()> {
+    fn record_successful_step<'a>(&'a mut self, id: &'a str) -> BoxFuture<'a, ConnectorResult<()>> {
         use quaint::ast::*;
 
         let update = Update::table(self.flavour().migrations_table())
@@ -91,91 +104,102 @@ impl MigrationPersistence for SqlMigrationConnector {
                 Expression::from(Column::from("applied_steps_count")) + Expression::from(1),
             );
 
-        self.flavour.query(update.into()).await?;
+        Box::pin(async move {
+            self.flavour.query(update.into()).await?;
 
-        Ok(())
+            Ok(())
+        })
     }
 
-    async fn record_failed_step(&mut self, id: &str, logs: &str) -> ConnectorResult<()> {
+    fn record_failed_step<'a>(&'a mut self, id: &'a str, logs: &'a str) -> BoxFuture<'a, ConnectorResult<()>> {
         let update = Update::table(self.flavour().migrations_table())
             .so_that(Column::from("id").equals(id))
             .set("logs", logs);
 
-        self.flavour.query(update.into()).await?;
+        Box::pin(async move {
+            self.flavour.query(update.into()).await?;
 
-        Ok(())
+            Ok(())
+        })
     }
 
-    async fn record_migration_finished(&mut self, id: &str) -> ConnectorResult<()> {
+    fn record_migration_finished<'a>(&'a mut self, id: &'a str) -> BoxFuture<'a, ConnectorResult<()>> {
         let update = Update::table(self.flavour().migrations_table())
             .so_that(Column::from("id").equals(id))
             .set("finished_at", chrono::Utc::now()); // TODO maybe use a database generated timestamp
+        Box::pin(async move {
+            self.flavour.query(update.into()).await?;
 
-        self.flavour.query(update.into()).await?;
-
-        Ok(())
+            Ok(())
+        })
     }
 
     #[tracing::instrument(skip(self))]
-    async fn list_migrations(
+    fn list_migrations(
         &mut self,
-    ) -> ConnectorResult<Result<Vec<MigrationRecord>, PersistenceNotInitializedError>> {
-        let select = Select::from_table(self.flavour().migrations_table())
-            .column("id")
-            .column("checksum")
-            .column("finished_at")
-            .column("migration_name")
-            .column("logs")
-            .column("rolled_back_at")
-            .column("started_at")
-            .column("applied_steps_count")
-            .order_by("started_at".ascend());
+    ) -> BoxFuture<'_, ConnectorResult<Result<Vec<MigrationRecord>, PersistenceNotInitializedError>>> {
+        Box::pin(async move {
+            let select = Select::from_table(self.flavour().migrations_table())
+                .column("id")
+                .column("checksum")
+                .column("finished_at")
+                .column("migration_name")
+                .column("logs")
+                .column("rolled_back_at")
+                .column("started_at")
+                .column("applied_steps_count")
+                .order_by("started_at".ascend());
 
-        let rows = match self.flavour.query(select.into()).await {
-            Ok(result) => result,
-            Err(err)
-                if err.is_user_facing_error::<user_facing_errors::query_engine::TableDoesNotExist>()
-                    || err.is_user_facing_error::<user_facing_errors::common::InvalidModel>() =>
-            {
-                return Ok(Err(PersistenceNotInitializedError))
-            }
-            err @ Err(_) => err?,
-        };
+            let rows = match self.flavour.query(select.into()).await {
+                Ok(result) => result,
+                Err(err)
+                    if err.is_user_facing_error::<user_facing_errors::query_engine::TableDoesNotExist>()
+                        || err.is_user_facing_error::<user_facing_errors::common::InvalidModel>() =>
+                {
+                    return Ok(Err(PersistenceNotInitializedError))
+                }
+                err @ Err(_) => err?,
+            };
 
-        let rows = rows
-            .into_iter()
-            .map(|row| -> ConnectorResult<_> {
-                Ok(MigrationRecord {
-                    id: row.get("id").and_then(|v| v.to_string()).ok_or_else(|| {
-                        ConnectorError::from_msg("Failed to extract `id` from `_prisma_migrations` row.".into())
-                    })?,
-                    checksum: row.get("checksum").and_then(|v| v.to_string()).ok_or_else(|| {
-                        ConnectorError::from_msg("Failed to extract `checksum` from `_prisma_migrations` row.".into())
-                    })?,
-                    finished_at: row.get("finished_at").and_then(|v| v.as_datetime()),
-                    migration_name: row.get("migration_name").and_then(|v| v.to_string()).ok_or_else(|| {
-                        ConnectorError::from_msg(
-                            "Failed to extract `migration_name` from `_prisma_migrations` row.".into(),
-                        )
-                    })?,
-                    logs: None,
-                    rolled_back_at: row.get("rolled_back_at").and_then(|v| v.as_datetime()),
-                    started_at: row.get("started_at").and_then(|v| v.as_datetime()).ok_or_else(|| {
-                        ConnectorError::from_msg("Failed to extract `started_at` from `_prisma_migrations` row.".into())
-                    })?,
-                    applied_steps_count: row.get("applied_steps_count").and_then(|v| v.as_integer()).ok_or_else(
-                        || {
+            let rows = rows
+                .into_iter()
+                .map(|row| -> ConnectorResult<_> {
+                    Ok(MigrationRecord {
+                        id: row.get("id").and_then(|v| v.to_string()).ok_or_else(|| {
+                            ConnectorError::from_msg("Failed to extract `id` from `_prisma_migrations` row.".into())
+                        })?,
+                        checksum: row.get("checksum").and_then(|v| v.to_string()).ok_or_else(|| {
                             ConnectorError::from_msg(
-                                "Failed to extract `applied_steps_count` from `_prisma_migrations` row.".into(),
+                                "Failed to extract `checksum` from `_prisma_migrations` row.".into(),
                             )
-                        },
-                    )? as u32,
+                        })?,
+                        finished_at: row.get("finished_at").and_then(|v| v.as_datetime()),
+                        migration_name: row.get("migration_name").and_then(|v| v.to_string()).ok_or_else(|| {
+                            ConnectorError::from_msg(
+                                "Failed to extract `migration_name` from `_prisma_migrations` row.".into(),
+                            )
+                        })?,
+                        logs: None,
+                        rolled_back_at: row.get("rolled_back_at").and_then(|v| v.as_datetime()),
+                        started_at: row.get("started_at").and_then(|v| v.as_datetime()).ok_or_else(|| {
+                            ConnectorError::from_msg(
+                                "Failed to extract `started_at` from `_prisma_migrations` row.".into(),
+                            )
+                        })?,
+                        applied_steps_count: row.get("applied_steps_count").and_then(|v| v.as_integer()).ok_or_else(
+                            || {
+                                ConnectorError::from_msg(
+                                    "Failed to extract `applied_steps_count` from `_prisma_migrations` row.".into(),
+                                )
+                            },
+                        )? as u32,
+                    })
                 })
-            })
-            .collect::<Result<Vec<_>, _>>()?;
+                .collect::<Result<Vec<_>, _>>()?;
 
-        tracing::debug!("Found {} migrations in the migrations table.", rows.len());
+            tracing::debug!("Found {} migrations in the migrations table.", rows.len());
 
-        Ok(Ok(rows))
+            Ok(Ok(rows))
+        })
     }
 }

--- a/migration-engine/core/Cargo.toml
+++ b/migration-engine/core/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Marcus Böhm <boehm@prisma.io>", "Julius de Bruijn <bruijn@prisma.io>"]
 edition = "2021"
 name = "migration-core"
 version = "0.1.0"

--- a/migration-engine/migration-engine-tests/Cargo.toml
+++ b/migration-engine/migration-engine-tests/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "migration-engine-tests"
 version = "0.1.0"
-authors = ["Tom Houlé <tom@tomhoule.com>"]
 edition = "2021"
 
 [dependencies]
@@ -15,7 +14,6 @@ test-macros = { path = "../../libs/test-macros" }
 test-setup = { path = "../../libs/test-setup" }
 prisma-value = { path = "../../libs/prisma-value" }
 
-async-trait = "0.1.0"
 bigdecimal = "0.2"
 chrono = "0.4.15"
 connection-string = "0.1.13"

--- a/migration-engine/qe-setup/Cargo.toml
+++ b/migration-engine/qe-setup/Cargo.toml
@@ -8,7 +8,6 @@ datamodel = { path = "../../libs/datamodel/core" }
 mongodb-client = { path = "../../libs/mongodb-client" }
 migration-core = { path = "../core" }
 
-async-trait = "0.1.52"
 connection-string = "*"
 enumflags2 = "*"
 mongodb = "2.1.0"


### PR DESCRIPTION
- It produces worse compiler errors
- It obscures what is actually going on
- It's an extra dependency that brings in the whole proc macro machinery

I measured single-crate compile times for sql-migration connector before
942313679488ec2183105c6b3b2aa9d09459254c, at
942313679488ec2183105c6b3b2aa9d09459254c and with this commit. Together,
the two commits represent a ~1 second improvement (bringing compile time for the crate to ~5 seconds), with each one
contributing about half of it.