### PR TITLE
Structured errors for parsing overflowing ints

### DIFF
--- a/libs/user-facing-errors/src/query_engine.rs
+++ b/libs/user-facing-errors/src/query_engine.rs
@@ -324,3 +324,10 @@ pub struct MissingFieldsInModel {
     pub expected_type: String,
     pub found: String,
 }
+
+#[derive(Debug, UserFacingError, Serialize)]
+#[user_facing(code = "P2033", message = "{details}")]
+
+pub struct ValueFitError {
+    pub details: String,
+}

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/max_integer.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/max_integer.rs
@@ -14,27 +14,101 @@ mod max_integer {
     }
 
     #[connector_test]
-    async fn panics_gql_parser(runner: Runner) -> TestResult<()> {
+    async fn transform_gql_parser_too_large(runner: Runner) -> TestResult<()> {
+        assert_error!(
+            runner,
+            "mutation { createOneTest(data: { id: 1, int: 100000000000000000000 }) { id int } }",
+            2033,
+            "A number used in the query does not fit into a 64 bit signed integer. Consider using `BigInt` as field type if you're trying to store large integers."
+        );
+
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn transform_gql_parser_too_small(runner: Runner) -> TestResult<()> {
+        assert_error!(
+            runner,
+            "mutation { createOneTest(data: { id: 1, int: -100000000000000000000 }) { id int } }",
+            2033,
+            "A number used in the query does not fit into a 64 bit signed integer. Consider using `BigInt` as field type if you're trying to store large integers."
+        );
+
+        Ok(())
+    }
+
+    // The document parser does not crash on encountering an exponent-notation-serialized int.
+    // This triggers a 2009 instead of 2033 as this is in the document parser.
+    #[connector_test]
+    async fn document_parser_no_crash_too_large(runner: Runner) -> TestResult<()> {
+        assert_error!(
+            runner,
+            "mutation { createOneTest(data: { id: 1, int: 1e20 }) { id int } }",
+            2009,
+            "Unable to fit float value (or large JS integer serialized in exponent notation) '100000000000000000000' into a 64 Bit signed integer for field 'int'. If you're trying to store large integers, consider using `BigInt`"
+        );
+
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn document_parser_no_crash_too_small(runner: Runner) -> TestResult<()> {
+        assert_error!(
+            runner,
+            "mutation { createOneTest(data: { id: 1, int: -1e20 }) { id int } }",
+            2009,
+            "Unable to fit float value (or large JS integer serialized in exponent notation) '-100000000000000000000' into a 64 Bit signed integer for field 'int'. If you're trying to store large integers, consider using `BigInt`"
+        );
+
+        Ok(())
+    }
+
+    // This will not work anymore in the future as we'll redo the float / decimal story. Right now this "works" because floats are deserialized as BigDecimal.
+    #[connector_test]
+    async fn document_parser_no_crash_ridiculously_big(runner: Runner) -> TestResult<()> {
+        assert_error!(
+            runner,
+            "mutation { createOneTest(data: { id: 1, int: 1e100 }) { id int } }",
+            2009,
+            "Unable to fit float value (or large JS integer serialized in exponent notation) '10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000' into a 64 Bit signed integer for field 'int'. If you're trying to store large integers, consider using `BigInt`"
+        );
+
+        Ok(())
+    }
+}
+
+#[test_suite(schema(schema))]
+mod float_serialization_issues {
+    fn schema() -> String {
+        let schema = indoc! {r#"
+        model Test {
+            id    Int   @id
+            float Float
+        }
+        "#};
+
+        schema.to_string()
+    }
+
+    #[connector_test]
+    async fn int_range_overlap_works(runner: Runner) -> TestResult<()> {
         runner
-            .query(format!(
-                "mutation {{ createOneTest(data: {{ id: 1, int: {} }}) {{ id int }} }}",
-                "100000000000000000000"
-            ))
+            .query("mutation { createOneTest(data: { id: 1, float: 1e20 }) { id float } }")
             .await?
             .assert_success();
 
         Ok(())
     }
 
+    // The same number as above, just not in the exponent notation. That one fails, because f64 can represent the number, i64 can't.
     #[connector_test]
-    async fn panics_250_87(runner: Runner) -> TestResult<()> {
-        runner
-            .query(format!(
-                "mutation {{ createOneTest(data: {{ id: 1, int: {} }}) {{ id int }} }}",
-                "1e22"
-            ))
-            .await?
-            .assert_success();
+    async fn int_range_overlap_fails(runner: Runner) -> TestResult<()> {
+        assert_error!(
+            runner,
+            "mutation { createOneTest(data: { id: 1, float: 100000000000000000000 }) { id float } }",
+            2033,
+            "A number used in the query does not fit into a 64 bit signed integer. Consider using `BigInt` as field type if you're trying to store large integers."
+        );
 
         Ok(())
     }

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/max_integer.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/max_integer.rs
@@ -5,7 +5,7 @@ mod max_integer {
     fn schema() -> String {
         let schema = indoc! {r#"
         model Test {
-            id  Int @id
+            #id(id, Int, @id)
             int Int
         }
         "#};
@@ -82,7 +82,7 @@ mod float_serialization_issues {
     fn schema() -> String {
         let schema = indoc! {r#"
         model Test {
-            id    Int   @id
+            #id(id, Int, @id)
             float Float
         }
         "#};
@@ -90,7 +90,7 @@ mod float_serialization_issues {
         schema.to_string()
     }
 
-    #[connector_test]
+    #[connector_test(exclude(SqlServer))]
     async fn int_range_overlap_works(runner: Runner) -> TestResult<()> {
         runner
             .query("mutation { createOneTest(data: { id: 1, float: 1e20 }) { id float } }")

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/max_integer.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/max_integer.rs
@@ -1,0 +1,41 @@
+use query_engine_tests::*;
+
+#[test_suite(schema(schema))]
+mod max_integer {
+    fn schema() -> String {
+        let schema = indoc! {r#"
+        model Test {
+            id  Int @id
+            int Int
+        }
+        "#};
+
+        schema.to_string()
+    }
+
+    #[connector_test]
+    async fn panics_gql_parser(runner: Runner) -> TestResult<()> {
+        runner
+            .query(format!(
+                "mutation {{ createOneTest(data: {{ id: 1, int: {} }}) {{ id int }} }}",
+                "100000000000000000000"
+            ))
+            .await?
+            .assert_success();
+
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn panics_250_87(runner: Runner) -> TestResult<()> {
+        runner
+            .query(format!(
+                "mutation {{ createOneTest(data: {{ id: 1, int: {} }}) {{ id int }} }}",
+                "1e22"
+            ))
+            .await?
+            .assert_success();
+
+        Ok(())
+    }
+}

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
@@ -1,3 +1,4 @@
+mod max_integer;
 mod prisma_10098;
 mod prisma_12929;
 mod prisma_6173;

--- a/query-engine/core/src/query_document/error.rs
+++ b/query-engine/core/src/query_document/error.rs
@@ -42,6 +42,10 @@ impl QueryPath {
         path.segments.push(segment);
         path
     }
+
+    pub fn last(&self) -> Option<&str> {
+        self.segments.last().map(|s| s.as_str())
+    }
 }
 
 impl fmt::Display for QueryPath {
@@ -60,6 +64,7 @@ pub enum QueryParserErrorKind {
     ValueParseError(String),
     ValueTypeMismatchError { have: QueryValue, want: InputType },
     InputUnionParseError { parsing_errors: Vec<QueryParserError> },
+    ValueFitError(String),
 }
 
 impl Display for QueryParserErrorKind {
@@ -83,6 +88,7 @@ impl Display for QueryParserErrorKind {
             Self::ValueTypeMismatchError { have, want } => {
                 write!(f, "Value types mismatch. Have: {:?}, want: {:?}", have, want)
             }
+            Self::ValueFitError(s) => write!(f, "{}", s),
         }
     }
 }

--- a/query-engine/core/src/query_document/parser.rs
+++ b/query-engine/core/src/query_document/parser.rs
@@ -243,8 +243,12 @@ impl QueryDocumentParser {
             (QueryValue::Int(i), ScalarType::BigInt) => Ok(PrismaValue::BigInt(i)),
 
             (QueryValue::Float(f), ScalarType::Float) => Ok(PrismaValue::Float(f)),
-            (QueryValue::Float(f), ScalarType::Int) => Ok(PrismaValue::Int(f.to_i64().unwrap())),
-            (QueryValue::Float(d), ScalarType::Decimal) => Ok(PrismaValue::Float(d)),
+            (QueryValue::Float(f), ScalarType::Decimal) => Ok(PrismaValue::Float(f)),
+            (QueryValue::Float(f), ScalarType::Int) => match f.to_i64() {
+                Some(converted) => Ok(PrismaValue::Int(converted)),
+                None => Err(QueryParserError::new(parent_path.clone(), QueryParserErrorKind::ValueFitError(
+                    format!("Unable to fit float value (or large JS integer serialized in exponent notation) '{}' into a 64 Bit signed integer for field '{}'. If you're trying to store large integers, consider using `BigInt`.", f, parent_path.last().unwrap())))),
+            },
 
             (QueryValue::Boolean(b), ScalarType::Boolean) => Ok(PrismaValue::Boolean(b)),
 

--- a/query-engine/request-handlers/src/graphql/body.rs
+++ b/query-engine/request-handlers/src/graphql/body.rs
@@ -1,11 +1,9 @@
+use super::GraphQLProtocolAdapter;
+use crate::HandlerError;
 use graphql_parser as gql;
 use query_core::{BatchDocument, Operation, QueryDocument};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-
-use crate::HandlerError;
-
-use super::GraphQLProtocolAdapter;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", untagged)]

--- a/query-engine/request-handlers/src/graphql/body.rs
+++ b/query-engine/request-handlers/src/graphql/body.rs
@@ -56,8 +56,11 @@ impl GraphQlBody {
             GraphQlBody::Single(body) => {
                 let gql_doc = match gql::parse_query(&body.query) {
                     Ok(doc) => doc,
-                    Err(err) if err.to_string().contains("number too large to fit in target type") | err.to_string().contains("number too small to fit in target type") => {
-                        Err(HandlerError::ValueFitError("Query parsing failure: A number used in the query does not fit into a 64 bit signed integer. Consider using `BigInt` as field type if you're trying to store large integers.".to_owned()))?
+                    Err(err)
+                        if err.to_string().contains("number too large to fit in target type")
+                            | err.to_string().contains("number too small to fit in target type") =>
+                    {
+                        return Err(HandlerError::ValueFitError("Query parsing failure: A number used in the query does not fit into a 64 bit signed integer. Consider using `BigInt` as field type if you're trying to store large integers.".to_owned()));
                     }
                     err @ Err(_) => err?,
                 };

--- a/query-engine/request-handlers/src/graphql/body.rs
+++ b/query-engine/request-handlers/src/graphql/body.rs
@@ -57,7 +57,7 @@ impl GraphQlBody {
                 let gql_doc = match gql::parse_query(&body.query) {
                     Ok(doc) => doc,
                     Err(err) if err.to_string().contains("number too large to fit in target type") | err.to_string().contains("number too small to fit in target type") => {
-                        Err(HandlerError::ValueFitError(format!("Query parsing failure: A number used in the query does not fit into a 64 bit signed integer. Consider using `BigInt` as field type if you're trying to store large integers.")))?
+                        Err(HandlerError::ValueFitError("Query parsing failure: A number used in the query does not fit into a 64 bit signed integer. Consider using `BigInt` as field type if you're trying to store large integers.".to_owned()))?
                     }
                     err @ Err(_) => err?,
                 };

--- a/query-engine/request-handlers/src/graphql/handler.rs
+++ b/query-engine/request-handlers/src/graphql/handler.rs
@@ -35,7 +35,10 @@ impl<'a> GraphQlHandler<'a> {
                 }
                 BatchDocument::Compact(compacted) => self.handle_compacted(compacted, tx_id, trace_id).await,
             },
-            Err(err) => PrismaResponse::Single(err.into()),
+            Err(err) => match err.as_known_error() {
+                Some(transformed) => PrismaResponse::Single(user_facing_errors::Error::new_known(transformed).into()),
+                None => PrismaResponse::Single(err.into()),
+            },
         }
     }
 


### PR DESCRIPTION
Related issues:
- https://github.com/prisma/prisma/issues/12651 (only partially addresses this ticket!)
- https://github.com/prisma/prisma/issues/12526
- https://github.com/prisma/prisma/issues/12737
- https://github.com/prisma/prisma/issues/12841
- https://github.com/prisma/prisma/issues/12491
- https://github.com/prisma/prisma/issues/10586
- https://github.com/prisma/prisma/issues/12654
- https://github.com/prisma/prisma/issues/10049
- https://github.com/prisma/prisma/issues/12969
- https://github.com/prisma/prisma/issues/11467
- https://github.com/prisma/prisma/issues/11263
- https://github.com/prisma/prisma/issues/9896
- https://github.com/prisma/prisma/issues/13293

Makes sure the engine doesn't crash on encountering an integer serialized as float that is outside of the i64 range (surfaced as P2009). Introduces a less concrete P2033 error code for when the GraphQL parser errors on an int that doesn't fit. The reason for the separate error is that we have very little actual information on that parsing stage, plus the later parsing error (where the unwrap tickets point to) is on a completely different layer with more info, which can't easily be propagated as a different error code than the enclosing parser error (P2009).

Example P2009: 
```
Unable to fit float value (or large JS integer serialized in exponent notation) '100000000000000000000' into a 64 Bit signed integer for field 'int'. If you're trying to store large integers, consider using `BigInt`
```

Example P2033:
```
A number used in the query does not fit into a 64 bit signed integer. Consider using `BigInt` as field type if you're trying to store large integers.
```