### PR TITLE
chore(qe): cleaner logs

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -20,7 +20,7 @@ export SIMPLE_TEST_MODE="yes" # Reduces the amount of generated `relation_link_t
 
 ### QE specific logging vars ###
 export QE_LOG_LEVEL=debug # Set it to "trace" to enable query-graph debugging logs
-# export QUAINT_FMT_SQL=1 # Uncomment it to enable logging formatted SQL queries
+# export FMT_SQL=1 # Uncomment it to enable logging formatted SQL queries
 
 # Mongo image requires additional wait time on arm arch for some reason.
 if uname -a | grep -q 'arm64'; then

--- a/.envrc
+++ b/.envrc
@@ -19,7 +19,7 @@ export LOG_LEVEL=trace
 export SIMPLE_TEST_MODE="yes" # Reduces the amount of generated `relation_link_test` tests. Remove the export entirely to disable it.
 
 ### QE specific logging vars ###
-export QE_LOG_LEVEL=trace # Set it to "trace" to enable query-graph debugging logs
+export QE_LOG_LEVEL=debug # Set it to "trace" to enable query-graph debugging logs
 # export QUAINT_FMT_SQL=1 # Uncomment it to enable logging formatted SQL queries
 
 # Mongo image requires additional wait time on arm arch for some reason.

--- a/.envrc
+++ b/.envrc
@@ -2,7 +2,7 @@
 export WORKSPACE_ROOT=$(pwd)
 export RUST_LOG_FORMAT=devel
 export RUST_BACKTRACE=1
-export RUST_LOG=query_engine_tests=trace,query_engine=debug,query_core=trace,query_connector=debug,sql_query_connector=debug,prisma_models=debug,engineer=info,sql_introspection_connector=debug,tiberius=trace,quaint=debug,mongodb_query_connector=trace
+export RUST_LOG=query_engine_tests=trace,query_engine=debug,query_core=debug,query_connector=debug,sql_query_connector=debug,prisma_models=debug,engineer=info,sql_introspection_connector=debug,tiberius=trace,quaint=debug,mongodb_query_connector=trace
 
 ### Various local dev env vars ###
 export PRISMA_DML_PATH=$(pwd)/dev_datamodel.prisma
@@ -17,6 +17,10 @@ export CLOSED_TX_CLEANUP=2 # Time in seconds when a closed interactive transacti
 ### QE test setup vars ###
 export LOG_LEVEL=trace
 export SIMPLE_TEST_MODE="yes" # Reduces the amount of generated `relation_link_test` tests. Remove the export entirely to disable it.
+
+### QE specific logging vars ###
+export QE_LOG_LEVEL=trace # Set it to "trace" to enable query-graph debugging logs
+# export QUAINT_FMT_SQL=1 # Uncomment it to enable logging formatted SQL queries
 
 # Mongo image requires additional wait time on arm arch for some reason.
 if uname -a | grep -q 'arm64'; then

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3174,7 +3174,7 @@ dependencies = [
 [[package]]
 name = "quaint"
 version = "0.2.0-alpha.13"
-source = "git+https://github.com/prisma/quaint#231346a221ab6705913c7efb40a133c2fcc7e9b4"
+source = "git+https://github.com/prisma/quaint#a97e758b28d82b429998ea5bbf335b77d8379f7b"
 dependencies = [
  "async-trait",
  "base64 0.12.3",
@@ -3199,6 +3199,7 @@ dependencies = [
  "postgres-types",
  "rusqlite",
  "serde_json",
+ "sqlformat",
  "thiserror",
  "tiberius",
  "tokio",
@@ -3955,7 +3956,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0bccbcf40c8938196944a3da0e133e031a33f4d6b72db3bda3cc556e361905d"
 dependencies = [
  "lazy_static",
- "parking_lot 0.11.2",
+ "parking_lot 0.10.2",
  "serial_test_derive",
 ]
 
@@ -4246,6 +4247,17 @@ dependencies = [
  "tracing",
  "tracing-error",
  "tracing-futures",
+]
+
+[[package]]
+name = "sqlformat"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87e292b4291f154971a43c3774364e2cbcaec599d3f5bf6fa9d122885dbc38a"
+dependencies = [
+ "itertools",
+ "nom",
+ "unicode_categories",
 ]
 
 [[package]]
@@ -4946,7 +4958,7 @@ version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f559b464de2e2bdabcac6a210d12e9b5a5973c251e102c44c585c71d51bd78e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "rand 0.8.4",
  "static_assertions",
 ]
@@ -5006,6 +5018,12 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "unindent"

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ change any time. There is no guaranteed API stability.
 
 Notable environment flags:
 - `RUST_LOG_FORMAT=(devel|json)` sets the log format. By default outputs `json`.
+- `QE_LOG_LEVEL=(info|debug|trace)` sets the log level for the Query Engine. If you need Query Graph debugging logs, set it to "trace"
+- `FMT_SQL=1` enables logging _formatted_ SQL queries
 - `PRISMA_DML_PATH=[path_to_datamodel_file]` should point to the datamodel file
   location. This or `PRISMA_DML` is required for the Query Engine to run.
 - `PRISMA_DML=[base64_encoded_datamodel]` an alternative way to provide a

--- a/query-engine/connectors/query-connector/src/filter/relation.rs
+++ b/query-engine/connectors/query-connector/src/filter/relation.rs
@@ -3,7 +3,7 @@ use crate::filter::Filter;
 use prisma_models::RelationField;
 use std::sync::Arc;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct RelationFilter {
     /// Starting field of the relation traversal.
     pub field: Arc<RelationField>,
@@ -15,6 +15,16 @@ pub struct RelationFilter {
     /// E.g. if all related records or only some need
     /// to fulfill `nested_filter`.
     pub condition: RelationCondition,
+}
+
+impl std::fmt::Debug for RelationFilter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RelationFilter")
+            .field("field", &format!("{}", self.field))
+            .field("nested_filter", &self.nested_filter)
+            .field("condition", &self.condition)
+            .finish()
+    }
 }
 
 impl RelationFilter {

--- a/query-engine/connectors/query-connector/src/filter/scalar.rs
+++ b/query-engine/connectors/query-connector/src/filter/scalar.rs
@@ -3,13 +3,30 @@ use crate::{compare::ScalarCompare, JsonFilterPath, JsonTargetType};
 use prisma_models::{FieldSelection, ModelProjection, PrismaListValue, PrismaValue, ScalarFieldRef};
 use std::{collections::BTreeSet, sync::Arc};
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub enum ScalarProjection {
     /// A single field projection.
     Single(ScalarFieldRef),
 
     /// A tuple projection, e.g. if (a, b) <in> ((1, 2), (1, 3), ...) is supposed to be queried.
     Compound(Vec<ScalarFieldRef>),
+}
+
+impl std::fmt::Debug for ScalarProjection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Single(sf) => f.debug_tuple("SingleProjection").field(&format!("{sf}")).finish(),
+            Self::Compound(sfs) => {
+                let mut dbg = f.debug_tuple("CompoundProjection");
+
+                for sf in sfs {
+                    dbg.field(&format!("{sf}"));
+                }
+
+                dbg.finish()
+            }
+        }
+    }
 }
 
 impl ScalarProjection {

--- a/query-engine/connectors/query-connector/src/query_arguments.rs
+++ b/query-engine/connectors/query-connector/src/query_arguments.rs
@@ -19,7 +19,7 @@ pub struct SkipAndLimit {
 /// A query argument struct is always valid over a single model only, meaning that all
 /// data referenced in a single query argument instance is always refering to data of
 /// a single model (e.g. the cursor projection, distinct projection, orderby, ...).
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct QueryArguments {
     pub model: ModelRef,
     pub cursor: Option<SelectionResult>,
@@ -30,6 +30,22 @@ pub struct QueryArguments {
     pub distinct: Option<FieldSelection>,
     pub ignore_skip: bool,
     pub ignore_take: bool,
+}
+
+impl std::fmt::Debug for QueryArguments {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("QueryArguments")
+            .field("model", &self.model.name)
+            .field("cursor", &self.cursor)
+            .field("take", &self.take)
+            .field("skip", &self.skip)
+            .field("filter", &self.filter)
+            .field("order_by", &self.order_by)
+            .field("distinct", &self.distinct)
+            .field("ignore_skip", &self.ignore_skip)
+            .field("ignore_take", &self.ignore_take)
+            .finish()
+    }
 }
 
 impl QueryArguments {

--- a/query-engine/connectors/sql-query-connector/Cargo.toml
+++ b/query-engine/connectors/sql-query-connector/Cargo.toml
@@ -34,6 +34,7 @@ features = [
   "mysql",
   "mssql",
   "bigdecimal",
+  "fmt-sql"
 ]
 git = "https://github.com/prisma/quaint"
 

--- a/query-engine/core/src/query_ast/read.rs
+++ b/query-engine/core/src/query_ast/read.rs
@@ -65,17 +65,17 @@ impl Display for ReadQuery {
         match self {
             Self::RecordQuery(q) => write!(
                 f,
-                "RecordQuery(name: '{}', filter: {:?}, selection: {:?})",
-                q.name, q.filter, q.selected_fields,
+                "RecordQuery(name: '{}', selection: {}, filter: {:?})",
+                q.name, q.selected_fields, q.filter
             ),
             Self::ManyRecordsQuery(q) => write!(
                 f,
-                "ManyRecordsQuery(name: '{}', model: {}, args: {:?}, selection: {:?})",
-                q.name, q.model.name, q.args, q.selected_fields
+                r#"ManyRecordsQuery(name: '{}', model: '{}', selection: {}, args: {:?})"#,
+                q.name, q.model.name, q.selected_fields, q.args
             ),
             Self::RelatedRecordsQuery(q) => write!(
                 f,
-                "RelatedRecordsQuery(name: '{}', parent model: {}, parent relation field: {}, selection: {:?})",
+                "RelatedRecordsQuery(name: '{}', parent model: '{}', parent relation field: {}, selection: {})",
                 q.name,
                 q.parent_field.model().name,
                 q.parent_field.name,

--- a/query-engine/prisma-models/src/field/composite.rs
+++ b/query-engine/prisma-models/src/field/composite.rs
@@ -1,7 +1,7 @@
 use crate::{parent_container::ParentContainer, CompositeTypeRef};
 use datamodel::dml::FieldArity;
 use std::{
-    fmt::Debug,
+    fmt::{Debug, Display},
     hash::{Hash, Hasher},
     sync::{Arc, Weak},
 };
@@ -48,6 +48,12 @@ impl Debug for CompositeField {
             .field("container", &self.container)
             .field("composite_type", &self.typ.name)
             .finish()
+    }
+}
+
+impl Display for CompositeField {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{}", self.container().name(), self.name)
     }
 }
 

--- a/query-engine/prisma-models/src/field/relation.rs
+++ b/query-engine/prisma-models/src/field/relation.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 use dml::{FieldArity, ReferentialAction, RelationInfo};
 use once_cell::sync::OnceCell;
 use std::{
-    fmt::Debug,
+    fmt::{Debug, Display},
     hash::{Hash, Hasher},
     sync::{Arc, Weak},
 };
@@ -245,6 +245,12 @@ impl Debug for RelationField {
             .field("model", &"#ModelWeakRef#")
             .field("fields", &self.fields)
             .finish()
+    }
+}
+
+impl Display for RelationField {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{}", self.model().name, self.name)
     }
 }
 

--- a/query-engine/prisma-models/src/field/scalar.rs
+++ b/query-engine/prisma-models/src/field/scalar.rs
@@ -2,7 +2,7 @@ use crate::{parent_container::ParentContainer, prelude::*, InternalEnum};
 use dml::{DefaultValue, FieldArity, NativeTypeInstance};
 use once_cell::sync::OnceCell;
 use std::{
-    fmt::Debug,
+    fmt::{Debug, Display},
     hash::{Hash, Hasher},
     sync::{Arc, Weak},
 };
@@ -87,6 +87,12 @@ impl Debug for ScalarField {
             .field("is_unique", &self.is_unique)
             .field("read_only", &self.read_only)
             .finish()
+    }
+}
+
+impl Display for ScalarField {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{}", self.container().name(), self.name)
     }
 }
 

--- a/query-engine/prisma-models/src/field_selection.rs
+++ b/query-engine/prisma-models/src/field_selection.rs
@@ -295,11 +295,11 @@ impl Display for FieldSelection {
 impl Display for SelectedField {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            SelectedField::Scalar(sf) => write!(f, "{}", sf.name),
+            SelectedField::Scalar(sf) => write!(f, "{sf}"),
             SelectedField::Composite(cs) => write!(
                 f,
                 "{} {{ {} }}",
-                cs.field.name,
+                cs.field,
                 cs.selections
                     .iter()
                     .map(|selection| format!("{}", selection))

--- a/query-engine/prisma-models/src/order_by.rs
+++ b/query-engine/prisma-models/src/order_by.rs
@@ -103,10 +103,19 @@ impl OrderBy {
 }
 
 /// Describes a hop over to a relation or composite for an orderBy statement.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub enum OrderByHop {
     Relation(RelationFieldRef),
     Composite(CompositeFieldRef),
+}
+
+impl std::fmt::Debug for OrderByHop {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Relation(rf) => f.debug_tuple("Relation").field(&format!("{rf}")).finish(),
+            Self::Composite(cf) => f.debug_tuple("Composite").field(&format!("{cf}")).finish(),
+        }
+    }
 }
 
 impl OrderByHop {

--- a/query-engine/prisma-models/src/selection_result.rs
+++ b/query-engine/prisma-models/src/selection_result.rs
@@ -1,10 +1,25 @@
 use crate::{DomainError, FieldSelection, PrismaValue, ScalarFieldRef, SelectedField};
+use itertools::Itertools;
 use std::convert::TryFrom;
 
 /// Represents a set of results.
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Clone, PartialEq, Eq, Hash)]
 pub struct SelectionResult {
     pub pairs: Vec<(SelectedField, PrismaValue)>,
+}
+
+impl std::fmt::Debug for SelectionResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_list()
+            .entries(
+                &self
+                    .pairs
+                    .iter()
+                    .map(|pair| (format!("{}", pair.0), pair.1.clone()))
+                    .collect_vec(),
+            )
+            .finish()
+    }
 }
 
 impl SelectionResult {

--- a/query-engine/query-engine/src/logger.rs
+++ b/query-engine/query-engine/src/logger.rs
@@ -64,6 +64,15 @@ impl<'a> Logger<'a> {
             .add_directive("hyper=error".parse().unwrap())
             .add_directive("tower=error".parse().unwrap());
 
+        if let Some(qe_log_level) = std::env::var("QE_LOG_LEVEL").ok() {
+            filter = filter
+                .add_directive(format!("query_engine={}", &qe_log_level).parse().unwrap())
+                .add_directive(format!("query_core={}", &qe_log_level).parse().unwrap())
+                .add_directive(format!("query_connector={}", &qe_log_level).parse().unwrap())
+                .add_directive(format!("sql_query_connector={}", &qe_log_level).parse().unwrap())
+                .add_directive(format!("mongodb_query_connector={}", &qe_log_level).parse().unwrap());
+        }
+
         if self.log_queries {
             filter = filter.add_directive("quaint[{is_query}]=trace".parse().unwrap());
         }

--- a/query-engine/query-engine/src/logger.rs
+++ b/query-engine/query-engine/src/logger.rs
@@ -64,7 +64,7 @@ impl<'a> Logger<'a> {
             .add_directive("hyper=error".parse().unwrap())
             .add_directive("tower=error".parse().unwrap());
 
-        if let Some(qe_log_level) = std::env::var("QE_LOG_LEVEL").ok() {
+        if let Ok(qe_log_level) = std::env::var("QE_LOG_LEVEL") {
             filter = filter
                 .add_directive(format!("query_engine={}", &qe_log_level).parse().unwrap())
                 .add_directive(format!("query_core={}", &qe_log_level).parse().unwrap())


### PR DESCRIPTION
## Overview

- Makes default log level for all QE crates `debug`. _That means query graph logs are not enabled by default._
- Adds a new `QE_LOG_LEVEL` env var to easily set the log level back to trace if needed
- Shortens query graph logs with various custom debug implementations
- Enables logging formatted SQL queries thanks to the `FMT_SQL=1` env var

### Query logs improvements

Considering this `findMany` query:

```graphql
{
  findManyTestModel(
    where: { toOne: { id: 1 } },
    cursor: { id: 1 },
    orderBy: { toOne: { children: { _count: asc } } }
  ) {
    id
  }
}

```

#### Before

(Scroll to the right to see the length of the logs)

```
2022-05-13T14:23:23.348665Z  INFO query_engine::server: Started query engine http server on http://127.0.0.1:4466
2022-05-13T14:23:29.762720Z TRACE query_core::query_graph_builder::builder: ---- Query Graph ----
Result Nodes: []
Marked Nodes: []
Root Nodes: [Node 0]

Node 0: ManyRecordsQuery(name: 'findManyTestModel', model: TestModel, args: QueryArguments { model: Model { name: "TestModel", manifestation: None, fields: OnceCell(Fields { all: [Scalar(ScalarField { name: "id", type_identifier: Int, is_id: true, is_auto_generated_int_id: false, is_autoincrement: false, internal_enum: None, is_updated_at: false, arity: Required, db_name: Some("_id"), default_value: None, model: "TestModel", is_unique: false, read_only: OnceCell(false) }), Scalar(ScalarField { name: "name", type_identifier: String, is_id: false, is_auto_generated_int_id: false, is_autoincrement: false, internal_enum: None, is_updated_at: false, arity: Required, db_name: None, default_value: None, model: "TestModel", is_unique: false, read_only: OnceCell(false) }), Relation(RelationField { name: "toOne", arity: Optional, relation_name: "TestModelToToOne", relation_side: A, relation: OnceCell((Weak)), relation_info: RelationInfo { to: "ToOne", fields: ["toOneId"], references: ["id"], name: "TestModelToToOne", fk_name: Some("TestModel_toOneId_fkey"), on_delete: None, on_update: None }, model: "#ModelWeakRef#", fields: OnceCell([(Weak)]) }), Scalar(ScalarField { name: "toOneId", type_identifier: Int, is_id: false, is_auto_generated_int_id: false, is_autoincrement: false, internal_enum: None, is_updated_at: false, arity: Optional, db_name: None, default_value: None, model: "TestModel", is_unique: false, read_only: OnceCell(true) }), Relation(RelationField { name: "RelationModel", arity: List, relation_name: "RelationModelToTestModel", relation_side: B, relation: OnceCell((Weak)), relation_info: RelationInfo { to: "RelationModel", fields: [], references: [], name: "RelationModelToTestModel", fk_name: None, on_delete: None, on_update: None }, model: "#ModelWeakRef#", fields: OnceCell(Uninit) })], primary_key: Some(PrimaryKey { alias: None, fields: [(Weak)] }), scalar: OnceCell([(Weak), (Weak), (Weak)]), relation: OnceCell([(Weak), (Weak)]), composite: OnceCell(Uninit), model: (Weak), updated_at: OnceCell(Uninit) }), indexes: OnceCell([]), primary_identifier: OnceCell(FieldSelection { selections: [Scalar(ScalarField { name: "id", type_identifier: Int, is_id: true, is_auto_generated_int_id: false, is_autoincrement: false, internal_enum: None, is_updated_at: false, arity: Required, db_name: Some("_id"), default_value: None, model: "TestModel", is_unique: false, read_only: OnceCell(false) })] }), dml_model: Model { name: "TestModel", fields: [ScalarField(ScalarField { name: "id", field_type: Scalar(Int, None, None), arity: Required, database_name: Some("_id"), default_value: None, documentation: None, is_generated: false, is_updated_at: false, is_commented_out: false, is_ignored: false }), ScalarField(ScalarField { name: "name", field_type: Scalar(String, None, None), arity: Required, database_name: None, default_value: None, documentation: None, is_generated: false, is_updated_at: false, is_commented_out: false, is_ignored: false }), RelationField(RelationField { name: "toOne", relation_info: RelationInfo { to: "ToOne", fields: ["toOneId"], references: ["id"], name: "TestModelToToOne", fk_name: Some("TestModel_toOneId_fkey"), on_delete: None, on_update: None }, arity: Optional, referential_arity: Optional, documentation: None, is_generated: false, is_commented_out: false, is_ignored: false, supports_restrict_action: Some(true), emulates_referential_actions: Some(false) }), ScalarField(ScalarField { name: "toOneId", field_type: Scalar(Int, None, None), arity: Optional, database_name: None, default_value: None, documentation: None, is_generated: false, is_updated_at: false, is_commented_out: false, is_ignored: false }), RelationField(RelationField { name: "RelationModel", relation_info: RelationInfo { to: "RelationModel", fields: [], references: [], name: "RelationModelToTestModel", fk_name: None, on_delete: None, on_update: None }, arity: List, referential_arity: List, documentation: None, is_generated: false, is_commented_out: false, is_ignored: false, supports_restrict_action: Some(true), emulates_referential_actions: Some(false) })], documentation: None, database_name: None, indices: [], primary_key: Some(PrimaryKeyDefinition { name: None, db_name: Some("TestModel_pkey"), fields: [PrimaryKeyField { name: "id", sort_order: None, length: None }], defined_on_field: true, clustered: None }), is_generated: false, is_commented_out: false, is_ignored: false }, internal_data_model: "#InternalDataModelWeakRef#" }, cursor: Some(SelectionResult { pairs: [(Scalar(ScalarField { name: "id", type_identifier: Int, is_id: true, is_auto_generated_int_id: false, is_autoincrement: false, internal_enum: None, is_updated_at: false, arity: Required, db_name: Some("_id"), default_value: None, model: "TestModel", is_unique: false, read_only: OnceCell(false) }), Int(1))] }), take: None, skip: None, filter: Some(Relation(RelationFilter { field: RelationField { name: "toOne", arity: Optional, relation_name: "TestModelToToOne", relation_side: A, relation: OnceCell((Weak)), relation_info: RelationInfo { to: "ToOne", fields: ["toOneId"], references: ["id"], name: "TestModelToToOne", fk_name: Some("TestModel_toOneId_fkey"), on_delete: None, on_update: None }, model: "#ModelWeakRef#", fields: OnceCell([(Weak)]) }, nested_filter: Scalar(ScalarFilter { projection: Single(ScalarField { name: "id", type_identifier: Int, is_id: true, is_auto_generated_int_id: false, is_autoincrement: false, internal_enum: None, is_updated_at: false, arity: Required, db_name: Some("_id"), default_value: None, model: "ToOne", is_unique: false, read_only: OnceCell(false) }), condition: Equals(Int(1)), mode: Default }), condition: ToOneRelatedRecord })), order_by: [ToManyAggregation(OrderByToManyAggregation { path: [Relation(RelationField { name: "toOne", arity: Optional, relation_name: "TestModelToToOne", relation_side: A, relation: OnceCell((Weak)), relation_info: RelationInfo { to: "ToOne", fields: ["toOneId"], references: ["id"], name: "TestModelToToOne", fk_name: Some("TestModel_toOneId_fkey"), on_delete: None, on_update: None }, model: "#ModelWeakRef#", fields: OnceCell([(Weak)]) }), Relation(RelationField { name: "children", arity: List, relation_name: "RelationModelToToOne", relation_side: B, relation: OnceCell((Weak)), relation_info: RelationInfo { to: "RelationModel", fields: [], references: [], name: "RelationModelToToOne", fk_name: None, on_delete: None, on_update: None }, model: "#ModelWeakRef#", fields: OnceCell(Uninit) })], sort_order: Ascending, sort_aggregation: Count })], distinct: None, ignore_skip: false, ignore_take: false }, selection: FieldSelection { selections: [Scalar(ScalarField { name: "id", type_identifier: Int, is_id: true, is_auto_generated_int_id: false, is_autoincrement: false, internal_enum: None, is_updated_at: false, arity: Required, db_name: Some("_id"), default_value: None, model: "TestModel", is_unique: false, read_only: OnceCell(false) })] })
  
----------------------
2022-05-13T14:23:29.777945Z TRACE fetch_new_connection_from_pool: quaint::connector::metrics: Fetched a connection from the pool duration_ms=0 item_type="query" is_query=true result="success"
2022-05-13T14:23:29.778098Z TRACE query_core::query_graph: Visited: 0
2022-05-13T14:23:29.783152Z TRACE filter read query:query_raw{sql="SELECT \"json_test\".\"TestModel\".\"_id\" FROM \"json_test\".\"TestModel\" LEFT JOIN \"json_test\".\"ToOne\" AS \"orderby_0_ToOne\" ON (\"json_test\".\"TestModel\".\"toOneId\" = \"orderby_0_ToOne\".\"_id\") LEFT JOIN (SELECT \"json_test\".\"RelationModel\".\"toOneId\", COUNT(*) AS \"orderby_aggregator\" FROM \"json_test\".\"RelationModel\" GROUP BY \"json_test\".\"RelationModel\".\"toOneId\") AS \"orderby_0_RelationModel\" ON (\"orderby_0_ToOne\".\"_id\" = \"orderby_0_RelationModel\".\"toOneId\"), (SELECT COALESCE(\"orderby_0_RelationModel\".\"orderby_aggregator\", $1) AS \"aggr_TestModel_ToOne_0\" FROM \"json_test\".\"TestModel\" LEFT JOIN \"json_test\".\"ToOne\" AS \"orderby_0_ToOne\" ON (\"json_test\".\"TestModel\".\"toOneId\" = \"orderby_0_ToOne\".\"_id\") LEFT JOIN (SELECT \"json_test\".\"RelationModel\".\"toOneId\", COUNT(*) AS \"orderby_aggregator\" FROM \"json_test\".\"RelationModel\" GROUP BY \"json_test\".\"RelationModel\".\"toOneId\") AS \"orderby_0_RelationModel\" ON (\"orderby_0_ToOne\".\"_id\" = \"orderby_0_RelationModel\".\"toOneId\") WHERE (\"json_test\".\"TestModel\".\"_id\") = ($2)) AS \"order_cmp\" WHERE ((\"json_test\".\"TestModel\".\"_id\") IN (SELECT \"t0\".\"_id\" FROM \"json_test\".\"TestModel\" AS \"t0\" INNER JOIN \"json_test\".\"ToOne\" AS \"j0\" ON (\"j0\".\"_id\") = (\"t0\".\"toOneId\") WHERE (\"j0\".\"_id\" = $3 AND \"t0\".\"_id\" IS NOT NULL)) AND COALESCE(\"orderby_0_RelationModel\".\"orderby_aggregator\", $4) >= \"order_cmp\".\"aggr_TestModel_ToOne_0\") ORDER BY COALESCE(\"orderby_0_RelationModel\".\"orderby_aggregator\", $5) ASC OFFSET $6"}: quaint::connector::metrics: query="SELECT \"json_test\".\"TestModel\".\"_id\" FROM \"json_test\".\"TestModel\" LEFT JOIN \"json_test\".\"ToOne\" AS \"orderby_0_ToOne\" ON (\"json_test\".\"TestModel\".\"toOneId\" = \"orderby_0_ToOne\".\"_id\") LEFT JOIN (SELECT \"json_test\".\"RelationModel\".\"toOneId\", COUNT(*) AS \"orderby_aggregator\" FROM \"json_test\".\"RelationModel\" GROUP BY \"json_test\".\"RelationModel\".\"toOneId\") AS \"orderby_0_RelationModel\" ON (\"orderby_0_ToOne\".\"_id\" = \"orderby_0_RelationModel\".\"toOneId\"), (SELECT COALESCE(\"orderby_0_RelationModel\".\"orderby_aggregator\", $1) AS \"aggr_TestModel_ToOne_0\" FROM \"json_test\".\"TestModel\" LEFT JOIN \"json_test\".\"ToOne\" AS \"orderby_0_ToOne\" ON (\"json_test\".\"TestModel\".\"toOneId\" = \"orderby_0_ToOne\".\"_id\") LEFT JOIN (SELECT \"json_test\".\"RelationModel\".\"toOneId\", COUNT(*) AS \"orderby_aggregator\" FROM \"json_test\".\"RelationModel\" GROUP BY \"json_test\".\"RelationModel\".\"toOneId\") AS \"orderby_0_RelationModel\" ON (\"orderby_0_ToOne\".\"_id\" = \"orderby_0_RelationModel\".\"toOneId\") WHERE (\"json_test\".\"TestModel\".\"_id\") = ($2)) AS \"order_cmp\" WHERE ((\"json_test\".\"TestModel\".\"_id\") IN (SELECT \"t0\".\"_id\" FROM \"json_test\".\"TestModel\" AS \"t0\" INNER JOIN \"json_test\".\"ToOne\" AS \"j0\" ON (\"j0\".\"_id\") = (\"t0\".\"toOneId\") WHERE (\"j0\".\"_id\" = $3 AND \"t0\".\"_id\" IS NOT NULL)) AND COALESCE(\"orderby_0_RelationModel\".\"orderby_aggregator\", $4) >= \"order_cmp\".\"aggr_TestModel_ToOne_0\") ORDER BY COALESCE(\"orderby_0_RelationModel\".\"orderby_aggregator\", $5) ASC OFFSET $6" item_type="query" is_query=true params=[0,1,1,0,0,0] duration_ms=3 result="error"
2022-05-13T14:23:29.783587Z TRACE query_core::executor::pipeline: 
SEQ
  READ ManyRecordsQuery(name: 'findManyTestModel', model: TestModel, args: QueryArguments { model: Model { name: "TestModel", manifestation: None, fields: OnceCell(Fields { all: [Scalar(ScalarField { name: "id", type_identifier: Int, is_id: true, is_auto_generated_int_id: false, is_autoincrement: false, internal_enum: None, is_updated_at: false, arity: Required, db_name: Some("_id"), default_value: None, model: "TestModel", is_unique: false, read_only: OnceCell(false) }), Scalar(ScalarField { name: "name", type_identifier: String, is_id: false, is_auto_generated_int_id: false, is_autoincrement: false, internal_enum: None, is_updated_at: false, arity: Required, db_name: None, default_value: None, model: "TestModel", is_unique: false, read_only: OnceCell(false) }), Relation(RelationField { name: "toOne", arity: Optional, relation_name: "TestModelToToOne", relation_side: A, relation: OnceCell((Weak)), relation_info: RelationInfo { to: "ToOne", fields: ["toOneId"], references: ["id"], name: "TestModelToToOne", fk_name: Some("TestModel_toOneId_fkey"), on_delete: None, on_update: None }, model: "#ModelWeakRef#", fields: OnceCell([(Weak)]) }), Scalar(ScalarField { name: "toOneId", type_identifier: Int, is_id: false, is_auto_generated_int_id: false, is_autoincrement: false, internal_enum: None, is_updated_at: false, arity: Optional, db_name: None, default_value: None, model: "TestModel", is_unique: false, read_only: OnceCell(true) }), Relation(RelationField { name: "RelationModel", arity: List, relation_name: "RelationModelToTestModel", relation_side: B, relation: OnceCell((Weak)), relation_info: RelationInfo { to: "RelationModel", fields: [], references: [], name: "RelationModelToTestModel", fk_name: None, on_delete: None, on_update: None }, model: "#ModelWeakRef#", fields: OnceCell(Uninit) })], primary_key: Some(PrimaryKey { alias: None, fields: [(Weak)] }), scalar: OnceCell([(Weak), (Weak), (Weak)]), relation: OnceCell([(Weak), (Weak)]), composite: OnceCell(Uninit), model: (Weak), updated_at: OnceCell(Uninit) }), indexes: OnceCell([]), primary_identifier: OnceCell(FieldSelection { selections: [Scalar(ScalarField { name: "id", type_identifier: Int, is_id: true, is_auto_generated_int_id: false, is_autoincrement: false, internal_enum: None, is_updated_at: false, arity: Required, db_name: Some("_id"), default_value: None, model: "TestModel", is_unique: false, read_only: OnceCell(false) })] }), dml_model: Model { name: "TestModel", fields: [ScalarField(ScalarField { name: "id", field_type: Scalar(Int, None, None), arity: Required, database_name: Some("_id"), default_value: None, documentation: None, is_generated: false, is_updated_at: false, is_commented_out: false, is_ignored: false }), ScalarField(ScalarField { name: "name", field_type: Scalar(String, None, None), arity: Required, database_name: None, default_value: None, documentation: None, is_generated: false, is_updated_at: false, is_commented_out: false, is_ignored: false }), RelationField(RelationField { name: "toOne", relation_info: RelationInfo { to: "ToOne", fields: ["toOneId"], references: ["id"], name: "TestModelToToOne", fk_name: Some("TestModel_toOneId_fkey"), on_delete: None, on_update: None }, arity: Optional, referential_arity: Optional, documentation: None, is_generated: false, is_commented_out: false, is_ignored: false, supports_restrict_action: Some(true), emulates_referential_actions: Some(false) }), ScalarField(ScalarField { name: "toOneId", field_type: Scalar(Int, None, None), arity: Optional, database_name: None, default_value: None, documentation: None, is_generated: false, is_updated_at: false, is_commented_out: false, is_ignored: false }), RelationField(RelationField { name: "RelationModel", relation_info: RelationInfo { to: "RelationModel", fields: [], references: [], name: "RelationModelToTestModel", fk_name: None, on_delete: None, on_update: None }, arity: List, referential_arity: List, documentation: None, is_generated: false, is_commented_out: false, is_ignored: false, supports_restrict_action: Some(true), emulates_referential_actions: Some(false) })], documentation: None, database_name: None, indices: [], primary_key: Some(PrimaryKeyDefinition { name: None, db_name: Some("TestModel_pkey"), fields: [PrimaryKeyField { name: "id", sort_order: None, length: None }], defined_on_field: true, clustered: None }), is_generated: false, is_commented_out: false, is_ignored: false }, internal_data_model: "#InternalDataModelWeakRef#" }, cursor: Some(SelectionResult { pairs: [(Scalar(ScalarField { name: "id", type_identifier: Int, is_id: true, is_auto_generated_int_id: false, is_autoincrement: false, internal_enum: None, is_updated_at: false, arity: Required, db_name: Some("_id"), default_value: None, model: "TestModel", is_unique: false, read_only: OnceCell(false) }), Int(1))] }), take: None, skip: None, filter: Some(Relation(RelationFilter { field: RelationField { name: "toOne", arity: Optional, relation_name: "TestModelToToOne", relation_side: A, relation: OnceCell((Weak)), relation_info: RelationInfo { to: "ToOne", fields: ["toOneId"], references: ["id"], name: "TestModelToToOne", fk_name: Some("TestModel_toOneId_fkey"), on_delete: None, on_update: None }, model: "#ModelWeakRef#", fields: OnceCell([(Weak)]) }, nested_filter: Scalar(ScalarFilter { projection: Single(ScalarField { name: "id", type_identifier: Int, is_id: true, is_auto_generated_int_id: false, is_autoincrement: false, internal_enum: None, is_updated_at: false, arity: Required, db_name: Some("_id"), default_value: None, model: "ToOne", is_unique: false, read_only: OnceCell(false) }), condition: Equals(Int(1)), mode: Default }), condition: ToOneRelatedRecord })), order_by: [ToManyAggregation(OrderByToManyAggregation { path: [Relation(RelationField { name: "toOne", arity: Optional, relation_name: "TestModelToToOne", relation_side: A, relation: OnceCell((Weak)), relation_info: RelationInfo { to: "ToOne", fields: ["toOneId"], references: ["id"], name: "TestModelToToOne", fk_name: Some("TestModel_toOneId_fkey"), on_delete: None, on_update: None }, model: "#ModelWeakRef#", fields: OnceCell([(Weak)]) }), Relation(RelationField { name: "children", arity: List, relation_name: "RelationModelToToOne", relation_side: B, relation: OnceCell((Weak)), relation_info: RelationInfo { to: "RelationModel", fields: [], references: [], name: "RelationModelToToOne", fk_name: None, on_delete: None, on_update: None }, model: "#ModelWeakRef#", fields: OnceCell(Uninit) })], sort_order: Ascending, sort_aggregation: Count })], distinct: None, ignore_skip: false, ignore_take: false }, selection: FieldSelection { selections: [Scalar(ScalarField { name: "id", type_identifier: Int, is_id: true, is_auto_generated_int_id: false, is_autoincrement: false, internal_enum: None, is_updated_at: false, arity: Required, db_name: Some("_id"), default_value: None, model: "TestModel", is_unique: false, read_only: OnceCell(false) })] })
```

#### After

**1) By default**

```
2022-05-13T14:26:40.768306Z  INFO query_engine::server: Started query engine http server on http://127.0.0.1:4466
2022-05-13T14:26:42.620539Z TRACE quaint::connector::metrics: Fetched a connection from the pool duration_ms=0 item_type="query" is_query=true result="success"
2022-05-13T14:26:42.624077Z DEBUG filter read query: quaint::connector::metrics: query=SELECT "json_test"."TestModel"."_id" FROM "json_test"."TestModel" LEFT JOIN "json_test"."ToOne" AS "orderby_0_ToOne" ON ("json_test"."TestModel"."toOneId" = "orderby_0_ToOne"."_id") LEFT JOIN (SELECT "json_test"."RelationModel"."toOneId", COUNT(*) AS "orderby_aggregator" FROM "json_test"."RelationModel" GROUP BY "json_test"."RelationModel"."toOneId") AS "orderby_0_RelationModel" ON ("orderby_0_ToOne"."_id" = "orderby_0_RelationModel"."toOneId"), (SELECT COALESCE("orderby_0_RelationModel"."orderby_aggregator", $1) AS "aggr_TestModel_ToOne_0" FROM "json_test"."TestModel" LEFT JOIN "json_test"."ToOne" AS "orderby_0_ToOne" ON ("json_test"."TestModel"."toOneId" = "orderby_0_ToOne"."_id") LEFT JOIN (SELECT "json_test"."RelationModel"."toOneId", COUNT(*) AS "orderby_aggregator" FROM "json_test"."RelationModel" GROUP BY "json_test"."RelationModel"."toOneId") AS "orderby_0_RelationModel" ON ("orderby_0_ToOne"."_id" = "orderby_0_RelationModel"."toOneId") WHERE ("json_test"."TestModel"."_id") = ($2)) AS "order_cmp" WHERE (("json_test"."TestModel"."_id") IN (SELECT "t0"."_id" FROM "json_test"."TestModel" AS "t0" INNER JOIN "json_test"."ToOne" AS "j0" ON ("j0"."_id") = ("t0"."toOneId") WHERE ("j0"."_id" = $3 AND "t0"."_id" IS NOT NULL)) AND COALESCE("orderby_0_RelationModel"."orderby_aggregator", $4) >= "order_cmp"."aggr_TestModel_ToOne_0") ORDER BY COALESCE("orderby_0_RelationModel"."orderby_aggregator", $5) ASC OFFSET $6 params=[0,1,1,0,0,0] result="error" item_type="query" is_query=true duration_ms=2
```

**2) If `FMT_SQL=1` is set**

```
2022-05-13T14:27:36.450849Z  INFO query_engine::server: Started query engine http server on http://127.0.0.1:4466
2022-05-13T14:27:38.361670Z TRACE quaint::connector::metrics: Fetched a connection from the pool duration_ms=0 item_type="query" is_query=true result="success"
2022-05-13T14:27:38.380455Z DEBUG filter read query: quaint::connector::metrics: query=SELECT
  "json_test"."TestModel"."_id"
FROM
  "json_test"."TestModel"
  LEFT JOIN "json_test"."ToOne" AS "orderby_0_ToOne" ON (
    "json_test"."TestModel"."toOneId" = "orderby_0_ToOne"."_id"
  )
  LEFT JOIN (
    SELECT
      "json_test"."RelationModel"."toOneId",
      COUNT(*) AS "orderby_aggregator"
    FROM
      "json_test"."RelationModel"
    GROUP BY
      "json_test"."RelationModel"."toOneId"
  ) AS "orderby_0_RelationModel" ON (
    "orderby_0_ToOne"."_id" = "orderby_0_RelationModel"."toOneId"
  ),
  (
    SELECT
      COALESCE(
        "orderby_0_RelationModel"."orderby_aggregator",
        $1
      ) AS "aggr_TestModel_ToOne_0"
    FROM
      "json_test"."TestModel"
      LEFT JOIN "json_test"."ToOne" AS "orderby_0_ToOne" ON (
        "json_test"."TestModel"."toOneId" = "orderby_0_ToOne"."_id"
      )
      LEFT JOIN (
        SELECT
          "json_test"."RelationModel"."toOneId",
          COUNT(*) AS "orderby_aggregator"
        FROM
          "json_test"."RelationModel"
        GROUP BY
          "json_test"."RelationModel"."toOneId"
      ) AS "orderby_0_RelationModel" ON (
        "orderby_0_ToOne"."_id" = "orderby_0_RelationModel"."toOneId"
      )
    WHERE
      ("json_test"."TestModel"."_id") = ($2)
  ) AS "order_cmp"
WHERE
  (
    ("json_test"."TestModel"."_id") IN (
      SELECT
        "t0"."_id"
      FROM
        "json_test"."TestModel" AS "t0"
        INNER JOIN "json_test"."ToOne" AS "j0" ON ("j0"."_id") = ("t0"."toOneId")
      WHERE
        (
          "j0"."_id" = $3
          AND "t0"."_id" IS NOT NULL
        )
    )
    AND COALESCE(
      "orderby_0_RelationModel"."orderby_aggregator",
      $4
    ) >= "order_cmp"."aggr_TestModel_ToOne_0"
  )
ORDER BY
  COALESCE(
    "orderby_0_RelationModel"."orderby_aggregator",
    $5
  ) ASC OFFSET $6 params=[0,1,1,0,0,0] result="error" item_type="query" is_query=true duration_ms=14
```

**3) If `QE_LOG_LEVEL` is set to `trace`** (from 17900 characters down to 3600)

```
2022-05-13T14:28:20.939615Z  INFO query_engine::server: Started query engine http server on http://127.0.0.1:4466
2022-05-13T14:28:25.190903Z TRACE graphql_handler: query_core::query_graph_builder::builder: ---- Query Graph ----
Result Nodes: []
Marked Nodes: []
Root Nodes: [Node 0]

Node 0: ManyRecordsQuery(name: 'findManyTestModel', model: 'TestModel', selection: FieldSelection { fields: [TestModel.id] }, args: QueryArguments { model: "TestModel", cursor: Some([("TestModel.id", Int(1))]), take: None, skip: None, filter: Some(Relation(RelationFilter { field: "TestModel.toOne", nested_filter: Scalar(ScalarFilter { projection: SingleProjection("ToOne.id"), condition: Equals(Int(1)), mode: Default }), condition: ToOneRelatedRecord })), order_by: [ToManyAggregation(OrderByToManyAggregation { path: [Relation("TestModel.toOne"), Relation("ToOne.children")], sort_order: Ascending, sort_aggregation: Count })], distinct: None, ignore_skip: false, ignore_take: false })
  
----------------------
2022-05-13T14:28:25.191320Z TRACE graphql_handler: quaint::connector::metrics: Fetched a connection from the pool duration_ms=0 item_type="query" is_query=true result="success"
2022-05-13T14:28:25.191473Z TRACE graphql_handler: query_core::query_graph: Visited: 0
2022-05-13T14:28:25.199191Z DEBUG graphql_handler:filter read query: quaint::connector::metrics: query=SELECT "json_test"."TestModel"."_id" FROM "json_test"."TestModel" LEFT JOIN "json_test"."ToOne" AS "orderby_0_ToOne" ON ("json_test"."TestModel"."toOneId" = "orderby_0_ToOne"."_id") LEFT JOIN (SELECT "json_test"."RelationModel"."toOneId", COUNT(*) AS "orderby_aggregator" FROM "json_test"."RelationModel" GROUP BY "json_test"."RelationModel"."toOneId") AS "orderby_0_RelationModel" ON ("orderby_0_ToOne"."_id" = "orderby_0_RelationModel"."toOneId"), (SELECT COALESCE("orderby_0_RelationModel"."orderby_aggregator", $1) AS "aggr_TestModel_ToOne_0" FROM "json_test"."TestModel" LEFT JOIN "json_test"."ToOne" AS "orderby_0_ToOne" ON ("json_test"."TestModel"."toOneId" = "orderby_0_ToOne"."_id") LEFT JOIN (SELECT "json_test"."RelationModel"."toOneId", COUNT(*) AS "orderby_aggregator" FROM "json_test"."RelationModel" GROUP BY "json_test"."RelationModel"."toOneId") AS "orderby_0_RelationModel" ON ("orderby_0_ToOne"."_id" = "orderby_0_RelationModel"."toOneId") WHERE ("json_test"."TestModel"."_id") = ($2)) AS "order_cmp" WHERE (("json_test"."TestModel"."_id") IN (SELECT "t0"."_id" FROM "json_test"."TestModel" AS "t0" INNER JOIN "json_test"."ToOne" AS "j0" ON ("j0"."_id") = ("t0"."toOneId") WHERE ("j0"."_id" = $3 AND "t0"."_id" IS NOT NULL)) AND COALESCE("orderby_0_RelationModel"."orderby_aggregator", $4) >= "order_cmp"."aggr_TestModel_ToOne_0") ORDER BY COALESCE("orderby_0_RelationModel"."orderby_aggregator", $5) ASC OFFSET $6 params=[0,1,1,0,0,0] result="error" item_type="query" is_query=true duration_ms=5
2022-05-13T14:28:25.199459Z TRACE graphql_handler: query_core::executor::pipeline: 
SEQ
  READ ManyRecordsQuery(name: 'findManyTestModel', model: 'TestModel', selection: FieldSelection { fields: [TestModel.id] }, args: QueryArguments { model: "TestModel", cursor: Some([("TestModel.id", Int(1))]), take: None, skip: None, filter: Some(Relation(RelationFilter { field: "TestModel.toOne", nested_filter: Scalar(ScalarFilter { projection: SingleProjection("ToOne.id"), condition: Equals(Int(1)), mode: Default }), condition: ToOneRelatedRecord })), order_by: [ToManyAggregation(OrderByToManyAggregation { path: [Relation("TestModel.toOne"), Relation("ToOne.children")], sort_order: Ascending, sort_aggregation: Count })], distinct: None, ignore_skip: false, ignore_take: false })
```

**4) If `FMT_SQL` and `QE_LOG_LEVEL=trace` are set:**

```
2022-05-13T14:29:54.633473Z  INFO query_engine::server: Started query engine http server on http://127.0.0.1:4466
2022-05-13T14:29:57.710767Z TRACE graphql_handler: query_core::query_graph_builder::builder: ---- Query Graph ----
Result Nodes: []
Marked Nodes: []
Root Nodes: [Node 0]

Node 0: ManyRecordsQuery(name: 'findManyTestModel', model: 'TestModel', selection: FieldSelection { fields: [TestModel.id] }, args: QueryArguments { model: "TestModel", cursor: Some([("TestModel.id", Int(1))]), take: None, skip: None, filter: Some(Relation(RelationFilter { field: "TestModel.toOne", nested_filter: Scalar(ScalarFilter { projection: SingleProjection("ToOne.id"), condition: Equals(Int(1)), mode: Default }), condition: ToOneRelatedRecord })), order_by: [ToManyAggregation(OrderByToManyAggregation { path: [Relation("TestModel.toOne"), Relation("ToOne.children")], sort_order: Ascending, sort_aggregation: Count })], distinct: None, ignore_skip: false, ignore_take: false })
  
----------------------
2022-05-13T14:29:57.710986Z TRACE graphql_handler: quaint::connector::metrics: Fetched a connection from the pool duration_ms=0 item_type="query" is_query=true result="success"
2022-05-13T14:29:57.711112Z TRACE graphql_handler: query_core::query_graph: Visited: 0
2022-05-13T14:29:57.723210Z DEBUG graphql_handler:filter read query: quaint::connector::metrics: query=SELECT
  "json_test"."TestModel"."_id"
FROM
  "json_test"."TestModel"
  LEFT JOIN "json_test"."ToOne" AS "orderby_0_ToOne" ON (
    "json_test"."TestModel"."toOneId" = "orderby_0_ToOne"."_id"
  )
  LEFT JOIN (
    SELECT
      "json_test"."RelationModel"."toOneId",
      COUNT(*) AS "orderby_aggregator"
    FROM
      "json_test"."RelationModel"
    GROUP BY
      "json_test"."RelationModel"."toOneId"
  ) AS "orderby_0_RelationModel" ON (
    "orderby_0_ToOne"."_id" = "orderby_0_RelationModel"."toOneId"
  ),
  (
    SELECT
      COALESCE(
        "orderby_0_RelationModel"."orderby_aggregator",
        $1
      ) AS "aggr_TestModel_ToOne_0"
    FROM
      "json_test"."TestModel"
      LEFT JOIN "json_test"."ToOne" AS "orderby_0_ToOne" ON (
        "json_test"."TestModel"."toOneId" = "orderby_0_ToOne"."_id"
      )
      LEFT JOIN (
        SELECT
          "json_test"."RelationModel"."toOneId",
          COUNT(*) AS "orderby_aggregator"
        FROM
          "json_test"."RelationModel"
        GROUP BY
          "json_test"."RelationModel"."toOneId"
      ) AS "orderby_0_RelationModel" ON (
        "orderby_0_ToOne"."_id" = "orderby_0_RelationModel"."toOneId"
      )
    WHERE
      ("json_test"."TestModel"."_id") = ($2)
  ) AS "order_cmp"
WHERE
  (
    ("json_test"."TestModel"."_id") IN (
      SELECT
        "t0"."_id"
      FROM
        "json_test"."TestModel" AS "t0"
        INNER JOIN "json_test"."ToOne" AS "j0" ON ("j0"."_id") = ("t0"."toOneId")
      WHERE
        (
          "j0"."_id" = $3
          AND "t0"."_id" IS NOT NULL
        )
    )
    AND COALESCE(
      "orderby_0_RelationModel"."orderby_aggregator",
      $4
    ) >= "order_cmp"."aggr_TestModel_ToOne_0"
  )
ORDER BY
  COALESCE(
    "orderby_0_RelationModel"."orderby_aggregator",
    $5
  ) ASC OFFSET $6 params=[0,1,1,0,0,0] result="error" item_type="query" is_query=true duration_ms=10
2022-05-13T14:29:57.723636Z TRACE graphql_handler: query_core::executor::pipeline: 
SEQ
  READ ManyRecordsQuery(name: 'findManyTestModel', model: 'TestModel', selection: FieldSelection { fields: [TestModel.id] }, args: QueryArguments { model: "TestModel", cursor: Some([("TestModel.id", Int(1))]), take: None, skip: None, filter: Some(Relation(RelationFilter { field: "TestModel.toOne", nested_filter: Scalar(ScalarFilter { projection: SingleProjection("ToOne.id"), condition: Equals(Int(1)), mode: Default }), condition: ToOneRelatedRecord })), order_by: [ToManyAggregation(OrderByToManyAggregation { path: [Relation("TestModel.toOne"), Relation("ToOne.children")], sort_order: Ascending, sort_aggregation: Count })], distinct: None, ignore_skip: false, ignore_take: false })
```