### PR TITLE
Fix coerced id map

### DIFF
--- a/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
@@ -80,10 +80,12 @@ pub async fn m2m(
     let mut id_map: HashMap<SelectionResult, Vec<SelectionResult>> = HashMap::new();
 
     for (parent_id, child_id) in ids {
-        match id_map.get_mut(&child_id) {
-            Some(v) => v.push(parent_id),
+        let coerced_child_id = child_id.clone().coerce_values()?;
+        let coerced_parent_id = parent_id.clone().coerce_values()?;
+        match id_map.get_mut(&coerced_child_id) {
+            Some(v) => v.push(coerced_parent_id),
             None => {
-                id_map.insert(child_id.coerce_values()?, vec![parent_id.coerce_values()?]);
+                id_map.insert(coerced_child_id, vec![coerced_parent_id]);
             }
         };
     }


### PR DESCRIPTION
Linked to https://github.com/prisma/prisma-engines/issues/2928

My attempt at fixing the problem associated with `bigint` and m2m relationships.

Originally we only used `coerce_values` for the `None` case and not for the `Some` case. This meant that `get_mut` would never actually match onto an existing key and simply overwrite existing values in the `id_map`. Now `get_mut` returns existing values and no overwriting occurs.

To be frank, I'm not a Rust developer (I have never set eyes on a Rust codebase until looking at this code). So I'm not sure how to unit test this change. However I tested using the GraphQL playground provided and it works like a charm.