### PR TITLE
ci: fix buildkite mariadb issue

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,7 +143,7 @@ services:
     tmpfs: /var/lib/mysql8
 
   mariadb-10-0:
-    image: mariadb:10
+    image: mariadb:10.7.3
     restart: always
     environment:
       MYSQL_USER: root


### PR DESCRIPTION
Fixed mariadb's version to v10.7.3

@garrensmith, if the CI tests of this PR succeed, I think you can just merge this PR to main, merge main into your PR https://github.com/prisma/prisma-engines/pull/2904, and that should solve hopefully the mariadb issue.