### PR TITLE
Only allow `file:` for SQLite URIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3285,7 +3285,7 @@ dependencies = [
 [[package]]
 name = "quaint"
 version = "0.2.0-alpha.13"
-source = "git+https://github.com/prisma/quaint#682520f3a813014c963d5119d47f40938015a9a5"
+source = "git+https://github.com/prisma/quaint#27cf871d0af0c59c9931eb2950de10eea433cd3c"
 dependencies = [
  "async-trait",
  "base64 0.12.3",
@@ -4057,7 +4057,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5bcc41d18f7a1d50525d080fd3e953be87c4f9f1a974f3c21798ca00d54ec15"
 dependencies = [
  "lazy_static",
- "parking_lot 0.11.2",
+ "parking_lot 0.10.2",
  "serial_test_derive",
 ]
 
@@ -5052,7 +5052,7 @@ version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f559b464de2e2bdabcac6a210d12e9b5a5973c251e102c44c585c71d51bd78e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "rand 0.8.4",
  "static_assertions",
 ]

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/sqlite_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/sqlite_datamodel_connector.rs
@@ -92,7 +92,7 @@ impl Connector for SqliteDatamodelConnector {
             }
         };
 
-        if let Some(path) = set_root(url.trim_start_matches("file:").trim_start_matches("sqlite:")) {
+        if let Some(path) = set_root(url.trim_start_matches("file:")) {
             return Cow::Owned(format!("file:{}", path));
         };
 
@@ -100,7 +100,7 @@ impl Connector for SqliteDatamodelConnector {
     }
 
     fn validate_url(&self, url: &str) -> Result<(), String> {
-        if !url.starts_with("file") && !url.starts_with("sqlite:") {
+        if !url.starts_with("file") {
             return Err("must start with the protocol `file:`.".to_string());
         }
 

--- a/libs/datamodel/core/tests/attributes/constraint_names_negative.rs
+++ b/libs/datamodel/core/tests/attributes/constraint_names_negative.rs
@@ -15,7 +15,7 @@ const MYSQL: &str = r#"datasource mysql {
                                 }"#;
 const SQLITE: &str = r#"datasource sqlite {
                                   provider = "sqlite"
-                                  url = "sqlite://asdlj"
+                                  url = "file:asdlj"
                                 }"#;
 
 #[test]

--- a/libs/datamodel/core/tests/attributes/relations/relations_negative.rs
+++ b/libs/datamodel/core/tests/attributes/relations/relations_negative.rs
@@ -785,7 +785,7 @@ fn mapping_foreign_keys_on_sqlite_should_error() {
     let dml = indoc! {r#"
         datasource test {
           provider = "sqlite"
-          url = "sqlite://..."
+          url = "file:."
         }
 
         model User {

--- a/libs/datamodel/core/tests/config/datasources.rs
+++ b/libs/datamodel/core/tests/config/datasources.rs
@@ -52,7 +52,7 @@ fn serialize_builtin_sources_to_dmmf() {
     let schema = indoc! {r#"
         datasource sqlite1 {
             provider = "sqlite"
-            url = "sqlite://file.db"
+            url = "file://file.db"
         }
     "#};
 
@@ -64,7 +64,7 @@ fn serialize_builtin_sources_to_dmmf() {
             "activeProvider": "sqlite",
             "url": {
               "fromEnvVar": null,
-              "value": "sqlite://file.db"
+              "value": "file://file.db"
             }
           }
         ]"#]];

--- a/libs/test-cli/src/main.rs
+++ b/libs/test-cli/src/main.rs
@@ -291,7 +291,7 @@ fn read_datamodel_from_file(path: &str) -> std::io::Result<String> {
 
 fn minimal_schema_from_url(url: &str) -> anyhow::Result<String> {
     let provider = match url.split("://").next() {
-        Some("file") | Some("sqlite") => "sqlite",
+        Some("file") => "sqlite",
         Some(s) if s.starts_with("postgres") => "postgresql",
         Some("mysql") => "mysql",
         Some("sqlserver") => "sqlserver",

--- a/migration-engine/core/src/lib.rs
+++ b/migration-engine/core/src/lib.rs
@@ -60,7 +60,7 @@ fn connector_for_connection_string(
         // seem to be used by some tests in prisma/prisma. They are not tested at all engine-side.
         //
         // Tracking issue: https://github.com/prisma/prisma/issues/11468
-        Some("file") | Some("sqlite") => {
+        Some("file") => {
             let params = ConnectorParams {
                 connection_string,
                 preview_features,

--- a/migration-engine/core/src/lib.rs
+++ b/migration-engine/core/src/lib.rs
@@ -56,10 +56,6 @@ fn connector_for_connection_string(
             connector.set_params(params)?;
             Ok(Box::new(connector))
         }
-        // TODO: `sqlite:` connection strings may not work if we try to connect to them, but they
-        // seem to be used by some tests in prisma/prisma. They are not tested at all engine-side.
-        //
-        // Tracking issue: https://github.com/prisma/prisma/issues/11468
         Some("file") => {
             let params = ConnectorParams {
                 connection_string,


### PR DESCRIPTION
The quaint must be merged, then updated here and tests should be run before merging. Do not merge before Prisma 4 is due.

Quaint: https://github.com/prisma/quaint/pull/370
Closes: https://github.com/prisma/prisma/issues/11468