### PR TITLE
Add default metrics dashboard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,6 +217,9 @@ use-local-query-engine:
 	cp target/release/query-engine $(PRISMA2_BINARY_PATH)/runtime/
 	cp target/release/query-engine $(PRISMA2_BINARY_PATH)/query-engine-darwin
 
+show-metrics:
+	docker-compose -f docker-compose.yml up -d --remove-orphans grafana prometheus
+
 
 ## OpenTelemetry
 otel:

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Client](https://www.prisma.io/client) and [Prisma
 Migrate](https://www.prisma.io/migrate).
 
 The engines and their respective binary crates are:
+
 - Query engine: `query-engine`
 - Migration engine: `migration-engine-cli`
 - Introspection engine: `introspection-engine`
@@ -23,15 +24,16 @@ published on the repo GitHub pages.
 ## Building Prisma Engines
 
 **Prerequisites:**
+
 - Installed the stable Rust toolchain, at least version 1.52.0. You can get the
   toolchain at [rustup](https://rustup.rs/) or the package manager of your
   choice.
 - Linux only: OpenSSL is required to be installed.
 - Installed [direnv](https://github.com/direnv/direnv), then `direnv allow` on
-  the repository root. 
-    - Make sure direnv is [hooked](https://direnv.net/docs/hook.html) into your shell
-    - Alternatively: Load the defined environment in `./.envrc` manually in your
-      shell.
+  the repository root.
+  - Make sure direnv is [hooked](https://direnv.net/docs/hook.html) into your shell
+  - Alternatively: Load the defined environment in `./.envrc` manually in your
+    shell.
 - **For m1 users**: Install [Protocol Buffers](https://grpc.io/docs/protoc-installation/)
 
 **How to build:**
@@ -44,12 +46,12 @@ Depending on how you invoked `cargo` in the previous step, you can find the
 compiled binaries inside the repository root in the `target/debug` (without
 `--release`) or `target/release` directories (with `--release`):
 
-| Prisma Component           | Path to Binary                                            |
-| -------------------------- | --------------------------------------------------------- |
-| Query Engine               | `./target/[debug\|release]/query-engine`                         |
-| Migration Engine           | `./target/[debug\|release]/migration-engine`               |
-| Introspection Engine       | `./target/[debug\|release]/introspection-engine`           |
-| Prisma Format              | `./target/[debug\|release]/prisma-fmt`                     |
+| Prisma Component     | Path to Binary                                   |
+| -------------------- | ------------------------------------------------ |
+| Query Engine         | `./target/[debug\|release]/query-engine`         |
+| Migration Engine     | `./target/[debug\|release]/migration-engine`     |
+| Introspection Engine | `./target/[debug\|release]/introspection-engine` |
+| Prisma Format        | `./target/[debug\|release]/prisma-fmt`           |
 
 ## Query Engine
 
@@ -60,6 +62,7 @@ If using it on production please be aware the api and the query language can
 change any time. There is no guaranteed API stability.
 
 Notable environment flags:
+
 - `RUST_LOG_FORMAT=(devel|json)` sets the log format. By default outputs `json`.
 - `QE_LOG_LEVEL=(info|debug|trace)` sets the log level for the Query Engine. If you need Query Graph debugging logs, set it to "trace"
 - `FMT_SQL=1` enables logging _formatted_ SQL queries
@@ -83,6 +86,7 @@ pre-building a binary and running it directly. If using `cargo`, replace
 whatever command that starts with `./query-engine` with `cargo run --bin query-engine --`.
 
 **Help**
+
 ```bash
 > ./target/release/query-engine --help
 query-engine d6f9915c25a2ae6eb793a3a18f87e576fb82e9da
@@ -124,28 +128,36 @@ SUBCOMMANDS:
 
 The prisma version hash is the latest git commit at the time the binary was built.
 
+## Metrics
+
+Running `make show-metrics` will start Prometheus and Grafana with a default metrics dashboard.
+Prometheus will scrape the `/metrics` endpoint to collect the engine's metrics
+
+Navigate to `http://localhost:3000` to view the Grafana dashboard.
+
 ## Testing
 
 There are two test suites for the engines: Unit tests and
 integration tests.
 
 - **Unit tests**: They test internal
-functionality of individual crates and components.
+  functionality of individual crates and components.
 
-  You can find them across the whole codebase, usually in `./tests` folders at the root of modules. 
+  You can find them across the whole codebase, usually in `./tests` folders at the root of modules.
 
 - **Integration tests**: They run GraphQL queries against isolated
-instances of the Query Engine and asserts that the responses are correct.
+  instances of the Query Engine and asserts that the responses are correct.
 
   You can find them at `./query-engine/connector-test-kit-rs`.
 
 ### Set up & run tests:
 
 **Prerequisites:**
+
 - Installed Rust toolchain.
 - Installed Docker and Docker-Compose.
 - Installed `direnv`, then `direnv allow` on the repository root.
-    - Alternatively: Load the defined environment in `./.envrc` manually in your shell.
+  - Alternatively: Load the defined environment in `./.envrc` manually in your shell.
 
 **Setup:**
 There are helper `make` commands to set up a test environment for a specific
@@ -159,13 +171,12 @@ tests:
 - `make dev-sqlite`: SQLite
 - `make dev-mongodb5`: MongoDB 5
 
-**On windows:*
+\*_On windows:_
 If not using WSL, `make` is not available and you should just see what your
 command does and do it manually. Basically this means editing the
 `.test_config` file and starting the needed Docker containers.
 
-To actually get the tests working, read the contents of `.envrc`. Then `Edit
-environment variables for your account` from Windows settings, and add at least
+To actually get the tests working, read the contents of `.envrc`. Then `Edit environment variables for your account` from Windows settings, and add at least
 the correct values for the following variables:
 
 - `WORKSPACE_ROOT` should point to the root directory of `prisma-engines` project.
@@ -182,13 +193,12 @@ Run `cargo test` in the repository root.
 
 ## Parallel rust-analyzer builds
 
-When rust-analzyer runs `cargo check` it will lock the build directory and stop any cargo commands from running until it has completed. This makes the build process feel a lot longer. It is possible to avoid this by setting a different build path for 
+When rust-analzyer runs `cargo check` it will lock the build directory and stop any cargo commands from running until it has completed. This makes the build process feel a lot longer. It is possible to avoid this by setting a different build path for
 rust-analyzer. To avoid this. Open VSCode settings and search for `Check on Save: Extra Args`. Look for the `Rust-analyzer › Check On Save: Extra Args` settings and add a new directory for rust-analyzer. Something like:
 
 ```
 --target-dir:/tmp/rust-analyzer-check
 ```
-
 
 ## Security
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -328,5 +328,20 @@ services:
       - 16686:16686
       - 4317:55680
 
+  prometheus:
+    image: prom/prometheus
+    volumes:
+      - ${PWD}/metrics/prometheus:/prometheus-data
+    command: --config.file=/prometheus-data/prometheus.yml
+    ports:
+      - 9090:9090
+  grafana:
+    image: grafana/grafana
+    volumes:
+      - ${PWD}/metrics/grafana/datasources:/etc/grafana/provisioning/datasources/
+      - ${PWD}/metrics/grafana/dashboards:/etc/grafana/provisioning/dashboards/
+    ports:
+      - 3000:3000
+
 networks:
   databases: null

--- a/metrics/grafana/dashboards/dashboards.json
+++ b/metrics/grafana/dashboards/dashboards.json
@@ -1,0 +1,451 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 1,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "editorMode": "code",
+          "expr": "pool_active_connections",
+          "legendFormat": "Active",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "editorMode": "code",
+          "expr": "pool_idle_connections",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Idle",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "editorMode": "code",
+          "expr": "pool_wait_count",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Wait Count",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Connections: Active vs Idle vs Wait count",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "editorMode": "code",
+          "expr": "query_active_transactions",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "expr": "",
+          "hide": false,
+          "refId": "B"
+        }
+      ],
+      "title": "Active Transactions",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(query_operation_total_elapsed_time_ms_bucket[$__rate_interval])) by (le))",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(query_total_elapsed_time_ms_bucket[$__rate_interval])) by (le))",
+          "hide": false,
+          "refId": "B"
+        }
+      ],
+      "title": "95% Total Operation Elapsed Time vs Query Elapsed Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "expr": "rate(query_total_operations[$__rate_interval])",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "expr": "rate(query_total_queries[$__rate_interval])",
+          "hide": false,
+          "refId": "B"
+        }
+      ],
+      "title": "Operations vs Queries",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 36,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Prisma Engine",
+  "uid": "qZbkmnr7k",
+  "version": 1,
+  "weekStart": ""
+}

--- a/metrics/grafana/dashboards/prometheus.yml
+++ b/metrics/grafana/dashboards/prometheus.yml
@@ -1,0 +1,22 @@
+apiVersion: 1
+
+providers:
+  # <string> an unique provider name
+- name: 'Prisma Engine'
+  # <int> org id. will default to orgId 1 if not specified
+  orgId: 1
+  # <string, required> name of the dashboard folder. Required
+  folder: ''
+  # <string> folder UID. will be automatically generated if not specified
+  folderUid: ''
+  # <string, required> provider type. Required
+  type: file
+  # <bool> disable dashboard deletion
+  disableDeletion: false
+  # <bool> enable dashboard editing
+  editable: true
+  # <int> how often Grafana will scan for changed dashboards
+  updateIntervalSeconds: 10
+  options:
+    # <string, required> path to dashboard files on disk. Required
+    path: /etc/grafana/provisioning/dashboards

--- a/metrics/grafana/datasources/all.yml
+++ b/metrics/grafana/datasources/all.yml
@@ -1,0 +1,9 @@
+datasources:
+-  access: 'proxy'                       # make grafana perform the requests
+   editable: true                        # whether it should be editable
+   is_default: true                      # whether this should be the default DS
+   name: 'prometheus'                         # name of the datasource
+   org_id: 1                             # id of the organization to tie this datasource to
+   type: 'prometheus'                    # type of the data source
+   url: 'http://prometheus:9090'         # url of the prom instance
+   version: 1   

--- a/metrics/prometheus/prometheus.yml
+++ b/metrics/prometheus/prometheus.yml
@@ -1,0 +1,9 @@
+scrape_configs:
+  - job_name: 'prometheus'
+    scrape_interval: 1s
+
+    static_configs:
+      - targets: ['host.docker.internal:4466']
+        labels:
+          service: 'prisma-engine'
+          group: 'development'

--- a/query-engine/query-engine/src/server/mod.rs
+++ b/query-engine/query-engine/src/server/mod.rs
@@ -119,7 +119,10 @@ pub async fn routes(state: State, req: Request<Body>) -> Result<Response<Body>, 
         return handle_transaction(state, req).await;
     }
 
-    if req.method() == Method::POST && req.uri().path().contains("metrics") && state.enable_metrics {
+    if [Method::POST, Method::GET].contains(req.method())
+        && req.uri().path().contains("metrics")
+        && state.enable_metrics
+    {
         return handle_metrics(state, req).await;
     }
 


### PR DESCRIPTION
running `make show-metrics` starts a Prometheus and Grafana with
a default dashboard to view the current metrics that the engine
exposes.

Navigate to `http://locahost:3000` to view the metrics

The Dashboard looks like this:
<img width="2133" alt="Screenshot 2022-06-01 at 14 36 27" src="https://user-images.githubusercontent.com/179458/171408901-3a4de5f6-28fd-425f-8f91-b3b9717c7ce8.png">


I have had to allow us to expose the metrics via POST or GET. The client uses POST to get the metrics but sadly Prometheus doesn't seem to support POST