### PR TITLE
refactor(datamodel): make dml_to_ast ready for new param

### DIFF
--- a/libs/datamodel/CONTRIBUTING.md
+++ b/libs/datamodel/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+# Contributing to datamodel
+
+## Testing
+
+Run `cargo test` in the `core` crate.
+
+## Style guidelines
+
+- Avoid unnecessary object-like structs. Use free-standing functions and context structs.
+- Function arguments should generally be ordered from more specific to less specific. Any context-like arguments should come last. Mutable arguments also should tend to come last, since they're for generally for writing (side-effects, context) rather than reading.

--- a/libs/datamodel/core/src/lib.rs
+++ b/libs/datamodel/core/src/lib.rs
@@ -243,32 +243,8 @@ pub fn render_datamodel_to(
     configuration: Option<&Configuration>,
 ) {
     let datasource = configuration.and_then(|c| c.datasources.first());
+    let lowered = lower(LowerParams { datasource, datamodel });
 
-    let preview_features = configuration
-        .map(|c| c.preview_features())
-        .unwrap_or_else(BitFlags::empty);
-
-    let lowered = lower(LowerParams {
-        datasource,
-        _preview_features: preview_features,
-        datamodel,
-    });
-
-    render_schema_ast_to(stream, &lowered, 2);
-}
-
-/// Renders as a string into the stream.
-pub fn render_datamodel_to_with_preview_flags(
-    stream: &mut dyn std::fmt::Write,
-    datamodel: &dml::Datamodel,
-    datasource: Option<&Datasource>,
-    flags: BitFlags<PreviewFeature>,
-) {
-    let lowered = lower(LowerParams {
-        datasource,
-        _preview_features: flags,
-        datamodel,
-    });
     render_schema_ast_to(stream, &lowered, 2);
 }
 
@@ -292,7 +268,6 @@ fn render_datamodel_and_config_to(
 ) {
     let mut lowered = lower(LowerParams {
         datasource: config.datasources.first(),
-        _preview_features: config.preview_features(),
         datamodel,
     });
 

--- a/libs/datamodel/core/src/transform/dml_to_ast/lower.rs
+++ b/libs/datamodel/core/src/transform/dml_to_ast/lower.rs
@@ -1,17 +1,14 @@
 use super::*;
 use crate::{
     ast,
-    common::preview_features::PreviewFeature,
     dml::{self, IndexField, PrimaryKeyField, SortOrder},
     Datasource,
 };
-use enumflags2::BitFlags;
 use itertools::Itertools;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct LowerParams<'a> {
     pub datasource: Option<&'a Datasource>,
-    pub _preview_features: BitFlags<PreviewFeature>,
     pub datamodel: &'a dml::Datamodel,
 }
 

--- a/libs/datamodel/core/src/transform/dml_to_ast/lower.rs
+++ b/libs/datamodel/core/src/transform/dml_to_ast/lower.rs
@@ -1,3 +1,4 @@
+use super::*;
 use crate::{
     ast,
     common::preview_features::PreviewFeature,
@@ -7,234 +8,225 @@ use crate::{
 use enumflags2::BitFlags;
 use itertools::Itertools;
 
-pub struct LowerDmlToAst<'a> {
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct LowerParams<'a> {
     pub datasource: Option<&'a Datasource>,
-    pub preview_features: BitFlags<PreviewFeature>,
+    pub _preview_features: BitFlags<PreviewFeature>,
+    pub datamodel: &'a dml::Datamodel,
 }
 
-impl<'a> LowerDmlToAst<'a> {
-    /// Creates a new instance, with all builtin attributes registered.
-    pub fn new(datasource: Option<&'a Datasource>, preview_features: BitFlags<PreviewFeature>) -> Self {
-        Self {
-            datasource,
-            preview_features,
+pub(crate) fn lower(params: LowerParams<'_>) -> ast::SchemaAst {
+    let datamodel = params.datamodel;
+    let mut tops: Vec<ast::Top> = Vec::new();
+
+    for r#type in datamodel.composite_types.iter() {
+        tops.push(ast::Top::CompositeType(lower_composite_type(r#type, params)));
+    }
+
+    for model in datamodel.models() {
+        if !model.is_generated {
+            tops.push(ast::Top::Model(lower_model(model, params)))
         }
     }
 
-    pub fn lower(&self, datamodel: &dml::Datamodel) -> ast::SchemaAst {
-        let mut tops: Vec<ast::Top> = Vec::new();
-
-        for r#type in datamodel.composite_types.iter() {
-            tops.push(ast::Top::CompositeType(self.lower_composite_type(r#type)));
-        }
-
-        for model in datamodel.models() {
-            if !model.is_generated {
-                tops.push(ast::Top::Model(self.lower_model(model, datamodel)))
-            }
-        }
-
-        for enm in datamodel.enums() {
-            tops.push(ast::Top::Enum(self.lower_enum(enm)))
-        }
-
-        ast::SchemaAst { tops }
+    for enm in datamodel.enums() {
+        tops.push(ast::Top::Enum(lower_enum(enm)))
     }
 
-    pub fn lower_model(&self, model: &dml::Model, datamodel: &dml::Datamodel) -> ast::Model {
-        let mut fields: Vec<ast::Field> = Vec::new();
+    ast::SchemaAst { tops }
+}
 
-        for field in model.fields() {
-            fields.push(self.lower_field(model, field, datamodel))
-        }
+pub(super) fn lower_model(model: &dml::Model, params: LowerParams<'_>) -> ast::Model {
+    let mut fields: Vec<ast::Field> = Vec::new();
 
-        ast::Model {
-            name: ast::Identifier::new(&model.name),
-            fields,
-            attributes: self.lower_model_attributes(datamodel, model),
-            documentation: model.documentation.clone().map(|text| ast::Comment { text }),
-            span: ast::Span::empty(),
-            commented_out: model.is_commented_out,
-        }
+    for field in model.fields() {
+        fields.push(lower_field(model, field, params))
     }
 
-    fn lower_enum(&self, enm: &dml::Enum) -> ast::Enum {
-        ast::Enum {
-            name: ast::Identifier::new(&enm.name),
-            values: enm
-                .values()
-                .map(|v| ast::EnumValue {
-                    name: ast::Identifier::new(&v.name),
-                    attributes: self.lower_enum_value_attributes(v),
-                    documentation: v.documentation.clone().map(|text| ast::Comment { text }),
-                    span: ast::Span::empty(),
-                    commented_out: v.commented_out,
-                })
-                .collect(),
-            attributes: self.lower_enum_attributes(enm),
-            documentation: enm.documentation.clone().map(|text| ast::Comment { text }),
-            span: ast::Span::empty(),
-        }
+    ast::Model {
+        name: ast::Identifier::new(&model.name),
+        fields,
+        attributes: lower_model_attributes(model, params),
+        documentation: model.documentation.clone().map(|text| ast::Comment { text }),
+        span: ast::Span::empty(),
+        commented_out: model.is_commented_out,
     }
+}
 
-    pub fn lower_field(&self, model: &dml::Model, field: &dml::Field, datamodel: &dml::Datamodel) -> ast::Field {
-        let mut attributes = self.lower_field_attributes(model, field, datamodel);
-
-        let native_type = field.as_scalar_field().and_then(|sf| sf.field_type.as_native_type());
-
-        if let (Some((scalar_type, native_type)), Some(datasource)) = (native_type, self.datasource) {
-            self.lower_native_type_attribute(scalar_type, native_type, &mut attributes, datasource);
-        }
-
-        ast::Field {
-            name: ast::Identifier::new(field.name()),
-            arity: self.lower_field_arity(field.arity()),
-            attributes,
-            field_type: self.lower_type(&field.field_type()),
-            documentation: field.documentation().map(|text| ast::Comment { text: text.to_owned() }),
-            span: ast::Span::empty(),
-            is_commented_out: field.is_commented_out(),
-        }
-    }
-
-    pub(super) fn lower_composite_type(&self, r#type: &dml::CompositeType) -> ast::CompositeType {
-        let mut fields: Vec<ast::Field> = Vec::new();
-
-        for field in r#type.fields.iter() {
-            let mut attributes = field
-                .database_name
-                .as_ref()
-                .map(|db_name| {
-                    vec![ast::Attribute::new(
-                        "map",
-                        vec![ast::Argument::new_unnamed(ast::Expression::StringValue(
-                            String::from(db_name),
-                            ast::Span::empty(),
-                        ))],
-                    )]
-                })
-                .unwrap_or_else(Vec::new);
-
-            let native_type = field.r#type.as_native_type();
-
-            if let (Some((scalar_type, native_type)), Some(datasource)) = (native_type, self.datasource) {
-                self.lower_native_type_attribute(scalar_type, native_type, &mut attributes, datasource);
-            }
-
-            fields.push(ast::Field {
-                field_type: self.lower_composite_field_type(&field.r#type),
-                name: ast::Identifier::new(&field.name),
-                arity: self.lower_field_arity(&field.arity),
-                attributes,
-                documentation: field
-                    .documentation
-                    .as_ref()
-                    .map(|text| ast::Comment { text: text.to_owned() }),
+fn lower_enum(enm: &dml::Enum) -> ast::Enum {
+    ast::Enum {
+        name: ast::Identifier::new(&enm.name),
+        values: enm
+            .values()
+            .map(|v| ast::EnumValue {
+                name: ast::Identifier::new(&v.name),
+                attributes: lower_enum_value_attributes(v),
+                documentation: v.documentation.clone().map(|text| ast::Comment { text }),
                 span: ast::Span::empty(),
-                is_commented_out: field.is_commented_out,
-            });
+                commented_out: v.commented_out,
+            })
+            .collect(),
+        attributes: lower_enum_attributes(enm),
+        documentation: enm.documentation.clone().map(|text| ast::Comment { text }),
+        span: ast::Span::empty(),
+    }
+}
+
+pub(super) fn lower_field(model: &dml::Model, field: &dml::Field, params: LowerParams<'_>) -> ast::Field {
+    let mut attributes = lower_field_attributes(model, field, params);
+
+    let native_type = field.as_scalar_field().and_then(|sf| sf.field_type.as_native_type());
+
+    if let (Some((scalar_type, native_type)), Some(datasource)) = (native_type, params.datasource) {
+        lower_native_type_attribute(scalar_type, native_type, &mut attributes, datasource);
+    }
+
+    ast::Field {
+        name: ast::Identifier::new(field.name()),
+        arity: lower_field_arity(field.arity()),
+        attributes,
+        field_type: lower_type(&field.field_type()),
+        documentation: field.documentation().map(|text| ast::Comment { text: text.to_owned() }),
+        span: ast::Span::empty(),
+        is_commented_out: field.is_commented_out(),
+    }
+}
+
+pub(super) fn lower_composite_type(r#type: &dml::CompositeType, params: LowerParams<'_>) -> ast::CompositeType {
+    let mut fields: Vec<ast::Field> = Vec::new();
+
+    for field in r#type.fields.iter() {
+        let mut attributes = field
+            .database_name
+            .as_ref()
+            .map(|db_name| {
+                vec![ast::Attribute::new(
+                    "map",
+                    vec![ast::Argument::new_unnamed(ast::Expression::StringValue(
+                        String::from(db_name),
+                        ast::Span::empty(),
+                    ))],
+                )]
+            })
+            .unwrap_or_else(Vec::new);
+
+        let native_type = field.r#type.as_native_type();
+
+        if let (Some((scalar_type, native_type)), Some(datasource)) = (native_type, params.datasource) {
+            lower_native_type_attribute(scalar_type, native_type, &mut attributes, datasource);
         }
 
-        ast::CompositeType {
-            name: ast::Identifier::new(&r#type.name),
-            fields,
-            documentation: None,
+        fields.push(ast::Field {
+            field_type: lower_composite_field_type(&field.r#type),
+            name: ast::Identifier::new(&field.name),
+            arity: lower_field_arity(&field.arity),
+            attributes,
+            documentation: field
+                .documentation
+                .as_ref()
+                .map(|text| ast::Comment { text: text.to_owned() }),
             span: ast::Span::empty(),
-        }
+            is_commented_out: field.is_commented_out,
+        });
     }
 
-    pub fn field_array(fields: &[String]) -> Vec<ast::Expression> {
-        fields
-            .iter()
-            .map(|f| ast::Expression::ConstantValue(f.to_string(), ast::Span::empty()))
-            .collect()
+    ast::CompositeType {
+        name: ast::Identifier::new(&r#type.name),
+        fields,
+        documentation: None,
+        span: ast::Span::empty(),
     }
+}
 
-    pub fn pk_field_array(fields: &[PrimaryKeyField]) -> Vec<ast::Expression> {
-        fields
-            .iter()
-            .map(|f| {
-                let mut args = vec![];
-                args.extend(f.length.map(|length| ast::Argument::new_numeric("length", length)));
+pub(super) fn field_array(fields: &[String]) -> Vec<ast::Expression> {
+    fields
+        .iter()
+        .map(|f| ast::Expression::ConstantValue(f.to_string(), ast::Span::empty()))
+        .collect()
+}
 
-                args.extend(
-                    (f.sort_order == Some(SortOrder::Desc)).then(|| ast::Argument::new_constant("sort", "Desc")),
-                );
+pub fn pk_field_array(fields: &[PrimaryKeyField]) -> Vec<ast::Expression> {
+    fields
+        .iter()
+        .map(|f| {
+            let mut args = vec![];
+            args.extend(f.length.map(|length| ast::Argument::new_numeric("length", length)));
 
-                if args.is_empty() {
-                    ast::Expression::ConstantValue(f.name.clone(), ast::Span::empty())
-                } else {
-                    ast::Expression::Function(
-                        f.name.clone(),
-                        ast::ArgumentsList {
-                            arguments: args,
-                            ..Default::default()
-                        },
-                        ast::Span::empty(),
-                    )
-                }
-            })
-            .collect()
-    }
+            args.extend((f.sort_order == Some(SortOrder::Desc)).then(|| ast::Argument::new_constant("sort", "Desc")));
 
-    pub fn index_field_array(fields: &[IndexField], always_render_sort_order: bool) -> Vec<ast::Expression> {
-        fields
-            .iter()
-            .map(|f| {
-                let mut args = vec![];
+            if args.is_empty() {
+                ast::Expression::ConstantValue(f.name.clone(), ast::Span::empty())
+            } else {
+                ast::Expression::Function(
+                    f.name.clone(),
+                    ast::ArgumentsList {
+                        arguments: args,
+                        ..Default::default()
+                    },
+                    ast::Span::empty(),
+                )
+            }
+        })
+        .collect()
+}
 
-                args.extend(f.length.map(|length| ast::Argument::new_numeric("length", length)));
+pub fn index_field_array(fields: &[IndexField], always_render_sort_order: bool) -> Vec<ast::Expression> {
+    fields
+        .iter()
+        .map(|f| {
+            let mut args = vec![];
 
-                if always_render_sort_order {
-                    let ordering = f.sort_order.map(|ordering| match ordering {
-                        SortOrder::Asc => ast::Argument::new_constant("sort", "Asc"),
-                        SortOrder::Desc => ast::Argument::new_constant("sort", "Desc"),
-                    });
+            args.extend(f.length.map(|length| ast::Argument::new_numeric("length", length)));
 
-                    args.extend(ordering);
-                } else {
-                    let ordering = f
-                        .sort_order
-                        .filter(|s| *s == SortOrder::Desc)
-                        .map(|_| ast::Argument::new_constant("sort", "Desc"));
+            if always_render_sort_order {
+                let ordering = f.sort_order.map(|ordering| match ordering {
+                    SortOrder::Asc => ast::Argument::new_constant("sort", "Asc"),
+                    SortOrder::Desc => ast::Argument::new_constant("sort", "Desc"),
+                });
 
-                    args.extend(ordering);
-                }
+                args.extend(ordering);
+            } else {
+                let ordering = f
+                    .sort_order
+                    .filter(|s| *s == SortOrder::Desc)
+                    .map(|_| ast::Argument::new_constant("sort", "Desc"));
 
-                if let Some(opclass) = &f.operator_class {
-                    let expr = if opclass.is_raw() {
-                        let args = ast::ArgumentsList {
-                            arguments: vec![ast::Argument {
-                                name: None,
-                                value: ast::Expression::StringValue(opclass.to_string(), ast::Span::empty()),
-                                span: ast::Span::empty(),
-                            }],
-                            empty_arguments: Vec::new(),
-                            trailing_comma: None,
-                        };
-                        ast::Expression::Function("raw".to_string(), args, ast::Span::empty())
-                    } else {
-                        ast::Expression::ConstantValue(opclass.to_string(), ast::Span::empty())
+                args.extend(ordering);
+            }
+
+            if let Some(opclass) = &f.operator_class {
+                let expr = if opclass.is_raw() {
+                    let args = ast::ArgumentsList {
+                        arguments: vec![ast::Argument {
+                            name: None,
+                            value: ast::Expression::StringValue(opclass.to_string(), ast::Span::empty()),
+                            span: ast::Span::empty(),
+                        }],
+                        empty_arguments: Vec::new(),
+                        trailing_comma: None,
                     };
-
-                    args.push(ast::Argument::new("ops", expr));
-                }
-
-                let name = f.path.iter().map(|(name, _)| name).join(".");
-
-                if args.is_empty() {
-                    ast::Expression::ConstantValue(name, ast::Span::empty())
+                    ast::Expression::Function("raw".to_string(), args, ast::Span::empty())
                 } else {
-                    ast::Expression::Function(
-                        name,
-                        ast::ArgumentsList {
-                            arguments: args,
-                            ..Default::default()
-                        },
-                        ast::Span::empty(),
-                    )
-                }
-            })
-            .collect()
-    }
+                    ast::Expression::ConstantValue(opclass.to_string(), ast::Span::empty())
+                };
+
+                args.push(ast::Argument::new("ops", expr));
+            }
+
+            let name = f.path.iter().map(|(name, _)| name).join(".");
+
+            if args.is_empty() {
+                ast::Expression::ConstantValue(name, ast::Span::empty())
+            } else {
+                ast::Expression::Function(
+                    name,
+                    ast::ArgumentsList {
+                        arguments: args,
+                        ..Default::default()
+                    },
+                    ast::Span::empty(),
+                )
+            }
+        })
+        .collect()
 }

--- a/libs/datamodel/core/src/transform/dml_to_ast/lower_enum_attributes.rs
+++ b/libs/datamodel/core/src/transform/dml_to_ast/lower_enum_attributes.rs
@@ -1,16 +1,11 @@
-use crate::transform::dml_to_ast::LowerDmlToAst;
-use crate::{
-    ast::{self},
-    dml,
-};
+use super::*;
+use crate::{ast, dml};
 
-impl<'a> LowerDmlToAst<'a> {
-    /// Internal: Lowers an enum's attributes.
-    pub(crate) fn lower_enum_attributes(&self, enm: &dml::Enum) -> Vec<ast::Attribute> {
-        let mut attributes = vec![];
+/// Internal: Lowers an enum's attributes.
+pub(super) fn lower_enum_attributes(enm: &dml::Enum) -> Vec<ast::Attribute> {
+    let mut attributes = vec![];
 
-        <LowerDmlToAst<'a>>::push_model_index_map_arg(enm, &mut attributes);
+    push_model_index_map_arg(enm, &mut attributes);
 
-        attributes
-    }
+    attributes
 }

--- a/libs/datamodel/core/src/transform/dml_to_ast/lower_enum_value_attributes.rs
+++ b/libs/datamodel/core/src/transform/dml_to_ast/lower_enum_value_attributes.rs
@@ -1,16 +1,11 @@
-use crate::transform::dml_to_ast::LowerDmlToAst;
-use crate::{
-    ast::{self},
-    dml,
-};
+use super::*;
+use crate::{ast, dml};
 
-impl<'a> LowerDmlToAst<'a> {
-    /// Internal: Lowers an enum's attributes.
-    pub(crate) fn lower_enum_value_attributes(&self, enum_value: &dml::EnumValue) -> Vec<ast::Attribute> {
-        let mut attributes = vec![];
+/// Internal: Lowers an enum's attributes.
+pub(super) fn lower_enum_value_attributes(enum_value: &dml::EnumValue) -> Vec<ast::Attribute> {
+    let mut attributes = vec![];
 
-        <LowerDmlToAst<'a>>::push_model_index_map_arg(enum_value, &mut attributes);
+    push_model_index_map_arg(enum_value, &mut attributes);
 
-        attributes
-    }
+    attributes
 }

--- a/libs/datamodel/core/src/transform/dml_to_ast/lower_field.rs
+++ b/libs/datamodel/core/src/transform/dml_to_ast/lower_field.rs
@@ -1,326 +1,315 @@
+use super::*;
 use crate::{
     ast::{self, Attribute, Span},
     common::{constraint_names::ConstraintNames, RelationNames},
     dml::{self, Field, Ignorable, SortOrder},
-    transform::dml_to_ast::LowerDmlToAst,
     Datasource,
 };
 use ::dml::{prisma_value, traits::WithName, PrismaValue};
 use datamodel_connector::{Connector, EmptyDatamodelConnector};
 
-impl<'a> LowerDmlToAst<'a> {
-    /// Internal: Lowers a field's arity.
-    pub(crate) fn lower_field_arity(&self, field_arity: &dml::FieldArity) -> ast::FieldArity {
-        match field_arity {
-            dml::FieldArity::Required => ast::FieldArity::Required,
-            dml::FieldArity::Optional => ast::FieldArity::Optional,
-            dml::FieldArity::List => ast::FieldArity::List,
-        }
+/// Internal: Lowers a field's arity.
+pub(crate) fn lower_field_arity(field_arity: &dml::FieldArity) -> ast::FieldArity {
+    match field_arity {
+        dml::FieldArity::Required => ast::FieldArity::Required,
+        dml::FieldArity::Optional => ast::FieldArity::Optional,
+        dml::FieldArity::List => ast::FieldArity::List,
     }
+}
 
-    pub(crate) fn lower_composite_field_type(&self, field_type: &dml::CompositeTypeFieldType) -> ast::FieldType {
-        match field_type {
-            ::dml::composite_type::CompositeTypeFieldType::CompositeType(name) => {
-                ast::FieldType::Supported(ast::Identifier::new(name))
-            }
-            ::dml::composite_type::CompositeTypeFieldType::Enum(name) => {
-                ast::FieldType::Supported(ast::Identifier::new(name))
-            }
-            ::dml::composite_type::CompositeTypeFieldType::Unsupported(name) => {
-                ast::FieldType::Unsupported(name.clone(), Span::empty())
-            }
-            ::dml::composite_type::CompositeTypeFieldType::Scalar(tpe, custom_type_name, _) => {
-                ast::FieldType::Supported(ast::Identifier::new(
-                    custom_type_name.as_ref().unwrap_or(&tpe.to_string()),
-                ))
-            }
+pub(crate) fn lower_composite_field_type(field_type: &dml::CompositeTypeFieldType) -> ast::FieldType {
+    match field_type {
+        ::dml::composite_type::CompositeTypeFieldType::CompositeType(name) => {
+            ast::FieldType::Supported(ast::Identifier::new(name))
         }
-    }
-
-    /// Internal: Lowers a field's type.
-    pub(crate) fn lower_type(&self, field_type: &dml::FieldType) -> ast::FieldType {
-        match field_type {
-            dml::FieldType::Scalar(tpe, custom_type_name, _) => ast::FieldType::Supported(ast::Identifier::new(
-                custom_type_name.as_ref().unwrap_or(&tpe.to_string()),
-            )),
-            dml::FieldType::CompositeType(name) => ast::FieldType::Supported(ast::Identifier::new(name)),
-            dml::FieldType::Enum(tpe) => ast::FieldType::Supported(ast::Identifier::new(tpe)),
-            dml::FieldType::Unsupported(tpe) => ast::FieldType::Unsupported(tpe.clone(), Span::empty()),
-            dml::FieldType::Relation(rel) => ast::FieldType::Supported(ast::Identifier::new(&rel.to)),
+        ::dml::composite_type::CompositeTypeFieldType::Enum(name) => {
+            ast::FieldType::Supported(ast::Identifier::new(name))
         }
+        ::dml::composite_type::CompositeTypeFieldType::Unsupported(name) => {
+            ast::FieldType::Unsupported(name.clone(), Span::empty())
+        }
+        ::dml::composite_type::CompositeTypeFieldType::Scalar(tpe, custom_type_name, _) => ast::FieldType::Supported(
+            ast::Identifier::new(custom_type_name.as_ref().unwrap_or(&tpe.to_string())),
+        ),
     }
+}
 
-    pub(crate) fn lower_native_type_attribute(
-        &self,
-        scalar_type: &dml::ScalarType,
-        native_type: &dml::NativeTypeInstance,
-        attributes: &mut Vec<Attribute>,
-        datasource: &Datasource,
+/// Internal: Lowers a field's type.
+pub(crate) fn lower_type(field_type: &dml::FieldType) -> ast::FieldType {
+    match field_type {
+        dml::FieldType::Scalar(tpe, custom_type_name, _) => ast::FieldType::Supported(ast::Identifier::new(
+            custom_type_name.as_ref().unwrap_or(&tpe.to_string()),
+        )),
+        dml::FieldType::CompositeType(name) => ast::FieldType::Supported(ast::Identifier::new(name)),
+        dml::FieldType::Enum(tpe) => ast::FieldType::Supported(ast::Identifier::new(tpe)),
+        dml::FieldType::Unsupported(tpe) => ast::FieldType::Unsupported(tpe.clone(), Span::empty()),
+        dml::FieldType::Relation(rel) => ast::FieldType::Supported(ast::Identifier::new(&rel.to)),
+    }
+}
+
+pub(crate) fn lower_native_type_attribute(
+    scalar_type: &dml::ScalarType,
+    native_type: &dml::NativeTypeInstance,
+    attributes: &mut Vec<Attribute>,
+    datasource: &Datasource,
+) {
+    if datasource.active_connector.native_type_is_default_for_scalar_type(
+        native_type.serialized_native_type.clone(),
+        &dml_scalar_type_to_parser_database_scalar_type(*scalar_type),
     ) {
-        if datasource.active_connector.native_type_is_default_for_scalar_type(
-            native_type.serialized_native_type.clone(),
-            &dml_scalar_type_to_parser_database_scalar_type(*scalar_type),
-        ) {
-            return;
-        }
-
-        let new_attribute_name = format!("{}.{}", datasource.name, native_type.name);
-        let arguments = native_type
-            .args
-            .iter()
-            .map(|arg| ast::Argument::new_unnamed(ast::Expression::NumericValue(arg.to_owned(), Span::empty())))
-            .collect();
-
-        attributes.push(ast::Attribute::new(new_attribute_name.as_str(), arguments));
+        return;
     }
 
-    /// Internal: Lowers a field's attributes.
-    pub(crate) fn lower_field_attributes(
-        &self,
-        model: &dml::Model,
-        field: &dml::Field,
-        datamodel: &dml::Datamodel,
-    ) -> Vec<ast::Attribute> {
-        let mut attributes = vec![];
+    let new_attribute_name = format!("{}.{}", datasource.name, native_type.name);
+    let arguments = native_type
+        .args
+        .iter()
+        .map(|arg| ast::Argument::new_unnamed(ast::Expression::NumericValue(arg.to_owned(), Span::empty())))
+        .collect();
 
-        // @id
-        if let dml::Field::ScalarField(sf) = field {
-            if model.field_is_primary_and_defined_on_field(&sf.name) {
-                let mut args = Vec::new();
-                let pk = model.primary_key.as_ref().unwrap();
-                if let Some(src) = self.datasource {
-                    if pk.db_name.is_some() && !super::primary_key_name_matches(pk, model, &*src.active_connector) {
-                        args.push(ast::Argument::new(
-                            "map",
-                            ast::Expression::StringValue(String::from(pk.db_name.as_ref().unwrap()), Span::empty()),
-                        ));
-                    }
-                }
+    attributes.push(ast::Attribute::new(new_attribute_name.as_str(), arguments));
+}
 
-                if let Some(length) = pk.fields.first().unwrap().length {
-                    args.push(ast::Argument::new(
-                        "length",
-                        ast::Expression::NumericValue(length.to_string(), Span::empty()),
-                    ));
-                }
+/// Internal: Lowers a field's attributes.
+pub(crate) fn lower_field_attributes(
+    model: &dml::Model,
+    field: &dml::Field,
+    params: LowerParams<'_>,
+) -> Vec<ast::Attribute> {
+    let datamodel = params.datamodel;
+    let mut attributes = vec![];
 
-                if let Some(SortOrder::Desc) = pk.fields.first().unwrap().sort_order {
-                    args.push(ast::Argument::new(
-                        "sort",
-                        ast::Expression::NumericValue("Desc".to_string(), Span::empty()),
-                    ));
-                }
-
-                if matches!(pk.clustered, Some(false)) {
-                    args.push(ast::Argument::new(
-                        "clustered",
-                        ast::Expression::ConstantValue("false".to_string(), Span::empty()),
-                    ));
-                }
-
-                attributes.push(ast::Attribute::new("id", args));
-            }
-        }
-
-        // @unique
-        if let dml::Field::ScalarField(sf) = field {
-            if model.field_is_unique_and_defined_on_field(&sf.name) {
-                let mut arguments = Vec::new();
-                if let Some(idx) = model.indices.iter().find(|i| {
-                    let path = &i.fields.first().unwrap().path;
-
-                    // A composite field index cannot be defined in field, so
-                    // we can do a dumb comparison.
-                    let names_match = path
-                        .first()
-                        .map(|(field_name, _)| field_name == field.name())
-                        .unwrap_or(false);
-
-                    i.is_unique() && i.defined_on_field && i.fields.len() == 1 && names_match
-                }) {
-                    if matches!(idx.clustered, Some(true)) {
-                        arguments.push(ast::Argument::new(
-                            "clustered",
-                            ast::Expression::ConstantValue("true".to_string(), Span::empty()),
-                        ));
-                    }
-
-                    self.push_field_index_arguments(datamodel, model, idx, &mut arguments);
-                }
-
-                attributes.push(ast::Attribute::new("unique", arguments));
-            }
-        }
-
-        // @default
-        if let Some(default_value) = field.default_value() {
-            let mut args = vec![ast::Argument::new_unnamed(LowerDmlToAst::<'a>::lower_default_value(
-                default_value.clone(),
-            ))];
-
-            let connector = self
-                .datasource
-                .map(|source| source.active_connector)
-                .unwrap_or(&EmptyDatamodelConnector as &dyn Connector);
-
-            let prisma_default = ConstraintNames::default_name(model.name(), field.name(), connector);
-
-            if let Some(name) = default_value.db_name() {
-                if name != prisma_default {
-                    args.push(ast::Argument::new("map", Self::lower_string(name)))
-                }
-            }
-
-            attributes.push(ast::Attribute::new("default", args));
-        }
-
-        // @updatedAt
-        if field.is_updated_at() {
-            attributes.push(ast::Attribute::new("updatedAt", Vec::new()));
-        }
-
-        // @map
-        <LowerDmlToAst<'a>>::push_model_index_map_arg(field, &mut attributes);
-
-        // @relation
-        if let dml::Field::RelationField(rf) = field {
+    // @id
+    if let dml::Field::ScalarField(sf) = field {
+        if model.field_is_primary_and_defined_on_field(&sf.name) {
             let mut args = Vec::new();
-            let relation_info = &rf.relation_info;
-            let parent_model = datamodel.find_model_by_relation_field_ref(rf).unwrap();
-
-            let related_model = datamodel
-                .find_model(&relation_info.to)
-                .unwrap_or_else(|| panic!("Related model not found: {}.", relation_info.to));
-
-            let has_default_name = relation_info.name
-                == RelationNames::name_for_unambiguous_relation(&relation_info.to, &parent_model.name);
-
-            if !relation_info.name.is_empty() && (!has_default_name || parent_model.name == related_model.name) {
-                args.push(ast::Argument::new_unnamed(ast::Expression::StringValue(
-                    relation_info.name.to_string(),
-                    ast::Span::empty(),
-                )));
+            let pk = model.primary_key.as_ref().unwrap();
+            if let Some(src) = params.datasource {
+                if pk.db_name.is_some() && !super::primary_key_name_matches(pk, model, &*src.active_connector) {
+                    args.push(ast::Argument::new(
+                        "map",
+                        ast::Expression::StringValue(String::from(pk.db_name.as_ref().unwrap()), Span::empty()),
+                    ));
+                }
             }
 
-            let mut relation_fields = relation_info.references.clone();
-
-            relation_fields.sort();
-
-            if !relation_info.fields.is_empty() {
-                args.push(ast::Argument::new_array(
-                    "fields",
-                    LowerDmlToAst::field_array(&relation_info.fields),
+            if let Some(length) = pk.fields.first().unwrap().length {
+                args.push(ast::Argument::new(
+                    "length",
+                    ast::Expression::NumericValue(length.to_string(), Span::empty()),
                 ));
             }
 
-            // if we are on the physical field
-            if !relation_info.references.is_empty() {
-                let is_many_to_many = match &field {
-                    Field::RelationField(relation_field) => {
-                        let (_, related_field) = datamodel.find_related_field(relation_field).unwrap();
-                        relation_field.arity.is_list() && related_field.arity.is_list()
-                    }
-                    _ => false,
-                };
+            if let Some(SortOrder::Desc) = pk.fields.first().unwrap().sort_order {
+                args.push(ast::Argument::new(
+                    "sort",
+                    ast::Expression::NumericValue("Desc".to_string(), Span::empty()),
+                ));
+            }
 
-                if !is_many_to_many {
-                    args.push(ast::Argument::new_array(
-                        "references",
-                        LowerDmlToAst::field_array(&relation_info.references),
+            if matches!(pk.clustered, Some(false)) {
+                args.push(ast::Argument::new(
+                    "clustered",
+                    ast::Expression::ConstantValue("false".to_string(), Span::empty()),
+                ));
+            }
+
+            attributes.push(ast::Attribute::new("id", args));
+        }
+    }
+
+    // @unique
+    if let dml::Field::ScalarField(sf) = field {
+        if model.field_is_unique_and_defined_on_field(&sf.name) {
+            let mut arguments = Vec::new();
+            if let Some(idx) = model.indices.iter().find(|i| {
+                let path = &i.fields.first().unwrap().path;
+
+                // A composite field index cannot be defined in field, so
+                // we can do a dumb comparison.
+                let names_match = path
+                    .first()
+                    .map(|(field_name, _)| field_name == field.name())
+                    .unwrap_or(false);
+
+                i.is_unique() && i.defined_on_field && i.fields.len() == 1 && names_match
+            }) {
+                if matches!(idx.clustered, Some(true)) {
+                    arguments.push(ast::Argument::new(
+                        "clustered",
+                        ast::Expression::ConstantValue("true".to_string(), Span::empty()),
                     ));
                 }
+
+                push_field_index_arguments(model, idx, &mut arguments, params);
             }
 
-            if let Some(ref_action) = relation_info.on_delete {
-                if rf.default_on_delete_action() != ref_action {
-                    let expression = ast::Expression::ConstantValue(ref_action.to_string(), ast::Span::empty());
-                    args.push(ast::Argument::new("onDelete", expression));
-                }
-            }
-
-            if let Some(ref_action) = relation_info.on_update {
-                if rf.default_on_update_action() != ref_action {
-                    let expression = ast::Expression::ConstantValue(ref_action.to_string(), ast::Span::empty());
-                    args.push(ast::Argument::new("onUpdate", expression));
-                }
-            }
-
-            if let Some(fk_name) = &relation_info.fk_name {
-                if let Some(src) = self.datasource {
-                    if !super::foreign_key_name_matches(relation_info, model, &*src.active_connector) {
-                        args.push(ast::Argument::new(
-                            "map",
-                            ast::Expression::StringValue(String::from(fk_name), Span::empty()),
-                        ));
-                    }
-                };
-            }
-
-            if !args.is_empty() {
-                attributes.push(ast::Attribute::new("relation", args));
-            }
-        }
-
-        // @ignore
-        if field.is_ignored() {
-            attributes.push(ast::Attribute::new("ignore", vec![]));
-        }
-
-        attributes
-    }
-
-    pub fn lower_default_value(dv: dml::DefaultValue) -> ast::Expression {
-        match dv.kind() {
-            dml::DefaultKind::Single(v) => LowerDmlToAst::<'a>::lower_prisma_value(v),
-            dml::DefaultKind::Expression(e) => {
-                let arguments = e
-                    .args()
-                    .iter()
-                    .map(|(name, value)| {
-                        let value = LowerDmlToAst::<'a>::lower_prisma_value(value);
-                        match name {
-                            Some(name) => ast::Argument::new(name, value),
-                            None => ast::Argument::new_unnamed(value),
-                        }
-                    })
-                    .collect();
-                ast::Expression::Function(
-                    e.name().to_string(),
-                    ast::ArgumentsList {
-                        arguments,
-                        ..Default::default()
-                    },
-                    ast::Span::empty(),
-                )
-            }
+            attributes.push(ast::Attribute::new("unique", arguments));
         }
     }
 
-    pub fn lower_string(s: impl ToString) -> ast::Expression {
-        ast::Expression::StringValue(s.to_string(), ast::Span::empty())
+    // @default
+    if let Some(default_value) = field.default_value() {
+        let mut args = vec![ast::Argument::new_unnamed(lower_default_value(default_value.clone()))];
+
+        let connector = params
+            .datasource
+            .map(|source| source.active_connector)
+            .unwrap_or(&EmptyDatamodelConnector as &dyn Connector);
+
+        let prisma_default = ConstraintNames::default_name(model.name(), field.name(), connector);
+
+        if let Some(name) = default_value.db_name() {
+            if name != prisma_default {
+                args.push(ast::Argument::new("map", lower_string(name)))
+            }
+        }
+
+        attributes.push(ast::Attribute::new("default", args));
     }
 
-    pub fn lower_prisma_value(pv: &PrismaValue) -> ast::Expression {
-        match pv {
-            PrismaValue::Boolean(true) => ast::Expression::ConstantValue(String::from("true"), ast::Span::empty()),
-            PrismaValue::Boolean(false) => ast::Expression::ConstantValue(String::from("false"), ast::Span::empty()),
-            PrismaValue::String(value) => Self::lower_string(value),
-            PrismaValue::Enum(value) => ast::Expression::ConstantValue(value.clone(), ast::Span::empty()),
-            PrismaValue::DateTime(value) => Self::lower_string(value),
-            PrismaValue::Float(value) => ast::Expression::NumericValue(value.to_string(), ast::Span::empty()),
-            PrismaValue::Int(value) => ast::Expression::NumericValue(value.to_string(), ast::Span::empty()),
-            PrismaValue::BigInt(value) => ast::Expression::NumericValue(value.to_string(), ast::Span::empty()),
-            PrismaValue::Null => ast::Expression::ConstantValue("null".to_string(), ast::Span::empty()),
-            PrismaValue::Uuid(val) => Self::lower_string(val),
-            PrismaValue::Json(val) => Self::lower_string(val),
-            PrismaValue::List(vec) => ast::Expression::Array(
-                vec.iter().map(LowerDmlToAst::<'a>::lower_prisma_value).collect(),
+    // @updatedAt
+    if field.is_updated_at() {
+        attributes.push(ast::Attribute::new("updatedAt", Vec::new()));
+    }
+
+    // @map
+    push_model_index_map_arg(field, &mut attributes);
+
+    // @relation
+    if let dml::Field::RelationField(rf) = field {
+        let mut args = Vec::new();
+        let relation_info = &rf.relation_info;
+        let parent_model = datamodel.find_model_by_relation_field_ref(rf).unwrap();
+
+        let related_model = datamodel
+            .find_model(&relation_info.to)
+            .unwrap_or_else(|| panic!("Related model not found: {}.", relation_info.to));
+
+        let has_default_name =
+            relation_info.name == RelationNames::name_for_unambiguous_relation(&relation_info.to, &parent_model.name);
+
+        if !relation_info.name.is_empty() && (!has_default_name || parent_model.name == related_model.name) {
+            args.push(ast::Argument::new_unnamed(ast::Expression::StringValue(
+                relation_info.name.to_string(),
                 ast::Span::empty(),
-            ),
-            PrismaValue::Xml(val) => ast::Expression::StringValue(val.to_string(), ast::Span::empty()),
-            PrismaValue::Bytes(b) => ast::Expression::StringValue(prisma_value::encode_bytes(b), ast::Span::empty()),
-            PrismaValue::Object(_) => unreachable!(), // There's no concept of object values in the PSL right now.
+            )));
         }
+
+        let mut relation_fields = relation_info.references.clone();
+
+        relation_fields.sort();
+
+        if !relation_info.fields.is_empty() {
+            args.push(ast::Argument::new_array("fields", field_array(&relation_info.fields)));
+        }
+
+        // if we are on the physical field
+        if !relation_info.references.is_empty() {
+            let is_many_to_many = match &field {
+                Field::RelationField(relation_field) => {
+                    let (_, related_field) = datamodel.find_related_field(relation_field).unwrap();
+                    relation_field.arity.is_list() && related_field.arity.is_list()
+                }
+                _ => false,
+            };
+
+            if !is_many_to_many {
+                args.push(ast::Argument::new_array(
+                    "references",
+                    field_array(&relation_info.references),
+                ));
+            }
+        }
+
+        if let Some(ref_action) = relation_info.on_delete {
+            if rf.default_on_delete_action() != ref_action {
+                let expression = ast::Expression::ConstantValue(ref_action.to_string(), ast::Span::empty());
+                args.push(ast::Argument::new("onDelete", expression));
+            }
+        }
+
+        if let Some(ref_action) = relation_info.on_update {
+            if rf.default_on_update_action() != ref_action {
+                let expression = ast::Expression::ConstantValue(ref_action.to_string(), ast::Span::empty());
+                args.push(ast::Argument::new("onUpdate", expression));
+            }
+        }
+
+        if let Some(fk_name) = &relation_info.fk_name {
+            if let Some(src) = params.datasource {
+                if !super::foreign_key_name_matches(relation_info, model, &*src.active_connector) {
+                    args.push(ast::Argument::new(
+                        "map",
+                        ast::Expression::StringValue(String::from(fk_name), Span::empty()),
+                    ));
+                }
+            };
+        }
+
+        if !args.is_empty() {
+            attributes.push(ast::Attribute::new("relation", args));
+        }
+    }
+
+    // @ignore
+    if field.is_ignored() {
+        attributes.push(ast::Attribute::new("ignore", vec![]));
+    }
+
+    attributes
+}
+
+pub fn lower_default_value(dv: dml::DefaultValue) -> ast::Expression {
+    match dv.kind() {
+        dml::DefaultKind::Single(v) => lower_prisma_value(v),
+        dml::DefaultKind::Expression(e) => {
+            let arguments = e
+                .args()
+                .iter()
+                .map(|(name, value)| {
+                    let value = lower_prisma_value(value);
+                    match name {
+                        Some(name) => ast::Argument::new(name, value),
+                        None => ast::Argument::new_unnamed(value),
+                    }
+                })
+                .collect();
+            ast::Expression::Function(
+                e.name().to_string(),
+                ast::ArgumentsList {
+                    arguments,
+                    ..Default::default()
+                },
+                ast::Span::empty(),
+            )
+        }
+    }
+}
+
+pub fn lower_string(s: impl ToString) -> ast::Expression {
+    ast::Expression::StringValue(s.to_string(), ast::Span::empty())
+}
+
+pub fn lower_prisma_value(pv: &PrismaValue) -> ast::Expression {
+    match pv {
+        PrismaValue::Boolean(true) => ast::Expression::ConstantValue(String::from("true"), ast::Span::empty()),
+        PrismaValue::Boolean(false) => ast::Expression::ConstantValue(String::from("false"), ast::Span::empty()),
+        PrismaValue::String(value) => lower_string(value),
+        PrismaValue::Enum(value) => ast::Expression::ConstantValue(value.clone(), ast::Span::empty()),
+        PrismaValue::DateTime(value) => lower_string(value),
+        PrismaValue::Float(value) => ast::Expression::NumericValue(value.to_string(), ast::Span::empty()),
+        PrismaValue::Int(value) => ast::Expression::NumericValue(value.to_string(), ast::Span::empty()),
+        PrismaValue::BigInt(value) => ast::Expression::NumericValue(value.to_string(), ast::Span::empty()),
+        PrismaValue::Null => ast::Expression::ConstantValue("null".to_string(), ast::Span::empty()),
+        PrismaValue::Uuid(val) => lower_string(val),
+        PrismaValue::Json(val) => lower_string(val),
+        PrismaValue::List(vec) => {
+            ast::Expression::Array(vec.iter().map(lower_prisma_value).collect(), ast::Span::empty())
+        }
+        PrismaValue::Xml(val) => ast::Expression::StringValue(val.to_string(), ast::Span::empty()),
+        PrismaValue::Bytes(b) => ast::Expression::StringValue(prisma_value::encode_bytes(b), ast::Span::empty()),
+        PrismaValue::Object(_) => unreachable!(), // There's no concept of object values in the PSL right now.
     }
 }
 

--- a/libs/datamodel/core/src/transform/dml_to_ast/lower_model_attributes.rs
+++ b/libs/datamodel/core/src/transform/dml_to_ast/lower_model_attributes.rs
@@ -1,196 +1,190 @@
-use crate::ast::{Argument, Attribute};
-use crate::transform::dml_to_ast::LowerDmlToAst;
+use super::*;
 use crate::{
-    ast::{self, Span},
+    ast::{self, Argument, Attribute, Span},
     dml::{self, Ignorable, IndexDefinition, IndexType, Model, SortOrder, WithDatabaseName},
 };
-use ::dml::datamodel::Datamodel;
 use ::dml::model::IndexAlgorithm;
 
-impl<'a> LowerDmlToAst<'a> {
-    /// Internal: Lowers a model's attributes.
-    pub(crate) fn lower_model_attributes(&self, datamodel: &Datamodel, model: &dml::Model) -> Vec<ast::Attribute> {
-        let mut attributes = vec![];
+/// Internal: Lowers a model's attributes.
+pub(crate) fn lower_model_attributes(model: &dml::Model, params: LowerParams<'_>) -> Vec<ast::Attribute> {
+    let mut attributes = vec![];
 
-        // @@id
+    // @@id
 
-        if let Some(pk) = &model.primary_key {
-            if !pk.defined_on_field {
-                let mut args = vec![ast::Argument::new_unnamed(ast::Expression::Array(
-                    LowerDmlToAst::pk_field_array(&pk.fields),
-                    ast::Span::empty(),
-                ))];
+    if let Some(pk) = &model.primary_key {
+        if !pk.defined_on_field {
+            let mut args = vec![ast::Argument::new_unnamed(ast::Expression::Array(
+                pk_field_array(&pk.fields),
+                ast::Span::empty(),
+            ))];
 
-                if pk.name.is_some() {
-                    args.push(ast::Argument::new(
-                        "name",
-                        ast::Expression::StringValue(String::from(pk.name.as_ref().unwrap()), Span::empty()),
-                    ));
-                }
-
-                if pk.db_name.is_some() {
-                    if let Some(src) = self.datasource {
-                        if !super::primary_key_name_matches(pk, model, &*src.active_connector) {
-                            args.push(ast::Argument::new(
-                                "map",
-                                ast::Expression::StringValue(String::from(pk.db_name.as_ref().unwrap()), Span::empty()),
-                            ));
-                        }
-                    }
-                }
-
-                if matches!(pk.clustered, Some(false)) {
-                    args.push(ast::Argument::new(
-                        "clustered",
-                        ast::Expression::ConstantValue("false".to_string(), Span::empty()),
-                    ));
-                }
-
-                attributes.push(ast::Attribute::new("id", args));
+            if pk.name.is_some() {
+                args.push(ast::Argument::new(
+                    "name",
+                    ast::Expression::StringValue(String::from(pk.name.as_ref().unwrap()), Span::empty()),
+                ));
             }
-        }
 
-        // @@unique
-        model
-            .indices
-            .iter()
-            .filter(|index| index.is_unique() && !index.defined_on_field)
-            .for_each(|index_def| {
-                let mut args = self.fields_argument(index_def, false);
-                if let Some(name) = &index_def.name {
-                    args.push(ast::Argument::new_string("name", name.to_string()));
-                }
-
-                self.push_index_map_argument(datamodel, model, index_def, &mut args);
-
-                if matches!(index_def.clustered, Some(true)) {
-                    args.push(ast::Argument::new(
-                        "clustered",
-                        ast::Expression::NumericValue("true".to_string(), Span::empty()),
-                    ));
-                }
-
-                attributes.push(ast::Attribute::new("unique", args));
-            });
-
-        // @@index
-        model
-            .indices
-            .iter()
-            .filter(|index| index.tpe == IndexType::Normal)
-            .for_each(|index_def| {
-                let mut args = self.fields_argument(index_def, false);
-                self.push_index_map_argument(datamodel, model, index_def, &mut args);
-
-                match index_def.algorithm {
-                    Some(IndexAlgorithm::BTree) | None => (),
-                    Some(algo) => {
+            if pk.db_name.is_some() {
+                if let Some(src) = params.datasource {
+                    if !super::primary_key_name_matches(pk, model, &*src.active_connector) {
                         args.push(ast::Argument::new(
-                            "type",
-                            ast::Expression::ConstantValue(algo.to_string(), Span::empty()),
+                            "map",
+                            ast::Expression::StringValue(String::from(pk.db_name.as_ref().unwrap()), Span::empty()),
                         ));
                     }
                 }
+            }
 
-                if matches!(index_def.clustered, Some(true)) {
+            if matches!(pk.clustered, Some(false)) {
+                args.push(ast::Argument::new(
+                    "clustered",
+                    ast::Expression::ConstantValue("false".to_string(), Span::empty()),
+                ));
+            }
+
+            attributes.push(ast::Attribute::new("id", args));
+        }
+    }
+
+    // @@unique
+    model
+        .indices
+        .iter()
+        .filter(|index| index.is_unique() && !index.defined_on_field)
+        .for_each(|index_def| {
+            let mut args = fields_argument(index_def, false);
+            if let Some(name) = &index_def.name {
+                args.push(ast::Argument::new_string("name", name.to_string()));
+            }
+
+            push_index_map_argument(model, index_def, &mut args, params);
+
+            if matches!(index_def.clustered, Some(true)) {
+                args.push(ast::Argument::new(
+                    "clustered",
+                    ast::Expression::NumericValue("true".to_string(), Span::empty()),
+                ));
+            }
+
+            attributes.push(ast::Attribute::new("unique", args));
+        });
+
+    // @@index
+    model
+        .indices
+        .iter()
+        .filter(|index| index.tpe == IndexType::Normal)
+        .for_each(|index_def| {
+            let mut args = fields_argument(index_def, false);
+            push_index_map_argument(model, index_def, &mut args, params);
+
+            match index_def.algorithm {
+                Some(IndexAlgorithm::BTree) | None => (),
+                Some(algo) => {
                     args.push(ast::Argument::new(
-                        "clustered",
-                        ast::Expression::ConstantValue("true".to_string(), Span::empty()),
+                        "type",
+                        ast::Expression::ConstantValue(algo.to_string(), Span::empty()),
                     ));
                 }
+            }
 
-                attributes.push(ast::Attribute::new("index", args));
-            });
-
-        // @@fulltext
-        model
-            .indices
-            .iter()
-            .filter(|index| index.is_fulltext())
-            .for_each(|index_def| {
-                let mut args = self.fields_argument(index_def, true);
-                self.push_index_map_argument(datamodel, model, index_def, &mut args);
-
-                attributes.push(ast::Attribute::new("fulltext", args));
-            });
-
-        // @@map
-        <LowerDmlToAst<'a>>::push_model_index_map_arg(model, &mut attributes);
-
-        // @@ignore
-        if model.is_ignored() {
-            attributes.push(ast::Attribute::new("ignore", vec![]));
-        }
-
-        attributes
-    }
-
-    fn fields_argument(&self, index_def: &IndexDefinition, always_render_sort_order: bool) -> Vec<Argument> {
-        vec![ast::Argument::new_unnamed(ast::Expression::Array(
-            LowerDmlToAst::index_field_array(&index_def.fields, always_render_sort_order),
-            ast::Span::empty(),
-        ))]
-    }
-
-    pub(crate) fn push_field_index_arguments(
-        &self,
-        datamodel: &Datamodel,
-        model: &Model,
-        index_def: &IndexDefinition,
-        args: &mut Vec<Argument>,
-    ) {
-        let field = index_def.fields.first().unwrap();
-
-        if let Some(src) = self.datasource {
-            if !super::index_name_matches(index_def, datamodel, model, &*src.active_connector) {
+            if matches!(index_def.clustered, Some(true)) {
                 args.push(ast::Argument::new(
-                    "map",
-                    ast::Expression::StringValue(String::from(index_def.db_name.as_ref().unwrap()), Span::empty()),
+                    "clustered",
+                    ast::Expression::ConstantValue("true".to_string(), Span::empty()),
                 ));
             }
 
-            if let Some(length) = field.length {
-                args.push(ast::Argument::new(
-                    "length",
-                    ast::Expression::NumericValue(length.to_string(), Span::empty()),
-                ));
-            }
+            attributes.push(ast::Attribute::new("index", args));
+        });
 
-            if field.sort_order == Some(SortOrder::Desc) {
-                args.push(ast::Argument::new(
-                    "sort",
-                    ast::Expression::ConstantValue("Desc".to_string(), Span::empty()),
-                ));
-            }
-        }
+    // @@fulltext
+    model
+        .indices
+        .iter()
+        .filter(|index| index.is_fulltext())
+        .for_each(|index_def| {
+            let mut args = fields_argument(index_def, true);
+            push_index_map_argument(model, index_def, &mut args, params);
+
+            attributes.push(ast::Attribute::new("fulltext", args));
+        });
+
+    // @@map
+    push_model_index_map_arg(model, &mut attributes);
+
+    // @@ignore
+    if model.is_ignored() {
+        attributes.push(ast::Attribute::new("ignore", vec![]));
     }
 
-    pub(crate) fn push_index_map_argument(
-        &self,
-        datamodel: &Datamodel,
-        model: &Model,
-        index_def: &IndexDefinition,
-        args: &mut Vec<Argument>,
-    ) {
-        if let Some(src) = self.datasource {
-            if !super::index_name_matches(index_def, datamodel, model, &*src.active_connector) {
-                args.push(ast::Argument::new(
-                    "map",
-                    ast::Expression::StringValue(String::from(index_def.db_name.as_ref().unwrap()), Span::empty()),
-                ));
-            }
-        }
-    }
+    attributes
+}
 
-    pub(crate) fn push_model_index_map_arg<T: WithDatabaseName>(obj: &T, attributes: &mut Vec<Attribute>) {
-        if let Some(db_name) = obj.database_name() {
-            attributes.push(ast::Attribute::new(
+fn fields_argument(index_def: &IndexDefinition, always_render_sort_order: bool) -> Vec<Argument> {
+    vec![ast::Argument::new_unnamed(ast::Expression::Array(
+        index_field_array(&index_def.fields, always_render_sort_order),
+        ast::Span::empty(),
+    ))]
+}
+
+pub(crate) fn push_field_index_arguments(
+    model: &Model,
+    index_def: &IndexDefinition,
+    args: &mut Vec<Argument>,
+    params: LowerParams<'_>,
+) {
+    let field = index_def.fields.first().unwrap();
+
+    if let Some(src) = params.datasource {
+        if !super::index_name_matches(index_def, params.datamodel, model, &*src.active_connector) {
+            args.push(ast::Argument::new(
                 "map",
-                vec![ast::Argument::new_unnamed(ast::Expression::StringValue(
-                    String::from(db_name),
-                    Span::empty(),
-                ))],
+                ast::Expression::StringValue(String::from(index_def.db_name.as_ref().unwrap()), Span::empty()),
             ));
         }
+
+        if let Some(length) = field.length {
+            args.push(ast::Argument::new(
+                "length",
+                ast::Expression::NumericValue(length.to_string(), Span::empty()),
+            ));
+        }
+
+        if field.sort_order == Some(SortOrder::Desc) {
+            args.push(ast::Argument::new(
+                "sort",
+                ast::Expression::ConstantValue("Desc".to_string(), Span::empty()),
+            ));
+        }
+    }
+}
+
+pub(crate) fn push_index_map_argument(
+    model: &Model,
+    index_def: &IndexDefinition,
+    args: &mut Vec<Argument>,
+    params: LowerParams<'_>,
+) {
+    if let Some(src) = params.datasource {
+        if !super::index_name_matches(index_def, params.datamodel, model, &*src.active_connector) {
+            args.push(ast::Argument::new(
+                "map",
+                ast::Expression::StringValue(String::from(index_def.db_name.as_ref().unwrap()), Span::empty()),
+            ));
+        }
+    }
+}
+
+pub(crate) fn push_model_index_map_arg<T: WithDatabaseName>(obj: &T, attributes: &mut Vec<Attribute>) {
+    if let Some(db_name) = obj.database_name() {
+        attributes.push(ast::Attribute::new(
+            "map",
+            vec![ast::Argument::new_unnamed(ast::Expression::StringValue(
+                String::from(db_name),
+                Span::empty(),
+            ))],
+        ));
     }
 }

--- a/libs/datamodel/core/src/transform/dml_to_ast/mod.rs
+++ b/libs/datamodel/core/src/transform/dml_to_ast/mod.rs
@@ -6,14 +6,19 @@ mod lower_enum_value_attributes;
 mod lower_field;
 mod lower_model_attributes;
 
-pub use datasource_serializer::add_sources_to_ast;
-use dml::datamodel::Datamodel;
-pub use generator_serializer::GeneratorSerializer;
-pub use lower::LowerDmlToAst;
+pub(crate) use datasource_serializer::add_sources_to_ast;
+pub(crate) use generator_serializer::GeneratorSerializer;
+pub(crate) use lower::{lower, LowerParams};
 
 use crate::{ast, configuration::StringFromEnvVar};
 use ::dml::{model::*, traits::*};
 use datamodel_connector::{constraint_names::ConstraintNames, Connector};
+use dml::datamodel::Datamodel;
+use lower::*;
+use lower_enum_attributes::*;
+use lower_enum_value_attributes::*;
+use lower_field::*;
+use lower_model_attributes::*;
 
 fn lower_string_from_env_var(arg_name: &str, string_from_env: &StringFromEnvVar) -> ast::ConfigBlockProperty {
     match string_from_env.as_env_var() {

--- a/libs/datamodel/core/tests/attributes/constraint_names.rs
+++ b/libs/datamodel/core/tests/attributes/constraint_names.rs
@@ -1,5 +1,4 @@
 use crate::common::*;
-use datamodel::render_datamodel_to_with_preview_flags;
 
 #[test]
 fn constraint_names() {
@@ -191,15 +190,9 @@ fn constraint_names() {
     "#]];
 
     let datamodel = parse(input);
-    let preview_features = parse_configuration(input).preview_features();
     let mut rendered = String::new();
 
-    render_datamodel_to_with_preview_flags(
-        &mut rendered,
-        &datamodel,
-        parse_configuration(input).datasources.first(),
-        preview_features,
-    );
+    datamodel::render_datamodel_to(&mut rendered, &datamodel, Some(&parse_configuration(input)));
 
     //todo can't be exactly the same since explicit default names will be suppressed when rerendering
     // the expected result after parsing and rendering is not exactly the same as the input.


### PR DESCRIPTION
In order to fix https://github.com/prisma/prisma/issues/12998, we want
LowerDmlToAst to take a new parameter. To make room for it without
changing the lowering API outside of introspection, this commit removes
the LowerDmlToAst struct and replaces it with a free-standing function
taking a context-like argument (LowerParams).

The resulting code is more consistent with the patterns we use in the
parser database and validation, and arguably simpler, easier to follow.