### PR TITLE
Relation references must always be unique for QE to work

### DIFF
--- a/libs/datamodel/connectors/datamodel-connector/src/capabilities.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/capabilities.rs
@@ -43,7 +43,6 @@ macro_rules! capabilities {
 capabilities!(
     // General capabilities, not specific to any part of Prisma.
     ScalarLists,
-    RelationsOverNonUniqueCriteria,
     Enums,
     EnumArrayPush,
     Json,

--- a/libs/datamodel/connectors/datamodel-connector/src/lib.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/lib.rs
@@ -195,10 +195,6 @@ pub trait Connector: Send + Sync {
         self.has_capability(ConnectorCapability::ScalarLists)
     }
 
-    fn supports_relations_over_non_unique_criteria(&self) -> bool {
-        self.has_capability(ConnectorCapability::RelationsOverNonUniqueCriteria)
-    }
-
     fn supports_enums(&self) -> bool {
         self.has_capability(ConnectorCapability::Enums)
     }

--- a/libs/datamodel/connectors/mongodb-datamodel-connector/src/lib.rs
+++ b/libs/datamodel/connectors/mongodb-datamodel-connector/src/lib.rs
@@ -11,7 +11,6 @@ use native_types::{MongoDbType, NativeType};
 use std::result::Result as StdResult;
 
 const CAPABILITIES: &[ConnectorCapability] = &[
-    ConnectorCapability::RelationsOverNonUniqueCriteria,
     ConnectorCapability::Json,
     ConnectorCapability::Enums,
     ConnectorCapability::EnumArrayPush,

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
@@ -92,7 +92,6 @@ const NATIVE_TYPE_CONSTRUCTORS: &[NativeTypeConstructor] = &[
 ];
 
 const CAPABILITIES: &[ConnectorCapability] = &[
-    ConnectorCapability::RelationsOverNonUniqueCriteria,
     ConnectorCapability::Enums,
     ConnectorCapability::EnumArrayPush,
     ConnectorCapability::Json,

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/relations.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/relations.rs
@@ -130,9 +130,7 @@ pub(super) fn references_unique_fields(relation: InlineRelationWalker<'_>, ctx: 
         return;
     };
 
-    if relation_field.referenced_fields().map(|f| f.len() == 0).unwrap_or(true)
-        || !ctx.diagnostics.errors().is_empty()
-        || ctx.connector.supports_relations_over_non_unique_criteria()
+    if relation_field.referenced_fields().map(|f| f.len() == 0).unwrap_or(true) || !ctx.diagnostics.errors().is_empty()
     {
         return;
     }

--- a/libs/datamodel/core/tests/attributes/relations/relations_new.rs
+++ b/libs/datamodel/core/tests/attributes/relations/relations_new.rs
@@ -361,33 +361,6 @@ fn relation_must_succeed_when_referenced_fields_are_a_unique_criteria() {
 }
 
 #[test]
-fn relation_must_not_error_when_referenced_fields_are_not_a_unique_criteria_on_mysql() {
-    // MySQL allows foreign key to references a non unique criteria
-    // https://stackoverflow.com/questions/588741/can-a-foreign-key-reference-a-non-unique-index
-    let dml = r#"
-    datasource db {
-        provider = "mysql"
-        url = "mysql://localhost:3306"
-    }
-
-    model User {
-        id        Int    @id
-        firstName String
-        posts     Post[]
-    }
-
-    model Post {
-        id       Int    @id
-        text     String
-        userName String
-        user     User   @relation(fields: [userName], references: [firstName])
-    }
-    "#;
-
-    let _ = parse(dml);
-}
-
-#[test]
 fn relation_must_error_when_referenced_fields_are_multiple_uniques() {
     let dml = r#"
     model User {

--- a/libs/datamodel/core/tests/capabilities/mysql.rs
+++ b/libs/datamodel/core/tests/capabilities/mysql.rs
@@ -96,30 +96,6 @@ fn json_support() {
 }
 
 #[test]
-fn non_unique_relation_criteria_support() {
-    let dml = indoc! {r#"
-        datasource db {
-          provider = "mysql"
-          url = "mysql://"
-        }
-
-        model Todo {
-          id           Int    @id
-          assigneeName String
-          assignee     User   @relation(fields: [assigneeName], references: [name])
-        }
-
-        model User {
-          id   Int    @id
-          name String
-          todos Todo[]
-        }
-    "#};
-
-    assert!(datamodel::parse_schema(dml).is_ok());
-}
-
-#[test]
 fn auto_increment_on_non_primary_column_support() {
     let dml = indoc! {r#"
         datasource db {


### PR DESCRIPTION
So... In the database level MySQL and MongoDB can have relations referencing fields that are not unique. This is fine for migrations/introspection, but will panic the Query Engine in some queries.

We could make this uniform over all databases we support, and would be the easiest way to fix the issues in Query Engine too. This is a breaking change for MongoDB and MySQL.

Internal writeup: https://www.notion.so/prismaio/MySQL-Foreign-Keys-Without-Unique-Constraints-7b446d82efbb4de4afa70a695352e1d6

Closes: https://github.com/prisma/prisma/issues/13340