### PR TITLE
BuildJet 16 vCPU runners

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   build:
     name: "WebAssembly build ${{ github.event.ref }} for commit ${{ github.event.inputs.commit }}"
-    runs-on: ubuntu-latest
+    runs-on: buildjet-16vcpu-ubuntu-2004
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -22,14 +22,6 @@ jobs:
           toolchain: stable
           target: wasm32-unknown-unknown
           default: true
-
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build the datamodel crate with default features
         uses: actions-rs/cargo@v1

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -13,22 +13,18 @@ on:
 
 jobs:
   clippy:
-    runs-on: ubuntu-latest
+    runs-on: buildjet-16vcpu-ubuntu-2004
     env:
       RUSTFLAGS: "-Dwarnings"
     steps:
       - uses: actions/checkout@v2
+
       - uses: actions-rs/toolchain@v1
         with:
             toolchain: stable
             components: clippy
             override: true
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: clippy
+
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/migration-engine.yml
+++ b/.github/workflows/migration-engine.yml
@@ -24,9 +24,15 @@ jobs:
             url: "mongodb://prisma:prisma@localhost:27017/?authSource=admin&retryWrites=true"
           - name: "mongodb5"
             url: "mongodb://prisma:prisma@localhost:27018/?authSource=admin&retryWrites=true"
-    runs-on: ubuntu-latest
+    runs-on: buildjet-16vcpu-ubuntu-2004
     steps:
       - uses: actions/checkout@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: "Start ${{ matrix.database.name }}"
         run: make start-${{ matrix.database.name }}-single
@@ -35,14 +41,6 @@ jobs:
         with:
           toolchain: stable
           default: true
-
-      # - uses: actions/cache@v2
-      #   with:
-      #     path: |
-      #       ~/.cargo/registry
-      #       ~/.cargo/git
-      #       target
-      #     key: me-ie-ubuntu-latest-mongodb-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - run: cargo test -p mongodb-introspection-connector
         env:
@@ -102,9 +100,15 @@ jobs:
             is_vitess: true
             single_threaded: true
 
-    runs-on: ubuntu-latest
+    runs-on: buildjet-16vcpu-ubuntu-2004
     steps:
       - uses: actions/checkout@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: "Start ${{ matrix.database.name }}"
         run: make start-${{ matrix.database.name }}
@@ -113,14 +117,6 @@ jobs:
         with:
           toolchain: stable
           default: true
-
-      # - uses: actions/cache@v2
-      #   with:
-      #     path: |
-      #       ~/.cargo/registry
-      #       ~/.cargo/git
-      #       target
-      #     key: me-ie-${{ runner.os }}-${{ matrix.database.name }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - run: cargo test -p introspection-engine-tests
         if: ${{ !matrix.database.single_threaded }}

--- a/.github/workflows/query-engine.yml
+++ b/.github/workflows/query-engine.yml
@@ -13,14 +13,16 @@ on:
 
 jobs:
   rust-vitess-tests:
-    name: "Rust test suite: ${{ matrix.database }} on Linux"
+    name: "Rust test suite: ${{ matrix.database.name }} on Linux"
 
     strategy:
       fail-fast: false
       matrix:
         database:
-          - "vitess_5_7"
-          - "vitess_8_0"
+          - name: "vitess_5_7"
+            single_threaded: true
+          - name: "vitess_8_0"
+            single_threaded: true
 
     env:
       LOG_LEVEL: "info"
@@ -29,26 +31,30 @@ jobs:
       RUST_BACKTRACE: 1
       CLICOLOR_FORCE: 1
 
-    runs-on: ubuntu-latest
+    runs-on: buildjet-16vcpu-ubuntu-2004
     steps:
       - uses: actions/checkout@v2
 
-      - name: "Start ${{ matrix.database }}"
-        run: make dev-${{ matrix.database }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: "Start ${{ matrix.database.name }}"
+        run: make dev-${{ matrix.database.name }}
 
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           default: true
 
-      # - uses: actions/cache@v2
-      #   with:
-      #     path: |
-      #       ~/.cargo/registry
-      #       ~/.cargo/git
-      #       target
-      #     key: query-engine-rust-${{ runner.os }}-cargo-vitess-${{ matrix.version }}-${{ hashFiles('**/Cargo.lock') }}
-
       - run: export WORKSPACE_ROOT=$(pwd) && cargo test --package query-engine-tests -- --test-threads=1
+        if: ${{ matrix.database.single_threaded }}
+        env:
+          CLICOLOR_FORCE: 1
+
+      - run: export WORKSPACE_ROOT=$(pwd) && cargo test --package query-engine-tests
+        if: ${{ !matrix.database.single_threaded }}
         env:
           CLICOLOR_FORCE: 1

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -10,7 +10,7 @@ on:
       - 'LICENSE'
       - 'CODEOWNERS'
       - 'renovate.json'
-      
+
 jobs:
   test:
     name: Workspace unit tests
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
 
-    runs-on: ubuntu-latest
+    runs-on: buildjet-16vcpu-ubuntu-2004
     steps:
       - uses: actions/checkout@v2
 
@@ -26,14 +26,6 @@ jobs:
         with:
           toolchain: stable
           default: true
-
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: datamodel-cache-v2
 
       - run: |
             cargo test --workspace \

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ start-cockroach_22_1_0:
 	docker-compose -f docker-compose.yml up -d --remove-orphans cockroach_22_1_0
 
 dev-cockroach_22_1_0: start-cockroach_22_1_0
-	cp $(CONFIG_PATH)/cockroach_22_1_0 $(CONFIG_FILE)
+	cp $(CONFIG_PATH)/cockroach $(CONFIG_FILE)
 
 start-cockroach_21_2_0_patched:
 	docker-compose -f docker-compose.yml up -d --remove-orphans cockroach_21_2_0_patched


### PR DESCRIPTION
We pay BuildJet for fast CI machines, so why not using them in engines too. The TS repo already uses these runners, and for engines we go with 16 vCPU instances, meaning many of our test runs are down from 14 minutes to 4 minutes approximately.