### PR TITLE
Allow `length` prefix on unsupported types indexing

### DIFF
--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/fields.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/fields.rs
@@ -107,6 +107,10 @@ pub(crate) fn validate_length_used_with_correct_types(
         return;
     }
 
+    if attr.as_index_field().scalar_field_type().is_unsupported() {
+        return;
+    }
+
     if let Some(r#type) = attr.as_index_field().scalar_field_type().as_builtin_scalar() {
         if [ScalarType::String, ScalarType::Bytes].iter().any(|t| t == &r#type) {
             return;

--- a/libs/datamodel/core/tests/attributes/index_positive.rs
+++ b/libs/datamodel/core/tests/attributes/index_positive.rs
@@ -300,6 +300,21 @@ fn mysql_allows_index_length_prefix() {
 }
 
 #[test]
+fn mysql_allows_index_length_prefix_on_unsupported_field() {
+    let dml = indoc! {r#"
+        model A {
+          id Int                     @id
+          a  Unsupported("geometry")
+
+          @@index([a(length: 10)])
+        }
+    "#};
+
+    let schema = with_header(dml, Provider::Mysql, &[]);
+    assert!(datamodel::parse_schema(&schema).is_ok());
+}
+
+#[test]
 fn mysql_allows_unique_sort_order() {
     let dml = indoc! {r#"
         model A {


### PR DESCRIPTION
Closes: https://github.com/prisma/prisma/issues/13786