### PR TITLE
CI: Continue the action even if dockerhub login fails

### DIFF
--- a/.github/workflows/migration-engine.yml
+++ b/.github/workflows/migration-engine.yml
@@ -30,6 +30,7 @@ jobs:
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2
+        continue-on-error: true
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -106,6 +107,7 @@ jobs:
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2
+        continue-on-error: true
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/query-engine.yml
+++ b/.github/workflows/query-engine.yml
@@ -37,6 +37,7 @@ jobs:
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2
+        continue-on-error: true
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
If we have 3rd party PRs, this makes sure we do not fail the CI when the build does not have our docker credentials. It just gives a smaller pull limit they can solve by introducing their own login details.