### PR TITLE
fix(schema): nested update many input type

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_delete_inside_update.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_delete_inside_update.rs
@@ -320,7 +320,7 @@ mod delete_inside_update {
               }}
             }}"#, parent = parent),
             2009,
-            "`Mutation.updateOneParent.data.ParentUpdateInput.childReq.ChildUpdateOneRequiredWithoutParentsOptInput.delete`: Field does not exist on enclosing type."
+            "`Mutation.updateOneParent.data.ParentUpdateInput.childReq.ChildUpdateOneRequiredWithoutParentsOptNestedInput.delete`: Field does not exist on enclosing type."
         );
         Ok(())
     }

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_delete_inside_upsert.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_delete_inside_upsert.rs
@@ -278,7 +278,7 @@ mod delete_inside_upsert {
               }}
             }}"#, parent = parent),
             2009,
-            "`Mutation.upsertOneParent.update.ParentUpdateInput.childReq.ChildUpdateOneRequiredWithoutParentsOptInput.delete`: Field does not exist on enclosing type."
+            "`Mutation.upsertOneParent.update.ParentUpdateInput.childReq.ChildUpdateOneRequiredWithoutParentsOptNestedInput.delete`: Field does not exist on enclosing type."
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_delete_many_inside_update.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_delete_many_inside_update.rs
@@ -38,7 +38,7 @@ mod delete_many_inside_update {
               }}
             }}"#, parent = parent),
             2009,
-            "`Mutation.updateOneParent.data.ParentUpdateInput.childOpt.ChildUpdateOneWithoutParentOptInput.deleteMany`: Field does not exist on enclosing type."
+            "`Mutation.updateOneParent.data.ParentUpdateInput.childOpt.ChildUpdateOneWithoutParentOptNestedInput.deleteMany`: Field does not exist on enclosing type."
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_update_many_inside_update.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_update_many_inside_update.rs
@@ -44,7 +44,7 @@ mod um_inside_update {
               }}
             }}"#, parent = parent, selection = t.parent().selection()),
             2009,
-            "`Mutation.updateOneParent.data.ParentUpdateInput.childOpt.ChildUpdateOneWithoutParentOptInput.updateMany`: Field does not exist on enclosing type."
+            "`Mutation.updateOneParent.data.ParentUpdateInput.childOpt.ChildUpdateOneWithoutParentOptNestedInput.updateMany`: Field does not exist on enclosing type."
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/not_using_schema_base/nested_update_inside_update.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/not_using_schema_base/nested_update_inside_update.rs
@@ -346,7 +346,7 @@ mod update_inside_update {
               }
             }"#,
             2009, // 3040
-            "`Mutation.updateOneNote.data.NoteUpdateInput.todos.TodoUpdateManyWithoutNotesInput.update.TodoUpdateWithWhereUniqueWithoutNotesInput.where.TodoWhereUniqueInput.unique`: A value is required but not set."
+            "`Mutation.updateOneNote.data.NoteUpdateInput.todos.TodoUpdateManyWithoutNotesNestedInput.update.TodoUpdateWithWhereUniqueWithoutNotesInput.where.TodoWhereUniqueInput.unique`: A value is required but not set."
         );
 
         Ok(())

--- a/query-engine/schema-builder/src/input_types/fields/data_input_mapper/update.rs
+++ b/query-engine/schema-builder/src/input_types/fields/data_input_mapper/update.rs
@@ -115,7 +115,7 @@ impl DataInputFieldMapper for UpdateDataInputFieldMapper {
         let unchecked_part = if self.unchecked { "Unchecked" } else { "" };
         let ident = Identifier::new(
             format!(
-                "{}{}Update{}{}Input",
+                "{}{}Update{}{}NestedInput",
                 related_model.name, unchecked_part, arity_part, without_part
             ),
             PRISMA_NAMESPACE,


### PR DESCRIPTION
## Overview

fixes https://github.com/prisma/prisma/issues/10636

**BREAKING**: Two input types were name clashing, resulting in one overriding the other which enabled queries that couldn't be processed by the core.