### PR TITLE
Avoid printing full connection string in introspection errors

### DIFF
--- a/introspection-engine/core/src/error.rs
+++ b/introspection-engine/core/src/error.rs
@@ -11,7 +11,7 @@ pub enum Error {
     Generic(String),
     InvalidDatabaseUrl(String),
     /// When there are no models or enums detected.
-    IntrospectionResultEmpty(String),
+    IntrospectionResultEmpty,
     /// Preview feature was not enabled
     PreviewFeatureNotEnabled(String),
 }
@@ -22,10 +22,7 @@ impl Display for Error {
             Error::ConnectorError(err) => write!(f, "Error in connector: {}", err),
             Error::DatamodelError(err) => write!(f, "Error in datamodel:\n{}", err),
             Error::InvalidDatabaseUrl(err) => f.write_str(err),
-            Error::IntrospectionResultEmpty(details) => {
-                f.write_str("The introspected database was empty: ")?;
-                f.write_str(details)
-            }
+            Error::IntrospectionResultEmpty => f.write_str("The introspected database was empty"),
             Error::Generic(err) => f.write_str(err),
             Error::PreviewFeatureNotEnabled(err) => f.write_str(err),
         }
@@ -38,7 +35,7 @@ impl std::error::Error for Error {
             Error::ConnectorError(err) => Some(err),
             Error::DatamodelError(_) => None,
             Error::InvalidDatabaseUrl(_) => None,
-            Error::IntrospectionResultEmpty(_) => None,
+            Error::IntrospectionResultEmpty => None,
             Error::Generic(_) => None,
             Error::PreviewFeatureNotEnabled(_) => None,
         }

--- a/introspection-engine/core/src/error_rendering.rs
+++ b/introspection-engine/core/src/error_rendering.rs
@@ -11,9 +11,7 @@ pub fn render_error(crate_error: Error) -> UserFacingError {
             user_facing_error: Some(user_facing_error),
             ..
         }) => user_facing_error.into(),
-        Error::IntrospectionResultEmpty(connection_string) => {
-            KnownError::new(IntrospectionResultEmpty { connection_string }).into()
-        }
+        Error::IntrospectionResultEmpty => KnownError::new(IntrospectionResultEmpty).into(),
         Error::DatamodelError(full_error) => KnownError::new(SchemaParserError { full_error }).into(),
         _ => UserFacingError::from_dyn_error(&crate_error),
     }

--- a/introspection-engine/core/src/rpc.rs
+++ b/introspection-engine/core/src/rpc.rs
@@ -103,7 +103,7 @@ impl RpcImpl {
         force: bool,
         composite_type_depth: CompositeTypeDepth,
     ) -> RpcResult<IntrospectionResultOutput> {
-        let (config, url, connector) = RpcImpl::load_connector(&schema).await?;
+        let (config, _url, connector) = RpcImpl::load_connector(&schema).await?;
 
         let input_data_model = if !force {
             Self::parse_datamodel(&schema)?
@@ -122,7 +122,7 @@ impl RpcImpl {
         let result = match connector.introspect(&input_data_model, ctx).await {
             Ok(introspection_result) => {
                 if introspection_result.data_model.is_empty() {
-                    Err(Error::IntrospectionResultEmpty(url.to_string()))
+                    Err(Error::IntrospectionResultEmpty)
                 } else {
                     Ok(IntrospectionResultOutput {
                         datamodel: datamodel::render_datamodel_and_config_to_string(

--- a/libs/user-facing-error-macros/Cargo.toml
+++ b/libs/user-facing-error-macros/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "user-facing-error-macros"
 version = "0.1.0"
-authors = ["Tom Houlé <tom@tomhoule.com>"]
 edition = "2021"
 
 [lib]

--- a/libs/user-facing-errors/src/common.rs
+++ b/libs/user-facing-errors/src/common.rs
@@ -234,7 +234,7 @@ pub struct IncorrectNumberOfParameters {
     pub actual: usize,
 }
 
-#[derive(Debug, UserFacingError, Serialize)]
+#[derive(Debug, SimpleUserFacingError)]
 #[user_facing(code = "P1017", message = "Server has closed the connection.")]
 pub struct ConnectionClosed;
 

--- a/libs/user-facing-errors/src/introspection_engine.rs
+++ b/libs/user-facing-errors/src/introspection_engine.rs
@@ -11,12 +11,9 @@ pub struct IntrospectionFailed {
     pub introspection_error: String,
 }
 
-#[derive(Debug, UserFacingError, Serialize)]
+#[derive(Debug, SimpleUserFacingError)]
 #[user_facing(code = "P4001", message = "The introspected database was empty: {connection_string}")]
-pub struct IntrospectionResultEmpty {
-    /// There were no models and no enums detected in the database.
-    pub connection_string: String,
-}
+pub struct IntrospectionResultEmpty;
 
 #[derive(Debug, UserFacingError, Serialize)]
 #[user_facing(

--- a/libs/user-facing-errors/src/lib.rs
+++ b/libs/user-facing-errors/src/lib.rs
@@ -19,6 +19,25 @@ pub trait UserFacingError: serde::Serialize {
     fn message(&self) -> String;
 }
 
+/// A less dynamic type of user-facing errors. This is used in the introspection and migration
+/// engines for simpler, more robust and helpful error handling — extra details are attached
+/// opportunistically.
+pub trait SimpleUserFacingError {
+    const ERROR_CODE: &'static str;
+    const MESSAGE: &'static str;
+}
+
+impl<T> UserFacingError for T
+where
+    T: SimpleUserFacingError + Serialize,
+{
+    const ERROR_CODE: &'static str = <Self as SimpleUserFacingError>::ERROR_CODE;
+
+    fn message(&self) -> String {
+        <Self as SimpleUserFacingError>::MESSAGE.to_owned()
+    }
+}
+
 #[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
 pub struct KnownError {
     pub message: String,

--- a/libs/user-facing-errors/src/migration_engine.rs
+++ b/libs/user-facing-errors/src/migration_engine.rs
@@ -28,7 +28,7 @@ struct MigrationRollback {
 }
 
 // No longer used.
-#[derive(Debug, UserFacingError, Serialize)]
+#[derive(Debug, SimpleUserFacingError)]
 #[user_facing(
     code = "P3003",
     message = "The format of migrations changed, the saved migrations are no longer valid. To solve this problem, please follow the steps at: https://pris.ly/d/migrate"
@@ -44,7 +44,7 @@ pub struct MigrateSystemDatabase {
     pub database_name: String,
 }
 
-#[derive(Debug, UserFacingError, Serialize)]
+#[derive(Debug, SimpleUserFacingError)]
 #[user_facing(
     code = "P3005",
     message = "The database schema is not empty. Read more about how to baseline an existing production database: https://pris.ly/d/migrate-baseline"
@@ -117,7 +117,7 @@ pub struct FoundFailedMigrations {
     pub details: String,
 }
 
-#[derive(Debug, Serialize, UserFacingError)]
+#[derive(Debug, SimpleUserFacingError)]
 #[user_facing(
     code = "P3010",
     message = "The name of the migration is too long. It must not be longer than 200 characters (bytes)."
@@ -144,7 +144,7 @@ pub struct CannotRollBackSucceededMigration {
     pub migration_name: String,
 }
 
-#[derive(Debug, Serialize, UserFacingError)]
+#[derive(Debug, SimpleUserFacingError)]
 #[user_facing(
     code = "P3013",
     message = "Datasource provider arrays are no longer supported in migrate. Please change your datasource to use a single provider. Read more at https://pris.ly/multi-provider-deprecation"
@@ -246,21 +246,21 @@ pub struct ProviderSwitchedError {
     pub expected_provider: String,
 }
 
-#[derive(Debug, Serialize, UserFacingError)]
+#[derive(Debug, SimpleUserFacingError)]
 #[user_facing(
     code = "P3020",
     message = "The automatic creation of shadow databases is disabled on Azure SQL. Please set up a shadow database using the `shadowDatabaseUrl` datasource attribute.\nRead the docs page for more details: https://pris.ly/d/migrate-shadow"
 )]
 pub struct AzureMssqlShadowDb;
 
-#[derive(Debug, Serialize, UserFacingError)]
+#[derive(Debug, SimpleUserFacingError)]
 #[user_facing(
     code = "P3021",
     message = "Foreign keys cannot be created on this database. Learn more how to handle this: https://pris.ly/d/migrate-no-foreign-keys"
 )]
 pub struct ForeignKeyCreationNotAllowed;
 
-#[derive(Debug, Serialize, UserFacingError)]
+#[derive(Debug, SimpleUserFacingError)]
 #[user_facing(
     code = "P3022",
     message = "Direct execution of DDL (Data Definition Language) SQL statements is disabled on this database. Please read more here how to handle this: https://pris.ly/d/migrate-no-direct-ddl"


### PR DESCRIPTION
This was occuring when we introspect an empty database.

This commit also takes the occasion to start enabling a simplified form
of user facing errors, without dynamic component.

A SimpleUserFacingError has an error code and a _static_ error message
without dynamically attached data baked into it.

This makes it easier to attach the relevant context opportunistically,
possibly in connector-specific ways, and improves search engine
friendliness of error messages. Longer term, when all introspection and
migration engine user facing errors follow this format, we can convert
the rust macro based approach from user-facing-errors into a flat file
in TOML or a similar format, which would make generating documentation
trivial.