### PR TITLE
fix: reformat optional list types, legacy list and required types

### DIFF
--- a/libs/datamodel/core/src/reformat.rs
+++ b/libs/datamodel/core/src/reformat.rs
@@ -449,6 +449,8 @@ impl<'a> Reformatter<'a> {
     }
 
     fn reformat_field_type(token: &Token<'_>) -> String {
+        assert!(token.as_rule() == Rule::field_type);
+
         let mut builder = StringBuilder::new();
 
         for current in token.clone().into_inner() {
@@ -457,14 +459,18 @@ impl<'a> Reformatter<'a> {
                     builder.write(Self::get_identifier(current));
                     builder.write("?");
                 }
-                Rule::base_type => {
+                Rule::base_type | Rule::legacy_required_type => {
                     builder.write(Self::get_identifier(current));
                 }
-                Rule::list_type => {
+                Rule::list_type | Rule::legacy_list_type => {
                     builder.write(Self::get_identifier(current));
                     builder.write("[]");
                 }
-                _ => Self::reformat_generic_token(&mut builder, &current),
+                Rule::unsupported_optional_list_type => {
+                    builder.write(Self::get_identifier(current));
+                    builder.write("[]?");
+                }
+                _ => unreachable!(),
             }
         }
 

--- a/libs/datamodel/core/tests/reformat/reformat.rs
+++ b/libs/datamodel/core/tests/reformat/reformat.rs
@@ -1336,3 +1336,43 @@ fn removes_legacy_colon_from_fields() {
 
     expected.assert_eq(&reformat(input));
 }
+
+#[test]
+fn rewrites_legacy_list_and_required_type_arities() {
+    let input = indoc! {r#"
+        model Site {
+          name String!
+          htmlTitles [String]
+        }
+    "#};
+
+    let expected = expect![[r#"
+        model Site {
+          name       String
+          htmlTitles String[]
+        }
+    "#]];
+
+    expected.assert_eq(&reformat(input));
+}
+
+#[test]
+fn reformatting_optional_list_fields_works() {
+    let schema = r#"
+        model Pizza {
+            id Int @id
+            toppings String[]?
+            prices Int[]? @default([3, 6, 9])
+        }
+    "#;
+
+    let expected = expect![[r#"
+        model Pizza {
+          id       Int       @id
+          toppings String[]?
+          prices   Int[]?    @default([3, 6, 9])
+        }
+    "#]];
+
+    expected.assert_eq(&reformat(schema));
+}

--- a/libs/datamodel/schema-ast/src/parser/datamodel.pest
+++ b/libs/datamodel/schema-ast/src/parser/datamodel.pest
@@ -39,8 +39,8 @@ base_type = { unsupported_type | non_empty_identifier } // Called base type to n
 unsupported_optional_list_type = { base_type ~ "[]" ~ "?" }
 list_type = { base_type ~ "[]" }
 optional_type = { base_type ~ "?" }
-legacy_required_type = { non_empty_identifier ~ "!" }
-legacy_list_type = { "[" ~ non_empty_identifier ~ "]" }
+legacy_required_type = { base_type ~ "!" }
+legacy_list_type = { "[" ~ base_type ~ "]" }
 
 // ######################################
 // Type Alias


### PR DESCRIPTION
...without crashing.

closes https://github.com/prisma/prisma/issues/13866