### PR TITLE
fix: decimal @id coercion failure

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/data_types/decimal.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/data_types/decimal.rs
@@ -65,4 +65,24 @@ mod decimal {
 
         Ok(())
     }
+
+    fn deicmal_id() -> String {
+        let schema = indoc! {
+            r#"model Model {
+              #id(id, Decimal, @id)
+             }"#
+        };
+
+        schema.to_owned()
+    }
+
+    #[connector_test(schema(deicmal_id), capabilities(DecimalType))]
+    async fn using_decimal_as_id(runner: Runner) -> TestResult<()> {
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"mutation { createOneModel( data: { id: "1000000000" } ) { id } }"#),
+          @r###"{"data":{"createOneModel":{"id":"1000000000"}}}"###
+        );
+
+        Ok(())
+    }
 }

--- a/query-engine/prisma-models/src/prisma_value_ext.rs
+++ b/query-engine/prisma-models/src/prisma_value_ext.rs
@@ -17,6 +17,7 @@ impl PrismaValueExtensions for PrismaValue {
             (val @ PrismaValue::String(_), TypeIdentifier::String) => val,
             (val @ PrismaValue::Int(_), TypeIdentifier::Int) => val,
             (val @ PrismaValue::Float(_), TypeIdentifier::Float) => val,
+            (val @ PrismaValue::Float(_), TypeIdentifier::Decimal) => val,
             (val @ PrismaValue::Boolean(_), TypeIdentifier::Boolean) => val,
             (val @ PrismaValue::DateTime(_), TypeIdentifier::DateTime) => val,
             (val @ PrismaValue::Enum(_), TypeIdentifier::Enum(_)) => val,


### PR DESCRIPTION
## Overview

fixes https://github.com/prisma/prisma/issues/7061
fixes https://github.com/prisma/prisma/issues/12761

Creating a record with a Decimal as `@id` was panicking.