### PR TITLE
datamodel: implement PSL string literal grammar proposal

### DIFF
--- a/introspection-engine/introspection-engine-tests/tests/tables/cockroachdb.rs
+++ b/introspection-engine/introspection-engine-tests/tests/tables/cockroachdb.rs
@@ -334,7 +334,8 @@ async fn introspecting_json_defaults_on_cockroach(api: &TestApi) -> TestResult {
            id INTEGER NOT NULL PRIMARY KEY,
            json JSON DEFAULT '[]'::json,
            jsonb JSONB DEFAULT '{}'::jsonb,
-           jsonb_object JSONB DEFAULT '{"a": ["b"], "c": true, "d": null }'
+           jsonb_string JSONB DEFAULT E'"ab\'c"',
+           jsonb_object JSONB DEFAULT '{"a": ["b''"], "c": true, "d": null }'
          );
 
        "#};
@@ -345,7 +346,8 @@ async fn introspecting_json_defaults_on_cockroach(api: &TestApi) -> TestResult {
           id           Int   @id
           json         Json? @default("[]")
           jsonb        Json? @default("{}")
-          jsonb_object Json? @default("{\"a\": [\"b\"], \"c\": true, \"d\": null}")
+          jsonb_string Json? @default("\"ab'c\"")
+          jsonb_object Json? @default("{\"a\": [\"b'\"], \"c\": true, \"d\": null}")
         }
     "#]];
 

--- a/introspection-engine/introspection-engine-tests/tests/tables/cockroachdb.rs
+++ b/introspection-engine/introspection-engine-tests/tests/tables/cockroachdb.rs
@@ -353,3 +353,41 @@ async fn introspecting_json_defaults_on_cockroach(api: &TestApi) -> TestResult {
 
     Ok(())
 }
+
+#[test_connector(tags(CockroachDb))]
+async fn string_defaults_that_need_escaping(api: &TestApi) -> TestResult {
+    let setup = r#"
+        CREATE TABLE "stringstest" (
+            id INTEGER PRIMARY KEY,
+            needs_escaping TEXT NOT NULL DEFAULT $$
+abc def
+backspaces: \abcd\
+	(tab character)
+and "quotes" and a vertical tabulation here -><-
+
+$$
+        );
+    "#;
+
+    api.raw_cmd(setup).await;
+
+    let expected = expect![[r#"
+        generator client {
+          provider = "prisma-client-js"
+        }
+
+        datasource db {
+          provider = "cockroachdb"
+          url      = "env(TEST_DATABASE_URL)"
+        }
+
+        model stringstest {
+          id             Int    @id
+          needs_escaping String @default("\nabc def\nbackspaces: \\abcd\\\n\t(tab character)\nand \"quotes\" and a vertical tabulation here ->x16<-\n\n")
+        }
+    "#]];
+
+    api.expect_datamodel(&expected).await;
+
+    Ok(())
+}

--- a/introspection-engine/introspection-engine-tests/tests/tables/postgres.rs
+++ b/introspection-engine/introspection-engine-tests/tests/tables/postgres.rs
@@ -1,8 +1,7 @@
-use barrel::types;
 use indoc::indoc;
 use introspection_engine_tests::test_api::*;
 
-#[test_connector(tags(Postgres))]
+#[test_connector(tags(Postgres), exclude(CockroachDb))]
 async fn string_defaults_that_need_escaping(api: &TestApi) -> TestResult {
     let setup = r#"
         CREATE TABLE "stringstest" (
@@ -213,27 +212,36 @@ async fn introspecting_now_functions(api: &TestApi) -> TestResult {
     Ok(())
 }
 
+// https://github.com/prisma/prisma/issues/12095
 #[test_connector(tags(Postgres), exclude(CockroachDb))]
-async fn introspecting_a_table_with_json_type_must_work(api: &TestApi) -> TestResult {
-    api.barrel()
-        .execute(|migration| {
-            migration.create_table("Blog", |t| {
-                t.add_column("id", types::primary());
-                t.add_column("json", types::json());
-            });
-        })
-        .await?;
+async fn a_table_with_json_columns(api: &TestApi) -> TestResult {
+    let setup = r#"
+        CREATE TABLE "Foo" (
+            "id" INTEGER NOT NULL,
+            "bar" JSONB DEFAULT '{"message": "This message includes a quote: Here''s it!"}',
 
-    let dm = indoc! {r#"
-        model Blog {
-            id      Int @id @default(autoincrement())
-            json    Json @db.Json
+            CONSTRAINT "Foo_pkey" PRIMARY KEY ("id")
+        );
+    "#;
+
+    api.raw_cmd(setup).await;
+
+    let expected = expect![[r#"
+        generator client {
+          provider = "prisma-client-js"
         }
-    "#};
 
-    let result = api.introspect().await?;
+        datasource db {
+          provider = "postgresql"
+          url      = "env(TEST_DATABASE_URL)"
+        }
 
-    api.assert_eq_datamodels(dm, &result);
+        model Foo {
+          id  Int   @id
+          bar Json? @default("{\"message\": \"This message includes a quote: Here's it!\"}")
+        }
+    "#]];
 
+    api.expect_datamodel(&expected).await;
     Ok(())
 }

--- a/libs/datamodel/core/tests/config/datasources.rs
+++ b/libs/datamodel/core/tests/config/datasources.rs
@@ -127,21 +127,17 @@ fn unescaped_windows_paths_give_a_good_error() {
     "#};
 
     let expect = expect![[r#"
-        [1;91merror[0m: [1mError validating: This line is not a valid definition within a datasource. If the value is a windows-style path, `\` must be escaped as `\\`.[0m
+        [1;91merror[0m: [1mUnknown escape sequence. If the value is a windows-style path, `\` must be escaped as `\\`.[0m
           [1;94m-->[0m  [4mschema.prisma:3[0m
         [1;94m   | [0m
         [1;94m 2 | [0m  provider = "sqlite"
-        [1;94m 3 | [0m  [1;91murl = "file:c:\Windows32\data.db"[0m
-        [1;94m 4 | [0m}
+        [1;94m 3 | [0m  url = "file:c:[1;91m\W[0mindows32\data.db"
         [1;94m   | [0m
-        [1;91merror[0m: [1mArgument "url" is missing in data source block "ds".[0m
-          [1;94m-->[0m  [4mschema.prisma:1[0m
+        [1;91merror[0m: [1mUnknown escape sequence. If the value is a windows-style path, `\` must be escaped as `\\`.[0m
+          [1;94m-->[0m  [4mschema.prisma:3[0m
         [1;94m   | [0m
-        [1;94m   | [0m
-        [1;94m 1 | [0m[1;91mdatasource ds {[0m
         [1;94m 2 | [0m  provider = "sqlite"
-        [1;94m 3 | [0m  url = "file:c:\Windows32\data.db"
-        [1;94m 4 | [0m}
+        [1;94m 3 | [0m  url = "file:c:\Windows32[1;91m\d[0mata.db"
         [1;94m   | [0m
     "#]];
 

--- a/libs/datamodel/core/tests/config/generators.rs
+++ b/libs/datamodel/core/tests/config/generators.rs
@@ -145,11 +145,12 @@ fn hidden_preview_features_setting_must_work() {
 
     expected.assert_eq(&rendered);
 }
+
 #[test]
 fn back_slashes_in_providers_must_work() {
     let schema = indoc! {r#"
         generator mygen {
-          provider = "../folder\ with\\ space/my\ generator.js"
+          provider = "../folder\twith\ttabs/my\tgenerator.js"
         }
     "#};
 
@@ -159,7 +160,7 @@ fn back_slashes_in_providers_must_work() {
             "name": "mygen",
             "provider": {
               "fromEnvVar": null,
-              "value": "../folder with\\ space/my generator.js"
+              "value": "../folder\twith\ttabs/my\tgenerator.js"
             },
             "output": null,
             "config": {},

--- a/libs/datamodel/core/tests/parsing/literals.rs
+++ b/libs/datamodel/core/tests/parsing/literals.rs
@@ -1,4 +1,4 @@
-use crate::common::parse;
+use crate::common::*;
 use indoc::indoc;
 use pretty_assertions::assert_eq;
 use std::path::Path;
@@ -34,7 +34,7 @@ fn strings_with_quotes_are_unescaped() {
 }
 
 #[test]
-fn strings_with_newlines_are_unescpaed() {
+fn strings_with_newlines_are_unescaped() {
     let input = indoc!(
         r#"
         model Category {
@@ -57,6 +57,82 @@ fn strings_with_newlines_are_unescpaed() {
             .unwrap(),
         "Jean\nClaude\nVan\nDamme"
     );
+}
+
+#[test]
+fn strings_with_escaped_unicode_codepoints_are_unescaped() {
+    let input = indoc!(
+        r#"
+        model Category {
+          id   String @id
+          name String @default("mfw \u56e7 - \u56E7 ^^")
+          // Escaped UTF-16 with surrogate pair (rolling eyes emoji).
+          nameUtf16 String @default("oh my \ud83d\ude44...")
+        }"#
+    );
+
+    let mut dml = parse(input);
+    let cat = dml.models_mut().find(|m| m.name == "Category").unwrap();
+    let name = cat.scalar_fields().find(|f| f.name == "name").unwrap();
+
+    assert_eq!(
+        name.default_value
+            .as_ref()
+            .unwrap()
+            .as_single()
+            .unwrap()
+            .as_string()
+            .unwrap(),
+        "mfw 囧 - 囧 ^^"
+    );
+
+    let nameutf16 = cat.scalar_fields().find(|f| f.name == "nameUtf16").unwrap();
+
+    assert_eq!(
+        nameutf16
+            .default_value
+            .as_ref()
+            .unwrap()
+            .as_single()
+            .unwrap()
+            .as_string()
+            .unwrap(),
+        "oh my 🙄..."
+    );
+}
+
+#[test]
+fn string_literals_with_invalid_unicode_escapes() {
+    let input = indoc!(
+        r#"
+        model Category {
+          id   String @id
+          name String @default("Something \uD802 \ut \u12")
+        }"#
+    );
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mInvalid unicode escape sequence.[0m
+          [1;94m-->[0m  [4mschema.prisma:3[0m
+        [1;94m   | [0m
+        [1;94m 2 | [0m  id   String @id
+        [1;94m 3 | [0m  name String @default("Something [1;91m\uD802[0m \ut \u12")
+        [1;94m   | [0m
+        [1;91merror[0m: [1mInvalid unicode escape sequence.[0m
+          [1;94m-->[0m  [4mschema.prisma:3[0m
+        [1;94m   | [0m
+        [1;94m 2 | [0m  id   String @id
+        [1;94m 3 | [0m  name String @default("Something \uD802 [1;91m\u[0mt \u12")
+        [1;94m   | [0m
+        [1;91merror[0m: [1mInvalid unicode escape sequence.[0m
+          [1;94m-->[0m  [4mschema.prisma:3[0m
+        [1;94m   | [0m
+        [1;94m 2 | [0m  id   String @id
+        [1;94m 3 | [0m  name String @default("Something \uD802 \ut [1;91m\u12[0m")
+        [1;94m   | [0m
+    "#]];
+
+    expect_error(input, &expectation);
 }
 
 #[test]

--- a/libs/datamodel/schema-ast/src/parser/datamodel.pest
+++ b/libs/datamodel/schema-ast/src/parser/datamodel.pest
@@ -133,12 +133,13 @@ number = @{ ASCII_DIGIT+ }
 
 numeric_literal = @{ ("-")? ~ ASCII_DIGIT+ ~("." ~ ASCII_DIGIT+)? }
 
-// String literals with support for escaped characters.
-string_escaped_predefined = { "n" | "r" | "t" | "\\" | "0" | "\"" | "'" | SPACE_SEPARATOR }
-string_escape = { "\\" ~ string_escaped_predefined }
-// This is only used to escape in the parser. The string above is still treated as atomic.
-string_raw = { (!("\\" | "\"" | NEWLINE ) ~ ANY)+ }
-string_content = ${ (string_raw | string_escape )* }
-string_literal = { "\"" ~ string_content ~ "\"" }
+// String literals. We follow exactly the same grammar as JSON strings
+// References:
+// - https://www.ietf.org/rfc/rfc4627.txt 
+// - https://www.json.org/json-en.html
+UNICODE_CONTROL_CHARACTER = _{ '\u{0000}'..'\u{001F}' }
+string_escape = _{ "\\" ~ ANY }
+string_content = @{ (string_escape | !("\"" | UNICODE_CONTROL_CHARACTER) ~ ANY)* }
+string_literal = ${ "\"" ~ string_content ~ "\"" }
 
 constant_literal = @{ path_identifier }

--- a/libs/datamodel/schema-ast/src/parser/parse_attribute.rs
+++ b/libs/datamodel/schema-ast/src/parser/parse_attribute.rs
@@ -4,15 +4,15 @@ use super::{
 };
 use crate::{ast::*, parser::parse_arguments::parse_arguments_list};
 
-pub fn parse_attribute(token: &Token<'_>) -> Attribute {
+pub fn parse_attribute(token: &Token<'_>, diagnostics: &mut diagnostics::Diagnostics) -> Attribute {
     let mut name: Option<Identifier> = None;
     let mut arguments: ArgumentsList = ArgumentsList::default();
 
     for current in token.relevant_children() {
         match current.as_rule() {
-            Rule::attribute => return parse_attribute(&current),
+            Rule::attribute => return parse_attribute(&current, diagnostics),
             Rule::attribute_name => name = Some(current.to_id()),
-            Rule::arguments_list => parse_arguments_list(&current, &mut arguments),
+            Rule::arguments_list => parse_arguments_list(&current, &mut arguments, diagnostics),
             _ => parsing_catch_all(&current, "attribute"),
         }
     }

--- a/libs/datamodel/schema-ast/src/parser/parse_composite_type.rs
+++ b/libs/datamodel/schema-ast/src/parser/parse_composite_type.rs
@@ -18,7 +18,7 @@ pub(crate) fn parse_composite_type(token: &Token<'_>, diagnostics: &mut Diagnost
             Rule::TYPE_KEYWORD => (),
             Rule::non_empty_identifier => name = Some(current.to_id()),
             Rule::block_level_attribute => {
-                let attr = parse_attribute(&current);
+                let attr = parse_attribute(&current, diagnostics);
 
                 let err = match attr.name.name.as_str() {
                     "map" => {
@@ -67,7 +67,7 @@ pub(crate) fn parse_composite_type(token: &Token<'_>, diagnostics: &mut Diagnost
 
                 diagnostics.push_error(err);
             }
-            Rule::field_declaration => match parse_field(&name.as_ref().unwrap().name, &current) {
+            Rule::field_declaration => match parse_field(&name.as_ref().unwrap().name, &current, diagnostics) {
                 Ok(field) => {
                     for attr in field.attributes.iter() {
                         let error = match attr.name.name.as_str() {

--- a/libs/datamodel/schema-ast/src/parser/parse_model.rs
+++ b/libs/datamodel/schema-ast/src/parser/parse_model.rs
@@ -18,8 +18,8 @@ pub(crate) fn parse_model(token: &Token<'_>, diagnostics: &mut Diagnostics) -> M
         match current.as_rule() {
             Rule::MODEL_KEYWORD => (),
             Rule::non_empty_identifier => name = Some(current.to_id()),
-            Rule::block_level_attribute => attributes.push(parse_attribute(&current)),
-            Rule::field_declaration => match parse_field(&name.as_ref().unwrap().name, &current) {
+            Rule::block_level_attribute => attributes.push(parse_attribute(&current, diagnostics)),
+            Rule::field_declaration => match parse_field(&name.as_ref().unwrap().name, &current, diagnostics) {
                 Ok(field) => fields.push(field),
                 Err(err) => diagnostics.push_error(err),
             },

--- a/libs/datamodel/schema-ast/src/parser/parse_types.rs
+++ b/libs/datamodel/schema-ast/src/parser/parse_types.rs
@@ -3,14 +3,23 @@ use super::{
     Rule,
 };
 use crate::{ast::*, parser::parse_expression::parse_expression};
-use diagnostics::DatamodelError;
+use diagnostics::{DatamodelError, Diagnostics};
 
-pub fn parse_field_type(token: &Token<'_>) -> Result<(FieldArity, FieldType), DatamodelError> {
+pub fn parse_field_type(
+    token: &Token<'_>,
+    diagnostics: &mut Diagnostics,
+) -> Result<(FieldArity, FieldType), DatamodelError> {
     let current = token.first_relevant_child();
     match current.as_rule() {
-        Rule::optional_type => Ok((FieldArity::Optional, parse_base_type(&current.first_relevant_child()))),
-        Rule::base_type => Ok((FieldArity::Required, parse_base_type(&current))),
-        Rule::list_type => Ok((FieldArity::List, parse_base_type(&current.first_relevant_child()))),
+        Rule::optional_type => Ok((
+            FieldArity::Optional,
+            parse_base_type(&current.first_relevant_child(), diagnostics),
+        )),
+        Rule::base_type => Ok((FieldArity::Required, parse_base_type(&current, diagnostics))),
+        Rule::list_type => Ok((
+            FieldArity::List,
+            parse_base_type(&current.first_relevant_child(), diagnostics),
+        )),
         Rule::legacy_required_type => Err(DatamodelError::new_legacy_parser_error(
             "Fields are required by default, `!` is no longer required.",
             current.as_span().into(),
@@ -27,14 +36,14 @@ pub fn parse_field_type(token: &Token<'_>) -> Result<(FieldArity, FieldType), Da
     }
 }
 
-fn parse_base_type(token: &Token<'_>) -> FieldType {
+fn parse_base_type(token: &Token<'_>, diagnostics: &mut Diagnostics) -> FieldType {
     let current = token.first_relevant_child();
     match current.as_rule() {
         Rule::non_empty_identifier => FieldType::Supported(Identifier {
             name: current.as_str().to_string(),
             span: Span::from(current.as_span()),
         }),
-        Rule::unsupported_type => match parse_expression(&current) {
+        Rule::unsupported_type => match parse_expression(&current, diagnostics) {
             Expression::StringValue(lit, span) => FieldType::Unsupported(lit, span),
             _ => unreachable!("Encountered impossible type during parsing: {:?}", current.tokens()),
         },

--- a/migration-engine/migration-engine-tests/tests/migrations/cockroachdb.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/cockroachdb.rs
@@ -1185,3 +1185,37 @@ fn alter_sequence(api: TestApi) {
 //     api.schema_push(schema).send().assert_green();
 //     api.schema_push(schema).send().assert_green().assert_no_steps();
 // }
+
+// https://github.com/prisma/prisma/issues/12095
+#[test_connector(tags(CockroachDb))]
+fn json_defaults_with_escaped_quotes_work(api: TestApi) {
+    let schema = r#"
+        datasource db {
+          provider = "postgresql"
+          url      = env("DATABASE_URL")
+        }
+
+        model Foo {
+          id             Int   @id
+          bar Json? @default("{\"message\": \"This message includes a quote: Here''s it!\"}")
+        }
+    "#;
+
+    api.schema_push(schema)
+        .send()
+        .assert_green()
+        .assert_has_executed_steps();
+    api.schema_push(schema).send().assert_green().assert_no_steps();
+
+    let sql = expect![[r#"
+        -- CreateTable
+        CREATE TABLE "Foo" (
+            "id" INT4 NOT NULL,
+            "bar" JSONB DEFAULT '{"message": "This message includes a quote: Here''''s it!"}',
+
+            CONSTRAINT "Foo_pkey" PRIMARY KEY ("id")
+        );
+    "#]];
+
+    api.expect_sql_for_schema(schema, &sql);
+}


### PR DESCRIPTION
Simplify pest grammar of string literals

We want to tokenize invalid escape sequences and report them as such
later in validation.

This results in better error messages across the board.

closes https://github.com/prisma/prisma/issues/4167

and confirm that user issue is closed by the combination of the new postgres default parsing code from the
scalar list defaults work and the new string literal code in PSL.

closes https://github.com/prisma/prisma/issues/12095
