### PR TITLE
Update node-api to version 8 (node.js v14.17.0)

### DIFF
--- a/query-engine/query-engine-node-api/Cargo.toml
+++ b/query-engine/query-engine-node-api/Cargo.toml
@@ -22,7 +22,7 @@ datamodel = { path = "../../libs/datamodel/core" }
 sql-connector = { path = "../connectors/sql-query-connector", package = "sql-query-connector" }
 prisma-models = { path = "../prisma-models" }
 
-napi = { version = "2", default-features = false, features = ["napi4", "tokio_rt", "serde-json"] }
+napi = { version = "2", default-features = false, features = ["napi8", "tokio_rt", "serde-json"] }
 napi-derive = "2"
 
 thiserror = "1"


### PR DESCRIPTION
Prisma 4 minimum node version is 14.17.x, so we can update the node-api to a later version.

Node-API version matrix
https://nodejs.org/api/n-api.html#node-api-version-matrix