### PR TITLE
feat(datamodel): reformat after rendering datamodel

### DIFF
--- a/introspection-engine/connectors/mongodb-introspection-connector/tests/remapping_names/mod.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/tests/remapping_names/mod.rs
@@ -129,7 +129,7 @@ fn remapping_model_fields_with_numbers() {
 
     let expected = expect![[r#"
         model Outer {
-          id   String @id @default(auto()) @map("_id") @db.ObjectId
+          id String @id @default(auto()) @map("_id") @db.ObjectId
           // This field was commented out because of an invalid name. Please provide a valid one that matches [a-zA-Z][a-zA-Z0-9_]*
           // 1 Int    @map("1")
         }
@@ -158,7 +158,7 @@ fn remapping_model_fields_with_numbers_dirty() {
 
     let expected = expect![[r#"
         model Outer {
-          id   String @id @default(auto()) @map("_id") @db.ObjectId
+          id String @id @default(auto()) @map("_id") @db.ObjectId
           // Multiple data types found: String: 50%, Int: 50% out of 2 sampled entries
           // This field was commented out because of an invalid name. Please provide a valid one that matches [a-zA-Z][a-zA-Z0-9_]*
           // 1 Json   @map("1")

--- a/introspection-engine/introspection-engine-tests/tests/re_introspection/mysql.rs
+++ b/introspection-engine/introspection-engine-tests/tests/re_introspection/mysql.rs
@@ -259,8 +259,8 @@ async fn mysql_keeps_renamed_enum_defaults(api: &TestApi) -> TestResult {
         }
 
         enum A_val {
-          is_false @map("0")
-          is_true @map("1")
+          is_false  @map("0")
+          is_true   @map("1")
         }
     "#]];
 

--- a/libs/datamodel/core/src/lib.rs
+++ b/libs/datamodel/core/src/lib.rs
@@ -224,7 +224,7 @@ fn load_sources(
 pub fn render_datamodel_to_string(datamodel: &dml::Datamodel, configuration: Option<&Configuration>) -> String {
     let mut writable_string = String::with_capacity(datamodel.models.len() * 20);
     render_datamodel_to(&mut writable_string, datamodel, configuration);
-    writable_string
+    reformat(&writable_string, 2).expect("Internal error: failed to reformat introspected schema")
 }
 
 /// Renders an AST to a string.
@@ -237,7 +237,7 @@ pub fn render_schema_ast_to_string(schema: &ast::SchemaAst) -> String {
 }
 
 /// Renders as a string into the stream.
-pub fn render_datamodel_to(
+fn render_datamodel_to(
     stream: &mut dyn std::fmt::Write,
     datamodel: &dml::Datamodel,
     configuration: Option<&Configuration>,

--- a/libs/datamodel/core/tests/attributes/constraint_names.rs
+++ b/libs/datamodel/core/tests/attributes/constraint_names.rs
@@ -190,9 +190,7 @@ fn constraint_names() {
     "#]];
 
     let datamodel = parse(input);
-    let mut rendered = String::new();
-
-    datamodel::render_datamodel_to(&mut rendered, &datamodel, Some(&parse_configuration(input)));
+    let rendered = datamodel::render_datamodel_to_string(&datamodel, Some(&parse_configuration(input)));
 
     //todo can't be exactly the same since explicit default names will be suppressed when rerendering
     // the expected result after parsing and rendering is not exactly the same as the input.


### PR DESCRIPTION
In introspection, we use lowering, the AST renderer from schema-ast to
produce the final prisma schema string we return to the user. This is
one implementation of prisma schema formatting.

We also have the reformatter used by prisma-fmt. The two formattings
produced by these two components are different. We want to align on a
single formatting eventually: this is the purpose of this commit.
The only change in this commit is that we run introspected schemas
through the reformatter.

After this, we are free to stop caring about indentation and formatting
details in schema_ast::renderer, since these are concerns for the
reformatter.

relevant issue: https://github.com/prisma/prisma/issues/12580