### PR TITLE
fix(pg): js int should be sent to pg as int32

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/raw/sql/errors.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/raw/sql/errors.rs
@@ -43,7 +43,7 @@ mod raw_errors {
                 vec![RawParam::array(vec![1])],
             ),
             2010,
-            r#"column "id" is of type integer but expression is of type bigint[]"#
+            r#"column "id" is of type integer but expression is of type integer[]"#
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/raw/sql/input_coercion.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/raw/sql/input_coercion.rs
@@ -61,4 +61,26 @@ mod input_coercion {
 
         Ok(())
     }
+
+    #[connector_test]
+    async fn int32_input_correctly_coerced(runner: Runner) -> TestResult<()> {
+        run_query!(
+            &runner,
+            fmt_execute_raw(
+                r#"
+                    CREATE FUNCTION my_fn(x integer) RETURNS integer AS $$
+                        SELECT x;
+                    $$ LANGUAGE SQL;
+                "#,
+                vec![]
+            )
+        );
+
+        insta::assert_snapshot!(
+            run_query!(&runner, fmt_query_raw(r#"SELECT my_fn($1);"#, vec![RawParam::from(1)])),
+            @r###"{"data":{"queryRaw":[{"my_fn":{"prisma__type":"int","prisma__value":1}}]}}"###
+        );
+
+        Ok(())
+    }
 }

--- a/query-engine/connectors/sql-query-connector/src/model_extensions/scalar_field.rs
+++ b/query-engine/connectors/sql-query-connector/src/model_extensions/scalar_field.rs
@@ -51,7 +51,13 @@ pub fn convert_lossy<'a>(pv: PrismaValue) -> Value<'a> {
         PrismaValue::Boolean(b) => b.into(),
         PrismaValue::DateTime(d) => d.with_timezone(&Utc).into(),
         PrismaValue::Enum(e) => e.into(),
-        PrismaValue::Int(i) => (i as i64).into(),
+        PrismaValue::Int(i) => {
+            if i32::try_from(i).is_ok() {
+                Value::int32(i as i32)
+            } else {
+                Value::int64(i)
+            }
+        }
         PrismaValue::BigInt(i) => (i as i64).into(),
         PrismaValue::Uuid(u) => u.to_string().into(),
         PrismaValue::List(l) => Value::Array(Some(l.into_iter().map(convert_lossy).collect())),


### PR DESCRIPTION
## Overview

fixes failing test here https://github.com/prisma/prisma-examples/runs/7059247611?check_suite_focus=true#step:5:51

JS integers were still sent as `INT8` to PG. Since JS numbers can go above `int32::MAX`, we check whether they can fit into an int32 and send them as `INT4` if they do.