### PR TITLE
refactor(reformat): completely separate relation additions from AST reformatting

### DIFF
--- a/libs/datamodel/core/src/reformat/helpers.rs
+++ b/libs/datamodel/core/src/reformat/helpers.rs
@@ -1,8 +1,8 @@
 use schema_ast::{parser::Rule, renderer::LineWriteable};
 
-pub type Token<'a> = pest::iterators::Pair<'a, Rule>;
+pub(super) type Token<'a> = pest::iterators::Pair<'a, Rule>;
 
-pub trait TokenExtensions {
+pub(super) trait TokenExtensions {
     fn is_top_level_element(&self) -> bool;
 }
 
@@ -19,7 +19,7 @@ impl TokenExtensions for Token<'_> {
     }
 }
 
-pub fn comment(target: &mut dyn LineWriteable, comment_text: &str) {
+pub(super) fn comment(target: &mut dyn LineWriteable, comment_text: &str) {
     let trimmed = strip_new_line(comment_text);
     let trimmed = trimmed.trim();
 
@@ -27,7 +27,7 @@ pub fn comment(target: &mut dyn LineWriteable, comment_text: &str) {
     target.end_line();
 }
 
-pub fn strip_new_line(str: &str) -> &str {
+pub(super) fn strip_new_line(str: &str) -> &str {
     if str.ends_with('\n') {
         &str[0..str.len() - 1] // slice away line break.
     } else {

--- a/libs/datamodel/core/tests/attributes/composite_index.rs
+++ b/libs/datamodel/core/tests/attributes/composite_index.rs
@@ -238,7 +238,7 @@ fn reformat() {
     "#};
 
     let datamodel = with_header(schema, crate::Provider::Mongo, &["fullTextIndex"]);
-    let result = datamodel::reformat(&datamodel, 2).unwrap_or_else(|_| datamodel.to_owned());
+    let result = datamodel::reformat(&datamodel, 2).unwrap_or_else(|| datamodel.to_owned());
 
     let expected = expect![[r#"
         datasource test {

--- a/libs/datamodel/core/tests/common/mod.rs
+++ b/libs/datamodel/core/tests/common/mod.rs
@@ -5,6 +5,10 @@ pub use indoc::{formatdoc, indoc};
 use datamodel::{diagnostics::*, Configuration, StringFromEnvVar};
 use pretty_assertions::assert_eq;
 
+pub(crate) fn reformat(input: &str) -> String {
+    datamodel::reformat(input, 2).unwrap_or_else(|| input.to_owned())
+}
+
 pub(crate) trait DatasourceAsserts {
     fn assert_name(&self, name: &str) -> &Self;
     fn assert_url(&self, url: StringFromEnvVar) -> &Self;

--- a/libs/datamodel/core/tests/reformat/reformat_implicit_relations.rs
+++ b/libs/datamodel/core/tests/reformat/reformat_implicit_relations.rs
@@ -1,9 +1,4 @@
-use expect_test::expect;
-use indoc::indoc;
-
-fn reformat(input: &str) -> String {
-    datamodel::reformat(input, 2).unwrap_or_else(|_| input.to_owned())
-}
+use crate::common::*;
 
 #[test]
 fn native_types_in_missing_back_relation_fields() {

--- a/prisma-fmt/src/format.rs
+++ b/prisma-fmt/src/format.rs
@@ -21,7 +21,7 @@ pub fn run(opts: FormatOpts) {
         }
     };
 
-    let reformatted = reformat(&datamodel_string, opts.tabwidth).unwrap_or_else(|err: &str| err.to_owned());
+    let reformatted = reformat(&datamodel_string, opts.tabwidth).unwrap_or(datamodel_string);
     match opts.output {
         Some(file_name) => {
             let file = File::open(&file_name).unwrap_or_else(|_| panic!("Unable to open file {}", file_name.display()));

--- a/prisma-fmt/src/lib.rs
+++ b/prisma-fmt/src/lib.rs
@@ -57,7 +57,7 @@ pub fn format(schema: &str, params: &str) -> String {
         }
     };
 
-    datamodel::reformat(schema, params.options.tab_size as usize).unwrap_or_else(|err| err.to_owned())
+    datamodel::reformat(schema, params.options.tab_size as usize).unwrap_or_else(|| schema.to_owned())
 }
 
 pub fn lint(schema: String) -> String {


### PR DESCRIPTION
That way we can do pure AST reformatting if we want, and reuse the logic
for relation and relation scalar field additions in code actions. As a
side-effect, that makes the formatter idempotent (and much simpler).

There will be a follow-up PR to split the two functionalities in two
different modules, but I stopped here for readability in this PR.

closes https://github.com/prisma/prisma/issues/12726