### PR TITLE
Logger tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1016,9 +1016,9 @@ checksum = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
 
 [[package]]
 name = "fixedbitset"
-version = "0.2.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
+checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
 
 [[package]]
 name = "flate2"
@@ -2663,13 +2663,15 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cf9b1c4e9a6c4de793c632496fa490bdc0e1eea73f0c91394f7b6990935d22"
+checksum = "6105e89802af13fdf48c49d7646d3b533a70e536d818aae7e78ba0433d01acb8"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
- "futures",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
  "js-sys",
  "lazy_static",
  "percent-encoding",
@@ -2682,18 +2684,19 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f19d4b43842433c420c548c985d158f5628bba5b518e0be64627926d19889992"
+checksum = "9d1a6ca9de4c8b00aa7f1a153bd76cb263287155cec642680d79d98706f3d28a"
 dependencies = [
  "async-trait",
  "futures",
+ "futures-util",
  "http",
  "opentelemetry",
  "prost",
  "thiserror",
  "tokio",
- "tonic 0.5.2",
+ "tonic 0.6.2",
  "tonic-build",
 ]
 
@@ -2925,11 +2928,11 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
-version = "0.5.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
+checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
 dependencies = [
- "fixedbitset 0.2.0",
+ "fixedbitset 0.4.1",
  "indexmap",
 ]
 
@@ -3162,9 +3165,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
+checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -3172,27 +3175,29 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "355f634b43cdd80724ee7848f95770e7e70eefa6dcf14fea676216573b8fd603"
+checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
 dependencies = [
  "bytes",
  "heck 0.3.3",
  "itertools",
+ "lazy_static",
  "log",
  "multimap",
- "petgraph 0.5.1",
+ "petgraph 0.6.2",
  "prost",
  "prost-types",
+ "regex",
  "tempfile",
  "which",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "600d2f334aa05acb02a755e217ef1ab6dea4d51b58b7846588b747edec04efba"
+checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
 dependencies = [
  "anyhow",
  "itertools",
@@ -3203,9 +3208,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "603bbd6394701d13f3f25aada59c7de9d35a6a5887cfc156181234a44002771b"
+checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
 dependencies = [
  "bytes",
  "prost",
@@ -3229,7 +3234,7 @@ dependencies = [
 [[package]]
 name = "quaint"
 version = "0.2.0-alpha.13"
-source = "git+https://github.com/prisma/quaint#ca97fcada658c3ee511becc9bce0758ec8829bc8"
+source = "git+https://github.com/prisma/quaint#8f9d2c5fb1e0198777c556c4756bcdb28dc9859a"
 dependencies = [
  "async-trait",
  "base64 0.12.3",
@@ -3327,6 +3332,7 @@ dependencies = [
  "mongodb-client",
  "mongodb-query-connector",
  "once_cell",
+ "opentelemetry",
  "parking_lot 0.12.1",
  "petgraph 0.4.13",
  "pin-utils",
@@ -3343,6 +3349,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-futures",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "url",
  "user-facing-errors",
@@ -3398,6 +3405,7 @@ name = "query-engine-node-api"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "connection-string",
  "datamodel",
  "datamodel-connector",
@@ -4760,9 +4768,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.5.2"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "796c5e1cd49905e65dd8e700d4cb1dffcbfdb4fc9d017de08c1a537afd83627c"
+checksum = "ff08f4649d10a70ffa3522ca559031285d8e421d727ac85c60825761818f5d0a"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4793,9 +4801,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.5.2"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b52d07035516c2b74337d2ac7746075e7dcae7643816c1b12c5ff8a7484c08"
+checksum = "9403f1bafde247186684b230dc6f38b5cd514584e8bec1dd32514be4745fa757"
 dependencies = [
  "proc-macro2",
  "prost-build",
@@ -4902,10 +4910,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.16.0"
+version = "0.17.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ffbf13a0f8b054a4e59df3a173b818e9c6177c02789871f2073977fd0062076"
+checksum = "fbbe89715c1dbbb790059e2565353978564924ee85017b5fff365c872ff6721f"
 dependencies = [
+ "once_cell",
  "opentelemetry",
  "tracing",
  "tracing-core",
@@ -5002,7 +5011,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "rand 0.8.5",
  "static_assertions",
 ]

--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,7 @@ validate:
 	cargo run --bin test-cli -- validate-datamodel dev_datamodel.prisma
 
 qe:
-	cargo run --bin query-engine -- --enable-playground --enable-raw-queries --enable-metrics
+	cargo run --bin query-engine -- --enable-playground --enable-raw-queries --enable-metrics --enable-open-telemetry
 
 qe-dmmf:
 	cargo run --bin query-engine -- cli dmmf > dmmf.json
@@ -225,7 +225,6 @@ use-local-query-engine:
 
 show-metrics:
 	docker-compose -f docker-compose.yml up -d --remove-orphans grafana prometheus
-
 
 ## OpenTelemetry
 otel:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -335,11 +335,21 @@ services:
       - databases
 
   otel:
-    image: jaegertracing/opentelemetry-all-in-one:latest
+    image: jaegertracing/all-in-one:1.35
+    environment:
+      COLLECTOR_OTLP_ENABLED: "true"
+      COLLECTOR_ZIPKIN_HOST_PORT: ":9411"
     ports:
-      - 13133:13133
+      - 6831:6831/udp
+      - 6832:6832/udp
+      - 5778:5778
       - 16686:16686
-      - 4317:55680
+      - 4317:4317
+      - 4318:4318
+      - 14250:14250
+      - 14268:14268
+      - 14269:14269
+      - 9411:9411
 
   prometheus:
     image: prom/prometheus

--- a/query-engine/connectors/sql-query-connector/Cargo.toml
+++ b/query-engine/connectors/sql-query-connector/Cargo.toml
@@ -20,8 +20,8 @@ tokio = "1.0"
 tracing = "0.1"
 tracing-futures = "0.2"
 uuid = "0.8"
-opentelemetry = { version = "0.16", features = ["tokio"] }
-tracing-opentelemetry = "0.16"
+opentelemetry = { version = "0.17", features = ["tokio"] }
+tracing-opentelemetry = "0.17.3"
 
 [dependencies.quaint]
 features = [

--- a/query-engine/connectors/sql-query-connector/src/query_ext.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_ext.rs
@@ -22,7 +22,7 @@ use std::{collections::HashMap, panic::AssertUnwindSafe};
 use crate::sql_trace::trace_parent_to_string;
 
 use opentelemetry::trace::TraceContextExt;
-use tracing::{span, Span};
+use tracing::{info_span, Span};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 impl<'t> QueryExt for connector::Transaction<'t> {}
@@ -39,7 +39,7 @@ pub trait QueryExt: Queryable + Send + Sync {
         idents: &[ColumnMetadata<'_>],
         trace_id: Option<String>,
     ) -> crate::Result<Vec<SqlRow>> {
-        let span = span!(tracing::Level::INFO, "filter read query");
+        let span = info_span!("filter read query");
 
         let otel_ctx = span.context();
         let span_ref = otel_ctx.span();

--- a/query-engine/connectors/sql-query-connector/src/sql_trace.rs
+++ b/query-engine/connectors/sql-query-connector/src/sql_trace.rs
@@ -4,11 +4,11 @@ use tracing::Span;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 pub fn trace_parent_to_string(context: &SpanContext) -> String {
-    let trace_id = context.trace_id().to_hex();
-    let span_id = context.span_id().to_hex();
+    let trace_id = context.trace_id();
+    let span_id = context.span_id();
 
     // see https://www.w3.org/TR/trace-context/#traceparent-header-field-values
-    format!("traceparent=00-{}-{}-01", trace_id, span_id)
+    format!("traceparent=00-{:032x}-{:032x}-01", trace_id, span_id)
 }
 
 pub trait SqlTraceComment: Sized {

--- a/query-engine/core/Cargo.toml
+++ b/query-engine/core/Cargo.toml
@@ -30,6 +30,7 @@ petgraph = "0.4"
 prisma-inflector = { path = "../../libs/prisma-inflector" }
 prisma-models = { path = "../prisma-models" }
 prisma-value = { path = "../../libs/prisma-value" }
+opentelemetry = { version = "0.17"}
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sql-connector = { path = "../connectors/sql-query-connector", package = "sql-query-connector", optional = true }
@@ -38,6 +39,7 @@ tokio = { version = "1.8" }
 tracing = { version = "0.1", features = ["attributes"] }
 tracing-futures = "0.2"
 tracing-subscriber = "0.3.11"
+tracing-opentelemetry = "0.17.4"
 url = "2"
 user-facing-errors = { path = "../../libs/user-facing-errors" }
 uuid = "0.8"

--- a/query-engine/core/src/lib.rs
+++ b/query-engine/core/src/lib.rs
@@ -31,6 +31,7 @@ pub mod query_graph;
 pub mod query_graph_builder;
 pub mod response_ir;
 pub mod result_ast;
+pub mod trace_helpers;
 
 pub use crate::metrics::*;
 pub use error::*;
@@ -43,6 +44,7 @@ pub use query_graph::*;
 pub use query_graph_builder::*;
 pub use response_ir::*;
 pub use result_ast::*;
+pub use trace_helpers::*;
 
 /// Result type tying all sub-result type hierarchies of the core together.
 pub type Result<T> = std::result::Result<T, CoreError>;

--- a/query-engine/core/src/query_graph_builder/builder.rs
+++ b/query-engine/core/src/query_graph_builder/builder.rs
@@ -20,6 +20,7 @@ impl QueryGraphBuilder {
 
     /// Maps an operation to a query.
     pub fn build(self, operation: Operation) -> QueryGraphBuilderResult<(QueryGraph, IrSerializer)> {
+        let _span = info_span!("engine:build_graph");
         match operation {
             Operation::Read(selection) => self.build_internal(selection, &self.query_schema.query()),
             Operation::Write(selection) => self.build_internal(selection, &self.query_schema.mutation()),

--- a/query-engine/core/src/response_ir/ir_serializer.rs
+++ b/query-engine/core/src/response_ir/ir_serializer.rs
@@ -16,6 +16,7 @@ pub struct IrSerializer {
 
 impl IrSerializer {
     pub fn serialize(&self, result: ExpressionResult) -> crate::Result<ResponseData> {
+        let _span = info_span!("engine:serialize");
         match result {
             ExpressionResult::Query(QueryResult::Json(json)) => {
                 Ok(ResponseData::new(self.key.clone(), Item::Json(json)))

--- a/query-engine/core/src/trace_helpers/mod.rs
+++ b/query-engine/core/src/trace_helpers/mod.rs
@@ -34,10 +34,9 @@ fn span_to_json(span: &SpanData) -> Value {
 
     // Override the name of quaint. It will be confusing for users to see quaint instead of
     // Prisma in the spans.
-    let name: Cow<str> = if span.name == "quaint:query" {
-        "prisma:db_query".into()
-    } else {
-        span.name.clone()
+    let name: Cow<str> = match span.name {
+        Cow::Borrowed("quaint:query") => "prisma:db_query".into(),
+        _ => span.name.clone(),
     };
 
     json!({
@@ -57,8 +56,7 @@ pub fn set_span_context(span: &Span, trace_id: Option<String>) {
         return;
     }
 
-    let mut trace: HashMap<String, String> = HashMap::new();
-    trace.insert("traceparent".to_string(), trace_id.unwrap());
+    let trace = HashMap::from([("traceparent".to_string(), trace_id.unwrap())]);
     let parent_context = opentelemetry::global::get_text_map_propagator(|propagator| propagator.extract(&trace));
 
     span.set_parent(parent_context)

--- a/query-engine/core/src/trace_helpers/mod.rs
+++ b/query-engine/core/src/trace_helpers/mod.rs
@@ -42,9 +42,9 @@ fn span_to_json(span: &SpanData) -> Value {
 
     json!({
         "span": true,
-        "trace_id": format!("{}", span.span_context.trace_id()),
-        "span_id": format!("{}",span.span_context.span_id()),
-        "parent_span_id": format!("{}",span.parent_span_id),
+        "trace_id": span.span_context.trace_id().to_string(),
+        "span_id": span.span_context.span_id().to_string(),
+        "parent_span_id": span.parent_span_id.to_string(),
         "name": name,
         "start_time": span.start_time.duration_since(SystemTime::UNIX_EPOCH).unwrap().as_millis().to_string(),
         "end_time": span.end_time.duration_since(SystemTime::UNIX_EPOCH).unwrap().as_millis().to_string(),

--- a/query-engine/core/src/trace_helpers/mod.rs
+++ b/query-engine/core/src/trace_helpers/mod.rs
@@ -1,0 +1,74 @@
+use opentelemetry::sdk::export::trace::SpanData;
+use serde_json::{json, Value};
+use std::borrow::Cow;
+use std::{collections::HashMap, time::SystemTime};
+use tracing::Span;
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+const ACCEPT_ATTRIBUTES: &[&str] = &["db.statement", "itx_id", "db.type"];
+
+pub fn spans_to_json(spans: &[SpanData]) -> String {
+    let json_spans: Vec<Value> = spans.iter().map(span_to_json).collect();
+    let span_result = json!({
+        "span": true,
+        "spans": json_spans
+    });
+
+    match serde_json::to_string(&span_result) {
+        Ok(json_string) => json_string,
+        Err(_) => "".to_string(),
+    }
+}
+
+fn span_to_json(span: &SpanData) -> Value {
+    let attributes: HashMap<String, String> =
+        span.attributes
+            .iter()
+            .fold(HashMap::default(), |mut map, (key, value)| {
+                if ACCEPT_ATTRIBUTES.contains(&key.as_str()) {
+                    map.insert(key.to_string(), value.to_string());
+                }
+
+                map
+            });
+
+    // Override the name of quaint. It will be confusing for users to see quaint instead of
+    // Prisma in the spans.
+    let name: Cow<str> = if span.name == "quaint:query" {
+        "prisma:db_query".into()
+    } else {
+        span.name.clone()
+    };
+
+    json!({
+        "span": true,
+        "trace_id": format!("{}", span.span_context.trace_id()),
+        "span_id": format!("{}",span.span_context.span_id()),
+        "parent_span_id": format!("{}",span.parent_span_id),
+        "name": name,
+        "start_time": span.start_time.duration_since(SystemTime::UNIX_EPOCH).unwrap().as_millis().to_string(),
+        "end_time": span.end_time.duration_since(SystemTime::UNIX_EPOCH).unwrap().as_millis().to_string(),
+        "attributes": attributes
+    })
+}
+
+pub fn set_span_context(span: &Span, trace_id: Option<String>) {
+    if trace_id.is_none() {
+        return;
+    }
+
+    let mut trace: HashMap<String, String> = HashMap::new();
+    trace.insert("traceparent".to_string(), trace_id.unwrap());
+    let parent_context = opentelemetry::global::get_text_map_propagator(|propagator| propagator.extract(&trace));
+
+    span.set_parent(parent_context)
+}
+
+// set the parent context and return the traceparent
+pub fn set_parent_context_from_json_str(span: &Span, trace: String) -> Option<String> {
+    let trace: HashMap<String, String> = serde_json::from_str(&trace).unwrap_or_default();
+    let trace_id = trace.get("traceparent").map(String::from);
+    let cx = opentelemetry::global::get_text_map_propagator(|propagator| propagator.extract(&trace));
+    span.set_parent(cx);
+    trace_id
+}

--- a/query-engine/query-engine-node-api/Cargo.toml
+++ b/query-engine/query-engine-node-api/Cargo.toml
@@ -14,6 +14,7 @@ vendored-openssl = ["sql-connector/vendored-openssl"]
 
 [dependencies]
 anyhow = "1"
+async-trait = "0.1"
 query-core = { path = "../core" }
 request-handlers = { path = "../request-handlers" }
 query-connector = { path = "../connectors/query-connector" }
@@ -34,9 +35,9 @@ serde = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3" }
 tracing-futures = "0.2"
-tracing-opentelemetry = "0.16"
+tracing-opentelemetry = "0.17.3"
 datamodel-connector = { path = "../../libs/datamodel/connectors/datamodel-connector" }
-opentelemetry = { version = "0.16" }
+opentelemetry = { version = "0.17"}
 
 tokio = { version = "1", features = ["sync"] }
 futures = "0.3"

--- a/query-engine/query-engine-node-api/src/lib.rs
+++ b/query-engine/query-engine-node-api/src/lib.rs
@@ -4,6 +4,7 @@ pub mod engine;
 pub mod error;
 pub mod functions;
 pub mod logger;
+mod tracer;
 
 pub(crate) type Result<T> = std::result::Result<T, error::ApiError>;
 pub(crate) type Executor = Box<dyn query_core::QueryExecutor + Send + Sync>;

--- a/query-engine/query-engine-node-api/src/logger.rs
+++ b/query-engine/query-engine-node-api/src/logger.rs
@@ -8,7 +8,6 @@ use tracing::{
     level_filters::LevelFilter,
     Dispatch, Level, Subscriber,
 };
-
 use tracing_subscriber::{
     filter::{filter_fn, FilterExt},
     layer::SubscriberExt,
@@ -31,6 +30,7 @@ impl Logger {
         let is_sql_query = filter_fn(|meta| {
             meta.target() == "quaint::connector::metrics" && meta.fields().iter().any(|f| f.name() == "query")
         });
+
         // is a mongodb query?
         let is_mongo_query = filter_fn(|meta| meta.target() == "mongodb_query_connector::query");
 
@@ -43,6 +43,22 @@ impl Logger {
             FilterExt::boxed(log_level)
         };
 
+        let is_user_trace = filter_fn(|meta| {
+            if !meta.is_span() {
+                return false;
+            }
+
+            if meta.fields().iter().any(|f| f.name() == "user_facing") {
+                return true;
+            }
+
+            meta.target() == "quaint::connector::metrics" && meta.name() == "quaint:query"
+        });
+        let tracer = crate::tracer::new_pipeline().install_simple(log_callback.clone());
+        let telemetry = tracing_opentelemetry::layer()
+            .with_tracer(tracer)
+            .with_filter(is_user_trace);
+
         let layer = CallbackLayer::new(log_callback).with_filter(filters);
 
         let metrics = if enable_metrics {
@@ -53,7 +69,7 @@ impl Logger {
         };
 
         Self {
-            dispatcher: Dispatch::new(Registry::default().with(layer).with(metrics.clone())),
+            dispatcher: Dispatch::new(Registry::default().with(telemetry).with(layer).with(metrics.clone())),
             metrics,
         }
     }

--- a/query-engine/query-engine-node-api/src/tracer.rs
+++ b/query-engine/query-engine-node-api/src/tracer.rs
@@ -1,0 +1,87 @@
+use async_trait::async_trait;
+use napi::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
+use opentelemetry::{
+    global, sdk,
+    sdk::{
+        export::trace::{ExportResult, SpanData, SpanExporter},
+        propagation::TraceContextPropagator,
+    },
+    trace::TracerProvider,
+};
+use std::fmt::{self, Debug};
+
+/// Pipeline builder
+#[derive(Debug)]
+pub struct PipelineBuilder {
+    trace_config: Option<sdk::trace::Config>,
+}
+
+/// Create a new stdout exporter pipeline builder.
+pub fn new_pipeline() -> PipelineBuilder {
+    PipelineBuilder::default()
+}
+
+impl Default for PipelineBuilder {
+    /// Return the default pipeline builder.
+    fn default() -> Self {
+        Self { trace_config: None }
+    }
+}
+
+impl PipelineBuilder {
+    /// Assign the SDK trace configuration.
+    #[allow(dead_code)]
+    pub fn with_trace_config(mut self, config: sdk::trace::Config) -> Self {
+        self.trace_config = Some(config);
+        self
+    }
+}
+
+impl PipelineBuilder {
+    pub fn install_simple(mut self, log_callback: ThreadsafeFunction<String>) -> sdk::trace::Tracer {
+        global::set_text_map_propagator(TraceContextPropagator::new());
+        let exporter = ClientSpanExporter::new(log_callback);
+
+        let mut provider_builder = sdk::trace::TracerProvider::builder().with_simple_exporter(exporter);
+        // This doesn't work at the moment because we create the logger outside of an async runtime
+        // we could later move the creation of logger into the `connect` function
+        // let mut provider_builder = sdk::trace::TracerProvider::builder().with_batch_exporter(exporter, runtime::Tokio);
+        // remember to add features = ["rt-tokio"] to the cargo.toml
+        if let Some(config) = self.trace_config.take() {
+            provider_builder = provider_builder.with_config(config);
+        }
+        let provider = provider_builder.build();
+        let tracer = provider.tracer("opentelemetry");
+        let _ = global::set_tracer_provider(provider);
+
+        tracer
+    }
+}
+
+/// A [`ClientSpanExporter`] that sends spans to the JS callback.
+pub struct ClientSpanExporter {
+    callback: ThreadsafeFunction<String>,
+}
+
+impl ClientSpanExporter {
+    pub fn new(callback: ThreadsafeFunction<String>) -> Self {
+        Self { callback }
+    }
+}
+
+impl Debug for ClientSpanExporter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ClientSpanExporter").finish()
+    }
+}
+
+#[async_trait]
+impl SpanExporter for ClientSpanExporter {
+    /// Export spans to stdout
+    async fn export(&mut self, batch: Vec<SpanData>) -> ExportResult {
+        let result = query_core::spans_to_json(&batch);
+        self.callback.call(Ok(result), ThreadsafeFunctionCallMode::Blocking);
+
+        Ok(())
+    }
+}

--- a/query-engine/query-engine-node-api/src/tracer.rs
+++ b/query-engine/query-engine-node-api/src/tracer.rs
@@ -52,7 +52,7 @@ impl PipelineBuilder {
         }
         let provider = provider_builder.build();
         let tracer = provider.tracer("opentelemetry");
-        let _ = global::set_tracer_provider(provider);
+        global::set_tracer_provider(provider);
 
         tracer
     }

--- a/query-engine/query-engine/Cargo.toml
+++ b/query-engine/query-engine/Cargo.toml
@@ -36,11 +36,11 @@ thiserror = "1.0"
 url = "2.1"
 hyper = { version = "0.14", features = ["server", "http1", "http2", "runtime"] }
 tracing = "0.1"
-tracing-opentelemetry = "0.16"
+tracing-opentelemetry = "0.17.3"
 tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
 tracing-futures = "0.2"
-opentelemetry = { version = "0.16", features = ["rt-tokio"] }
-opentelemetry-otlp = { version = "0.9", features = ["tls", "tls-roots"] }
+opentelemetry = { version = "0.17.0", features = ["rt-tokio"] }
+opentelemetry-otlp = { version = "0.10", features = ["tls", "tls-roots"] }
 
 rand = "0.8"
 tonic = { version = "0.4", default-features = false }

--- a/query-engine/query-engine/src/lib.rs
+++ b/query-engine/query-engine/src/lib.rs
@@ -4,6 +4,7 @@ pub mod error;
 pub mod logger;
 pub mod opt;
 pub mod server;
+pub mod tracer;
 
 use error::PrismaError;
 

--- a/query-engine/query-engine/src/logger.rs
+++ b/query-engine/query-engine/src/logger.rs
@@ -83,7 +83,7 @@ impl<'a> Logger<'a> {
                 return true;
             }
 
-            meta.target() == "quaint::connector::metrics" && meta.fields().iter().any(|f| f.name() == "query")
+            meta.target() == "quaint::connector::metrics" && meta.name() == "quaint:query"
         });
 
         let telemetry = if self.enable_telemetry {

--- a/query-engine/query-engine/src/logger.rs
+++ b/query-engine/query-engine/src/logger.rs
@@ -1,12 +1,16 @@
 use opentelemetry::{
     global,
-    sdk::{propagation::TraceContextPropagator, trace::Config, Resource},
+    sdk::{
+        propagation::TraceContextPropagator,
+        trace::{Config, Tracer},
+        Resource,
+    },
     KeyValue,
 };
 use opentelemetry_otlp::WithExportConfig;
 use query_core::MetricRegistry;
 use tracing::{dispatcher::SetGlobalDefaultError, subscriber};
-use tracing_subscriber::{layer::SubscriberExt, registry::LookupSpan, EnvFilter, FmtSubscriber, Layer};
+use tracing_subscriber::{filter::filter_fn, layer::SubscriberExt, EnvFilter, Layer};
 
 use crate::LogFormat;
 
@@ -51,9 +55,13 @@ impl<'a> Logger<'a> {
         self.enable_telemetry = enable_telemetry;
     }
 
-    /// Sets a custom telemetry endpoint (default: http://localhost:4317)
+    /// Sets a custom telemetry endpoint
     pub fn telemetry_endpoint(&mut self, endpoint: &'a str) {
-        self.telemetry_endpoint = Some(endpoint);
+        if endpoint.is_empty() {
+            self.telemetry_endpoint = None
+        } else {
+            self.telemetry_endpoint = Some(endpoint);
+        }
     }
 
     pub fn enable_metrics(&mut self, metrics: MetricRegistry) {
@@ -64,84 +72,87 @@ impl<'a> Logger<'a> {
     /// instance. The returned guard value needs to stay in scope for the whole
     /// lifetime of the service.
     pub fn install(self) -> LoggerResult<()> {
-        let mut filter = EnvFilter::from_default_env()
-            .add_directive("tide=error".parse().unwrap())
-            .add_directive("tonic=error".parse().unwrap())
-            .add_directive("h2=error".parse().unwrap())
-            .add_directive("hyper=error".parse().unwrap())
-            .add_directive("tower=error".parse().unwrap());
+        let filter = create_env_filter(self.log_queries);
 
-        if let Ok(qe_log_level) = std::env::var("QE_LOG_LEVEL") {
-            filter = filter
-                .add_directive(format!("query_engine={}", &qe_log_level).parse().unwrap())
-                .add_directive(format!("query_core={}", &qe_log_level).parse().unwrap())
-                .add_directive(format!("query_connector={}", &qe_log_level).parse().unwrap())
-                .add_directive(format!("sql_query_connector={}", &qe_log_level).parse().unwrap())
-                .add_directive(format!("mongodb_query_connector={}", &qe_log_level).parse().unwrap());
-        }
+        let is_user_trace = filter_fn(|meta| {
+            if !meta.is_span() {
+                return false;
+            }
 
-        if self.log_queries {
-            filter = filter.add_directive("quaint[{is_query}]=trace".parse().unwrap());
-        }
+            if meta.fields().iter().any(|f| f.name() == "user_facing") {
+                return true;
+            }
 
-        match self.log_format {
+            meta.target() == "quaint::connector::metrics" && meta.fields().iter().any(|f| f.name() == "query")
+        });
+
+        let telemetry = if self.enable_telemetry {
+            let tracer = create_otel_tracer(self.service_name, self.telemetry_endpoint);
+            let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
+            let telemetry = telemetry.with_filter(is_user_trace);
+            Some(telemetry)
+        } else {
+            None
+        };
+
+        let fmt_layer = match self.log_format {
             LogFormat::Text => {
-                if self.enable_telemetry {
-                    // Leaving this the old way since this will be removed with the new tracing work
-                    let subscriber = FmtSubscriber::builder()
-                        .with_env_filter(filter.add_directive("trace".parse().unwrap()))
-                        .finish();
-
-                    self.finalize(subscriber)
-                } else {
-                    let fmt_layer = tracing_subscriber::fmt::layer().with_filter(filter);
-
-                    let subscriber = tracing_subscriber::registry().with(fmt_layer).with(self.metrics);
-                    subscriber::set_global_default(subscriber)?;
-
-                    Ok(())
-                }
+                let fmt_layer = tracing_subscriber::fmt::layer().with_filter(filter);
+                fmt_layer.boxed()
             }
             LogFormat::Json => {
                 let fmt_layer = tracing_subscriber::fmt::layer().json().with_filter(filter);
-
-                let subscriber = tracing_subscriber::registry().with(fmt_layer).with(self.metrics);
-                subscriber::set_global_default(subscriber)?;
-                Ok(())
+                fmt_layer.boxed()
             }
-        }
+        };
+
+        let subscriber = tracing_subscriber::registry()
+            .with(fmt_layer)
+            .with(self.metrics)
+            .with(telemetry);
+
+        subscriber::set_global_default(subscriber)?;
+
+        Ok(())
+    }
+}
+
+fn create_otel_tracer(service_name: &'static str, collector_endpoint: Option<&str>) -> Tracer {
+    global::set_text_map_propagator(TraceContextPropagator::new());
+
+    if let Some(endpoint) = collector_endpoint {
+        // A special parameter for Jaeger to set the service name in spans.
+        let resource = Resource::new(vec![KeyValue::new("service.name", service_name)]);
+        let config = Config::default().with_resource(resource);
+
+        let builder = opentelemetry_otlp::new_pipeline().tracing().with_trace_config(config);
+        let exporter = opentelemetry_otlp::new_exporter().tonic().with_endpoint(endpoint);
+        builder.with_exporter(exporter).install_simple().unwrap()
+    } else {
+        crate::tracer::new_pipeline().install_simple()
+    }
+}
+
+fn create_env_filter(log_queries: bool) -> EnvFilter {
+    let mut filter = EnvFilter::from_default_env()
+        .add_directive("tide=error".parse().unwrap())
+        .add_directive("tonic=error".parse().unwrap())
+        .add_directive("h2=error".parse().unwrap())
+        .add_directive("hyper=error".parse().unwrap())
+        .add_directive("tower=error".parse().unwrap());
+
+    if let Ok(qe_log_level) = std::env::var("QE_LOG_LEVEL") {
+        filter = filter
+            .add_directive(format!("query_engine={}", &qe_log_level).parse().unwrap())
+            .add_directive(format!("query_core={}", &qe_log_level).parse().unwrap())
+            .add_directive(format!("query_connector={}", &qe_log_level).parse().unwrap())
+            .add_directive(format!("sql_query_connector={}", &qe_log_level).parse().unwrap())
+            .add_directive(format!("mongodb_query_connector={}", &qe_log_level).parse().unwrap());
     }
 
-    fn finalize<T>(self, subscriber: T) -> LoggerResult<()>
-    where
-        T: SubscriberExt + Send + Sync + 'static + for<'span> LookupSpan<'span>,
-    {
-        if self.enable_telemetry {
-            global::set_text_map_propagator(TraceContextPropagator::new());
-
-            // A special parameter for Jaeger to set the service name in spans.
-            let resource = Resource::new(vec![KeyValue::new("service.name", self.service_name)]);
-            let config = Config::default().with_resource(resource);
-
-            let mut builder = opentelemetry_otlp::new_pipeline().tracing().with_trace_config(config);
-            let mut exporter = opentelemetry_otlp::new_exporter().tonic();
-
-            if let Some(endpoint) = self.telemetry_endpoint {
-                exporter = exporter.with_endpoint(endpoint);
-            }
-
-            builder = builder.with_exporter(exporter);
-
-            let tracer = builder.install_simple().unwrap();
-
-            let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
-
-            subscriber::set_global_default(subscriber.with(telemetry))?;
-
-            Ok(())
-        } else {
-            subscriber::set_global_default(subscriber)?;
-            Ok(())
-        }
+    if log_queries {
+        filter = filter.add_directive("quaint[{is_query}]=trace".parse().unwrap());
     }
+
+    filter
 }

--- a/query-engine/query-engine/src/main.rs
+++ b/query-engine/query-engine/src/main.rs
@@ -28,10 +28,10 @@ async fn main() -> Result<(), AnyError> {
 
         let metrics = MetricRegistry::new();
 
-        let mut logger = Logger::new("query-engine-http");
+        let mut logger = Logger::new("prisma-engine-http");
         logger.log_format(opts.log_format());
         logger.log_queries(opts.log_queries());
-        logger.enable_telemetry(opts.open_telemetry);
+        logger.enable_telemetry(opts.enable_open_telemetry);
         logger.telemetry_endpoint(&opts.open_telemetry_endpoint);
         logger.enable_metrics(metrics.clone());
 

--- a/query-engine/query-engine/src/opt.rs
+++ b/query-engine/query-engine/src/opt.rs
@@ -106,10 +106,12 @@ pub struct PrismaOpt {
 
     /// Enable OpenTelemetry streaming from requests.
     #[structopt(long)]
-    pub open_telemetry: bool,
+    pub enable_open_telemetry: bool,
 
     /// The url to the OpenTelemetry collector.
-    #[structopt(long, default_value = "http://localhost:4317")]
+    /// Enabling this will send the OpenTelemtry tracing to a collector
+    /// and not via our custom stdout tracer
+    #[structopt(long, default_value)]
     pub open_telemetry_endpoint: String,
 
     #[structopt(subcommand)]

--- a/query-engine/query-engine/src/server/mod.rs
+++ b/query-engine/query-engine/src/server/mod.rs
@@ -190,7 +190,7 @@ async fn graphql_handler(state: State, req: Request<Body>) -> Result<Response<Bo
     let tx_id = get_transaction_id_from_header(&req);
 
     let cx = get_parent_span_context(&req);
-    let span = info_span!("prisma:query_bulder", user_facing = true);
+    let span = info_span!("prisma:query_builder", user_facing = true);
     span.set_parent(cx);
 
     let work = async move {

--- a/query-engine/query-engine/src/server/mod.rs
+++ b/query-engine/query-engine/src/server/mod.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Instant;
-use tracing::{Instrument, Span};
+use tracing::Instrument;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 const TRANSACTION_ID_HEADER: &str = "X-transaction-id";

--- a/query-engine/query-engine/src/tests/dmmf.rs
+++ b/query-engine/query-engine/src/tests/dmmf.rs
@@ -111,7 +111,7 @@ fn test_dmmf_cli_command(schema: &str) -> PrismaResult<()> {
         port: 123,
         unix_path: None,
         subcommand: Some(Subcommand::Cli(CliOpt::Dmmf)),
-        open_telemetry: false,
+        enable_open_telemetry: false,
         open_telemetry_endpoint: String::new(),
     };
 

--- a/query-engine/query-engine/src/tracer.rs
+++ b/query-engine/query-engine/src/tracer.rs
@@ -49,7 +49,7 @@ impl PipelineBuilder {
         }
         let provider = provider_builder.build();
         let tracer = provider.tracer("opentelemetry");
-        let _ = global::set_tracer_provider(provider);
+        global::set_tracer_provider(provider);
 
         tracer
     }

--- a/query-engine/query-engine/src/tracer.rs
+++ b/query-engine/query-engine/src/tracer.rs
@@ -1,0 +1,98 @@
+use async_trait::async_trait;
+use opentelemetry::{
+    global,
+    sdk::{self, export::ExportError},
+    sdk::{
+        export::trace::{ExportResult, SpanData, SpanExporter},
+        propagation::TraceContextPropagator,
+    },
+    trace::TracerProvider,
+};
+use query_core::spans_to_json;
+use std::io::{stdout, Stdout};
+use std::{fmt::Debug, io::Write};
+
+/// Pipeline builder
+#[derive(Debug)]
+pub struct PipelineBuilder {
+    trace_config: Option<sdk::trace::Config>,
+}
+
+/// Create a new stdout exporter pipeline builder.
+pub fn new_pipeline() -> PipelineBuilder {
+    PipelineBuilder::default()
+}
+
+impl Default for PipelineBuilder {
+    /// Return the default pipeline builder.
+    fn default() -> Self {
+        Self { trace_config: None }
+    }
+}
+
+impl PipelineBuilder {
+    /// Assign the SDK trace configuration.
+    pub fn with_trace_config(mut self, config: sdk::trace::Config) -> Self {
+        self.trace_config = Some(config);
+        self
+    }
+}
+
+impl PipelineBuilder {
+    pub fn install_simple(mut self) -> sdk::trace::Tracer {
+        global::set_text_map_propagator(TraceContextPropagator::new());
+        let exporter = ClientSpanExporter::new();
+
+        let mut provider_builder = sdk::trace::TracerProvider::builder().with_simple_exporter(exporter);
+        if let Some(config) = self.trace_config.take() {
+            provider_builder = provider_builder.with_config(config);
+        }
+        let provider = provider_builder.build();
+        let tracer = provider.tracer("opentelemetry");
+        let _ = global::set_tracer_provider(provider);
+
+        tracer
+    }
+}
+
+/// A [`ClientSpanExporter`] that sends spans to stdout.
+#[derive(Debug)]
+pub struct ClientSpanExporter {
+    writer: Stdout,
+}
+
+impl ClientSpanExporter {
+    pub fn new() -> Self {
+        Self { writer: stdout() }
+    }
+}
+
+impl Default for ClientSpanExporter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl SpanExporter for ClientSpanExporter {
+    async fn export(&mut self, batch: Vec<SpanData>) -> ExportResult {
+        let result = spans_to_json(&batch);
+
+        if let Err(err) = writeln!(self.writer, "{result}") {
+            Err(ClientSpanExporterError(err).into())
+        } else {
+            Ok(())
+        }
+    }
+}
+
+// ClientSpanExporter exporter's error
+#[derive(thiserror::Error, Debug)]
+#[error(transparent)]
+struct ClientSpanExporterError(std::io::Error);
+
+impl ExportError for ClientSpanExporterError {
+    fn exporter_name(&self) -> &'static str {
+        "stdout"
+    }
+}


### PR DESCRIPTION
Add tracing to engine
This adds useful tracing spans to the engine to observe the flow
of prisma queries. A tracer is implemented for the node-api that passes
the traces to the log callback function as json so that the prisma client
can process them and add them to the OTEL pipeline.
    
On the queryengine binary side, the traces are written to stdout via
a new tracer. This again allows the client to read the traces and
add the tracing spans to the OTEL pipeline.

only traces with the `user_facing = true` attribute will be forwarded by the tracers. 