### PR TITLE
Make spans to match on the referencing side

### DIFF
--- a/prisma-fmt/src/code_actions/relations.rs
+++ b/prisma-fmt/src/code_actions/relations.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use datamodel::parser_database::walkers::CompleteInlineRelationWalker;
+use datamodel::parser_database::walkers::{CompleteInlineRelationWalker, ModelWalker, ScalarFieldWalker};
 use lsp_types::{CodeAction, CodeActionKind, CodeActionOrCommand, CodeActionParams, Range, TextEdit, WorkspaceEdit};
 
 /// If the referencing side of the one-to-one relation does not point
@@ -63,39 +63,7 @@ pub(super) fn add_referencing_side_unique(
         _ => (),
     }
 
-    let mut fields = relation.referencing_fields();
-
-    let (new_text, start, end) = if fields.len() == 1 {
-        let new_text = String::from(" @unique");
-
-        let field = fields.next().unwrap();
-        let range = crate::span_to_range(field.ast_field().span, schema);
-
-        (new_text, range.end, range.end)
-    } else {
-        let fields = fields.map(|f| f.name()).collect::<Vec<_>>().join(", ");
-        let model = relation.referencing_model();
-        let newline = model.newline();
-
-        let separator = if model.ast_model().attributes.is_empty() {
-            ""
-        } else {
-            newline.as_ref()
-        };
-
-        let indentation = model.indentation();
-        let new_text = format!("{separator}{indentation}@@unique([{fields}]){newline}}}");
-
-        let start = crate::offset_to_position(model.ast_model().span.end - 1, schema).unwrap();
-        let end = crate::offset_to_position(model.ast_model().span.end, schema).unwrap();
-
-        (new_text, start, end)
-    };
-
-    let text = TextEdit {
-        range: Range { start, end },
-        new_text,
-    };
+    let text = create_missing_unique(schema, relation.referencing_model(), relation.referencing_fields());
 
     let mut changes = HashMap::new();
     changes.insert(params.text_document.uri.clone(), vec![text]);
@@ -181,40 +149,7 @@ pub(super) fn add_referenced_side_unique(
         _ => (),
     }
 
-    let mut fields = relation.referenced_fields();
-
-    let (new_text, start, end) = if fields.len() == 1 {
-        let new_text = String::from(" @unique");
-
-        let field = fields.next().unwrap();
-        let start = crate::offset_to_position(field.ast_field().span.end - 1, schema).unwrap();
-
-        (new_text, start, start)
-    } else {
-        let model = relation.referenced_model();
-        let fields = fields.map(|f| f.name()).collect::<Vec<_>>().join(", ");
-
-        let indentation = model.indentation();
-        let newline = model.newline();
-
-        let separator = if model.ast_model().attributes.is_empty() {
-            newline.as_ref()
-        } else {
-            ""
-        };
-
-        let new_text = format!("{separator}{indentation}@@unique([{fields}]){newline}}}");
-
-        let start = crate::offset_to_position(model.ast_model().span.end - 1, schema).unwrap();
-        let end = crate::offset_to_position(model.ast_model().span.end, schema).unwrap();
-
-        (new_text, start, end)
-    };
-
-    let text = TextEdit {
-        range: Range { start, end },
-        new_text,
-    };
+    let text = create_missing_unique(schema, relation.referenced_model(), relation.referenced_fields());
 
     let mut changes = HashMap::new();
     changes.insert(params.text_document.uri.clone(), vec![text]);
@@ -241,4 +176,46 @@ pub(super) fn add_referenced_side_unique(
     };
 
     actions.push(CodeActionOrCommand::CodeAction(action));
+}
+
+fn create_missing_unique<'a>(
+    schema: &str,
+    model: ModelWalker<'a>,
+    mut fields: impl ExactSizeIterator<Item = ScalarFieldWalker<'a>> + 'a,
+) -> TextEdit {
+    let (new_text, range) = if fields.len() == 1 {
+        let new_text = String::from(" @unique");
+
+        let field = fields.next().unwrap();
+        let position = crate::position_after_span(field.ast_field().span, schema);
+
+        let range = Range {
+            start: position,
+            end: position,
+        };
+
+        (new_text, range)
+    } else {
+        let fields = fields.map(|f| f.name()).collect::<Vec<_>>().join(", ");
+
+        let indentation = model.indentation();
+        let newline = model.newline();
+
+        let separator = if model.ast_model().attributes.is_empty() {
+            newline.as_ref()
+        } else {
+            ""
+        };
+
+        let new_text = format!("{separator}{indentation}@@unique([{fields}]){newline}}}");
+
+        let start = crate::offset_to_position(model.ast_model().span.end - 1, schema).unwrap();
+        let end = crate::offset_to_position(model.ast_model().span.end, schema).unwrap();
+
+        let range = Range { start, end };
+
+        (new_text, range)
+    };
+
+    TextEdit { range, new_text }
 }

--- a/prisma-fmt/src/lib.rs
+++ b/prisma-fmt/src/lib.rs
@@ -166,12 +166,9 @@ pub(crate) fn range_to_span(range: Range, document: &str) -> ast::Span {
     ast::Span::new(start, end)
 }
 
-/// Converts a span of byte offsets to an LSP range.
-pub(crate) fn span_to_range(span: ast::Span, document: &str) -> Range {
-    let start = offset_to_position(span.start, document).unwrap();
-    let end = offset_to_position(span.end - 2, document).unwrap();
-
-    Range { start, end }
+/// Gives the LSP position right after the given span.
+pub(crate) fn position_after_span(span: ast::Span, document: &str) -> Position {
+    offset_to_position(span.end - 1, document).unwrap()
 }
 
 /// Converts a byte offset to an LSP position, if the given offset

--- a/prisma-fmt/tests/code_actions/scenarios/one_to_one_referencing_side_misses_unique_compound_field/result.json
+++ b/prisma-fmt/tests/code_actions/scenarios/one_to_one_referencing_side_misses_unique_compound_field/result.json
@@ -32,7 +32,7 @@
                 "character": 1
               }
             },
-            "newText": "  @@unique([bId1, bId2])\n}"
+            "newText": "\n  @@unique([bId1, bId2])\n}"
           }
         ]
       }

--- a/prisma-fmt/tests/code_actions/scenarios/one_to_one_referencing_side_misses_unique_compound_field_indentation_four_spaces/result.json
+++ b/prisma-fmt/tests/code_actions/scenarios/one_to_one_referencing_side_misses_unique_compound_field_indentation_four_spaces/result.json
@@ -32,7 +32,7 @@
                 "character": 1
               }
             },
-            "newText": "    @@unique([bId1, bId2])\n}"
+            "newText": "\n    @@unique([bId1, bId2])\n}"
           }
         ]
       }

--- a/prisma-fmt/tests/code_actions/scenarios/one_to_one_referencing_side_misses_unique_single_field/diagnostics.json
+++ b/prisma-fmt/tests/code_actions/scenarios/one_to_one_referencing_side_misses_unique_single_field/diagnostics.json
@@ -2,12 +2,12 @@
   {
     "range": {
       "start": {
-        "line": 13,
+        "line": 8,
         "character": 2
       },
       "end": {
-        "line": 13,
-        "character": 10
+        "line": 8,
+        "character": 55
       }
     },
     "severity": 1,

--- a/prisma-fmt/tests/code_actions/scenarios/one_to_one_referencing_side_misses_unique_single_field/result.json
+++ b/prisma-fmt/tests/code_actions/scenarios/one_to_one_referencing_side_misses_unique_single_field/result.json
@@ -1,17 +1,17 @@
 [
   {
-    "title": "Make referenced field(s) unique",
+    "title": "Make referencing fields unique",
     "kind": "quickfix",
     "diagnostics": [
       {
         "range": {
           "start": {
-            "line": 13,
+            "line": 8,
             "character": 2
           },
           "end": {
-            "line": 13,
-            "character": 10
+            "line": 8,
+            "character": 55
           }
         },
         "severity": 1,
@@ -24,12 +24,12 @@
           {
             "range": {
               "start": {
-                "line": 13,
-                "character": 11
+                "line": 7,
+                "character": 9
               },
               "end": {
-                "line": 13,
-                "character": 11
+                "line": 7,
+                "character": 9
               }
             },
             "newText": " @unique"

--- a/prisma-fmt/tests/code_actions/tests.rs
+++ b/prisma-fmt/tests/code_actions/tests.rs
@@ -20,6 +20,7 @@ scenarios! {
     one_to_many_referenced_side_misses_unique_compound_field_broken_relation
     one_to_one_referenced_side_misses_unique_single_field
     one_to_one_referenced_side_misses_unique_compound_field
+    one_to_one_referencing_side_misses_unique_single_field
     one_to_one_referencing_side_misses_unique_compound_field
     one_to_one_referencing_side_misses_unique_compound_field_indentation_four_spaces
 }


### PR DESCRIPTION
This quickfix removed characters that should not be removed, fixing it.

Btw... we might want a better test setup to catch these @tomhoule...