### PR TITLE
fix(sql-schema-describer): always return foreign keys sorted

### DIFF
--- a/introspection-engine/connectors/sql-introspection-connector/src/calculate_datamodel.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/calculate_datamodel.rs
@@ -63,7 +63,7 @@ pub fn calculate_datamodel(
     let mut warnings = vec![];
     if !previous_datamodel.is_empty() {
         enrich(previous_datamodel, &mut datamodel, &ctx, &mut warnings);
-        tracing::debug!("Enriching datamodel is done: {:?}", datamodel);
+        debug!("Enriching datamodel is done.");
     }
 
     // commenting out models, fields, enums, enum values
@@ -75,8 +75,7 @@ pub fn calculate_datamodel(
     // if based on a previous Prisma version add id default opinionations
     add_prisma_1_id_defaults(&version, &mut datamodel, schema, &mut warnings, &ctx);
 
-    // renderer -> parser -> validator, is_commented_out gets lost between renderer and parser
-    debug!("Done calculating data model {:?}", datamodel);
+    debug!("Done calculating datamodel.");
     Ok(IntrospectionResult {
         data_model: datamodel,
         warnings,

--- a/introspection-engine/connectors/sql-introspection-connector/src/introspection.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/introspection.rs
@@ -59,6 +59,7 @@ pub(crate) fn introspect(version_check: &mut VersionChecker, ctx: &mut Context) 
             })
             .map(|(_, fk)| fk.id)
             .collect();
+
         for foreign_key in table
             .foreign_keys()
             .filter(|fk| !duplicated_foreign_keys.contains(&fk.id))

--- a/introspection-engine/connectors/sql-introspection-connector/src/lib.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/lib.rs
@@ -158,14 +158,11 @@ impl IntrospectionConnector for SqlIntrospectionConnector {
         ctx: IntrospectionContext,
     ) -> ConnectorResult<IntrospectionResult> {
         let sql_schema = self.catch(self.describe(Some(&ctx.source.active_provider))).await?;
-        tracing::debug!("SQL Schema Describer is done: {:?}", sql_schema);
 
         let introspection_result = calculate_datamodel::calculate_datamodel(&sql_schema, previous_data_model, ctx)
             .map_err(|sql_introspection_error| {
                 sql_introspection_error.into_connector_error(self.connection.connection_info())
             })?;
-
-        tracing::debug!("Calculating datamodel is done: {:?}", introspection_result.data_model);
 
         Ok(introspection_result)
     }

--- a/introspection-engine/introspection-engine-tests/tests/tables/mysql.rs
+++ b/introspection-engine/introspection-engine-tests/tests/tables/mysql.rs
@@ -424,3 +424,385 @@ async fn missing_select_rights(api: &TestApi) -> TestResult {
 
     Ok(())
 }
+
+#[test_connector(tags(Mysql), exclude(Vitess))]
+async fn northwind(api: TestApi) {
+    let setup = include_str!("./northwind_mysql.sql");
+    api.raw_cmd(setup).await;
+    let expectation = expect![[r#"
+        generator client {
+          provider = "prisma-client-js"
+        }
+
+        datasource db {
+          provider = "mysql"
+          url      = "env(TEST_DATABASE_URL)"
+        }
+
+        model customers {
+          id              Int      @id @default(autoincrement())
+          company         String?  @db.VarChar(50)
+          last_name       String?  @db.VarChar(50)
+          first_name      String?  @db.VarChar(50)
+          email_address   String?  @db.VarChar(50)
+          job_title       String?  @db.VarChar(50)
+          business_phone  String?  @db.VarChar(25)
+          home_phone      String?  @db.VarChar(25)
+          mobile_phone    String?  @db.VarChar(25)
+          fax_number      String?  @db.VarChar(25)
+          address         String?  @db.LongText
+          city            String?  @db.VarChar(50)
+          state_province  String?  @db.VarChar(50)
+          zip_postal_code String?  @db.VarChar(15)
+          country_region  String?  @db.VarChar(50)
+          web_page        String?  @db.LongText
+          notes           String?  @db.LongText
+          attachments     Bytes?
+          orders          orders[]
+
+          @@index([city], map: "city")
+          @@index([company], map: "company")
+          @@index([first_name], map: "first_name")
+          @@index([last_name], map: "last_name")
+          @@index([state_province], map: "state_province")
+          @@index([zip_postal_code], map: "zip_postal_code")
+        }
+
+        model employee_privileges {
+          employee_id  Int
+          privilege_id Int
+          employees    employees  @relation(fields: [employee_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fk_employee_privileges_employees1")
+          privileges   privileges @relation(fields: [privilege_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fk_employee_privileges_privileges1")
+
+          @@id([employee_id, privilege_id])
+          @@index([employee_id], map: "employee_id")
+          @@index([privilege_id], map: "privilege_id")
+          @@index([privilege_id], map: "privilege_id_2")
+        }
+
+        model employees {
+          id                  Int                   @id @default(autoincrement())
+          company             String?               @db.VarChar(50)
+          last_name           String?               @db.VarChar(50)
+          first_name          String?               @db.VarChar(50)
+          email_address       String?               @db.VarChar(50)
+          job_title           String?               @db.VarChar(50)
+          business_phone      String?               @db.VarChar(25)
+          home_phone          String?               @db.VarChar(25)
+          mobile_phone        String?               @db.VarChar(25)
+          fax_number          String?               @db.VarChar(25)
+          address             String?               @db.LongText
+          city                String?               @db.VarChar(50)
+          state_province      String?               @db.VarChar(50)
+          zip_postal_code     String?               @db.VarChar(15)
+          country_region      String?               @db.VarChar(50)
+          web_page            String?               @db.LongText
+          notes               String?               @db.LongText
+          attachments         Bytes?
+          employee_privileges employee_privileges[]
+          orders              orders[]
+          purchase_orders     purchase_orders[]
+
+          @@index([city], map: "city")
+          @@index([company], map: "company")
+          @@index([first_name], map: "first_name")
+          @@index([last_name], map: "last_name")
+          @@index([state_province], map: "state_province")
+          @@index([zip_postal_code], map: "zip_postal_code")
+        }
+
+        model inventory_transaction_types {
+          id                     Int                      @id @db.TinyInt
+          type_name              String                   @db.VarChar(50)
+          inventory_transactions inventory_transactions[]
+        }
+
+        model inventory_transactions {
+          id                          Int                         @id @default(autoincrement())
+          transaction_type            Int                         @db.TinyInt
+          transaction_created_date    DateTime?                   @db.DateTime(0)
+          transaction_modified_date   DateTime?                   @db.DateTime(0)
+          product_id                  Int
+          quantity                    Int
+          purchase_order_id           Int?
+          customer_order_id           Int?
+          comments                    String?                     @db.VarChar(255)
+          inventory_transaction_types inventory_transaction_types @relation(fields: [transaction_type], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fk_inventory_transactions_inventory_transaction_types1")
+          orders                      orders?                     @relation(fields: [customer_order_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fk_inventory_transactions_orders1")
+          products                    products                    @relation(fields: [product_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fk_inventory_transactions_products1")
+          purchase_orders             purchase_orders?            @relation(fields: [purchase_order_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fk_inventory_transactions_purchase_orders1")
+          purchase_order_details      purchase_order_details[]
+
+          @@index([customer_order_id], map: "customer_order_id")
+          @@index([customer_order_id], map: "customer_order_id_2")
+          @@index([product_id], map: "product_id")
+          @@index([product_id], map: "product_id_2")
+          @@index([purchase_order_id], map: "purchase_order_id")
+          @@index([purchase_order_id], map: "purchase_order_id_2")
+          @@index([transaction_type], map: "transaction_type")
+        }
+
+        model invoices {
+          id           Int       @id @default(autoincrement())
+          order_id     Int?
+          invoice_date DateTime? @db.DateTime(0)
+          due_date     DateTime? @db.DateTime(0)
+          tax          Decimal?  @default(0.0000) @db.Decimal(19, 4)
+          shipping     Decimal?  @default(0.0000) @db.Decimal(19, 4)
+          amount_due   Decimal?  @default(0.0000) @db.Decimal(19, 4)
+          orders       orders?   @relation(fields: [order_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fk_invoices_orders1")
+
+          @@index([order_id], map: "fk_invoices_orders1_idx")
+          @@index([id], map: "id")
+          @@index([id], map: "id_2")
+        }
+
+        model order_details {
+          id                   Int                   @id @default(autoincrement())
+          order_id             Int
+          product_id           Int?
+          quantity             Decimal               @default(0.0000) @db.Decimal(18, 4)
+          unit_price           Decimal?              @default(0.0000) @db.Decimal(19, 4)
+          discount             Float                 @default(0)
+          status_id            Int?
+          date_allocated       DateTime?             @db.DateTime(0)
+          purchase_order_id    Int?
+          inventory_id         Int?
+          order_details_status order_details_status? @relation(fields: [status_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fk_order_details_order_details_status1")
+          orders               orders                @relation(fields: [order_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fk_order_details_orders1")
+          products             products?             @relation(fields: [product_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fk_order_details_products1")
+
+          @@index([status_id], map: "fk_order_details_order_details_status1_idx")
+          @@index([order_id], map: "fk_order_details_orders1_idx")
+          @@index([id], map: "id")
+          @@index([id], map: "id_2")
+          @@index([id], map: "id_3")
+          @@index([id], map: "id_4")
+          @@index([id], map: "id_5")
+          @@index([inventory_id], map: "inventory_id")
+          @@index([product_id], map: "product_id")
+          @@index([product_id], map: "product_id_2")
+          @@index([purchase_order_id], map: "purchase_order_id")
+        }
+
+        model order_details_status {
+          id            Int             @id
+          status_name   String          @db.VarChar(50)
+          order_details order_details[]
+        }
+
+        model orders {
+          id                     Int                      @id @default(autoincrement())
+          employee_id            Int?
+          customer_id            Int?
+          order_date             DateTime?                @db.DateTime(0)
+          shipped_date           DateTime?                @db.DateTime(0)
+          shipper_id             Int?
+          ship_name              String?                  @db.VarChar(50)
+          ship_address           String?                  @db.LongText
+          ship_city              String?                  @db.VarChar(50)
+          ship_state_province    String?                  @db.VarChar(50)
+          ship_zip_postal_code   String?                  @db.VarChar(50)
+          ship_country_region    String?                  @db.VarChar(50)
+          shipping_fee           Decimal?                 @default(0.0000) @db.Decimal(19, 4)
+          taxes                  Decimal?                 @default(0.0000) @db.Decimal(19, 4)
+          payment_type           String?                  @db.VarChar(50)
+          paid_date              DateTime?                @db.DateTime(0)
+          notes                  String?                  @db.LongText
+          tax_rate               Float?                   @default(0)
+          tax_status_id          Int?                     @db.TinyInt
+          status_id              Int?                     @default(0) @db.TinyInt
+          customers              customers?               @relation(fields: [customer_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fk_orders_customers")
+          employees              employees?               @relation(fields: [employee_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fk_orders_employees1")
+          orders_status          orders_status?           @relation(fields: [status_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fk_orders_orders_status1")
+          orders_tax_status      orders_tax_status?       @relation(fields: [tax_status_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fk_orders_orders_tax_status1")
+          shippers               shippers?                @relation(fields: [shipper_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fk_orders_shippers1")
+          inventory_transactions inventory_transactions[]
+          invoices               invoices[]
+          order_details          order_details[]
+
+          @@index([customer_id], map: "customer_id")
+          @@index([customer_id], map: "customer_id_2")
+          @@index([employee_id], map: "employee_id")
+          @@index([employee_id], map: "employee_id_2")
+          @@index([status_id], map: "fk_orders_orders_status1")
+          @@index([id], map: "id")
+          @@index([id], map: "id_2")
+          @@index([id], map: "id_3")
+          @@index([ship_zip_postal_code], map: "ship_zip_postal_code")
+          @@index([shipper_id], map: "shipper_id")
+          @@index([shipper_id], map: "shipper_id_2")
+          @@index([tax_status_id], map: "tax_status")
+        }
+
+        model orders_status {
+          id          Int      @id @db.TinyInt
+          status_name String   @db.VarChar(50)
+          orders      orders[]
+        }
+
+        model orders_tax_status {
+          id              Int      @id @db.TinyInt
+          tax_status_name String   @db.VarChar(50)
+          orders          orders[]
+        }
+
+        model privileges {
+          id                  Int                   @id @default(autoincrement())
+          privilege_name      String?               @db.VarChar(50)
+          employee_privileges employee_privileges[]
+        }
+
+        model products {
+          supplier_ids             String?                  @db.LongText
+          id                       Int                      @id @default(autoincrement())
+          product_code             String?                  @db.VarChar(25)
+          product_name             String?                  @db.VarChar(50)
+          description              String?                  @db.LongText
+          standard_cost            Decimal?                 @default(0.0000) @db.Decimal(19, 4)
+          list_price               Decimal                  @default(0.0000) @db.Decimal(19, 4)
+          reorder_level            Int?
+          target_level             Int?
+          quantity_per_unit        String?                  @db.VarChar(50)
+          discontinued             Boolean                  @default(false)
+          minimum_reorder_quantity Int?
+          category                 String?                  @db.VarChar(50)
+          attachments              Bytes?
+          inventory_transactions   inventory_transactions[]
+          order_details            order_details[]
+          purchase_order_details   purchase_order_details[]
+
+          @@index([product_code], map: "product_code")
+        }
+
+        model purchase_order_details {
+          id                     Int                     @id @default(autoincrement())
+          purchase_order_id      Int
+          product_id             Int?
+          quantity               Decimal                 @db.Decimal(18, 4)
+          unit_cost              Decimal                 @db.Decimal(19, 4)
+          date_received          DateTime?               @db.DateTime(0)
+          posted_to_inventory    Boolean                 @default(false)
+          inventory_id           Int?
+          inventory_transactions inventory_transactions? @relation(fields: [inventory_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fk_purchase_order_details_inventory_transactions1")
+          products               products?               @relation(fields: [product_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fk_purchase_order_details_products1")
+          purchase_orders        purchase_orders         @relation(fields: [purchase_order_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fk_purchase_order_details_purchase_orders1")
+
+          @@index([id], map: "id")
+          @@index([inventory_id], map: "inventory_id")
+          @@index([inventory_id], map: "inventory_id_2")
+          @@index([product_id], map: "product_id")
+          @@index([product_id], map: "product_id_2")
+          @@index([purchase_order_id], map: "purchase_order_id")
+          @@index([purchase_order_id], map: "purchase_order_id_2")
+        }
+
+        model purchase_order_status {
+          id              Int               @id
+          status          String?           @db.VarChar(50)
+          purchase_orders purchase_orders[]
+        }
+
+        model purchase_orders {
+          id                     Int                      @id @unique(map: "id") @default(autoincrement())
+          supplier_id            Int?
+          created_by             Int?
+          submitted_date         DateTime?                @db.DateTime(0)
+          creation_date          DateTime?                @db.DateTime(0)
+          status_id              Int?                     @default(0)
+          expected_date          DateTime?                @db.DateTime(0)
+          shipping_fee           Decimal                  @default(0.0000) @db.Decimal(19, 4)
+          taxes                  Decimal                  @default(0.0000) @db.Decimal(19, 4)
+          payment_date           DateTime?                @db.DateTime(0)
+          payment_amount         Decimal?                 @default(0.0000) @db.Decimal(19, 4)
+          payment_method         String?                  @db.VarChar(50)
+          notes                  String?                  @db.LongText
+          approved_by            Int?
+          approved_date          DateTime?                @db.DateTime(0)
+          submitted_by           Int?
+          employees              employees?               @relation(fields: [created_by], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fk_purchase_orders_employees1")
+          purchase_order_status  purchase_order_status?   @relation(fields: [status_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fk_purchase_orders_purchase_order_status1")
+          suppliers              suppliers?               @relation(fields: [supplier_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fk_purchase_orders_suppliers1")
+          inventory_transactions inventory_transactions[]
+          purchase_order_details purchase_order_details[]
+
+          @@index([created_by], map: "created_by")
+          @@index([id], map: "id_2")
+          @@index([status_id], map: "status_id")
+          @@index([supplier_id], map: "supplier_id")
+          @@index([supplier_id], map: "supplier_id_2")
+        }
+
+        model sales_reports {
+          group_by          String  @id @db.VarChar(50)
+          display           String? @db.VarChar(50)
+          title             String? @db.VarChar(50)
+          filter_row_source String? @db.LongText
+          default           Boolean @default(false)
+        }
+
+        model shippers {
+          id              Int      @id @default(autoincrement())
+          company         String?  @db.VarChar(50)
+          last_name       String?  @db.VarChar(50)
+          first_name      String?  @db.VarChar(50)
+          email_address   String?  @db.VarChar(50)
+          job_title       String?  @db.VarChar(50)
+          business_phone  String?  @db.VarChar(25)
+          home_phone      String?  @db.VarChar(25)
+          mobile_phone    String?  @db.VarChar(25)
+          fax_number      String?  @db.VarChar(25)
+          address         String?  @db.LongText
+          city            String?  @db.VarChar(50)
+          state_province  String?  @db.VarChar(50)
+          zip_postal_code String?  @db.VarChar(15)
+          country_region  String?  @db.VarChar(50)
+          web_page        String?  @db.LongText
+          notes           String?  @db.LongText
+          attachments     Bytes?
+          orders          orders[]
+
+          @@index([city], map: "city")
+          @@index([company], map: "company")
+          @@index([first_name], map: "first_name")
+          @@index([last_name], map: "last_name")
+          @@index([state_province], map: "state_province")
+          @@index([zip_postal_code], map: "zip_postal_code")
+        }
+
+        model strings {
+          string_id   Int     @id @default(autoincrement())
+          string_data String? @db.VarChar(255)
+        }
+
+        model suppliers {
+          id              Int               @id @default(autoincrement())
+          company         String?           @db.VarChar(50)
+          last_name       String?           @db.VarChar(50)
+          first_name      String?           @db.VarChar(50)
+          email_address   String?           @db.VarChar(50)
+          job_title       String?           @db.VarChar(50)
+          business_phone  String?           @db.VarChar(25)
+          home_phone      String?           @db.VarChar(25)
+          mobile_phone    String?           @db.VarChar(25)
+          fax_number      String?           @db.VarChar(25)
+          address         String?           @db.LongText
+          city            String?           @db.VarChar(50)
+          state_province  String?           @db.VarChar(50)
+          zip_postal_code String?           @db.VarChar(15)
+          country_region  String?           @db.VarChar(50)
+          web_page        String?           @db.LongText
+          notes           String?           @db.LongText
+          attachments     Bytes?
+          purchase_orders purchase_orders[]
+
+          @@index([city], map: "city")
+          @@index([company], map: "company")
+          @@index([first_name], map: "first_name")
+          @@index([last_name], map: "last_name")
+          @@index([state_province], map: "state_province")
+          @@index([zip_postal_code], map: "zip_postal_code")
+        }
+    "#]];
+    api.expect_datamodel(&expectation).await;
+}

--- a/introspection-engine/introspection-engine-tests/tests/tables/northwind_mysql.sql
+++ b/introspection-engine/introspection-engine-tests/tests/tables/northwind_mysql.sql
@@ -1,0 +1,513 @@
+-- -----------------------------------------------------
+-- Table `customers`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `customers` (
+  `id` INT(11) NOT NULL AUTO_INCREMENT,
+  `company` VARCHAR(50) NULL DEFAULT NULL,
+  `last_name` VARCHAR(50) NULL DEFAULT NULL,
+  `first_name` VARCHAR(50) NULL DEFAULT NULL,
+  `email_address` VARCHAR(50) NULL DEFAULT NULL,
+  `job_title` VARCHAR(50) NULL DEFAULT NULL,
+  `business_phone` VARCHAR(25) NULL DEFAULT NULL,
+  `home_phone` VARCHAR(25) NULL DEFAULT NULL,
+  `mobile_phone` VARCHAR(25) NULL DEFAULT NULL,
+  `fax_number` VARCHAR(25) NULL DEFAULT NULL,
+  `address` LONGTEXT NULL DEFAULT NULL,
+  `city` VARCHAR(50) NULL DEFAULT NULL,
+  `state_province` VARCHAR(50) NULL DEFAULT NULL,
+  `zip_postal_code` VARCHAR(15) NULL DEFAULT NULL,
+  `country_region` VARCHAR(50) NULL DEFAULT NULL,
+  `web_page` LONGTEXT NULL DEFAULT NULL,
+  `notes` LONGTEXT NULL DEFAULT NULL,
+  `attachments` LONGBLOB NULL DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  INDEX `city` (`city` ASC),
+  INDEX `company` (`company` ASC),
+  INDEX `first_name` (`first_name` ASC),
+  INDEX `last_name` (`last_name` ASC),
+  INDEX `zip_postal_code` (`zip_postal_code` ASC),
+  INDEX `state_province` (`state_province` ASC))
+DEFAULT CHARACTER SET = utf8;
+
+
+-- -----------------------------------------------------
+-- Table `employees`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `employees` (
+  `id` INT(11) NOT NULL AUTO_INCREMENT,
+  `company` VARCHAR(50) NULL DEFAULT NULL,
+  `last_name` VARCHAR(50) NULL DEFAULT NULL,
+  `first_name` VARCHAR(50) NULL DEFAULT NULL,
+  `email_address` VARCHAR(50) NULL DEFAULT NULL,
+  `job_title` VARCHAR(50) NULL DEFAULT NULL,
+  `business_phone` VARCHAR(25) NULL DEFAULT NULL,
+  `home_phone` VARCHAR(25) NULL DEFAULT NULL,
+  `mobile_phone` VARCHAR(25) NULL DEFAULT NULL,
+  `fax_number` VARCHAR(25) NULL DEFAULT NULL,
+  `address` LONGTEXT NULL DEFAULT NULL,
+  `city` VARCHAR(50) NULL DEFAULT NULL,
+  `state_province` VARCHAR(50) NULL DEFAULT NULL,
+  `zip_postal_code` VARCHAR(15) NULL DEFAULT NULL,
+  `country_region` VARCHAR(50) NULL DEFAULT NULL,
+  `web_page` LONGTEXT NULL DEFAULT NULL,
+  `notes` LONGTEXT NULL DEFAULT NULL,
+  `attachments` LONGBLOB NULL DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  INDEX `city` (`city` ASC),
+  INDEX `company` (`company` ASC),
+  INDEX `first_name` (`first_name` ASC),
+  INDEX `last_name` (`last_name` ASC),
+  INDEX `zip_postal_code` (`zip_postal_code` ASC),
+  INDEX `state_province` (`state_province` ASC))
+DEFAULT CHARACTER SET = utf8;
+
+
+-- -----------------------------------------------------
+-- Table `privileges`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `privileges` (
+  `id` INT(11) NOT NULL AUTO_INCREMENT,
+  `privilege_name` VARCHAR(50) NULL DEFAULT NULL,
+  PRIMARY KEY (`id`))
+DEFAULT CHARACTER SET = utf8;
+
+
+-- -----------------------------------------------------
+-- Table `employee_privileges`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `employee_privileges` (
+  `employee_id` INT(11) NOT NULL,
+  `privilege_id` INT(11) NOT NULL,
+  PRIMARY KEY (`employee_id`, `privilege_id`),
+  INDEX `employee_id` (`employee_id` ASC),
+  INDEX `privilege_id` (`privilege_id` ASC),
+  INDEX `privilege_id_2` (`privilege_id` ASC),
+  CONSTRAINT `fk_employee_privileges_employees1`
+    FOREIGN KEY (`employee_id`)
+    REFERENCES `employees` (`id`)
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION,
+  CONSTRAINT `fk_employee_privileges_privileges1`
+    FOREIGN KEY (`privilege_id`)
+    REFERENCES `privileges` (`id`)
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION)
+DEFAULT CHARACTER SET = utf8;
+
+
+-- -----------------------------------------------------
+-- Table `inventory_transaction_types`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `inventory_transaction_types` (
+  `id` TINYINT(4) NOT NULL,
+  `type_name` VARCHAR(50) NOT NULL,
+  PRIMARY KEY (`id`))
+DEFAULT CHARACTER SET = utf8;
+
+
+-- -----------------------------------------------------
+-- Table `shippers`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `shippers` (
+  `id` INT(11) NOT NULL AUTO_INCREMENT,
+  `company` VARCHAR(50) NULL DEFAULT NULL,
+  `last_name` VARCHAR(50) NULL DEFAULT NULL,
+  `first_name` VARCHAR(50) NULL DEFAULT NULL,
+  `email_address` VARCHAR(50) NULL DEFAULT NULL,
+  `job_title` VARCHAR(50) NULL DEFAULT NULL,
+  `business_phone` VARCHAR(25) NULL DEFAULT NULL,
+  `home_phone` VARCHAR(25) NULL DEFAULT NULL,
+  `mobile_phone` VARCHAR(25) NULL DEFAULT NULL,
+  `fax_number` VARCHAR(25) NULL DEFAULT NULL,
+  `address` LONGTEXT NULL DEFAULT NULL,
+  `city` VARCHAR(50) NULL DEFAULT NULL,
+  `state_province` VARCHAR(50) NULL DEFAULT NULL,
+  `zip_postal_code` VARCHAR(15) NULL DEFAULT NULL,
+  `country_region` VARCHAR(50) NULL DEFAULT NULL,
+  `web_page` LONGTEXT NULL DEFAULT NULL,
+  `notes` LONGTEXT NULL DEFAULT NULL,
+  `attachments` LONGBLOB NULL DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  INDEX `city` (`city` ASC),
+  INDEX `company` (`company` ASC),
+  INDEX `first_name` (`first_name` ASC),
+  INDEX `last_name` (`last_name` ASC),
+  INDEX `zip_postal_code` (`zip_postal_code` ASC),
+  INDEX `state_province` (`state_province` ASC))
+DEFAULT CHARACTER SET = utf8;
+
+
+-- -----------------------------------------------------
+-- Table `orders_tax_status`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `orders_tax_status` (
+  `id` TINYINT(4) NOT NULL,
+  `tax_status_name` VARCHAR(50) NOT NULL,
+  PRIMARY KEY (`id`))
+DEFAULT CHARACTER SET = utf8;
+
+
+-- -----------------------------------------------------
+-- Table `orders_status`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `orders_status` (
+  `id` TINYINT(4) NOT NULL,
+  `status_name` VARCHAR(50) NOT NULL,
+  PRIMARY KEY (`id`))
+DEFAULT CHARACTER SET = utf8;
+
+
+-- -----------------------------------------------------
+-- Table `orders`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `orders` (
+  `id` INT(11) NOT NULL AUTO_INCREMENT,
+  `employee_id` INT(11) NULL DEFAULT NULL,
+  `customer_id` INT(11) NULL DEFAULT NULL,
+  `order_date` DATETIME NULL DEFAULT NULL,
+  `shipped_date` DATETIME NULL DEFAULT NULL,
+  `shipper_id` INT(11) NULL DEFAULT NULL,
+  `ship_name` VARCHAR(50) NULL DEFAULT NULL,
+  `ship_address` LONGTEXT NULL DEFAULT NULL,
+  `ship_city` VARCHAR(50) NULL DEFAULT NULL,
+  `ship_state_province` VARCHAR(50) NULL DEFAULT NULL,
+  `ship_zip_postal_code` VARCHAR(50) NULL DEFAULT NULL,
+  `ship_country_region` VARCHAR(50) NULL DEFAULT NULL,
+  `shipping_fee` DECIMAL(19,4) NULL DEFAULT '0.0000',
+  `taxes` DECIMAL(19,4) NULL DEFAULT '0.0000',
+  `payment_type` VARCHAR(50) NULL DEFAULT NULL,
+  `paid_date` DATETIME NULL DEFAULT NULL,
+  `notes` LONGTEXT NULL DEFAULT NULL,
+  `tax_rate` DOUBLE NULL DEFAULT '0',
+  `tax_status_id` TINYINT(4) NULL DEFAULT NULL,
+  `status_id` TINYINT(4) NULL DEFAULT '0',
+  PRIMARY KEY (`id`),
+  INDEX `customer_id` (`customer_id` ASC),
+  INDEX `customer_id_2` (`customer_id` ASC),
+  INDEX `employee_id` (`employee_id` ASC),
+  INDEX `employee_id_2` (`employee_id` ASC),
+  INDEX `id` (`id` ASC),
+  INDEX `id_2` (`id` ASC),
+  INDEX `shipper_id` (`shipper_id` ASC),
+  INDEX `shipper_id_2` (`shipper_id` ASC),
+  INDEX `id_3` (`id` ASC),
+  INDEX `tax_status` (`tax_status_id` ASC),
+  INDEX `ship_zip_postal_code` (`ship_zip_postal_code` ASC),
+  CONSTRAINT `fk_orders_customers`
+    FOREIGN KEY (`customer_id`)
+    REFERENCES `customers` (`id`)
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION,
+  CONSTRAINT `fk_orders_employees1`
+    FOREIGN KEY (`employee_id`)
+    REFERENCES `employees` (`id`)
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION,
+  CONSTRAINT `fk_orders_shippers1`
+    FOREIGN KEY (`shipper_id`)
+    REFERENCES `shippers` (`id`)
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION,
+  CONSTRAINT `fk_orders_orders_tax_status1`
+    FOREIGN KEY (`tax_status_id`)
+    REFERENCES `orders_tax_status` (`id`)
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION,
+  CONSTRAINT `fk_orders_orders_status1`
+    FOREIGN KEY (`status_id`)
+    REFERENCES `orders_status` (`id`)
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION)
+DEFAULT CHARACTER SET = utf8;
+
+
+-- -----------------------------------------------------
+-- Table `products`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `products` (
+  `supplier_ids` LONGTEXT NULL DEFAULT NULL,
+  `id` INT(11) NOT NULL AUTO_INCREMENT,
+  `product_code` VARCHAR(25) NULL DEFAULT NULL,
+  `product_name` VARCHAR(50) NULL DEFAULT NULL,
+  `description` LONGTEXT NULL DEFAULT NULL,
+  `standard_cost` DECIMAL(19,4) NULL DEFAULT '0.0000',
+  `list_price` DECIMAL(19,4) NOT NULL DEFAULT '0.0000',
+  `reorder_level` INT(11) NULL DEFAULT NULL,
+  `target_level` INT(11) NULL DEFAULT NULL,
+  `quantity_per_unit` VARCHAR(50) NULL DEFAULT NULL,
+  `discontinued` TINYINT(1) NOT NULL DEFAULT '0',
+  `minimum_reorder_quantity` INT(11) NULL DEFAULT NULL,
+  `category` VARCHAR(50) NULL DEFAULT NULL,
+  `attachments` LONGBLOB NULL DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  INDEX `product_code` (`product_code` ASC))
+DEFAULT CHARACTER SET = utf8;
+
+
+-- -----------------------------------------------------
+-- Table `purchase_order_status`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `purchase_order_status` (
+  `id` INT(11) NOT NULL,
+  `status` VARCHAR(50) NULL DEFAULT NULL,
+  PRIMARY KEY (`id`))
+DEFAULT CHARACTER SET = utf8;
+
+
+-- -----------------------------------------------------
+-- Table `suppliers`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `suppliers` (
+  `id` INT(11) NOT NULL AUTO_INCREMENT,
+  `company` VARCHAR(50) NULL DEFAULT NULL,
+  `last_name` VARCHAR(50) NULL DEFAULT NULL,
+  `first_name` VARCHAR(50) NULL DEFAULT NULL,
+  `email_address` VARCHAR(50) NULL DEFAULT NULL,
+  `job_title` VARCHAR(50) NULL DEFAULT NULL,
+  `business_phone` VARCHAR(25) NULL DEFAULT NULL,
+  `home_phone` VARCHAR(25) NULL DEFAULT NULL,
+  `mobile_phone` VARCHAR(25) NULL DEFAULT NULL,
+  `fax_number` VARCHAR(25) NULL DEFAULT NULL,
+  `address` LONGTEXT NULL DEFAULT NULL,
+  `city` VARCHAR(50) NULL DEFAULT NULL,
+  `state_province` VARCHAR(50) NULL DEFAULT NULL,
+  `zip_postal_code` VARCHAR(15) NULL DEFAULT NULL,
+  `country_region` VARCHAR(50) NULL DEFAULT NULL,
+  `web_page` LONGTEXT NULL DEFAULT NULL,
+  `notes` LONGTEXT NULL DEFAULT NULL,
+  `attachments` LONGBLOB NULL DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  INDEX `city` (`city` ASC),
+  INDEX `company` (`company` ASC),
+  INDEX `first_name` (`first_name` ASC),
+  INDEX `last_name` (`last_name` ASC),
+  INDEX `zip_postal_code` (`zip_postal_code` ASC),
+  INDEX `state_province` (`state_province` ASC))
+DEFAULT CHARACTER SET = utf8;
+
+
+-- -----------------------------------------------------
+-- Table `purchase_orders`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `purchase_orders` (
+  `id` INT(11) NOT NULL AUTO_INCREMENT,
+  `supplier_id` INT(11) NULL DEFAULT NULL,
+  `created_by` INT(11) NULL DEFAULT NULL,
+  `submitted_date` DATETIME NULL DEFAULT NULL,
+  `creation_date` DATETIME NULL DEFAULT NULL,
+  `status_id` INT(11) NULL DEFAULT '0',
+  `expected_date` DATETIME NULL DEFAULT NULL,
+  `shipping_fee` DECIMAL(19,4) NOT NULL DEFAULT '0.0000',
+  `taxes` DECIMAL(19,4) NOT NULL DEFAULT '0.0000',
+  `payment_date` DATETIME NULL DEFAULT NULL,
+  `payment_amount` DECIMAL(19,4) NULL DEFAULT '0.0000',
+  `payment_method` VARCHAR(50) NULL DEFAULT NULL,
+  `notes` LONGTEXT NULL DEFAULT NULL,
+  `approved_by` INT(11) NULL DEFAULT NULL,
+  `approved_date` DATETIME NULL DEFAULT NULL,
+  `submitted_by` INT(11) NULL DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE INDEX `id` (`id` ASC),
+  INDEX `created_by` (`created_by` ASC),
+  INDEX `status_id` (`status_id` ASC),
+  INDEX `id_2` (`id` ASC),
+  INDEX `supplier_id` (`supplier_id` ASC),
+  INDEX `supplier_id_2` (`supplier_id` ASC),
+  CONSTRAINT `fk_purchase_orders_employees1`
+    FOREIGN KEY (`created_by`)
+    REFERENCES `employees` (`id`)
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION,
+  CONSTRAINT `fk_purchase_orders_purchase_order_status1`
+    FOREIGN KEY (`status_id`)
+    REFERENCES `purchase_order_status` (`id`)
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION,
+  CONSTRAINT `fk_purchase_orders_suppliers1`
+    FOREIGN KEY (`supplier_id`)
+    REFERENCES `suppliers` (`id`)
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION)
+DEFAULT CHARACTER SET = utf8;
+
+
+-- -----------------------------------------------------
+-- Table `inventory_transactions`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `inventory_transactions` (
+  `id` INT(11) NOT NULL AUTO_INCREMENT,
+  `transaction_type` TINYINT(4) NOT NULL,
+  `transaction_created_date` DATETIME NULL DEFAULT NULL,
+  `transaction_modified_date` DATETIME NULL DEFAULT NULL,
+  `product_id` INT(11) NOT NULL,
+  `quantity` INT(11) NOT NULL,
+  `purchase_order_id` INT(11) NULL DEFAULT NULL,
+  `customer_order_id` INT(11) NULL DEFAULT NULL,
+  `comments` VARCHAR(255) NULL DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  INDEX `customer_order_id` (`customer_order_id` ASC),
+  INDEX `customer_order_id_2` (`customer_order_id` ASC),
+  INDEX `product_id` (`product_id` ASC),
+  INDEX `product_id_2` (`product_id` ASC),
+  INDEX `purchase_order_id` (`purchase_order_id` ASC),
+  INDEX `purchase_order_id_2` (`purchase_order_id` ASC),
+  INDEX `transaction_type` (`transaction_type` ASC),
+  CONSTRAINT `fk_inventory_transactions_orders1`
+    FOREIGN KEY (`customer_order_id`)
+    REFERENCES `orders` (`id`)
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION,
+  CONSTRAINT `fk_inventory_transactions_products1`
+    FOREIGN KEY (`product_id`)
+    REFERENCES `products` (`id`)
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION,
+  CONSTRAINT `fk_inventory_transactions_purchase_orders1`
+    FOREIGN KEY (`purchase_order_id`)
+    REFERENCES `purchase_orders` (`id`)
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION,
+  CONSTRAINT `fk_inventory_transactions_inventory_transaction_types1`
+    FOREIGN KEY (`transaction_type`)
+    REFERENCES `inventory_transaction_types` (`id`)
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION)
+DEFAULT CHARACTER SET = utf8;
+
+
+-- -----------------------------------------------------
+-- Table `invoices`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `invoices` (
+  `id` INT(11) NOT NULL AUTO_INCREMENT,
+  `order_id` INT(11) NULL DEFAULT NULL,
+  `invoice_date` DATETIME NULL DEFAULT NULL,
+  `due_date` DATETIME NULL DEFAULT NULL,
+  `tax` DECIMAL(19,4) NULL DEFAULT '0.0000',
+  `shipping` DECIMAL(19,4) NULL DEFAULT '0.0000',
+  `amount_due` DECIMAL(19,4) NULL DEFAULT '0.0000',
+  PRIMARY KEY (`id`),
+  INDEX `id` (`id` ASC),
+  INDEX `id_2` (`id` ASC),
+  INDEX `fk_invoices_orders1_idx` (`order_id` ASC),
+  CONSTRAINT `fk_invoices_orders1`
+    FOREIGN KEY (`order_id`)
+    REFERENCES `orders` (`id`)
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION)
+DEFAULT CHARACTER SET = utf8;
+
+
+-- -----------------------------------------------------
+-- Table `order_details_status`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `order_details_status` (
+  `id` INT(11) NOT NULL,
+  `status_name` VARCHAR(50) NOT NULL,
+  PRIMARY KEY (`id`))
+DEFAULT CHARACTER SET = utf8;
+
+
+-- -----------------------------------------------------
+-- Table `order_details`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `order_details` (
+  `id` INT(11) NOT NULL AUTO_INCREMENT,
+  `order_id` INT(11) NOT NULL,
+  `product_id` INT(11) NULL DEFAULT NULL,
+  `quantity` DECIMAL(18,4) NOT NULL DEFAULT '0.0000',
+  `unit_price` DECIMAL(19,4) NULL DEFAULT '0.0000',
+  `discount` DOUBLE NOT NULL DEFAULT '0',
+  `status_id` INT(11) NULL DEFAULT NULL,
+  `date_allocated` DATETIME NULL DEFAULT NULL,
+  `purchase_order_id` INT(11) NULL DEFAULT NULL,
+  `inventory_id` INT(11) NULL DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  INDEX `id` (`id` ASC),
+  INDEX `inventory_id` (`inventory_id` ASC),
+  INDEX `id_2` (`id` ASC),
+  INDEX `id_3` (`id` ASC),
+  INDEX `id_4` (`id` ASC),
+  INDEX `product_id` (`product_id` ASC),
+  INDEX `product_id_2` (`product_id` ASC),
+  INDEX `purchase_order_id` (`purchase_order_id` ASC),
+  INDEX `id_5` (`id` ASC),
+  INDEX `fk_order_details_orders1_idx` (`order_id` ASC),
+  INDEX `fk_order_details_order_details_status1_idx` (`status_id` ASC),
+  CONSTRAINT `fk_order_details_orders1`
+    FOREIGN KEY (`order_id`)
+    REFERENCES `orders` (`id`)
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION,
+  CONSTRAINT `fk_order_details_products1`
+    FOREIGN KEY (`product_id`)
+    REFERENCES `products` (`id`)
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION,
+  CONSTRAINT `fk_order_details_order_details_status1`
+    FOREIGN KEY (`status_id`)
+    REFERENCES `order_details_status` (`id`)
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION)
+DEFAULT CHARACTER SET = utf8;
+
+
+-- -----------------------------------------------------
+-- Table `purchase_order_details`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `purchase_order_details` (
+  `id` INT(11) NOT NULL AUTO_INCREMENT,
+  `purchase_order_id` INT(11) NOT NULL,
+  `product_id` INT(11) NULL DEFAULT NULL,
+  `quantity` DECIMAL(18,4) NOT NULL,
+  `unit_cost` DECIMAL(19,4) NOT NULL,
+  `date_received` DATETIME NULL DEFAULT NULL,
+  `posted_to_inventory` TINYINT(1) NOT NULL DEFAULT '0',
+  `inventory_id` INT(11) NULL DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  INDEX `id` (`id` ASC),
+  INDEX `inventory_id` (`inventory_id` ASC),
+  INDEX `inventory_id_2` (`inventory_id` ASC),
+  INDEX `purchase_order_id` (`purchase_order_id` ASC),
+  INDEX `product_id` (`product_id` ASC),
+  INDEX `product_id_2` (`product_id` ASC),
+  INDEX `purchase_order_id_2` (`purchase_order_id` ASC),
+  CONSTRAINT `fk_purchase_order_details_inventory_transactions1`
+    FOREIGN KEY (`inventory_id`)
+    REFERENCES `inventory_transactions` (`id`)
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION,
+  CONSTRAINT `fk_purchase_order_details_products1`
+    FOREIGN KEY (`product_id`)
+    REFERENCES `products` (`id`)
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION,
+  CONSTRAINT `fk_purchase_order_details_purchase_orders1`
+    FOREIGN KEY (`purchase_order_id`)
+    REFERENCES `purchase_orders` (`id`)
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION)
+DEFAULT CHARACTER SET = utf8;
+
+
+-- -----------------------------------------------------
+-- Table `sales_reports`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `sales_reports` (
+  `group_by` VARCHAR(50) NOT NULL,
+  `display` VARCHAR(50) NULL DEFAULT NULL,
+  `title` VARCHAR(50) NULL DEFAULT NULL,
+  `filter_row_source` LONGTEXT NULL DEFAULT NULL,
+  `default` TINYINT(1) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`group_by`))
+DEFAULT CHARACTER SET = utf8;
+
+
+-- -----------------------------------------------------
+-- Table `strings`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `strings` (
+  `string_id` INT(11) NOT NULL AUTO_INCREMENT,
+  `string_data` VARCHAR(255) NULL DEFAULT NULL,
+  PRIMARY KEY (`string_id`))
+DEFAULT CHARACTER SET = utf8;

--- a/introspection-engine/introspection-engine-tests/tests/tables/northwind_postgresql.sql
+++ b/introspection-engine/introspection-engine-tests/tests/tables/northwind_postgresql.sql
@@ -1,0 +1,445 @@
+SET default_tablespace = '';
+SET default_with_oids = false;
+
+---
+--- drop tables
+---
+
+
+DROP TABLE IF EXISTS customer_customer_demo;
+DROP TABLE IF EXISTS customer_demographics;
+DROP TABLE IF EXISTS employee_territories;
+DROP TABLE IF EXISTS order_details;
+DROP TABLE IF EXISTS orders;
+DROP TABLE IF EXISTS customers;
+DROP TABLE IF EXISTS products;
+DROP TABLE IF EXISTS shippers;
+DROP TABLE IF EXISTS suppliers;
+DROP TABLE IF EXISTS territories;
+DROP TABLE IF EXISTS us_states;
+DROP TABLE IF EXISTS categories;
+DROP TABLE IF EXISTS region;
+DROP TABLE IF EXISTS employees;
+
+--
+-- Name: categories; Type: TABLE; Schema: public; Owner: -; Tablespace:
+--
+
+CREATE TABLE categories (
+    category_id smallint NOT NULL,
+    category_name character varying(15) NOT NULL,
+    description text,
+    picture bytea
+);
+
+
+--
+-- Name: customer_customer_demo; Type: TABLE; Schema: public; Owner: -; Tablespace:
+--
+
+CREATE TABLE customer_customer_demo (
+    customer_id bpchar NOT NULL,
+    customer_type_id bpchar NOT NULL
+);
+
+
+--
+-- Name: customer_demographics; Type: TABLE; Schema: public; Owner: -; Tablespace:
+--
+
+CREATE TABLE customer_demographics (
+    customer_type_id bpchar NOT NULL,
+    customer_desc text
+);
+
+
+--
+-- Name: customers; Type: TABLE; Schema: public; Owner: -; Tablespace:
+--
+
+CREATE TABLE customers (
+    customer_id bpchar NOT NULL,
+    company_name character varying(40) NOT NULL,
+    contact_name character varying(30),
+    contact_title character varying(30),
+    address character varying(60),
+    city character varying(15),
+    region character varying(15),
+    postal_code character varying(10),
+    country character varying(15),
+    phone character varying(24),
+    fax character varying(24)
+);
+
+
+--
+-- Name: employees; Type: TABLE; Schema: public; Owner: -; Tablespace:
+--
+
+CREATE TABLE employees (
+    employee_id smallint NOT NULL,
+    last_name character varying(20) NOT NULL,
+    first_name character varying(10) NOT NULL,
+    title character varying(30),
+    title_of_courtesy character varying(25),
+    birth_date date,
+    hire_date date,
+    address character varying(60),
+    city character varying(15),
+    region character varying(15),
+    postal_code character varying(10),
+    country character varying(15),
+    home_phone character varying(24),
+    extension character varying(4),
+    photo bytea,
+    notes text,
+    reports_to smallint,
+    photo_path character varying(255)
+);
+
+
+--
+-- Name: employee_territories; Type: TABLE; Schema: public; Owner: -; Tablespace:
+--
+
+CREATE TABLE employee_territories (
+    employee_id smallint NOT NULL,
+    territory_id character varying(20) NOT NULL
+);
+
+
+
+
+--
+-- Name: order_details; Type: TABLE; Schema: public; Owner: -; Tablespace:
+--
+
+CREATE TABLE order_details (
+    order_id smallint NOT NULL,
+    product_id smallint NOT NULL,
+    unit_price real NOT NULL,
+    quantity smallint NOT NULL,
+    discount real NOT NULL
+);
+
+
+--
+-- Name: orders; Type: TABLE; Schema: public; Owner: -; Tablespace:
+--
+
+CREATE TABLE orders (
+    order_id smallint NOT NULL,
+    customer_id bpchar,
+    employee_id smallint,
+    order_date date,
+    required_date date,
+    shipped_date date,
+    ship_via smallint,
+    freight real,
+    ship_name character varying(40),
+    ship_address character varying(60),
+    ship_city character varying(15),
+    ship_region character varying(15),
+    ship_postal_code character varying(10),
+    ship_country character varying(15)
+);
+
+
+--
+-- Name: products; Type: TABLE; Schema: public; Owner: -; Tablespace:
+--
+
+CREATE TABLE products (
+    product_id smallint NOT NULL,
+    product_name character varying(40) NOT NULL,
+    supplier_id smallint,
+    category_id smallint,
+    quantity_per_unit character varying(20),
+    unit_price real,
+    units_in_stock smallint,
+    units_on_order smallint,
+    reorder_level smallint,
+    discontinued integer NOT NULL
+);
+
+
+--
+-- Name: region; Type: TABLE; Schema: public; Owner: -; Tablespace:
+--
+
+CREATE TABLE region (
+    region_id smallint NOT NULL,
+    region_description bpchar NOT NULL
+);
+
+
+--
+-- Name: shippers; Type: TABLE; Schema: public; Owner: -; Tablespace:
+--
+
+CREATE TABLE shippers (
+    shipper_id smallint NOT NULL,
+    company_name character varying(40) NOT NULL,
+    phone character varying(24)
+);
+
+
+
+--
+-- Name: suppliers; Type: TABLE; Schema: public; Owner: -; Tablespace:
+--
+
+CREATE TABLE suppliers (
+    supplier_id smallint NOT NULL,
+    company_name character varying(40) NOT NULL,
+    contact_name character varying(30),
+    contact_title character varying(30),
+    address character varying(60),
+    city character varying(15),
+    region character varying(15),
+    postal_code character varying(10),
+    country character varying(15),
+    phone character varying(24),
+    fax character varying(24),
+    homepage text
+);
+
+
+--
+-- Name: territories; Type: TABLE; Schema: public; Owner: -; Tablespace:
+--
+
+CREATE TABLE territories (
+    territory_id character varying(20) NOT NULL,
+    territory_description bpchar NOT NULL,
+    region_id smallint NOT NULL
+);
+
+
+--
+-- Name: us_states; Type: TABLE; Schema: public; Owner: -; Tablespace:
+--
+
+CREATE TABLE us_states (
+    state_id smallint NOT NULL,
+    state_name character varying(100),
+    state_abbr character varying(2),
+    state_region character varying(50)
+);
+
+
+--
+-- Name: pk_categories; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+--
+
+ALTER TABLE ONLY categories
+    ADD CONSTRAINT pk_categories PRIMARY KEY (category_id);
+
+
+--
+-- Name: pk_customer_customer_demo; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+--
+
+ALTER TABLE ONLY customer_customer_demo
+    ADD CONSTRAINT pk_customer_customer_demo PRIMARY KEY (customer_id, customer_type_id);
+
+
+--
+-- Name: pk_customer_demographics; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+--
+
+ALTER TABLE ONLY customer_demographics
+    ADD CONSTRAINT pk_customer_demographics PRIMARY KEY (customer_type_id);
+
+
+--
+-- Name: pk_customers; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+--
+
+ALTER TABLE ONLY customers
+    ADD CONSTRAINT pk_customers PRIMARY KEY (customer_id);
+
+
+--
+-- Name: pk_employees; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+--
+
+ALTER TABLE ONLY employees
+    ADD CONSTRAINT pk_employees PRIMARY KEY (employee_id);
+
+
+--
+-- Name: pk_employee_territories; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+--
+
+ALTER TABLE ONLY employee_territories
+    ADD CONSTRAINT pk_employee_territories PRIMARY KEY (employee_id, territory_id);
+
+
+--
+-- Name: pk_order_details; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+--
+
+ALTER TABLE ONLY order_details
+    ADD CONSTRAINT pk_order_details PRIMARY KEY (order_id, product_id);
+
+
+--
+-- Name: pk_orders; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+--
+
+ALTER TABLE ONLY orders
+    ADD CONSTRAINT pk_orders PRIMARY KEY (order_id);
+
+
+--
+-- Name: pk_products; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+--
+
+ALTER TABLE ONLY products
+    ADD CONSTRAINT pk_products PRIMARY KEY (product_id);
+
+
+--
+-- Name: pk_region; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+--
+
+ALTER TABLE ONLY region
+    ADD CONSTRAINT pk_region PRIMARY KEY (region_id);
+
+
+--
+-- Name: pk_shippers; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+--
+
+ALTER TABLE ONLY shippers
+    ADD CONSTRAINT pk_shippers PRIMARY KEY (shipper_id);
+
+
+--
+-- Name: pk_suppliers; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+--
+
+ALTER TABLE ONLY suppliers
+    ADD CONSTRAINT pk_suppliers PRIMARY KEY (supplier_id);
+
+
+--
+-- Name: pk_territories; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+--
+
+ALTER TABLE ONLY territories
+    ADD CONSTRAINT pk_territories PRIMARY KEY (territory_id);
+
+
+--
+-- Name: pk_usstates; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
+--
+
+ALTER TABLE ONLY us_states
+    ADD CONSTRAINT pk_usstates PRIMARY KEY (state_id);
+
+
+--
+-- Name: fk_orders_customers; Type: Constraint; Schema: -; Owner: -
+--
+
+ALTER TABLE ONLY orders
+    ADD CONSTRAINT fk_orders_customers FOREIGN KEY (customer_id) REFERENCES customers;
+
+
+--
+-- Name: fk_orders_employees; Type: Constraint; Schema: -; Owner: -
+--
+
+ALTER TABLE ONLY orders
+    ADD CONSTRAINT fk_orders_employees FOREIGN KEY (employee_id) REFERENCES employees;
+
+
+--
+-- Name: fk_orders_shippers; Type: Constraint; Schema: -; Owner: -
+--
+
+ALTER TABLE ONLY orders
+    ADD CONSTRAINT fk_orders_shippers FOREIGN KEY (ship_via) REFERENCES shippers;
+
+
+--
+-- Name: fk_order_details_products; Type: Constraint; Schema: -; Owner: -
+--
+
+ALTER TABLE ONLY order_details
+    ADD CONSTRAINT fk_order_details_products FOREIGN KEY (product_id) REFERENCES products;
+
+
+--
+-- Name: fk_order_details_orders; Type: Constraint; Schema: -; Owner: -
+--
+
+ALTER TABLE ONLY order_details
+    ADD CONSTRAINT fk_order_details_orders FOREIGN KEY (order_id) REFERENCES orders;
+
+
+--
+-- Name: fk_products_categories; Type: Constraint; Schema: -; Owner: -
+--
+
+ALTER TABLE ONLY products
+    ADD CONSTRAINT fk_products_categories FOREIGN KEY (category_id) REFERENCES categories;
+
+
+--
+-- Name: fk_products_suppliers; Type: Constraint; Schema: -; Owner: -
+--
+
+ALTER TABLE ONLY products
+    ADD CONSTRAINT fk_products_suppliers FOREIGN KEY (supplier_id) REFERENCES suppliers;
+
+
+--
+-- Name: fk_territories_region; Type: Constraint; Schema: -; Owner: -
+--
+
+ALTER TABLE ONLY territories
+    ADD CONSTRAINT fk_territories_region FOREIGN KEY (region_id) REFERENCES region;
+
+
+--
+-- Name: fk_employee_territories_territories; Type: Constraint; Schema: -; Owner: -
+--
+
+ALTER TABLE ONLY employee_territories
+    ADD CONSTRAINT fk_employee_territories_territories FOREIGN KEY (territory_id) REFERENCES territories;
+
+
+--
+-- Name: fk_employee_territories_employees; Type: Constraint; Schema: -; Owner: -
+--
+
+ALTER TABLE ONLY employee_territories
+    ADD CONSTRAINT fk_employee_territories_employees FOREIGN KEY (employee_id) REFERENCES employees;
+
+
+--
+-- Name: fk_customer_customer_demo_customer_demographics; Type: Constraint; Schema: -; Owner: -
+--
+
+ALTER TABLE ONLY customer_customer_demo
+    ADD CONSTRAINT fk_customer_customer_demo_customer_demographics FOREIGN KEY (customer_type_id) REFERENCES customer_demographics;
+
+
+--
+-- Name: fk_customer_customer_demo_customers; Type: Constraint; Schema: -; Owner: -
+--
+
+ALTER TABLE ONLY customer_customer_demo
+    ADD CONSTRAINT fk_customer_customer_demo_customers FOREIGN KEY (customer_id) REFERENCES customers;
+
+
+--
+-- Name: fk_employees_employees; Type: Constraint; Schema: -; Owner: -
+--
+
+ALTER TABLE ONLY employees
+    ADD CONSTRAINT fk_employees_employees FOREIGN KEY (reports_to) REFERENCES employees;
+

--- a/introspection-engine/introspection-engine-tests/tests/tables/postgres.rs
+++ b/introspection-engine/introspection-engine-tests/tests/tables/postgres.rs
@@ -278,3 +278,186 @@ async fn datetime_default_expressions_are_not_truncated(api: &TestApi) -> TestRe
     api.expect_datamodel(&expected).await;
     Ok(())
 }
+
+#[test_connector(tags(Postgres12, Postgres14), exclude(CockroachDb))]
+async fn northwind(api: TestApi) {
+    let setup = include_str!("./northwind_postgresql.sql");
+    api.raw_cmd(setup).await;
+    let expectation = expect![[r#"
+        generator client {
+          provider = "prisma-client-js"
+        }
+
+        datasource db {
+          provider = "postgresql"
+          url      = "env(TEST_DATABASE_URL)"
+        }
+
+        model categories {
+          category_id   Int        @id(map: "pk_categories") @db.SmallInt
+          category_name String     @db.VarChar(15)
+          description   String?
+          picture       Bytes?
+          products      products[]
+        }
+
+        model customer_customer_demo {
+          customer_id           String                @db.Char
+          customer_type_id      String                @db.Char
+          customer_demographics customer_demographics @relation(fields: [customer_type_id], references: [customer_type_id], onDelete: NoAction, onUpdate: NoAction, map: "fk_customer_customer_demo_customer_demographics")
+          customers             customers             @relation(fields: [customer_id], references: [customer_id], onDelete: NoAction, onUpdate: NoAction, map: "fk_customer_customer_demo_customers")
+
+          @@id([customer_id, customer_type_id], map: "pk_customer_customer_demo")
+        }
+
+        model customer_demographics {
+          customer_type_id       String                   @id(map: "pk_customer_demographics") @db.Char
+          customer_desc          String?
+          customer_customer_demo customer_customer_demo[]
+        }
+
+        model customers {
+          customer_id            String                   @id(map: "pk_customers") @db.Char
+          company_name           String                   @db.VarChar(40)
+          contact_name           String?                  @db.VarChar(30)
+          contact_title          String?                  @db.VarChar(30)
+          address                String?                  @db.VarChar(60)
+          city                   String?                  @db.VarChar(15)
+          region                 String?                  @db.VarChar(15)
+          postal_code            String?                  @db.VarChar(10)
+          country                String?                  @db.VarChar(15)
+          phone                  String?                  @db.VarChar(24)
+          fax                    String?                  @db.VarChar(24)
+          customer_customer_demo customer_customer_demo[]
+          orders                 orders[]
+        }
+
+        model employee_territories {
+          employee_id  Int         @db.SmallInt
+          territory_id String      @db.VarChar(20)
+          employees    employees   @relation(fields: [employee_id], references: [employee_id], onDelete: NoAction, onUpdate: NoAction, map: "fk_employee_territories_employees")
+          territories  territories @relation(fields: [territory_id], references: [territory_id], onDelete: NoAction, onUpdate: NoAction, map: "fk_employee_territories_territories")
+
+          @@id([employee_id, territory_id], map: "pk_employee_territories")
+        }
+
+        model employees {
+          employee_id          Int                    @id(map: "pk_employees") @db.SmallInt
+          last_name            String                 @db.VarChar(20)
+          first_name           String                 @db.VarChar(10)
+          title                String?                @db.VarChar(30)
+          title_of_courtesy    String?                @db.VarChar(25)
+          birth_date           DateTime?              @db.Date
+          hire_date            DateTime?              @db.Date
+          address              String?                @db.VarChar(60)
+          city                 String?                @db.VarChar(15)
+          region               String?                @db.VarChar(15)
+          postal_code          String?                @db.VarChar(10)
+          country              String?                @db.VarChar(15)
+          home_phone           String?                @db.VarChar(24)
+          extension            String?                @db.VarChar(4)
+          photo                Bytes?
+          notes                String?
+          reports_to           Int?                   @db.SmallInt
+          photo_path           String?                @db.VarChar(255)
+          employees            employees?             @relation("employeesToemployees", fields: [reports_to], references: [employee_id], onDelete: NoAction, onUpdate: NoAction, map: "fk_employees_employees")
+          employee_territories employee_territories[]
+          other_employees      employees[]            @relation("employeesToemployees")
+          orders               orders[]
+        }
+
+        model order_details {
+          order_id   Int      @db.SmallInt
+          product_id Int      @db.SmallInt
+          unit_price Float    @db.Real
+          quantity   Int      @db.SmallInt
+          discount   Float    @db.Real
+          orders     orders   @relation(fields: [order_id], references: [order_id], onDelete: NoAction, onUpdate: NoAction, map: "fk_order_details_orders")
+          products   products @relation(fields: [product_id], references: [product_id], onDelete: NoAction, onUpdate: NoAction, map: "fk_order_details_products")
+
+          @@id([order_id, product_id], map: "pk_order_details")
+        }
+
+        model orders {
+          order_id         Int             @id(map: "pk_orders") @db.SmallInt
+          customer_id      String?         @db.Char
+          employee_id      Int?            @db.SmallInt
+          order_date       DateTime?       @db.Date
+          required_date    DateTime?       @db.Date
+          shipped_date     DateTime?       @db.Date
+          ship_via         Int?            @db.SmallInt
+          freight          Float?          @db.Real
+          ship_name        String?         @db.VarChar(40)
+          ship_address     String?         @db.VarChar(60)
+          ship_city        String?         @db.VarChar(15)
+          ship_region      String?         @db.VarChar(15)
+          ship_postal_code String?         @db.VarChar(10)
+          ship_country     String?         @db.VarChar(15)
+          customers        customers?      @relation(fields: [customer_id], references: [customer_id], onDelete: NoAction, onUpdate: NoAction, map: "fk_orders_customers")
+          employees        employees?      @relation(fields: [employee_id], references: [employee_id], onDelete: NoAction, onUpdate: NoAction, map: "fk_orders_employees")
+          shippers         shippers?       @relation(fields: [ship_via], references: [shipper_id], onDelete: NoAction, onUpdate: NoAction, map: "fk_orders_shippers")
+          order_details    order_details[]
+        }
+
+        model products {
+          product_id        Int             @id(map: "pk_products") @db.SmallInt
+          product_name      String          @db.VarChar(40)
+          supplier_id       Int?            @db.SmallInt
+          category_id       Int?            @db.SmallInt
+          quantity_per_unit String?         @db.VarChar(20)
+          unit_price        Float?          @db.Real
+          units_in_stock    Int?            @db.SmallInt
+          units_on_order    Int?            @db.SmallInt
+          reorder_level     Int?            @db.SmallInt
+          discontinued      Int
+          categories        categories?     @relation(fields: [category_id], references: [category_id], onDelete: NoAction, onUpdate: NoAction, map: "fk_products_categories")
+          suppliers         suppliers?      @relation(fields: [supplier_id], references: [supplier_id], onDelete: NoAction, onUpdate: NoAction, map: "fk_products_suppliers")
+          order_details     order_details[]
+        }
+
+        model region {
+          region_id          Int           @id(map: "pk_region") @db.SmallInt
+          region_description String        @db.Char
+          territories        territories[]
+        }
+
+        model shippers {
+          shipper_id   Int      @id(map: "pk_shippers") @db.SmallInt
+          company_name String   @db.VarChar(40)
+          phone        String?  @db.VarChar(24)
+          orders       orders[]
+        }
+
+        model suppliers {
+          supplier_id   Int        @id(map: "pk_suppliers") @db.SmallInt
+          company_name  String     @db.VarChar(40)
+          contact_name  String?    @db.VarChar(30)
+          contact_title String?    @db.VarChar(30)
+          address       String?    @db.VarChar(60)
+          city          String?    @db.VarChar(15)
+          region        String?    @db.VarChar(15)
+          postal_code   String?    @db.VarChar(10)
+          country       String?    @db.VarChar(15)
+          phone         String?    @db.VarChar(24)
+          fax           String?    @db.VarChar(24)
+          homepage      String?
+          products      products[]
+        }
+
+        model territories {
+          territory_id          String                 @id(map: "pk_territories") @db.VarChar(20)
+          territory_description String                 @db.Char
+          region_id             Int                    @db.SmallInt
+          region                region                 @relation(fields: [region_id], references: [region_id], onDelete: NoAction, onUpdate: NoAction, map: "fk_territories_region")
+          employee_territories  employee_territories[]
+        }
+
+        model us_states {
+          state_id     Int     @id(map: "pk_usstates") @db.SmallInt
+          state_name   String? @db.VarChar(100)
+          state_abbr   String? @db.VarChar(2)
+          state_region String? @db.VarChar(50)
+        }
+    "#]];
+    api.expect_datamodel(&expectation).await;
+}

--- a/libs/sql-schema-describer/src/postgres.rs
+++ b/libs/sql-schema-describer/src/postgres.rs
@@ -775,7 +775,7 @@ impl<'a> SqlSchemaDescriber<'a> {
                     JOIN pg_attribute att2 on att2.attrelid = con.conrelid and att2.attnum = con.parent
                     JOIN pg_class rel_cl on con.confrelid = rel_cl.oid
                     JOIN pg_namespace rel_ns on rel_cl.relnamespace = rel_ns.oid
-            ORDER BY constraint_name, con_id, con.colidx;
+            ORDER BY table_name, constraint_name, con_id, con.colidx;
         "#;
 
         let mut current_fk: Option<(i64, ForeignKeyId)> = None;

--- a/libs/sql-schema-describer/src/walkers.rs
+++ b/libs/sql-schema-describer/src/walkers.rs
@@ -20,7 +20,7 @@ pub fn walk_columns(schema: &SqlSchema) -> impl Iterator<Item = ColumnWalker<'_>
 
 /// A generic reference to a schema item. It holds a reference to the schema so it can offer a
 /// convenient API based on the Id type.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy)]
 pub struct Walker<'a, Id> {
     /// The identifier.
     pub id: Id,
@@ -28,9 +28,17 @@ pub struct Walker<'a, Id> {
     pub schema: &'a SqlSchema,
 }
 
+impl<I: std::fmt::Debug> std::fmt::Debug for Walker<'_, I> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct(std::any::type_name::<Self>())
+            .field("id", &self.id)
+            .finish()
+    }
+}
+
 impl<'a, Id> Walker<'a, Id> {
     /// Jump to the item identified by `other_id`.
-    pub fn walk<I: 'static>(self, other_id: I) -> Walker<'a, I> {
+    pub fn walk<I>(self, other_id: I) -> Walker<'a, I> {
         self.schema.walk(other_id)
     }
 }


### PR DESCRIPTION
This caused introspection to not find foreign keys that were in the
SqlSchema (see
https://github.com/prisma/introspection-ci/commit/80965f82d27159a9b8d40818f0b6e6387f62789d) on postgres and mysql.

The error was not caught because we were not testing with large enough
schemas with constraint names repeating between tables. We import the
northwind schema for mysql and postgres in introrspection tests, since
it did exhibit these bugs.