### PR TITLE
Config should be parsed even if native type is not fully written

### DIFF
--- a/libs/datamodel/core/tests/config/datasources.rs
+++ b/libs/datamodel/core/tests/config/datasources.rs
@@ -2,6 +2,23 @@ use crate::common::*;
 use indoc::indoc;
 
 #[test]
+fn missing_native_type_should_still_allow_config_parsing() {
+    let schema = indoc! { r#"
+        datasource db {
+            provider = "postgresql"
+            url  = env("DATABASE_URL")
+        }
+
+        model A {
+            id Int @id
+            val Int @db.
+        }
+    "#};
+
+    parse_configuration(schema);
+}
+
+#[test]
 fn serialize_builtin_sources_to_dmmf() {
     std::env::set_var("pg2", "postgresql://localhost/postgres2");
 

--- a/libs/datamodel/schema-ast/src/parser/datamodel.pest
+++ b/libs/datamodel/schema-ast/src/parser/datamodel.pest
@@ -102,7 +102,7 @@ block_level_attribute = { "@@" ~ attribute ~ trailing_comment? ~ NEWLINE }
 // An attribute may have no arguments at all.
 attribute = { attribute_name? ~ arguments_list? }
 // This is a poor-mans version of name spacing. This is currently used for native types.
-attribute_name = @{ (non_empty_identifier ~ ".")? ~ non_empty_identifier }
+attribute_name = @{ (non_empty_identifier ~ ".")? ~ non_empty_identifier? }
 
 // ######################################
 // Arguments


### PR DESCRIPTION
This broke native type autocompletes. The following data model:

```prisma
datasource db {
    provider = "postgresql"
    url  = env("DATABASE_URL")
}

model A {
    id Int @id
    val Int @db.
}
```

would now already error in the pest level parsing, leaving us with no valid configuration and sending back empty native types.