### PR TITLE
sql-schema-decriber: normalize indexes

### DIFF
--- a/introspection-engine/introspection-engine-tests/tests/rpc_calls/get_database_description.rs
+++ b/introspection-engine/introspection-engine-tests/tests/rpc_calls/get_database_description.rs
@@ -24,18 +24,7 @@ async fn database_description_for_mysql_should_work(api: &TestApi) -> TestResult
         {
           "tables": [
             {
-              "name": "Blog",
-              "indices": [],
-              "primary_key": {
-                "columns": [
-                  {
-                    "name": "id",
-                    "length": null,
-                    "sort_order": null
-                  }
-                ],
-                "constraint_name": null
-              }
+              "name": "Blog"
             }
           ],
           "enums": [],
@@ -71,6 +60,21 @@ async fn database_description_for_mysql_should_work(api: &TestApi) -> TestResult
           ],
           "foreign_keys": [],
           "foreign_key_columns": [],
+          "indexes": [
+            {
+              "table_id": 0,
+              "index_name": "",
+              "tpe": "PrimaryKey"
+            }
+          ],
+          "index_columns": [
+            {
+              "index_id": 0,
+              "column_id": 0,
+              "sort_order": "Asc",
+              "length": null
+            }
+          ],
           "views": [],
           "procedures": [],
           "user_defined_types": [],
@@ -90,18 +94,7 @@ async fn database_description_for_mysql_8_should_work(api: &TestApi) -> TestResu
         {
           "tables": [
             {
-              "name": "Blog",
-              "indices": [],
-              "primary_key": {
-                "columns": [
-                  {
-                    "name": "id",
-                    "length": null,
-                    "sort_order": null
-                  }
-                ],
-                "constraint_name": null
-              }
+              "name": "Blog"
             }
           ],
           "enums": [],
@@ -137,6 +130,21 @@ async fn database_description_for_mysql_8_should_work(api: &TestApi) -> TestResu
           ],
           "foreign_keys": [],
           "foreign_key_columns": [],
+          "indexes": [
+            {
+              "table_id": 0,
+              "index_name": "",
+              "tpe": "PrimaryKey"
+            }
+          ],
+          "index_columns": [
+            {
+              "index_id": 0,
+              "column_id": 0,
+              "sort_order": "Asc",
+              "length": null
+            }
+          ],
           "views": [],
           "procedures": [],
           "user_defined_types": [],
@@ -156,18 +164,7 @@ async fn database_description_for_postgres_should_work(api: &TestApi) -> TestRes
         {
           "tables": [
             {
-              "name": "Blog",
-              "indices": [],
-              "primary_key": {
-                "columns": [
-                  {
-                    "name": "id",
-                    "length": null,
-                    "sort_order": null
-                  }
-                ],
-                "constraint_name": "Blog_pkey"
-              }
+              "name": "Blog"
             }
           ],
           "enums": [],
@@ -208,6 +205,21 @@ async fn database_description_for_postgres_should_work(api: &TestApi) -> TestRes
           ],
           "foreign_keys": [],
           "foreign_key_columns": [],
+          "indexes": [
+            {
+              "table_id": 0,
+              "index_name": "Blog_pkey",
+              "tpe": "PrimaryKey"
+            }
+          ],
+          "index_columns": [
+            {
+              "index_id": 0,
+              "column_id": 0,
+              "sort_order": "Asc",
+              "length": null
+            }
+          ],
           "views": [],
           "procedures": [],
           "user_defined_types": [],
@@ -227,18 +239,7 @@ async fn database_description_for_sqlite_should_work(api: &TestApi) -> TestResul
         {
           "tables": [
             {
-              "name": "Blog",
-              "indices": [],
-              "primary_key": {
-                "columns": [
-                  {
-                    "name": "id",
-                    "length": null,
-                    "sort_order": null
-                  }
-                ],
-                "constraint_name": null
-              }
+              "name": "Blog"
             }
           ],
           "enums": [],
@@ -248,7 +249,7 @@ async fn database_description_for_sqlite_should_work(api: &TestApi) -> TestResul
               {
                 "name": "id",
                 "tpe": {
-                  "full_data_type": "INTEGER",
+                  "full_data_type": "integer",
                   "family": "Int",
                   "arity": "Required",
                   "native_type": null
@@ -262,7 +263,7 @@ async fn database_description_for_sqlite_should_work(api: &TestApi) -> TestResul
               {
                 "name": "string",
                 "tpe": {
-                  "full_data_type": "TEXT",
+                  "full_data_type": "text",
                   "family": "String",
                   "arity": "Required",
                   "native_type": null
@@ -274,6 +275,21 @@ async fn database_description_for_sqlite_should_work(api: &TestApi) -> TestResul
           ],
           "foreign_keys": [],
           "foreign_key_columns": [],
+          "indexes": [
+            {
+              "table_id": 0,
+              "index_name": "",
+              "tpe": "PrimaryKey"
+            }
+          ],
+          "index_columns": [
+            {
+              "index_id": 0,
+              "column_id": 0,
+              "sort_order": null,
+              "length": null
+            }
+          ],
           "views": [],
           "procedures": [],
           "user_defined_types": [],

--- a/libs/datamodel/core/src/transform/dml_to_ast/lower_field.rs
+++ b/libs/datamodel/core/src/transform/dml_to_ast/lower_field.rs
@@ -1,0 +1,330 @@
+use super::*;
+use crate::{
+    ast::{self, Attribute, Span},
+    common::{constraint_names::ConstraintNames, RelationNames},
+    dml::{self, Field, Ignorable, SortOrder},
+    Datasource,
+};
+use ::dml::{prisma_value, traits::WithName, PrismaValue};
+use datamodel_connector::{Connector, EmptyDatamodelConnector};
+
+/// Internal: Lowers a field's arity.
+pub(crate) fn lower_field_arity(field_arity: &dml::FieldArity) -> ast::FieldArity {
+    match field_arity {
+        dml::FieldArity::Required => ast::FieldArity::Required,
+        dml::FieldArity::Optional => ast::FieldArity::Optional,
+        dml::FieldArity::List => ast::FieldArity::List,
+    }
+}
+
+pub(crate) fn lower_composite_field_type(field_type: &dml::CompositeTypeFieldType) -> ast::FieldType {
+    match field_type {
+        ::dml::composite_type::CompositeTypeFieldType::CompositeType(name) => {
+            ast::FieldType::Supported(ast::Identifier::new(name))
+        }
+        ::dml::composite_type::CompositeTypeFieldType::Enum(name) => {
+            ast::FieldType::Supported(ast::Identifier::new(name))
+        }
+        ::dml::composite_type::CompositeTypeFieldType::Unsupported(name) => {
+            ast::FieldType::Unsupported(name.clone(), Span::empty())
+        }
+        ::dml::composite_type::CompositeTypeFieldType::Scalar(tpe, custom_type_name, _) => ast::FieldType::Supported(
+            ast::Identifier::new(custom_type_name.as_ref().unwrap_or(&tpe.to_string())),
+        ),
+    }
+}
+
+/// Internal: Lowers a field's type.
+pub(crate) fn lower_type(field_type: &dml::FieldType) -> ast::FieldType {
+    match field_type {
+        dml::FieldType::Scalar(tpe, custom_type_name, _) => ast::FieldType::Supported(ast::Identifier::new(
+            custom_type_name.as_ref().unwrap_or(&tpe.to_string()),
+        )),
+        dml::FieldType::CompositeType(name) => ast::FieldType::Supported(ast::Identifier::new(name)),
+        dml::FieldType::Enum(tpe) => ast::FieldType::Supported(ast::Identifier::new(tpe)),
+        dml::FieldType::Unsupported(tpe) => ast::FieldType::Unsupported(tpe.clone(), Span::empty()),
+        dml::FieldType::Relation(rel) => ast::FieldType::Supported(ast::Identifier::new(&rel.to)),
+    }
+}
+
+pub(crate) fn lower_native_type_attribute(
+    scalar_type: &dml::ScalarType,
+    native_type: &dml::NativeTypeInstance,
+    attributes: &mut Vec<Attribute>,
+    datasource: &Datasource,
+) {
+    if datasource.active_connector.native_type_is_default_for_scalar_type(
+        native_type.serialized_native_type.clone(),
+        &dml_scalar_type_to_parser_database_scalar_type(*scalar_type),
+    ) {
+        return;
+    }
+
+    let new_attribute_name = format!("{}.{}", datasource.name, native_type.name);
+    let arguments = native_type
+        .args
+        .iter()
+        .map(|arg| ast::Argument::new_unnamed(ast::Expression::NumericValue(arg.to_owned(), Span::empty())))
+        .collect();
+
+    attributes.push(ast::Attribute::new(new_attribute_name.as_str(), arguments));
+}
+
+/// Internal: Lowers a field's attributes.
+pub(crate) fn lower_field_attributes(
+    model: &dml::Model,
+    field: &dml::Field,
+    params: LowerParams<'_>,
+) -> Vec<ast::Attribute> {
+    let datamodel = params.datamodel;
+    let mut attributes = vec![];
+
+    // @id
+    if let dml::Field::ScalarField(sf) = field {
+        if model.field_is_primary_and_defined_on_field(&sf.name) {
+            let mut args = Vec::new();
+            let pk = model.primary_key.as_ref().unwrap();
+            if let Some(src) = params.datasource {
+                if !matches!(pk.db_name.as_deref(), None | Some(""))
+                    && !super::primary_key_name_matches(pk, model, &*src.active_connector)
+                {
+                    args.push(ast::Argument::new(
+                        "map",
+                        ast::Expression::StringValue(String::from(pk.db_name.as_ref().unwrap()), Span::empty()),
+                    ));
+                }
+            }
+
+            if let Some(length) = pk.fields.first().unwrap().length {
+                args.push(ast::Argument::new(
+                    "length",
+                    ast::Expression::NumericValue(length.to_string(), Span::empty()),
+                ));
+            }
+
+            if let Some(SortOrder::Desc) = pk.fields.first().unwrap().sort_order {
+                args.push(ast::Argument::new(
+                    "sort",
+                    ast::Expression::NumericValue("Desc".to_string(), Span::empty()),
+                ));
+            }
+
+            if matches!(pk.clustered, Some(false)) {
+                args.push(ast::Argument::new(
+                    "clustered",
+                    ast::Expression::ConstantValue("false".to_string(), Span::empty()),
+                ));
+            }
+
+            attributes.push(ast::Attribute::new("id", args));
+        }
+    }
+
+    // @unique
+    if let dml::Field::ScalarField(sf) = field {
+        if model.field_is_unique_and_defined_on_field(&sf.name) {
+            let mut arguments = Vec::new();
+            if let Some(idx) = model.indices.iter().find(|i| {
+                let path = &i.fields.first().unwrap().path;
+
+                // A composite field index cannot be defined in field, so
+                // we can do a dumb comparison.
+                let names_match = path
+                    .first()
+                    .map(|(field_name, _)| field_name == field.name())
+                    .unwrap_or(false);
+
+                i.is_unique() && i.defined_on_field && i.fields.len() == 1 && names_match
+            }) {
+                if matches!(idx.clustered, Some(true)) {
+                    arguments.push(ast::Argument::new(
+                        "clustered",
+                        ast::Expression::ConstantValue("true".to_string(), Span::empty()),
+                    ));
+                }
+
+                push_field_index_arguments(model, idx, &mut arguments, params);
+            }
+
+            attributes.push(ast::Attribute::new("unique", arguments));
+        }
+    }
+
+    // @default
+    if let Some(default_value) = field.default_value() {
+        let mut args = vec![ast::Argument::new_unnamed(lower_default_value(default_value.clone()))];
+
+        let connector = params
+            .datasource
+            .map(|source| source.active_connector)
+            .unwrap_or(&EmptyDatamodelConnector as &dyn Connector);
+
+        let prisma_default = ConstraintNames::default_name(model.name(), field.name(), connector);
+
+        if let Some(name) = default_value.db_name() {
+            if name != prisma_default {
+                args.push(ast::Argument::new("map", lower_string(name)))
+            }
+        }
+
+        attributes.push(ast::Attribute::new("default", args));
+    }
+
+    // @updatedAt
+    if field.is_updated_at() {
+        attributes.push(ast::Attribute::new("updatedAt", Vec::new()));
+    }
+
+    // @map
+    push_model_index_map_arg(field, &mut attributes);
+
+    // @relation
+    if let dml::Field::RelationField(rf) = field {
+        let mut args = Vec::new();
+        let relation_info = &rf.relation_info;
+        let parent_model = datamodel.find_model_by_relation_field_ref(rf).unwrap();
+
+        let related_model = datamodel
+            .find_model(&relation_info.to)
+            .unwrap_or_else(|| panic!("Related model not found: {}.", relation_info.to));
+
+        let has_default_name =
+            relation_info.name == RelationNames::name_for_unambiguous_relation(&relation_info.to, &parent_model.name);
+
+        if !relation_info.name.is_empty() && (!has_default_name || parent_model.name == related_model.name) {
+            args.push(ast::Argument::new_unnamed(ast::Expression::StringValue(
+                relation_info.name.to_string(),
+                ast::Span::empty(),
+            )));
+        }
+
+        let mut relation_fields = relation_info.references.clone();
+
+        relation_fields.sort();
+
+        if !relation_info.fields.is_empty() {
+            args.push(ast::Argument::new_array("fields", field_array(&relation_info.fields)));
+        }
+
+        // if we are on the physical field
+        if !relation_info.references.is_empty() {
+            let is_many_to_many = match &field {
+                Field::RelationField(relation_field) => {
+                    let (_, related_field) = datamodel.find_related_field(relation_field).unwrap();
+                    relation_field.arity.is_list() && related_field.arity.is_list()
+                }
+                _ => false,
+            };
+
+            if !is_many_to_many {
+                args.push(ast::Argument::new_array(
+                    "references",
+                    field_array(&relation_info.references),
+                ));
+            }
+        }
+
+        if let Some(ref_action) = relation_info.on_delete {
+            if rf.default_on_delete_action() != ref_action {
+                let expression = ast::Expression::ConstantValue(ref_action.to_string(), ast::Span::empty());
+                args.push(ast::Argument::new("onDelete", expression));
+            }
+        }
+
+        if let Some(ref_action) = relation_info.on_update {
+            if rf.default_on_update_action() != ref_action {
+                let expression = ast::Expression::ConstantValue(ref_action.to_string(), ast::Span::empty());
+                args.push(ast::Argument::new("onUpdate", expression));
+            }
+        }
+
+        if let Some(fk_name) = &relation_info.fk_name {
+            if let Some(src) = params.datasource {
+                if !super::foreign_key_name_matches(relation_info, model, &*src.active_connector) {
+                    args.push(ast::Argument::new(
+                        "map",
+                        ast::Expression::StringValue(String::from(fk_name), Span::empty()),
+                    ));
+                }
+            };
+        }
+
+        if !args.is_empty() {
+            attributes.push(ast::Attribute::new("relation", args));
+        }
+    }
+
+    // @ignore
+    if field.is_ignored() {
+        attributes.push(ast::Attribute::new("ignore", vec![]));
+    }
+
+    attributes
+}
+
+pub fn lower_default_value(dv: dml::DefaultValue) -> ast::Expression {
+    match dv.kind() {
+        dml::DefaultKind::Single(v) => lower_prisma_value(v),
+        dml::DefaultKind::Expression(e) => {
+            let arguments = e
+                .args()
+                .iter()
+                .map(|(name, value)| {
+                    let value = lower_prisma_value(value);
+                    match name {
+                        Some(name) => ast::Argument::new(name, value),
+                        None => ast::Argument::new_unnamed(value),
+                    }
+                })
+                .collect();
+            ast::Expression::Function(
+                e.name().to_string(),
+                ast::ArgumentsList {
+                    arguments,
+                    ..Default::default()
+                },
+                ast::Span::empty(),
+            )
+        }
+    }
+}
+
+pub fn lower_string(s: impl ToString) -> ast::Expression {
+    ast::Expression::StringValue(s.to_string(), ast::Span::empty())
+}
+
+pub fn lower_prisma_value(pv: &PrismaValue) -> ast::Expression {
+    match pv {
+        PrismaValue::Boolean(true) => ast::Expression::ConstantValue(String::from("true"), ast::Span::empty()),
+        PrismaValue::Boolean(false) => ast::Expression::ConstantValue(String::from("false"), ast::Span::empty()),
+        PrismaValue::String(value) => lower_string(value),
+        PrismaValue::Enum(value) => ast::Expression::ConstantValue(value.clone(), ast::Span::empty()),
+        PrismaValue::DateTime(value) => lower_string(value),
+        PrismaValue::Float(value) => ast::Expression::NumericValue(value.to_string(), ast::Span::empty()),
+        PrismaValue::Int(value) => ast::Expression::NumericValue(value.to_string(), ast::Span::empty()),
+        PrismaValue::BigInt(value) => ast::Expression::NumericValue(value.to_string(), ast::Span::empty()),
+        PrismaValue::Null => ast::Expression::ConstantValue("null".to_string(), ast::Span::empty()),
+        PrismaValue::Uuid(val) => lower_string(val),
+        PrismaValue::Json(val) => lower_string(val),
+        PrismaValue::List(vec) => {
+            ast::Expression::Array(vec.iter().map(lower_prisma_value).collect(), ast::Span::empty())
+        }
+        PrismaValue::Xml(val) => ast::Expression::StringValue(val.to_string(), ast::Span::empty()),
+        PrismaValue::Bytes(b) => ast::Expression::StringValue(prisma_value::encode_bytes(b), ast::Span::empty()),
+        PrismaValue::Object(_) => unreachable!(), // There's no concept of object values in the PSL right now.
+    }
+}
+
+fn dml_scalar_type_to_parser_database_scalar_type(st: dml::ScalarType) -> parser_database::ScalarType {
+    match st {
+        dml::ScalarType::Int => parser_database::ScalarType::Int,
+        dml::ScalarType::BigInt => parser_database::ScalarType::BigInt,
+        dml::ScalarType::Float => parser_database::ScalarType::Float,
+        dml::ScalarType::Boolean => parser_database::ScalarType::Boolean,
+        dml::ScalarType::String => parser_database::ScalarType::String,
+        dml::ScalarType::DateTime => parser_database::ScalarType::DateTime,
+        dml::ScalarType::Json => parser_database::ScalarType::Json,
+        dml::ScalarType::Bytes => parser_database::ScalarType::Bytes,
+        dml::ScalarType::Decimal => parser_database::ScalarType::Decimal,
+    }
+}

--- a/libs/datamodel/core/src/transform/dml_to_ast/lower_model_attributes.rs
+++ b/libs/datamodel/core/src/transform/dml_to_ast/lower_model_attributes.rs
@@ -1,0 +1,191 @@
+use super::*;
+use crate::{
+    ast::{self, Argument, Attribute, Span},
+    dml::{self, Ignorable, IndexDefinition, IndexType, Model, SortOrder, WithDatabaseName},
+};
+use ::dml::model::IndexAlgorithm;
+
+/// Internal: Lowers a model's attributes.
+pub(crate) fn lower_model_attributes(model: &dml::Model, params: LowerParams<'_>) -> Vec<ast::Attribute> {
+    let mut attributes = vec![];
+
+    // @@id
+    if let Some(pk) = &model.primary_key {
+        if !pk.defined_on_field {
+            let mut args = vec![ast::Argument::new_unnamed(ast::Expression::Array(
+                pk_field_array(&pk.fields),
+                ast::Span::empty(),
+            ))];
+
+            if pk.name.is_some() {
+                args.push(ast::Argument::new(
+                    "name",
+                    ast::Expression::StringValue(String::from(pk.name.as_ref().unwrap()), Span::empty()),
+                ));
+            }
+
+            if pk.db_name.is_some() {
+                if let Some(src) = params.datasource {
+                    if !matches!(pk.db_name.as_deref(), None | Some(""))
+                        && !super::primary_key_name_matches(pk, model, &*src.active_connector)
+                    {
+                        args.push(ast::Argument::new(
+                            "map",
+                            ast::Expression::StringValue(String::from(pk.db_name.as_ref().unwrap()), Span::empty()),
+                        ));
+                    }
+                }
+            }
+
+            if matches!(pk.clustered, Some(false)) {
+                args.push(ast::Argument::new(
+                    "clustered",
+                    ast::Expression::ConstantValue("false".to_string(), Span::empty()),
+                ));
+            }
+
+            attributes.push(ast::Attribute::new("id", args));
+        }
+    }
+
+    // @@unique
+    model
+        .indices
+        .iter()
+        .filter(|index| index.is_unique() && !index.defined_on_field)
+        .for_each(|index_def| {
+            let mut args = fields_argument(index_def, false);
+            if let Some(name) = &index_def.name {
+                args.push(ast::Argument::new_string("name", name.to_string()));
+            }
+
+            push_index_map_argument(model, index_def, &mut args, params);
+
+            if matches!(index_def.clustered, Some(true)) {
+                args.push(ast::Argument::new(
+                    "clustered",
+                    ast::Expression::NumericValue("true".to_string(), Span::empty()),
+                ));
+            }
+
+            attributes.push(ast::Attribute::new("unique", args));
+        });
+
+    // @@index
+    model
+        .indices
+        .iter()
+        .filter(|index| index.tpe == IndexType::Normal)
+        .for_each(|index_def| {
+            let mut args = fields_argument(index_def, false);
+            push_index_map_argument(model, index_def, &mut args, params);
+
+            match index_def.algorithm {
+                Some(IndexAlgorithm::BTree) | None => (),
+                Some(algo) => {
+                    args.push(ast::Argument::new(
+                        "type",
+                        ast::Expression::ConstantValue(algo.to_string(), Span::empty()),
+                    ));
+                }
+            }
+
+            if matches!(index_def.clustered, Some(true)) {
+                args.push(ast::Argument::new(
+                    "clustered",
+                    ast::Expression::ConstantValue("true".to_string(), Span::empty()),
+                ));
+            }
+
+            attributes.push(ast::Attribute::new("index", args));
+        });
+
+    // @@fulltext
+    model
+        .indices
+        .iter()
+        .filter(|index| index.is_fulltext())
+        .for_each(|index_def| {
+            let mut args = fields_argument(index_def, true);
+            push_index_map_argument(model, index_def, &mut args, params);
+
+            attributes.push(ast::Attribute::new("fulltext", args));
+        });
+
+    // @@map
+    push_model_index_map_arg(model, &mut attributes);
+
+    // @@ignore
+    if model.is_ignored() {
+        attributes.push(ast::Attribute::new("ignore", vec![]));
+    }
+
+    attributes
+}
+
+fn fields_argument(index_def: &IndexDefinition, always_render_sort_order: bool) -> Vec<Argument> {
+    vec![ast::Argument::new_unnamed(ast::Expression::Array(
+        index_field_array(&index_def.fields, always_render_sort_order),
+        ast::Span::empty(),
+    ))]
+}
+
+pub(crate) fn push_field_index_arguments(
+    model: &Model,
+    index_def: &IndexDefinition,
+    args: &mut Vec<Argument>,
+    params: LowerParams<'_>,
+) {
+    let field = index_def.fields.first().unwrap();
+
+    if let Some(src) = params.datasource {
+        if !super::index_name_matches(index_def, params.datamodel, model, &*src.active_connector) {
+            args.push(ast::Argument::new(
+                "map",
+                ast::Expression::StringValue(String::from(index_def.db_name.as_ref().unwrap()), Span::empty()),
+            ));
+        }
+
+        if let Some(length) = field.length {
+            args.push(ast::Argument::new(
+                "length",
+                ast::Expression::NumericValue(length.to_string(), Span::empty()),
+            ));
+        }
+
+        if field.sort_order == Some(SortOrder::Desc) {
+            args.push(ast::Argument::new(
+                "sort",
+                ast::Expression::ConstantValue("Desc".to_string(), Span::empty()),
+            ));
+        }
+    }
+}
+
+pub(crate) fn push_index_map_argument(
+    model: &Model,
+    index_def: &IndexDefinition,
+    args: &mut Vec<Argument>,
+    params: LowerParams<'_>,
+) {
+    if let Some(src) = params.datasource {
+        if !super::index_name_matches(index_def, params.datamodel, model, &*src.active_connector) {
+            args.push(ast::Argument::new(
+                "map",
+                ast::Expression::StringValue(String::from(index_def.db_name.as_ref().unwrap()), Span::empty()),
+            ));
+        }
+    }
+}
+
+pub(crate) fn push_model_index_map_arg<T: WithDatabaseName>(obj: &T, attributes: &mut Vec<Attribute>) {
+    if let Some(db_name) = obj.database_name() {
+        attributes.push(ast::Attribute::new(
+            "map",
+            vec![ast::Argument::new_unnamed(ast::Expression::StringValue(
+                String::from(db_name),
+                Span::empty(),
+            ))],
+        ));
+    }
+}

--- a/libs/datamodel/core/src/transform/dml_to_ast/render_datamodel.rs
+++ b/libs/datamodel/core/src/transform/dml_to_ast/render_datamodel.rs
@@ -193,7 +193,7 @@ fn render_field_attributes(field: &Field, model: &Model, params: RenderParams<'_
                 args.push((Some("name"), string_literal(name).to_string()));
             }
 
-            if let Some(db_name) = &pk.db_name {
+            if let Some(db_name) = pk.db_name.as_ref().filter(|s| !s.is_empty()) {
                 if !primary_key_name_matches(pk, model, params.connector()) {
                     args.push((Some("map"), string_literal(db_name).to_string()));
                 }
@@ -268,7 +268,7 @@ fn render_field_attributes(field: &Field, model: &Model, params: RenderParams<'_
             }
         }
 
-        if let Some(fk_name) = &relation_info.fk_name {
+        if let Some(fk_name) = relation_info.fk_name.as_ref().filter(|s| !s.is_empty()) {
             if let Some(src) = params.datasource {
                 if !foreign_key_name_matches(relation_info, parent_model, &*src.active_connector) {
                     args.push((Some("map"), string_literal(fk_name).to_string()));
@@ -434,7 +434,7 @@ fn render_model_attributes(model: &dml::Model, params: RenderParams<'_>, out: &m
                 args.push((Some("name"), string_literal(name).to_string()));
             }
 
-            if let (Some(db_name), Some(src)) = (&pk.db_name, params.datasource) {
+            if let (Some(db_name), Some(src)) = (pk.db_name.as_ref().filter(|s| !s.is_empty()), params.datasource) {
                 if !primary_key_name_matches(pk, model, &*src.active_connector) {
                     args.push((Some("map"), string_literal(db_name).to_string()));
                 }
@@ -560,7 +560,7 @@ fn push_index_arguments(
         args.push((Some("name"), string_literal(name).to_string()));
     }
 
-    if let Some(mapped_name) = &index.db_name {
+    if let Some(mapped_name) = index.db_name.as_ref().filter(|s| !s.is_empty()) {
         if !index_name_matches(index, params.datamodel, model, params.connector()) {
             args.push((Some("map"), string_literal(mapped_name).to_string()));
         }

--- a/libs/sql-schema-describer/src/ids.rs
+++ b/libs/sql-schema-describer/src/ids.rs
@@ -1,79 +1,24 @@
-use crate::{Column, Enum, SqlSchema, Table};
-use serde::*;
-use std::ops::{Index, IndexMut};
+use serde::{Deserialize, Serialize};
 
-/// The identifier for a table in a SqlSchema. Use it with the indexing syntax:
-/// `let table = schema[table_id];`
+/// The identifier for a table in a SqlSchema.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-pub struct TableId(pub u32);
-
-impl Index<TableId> for SqlSchema {
-    type Output = Table;
-
-    fn index(&self, index: TableId) -> &Self::Output {
-        &self.tables[index.0 as usize]
-    }
-}
-
-impl IndexMut<TableId> for SqlSchema {
-    fn index_mut(&mut self, index: TableId) -> &mut Self::Output {
-        &mut self.tables[index.0 as usize]
-    }
-}
+pub struct TableId(pub(crate) u32);
 
 /// The identifier for an enum in a SqlSchema.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct EnumId(pub(crate) u32);
 
-impl Index<EnumId> for SqlSchema {
-    type Output = Enum;
-
-    fn index(&self, index: EnumId) -> &Self::Output {
-        &self.enums[index.0 as usize]
-    }
-}
-
 /// The identifier for a column in a SqlSchema.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-pub struct ColumnId(pub u32);
-
-impl Index<ColumnId> for SqlSchema {
-    type Output = (TableId, Column);
-
-    fn index(&self, index: ColumnId) -> &Self::Output {
-        &self.columns[index.0 as usize]
-    }
-}
-
-impl IndexMut<ColumnId> for SqlSchema {
-    fn index_mut(&mut self, index: ColumnId) -> &mut Self::Output {
-        &mut self.columns[index.0 as usize]
-    }
-}
+pub struct ColumnId(pub(crate) u32);
 
 /// The identifier for an Index in a SqlSchema.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct IndexId(pub(crate) u32);
+
+/// The identifier for a column indexed by a specific index in a SqlSchema.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct IndexId(pub TableId, pub u32);
-
-impl Index<IndexId> for SqlSchema {
-    type Output = crate::Index;
-
-    fn index(&self, index: IndexId) -> &Self::Output {
-        &self[index.0].indices[index.1 as usize]
-    }
-}
-
-/// The identifier for an Index in a SqlSchema.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct IndexFieldId(pub IndexId, pub u32);
-
-impl Index<IndexFieldId> for SqlSchema {
-    type Output = crate::IndexColumn;
-
-    fn index(&self, index: IndexFieldId) -> &Self::Output {
-        &self[index.0].columns[index.1 as usize]
-    }
-}
+pub struct IndexColumnId(pub(crate) u32);
 
 /// The identifier for a ForeignKey in the schema.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]

--- a/libs/sql-schema-describer/src/lib.rs
+++ b/libs/sql-schema-describer/src/lib.rs
@@ -1,6 +1,4 @@
 //! Database description. This crate is used heavily in the introspection and migration engines.
-#![allow(clippy::trivial_regex)] // this is allowed, because we want to do CoW replaces and these regexes will grow.
-#![allow(clippy::match_bool)] // we respectfully disagree that it makes the code less readable.
 
 pub mod mssql;
 pub mod mysql;
@@ -63,6 +61,10 @@ pub struct SqlSchema {
     foreign_keys: Vec<ForeignKey>,
     /// Constrained and referenced columns of foreign keys.
     foreign_key_columns: Vec<ForeignKeyColumn>,
+    /// All indexes and unique constraints.
+    indexes: Vec<Index>,
+    /// All columns of indexes.
+    index_columns: Vec<IndexColumn>,
     /// The schema's views,
     views: Vec<View>,
     /// The stored procedures.
@@ -76,38 +78,13 @@ pub struct SqlSchema {
 impl SqlSchema {
     /// Extract connector-specific constructs. The type parameter must be the right one.
     #[track_caller]
-    pub fn downcast_connector_data<T: 'static>(&self) -> Option<&T> {
-        self.connector_data.data.as_ref()?.downcast_ref()
+    pub fn downcast_connector_data<T: 'static>(&self) -> &T {
+        self.connector_data.data.as_ref().unwrap().downcast_ref().unwrap()
     }
 
-    /// Extract connector-specific constructs. The type parameter must be the right one.
-    pub fn downcast_connector_data_mut<T: Default + Send + Sync + 'static>(&mut self) -> &mut T {
-        if self.connector_data.data.is_none() {
-            self.connector_data.data = Some(Box::new(T::default()));
-        }
-
-        self.connector_data.data.as_mut().unwrap().downcast_mut().unwrap()
-    }
-
+    /// Insert connector-specific data into the schema. This will replace existing connector data.
     pub fn set_connector_data(&mut self, data: Box<dyn Any + Send + Sync>) {
         self.connector_data.data = Some(data);
-    }
-
-    /// Find a column by table and name. Prefer `walk_column()` if possible.
-    pub fn find_column<'a>(&'a self, table_id: TableId, name: &str) -> Option<(ColumnId, &'a Column)> {
-        self.walk(table_id)
-            .columns()
-            .find(|col| col.name() == name)
-            .map(|col| (col.id, col.column()))
-    }
-
-    /// Find a column or panic. For tests.
-    pub fn column_bang(&self, table_id: TableId, name: &str) -> &Column {
-        self.walk(table_id)
-            .columns()
-            .find(|col| col.name() == name)
-            .map(|col| col.column())
-            .unwrap()
     }
 
     /// Get a view.
@@ -129,23 +106,67 @@ impl SqlSchema {
         self.user_defined_types.iter().find(|x| x.name == name)
     }
 
-    pub fn iter_tables(&self) -> impl Iterator<Item = (TableId, &Table)> {
-        self.tables
-            .iter()
-            .enumerate()
-            .map(|(table_index, table)| (TableId(table_index as u32), table))
+    pub fn indexes_count(&self) -> usize {
+        self.indexes.len()
     }
 
-    pub fn iter_tables_mut(&mut self) -> impl Iterator<Item = (TableId, &mut Table)> {
-        self.tables
-            .iter_mut()
-            .enumerate()
-            .map(|(table_index, table)| (TableId(table_index as u32), table))
+    pub fn make_fulltext_indexes_normal(&mut self) {
+        for idx in self.indexes.iter_mut() {
+            if matches!(idx.tpe, IndexType::Fulltext) {
+                idx.tpe = IndexType::Normal;
+            }
+        }
     }
 
     pub fn push_column(&mut self, table_id: TableId, column: Column) -> ColumnId {
         let id = ColumnId(self.columns.len() as u32);
         self.columns.push((table_id, column));
+        id
+    }
+
+    pub fn push_fulltext_index(&mut self, table_id: TableId, index_name: String) -> IndexId {
+        let id = IndexId(self.indexes.len() as u32);
+        self.indexes.push(Index {
+            table_id,
+            index_name,
+            tpe: IndexType::Fulltext,
+        });
+        id
+    }
+
+    pub fn push_index(&mut self, table_id: TableId, index_name: String) -> IndexId {
+        let id = IndexId(self.indexes.len() as u32);
+        self.indexes.push(Index {
+            table_id,
+            index_name,
+            tpe: IndexType::Normal,
+        });
+        id
+    }
+
+    pub fn push_primary_key(&mut self, table_id: TableId, index_name: String) -> IndexId {
+        let id = IndexId(self.indexes.len() as u32);
+        self.indexes.push(Index {
+            table_id,
+            index_name,
+            tpe: IndexType::PrimaryKey,
+        });
+        id
+    }
+
+    pub fn push_unique_constraint(&mut self, table_id: TableId, index_name: String) -> IndexId {
+        let id = IndexId(self.indexes.len() as u32);
+        self.indexes.push(Index {
+            table_id,
+            index_name,
+            tpe: IndexType::Unique,
+        });
+        id
+    }
+
+    pub fn push_index_column(&mut self, column: IndexColumn) -> IndexColumnId {
+        let id = IndexColumnId(self.index_columns.len() as u32);
+        self.index_columns.push(column);
         id
     }
 
@@ -180,16 +201,8 @@ impl SqlSchema {
 
     pub fn push_table(&mut self, name: String) -> TableId {
         let id = TableId(self.tables.len() as u32);
-        self.tables.push(Table {
-            name,
-            ..Default::default()
-        });
+        self.tables.push(Table { name });
         id
-    }
-
-    #[track_caller]
-    pub fn table_bang(&self, name: &str) -> (TableId, &Table) {
-        self.iter_tables().find(|(_, t)| t.name == name).unwrap()
     }
 
     pub fn tables_count(&self) -> usize {
@@ -234,12 +247,7 @@ impl SqlSchema {
 /// A table found in a schema.
 #[derive(Serialize, Deserialize, PartialEq, Debug, Default)]
 pub struct Table {
-    /// The table's name.
-    pub name: String,
-    /// The table's indices.
-    pub indices: Vec<Index>,
-    /// The table's primary key, if there is one.
-    pub primary_key: Option<PrimaryKey>,
+    name: String,
 }
 
 /// The type of an index.
@@ -251,16 +259,8 @@ pub enum IndexType {
     Normal,
     /// Fulltext type.
     Fulltext,
-}
-
-impl IndexType {
-    pub fn is_unique(self) -> bool {
-        matches!(self, IndexType::Unique)
-    }
-
-    pub fn is_fulltext(self) -> bool {
-        matches!(self, IndexType::Fulltext)
-    }
+    /// The table's primary key
+    PrimaryKey,
 }
 
 /// The sort order of an index.
@@ -291,39 +291,20 @@ impl fmt::Display for SQLSortOrder {
     }
 }
 
-#[derive(Default, Serialize, Deserialize, PartialEq, Debug, Clone)]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct IndexColumn {
-    pub name: String,
+    pub index_id: IndexId,
+    pub column_id: ColumnId,
     pub sort_order: Option<SQLSortOrder>,
     pub length: Option<u32>,
 }
 
-impl IndexColumn {
-    pub fn new(name: impl ToString) -> Self {
-        Self {
-            name: name.to_string(),
-            ..Default::default()
-        }
-    }
-
-    pub fn name(&self) -> &str {
-        &self.name
-    }
-
-    pub fn set_sort_order(&mut self, sort_order: SQLSortOrder) {
-        self.sort_order = Some(sort_order);
-    }
-}
-
-/// An index of a table.
+/// An index on a table.
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
-pub struct Index {
-    /// Index name.
-    pub name: String,
-    /// Index columns.
-    pub columns: Vec<IndexColumn>,
-    /// Type of index.
-    pub tpe: IndexType,
+struct Index {
+    table_id: TableId,
+    index_name: String,
+    tpe: IndexType,
 }
 
 /// A stored procedure (like, the function inside your database).
@@ -344,60 +325,6 @@ pub struct UserDefinedType {
     pub definition: Option<String>,
 }
 
-#[derive(Default, Serialize, Deserialize, Debug, Clone)]
-pub struct PrimaryKeyColumn {
-    pub name: String,
-    pub length: Option<u32>,
-    pub sort_order: Option<SQLSortOrder>,
-}
-
-impl PartialEq for PrimaryKeyColumn {
-    fn eq(&self, other: &Self) -> bool {
-        self.name == other.name && self.length == other.length && self.sort_order() == other.sort_order()
-    }
-}
-
-impl PrimaryKeyColumn {
-    pub fn new(name: impl ToString) -> Self {
-        Self {
-            name: name.to_string(),
-            ..Default::default()
-        }
-    }
-
-    pub fn name(&self) -> &str {
-        &self.name
-    }
-
-    pub fn set_sort_order(&mut self, sort_order: SQLSortOrder) {
-        self.sort_order = Some(sort_order);
-    }
-
-    pub fn sort_order(&self) -> SQLSortOrder {
-        self.sort_order.unwrap_or(SQLSortOrder::Asc)
-    }
-}
-
-/// The primary key of a table.
-#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
-pub struct PrimaryKey {
-    /// Columns.
-    pub columns: Vec<PrimaryKeyColumn>,
-    /// The name of the primary key constraint, when available.
-    pub constraint_name: Option<String>,
-}
-
-impl PrimaryKey {
-    pub fn is_single_primary_key(&self, column: &str) -> bool {
-        self.columns.len() == 1 && self.columns.iter().any(|col| col.name() == column)
-    }
-
-    pub fn column_names(&self) -> impl ExactSizeIterator<Item = &str> + '_ {
-        self.columns.iter().map(|c| c.name())
-    }
-}
-
-/// A column of a table.
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 pub struct Column {
     /// Column name.
@@ -408,12 +335,6 @@ pub struct Column {
     pub default: Option<DefaultValue>,
     /// Is the column auto-incrementing?
     pub auto_increment: bool,
-}
-
-impl Column {
-    pub fn is_required(&self) -> bool {
-        self.tpe.arity == ColumnArity::Required
-    }
 }
 
 /// The type of a column.
@@ -451,7 +372,6 @@ impl ColumnType {
 
 /// Enumeration of column type families.
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
-// TODO: this name feels weird.
 pub enum ColumnTypeFamily {
     /// Integer types.
     Int,
@@ -517,7 +437,7 @@ impl ColumnTypeFamily {
 }
 
 /// A column's arity.
-#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Copy)]
 pub enum ColumnArity {
     /// Required column.
     Required,

--- a/libs/sql-schema-describer/src/mysql/indexes_query.sql
+++ b/libs/sql-schema-describer/src/mysql/indexes_query.sql
@@ -1,0 +1,12 @@
+SELECT
+    table_name AS table_name,
+    index_name AS index_name,
+    column_name AS column_name,
+    sub_part AS partial,
+    seq_in_index AS seq_in_index,
+    collation AS column_order,
+    non_unique AS non_unique,
+    index_type AS index_type
+FROM information_schema.statistics
+WHERE table_schema = ?
+ORDER BY BINARY table_name, BINARY index_name, seq_in_index

--- a/libs/sql-schema-describer/src/postgres/tables_query.sql
+++ b/libs/sql-schema-describer/src/postgres/tables_query.sql
@@ -1,0 +1,5 @@
+SELECT tbl.relname AS table_name
+FROM pg_class AS tbl
+INNER JOIN pg_namespace AS namespace ON namespace.oid = tbl.relnamespace
+WHERE tbl.relkind = 'r' AND namespace.nspname = $1
+ORDER BY table_name;

--- a/libs/sql-schema-describer/src/sqlite.rs
+++ b/libs/sql-schema-describer/src/sqlite.rs
@@ -2,8 +2,8 @@
 
 use crate::{
     getters::Getter, ids::*, parsers::Parser, Column, ColumnArity, ColumnType, ColumnTypeFamily, DefaultValue,
-    DescriberResult, ForeignKeyAction, Index, IndexColumn, IndexType, Lazy, PrimaryKey, PrimaryKeyColumn, PrismaValue,
-    Regex, SQLSortOrder, SqlMetadata, SqlSchema, SqlSchemaDescriberBackend, Table, View,
+    DescriberResult, ForeignKeyAction, Lazy, PrismaValue, Regex, SQLSortOrder, SqlMetadata, SqlSchema,
+    SqlSchemaDescriberBackend, View,
 };
 use indexmap::IndexMap;
 use quaint::{
@@ -126,20 +126,8 @@ impl<'a> SqlSchemaDescriber<'a> {
     }
 
     async fn push_table(&self, name: &str, table_id: TableId, schema: &mut SqlSchema) -> DescriberResult<()> {
-        let (table_columns, primary_key) = self.get_columns(name).await?;
-        let indices = self.get_indices(name).await?;
-
-        schema[table_id] = Table {
-            name: name.to_owned(),
-            indices,
-            primary_key,
-        };
-
-        for col in table_columns {
-            schema.columns.push((table_id, col));
-        }
-
-        Ok(())
+        push_columns(name, table_id, schema, self.conn).await?;
+        push_indexes(name, table_id, schema, self.conn).await
     }
 
     async fn get_views(&self) -> DescriberResult<Vec<View>> {
@@ -155,143 +143,6 @@ impl<'a> SqlSchemaDescriber<'a> {
         }
 
         Ok(views)
-    }
-
-    async fn get_columns(&self, table: &str) -> DescriberResult<(Vec<Column>, Option<PrimaryKey>)> {
-        let sql = format!(r#"PRAGMA table_info ("{}")"#, table);
-        let result_set = self.conn.query_raw(&sql, &[]).await?;
-        let mut pk_cols: BTreeMap<i64, String> = BTreeMap::new();
-        let mut cols: Vec<Column> = result_set
-            .into_iter()
-            .map(|row| {
-                trace!("Got column row {:?}", row);
-                let is_required = row.get("notnull").and_then(|x| x.as_bool()).expect("notnull");
-
-                let arity = if is_required {
-                    ColumnArity::Required
-                } else {
-                    ColumnArity::Nullable
-                };
-
-                let tpe = get_column_type(&row.get("type").and_then(|x| x.to_string()).expect("type"), arity);
-
-                let default = match row.get("dflt_value") {
-                    None => None,
-                    Some(val) if val.is_null() => None,
-                    Some(Value::Text(Some(cow_string))) => {
-                        let default_string = cow_string.to_string();
-
-                        if default_string.to_lowercase() == "null" {
-                            None
-                        } else {
-                            Some(match &tpe.family {
-                                ColumnTypeFamily::Int => match Self::parse_int(&default_string) {
-                                    Some(int_value) => DefaultValue::value(int_value),
-                                    None => DefaultValue::db_generated(default_string),
-                                },
-                                ColumnTypeFamily::BigInt => match Self::parse_big_int(&default_string) {
-                                    Some(int_value) => DefaultValue::value(int_value),
-                                    None => DefaultValue::db_generated(default_string),
-                                },
-                                ColumnTypeFamily::Float => match Self::parse_float(&default_string) {
-                                    Some(float_value) => DefaultValue::value(float_value),
-                                    None => DefaultValue::db_generated(default_string),
-                                },
-                                ColumnTypeFamily::Decimal => match Self::parse_float(&default_string) {
-                                    Some(float_value) => DefaultValue::value(float_value),
-                                    None => DefaultValue::db_generated(default_string),
-                                },
-                                ColumnTypeFamily::Boolean => match Self::parse_int(&default_string) {
-                                    Some(PrismaValue::Int(1)) => DefaultValue::value(true),
-                                    Some(PrismaValue::Int(0)) => DefaultValue::value(false),
-                                    _ => match Self::parse_bool(&default_string) {
-                                        Some(bool_value) => DefaultValue::value(bool_value),
-                                        None => DefaultValue::db_generated(default_string),
-                                    },
-                                },
-                                ColumnTypeFamily::String => {
-                                    DefaultValue::value(unquote_sqlite_string_default(&default_string).into_owned())
-                                }
-                                ColumnTypeFamily::DateTime => match default_string.to_lowercase().as_str() {
-                                    "current_timestamp" | "datetime(\'now\')" | "datetime(\'now\', \'localtime\')" => {
-                                        DefaultValue::now()
-                                    }
-                                    _ => DefaultValue::db_generated(default_string),
-                                },
-                                ColumnTypeFamily::Binary => DefaultValue::db_generated(default_string),
-                                ColumnTypeFamily::Json => DefaultValue::db_generated(default_string),
-                                ColumnTypeFamily::Uuid => DefaultValue::db_generated(default_string),
-                                ColumnTypeFamily::Enum(_) => DefaultValue::value(PrismaValue::Enum(default_string)),
-                                ColumnTypeFamily::Unsupported(_) => DefaultValue::db_generated(default_string),
-                            })
-                        }
-                    }
-                    Some(_) => None,
-                };
-
-                let pk_col = row.get("pk").and_then(|x| x.as_integer()).expect("primary key");
-
-                let col = Column {
-                    name: row.get("name").and_then(|x| x.to_string()).expect("name"),
-                    tpe,
-                    default,
-                    auto_increment: false,
-                };
-
-                if pk_col > 0 {
-                    pk_cols.insert(pk_col, col.name.clone());
-                }
-
-                trace!(
-                    "Found column '{}', type: '{:?}', default: {:?}, primary key: {}",
-                    col.name,
-                    col.tpe,
-                    col.default,
-                    pk_col > 0
-                );
-
-                col
-            })
-            .collect();
-
-        let primary_key = if pk_cols.is_empty() {
-            trace!("Determined that table has no primary key");
-            None
-        } else {
-            let mut columns: Vec<PrimaryKeyColumn> = vec![];
-            let mut col_idxs: Vec<&i64> = pk_cols.keys().collect();
-
-            col_idxs.sort_unstable();
-
-            for i in col_idxs {
-                columns.push(PrimaryKeyColumn::new(pk_cols[i].clone()));
-            }
-
-            //Integer Id columns are always implemented with either row id or autoincrement
-            if pk_cols.len() == 1 {
-                let pk_col = &columns[0];
-                for col in cols.iter_mut() {
-                    if col.name == pk_col.name() && &col.tpe.full_data_type.to_lowercase() == "integer" {
-                        trace!(
-                            "Detected that the primary key column corresponds to rowid and \
-                                 is auto incrementing"
-                        );
-                        col.auto_increment = true;
-                        // It is impossible to write a null value to an
-                        // autoincrementing primary key column.
-                        col.tpe.arity = ColumnArity::Required;
-                    }
-                }
-            }
-
-            trace!("Determined that table has primary key with columns {:?}", columns);
-            Some(PrimaryKey {
-                columns,
-                constraint_name: None,
-            })
-        };
-
-        Ok((cols, primary_key))
     }
 
     async fn push_foreign_keys(
@@ -361,7 +212,9 @@ impl<'a> SqlSchemaDescriber<'a> {
                     .walk(fkid)
                     .referenced_table()
                     .primary_key_columns()
-                    .map(|w| w.column_id)
+                    .into_iter()
+                    .flatten()
+                    .map(|w| w.as_column().id)
                     .collect::<Vec<_>>();
 
                 if referenced_table_pk_columns.len() == current_columns.len() {
@@ -415,83 +268,213 @@ impl<'a> SqlSchemaDescriber<'a> {
 
         Ok(())
     }
+}
 
-    async fn get_indices(&self, table: &str) -> DescriberResult<Vec<Index>> {
-        let sql = format!(r#"PRAGMA index_list("{}");"#, table);
-        let result_set = self.conn.query_raw(&sql, &[]).await?;
-        trace!("Got indices description results: {:?}", result_set);
+async fn push_columns(
+    table_name: &str,
+    table_id: TableId,
+    schema: &mut SqlSchema,
+    conn: &dyn Queryable,
+) -> DescriberResult<()> {
+    let sql = format!(r#"PRAGMA table_info ("{}")"#, table_name);
+    let result_set = conn.query_raw(&sql, &[]).await?;
+    let mut pk_cols: BTreeMap<i64, ColumnId> = BTreeMap::new();
+    for row in result_set {
+        trace!("Got column row {:?}", row);
+        let is_required = row.get("notnull").and_then(|x| x.as_bool()).expect("notnull");
 
-        let mut indices = Vec::new();
-        let filtered_rows = result_set
-            .into_iter()
-            // Exclude primary keys, they are inferred separately.
-            .filter(|row| row.get("origin").and_then(|origin| origin.as_str()).unwrap() != "pk")
-            // Exclude partial indices
-            .filter(|row| !row.get("partial").and_then(|partial| partial.as_bool()).unwrap());
+        let arity = if is_required {
+            ColumnArity::Required
+        } else {
+            ColumnArity::Nullable
+        };
 
-        for row in filtered_rows {
-            let mut valid_index = true;
+        let tpe = get_column_type(row.get_expect_string("type"), arity);
 
-            let is_unique = row.get("unique").and_then(|x| x.as_bool()).expect("get unique");
-            let name = row.get("name").and_then(|x| x.to_string()).expect("get name");
-            let mut index = Index {
-                name: name.clone(),
-                tpe: match is_unique {
-                    true => IndexType::Unique,
-                    false => IndexType::Normal,
-                },
-                columns: vec![],
-            };
+        let default = match row.get("dflt_value") {
+            None => None,
+            Some(val) if val.is_null() => None,
+            Some(Value::Text(Some(cow_string))) => {
+                let default_string = cow_string.to_string();
 
-            let sql = format!(r#"PRAGMA index_info("{}");"#, name);
-            let result_set = self.conn.query_raw(&sql, &[]).await.expect("querying for index info");
-            trace!("Got index description results: {:?}", result_set);
-
-            for row in result_set.into_iter() {
-                //if the index is on a rowid or expression, the name of the column will be null, we ignore these for now
-                match row.get("name").and_then(|x| x.to_string()) {
-                    Some(name) => {
-                        let pos = row.get("seqno").and_then(|x| x.as_integer()).expect("get seqno") as usize;
-                        if index.columns.len() <= pos {
-                            index.columns.resize(pos + 1, IndexColumn::default());
+                if default_string.to_lowercase() == "null" {
+                    None
+                } else {
+                    Some(match &tpe.family {
+                        ColumnTypeFamily::Int => match SqlSchemaDescriber::parse_int(&default_string) {
+                            Some(int_value) => DefaultValue::value(int_value),
+                            None => DefaultValue::db_generated(default_string),
+                        },
+                        ColumnTypeFamily::BigInt => match SqlSchemaDescriber::parse_big_int(&default_string) {
+                            Some(int_value) => DefaultValue::value(int_value),
+                            None => DefaultValue::db_generated(default_string),
+                        },
+                        ColumnTypeFamily::Float => match SqlSchemaDescriber::parse_float(&default_string) {
+                            Some(float_value) => DefaultValue::value(float_value),
+                            None => DefaultValue::db_generated(default_string),
+                        },
+                        ColumnTypeFamily::Decimal => match SqlSchemaDescriber::parse_float(&default_string) {
+                            Some(float_value) => DefaultValue::value(float_value),
+                            None => DefaultValue::db_generated(default_string),
+                        },
+                        ColumnTypeFamily::Boolean => match SqlSchemaDescriber::parse_int(&default_string) {
+                            Some(PrismaValue::Int(1)) => DefaultValue::value(true),
+                            Some(PrismaValue::Int(0)) => DefaultValue::value(false),
+                            _ => match SqlSchemaDescriber::parse_bool(&default_string) {
+                                Some(bool_value) => DefaultValue::value(bool_value),
+                                None => DefaultValue::db_generated(default_string),
+                            },
+                        },
+                        ColumnTypeFamily::String => {
+                            DefaultValue::value(unquote_sqlite_string_default(&default_string).into_owned())
                         }
-                        index.columns[pos] = IndexColumn::new(name);
-                    }
-                    None => valid_index = false,
+                        ColumnTypeFamily::DateTime => match default_string.to_lowercase().as_str() {
+                            "current_timestamp" | "datetime(\'now\')" | "datetime(\'now\', \'localtime\')" => {
+                                DefaultValue::now()
+                            }
+                            _ => DefaultValue::db_generated(default_string),
+                        },
+                        ColumnTypeFamily::Binary => DefaultValue::db_generated(default_string),
+                        ColumnTypeFamily::Json => DefaultValue::db_generated(default_string),
+                        ColumnTypeFamily::Uuid => DefaultValue::db_generated(default_string),
+                        ColumnTypeFamily::Enum(_) => DefaultValue::value(PrismaValue::Enum(default_string)),
+                        ColumnTypeFamily::Unsupported(_) => DefaultValue::db_generated(default_string),
+                    })
                 }
             }
+            Some(_) => None,
+        };
 
-            let sql = format!(r#"PRAGMA index_xinfo("{}");"#, name);
-            let result_set = self.conn.query_raw(&sql, &[]).await.expect("querying for index info");
-            trace!("Got index description results: {:?}", result_set);
+        let pk_col = row.get("pk").and_then(|x| x.as_integer()).expect("primary key");
 
-            for row in result_set.into_iter() {
-                //if the index is on a rowid or expression, the name of the column will be null, we ignore these for now
-                if row.get("name").and_then(|x| x.to_string()).is_some() {
-                    let pos = row.get("seqno").and_then(|x| x.as_integer()).expect("get seqno") as usize;
+        let column_id = schema.push_column(
+            table_id,
+            Column {
+                name: row.get_expect_string("name"),
+                tpe,
+                default,
+                auto_increment: false,
+            },
+        );
 
-                    let sort_order = row.get("desc").and_then(|r| r.as_integer()).map(|v| match v {
-                        0 => SQLSortOrder::Asc,
-                        _ => SQLSortOrder::Desc,
-                    });
+        if pk_col > 0 {
+            pk_cols.insert(pk_col, column_id);
+        }
+    }
 
-                    index.columns[pos].sort_order = sort_order;
-                }
+    if !pk_cols.is_empty() {
+        let pk_id = schema.push_primary_key(table_id, String::new());
+        for column_id in pk_cols.values() {
+            schema.push_index_column(crate::IndexColumn {
+                index_id: pk_id,
+                column_id: *column_id,
+                sort_order: None,
+                length: None,
+            });
+        }
+
+        // Integer ID columns are always implemented with either row id or autoincrement
+        if pk_cols.len() == 1 {
+            let pk_col_id = *pk_cols.values().next().unwrap();
+            let pk_col = &mut schema.columns[pk_col_id.0 as usize];
+            if pk_col.1.tpe.full_data_type.contains("int") {
+                pk_col.1.auto_increment = true;
+                pk_col.1.tpe.arity = ColumnArity::Required;
             }
+        }
+    }
 
-            if valid_index {
-                indices.push(index)
+    Ok(())
+}
+
+async fn push_indexes(
+    table: &str,
+    table_id: TableId,
+    schema: &mut SqlSchema,
+    conn: &dyn Queryable,
+) -> DescriberResult<()> {
+    let sql = format!(r#"PRAGMA index_list("{}");"#, table);
+    let result_set = conn.query_raw(&sql, &[]).await?;
+    let mut indexes = Vec::new(); // (index_name, is_unique, columns)
+
+    let filtered_rows = result_set
+        .into_iter()
+        // Exclude primary keys, they are inferred separately.
+        .filter(|row| row.get("origin").and_then(|origin| origin.as_str()).unwrap() != "pk")
+        // Exclude partial indices
+        .filter(|row| !row.get("partial").and_then(|partial| partial.as_bool()).unwrap());
+
+    for row in filtered_rows {
+        let mut valid_index = true;
+
+        let is_unique = row.get_expect_bool("unique");
+        let index_name = row.get_expect_string("name");
+        let mut columns = Vec::new();
+
+        let sql = format!(r#"PRAGMA index_info("{}");"#, index_name);
+        let result_set = conn.query_raw(&sql, &[]).await.expect("querying for index info");
+        trace!("Got index description results: {:?}", result_set);
+
+        for row in result_set.into_iter() {
+            // if the index is on a rowid or expression, the name of the column will be null,
+            // we ignore these for now
+            match row
+                .get_string("name")
+                .and_then(|name| schema.walk(table_id).column(&name))
+            {
+                Some(col) => {
+                    columns.push((col.id, SQLSortOrder::Asc));
+                }
+                None => valid_index = false,
             }
         }
 
-        Ok(indices)
+        let sql = format!(r#"PRAGMA index_xinfo("{}");"#, index_name);
+        let result_set = conn.query_raw(&sql, &[]).await.expect("querying for index info");
+        trace!("Got index description results: {:?}", result_set);
+
+        for row in result_set.into_iter() {
+            //if the index is on a rowid or expression, the name of the column will be null, we ignore these for now
+            if row.get("name").and_then(|x| x.to_string()).is_some() {
+                let pos = row.get_expect_i64("seqno");
+                let sort_order = match row.get_expect_i64("desc") {
+                    0 => SQLSortOrder::Asc,
+                    _ => SQLSortOrder::Desc,
+                };
+                if let Some(col) = columns.get_mut(pos as usize) {
+                    col.1 = sort_order;
+                }
+            }
+        }
+
+        if valid_index {
+            indexes.push((index_name, is_unique, columns))
+        }
     }
+
+    for (index_name, unique, columns) in indexes {
+        let index_id = if unique {
+            schema.push_unique_constraint(table_id, index_name)
+        } else {
+            schema.push_index(table_id, index_name)
+        };
+
+        for (column_id, sort_order) in columns {
+            schema.push_index_column(crate::IndexColumn {
+                index_id,
+                column_id,
+                sort_order: Some(sort_order),
+                length: None,
+            });
+        }
+    }
+
+    Ok(())
 }
 
-fn get_column_type(tpe: &str, arity: ColumnArity) -> ColumnType {
-    let tpe_lower = tpe.to_lowercase();
-
-    let family = match tpe_lower.as_ref() {
+fn get_column_type(mut tpe: String, arity: ColumnArity) -> ColumnType {
+    tpe.make_ascii_lowercase();
+    let family = match tpe.as_ref() {
         // SQLite only has a few native data types: https://www.sqlite.org/datatype3.html
         // It's tolerant though, and you can assign any data type you like to columns
         "int" => ColumnTypeFamily::Int,
@@ -525,7 +508,7 @@ fn get_column_type(tpe: &str, arity: ColumnArity) -> ColumnType {
         data_type => ColumnTypeFamily::Unsupported(data_type.into()),
     };
     ColumnType {
-        full_data_type: tpe.to_string(),
+        full_data_type: tpe,
         family,
         arity,
         native_type: None,

--- a/libs/sql-schema-describer/src/walkers.rs
+++ b/libs/sql-schema-describer/src/walkers.rs
@@ -4,8 +4,7 @@
 
 use crate::{
     ids::*, Column, ColumnArity, ColumnType, ColumnTypeFamily, DefaultValue, Enum, ForeignKey, ForeignKeyAction,
-    ForeignKeyColumn, Index, IndexColumn, IndexType, PrimaryKey, PrimaryKeyColumn, SQLSortOrder, SqlSchema, Table,
-    UserDefinedType, View,
+    ForeignKeyColumn, Index, IndexColumn, IndexType, SQLSortOrder, SqlSchema, Table, UserDefinedType, View,
 };
 use serde::de::DeserializeOwned;
 use std::ops::Range;
@@ -58,23 +57,21 @@ pub type EnumWalker<'a> = Walker<'a, EnumId>;
 /// Traverse an index.
 pub type IndexWalker<'a> = Walker<'a, IndexId>;
 
+/// Traverse a specific column inside an index.
+pub type IndexColumnWalker<'a> = Walker<'a, IndexColumnId>;
+
 impl<'a> ColumnWalker<'a> {
     /// The nullability and arity of the column.
-    pub fn arity(&self) -> &ColumnArity {
-        &self.column().tpe.arity
+    pub fn arity(self) -> ColumnArity {
+        self.get().1.tpe.arity
     }
 
-    /// A reference to the underlying Column struct.
-    pub fn column(&self) -> &'a Column {
-        &self.schema[self.id].1
-    }
-
-    fn table_id(&self) -> TableId {
-        self.schema[self.id].0
+    fn get(self) -> &'a (TableId, Column) {
+        &self.schema.columns[self.id.0 as usize]
     }
 
     /// Returns whether the column has the enum default value of the given enum type.
-    pub fn column_has_enum_default_value(&self, enum_name: &str, value: &str) -> bool {
+    pub fn column_has_enum_default_value(self, enum_name: &str, value: &str) -> bool {
         self.column_type_family_as_enum().map(|enm| enm.name.as_str()) == Some(enum_name)
             && self
                 .default()
@@ -84,19 +81,19 @@ impl<'a> ColumnWalker<'a> {
     }
 
     /// Returns whether the type of the column matches the provided enum name.
-    pub fn column_type_is_enum(&self, enum_name: &str) -> bool {
+    pub fn column_type_is_enum(self, enum_name: &str) -> bool {
         self.column_type_family_as_enum()
             .map(|enm| enm.name == enum_name)
             .unwrap_or(false)
     }
 
     /// The type family.
-    pub fn column_type_family(&self) -> &'a ColumnTypeFamily {
-        &self.column().tpe.family
+    pub fn column_type_family(self) -> &'a ColumnTypeFamily {
+        &self.get().1.tpe.family
     }
 
     /// Extract an `Enum` column type family, or `None` if the family is something else.
-    pub fn column_type_family_as_enum(&self) -> Option<&'a Enum> {
+    pub fn column_type_family_as_enum(self) -> Option<&'a Enum> {
         self.column_type_family().as_enum().map(|enum_name| {
             self.schema
                 .get_enum(enum_name)
@@ -106,48 +103,45 @@ impl<'a> ColumnWalker<'a> {
     }
 
     /// The column name.
-    pub fn name(&self) -> &'a str {
-        &self.column().name
+    pub fn name(self) -> &'a str {
+        &self.get().1.name
     }
 
     /// The default value for the column.
-    pub fn default(&self) -> Option<&'a DefaultValue> {
-        self.column().default.as_ref()
+    pub fn default(self) -> Option<&'a DefaultValue> {
+        self.get().1.default.as_ref()
     }
 
     /// The full column type.
     pub fn column_type(self) -> &'a ColumnType {
-        &self.column().tpe
+        &self.get().1.tpe
     }
 
     /// The column native type.
-    pub fn column_native_type<T>(&self) -> Option<T>
+    pub fn column_native_type<T>(self) -> Option<T>
     where
         T: DeserializeOwned,
     {
-        self.column()
-            .tpe
+        self.column_type()
             .native_type
             .as_ref()
             .map(|val| serde_json::from_value(val.clone()).unwrap())
     }
 
     /// Is this column an auto-incrementing integer?
-    pub fn is_autoincrement(&self) -> bool {
-        self.column().auto_increment
+    pub fn is_autoincrement(self) -> bool {
+        self.get().1.auto_increment
     }
 
     /// Is this column indexed by a secondary index??
-    pub fn is_part_of_secondary_index(&self) -> bool {
-        let table = self.table();
-        let name = self.name();
-        table.indexes().any(|idx| idx.contains_column(name))
+    pub fn is_part_of_secondary_index(self) -> bool {
+        self.table().indexes().any(|idx| idx.contains_column(self.id))
     }
 
     /// Is this column a part of the table's primary key?
-    pub fn is_part_of_primary_key(&self) -> bool {
+    pub fn is_part_of_primary_key(self) -> bool {
         match self.table().primary_key() {
-            Some(pk) => pk.columns.iter().any(|c| c.name() == self.name()),
+            Some(pk) => pk.contains_column(self.id),
             None => false,
         }
     }
@@ -161,24 +155,21 @@ impl<'a> ColumnWalker<'a> {
     }
 
     /// Returns whether two columns are named the same and belong to the same table.
-    pub fn is_same_column(&self, other: ColumnWalker<'_>) -> bool {
+    pub fn is_same_column(self, other: ColumnWalker<'_>) -> bool {
         self.name() == other.name() && self.table().name() == other.table().name()
     }
 
     /// Returns whether this column is the primary key. If it is only part of the primary key, this will return false.
-    pub fn is_single_primary_key(&self) -> bool {
+    pub fn is_single_primary_key(self) -> bool {
         self.table()
             .primary_key()
-            .map(|pk| pk.columns.len() == 1 && pk.columns.first().map(|c| c.name() == self.name()).unwrap_or(false))
+            .map(|pk| pk.columns().len() == 1 && pk.columns().next().map(|c| c.name() == self.name()).unwrap_or(false))
             .unwrap_or(false)
     }
 
     /// Traverse to the column's table.
-    pub fn table(&self) -> TableWalker<'a> {
-        TableWalker {
-            schema: self.schema,
-            id: self.table_id(),
-        }
+    pub fn table(self) -> TableWalker<'a> {
+        self.walk(self.get().0)
     }
 }
 
@@ -198,21 +189,21 @@ impl<'a> ViewWalker<'a> {
     }
 
     /// The name of the view
-    pub fn name(&self) -> &'a str {
+    pub fn name(self) -> &'a str {
         &self.view().name
     }
 
     /// The SQL definition of the view
-    pub fn definition(&self) -> Option<&'a str> {
+    pub fn definition(self) -> Option<&'a str> {
         self.view().definition.as_deref()
     }
 
     /// The index of the view in the schema.
-    pub fn view_index(&self) -> usize {
+    pub fn view_index(self) -> usize {
         self.view_index
     }
 
-    fn view(&self) -> &'a View {
+    fn view(self) -> &'a View {
         &self.schema.views[self.view_index]
     }
 }
@@ -231,33 +222,33 @@ impl<'a> UserDefinedTypeWalker<'a> {
     }
 
     /// The name of the type
-    pub fn name(&self) -> &'a str {
+    pub fn name(self) -> &'a str {
         &self.udt().name
     }
 
     /// The SQL definition of the type
-    pub fn definition(&self) -> Option<&'a str> {
+    pub fn definition(self) -> Option<&'a str> {
         self.udt().definition.as_deref()
     }
 
     /// The index of the user-defined type in the schema.
-    pub fn udt_index(&self) -> usize {
+    pub fn udt_index(self) -> usize {
         self.udt_index
     }
 
-    fn udt(&self) -> &'a UserDefinedType {
+    fn udt(self) -> &'a UserDefinedType {
         &self.schema.user_defined_types[self.udt_index]
     }
 }
 
 impl<'a> TableWalker<'a> {
     /// Get a column in the table, by name.
-    pub fn column(&self, column_name: &str) -> Option<ColumnWalker<'a>> {
+    pub fn column(self, column_name: &str) -> Option<ColumnWalker<'a>> {
         self.columns().find(|column| column.name() == column_name)
     }
 
     /// Get a column in the table, by name.
-    pub fn column_case_insensitive(&self, column_name: &str) -> Option<ColumnWalker<'a>> {
+    pub fn column_case_insensitive(self, column_name: &str) -> Option<ColumnWalker<'a>> {
         self.columns().find(|column| column.name() == column_name)
     }
 
@@ -273,20 +264,14 @@ impl<'a> TableWalker<'a> {
     }
 
     /// The number of foreign key constraints on the table.
-    pub fn foreign_key_count(&self) -> usize {
+    pub fn foreign_key_count(self) -> usize {
         self.foreign_keys_range().into_iter().len()
-    }
-
-    /// Traverse to an index by id.
-    pub fn index_at(&self, index_id: IndexId) -> IndexWalker<'a> {
-        self.walk(index_id)
     }
 
     /// Traverse the indexes on the table.
     pub fn indexes(self) -> impl ExactSizeIterator<Item = IndexWalker<'a>> {
-        let table_id = self.id;
-
-        (0..self.table().indices.len()).map(move |index_index| self.walk(IndexId(table_id, index_index as u32)))
+        let range = range_for_key(&self.schema.indexes, self.id, |idx| idx.table_id);
+        range.map(move |idx| self.walk(IndexId(idx as u32)))
     }
 
     /// Traverse the foreign keys on the table.
@@ -323,80 +308,23 @@ impl<'a> TableWalker<'a> {
     }
 
     /// Traverse to the primary key of the table.
-    pub fn primary_key(self) -> Option<&'a PrimaryKey> {
-        self.table().primary_key.as_ref()
+    pub fn primary_key(self) -> Option<IndexWalker<'a>> {
+        self.indexes().find(|idx| idx.is_primary_key())
     }
 
     /// The columns that are part of the primary keys.
-    pub fn primary_key_columns(&'a self) -> Box<dyn ExactSizeIterator<Item = PrimaryKeyColumnWalker<'a>> + 'a> {
-        let as_walker = move |primary_key_column_id: usize, c: &PrimaryKeyColumn| {
-            let column_id = self.column(c.name()).map(|c| c.id).unwrap();
-
-            PrimaryKeyColumnWalker {
-                schema: self.schema,
-                primary_key_column_id,
-                table_id: self.id,
-                column_id,
-            }
-        };
-
-        match self.table().primary_key.as_ref() {
-            Some(pk) => Box::new(pk.columns.iter().enumerate().map(move |(i, c)| as_walker(i, c))),
-            None => Box::new(std::iter::empty()),
-        }
+    pub fn primary_key_columns(self) -> Option<impl ExactSizeIterator<Item = IndexColumnWalker<'a>>> {
+        self.primary_key().map(|pk| pk.columns())
     }
 
-    /// The names of the columns that are part of the primary key.
-    pub fn primary_key_column_names(self) -> Option<Vec<String>> {
-        self.table()
-            .primary_key
-            .as_ref()
-            .map(|pk| pk.columns.iter().map(|c| c.name().to_string()).collect())
+    /// How many columns are in the primary key? Returns 0 in the absence of a pk.
+    pub fn primary_key_columns_count(self) -> usize {
+        self.primary_key_columns().map(|cols| cols.len()).unwrap_or(0)
     }
 
     /// Reference to the underlying `Table` struct.
-    pub fn table(self) -> &'a Table {
-        &self.schema[self.id]
-    }
-}
-
-/// A walker of a column in a primary key.
-#[derive(Clone, Copy)]
-pub struct PrimaryKeyColumnWalker<'a> {
-    schema: &'a SqlSchema,
-    primary_key_column_id: usize,
-    table_id: TableId,
-    pub(crate) column_id: ColumnId,
-}
-
-impl<'a> PrimaryKeyColumnWalker<'a> {
-    /// Conversion to a normal column walker.
-    pub fn as_column(self) -> ColumnWalker<'a> {
-        ColumnWalker {
-            schema: self.schema,
-            id: self.column_id,
-        }
-    }
-
-    /// The length limit of the (text) column. Matters on MySQL only.
-    pub fn length(self) -> Option<u32> {
-        self.get().length
-    }
-
-    /// The BTree ordering. Matters on SQL Server only.
-    pub fn sort_order(self) -> Option<SQLSortOrder> {
-        self.get().sort_order
-    }
-
-    fn table(self) -> TableWalker<'a> {
-        TableWalker {
-            schema: self.schema,
-            id: self.table_id,
-        }
-    }
-
-    fn get(self) -> &'a PrimaryKeyColumn {
-        &self.table().primary_key().unwrap().columns[self.primary_key_column_id]
+    fn table(self) -> &'a Table {
+        &self.schema.tables[self.id.0 as usize]
     }
 }
 
@@ -412,7 +340,7 @@ impl<'schema> ForeignKeyWalker<'schema> {
     }
 
     /// The name of the foreign key constraint.
-    pub fn constraint_name(&self) -> Option<&'schema str> {
+    pub fn constraint_name(self) -> Option<&'schema str> {
         self.foreign_key().constraint_name.as_deref()
     }
 
@@ -457,18 +385,15 @@ impl<'schema> ForeignKeyWalker<'schema> {
     }
 }
 
-/// Traverse an index column.
-#[derive(Clone, Copy)]
-pub struct IndexColumnWalker<'a> {
-    schema: &'a SqlSchema,
-    index_column_id: usize,
-    index_id: IndexId,
-}
-
 impl<'a> IndexColumnWalker<'a> {
     /// Get the index column data.
-    pub fn get(&self) -> &'a IndexColumn {
-        &self.index().get().columns[self.index_column_id]
+    pub fn get(self) -> &'a IndexColumn {
+        &self.schema.index_columns[self.id.0 as usize]
+    }
+
+    /// The name of the column.
+    pub fn name(self) -> &'a str {
+        self.as_column().name()
     }
 
     /// The length limit of the (text) column. Matters on MySQL only.
@@ -482,97 +407,80 @@ impl<'a> IndexColumnWalker<'a> {
     }
 
     /// The table where the column is located.
-    pub fn table(&self) -> TableWalker<'a> {
-        TableWalker {
-            id: self.index_id.0,
-            schema: self.schema,
-        }
+    pub fn table(self) -> TableWalker<'a> {
+        self.index().table()
     }
 
     /// The index of the column.
-    pub fn index(&self) -> IndexWalker<'a> {
-        IndexWalker {
-            schema: self.schema,
-            id: self.index_id,
-        }
+    pub fn index(self) -> IndexWalker<'a> {
+        self.walk(self.get().index_id)
     }
 
     /// Convert to a normal column walker, losing the possible index arguments.
-    pub fn as_column(&self) -> ColumnWalker<'a> {
-        let column = self
-            .table()
-            .columns()
-            .find(|c| c.name() == self.get().name())
-            .expect("STATE ERROR BOOP");
-
-        ColumnWalker {
-            schema: self.schema,
-            id: column.id,
-        }
-    }
-
-    /// The identifier of the index column.
-    pub fn index_field_id(&self) -> IndexFieldId {
-        IndexFieldId(self.index().id, self.index_column_id as u32)
+    pub fn as_column(self) -> ColumnWalker<'a> {
+        self.walk(self.get().column_id)
     }
 }
 
 impl<'a> IndexWalker<'a> {
     /// The names of the indexed columns.
-    pub fn column_names(&'a self) -> impl ExactSizeIterator<Item = &'a str> + 'a {
-        self.get().columns.iter().map(|c| c.name())
+    pub fn column_names(self) -> impl ExactSizeIterator<Item = &'a str> {
+        self.columns().map(|c| c.as_column().name())
     }
 
     /// Traverse the indexed columns.
-    pub fn columns<'b>(&'b self) -> impl ExactSizeIterator<Item = IndexColumnWalker<'a>> + 'b {
-        self.get()
-            .columns
-            .iter()
-            .enumerate()
-            .map(move |(index_column_id, _)| IndexColumnWalker {
-                schema: self.schema,
-                index_column_id,
-                index_id: self.id,
-            })
+    pub fn columns(self) -> impl ExactSizeIterator<Item = IndexColumnWalker<'a>> {
+        range_for_key(&self.schema.index_columns, self.id, |i| i.index_id)
+            .map(move |idx| self.walk(IndexColumnId(idx as u32)))
     }
 
     /// True if index contains the given column.
-    pub fn contains_column(&self, column_name: &str) -> bool {
-        self.get().columns.iter().any(|column| column.name() == column_name)
+    pub fn contains_column(self, column_id: ColumnId) -> bool {
+        self.columns().any(|column| column.as_column().id == column_id)
     }
 
-    fn get(&self) -> &'a Index {
-        &self.table().table().indices[self.id.1 as usize]
+    fn get(self) -> &'a Index {
+        &self.schema.indexes[self.id.0 as usize]
     }
 
     /// The IndexType
-    pub fn index_type(&self) -> IndexType {
+    pub fn index_type(self) -> IndexType {
         self.get().tpe
     }
 
+    /// Is this index the primary key of the table?
+    pub fn is_primary_key(self) -> bool {
+        matches!(self.get().tpe, IndexType::PrimaryKey)
+    }
+
+    /// Is this index a unique constraint? NB: This will return `false` for the primary key.
+    pub fn is_unique(self) -> bool {
+        matches!(self.get().tpe, IndexType::Unique)
+    }
+
     /// The name of the index.
-    pub fn name(&self) -> &'a str {
-        &self.get().name
+    pub fn name(self) -> &'a str {
+        &self.get().index_name
     }
 
     /// Traverse to the table of the index.
     pub fn table(self) -> TableWalker<'a> {
-        self.walk(self.id.0)
+        self.walk(self.get().table_id)
     }
 }
 
 impl<'a> EnumWalker<'a> {
-    fn get(&self) -> &'a Enum {
-        &self.schema[self.id]
+    fn get(self) -> &'a Enum {
+        &self.schema.enums[self.id.0 as usize]
     }
 
     /// The name of the enum. This is a made up name on MySQL.
-    pub fn name(&self) -> &'a str {
+    pub fn name(self) -> &'a str {
         &self.get().name
     }
 
     /// The values of the enum
-    pub fn values(&self) -> &'a [String] {
+    pub fn values(self) -> &'a [String] {
         &self.get().values
     }
 }
@@ -591,10 +499,8 @@ pub trait SqlSchemaExt {
 
 impl SqlSchemaExt for SqlSchema {
     fn table_walker<'a>(&'a self, name: &str) -> Option<TableWalker<'a>> {
-        Some(TableWalker {
-            id: TableId(self.tables.iter().position(|table| table.name == name)? as u32),
-            schema: self,
-        })
+        let table_idx = self.tables.iter().position(|table| table.name == name)?;
+        Some(self.walk(TableId(table_idx as u32)))
     }
 
     fn view_walker_at(&self, index: usize) -> ViewWalker<'_> {

--- a/libs/sql-schema-describer/tests/describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describer_tests.rs
@@ -5,7 +5,6 @@ use crate::test_api::*;
 use barrel::types;
 use pretty_assertions::assert_eq;
 use quaint::prelude::SqlFamily;
-use sql_schema_describer::*;
 
 #[test_connector]
 fn is_required_must_work(api: TestApi) {
@@ -153,40 +152,15 @@ fn composite_primary_keys_must_work(api: TestApi) {
     };
 
     api.raw_cmd(&sql);
-
     let schema = api.describe();
-    let (_, table) = schema.table_bang("User");
-
-    let columns = if api.sql_family().is_mssql() {
-        vec![
-            PrimaryKeyColumn {
-                name: "id".to_string(),
-                sort_order: Some(SQLSortOrder::Asc),
-                length: None,
-            },
-            PrimaryKeyColumn {
-                name: "name".to_string(),
-                sort_order: Some(SQLSortOrder::Asc),
-                length: None,
-            },
-        ]
-    } else {
-        vec![PrimaryKeyColumn::new("id"), PrimaryKeyColumn::new("name")]
-    };
-
+    let table = schema.table_walkers().next().unwrap();
+    assert_eq!(table.name(), "User");
     assert_eq!(
-        table,
-        &Table {
-            name: "User".to_string(),
-            indices: vec![],
-            primary_key: Some(PrimaryKey {
-                columns,
-                constraint_name: match api.sql_family() {
-                    SqlFamily::Postgres => Some("User_pkey".into()),
-                    SqlFamily::Mssql => Some("PK_User".into()),
-                    _ => None,
-                },
-            }),
-        }
+        table
+            .primary_key_columns()
+            .unwrap()
+            .map(|c| c.name())
+            .collect::<Vec<_>>(),
+        &["id", "name"]
     );
 }

--- a/libs/sql-schema-describer/tests/describers/mysql_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/mysql_describer_tests.rs
@@ -1,6 +1,5 @@
 use crate::test_api::*;
 use barrel::{types, Migration};
-use indoc::indoc;
 use pretty_assertions::assert_eq;
 use sql_schema_describer::*;
 
@@ -95,19 +94,6 @@ fn all_mysql_column_types_must_work(api: TestApi) {
             tables: [
                 Table {
                     name: "User",
-                    indices: [],
-                    primary_key: Some(
-                        PrimaryKey {
-                            columns: [
-                                PrimaryKeyColumn {
-                                    name: "primary_col",
-                                    length: None,
-                                    sort_order: None,
-                                },
-                            ],
-                            constraint_name: None,
-                        },
-                    ),
                 },
             ],
             enums: [
@@ -914,6 +900,29 @@ fn all_mysql_column_types_must_work(api: TestApi) {
             ],
             foreign_keys: [],
             foreign_key_columns: [],
+            indexes: [
+                Index {
+                    table_id: TableId(
+                        0,
+                    ),
+                    index_name: "",
+                    tpe: PrimaryKey,
+                },
+            ],
+            index_columns: [
+                IndexColumn {
+                    index_id: IndexId(
+                        0,
+                    ),
+                    column_id: ColumnId(
+                        0,
+                    ),
+                    sort_order: Some(
+                        Asc,
+                    ),
+                    length: None,
+                },
+            ],
             views: [],
             procedures: [],
             user_defined_types: [],
@@ -975,19 +984,6 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
             tables: [
                 Table {
                     name: "User",
-                    indices: [],
-                    primary_key: Some(
-                        PrimaryKey {
-                            columns: [
-                                PrimaryKeyColumn {
-                                    name: "primary_col",
-                                    length: None,
-                                    sort_order: None,
-                                },
-                            ],
-                            constraint_name: None,
-                        },
-                    ),
                 },
             ],
             enums: [
@@ -1794,6 +1790,29 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
             ],
             foreign_keys: [],
             foreign_key_columns: [],
+            indexes: [
+                Index {
+                    table_id: TableId(
+                        0,
+                    ),
+                    index_name: "",
+                    tpe: PrimaryKey,
+                },
+            ],
+            index_columns: [
+                IndexColumn {
+                    index_id: IndexId(
+                        0,
+                    ),
+                    column_id: ColumnId(
+                        0,
+                    ),
+                    sort_order: Some(
+                        Asc,
+                    ),
+                    length: None,
+                },
+            ],
             views: [],
             procedures: [],
             user_defined_types: [],
@@ -1855,19 +1874,6 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
             tables: [
                 Table {
                     name: "User",
-                    indices: [],
-                    primary_key: Some(
-                        PrimaryKey {
-                            columns: [
-                                PrimaryKeyColumn {
-                                    name: "primary_col",
-                                    length: None,
-                                    sort_order: None,
-                                },
-                            ],
-                            constraint_name: None,
-                        },
-                    ),
                 },
             ],
             enums: [
@@ -2669,6 +2675,29 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
             ],
             foreign_keys: [],
             foreign_key_columns: [],
+            indexes: [
+                Index {
+                    table_id: TableId(
+                        0,
+                    ),
+                    index_name: "",
+                    tpe: PrimaryKey,
+                },
+            ],
+            index_columns: [
+                IndexColumn {
+                    index_id: IndexId(
+                        0,
+                    ),
+                    column_id: ColumnId(
+                        0,
+                    ),
+                    sort_order: Some(
+                        Asc,
+                    ),
+                    length: None,
+                },
+            ],
             views: [],
             procedures: [],
             user_defined_types: [],
@@ -2737,29 +2766,9 @@ fn mysql_multi_field_indexes_must_be_inferred(api: TestApi) {
     let full_sql = migration.make::<barrel::backend::MySql>();
     api.raw_cmd(&full_sql);
     let result = api.describe();
-    let (_, table) = result.table_bang("Employee");
-
-    let columns = vec![
-        IndexColumn {
-            name: "name".into(),
-            sort_order: Some(SQLSortOrder::Asc),
-            length: None,
-        },
-        IndexColumn {
-            name: "age".into(),
-            sort_order: Some(SQLSortOrder::Asc),
-            length: None,
-        },
-    ];
-
-    assert_eq!(
-        table.indices,
-        &[Index {
-            name: "age_and_name_index".into(),
-            columns,
-            tpe: IndexType::Unique,
-        }]
-    );
+    result.assert_table("Employee", |t| {
+        t.assert_index_on_columns(&["name", "age"], |idx| idx.assert_name("age_and_name_index"))
+    });
 }
 
 #[test_connector(tags(Mysql), exclude(Mysql8))]
@@ -2775,29 +2784,9 @@ fn old_mysql_multi_field_indexes_must_be_inferred(api: TestApi) {
     let full_sql = migration.make::<barrel::backend::MySql>();
     api.raw_cmd(&full_sql);
     let result = api.describe();
-    let (_, table) = result.table_bang("Employee");
-
-    let columns = vec![
-        IndexColumn {
-            name: "name".into(),
-            sort_order: Some(SQLSortOrder::Asc),
-            length: None,
-        },
-        IndexColumn {
-            name: "age".into(),
-            sort_order: Some(SQLSortOrder::Asc),
-            length: None,
-        },
-    ];
-
-    assert_eq!(
-        table.indices,
-        &[Index {
-            name: "age_and_name_index".into(),
-            columns,
-            tpe: IndexType::Unique,
-        }]
-    );
+    result.assert_table("Employee", |t| {
+        t.assert_index_on_columns(&["name", "age"], |idx| idx.assert_name("age_and_name_index"))
+    });
 }
 
 #[test_connector(tags(Mysql))]
@@ -2873,49 +2862,9 @@ fn constraints_from_other_databases_should_not_be_introspected(api: TestApi) {
             tables: [
                 Table {
                     name: "Post",
-                    indices: [
-                        Index {
-                            name: "user_id",
-                            columns: [
-                                IndexColumn {
-                                    name: "user_id",
-                                    sort_order: Some(
-                                        Asc,
-                                    ),
-                                    length: None,
-                                },
-                            ],
-                            tpe: Normal,
-                        },
-                    ],
-                    primary_key: Some(
-                        PrimaryKey {
-                            columns: [
-                                PrimaryKeyColumn {
-                                    name: "id",
-                                    length: None,
-                                    sort_order: None,
-                                },
-                            ],
-                            constraint_name: None,
-                        },
-                    ),
                 },
                 Table {
                     name: "User",
-                    indices: [],
-                    primary_key: Some(
-                        PrimaryKey {
-                            columns: [
-                                PrimaryKeyColumn {
-                                    name: "id",
-                                    length: None,
-                                    sort_order: None,
-                                },
-                            ],
-                            constraint_name: None,
-                        },
-                    ),
                 },
             ],
             enums: [],
@@ -3015,6 +2964,67 @@ fn constraints_from_other_databases_should_not_be_introspected(api: TestApi) {
                     ),
                 },
             ],
+            indexes: [
+                Index {
+                    table_id: TableId(
+                        0,
+                    ),
+                    index_name: "",
+                    tpe: PrimaryKey,
+                },
+                Index {
+                    table_id: TableId(
+                        0,
+                    ),
+                    index_name: "user_id",
+                    tpe: Normal,
+                },
+                Index {
+                    table_id: TableId(
+                        1,
+                    ),
+                    index_name: "",
+                    tpe: PrimaryKey,
+                },
+            ],
+            index_columns: [
+                IndexColumn {
+                    index_id: IndexId(
+                        0,
+                    ),
+                    column_id: ColumnId(
+                        0,
+                    ),
+                    sort_order: Some(
+                        Asc,
+                    ),
+                    length: None,
+                },
+                IndexColumn {
+                    index_id: IndexId(
+                        1,
+                    ),
+                    column_id: ColumnId(
+                        1,
+                    ),
+                    sort_order: Some(
+                        Asc,
+                    ),
+                    length: None,
+                },
+                IndexColumn {
+                    index_id: IndexId(
+                        2,
+                    ),
+                    column_id: ColumnId(
+                        2,
+                    ),
+                    sort_order: Some(
+                        Asc,
+                    ),
+                    length: None,
+                },
+            ],
             views: [],
             procedures: [],
             user_defined_types: [],
@@ -3038,8 +3048,6 @@ fn introspected_default_strings_should_be_unescaped(api: TestApi) {
             tables: [
                 Table {
                     name: "User",
-                    indices: [],
-                    primary_key: None,
                 },
             ],
             enums: [],
@@ -3078,6 +3086,8 @@ fn introspected_default_strings_should_be_unescaped(api: TestApi) {
             ],
             foreign_keys: [],
             foreign_key_columns: [],
+            indexes: [],
+            index_columns: [],
             views: [],
             procedures: [],
             user_defined_types: [],
@@ -3102,8 +3112,6 @@ fn escaped_quotes_in_string_defaults_must_be_unescaped(api: TestApi) {
             tables: [
                 Table {
                     name: "string_defaults_test",
-                    indices: [],
-                    primary_key: None,
                 },
             ],
             enums: [],
@@ -3173,6 +3181,8 @@ fn escaped_quotes_in_string_defaults_must_be_unescaped(api: TestApi) {
             ],
             foreign_keys: [],
             foreign_key_columns: [],
+            indexes: [],
+            index_columns: [],
             views: [],
             procedures: [],
             user_defined_types: [],
@@ -3197,8 +3207,6 @@ fn escaped_backslashes_in_string_literals_must_be_unescaped(api: TestApi) {
             tables: [
                 Table {
                     name: "test",
-                    indices: [],
-                    primary_key: None,
                 },
             ],
             enums: [],
@@ -3237,6 +3245,8 @@ fn escaped_backslashes_in_string_literals_must_be_unescaped(api: TestApi) {
             ],
             foreign_keys: [],
             foreign_key_columns: [],
+            indexes: [],
+            index_columns: [],
             views: [],
             procedures: [],
             user_defined_types: [],
@@ -3272,8 +3282,6 @@ fn function_expression_defaults_are_described_as_dbgenerated(api: TestApi) {
             tables: [
                 Table {
                     name: "game",
-                    indices: [],
-                    primary_key: None,
                 },
             ],
             enums: [
@@ -3619,6 +3627,8 @@ fn function_expression_defaults_are_described_as_dbgenerated(api: TestApi) {
             ],
             foreign_keys: [],
             foreign_key_columns: [],
+            indexes: [],
+            index_columns: [],
             views: [],
             procedures: [],
             user_defined_types: [],
@@ -3650,155 +3660,23 @@ fn dangling_foreign_keys_are_filtered_out(api: TestApi) {
     "#;
 
     api.raw_cmd(setup);
+    let result = api.describe();
+    let fks: Vec<_> = result
+        .walk_foreign_keys()
+        .map(|fk| (fk.constraint_name(), fk.referenced_table().name()))
+        .collect();
 
     let expectation = expect![[r#"
-        SqlSchema {
-            tables: [
-                Table {
-                    name: "dog",
-                    indices: [
-                        Index {
-                            name: "bestFriendId",
-                            columns: [
-                                IndexColumn {
-                                    name: "bestFriendId",
-                                    sort_order: Some(
-                                        Asc,
-                                    ),
-                                    length: None,
-                                },
-                            ],
-                            tpe: Normal,
-                        },
-                    ],
-                    primary_key: Some(
-                        PrimaryKey {
-                            columns: [
-                                PrimaryKeyColumn {
-                                    name: "id",
-                                    length: None,
-                                    sort_order: None,
-                                },
-                            ],
-                            constraint_name: None,
-                        },
-                    ),
-                },
-                Table {
-                    name: "platypus",
-                    indices: [],
-                    primary_key: Some(
-                        PrimaryKey {
-                            columns: [
-                                PrimaryKeyColumn {
-                                    name: "id",
-                                    length: None,
-                                    sort_order: None,
-                                },
-                            ],
-                            constraint_name: None,
-                        },
-                    ),
-                },
-            ],
-            enums: [],
-            columns: [
-                (
-                    TableId(
-                        0,
-                    ),
-                    Column {
-                        name: "id",
-                        tpe: ColumnType {
-                            full_data_type: "int(11)",
-                            family: Int,
-                            arity: Required,
-                            native_type: Some(
-                                String(
-                                    "Int",
-                                ),
-                            ),
-                        },
-                        default: None,
-                        auto_increment: false,
-                    },
+        [
+            (
+                Some(
+                    "dog_ibfk_2",
                 ),
-                (
-                    TableId(
-                        0,
-                    ),
-                    Column {
-                        name: "bestFriendId",
-                        tpe: ColumnType {
-                            full_data_type: "int(11)",
-                            family: Int,
-                            arity: Nullable,
-                            native_type: Some(
-                                String(
-                                    "Int",
-                                ),
-                            ),
-                        },
-                        default: None,
-                        auto_increment: false,
-                    },
-                ),
-                (
-                    TableId(
-                        1,
-                    ),
-                    Column {
-                        name: "id",
-                        tpe: ColumnType {
-                            full_data_type: "int(11)",
-                            family: Int,
-                            arity: Required,
-                            native_type: Some(
-                                String(
-                                    "Int",
-                                ),
-                            ),
-                        },
-                        default: None,
-                        auto_increment: false,
-                    },
-                ),
-            ],
-            foreign_keys: [
-                ForeignKey {
-                    constrained_table: TableId(
-                        0,
-                    ),
-                    referenced_table: TableId(
-                        1,
-                    ),
-                    constraint_name: Some(
-                        "dog_ibfk_2",
-                    ),
-                    on_delete_action: Restrict,
-                    on_update_action: Restrict,
-                },
-            ],
-            foreign_key_columns: [
-                ForeignKeyColumn {
-                    foreign_key_id: ForeignKeyId(
-                        0,
-                    ),
-                    constrained_column: ColumnId(
-                        1,
-                    ),
-                    referenced_column: ColumnId(
-                        2,
-                    ),
-                },
-            ],
-            views: [],
-            procedures: [],
-            user_defined_types: [],
-            connector_data: <ConnectorData>,
-        }
+                "platypus",
+            ),
+        ]
     "#]];
-    api.expect_schema(expectation);
+    expectation.assert_debug_eq(&fks);
 }
 
 #[test_connector(tags(Mysql8))]
@@ -3815,9 +3693,9 @@ fn primary_key_length_is_handled(api: TestApi) {
     let schema = api.describe();
     let table = schema.table_walkers().next().unwrap();
 
-    assert_eq!(1, table.primary_key_columns().len());
+    assert_eq!(1, table.primary_key_columns_count());
 
-    let columns = table.primary_key_columns().collect::<Vec<_>>();
+    let columns = table.primary_key_columns().unwrap().collect::<Vec<_>>();
 
     assert_eq!("id", columns[0].as_column().name());
     assert_eq!(Some(255), columns[0].length());
@@ -3840,9 +3718,9 @@ fn index_length_and_sorting_is_handled(api: TestApi) {
     let schema = api.describe();
     let table = schema.table_walkers().next().unwrap();
 
-    assert_eq!(1, table.indexes().len());
+    assert_eq!(2, table.indexes().len());
 
-    let index = table.indexes().next().unwrap();
+    let index = table.indexes().find(|idx| !idx.is_primary_key()).unwrap();
     let columns = index.columns().collect::<Vec<_>>();
 
     assert_eq!(2, columns.len());

--- a/libs/sql-schema-describer/tests/describers/postgres_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/postgres_describer_tests.rs
@@ -2,7 +2,6 @@ mod cockroach_describer_tests;
 
 use crate::test_api::*;
 use barrel::{types, Migration};
-use indoc::indoc;
 use pretty_assertions::assert_eq;
 use prisma_value::PrismaValue;
 use sql_schema_describer::{postgres::PostgresSchemaExt, *};
@@ -59,7 +58,6 @@ fn all_postgres_column_types_must_work(api: TestApi) {
         t.add_column("smallint_col", types::custom("SMALLINT"));
         t.add_column("smallserial_col", types::custom("SMALLSERIAL"));
         t.add_column("serial_col", types::custom("SERIAL"));
-        // TODO: Test also autoincrement variety
         t.add_column("primary_col", types::primary());
         t.add_column("string1_col", types::text());
         t.add_column("string2_col", types::varchar(1));
@@ -82,35 +80,6 @@ fn all_postgres_column_types_must_work(api: TestApi) {
             tables: [
                 Table {
                     name: "User",
-                    indices: [
-                        Index {
-                            name: "User_uuid_col_key",
-                            columns: [
-                                IndexColumn {
-                                    name: "uuid_col",
-                                    sort_order: Some(
-                                        Asc,
-                                    ),
-                                    length: None,
-                                },
-                            ],
-                            tpe: Unique,
-                        },
-                    ],
-                    primary_key: Some(
-                        PrimaryKey {
-                            columns: [
-                                PrimaryKeyColumn {
-                                    name: "primary_col",
-                                    length: None,
-                                    sort_order: None,
-                                },
-                            ],
-                            constraint_name: Some(
-                                "User_pkey",
-                            ),
-                        },
-                    ),
                 },
             ],
             enums: [],
@@ -1004,6 +973,48 @@ fn all_postgres_column_types_must_work(api: TestApi) {
             ],
             foreign_keys: [],
             foreign_key_columns: [],
+            indexes: [
+                Index {
+                    table_id: TableId(
+                        0,
+                    ),
+                    index_name: "User_pkey",
+                    tpe: PrimaryKey,
+                },
+                Index {
+                    table_id: TableId(
+                        0,
+                    ),
+                    index_name: "User_uuid_col_key",
+                    tpe: Unique,
+                },
+            ],
+            index_columns: [
+                IndexColumn {
+                    index_id: IndexId(
+                        0,
+                    ),
+                    column_id: ColumnId(
+                        30,
+                    ),
+                    sort_order: Some(
+                        Asc,
+                    ),
+                    length: None,
+                },
+                IndexColumn {
+                    index_id: IndexId(
+                        1,
+                    ),
+                    column_id: ColumnId(
+                        42,
+                    ),
+                    sort_order: Some(
+                        Asc,
+                    ),
+                    length: None,
+                },
+            ],
             views: [],
             procedures: [],
             user_defined_types: [],
@@ -1024,10 +1035,13 @@ fn all_postgres_column_types_must_work(api: TestApi) {
             indexes: [
                 (
                     IndexId(
-                        TableId(
-                            0,
-                        ),
                         0,
+                    ),
+                    BTree,
+                ),
+                (
+                    IndexId(
+                        1,
                     ),
                     BTree,
                 ),
@@ -1200,155 +1214,55 @@ fn postgres_sequences_must_work(api: TestApi) {
 
 #[test_connector(tags(Postgres), exclude(CockroachDb))]
 fn postgres_multi_field_indexes_must_be_inferred_in_the_right_order(api: TestApi) {
-    let schema = format!(
-        r##"
-            CREATE TABLE "{schema_name}"."indexes_test" (
-                id TEXT PRIMARY KEY,
-                name TEXT NOT NULL,
-                age INTEGER NOT NULL
-            );
+    let schema = r##"
+        CREATE TABLE "indexes_test" (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            age INTEGER NOT NULL
+        );
 
-            CREATE UNIQUE INDEX "my_idx" ON "{schema_name}"."indexes_test" (name, age);
-            CREATE INDEX "my_idx2" ON "{schema_name}"."indexes_test" (age, name);
-        "##,
-        schema_name = api.schema_name()
-    );
-    api.raw_cmd(&schema);
+        CREATE UNIQUE INDEX "my_idx" ON "indexes_test" (name, age);
+        CREATE INDEX "my_idx2" ON "indexes_test" (age, name);
+    "##;
+    api.raw_cmd(schema);
+
+    let schema = api.describe();
+    let found: Vec<_> = schema
+        .table_walkers()
+        .next()
+        .unwrap()
+        .indexes()
+        .map(|idx| (idx.name(), idx.is_unique(), idx.column_names().collect::<Vec<_>>()))
+        .collect();
+
     let expectation = expect![[r#"
-        SqlSchema {
-            tables: [
-                Table {
-                    name: "indexes_test",
-                    indices: [
-                        Index {
-                            name: "my_idx",
-                            columns: [
-                                IndexColumn {
-                                    name: "name",
-                                    sort_order: Some(
-                                        Asc,
-                                    ),
-                                    length: None,
-                                },
-                                IndexColumn {
-                                    name: "age",
-                                    sort_order: Some(
-                                        Asc,
-                                    ),
-                                    length: None,
-                                },
-                            ],
-                            tpe: Unique,
-                        },
-                        Index {
-                            name: "my_idx2",
-                            columns: [
-                                IndexColumn {
-                                    name: "age",
-                                    sort_order: Some(
-                                        Asc,
-                                    ),
-                                    length: None,
-                                },
-                                IndexColumn {
-                                    name: "name",
-                                    sort_order: Some(
-                                        Asc,
-                                    ),
-                                    length: None,
-                                },
-                            ],
-                            tpe: Normal,
-                        },
-                    ],
-                    primary_key: Some(
-                        PrimaryKey {
-                            columns: [
-                                PrimaryKeyColumn {
-                                    name: "id",
-                                    length: None,
-                                    sort_order: None,
-                                },
-                            ],
-                            constraint_name: Some(
-                                "indexes_test_pkey",
-                            ),
-                        },
-                    ),
-                },
-            ],
-            enums: [],
-            columns: [
-                (
-                    TableId(
-                        0,
-                    ),
-                    Column {
-                        name: "id",
-                        tpe: ColumnType {
-                            full_data_type: "text",
-                            family: String,
-                            arity: Required,
-                            native_type: Some(
-                                String(
-                                    "Text",
-                                ),
-                            ),
-                        },
-                        default: None,
-                        auto_increment: false,
-                    },
-                ),
-                (
-                    TableId(
-                        0,
-                    ),
-                    Column {
-                        name: "name",
-                        tpe: ColumnType {
-                            full_data_type: "text",
-                            family: String,
-                            arity: Required,
-                            native_type: Some(
-                                String(
-                                    "Text",
-                                ),
-                            ),
-                        },
-                        default: None,
-                        auto_increment: false,
-                    },
-                ),
-                (
-                    TableId(
-                        0,
-                    ),
-                    Column {
-                        name: "age",
-                        tpe: ColumnType {
-                            full_data_type: "int4",
-                            family: Int,
-                            arity: Required,
-                            native_type: Some(
-                                String(
-                                    "Integer",
-                                ),
-                            ),
-                        },
-                        default: None,
-                        auto_increment: false,
-                    },
-                ),
-            ],
-            foreign_keys: [],
-            foreign_key_columns: [],
-            views: [],
-            procedures: [],
-            user_defined_types: [],
-            connector_data: <ConnectorData>,
-        }
+        [
+            (
+                "indexes_test_pkey",
+                false,
+                [
+                    "id",
+                ],
+            ),
+            (
+                "my_idx",
+                true,
+                [
+                    "name",
+                    "age",
+                ],
+            ),
+            (
+                "my_idx2",
+                false,
+                [
+                    "age",
+                    "name",
+                ],
+            ),
+        ]
     "#]];
-    api.expect_schema(expectation);
+    expectation.assert_debug_eq(&found);
 }
 
 #[test_connector(tags(Postgres), exclude(CockroachDb))]
@@ -1368,21 +1282,6 @@ fn escaped_quotes_in_string_defaults_must_be_unescaped(api: TestApi) {
             tables: [
                 Table {
                     name: "string_defaults_test",
-                    indices: [],
-                    primary_key: Some(
-                        PrimaryKey {
-                            columns: [
-                                PrimaryKeyColumn {
-                                    name: "id",
-                                    length: None,
-                                    sort_order: None,
-                                },
-                            ],
-                            constraint_name: Some(
-                                "string_defaults_test_pkey",
-                            ),
-                        },
-                    ),
                 },
             ],
             enums: [],
@@ -1497,6 +1396,29 @@ fn escaped_quotes_in_string_defaults_must_be_unescaped(api: TestApi) {
             ],
             foreign_keys: [],
             foreign_key_columns: [],
+            indexes: [
+                Index {
+                    table_id: TableId(
+                        0,
+                    ),
+                    index_name: "string_defaults_test_pkey",
+                    tpe: PrimaryKey,
+                },
+            ],
+            index_columns: [
+                IndexColumn {
+                    index_id: IndexId(
+                        0,
+                    ),
+                    column_id: ColumnId(
+                        0,
+                    ),
+                    sort_order: Some(
+                        Asc,
+                    ),
+                    length: None,
+                },
+            ],
             views: [],
             procedures: [],
             user_defined_types: [],
@@ -1521,8 +1443,6 @@ fn seemingly_escaped_backslashes_in_string_literals_must_not_be_unescaped(api: T
             tables: [
                 Table {
                     name: "test",
-                    indices: [],
-                    primary_key: None,
                 },
             ],
             enums: [],
@@ -1561,6 +1481,8 @@ fn seemingly_escaped_backslashes_in_string_literals_must_not_be_unescaped(api: T
             ],
             foreign_keys: [],
             foreign_key_columns: [],
+            indexes: [],
+            index_columns: [],
             views: [],
             procedures: [],
             user_defined_types: [],
@@ -1585,8 +1507,7 @@ fn index_sort_order_is_handled(api: TestApi) {
 
     let schema = api.describe();
     let table = schema.table_walkers().next().unwrap();
-    let index = table.indexes().next().unwrap();
-
+    let index = table.indexes().nth(1).unwrap();
     let columns = index.columns().collect::<Vec<_>>();
 
     assert_eq!(1, columns.len());
@@ -1598,7 +1519,6 @@ fn index_sort_order_is_handled(api: TestApi) {
 fn index_sort_order_composite_type_desc_desc_is_handled(api: TestApi) {
     let sql = indoc! {r#"
         CREATE TABLE A (
-            id INT PRIMARY KEY,
             a  INT NOT NULL,
             b  INT NOT NULL
         );
@@ -1627,7 +1547,6 @@ fn index_sort_order_composite_type_desc_desc_is_handled(api: TestApi) {
 fn index_sort_order_composite_type_asc_desc_is_handled(api: TestApi) {
     let sql = indoc! {r#"
         CREATE TABLE A (
-            id INT PRIMARY KEY,
             a  INT NOT NULL,
             b  INT NOT NULL
         );
@@ -1812,5 +1731,5 @@ fn int_expressions_in_defaults(api: TestApi) {
 }
 
 fn extract_ext(schema: &SqlSchema) -> &PostgresSchemaExt {
-    schema.downcast_connector_data().unwrap_or_default()
+    schema.downcast_connector_data()
 }

--- a/libs/sql-schema-describer/tests/describers/postgres_describer_tests/cockroach_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/postgres_describer_tests/cockroach_describer_tests.rs
@@ -1,6 +1,6 @@
 use crate::test_api::*;
 use prisma_value::PrismaValue;
-use sql_schema_describer::{postgres::PostgresSchemaExt, ColumnTypeFamily};
+use sql_schema_describer::{postgres::PostgresSchemaExt, ColumnTypeFamily, SqlSchemaExt};
 
 #[test_connector(tags(CockroachDb))]
 fn views_can_be_described(api: TestApi) {
@@ -235,62 +235,6 @@ fn multi_field_indexes_must_be_inferred_in_the_right_order(api: TestApi) {
             tables: [
                 Table {
                     name: "indexes_test",
-                    indices: [
-                        Index {
-                            name: "my_idx",
-                            columns: [
-                                IndexColumn {
-                                    name: "name",
-                                    sort_order: Some(
-                                        Asc,
-                                    ),
-                                    length: None,
-                                },
-                                IndexColumn {
-                                    name: "age",
-                                    sort_order: Some(
-                                        Asc,
-                                    ),
-                                    length: None,
-                                },
-                            ],
-                            tpe: Unique,
-                        },
-                        Index {
-                            name: "my_idx2",
-                            columns: [
-                                IndexColumn {
-                                    name: "age",
-                                    sort_order: Some(
-                                        Asc,
-                                    ),
-                                    length: None,
-                                },
-                                IndexColumn {
-                                    name: "name",
-                                    sort_order: Some(
-                                        Asc,
-                                    ),
-                                    length: None,
-                                },
-                            ],
-                            tpe: Normal,
-                        },
-                    ],
-                    primary_key: Some(
-                        PrimaryKey {
-                            columns: [
-                                PrimaryKeyColumn {
-                                    name: "id",
-                                    length: None,
-                                    sort_order: None,
-                                },
-                            ],
-                            constraint_name: Some(
-                                "indexes_test_pkey",
-                            ),
-                        },
-                    ),
                 },
             ],
             enums: [],
@@ -358,6 +302,91 @@ fn multi_field_indexes_must_be_inferred_in_the_right_order(api: TestApi) {
             ],
             foreign_keys: [],
             foreign_key_columns: [],
+            indexes: [
+                Index {
+                    table_id: TableId(
+                        0,
+                    ),
+                    index_name: "indexes_test_pkey",
+                    tpe: PrimaryKey,
+                },
+                Index {
+                    table_id: TableId(
+                        0,
+                    ),
+                    index_name: "my_idx",
+                    tpe: Unique,
+                },
+                Index {
+                    table_id: TableId(
+                        0,
+                    ),
+                    index_name: "my_idx2",
+                    tpe: Normal,
+                },
+            ],
+            index_columns: [
+                IndexColumn {
+                    index_id: IndexId(
+                        0,
+                    ),
+                    column_id: ColumnId(
+                        0,
+                    ),
+                    sort_order: Some(
+                        Asc,
+                    ),
+                    length: None,
+                },
+                IndexColumn {
+                    index_id: IndexId(
+                        1,
+                    ),
+                    column_id: ColumnId(
+                        1,
+                    ),
+                    sort_order: Some(
+                        Asc,
+                    ),
+                    length: None,
+                },
+                IndexColumn {
+                    index_id: IndexId(
+                        1,
+                    ),
+                    column_id: ColumnId(
+                        2,
+                    ),
+                    sort_order: Some(
+                        Asc,
+                    ),
+                    length: None,
+                },
+                IndexColumn {
+                    index_id: IndexId(
+                        2,
+                    ),
+                    column_id: ColumnId(
+                        2,
+                    ),
+                    sort_order: Some(
+                        Asc,
+                    ),
+                    length: None,
+                },
+                IndexColumn {
+                    index_id: IndexId(
+                        2,
+                    ),
+                    column_id: ColumnId(
+                        1,
+                    ),
+                    sort_order: Some(
+                        Asc,
+                    ),
+                    length: None,
+                },
+            ],
             views: [],
             procedures: [],
             user_defined_types: [],
@@ -380,11 +409,11 @@ fn escaped_characters_in_string_defaults(api: TestApi) {
     "#;
     api.raw_cmd(init);
     let schema = api.describe();
-    let (table_id, _table) = schema.table_bang("Fruit");
+    let table = schema.table_walker("Fruit").unwrap();
 
     let expect_col = |name: &str, expected: &str| {
-        let col = schema.column_bang(table_id, name);
-        let default = col.default.as_ref().unwrap().as_value().unwrap().as_string().unwrap();
+        let col = table.column(name).unwrap();
+        let default = col.default().unwrap().as_value().unwrap().as_string().unwrap();
         assert_eq!(default, expected);
     };
     expect_col("seasonality", r#""summer""#);
@@ -413,7 +442,7 @@ fn cockroachdb_sequences_must_work(api: TestApi) {
     api.raw_cmd(sql);
 
     let schema = api.describe();
-    let ext: &PostgresSchemaExt = schema.downcast_connector_data().unwrap_or_default();
+    let ext: &PostgresSchemaExt = schema.downcast_connector_data();
     let expected_ext = expect![[r#"
         PostgresSchemaExt {
             opclasses: [],

--- a/libs/sql-schema-describer/tests/describers/sqlite_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/sqlite_describer_tests.rs
@@ -1,6 +1,5 @@
 use crate::test_api::*;
 use barrel::{types, Migration};
-use indoc::indoc;
 use pretty_assertions::assert_eq;
 use sql_schema_describer::*;
 
@@ -76,19 +75,6 @@ fn sqlite_column_types_must_work(api: TestApi) {
             tables: [
                 Table {
                     name: "User",
-                    indices: [],
-                    primary_key: Some(
-                        PrimaryKey {
-                            columns: [
-                                PrimaryKeyColumn {
-                                    name: "primary_col",
-                                    length: None,
-                                    sort_order: None,
-                                },
-                            ],
-                            constraint_name: None,
-                        },
-                    ),
                 },
             ],
             enums: [],
@@ -116,7 +102,7 @@ fn sqlite_column_types_must_work(api: TestApi) {
                     Column {
                         name: "int4_col",
                         tpe: ColumnType {
-                            full_data_type: "INTEGER",
+                            full_data_type: "integer",
                             family: Int,
                             arity: Required,
                             native_type: None,
@@ -132,7 +118,7 @@ fn sqlite_column_types_must_work(api: TestApi) {
                     Column {
                         name: "text_col",
                         tpe: ColumnType {
-                            full_data_type: "TEXT",
+                            full_data_type: "text",
                             family: String,
                             arity: Required,
                             native_type: None,
@@ -148,7 +134,7 @@ fn sqlite_column_types_must_work(api: TestApi) {
                     Column {
                         name: "real_col",
                         tpe: ColumnType {
-                            full_data_type: "REAL",
+                            full_data_type: "real",
                             family: Float,
                             arity: Required,
                             native_type: None,
@@ -164,7 +150,7 @@ fn sqlite_column_types_must_work(api: TestApi) {
                     Column {
                         name: "primary_col",
                         tpe: ColumnType {
-                            full_data_type: "INTEGER",
+                            full_data_type: "integer",
                             family: Int,
                             arity: Required,
                             native_type: None,
@@ -192,6 +178,27 @@ fn sqlite_column_types_must_work(api: TestApi) {
             ],
             foreign_keys: [],
             foreign_key_columns: [],
+            indexes: [
+                Index {
+                    table_id: TableId(
+                        0,
+                    ),
+                    index_name: "",
+                    tpe: PrimaryKey,
+                },
+            ],
+            index_columns: [
+                IndexColumn {
+                    index_id: IndexId(
+                        0,
+                    ),
+                    column_id: ColumnId(
+                        4,
+                    ),
+                    sort_order: None,
+                    length: None,
+                },
+            ],
             views: [],
             procedures: [],
             user_defined_types: [],
@@ -237,32 +244,23 @@ fn sqlite_foreign_key_on_delete_must_be_handled(api: TestApi) {
 
 #[test_connector(tags(Sqlite))]
 fn sqlite_text_primary_keys_must_be_inferred_on_table_and_not_as_separate_indexes(api: TestApi) {
-    let mut migration = Migration::new();
-    migration.create_table("User", move |t| {
-        t.add_column("int4_col", types::integer());
-        t.add_column("text_col", types::text());
-        t.add_column("real_col", types::float());
-        t.add_column("primary_col", types::text());
+    let sql = r#"
+        CREATE TABLE "User" (
+            int4_col INTEGER,
+            text_col TEXT,
+            real_col FLOAT,
+            primary_col TEXT,
 
-        // Simulate how we create primary keys in the migrations engine.
-        t.inject_custom("PRIMARY KEY (\"primary_col\")");
-    });
-    let full_sql = migration.make::<barrel::backend::Sqlite>();
-    api.raw_cmd(&full_sql);
+            PRIMARY KEY ("primary_col")
+        );
+    "#;
+    api.raw_cmd(sql);
 
     let result = api.describe();
-
-    let (_, table) = result.table_bang("User");
-
-    assert!(table.indices.is_empty());
-
-    assert_eq!(
-        table.primary_key.as_ref().unwrap(),
-        &PrimaryKey {
-            columns: vec![PrimaryKeyColumn::new("primary_col")],
-            constraint_name: None,
-        }
-    );
+    let table = result.table_walker("User").unwrap();
+    assert!(result.indexes_count() == 1);
+    assert!(table.primary_key_columns_count() == 1);
+    assert!(table.primary_key_columns().unwrap().next().unwrap().name() == "primary_col");
 }
 
 #[test_connector(tags(Sqlite))]
@@ -281,8 +279,6 @@ fn escaped_quotes_in_string_defaults_must_be_unescaped(api: TestApi) {
             tables: [
                 Table {
                     name: "string_defaults_test",
-                    indices: [],
-                    primary_key: None,
                 },
             ],
             enums: [],
@@ -294,7 +290,7 @@ fn escaped_quotes_in_string_defaults_must_be_unescaped(api: TestApi) {
                     Column {
                         name: "regular",
                         tpe: ColumnType {
-                            full_data_type: "VARCHAR",
+                            full_data_type: "varchar",
                             family: String,
                             arity: Required,
                             native_type: None,
@@ -319,7 +315,7 @@ fn escaped_quotes_in_string_defaults_must_be_unescaped(api: TestApi) {
                     Column {
                         name: "escaped",
                         tpe: ColumnType {
-                            full_data_type: "VARCHAR",
+                            full_data_type: "varchar",
                             family: String,
                             arity: Required,
                             native_type: None,
@@ -340,6 +336,8 @@ fn escaped_quotes_in_string_defaults_must_be_unescaped(api: TestApi) {
             ],
             foreign_keys: [],
             foreign_key_columns: [],
+            indexes: [],
+            index_columns: [],
             views: [],
             procedures: [],
             user_defined_types: [],
@@ -364,8 +362,6 @@ fn backslashes_in_string_literals(api: TestApi) {
             tables: [
                 Table {
                     name: "test",
-                    indices: [],
-                    primary_key: None,
                 },
             ],
             enums: [],
@@ -377,7 +373,7 @@ fn backslashes_in_string_literals(api: TestApi) {
                     Column {
                         name: "model_name_space",
                         tpe: ColumnType {
-                            full_data_type: "VARCHAR(255)",
+                            full_data_type: "varchar(255)",
                             family: String,
                             arity: Required,
                             native_type: None,
@@ -398,6 +394,8 @@ fn backslashes_in_string_literals(api: TestApi) {
             ],
             foreign_keys: [],
             foreign_key_columns: [],
+            indexes: [],
+            index_columns: [],
             views: [],
             procedures: [],
             user_defined_types: [],
@@ -434,35 +432,9 @@ fn broken_relations_are_filtered_out(api: TestApi) {
             tables: [
                 Table {
                     name: "dog",
-                    indices: [],
-                    primary_key: Some(
-                        PrimaryKey {
-                            columns: [
-                                PrimaryKeyColumn {
-                                    name: "id",
-                                    length: None,
-                                    sort_order: None,
-                                },
-                            ],
-                            constraint_name: None,
-                        },
-                    ),
                 },
                 Table {
                     name: "platypus",
-                    indices: [],
-                    primary_key: Some(
-                        PrimaryKey {
-                            columns: [
-                                PrimaryKeyColumn {
-                                    name: "id",
-                                    length: None,
-                                    sort_order: None,
-                                },
-                            ],
-                            constraint_name: None,
-                        },
-                    ),
                 },
             ],
             enums: [],
@@ -474,7 +446,7 @@ fn broken_relations_are_filtered_out(api: TestApi) {
                     Column {
                         name: "id",
                         tpe: ColumnType {
-                            full_data_type: "INTEGER",
+                            full_data_type: "integer",
                             family: Int,
                             arity: Required,
                             native_type: None,
@@ -490,7 +462,7 @@ fn broken_relations_are_filtered_out(api: TestApi) {
                     Column {
                         name: "bestFriendId",
                         tpe: ColumnType {
-                            full_data_type: "INTEGER",
+                            full_data_type: "integer",
                             family: Int,
                             arity: Nullable,
                             native_type: None,
@@ -506,7 +478,7 @@ fn broken_relations_are_filtered_out(api: TestApi) {
                     Column {
                         name: "realBestFriendId",
                         tpe: ColumnType {
-                            full_data_type: "INTEGER",
+                            full_data_type: "integer",
                             family: Int,
                             arity: Nullable,
                             native_type: None,
@@ -522,7 +494,7 @@ fn broken_relations_are_filtered_out(api: TestApi) {
                     Column {
                         name: "otherBestFriendId",
                         tpe: ColumnType {
-                            full_data_type: "INTEGER",
+                            full_data_type: "integer",
                             family: Int,
                             arity: Nullable,
                             native_type: None,
@@ -538,7 +510,7 @@ fn broken_relations_are_filtered_out(api: TestApi) {
                     Column {
                         name: "id",
                         tpe: ColumnType {
-                            full_data_type: "INTEGER",
+                            full_data_type: "integer",
                             family: Int,
                             arity: Required,
                             native_type: None,
@@ -574,6 +546,44 @@ fn broken_relations_are_filtered_out(api: TestApi) {
                     ),
                 },
             ],
+            indexes: [
+                Index {
+                    table_id: TableId(
+                        0,
+                    ),
+                    index_name: "",
+                    tpe: PrimaryKey,
+                },
+                Index {
+                    table_id: TableId(
+                        1,
+                    ),
+                    index_name: "",
+                    tpe: PrimaryKey,
+                },
+            ],
+            index_columns: [
+                IndexColumn {
+                    index_id: IndexId(
+                        0,
+                    ),
+                    column_id: ColumnId(
+                        0,
+                    ),
+                    sort_order: None,
+                    length: None,
+                },
+                IndexColumn {
+                    index_id: IndexId(
+                        1,
+                    ),
+                    column_id: ColumnId(
+                        4,
+                    ),
+                    sort_order: None,
+                    length: None,
+                },
+            ],
             views: [],
             procedures: [],
             user_defined_types: [],
@@ -599,7 +609,7 @@ fn index_sort_order_is_handled(api: TestApi) {
 
     let schema = api.describe();
     let table = schema.table_walkers().next().unwrap();
-    let index = table.indexes().next().unwrap();
+    let index = table.indexes().nth(1).unwrap();
 
     let columns = index.columns().collect::<Vec<_>>();
 

--- a/libs/sql-schema-describer/tests/test_api/mod.rs
+++ b/libs/sql-schema-describer/tests/test_api/mod.rs
@@ -1,4 +1,5 @@
 pub use expect_test::expect;
+pub use indoc::{formatdoc, indoc};
 pub use quaint::{prelude::Queryable, single::Quaint};
 pub use test_macros::test_connector;
 pub use test_setup::{runtime::run_with_thread_local_runtime as tok, BitFlags, Capabilities, Tags};
@@ -214,7 +215,7 @@ impl TableAssertion<'_> {
             .indexes()
             .find(|i| {
                 let lengths_match = i.columns().len() == columns.len();
-                let columns_match = i.columns().zip(columns.iter()).all(|(a, b)| a.get().name() == *b);
+                let columns_match = i.columns().zip(columns.iter()).all(|(a, b)| a.as_column().name() == *b);
 
                 lengths_match && columns_match
             })
@@ -230,8 +231,7 @@ impl TableAssertion<'_> {
             .table
             .primary_key()
             .unwrap()
-            .columns
-            .iter()
+            .columns()
             .map(|c| c.name())
             .collect::<Vec<_>>();
 
@@ -253,7 +253,7 @@ impl ColumnAssertion<'_> {
 
     pub fn assert_full_data_type(&self, full_data_type: &str) -> &Self {
         assert_eq!(
-            self.column.column().tpe.full_data_type,
+            self.column.column_type().full_data_type,
             full_data_type,
             "assert_full_data_type() for {}",
             self.column.name()
@@ -304,12 +304,12 @@ impl IndexAssertion<'_> {
     }
 
     pub fn assert_is_unique(&self) -> &Self {
-        assert!(self.index.index_type().is_unique());
+        assert!(self.index.is_unique());
         self
     }
 
     pub fn assert_is_not_unique(&self) -> &Self {
-        assert!(!self.index.index_type().is_unique());
+        assert!(!self.index.is_unique());
         self
     }
 }

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/mssql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/mssql.rs
@@ -336,6 +336,12 @@ impl SqlFlavour for MssqlFlavour {
         })
     }
 
+    fn empty_database_schema(&self) -> SqlSchema {
+        let mut schema = SqlSchema::default();
+        schema.set_connector_data(Box::new(sql_schema_describer::mssql::MssqlSchemaExt::default()));
+        schema
+    }
+
     fn ensure_connection_validity(&mut self) -> BoxFuture<'_, ConnectorResult<()>> {
         self.raw_cmd("SELECT 1")
     }

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/postgres.rs
@@ -1,8 +1,6 @@
 mod shadow_db;
 
 use crate::{sql_renderer::IteratorJoin, SqlFlavour};
-#[allow(unused_imports)] // wtf, this one is unused on CI, not locally
-use datamodel::common::preview_features::PreviewFeature;
 use enumflags2::BitFlags;
 use indoc::indoc;
 use migration_connector::{
@@ -346,6 +344,12 @@ impl SqlFlavour for PostgresFlavour {
 
     fn drop_migrations_table(&mut self) -> BoxFuture<'_, ConnectorResult<()>> {
         Box::pin(self.raw_cmd("DROP TABLE _prisma_migrations"))
+    }
+
+    fn empty_database_schema(&self) -> SqlSchema {
+        let mut schema = SqlSchema::default();
+        schema.set_connector_data(Box::new(sql_schema_describer::postgres::PostgresSchemaExt::default()));
+        schema
     }
 
     fn ensure_connection_validity(&mut self) -> BoxFuture<'_, ConnectorResult<()>> {

--- a/migration-engine/connectors/sql-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/lib.rs
@@ -23,7 +23,7 @@ use flavour::{MssqlFlavour, MysqlFlavour, PostgresFlavour, SqlFlavour, SqliteFla
 use migration_connector::{migrations_directory::MigrationDirectory, *};
 use pair::Pair;
 use sql_migration::{DropUserDefinedType, DropView, SqlMigration, SqlMigrationStep};
-use sql_schema_describer::{self as describer, walkers::SqlSchemaExt, SqlSchema};
+use sql_schema_describer::{self as describer, walkers::SqlSchemaExt};
 use std::sync::Arc;
 
 /// The top-level SQL migration connector.
@@ -129,7 +129,7 @@ impl SqlMigrationConnector {
                 .await
                 .map(From::from),
             DiffTarget::Database => self.flavour.describe_schema().await.map(From::from),
-            DiffTarget::Empty => Ok(SqlDatabaseSchema::default()),
+            DiffTarget::Empty => Ok(self.flavour.empty_database_schema().into()),
         }
     }
 }
@@ -164,7 +164,7 @@ impl MigrationConnector for SqlMigrationConnector {
     }
 
     fn empty_database_schema(&self) -> DatabaseSchema {
-        SqlDatabaseSchema::default().into()
+        DatabaseSchema::new(SqlDatabaseSchema::from(self.flavour.empty_database_schema()))
     }
 
     fn ensure_connection_validity(&mut self) -> BoxFuture<'_, ConnectorResult<()>> {
@@ -298,7 +298,7 @@ async fn best_effort_reset_impl(flavour: &mut (dyn SqlFlavour + Send + Sync)) ->
     tracing::info!("Attempting best_effort_reset");
 
     let source_schema = flavour.describe_schema().await?;
-    let target_schema = SqlSchema::default();
+    let target_schema = flavour.empty_database_schema();
     let mut steps = Vec::new();
 
     // We drop views here, not in the normal migration process to not

--- a/migration-engine/connectors/sql-migration-connector/src/pair.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/pair.rs
@@ -1,8 +1,5 @@
 use crate::SqlDatabaseSchema;
-use sql_schema_describer::{
-    walkers::{ColumnWalker, EnumWalker, ForeignKeyWalker, IndexWalker, TableWalker},
-    ColumnId, EnumId, ForeignKeyId, IndexId, SqlSchema, TableId,
-};
+use sql_schema_describer::{walkers::Walker, SqlSchema};
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) struct Pair<T> {
@@ -48,13 +45,6 @@ impl<T> Pair<T> {
     pub(crate) fn zip<U>(self, other: Pair<U>) -> Pair<(T, U)> {
         Pair::new((self.previous, other.previous), (self.next, other.next))
     }
-
-    pub(crate) fn combine<U>(self, other: Pair<U>) -> Pair<(T, U)> {
-        Pair {
-            previous: (self.previous, other.previous),
-            next: (self.next, other.next),
-        }
-    }
 }
 
 impl<T> Pair<Option<T>> {
@@ -67,42 +57,20 @@ impl<T> Pair<Option<T>> {
 }
 
 impl<'a> Pair<&'a SqlDatabaseSchema> {
-    pub(crate) fn enums(&self, ids: Pair<EnumId>) -> Pair<EnumWalker<'a>> {
-        Pair::new(self.previous.walk(ids.previous), self.next.walk(ids.next))
-    }
-
-    pub(crate) fn tables(&self, table_ids: &Pair<TableId>) -> Pair<TableWalker<'a>> {
-        Pair::new(self.previous.walk(table_ids.previous), self.next.walk(table_ids.next))
-    }
-}
-
-impl<'a> Pair<&'a SqlDatabaseSchema> {
-    pub(crate) fn columns(&self, column_ids: Pair<ColumnId>) -> Pair<ColumnWalker<'a>> {
-        self.zip(column_ids).map(|(s, c)| s.describer_schema.walk(c))
+    pub(crate) fn walk<I>(self, ids: Pair<I>) -> Pair<Walker<'a, I>> {
+        self.zip(ids).map(|(schema, id)| schema.describer_schema.walk(id))
     }
 }
 
 impl<'a> Pair<&'a SqlSchema> {
-    pub(crate) fn enums(self, ids: Pair<EnumId>) -> Pair<EnumWalker<'a>> {
-        Pair::new(self.previous.walk(ids.previous), self.next.walk(ids.next))
-    }
-
-    pub(crate) fn tables(self, table_ids: Pair<TableId>) -> Pair<TableWalker<'a>> {
-        self.zip(table_ids).map(|(s, t)| s.walk(t))
-    }
-
-    pub(crate) fn columns(self, column_ids: Pair<ColumnId>) -> Pair<ColumnWalker<'a>> {
-        self.zip(column_ids).map(|(s, c)| s.walk(c))
-    }
-
-    pub(crate) fn foreign_keys(self, fk_ids: Pair<ForeignKeyId>) -> Pair<ForeignKeyWalker<'a>> {
-        self.zip(fk_ids).map(|(s, id)| s.walk(id))
+    pub(crate) fn walk<I>(self, ids: Pair<I>) -> Pair<Walker<'a, I>> {
+        self.zip(ids).map(|(schema, id)| schema.walk(id))
     }
 }
 
-impl<'a> Pair<TableWalker<'a>> {
-    pub(crate) fn indexes(&self, index_indexes: &Pair<IndexId>) -> Pair<IndexWalker<'a>> {
-        self.as_ref().zip(index_indexes.as_ref()).map(|(t, i)| t.index_at(*i))
+impl<'a, T> Pair<Walker<'a, T>> {
+    pub(crate) fn walk<I>(self, ids: Pair<I>) -> Pair<Walker<'a, I>> {
+        self.zip(ids).map(|(w, id)| w.walk(id))
     }
 }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
@@ -17,7 +17,7 @@ use std::borrow::Cow;
 
 impl PostgresFlavour {
     fn render_column(&self, column: ColumnWalker<'_>) -> String {
-        let column_name = self.quote(column.name());
+        let column_name = Quoted::postgres_ident(column.name());
         let tpe_str = render_column_type(column, self);
         let nullability_str = render_nullability(column);
         let default_str = column
@@ -40,9 +40,9 @@ impl SqlRenderer for PostgresFlavour {
         changes: SequenceChanges,
         schemas: Pair<&SqlSchema>,
     ) -> Vec<String> {
-        let exts: Pair<&PostgresSchemaExt> = schemas.map(|schema| schema.downcast_connector_data().unwrap_or_default());
+        let exts: Pair<&PostgresSchemaExt> = schemas.map(|schema| schema.downcast_connector_data());
         let (prev_seq, next_seq) = exts
-            .combine(sequence_idx)
+            .zip(sequence_idx)
             .map(|(ext, idx)| &ext.sequences[idx as usize])
             .into_tuple();
         render_step(&mut |step| {
@@ -158,39 +158,21 @@ impl SqlRenderer for PostgresFlavour {
         let mut lines = Vec::new();
         let mut before_statements = Vec::new();
         let mut after_statements = Vec::new();
-        let tables = schemas.tables(*table_ids);
+        let tables = schemas.walk(*table_ids);
 
         for change in changes {
             match change {
                 TableChange::DropPrimaryKey => lines.push(format!(
                     "DROP CONSTRAINT {}",
-                    Quoted::postgres_ident(
-                        tables
-                            .previous
-                            .primary_key()
-                            .and_then(|pk| pk.constraint_name.as_ref())
-                            .expect("Missing constraint name for DROP CONSTRAINT on Postgres.")
-                    )
+                    Quoted::postgres_ident(tables.previous.primary_key().unwrap().name())
                 )),
                 TableChange::RenamePrimaryKey => lines.push(format!(
                     "RENAME CONSTRAINT {} TO {}",
-                    Quoted::postgres_ident(
-                        tables
-                            .previous
-                            .primary_key()
-                            .and_then(|pk| pk.constraint_name.as_ref())
-                            .expect("Missing constraint name for DROP CONSTRAINT on Postgres.")
-                    ),
-                    Quoted::postgres_ident(
-                        tables
-                            .next
-                            .primary_key()
-                            .and_then(|pk| pk.constraint_name.as_ref())
-                            .expect("Missing constraint name for DROP CONSTRAINT on Postgres.")
-                    )
+                    Quoted::postgres_ident(tables.previous.primary_key().unwrap().name()),
+                    Quoted::postgres_ident(tables.next.primary_key().unwrap().name())
                 )),
                 TableChange::AddPrimaryKey => lines.push({
-                    let named = match tables.next.primary_key().and_then(|pk| pk.constraint_name.as_ref()) {
+                    let named = match tables.next.primary_key().map(|pk| pk.name()) {
                         Some(name) => format!("CONSTRAINT {} ", self.quote(name)),
                         None => "".into(),
                     };
@@ -200,10 +182,9 @@ impl SqlRenderer for PostgresFlavour {
                         named,
                         tables
                             .next
-                            .primary_key_column_names()
+                            .primary_key_columns()
                             .unwrap()
-                            .iter()
-                            .map(|colname| self.quote(colname))
+                            .map(|col| self.quote(col.name()))
                             .join(", ")
                     )
                 }),
@@ -225,7 +206,7 @@ impl SqlRenderer for PostgresFlavour {
                     changes,
                     type_change: _,
                 }) => {
-                    let columns = schemas.columns(*column_id);
+                    let columns = schemas.walk(*column_id);
 
                     render_alter_column(
                         columns,
@@ -237,7 +218,7 @@ impl SqlRenderer for PostgresFlavour {
                     );
                 }
                 TableChange::DropAndRecreateColumn { column_id, changes: _ } => {
-                    let columns = schemas.columns(*column_id);
+                    let columns = schemas.walk(*column_id);
                     let name = self.quote(columns.previous.name());
 
                     lines.push(format!("DROP COLUMN {}", name));
@@ -287,11 +268,11 @@ impl SqlRenderer for PostgresFlavour {
     }
 
     fn render_create_index(&self, index: IndexWalker<'_>) -> String {
-        let pg_ext: &PostgresSchemaExt = index.schema.downcast_connector_data().unwrap_or_default();
+        let pg_ext: &PostgresSchemaExt = index.schema.downcast_connector_data();
 
         ddl::CreateIndex {
             index_name: index.name().into(),
-            is_unique: index.index_type().is_unique(),
+            is_unique: index.is_unique(),
             table_reference: index.table().name().into(),
             using: Some(match pg_ext.index_algorithm(index.id) {
                 SqlIndexAlgorithm::BTree => ddl::IndexAlgorithm::BTree,
@@ -310,7 +291,7 @@ impl SqlRenderer for PostgresFlavour {
                         SQLSortOrder::Asc => SortOrder::Asc,
                         SQLSortOrder::Desc => SortOrder::Desc,
                     }),
-                    operator_class: pg_ext.get_opclass(c.index_field_id()).map(|c| c.kind.as_ref().into()),
+                    operator_class: pg_ext.get_opclass(c.id).map(|c| c.kind.as_ref().into()),
                 })
                 .collect(),
         }
@@ -321,16 +302,13 @@ impl SqlRenderer for PostgresFlavour {
         let columns: String = table.columns().map(|column| self.render_column(column)).join(",\n");
 
         let pk = if let Some(pk) = table.primary_key() {
-            let named_constraint = match &pk.constraint_name {
-                Some(name) => format!("CONSTRAINT {} ", self.quote(name)),
-                None => "".into(),
-            };
+            let named_constraint = format!("CONSTRAINT {} ", Quoted::postgres_ident(pk.name()));
 
             format!(
                 ",\n\n{}{}PRIMARY KEY ({})",
                 SQL_INDENTATION,
                 named_constraint,
-                pk.columns.as_slice().iter().map(|col| self.quote(col.name())).join(",")
+                pk.columns().map(|col| Quoted::postgres_ident(col.name())).join(",")
             )
         } else {
             String::new()
@@ -391,20 +369,20 @@ impl SqlRenderer for PostgresFlavour {
         let mut result = Vec::new();
 
         for redefine_table in tables {
-            let tables = schemas.tables(redefine_table.table_ids);
+            let tables = schemas.walk(redefine_table.table_ids);
             let temporary_table_name = format!("_prisma_new_{}", &tables.next.name());
             result.push(self.render_create_table_as(tables.next, &temporary_table_name));
 
             let columns: Vec<_> = redefine_table
                 .column_pairs
                 .iter()
-                .map(|(column_ids, _, _)| schemas.columns(*column_ids).next.name())
-                .map(|c| self.quote(c).to_string())
+                .map(|(column_ids, _, _)| schemas.walk(*column_ids).next.name())
+                .map(|c| Quoted::postgres_ident(c).to_string())
                 .collect();
 
             let table = tables.previous.name();
 
-            for index in tables.previous.indexes() {
+            for index in tables.previous.indexes().filter(|idx| !idx.is_primary_key()) {
                 result.push(self.render_drop_index(index));
             }
 
@@ -425,7 +403,7 @@ impl SqlRenderer for PostgresFlavour {
 
             result.push(self.render_rename_table(&temporary_table_name, tables.next.name()));
 
-            for index in tables.next.indexes() {
+            for index in tables.next.indexes().filter(|idx| !idx.is_primary_key()) {
                 result.push(self.render_create_index(index));
             }
 
@@ -801,7 +779,7 @@ fn render_postgres_alter_enum(alter_enum: &AlterEnum, schemas: Pair<&SqlSchema>)
             .map(|created_value| {
                 format!(
                     "ALTER TYPE {enum_name} ADD VALUE {value}",
-                    enum_name = Quoted::postgres_ident(schemas.enums(alter_enum.id).previous.name()),
+                    enum_name = Quoted::postgres_ident(schemas.walk(alter_enum.id).previous.name()),
                     value = Quoted::postgres_string(created_value)
                 )
             })
@@ -824,7 +802,7 @@ fn render_postgres_alter_enum(alter_enum: &AlterEnum, schemas: Pair<&SqlSchema>)
         return stmts;
     }
 
-    let enums = schemas.enums(alter_enum.id);
+    let enums = schemas.walk(alter_enum.id);
 
     let mut stmts = Vec::with_capacity(10);
 
@@ -919,7 +897,7 @@ fn render_postgres_alter_enum(alter_enum: &AlterEnum, schemas: Pair<&SqlSchema>)
             .iter()
             .filter_map(|(prev, next)| next.map(|next| (prev, next)))
         {
-            let columns = schemas.columns(Pair::new(*prev_colidx, next_colidx));
+            let columns = schemas.walk(Pair::new(*prev_colidx, next_colidx));
             let table_name = columns.previous.table().name();
             let column_name = columns.previous.name();
             let default_str = columns
@@ -946,7 +924,7 @@ fn render_postgres_alter_enum(alter_enum: &AlterEnum, schemas: Pair<&SqlSchema>)
 }
 
 fn render_cockroach_alter_enum(alter_enum: &AlterEnum, schemas: Pair<&SqlSchema>, renderer: &mut StepRenderer) {
-    let enums = schemas.enums(alter_enum.id);
+    let enums = schemas.walk(alter_enum.id);
     let mut prefix = String::new();
     prefix.push_str("ALTER TYPE \"");
     prefix.push_str(enums.previous.name());
@@ -1000,7 +978,7 @@ fn render_column_identity_str(column: ColumnWalker<'_>, flavour: &PostgresFlavou
     }
 
     let sequence = if let Some(seq_name) = column.default().and_then(|d| d.as_sequence()) {
-        let connector_data: &PostgresSchemaExt = column.schema.downcast_connector_data().unwrap_or_default();
+        let connector_data: &PostgresSchemaExt = column.schema.downcast_connector_data();
         connector_data
             .sequences
             .iter()

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
@@ -22,17 +22,12 @@ impl SqlRenderer for SqliteFlavour {
     }
 
     fn render_create_index(&self, index: IndexWalker<'_>) -> String {
-        let index_type = match index.index_type() {
-            IndexType::Unique => "UNIQUE ",
-            IndexType::Normal => "",
-            IndexType::Fulltext => unreachable!("Fulltext index on SQLite"),
-        };
-
-        let index_name = self.quote(index.name());
-        let table_reference = self.quote(index.table().name());
+        let index_type = if index.is_unique() { "UNIQUE " } else { "" };
+        let index_name = Quoted::sqlite_ident(index.name());
+        let table_reference = Quoted::sqlite_ident(index.table().name());
 
         let columns = index.columns().map(|c| {
-            let mut rendered = format!("{}", self.quote(c.get().name()));
+            let mut rendered = format!("{}", self.quote(c.as_column().name()));
 
             if let Some(sort_order) = c.sort_order() {
                 rendered.push(' ');
@@ -67,13 +62,8 @@ impl SqlRenderer for SqliteFlavour {
     }
 
     fn render_alter_table(&self, alter_table: &AlterTable, schemas: Pair<&SqlSchema>) -> Vec<String> {
-        let AlterTable {
-            changes,
-            table_ids: table_index,
-        } = alter_table;
-
-        let tables = schemas.tables(*table_index);
-
+        let AlterTable { changes, table_ids } = alter_table;
+        let tables = schemas.walk(*table_ids);
         let mut statements = Vec::new();
 
         // See https://www.sqlite.org/lang_altertable.html for the reference on
@@ -144,8 +134,8 @@ impl SqlRenderer for SqliteFlavour {
 
         if !table.columns().any(|col| col.is_single_primary_key()) {
             create_table.primary_key = table
-                .primary_key_column_names()
-                .map(|v| v.into_iter().map(|name| name.into()).collect());
+                .primary_key_columns()
+                .map(|c| c.map(|c| c.name().into()).collect());
         }
 
         create_table.to_string()
@@ -194,7 +184,7 @@ impl SqlRenderer for SqliteFlavour {
         let mut result = vec!["PRAGMA foreign_keys=OFF".to_string()];
 
         for redefine_table in tables {
-            let tables = schemas.tables(redefine_table.table_ids);
+            let tables = schemas.walk(redefine_table.table_ids);
             let temporary_table_name = format!("new_{}", &tables.next.name());
 
             result.push(self.render_create_table_as(tables.next, &temporary_table_name));
@@ -209,7 +199,7 @@ impl SqlRenderer for SqliteFlavour {
                 new_name = tables.next.name(),
             ));
 
-            for index in tables.next.indexes() {
+            for index in tables.next.indexes().filter(|idx| !idx.is_primary_key()) {
                 result.push(self.render_create_index(index));
             }
         }
@@ -281,7 +271,7 @@ fn copy_current_table_into_new_table(
         .map(|(column_ids, _, _)| tables.next.walk(column_ids.next).name());
 
     let source_columns = redefine_table.column_pairs.iter().map(|(column_ides, changes, _)| {
-        let columns = tables.map(|t| t.schema).columns(*column_ides);
+        let columns = tables.map(|t| t.schema).walk(*column_ides);
 
         let col_became_required_with_a_default =
             changes.arity_changed() && columns.next.arity().is_required() && columns.next.default().is_some();

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
@@ -6,7 +6,11 @@ use crate::{flavour::SqlFlavour, SqlDatabaseSchema};
 use datamodel::{
     datamodel_connector::{walker_ext_traits::*, ReferentialAction, ScalarType},
     dml::{prisma_value, PrismaValue},
-    parser_database::{ast, walkers::ScalarFieldWalker, IndexType, ScalarFieldType, SortOrder},
+    parser_database::{
+        ast,
+        walkers::{ModelWalker, ScalarFieldWalker},
+        ScalarFieldType, SortOrder,
+    },
     ValidatedSchema,
 };
 use sql_schema_describer as sql;
@@ -41,56 +45,69 @@ fn push_model_tables(ctx: &mut Context<'_>) {
     for model in ctx.datamodel.db.walk_models() {
         let table_id = ctx.schema.describer_schema.push_table(model.database_name().to_owned());
         ctx.model_id_to_table_id.insert(model.model_id(), table_id);
-        let table = &mut ctx.schema.describer_schema[table_id];
-
-        table.primary_key = model.primary_key().map(|pk| sql::PrimaryKey {
-            columns: pk
-                .scalar_field_attributes()
-                .map(|field| sql::PrimaryKeyColumn {
-                    name: field.as_index_field().database_name().to_owned(),
-                    length: field.length(),
-                    sort_order: field.sort_order().map(|so| match so {
-                        SortOrder::Asc => sql::SQLSortOrder::Asc,
-                        SortOrder::Desc => sql::SQLSortOrder::Desc,
-                    }),
-                })
-                .collect(),
-            constraint_name: pk
-                .constraint_name(ctx.flavour.datamodel_connector())
-                .map(|c| c.into_owned()),
-        });
-
-        table.indices = model
-            .indexes()
-            .map(|index| {
-                let columns = index
-                    .scalar_field_attributes()
-                    .map(|sf| sql::IndexColumn {
-                        name: sf.as_index_field().database_name().to_owned(),
-                        sort_order: sf.sort_order().map(|s| match s {
-                            SortOrder::Asc => sql::SQLSortOrder::Asc,
-                            SortOrder::Desc => sql::SQLSortOrder::Desc,
-                        }),
-                        length: sf.length(),
-                    })
-                    .collect();
-
-                let index_type = match index.index_type() {
-                    IndexType::Unique => sql::IndexType::Unique,
-                    IndexType::Normal => sql::IndexType::Normal,
-                    IndexType::Fulltext => sql::IndexType::Fulltext,
-                };
-
-                sql::Index {
-                    name: index.constraint_name(ctx.flavour.datamodel_connector()).into_owned(),
-                    columns,
-                    tpe: index_type,
-                }
-            })
-            .collect();
 
         for field in model.scalar_fields() {
             push_column_for_scalar_field(field, table_id, ctx);
+        }
+
+        push_model_indexes(model, table_id, ctx);
+    }
+}
+
+fn push_model_indexes(model: ModelWalker<'_>, table_id: sql::TableId, ctx: &mut Context<'_>) {
+    if let Some(pk) = model.primary_key() {
+        let constraint_name = pk
+            .constraint_name(ctx.flavour.datamodel_connector())
+            .map(String::from)
+            .unwrap_or_else(String::new);
+        let pkid = ctx.schema.describer_schema.push_primary_key(table_id, constraint_name);
+        for field in pk.scalar_field_attributes() {
+            let column_id = ctx
+                .walk(table_id)
+                .column(field.as_index_field().database_name())
+                .unwrap()
+                .id;
+            ctx.schema.describer_schema.push_index_column(sql::IndexColumn {
+                index_id: pkid,
+                column_id,
+                sort_order: field.sort_order().map(|so| match so {
+                    SortOrder::Asc => sql::SQLSortOrder::Asc,
+                    SortOrder::Desc => sql::SQLSortOrder::Desc,
+                }),
+                length: field.length(),
+            });
+        }
+    }
+
+    for index in model.indexes() {
+        let constraint_name = index.constraint_name(ctx.flavour.datamodel_connector()).into_owned();
+        let index_id = if index.is_unique() {
+            ctx.schema
+                .describer_schema
+                .push_unique_constraint(table_id, constraint_name)
+        } else if index.is_fulltext() {
+            ctx.schema
+                .describer_schema
+                .push_fulltext_index(table_id, constraint_name)
+        } else {
+            ctx.schema.describer_schema.push_index(table_id, constraint_name)
+        };
+
+        for sf in index.scalar_field_attributes() {
+            let column_id = ctx
+                .walk(table_id)
+                .column(sf.as_index_field().database_name())
+                .unwrap()
+                .id;
+            ctx.schema.describer_schema.push_index_column(sql::IndexColumn {
+                index_id,
+                column_id,
+                sort_order: sf.sort_order().map(|s| match s {
+                    SortOrder::Asc => sql::SQLSortOrder::Asc,
+                    SortOrder::Desc => sql::SQLSortOrder::Desc,
+                }),
+                length: sf.length(),
+            });
         }
     }
 }
@@ -180,10 +197,11 @@ fn push_relation_tables(ctx: &mut Context<'_>) {
             format!("{table_name}_B{fk_suffix}")
         };
 
-        let table_id = ctx.schema.describer_schema.push_table(table_name);
+        let table_id = ctx.schema.describer_schema.push_table(table_name.clone());
         let column_a_type = ctx
             .walk(model_a_table_id)
             .primary_key_columns()
+            .unwrap()
             .next()
             .unwrap()
             .as_column()
@@ -192,6 +210,7 @@ fn push_relation_tables(ctx: &mut Context<'_>) {
         let column_b_type = ctx
             .walk(model_b_table_id)
             .primary_key_columns()
+            .unwrap()
             .next()
             .unwrap()
             .as_column()
@@ -217,29 +236,40 @@ fn push_relation_tables(ctx: &mut Context<'_>) {
             },
         );
 
+        // Unique index on AB
         {
-            let mut table = &mut ctx.schema.describer_schema[table_id];
-            table.indices = vec![
-                sql::Index {
-                    name: format!(
-                        "{}_AB_unique",
-                        table.name.chars().take(max_identifier_length - 10).collect::<String>()
-                    ),
-                    columns: vec![
-                        sql::IndexColumn::new(model_a_column),
-                        sql::IndexColumn::new(model_b_column),
-                    ],
-                    tpe: sql::IndexType::Unique,
-                },
-                sql::Index {
-                    name: format!(
-                        "{}_B_index",
-                        table.name.chars().take(max_identifier_length - 8).collect::<String>()
-                    ),
-                    columns: vec![sql::IndexColumn::new(model_b_column)],
-                    tpe: sql::IndexType::Normal,
-                },
-            ];
+            let index_name = format!(
+                "{}_AB_unique",
+                table_name.chars().take(max_identifier_length - 10).collect::<String>()
+            );
+            let index_id = ctx.schema.describer_schema.push_unique_constraint(table_id, index_name);
+            ctx.schema.describer_schema.push_index_column(sql::IndexColumn {
+                index_id,
+                column_id: column_a_id,
+                sort_order: None,
+                length: None,
+            });
+            ctx.schema.describer_schema.push_index_column(sql::IndexColumn {
+                index_id,
+                column_id: column_b_id,
+                sort_order: None,
+                length: None,
+            });
+        }
+
+        // Index on B
+        {
+            let index_name = format!(
+                "{}_B_index",
+                table_name.chars().take(max_identifier_length - 8).collect::<String>()
+            );
+            let index_id = ctx.schema.describer_schema.push_index(table_id, index_name);
+            ctx.schema.describer_schema.push_index_column(sql::IndexColumn {
+                index_id,
+                column_id: column_b_id,
+                sort_order: None,
+                length: None,
+            });
         }
 
         if ctx.datamodel.referential_integrity().uses_foreign_keys() {
@@ -399,11 +429,59 @@ fn push_column_for_builtin_scalar_type(
         .map(|instance| instance.serialized_native_type)
         .unwrap_or_else(|| connector.default_native_type_for_scalar_type(&scalar_type));
 
+    enum ColumnDefault {
+        Available(sql::DefaultValue),
+        PrismaGenerated,
+        NA,
+    }
+
+    let default: Option<ColumnDefault> = field.default_value().map(|v| {
+        let column_default = {
+            if v.is_dbgenerated() {
+                unwrap_dbgenerated(v.value())
+                    .map(|v| ColumnDefault::Available(sql::DefaultValue::new(sql::DefaultKind::DbGenerated(v))))
+                    .unwrap_or(ColumnDefault::NA)
+            } else if v.is_now() {
+                ColumnDefault::Available(sql::DefaultValue::now())
+            } else if v.is_autoincrement() {
+                ctx.flavour
+                    .column_default_value_for_autoincrement()
+                    .map(ColumnDefault::Available)
+                    .unwrap_or(ColumnDefault::NA)
+            } else if v.is_sequence() {
+                ColumnDefault::Available(sql::DefaultValue::new(sql::DefaultKind::Sequence(format!(
+                    "prisma_sequence_{}_{}",
+                    field.model().database_name(),
+                    field.database_name()
+                ))))
+            } else {
+                match v.value() {
+                    ast::Expression::Function(_, _, _) => ColumnDefault::PrismaGenerated,
+                    constant => ColumnDefault::Available(sql::DefaultValue::new(sql::DefaultKind::Value(
+                        constant_expression_to_sql_default(constant, scalar_type),
+                    ))),
+                }
+            }
+        };
+        match column_default {
+            ColumnDefault::Available(df) => {
+                ColumnDefault::Available(df.with_constraint_name(ctx.flavour.default_constraint_name(v)))
+            }
+            other => other,
+        }
+    });
+
+    let default_is_prisma_level = matches!(default, Some(ColumnDefault::PrismaGenerated));
     let column_id = ctx.schema.describer_schema.push_column(
         table_id,
         sql::Column {
             name: field.database_name().to_owned(),
-            default: None,
+            default: if let Some(ColumnDefault::Available(d)) = default {
+                Some(d)
+            } else {
+                None
+            },
+
             tpe: sql::ColumnType {
                 family,
                 full_data_type: String::new(),
@@ -414,36 +492,8 @@ fn push_column_for_builtin_scalar_type(
         },
     );
 
-    if let Some(v) = field.default_value() {
-        let default_value = {
-            if v.is_dbgenerated() {
-                unwrap_dbgenerated(v.value()).map(|v| sql::DefaultValue::new(sql::DefaultKind::DbGenerated(v)))
-            } else if v.is_now() {
-                Some(sql::DefaultValue::now())
-            } else if v.is_autoincrement() {
-                ctx.flavour.column_default_value_for_autoincrement()
-            } else if v.is_sequence() {
-                Some(sql::DefaultValue::new(sql::DefaultKind::Sequence(format!(
-                    "prisma_sequence_{}_{}",
-                    field.model().database_name(),
-                    field.database_name()
-                ))))
-            } else {
-                match v.value() {
-                    ast::Expression::Function(_, _, _) => {
-                        // prisma-generated
-                        ctx.schema.prisma_level_defaults.push(column_id);
-                        return;
-                    }
-                    constant => Some(sql::DefaultValue::new(sql::DefaultKind::Value(
-                        constant_expression_to_sql_default(constant, scalar_type),
-                    ))),
-                }
-            }
-        };
-
-        let (_, column) = &mut ctx.schema.describer_schema[column_id];
-        column.default = default_value.map(|df| df.with_constraint_name(ctx.flavour.default_constraint_name(v)));
+    if default_is_prisma_level {
+        ctx.schema.prisma_level_defaults.push(column_id);
     }
 }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/mssql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/mssql.rs
@@ -1,7 +1,14 @@
-use super::SqlSchemaCalculatorFlavour;
 use crate::flavour::{MssqlFlavour, SqlFlavour};
-use datamodel::{datamodel_connector::walker_ext_traits::DefaultValueExt, parser_database::walkers::*};
-use sql_schema_describer::{mssql::MssqlSchemaExt, ForeignKeyAction};
+use datamodel::{
+    datamodel_connector::walker_ext_traits::{DefaultValueExt, IndexWalkerExt},
+    parser_database::walkers::*,
+};
+use sql_schema_describer::{
+    mssql::{IndexBits, MssqlSchemaExt},
+    ForeignKeyAction,
+};
+
+use super::SqlSchemaCalculatorFlavour;
 
 impl SqlSchemaCalculatorFlavour for MssqlFlavour {
     fn default_constraint_name(&self, default_value: DefaultValueWalker<'_>) -> Option<String> {
@@ -20,16 +27,25 @@ impl SqlSchemaCalculatorFlavour for MssqlFlavour {
     fn push_connector_data(&self, context: &mut super::super::Context<'_>) {
         let mut data = MssqlSchemaExt::default();
 
-        for (table_idx, model) in context.datamodel.db.walk_models().enumerate() {
-            let table_id = sql_schema_describer::TableId(table_idx as u32);
-            if model.primary_key().and_then(|pk| pk.clustered()) == Some(false) {
-                data.nonclustered_primary_keys.push(table_id);
+        for model in context.datamodel.db.walk_models() {
+            let table_id = context.model_id_to_table_id[&model.model_id()];
+            let table = context.schema.walk(table_id);
+            if model
+                .primary_key()
+                .map(|pk| pk.clustered().is_none() || pk.clustered() == Some(true))
+                .unwrap_or(false)
+            {
+                *data.index_bits.entry(table.primary_key().unwrap().id).or_default() |= IndexBits::Clustered;
             }
 
-            for (index_index, index) in model.indexes().enumerate() {
+            for index in model.indexes() {
+                let sql_index = table
+                    .indexes()
+                    .find(|idx| idx.name() == index.constraint_name(self.datamodel_connector()))
+                    .unwrap();
+
                 if index.clustered() == Some(true) {
-                    data.clustered_indexes
-                        .push(sql_schema_describer::IndexId(table_id, index_index as u32))
+                    *data.index_bits.entry(sql_index.id).or_default() |= IndexBits::Clustered;
                 }
             }
         }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
@@ -16,7 +16,7 @@ use crate::{
     SqlFlavour,
 };
 use column::ColumnTypeChange;
-use sql_schema_describer::{walkers::ForeignKeyWalker, ColumnId, IndexId, TableId};
+use sql_schema_describer::{walkers::ForeignKeyWalker, ColumnId, IndexId};
 use std::collections::HashSet;
 use table::TableDiffer;
 
@@ -52,7 +52,7 @@ fn push_created_table_steps(steps: &mut Vec<SqlMigrationStep>, db: &DifferDataba
         if db.flavour.should_create_indexes_from_created_tables() {
             let create_indexes_from_created_tables = table
                 .indexes()
-                .filter(|index| !db.flavour.should_skip_index_for_new_table(*index))
+                .filter(|index| !index.is_primary_key() && !db.flavour.should_skip_index_for_new_table(*index))
                 .map(|index| SqlMigrationStep::CreateIndex {
                     table_id: (None, index.table().id),
                     index_id: index.id,
@@ -107,13 +107,12 @@ fn push_altered_table_steps(steps: &mut Vec<SqlMigrationStep>, db: &DifferDataba
             .index_pairs()
             .filter(|pair| db.flavour.index_should_be_renamed(*pair))
         {
-            let table: Pair<TableId> = table.tables.map(|t| t.id);
             let index: Pair<IndexId> = i.map(|i| i.id);
 
             let step = if db.flavour.can_rename_index() {
-                SqlMigrationStep::RenameIndex { table, index }
+                SqlMigrationStep::RenameIndex { index }
             } else {
-                SqlMigrationStep::RedefineIndex { table, index }
+                SqlMigrationStep::RedefineIndex { index }
             };
 
             steps.push(step);
@@ -225,7 +224,6 @@ fn added_primary_key(differ: &TableDiffer<'_, '_>) -> Option<TableChange> {
 
     let from_psl_change = differ
         .created_primary_key()
-        .filter(|pk| !pk.columns.is_empty())
         .map(|_| TableChange::AddPrimaryKey)
         .or_else(|| Some(TableChange::AddPrimaryKey).filter(|_| differ.primary_key_changed()));
 
@@ -289,7 +287,7 @@ fn dropped_primary_key(differ: &TableDiffer<'_, '_>) -> Option<TableChange> {
 fn renamed_primary_key(differ: &TableDiffer<'_, '_>) -> Option<TableChange> {
     differ
         .tables
-        .map(|pk| pk.primary_key().and_then(|pk| pk.constraint_name.as_ref()))
+        .map(|pk| pk.primary_key().map(|pk| pk.name()))
         .transpose()
         .filter(|names| names.previous != names.next)
         .map(|_| TableChange::RenamePrimaryKey)
@@ -363,7 +361,7 @@ fn push_dropped_index_steps(steps: &mut Vec<SqlMigrationStep>, db: &DifferDataba
                 continue;
             }
 
-            drop_indexes.insert((index.table().id, index.id));
+            drop_indexes.insert(index.id);
         }
     }
 
@@ -371,14 +369,14 @@ fn push_dropped_index_steps(steps: &mut Vec<SqlMigrationStep>, db: &DifferDataba
     // because they are needed for implementing new foreign key constraints.
     if !db.tables_to_redefine.is_empty() && db.flavour.should_drop_indexes_from_dropped_tables() {
         for table in db.dropped_tables() {
-            for index in table.indexes() {
-                drop_indexes.insert((index.table().id, index.id));
+            for index in table.indexes().filter(|idx| !idx.is_primary_key()) {
+                drop_indexes.insert(index.id);
             }
         }
     }
 
-    for (table_id, index_id) in drop_indexes.into_iter() {
-        steps.push(SqlMigrationStep::DropIndex { table_id, index_id })
+    for index_id in drop_indexes.into_iter() {
+        steps.push(SqlMigrationStep::DropIndex { index_id })
     }
 }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/differ_database.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/differ_database.rs
@@ -79,7 +79,7 @@ impl<'a> DifferDatabase<'a> {
             // Deal with tables that are both in the previous and the next
             // schema: we are going to look at heir columns.
             if let Some(table_pair) = entry.transpose() {
-                let tables = schemas.tables(&table_pair);
+                let tables = schemas.walk(table_pair);
 
                 columns_cache.clear();
 
@@ -99,7 +99,7 @@ impl<'a> DifferDatabase<'a> {
                     db.columns.insert((table_pair, column_name), *column_ids);
 
                     if let Some(column_ids) = column_ids.transpose() {
-                        let column_walkers = schemas.columns(column_ids);
+                        let column_walkers = schemas.walk(column_ids);
                         let changes = column::all_changes(column_walkers, flavour);
                         db.column_changes.insert(column_ids, changes);
                     }
@@ -112,10 +112,8 @@ impl<'a> DifferDatabase<'a> {
         db
     }
 
-    pub(crate) fn all_column_pairs(&self) -> impl Iterator<Item = Pair<(TableId, ColumnId)>> + '_ {
-        self.columns
-            .iter()
-            .filter_map(|((tables, _), cols)| cols.transpose().map(|cols| tables.combine(cols)))
+    pub(crate) fn all_column_pairs(&self) -> impl Iterator<Item = Pair<ColumnId>> + '_ {
+        self.columns.iter().filter_map(|(_, cols)| cols.transpose())
     }
 
     pub(crate) fn column_pairs(&self, table: Pair<TableId>) -> impl Iterator<Item = Pair<ColumnId>> + '_ {
@@ -173,7 +171,7 @@ impl<'a> DifferDatabase<'a> {
             .values()
             .filter_map(|p| p.transpose())
             .map(move |table_ids| TableDiffer {
-                tables: self.schemas.tables(&table_ids),
+                tables: self.schemas.walk(table_ids),
                 db: self,
             })
     }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/postgres.rs
@@ -93,19 +93,16 @@ impl SqlSchemaDifferFlavour for PostgresFlavour {
             return;
         }
 
-        let schemas: Pair<(&SqlDatabaseSchema, &PostgresSchemaExt)> = db.schemas().map(|schema| {
-            (
-                schema,
-                schema.describer_schema.downcast_connector_data().unwrap_or_default(),
-            )
-        });
+        let schemas: Pair<(&SqlDatabaseSchema, &PostgresSchemaExt)> = db
+            .schemas()
+            .map(|schema| (schema, schema.describer_schema.downcast_connector_data()));
 
         let sequence_pairs = db
             .all_column_pairs()
             .map(|cols| {
                 schemas
-                    .combine(cols)
-                    .map(|((schema, ext), (_table_id, column_id))| (schema.walk(column_id), ext))
+                    .zip(cols)
+                    .map(|((schema, ext), column_id)| (schema.walk(column_id), ext))
             })
             .filter_map(|cols| {
                 cols.map(|(col, ext)| {
@@ -154,8 +151,8 @@ impl SqlSchemaDifferFlavour for PostgresFlavour {
         let columns_previous = a.columns();
         let columns_next = b.columns();
 
-        let pg_ext_previous: &PostgresSchemaExt = a.schema.downcast_connector_data().unwrap_or_default();
-        let pg_ext_next: &PostgresSchemaExt = b.schema.downcast_connector_data().unwrap_or_default();
+        let pg_ext_previous: &PostgresSchemaExt = a.schema.downcast_connector_data();
+        let pg_ext_next: &PostgresSchemaExt = b.schema.downcast_connector_data();
 
         let previous_algo = pg_ext_previous.index_algorithm(a.id);
         let next_algo = pg_ext_next.index_algorithm(b.id);
@@ -163,8 +160,8 @@ impl SqlSchemaDifferFlavour for PostgresFlavour {
         columns_previous.len() == columns_next.len()
             && previous_algo == next_algo
             && columns_previous.zip(columns_next).all(|(col_a, col_b)| {
-                let a_class = pg_ext_previous.get_opclass(col_a.index_field_id());
-                let b_class = pg_ext_next.get_opclass(col_b.index_field_id());
+                let a_class = pg_ext_previous.get_opclass(col_a.id);
+                let b_class = pg_ext_next.get_opclass(col_b.id);
                 let a_kind = a_class.map(|c| &c.kind);
                 let b_kind = b_class.map(|c| &c.kind);
                 let a_is_default = a_class.map(|c| c.is_default).unwrap_or(false);
@@ -617,7 +614,7 @@ fn postgres_native_type_change_riskyness(previous: PostgresType, next: PostgresT
 fn push_alter_enum_previous_usages_as_default(db: &DifferDatabase<'_>, alter_enum: &mut AlterEnum) {
     let mut previous_usages_as_default: Vec<(_, Option<_>)> = Vec::new();
 
-    let enum_names = db.schemas().enums(alter_enum.id).map(|enm| enm.name());
+    let enum_names = db.schemas().walk(alter_enum.id).map(|enm| enm.name());
 
     for table in db.dropped_tables() {
         for column in table

--- a/migration-engine/migration-engine-tests/src/assertions.rs
+++ b/migration-engine/migration-engine-tests/src/assertions.rs
@@ -10,13 +10,11 @@ use prisma_value::PrismaValue;
 use sql::{
     postgres::PostgresSchemaExt,
     walkers::{ColumnWalker, ForeignKeyWalker, IndexWalker, TableWalker},
-    IndexFieldId,
 };
 use sql_schema_describer::{
     self as sql,
     postgres::{SQLOperatorClassKind, SqlIndexAlgorithm},
-    ColumnTypeFamily, DefaultKind, DefaultValue, Enum, ForeignKeyAction, IndexType, PrimaryKey, SQLSortOrder,
-    SqlSchema,
+    ColumnTypeFamily, DefaultKind, DefaultValue, Enum, ForeignKeyAction, IndexType, SQLSortOrder, SqlSchema,
 };
 use test_setup::{BitFlags, Tags};
 
@@ -271,11 +269,7 @@ impl<'a> TableAssertion<'a> {
     {
         match self.table.primary_key() {
             Some(pk) => {
-                pk_assertions(PrimaryKeyAssertion {
-                    pk,
-                    table: self.table,
-                    tags: self.tags,
-                });
+                pk_assertions(PrimaryKeyAssertion { pk, tags: self.tags });
                 self
             }
             None => panic!("Primary key not found on {}.", self.table.name()),
@@ -284,7 +278,7 @@ impl<'a> TableAssertion<'a> {
 
     #[track_caller]
     pub fn assert_indexes_count(self, n: usize) -> Self {
-        let idx_count = self.table.indexes().len();
+        let idx_count = self.table.indexes().filter(|idx| !idx.is_primary_key()).count();
         assert!(idx_count == n, "Expected {} indexes, found {}.", n, idx_count);
         self
     }
@@ -296,6 +290,7 @@ impl<'a> TableAssertion<'a> {
         if let Some(idx) = self
             .table
             .indexes()
+            .filter(|idx| !idx.is_primary_key())
             .find(|idx| idx.column_names().collect::<Vec<_>>() == columns)
         {
             index_assertions(IndexAssertion {
@@ -313,17 +308,12 @@ impl<'a> TableAssertion<'a> {
         if self
             .table
             .indexes()
-            .any(|idx| idx.name() == name && idx.index_type().is_unique() == unique)
+            .any(|idx| idx.name() == name && idx.is_unique() == unique)
         {
             self
         } else {
             panic!("Could not find index with name {} and correct type", name);
         }
-    }
-
-    pub fn debug_print(self) -> Self {
-        println!("{:?}", self.table);
-        self
     }
 }
 
@@ -634,8 +624,7 @@ impl IndexColumnAssertion {
 }
 
 pub struct PrimaryKeyAssertion<'a> {
-    pk: &'a PrimaryKey,
-    table: TableWalker<'a>,
+    pk: IndexWalker<'a>,
     tags: BitFlags<Tags>,
 }
 
@@ -652,14 +641,13 @@ impl<'a> PrimaryKeyAssertion<'a> {
     {
         let col = self
             .pk
-            .columns
-            .iter()
-            .find(|c| c.name == column_name)
+            .columns()
+            .find(|c| c.name() == column_name)
             .unwrap_or_else(|| panic!("Could not find column {}", column_name));
 
         f(IndexColumnAssertion {
-            length: col.length,
-            sort_order: col.sort_order,
+            length: col.length(),
+            sort_order: col.sort_order(),
             operator_class: None,
         });
 
@@ -669,12 +657,11 @@ impl<'a> PrimaryKeyAssertion<'a> {
     #[track_caller]
     pub fn assert_has_autoincrement(self) -> Self {
         assert!(
-            self.table
-                .columns()
-                .any(
-                    |column| self.pk.column_names().any(|name| name == column.name()) && column.is_autoincrement()
-                        || matches!(column.default().map(|d| d.kind()), Some(DefaultKind::UniqueRowid))
-                ),
+            self.pk.columns().any(|column| column.as_column().is_autoincrement()
+                || matches!(
+                    column.as_column().default().map(|d| d.kind()),
+                    Some(DefaultKind::UniqueRowid)
+                )),
             "Assertion failed: expected a sequence on the primary key, found none."
         );
 
@@ -683,27 +670,23 @@ impl<'a> PrimaryKeyAssertion<'a> {
 
     pub fn assert_has_no_autoincrement(self) -> Self {
         assert!(
-            !self
-                .table
-                .columns()
-                .any(|column| self.pk.column_names().any(|c| c == column.name()) && column.is_autoincrement()),
+            !self.pk.columns().any(|column| column.as_column().is_autoincrement()),
             "Assertion failed: expected no sequence on the primary key, but found one."
         );
 
         self
     }
 
-    pub fn assert_constraint_name(self, constraint_name: Option<String>) -> Self {
-        assert_eq!(self.pk.constraint_name, constraint_name);
-
+    pub fn assert_constraint_name(self, constraint_name: &str) -> Self {
+        assert_eq!(self.pk.name(), constraint_name);
         self
     }
 
     #[track_caller]
     pub fn assert_non_clustered(self) -> Self {
         if self.tags.contains(Tags::Mssql) {
-            let ext: &sql::mssql::MssqlSchemaExt = self.table.schema.downcast_connector_data().unwrap_or_default();
-            assert!(!ext.pk_is_clustered(self.table.id))
+            let ext: &sql::mssql::MssqlSchemaExt = self.pk.schema.downcast_connector_data();
+            assert!(!ext.index_is_clustered(self.pk.id))
         }
 
         self
@@ -712,8 +695,8 @@ impl<'a> PrimaryKeyAssertion<'a> {
     #[track_caller]
     pub fn assert_clustered(self) -> Self {
         if self.tags.contains(Tags::Mssql) {
-            let ext: &sql::mssql::MssqlSchemaExt = self.table.schema.downcast_connector_data().unwrap_or_default();
-            assert!(ext.pk_is_clustered(self.table.id))
+            let ext: &sql::mssql::MssqlSchemaExt = self.pk.schema.downcast_connector_data();
+            assert!(ext.index_is_clustered(self.pk.id))
         }
 
         self
@@ -806,7 +789,7 @@ impl<'a> IndexAssertion<'a> {
     #[track_caller]
     pub fn assert_clustered(self) -> Self {
         if self.tags.contains(Tags::Mssql) {
-            let ext: &sql::mssql::MssqlSchemaExt = self.index.schema.downcast_connector_data().unwrap_or_default();
+            let ext: &sql::mssql::MssqlSchemaExt = self.index.schema.downcast_connector_data();
             assert!(ext.index_is_clustered(self.index.id))
         }
 
@@ -816,7 +799,7 @@ impl<'a> IndexAssertion<'a> {
     #[track_caller]
     pub fn assert_non_clustered(self) -> Self {
         if self.tags.contains(Tags::Mssql) {
-            let ext: &sql::mssql::MssqlSchemaExt = self.index.schema.downcast_connector_data().unwrap_or_default();
+            let ext: &sql::mssql::MssqlSchemaExt = self.index.schema.downcast_connector_data();
             assert!(!ext.index_is_clustered(self.index.id))
         }
 
@@ -830,7 +813,7 @@ impl<'a> IndexAssertion<'a> {
     }
 
     pub fn assert_algorithm(self, algo: SqlIndexAlgorithm) -> Self {
-        let postgres_ext: &PostgresSchemaExt = self.index.schema.downcast_connector_data().unwrap_or_default();
+        let postgres_ext: &PostgresSchemaExt = self.index.schema.downcast_connector_data();
         let algorithm = postgres_ext.index_algorithm(self.index.id);
         assert_eq!(algorithm, algo);
 
@@ -841,18 +824,16 @@ impl<'a> IndexAssertion<'a> {
     where
         F: FnOnce(IndexColumnAssertion) -> IndexColumnAssertion,
     {
-        let (col_idx, col) = self
+        let col = self
             .index
             .columns()
-            .enumerate()
-            .find(|(_, c)| c.as_column().name() == column_name)
+            .find(|c| c.as_column().name() == column_name)
             .unwrap();
 
         let operator_class = if self.tags.contains(Tags::Postgres) {
-            let ext: &PostgresSchemaExt = self.index.schema.downcast_connector_data().unwrap_or_default();
+            let ext: &PostgresSchemaExt = self.index.schema.downcast_connector_data();
 
-            ext.get_opclass(IndexFieldId(self.index.id, col_idx as u32))
-                .map(|c| c.kind.clone())
+            ext.get_opclass(col.id).map(|c| c.kind.clone())
         } else {
             None
         };

--- a/migration-engine/migration-engine-tests/tests/migrations/basic.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/basic.rs
@@ -500,7 +500,6 @@ fn adding_a_primary_key_must_work(api: TestApi) {
 
     api.schema_push_w_datasource(dm2).send().assert_green();
 
-    api.assert_schema().assert_table("Test", |t| {
-        t.assert_pk(|pk| pk.assert_constraint_name(Some("Test_pkey".into())))
-    });
+    api.assert_schema()
+        .assert_table("Test", |t| t.assert_pk(|pk| pk.assert_constraint_name("Test_pkey")));
 }

--- a/migration-engine/migration-engine-tests/tests/migrations/indexes.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/indexes.rs
@@ -882,24 +882,27 @@ fn fulltext_index(api: TestApi) {
 
 #[test_connector(tags(Mysql), preview_features("fullTextIndex"))]
 fn fulltext_index_with_map(api: TestApi) {
-    let dm = formatdoc! {r#"
-        {}
+    let dm = indoc! {r#"
+        datasource db {
+            provider = "mysql"
+            url = env("TEST_DATABASE_URL")
+        }
 
-        generator client {{
+        generator client {
           provider = "prisma-client-js"
           previewFeatures = ["fullTextIndex"]
-        }}
+        }
 
-        model A {{
+        model A {
           id Int    @id
           a  String @db.Text
           b  String @db.Text
 
           @@fulltext([a, b], map: "with_map")
-        }}
-    "#, api.datasource_block()};
+        }
+    "#};
 
-    api.schema_push(&dm).send().assert_green();
+    api.schema_push(dm).send().assert_green();
 
     api.assert_schema().assert_table("A", |table| {
         table.assert_index_on_columns(&["a", "b"], |index| index.assert_is_fulltext().assert_name("with_map"))

--- a/migration-engine/migration-engine-tests/tests/schema_push/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/schema_push/mod.rs
@@ -222,7 +222,7 @@ fn alter_constraint_name_push(api: TestApi) {
 
     api.assert_schema().assert_table("A", |table| {
         if !no_named_pk {
-            table.assert_pk(|pk| pk.assert_constraint_name(Some("CustomId".into())));
+            table.assert_pk(|pk| pk.assert_constraint_name("CustomId"));
         };
         table.assert_has_index_name_and_type("CustomUnique", true);
         table.assert_has_index_name_and_type("CustomCompoundUnique", true);
@@ -231,7 +231,7 @@ fn alter_constraint_name_push(api: TestApi) {
 
     api.assert_schema().assert_table("B", |table| {
         if !no_named_pk {
-            table.assert_pk(|pk| pk.assert_constraint_name(Some("CustomCompoundId".into())));
+            table.assert_pk(|pk| pk.assert_constraint_name("CustomCompoundId"));
         };
         if !api.is_sqlite() {
             table.assert_fk_with_name("CustomFK");


### PR DESCRIPTION
Last piece of the sql schema describer normalization saga. Previous PR was https://github.com/prisma/prisma-engines/pull/3019.

- `sql_schema_describer::Index` is now private. `IndexWalker` is the public API.
- `sql_schema_describer::PrimaryKey` no longer exists. Primary keys are part of indexes.
- `ConnectorData` is expected to be defined whenever we might need it in sql-migration-connector.
- `Index<_>/IndexMut<_> for SqlSchema` implementations for id types are mostly removed, because they indexed structs that are now private. Walkers are the access method.
