### PR TITLE
Try not to panic with a weird composite index

### DIFF
--- a/introspection-engine/connectors/mongodb-introspection-connector/src/sampler/statistics/indices.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/src/sampler/statistics/indices.rs
@@ -216,13 +216,10 @@ fn add_missing_types_from_index(
                 .iter()
                 .find(|f| f.database_name.as_deref() == Some(field_name) || f.name == field_name);
 
-            next_type = match cf {
-                Some(_) if i + 1 == path_length => None,
-                Some(cf) => {
-                    let type_name = cf.r#type.as_composite_type().unwrap();
-                    Some(type_name.to_string())
-                }
-                None => {
+            next_type = match (cf, cf.and_then(|cf| cf.r#type.as_composite_type())) {
+                (Some(_), _) if i + 1 == path_length => None,
+                (Some(_), Some(type_name)) => Some(type_name.to_string()),
+                (None, _) | (_, None) => {
                     let docs = String::from("Field referred in an index, but found no data to define the type.");
 
                     let (field_name, database_name) = match super::sanitize_string(field_name) {


### PR DESCRIPTION
Basically this happens when we have data that triggers a PSL such as:

```prisma
model A {
  id Int @id
  a AA

  @@index([a.b.c])
}

type AA {
  b Int
}
```

Now, `b` is not going to a composite type, but an integer. We should not crash though, but the data model here is not usable without user action.

Closes: https://github.com/prisma/prisma/issues/14135