### PR TITLE
ITx: Allow setting isolation level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3232,7 +3232,7 @@ dependencies = [
 [[package]]
 name = "quaint"
 version = "0.2.0-alpha.13"
-source = "git+https://github.com/prisma/quaint#c0f917e4dd31641a229cdcd189988bc2949a41c0"
+source = "git+https://github.com/prisma/quaint#d0ec0d1446d42d0cf6f79033f739a99426e7d57a"
 dependencies = [
  "async-trait",
  "base64 0.12.3",
@@ -5009,7 +5009,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "rand 0.8.5",
  "static_assertions",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5009,7 +5009,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "rand 0.8.5",
  "static_assertions",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3232,7 +3232,7 @@ dependencies = [
 [[package]]
 name = "quaint"
 version = "0.2.0-alpha.13"
-source = "git+https://github.com/prisma/quaint#df52315fae3f366509da3e5d0815ebc13f445e31"
+source = "git+https://github.com/prisma/quaint#c0f917e4dd31641a229cdcd189988bc2949a41c0"
 dependencies = [
  "async-trait",
  "base64 0.12.3",
@@ -5009,7 +5009,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "rand 0.8.5",
  "static_assertions",
 ]

--- a/libs/datamodel/connectors/datamodel-connector/src/capabilities.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/capabilities.rs
@@ -88,7 +88,13 @@ capabilities!(
     UndefinedType,              // Connector distinguishes `null` and `undefined`
     DecimalType,                // Connector supports Prisma Decimal type.
     BackwardCompatibleQueryRaw, // Temporary SQLite specific capability. Should be removed once https://github.com/prisma/prisma/issues/12784 is fixed,
-    OrderByNullsFirstLast       // Connector supports ORDER BY NULLS LAST/FIRST
+    OrderByNullsFirstLast,      // Connector supports ORDER BY NULLS LAST/FIRST
+    // Block of isolation levels.
+    SupportsTxIsolationReadUncommitted,
+    SupportsTxIsolationReadCommitted,
+    SupportsTxIsolationRepeatableRead,
+    SupportsTxIsolationSerializable,
+    SupportsTxIsolationSnapshot,
 );
 
 /// Contains all capabilities that the connector is able to serve.

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/cockroach_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/cockroach_datamodel_connector.rs
@@ -90,6 +90,7 @@ const CAPABILITIES: &[ConnectorCapability] = &[
     ConnectorCapability::ImplicitManyToManyRelation,
     ConnectorCapability::DecimalType,
     ConnectorCapability::OrderByNullsFirstLast,
+    ConnectorCapability::SupportsTxIsolationSerializable,
 ];
 
 const SCALAR_TYPE_DEFAULTS: &[(ScalarType, CockroachType)] = &[

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/mssql_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/mssql_datamodel_connector.rs
@@ -100,6 +100,11 @@ const CAPABILITIES: &[ConnectorCapability] = &[
     ConnectorCapability::DecimalType,
     ConnectorCapability::ClusteringSetting,
     ConnectorCapability::OrderByNullsFirstLast,
+    ConnectorCapability::SupportsTxIsolationReadUncommitted,
+    ConnectorCapability::SupportsTxIsolationReadCommitted,
+    ConnectorCapability::SupportsTxIsolationRepeatableRead,
+    ConnectorCapability::SupportsTxIsolationSerializable,
+    ConnectorCapability::SupportsTxIsolationSnapshot,
 ];
 
 pub struct MsSqlDatamodelConnector;

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/mysql_datamodel_connector.rs
@@ -117,6 +117,10 @@ const CAPABILITIES: &[ConnectorCapability] = &[
     ConnectorCapability::ImplicitManyToManyRelation,
     ConnectorCapability::DecimalType,
     ConnectorCapability::OrderByNullsFirstLast,
+    ConnectorCapability::SupportsTxIsolationReadUncommitted,
+    ConnectorCapability::SupportsTxIsolationReadCommitted,
+    ConnectorCapability::SupportsTxIsolationRepeatableRead,
+    ConnectorCapability::SupportsTxIsolationSerializable,
 ];
 
 const CONSTRAINT_SCOPES: &[ConstraintScope] = &[ConstraintScope::GlobalForeignKey, ConstraintScope::ModelKeyIndex];

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
@@ -107,6 +107,10 @@ const CAPABILITIES: &[ConnectorCapability] = &[
     ConnectorCapability::ImplicitManyToManyRelation,
     ConnectorCapability::DecimalType,
     ConnectorCapability::OrderByNullsFirstLast,
+    ConnectorCapability::SupportsTxIsolationReadUncommitted,
+    ConnectorCapability::SupportsTxIsolationReadCommitted,
+    ConnectorCapability::SupportsTxIsolationRepeatableRead,
+    ConnectorCapability::SupportsTxIsolationSerializable,
 ];
 
 pub struct PostgresDatamodelConnector;

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/sqlite_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/sqlite_datamodel_connector.rs
@@ -19,6 +19,7 @@ const CAPABILITIES: &[ConnectorCapability] = &[
     ConnectorCapability::DecimalType,
     ConnectorCapability::BackwardCompatibleQueryRaw,
     ConnectorCapability::OrderByNullsFirstLast,
+    ConnectorCapability::SupportsTxIsolationSerializable,
 ];
 
 pub struct SqliteDatamodelConnector;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/interactive_tx.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/interactive_tx.rs
@@ -9,7 +9,7 @@ mod interactive_tx {
 
     #[connector_test]
     async fn basic_commit_workflow(mut runner: Runner) -> TestResult<()> {
-        let tx_id = runner.start_tx(5000, 5000).await?;
+        let tx_id = runner.start_tx(5000, 5000, None).await?;
         runner.set_active_tx(tx_id.clone());
 
         insta::assert_snapshot!(
@@ -36,7 +36,7 @@ mod interactive_tx {
 
     #[connector_test]
     async fn basic_rollback_workflow(mut runner: Runner) -> TestResult<()> {
-        let tx_id = runner.start_tx(5000, 5000).await?;
+        let tx_id = runner.start_tx(5000, 5000, None).await?;
         runner.set_active_tx(tx_id.clone());
 
         insta::assert_snapshot!(
@@ -64,7 +64,7 @@ mod interactive_tx {
     #[connector_test]
     async fn tx_expiration_cycle(mut runner: Runner) -> TestResult<()> {
         // Tx expires after one second.
-        let tx_id = runner.start_tx(5000, 1000).await?;
+        let tx_id = runner.start_tx(5000, 1000, None).await?;
         runner.set_active_tx(tx_id.clone());
 
         insta::assert_snapshot!(
@@ -108,7 +108,7 @@ mod interactive_tx {
     #[connector_test]
     async fn no_auto_rollback(mut runner: Runner) -> TestResult<()> {
         // Tx expires after five second.
-        let tx_id = runner.start_tx(5000, 5000).await?;
+        let tx_id = runner.start_tx(5000, 5000, None).await?;
         runner.set_active_tx(tx_id.clone());
 
         // Row is created
@@ -135,7 +135,7 @@ mod interactive_tx {
     #[connector_test(only(Postgres))]
     async fn raw_queries(mut runner: Runner) -> TestResult<()> {
         // Tx expires after five second.
-        let tx_id = runner.start_tx(5000, 5000).await?;
+        let tx_id = runner.start_tx(5000, 5000, None).await?;
         runner.set_active_tx(tx_id.clone());
 
         insta::assert_snapshot!(
@@ -164,7 +164,7 @@ mod interactive_tx {
     #[connector_test]
     async fn batch_queries_success(mut runner: Runner) -> TestResult<()> {
         // Tx expires after five second.
-        let tx_id = runner.start_tx(5000, 5000).await?;
+        let tx_id = runner.start_tx(5000, 5000, None).await?;
         runner.set_active_tx(tx_id.clone());
 
         let queries = vec![
@@ -190,7 +190,7 @@ mod interactive_tx {
     #[connector_test]
     async fn batch_queries_rollback(mut runner: Runner) -> TestResult<()> {
         // Tx expires after five second.
-        let tx_id = runner.start_tx(5000, 5000).await?;
+        let tx_id = runner.start_tx(5000, 5000, None).await?;
         runner.set_active_tx(tx_id.clone());
 
         let queries = vec![
@@ -216,7 +216,7 @@ mod interactive_tx {
     #[connector_test]
     async fn batch_queries_failure(mut runner: Runner) -> TestResult<()> {
         // Tx expires after five second.
-        let tx_id = runner.start_tx(5000, 5000).await?;
+        let tx_id = runner.start_tx(5000, 5000, None).await?;
         runner.set_active_tx(tx_id.clone());
 
         // One dup key, will cause failure of the batch.
@@ -259,7 +259,7 @@ mod interactive_tx {
     #[connector_test]
     async fn tx_expiration_failure_cycle(mut runner: Runner) -> TestResult<()> {
         // Tx expires after one seconds.
-        let tx_id = runner.start_tx(5000, 1000).await?;
+        let tx_id = runner.start_tx(5000, 1000, None).await?;
         runner.set_active_tx(tx_id.clone());
 
         // Row is created
@@ -327,10 +327,10 @@ mod interactive_tx {
     #[connector_test(exclude(Sqlite))]
     async fn multiple_tx(mut runner: Runner) -> TestResult<()> {
         // First transaction.
-        let tx_id_a = runner.start_tx(2000, 2000).await?;
+        let tx_id_a = runner.start_tx(2000, 2000, None).await?;
 
         // Second transaction.
-        let tx_id_b = runner.start_tx(2000, 2000).await?;
+        let tx_id_b = runner.start_tx(2000, 2000, None).await?;
 
         // Execute on first transaction.
         runner.set_active_tx(tx_id_a.clone());

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/interactive_tx.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/interactive_tx.rs
@@ -443,8 +443,10 @@ mod itx_isolation {
         let tx_id = runner.start_tx(5000, 5000, Some("Serializable".to_owned())).await;
 
         match tx_id {
-          Ok(_) => panic!("Expected mongo to throw an unsupported error, but it succeeded instead."),
-          Err(err) => assert!(dbg!(err.to_string()).contains("Unsupported connector feature: Mongo does not support setting transaction isolation levels")),
+            Ok(_) => panic!("Expected mongo to throw an unsupported error, but it succeeded instead."),
+            Err(err) => assert!(dbg!(err.to_string()).contains(
+                "Unsupported connector feature: Mongo does not support setting transaction isolation levels"
+            )),
         };
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/metrics.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/metrics.rs
@@ -35,7 +35,7 @@ mod metrics {
 
     #[connector_test]
     async fn metrics_tx_do_not_go_negative(mut runner: Runner) -> TestResult<()> {
-        let tx_id = runner.start_tx(5000, 5000).await?;
+        let tx_id = runner.start_tx(5000, 5000, None).await?;
         runner.set_active_tx(tx_id.clone());
 
         insta::assert_snapshot!(
@@ -52,7 +52,7 @@ mod metrics {
         let active_transactions = get_gauge(&json, "query_active_transactions");
         assert_eq!(active_transactions, 0.0);
 
-        let tx_id = runner.start_tx(5000, 5000).await?;
+        let tx_id = runner.start_tx(5000, 5000, None).await?;
         runner.set_active_tx(tx_id.clone());
 
         insta::assert_snapshot!(

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/error.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/error.rs
@@ -21,7 +21,7 @@ pub enum TestError {
     TemplatingError(#[from] TemplatingError),
 
     #[error("Error during interactive transaction processing: {}", _0)]
-    InteractiveTransactionError(String)
+    InteractiveTransactionError(String),
 }
 
 impl TestError {

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/error.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/error.rs
@@ -19,6 +19,9 @@ pub enum TestError {
 
     #[error("Error processing schema template: {0}")]
     TemplatingError(#[from] TemplatingError),
+
+    #[error("Error during interactive transaction processing: {}", _0)]
+    InteractiveTransactionError(String)
 }
 
 impl TestError {

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/binary.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/binary.rs
@@ -1,4 +1,4 @@
-use crate::{ConnectorTag, RunnerInterface, TestResult, TxResult, TestError};
+use crate::{ConnectorTag, RunnerInterface, TestError, TestResult, TxResult};
 use hyper::{Body, Method, Request, Response};
 use query_core::{MetricRegistry, TxId};
 use query_engine::opt::PrismaOpt;
@@ -112,7 +112,9 @@ impl RunnerInterface for BinaryRunner {
         let json_obj = json_resp.as_object().unwrap();
 
         match json_obj.get("error_code") {
-            Some(_) => Err(TestError::InteractiveTransactionError(serde_json::to_string(json_obj).unwrap())),
+            Some(_) => Err(TestError::InteractiveTransactionError(
+                serde_json::to_string(json_obj).unwrap(),
+            )),
             None => Ok(json_obj.get("id").unwrap().as_str().unwrap().into()),
         }
     }

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/binary.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/binary.rs
@@ -87,10 +87,16 @@ impl RunnerInterface for BinaryRunner {
         Ok(PrismaResponse::Multi(batch_response).into())
     }
 
-    async fn start_tx(&self, max_acquisition_millis: u64, valid_for_millis: u64) -> TestResult<TxId> {
+    async fn start_tx(
+        &self,
+        max_acquisition_millis: u64,
+        valid_for_millis: u64,
+        isolation_level: Option<String>,
+    ) -> TestResult<TxId> {
         let body = serde_json::json!({
             "max_wait": max_acquisition_millis,
-            "timeout": valid_for_millis
+            "timeout": valid_for_millis,
+            "isolation_level": isolation_level,
         });
 
         let body_bytes = serde_json::to_vec(&body).unwrap();

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/direct.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/direct.rs
@@ -59,10 +59,20 @@ impl RunnerInterface for DirectRunner {
         Ok(handler.handle(query, self.current_tx_id.clone(), None).await.into())
     }
 
-    async fn start_tx(&self, max_acquisition_millis: u64, valid_for_millis: u64) -> TestResult<TxId> {
+    async fn start_tx(
+        &self,
+        max_acquisition_millis: u64,
+        valid_for_millis: u64,
+        isolation_level: Option<String>,
+    ) -> TestResult<TxId> {
         let id = self
             .executor
-            .start_tx(self.query_schema.clone(), max_acquisition_millis, valid_for_millis)
+            .start_tx(
+                self.query_schema.clone(),
+                max_acquisition_millis,
+                valid_for_millis,
+                isolation_level,
+            )
             .await?;
         Ok(id)
     }

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/mod.rs
@@ -24,7 +24,12 @@ pub trait RunnerInterface: Sized {
     async fn batch(&self, queries: Vec<String>, transaction: bool) -> TestResult<QueryResult>;
 
     /// start a transaction for a batch run
-    async fn start_tx(&self, max_acquisition_millis: u64, valid_for_millis: u64) -> TestResult<TxId>;
+    async fn start_tx(
+        &self,
+        max_acquisition_millis: u64,
+        valid_for_millis: u64,
+        isolation_level: Option<String>,
+    ) -> TestResult<TxId>;
 
     /// commit transaction
     async fn commit_tx(&self, tx_id: TxId) -> TestResult<TxResult>;
@@ -92,11 +97,22 @@ impl Runner {
         Ok(response)
     }
 
-    pub async fn start_tx(&self, max_acquisition_millis: u64, valid_for_millis: u64) -> TestResult<TxId> {
+    pub async fn start_tx(
+        &self,
+        max_acquisition_millis: u64,
+        valid_for_millis: u64,
+        isolation_level: Option<String>,
+    ) -> TestResult<TxId> {
         match self {
-            Runner::Direct(r) => r.start_tx(max_acquisition_millis, valid_for_millis).await,
+            Runner::Direct(r) => {
+                r.start_tx(max_acquisition_millis, valid_for_millis, isolation_level)
+                    .await
+            }
+            Runner::Binary(r) => {
+                r.start_tx(max_acquisition_millis, valid_for_millis, isolation_level)
+                    .await
+            }
             Runner::NodeApi(_) => todo!(),
-            Runner::Binary(r) => r.start_tx(max_acquisition_millis, valid_for_millis).await,
         }
     }
 

--- a/query-engine/connectors/query-connector/src/interface.rs
+++ b/query-engine/connectors/query-connector/src/interface.rs
@@ -16,7 +16,10 @@ pub trait Connector {
 
 #[async_trait]
 pub trait Connection: ConnectionLike {
-    async fn start_transaction<'a>(&'a mut self) -> crate::Result<Box<dyn Transaction + 'a>>;
+    async fn start_transaction<'a>(
+        &'a mut self,
+        isolation_level: Option<String>,
+    ) -> crate::Result<Box<dyn Transaction + 'a>>;
 
     /// Explicit upcast.
     fn as_connection_like(&mut self) -> &mut dyn ConnectionLike;
@@ -35,6 +38,8 @@ pub trait Transaction: ConnectionLike {
 /// Marker trait required by the query core executor to abstract connections and
 /// transactions into something that can is capable of writing to or reading from the database.
 pub trait ConnectionLike: ReadOperations + WriteOperations + Send + Sync {}
+
+// pub enum IsolationLevel {}
 
 /// A wrapper struct allowing to either filter for records or for the core to
 /// communicate already known record selectors to connectors.

--- a/query-engine/connectors/query-connector/src/interface.rs
+++ b/query-engine/connectors/query-connector/src/interface.rs
@@ -39,8 +39,6 @@ pub trait Transaction: ConnectionLike {
 /// transactions into something that can is capable of writing to or reading from the database.
 pub trait ConnectionLike: ReadOperations + WriteOperations + Send + Sync {}
 
-// pub enum IsolationLevel {}
-
 /// A wrapper struct allowing to either filter for records or for the core to
 /// communicate already known record selectors to connectors.
 ///

--- a/query-engine/connectors/sql-query-connector/src/database/transaction.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/transaction.rs
@@ -1,5 +1,5 @@
-use crate::SqlError;
-use crate::{database::operations::*, sql_info::SqlInfo};
+use super::catch;
+use crate::{database::operations::*, sql_info::SqlInfo, SqlError};
 use async_trait::async_trait;
 use connector::{ConnectionLike, RelAggregationSelection};
 use connector_interface::{
@@ -11,8 +11,6 @@ use prisma_models::{prelude::*, SelectionResult};
 use prisma_value::PrismaValue;
 use quaint::prelude::ConnectionInfo;
 use std::collections::HashMap;
-
-use super::catch;
 
 pub struct SqlConnectorTransaction<'tx> {
     inner: quaint::connector::Transaction<'tx>,

--- a/query-engine/connectors/sql-query-connector/src/error.rs
+++ b/query-engine/connectors/sql-query-connector/src/error.rs
@@ -156,6 +156,9 @@ pub enum SqlError {
     #[error("{}", _0)]
     TransactionAlreadyClosed(String),
 
+    #[error("{}", _0)]
+    InvalidIsolationLevel(String),
+
     #[error("Query parameter limit exceeded error: {0}.")]
     QueryParameterLimitExceeded(String),
 
@@ -255,6 +258,7 @@ impl SqlError {
                 ConnectorError::from_kind(ErrorKind::QueryParameterLimitExceeded(e))
             }
             SqlError::MissingFullTextSearchIndex => ConnectorError::from_kind(ErrorKind::MissingFullTextSearchIndex),
+            SqlError::InvalidIsolationLevel(msg) => ConnectorError::from_kind(ErrorKind::InternalConversionError(msg))
         }
     }
 }
@@ -288,6 +292,7 @@ impl From<quaint::error::Error> for SqlError {
             QuaintKind::ColumnNotFound { column } => SqlError::ColumnDoesNotExist(format!("{}", column)),
             QuaintKind::TableDoesNotExist { table } => SqlError::TableDoesNotExist(format!("{}", table)),
             QuaintKind::ConnectionClosed => SqlError::ConnectionClosed,
+            QuaintKind::InvalidIsolationLevel(msg) => Self::InvalidIsolationLevel(msg),
             e @ QuaintKind::UnsupportedColumnType { .. } => SqlError::ConversionError(e.into()),
             e @ QuaintKind::TransactionAlreadyClosed(_) => SqlError::TransactionAlreadyClosed(format!("{}", e)),
             e @ QuaintKind::IncorrectNumberOfParameters { .. } => SqlError::QueryError(e.into()),

--- a/query-engine/connectors/sql-query-connector/src/error.rs
+++ b/query-engine/connectors/sql-query-connector/src/error.rs
@@ -258,7 +258,7 @@ impl SqlError {
                 ConnectorError::from_kind(ErrorKind::QueryParameterLimitExceeded(e))
             }
             SqlError::MissingFullTextSearchIndex => ConnectorError::from_kind(ErrorKind::MissingFullTextSearchIndex),
-            SqlError::InvalidIsolationLevel(msg) => ConnectorError::from_kind(ErrorKind::InternalConversionError(msg))
+            SqlError::InvalidIsolationLevel(msg) => ConnectorError::from_kind(ErrorKind::InternalConversionError(msg)),
         }
     }
 }

--- a/query-engine/core/src/executor/execute_operation.rs
+++ b/query-engine/core/src/executor/execute_operation.rs
@@ -128,7 +128,7 @@ async fn execute_self_contained(
 ) -> crate::Result<ResponseData> {
     let operation_timer = Instant::now();
     let result = if force_transactions || graph.needs_transaction() {
-        let mut tx = conn.start_transaction().await?;
+        let mut tx = conn.start_transaction(None).await?;
         let result = execute_on(tx.as_connection_like(), graph, serializer, trace_id).await;
 
         if result.is_ok() {

--- a/query-engine/core/src/executor/mod.rs
+++ b/query-engine/core/src/executor/mod.rs
@@ -62,6 +62,7 @@ pub trait TransactionManager {
         query_schema: QuerySchemaRef,
         max_acquisition_millis: u64,
         valid_for_millis: u64,
+        isolation_level: Option<String>,
     ) -> crate::Result<TxId>;
 
     /// Commits a transaction.

--- a/query-engine/core/src/interactive_transactions/mod.rs
+++ b/query-engine/core/src/interactive_transactions/mod.rs
@@ -110,12 +110,12 @@ pub struct OpenTx {
 }
 
 impl OpenTx {
-    pub async fn start(mut conn: Box<dyn Connection>) -> crate::Result<Self> {
+    pub async fn start(mut conn: Box<dyn Connection>, isolation_level: Option<String>) -> crate::Result<Self> {
         // Forces static lifetime for the transaction, disabling the lifetime checks for `tx`.
         // Why is this okay? We store the connection the tx depends on with its lifetime next to
         // the tx in the struct. Neither the connection nor the tx are moved out of this struct.
         // The `OpenTx` struct is dropped as a unit.
-        let transaction: Box<dyn Transaction + '_> = conn.start_transaction().await?;
+        let transaction: Box<dyn Transaction + '_> = conn.start_transaction(isolation_level).await?;
         let tx = unsafe {
             let tx: Box<dyn Transaction + 'static> = std::mem::transmute(transaction);
             tx

--- a/query-engine/core/src/query_document/parser.rs
+++ b/query-engine/core/src/query_document/parser.rs
@@ -182,9 +182,9 @@ impl QueryDocumentParser {
                     .map(ParsedInputValue::Single),
 
                 // Enum handling
-                (QueryValue::Enum(_), InputType::Enum(et)) => self.parse_enum(&parent_path, value, et),
-                (QueryValue::String(_), InputType::Enum(et)) => self.parse_enum(&parent_path, value, et),
-                (QueryValue::Boolean(_), InputType::Enum(et)) => self.parse_enum(&parent_path, value, et),
+                (QueryValue::Enum(_), InputType::Enum(et)) => self.parse_enum(&parent_path, value, &et.into_arc()),
+                (QueryValue::String(_), InputType::Enum(et)) => self.parse_enum(&parent_path, value, &et.into_arc()),
+                (QueryValue::Boolean(_), InputType::Enum(et)) => self.parse_enum(&parent_path, value, &et.into_arc()),
 
                 // List handling.
                 (QueryValue::List(values), InputType::List(l)) => self
@@ -404,15 +404,15 @@ impl QueryDocumentParser {
         match typ.borrow() {
             EnumType::Database(db) => match db.map_input_value(&raw) {
                 Some(value) => Ok(ParsedInputValue::Single(value)),
-                None => err(&db.name),
+                None => err(db.identifier().name()),
             },
             EnumType::String(s) => match s.value_for(raw.as_str()) {
                 Some(val) => Ok(ParsedInputValue::Single(PrismaValue::Enum(val.to_owned()))),
-                None => err(&s.name),
+                None => err(s.identifier().name()),
             },
             EnumType::FieldRef(f) => match f.value_for(raw.as_str()) {
                 Some(value) => Ok(ParsedInputValue::ScalarField(value.clone())),
-                None => err(&f.name),
+                None => err(f.identifier().name()),
             },
         }
     }

--- a/query-engine/dmmf/src/ast_builders/schema_ast_builder/enum_renderer.rs
+++ b/query-engine/dmmf/src/ast_builders/schema_ast_builder/enum_renderer.rs
@@ -1,7 +1,10 @@
 use super::*;
 
 pub(crate) fn render_enum_types(ctx: &mut RenderContext, enum_types: &[EnumTypeRef]) {
-    enum_types.iter().for_each(|et| DmmfEnumRenderer::new(et).render(ctx))
+    let mut borrows: Vec<_> = enum_types.iter().collect();
+
+    borrows.sort_by(|a, b| a.name().cmp(b.name()));
+    borrows.into_iter().for_each(|et| DmmfEnumRenderer::new(et).render(ctx));
 }
 
 pub struct DmmfEnumRenderer {

--- a/query-engine/dmmf/src/ast_builders/schema_ast_builder/enum_renderer.rs
+++ b/query-engine/dmmf/src/ast_builders/schema_ast_builder/enum_renderer.rs
@@ -1,5 +1,11 @@
 use super::*;
 
+pub(crate) fn render_enum_types(ctx: &mut RenderContext, enum_types: &[EnumTypeRef]) {
+    enum_types
+        .into_iter()
+        .for_each(|et| DmmfEnumRenderer::new(et).render(ctx))
+}
+
 pub struct DmmfEnumRenderer {
     enum_type: EnumType,
 }
@@ -7,18 +13,17 @@ pub struct DmmfEnumRenderer {
 impl Renderer for DmmfEnumRenderer {
     fn render(&self, ctx: &mut RenderContext) {
         let ident = self.enum_type.identifier();
-        if ctx.already_rendered(&ident) {
+        if ctx.already_rendered(ident) {
             return;
         }
 
         let values = self.format_enum_values();
-
         let rendered = DmmfEnum {
             name: self.enum_type.name().to_owned(),
             values,
         };
 
-        ctx.add_enum(ident, rendered);
+        ctx.add_enum(ident.clone(), rendered);
     }
 }
 

--- a/query-engine/dmmf/src/ast_builders/schema_ast_builder/enum_renderer.rs
+++ b/query-engine/dmmf/src/ast_builders/schema_ast_builder/enum_renderer.rs
@@ -1,9 +1,7 @@
 use super::*;
 
 pub(crate) fn render_enum_types(ctx: &mut RenderContext, enum_types: &[EnumTypeRef]) {
-    enum_types
-        .iter()
-        .for_each(|et| DmmfEnumRenderer::new(et).render(ctx))
+    enum_types.iter().for_each(|et| DmmfEnumRenderer::new(et).render(ctx))
 }
 
 pub struct DmmfEnumRenderer {

--- a/query-engine/dmmf/src/ast_builders/schema_ast_builder/enum_renderer.rs
+++ b/query-engine/dmmf/src/ast_builders/schema_ast_builder/enum_renderer.rs
@@ -2,7 +2,7 @@ use super::*;
 
 pub(crate) fn render_enum_types(ctx: &mut RenderContext, enum_types: &[EnumTypeRef]) {
     enum_types
-        .into_iter()
+        .iter()
         .for_each(|et| DmmfEnumRenderer::new(et).render(ctx))
 }
 

--- a/query-engine/dmmf/src/ast_builders/schema_ast_builder/mod.rs
+++ b/query-engine/dmmf/src/ast_builders/schema_ast_builder/mod.rs
@@ -190,7 +190,7 @@ impl<'a> IntoRenderer for &'a EnumType {
     }
 
     fn is_already_rendered(&self, ctx: &RenderContext) -> bool {
-        ctx.already_rendered(&self.identifier())
+        ctx.already_rendered(self.identifier())
     }
 }
 

--- a/query-engine/dmmf/src/ast_builders/schema_ast_builder/schema_renderer.rs
+++ b/query-engine/dmmf/src/ast_builders/schema_ast_builder/schema_renderer.rs
@@ -6,6 +6,8 @@ pub struct DmmfSchemaRenderer {
 
 impl Renderer for DmmfSchemaRenderer {
     fn render(&self, ctx: &mut RenderContext) {
+        // This ensures that all enums are rendered, even if not reached by the output and input types.
+        render_enum_types(ctx, &self.query_schema.enum_types());
         render_output_type(&self.query_schema.query, ctx);
         render_output_type(&self.query_schema.mutation, ctx);
     }

--- a/query-engine/dmmf/src/ast_builders/schema_ast_builder/schema_renderer.rs
+++ b/query-engine/dmmf/src/ast_builders/schema_ast_builder/schema_renderer.rs
@@ -7,7 +7,7 @@ pub struct DmmfSchemaRenderer {
 impl Renderer for DmmfSchemaRenderer {
     fn render(&self, ctx: &mut RenderContext) {
         // This ensures that all enums are rendered, even if not reached by the output and input types.
-        render_enum_types(ctx, &self.query_schema.enum_types());
+        render_enum_types(ctx, self.query_schema.enum_types());
         render_output_type(&self.query_schema.query, ctx);
         render_output_type(&self.query_schema.mutation, ctx);
     }

--- a/query-engine/dmmf/src/ast_builders/schema_ast_builder/type_renderer.rs
+++ b/query-engine/dmmf/src/ast_builders/schema_ast_builder/type_renderer.rs
@@ -35,23 +35,9 @@ pub(super) fn render_output_type(output_type: &OutputType, ctx: &mut RenderConte
         OutputType::List(ref l) => {
             let mut type_reference = render_output_type(l, ctx);
             type_reference.is_list = true;
-
             type_reference
         }
 
-        // OutputType::Scalar(ScalarType::Enum(et)) => {
-        //     ctx.mark_to_be_rendered(&et.as_ref());
-
-        //     let ident = et.identifier();
-        //     let type_reference = DmmfTypeReference {
-        //         typ: ident.name().to_owned(),
-        //         namespace: Some(ident.namespace().to_owned()),
-        //         location: TypeLocation::Scalar,
-        //         is_list: false,
-        //     };
-
-        //     type_reference
-        // }
         OutputType::Scalar(ref scalar) => {
             let stringified = match scalar {
                 ScalarType::Null => "Null",
@@ -67,7 +53,6 @@ pub(super) fn render_output_type(output_type: &OutputType, ctx: &mut RenderConte
                 ScalarType::JsonList => "Json",
                 ScalarType::Xml => "Xml",
                 ScalarType::Bytes => "Bytes",
-                // ScalarType::Enum(_) => unreachable!(), // Handled separately above.
             };
 
             DmmfTypeReference {
@@ -125,17 +110,6 @@ pub(super) fn render_input_type(input_type: &InputType, ctx: &mut RenderContext)
             type_reference
         }
 
-        // InputType::Scalar(ScalarType::Enum(et)) => {
-        //     ctx.mark_to_be_rendered(&et.as_ref());
-        //     let type_reference = DmmfTypeReference {
-        //         typ: et.name().to_owned(),
-        //         namespace: Some(et.namespace()),
-        //         location: TypeLocation::Scalar,
-        //         is_list: false,
-        //     };
-
-        //     type_reference
-        // }
         InputType::Scalar(ref scalar) => {
             let stringified = match scalar {
                 ScalarType::Null => "Null",
@@ -151,7 +125,6 @@ pub(super) fn render_input_type(input_type: &InputType, ctx: &mut RenderContext)
                 ScalarType::JsonList => "Json",
                 ScalarType::Xml => "Xml",
                 ScalarType::Bytes => "Bytes",
-                // ScalarType::Enum(_) => unreachable!(), // Handled separately above.
             };
 
             DmmfTypeReference {

--- a/query-engine/dmmf/src/ast_builders/schema_ast_builder/type_renderer.rs
+++ b/query-engine/dmmf/src/ast_builders/schema_ast_builder/type_renderer.rs
@@ -18,10 +18,13 @@ pub(super) fn render_output_type(output_type: &OutputType, ctx: &mut RenderConte
         }
 
         OutputType::Enum(et) => {
+            let et = et.into_arc();
             ctx.mark_to_be_rendered(&et.as_ref());
+
+            let ident = et.identifier();
             let type_reference = DmmfTypeReference {
-                typ: et.name().to_owned(),
-                namespace: Some(et.namespace()),
+                typ: ident.name().to_owned(),
+                namespace: Some(ident.namespace().to_owned()),
                 location: TypeLocation::EnumTypes,
                 is_list: false,
             };
@@ -36,18 +39,19 @@ pub(super) fn render_output_type(output_type: &OutputType, ctx: &mut RenderConte
             type_reference
         }
 
-        OutputType::Scalar(ScalarType::Enum(et)) => {
-            ctx.mark_to_be_rendered(&et.as_ref());
-            let type_reference = DmmfTypeReference {
-                typ: et.name().to_owned(),
-                namespace: Some(et.namespace()),
-                location: TypeLocation::Scalar,
-                is_list: false,
-            };
+        // OutputType::Scalar(ScalarType::Enum(et)) => {
+        //     ctx.mark_to_be_rendered(&et.as_ref());
 
-            type_reference
-        }
+        //     let ident = et.identifier();
+        //     let type_reference = DmmfTypeReference {
+        //         typ: ident.name().to_owned(),
+        //         namespace: Some(ident.namespace().to_owned()),
+        //         location: TypeLocation::Scalar,
+        //         is_list: false,
+        //     };
 
+        //     type_reference
+        // }
         OutputType::Scalar(ref scalar) => {
             let stringified = match scalar {
                 ScalarType::Null => "Null",
@@ -63,7 +67,7 @@ pub(super) fn render_output_type(output_type: &OutputType, ctx: &mut RenderConte
                 ScalarType::JsonList => "Json",
                 ScalarType::Xml => "Xml",
                 ScalarType::Bytes => "Bytes",
-                ScalarType::Enum(_) => unreachable!(), // Handled separately above.
+                // ScalarType::Enum(_) => unreachable!(), // Handled separately above.
             };
 
             DmmfTypeReference {
@@ -100,10 +104,13 @@ pub(super) fn render_input_type(input_type: &InputType, ctx: &mut RenderContext)
         }
 
         InputType::Enum(et) => {
+            let et = et.into_arc();
             ctx.mark_to_be_rendered(&et.as_ref());
+
+            let ident = et.identifier();
             let type_reference = DmmfTypeReference {
-                typ: et.name().to_owned(),
-                namespace: Some(et.namespace()),
+                typ: ident.name().to_owned(),
+                namespace: Some(ident.namespace().to_owned()),
                 location: TypeLocation::EnumTypes,
                 is_list: false,
             };
@@ -118,18 +125,17 @@ pub(super) fn render_input_type(input_type: &InputType, ctx: &mut RenderContext)
             type_reference
         }
 
-        InputType::Scalar(ScalarType::Enum(et)) => {
-            ctx.mark_to_be_rendered(&et.as_ref());
-            let type_reference = DmmfTypeReference {
-                typ: et.name().to_owned(),
-                namespace: Some(et.namespace()),
-                location: TypeLocation::Scalar,
-                is_list: false,
-            };
+        // InputType::Scalar(ScalarType::Enum(et)) => {
+        //     ctx.mark_to_be_rendered(&et.as_ref());
+        //     let type_reference = DmmfTypeReference {
+        //         typ: et.name().to_owned(),
+        //         namespace: Some(et.namespace()),
+        //         location: TypeLocation::Scalar,
+        //         is_list: false,
+        //     };
 
-            type_reference
-        }
-
+        //     type_reference
+        // }
         InputType::Scalar(ref scalar) => {
             let stringified = match scalar {
                 ScalarType::Null => "Null",
@@ -145,7 +151,7 @@ pub(super) fn render_input_type(input_type: &InputType, ctx: &mut RenderContext)
                 ScalarType::JsonList => "Json",
                 ScalarType::Xml => "Xml",
                 ScalarType::Bytes => "Bytes",
-                ScalarType::Enum(_) => unreachable!(), // Handled separately above.
+                // ScalarType::Enum(_) => unreachable!(), // Handled separately above.
             };
 
             DmmfTypeReference {

--- a/query-engine/example_schemas/generic_mongo4.prisma
+++ b/query-engine/example_schemas/generic_mongo4.prisma
@@ -4,7 +4,7 @@ datasource db {
 }
 
 generator js {
-  previewFeatures = ["mongodb", "interactiveTransactions"]
+  previewFeatures = ["interactiveTransactions"]
   provider        = "prisma-client-js"
 }
 

--- a/query-engine/prisma-models/src/builders/internal_dm_builder.rs
+++ b/query-engine/prisma-models/src/builders/internal_dm_builder.rs
@@ -74,7 +74,7 @@ impl InternalDataModelBuilder {
                 println!(
                     "{}: {}",
                     ct.name,
-                    ct.fields().into_iter().map(|f| f.name()).collect_vec().join(", ")
+                    ct.fields().iter().map(|f| f.name()).collect_vec().join(", ")
                 )
             });
 

--- a/query-engine/prisma-models/src/builders/internal_dm_builder.rs
+++ b/query-engine/prisma-models/src/builders/internal_dm_builder.rs
@@ -9,7 +9,6 @@ use crate::{
     RelationLinkManifestation, RelationSide, RelationTable, TypeIdentifier,
 };
 use datamodel::dml::{self, CompositeTypeFieldType, Datamodel, Ignorable, WithDatabaseName};
-use itertools::Itertools;
 use once_cell::sync::OnceCell;
 use std::sync::Arc;
 
@@ -64,20 +63,6 @@ impl InternalDataModelBuilder {
 
         internal_data_model.relations.set(relations).unwrap();
         internal_data_model.finalize();
-
-        internal_data_model
-            .composite_types
-            .get()
-            .unwrap()
-            .iter()
-            .for_each(|ct| {
-                println!(
-                    "{}: {}",
-                    ct.name,
-                    ct.fields().iter().map(|f| f.name()).collect_vec().join(", ")
-                )
-            });
-
         internal_data_model
     }
 }

--- a/query-engine/prisma-models/src/builders/internal_dm_builder.rs
+++ b/query-engine/prisma-models/src/builders/internal_dm_builder.rs
@@ -9,6 +9,7 @@ use crate::{
     RelationLinkManifestation, RelationSide, RelationTable, TypeIdentifier,
 };
 use datamodel::dml::{self, CompositeTypeFieldType, Datamodel, Ignorable, WithDatabaseName};
+use itertools::Itertools;
 use once_cell::sync::OnceCell;
 use std::sync::Arc;
 
@@ -63,6 +64,20 @@ impl InternalDataModelBuilder {
 
         internal_data_model.relations.set(relations).unwrap();
         internal_data_model.finalize();
+
+        internal_data_model
+            .composite_types
+            .get()
+            .unwrap()
+            .iter()
+            .for_each(|ct| {
+                println!(
+                    "{}: {}",
+                    ct.name,
+                    ct.fields().into_iter().map(|f| f.name()).collect_vec().join(", ")
+                )
+            });
+
         internal_data_model
     }
 }

--- a/query-engine/query-engine-node-api/src/engine.rs
+++ b/query-engine/query-engine-node-api/src/engine.rs
@@ -330,7 +330,12 @@ impl QueryEngine {
                 let input: TxInput = serde_json::from_str(&input)?;
                 match engine
                     .executor()
-                    .start_tx(engine.query_schema().clone(), input.max_wait, input.timeout)
+                    .start_tx(
+                        engine.query_schema().clone(),
+                        input.max_wait,
+                        input.timeout,
+                        input.isolation_level,
+                    )
                     .instrument(span)
                     .await
                 {

--- a/query-engine/query-engine/src/server/mod.rs
+++ b/query-engine/query-engine/src/server/mod.rs
@@ -359,7 +359,12 @@ async fn transaction_start_handler(state: State, req: Request<Body>) -> Result<R
     match state
         .cx
         .executor
-        .start_tx(state.cx.query_schema().clone(), input.max_wait, input.timeout)
+        .start_tx(
+            state.cx.query_schema().clone(),
+            input.max_wait,
+            input.timeout,
+            input.isolation_level,
+        )
         .instrument(span)
         .await
     {

--- a/query-engine/request-handlers/src/graphql/schema_renderer/type_renderer.rs
+++ b/query-engine/request-handlers/src/graphql/schema_renderer/type_renderer.rs
@@ -24,19 +24,14 @@ impl<'a> GqlTypeRenderer<'a> {
             }
 
             InputType::Enum(et) => {
-                // Not sure how this fits together with the enum handling below.
-                let _ = et.into_renderer().render(ctx);
-                et.name().to_string()
+                let et = et.into_arc();
+                et.into_renderer().render(ctx);
+                et.identifier().name().to_string()
             }
 
             InputType::List(ref l) => {
                 let substring = self.render_input_type(l, ctx);
                 format!("[{}]", substring)
-            }
-
-            InputType::Scalar(ScalarType::Enum(et)) => {
-                let _ = et.into_renderer().render(ctx);
-                et.name().to_string()
             }
 
             InputType::Scalar(ref scalar) => {
@@ -53,7 +48,6 @@ impl<'a> GqlTypeRenderer<'a> {
                     ScalarType::JsonList => "Json",
                     ScalarType::Xml => "Xml",
                     ScalarType::Bytes => "Bytes",
-                    ScalarType::Enum(_) => unreachable!("Encountered enum type during GQL scalar rendering."), // Handled separately above.
                     ScalarType::Null => unreachable!("Null types should not be picked for GQL rendering."),
                 };
 
@@ -70,19 +64,14 @@ impl<'a> GqlTypeRenderer<'a> {
             }
 
             OutputType::Enum(et) => {
-                // Not sure how this fits together with the enum handling below.
-                let _ = et.into_renderer().render(ctx);
-                et.name().to_string()
+                let et = et.into_arc();
+                et.into_renderer().render(ctx);
+                et.identifier().name().to_string()
             }
 
             OutputType::List(l) => {
                 let substring = self.render_output_type(l, ctx);
                 format!("[{}]", substring)
-            }
-
-            OutputType::Scalar(ScalarType::Enum(et)) => {
-                let _ = et.into_renderer().render(ctx);
-                et.name().to_string()
             }
 
             OutputType::Scalar(ref scalar) => {
@@ -99,7 +88,6 @@ impl<'a> GqlTypeRenderer<'a> {
                     ScalarType::JsonList => "Json",
                     ScalarType::Xml => "Xml",
                     ScalarType::Bytes => "Bytes",
-                    ScalarType::Enum(_) => unreachable!("Encountered enum type during GQL scalar rendering."), // Handled separately above.
                     ScalarType::Null => unreachable!("Null types should not be picked for GQL rendering."),
                 };
 

--- a/query-engine/request-handlers/src/transactions/mod.rs
+++ b/query-engine/request-handlers/src/transactions/mod.rs
@@ -7,4 +7,7 @@ pub struct TxInput {
 
     /// Time in milliseconds after which the transaction rolls back automatically.
     pub timeout: u64,
+
+    /// Isolation level to use for the transaction.
+    pub isolation_level: Option<String>,
 }

--- a/query-engine/schema-builder/src/cache.rs
+++ b/query-engine/schema-builder/src/cache.rs
@@ -85,3 +85,12 @@ macro_rules! return_cached_output {
         }
     };
 }
+
+/// Convenience cache utility to load and return immediately if an output object type is already cached.
+macro_rules! return_cached_enum {
+    ($ctx:ident, $name:expr) => {
+        if let Some(existing_type) = $ctx.get_enum_type($name) {
+            return existing_type;
+        }
+    };
+}

--- a/query-engine/schema-builder/src/constants.rs
+++ b/query-engine/schema-builder/src/constants.rs
@@ -155,4 +155,12 @@ pub mod output_fields {
     pub const AFFECTED_COUNT: &str = "count";
 }
 
+pub mod itx {
+    pub const READ_UNCOMMITTED: &str = "ReadUncommitted";
+    pub const READ_COMMITTED: &str = "ReadCommitted";
+    pub const REPEATABLE_READ: &str = "RepeatableRead";
+    pub const SERIALIZABLE: &str = "Serializable";
+    pub const SNAPSHOT: &str = "Snapshot";
+}
+
 pub mod deprecation {}

--- a/query-engine/schema-builder/src/enum_types.rs
+++ b/query-engine/schema-builder/src/enum_types.rs
@@ -45,7 +45,7 @@ pub(crate) fn map_schema_enum_type(ctx: &mut BuilderContext, enum_name: &str) ->
 
 pub(crate) fn model_field_enum(ctx: &mut BuilderContext, model: &ModelRef) -> EnumTypeWeakRef {
     let name = format!("{}ScalarFieldEnum", capitalize(&model.name));
-    let ident = Identifier::new(name.clone(), PRISMA_NAMESPACE);
+    let ident = Identifier::new(name, PRISMA_NAMESPACE);
     return_cached_enum!(ctx, &ident);
 
     let values = model
@@ -106,7 +106,7 @@ pub(crate) fn order_by_relevance_enum(
     values: Vec<String>,
 ) -> EnumTypeWeakRef {
     let name = format!("{}OrderByRelevanceFieldEnum", container);
-    let ident = Identifier::new(name.clone(), PRISMA_NAMESPACE);
+    let ident = Identifier::new(name, PRISMA_NAMESPACE);
     return_cached_enum!(ctx, &ident);
 
     let typ = Arc::new(EnumType::string(ident.clone(), values));

--- a/query-engine/schema-builder/src/enum_types.rs
+++ b/query-engine/schema-builder/src/enum_types.rs
@@ -1,0 +1,129 @@
+use super::*;
+use crate::constants::{filters, json_null, ordering};
+use schema::EnumType;
+
+pub(crate) fn sort_order_enum(ctx: &mut BuilderContext) -> EnumTypeWeakRef {
+    let ident = Identifier::new(ordering::SORT_ORDER, PRISMA_NAMESPACE);
+    return_cached_enum!(ctx, &ident);
+
+    let typ = Arc::new(EnumType::string(
+        ident.clone(),
+        vec![ordering::ASC.to_owned(), ordering::DESC.to_owned()],
+    ));
+
+    ctx.cache_enum_type(ident, typ.clone());
+    Arc::downgrade(&typ)
+}
+
+pub(crate) fn nulls_order_enum(ctx: &mut BuilderContext) -> EnumTypeWeakRef {
+    let ident = Identifier::new(ordering::NULLS_ORDER, PRISMA_NAMESPACE);
+    return_cached_enum!(ctx, &ident);
+
+    let typ = Arc::new(EnumType::string(
+        ident.clone(),
+        vec![ordering::FIRST.to_owned(), ordering::LAST.to_owned()],
+    ));
+
+    ctx.cache_enum_type(ident, typ.clone());
+    Arc::downgrade(&typ)
+}
+
+pub(crate) fn map_schema_enum_type(ctx: &mut BuilderContext, enum_name: &str) -> EnumTypeWeakRef {
+    let ident = Identifier::new(enum_name, MODEL_NAMESPACE);
+    return_cached_enum!(ctx, &ident);
+
+    let schema_enum = ctx
+        .internal_data_model
+        .find_enum(enum_name)
+        .expect("Enum references must always be valid.");
+
+    let typ = Arc::new(EnumType::database(ident.clone(), schema_enum));
+
+    ctx.cache_enum_type(ident, typ.clone());
+    Arc::downgrade(&typ)
+}
+
+pub(crate) fn model_field_enum(ctx: &mut BuilderContext, model: &ModelRef) -> EnumTypeWeakRef {
+    let name = format!("{}ScalarFieldEnum", capitalize(&model.name));
+    let ident = Identifier::new(name.clone(), PRISMA_NAMESPACE);
+    return_cached_enum!(ctx, &ident);
+
+    let values = model
+        .fields()
+        .scalar()
+        .into_iter()
+        .map(|field| (field.name.clone(), field))
+        .collect();
+
+    let typ = Arc::new(EnumType::field_ref(ident.clone(), values));
+
+    ctx.cache_enum_type(ident, typ.clone());
+    Arc::downgrade(&typ)
+}
+
+pub(crate) fn json_null_filter_enum(ctx: &mut BuilderContext) -> EnumTypeWeakRef {
+    let ident = Identifier::new(json_null::FILTER_ENUM_NAME, PRISMA_NAMESPACE);
+    return_cached_enum!(ctx, &ident);
+
+    let typ = Arc::new(EnumType::string(
+        ident.clone(),
+        vec![
+            json_null::DB_NULL.to_owned(),
+            json_null::JSON_NULL.to_owned(),
+            json_null::ANY_NULL.to_owned(),
+        ],
+    ));
+
+    ctx.cache_enum_type(ident, typ.clone());
+    Arc::downgrade(&typ)
+}
+
+pub(crate) fn json_null_input_enum(ctx: &mut BuilderContext, nullable: bool) -> EnumTypeWeakRef {
+    let ident = if nullable {
+        Identifier::new(json_null::NULLABLE_INPUT_ENUM_NAME, PRISMA_NAMESPACE)
+    } else {
+        Identifier::new(json_null::INPUT_ENUM_NAME, PRISMA_NAMESPACE)
+    };
+
+    return_cached_enum!(ctx, &ident);
+
+    let typ = if nullable {
+        Arc::new(EnumType::string(
+            ident.clone(),
+            vec![json_null::DB_NULL.to_owned(), json_null::JSON_NULL.to_owned()],
+        ))
+    } else {
+        Arc::new(EnumType::string(ident.clone(), vec![json_null::JSON_NULL.to_owned()]))
+    };
+
+    ctx.cache_enum_type(ident, typ.clone());
+    Arc::downgrade(&typ)
+}
+
+pub(crate) fn order_by_relevance_enum(
+    ctx: &mut BuilderContext,
+    container: &str,
+    values: Vec<String>,
+) -> EnumTypeWeakRef {
+    let name = format!("{}OrderByRelevanceFieldEnum", container);
+    let ident = Identifier::new(name.clone(), PRISMA_NAMESPACE);
+    return_cached_enum!(ctx, &ident);
+
+    let typ = Arc::new(EnumType::string(ident.clone(), values));
+
+    ctx.cache_enum_type(ident, typ.clone());
+    Arc::downgrade(&typ)
+}
+
+pub(crate) fn query_mode_enum(ctx: &mut BuilderContext) -> EnumTypeWeakRef {
+    let ident = Identifier::new("QueryMode", PRISMA_NAMESPACE);
+    return_cached_enum!(ctx, &ident);
+
+    let typ = Arc::new(EnumType::string(
+        ident.clone(),
+        vec![filters::DEFAULT.to_owned(), filters::INSENSITIVE.to_owned()],
+    ));
+
+    ctx.cache_enum_type(ident, typ.clone());
+    Arc::downgrade(&typ)
+}

--- a/query-engine/schema-builder/src/input_types/fields/arguments.rs
+++ b/query-engine/schema-builder/src/input_types/fields/arguments.rs
@@ -114,7 +114,7 @@ pub(crate) fn relation_selection_arguments(
         args.push(
             input_field(
                 args::DISTINCT,
-                InputType::list(InputType::Enum(model_field_enum(model))),
+                InputType::list(InputType::Enum(model_field_enum(ctx, model))),
                 None,
             )
             .optional(),
@@ -126,8 +126,6 @@ pub(crate) fn relation_selection_arguments(
 
 /// Builds "many composite where" arguments for to-many composite selection sets.
 pub(crate) fn composite_selection_arguments(_ctx: &mut BuilderContext, _cf: &CompositeFieldRef) -> Vec<InputField> {
-    //vec![order_by_argument(ctx, &(&cf.typ).into(), &OrderByOptions::new())]
-
     vec![]
 }
 
@@ -148,7 +146,7 @@ pub(crate) fn order_by_argument(
 }
 
 pub(crate) fn group_by_arguments(ctx: &mut BuilderContext, model: &ModelRef) -> Vec<InputField> {
-    let field_enum_type = InputType::Enum(model_field_enum(model));
+    let field_enum_type = InputType::Enum(model_field_enum(ctx, model));
 
     vec![
         where_argument(ctx, model),

--- a/query-engine/schema-builder/src/input_types/fields/data_input_mapper/create.rs
+++ b/query-engine/schema-builder/src/input_types/fields/data_input_mapper/create.rs
@@ -23,14 +23,10 @@ impl DataInputFieldMapper for CreateDataInputFieldMapper {
 
         match &sf.type_identifier {
             TypeIdentifier::Json if supports_advanced_json => {
-                let enum_type = json_null_input_enum(!sf.is_required());
+                let enum_type = InputType::enum_type(json_null_input_enum(ctx, !sf.is_required()));
 
-                input_field(
-                    sf.name.clone(),
-                    vec![InputType::Enum(enum_type), typ],
-                    sf.default_value.clone(),
-                )
-                .optional_if(!sf.is_required() || sf.default_value.is_some() || sf.is_updated_at)
+                input_field(sf.name.clone(), vec![enum_type, typ], sf.default_value.clone())
+                    .optional_if(!sf.is_required() || sf.default_value.is_some() || sf.is_updated_at)
             }
 
             _ => input_field(sf.name.clone(), typ, sf.default_value.clone())

--- a/query-engine/schema-builder/src/input_types/fields/data_input_mapper/mod.rs
+++ b/query-engine/schema-builder/src/input_types/fields/data_input_mapper/mod.rs
@@ -5,7 +5,6 @@ pub(crate) use create::*;
 pub(crate) use update::*;
 
 use super::*;
-use crate::constants::json_null;
 use prisma_models::prelude::*;
 
 // Todo: This isn't final, this is only the first draft to get structure into the
@@ -30,18 +29,4 @@ pub(crate) trait DataInputFieldMapper {
     fn map_relation(&self, ctx: &mut BuilderContext, rf: &RelationFieldRef) -> InputField;
 
     fn map_composite(&self, ctx: &mut BuilderContext, cf: &CompositeFieldRef) -> InputField;
-}
-
-fn json_null_input_enum(nullable: bool) -> EnumTypeRef {
-    if nullable {
-        Arc::new(string_enum_type(
-            json_null::NULLABLE_INPUT_ENUM_NAME,
-            vec![json_null::DB_NULL.to_owned(), json_null::JSON_NULL.to_owned()],
-        ))
-    } else {
-        Arc::new(string_enum_type(
-            json_null::INPUT_ENUM_NAME,
-            vec![json_null::JSON_NULL.to_owned()],
-        ))
-    }
 }

--- a/query-engine/schema-builder/src/input_types/fields/data_input_mapper/update.rs
+++ b/query-engine/schema-builder/src/input_types/fields/data_input_mapper/update.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::constants::*;
+use crate::{constants::*, enum_types::*};
 use prisma_models::CompositeFieldRef;
 
 pub(crate) struct UpdateDataInputFieldMapper {
@@ -40,12 +40,8 @@ impl DataInputFieldMapper for UpdateDataInputFieldMapper {
         let has_adv_json = ctx.has_capability(ConnectorCapability::AdvancedJsonNullability);
         match &sf.type_identifier {
             TypeIdentifier::Json if has_adv_json => {
-                let enum_type = json_null_input_enum(!sf.is_required());
-                let input_field = input_field(
-                    sf.name.clone(),
-                    vec![InputType::Enum(enum_type), base_update_type],
-                    None,
-                );
+                let enum_type = InputType::enum_type(json_null_input_enum(ctx, !sf.is_required()));
+                let input_field = input_field(sf.name.clone(), vec![enum_type, base_update_type], None);
 
                 input_field.optional()
             }

--- a/query-engine/schema-builder/src/input_types/mod.rs
+++ b/query-engine/schema-builder/src/input_types/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod fields;
 pub(crate) mod objects;
 
 use super::*;
+use crate::enum_types::*;
 use fields::*;
 use prisma_models::ScalarFieldRef;
 use schema::*;
@@ -20,7 +21,7 @@ fn map_scalar_input_type(ctx: &mut BuilderContext, typ: &TypeIdentifier, list: b
         TypeIdentifier::UUID => InputType::uuid(),
         TypeIdentifier::DateTime => InputType::date_time(),
         TypeIdentifier::Json => InputType::json(),
-        TypeIdentifier::Enum(e) => map_enum_input_type(ctx, e),
+        TypeIdentifier::Enum(e) => InputType::enum_type(map_schema_enum_type(ctx, e)),
         TypeIdentifier::Xml => InputType::xml(),
         TypeIdentifier::Bytes => InputType::bytes(),
         TypeIdentifier::BigInt => InputType::bigint(),
@@ -32,17 +33,6 @@ fn map_scalar_input_type(ctx: &mut BuilderContext, typ: &TypeIdentifier, list: b
     } else {
         typ
     }
-}
-
-fn map_enum_input_type(ctx: &mut BuilderContext, enum_name: &str) -> InputType {
-    let e = ctx
-        .internal_data_model
-        .find_enum(enum_name)
-        .expect("Enum references must always be valid.");
-
-    let et: EnumType = e.into();
-
-    et.into()
 }
 
 /// Convenience function to return [object_type, list_object_type]
@@ -67,16 +57,4 @@ fn compound_object_name(alias: Option<&String>, from_fields: &[ScalarFieldRef]) 
         let field_names: Vec<String> = from_fields.iter().map(|field| capitalize(&field.name)).collect();
         field_names.join("")
     })
-}
-
-fn model_field_enum(model: &ModelRef) -> EnumTypeRef {
-    Arc::new(EnumType::FieldRef(FieldRefEnumType {
-        name: format!("{}ScalarFieldEnum", capitalize(&model.name)),
-        values: model
-            .fields()
-            .scalar()
-            .into_iter()
-            .map(|field| (field.name.clone(), field))
-            .collect(),
-    }))
 }

--- a/query-engine/schema-builder/src/lib.rs
+++ b/query-engine/schema-builder/src/lib.rs
@@ -33,6 +33,7 @@
 #[macro_use]
 mod cache;
 pub mod constants;
+mod enum_types;
 mod input_types;
 mod mutations;
 mod output_types;
@@ -57,6 +58,7 @@ pub(crate) struct BuilderContext {
     preview_features: Vec<PreviewFeature>,
     nested_create_inputs_queue: NestedInputsQueue,
     nested_update_inputs_queue: NestedInputsQueue,
+    // enums?
 }
 
 impl BuilderContext {
@@ -95,6 +97,11 @@ impl BuilderContext {
         self.cache.output_types.get(ident)
     }
 
+    /// Get an enum type.
+    pub fn get_enum_type(&mut self, ident: &Identifier) -> Option<EnumTypeWeakRef> {
+        self.cache.enum_types.get(ident)
+    }
+
     /// Caches an input (object) type.
     pub fn cache_input_type(&mut self, ident: Identifier, typ: InputObjectTypeStrongRef) {
         self.cache.input_types.insert(ident, typ);
@@ -103,6 +110,11 @@ impl BuilderContext {
     /// Caches an output (object) type.
     pub fn cache_output_type(&mut self, ident: Identifier, typ: ObjectTypeStrongRef) {
         self.cache.output_types.insert(ident, typ);
+    }
+
+    /// Caches an enum type.
+    pub fn cache_enum_type(&mut self, ident: Identifier, e: EnumTypeRef) {
+        self.cache.enum_types.insert(ident, e);
     }
 
     pub fn can_full_text_search(&self) -> bool {
@@ -124,6 +136,7 @@ impl BuilderContext {
 struct TypeCache {
     input_types: TypeRefCache<InputObjectType>,
     output_types: TypeRefCache<ObjectType>,
+    enum_types: TypeRefCache<EnumType>,
 }
 
 impl TypeCache {
@@ -131,6 +144,7 @@ impl TypeCache {
         Self {
             input_types: TypeRefCache::new(),
             output_types: TypeRefCache::new(),
+            enum_types: TypeRefCache::new(),
         }
     }
 
@@ -178,6 +192,7 @@ pub fn build(
         mutation_type,
         input_objects,
         output_objects,
+        vec![],
         ctx.internal_data_model,
         ctx.capabilities.capabilities,
         preview_features,

--- a/query-engine/schema-builder/src/output_types/field.rs
+++ b/query-engine/schema-builder/src/output_types/field.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::enum_types::*;
 use input_types::fields::arguments;
 use prisma_models::{CompositeFieldRef, ScalarFieldRef};
 
@@ -30,7 +31,7 @@ pub(crate) fn map_scalar_output_type(ctx: &mut BuilderContext, typ: &TypeIdentif
         TypeIdentifier::Float => OutputType::float(),
         TypeIdentifier::Decimal => OutputType::decimal(),
         TypeIdentifier::Boolean => OutputType::boolean(),
-        TypeIdentifier::Enum(e) => map_enum_type(ctx, e).into(),
+        TypeIdentifier::Enum(e) => OutputType::enum_type(map_schema_enum_type(ctx, e)),
         TypeIdentifier::Json => OutputType::json(),
         TypeIdentifier::DateTime => OutputType::date_time(),
         TypeIdentifier::UUID => OutputType::uuid(),
@@ -56,15 +57,6 @@ pub(crate) fn map_relation_output_type(ctx: &mut BuilderContext, rf: &RelationFi
     } else {
         related_model_obj
     }
-}
-
-fn map_enum_type(ctx: &mut BuilderContext, enum_name: &str) -> EnumType {
-    let e = ctx
-        .internal_data_model
-        .find_enum(enum_name)
-        .expect("Enum references must always be valid.");
-
-    e.into()
 }
 
 fn map_composite_field_output_type(ctx: &mut BuilderContext, cf: &CompositeFieldRef) -> OutputType {

--- a/query-engine/schema-builder/src/utils.rs
+++ b/query-engine/schema-builder/src/utils.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::EnumType;
 use once_cell::sync::OnceCell;
 use prisma_models::pk::PrimaryKey;
 use prisma_models::{dml, ModelRef};
@@ -29,17 +28,6 @@ pub fn init_input_object_type(ident: Identifier) -> InputObjectType {
         fields: OnceCell::new(),
         tag: None,
     }
-}
-
-/// Enum type convenience wrapper function.
-pub fn string_enum_type<T>(name: T, values: Vec<String>) -> EnumType
-where
-    T: Into<String>,
-{
-    EnumType::String(StringEnumType {
-        name: name.into(),
-        values,
-    })
 }
 
 /// Field convenience wrapper function.

--- a/query-engine/schema/src/input_types.rs
+++ b/query-engine/schema/src/input_types.rs
@@ -163,7 +163,7 @@ impl InputField {
 #[derive(Clone)]
 pub enum InputType {
     Scalar(ScalarType),
-    Enum(EnumTypeRef),
+    Enum(EnumTypeWeakRef),
     List(Box<InputType>),
     Object(InputObjectTypeWeakRef),
 }
@@ -254,7 +254,7 @@ impl InputType {
         InputType::Scalar(ScalarType::Null)
     }
 
-    pub fn enum_type(containing: EnumTypeRef) -> InputType {
+    pub fn enum_type(containing: EnumTypeWeakRef) -> InputType {
         InputType::Enum(containing)
     }
 

--- a/query-engine/schema/src/lib.rs
+++ b/query-engine/schema/src/lib.rs
@@ -27,7 +27,9 @@ pub type QuerySchemaRef = Arc<QuerySchema>;
 pub type OutputTypeRef = Arc<OutputType>;
 pub type OutputFieldRef = Arc<OutputField>;
 pub type InputFieldRef = Arc<InputField>;
+
 pub type EnumTypeRef = Arc<EnumType>;
+pub type EnumTypeWeakRef = Weak<EnumType>;
 
 /// Since we have the invariant that the weak refs that are used throughout the query
 /// schema have to be always valid, we use this simple trait to keep the code clutter low.

--- a/query-engine/schema/src/output_types.rs
+++ b/query-engine/schema/src/output_types.rs
@@ -6,7 +6,7 @@ use std::{fmt, sync::Arc};
 
 #[derive(Debug, Clone)]
 pub enum OutputType {
-    Enum(EnumTypeRef),
+    Enum(EnumTypeWeakRef),
     List(OutputTypeRef),
     Object(ObjectTypeWeakRef),
     Scalar(ScalarType),
@@ -43,6 +43,10 @@ impl OutputType {
 
     pub fn boolean() -> OutputType {
         OutputType::Scalar(ScalarType::Boolean)
+    }
+
+    pub fn enum_type(containing: EnumTypeWeakRef) -> OutputType {
+        OutputType::Enum(containing)
     }
 
     pub fn date_time() -> OutputType {

--- a/query-engine/schema/src/query_schema.rs
+++ b/query-engine/schema/src/query_schema.rs
@@ -36,6 +36,9 @@ pub struct QuerySchema {
 
     /// Internal. Stores all strong Arc refs to the output object types.
     _output_object_types: Vec<ObjectTypeStrongRef>,
+
+    /// Internal. Stores all enum refs.
+    _enum_types: Vec<EnumTypeRef>,
 }
 
 /// Connector meta information, to be used in query execution if necessary.
@@ -72,6 +75,7 @@ impl QuerySchema {
         mutation: OutputTypeRef,
         _input_object_types: Vec<InputObjectTypeStrongRef>,
         _output_object_types: Vec<ObjectTypeStrongRef>,
+        _enum_types: Vec<EnumTypeRef>,
         internal_data_model: InternalDataModelRef,
         capabilities: Vec<ConnectorCapability>,
         features: Vec<PreviewFeature>,
@@ -82,6 +86,7 @@ impl QuerySchema {
             mutation,
             _input_object_types,
             _output_object_types,
+            _enum_types,
             internal_data_model,
             context: ConnectorContext::new(capabilities, features, referential_integrity),
         }
@@ -115,6 +120,10 @@ impl QuerySchema {
             OutputType::Object(ref o) => o.into_arc(),
             _ => unreachable!(),
         }
+    }
+
+    pub fn enum_types(&self) -> &[EnumTypeRef] {
+        &self._enum_types
     }
 
     pub fn context(&self) -> &ConnectorContext {
@@ -213,7 +222,6 @@ pub enum ScalarType {
     Float,
     Decimal,
     Boolean,
-    Enum(EnumTypeRef),
     DateTime,
     Json,
     JsonList,


### PR DESCRIPTION
Allows setting the isolation level when starting an interactive transaction (iTx).
The configuration payload has an additional field:
```jsonc
{
    "max_wait": 1234,
    "timeout": 4321,
    "isolation_level": "Serializable" // << New
}
```

An enum is exposed on the DMMF that specifies valid values for the currently loaded connector:
```jsonc
{
  "datamodel": {
    // ...
  },
  "schema": {
    "inputObjectTypes": {
      // ...
    },
    "outputObjectTypes": {
      // ...
    },
    "enumTypes": {
      "prisma": [
        { // <<< This is added
          "name": "TransactionIsolationLevel",
          "values": [
            // <<< These are dependent on the datasource
            "ReadCommitted",
            "ReadUncommitted",
            // ...
          ]
        }
      ],
      "model": [
        // ...
      ]
    }
  },
  "mappings": {
    // ...
  }
}
```