### PR TITLE
feat(prisma-fmt): implement native types in text_document_completion

### DIFF
--- a/prisma-fmt/tests/text_document_completion/scenarios/native_type_empty/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/native_type_empty/result.json
@@ -1,0 +1,23 @@
+{
+  "isIncomplete": false,
+  "items": [
+    {
+      "label": "Int2",
+      "kind": 4,
+      "insertText": "Int2",
+      "insertTextFormat": 2
+    },
+    {
+      "label": "Int4",
+      "kind": 4,
+      "insertText": "Int4",
+      "insertTextFormat": 2
+    },
+    {
+      "label": "Oid",
+      "kind": 4,
+      "insertText": "Oid",
+      "insertTextFormat": 2
+    }
+  ]
+}

--- a/prisma-fmt/tests/text_document_completion/scenarios/native_type_empty/schema.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/native_type_empty/schema.prisma
@@ -1,0 +1,9 @@
+datasource cr {
+    provider = "cockroachdb"
+    url = env("TEST_DATABASE_URL")
+}
+
+model test {
+    id String @id @default(uuid())
+    number Int @cr.<|>
+}

--- a/prisma-fmt/tests/text_document_completion/scenarios/native_type_partially_typed/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/native_type_partially_typed/result.json
@@ -1,0 +1,47 @@
+{
+  "isIncomplete": false,
+  "items": [
+    {
+      "label": "Bit",
+      "kind": 4,
+      "insertText": "Bit($0)",
+      "insertTextFormat": 2
+    },
+    {
+      "label": "Binary",
+      "kind": 4,
+      "insertText": "Binary($0)",
+      "insertTextFormat": 2
+    },
+    {
+      "label": "VarBinary",
+      "kind": 4,
+      "insertText": "VarBinary($0)",
+      "insertTextFormat": 2
+    },
+    {
+      "label": "TinyBlob",
+      "kind": 4,
+      "insertText": "TinyBlob",
+      "insertTextFormat": 2
+    },
+    {
+      "label": "Blob",
+      "kind": 4,
+      "insertText": "Blob",
+      "insertTextFormat": 2
+    },
+    {
+      "label": "MediumBlob",
+      "kind": 4,
+      "insertText": "MediumBlob",
+      "insertTextFormat": 2
+    },
+    {
+      "label": "LongBlob",
+      "kind": 4,
+      "insertText": "LongBlob",
+      "insertTextFormat": 2
+    }
+  ]
+}

--- a/prisma-fmt/tests/text_document_completion/scenarios/native_type_partially_typed/schema.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/native_type_partially_typed/schema.prisma
@@ -1,0 +1,10 @@
+datasource cr {
+    provider = "mysql"
+    url = env("TEST_DATABASE_URL")
+}
+
+model testModel {
+    id Int @id
+    wat Bytes @cr.Bl<|>
+    name String
+}

--- a/prisma-fmt/tests/text_document_completion/tests.rs
+++ b/prisma-fmt/tests/text_document_completion/tests.rs
@@ -17,18 +17,20 @@ scenarios! {
     default_map_mssql
     empty_schema
     extended_indexes_basic
-    extended_indexes_types_postgres
-    extended_indexes_types_mysql
-    extended_indexes_types_sqlserver
-    extended_indexes_types_sqlite
-    extended_indexes_types_mongo
-    extended_indexes_types_cockroach
-    extended_indexes_operators_postgres_gist
-    extended_indexes_operators_postgres_gin
-    extended_indexes_operators_postgres_spgist
-    extended_indexes_operators_postgres_brin
     extended_indexes_operators_cockroach_gin
+    extended_indexes_operators_postgres_brin
+    extended_indexes_operators_postgres_gin
+    extended_indexes_operators_postgres_gist
+    extended_indexes_operators_postgres_spgist
+    extended_indexes_types_cockroach
+    extended_indexes_types_mongo
+    extended_indexes_types_mysql
+    extended_indexes_types_postgres
+    extended_indexes_types_sqlite
+    extended_indexes_types_sqlserver
     language_tools_relation_directive
+    native_type_empty
+    native_type_partially_typed
     no_default_map_on_postgres
     referential_actions_end_of_args_list
     referential_actions_in_progress


### PR DESCRIPTION
Originally to fix https://github.com/prisma/language-tools/issues/1195,
but that would also let us remove the native_types method on prisma-fmt.