### PR TITLE
feat: enable filtering on _count

### DIFF
--- a/libs/datamodel/core/src/common/preview_features.rs
+++ b/libs/datamodel/core/src/common/preview_features.rs
@@ -65,6 +65,7 @@ features!(
     Metrics,
     OrderByNulls,
     MultiSchema,
+    FilteredCount
 );
 
 /// Generator preview features

--- a/libs/datamodel/core/src/common/preview_features.rs
+++ b/libs/datamodel/core/src/common/preview_features.rs
@@ -65,7 +65,7 @@ features!(
     Metrics,
     OrderByNulls,
     MultiSchema,
-    FilteredCount
+    FilteredRelationCount,
 );
 
 /// Generator preview features

--- a/libs/datamodel/core/src/common/preview_features.rs
+++ b/libs/datamodel/core/src/common/preview_features.rs
@@ -78,6 +78,7 @@ pub const GENERATOR: FeatureMap = FeatureMap {
          | Tracing
          | Metrics
          | OrderByNulls
+         | FilteredRelationCount
     }),
     deprecated: enumflags2::make_bitflags!(PreviewFeature::{
         AtomicNumberOperations

--- a/libs/datamodel/core/tests/config/generators.rs
+++ b/libs/datamodel/core/tests/config/generators.rs
@@ -259,7 +259,7 @@ fn nice_error_for_unknown_generator_preview_feature() {
         .unwrap_err();
 
     let expectation = expect![[r#"
-        [1;91merror[0m: [1mThe preview feature "foo" is not known. Expected one of: referentialIntegrity, interactiveTransactions, fullTextSearch, fullTextIndex, tracing, metrics, orderByNulls[0m
+        [1;91merror[0m: [1mThe preview feature "foo" is not known. Expected one of: referentialIntegrity, interactiveTransactions, fullTextSearch, fullTextIndex, tracing, metrics, orderByNulls, filteredRelationCount[0m
           [1;94m-->[0m  [4mschema.prisma:3[0m
         [1;94m   | [0m
         [1;94m 2 | [0m  provider = "prisma-client-js"

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/many_count_relation.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/many_count_relation.rs
@@ -613,7 +613,7 @@ mod many_count_rel {
         schema.to_owned()
     }
 
-    #[connector_test(schema(composite_schema), only(MongoDb))]
+    #[connector_test(schema(composite_schema), capabilities(CompositeTypes))]
     async fn filtered_count_composite(runner: Runner) -> TestResult<()> {
         run_query!(
             &runner,

--- a/query-engine/connectors/mongodb-query-connector/src/filter.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/filter.rs
@@ -6,7 +6,7 @@ use connector_interface::{
 use mongodb::bson::{doc, Bson, Document};
 use prisma_models::{CompositeFieldRef, PrismaValue, ScalarFieldRef, TypeIdentifier};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) enum MongoFilter {
     Scalar(Document),
     Composite(Document),
@@ -17,8 +17,8 @@ impl MongoFilter {
     pub(crate) fn render(self) -> (Document, Vec<JoinStage>) {
         match self {
             Self::Scalar(document) => (document, vec![]),
-            Self::Relation(rf) => (rf.filter, rf.joins),
             Self::Composite(document) => (document, vec![]),
+            Self::Relation(rf) => (rf.filter, rf.joins),
         }
     }
 
@@ -27,7 +27,7 @@ impl MongoFilter {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct MongoRelationFilter {
     /// The filter that has to be applied to this layer of nesting (after all joins on this layer are done).
     pub filter: Document,

--- a/query-engine/connectors/mongodb-query-connector/src/join.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/join.rs
@@ -1,3 +1,4 @@
+use crate::filter::MongoFilter;
 use mongodb::bson::{doc, Document};
 use prisma_models::RelationFieldRef;
 
@@ -22,6 +23,9 @@ pub(crate) struct JoinStage {
 
     /// Nested joins
     pub(crate) nested: Vec<JoinStage>,
+
+    /// Filter on the join itself, used for aggregations on relations.
+    pub(crate) filter: Option<MongoFilter>,
 }
 
 impl JoinStage {
@@ -30,6 +34,7 @@ impl JoinStage {
             source,
             alias: None,
             nested: vec![],
+            filter: None,
         }
     }
 
@@ -55,9 +60,18 @@ impl JoinStage {
     ///
     /// Returns: `(Join document, Unwind document)`
     pub(crate) fn build(self) -> (Document, Option<Document>) {
+        let (filter_doc, filter_joins) = if let Some(filter) = self.filter {
+            let (filter, joins) = filter.render();
+
+            (Some(filter), joins)
+        } else {
+            (None, vec![])
+        };
+
         let nested_stages: Vec<Document> = self
             .nested
             .into_iter()
+            .chain(filter_joins)
             .map(|nested_stage| {
                 let (join, _) = nested_stage.build();
 
@@ -130,7 +144,13 @@ impl JoinStage {
 
         // We can now express the match from the operators
         pipeline.push(doc! { "$match": { "$expr": { "$and": ops } }});
+
         pipeline.extend(nested_stages);
+
+        // Add
+        if let Some(doc) = filter_doc {
+            pipeline.push(doc! { "$match": { "$expr": doc } });
+        }
 
         // If the field is a to-one, add an unwind stage.
         let unwind_stage = if !from_field.is_list() {

--- a/query-engine/connectors/query-connector/src/interface.rs
+++ b/query-engine/connectors/query-connector/src/interface.rs
@@ -174,7 +174,7 @@ pub enum AggregationResult {
 #[derive(Debug, Clone)]
 pub enum RelAggregationSelection {
     // Always a count(*) for now
-    Count(RelationFieldRef),
+    Count(RelationFieldRef, Option<Filter>),
 }
 
 pub type RelAggregationRow = Vec<RelAggregationResult>;
@@ -187,7 +187,7 @@ pub enum RelAggregationResult {
 impl RelAggregationSelection {
     pub fn db_alias(&self) -> String {
         match self {
-            RelAggregationSelection::Count(rf) => {
+            RelAggregationSelection::Count(rf, _) => {
                 format!("_aggr_count_{}", rf.name.to_owned())
             }
         }
@@ -195,19 +195,19 @@ impl RelAggregationSelection {
 
     pub fn field_name(&self) -> &str {
         match self {
-            RelAggregationSelection::Count(rf) => rf.name.as_str(),
+            RelAggregationSelection::Count(rf, _) => rf.name.as_str(),
         }
     }
 
     pub fn type_identifier_with_arity(&self) -> (TypeIdentifier, FieldArity) {
         match self {
-            RelAggregationSelection::Count(_) => (TypeIdentifier::Int, FieldArity::Required),
+            RelAggregationSelection::Count(_, _) => (TypeIdentifier::Int, FieldArity::Required),
         }
     }
 
     pub fn into_result(self, val: PrismaValue) -> RelAggregationResult {
         match self {
-            RelAggregationSelection::Count(rf) => RelAggregationResult::Count(rf, coerce_null_to_zero_value(val)),
+            RelAggregationSelection::Count(rf, _) => RelAggregationResult::Count(rf, coerce_null_to_zero_value(val)),
         }
     }
 }

--- a/query-engine/connectors/sql-query-connector/src/join_utils.rs
+++ b/query-engine/connectors/sql-query-connector/src/join_utils.rs
@@ -120,7 +120,7 @@ fn compute_aggr_join_m2m(
     join_alias: &str,
     previous_join: Option<&AliasedJoin>,
 ) -> AliasedJoin {
-    // _ParentToChild table
+    // _ParentToChild m2m join table
     let m2m_table = rf.as_table();
     // _ParentToChild.Child columns
     let m2m_child_columns = rf.related_field().m2m_columns();

--- a/query-engine/connectors/sql-query-connector/src/nested_aggregations.rs
+++ b/query-engine/connectors/sql-query-connector/src/nested_aggregations.rs
@@ -16,12 +16,13 @@ pub fn build(aggr_selections: &[RelAggregationSelection]) -> RelAggregationJoins
 
     for (index, selection) in aggr_selections.iter().enumerate() {
         match selection {
-            RelAggregationSelection::Count(rf) => {
+            RelAggregationSelection::Count(rf, filter) => {
                 let join_alias = format!("aggr_selection_{}", index);
                 let aggregator_alias = selection.db_alias();
                 let join = compute_aggr_join(
                     rf,
                     AggregationType::Count,
+                    filter.clone(),
                     aggregator_alias.as_str(),
                     join_alias.as_str(),
                     None,

--- a/query-engine/connectors/sql-query-connector/src/ordering.rs
+++ b/query-engine/connectors/sql-query-connector/src/ordering.rs
@@ -144,6 +144,7 @@ pub fn compute_joins_aggregation(
     let last_aggr_join = compute_aggr_join(
         last_hop.into_relation_hop().unwrap(),
         aggregation_type,
+        None,
         ORDER_AGGREGATOR_ALIAS,
         join_prefix.as_str(),
         joins.last(),

--- a/query-engine/core/src/query_graph_builder/read/many.rs
+++ b/query-engine/core/src/query_graph_builder/read/many.rs
@@ -8,7 +8,7 @@ pub fn find_many(field: ParsedField, model: ModelRef) -> QueryGraphBuilderResult
     let alias = field.alias;
     let nested_fields = field.nested_fields.unwrap().fields;
     let (aggr_fields_pairs, nested_fields) = extractors::extract_nested_rel_aggr_selections(nested_fields);
-    let aggr_selections: Vec<_> = utils::collect_relation_aggr_selections(&aggr_fields_pairs, &model);
+    let aggregation_selections = utils::collect_relation_aggr_selections(aggr_fields_pairs, &model)?;
     let selection_order: Vec<String> = utils::collect_selection_order(&nested_fields);
     let selected_fields = utils::collect_selected_fields(&nested_fields, args.distinct.clone(), &model);
     let nested = utils::collect_nested_queries(nested_fields, &model)?;
@@ -25,6 +25,6 @@ pub fn find_many(field: ParsedField, model: ModelRef) -> QueryGraphBuilderResult
         selected_fields,
         nested,
         selection_order,
-        aggregation_selections: aggr_selections,
+        aggregation_selections,
     }))
 }

--- a/query-engine/core/src/query_graph_builder/read/one.rs
+++ b/query-engine/core/src/query_graph_builder/read/one.rs
@@ -19,7 +19,7 @@ pub fn find_unique(mut field: ParsedField, model: ModelRef) -> QueryGraphBuilder
     let model = model;
     let nested_fields = field.nested_fields.unwrap().fields;
     let (aggr_fields_pairs, nested_fields) = extractors::extract_nested_rel_aggr_selections(nested_fields);
-    let aggregation_selections: Vec<_> = utils::collect_relation_aggr_selections(&aggr_fields_pairs, &model);
+    let aggregation_selections = utils::collect_relation_aggr_selections(aggr_fields_pairs, &model)?;
     let selection_order: Vec<String> = utils::collect_selection_order(&nested_fields);
     let selected_fields = utils::collect_selected_fields(&nested_fields, None, &model);
     let nested = utils::collect_nested_queries(nested_fields, &model)?;

--- a/query-engine/core/src/query_graph_builder/read/related.rs
+++ b/query-engine/core/src/query_graph_builder/read/related.rs
@@ -12,7 +12,7 @@ pub fn find_related(
     let alias = field.alias;
     let sub_selections = field.nested_fields.unwrap().fields;
     let (aggr_fields_pairs, sub_selections) = extractors::extract_nested_rel_aggr_selections(sub_selections);
-    let aggr_selections: Vec<_> = utils::collect_relation_aggr_selections(&aggr_fields_pairs, &model);
+    let aggregation_selections = utils::collect_relation_aggr_selections(aggr_fields_pairs, &model)?;
     let selection_order: Vec<String> = utils::collect_selection_order(&sub_selections);
     let selected_fields = utils::collect_selected_fields(&sub_selections, args.distinct.clone(), &model);
     let nested = utils::collect_nested_queries(sub_selections, &model)?;
@@ -29,7 +29,7 @@ pub fn find_related(
         selected_fields,
         nested,
         selection_order,
-        aggregation_selections: aggr_selections,
+        aggregation_selections,
         parent_results: None,
     }))
 }

--- a/query-engine/core/src/query_graph_builder/read/utils.rs
+++ b/query-engine/core/src/query_graph_builder/read/utils.rs
@@ -1,8 +1,8 @@
 use super::*;
-use crate::{FieldPair, ParsedField, ReadQuery};
+use crate::{ArgumentListLookup, FieldPair, ParsedField, ReadQuery};
 use connector::RelAggregationSelection;
 use prisma_models::prelude::*;
-use schema_builder::constants::aggregations::*;
+use schema_builder::constants::{aggregations::*, args};
 use std::sync::Arc;
 
 pub fn collect_selection_order(from: &[FieldPair]) -> Vec<String> {
@@ -138,26 +138,33 @@ pub fn merge_cursor_fields(selected_fields: FieldSelection, cursor: &Option<Sele
     }
 }
 
-pub fn collect_relation_aggr_selections(from: &[FieldPair], model: &ModelRef) -> Vec<RelAggregationSelection> {
-    from.iter()
-        .flat_map(|pair| match pair.parsed_field.name.as_str() {
+pub fn collect_relation_aggr_selections(
+    from: Vec<FieldPair>,
+    model: &ModelRef,
+) -> QueryGraphBuilderResult<Vec<RelAggregationSelection>> {
+    let mut selections = vec![];
+
+    for pair in from {
+        match pair.parsed_field.name.as_str() {
             UNDERSCORE_COUNT => {
-                let nested_fields = pair.parsed_field.nested_fields.as_ref().unwrap();
+                let nested_fields = pair.parsed_field.nested_fields.unwrap();
 
-                nested_fields
-                    .fields
-                    .iter()
-                    .map(|nested_pair| {
-                        let rf = model
-                            .fields()
-                            .find_from_relation_fields(&nested_pair.parsed_field.name)
-                            .unwrap();
+                for mut nested_pair in nested_fields.fields {
+                    let rf = model
+                        .fields()
+                        .find_from_relation_fields(&nested_pair.parsed_field.name)
+                        .unwrap();
+                    let filter = match nested_pair.parsed_field.arguments.lookup(args::WHERE) {
+                        Some(where_arg) => Some(extract_filter(where_arg.value.try_into()?, rf.related_model())?),
+                        _ => None,
+                    };
 
-                        RelAggregationSelection::Count(rf)
-                    })
-                    .collect::<Vec<_>>()
+                    selections.push(RelAggregationSelection::Count(rf, filter));
+                }
             }
             field_name => panic!("Unknown field name \"{}\" for a relation aggregation", field_name),
-        })
-        .collect::<Vec<_>>()
+        }
+    }
+
+    Ok(selections)
 }

--- a/query-engine/schema-builder/src/output_types/field.rs
+++ b/query-engine/schema-builder/src/output_types/field.rs
@@ -116,7 +116,15 @@ where
 
     let fields: Vec<OutputField> = fields
         .iter()
-        .map(|rf| field(rf.name.clone(), vec![], type_mapper(ctx, rf), None))
+        .map(|rf| {
+            let mut args = vec![];
+
+            if ctx.has_feature(&PreviewFeature::FilteredCount) {
+                args.push(arguments::where_argument(ctx, &rf.related_model()))
+            }
+
+            field(rf.name.clone(), args, type_mapper(ctx, rf), None)
+        })
         .collect();
 
     let object = object_mapper(object_type(ident.clone(), fields, None));

--- a/query-engine/schema-builder/src/output_types/field.rs
+++ b/query-engine/schema-builder/src/output_types/field.rs
@@ -119,7 +119,7 @@ where
         .map(|rf| {
             let mut args = vec![];
 
-            if ctx.has_feature(&PreviewFeature::FilteredCount) {
+            if ctx.has_feature(&PreviewFeature::FilteredRelationCount) {
                 args.push(arguments::where_argument(ctx, &rf.related_model()))
             }
 


### PR DESCRIPTION
## Overview

fixes https://github.com/prisma/prisma/issues/8413

Enable filtering on relation `_count`. Scalar & nested relation filters are supported.

- Adds a `filteredRelationCount` preview feature
- Adds a `where` input to the `_count` fields
- Works on _all_ connectors

## Usage

```js
await prisma.x.findMany({
  select: {
    _count: {
      select: {
        one2m: { where: { /* ... any scalar or relation filter ... */ } },
        m2m:   { where: { /* ... any scalar or relation filter ... */ } }
      }
   }
  }
})
```