### PR TITLE
fix(introspection): fix commenting out of enum values

### DIFF
--- a/introspection-engine/introspection-engine-tests/tests/commenting_out/mod.rs
+++ b/introspection-engine/introspection-engine-tests/tests/commenting_out/mod.rs
@@ -1,12 +1,11 @@
 mod cockroachdb;
 mod mssql;
 mod mysql;
+mod postgres;
 mod sqlite;
 
 use barrel::types;
-use indoc::indoc;
-use introspection_engine_tests::{assert_eq_json, test_api::*, TestResult};
-use serde_json::json;
+use introspection_engine_tests::test_api::*;
 
 #[test_connector(exclude(Mssql, Mysql, CockroachDb))]
 async fn a_table_without_uniques_should_ignore(api: &TestApi) -> TestResult {
@@ -38,45 +37,6 @@ async fn a_table_without_uniques_should_ignore(api: &TestApi) -> TestResult {
         model User {
           id   Int    @id @default(autoincrement())
           Post Post[] @ignore
-        }
-    "#]];
-
-    expected.assert_eq(&api.introspect_dml().await?);
-
-    Ok(())
-}
-
-#[test_connector(tags(Postgres), exclude(CockroachDb))]
-async fn relations_between_ignored_models_should_not_have_field_level_ignores(api: &TestApi) -> TestResult {
-    api.barrel()
-        .execute(|migration| {
-            migration.create_table("User", |t| {
-                t.inject_custom("id macaddr primary key not null");
-            });
-            migration.create_table("Post", |t| {
-                t.inject_custom("id macaddr primary key not null");
-                t.inject_custom("user_id macaddr not null");
-                t.add_foreign_key(&["user_id"], "User", &["id"]);
-            });
-        })
-        .await?;
-
-    let expected = expect![[r#"
-        /// The underlying table does not contain a valid unique identifier and can therefore currently not be handled by the Prisma Client.
-        model Post {
-          id      Unsupported("macaddr") @id
-          user_id Unsupported("macaddr")
-          User    User                   @relation(fields: [user_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
-
-          @@ignore
-        }
-
-        /// The underlying table does not contain a valid unique identifier and can therefore currently not be handled by the Prisma Client.
-        model User {
-          id   Unsupported("macaddr") @id
-          Post Post[]
-
-          @@ignore
         }
     "#]];
 
@@ -148,139 +108,6 @@ async fn a_table_without_fully_required_compound_unique(api: &TestApi) -> TestRe
     Ok(())
 }
 
-#[test_connector(tags(Postgres), exclude(CockroachDb))]
-async fn unsupported_type_keeps_its_usages(api: &TestApi) -> TestResult {
-    api.barrel()
-        .execute(|migration| {
-            migration.create_table("Test", |t| {
-                t.add_column("id", types::integer().unique(true));
-                t.add_column("dummy", types::integer());
-                t.add_column("broken", types::custom("macaddr"));
-                t.add_index("unique", types::index(vec!["broken", "dummy"]).unique(true));
-                t.add_index("non_unique", types::index(vec!["broken", "dummy"]).unique(false));
-                t.set_primary_key(&["broken", "dummy"]);
-            });
-        })
-        .await?;
-
-    let expected = json!([{
-        "code": 3,
-        "message": "These fields are not supported by the Prisma Client, because Prisma currently does not support their types.",
-        "affected": [
-            {
-                "model": "Test",
-                "field": "broken",
-                "tpe": "macaddr"
-            }
-        ]
-    }]);
-
-    assert_eq_json!(expected, api.introspection_warnings().await?);
-
-    let dm = expect![[r#"
-        model Test {
-          id     Int                    @unique
-          dummy  Int
-          broken Unsupported("macaddr")
-
-          @@id([broken, dummy])
-          @@unique([broken, dummy], map: "unique")
-          @@index([broken, dummy], map: "non_unique")
-        }
-    "#]];
-
-    let result = api.introspect_dml().await?;
-
-    dm.assert_eq(&result);
-
-    Ok(())
-}
-
-#[test_connector(tags(Postgres), exclude(CockroachDb))]
-async fn a_table_with_only_an_unsupported_id(api: &TestApi) -> TestResult {
-    api.barrel()
-        .execute(|migration| {
-            migration.create_table("Test", |t| {
-                t.add_column("dummy", types::integer());
-                t.add_column(
-                    "network_mac",
-                    types::custom("macaddr").primary(true).default("08:00:2b:01:02:03"),
-                );
-            });
-        })
-        .await?;
-
-    let expected = json!([
-        {
-            "code": 1,
-            "message": "The following models were commented out as they do not have a valid unique identifier or id. This is currently not supported by the Prisma Client.",
-            "affected": [{
-                "model": "Test"
-            }]
-        },
-        {
-            "code": 3,
-            "message": "These fields are not supported by the Prisma Client, because Prisma currently does not support their types.",
-            "affected": [{
-                "model": "Test",
-                "field": "network_mac",
-                "tpe": "macaddr"
-            }]
-        }
-    ]);
-
-    assert_eq_json!(expected, api.introspection_warnings().await?);
-
-    let dm = indoc! {r#"
-        /// The underlying table does not contain a valid unique identifier and can therefore currently not be handled by the Prisma Client.
-        model Test {
-          dummy       Int
-          network_mac Unsupported("macaddr") @id @default(dbgenerated("'08:00:2b:01:02:03'::macaddr"))
-
-          @@ignore
-        }
-    "#};
-
-    api.assert_eq_datamodels(dm, &api.introspect().await?);
-
-    Ok(())
-}
-
-#[test_connector(tags(Postgres), exclude(CockroachDb))]
-async fn a_table_with_unsupported_types_in_a_relation(api: &TestApi) -> TestResult {
-    api.barrel()
-        .execute(|migration| {
-            migration.create_table("User", |t| {
-                t.add_column("id", types::primary());
-                t.inject_custom("ip cidr not null unique");
-            });
-            migration.create_table("Post", |t| {
-                t.add_column("id", types::primary());
-                t.inject_custom("user_ip cidr not null");
-                t.add_foreign_key(&["user_ip"], "User", &["ip"]);
-            });
-        })
-        .await?;
-
-    let expected = expect![[r#"
-        model Post {
-          id      Int                 @id @default(autoincrement())
-          user_ip Unsupported("cidr")
-          User    User                @relation(fields: [user_ip], references: [ip], onDelete: NoAction, onUpdate: NoAction)
-        }
-
-        model User {
-          id   Int                 @id @default(autoincrement())
-          ip   Unsupported("cidr") @unique
-          Post Post[]
-        }
-    "#]];
-
-    expected.assert_eq(&api.introspect_dml().await?);
-
-    Ok(())
-}
-
 #[test_connector(exclude(CockroachDb))]
 async fn remapping_field_names_to_empty(api: &TestApi) -> TestResult {
     api.barrel()
@@ -303,102 +130,6 @@ async fn remapping_field_names_to_empty(api: &TestApi) -> TestResult {
     "#};
 
     api.assert_eq_datamodels(dm, &api.introspect().await?);
-
-    Ok(())
-}
-
-#[test_connector(tags(Postgres), exclude(CockroachDb))]
-async fn dbgenerated_in_unsupported(api: &TestApi) -> TestResult {
-    api.barrel()
-        .execute(|migration| {
-            migration.create_table("Blog", move |t| {
-                t.add_column("id", types::primary());
-                t.inject_custom("number Integer Default 1");
-                t.inject_custom("bigger_number Integer DEFAULT sqrt(4)");
-                t.inject_custom("point Point DEFAULT Point(0, 0)");
-            });
-        })
-        .await?;
-
-    let dm = indoc! {r##"
-        model Blog {
-          id                Int    @id @default(autoincrement())
-          number            Int?   @default(1)
-          bigger_number     Int?   @default(dbgenerated("sqrt((4)::double precision)"))
-          point             Unsupported("point")? @default(dbgenerated("point((0)::double precision, (0)::double precision)"))
-        }
-    "##};
-
-    api.assert_eq_datamodels(dm, &api.introspect().await?);
-
-    Ok(())
-}
-
-#[test_connector(tags(Postgres))]
-async fn commenting_out_a_table_without_columns(api: &TestApi) -> TestResult {
-    api.barrel()
-        .execute(|migration| {
-            migration.create_table("Test", |_t| {});
-        })
-        .await?;
-
-    let expected = json!([{
-        "code": 14,
-        "message": "The following models were commented out as we could not retrieve columns for them. Please check your privileges.",
-        "affected": [
-            {
-                "model": "Test"
-            }
-        ]
-    }]);
-
-    assert_eq_json!(expected, api.introspection_warnings().await?);
-
-    let dm = indoc! {r#"
-        // We could not retrieve columns for the underlying table. Either it has none or you are missing rights to see them. Please check your privileges.
-        // model Test {
-        // }
-    "#};
-
-    api.assert_eq_datamodels(dm, &api.introspect().await?);
-
-    Ok(())
-}
-
-#[test_connector(tags(Postgres), exclude(CockroachDb))]
-async fn ignore_on_back_relation_field_if_pointing_to_ignored_model(api: &TestApi) -> TestResult {
-    api.barrel()
-        .execute(|migration| {
-            migration.create_table("User", |t| {
-                t.add_column("id", types::primary());
-                t.inject_custom("ip integer not null unique");
-            });
-            migration.create_table("Post", |t| {
-                t.add_column("id", types::integer());
-                t.inject_custom("user_ip integer not null ");
-                t.add_foreign_key(&["user_ip"], "User", &["ip"]);
-            });
-        })
-        .await?;
-
-    let expected = expect![[r#"
-        /// The underlying table does not contain a valid unique identifier and can therefore currently not be handled by the Prisma Client.
-        model Post {
-          id      Int
-          user_ip Int
-          User    User @relation(fields: [user_ip], references: [ip], onDelete: NoAction, onUpdate: NoAction)
-
-          @@ignore
-        }
-
-        model User {
-          id   Int    @id @default(autoincrement())
-          ip   Int    @unique
-          Post Post[] @ignore
-        }
-    "#]];
-
-    expected.assert_eq(&api.introspect_dml().await?);
 
     Ok(())
 }

--- a/introspection-engine/introspection-engine-tests/tests/commenting_out/postgres.rs
+++ b/introspection-engine/introspection-engine-tests/tests/commenting_out/postgres.rs
@@ -1,0 +1,271 @@
+use barrel::types;
+use introspection_engine_tests::{assert_eq_json, test_api::*};
+use serde_json::json;
+
+#[test_connector(tags(Postgres), exclude(CockroachDb))]
+async fn relations_between_ignored_models_should_not_have_field_level_ignores(api: &TestApi) -> TestResult {
+    api.barrel()
+        .execute(|migration| {
+            migration.create_table("User", |t| {
+                t.inject_custom("id macaddr primary key not null");
+            });
+            migration.create_table("Post", |t| {
+                t.inject_custom("id macaddr primary key not null");
+                t.inject_custom("user_id macaddr not null");
+                t.add_foreign_key(&["user_id"], "User", &["id"]);
+            });
+        })
+        .await?;
+
+    let expected = expect![[r#"
+        /// The underlying table does not contain a valid unique identifier and can therefore currently not be handled by the Prisma Client.
+        model Post {
+          id      Unsupported("macaddr") @id
+          user_id Unsupported("macaddr")
+          User    User                   @relation(fields: [user_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
+
+          @@ignore
+        }
+
+        /// The underlying table does not contain a valid unique identifier and can therefore currently not be handled by the Prisma Client.
+        model User {
+          id   Unsupported("macaddr") @id
+          Post Post[]
+
+          @@ignore
+        }
+    "#]];
+
+    expected.assert_eq(&api.introspect_dml().await?);
+
+    Ok(())
+}
+
+#[test_connector(tags(Postgres), exclude(CockroachDb))]
+async fn unsupported_type_keeps_its_usages(api: &TestApi) -> TestResult {
+    api.barrel()
+        .execute(|migration| {
+            migration.create_table("Test", |t| {
+                t.add_column("id", types::integer().unique(true));
+                t.add_column("dummy", types::integer());
+                t.add_column("broken", types::custom("macaddr"));
+                t.add_index("unique", types::index(vec!["broken", "dummy"]).unique(true));
+                t.add_index("non_unique", types::index(vec!["broken", "dummy"]).unique(false));
+                t.set_primary_key(&["broken", "dummy"]);
+            });
+        })
+        .await?;
+
+    let expected = json!([{
+        "code": 3,
+        "message": "These fields are not supported by the Prisma Client, because Prisma currently does not support their types.",
+        "affected": [
+            {
+                "model": "Test",
+                "field": "broken",
+                "tpe": "macaddr"
+            }
+        ]
+    }]);
+
+    assert_eq_json!(expected, api.introspection_warnings().await?);
+
+    let dm = expect![[r#"
+        model Test {
+          id     Int                    @unique
+          dummy  Int
+          broken Unsupported("macaddr")
+
+          @@id([broken, dummy])
+          @@unique([broken, dummy], map: "unique")
+          @@index([broken, dummy], map: "non_unique")
+        }
+    "#]];
+
+    let result = api.introspect_dml().await?;
+
+    dm.assert_eq(&result);
+
+    Ok(())
+}
+
+#[test_connector(tags(Postgres), exclude(CockroachDb))]
+async fn a_table_with_only_an_unsupported_id(api: &TestApi) -> TestResult {
+    api.barrel()
+        .execute(|migration| {
+            migration.create_table("Test", |t| {
+                t.add_column("dummy", types::integer());
+                t.add_column(
+                    "network_mac",
+                    types::custom("macaddr").primary(true).default("08:00:2b:01:02:03"),
+                );
+            });
+        })
+        .await?;
+
+    let expected = json!([
+        {
+            "code": 1,
+            "message": "The following models were commented out as they do not have a valid unique identifier or id. This is currently not supported by the Prisma Client.",
+            "affected": [{
+                "model": "Test"
+            }]
+        },
+        {
+            "code": 3,
+            "message": "These fields are not supported by the Prisma Client, because Prisma currently does not support their types.",
+            "affected": [{
+                "model": "Test",
+                "field": "network_mac",
+                "tpe": "macaddr"
+            }]
+        }
+    ]);
+
+    assert_eq_json!(expected, api.introspection_warnings().await?);
+
+    let dm = indoc! {r#"
+        /// The underlying table does not contain a valid unique identifier and can therefore currently not be handled by the Prisma Client.
+        model Test {
+          dummy       Int
+          network_mac Unsupported("macaddr") @id @default(dbgenerated("'08:00:2b:01:02:03'::macaddr"))
+
+          @@ignore
+        }
+    "#};
+
+    api.assert_eq_datamodels(dm, &api.introspect().await?);
+
+    Ok(())
+}
+
+#[test_connector(tags(Postgres), exclude(CockroachDb))]
+async fn a_table_with_unsupported_types_in_a_relation(api: &TestApi) -> TestResult {
+    api.barrel()
+        .execute(|migration| {
+            migration.create_table("User", |t| {
+                t.add_column("id", types::primary());
+                t.inject_custom("ip cidr not null unique");
+            });
+            migration.create_table("Post", |t| {
+                t.add_column("id", types::primary());
+                t.inject_custom("user_ip cidr not null");
+                t.add_foreign_key(&["user_ip"], "User", &["ip"]);
+            });
+        })
+        .await?;
+
+    let expected = expect![[r#"
+        model Post {
+          id      Int                 @id @default(autoincrement())
+          user_ip Unsupported("cidr")
+          User    User                @relation(fields: [user_ip], references: [ip], onDelete: NoAction, onUpdate: NoAction)
+        }
+
+        model User {
+          id   Int                 @id @default(autoincrement())
+          ip   Unsupported("cidr") @unique
+          Post Post[]
+        }
+    "#]];
+
+    expected.assert_eq(&api.introspect_dml().await?);
+
+    Ok(())
+}
+
+#[test_connector(tags(Postgres), exclude(CockroachDb))]
+async fn dbgenerated_in_unsupported(api: &TestApi) -> TestResult {
+    api.barrel()
+        .execute(|migration| {
+            migration.create_table("Blog", move |t| {
+                t.add_column("id", types::primary());
+                t.inject_custom("number Integer Default 1");
+                t.inject_custom("bigger_number Integer DEFAULT sqrt(4)");
+                t.inject_custom("point Point DEFAULT Point(0, 0)");
+            });
+        })
+        .await?;
+
+    let dm = indoc! {r##"
+        model Blog {
+          id                Int    @id @default(autoincrement())
+          number            Int?   @default(1)
+          bigger_number     Int?   @default(dbgenerated("sqrt((4)::double precision)"))
+          point             Unsupported("point")? @default(dbgenerated("point((0)::double precision, (0)::double precision)"))
+        }
+    "##};
+
+    api.assert_eq_datamodels(dm, &api.introspect().await?);
+
+    Ok(())
+}
+
+#[test_connector(tags(Postgres))]
+async fn commenting_out_a_table_without_columns(api: &TestApi) -> TestResult {
+    api.barrel()
+        .execute(|migration| {
+            migration.create_table("Test", |_t| {});
+        })
+        .await?;
+
+    let expected = json!([{
+        "code": 14,
+        "message": "The following models were commented out as we could not retrieve columns for them. Please check your privileges.",
+        "affected": [
+            {
+                "model": "Test"
+            }
+        ]
+    }]);
+
+    assert_eq_json!(expected, api.introspection_warnings().await?);
+
+    let dm = indoc! {r#"
+        // We could not retrieve columns for the underlying table. Either it has none or you are missing rights to see them. Please check your privileges.
+        // model Test {
+        // }
+    "#};
+
+    api.assert_eq_datamodels(dm, &api.introspect().await?);
+
+    Ok(())
+}
+
+#[test_connector(tags(Postgres), exclude(CockroachDb))]
+async fn ignore_on_back_relation_field_if_pointing_to_ignored_model(api: &TestApi) -> TestResult {
+    api.barrel()
+        .execute(|migration| {
+            migration.create_table("User", |t| {
+                t.add_column("id", types::primary());
+                t.inject_custom("ip integer not null unique");
+            });
+            migration.create_table("Post", |t| {
+                t.add_column("id", types::integer());
+                t.inject_custom("user_ip integer not null ");
+                t.add_foreign_key(&["user_ip"], "User", &["ip"]);
+            });
+        })
+        .await?;
+
+    let expected = expect![[r#"
+        /// The underlying table does not contain a valid unique identifier and can therefore currently not be handled by the Prisma Client.
+        model Post {
+          id      Int
+          user_ip Int
+          User    User @relation(fields: [user_ip], references: [ip], onDelete: NoAction, onUpdate: NoAction)
+
+          @@ignore
+        }
+
+        model User {
+          id   Int    @id @default(autoincrement())
+          ip   Int    @unique
+          Post Post[] @ignore
+        }
+    "#]];
+
+    expected.assert_eq(&api.introspect_dml().await?);
+
+    Ok(())
+}

--- a/introspection-engine/introspection-engine-tests/tests/enums/mod.rs
+++ b/introspection-engine/introspection-engine-tests/tests/enums/mod.rs
@@ -115,7 +115,6 @@ async fn a_table_with_an_enum_default_value_that_is_an_empty_string(api: &TestAp
     Ok(())
 }
 
-
 #[test_connector(exclude(CockroachDb), capabilities(Enums))]
 async fn a_table_with_enum_default_values_that_look_like_booleans(api: &TestApi) -> TestResult {
     let sql_family = api.sql_family();

--- a/introspection-engine/introspection-engine-tests/tests/enums/mod.rs
+++ b/introspection-engine/introspection-engine-tests/tests/enums/mod.rs
@@ -1,9 +1,10 @@
 mod cockroachdb;
+mod mysql;
+mod postgres;
 
 use barrel::types;
-use indoc::indoc;
 use introspection_engine_tests::{test_api::*, TestResult};
-use quaint::prelude::{Queryable, SqlFamily};
+use quaint::prelude::Queryable;
 use test_macros::test_connector;
 
 #[test_connector(exclude(CockroachDb), capabilities(Enums))]
@@ -11,13 +12,11 @@ async fn a_table_with_enums(api: &TestApi) -> TestResult {
     let sql_family = api.sql_family();
 
     if sql_family.is_postgres() {
-        api.database()
-            .raw_cmd(r#"CREATE TYPE "color" AS ENUM ('black', 'white')"#)
-            .await?;
-
-        api.database()
-            .raw_cmd(r#"CREATE TYPE "color2" AS ENUM ('black2', 'white2')"#)
-            .await?;
+        let sql = r#"
+            CREATE TYPE "color" AS ENUM ('black', 'white');
+            CREATE TYPE "color2" AS ENUM ('black2', 'white2');
+        "#;
+        api.database().raw_cmd(sql).await?;
     }
 
     api.barrel()
@@ -109,6 +108,59 @@ async fn a_table_with_an_enum_default_value_that_is_an_empty_string(api: &TestAp
         }}
     "#,
         color,
+    );
+
+    api.assert_eq_datamodels(&dm, &api.introspect().await?);
+
+    Ok(())
+}
+
+
+#[test_connector(exclude(CockroachDb), capabilities(Enums))]
+async fn a_table_with_enum_default_values_that_look_like_booleans(api: &TestApi) -> TestResult {
+    let sql_family = api.sql_family();
+
+    if sql_family.is_postgres() {
+        api.database()
+            .raw_cmd("CREATE Type truth as ENUM ('true', 'false', 'rumor')")
+            .await?;
+    }
+
+    api.barrel()
+        .execute(move |migration| {
+            migration.create_table("News", move |t| {
+                t.add_column("id", types::primary());
+
+                let typ = if sql_family.is_postgres() {
+                    "truth"
+                } else {
+                    "ENUM ('true', 'false', 'rumor')"
+                };
+
+                t.add_column("confirmed", types::custom(typ).nullable(false).default("true"));
+            });
+        })
+        .await?;
+
+    let enum_name = if sql_family.is_mysql() {
+        "News_confirmed"
+    } else {
+        "truth"
+    };
+
+    let dm = format!(
+        r#"
+        model News {{
+            id          Int @id @default(autoincrement())
+            confirmed   {0} @default(true)
+        }}
+        enum {0} {{
+            true
+            false
+            rumor
+        }}
+    "#,
+        enum_name,
     );
 
     api.assert_eq_datamodels(&dm, &api.introspect().await?);
@@ -222,130 +274,6 @@ async fn a_table_with_enum_default_values(api: &TestApi) -> TestResult {
     );
 
     api.assert_eq_datamodels(&dm, &api.introspect().await?);
-
-    Ok(())
-}
-
-#[test_connector(exclude(CockroachDb), capabilities(Enums, ScalarLists))]
-async fn a_table_enums_array(api: &TestApi) -> TestResult {
-    let sql_family = api.sql_family();
-
-    match sql_family {
-        SqlFamily::Postgres => {
-            api.database()
-                .raw_cmd(r#"CREATE Type "color" as ENUM ('black','white')"#)
-                .await?;
-        }
-        _ => todo!("{}", sql_family),
-    }
-
-    api.barrel()
-        .execute(|migration| {
-            migration.create_table("Book", |t| {
-                t.add_column("id", types::primary());
-                t.add_column("color", types::custom("color[]"));
-            });
-        })
-        .await?;
-
-    let dm = indoc! {
-        r#"
-        model Book {
-            id      Int     @id @default(autoincrement())
-            color   color[]
-        }
-
-        enum color {
-            black
-            white
-        }
-        "#,
-    };
-
-    let result = api.introspect().await?;
-
-    api.assert_eq_datamodels(dm, &result);
-
-    Ok(())
-}
-
-#[test_connector(exclude(CockroachDb), capabilities(Enums))]
-async fn a_table_with_enum_default_values_that_look_like_booleans(api: &TestApi) -> TestResult {
-    let sql_family = api.sql_family();
-
-    if sql_family.is_postgres() {
-        api.database()
-            .raw_cmd("CREATE Type truth as ENUM ('true', 'false', 'rumor')")
-            .await?;
-    }
-
-    api.barrel()
-        .execute(move |migration| {
-            migration.create_table("News", move |t| {
-                t.add_column("id", types::primary());
-
-                let typ = if sql_family.is_postgres() {
-                    "truth"
-                } else {
-                    "ENUM ('true', 'false', 'rumor')"
-                };
-
-                t.add_column("confirmed", types::custom(typ).nullable(false).default("true"));
-            });
-        })
-        .await?;
-
-    let enum_name = if sql_family.is_mysql() {
-        "News_confirmed"
-    } else {
-        "truth"
-    };
-
-    let dm = format!(
-        r#"
-        model News {{
-            id          Int @id @default(autoincrement())
-            confirmed   {0} @default(true)
-        }}
-
-        enum {0} {{
-            true
-            false
-            rumor
-        }}
-    "#,
-        enum_name,
-    );
-
-    api.assert_eq_datamodels(&dm, &api.introspect().await?);
-
-    Ok(())
-}
-
-#[test_connector(tags(Postgres))]
-async fn enum_reintrospection_preserves_good_indentation(api: &TestApi) -> TestResult {
-    let original = indoc!(
-        r#"
-        enum MyEnum {
-          A
-          B
-
-          @@map("theEnumName")
-        }
-        "#
-    );
-
-    api.raw_cmd(r#"CREATE TYPE "theEnumName" AS ENUM ('A', 'B');"#).await;
-
-    let reintrospected: String = api
-        .re_introspect(original)
-        .await?
-        .lines()
-        .skip_while(|l| !l.starts_with("enum"))
-        .collect::<Vec<&str>>()
-        .join("\n");
-
-    assert_eq!(original.trim_end(), reintrospected);
 
     Ok(())
 }

--- a/introspection-engine/introspection-engine-tests/tests/enums/mysql.rs
+++ b/introspection-engine/introspection-engine-tests/tests/enums/mysql.rs
@@ -1,0 +1,32 @@
+use introspection_engine_tests::test_api::*;
+
+#[test_connector(tags(Mysql))]
+async fn an_enum_with_invalid_value_names_should_have_them_commented_out(api: &TestApi) -> TestResult {
+    let sql = r#"CREATE TABLE `test` ( `threechars` ENUM ('123', 'wow','$§!') );"#;
+    api.raw_cmd(sql).await;
+    let expected = expect![[r#"
+        generator client {
+          provider = "prisma-client-js"
+        }
+
+        datasource db {
+          provider = "mysql"
+          url      = "env(TEST_DATABASE_URL)"
+        }
+
+        /// The underlying table does not contain a valid unique identifier and can therefore currently not be handled by the Prisma Client.
+        model test {
+          threechars test_threechars?
+
+          @@ignore
+        }
+
+        enum test_threechars {
+          // 123 @map("123")
+          wow
+          // $§! @map("$§!")
+        }
+    "#]];
+    api.expect_datamodel(&expected).await;
+    Ok(())
+}

--- a/introspection-engine/introspection-engine-tests/tests/enums/postgres.rs
+++ b/introspection-engine/introspection-engine-tests/tests/enums/postgres.rs
@@ -59,3 +59,27 @@ async fn a_table_enums_array(api: &TestApi) -> TestResult {
 
     Ok(())
 }
+
+#[test_connector(tags(Postgres), exclude(CockroachDb))]
+async fn an_enum_with_invalid_value_names_should_have_them_commented_out(api: &TestApi) -> TestResult {
+    let sql = r#"CREATE TYPE "threechars" AS ENUM ('123', 'wow','$§!');"#;
+    api.raw_cmd(sql).await;
+    let expected = expect![[r#"
+        generator client {
+          provider = "prisma-client-js"
+        }
+
+        datasource db {
+          provider = "postgresql"
+          url      = "env(TEST_DATABASE_URL)"
+        }
+
+        enum threechars {
+          // 123 @map("123")
+          wow
+          // $§! @map("$§!")
+        }
+    "#]];
+    api.expect_datamodel(&expected).await;
+    Ok(())
+}

--- a/introspection-engine/introspection-engine-tests/tests/enums/postgres.rs
+++ b/introspection-engine/introspection-engine-tests/tests/enums/postgres.rs
@@ -1,0 +1,61 @@
+use introspection_engine_tests::test_api::*;
+
+#[test_connector(tags(Postgres))]
+async fn enum_reintrospection_preserves_good_indentation(api: &TestApi) -> TestResult {
+    let original = indoc!(
+        r#"
+        enum MyEnum {
+          A
+          B
+
+          @@map("theEnumName")
+        }
+        "#
+    );
+
+    api.raw_cmd(r#"CREATE TYPE "theEnumName" AS ENUM ('A', 'B');"#).await;
+
+    let reintrospected: String = api
+        .re_introspect(original)
+        .await?
+        .lines()
+        .skip_while(|l| !l.starts_with("enum"))
+        .collect::<Vec<&str>>()
+        .join("\n");
+
+    assert_eq!(original.trim_end(), reintrospected);
+
+    Ok(())
+}
+
+#[test_connector(tags(Postgres), exclude(CockroachDb))]
+async fn a_table_enums_array(api: &TestApi) -> TestResult {
+    let sql = r#"
+        CREATE TYPE "color" AS ENUM ('black','white');
+
+        CREATE TABLE "Book" (
+            id SERIAL PRIMARY KEY,
+            color color[] NOT NULL
+        );
+    "#;
+    api.raw_cmd(sql).await;
+    let dm = indoc! {
+        r#"
+        model Book {
+            id      Int     @id @default(autoincrement())
+            color   color[]
+        }
+
+        enum color {
+            black
+            white
+        }
+        "#,
+    };
+
+    let result = api.introspect().await?;
+
+    api.assert_eq_datamodels(dm, &result);
+
+    Ok(())
+}

--- a/libs/datamodel/core/src/transform/dml_to_ast/render_datamodel.rs
+++ b/libs/datamodel/core/src/transform/dml_to_ast/render_datamodel.rs
@@ -43,6 +43,11 @@ fn render_enum(enm: &Enum, out: &mut String) {
         if let Some(docs) = &variant.documentation {
             super::render_documentation(docs, false, out);
         }
+
+        if variant.commented_out {
+            out.push_str("// ");
+        }
+
         out.push_str(&variant.name);
 
         if let Some(mapped_name) = &variant.database_name {


### PR DESCRIPTION
 This was previously not tested.

The first commit is just moving postgres-specific tests to postgres-specific modules, the actual fix and associated test are in the second commit.