### PR TITLE
refactor(datamodel): shake off the dependency on thiserror in diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,7 +770,6 @@ version = "0.1.0"
 dependencies = [
  "colored",
  "pest",
- "thiserror",
 ]
 
 [[package]]

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/cockroach_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/cockroach_datamodel_connector.rs
@@ -404,8 +404,8 @@ impl SequenceFunction {
                     Ok(i) => this.start = Some(i),
                     Err(err) => diagnostics.push_error(err),
                 },
-                (Some(_), _) | (None, _) => diagnostics.push_error(DatamodelError::new(
-                    "Unexpected argument in `sequence()` function call".into(),
+                (Some(_), _) | (None, _) => diagnostics.push_error(DatamodelError::new_static(
+                    "Unexpected argument in `sequence()` function call",
                     span,
                 )),
             }

--- a/libs/datamodel/core/src/configuration/configuration_struct.rs
+++ b/libs/datamodel/core/src/configuration/configuration_struct.rs
@@ -16,7 +16,7 @@ impl Configuration {
     pub fn validate_that_one_datasource_is_provided(&self) -> Result<(), Diagnostics> {
         if self.datasources.is_empty() {
             Err(DatamodelError::new_validation_error(
-                "You defined no datasource. You must define exactly one datasource.".to_owned(),
+                "You defined no datasource. You must define exactly one datasource.",
                 schema_ast::ast::Span::new(0, 0),
             )
             .into())

--- a/libs/datamodel/core/src/transform/ast_to_dml/datasource_loader.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/datasource_loader.rs
@@ -280,6 +280,6 @@ fn preview_features_guardrail(args: &HashMap<&str, (Span, ValueValidator<'_>)>, 
             }
         }
         let msg = "Preview features are only supported in the generator block. Please move this field to the generator block.";
-        diagnostics.push_error(DatamodelError::new(std::borrow::Cow::Borrowed(msg), span));
+        diagnostics.push_error(DatamodelError::new_static(msg, span));
     }
 }

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations.rs
@@ -117,7 +117,7 @@ pub(super) fn validate(ctx: &mut Context<'_>) {
     if !connector.supports_enums() {
         for r#enum in db.ast().iter_tops().filter_map(|(_, top)| top.as_enum()) {
             ctx.push_error(DatamodelError::new_validation_error(
-                format!(
+                &format!(
                     "You defined the enum `{}`. But the current connector does not support enums.",
                     &r#enum.name.name
                 ),

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/composite_types.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/composite_types.rs
@@ -87,7 +87,7 @@ pub(crate) fn composite_types_support(composite_type: CompositeTypeWalker<'_>, c
     }
 
     ctx.push_error(DatamodelError::new_validation_error(
-        format!("Composite types are not supported on {}.", ctx.connector.name()),
+        &format!("Composite types are not supported on {}.", ctx.connector.name()),
         composite_type.ast_composite_type().span,
     ));
 }
@@ -101,7 +101,7 @@ pub(crate) fn more_than_one_field(composite_type: CompositeTypeWalker<'_>, ctx: 
     }
 
     ctx.push_error(DatamodelError::new_validation_error(
-        String::from("A type must have at least one field defined."),
+        "A type must have at least one field defined.",
         composite_type.ast_composite_type().span,
     ));
 }

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/fields.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/fields.rs
@@ -339,7 +339,7 @@ pub(super) fn validate_unsupported_field_type(field: ScalarFieldWalker<'_>, ctx:
                         unsupported_lit, field.name(), prisma_type.as_str(), &source.name, native_type
                     );
 
-            ctx.push_error(DatamodelError::new_validation_error(msg, field.ast_field().span));
+            ctx.push_error(DatamodelError::new_validation_error(&msg, field.ast_field().span));
         }
     }
 }

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/relation_fields.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/relation_fields.rs
@@ -167,7 +167,7 @@ pub(super) fn referential_actions(field: RelationFieldWalker<'_>, ctx: &mut Cont
                 .span_for_argument("relation", "onDelete")
                 .unwrap_or_else(|| field.ast_field().span);
 
-            ctx.push_error(DatamodelError::new_validation_error(msg(on_delete), span));
+            ctx.push_error(DatamodelError::new_validation_error(&msg(on_delete), span));
         }
     }
 
@@ -181,7 +181,7 @@ pub(super) fn referential_actions(field: RelationFieldWalker<'_>, ctx: &mut Cont
                 .span_for_argument("relation", "onUpdate")
                 .unwrap_or_else(|| field.ast_field().span);
 
-            ctx.push_error(DatamodelError::new_validation_error(msg(on_update), span));
+            ctx.push_error(DatamodelError::new_validation_error(&msg(on_update), span));
         }
     }
 }

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/relations.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/relations.rs
@@ -88,7 +88,7 @@ pub(super) fn field_arity(relation: InlineRelationWalker<'_>, ctx: &mut Context<
     let scalar_field_names: Vec<&str> = relation.referencing_fields().unwrap().map(|f| f.name()).collect();
 
     ctx.push_error(DatamodelError::new_validation_error(
-        format!(
+        &format!(
             "The relation field `{}` uses the scalar fields {}. At least one of those fields is optional. Hence the relation field must be optional as well.",
             forward_relation_field.name(),
             scalar_field_names.join(", "),
@@ -108,7 +108,7 @@ pub(super) fn same_length_in_referencing_and_referenced(relation: InlineRelation
     match (relation_field.referencing_fields(), relation_field.referenced_fields()) {
         (Some(fields), Some(references)) if fields.len() != references.len() => {
             ctx.push_error(DatamodelError::new_validation_error(
-                "You must specify the same number of fields in `fields` and `references`.".to_owned(),
+                "You must specify the same number of fields in `fields` and `references`.",
                 relation_field.relation_attribute().unwrap().span,
             ));
         }
@@ -200,7 +200,7 @@ fn referencing_fields_in_correct_order(relation: InlineRelationWalker<'_>, ctx: 
     }
 
     ctx.push_error(DatamodelError::new_validation_error(
-        format!(
+        &format!(
             "The argument `references` must refer to a unique criteria in the related model `{}` using the same order of fields. Please check the ordering in the following fields: `{}`.",
             relation.referenced_model().name(),
             relation.referenced_fields().map(|f| f.name()).join(", ")
@@ -488,7 +488,7 @@ fn cascade_error_with_default_values(
 
     msg.push_str(" Read more at https://pris.ly/d/cyclic-referential-actions");
 
-    DatamodelError::new_validation_error(msg, relation.referencing_field().ast_field().span)
+    DatamodelError::new_validation_error(&msg, relation.referencing_field().ast_field().span)
 }
 
 /// The types of the referencing and referenced scalar fields in a relation must be compatible.

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/relations/many_to_many/embedded.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/relations/many_to_many/embedded.rs
@@ -22,7 +22,7 @@ pub(crate) fn supports_embedded_relations(relation: TwoWayEmbeddedManyToManyRela
     );
 
     for span in spans {
-        ctx.push_error(DatamodelError::new_validation_error(msg.clone(), span));
+        ctx.push_error(DatamodelError::new_validation_error(&msg, span));
     }
 }
 
@@ -196,9 +196,7 @@ pub(crate) fn validate_no_referential_actions(
     });
 
     for span in referential_action_spans {
-        ctx.push_error(DatamodelError::new_validation_error(
-            "Referential actions on two-way embedded many-to-many relations are not supported".to_owned(),
-            span,
-        ));
+        let msg = "Referential actions on two-way embedded many-to-many relations are not supported";
+        ctx.push_error(DatamodelError::new_validation_error(msg, span));
     }
 }

--- a/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/relations/many_to_many/implicit.rs
+++ b/libs/datamodel/core/src/transform/ast_to_dml/validation_pipeline/validations/relations/many_to_many/implicit.rs
@@ -27,7 +27,7 @@ pub(crate) fn validate_singular_id(relation: ImplicitManyToManyRelationWalker<'_
 
         if !relation_field.references_singular_id_field() {
             ctx.push_error(DatamodelError::new_validation_error(
-            format!(
+            &format!(
                 "Implicit many-to-many relations must always reference the id field of the related model. Change the argument `references` to use the id field of the related model `{}`. But it is referencing the following fields that are not the id: {}",
                 &relation_field.related_model().name(),
                 relation_field.referenced_fields().into_iter().flatten().map(|f| f.name()).collect::<Vec<_>>().join(", ")
@@ -48,10 +48,8 @@ pub(crate) fn validate_no_referential_actions(relation: ImplicitManyToManyRelati
     });
 
     for span in referential_action_spans {
-        ctx.push_error(DatamodelError::new_validation_error(
-            "Referential actions on implicit many-to-many relations are not supported".to_owned(),
-            span,
-        ));
+        let msg = "Referential actions on implicit many-to-many relations are not supported";
+        ctx.push_error(DatamodelError::new_validation_error(msg, span));
     }
 }
 
@@ -74,7 +72,7 @@ pub(crate) fn supports_implicit_relations(relation: ImplicitManyToManyRelationWa
     );
 
     for span in spans {
-        ctx.push_error(DatamodelError::new_validation_error(msg.clone(), span));
+        ctx.push_error(DatamodelError::new_validation_error(&msg, span));
     }
 }
 

--- a/libs/datamodel/diagnostics/Cargo.toml
+++ b/libs/datamodel/diagnostics/Cargo.toml
@@ -6,4 +6,3 @@ edition = "2021"
 [dependencies]
 colored = "2"
 pest = "2.1.3"
-thiserror = "1"

--- a/libs/datamodel/diagnostics/src/collection.rs
+++ b/libs/datamodel/diagnostics/src/collection.rs
@@ -64,13 +64,6 @@ impl Diagnostics {
     }
 }
 
-impl std::fmt::Display for Diagnostics {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let msg: Vec<String> = self.errors.iter().map(|e| e.to_string()).collect();
-        f.write_str(&msg.join("\n"))
-    }
-}
-
 impl From<DatamodelError> for Diagnostics {
     fn from(error: DatamodelError) -> Self {
         let mut col = Diagnostics::new();

--- a/libs/datamodel/diagnostics/src/error.rs
+++ b/libs/datamodel/diagnostics/src/error.rs
@@ -1,177 +1,31 @@
 use crate::{pretty_print::pretty_print, Span};
-use std::{borrow::Cow, fmt};
-use thiserror::Error;
+use std::borrow::Cow;
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct DatamodelError(DatamodelErrorKind);
-
-impl fmt::Display for DatamodelError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&self.0, f)
-    }
-}
-
-impl From<DatamodelErrorKind> for DatamodelError {
-    fn from(kind: DatamodelErrorKind) -> Self {
-        DatamodelError(kind)
-    }
-}
-
-/// Enum for different errors which can happen during parsing or validation.
-///
-/// For fancy printing, please use the `pretty_print_error` function.
-// No format for this file, on purpose.
-// Line breaks make the declarations very hard to read.
-#[derive(Debug, Error, Clone, PartialEq)]
-#[rustfmt::skip]
-enum DatamodelErrorKind {
-  #[error("Argument \"{}\" is missing.", argument_name)]
-  ArgumentNotFound { argument_name: String, span: Span },
-
-  #[error("Function \"{}\" takes {} arguments, but received {}.", function_name, required_count, given_count)]
-  ArgumentCountMismatch { function_name: String, required_count: usize, given_count: usize, span: Span },
-
-  #[error("Argument \"{}\" is missing in attribute \"@{}\".", argument_name, attribute_name)]
-  AttributeArgumentNotFound { argument_name: String, attribute_name: String, span: Span },
-
-  #[error("Native types are not supported with {} connector", connector_name)]
-  NativeTypesNotSupported { connector_name: String, span: Span },
-
-  #[error("Argument \"{}\" is missing in data source block \"{}\".", argument_name, source_name)]
-  SourceArgumentNotFound { argument_name: String, source_name: String, span: Span },
-
-  #[error("Argument \"{}\" is missing in generator block \"{}\".", argument_name, generator_name)]
-  GeneratorArgumentNotFound { argument_name: String, generator_name: String, span: Span },
-
-  #[error("Attribute \"@{}\" is defined twice.", attribute_name)]
-  DuplicateAttributeError { attribute_name: String, span: Span },
-
-  #[error("The model with database name \"{}\" could not be defined because another model with this name exists: \"{}\"", model_database_name, existing_model_name)]
-  DuplicateModelDatabaseNameError { model_database_name: String, existing_model_name: String, span: Span },
-
-  #[error("Invalid Native type {}.", native_type)]
-  InvalidNativeType { native_type: String, span: Span },
-
-  #[error(
-      "Native type {} takes {} arguments, but received {}.",
-      native_type,
-      required_count,
-      given_count
-  )]
-  NativeTypeArgumentCountMismatchError {
-      native_type: String,
-      required_count: usize,
-      given_count: usize,
-      span: Span,
-  },
-
-  #[error("\"{}\" is a reserved scalar type name and cannot be used.", type_name)]
-  ReservedScalarTypeError { type_name: String, span: Span },
-
-  #[error("The {} \"{}\" cannot be defined because a {} with that name already exists.", top_type, name, existing_top_type)]
-  DuplicateTopError { name: String, top_type: String, existing_top_type: String, span: Span },
-
-  // conf_block_name is pre-populated with "" in precheck.ts.
-  #[error("Key \"{}\" is already defined in {}.", key_name, conf_block_name)]
-  DuplicateConfigKeyError { conf_block_name: String, key_name: String, span: Span },
-
-  #[error("Argument \"{}\" is already specified as unnamed argument.", arg_name)]
-  DuplicateDefaultArgumentError { arg_name: String, span: Span },
-
-  #[error("Argument \"{}\" is already specified.", arg_name)]
-  DuplicateArgumentError { arg_name: String, span: Span },
-
-  #[error("No such argument.")]
-  UnusedArgumentError { arg_name: String, span: Span },
-
-  #[error("Field \"{}\" is already defined on {} \"{}\".", field_name, container_type, model_name)]
-  DuplicateFieldError { model_name: String, field_name: String, span: Span, container_type: &'static str },
-
-  #[error("Field \"{}\" in model \"{}\" can't be a list. The current connector does not support lists of primitive types.", field_name, model_name)]
-  ScalarListFieldsAreNotSupported { model_name: String, field_name: String, span: Span },
-
-  #[error("Value \"{}\" is already defined on enum \"{}\".", value_name, enum_name)]
-  DuplicateEnumValueError { enum_name: String, value_name: String, span: Span },
-
-  #[error("Attribute not known: \"@{}\".", attribute_name)]
-  AttributeNotKnownError { attribute_name: String, span: Span },
-
-  #[error("Property not known: \"{}\".", property_name)]
-  PropertyNotKnownError { property_name: String, span: Span },
-
-  #[error("Datasource provider not known: \"{}\".", provider)]
-  DatasourceProviderNotKnownError { provider: String, span: Span },
-
-  #[error("shadowDatabaseUrl is the same as url for datasource \"{}\". Please specify a different database as shadow database.", source_name)]
-  ShadowDatabaseUrlIsSameAsMainUrl { source_name: String, span: Span },
-
-  #[error("The preview feature \"{}\" is not known. Expected one of: {}", preview_feature, expected_preview_features)]
-  PreviewFeatureNotKnownError { preview_feature: String, expected_preview_features: String, span: Span },
-
-  #[error("\"{}\" is not a valid value for {}.", raw_value, literal_type)]
-  LiteralParseError { literal_type: String, raw_value: String, span: Span },
-
-  #[error("Type \"{}\" is neither a built-in type, nor refers to another model, custom type, or enum.", type_name)]
-  TypeNotFoundError { type_name: String, span: Span },
-
-  #[error("Type \"{}\" is not a built-in type.", type_name)]
-  ScalarTypeNotFoundError { type_name: String, span: Span },
-
-  #[error("Unexpected token. Expected one of: {}", expected_str)]
-  ParserError { expected_str: String, span: Span },
-
-  #[error("Environment variable not found: {}.", var_name)]
-  EnvironmentFunctionalEvaluationError { var_name: String, span: Span },
-
-  #[error("Expected a {} value, but received {} value `{}`.", expected_type, received_type, raw)]
-  TypeMismatchError { expected_type: String, received_type: String, raw: String, span: Span },
-
-  #[error("Expected a {} value, but failed while parsing \"{}\": {}.", expected_type, raw, parser_error)]
-  ValueParserError { expected_type: String, parser_error: String, raw: String, span: Span },
-
-  #[error("Error validating model \"{}\": {}", model_name, message)]
-  ModelValidationError { message: String, model_name: String, span: Span  },
-
-  #[error("Error validating composite type \"{}\": {}", composite_type_name, message)]
-  CompositeTypeValidationError { message: String, composite_type_name: String, span: Span  },
-
-  #[error("Error validating field `{}` in {} `{}`: {}", field, container_type, container_name, message)]
-  FieldValidationError { message: String, container_name: String, field: String, span: Span, container_type: &'static str },
-
-  #[error("Error validating datasource `{datasource}`: {message}")]
-  SourceValidationError { message: String, datasource: String, span: Span },
-
-  #[error("Error validating enum `{}`: {}", enum_name, message)]
-  EnumValidationError { message: String, enum_name: String, span: Span },
-
-  #[error("Error validating: {}", message)]
-  ValidationError { message: String, span: Span },
-
-  #[error("{}", message)]
-  Raw { message: Cow<'static, str>, span: Span },
-
+pub struct DatamodelError {
+    span: Span,
+    message: Cow<'static, str>,
 }
 
 impl DatamodelError {
-    pub fn new(message: Cow<'static, str>, span: Span) -> Self {
-        DatamodelError(DatamodelErrorKind::Raw { message, span })
+    pub(crate) fn new(message: impl Into<Cow<'static, str>>, span: Span) -> Self {
+        let message = message.into();
+        DatamodelError { message, span }
+    }
+
+    pub fn new_static(message: &'static str, span: Span) -> Self {
+        Self::new(message, span)
     }
 
     pub fn new_literal_parser_error(literal_type: &str, raw_value: &str, span: Span) -> DatamodelError {
-        DatamodelErrorKind::LiteralParseError {
-            literal_type: String::from(literal_type),
-            raw_value: String::from(raw_value),
+        Self::new(
+            format!("\"{raw_value}\" is not a valid value for {literal_type}."),
             span,
-        }
-        .into()
+        )
     }
 
     pub fn new_argument_not_found_error(argument_name: &str, span: Span) -> DatamodelError {
-        DatamodelErrorKind::ArgumentNotFound {
-            argument_name: String::from(argument_name),
-            span,
-        }
-        .into()
+        Self::new(format!("Argument \"{argument_name}\" is missing."), span)
     }
 
     pub fn new_argument_count_mismatch_error(
@@ -180,13 +34,8 @@ impl DatamodelError {
         given_count: usize,
         span: Span,
     ) -> DatamodelError {
-        DatamodelErrorKind::ArgumentCountMismatch {
-            function_name: String::from(function_name),
-            required_count,
-            given_count,
-            span,
-        }
-        .into()
+        let msg = format!("Function \"{function_name}\" takes {required_count} arguments, but received {given_count}.");
+        Self::new(msg, span)
     }
 
     pub fn new_attribute_argument_not_found_error(
@@ -194,21 +43,17 @@ impl DatamodelError {
         attribute_name: &str,
         span: Span,
     ) -> DatamodelError {
-        DatamodelErrorKind::AttributeArgumentNotFound {
-            argument_name: String::from(argument_name),
-            attribute_name: String::from(attribute_name),
+        Self::new(
+            format!("Argument \"{argument_name}\" is missing in attribute \"@{attribute_name}\"."),
             span,
-        }
-        .into()
+        )
     }
 
     pub fn new_source_argument_not_found_error(argument_name: &str, source_name: &str, span: Span) -> DatamodelError {
-        DatamodelErrorKind::SourceArgumentNotFound {
-            argument_name: String::from(argument_name),
-            source_name: String::from(source_name),
+        Self::new(
+            format!("Argument \"{argument_name}\" is missing in data source block \"{source_name}\"."),
             span,
-        }
-        .into()
+        )
     }
 
     pub fn new_generator_argument_not_found_error(
@@ -216,25 +61,19 @@ impl DatamodelError {
         generator_name: &str,
         span: Span,
     ) -> DatamodelError {
-        DatamodelErrorKind::GeneratorArgumentNotFound {
-            argument_name: String::from(argument_name),
-            generator_name: String::from(generator_name),
+        Self::new(
+            format!("Argument \"{argument_name}\" is missing in generator block \"{generator_name}\"."),
             span,
-        }
-        .into()
+        )
     }
 
     pub fn new_attribute_validation_error(message: &str, attribute_name: &str, span: Span) -> DatamodelError {
-        let msg = format!("Error parsing attribute \"{attribute_name}\": {message}");
-        Self::new(msg.into(), span)
+        Self::new(format!("Error parsing attribute \"{attribute_name}\": {message}"), span)
     }
 
     pub fn new_duplicate_attribute_error(attribute_name: &str, span: Span) -> DatamodelError {
-        DatamodelErrorKind::DuplicateAttributeError {
-            attribute_name: String::from(attribute_name),
-            span,
-        }
-        .into()
+        let msg = format!("Attribute \"@{attribute_name}\" is defined twice.");
+        Self::new(msg, span)
     }
 
     pub fn new_incompatible_native_type(
@@ -247,7 +86,7 @@ impl DatamodelError {
             "Native type {} is not compatible with declared field type {}, expected field type {}.",
             native_type, field_type, expected_types
         );
-        DatamodelError::new(msg.into(), span)
+        Self::new(msg, span)
     }
 
     pub fn new_invalid_native_type_argument(
@@ -260,7 +99,7 @@ impl DatamodelError {
             "Invalid argument for type {}: {}. Allowed values: {}.",
             native_type, got, expected
         );
-        DatamodelError::new(msg.into(), span)
+        Self::new(msg, span)
     }
 
     pub fn new_invalid_prefix_for_native_types(
@@ -270,144 +109,97 @@ impl DatamodelError {
         span: Span,
     ) -> DatamodelError {
         let msg =  format!("The prefix {} is invalid. It must be equal to the name of an existing datasource e.g. {}. Did you mean to use {}?", given_prefix, expected_prefix, suggestion);
-        DatamodelError::new(msg.into(), span)
+        DatamodelError::new(msg, span)
     }
 
     pub fn new_native_types_not_supported(connector_name: String, span: Span) -> DatamodelError {
-        DatamodelErrorKind::NativeTypesNotSupported { connector_name, span }.into()
+        let msg = format!("Native types are not supported with {connector_name} connector");
+        Self::new(msg, span)
     }
 
     pub fn new_reserved_scalar_type_error(type_name: &str, span: Span) -> DatamodelError {
-        DatamodelErrorKind::ReservedScalarTypeError {
-            type_name: String::from(type_name),
-            span,
-        }
-        .into()
+        let msg = format!("\"{type_name}\" is a reserved scalar type name and cannot be used.");
+        Self::new(msg, span)
     }
 
     pub fn new_duplicate_model_database_name_error(
-        model_database_name: String,
-        existing_model_name: String,
+        model_database_name: &str,
+        existing_model_name: &str,
         span: Span,
     ) -> DatamodelError {
-        DatamodelErrorKind::DuplicateModelDatabaseNameError {
-            model_database_name,
-            existing_model_name,
-            span,
-        }
-        .into()
+        let msg = format!("The model with database name \"{}\" could not be defined because another model with this name exists: \"{}\"",
+          model_database_name,
+          existing_model_name
+        );
+        Self::new(msg, span)
     }
 
     pub fn new_duplicate_top_error(name: &str, top_type: &str, existing_top_type: &str, span: Span) -> DatamodelError {
-        DatamodelErrorKind::DuplicateTopError {
-            name: String::from(name),
-            top_type: String::from(top_type),
-            existing_top_type: String::from(existing_top_type),
-            span,
-        }
-        .into()
+        let msg = format!(
+            "The {} \"{}\" cannot be defined because a {} with that name already exists.",
+            top_type, name, existing_top_type
+        );
+        Self::new(msg, span)
     }
 
     pub fn new_duplicate_config_key_error(conf_block_name: &str, key_name: &str, span: Span) -> DatamodelError {
-        DatamodelErrorKind::DuplicateConfigKeyError {
-            conf_block_name: String::from(conf_block_name),
-            key_name: String::from(key_name),
-            span,
-        }
-        .into()
+        let msg = format!("Key \"{}\" is already defined in {}.", key_name, conf_block_name);
+        Self::new(msg, span)
     }
 
     pub fn new_duplicate_argument_error(arg_name: &str, span: Span) -> DatamodelError {
-        DatamodelErrorKind::DuplicateArgumentError {
-            arg_name: String::from(arg_name),
-            span,
-        }
-        .into()
+        Self::new(format!("Argument \"{arg_name}\" is already specified."), span)
     }
 
-    pub fn new_unused_argument_error(arg_name: &str, span: Span) -> DatamodelError {
-        DatamodelErrorKind::UnusedArgumentError {
-            arg_name: String::from(arg_name),
-            span,
-        }
-        .into()
+    pub fn new_unused_argument_error(span: Span) -> DatamodelError {
+        Self::new("No such argument.", span)
     }
 
     pub fn new_duplicate_default_argument_error(arg_name: &str, span: Span) -> DatamodelError {
-        DatamodelErrorKind::DuplicateDefaultArgumentError {
-            arg_name: String::from(arg_name),
-            span,
-        }
-        .into()
+        let msg = format!("Argument \"{arg_name}\" is already specified as unnamed argument.");
+        Self::new(msg, span)
     }
 
     pub fn new_duplicate_enum_value_error(enum_name: &str, value_name: &str, span: Span) -> DatamodelError {
-        DatamodelErrorKind::DuplicateEnumValueError {
-            enum_name: String::from(enum_name),
-            value_name: String::from(value_name),
-            span,
-        }
-        .into()
+        let msg = format!("Value \"{}\" is already defined on enum \"{}\".", value_name, enum_name);
+        Self::new(msg, span)
     }
 
     pub fn new_composite_type_duplicate_field_error(type_name: &str, field_name: &str, span: Span) -> DatamodelError {
-        DatamodelErrorKind::DuplicateFieldError {
-            container_type: "composite type",
-            model_name: String::from(type_name),
-            field_name: String::from(field_name),
-            span,
-        }
-        .into()
+        let msg = format!(
+            "Field \"{}\" is already defined on {} \"{}\".",
+            field_name, "composite type", type_name
+        );
+        Self::new(msg, span)
     }
 
     pub fn new_duplicate_field_error(model_name: &str, field_name: &str, span: Span) -> DatamodelError {
-        DatamodelErrorKind::DuplicateFieldError {
-            container_type: "model",
-            model_name: String::from(model_name),
-            field_name: String::from(field_name),
-            span,
-        }
-        .into()
+        let msg = format!(
+            "Field \"{}\" is already defined on {} \"{}\".",
+            field_name, "model", model_name
+        );
+        Self::new(msg, span)
     }
 
     pub fn new_scalar_list_fields_are_not_supported(model_name: &str, field_name: &str, span: Span) -> DatamodelError {
-        DatamodelErrorKind::ScalarListFieldsAreNotSupported {
-            model_name: String::from(model_name),
-            field_name: String::from(field_name),
-            span,
-        }
-        .into()
+        let msg = format!("Field \"{}\" in model \"{}\" can't be a list. The current connector does not support lists of primitive types.", field_name, model_name);
+        Self::new(msg, span)
     }
 
     pub fn new_model_validation_error(message: &str, model_name: &str, span: Span) -> DatamodelError {
-        DatamodelErrorKind::ModelValidationError {
-            message: String::from(message),
-            model_name: String::from(model_name),
-            span,
-        }
-        .into()
+        Self::new(format!("Error validating model \"{model_name}\": {message}"), span)
     }
 
-    pub fn new_composite_type_validation_error(
-        message: String,
-        composite_type_name: String,
-        span: Span,
-    ) -> DatamodelError {
-        DatamodelErrorKind::CompositeTypeValidationError {
-            message,
-            composite_type_name,
-            span,
-        }
-        .into()
+    pub fn new_composite_type_validation_error(message: &str, composite_type_name: &str, span: Span) -> DatamodelError {
+        let msg = format!(
+            "Error validating composite type \"{}\": {}",
+            composite_type_name, message
+        );
+        Self::new(msg, span)
     }
 
-    pub fn new_enum_validation_error(message: String, enum_name: String, span: Span) -> DatamodelError {
-        DatamodelErrorKind::EnumValidationError {
-            message,
-            enum_name,
-            span,
-        }
-        .into()
+    pub fn new_enum_validation_error(message: &str, enum_name: &str, span: Span) -> DatamodelError {
+        Self::new(format!("Error validating enum `{enum_name}`: {message}"), span)
     }
 
     pub fn new_composite_type_field_validation_error(
@@ -416,38 +208,27 @@ impl DatamodelError {
         field: &str,
         span: Span,
     ) -> DatamodelError {
-        DatamodelErrorKind::FieldValidationError {
-            message: message.to_owned(),
-            container_name: composite_type_name.to_owned(),
-            container_type: "composite type",
-            field: field.to_owned(),
-            span,
-        }
-        .into()
+        let msg = format!(
+            "Error validating field `{}` in {} `{}`: {}",
+            field, "composite type", composite_type_name, message
+        );
+        Self::new(msg, span)
     }
 
     pub fn new_field_validation_error(message: &str, model: &str, field: &str, span: Span) -> DatamodelError {
-        DatamodelErrorKind::FieldValidationError {
-            message: message.to_owned(),
-            container_name: model.to_owned(),
-            container_type: "model",
-            field: field.to_owned(),
-            span,
-        }
-        .into()
+        let msg = format!(
+            "Error validating field `{}` in {} `{}`: {}",
+            field, "model", model, message
+        );
+        Self::new(msg, span)
     }
 
     pub fn new_source_validation_error(message: &str, source: &str, span: Span) -> DatamodelError {
-        DatamodelErrorKind::SourceValidationError {
-            message: message.to_owned(),
-            datasource: source.to_owned(),
-            span,
-        }
-        .into()
+        Self::new(format!("Error validating datasource `{source}`: {message}"), span)
     }
 
-    pub fn new_validation_error(message: String, span: Span) -> DatamodelError {
-        DatamodelErrorKind::ValidationError { message, span }.into()
+    pub fn new_validation_error(message: &str, span: Span) -> DatamodelError {
+        Self::new(format!("Error validating: {message}"), span)
     }
 
     pub fn new_legacy_parser_error(message: impl Into<Cow<'static, str>>, span: Span) -> DatamodelError {
@@ -464,11 +245,11 @@ impl DatamodelError {
             "Native type {} takes {} optional arguments, but received {}.",
             native_type, optional_count, given_count
         );
-        DatamodelError::new(msg.into(), span)
+        DatamodelError::new(msg, span)
     }
 
     pub fn new_parser_error(expected_str: String, span: Span) -> DatamodelError {
-        DatamodelErrorKind::ParserError { expected_str, span }.into()
+        Self::new(format!("Unexpected token. Expected one of: {expected_str}"), span)
     }
 
     pub fn new_functional_evaluation_error(message: impl Into<Cow<'static, str>>, span: Span) -> DatamodelError {
@@ -476,63 +257,47 @@ impl DatamodelError {
     }
 
     pub fn new_environment_functional_evaluation_error(var_name: String, span: Span) -> DatamodelError {
-        DatamodelErrorKind::EnvironmentFunctionalEvaluationError { var_name, span }.into()
+        Self::new(format!("Environment variable not found: {var_name}."), span)
     }
 
     pub fn new_type_not_found_error(type_name: &str, span: Span) -> DatamodelError {
-        DatamodelErrorKind::TypeNotFoundError {
-            type_name: String::from(type_name),
-            span,
-        }
-        .into()
+        let msg = format!(
+            "Type \"{type_name}\" is neither a built-in type, nor refers to another model, custom type, or enum."
+        );
+        Self::new(msg, span)
     }
 
     pub fn new_scalar_type_not_found_error(type_name: &str, span: Span) -> DatamodelError {
-        DatamodelErrorKind::ScalarTypeNotFoundError {
-            type_name: String::from(type_name),
-            span,
-        }
-        .into()
+        Self::new(format!("Type \"{type_name}\" is not a built-in type."), span)
     }
 
     pub fn new_attribute_not_known_error(attribute_name: &str, span: Span) -> DatamodelError {
-        DatamodelErrorKind::AttributeNotKnownError {
-            attribute_name: String::from(attribute_name),
-            span,
-        }
-        .into()
+        Self::new(format!("Attribute not known: \"@{attribute_name}\"."), span)
     }
 
     pub fn new_property_not_known_error(property_name: &str, span: Span) -> DatamodelError {
-        DatamodelErrorKind::PropertyNotKnownError {
-            property_name: String::from(property_name),
-            span,
-        }
-        .into()
+        Self::new(format!("Property not known: \"{property_name}\"."), span)
     }
 
     pub fn new_default_unknown_function(function_name: &str, span: Span) -> DatamodelError {
         DatamodelError::new(format!(
                 "Unknown function in @default(): `{function_name}` is not known. You can read about the available functions here: https://pris.ly/d/attribute-functions"
-            ).into(),
+            ),
             span
         )
     }
 
     pub fn new_invalid_model_error(msg: &str, span: Span) -> DatamodelError {
-        DatamodelError::new(format!("Invalid model: {}", msg).into(), span)
+        DatamodelError::new(format!("Invalid model: {}", msg), span)
     }
 
     pub fn new_datasource_provider_not_known_error(provider: &str, span: Span) -> DatamodelError {
-        DatamodelErrorKind::DatasourceProviderNotKnownError {
-            provider: String::from(provider),
-            span,
-        }
-        .into()
+        Self::new(format!("Datasource provider not known: \"{provider}\"."), span)
     }
 
     pub fn new_shadow_database_is_same_as_main_url_error(source_name: String, span: Span) -> DatamodelError {
-        DatamodelErrorKind::ShadowDatabaseUrlIsSameAsMainUrl { source_name, span }.into()
+        let msg = format!("shadowDatabaseUrl is the same as url for datasource \"{source_name}\". Please specify a different database as shadow database.");
+        Self::new(msg, span)
     }
 
     pub fn new_preview_feature_not_known_error(
@@ -540,22 +305,16 @@ impl DatamodelError {
         expected_preview_features: String,
         span: Span,
     ) -> DatamodelError {
-        DatamodelErrorKind::PreviewFeatureNotKnownError {
-            preview_feature: String::from(preview_feature),
-            expected_preview_features,
-            span,
-        }
-        .into()
+        let msg = format!(
+            "The preview feature \"{}\" is not known. Expected one of: {}",
+            preview_feature, expected_preview_features
+        );
+        Self::new(msg, span)
     }
 
     pub fn new_value_parser_error(expected_type: &str, parser_error: &str, raw: &str, span: Span) -> DatamodelError {
-        DatamodelErrorKind::ValueParserError {
-            expected_type: String::from(expected_type),
-            parser_error: String::from(parser_error),
-            raw: String::from(raw),
-            span,
-        }
-        .into()
+        let msg = format!("Expected a {expected_type} value, but failed while parsing \"{raw}\": {parser_error}.");
+        Self::new(msg, span)
     }
 
     pub fn new_native_type_argument_count_mismatch_error(
@@ -564,13 +323,8 @@ impl DatamodelError {
         given_count: usize,
         span: Span,
     ) -> DatamodelError {
-        DatamodelErrorKind::NativeTypeArgumentCountMismatchError {
-            native_type: String::from(native_type),
-            required_count,
-            given_count,
-            span,
-        }
-        .into()
+        let msg = format!("Native type {native_type} takes {required_count} arguments, but received {given_count}.");
+        Self::new(msg, span)
     }
 
     pub fn new_native_type_name_unknown(connector_name: &str, native_type: &str, span: Span) -> DatamodelError {
@@ -578,75 +332,28 @@ impl DatamodelError {
             "Native type {} is not supported for {} connector.",
             native_type, connector_name
         );
-        DatamodelError::new(msg.into(), span)
+        DatamodelError::new(msg, span)
     }
 
     pub fn new_native_type_parser_error(native_type: &str, span: Span) -> DatamodelError {
-        DatamodelErrorKind::InvalidNativeType {
-            native_type: String::from(native_type),
-            span,
-        }
-        .into()
+        let msg = format!("Invalid Native type {native_type}.");
+        Self::new(msg, span)
     }
 
     pub fn new_type_mismatch_error(expected_type: &str, received_type: &str, raw: &str, span: Span) -> DatamodelError {
-        DatamodelErrorKind::TypeMismatchError {
-            expected_type: String::from(expected_type),
-            received_type: String::from(received_type),
-            raw: String::from(raw),
-            span,
-        }
-        .into()
+        let msg = format!("Expected a {expected_type} value, but received {received_type} value `{raw}`.");
+        Self::new(msg, span)
     }
 
     pub fn span(&self) -> Span {
-        match &self.0 {
-            DatamodelErrorKind::ArgumentNotFound { span, .. } => *span,
-            DatamodelErrorKind::AttributeArgumentNotFound { span, .. } => *span,
-            DatamodelErrorKind::ArgumentCountMismatch { span, .. } => *span,
-            DatamodelErrorKind::SourceArgumentNotFound { span, .. } => *span,
-            DatamodelErrorKind::GeneratorArgumentNotFound { span, .. } => *span,
-            DatamodelErrorKind::AttributeNotKnownError { span, .. } => *span,
-            DatamodelErrorKind::ReservedScalarTypeError { span, .. } => *span,
-            DatamodelErrorKind::DatasourceProviderNotKnownError { span, .. } => *span,
-            DatamodelErrorKind::LiteralParseError { span, .. } => *span,
-            DatamodelErrorKind::NativeTypeArgumentCountMismatchError { span, .. } => *span,
-            DatamodelErrorKind::TypeNotFoundError { span, .. } => *span,
-            DatamodelErrorKind::ScalarTypeNotFoundError { span, .. } => *span,
-            DatamodelErrorKind::ParserError { span, .. } => *span,
-            DatamodelErrorKind::EnvironmentFunctionalEvaluationError { span, .. } => *span,
-            DatamodelErrorKind::TypeMismatchError { span, .. } => *span,
-            DatamodelErrorKind::ValueParserError { span, .. } => *span,
-            DatamodelErrorKind::ValidationError { span, .. } => *span,
-            DatamodelErrorKind::ModelValidationError { span, .. } => *span,
-            DatamodelErrorKind::DuplicateAttributeError { span, .. } => *span,
-            DatamodelErrorKind::DuplicateConfigKeyError { span, .. } => *span,
-            DatamodelErrorKind::DuplicateTopError { span, .. } => *span,
-            DatamodelErrorKind::DuplicateFieldError { span, .. } => *span,
-            DatamodelErrorKind::DuplicateEnumValueError { span, .. } => *span,
-            DatamodelErrorKind::DuplicateArgumentError { span, .. } => *span,
-            DatamodelErrorKind::DuplicateModelDatabaseNameError { span, .. } => *span,
-            DatamodelErrorKind::DuplicateDefaultArgumentError { span, .. } => *span,
-            DatamodelErrorKind::UnusedArgumentError { span, .. } => *span,
-            DatamodelErrorKind::ScalarListFieldsAreNotSupported { span, .. } => *span,
-            DatamodelErrorKind::FieldValidationError { span, .. } => *span,
-            DatamodelErrorKind::SourceValidationError { span, .. } => *span,
-            DatamodelErrorKind::EnumValidationError { span, .. } => *span,
-            DatamodelErrorKind::Raw { span, .. } => *span,
-            DatamodelErrorKind::PreviewFeatureNotKnownError { span, .. } => *span,
-            DatamodelErrorKind::ShadowDatabaseUrlIsSameAsMainUrl { span, .. } => *span,
-            DatamodelErrorKind::CompositeTypeValidationError { span, .. } => *span,
-            DatamodelErrorKind::PropertyNotKnownError { span, .. } => *span,
-            DatamodelErrorKind::InvalidNativeType { span, .. } => *span,
-            DatamodelErrorKind::NativeTypesNotSupported { span, .. } => *span,
-        }
+        self.span
     }
 
-    pub fn description(&self) -> String {
-        self.to_string()
+    pub fn message(&self) -> &str {
+        &self.message
     }
 
     pub fn pretty_print(&self, f: &mut dyn std::io::Write, file_name: &str, text: &str) -> std::io::Result<()> {
-        pretty_print(f, file_name, text, self.span(), self.description().as_str())
+        pretty_print(f, file_name, text, self.span(), self.message.as_ref())
     }
 }

--- a/libs/datamodel/diagnostics/src/native_type_error_factory.rs
+++ b/libs/datamodel/diagnostics/src/native_type_error_factory.rs
@@ -15,8 +15,7 @@ impl NativeTypeErrorFactory {
             format!(
                 "The scale must not be larger than the precision for the {} native type in {}.",
                 self.native_type, self.connector
-            )
-            .into(),
+            ),
             span,
         )
     }
@@ -26,8 +25,7 @@ impl NativeTypeErrorFactory {
             format!(
                 "You cannot define an index on fields with native type `{}` of {}.{message}",
                 self.native_type, self.connector
-            )
-            .into(),
+            ),
             span,
         )
     }
@@ -37,8 +35,7 @@ impl NativeTypeErrorFactory {
             format!(
                 "Native type `{}` cannot be unique in {}.{message}",
                 self.native_type, self.connector
-            )
-            .into(),
+            ),
             span,
         )
     }
@@ -48,8 +45,7 @@ impl NativeTypeErrorFactory {
             format!(
                 "Native type `{}` of {} cannot be used on a field that is `@id` or `@@id`.{message}",
                 self.native_type, self.connector
-            )
-            .into(),
+            ),
             span,
         )
     }
@@ -59,8 +55,7 @@ impl NativeTypeErrorFactory {
             format!(
                 "Argument M is out of range for native type `{}` of {}: {message}",
                 self.native_type, self.connector
-            )
-            .into(),
+            ),
             span,
         )
     }
@@ -70,8 +65,7 @@ impl NativeTypeErrorFactory {
             format!(
                 "Native type {} is not supported for {} connector.",
                 self.native_type, self.connector
-            )
-            .into(),
+            ),
             span,
         )
     }

--- a/libs/datamodel/parser-database/src/attributes.rs
+++ b/libs/datamodel/parser-database/src/attributes.rs
@@ -692,7 +692,7 @@ fn visit_relation(model_id: ast::ModelId, relation_field: &mut RelationField, ct
 
                     let msg = format!("The argument fields must refer only to existing fields. The following fields do not exist in this model: {unresolvable_fields}");
 
-                    ctx.push_error(DatamodelError::new_validation_error(msg, fields.span()))
+                    ctx.push_error(DatamodelError::new_validation_error(&msg, fields.span()))
                 }
 
                 if !relation_fields.is_empty() {
@@ -704,7 +704,7 @@ fn visit_relation(model_id: ast::ModelId, relation_field: &mut RelationField, ct
 
                     let msg = format!("The argument fields must refer only to scalar fields. But it is referencing the following relation fields: {relation_fields}");
 
-                    ctx.push_error(DatamodelError::new_validation_error(msg, fields.span()));
+                    ctx.push_error(DatamodelError::new_validation_error(&msg, fields.span()));
                 }
 
                 Vec::new()
@@ -740,7 +740,7 @@ fn visit_relation(model_id: ast::ModelId, relation_field: &mut RelationField, ct
                         "The argument `references` must refer only to existing fields in the related model `{model_name}`. The following fields do not exist in the related model: {field_names}",
                     );
 
-                    ctx.push_error(DatamodelError::new_validation_error(msg, attr.span));
+                    ctx.push_error(DatamodelError::new_validation_error(&msg, attr.span));
                 }
 
                 if !relation_fields.is_empty() {
@@ -749,7 +749,7 @@ fn visit_relation(model_id: ast::ModelId, relation_field: &mut RelationField, ct
                         ctx.ast[relation_field.referenced_model].name(),
                         relation_fields.iter().map(|(f, _)| f.name()).collect::<Vec<_>>().join(", "),
                     );
-                    ctx.push_error(DatamodelError::new_validation_error(msg, attr.span));
+                    ctx.push_error(DatamodelError::new_validation_error(&msg, attr.span));
                 }
 
                 Vec::new()

--- a/libs/datamodel/parser-database/src/attributes/map.rs
+++ b/libs/datamodel/parser-database/src/attributes/map.rs
@@ -16,8 +16,8 @@ pub(super) fn model(model_attributes: &mut ModelAttributes, model_id: ast::Model
     if let Some(existing_model_id) = ctx.mapped_model_names.insert(mapped_name, model_id) {
         let existing_model_name = ctx.ast[existing_model_id].name();
         ctx.push_error(DatamodelError::new_duplicate_model_database_name_error(
-            ctx[mapped_name].to_owned(),
-            existing_model_name.to_owned(),
+            &ctx[mapped_name],
+            existing_model_name,
             ctx.ast[model_id].span,
         ));
     }
@@ -25,8 +25,8 @@ pub(super) fn model(model_attributes: &mut ModelAttributes, model_id: ast::Model
     if let Some(existing_model_id) = ctx.names.tops.get(&mapped_name).and_then(|id| id.as_model_id()) {
         let existing_model_name = ctx.ast[existing_model_id].name();
         ctx.push_error(DatamodelError::new_duplicate_model_database_name_error(
-            ctx[mapped_name].to_owned(),
-            existing_model_name.to_owned(),
+            &ctx[mapped_name],
+            existing_model_name,
             ctx.current_attribute().span,
         ));
     }
@@ -129,7 +129,7 @@ pub(super) fn visit_map_attribute(ctx: &mut Context<'_>) -> Option<StringId> {
     match ctx.visit_default_arg("name").map(|value| value.as_str()) {
         Ok(Ok(name)) => return Some(ctx.interner.intern(name)),
         Err(err) => ctx.push_error(err), // not flattened for error handing legacy reasons
-        Ok(Err(err)) => ctx.push_attribute_validation_error(&err.to_string()),
+        Ok(Err(err)) => ctx.push_error(err),
     };
 
     None

--- a/libs/datamodel/parser-database/src/context.rs
+++ b/libs/datamodel/parser-database/src/context.rs
@@ -280,10 +280,7 @@ impl<'db> Context<'db> {
         let diagnostics = &mut self.diagnostics;
         for arg_idx in self.attributes.args.values() {
             let arg = &attr.arguments.arguments[*arg_idx];
-            diagnostics.push_error(DatamodelError::new_unused_argument_error(
-                arg.name.as_ref().map(|n| n.name.as_str()).unwrap_or(""),
-                arg.span,
-            ));
+            diagnostics.push_error(DatamodelError::new_unused_argument_error(arg.span));
         }
 
         self.discard_arguments();

--- a/libs/datamodel/parser-database/src/names.rs
+++ b/libs/datamodel/parser-database/src/names.rs
@@ -168,17 +168,17 @@ fn validate_attribute_identifiers(with_attrs: &dyn WithAttributes, ctx: &mut Con
 fn validate_identifier(ident: &ast::Identifier, schema_item: &str, ctx: &mut Context<'_>) {
     if ident.name.is_empty() {
         ctx.push_error(DatamodelError::new_validation_error(
-            format!("The name of a {} must not be empty.", schema_item),
+            &format!("The name of a {} must not be empty.", schema_item),
             ident.span,
         ))
     } else if ident.name.chars().next().unwrap().is_numeric() {
         ctx.push_error(DatamodelError::new_validation_error(
-            format!("The name of a {} must not start with a number.", schema_item),
+            &format!("The name of a {} must not start with a number.", schema_item),
             ident.span,
         ))
     } else if ident.name.contains('-') {
         ctx.push_error(DatamodelError::new_validation_error(
-            format!("The character `-` is not allowed in {} names.", schema_item),
+            &format!("The character `-` is not allowed in {} names.", schema_item),
             ident.span,
         ))
     }

--- a/libs/datamodel/parser-database/src/names/reserved_model_names.rs
+++ b/libs/datamodel/parser-database/src/names/reserved_model_names.rs
@@ -26,11 +26,11 @@ pub(crate) fn validate_enum_name(ast_enum: &ast::Enum, diagnostics: &mut Diagnos
     }
 
     diagnostics.push_error(DatamodelError::new_enum_validation_error(
-        format!(
+        &format!(
           "The enum name `{}` is invalid. It is a reserved name. Please change it. Read more at https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-schema/data-model#naming-enums",
           &ast_enum.name.name
         ),
-        ast_enum.name.name.to_owned(),
+        &ast_enum.name.name,
         ast_enum.span,
 ));
 }

--- a/libs/datamodel/parser-database/src/types.rs
+++ b/libs/datamodel/parser-database/src/types.rs
@@ -561,7 +561,7 @@ fn visit_composite_type<'db>(ct_id: ast::CompositeTypeId, ct: &'db ast::Composit
             }
             Ok(FieldType::Model(referenced_model_id)) => {
                 let referenced_model_name = ctx.ast[referenced_model_id].name();
-                ctx.push_error(DatamodelError::new_composite_type_validation_error(format!("{} refers to a model, making this a relation field. Relation fields inside composite types are not supported.", referenced_model_name), ct.name.name.clone(), ast_field.field_type.span()))
+                ctx.push_error(DatamodelError::new_composite_type_validation_error(&format!("{} refers to a model, making this a relation field. Relation fields inside composite types are not supported.", referenced_model_name), &ct.name.name, ast_field.field_type.span()))
             }
             Err(supported) => ctx.push_error(DatamodelError::new_type_not_found_error(
                 supported,
@@ -573,10 +573,8 @@ fn visit_composite_type<'db>(ct_id: ast::CompositeTypeId, ct: &'db ast::Composit
 
 fn visit_enum<'db>(enm: &'db ast::Enum, ctx: &mut Context<'db>) {
     if enm.values.is_empty() {
-        ctx.push_error(DatamodelError::new_validation_error(
-            "An enum must have at least one value.".to_owned(),
-            enm.span,
-        ))
+        let msg = "An enum must have at least one value.";
+        ctx.push_error(DatamodelError::new_validation_error(msg, enm.span))
     }
 }
 

--- a/libs/datamodel/schema-ast/src/parser/parse_composite_type.rs
+++ b/libs/datamodel/schema-ast/src/parser/parse_composite_type.rs
@@ -30,43 +30,37 @@ pub(crate) fn parse_composite_type(
                 let err = match attr.name.name.as_str() {
                     "map" => {
                         DatamodelError::new_validation_error(
-                            "The name of a composite type is not persisted in the database, therefore it does not need a mapped database name."
-                                .to_owned(),
+                            "The name of a composite type is not persisted in the database, therefore it does not need a mapped database name.",
                             current_span.into(),
                         )
                     }
                     "unique" => {
                         DatamodelError::new_validation_error(
-                            "A unique constraint should be defined in the model containing the embed."
-                                .to_owned(),
+                            "A unique constraint should be defined in the model containing the embed.",
                             current_span.into(),
                         )
                     }
                     "index" => {
                         DatamodelError::new_validation_error(
-                            "An index should be defined in the model containing the embed."
-                                .to_owned(),
+                            "An index should be defined in the model containing the embed.",
                             current_span.into(),
                         )
                     }
                     "fulltext" => {
                         DatamodelError::new_validation_error(
-                            "A fulltext index should be defined in the model containing the embed."
-                                .to_owned(),
+                            "A fulltext index should be defined in the model containing the embed.",
                             current_span.into(),
                         )
                     }
                     "id" => {
                         DatamodelError::new_validation_error(
-                            "A composite type cannot define an id."
-                                .to_owned(),
+                            "A composite type cannot define an id.",
                             current_span.into(),
                         )
                     }
                     _ => {
                         DatamodelError::new_validation_error(
-                            "A composite type cannot have block-level attributes."
-                                .to_owned(),
+                            "A composite type cannot have block-level attributes.",
                             current_span.into(),
                         )
                     }
@@ -90,7 +84,7 @@ pub(crate) fn parse_composite_type(
                                     "Defining `@{name}` attribute for a field in a composite type is not allowed."
                                 );
 
-                                DatamodelError::new_validation_error(msg, current_span.clone().into())
+                                DatamodelError::new_validation_error(&msg, current_span.clone().into())
                             }
                             _ => continue,
                         };
@@ -109,7 +103,7 @@ pub(crate) fn parse_composite_type(
             }
             Rule::BLOCK_OPEN | Rule::BLOCK_CLOSE => {}
             Rule::BLOCK_LEVEL_CATCH_ALL => diagnostics.push_error(DatamodelError::new_validation_error(
-                "This line is not a valid field or attribute definition.".to_owned(),
+                "This line is not a valid field or attribute definition.",
                 current.as_span().into(),
             )),
             _ => parsing_catch_all(&current, "composite type"),

--- a/libs/datamodel/schema-ast/src/parser/parse_enum.rs
+++ b/libs/datamodel/schema-ast/src/parser/parse_enum.rs
@@ -33,7 +33,7 @@ pub fn parse_enum(pair: Pair<'_>, doc_comment: Option<Pair<'_>>, diagnostics: &m
                 }
             }
             Rule::BLOCK_LEVEL_CATCH_ALL => diagnostics.push_error(DatamodelError::new_validation_error(
-                "This line is not an enum value definition.".to_owned(),
+                "This line is not an enum value definition.",
                 current.as_span().into(),
             )),
             _ => parsing_catch_all(&current, "enum"),

--- a/libs/datamodel/schema-ast/src/parser/parse_expression.rs
+++ b/libs/datamodel/schema-ast/src/parser/parse_expression.rs
@@ -112,8 +112,8 @@ fn parse_string_literal(token: Pair<'_>, diagnostics: &mut Diagnostics) -> Strin
                     let mut final_span: crate::ast::Span = contents.as_span().into();
                     final_span.start += start;
                     final_span.end = final_span.start + 1 + c.len_utf8();
-                    diagnostics.push_error(DatamodelError::new(
-                        r#"Unknown escape sequence. If the value is a windows-style path, `\` must be escaped as `\\`."#.into(),
+                    diagnostics.push_error(DatamodelError::new_static(
+                        r#"Unknown escape sequence. If the value is a windows-style path, `\` must be escaped as `\\`."#,
                         final_span
                     ));
                 }
@@ -138,7 +138,7 @@ fn try_parse_unicode_codepoint(
             start: slice_offset,
             end: (slice_offset + slice.len()).min(slice_offset + consumed),
         };
-        DatamodelError::new("Invalid unicode escape sequence.".into(), span)
+        DatamodelError::new_static("Invalid unicode escape sequence.", span)
     };
 
     match parse_codepoint(slice) {

--- a/libs/datamodel/schema-ast/src/parser/parse_model.rs
+++ b/libs/datamodel/schema-ast/src/parser/parse_model.rs
@@ -31,7 +31,7 @@ pub(crate) fn parse_model(pair: Pair<'_>, doc_comment: Option<Pair<'_>>, diagnos
             },
             Rule::comment_block => pending_field_comment = Some(current),
             Rule::BLOCK_LEVEL_CATCH_ALL => diagnostics.push_error(DatamodelError::new_validation_error(
-                "This line is not a valid field or attribute definition.".to_owned(),
+                "This line is not a valid field or attribute definition.",
                 current.as_span().into(),
             )),
             _ => parsing_catch_all(&current, "model"),

--- a/libs/datamodel/schema-ast/src/parser/parse_schema.rs
+++ b/libs/datamodel/schema-ast/src/parser/parse_schema.rs
@@ -39,7 +39,7 @@ pub fn parse_schema(datamodel_string: &str, diagnostics: &mut Diagnostics) -> Sc
                     },
                     Rule::type_alias => {
                         let error = DatamodelError::new_validation_error(
-                            "Invalid type definition. Please check the documentation in https://pris.ly/d/composite-types".to_string(),
+                            "Invalid type definition. Please check the documentation in https://pris.ly/d/composite-types",
                             current.as_span().into()
                         );
 
@@ -58,11 +58,11 @@ pub fn parse_schema(datamodel_string: &str, diagnostics: &mut Diagnostics) -> Sc
                     },
                     Rule::EOI => {}
                     Rule::CATCH_ALL => diagnostics.push_error(DatamodelError::new_validation_error(
-                        "This line is invalid. It does not start with any known Prisma schema keyword.".to_owned(),
+                        "This line is invalid. It does not start with any known Prisma schema keyword.",
                         current.as_span().into(),
                     )),
                     Rule::arbitrary_block => diagnostics.push_error(DatamodelError::new_validation_error(
-                        "This block is invalid. It does not start with any known Prisma schema keyword. Valid keywords include \'model\', \'enum\', \'datasource\' and \'generator\'.".to_owned(),
+                        "This block is invalid. It does not start with any known Prisma schema keyword. Valid keywords include \'model\', \'enum\', \'datasource\' and \'generator\'.",
                         current.as_span().into(),
                     )),
                     Rule::empty_lines => (),

--- a/libs/datamodel/schema-ast/src/parser/parse_source_and_generator.rs
+++ b/libs/datamodel/schema-ast/src/parser/parse_source_and_generator.rs
@@ -27,7 +27,7 @@ pub(crate) fn parse_config_block(pair: Pair<'_>, diagnostics: &mut Diagnostics) 
                     kw.unwrap_or("configuration block")
                 );
 
-                let err = DatamodelError::new_validation_error(msg, current.as_span().into());
+                let err = DatamodelError::new_validation_error(&msg, current.as_span().into());
                 diagnostics.push_error(err);
             }
             _ => parsing_catch_all(&current, "source"),

--- a/prisma-fmt/src/lint.rs
+++ b/prisma-fmt/src/lint.rs
@@ -19,7 +19,7 @@ pub(crate) fn run(schema: &str) -> String {
                 .map(|err: &DatamodelError| MiniError {
                     start: err.span().start,
                     end: err.span().end,
-                    text: format!("{}", err),
+                    text: err.message().to_string(),
                     is_warning: false,
                 })
                 .collect();

--- a/query-engine/query-engine-node-api/src/error.rs
+++ b/query-engine/query-engine-node-api/src/error.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum ApiError {
-    #[error("{}", _0)]
+    #[error("{:?}", _0)]
     Conversion(Diagnostics, String),
 
     #[error("{}", _0)]

--- a/query-engine/query-engine/src/error.rs
+++ b/query-engine/query-engine/src/error.rs
@@ -23,7 +23,7 @@ pub enum PrismaError {
     #[error("{}", _0)]
     ConnectorError(Box<ConnectorError>),
 
-    #[error("{}", _0)]
+    #[error("{:?}", _0)]
     ConversionError(Diagnostics, String),
 
     #[error("{}", _0)]
@@ -36,7 +36,7 @@ pub enum PrismaError {
     #[error("Unsupported feature: {}. {}", _0, _1)]
     UnsupportedFeatureError(&'static str, String),
 
-    #[error("Error in data model: {}", _0)]
+    #[error("Error in data model: {:?}", _0)]
     DatamodelError(Diagnostics),
 
     #[error("{}", _0)]


### PR DESCRIPTION
This pulls in the whole procedural macro machinery before we can even
get to compile schema_ast. Removing it should improve compile times
considerably.

From a logic perspective, ErrorKind was implemented as an std::Error
implementation a long time ago, but it is the wrong tool for parser
or validation errors, since they are not logic errors, they are an
expected output of the parser, that we just accumulate.