### PR TITLE
    fix(sqlite): int primary key ≠ integer primary key

### DIFF
--- a/introspection-engine/connectors/sql-introspection-connector/src/prisma_1_defaults.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/prisma_1_defaults.rs
@@ -3,7 +3,7 @@ use crate::SqlFamilyTrait;
 use datamodel::dml::{self, Datamodel, ValueGenerator};
 use introspection_connector::{IntrospectionContext, Version, Warning};
 use native_types::{MySqlType, PostgresType};
-use sql_schema_describer::{SqlSchema, SqlSchemaExt};
+use sql_schema_describer::SqlSchema;
 
 pub fn add_prisma_1_id_defaults(
     version: &Version,

--- a/introspection-engine/introspection-engine-tests/tests/relations/sqlite.rs
+++ b/introspection-engine/introspection-engine-tests/tests/relations/sqlite.rs
@@ -281,21 +281,18 @@ async fn multiple_foreign_key_constraints_are_taken_always_in_the_same_order(api
 
     let expected = expect![[r#"
         model A {
-          id  Int @id @default(autoincrement())
+          id  Int @id
           foo Int
           B   B   @relation(fields: [foo], references: [id], onUpdate: Restrict)
         }
 
         model B {
-          id Int @id @default(autoincrement())
+          id Int @id
           A  A[]
         }
     "#]];
 
-    for _ in 0..6 {
-        expected.assert_eq(&api.introspect_dml().await?);
-    }
-
+    expected.assert_eq(&api.introspect_dml().await?);
     Ok(())
 }
 

--- a/libs/sql-schema-describer/src/mssql.rs
+++ b/libs/sql-schema-describer/src/mssql.rs
@@ -1,3 +1,5 @@
+//! SQL server schema description.
+
 use crate::{
     getters::Getter, ids::*, parsers::Parser, Column, ColumnArity, ColumnType, ColumnTypeFamily, DefaultValue,
     DescriberError, DescriberErrorKind, DescriberResult, ForeignKeyAction, IndexColumn, Procedure, SQLSortOrder,
@@ -92,7 +94,7 @@ impl MssqlSchemaExt {
 
 impl std::fmt::Debug for SqlSchemaDescriber<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct(type_name::<SqlSchemaDescriber>()).finish()
+        f.debug_struct(type_name::<SqlSchemaDescriber<'_>>()).finish()
     }
 }
 

--- a/libs/sql-schema-describer/src/mysql.rs
+++ b/libs/sql-schema-describer/src/mysql.rs
@@ -1,3 +1,5 @@
+//! MySQL schema description.
+
 use crate::{getters::Getter, parsers::Parser, *};
 use bigdecimal::ToPrimitive;
 use indexmap::IndexMap;
@@ -521,7 +523,7 @@ impl<'a> SqlSchemaDescriber<'a> {
         full_data_type: &str,
         precision: Precision,
         arity: ColumnArity,
-        default: Option<&Value>,
+        default: Option<&Value<'_>>,
     ) -> (ColumnType, Option<Enum>) {
         static UNSIGNEDNESS_RE: Lazy<Regex> = Lazy::new(|| Regex::new("(?i)unsigned$").unwrap());
         let is_tinyint1 = || Self::extract_precision(full_data_type) == Some(1);
@@ -669,7 +671,7 @@ impl<'a> SqlSchemaDescriber<'a> {
         static MARIADB_NEWLINE_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r#"\\n"#).unwrap());
         static MARIADB_DEFAULT_QUOTE_UNESCAPE_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r#"'(.*)'"#).unwrap());
 
-        let maybe_unquoted: Cow<str> = if matches!(flavour, Flavour::MariaDb) {
+        let maybe_unquoted: Cow<'_, str> = if matches!(flavour, Flavour::MariaDb) {
             let unquoted = MARIADB_DEFAULT_QUOTE_UNESCAPE_RE
                 .captures(&default)
                 .and_then(|cap| cap.get(1).map(|x| x.as_str()))

--- a/libs/sql-schema-describer/src/postgres.rs
+++ b/libs/sql-schema-describer/src/postgres.rs
@@ -102,7 +102,7 @@ pub struct SqlSchemaDescriber<'a> {
 
 impl Debug for SqlSchemaDescriber<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct(type_name::<SqlSchemaDescriber>())
+        f.debug_struct(type_name::<SqlSchemaDescriber<'_>>())
             .field("circumstances", &self.circumstances)
             .finish()
     }

--- a/libs/sql-schema-describer/src/postgres/default.rs
+++ b/libs/sql-schema-describer/src/postgres/default.rs
@@ -109,7 +109,7 @@ fn parse_unsupported(_parser: &mut Parser<'_>) -> Option<DefaultValue> {
     None
 }
 
-fn parse_datetime_default(parser: &mut Parser) -> Option<DefaultValue> {
+fn parse_datetime_default(parser: &mut Parser<'_>) -> Option<DefaultValue> {
     let value = match parser.peek_token()? {
         Token::Identifier => {
             let func_name = parser.expect(Token::Identifier)?;
@@ -133,7 +133,7 @@ fn parse_datetime_default(parser: &mut Parser) -> Option<DefaultValue> {
     value
 }
 
-fn parse_enum_default(parser: &mut Parser) -> Option<DefaultValue> {
+fn parse_enum_default(parser: &mut Parser<'_>) -> Option<DefaultValue> {
     match parser.peek_token()? {
         Token::Identifier => {
             let s = parser.expect(Token::Identifier)?;
@@ -412,7 +412,7 @@ fn parse_float_default(parser: &mut Parser<'_>) -> Option<DefaultValue> {
     Some(value)
 }
 
-fn parse_bool_default(parser: &mut Parser) -> Option<DefaultValue> {
+fn parse_bool_default(parser: &mut Parser<'_>) -> Option<DefaultValue> {
     let s = parser.expect(Token::Identifier)?;
 
     let bool_value = if s.eq_ignore_ascii_case("t") || s.eq_ignore_ascii_case("true") {
@@ -511,7 +511,7 @@ fn get_list_default_value(parser: &mut Parser<'_>, tpe: &ColumnType) -> DefaultV
 
 /// Some(()) on valid cast or absence of cast. None if we can't make sense of the input.
 #[must_use]
-fn eat_cast(parser: &mut Parser) -> Option<()> {
+fn eat_cast(parser: &mut Parser<'_>) -> Option<()> {
     match parser.peek_token() {
         Some(Token::CastOperator) => {
             parser.expect(Token::CastOperator)?;

--- a/libs/sql-schema-describer/src/sqlite.rs
+++ b/libs/sql-schema-describer/src/sqlite.rs
@@ -377,7 +377,8 @@ async fn push_columns(
         if pk_cols.len() == 1 {
             let pk_col_id = *pk_cols.values().next().unwrap();
             let pk_col = &mut schema.columns[pk_col_id.0 as usize];
-            if pk_col.1.tpe.full_data_type.contains("int") {
+            // See https://www.sqlite.org/lang_createtable.html for the exact logic.
+            if pk_col.1.tpe.full_data_type.eq_ignore_ascii_case("INTEGER") {
                 pk_col.1.auto_increment = true;
                 pk_col.1.tpe.arity = ColumnArity::Required;
             }

--- a/libs/sql-schema-describer/src/sqlite.rs
+++ b/libs/sql-schema-describer/src/sqlite.rs
@@ -19,7 +19,7 @@ pub struct SqlSchemaDescriber<'a> {
 
 impl Debug for SqlSchemaDescriber<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct(type_name::<SqlSchemaDescriber>()).finish()
+        f.debug_struct(type_name::<SqlSchemaDescriber<'_>>()).finish()
     }
 }
 

--- a/libs/sql-schema-describer/src/walkers.rs
+++ b/libs/sql-schema-describer/src/walkers.rs
@@ -9,14 +9,6 @@ use crate::{
 use serde::de::DeserializeOwned;
 use std::ops::Range;
 
-/// Traverse all the columns in the schema.
-pub fn walk_columns(schema: &SqlSchema) -> impl Iterator<Item = ColumnWalker<'_>> {
-    (0..schema.columns.len()).map(|idx| ColumnWalker {
-        schema,
-        id: ColumnId(idx as u32),
-    })
-}
-
 /// A generic reference to a schema item. It holds a reference to the schema so it can offer a
 /// convenient API based on the Id type.
 #[derive(Clone, Copy)]
@@ -177,9 +169,9 @@ impl<'a> ColumnWalker<'a> {
 #[derive(Clone, Copy)]
 pub struct ViewWalker<'a> {
     /// The schema the view is contained in.
-    schema: &'a SqlSchema,
+    pub(crate) schema: &'a SqlSchema,
     /// The index of the view in the schema.
-    view_index: usize,
+    pub(crate) view_index: usize,
 }
 
 impl<'a> ViewWalker<'a> {
@@ -211,8 +203,8 @@ impl<'a> ViewWalker<'a> {
 /// Traverse a user-defined type
 #[derive(Clone, Copy)]
 pub struct UserDefinedTypeWalker<'a> {
-    schema: &'a SqlSchema,
-    udt_index: usize,
+    pub(crate) schema: &'a SqlSchema,
+    pub(crate) udt_index: usize,
 }
 
 impl<'a> UserDefinedTypeWalker<'a> {
@@ -482,39 +474,6 @@ impl<'a> EnumWalker<'a> {
     /// The values of the enum
     pub fn values(self) -> &'a [String] {
         &self.get().values
-    }
-}
-
-/// Extension methods for the traversal of a SqlSchema.
-pub trait SqlSchemaExt {
-    /// Find a table by name.
-    fn table_walker<'a>(&'a self, name: &str) -> Option<TableWalker<'a>>;
-
-    /// Find a view by index.
-    fn view_walker_at(&self, index: usize) -> ViewWalker<'_>;
-
-    /// Find a user-defined type by index.
-    fn udt_walker_at(&self, index: usize) -> UserDefinedTypeWalker<'_>;
-}
-
-impl SqlSchemaExt for SqlSchema {
-    fn table_walker<'a>(&'a self, name: &str) -> Option<TableWalker<'a>> {
-        let table_idx = self.tables.iter().position(|table| table.name == name)?;
-        Some(self.walk(TableId(table_idx as u32)))
-    }
-
-    fn view_walker_at(&self, index: usize) -> ViewWalker<'_> {
-        ViewWalker {
-            view_index: index,
-            schema: self,
-        }
-    }
-
-    fn udt_walker_at(&self, index: usize) -> UserDefinedTypeWalker<'_> {
-        UserDefinedTypeWalker {
-            udt_index: index,
-            schema: self,
-        }
     }
 }
 

--- a/libs/sql-schema-describer/tests/describers/postgres_describer_tests/cockroach_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/postgres_describer_tests/cockroach_describer_tests.rs
@@ -1,6 +1,6 @@
 use crate::test_api::*;
 use prisma_value::PrismaValue;
-use sql_schema_describer::{postgres::PostgresSchemaExt, ColumnTypeFamily, SqlSchemaExt};
+use sql_schema_describer::{postgres::PostgresSchemaExt, ColumnTypeFamily};
 
 #[test_connector(tags(CockroachDb))]
 fn views_can_be_described(api: TestApi) {

--- a/libs/sql-schema-describer/tests/test_api/mod.rs
+++ b/libs/sql-schema-describer/tests/test_api/mod.rs
@@ -8,7 +8,7 @@ use barrel::Migration;
 use quaint::prelude::SqlFamily;
 use sql_schema_describer::{
     postgres::Circumstances,
-    walkers::{ColumnWalker, ForeignKeyWalker, IndexWalker, SqlSchemaExt, TableWalker},
+    walkers::{ColumnWalker, ForeignKeyWalker, IndexWalker, TableWalker},
     ColumnTypeFamily, DescriberError, ForeignKeyAction, SqlSchema, SqlSchemaDescriberBackend,
 };
 use std::future::Future;

--- a/migration-engine/connectors/sql-migration-connector/src/apply_migration.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/apply_migration.rs
@@ -4,7 +4,7 @@ use crate::{
     SqlFlavour, SqlMigrationConnector,
 };
 use migration_connector::{ConnectorResult, DestructiveChangeDiagnostics, Migration};
-use sql_schema_describer::{walkers::SqlSchemaExt, SqlSchema};
+use sql_schema_describer::SqlSchema;
 
 #[tracing::instrument(skip(flavour, migration))]
 pub(crate) async fn apply_migration(

--- a/migration-engine/connectors/sql-migration-connector/src/database_schema.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/database_schema.rs
@@ -1,5 +1,5 @@
 use migration_connector::DatabaseSchema;
-use sql_schema_describer::{self as sql, walkers::SqlSchemaExt, SqlSchema};
+use sql_schema_describer::{self as sql, SqlSchema};
 
 #[derive(Default, Debug)]
 pub(crate) struct SqlDatabaseSchema {
@@ -30,19 +30,5 @@ impl From<SqlSchema> for SqlDatabaseSchema {
 impl From<SqlDatabaseSchema> for DatabaseSchema {
     fn from(s: SqlDatabaseSchema) -> Self {
         DatabaseSchema::new(s)
-    }
-}
-
-impl SqlSchemaExt for SqlDatabaseSchema {
-    fn table_walker<'a>(&'a self, name: &str) -> Option<sql_schema_describer::walkers::TableWalker<'a>> {
-        self.describer_schema.table_walker(name)
-    }
-
-    fn view_walker_at(&self, index: usize) -> sql_schema_describer::walkers::ViewWalker<'_> {
-        self.describer_schema.view_walker_at(index)
-    }
-
-    fn udt_walker_at(&self, index: usize) -> sql_schema_describer::walkers::UserDefinedTypeWalker<'_> {
-        self.describer_schema.udt_walker_at(index)
     }
 }

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/mssql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/mssql.rs
@@ -351,8 +351,7 @@ impl SqlFlavour for MssqlFlavour {
     }
 
     fn set_params(&mut self, connector_params: ConnectorParams) -> ConnectorResult<()> {
-        let url =
-            MssqlUrl::new(&connector_params.connection_string).map_err(|err| ConnectorError::url_parse_error(err))?;
+        let url = MssqlUrl::new(&connector_params.connection_string).map_err(ConnectorError::url_parse_error)?;
         let params = Params { connector_params, url };
         self.state.set_params(params);
         Ok(())

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/postgres.rs
@@ -377,10 +377,10 @@ impl SqlFlavour for PostgresFlavour {
         let mut url: Url = connector_params
             .connection_string
             .parse()
-            .map_err(|err| ConnectorError::url_parse_error(err))?;
+            .map_err(ConnectorError::url_parse_error)?;
         disable_postgres_statement_cache(&mut url)?;
         let connection_string = url.to_string();
-        let url = PostgresUrl::new(url).map_err(|err| ConnectorError::url_parse_error(err))?;
+        let url = PostgresUrl::new(url).map_err(ConnectorError::url_parse_error)?;
         connector_params.connection_string = connection_string;
         let params = Params { connector_params, url };
         self.state.set_params(params);

--- a/migration-engine/connectors/sql-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/lib.rs
@@ -1,8 +1,6 @@
 //! The SQL migration connector.
 
 #![deny(rust_2018_idioms, unsafe_code, missing_docs)]
-#![allow(clippy::trivial_regex)] // these will grow
-#![allow(clippy::redundant_closure)] // too eager, sometimes wrong
 #![allow(clippy::ptr_arg)] // remove after https://github.com/rust-lang/rust-clippy/issues/8482 is fixed and shipped
 
 mod apply_migration;
@@ -23,7 +21,7 @@ use flavour::{MssqlFlavour, MysqlFlavour, PostgresFlavour, SqlFlavour, SqliteFla
 use migration_connector::{migrations_directory::MigrationDirectory, *};
 use pair::Pair;
 use sql_migration::{DropUserDefinedType, DropView, SqlMigration, SqlMigrationStep};
-use sql_schema_describer::{self as describer, walkers::SqlSchemaExt};
+use sql_schema_describer as sql;
 use std::sync::Arc;
 
 /// The top-level SQL migration connector.
@@ -78,7 +76,7 @@ impl SqlMigrationConnector {
     }
 
     /// Made public for tests.
-    pub fn describe_schema(&mut self) -> BoxFuture<'_, ConnectorResult<describer::SqlSchema>> {
+    pub fn describe_schema(&mut self) -> BoxFuture<'_, ConnectorResult<sql::SqlSchema>> {
         self.flavour.describe_schema()
     }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_migration.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_migration.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use enumflags2::BitFlags;
 use sql_schema_describer::{
-    walkers::{ColumnWalker, SqlSchemaExt, TableWalker},
+    walkers::{ColumnWalker, TableWalker},
     ColumnId, EnumId, ForeignKeyId, IndexId, SqlSchema, TableId,
 };
 use std::{collections::BTreeSet, fmt::Write as _};

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
@@ -604,7 +604,7 @@ fn render_alter_column(
 
                 // We also need to drop the sequence, in case it isn't used by any other column.
                 if let Some(DefaultKind::Sequence(sequence_name)) = columns.previous.default().map(|d| d.kind()) {
-                    let sequence_is_still_used = walk_columns(columns.next.schema).any(|column| matches!(column.default().map(|d| d.kind()), Some(DefaultKind::Sequence(other_sequence)) if other_sequence == sequence_name) && !column.is_same_column(columns.next));
+                    let sequence_is_still_used = columns.next.schema.walk_columns().any(|column| matches!(column.default().map(|d| d.kind()), Some(DefaultKind::Sequence(other_sequence)) if other_sequence == sequence_name) && !column.is_same_column(columns.next));
 
                     if !sequence_is_still_used {
                         after_statements.push(format!("DROP SEQUENCE {}", Quoted::postgres_ident(sequence_name)));
@@ -839,7 +839,7 @@ fn render_postgres_alter_enum(alter_enum: &AlterEnum, schemas: Pair<&SqlSchema>)
 
     // Alter type of the current columns to new, with a cast
     {
-        let affected_columns = walk_columns(schemas.next).filter(|column| matches!(&column.column_type().family, ColumnTypeFamily::Enum(name) if name.as_str() == enums.next.name()));
+        let affected_columns = schemas.next.walk_columns().filter(|column| matches!(&column.column_type().family, ColumnTypeFamily::Enum(name) if name.as_str() == enums.next.name()));
 
         for column in affected_columns {
             let array = if column.arity().is_list() { "[]" } else { "" };

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
@@ -493,7 +493,7 @@ fn push_foreign_key_pair_changes(
         // many-to-many relation tables, but we used not to (we did not provide a constraint
         // names), and we do not want to cause new migrations on upgrade, we ignore the foreign
         // keys of implicit many-to-many relation tables for renamings.
-        if fk.map(|fk| is_prisma_implicit_m2m_fk(fk)).into_tuple() == (true, true) {
+        if fk.map(is_prisma_implicit_m2m_fk).into_tuple() == (true, true) {
             return;
         }
 

--- a/migration-engine/migration-engine-tests/tests/migrations/defaults.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/defaults.rs
@@ -1,6 +1,6 @@
 use migration_engine_tests::test_api::*;
 use prisma_value::PrismaValue;
-use sql_schema_describer::{DefaultKind, DefaultValue, SqlSchemaExt};
+use sql_schema_describer::{DefaultKind, DefaultValue};
 
 // MySQL 5.7 and MariaDB are skipped, because the datamodel parser gives us a
 // chrono DateTime, and we don't render that in the exact expected format.


### PR DESCRIPTION

 `int primary key` has affinity integer, but will not be automatically
identified with the rowid. The type has to match "integer" exactly for
that to happen.
    
Official docs with explanation at https://www.sqlite.org/lang_createtable.html

The first two commits are just very basic cleanups that the opportunity just came for.