### PR TITLE
fixes to tracing with itx

### DIFF
--- a/query-engine/core/src/trace_helpers/mod.rs
+++ b/query-engine/core/src/trace_helpers/mod.rs
@@ -51,17 +51,6 @@ fn span_to_json(span: &SpanData) -> Value {
     })
 }
 
-pub fn set_span_context(span: &Span, trace_id: Option<String>) {
-    if trace_id.is_none() {
-        return;
-    }
-
-    let trace = HashMap::from([("traceparent".to_string(), trace_id.unwrap())]);
-    let parent_context = opentelemetry::global::get_text_map_propagator(|propagator| propagator.extract(&trace));
-
-    span.set_parent(parent_context)
-}
-
 // set the parent context and return the traceparent
 pub fn set_parent_context_from_json_str(span: &Span, trace: String) -> Option<String> {
     let trace: HashMap<String, String> = serde_json::from_str(&trace).unwrap_or_default();


### PR DESCRIPTION
This makes sure the interactive transaction traces line up as:

<img width="1874" alt="Screenshot 2022-07-14 at 13 12 51" src="https://user-images.githubusercontent.com/179458/178970076-d6452ea7-2349-4e94-9b8d-8436c2f007d6.png">

It also adds the itx id to the `itx_runner` span