### PR TITLE
me/ie/describer: make mssql use one database per test

### DIFF
--- a/.github/workflows/migration-engine.yml
+++ b/.github/workflows/migration-engine.yml
@@ -62,10 +62,8 @@ jobs:
         database:
           - name: mssql_2017
             url: "sqlserver://localhost:1434;database=master;user=SA;password=<YourStrong@Passw0rd>;trustServerCertificate=true;socket_timeout=60;isolationLevel=READ UNCOMMITTED"
-            single_threaded: true
           - name: mssql_2019
             url: "sqlserver://localhost:1433;database=master;user=SA;password=<YourStrong@Passw0rd>;trustServerCertificate=true;socket_timeout=60;isolationLevel=READ UNCOMMITTED"
-            single_threaded: true
           - name: mysql_5_6
             url: "mysql://root:prisma@localhost:3309"
           - name: mysql_5_7

--- a/introspection-engine/introspection-engine-tests/build.rs
+++ b/introspection-engine/introspection-engine-tests/build.rs
@@ -3,8 +3,7 @@ use std::{env, fs, io::Write as _, path};
 const ROOT_DIR: &str = "tests/simple";
 
 fn main() {
-    println!("cargo:rerun-if-changed={}", ROOT_DIR);
-    println!("cargo:rerun-if-changed={}", file!());
+    println!("cargo:rerun-if-changed={ROOT_DIR}");
 
     let mut all_sql_files = Vec::new();
     find_all_sql_files("", &mut all_sql_files);

--- a/introspection-engine/introspection-engine-tests/tests/mssql/mod.rs
+++ b/introspection-engine/introspection-engine-tests/tests/mssql/mod.rs
@@ -4,32 +4,6 @@ use quaint::prelude::Queryable;
 use test_macros::test_connector;
 
 #[test_connector(tags(Mssql))]
-async fn geometry_should_be_unsupported(api: &TestApi) -> TestResult {
-    let setup = r#"
-        CREATE TABLE [geometry_should_be_unsupported].[A] (
-            id INT IDENTITY,
-            location GEOGRAPHY,
-            CONSTRAINT [A_pkey] PRIMARY KEY (id)
-        );
-    "#;
-
-    api.raw_cmd(setup).await;
-
-    let result = api.introspect_dml().await?;
-
-    let expected = expect![[r#"
-        model A {
-          id       Int                       @id @default(autoincrement())
-          location Unsupported("geography")?
-        }
-    "#]];
-
-    expected.assert_eq(&result);
-
-    Ok(())
-}
-
-#[test_connector(tags(Mssql))]
 async fn user_defined_type_aliases_should_map_to_the_system_type(api: &TestApi) -> TestResult {
     let create_type = format!("CREATE TYPE [{}].[Name] FROM [nvarchar](50) NULL", api.schema_name());
     api.database().raw_cmd(&create_type).await?;

--- a/introspection-engine/introspection-engine-tests/tests/referential_actions/mod.rs
+++ b/introspection-engine/introspection-engine-tests/tests/referential_actions/mod.rs
@@ -84,45 +84,6 @@ async fn referential_actions_mysql(api: &TestApi) -> TestResult {
     Ok(())
 }
 
-#[test_connector(tags(Mssql))]
-async fn referential_actions_mssql(api: &TestApi) -> TestResult {
-    api.barrel()
-        .execute(move |migration| {
-            migration.create_table("a", |t| {
-                t.add_column("id", types::integer().increments(true));
-                t.add_constraint("a_pkey", types::primary_constraint(vec!["id"]));
-            });
-
-            migration.create_table("b", move |t| {
-                t.add_column("id", types::integer().increments(true));
-                t.add_column("a_id", types::integer().nullable(false));
-
-                t.inject_custom(
-                    "CONSTRAINT asdf FOREIGN KEY (a_id) REFERENCES referential_actions_mssql.a(id) ON DELETE CASCADE ON UPDATE NO ACTION",
-                );
-                t.add_constraint("b_pkey", types::primary_constraint(vec!["id"]));
-            });
-        })
-        .await?;
-
-    let expected = expect![[r#"
-        model a {
-          id Int @id @default(autoincrement())
-          b  b[]
-        }
-
-        model b {
-          id   Int @id @default(autoincrement())
-          a_id Int
-          a    a   @relation(fields: [a_id], references: [id], onDelete: Cascade, onUpdate: NoAction, map: "asdf")
-        }
-    "#]];
-
-    expected.assert_eq(&api.introspect_dml().await?);
-
-    Ok(())
-}
-
 #[test_connector(tags(Postgres), exclude(CockroachDb))]
 async fn default_referential_actions_with_restrict_postgres(api: &TestApi) -> TestResult {
     api.barrel()
@@ -225,81 +186,6 @@ async fn default_referential_actions_with_restrict_mysql(api: &TestApi) -> TestR
           a    a   @relation(fields: [a_id], references: [id], map: "asdf")
 
           @@index([a_id], map: "asdf")
-        }
-    "#]];
-
-    expected.assert_eq(&api.introspect_dml().await?);
-
-    Ok(())
-}
-
-#[test_connector(tags(Mssql))]
-async fn default_referential_actions_without_restrict_mssql(api: &TestApi) -> TestResult {
-    api.barrel()
-        .execute(|migration| {
-            migration.create_table("a", |t| {
-                t.add_column("id", types::integer().increments(true));
-                t.add_constraint("a_pkey", types::primary_constraint(vec!["id"]));
-            });
-
-            migration.create_table("b", |t| {
-                t.add_column("id", types::integer().increments(true));
-                t.add_column("a_id", types::integer().nullable(false));
-                t.inject_custom(
-                    "CONSTRAINT asdf FOREIGN KEY (a_id) REFERENCES default_referential_actions_without_restrict_mssql.a(id) ON DELETE NO ACTION ON UPDATE CASCADE",
-                );
-                t.add_constraint("b_pkey", types::primary_constraint(vec!["id"]));
-            });
-        })
-        .await?;
-
-    let expected = expect![[r#"
-        model a {
-          id Int @id @default(autoincrement())
-          b  b[]
-        }
-
-        model b {
-          id   Int @id @default(autoincrement())
-          a_id Int
-          a    a   @relation(fields: [a_id], references: [id], map: "asdf")
-        }
-    "#]];
-
-    expected.assert_eq(&api.introspect_dml().await?);
-
-    Ok(())
-}
-
-#[test_connector(tags(Mssql))]
-async fn default_optional_actions_mssql(api: &TestApi) -> TestResult {
-    let setup = r#"
-       CREATE TABLE [default_optional_actions_mssql].[a] (
-            [id] INTEGER IDENTITY,
-            CONSTRAINT a_pkey PRIMARY KEY CLUSTERED ([id])
-        );
-
-        CREATE TABLE [default_optional_actions_mssql].[b] (
-            [id] INTEGER IDENTITY,
-            [a_id] INTEGER,
-
-            CONSTRAINT b_pkey PRIMARY KEY CLUSTERED ([id]),
-            CONSTRAINT asdf FOREIGN KEY (a_id) REFERENCES default_optional_actions_mssql.a(id) ON DELETE SET NULL ON UPDATE CASCADE
-        );
-    "#;
-
-    api.raw_cmd(setup).await;
-
-    let expected = expect![[r#"
-        model a {
-          id Int @id @default(autoincrement())
-          b  b[]
-        }
-
-        model b {
-          id   Int  @id @default(autoincrement())
-          a_id Int?
-          a    a?   @relation(fields: [a_id], references: [id], map: "asdf")
         }
     "#]];
 

--- a/introspection-engine/introspection-engine-tests/tests/simple/mssql/composite_primary_key.sql
+++ b/introspection-engine/introspection-engine-tests/tests/simple/mssql/composite_primary_key.sql
@@ -1,0 +1,25 @@
+-- tags=mssql
+
+CREATE TABLE [dbo].[User] (
+    [id] INT NOT NULL,
+    [name] VARCHAR(255) NOT NULL,
+    CONSTRAINT [PK_User] PRIMARY KEY ([id], [name])
+)
+
+/*
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlserver"
+  url      = "env(TEST_DATABASE_URL)"
+}
+
+model User {
+  id   Int
+  name String @db.VarChar(255)
+
+  @@id([id, name], map: "PK_User")
+}
+*/

--- a/introspection-engine/introspection-engine-tests/tests/simple/mssql/geometry_should_be_unsupported.sql
+++ b/introspection-engine/introspection-engine-tests/tests/simple/mssql/geometry_should_be_unsupported.sql
@@ -1,0 +1,23 @@
+-- tags=mssql
+
+CREATE TABLE [dbo].[A] (
+    id INT IDENTITY,
+    location GEOGRAPHY,
+    CONSTRAINT [A_pkey] PRIMARY KEY (id)
+);
+
+/*
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlserver"
+  url      = "env(TEST_DATABASE_URL)"
+}
+
+model A {
+  id       Int                       @id @default(autoincrement())
+  location Unsupported("geography")?
+}
+*/

--- a/introspection-engine/introspection-engine-tests/tests/simple/mssql/referential_actions.sql
+++ b/introspection-engine/introspection-engine-tests/tests/simple/mssql/referential_actions.sql
@@ -1,0 +1,39 @@
+-- tags=mssql
+
+CREATE TABLE a (
+    id INT IDENTITY,
+    CONSTRAINT a_pkey PRIMARY KEY (id)
+);
+
+CREATE TABLE b (
+    id INT IDENTITY,
+    a_id INT NOT NULL
+
+    CONSTRAINT b_pkey PRIMARY KEY (id),
+    CONSTRAINT asdf
+        FOREIGN KEY (a_id) REFERENCES a(id)
+            ON DELETE CASCADE
+            ON UPDATE NO ACTION
+);
+
+/*
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlserver"
+  url      = "env(TEST_DATABASE_URL)"
+}
+
+model a {
+  id Int @id @default(autoincrement())
+  b  b[]
+}
+
+model b {
+  id   Int @id @default(autoincrement())
+  a_id Int
+  a    a   @relation(fields: [a_id], references: [id], onDelete: Cascade, onUpdate: NoAction, map: "asdf")
+}
+*/

--- a/introspection-engine/introspection-engine-tests/tests/simple/mssql/referential_actions_default_for_optional_fields.sql
+++ b/introspection-engine/introspection-engine-tests/tests/simple/mssql/referential_actions_default_for_optional_fields.sql
@@ -1,0 +1,40 @@
+-- tags=mssql
+
+CREATE TABLE [a] (
+    [id] INTEGER IDENTITY,
+    CONSTRAINT a_pkey PRIMARY KEY CLUSTERED ([id])
+);
+
+CREATE TABLE [b] (
+    [id] INTEGER IDENTITY,
+    [a_id] INTEGER,
+
+    CONSTRAINT b_pkey PRIMARY KEY CLUSTERED ([id]),
+    CONSTRAINT asdf
+        FOREIGN KEY (a_id) REFERENCES a(id)
+            ON DELETE SET NULL
+            ON UPDATE CASCADE
+);
+
+
+/*
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlserver"
+  url      = "env(TEST_DATABASE_URL)"
+}
+
+model a {
+  id Int @id @default(autoincrement())
+  b  b[]
+}
+
+model b {
+  id   Int  @id @default(autoincrement())
+  a_id Int?
+  a    a?   @relation(fields: [a_id], references: [id], map: "asdf")
+}
+*/

--- a/introspection-engine/introspection-engine-tests/tests/simple/mssql/referential_actions_without_restrict.sql
+++ b/introspection-engine/introspection-engine-tests/tests/simple/mssql/referential_actions_without_restrict.sql
@@ -1,0 +1,38 @@
+-- tags=mssql
+
+CREATE TABLE a (
+    id INT IDENTITY,
+    CONSTRAINT a_pkey PRIMARY KEY (id)
+);
+
+CREATE TABLE b (
+    id INT IDENTITY,
+    a_id INT NOT NULL,
+
+    CONSTRAINT asdf FOREIGN KEY (a_id) REFERENCES a(id)
+        ON DELETE NO ACTION
+        ON UPDATE CASCADE,
+    CONSTRAINT b_pkey PRIMARY KEY (id)
+);
+
+/*
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlserver"
+  url      = "env(TEST_DATABASE_URL)"
+}
+
+model a {
+  id Int @id @default(autoincrement())
+  b  b[]
+}
+
+model b {
+  id   Int @id @default(autoincrement())
+  a_id Int
+  a    a   @relation(fields: [a_id], references: [id], map: "asdf")
+}
+*/

--- a/introspection-engine/introspection-engine-tests/tests/tables/mod.rs
+++ b/introspection-engine/introspection-engine-tests/tests/tables/mod.rs
@@ -824,19 +824,16 @@ async fn unique_and_id_on_same_field_works_sqlite(api: &TestApi) -> TestResult {
 
 #[test_connector(tags(Mssql))]
 async fn unique_and_id_on_same_field_works_mssql(api: &TestApi) -> TestResult {
-    let setup = format!(
-        r#"
-        CREATE TABLE [{}].users (
+    let setup = r#"
+        CREATE TABLE users (
             id INT IDENTITY,
 
             CONSTRAINT users_id_key UNIQUE (id),
             CONSTRAINT users_pkey PRIMARY KEY (id)
         );
-        "#,
-        schema = api.schema_name(),
-    );
+        "#;
 
-    api.raw_cmd(&setup).await;
+    api.raw_cmd(setup).await;
 
     let dm = indoc! {r##"
         model users {

--- a/introspection-engine/introspection-engine-tests/tests/tables/mssql.rs
+++ b/introspection-engine/introspection-engine-tests/tests/tables/mssql.rs
@@ -4,7 +4,7 @@ use introspection_engine_tests::test_api::*;
 #[test_connector(tags(Mssql))]
 async fn default_values(api: &TestApi) -> TestResult {
     let setup = r#"
-        CREATE TABLE [default_values].[Test] (
+        CREATE TABLE [dbo].[Test] (
             id INTEGER,
 
             string_static_char CHAR(5) CONSTRAINT [charconstraint] DEFAULT 'test',
@@ -41,9 +41,8 @@ async fn default_values(api: &TestApi) -> TestResult {
 
 #[test_connector(tags(Mssql))]
 async fn negative_default_values_should_work(api: &TestApi) -> TestResult {
-    let setup = format!(
-        r#"
-        CREATE TABLE [{schema_name}].[Blog] (
+    let setup = r#"
+        CREATE TABLE [Blog] (
             id INTEGER IDENTITY,
 
             int INTEGER CONSTRAINT [intdefault] DEFAULT 1,
@@ -54,12 +53,10 @@ async fn negative_default_values_should_work(api: &TestApi) -> TestResult {
             neg_big_int BIGINT CONSTRAINT [neg_bigint_def] DEFAULT -3,
 
             CONSTRAINT [Blog_pkey] PRIMARY KEY (id)
-        );
-        "#,
-        schema_name = api.schema_name()
-    );
+        )
+        "#;
 
-    api.raw_cmd(&setup).await;
+    api.raw_cmd(setup).await;
 
     let expectation = expect![[r#"
         model Blog {

--- a/libs/datamodel/core/tests/types/composite_types.rs
+++ b/libs/datamodel/core/tests/types/composite_types.rs
@@ -1,11 +1,6 @@
-use datamodel::{parse_schema, parse_schema_ast};
+use crate::{common::*, with_header};
 use expect_test::expect;
 use indoc::indoc;
-
-use crate::{
-    common::{CompositeTypeAsserts, DatamodelAsserts},
-    with_header, Provider,
-};
 
 #[test]
 fn composite_types_are_parsed_without_error() {
@@ -26,480 +21,34 @@ fn composite_types_are_parsed_without_error() {
         }
     "#;
 
-    let expected_ast = expect![[r#"
-        SchemaAst {
-            tops: [
-                Source(
-                    SourceConfig {
-                        name: Identifier {
-                            name: "db",
-                            span: Span {
-                                start: 20,
-                                end: 22,
-                            },
-                        },
-                        properties: [
-                            ConfigBlockProperty {
-                                name: Identifier {
-                                    name: "provider",
-                                    span: Span {
-                                        start: 36,
-                                        end: 44,
-                                    },
-                                },
-                                value: StringValue(
-                                    "mongodb",
-                                    Span {
-                                        start: 47,
-                                        end: 56,
-                                    },
-                                ),
-                                span: Span {
-                                    start: 36,
-                                    end: 57,
-                                },
-                            },
-                            ConfigBlockProperty {
-                                name: Identifier {
-                                    name: "url",
-                                    span: Span {
-                                        start: 69,
-                                        end: 72,
-                                    },
-                                },
-                                value: StringValue(
-                                    "mongo+srv:/....",
-                                    Span {
-                                        start: 75,
-                                        end: 92,
-                                    },
-                                ),
-                                span: Span {
-                                    start: 69,
-                                    end: 93,
-                                },
-                            },
-                        ],
-                        documentation: None,
-                        span: Span {
-                            start: 9,
-                            end: 102,
-                        },
-                    },
-                ),
-                CompositeType(
-                    CompositeType {
-                        name: Identifier {
-                            name: "Address",
-                            span: Span {
-                                start: 117,
-                                end: 124,
-                            },
-                        },
-                        fields: [
-                            Field {
-                                field_type: Supported(
-                                    Identifier {
-                                        name: "String",
-                                        span: Span {
-                                            start: 144,
-                                            end: 150,
-                                        },
-                                    },
-                                ),
-                                name: Identifier {
-                                    name: "name",
-                                    span: Span {
-                                        start: 139,
-                                        end: 143,
-                                    },
-                                },
-                                arity: Optional,
-                                attributes: [],
-                                documentation: None,
-                                span: Span {
-                                    start: 139,
-                                    end: 152,
-                                },
-                            },
-                            Field {
-                                field_type: Supported(
-                                    Identifier {
-                                        name: "String",
-                                        span: Span {
-                                            start: 171,
-                                            end: 177,
-                                        },
-                                    },
-                                ),
-                                name: Identifier {
-                                    name: "street",
-                                    span: Span {
-                                        start: 164,
-                                        end: 170,
-                                    },
-                                },
-                                arity: Required,
-                                attributes: [
-                                    Attribute {
-                                        name: Identifier {
-                                            name: "db.ObjectId",
-                                            span: Span {
-                                                start: 179,
-                                                end: 190,
-                                            },
-                                        },
-                                        arguments: ArgumentsList {
-                                            arguments: [],
-                                            empty_arguments: [],
-                                            trailing_comma: None,
-                                        },
-                                        span: Span {
-                                            start: 178,
-                                            end: 190,
-                                        },
-                                    },
-                                ],
-                                documentation: None,
-                                span: Span {
-                                    start: 164,
-                                    end: 191,
-                                },
-                            },
-                        ],
-                        documentation: None,
-                        span: Span {
-                            start: 112,
-                            end: 200,
-                        },
-                    },
-                ),
-                Model(
-                    Model {
-                        name: Identifier {
-                            name: "User",
-                            span: Span {
-                                start: 216,
-                                end: 220,
-                            },
-                        },
-                        fields: [
-                            Field {
-                                field_type: Supported(
-                                    Identifier {
-                                        name: "String",
-                                        span: Span {
-                                            start: 239,
-                                            end: 245,
-                                        },
-                                    },
-                                ),
-                                name: Identifier {
-                                    name: "id",
-                                    span: Span {
-                                        start: 235,
-                                        end: 237,
-                                    },
-                                },
-                                arity: Required,
-                                attributes: [
-                                    Attribute {
-                                        name: Identifier {
-                                            name: "id",
-                                            span: Span {
-                                                start: 247,
-                                                end: 249,
-                                            },
-                                        },
-                                        arguments: ArgumentsList {
-                                            arguments: [],
-                                            empty_arguments: [],
-                                            trailing_comma: None,
-                                        },
-                                        span: Span {
-                                            start: 246,
-                                            end: 250,
-                                        },
-                                    },
-                                    Attribute {
-                                        name: Identifier {
-                                            name: "default",
-                                            span: Span {
-                                                start: 251,
-                                                end: 258,
-                                            },
-                                        },
-                                        arguments: ArgumentsList {
-                                            arguments: [
-                                                Argument {
-                                                    name: None,
-                                                    value: Function(
-                                                        "auto",
-                                                        ArgumentsList {
-                                                            arguments: [],
-                                                            empty_arguments: [],
-                                                            trailing_comma: None,
-                                                        },
-                                                        Span {
-                                                            start: 259,
-                                                            end: 265,
-                                                        },
-                                                    ),
-                                                    span: Span {
-                                                        start: 259,
-                                                        end: 265,
-                                                    },
-                                                },
-                                            ],
-                                            empty_arguments: [],
-                                            trailing_comma: None,
-                                        },
-                                        span: Span {
-                                            start: 250,
-                                            end: 266,
-                                        },
-                                    },
-                                    Attribute {
-                                        name: Identifier {
-                                            name: "map",
-                                            span: Span {
-                                                start: 268,
-                                                end: 271,
-                                            },
-                                        },
-                                        arguments: ArgumentsList {
-                                            arguments: [
-                                                Argument {
-                                                    name: None,
-                                                    value: StringValue(
-                                                        "_id",
-                                                        Span {
-                                                            start: 272,
-                                                            end: 277,
-                                                        },
-                                                    ),
-                                                    span: Span {
-                                                        start: 272,
-                                                        end: 277,
-                                                    },
-                                                },
-                                            ],
-                                            empty_arguments: [],
-                                            trailing_comma: None,
-                                        },
-                                        span: Span {
-                                            start: 267,
-                                            end: 278,
-                                        },
-                                    },
-                                    Attribute {
-                                        name: Identifier {
-                                            name: "db.ObjectId",
-                                            span: Span {
-                                                start: 280,
-                                                end: 291,
-                                            },
-                                        },
-                                        arguments: ArgumentsList {
-                                            arguments: [],
-                                            empty_arguments: [],
-                                            trailing_comma: None,
-                                        },
-                                        span: Span {
-                                            start: 279,
-                                            end: 291,
-                                        },
-                                    },
-                                ],
-                                documentation: None,
-                                span: Span {
-                                    start: 235,
-                                    end: 292,
-                                },
-                            },
-                            Field {
-                                field_type: Supported(
-                                    Identifier {
-                                        name: "Address",
-                                        span: Span {
-                                            start: 312,
-                                            end: 319,
-                                        },
-                                    },
-                                ),
-                                name: Identifier {
-                                    name: "address",
-                                    span: Span {
-                                        start: 304,
-                                        end: 311,
-                                    },
-                                },
-                                arity: Optional,
-                                attributes: [],
-                                documentation: None,
-                                span: Span {
-                                    start: 304,
-                                    end: 321,
-                                },
-                            },
-                        ],
-                        attributes: [],
-                        documentation: None,
-                        span: Span {
-                            start: 210,
-                            end: 330,
-                        },
-                    },
-                ),
-            ],
-        }
-    "#]];
-
-    let found = parse_schema_ast(datamodel).unwrap();
-    let (_, datamodel) = parse_schema(datamodel).unwrap();
-
-    let expected_datamodel = expect![[r#"
-        Datamodel {
-            enums: [],
-            models: [
-                Model {
-                    name: "User",
-                    fields: [
-                        ScalarField(
-                            ScalarField {
-                                name: "id",
-                                field_type: Scalar(
-                                    String,
-                                    Some(
-                                        NativeTypeInstance {
-                                            name: "ObjectId",
-                                            args: [],
-                                            serialized_native_type: String(
-                                                "ObjectId",
-                                            ),
-                                        },
-                                    ),
-                                ),
-                                arity: Required,
-                                database_name: Some(
-                                    "_id",
-                                ),
-                                default_value: Some(
-                                    DefaultValue::Expression(auto()[]),
-                                ),
-                                documentation: None,
-                                is_generated: false,
-                                is_updated_at: false,
-                                is_commented_out: false,
-                                is_ignored: false,
-                            },
-                        ),
-                        CompositeField(
-                            CompositeField {
-                                name: "address",
-                                database_name: None,
-                                composite_type: "Address",
-                                arity: Optional,
-                                documentation: None,
-                                is_commented_out: false,
-                                is_ignored: false,
-                                default_value: None,
-                            },
-                        ),
-                    ],
-                    documentation: None,
-                    database_name: None,
-                    indices: [],
-                    primary_key: Some(
-                        PrimaryKeyDefinition {
-                            name: None,
-                            db_name: None,
-                            fields: [
-                                PrimaryKeyField {
-                                    name: "id",
-                                    sort_order: None,
-                                    length: None,
-                                },
-                            ],
-                            defined_on_field: true,
-                            clustered: None,
-                        },
-                    ),
-                    is_generated: false,
-                    is_commented_out: false,
-                    is_ignored: false,
-                },
-            ],
-            composite_types: [
-                CompositeType {
-                    name: "Address",
-                    fields: [
-                        CompositeTypeField {
-                            name: "name",
-                            type: Scalar(
-                                String,
-                                None,
-                            ),
-                            arity: Optional,
-                            database_name: None,
-                            documentation: None,
-                            default_value: None,
-                            is_commented_out: false,
-                        },
-                        CompositeTypeField {
-                            name: "street",
-                            type: Scalar(
-                                String,
-                                Some(
-                                    NativeTypeInstance {
-                                        name: "ObjectId",
-                                        args: [],
-                                        serialized_native_type: String(
-                                            "ObjectId",
-                                        ),
-                                    },
-                                ),
-                            ),
-                            arity: Required,
-                            database_name: None,
-                            documentation: None,
-                            default_value: None,
-                            is_commented_out: false,
-                        },
-                    ],
-                },
-            ],
-        }
-    "#]];
-
-    expected_ast.assert_debug_eq(&found);
-    expected_datamodel.assert_debug_eq(&datamodel);
+    assert_valid(datamodel);
 }
 
 #[test]
 fn composite_types_must_have_at_least_one_visible_field() {
     let schema = indoc! {r#"
+        datasource mongodb {
+            provider = "mongodb"
+            url = env("TEST_DATABASE_URL")
+        }
+
         type Address {
           // name String?
         }
     "#};
 
-    let datamodel = with_header(schema, Provider::Mongo, &[]);
-
     let expected = expect![[r#"
         [1;91merror[0m: [1mError validating: A type must have at least one field defined.[0m
-          [1;94m-->[0m  [4mschema.prisma:11[0m
+          [1;94m-->[0m  [4mschema.prisma:6[0m
         [1;94m   | [0m
-        [1;94m10 | [0m
-        [1;94m11 | [0m[1;91mtype Address {[0m
-        [1;94m12 | [0m  // name String?
-        [1;94m13 | [0m}
+        [1;94m 5 | [0m
+        [1;94m 6 | [0m[1;91mtype Address {[0m
+        [1;94m 7 | [0m  // name String?
+        [1;94m 8 | [0m}
         [1;94m   | [0m
     "#]];
 
-    let error = datamodel::parse_schema(&datamodel).map(drop).unwrap_err();
-
-    expected.assert_eq(&error);
+    expect_error(schema, &expected);
 }
 
 #[test]
@@ -516,7 +65,7 @@ fn composite_types_can_nest() {
         }
     "#;
 
-    assert!(parse_schema(schema).is_ok());
+    assert_valid(schema);
 }
 
 #[test]
@@ -543,7 +92,7 @@ fn required_cycles_to_self_are_not_allowed() {
         [1;94m   | [0m
     "#]];
 
-    expected.assert_eq(&parse_schema(datamodel).unwrap_err());
+    expect_error(datamodel, &expected);
 }
 
 #[test]
@@ -560,7 +109,7 @@ fn list_cycles_to_self_are_allowed() {
         }
     "#};
 
-    assert!(parse_schema(datamodel).is_ok())
+    assert_valid(datamodel);
 }
 
 #[test]
@@ -604,7 +153,7 @@ fn required_cycles_are_not_allowed() {
         [1;94m   | [0m
     "#]];
 
-    expected.assert_eq(&parse_schema(datamodel).unwrap_err());
+    expect_error(datamodel, &expected);
 }
 
 #[test]
@@ -631,23 +180,23 @@ fn cycles_broken_with_an_optional_are_allowed() {
         }
     "#};
 
-    assert!(parse_schema(datamodel).is_ok());
+    assert_valid(datamodel);
 }
 
 #[test]
 fn unsupported_should_work() {
     let schema = indoc! {r#"
+        datasource mongodb {
+            provider = "mongodb"
+            url = env("TEST_DATABASE_URL")
+        }
+
         type A {
           field Unsupported("Unknown")
         }
     "#};
 
-    let dml = with_header(schema, crate::Provider::Mongo, &[]);
-    let (_, datamodel) = parse_schema(&dml).unwrap();
-
-    datamodel
-        .assert_has_composite_type("A")
-        .assert_has_unsupported_field("field");
+    assert_valid(schema);
 }
 
 #[test]

--- a/libs/sql-schema-describer/tests/describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describer_tests.rs
@@ -122,7 +122,7 @@ fn names_with_hyphens_must_work(api: TestApi) {
     });
 }
 
-#[test_connector]
+#[test_connector(exclude(Mssql))]
 fn composite_primary_keys_must_work(api: TestApi) {
     let sql = match api.sql_family() {
         SqlFamily::Mysql => format!(
@@ -132,14 +132,6 @@ fn composite_primary_keys_must_work(api: TestApi) {
                 PRIMARY KEY(id, name)
             )",
             api.db_name()
-        ),
-        SqlFamily::Mssql => format!(
-            "CREATE TABLE [{}].[User] (
-                [id] INT NOT NULL,
-                [name] VARCHAR(255) NOT NULL,
-                CONSTRAINT [PK_User] PRIMARY KEY ([id], [name])
-            )",
-            api.schema_name(),
         ),
         _ => format!(
             "CREATE TABLE \"{0}\".\"User\" (

--- a/libs/sql-schema-describer/tests/describers/mssql_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/mssql_describer_tests.rs
@@ -1,13 +1,10 @@
 use crate::test_api::*;
 use barrel::{types, Migration};
 use pretty_assertions::assert_eq;
-use sql_schema_describer::{mssql::SqlSchemaDescriber, *};
+use sql_schema_describer::*;
 
 #[test_connector(tags(Mssql))]
 fn udts_can_be_described(api: TestApi) {
-    let conn = api.database();
-    let db_name = api.db_name();
-
     let types = &[
         "bigint",
         "binary(255)",
@@ -43,9 +40,7 @@ fn udts_can_be_described(api: TestApi) {
     ];
 
     for r#type in types {
-        api.block_on(test_setup::reset_mssql_schema(conn, db_name)).unwrap();
-
-        api.raw_cmd(&format!("CREATE TYPE {}.a FROM {}", db_name, r#type));
+        api.raw_cmd(&format!("DROP TYPE IF EXISTS a; CREATE TYPE a FROM {type}"));
 
         let result = api.describe();
         let udt = result
@@ -60,54 +55,43 @@ fn udts_can_be_described(api: TestApi) {
 
 #[test_connector(tags(Mssql))]
 fn views_can_be_described(api: TestApi) {
-    let db_name = api.db_name();
-    let conn = api.database();
-
-    api.block_on(test_setup::reset_mssql_schema(conn, db_name)).unwrap();
-
-    api.raw_cmd(&format!("CREATE TABLE {}.a (a_id int)", db_name));
-    api.raw_cmd(&format!("CREATE TABLE {}.b (b_id int)", db_name));
-
-    let create_view = format!(
-        r#"
-            CREATE VIEW {0}.ab AS
+    let view_definition = r#"
+        CREATE VIEW ab AS
             SELECT a_id
-            FROM {0}.a
+            FROM a
             UNION ALL
             SELECT b_id
-            FROM {0}.b"#,
-        db_name
-    );
+            FROM b;
+    "#;
+    let create_tables = r#"
+        CREATE TABLE a (a_id int);
+        CREATE TABLE b (b_id int);
+    "#;
+    api.raw_cmd(create_tables);
+    api.raw_cmd(view_definition);
 
-    api.raw_cmd(&create_view);
-
-    let inspector = SqlSchemaDescriber::new(conn);
-    let result = api.block_on(inspector.describe(db_name)).unwrap();
+    let result = api.describe();
     let view = result.get_view("ab").expect("couldn't get ab view").to_owned();
 
     assert_eq!("ab", &view.name);
-    assert_eq!(create_view, view.definition.unwrap());
+    assert_eq!(view_definition, view.definition.unwrap());
 }
 
 #[test_connector(tags(Mssql))]
 fn procedures_can_be_described(api: TestApi) {
-    let sql = format!(
-        "CREATE PROCEDURE [{}].foo @ID INT AS SELECT DB_NAME(@ID) AS bar",
-        api.db_name()
-    );
-
-    api.raw_cmd(&sql);
+    let sql = "CREATE PROCEDURE [dbo].foo @ID INT AS SELECT DB_NAME(@ID) AS bar";
+    api.raw_cmd(sql);
 
     let result = api.describe();
     let procedure = result.get_procedure("foo").unwrap();
 
     assert_eq!("foo", &procedure.name);
-    assert_eq!(Some(sql), procedure.definition);
+    assert_eq!(Some(sql), procedure.definition.as_deref());
 }
 
 #[test_connector(tags(Mssql))]
 fn all_mssql_column_types_must_work(api: TestApi) {
-    let mut migration = Migration::new().schema(api.db_name());
+    let mut migration = Migration::new();
     migration.create_table("User", move |t| {
         t.add_column("primary_col", types::integer());
         t.add_column("bit_col", types::custom("bit"));
@@ -807,34 +791,29 @@ fn all_mssql_column_types_must_work(api: TestApi) {
 
 #[test_connector(tags(Mssql))]
 fn mssql_cross_schema_references_are_not_allowed(api: TestApi) {
-    let db_name = api.db_name();
-    let secondary = "mssql_foreign_key_on_delete_must_be_handled_B";
-    let conn = api.database();
-
-    api.raw_cmd("DROP DATABASE IF EXISTS \"mssql_foreign_key_on_delete_must_be_handled_B\"");
-    api.block_on(test_setup::reset_mssql_schema(conn, secondary)).unwrap();
+    api.raw_cmd("CREATE SCHEMA mssql_foreign_key_on_delete_must_be_handled_B");
 
     let sql = format!(
         "
-            CREATE TABLE [{1}].[City] (id INT NOT NULL IDENTITY(1,1), CONSTRAINT [PK__City] PRIMARY KEY ([id]));
-            CREATE TABLE [{0}].[User]
+            CREATE TABLE [{0}].[City] (id INT NOT NULL IDENTITY(1,1), CONSTRAINT [PK__City] PRIMARY KEY ([id]));
+            CREATE TABLE [dbo].[User]
             (
                 id           INT NOT NULL IDENTITY (1,1),
                 city         INT,
                 city_cascade INT,
-                CONSTRAINT [FK__city] FOREIGN KEY (city) REFERENCES [{1}].[City] (id) ON DELETE NO ACTION,
+                CONSTRAINT [FK__city] FOREIGN KEY (city) REFERENCES [{0}].[City] (id) ON DELETE NO ACTION,
                 CONSTRAINT [PK__User] PRIMARY KEY ([id])
             );
         ",
-        db_name, secondary
+        "mssql_foreign_key_on_delete_must_be_handled_B"
     );
 
     api.raw_cmd(&sql);
     let err = api.describe_error();
 
     assert_eq!(
-        "Illegal cross schema reference from `mssql_cross_schema_references_are_not_allowed.User` to `mssql_foreign_key_on_delete_must_be_handled_B.City` in constraint `FK__city`. Foreign keys between database schemas are not supported in Prisma. Please follow the GitHub ticket: https://github.com/prisma/prisma/issues/1175".to_string(),
-        format!("{}", err),
+        "Illegal cross schema reference from `dbo.User` to `mssql_foreign_key_on_delete_must_be_handled_B.City` in constraint `FK__city`. Foreign keys between database schemas are not supported in Prisma. Please follow the GitHub ticket: https://github.com/prisma/prisma/issues/1175",
+        err.to_string(),
     );
 }
 
@@ -897,23 +876,20 @@ fn index_sort_order_desc_is_handled(api: TestApi) {
 
 #[test_connector(tags(Mssql))]
 fn mssql_foreign_key_on_delete_must_be_handled(api: TestApi) {
-    let sql = format!(
-        "
-            CREATE TABLE [{0}].[City] (id INT NOT NULL IDENTITY(1,1), CONSTRAINT [PK__City] PRIMARY KEY ([id]));
-            CREATE TABLE [{0}].[User]
-            (
-                id           INT NOT NULL IDENTITY (1,1),
-                city         INT,
-                city_cascade INT,
-                CONSTRAINT [FK__city] FOREIGN KEY (city) REFERENCES [{0}].[City] (id) ON DELETE NO ACTION,
-                CONSTRAINT [FK__city_cascade] FOREIGN KEY (city_cascade) REFERENCES [{0}].[City] (id) ON DELETE CASCADE,
-                CONSTRAINT [PK__User] PRIMARY KEY ([id])
-            );
-        ",
-        api.db_name()
-    );
+    let sql = "
+        CREATE TABLE [dbo].[City] (id INT NOT NULL IDENTITY(1,1), CONSTRAINT [PK__City] PRIMARY KEY ([id]));
+    CREATE TABLE [dbo].[User]
+        (
+            id           INT NOT NULL IDENTITY (1,1),
+            city         INT,
+            city_cascade INT,
+            CONSTRAINT [FK__city] FOREIGN KEY (city) REFERENCES [dbo].[City] (id) ON DELETE NO ACTION,
+            CONSTRAINT [FK__city_cascade] FOREIGN KEY (city_cascade) REFERENCES [dbo].[City] (id) ON DELETE CASCADE,
+            CONSTRAINT [PK__User] PRIMARY KEY ([id])
+        );
+    ";
 
-    api.raw_cmd(&sql);
+    api.raw_cmd(sql);
     let schema = api.describe();
     let table = schema.table_walker("User").unwrap();
     let expectations = [
@@ -929,7 +905,7 @@ fn mssql_foreign_key_on_delete_must_be_handled(api: TestApi) {
 
 #[test_connector(tags(Mssql))]
 fn mssql_multi_field_indexes_must_be_inferred(api: TestApi) {
-    let mut migration = Migration::new().schema(api.db_name());
+    let mut migration = Migration::new();
     migration.create_table("Employee", move |t| {
         t.add_column("id", types::primary());
         t.add_column("age", types::integer());
@@ -947,7 +923,7 @@ fn mssql_multi_field_indexes_must_be_inferred(api: TestApi) {
 
 #[test_connector(tags(Mssql))]
 fn mssql_join_table_unique_indexes_must_be_inferred(api: TestApi) {
-    let mut migration = Migration::new().schema(api.db_name());
+    let mut migration = Migration::new();
 
     migration.create_table("Cat", move |t| {
         t.add_column("id", types::primary());

--- a/libs/sql-schema-describer/tests/test_api/mod.rs
+++ b/libs/sql-schema-describer/tests/test_api/mod.rs
@@ -117,12 +117,7 @@ impl TestApi {
     }
 
     pub(crate) fn schema_name(&self) -> &str {
-        match self.sql_family() {
-            // It is not possible to connect to a specific schema in MSSQL. The
-            // user has a dedicated schema from the admin, that's all.
-            SqlFamily::Mssql => self.db_name(),
-            _ => self.database.connection_info().schema_name(),
-        }
+        self.database.connection_info().schema_name()
     }
 
     #[track_caller]

--- a/libs/test-setup/src/mssql.rs
+++ b/libs/test-setup/src/mssql.rs
@@ -27,133 +27,26 @@ pub(crate) fn get_mssql_tags(database_url: &str) -> Result<BitFlags<Tags>, Strin
 }
 
 pub async fn init_mssql_database(original_url: &str, db_name: &str) -> Result<(Quaint, String), Error> {
-    let mut url: JdbcString = format!("jdbc:{}", original_url).parse().unwrap();
-    url.properties_mut().insert("schema".into(), db_name.into());
-    let url = url.to_string().trim_start_matches("jdbc:").to_owned();
-    let conn = Quaint::new(&url).await?;
-
+    let conn = Quaint::new(original_url).await?;
     reset_schema(&conn, db_name).await?;
+
+    let mut url: JdbcString = format!("jdbc:{}", original_url).parse().unwrap();
+    url.properties_mut().insert("database".into(), db_name.into());
+    let url = url.to_string().trim_start_matches("jdbc:").to_owned();
 
     Ok((conn, url))
 }
 
 #[tracing::instrument(skip(conn))]
 pub async fn reset_schema(conn: &dyn Queryable, schema_name: &str) -> Result<(), Error> {
-    // Mickie misses DROP SCHEMA .. CASCADE, so what we need to do here is to
-    // delete first the foreign keys, then all the tables from the test schema
-    // to allow a clean slate for the next test.
-
-    let drop_types = format!(
+    let sql = format!(
         r#"
-        DECLARE @stmt NVARCHAR(max)
-        DECLARE @n CHAR(1)
-
-        SET @n = CHAR(10)
-
-        SELECT @stmt = ISNULL(@stmt + @n, '') +
-            'DROP TYPE [' + SCHEMA_NAME(schema_id) + '].[' + name + ']'
-        FROM sys.types
-        WHERE SCHEMA_NAME(schema_id) = '{0}' AND is_user_defined = 1
-
-        EXEC SP_EXECUTESQL @stmt
-        "#,
-        schema_name
+        DROP DATABASE IF EXISTS [{schema_name}];
+        CREATE DATABASE [{schema_name}];
+    "#
     );
-
-    let drop_procedures = format!(
-        r#"
-        DECLARE @stmt NVARCHAR(max)
-        DECLARE @n CHAR(1)
-
-        SET @n = CHAR(10)
-
-        SELECT @stmt = ISNULL(@stmt + @n, '') +
-            'DROP PROCEDURE [' + SCHEMA_NAME(schema_id) + '].[' + OBJECT_NAME(object_id) + ']'
-        FROM sys.objects
-        WHERE SCHEMA_NAME(schema_id) = '{0}' AND type = 'P'
-
-        EXEC SP_EXECUTESQL @stmt
-        "#,
-        schema_name
-    );
-
-    let drop_shared_defaults = format!(
-        r#"
-        DECLARE @stmt NVARCHAR(max)
-        DECLARE @n CHAR(1)
-
-        SET @n = CHAR(10)
-
-        SELECT @stmt = ISNULL(@stmt + @n, '') +
-            'DROP DEFAULT [' + SCHEMA_NAME(schema_id) + '].[' + OBJECT_NAME(object_id) + ']'
-        FROM sys.objects
-        WHERE SCHEMA_NAME(schema_id) = '{0}' AND type = 'D'
-
-        EXEC SP_EXECUTESQL @stmt
-        "#,
-        schema_name
-    );
-
-    let drop_fks = format!(
-        r#"
-        DECLARE @stmt NVARCHAR(max)
-        DECLARE @n CHAR(1)
-
-        SET @n = CHAR(10)
-
-        SELECT @stmt = ISNULL(@stmt + @n, '') +
-            'ALTER TABLE [' + SCHEMA_NAME(schema_id) + '].[' + OBJECT_NAME(parent_object_id) + '] DROP CONSTRAINT [' + name + ']'
-        FROM sys.foreign_keys
-        WHERE SCHEMA_NAME(schema_id) = '{0}'
-
-        EXEC SP_EXECUTESQL @stmt
-        "#,
-        schema_name
-    );
-
-    let drop_views = format!(
-        r#"
-        DECLARE @stmt NVARCHAR(max)
-        DECLARE @n CHAR(1)
-
-        SET @n = CHAR(10)
-
-        SELECT @stmt = ISNULL(@stmt + @n, '') +
-            'DROP VIEW [' + SCHEMA_NAME(schema_id) + '].[' + name + ']'
-        FROM sys.views
-        WHERE SCHEMA_NAME(schema_id) = '{0}'
-
-        EXEC SP_EXECUTESQL @stmt
-        "#,
-        schema_name
-    );
-
-    let drop_tables = format!(
-        r#"
-        DECLARE @stmt NVARCHAR(max)
-        DECLARE @n CHAR(1)
-
-        SET @n = CHAR(10)
-
-        SELECT @stmt = ISNULL(@stmt + @n, '') +
-            'DROP TABLE [' + SCHEMA_NAME(schema_id) + '].[' + name + ']'
-        FROM sys.tables
-        WHERE SCHEMA_NAME(schema_id) = '{0}'
-
-        EXEC SP_EXECUTESQL @stmt
-        "#,
-        schema_name
-    );
-
-    conn.raw_cmd(&drop_procedures).await?;
-    conn.raw_cmd(&drop_views).await?;
-    conn.raw_cmd(&drop_fks).await?;
-    conn.raw_cmd(&drop_tables).await?;
-    conn.raw_cmd(&drop_shared_defaults).await?;
-    conn.raw_cmd(&drop_types).await?;
-
-    conn.raw_cmd(&format!("DROP SCHEMA IF EXISTS {}", schema_name)).await?;
-    conn.raw_cmd(&format!("CREATE SCHEMA {}", schema_name)).await?;
+    conn.raw_cmd(&sql).await?;
+    conn.raw_cmd(&format!("USE [{schema_name}];")).await?;
 
     Ok(())
 }

--- a/migration-engine/cli/tests/cli_tests.rs
+++ b/migration-engine/cli/tests/cli_tests.rs
@@ -143,7 +143,6 @@ fn test_create_database(api: TestApi) {
 fn test_create_database_mssql(api: TestApi) {
     let connection_string = api
         .connection_string()
-        .replace("master", "masterNEW")
         .replace("test_create_database_mssql", "test_create_database_NEW");
 
     let output = api.run(&["--datasource", &connection_string, "drop-database"]);
@@ -153,7 +152,7 @@ fn test_create_database_mssql(api: TestApi) {
     assert!(output.status.success());
 
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("Database 'masterNEW\' was successfully created."));
+    assert!(stderr.contains("Database 'test_create_database_NEW\' was successfully created."));
 
     let output = api.run(&["--datasource", &connection_string, "can-connect-to-database"]);
     assert!(output.status.success());

--- a/migration-engine/migration-engine-tests/tests/create_migration/create_migration_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/create_migration/create_migration_tests.rs
@@ -69,7 +69,7 @@ fn basic_create_migration_works(api: TestApi) {
                     BEGIN TRAN;
 
                     -- CreateTable
-                    CREATE TABLE [basic_create_migration_works].[Cat] (
+                    CREATE TABLE [dbo].[Cat] (
                         [id] INT NOT NULL,
                         [name] NVARCHAR(1000) NOT NULL,
                         CONSTRAINT [Cat_pkey] PRIMARY KEY CLUSTERED ([id])
@@ -137,8 +137,7 @@ fn creating_a_second_migration_should_have_the_previous_sql_schema_as_baseline(a
         .assert_migration_directories_count(2)
         .assert_migration("create-dogs", |migration| {
             let expected_script = if is_cockroach {
-                expect![[
-                        r#"
+                expect![[r#"
                     -- CreateTable
                     CREATE TABLE "Dog" (
                         "id" INT4 NOT NULL,
@@ -146,13 +145,9 @@ fn creating_a_second_migration_should_have_the_previous_sql_schema_as_baseline(a
 
                         CONSTRAINT "Dog_pkey" PRIMARY KEY ("id")
                     );
-                "#
-                ]]
-                }
-                else if is_postgres
-                {
-                    expect![[
-                        r#"
+                "#]]
+            } else if is_postgres {
+                expect![[r#"
                         -- CreateTable
                         CREATE TABLE "Dog" (
                             "id" INTEGER NOT NULL,
@@ -160,11 +155,9 @@ fn creating_a_second_migration_should_have_the_previous_sql_schema_as_baseline(a
 
                             CONSTRAINT "Dog_pkey" PRIMARY KEY ("id")
                         );
-                        "#
-                    ]]
-                } else if is_mysql {
-                    expect![[
-                        r#"
+                        "#]]
+            } else if is_mysql {
+                expect![[r#"
                         -- CreateTable
                         CREATE TABLE `Dog` (
                             `id` INTEGER NOT NULL,
@@ -172,28 +165,23 @@ fn creating_a_second_migration_should_have_the_previous_sql_schema_as_baseline(a
 
                             PRIMARY KEY (`id`)
                         ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-                        "#
-                    ]]
-                }
-                else if is_sqlite {
-                    expect![[
-                        r#"
+                        "#]]
+            } else if is_sqlite {
+                expect![[r#"
                         -- CreateTable
                         CREATE TABLE "Dog" (
                             "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
                             "name" TEXT NOT NULL
                         );
-                        "#
-                            ]]
-                } else if is_mssql {
-                    expect![[
-                        r#"
+                        "#]]
+            } else if is_mssql {
+                expect![[r#"
                         BEGIN TRY
 
                         BEGIN TRAN;
 
                         -- CreateTable
-                        CREATE TABLE [creating_a_second_migration_should_have_the_previous_sql_schema_as_baseline].[Dog] (
+                        CREATE TABLE [dbo].[Dog] (
                             [id] INT NOT NULL,
                             [name] NVARCHAR(1000) NOT NULL,
                             CONSTRAINT [Dog_pkey] PRIMARY KEY CLUSTERED ([id])
@@ -211,11 +199,10 @@ fn creating_a_second_migration_should_have_the_previous_sql_schema_as_baseline(a
                         THROW
 
                         END CATCH
-                    "#
-                        ]]
-                } else {
-                    unreachable!()
-                };
+                    "#]]
+            } else {
+                unreachable!()
+            };
 
             migration.expect_contents(expected_script)
         });
@@ -584,14 +571,13 @@ fn create_constraint_name_tests_w_implicit_names(api: TestApi) {
         .assert_migration_directories_count(1)
         .assert_migration("setup", |migration| {
             let expected_script = if is_mssql {
-                expect![[
-                     r#"
+                expect![[r#"
                     BEGIN TRY
 
                     BEGIN TRAN;
 
                     -- CreateTable
-                    CREATE TABLE [create_constraint_name_tests_w_implicit_names].[A] (
+                    CREATE TABLE [dbo].[A] (
                         [id] INT NOT NULL,
                         [name] NVARCHAR(1000) NOT NULL,
                         [a] NVARCHAR(1000) NOT NULL,
@@ -602,7 +588,7 @@ fn create_constraint_name_tests_w_implicit_names(api: TestApi) {
                     );
 
                     -- CreateTable
-                    CREATE TABLE [create_constraint_name_tests_w_implicit_names].[B] (
+                    CREATE TABLE [dbo].[B] (
                         [a] NVARCHAR(1000) NOT NULL,
                         [b] NVARCHAR(1000) NOT NULL,
                         [aId] INT NOT NULL,
@@ -610,13 +596,13 @@ fn create_constraint_name_tests_w_implicit_names(api: TestApi) {
                     );
 
                     -- CreateIndex
-                    CREATE NONCLUSTERED INDEX [A_a_idx] ON [create_constraint_name_tests_w_implicit_names].[A]([a]);
+                    CREATE NONCLUSTERED INDEX [A_a_idx] ON [dbo].[A]([a]);
 
                     -- CreateIndex
-                    CREATE NONCLUSTERED INDEX [B_a_b_idx] ON [create_constraint_name_tests_w_implicit_names].[B]([a], [b]);
+                    CREATE NONCLUSTERED INDEX [B_a_b_idx] ON [dbo].[B]([a], [b]);
 
                     -- AddForeignKey
-                    ALTER TABLE [create_constraint_name_tests_w_implicit_names].[B] ADD CONSTRAINT [B_aId_fkey] FOREIGN KEY ([aId]) REFERENCES [create_constraint_name_tests_w_implicit_names].[A]([id]) ON DELETE NO ACTION ON UPDATE CASCADE;
+                    ALTER TABLE [dbo].[B] ADD CONSTRAINT [B_aId_fkey] FOREIGN KEY ([aId]) REFERENCES [dbo].[A]([id]) ON DELETE NO ACTION ON UPDATE CASCADE;
 
                     COMMIT TRAN;
 
@@ -630,8 +616,7 @@ fn create_constraint_name_tests_w_implicit_names(api: TestApi) {
                     THROW
 
                     END CATCH
-                "#
-                 ]]
+                "#]]
             } else if is_cockroach {
                 expect![[
                      r#"
@@ -818,14 +803,13 @@ fn create_constraint_name_tests_w_explicit_names(api: TestApi) {
         .assert_migration_directories_count(1)
         .assert_migration("setup", move |migration| {
             let expected_script = if is_mssql {
-                expect![[
-                     r#"
+                expect![[r#"
                     BEGIN TRY
 
                     BEGIN TRAN;
 
                     -- CreateTable
-                    CREATE TABLE [create_constraint_name_tests_w_explicit_names].[A] (
+                    CREATE TABLE [dbo].[A] (
                         [id] INT NOT NULL,
                         [name] NVARCHAR(1000) NOT NULL,
                         [a] NVARCHAR(1000) NOT NULL,
@@ -837,7 +821,7 @@ fn create_constraint_name_tests_w_explicit_names(api: TestApi) {
                     );
 
                     -- CreateTable
-                    CREATE TABLE [create_constraint_name_tests_w_explicit_names].[B] (
+                    CREATE TABLE [dbo].[B] (
                         [a] NVARCHAR(1000) NOT NULL,
                         [b] NVARCHAR(1000) NOT NULL,
                         [aId] INT NOT NULL,
@@ -845,13 +829,13 @@ fn create_constraint_name_tests_w_explicit_names(api: TestApi) {
                     );
 
                     -- CreateIndex
-                    CREATE NONCLUSTERED INDEX [SingleIndex] ON [create_constraint_name_tests_w_explicit_names].[A]([a]);
+                    CREATE NONCLUSTERED INDEX [SingleIndex] ON [dbo].[A]([a]);
 
                     -- CreateIndex
-                    CREATE NONCLUSTERED INDEX [CompoundIndex] ON [create_constraint_name_tests_w_explicit_names].[B]([a], [b]);
+                    CREATE NONCLUSTERED INDEX [CompoundIndex] ON [dbo].[B]([a], [b]);
 
                     -- AddForeignKey
-                    ALTER TABLE [create_constraint_name_tests_w_explicit_names].[B] ADD CONSTRAINT [ForeignKey] FOREIGN KEY ([aId]) REFERENCES [create_constraint_name_tests_w_explicit_names].[A]([id]) ON DELETE NO ACTION ON UPDATE CASCADE;
+                    ALTER TABLE [dbo].[B] ADD CONSTRAINT [ForeignKey] FOREIGN KEY ([aId]) REFERENCES [dbo].[A]([id]) ON DELETE NO ACTION ON UPDATE CASCADE;
 
                     COMMIT TRAN;
 
@@ -865,8 +849,7 @@ fn create_constraint_name_tests_w_explicit_names(api: TestApi) {
                     THROW
 
                     END CATCH
-                "#
-                 ]]
+                "#]]
             } else if is_cockroach {
                 expect![[
                      r#"
@@ -1098,25 +1081,25 @@ fn alter_constraint_name(mut api: TestApi) {
                     BEGIN TRAN;
 
                     -- AlterTable
-                    EXEC SP_RENAME N'alter_constraint_name.A_pkey', N'CustomId';
+                    EXEC SP_RENAME N'dbo.A_pkey', N'CustomId';
 
                     -- AlterTable
-                    EXEC SP_RENAME N'alter_constraint_name.B_pkey', N'CustomCompoundId';
+                    EXEC SP_RENAME N'dbo.B_pkey', N'CustomCompoundId';
 
                     -- RenameForeignKey
-                    EXEC sp_rename 'alter_constraint_name.B_aId_fkey', 'CustomFK', 'OBJECT';
+                    EXEC sp_rename 'dbo.B_aId_fkey', 'CustomFK', 'OBJECT';
 
                     -- RenameIndex
-                    EXEC SP_RENAME N'alter_constraint_name.A.A_a_b_key', N'CustomCompoundUnique', N'INDEX';
+                    EXEC SP_RENAME N'dbo.A.A_a_b_key', N'CustomCompoundUnique', N'INDEX';
 
                     -- RenameIndex
-                    EXEC SP_RENAME N'alter_constraint_name.A.A_a_idx', N'CustomIndex', N'INDEX';
+                    EXEC SP_RENAME N'dbo.A.A_a_idx', N'CustomIndex', N'INDEX';
 
                     -- RenameIndex
-                    EXEC SP_RENAME N'alter_constraint_name.A.A_name_key', N'CustomUnique', N'INDEX';
+                    EXEC SP_RENAME N'dbo.A.A_name_key', N'CustomUnique', N'INDEX';
 
                     -- RenameIndex
-                    EXEC SP_RENAME N'alter_constraint_name.B.B_a_b_idx', N'AnotherCustomIndex', N'INDEX';
+                    EXEC SP_RENAME N'dbo.B.B_a_b_idx', N'AnotherCustomIndex', N'INDEX';
 
                     COMMIT TRAN;
 
@@ -1130,7 +1113,7 @@ fn alter_constraint_name(mut api: TestApi) {
                     THROW
 
                     END CATCH
-                 "#]]
+                "#]]
             } else if is_cockroach {
                 expect![[r#"
                     -- AlterTable

--- a/migration-engine/migration-engine-tests/tests/migrations/diagnose_migration_history_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/diagnose_migration_history_tests.rs
@@ -911,11 +911,10 @@ fn shadow_database_creation_error_is_special_cased_mssql(api: TestApi) {
         r#"
         datasource db {{
             provider = "sqlserver"
-            url = "sqlserver://{dbhost}:{dbport};database={dbname};user=prismashadowdbtestuser;password=1234batmanZ;trustservercertificate=true"
+            url = "sqlserver://{dbhost}:{dbport};user=prismashadowdbtestuser;password=1234batmanZ;trustservercertificate=true"
         }}
         "#,
         dbhost = api.connection_info().host(),
-        dbname = api.connection_info().dbname().unwrap(),
         dbport = api.connection_info().port().unwrap(),
     );
 

--- a/migration-engine/migration-engine-tests/tests/migrations/mssql.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/mssql.rs
@@ -120,7 +120,7 @@ fn mssql_apply_migrations_error_output(api: TestApi) {
         Database error code: 3701
 
         Database error:
-        Cannot drop the table 'mssql_apply_migrations_error_output.Emu', because it does not exist or you do not have permission."#]];
+        Cannot drop the table 'dbo.Emu', because it does not exist or you do not have permission."#]];
 
     let first_segment = err
         .split_terminator("   0: ")
@@ -183,7 +183,7 @@ fn foreign_key_renaming_to_default_works(api: TestApi) {
         BEGIN TRAN;
 
         -- RenameForeignKey
-        EXEC sp_rename 'foreign_key_renaming_to_default_works.favouriteFood', 'Dog_favourite_food_id_fkey', 'OBJECT';
+        EXEC sp_rename 'dbo.favouriteFood', 'Dog_favourite_food_id_fkey', 'OBJECT';
 
         COMMIT TRAN;
 
@@ -278,7 +278,7 @@ fn bigint_defaults_work(api: TestApi) {
         BEGIN TRAN;
 
         -- CreateTable
-        CREATE TABLE [bigint_defaults_work].[foo] (
+        CREATE TABLE [dbo].[foo] (
             [id] NVARCHAR(1000) NOT NULL,
             [bar] BIGINT NOT NULL CONSTRAINT [foo_bar_df] DEFAULT 0,
             CONSTRAINT [foo_pkey] PRIMARY KEY CLUSTERED ([id])
@@ -324,7 +324,7 @@ fn float_columns(api: TestApi) {
         BEGIN TRAN;
 
         -- CreateTable
-        CREATE TABLE [float_columns].[foo] (
+        CREATE TABLE [dbo].[foo] (
             [id] NVARCHAR(1000) NOT NULL,
             [bar] FLOAT NOT NULL CONSTRAINT [foo_bar_df] DEFAULT 0.90001,
             [baz] FLOAT,

--- a/migration-engine/migration-engine-tests/tests/migrations/soft_resets.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/soft_resets.rs
@@ -153,31 +153,14 @@ fn soft_resets_work_on_sql_server(api: TestApi) {
     {
         let mut engine = api.new_engine_with_connection_strings(test_user_connection_string, None);
 
-        let create_schema = format!("CREATE SCHEMA [{}];", engine.schema_name());
-        engine.raw_cmd(&create_schema);
-
         engine
             .apply_migrations(&migrations_directory)
             .send_sync()
             .assert_applied_migrations(&["01init"]);
 
-        let add_view = format!(
-            r#"CREATE VIEW [{0}].[catcat] AS SELECT * FROM [{0}].[Cat]"#,
-            engine.schema_name(),
-        );
-
-        engine.raw_cmd(&add_view);
-
-        let add_type = format!(r#"CREATE TYPE [{0}].[Litter] FROM int"#, engine.schema_name(),);
-
-        engine.raw_cmd(&add_type);
-
-        let add_table_with_type = format!(
-            r#"CREATE TABLE [{0}].specialLitter (id int primary key, litterAmount [{0}].Litter)"#,
-            engine.schema_name()
-        );
-
-        engine.raw_cmd(&add_table_with_type);
+        engine.raw_cmd("CREATE TYPE [dbo].[Litter] FROM int;");
+        engine.raw_cmd("CREATE VIEW [dbo].[catcat] AS (SELECT * FROM [dbo].[Cat]);");
+        engine.raw_cmd(r#"CREATE TABLE [dbo].specialLitter (id int primary key, litterAmount [dbo].[Litter]);"#);
 
         engine
             .assert_schema()


### PR DESCRIPTION
This is necessary because we are going to work on multi-schema support,
and we will have to test that.

Command: hyperfine -w2 --show-output 'mold -run cargo test'

introspection-engine-tests, this branch, mssql 2017:

```
  Time (mean ± σ):     21.419 s ±  0.597 s    [User: 4.892 s, System: 0.329 s]
  Range (min … max):   20.315 s … 22.272 s    10 runs
```

On main, the fastest I managed the introspection tests to go, with 2
threads to avoid deadlocks, was this:

```
  Time (mean ± σ):      6.911 s ±  0.145 s    [User: 4.609 s, System: 0.241 s]
  Range (min … max):    6.689 s …  7.081 s    6 runs
```

So database-per-test is definitely slower than schema-per-test, but we
do not have a choice, because we will support and test multiple schemas.