### PR TITLE
Metric renaming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2165,6 +2165,7 @@ dependencies = [
 [[package]]
 name = "mobc"
 version = "0.7.3"
+source = "git+https://github.com/prisma/mobc?tag=1.0.5#d50fd5de25f80880b0f533bcb48cc65f2c4960b0"
 dependencies = [
  "async-trait",
  "futures-channel",
@@ -5012,7 +5013,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "rand 0.8.5",
  "static_assertions",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2165,7 +2165,6 @@ dependencies = [
 [[package]]
 name = "mobc"
 version = "0.7.3"
-source = "git+https://github.com/prisma/mobc?tag=1.0.4#4d0d2daa5a0424577a5011a4bc6db928e5b2b694"
 dependencies = [
  "async-trait",
  "futures-channel",
@@ -2176,6 +2175,8 @@ dependencies = [
  "metrics 0.18.1",
  "thiserror",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3234,7 +3235,6 @@ dependencies = [
 [[package]]
 name = "quaint"
 version = "0.2.0-alpha.13"
-source = "git+https://github.com/prisma/quaint#df52315fae3f366509da3e5d0815ebc13f445e31"
 dependencies = [
  "async-trait",
  "base64 0.12.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,3 +56,6 @@ opt-level = 3
 codegen-units = 1
 opt-level = 'z' # Optimize for size.
 #strip="symbols"
+
+[patch."https://github.com/prisma/quaint"]
+quaint = {path = "/Users/garren/dev/prisma/quaint"}

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/metrics.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/metrics.rs
@@ -20,8 +20,8 @@ mod metrics {
 
         let json = runner.get_metrics().to_json(Default::default());
         // We cannot assert the full response it will be slightly different per database
-        let total_queries = get_counter(&json, "query_total_queries");
-        let total_operations = get_counter(&json, "query_total_operations");
+        let total_queries = get_counter(&json, "prisma_datasource_queries_total");
+        let total_operations = get_counter(&json, "prisma_client_queries_total");
 
         match runner.connector_version() {
             Sqlite => assert_eq!(total_queries, 9),
@@ -49,7 +49,7 @@ mod metrics {
         let _ = runner.commit_tx(tx_id).await?;
 
         let json = runner.get_metrics().to_json(Default::default());
-        let active_transactions = get_gauge(&json, "query_active_transactions");
+        let active_transactions = get_gauge(&json, "prisma_client_queries_active");
         assert_eq!(active_transactions, 0.0);
 
         let tx_id = runner.start_tx(5000, 5000).await?;
@@ -66,7 +66,7 @@ mod metrics {
         let _ = runner.rollback_tx(tx_id.clone()).await?;
 
         let json = runner.get_metrics().to_json(Default::default());
-        let active_transactions = get_gauge(&json, "query_active_transactions");
+        let active_transactions = get_gauge(&json, "prisma_client_queries_active");
         assert_eq!(active_transactions, 0.0);
         Ok(())
     }

--- a/query-engine/connectors/mongodb-query-connector/src/interface/transaction.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/interface/transaction.rs
@@ -30,7 +30,7 @@ impl<'conn> MongoDbTransaction<'conn> {
             .await
             .map_err(|err| MongoError::from(err).into_connector_error())?;
 
-        increment_gauge!("query_active_transactions", 1.0);
+        increment_gauge!("prisma_client_queries_active", 1.0);
 
         Ok(Self { connection })
     }
@@ -39,7 +39,7 @@ impl<'conn> MongoDbTransaction<'conn> {
 #[async_trait]
 impl<'conn> Transaction for MongoDbTransaction<'conn> {
     async fn commit(&mut self) -> connector_interface::Result<()> {
-        decrement_gauge!("query_active_transactions", 1.0);
+        decrement_gauge!("prisma_client_queries_active", 1.0);
         self.connection
             .session
             .commit_transaction()
@@ -50,7 +50,7 @@ impl<'conn> Transaction for MongoDbTransaction<'conn> {
     }
 
     async fn rollback(&mut self) -> connector_interface::Result<()> {
-        decrement_gauge!("query_active_transactions", 1.0);
+        decrement_gauge!("prisma_client_queries_active", 1.0);
         self.connection
             .session
             .abort_transaction()

--- a/query-engine/connectors/mongodb-query-connector/src/root_queries/mod.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/root_queries/mod.rs
@@ -50,8 +50,8 @@ where
     let start = Instant::now();
     let res = f().await;
 
-    histogram!("query_total_elapsed_time_ms", start.elapsed());
-    increment_counter!("query_total_queries");
+    histogram!("prisma_datasource_queries_duration_histogram_ms", start.elapsed());
+    increment_counter!("prisma_datasource_queries_total");
 
     res
 }

--- a/query-engine/core/src/executor/execute_operation.rs
+++ b/query-engine/core/src/executor/execute_operation.rs
@@ -1,7 +1,10 @@
 use std::time::Instant;
 
 use super::pipeline::QueryPipeline;
-use crate::{IrSerializer, Operation, QueryGraph, QueryGraphBuilder, QueryInterpreter, ResponseData};
+use crate::{
+    IrSerializer, Operation, QueryGraph, QueryGraphBuilder, QueryInterpreter, ResponseData,
+    PRISMA_CLIENT_QUERIES_HISTOGRAM_MS, PRISMA_CLIENT_QUERIES_TOTAL,
+};
 use connector::{Connection, ConnectionLike, Connector};
 use futures::future;
 use metrics::{histogram, increment_counter};
@@ -19,13 +22,13 @@ pub async fn execute_single_operation(
     let interpreter = QueryInterpreter::new(conn);
     let (query_graph, serializer) = QueryGraphBuilder::new(query_schema.clone()).build(operation.clone())?;
 
-    increment_counter!("query_total_operations");
+    increment_counter!(PRISMA_CLIENT_QUERIES_TOTAL);
 
     let result = QueryPipeline::new(query_graph, interpreter, serializer)
         .execute(trace_id)
         .await;
 
-    histogram!("query_operation_total_elapsed_time_ms", operation_timer.elapsed());
+    histogram!(PRISMA_CLIENT_QUERIES_HISTOGRAM_MS, operation_timer.elapsed());
     result
 }
 
@@ -43,14 +46,14 @@ pub async fn execute_many_operations(
     let mut results = Vec::with_capacity(queries.len());
 
     for (query_graph, serializer) in queries {
-        increment_counter!("query_total_operations");
+        increment_counter!(PRISMA_CLIENT_QUERIES_TOTAL);
         let operation_timer = Instant::now();
         let interpreter = QueryInterpreter::new(conn);
         let result = QueryPipeline::new(query_graph, interpreter, serializer)
             .execute(trace_id.clone())
             .await?;
 
-        histogram!("query_operation_total_elapsed_time_ms", operation_timer.elapsed());
+        histogram!(PRISMA_CLIENT_QUERIES_HISTOGRAM_MS, operation_timer.elapsed());
         results.push(Ok(result));
     }
 
@@ -88,7 +91,7 @@ pub async fn execute_many_self_contained<C: Connector + Send + Sync>(
     for op in operations {
         match QueryGraphBuilder::new(query_schema.clone()).build(op.clone()) {
             Ok((graph, serializer)) => {
-                increment_counter!("query_total_operations");
+                increment_counter!(PRISMA_CLIENT_QUERIES_TOTAL);
 
                 let connection_name = connector.name();
                 let conn_span = info_span!(
@@ -142,7 +145,7 @@ async fn execute_self_contained(
         execute_on(conn.as_connection_like(), graph, serializer, trace_id).await
     };
 
-    histogram!("query_operation_total_elapsed_time_ms", operation_timer.elapsed());
+    histogram!(PRISMA_CLIENT_QUERIES_HISTOGRAM_MS, operation_timer.elapsed());
     result
 }
 
@@ -153,7 +156,7 @@ async fn execute_on(
     serializer: IrSerializer,
     trace_id: Option<String>,
 ) -> crate::Result<ResponseData> {
-    increment_counter!("query_total_operations");
+    increment_counter!(PRISMA_CLIENT_QUERIES_TOTAL);
     let interpreter = QueryInterpreter::new(conn);
     let result = QueryPipeline::new(graph, interpreter, serializer)
         .execute(trace_id)

--- a/query-engine/core/src/interactive_transactions/actors.rs
+++ b/query-engine/core/src/interactive_transactions/actors.rs
@@ -75,6 +75,7 @@ impl ITXServer {
 
     async fn execute_single(&mut self, operation: &Operation, trace_id: Option<String>) -> crate::Result<ResponseData> {
         let span = info_span!("prisma:itx_execute", user_facing = true);
+        println!("itx execute TRACE INFO {:?}", trace_id);
         set_span_context(&span, trace_id.clone());
 
         let conn = self.cached_tx.as_open()?;

--- a/query-engine/query-engine/src/server/mod.rs
+++ b/query-engine/query-engine/src/server/mod.rs
@@ -201,6 +201,7 @@ async fn graphql_handler(state: State, req: Request<Body>) -> Result<Response<Bo
         _ => None,
     };
 
+    println!("GRAPQH HANDLE TRACE {:?}", trace_id);
     let work = async move {
         let body_start = req.into_body();
         // block and buffer request until the request has completed


### PR DESCRIPTION
Renames metrics to match the new prisma naming convention. 

Closes https://github.com/prisma/client-planning/issues/66