### PR TITLE
Create the `psl` crate and use it in migration core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2062,12 +2062,12 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "chrono",
- "datamodel",
  "enumflags2",
  "json-rpc-api-build",
  "jsonrpc-core",
  "migration-connector",
  "mongodb-migration-connector",
+ "psl",
  "serde",
  "serde_json",
  "sql-migration-connector",
@@ -3214,6 +3214,13 @@ checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
 dependencies = [
  "bytes",
  "prost",
+]
+
+[[package]]
+name = "psl"
+version = "0.1.0"
+dependencies = [
+ "datamodel",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,7 @@ members = [
   "introspection-engine/connectors/mongodb-introspection-connector",
   "introspection-engine/core",
   "introspection-engine/introspection-engine-tests",
-  "libs/datamodel/connectors/datamodel-connector",
-  "libs/datamodel/connectors/sql-datamodel-connector",
-  "libs/datamodel/connectors/mongodb-datamodel-connector",
+  "libs/datamodel/connectors/*",
   "migration-engine/cli",
   "migration-engine/connectors/migration-connector",
   "migration-engine/connectors/sql-migration-connector",
@@ -44,6 +42,7 @@ members = [
   "libs/mongodb-client",
   "libs/test-cli",
   "libs/user-facing-errors",
+  "psl/*",
 ]
 
 [profile.dev]

--- a/migration-engine/core/Cargo.toml
+++ b/migration-engine/core/Cargo.toml
@@ -4,7 +4,7 @@ name = "migration-core"
 version = "0.1.0"
 
 [dependencies]
-datamodel = { path = "../../libs/datamodel/core" }
+psl = { path = "../../psl/psl" }
 migration-connector = { path = "../connectors/migration-connector" }
 mongodb-migration-connector = { path = "../connectors/mongodb-migration-connector" }
 sql-migration-connector = { path = "../connectors/sql-migration-connector" }

--- a/migration-engine/core/src/commands/create_migration.rs
+++ b/migration-engine/core/src/commands/create_migration.rs
@@ -1,6 +1,6 @@
 use crate::{json_rpc::types::*, CoreError, CoreResult};
-use datamodel::parser_database::SourceFile;
 use migration_connector::{migrations_directory::*, DiffTarget, MigrationConnector};
+use psl::parser_database::SourceFile;
 use std::{path::Path, sync::Arc};
 use user_facing_errors::migration_engine::MigrationNameTooLong;
 

--- a/migration-engine/core/src/commands/diff.rs
+++ b/migration-engine/core/src/commands/diff.rs
@@ -2,9 +2,9 @@ use crate::{
     core_error::CoreResult,
     json_rpc::types::{DiffParams, DiffResult, DiffTarget, PathContainer, SchemaContainer, UrlContainer},
 };
-use datamodel::parser_database::SourceFile;
 use enumflags2::BitFlags;
 use migration_connector::{ConnectorError, ConnectorHost, DatabaseSchema, DiffTarget as McDiff, MigrationConnector};
+use psl::parser_database::SourceFile;
 use std::{path::Path, sync::Arc};
 
 pub async fn diff(params: DiffParams, host: Arc<dyn ConnectorHost>) -> CoreResult<DiffResult> {

--- a/migration-engine/core/src/commands/evaluate_data_loss.rs
+++ b/migration-engine/core/src/commands/evaluate_data_loss.rs
@@ -1,6 +1,6 @@
 use crate::{json_rpc::types::*, CoreResult};
-use datamodel::parser_database::SourceFile;
 use migration_connector::{migrations_directory::*, DiffTarget, MigrationConnector};
+use psl::parser_database::SourceFile;
 use std::sync::Arc;
 
 /// Development command for migrations. Evaluate the data loss induced by the

--- a/migration-engine/core/src/commands/schema_push.rs
+++ b/migration-engine/core/src/commands/schema_push.rs
@@ -1,6 +1,6 @@
 use crate::{json_rpc::types::*, parse_schema, CoreResult};
-use datamodel::parser_database::SourceFile;
 use migration_connector::{ConnectorError, DiffTarget, MigrationConnector};
+use psl::parser_database::SourceFile;
 use std::sync::Arc;
 use tracing_futures::Instrument;
 

--- a/migration-engine/core/src/lib.rs
+++ b/migration-engine/core/src/lib.rs
@@ -18,19 +18,19 @@ mod timings;
 pub use self::{api::GenericApi, core_error::*, rpc::rpc_api, timings::TimingsLayer};
 pub use migration_connector;
 
-use datamodel::{
-    builtin_connectors::*, common::preview_features::PreviewFeature, parser_database::SourceFile, Datasource,
-    ValidatedSchema,
-};
 use enumflags2::BitFlags;
 use migration_connector::ConnectorParams;
 use mongodb_migration_connector::MongoDbMigrationConnector;
+use psl::{
+    builtin_connectors::*, common::preview_features::PreviewFeature, parser_database::SourceFile, Datasource,
+    ValidatedSchema,
+};
 use sql_migration_connector::SqlMigrationConnector;
 use std::{env, path::Path};
 use user_facing_errors::common::InvalidConnectionString;
 
 fn parse_schema(schema: SourceFile) -> CoreResult<ValidatedSchema> {
-    datamodel::parse_schema_parserdb(schema).map_err(CoreError::new_schema_parser_error)
+    psl::parse_schema_parserdb(schema).map_err(CoreError::new_schema_parser_error)
 }
 
 fn connector_for_connection_string(
@@ -99,7 +99,7 @@ fn connector_for_connection_string(
 
 /// Same as schema_to_connector, but it will only read the provider, not the connector params.
 fn schema_to_connector_unchecked(schema: &str) -> CoreResult<Box<dyn migration_connector::MigrationConnector>> {
-    let config = datamodel::parse_configuration(schema)
+    let config = psl::parse_configuration(schema)
         .map(|validated_config| validated_config.subject)
         .map_err(|err| CoreError::new_schema_parser_error(err.to_pretty_string("schema.prisma", schema)))?;
 
@@ -180,7 +180,7 @@ pub fn migration_api(
 }
 
 fn parse_configuration(datamodel: &str) -> CoreResult<(Datasource, String, BitFlags<PreviewFeature>, Option<String>)> {
-    let config = datamodel::parse_configuration(datamodel)
+    let config = psl::parse_configuration(datamodel)
         .map(|validated_config| validated_config.subject)
         .map_err(|err| CoreError::new_schema_parser_error(err.to_pretty_string("schema.prisma", datamodel)))?;
 

--- a/psl/psl/Cargo.toml
+++ b/psl/psl/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "psl"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+psl-core = { path = "../../libs/datamodel/core", package = "datamodel" }

--- a/psl/psl/README.md
+++ b/psl/psl/README.md
@@ -1,0 +1,3 @@
+# PSL stands for Prisma Schema Language
+
+This is the façade crate for the Prisma Schema Language implementation.

--- a/psl/psl/src/lib.rs
+++ b/psl/psl/src/lib.rs
@@ -1,0 +1,4 @@
+#![doc = include_str!("../README.md")]
+#![deny(rust_2018_idioms, unsafe_code, missing_docs)]
+
+pub use psl_core::*;


### PR DESCRIPTION
This is the first step of the renaming proposed in https://www.notion.so/prismaio/prisma-engines-proposal-reorganize-datamodel-crates-daa14d2ed7404871880737a8f06da359