### PR TITLE
add top level models and composites api to builder

### DIFF
--- a/query-engine/schema-builder/src/lib.rs
+++ b/query-engine/schema-builder/src/lib.rs
@@ -40,8 +40,8 @@ mod utils;
 use cache::TypeRefCache;
 use datamodel_connector::{ConnectorCapabilities, ConnectorCapability, ReferentialIntegrity};
 use prisma_models::{
-    datamodel::common::preview_features::PreviewFeature, Field as ModelField, Index, InternalDataModelRef, ModelRef,
-    RelationFieldRef, TypeIdentifier,
+    datamodel::common::preview_features::PreviewFeature, CompositeTypeRef, Field as ModelField, Index,
+    InternalDataModelRef, ModelRef, RelationFieldRef, TypeIdentifier,
 };
 use schema::*;
 use std::sync::Arc;
@@ -108,6 +108,14 @@ impl BuilderContext {
         self.has_feature(&PreviewFeature::FullTextSearch)
             && (self.has_capability(ConnectorCapability::FullTextSearchWithoutIndex)
                 || self.has_capability(ConnectorCapability::FullTextSearchWithIndex))
+    }
+
+    pub fn models(&self) -> Vec<ModelRef> {
+        self.internal_data_model.models_cloned()
+    }
+
+    pub fn composite_types(&self) -> Vec<CompositeTypeRef> {
+        self.internal_data_model.composite_types().to_owned()
     }
 }
 

--- a/query-engine/schema-builder/src/output_types/mutation_type.rs
+++ b/query-engine/schema-builder/src/output_types/mutation_type.rs
@@ -6,8 +6,7 @@ use prisma_models::{dml, PrismaValue};
 /// Builds the root `Mutation` type.
 pub(crate) fn build(ctx: &mut BuilderContext) -> (OutputType, ObjectTypeStrongRef) {
     let mut fields: Vec<OutputField> = ctx
-        .internal_data_model
-        .models_cloned()
+        .models()
         .into_iter()
         .flat_map(|model| {
             let mut vec = vec![];

--- a/query-engine/schema-builder/src/output_types/objects/composite.rs
+++ b/query-engine/schema-builder/src/output_types/objects/composite.rs
@@ -6,28 +6,20 @@ use prisma_models::CompositeTypeRef;
 /// Compute initial composites cache. No fields are computed because we first
 /// need all composites to be present, then we can compute fields in a second pass.
 pub(crate) fn initialize_cache(ctx: &mut BuilderContext) {
-    ctx.internal_data_model
-        .composite_types()
-        .to_owned()
-        .into_iter()
-        .for_each(|composite| {
-            let ident = Identifier::new(composite.name.clone(), MODEL_NAMESPACE);
-            ctx.cache_output_type(ident.clone(), Arc::new(ObjectType::new(ident, None)));
-        });
+    ctx.composite_types().into_iter().for_each(|composite| {
+        let ident = Identifier::new(composite.name.clone(), MODEL_NAMESPACE);
+        ctx.cache_output_type(ident.clone(), Arc::new(ObjectType::new(ident, None)));
+    });
 }
 
 // Compute fields on all cached composite object types.
 pub(crate) fn initialize_fields(ctx: &mut BuilderContext) {
-    ctx.internal_data_model
-        .composite_types()
-        .to_owned()
-        .into_iter()
-        .for_each(|composite| {
-            let fields = compute_composite_object_type_fields(ctx, &composite);
-            let obj: ObjectTypeWeakRef = map_type(ctx, &composite);
+    ctx.composite_types().into_iter().for_each(|composite| {
+        let fields = compute_composite_object_type_fields(ctx, &composite);
+        let obj: ObjectTypeWeakRef = map_type(ctx, &composite);
 
-            obj.into_arc().set_fields(fields);
-        });
+        obj.into_arc().set_fields(fields);
+    });
 }
 
 pub(crate) fn map_type(ctx: &mut BuilderContext, ct: &CompositeTypeRef) -> ObjectTypeWeakRef {

--- a/query-engine/schema-builder/src/output_types/objects/model.rs
+++ b/query-engine/schema-builder/src/output_types/objects/model.rs
@@ -7,43 +7,35 @@ use std::convert::identity;
 /// Compute initial model cache. No fields are computed because we first
 /// need all models to be present, then we can compute fields in a second pass.
 pub(crate) fn initialize_cache(ctx: &mut BuilderContext) {
-    ctx.internal_data_model
-        .models()
-        .to_owned()
-        .into_iter()
-        .for_each(|model| {
-            let ident = Identifier::new(model.name.clone(), MODEL_NAMESPACE);
-            ctx.cache_output_type(ident.clone(), Arc::new(ObjectType::new(ident, Some(model))));
-        });
+    ctx.models().into_iter().for_each(|model| {
+        let ident = Identifier::new(&model.name, MODEL_NAMESPACE);
+        ctx.cache_output_type(ident.clone(), Arc::new(ObjectType::new(ident, Some(model))));
+    });
 }
 
 // Compute fields on all cached model object types.
 pub(crate) fn initialize_fields(ctx: &mut BuilderContext) {
-    ctx.internal_data_model
-        .models()
-        .to_owned()
-        .into_iter()
-        .for_each(|model| {
-            let obj: ObjectTypeWeakRef = map_type(ctx, &model);
-            let mut fields = compute_model_object_type_fields(ctx, &model);
+    ctx.models().into_iter().for_each(|model| {
+        let obj: ObjectTypeWeakRef = map_type(ctx, &model);
+        let mut fields = compute_model_object_type_fields(ctx, &model);
 
-            // Add _count field. Only include to-many fields.
-            let relation_fields = model.fields().relation().into_iter().filter(|f| f.is_list()).collect();
+        // Add _count field. Only include to-many fields.
+        let relation_fields = model.fields().relation().into_iter().filter(|f| f.is_list()).collect();
 
-            append_opt(
-                &mut fields,
-                field::aggregation_relation_field(
-                    ctx,
-                    UNDERSCORE_COUNT,
-                    &model,
-                    relation_fields,
-                    |_, _| OutputType::int(),
-                    identity,
-                ),
-            );
+        append_opt(
+            &mut fields,
+            field::aggregation_relation_field(
+                ctx,
+                UNDERSCORE_COUNT,
+                &model,
+                relation_fields,
+                |_, _| OutputType::int(),
+                identity,
+            ),
+        );
 
-            obj.into_arc().set_fields(fields);
-        });
+        obj.into_arc().set_fields(fields);
+    });
 }
 
 /// Returns an output object type for the given model.

--- a/query-engine/schema-builder/src/output_types/query_type.rs
+++ b/query-engine/schema-builder/src/output_types/query_type.rs
@@ -4,8 +4,7 @@ use input_types::fields::arguments;
 /// Builds the root `Query` type.
 pub(crate) fn build(ctx: &mut BuilderContext) -> (OutputType, ObjectTypeStrongRef) {
     let fields: Vec<_> = ctx
-        .internal_data_model
-        .models_cloned()
+        .models()
         .into_iter()
         .flat_map(|model| {
             let mut vec = vec![


### PR DESCRIPTION
A very small code improvement to remove calls to a field in a struct and rather call a method on the struct. That way we create a defined API, and can change how we generate the API. For example with the models, longer term we could look to use the parser database instead of having to rely on our intermediate data structures. 