### PR TITLE
dml-renaming: start preparing datamodel tests to move to psl

### DIFF
--- a/libs/datamodel/core/tests/attributes/id_negative.rs
+++ b/libs/datamodel/core/tests/attributes/id_negative.rs
@@ -8,8 +8,6 @@ fn id_should_error_if_the_field_is_not_required() {
         }
     "#};
 
-    let error = datamodel::parse_schema(dml).map(drop).unwrap_err();
-
     let expectation = expect![[r#"
         [1;91merror[0m: [1mError parsing attribute "@id": Fields that are marked as id must be required.[0m
           [1;94m-->[0m  [4mschema.prisma:2[0m
@@ -19,7 +17,7 @@ fn id_should_error_if_the_field_is_not_required() {
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(dml, &expectation)
 }
 
 #[test]
@@ -30,8 +28,6 @@ fn id_should_error_multiple_ids_are_provided() {
           internalId String   @id @default(uuid())
         }
     "#};
-
-    let error = datamodel::parse_schema(dml).map(drop).unwrap_err();
 
     let expectation = expect![[r#"
         [1;91merror[0m: [1mError validating model "Model": At most one field must be marked as the id field with the `@id` attribute.[0m
@@ -45,7 +41,7 @@ fn id_should_error_multiple_ids_are_provided() {
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(dml, &expectation)
 }
 
 #[test]
@@ -58,8 +54,6 @@ fn id_must_error_when_single_and_multi_field_id_is_used() {
           @@id([id,b])
         }
     "#};
-
-    let error = datamodel::parse_schema(dml).map(drop).unwrap_err();
 
     let expectation = expect![[r#"
         [1;91merror[0m: [1mError validating model "Model": Each model must have at most one id criteria. You can't have `@id` and `@@id` at the same time.[0m
@@ -75,7 +69,7 @@ fn id_must_error_when_single_and_multi_field_id_is_used() {
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(dml, &expectation)
 }
 
 #[test]
@@ -89,8 +83,6 @@ fn id_must_error_when_multi_field_is_referring_to_undefined_fields() {
         }
     "#};
 
-    let error = datamodel::parse_schema(dml).map(drop).unwrap_err();
-
     let expectation = expect![[r#"
         [1;91merror[0m: [1mError validating model "Model": The multi field id declaration refers to the unknown fields c.[0m
           [1;94m-->[0m  [4mschema.prisma:5[0m
@@ -100,7 +92,7 @@ fn id_must_error_when_multi_field_is_referring_to_undefined_fields() {
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(dml, &expectation)
 }
 
 #[test]
@@ -118,8 +110,6 @@ fn relation_fields_as_part_of_compound_id_must_error() {
         }
     "#};
 
-    let error = datamodel::parse_schema(dml).map(drop).unwrap_err();
-
     let expectation = expect![[r#"
         [1;91merror[0m: [1mError validating model "User": The id definition refers to the relation fields identification. ID definitions must reference only scalar fields.[0m
           [1;94m-->[0m  [4mschema.prisma:5[0m
@@ -129,7 +119,7 @@ fn relation_fields_as_part_of_compound_id_must_error() {
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(dml, &expectation)
 }
 
 #[test]
@@ -144,8 +134,6 @@ fn must_error_when_multi_field_is_referring_fields_that_are_not_required() {
         }
     "#};
 
-    let error = datamodel::parse_schema(dml).map(drop).unwrap_err();
-
     let expectation = expect![[r#"
         [1;91merror[0m: [1mError validating model "Model": The id definition refers to the optional fields b, c. ID definitions must reference only required fields.[0m
           [1;94m-->[0m  [4mschema.prisma:6[0m
@@ -155,7 +143,7 @@ fn must_error_when_multi_field_is_referring_fields_that_are_not_required() {
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(dml, &expectation)
 }
 
 #[test]
@@ -169,8 +157,6 @@ fn stringified_field_names_in_id_return_nice_error() {
         }
     "#};
 
-    let error = datamodel::parse_schema(dml).map(drop).unwrap_err();
-
     let expectation = expect![[r#"
         [1;91merror[0m: [1mExpected a constant literal value, but received string value `"firstName"`.[0m
           [1;94m-->[0m  [4mschema.prisma:5[0m
@@ -180,7 +166,7 @@ fn stringified_field_names_in_id_return_nice_error() {
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(dml, &expectation)
 }
 
 #[test]
@@ -195,8 +181,6 @@ fn relation_field_as_id_must_error() {
         }
     "#};
 
-    let error = datamodel::parse_schema(dml).map(drop).unwrap_err();
-
     let expectation = expect![[r#"
         [1;91merror[0m: [1mError parsing attribute "@id": The field `identification` is a relation field and cannot be marked with `@id`. Only scalar fields can be declared as id.[0m
           [1;94m-->[0m  [4mschema.prisma:2[0m
@@ -206,36 +190,35 @@ fn relation_field_as_id_must_error() {
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(dml, &expectation)
 }
 
 #[test]
 fn invalid_name_for_compound_id_must_error() {
-    let dml = with_header(
-        indoc! {r#"
+    let dml = indoc! {r#"
+        datasource db {
+          provider = "postgresql"
+          url      = env("DATABASE_URL")
+        }
+
         model User {
           name           String
           identification Int
 
           @@id([name, identification], name: "Test.User")
         }
-    "#},
-        Provider::Postgres,
-        &[],
-    );
-
-    let error = datamodel::parse_schema(&dml).map(drop).unwrap_err();
+    "#};
 
     let expectation = expect![[r#"
         [1;91merror[0m: [1mError validating model "User": The `name` property within the `@@id` attribute only allows for the following characters: `_a-zA-Z0-9`.[0m
-          [1;94m-->[0m  [4mschema.prisma:15[0m
+          [1;94m-->[0m  [4mschema.prisma:10[0m
         [1;94m   | [0m
-        [1;94m14 | [0m
-        [1;94m15 | [0m  [1;91m@@id([name, identification], name: "Test.User")[0m
+        [1;94m 9 | [0m
+        [1;94m10 | [0m  [1;91m@@id([name, identification], name: "Test.User")[0m
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(&dml, &expectation)
 }
 
 #[test]
@@ -258,8 +241,6 @@ fn mapped_id_must_error_on_mysql() {
         }
     "#};
 
-    let error = datamodel::parse_schema(dml).map(drop).unwrap_err();
-
     let expectation = expect![[r#"
         [1;91merror[0m: [1mError validating model "User": You defined a database name for the primary key on the model. This is not supported by the provider.[0m
           [1;94m-->[0m  [4mschema.prisma:6[0m
@@ -282,7 +263,7 @@ fn mapped_id_must_error_on_mysql() {
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(dml, &expectation)
 }
 
 #[test]
@@ -305,8 +286,6 @@ fn mapped_id_must_error_on_sqlite() {
         }
     "#};
 
-    let error = datamodel::parse_schema(dml).map(drop).unwrap_err();
-
     let expectation = expect![[r#"
         [1;91merror[0m: [1mError validating model "User": You defined a database name for the primary key on the model. This is not supported by the provider.[0m
           [1;94m-->[0m  [4mschema.prisma:6[0m
@@ -329,13 +308,17 @@ fn mapped_id_must_error_on_sqlite() {
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(dml, &expectation)
 }
 
 #[test]
 fn naming_id_to_a_field_name_should_error() {
-    let dml = with_header(
-        indoc! {r#"
+    let dml = indoc! {r#"
+        datasource db {
+          provider = "postgresql"
+          url      = env("DATABASE_URL")
+        }
+
         model User {
           used           Int
           name           String
@@ -343,35 +326,34 @@ fn naming_id_to_a_field_name_should_error() {
 
           @@id([name, identification], name: "used")
         }
-    "#},
-        Provider::Postgres,
-        &[],
-    );
-
-    let error = datamodel::parse_schema(&dml).map(drop).unwrap_err();
+    "#};
 
     let expectation = expect![[r#"
         [1;91merror[0m: [1mError validating model "User": The custom name `used` specified for the `@@id` attribute is already used as a name for a field. Please choose a different name.[0m
-          [1;94m-->[0m  [4mschema.prisma:11[0m
+          [1;94m-->[0m  [4mschema.prisma:6[0m
         [1;94m   | [0m
+        [1;94m 5 | [0m
+        [1;94m 6 | [0m[1;91mmodel User {[0m
+        [1;94m 7 | [0m  used           Int
+        [1;94m 8 | [0m  name           String
+        [1;94m 9 | [0m  identification Int
         [1;94m10 | [0m
-        [1;94m11 | [0m[1;91mmodel User {[0m
-        [1;94m12 | [0m  used           Int
-        [1;94m13 | [0m  name           String
-        [1;94m14 | [0m  identification Int
-        [1;94m15 | [0m
-        [1;94m16 | [0m  @@id([name, identification], name: "used")
-        [1;94m17 | [0m}
+        [1;94m11 | [0m  @@id([name, identification], name: "used")
+        [1;94m12 | [0m}
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(&dml, &expectation)
 }
 
 #[test]
 fn mapping_id_with_a_name_that_is_too_long_should_error() {
-    let dml = with_header(
-        indoc! {r#"
+    let schema = indoc! {r#"
+        datasource test {
+          provider = "postgresql"
+          url      = env("DATABASE_URL")
+        }
+
         model User {
           name           String
           identification Int
@@ -383,29 +365,24 @@ fn mapping_id_with_a_name_that_is_too_long_should_error() {
           name           String @id(map: "IfYouAreGoingToPickTheNameYourselfYouShouldReallyPickSomethingShortAndSweetInsteadOfASuperLongNameViolatingLengthLimitsHereAsWell")
           identification Int
         }
-    "#},
-        Provider::Postgres,
-        &[],
-    );
-
-    let error = datamodel::parse_schema(&dml).map(drop).unwrap_err();
+    "#};
 
     let expectation = expect![[r#"
         [1;91merror[0m: [1mError validating model "User": The constraint name 'IfYouAreGoingToPickTheNameYourselfYouShouldReallyPickSomethingShortAndSweetInsteadOfASuperLongNameViolatingLengthLimits' specified in the `map` argument for the `@@id` constraint is too long for your chosen provider. The maximum allowed length is 63 bytes.[0m
-          [1;94m-->[0m  [4mschema.prisma:15[0m
+          [1;94m-->[0m  [4mschema.prisma:10[0m
         [1;94m   | [0m
-        [1;94m14 | [0m
-        [1;94m15 | [0m  [1;91m@@id([name, identification], map: "IfYouAreGoingToPickTheNameYourselfYouShouldReallyPickSomethingShortAndSweetInsteadOfASuperLongNameViolatingLengthLimits")[0m
+        [1;94m 9 | [0m
+        [1;94m10 | [0m  [1;91m@@id([name, identification], map: "IfYouAreGoingToPickTheNameYourselfYouShouldReallyPickSomethingShortAndSweetInsteadOfASuperLongNameViolatingLengthLimits")[0m
         [1;94m   | [0m
         [1;91merror[0m: [1mError validating model "User1": The constraint name 'IfYouAreGoingToPickTheNameYourselfYouShouldReallyPickSomethingShortAndSweetInsteadOfASuperLongNameViolatingLengthLimitsHereAsWell' specified in the `map` argument for the `@id` constraint is too long for your chosen provider. The maximum allowed length is 63 bytes.[0m
-          [1;94m-->[0m  [4mschema.prisma:19[0m
+          [1;94m-->[0m  [4mschema.prisma:14[0m
         [1;94m   | [0m
-        [1;94m18 | [0mmodel User1 {
-        [1;94m19 | [0m  name           String [1;91m@id(map: "IfYouAreGoingToPickTheNameYourselfYouShouldReallyPickSomethingShortAndSweetInsteadOfASuperLongNameViolatingLengthLimitsHereAsWell")[0m
+        [1;94m13 | [0mmodel User1 {
+        [1;94m14 | [0m  name           String [1;91m@id(map: "IfYouAreGoingToPickTheNameYourselfYouShouldReallyPickSomethingShortAndSweetInsteadOfASuperLongNameViolatingLengthLimitsHereAsWell")[0m
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(schema, &expectation)
 }
 
 #[test]
@@ -420,8 +397,6 @@ fn name_on_field_level_id_should_error() {
         &[],
     );
 
-    let error = datamodel::parse_schema(&dml).map(drop).unwrap_err();
-
     let expectation = expect![[r#"
         [1;91merror[0m: [1mNo such argument.[0m
           [1;94m-->[0m  [4mschema.prisma:12[0m
@@ -431,7 +406,7 @@ fn name_on_field_level_id_should_error() {
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(&dml, &expectation)
 }
 
 #[test]
@@ -451,8 +426,6 @@ fn bytes_should_not_be_allowed_as_id_on_sql_server() {
         }
     "#};
 
-    let error = datamodel::parse_schema(dml).map(drop).unwrap_err();
-
     let expected = expect![[r#"
         [1;91merror[0m: [1mInvalid model: Using Bytes type is not allowed in the model's id.[0m
           [1;94m-->[0m  [4mschema.prisma:11[0m
@@ -462,7 +435,7 @@ fn bytes_should_not_be_allowed_as_id_on_sql_server() {
         [1;94m   | [0m
     "#]];
 
-    expected.assert_eq(&error);
+    expect_error(dml, &expected)
 }
 
 #[test]
@@ -485,8 +458,6 @@ fn primary_key_and_foreign_key_names_cannot_clash() {
         }
     "#};
 
-    let error = datamodel::parse_schema(dml).map(drop).unwrap_err();
-
     let expectation = expect![[r#"
         [1;91merror[0m: [1mError parsing attribute "@id": The given constraint name `foo` has to be unique in the following namespace: on model `A` for primary key, indexes, unique constraints and foreign keys. Please provide a different name using the `map` argument.[0m
           [1;94m-->[0m  [4mschema.prisma:7[0m
@@ -502,35 +473,42 @@ fn primary_key_and_foreign_key_names_cannot_clash() {
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(dml, &expectation)
 }
 
 #[test]
 fn mysql_does_not_allow_id_sort_argument() {
     let dml = indoc! {r#"
+        datasource db {
+          provider = "mysql"
+          url      = env("DATABASE_URL")
+        }
+
         model A {
           id Int @id(sort: Desc)
         }
     "#};
 
-    let schema = with_header(dml, Provider::Mysql, &[]);
-    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
-
     let expectation = expect![[r#"
         [1;91merror[0m: [1mError parsing attribute "@id": The sort argument is not supported in the primary key with the current connector[0m
-          [1;94m-->[0m  [4mschema.prisma:12[0m
+          [1;94m-->[0m  [4mschema.prisma:7[0m
         [1;94m   | [0m
-        [1;94m11 | [0mmodel A {
-        [1;94m12 | [0m  id Int [1;91m@id(sort: Desc)[0m
+        [1;94m 6 | [0mmodel A {
+        [1;94m 7 | [0m  id Int [1;91m@id(sort: Desc)[0m
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(dml, &expectation)
 }
 
 #[test]
 fn mysql_does_not_allow_compound_id_sort_argument() {
     let dml = indoc! {r#"
+        datasource test {
+          provider = "mysql"
+          url      = env("DATABASE_URL")
+        }
+
         model A {
           a String @test.VarChar(255)
           b String @test.VarChar(255)
@@ -539,47 +517,51 @@ fn mysql_does_not_allow_compound_id_sort_argument() {
         }
     "#};
 
-    let schema = with_header(dml, Provider::Mysql, &[]);
-    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
-
     let expectation = expect![[r#"
         [1;91merror[0m: [1mError parsing attribute "@@id": The sort argument is not supported in the primary key with the current connector[0m
-          [1;94m-->[0m  [4mschema.prisma:15[0m
+          [1;94m-->[0m  [4mschema.prisma:10[0m
         [1;94m   | [0m
-        [1;94m14 | [0m
-        [1;94m15 | [0m  [1;91m@@id([a(sort: Asc), b(sort: Desc)])[0m
+        [1;94m 9 | [0m
+        [1;94m10 | [0m  [1;91m@@id([a(sort: Asc), b(sort: Desc)])[0m
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(dml, &expectation)
 }
 
 #[test]
 fn postgresql_does_not_allow_id_sort_argument() {
     let dml = indoc! {r#"
+        datasource db {
+          provider = "postgresql"
+          url      = env("DATABASE_URL")
+        }
+
         model A {
           id Int @id(sort: Desc)
         }
     "#};
 
-    let schema = with_header(dml, Provider::Postgres, &[]);
-    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
-
     let expectation = expect![[r#"
         [1;91merror[0m: [1mError parsing attribute "@id": The sort argument is not supported in the primary key with the current connector[0m
-          [1;94m-->[0m  [4mschema.prisma:12[0m
+          [1;94m-->[0m  [4mschema.prisma:7[0m
         [1;94m   | [0m
-        [1;94m11 | [0mmodel A {
-        [1;94m12 | [0m  id Int [1;91m@id(sort: Desc)[0m
+        [1;94m 6 | [0mmodel A {
+        [1;94m 7 | [0m  id Int [1;91m@id(sort: Desc)[0m
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(dml, &expectation)
 }
 
 #[test]
 fn postgresql_does_not_allow_compound_id_sort_argument() {
     let dml = indoc! {r#"
+        datasource test {
+          provider = "postgresql"
+          url      = env("DATABASE_URL")
+        }
+
         model A {
           a String @test.VarChar(255)
           b String @test.VarChar(255)
@@ -588,65 +570,66 @@ fn postgresql_does_not_allow_compound_id_sort_argument() {
         }
     "#};
 
-    let schema = with_header(dml, Provider::Postgres, &[]);
-    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
-
     let expectation = expect![[r#"
         [1;91merror[0m: [1mError parsing attribute "@@id": The sort argument is not supported in the primary key with the current connector[0m
-          [1;94m-->[0m  [4mschema.prisma:15[0m
+          [1;94m-->[0m  [4mschema.prisma:10[0m
         [1;94m   | [0m
-        [1;94m14 | [0m
-        [1;94m15 | [0m  [1;91m@@id([a(sort: Asc), b(sort: Desc)])[0m
+        [1;94m 9 | [0m
+        [1;94m10 | [0m  [1;91m@@id([a(sort: Asc), b(sort: Desc)])[0m
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(dml, &expectation)
 }
 
 #[test]
 fn sqlite_does_not_allow_id_sort_argument() {
     let dml = indoc! {r#"
+        datasource db {
+          provider = "postgresql"
+          url      = env("DATABASE_URL")
+        }
+
         model A {
           id Int @id(sort: Desc)
         }
     "#};
 
-    let schema = with_header(dml, Provider::Postgres, &[]);
-    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
-
     let expectation = expect![[r#"
         [1;91merror[0m: [1mError parsing attribute "@id": The sort argument is not supported in the primary key with the current connector[0m
-          [1;94m-->[0m  [4mschema.prisma:12[0m
+          [1;94m-->[0m  [4mschema.prisma:7[0m
         [1;94m   | [0m
-        [1;94m11 | [0mmodel A {
-        [1;94m12 | [0m  id Int [1;91m@id(sort: Desc)[0m
+        [1;94m 6 | [0mmodel A {
+        [1;94m 7 | [0m  id Int [1;91m@id(sort: Desc)[0m
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(dml, &expectation)
 }
 
 #[test]
 fn mongodb_does_not_allow_id_sort_argument() {
     let dml = indoc! {r#"
+        datasource test {
+          provider = "mongodb"
+          url      = env("DATABASE_URL")
+        }
+
         model A {
           id String @id(sort: Desc) @map("_id") @test.ObjectId
         }
     "#};
 
-    let schema = with_header(dml, Provider::Mongo, &[]);
-    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
-
     let expectation = expect![[r#"
         [1;91merror[0m: [1mError parsing attribute "@id": The sort argument is not supported in the primary key with the current connector[0m
-          [1;94m-->[0m  [4mschema.prisma:12[0m
+          [1;94m-->[0m  [4mschema.prisma:7[0m
         [1;94m   | [0m
-        [1;94m11 | [0mmodel A {
-        [1;94m12 | [0m  id String [1;91m@id(sort: Desc)[0m @map("_id") @test.ObjectId
+        [1;94m 6 | [0mmodel A {
+        [1;94m 7 | [0m  id String [1;91m@id(sort: Desc)[0m @map("_id") @test.ObjectId
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(dml, &expectation)
 }
 
 #[test]
@@ -661,7 +644,6 @@ fn sqlite_does_not_allow_compound_id_sort_argument() {
     "#};
 
     let schema = with_header(dml, Provider::Sqlite, &[]);
-    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
 
     let expectation = expect![[r#"
         [1;91merror[0m: [1mError parsing attribute "@@id": The sort argument is not supported in the primary key with the current connector[0m
@@ -672,7 +654,7 @@ fn sqlite_does_not_allow_compound_id_sort_argument() {
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(&schema, &expectation)
 }
 
 #[test]
@@ -684,7 +666,6 @@ fn postgresql_does_not_allow_id_length_prefix() {
     "#};
 
     let schema = with_header(dml, Provider::Postgres, &[]);
-    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
 
     let expectation = expect![[r#"
         [1;91merror[0m: [1mError parsing attribute "@id": The length argument is not supported in the primary key with the current connector[0m
@@ -695,7 +676,7 @@ fn postgresql_does_not_allow_id_length_prefix() {
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(&schema, &expectation)
 }
 
 #[test]
@@ -710,7 +691,6 @@ fn postgresql_does_not_allow_compound_id_length_prefix() {
     "#};
 
     let schema = with_header(dml, Provider::Postgres, &[]);
-    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
 
     let expectation = expect![[r#"
         [1;91merror[0m: [1mError parsing attribute "@@id": The length argument is not supported in the primary key with the current connector[0m
@@ -721,7 +701,7 @@ fn postgresql_does_not_allow_compound_id_length_prefix() {
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(&schema, &expectation)
 }
 
 #[test]
@@ -733,7 +713,6 @@ fn sqlserver_does_not_allow_id_length_prefix() {
     "#};
 
     let schema = with_header(dml, Provider::SqlServer, &[]);
-    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
 
     let expectation = expect![[r#"
         [1;91merror[0m: [1mError parsing attribute "@id": The length argument is not supported in the primary key with the current connector[0m
@@ -744,7 +723,7 @@ fn sqlserver_does_not_allow_id_length_prefix() {
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(&schema, &expectation)
 }
 
 #[test]
@@ -759,7 +738,6 @@ fn sqlserver_does_not_allow_compound_id_length_prefix() {
     "#};
 
     let schema = with_header(dml, Provider::SqlServer, &[]);
-    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
 
     let expectation = expect![[r#"
         [1;91merror[0m: [1mError parsing attribute "@@id": The length argument is not supported in the primary key with the current connector[0m
@@ -770,7 +748,7 @@ fn sqlserver_does_not_allow_compound_id_length_prefix() {
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(&schema, &expectation)
 }
 
 #[test]
@@ -782,7 +760,6 @@ fn sqlite_does_not_allow_id_length_prefix() {
     "#};
 
     let schema = with_header(dml, Provider::Sqlite, &[]);
-    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
 
     let expectation = expect![[r#"
         [1;91merror[0m: [1mError parsing attribute "@id": The length argument is not supported in the primary key with the current connector[0m
@@ -793,7 +770,7 @@ fn sqlite_does_not_allow_id_length_prefix() {
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(&schema, &expectation)
 }
 
 #[test]
@@ -805,7 +782,6 @@ fn mongodb_does_not_allow_id_length_prefix() {
     "#};
 
     let schema = with_header(dml, Provider::Mongo, &[]);
-    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
 
     let expectation = expect![[r#"
         [1;91merror[0m: [1mError parsing attribute "@id": The length argument is not supported in the primary key with the current connector[0m
@@ -816,7 +792,7 @@ fn mongodb_does_not_allow_id_length_prefix() {
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(&schema, &expectation)
 }
 
 #[test]
@@ -831,7 +807,6 @@ fn sqlite_does_not_allow_compound_id_length_prefix() {
     "#};
 
     let schema = with_header(dml, Provider::Sqlite, &[]);
-    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
 
     let expectation = expect![[r#"
         [1;91merror[0m: [1mError parsing attribute "@@id": The length argument is not supported in the primary key with the current connector[0m
@@ -842,7 +817,7 @@ fn sqlite_does_not_allow_compound_id_length_prefix() {
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(&schema, &expectation)
 }
 
 #[test]
@@ -854,7 +829,6 @@ fn length_argument_does_not_work_with_decimal() {
     "#};
 
     let schema = with_header(dml, Provider::Mysql, &[]);
-    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
 
     let expectation = expect![[r#"
         [1;91merror[0m: [1mError parsing attribute "@id": The length argument is only allowed with field types `String` or `Bytes`.[0m
@@ -865,7 +839,7 @@ fn length_argument_does_not_work_with_decimal() {
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(&schema, &expectation)
 }
 
 #[test]
@@ -877,7 +851,6 @@ fn length_argument_does_not_work_with_json() {
     "#};
 
     let schema = with_header(dml, Provider::Mysql, &[]);
-    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
 
     let expectation = expect![[r#"
         [1;91merror[0m: [1mError parsing attribute "@id": The length argument is only allowed with field types `String` or `Bytes`.[0m
@@ -888,7 +861,7 @@ fn length_argument_does_not_work_with_json() {
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(&schema, &expectation)
 }
 
 #[test]
@@ -900,7 +873,6 @@ fn length_argument_does_not_work_with_datetime() {
     "#};
 
     let schema = with_header(dml, Provider::Mysql, &[]);
-    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
 
     let expectation = expect![[r#"
         [1;91merror[0m: [1mError parsing attribute "@id": The length argument is only allowed with field types `String` or `Bytes`.[0m
@@ -911,7 +883,7 @@ fn length_argument_does_not_work_with_datetime() {
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(&schema, &expectation)
 }
 
 #[test]
@@ -923,7 +895,6 @@ fn length_argument_does_not_work_with_boolean() {
     "#};
 
     let schema = with_header(dml, Provider::Mysql, &[]);
-    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
 
     let expectation = expect![[r#"
         [1;91merror[0m: [1mError parsing attribute "@id": The length argument is only allowed with field types `String` or `Bytes`.[0m
@@ -934,7 +905,7 @@ fn length_argument_does_not_work_with_boolean() {
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(&schema, &expectation)
 }
 
 #[test]
@@ -946,7 +917,6 @@ fn length_argument_does_not_work_with_float() {
     "#};
 
     let schema = with_header(dml, Provider::Mysql, &[]);
-    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
 
     let expectation = expect![[r#"
         [1;91merror[0m: [1mError parsing attribute "@id": The length argument is only allowed with field types `String` or `Bytes`.[0m
@@ -957,7 +927,7 @@ fn length_argument_does_not_work_with_float() {
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(&schema, &expectation)
 }
 
 #[test]
@@ -969,7 +939,6 @@ fn length_argument_does_not_work_with_bigint() {
     "#};
 
     let schema = with_header(dml, Provider::Mysql, &[]);
-    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
 
     let expectation = expect![[r#"
         [1;91merror[0m: [1mError parsing attribute "@id": The length argument is only allowed with field types `String` or `Bytes`.[0m
@@ -980,7 +949,7 @@ fn length_argument_does_not_work_with_bigint() {
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(&schema, &expectation)
 }
 
 #[test]
@@ -992,7 +961,6 @@ fn length_argument_does_not_work_with_int() {
     "#};
 
     let schema = with_header(dml, Provider::Mysql, &[]);
-    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
 
     let expectation = expect![[r#"
         [1;91merror[0m: [1mError parsing attribute "@id": The length argument is only allowed with field types `String` or `Bytes`.[0m
@@ -1003,7 +971,7 @@ fn length_argument_does_not_work_with_int() {
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(&schema, &expectation)
 }
 
 #[test]
@@ -1035,38 +1003,44 @@ fn empty_fields_must_error() {
         [1;94m   | [0m
     "#]];
 
-    let error = datamodel::parse_schema(schema).map(drop).unwrap_err();
-    expected.assert_eq(&error);
+    expect_error(schema, &expected)
 }
 
 #[test]
 fn mongodb_must_be_id_if_using_auto() {
     let schema = indoc! {r#"
+        datasource test {
+          provider = "mongodb"
+          url      = env("DATABASE_URL")
+        }
+
         model A {
           og Int    @id @map("_id")
           id String @default(auto()) @test.ObjectId
         }
     "#};
 
-    let dml = with_header(schema, Provider::Mongo, &[]);
-    let error = datamodel::parse_schema(&dml).map(drop).unwrap_err();
-
     let expected = expect![[r#"
         [1;91merror[0m: [1mError validating field `id` in model `A`: MongoDB `@default(auto())` fields must have the `@id` attribute.[0m
-          [1;94m-->[0m  [4mschema.prisma:13[0m
+          [1;94m-->[0m  [4mschema.prisma:8[0m
         [1;94m   | [0m
-        [1;94m12 | [0m  og Int    @id @map("_id")
-        [1;94m13 | [0m  [1;91mid String @default(auto()) @test.ObjectId[0m
-        [1;94m14 | [0m}
+        [1;94m 7 | [0m  og Int    @id @map("_id")
+        [1;94m 8 | [0m  [1;91mid String @default(auto()) @test.ObjectId[0m
+        [1;94m 9 | [0m}
         [1;94m   | [0m
     "#]];
 
-    expected.assert_eq(&error);
+    expect_error(schema, &expected)
 }
 
 #[test]
 fn compound_ids_are_not_allowed_on_mongo() {
     let schema = indoc! {r#"
+        datasource test {
+          provider = "mongodb"
+          url      = env("DATABASE_URL")
+        }
+
         model A {
           id  String @map("_id") @default(auto()) @test.ObjectId
           id2 String @default(auto()) @test.ObjectId
@@ -1075,47 +1049,51 @@ fn compound_ids_are_not_allowed_on_mongo() {
         }
     "#};
 
-    let dml = with_header(schema, Provider::Mongo, &[]);
-    let error = datamodel::parse_schema(&dml).map(drop).unwrap_err();
-
     let expected = expect![[r#"
         [1;91merror[0m: [1mError validating model "A": The current connector does not support compound ids.[0m
-          [1;94m-->[0m  [4mschema.prisma:15[0m
+          [1;94m-->[0m  [4mschema.prisma:10[0m
         [1;94m   | [0m
-        [1;94m14 | [0m
-        [1;94m15 | [0m  [1;91m@@id([id, id2])[0m
+        [1;94m 9 | [0m
+        [1;94m10 | [0m  [1;91m@@id([id, id2])[0m
         [1;94m   | [0m
     "#]];
 
-    expected.assert_eq(&error);
+    expect_error(schema, &expected)
 }
 
 #[test]
 fn mongodb_no_unique_index_for_id() {
     let schema = indoc! {r#"
+        datasource test {
+          provider = "mongodb"
+          url      = env("DATABASE_URL")
+        }
+
         model User {
           id String @unique @id @map("_id") @test.ObjectId
         }
     "#};
 
-    let dml = with_header(schema, Provider::Mongo, &[]);
-    let error = datamodel::parse_schema(&dml).map(drop).unwrap_err();
-
     let expected = expect![[r#"
         [1;91merror[0m: [1mError parsing attribute "@unique": The same field cannot be an id and unique on MongoDB.[0m
-          [1;94m-->[0m  [4mschema.prisma:12[0m
+          [1;94m-->[0m  [4mschema.prisma:7[0m
         [1;94m   | [0m
-        [1;94m11 | [0mmodel User {
-        [1;94m12 | [0m  id String [1;91m@unique [0m@id @map("_id") @test.ObjectId
+        [1;94m 6 | [0mmodel User {
+        [1;94m 7 | [0m  id String [1;91m@unique [0m@id @map("_id") @test.ObjectId
         [1;94m   | [0m
     "#]];
 
-    expected.assert_eq(&error);
+    expect_error(schema, &expected)
 }
 
 #[test]
 fn mongodb_no_unique_index_for_id_model_attribute() {
     let schema = indoc! {r#"
+        datasource test {
+          provider = "mongodb"
+          url      = env("DATABASE_URL")
+        }
+
         model User {
           id String @id @map("_id") @test.ObjectId
 
@@ -1123,17 +1101,14 @@ fn mongodb_no_unique_index_for_id_model_attribute() {
         }
     "#};
 
-    let dml = with_header(schema, Provider::Mongo, &[]);
-    let error = datamodel::parse_schema(&dml).map(drop).unwrap_err();
-
     let expected = expect![[r#"
         [1;91merror[0m: [1mError parsing attribute "@@unique": The same field cannot be an id and unique on MongoDB.[0m
-          [1;94m-->[0m  [4mschema.prisma:14[0m
+          [1;94m-->[0m  [4mschema.prisma:9[0m
         [1;94m   | [0m
-        [1;94m13 | [0m
-        [1;94m14 | [0m  [1;91m@@unique([id])[0m
+        [1;94m 8 | [0m
+        [1;94m 9 | [0m  [1;91m@@unique([id])[0m
         [1;94m   | [0m
     "#]];
 
-    expected.assert_eq(&error);
+    expect_error(schema, &expected)
 }

--- a/libs/datamodel/core/tests/attributes/postgres_indices/brin.rs
+++ b/libs/datamodel/core/tests/attributes/postgres_indices/brin.rs
@@ -3,6 +3,11 @@ use crate::{common::*, with_header, Provider};
 #[test]
 fn on_mysql() {
     let dml = indoc! {r#"
+        datasource db {
+          provider = "mysql"
+          url      = env("DATABASE_URL")
+        }
+
         model A {
           id Int  @id
           a  Int
@@ -11,19 +16,16 @@ fn on_mysql() {
         }
     "#};
 
-    let schema = with_header(dml, Provider::Mysql, &[]);
-    let error = datamodel::parse_schema(&schema).map(drop).unwrap_err();
-
     let expectation = expect![[r#"
         [1;91merror[0m: [1mError parsing attribute "@@index": The given index type is not supported with the current connector[0m
-          [1;94m-->[0m  [4mschema.prisma:15[0m
+          [1;94m-->[0m  [4mschema.prisma:10[0m
         [1;94m   | [0m
-        [1;94m14 | [0m
-        [1;94m15 | [0m  @@index([a(ops: raw("whatever_ops"))], [1;91mtype: Brin[0m)
+        [1;94m 9 | [0m
+        [1;94m10 | [0m  @@index([a(ops: raw("whatever_ops"))], [1;91mtype: Brin[0m)
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(dml, &expectation);
 }
 
 #[test]

--- a/libs/datamodel/core/tests/attributes/relations/relations_new.rs
+++ b/libs/datamodel/core/tests/attributes/relations/relations_new.rs
@@ -60,7 +60,7 @@ fn relation_must_error_when_base_field_does_not_exist() {
         [1;94m   | [0m
     "#]];
 
-    expect.assert_eq(&datamodel::parse_schema(dml).map(drop).unwrap_err());
+    expect_error(dml, &expect)
 }
 
 #[test]
@@ -97,7 +97,7 @@ fn relation_must_error_when_base_field_is_not_scalar() {
         [1;94m   | [0m
     "#]];
 
-    expect.assert_eq(&datamodel::parse_schema(dml).map(drop).unwrap_err());
+    expect_error(dml, &expect)
 }
 
 #[test]
@@ -158,7 +158,7 @@ fn required_relation_field_must_error_when_one_underlying_field_is_optional() {
         [1;94m   | [0m
     "#]];
 
-    expect.assert_eq(&datamodel::parse_schema(dml).map(drop).unwrap_err());
+    expect_error(dml, &expect)
 }
 
 #[test]
@@ -219,7 +219,7 @@ fn required_relation_field_must_error_when_all_underlying_fields_are_optional() 
         [1;94m   | [0m
     "#]];
 
-    expect.assert_eq(&datamodel::parse_schema(dml).map(drop).unwrap_err());
+    expect_error(dml, &expect)
 }
 
 #[test]
@@ -247,7 +247,7 @@ fn required_relation_field_must_error_if_it_is_virtual() {
         [1;94m   | [0m
     "#]];
 
-    expect.assert_eq(&datamodel::parse_schema(dml).map(drop).unwrap_err());
+    expect_error(dml, &expect)
 }
 
 #[test]
@@ -276,7 +276,7 @@ fn relation_must_error_when_referenced_field_does_not_exist() {
         [1;94m   | [0m
     "#]];
 
-    expect.assert_eq(&datamodel::parse_schema(dml).map(drop).unwrap_err());
+    expect_error(dml, &expect)
 }
 
 #[test]
@@ -305,7 +305,7 @@ fn relation_must_error_when_referenced_field_is_not_scalar() {
         [1;94m   | [0m
     "#]];
 
-    expect.assert_eq(&datamodel::parse_schema(dml).map(drop).unwrap_err());
+    expect_error(dml, &expect)
 }
 
 #[test]
@@ -335,7 +335,7 @@ fn relation_must_error_when_referenced_fields_are_not_a_unique_criteria() {
         [1;94m   | [0m
     "#]];
 
-    expect.assert_eq(&datamodel::parse_schema(dml).map(drop).unwrap_err());
+    expect_error(dml, &expect)
 }
 
 #[test]
@@ -367,7 +367,7 @@ fn relation_must_error_when_referenced_compound_fields_are_not_a_unique_criteria
         [1;94m   | [0m
     "#]];
 
-    expect.assert_eq(&datamodel::parse_schema(dml).map(drop).unwrap_err());
+    expect_error(dml, &expect)
 }
 
 #[test]
@@ -421,7 +421,7 @@ fn relation_must_error_when_referenced_fields_are_multiple_uniques() {
         [1;94m   | [0m
     "#]];
 
-    expect.assert_eq(&datamodel::parse_schema(dml).map(drop).unwrap_err());
+    expect_error(dml, &expect)
 }
 
 #[test]
@@ -450,7 +450,7 @@ fn relation_must_error_when_types_of_base_field_and_referenced_field_do_not_matc
         [1;94m   | [0m
     "#]];
 
-    expect.assert_eq(&datamodel::parse_schema(dml).map(drop).unwrap_err());
+    expect_error(dml, &expect)
 }
 
 #[test]
@@ -479,7 +479,7 @@ fn relation_must_error_when_number_of_fields_and_references_is_not_equal() {
         [1;94m   | [0m
     "#]];
 
-    expect.assert_eq(&datamodel::parse_schema(dml).map(drop).unwrap_err());
+    expect_error(dml, &expect)
 }
 
 #[test]
@@ -508,7 +508,7 @@ fn must_error_when_references_argument_is_missing_for_one_to_many() {
         [1;94m   | [0m
     "#]];
 
-    expect.assert_eq(&datamodel::parse_schema(dml).map(drop).unwrap_err());
+    expect_error(dml, &expect)
 }
 
 #[test]
@@ -542,7 +542,7 @@ fn must_error_fields_or_references_argument_is_placed_on_wrong_side_for_one_to_m
         [1;94m   | [0m
     "#]];
 
-    expect.assert_eq(&datamodel::parse_schema(dml).map(drop).unwrap_err());
+    expect_error(dml, &expect)
 }
 
 #[test]
@@ -578,7 +578,7 @@ fn must_error_when_both_arguments_are_missing_for_one_to_many() {
         [1;94m   | [0m
     "#]];
 
-    expect.assert_eq(&datamodel::parse_schema(dml).map(drop).unwrap_err());
+    expect_error(dml, &expect)
 }
 
 #[test]
@@ -614,7 +614,7 @@ fn must_error_when_fields_argument_is_missing_for_one_to_one() {
         [1;94m   | [0m
     "#]];
 
-    expect.assert_eq(&datamodel::parse_schema(dml).map(drop).unwrap_err());
+    expect_error(dml, &expect)
 }
 
 #[test]
@@ -650,7 +650,7 @@ fn must_error_when_references_argument_is_missing_for_one_to_one() {
         [1;94m   | [0m
     "#]];
 
-    expect.assert_eq(&datamodel::parse_schema(dml).map(drop).unwrap_err());
+    expect_error(dml, &expect)
 }
 
 #[test]
@@ -687,7 +687,7 @@ fn must_error_when_fields_and_references_argument_are_placed_on_different_sides_
         [1;94m   | [0m
     "#]];
 
-    expect.assert_eq(&datamodel::parse_schema(dml).map(drop).unwrap_err());
+    expect_error(dml, &expect)
 }
 
 #[test]
@@ -738,7 +738,7 @@ fn must_error_when_fields_or_references_argument_is_placed_on_both_sides_for_one
         [1;94m   | [0m
     "#]];
 
-    expect.assert_eq(&datamodel::parse_schema(dml).map(drop).unwrap_err());
+    expect_error(dml, &expect)
 }
 
 #[test]
@@ -762,7 +762,7 @@ fn must_error_for_required_one_to_one_self_relations() {
         [1;94m   | [0m
     "#]];
 
-    expect.assert_eq(&datamodel::parse_schema(dml).map(drop).unwrap_err());
+    expect_error(dml, &expect)
 }
 
 #[test]
@@ -792,7 +792,7 @@ fn must_error_nicely_when_a_many_to_many_is_not_possible() {
         [1;94m   | [0m
     "#]];
 
-    expect.assert_eq(&datamodel::parse_schema(dml).map(drop).unwrap_err());
+    expect_error(dml, &expect)
 }
 
 #[test]
@@ -820,7 +820,7 @@ fn must_error_when_many_to_many_is_not_possible_due_to_missing_id() {
         [1;94m   | [0m
     "#]];
 
-    expect.assert_eq(&datamodel::parse_schema(dml).map(drop).unwrap_err());
+    expect_error(dml, &expect)
 }
 
 #[test]
@@ -897,7 +897,7 @@ fn must_allow_relations_with_default_native_types_with_annotation_on_one_side() 
 
 #[test]
 fn a_one_on_one_relation_with_fields_on_the_wrong_side_should_not_pass() {
-    let schema = r#"
+    let dml = r#"
 datasource db {
   provider = "postgresql"
   url      = env("TEST_DATABASE_URL")
@@ -926,5 +926,5 @@ model Bam {
         [1;94m   | [0m
     "#]];
 
-    expect.assert_eq(&datamodel::parse_schema(schema).map(drop).unwrap_err());
+    expect_error(dml, &expect)
 }

--- a/libs/datamodel/core/tests/capabilities/cockroachdb.rs
+++ b/libs/datamodel/core/tests/capabilities/cockroachdb.rs
@@ -20,7 +20,7 @@ fn enum_support() {
         }
     "#};
 
-    assert!(datamodel::parse_schema(dml).is_ok());
+    assert_valid(dml)
 }
 
 #[test]
@@ -37,7 +37,7 @@ fn scalar_list_support() {
         }
     "#};
 
-    assert!(datamodel::parse_schema(dml).is_ok());
+    assert_valid(dml)
 }
 
 #[test]
@@ -54,7 +54,7 @@ fn json_support() {
         }
     "#};
 
-    assert!(datamodel::parse_schema(dml).is_ok());
+    assert_valid(dml)
 }
 
 #[test]
@@ -107,7 +107,7 @@ fn auto_increment_on_non_primary_column_support() {
         }
     "#};
 
-    assert!(datamodel::parse_schema(dml).is_ok());
+    assert_valid(dml)
 }
 
 #[test]
@@ -135,7 +135,7 @@ fn key_order_enforcement_support() {
         }
     "#};
 
-    assert!(datamodel::parse_schema(dml).is_ok());
+    assert_valid(dml)
 }
 
 #[test]

--- a/libs/datamodel/core/tests/capabilities/mysql.rs
+++ b/libs/datamodel/core/tests/capabilities/mysql.rs
@@ -20,7 +20,7 @@ fn enum_support() {
         }
     "#};
 
-    assert!(datamodel::parse_schema(dml).is_ok());
+    assert_valid(dml)
 }
 
 #[test]
@@ -75,7 +75,7 @@ fn unique_index_names_support() {
         }
     "#};
 
-    assert!(datamodel::parse_schema(dml).is_ok());
+    assert_valid(dml)
 }
 
 #[test]
@@ -92,7 +92,7 @@ fn json_support() {
         }
     "#};
 
-    assert!(datamodel::parse_schema(dml).is_ok());
+    assert_valid(dml)
 }
 
 #[test]
@@ -109,7 +109,7 @@ fn auto_increment_on_non_primary_column_support() {
         }
     "#};
 
-    assert!(datamodel::parse_schema(dml).is_ok());
+    assert_valid(dml)
 }
 
 #[test]
@@ -137,7 +137,7 @@ fn key_order_enforcement_support() {
         }
     "#};
 
-    assert!(datamodel::parse_schema(dml).is_ok());
+    assert_valid(dml)
 }
 
 #[test]

--- a/libs/datamodel/core/tests/parsing/attributes.rs
+++ b/libs/datamodel/core/tests/parsing/attributes.rs
@@ -1,5 +1,4 @@
-use datamodel::parse_schema;
-use expect_test::expect;
+use crate::common::*;
 
 #[test]
 fn empty_arguments_are_rejected_with_nice_error() {
@@ -25,7 +24,7 @@ fn empty_arguments_are_rejected_with_nice_error() {
         [1;94m   | [0m
     "#]];
 
-    expected.assert_eq(&parse_schema(schema).map(|_| ()).unwrap_err());
+    expect_error(schema, &expected)
 }
 
 #[test]
@@ -47,7 +46,7 @@ fn empty_model_attribute_arguments_are_rejected_with_nice_error() {
         [1;94m   | [0m
     "#]];
 
-    expected.assert_eq(&parse_schema(schema).map(|_| ()).unwrap_err());
+    expect_error(schema, &expected)
 }
 
 #[test]
@@ -71,7 +70,7 @@ fn empty_enum_attribute_arguments_are_rejected_with_nice_error() {
         [1;94m   | [0m
     "#]];
 
-    expected.assert_eq(&parse_schema(schema).map(|_| ()).unwrap_err());
+    expect_error(schema, &expected)
 }
 
 #[test]
@@ -95,7 +94,7 @@ fn trailing_commas_without_space_are_rejected_with_nice_error() {
         [1;94m   | [0m
     "#]];
 
-    expected.assert_eq(&parse_schema(schema).map(|_| ()).unwrap_err());
+    expect_error(schema, &expected)
 }
 
 #[test]
@@ -119,5 +118,5 @@ fn trailing_commas_with_space_are_rejected_with_nice_error() {
         [1;94m   | [0m
     "#]];
 
-    expected.assert_eq(&parse_schema(schema).map(|_| ()).unwrap_err());
+    expect_error(schema, &expected)
 }

--- a/libs/datamodel/core/tests/parsing/nice_errors.rs
+++ b/libs/datamodel/core/tests/parsing/nice_errors.rs
@@ -8,8 +8,6 @@ fn nice_error_for_missing_model_keyword() {
         }
     "#};
 
-    let error = datamodel::parse_schema(dml).map(drop).unwrap_err();
-
     let expectation = expect![[r#"
         [1;91merror[0m: [1mError validating: This block is invalid. It does not start with any known Prisma schema keyword. Valid keywords include 'model', 'enum', 'datasource' and 'generator'.[0m
           [1;94m-->[0m  [4mschema.prisma:1[0m
@@ -21,7 +19,7 @@ fn nice_error_for_missing_model_keyword() {
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(dml, &expectation)
 }
 
 #[test]
@@ -36,8 +34,6 @@ fn nice_error_for_missing_model_keyword_2() {
         }
     "#};
 
-    let error = datamodel::parse_schema(dml).map(drop).unwrap_err();
-
     let expectation = expect![[r#"
         [1;91merror[0m: [1mError validating: This block is invalid. It does not start with any known Prisma schema keyword. Valid keywords include 'model', 'enum', 'datasource' and 'generator'.[0m
           [1;94m-->[0m  [4mschema.prisma:5[0m
@@ -49,7 +45,7 @@ fn nice_error_for_missing_model_keyword_2() {
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(dml, &expectation)
 }
 
 #[test]
@@ -61,8 +57,6 @@ fn nice_error_on_incorrect_enum_field() {
         }
     "#};
 
-    let error = datamodel::parse_schema(dml).map(drop).unwrap_err();
-
     let expectation = expect![[r#"
         [1;91merror[0m: [1mError validating: The character `-` is not allowed in Enum Value names.[0m
           [1;94m-->[0m  [4mschema.prisma:2[0m
@@ -72,7 +66,7 @@ fn nice_error_on_incorrect_enum_field() {
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(dml, &expectation)
 }
 
 #[test]
@@ -84,8 +78,6 @@ fn nice_error_missing_type() {
         }
     "#};
 
-    let error = datamodel::parse_schema(dml).map(drop).unwrap_err();
-
     let expectation = expect![[r#"
         [1;91merror[0m: [1mError validating model "User": This field declaration is invalid. It is either missing a name or a type.[0m
           [1;94m-->[0m  [4mschema.prisma:3[0m
@@ -96,7 +88,7 @@ fn nice_error_missing_type() {
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(dml, &expectation)
 }
 
 #[test]
@@ -106,8 +98,6 @@ fn nice_error_missing_attribute_name() {
           id Int @id @
         }
     "#};
-
-    let error = datamodel::parse_schema(dml).map(drop).unwrap_err();
 
     let expectation = expect![[r#"
         [1;91merror[0m: [1mError validating: This line is not a valid field or attribute definition.[0m
@@ -119,7 +109,7 @@ fn nice_error_missing_attribute_name() {
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(dml, &expectation)
 }
 
 #[test]
@@ -128,8 +118,6 @@ fn nice_error_missing_braces() {
         model User
           id Int @id
     "#};
-
-    let error = datamodel::parse_schema(dml).map(drop).unwrap_err();
 
     let expectation = expect![[r#"
         [1;91merror[0m: [1mError validating: This line is invalid. It does not start with any known Prisma schema keyword.[0m
@@ -148,7 +136,7 @@ fn nice_error_missing_braces() {
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(dml, &expectation)
 }
 
 #[test]
@@ -159,8 +147,6 @@ fn nice_error_broken_field_type_legacy_list() {
         }
     "#};
 
-    let error = datamodel::parse_schema(dml).map(drop).unwrap_err();
-
     let expectation = expect![[r#"
         [1;91merror[0m: [1mTo specify a list, please use `Type[]` instead of `[Type]`.[0m
           [1;94m-->[0m  [4mschema.prisma:2[0m
@@ -170,7 +156,7 @@ fn nice_error_broken_field_type_legacy_list() {
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(dml, &expectation)
 }
 
 #[test]
@@ -181,8 +167,6 @@ fn nice_error_broken_field_type_legacy_colon() {
         }
     "#};
 
-    let error = datamodel::parse_schema(dml).map(drop).unwrap_err();
-
     let expectation = expect![[r#"
         [1;91merror[0m: [1mField declarations don't require a `:`.[0m
           [1;94m-->[0m  [4mschema.prisma:2[0m
@@ -192,7 +176,7 @@ fn nice_error_broken_field_type_legacy_colon() {
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(dml, &expectation)
 }
 
 #[test]
@@ -203,8 +187,6 @@ fn nice_error_broken_field_type_legacy_required() {
         }
     "#};
 
-    let error = datamodel::parse_schema(dml).map(drop).unwrap_err();
-
     let expectation = expect![[r#"
         [1;91merror[0m: [1mFields are required by default, `!` is no longer required.[0m
           [1;94m-->[0m  [4mschema.prisma:2[0m
@@ -214,7 +196,7 @@ fn nice_error_broken_field_type_legacy_required() {
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(dml, &expectation)
 }
 
 #[test]
@@ -226,8 +208,6 @@ fn nice_error_in_case_of_literal_type_in_env_var() {
         }
     "#};
 
-    let error = datamodel::parse_schema(source).map(drop).unwrap_err();
-
     let expectation = expect![[r#"
         [1;91merror[0m: [1mExpected a String value, but received literal value `DATABASE_URL`.[0m
           [1;94m-->[0m  [4mschema.prisma:3[0m
@@ -237,7 +217,7 @@ fn nice_error_in_case_of_literal_type_in_env_var() {
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(source, &expectation)
 }
 
 #[test]
@@ -249,8 +229,6 @@ fn nice_error_in_case_of_bool_type_in_env_var() {
         }
     "#};
 
-    let error = datamodel::parse_schema(source).map(drop).unwrap_err();
-
     let expectation = expect![[r#"
         [1;91merror[0m: [1mExpected a String value, but received literal value `true`.[0m
           [1;94m-->[0m  [4mschema.prisma:3[0m
@@ -260,7 +238,7 @@ fn nice_error_in_case_of_bool_type_in_env_var() {
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(source, &expectation)
 }
 
 #[test]
@@ -272,8 +250,6 @@ fn nice_error_in_case_of_numeric_type_in_env_var() {
         }
     "#};
 
-    let error = datamodel::parse_schema(source).map(drop).unwrap_err();
-
     let expectation = expect![[r#"
         [1;91merror[0m: [1mExpected a String value, but received numeric value `4`.[0m
           [1;94m-->[0m  [4mschema.prisma:3[0m
@@ -283,7 +259,7 @@ fn nice_error_in_case_of_numeric_type_in_env_var() {
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(source, &expectation)
 }
 
 #[test]
@@ -295,8 +271,6 @@ fn nice_error_in_case_of_array_type_in_env_var() {
         }
     "#};
 
-    let error = datamodel::parse_schema(source).map(drop).unwrap_err();
-
     let expectation = expect![[r#"
         [1;91merror[0m: [1mExpected a String value, but received array value `[DATABASE_URL]`.[0m
           [1;94m-->[0m  [4mschema.prisma:3[0m
@@ -306,7 +280,7 @@ fn nice_error_in_case_of_array_type_in_env_var() {
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(source, &expectation)
 }
 
 #[test]
@@ -318,8 +292,6 @@ fn optional_list_fields_must_error() {
         }
     "#};
 
-    let error = datamodel::parse_schema(dml).map(drop).unwrap_err();
-
     let expectation = expect![[r#"
         [1;91merror[0m: [1mOptional lists are not supported. Use either `Type[]` or `Type?`.[0m
           [1;94m-->[0m  [4mschema.prisma:3[0m
@@ -329,7 +301,7 @@ fn optional_list_fields_must_error() {
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(dml, &expectation)
 }
 
 #[test]
@@ -346,8 +318,6 @@ fn invalid_lines_at_the_top_level_must_render_nicely() {
         model Bl
     "#};
 
-    let error = datamodel::parse_schema(dml).map(drop).unwrap_err();
-
     let expectation = expect![[r#"
         [1;91merror[0m: [1mError validating: This line is invalid. It does not start with any known Prisma schema keyword.[0m
           [1;94m-->[0m  [4mschema.prisma:6[0m
@@ -358,7 +328,7 @@ fn invalid_lines_at_the_top_level_must_render_nicely() {
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(dml, &expectation)
 }
 
 #[test]
@@ -371,8 +341,6 @@ fn invalid_lines_in_datasources_must_render_nicely() {
         }
     "#};
 
-    let error = datamodel::parse_schema(dml).map(drop).unwrap_err();
-
     let expectation = expect![[r#"
         [1;91merror[0m: [1mError validating: This line is not a valid definition within a datasource.[0m
           [1;94m-->[0m  [4mschema.prisma:4[0m
@@ -383,7 +351,7 @@ fn invalid_lines_in_datasources_must_render_nicely() {
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(dml, &expectation)
 }
 
 #[test]
@@ -395,8 +363,6 @@ fn invalid_lines_in_generators_must_render_nicely() {
         }
     "#};
 
-    let error = datamodel::parse_schema(dml).map(drop).unwrap_err();
-
     let expectation = expect![[r#"
         [1;91merror[0m: [1mError validating: This line is not a valid definition within a generator.[0m
           [1;94m-->[0m  [4mschema.prisma:3[0m
@@ -407,7 +373,7 @@ fn invalid_lines_in_generators_must_render_nicely() {
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(dml, &expectation)
 }
 
 #[test]
@@ -422,8 +388,6 @@ fn invalid_field_line_must_error_nicely() {
         }
     "#};
 
-    let error = datamodel::parse_schema(dml).map(drop).unwrap_err();
-
     let expectation = expect![[r#"
         [1;91merror[0m: [1mError validating: This line is not a valid field or attribute definition.[0m
           [1;94m-->[0m  [4mschema.prisma:3[0m
@@ -434,5 +398,5 @@ fn invalid_field_line_must_error_nicely() {
         [1;94m   | [0m
     "#]];
 
-    expectation.assert_eq(&error)
+    expect_error(dml, &expectation)
 }


### PR DESCRIPTION
The big difficulty is that the tests are not consistent in how they use
the datamodel API and how they are set up, so it is going to be a lot of
manual work. We have convenient test helpers in `common` that we can use
as a level of indirection, so this PR makes more tests use them.

There is still a long road ahead.

Eventually, we want to eliminate accidental complexity like variable
names and the choice of how you get and render datamodel errors from
datamodel tests. Something like the new introspection engine simple test
setup would make the most sense.