### PR TITLE
set and return tracing links

### DIFF
--- a/query-engine/core/src/interactive_transactions/actors.rs
+++ b/query-engine/core/src/interactive_transactions/actors.rs
@@ -1,5 +1,8 @@
 use super::{CachedTx, TransactionError, TxOpRequest, TxOpRequestMsg, TxOpResponse};
-use crate::{execute_many_operations, execute_single_operation, OpenTx, Operation, ResponseData, TxId};
+use crate::{
+    execute_many_operations, execute_single_operation, set_span_link_from_trace_id, OpenTx, Operation, ResponseData,
+    TxId,
+};
 use schema::QuerySchemaRef;
 use std::{collections::HashMap, sync::Arc};
 use tokio::{
@@ -73,6 +76,7 @@ impl ITXServer {
 
     async fn execute_single(&mut self, operation: &Operation, trace_id: Option<String>) -> crate::Result<ResponseData> {
         let span = info_span!("prisma:itx_query_builder", user_facing = true);
+        set_span_link_from_trace_id(&span, trace_id.clone());
 
         let conn = self.cached_tx.as_open()?;
         execute_single_operation(

--- a/query-engine/query-engine-node-api/src/engine.rs
+++ b/query-engine/query-engine-node-api/src/engine.rs
@@ -292,13 +292,13 @@ impl QueryEngine {
             let dispatcher = self.logger.dispatcher();
 
             async move {
-                let (span, trace_id) = if tx_id.is_none() {
-                    let span = tracing::info_span!("prisma:query_builder", user_facing = true);
-                    let trace_id = set_parent_context_from_json_str(&span, trace);
-                    (span, trace_id)
+                let span = if tx_id.is_none() {
+                    tracing::info_span!("prisma:query_builder", user_facing = true)
                 } else {
-                    (Span::none(), None)
+                    Span::none()
                 };
+
+                let trace_id = set_parent_context_from_json_str(&span, trace);
 
                 let handler = GraphQlHandler::new(engine.executor(), engine.query_schema());
                 let response = handler


### PR DESCRIPTION
Adds a link to `prisma:itx_query_builder` so that we can link it back to the client request. 
Also pass links back to the client. 