### PR TITLE
refactor(me/sqlite): remove one level of error transformation for better error messages

### DIFF
--- a/introspection-engine/connectors/sql-introspection-connector/src/schema_describer_loading.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/schema_describer_loading.rs
@@ -3,7 +3,7 @@ use quaint::prelude::{ConnectionInfo, Queryable, SqlFamily};
 use sql_schema_describer::{postgres::Circumstances, SqlSchemaDescriberBackend};
 
 pub async fn load_describer<'a>(
-    connection: &'a dyn Queryable,
+    connection: &'a quaint::single::Quaint,
     connection_info: &ConnectionInfo,
     provider: Option<&str>,
 ) -> Result<Box<dyn SqlSchemaDescriberBackend + 'a>, crate::SqlError> {

--- a/libs/datamodel/core/tests/attributes/id_negative.rs
+++ b/libs/datamodel/core/tests/attributes/id_negative.rs
@@ -218,7 +218,7 @@ fn invalid_name_for_compound_id_must_error() {
         [1;94m   | [0m
     "#]];
 
-    expect_error(&dml, &expectation)
+    expect_error(dml, &expectation)
 }
 
 #[test]
@@ -343,7 +343,7 @@ fn naming_id_to_a_field_name_should_error() {
         [1;94m   | [0m
     "#]];
 
-    expect_error(&dml, &expectation)
+    expect_error(dml, &expectation)
 }
 
 #[test]

--- a/libs/sql-schema-describer/Cargo.toml
+++ b/libs/sql-schema-describer/Cargo.toml
@@ -24,6 +24,7 @@ tracing-futures = "0.2"
 [dependencies.quaint]
 git = "https://github.com/prisma/quaint"
 features = [
+    "expose-drivers",
     "chrono",
     "sqlite",
     "postgresql",

--- a/libs/sql-schema-describer/src/sqlite.rs
+++ b/libs/sql-schema-describer/src/sqlite.rs
@@ -8,13 +8,54 @@ use crate::{
 use indexmap::IndexMap;
 use quaint::{
     ast::Value,
-    prelude::{Queryable, ResultRow},
+    connector::{GetRow, ToColumnNames},
+    prelude::ResultRow,
 };
 use std::{any::type_name, borrow::Cow, collections::BTreeMap, convert::TryInto, fmt::Debug, path::Path};
 use tracing::trace;
 
+#[async_trait::async_trait]
+pub trait Connection {
+    async fn query_raw<'a>(
+        &'a self,
+        sql: &'a str,
+        params: &'a [quaint::prelude::Value<'a>],
+    ) -> quaint::Result<quaint::prelude::ResultSet>;
+}
+
+#[async_trait::async_trait]
+impl Connection for std::sync::Mutex<quaint::connector::rusqlite::Connection> {
+    async fn query_raw<'a>(
+        &'a self,
+        sql: &'a str,
+        params: &'a [quaint::prelude::Value<'a>],
+    ) -> quaint::Result<quaint::prelude::ResultSet> {
+        let conn = self.lock().unwrap();
+        let mut stmt = conn.prepare_cached(sql)?;
+        let mut rows = stmt.query(quaint::connector::rusqlite::params_from_iter(params.iter()))?;
+        let column_names = rows.to_column_names();
+        let mut converted_rows = Vec::new();
+        while let Some(row) = rows.next()? {
+            converted_rows.push(row.get_result_row().unwrap());
+        }
+
+        Ok(quaint::prelude::ResultSet::new(column_names, converted_rows))
+    }
+}
+
+#[async_trait::async_trait]
+impl Connection for quaint::single::Quaint {
+    async fn query_raw<'a>(
+        &'a self,
+        sql: &'a str,
+        params: &'a [quaint::prelude::Value<'a>],
+    ) -> quaint::Result<quaint::prelude::ResultSet> {
+        quaint::prelude::Queryable::query_raw(self, sql, params).await
+    }
+}
+
 pub struct SqlSchemaDescriber<'a> {
-    conn: &'a dyn Queryable,
+    conn: &'a (dyn Connection + Send + Sync),
 }
 
 impl Debug for SqlSchemaDescriber<'_> {
@@ -41,6 +82,23 @@ impl SqlSchemaDescriberBackend for SqlSchemaDescriber<'_> {
     }
 
     async fn describe(&self, _schema: &str) -> DescriberResult<SqlSchema> {
+        self.describe_impl().await
+    }
+
+    async fn version(&self, _schema: &str) -> DescriberResult<Option<String>> {
+        Ok(Some(quaint::connector::sqlite_version().to_owned()))
+    }
+}
+
+impl Parser for SqlSchemaDescriber<'_> {}
+
+impl<'a> SqlSchemaDescriber<'a> {
+    /// Constructor.
+    pub fn new(conn: &'a (dyn Connection + Send + Sync)) -> SqlSchemaDescriber<'a> {
+        SqlSchemaDescriber { conn }
+    }
+
+    pub async fn describe_impl(&self) -> DescriberResult<SqlSchema> {
         let mut schema = SqlSchema::default();
         let table_ids = self.get_table_names(&mut schema).await?;
 
@@ -56,19 +114,6 @@ impl SqlSchemaDescriberBackend for SqlSchemaDescriber<'_> {
         schema.views = self.get_views().await?;
 
         Ok(schema)
-    }
-
-    async fn version(&self, _schema: &str) -> DescriberResult<Option<String>> {
-        Ok(self.conn.version().await?)
-    }
-}
-
-impl Parser for SqlSchemaDescriber<'_> {}
-
-impl<'a> SqlSchemaDescriber<'a> {
-    /// Constructor.
-    pub fn new(conn: &'a dyn Queryable) -> SqlSchemaDescriber<'a> {
-        SqlSchemaDescriber { conn }
     }
 
     async fn get_databases(&self) -> DescriberResult<Vec<String>> {
@@ -274,7 +319,7 @@ async fn push_columns(
     table_name: &str,
     table_id: TableId,
     schema: &mut SqlSchema,
-    conn: &dyn Queryable,
+    conn: &(dyn Connection + Send + Sync),
 ) -> DescriberResult<()> {
     let sql = format!(r#"PRAGMA table_info ("{}")"#, table_name);
     let result_set = conn.query_raw(&sql, &[]).await?;
@@ -392,7 +437,7 @@ async fn push_indexes(
     table: &str,
     table_id: TableId,
     schema: &mut SqlSchema,
-    conn: &dyn Queryable,
+    conn: &(dyn Connection + Send + Sync),
 ) -> DescriberResult<()> {
     let sql = format!(r#"PRAGMA index_list("{}");"#, table);
     let result_set = conn.query_raw(&sql, &[]).await?;
@@ -413,7 +458,7 @@ async fn push_indexes(
         let mut columns = Vec::new();
 
         let sql = format!(r#"PRAGMA index_info("{}");"#, index_name);
-        let result_set = conn.query_raw(&sql, &[]).await.expect("querying for index info");
+        let result_set = conn.query_raw(&sql, &[]).await?;
         trace!("Got index description results: {:?}", result_set);
 
         for row in result_set.into_iter() {
@@ -431,7 +476,7 @@ async fn push_indexes(
         }
 
         let sql = format!(r#"PRAGMA index_xinfo("{}");"#, index_name);
-        let result_set = conn.query_raw(&sql, &[]).await.expect("querying for index info");
+        let result_set = conn.query_raw(&sql, &[]).await?;
         trace!("Got index description results: {:?}", result_set);
 
         for row in result_set.into_iter() {

--- a/migration-engine/connectors/migration-connector/src/error.rs
+++ b/migration-engine/connectors/migration-connector/src/error.rs
@@ -166,6 +166,12 @@ impl ConnectorError {
         ConnectorError::user_facing(SchemaParserError { full_error })
     }
 
+    /// Try to downcast the source to a specific type.
+    pub fn source_as<T: StdError + 'static>(&self) -> Option<&T> {
+        let source = self.0.source.as_ref()?;
+        source.downcast_ref()
+    }
+
     /// Render to a user_facing_error::Error
     pub fn to_user_facing(&self) -> user_facing_errors::Error {
         match &self.0.user_facing_error {

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/sqlite/connection.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/sqlite/connection.rs
@@ -1,90 +1,94 @@
 //! All the quaint-wrangling for the sqlite connector should happen here.
 
+pub(crate) use quaint::connector::rusqlite;
+
 use migration_connector::{ConnectorError, ConnectorResult};
-use quaint::{
-    connector,
-    prelude::{ConnectionInfo, Queryable},
-};
-use sql_schema_describer::{sqlite as describer, DescriberErrorKind, SqlSchema, SqlSchemaDescriberBackend};
+use quaint::connector::{GetRow, ToColumnNames};
+use sql_schema_describer::{sqlite as describer, DescriberErrorKind, SqlSchema};
+use std::sync::Mutex;
 use user_facing_errors::migration_engine::ApplyMigrationError;
 
-pub(super) struct Connection(connector::Sqlite);
+pub(super) struct Connection(Mutex<rusqlite::Connection>);
 
 impl Connection {
     pub(super) fn new(params: &super::Params) -> ConnectorResult<Self> {
-        Ok(Connection(
-            connector::Sqlite::new(&params.file_path).map_err(quaint_err(params))?,
-        ))
+        Ok(Connection(Mutex::new(
+            rusqlite::Connection::open(&params.file_path).map_err(convert_error)?,
+        )))
     }
 
     pub(super) fn new_in_memory() -> Self {
-        Connection(connector::Sqlite::new_in_memory().unwrap())
+        Connection(Mutex::new(rusqlite::Connection::open_in_memory().unwrap()))
     }
 
-    pub(super) async fn describe_schema(&mut self, params: &super::Params) -> ConnectorResult<SqlSchema> {
+    pub(super) async fn describe_schema(&mut self) -> ConnectorResult<SqlSchema> {
         describer::SqlSchemaDescriber::new(&self.0)
-            .describe(&params.attached_name)
+            .describe_impl()
             .await
             .map_err(|err| match err.into_kind() {
-                DescriberErrorKind::QuaintError(err) => quaint_err(params)(err),
+                DescriberErrorKind::QuaintError(err) => panic!("{}", err),
                 DescriberErrorKind::CrossSchemaReference { .. } => {
                     unreachable!("No schemas on SQLite")
                 }
             })
     }
 
-    pub(super) async fn raw_cmd(&mut self, sql: &str, params: &super::Params) -> ConnectorResult<()> {
+    pub(super) fn raw_cmd(&mut self, sql: &str) -> ConnectorResult<()> {
         tracing::debug!(query_type = "raw_cmd", sql);
-        self.0.raw_cmd(sql).await.map_err(quaint_err(params))
+        let conn = self.0.lock().unwrap();
+        conn.execute_batch(sql).map_err(convert_error)
     }
 
-    pub(super) async fn query(
-        &mut self,
-        query: quaint::ast::Query<'_>,
-        conn_params: &super::Params,
-    ) -> ConnectorResult<quaint::prelude::ResultSet> {
+    pub(super) fn query(&mut self, query: quaint::ast::Query<'_>) -> ConnectorResult<quaint::prelude::ResultSet> {
         use quaint::visitor::Visitor;
         let (sql, params) = quaint::visitor::Sqlite::build(query).unwrap();
-        self.query_raw(&sql, &params, conn_params).await
+        self.query_raw(&sql, &params)
     }
 
-    pub(super) async fn query_raw(
-        &self,
+    pub(super) fn query_raw(
+        &mut self,
         sql: &str,
         params: &[quaint::prelude::Value<'_>],
-        conn_params: &super::Params,
     ) -> ConnectorResult<quaint::prelude::ResultSet> {
         tracing::debug!(query_type = "query_raw", sql);
-        self.0.query_raw(sql, params).await.map_err(quaint_err(conn_params))
+        let conn = self.0.lock().unwrap();
+        let mut stmt = conn.prepare_cached(sql).map_err(convert_error)?;
+
+        let mut rows = stmt
+            .query(rusqlite::params_from_iter(params.iter()))
+            .map_err(convert_error)?;
+        let column_names = rows.to_column_names();
+        let mut converted_rows = Vec::new();
+        while let Some(row) = rows.next().map_err(convert_error)? {
+            converted_rows.push(row.get_result_row().unwrap());
+        }
+
+        Ok(quaint::prelude::ResultSet::new(column_names, converted_rows))
     }
 }
 
-pub(super) async fn generic_apply_migration_script(
+pub(super) fn generic_apply_migration_script(
     migration_name: &str,
     script: &str,
     conn: &Connection,
 ) -> ConnectorResult<()> {
     tracing::debug!(query_type = "raw_cmd", sql = script);
-    conn.0.raw_cmd(script).await.map_err(|sql_error| {
+    let conn = conn.0.lock().unwrap();
+    conn.execute_batch(script).map_err(|sqlite_error: rusqlite::Error| {
+        let database_error_code =
+            if let rusqlite::Error::SqliteFailure(rusqlite::ffi::Error { code: _, extended_code }, _) = sqlite_error {
+                extended_code.to_string()
+            } else {
+                "none".to_owned()
+            };
         ConnectorError::user_facing(ApplyMigrationError {
             migration_name: migration_name.to_owned(),
-            database_error_code: String::from(sql_error.original_code().unwrap_or("none")),
-            database_error: sql_error
-                .original_message()
-                .map(String::from)
-                .unwrap_or_else(|| sql_error.to_string()),
+            database_error_code,
+            database_error: sqlite_error.to_string(),
         })
     })
 }
 
-fn quaint_err(params: &super::Params) -> impl (Fn(quaint::error::Error) -> ConnectorError) + '_ {
-    |err| {
-        super::super::quaint_error_to_connector_error(
-            err,
-            &ConnectionInfo::Sqlite {
-                file_path: params.file_path.clone(),
-                db_name: params.attached_name.clone(),
-            },
-        )
-    }
+fn convert_error(err: rusqlite::Error) -> ConnectorError {
+    ConnectorError::from_source(err, "SQLite database error")
 }

--- a/migration-engine/migration-engine-tests/tests/errors/error_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/errors/error_tests.rs
@@ -287,7 +287,7 @@ fn datamodel_parser_errors_must_return_a_known_error(api: TestApi) {
     assert_eq!(error, expected_error);
 }
 
-#[test_connector(exclude(CockroachDb))]
+#[test_connector(exclude(CockroachDb, Sqlite))]
 fn unique_constraint_errors_in_migrations_must_return_a_known_error(api: TestApi) {
     let dm = r#"
         model Fruit {

--- a/migration-engine/migration-engine-tests/tests/migrations/sqlite.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/sqlite.rs
@@ -1,4 +1,5 @@
 use migration_engine_tests::test_api::*;
+use quaint::prelude::Insert;
 
 #[test_connector(tags(Sqlite))]
 fn sqlite_must_recreate_indexes(api: TestApi) {
@@ -147,4 +148,45 @@ fn default_string_with_escaped_unicode(api: TestApi) {
 
     api.schema_push(dm).send().assert_green().assert_has_executed_steps();
     api.schema_push(dm).send().assert_green().assert_no_steps();
+}
+
+#[test_connector(tags(Sqlite))]
+fn unique_constraint_errors_in_migrations(api: TestApi) {
+    let dm = r#"
+        model Fruit {
+            id   Int @id @default(autoincrement())
+            name String
+        }
+    "#;
+
+    api.schema_push_w_datasource(dm).send().assert_green();
+
+    let insert = Insert::multi_into(api.render_table_name("Fruit"), &["name"])
+        .values(("banana",))
+        .values(("apple",))
+        .values(("banana",));
+
+    api.query(insert.into());
+
+    let dm2 = r#"
+        model Fruit {
+            id   Int @id @default(autoincrement())
+            name String @unique
+        }
+    "#;
+
+    let res = api
+        .schema_push_w_datasource(dm2)
+        .force(true)
+        .migration_id(Some("the-migration"))
+        .send_unwrap_err()
+        .to_user_facing();
+
+    let expected_json = expect![[r#"
+        {
+          "is_panic": false,
+          "message": "SQLite database error\nUNIQUE constraint failed: Fruit.name\n   0: sql_migration_connector::apply_migration::apply_migration\n             at migration-engine/connectors/sql-migration-connector/src/apply_migration.rs:10\n   1: migration_engine_tests::commands::schema_push::SchemaPush\n           with \u001b[3mmigration_id\u001b[0m\u001b[2m=\u001b[0mSome(\"the-migration\")\n             at migration-engine/migration-engine-tests/src/commands/schema_push.rs:42",
+          "backtrace": null
+        }"#]];
+    expected_json.assert_eq(&serde_json::to_string_pretty(&res).unwrap())
 }


### PR DESCRIPTION
We now handle rusqlite errors directly instead of relying on quaint. This generally gives us more flexibility and more context on the errors we report, less noise. The idea is to progressively do this for the other connectors as well. On SQLite, another benefit of this change is that we can make some asynchronous code synchronous.

This commit is part of the general effort to remove unnecessary layers of abstraction in the migration engine: we have a connector abstraction, everything below that can and should be connector specific, there is nothing to be gained from e.g. extra layers of error translation that require their own extra context to operate.