### PR TITLE
gh-workflows: use macos-11 for OSX jobs

### DIFF
--- a/.github/workflows/build-apple-intel.yml
+++ b/.github/workflows/build-apple-intel.yml
@@ -12,7 +12,7 @@ jobs:
     env:
       SQLITE_MAX_VARIABLE_NUMBER: 250000
       SQLITE_MAX_EXPR_DEPTH: 10000
-    runs-on: macos-10.15
+    runs-on: macos-11
 
     steps:
       - name: Output link to real commit

--- a/.github/workflows/build-apple-silicon.yml
+++ b/.github/workflows/build-apple-silicon.yml
@@ -12,7 +12,7 @@ jobs:
     env:
       SQLITE_MAX_VARIABLE_NUMBER: 250000
       SQLITE_MAX_EXPR_DEPTH: 10000
-    runs-on: macos-10.15
+    runs-on: macos-11
 
     steps:
       - name: Output link to real commit


### PR DESCRIPTION
macos-10.15 is deprecated and will be removed soon: https://github.com/actions/virtual-environments/issues/5583