### PR TITLE
sql-schema-describer/pg: fix index query failure w/ intarray ext

### DIFF
--- a/introspection-engine/introspection-engine-tests/tests/simple/postgres/int_array_extension_does_not_conflict.sql
+++ b/introspection-engine/introspection-engine-tests/tests/simple/postgres/int_array_extension_does_not_conflict.sql
@@ -1,0 +1,28 @@
+-- tags=postgres
+-- exclude=cockroachdb
+
+-- Test repro for https://github.com/prisma/prisma/issues/14389
+
+CREATE EXTENSION intarray;
+
+CREATE TABLE test (
+    big_data BOOLEAN PRIMARY KEY
+);
+
+CREATE INDEX futureproof ON test(big_data);
+/*
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = "env(TEST_DATABASE_URL)"
+}
+
+model test {
+  big_data Boolean @id
+
+  @@index([big_data], map: "futureproof")
+}
+*/

--- a/libs/sql-schema-describer/src/postgres/indexes_query.sql
+++ b/libs/sql-schema-describer/src/postgres/indexes_query.sql
@@ -11,7 +11,7 @@ WITH rawindex AS (
     FROM pg_index -- https://www.postgresql.org/docs/current/catalog-pg-index.html
     WHERE
         indpred IS NULL -- filter out partial indexes
-        AND NOT indkey::int2[] @> ARRAY[0]::int2[] -- filter out expression indexes
+        AND array_position(indkey::int2[], 0::int2) IS NULL -- filter out expression indexes
 )
 SELECT 
     indexinfo.relname AS index_name,

--- a/libs/sql-schema-describer/tests/describers/postgres_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/postgres_describer_tests.rs
@@ -1,7 +1,6 @@
 mod cockroach_describer_tests;
 
 use crate::test_api::*;
-use barrel::{types, Migration};
 use pretty_assertions::assert_eq;
 use prisma_value::PrismaValue;
 use sql_schema_describer::{postgres::PostgresSchemaExt, *};
@@ -26,55 +25,54 @@ fn views_can_be_described(api: TestApi) {
 
 #[test_connector(tags(Postgres), exclude(CockroachDb))]
 fn all_postgres_column_types_must_work(api: TestApi) {
-    let mut migration = Migration::new().schema(api.schema_name());
-    migration.create_table("User", move |t| {
-        t.add_column("array_bin_col", types::array(&types::binary()));
-        t.add_column("array_bool_col", types::array(&types::boolean()));
-        t.add_column("array_date_col", types::array(&types::date()));
-        t.add_column("array_double_col", types::array(&types::double()));
-        t.add_column("array_float_col", types::array(&types::float()));
-        t.add_column("array_int_col", types::array(&types::integer()));
-        t.add_column("array_text_col", types::array(&types::text()));
-        t.add_column("array_varchar_col", types::array(&types::varchar(255)));
-        t.add_column("bigint_col", types::custom("BIGINT"));
-        t.add_column("bigserial_col", types::custom("BIGSERIAL"));
-        t.add_column("bit_col", types::custom("BIT"));
-        t.add_column("bit_varying_col", types::custom("BIT VARYING(1)"));
-        t.add_column("binary_col", types::binary());
-        t.add_column("boolean_col", types::boolean());
-        t.add_column("box_col", types::custom("BOX"));
-        t.add_column("char_col", types::custom("CHARACTER(1)"));
-        t.add_column("circle_col", types::custom("CIRCLE"));
-        t.add_column("date_time_col", types::date());
-        t.add_column("double_col", types::double());
-        t.add_column("float_col", types::float());
-        t.add_column("int_col", types::integer());
-        t.add_column("line_col", types::custom("LINE"));
-        t.add_column("lseg_col", types::custom("LSEG"));
-        t.add_column("numeric_col", types::custom("NUMERIC"));
-        t.add_column("path_col", types::custom("PATH"));
-        t.add_column("pg_lsn_col", types::custom("PG_LSN"));
-        t.add_column("polygon_col", types::custom("POLYGON"));
-        t.add_column("smallint_col", types::custom("SMALLINT"));
-        t.add_column("smallserial_col", types::custom("SMALLSERIAL"));
-        t.add_column("serial_col", types::custom("SERIAL"));
-        t.add_column("primary_col", types::primary());
-        t.add_column("string1_col", types::text());
-        t.add_column("string2_col", types::varchar(1));
-        t.add_column("time_col", types::custom("TIME"));
-        t.add_column("timetz_col", types::custom("TIMETZ"));
-        t.add_column("timestamp_col", types::custom("TIMESTAMP"));
-        t.add_column("timestamptz_col", types::custom("TIMESTAMPTZ"));
-        t.add_column("tsquery_col", types::custom("TSQUERY"));
-        t.add_column("tsvector_col", types::custom("TSVECTOR"));
-        t.add_column("txid_col", types::custom("TXID_SNAPSHOT"));
-        t.add_column("json_col", types::json());
-        t.add_column("jsonb_col", types::custom("JSONB"));
-        t.add_column("uuid_col", types::uuid());
-    });
-
-    let full_sql = migration.make::<barrel::backend::Pg>();
-    api.raw_cmd(&full_sql);
+    let sql = r#"
+        CREATE TABLE "User" (
+            array_bin_col BYTEA[],
+            array_bool_col BOOLEAN[],
+            array_date_col DATE[],
+            array_double_col DOUBLE PRECISION[],
+            array_float_col FLOAT[],
+            array_int_col INTEGER[],
+            array_text_col TEXT[],
+            array_varchar_col VARCHAR(255)[],
+            bigint_col BIGINT,
+            bigserial_col BIGSERIAL,
+            bit_col BIT,
+            bit_varying_col BIT VARYING(1),
+            binary_col BYTEA,
+            boolean_col BOOLEAN,
+            box_col BOX,
+            char_col CHARACTER(1),
+            circle_col CIRCLE,
+            date_time_col DATE,
+            double_col DOUBLE PRECISION,
+            float_col FLOAT,
+            int_col INTEGER,
+            line_col LINE,
+            lseg_col LSEG,
+            numeric_col NUMERIC,
+            path_col PATH,
+            pg_lsn_col PG_LSN,
+            polygon_col POLYGON,
+            smallint_col SMALLINT,
+            smallserial_col SMALLSERIAL,
+            serial_col SERIAL,
+            primary_col SERIAL PRIMARY KEY,
+            string1_col TEXT,
+            string2_col VARCHAR(1),
+            time_col TIME,
+            timetz_col TIMETZ,
+            timestamp_col TIMESTAMP,
+            timestamptz_col TIMESTAMPTZ,
+            tsquery_col TSQUERY,
+            tsvector_col TSVECTOR,
+            txid_col TXID_SNAPSHOT,
+            json_col JSON,
+            jsonb_col JSONB,
+            uuid_col UUID
+        );
+    "#;
+    api.raw_cmd(sql);
     let expectation = expect![[r#"
         SqlSchema {
             tables: [
@@ -255,7 +253,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                         tpe: ColumnType {
                             full_data_type: "int8",
                             family: BigInt,
-                            arity: Required,
+                            arity: Nullable,
                             native_type: Some(
                                 String(
                                     "BigInt",
@@ -302,7 +300,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                         tpe: ColumnType {
                             full_data_type: "bit",
                             family: String,
-                            arity: Required,
+                            arity: Nullable,
                             native_type: Some(
                                 Object({
                                     "Bit": Number(
@@ -324,7 +322,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                         tpe: ColumnType {
                             full_data_type: "varbit",
                             family: String,
-                            arity: Required,
+                            arity: Nullable,
                             native_type: Some(
                                 Object({
                                     "VarBit": Number(
@@ -346,7 +344,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                         tpe: ColumnType {
                             full_data_type: "bytea",
                             family: Binary,
-                            arity: Required,
+                            arity: Nullable,
                             native_type: Some(
                                 String(
                                     "ByteA",
@@ -366,7 +364,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                         tpe: ColumnType {
                             full_data_type: "bool",
                             family: Boolean,
-                            arity: Required,
+                            arity: Nullable,
                             native_type: Some(
                                 String(
                                     "Boolean",
@@ -388,7 +386,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             family: Unsupported(
                                 "box",
                             ),
-                            arity: Required,
+                            arity: Nullable,
                             native_type: None,
                         },
                         default: None,
@@ -404,7 +402,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                         tpe: ColumnType {
                             full_data_type: "bpchar",
                             family: String,
-                            arity: Required,
+                            arity: Nullable,
                             native_type: Some(
                                 Object({
                                     "Char": Number(
@@ -428,7 +426,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             family: Unsupported(
                                 "circle",
                             ),
-                            arity: Required,
+                            arity: Nullable,
                             native_type: None,
                         },
                         default: None,
@@ -444,7 +442,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                         tpe: ColumnType {
                             full_data_type: "date",
                             family: DateTime,
-                            arity: Required,
+                            arity: Nullable,
                             native_type: Some(
                                 String(
                                     "Date",
@@ -464,7 +462,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                         tpe: ColumnType {
                             full_data_type: "float8",
                             family: Float,
-                            arity: Required,
+                            arity: Nullable,
                             native_type: Some(
                                 String(
                                     "DoublePrecision",
@@ -484,7 +482,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                         tpe: ColumnType {
                             full_data_type: "float8",
                             family: Float,
-                            arity: Required,
+                            arity: Nullable,
                             native_type: Some(
                                 String(
                                     "DoublePrecision",
@@ -504,7 +502,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                         tpe: ColumnType {
                             full_data_type: "int4",
                             family: Int,
-                            arity: Required,
+                            arity: Nullable,
                             native_type: Some(
                                 String(
                                     "Integer",
@@ -526,7 +524,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             family: Unsupported(
                                 "line",
                             ),
-                            arity: Required,
+                            arity: Nullable,
                             native_type: None,
                         },
                         default: None,
@@ -544,7 +542,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             family: Unsupported(
                                 "lseg",
                             ),
-                            arity: Required,
+                            arity: Nullable,
                             native_type: None,
                         },
                         default: None,
@@ -560,7 +558,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                         tpe: ColumnType {
                             full_data_type: "numeric",
                             family: Decimal,
-                            arity: Required,
+                            arity: Nullable,
                             native_type: Some(
                                 Object({
                                     "Decimal": Null,
@@ -582,7 +580,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             family: Unsupported(
                                 "path",
                             ),
-                            arity: Required,
+                            arity: Nullable,
                             native_type: None,
                         },
                         default: None,
@@ -600,7 +598,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             family: Unsupported(
                                 "pg_lsn",
                             ),
-                            arity: Required,
+                            arity: Nullable,
                             native_type: None,
                         },
                         default: None,
@@ -618,7 +616,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             family: Unsupported(
                                 "polygon",
                             ),
-                            arity: Required,
+                            arity: Nullable,
                             native_type: None,
                         },
                         default: None,
@@ -634,7 +632,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                         tpe: ColumnType {
                             full_data_type: "int2",
                             family: Int,
-                            arity: Required,
+                            arity: Nullable,
                             native_type: Some(
                                 String(
                                     "SmallInt",
@@ -735,7 +733,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                         tpe: ColumnType {
                             full_data_type: "text",
                             family: String,
-                            arity: Required,
+                            arity: Nullable,
                             native_type: Some(
                                 String(
                                     "Text",
@@ -755,7 +753,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                         tpe: ColumnType {
                             full_data_type: "varchar",
                             family: String,
-                            arity: Required,
+                            arity: Nullable,
                             native_type: Some(
                                 Object({
                                     "VarChar": Number(
@@ -777,7 +775,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                         tpe: ColumnType {
                             full_data_type: "time",
                             family: DateTime,
-                            arity: Required,
+                            arity: Nullable,
                             native_type: Some(
                                 Object({
                                     "Time": Number(
@@ -799,7 +797,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                         tpe: ColumnType {
                             full_data_type: "timetz",
                             family: DateTime,
-                            arity: Required,
+                            arity: Nullable,
                             native_type: Some(
                                 Object({
                                     "Timetz": Number(
@@ -821,7 +819,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                         tpe: ColumnType {
                             full_data_type: "timestamp",
                             family: DateTime,
-                            arity: Required,
+                            arity: Nullable,
                             native_type: Some(
                                 Object({
                                     "Timestamp": Number(
@@ -843,7 +841,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                         tpe: ColumnType {
                             full_data_type: "timestamptz",
                             family: DateTime,
-                            arity: Required,
+                            arity: Nullable,
                             native_type: Some(
                                 Object({
                                     "Timestamptz": Number(
@@ -867,7 +865,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             family: Unsupported(
                                 "tsquery",
                             ),
-                            arity: Required,
+                            arity: Nullable,
                             native_type: None,
                         },
                         default: None,
@@ -885,7 +883,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             family: Unsupported(
                                 "tsvector",
                             ),
-                            arity: Required,
+                            arity: Nullable,
                             native_type: None,
                         },
                         default: None,
@@ -903,7 +901,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             family: Unsupported(
                                 "txid_snapshot",
                             ),
-                            arity: Required,
+                            arity: Nullable,
                             native_type: None,
                         },
                         default: None,
@@ -919,7 +917,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                         tpe: ColumnType {
                             full_data_type: "json",
                             family: Json,
-                            arity: Required,
+                            arity: Nullable,
                             native_type: Some(
                                 String(
                                     "Json",
@@ -939,7 +937,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                         tpe: ColumnType {
                             full_data_type: "jsonb",
                             family: Json,
-                            arity: Required,
+                            arity: Nullable,
                             native_type: Some(
                                 String(
                                     "JsonB",
@@ -959,7 +957,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                         tpe: ColumnType {
                             full_data_type: "uuid",
                             family: Uuid,
-                            arity: Required,
+                            arity: Nullable,
                             native_type: Some(
                                 String(
                                     "Uuid",
@@ -981,13 +979,6 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                     index_name: "User_pkey",
                     tpe: PrimaryKey,
                 },
-                Index {
-                    table_id: TableId(
-                        0,
-                    ),
-                    index_name: "User_uuid_col_key",
-                    tpe: Unique,
-                },
             ],
             index_columns: [
                 IndexColumn {
@@ -996,18 +987,6 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                     ),
                     column_id: ColumnId(
                         30,
-                    ),
-                    sort_order: Some(
-                        Asc,
-                    ),
-                    length: None,
-                },
-                IndexColumn {
-                    index_id: IndexId(
-                        1,
-                    ),
-                    column_id: ColumnId(
-                        42,
                     ),
                     sort_order: Some(
                         Asc,
@@ -1036,12 +1015,6 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                 (
                     IndexId(
                         0,
-                    ),
-                    BTree,
-                ),
-                (
-                    IndexId(
-                        1,
                     ),
                     BTree,
                 ),


### PR DESCRIPTION
The intarray extension defines its own `@>` operator for integer arrays,
and that conflicts with the builtin postgres `@>` operator — the query
fails with a call to disambiguate using the `OPERATOR(_, _)` construct,
which is unfamiliar to most people. This commit replaces that usage of
`@>` with a more readable call to `array_position()`.

closes https://github.com/prisma/prisma/issues/14389