### PR TITLE
gh-workflows: try a simpler apple silicon setup

### DIFF
--- a/.github/workflows/build-apple-silicon.yml
+++ b/.github/workflows/build-apple-silicon.yml
@@ -41,18 +41,7 @@ jobs:
 
       - run: xcodebuild -showsdks
 
-      # Remove Xcode Command Line Tools so old version can not be used in build via https://github.com/prisma/prisma/issues/5245#issuecomment-864356168
-      - run: sudo rm -Rf /Library/Developer/CommandLineTools/SDKs/*;
-
-      # Activate newest available Xcode
-      - uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: latest-stable
-
-      # Build with fancy params via https://github.com/shepmaster/rust/blob/silicon/silicon/README.md
       - run: |
-          SDKROOT=$(xcrun -sdk macosx11.1 --show-sdk-path)
-          MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.1 --show-sdk-platform-version)
           cargo build --target=aarch64-apple-darwin --release -p query-engine -p query-engine-node-api -p migration-engine-cli -p introspection-core -p prisma-fmt
 
       - uses: actions/upload-artifact@v2


### PR DESCRIPTION
Context: silicon builds are failing after the upgrade to macos 11