### PR TITLE
sql-schema-describer: introduce namespaces

### DIFF
--- a/introspection-engine/introspection-engine-tests/tests/rpc_calls/get_database_description.rs
+++ b/introspection-engine/introspection-engine-tests/tests/rpc_calls/get_database_description.rs
@@ -92,9 +92,12 @@ async fn database_description_for_mysql_8_should_work(api: &TestApi) -> TestResu
 
     let expected = expect![[r#"
         {
+          "namespaces": [],
+          "default_namespace": 0,
           "tables": [
             {
-              "name": "Blog"
+              "name": "Blog",
+              "namespace": 0
             }
           ],
           "enums": [],
@@ -162,8 +165,10 @@ async fn database_description_for_postgres_should_work(api: &TestApi) -> TestRes
 
     let expected = expect![[r#"
         {
+          "namespaces": [],
           "tables": [
             {
+              "namespace": 0,
               "name": "Blog"
             }
           ],
@@ -237,9 +242,12 @@ async fn database_description_for_sqlite_should_work(api: &TestApi) -> TestResul
 
     let expected = expect![[r#"
         {
+          "namespaces": [],
+          "default_namespace": 0,
           "tables": [
             {
-              "name": "Blog"
+              "name": "Blog",
+              "namespace": 0
             }
           ],
           "enums": [],

--- a/libs/sql-schema-describer/src/ids.rs
+++ b/libs/sql-schema-describer/src/ids.rs
@@ -23,3 +23,7 @@ pub struct IndexColumnId(pub(crate) u32);
 /// The identifier for a ForeignKey in the schema.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct ForeignKeyId(pub(crate) u32);
+
+/// The identifier for a namespace (schema).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Serialize, Deserialize)]
+pub struct NamespaceId(pub(crate) u32);

--- a/libs/sql-schema-describer/src/lib.rs
+++ b/libs/sql-schema-describer/src/lib.rs
@@ -51,10 +51,16 @@ pub struct SqlMetadata {
     pub size_in_bytes: usize,
 }
 
-/// The result of describing a database schema.
+/// The result of describing a logical database.
 #[derive(Serialize, Deserialize, Debug, Default)]
 pub struct SqlSchema {
-    /// The schema's tables.
+    /// The namespaces (schemas) defined on the database. Empty where not relevant.
+    namespaces: Vec<String>,
+
+    #[serde(skip_serializing)] // not relevant, would deserialize back fine
+    _default_namespace: NamespaceId,
+
+    /// The schema's tables, sorted by namespace id, then name.
     tables: Vec<Table>,
     /// The schema's enums.
     pub enums: Vec<Enum>,
@@ -210,9 +216,9 @@ impl SqlSchema {
         });
     }
 
-    pub fn push_table(&mut self, name: String) -> TableId {
+    pub fn push_table(&mut self, namespace: NamespaceId, name: String) -> TableId {
         let id = TableId(self.tables.len() as u32);
-        self.tables.push(Table { name });
+        self.tables.push(Table { name, namespace });
         id
     }
 
@@ -279,9 +285,9 @@ impl SqlSchema {
     }
 }
 
-/// A table found in a schema.
 #[derive(Serialize, Deserialize, PartialEq, Debug, Default)]
-pub struct Table {
+pub(crate) struct Table {
+    namespace: NamespaceId,
     name: String,
 }
 

--- a/libs/sql-schema-describer/src/mssql.rs
+++ b/libs/sql-schema-describer/src/mssql.rs
@@ -197,7 +197,7 @@ impl<'a> SqlSchemaDescriber<'a> {
 
         for name in names {
             let cloned_name = name.clone();
-            let id = sql_schema.push_table(name);
+            let id = sql_schema.push_table(Default::default(), name);
             map.insert(cloned_name, id);
         }
 

--- a/libs/sql-schema-describer/src/mysql.rs
+++ b/libs/sql-schema-describer/src/mysql.rs
@@ -279,7 +279,7 @@ impl<'a> SqlSchemaDescriber<'a> {
 
         for name in names {
             let cloned_name = name.clone();
-            let id = sql_schema.push_table(name);
+            let id = sql_schema.push_table(Default::default(), name);
             map.insert(cloned_name, id);
         }
 

--- a/libs/sql-schema-describer/src/postgres.rs
+++ b/libs/sql-schema-describer/src/postgres.rs
@@ -512,7 +512,7 @@ impl<'a> SqlSchemaDescriber<'a> {
 
         for name in names {
             let cloned_name = name.clone();
-            let id = sql_schema.push_table(name);
+            let id = sql_schema.push_table(Default::default(), name);
             map.insert(cloned_name, id);
         }
 

--- a/libs/sql-schema-describer/src/sqlite.rs
+++ b/libs/sql-schema-describer/src/sqlite.rs
@@ -152,7 +152,7 @@ impl<'a> SqlSchemaDescriber<'a> {
 
         for name in names {
             let cloned_name = name.clone();
-            let id = schema.push_table(name);
+            let id = schema.push_table(Default::default(), name);
             map.insert(cloned_name, id);
         }
 

--- a/libs/sql-schema-describer/tests/describers/mysql_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/mysql_describer_tests.rs
@@ -44,51 +44,53 @@ fn procedures_can_be_described(api: TestApi) {
 
 #[test_connector(tags(Mysql), exclude(Mysql8, Mysql56, Mariadb))]
 fn all_mysql_column_types_must_work(api: TestApi) {
-    let mut migration = Migration::new().schema(api.db_name());
-    migration.create_table("User", move |t| {
-        t.add_column("primary_col", types::primary());
-        t.add_column("int_col", types::custom("int"));
-        t.add_column("smallint_col", types::custom("smallint"));
-        t.add_column("tinyint4_col", types::custom("tinyint(4)"));
-        t.add_column("tinyint1_col", types::custom("tinyint(1)"));
-        t.add_column("mediumint_col", types::custom("mediumint"));
-        t.add_column("bigint_col", types::custom("bigint"));
-        t.add_column("decimal_col", types::custom("decimal"));
-        t.add_column("numeric_col", types::custom("numeric"));
-        t.add_column("float_col", types::custom("float"));
-        t.add_column("double_col", types::custom("double"));
-        t.add_column("date_col", types::custom("date"));
-        t.add_column("time_col", types::custom("time"));
-        t.add_column("datetime_col", types::custom("datetime"));
-        t.add_column("timestamp_col", types::custom("timestamp"));
-        t.add_column("year_col", types::custom("year"));
-        t.add_column("char_col", types::custom("char"));
-        t.add_column("varchar_col", types::custom("varchar(255)"));
-        t.add_column("text_col", types::custom("text"));
-        t.add_column("tinytext_col", types::custom("tinytext"));
-        t.add_column("mediumtext_col", types::custom("mediumtext"));
-        t.add_column("longtext_col", types::custom("longtext"));
-        t.add_column("enum_col", types::custom("enum('a', 'b')"));
-        t.add_column("set_col", types::custom("set('a', 'b')"));
-        t.add_column("binary_col", types::custom("binary"));
-        t.add_column("varbinary_col", types::custom("varbinary(255)"));
-        t.add_column("blob_col", types::custom("blob"));
-        t.add_column("tinyblob_col", types::custom("tinyblob"));
-        t.add_column("mediumblob_col", types::custom("mediumblob"));
-        t.add_column("longblob_col", types::custom("longblob"));
-        t.add_column("geometry_col", types::custom("geometry"));
-        t.add_column("point_col", types::custom("point"));
-        t.add_column("linestring_col", types::custom("linestring"));
-        t.add_column("polygon_col", types::custom("polygon"));
-        t.add_column("multipoint_col", types::custom("multipoint"));
-        t.add_column("multilinestring_col", types::custom("multilinestring"));
-        t.add_column("multipolygon_col", types::custom("multipolygon"));
-        t.add_column("geometrycollection_col", types::custom("geometrycollection"));
-        t.add_column("json_col", types::custom("json"));
-    });
+    let create_table = r#"
+        CREATE TABLE `User` (
+            t.add_column("primary_col", types::primary());
+            int_col int,
+            smallint_col smallint,
+            tinyint4_col tinyint(4),
+            tinyint1_col tinyint(1),
+            mediumint_col mediumint,
+            bigint_col bigint,
+            decimal_col decimal,
+            numeric_col numeric,
+            float_col float,
+            double_col double,
+            date_col date,
+            time_col time,
+            datetime_col datetime,
+            timestamp_col timestamp,
+            year_col year,
+            char_col char,
+            varchar_col varchar(255),
+            text_col text,
+            tinytext_col tinytext,
+            mediumtext_col mediumtext,
+            longtext_col longtext,
+            enum_col enum('a', 'b'),
+            set_col set('a', 'b'),
+            binary_col binary,
+            varbinary_col varbinary(255),
+            blob_col blob,
+            tinyblob_col tinyblob,
+            mediumblob_col mediumblob,
+            longblob_col longblob,
+            geometry_col geometry,
+            point_col point,
+            linestring_col linestring,
+            polygon_col polygon,
+            multipoint_col multipoint,
+            multilinestring_col multilinestring,
+            multipolygon_col multipolygon,
+            geometrycollection_col geometrycollection,
+            json_col json
+        );
 
-    let full_sql = migration.make::<barrel::backend::MySql>();
-    api.raw_cmd(&full_sql);
+    "#;
+
+    api.raw_cmd(create_table);
+
     let expectation = expect![[r#"
         SqlSchema {
             tables: [
@@ -1871,9 +1873,16 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
     api.raw_cmd(&full_sql);
     let expectation = expect![[r#"
         SqlSchema {
+            namespaces: [],
+            default_namespace: NamespaceId(
+                0,
+            ),
             tables: [
                 Table {
                     name: "User",
+                    namespace: NamespaceId(
+                        0,
+                    ),
                 },
             ],
             enums: [
@@ -2859,12 +2868,22 @@ fn constraints_from_other_databases_should_not_be_introspected(api: TestApi) {
 
     let expectation = expect![[r#"
         SqlSchema {
+            namespaces: [],
+            default_namespace: NamespaceId(
+                0,
+            ),
             tables: [
                 Table {
                     name: "Post",
+                    namespace: NamespaceId(
+                        0,
+                    ),
                 },
                 Table {
                     name: "User",
+                    namespace: NamespaceId(
+                        0,
+                    ),
                 },
             ],
             enums: [],
@@ -3045,9 +3064,16 @@ fn introspected_default_strings_should_be_unescaped(api: TestApi) {
     api.raw_cmd(create_table);
     let expectation = expect![[r#"
         SqlSchema {
+            namespaces: [],
+            default_namespace: NamespaceId(
+                0,
+            ),
             tables: [
                 Table {
                     name: "User",
+                    namespace: NamespaceId(
+                        0,
+                    ),
                 },
             ],
             enums: [],
@@ -3109,9 +3135,16 @@ fn escaped_quotes_in_string_defaults_must_be_unescaped(api: TestApi) {
 
     let expectation = expect![[r#"
         SqlSchema {
+            namespaces: [],
+            default_namespace: NamespaceId(
+                0,
+            ),
             tables: [
                 Table {
                     name: "string_defaults_test",
+                    namespace: NamespaceId(
+                        0,
+                    ),
                 },
             ],
             enums: [],
@@ -3204,9 +3237,16 @@ fn escaped_backslashes_in_string_literals_must_be_unescaped(api: TestApi) {
 
     let expectation = expect![[r#"
         SqlSchema {
+            namespaces: [],
+            default_namespace: NamespaceId(
+                0,
+            ),
             tables: [
                 Table {
                     name: "test",
+                    namespace: NamespaceId(
+                        0,
+                    ),
                 },
             ],
             enums: [],
@@ -3279,9 +3319,16 @@ fn function_expression_defaults_are_described_as_dbgenerated(api: TestApi) {
 
     let expectation = expect![[r#"
         SqlSchema {
+            namespaces: [],
+            default_namespace: NamespaceId(
+                0,
+            ),
             tables: [
                 Table {
                     name: "game",
+                    namespace: NamespaceId(
+                        0,
+                    ),
                 },
             ],
             enums: [

--- a/libs/sql-schema-describer/tests/describers/postgres_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/postgres_describer_tests.rs
@@ -75,8 +75,15 @@ fn all_postgres_column_types_must_work(api: TestApi) {
     api.raw_cmd(sql);
     let expectation = expect![[r#"
         SqlSchema {
+            namespaces: [],
+            _default_namespace: NamespaceId(
+                0,
+            ),
             tables: [
                 Table {
+                    namespace: NamespaceId(
+                        0,
+                    ),
                     name: "User",
                 },
             ],
@@ -1252,8 +1259,15 @@ fn escaped_quotes_in_string_defaults_must_be_unescaped(api: TestApi) {
     api.raw_cmd(create_table);
     let expectation = expect![[r#"
         SqlSchema {
+            namespaces: [],
+            _default_namespace: NamespaceId(
+                0,
+            ),
             tables: [
                 Table {
+                    namespace: NamespaceId(
+                        0,
+                    ),
                     name: "string_defaults_test",
                 },
             ],
@@ -1413,8 +1427,15 @@ fn seemingly_escaped_backslashes_in_string_literals_must_not_be_unescaped(api: T
     api.raw_cmd(create_table);
     let expectation = expect![[r#"
         SqlSchema {
+            namespaces: [],
+            _default_namespace: NamespaceId(
+                0,
+            ),
             tables: [
                 Table {
+                    namespace: NamespaceId(
+                        0,
+                    ),
                     name: "test",
                 },
             ],

--- a/libs/sql-schema-describer/tests/describers/sqlite_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/sqlite_describer_tests.rs
@@ -62,8 +62,15 @@ fn sqlite_column_types_must_work(api: TestApi) {
     api.raw_cmd(sql);
     let expectation = expect![[r#"
         SqlSchema {
+            namespaces: [],
+            _default_namespace: NamespaceId(
+                0,
+            ),
             tables: [
                 Table {
+                    namespace: NamespaceId(
+                        0,
+                    ),
                     name: "User",
                 },
             ],
@@ -266,8 +273,15 @@ fn escaped_quotes_in_string_defaults_must_be_unescaped(api: TestApi) {
     api.raw_cmd(create_table);
     let expectation = expect![[r#"
         SqlSchema {
+            namespaces: [],
+            _default_namespace: NamespaceId(
+                0,
+            ),
             tables: [
                 Table {
+                    namespace: NamespaceId(
+                        0,
+                    ),
                     name: "string_defaults_test",
                 },
             ],
@@ -349,8 +363,15 @@ fn backslashes_in_string_literals(api: TestApi) {
 
     let expectation = expect![[r#"
         SqlSchema {
+            namespaces: [],
+            _default_namespace: NamespaceId(
+                0,
+            ),
             tables: [
                 Table {
+                    namespace: NamespaceId(
+                        0,
+                    ),
                     name: "test",
                 },
             ],
@@ -419,11 +440,21 @@ fn broken_relations_are_filtered_out(api: TestApi) {
     // the relation to platypus should be the only foreign key on dog
     let expectation = expect![[r#"
         SqlSchema {
+            namespaces: [],
+            _default_namespace: NamespaceId(
+                0,
+            ),
             tables: [
                 Table {
+                    namespace: NamespaceId(
+                        0,
+                    ),
                     name: "dog",
                 },
                 Table {
+                    namespace: NamespaceId(
+                        0,
+                    ),
                     name: "platypus",
                 },
             ],

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
@@ -43,7 +43,7 @@ pub(crate) fn calculate_sql_schema(datamodel: &ValidatedSchema, flavour: &dyn Sq
 
 fn push_model_tables(ctx: &mut Context<'_>) {
     for model in ctx.datamodel.db.walk_models() {
-        let table_id = ctx.schema.describer_schema.push_table(model.database_name().to_owned());
+        let table_id = ctx.schema.describer_schema.push_table(Default::default(), model.database_name().to_owned());
         ctx.model_id_to_table_id.insert(model.model_id(), table_id);
 
         for field in model.scalar_fields() {
@@ -197,7 +197,7 @@ fn push_relation_tables(ctx: &mut Context<'_>) {
             format!("{table_name}_B{fk_suffix}")
         };
 
-        let table_id = ctx.schema.describer_schema.push_table(table_name.clone());
+        let table_id = ctx.schema.describer_schema.push_table(Default::default(), table_name.clone());
         let column_a_type = ctx
             .walk(model_a_table_id)
             .primary_key_columns()


### PR DESCRIPTION
They will be used for multi-schema support. This commit is only about
adding the relevant data: which namespaces are in the database, and
which one is the default one. The default one will be 0 for databases
that do not have a notion of schemas or namespaces (sqlite), the search
path on postgres, and the schema from the connection string on mssql.