### PR TITLE
Add regression test for upserts and prisma ref. integrity

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,6 +118,7 @@ services:
     image: mysql:5.6.50
     command: mysqld
     restart: always
+    platform: linux/x86_64
     environment:
       MYSQL_USER: root
       MYSQL_ROOT_PASSWORD: prisma
@@ -132,6 +133,7 @@ services:
     image: mysql:5.7.32
     command: mysqld
     restart: always
+    platform: linux/x86_64
     environment:
       MYSQL_USER: root
       MYSQL_ROOT_PASSWORD: prisma
@@ -146,6 +148,7 @@ services:
     image: mysql:8.0.28
     command: mysqld
     restart: always
+    platform: linux/x86_64
     environment:
       MYSQL_ROOT_PASSWORD: prisma
       MYSQL_DATABASE: prisma

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
@@ -1,5 +1,6 @@
 mod max_integer;
 mod prisma_10098;
+mod prisma_10935;
 mod prisma_12929;
 mod prisma_6173;
 mod prisma_7010;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_10935.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_10935.rs
@@ -1,0 +1,58 @@
+use indoc::indoc;
+use query_engine_tests::*;
+
+#[test_suite(schema(schema), only(MySql))]
+mod prisma_ref_integrity {
+    fn schema() -> String {
+        let schema = indoc! {
+            r#"
+              model User {
+                id      Int       @id @default(autoincrement())
+                email   String    @unique
+                name    String?   @unique
+                bio     String?
+              }
+            "#
+        };
+
+        schema.to_owned()
+    }
+
+    #[connector_test(referential_integrity = "prisma")]
+    async fn upserts_must_not_return_count(runner: Runner) -> TestResult<()> {
+        insta::assert_snapshot!(
+          &run_upsert(&runner).await?,
+          @r###"{"data":{"upsertOneUser":{"email":"test@test.com","name":"test","bio":"test"}}}"###
+        );
+
+        insta::assert_snapshot!(
+          &run_upsert(&runner).await?,
+          @r###"{"data":{"upsertOneUser":{"email":"test@test.com","name":"test","bio":"updated"}}}"###
+        );
+
+        Ok(())
+    }
+
+    async fn run_upsert(runner: &Runner) -> TestResult<String> {
+        Ok(run_query!(
+            runner,
+            r#"
+            mutation {
+                upsertOneUser(where: {
+                    name: "test"
+                }, create: {
+                    email: "test@test.com"
+                    name: "test"
+                    bio: "test"
+                }, update: {
+                    bio: "updated"
+                }) {
+                    email
+                    name
+                    bio
+                }
+            }
+          "#
+        ))
+    }
+}

--- a/query-engine/connector-test-kit-rs/query-test-macros/src/args/connector_test.rs
+++ b/query-engine/connector-test-kit-rs/query-test-macros/src/args/connector_test.rs
@@ -27,6 +27,9 @@ pub struct ConnectorTestArgs {
 
     #[darling(default)]
     pub capabilities: RunOnlyForCapabilities,
+
+    #[darling(default)]
+    pub referential_integrity: Option<ReferentialIntegrity>,
 }
 
 impl ConnectorTestArgs {
@@ -45,6 +48,32 @@ impl ConnectorTestArgs {
     /// Returns all the connectors that the test is valid for.
     pub fn connectors_to_test(&self) -> Vec<ConnectorTag> {
         connectors_to_test(&self.only, &self.exclude)
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug)]
+pub enum ReferentialIntegrity {
+    ForeignKeys,
+    Prisma,
+}
+
+impl darling::FromMeta for ReferentialIntegrity {
+    fn from_string(value: &str) -> darling::Result<Self> {
+        match value.to_lowercase().as_str() {
+            "prisma" => Ok(Self::Prisma),
+            "foreignkeys" => Ok(Self::ForeignKeys),
+            _ => Err(darling::Error::custom(format!("Invalid value: {}", value)))
+        }
+    }
+}
+
+impl ToString for ReferentialIntegrity {
+    fn to_string(&self) -> String {
+        match self {
+            ReferentialIntegrity::Prisma => "prisma".to_string(),
+            ReferentialIntegrity::ForeignKeys => "foreignKeys".to_string(),
+        }
     }
 }
 

--- a/query-engine/connector-test-kit-rs/query-test-macros/src/connector_test.rs
+++ b/query-engine/connector-test-kit-rs/query-test-macros/src/connector_test.rs
@@ -71,6 +71,14 @@ pub fn connector_test_impl(attr: TokenStream, input: TokenStream) -> TokenStream
         })
         .collect();
 
+    let referential_override = match args.referential_integrity {
+        Some(ref_override) => {
+            let wat = ref_override.to_string();
+            quote! { Some(#wat.to_string()) }
+        },
+        None => quote! { None },
+    };
+
     // The actual test is a shell function that gets the name of the original function,
     // which is then calling `{orig_name}_run` in the end (see `runner_fn_ident`).
     let test = quote! {
@@ -87,7 +95,7 @@ pub fn connector_test_impl(attr: TokenStream, input: TokenStream) -> TokenStream
 
             if ConnectorTag::should_run(&config, &enabled_connectors, &capabilities, #test_name) {
                 let template = #handler();
-                let datamodel = query_tests_setup::render_test_datamodel(config, #test_database, template, #excluded_features);
+                let datamodel = query_tests_setup::render_test_datamodel(config, #test_database, template, #excluded_features, #referential_override);
                 let connector = config.test_connector_tag().unwrap();
                 let metrics = query_tests_setup::setup_metrics();
                 let metrics_for_subscriber = metrics.clone();

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/datamodel_rendering/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/datamodel_rendering/mod.rs
@@ -35,6 +35,7 @@ pub fn render_test_datamodel(
     test_database: &str,
     template: String,
     excluded_features: &[&str],
+    referential_integrity_override: Option<String>,
 ) -> String {
     let tag = config.test_connector_tag().unwrap();
     let preview_features = render_preview_features(excluded_features);
@@ -54,7 +55,7 @@ pub fn render_test_datamodel(
         "#},
         tag.datamodel_provider(),
         tag.connection_string(test_database, config.is_ci()),
-        tag.referential_integrity(),
+        referential_integrity_override.unwrap_or(tag.referential_integrity().to_string()),
         preview_features
     );
 

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/lib.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/lib.rs
@@ -107,7 +107,7 @@ pub fn run_relation_link_test<F>(
     let dm_with_params_json: DatamodelWithParams = dm_with_params.parse().unwrap();
 
     if ConnectorTag::should_run(config, &enabled_connectors, capabilities, test_name) {
-        let datamodel = render_test_datamodel(config, test_database, template, &[]);
+        let datamodel = render_test_datamodel(config, test_database, template, &[], None);
         let connector = config.test_connector_tag().unwrap();
         let requires_teardown = connector.requires_teardown();
         let metrics = setup_metrics();


### PR DESCRIPTION
- Adds a regression test for prisma/prisma#10935.
- Adds capability for tests to override referential integrity.
