### PR TITLE
fix: tracing always get trace_id for links

### DIFF
--- a/query-engine/query-engine-node-api/src/engine.rs
+++ b/query-engine/query-engine-node-api/src/engine.rs
@@ -309,7 +309,7 @@ impl QueryEngine {
 
             async move {
                 let span = if tx_id.is_none() {
-                    tracing::info_span!("prisma:engine:query_builder", user_facing = true)
+                    tracing::info_span!("prisma:engine", user_facing = true)
                 } else {
                     Span::none()
                 };

--- a/query-engine/query-engine-node-api/src/engine.rs
+++ b/query-engine/query-engine-node-api/src/engine.rs
@@ -308,13 +308,13 @@ impl QueryEngine {
             let dispatcher = self.logger.dispatcher();
 
             async move {
-                let (span, trace_id) = if tx_id.is_none() {
-                    let span = tracing::info_span!("prisma:engine", user_facing = true);
-                    let trace_id = set_parent_context_from_json_str(&span, &trace);
-                    (span, trace_id)
+                let span = if tx_id.is_none() {
+                    tracing::info_span!("prisma:engine:query_builder", user_facing = true)
                 } else {
-                    (Span::none(), None)
+                    Span::none()
                 };
+
+                let trace_id = set_parent_context_from_json_str(&span, &trace);
 
                 let handler = GraphQlHandler::new(engine.executor(), engine.query_schema());
                 let response = handler


### PR DESCRIPTION
Fixes Lib engine links for tracing. Original PR: https://github.com/prisma/prisma-engines/pull/3091

Reverts the changes here: 

https://github.com/prisma/prisma-engines/commit/1cf3730627092afd6fe395b345bebd05e716030a#diff-a54ef472e7479d11db6225bd958bef26edb88dd5f7ff629d11a5aa3716e29c70R311