### PR TITLE
sql-schema-describer: align views and udts w/ others

### DIFF
--- a/libs/sql-schema-describer/src/ids.rs
+++ b/libs/sql-schema-describer/src/ids.rs
@@ -23,3 +23,11 @@ pub struct IndexColumnId(pub(crate) u32);
 /// The identifier for a ForeignKey in the schema.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct ForeignKeyId(pub(crate) u32);
+
+/// The identifier for a user defined type in the database.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct UdtId(pub(crate) u32);
+
+/// The identifier for a view in the database.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ViewId(pub(crate) u32);

--- a/libs/sql-schema-describer/src/lib.rs
+++ b/libs/sql-schema-describer/src/lib.rs
@@ -233,11 +233,11 @@ impl SqlSchema {
     }
 
     pub fn view_walkers(&self) -> impl Iterator<Item = ViewWalker<'_>> {
-        (0..self.views.len()).map(move |view_index| ViewWalker::new(self, view_index))
+        (0..self.views.len()).map(move |view_index| self.walk(ViewId(view_index as u32)))
     }
 
     pub fn udt_walkers(&self) -> impl Iterator<Item = UserDefinedTypeWalker<'_>> {
-        (0..self.user_defined_types.len()).map(move |udt_index| UserDefinedTypeWalker::new(self, udt_index))
+        (0..self.user_defined_types.len()).map(move |udt_index| self.walk(UdtId(udt_index as u32)))
     }
 
     pub fn enum_walkers(&self) -> impl Iterator<Item = EnumWalker<'_>> {
@@ -257,20 +257,6 @@ impl SqlSchema {
     /// Traverse a schema item by id.
     pub fn walk<I>(&self, id: I) -> Walker<'_, I> {
         Walker { id, schema: self }
-    }
-
-    pub fn udt_walker_at(&self, index: usize) -> UserDefinedTypeWalker<'_> {
-        UserDefinedTypeWalker {
-            udt_index: index,
-            schema: self,
-        }
-    }
-
-    pub fn view_walker_at(&self, index: usize) -> ViewWalker<'_> {
-        ViewWalker {
-            view_index: index,
-            schema: self,
-        }
     }
 
     /// Traverse all the columns in the schema.

--- a/libs/sql-schema-describer/src/walkers.rs
+++ b/libs/sql-schema-describer/src/walkers.rs
@@ -52,6 +52,12 @@ pub type IndexWalker<'a> = Walker<'a, IndexId>;
 /// Traverse a specific column inside an index.
 pub type IndexColumnWalker<'a> = Walker<'a, IndexColumnId>;
 
+/// Traverse a user-defined type
+pub type UserDefinedTypeWalker<'a> = Walker<'a, UdtId>;
+
+/// Traverse a view
+pub type ViewWalker<'a> = Walker<'a, ViewId>;
+
 impl<'a> ColumnWalker<'a> {
     /// The nullability and arity of the column.
     pub fn arity(self) -> ColumnArity {
@@ -165,21 +171,7 @@ impl<'a> ColumnWalker<'a> {
     }
 }
 
-/// Traverse a view
-#[derive(Clone, Copy)]
-pub struct ViewWalker<'a> {
-    /// The schema the view is contained in.
-    pub(crate) schema: &'a SqlSchema,
-    /// The index of the view in the schema.
-    pub(crate) view_index: usize,
-}
-
 impl<'a> ViewWalker<'a> {
-    /// Create a ViewWalker from a schema and a reference to one of its views.
-    pub fn new(schema: &'a SqlSchema, view_index: usize) -> Self {
-        Self { schema, view_index }
-    }
-
     /// The name of the view
     pub fn name(self) -> &'a str {
         &self.view().name
@@ -190,29 +182,12 @@ impl<'a> ViewWalker<'a> {
         self.view().definition.as_deref()
     }
 
-    /// The index of the view in the schema.
-    pub fn view_index(self) -> usize {
-        self.view_index
-    }
-
     fn view(self) -> &'a View {
-        &self.schema.views[self.view_index]
+        &self.schema.views[self.id.0 as usize]
     }
-}
-
-/// Traverse a user-defined type
-#[derive(Clone, Copy)]
-pub struct UserDefinedTypeWalker<'a> {
-    pub(crate) schema: &'a SqlSchema,
-    pub(crate) udt_index: usize,
 }
 
 impl<'a> UserDefinedTypeWalker<'a> {
-    /// Create a UserDefinedTypeWalker from a schema and a reference to one of its udts.
-    pub fn new(schema: &'a SqlSchema, udt_index: usize) -> Self {
-        Self { schema, udt_index }
-    }
-
     /// The name of the type
     pub fn name(self) -> &'a str {
         &self.udt().name
@@ -223,13 +198,8 @@ impl<'a> UserDefinedTypeWalker<'a> {
         self.udt().definition.as_deref()
     }
 
-    /// The index of the user-defined type in the schema.
-    pub fn udt_index(self) -> usize {
-        self.udt_index
-    }
-
     fn udt(self) -> &'a UserDefinedType {
-        &self.schema.user_defined_types[self.udt_index]
+        &self.schema.user_defined_types[self.id.0 as usize]
     }
 }
 

--- a/migration-engine/connectors/sql-migration-connector/src/apply_migration.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/apply_migration.rs
@@ -156,12 +156,12 @@ fn render_raw_sql(
         }
         SqlMigrationStep::RenameIndex { index } => renderer.render_rename_index(schemas.walk(*index)),
         SqlMigrationStep::DropView(drop_view) => {
-            let view = schemas.previous.view_walker_at(drop_view.view_index);
+            let view = schemas.previous.walk(drop_view.view_id);
 
             vec![renderer.render_drop_view(view)]
         }
         SqlMigrationStep::DropUserDefinedType(drop_udt) => {
-            let udt = schemas.previous.udt_walker_at(drop_udt.udt_index);
+            let udt = schemas.previous.walk(drop_udt.udt_id);
 
             vec![renderer.render_drop_user_defined_type(&udt)]
         }

--- a/migration-engine/connectors/sql-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/lib.rs
@@ -306,8 +306,7 @@ async fn best_effort_reset_impl(flavour: &mut (dyn SqlFlavour + Send + Sync)) ->
     let drop_views = source_schema
         .view_walkers()
         .filter(|view| !flavour.view_should_be_ignored(view.name()))
-        .map(|vw| vw.view_index())
-        .map(DropView::new)
+        .map(|vw| DropView::new(vw.id))
         .map(SqlMigrationStep::DropView);
 
     steps.extend(drop_views);
@@ -318,7 +317,7 @@ async fn best_effort_reset_impl(flavour: &mut (dyn SqlFlavour + Send + Sync)) ->
 
     let drop_udts = source_schema
         .udt_walkers()
-        .map(|udtw| udtw.udt_index())
+        .map(|udtw| udtw.id)
         .map(DropUserDefinedType::new)
         .map(SqlMigrationStep::DropUserDefinedType);
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_migration.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_migration.rs
@@ -6,7 +6,7 @@ use crate::{
 use enumflags2::BitFlags;
 use sql_schema_describer::{
     walkers::{ColumnWalker, TableWalker},
-    ColumnId, EnumId, ForeignKeyId, IndexId, SqlSchema, TableId,
+    ColumnId, EnumId, ForeignKeyId, IndexId, SqlSchema, TableId, UdtId, ViewId,
 };
 use std::{collections::BTreeSet, fmt::Write as _};
 
@@ -63,14 +63,14 @@ impl SqlMigration {
                 SqlMigrationStep::DropView(drop_view) => {
                     drift_items.insert((
                         DriftType::RemovedView,
-                        self.schemas().previous.view_walker_at(drop_view.view_index).name(),
+                        self.schemas().previous.walk(drop_view.view_id).name(),
                         idx,
                     ));
                 }
                 SqlMigrationStep::DropUserDefinedType(drop_udt) => {
                     drift_items.insert((
                         DriftType::RemovedUdt,
-                        self.schemas().previous.udt_walker_at(drop_udt.udt_index).name(),
+                        self.schemas().previous.walk(drop_udt.udt_id).name(),
                         idx,
                     ));
                 }
@@ -511,29 +511,24 @@ pub(crate) enum TableChange {
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct DropView {
-    pub view_index: usize,
+    pub view_id: ViewId,
 }
 
 impl DropView {
-    pub fn new(view_index: usize) -> Self {
-        Self { view_index }
+    pub fn new(view_id: ViewId) -> Self {
+        Self { view_id }
     }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct DropUserDefinedType {
-    pub udt_index: usize,
+    pub udt_id: UdtId,
 }
 
 impl DropUserDefinedType {
-    pub(crate) fn new(udt_index: usize) -> Self {
-        Self { udt_index }
+    pub(crate) fn new(udt_id: UdtId) -> Self {
+        Self { udt_id }
     }
-}
-
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub(crate) struct DropColumn {
-    pub index: usize,
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]


### PR DESCRIPTION
Views and user defined types were the only schema elements left with no
typed identifiers, but rather integer indexes. That left them out of the
common Walker abstraction. This commit aligns them with other top-level
items in SqlSchema by defining and using typed identifiers.