### PR TITLE
sql-schema-describer(mssql): filter out INCLUDEd columns from indexes

### DIFF
--- a/introspection-engine/introspection-engine-tests/tests/simple/mssql/index_included_columns_should_not_be_introspected.sql
+++ b/introspection-engine/introspection-engine-tests/tests/simple/mssql/index_included_columns_should_not_be_introspected.sql
@@ -1,0 +1,49 @@
+-- tags=mssql
+
+CREATE TABLE [dbo].[a] (
+    aid INT IDENTITY,
+    acol INT NOT NULL
+);
+
+CREATE TABLE [dbo].[b] (
+    bid INT IDENTITY,
+    bcol INT NOT NULL
+);
+
+/* The first index will be the primary key of a. */
+ALTER TABLE a ADD CONSTRAINT a_pkey PRIMARY KEY (aid);
+
+/*
+    The second index will be the index on b with an included (non-key) column.
+
+    The bcol column should not be included in the index in the introspected
+    schema, because it is not part of the key (the indexed columns). It was
+    previously erroneously included in the primary key of `a` because its
+    key_ordinal was 0. That caused crashes.
+
+    See the official docs on included columns:
+    https://docs.microsoft.com/en-us/sql/t-sql/statements/create-index-transact-sql?view=sql-server-ver16#include-column---n--
+*/
+CREATE UNIQUE INDEX bidx ON b (bid) INCLUDE (bcol);
+
+
+/*
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlserver"
+  url      = "env(TEST_DATABASE_URL)"
+}
+
+model a {
+  aid  Int @id @default(autoincrement())
+  acol Int
+}
+
+model b {
+  bid  Int @unique(map: "bidx") @default(autoincrement())
+  bcol Int
+}
+*/

--- a/libs/sql-schema-describer/src/mssql.rs
+++ b/libs/sql-schema-describer/src/mssql.rs
@@ -186,8 +186,8 @@ impl<'a> SqlSchemaDescriber<'a> {
             SELECT tbl.name AS table_name
             FROM sys.tables tbl
             WHERE SCHEMA_NAME(tbl.schema_id) = @P1
-            AND tbl.is_ms_shipped = 0
-            AND tbl.type = 'U'
+                AND tbl.is_ms_shipped = 0
+                AND tbl.type = 'U'
             ORDER BY tbl.name;
         "#;
 
@@ -387,7 +387,7 @@ impl<'a> SqlSchemaDescriber<'a> {
                 ind.is_unique AS is_unique,
                 ind.is_unique_constraint AS is_unique_constraint,
                 ind.is_primary_key AS is_primary_key,
-                ind.type_desc as clustering,
+                ind.type_desc AS clustering,
                 col.name AS column_name,
                 ic.key_ordinal AS seq_in_index,
                 ic.is_descending_key AS is_descending,
@@ -401,6 +401,8 @@ impl<'a> SqlSchemaDescriber<'a> {
             INNER JOIN
                 sys.tables t ON ind.object_id = t.object_id
             WHERE SCHEMA_NAME(t.schema_id) = @P1
+                -- https://docs.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-index-columns-transact-sql?view=sql-server-ver16
+                AND ic.key_ordinal != 0
                 AND t.is_ms_shipped = 0
                 AND ind.filter_definition IS NULL
                 AND ind.name IS NOT NULL
@@ -428,7 +430,7 @@ impl<'a> SqlSchemaDescriber<'a> {
 
             let clustered = row.get_expect_string("clustering").starts_with("CLUSTERED");
 
-            let column_name = row.get("column_name").and_then(|x| x.to_string()).unwrap();
+            let column_name = row.get_expect_string("column_name");
             let column_id = if let Some(col) = sql_schema.walk(table_id).column(&column_name) {
                 col.id
             } else {


### PR DESCRIPTION
On MSSQL, indexes can have an `INCLUDE` clause. Columns listed in that
clause are _not part of the key_, meaning they are not indexed, but they
are stored at the leaf. This is useful for queries that only care about
columns that are part of the key or INCLUDed: they will not need to
fetch the whole tuple from the main table, the query can be resolved
purely from the index. This commit changes sql-schema-describer to
ignore included columns: they are not part of the index and should not
show up in introspected schemas.

Before Prisma 4.1, we already erroneously introspected the included columns
as part of the index. Due to a data structure change in 4.1, we
continued wrongly introspecting them, but _at the end of a different
index_ (the previous one), potentially on another model, triggering the
error about "your friendly prisma developers" you can see in the issues
below.

See the official docs on included columns:
https://docs.microsoft.com/en-us/sql/t-sql/statements/create-index-transact-sql?view=sql-server-ver16#include-column---n--

closes https://github.com/prisma/prisma/issues/14636
closes https://github.com/prisma/prisma/issues/14438
closes https://github.com/prisma/prisma/issues/14403
closes https://github.com/prisma/prisma/issues/14511
closes https://github.com/prisma/prisma/issues/14611
closes https://github.com/prisma/prisma/issues/14647
closes https://github.com/prisma/prisma/issues/14462