### PR TITLE
load the metric descriptions in a tokio runtime

### DIFF
--- a/query-engine/core/src/metrics/mod.rs
+++ b/query-engine/core/src/metrics/mod.rs
@@ -75,7 +75,7 @@ pub fn setup() {
 // Describe all metric here so that every time for create
 // a new metric registry for a Query Instance the descriptions
 // will be in place
-fn describe_metrics() {
+pub fn describe_metrics() {
     describe_counter!(
         "prisma_pool_connections_opened_total",
         "Total number of Pool Connections opened"


### PR DESCRIPTION
Not all the descriptions for metrics were being set at creation of the prisma instance. We ended up in situations like this:

```js
{
histograms: [
    {
      key: 'prisma_client_queries_duration_histogram_ms',
      labels: {},
      value: [Object],
      description: ''
    },
    {
      key: 'prisma_client_queries_wait_histogram_ms',
      labels: {},
      value: [Object],
      description: 'Histogram of the wait time of all Prisma Client Queries in ms'
    },
    {
      key: 'prisma_datasource_queries_duration_histogram_ms',
      labels: {},
      value: [Object],
      description: 'Histogram of the duration of all executed Datasource Queries in ms'
    }
  ]

```

We have a function `describe_metrics` that runs and sets the default values for our metrics and the descriptions. The problem we had was that it was not being run with our logging dispatcher set. So the metric configuration did not reach the registry and was not recorded. 
This changes it run the descriptions in a tokio async task with the correct dispatcher set. 
I've also renamed the `env` coming from napi because there is also the default `env` macro that was being used. This was really confusing. 