### PR TITLE
remove cli flag + hide engine connect & disconnect spans

### DIFF
--- a/query-engine/query-engine-node-api/src/engine.rs
+++ b/query-engine/query-engine-node-api/src/engine.rs
@@ -205,7 +205,7 @@ impl QueryEngine {
         let dispatcher = self.logger.dispatcher();
 
         async_panic_to_js_error(async {
-            let span = tracing::info_span!("prisma:engine:connect", user_facing = true);
+            let span = tracing::info_span!("prisma:engine:connect");
             let _ = set_parent_context_from_json_str(&span, &trace);
 
             let mut inner = self.inner.write().await;
@@ -268,7 +268,7 @@ impl QueryEngine {
         let dispatcher = self.logger.dispatcher();
 
         async_panic_to_js_error(async {
-            let span = tracing::info_span!("prisma:engine:disconnect", user_facing = true);
+            let span = tracing::info_span!("prisma:engine:disconnect");
             let _ = set_parent_context_from_json_str(&span, &trace);
 
             async {

--- a/query-engine/query-engine/src/opt.rs
+++ b/query-engine/query-engine/src/opt.rs
@@ -107,10 +107,6 @@ pub struct PrismaOpt {
     #[structopt(long, default_value)]
     pub open_telemetry_endpoint: String,
 
-    /// JSON object for tracing headers such as the traceparent
-    #[structopt(long)]
-    pub tracing_headers: Option<String>,
-
     #[structopt(subcommand)]
     pub subcommand: Option<Subcommand>,
 }

--- a/query-engine/query-engine/src/opt.rs
+++ b/query-engine/query-engine/src/opt.rs
@@ -108,8 +108,8 @@ pub struct PrismaOpt {
     pub open_telemetry_endpoint: String,
 
     /// JSON object for tracing headers such as the traceparent
-    #[structopt(long, default_value = "{}")]
-    pub tracing_headers: String,
+    #[structopt(long)]
+    pub tracing_headers: Option<String>,
 
     #[structopt(subcommand)]
     pub subcommand: Option<Subcommand>,

--- a/query-engine/query-engine/src/server/mod.rs
+++ b/query-engine/query-engine/src/server/mod.rs
@@ -3,7 +3,7 @@ use datamodel::common::preview_features::PreviewFeature;
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{header::CONTENT_TYPE, Body, HeaderMap, Method, Request, Response, Server, StatusCode};
 use opentelemetry::{global, propagation::Extractor, Context};
-use query_core::{schema::QuerySchemaRenderer, set_parent_context_from_json_str, TxId};
+use query_core::{schema::QuerySchemaRenderer, TxId};
 use query_core::{MetricFormat, MetricRegistry};
 use request_handlers::{dmmf, GraphQLSchemaRenderer, GraphQlHandler, TxInput};
 use serde_json::json;
@@ -63,6 +63,8 @@ impl Clone for State {
 pub async fn setup(opts: &PrismaOpt, metrics: MetricRegistry) -> PrismaResult<State> {
     let config = opts.configuration(false)?.subject;
     config.validate_that_one_datasource_is_provided()?;
+
+    let span = tracing::info_span!("prisma:engine:connect");
 
     let enable_itx = config
         .preview_features()

--- a/query-engine/query-engine/src/server/mod.rs
+++ b/query-engine/query-engine/src/server/mod.rs
@@ -65,7 +65,10 @@ pub async fn setup(opts: &PrismaOpt, metrics: MetricRegistry) -> PrismaResult<St
     config.validate_that_one_datasource_is_provided()?;
 
     let span = tracing::info_span!("prisma:engine:connect", user_facing = true);
-    let _ = set_parent_context_from_json_str(&span, &(opts.tracing_headers));
+
+    if let Some(tracing_headers) = &opts.tracing_headers {
+        let _ = set_parent_context_from_json_str(&span, tracing_headers);
+    }
 
     let enable_itx = config
         .preview_features()

--- a/query-engine/query-engine/src/server/mod.rs
+++ b/query-engine/query-engine/src/server/mod.rs
@@ -64,12 +64,6 @@ pub async fn setup(opts: &PrismaOpt, metrics: MetricRegistry) -> PrismaResult<St
     let config = opts.configuration(false)?.subject;
     config.validate_that_one_datasource_is_provided()?;
 
-    let span = tracing::info_span!("prisma:engine:connect", user_facing = true);
-
-    if let Some(tracing_headers) = &opts.tracing_headers {
-        let _ = set_parent_context_from_json_str(&span, tracing_headers);
-    }
-
     let enable_itx = config
         .preview_features()
         .contains(PreviewFeature::InteractiveTransactions);

--- a/query-engine/query-engine/src/tests/dmmf.rs
+++ b/query-engine/query-engine/src/tests/dmmf.rs
@@ -112,7 +112,6 @@ fn test_dmmf_cli_command(schema: &str) -> PrismaResult<()> {
         subcommand: Some(Subcommand::Cli(CliOpt::Dmmf)),
         enable_open_telemetry: false,
         open_telemetry_endpoint: String::new(),
-        tracing_headers: None,
     };
 
     let cli_cmd = CliCommand::from_opt(&prisma_opt)?.unwrap();

--- a/query-engine/query-engine/src/tests/dmmf.rs
+++ b/query-engine/query-engine/src/tests/dmmf.rs
@@ -112,6 +112,7 @@ fn test_dmmf_cli_command(schema: &str) -> PrismaResult<()> {
         subcommand: Some(Subcommand::Cli(CliOpt::Dmmf)),
         enable_open_telemetry: false,
         open_telemetry_endpoint: String::new(),
+        tracing_headers: None,
     };
 
     let cli_cmd = CliCommand::from_opt(&prisma_opt)?.unwrap();


### PR DESCRIPTION
## Overview

- Removes `tracing_headers` CLI flag
- Hides connect & disconnect spans in library mode
- Remove connect span in binary mode