### PR TITLE
feat(qe): Capture query logs and return with response

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,7 @@ validate:
 	cargo run --bin test-cli -- validate-datamodel dev_datamodel.prisma
 
 qe:
-	cargo run --bin query-engine -- --enable-playground --enable-raw-queries --enable-metrics --enable-open-telemetry
+	cargo run --bin query-engine -- --enable-playground --enable-raw-queries --enable-metrics --enable-open-telemetry --enable-logs-in-response
 
 qe-dmmf:
 	cargo run --bin query-engine -- cli dmmf > dmmf.json

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/binary.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/binary.rs
@@ -2,7 +2,8 @@ use crate::{ConnectorTag, RunnerInterface, TestError, TestResult, TxResult};
 use hyper::{Body, Method, Request, Response};
 use query_core::{schema::QuerySchemaRef, TxId};
 use query_engine::opt::PrismaOpt;
-use query_engine::server::{routes, setup, State};
+use query_engine::server::routes;
+use query_engine::state::{init_state, State};
 use query_engine_metrics::MetricRegistry;
 use request_handlers::{GQLBatchResponse, GQLError, GQLResponse, GraphQlBody, MultiQuery, PrismaResponse};
 
@@ -16,7 +17,7 @@ pub struct BinaryRunner {
 impl RunnerInterface for BinaryRunner {
     async fn load(datamodel: String, connector_tag: ConnectorTag, metrics: MetricRegistry) -> TestResult<Self> {
         let opts = PrismaOpt::from_list(&["binary", "--enable-raw-queries", "--datamodel", &datamodel]);
-        let state = setup(&opts, metrics).await.unwrap();
+        let state = init_state(&opts, false, Some(metrics)).await.unwrap();
 
         Ok(BinaryRunner {
             state,

--- a/query-engine/core/src/trace_helpers/mod.rs
+++ b/query-engine/core/src/trace_helpers/mod.rs
@@ -1,6 +1,7 @@
 use once_cell::sync::Lazy;
 use opentelemetry::sdk::export::trace::SpanData;
-use opentelemetry::trace::TraceContextExt;
+use opentelemetry::trace::{TraceContextExt, TraceId};
+use opentelemetry::Context;
 use serde_json::{json, Value};
 use std::borrow::Cow;
 
@@ -93,6 +94,11 @@ pub fn set_span_link_from_trace_id(span: &Span, trace_id: Option<String>) {
         let context_span = cx.span();
         span.add_link(context_span.span_context().clone());
     }
+}
+
+pub fn get_trace_id_from_context(context: &Context) -> TraceId {
+    let context_span = context.span();
+    context_span.span_context().trace_id()
 }
 
 pub fn is_user_facing_trace_filter(meta: &Metadata) -> bool {

--- a/query-engine/core/src/trace_helpers/mod.rs
+++ b/query-engine/core/src/trace_helpers/mod.rs
@@ -43,7 +43,9 @@ pub struct CapturedLog {
     name: String,
     start_time: [u64; 2],
     end_time: [u64; 2],
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
     attributes: HashMap<String, String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     links: Vec<Link>,
 }
 

--- a/query-engine/query-engine/src/capture_tracer.rs
+++ b/query-engine/query-engine/src/capture_tracer.rs
@@ -1,0 +1,108 @@
+use async_trait::async_trait;
+use opentelemetry::{
+    global,
+    sdk::{
+        self,
+        export::trace::{ExportResult, SpanData, SpanExporter},
+        propagation::TraceContextPropagator,
+    },
+    trace::{TraceId, TracerProvider},
+};
+use query_core::spans_to_json;
+use std::fmt::Debug;
+use std::{collections::HashMap, sync::Arc};
+use tokio::sync::Mutex;
+
+/// Pipeline builder
+#[derive(Debug)]
+pub struct PipelineBuilder {
+    trace_config: Option<sdk::trace::Config>,
+}
+
+/// Create a new stdout exporter pipeline builder.
+pub fn new_pipeline() -> PipelineBuilder {
+    PipelineBuilder::default()
+}
+
+impl Default for PipelineBuilder {
+    /// Return the default pipeline builder.
+    fn default() -> Self {
+        Self { trace_config: None }
+    }
+}
+
+impl PipelineBuilder {
+    /// Assign the SDK trace configuration.
+    pub fn with_trace_config(mut self, config: sdk::trace::Config) -> Self {
+        self.trace_config = Some(config);
+        self
+    }
+}
+
+impl PipelineBuilder {
+    pub fn install_simple(mut self, exporter: CaptureExporter) -> sdk::trace::Tracer {
+        global::set_text_map_propagator(TraceContextPropagator::new());
+
+        let mut provider_builder = sdk::trace::TracerProvider::builder().with_simple_exporter(exporter);
+        if let Some(config) = self.trace_config.take() {
+            provider_builder = provider_builder.with_config(config);
+        }
+        let provider = provider_builder.build();
+        let tracer = provider.tracer("opentelemetry");
+        global::set_tracer_provider(provider);
+
+        tracer
+    }
+}
+
+/// A [`CaptureExporter`] that sends spans to stdout.
+#[derive(Debug, Clone)]
+pub struct CaptureExporter {
+    logs: Arc<Mutex<HashMap<TraceId, Vec<SpanData>>>>,
+}
+
+impl CaptureExporter {
+    pub fn new() -> Self {
+        Self {
+            logs: Default::default(),
+        }
+    }
+
+    pub async fn capture(&self, trace_id: TraceId) {
+        let mut logs = self.logs.lock().await;
+        logs.insert(trace_id, Vec::new());
+    }
+
+    pub async fn get(&self, trace_id: TraceId) -> String {
+        let mut logs = self.logs.lock().await;
+        if let Some(spans) = logs.remove(&trace_id) {
+            spans_to_json(&spans)
+        } else {
+            String::new()
+        }
+    }
+}
+
+impl Default for CaptureExporter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl SpanExporter for CaptureExporter {
+    async fn export(&mut self, batch: Vec<SpanData>) -> ExportResult {
+        let batch = batch.into_iter().filter(|span| span.name == "quaint:query");
+
+        let mut logs = self.logs.lock().await;
+        for span in batch {
+            let trace_id = span.span_context.trace_id();
+
+            if let Some(spans) = logs.get_mut(&trace_id) {
+                spans.push(span)
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/query-engine/query-engine/src/capture_tracer.rs
+++ b/query-engine/query-engine/src/capture_tracer.rs
@@ -8,7 +8,7 @@ use opentelemetry::{
     },
     trace::{TraceId, TracerProvider},
 };
-use query_core::spans_to_json;
+use query_core::CapturedLog;
 use std::fmt::Debug;
 use std::{collections::HashMap, sync::Arc};
 use tokio::sync::Mutex;
@@ -73,12 +73,12 @@ impl CaptureExporter {
         logs.insert(trace_id, Vec::new());
     }
 
-    pub async fn get(&self, trace_id: TraceId) -> String {
+    pub async fn get_logs(&self, trace_id: TraceId) -> Vec<CapturedLog> {
         let mut logs = self.logs.lock().await;
         if let Some(spans) = logs.remove(&trace_id) {
-            spans_to_json(&spans)
+            spans.iter().map(CapturedLog::from).collect()
         } else {
-            String::new()
+            vec![]
         }
     }
 }

--- a/query-engine/query-engine/src/lib.rs
+++ b/query-engine/query-engine/src/lib.rs
@@ -1,11 +1,13 @@
 #![allow(clippy::derive_partial_eq_without_eq)]
 
+pub mod capture_tracer;
 pub mod cli;
 pub mod context;
 pub mod error;
 pub mod logger;
 pub mod opt;
 pub mod server;
+pub mod state;
 pub mod tracer;
 
 use error::PrismaError;

--- a/query-engine/query-engine/src/opt.rs
+++ b/query-engine/query-engine/src/opt.rs
@@ -103,6 +103,10 @@ pub struct PrismaOpt {
     #[structopt(long)]
     pub enable_open_telemetry: bool,
 
+    #[structopt(long)]
+    /// Enable tracer to capture logs and return in the response
+    pub enable_logs_in_response: bool,
+
     /// The url to the OpenTelemetry collector.
     /// Enabling this will send the OpenTelemtry tracing to a collector
     /// and not via our custom stdout tracer

--- a/query-engine/query-engine/src/server/mod.rs
+++ b/query-engine/query-engine/src/server/mod.rs
@@ -457,32 +457,21 @@ impl Default for LogCapture {
 
 fn process_gql_req_headers(req: &Request<Body>) -> (Option<TxId>, Span, LogCapture, Option<String>) {
     let tx_id = get_transaction_id_from_header(req);
-    // this is the case no transaction is in flight. What do we do when there's an ongoing transaction?
+    // TODO: this is the case no transaction is in flight. What do we do when there's an ongoing transaction?
     let (span, log_capture) = if tx_id.is_none() {
         let span = info_span!("prisma:engine", user_facing = true);
         let cx = get_parent_span_context(req);
         if let Some(context) = cx.clone() {
-            let span_ctx = span.context();
-            dbg!(get_trace_id_from_context(&span_ctx));
             span.set_parent(context);
         }
 
         let context = span.context();
         let trace_id = get_trace_id_from_context(&context);
-        dbg!(trace_id);
-
-        if let Some(context) = cx.clone() {
-            let parent_trace_id = get_trace_id_from_context(&context);
-            dbg!(parent_trace_id);
-        }
-
-        // Here trace_id is 0 (Invalid, there's no previous trace, we might want to create one)
-        // however when spans are created it assigns a new trace_id to them. Let me check were
         let log_capture = LogCapture::new_from_req(trace_id, req);
 
         (span, log_capture)
     } else {
-        // Is this case unimplemented yet? ask alexey.
+        // TODO: Is this case unimplemented yet? ask alexey.
         (Span::none(), LogCapture::default())
     };
 

--- a/query-engine/query-engine/src/server/mod.rs
+++ b/query-engine/query-engine/src/server/mod.rs
@@ -140,7 +140,13 @@ async fn graphql_handler(state: State, req: Request<Body>) -> Result<Response<Bo
 
                 let result_bytes = if log_capture.should_capture() {
                     tokio::time::sleep(Duration::from_millis(1)).await;
-                    let logs = state.cx.inflight_tracer.as_ref().unwrap().get(log_capture.id()).await;
+                    let logs = state
+                        .cx
+                        .inflight_tracer
+                        .as_ref()
+                        .unwrap()
+                        .get_logs(log_capture.id())
+                        .await;
                     let json = json!({
                         "result": result,
                         "logs": logs

--- a/query-engine/query-engine/src/server/mod.rs
+++ b/query-engine/query-engine/src/server/mod.rs
@@ -13,7 +13,7 @@ use serde_json::json;
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 use tracing::{field, Instrument, Span};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
@@ -139,7 +139,8 @@ async fn graphql_handler(state: State, req: Request<Body>) -> Result<Response<Bo
                 let result = handler.handle(body, tx_id, trace_id.clone()).instrument(span).await;
 
                 let result_bytes = if log_capture.should_capture() {
-                    tokio::time::sleep(Duration::from_millis(1)).await;
+                    global::force_flush_tracer_provider();
+
                     let logs = state
                         .cx
                         .inflight_tracer
@@ -147,6 +148,7 @@ async fn graphql_handler(state: State, req: Request<Body>) -> Result<Response<Bo
                         .unwrap()
                         .get_logs(log_capture.id())
                         .await;
+
                     let json = json!({
                         "result": result,
                         "logs": logs

--- a/query-engine/query-engine/src/server/mod.rs
+++ b/query-engine/query-engine/src/server/mod.rs
@@ -463,7 +463,7 @@ fn process_gql_req_headers(req: &Request<Body>) -> (Option<TxId>, Span, LogCaptu
     let (span, log_capture) = if tx_id.is_none() {
         let span = info_span!("prisma:engine", user_facing = true);
         let cx = get_parent_span_context(req);
-        if let Some(context) = cx.clone() {
+        if let Some(context) = cx {
             span.set_parent(context);
         }
 

--- a/query-engine/query-engine/src/state.rs
+++ b/query-engine/query-engine/src/state.rs
@@ -1,0 +1,97 @@
+use crate::{context::PrismaContext, logger::Logger, opt::PrismaOpt, PrismaResult};
+use psl::PreviewFeature;
+use query_core::schema::QuerySchemaRef;
+use query_engine_metrics::{setup as metric_setup, MetricRegistry};
+use std::sync::Arc;
+use tracing::Instrument;
+
+//// Shared application state.
+pub struct State {
+    pub cx: Arc<PrismaContext>,
+    pub enable_playground: bool,
+    pub enable_debug_mode: bool,
+    pub enable_metrics: bool,
+}
+
+impl State {
+    /// Create a new instance of `State`.
+    fn new(cx: PrismaContext, enable_playground: bool, enable_debug_mode: bool, enable_metrics: bool) -> Self {
+        Self {
+            cx: Arc::new(cx),
+            enable_playground,
+            enable_debug_mode,
+            enable_metrics,
+        }
+    }
+
+    pub fn get_metrics(&self) -> MetricRegistry {
+        self.cx.metrics.clone()
+    }
+
+    pub fn query_schema(&self) -> &QuerySchemaRef {
+        self.cx.query_schema()
+    }
+}
+
+impl Clone for State {
+    fn clone(&self) -> Self {
+        Self {
+            cx: self.cx.clone(),
+            enable_playground: self.enable_playground,
+            enable_debug_mode: self.enable_debug_mode,
+            enable_metrics: self.enable_metrics,
+        }
+    }
+}
+
+pub async fn init_state(
+    opts: &PrismaOpt,
+    install_logger: bool,
+    metrics: Option<MetricRegistry>,
+) -> PrismaResult<State> {
+    let metrics = if metrics.is_none() {
+        MetricRegistry::new()
+    } else {
+        metrics.unwrap()
+    };
+
+    let mut logger = Logger::new("prisma-engine-http");
+    logger.log_format(opts.log_format());
+    logger.log_queries(opts.log_queries());
+    logger.enable_telemetry(opts.enable_open_telemetry);
+    logger.telemetry_endpoint(&opts.open_telemetry_endpoint);
+    logger.enable_metrics(metrics.clone());
+
+    let logs_capture = if opts.enable_logs_in_response {
+        let exporter = logger.enable_logs_capture();
+        Some(exporter)
+    } else {
+        None
+    };
+
+    if install_logger {
+        logger.install().unwrap();
+    }
+
+    if opts.enable_metrics || opts.dataproxy_metric_override {
+        metric_setup();
+    }
+
+    let datamodel = opts.schema(false)?;
+    let config = &datamodel.configuration;
+    config.validate_that_one_datasource_is_provided()?;
+
+    let enable_metrics = config.preview_features().contains(PreviewFeature::Metrics) || opts.dataproxy_metric_override;
+    let span = tracing::info_span!("prisma:engine:connect");
+
+    let cx = PrismaContext::builder(datamodel) //  opts.enable_raw_queries, metrics, logs_capture)
+        .set_metrics(metrics)
+        .set_logs_capture_tracer(logs_capture)
+        .enable_raw_queries(opts.enable_raw_queries)
+        .build()
+        .instrument(span)
+        .await?;
+
+    let state = State::new(cx, opts.enable_playground, opts.enable_debug_mode, enable_metrics);
+    Ok(state)
+}

--- a/query-engine/query-engine/src/tests/dmmf.rs
+++ b/query-engine/query-engine/src/tests/dmmf.rs
@@ -94,6 +94,7 @@ fn test_dmmf_cli_command(schema: &str) -> PrismaResult<()> {
         subcommand: Some(Subcommand::Cli(CliOpt::Dmmf)),
         enable_open_telemetry: false,
         open_telemetry_endpoint: String::new(),
+        enable_logs_in_response: false,
         dataproxy_metric_override: false,
     };
 


### PR DESCRIPTION
Tracked in https://github.com/prisma/client-planning/issues/158

The Query engine server can use a new capture tracer that can
capture the query logs for a Prisma Operation and return them
as part of the response.

For the logs to be captured, start up the query engine with the flag `--enable-logs-in-response`.
For each query pass in a traceparent in the `traceparent` header. The trace-id is used to keep track of the relevant logs.
For each request you want a log response back add the header: `CAPTURE_LOGS: true`.

The response will then look like this:
```js
{
  "result": result,
  "logs": logs
};
```