### PR TITLE
psl: add direct access to fields to IndexWalker

### DIFF
--- a/libs/datamodel/parser-database/src/walkers/index.rs
+++ b/libs/datamodel/parser-database/src/walkers/index.rs
@@ -75,6 +75,35 @@ impl<'db> IndexWalker<'db> {
         self.index_attribute
     }
 
+    fn fields_array(self) -> &'db [ast::Expression] {
+        self.ast_attribute()
+            .arguments
+            .arguments
+            .iter()
+            .find(|arg| match &arg.name {
+                Some(ident) if ident.name == "" || ident.name == "fields" => true,
+                None => true,
+                Some(_) => false,
+            })
+            .and_then(|arg| arg.value.as_array())
+            .unwrap()
+            .0
+    }
+
+    /// Iterate over all the names in all the paths in the fields argument.
+    ///
+    /// For example, `@@index([a, b.c.d])` would return an iterator over "a", "b", "c", "d".
+    pub fn all_field_names(self) -> impl Iterator<Item = &'db str> {
+        self.fields_array()
+            .iter()
+            .map(|path| match path {
+                ast::Expression::ConstantValue(name, _) => name,
+                ast::Expression::Function(name, _, _) => name,
+                _ => unreachable!(),
+            })
+            .flat_map(|name| name.split('.'))
+    }
+
     /// The scalar fields covered by the index.
     pub fn fields(self) -> impl ExactSizeIterator<Item = IndexFieldWalker<'db>> {
         self.index_attribute.fields.iter().map(move |attributes| {

--- a/libs/datamodel/schema-ast/src/ast/expression.rs
+++ b/libs/datamodel/schema-ast/src/ast/expression.rs
@@ -36,6 +36,13 @@ impl fmt::Display for Expression {
 }
 
 impl Expression {
+    pub fn as_array(&self) -> Option<(&[Expression], Span)> {
+        match self {
+            Expression::Array(arr, span) => Some((arr, *span)),
+            _=> None
+        }
+    }
+
     pub fn as_string_value(&self) -> Option<(&str, Span)> {
         match self {
             Expression::StringValue(s, span) => Some((s, *span)),


### PR DESCRIPTION
We have too many layers of indirection, and are losing too much source
information in parser-database. The layers come from from needing
specific information in validations that needed to be resolved
_somewhere_, and that information was lost after parser-database, and
partly from not having a good AST data structure, that makes us lose
that information in the first place. This PR adds a method to dig
through the AST to the `fields: [...]` array inside an index. This will
become significantly easier when we replace the current SchemaAst
structure.