### PR TITLE
refactor(psl): simplify preview features handling

### DIFF
--- a/libs/datamodel/core/src/configuration/configuration_struct.rs
+++ b/libs/datamodel/core/src/configuration/configuration_struct.rs
@@ -37,9 +37,9 @@ impl Configuration {
     }
 
     pub fn preview_features(&self) -> BitFlags<PreviewFeature> {
-        self.generators
-            .iter()
-            .fold(BitFlags::empty(), |acc, generator| acc | generator.preview_features())
+        self.generators.iter().fold(BitFlags::empty(), |acc, generator| {
+            acc | generator.preview_features.unwrap_or_default()
+        })
     }
 
     pub fn resolve_datasource_urls_from_env<F>(

--- a/libs/datamodel/core/src/lib.rs
+++ b/libs/datamodel/core/src/lib.rs
@@ -199,7 +199,7 @@ pub fn render_datamodel_and_config_to_string(
 }
 
 fn preview_features(generators: &[Generator]) -> BitFlags<PreviewFeature> {
-    generators.iter().map(|gen| gen.preview_features()).collect()
+    generators.iter().filter_map(|gen| gen.preview_features).collect()
 }
 
 const DEFAULT_INDENT_WIDTH: usize = 2;

--- a/prisma-fmt/src/preview.rs
+++ b/prisma-fmt/src/preview.rs
@@ -1,5 +1,5 @@
 use datamodel::common::preview_features::GENERATOR;
 
 pub fn run() -> String {
-    serde_json::to_string(&GENERATOR.active_features()).unwrap()
+    serde_json::to_string(&GENERATOR.active_features().iter().collect::<Vec<_>>()).unwrap()
 }


### PR DESCRIPTION
- Bitflags instead of arrays make any set of preview features a single
  32 bit integer, instead of an allocated vector of enum values.