### PR TITLE
fix(qe): don't crash when executing request via CLI

### DIFF
--- a/query-engine/query-engine/src/context.rs
+++ b/query-engine/query-engine/src/context.rs
@@ -45,7 +45,7 @@ impl ContextBuilder {
             self.config,
             self.datamodel,
             self.enable_raw_queries,
-            self.metrics.unwrap(),
+            self.metrics.unwrap_or_default(),
         )
         .await
     }


### PR DESCRIPTION
Fix the panic when using `query-engine cli execute-request`:

```
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', /Users/aqrln/prisma/prisma-engines/query-engine/query-engine/src/context.rs:48:26
```

My first thought was to get rid of the `Option` here entirely, but the struct looked heavy-ish and it felt wrong to set it to `Default::default()` unconditionally in `PrismaContext::builder` given that it would be overwritten anyway in the most important code path, while passing it as a parameter of `builder` similar to `config` and `datamodel` would kinda defeats the purpose of the builder pattern here. So leaving it as an `Option` seems the best option here, it just that `unwrap()` needs to be changed to `unwrap_or_default()`.