### PR TITLE
psl: multi schema initial implementation 

### DIFF
--- a/libs/datamodel/connectors/datamodel-connector/src/capabilities.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/capabilities.rs
@@ -44,7 +44,6 @@ capabilities!(
     // General capabilities, not specific to any part of Prisma.
     ScalarLists,
     Enums,
-    EnumArrayPush,
     Json,
     JsonLists,
     AutoIncrement,
@@ -53,6 +52,7 @@ capabilities!(
     DefaultValueAuto,
     TwoWayEmbeddedManyToManyRelation,
     ImplicitManyToManyRelation,
+    MultiSchema,
     //Start of ME/IE only capabilities
     AutoIncrementAllowedOnNonId,
     AutoIncrementMultipleAllowed,
@@ -68,6 +68,7 @@ capabilities!(
     MultipleFullTextAttributesPerModel,
     ClusteringSetting,
     // Start of query-engine-only Capabilities
+    EnumArrayPush,
     InsensitiveFilters,
     CreateMany,
     CreateManyWriteableAutoIncId,

--- a/libs/datamodel/connectors/datamodel-connector/src/lib.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/lib.rs
@@ -105,6 +105,7 @@ pub trait Connector: Send + Sync {
     ) {
     }
 
+    fn validate_enum(&self, _enum: parser_database::walkers::EnumWalker<'_>, _: &mut Diagnostics) {}
     fn validate_model(&self, _model: parser_database::walkers::ModelWalker<'_>, _: &mut Diagnostics) {}
 
     fn validate_scalar_field_unknown_default_functions(

--- a/libs/datamodel/connectors/dml/src/enum.rs
+++ b/libs/datamodel/connectors/dml/src/enum.rs
@@ -13,6 +13,8 @@ pub struct Enum {
     pub database_name: Option<String>,
     /// Has to be commented out.
     pub commented_out: bool,
+    /// The contents of the `@@schema("...")` attribute.
+    pub schema: Option<String>,
 }
 
 impl Enum {
@@ -24,6 +26,7 @@ impl Enum {
             documentation: None,
             database_name: None,
             commented_out: false,
+            schema: None,
         }
     }
 

--- a/libs/datamodel/connectors/dml/src/model.rs
+++ b/libs/datamodel/connectors/dml/src/model.rs
@@ -26,6 +26,8 @@ pub struct Model {
     pub is_commented_out: bool,
     /// Indicates if this model has to be ignored by the Client.
     pub is_ignored: bool,
+    /// The contents of the `@@schema("...")` attribute.
+    pub schema: Option<String>,
 }
 
 #[derive(Debug, PartialEq, Clone, Copy)]
@@ -335,6 +337,7 @@ impl Model {
             is_generated: false,
             is_commented_out: false,
             is_ignored: false,
+            schema: None,
         }
     }
 

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/mssql_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/mssql_datamodel_connector.rs
@@ -89,6 +89,7 @@ const CAPABILITIES: &[ConnectorCapability] = &[
     ConnectorCapability::AutoIncrementNonIndexedAllowed,
     ConnectorCapability::CompoundIds,
     ConnectorCapability::CreateMany,
+    ConnectorCapability::MultiSchema,
     ConnectorCapability::NamedDefaultValues,
     ConnectorCapability::NamedForeignKeys,
     ConnectorCapability::NamedPrimaryKeys,

--- a/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
+++ b/libs/datamodel/connectors/sql-datamodel-connector/src/postgres_datamodel_connector.rs
@@ -96,6 +96,7 @@ const CAPABILITIES: &[ConnectorCapability] = &[
     ConnectorCapability::Json,
     ConnectorCapability::JsonFilteringArrayPath,
     ConnectorCapability::JsonFilteringAlphanumeric,
+    ConnectorCapability::MultiSchema,
     ConnectorCapability::NamedForeignKeys,
     ConnectorCapability::NamedPrimaryKeys,
     ConnectorCapability::SqlQueryRaw,

--- a/libs/datamodel/core/src/common/preview_features.rs
+++ b/libs/datamodel/core/src/common/preview_features.rs
@@ -64,6 +64,7 @@ features!(
     ImprovedQueryRaw,
     Metrics,
     OrderByNulls,
+    MultiSchema,
 );
 
 /// Generator preview features
@@ -102,7 +103,7 @@ pub const GENERATOR: FeatureMap = FeatureMap {
         | ImprovedQueryRaw
         | DataProxy
     }),
-    hidden: BitFlags::EMPTY,
+    hidden: enumflags2::make_bitflags!(PreviewFeature::{MultiSchema}),
 };
 
 #[derive(Debug)]

--- a/libs/datamodel/core/src/configuration/datasource.rs
+++ b/libs/datamodel/core/src/configuration/datasource.rs
@@ -21,6 +21,9 @@ pub struct Datasource {
     pub shadow_database_url: Option<(StringFromEnvVar, Span)>,
     /// In which layer referential actions are handled.
     pub referential_integrity: Option<ReferentialIntegrity>,
+    /// _Sorted_ vec of schemas defined in the schemas property.
+    pub(crate) schemas: Vec<(String, Span)>,
+    pub(crate) schemas_span: Option<Span>,
 }
 
 impl std::fmt::Debug for Datasource {
@@ -32,13 +35,18 @@ impl std::fmt::Debug for Datasource {
             .field("url", &"<url>")
             .field("documentation", &self.documentation)
             .field("active_connector", &&"...")
-            .field("shadow_database_url", &self.shadow_database_url)
+            .field("shadow_database_url", &"<shadow_database_url>")
             .field("referential_integrity", &self.referential_integrity)
+            .field("schemas", &self.schemas)
             .finish()
     }
 }
 
 impl Datasource {
+    pub(crate) fn has_schema(&self, name: &str) -> bool {
+        self.schemas.binary_search_by_key(&name, |(s, _)| s).is_ok()
+    }
+
     pub fn capabilities(&self) -> ConnectorCapabilities {
         let capabilities = self.active_connector.capabilities().to_owned();
 

--- a/libs/datamodel/core/src/lift.rs
+++ b/libs/datamodel/core/src/lift.rs
@@ -307,6 +307,7 @@ impl<'a> LiftAstToDml<'a> {
         model.documentation = ast_model.documentation().map(String::from);
         model.database_name = walker.mapped_name().map(String::from);
         model.is_ignored = walker.is_ignored();
+        model.schema = walker.schema().map(|(s, _)| s.to_owned());
 
         model.primary_key = walker.primary_key().map(|pk| dml::PrimaryKeyDefinition {
             name: pk.name().map(String::from),
@@ -433,6 +434,7 @@ impl<'a> LiftAstToDml<'a> {
 
         en.documentation = r#enum.ast_enum().documentation().map(String::from);
         en.database_name = r#enum.mapped_name().map(String::from);
+        en.schema = r#enum.schema().map(|(s, _)| s.to_owned());
         en
     }
 

--- a/libs/datamodel/core/src/validate/validation_pipeline/validations.rs
+++ b/libs/datamodel/core/src/validate/validation_pipeline/validations.rs
@@ -3,6 +3,7 @@ mod composite_types;
 mod constraint_namespace;
 mod database_name;
 mod default_value;
+mod enums;
 mod fields;
 mod indexes;
 mod models;
@@ -161,6 +162,25 @@ pub(super) fn validate(ctx: &mut Context<'_>) {
         for model in ctx.db.walk_models() {
             models::schema_exists(model, ctx);
             models::schema_capability(model, ctx);
+        }
+
+        for r#enum in ctx.db.walk_enums() {
+            enums::schema_exists(r#enum, ctx);
+            enums::schema_capability(r#enum, ctx);
+        }
+
+        if !ctx
+            .connector
+            .has_capability(datamodel_connector::ConnectorCapability::MultiSchema)
+        {
+            if let Some(ds) = ctx.datasource {
+                if let Some(span) = ds.schemas_span {
+                    ctx.push_error(DatamodelError::new_static(
+                        "The `schemas` property is not supported on the current connector.",
+                        span,
+                    ))
+                }
+            }
         }
     }
 

--- a/libs/datamodel/core/src/validate/validation_pipeline/validations/enums.rs
+++ b/libs/datamodel/core/src/validate/validation_pipeline/validations/enums.rs
@@ -1,0 +1,30 @@
+use crate::{
+    datamodel_connector::ConnectorCapability, diagnostics::DatamodelError, parser_database::walkers::EnumWalker,
+    validate::validation_pipeline::context::Context,
+};
+
+pub(super) fn schema_exists(enm: EnumWalker<'_>, ctx: &mut Context<'_>) {
+    let (_schema, span) = match (enm.schema(), ctx.datasource) {
+        (Some((schema_name, span)), Some(ds)) if !ds.has_schema(schema_name) => (schema_name, span),
+        _ => return,
+    };
+    ctx.push_error(DatamodelError::new_static(
+        "This schema is not defined in the datasource. Read more on `@@schema` at https://pris.ly/d/multi-schema",
+        span,
+    ))
+}
+
+pub(super) fn schema_capability(enm: EnumWalker<'_>, ctx: &mut Context<'_>) {
+    if ctx.connector.has_capability(ConnectorCapability::MultiSchema) {
+        return;
+    }
+    let span = if let Some((_, span)) = enm.schema() {
+        span
+    } else {
+        return;
+    };
+    ctx.push_error(DatamodelError::new_static(
+        "@@schema is not supported on the current datasource provider",
+        span,
+    ))
+}

--- a/libs/datamodel/core/src/validate/validation_pipeline/validations/models.rs
+++ b/libs/datamodel/core/src/validate/validation_pipeline/validations/models.rs
@@ -277,7 +277,7 @@ pub(super) fn schema_exists(model: ModelWalker<'_>, ctx: &mut Context<'_>) {
         _ => return,
     };
     ctx.push_error(DatamodelError::new_static(
-        "This schema is not defined in the datasource. Read more on `@@schema` at https://pris.ly/multi-schema",
+        "This schema is not defined in the datasource. Read more on `@@schema` at https://pris.ly/d/multi-schema",
         span,
     ))
 }
@@ -292,7 +292,7 @@ pub(super) fn schema_capability(model: ModelWalker<'_>, ctx: &mut Context<'_>) {
         return;
     };
     ctx.push_error(DatamodelError::new_static(
-        "@@schema is not defined on the current datasource provider",
+        "@@schema is not supported on the current datasource provider",
         span,
     ))
 }

--- a/libs/datamodel/core/src/validate/validation_pipeline/validations/models.rs
+++ b/libs/datamodel/core/src/validate/validation_pipeline/validations/models.rs
@@ -270,3 +270,29 @@ pub(super) fn id_client_name_does_not_clash_with_field(model: ModelWalker<'_>, c
         ));
     }
 }
+
+pub(super) fn schema_exists(model: ModelWalker<'_>, ctx: &mut Context<'_>) {
+    let (_schema, span) = match (model.schema(), ctx.datasource) {
+        (Some((schema_name, span)), Some(ds)) if !ds.has_schema(schema_name) => (schema_name, span),
+        _ => return,
+    };
+    ctx.push_error(DatamodelError::new_static(
+        "This schema is not defined in the datasource. Read more on `@@schema` at https://pris.ly/multi-schema",
+        span,
+    ))
+}
+
+pub(super) fn schema_capability(model: ModelWalker<'_>, ctx: &mut Context<'_>) {
+    if ctx.connector.has_capability(ConnectorCapability::MultiSchema) {
+        return;
+    }
+    let span = if let Some((_, span)) = model.schema() {
+        span
+    } else {
+        return;
+    };
+    ctx.push_error(DatamodelError::new_static(
+        "@@schema is not defined on the current datasource provider",
+        span,
+    ))
+}

--- a/libs/datamodel/core/tests/attributes/builtin_attributes.rs
+++ b/libs/datamodel/core/tests/attributes/builtin_attributes.rs
@@ -36,13 +36,13 @@ fn duplicate_attributes_should_error() {
     "#};
 
     let expect = expect![[r#"
-        [1;91merror[0m: [1mAttribute "@unique" is defined twice.[0m
+        [1;91merror[0m: [1mAttribute "@unique" can only be defined once.[0m
           [1;94m-->[0m  [4mschema.prisma:3[0m
         [1;94m   | [0m
         [1;94m 2 | [0m  id String @id
         [1;94m 3 | [0m  unique String [1;91m@unique [0m@unique
         [1;94m   | [0m
-        [1;91merror[0m: [1mAttribute "@unique" is defined twice.[0m
+        [1;91merror[0m: [1mAttribute "@unique" can only be defined once.[0m
           [1;94m-->[0m  [4mschema.prisma:3[0m
         [1;94m   | [0m
         [1;94m 2 | [0m  id String @id

--- a/libs/datamodel/core/tests/validation/attributes/schema/bad_schema_attribute.prisma
+++ b/libs/datamodel/core/tests/validation/attributes/schema/bad_schema_attribute.prisma
@@ -1,0 +1,47 @@
+datasource testds {
+    provider = "postgresql"
+    url = env("TEST_DATABASE_URL")
+    schemas = ["public"]
+}
+
+generator js {
+    provider = "prisma-client-js"
+    previewFeatures = ["multiSchema"]
+}
+
+model Test {
+  id Int @id
+  @@schema
+}
+
+enum Language {
+  English
+  Spanish
+
+  @@schema
+}
+
+model Test2 {
+  id Int @id
+  @@schema(101)
+}
+
+
+// [1;91merror[0m: [1mArgument "map" is missing.[0m
+//   [1;94m-->[0m  [4mschema.prisma:14[0m
+// [1;94m   | [0m
+// [1;94m13 | [0m  id Int @id
+// [1;94m14 | [0m  [1;91m@@schema[0m
+// [1;94m   | [0m
+// [1;91merror[0m: [1mArgument "map" is missing.[0m
+//   [1;94m-->[0m  [4mschema.prisma:21[0m
+// [1;94m   | [0m
+// [1;94m20 | [0m
+// [1;94m21 | [0m  [1;91m@@schema[0m
+// [1;94m   | [0m
+// [1;91merror[0m: [1mExpected a string value, but received numeric value `101`.[0m
+//   [1;94m-->[0m  [4mschema.prisma:26[0m
+// [1;94m   | [0m
+// [1;94m25 | [0m  id Int @id
+// [1;94m26 | [0m  @@schema([1;91m101[0m)
+// [1;94m   | [0m

--- a/libs/datamodel/core/tests/validation/attributes/schema/multiple_schemas_valid.prisma
+++ b/libs/datamodel/core/tests/validation/attributes/schema/multiple_schemas_valid.prisma
@@ -41,3 +41,5 @@ model Test5 {
   id Int @id
   @@schema("security")
 }
+
+

--- a/libs/datamodel/core/tests/validation/attributes/schema/multiple_schemas_valid.prisma
+++ b/libs/datamodel/core/tests/validation/attributes/schema/multiple_schemas_valid.prisma
@@ -1,0 +1,43 @@
+datasource testds {
+    provider = "postgresql"
+    url = env("TEST_DATABASE_URL")
+    schemas = ["public", "security", "users"]
+}
+
+generator js {
+    provider = "prisma-client-js"
+    previewFeatures = ["multiSchema"]
+}
+
+model Test {
+  id Int @id
+  @@schema("users")
+}
+
+model Test2 {
+  id Int @id
+  @@schema("public")
+}
+
+model Test3 {
+  id Int @id
+  @@schema("security")
+}
+
+enum UserType {
+  Bacteria
+  Archea
+  Eukaryote
+
+  @@schema("users")
+}
+
+model Test4 {
+  id Int @id
+  @@schema("public")
+}
+
+model Test5 {
+  id Int @id
+  @@schema("security")
+}

--- a/libs/datamodel/core/tests/validation/attributes/schema/mysql_enums_do_not_have_a_schema.prisma
+++ b/libs/datamodel/core/tests/validation/attributes/schema/mysql_enums_do_not_have_a_schema.prisma
@@ -17,6 +17,8 @@ enum MyEnum {
     @@schema("users")
 }
 
+
+
 // [1;91merror[0m: [1mMySQL enums do not belong to a schema.[0m
 //   [1;94m-->[0m  [4mschema.prisma:17[0m
 // [1;94m   | [0m

--- a/libs/datamodel/core/tests/validation/attributes/schema/mysql_enums_do_not_have_a_schema.prisma
+++ b/libs/datamodel/core/tests/validation/attributes/schema/mysql_enums_do_not_have_a_schema.prisma
@@ -1,0 +1,25 @@
+datasource testds {
+    provider = "mysql"
+    url = env("TEST_DATABASE_URL")
+    schemas = ["public", "security", "users"]
+}
+
+generator js {
+    provider = "prisma-client-js"
+    previewFeatures = ["multiSchema"]
+}
+
+
+enum MyEnum {
+    ONE
+    TWO
+
+    @@schema("users")
+}
+
+// [1;91merror[0m: [1mMySQL enums do not belong to a schema.[0m
+//   [1;94m-->[0m  [4mschema.prisma:17[0m
+// [1;94m   | [0m
+// [1;94m16 | [0m
+// [1;94m17 | [0m    @@schema([1;91m"users"[0m)
+// [1;94m   | [0m

--- a/libs/datamodel/core/tests/validation/attributes/schema/non_existing_schema.prisma
+++ b/libs/datamodel/core/tests/validation/attributes/schema/non_existing_schema.prisma
@@ -22,9 +22,17 @@ enum Language {
   @@schema("nonpublic")
 }
 
-// [1;91merror[0m: [1mThis schema is not defined in the datasource. Read more on `@@schema` at https://pris.ly/multi-schema[0m
+
+
+// [1;91merror[0m: [1mThis schema is not defined in the datasource. Read more on `@@schema` at https://pris.ly/d/multi-schema[0m
 //   [1;94m-->[0m  [4mschema.prisma:15[0m
 // [1;94m   | [0m
 // [1;94m14 | [0m
 // [1;94m15 | [0m  @@schema([1;91m"nonpublic"[0m)
+// [1;94m   | [0m
+// [1;91merror[0m: [1mThis schema is not defined in the datasource. Read more on `@@schema` at https://pris.ly/d/multi-schema[0m
+//   [1;94m-->[0m  [4mschema.prisma:22[0m
+// [1;94m   | [0m
+// [1;94m21 | [0m
+// [1;94m22 | [0m  @@schema([1;91m"nonpublic"[0m)
 // [1;94m   | [0m

--- a/libs/datamodel/core/tests/validation/attributes/schema/non_existing_schema.prisma
+++ b/libs/datamodel/core/tests/validation/attributes/schema/non_existing_schema.prisma
@@ -1,0 +1,30 @@
+datasource testds {
+    provider = "postgresql"
+    url = env("TEST_DATABASE_URL")
+    schemas = ["public"]
+}
+
+generator js {
+    provider = "prisma-client-js"
+    previewFeatures = ["multiSchema"]
+}
+
+model Test {
+  id Int @id
+
+  @@schema("nonpublic")
+}
+
+enum Language {
+  English
+  Foreign
+
+  @@schema("nonpublic")
+}
+
+// [1;91merror[0m: [1mThis schema is not defined in the datasource. Read more on `@@schema` at https://pris.ly/multi-schema[0m
+//   [1;94m-->[0m  [4mschema.prisma:15[0m
+// [1;94m   | [0m
+// [1;94m14 | [0m
+// [1;94m15 | [0m  @@schema([1;91m"nonpublic"[0m)
+// [1;94m   | [0m

--- a/libs/datamodel/core/tests/validation/attributes/schema/on_sqlite.prisma
+++ b/libs/datamodel/core/tests/validation/attributes/schema/on_sqlite.prisma
@@ -1,0 +1,23 @@
+datasource testds {
+    provider = "sqlite"
+    url = env("TEST_DATABASE_URL")
+    schemas = ["public", "sphere"]
+}
+
+generator js {
+    provider = "prisma-client-js"
+    previewFeatures = ["multiSchema"]
+}
+
+model Test {
+  id Int @id
+
+  @@schema("public")
+}
+
+// [1;91merror[0m: [1m@@schema is not defined on the current datasource provider[0m
+//   [1;94m-->[0m  [4mschema.prisma:15[0m
+// [1;94m   | [0m
+// [1;94m14 | [0m
+// [1;94m15 | [0m  @@schema([1;91m"public"[0m)
+// [1;94m   | [0m

--- a/libs/datamodel/core/tests/validation/attributes/schema/on_sqlite.prisma
+++ b/libs/datamodel/core/tests/validation/attributes/schema/on_sqlite.prisma
@@ -15,9 +15,16 @@ model Test {
   @@schema("public")
 }
 
-// [1;91merror[0m: [1m@@schema is not defined on the current datasource provider[0m
+
+// [1;91merror[0m: [1m@@schema is not supported on the current datasource provider[0m
 //   [1;94m-->[0m  [4mschema.prisma:15[0m
 // [1;94m   | [0m
 // [1;94m14 | [0m
 // [1;94m15 | [0m  @@schema([1;91m"public"[0m)
+// [1;94m   | [0m
+// [1;91merror[0m: [1mThe `schemas` property is not supported on the current connector.[0m
+//   [1;94m-->[0m  [4mschema.prisma:4[0m
+// [1;94m   | [0m
+// [1;94m 3 | [0m    url = env("TEST_DATABASE_URL")
+// [1;94m 4 | [0m    schemas = [1;91m["public", "sphere"][0m
 // [1;94m   | [0m

--- a/libs/datamodel/core/tests/validation/attributes/schema/repeated_schema_attribute.prisma
+++ b/libs/datamodel/core/tests/validation/attributes/schema/repeated_schema_attribute.prisma
@@ -1,0 +1,37 @@
+datasource testds {
+    provider = "postgresql"
+    url = env("TEST_DATABASE_URL")
+    schemas = ["public", "private"]
+}
+
+generator js {
+    provider = "prisma-client-js"
+    previewFeatures = ["multiSchema"]
+}
+
+model Test {
+  id Int @id
+  @@schema("public")
+}
+
+enum toggle {
+  on
+  off
+
+  @@schema("public")
+  @@schema("private")
+}
+
+
+// [1;91merror[0m: [1mAttribute "@schema" is defined twice.[0m
+//   [1;94m-->[0m  [4mschema.prisma:21[0m
+// [1;94m   | [0m
+// [1;94m20 | [0m
+// [1;94m21 | [0m  [1;91m@@schema("public")[0m
+// [1;94m   | [0m
+// [1;91merror[0m: [1mAttribute "@schema" is defined twice.[0m
+//   [1;94m-->[0m  [4mschema.prisma:22[0m
+// [1;94m   | [0m
+// [1;94m21 | [0m  @@schema("public")
+// [1;94m22 | [0m  [1;91m@@schema("private")[0m
+// [1;94m   | [0m

--- a/libs/datamodel/core/tests/validation/attributes/schema/repeated_schema_attribute.prisma
+++ b/libs/datamodel/core/tests/validation/attributes/schema/repeated_schema_attribute.prisma
@@ -23,13 +23,14 @@ enum toggle {
 }
 
 
-// [1;91merror[0m: [1mAttribute "@schema" is defined twice.[0m
+
+// [1;91merror[0m: [1mAttribute "@schema" can only be defined once.[0m
 //   [1;94m-->[0m  [4mschema.prisma:21[0m
 // [1;94m   | [0m
 // [1;94m20 | [0m
 // [1;94m21 | [0m  [1;91m@@schema("public")[0m
 // [1;94m   | [0m
-// [1;91merror[0m: [1mAttribute "@schema" is defined twice.[0m
+// [1;91merror[0m: [1mAttribute "@schema" can only be defined once.[0m
 //   [1;94m-->[0m  [4mschema.prisma:22[0m
 // [1;94m   | [0m
 // [1;94m21 | [0m  @@schema("public")

--- a/libs/datamodel/core/tests/validation/attributes/schema/with_single_schema.prisma
+++ b/libs/datamodel/core/tests/validation/attributes/schema/with_single_schema.prisma
@@ -20,3 +20,5 @@ enum Language {
 
   @@schema("public")
 }
+
+

--- a/libs/datamodel/core/tests/validation/attributes/schema/with_single_schema.prisma
+++ b/libs/datamodel/core/tests/validation/attributes/schema/with_single_schema.prisma
@@ -1,0 +1,22 @@
+datasource testds {
+    provider = "postgresql"
+    url = env("TEST_DATABASE_URL")
+    schemas = ["public"]
+}
+
+generator js {
+    provider = "prisma-client-js"
+    previewFeatures = ["multiSchema"]
+}
+
+model Test {
+  id Int @id
+  @@schema("public")
+}
+
+enum Language {
+  English
+  Spanish
+
+  @@schema("public")
+}

--- a/libs/datamodel/core/tests/validation/attributes/schema/with_single_schema_mysql.prisma
+++ b/libs/datamodel/core/tests/validation/attributes/schema/with_single_schema_mysql.prisma
@@ -1,0 +1,23 @@
+datasource testds {
+    provider = "mysql"
+    url = env("TEST_DATABASE_URL")
+    schemas = ["public"]
+}
+
+generator js {
+    provider = "prisma-client-js"
+    previewFeatures = ["multiSchema"]
+}
+
+model Test {
+  id Int @id
+  lang Language
+
+  @@schema("public")
+}
+
+enum Language {
+  English
+  Spanish
+}
+

--- a/libs/datamodel/core/tests/validation/attributes/schema/with_single_schema_mysql.prisma
+++ b/libs/datamodel/core/tests/validation/attributes/schema/with_single_schema_mysql.prisma
@@ -21,3 +21,5 @@ enum Language {
   Spanish
 }
 
+
+

--- a/libs/datamodel/core/tests/validation/attributes/schema/with_single_schema_sqlserver.prisma
+++ b/libs/datamodel/core/tests/validation/attributes/schema/with_single_schema_sqlserver.prisma
@@ -13,3 +13,5 @@ model Test {
   id Int @id
   @@schema("public")
 }
+
+

--- a/libs/datamodel/core/tests/validation/attributes/schema/with_single_schema_sqlserver.prisma
+++ b/libs/datamodel/core/tests/validation/attributes/schema/with_single_schema_sqlserver.prisma
@@ -1,0 +1,15 @@
+datasource testds {
+    provider = "sqlserver"
+    url = env("TEST_DATABASE_URL")
+    schemas = ["public"]
+}
+
+generator js {
+    provider = "prisma-client-js"
+    previewFeatures = ["multiSchema"]
+}
+
+model Test {
+  id Int @id
+  @@schema("public")
+}

--- a/libs/datamodel/core/tests/validation/attributes/schema/without_preview_feature.prisma
+++ b/libs/datamodel/core/tests/validation/attributes/schema/without_preview_feature.prisma
@@ -1,0 +1,17 @@
+datasource testds {
+    provider = "postgresql"
+    url = env("TEST_DATABASE_URL")
+}
+
+model Test {
+    id Int @id
+
+    @@schema("public")
+}
+
+// [1;91merror[0m: [1m@@schema is only available with the `multiSchema` preview feature.[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
+// [1;94m   | [0m
+// [1;94m 8 | [0m
+// [1;94m 9 | [0m    @@schema([1;91m"public"[0m)
+// [1;94m   | [0m

--- a/libs/datamodel/core/tests/validation/composite_types/ignore_field_attribute_is_not_allowed.prisma
+++ b/libs/datamodel/core/tests/validation/composite_types/ignore_field_attribute_is_not_allowed.prisma
@@ -15,9 +15,10 @@ model B {
 
 
 
+
 // [1;91merror[0m: [1mAttribute not known: "@ignore".[0m
 //   [1;94m-->[0m  [4mschema.prisma:8[0m
 // [1;94m   | [0m
 // [1;94m 7 | [0m  name String
-// [1;94m 8 | [0m  c String @[1;91mignore[0m
+// [1;94m 8 | [0m  c String [1;91m@ignore[0m
 // [1;94m   | [0m

--- a/libs/datamodel/core/tests/validation/datasource/duplicates_in_schemas.prisma
+++ b/libs/datamodel/core/tests/validation/datasource/duplicates_in_schemas.prisma
@@ -1,0 +1,18 @@
+datasource testds {
+    provider = "postgresql"
+    url = env("TEST_DATABASE_URL")
+    schemas = ["one", "two", "two", "three", "three"]
+}
+
+// [1;91merror[0m: [1mDuplicated schema names are not allowed[0m
+//   [1;94m-->[0m  [4mschema.prisma:4[0m
+// [1;94m   | [0m
+// [1;94m 3 | [0m    url = env("TEST_DATABASE_URL")
+// [1;94m 4 | [0m    schemas = ["one", "two", "two", [1;91m"three"[0m, "three"]
+// [1;94m   | [0m
+// [1;91merror[0m: [1mDuplicated schema names are not allowed[0m
+//   [1;94m-->[0m  [4mschema.prisma:4[0m
+// [1;94m   | [0m
+// [1;94m 3 | [0m    url = env("TEST_DATABASE_URL")
+// [1;94m 4 | [0m    schemas = ["one", [1;91m"two"[0m, "two", "three", "three"]
+// [1;94m   | [0m

--- a/libs/datamodel/core/tests/validation/datasource/schemas_array_with_non_string_values.prisma
+++ b/libs/datamodel/core/tests/validation/datasource/schemas_array_with_non_string_values.prisma
@@ -1,0 +1,19 @@
+datasource testds {
+    provider = "postgresql"
+    url = env("TEST_DATABASE_URL")
+    schemas = ["one", 2, ["three"]]
+}
+
+
+// [1;91merror[0m: [1mExpected a string value, but received numeric value `2`.[0m
+//   [1;94m-->[0m  [4mschema.prisma:4[0m
+// [1;94m   | [0m
+// [1;94m 3 | [0m    url = env("TEST_DATABASE_URL")
+// [1;94m 4 | [0m    schemas = ["one", [1;91m2[0m, ["three"]]
+// [1;94m   | [0m
+// [1;91merror[0m: [1mExpected a string value, but received array value `["three"]`.[0m
+//   [1;94m-->[0m  [4mschema.prisma:4[0m
+// [1;94m   | [0m
+// [1;94m 3 | [0m    url = env("TEST_DATABASE_URL")
+// [1;94m 4 | [0m    schemas = ["one", 2, [1;91m["three"][0m]
+// [1;94m   | [0m

--- a/libs/datamodel/diagnostics/src/error.rs
+++ b/libs/datamodel/diagnostics/src/error.rs
@@ -72,7 +72,7 @@ impl DatamodelError {
     }
 
     pub fn new_duplicate_attribute_error(attribute_name: &str, span: Span) -> DatamodelError {
-        let msg = format!("Attribute \"@{attribute_name}\" is defined twice.");
+        let msg = format!("Attribute \"@{attribute_name}\" can only be defined once.");
         Self::new(msg, span)
     }
 

--- a/libs/datamodel/parser-database/src/attributes.rs
+++ b/libs/datamodel/parser-database/src/attributes.rs
@@ -2,6 +2,7 @@ mod default;
 mod id;
 mod map;
 mod native_types;
+mod schema;
 
 use crate::{
     ast::{self, WithName, WithSpan},
@@ -98,6 +99,12 @@ fn resolve_enum_attributes<'db>(enum_id: ast::EnumId, ast_enum: &'db ast::Enum, 
         ctx.validate_visited_arguments();
     }
 
+    // @@schema
+    if ctx.visit_optional_single_attr("schema") {
+        schema::r#enum(&mut enum_attributes, ctx);
+        ctx.validate_visited_arguments();
+    }
+
     ctx.types.enum_attributes.insert(enum_id, enum_attributes);
     ctx.validate_visited_attributes();
 }
@@ -149,6 +156,12 @@ fn resolve_model_attributes<'db>(model_id: ast::ModelId, ast_model: &'db ast::Mo
     // @@map
     if ctx.visit_optional_single_attr("map") {
         map::model(&mut model_attributes, model_id, ctx);
+        ctx.validate_visited_arguments();
+    }
+
+    // @@schema
+    if ctx.visit_optional_single_attr("schema") {
+        schema::model(&mut model_attributes, ctx);
         ctx.validate_visited_arguments();
     }
 

--- a/libs/datamodel/parser-database/src/attributes/schema.rs
+++ b/libs/datamodel/parser-database/src/attributes/schema.rs
@@ -1,0 +1,21 @@
+use crate::{ast, coerce, context::*, types::*, StringId};
+
+pub(super) fn model(model_attributes: &mut ModelAttributes, ctx: &mut Context<'_>) {
+    model_attributes.schema = visit_schema_attribute(ctx);
+}
+
+pub(super) fn r#enum(enum_attributes: &mut EnumAttributes, ctx: &mut Context<'_>) {
+    enum_attributes.schema = visit_schema_attribute(ctx);
+}
+
+fn visit_schema_attribute(ctx: &mut Context<'_>) -> Option<(StringId, ast::Span)> {
+    let arg = match ctx.visit_default_arg("map") {
+        Ok(arg) => arg,
+        Err(err) => {
+            ctx.push_error(err);
+            return None;
+        }
+    };
+    let name = coerce::string(arg, ctx.diagnostics)?;
+    Some((ctx.interner.intern(name), arg.span()))
+}

--- a/libs/datamodel/parser-database/src/coerce_expression.rs
+++ b/libs/datamodel/parser-database/src/coerce_expression.rs
@@ -22,6 +22,7 @@ impl_coercions! {
     'a;
     constant : "constant" => &'a str;
     string : "string" => &'a str;
+    string_with_span : "string" => (&'a str, ast::Span);
     boolean : "boolean" => bool;
     integer : "numeric" => i64;
     float : "float" => f64;
@@ -40,6 +41,10 @@ pub mod coerce_opt {
 
     pub fn string<'a>(expr: &'a ast::Expression) -> Option<&'a str> {
         expr.as_string_value().map(|(s, _)| s)
+    }
+
+    pub fn string_with_span<'a>(expr: &'a ast::Expression) -> Option<(&'a str, ast::Span)> {
+        expr.as_string_value()
     }
 
     pub fn boolean<'a>(expr: &'a ast::Expression) -> Option<bool> {

--- a/libs/datamodel/parser-database/src/context.rs
+++ b/libs/datamodel/parser-database/src/context.rs
@@ -296,7 +296,7 @@ impl<'db> Context<'db> {
             let attribute = &self.ast[*attribute_id];
             diagnostics.push_error(DatamodelError::new_attribute_not_known_error(
                 &attribute.name.name,
-                attribute.name.span,
+                attribute.span,
             ))
         }
         self.attributes.attributes.clear();

--- a/libs/datamodel/parser-database/src/types.rs
+++ b/libs/datamodel/parser-database/src/types.rs
@@ -224,6 +224,11 @@ pub(crate) struct ModelAttributes {
     pub(super) ast_indexes: Vec<(ast::AttributeId, IndexAttribute)>,
     /// @@map
     pub(crate) mapped_name: Option<StringId>,
+    /// ```ignore
+    /// @@schema("public")
+    ///          ^^^^^^^^
+    /// ```
+    pub(crate) schema: Option<(StringId, ast::Span)>,
 }
 
 /// A type of index as defined by the `type: ...` argument on an index attribute.
@@ -520,6 +525,11 @@ pub(super) struct EnumAttributes {
     pub(super) mapped_name: Option<StringId>,
     /// @map on enum values.
     pub(super) mapped_values: HashMap<u32, StringId>,
+    /// ```ignore
+    /// @@schema("public")
+    ///          ^^^^^^^^
+    /// ```
+    pub(crate) schema: Option<(StringId, ast::Span)>,
 }
 
 fn visit_model<'db>(model_id: ast::ModelId, ast_model: &'db ast::Model, ctx: &mut Context<'db>) {

--- a/libs/datamodel/parser-database/src/walkers/model.rs
+++ b/libs/datamodel/parser-database/src/walkers/model.rs
@@ -316,4 +316,14 @@ impl<'db> ModelWalker<'db> {
             _ => NewlineType::Unix,
         }
     }
+
+    /// The name of the schema the enum belongs to.
+    ///
+    /// ```ignore
+    /// @@schema("public")
+    ///          ^^^^^^^^
+    /// ```
+    pub fn schema(self) -> Option<(&'db str, ast::Span)> {
+        self.attributes().schema.map(|(id, span)| (&self.db[id], span))
+    }
 }

--- a/libs/datamodel/parser-database/src/walkers/model.rs
+++ b/libs/datamodel/parser-database/src/walkers/model.rs
@@ -317,7 +317,7 @@ impl<'db> ModelWalker<'db> {
         }
     }
 
-    /// The name of the schema the enum belongs to.
+    /// The name of the schema the model belongs to.
     ///
     /// ```ignore
     /// @@schema("public")


### PR DESCRIPTION
Contents:

- A new preview feature: `multiSchema`.
- Initial set of validations (see tests).
- The value of the `@@schema` attribute is parsed in parser-database, and passed on to the dml data structure used by the query engine.