### PR TITLE
me: minimal multi-schema

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -172,7 +172,7 @@ services:
     tmpfs: /var/lib/mariadb
 
   vitess-test-5_7:
-    image: vitess/vttestserver:mysql57@sha256:3d7ce4c7b3b2ef368ab9238a10ffc5d5c536e72bb659edcccc870f36e4e7fa1d
+    image: vitess/vttestserver:mysql57@sha256:2b132a22d08b3b227d9391f8f58ed7ab5c081ca07bf0f87a0c166729124d360a
     restart: always
     ports:
       - 33577:33577
@@ -196,7 +196,7 @@ services:
       FOREIGN_KEY_MODE: "disallow"
 
   vitess-shadow-5_7:
-    image: vitess/vttestserver:mysql57@sha256:3d7ce4c7b3b2ef368ab9238a10ffc5d5c536e72bb659edcccc870f36e4e7fa1d
+    image: vitess/vttestserver:mysql57@sha256:2b132a22d08b3b227d9391f8f58ed7ab5c081ca07bf0f87a0c166729124d360a
     restart: always
     ports:
       - 33578:33577

--- a/introspection-engine/introspection-engine-tests/tests/rpc_calls/get_database_description.rs
+++ b/introspection-engine/introspection-engine-tests/tests/rpc_calls/get_database_description.rs
@@ -22,8 +22,10 @@ async fn database_description_for_mysql_should_work(api: &TestApi) -> TestResult
 
     let expected = expect![[r#"
         {
+          "namespaces": [],
           "tables": [
             {
+              "namespace_id": 0,
               "name": "Blog"
             }
           ],
@@ -92,8 +94,10 @@ async fn database_description_for_mysql_8_should_work(api: &TestApi) -> TestResu
 
     let expected = expect![[r#"
         {
+          "namespaces": [],
           "tables": [
             {
+              "namespace_id": 0,
               "name": "Blog"
             }
           ],
@@ -162,8 +166,10 @@ async fn database_description_for_postgres_should_work(api: &TestApi) -> TestRes
 
     let expected = expect![[r#"
         {
+          "namespaces": [],
           "tables": [
             {
+              "namespace_id": 0,
               "name": "Blog"
             }
           ],
@@ -237,8 +243,10 @@ async fn database_description_for_sqlite_should_work(api: &TestApi) -> TestResul
 
     let expected = expect![[r#"
         {
+          "namespaces": [],
           "tables": [
             {
+              "namespace_id": 0,
               "name": "Blog"
             }
           ],

--- a/libs/datamodel/core/src/configuration/datasource.rs
+++ b/libs/datamodel/core/src/configuration/datasource.rs
@@ -22,7 +22,7 @@ pub struct Datasource {
     /// In which layer referential actions are handled.
     pub referential_integrity: Option<ReferentialIntegrity>,
     /// _Sorted_ vec of schemas defined in the schemas property.
-    pub(crate) schemas: Vec<(String, Span)>,
+    pub schemas: Vec<(String, Span)>,
     pub(crate) schemas_span: Option<Span>,
 }
 

--- a/libs/datamodel/core/src/validate/validation_pipeline/validations.rs
+++ b/libs/datamodel/core/src/validate/validation_pipeline/validations.rs
@@ -160,13 +160,11 @@ pub(super) fn validate(ctx: &mut Context<'_>) {
         }
     } else {
         for model in ctx.db.walk_models() {
-            models::schema_exists(model, ctx);
-            models::schema_capability(model, ctx);
+            models::schema_attribute(model, ctx);
         }
 
         for r#enum in ctx.db.walk_enums() {
-            enums::schema_exists(r#enum, ctx);
-            enums::schema_capability(r#enum, ctx);
+            enums::schema_attribute(r#enum, ctx);
         }
 
         if !ctx

--- a/libs/datamodel/core/src/validate/validation_pipeline/validations/enums.rs
+++ b/libs/datamodel/core/src/validate/validation_pipeline/validations/enums.rs
@@ -1,30 +1,25 @@
 use crate::{
-    datamodel_connector::ConnectorCapability, diagnostics::DatamodelError, parser_database::walkers::EnumWalker,
+    datamodel_connector::ConnectorCapability,
+    diagnostics::DatamodelError,
+    parser_database::{self, walkers::EnumWalker},
     validate::validation_pipeline::context::Context,
 };
 
-pub(super) fn schema_exists(enm: EnumWalker<'_>, ctx: &mut Context<'_>) {
-    let (_schema, span) = match (enm.schema(), ctx.datasource) {
-        (Some((schema_name, span)), Some(ds)) if !ds.has_schema(schema_name) => (schema_name, span),
-        _ => return,
-    };
-    ctx.push_error(DatamodelError::new_static(
-        "This schema is not defined in the datasource. Read more on `@@schema` at https://pris.ly/d/multi-schema",
-        span,
-    ))
-}
-
-pub(super) fn schema_capability(enm: EnumWalker<'_>, ctx: &mut Context<'_>) {
-    if ctx.connector.has_capability(ConnectorCapability::MultiSchema) {
-        return;
+pub(super) fn schema_attribute(enm: EnumWalker<'_>, ctx: &mut Context<'_>) {
+    match (enm.schema(), ctx.datasource) {
+        (Some((schema_name, span)), Some(ds)) if !ds.has_schema(schema_name) => {
+            ctx.push_error(DatamodelError::new_static(
+                "This schema is not defined in the datasource. Read more on `@@schema` at https://pris.ly/d/multi-schema",
+                span,
+            ))
+        },
+        (Some((_, span)), _) if !ctx.connector.has_capability(ConnectorCapability::MultiSchema) => {
+            ctx.push_error(DatamodelError::new_static(
+                "@@schema is not supported on the current datasource provider",
+                span,
+            ))
+        }
+        (None, _) if ctx.db.schema_flags().contains(parser_database::SchemaFlags::UsesSchemaAttribute) && !ctx.connector.is_provider("mysql") => ctx.push_error(DatamodelError::new_static("This enum is missing an `@@schema` attribute.", enm.ast_enum().span)),
+        _ => (),
     }
-    let span = if let Some((_, span)) = enm.schema() {
-        span
-    } else {
-        return;
-    };
-    ctx.push_error(DatamodelError::new_static(
-        "@@schema is not supported on the current datasource provider",
-        span,
-    ))
 }

--- a/libs/datamodel/core/src/validate/validation_pipeline/validations/models.rs
+++ b/libs/datamodel/core/src/validate/validation_pipeline/validations/models.rs
@@ -271,28 +271,28 @@ pub(super) fn id_client_name_does_not_clash_with_field(model: ModelWalker<'_>, c
     }
 }
 
-pub(super) fn schema_exists(model: ModelWalker<'_>, ctx: &mut Context<'_>) {
-    let (_schema, span) = match (model.schema(), ctx.datasource) {
-        (Some((schema_name, span)), Some(ds)) if !ds.has_schema(schema_name) => (schema_name, span),
-        _ => return,
-    };
+pub(super) fn schema_attribute(model: ModelWalker<'_>, ctx: &mut Context<'_>) {
+    match (model.schema(), ctx.datasource) {
+        (Some((_, span)), _) if !ctx.connector.has_capability(ConnectorCapability::MultiSchema) => ctx.push_error(
+            DatamodelError::new_static("@@schema is not supported on the current datasource provider", span),
+        ),
+        (Some((schema_name, span)), Some(ds)) if !ds.has_schema(schema_name) => {
     ctx.push_error(DatamodelError::new_static(
         "This schema is not defined in the datasource. Read more on `@@schema` at https://pris.ly/d/multi-schema",
         span,
     ))
-}
-
-pub(super) fn schema_capability(model: ModelWalker<'_>, ctx: &mut Context<'_>) {
-    if ctx.connector.has_capability(ConnectorCapability::MultiSchema) {
-        return;
+        },
+        (None, _)
+            if ctx
+                .db
+                .schema_flags()
+                .contains(parser_database::SchemaFlags::UsesSchemaAttribute) =>
+        {
+            ctx.push_error(DatamodelError::new_static(
+                "This model is missing an `@@schema` attribute.",
+                model.ast_model().span(),
+            ))
+        }
+        _ => (),
     }
-    let span = if let Some((_, span)) = model.schema() {
-        span
-    } else {
-        return;
-    };
-    ctx.push_error(DatamodelError::new_static(
-        "@@schema is not supported on the current datasource provider",
-        span,
-    ))
 }

--- a/libs/datamodel/core/tests/validation/attributes/schema/missing_schema_annotations.prisma
+++ b/libs/datamodel/core/tests/validation/attributes/schema/missing_schema_annotations.prisma
@@ -1,0 +1,47 @@
+// This is _not_ be valid: once @@schema is specified once, it has to be
+// specified for every model and enum.
+
+datasource testds {
+    provider = "postgresql"
+    url = env("TEST_DATABASE_URL")
+    schemas = ["public", "security", "users"]
+}
+
+generator js {
+    provider = "prisma-client-js"
+    previewFeatures = ["multiSchema"]
+}
+
+model Test {
+  id Int @id
+}
+
+model Test2 {
+  id Int @id
+  @@schema("public")
+}
+
+enum UserType {
+  Bacteria
+  Archea
+  Eukaryote
+}
+
+// [1;91merror[0m: [1mThis model is missing an `@@schema` attribute.[0m
+//   [1;94m-->[0m  [4mschema.prisma:15[0m
+// [1;94m   | [0m
+// [1;94m14 | [0m
+// [1;94m15 | [0m[1;91mmodel Test {[0m
+// [1;94m16 | [0m  id Int @id
+// [1;94m17 | [0m}
+// [1;94m   | [0m
+// [1;91merror[0m: [1mThis enum is missing an `@@schema` attribute.[0m
+//   [1;94m-->[0m  [4mschema.prisma:24[0m
+// [1;94m   | [0m
+// [1;94m23 | [0m
+// [1;94m24 | [0m[1;91menum UserType {[0m
+// [1;94m25 | [0m  Bacteria
+// [1;94m26 | [0m  Archea
+// [1;94m27 | [0m  Eukaryote
+// [1;94m28 | [0m}
+// [1;94m   | [0m

--- a/libs/datamodel/core/tests/validation/attributes/schema/missing_schema_annotations.prisma
+++ b/libs/datamodel/core/tests/validation/attributes/schema/missing_schema_annotations.prisma
@@ -1,4 +1,4 @@
-// This is _not_ be valid: once @@schema is specified once, it has to be
+// This is _not_ valid: once @@schema is specified once, it has to be
 // specified for every model and enum.
 
 datasource testds {

--- a/libs/datamodel/parser-database/src/attributes/schema.rs
+++ b/libs/datamodel/parser-database/src/attributes/schema.rs
@@ -17,5 +17,6 @@ fn visit_schema_attribute(ctx: &mut Context<'_>) -> Option<(StringId, ast::Span)
         }
     };
     let name = coerce::string(arg, ctx.diagnostics)?;
+    ctx.types.flags |= crate::types::SchemaFlags::UsesSchemaAttribute;
     Some((ctx.interner.intern(name), arg.span()))
 }

--- a/libs/datamodel/parser-database/src/lib.rs
+++ b/libs/datamodel/parser-database/src/lib.rs
@@ -40,7 +40,9 @@ pub use coerce_expression::{coerce, coerce_array, coerce_opt};
 pub use names::is_reserved_type_name;
 pub use relations::ReferentialAction;
 pub use schema_ast::{ast, SourceFile};
-pub use types::{IndexAlgorithm, IndexFieldPath, IndexType, OperatorClass, ScalarFieldType, ScalarType, SortOrder};
+pub use types::{
+    IndexAlgorithm, IndexFieldPath, IndexType, OperatorClass, ScalarFieldType, ScalarType, SchemaFlags, SortOrder,
+};
 
 use self::{context::Context, interner::StringId, relations::Relations, types::Types};
 use diagnostics::{DatamodelError, Diagnostics};
@@ -146,6 +148,11 @@ impl ParserDatabase {
     /// The source file contents.
     pub fn source(&self) -> &str {
         self.file.as_str()
+    }
+
+    /// Global properties of the schema.
+    pub fn schema_flags(&self) -> enumflags2::BitFlags<types::SchemaFlags> {
+        self.types.flags
     }
 }
 

--- a/libs/datamodel/parser-database/src/types.rs
+++ b/libs/datamodel/parser-database/src/types.rs
@@ -2,7 +2,7 @@ pub(crate) mod index_fields;
 
 use crate::{context::Context, interner::StringId, walkers::IndexFieldWalker, DatamodelError};
 use either::Either;
-use enumflags2::bitflags;
+use enumflags2::{bitflags, BitFlags};
 use schema_ast::ast::{self, WithName};
 use std::{
     collections::{BTreeMap, HashMap},
@@ -23,6 +23,7 @@ pub(super) fn resolve_types(ctx: &mut Context<'_>) {
 
 #[derive(Debug, Default)]
 pub(super) struct Types {
+    pub(super) flags: BitFlags<SchemaFlags>,
     pub(super) composite_type_fields: BTreeMap<(ast::CompositeTypeId, ast::FieldId), CompositeTypeField>,
     pub(super) scalar_fields: BTreeMap<(ast::ModelId, ast::FieldId), ScalarField>,
     /// This contains only the relation fields actually present in the schema
@@ -57,6 +58,15 @@ impl Types {
     ) -> Option<RelationField> {
         self.relation_fields.remove(&(model_id, field_id))
     }
+}
+
+/// Global properties of a PSL document.
+#[derive(Debug, Clone, Copy)]
+#[bitflags]
+#[repr(u8)]
+pub enum SchemaFlags {
+    /// Is there at least one `@@schema` in the schema?
+    UsesSchemaAttribute = 0b1,
 }
 
 #[derive(Debug, Clone)]

--- a/libs/sql-ddl/src/mysql.rs
+++ b/libs/sql-ddl/src/mysql.rs
@@ -225,9 +225,8 @@ impl Display for CreateIndex<'_> {
     }
 }
 
-#[derive(Debug, Default)]
 pub struct CreateTable<'a> {
-    pub table_name: Cow<'a, str>,
+    pub table_name: &'a dyn Display,
     pub columns: Vec<Column<'a>>,
     pub indexes: Vec<IndexClause<'a>>,
     pub primary_key: Vec<IndexColumn<'a>>,
@@ -238,7 +237,7 @@ pub struct CreateTable<'a> {
 impl Display for CreateTable<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("CREATE TABLE ")?;
-        Display::fmt(&Ident(self.table_name.as_ref()), f)?;
+        Display::fmt(self.table_name, f)?;
 
         f.write_str(" (\n")?;
 
@@ -400,7 +399,7 @@ mod tests {
     #[test]
     fn full_create_table() {
         let stmt = CreateTable {
-            table_name: "Cat".into(),
+            table_name: &Ident("Cat"),
             columns: vec![
                 Column {
                     column_type: "INTEGER".into(),
@@ -424,7 +423,7 @@ mod tests {
             indexes: vec![],
             default_character_set: Some("utf8mb4".into()),
             collate: Some("utf8mb4_unicode_ci".into()),
-            ..Default::default()
+            primary_key: Vec::new(),
         };
 
         let expected = indoc!(

--- a/libs/sql-ddl/src/sqlite.rs
+++ b/libs/sql-ddl/src/sqlite.rs
@@ -9,9 +9,8 @@ impl<T: Display> Display for SqliteIdentifier<T> {
     }
 }
 
-#[derive(Debug, Default)]
 pub struct CreateTable<'a> {
-    pub table_name: Cow<'a, str>,
+    pub table_name: &'a dyn Display,
     pub columns: Vec<Column<'a>>,
     pub primary_key: Option<Vec<Cow<'a, str>>>,
     pub foreign_keys: Vec<ForeignKey<'a>>,
@@ -19,7 +18,7 @@ pub struct CreateTable<'a> {
 
 impl Display for CreateTable<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        writeln!(f, "CREATE TABLE \"{}\" (", self.table_name)?;
+        writeln!(f, "CREATE TABLE {} (", self.table_name)?;
 
         self.columns.iter().map(Indented).join(",\n", f)?;
 
@@ -162,7 +161,7 @@ mod tests {
     #[test]
     fn basic_create_table() {
         let create_table = CreateTable {
-            table_name: "Cat".into(),
+            table_name: &SqliteIdentifier("Cat"),
             columns: vec![
                 Column {
                     name: "id".into(),
@@ -177,7 +176,8 @@ mod tests {
                     ..Default::default()
                 },
             ],
-            ..Default::default()
+            primary_key: None,
+            foreign_keys: Vec::new(),
         };
 
         let expected = indoc::indoc!(
@@ -195,7 +195,7 @@ mod tests {
     #[test]
     fn create_table_with_primary_key() {
         let create_table = CreateTable {
-            table_name: "Cat".into(),
+            table_name: &SqliteIdentifier("Cat"),
             columns: vec![
                 Column {
                     name: "id".into(),
@@ -210,7 +210,7 @@ mod tests {
                 },
             ],
             primary_key: Some(vec!["id".into(), "boxId".into()]),
-            ..Default::default()
+            foreign_keys: Vec::new(),
         };
 
         let expected = indoc!(
@@ -230,7 +230,7 @@ mod tests {
     #[test]
     fn create_table_with_primary_key_and_foreign_keys() {
         let create_table = CreateTable {
-            table_name: "Cat".into(),
+            table_name: &SqliteIdentifier("Cat"),
             columns: vec![
                 Column {
                     name: "id".into(),

--- a/libs/sql-schema-describer/src/ids.rs
+++ b/libs/sql-schema-describer/src/ids.rs
@@ -20,9 +20,13 @@ pub struct IndexId(pub(crate) u32);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct IndexColumnId(pub(crate) u32);
 
-/// The identifier for a ForeignKey in the schema.
+/// The identifier for a foreign key in the schema.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct ForeignKeyId(pub(crate) u32);
+
+/// The identifier for a namespace in the schema.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Default)]
+pub struct NamespaceId(pub(crate) u32);
 
 /// The identifier for a user defined type in the database.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/libs/sql-schema-describer/src/mssql.rs
+++ b/libs/sql-schema-describer/src/mssql.rs
@@ -197,7 +197,7 @@ impl<'a> SqlSchemaDescriber<'a> {
 
         for name in names {
             let cloned_name = name.clone();
-            let id = sql_schema.push_table(name);
+            let id = sql_schema.push_table(name, Default::default());
             map.insert(cloned_name, id);
         }
 

--- a/libs/sql-schema-describer/src/mysql.rs
+++ b/libs/sql-schema-describer/src/mysql.rs
@@ -279,7 +279,7 @@ impl<'a> SqlSchemaDescriber<'a> {
 
         for name in names {
             let cloned_name = name.clone();
-            let id = sql_schema.push_table(name);
+            let id = sql_schema.push_table(name, Default::default());
             map.insert(cloned_name, id);
         }
 
@@ -634,6 +634,7 @@ impl<'a> SqlSchemaDescriber<'a> {
 
         let enm = match &family {
             ColumnTypeFamily::Enum(name) => Some(Enum {
+                namespace_id: Default::default(),
                 name: name.clone(),
                 values: Self::extract_enum_values(&full_data_type),
             }),

--- a/libs/sql-schema-describer/src/postgres.rs
+++ b/libs/sql-schema-describer/src/postgres.rs
@@ -512,7 +512,7 @@ impl<'a> SqlSchemaDescriber<'a> {
 
         for name in names {
             let cloned_name = name.clone();
-            let id = sql_schema.push_table(name);
+            let id = sql_schema.push_table(name, Default::default());
             map.insert(cloned_name, id);
         }
 
@@ -1035,7 +1035,11 @@ impl<'a> SqlSchemaDescriber<'a> {
 
         let mut enums: Vec<Enum> = enum_values
             .into_iter()
-            .map(|(k, v)| Enum { name: k, values: v })
+            .map(|(k, v)| Enum {
+                namespace_id: Default::default(),
+                name: k,
+                values: v,
+            })
             .collect();
 
         enums.sort_by(|a, b| Ord::cmp(&a.name, &b.name));

--- a/libs/sql-schema-describer/src/sqlite.rs
+++ b/libs/sql-schema-describer/src/sqlite.rs
@@ -152,7 +152,7 @@ impl<'a> SqlSchemaDescriber<'a> {
 
         for name in names {
             let cloned_name = name.clone();
-            let id = schema.push_table(name);
+            let id = schema.push_table(name, Default::default());
             map.insert(cloned_name, id);
         }
 

--- a/libs/sql-schema-describer/tests/describers/mssql_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/mssql_describer_tests.rs
@@ -129,8 +129,12 @@ fn all_mssql_column_types_must_work(api: TestApi) {
     api.raw_cmd(&full_sql);
     let expectation = expect![[r#"
         SqlSchema {
+            namespaces: [],
             tables: [
                 Table {
+                    namespace_id: NamespaceId(
+                        0,
+                    ),
                     name: "User",
                 },
             ],

--- a/libs/sql-schema-describer/tests/describers/mysql_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/mysql_describer_tests.rs
@@ -91,13 +91,20 @@ fn all_mysql_column_types_must_work(api: TestApi) {
     api.raw_cmd(&full_sql);
     let expectation = expect![[r#"
         SqlSchema {
+            namespaces: [],
             tables: [
                 Table {
+                    namespace_id: NamespaceId(
+                        0,
+                    ),
                     name: "User",
                 },
             ],
             enums: [
                 Enum {
+                    namespace_id: NamespaceId(
+                        0,
+                    ),
                     name: "User_enum_col",
                     values: [
                         "a",
@@ -981,13 +988,20 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
     api.raw_cmd(&full_sql);
     let expectation = expect![[r#"
         SqlSchema {
+            namespaces: [],
             tables: [
                 Table {
+                    namespace_id: NamespaceId(
+                        0,
+                    ),
                     name: "User",
                 },
             ],
             enums: [
                 Enum {
+                    namespace_id: NamespaceId(
+                        0,
+                    ),
                     name: "User_enum_col",
                     values: [
                         "a",
@@ -1871,13 +1885,20 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
     api.raw_cmd(&full_sql);
     let expectation = expect![[r#"
         SqlSchema {
+            namespaces: [],
             tables: [
                 Table {
+                    namespace_id: NamespaceId(
+                        0,
+                    ),
                     name: "User",
                 },
             ],
             enums: [
                 Enum {
+                    namespace_id: NamespaceId(
+                        0,
+                    ),
                     name: "User_enum_col",
                     values: [
                         "a",
@@ -2859,11 +2880,18 @@ fn constraints_from_other_databases_should_not_be_introspected(api: TestApi) {
 
     let expectation = expect![[r#"
         SqlSchema {
+            namespaces: [],
             tables: [
                 Table {
+                    namespace_id: NamespaceId(
+                        0,
+                    ),
                     name: "Post",
                 },
                 Table {
+                    namespace_id: NamespaceId(
+                        0,
+                    ),
                     name: "User",
                 },
             ],
@@ -3045,8 +3073,12 @@ fn introspected_default_strings_should_be_unescaped(api: TestApi) {
     api.raw_cmd(create_table);
     let expectation = expect![[r#"
         SqlSchema {
+            namespaces: [],
             tables: [
                 Table {
+                    namespace_id: NamespaceId(
+                        0,
+                    ),
                     name: "User",
                 },
             ],
@@ -3109,8 +3141,12 @@ fn escaped_quotes_in_string_defaults_must_be_unescaped(api: TestApi) {
 
     let expectation = expect![[r#"
         SqlSchema {
+            namespaces: [],
             tables: [
                 Table {
+                    namespace_id: NamespaceId(
+                        0,
+                    ),
                     name: "string_defaults_test",
                 },
             ],
@@ -3204,8 +3240,12 @@ fn escaped_backslashes_in_string_literals_must_be_unescaped(api: TestApi) {
 
     let expectation = expect![[r#"
         SqlSchema {
+            namespaces: [],
             tables: [
                 Table {
+                    namespace_id: NamespaceId(
+                        0,
+                    ),
                     name: "test",
                 },
             ],
@@ -3279,13 +3319,20 @@ fn function_expression_defaults_are_described_as_dbgenerated(api: TestApi) {
 
     let expectation = expect![[r#"
         SqlSchema {
+            namespaces: [],
             tables: [
                 Table {
+                    namespace_id: NamespaceId(
+                        0,
+                    ),
                     name: "game",
                 },
             ],
             enums: [
                 Enum {
+                    namespace_id: NamespaceId(
+                        0,
+                    ),
                     name: "game_enum_col",
                     values: [
                         "x-small",

--- a/libs/sql-schema-describer/tests/describers/postgres_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/postgres_describer_tests.rs
@@ -75,8 +75,12 @@ fn all_postgres_column_types_must_work(api: TestApi) {
     api.raw_cmd(sql);
     let expectation = expect![[r#"
         SqlSchema {
+            namespaces: [],
             tables: [
                 Table {
+                    namespace_id: NamespaceId(
+                        0,
+                    ),
                     name: "User",
                 },
             ],
@@ -1252,8 +1256,12 @@ fn escaped_quotes_in_string_defaults_must_be_unescaped(api: TestApi) {
     api.raw_cmd(create_table);
     let expectation = expect![[r#"
         SqlSchema {
+            namespaces: [],
             tables: [
                 Table {
+                    namespace_id: NamespaceId(
+                        0,
+                    ),
                     name: "string_defaults_test",
                 },
             ],
@@ -1413,8 +1421,12 @@ fn seemingly_escaped_backslashes_in_string_literals_must_not_be_unescaped(api: T
     api.raw_cmd(create_table);
     let expectation = expect![[r#"
         SqlSchema {
+            namespaces: [],
             tables: [
                 Table {
+                    namespace_id: NamespaceId(
+                        0,
+                    ),
                     name: "test",
                 },
             ],

--- a/libs/sql-schema-describer/tests/describers/postgres_describer_tests/cockroach_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/postgres_describer_tests/cockroach_describer_tests.rs
@@ -232,8 +232,12 @@ fn multi_field_indexes_must_be_inferred_in_the_right_order(api: TestApi) {
     api.raw_cmd(&schema);
     let expectation = expect![[r#"
         SqlSchema {
+            namespaces: [],
             tables: [
                 Table {
+                    namespace_id: NamespaceId(
+                        0,
+                    ),
                     name: "indexes_test",
                 },
             ],

--- a/libs/sql-schema-describer/tests/describers/sqlite_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/sqlite_describer_tests.rs
@@ -62,8 +62,12 @@ fn sqlite_column_types_must_work(api: TestApi) {
     api.raw_cmd(sql);
     let expectation = expect![[r#"
         SqlSchema {
+            namespaces: [],
             tables: [
                 Table {
+                    namespace_id: NamespaceId(
+                        0,
+                    ),
                     name: "User",
                 },
             ],
@@ -266,8 +270,12 @@ fn escaped_quotes_in_string_defaults_must_be_unescaped(api: TestApi) {
     api.raw_cmd(create_table);
     let expectation = expect![[r#"
         SqlSchema {
+            namespaces: [],
             tables: [
                 Table {
+                    namespace_id: NamespaceId(
+                        0,
+                    ),
                     name: "string_defaults_test",
                 },
             ],
@@ -349,8 +357,12 @@ fn backslashes_in_string_literals(api: TestApi) {
 
     let expectation = expect![[r#"
         SqlSchema {
+            namespaces: [],
             tables: [
                 Table {
+                    namespace_id: NamespaceId(
+                        0,
+                    ),
                     name: "test",
                 },
             ],
@@ -419,11 +431,18 @@ fn broken_relations_are_filtered_out(api: TestApi) {
     // the relation to platypus should be the only foreign key on dog
     let expectation = expect![[r#"
         SqlSchema {
+            namespaces: [],
             tables: [
                 Table {
+                    namespace_id: NamespaceId(
+                        0,
+                    ),
                     name: "dog",
                 },
                 Table {
+                    namespace_id: NamespaceId(
+                        0,
+                    ),
                     name: "platypus",
                 },
             ],

--- a/migration-engine/ARCHITECTURE.md
+++ b/migration-engine/ARCHITECTURE.md
@@ -474,3 +474,11 @@ Note that the Client API for this schema will not be as ergonomic as a proper
 many-to-many relations API. There are issues about this problem,
 https://github.com/prisma/prisma/issues/6135 for example. Please participate in
 these discussions to help push design work forward.
+
+### Why do the migrations we generate not use CREATE IF NOT EXISTS type queries?
+
+Our stance so far has been "never use IF NOT EXISTS, we should always know if
+something exists or not in diffing". We have a first exception in a work in
+progress proposal proposal, motivated by not wanting to make the feature a
+breaking change, but the general rule is that we want diffing to be as precise
+as possible, so generated migrations should not rely on IF NOT EXISTS.

--- a/migration-engine/connectors/sql-migration-connector/src/apply_migration.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/apply_migration.rs
@@ -129,6 +129,9 @@ fn render_raw_sql(
         SqlMigrationStep::AlterEnum(alter_enum) => renderer.render_alter_enum(alter_enum, schemas),
         SqlMigrationStep::RedefineTables(redefine_tables) => renderer.render_redefine_tables(redefine_tables, schemas),
         SqlMigrationStep::CreateEnum(enum_id) => renderer.render_create_enum(schemas.next.walk(*enum_id)),
+        SqlMigrationStep::CreateSchema(namespace_id) => {
+            vec![renderer.render_create_namespace(schemas.next.walk(*namespace_id))]
+        }
         SqlMigrationStep::DropEnum(enum_id) => renderer.render_drop_enum(schemas.previous.walk(*enum_id)),
         SqlMigrationStep::CreateTable { table_id } => {
             let table = schemas.next.walk(*table_id);

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/mysql.rs
@@ -147,11 +147,11 @@ fn is_safe_enum_change(columns: &Pair<ColumnWalker<'_>>, plan: &mut DestructiveC
         columns.next.column_type_family_as_enum(),
     ) {
         let removed_values: Vec<String> = previous_enum
-            .values
+            .values()
             .iter()
             .filter(|previous_value| {
                 !next_enum
-                    .values
+                    .values()
                     .iter()
                     .any(|next_value| previous_value.as_str() == next_value.as_str())
             })
@@ -161,7 +161,7 @@ fn is_safe_enum_change(columns: &Pair<ColumnWalker<'_>>, plan: &mut DestructiveC
         if !removed_values.is_empty() {
             plan.push_warning(
                 SqlMigrationWarningCheck::EnumValueRemoval {
-                    enm: next_enum.name.clone(),
+                    enm: next_enum.name().to_owned(),
                     values: removed_values,
                 },
                 step_index,

--- a/migration-engine/connectors/sql-migration-connector/src/sql_migration.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_migration.rs
@@ -60,6 +60,7 @@ impl SqlMigration {
             let idx = idx as u32;
             match step {
                 SqlMigrationStep::AlterSequence(_, _) => (),
+                SqlMigrationStep::CreateSchema(_) => (), // todo
                 SqlMigrationStep::DropView(drop_view) => {
                     drift_items.insert((
                         DriftType::RemovedView,
@@ -201,6 +202,7 @@ impl SqlMigration {
                     out.push_str(self.schemas().next.walk(*enum_id).name());
                     out.push('\n');
                 }
+                SqlMigrationStep::CreateSchema(_) => {} // todo
                 SqlMigrationStep::AlterEnum(alter_enum) => {
                     for added in &alter_enum.created_variants {
                         out.push_str("  [+] Added variant `");
@@ -405,6 +407,7 @@ fn render_column_changes(columns: Pair<ColumnWalker<'_>>, changes: &ColumnChange
 // you would intuitively expect.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) enum SqlMigrationStep {
+    CreateSchema(sql_schema_describer::NamespaceId),
     AlterSequence(Pair<u32>, SequenceChanges),
     DropView(DropView),
     DropUserDefinedType(DropUserDefinedType),
@@ -468,6 +471,7 @@ impl SqlMigrationStep {
             SqlMigrationStep::AlterTable(_) => "AlterTable",
             SqlMigrationStep::CreateEnum(_) => "CreateEnum",
             SqlMigrationStep::CreateIndex { .. } => "CreateIndex",
+            SqlMigrationStep::CreateSchema { .. } => "CreateSchema",
             SqlMigrationStep::CreateTable { .. } => "CreateTable",
             SqlMigrationStep::DropEnum(_) => "DropEnum",
             SqlMigrationStep::DropForeignKey { .. } => "DropForeignKey",

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer.rs
@@ -16,12 +16,13 @@ mod sqlite_renderer;
 
 pub(crate) use common::IteratorJoin;
 
+use self::common::{Quoted, TableName};
 use crate::{
     pair::Pair,
     sql_migration::{AlterEnum, AlterTable, RedefineTable, SequenceChanges},
 };
-use common::Quoted;
 use sql_schema_describer::{
+    self as sql,
     walkers::{EnumWalker, ForeignKeyWalker, IndexWalker, TableWalker, UserDefinedTypeWalker, ViewWalker},
     SqlSchema,
 };
@@ -57,12 +58,10 @@ pub(crate) trait SqlRenderer {
     fn render_create_index(&self, index: IndexWalker<'_>) -> String;
 
     /// Render a table creation step.
-    fn render_create_table(&self, table: TableWalker<'_>) -> String {
-        self.render_create_table_as(table, table.name())
-    }
+    fn render_create_table(&self, table: TableWalker<'_>) -> String;
 
     /// Render a table creation with the provided table name.
-    fn render_create_table_as(&self, table: TableWalker<'_>, table_name: &str) -> String;
+    fn render_create_table_as(&self, table: TableWalker<'_>, table_name: TableName<&str>) -> String;
 
     fn render_drop_and_recreate_index(&self, _indexes: Pair<IndexWalker<'_>>) -> Vec<String> {
         unreachable!("unreachable render_drop_and_recreate_index")
@@ -106,4 +105,8 @@ pub(crate) trait SqlRenderer {
 
     /// Render a `RenameForeignKey` step.
     fn render_rename_foreign_key(&self, fks: Pair<ForeignKeyWalker<'_>>) -> String;
+
+    fn render_create_namespace(&self, _namespace: sql::NamespaceWalker<'_>) -> String {
+        unreachable!()
+    }
 }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/common.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/common.rs
@@ -3,6 +3,22 @@ use std::fmt::{Display, Write as _};
 
 pub(super) const SQL_INDENTATION: &str = "    ";
 
+/// A table name with an optional schema prefix.
+pub(crate) struct TableName<T>(pub(crate) Option<Quoted<T>>, pub(crate) Quoted<T>);
+
+impl<T> Display for TableName<T>
+where
+    T: Display,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(schema) = &self.0 {
+            Display::fmt(&schema, f)?;
+            f.write_str(".")?;
+        }
+        Display::fmt(&self.1, f)
+    }
+}
+
 #[derive(Debug)]
 pub(crate) enum Quoted<T> {
     Double(T),

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
@@ -220,9 +220,9 @@ impl SqlRenderer for MysqlFlavour {
         .to_string()
     }
 
-    fn render_create_table_as(&self, table: TableWalker<'_>, table_name: &str) -> String {
+    fn render_create_table_as(&self, table: TableWalker<'_>, table_name: TableName<&str>) -> String {
         ddl::CreateTable {
-            table_name: table_name.into(),
+            table_name: &table_name,
             columns: table.columns().map(|col| self.render_column(col)).collect(),
             indexes: table
                 .indexes()
@@ -328,7 +328,7 @@ impl SqlRenderer for MysqlFlavour {
     }
 
     fn render_create_table(&self, table: TableWalker<'_>) -> String {
-        self.render_create_table_as(table, table.name())
+        self.render_create_table_as(table, TableName(None, Quoted::mysql_ident(table.name())))
     }
 
     fn render_drop_view(&self, view: ViewWalker<'_>) -> String {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
@@ -84,12 +84,18 @@ impl SqlRenderer for PostgresFlavour {
 
     fn render_add_foreign_key(&self, foreign_key: ForeignKeyWalker<'_>) -> String {
         ddl::AlterTable {
-            table_name: ddl::PostgresIdentifier::Simple(foreign_key.table().name().into()),
+            table_name: &TableName(
+                foreign_key.table().namespace().map(Quoted::postgres_ident),
+                Quoted::postgres_ident(foreign_key.table().name()),
+            ),
             clauses: vec![ddl::AlterTableClause::AddForeignKey(ddl::ForeignKey {
                 constrained_columns: foreign_key.constrained_columns().map(|c| c.name().into()).collect(),
                 referenced_columns: foreign_key.referenced_columns().map(|c| c.name().into()).collect(),
                 constraint_name: foreign_key.constraint_name().map(From::from),
-                referenced_table: foreign_key.referenced_table().name().into(),
+                referenced_table: &TableName(
+                    foreign_key.referenced_table().namespace().map(Quoted::postgres_ident),
+                    Quoted::postgres_ident(foreign_key.referenced_table().name()),
+                ),
                 on_delete: Some(match foreign_key.on_delete_action() {
                     ForeignKeyAction::Cascade => ddl::ForeignKeyAction::Cascade,
                     ForeignKeyAction::NoAction => ddl::ForeignKeyAction::NoAction,
@@ -259,10 +265,20 @@ impl SqlRenderer for PostgresFlavour {
     fn render_create_enum(&self, enm: EnumWalker<'_>) -> Vec<String> {
         render_step(&mut |step| {
             step.render_statement(&mut |stmt| {
-                stmt.push_display(&ddl::CreateEnum {
-                    enum_name: enm.name().into(),
-                    variants: enm.values().iter().map(|s| Cow::Borrowed(s.as_str())).collect(),
-                })
+                stmt.push_str("CREATE TYPE ");
+                stmt.push_display(&TableName(
+                    enm.namespace().map(Quoted::postgres_ident),
+                    Quoted::postgres_ident(enm.name()),
+                ));
+                stmt.push_str(" AS ENUM (");
+                let mut values = enm.values().iter().peekable();
+                while let Some(value) = values.next() {
+                    stmt.push_display(&Quoted::postgres_string(value));
+                    if values.peek().is_some() {
+                        stmt.push_str(", ");
+                    }
+                }
+                stmt.push_str(")");
             })
         })
     }
@@ -298,7 +314,21 @@ impl SqlRenderer for PostgresFlavour {
         .to_string()
     }
 
-    fn render_create_table_as(&self, table: TableWalker<'_>, table_name: &str) -> String {
+    fn render_create_namespace(&self, ns: sql_schema_describer::NamespaceWalker<'_>) -> String {
+        format!("CREATE SCHEMA IF NOT EXISTS {}", Quoted::postgres_ident(ns.name()))
+    }
+
+    fn render_create_table(&self, table: TableWalker<'_>) -> String {
+        self.render_create_table_as(
+            table,
+            TableName(
+                table.namespace().map(Quoted::postgres_ident),
+                Quoted::postgres_ident(table.name()),
+            ),
+        )
+    }
+
+    fn render_create_table_as(&self, table: TableWalker<'_>, table_name: TableName<&str>) -> String {
         let columns: String = table.columns().map(|column| self.render_column(column)).join(",\n");
 
         let pk = if let Some(pk) = table.primary_key() {
@@ -314,12 +344,7 @@ impl SqlRenderer for PostgresFlavour {
             String::new()
         };
 
-        format!(
-            "CREATE TABLE {table_name} (\n{columns}{primary_key}\n)",
-            table_name = self.quote(table_name),
-            columns = columns,
-            primary_key = pk,
-        )
+        format!("CREATE TABLE {table_name} (\n{columns}{pk}\n)")
     }
 
     fn render_drop_enum(&self, dropped_enum: EnumWalker<'_>) -> Vec<String> {
@@ -371,7 +396,10 @@ impl SqlRenderer for PostgresFlavour {
         for redefine_table in tables {
             let tables = schemas.walk(redefine_table.table_ids);
             let temporary_table_name = format!("_prisma_new_{}", &tables.next.name());
-            result.push(self.render_create_table_as(tables.next, &temporary_table_name));
+            result.push(self.render_create_table_as(
+                tables.next,
+                TableName(None, Quoted::postgres_ident(&temporary_table_name)),
+            ));
 
             let columns: Vec<_> = redefine_table
                 .column_pairs
@@ -416,11 +444,11 @@ impl SqlRenderer for PostgresFlavour {
     }
 
     fn render_rename_table(&self, name: &str, new_name: &str) -> String {
-        ddl::AlterTable {
-            table_name: name.into(),
-            clauses: vec![ddl::AlterTableClause::RenameTo(new_name.into())],
-        }
-        .to_string()
+        format!(
+            "ALTER TABLE {} RENAME TO {}",
+            Quoted::postgres_ident(name),
+            Quoted::postgres_ident(new_name)
+        )
     }
 
     fn render_drop_user_defined_type(&self, _: &UserDefinedTypeWalker<'_>) -> String {
@@ -439,8 +467,13 @@ impl SqlRenderer for PostgresFlavour {
 
 fn render_column_type(col: ColumnWalker<'_>, flavour: &PostgresFlavour) -> Cow<'static, str> {
     let t = col.column_type();
-    if let ColumnTypeFamily::Enum(name) = &t.family {
-        return format!("\"{}\"{}", name, if t.arity.is_list() { "[]" } else { "" }).into();
+    if let Some(enm) = col.column_type_family_as_enum() {
+        let name = TableName(
+            enm.namespace().map(Quoted::postgres_ident),
+            Quoted::postgres_ident(enm.name()),
+        );
+        let arity = if t.arity.is_list() { "[]" } else { "" };
+        return format!("{name}{arity}").into();
     }
 
     if let ColumnTypeFamily::Unsupported(description) = &t.family {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
@@ -19,14 +19,29 @@ use std::collections::HashMap;
 pub(crate) fn calculate_sql_schema(datamodel: &ValidatedSchema, flavour: &dyn SqlFlavour) -> SqlDatabaseSchema {
     let mut schema = SqlDatabaseSchema::default();
 
-    schema.describer_schema.enums = flavour.calculate_enums(datamodel);
-
     let mut context = Context {
         datamodel,
         schema: &mut schema,
         flavour,
         model_id_to_table_id: HashMap::with_capacity(datamodel.db.models_count()),
+        schemas: Default::default(),
     };
+
+    if datamodel
+        .configuration
+        .preview_features()
+        .contains(datamodel::common::preview_features::PreviewFeature::MultiSchema)
+    {
+        if let Some(ds) = context.datamodel.configuration.datasources.get(0) {
+            for (schema, _) in &ds.schemas {
+                context
+                    .schemas
+                    .insert(schema, context.schema.describer_schema.push_namespace(schema.clone()));
+            }
+        }
+    }
+
+    context.schema.describer_schema.enums = flavour.calculate_enums(&context);
 
     // Two types of tables: model tables and implicit M2M relation tables (a.k.a. join tables.).
     push_model_tables(&mut context);
@@ -43,7 +58,15 @@ pub(crate) fn calculate_sql_schema(datamodel: &ValidatedSchema, flavour: &dyn Sq
 
 fn push_model_tables(ctx: &mut Context<'_>) {
     for model in ctx.datamodel.db.walk_models() {
-        let table_id = ctx.schema.describer_schema.push_table(model.database_name().to_owned());
+        let namespace_id = model
+            .schema()
+            .and_then(|(name, _)| ctx.schemas.get(name))
+            .copied()
+            .unwrap_or_default();
+        let table_id = ctx
+            .schema
+            .describer_schema
+            .push_table(model.database_name().to_owned(), namespace_id);
         ctx.model_id_to_table_id.insert(model.model_id(), table_id);
 
         for field in model.scalar_fields() {
@@ -197,7 +220,8 @@ fn push_relation_tables(ctx: &mut Context<'_>) {
             format!("{table_name}_B{fk_suffix}")
         };
 
-        let table_id = ctx.schema.describer_schema.push_table(table_name.clone());
+        let namespace_id = ctx.walk(model_a_table_id).namespace_id(); // we put the join table in the schema of table A.
+        let table_id = ctx.schema.describer_schema.push_table(table_name.clone(), namespace_id);
         let column_a_type = ctx
             .walk(model_a_table_id)
             .primary_key_columns()
@@ -544,6 +568,7 @@ pub(crate) struct Context<'a> {
     datamodel: &'a ValidatedSchema,
     schema: &'a mut SqlDatabaseSchema,
     flavour: &'a dyn SqlFlavour,
+    schemas: HashMap<&'a str, sql::NamespaceId>,
     model_id_to_table_id: HashMap<ast::ModelId, sql::TableId>,
 }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour.rs
@@ -3,14 +3,11 @@ mod mysql;
 mod postgres;
 mod sqlite;
 
-use datamodel::{
-    parser_database::{ast::FieldArity, walkers::*},
-    ValidatedSchema,
-};
+use datamodel::parser_database::{ast::FieldArity, walkers::*};
 use sql_schema_describer::{self as sql, ColumnArity, ColumnType, ColumnTypeFamily};
 
 pub(crate) trait SqlSchemaCalculatorFlavour {
-    fn calculate_enums(&self, _datamodel: &ValidatedSchema) -> Vec<sql::Enum> {
+    fn calculate_enums(&self, _ctx: &super::Context<'_>) -> Vec<sql::Enum> {
         Vec::new()
     }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/mysql.rs
@@ -1,10 +1,11 @@
-use super::SqlSchemaCalculatorFlavour;
+use super::{super::Context, SqlSchemaCalculatorFlavour};
 use crate::flavour::MysqlFlavour;
-use datamodel::{parser_database::walkers::*, ValidatedSchema};
+use datamodel::parser_database::walkers::*;
 use sql_schema_describer as sql;
 
 impl SqlSchemaCalculatorFlavour for MysqlFlavour {
-    fn calculate_enums(&self, datamodel: &ValidatedSchema) -> Vec<sql::Enum> {
+    fn calculate_enums(&self, ctx: &Context<'_>) -> Vec<sql::Enum> {
+        let datamodel = ctx.datamodel;
         // This is a lower bound for the size of the generated enums (we assume
         // each enum is used at least once).
         let mut enums = Vec::new();
@@ -17,6 +18,7 @@ impl SqlSchemaCalculatorFlavour for MysqlFlavour {
 
         for (field, enum_tpe) in enum_fields {
             let sql_enum = sql::Enum {
+                namespace_id: Default::default(),
                 name: format!(
                     "{model_name}_{field_name}",
                     model_name = field.model().database_name(),

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/postgres.rs
@@ -1,20 +1,23 @@
-use super::SqlSchemaCalculatorFlavour;
+use super::{super::Context, SqlSchemaCalculatorFlavour};
 use crate::flavour::{PostgresFlavour, SqlFlavour};
 use datamodel::{
     builtin_connectors::cockroach_datamodel_connector::SequenceFunction,
     datamodel_connector::walker_ext_traits::IndexWalkerExt,
     parser_database::{walkers::*, IndexAlgorithm, OperatorClass},
-    ValidatedSchema,
 };
 use either::Either;
 use sql_schema_describer::{self as sql, postgres::PostgresSchemaExt};
 
 impl SqlSchemaCalculatorFlavour for PostgresFlavour {
-    fn calculate_enums(&self, datamodel: &ValidatedSchema) -> Vec<sql::Enum> {
-        datamodel
+    fn calculate_enums(&self, ctx: &Context<'_>) -> Vec<sql::Enum> {
+        ctx.datamodel
             .db
             .walk_enums()
             .map(|r#enum| sql::Enum {
+                namespace_id: r#enum
+                    .schema()
+                    .map(|(schema, _)| ctx.schemas[schema])
+                    .unwrap_or_default(),
                 name: r#enum.database_name().to_owned(),
                 values: r#enum.values().map(|val| val.database_name().to_owned()).collect(),
             })

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
@@ -24,6 +24,7 @@ pub(crate) fn calculate_steps(schemas: Pair<&SqlDatabaseSchema>, flavour: &dyn S
     let db = DifferDatabase::new(schemas, flavour);
     let mut steps: Vec<SqlMigrationStep> = Vec::new();
 
+    push_created_schema_steps(&mut steps, &db);
     push_created_table_steps(&mut steps, &db);
     push_dropped_table_steps(&mut steps, &db);
     push_dropped_index_steps(&mut steps, &db);
@@ -37,6 +38,12 @@ pub(crate) fn calculate_steps(schemas: Pair<&SqlDatabaseSchema>, flavour: &dyn S
     steps.sort();
 
     steps
+}
+
+fn push_created_schema_steps(steps: &mut Vec<SqlMigrationStep>, db: &DifferDatabase<'_>) {
+    for schema in db.schemas().next.describer_schema.walk_namespaces() {
+        steps.push(SqlMigrationStep::CreateSchema(schema.id))
+    }
 }
 
 fn push_created_table_steps(steps: &mut Vec<SqlMigrationStep>, db: &DifferDatabase<'_>) {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/mysql.rs
@@ -40,14 +40,14 @@ impl SqlSchemaDifferFlavour for MysqlFlavour {
             differ.next.column_type_family_as_enum(),
         ) {
             (Some(previous_enum), Some(next_enum)) => {
-                if previous_enum.values == next_enum.values {
+                if previous_enum.values() == next_enum.values() {
                     return None;
                 }
 
                 return if previous_enum
-                    .values
+                    .values()
                     .iter()
-                    .all(|previous_value| next_enum.values.iter().any(|next_value| previous_value == next_value))
+                    .all(|previous_value| next_enum.values().iter().any(|next_value| previous_value == next_value))
                 {
                     Some(ColumnTypeChange::SafeCast)
                 } else {

--- a/migration-engine/migration-engine-tests/build.rs
+++ b/migration-engine/migration-engine-tests/build.rs
@@ -1,0 +1,46 @@
+use std::{env, fs, io::Write as _, path};
+
+const ROOT_DIR: &str = "tests/single_migration_tests";
+
+fn main() {
+    println!("cargo:rerun-if-changed={ROOT_DIR}");
+
+    let mut all_schemas = Vec::new();
+    find_all_schemas("", &mut all_schemas);
+
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let out_file_path = path::Path::new(&out_dir).join("single_migration_tests.rs");
+    let mut out_file = fs::File::create(out_file_path).unwrap();
+
+    for schema_path in &all_schemas {
+        let test_name = schema_path.trim_start_matches('/').trim_end_matches(".prisma");
+        let test_name = test_name.replace(&['/', '\\'], "_");
+        let file_path = schema_path.trim_start_matches('/');
+        writeln!(
+            out_file,
+            "#[test] fn {test_name}() {{ run_single_migration_test(\"{file_path}\", \"{test_name}\"); }}"
+        )
+        .unwrap();
+    }
+}
+
+fn find_all_schemas(prefix: &str, all_schemas: &mut Vec<String>) {
+    let cargo_manifest_dir = env!("CARGO_MANIFEST_DIR");
+    for entry in fs::read_dir(format!("{cargo_manifest_dir}/{ROOT_DIR}/{prefix}")).unwrap() {
+        let entry = entry.unwrap();
+        let file_name = entry.file_name();
+        let file_name = file_name.to_str().unwrap();
+        let entry_path = format!("{}/{}", prefix, file_name);
+        let file_type = entry.file_type().unwrap();
+
+        if file_name == "." || file_name == ".." {
+            continue;
+        }
+
+        if file_type.is_file() {
+            all_schemas.push(entry_path);
+        } else if file_type.is_dir() {
+            find_all_schemas(&entry_path, all_schemas);
+        }
+    }
+}

--- a/migration-engine/migration-engine-tests/tests/single_migration_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/single_migration_tests.rs
@@ -1,0 +1,100 @@
+use migration_engine_tests::test_api::*;
+use std::{fs, io::Write as _, path, sync::Arc};
+use test_setup::TestApiArgs;
+
+const TESTS_ROOT: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/single_migration_tests");
+
+#[inline(never)] // we want to compile fast
+fn run_single_migration_test(test_file_path: &str, test_function_name: &'static str) {
+    let file_path = path::Path::new(TESTS_ROOT).join(test_file_path);
+    let text: Arc<str> = Arc::from(std::fs::read_to_string(&file_path).unwrap().into_boxed_str());
+
+    let last_comment_idx = {
+        let mut idx = None;
+        let newlines = text.char_indices().filter(|(_, c)| *c == '\n');
+
+        for (newline_idx, _) in newlines {
+            match (text.get(newline_idx + 1..newline_idx + 3), idx) {
+                (Some("//"), None) => {
+                    idx = Some(newline_idx + 1); // new comment
+                }
+                (Some("//"), Some(_)) => (), // comment continues
+                (None, _) => (),             // eof
+                (Some(_), _) => {
+                    idx = None;
+                }
+            }
+        }
+
+        idx
+    };
+    let last_comment_contents: String = last_comment_idx
+        .map(|idx| {
+            let mut out = String::with_capacity(text.len() - idx);
+            for line in text[idx..].lines() {
+                out.push_str(line.trim_start_matches("// "));
+                out.push('\n');
+            }
+            out
+        })
+        .unwrap_or_default();
+
+    let mut lines = text.lines();
+    let tags = {
+        let first_line = lines.next().expect("Expected file not to be empty.");
+        let expected_tags_prefix = "// tags=";
+        assert!(
+            first_line.starts_with(expected_tags_prefix),
+            "The first line of a single migration test test must start with \"{}\"",
+            expected_tags_prefix
+        );
+        let tags = first_line.trim_start_matches(expected_tags_prefix);
+        test_setup::tags_from_comma_separated_list(tags)
+    };
+    let excluded = {
+        let second_line = lines.next().expect("Expected test file not to be empty.");
+        let expected_tags_prefix = "// exclude=";
+        if second_line.starts_with(expected_tags_prefix) {
+            let tags = second_line.trim_start_matches(expected_tags_prefix);
+            test_setup::tags_from_comma_separated_list(tags)
+        } else {
+            Default::default()
+        }
+    };
+
+    if test_setup::should_skip_test(tags, excluded, Default::default()) {
+        return;
+    }
+
+    let test_api_args = TestApiArgs::new(test_function_name, &[]);
+    let mut test_api = TestApi::new(test_api_args);
+
+    let migration: String = test_api.connector_diff(
+        migration_core::migration_connector::DiffTarget::Empty,
+        migration_core::migration_connector::DiffTarget::Datamodel(
+            datamodel::parser_database::SourceFile::new_allocated(text.clone()),
+        ),
+    );
+
+    test_api.raw_cmd(&migration); // check that it runs
+
+    if migration == last_comment_contents {
+        return; // success!
+    }
+
+    if std::env::var("UPDATE_EXPECT").is_ok() {
+        let mut file = fs::File::create(&file_path).unwrap(); // truncate
+
+        let schema = last_comment_idx.map(|idx| &text[..idx]).unwrap_or(&text);
+        file.write_all(schema.as_bytes()).unwrap();
+
+        for line in migration.lines() {
+            writeln!(file, "// {line}").unwrap();
+        }
+        return;
+    }
+
+    test_setup::panic_with_diff(&last_comment_contents, &migration);
+}
+
+include!(concat!(env!("OUT_DIR"), "/single_migration_tests.rs"));

--- a/migration-engine/migration-engine-tests/tests/single_migration_tests/postgres/multi_schema_basic.prisma
+++ b/migration-engine/migration-engine-tests/tests/single_migration_tests/postgres/multi_schema_basic.prisma
@@ -1,0 +1,100 @@
+// tags=postgres
+// exclude=cockroachdb
+
+datasource testds {
+    provider = "postgresql"
+    url = env("TEST_DATABASE_URL")
+    schemas = ["public", "security", "users"]
+}
+
+generator js {
+    provider = "prisma-client-js"
+    previewFeatures = ["multiSchema"]
+}
+
+model Test {
+  id Int @id
+  @@schema("users")
+}
+
+model Test2 {
+  id Int @id
+  @@schema("public")
+}
+
+model Test3 {
+  id Int @id
+  type UserType
+  @@schema("security")
+}
+
+enum UserType {
+  Bacteria
+  Archea
+  Eukaryote
+
+  @@schema("users")
+}
+
+model Test4 {
+  id Int @id
+  test5 Test5 @relation(fields: [id], references: [id])
+  @@schema("public")
+}
+
+model Test5 {
+  id Int @id
+  test4 Test4[]
+  @@schema("security")
+}
+
+// -- CreateSchema
+// CREATE SCHEMA IF NOT EXISTS "public";
+// 
+// -- CreateSchema
+// CREATE SCHEMA IF NOT EXISTS "security";
+// 
+// -- CreateSchema
+// CREATE SCHEMA IF NOT EXISTS "users";
+// 
+// -- CreateEnum
+// CREATE TYPE "users"."UserType" AS ENUM ('Bacteria', 'Archea', 'Eukaryote');
+// 
+// -- CreateTable
+// CREATE TABLE "users"."Test" (
+//     "id" INTEGER NOT NULL,
+// 
+//     CONSTRAINT "Test_pkey" PRIMARY KEY ("id")
+// );
+// 
+// -- CreateTable
+// CREATE TABLE "public"."Test2" (
+//     "id" INTEGER NOT NULL,
+// 
+//     CONSTRAINT "Test2_pkey" PRIMARY KEY ("id")
+// );
+// 
+// -- CreateTable
+// CREATE TABLE "security"."Test3" (
+//     "id" INTEGER NOT NULL,
+//     "type" "users"."UserType" NOT NULL,
+// 
+//     CONSTRAINT "Test3_pkey" PRIMARY KEY ("id")
+// );
+// 
+// -- CreateTable
+// CREATE TABLE "public"."Test4" (
+//     "id" INTEGER NOT NULL,
+// 
+//     CONSTRAINT "Test4_pkey" PRIMARY KEY ("id")
+// );
+// 
+// -- CreateTable
+// CREATE TABLE "security"."Test5" (
+//     "id" INTEGER NOT NULL,
+// 
+//     CONSTRAINT "Test5_pkey" PRIMARY KEY ("id")
+// );
+// 
+// -- AddForeignKey
+// ALTER TABLE "public"."Test4" ADD CONSTRAINT "Test4_id_fkey" FOREIGN KEY ("id") REFERENCES "security"."Test5"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/migration-engine/migration-engine-tests/tests/single_migration_tests/sqlite/constraint_names_basic.prisma
+++ b/migration-engine/migration-engine-tests/tests/single_migration_tests/sqlite/constraint_names_basic.prisma
@@ -1,0 +1,59 @@
+// tags=sqlite
+
+datasource db {
+    provider = "sqlite"
+    url = env("TEST_DATABASE_URL")
+}
+
+model A {
+  id   Int    @id
+  name String @unique(map: "SingleUnique")
+  a    String
+  b    String
+  B    B[]    @relation("AtoB")
+  @@unique([a, b], name: "compound", map:"NamedCompoundUnique")
+  @@unique([a, b], map:"UnNamedCompoundUnique")
+  @@index([a], map: "SingleIndex")
+}
+
+model B {
+  a   String
+  b   String
+  aId Int
+  A   A      @relation("AtoB", fields: [aId], references: [id])
+  @@index([a,b], map: "CompoundIndex")
+  @@id([a, b])
+}
+
+// -- CreateTable
+// CREATE TABLE "A" (
+//     "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+//     "name" TEXT NOT NULL,
+//     "a" TEXT NOT NULL,
+//     "b" TEXT NOT NULL
+// );
+// 
+// -- CreateTable
+// CREATE TABLE "B" (
+//     "a" TEXT NOT NULL,
+//     "b" TEXT NOT NULL,
+//     "aId" INTEGER NOT NULL,
+// 
+//     PRIMARY KEY ("a", "b"),
+//     CONSTRAINT "B_aId_fkey" FOREIGN KEY ("aId") REFERENCES "A" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+// );
+// 
+// -- CreateIndex
+// CREATE UNIQUE INDEX "SingleUnique" ON "A"("name");
+// 
+// -- CreateIndex
+// CREATE INDEX "SingleIndex" ON "A"("a");
+// 
+// -- CreateIndex
+// CREATE UNIQUE INDEX "NamedCompoundUnique" ON "A"("a", "b");
+// 
+// -- CreateIndex
+// CREATE UNIQUE INDEX "UnNamedCompoundUnique" ON "A"("a", "b");
+// 
+// -- CreateIndex
+// CREATE INDEX "CompoundIndex" ON "B"("a", "b");


### PR DESCRIPTION
This is an extremely restricted version of the multi-schema feature
implementation meant to just about enable writing query engine tests
using multiple schemas __on postgres only__.

- Add rudimentary multi-namespace (schema) support to sql-schema-describer.
- Calculate (sql-schema-calculator), diff and render schema names on
  postgres in the migration engine.
- Set up the declarative single-migration test suite we have been
  discussing in the team for a while.

Also includes:

psl: validate that if one Schema attribute is used, all items must be annotated