### PR TITLE
chore(qe) Cleans up test logging to be more useful

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -20,7 +20,7 @@ export SIMPLE_TEST_MODE="yes" # Reduces the amount of generated `relation_link_t
 
 ### QE specific logging vars ###
 export QE_LOG_LEVEL=debug # Set it to "trace" to enable query-graph debugging logs
-# export FMT_SQL=1 # Uncomment it to enable logging formatted SQL queries
+export FMT_SQL=1 # Uncomment it to enable logging formatted SQL queries
 
 # Mongo image requires additional wait time on arm arch for some reason.
 if uname -a | grep -q 'arm64'; then

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/logging.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/logging.rs
@@ -1,74 +1,63 @@
 use query_engine_metrics::MetricRegistry;
 use tracing_error::ErrorLayer;
-use tracing_subscriber::{
-    filter::Filtered, fmt::format::DefaultFields, layer::Layered, prelude::*, EnvFilter, Registry,
-};
+use tracing_subscriber::{layer::Layered, prelude::*, EnvFilter, Registry};
 
 // Pretty ugly. I'm not sure how to make this better
 type Sub = Layered<
     ErrorLayer<
         Layered<
-            MetricRegistry,
-            Layered<
-                Filtered<
-                    tracing_subscriber::fmt::Layer<
-                        Registry,
-                        DefaultFields,
-                        tracing_subscriber::fmt::format::Format,
-                        PrintWriter,
-                    >,
-                    EnvFilter,
-                    Registry,
-                >,
-                Registry,
+            Box<
+                dyn tracing_subscriber::Layer<
+                        Layered<Box<dyn tracing_subscriber::Layer<Registry> + Send + Sync>, Registry>,
+                    > + Send
+                    + Sync,
             >,
+            Layered<Box<dyn tracing_subscriber::Layer<Registry> + Send + Sync>, Registry>,
         >,
     >,
     Layered<
-        MetricRegistry,
-        Layered<
-            Filtered<
-                tracing_subscriber::fmt::Layer<
-                    Registry,
-                    DefaultFields,
-                    tracing_subscriber::fmt::format::Format,
-                    PrintWriter,
-                >,
-                EnvFilter,
-                Registry,
-            >,
-            Registry,
+        Box<
+            dyn tracing_subscriber::Layer<Layered<Box<dyn tracing_subscriber::Layer<Registry> + Send + Sync>, Registry>>
+                + Send
+                + Sync,
         >,
-    >,
-    Layered<
-        MetricRegistry,
-        Layered<
-            Filtered<
-                tracing_subscriber::fmt::Layer<
-                    Registry,
-                    DefaultFields,
-                    tracing_subscriber::fmt::format::Format,
-                    PrintWriter,
-                >,
-                EnvFilter,
-                Registry,
-            >,
-            Registry,
-        >,
+        Layered<Box<dyn tracing_subscriber::Layer<Registry> + Send + Sync>, Registry>,
     >,
 >;
 
 pub fn test_tracing_subscriber(log_config: String, metrics: MetricRegistry) -> Sub {
-    let filter = EnvFilter::new(log_config);
+    let filter = create_env_filter(true, log_config);
 
     let fmt_layer = tracing_subscriber::fmt::layer()
         .with_writer(PrintWriter)
         .with_filter(filter);
 
     tracing_subscriber::registry()
-        .with(fmt_layer)
-        .with(metrics)
+        .with(fmt_layer.boxed())
+        .with(metrics.boxed())
         .with(ErrorLayer::default())
+}
+
+fn create_env_filter(log_queries: bool, qe_log_level: String) -> EnvFilter {
+    let mut filter = EnvFilter::from_default_env()
+        .add_directive("tide=error".parse().unwrap())
+        .add_directive("tonic=error".parse().unwrap())
+        .add_directive("h2=error".parse().unwrap())
+        .add_directive("hyper=error".parse().unwrap())
+        .add_directive("tower=error".parse().unwrap());
+
+    filter = filter
+        .add_directive(format!("query_engine={}", &qe_log_level).parse().unwrap())
+        .add_directive(format!("query_core={}", &qe_log_level).parse().unwrap())
+        .add_directive(format!("query_connector={}", &qe_log_level).parse().unwrap())
+        .add_directive(format!("sql_query_connector={}", &qe_log_level).parse().unwrap())
+        .add_directive(format!("mongodb_query_connector={}", &qe_log_level).parse().unwrap());
+
+    if log_queries {
+        filter = filter.add_directive("quaint[{is_query}]=trace".parse().unwrap());
+    }
+
+    filter
 }
 
 /// This is a temporary implementation detail for `tracing` logs in tests.


### PR DESCRIPTION
Cleans up the test logging to remove a lot of noise that we had. 
Logging for a test now looks like:

```
2022-08-22T12:22:55.416098Z  INFO quaint::single: Starting a postgresql connection.
2022-08-22T12:22:55.418409Z DEBUG quaint::connector::metrics: query=CREATE DATABASE "db" params=[] result="error" item_type="query" is_query=true duration_ms=2
2022-08-22T12:22:55.433280Z  INFO quaint::single: Starting a postgresql connection.
2022-08-22T12:22:55.451352Z DEBUG quaint::connector::metrics: query=DROP SCHEMA IF EXISTS "single_col_foo" CASCADE;
CREATE SCHEMA "single_col_foo"; params=[] result="success" item_type="query" is_query=true duration_ms=17
2022-08-22T12:22:55.490961Z TRACE query_core::executor::loader: Loading Postgres query connector...
2022-08-22T12:22:55.491293Z  INFO quaint::pooled: Starting a postgresql pool with 21 connections.
2022-08-22T12:22:55.491834Z TRACE query_core::executor::loader: Loaded Postgres query connector.
2022-08-22T12:22:55.497275Z TRACE query_core::query_graph_builder::builder: ---- Query Graph ----
Result Nodes: []
Marked Nodes: []
Root Nodes: [Node 0]

Node 0: CreateManyRecord(model: TestModel)
  
----------------------
2022-08-22T12:22:55.505620Z DEBUG prisma:engine:connection{user_facing=true db.type="postgres"}: quaint::pooled::manager: Acquired database connection.
2022-08-22T12:22:55.505854Z TRACE prisma:engine:connection{user_facing=true db.type="postgres"}: quaint::connector::metrics: Fetched a connection from the pool duration_ms=8 item_type="query" is_query=true result="success"
2022-08-22T12:22:55.507582Z DEBUG quaint::connector::metrics: query=BEGIN params=[] result="success" item_type="query" is_query=true duration_ms=1
2022-08-22T12:22:55.507854Z TRACE query_core::query_graph: Visited: 0
2022-08-22T12:22:55.513808Z DEBUG prisma:engine:interpret:prisma:engine:write-execute: quaint::connector::metrics: query=INSERT INTO
  "single_col_foo"."TestModel" DEFAULT
VALUES params=[] result="success" item_type="query" is_query=true duration_ms=5
2022-08-22T12:22:55.515649Z DEBUG prisma:engine:interpret:prisma:engine:write-execute: quaint::connector::metrics: query=INSERT INTO
  "single_col_foo"."TestModel" DEFAULT
VALUES params=[] result="success" item_type="query" is_query=true duration_ms=1
2022-08-22T12:22:55.515882Z TRACE query_core::executor::pipeline: 
SEQ
  WRITE CreateManyRecord(model: TestModel)

2022-08-22T12:22:55.518387Z DEBUG quaint::connector::metrics: query=COMMIT params=[] result="success" item_type="query" is_query=true duration_ms=2
2022-08-22T12:22:55.551183Z TRACE query_core::query_graph_builder::builder: ---- Query Graph ----
Result Nodes: []
Marked Nodes: []
Root Nodes: [Node 0]

Node 0: ManyRecordsQuery(name: 'findManyTestModel', model: 'TestModel', selection: FieldSelection { fields: [TestModel.id] }, args: QueryArguments { model: "TestModel", cursor: None, take: None, skip: None, filter: None, order_by: [], distinct: None, ignore_skip: false, ignore_take: false })
  
----------------------
2022-08-22T12:22:55.558745Z DEBUG prisma:engine:connection{user_facing=true db.type="postgres"}: quaint::pooled::manager: Acquired database connection.
2022-08-22T12:22:55.558935Z TRACE prisma:engine:connection{user_facing=true db.type="postgres"}: quaint::connector::metrics: Fetched a connection from the pool duration_ms=7 item_type="query" is_query=true result="success"
2022-08-22T12:22:55.559060Z TRACE query_core::query_graph: Visited: 0
2022-08-22T12:22:55.563109Z DEBUG prisma:engine:interpret:prisma:engine:read-execute:filter read query: quaint::connector::metrics: query=SELECT
  "single_col_foo"."TestModel"."id"
FROM
  "single_col_foo"."TestModel"
WHERE
  1 = 1 OFFSET $1 params=[0] result="success" item_type="query" is_query=true duration_ms=3
2022-08-22T12:22:55.563341Z TRACE query_core::executor::pipeline: 
SEQ
  READ ManyRecordsQuery(name: 'findManyTestModel', model: 'TestModel', selection: FieldSelection { fields: [TestModel.id] }, args: QueryArguments { model: "TestModel", cursor: None, take: None, skip: None, filter: None, order_by: [], distinct: None, ignore_skip: false, ignore_take: false })

2022-08-22T12:22:55.563798Z DEBUG query_core::interactive_transactions::actor_manager: DROPPING TPM
test new::create_many::single_col::foo ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 6 filtered out; finished in 0.23s
```