### PR TITLE
me: add an introspect() method to the JSON-RPC API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1994,6 +1994,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "enumflags2",
+ "introspection-connector",
  "psl",
  "sha2 0.9.9",
  "tracing",
@@ -2227,6 +2228,7 @@ dependencies = [
  "migration-connector",
  "mongodb",
  "mongodb-client",
+ "mongodb-introspection-connector",
  "mongodb-schema-describer",
  "once_cell",
  "psl",
@@ -4186,6 +4188,7 @@ dependencies = [
  "regex",
  "serde_json",
  "sql-ddl",
+ "sql-introspection-connector",
  "sql-schema-describer",
  "tokio",
  "tracing",

--- a/introspection-engine/connectors/introspection-connector/src/lib.rs
+++ b/introspection-engine/connectors/introspection-connector/src/lib.rs
@@ -52,7 +52,7 @@ pub struct IntrospectionResult {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Warning {
-    pub code: i16,
+    pub code: u32,
     pub message: String,
     pub affected: Value,
 }

--- a/introspection-engine/connectors/mongodb-introspection-connector/tests/test_api/mod.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/tests/test_api/mod.rs
@@ -37,7 +37,7 @@ impl TestResult {
     }
 
     #[track_caller]
-    pub fn assert_warning_code(&self, code: i16) {
+    pub fn assert_warning_code(&self, code: u32) {
         assert!(self.warnings.iter().any(|w| w.code == code), "{:#?}", self.warnings)
     }
 

--- a/libs/datamodel/core/src/configuration/datasource.rs
+++ b/libs/datamodel/core/src/configuration/datasource.rs
@@ -6,6 +6,7 @@ use datamodel_connector::{Connector, ConnectorCapabilities, ReferentialIntegrity
 use std::{borrow::Cow, path::Path};
 
 /// a `datasource` from the prisma schema.
+#[derive(Clone)]
 pub struct Datasource {
     pub name: String,
     /// The provider string

--- a/migration-engine/cli/tests/cli_tests.rs
+++ b/migration-engine/cli/tests/cli_tests.rs
@@ -291,7 +291,7 @@ fn basic_jsonrpc_roundtrip_works(_api: TestApi) {
         .env("RUST_LOG", "INFO")
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
         .spawn()
         .unwrap();
     let stdin = process.stdin.as_mut().unwrap();
@@ -309,6 +309,51 @@ fn basic_jsonrpc_roundtrip_works(_api: TestApi) {
 
         assert!(response.contains("PostgreSQL") || response.contains("CockroachDB"));
     }
+}
 
-    process.kill().unwrap();
+#[test]
+fn introspect_e2e() {
+    use std::io::{BufRead, BufReader, Write as _};
+    let tmpdir = tempfile::tempdir().unwrap();
+    let schema = r#"
+        datasource db {
+            provider = "sqlite"
+            url = env("TEST_DB_URL")
+        }
+
+    "#;
+    let mut process = Command::new(migration_engine_bin_path())
+        .env("RUST_LOG", "INFO")
+        .env(
+            "TEST_DB_URL",
+            format!("file:{}/dev.db", tmpdir.path().to_string_lossy()),
+        )
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .unwrap();
+    let stdin = process.stdin.as_mut().unwrap();
+    let mut stdout = BufReader::new(process.stdout.as_mut().unwrap());
+
+    for iteration in 0..2 {
+        let msg = serde_json::to_string(&serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "introspect",
+            "id": iteration,
+            "params": {
+                "schema": schema,
+                "force": true,
+                "compositeTypeDepth": 5,
+            }
+        }))
+        .unwrap();
+        stdin.write_all(msg.as_bytes()).unwrap();
+        stdin.write_all(b"\n").unwrap();
+
+        let mut response = String::new();
+        stdout.read_line(&mut response).unwrap();
+
+        assert!(response.starts_with(r##"{"jsonrpc":"2.0","result":{"datamodel":"datasource db {\n  provider = \"sqlite\"\n  url      = env(\"TEST_DB_URL\")\n}\n","version":"NonPrisma","warnings":[]},"##));
+    }
 }

--- a/migration-engine/connectors/migration-connector/Cargo.toml
+++ b/migration-engine/connectors/migration-connector/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 psl = { path = "../../../psl/psl" }
+introspection-connector = { path = "../../../introspection-engine/connectors/introspection-connector" }
 user-facing-errors = { path = "../../../libs/user-facing-errors" }
 
 chrono = "0.4"

--- a/migration-engine/connectors/migration-connector/src/lib.rs
+++ b/migration-engine/connectors/migration-connector/src/lib.rs
@@ -17,6 +17,7 @@ pub use destructive_change_checker::{
 };
 pub use diff::DiffTarget;
 pub use error::{ConnectorError, ConnectorResult};
+pub use introspection_connector::{IntrospectionConnector, IntrospectionContext, IntrospectionResult};
 pub use migration_persistence::{MigrationPersistence, MigrationRecord, PersistenceNotInitializedError, Timestamp};
 
 use migrations_directory::MigrationDirectory;
@@ -189,6 +190,13 @@ pub trait MigrationConnector: Send + Sync + 'static {
         target: DiffTarget<'a>,
         shadow_database_connection_string: Option<String>,
     ) -> BoxFuture<'a, ConnectorResult<DatabaseSchema>>;
+
+    /// In-tro-spec-shon.
+    fn introspect<'a>(
+        &'a mut self,
+        schema: &'a ValidatedSchema,
+        ctx: introspection_connector::IntrospectionContext,
+    ) -> BoxFuture<'_, ConnectorResult<introspection_connector::IntrospectionResult>>;
 
     /// If possible, check that the passed in migrations apply cleanly.
     fn validate_migrations<'a>(

--- a/migration-engine/connectors/mongodb-migration-connector/Cargo.toml
+++ b/migration-engine/connectors/mongodb-migration-connector/Cargo.toml
@@ -8,6 +8,7 @@ psl = { path = "../../../psl/psl" }
 mongodb-client = { path = "../../../libs/mongodb-client" }
 mongodb-schema-describer = { path = "../../../libs/mongodb-schema-describer" }
 migration-connector = { path = "../migration-connector" }
+mongodb-introspection-connector = { path = "../../../introspection-engine/connectors/mongodb-introspection-connector" }
 
 enumflags2 = "0.7"
 futures = "0.3"

--- a/migration-engine/connectors/sql-migration-connector/Cargo.toml
+++ b/migration-engine/connectors/sql-migration-connector/Cargo.toml
@@ -9,6 +9,7 @@ migration-connector = { path = "../migration-connector" }
 native-types = { path = "../../../libs/native-types" }
 sql-schema-describer = { path = "../../../libs/sql-schema-describer" }
 sql-ddl = { path = "../../../libs/sql-ddl" }
+sql-introspection-connector = { path = "../../../introspection-engine/connectors/sql-introspection-connector" }
 user-facing-errors = { path = "../../../libs/user-facing-errors", features = ["sql"] }
 
 chrono = { version = "0.4" }

--- a/migration-engine/core/src/api.rs
+++ b/migration-engine/core/src/api.rs
@@ -49,6 +49,9 @@ pub trait GenericApi: Send + Sync + 'static {
     /// Evaluate the consequences of running the next migration we would generate, given the current state of a Prisma schema.
     async fn evaluate_data_loss(&self, input: EvaluateDataLossInput) -> CoreResult<EvaluateDataLossOutput>;
 
+    /// Introspect the database schema.
+    async fn introspect(&self, input: IntrospectParams) -> CoreResult<IntrospectResult>;
+
     /// List the migration directories.
     async fn list_migration_directories(
         &self,

--- a/migration-engine/core/src/rpc.rs
+++ b/migration-engine/core/src/rpc.rs
@@ -36,6 +36,7 @@ async fn run_command(
         ENSURE_CONNECTION_VALIDITY => render(executor.ensure_connection_validity(params.parse()?).await),
         EVALUATE_DATA_LOSS => render(executor.evaluate_data_loss(params.parse()?).await),
         GET_DATABASE_VERSION => render(executor.version().await),
+        INTROSPECT => render(executor.introspect(params.parse()?).await),
         LIST_MIGRATION_DIRECTORIES => render(executor.list_migration_directories(params.parse()?).await),
         MARK_MIGRATION_APPLIED => render(executor.mark_migration_applied(params.parse()?).await),
         MARK_MIGRATION_ROLLED_BACK => render(executor.mark_migration_rolled_back(params.parse()?).await),

--- a/migration-engine/core/src/state.rs
+++ b/migration-engine/core/src/state.rs
@@ -6,6 +6,7 @@
 use crate::{api::GenericApi, commands, json_rpc::types::*, CoreResult};
 use enumflags2::BitFlags;
 use migration_connector::{ConnectorError, ConnectorHost, MigrationConnector};
+use psl::parser_database::SourceFile;
 use std::{collections::HashMap, future::Future, path::Path, pin::Pin, sync::Arc};
 use tokio::sync::{mpsc, Mutex};
 use tracing_futures::Instrument;
@@ -294,6 +295,40 @@ impl GenericApi for EngineState {
         self.with_default_connector(Box::new(|connector| {
             Box::pin(commands::evaluate_data_loss(input, connector).instrument(tracing::info_span!("EvaluateDataLoss")))
         }))
+        .await
+    }
+
+    async fn introspect(&self, params: IntrospectParams) -> CoreResult<IntrospectResult> {
+        let source_file = SourceFile::new_allocated(Arc::from(params.schema.clone().into_boxed_str()));
+        let schema = psl::parse_schema_parserdb(source_file).map_err(ConnectorError::new_schema_parser_error)?;
+        self.with_connector_for_schema(
+            &params.schema,
+            None,
+            Box::new(move |connector| {
+                let ctx = migration_connector::IntrospectionContext {
+                    composite_type_depth: From::from(params.composite_type_depth as isize),
+                    preview_features: schema.configuration.preview_features(),
+                    source: schema.configuration.datasources[0].clone(),
+                };
+                Box::pin(async move {
+                    let result = connector.introspect(&schema, ctx).await?;
+                    let rendered_result =
+                        psl::render_datamodel_and_config_to_string(&result.data_model, &schema.configuration);
+                    Ok(IntrospectResult {
+                        datamodel: rendered_result,
+                        version: format!("{:?}", result.version),
+                        warnings: result
+                            .warnings
+                            .into_iter()
+                            .map(|warning| crate::json_rpc::types::IntrospectionWarning {
+                                code: warning.code as u32,
+                                message: warning.message,
+                            })
+                            .collect(),
+                    })
+                })
+            }),
+        )
         .await
     }
 

--- a/migration-engine/json-rpc-api-build/methods/introspect.toml
+++ b/migration-engine/json-rpc-api-build/methods/introspect.toml
@@ -1,0 +1,37 @@
+[methods.introspect]
+description = "Introspect the database (db pull)"
+requestShape = "introspectParams"
+responseShape = "introspectResult"
+
+[recordShapes.introspectParams]
+description = "Params type for the introspect method."
+
+[recordShapes.introspectParams.fields.schema]
+shape = "string"
+
+[recordShapes.introspectParams.fields.force]
+shape = "bool"
+
+[recordShapes.introspectParams.fields.compositeTypeDepth]
+shape = "u32"
+
+[recordShapes.introspectResult]
+description = "Result type for the introspect method."
+
+[recordShapes.introspectResult.fields.datamodel]
+shape = "string"
+
+[recordShapes.introspectResult.fields.warnings]
+shape = "introspectionWarning"
+isList = true
+
+[recordShapes.introspectResult.fields.version]
+shape = "string"
+
+[recordShapes.introspectionWarning]
+
+[recordShapes.introspectionWarning.fields.code]
+shape = "u32"
+
+[recordShapes.introspectionWarning.fields.message]
+shape = "string"

--- a/migration-engine/json-rpc-api-build/src/lib.rs
+++ b/migration-engine/json-rpc-api-build/src/lib.rs
@@ -10,6 +10,10 @@ use std::{
 
 pub fn generate_rust_modules(out_dir: &Path) -> CrateResult {
     let api_defs_root = concat!(env!("CARGO_MANIFEST_DIR"), "/methods");
+
+    // https://doc.rust-lang.org/cargo/reference/build-scripts.html
+    println!("cargo:rerun-if-changed={}", api_defs_root);
+
     let entries = std::fs::read_dir(api_defs_root)?;
     let mut api = Api::default();
 
@@ -18,9 +22,6 @@ pub fn generate_rust_modules(out_dir: &Path) -> CrateResult {
         if !entry.file_type()?.is_file() {
             continue;
         }
-
-        // https://doc.rust-lang.org/cargo/reference/build-scripts.html
-        println!("cargo:rerun-if-changed={}", entry.path().to_string_lossy());
 
         let contents = std::fs::read_to_string(entry.path())?;
         eprintln!("Merging {}", entry.path().file_name().unwrap().to_string_lossy());


### PR DESCRIPTION
This is the first step of
https://www.notion.so/prismaio/Project-outline-merging-introspection-and-migration-engine-5c19ce49627542768f2283d82731b4a7

The measured size increase of release builds of the migration engine on
this branch is ~3MB.