### PR TITLE
Decouple introspection and version checking

### DIFF
--- a/introspection-engine/connectors/sql-introspection-connector/src/introspection.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/introspection.rs
@@ -5,7 +5,6 @@ use crate::{
         calculate_scalar_field, is_new_migration_table, is_old_migration_table, is_prisma_1_point_0_join_table,
         is_prisma_1_point_1_or_2_join_table, is_relay_table, primary_key_is_clustered,
     },
-    version_checker::VersionChecker,
     SqlError, SqlFamilyTrait,
 };
 use datamodel::dml::{self, Field, Model, PrimaryKeyDefinition, PrimaryKeyField, RelationField, SortOrder};
@@ -13,7 +12,7 @@ use sql_schema_describer::{walkers::TableWalker, ForeignKeyId, SQLSortOrder};
 use std::collections::HashSet;
 use tracing::debug;
 
-pub(crate) fn introspect(version_check: &mut VersionChecker, ctx: &mut Context) -> Result<(), SqlError> {
+pub(crate) fn introspect(ctx: &mut Context) -> Result<(), SqlError> {
     let schema = ctx.schema;
     // collect m2m table names
     let m2m_tables: Vec<String> = schema
@@ -34,7 +33,6 @@ pub(crate) fn introspect(version_check: &mut VersionChecker, ctx: &mut Context) 
         let mut model = Model::new(table.name().to_owned(), None);
 
         for column in table.columns() {
-            version_check.check_column_for_type_and_default_value(column);
             let field = calculate_scalar_field(column, ctx);
             model.add_field(Field::ScalarField(field));
         }
@@ -64,9 +62,6 @@ pub(crate) fn introspect(version_check: &mut VersionChecker, ctx: &mut Context) 
             .foreign_keys()
             .filter(|fk| !duplicated_foreign_keys.contains(&fk.id))
         {
-            version_check.has_inline_relations(table);
-            version_check.uses_on_delete(foreign_key);
-
             let mut relation_field = calculate_relation_field(foreign_key, &m2m_tables, &duplicated_foreign_keys);
 
             relation_field.supports_restrict_action(!ctx.sql_family().is_mssql());
@@ -105,9 +100,6 @@ pub(crate) fn introspect(version_check: &mut VersionChecker, ctx: &mut Context) 
                 clustered,
             });
         }
-
-        version_check.always_has_created_at_updated_at(table, &model);
-        version_check.has_p1_compatible_primary_key_column(table);
 
         ctx.datamodel.add_model(model);
     }

--- a/introspection-engine/connectors/sql-introspection-connector/src/introspection_helpers.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/introspection_helpers.rs
@@ -49,6 +49,18 @@ pub(crate) fn is_relay_table(table: TableWalker<'_>) -> bool {
             .any(|col| col.name().eq_ignore_ascii_case("stablemodelidentifier"))
 }
 
+pub(crate) fn has_created_at_and_updated_at(table: TableWalker<'_>) -> bool {
+    let has_created_at = table.columns().any(|col| {
+        col.name().eq_ignore_ascii_case("createdat") && col.column_type().family == ColumnTypeFamily::DateTime
+    });
+
+    let has_updated_at = table.columns().any(|col| {
+        col.name().eq_ignore_ascii_case("updatedat") && col.column_type().family == ColumnTypeFamily::DateTime
+    });
+
+    has_created_at && has_updated_at
+}
+
 pub(crate) fn is_prisma_1_or_11_list_table(table: TableWalker<'_>) -> bool {
     table.columns().len() == 3
         && table.columns().any(|col| col.name().eq_ignore_ascii_case("nodeid"))

--- a/libs/sql-schema-describer/src/lib.rs
+++ b/libs/sql-schema-describer/src/lib.rs
@@ -277,6 +277,11 @@ impl SqlSchema {
     pub fn walk_namespaces(&self) -> impl ExactSizeIterator<Item = NamespaceWalker<'_>> {
         (0..self.namespaces.len()).map(|idx| self.walk(NamespaceId(idx as u32)))
     }
+
+    /// No tables or enums in the catalog.
+    pub fn is_empty(&self) -> bool {
+        self.tables.is_empty() && self.enums.is_empty()
+    }
 }
 
 /// A table found in a schema.


### PR DESCRIPTION
They are two separate concerns, and can be decoupled into different functions. Also removes the dependency for the `dml` in the version checking -- we can get all the information needed from the sql schema.

This is the first step to remove the dependency to the `dml` crate in the introspection. Following the teachings of sensei Houle, we go in small steps.