### PR TITLE
Feature gate mongodb

### DIFF
--- a/introspection-engine/connectors/sql-introspection-connector/Cargo.toml
+++ b/introspection-engine/connectors/sql-introspection-connector/Cargo.toml
@@ -10,7 +10,7 @@ vendored-openssl = ["quaint/vendored-openssl"]
 [dependencies]
 anyhow = "1.0.26"
 async-trait = "0.1.17"
-datamodel = { path = "../../../libs/datamodel/core" }
+datamodel = { path = "../../../libs/datamodel/core", features = ["sql"] }
 native-types = { path = "../../../libs/native-types" }
 introspection-connector = { path = "../introspection-connector" }
 once_cell = "1.3"

--- a/introspection-engine/core/Cargo.toml
+++ b/introspection-engine/core/Cargo.toml
@@ -4,15 +4,18 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
+default = ["mongodb", "sql"]
 vendored-openssl = ["sql-introspection-connector/vendored-openssl"]
+mongodb = ["mongodb-introspection-connector"]
+sql = ["sql-introspection-connector"]
 
 # Please keep the pyramid form
 [dependencies]
 psl = { path = "../../psl/psl" }
 user-facing-errors = { path = "../../libs/user-facing-errors" }
 introspection-connector = { path = "../connectors/introspection-connector" }
-sql-introspection-connector = { path = "../connectors/sql-introspection-connector" }
-mongodb-introspection-connector = { path = "../connectors/mongodb-introspection-connector" }
+sql-introspection-connector = { path = "../connectors/sql-introspection-connector", optional = true }
+mongodb-introspection-connector = { path = "../connectors/mongodb-introspection-connector", optional = true }
 
 serde = "1.0"
 serde_json = { version = "1.0", features = ["float_roundtrip"] }

--- a/libs/datamodel/core/Cargo.toml
+++ b/libs/datamodel/core/Cargo.toml
@@ -3,12 +3,18 @@ edition = "2021"
 name = "datamodel"
 version = "0.1.0"
 
+[features]
+default = []
+default_generators = ["dml/default_generators"]
+mongodb = ["mongodb-datamodel-connector"]
+sql = ["sql-datamodel-connector"]
+
 [dependencies]
 datamodel-connector = { path = "../connectors/datamodel-connector" }
 dml = { path = "../connectors/dml" }
-mongodb-datamodel-connector = { path = "../connectors/mongodb-datamodel-connector" }
+mongodb-datamodel-connector = { path = "../connectors/mongodb-datamodel-connector", optional = true }
 schema-ast = { path = "../schema-ast" }
-sql-datamodel-connector = { path = "../connectors/sql-datamodel-connector" }
+sql-datamodel-connector = { path = "../connectors/sql-datamodel-connector", optional = true }
 diagnostics = { path = "../diagnostics" }
 parser-database = { path = "../parser-database" }
 
@@ -22,6 +28,3 @@ serde_json = { version = "1.0", features = ["preserve_order", "float_roundtrip"]
 enumflags2 = "0.7"
 indoc = "1"
 either = "1.6"
-
-[features]
-default_generators = ["dml/default_generators"]

--- a/libs/datamodel/core/src/lib.rs
+++ b/libs/datamodel/core/src/lib.rs
@@ -30,7 +30,9 @@ use parser_database::{ast, ParserDatabase, SourceFile};
 use std::sync::Arc;
 
 pub mod builtin_connectors {
+    #[cfg(feature = "mongodb")]
     pub use mongodb_datamodel_connector::*;
+    #[cfg(feature = "sql")]
     pub use sql_datamodel_connector::*;
 }
 

--- a/libs/datamodel/core/src/validate/datasource_loader.rs
+++ b/libs/datamodel/core/src/validate/datasource_loader.rs
@@ -7,8 +7,10 @@ use crate::{
 };
 use datamodel_connector::ReferentialIntegrity;
 use enumflags2::BitFlags;
+#[cfg(feature = "mongodb")]
 use mongodb_datamodel_connector::*;
 use parser_database::{ast::WithDocumentation, coerce, coerce_array, coerce_opt};
+#[cfg(feature = "sql")]
 use sql_datamodel_connector::*;
 use std::{borrow::Cow, collections::HashMap};
 
@@ -135,11 +137,17 @@ impl DatasourceLoader {
         let referential_integrity = get_referential_integrity(&args, preview_features, ast_source, diagnostics);
 
         let active_connector: &'static dyn datamodel_connector::Connector = match provider {
+            #[cfg(feature = "sql")]
             p if MYSQL.is_provider(p) => MYSQL,
+            #[cfg(feature = "sql")]
             p if POSTGRES.is_provider(p) => POSTGRES,
+            #[cfg(feature = "sql")]
             p if SQLITE.is_provider(p) => SQLITE,
+            #[cfg(feature = "sql")]
             p if MSSQL.is_provider(p) => MSSQL,
+            #[cfg(feature = "mongodb")]
             p if MONGODB.is_provider(p) => MONGODB,
+            #[cfg(feature = "sql")]
             p if COCKROACH.is_provider(p) => COCKROACH,
 
             _ => {

--- a/migration-engine/connectors/mongodb-migration-connector/Cargo.toml
+++ b/migration-engine/connectors/mongodb-migration-connector/Cargo.toml
@@ -4,7 +4,7 @@ name = "mongodb-migration-connector"
 version = "0.1.0"
 
 [dependencies]
-psl = { path = "../../../psl/psl" }
+psl = { path = "../../../psl/psl", features = ["mongodb"] }
 mongodb-client = { path = "../../../libs/mongodb-client" }
 mongodb-schema-describer = { path = "../../../libs/mongodb-schema-describer" }
 migration-connector = { path = "../migration-connector" }

--- a/migration-engine/connectors/mongodb-migration-connector/src/schema_calculator.rs
+++ b/migration-engine/connectors/mongodb-migration-connector/src/schema_calculator.rs
@@ -1,6 +1,6 @@
 use mongodb_schema_describer::{IndexField, IndexFieldProperty, MongoSchema};
 use psl::{
-    builtin_connectors::MONGODB,
+    builtin_connectors,
     datamodel_connector::walker_ext_traits::*,
     parser_database::{IndexType, SortOrder},
     ValidatedSchema,
@@ -14,7 +14,7 @@ pub(crate) fn calculate(datamodel: &ValidatedSchema) -> MongoSchema {
         let collection_id = schema.push_collection(model.database_name().to_owned());
 
         for index in model.indexes() {
-            let name = index.constraint_name(MONGODB);
+            let name = index.constraint_name(builtin_connectors::MONGODB);
 
             let fields = index
                 .scalar_field_attributes()

--- a/psl/psl/Cargo.toml
+++ b/psl/psl/Cargo.toml
@@ -3,6 +3,11 @@ name = "psl"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+default = []
+mongodb = ["psl-core/mongodb"]
+sql = ["psl-core/sql"]
+
 [dependencies]
 psl-core = { path = "../../libs/datamodel/core", package = "datamodel", default-features = false }
 

--- a/query-engine/core/Cargo.toml
+++ b/query-engine/core/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 
 [features]
 default = ["sql", "mongodb"]
-mongodb = ["mongodb-connector"]
+mongodb = ["mongodb-connector", "mongodb-client"]
 sql = ["sql-connector"]
 
 [dependencies]
@@ -17,7 +17,7 @@ chrono = "0.4"
 connection-string = "0.1"
 connector = { path = "../connectors/query-connector", package = "query-connector" }
 crossbeam-queue = "0.3.5"
-mongodb-client = { path = "../../libs/mongodb-client/" }
+mongodb-client = { path = "../../libs/mongodb-client/", optional = true }
 datamodel = { path = "../../libs/datamodel/core" }
 datamodel-connector = { path = "../../libs/datamodel/connectors/datamodel-connector" }
 futures = "0.3"

--- a/query-engine/core/src/executor/loader.rs
+++ b/query-engine/core/src/executor/loader.rs
@@ -3,11 +3,13 @@ use crate::CoreError;
 use connection_string::JdbcString;
 use connector::Connector;
 use datamodel::{builtin_connectors::*, common::preview_features::PreviewFeature, Datasource};
-use mongodb_client::MongoConnectionString;
 use sql_connector::*;
 use std::collections::HashMap;
 use std::str::FromStr;
 use url::Url;
+
+#[cfg(feature = "mongodb")]
+use mongodb_client::MongoConnectionString;
 
 #[cfg(feature = "mongodb")]
 use mongodb_connector::MongoDb;


### PR DESCRIPTION
The Prisma Engines already feature gate the `sql` and `monogodb` in many crates throughout the workspace however this convention has not been followed everywhere. This PR fixes the code throughout the rest of the repository to follow the convention.

I very much understand this change isn't something that provides benefits to the core Prisma product and I can fully understand it being closed, however, this change is based on following a convention that was already set in the codebase. The main benefit behind this change is to provide a much-needed improvement to the compile time performance of Prisma Client Rust. Having to wait for the MongoDB connector to compile when using an SQL DB is slow and unnecessary.

This links to issue prisma/prisma#14890 although that issue is around splitting all database connectors into their own feature flags. That is something I would like to look into if this PR is accepted, however, I suspect those changes will be harder without having adverse effects on the development of the engines.