### PR TITLE
ci: check that Cargo.lock is up to date

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -37,3 +37,5 @@ jobs:
       - run: "cargo clean && cargo build --release -p query-engine-node-api"
         name: "Compile Query Engine Library"
 
+      - name: "Check that Cargo.lock did not change"
+        run: "git diff --exit-code"


### PR DESCRIPTION
I tested this in this branch. The check works. Proof: https://github.com/prisma/prisma-engines/runs/8107324569?check_suite_focus=true