### PR TITLE
Render datamodel as string in connectors

### DIFF
--- a/introspection-engine/connectors/introspection-connector/src/lib.rs
+++ b/introspection-engine/connectors/introspection-connector/src/lib.rs
@@ -68,7 +68,7 @@ pub struct IntrospectionResultOutput {
 pub struct IntrospectionContext {
     pub previous_data_model: Datamodel,
     /// This should always be true. TODO: change everything where it's
-    /// set to false to use take the config into account.
+    /// set to false to take the config into account.
     pub render_config: bool,
     pub source: Datasource,
     pub composite_type_depth: CompositeTypeDepth,

--- a/introspection-engine/connectors/introspection-connector/src/lib.rs
+++ b/introspection-engine/connectors/introspection-connector/src/lib.rs
@@ -28,7 +28,7 @@ pub struct DatabaseMetadata {
     pub size_in_bytes: usize,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy)]
 pub enum Version {
     NonPrisma,
     Prisma1,
@@ -39,7 +39,9 @@ pub enum Version {
 #[derive(Debug)]
 pub struct IntrospectionResult {
     /// Datamodel
-    pub data_model: Datamodel,
+    pub data_model: String,
+    /// The introspected data model is empty
+    pub is_empty: bool,
     /// Introspection warnings
     pub warnings: Vec<Warning>,
     /// Inferred Prisma version
@@ -65,6 +67,9 @@ pub struct IntrospectionResultOutput {
 
 pub struct IntrospectionContext {
     pub previous_data_model: Datamodel,
+    /// This should always be true. TODO: change everything where it's
+    /// set to false to use take the config into account.
+    pub render_config: bool,
     pub source: Datasource,
     pub composite_type_depth: CompositeTypeDepth,
     pub preview_features: BitFlags<PreviewFeature>,
@@ -108,6 +113,7 @@ impl IntrospectionContext {
             source,
             composite_type_depth,
             preview_features,
+            render_config: true,
         }
     }
 

--- a/introspection-engine/connectors/mongodb-introspection-connector/src/lib.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/src/lib.rs
@@ -125,6 +125,6 @@ impl IntrospectionConnector for MongoDbIntrospectionConnector {
 
     async fn introspect(&self, ctx: &IntrospectionContext) -> ConnectorResult<IntrospectionResult> {
         let schema = self.describe(ctx.preview_features).await?;
-        Ok(sampler::sample(self.database(), ctx.composite_type_depth, schema).await?)
+        Ok(sampler::sample(self.database(), schema, ctx).await?)
     }
 }

--- a/introspection-engine/connectors/mongodb-introspection-connector/tests/test_api/mod.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/tests/test_api/mod.rs
@@ -104,7 +104,8 @@ where
     );
 
     let validated_schema = psl::parse_schema(datamodel_string).unwrap();
-    let ctx = IntrospectionContext::new(validated_schema, composite_type_depth);
+    let mut ctx = IntrospectionContext::new(validated_schema, composite_type_depth);
+    ctx.render_config = false;
 
     RT.block_on(async move {
         let client = mongodb_client::create(&connection_string).await.unwrap();
@@ -119,10 +120,9 @@ where
         database.drop(None).await.unwrap();
 
         let res = res.unwrap();
-        let config = &ctx.configuration();
 
         TestResult {
-            datamodel: psl::render_datamodel_to_string(&res.data_model, Some(config)),
+            datamodel: res.data_model,
             warnings: res.warnings,
         }
     })

--- a/introspection-engine/connectors/sql-introspection-connector/src/calculate_datamodel.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/calculate_datamodel.rs
@@ -1,23 +1,17 @@
-use crate::{
-    commenting_out_guardrails::commenting_out_guardrails,
-    introspection::introspect,
-    introspection_helpers::*,
-    prisma_1_defaults::*,
-    re_introspection::enrich,
-    sanitize_datamodel_names::{sanitization_leads_to_duplicate_names, sanitize_datamodel_names},
-    version_checker, SqlFamilyTrait, SqlIntrospectionResult,
-};
+use crate::{introspection::introspect, SqlFamilyTrait, SqlIntrospectionResult};
 use enumflags2::BitFlags;
 use introspection_connector::{IntrospectionContext, IntrospectionResult};
-use psl::{builtin_connectors::*, common::preview_features::PreviewFeature, dml::Datamodel, Datasource};
+use psl::{builtin_connectors::*, common::preview_features::PreviewFeature, dml::Datamodel, Configuration, Datasource};
 use quaint::prelude::SqlFamily;
 use sql_schema_describer::SqlSchema;
 use tracing::debug;
 
 pub(crate) struct CalculateDatamodelContext<'a> {
+    pub config: &'a Configuration,
+    pub render_config: bool,
     pub source: &'a Datasource,
     pub preview_features: BitFlags<PreviewFeature>,
-    pub datamodel: &'a mut Datamodel,
+    pub previous_datamodel: &'a Datamodel,
     pub schema: &'a SqlSchema,
     pub sql_family: SqlFamily,
 }
@@ -25,6 +19,10 @@ pub(crate) struct CalculateDatamodelContext<'a> {
 impl CalculateDatamodelContext<'_> {
     pub(crate) fn is_cockroach(&self) -> bool {
         self.source.active_connector.provider_name() == COCKROACH.provider_name()
+    }
+
+    pub(crate) fn foreign_keys_enabled(&self) -> bool {
+        self.source.relation_mode().uses_foreign_keys()
     }
 }
 
@@ -36,45 +34,25 @@ pub fn calculate_datamodel(
     debug!("Calculating data model.");
 
     let previous_datamodel = &ctx.previous_data_model;
-    let mut datamodel = Datamodel::new();
-
-    let mut context = CalculateDatamodelContext {
+    let context = CalculateDatamodelContext {
+        config: ctx.configuration(),
+        render_config: ctx.render_config,
         source: &ctx.source,
         preview_features: ctx.preview_features,
-        datamodel: &mut datamodel,
+        previous_datamodel,
         schema,
         sql_family: ctx.sql_family(),
     };
 
-    // 1to1 translation of the sql schema
-    introspect(&mut context)?;
+    let mut warnings = Vec::new();
 
-    if !sanitization_leads_to_duplicate_names(context.datamodel) {
-        // our opinionation about valid names
-        sanitize_datamodel_names(&mut context);
-    }
-
-    // deduplicating relation field names
-    deduplicate_relation_field_names(&mut datamodel);
-
-    let mut warnings = vec![];
-    if !previous_datamodel.is_empty() {
-        enrich(previous_datamodel, &mut datamodel, ctx, &mut warnings);
-        debug!("Enriching datamodel is done.");
-    }
-
-    // commenting out models, fields, enums, enum values
-    warnings.append(&mut commenting_out_guardrails(&mut datamodel, ctx));
-
-    // try to identify whether the schema was created by a previous Prisma version
-    let version = version_checker::check_prisma_version(schema, ctx, &mut warnings);
-
-    // if based on a previous Prisma version add id default opinionations
-    add_prisma_1_id_defaults(&version, &mut datamodel, schema, &mut warnings, ctx);
+    let (version, data_model, is_empty) = introspect(&context, &mut warnings)?;
 
     debug!("Done calculating datamodel.");
+
     Ok(IntrospectionResult {
-        data_model: datamodel,
+        data_model,
+        is_empty,
         warnings,
         version,
     })

--- a/introspection-engine/connectors/sql-introspection-connector/src/commenting_out_guardrails.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/commenting_out_guardrails.rs
@@ -1,13 +1,14 @@
+use crate::calculate_datamodel::CalculateDatamodelContext;
 use crate::warnings::{
     warning_enum_values_with_empty_names, warning_fields_with_empty_names, warning_models_without_columns,
     warning_models_without_identifier, warning_unsupported_types, EnumAndValue, Model, ModelAndField,
     ModelAndFieldAndType,
 };
 use crate::SqlFamilyTrait;
-use introspection_connector::{IntrospectionContext, Warning};
+use introspection_connector::Warning;
 use psl::dml::{Datamodel, FieldType};
 
-pub fn commenting_out_guardrails(datamodel: &mut Datamodel, ctx: &IntrospectionContext) -> Vec<Warning> {
+pub(crate) fn commenting_out_guardrails(datamodel: &mut Datamodel, ctx: &CalculateDatamodelContext) -> Vec<Warning> {
     let mut warnings = vec![];
 
     // order matters...
@@ -42,7 +43,7 @@ pub fn commenting_out_guardrails(datamodel: &mut Datamodel, ctx: &IntrospectionC
 
 // on postgres this is allowed, on the other dbs, this could be a symptom of
 // missing privileges
-fn models_without_columns(datamodel: &mut Datamodel, ctx: &IntrospectionContext) -> Vec<Model> {
+fn models_without_columns(datamodel: &mut Datamodel, ctx: &CalculateDatamodelContext) -> Vec<Model> {
     let mut models_without_columns = vec![];
 
     for model in datamodel.models_mut() {

--- a/introspection-engine/connectors/sql-introspection-connector/src/defaults.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/defaults.rs
@@ -2,7 +2,7 @@ use crate::calculate_datamodel::CalculateDatamodelContext as Context;
 use psl::dml;
 use sql_schema_describer::{self as sql, postgres::PostgresSchemaExt};
 
-pub(crate) fn calculate_default(column: sql::ColumnWalker<'_>, ctx: &mut Context) -> Option<dml::DefaultValue> {
+pub(crate) fn calculate_default(column: sql::ColumnWalker<'_>, ctx: &Context) -> Option<dml::DefaultValue> {
     match (column.default().map(|d| d.kind()), &column.column_type_family()) {
         (Some(sql::DefaultKind::Sequence(name)), _) if ctx.is_cockroach() => {
             use dml::PrismaValue;

--- a/introspection-engine/connectors/sql-introspection-connector/src/introspection.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/introspection.rs
@@ -1,19 +1,22 @@
 use crate::{
     calculate_datamodel::CalculateDatamodelContext as Context,
-    introspection_helpers::{
-        calculate_backrelation_field, calculate_index, calculate_many_to_many_field, calculate_relation_field,
-        calculate_scalar_field, is_new_migration_table, is_old_migration_table, is_prisma_1_point_0_join_table,
-        is_prisma_1_point_1_or_2_join_table, is_relay_table, primary_key_is_clustered,
-    },
-    SqlError, SqlFamilyTrait,
+    commenting_out_guardrails::commenting_out_guardrails,
+    introspection_helpers::*,
+    prisma_1_defaults::add_prisma_1_id_defaults,
+    re_introspection::enrich,
+    sanitize_datamodel_names::{sanitization_leads_to_duplicate_names, sanitize_datamodel_names},
+    version_checker, SqlError, SqlFamilyTrait,
 };
-use psl::dml::{self, Field, Model, PrimaryKeyDefinition, PrimaryKeyField, RelationField, SortOrder};
+use introspection_connector::{Version, Warning};
+use psl::dml::{self, Datamodel, Field, Model, PrimaryKeyDefinition, PrimaryKeyField, RelationField, SortOrder};
 use sql_schema_describer::{walkers::TableWalker, ForeignKeyId, SQLSortOrder};
 use std::collections::HashSet;
 use tracing::debug;
 
-pub(crate) fn introspect(ctx: &mut Context) -> Result<(), SqlError> {
+pub(crate) fn introspect(ctx: &Context, warnings: &mut Vec<Warning>) -> Result<(Version, String, bool), SqlError> {
+    let mut datamodel = Datamodel::new();
     let schema = ctx.schema;
+
     // collect m2m table names
     let m2m_tables: Vec<String> = schema
         .table_walkers()
@@ -101,26 +104,25 @@ pub(crate) fn introspect(ctx: &mut Context) -> Result<(), SqlError> {
             });
         }
 
-        ctx.datamodel.add_model(model);
+        datamodel.add_model(model);
     }
 
     for e in schema.enums.iter() {
         let values = e.values.iter().map(|v| dml::EnumValue::new(v)).collect();
-        ctx.datamodel.add_enum(dml::Enum::new(&e.name, values));
+        datamodel.add_enum(dml::Enum::new(&e.name, values));
     }
 
     let mut fields_to_be_added = Vec::new();
 
     // add backrelation fields
-    for model in ctx.datamodel.models() {
+    for model in datamodel.models() {
         for relation_field in model.relation_fields() {
             let relation_info = &relation_field.relation_info;
-            if ctx
-                .datamodel
+            if datamodel
                 .find_related_field_for_info(relation_info, &relation_field.name)
                 .is_none()
             {
-                let other_model = ctx.datamodel.find_model(&relation_info.to).unwrap();
+                let other_model = datamodel.find_model(&relation_info.to).unwrap();
                 let field = calculate_backrelation_field(schema, model, other_model, relation_field, relation_info)?;
 
                 fields_to_be_added.push((other_model.name.clone(), field));
@@ -133,29 +135,57 @@ pub(crate) fn introspect(ctx: &mut Context) -> Result<(), SqlError> {
         .table_walkers()
         .filter(|table| is_prisma_1_point_1_or_2_join_table(*table) || is_prisma_1_point_0_join_table(*table))
     {
-        calculate_fields_for_prisma_join_table(table, &mut fields_to_be_added, ctx)
+        calculate_fields_for_prisma_join_table(table, &mut fields_to_be_added, &datamodel)
     }
 
     for (model, field) in fields_to_be_added {
-        ctx.datamodel
-            .find_model_mut(&model)
-            .add_field(Field::RelationField(field));
+        datamodel.find_model_mut(&model).add_field(Field::RelationField(field));
     }
 
-    Ok(())
+    if !sanitization_leads_to_duplicate_names(&datamodel) {
+        // our opinionation about valid names
+        sanitize_datamodel_names(ctx, &mut datamodel);
+    }
+
+    // deduplicating relation field names
+    deduplicate_relation_field_names(&mut datamodel);
+
+    if !ctx.previous_datamodel.is_empty() {
+        enrich(ctx.previous_datamodel, &mut datamodel, ctx, warnings);
+        debug!("Enriching datamodel is done.");
+    }
+
+    // commenting out models, fields, enums, enum values
+    warnings.append(&mut commenting_out_guardrails(&mut datamodel, ctx));
+
+    // try to identify whether the schema was created by a previous Prisma version
+    let version = version_checker::check_prisma_version(ctx, warnings);
+
+    // if based on a previous Prisma version add id default opinionations
+    add_prisma_1_id_defaults(&version, &mut datamodel, schema, warnings, ctx);
+
+    let is_empty = datamodel.is_empty();
+
+    let data_model = if ctx.render_config {
+        psl::render_datamodel_and_config_to_string(&datamodel, ctx.config)
+    } else {
+        psl::render_datamodel_to_string(&datamodel, Some(ctx.config))
+    };
+
+    Ok((version, data_model, is_empty))
 }
 
 fn calculate_fields_for_prisma_join_table(
     join_table: TableWalker<'_>,
     fields_to_be_added: &mut Vec<(String, RelationField)>,
-    ctx: &mut Context,
+    datamodel: &Datamodel,
 ) {
     let mut foreign_keys = join_table.foreign_keys();
     if let (Some(fk_a), Some(fk_b)) = (foreign_keys.next(), foreign_keys.next()) {
         let is_self_relation = fk_a.referenced_table().id == fk_b.referenced_table().id;
 
         for (fk, opposite_fk) in &[(fk_a, fk_b), (fk_b, fk_a)] {
-            let referenced_model = dml::find_model_by_db_name(ctx.datamodel, fk.referenced_table().name())
+            let referenced_model = dml::find_model_by_db_name(datamodel, fk.referenced_table().name())
                 .expect("Could not find model referenced in relation table.");
 
             let relation_name = join_table.name()[1..].to_owned();

--- a/introspection-engine/connectors/sql-introspection-connector/src/introspection_helpers.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/introspection_helpers.rs
@@ -152,7 +152,7 @@ pub fn calculate_many_to_many_field(
     RelationField::new(&name, FieldArity::List, FieldArity::List, relation_info)
 }
 
-pub(crate) fn calculate_index(index: sql::walkers::IndexWalker<'_>, ctx: &mut Context) -> Option<IndexDefinition> {
+pub(crate) fn calculate_index(index: sql::walkers::IndexWalker<'_>, ctx: &Context) -> Option<IndexDefinition> {
     let tpe = match index.index_type() {
         IndexType::Unique => psl::dml::IndexType::Unique,
         IndexType::Normal => psl::dml::IndexType::Normal,
@@ -196,7 +196,7 @@ pub(crate) fn calculate_index(index: sql::walkers::IndexWalker<'_>, ctx: &mut Co
     })
 }
 
-pub(crate) fn calculate_scalar_field(column: ColumnWalker<'_>, ctx: &mut Context) -> ScalarField {
+pub(crate) fn calculate_scalar_field(column: ColumnWalker<'_>, ctx: &Context) -> ScalarField {
     debug!("Handling column {:?}", column);
 
     let field_type = calculate_scalar_field_type_with_native_types(column, ctx);
@@ -376,10 +376,7 @@ pub(crate) fn calculate_scalar_field_type_for_native_type(column: ColumnWalker<'
     }
 }
 
-pub(crate) fn calculate_scalar_field_type_with_native_types(
-    column: sql::ColumnWalker<'_>,
-    ctx: &mut Context,
-) -> FieldType {
+pub(crate) fn calculate_scalar_field_type_with_native_types(column: sql::ColumnWalker<'_>, ctx: &Context) -> FieldType {
     debug!("Calculating native field type for '{}'", column.name());
     let scalar_type = calculate_scalar_field_type_for_native_type(column);
 
@@ -451,7 +448,7 @@ pub(crate) fn replace_index_field_names(target: &mut Vec<IndexField>, old_name: 
     }
 }
 
-fn index_algorithm(index: sql::walkers::IndexWalker<'_>, ctx: &mut Context) -> Option<IndexAlgorithm> {
+fn index_algorithm(index: sql::walkers::IndexWalker<'_>, ctx: &Context) -> Option<IndexAlgorithm> {
     if !ctx.sql_family().is_postgres() {
         return None;
     }
@@ -468,7 +465,7 @@ fn index_algorithm(index: sql::walkers::IndexWalker<'_>, ctx: &mut Context) -> O
     })
 }
 
-fn index_is_clustered(index_id: sql::IndexId, schema: &SqlSchema, ctx: &mut Context) -> Option<bool> {
+fn index_is_clustered(index_id: sql::IndexId, schema: &SqlSchema, ctx: &Context) -> Option<bool> {
     if !ctx.sql_family().is_mssql() {
         return None;
     }
@@ -478,7 +475,7 @@ fn index_is_clustered(index_id: sql::IndexId, schema: &SqlSchema, ctx: &mut Cont
     Some(ext.index_is_clustered(index_id))
 }
 
-pub(crate) fn primary_key_is_clustered(pkid: sql::IndexId, ctx: &mut Context) -> Option<bool> {
+pub(crate) fn primary_key_is_clustered(pkid: sql::IndexId, ctx: &Context) -> Option<bool> {
     if !ctx.sql_family().is_mssql() {
         return None;
     }
@@ -488,7 +485,7 @@ pub(crate) fn primary_key_is_clustered(pkid: sql::IndexId, ctx: &mut Context) ->
     Some(ext.index_is_clustered(pkid))
 }
 
-fn get_opclass(index_field_id: sql::IndexColumnId, schema: &SqlSchema, ctx: &mut Context) -> Option<OperatorClass> {
+fn get_opclass(index_field_id: sql::IndexColumnId, schema: &SqlSchema, ctx: &Context) -> Option<OperatorClass> {
     if !ctx.sql_family().is_postgres() {
         return None;
     }

--- a/introspection-engine/connectors/sql-introspection-connector/src/prisma_1_defaults.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/prisma_1_defaults.rs
@@ -1,18 +1,19 @@
 use crate::{
+    calculate_datamodel::CalculateDatamodelContext,
     warnings::{warning_default_cuid_warning, warning_default_uuid_warning, ModelAndField},
     SqlFamilyTrait,
 };
-use introspection_connector::{IntrospectionContext, Version, Warning};
+use introspection_connector::{Version, Warning};
 use native_types::{MySqlType, PostgresType};
 use psl::dml::{self, Datamodel, ValueGenerator};
 use sql_schema_describer::SqlSchema;
 
-pub fn add_prisma_1_id_defaults(
+pub(crate) fn add_prisma_1_id_defaults(
     version: &Version,
     data_model: &mut Datamodel,
     schema: &SqlSchema,
     warnings: &mut Vec<Warning>,
-    ctx: &IntrospectionContext,
+    ctx: &CalculateDatamodelContext,
 ) {
     let mut needs_to_be_changed = vec![];
 

--- a/introspection-engine/connectors/sql-introspection-connector/src/re_introspection.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/re_introspection.rs
@@ -1,19 +1,20 @@
 use crate::{
+    calculate_datamodel::CalculateDatamodelContext,
     introspection_helpers::{replace_index_field_names, replace_pk_field_names, replace_relation_info_field_names},
     warnings::*,
     SqlFamilyTrait,
 };
-use introspection_connector::{IntrospectionContext, Warning};
+use introspection_connector::Warning;
 use psl::dml::{self, Datamodel, DefaultValue, Field, FieldType, Ignorable, PrismaValue, ValueGenerator, WithName};
 use std::{
     cmp::Ordering::{self, Equal, Greater, Less},
     collections::{BTreeSet, HashMap},
 };
 
-pub fn enrich(
+pub(crate) fn enrich(
     old_data_model: &Datamodel,
     new_data_model: &mut Datamodel,
-    ctx: &IntrospectionContext,
+    ctx: &CalculateDatamodelContext,
     warnings: &mut Vec<Warning>,
 ) {
     // Keep @relation attributes even if the database doesn't use foreign keys
@@ -635,7 +636,7 @@ fn merge_changed_enum_values(old_data_model: &Datamodel, new_data_model: &mut Da
 }
 
 //mysql enum names
-fn merge_mysql_enum_names(old_data_model: &Datamodel, new_data_model: &mut Datamodel, ctx: &IntrospectionContext) {
+fn merge_mysql_enum_names(old_data_model: &Datamodel, new_data_model: &mut Datamodel, ctx: &CalculateDatamodelContext) {
     let mut changed_mysql_enum_names = vec![];
 
     if ctx.sql_family().is_mysql() {

--- a/introspection-engine/connectors/sql-introspection-connector/src/sanitize_datamodel_names.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/sanitize_datamodel_names.rs
@@ -16,9 +16,9 @@ static EMPTY_ENUM_PLACEHOLDER: &str = "EMPTY_ENUM_VALUE";
 static RE_START: Lazy<Regex> = Lazy::new(|| Regex::new("^[^a-zA-Z]+").unwrap());
 static RE: Lazy<Regex> = Lazy::new(|| Regex::new("[^_a-zA-Z0-9]").unwrap());
 
-pub(crate) fn sanitize_datamodel_names(ctx: &mut Context) {
-    let enum_renames = sanitize_models(ctx);
-    sanitize_enums(&enum_renames, ctx);
+pub(crate) fn sanitize_datamodel_names(ctx: &Context, datamodel: &mut Datamodel) {
+    let enum_renames = sanitize_models(ctx, datamodel);
+    sanitize_enums(&enum_renames, datamodel);
 }
 
 // if after opionated renames we have duplicated names, e.g. a database with
@@ -42,11 +42,11 @@ pub fn sanitization_leads_to_duplicate_names(datamodel: &Datamodel) -> bool {
 }
 
 // Todo: Sanitizing might need to be adjusted to also change the fields in the RelationInfo
-fn sanitize_models(ctx: &mut Context) -> HashMap<String, (String, Option<String>)> {
+fn sanitize_models(ctx: &Context, datamodel: &mut Datamodel) -> HashMap<String, (String, Option<String>)> {
     let mut enum_renames = HashMap::new();
     let sql_family = ctx.sql_family();
 
-    for model in ctx.datamodel.models_mut() {
+    for model in datamodel.models_mut() {
         rename_reserved(model);
         sanitize_name(model);
 
@@ -132,8 +132,8 @@ fn sanitize_models(ctx: &mut Context) -> HashMap<String, (String, Option<String>
     enum_renames
 }
 
-fn sanitize_enums(enum_renames: &HashMap<String, (String, Option<String>)>, ctx: &mut Context) {
-    for enm in ctx.datamodel.enums_mut() {
+fn sanitize_enums(enum_renames: &HashMap<String, (String, Option<String>)>, datamodel: &mut Datamodel) {
+    for enm in datamodel.enums_mut() {
         if let Some((sanitized_name, db_name)) = enum_renames.get(&enm.name) {
             if enm.database_name().is_none() {
                 enm.set_database_name(db_name.clone());

--- a/introspection-engine/connectors/sql-introspection-connector/src/version_checker.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/version_checker.rs
@@ -1,15 +1,16 @@
+use crate::calculate_datamodel::CalculateDatamodelContext;
 use crate::introspection_helpers::{
     has_created_at_and_updated_at, is_new_migration_table, is_old_migration_table, is_prisma_1_or_11_list_table,
     is_prisma_1_point_0_join_table, is_prisma_1_point_1_or_2_join_table, is_relay_table,
 };
 use crate::SqlFamilyTrait;
-use introspection_connector::{IntrospectionContext, Version, Warning};
+use introspection_connector::{Version, Warning};
 use native_types::{MySqlType, PostgresType};
 use quaint::connector::SqlFamily;
 use sql_schema_describer::ForeignKeyWalker;
 use sql_schema_describer::{
     walkers::{ColumnWalker, TableWalker},
-    ForeignKeyAction, SqlSchema,
+    ForeignKeyAction,
 };
 use tracing::debug;
 
@@ -53,18 +54,14 @@ const MYSQL_TYPES: &[MySqlType] = &[
     MySqlType::Char(36),
 ];
 
-pub(crate) fn check_prisma_version(
-    schema: &SqlSchema,
-    ctx: &IntrospectionContext,
-    warnings: &mut Vec<Warning>,
-) -> Version {
+pub(crate) fn check_prisma_version(ctx: &CalculateDatamodelContext, warnings: &mut Vec<Warning>) -> Version {
     let mut version_checker = VersionChecker {
         sql_family: ctx.sql_family(),
         is_cockroachdb: ctx.source.active_provider == "cockroachdb",
-        has_migration_table: schema.table_walkers().any(is_old_migration_table),
-        has_relay_table: schema.table_walkers().any(is_relay_table),
-        has_prisma_1_join_table: schema.table_walkers().any(is_prisma_1_point_0_join_table),
-        has_prisma_1_1_or_2_join_table: schema.table_walkers().any(is_prisma_1_point_1_or_2_join_table),
+        has_migration_table: ctx.schema.table_walkers().any(is_old_migration_table),
+        has_relay_table: ctx.schema.table_walkers().any(is_relay_table),
+        has_prisma_1_join_table: ctx.schema.table_walkers().any(is_prisma_1_point_0_join_table),
+        has_prisma_1_1_or_2_join_table: ctx.schema.table_walkers().any(is_prisma_1_point_1_or_2_join_table),
         uses_on_delete: false,
         uses_default_values: false,
         always_has_created_at_updated_at: true,
@@ -73,7 +70,8 @@ pub(crate) fn check_prisma_version(
         has_inline_relations: false,
     };
 
-    for table in schema
+    for table in ctx
+        .schema
         .table_walkers()
         .filter(|table| !is_old_migration_table(*table))
         .filter(|table| !is_new_migration_table(*table))
@@ -102,7 +100,7 @@ pub(crate) fn check_prisma_version(
     debug!("{:?}", &version_checker);
 
     match version_checker.sql_family {
-        _ if schema.is_empty() => Version::NonPrisma,
+        _ if ctx.schema.is_empty() => Version::NonPrisma,
         SqlFamily::Sqlite if version_checker.is_prisma_2(warnings) => Version::Prisma2,
         SqlFamily::Sqlite => Version::NonPrisma,
         SqlFamily::Mysql if version_checker.is_prisma_2(warnings) => Version::Prisma2,

--- a/introspection-engine/introspection-engine-tests/src/test_api.rs
+++ b/introspection-engine/introspection-engine-tests/src/test_api.rs
@@ -105,22 +105,16 @@ impl TestApi {
 
     pub async fn introspect(&self) -> Result<String> {
         let previous_schema = psl::validate(self.pure_config().into());
-        let introspection_result = self.test_introspect_internal(previous_schema).await?;
+        let introspection_result = self.test_introspect_internal(previous_schema, true).await?;
 
-        Ok(psl::render_datamodel_and_config_to_string(
-            &introspection_result.data_model,
-            &self.configuration(),
-        ))
+        Ok(introspection_result.data_model)
     }
 
     pub async fn introspect_dml(&self) -> Result<String> {
         let previous_schema = psl::validate(self.pure_config().into());
-        let introspection_result = self.test_introspect_internal(previous_schema).await?;
+        let introspection_result = self.test_introspect_internal(previous_schema, false).await?;
 
-        Ok(psl::render_datamodel_to_string(
-            &introspection_result.data_model,
-            Some(&self.configuration()),
-        ))
+        Ok(introspection_result.data_model)
     }
 
     pub fn is_cockroach(&self) -> bool {
@@ -144,8 +138,10 @@ impl TestApi {
     async fn test_introspect_internal(
         &self,
         previous_schema: psl::ValidatedSchema,
+        render_config: bool,
     ) -> ConnectorResult<IntrospectionResult> {
-        let ctx = IntrospectionContext::new(previous_schema, CompositeTypeDepth::Infinite);
+        let mut ctx = IntrospectionContext::new(previous_schema, CompositeTypeDepth::Infinite);
+        ctx.render_config = render_config;
 
         self.api
             .introspect(&ctx)
@@ -158,47 +154,37 @@ impl TestApi {
     pub async fn re_introspect(&self, data_model_string: &str) -> Result<String> {
         let schema = format!("{}{}", self.pure_config(), data_model_string);
         let schema = parse_datamodel(&schema);
-        let config = self.configuration();
-        let introspection_result = self.test_introspect_internal(schema).await?;
+        let introspection_result = self.test_introspect_internal(schema, true).await?;
 
-        let rendering_span = tracing::info_span!("render_datamodel after introspection");
-        let _span = rendering_span.enter();
-        let dm = psl::render_datamodel_and_config_to_string(&introspection_result.data_model, &config);
-
-        Ok(dm)
+        Ok(introspection_result.data_model)
     }
 
     #[tracing::instrument(skip(self, data_model_string))]
     #[track_caller]
     pub async fn re_introspect_dml(&self, data_model_string: &str) -> Result<String> {
-        let config = self.configuration();
         let data_model = parse_datamodel(&format!("{}{}", self.pure_config(), data_model_string));
-        let introspection_result = self.test_introspect_internal(data_model).await?;
+        let introspection_result = self.test_introspect_internal(data_model, false).await?;
 
-        let rendering_span = tracing::info_span!("render_datamodel after introspection");
-        let _span = rendering_span.enter();
-        let dm = psl::render_datamodel_to_string(&introspection_result.data_model, Some(&config));
-
-        Ok(dm)
+        Ok(introspection_result.data_model)
     }
 
     pub async fn re_introspect_warnings(&self, data_model_string: &str) -> Result<String> {
         let data_model = parse_datamodel(&format!("{}{}", self.pure_config(), data_model_string));
-        let introspection_result = self.test_introspect_internal(data_model).await?;
+        let introspection_result = self.test_introspect_internal(data_model, false).await?;
 
         Ok(serde_json::to_string(&introspection_result.warnings)?)
     }
 
     pub async fn introspect_version(&self) -> Result<Version> {
         let previous_schema = psl::validate(self.pure_config().into());
-        let introspection_result = self.test_introspect_internal(previous_schema).await?;
+        let introspection_result = self.test_introspect_internal(previous_schema, false).await?;
 
         Ok(introspection_result.version)
     }
 
     pub async fn introspection_warnings(&self) -> Result<String> {
         let previous_schema = psl::validate(self.pure_config().into());
-        let introspection_result = self.test_introspect_internal(previous_schema).await?;
+        let introspection_result = self.test_introspect_internal(previous_schema, false).await?;
 
         Ok(serde_json::to_string(&introspection_result.warnings)?)
     }
@@ -276,11 +262,10 @@ impl TestApi {
 
     #[track_caller]
     pub async fn expect_re_introspected_datamodel(&self, schema: &str, expectation: expect_test::Expect) {
-        let config = self.configuration();
         let data_model = parse_datamodel(&format!("{}{}", self.pure_config(), schema));
-        let reintrospected = self.test_introspect_internal(data_model).await.unwrap();
-        let found = psl::render_datamodel_to_string(&reintrospected.data_model, Some(&config));
-        expectation.assert_eq(&found);
+        let reintrospected = self.test_introspect_internal(data_model, false).await.unwrap();
+
+        expectation.assert_eq(&reintrospected.data_model);
     }
 
     #[track_caller]

--- a/introspection-engine/introspection-engine-tests/tests/simple/postgres/index_with_expression_column.sql
+++ b/introspection-engine/introspection-engine-tests/tests/simple/postgres/index_with_expression_column.sql
@@ -20,6 +20,8 @@ CREATE INDEX index_communication_channels_on_path_and_path_type ON communication
 CREATE UNIQUE INDEX index_communication_channels_on_user_id_and_path_and_path_type ON communication_channels (user_id, lower((path)::text), path_type);
 CREATE INDEX index_communication_channels_on_confirmation_code ON communication_channels (confirmation_code);
 
+
+
 /*
 generator client {
   provider = "prisma-client-js"

--- a/introspection-engine/introspection-engine-tests/tests/simple/postgres/int_array_extension_does_not_conflict.sql
+++ b/introspection-engine/introspection-engine-tests/tests/simple/postgres/int_array_extension_does_not_conflict.sql
@@ -10,6 +10,8 @@ CREATE TABLE test (
 );
 
 CREATE INDEX futureproof ON test(big_data);
+
+
 /*
 generator client {
   provider = "prisma-client-js"

--- a/introspection-engine/introspection-engine-tests/tests/tables/mysql.rs
+++ b/introspection-engine/introspection-engine-tests/tests/tables/mysql.rs
@@ -415,7 +415,7 @@ async fn missing_select_rights(api: &TestApi) -> TestResult {
     let ctx = IntrospectionContext::new(config, Default::default());
 
     let res = conn.introspect(&ctx).await.unwrap();
-    assert!(res.data_model.is_empty());
+    assert!(res.is_empty);
 
     Ok(())
 }

--- a/migration-engine/core/src/state.rs
+++ b/migration-engine/core/src/state.rs
@@ -309,10 +309,9 @@ impl GenericApi for EngineState {
                 let ctx = migration_connector::IntrospectionContext::new(schema, composite_type_depth);
                 Box::pin(async move {
                     let result = connector.introspect(&ctx).await?;
-                    let rendered_result =
-                        psl::render_datamodel_and_config_to_string(&result.data_model, ctx.configuration());
+
                     Ok(IntrospectResult {
-                        datamodel: rendered_result,
+                        datamodel: result.data_model,
                         version: format!("{:?}", result.version),
                         warnings: result
                             .warnings


### PR DESCRIPTION
This is a step forward for getting rid of the dml in introspection. Here we make the connector API to return a String. Next steps would be to stop using dml for rendering and basis for re-introspection, which we make easier here by changing the API signatures.