### PR TITLE
query-engine-tests: add compile time measurement script, reduce compile times by 15+%

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/bench.sh
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/bench.sh
@@ -1,0 +1,1 @@
+hyperfine --warmup 1 --max-runs 3  -p 'cargo clean -p query-engine-tests' 'cargo build --tests' --export-markdown=compile-bench.md

--- a/query-engine/connector-test-kit-rs/query-engine-tests/compile-bench.md
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/compile-bench.md
@@ -1,3 +1,3 @@
 | Command | Mean [s] | Min [s] | Max [s] | Relative |
 |:---|---:|---:|---:|---:|
-| `cargo build --tests` | 100.286 ± 1.143 | 99.541 | 101.602 | 1.00 |
+| `cargo build --tests` | 98.519 ± 1.156 | 97.353 | 99.665 | 1.00 |

--- a/query-engine/connector-test-kit-rs/query-engine-tests/compile-bench.md
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/compile-bench.md
@@ -1,0 +1,3 @@
+| Command | Mean [s] | Min [s] | Max [s] | Relative |
+|:---|---:|---:|---:|---:|
+| `cargo build --tests` | 117.675 ± 2.068 | 116.272 | 120.050 | 1.00 |

--- a/query-engine/connector-test-kit-rs/query-engine-tests/compile-bench.md
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/compile-bench.md
@@ -1,3 +1,3 @@
 | Command | Mean [s] | Min [s] | Max [s] | Relative |
 |:---|---:|---:|---:|---:|
-| `cargo build --tests` | 117.675 ± 2.068 | 116.272 | 120.050 | 1.00 |
+| `cargo build --tests` | 100.286 ± 1.143 | 99.541 | 101.602 | 1.00 |

--- a/query-engine/connector-test-kit-rs/query-test-macros/src/relation_link_test.rs
+++ b/query-engine/connector-test-kit-rs/query-test-macros/src/relation_link_test.rs
@@ -56,11 +56,8 @@ pub fn relation_link_test_impl(attr: TokenStream, input: TokenStream) -> TokenSt
 
     // Renders the connectors as list to use in the code.
     let connectors = args.connectors_to_test();
-    let connectors = connectors.into_iter().map(quote_connector).reduce(|aggr, next| {
-        quote! {
-            #aggr, #next
-        }
-    });
+    let connectors = connectors.into_iter().map(quote_connector);
+    let connectors = quote!(#(#connectors,)*);
 
     let mut test_function = parse_macro_input!(input as ItemFn);
     if test_function.sig.inputs.len() != 2 {
@@ -123,16 +120,16 @@ pub fn relation_link_test_impl(attr: TokenStream, input: TokenStream) -> TokenSt
             .get(i)
             .expect("Could not find some required capabilities")
             .iter()
-            .map(|cap| format!("{}", cap))
+            .map(|cap| cap.to_string())
             .collect::<Vec<_>>();
 
         let ts = quote! {
             #[test]
             fn #test_fn_ident() {
               query_tests_setup::run_relation_link_test(
-                  vec![#connectors],
+                  &[#connectors],
                   &mut vec![#(#capabilities),*],
-                  vec![#(#required_capabilities),*],
+                  &[#(#required_capabilities),*],
                   #datamodel,
                   #dm_with_params,
                   #test_name,
@@ -145,18 +142,8 @@ pub fn relation_link_test_impl(attr: TokenStream, input: TokenStream) -> TokenSt
         ts
     });
 
-    let all_funcs: proc_macro2::TokenStream = test_shells
-        .reduce(|aggr, next| {
-            quote! {
-                #aggr
-
-                #next
-            }
-        })
-        .unwrap();
-
     let all_funcs_with_original_func = quote! {
-        #all_funcs
+        #(#test_shells)*
 
         #test_function
     };

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/lib.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/lib.rs
@@ -83,10 +83,11 @@ impl<'a, A: 'a, B: 'a, Fut: Future + 'a, F: FnOnce(&'a A, &'a B) -> Fut> AsyncFn
 }
 
 #[allow(clippy::too_many_arguments)]
+#[inline(never)] // currently not inlined, but let's make sure it doesn't change
 pub fn run_relation_link_test<F>(
-    enabled_connectors: Vec<ConnectorTag>,
+    enabled_connectors: &[ConnectorTag],
     capabilities: &mut Vec<ConnectorCapability>,
-    required_capabilities: Vec<&str>,
+    required_capabilities: &[&str],
     datamodel: &str,
     dm_with_params: &str,
     test_name: &str,


### PR DESCRIPTION
This is only very low hanging fruits, and mostly on relation_link_tests, which is the minority of tests. connector_tests is heavier on the compiler, and more tests use it, so there are a lot more gains to be made there later. See the individual commits and their messages for more details.