### PR TITLE
qe: shave another 30%+ off query-engine-tests compile times

### DIFF
--- a/migration-engine/migration-engine-tests/tests/migrations/cockroachdb/failure_modes.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/cockroachdb/failure_modes.rs
@@ -38,7 +38,7 @@ fn failing_migration_after_migration_dropping_data(api: TestApi) {
         Database error:
         ERROR: column "is_good_dog" does not exist
 
-        DbError { severity: "ERROR", parsed_severity: None, code: SqlState(E42703), message: "column \"is_good_dog\" does not exist", detail: None, hint: None, position: None, where_: None, schema: None, table: None, column: None, datatype: None, constraint: None, file: Some("column_resolver.go"), line: Some(196), routine: Some("NewUndefinedColumnError") }
+        DbError { severity: "ERROR", parsed_severity: Some(Error), code: SqlState(E42703), message: "column \"is_good_dog\" does not exist", detail: None, hint: None, position: None, where_: None, schema: None, table: None, column: None, datatype: None, constraint: None, file: Some("column_resolver.go"), line: Some(196), routine: Some("NewUndefinedColumnError") }
 
            0: sql_migration_connector::apply_migration::apply_script
                    with [3mmigration_name[0m[2m=[0m"  2"
@@ -85,7 +85,7 @@ fn failing_step_in_migration_dropping_data(api: TestApi) {
         Database error:
         ERROR: column "is_good_dog" does not exist
 
-        DbError { severity: "ERROR", parsed_severity: None, code: SqlState(E42703), message: "column \"is_good_dog\" does not exist", detail: None, hint: None, position: None, where_: None, schema: None, table: None, column: None, datatype: None, constraint: None, file: Some("column_resolver.go"), line: Some(196), routine: Some("NewUndefinedColumnError") }
+        DbError { severity: "ERROR", parsed_severity: Some(Error), code: SqlState(E42703), message: "column \"is_good_dog\" does not exist", detail: None, hint: None, position: None, where_: None, schema: None, table: None, column: None, datatype: None, constraint: None, file: Some("column_resolver.go"), line: Some(196), routine: Some("NewUndefinedColumnError") }
 
            0: sql_migration_connector::apply_migration::apply_script
                    with [3mmigration_name[0m[2m=[0m"  1"
@@ -198,7 +198,7 @@ fn syntax_errors_return_error_position(api: TestApi) {
                         ^
         HINT: try \h CREATE TABLE
 
-        DbError { severity: "ERROR", parsed_severity: None, code: SqlState(E42601), message: "at or near \"is_good_dog\": syntax error", detail: Some("source SQL:\nCREATE TABLE \"Dog\" (\n                id              SERIAL PRIMARY KEY,\n                name            TEXT NOT NULL\n                is_good_dog     BOOLEAN NOT NULL DEFAULT TRUE\n                ^"), hint: Some("try \\h CREATE TABLE"), position: None, where_: None, schema: None, table: None, column: None, datatype: None, constraint: None, file: Some("lexer.go"), line: Some(251), routine: Some("Error") }
+        DbError { severity: "ERROR", parsed_severity: Some(Error), code: SqlState(E42601), message: "at or near \"is_good_dog\": syntax error", detail: Some("source SQL:\nCREATE TABLE \"Dog\" (\n                id              SERIAL PRIMARY KEY,\n                name            TEXT NOT NULL\n                is_good_dog     BOOLEAN NOT NULL DEFAULT TRUE\n                ^"), hint: Some("try \\h CREATE TABLE"), position: None, where_: None, schema: None, table: None, column: None, datatype: None, constraint: None, file: Some("lexer.go"), line: Some(271), routine: Some("Error") }
 
            0: sql_migration_connector::apply_migration::apply_script
                    with [3mmigration_name[0m[2m=[0m"  0"

--- a/query-engine/connector-test-kit-rs/query-engine-tests/compile-bench.md
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/compile-bench.md
@@ -1,3 +1,3 @@
 | Command | Mean [s] | Min [s] | Max [s] | Relative |
 |:---|---:|---:|---:|---:|
-| `cargo build --tests` | 98.519 ± 1.156 | 97.353 | 99.665 | 1.00 |
+| `cargo build --tests` | 67.231 ± 0.091 | 67.167 | 67.335 | 1.00 |

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/field_reference/decimal_filter.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/field_reference/decimal_filter.rs
@@ -245,7 +245,7 @@ mod decimal_filter {
 
     pub async fn test_list_data(runner: &Runner) -> TestResult<()> {
         run_query!(
-            &runner,
+            runner,
             r#"mutation { createOneTestModel(data: {
                 id: 1,
                 dec: "1.5",
@@ -254,7 +254,7 @@ mod decimal_filter {
             }) { id }}"#
         );
         run_query!(
-            &runner,
+            runner,
             r#"mutation { createOneTestModel(data: {
                 id: 2,
                 dec: "1.2",

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/field_reference/json_filter.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/field_reference/json_filter.rs
@@ -428,7 +428,7 @@ mod json_filter {
 
     pub async fn test_data_list(runner: &Runner) -> TestResult<()> {
         run_query!(
-            &runner,
+            runner,
             r#"
               mutation { createOneTestModel(data: {
                   id: 1,
@@ -440,7 +440,7 @@ mod json_filter {
         );
 
         run_query!(
-            &runner,
+            runner,
             r#"
               mutation { createOneTestModel(data: {
                   id: 2,
@@ -451,7 +451,7 @@ mod json_filter {
             "#
         );
 
-        run_query!(&runner, r#"mutation { createOneTestModel(data: { id: 3 }) { id }}"#);
+        run_query!(runner, r#"mutation { createOneTestModel(data: { id: 3 }) { id }}"#);
 
         Ok(())
     }

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/field_reference/relation_filter.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/field_reference/relation_filter.rs
@@ -303,7 +303,7 @@ mod relation_filter {
 
     async fn create_to_many_data(runner: &Runner) -> TestResult<()> {
         create_row(
-            &runner,
+            runner,
             r#"{
               id: 1,
               children: {
@@ -324,7 +324,7 @@ mod relation_filter {
         )
         .await?;
         create_row(
-            &runner,
+            runner,
             r#"{
               id: 2,
               children: {
@@ -345,7 +345,7 @@ mod relation_filter {
         )
         .await?;
         create_row(
-            &runner,
+            runner,
             r#"{
               id: 3,
               children: {

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/create.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/create.rs
@@ -87,7 +87,7 @@ mod create {
         Ok(())
     }
 
-    // "A Create Mutation" should "create and return item with explicit null attributes"
+    // A Create Mutation should create and return item with explicit null attributes
     #[connector_test]
     async fn return_item_explicit_null_attrs(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
@@ -105,9 +105,25 @@ mod create {
         Ok(())
     }
 
-    // "A Create Mutation" should "create and return item with explicit null attributes when other mutation has explicit non-null values"
+    // "A Create Mutation" should "create and return item with implicit null attributes and createdAt should be set"
     #[connector_test]
-    async fn return_item_explicit_null_attrs_other_mut(runner: Runner) -> TestResult<()> {
+    async fn return_item_implicit_null_attr(runner: Runner) -> TestResult<()> {
+        // if the query succeeds createdAt did work. If would not have been set we would get a NullConstraintViolation.
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"mutation {
+            createOneScalarModel(data:{ id: "1" }){
+              optString, optInt, optFloat, optBoolean, optEnum
+            }
+          }"#),
+          @r###"{"data":{"createOneScalarModel":{"optString":null,"optInt":null,"optFloat":null,"optBoolean":null,"optEnum":null}}}"###
+        );
+
+        Ok(())
+    }
+
+    // A Create Mutation should create and return item with explicit null values after previous mutation with explicit non-null values
+    #[connector_test]
+    async fn return_item_non_null_attrs_then_explicit_null_attrs(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(&runner, r#"mutation {
             createOneScalarModel(
@@ -127,22 +143,6 @@ mod create {
               optString, optInt, optFloat, optBoolean, optEnum
             }
            }"#),
-          @r###"{"data":{"createOneScalarModel":{"optString":null,"optInt":null,"optFloat":null,"optBoolean":null,"optEnum":null}}}"###
-        );
-
-        Ok(())
-    }
-
-    // "A Create Mutation" should "create and return item with implicit null attributes and createdAt should be set"
-    #[connector_test]
-    async fn return_item_implicit_null_attr(runner: Runner) -> TestResult<()> {
-        // if the query succeeds createdAt did work. If would not have been set we would get a NullConstraintViolation.
-        insta::assert_snapshot!(
-          run_query!(&runner, r#"mutation {
-            createOneScalarModel(data:{ id: "1" }){
-              optString, optInt, optFloat, optBoolean, optEnum
-            }
-          }"#),
           @r###"{"data":{"createOneScalarModel":{"optString":null,"optInt":null,"optFloat":null,"optBoolean":null,"optEnum":null}}}"###
         );
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/insert_null_in_required_field.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/insert_null_in_required_field.rs
@@ -3,7 +3,7 @@ use query_engine_tests::*;
 #[test_suite]
 mod insert_null {
     use indoc::indoc;
-    use query_engine_tests::{assert_error, run_query, ConnectorTagInterface, Runner};
+    use query_engine_tests::{assert_error, run_query, Runner};
 
     fn schema_1() -> String {
         let schema = indoc! {

--- a/query-engine/connector-test-kit-rs/query-test-macros/src/connector_test.rs
+++ b/query-engine/connector-test-kit-rs/query-test-macros/src/connector_test.rs
@@ -19,11 +19,7 @@ pub fn connector_test_impl(attr: TokenStream, input: TokenStream) -> TokenStream
     };
 
     let excluded_features = args.exclude_features.features();
-    let excluded_features = quote! { &[#(#excluded_features),*] };
-
     let db_schemas = args.db_schemas.schemas();
-    let db_schemas = quote! { &[#(#db_schemas),*] };
-
     let connectors = args.connectors_to_test();
     let handler = args.schema.unwrap().handler_path;
 
@@ -58,17 +54,8 @@ pub fn connector_test_impl(attr: TokenStream, input: TokenStream) -> TokenStream
     // Combination of test name and test mod name.
     let test_name = test_fn_ident.to_string();
     let suite_name = args.suite.expect("A test must have a test suite.");
-    let test_database = format!("{}_{}", suite_name, test_name);
-    let capabilities: Vec<_> = args
-        .capabilities
-        .idents
-        .into_iter()
-        .map(|cap| {
-            quote! {
-                ConnectorCapability::#cap
-            }
-        })
-        .collect();
+    let test_database_name = format!("{}_{}", suite_name, test_name);
+    let capabilities = args.capabilities.idents;
 
     let referential_override = match args.referential_integrity {
         Some(ref_override) => {
@@ -83,33 +70,17 @@ pub fn connector_test_impl(attr: TokenStream, input: TokenStream) -> TokenStream
     let test = quote! {
         #[test]
         fn #test_fn_ident() {
-            let config = &query_tests_setup::CONFIG;
-            let enabled_connectors = &[
-                #(#connectors,)*
-            ];
-
-            let capabilities: &[ConnectorCapability] = &[
-                #(#capabilities),*
-            ];
-
-            if ConnectorTag::should_run(&config, enabled_connectors, capabilities, #test_name) {
-                let template = #handler();
-                let datamodel = query_tests_setup::render_test_datamodel(config, #test_database, template, #excluded_features, #referential_override, #db_schemas);
-                let connector = config.test_connector_tag().unwrap();
-                let metrics = query_tests_setup::setup_metrics();
-                let metrics_for_subscriber = metrics.clone();
-
-                query_tests_setup::run_with_tokio(async move {
-                    query_tests_setup::setup_project(&datamodel, #db_schemas).await.unwrap();
-
-                    let requires_teardown = connector.requires_teardown();
-                    let runner = Runner::load(config.runner(), datamodel.clone(), connector, metrics).await.unwrap();
-
-                    #runner_fn_ident(runner).await.unwrap();
-
-                    if requires_teardown { query_tests_setup::teardown_project(&datamodel, #db_schemas).await.unwrap(); }
-                }.with_subscriber(test_tracing_subscriber(std::env::var("LOG_LEVEL").unwrap_or("info".to_string()), metrics_for_subscriber)));
-            }
+            query_tests_setup::run_connector_test(
+                #test_name,
+                #test_database_name,
+                &[#(#connectors,)*],
+                &[#(ConnectorCapability::#capabilities),*],
+                &[#(#excluded_features),*],
+                #handler,
+                &[#(#db_schemas),*],
+                #referential_override,
+                #runner_fn_ident,
+            );
         }
 
         #test_function

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/logging.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/logging.rs
@@ -25,7 +25,7 @@ type Sub = Layered<
     >,
 >;
 
-pub fn test_tracing_subscriber(log_config: String, metrics: MetricRegistry) -> Sub {
+pub fn test_tracing_subscriber(log_config: &str, metrics: MetricRegistry) -> Sub {
     let filter = create_env_filter(true, log_config);
 
     let fmt_layer = tracing_subscriber::fmt::layer()
@@ -38,7 +38,7 @@ pub fn test_tracing_subscriber(log_config: String, metrics: MetricRegistry) -> S
         .with(ErrorLayer::default())
 }
 
-fn create_env_filter(log_queries: bool, qe_log_level: String) -> EnvFilter {
+fn create_env_filter(log_queries: bool, qe_log_level: &str) -> EnvFilter {
     let mut filter = EnvFilter::from_default_env()
         .add_directive("tide=error".parse().unwrap())
         .add_directive("tonic=error".parse().unwrap())


### PR DESCRIPTION
We do this by generating a call to a regular function in the
connector_test macro, instead of generating the same async function
implementation once per test. The compiler has a lot less code to
compile. In query-tests-setup, we then type-erase the future for the
test body, meaning the compiler only needs to compile the test setup
function exactly once for the whole test suite, instead of once per
test.