### PR TITLE
qe: fix prisma 14696

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/interactive_tx.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/interactive_tx.rs
@@ -444,7 +444,7 @@ mod itx_isolation {
 
         match tx_id {
             Ok(_) => panic!("Expected mongo to throw an unsupported error, but it succeeded instead."),
-            Err(err) => assert!(dbg!(err.to_string()).contains(
+            Err(err) => assert!(err.to_string().contains(
                 "Unsupported connector feature: Mongo does not support setting transaction isolation levels"
             )),
         };

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
@@ -2,6 +2,7 @@ mod max_integer;
 mod prisma_10098;
 mod prisma_10935;
 mod prisma_12929;
+mod prisma_14696;
 mod prisma_6173;
 mod prisma_7010;
 mod prisma_7072;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_14696.prisma
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_14696.prisma
@@ -1,0 +1,67 @@
+model User {
+  id BigInt @id @default(autoincrement()) @unique
+  googleId String @unique
+  username String @unique
+  avatar String
+  description String
+  password String
+  followers Follow[] @relation("following")
+  followings Follow[] @relation("follower")
+  createdAt DateTime @default(now())
+  posts Post[] @relation("user")
+  comments Comment[] @relation("user")
+  commentLikes CommentLike[] @relation("user")
+  postLikes PostLike[] @relation("user")
+  refreshToken RefreshToken? @relation("user")
+}
+
+model Follow {
+  follower User @relation("follower",fields: [followerId], references: [id])
+  followerId BigInt
+  following User @relation("following", fields: [followingId], references: [id])
+  followingId BigInt
+  @@id([followerId, followingId])
+  createdAt DateTime @default(now())
+}
+
+model Post {
+  id BigInt @id @default(autoincrement()) @unique
+  user User @relation("user", fields: [userId], references: [id])
+  userId BigInt
+  comments Comment[] @relation("post")
+  likes PostLike[] @relation("post")
+  createdAt DateTime @default(now())
+}
+
+model PostLike {
+  id BigInt @id @default(autoincrement()) @unique
+  post Post @relation("post", fields: [postId], references: [id])
+  postId BigInt
+  user User @relation("user", fields: [userId], references: [id])
+  userId BigInt
+  createdAt DateTime @default(now())
+}
+
+model Comment {
+  id BigInt @id @default(autoincrement()) @unique
+  post Post @relation("post", fields: [postId], references: [id])
+  postId BigInt
+  user User @relation("user", fields: [userId], references: [id])
+  userId BigInt
+  likes CommentLike[] @relation("comment")
+  createdAt DateTime @default(now())
+}
+
+model CommentLike {
+  id BigInt @id @default(autoincrement()) @unique
+  comment Comment @relation("comment", fields: [commentId], references: [id])
+  commentId BigInt
+  user User @relation("user", fields: [userId], references: [id])
+  userId BigInt
+  createdAt DateTime @default(now())
+}
+
+model RefreshToken {
+  user User @relation("user", fields: [userId], references: [id]) 
+  userId BigInt @unique
+}

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_14696.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_14696.rs
@@ -1,0 +1,78 @@
+use query_engine_tests::*;
+
+// mongodb has very specific constraint on id fields
+// mssql fails with a multiple cascading referential actions paths error
+#[test_suite(schema(schema), exclude(MongoDB, SqlServer))]
+mod prisma_14696 {
+    fn schema() -> String {
+        include_str!("./prisma_14696.prisma").to_string()
+    }
+
+    #[connector_test]
+    async fn create_does_not_panic(runner: Runner) -> TestResult<()> {
+        // Create the user.
+        {
+            let response = runner
+                .query(
+                    r#"
+                mutation { createOneUser(data: {
+                    id: 1,
+                    password: "1234batman",
+                    description: "rad",
+                    username: "1337kv",
+                    googleId: "1",
+                    avatar: "1",
+                }) { id } }
+            "#,
+                )
+                .await?;
+            response.assert_success();
+        }
+
+        let final_request = r#"
+            mutation {
+              createOnePost(data: {
+                id: 8,
+                user: {
+                  connect: {
+                    id: 1
+                  }
+                }
+                comments: {
+
+                }
+                likes: {
+
+                }
+              }) {
+                id
+                user {
+                  id
+                  googleId
+                  username
+                  avatar
+                  description
+                  password
+                  createdAt
+                }
+                userId
+                comments {
+                  id
+                  postId
+                  userId
+                  createdAt
+                }
+                likes {
+                  id
+                  userId
+                  createdAt
+                }
+                createdAt
+              }
+            }
+        "#;
+        let response = runner.query(final_request).await?;
+        response.assert_success();
+        Ok(())
+    }
+}

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/relations/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/relations/mod.rs
@@ -4,5 +4,6 @@ mod optional_rel;
 mod rel_defaults;
 mod rel_design;
 mod rel_graphql;
+mod rel_names;
 mod required_rel;
 mod same_model_self_rel_without_back_rel;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/relations/rel_names.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/relations/rel_names.rs
@@ -1,0 +1,61 @@
+use query_engine_tests::*;
+
+// We were creating a child_a record instead of child_b.
+// https://github.com/prisma/prisma/issues/14696
+//
+// This was due to a relation resolution logic issue.
+//
+// exclude: mongodb has very specific constraint on id fields
+#[test_suite(exclude(MongoDB))]
+mod rel_names {
+    fn schema() -> String {
+        let schema = r#"
+            model parent {
+              id          String   @id
+              child_a_id  String?
+              child_b_id  String?
+              child_a_rel child_a? @relation("child", fields: [child_a_id], references: [id])
+              child_b_rel child_b? @relation("child", fields: [child_b_id], references: [id])
+            }
+
+            model child_a {
+              id     String   @id
+              name String?
+              parent parent[] @relation("child")
+            }
+
+            model child_b {
+              id     String   @id
+              name String?
+              parent parent[] @relation("child")
+            }
+        "#;
+
+        schema.to_owned()
+    }
+
+    #[connector_test(schema(schema))]
+    async fn relation_names_are_resolved_correctly_in_create(runner: Runner) -> TestResult<()> {
+        let result = runner.query(r#"
+            mutation { createOneparent(data: { id: "theparent", child_b_rel: { create: { id: "the_child_emphatically_b" } } }) { id } }
+        "#).await?;
+        dbg!(result.to_string_pretty());
+        result.assert_success();
+
+        dbg!(runner
+            .query(r#"query { findManychild_a { id } }"#)
+            .await?
+            .to_string_pretty());
+        insta::assert_snapshot!(
+          run_query!(runner, r#"query { findManychild_a { id } }"#),
+          @r###"{"data":{"findManychild_a":[]}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(runner, r#"query { findManychild_b { id } }"#),
+          @r###"{"data":{"findManychild_b":[{"id":"the_child_emphatically_b"}]}}"###
+        );
+
+        Ok(())
+    }
+}

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/relations/rel_names.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/relations/rel_names.rs
@@ -39,13 +39,8 @@ mod rel_names {
         let result = runner.query(r#"
             mutation { createOneparent(data: { id: "theparent", child_b_rel: { create: { id: "the_child_emphatically_b" } } }) { id } }
         "#).await?;
-        dbg!(result.to_string_pretty());
         result.assert_success();
 
-        dbg!(runner
-            .query(r#"query { findManychild_a { id } }"#)
-            .await?
-            .to_string_pretty());
         insta::assert_snapshot!(
           run_query!(runner, r#"query { findManychild_a { id } }"#),
           @r###"{"data":{"findManychild_a":[]}}"###

--- a/query-engine/prisma-models/src/field/relation.rs
+++ b/query-engine/prisma-models/src/field/relation.rs
@@ -111,7 +111,7 @@ impl RelationField {
             .get_or_init(|| {
                 self.model()
                     .internal_data_model()
-                    .find_relation(&self.relation_name)
+                    .find_relation((&self.model().name, &self.relation_info.to), &self.relation_name)
                     .unwrap()
             })
             .upgrade()
@@ -125,9 +125,9 @@ impl RelationField {
 
     /// Inlined in self / model of self
     pub fn relation_is_inlined_in_parent(&self) -> bool {
-        let relation = self.relation();
+        let relation = &self.relation();
 
-        match relation.manifestation {
+        match &relation.manifestation {
             RelationLinkManifestation::Inline(ref m) => {
                 let is_self_rel = relation.is_self_relation();
 

--- a/query-engine/prisma-models/tests/datamodel_converter_tests.rs
+++ b/query-engine/prisma-models/tests/datamodel_converter_tests.rs
@@ -298,7 +298,7 @@ fn explicit_relation_fields() {
     let relation_name = "BlogToPost";
     let blog = datamodel.assert_model("Blog");
     let post = datamodel.assert_model("Post");
-    let relation = datamodel.assert_relation(relation_name);
+    let relation = datamodel.assert_relation(("Blog", "Post"), relation_name);
 
     blog.assert_relation_field("posts")
         .assert_list()
@@ -339,7 +339,7 @@ fn many_to_many_relations() {
     let relation_name = "BlogToPost";
     let blog = datamodel.assert_model("Blog");
     let post = datamodel.assert_model("Post");
-    let relation = datamodel.assert_relation(relation_name);
+    let relation = datamodel.assert_relation(("Blog", "Post"), relation_name);
 
     blog.assert_relation_field("posts")
         .assert_list()
@@ -499,7 +499,7 @@ fn convert(datamodel: &str) -> Arc<InternalDataModel> {
 
 trait DatamodelAssertions {
     fn assert_model(&self, name: &str) -> Arc<Model>;
-    fn assert_relation(&self, name: &str) -> Arc<Relation>;
+    fn assert_relation(&self, models: (&str, &str), name: &str) -> Arc<Relation>;
 }
 
 impl DatamodelAssertions for InternalDataModel {
@@ -507,8 +507,8 @@ impl DatamodelAssertions for InternalDataModel {
         self.find_model(name).unwrap()
     }
 
-    fn assert_relation(&self, name: &str) -> Arc<Relation> {
-        self.find_relation(name).unwrap().upgrade().unwrap()
+    fn assert_relation(&self, models: (&str, &str), name: &str) -> Arc<Relation> {
+        self.find_relation(models, name).unwrap().upgrade().unwrap()
     }
 }
 


### PR DESCRIPTION
qe: fix prisma 14696

See this internal doc for the explanation of the bug, its symptoms, its
causes and the suggested fix: https://www.notion.so/prismaio/Repair-Prisma-14696-relation-ambiguity-e881652fc48b48e69bcad63f23fb296a#44c9b285938c4c2db8cd2e386dca5df7

The TL;DR is that the PSL validations and the QE don't agree on the
scope of relation names (`@relation("this-is-the-name")`). This caused
the QE to pick the wrong relation to follow in cases where two relation
fields on the same model shared the same relation name without being in
the same relation. This lead mostly to panics, but also in some cases to
writes on the wrong table.

closes https://github.com/prisma/prisma/issues/14696
