### PR TITLE
qe-test-setup: starting re-using db setup logic from me+ie

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3153,6 +3153,7 @@ dependencies = [
  "psl",
  "quaint",
  "tempfile",
+ "test-setup",
  "url",
 ]
 

--- a/libs/test-setup/src/lib.rs
+++ b/libs/test-setup/src/lib.rs
@@ -4,6 +4,7 @@
 //! This crate contains constants and utilities that are useful for writing tests across the
 //! engines.
 
+pub mod mysql;
 /// Tokio test runtime utils.
 pub mod runtime;
 
@@ -11,7 +12,6 @@ mod capabilities;
 mod diff;
 mod logging;
 mod mssql;
-mod mysql;
 mod postgres;
 mod sqlite;
 mod tags;

--- a/libs/test-setup/src/mysql.rs
+++ b/libs/test-setup/src/mysql.rs
@@ -7,10 +7,10 @@ use url::Url;
 ///
 /// Source: https://dev.mysql.com/doc/mysql-reslimits-excerpt/5.5/en/identifier-length.html
 fn mysql_safe_identifier(identifier: &str) -> &str {
-    if identifier.len() < 64 {
+    if identifier.len() <= 64 {
         identifier
     } else {
-        identifier.get(0..63).expect("mysql identifier truncation")
+        identifier.get(0..64).expect("mysql identifier truncation")
     }
 }
 
@@ -78,10 +78,7 @@ pub(crate) fn get_mysql_tags(database_url: &str) -> Result<BitFlags<Tags>, Strin
 /// Returns a connection to the new database, as well as the corresponding
 /// complete connection string.
 #[allow(clippy::needless_lifetimes)] // clippy is wrong
-pub(crate) async fn create_mysql_database<'a>(
-    database_url: &str,
-    db_name: &'a str,
-) -> Result<(&'a str, String), AnyError> {
+pub async fn create_mysql_database<'a>(database_url: &str, db_name: &'a str) -> Result<(&'a str, String), AnyError> {
     let mut url: Url = database_url.parse()?;
     let mut mysql_db_url = url.clone();
     let db_name = mysql_safe_identifier(db_name);
@@ -91,8 +88,8 @@ pub(crate) async fn create_mysql_database<'a>(
 
     debug_assert!(!db_name.is_empty());
     debug_assert!(
-        db_name.len() < 64,
-        "db_name should be less than 64 characters, got {:?}",
+        db_name.len() <= 64,
+        "db_name should be at most 64 characters, got {:?}",
         db_name.len()
     );
 

--- a/migration-engine/qe-setup/Cargo.toml
+++ b/migration-engine/qe-setup/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 psl = { path = "../../psl/psl" }
 mongodb-client = { path = "../../libs/mongodb-client" }
 migration-core = { path = "../core" }
+test-setup = { path = "../../libs/test-setup" }
 
 connection-string = "*"
 enumflags2 = "*"

--- a/migration-engine/qe-setup/src/lib.rs
+++ b/migration-engine/qe-setup/src/lib.rs
@@ -50,17 +50,7 @@ pub async fn setup(prisma_schema: &str, db_schemas: &[&str]) -> ConnectorResult<
             diff_and_apply(prisma_schema).await;
         }
         provider if SQLITE.is_provider(provider) => {
-            // 1. creates schema & database
-            let api = migration_core::migration_api(Some(prisma_schema.to_owned()), None)?;
-            api.drop_database(url).await.ok();
-            api.create_database(CreateDatabaseParams {
-                datasource: DatasourceParam::SchemaString(SchemaContainer {
-                    schema: prisma_schema.to_owned(),
-                }),
-            })
-            .await?;
-
-            // 2. create the database schema for given Prisma schema
+            std::fs::remove_file(source.url.as_literal().unwrap().trim_start_matches("file:")).ok();
             diff_and_apply(prisma_schema).await;
         }
 

--- a/migration-engine/qe-setup/src/mysql.rs
+++ b/migration-engine/qe-setup/src/mysql.rs
@@ -1,22 +1,10 @@
 use migration_core::migration_connector::{ConnectorError, ConnectorResult};
-use quaint::{prelude::*, single::Quaint};
+use test_setup::mysql::create_mysql_database;
 use url::Url;
 
-pub(crate) async fn mysql_reset(url: &str) -> ConnectorResult<()> {
-    let mut url = Url::parse(url).map_err(ConnectorError::url_parse_error)?;
-    let db_name = url.path().trim_start_matches('/').to_owned();
-    url.set_path("/mysql");
-
-    let conn = Quaint::new(url.as_ref()).await.unwrap();
-
-    let query = format!("DROP DATABASE IF EXISTS `{}`", db_name);
-    conn.raw_cmd(&query).await.unwrap();
-
-    let query = format!(
-        "CREATE DATABASE `{}` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;",
-        db_name
-    );
-    conn.raw_cmd(&query).await.unwrap();
-
+pub(crate) async fn mysql_reset(original_url: &str) -> ConnectorResult<()> {
+    let url = Url::parse(original_url).map_err(ConnectorError::url_parse_error)?;
+    let db_name = url.path().trim_start_matches('/');
+    create_mysql_database(original_url, db_name).await.unwrap();
     Ok(())
 }

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_update/cascade.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_update/cascade.rs
@@ -494,7 +494,7 @@ mod multiple_cascading_paths {
     //   - User -> Comment
     //   - User -> Post -> Comment
     #[connector_test]
-    async fn should_work(runner: Runner) -> TestResult<()> {
+    async fn it_should_work(runner: Runner) -> TestResult<()> {
         run_query!(
             &runner,
             r#"mutation {


### PR DESCRIPTION
This is a first step towards a more unified test setup.

Only deals with sqlite and mysql.