### PR TITLE
Update tiberius to 0.11.0, uuid to 1.x and bigdecimal to 0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,16 +23,16 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom 0.2.6",
+ "getrandom 0.2.7",
  "once_cell",
  "version_check",
 ]
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
 dependencies = [
  "memchr",
 ]
@@ -57,9 +57,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.57"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
+checksum = "b9a8f622bcf6ff3df478e9deba3e03e4e04b300f8e6a139e192c05fa3490afc7"
 
 [[package]]
 name = "arrayvec"
@@ -108,9 +108,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.56"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96cf8829f67d2eab0b2dfa42c5d0ef737e0724e4a82b01b3e292456202b19716"
+checksum = "76464446b8bc32758d7e88ee1a804d9914cd9b1cb264c029899680b0be29826f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -119,9 +119,9 @@ dependencies = [
 
 [[package]]
 name = "asynchronous-codec"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb4401f0a3622dad2e0763fa79e0eb328bc70fb7dccfdd645341f00d671247d6"
+checksum = "f0de5164e5edbf51c45fb8c2d9664ae1c095cce1b265ecf7569093c0d66ef690"
 dependencies = [
  "bytes",
  "futures-sink",
@@ -158,9 +158,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.65"
+version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11a17d453482a265fd5f8479f2a3f405566e6ca627837aaddb85af8b1ab8ef61"
+checksum = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7"
 dependencies = [
  "addr2line",
  "cc",
@@ -190,22 +190,11 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bigdecimal"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1e50562e37200edf7c6c43e54a08e64a5553bfb59d9c297d5572512aa517256"
-dependencies = [
- "num-bigint 0.3.3",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "bigdecimal"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6aaf33151a6429fe9211d1b276eafdf70cdff28b071e76c0b0e1503221ea3744"
 dependencies = [
- "num-bigint 0.4.3",
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -252,9 +241,9 @@ dependencies = [
 
 [[package]]
 name = "bitvec"
-version = "0.22.3"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5237f00a8c86130a0cc317830e558b966dd7850d48a953d998c813f01a41b527"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
 dependencies = [
  "funty",
  "radium",
@@ -264,48 +253,26 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
-dependencies = [
- "block-padding",
- "byte-tools",
- "byteorder",
- "generic-array 0.12.4",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array 0.14.5",
+ "generic-array",
 ]
 
 [[package]]
 name = "block-buffer"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
+checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
- "generic-array 0.14.5",
-]
-
-[[package]]
-name = "block-padding"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
-dependencies = [
- "byte-tools",
+ "generic-array",
 ]
 
 [[package]]
 name = "bson"
 version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a24ecf39f5a314493ede1bb015984735d41aa6aedb59cafb95492d40cd893330"
+source = "git+https://github.com/mongodb/bson-rust?branch=main#bad146878902da3add29c5e656ddbde65927300e"
 dependencies = [
  "ahash",
  "base64 0.13.0",
@@ -317,21 +284,15 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
- "time 0.3.9",
+ "time 0.3.14",
  "uuid",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.10.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
-
-[[package]]
-name = "byte-tools"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
+checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
 
 [[package]]
 name = "byteorder"
@@ -341,9 +302,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 
 [[package]]
 name = "cc"
@@ -368,15 +329,16 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+checksum = "6127248204b9aba09a362f6c930ef6a78f2c1b2215f8a7b398c06e1083f17af0"
 dependencies = [
- "libc",
+ "js-sys",
  "num-integer",
  "num-traits",
  "serde",
  "time 0.1.43",
+ "wasm-bindgen",
  "winapi",
 ]
 
@@ -451,9 +413,9 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28b32d32ca44b70c3e4acd7db1babf555fa026e385fb95f18028f88848b3c31"
+checksum = "89eab4d20ce20cea182308bca13088fecea9c05f6776cf287205d41a0ed3c847"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -486,9 +448,9 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.2"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
+checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
 ]
@@ -504,9 +466,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae5588f6b3c3cb05239e90bd110f257254aecd01e4635400391aeae07497845"
+checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
 dependencies = [
  "cfg-if",
  "crossbeam-channel",
@@ -518,9 +480,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.4"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -528,9 +490,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
 dependencies = [
  "cfg-if",
  "crossbeam-epoch",
@@ -539,23 +501,23 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.8"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
+checksum = "045ebe27666471bb549370b4b0b3e51b07f56325befa4284db65fc89c02511b1"
 dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "lazy_static",
  "memoffset",
+ "once_cell",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f25d8400f4a7a5778f0e4e52384a48cbd9b5c495d110786187fc750075277a2"
+checksum = "1cd42583b04998a5363558e5f9291ee5a5ff6b49944332103f251e7479a82aa7"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -563,29 +525,29 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.8"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
+checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
 dependencies = [
  "cfg-if",
- "lazy_static",
+ "once_cell",
 ]
 
 [[package]]
 name = "crypto-common"
-version = "0.1.3"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
- "generic-array 0.14.5",
+ "generic-array",
  "typenum",
 ]
 
 [[package]]
 name = "ctor"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f877be4f7c9f246b183111634f75baa039715e3f46ce860677d3b19a69fb229c"
+checksum = "cdffe87e1d521a10f9696f833fe502293ea446d7f256c06128293a4119bdf4cb"
 dependencies = [
  "quote",
  "syn",
@@ -673,6 +635,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.12.3",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core 0.9.3",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -682,7 +657,7 @@ checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 name = "datamodel"
 version = "0.1.0"
 dependencies = [
- "bigdecimal 0.2.2",
+ "bigdecimal",
  "chrono",
  "datamodel-connector",
  "diagnostics",
@@ -740,20 +715,11 @@ checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 
 [[package]]
 name = "digest"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
-dependencies = [
- "generic-array 0.12.4",
-]
-
-[[package]]
-name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array 0.14.5",
+ "generic-array",
 ]
 
 [[package]]
@@ -762,7 +728,7 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
 dependencies = [
- "block-buffer 0.10.2",
+ "block-buffer 0.10.3",
  "crypto-common",
  "subtle",
 ]
@@ -792,7 +758,7 @@ dependencies = [
 name = "dmmf"
 version = "0.1.0"
 dependencies = [
- "bigdecimal 0.2.2",
+ "bigdecimal",
  "expect-test",
  "indexmap",
  "indoc",
@@ -807,9 +773,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.6.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "encode_unicode"
@@ -933,19 +899,13 @@ dependencies = [
 
 [[package]]
 name = "expect-test"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dced95c9dcd4e3241f95841aad395f9c8d7933a3b0b524bdeb2440885c72a271"
+checksum = "1d4661aca38d826eb7c72fe128e4238220616de4c0cc00db7bfc38e2e1364dd3"
 dependencies = [
  "dissimilar",
  "once_cell",
 ]
-
-[[package]]
-name = "fake-simd"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "fallible-iterator"
@@ -961,9 +921,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
 dependencies = [
  "instant",
 ]
@@ -976,9 +936,9 @@ checksum = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
 
 [[package]]
 name = "fixedbitset"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -1088,15 +1048,15 @@ dependencies = [
 
 [[package]]
 name = "funty"
-version = "1.2.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
+checksum = "7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1109,9 +1069,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
+checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1119,15 +1079,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
+checksum = "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1136,15 +1096,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
+checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
+checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1153,15 +1113,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
+checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
 
 [[package]]
 name = "futures-task"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
+checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
 
 [[package]]
 name = "futures-timer"
@@ -1171,9 +1131,9 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
+checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1189,18 +1149,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.12.4"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
-dependencies = [
- "typenum",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
  "version_check",
@@ -1219,20 +1170,20 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
+checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
+checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
 
 [[package]]
 name = "glob"
@@ -1252,9 +1203,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37a82c6d637fc9515a4694bbf1cb2457b79d81ce52b3108bdeea58b07dd34a57"
+checksum = "5ca32592cf21ac7ccab1825cd87f6c9b3d9022c44d086172ed0966bec8af30be"
 dependencies = [
  "bytes",
  "fnv",
@@ -1280,9 +1231,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashlink"
@@ -1386,9 +1340,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "496ce29bb5a52785b44e0f7ca2847ae0bb839c9bd28f69acac9b99d461c0c04c"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
 name = "httpdate"
@@ -1398,9 +1352,9 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "hyper"
-version = "0.14.19"
+version = "0.14.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42dc3c131584288d375f2d07f822b0cb012d8c6fb899a5b9fdb3cb7eb9b6004f"
+checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1470,28 +1424,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
- "hashbrown 0.12.1",
+ "hashbrown 0.12.3",
  "serde",
 ]
 
 [[package]]
 name = "indoc"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05a0bd019339e5d968b37855180087b7b9d512c5046fbd244cf8c95687927d6e"
+checksum = "adab1eaa3408fb7f0c777a73e7465fd5656136fc93b670eb6df3c88c2c1344e3"
 
 [[package]]
 name = "insta"
-version = "1.15.0"
+version = "1.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4126dd76ebfe2561486a1bd6738a33d2029ffb068a99ac446b7f8c77b2e58dbc"
+checksum = "fc61e98be01e89296f3343a878e9f8ca75a494cb5aaf29df65ef55734aeb85f5"
 dependencies = [
  "console",
+ "linked-hash-map",
  "once_cell",
- "serde",
- "serde_json",
- "serde_yaml",
  "similar",
+ "yaml-rust",
 ]
 
 [[package]]
@@ -1595,9 +1548,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
+checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
 name = "js-sys"
@@ -1743,9 +1696,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
 
 [[package]]
 name = "libloading"
@@ -1781,15 +1734,15 @@ dependencies = [
 
 [[package]]
 name = "linked-hash-map"
-version = "0.5.4"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "lock_api"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
+checksum = "9f80bf5aacaf25cbfc8210d1cfb718f2bf3b11c4c54e5afe36c236853a8ec390"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1806,11 +1759,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c84e6fe5655adc6ce00787cf7dcaf8dc4f998a0565d23eafc207a8b08ca3349a"
+checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
 dependencies = [
- "hashbrown 0.11.2",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -1845,12 +1798,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "maplit"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
-
-[[package]]
 name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1873,9 +1820,9 @@ checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "md-5"
-version = "0.10.1"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658646b21e0b72f7866c7038ab086d3d5e1cd6271f060fd37defb241949d0582"
+checksum = "66b48670c893079d3c2ed79114e3644b7004df1c361a4e0ad52e2e6940d07c3d"
 dependencies = [
  "digest 0.10.3",
 ]
@@ -2053,7 +2000,7 @@ dependencies = [
 name = "migration-engine-tests"
 version = "0.1.0"
 dependencies = [
- "bigdecimal 0.2.2",
+ "bigdecimal",
  "chrono",
  "connection-string",
  "enumflags2",
@@ -2088,18 +2035,18 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc"
+checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
 dependencies = [
  "adler",
 ]
 
 [[package]]
 name = "mio"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713d550d9b44d89174e066b7a6217ae06234c10cb47819a88290d2b353c31799"
+checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
 dependencies = [
  "libc",
  "log",
@@ -2127,9 +2074,8 @@ dependencies = [
 
 [[package]]
 name = "mongodb"
-version = "2.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28f3943e379e9dcaaab9dc319c308a8caaf9e7ff083c6838dff740afbba59df7"
+version = "2.4.0"
+source = "git+https://github.com/mongodb/mongo-rust-driver#6be426274c643590f005cd5d12a29eda2f1193e8"
 dependencies = [
  "async-trait",
  "base64 0.13.0",
@@ -2154,8 +2100,8 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_with",
- "sha-1 0.10.0",
- "sha2 0.10.2",
+ "sha-1",
+ "sha2 0.10.5",
  "socket2",
  "stringprep",
  "strsim 0.10.0",
@@ -2245,7 +2191,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "bigdecimal 0.2.2",
+ "bigdecimal",
  "chrono",
  "cuid",
  "futures",
@@ -2288,8 +2234,8 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "mysql_async"
-version = "0.29.0"
-source = "git+https://github.com/prisma/mysql_async?branch=vendored-openssl#650f07121681ada8a5baec3669197e5ce7e0e6d7"
+version = "0.30.0"
+source = "git+https://github.com/prisma/mysql_async?branch=vendored-openssl#e3f8bdb41d57e769412f53d0f479bf67fdcc0ee3"
 dependencies = [
  "bytes",
  "crossbeam",
@@ -2312,20 +2258,19 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-native-tls",
- "tokio-util 0.6.10",
+ "tokio-util 0.7.3",
  "twox-hash",
  "url",
- "uuid",
 ]
 
 [[package]]
 name = "mysql_common"
-version = "0.28.2"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4140827f2d12750de1e8755442577e4292a835f26ff2f659f0a380d1d71020b0"
+checksum = "522f2f30f72de409fc04f88df25a031f98cfc5c398a94e0b892cabb33a1464cb"
 dependencies = [
  "base64 0.13.0",
- "bigdecimal 0.3.0",
+ "bigdecimal",
  "bindgen",
  "bitflags",
  "bitvec",
@@ -2338,7 +2283,7 @@ dependencies = [
  "frunk",
  "lazy_static",
  "lexical",
- "num-bigint 0.4.3",
+ "num-bigint",
  "num-traits",
  "rand 0.8.5",
  "regex",
@@ -2346,12 +2291,12 @@ dependencies = [
  "saturating",
  "serde",
  "serde_json",
- "sha-1 0.10.0",
- "sha2 0.10.2",
+ "sha-1",
+ "sha2 0.10.5",
  "smallvec",
  "subprocess",
  "thiserror",
- "time 0.3.9",
+ "time 0.3.14",
  "uuid",
 ]
 
@@ -2366,13 +2311,14 @@ dependencies = [
 
 [[package]]
 name = "napi"
-version = "2.5.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec369bd2ae196a21bb08fb53761e637862c3c0699da9cd21b6d954e32dda04b3"
+checksum = "0e2f9ad803cde148d81d0ca9e5fd4d80773d15e992d09e3a44f62f41b9af4558"
 dependencies = [
+ "bitflags",
  "ctor",
- "lazy_static",
  "napi-sys",
+ "once_cell",
  "serde",
  "serde_json",
  "thread_local",
@@ -2387,9 +2333,9 @@ checksum = "ebd4419172727423cf30351406c54f6cc1b354a2cfb4f1dba3e6cd07f6d5522b"
 
 [[package]]
 name = "napi-derive"
-version = "2.5.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c0308f2313ee504b032bad9c75343d967e6ba27be2e3f19e89bb0ee8786b5b0"
+checksum = "1be75210f300e9fbf386ccac1c8eaaed23410e2f7f7aa9295b78c436a172ef51"
 dependencies = [
  "convert_case",
  "napi-derive-backend",
@@ -2400,9 +2346,9 @@ dependencies = [
 
 [[package]]
 name = "napi-derive-backend"
-version = "1.0.33"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c97606e865ebfca1c5d0c952e34969ca26b3c8ba0c246c569a2fc945719a78ea"
+checksum = "92ba4800264fac8a7726b208d5dd4c6d637d1027d73b026061a69d3339a0a930"
 dependencies = [
  "convert_case",
  "once_cell",
@@ -2468,17 +2414,6 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6f7833f2cbf2360a6cfd58cd41a53aa7a90bd4c202f5b1c7dd2ed73c57b2c3"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
@@ -2528,24 +2463,18 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.28.4"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e42c982f2d955fac81dd7e1d0e1426a7d702acd9c98d19ab01083a6a0328c424"
+checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.12.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
-
-[[package]]
-name = "opaque-debug"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
 
 [[package]]
 name = "opaque-debug"
@@ -2555,9 +2484,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.40"
+version = "0.10.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb81a6430ac911acb25fe5ac8f1d2af1b4ea8a4fdfda0f1ee4292af2e2d8eb0e"
+checksum = "618febf65336490dfcf20b73f885f5651a0c89c64c2d4a8c3662585a70bf5bd0"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -2596,9 +2525,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.74"
+version = "0.9.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835363342df5fba8354c5b453325b110ffd54044e588c539cf2f20a8014e4cb1"
+checksum = "e5f9bd0c2710541a3cda73d6f9ac4f1b240de4ae261065d309dbe73d9dceb42f"
 dependencies = [
  "autocfg",
  "cc",
@@ -2678,9 +2607,9 @@ checksum = "a86ed3f5f244b372d6b1a00b72ef7f8876d0bc6a78a4c9985c53614041512063"
 
 [[package]]
 name = "os_info"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eca3ecae1481e12c3d9379ec541b238a16f0b75c9a409942daa8ec20dbfdb62"
+checksum = "5209b2162b2c140df493a93689e04f8deab3a67634f5bc7a553c0a98e5b8d399"
 dependencies = [
  "log",
  "winapi",
@@ -2745,9 +2674,9 @@ dependencies = [
 
 [[package]]
 name = "parse-hyperlinks"
-version = "0.23.3"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1218d8a546efe31f9d3f490a1272ae76a66201d82bbf2a39f8dd0eacca5d712"
+checksum = "0181d37c4d5ae35cc8be7cf823c1a933005661da6a08bcb2855aa392c9a54b8e"
 dependencies = [
  "html-escape",
  "nom",
@@ -2768,9 +2697,9 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271779f35b581956db91a3e55737327a03aa051e90b1c47aeb189508533adfd7"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
  "digest 0.10.3",
 ]
@@ -2783,9 +2712,9 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pem"
-version = "1.0.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9a3b09a20e374558580a4914d3b7d89bd61b954a5a5e1dcbea98753addb1947"
+checksum = "03c64931a1a212348ec4f3b4362585eca7159d0d09cbdf4a7f74f02173596fd4"
 dependencies = [
  "base64 0.13.0",
 ]
@@ -2798,18 +2727,19 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pest"
-version = "2.1.3"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+checksum = "4b0560d531d1febc25a3c9398a62a71256c0178f2e3443baedd9ad4bb8c9deb4"
 dependencies = [
+ "thiserror",
  "ucd-trie",
 ]
 
 [[package]]
 name = "pest_derive"
-version = "2.1.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0"
+checksum = "905708f7f674518498c1f8d644481440f476d39ca6ecae83319bba7c6c12da91"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2817,9 +2747,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.1.3"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
+checksum = "5803d8284a629cc999094ecd630f55e91b561a1d1ba75e233b00ae13b91a69ad"
 dependencies = [
  "pest",
  "pest_meta",
@@ -2830,13 +2760,13 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.1.3"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d"
+checksum = "1538eb784f07615c6d9a8ab061089c6c54a344c5b4301db51990ca1c241e8c04"
 dependencies = [
- "maplit",
+ "once_cell",
  "pest",
- "sha-1 0.8.2",
+ "sha-1",
 ]
 
 [[package]]
@@ -2855,42 +2785,42 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
 dependencies = [
- "fixedbitset 0.4.1",
+ "fixedbitset 0.4.2",
  "indexmap",
 ]
 
 [[package]]
 name = "phf"
-version = "0.10.1"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
+checksum = "928c6535de93548188ef63bb7c4036bd415cd8f36ad25af44b9789b2ee72a48c"
 dependencies = [
  "phf_shared",
 ]
 
 [[package]]
 name = "phf_shared"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+checksum = "e1fb5f6f826b772a8d4c0394209441e7d37cbbb967ae9c7e0e8134365c9ee676"
 dependencies = [
  "siphasher",
 ]
 
 [[package]]
 name = "pin-project"
-version = "1.0.10"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58ad3879ad3baf4e44784bc6a718a8698867bb991f8ce24d1bcbe2cfb4c3a75e"
+checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.10"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
+checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2918,9 +2848,8 @@ checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 [[package]]
 name = "postgres-native-tls"
 version = "0.5.0"
-source = "git+https://github.com/pimeys/rust-postgres?branch=pgbouncer-mode#5ec2a4fa4635c721faf01dc560e48646479ec1b6"
+source = "git+https://github.com/pimeys/rust-postgres?branch=pgbouncer-mode#064a6a50427542e2c166e870027735aab3b52e77"
 dependencies = [
- "futures",
  "native-tls",
  "tokio",
  "tokio-native-tls",
@@ -2930,7 +2859,7 @@ dependencies = [
 [[package]]
 name = "postgres-protocol"
 version = "0.6.4"
-source = "git+https://github.com/pimeys/rust-postgres?branch=pgbouncer-mode#5ec2a4fa4635c721faf01dc560e48646479ec1b6"
+source = "git+https://github.com/pimeys/rust-postgres?branch=pgbouncer-mode#064a6a50427542e2c166e870027735aab3b52e77"
 dependencies = [
  "base64 0.13.0",
  "byteorder",
@@ -2940,14 +2869,14 @@ dependencies = [
  "md-5",
  "memchr",
  "rand 0.8.5",
- "sha2 0.10.2",
+ "sha2 0.10.5",
  "stringprep",
 ]
 
 [[package]]
 name = "postgres-types"
-version = "0.2.3"
-source = "git+https://github.com/pimeys/rust-postgres?branch=pgbouncer-mode#5ec2a4fa4635c721faf01dc560e48646479ec1b6"
+version = "0.2.4"
+source = "git+https://github.com/pimeys/rust-postgres?branch=pgbouncer-mode#064a6a50427542e2c166e870027735aab3b52e77"
 dependencies = [
  "bit-vec",
  "bytes",
@@ -2967,9 +2896,9 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "pretty-hex"
-version = "0.1.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be91bcc43e73799dc46a6c194a55e7aae1d86cc867c860fd4a436019af21bd8c"
+checksum = "c6fa0831dd7cc608c38a5e323422a0077678fa5744aa2be4ad91c4ece8eec8d5"
 
 [[package]]
 name = "pretty_assertions"
@@ -3003,7 +2932,7 @@ dependencies = [
 name = "prisma-models"
 version = "0.0.0"
 dependencies = [
- "bigdecimal 0.2.2",
+ "bigdecimal",
  "chrono",
  "itertools",
  "once_cell",
@@ -3020,7 +2949,7 @@ name = "prisma-value"
 version = "0.1.0"
 dependencies = [
  "base64 0.12.3",
- "bigdecimal 0.2.2",
+ "bigdecimal",
  "chrono",
  "once_cell",
  "regex",
@@ -3070,9 +2999,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.39"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
+checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
 dependencies = [
  "unicode-ident",
 ]
@@ -3160,11 +3089,11 @@ dependencies = [
 [[package]]
 name = "quaint"
 version = "0.2.0-alpha.13"
-source = "git+https://github.com/prisma/quaint#5a48e93cefb0b6d914fb59f2c34baf64ca57b99b"
+source = "git+https://github.com/prisma/quaint#2baa684d8c4d2512c9d99dc84fdafbdffc638b6a"
 dependencies = [
  "async-trait",
  "base64 0.12.3",
- "bigdecimal 0.2.2",
+ "bigdecimal",
  "bit-vec",
  "byteorder",
  "bytes",
@@ -3238,7 +3167,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "base64 0.12.3",
- "bigdecimal 0.2.2",
+ "bigdecimal",
  "chrono",
  "connection-string",
  "crossbeam-queue",
@@ -3449,18 +3378,18 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.18"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "radium"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "radix_trie"
@@ -3531,7 +3460,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom 0.2.6",
+ "getrandom 0.2.7",
 ]
 
 [[package]]
@@ -3554,27 +3483,27 @@ dependencies = [
 
 [[package]]
 name = "raw-cpuid"
-version = "10.4.0"
+version = "10.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c49596760fce12ca21550ac21dc5a9617b2ea4b6e0aa7d8dab8ff2824fc2bba"
+checksum = "6aa2540135b6a94f74c7bc90ad4b794f822026a894f3d7bcd185c100d13d4ad6"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.13"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.5.6"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3592,9 +3521,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.26"
+version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "remove_dir_all"
@@ -3609,7 +3538,7 @@ dependencies = [
 name = "request-handlers"
 version = "0.1.0"
 dependencies = [
- "bigdecimal 0.2.2",
+ "bigdecimal",
  "connection-string",
  "datamodel",
  "datamodel-connector",
@@ -3673,9 +3602,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.24.0"
+version = "1.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2ee7337df68898256ad0d4af4aad178210d9e44d2ff900ce44064a97cd86530"
+checksum = "ee9164faf726e4f3ece4978b25ca877ddc6802fa77f38cdccb32c7f805ecd70c"
 dependencies = [
  "arrayvec",
  "num-traits",
@@ -3752,24 +3681,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "0.3.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee86d63972a7c661d1536fefe8c3c8407321c3df668891286de28abcd087360"
+checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
 dependencies = [
  "base64 0.13.0",
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0a5f7c728f5d284929a1cccb5bc19884422bfe6ef4d6c409da2c41838983fcf"
-
-[[package]]
 name = "ryu"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
+checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
 name = "saturating"
@@ -3845,9 +3768,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
+checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -3883,27 +3806,27 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.137"
+version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
+checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.6"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212e73464ebcde48d723aa02eb270ba62eff38a9b732df31f33f1b4e145f3a54"
+checksum = "cfc50e8183eeeb6178dcb167ae34a8051d63535023ae38b5d8d12beae193d37b"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.137"
+version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
+checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3912,9 +3835,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.81"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
+checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
 dependencies = [
  "indexmap",
  "itoa",
@@ -3924,9 +3847,9 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ad84e47328a31223de7fed7a4f5087f2d6ddfe586cf3ca25b7a165bc0a5aed"
+checksum = "1fe39d9fbb0ebf5eb2c7cb7e2a47e4f462fad1379f1166b8ae49ad9eae89a7ca"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3956,23 +3879,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.8.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707d15895415db6628332b737c838b88c598522e4dc70647e59b72312924aebc"
-dependencies = [
- "indexmap",
- "ryu",
- "serde",
- "yaml-rust",
-]
-
-[[package]]
 name = "serial_test"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eec42e7232e5ca56aa59d63af3c7f991fe71ee6a3ddd2d3480834cf3902b007"
+checksum = "92761393ee4dc3ff8f4af487bd58f4307c9329bbedea02cac0089ad9c411e153"
 dependencies = [
+ "dashmap",
  "futures",
  "lazy_static",
  "log",
@@ -3982,27 +3894,14 @@ dependencies = [
 
 [[package]]
 name = "serial_test_derive"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1b95bb2f4f624565e8fe8140c789af7e2082c0e0561b5a82a1b678baa9703dc"
+checksum = "4b6f5d1c3087fb119617cff2966fe3808a80e5eb59a8c1601d5994d66f4346a5"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "rustversion",
  "syn",
-]
-
-[[package]]
-name = "sha-1"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
-dependencies = [
- "block-buffer 0.7.3",
- "digest 0.8.1",
- "fake-simd",
- "opaque-debug 0.2.3",
 ]
 
 [[package]]
@@ -4026,14 +3925,14 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.9.0",
- "opaque-debug 0.3.0",
+ "opaque-debug",
 ]
 
 [[package]]
 name = "sha2"
-version = "0.10.2"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
+checksum = "cf9db03534dff993187064c4e0c05a5708d2a9728ace9a8959b77bedf415dac5"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -4066,9 +3965,9 @@ dependencies = [
 
 [[package]]
 name = "similar"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e24979f63a11545f5f2c60141afe249d4f19f84581ea2138065e400941d83d3"
+checksum = "62ac7f900db32bf3fd12e0117dd3dc4da74bc52ebaac97f39668446d89694803"
 
 [[package]]
 name = "siphasher"
@@ -4094,21 +3993,24 @@ checksum = "04d2ecae5fcf33b122e2e6bd520a57ccf152d2dde3b38c71039df1a6867264ee"
 
 [[package]]
 name = "slab"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
+checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "smallvec"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
 name = "socket2"
-version = "0.4.4"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
+checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
 dependencies = [
  "libc",
  "winapi",
@@ -4148,7 +4050,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "bigdecimal 0.2.2",
+ "bigdecimal",
  "enumflags2",
  "expect-test",
  "introspection-connector",
@@ -4200,7 +4102,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "bigdecimal 0.2.2",
+ "bigdecimal",
  "chrono",
  "cuid",
  "futures",
@@ -4230,7 +4132,7 @@ name = "sql-schema-describer"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "bigdecimal 0.2.2",
+ "bigdecimal",
  "enumflags2",
  "expect-test",
  "indexmap",
@@ -4332,9 +4234,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.96"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0748dd251e24453cb8717f0354206b91557e4ec8703673a4b30208f2abaf1ebf"
+checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4434,18 +4336,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.31"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
+checksum = "8c1b05ca9d106ba7d2e31a9dab4a64e7be2cce415321966ea3132c49a656e252"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.31"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
+checksum = "e8f2591983642de85c921015f3f070c665a197ed69e417af436115e3a1407487"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4463,14 +4365,14 @@ dependencies = [
 
 [[package]]
 name = "tiberius"
-version = "0.9.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb0b4d064237401eec66db38a14f7205b0cf2d37104402934009cc6f53dc16f4"
+checksum = "6f9232bb2d5c2e28c922c1247c9e8cf0bec361ae1865300308387ced5d0a922d"
 dependencies = [
  "async-native-tls",
  "async-trait",
  "asynchronous-codec",
- "bigdecimal 0.2.2",
+ "bigdecimal",
  "byteorder",
  "bytes",
  "chrono",
@@ -4487,7 +4389,7 @@ dependencies = [
  "pretty-hex",
  "thiserror",
  "tokio",
- "tokio-util 0.6.10",
+ "tokio-util 0.7.3",
  "tracing",
  "uuid",
  "winauth",
@@ -4505,9 +4407,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.9"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
+checksum = "3c3f9a28b618c3a6b9251b6908e9c99e04b9e5c02e6581ccbb67d59c34ef7f9b"
 dependencies = [
  "itoa",
  "libc",
@@ -4538,10 +4440,11 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.19.2"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51a52ed6686dd62c320f9b89299e9dfb46f730c7a48e635c19f21d116cb1439"
+checksum = "89797afd69d206ccd11fb0ea560a44bbb87731d020670e79416d442919257d42"
 dependencies = [
+ "autocfg",
  "bytes",
  "libc",
  "memchr",
@@ -4588,14 +4491,15 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres"
-version = "0.7.6"
-source = "git+https://github.com/pimeys/rust-postgres?branch=pgbouncer-mode#5ec2a4fa4635c721faf01dc560e48646479ec1b6"
+version = "0.7.7"
+source = "git+https://github.com/pimeys/rust-postgres?branch=pgbouncer-mode#064a6a50427542e2c166e870027735aab3b52e77"
 dependencies = [
  "async-trait",
  "byteorder",
  "bytes",
  "fallible-iterator",
- "futures",
+ "futures-channel",
+ "futures-util",
  "log",
  "parking_lot 0.12.1",
  "percent-encoding",
@@ -4664,6 +4568,7 @@ checksum = "cc463cd8deddc3770d20f9852143d50bf6094e640b485cb2e189a2099085ff45"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -4779,9 +4684,9 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.35"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a400e31aa60b9d44a52a8ee0343b5b18566b03a8321e0d321f695cf56e940160"
+checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
 dependencies = [
  "cfg-if",
  "log",
@@ -4792,9 +4697,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6b8ad3567499f98a1db7a752b07a7c8c7c7c34c332ec00effb2b0027974b7c"
+checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4803,9 +4708,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.27"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709595b8878a4965ce5e87ebf880a7d39c9afc6837721b21a5a816a8117d921"
+checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
 dependencies = [
  "once_cell",
  "valuable",
@@ -4868,20 +4773,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.11"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bc28f93baff38037f64e6f43d34cfa1605f27a49c34e8a04c5e78b0babf2596"
+checksum = "60db860322da191b40952ad9affe65ea23e7dd6a5c442c2c42865810c6ab8e6b"
 dependencies = [
  "ansi_term 0.12.1",
- "lazy_static",
  "matchers",
+ "once_cell",
  "regex",
  "serde",
  "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
- "time 0.3.9",
+ "time 0.3.14",
  "tracing",
  "tracing-core",
  "tracing-log",
@@ -4969,9 +4874,9 @@ checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "ucd-trie"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
+checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
 name = "unicode-bidi"
@@ -4981,15 +4886,15 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
+checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.19"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+checksum = "854cbdc4f7bc6ae19c820d44abdc3277ac3e1b2b93db20a636825d9322fb60e6"
 dependencies = [
  "tinyvec",
 ]
@@ -5070,11 +4975,11 @@ checksum = "5190c9442dcdaf0ddd50f37420417d219ae5261bbf5db120d0f9bab996c9cba1"
 
 [[package]]
 name = "uuid"
-version = "0.8.2"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
 dependencies = [
- "getrandom 0.2.6",
+ "getrandom 0.2.7",
  "serde",
 ]
 
@@ -5222,22 +5127,22 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.22.3"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d8de8415c823c8abd270ad483c6feeac771fad964890779f9a8cb24fbbc1bf"
+checksum = "f1c760f0d366a6c24a02ed7816e23e691f5d92291f94d15e836006fd11b04daf"
 dependencies = [
  "webpki 0.22.0",
 ]
 
 [[package]]
 name = "which"
-version = "4.2.5"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c4fb54e6113b6a8772ee41c3404fb0301ac79604489467e0a9ce1f3e97c24ae"
+checksum = "1c831fbbee9e129a8cf93e7747a82da9d95ba8e16621cae60ec2cdc849bacb7b"
 dependencies = [
  "either",
- "lazy_static",
  "libc",
+ "once_cell",
 ]
 
 [[package]]
@@ -5344,9 +5249,9 @@ dependencies = [
 
 [[package]]
 name = "wyz"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "129e027ad65ce1453680623c3fb5163cbf7107bfe1aa32257e7d0e63f9ced188"
+checksum = "30b31594f29d27036c383b53b59ed3476874d518f0efb151b27a4c275141390e"
 dependencies = [
  "tap",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,8 +271,9 @@ dependencies = [
 
 [[package]]
 name = "bson"
-version = "2.3.0"
-source = "git+https://github.com/mongodb/bson-rust?branch=main#bad146878902da3add29c5e656ddbde65927300e"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d76085681585d39016f4d3841eb019201fc54d2dd0d92ad1e4fab3bfb32754"
 dependencies = [
  "ahash",
  "base64 0.13.0",
@@ -285,7 +286,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "time 0.3.14",
- "uuid",
+ "uuid 1.1.2",
 ]
 
 [[package]]
@@ -751,7 +752,7 @@ dependencies = [
  "prisma-value",
  "serde",
  "serde_json",
- "uuid",
+ "uuid 1.1.2",
 ]
 
 [[package]]
@@ -2074,8 +2075,9 @@ dependencies = [
 
 [[package]]
 name = "mongodb"
-version = "2.4.0"
-source = "git+https://github.com/mongodb/mongo-rust-driver#6be426274c643590f005cd5d12a29eda2f1193e8"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95afe97b0c799fdf69cd960272a2cb9662d077bd6efd84eb722bb9805d47554"
 dependencies = [
  "async-trait",
  "base64 0.13.0",
@@ -2113,7 +2115,7 @@ dependencies = [
  "trust-dns-proto",
  "trust-dns-resolver",
  "typed-builder",
- "uuid",
+ "uuid 0.8.2",
  "webpki-roots",
 ]
 
@@ -2192,6 +2194,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bigdecimal",
+ "bson",
  "chrono",
  "cuid",
  "futures",
@@ -2214,7 +2217,7 @@ dependencies = [
  "tracing",
  "tracing-futures",
  "user-facing-errors",
- "uuid",
+ "uuid 1.1.2",
 ]
 
 [[package]]
@@ -2297,7 +2300,7 @@ dependencies = [
  "subprocess",
  "thiserror",
  "time 0.3.14",
- "uuid",
+ "uuid 1.1.2",
 ]
 
 [[package]]
@@ -2697,9 +2700,9 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
-version = "0.11.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+checksum = "271779f35b581956db91a3e55737327a03aa051e90b1c47aeb189508533adfd7"
 dependencies = [
  "digest 0.10.3",
 ]
@@ -2885,7 +2888,7 @@ dependencies = [
  "postgres-protocol",
  "serde",
  "serde_json",
- "uuid",
+ "uuid 1.1.2",
 ]
 
 [[package]]
@@ -2955,7 +2958,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "uuid",
+ "uuid 1.1.2",
 ]
 
 [[package]]
@@ -3123,7 +3126,7 @@ dependencies = [
  "tracing",
  "tracing-core",
  "url",
- "uuid",
+ "uuid 1.1.2",
 ]
 
 [[package]]
@@ -3158,7 +3161,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "user-facing-errors",
- "uuid",
+ "uuid 1.1.2",
 ]
 
 [[package]]
@@ -3203,7 +3206,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "user-facing-errors",
- "uuid",
+ "uuid 1.1.2",
 ]
 
 [[package]]
@@ -3318,7 +3321,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-futures",
- "uuid",
+ "uuid 1.1.2",
 ]
 
 [[package]]
@@ -3681,9 +3684,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
+checksum = "1ee86d63972a7c661d1536fefe8c3c8407321c3df668891286de28abcd087360"
 dependencies = [
  "base64 0.13.0",
 ]
@@ -4093,7 +4096,7 @@ dependencies = [
  "tracing-futures",
  "url",
  "user-facing-errors",
- "uuid",
+ "uuid 1.1.2",
 ]
 
 [[package]]
@@ -4124,7 +4127,7 @@ dependencies = [
  "tracing-futures",
  "tracing-opentelemetry",
  "user-facing-errors",
- "uuid",
+ "uuid 1.1.2",
 ]
 
 [[package]]
@@ -4391,7 +4394,7 @@ dependencies = [
  "tokio",
  "tokio-util 0.7.3",
  "tracing",
- "uuid",
+ "uuid 1.1.2",
  "winauth",
 ]
 
@@ -4972,6 +4975,15 @@ name = "utf8-width"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5190c9442dcdaf0ddd50f37420417d219ae5261bbf5db120d0f9bab996c9cba1"
+
+[[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom 0.2.7",
+]
 
 [[package]]
 name = "uuid"

--- a/introspection-engine/connectors/mongodb-introspection-connector/Cargo.toml
+++ b/introspection-engine/connectors/mongodb-introspection-connector/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-mongodb = { git = "https://github.com/mongodb/mongo-rust-driver", features = ["bson-chrono-0_4", "bson-uuid-1"] }
+mongodb = "2.3.0"
 thiserror = "1.0"
 async-trait = "0.1"
 mongodb-client = { path = "../../../libs/mongodb-client" }

--- a/introspection-engine/connectors/mongodb-introspection-connector/Cargo.toml
+++ b/introspection-engine/connectors/mongodb-introspection-connector/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-mongodb = { version = "2.1.0", features = ["bson-chrono-0_4", "bson-uuid-0_8"] }
+mongodb = { git = "https://github.com/mongodb/mongo-rust-driver", features = ["bson-chrono-0_4", "bson-uuid-1"] }
 thiserror = "1.0"
 async-trait = "0.1"
 mongodb-client = { path = "../../../libs/mongodb-client" }

--- a/introspection-engine/connectors/sql-introspection-connector/Cargo.toml
+++ b/introspection-engine/connectors/sql-introspection-connector/Cargo.toml
@@ -15,7 +15,7 @@ native-types = { path = "../../../libs/native-types" }
 introspection-connector = { path = "../introspection-connector" }
 once_cell = "1.3"
 regex = "1.2"
-bigdecimal = "0.2"
+bigdecimal = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1.0", features = ["float_roundtrip"] }
 sql-schema-describer = { path = "../../../libs/sql-schema-describer" }

--- a/libs/datamodel/connectors/dml/Cargo.toml
+++ b/libs/datamodel/connectors/dml/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 prisma-value = { path = "../../../prisma-value" }
 
-uuid = { version = "0.8", features = ["serde", "v4"], optional = true }
+uuid = { version = "1", features = ["serde", "v4"], optional = true }
 cuid = { git = "https://github.com/prisma/cuid-rust", optional = true }
 chrono = { version = "0.4.6", features = ["serde"] }
 serde = { version = "1.0.90", features = ["derive"] }

--- a/libs/datamodel/core/Cargo.toml
+++ b/libs/datamodel/core/Cargo.toml
@@ -12,7 +12,7 @@ sql-datamodel-connector = { path = "../connectors/sql-datamodel-connector" }
 diagnostics = { path = "../diagnostics" }
 parser-database = { path = "../parser-database" }
 
-bigdecimal = "0.2"
+bigdecimal = "0.3"
 chrono = { version = "0.4.6", default_features = false }
 itertools = "0.10"
 once_cell = "1.3.1"

--- a/libs/datamodel/schema-ast/src/parser/parse_composite_type.rs
+++ b/libs/datamodel/schema-ast/src/parser/parse_composite_type.rs
@@ -84,7 +84,7 @@ pub(crate) fn parse_composite_type(
                                     "Defining `@{name}` attribute for a field in a composite type is not allowed."
                                 );
 
-                                DatamodelError::new_validation_error(&msg, current_span.clone().into())
+                                DatamodelError::new_validation_error(&msg, current_span.into())
                             }
                             _ => continue,
                         };

--- a/libs/mongodb-client/Cargo.toml
+++ b/libs/mongodb-client/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-mongodb = { git = "https://github.com/mongodb/mongo-rust-driver" }
+mongodb = "2.3.0"
 
 # Remove these when mongo opens up their connection string parsing
 percent-encoding = "2.0.0"

--- a/libs/mongodb-client/Cargo.toml
+++ b/libs/mongodb-client/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-mongodb = "2.1.0"
+mongodb = { git = "https://github.com/mongodb/mongo-rust-driver" }
 
 # Remove these when mongo opens up their connection string parsing
 percent-encoding = "2.0.0"

--- a/libs/mongodb-schema-describer/Cargo.toml
+++ b/libs/mongodb-schema-describer/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-mongodb = { git = "https://github.com/mongodb/mongo-rust-driver" }
+mongodb = "2.3.0"
 futures = "0.3"
 serde = "1"

--- a/libs/mongodb-schema-describer/Cargo.toml
+++ b/libs/mongodb-schema-describer/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-mongodb = "2.1.0"
+mongodb = { git = "https://github.com/mongodb/mongo-rust-driver" }
 futures = "0.3"
 serde = "1"

--- a/libs/prisma-value/Cargo.toml
+++ b/libs/prisma-value/Cargo.toml
@@ -12,7 +12,7 @@ base64 = "0.12"
 chrono = { version = "0.4", features = ["serde"] }
 once_cell = "1.3"
 regex = "1.2"
-bigdecimal = "0.2"
+bigdecimal = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["float_roundtrip"] }
-uuid = { version = "0.8", features = ["serde"] }
+uuid = { version = "1", features = ["serde"] }

--- a/libs/sql-schema-describer/Cargo.toml
+++ b/libs/sql-schema-describer/Cargo.toml
@@ -8,7 +8,7 @@ native-types = { path = "../native-types" }
 prisma-value = { path = "../prisma-value" }
 
 async-trait = "0.1.17"
-bigdecimal = "0.2"
+bigdecimal = "0.3"
 enumflags2 = "0.7"
 indexmap = { version = "1.9.1", default_features = false }
 indoc = "1"

--- a/libs/sql-schema-describer/tests/describers/mssql_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/mssql_describer_tests.rs
@@ -149,9 +149,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             family: Int,
                             arity: Required,
                             native_type: Some(
-                                String(
-                                    "Int",
-                                ),
+                                String("Int"),
                             ),
                         },
                         default: None,
@@ -169,9 +167,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             family: Boolean,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "Bit",
-                                ),
+                                String("Bit"),
                             ),
                         },
                         default: None,
@@ -189,16 +185,12 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             family: Decimal,
                             arity: Nullable,
                             native_type: Some(
-                                Object({
-                                    "Decimal": Array([
-                                        Number(
-                                            18,
-                                        ),
-                                        Number(
-                                            0,
-                                        ),
-                                    ]),
-                                }),
+                                Object {
+                                    "Decimal": Array [
+                                        Number(18),
+                                        Number(0),
+                                    ],
+                                },
                             ),
                         },
                         default: None,
@@ -216,9 +208,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             family: Int,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "Int",
-                                ),
+                                String("Int"),
                             ),
                         },
                         default: None,
@@ -236,9 +226,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             family: Float,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "Money",
-                                ),
+                                String("Money"),
                             ),
                         },
                         default: None,
@@ -256,16 +244,12 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             family: Decimal,
                             arity: Nullable,
                             native_type: Some(
-                                Object({
-                                    "Decimal": Array([
-                                        Number(
-                                            18,
-                                        ),
-                                        Number(
-                                            0,
-                                        ),
-                                    ]),
-                                }),
+                                Object {
+                                    "Decimal": Array [
+                                        Number(18),
+                                        Number(0),
+                                    ],
+                                },
                             ),
                         },
                         default: None,
@@ -283,9 +267,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             family: Int,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "SmallInt",
-                                ),
+                                String("SmallInt"),
                             ),
                         },
                         default: None,
@@ -303,9 +285,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             family: Float,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "SmallMoney",
-                                ),
+                                String("SmallMoney"),
                             ),
                         },
                         default: None,
@@ -323,9 +303,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             family: Int,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "TinyInt",
-                                ),
+                                String("TinyInt"),
                             ),
                         },
                         default: None,
@@ -343,9 +321,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             family: Float,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "Real",
-                                ),
+                                String("Real"),
                             ),
                         },
                         default: None,
@@ -363,11 +339,9 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             family: Float,
                             arity: Nullable,
                             native_type: Some(
-                                Object({
-                                    "Float": Number(
-                                        53,
-                                    ),
-                                }),
+                                Object {
+                                    "Float": Number(53),
+                                },
                             ),
                         },
                         default: None,
@@ -385,9 +359,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             family: DateTime,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "Date",
-                                ),
+                                String("Date"),
                             ),
                         },
                         default: None,
@@ -405,9 +377,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             family: DateTime,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "DateTime2",
-                                ),
+                                String("DateTime2"),
                             ),
                         },
                         default: None,
@@ -425,9 +395,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             family: DateTime,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "DateTime",
-                                ),
+                                String("DateTime"),
                             ),
                         },
                         default: None,
@@ -445,9 +413,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             family: DateTime,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "DateTimeOffset",
-                                ),
+                                String("DateTimeOffset"),
                             ),
                         },
                         default: None,
@@ -465,9 +431,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             family: DateTime,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "SmallDateTime",
-                                ),
+                                String("SmallDateTime"),
                             ),
                         },
                         default: None,
@@ -485,9 +449,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             family: DateTime,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "Time",
-                                ),
+                                String("Time"),
                             ),
                         },
                         default: None,
@@ -505,11 +467,9 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             family: String,
                             arity: Nullable,
                             native_type: Some(
-                                Object({
-                                    "Char": Number(
-                                        255,
-                                    ),
-                                }),
+                                Object {
+                                    "Char": Number(255),
+                                },
                             ),
                         },
                         default: None,
@@ -527,13 +487,11 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             family: String,
                             arity: Nullable,
                             native_type: Some(
-                                Object({
-                                    "VarChar": Object({
-                                        "Number": Number(
-                                            255,
-                                        ),
-                                    }),
-                                }),
+                                Object {
+                                    "VarChar": Object {
+                                        "Number": Number(255),
+                                    },
+                                },
                             ),
                         },
                         default: None,
@@ -551,11 +509,9 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             family: String,
                             arity: Nullable,
                             native_type: Some(
-                                Object({
-                                    "VarChar": String(
-                                        "Max",
-                                    ),
-                                }),
+                                Object {
+                                    "VarChar": String("Max"),
+                                },
                             ),
                         },
                         default: None,
@@ -573,9 +529,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             family: String,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "Text",
-                                ),
+                                String("Text"),
                             ),
                         },
                         default: None,
@@ -593,13 +547,11 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             family: String,
                             arity: Nullable,
                             native_type: Some(
-                                Object({
-                                    "NVarChar": Object({
-                                        "Number": Number(
-                                            255,
-                                        ),
-                                    }),
-                                }),
+                                Object {
+                                    "NVarChar": Object {
+                                        "Number": Number(255),
+                                    },
+                                },
                             ),
                         },
                         default: None,
@@ -617,11 +569,9 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             family: String,
                             arity: Nullable,
                             native_type: Some(
-                                Object({
-                                    "NVarChar": String(
-                                        "Max",
-                                    ),
-                                }),
+                                Object {
+                                    "NVarChar": String("Max"),
+                                },
                             ),
                         },
                         default: None,
@@ -639,9 +589,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             family: String,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "NText",
-                                ),
+                                String("NText"),
                             ),
                         },
                         default: None,
@@ -659,11 +607,9 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             family: Binary,
                             arity: Nullable,
                             native_type: Some(
-                                Object({
-                                    "Binary": Number(
-                                        20,
-                                    ),
-                                }),
+                                Object {
+                                    "Binary": Number(20),
+                                },
                             ),
                         },
                         default: None,
@@ -681,13 +627,11 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             family: Binary,
                             arity: Nullable,
                             native_type: Some(
-                                Object({
-                                    "VarBinary": Object({
-                                        "Number": Number(
-                                            20,
-                                        ),
-                                    }),
-                                }),
+                                Object {
+                                    "VarBinary": Object {
+                                        "Number": Number(20),
+                                    },
+                                },
                             ),
                         },
                         default: None,
@@ -705,11 +649,9 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             family: Binary,
                             arity: Nullable,
                             native_type: Some(
-                                Object({
-                                    "VarBinary": String(
-                                        "Max",
-                                    ),
-                                }),
+                                Object {
+                                    "VarBinary": String("Max"),
+                                },
                             ),
                         },
                         default: None,
@@ -727,9 +669,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             family: Binary,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "Image",
-                                ),
+                                String("Image"),
                             ),
                         },
                         default: None,
@@ -747,9 +687,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             family: String,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "Xml",
-                                ),
+                                String("Xml"),
                             ),
                         },
                         default: None,

--- a/libs/sql-schema-describer/tests/describers/mysql_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/mysql_describer_tests.rs
@@ -1917,9 +1917,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             family: Int,
                             arity: Required,
                             native_type: Some(
-                                String(
-                                    "Int",
-                                ),
+                                String("Int"),
                             ),
                         },
                         default: None,
@@ -1937,9 +1935,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             family: Int,
                             arity: Required,
                             native_type: Some(
-                                String(
-                                    "Int",
-                                ),
+                                String("Int"),
                             ),
                         },
                         default: None,
@@ -1957,9 +1953,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             family: Int,
                             arity: Required,
                             native_type: Some(
-                                String(
-                                    "SmallInt",
-                                ),
+                                String("SmallInt"),
                             ),
                         },
                         default: None,
@@ -1977,9 +1971,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             family: Int,
                             arity: Required,
                             native_type: Some(
-                                String(
-                                    "TinyInt",
-                                ),
+                                String("TinyInt"),
                             ),
                         },
                         default: None,
@@ -1997,9 +1989,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             family: Boolean,
                             arity: Required,
                             native_type: Some(
-                                String(
-                                    "TinyInt",
-                                ),
+                                String("TinyInt"),
                             ),
                         },
                         default: None,
@@ -2017,9 +2007,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             family: Int,
                             arity: Required,
                             native_type: Some(
-                                String(
-                                    "MediumInt",
-                                ),
+                                String("MediumInt"),
                             ),
                         },
                         default: None,
@@ -2037,9 +2025,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             family: BigInt,
                             arity: Required,
                             native_type: Some(
-                                String(
-                                    "BigInt",
-                                ),
+                                String("BigInt"),
                             ),
                         },
                         default: None,
@@ -2057,16 +2043,12 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             family: Decimal,
                             arity: Required,
                             native_type: Some(
-                                Object({
-                                    "Decimal": Array([
-                                        Number(
-                                            10,
-                                        ),
-                                        Number(
-                                            0,
-                                        ),
-                                    ]),
-                                }),
+                                Object {
+                                    "Decimal": Array [
+                                        Number(10),
+                                        Number(0),
+                                    ],
+                                },
                             ),
                         },
                         default: None,
@@ -2084,16 +2066,12 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             family: Decimal,
                             arity: Required,
                             native_type: Some(
-                                Object({
-                                    "Decimal": Array([
-                                        Number(
-                                            10,
-                                        ),
-                                        Number(
-                                            0,
-                                        ),
-                                    ]),
-                                }),
+                                Object {
+                                    "Decimal": Array [
+                                        Number(10),
+                                        Number(0),
+                                    ],
+                                },
                             ),
                         },
                         default: None,
@@ -2111,9 +2089,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             family: Float,
                             arity: Required,
                             native_type: Some(
-                                String(
-                                    "Float",
-                                ),
+                                String("Float"),
                             ),
                         },
                         default: None,
@@ -2131,9 +2107,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             family: Float,
                             arity: Required,
                             native_type: Some(
-                                String(
-                                    "Double",
-                                ),
+                                String("Double"),
                             ),
                         },
                         default: None,
@@ -2151,9 +2125,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             family: DateTime,
                             arity: Required,
                             native_type: Some(
-                                String(
-                                    "Date",
-                                ),
+                                String("Date"),
                             ),
                         },
                         default: None,
@@ -2171,11 +2143,9 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             family: DateTime,
                             arity: Required,
                             native_type: Some(
-                                Object({
-                                    "Time": Number(
-                                        0,
-                                    ),
-                                }),
+                                Object {
+                                    "Time": Number(0),
+                                },
                             ),
                         },
                         default: None,
@@ -2193,11 +2163,9 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             family: DateTime,
                             arity: Required,
                             native_type: Some(
-                                Object({
-                                    "DateTime": Number(
-                                        0,
-                                    ),
-                                }),
+                                Object {
+                                    "DateTime": Number(0),
+                                },
                             ),
                         },
                         default: None,
@@ -2215,11 +2183,9 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             family: DateTime,
                             arity: Required,
                             native_type: Some(
-                                Object({
-                                    "Timestamp": Number(
-                                        0,
-                                    ),
-                                }),
+                                Object {
+                                    "Timestamp": Number(0),
+                                },
                             ),
                         },
                         default: None,
@@ -2237,9 +2203,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             family: Int,
                             arity: Required,
                             native_type: Some(
-                                String(
-                                    "Year",
-                                ),
+                                String("Year"),
                             ),
                         },
                         default: None,
@@ -2257,11 +2221,9 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             family: String,
                             arity: Required,
                             native_type: Some(
-                                Object({
-                                    "Char": Number(
-                                        1,
-                                    ),
-                                }),
+                                Object {
+                                    "Char": Number(1),
+                                },
                             ),
                         },
                         default: None,
@@ -2279,11 +2241,9 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             family: String,
                             arity: Required,
                             native_type: Some(
-                                Object({
-                                    "VarChar": Number(
-                                        255,
-                                    ),
-                                }),
+                                Object {
+                                    "VarChar": Number(255),
+                                },
                             ),
                         },
                         default: None,
@@ -2301,9 +2261,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             family: String,
                             arity: Required,
                             native_type: Some(
-                                String(
-                                    "Text",
-                                ),
+                                String("Text"),
                             ),
                         },
                         default: None,
@@ -2321,9 +2279,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             family: String,
                             arity: Required,
                             native_type: Some(
-                                String(
-                                    "TinyText",
-                                ),
+                                String("TinyText"),
                             ),
                         },
                         default: None,
@@ -2341,9 +2297,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             family: String,
                             arity: Required,
                             native_type: Some(
-                                String(
-                                    "MediumText",
-                                ),
+                                String("MediumText"),
                             ),
                         },
                         default: None,
@@ -2361,9 +2315,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             family: String,
                             arity: Required,
                             native_type: Some(
-                                String(
-                                    "LongText",
-                                ),
+                                String("LongText"),
                             ),
                         },
                         default: None,
@@ -2415,11 +2367,9 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             family: Binary,
                             arity: Required,
                             native_type: Some(
-                                Object({
-                                    "Binary": Number(
-                                        1,
-                                    ),
-                                }),
+                                Object {
+                                    "Binary": Number(1),
+                                },
                             ),
                         },
                         default: None,
@@ -2437,11 +2387,9 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             family: Binary,
                             arity: Required,
                             native_type: Some(
-                                Object({
-                                    "VarBinary": Number(
-                                        255,
-                                    ),
-                                }),
+                                Object {
+                                    "VarBinary": Number(255),
+                                },
                             ),
                         },
                         default: None,
@@ -2459,9 +2407,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             family: Binary,
                             arity: Required,
                             native_type: Some(
-                                String(
-                                    "Blob",
-                                ),
+                                String("Blob"),
                             ),
                         },
                         default: None,
@@ -2479,9 +2425,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             family: Binary,
                             arity: Required,
                             native_type: Some(
-                                String(
-                                    "TinyBlob",
-                                ),
+                                String("TinyBlob"),
                             ),
                         },
                         default: None,
@@ -2499,9 +2443,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             family: Binary,
                             arity: Required,
                             native_type: Some(
-                                String(
-                                    "MediumBlob",
-                                ),
+                                String("MediumBlob"),
                             ),
                         },
                         default: None,
@@ -2519,9 +2461,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             family: Binary,
                             arity: Required,
                             native_type: Some(
-                                String(
-                                    "LongBlob",
-                                ),
+                                String("LongBlob"),
                             ),
                         },
                         default: None,
@@ -2683,9 +2623,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             family: Json,
                             arity: Required,
                             native_type: Some(
-                                String(
-                                    "Json",
-                                ),
+                                String("Json"),
                             ),
                         },
                         default: None,
@@ -2870,11 +2808,9 @@ fn constraints_from_other_databases_should_not_be_introspected(api: TestApi) {
                             family: String,
                             arity: Required,
                             native_type: Some(
-                                Object({
-                                    "VarChar": Number(
-                                        40,
-                                    ),
-                                }),
+                                Object {
+                                    "VarChar": Number(40),
+                                },
                             ),
                         },
                         default: None,
@@ -2892,11 +2828,9 @@ fn constraints_from_other_databases_should_not_be_introspected(api: TestApi) {
                             family: String,
                             arity: Nullable,
                             native_type: Some(
-                                Object({
-                                    "VarChar": Number(
-                                        100,
-                                    ),
-                                }),
+                                Object {
+                                    "VarChar": Number(100),
+                                },
                             ),
                         },
                         default: None,
@@ -2914,11 +2848,9 @@ fn constraints_from_other_databases_should_not_be_introspected(api: TestApi) {
                             family: String,
                             arity: Required,
                             native_type: Some(
-                                Object({
-                                    "VarChar": Number(
-                                        100,
-                                    ),
-                                }),
+                                Object {
+                                    "VarChar": Number(100),
+                                },
                             ),
                         },
                         default: None,
@@ -3057,11 +2989,9 @@ fn introspected_default_strings_should_be_unescaped(api: TestApi) {
                             family: String,
                             arity: Required,
                             native_type: Some(
-                                Object({
-                                    "VarChar": Number(
-                                        500,
-                                    ),
-                                }),
+                                Object {
+                                    "VarChar": Number(500),
+                                },
                             ),
                         },
                         default: Some(
@@ -3125,11 +3055,9 @@ fn escaped_quotes_in_string_defaults_must_be_unescaped(api: TestApi) {
                             family: String,
                             arity: Required,
                             native_type: Some(
-                                Object({
-                                    "VarChar": Number(
-                                        200,
-                                    ),
-                                }),
+                                Object {
+                                    "VarChar": Number(200),
+                                },
                             ),
                         },
                         default: Some(
@@ -3156,11 +3084,9 @@ fn escaped_quotes_in_string_defaults_must_be_unescaped(api: TestApi) {
                             family: String,
                             arity: Required,
                             native_type: Some(
-                                Object({
-                                    "VarChar": Number(
-                                        200,
-                                    ),
-                                }),
+                                Object {
+                                    "VarChar": Number(200),
+                                },
                             ),
                         },
                         default: Some(
@@ -3224,11 +3150,9 @@ fn escaped_backslashes_in_string_literals_must_be_unescaped(api: TestApi) {
                             family: String,
                             arity: Required,
                             native_type: Some(
-                                Object({
-                                    "VarChar": Number(
-                                        255,
-                                    ),
-                                }),
+                                Object {
+                                    "VarChar": Number(255),
+                                },
                             ),
                         },
                         default: Some(
@@ -3313,9 +3237,7 @@ fn function_expression_defaults_are_described_as_dbgenerated(api: TestApi) {
                             family: Int,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "Int",
-                                ),
+                                String("Int"),
                             ),
                         },
                         default: Some(
@@ -3342,9 +3264,7 @@ fn function_expression_defaults_are_described_as_dbgenerated(api: TestApi) {
                             family: BigInt,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "BigInt",
-                                ),
+                                String("BigInt"),
                             ),
                         },
                         default: Some(
@@ -3371,9 +3291,7 @@ fn function_expression_defaults_are_described_as_dbgenerated(api: TestApi) {
                             family: Float,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "Float",
-                                ),
+                                String("Float"),
                             ),
                         },
                         default: Some(
@@ -3400,16 +3318,12 @@ fn function_expression_defaults_are_described_as_dbgenerated(api: TestApi) {
                             family: Decimal,
                             arity: Nullable,
                             native_type: Some(
-                                Object({
-                                    "Decimal": Array([
-                                        Number(
-                                            10,
-                                        ),
-                                        Number(
-                                            0,
-                                        ),
-                                    ]),
-                                }),
+                                Object {
+                                    "Decimal": Array [
+                                        Number(10),
+                                        Number(0),
+                                    ],
+                                },
                             ),
                         },
                         default: Some(
@@ -3436,9 +3350,7 @@ fn function_expression_defaults_are_described_as_dbgenerated(api: TestApi) {
                             family: Boolean,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "TinyInt",
-                                ),
+                                String("TinyInt"),
                             ),
                         },
                         default: Some(
@@ -3465,11 +3377,9 @@ fn function_expression_defaults_are_described_as_dbgenerated(api: TestApi) {
                             family: String,
                             arity: Nullable,
                             native_type: Some(
-                                Object({
-                                    "VarChar": Number(
-                                        8,
-                                    ),
-                                }),
+                                Object {
+                                    "VarChar": Number(8),
+                                },
                             ),
                         },
                         default: Some(
@@ -3496,11 +3406,9 @@ fn function_expression_defaults_are_described_as_dbgenerated(api: TestApi) {
                             family: DateTime,
                             arity: Nullable,
                             native_type: Some(
-                                Object({
-                                    "DateTime": Number(
-                                        0,
-                                    ),
-                                }),
+                                Object {
+                                    "DateTime": Number(0),
+                                },
                             ),
                         },
                         default: Some(
@@ -3523,11 +3431,9 @@ fn function_expression_defaults_are_described_as_dbgenerated(api: TestApi) {
                             family: DateTime,
                             arity: Nullable,
                             native_type: Some(
-                                Object({
-                                    "DateTime": Number(
-                                        0,
-                                    ),
-                                }),
+                                Object {
+                                    "DateTime": Number(0),
+                                },
                             ),
                         },
                         default: Some(
@@ -3554,11 +3460,9 @@ fn function_expression_defaults_are_described_as_dbgenerated(api: TestApi) {
                             family: Binary,
                             arity: Required,
                             native_type: Some(
-                                Object({
-                                    "Binary": Number(
-                                        16,
-                                    ),
-                                }),
+                                Object {
+                                    "Binary": Number(16),
+                                },
                             ),
                         },
                         default: Some(
@@ -3585,9 +3489,7 @@ fn function_expression_defaults_are_described_as_dbgenerated(api: TestApi) {
                             family: Json,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "Json",
-                                ),
+                                String("Json"),
                             ),
                         },
                         default: Some(

--- a/libs/sql-schema-describer/tests/describers/mysql_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/mysql_describer_tests.rs
@@ -122,9 +122,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             family: Int,
                             arity: Required,
                             native_type: Some(
-                                String(
-                                    "Int",
-                                ),
+                                String("Int"),
                             ),
                         },
                         default: None,
@@ -142,9 +140,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             family: Int,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "Int",
-                                ),
+                                String("Int"),
                             ),
                         },
                         default: None,
@@ -162,9 +158,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             family: Int,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "SmallInt",
-                                ),
+                                String("SmallInt"),
                             ),
                         },
                         default: None,
@@ -182,9 +176,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             family: Int,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "TinyInt",
-                                ),
+                                String("TinyInt"),
                             ),
                         },
                         default: None,
@@ -202,9 +194,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             family: Boolean,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "TinyInt",
-                                ),
+                                String("TinyInt"),
                             ),
                         },
                         default: None,
@@ -222,9 +212,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             family: Int,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "MediumInt",
-                                ),
+                                String("MediumInt"),
                             ),
                         },
                         default: None,
@@ -242,9 +230,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             family: BigInt,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "BigInt",
-                                ),
+                                String("BigInt"),
                             ),
                         },
                         default: None,
@@ -262,16 +248,12 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             family: Decimal,
                             arity: Nullable,
                             native_type: Some(
-                                Object({
-                                    "Decimal": Array([
-                                        Number(
-                                            10,
-                                        ),
-                                        Number(
-                                            0,
-                                        ),
-                                    ]),
-                                }),
+                                Object {
+                                    "Decimal": Array [
+                                        Number(10),
+                                        Number(0),
+                                    ],
+                                },
                             ),
                         },
                         default: None,
@@ -289,16 +271,12 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             family: Decimal,
                             arity: Nullable,
                             native_type: Some(
-                                Object({
-                                    "Decimal": Array([
-                                        Number(
-                                            10,
-                                        ),
-                                        Number(
-                                            0,
-                                        ),
-                                    ]),
-                                }),
+                                Object {
+                                    "Decimal": Array [
+                                        Number(10),
+                                        Number(0),
+                                    ],
+                                },
                             ),
                         },
                         default: None,
@@ -316,9 +294,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             family: Float,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "Float",
-                                ),
+                                String("Float"),
                             ),
                         },
                         default: None,
@@ -336,9 +312,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             family: Float,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "Double",
-                                ),
+                                String("Double"),
                             ),
                         },
                         default: None,
@@ -356,9 +330,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             family: DateTime,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "Date",
-                                ),
+                                String("Date"),
                             ),
                         },
                         default: None,
@@ -376,11 +348,9 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             family: DateTime,
                             arity: Nullable,
                             native_type: Some(
-                                Object({
-                                    "Time": Number(
-                                        0,
-                                    ),
-                                }),
+                                Object {
+                                    "Time": Number(0),
+                                },
                             ),
                         },
                         default: None,
@@ -398,11 +368,9 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             family: DateTime,
                             arity: Nullable,
                             native_type: Some(
-                                Object({
-                                    "DateTime": Number(
-                                        0,
-                                    ),
-                                }),
+                                Object {
+                                    "DateTime": Number(0),
+                                },
                             ),
                         },
                         default: None,
@@ -420,11 +388,9 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             family: DateTime,
                             arity: Required,
                             native_type: Some(
-                                Object({
-                                    "Timestamp": Number(
-                                        0,
-                                    ),
-                                }),
+                                Object {
+                                    "Timestamp": Number(0),
+                                },
                             ),
                         },
                         default: Some(
@@ -447,9 +413,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             family: Int,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "Year",
-                                ),
+                                String("Year"),
                             ),
                         },
                         default: None,
@@ -467,11 +431,9 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             family: String,
                             arity: Nullable,
                             native_type: Some(
-                                Object({
-                                    "Char": Number(
-                                        1,
-                                    ),
-                                }),
+                                Object {
+                                    "Char": Number(1),
+                                },
                             ),
                         },
                         default: None,
@@ -489,11 +451,9 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             family: String,
                             arity: Nullable,
                             native_type: Some(
-                                Object({
-                                    "VarChar": Number(
-                                        255,
-                                    ),
-                                }),
+                                Object {
+                                    "VarChar": Number(255),
+                                },
                             ),
                         },
                         default: None,
@@ -511,9 +471,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             family: String,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "Text",
-                                ),
+                                String("Text"),
                             ),
                         },
                         default: None,
@@ -531,9 +489,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             family: String,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "TinyText",
-                                ),
+                                String("TinyText"),
                             ),
                         },
                         default: None,
@@ -551,9 +507,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             family: String,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "MediumText",
-                                ),
+                                String("MediumText"),
                             ),
                         },
                         default: None,
@@ -571,9 +525,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             family: String,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "LongText",
-                                ),
+                                String("LongText"),
                             ),
                         },
                         default: None,
@@ -625,11 +577,9 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             family: Binary,
                             arity: Nullable,
                             native_type: Some(
-                                Object({
-                                    "Binary": Number(
-                                        1,
-                                    ),
-                                }),
+                                Object {
+                                    "Binary": Number(1),
+                                },
                             ),
                         },
                         default: None,
@@ -647,11 +597,9 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             family: Binary,
                             arity: Nullable,
                             native_type: Some(
-                                Object({
-                                    "VarBinary": Number(
-                                        255,
-                                    ),
-                                }),
+                                Object {
+                                    "VarBinary": Number(255),
+                                },
                             ),
                         },
                         default: None,
@@ -669,9 +617,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             family: Binary,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "Blob",
-                                ),
+                                String("Blob"),
                             ),
                         },
                         default: None,
@@ -689,9 +635,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             family: Binary,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "TinyBlob",
-                                ),
+                                String("TinyBlob"),
                             ),
                         },
                         default: None,
@@ -709,9 +653,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             family: Binary,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "MediumBlob",
-                                ),
+                                String("MediumBlob"),
                             ),
                         },
                         default: None,
@@ -729,9 +671,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             family: Binary,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "LongBlob",
-                                ),
+                                String("LongBlob"),
                             ),
                         },
                         default: None,
@@ -893,9 +833,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             family: Json,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "Json",
-                                ),
+                                String("Json"),
                             ),
                         },
                         default: None,
@@ -1018,9 +956,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             family: Int,
                             arity: Required,
                             native_type: Some(
-                                String(
-                                    "Int",
-                                ),
+                                String("Int"),
                             ),
                         },
                         default: None,
@@ -1038,9 +974,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             family: Int,
                             arity: Required,
                             native_type: Some(
-                                String(
-                                    "Int",
-                                ),
+                                String("Int"),
                             ),
                         },
                         default: None,
@@ -1058,9 +992,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             family: Int,
                             arity: Required,
                             native_type: Some(
-                                String(
-                                    "SmallInt",
-                                ),
+                                String("SmallInt"),
                             ),
                         },
                         default: None,
@@ -1078,9 +1010,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             family: Int,
                             arity: Required,
                             native_type: Some(
-                                String(
-                                    "TinyInt",
-                                ),
+                                String("TinyInt"),
                             ),
                         },
                         default: None,
@@ -1098,9 +1028,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             family: Boolean,
                             arity: Required,
                             native_type: Some(
-                                String(
-                                    "TinyInt",
-                                ),
+                                String("TinyInt"),
                             ),
                         },
                         default: None,
@@ -1118,9 +1046,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             family: Int,
                             arity: Required,
                             native_type: Some(
-                                String(
-                                    "MediumInt",
-                                ),
+                                String("MediumInt"),
                             ),
                         },
                         default: None,
@@ -1138,9 +1064,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             family: BigInt,
                             arity: Required,
                             native_type: Some(
-                                String(
-                                    "BigInt",
-                                ),
+                                String("BigInt"),
                             ),
                         },
                         default: None,
@@ -1158,16 +1082,12 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             family: Decimal,
                             arity: Required,
                             native_type: Some(
-                                Object({
-                                    "Decimal": Array([
-                                        Number(
-                                            10,
-                                        ),
-                                        Number(
-                                            0,
-                                        ),
-                                    ]),
-                                }),
+                                Object {
+                                    "Decimal": Array [
+                                        Number(10),
+                                        Number(0),
+                                    ],
+                                },
                             ),
                         },
                         default: None,
@@ -1185,16 +1105,12 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             family: Decimal,
                             arity: Required,
                             native_type: Some(
-                                Object({
-                                    "Decimal": Array([
-                                        Number(
-                                            10,
-                                        ),
-                                        Number(
-                                            0,
-                                        ),
-                                    ]),
-                                }),
+                                Object {
+                                    "Decimal": Array [
+                                        Number(10),
+                                        Number(0),
+                                    ],
+                                },
                             ),
                         },
                         default: None,
@@ -1212,9 +1128,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             family: Float,
                             arity: Required,
                             native_type: Some(
-                                String(
-                                    "Float",
-                                ),
+                                String("Float"),
                             ),
                         },
                         default: None,
@@ -1232,9 +1146,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             family: Float,
                             arity: Required,
                             native_type: Some(
-                                String(
-                                    "Double",
-                                ),
+                                String("Double"),
                             ),
                         },
                         default: None,
@@ -1252,9 +1164,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             family: DateTime,
                             arity: Required,
                             native_type: Some(
-                                String(
-                                    "Date",
-                                ),
+                                String("Date"),
                             ),
                         },
                         default: None,
@@ -1272,11 +1182,9 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             family: DateTime,
                             arity: Required,
                             native_type: Some(
-                                Object({
-                                    "Time": Number(
-                                        0,
-                                    ),
-                                }),
+                                Object {
+                                    "Time": Number(0),
+                                },
                             ),
                         },
                         default: None,
@@ -1294,11 +1202,9 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             family: DateTime,
                             arity: Required,
                             native_type: Some(
-                                Object({
-                                    "DateTime": Number(
-                                        0,
-                                    ),
-                                }),
+                                Object {
+                                    "DateTime": Number(0),
+                                },
                             ),
                         },
                         default: None,
@@ -1316,11 +1222,9 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             family: DateTime,
                             arity: Required,
                             native_type: Some(
-                                Object({
-                                    "Timestamp": Number(
-                                        0,
-                                    ),
-                                }),
+                                Object {
+                                    "Timestamp": Number(0),
+                                },
                             ),
                         },
                         default: Some(
@@ -1343,9 +1247,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             family: Int,
                             arity: Required,
                             native_type: Some(
-                                String(
-                                    "Year",
-                                ),
+                                String("Year"),
                             ),
                         },
                         default: None,
@@ -1363,11 +1265,9 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             family: String,
                             arity: Required,
                             native_type: Some(
-                                Object({
-                                    "Char": Number(
-                                        1,
-                                    ),
-                                }),
+                                Object {
+                                    "Char": Number(1),
+                                },
                             ),
                         },
                         default: None,
@@ -1385,11 +1285,9 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             family: String,
                             arity: Required,
                             native_type: Some(
-                                Object({
-                                    "VarChar": Number(
-                                        255,
-                                    ),
-                                }),
+                                Object {
+                                    "VarChar": Number(255),
+                                },
                             ),
                         },
                         default: None,
@@ -1407,9 +1305,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             family: String,
                             arity: Required,
                             native_type: Some(
-                                String(
-                                    "Text",
-                                ),
+                                String("Text"),
                             ),
                         },
                         default: None,
@@ -1427,9 +1323,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             family: String,
                             arity: Required,
                             native_type: Some(
-                                String(
-                                    "TinyText",
-                                ),
+                                String("TinyText"),
                             ),
                         },
                         default: None,
@@ -1447,9 +1341,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             family: String,
                             arity: Required,
                             native_type: Some(
-                                String(
-                                    "MediumText",
-                                ),
+                                String("MediumText"),
                             ),
                         },
                         default: None,
@@ -1467,9 +1359,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             family: String,
                             arity: Required,
                             native_type: Some(
-                                String(
-                                    "LongText",
-                                ),
+                                String("LongText"),
                             ),
                         },
                         default: None,
@@ -1521,11 +1411,9 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             family: Binary,
                             arity: Required,
                             native_type: Some(
-                                Object({
-                                    "Binary": Number(
-                                        1,
-                                    ),
-                                }),
+                                Object {
+                                    "Binary": Number(1),
+                                },
                             ),
                         },
                         default: None,
@@ -1543,11 +1431,9 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             family: Binary,
                             arity: Required,
                             native_type: Some(
-                                Object({
-                                    "VarBinary": Number(
-                                        255,
-                                    ),
-                                }),
+                                Object {
+                                    "VarBinary": Number(255),
+                                },
                             ),
                         },
                         default: None,
@@ -1565,9 +1451,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             family: Binary,
                             arity: Required,
                             native_type: Some(
-                                String(
-                                    "Blob",
-                                ),
+                                String("Blob"),
                             ),
                         },
                         default: None,
@@ -1585,9 +1469,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             family: Binary,
                             arity: Required,
                             native_type: Some(
-                                String(
-                                    "TinyBlob",
-                                ),
+                                String("TinyBlob"),
                             ),
                         },
                         default: None,
@@ -1605,9 +1487,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             family: Binary,
                             arity: Required,
                             native_type: Some(
-                                String(
-                                    "MediumBlob",
-                                ),
+                                String("MediumBlob"),
                             ),
                         },
                         default: None,
@@ -1625,9 +1505,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             family: Binary,
                             arity: Required,
                             native_type: Some(
-                                String(
-                                    "LongBlob",
-                                ),
+                                String("LongBlob"),
                             ),
                         },
                         default: None,
@@ -1789,9 +1667,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             family: String,
                             arity: Required,
                             native_type: Some(
-                                String(
-                                    "LongText",
-                                ),
+                                String("LongText"),
                             ),
                         },
                         default: None,

--- a/libs/sql-schema-describer/tests/describers/postgres_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/postgres_describer_tests.rs
@@ -97,9 +97,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             family: Binary,
                             arity: List,
                             native_type: Some(
-                                String(
-                                    "ByteA",
-                                ),
+                                String("ByteA"),
                             ),
                         },
                         default: None,
@@ -117,9 +115,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             family: Boolean,
                             arity: List,
                             native_type: Some(
-                                String(
-                                    "Boolean",
-                                ),
+                                String("Boolean"),
                             ),
                         },
                         default: None,
@@ -137,9 +133,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             family: DateTime,
                             arity: List,
                             native_type: Some(
-                                String(
-                                    "Date",
-                                ),
+                                String("Date"),
                             ),
                         },
                         default: None,
@@ -157,9 +151,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             family: Float,
                             arity: List,
                             native_type: Some(
-                                String(
-                                    "DoublePrecision",
-                                ),
+                                String("DoublePrecision"),
                             ),
                         },
                         default: None,
@@ -177,9 +169,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             family: Float,
                             arity: List,
                             native_type: Some(
-                                String(
-                                    "DoublePrecision",
-                                ),
+                                String("DoublePrecision"),
                             ),
                         },
                         default: None,
@@ -197,9 +187,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             family: Int,
                             arity: List,
                             native_type: Some(
-                                String(
-                                    "Integer",
-                                ),
+                                String("Integer"),
                             ),
                         },
                         default: None,
@@ -217,9 +205,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             family: String,
                             arity: List,
                             native_type: Some(
-                                String(
-                                    "Text",
-                                ),
+                                String("Text"),
                             ),
                         },
                         default: None,
@@ -237,11 +223,9 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             family: String,
                             arity: List,
                             native_type: Some(
-                                Object({
-                                    "VarChar": Number(
-                                        255,
-                                    ),
-                                }),
+                                Object {
+                                    "VarChar": Number(255),
+                                },
                             ),
                         },
                         default: None,
@@ -259,9 +243,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             family: BigInt,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "BigInt",
-                                ),
+                                String("BigInt"),
                             ),
                         },
                         default: None,
@@ -279,9 +261,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             family: BigInt,
                             arity: Required,
                             native_type: Some(
-                                String(
-                                    "BigInt",
-                                ),
+                                String("BigInt"),
                             ),
                         },
                         default: Some(
@@ -306,11 +286,9 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             family: String,
                             arity: Nullable,
                             native_type: Some(
-                                Object({
-                                    "Bit": Number(
-                                        1,
-                                    ),
-                                }),
+                                Object {
+                                    "Bit": Number(1),
+                                },
                             ),
                         },
                         default: None,
@@ -328,11 +306,9 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             family: String,
                             arity: Nullable,
                             native_type: Some(
-                                Object({
-                                    "VarBit": Number(
-                                        1,
-                                    ),
-                                }),
+                                Object {
+                                    "VarBit": Number(1),
+                                },
                             ),
                         },
                         default: None,
@@ -350,9 +326,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             family: Binary,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "ByteA",
-                                ),
+                                String("ByteA"),
                             ),
                         },
                         default: None,
@@ -370,9 +344,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             family: Boolean,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "Boolean",
-                                ),
+                                String("Boolean"),
                             ),
                         },
                         default: None,
@@ -408,11 +380,9 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             family: String,
                             arity: Nullable,
                             native_type: Some(
-                                Object({
-                                    "Char": Number(
-                                        1,
-                                    ),
-                                }),
+                                Object {
+                                    "Char": Number(1),
+                                },
                             ),
                         },
                         default: None,
@@ -448,9 +418,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             family: DateTime,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "Date",
-                                ),
+                                String("Date"),
                             ),
                         },
                         default: None,
@@ -468,9 +436,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             family: Float,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "DoublePrecision",
-                                ),
+                                String("DoublePrecision"),
                             ),
                         },
                         default: None,
@@ -488,9 +454,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             family: Float,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "DoublePrecision",
-                                ),
+                                String("DoublePrecision"),
                             ),
                         },
                         default: None,
@@ -508,9 +472,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             family: Int,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "Integer",
-                                ),
+                                String("Integer"),
                             ),
                         },
                         default: None,
@@ -564,9 +526,9 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             family: Decimal,
                             arity: Nullable,
                             native_type: Some(
-                                Object({
+                                Object {
                                     "Decimal": Null,
-                                }),
+                                },
                             ),
                         },
                         default: None,
@@ -638,9 +600,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             family: Int,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "SmallInt",
-                                ),
+                                String("SmallInt"),
                             ),
                         },
                         default: None,
@@ -658,9 +618,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             family: Int,
                             arity: Required,
                             native_type: Some(
-                                String(
-                                    "SmallInt",
-                                ),
+                                String("SmallInt"),
                             ),
                         },
                         default: Some(
@@ -685,9 +643,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             family: Int,
                             arity: Required,
                             native_type: Some(
-                                String(
-                                    "Integer",
-                                ),
+                                String("Integer"),
                             ),
                         },
                         default: Some(
@@ -712,9 +668,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             family: Int,
                             arity: Required,
                             native_type: Some(
-                                String(
-                                    "Integer",
-                                ),
+                                String("Integer"),
                             ),
                         },
                         default: Some(
@@ -739,9 +693,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             family: String,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "Text",
-                                ),
+                                String("Text"),
                             ),
                         },
                         default: None,
@@ -759,11 +711,9 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             family: String,
                             arity: Nullable,
                             native_type: Some(
-                                Object({
-                                    "VarChar": Number(
-                                        1,
-                                    ),
-                                }),
+                                Object {
+                                    "VarChar": Number(1),
+                                },
                             ),
                         },
                         default: None,
@@ -781,11 +731,9 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             family: DateTime,
                             arity: Nullable,
                             native_type: Some(
-                                Object({
-                                    "Time": Number(
-                                        6,
-                                    ),
-                                }),
+                                Object {
+                                    "Time": Number(6),
+                                },
                             ),
                         },
                         default: None,
@@ -803,11 +751,9 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             family: DateTime,
                             arity: Nullable,
                             native_type: Some(
-                                Object({
-                                    "Timetz": Number(
-                                        6,
-                                    ),
-                                }),
+                                Object {
+                                    "Timetz": Number(6),
+                                },
                             ),
                         },
                         default: None,
@@ -825,11 +771,9 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             family: DateTime,
                             arity: Nullable,
                             native_type: Some(
-                                Object({
-                                    "Timestamp": Number(
-                                        6,
-                                    ),
-                                }),
+                                Object {
+                                    "Timestamp": Number(6),
+                                },
                             ),
                         },
                         default: None,
@@ -847,11 +791,9 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             family: DateTime,
                             arity: Nullable,
                             native_type: Some(
-                                Object({
-                                    "Timestamptz": Number(
-                                        6,
-                                    ),
-                                }),
+                                Object {
+                                    "Timestamptz": Number(6),
+                                },
                             ),
                         },
                         default: None,
@@ -923,9 +865,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             family: Json,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "Json",
-                                ),
+                                String("Json"),
                             ),
                         },
                         default: None,
@@ -943,9 +883,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             family: Json,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "JsonB",
-                                ),
+                                String("JsonB"),
                             ),
                         },
                         default: None,
@@ -963,9 +901,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             family: Uuid,
                             arity: Nullable,
                             native_type: Some(
-                                String(
-                                    "Uuid",
-                                ),
+                                String("Uuid"),
                             ),
                         },
                         default: None,
@@ -1278,9 +1214,7 @@ fn escaped_quotes_in_string_defaults_must_be_unescaped(api: TestApi) {
                             family: Int,
                             arity: Required,
                             native_type: Some(
-                                String(
-                                    "Integer",
-                                ),
+                                String("Integer"),
                             ),
                         },
                         default: None,
@@ -1298,9 +1232,9 @@ fn escaped_quotes_in_string_defaults_must_be_unescaped(api: TestApi) {
                             family: String,
                             arity: Required,
                             native_type: Some(
-                                Object({
+                                Object {
                                     "VarChar": Null,
-                                }),
+                                },
                             ),
                         },
                         default: Some(
@@ -1327,9 +1261,9 @@ fn escaped_quotes_in_string_defaults_must_be_unescaped(api: TestApi) {
                             family: String,
                             arity: Required,
                             native_type: Some(
-                                Object({
+                                Object {
                                     "VarChar": Null,
-                                }),
+                                },
                             ),
                         },
                         default: Some(
@@ -1356,9 +1290,9 @@ fn escaped_quotes_in_string_defaults_must_be_unescaped(api: TestApi) {
                             family: String,
                             arity: Required,
                             native_type: Some(
-                                Object({
+                                Object {
                                     "VarChar": Null,
-                                }),
+                                },
                             ),
                         },
                         default: Some(
@@ -1443,11 +1377,9 @@ fn seemingly_escaped_backslashes_in_string_literals_must_not_be_unescaped(api: T
                             family: String,
                             arity: Required,
                             native_type: Some(
-                                Object({
-                                    "VarChar": Number(
-                                        255,
-                                    ),
-                                }),
+                                Object {
+                                    "VarChar": Number(255),
+                                },
                             ),
                         },
                         default: Some(

--- a/libs/sql-schema-describer/tests/describers/postgres_describer_tests/cockroach_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/postgres_describer_tests/cockroach_describer_tests.rs
@@ -254,9 +254,9 @@ fn multi_field_indexes_must_be_inferred_in_the_right_order(api: TestApi) {
                             family: String,
                             arity: Required,
                             native_type: Some(
-                                Object({
+                                Object {
                                     "String": Null,
-                                }),
+                                },
                             ),
                         },
                         default: None,
@@ -274,9 +274,9 @@ fn multi_field_indexes_must_be_inferred_in_the_right_order(api: TestApi) {
                             family: String,
                             arity: Required,
                             native_type: Some(
-                                Object({
+                                Object {
                                     "String": Null,
-                                }),
+                                },
                             ),
                         },
                         default: None,
@@ -294,9 +294,7 @@ fn multi_field_indexes_must_be_inferred_in_the_right_order(api: TestApi) {
                             family: Int,
                             arity: Required,
                             native_type: Some(
-                                String(
-                                    "Int4",
-                                ),
+                                String("Int4"),
                             ),
                         },
                         default: None,

--- a/migration-engine/connectors/mongodb-migration-connector/Cargo.toml
+++ b/migration-engine/connectors/mongodb-migration-connector/Cargo.toml
@@ -12,7 +12,7 @@ mongodb-introspection-connector = { path = "../../../introspection-engine/connec
 
 enumflags2 = "0.7"
 futures = "0.3"
-mongodb = { git = "https://github.com/mongodb/mongo-rust-driver" }
+mongodb = "2.3.0"
 serde_json = "1"
 tokio = { version = "1.0", features = ["parking_lot"] }
 tracing = "0.1"

--- a/migration-engine/connectors/mongodb-migration-connector/Cargo.toml
+++ b/migration-engine/connectors/mongodb-migration-connector/Cargo.toml
@@ -12,7 +12,7 @@ mongodb-introspection-connector = { path = "../../../introspection-engine/connec
 
 enumflags2 = "0.7"
 futures = "0.3"
-mongodb = "2.1.0"
+mongodb = { git = "https://github.com/mongodb/mongo-rust-driver" }
 serde_json = "1"
 tokio = { version = "1.0", features = ["parking_lot"] }
 tracing = "0.1"

--- a/migration-engine/connectors/sql-migration-connector/Cargo.toml
+++ b/migration-engine/connectors/sql-migration-connector/Cargo.toml
@@ -23,7 +23,7 @@ tokio = { version = "1.0", default-features = false, features = ["time"] }
 tracing = "0.1"
 tracing-futures = "0.2"
 url = "2.1.1"
-uuid = { version = "0.8", features = ["v4"] }
+uuid = { version = "1", features = ["v4"] }
 either = "1.6"
 
 [dependencies.quaint]

--- a/migration-engine/migration-engine-tests/Cargo.toml
+++ b/migration-engine/migration-engine-tests/Cargo.toml
@@ -13,7 +13,7 @@ test-macros = { path = "../../libs/test-macros" }
 test-setup = { path = "../../libs/test-setup" }
 prisma-value = { path = "../../libs/prisma-value" }
 
-bigdecimal = "0.2"
+bigdecimal = "0.3"
 chrono = "0.4.15"
 connection-string = "0.1.13"
 enumflags2 = "0.7"

--- a/migration-engine/qe-setup/Cargo.toml
+++ b/migration-engine/qe-setup/Cargo.toml
@@ -11,7 +11,7 @@ test-setup = { path = "../../libs/test-setup" }
 
 connection-string = "*"
 enumflags2 = "*"
-mongodb = "2.1.0"
+mongodb = { git = "https://github.com/mongodb/mongo-rust-driver" }
 tempfile = "3.3.0"
 url = "2"
 

--- a/migration-engine/qe-setup/Cargo.toml
+++ b/migration-engine/qe-setup/Cargo.toml
@@ -11,7 +11,7 @@ test-setup = { path = "../../libs/test-setup" }
 
 connection-string = "*"
 enumflags2 = "*"
-mongodb = { git = "https://github.com/mongodb/mongo-rust-driver" }
+mongodb = "2.3.0"
 tempfile = "3.3.0"
 url = "2"
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/Cargo.toml
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/Cargo.toml
@@ -16,7 +16,7 @@ colored = "2"
 chrono = "0.4"
 datamodel-connector = { path = "../../../libs/datamodel/connectors/datamodel-connector" }
 base64 = "0.13"
-uuid = "0.8"
+uuid = "1"
 tokio = "1.8"
 prisma-value = { path = "../../../libs/prisma-value" }
 query-engine-metrics = { path = "../../metrics"}

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
@@ -3,6 +3,7 @@ mod prisma_10098;
 mod prisma_10935;
 mod prisma_12929;
 mod prisma_14696;
+mod prisma_14703;
 mod prisma_6173;
 mod prisma_7010;
 mod prisma_7072;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_14703.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_14703.rs
@@ -1,0 +1,36 @@
+use indoc::indoc;
+use query_engine_tests::*;
+
+#[test_suite(schema(schema), exclude(MongoDB, Sqlite))]
+mod prisma_14703 {
+    fn schema() -> String {
+        String::from(indoc! {r#"
+            model A {
+              id Decimal @id @test.Decimal(10, 0)
+            }
+        "#})
+    }
+
+    #[connector_test]
+    async fn upsert_does_not_panic_if_underflowing_the_scale(runner: Runner) -> TestResult<()> {
+        let query = indoc! {r#"
+            mutation {
+              createOneA(data: { id: "90" }) { id }
+            }
+        "#};
+
+        let response = runner.query(query).await?;
+        response.assert_success();
+
+        let query = indoc! {r#"
+            mutation {
+              upsertOneA(where: { id: "90" }, create: { id: "90" }, update: { id: "900" } ) { id }
+            }
+        "#};
+
+        let response = runner.query(query).await?;
+        response.assert_success();
+
+        Ok(())
+    }
+}

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/query_result.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/query_result.rs
@@ -14,6 +14,10 @@ impl QueryResult {
 
     /// Asserts absence of errors in the result. Panics with assertion error.
     pub fn assert_success(&self) {
+        if self.failed() {
+            dbg!(self.errors());
+        }
+
         assert!(!self.failed())
     }
 

--- a/query-engine/connectors/mongodb-query-connector/Cargo.toml
+++ b/query-engine/connectors/mongodb-query-connector/Cargo.toml
@@ -10,7 +10,8 @@ bigdecimal = "0.3"
 # bson = {version = "1.1.0", features = ["decimal128"]}
 futures = "0.3"
 itertools = "0.10"
-mongodb = { git = "https://github.com/mongodb/mongo-rust-driver", features = ["bson-chrono-0_4", "bson-uuid-1"] }
+mongodb = "2.3.0"
+bson = { version = "2.4.0", features = ["chrono-0_4", "uuid-1"] }
 rand = "0.7"
 regex = "1"
 serde_json = { version = "1.0", features = ["float_roundtrip"] }

--- a/query-engine/connectors/mongodb-query-connector/Cargo.toml
+++ b/query-engine/connectors/mongodb-query-connector/Cargo.toml
@@ -6,11 +6,11 @@ version = "0.1.0"
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-bigdecimal = "0.2"
+bigdecimal = "0.3"
 # bson = {version = "1.1.0", features = ["decimal128"]}
 futures = "0.3"
 itertools = "0.10"
-mongodb = { version = "2.1.0", features = ["bson-chrono-0_4", "bson-uuid-0_8"] }
+mongodb = { git = "https://github.com/mongodb/mongo-rust-driver", features = ["bson-chrono-0_4", "bson-uuid-1"] }
 rand = "0.7"
 regex = "1"
 serde_json = { version = "1.0", features = ["float_roundtrip"] }
@@ -18,7 +18,7 @@ thiserror = "1.0"
 tokio = "1.0"
 tracing = "0.1"
 tracing-futures = "0.2"
-uuid = "0.8"
+uuid = "1"
 indexmap = "1.7"
 query-engine-metrics = {path = "../../metrics"}
 

--- a/query-engine/connectors/query-connector/Cargo.toml
+++ b/query-engine/connectors/query-connector/Cargo.toml
@@ -15,5 +15,5 @@ serde = {version = "1.0", features = ["derive"]}
 serde_json = {version = "1.0", features = ["float_roundtrip"]}
 thiserror = "1.0"
 user-facing-errors = {path = "../../../libs/user-facing-errors"}
-uuid = "0.8"
+uuid = "1"
 indexmap = "1.7"

--- a/query-engine/connectors/sql-query-connector/Cargo.toml
+++ b/query-engine/connectors/sql-query-connector/Cargo.toml
@@ -9,7 +9,7 @@ vendored-openssl = ["quaint/vendored-openssl"]
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-bigdecimal = "0.2"
+bigdecimal = "0.3"
 futures = "0.3"
 itertools = "0.10"
 once_cell = "1.3"
@@ -19,7 +19,7 @@ thiserror = "1.0"
 tokio = "1.0"
 tracing = "0.1"
 tracing-futures = "0.2"
-uuid = "0.8"
+uuid = "1"
 opentelemetry = { version = "0.17", features = ["tokio"] }
 tracing-opentelemetry = "0.17.3"
 

--- a/query-engine/core/Cargo.toml
+++ b/query-engine/core/Cargo.toml
@@ -12,7 +12,7 @@ sql = ["sql-connector"]
 [dependencies]
 async-trait = "0.1"
 base64 = "0.12"
-bigdecimal = "0.2"
+bigdecimal = "0.3"
 chrono = "0.4"
 connection-string = "0.1"
 connector = { path = "../connectors/query-connector", package = "query-connector" }
@@ -41,7 +41,7 @@ tracing-subscriber = "0.3.11"
 tracing-opentelemetry = "0.17.4"
 url = "2"
 user-facing-errors = { path = "../../libs/user-facing-errors" }
-uuid = "0.8"
+uuid = "1"
 cuid = { git = "https://github.com/prisma/cuid-rust" }
 pin-utils = "0.1"
 lazy_static = "1.4"

--- a/query-engine/core/src/query_document/query_value.rs
+++ b/query-engine/core/src/query_document/query_value.rs
@@ -69,7 +69,7 @@ impl From<PrismaValue> for QueryValue {
             PrismaValue::List(l) => Self::List(l.into_iter().map(QueryValue::from).collect()),
             PrismaValue::Int(i) => Self::Int(i),
             PrismaValue::Null => Self::Null,
-            PrismaValue::Uuid(u) => Self::String(u.to_hyphenated().to_string()),
+            PrismaValue::Uuid(u) => Self::String(u.hyphenated().to_string()),
             PrismaValue::Json(s) => Self::String(s),
             PrismaValue::Xml(s) => Self::String(s),
             PrismaValue::Bytes(b) => Self::String(prisma_value::encode_bytes(&b)),

--- a/query-engine/dmmf/Cargo.toml
+++ b/query-engine/dmmf/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bigdecimal = "0.2.0"
+bigdecimal = "0.3.0"
 psl = { path = "../../psl/psl" }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.78"

--- a/query-engine/prisma-models/Cargo.toml
+++ b/query-engine/prisma-models/Cargo.toml
@@ -9,7 +9,7 @@ psl = { path = "../../psl/psl" }
 itertools = "0.10"
 once_cell = "1.3"
 prisma-value = { path = "../../libs/prisma-value" }
-bigdecimal = "0.2"
+bigdecimal = "0.3"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = { version = "1.0", features = ["float_roundtrip"] }

--- a/query-engine/request-handlers/Cargo.toml
+++ b/query-engine/request-handlers/Cargo.toml
@@ -15,7 +15,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 futures = "0.3"
 indexmap = { version = "1.7", features = ["serde-1"] }
-bigdecimal = "0.2"
+bigdecimal = "0.3"
 thiserror = "1"
 tracing = "0.1"
 url = "2"


### PR DESCRIPTION
Due to Tiberius already using uuid 1.x and bigdecimal 0.3, these things need to be updated throughout our system.

MongoDB has not yet released their 2.4.0 with the changes we need, so we need to point to their GitHub main branch until they're done.

This fixes the BigDecimal conversion errors on SQL Server.

Closes: https://github.com/prisma/prisma/issues/15079
Closes: https://github.com/prisma/prisma/issues/14703