### PR TITLE
Integration/occ fixes 8612

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3086,7 +3086,7 @@ dependencies = [
 [[package]]
 name = "quaint"
 version = "0.2.0-alpha.13"
-source = "git+https://github.com/prisma/quaint#2baa684d8c4d2512c9d99dc84fdafbdffc638b6a"
+source = "git+https://github.com/prisma/quaint#ffe1979c7b1761931a8ece6aad47a4627af1bc82"
 dependencies = [
  "async-trait",
  "base64 0.12.3",

--- a/query-engine/connector-test-kit-rs/query-engine-tests/Cargo.toml
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/Cargo.toml
@@ -17,7 +17,7 @@ chrono = "0.4"
 datamodel-connector = { path = "../../../libs/datamodel/connectors/datamodel-connector" }
 base64 = "0.13"
 uuid = "1"
-tokio = "1.8"
+tokio = "1.21.0"
 prisma-value = { path = "../../../libs/prisma-value" }
 query-engine-metrics = { path = "../../metrics"}
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/mod.rs
@@ -1,10 +1,10 @@
-// mod create_many;
-// mod cursor;
-// mod disconnect;
-// mod interactive_tx;
-// mod metrics;
+mod create_many;
+mod cursor;
+mod disconnect;
+mod interactive_tx;
+mod metrics;
 mod multi_schema;
-// mod native_types;
+mod native_types;
 mod occ;
-// mod ref_actions;
-// mod regressions;
+mod ref_actions;
+mod regressions;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/mod.rs
@@ -1,9 +1,10 @@
-mod create_many;
-mod cursor;
-mod disconnect;
-mod interactive_tx;
-mod metrics;
+// mod create_many;
+// mod cursor;
+// mod disconnect;
+// mod interactive_tx;
+// mod metrics;
 mod multi_schema;
-mod native_types;
-mod ref_actions;
-mod regressions;
+// mod native_types;
+mod occ;
+// mod ref_actions;
+// mod regressions;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/multi_schema.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/multi_schema.rs
@@ -1,4 +1,5 @@
 use query_engine_tests::test_suite;
+
 #[test_suite(capabilities(MultiSchema), exclude(Mysql))]
 mod multi_schema {
     use query_engine_tests::*;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/occ.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/occ.rs
@@ -7,135 +7,356 @@ mod occ {
         include_str!("occ_simple.prisma").to_owned()
     }
 
-    #[connector_test(schema(occ_simple))]
-    async fn occ_simple_test(runner: Runner) -> TestResult<()> {
-        const USERS_COUNT: usize = 3;
-        let runner = Arc::new(runner);
-
-        // CREATE seat
+    async fn create_one_seat(runner: Arc<Runner>) {
         runner
-            .query(r#"mutation { createOneSeat(data: { movie: "zardoz" }) { id } }"#)
-            .await?
+            .query(r#"mutation { createOneSeat(data: { movie: "zardoz", id: 1 }) { id } }"#)
+            .await
+            .unwrap()
             .assert_success();
+    }
 
-        // CREATE users
-        for i in 1..=USERS_COUNT {
-            let query = format!(r#"mutation {{ createOneUser(data: {{ id: {i} }}) {{ id }} }}"#);
-            runner.query(query).await?.assert_success();
+    async fn create_one_user(user_id: u64, runner: Arc<Runner>) {
+        let query = format!(r#"mutation {{ createOneUser(data: {{ id: {user_id} }}) {{ id }} }}"#);
+        runner.query(query).await.unwrap().assert_success();
+    }
+
+    async fn find_unclaimed_seat(runner: Arc<Runner>) -> (u64, u64) {
+        let seat_query = "query { findFirstSeat(where: { movie: \"zardoz\", userId: null }) { id version } }";
+        let seat_result = runner.query(seat_query).await.unwrap().to_json_value();
+        let available_seat = &seat_result["data"]["findFirstSeat"];
+        match available_seat {
+            serde_json::Value::Null => (0, 0),
+            other => (other["id"].as_u64().unwrap(), other["version"].as_u64().unwrap()),
         }
+    }
 
-        let (sender, mut receiver) = tokio::sync::mpsc::channel::<(usize, Option<u64>)>(USERS_COUNT);
-
-        for i in 1..=USERS_COUNT {
-            let sender = sender.clone();
-            let runner = Arc::clone(&runner);
-            tokio::spawn(async move {
-                let seat_query = "query { findFirstSeat(where: { movie: \"zardoz\", userId: null }) { id version } }";
-                let seat_result = runner.query(seat_query).await.unwrap().to_json_value();
-                let available_seat = &seat_result["data"]["findFirstSeat"];
-                let (available_seat_id, available_seat_version) = match available_seat {
-                    serde_json::Value::Null => {
-                        tracing::info!("no available seat for user {i}");
-                        sender.send((i, None)).await.unwrap();
-                        return Ok(());
-                    }
-                    other => (other["id"].as_u64().unwrap(), other["version"].as_u64().unwrap()),
-                };
-
-                let query = indoc::formatdoc!(
-                    r##"
+    async fn book_unclaimed_seat(user_id: u64, seat_id: u64, runner: Arc<Runner>) -> (u64, u64) {
+        let query = indoc::formatdoc!(
+            r##"
                       mutation {{
                           updateManySeat(
-                              data: {{ userId: {i}, version: {{ increment: 1 }} }},
-                              where: {{ id: {available_seat_id}, version: {available_seat_version} }}
+                              data: {{ userId: {user_id}, version: {{ increment: 1 }} }},
+                              where: {{ id: {seat_id}, version: 0 }}
                           )
                           {{ count }}
                       }}
                     "##
-                );
-                let response = dbg!(runner.query(query).await?.to_json_value());
-                let seat_count = response["data"]["updateManySeat"]["count"].as_u64().unwrap();
-                sender.send((i, Some(seat_count))).await.unwrap();
-                TestResult::<()>::Ok(())
-            });
+        );
+        let response = runner.query(query).await.unwrap().to_json_value();
+        let seat_count = response["data"]["updateManySeat"]["count"].as_u64().unwrap();
+        (user_id, seat_count)
+    }
+
+    async fn book_seat_for_user(user_id: u64, runner: Arc<Runner>) -> (u64, u64) {
+        let (seat_id, _version) = find_unclaimed_seat(runner.clone()).await;
+        book_unclaimed_seat(user_id, seat_id, runner).await
+    }
+
+    async fn delete_seats(runner: Arc<Runner>) {
+        let delete_seats = r#"
+            mutation {
+                deleteManySeat(where: {}) {
+                count
+                }
+            }
+        "#;
+        runner.query(delete_seats).await.unwrap().assert_success();
+    }
+
+    async fn delete_users(runner: Arc<Runner>) {
+        let delete_users = r#"
+            mutation {
+                deleteManyUser(where: {}) {
+                count
+                }
+            }
+        "#;
+        runner.query(delete_users).await.unwrap().assert_success();
+    }
+
+    async fn run_occ_reproduce_test(runner: Arc<Runner>) {
+        const USERS_COUNT: u64 = 5;
+
+        create_one_seat(runner.clone()).await;
+
+        for i in 0..=USERS_COUNT {
+            create_one_user(i, runner.clone()).await;
         }
 
-        let mut results = Vec::new();
-
-        for _ in 0..USERS_COUNT {
-            results.push(receiver.recv().await.unwrap());
+        let mut set = tokio::task::JoinSet::new();
+        for user_id in 0..=USERS_COUNT {
+            set.spawn(book_seat_for_user(user_id, runner.clone()));
         }
+
+        let mut booked_user_id = 100;
+        let mut total_booked = 0;
+        while let Some(res) = set.join_next().await {
+            let (user_id, count) = res.unwrap();
+
+            if count > 0 {
+                total_booked += count;
+                booked_user_id = user_id;
+            }
+        }
+
+        assert_eq!(total_booked, 1);
 
         let booked_seat = runner
             .query("query { findFirstSeat { id version userId } }")
-            .await?
+            .await
+            .unwrap()
             .to_json_value();
-        panic!("{:#?}", (results, booked_seat));
 
-        // // READ
-        // assert_query!(
-        //     runner,
-        //     "query { findFirstTestModel(where: { id: 1 }) { id }}",
-        //     r#"{"data":{"findFirstTestModel":{"id":1}}}"#
-        // );
+        let found_booked_user_id = booked_seat["data"]["findFirstSeat"]["userId"].as_u64().unwrap();
 
-        // assert_query!(
-        //     runner,
-        //     "query { findFirstTestModel2(where: { id: 1 }) { id, number }}",
-        //     r#"{"data":{"findFirstTestModel2":{"id":1,"number":1}}}"#
-        // );
+        assert_eq!(booked_user_id, found_booked_user_id);
+    }
 
-        // // UPDATE
-        // assert_query!(
-        //     runner,
-        //     r#"mutation { updateOneTestModel(where: { id: 1 }, data: { field: "two" }) { id } }"#,
-        //     r#"{"data":{"updateOneTestModel":{"id":1}}}"#
-        // );
+    #[connector_test(schema(occ_simple), exclude(MongoDB, CockroachDb))]
+    async fn occ_update_many_test(runner: Runner) -> TestResult<()> {
+        let runner = Arc::new(runner);
 
-        // assert_query!(
-        //     runner,
-        //     r#"mutation { updateOneTestModel2(where: { id: 1 }, data: { number: 2 }) { id } }"#,
-        //     r#"{"data":{"updateOneTestModel2":{"id":1}}}"#
-        // );
-
-        // assert_query!(
-        //     runner,
-        //     "query { findFirstTestModel(where: { id: 1 }) { id, field }}",
-        //     r#"{"data":{"findFirstTestModel":{"id":1,"field":"two"}}}"#
-        // );
-
-        // assert_query!(
-        //     runner,
-        //     "query { findFirstTestModel2(where: { id: 1 }) { id, number }}",
-        //     r#"{"data":{"findFirstTestModel2":{"id":1,"number":2}}}"#
-        // );
-
-        // // DELETE
-
-        // assert_query!(
-        //     runner,
-        //     "mutation { deleteOneTestModel(where: {id: 1}) { id } }",
-        //     r#"{"data":{"deleteOneTestModel":{"id":1}}}"#
-        // );
-
-        // assert_query!(
-        //     runner,
-        //     "mutation { deleteOneTestModel2(where: {id: 1}) { id } }",
-        //     r#"{"data":{"deleteOneTestModel2":{"id":1}}}"#
-        // );
-
-        // assert_query!(
-        //     runner,
-        //     "query { findFirstTestModel(where: { id: 1 }) { id, field }}",
-        //     r#"{"data":{"findFirstTestModel":null}}"#
-        // );
-
-        // assert_query!(
-        //     runner,
-        //     "query { findFirstTestModel2(where: { id: 1 }) { id, number }}",
-        //     r#"{"data":{"findFirstTestModel2":null}}"#
-        // );
+        // This test can give false positives so we run it a few times
+        // to make sure.
+        for _ in 0..=5 {
+            delete_seats(runner.clone()).await;
+            delete_users(runner.clone()).await;
+            run_occ_reproduce_test(runner.clone()).await;
+        }
 
         Ok(())
+    }
+
+    #[connector_test(schema(occ_simple), exclude(CockroachDb))]
+    async fn occ_update_test(runner: Runner) -> TestResult<()> {
+        let runner = Arc::new(runner);
+
+        create_one_resource(runner.clone()).await;
+
+        let mut set = tokio::task::JoinSet::new();
+
+        set.spawn(update_one_resource(runner.clone()));
+        set.spawn(update_one_resource(runner.clone()));
+        set.spawn(update_one_resource(runner.clone()));
+        set.spawn(update_one_resource(runner.clone()));
+
+        while (set.join_next().await).is_some() {}
+
+        let res = find_one_resource(runner).await;
+
+        let expected = serde_json::json!({
+            "data": {
+            "findFirstResource": {
+              "occStamp": 1,
+              "id": 1
+            }
+          }
+        });
+
+        assert_eq!(res, expected);
+
+        Ok(())
+    }
+
+    #[connector_test(schema(occ_simple))]
+    async fn occ_delete_test(runner: Runner) -> TestResult<()> {
+        let runner = Arc::new(runner);
+
+        create_one_resource(runner.clone()).await;
+
+        let mut set = tokio::task::JoinSet::new();
+
+        set.spawn(update_and_delete(runner.clone()));
+        set.spawn(update_and_delete(runner.clone()));
+        set.spawn(update_and_delete(runner.clone()));
+        set.spawn(update_and_delete(runner.clone()));
+        set.spawn(update_and_delete(runner.clone()));
+
+        while (set.join_next().await).is_some() {}
+
+        let res = find_one_resource(runner).await;
+
+        let expected = serde_json::json!({
+            "data": {
+            "findFirstResource": {
+              "occStamp": 1,
+              "id": 1
+            }
+          }
+        });
+
+        assert_eq!(res, expected);
+
+        Ok(())
+    }
+
+    #[connector_test(schema(occ_simple))]
+    async fn occ_delete_many_test(runner: Runner) -> TestResult<()> {
+        let runner = Arc::new(runner);
+
+        create_one_resource(runner.clone()).await;
+
+        let mut set = tokio::task::JoinSet::new();
+
+        set.spawn(delete_many_resource(runner.clone()));
+        set.spawn(delete_many_resource(runner.clone()));
+        set.spawn(delete_many_resource(runner.clone()));
+        set.spawn(delete_many_resource(runner.clone()));
+        set.spawn(delete_many_resource(runner.clone()));
+
+        let mut num_deleted: u64 = 0;
+        while let Some(res) = set.join_next().await {
+            if let Ok(row_count) = res {
+                if row_count > 0 {
+                    num_deleted += 1;
+                }
+            }
+        }
+
+        assert_eq!(num_deleted, 1);
+        let res = find_one_resource(runner).await;
+
+        let expected = serde_json::json!({
+            "data": {
+            "findFirstResource": serde_json::Value::Null
+          }
+        });
+        assert_eq!(res, expected);
+
+        Ok(())
+    }
+
+    // Because of the way upsert works this test is a little bit flaky. Ignoring until we fix upsert
+    #[allow(dead_code)]
+    #[ignore]
+    async fn occ_upsert_test(runner: Runner) -> TestResult<()> {
+        let runner = Arc::new(runner);
+
+        let mut set = tokio::task::JoinSet::new();
+
+        set.spawn(upsert_one_resource(runner.clone()));
+        set.spawn(upsert_one_resource(runner.clone()));
+        set.spawn(upsert_one_resource(runner.clone()));
+        set.spawn(upsert_one_resource(runner.clone()));
+        set.spawn(upsert_one_resource(runner.clone()));
+
+        while (set.join_next().await).is_some() {}
+
+        let res = find_one_resource(runner.clone()).await;
+
+        // MongoDB is different here and seems to only do one create with all the upserts
+        // where as all the sql databases will do one create and one upsert
+        let expected = if matches!(runner.connector(), ConnectorTag::MongoDb(_)) {
+            serde_json::json!({
+                "data": {
+                "findFirstResource": {
+                  "occStamp": 0,
+                  "id": 1
+                }
+              }
+            })
+        } else {
+            serde_json::json!({
+                "data": {
+                "findFirstResource": {
+                  "occStamp": 1,
+                  "id": 1
+                }
+              }
+            })
+        };
+        assert_eq!(res, expected);
+
+        Ok(())
+    }
+
+    async fn update_and_delete(runner: Arc<Runner>) {
+        update_one_resource(runner.clone()).await;
+        delete_one_resource(runner).await;
+    }
+
+    async fn create_one_resource(runner: Arc<Runner>) {
+        let create_one_resource = r#"
+        mutation {
+            createOneResource(data: {id: 1}) {
+              id
+            }
+          }"#;
+
+        runner.query(create_one_resource).await.unwrap().to_json_value();
+    }
+
+    async fn update_one_resource(runner: Arc<Runner>) -> serde_json::Value {
+        let update_one_resource = r#"
+        mutation {
+            updateOneResource(data: {occStamp: {increment: 1}}, where: {occStamp: 0}) {
+              occStamp,
+              id
+            }
+          }
+        "#;
+
+        runner.query(update_one_resource).await.unwrap().to_json_value()
+    }
+
+    #[allow(dead_code)]
+    async fn upsert_one_resource(runner: Arc<Runner>) -> serde_json::Value {
+        let upsert_one_resource = r#"
+        mutation {
+            upsertOneResource(where: {occStamp: 0}, 
+             create: {
+               occStamp: 0,
+               id: 1
+             },
+             update: {
+                 occStamp: {increment: 1}
+               }) {
+             id,
+             occStamp
+            }
+           }
+        "#;
+
+        runner.query(upsert_one_resource).await.unwrap().to_json_value()
+    }
+
+    async fn delete_one_resource(runner: Arc<Runner>) -> serde_json::Value {
+        let delete_one_resource = r#"
+        mutation {
+            deleteOneResource(where: {occStamp: 0}) {
+              occStamp,
+              id
+            }
+          }
+        "#;
+
+        runner.query(delete_one_resource).await.unwrap().to_json_value()
+    }
+
+    async fn delete_many_resource(runner: Arc<Runner>) -> u64 {
+        let delete_many_resource = r#"
+        mutation {
+            deleteManyResource(where: {occStamp: 0}) {
+              count
+            }
+          }
+        "#;
+
+        let res = runner.query(delete_many_resource).await.unwrap().to_json_value();
+
+        res["data"]["deleteManyResource"]["count"].as_u64().unwrap()
+    }
+
+    async fn find_one_resource(runner: Arc<Runner>) -> serde_json::Value {
+        let find_one_resource = r#"
+        {
+            findFirstResource(where: {}) {
+                occStamp,
+                id
+            }
+        }
+        "#;
+
+        runner.query(find_one_resource).await.unwrap().to_json_value()
     }
 }

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/occ.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/occ.rs
@@ -1,0 +1,141 @@
+use query_engine_tests::*;
+use std::sync::Arc;
+
+#[test_suite]
+mod occ {
+    pub fn occ_simple() -> String {
+        include_str!("occ_simple.prisma").to_owned()
+    }
+
+    #[connector_test(schema(occ_simple))]
+    async fn occ_simple_test(runner: Runner) -> TestResult<()> {
+        const USERS_COUNT: usize = 3;
+        let runner = Arc::new(runner);
+
+        // CREATE seat
+        runner
+            .query(r#"mutation { createOneSeat(data: { movie: "zardoz" }) { id } }"#)
+            .await?
+            .assert_success();
+
+        // CREATE users
+        for i in 1..=USERS_COUNT {
+            let query = format!(r#"mutation {{ createOneUser(data: {{ id: {i} }}) {{ id }} }}"#);
+            runner.query(query).await?.assert_success();
+        }
+
+        let (sender, mut receiver) = tokio::sync::mpsc::channel::<(usize, Option<u64>)>(USERS_COUNT);
+
+        for i in 1..=USERS_COUNT {
+            let sender = sender.clone();
+            let runner = Arc::clone(&runner);
+            tokio::spawn(async move {
+                let seat_query = "query { findFirstSeat(where: { movie: \"zardoz\", userId: null }) { id version } }";
+                let seat_result = runner.query(seat_query).await.unwrap().to_json_value();
+                let available_seat = &seat_result["data"]["findFirstSeat"];
+                let (available_seat_id, available_seat_version) = match available_seat {
+                    serde_json::Value::Null => {
+                        tracing::info!("no available seat for user {i}");
+                        sender.send((i, None)).await.unwrap();
+                        return Ok(());
+                    }
+                    other => (other["id"].as_u64().unwrap(), other["version"].as_u64().unwrap()),
+                };
+
+                let query = indoc::formatdoc!(
+                    r##"
+                      mutation {{
+                          updateManySeat(
+                              data: {{ userId: {i}, version: {{ increment: 1 }} }},
+                              where: {{ id: {available_seat_id}, version: {available_seat_version} }}
+                          )
+                          {{ count }}
+                      }}
+                    "##
+                );
+                let response = dbg!(runner.query(query).await?.to_json_value());
+                let seat_count = response["data"]["updateManySeat"]["count"].as_u64().unwrap();
+                sender.send((i, Some(seat_count))).await.unwrap();
+                TestResult::<()>::Ok(())
+            });
+        }
+
+        let mut results = Vec::new();
+
+        for _ in 0..USERS_COUNT {
+            results.push(receiver.recv().await.unwrap());
+        }
+
+        let booked_seat = runner
+            .query("query { findFirstSeat { id version userId } }")
+            .await?
+            .to_json_value();
+        panic!("{:#?}", (results, booked_seat));
+
+        // // READ
+        // assert_query!(
+        //     runner,
+        //     "query { findFirstTestModel(where: { id: 1 }) { id }}",
+        //     r#"{"data":{"findFirstTestModel":{"id":1}}}"#
+        // );
+
+        // assert_query!(
+        //     runner,
+        //     "query { findFirstTestModel2(where: { id: 1 }) { id, number }}",
+        //     r#"{"data":{"findFirstTestModel2":{"id":1,"number":1}}}"#
+        // );
+
+        // // UPDATE
+        // assert_query!(
+        //     runner,
+        //     r#"mutation { updateOneTestModel(where: { id: 1 }, data: { field: "two" }) { id } }"#,
+        //     r#"{"data":{"updateOneTestModel":{"id":1}}}"#
+        // );
+
+        // assert_query!(
+        //     runner,
+        //     r#"mutation { updateOneTestModel2(where: { id: 1 }, data: { number: 2 }) { id } }"#,
+        //     r#"{"data":{"updateOneTestModel2":{"id":1}}}"#
+        // );
+
+        // assert_query!(
+        //     runner,
+        //     "query { findFirstTestModel(where: { id: 1 }) { id, field }}",
+        //     r#"{"data":{"findFirstTestModel":{"id":1,"field":"two"}}}"#
+        // );
+
+        // assert_query!(
+        //     runner,
+        //     "query { findFirstTestModel2(where: { id: 1 }) { id, number }}",
+        //     r#"{"data":{"findFirstTestModel2":{"id":1,"number":2}}}"#
+        // );
+
+        // // DELETE
+
+        // assert_query!(
+        //     runner,
+        //     "mutation { deleteOneTestModel(where: {id: 1}) { id } }",
+        //     r#"{"data":{"deleteOneTestModel":{"id":1}}}"#
+        // );
+
+        // assert_query!(
+        //     runner,
+        //     "mutation { deleteOneTestModel2(where: {id: 1}) { id } }",
+        //     r#"{"data":{"deleteOneTestModel2":{"id":1}}}"#
+        // );
+
+        // assert_query!(
+        //     runner,
+        //     "query { findFirstTestModel(where: { id: 1 }) { id, field }}",
+        //     r#"{"data":{"findFirstTestModel":null}}"#
+        // );
+
+        // assert_query!(
+        //     runner,
+        //     "query { findFirstTestModel2(where: { id: 1 }) { id, number }}",
+        //     r#"{"data":{"findFirstTestModel2":null}}"#
+        // );
+
+        Ok(())
+    }
+}

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/occ_simple.prisma
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/occ_simple.prisma
@@ -1,0 +1,13 @@
+model User {
+  id   Int   @id
+  Seat Seat?
+}
+
+model Seat {
+  id        Int    @id @default(autoincrement())
+  movie     String @unique
+  userId    Int?   @unique
+  claimedBy User?  @relation(fields: [userId], references: [id])
+  version   Int    @default(0)
+  @@unique([id, version])
+}

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/occ_simple.prisma
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/occ_simple.prisma
@@ -1,13 +1,18 @@
 model User {
-  id   Int   @id
+  #id(id, Int, @id)
   Seat Seat?
 }
 
 model Seat {
-  id        Int    @id @default(autoincrement())
+  #id(id, Int, @id)
   movie     String @unique
   userId    Int?   @unique
   claimedBy User?  @relation(fields: [userId], references: [id])
   version   Int    @default(0)
   @@unique([id, version])
+}
+
+model Resource {
+  #id(id, Int, @id)
+  occStamp Int @default(0) @unique
 }

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_update/no_action.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_update/no_action.rs
@@ -176,6 +176,22 @@ mod one2one_opt {
             @r###"{"data":{"updateOneParent":{"id":1}}}"###
         );
 
+        Ok(())
+    }
+
+    /// Updating the parent succeeds if no child is connected.
+    #[connector_test]
+    async fn update_parent_with_many(runner: Runner) -> TestResult<()> {
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"mutation { createOneParent(data: { id: 1, uniq: "1" }) { id }}"#),
+          @r###"{"data":{"createOneParent":{"id":1}}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"mutation { createOneParent(data: { id: 2, uniq: "2" }) { id }}"#),
+          @r###"{"data":{"createOneParent":{"id":2}}}"###
+        );
+
         insta::assert_snapshot!(
             run_query!(&runner, r#"mutation { updateManyParent(where: { id: 1 }, data: { uniq: "u1" }) { count }}"#),
             @r###"{"data":{"updateManyParent":{"count":1}}}"###

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/query_engine_tests.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/query_engine_tests.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::module_inception, clippy::too_many_arguments)]
 
 mod new;
-// mod queries;
-// mod raw;
-// mod writes;
+mod queries;
+mod raw;
+mod writes;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/query_engine_tests.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/query_engine_tests.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::module_inception, clippy::too_many_arguments)]
 
 mod new;
-mod queries;
-mod raw;
-mod writes;
+// mod queries;
+// mod raw;
+// mod writes;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/create.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/create.rs
@@ -122,7 +122,7 @@ mod create {
     }
 
     // A Create Mutation should create and return item with explicit null values after previous mutation with explicit non-null values
-    #[connector_test]
+    #[connector_test(exclude(CockroachDb))]
     async fn return_item_non_null_attrs_then_explicit_null_attrs(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(&runner, r#"mutation {

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/update_many.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/update_many.rs
@@ -334,8 +334,23 @@ mod json_update_many {
         );
 
         insta::assert_snapshot!(
+          run_query!(&runner, r#"{ findFirstTestModel(where: {id: 1}) { id, json } }"#),
+          @r###"{"data":{"findFirstTestModel":{"id":1,"json":null}}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"mutation { updateManyTestModel(where: { id: 1 }, data: { json: "{}" }) { count }}"#),
+          @r###"{"data":{"updateManyTestModel":{"count":1}}}"###
+        );
+
+        insta::assert_snapshot!(
           run_query!(&runner, r#"mutation { updateManyTestModel(where: { id: 1 }, data: { json: null }) { count }}"#),
           @r###"{"data":{"updateManyTestModel":{"count":1}}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{ findFirstTestModel(where: {id: 1}) { id, json } }"#),
+          @r###"{"data":{"findFirstTestModel":{"id":1,"json":null}}}"###
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/query_result.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/query_result.rs
@@ -15,10 +15,8 @@ impl QueryResult {
     /// Asserts absence of errors in the result. Panics with assertion error.
     pub fn assert_success(&self) {
         if self.failed() {
-            dbg!(self.errors());
+            panic!("{}", self.to_string());
         }
-
-        assert!(!self.failed())
     }
 
     /// Asserts presence of errors in the result.

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/query_result.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/query_result.rs
@@ -71,6 +71,10 @@ impl QueryResult {
         }
     }
 
+    pub fn to_json_value(&self) -> serde_json::Value {
+        serde_json::to_value(&self.response).unwrap()
+    }
+
     pub fn to_string_pretty(&self) -> String {
         serde_json::to_string_pretty(&self.response).unwrap()
     }

--- a/query-engine/connectors/query-connector/src/interface.rs
+++ b/query-engine/connectors/query-connector/src/interface.rs
@@ -301,6 +301,16 @@ pub trait WriteOperations {
         trace_id: Option<String>,
     ) -> crate::Result<Vec<SelectionResult>>;
 
+    /// Update record in the `Model` with the given `WriteArgs` filtered by the
+    /// `Filter`.
+    async fn update_record(
+        &mut self,
+        model: &ModelRef,
+        record_filter: RecordFilter,
+        args: WriteArgs,
+        trace_id: Option<String>,
+    ) -> crate::Result<Option<SelectionResult>>;
+
     /// Delete records in the `Model` with the given `Filter`.
     async fn delete_records(
         &mut self,

--- a/query-engine/connectors/query-connector/src/lib.rs
+++ b/query-engine/connectors/query-connector/src/lib.rs
@@ -18,3 +18,13 @@ pub use query_arguments::*;
 pub use write_args::*;
 
 pub type Result<T> = std::result::Result<T, error::ConnectorError>;
+
+/// When we write a single record using this update_records function, we always
+/// want the id of the changed record back. Even if the row wasn't updated. This can happen in situations where
+/// we could increment a null value and the update count would be zero for mysql.
+/// However when we updating any records we want to return an empty array if zero items were updated
+#[derive(PartialEq)]
+pub enum UpdateType {
+    Many,
+    One,
+}

--- a/query-engine/connectors/sql-query-connector/src/database/transaction.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/transaction.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use connector::{ConnectionLike, RelAggregationSelection};
 use connector_interface::{
     self as connector, filter::Filter, AggregationRow, AggregationSelection, QueryArguments, ReadOperations,
-    RecordFilter, Transaction, WriteArgs, WriteOperations,
+    RecordFilter, Transaction, UpdateType, WriteArgs, WriteOperations,
 };
 use prisma_models::{prelude::*, SelectionResult};
 use prisma_value::PrismaValue;
@@ -190,7 +190,22 @@ impl<'tx> WriteOperations for SqlConnectorTransaction<'tx> {
         trace_id: Option<String>,
     ) -> connector::Result<Vec<SelectionResult>> {
         catch(self.connection_info.clone(), async move {
-            write::update_records(&self.inner, model, record_filter, args, trace_id).await
+            write::update_records(&self.inner, model, record_filter, args, UpdateType::Many, trace_id).await
+        })
+        .await
+    }
+
+    async fn update_record(
+        &mut self,
+        model: &ModelRef,
+        record_filter: RecordFilter,
+        args: WriteArgs,
+        trace_id: Option<String>,
+    ) -> connector::Result<Option<SelectionResult>> {
+        catch(self.connection_info.clone(), async move {
+            let mut res =
+                write::update_records(&self.inner, model, record_filter, args, UpdateType::One, trace_id).await?;
+            Ok(res.pop())
         })
         .await
     }

--- a/query-engine/connectors/sql-query-connector/src/join_utils.rs
+++ b/query-engine/connectors/sql-query-connector/src/join_utils.rs
@@ -74,7 +74,7 @@ fn compute_aggr_join_one2m(
     };
     let select_columns = right_fields.iter().map(|f| f.as_column());
     let conditions: ConditionTree = filter
-        .map(|f| f.aliased_cond(None, false))
+        .map(|f| f.aliased_condition_from(None, false))
         .unwrap_or(ConditionTree::NoCondition);
 
     // + SELECT Child.<fk> FROM Child WHERE <FILTER>
@@ -151,7 +151,7 @@ fn compute_aggr_join_m2m(
     let parent_ids: ModelProjection = rf.model().primary_identifier().into();
     // Rendered filters
     let conditions: ConditionTree = filter
-        .map(|f| f.aliased_cond(None, false))
+        .map(|f| f.aliased_condition_from(None, false))
         .unwrap_or(ConditionTree::NoCondition);
 
     // + SELECT _ParentToChild.ChildId FROM Child WHERE <FILTER>

--- a/query-engine/connectors/sql-query-connector/src/query_builder/read.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_builder/read.rs
@@ -67,7 +67,7 @@ impl SelectDefinition for QueryArguments {
 
         let filter: ConditionTree = self
             .filter
-            .map(|f| f.aliased_cond(None, false))
+            .map(|f| f.aliased_condition_from(None, false))
             .unwrap_or(ConditionTree::NoCondition);
 
         let conditions = match (filter, cursor_condition) {
@@ -253,7 +253,7 @@ pub fn group_by_aggregate(
     );
 
     match having {
-        Some(filter) => grouped.having(filter.aliased_cond(None, false)),
+        Some(filter) => grouped.having(filter.aliased_condition_from(None, false)),
         None => grouped,
     }
 }

--- a/query-engine/connectors/sql-query-connector/src/query_ext.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_ext.rs
@@ -163,7 +163,7 @@ pub trait QueryExt: Queryable + Send + Sync {
             .columns(id_cols)
             .append_trace(&Span::current())
             .add_trace_id(trace_id.clone())
-            .so_that(filter.aliased_cond(None, false));
+            .so_that(filter.aliased_condition_from(None, false));
 
         self.select_ids(select, model_id, trace_id).await
     }

--- a/query-engine/core/src/interpreter/query_interpreters/write.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/write.rs
@@ -62,9 +62,9 @@ async fn update_one(
     q: UpdateRecord,
     trace_id: Option<String>,
 ) -> InterpretationResult<QueryResult> {
-    let mut res = tx.update_records(&q.model, q.record_filter, q.args, trace_id).await?;
+    let res = tx.update_record(&q.model, q.record_filter, q.args, trace_id).await?;
 
-    Ok(QueryResult::Id(res.pop()))
+    Ok(QueryResult::Id(res))
 }
 
 async fn delete_one(


### PR DESCRIPTION
Improve the update and delete many to carry the full filter through to the update or delete. This avoids race conditions when a user manually implements occ. 

Fixes https://github.com/prisma/prisma/issues/8612