### PR TITLE
Downgrade `tracing-subscriber` due to a regression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4776,13 +4776,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.15"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60db860322da191b40952ad9affe65ea23e7dd6a5c442c2c42865810c6ab8e6b"
+checksum = "4bc28f93baff38037f64e6f43d34cfa1605f27a49c34e8a04c5e78b0babf2596"
 dependencies = [
  "ansi_term 0.12.1",
+ "lazy_static",
  "matchers",
- "once_cell",
  "regex",
  "serde",
  "serde_json",
@@ -4937,13 +4937,12 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "2.2.2"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+checksum = "22fe195a4f217c25b25cb5058ced57059824a678474874038dc88d211bf508d3"
 dependencies = [
  "form_urlencoded",
  "idna",
- "matches",
  "percent-encoding",
  "serde",
 ]


### PR DESCRIPTION
By doing a routing update to the dependencies, our CI gave an alarm that our logging layer doesn't produce any logs anymore. By going meticulously through every dependency, the culprit was `tracing-subscriber` updating from `0.3.11` to `0.3.15`. This minor upgrade introduced a regression, which set the log level to `none` always; hence missing logs. The issue is a good read for understanding the problem:

https://github.com/tokio-rs/tracing/issues/2265

In our code, we trigger this behavior by providing a filter that is `None` to the registry. This means in two places, if either tracing or metrics is not enabled, we pass `None` to the registry creation and lose all our logs:

https://github.com/prisma/prisma-engines/blob/main/query-engine/query-engine-node-api/src/logger.rs#L53-L74

Therefore, we now update everything else except `tracing-subscriber`, and we keep monitoring the issue for a resolution.