### PR TITLE
 qe+postgres: exclude `contains` filters on uuid fields

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,5 @@
 # Contributing
+
 Contributions include code, documentation, answering user questions, running the
 project's infrastructure, and advocating for all types of users.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3735,11 +3735,11 @@ dependencies = [
 name = "schema-builder"
 version = "0.1.0"
 dependencies = [
- "datamodel-connector",
  "itertools",
  "lazy_static",
  "once_cell",
  "prisma-models",
+ "psl",
  "schema",
 ]
 

--- a/libs/datamodel/connectors/datamodel-connector/src/filters.rs
+++ b/libs/datamodel/connectors/datamodel-connector/src/filters.rs
@@ -1,0 +1,40 @@
+//! Client filter types.
+
+#![deny(missing_docs)]
+
+use enumflags2::*;
+
+macro_rules! filters {
+    ($(#[$docs:meta] $variant:ident,)*) => {
+        /// Available filters for a given `String` scalar field.
+        #[bitflags]
+        #[derive(Debug, Clone, Copy)]
+        #[repr(u8)]
+        pub enum StringFilter {
+            $(#[$docs] $variant),*
+        }
+
+        impl StringFilter {
+            /// The property name of the filter in the client API.
+            pub fn name(&self) -> String {
+                let pascal_cased_name = match self {
+                    $(StringFilter::$variant => stringify!($variant)),*
+                };
+                let mut out = pascal_cased_name.to_owned();
+                out[0..1].make_ascii_lowercase(); // camel case it
+                out
+            }
+        }
+    };
+}
+
+filters! {
+    /// String equality.
+    Equals,
+    /// String contains another string.
+    Contains,
+    /// String starts with another string.
+    StartsWith,
+    /// String ends with another string.
+    EndsWith,
+}

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/mod.rs
@@ -21,6 +21,7 @@ pub mod relation_null;
 pub mod search_filter;
 pub mod self_relation;
 pub mod self_relation_regression;
+pub mod uuid_filters;
 pub mod where_unique;
 
 /// Creates test data used by filter tests using the `common_nullable_types` schema.

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/uuid_filters.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/uuid_filters.rs
@@ -1,0 +1,46 @@
+use query_engine_tests::*;
+
+#[test_suite(schema(schema), only(Postgres))]
+mod uuid_filter_spec {
+    fn schema() -> String {
+        r#"
+            model Cat {
+                id String @test.Uuid @id
+            }
+        "#
+        .to_owned()
+    }
+
+    // LIKE queries, or in general substring queries on postgres do not work on UUID columns. Our API
+    // must reflect that.
+    #[connector_test]
+    async fn contains_filter_is_rejected(runner: Runner) -> TestResult<()> {
+        // fb37a902-f54b-4520-8c90-8c0e4c7fd31d
+        // 5c517461-3eb8-4fd9-85ae-83582d2ee003
+        // execute the insert
+        run_query!(
+            runner,
+            r#"mutation { createManyCat(data: [{ id: "fb37a902-f54b-4520-8c90-8c0e4c7fd31d" }, { id: "5c517461-3eb8-4fd9-85ae-83582d2ee003" } ]) { count } }"#
+        );
+
+        // check that equality works
+        let filtered = run_query!(
+            runner,
+            r#"query { findManyCat(where: { id: "fb37a902-f54b-4520-8c90-8c0e4c7fd31d" }) { id } }"#
+        );
+        assert_eq!(
+            filtered,
+            "{\"data\":{\"findManyCat\":[{\"id\":\"fb37a902-f54b-4520-8c90-8c0e4c7fd31d\"}]}}"
+        );
+
+        // check that contains does not
+        assert_error!(
+            runner,
+            r#"query { findManyCat(where: { id: { contains: "fb37a902-f54b-4520-8c90-8c0e4c7fd31d" } }) { id } }"#,
+            2009,
+            r#"Query.findManyCat.where.CatWhereInput.id.UuidFilter.contains`: Field does not exist on enclosing type."#
+        );
+
+        Ok(())
+    }
+}

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/direct.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/direct.rs
@@ -29,7 +29,7 @@ impl RunnerInterface for DirectRunner {
         let query_schema: QuerySchemaRef = Arc::new(schema_builder::build(
             internal_data_model,
             true,
-            data_source.capabilities(),
+            data_source.active_connector,
             preview_features,
             data_source.referential_integrity(),
         ));

--- a/query-engine/dmmf/src/lib.rs
+++ b/query-engine/dmmf/src/lib.rs
@@ -26,7 +26,7 @@ pub fn dmmf_from_schema(schema: &str) -> DataModelMetaFormat {
     let query_schema = Arc::new(schema_builder::build(
         internal_data_model,
         true, // todo
-        data_source.capabilities(),
+        data_source.active_connector,
         preview_features,
         data_source.referential_integrity(),
     ));

--- a/query-engine/query-engine-node-api/src/engine.rs
+++ b/query-engine/query-engine-node-api/src/engine.rs
@@ -252,7 +252,7 @@ impl QueryEngine {
                 let query_schema = schema_builder::build(
                     internal_data_model,
                     true, // enable raw queries
-                    data_source.capabilities(),
+                    data_source.active_connector,
                     preview_features,
                     data_source.referential_integrity(),
                 );

--- a/query-engine/query-engine/src/context.rs
+++ b/query-engine/query-engine/src/context.rs
@@ -79,7 +79,7 @@ impl PrismaContext {
         let query_schema: QuerySchemaRef = Arc::new(schema_builder::build(
             internal_data_model,
             enable_raw_queries,
-            data_source.capabilities(),
+            data_source.active_connector,
             preview_features,
             data_source.referential_integrity(),
         ));

--- a/query-engine/schema-builder/Cargo.toml
+++ b/query-engine/schema-builder/Cargo.toml
@@ -4,9 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+psl = { path = "../../psl/psl" }
 schema = { path = "../schema" }
 prisma-models = { path = "../prisma-models" }
 once_cell = "1.3"
-datamodel-connector = { path = "../../libs/datamodel/connectors/datamodel-connector" }
 itertools = "0.10"
 lazy_static = "1.4"

--- a/query-engine/schema-builder/src/input_types/fields/input_fields.rs
+++ b/query-engine/schema-builder/src/input_types/fields/input_fields.rs
@@ -2,7 +2,7 @@ use super::objects::*;
 use super::*;
 use crate::mutations::{create_many, create_one};
 use constants::{args, operations};
-use datamodel_connector::ConnectorCapability;
+use psl::datamodel_connector::ConnectorCapability;
 
 pub(crate) fn filter_input_field(ctx: &mut BuilderContext, field: &ModelField, include_aggregates: bool) -> InputField {
     let types = field_filter_types::get_field_filter_types(ctx, field, include_aggregates);
@@ -38,7 +38,7 @@ pub(crate) fn nested_create_many_input_field(
     ctx: &mut BuilderContext,
     parent_field: &RelationFieldRef,
 ) -> Option<InputField> {
-    if ctx.capabilities.contains(ConnectorCapability::CreateMany)
+    if ctx.has_capability(ConnectorCapability::CreateMany)
         && parent_field.is_list()
         && !parent_field.is_inlined_on_enclosing_model()
         && !parent_field.relation().is_many_to_many()
@@ -65,7 +65,7 @@ fn nested_create_many_envelope(ctx: &mut BuilderContext, parent_field: &Relation
     let create_many_type = InputType::object(create_type);
     let data_arg = input_field("data", InputType::list(create_many_type), None);
 
-    let fields = if ctx.capabilities.contains(ConnectorCapability::CreateSkipDuplicates) {
+    let fields = if ctx.has_capability(ConnectorCapability::CreateSkipDuplicates) {
         let skip_arg = input_field(args::SKIP_DUPLICATES, InputType::boolean(), None).optional();
 
         vec![data_arg, skip_arg]

--- a/query-engine/schema-builder/src/input_types/objects/order_by_objects.rs
+++ b/query-engine/schema-builder/src/input_types/objects/order_by_objects.rs
@@ -139,7 +139,7 @@ fn orderby_field_mapper(field: &ModelField, ctx: &mut BuilderContext, options: &
             let mut types = vec![InputType::Enum(sort_order_enum(ctx))];
 
             if ctx.has_feature(&PreviewFeature::OrderByNulls)
-                && ctx.capabilities.contains(ConnectorCapability::OrderByNullsFirstLast)
+                && ctx.has_capability(ConnectorCapability::OrderByNullsFirstLast)
                 && !sf.is_required()
                 && !sf.is_list()
             {

--- a/query-engine/schema-builder/src/input_types/objects/update_one_objects.rs
+++ b/query-engine/schema-builder/src/input_types/objects/update_one_objects.rs
@@ -1,7 +1,6 @@
-use super::fields::data_input_mapper::*;
-use super::*;
+use super::{fields::data_input_mapper::*, *};
 use constants::args;
-use datamodel_connector::ConnectorCapability;
+use psl::datamodel_connector::ConnectorCapability;
 
 pub(crate) fn update_one_input_types(
     ctx: &mut BuilderContext,
@@ -97,7 +96,7 @@ pub(super) fn filter_checked_update_fields(
                     let model_id = sf.container.as_model().unwrap().primary_identifier();
                     let is_not_disallowed_id = if model_id.contains(&sf.name) {
                         // Is part of the id, connector must allow updating ID fields.
-                        ctx.capabilities.contains(ConnectorCapability::UpdateableId)
+                        ctx.has_capability(ConnectorCapability::UpdateableId)
                     } else {
                         true
                     };
@@ -154,7 +153,7 @@ pub(super) fn filter_unchecked_update_fields(
                     && if let Some(ref id_fields) = &id_fields {
                         // Exclude @@id or @id fields if not updatable
                         if id_fields.contains(sf) {
-                            ctx.capabilities.contains(ConnectorCapability::UpdateableId)
+                            ctx.has_capability(ConnectorCapability::UpdateableId)
                         } else {
                             true
                         }

--- a/query-engine/schema-builder/src/lib.rs
+++ b/query-engine/schema-builder/src/lib.rs
@@ -30,9 +30,10 @@
 //! The cache can be consumed to produce a list of strong references to the individual input and output
 //! object types, which are then moved to the query schema to keep weak references alive (see TypeRefCache for additional infos).
 
+pub mod constants;
+
 #[macro_use]
 mod cache;
-pub mod constants;
 mod enum_types;
 mod input_types;
 mod mutations;
@@ -40,11 +41,11 @@ mod output_types;
 mod utils;
 
 use cache::TypeRefCache;
-use datamodel_connector::{ConnectorCapabilities, ConnectorCapability, ReferentialIntegrity};
 use prisma_models::{
     psl::common::preview_features::PreviewFeature, CompositeTypeRef, Field as ModelField, Index, InternalDataModelRef,
     ModelRef, RelationFieldRef, TypeIdentifier,
 };
+use psl::datamodel_connector::{Connector, ConnectorCapability, ReferentialIntegrity};
 use schema::*;
 use std::sync::Arc;
 
@@ -54,7 +55,7 @@ pub(crate) struct BuilderContext {
     internal_data_model: InternalDataModelRef,
     enable_raw_queries: bool,
     cache: TypeCache,
-    capabilities: ConnectorCapabilities,
+    connector: &'static dyn Connector,
     preview_features: Vec<PreviewFeature>,
     nested_create_inputs_queue: NestedInputsQueue,
     nested_update_inputs_queue: NestedInputsQueue,
@@ -65,14 +66,14 @@ impl BuilderContext {
     pub fn new(
         internal_data_model: InternalDataModelRef,
         enable_raw_queries: bool,
-        capabilities: ConnectorCapabilities,
+        connector: &'static dyn Connector,
         preview_features: Vec<PreviewFeature>,
     ) -> Self {
         Self {
             internal_data_model,
             enable_raw_queries,
             cache: TypeCache::new(),
-            capabilities,
+            connector,
             preview_features,
             nested_create_inputs_queue: Vec::new(),
             nested_update_inputs_queue: Vec::new(),
@@ -84,7 +85,7 @@ impl BuilderContext {
     }
 
     pub fn has_capability(&self, capability: ConnectorCapability) -> bool {
-        self.capabilities.contains(capability)
+        self.connector.has_capability(capability)
     }
 
     /// Get an input (object) type.
@@ -130,6 +131,10 @@ impl BuilderContext {
     pub fn composite_types(&self) -> Vec<CompositeTypeRef> {
         self.internal_data_model.composite_types().to_owned()
     }
+
+    pub fn supports_any(&self, capabilities: &[ConnectorCapability]) -> bool {
+        capabilities.iter().any(|c| self.connector.has_capability(*c))
+    }
 }
 
 #[derive(Debug)]
@@ -170,14 +175,14 @@ impl TypeCache {
 pub fn build(
     internal_data_model: InternalDataModelRef,
     enable_raw_queries: bool,
-    capabilities: ConnectorCapabilities,
+    connector: &'static dyn Connector,
     preview_features: Vec<PreviewFeature>,
     referential_integrity: ReferentialIntegrity,
 ) -> QuerySchema {
     let mut ctx = BuilderContext::new(
         internal_data_model,
         enable_raw_queries,
-        capabilities,
+        connector,
         preview_features.clone(),
     );
 
@@ -206,7 +211,7 @@ pub fn build(
         output_objects,
         enum_types,
         ctx.internal_data_model,
-        ctx.capabilities.capabilities,
+        ctx.connector.capabilities().to_owned(),
         preview_features,
         referential_integrity,
     )

--- a/query-engine/schema-builder/src/mutations/create_many.rs
+++ b/query-engine/schema-builder/src/mutations/create_many.rs
@@ -8,8 +8,8 @@ use crate::{
     output_types::objects,
     BuilderContext, ModelField,
 };
-use datamodel_connector::ConnectorCapability;
 use prisma_models::{ModelRef, RelationFieldRef};
+use psl::datamodel_connector::ConnectorCapability;
 use schema::{
     Identifier, InputField, InputObjectTypeWeakRef, InputType, OutputField, OutputType, QueryInfo, QueryTag,
     PRISMA_NAMESPACE,

--- a/query-engine/schema-builder/src/output_types/mutation_type.rs
+++ b/query-engine/schema-builder/src/output_types/mutation_type.rs
@@ -1,9 +1,8 @@
-use crate::mutations::{create_many, create_one};
-
 use super::*;
-use datamodel_connector::ConnectorCapability;
+use crate::mutations::{create_many, create_one};
 use input_types::fields::{arguments, input_fields};
 use prisma_models::{dml, PrismaValue};
+use psl::datamodel_connector::ConnectorCapability;
 
 /// Builds the root `Mutation` type.
 pub(crate) fn build(ctx: &mut BuilderContext) -> (OutputType, ObjectTypeStrongRef) {
@@ -32,12 +31,12 @@ pub(crate) fn build(ctx: &mut BuilderContext) -> (OutputType, ObjectTypeStrongRe
 
     create_nested_inputs(ctx);
 
-    if ctx.enable_raw_queries && ctx.capabilities.contains(ConnectorCapability::SqlQueryRaw) {
+    if ctx.enable_raw_queries && ctx.has_capability(ConnectorCapability::SqlQueryRaw) {
         fields.push(create_execute_raw_field());
         fields.push(create_query_raw_field());
     }
 
-    if ctx.enable_raw_queries && ctx.capabilities.contains(ConnectorCapability::MongoDbQueryRaw) {
+    if ctx.enable_raw_queries && ctx.has_capability(ConnectorCapability::MongoDbQueryRaw) {
         fields.push(create_mongodb_run_command_raw());
     }
 


### PR DESCRIPTION
Internal doc on the problem and suggested solution: https://www.notion.so/prismaio/UUID-filters-in-Client-90da479ef4014b20bb846cbb572fb47e

The story on how to fix this became slightly more complicated than in
the spec.

The problem is that the string filters are registered on a global
`StringFilters` GraphQL input object type. All string fields have a
`StringFilters` input type for filtering over them. There cannot be two
different `StringFilters`, because this is not possible in the first
place in a GraphQL schema, and besides that input object types are
cached/memoized by name in schema-builder. For the adapted UUID filters,
we have to create a `UuidFilters` input type. The `scalar_filter_name()`
method on Connector takes care of that. It can evolve towards a more
typed API over time.

closes https://github.com/prisma/prisma/issues/9007