### PR TITLE
psl: shrink public API

### DIFF
--- a/libs/datamodel/core/src/lib.rs
+++ b/libs/datamodel/core/src/lib.rs
@@ -43,13 +43,6 @@ pub struct Validated<T> {
 pub type ValidatedDatamodel = Validated<dml::Datamodel>;
 pub type ValidatedConfiguration = Validated<Configuration>;
 
-/// Parse and validate the whole schema
-pub fn parse_schema(schema_str: &str) -> Result<(Configuration, dml::Datamodel), String> {
-    parse_datamodel_internal(schema_str)
-        .map_err(|err| err.to_pretty_string("schema.prisma", schema_str))
-        .map(|v| v.subject)
-}
-
 pub struct ValidatedSchema {
     pub configuration: Configuration,
     pub db: parser_database::ParserDatabase,

--- a/libs/datamodel/core/src/lib.rs
+++ b/libs/datamodel/core/src/lib.rs
@@ -130,15 +130,6 @@ fn parse_datamodel_internal(
     })
 }
 
-pub fn parse_schema_ast(datamodel_string: &str) -> Result<ast::SchemaAst, diagnostics::Diagnostics> {
-    let mut diagnostics = Diagnostics::default();
-    let schema = schema_ast::parse_schema(datamodel_string, &mut diagnostics);
-
-    diagnostics.to_result()?;
-
-    Ok(schema)
-}
-
 /// Loads all configuration blocks from a datamodel using the built-in source definitions.
 pub fn parse_configuration(schema: &str) -> Result<ValidatedConfiguration, diagnostics::Diagnostics> {
     let mut diagnostics = Diagnostics::default();

--- a/libs/datamodel/schema-ast/src/source_file.rs
+++ b/libs/datamodel/schema-ast/src/source_file.rs
@@ -27,9 +27,9 @@ impl SourceFile {
     }
 }
 
-impl From<&'static str> for SourceFile {
-    fn from(s: &'static str) -> Self {
-        Self::new_static(s)
+impl From<&str> for SourceFile {
+    fn from(s: &str) -> Self {
+        Self::new_allocated(Arc::from(s.to_owned().into_boxed_str()))
     }
 }
 

--- a/prisma-fmt/src/code_actions.rs
+++ b/prisma-fmt/src/code_actions.rs
@@ -2,10 +2,8 @@ mod relations;
 
 use datamodel::{
     datamodel_connector::Diagnostics,
-    parse_schema_ast,
     parser_database::{ast, walkers::RefinedRelationWalker, ParserDatabase, SourceFile},
 };
-use log::warn;
 use lsp_types::{CodeActionOrCommand, CodeActionParams, Diagnostic};
 use std::sync::Arc;
 
@@ -14,11 +12,6 @@ pub(crate) fn empty_code_actions() -> Vec<CodeActionOrCommand> {
 }
 
 pub(crate) fn available_actions(schema: String, params: CodeActionParams) -> Vec<CodeActionOrCommand> {
-    if parse_schema_ast(&schema).is_err() {
-        warn!("Failed to parse schema AST in code action request.");
-        return empty_code_actions();
-    };
-
     let mut actions = Vec::new();
 
     let file = SourceFile::new_allocated(Arc::from(schema.into_boxed_str()));

--- a/prisma-fmt/src/text_document_completion.rs
+++ b/prisma-fmt/src/text_document_completion.rs
@@ -1,6 +1,6 @@
 use datamodel::{
     datamodel_connector::{Connector, Diagnostics, ReferentialIntegrity},
-    parse_configuration, parse_schema_ast,
+    parse_configuration,
     parser_database::{ast, ParserDatabase, SourceFile},
 };
 use log::*;
@@ -15,10 +15,6 @@ pub(crate) fn empty_completion_list() -> CompletionList {
 }
 
 pub(crate) fn completion(schema: String, params: CompletionParams) -> CompletionList {
-    if parse_schema_ast(&schema).is_err() {
-        warn!("Failed to parse schema AST in completion request.");
-        return empty_completion_list();
-    };
     let source_file = SourceFile::new_allocated(Arc::from(schema.into_boxed_str()));
 
     let position =

--- a/prisma-fmt/tests/text_document_completion/scenarios/extended_indexes_basic/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/extended_indexes_basic/result.json
@@ -1,4 +1,4 @@
 {
-  "isIncomplete": true,
+  "isIncomplete": false,
   "items": []
 }

--- a/psl/psl/tests/attributes/default_composite_positive.rs
+++ b/psl/psl/tests/attributes/default_composite_positive.rs
@@ -129,7 +129,7 @@ fn string_literals_with_double_quotes_work() {
         }
     "#;
 
-    let (_, datamodel) = parse_schema(schema).unwrap();
+    let datamodel = parse(schema);
     let test_composite = datamodel.assert_has_composite_type("Test");
     test_composite
         .assert_has_scalar_field("id")

--- a/psl/psl/tests/attributes/default_positive.rs
+++ b/psl/psl/tests/attributes/default_positive.rs
@@ -177,7 +177,7 @@ fn string_literals_with_double_quotes_work() {
         }
     "#;
 
-    let (_, datamodel) = parse_schema(schema).unwrap();
+    let datamodel = parse(schema);
     let test_model = datamodel.assert_has_model("Test");
     test_model
         .assert_has_scalar_field("id")
@@ -206,7 +206,7 @@ fn mongodb_auto_id() {
         }
     "#};
 
-    let (_, datamodel) = parse_schema(dml).unwrap();
+    let datamodel = parse(dml);
 
     datamodel
         .assert_has_model("a")

--- a/psl/psl/tests/attributes/id_positive.rs
+++ b/psl/psl/tests/attributes/id_positive.rs
@@ -414,7 +414,7 @@ fn mysql_allows_id_length_prefix() {
         }
     "#};
     let schema = with_header(dml, Provider::Mysql, &[]);
-    assert!(parse_schema(&schema).is_ok());
+    assert_valid(&schema);
 }
 
 #[test]
@@ -429,7 +429,7 @@ fn mysql_allows_compound_id_length_prefix() {
     "#};
 
     let schema = with_header(dml, Provider::Mysql, &[]);
-    assert!(parse_schema(&schema).is_ok());
+    assert_valid(&schema);
 }
 
 #[test]
@@ -441,7 +441,7 @@ fn mssql_allows_id_sort_argument() {
     "#};
 
     let schema = with_header(dml, Provider::SqlServer, &[]);
-    assert!(parse_schema(&schema).is_ok());
+    assert_valid(&schema);
 }
 
 #[test]
@@ -456,7 +456,7 @@ fn mssql_allows_compound_id_sort_argument() {
     "#};
 
     let schema = with_header(dml, Provider::SqlServer, &[]);
-    assert!(parse_schema(&schema).is_ok());
+    assert_valid(&schema);
 }
 
 #[test]
@@ -471,5 +471,5 @@ fn mongodb_compound_unique_can_have_id_as_part_of_it() {
     "#};
 
     let schema = with_header(dml, Provider::Mongo, &[]);
-    assert!(parse_schema(&schema).is_ok());
+    assert_valid(&schema);
 }

--- a/psl/psl/tests/attributes/index_clustering.rs
+++ b/psl/psl/tests/attributes/index_clustering.rs
@@ -157,8 +157,7 @@ fn render_id_non_default_clustering() {
     "#]];
 
     let schema = with_header(input, Provider::SqlServer, &[]);
-    let (config, dml) = parse_schema(&schema).unwrap();
-    let rendered = psl::render_datamodel_to_string(&dml, Some(&config));
+    let rendered = rerender(&schema);
 
     expected.assert_eq(&rendered);
 }
@@ -184,8 +183,7 @@ fn do_not_render_compound_id_default_clustering() {
     "#]];
 
     let schema = with_header(input, Provider::SqlServer, &[]);
-    let (config, dml) = parse_schema(&schema).unwrap();
-    let rendered = psl::render_datamodel_to_string(&dml, Some(&config));
+    let rendered = rerender(&schema);
 
     expected.assert_eq(&rendered);
 }
@@ -211,8 +209,7 @@ fn render_compound_id_default_clustering() {
     "#]];
 
     let schema = with_header(input, Provider::SqlServer, &[]);
-    let (config, dml) = parse_schema(&schema).unwrap();
-    let rendered = psl::render_datamodel_to_string(&dml, Some(&config));
+    let rendered = rerender(&schema);
 
     expected.assert_eq(&rendered);
 }
@@ -238,8 +235,7 @@ fn do_not_render_index_default_clustering() {
     "#]];
 
     let schema = with_header(input, Provider::SqlServer, &[]);
-    let (config, dml) = parse_schema(&schema).unwrap();
-    let rendered = psl::render_datamodel_to_string(&dml, Some(&config));
+    let rendered = rerender(&schema);
 
     expected.assert_eq(&rendered);
 }
@@ -265,8 +261,7 @@ fn render_index_non_default_clustering() {
     "#]];
 
     let schema = with_header(input, Provider::SqlServer, &[]);
-    let (config, dml) = parse_schema(&schema).unwrap();
-    let rendered = psl::render_datamodel_to_string(&dml, Some(&config));
+    let rendered = rerender(&schema);
 
     expected.assert_eq(&rendered);
 }
@@ -288,8 +283,7 @@ fn do_not_render_unique_default_clustering() {
     "#]];
 
     let schema = with_header(input, Provider::SqlServer, &[]);
-    let (config, dml) = parse_schema(&schema).unwrap();
-    let rendered = psl::render_datamodel_to_string(&dml, Some(&config));
+    let rendered = rerender(&schema);
 
     expected.assert_eq(&rendered);
 }
@@ -311,8 +305,7 @@ fn render_unique_non_default_clustering() {
     "#]];
 
     let schema = with_header(input, Provider::SqlServer, &[]);
-    let (config, dml) = parse_schema(&schema).unwrap();
-    let rendered = psl::render_datamodel_to_string(&dml, Some(&config));
+    let rendered = rerender(&schema);
 
     expected.assert_eq(&rendered);
 }
@@ -340,8 +333,7 @@ fn do_not_render_compound_unique_default_clustering() {
     "#]];
 
     let schema = with_header(input, Provider::SqlServer, &[]);
-    let (config, dml) = parse_schema(&schema).unwrap();
-    let rendered = psl::render_datamodel_to_string(&dml, Some(&config));
+    let rendered = rerender(&schema);
 
     expected.assert_eq(&rendered);
 }
@@ -369,8 +361,7 @@ fn render_compound_unique_non_default_clustering() {
     "#]];
 
     let schema = with_header(input, Provider::SqlServer, &[]);
-    let (config, dml) = parse_schema(&schema).unwrap();
-    let rendered = psl::render_datamodel_to_string(&dml, Some(&config));
+    let rendered = rerender(&schema);
 
     expected.assert_eq(&rendered);
 }

--- a/psl/psl/tests/attributes/relations/referential_actions/cycle_detection.rs
+++ b/psl/psl/tests/attributes/relations/referential_actions/cycle_detection.rs
@@ -102,7 +102,7 @@ fn cycles_are_allowed_outside_of_emulation_and_sqlserver() {
         }
     "#};
 
-    assert!(parse_schema(dml).is_ok());
+    assert_valid(dml)
 }
 
 #[test]
@@ -938,5 +938,5 @@ fn separate_non_crossing_cascade_paths_should_work() {
         }
     "#;
 
-    assert!(parse_schema(dm).is_ok());
+    assert_valid(dm)
 }

--- a/psl/psl/tests/base/base_types.rs
+++ b/psl/psl/tests/base/base_types.rs
@@ -180,7 +180,7 @@ fn json_type_must_work_for_some_connectors() {
         .assert_has_scalar_field("json")
         .assert_base_type(&ScalarType::Json);
 
-    let error = parse_schema(&format!("{}\n{}", SQLITE_SOURCE, dml)).unwrap_err();
+    let error = parse_unwrap_err(&format!("{}\n{}", SQLITE_SOURCE, dml));
 
     let expectation = expect![[r#"
         [1;91merror[0m: [1mError validating field `json` in model `User`: Field `json` in model `User` can't be of type Json. The current connector does not support the Json type.[0m

--- a/psl/psl/tests/base/duplicates.rs
+++ b/psl/psl/tests/base/duplicates.rs
@@ -315,7 +315,7 @@ fn mapped_names_should_not_cause_collisions_with_names() {
     "#};
 
     let dml = with_header(schema, crate::Provider::Mongo, &[]);
-    let (_, datamodel) = parse_schema(&dml).unwrap();
+    let datamodel = parse(&dml);
     let r#type = datamodel.assert_has_composite_type("TestData");
 
     r#type.assert_has_scalar_field("id");

--- a/psl/psl/tests/capabilities/postgres.rs
+++ b/psl/psl/tests/capabilities/postgres.rs
@@ -19,7 +19,7 @@ fn enum_support() {
         }
     "#};
 
-    assert!(parse_schema(dml).is_ok());
+    assert_valid(dml);
 }
 
 #[test]
@@ -36,7 +36,7 @@ fn scalar_list_support() {
         }
     "#};
 
-    assert!(parse_schema(dml).is_ok());
+    assert_valid(dml);
 }
 
 #[test]
@@ -96,7 +96,7 @@ fn json_support() {
         }
     "#};
 
-    assert!(parse_schema(dml).is_ok());
+    assert_valid(dml);
 }
 
 #[test]
@@ -149,7 +149,7 @@ fn auto_increment_on_non_primary_column_support() {
         }
     "#};
 
-    assert!(parse_schema(dml).is_ok());
+    assert_valid(dml);
 }
 
 #[test]
@@ -177,7 +177,7 @@ fn key_order_enforcement_support() {
         }
     "#};
 
-    assert!(parse_schema(dml).is_ok());
+    assert_valid(dml);
 }
 
 #[test]
@@ -193,8 +193,6 @@ fn postgres_does_not_support_composite_types() {
         }
     "#;
 
-    let err = parse_unwrap_err(schema);
-
     let expected = expect![[r#"
         [1;91merror[0m: [1mError validating: Composite types are not supported on Postgres.[0m
           [1;94m-->[0m  [4mschema.prisma:7[0m
@@ -206,5 +204,5 @@ fn postgres_does_not_support_composite_types() {
         [1;94m   | [0m
     "#]];
 
-    expected.assert_eq(&err);
+    expect_error(schema, &expected);
 }

--- a/psl/psl/tests/capabilities/sqlite.rs
+++ b/psl/psl/tests/capabilities/sqlite.rs
@@ -227,7 +227,7 @@ fn key_order_enforcement_support() {
         }
     "#};
 
-    assert!(parse_schema(dml).is_ok());
+    assert_valid(dml)
 }
 
 #[test]

--- a/psl/psl/tests/config/datasources.rs
+++ b/psl/psl/tests/config/datasources.rs
@@ -169,7 +169,7 @@ fn escaped_windows_paths_should_work() {
         }
     "#};
 
-    assert!(parse_schema(schema).is_ok());
+    assert_valid(schema)
 }
 
 fn render_schema_json(schema: &str) -> String {

--- a/psl/psl/tests/config/generators.rs
+++ b/psl/psl/tests/config/generators.rs
@@ -399,9 +399,8 @@ fn empty_preview_features_array_should_work() {
         }
     "#;
 
-    let (config, _) = psl::parse_schema(schema).unwrap();
-
-    assert!(config.preview_features().is_empty());
+    let schema = psl::parse_schema_parserdb(schema).unwrap();
+    assert!(schema.configuration.preview_features().is_empty());
 }
 
 #[test]
@@ -418,9 +417,8 @@ fn empty_preview_features_array_with_empty_space_should_work() {
         }
     "#;
 
-    let (config, _) = psl::parse_schema(schema).unwrap();
-
-    assert!(config.preview_features().is_empty());
+    let schema = psl::parse_schema_parserdb(schema).unwrap();
+    assert!(schema.configuration.preview_features().is_empty());
 }
 
 #[test]
@@ -474,7 +472,7 @@ fn engine_type_must_be_a_string() {
         }
     "#};
 
-    assert!(psl::parse_schema(with_string).is_ok());
+    assert_valid(with_string);
 
     let with_array = indoc! {r#"
         generator client {

--- a/psl/psl/tests/renderer/configuration.rs
+++ b/psl/psl/tests/renderer/configuration.rs
@@ -18,8 +18,8 @@ fn shadow_database_url_round_trips() {
         "#
     );
 
-    let (ref config, ref datamodel) = parse_schema(schema_str).unwrap();
-    let rendered = render_datamodel_and_config_to_string(datamodel, config);
+    let schema = psl::parse_schema_parserdb(schema_str).unwrap();
+    let rendered = render_datamodel_and_config_to_string(&psl::lift(&schema), &schema.configuration);
 
     assert_eq!(schema_str, rendered);
 }

--- a/query-engine/dmmf/src/lib.rs
+++ b/query-engine/dmmf/src/lib.rs
@@ -15,7 +15,9 @@ pub fn dmmf_json_from_schema(schema: &str) -> String {
 
 // enable raw param?
 pub fn dmmf_from_schema(schema: &str) -> DataModelMetaFormat {
-    let (config, dml) = psl::parse_schema(schema).unwrap();
+    let schema = psl::parse_schema_parserdb(schema).unwrap();
+    let config = &schema.configuration;
+    let dml = psl::lift(&schema);
 
     // We only support one data source at the moment, so take the first one (default not exposed yet).
     let data_source = config.datasources.first().unwrap();

--- a/query-engine/prisma-models/tests/datamodel_converter_tests.rs
+++ b/query-engine/prisma-models/tests/datamodel_converter_tests.rs
@@ -468,10 +468,8 @@ fn duplicate_relation_name() {
           
         "#;
 
-    let (_, dml) = psl::parse_schema(schema).unwrap();
-    let res = std::panic::catch_unwind(|| InternalDataModelBuilder::from(&dml));
-
-    assert!(res.is_ok());
+    let dml = psl::parse_datamodel(schema).unwrap().subject;
+    InternalDataModelBuilder::from(&dml).build(String::new());
 }
 
 #[test]


### PR DESCRIPTION
While looking into simplifying prisma-models, it became apparent that we can delete psl::parse_schema(). This is an opportunistic cleanup to do just that.

edit: second commit also removes parse_schema_ast from the public API. We are getting closer to something neat.