### PR TITLE
psl: shrink the public api even further

### DIFF
--- a/introspection-engine/connectors/mongodb-introspection-connector/tests/test_api/mod.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/tests/test_api/mod.rs
@@ -106,7 +106,7 @@ where
     let validated_schema = psl::parse_schema_parserdb(datamodel_string).unwrap();
 
     let ctx = IntrospectionContext {
-        source: validated_schema.configuration.clone().datasources.pop().unwrap(),
+        source: validated_schema.configuration.datasources.clone().pop().unwrap(),
         composite_type_depth,
         preview_features,
     };

--- a/introspection-engine/connectors/mongodb-introspection-connector/tests/test_api/mod.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/tests/test_api/mod.rs
@@ -103,11 +103,10 @@ where
         features,
     );
 
-    let mut config = psl::parse_configuration(&datamodel_string).unwrap();
-    let datamodel = psl::parse_datamodel(&datamodel_string).unwrap();
+    let validated_schema = psl::parse_schema_parserdb(datamodel_string).unwrap();
 
     let ctx = IntrospectionContext {
-        source: config.subject.datasources.pop().unwrap(),
+        source: validated_schema.configuration.clone().datasources.pop().unwrap(),
         composite_type_depth,
         preview_features,
     };
@@ -121,11 +120,11 @@ where
             database.drop(None).await.unwrap();
         }
 
-        let res = connector.introspect(&datamodel.subject, ctx).await;
+        let res = connector.introspect(&psl::lift(&validated_schema), ctx).await;
         database.drop(None).await.unwrap();
 
         let res = res.unwrap();
-        let config = psl::parse_configuration(&datamodel_string).unwrap().subject;
+        let config = validated_schema.configuration;
 
         TestResult {
             datamodel: psl::render_datamodel_to_string(&res.data_model, Some(&config)),

--- a/introspection-engine/core/src/rpc.rs
+++ b/introspection-engine/core/src/rpc.rs
@@ -142,11 +142,9 @@ impl RpcImpl {
 
     /// This function parses the provided schema and returns the contained Datamodel.
     pub fn parse_datamodel(schema: &str) -> RpcResult<Datamodel> {
-        let final_dm = psl::parse_datamodel(schema)
-            .map(|d| d.subject)
-            .map_err(|err| Error::DatamodelError(err.to_pretty_string("schema.prisma", schema)))?;
+        let final_dm = psl::parse_schema_parserdb(schema).map_err(Error::DatamodelError)?;
 
-        Ok(final_dm)
+        Ok(psl::lift(&final_dm))
     }
 
     pub async fn list_databases_internal(schema: String) -> RpcResult<Vec<String>> {

--- a/introspection-engine/core/src/rpc.rs
+++ b/introspection-engine/core/src/rpc.rs
@@ -72,10 +72,9 @@ impl RpcImpl {
         let config = psl::parse_configuration(schema)
             .map_err(|diagnostics| Error::DatamodelError(diagnostics.to_pretty_string("schema.prisma", schema)))?;
 
-        let preview_features = config.subject.preview_features();
+        let preview_features = config.preview_features();
 
         let connection_string = config
-            .subject
             .datasources
             .first()
             .ok_or_else(|| Error::Generic("There is no datasource in the schema.".into()))?
@@ -88,7 +87,7 @@ impl RpcImpl {
             Box::new(SqlIntrospectionConnector::new(&connection_string, preview_features).await?)
         };
 
-        Ok((config.subject, connection_string.clone(), connector))
+        Ok((config, connection_string.clone(), connector))
     }
 
     pub async fn catch<O>(fut: impl std::future::Future<Output = ConnectorResult<O>>) -> RpcResult<O> {

--- a/introspection-engine/introspection-engine-tests/src/test_api.rs
+++ b/introspection-engine/introspection-engine-tests/src/test_api.rs
@@ -260,9 +260,7 @@ impl TestApi {
     }
 
     pub fn configuration(&self) -> Configuration {
-        psl::parse_configuration(&format!("{}\n{}", &self.datasource_block(), &self.generator_block()))
-            .unwrap()
-            .subject
+        psl::parse_configuration(&format!("{}\n{}", &self.datasource_block(), &self.generator_block())).unwrap()
     }
 
     #[track_caller]

--- a/introspection-engine/introspection-engine-tests/src/test_api.rs
+++ b/introspection-engine/introspection-engine-tests/src/test_api.rs
@@ -285,12 +285,8 @@ impl TestApi {
         let expected_with_source = self.dm_with_sources(expected_without_header);
         let expected_with_generator = self.dm_with_generator_and_preview_flags(&expected_with_source);
 
-        let parsed_expected = psl::parse_datamodel(&expected_with_generator)
-            .map_err(|err| err.to_pretty_string("schema.prisma", &expected_with_generator))
-            .unwrap()
-            .subject;
-
-        let parsed_result = psl::parse_datamodel(result_with_header).unwrap().subject;
+        let parsed_expected = parse_datamodel(&expected_with_generator);
+        let parsed_result = parse_datamodel(result_with_header);
 
         let reformatted_expected = psl::render_datamodel_and_config_to_string(&parsed_expected, &self.configuration());
         let reformatted_result = psl::render_datamodel_and_config_to_string(&parsed_result, &self.configuration());
@@ -347,8 +343,5 @@ impl TestApi {
 
 #[track_caller]
 fn parse_datamodel(dm: &str) -> Datamodel {
-    psl::parse_datamodel(dm)
-        .map_err(|diagnostics| diagnostics.to_pretty_string("schema.prisma", dm))
-        .unwrap()
-        .subject
+    psl::lift(&psl::parse_schema_parserdb(dm).unwrap())
 }

--- a/introspection-engine/introspection-engine-tests/tests/cockroachdb/mod.rs
+++ b/introspection-engine/introspection-engine-tests/tests/cockroachdb/mod.rs
@@ -31,7 +31,6 @@ async fn introspecting_cockroach_db_with_postgres_provider(api: TestApi) {
         preview_features: Default::default(),
         source: parse_configuration(&schema)
             .unwrap()
-            .subject
             .datasources
             .into_iter()
             .next()

--- a/introspection-engine/introspection-engine-tests/tests/cockroachdb/mod.rs
+++ b/introspection-engine/introspection-engine-tests/tests/cockroachdb/mod.rs
@@ -39,10 +39,8 @@ async fn introspecting_cockroach_db_with_postgres_provider(api: TestApi) {
         composite_type_depth: CompositeTypeDepth::Infinite,
     };
 
-    api.api
-        .introspect(&psl::parse_datamodel(&schema).unwrap().subject, ctx)
-        .await
-        .unwrap();
+    let schema = psl::parse_schema_parserdb(schema).unwrap();
+    api.api.introspect(&psl::lift(&schema), ctx).await.unwrap();
 }
 
 #[test_connector(tags(CockroachDb))]

--- a/introspection-engine/introspection-engine-tests/tests/tables/mysql.rs
+++ b/introspection-engine/introspection-engine-tests/tests/tables/mysql.rs
@@ -414,7 +414,7 @@ async fn missing_select_rights(api: &TestApi) -> TestResult {
     let config = psl::parse_configuration(&datasource).unwrap();
 
     let ctx = IntrospectionContext {
-        source: config.subject.datasources.into_iter().next().unwrap(),
+        source: config.datasources.into_iter().next().unwrap(),
         composite_type_depth: Default::default(),
         preview_features: Default::default(),
     };

--- a/libs/datamodel/core/src/configuration/configuration_struct.rs
+++ b/libs/datamodel/core/src/configuration/configuration_struct.rs
@@ -6,7 +6,7 @@ use crate::{
 use datamodel_connector::ReferentialIntegrity;
 use enumflags2::BitFlags;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Configuration {
     pub generators: Vec<Generator>,
     pub datasources: Vec<Datasource>,

--- a/libs/datamodel/core/src/configuration/configuration_struct.rs
+++ b/libs/datamodel/core/src/configuration/configuration_struct.rs
@@ -6,10 +6,11 @@ use crate::{
 use datamodel_connector::ReferentialIntegrity;
 use enumflags2::BitFlags;
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Configuration {
     pub generators: Vec<Generator>,
     pub datasources: Vec<Datasource>,
+    pub warnings: Vec<diagnostics::DatamodelWarning>,
 }
 
 impl Configuration {

--- a/libs/datamodel/core/src/mcf.rs
+++ b/libs/datamodel/core/src/mcf.rs
@@ -4,10 +4,9 @@ mod source;
 pub use generator::*;
 pub use source::*;
 
-use crate::ValidatedConfiguration;
 use serde::Serialize;
 
-pub fn config_to_mcf_json_value(mcf: &ValidatedConfiguration) -> serde_json::Value {
+pub fn config_to_mcf_json_value(mcf: &crate::Configuration) -> serde_json::Value {
     serde_json::to_value(&model_to_serializable(mcf)).expect("Failed to render JSON.")
 }
 
@@ -19,10 +18,10 @@ pub struct SerializeableMcf {
     warnings: Vec<String>,
 }
 
-fn model_to_serializable(config: &ValidatedConfiguration) -> SerializeableMcf {
+fn model_to_serializable(config: &crate::Configuration) -> SerializeableMcf {
     SerializeableMcf {
-        generators: generator::generators_to_json_value(&config.subject.generators),
-        datasources: source::render_sources_to_json_value(&config.subject.datasources),
+        generators: generator::generators_to_json_value(&config.generators),
+        datasources: source::render_sources_to_json_value(&config.datasources),
         warnings: config.warnings.iter().map(|f| f.message().to_owned()).collect(),
     }
 }

--- a/libs/datamodel/diagnostics/src/warning.rs
+++ b/libs/datamodel/diagnostics/src/warning.rs
@@ -2,7 +2,7 @@ use crate::Span;
 
 /// A non-fatal warning emitted by the schema parser.
 /// For fancy printing, please use the `pretty_print_error` function.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct DatamodelWarning {
     message: String,
     span: Span,

--- a/libs/test-cli/src/main.rs
+++ b/libs/test-cli/src/main.rs
@@ -228,9 +228,8 @@ async fn main() -> anyhow::Result<()> {
             let mut datamodel = String::new();
             file.read_to_string(&mut datamodel).unwrap();
 
-            if let Err(e) = psl::parse_datamodel(&datamodel) {
-                let pretty = e.to_pretty_string("schema.prisma", &datamodel);
-                println!("{pretty}");
+            if let Err(e) = psl::parse_schema_parserdb(datamodel) {
+                println!("{e}");
             };
         }
         Command::ResetDatabase(cmd) => {

--- a/migration-engine/core/src/lib.rs
+++ b/migration-engine/core/src/lib.rs
@@ -101,7 +101,6 @@ fn connector_for_connection_string(
 /// Same as schema_to_connector, but it will only read the provider, not the connector params.
 fn schema_to_connector_unchecked(schema: &str) -> CoreResult<Box<dyn migration_connector::MigrationConnector>> {
     let config = psl::parse_configuration(schema)
-        .map(|validated_config| validated_config.subject)
         .map_err(|err| CoreError::new_schema_parser_error(err.to_pretty_string("schema.prisma", schema)))?;
 
     let preview_features = config.preview_features();
@@ -182,7 +181,6 @@ pub fn migration_api(
 
 fn parse_configuration(datamodel: &str) -> CoreResult<(Datasource, String, BitFlags<PreviewFeature>, Option<String>)> {
     let config = psl::parse_configuration(datamodel)
-        .map(|validated_config| validated_config.subject)
         .map_err(|err| CoreError::new_schema_parser_error(err.to_pretty_string("schema.prisma", datamodel)))?;
 
     let preview_features = config.preview_features();

--- a/migration-engine/qe-setup/src/lib.rs
+++ b/migration-engine/qe-setup/src/lib.rs
@@ -18,7 +18,6 @@ use std::{env, sync::Arc};
 
 fn parse_configuration(datamodel: &str) -> ConnectorResult<(Datasource, String, BitFlags<PreviewFeature>)> {
     let config = psl::parse_configuration(datamodel)
-        .map(|validated_config| validated_config.subject)
         .map_err(|err| ConnectorError::new_schema_parser_error(err.to_pretty_string("schema.prisma", datamodel)))?;
 
     let url = config.datasources[0]

--- a/prisma-fmt/src/actions.rs
+++ b/prisma-fmt/src/actions.rs
@@ -3,9 +3,9 @@ pub(crate) fn run(schema: &str) -> String {
 
     match datamodel_result {
         Ok(validated_configuration) => {
-            if validated_configuration.subject.datasources.len() != 1 {
+            if validated_configuration.datasources.len() != 1 {
                 "[]".to_string()
-            } else if let Some(datasource) = validated_configuration.subject.datasources.first() {
+            } else if let Some(datasource) = validated_configuration.datasources.first() {
                 let referential_integrity = datasource.referential_integrity();
                 let available_referential_actions = datasource
                     .active_connector

--- a/prisma-fmt/src/get_config.rs
+++ b/prisma-fmt/src/get_config.rs
@@ -59,7 +59,6 @@ fn get_config_impl(params: GetConfigParams) -> Result<serde_json::Value, GetConf
     if !params.ignore_env_var_errors {
         let overrides: Vec<(_, _)> = params.datasource_overrides.into_iter().collect();
         config
-            .subject
             .resolve_datasource_urls_from_env(&overrides, |key| params.env.get(key).map(String::from))
             .map_err(|env_error| GetConfigError {
                 error_code: None,
@@ -90,7 +89,7 @@ mod tests {
         });
 
         let expected = expect![[
-            r#"{"error":{"message":"\u001b[1;91merror\u001b[0m: \u001b[1mError validating: This line is invalid. It does not start with any known Prisma schema keyword.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:5\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 4 | \u001b[0m\n\u001b[1;94m 5 | \u001b[0m            \u001b[1;91mdatasøurce yolo {\u001b[0m\n\u001b[1;94m 6 | \u001b[0m            }\n\u001b[1;94m   | \u001b[0m\n\u001b[1;91merror\u001b[0m: \u001b[1mError validating: This line is invalid. It does not start with any known Prisma schema keyword.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:6\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 5 | \u001b[0m            datasøurce yolo {\n\u001b[1;94m 6 | \u001b[0m            \u001b[1;91m}\u001b[0m\n\u001b[1;94m 7 | \u001b[0m        \n\u001b[1;94m   | \u001b[0m\n","error_code":null}}"#
+            r#"{"error":{"message":"\u001b[1;91merror\u001b[0m: \u001b[1mError validating: This line is invalid. It does not start with any known Prisma schema keyword.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:5\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 4 | \u001b[0m\n\u001b[1;94m 5 | \u001b[0m            \u001b[1;91mdatasøurce yolo {\u001b[0m\n\u001b[1;94m 6 | \u001b[0m            }\n\u001b[1;94m   | \u001b[0m\n\u001b[1;91merror\u001b[0m: \u001b[1mError validating: This line is invalid. It does not start with any known Prisma schema keyword.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:6\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 5 | \u001b[0m            datasøurce yolo {\n\u001b[1;94m 6 | \u001b[0m            \u001b[1;91m}\u001b[0m\n\u001b[1;94m 7 | \u001b[0m        \n\u001b[1;94m   | \u001b[0m\n\u001b[1;91merror\u001b[0m: \u001b[1mArgument \"provider\" is missing in generator block \"js\".\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:2\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 1 | \u001b[0m\n\u001b[1;94m 2 | \u001b[0m            \u001b[1;91mgenerator js {\u001b[0m\n\u001b[1;94m 3 | \u001b[0m            }\n\u001b[1;94m   | \u001b[0m\n","error_code":null}}"#
         ]];
         let response = get_config(&request.to_string());
 

--- a/prisma-fmt/src/lint.rs
+++ b/prisma-fmt/src/lint.rs
@@ -9,7 +9,8 @@ pub struct MiniError {
 }
 
 pub(crate) fn run(schema: &str) -> String {
-    let (diagnostics, _) = datamodel::validate(schema.into());
+    let schema = datamodel::validate(schema.into());
+    let diagnostics = &schema.diagnostics;
 
     let mut mini_errors: Vec<MiniError> = diagnostics
         .errors()

--- a/prisma-fmt/src/lint.rs
+++ b/prisma-fmt/src/lint.rs
@@ -9,51 +9,33 @@ pub struct MiniError {
 }
 
 pub(crate) fn run(schema: &str) -> String {
-    let datamodel_result = datamodel::parse_datamodel(schema);
+    let (diagnostics, _) = datamodel::validate(schema.into());
 
-    match datamodel_result {
-        Err(err) => {
-            let mut mini_errors: Vec<MiniError> = err
-                .errors()
-                .iter()
-                .map(|err: &DatamodelError| MiniError {
-                    start: err.span().start,
-                    end: err.span().end,
-                    text: err.message().to_string(),
-                    is_warning: false,
-                })
-                .collect();
+    let mut mini_errors: Vec<MiniError> = diagnostics
+        .errors()
+        .iter()
+        .map(|err: &DatamodelError| MiniError {
+            start: err.span().start,
+            end: err.span().end,
+            text: err.message().to_string(),
+            is_warning: false,
+        })
+        .collect();
 
-            let mut mini_warnings: Vec<MiniError> = err
-                .warnings()
-                .iter()
-                .map(|warn: &DatamodelWarning| MiniError {
-                    start: warn.span().start,
-                    end: warn.span().end,
-                    text: warn.message().to_owned(),
-                    is_warning: true,
-                })
-                .collect();
+    let mut mini_warnings: Vec<MiniError> = diagnostics
+        .warnings()
+        .iter()
+        .map(|warn: &DatamodelWarning| MiniError {
+            start: warn.span().start,
+            end: warn.span().end,
+            text: warn.message().to_owned(),
+            is_warning: true,
+        })
+        .collect();
 
-            mini_errors.append(&mut mini_warnings);
+    mini_errors.append(&mut mini_warnings);
 
-            print_diagnostics(mini_errors)
-        }
-        Ok(validated_datamodel) => {
-            let mini_warnings: Vec<MiniError> = validated_datamodel
-                .warnings
-                .into_iter()
-                .map(|warn: DatamodelWarning| MiniError {
-                    start: warn.span().start,
-                    end: warn.span().end,
-                    text: warn.message().to_owned(),
-                    is_warning: true,
-                })
-                .collect();
-
-            print_diagnostics(mini_warnings)
-        }
-    }
+    print_diagnostics(mini_errors)
 }
 
 fn print_diagnostics(diagnostics: Vec<MiniError>) -> String {

--- a/prisma-fmt/src/native.rs
+++ b/prisma-fmt/src/native.rs
@@ -6,11 +6,11 @@ pub(crate) fn run(schema: &str) -> String {
         Err(_) => return "[]".to_owned(),
     };
 
-    if validated_configuration.subject.datasources.len() != 1 {
+    if validated_configuration.datasources.len() != 1 {
         return "[]".to_owned();
     }
 
-    let datasource = &validated_configuration.subject.datasources[0];
+    let datasource = &validated_configuration.datasources[0];
     let available_native_type_constructors = datasource.active_connector.available_native_type_constructors();
     let available_native_type_constructors: Vec<SerializableNativeTypeConstructor> =
         available_native_type_constructors.iter().map(From::from).collect();

--- a/prisma-fmt/src/text_document_completion.rs
+++ b/prisma-fmt/src/text_document_completion.rs
@@ -27,7 +27,7 @@ pub(crate) fn completion(schema: String, params: CompletionParams) -> Completion
 
     let (connector, referential_integrity) = parse_configuration(source_file.as_str())
         .ok()
-        .and_then(|conf| conf.subject.datasources.into_iter().next())
+        .and_then(|conf| conf.datasources.into_iter().next())
         .map(|datasource| (datasource.active_connector, datasource.referential_integrity()))
         .unwrap_or_else(|| {
             (

--- a/psl/psl/tests/attributes/relations/referential_actions.rs
+++ b/psl/psl/tests/attributes/relations/referential_actions.rs
@@ -255,7 +255,7 @@ fn mongo_uses_prisma_referential_integrity_by_default() {
 
     assert_eq!(
         Some(ReferentialIntegrity::Prisma),
-        parse_config(dml).unwrap().subject.referential_integrity()
+        parse_config(dml).unwrap().referential_integrity()
     );
 }
 
@@ -282,7 +282,7 @@ fn sql_databases_use_foreign_keys_referential_integrity_by_default() {
 
         assert_eq!(
             Some(ReferentialIntegrity::ForeignKeys),
-            parse_config(&dml).unwrap().subject.referential_integrity()
+            parse_config(&dml).unwrap().referential_integrity()
         );
     }
 }

--- a/psl/psl/tests/common/mod.rs
+++ b/psl/psl/tests/common/mod.rs
@@ -2,7 +2,7 @@ pub use ::indoc::{formatdoc, indoc};
 pub use expect_test::expect;
 pub use psl::{dml, dml::*};
 
-use psl::{diagnostics::*, Configuration, StringFromEnvVar, ValidatedConfiguration};
+use psl::{diagnostics::*, Configuration, StringFromEnvVar};
 
 pub(crate) fn reformat(input: &str) -> String {
     psl::reformat(input, 2).unwrap_or_else(|| input.to_owned())
@@ -421,13 +421,13 @@ pub(crate) fn parse(datamodel_string: &str) -> Datamodel {
     psl::lift(&schema)
 }
 
-pub(crate) fn parse_config(schema: &str) -> Result<ValidatedConfiguration, String> {
+pub(crate) fn parse_config(schema: &str) -> Result<Configuration, String> {
     psl::parse_configuration(schema).map_err(|err| err.to_pretty_string("schema.prisma", schema))
 }
 
 pub(crate) fn parse_configuration(datamodel_string: &str) -> Configuration {
     match psl::parse_configuration(datamodel_string) {
-        Ok(c) => c.subject,
+        Ok(c) => c,
         Err(errs) => {
             panic!(
                 "Configuration parsing failed\n\n{}",

--- a/psl/psl/tests/common/mod.rs
+++ b/psl/psl/tests/common/mod.rs
@@ -1,6 +1,6 @@
 pub use ::indoc::{formatdoc, indoc};
 pub use expect_test::expect;
-pub use psl::{dml, dml::*, parse_datamodel};
+pub use psl::{dml, dml::*};
 
 use psl::{diagnostics::*, Configuration, StringFromEnvVar, ValidatedConfiguration};
 
@@ -417,15 +417,8 @@ pub(crate) fn parse_unwrap_err(schema: &str) -> String {
 }
 
 pub(crate) fn parse(datamodel_string: &str) -> Datamodel {
-    match parse_datamodel(datamodel_string) {
-        Ok(s) => s.subject,
-        Err(errs) => {
-            panic!(
-                "Datamodel parsing failed\n\n{}",
-                errs.to_pretty_string("", datamodel_string)
-            )
-        }
-    }
+    let schema = psl::parse_schema_parserdb(datamodel_string).unwrap();
+    psl::lift(&schema)
 }
 
 pub(crate) fn parse_config(schema: &str) -> Result<ValidatedConfiguration, String> {
@@ -453,10 +446,7 @@ pub(crate) fn expect_error(schema: &str, expectation: &expect_test::Expect) {
 }
 
 pub(crate) fn parse_and_render_error(schema: &str) -> String {
-    match psl::parse_datamodel(schema) {
-        Ok(_) => panic!("Expected an error when parsing schema."),
-        Err(errs) => errs.to_pretty_string("schema.prisma", schema),
-    }
+    parse_unwrap_err(schema)
 }
 
 #[track_caller]

--- a/psl/psl/tests/config/sources.rs
+++ b/psl/psl/tests/config/sources.rs
@@ -104,7 +104,7 @@ fn must_error_for_empty_urls() {
 
     let config = parse_config(dml).unwrap();
 
-    let error = config.subject.datasources[0]
+    let error = config.datasources[0]
         .load_url(load_env_var)
         .map_err(|e| e.to_pretty_string("schema.prisma", dml))
         .unwrap_err();
@@ -157,7 +157,7 @@ fn must_error_for_empty_urls_derived_load_env_vars() {
 
     let config = parse_config(dml).unwrap();
 
-    let error = config.subject.datasources[0]
+    let error = config.datasources[0]
         .load_url(load_env_var)
         .map_err(|e| e.to_pretty_string("schema.prisma", dml))
         .unwrap_err();
@@ -185,7 +185,7 @@ fn must_error_if_prisma_protocol_is_used_for_mysql() {
 
     let config = parse_config(dml).unwrap();
 
-    let error = config.subject.datasources[0]
+    let error = config.datasources[0]
         .load_url(load_env_var)
         .map_err(|e| e.to_pretty_string("schema.prisma", dml))
         .unwrap_err();
@@ -218,7 +218,7 @@ fn must_error_if_wrong_protocol_is_used_for_mysql() {
 
     let config = parse_config(dml).unwrap();
 
-    let error = config.subject.datasources[0]
+    let error = config.datasources[0]
         .load_url(load_env_var)
         .map_err(|e| e.to_pretty_string("schema.prisma", dml))
         .unwrap_err();
@@ -247,7 +247,7 @@ fn must_error_if_wrong_protocol_is_used_for_mysql_shadow_database_url() {
 
     let config = parse_config(dml).unwrap();
 
-    let error = config.subject.datasources[0]
+    let error = config.datasources[0]
         .load_shadow_database_url()
         .map_err(|e| e.to_pretty_string("schema.prisma", dml))
         .unwrap_err();
@@ -309,7 +309,7 @@ fn must_error_if_wrong_protocol_is_used_for_postgresql() {
 
     let config = parse_config(dml).unwrap();
 
-    let error = config.subject.datasources[0]
+    let error = config.datasources[0]
         .load_url(load_env_var)
         .map_err(|e| e.to_pretty_string("schema.prisma", dml))
         .unwrap_err();
@@ -338,7 +338,7 @@ fn must_error_if_wrong_protocol_is_used_for_postgresql_shadow_database_url() {
 
     let config = parse_config(dml).unwrap();
 
-    let error = config.subject.datasources[0]
+    let error = config.datasources[0]
         .load_shadow_database_url()
         .map_err(|e| e.to_pretty_string("schema.prisma", dml))
         .unwrap_err();
@@ -366,7 +366,7 @@ fn must_error_if_wrong_protocol_is_used_for_sqlite() {
 
     let config = parse_config(dml).unwrap();
 
-    let error = config.subject.datasources[0]
+    let error = config.datasources[0]
         .load_url(load_env_var)
         .map_err(|e| e.to_pretty_string("schema.prisma", dml))
         .unwrap_err();
@@ -423,7 +423,7 @@ fn must_error_if_env_var_is_missing() {
 
     let config = parse_config(dml).unwrap();
 
-    let error = config.subject.datasources[0]
+    let error = config.datasources[0]
         .load_url(load_env_var)
         .map_err(|e| e.to_pretty_string("schema.prisma", dml))
         .unwrap_err();
@@ -568,7 +568,7 @@ fn fail_when_no_source_is_declared() {
     let invalid_datamodel: &str = r#"        "#;
 
     let error = psl::parse_configuration(invalid_datamodel)
-        .and_then(|res| res.subject.validate_that_one_datasource_is_provided())
+        .and_then(|res| res.validate_that_one_datasource_is_provided())
         .map_err(|e| e.to_pretty_string("schema.prisma", invalid_datamodel))
         .unwrap_err();
 

--- a/psl/psl/tests/renderer/enums.rs
+++ b/psl/psl/tests/renderer/enums.rs
@@ -1,5 +1,4 @@
 use crate::common::*;
-use psl::*;
 
 #[test]
 fn enum_rendering_works() {
@@ -21,7 +20,6 @@ fn enum_rendering_works() {
         }
     "#]];
 
-    let dml = parse(dm);
-    let rendered = render_datamodel_to_string(&dml, None);
+    let rendered = rerender(dm);
     expected.assert_eq(&rendered)
 }

--- a/psl/psl/tests/renderer/extended_indexes.rs
+++ b/psl/psl/tests/renderer/extended_indexes.rs
@@ -34,7 +34,7 @@ fn expanded_index_capability_rendering_works() {
     "#]];
 
     let dml = parse(dm);
-    let configuration = psl::parse_configuration(dm).unwrap().subject;
+    let configuration = psl::parse_configuration(dm).unwrap();
     let rendered = psl::render_datamodel_to_string(&dml, Some(&configuration));
     expected.assert_eq(&rendered)
 }
@@ -72,7 +72,7 @@ fn expanded_id_capability_rendering_works_for_mysql() {
     "#]];
 
     let dml = parse(&dm);
-    let configuration = psl::parse_configuration(&dm).unwrap().subject;
+    let configuration = psl::parse_configuration(&dm).unwrap();
     let rendered = psl::render_datamodel_to_string(&dml, Some(&configuration));
     expected.assert_eq(&rendered)
 }

--- a/query-engine/dmmf/src/ast_builders/datamodel_ast_builder.rs
+++ b/query-engine/dmmf/src/ast_builders/datamodel_ast_builder.rs
@@ -286,14 +286,9 @@ mod tests {
     use std::fs;
 
     pub(crate) fn parse(datamodel_string: &str) -> Datamodel {
-        match psl::parse_datamodel(datamodel_string) {
-            Ok(s) => s.subject,
-            Err(errs) => {
-                panic!(
-                    "Datamodel parsing failed\n\n{}",
-                    errs.to_pretty_string("", datamodel_string)
-                )
-            }
+        match psl::parse_schema_parserdb(datamodel_string) {
+            Ok(s) => psl::lift(&s),
+            Err(err) => panic!("Datamodel parsing failed\n\n{err}",),
         }
     }
 

--- a/query-engine/prisma-models/src/builders/internal_dm_builder.rs
+++ b/query-engine/prisma-models/src/builders/internal_dm_builder.rs
@@ -21,10 +21,8 @@ pub struct InternalDataModelBuilder {
 }
 
 impl InternalDataModelBuilder {
-    pub fn new(datamodel: &str) -> Self {
-        let datamodel = psl::parse_datamodel(datamodel)
-            .expect("Expected valid datamodel.")
-            .subject;
+    pub fn new(datamodel: &psl::ValidatedSchema) -> Self {
+        let datamodel = psl::lift(datamodel);
 
         Self::from(&datamodel)
     }

--- a/query-engine/prisma-models/tests/datamodel_converter_tests.rs
+++ b/query-engine/prisma-models/tests/datamodel_converter_tests.rs
@@ -468,8 +468,8 @@ fn duplicate_relation_name() {
           
         "#;
 
-    let dml = psl::parse_datamodel(schema).unwrap().subject;
-    InternalDataModelBuilder::from(&dml).build(String::new());
+    let dml = psl::parse_schema_parserdb(schema).unwrap();
+    InternalDataModelBuilder::from(&psl::lift(&dml)).build(String::new());
 }
 
 #[test]
@@ -491,7 +491,8 @@ fn implicit_many_to_many_relation() {
 }
 
 fn convert(datamodel: &str) -> Arc<InternalDataModel> {
-    let builder = InternalDataModelBuilder::new(datamodel);
+    let schema = psl::parse_schema_parserdb(datamodel).unwrap();
+    let builder = InternalDataModelBuilder::new(&schema);
     builder.build("not_important".to_string())
 }
 

--- a/query-engine/query-engine-node-api/src/engine.rs
+++ b/query-engine/query-engine-node-api/src/engine.rs
@@ -157,10 +157,11 @@ impl QueryEngine {
 
         let env = stringify_env_values(env)?; // we cannot trust anything JS sends us from process.env
         let overrides: Vec<(_, _)> = datasource_overrides.into_iter().collect();
-        let (mut diagnostics, mut schema) = psl::validate(datamodel.into());
+        let mut schema = psl::validate(datamodel.into());
         let config = &mut schema.configuration;
 
-        diagnostics
+        schema
+            .diagnostics
             .to_result()
             .map_err(|err| ApiError::conversion(err, schema.db.source()))?;
 
@@ -291,8 +292,7 @@ impl QueryEngine {
                 let engine = inner.as_engine()?;
 
                 let config = psl::parse_configuration(&engine.datamodel.raw)
-                    .map_err(|errors| ApiError::conversion(errors, &engine.datamodel.raw))?
-                    .subject;
+                    .map_err(|errors| ApiError::conversion(errors, &engine.datamodel.raw))?;
 
                 let builder = EngineBuilder {
                     datamodel: engine.datamodel.clone(),

--- a/query-engine/query-engine-node-api/src/functions.rs
+++ b/query-engine/query-engine-node-api/src/functions.rs
@@ -26,12 +26,14 @@ pub fn version() -> Version {
 
 #[napi]
 pub fn dmmf(datamodel_string: String) -> napi::Result<String> {
-    let datamodel =
-        psl::parse_datamodel(&datamodel_string).map_err(|errors| ApiError::conversion(errors, &datamodel_string))?;
+    let (mut diagnostics, schema) = psl::validate(datamodel_string.into());
 
-    let config = psl::parse_configuration(&datamodel_string)
-        .map_err(|errors| ApiError::conversion(errors, &datamodel_string))?;
-    let datasource = config.subject.datasources.first();
+    diagnostics
+        .to_result()
+        .map_err(|errors| ApiError::conversion(errors, schema.db.source()))?;
+
+    let datasource = schema.configuration.datasources.first();
+    let datamodel = psl::lift(&schema);
 
     let connector = datasource
         .map(|ds| ds.active_connector)
@@ -39,17 +41,17 @@ pub fn dmmf(datamodel_string: String) -> napi::Result<String> {
 
     let referential_integrity = datasource.map(|ds| ds.referential_integrity()).unwrap_or_default();
 
-    let internal_data_model = InternalDataModelBuilder::from(&datamodel.subject).build("".into());
+    let internal_data_model = InternalDataModelBuilder::from(&datamodel).build("".into());
 
     let query_schema: QuerySchemaRef = Arc::new(schema_builder::build(
         internal_data_model,
         true,
         connector,
-        config.subject.preview_features().iter().collect(),
+        schema.configuration.preview_features().iter().collect(),
         referential_integrity,
     ));
 
-    let dmmf = dmmf::render_dmmf(&datamodel.subject, query_schema);
+    let dmmf = dmmf::render_dmmf(&datamodel, query_schema);
 
     Ok(serde_json::to_string(&dmmf)?)
 }

--- a/query-engine/query-engine-node-api/src/functions.rs
+++ b/query-engine/query-engine-node-api/src/functions.rs
@@ -26,9 +26,10 @@ pub fn version() -> Version {
 
 #[napi]
 pub fn dmmf(datamodel_string: String) -> napi::Result<String> {
-    let (mut diagnostics, schema) = psl::validate(datamodel_string.into());
+    let mut schema = psl::validate(datamodel_string.into());
 
-    diagnostics
+    schema
+        .diagnostics
         .to_result()
         .map_err(|errors| ApiError::conversion(errors, schema.db.source()))?;
 
@@ -84,7 +85,6 @@ pub fn get_config(js_env: Env, options: JsUnknown) -> napi::Result<JsUnknown> {
 
     if !ignore_env_var_errors {
         config
-            .subject
             .resolve_datasource_urls_from_env(&overrides, |key| env.get(key).map(ToString::to_string))
             .map_err(|errors| ApiError::conversion(errors, &datamodel))?;
     }

--- a/query-engine/query-engine/src/opt.rs
+++ b/query-engine/query-engine/src/opt.rs
@@ -1,9 +1,7 @@
 use crate::{error::PrismaError, PrismaResult};
 use psl::dml::Datamodel;
-use psl::ValidatedConfiguration;
 use serde::Deserialize;
-use std::env;
-use std::{ffi::OsStr, fs::File, io::Read};
+use std::{env, ffi::OsStr, fs::File, io::Read};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt, Clone)]
@@ -134,16 +132,17 @@ impl PrismaOpt {
 
     pub fn datamodel(&self) -> PrismaResult<Datamodel> {
         let datamodel_str = self.datamodel_str()?;
-        let (mut diagnostics, schema) = psl::validate(datamodel_str.into());
+        let mut schema = psl::validate(datamodel_str.into());
 
-        diagnostics
+        schema
+            .diagnostics
             .to_result()
             .map_err(|errors| PrismaError::ConversionError(errors, datamodel_str.to_string()))?;
 
         Ok(psl::lift(&schema))
     }
 
-    pub fn configuration(&self, ignore_env_errors: bool) -> PrismaResult<ValidatedConfiguration> {
+    pub fn configuration(&self, ignore_env_errors: bool) -> PrismaResult<psl::Configuration> {
         let datamodel_str = self.datamodel_str()?;
 
         let datasource_url_overrides: Vec<(String, String)> = if let Some(ref json) = self.overwrite_datasources {
@@ -157,9 +156,7 @@ impl PrismaOpt {
             psl::parse_configuration(datamodel_str)
         } else {
             psl::parse_configuration(datamodel_str).and_then(|mut config| {
-                config
-                    .subject
-                    .resolve_datasource_urls_from_env(&datasource_url_overrides, |key| env::var(key).ok())?;
+                config.resolve_datasource_urls_from_env(&datasource_url_overrides, |key| env::var(key).ok())?;
 
                 Ok(config)
             })

--- a/query-engine/query-engine/src/opt.rs
+++ b/query-engine/query-engine/src/opt.rs
@@ -134,13 +134,13 @@ impl PrismaOpt {
 
     pub fn datamodel(&self) -> PrismaResult<Datamodel> {
         let datamodel_str = self.datamodel_str()?;
+        let (mut diagnostics, schema) = psl::validate(datamodel_str.into());
 
-        let datamodel = psl::parse_datamodel(datamodel_str);
+        diagnostics
+            .to_result()
+            .map_err(|errors| PrismaError::ConversionError(errors, datamodel_str.to_string()))?;
 
-        match datamodel {
-            Err(errors) => Err(PrismaError::ConversionError(errors, datamodel_str.to_string())),
-            _ => Ok(datamodel.unwrap().subject),
-        }
+        Ok(psl::lift(&schema))
     }
 
     pub fn configuration(&self, ignore_env_errors: bool) -> PrismaResult<ValidatedConfiguration> {

--- a/query-engine/query-engine/src/server/mod.rs
+++ b/query-engine/query-engine/src/server/mod.rs
@@ -61,7 +61,7 @@ impl Clone for State {
 }
 
 pub async fn setup(opts: &PrismaOpt, metrics: MetricRegistry) -> PrismaResult<State> {
-    let config = opts.configuration(false)?.subject;
+    let config = opts.configuration(false)?;
     config.validate_that_one_datasource_is_provided()?;
 
     let span = tracing::info_span!("prisma:engine:connect");

--- a/query-engine/query-engine/src/tests/dmmf.rs
+++ b/query-engine/query-engine/src/tests/dmmf.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 pub fn get_query_schema(datamodel_string: &str) -> (QuerySchema, psl::dml::Datamodel) {
     let config = psl::parse_configuration(datamodel_string).unwrap();
     let dm = psl::parse_schema_parserdb(datamodel_string).unwrap();
-    let datasource = config.subject.datasources.first();
+    let datasource = config.datasources.first();
 
     let connector = datasource
         .map(|ds| ds.active_connector)
@@ -23,7 +23,7 @@ pub fn get_query_schema(datamodel_string: &str) -> (QuerySchema, psl::dml::Datam
         internal_ref,
         false,
         connector,
-        config.subject.preview_features().iter().collect(),
+        config.preview_features().iter().collect(),
         referential_integrity,
     );
 

--- a/query-engine/query-engine/src/tests/dmmf.rs
+++ b/query-engine/query-engine/src/tests/dmmf.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 pub fn get_query_schema(datamodel_string: &str) -> (QuerySchema, psl::dml::Datamodel) {
     let config = psl::parse_configuration(datamodel_string).unwrap();
-    let dm = psl::parse_datamodel(datamodel_string).unwrap().subject;
+    let dm = psl::parse_schema_parserdb(datamodel_string).unwrap();
     let datasource = config.subject.datasources.first();
 
     let connector = datasource
@@ -18,7 +18,7 @@ pub fn get_query_schema(datamodel_string: &str) -> (QuerySchema, psl::dml::Datam
         .unwrap_or(&psl::datamodel_connector::EmptyDatamodelConnector);
     let referential_integrity = datasource.map(|ds| ds.referential_integrity()).unwrap_or_default();
 
-    let internal_ref = InternalDataModelBuilder::from(&dm).build("db".to_owned());
+    let internal_ref = InternalDataModelBuilder::from(&psl::lift(&dm)).build("db".to_owned());
     let schema = schema_builder::build(
         internal_ref,
         false,
@@ -27,7 +27,7 @@ pub fn get_query_schema(datamodel_string: &str) -> (QuerySchema, psl::dml::Datam
         referential_integrity,
     );
 
-    (schema, dm)
+    (schema, psl::lift(&dm))
 }
 
 // Tests in this file run serially because the function `get_query_schema` depends on setting an env var.

--- a/query-engine/query-engine/src/tests/errors.rs
+++ b/query-engine/query-engine/src/tests/errors.rs
@@ -30,8 +30,8 @@ async fn connection_string_problems_give_a_nice_error() {
             provider.1
         );
 
-        let dml = psl::parse_datamodel(&dm).unwrap().subject;
         let config = psl::parse_configuration(&dm).unwrap();
+        let dml = psl::lift(&psl::parse_schema_parserdb(dm).unwrap());
 
         let error = PrismaContext::builder(config.subject, dml)
             .enable_raw_queries(true)

--- a/query-engine/query-engine/src/tests/errors.rs
+++ b/query-engine/query-engine/src/tests/errors.rs
@@ -33,7 +33,7 @@ async fn connection_string_problems_give_a_nice_error() {
         let config = psl::parse_configuration(&dm).unwrap();
         let dml = psl::lift(&psl::parse_schema_parserdb(dm).unwrap());
 
-        let error = PrismaContext::builder(config.subject, dml)
+        let error = PrismaContext::builder(config, dml)
             .enable_raw_queries(true)
             .build()
             .await


### PR DESCRIPTION
We now essentially have an infallible `validate()` method and the existing fallible `parse_schema_parserdb()`. Lifting is only exposed through `lift`. The places where we call `lift` in engines are expected to decrease over time and reach zero in the not too distant future.

The motivation is to unify error handling so we can use `validate` to get a `ValidatedSchema` into `InternalDataModelBuilder` (done, as of this commit), so we can use the parser database in prisma-models.