### PR TITLE
qe: fix prisma/13097

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
@@ -1,5 +1,6 @@
 mod max_integer;
 mod prisma_10098;
+mod prisma_13097;
 mod prisma_10935;
 mod prisma_12929;
 mod prisma_14696;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_13097.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_13097.rs
@@ -1,0 +1,68 @@
+use query_engine_tests::*;
+
+#[test_suite(schema(schema), only(Postgres))]
+mod prisma_13097 {
+    fn schema() -> String {
+        r#"
+enum AppCategories {
+  calendar
+  messaging
+  payment
+  other
+}
+
+model App {
+  slug       String          @id @unique
+  categories AppCategories[]
+  createdAt  DateTime        @default(now())
+  updatedAt  DateTime        @updatedAt
+}
+
+model Opp {
+  slug       String          @id @unique
+  categories Boolean[]
+}
+        "#
+        .to_owned()
+    }
+
+    #[connector_test]
+    async fn group_by_enum_array(runner: Runner) -> TestResult<()> {
+        // Insert some data first
+        run_query!(
+            runner,
+            r#"mutation { createManyApp(data: [{slug:"a",categories:[calendar,other]},{slug:"b",categories:[]},{slug:"c",categories:[calendar,other]},{slug:"d",categories:[messaging, payment]}]) { count } }"#
+        );
+
+        let result = run_query!(
+            runner,
+            r#"{groupByApp(by: [categories], orderBy: { categories: "desc" }) { _count { slug } categories }}"#
+        );
+        assert_eq!(result, "{\"data\":{\"groupByApp\":[{\"_count\":{\"slug\":1},\"categories\":[\"messaging\",\"payment\"]},{\"_count\":{\"slug\":2},\"categories\":[\"calendar\",\"other\"]},{\"_count\":{\"slug\":1},\"categories\":[]}]}}");
+
+        let result = run_query!(
+            runner,
+            r#"{groupByApp(by: [categories], orderBy: { categories: "asc" }) { _count { slug categories } }}"#
+        );
+        assert_eq!(result, "{\"data\":{\"groupByApp\":[{\"_count\":{\"slug\":1,\"categories\":1}},{\"_count\":{\"slug\":2,\"categories\":2}},{\"_count\":{\"slug\":1,\"categories\":1}}]}}");
+
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn group_by_boolean_array(runner: Runner) -> TestResult<()> {
+        // Insert some data first
+        run_query!(
+            runner,
+            r#"mutation { createManyOpp(data: [{slug:"a",categories:[true,false]},{slug:"b",categories:[]},{slug:"c",categories:[false,true]},{slug:"d",categories:[true,false]}]) { count } }"#
+        );
+
+        let result = run_query!(
+            runner,
+            r#"{groupByOpp(by: [categories], orderBy: { categories: "desc" }) { _count { slug } categories }}"#
+        );
+        assert_eq!(result, "{\"data\":{\"groupByOpp\":[{\"_count\":{\"slug\":2},\"categories\":[true,false]},{\"_count\":{\"slug\":1},\"categories\":[false,true]},{\"_count\":{\"slug\":1},\"categories\":[]}]}}");
+
+        Ok(())
+    }
+}

--- a/query-engine/connectors/query-connector/src/interface.rs
+++ b/query-engine/connectors/query-connector/src/interface.rs
@@ -119,7 +119,7 @@ impl AggregationSelection {
             AggregationSelection::Field(field) => vec![(
                 field.db_name().to_owned(),
                 field.type_identifier.clone(),
-                FieldArity::Required,
+                field.arity,
             )],
 
             AggregationSelection::Count { all, fields } => {

--- a/query-engine/connectors/sql-query-connector/src/row.rs
+++ b/query-engine/connectors/sql-query-connector/src/row.rs
@@ -122,7 +122,7 @@ impl ToSqlRow for ResultRow {
     }
 }
 
-pub fn row_value_to_prisma_value(p_value: Value, meta: ColumnMetadata<'_>) -> Result<PrismaValue, SqlError> {
+fn row_value_to_prisma_value(p_value: Value, meta: ColumnMetadata<'_>) -> Result<PrismaValue, SqlError> {
     let create_error = |value: &Value| {
         let message = match meta.name() {
             Some(name) => {


### PR DESCRIPTION


This appears to be a simple business logic error.

In this PR, we test that array field returned from groupBy queries are
properly retrieved from their rows, both when selected and when
aggregated.

closes https://github.com/prisma/prisma/issues/13097

Internal spec document: https://www.notion.so/prismaio/groupBy-array-columns-a1179e49a56c42c8b1f1bd69f617f26a

