### PR TITLE
Use mainline cuid instead of our fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,12 +556,12 @@ dependencies = [
 
 [[package]]
 name = "cuid"
-version = "0.1.0"
-source = "git+https://github.com/prisma/cuid-rust#1637fd2fc1c13815f93ea99c0c8f8f564e5b98f9"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2a2891c056384f8461606f2579208164d67475fb17a0f442ac8d5981d3c2807"
 dependencies = [
- "hostname 0.1.5",
+ "hostname",
  "lazy_static",
- "parking_lot 0.12.1",
  "rand 0.8.5",
 ]
 
@@ -1285,16 +1285,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.3",
-]
-
-[[package]]
-name = "hostname"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21ceb46a83a85e824ef93669c8b390009623863b5c195d1ba747292c0c72f94e"
-dependencies = [
- "libc",
- "winutil",
 ]
 
 [[package]]
@@ -3568,7 +3558,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
 dependencies = [
- "hostname 0.3.1",
+ "hostname",
  "quick-error",
 ]
 
@@ -5245,15 +5235,6 @@ name = "winreg"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "winutil"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7daf138b6b14196e3830a588acf1e86966c694d3e8fb026fb105b8b5dca07e6e"
 dependencies = [
  "winapi",
 ]

--- a/libs/datamodel/connectors/dml/Cargo.toml
+++ b/libs/datamodel/connectors/dml/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 prisma-value = { path = "../../../prisma-value" }
 
 uuid = { version = "1", features = ["serde", "v4"], optional = true }
-cuid = { git = "https://github.com/prisma/cuid-rust", optional = true }
+cuid = { version = "1.2", optional = true }
 chrono = { version = "0.4.6", features = ["serde"] }
 serde = { version = "1.0.90", features = ["derive"] }
 serde_json = { version = "1.0", features = ["float_roundtrip"] }

--- a/query-engine/connectors/mongodb-query-connector/Cargo.toml
+++ b/query-engine/connectors/mongodb-query-connector/Cargo.toml
@@ -51,7 +51,7 @@ features = ["derive"]
 version = "1.0"
 
 [dependencies.cuid]
-git = "https://github.com/prisma/cuid-rust"
+version = "1.2"
 
 [dependencies.user-facing-errors]
 features = ["sql"]

--- a/query-engine/connectors/sql-query-connector/Cargo.toml
+++ b/query-engine/connectors/sql-query-connector/Cargo.toml
@@ -64,7 +64,7 @@ features = ["derive"]
 version = "1.0"
 
 [dependencies.cuid]
-git = "https://github.com/prisma/cuid-rust"
+version = "1.2"
 
 [dependencies.user-facing-errors]
 features = ["sql"]

--- a/query-engine/core/Cargo.toml
+++ b/query-engine/core/Cargo.toml
@@ -42,7 +42,7 @@ tracing-opentelemetry = "0.17.4"
 url = "2"
 user-facing-errors = { path = "../../libs/user-facing-errors" }
 uuid = "1"
-cuid = { git = "https://github.com/prisma/cuid-rust" }
+cuid = "1.2"
 pin-utils = "0.1"
 lazy_static = "1.4"
 schema = { path = "../schema" }


### PR DESCRIPTION
We forked it in 2019 to fix two issues in cuid 0.1 we needed for releasing Prisma 2.0. Both of these issues are fixed ages ago in the mainline cuid. 1.2 gives always the correct block sizes for counters, always uses milliseconds for timestamps and does not depend on nightly Rust.

The crate depends on newer hostname crate, that resolves hostnames correctly on modern Windows platforms.

Closes: https://github.com/prisma/prisma/issues/14870