### PR TITLE
nix: add a derivation for all binaries in flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,8 +14,63 @@
         overlays = [ (import rust-overlay) ];
         pkgs = import nixpkgs { inherit system overlays; };
         shell = import ./shell.nix { inherit pkgs; };
+        inherit (pkgs) lib rustPlatform;
       in
       {
+        packages = {
+          prisma-engines = rustPlatform.buildRustPackage
+            {
+              name = "prisma-engines";
+              src = builtins.path {
+                path = ./.;
+                name = "prisma-engines-workspace-root-path";
+              };
+              cargoLock = {
+                lockFile = ./Cargo.lock;
+                # Hashes are required for git dependencies.
+                outputHashes = {
+                  "barrel-0.6.6-alpha.0" = "sha256-USh0lQ1z+3Spgc69bRFySUzhuY79qprLlEExTmYWFN8=";
+                  "graphql-parser-0.3.0" = "sha256-0ZAsj2mW6fCLhwTETucjbu4rPNzfbNiHu2wVTBlTNe4=";
+                  "mobc-0.7.3" = "sha256-88jSFqOyMy2E7TP1HtMcE4CQXoKhBpO8XuSFKGtfgqA=";
+                  "mysql_async-0.30.0" = "sha256-I1Q9G3H3BW/Paq9aOYGcxQf4JVwN/ZNhGuHwTqbuxWc=";
+                  "postgres-native-tls-0.5.0" = "sha256-kwqHalfwrvNQYUdAqObTAab3oWzBLl6hab2JGXVyJ3k=";
+                  "quaint-0.2.0-alpha.13" = "sha256-8vaYhXSFTibNLt+yTj+RQepzJ8CzWthhgQXVtSl+DhI=";
+                  "tokio-native-tls-0.3.0" = "sha256-ayH3TJ1iUQeZicR2nrsuxLykMoPL1fYBqRb21ValR5Q=";
+                };
+              };
+
+              cargoBuildFlags = ''
+                --package introspection-core
+                --package migration-engine-cli
+                --package prisma-fmt
+                --package query-engine
+                --package query-engine-node-api
+              '';
+
+              # Exclude the test suites that rely on a live database.
+              cargoTestFlags = ''
+                --workspace
+                --exclude query-engine-tests
+                --exclude migration-engine-tests
+                --exclude introspection-engine-tests
+                --exclude migration-engine-cli
+                --exclude mongodb-introspection-connector
+                --exclude mongodb-migration-connector
+                --exclude sql-schema-describer
+              '';
+
+              buildInputs = with pkgs; [
+                openssl
+              ];
+
+              nativeBuildInputs = with pkgs; [
+                pkg-config
+                protobuf
+                rust-bin.stable.latest.minimal
+              ];
+            };
+        };
+
         devShell = shell;
       }
     );

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
@@ -1,8 +1,8 @@
 mod max_integer;
 mod prisma_10098;
-mod prisma_13097;
 mod prisma_10935;
 mod prisma_12929;
+mod prisma_13097;
 mod prisma_14001;
 mod prisma_14696;
 mod prisma_14703;

--- a/query-engine/connectors/query-connector/src/interface.rs
+++ b/query-engine/connectors/query-connector/src/interface.rs
@@ -116,11 +116,9 @@ impl AggregationSelection {
     /// Returns (<field db name>, TypeIdentifier, FieldArity)
     pub fn identifiers(&self) -> Vec<(String, TypeIdentifier, FieldArity)> {
         match self {
-            AggregationSelection::Field(field) => vec![(
-                field.db_name().to_owned(),
-                field.type_identifier.clone(),
-                field.arity,
-            )],
+            AggregationSelection::Field(field) => {
+                vec![(field.db_name().to_owned(), field.type_identifier.clone(), field.arity)]
+            }
 
             AggregationSelection::Count { all, fields } => {
                 let mut mapped = Self::map_field_types(fields, Some(TypeIdentifier::Int));


### PR DESCRIPTION
To build it, use `nix build .#prisma-engines`. The binaries will be in `./result/bin`.

Pros:

- It's an actually reproducible build.
- It gives us a more precise picture of our external dependencies.
- It's convenient for nix users.
- It can be used as a new base for a devShell.