### PR TITLE
fix: onUpdate: restrict should only fail on fks update

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/src/utils/querying.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/src/utils/querying.rs
@@ -53,7 +53,7 @@ macro_rules! is_one_of {
 #[macro_export]
 macro_rules! run_query {
     ($runner:expr, $q:expr) => {{
-        let res = $runner.query($q).await?;
+        let res = $runner.query($q.to_string()).await?;
         res.assert_success();
         res.to_string()
     }};
@@ -62,7 +62,7 @@ macro_rules! run_query {
 #[macro_export]
 macro_rules! run_query_pretty {
     ($runner:expr, $q:expr) => {{
-        let res = $runner.query($q).await?;
+        let res = $runner.query($q.to_string()).await?;
         res.assert_success();
         res.to_string_pretty()
     }};

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_update/restrict.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_update/restrict.rs
@@ -10,6 +10,7 @@ mod one2one_req {
             r#"model Parent {
                 #id(id, Int, @id)
                 uniq  String @unique
+                name String
                 child Child?
             }
 
@@ -26,10 +27,7 @@ mod one2one_req {
     /// Updating the parent must fail if a child is connected.
     #[connector_test]
     async fn update_parent_failure(runner: Runner) -> TestResult<()> {
-        insta::assert_snapshot!(
-          run_query!(&runner, r#"mutation { createOneParent(data: { id: 1, uniq: "1", child: { create: { id: 1 }}}) { id }}"#),
-          @r###"{"data":{"createOneParent":{"id":1}}}"###
-        );
+        create_test_data(&runner).await?;
 
         let query = r#"mutation { updateOneParent(where: { id: 1 }, data: { uniq: "u1" }) { id }}"#;
 
@@ -54,10 +52,7 @@ mod one2one_req {
     /// Updating the parent must fail if a child is connected.
     #[connector_test]
     async fn update_many_parent_failure(runner: Runner) -> TestResult<()> {
-        insta::assert_snapshot!(
-          run_query!(&runner, r#"mutation { createOneParent(data: { id: 1, uniq: "1", child: { create: { id: 1 }}}) { id }}"#),
-          @r###"{"data":{"createOneParent":{"id":1}}}"###
-        );
+        create_test_data(&runner).await?;
 
         let query = r#"mutation { updateManyParent(where: { id: 1 }, data: { uniq: "u1" }) { count }}"#;
 
@@ -82,12 +77,9 @@ mod one2one_req {
     /// Updating the parent must fail if a child is connected.
     #[connector_test]
     async fn upsert_parent_failure(runner: Runner) -> TestResult<()> {
-        insta::assert_snapshot!(
-          run_query!(&runner, r#"mutation { createOneParent(data: { id: 1, uniq: "1", child: { create: { id: 1 }}}) { id }}"#),
-          @r###"{"data":{"createOneParent":{"id":1}}}"###
-        );
+        create_test_data(&runner).await?;
 
-        let query = r#"mutation { upsertOneParent(where: { id: 1 }, update: { uniq: "u1" }, create: { id: 1, uniq: "1", child: { create: { id: 1 }} }) { id }}"#;
+        let query = r#"mutation { upsertOneParent(where: { id: 1 }, update: { uniq: "u1" }, create: { id: 1, name: "Bob", uniq: "1", child: { create: { id: 1 }} }) { id }}"#;
 
         match runner.connector_version() {
             ConnectorVersion::MongoDb(_) => assert_error!(
@@ -106,6 +98,15 @@ mod one2one_req {
 
         Ok(())
     }
+
+    async fn create_test_data(runner: &Runner) -> TestResult<()> {
+        run_query!(
+            runner,
+            r#"mutation { createOneParent(data: { id: 1, name: "Bob", uniq: "1", child: { create: { id: 1 }}}) { id }}"#
+        );
+
+        Ok(())
+    }
 }
 
 #[test_suite(suite = "restrict_onU_1to1_opt", schema(optional), exclude(SqlServer))]
@@ -115,6 +116,7 @@ mod one2one_opt {
             r#"model Parent {
                 #id(id, Int, @id)
                 uniq  String @unique
+                name String
                 child Child?
             }
 
@@ -131,10 +133,7 @@ mod one2one_opt {
     /// Updating the parent must fail if a child is connected.
     #[connector_test]
     async fn update_parent_failure(runner: Runner) -> TestResult<()> {
-        insta::assert_snapshot!(
-          run_query!(&runner, r#"mutation { createOneParent(data: { id: 1, uniq: "1", child: { create: { id: 1 }}}) { id }}"#),
-          @r###"{"data":{"createOneParent":{"id":1}}}"###
-        );
+        create_test_data(&runner).await?;
 
         let query = r#"mutation { updateOneParent(where: { id: 1 }, data: { uniq: "u1" }) { id }}"#;
 
@@ -159,10 +158,7 @@ mod one2one_opt {
     /// Updating the parent must fail if a child is connected.
     #[connector_test]
     async fn update_many_parent_failure(runner: Runner) -> TestResult<()> {
-        insta::assert_snapshot!(
-          run_query!(&runner, r#"mutation { createOneParent(data: { id: 1, uniq: "1", child: { create: { id: 1 }}}) { id }}"#),
-          @r###"{"data":{"createOneParent":{"id":1}}}"###
-        );
+        create_test_data(&runner).await?;
 
         let query = r#"mutation { updateManyParent(where: { id: 1 }, data: { uniq: "u1" }) { count }}"#;
 
@@ -187,12 +183,9 @@ mod one2one_opt {
     /// Updating the parent must fail if a child is connected.
     #[connector_test]
     async fn upsert_parent_failure(runner: Runner) -> TestResult<()> {
-        insta::assert_snapshot!(
-          run_query!(&runner, r#"mutation { createOneParent(data: { id: 1, uniq: "1", child: { create: { id: 1 }}}) { id }}"#),
-          @r###"{"data":{"createOneParent":{"id":1}}}"###
-        );
+        create_test_data(&runner).await?;
 
-        let query = r#"mutation { upsertOneParent(where: { id: 1 }, update: { uniq: "u1" }, create: { id: 1, uniq: "1", child: { create: { id: 1 }} }) { id }}"#;
+        let query = r#"mutation { upsertOneParent(where: { id: 1 }, update: { uniq: "u1" }, create: { id: 1, name: "Bob", uniq: "1", child: { create: { id: 1 }} }) { id }}"#;
 
         match runner.connector_version() {
             ConnectorVersion::MongoDb(_) => assert_error!(
@@ -212,72 +205,10 @@ mod one2one_opt {
         Ok(())
     }
 
-    /// Updating the parent succeeds if no child is connected.
-    #[connector_test]
-    async fn update_parent(runner: Runner) -> TestResult<()> {
-        insta::assert_snapshot!(
-          run_query!(&runner, r#"mutation { createOneParent(data: { id: 1, uniq: "1" }) { id }}"#),
-          @r###"{"data":{"createOneParent":{"id":1}}}"###
-        );
-
-        insta::assert_snapshot!(
-          run_query!(&runner, r#"mutation { createOneParent(data: { id: 2, uniq: "2" }) { id }}"#),
-          @r###"{"data":{"createOneParent":{"id":2}}}"###
-        );
-
-        insta::assert_snapshot!(
-            r#run_query!(&runner, r#"mutation { updateOneParent(where: { id: 1 }, data: { uniq: "u1" }) { id }}"#),
-            @r###"{"data":{"updateOneParent":{"id":1}}}"###
-        );
-
-        insta::assert_snapshot!(
-            run_query!(&runner, r#"mutation { updateManyParent(where: { id: 2 }, data: { uniq: "u2" }) { count }}"#),
-            @r###"{"data":{"updateManyParent":{"count":1}}}"###
-        );
-
-        Ok(())
-    }
-
-    fn diff_id_name() -> String {
-        let schema = indoc! {
-            r#"model Parent {
-            #id(id, Int, @id)
-            uniq    Int? @unique
-            child   Child?
-          }
-          
-          model Child {
-            #id(childId, Int, @id)
-            childUniq       Int? @unique
-            parent           Parent? @relation(fields: [childUniq], references: [uniq], onUpdate: Restrict)
-          }"#
-        };
-
-        schema.to_owned()
-    }
-
-    // Updating the parent succeeds if no child is connected.
-    // Checks that it works even with different parent/child primary identifier names.
-    #[connector_test(schema(diff_id_name))]
-    async fn update_parent_diff_id_name(runner: Runner) -> TestResult<()> {
+    async fn create_test_data(runner: &Runner) -> TestResult<()> {
         run_query!(
-            &runner,
-            r#"mutation { createOneParent(data: { id: 1, uniq: 1 }) { id } }"#
-        );
-
-        insta::assert_snapshot!(
-          run_query!(&runner, r#"mutation {
-            updateOneParent(
-              where: { id: 1 }
-              data: { uniq: 2 }
-            ) {
-              id
-              uniq
-              child { childId childUniq }
-            }
-          }
-          "#),
-          @r###"{"data":{"updateOneParent":{"id":1,"uniq":2,"child":null}}}"###
+            runner,
+            r#"mutation { createOneParent(data: { id: 1, name: "Bob", uniq: "1", child: { create: { id: 1 }}}) { id }}"#
         );
 
         Ok(())
@@ -290,6 +221,7 @@ mod one2many_req {
         let schema = indoc! {
             r#"model Parent {
                 #id(id, Int, @id)
+                name String
                 uniq     String @unique
                 children Child[]
             }
@@ -307,10 +239,7 @@ mod one2many_req {
     /// Updating the parent must fail if a child is connected.
     #[connector_test]
     async fn update_parent_failure(runner: Runner) -> TestResult<()> {
-        insta::assert_snapshot!(
-          run_query!(&runner, r#"mutation { createOneParent(data: { id: 1, uniq: "1", children: { create: { id: 1 }}}) { id }}"#),
-          @r###"{"data":{"createOneParent":{"id":1}}}"###
-        );
+        create_test_data(&runner).await?;
 
         let query = r#"mutation { updateOneParent(where: { id: 1 }, data: { uniq: "u1" }) { id }}"#;
 
@@ -335,10 +264,7 @@ mod one2many_req {
     /// Updating the parent must fail if a child is connected.
     #[connector_test]
     async fn update_many_parent_failure(runner: Runner) -> TestResult<()> {
-        insta::assert_snapshot!(
-          run_query!(&runner, r#"mutation { createOneParent(data: { id: 1, uniq: "1", children: { create: { id: 1 }}}) { id }}"#),
-          @r###"{"data":{"createOneParent":{"id":1}}}"###
-        );
+        create_test_data(&runner).await?;
 
         let query = r#"mutation { updateManyParent(where: { id: 1 }, data: { uniq: "u1" }) { count }}"#;
 
@@ -363,12 +289,9 @@ mod one2many_req {
     /// Updating the parent must fail if a child is connected.
     #[connector_test]
     async fn upsert_parent_failure(runner: Runner) -> TestResult<()> {
-        insta::assert_snapshot!(
-          run_query!(&runner, r#"mutation { createOneParent(data: { id: 1, uniq: "1", children: { create: { id: 1 }}}) { id }}"#),
-          @r###"{"data":{"createOneParent":{"id":1}}}"###
-        );
+        create_test_data(&runner).await?;
 
-        let query = r#"mutation { upsertOneParent(where: { id: 1 }, update: { uniq: "u1" }, create: { id: 1, uniq: "1", children: { create: { id: 1 }} }) { id }}"#;
+        let query = r#"mutation { upsertOneParent(where: { id: 1 }, update: { uniq: "u1" }, create: { id: 1, name: "Bob", uniq: "1", children: { create: { id: 1 }} }) { id }}"#;
 
         match runner.connector_version() {
             ConnectorVersion::MongoDb(_) => assert_error!(
@@ -388,27 +311,46 @@ mod one2many_req {
         Ok(())
     }
 
-    /// Updating the parent succeeds if no child is connected.
+    /// Updating the parent succeeds if no child is connected or if the linking fields aren't part of the update payload.
     #[connector_test]
     async fn update_parent(runner: Runner) -> TestResult<()> {
-        insta::assert_snapshot!(
-          run_query!(&runner, r#"mutation { createOneParent(data: { id: 1, uniq: "1" }) { id }}"#),
-          @r###"{"data":{"createOneParent":{"id":1}}}"###
+        create_test_data(&runner).await?;
+        run_query!(
+            &runner,
+            r#"mutation { createOneParent(data: { id: 2, name: "Bob2", uniq: "2" }) { id }}"#
         );
 
+        // Linking field updated but no child connected: works
         insta::assert_snapshot!(
-          run_query!(&runner, r#"mutation { createOneParent(data: { id: 2, uniq: "2" }) { id }}"#),
-          @r###"{"data":{"createOneParent":{"id":2}}}"###
+            run_query!(&runner, r#"mutation { updateOneParent(where: { id: 2 }, data: { uniq: "u2" }) { id }}"#),
+            @r###"{"data":{"updateOneParent":{"id":2}}}"###
         );
 
+        // Child connected but no linking field updated: works
         insta::assert_snapshot!(
-            r#run_query!(&runner, r#"mutation { updateOneParent(where: { id: 1 }, data: { uniq: "u1" }) { id }}"#),
+            run_query!(&runner, r#"mutation { updateOneParent(where: { id: 1 }, data: { name: "Alice" }) { id }}"#),
             @r###"{"data":{"updateOneParent":{"id":1}}}"###
         );
 
+        // Linking field updated but no child connected: works
         insta::assert_snapshot!(
             run_query!(&runner, r#"mutation { updateManyParent(where: { id: 2 }, data: { uniq: "u2" }) { count }}"#),
             @r###"{"data":{"updateManyParent":{"count":1}}}"###
+        );
+
+        // Child connected but no linking field updated: works
+        insta::assert_snapshot!(
+            run_query!(&runner, r#"mutation { updateManyParent(where: { id: 2 }, data: { name: "Alice2" }) { count }}"#),
+            @r###"{"data":{"updateManyParent":{"count":1}}}"###
+        );
+
+        Ok(())
+    }
+
+    async fn create_test_data(runner: &Runner) -> TestResult<()> {
+        run_query!(
+            &runner,
+            r#"mutation { createOneParent(data: { id: 1, name: "Bob", uniq: "1", children: { create: { id: 1 }}}) { id }}"#
         );
 
         Ok(())
@@ -421,6 +363,7 @@ mod one2many_opt {
         let schema = indoc! {
             r#"model Parent {
                 #id(id, Int, @id)
+                name String
                 uniq     String @unique
                 children Child[]
             }
@@ -438,10 +381,7 @@ mod one2many_opt {
     /// Updating the parent must fail if a child is connected.
     #[connector_test]
     async fn update_parent_failure(runner: Runner) -> TestResult<()> {
-        insta::assert_snapshot!(
-          run_query!(&runner, r#"mutation { createOneParent(data: { id: 1, , uniq: "1", children: { create: { id: 1 }}}) { id }}"#),
-          @r###"{"data":{"createOneParent":{"id":1}}}"###
-        );
+        create_test_data(&runner).await?;
 
         let query = r#"mutation { updateOneParent(where: { id: 1 }, data: { uniq: "u1" }) { id }}"#;
 
@@ -466,10 +406,7 @@ mod one2many_opt {
     /// Updating the parent must fail if a child is connected.
     #[connector_test]
     async fn update_many_parent_failure(runner: Runner) -> TestResult<()> {
-        insta::assert_snapshot!(
-          run_query!(&runner, r#"mutation { createOneParent(data: { id: 1, uniq: "1", children: { create: { id: 1 }}}) { id }}"#),
-          @r###"{"data":{"createOneParent":{"id":1}}}"###
-        );
+        create_test_data(&runner).await?;
 
         let query = r#"mutation { updateManyParent(where: { id: 1 }, data: { uniq: "u1" }) { count }}"#;
 
@@ -494,12 +431,9 @@ mod one2many_opt {
     /// Updating the parent must fail if a child is connected.
     #[connector_test]
     async fn upsert_parent_failure(runner: Runner) -> TestResult<()> {
-        insta::assert_snapshot!(
-          run_query!(&runner, r#"mutation { createOneParent(data: { id: 1, uniq: "1", children: { create: { id: 1 }}}) { id }}"#),
-          @r###"{"data":{"createOneParent":{"id":1}}}"###
-        );
+        create_test_data(&runner).await?;
 
-        let query = r#"mutation { upsertOneParent(where: { id: 1 }, update: { uniq: "u1" }, create: { id: 1, uniq: "1", children: { create: { id: 1 }} }) { id }}"#;
+        let query = r#"mutation { upsertOneParent(where: { id: 1 }, update: { uniq: "u1" }, create: { id: 1, name: "Bob", uniq: "1", children: { create: { id: 1 }} }) { id }}"#;
 
         match runner.connector_version() {
             ConnectorVersion::MongoDb(_) => assert_error!(
@@ -519,27 +453,46 @@ mod one2many_opt {
         Ok(())
     }
 
-    /// Updating the parent succeeds if no child is connected.
+    /// Updating the parent succeeds if no child is connected or if the linking fields aren't part of the update payload.
     #[connector_test]
     async fn update_parent(runner: Runner) -> TestResult<()> {
-        insta::assert_snapshot!(
-          run_query!(&runner, r#"mutation { createOneParent(data: { id: 1, uniq: "1" }) { id }}"#),
-          @r###"{"data":{"createOneParent":{"id":1}}}"###
+        create_test_data(&runner).await?;
+        run_query!(
+            &runner,
+            r#"mutation { createOneParent(data: { id: 2, name: "Bob2", uniq: "2" }) { id }}"#
         );
 
+        // Linking field updated but no child connected: works
         insta::assert_snapshot!(
-          run_query!(&runner, r#"mutation { createOneParent(data: { id: 2, uniq: "2" }) { id }}"#),
-          @r###"{"data":{"createOneParent":{"id":2}}}"###
+            run_query!(&runner, r#"mutation { updateOneParent(where: { id: 2 }, data: { uniq: "u2" }) { id }}"#),
+            @r###"{"data":{"updateOneParent":{"id":2}}}"###
         );
 
+        // Child connected but no linking field updated: works
         insta::assert_snapshot!(
-            r#run_query!(&runner, r#"mutation { updateOneParent(where: { id: 1 }, data: { uniq: "u1" }) { id }}"#),
+            run_query!(&runner, r#"mutation { updateOneParent(where: { id: 1 }, data: { name: "Alice" }) { id }}"#),
             @r###"{"data":{"updateOneParent":{"id":1}}}"###
         );
 
+        // Linking field updated but no child connected: works
         insta::assert_snapshot!(
             run_query!(&runner, r#"mutation { updateManyParent(where: { id: 2 }, data: { uniq: "u2" }) { count }}"#),
             @r###"{"data":{"updateManyParent":{"count":1}}}"###
+        );
+
+        // Child connected but no linking field updated: works
+        insta::assert_snapshot!(
+            run_query!(&runner, r#"mutation { updateManyParent(where: { id: 2 }, data: { name: "Alice2" }) { count }}"#),
+            @r###"{"data":{"updateManyParent":{"count":1}}}"###
+        );
+
+        Ok(())
+    }
+
+    async fn create_test_data(runner: &Runner) -> TestResult<()> {
+        run_query!(
+            &runner,
+            r#"mutation { createOneParent(data: { id: 1, name: "Bob", uniq: "1", children: { create: { id: 1 }}}) { id }}"#
         );
 
         Ok(())

--- a/query-engine/core/src/query_graph_builder/write/utils.rs
+++ b/query-engine/core/src/query_graph_builder/write/utils.rs
@@ -325,7 +325,7 @@ pub fn insert_emulated_on_delete(
     for rf in relation_fields {
         match rf.relation().on_delete() {
             ReferentialAction::NoAction => continue, // Explicitly do nothing.
-            ReferentialAction::Restrict => emulate_restrict(graph, &rf, parent_node, child_node)?,
+            ReferentialAction::Restrict => emulate_on_delete_restrict(graph, &rf, parent_node, child_node)?,
             ReferentialAction::SetNull => {
                 emulate_on_delete_set_null(graph, connector_ctx, &rf, parent_node, child_node)?
             }
@@ -367,7 +367,7 @@ pub fn insert_emulated_on_delete(
 /// └ ▶   Delete / Update   │
 ///    └ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─
 /// ```
-pub fn emulate_restrict(
+pub fn emulate_on_delete_restrict(
     graph: &mut QueryGraph,
     relation_field: &RelationFieldRef,
     parent_node: &NodeRef,
@@ -746,7 +746,7 @@ pub fn emulate_on_update_set_null(
         match rf.relation().on_update() {
             ReferentialAction::NoAction => continue,
             ReferentialAction::Restrict => {
-                emulate_restrict(graph, &rf, &dependent_records_node, &set_null_dependents_node)?
+                emulate_on_delete_restrict(graph, &rf, &dependent_records_node, &set_null_dependents_node)?
             }
             ReferentialAction::SetNull => emulate_on_update_set_null(
                 graph,
@@ -765,6 +765,48 @@ pub fn emulate_on_update_set_null(
             x => panic!("Unsupported referential action emulation: {}", x),
         }
     }
+
+    Ok(())
+}
+
+pub fn emulate_on_update_restrict(
+    graph: &mut QueryGraph,
+    relation_field: &RelationFieldRef,
+    parent_node: &NodeRef,
+    child_node: &NodeRef,
+) -> QueryGraphBuilderResult<()> {
+    let noop_node = graph.create_node(Node::Empty);
+    let relation_field = relation_field.related_field();
+    let child_model_identifier = relation_field.related_model().primary_identifier();
+    let read_node = insert_find_children_by_parent_node(graph, parent_node, &relation_field, Filter::empty())?;
+
+    let linking_fields = relation_field.linking_fields();
+
+    // Unwraps are safe as in this stage, no node content can be replaced.
+    let parent_update_args = extract_update_args(graph.node_content(child_node).unwrap());
+
+    let linking_fields_updated = linking_fields
+        .into_iter()
+        .any(|parent_pk| parent_update_args.get_field_value(parent_pk.db_name()).is_some());
+
+    graph.create_edge(
+        &read_node,
+        &noop_node,
+        QueryGraphDependency::ProjectedDataDependency(
+            child_model_identifier,
+            Box::new(move |noop_node, child_ids| {
+                // If any linking fields are to be updated and there are already connected children, then fail
+                if !child_ids.is_empty() && linking_fields_updated {
+                    return Err(QueryGraphBuilderError::RelationViolation((relation_field).into()));
+                }
+
+                Ok(noop_node)
+            }),
+        ),
+    )?;
+
+    // Edge from empty node to the child (delete).
+    graph.create_edge(&noop_node, child_node, QueryGraphDependency::ExecutionOrder)?;
 
     Ok(())
 }
@@ -852,7 +894,7 @@ pub fn insert_emulated_on_update_with_intermediary_node(
     for rf in relation_fields {
         match rf.relation().on_update() {
             ReferentialAction::NoAction => continue, // Explicitly do nothing.
-            ReferentialAction::Restrict => emulate_restrict(graph, &rf, &join_node, child_node)?,
+            ReferentialAction::Restrict => emulate_on_update_restrict(graph, &rf, &join_node, child_node)?,
             ReferentialAction::SetNull => {
                 emulate_on_update_set_null(graph, &rf, connector_ctx, &join_node, child_node)?
             }
@@ -883,7 +925,7 @@ pub fn insert_emulated_on_update(
     for rf in relation_fields {
         match rf.relation().on_update() {
             ReferentialAction::NoAction => continue, // Explicitly do nothing.
-            ReferentialAction::Restrict => emulate_restrict(graph, &rf, &parent_node, child_node)?,
+            ReferentialAction::Restrict => emulate_on_update_restrict(graph, &rf, &parent_node, child_node)?,
             ReferentialAction::SetNull => {
                 emulate_on_update_set_null(graph, &rf, connector_ctx, &parent_node, child_node)?
             }


### PR DESCRIPTION
## Overview

internal spec https://www.notion.so/prismaio/emulated-onUpdate-Restrict-is-broken-e0e5109e23a64398896a748afdd8ddcd
fixes https://github.com/prisma/prisma/issues/13766