### PR TITLE
fix: prevent deletion of 'raster_columns' and 'raster_overviews' PostGIS columns in prisma migrate

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/postgres.rs
@@ -22,7 +22,6 @@ static POSTGIS_TABLES_OR_VIEWS: Lazy<RegexSet> = Lazy::new(|| {
         "(?i)^spatial_ref_sys$",
         "(?i)^geometry_columns$",
         "(?i)^geography_columns$",
-       
         // See §11.2 in: https://postgis.net/docs/using_raster_dataman.html
         "(?i)^raster_columns$",
         "(?i)^raster_overviews$",

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/postgres.rs
@@ -22,6 +22,8 @@ static POSTGIS_TABLES_OR_VIEWS: Lazy<RegexSet> = Lazy::new(|| {
         "(?i)^spatial_ref_sys$",
         "(?i)^geometry_columns$",
         "(?i)^geography_columns$",
+       
+        // See §11.2 in: https://postgis.net/docs/using_raster_dataman.html
         "(?i)^raster_columns$",
         "(?i)^raster_overviews$",
     ])

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/postgres.rs
@@ -22,6 +22,8 @@ static POSTGIS_TABLES_OR_VIEWS: Lazy<RegexSet> = Lazy::new(|| {
         "(?i)^spatial_ref_sys$",
         "(?i)^geometry_columns$",
         "(?i)^geography_columns$",
+        "(?i)^raster_columns$",
+        "(?i)^raster_overviews$",
     ])
     .unwrap()
 });

--- a/migration-engine/migration-engine-tests/tests/migrations/postgres.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/postgres.rs
@@ -71,6 +71,8 @@ fn existing_postgis_tables_must_not_be_migrated(api: TestApi) {
         /* The capitalized Geometry is intentional here, because we want the matching to be case-insensitive. */
         CREATE TABLE IF NOT EXISTS "Geometry_columns" ( id SERIAL PRIMARY KEY );
         CREATE TABLE IF NOT EXISTS "geography_columns" ( id SERIAL PRIMARY KEY );
+        CREATE TABLE IF NOT EXISTS "raster_columns" ( id SERIAL PRIMARY KEY );
+        CREATE TABLE IF NOT EXISTS "raster_overviews" ( id SERIAL PRIMARY KEY );
     "#;
 
     api.raw_cmd(create_tables);
@@ -79,7 +81,9 @@ fn existing_postgis_tables_must_not_be_migrated(api: TestApi) {
     api.assert_schema()
         .assert_has_table("spatial_ref_sys")
         .assert_has_table("Geometry_columns")
-        .assert_has_table("geography_columns");
+        .assert_has_table("geography_columns")
+        .assert_has_table("raster_columns")
+        .assert_has_table("raster_overviews");
 }
 
 // Reference for the views created by PostGIS: https://postgis.net/docs/manual-1.4/ch04.html#id418599


### PR DESCRIPTION
Follow up of [this comment](https://github.com/prisma/prisma/issues/15361) based on [this previous PR](https://github.com/prisma/prisma-engines/pull/3051).

Closes https://github.com/prisma/prisma/issues/15361 and https://github.com/prisma/prisma/issues/15363.