### PR TITLE
qe: sync @default(now()) and @updatedAt within a request

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,7 @@
                   "mobc-0.7.3" = "sha256-88jSFqOyMy2E7TP1HtMcE4CQXoKhBpO8XuSFKGtfgqA=";
                   "mysql_async-0.30.0" = "sha256-I1Q9G3H3BW/Paq9aOYGcxQf4JVwN/ZNhGuHwTqbuxWc=";
                   "postgres-native-tls-0.5.0" = "sha256-kwqHalfwrvNQYUdAqObTAab3oWzBLl6hab2JGXVyJ3k=";
-                  "quaint-0.2.0-alpha.13" = "sha256-8vaYhXSFTibNLt+yTj+RQepzJ8CzWthhgQXVtSl+DhI=";
+                  "quaint-0.2.0-alpha.13" = "sha256-kCbxrImKb5VqSjC+W/qZpS7sHSbepayZMId+TpReU5k=";
                   "tokio-native-tls-0.3.0" = "sha256-ayH3TJ1iUQeZicR2nrsuxLykMoPL1fYBqRb21ValR5Q=";
                 };
               };

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
@@ -1,6 +1,7 @@
 mod max_integer;
 mod prisma_10098;
 mod prisma_10935;
+mod prisma_12572;
 mod prisma_12929;
 mod prisma_13097;
 mod prisma_14001;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_12572.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_12572.rs
@@ -1,0 +1,59 @@
+use query_engine_tests::*;
+
+#[test_suite(schema(schema))]
+mod prisma_12572 {
+    fn schema() -> String {
+        r#"
+            model Test1 {
+                #id(id, String, @id)
+                up1 DateTime @updatedAt
+                cr1 DateTime @default(now())
+                cr2 DateTime @default(now())
+                up2 DateTime @updatedAt
+                test2s Test2[]
+            }
+
+            model Test2 {
+                #id(id, String, @id)
+                test1Id String @unique
+                test1 Test1 @relation(fields: [test1Id], references: [id])
+                cr DateTime @default(now())
+                up DateTime @updatedAt
+            }
+        "#
+        .to_owned()
+    }
+
+    #[connector_test]
+    async fn all_generated_timestamps_are_the_same(runner: Runner) -> TestResult<()> {
+        runner
+            .query(r#"mutation { createOneTest1(data: {id:"one", test2s: { create: {id: "two"}}}) { id }}"#)
+            .await?
+            .assert_success();
+        let testones = runner.query(r#"{ findManyTest1 { id up1 cr1 cr2 up2 } }"#).await?;
+        let testtwos = runner.query(r#"{ findManyTest2 { id up cr } }"#).await?;
+        testones.assert_success();
+        testtwos.assert_success();
+
+        let testones_json = testones.to_json_value();
+        let testtwos_json = testtwos.to_json_value();
+        let testone_obj = &testones_json["data"]["findManyTest1"][0];
+        let testtwo_obj = &testtwos_json["data"]["findManyTest2"][0];
+
+        let values = &[
+            &testone_obj["up1"].as_str().unwrap(),
+            &testone_obj["up2"].as_str().unwrap(),
+            &testone_obj["cr1"].as_str().unwrap(),
+            &testone_obj["cr2"].as_str().unwrap(),
+            &testtwo_obj["up"].as_str().unwrap(),
+            &testtwo_obj["cr"].as_str().unwrap(),
+        ];
+
+        // assert that all the datetimes are the same
+        for datetimes in values.windows(2) {
+            assert_eq!(datetimes[0], datetimes[1]);
+        }
+
+        Ok(())
+    }
+}

--- a/query-engine/connectors/sql-query-connector/src/model_extensions/column.rs
+++ b/query-engine/connectors/sql-query-connector/src/model_extensions/column.rs
@@ -103,10 +103,6 @@ where
         let col = sf.db_name().to_string();
 
         let column = Column::from((full_table_name, col)).type_family(sf.type_family());
-
-        match sf.default_value.as_ref().and_then(|d| d.get()) {
-            Some(default) => column.default(sf.value(default)),
-            None => column.default(quaint::ast::DefaultValue::Generated),
-        }
+        column.default(quaint::ast::DefaultValue::Generated)
     }
 }

--- a/query-engine/connectors/sql-query-connector/src/query_builder/write.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_builder/write.rs
@@ -9,7 +9,7 @@ use tracing::Span;
 
 /// `INSERT` a new record to the database. Resulting an `INSERT` ast and an
 /// optional `RecordProjection` if available from the arguments or model.
-pub fn create_record(model: &ModelRef, mut args: WriteArgs, trace_id: Option<String>) -> Insert<'static> {
+pub(crate) fn create_record(model: &ModelRef, mut args: WriteArgs, trace_id: Option<String>) -> Insert<'static> {
     let fields: Vec<_> = model
         .fields()
         .scalar()

--- a/query-engine/core/src/executor/interpreting_executor.rs
+++ b/query-engine/core/src/executor/interpreting_executor.rs
@@ -52,13 +52,16 @@ where
         if let Some(tx_id) = tx_id {
             self.itx_manager.execute(&tx_id, operation, trace_id).await
         } else {
-            execute_single_self_contained(
-                &self.connector,
-                query_schema,
-                operation,
-                trace_id,
-                self.force_transactions,
-            )
+            super::with_request_now(async move {
+                execute_single_self_contained(
+                    &self.connector,
+                    query_schema,
+                    operation,
+                    trace_id,
+                    self.force_transactions,
+                )
+                .await
+            })
             .await
         }
     }
@@ -101,7 +104,13 @@ where
             let mut conn = self.connector.get_connection().instrument(conn_span).await?;
             let mut tx = conn.start_transaction(transaction.isolation_level()).await?;
 
-            let results = execute_many_operations(query_schema, tx.as_connection_like(), &operations, trace_id).await;
+            let results = super::with_request_now(execute_many_operations(
+                query_schema,
+                tx.as_connection_like(),
+                &operations,
+                trace_id,
+            ))
+            .await;
 
             if results.is_err() {
                 tx.rollback().await?;
@@ -111,13 +120,16 @@ where
 
             results
         } else {
-            execute_many_self_contained(
-                &self.connector,
-                query_schema,
-                &operations,
-                trace_id,
-                self.force_transactions,
-            )
+            super::with_request_now(async move {
+                execute_many_self_contained(
+                    &self.connector,
+                    query_schema,
+                    &operations,
+                    trace_id,
+                    self.force_transactions,
+                )
+                .await
+            })
             .await
         }
     }
@@ -139,35 +151,38 @@ where
         valid_for_millis: u64,
         isolation_level: Option<String>,
     ) -> crate::Result<TxId> {
-        let id = TxId::default();
-        trace!("[{}] Starting...", id);
-        let connection_name = self.connector.name();
-        let conn_span = info_span!(
-            "prisma:engine:connection",
-            user_facing = true,
-            "db.type" = connection_name.as_str()
-        );
-        let conn = time::timeout(
-            Duration::from_millis(max_acquisition_millis),
-            self.connector.get_connection(),
-        )
-        .instrument(conn_span)
-        .await;
-
-        let conn = conn.map_err(|_| TransactionError::AcquisitionTimeout)??;
-        let c_tx = OpenTx::start(conn, isolation_level).await?;
-
-        self.itx_manager
-            .create_tx(
-                query_schema.clone(),
-                id.clone(),
-                c_tx,
-                Duration::from_millis(valid_for_millis),
+        super::with_request_now(async move {
+            let id = TxId::default();
+            trace!("[{}] Starting...", id);
+            let connection_name = self.connector.name();
+            let conn_span = info_span!(
+                "prisma:engine:connection",
+                user_facing = true,
+                "db.type" = connection_name.as_str()
+            );
+            let conn = time::timeout(
+                Duration::from_millis(max_acquisition_millis),
+                self.connector.get_connection(),
             )
+            .instrument(conn_span)
             .await;
 
-        debug!("[{}] Started.", id);
-        Ok(id)
+            let conn = conn.map_err(|_| TransactionError::AcquisitionTimeout)??;
+            let c_tx = OpenTx::start(conn, isolation_level).await?;
+
+            self.itx_manager
+                .create_tx(
+                    query_schema.clone(),
+                    id.clone(),
+                    c_tx,
+                    Duration::from_millis(valid_for_millis),
+                )
+                .await;
+
+            debug!("[{}] Started.", id);
+            Ok(id)
+        })
+        .await
     }
 
     async fn commit_tx(&self, tx_id: TxId) -> crate::Result<()> {

--- a/query-engine/core/src/interactive_transactions/actors.rs
+++ b/query-engine/core/src/interactive_transactions/actors.rs
@@ -272,7 +272,7 @@ pub fn spawn_itx_actor(
     span.record("itx_id", &tx_id_str.as_str());
 
     tokio::task::spawn(
-        async move {
+        crate::executor::with_request_now(async move {
             let sleep = time::sleep(timeout);
             tokio::pin!(sleep);
 
@@ -300,7 +300,7 @@ pub fn spawn_itx_actor(
             let _ = send_done.send(server.id.clone()).await;
 
             trace!("[{}] has stopped with {}", server.id.to_string(), server.cached_tx);
-        }
+        })
         .instrument(span)
         .with_subscriber(dispatcher),
     );

--- a/query-engine/core/src/query_ast/write.rs
+++ b/query-engine/core/src/query_ast/write.rs
@@ -36,7 +36,7 @@ impl WriteQuery {
             )
         }
 
-        args.update_datetimes(model);
+        args.update_datetimes(&model);
     }
 
     pub fn returns(&self, field_selection: &FieldSelection) -> bool {

--- a/query-engine/core/src/query_document/query_value.rs
+++ b/query-engine/core/src/query_document/query_value.rs
@@ -13,6 +13,7 @@ pub enum QueryValue {
     Enum(String),
     List(Vec<QueryValue>),
     Object(IndexMap<String, QueryValue>),
+    DateTime(chrono::DateTime<chrono::FixedOffset>),
 }
 
 impl PartialEq for QueryValue {
@@ -26,6 +27,9 @@ impl PartialEq for QueryValue {
             (QueryValue::Enum(kind1), QueryValue::Enum(kind2)) => kind1 == kind2,
             (QueryValue::List(list1), QueryValue::List(list2)) => list1 == list2,
             (QueryValue::Object(t1), QueryValue::Object(t2)) => t1 == t2,
+            (QueryValue::DateTime(t1), QueryValue::DateTime(t2)) => t1 == t2,
+            (QueryValue::String(t1), QueryValue::DateTime(t2)) => t1 == stringify_date(t2).as_str(),
+            (QueryValue::DateTime(t1), QueryValue::String(t2)) => stringify_date(t1).as_str() == t2,
             _ => false,
         }
     }
@@ -38,6 +42,7 @@ impl Hash for QueryValue {
             Self::Float(f) => f.hash(state),
             Self::String(s) => s.hash(state),
             Self::Boolean(b) => b.hash(state),
+            Self::DateTime(dt) => stringify_date(dt).hash(state),
             Self::Null => (),
             Self::Enum(s) => s.hash(state),
             Self::List(l) => l.hash(state),
@@ -64,7 +69,7 @@ impl From<PrismaValue> for QueryValue {
             PrismaValue::String(s) => Self::String(s),
             PrismaValue::Float(f) => Self::Float(f),
             PrismaValue::Boolean(b) => Self::Boolean(b),
-            PrismaValue::DateTime(dt) => Self::String(stringify_date(&dt)),
+            PrismaValue::DateTime(dt) => Self::DateTime(dt),
             PrismaValue::Enum(s) => Self::Enum(s),
             PrismaValue::List(l) => Self::List(l.into_iter().map(QueryValue::from).collect()),
             PrismaValue::Int(i) => Self::Int(i),

--- a/query-engine/core/src/query_graph_builder/builder.rs
+++ b/query-engine/core/src/query_graph_builder/builder.rs
@@ -33,8 +33,11 @@ impl QueryGraphBuilder {
         root_object: &ObjectTypeStrongRef, // Either the query or mutation object.
     ) -> QueryGraphBuilderResult<(QueryGraph, IrSerializer)> {
         let mut selections = vec![selection];
-        let mut parsed_object =
-            QueryDocumentParser::default().parse_object(QueryPath::default(), &selections, root_object)?;
+        let mut parsed_object = QueryDocumentParser::new(crate::executor::get_request_now()).parse_object(
+            QueryPath::default(),
+            &selections,
+            root_object,
+        )?;
 
         // Because we're processing root objects, there can only be one query / mutation.
         let field_pair = parsed_object.fields.pop().unwrap();

--- a/query-engine/core/src/query_graph_builder/write/update.rs
+++ b/query-engine/core/src/query_graph_builder/write/update.rs
@@ -148,7 +148,7 @@ where
     let update_args = WriteArgsParser::from(&model, data_map)?;
     let mut args = update_args.args;
 
-    args.update_datetimes(Arc::clone(&model));
+    args.update_datetimes(&model);
 
     let filter: Filter = filter.into();
     let update_parent = Query::Write(WriteQuery::UpdateRecord(UpdateRecord {
@@ -183,7 +183,7 @@ where
     let update_args = WriteArgsParser::from(&model, data_map)?;
     let mut args = update_args.args;
 
-    args.update_datetimes(Arc::clone(&model));
+    args.update_datetimes(&model);
 
     let update_many = UpdateManyRecords {
         model,

--- a/query-engine/core/src/query_graph_builder/write/utils.rs
+++ b/query-engine/core/src/query_graph_builder/write/utils.rs
@@ -144,7 +144,7 @@ pub fn update_records_node_placeholder<T>(graph: &mut QueryGraph, filter: T, mod
 where
     T: Into<Filter>,
 {
-    let args = WriteArgs::new();
+    let args = WriteArgs::new_empty(crate::executor::get_request_now());
     let filter = filter.into();
     let record_filter = filter.into();
 
@@ -568,7 +568,7 @@ pub fn emulate_on_delete_set_null(
     let set_null_query = WriteQuery::UpdateManyRecords(UpdateManyRecords {
         model: dependent_model.clone(),
         record_filter: RecordFilter::empty(),
-        args: child_update_args.into(),
+        args: WriteArgs::new(child_update_args, crate::executor::get_request_now()),
     });
 
     let set_null_dependents_node = graph.create_node(Query::Write(set_null_query));
@@ -693,7 +693,7 @@ pub fn emulate_on_update_set_null(
     let set_null_query = WriteQuery::UpdateManyRecords(UpdateManyRecords {
         model: dependent_model.clone(),
         record_filter: RecordFilter::empty(),
-        args: child_update_args.into(),
+        args: WriteArgs::new(child_update_args, crate::executor::get_request_now()),
     });
 
     let set_null_dependents_node = graph.create_node(Query::Write(set_null_query));
@@ -992,7 +992,10 @@ pub fn emulate_on_update_cascade(
     let update_query = WriteQuery::UpdateManyRecords(UpdateManyRecords {
         model: dependent_model.clone(),
         record_filter: RecordFilter::empty(),
-        args: child_update_args.into(),
+        args: WriteArgs::new(
+            child_update_args.into_iter().collect(),
+            crate::executor::get_request_now(),
+        ),
     });
 
     let update_dependents_node = graph.create_node(Query::Write(update_query));

--- a/query-engine/core/src/query_graph_builder/write/write_args_parser.rs
+++ b/query-engine/core/src/query_graph_builder/write/write_args_parser.rs
@@ -7,7 +7,7 @@ use prisma_models::{
 use schema_builder::constants::{args, json_null, operations};
 use std::{convert::TryInto, sync::Arc};
 
-#[derive(Default, Debug)]
+#[derive(Debug)]
 pub struct WriteArgsParser {
     pub args: WriteArgs,
     pub nested: Vec<(RelationFieldRef, ParsedInputMap)>,
@@ -18,7 +18,10 @@ impl WriteArgsParser {
     /// E.g.: { data: { THIS MAP } } from the `data` argument of a write query.
     pub fn from(model: &ModelRef, data_map: ParsedInputMap) -> QueryGraphBuilderResult<Self> {
         data_map.into_iter().try_fold(
-            WriteArgsParser::default(),
+            WriteArgsParser {
+                args: WriteArgs::new_empty(crate::executor::get_request_now()),
+                nested: Default::default(),
+            },
             |mut args, (k, v): (String, ParsedInputValue)| {
                 let field = model.fields().find_from_all(&k).unwrap();
 

--- a/query-engine/prisma-models/src/prisma_value_ext.rs
+++ b/query-engine/prisma-models/src/prisma_value_ext.rs
@@ -2,8 +2,6 @@ use super::{PrismaValue, TypeIdentifier};
 use crate::DomainError;
 use bigdecimal::ToPrimitive;
 
-// use std::convert::TryFrom;
-
 pub trait PrismaValueExtensions {
     fn coerce(self, to_type: &TypeIdentifier) -> crate::Result<PrismaValue>;
 }


### PR DESCRIPTION
Alternatives: passing the context through explicitly. I tried, it's a massive refactoring.

There are two points of difficulty here:

- Using the same PrismaValue::DateTime as the value of `now()` and `@updatedAt` for the duration of a request. We achieve that through a task local.
- The loss of precision due to the `From<PrismaValue>` impl for `QueryValue`. This is fixed by adding a `QueryValue::DateTime` variant that preserves the original precision.