### PR TITLE
qe: repair OVERWRITE_DATASOURCES param in binary CLI

### DIFF
--- a/query-engine/query-engine/src/cli.rs
+++ b/query-engine/query-engine/src/cli.rs
@@ -3,26 +3,23 @@ use crate::{
     opt::{CliOpt, PrismaOpt, Subcommand},
     PrismaResult,
 };
-use psl::Configuration;
 use query_core::{schema::QuerySchemaRef, schema_builder};
 use request_handlers::{dmmf, GraphQlHandler};
 use std::{env, sync::Arc};
 
 pub struct ExecuteRequest {
     query: String,
-    datamodel: psl::ValidatedSchema,
-    config: Configuration,
+    schema: psl::ValidatedSchema,
     enable_raw_queries: bool,
 }
 
 pub struct DmmfRequest {
-    datamodel: psl::ValidatedSchema,
+    schema: psl::ValidatedSchema,
     enable_raw_queries: bool,
-    config: Configuration,
 }
 
 pub struct GetConfigRequest {
-    config: Configuration,
+    config: psl::Configuration,
     ignore_env_var_errors: bool,
 }
 
@@ -49,9 +46,8 @@ impl CliCommand {
         match subcommand {
             Subcommand::Cli(ref cliopts) => match cliopts {
                 CliOpt::Dmmf => Ok(Some(CliCommand::Dmmf(DmmfRequest {
-                    datamodel: opts.datamodel()?,
+                    schema: opts.schema(true)?,
                     enable_raw_queries: opts.enable_raw_queries,
-                    config: opts.configuration(true)?,
                 }))),
                 CliOpt::GetConfig(input) => Ok(Some(CliCommand::GetConfig(GetConfigRequest {
                     config: opts.configuration(input.ignore_env_var_errors)?,
@@ -60,8 +56,7 @@ impl CliCommand {
                 CliOpt::ExecuteRequest(input) => Ok(Some(CliCommand::ExecuteRequest(ExecuteRequest {
                     query: input.query.clone(),
                     enable_raw_queries: opts.enable_raw_queries,
-                    datamodel: opts.datamodel()?,
-                    config: opts.configuration(false)?,
+                    schema: opts.schema(false)?,
                 }))),
                 CliOpt::DebugPanic(input) => Ok(Some(CliCommand::DebugPanic(DebugPanicRequest {
                     message: input.message.clone(),
@@ -86,23 +81,23 @@ impl CliCommand {
     }
 
     async fn dmmf(request: DmmfRequest) -> PrismaResult<()> {
-        let datasource = request.config.datasources.first();
+        let datasource = request.schema.configuration.datasources.first();
         let connector = datasource
             .map(|ds| ds.active_connector)
             .unwrap_or(&psl::datamodel_connector::EmptyDatamodelConnector);
         let referential_integrity = datasource.map(|ds| ds.referential_integrity()).unwrap_or_default();
 
         // temporary code duplication
-        let internal_data_model = prisma_models::convert(&request.datamodel, "".into());
+        let internal_data_model = prisma_models::convert(&request.schema, "".into());
         let query_schema: QuerySchemaRef = Arc::new(schema_builder::build(
             internal_data_model,
             request.enable_raw_queries,
             connector,
-            request.config.preview_features().iter().collect(),
+            request.schema.configuration.preview_features().iter().collect(),
             referential_integrity,
         ));
 
-        let dmmf = dmmf::render_dmmf(&psl::lift(&request.datamodel), query_schema);
+        let dmmf = dmmf::render_dmmf(&psl::lift(&request.schema), query_schema);
         let serialized = serde_json::to_string_pretty(&dmmf)?;
 
         println!("{}", serialized);
@@ -129,9 +124,12 @@ impl CliCommand {
         let decoded = base64::decode(&request.query)?;
         let decoded_request = String::from_utf8(decoded)?;
 
-        request.config.validate_that_one_datasource_is_provided()?;
+        request
+            .schema
+            .configuration
+            .validate_that_one_datasource_is_provided()?;
 
-        let cx = PrismaContext::builder(request.datamodel)
+        let cx = PrismaContext::builder(request.schema)
             .enable_raw_queries(request.enable_raw_queries)
             .build()
             .await?;

--- a/query-engine/query-engine/src/server/mod.rs
+++ b/query-engine/query-engine/src/server/mod.rs
@@ -61,7 +61,8 @@ impl Clone for State {
 }
 
 pub async fn setup(opts: &PrismaOpt, metrics: MetricRegistry) -> PrismaResult<State> {
-    let config = opts.configuration(false)?;
+    let datamodel = opts.schema(false)?;
+    let config = &datamodel.configuration;
     config.validate_that_one_datasource_is_provided()?;
 
     let span = tracing::info_span!("prisma:engine:connect");
@@ -72,7 +73,6 @@ pub async fn setup(opts: &PrismaOpt, metrics: MetricRegistry) -> PrismaResult<St
 
     let enable_metrics = config.preview_features().contains(PreviewFeature::Metrics);
 
-    let datamodel = opts.datamodel()?;
     let cx = PrismaContext::builder(datamodel)
         .set_metrics(metrics)
         .enable_raw_queries(opts.enable_raw_queries)


### PR DESCRIPTION
What happened:

- We introduced psl::ValidatedSchema in the QE. Unlike `parse_dml()`, it does not throw away the configuration part of the schema.
- We started using the configuration from the ValidatedSchema instead of calling `psl::parse_configuration()` on the same schema again through `Opts::configuration()`. That saved work and code.
- The logic about ignoring env vars, which is coupled to the logic for overriding datasource URLs, suddenly was out of the code paths.
- We were not overriding the datasource URLs anymore. That made the client tests fail in non-obvious ways in prisma/prisma.

How this commit fixes it:

- `Opts::schema()` now takes the same `ignore_env_var_errors` param as `Opts::configuration()` and overrides datasource urls in the same way.

It may be worth revisiting this whole mechanism later, but this should fix prisma/prisma integration for now.