### PR TITLE
qe: implement execute_raw and query_raw for MongoDbTransaction

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
@@ -5,6 +5,7 @@ mod prisma_12572;
 mod prisma_12929;
 mod prisma_13089;
 mod prisma_13097;
+mod prisma_13405;
 mod prisma_14001;
 mod prisma_14696;
 mod prisma_14703;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_13405.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_13405.rs
@@ -1,0 +1,91 @@
+use query_engine_tests::*;
+
+#[test_suite(schema(generic), only(MongoDb))]
+mod mongodb {
+    use query_engine_tests::query_core::TxId;
+    use serde_json::json;
+    use std::{future::Future, rc::Rc};
+
+    #[connector_test]
+    async fn find_raw_works_with_itx(runner: Runner) -> TestResult<()> {
+        run_in_itx(runner, |runner| async move {
+            run_query!(
+                runner,
+                r#"mutation { createOneTestModel(data: { id: 1, field: "A" }) { id }}"#
+            );
+
+            insta::assert_snapshot!(
+                run_query!(
+                    runner,
+                    r#"query { findTestModelRaw(filter: "{\"_id\": 1}") }"#
+                ),
+                @r###"{"data":{"findTestModelRaw":[{"_id":1,"field":"A"}]}}"###
+            );
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[connector_test]
+    async fn run_command_raw_works_with_itx(runner: Runner) -> TestResult<()> {
+        run_in_itx(runner, |runner| async move {
+            let command = json!({
+                "insert": "TestModel",
+                "documents": [
+                    { "_id": 1, "field": "A" },
+                    { "_id": 2, "field": "B" },
+                    { "_id": 3, "field": "C" }
+                ]
+            });
+
+            insta::assert_snapshot!(
+              run_query!(
+                runner,
+                format!(r#"mutation {{ runCommandRaw(command: "{}") }}"#, command.to_string().replace('\"', "\\\""))
+              ),
+              @r###"{"data":{"runCommandRaw":{"n":3,"ok":1.0}}}"###
+            );
+
+            Ok(())
+        })
+        .await
+    }
+
+    #[connector_test]
+    async fn aggregate_raw_works_with_itx(runner: Runner) -> TestResult<()> {
+        Ok(())
+    }
+
+    async fn run_in_itx<T, F, G>(mut runner: Runner, f: G) -> TestResult<T>
+    where
+        F: Future<Output = TestResult<T>>,
+        G: FnOnce(Rc<Runner>) -> F,
+    {
+        let tx_id = start_itx(&mut runner).await?;
+
+        let mut runner = Rc::new(runner);
+        let result = f(runner.clone()).await?;
+        let runner = Rc::get_mut(&mut runner).unwrap();
+
+        end_itx(runner, tx_id).await?;
+
+        Ok(result)
+    }
+
+    async fn start_itx(runner: &mut Runner) -> TestResult<TxId> {
+        let tx_id = runner.start_tx(5000, 5000, None).await?;
+        runner.set_active_tx(tx_id.clone());
+
+        Ok(tx_id)
+    }
+
+    async fn end_itx(runner: &mut Runner, tx_id: TxId) -> TestResult<()> {
+        let tx_result = runner.commit_tx(tx_id).await?;
+        assert!(tx_result.is_ok());
+
+        runner.clear_active_tx();
+
+        Ok(())
+    }
+}

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_13405.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_13405.rs
@@ -69,7 +69,8 @@ mod mongodb {
             );
 
             Ok(())
-        }).await
+        })
+        .await
     }
 
     async fn run_in_itx<T, F, O>(mut runner: Runner, f: O) -> TestResult<T>

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_13405.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_13405.rs
@@ -57,10 +57,10 @@ mod mongodb {
         Ok(())
     }
 
-    async fn run_in_itx<T, F, G>(mut runner: Runner, f: G) -> TestResult<T>
+    async fn run_in_itx<T, F, O>(mut runner: Runner, f: O) -> TestResult<T>
     where
         F: Future<Output = TestResult<T>>,
-        G: FnOnce(Rc<Runner>) -> F,
+        O: FnOnce(Rc<Runner>) -> F,
     {
         let tx_id = start_itx(&mut runner).await?;
 

--- a/query-engine/connectors/mongodb-query-connector/src/interface/transaction.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/interface/transaction.rs
@@ -201,17 +201,28 @@ impl<'conn> WriteOperations for MongoDbTransaction<'conn> {
         .await
     }
 
-    async fn execute_raw(&mut self, _inputs: HashMap<String, PrismaValue>) -> connector_interface::Result<usize> {
-        Err(MongoError::Unsupported("Raw queries".to_owned()).into_connector_error())
+    async fn execute_raw(&mut self, inputs: HashMap<String, PrismaValue>) -> connector_interface::Result<usize> {
+        catch(async move { write::execute_raw(&self.connection.database, &mut self.connection.session, inputs).await })
+            .await
     }
 
     async fn query_raw(
         &mut self,
-        _model: Option<&ModelRef>,
-        _inputs: HashMap<String, PrismaValue>,
-        _query_type: Option<String>,
+        model: Option<&ModelRef>,
+        inputs: HashMap<String, PrismaValue>,
+        query_type: Option<String>,
     ) -> connector_interface::Result<serde_json::Value> {
-        Err(MongoError::Unsupported("Raw queries".to_owned()).into_connector_error())
+        catch(async move {
+            write::query_raw(
+                &self.connection.database,
+                &mut self.connection.session,
+                model,
+                inputs,
+                query_type,
+            )
+            .await
+        })
+        .await
     }
 }
 

--- a/query-engine/connectors/mongodb-query-connector/src/root_queries/write.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/root_queries/write.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::{
-    error::DecorateErrorWithFieldInformationExtension,
+    error::{DecorateErrorWithFieldInformationExtension, MongoError},
     filter::{FilterPrefix, MongoFilter, MongoFilterVisitor},
     logger, output_meta,
     query_builder::MongoReadQueryBuilder,
@@ -410,7 +410,7 @@ pub async fn execute_raw<'conn>(
     _session: &mut ClientSession,
     _inputs: HashMap<String, PrismaValue>,
 ) -> crate::Result<usize> {
-    unimplemented!()
+    Err(MongoError::Unsupported("execute_raw".into()))
 }
 
 /// Execute a plain MongoDB query, returning the answer as a JSON `Value`.


### PR DESCRIPTION
In MongoDB connector, `execute_raw` and `query_raw` methods were
implemented for `MongoDbConnection` but not for `MongoDbTransaction`:
they instead contained the same stubs as `MongoDbConnection` had before
https://github.com/prisma/prisma-engines/pull/2394. It looks like they were just inadvertently forgotten.

- [x] Rust tests
- [x] TypeScript tests

Fixes: https://github.com/prisma/prisma/issues/13405
Fixes: https://github.com/prisma/prisma/issues/14543
Ref: https://github.com/prisma/prisma/pull/15442