### PR TITLE
fix: order by self-relation

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent.rs
@@ -458,7 +458,7 @@ mod order_by_dependent {
             r#"model Parent {
             #id(id, Int, @id)
           
-            resource   Resource @relation("Resource", fields: [resourceId], references: [id])
+            resource   Resource @relation("Resource", fields: [resourceId], references: [id], onUpdate: NoAction, onDelete: NoAction)
             resourceId Int      @unique
           }
           
@@ -466,7 +466,7 @@ mod order_by_dependent {
             #id(id, Int, @id)
           
             dependsOnId Int?
-            dependsOn   Resource?  @relation("DependsOn", fields: [dependsOnId], references: [id])
+            dependsOn   Resource?  @relation("DependsOn", fields: [dependsOnId], references: [id], onUpdate: NoAction, onDelete: NoAction)
           
             dependedOn  Resource[] @relation("DependsOn")
             parent      Parent?    @relation("Resource")

--- a/query-engine/connectors/sql-query-connector/src/ordering.rs
+++ b/query-engine/connectors/sql-query-connector/src/ordering.rs
@@ -17,172 +17,178 @@ pub struct OrderByDefinition {
     pub(crate) joins: Vec<AliasedJoin>,
 }
 
-/// Builds all expressions for an `ORDER BY` clause based on the query arguments.
-pub fn build(
-    query_arguments: &QueryArguments,
-    base_model: &ModelRef, // The model the ordering will start from
-) -> Vec<OrderByDefinition> {
-    let needs_reversed_order = query_arguments.needs_reversed_order();
-
-    // The index is used to differentiate potentially separate relations to the same model.
-    query_arguments
-        .order_by
-        .iter()
-        .enumerate()
-        .map(|(index, order_by)| match order_by {
-            OrderBy::Scalar(order_by) => build_order_scalar(order_by, base_model, needs_reversed_order, index),
-            OrderBy::ScalarAggregation(order_by) => build_order_aggr_scalar(order_by, needs_reversed_order),
-            OrderBy::ToManyAggregation(order_by) => {
-                build_order_aggr_rel(order_by, base_model, needs_reversed_order, index)
-            }
-            OrderBy::Relevance(order_by) => build_order_relevance(order_by, needs_reversed_order),
-        })
-        .collect_vec()
+#[derive(Debug, Default)]
+pub struct OrderByBuilder {
+    // Used to generate unique join alias
+    join_counter: usize,
 }
 
-fn build_order_scalar(
-    order_by: &OrderByScalar,
-    base_model: &ModelRef,
-    needs_reversed_order: bool,
-    index: usize,
-) -> OrderByDefinition {
-    let (joins, order_column) = compute_joins_scalar(order_by, index, base_model);
-    let order: Option<Order> = Some(into_order(
-        &order_by.sort_order,
-        order_by.nulls_order.as_ref(),
-        needs_reversed_order,
-    ));
-    let order_definition: OrderDefinition = (order_column.clone().into(), order);
+impl OrderByBuilder {
+    /// Builds all expressions for an `ORDER BY` clause based on the query arguments.
+    pub fn build(&mut self, query_arguments: &QueryArguments) -> Vec<OrderByDefinition> {
+        let needs_reversed_order = query_arguments.needs_reversed_order();
 
-    OrderByDefinition {
-        order_column: order_column.into(),
-        order_definition,
-        joins,
+        // The index is used to differentiate potentially separate relations to the same model.
+        query_arguments
+            .order_by
+            .iter()
+            .map(|order_by| match order_by {
+                OrderBy::Scalar(order_by) => self.build_order_scalar(order_by, needs_reversed_order),
+                OrderBy::ScalarAggregation(order_by) => self.build_order_aggr_scalar(order_by, needs_reversed_order),
+                OrderBy::ToManyAggregation(order_by) => self.build_order_aggr_rel(order_by, needs_reversed_order),
+                OrderBy::Relevance(order_by) => self.build_order_relevance(order_by, needs_reversed_order),
+            })
+            .collect_vec()
     }
-}
 
-fn build_order_relevance(order_by: &OrderByRelevance, needs_reversed_order: bool) -> OrderByDefinition {
-    let columns: Vec<Expression> = order_by.fields.iter().map(|sf| sf.as_column().into()).collect();
-    let order_column: Expression = text_search_relevance(&columns, order_by.search.clone()).into();
-    let order: Option<Order> = Some(into_order(&order_by.sort_order, None, needs_reversed_order));
-    let order_definition: OrderDefinition = (order_column.clone(), order);
+    fn build_order_scalar(&mut self, order_by: &OrderByScalar, needs_reversed_order: bool) -> OrderByDefinition {
+        let (joins, order_column) = self.compute_joins_scalar(order_by);
+        let order: Option<Order> = Some(into_order(
+            &order_by.sort_order,
+            order_by.nulls_order.as_ref(),
+            needs_reversed_order,
+        ));
+        let order_definition: OrderDefinition = (order_column.clone().into(), order);
 
-    OrderByDefinition {
-        order_column,
-        order_definition,
-        joins: vec![],
-    }
-}
-
-fn build_order_aggr_scalar(order_by: &OrderByScalarAggregation, needs_reversed_order: bool) -> OrderByDefinition {
-    let order: Option<Order> = Some(into_order(&order_by.sort_order, None, needs_reversed_order));
-    let order_column = order_by.field.as_column();
-    let order_definition: OrderDefinition = match order_by.sort_aggregation {
-        SortAggregation::Count => (count(order_column.clone()).into(), order),
-        SortAggregation::Avg => (avg(order_column.clone()).into(), order),
-        SortAggregation::Sum => (sum(order_column.clone()).into(), order),
-        SortAggregation::Min => (min(order_column.clone()).into(), order),
-        SortAggregation::Max => (max(order_column.clone()).into(), order),
-    };
-
-    OrderByDefinition {
-        order_column: order_column.into(),
-        order_definition,
-        joins: vec![],
-    }
-}
-
-fn build_order_aggr_rel(
-    order_by: &OrderByToManyAggregation,
-    base_model: &ModelRef,
-    needs_reversed_order: bool,
-    index: usize,
-) -> OrderByDefinition {
-    let order: Option<Order> = Some(into_order(&order_by.sort_order, None, needs_reversed_order));
-    let (joins, order_column) = compute_joins_aggregation(order_by, index, base_model);
-    let order_definition: OrderDefinition = match order_by.sort_aggregation {
-        SortAggregation::Count => {
-            let exprs: Vec<Expression> = vec![order_column.clone().into(), Value::integer(0).into()];
-
-            // We coalesce the order by expr to 0 so that if there's no relation,
-            // `COALESCE(NULL, 0)` will return `0`, thus preserving the order
-            (coalesce(exprs).into(), order)
+        OrderByDefinition {
+            order_column: order_column.into(),
+            order_definition,
+            joins,
         }
-        _ => unreachable!("Order by relation aggregation other than count are not supported"),
-    };
-
-    OrderByDefinition {
-        order_column: order_column.into(),
-        order_definition,
-        joins,
     }
-}
 
-pub fn compute_joins_aggregation(
-    order_by: &OrderByToManyAggregation,
-    order_by_index: usize,
-    base_model: &ModelRef,
-) -> (Vec<AliasedJoin>, Column<'static>) {
-    let join_prefix = format!("{}{}", ORDER_JOIN_PREFIX, order_by_index);
-    let (last_hop, rest_hops) = order_by
-        .path
-        .split_last()
-        .expect("An order by relation aggregation has to have at least one hop");
+    fn build_order_relevance(&mut self, order_by: &OrderByRelevance, needs_reversed_order: bool) -> OrderByDefinition {
+        let columns: Vec<Expression> = order_by.fields.iter().map(|sf| sf.as_column().into()).collect();
+        let order_column: Expression = text_search_relevance(&columns, order_by.search.clone()).into();
+        let order: Option<Order> = Some(into_order(&order_by.sort_order, None, needs_reversed_order));
+        let order_definition: OrderDefinition = (order_column.clone(), order);
 
-    // Unwraps are safe because the SQL connector doesn't yet support any other type of orderBy hop but the relation hop.
-    let mut joins = rest_hops
-        .iter()
-        .map(|hop| compute_one2m_join(base_model, hop.into_relation_hop().unwrap(), join_prefix.as_str()))
-        .collect_vec();
+        OrderByDefinition {
+            order_column,
+            order_definition,
+            joins: vec![],
+        }
+    }
 
-    let aggregation_type = match order_by.sort_aggregation {
-        SortAggregation::Count => AggregationType::Count,
-        _ => unreachable!("Order by relation aggregation other than count are not supported"),
-    };
+    fn build_order_aggr_scalar(
+        &mut self,
+        order_by: &OrderByScalarAggregation,
+        needs_reversed_order: bool,
+    ) -> OrderByDefinition {
+        let order: Option<Order> = Some(into_order(&order_by.sort_order, None, needs_reversed_order));
+        let order_column = order_by.field.as_column();
+        let order_definition: OrderDefinition = match order_by.sort_aggregation {
+            SortAggregation::Count => (count(order_column.clone()).into(), order),
+            SortAggregation::Avg => (avg(order_column.clone()).into(), order),
+            SortAggregation::Sum => (sum(order_column.clone()).into(), order),
+            SortAggregation::Min => (min(order_column.clone()).into(), order),
+            SortAggregation::Max => (max(order_column.clone()).into(), order),
+        };
 
-    // We perform the aggregation on the last join
-    let last_aggr_join = compute_aggr_join(
-        last_hop.into_relation_hop().unwrap(),
-        aggregation_type,
-        None,
-        ORDER_AGGREGATOR_ALIAS,
-        join_prefix.as_str(),
-        joins.last(),
-    );
+        OrderByDefinition {
+            order_column: order_column.into(),
+            order_definition,
+            joins: vec![],
+        }
+    }
 
-    // This is the final column identifier to be used for the scalar field to order by.
-    // `{last_join_alias}.{ORDER_AGGREGATOR_ALIAS}`
-    let order_by_column = Column::from((last_aggr_join.alias.to_owned(), ORDER_AGGREGATOR_ALIAS.to_owned()));
+    fn build_order_aggr_rel(
+        &mut self,
+        order_by: &OrderByToManyAggregation,
+        needs_reversed_order: bool,
+    ) -> OrderByDefinition {
+        let order: Option<Order> = Some(into_order(&order_by.sort_order, None, needs_reversed_order));
+        let (joins, order_column) = self.compute_joins_aggregation(order_by);
+        let order_definition: OrderDefinition = match order_by.sort_aggregation {
+            SortAggregation::Count => {
+                let exprs: Vec<Expression> = vec![order_column.clone().into(), Value::integer(0).into()];
 
-    joins.push(last_aggr_join);
+                // We coalesce the order by expr to 0 so that if there's no relation,
+                // `COALESCE(NULL, 0)` will return `0`, thus preserving the order
+                (coalesce(exprs).into(), order)
+            }
+            _ => unreachable!("Order by relation aggregation other than count are not supported"),
+        };
 
-    (joins, order_by_column)
-}
+        OrderByDefinition {
+            order_column: order_column.into(),
+            order_definition,
+            joins,
+        }
+    }
 
-pub fn compute_joins_scalar(
-    order_by: &OrderByScalar,
-    order_by_index: usize,
-    base_model: &ModelRef,
-) -> (Vec<AliasedJoin>, Column<'static>) {
-    let join_prefix = format!("{}{}", ORDER_JOIN_PREFIX, order_by_index);
-    let joins = order_by
-        .path
-        .iter()
-        .map(|hop| compute_one2m_join(base_model, hop.into_relation_hop().unwrap(), join_prefix.as_str()))
-        .collect_vec();
+    fn compute_joins_aggregation(
+        &mut self,
+        order_by: &OrderByToManyAggregation,
+    ) -> (Vec<AliasedJoin>, Column<'static>) {
+        let (last_hop, rest_hops) = order_by
+            .path
+            .split_last()
+            .expect("An order by relation aggregation has to have at least one hop");
 
-    // This is the final column identifier to be used for the scalar field to order by.
-    // - If we order by a scalar field on the base model, we simply use the model's scalar field. eg:
-    //   `{modelTable}.{field}`
-    // - If we order by some relations, we use the alias used for the last join, e.g.
-    //   `{join_alias}.{field}`
-    let order_by_column = if let Some(last_join) = joins.last() {
-        Column::from((last_join.alias.to_owned(), order_by.field.db_name().to_owned()))
-    } else {
-        order_by.field.as_column()
-    };
+        // Unwraps are safe because the SQL connector doesn't yet support any other type of orderBy hop but the relation hop.
+        let mut joins = vec![];
+        for (i, hop) in rest_hops.iter().enumerate() {
+            let previous_join = if i > 0 { joins.get(i - 1) } else { None };
 
-    (joins, order_by_column)
+            let join = compute_one2m_join(hop.into_relation_hop().unwrap(), &self.join_prefix(), previous_join);
+
+            joins.push(join);
+        }
+
+        let aggregation_type = match order_by.sort_aggregation {
+            SortAggregation::Count => AggregationType::Count,
+            _ => unreachable!("Order by relation aggregation other than count are not supported"),
+        };
+
+        // We perform the aggregation on the last join
+        let last_aggr_join = compute_aggr_join(
+            last_hop.into_relation_hop().unwrap(),
+            aggregation_type,
+            None,
+            ORDER_AGGREGATOR_ALIAS,
+            &self.join_prefix(),
+            joins.last(),
+        );
+
+        // This is the final column identifier to be used for the scalar field to order by.
+        // `{last_join_alias}.{ORDER_AGGREGATOR_ALIAS}`
+        let order_by_column = Column::from((last_aggr_join.alias.to_owned(), ORDER_AGGREGATOR_ALIAS.to_owned()));
+
+        joins.push(last_aggr_join);
+
+        (joins, order_by_column)
+    }
+
+    pub fn compute_joins_scalar(&mut self, order_by: &OrderByScalar) -> (Vec<AliasedJoin>, Column<'static>) {
+        let mut joins = vec![];
+
+        for (i, hop) in order_by.path.iter().enumerate() {
+            let previous_join = if i > 0 { joins.get(i - 1) } else { None };
+            let join = compute_one2m_join(hop.into_relation_hop().unwrap(), &self.join_prefix(), previous_join);
+
+            joins.push(join);
+        }
+
+        // This is the final column identifier to be used for the scalar field to order by.
+        // - If we order by a scalar field on the base model, we simply use the model's scalar field. eg:
+        //   `{modelTable}.{field}`
+        // - If we order by some relations, we use the alias used for the last join, e.g.
+        //   `{join_alias}.{field}`
+        let order_by_column = if let Some(last_join) = joins.last() {
+            Column::from((last_join.alias.to_owned(), order_by.field.db_name().to_owned()))
+        } else {
+            order_by.field.as_column()
+        };
+
+        (joins, order_by_column)
+    }
+
+    fn join_prefix(&mut self) -> String {
+        self.join_counter += 1;
+
+        format!("{}{}", ORDER_JOIN_PREFIX, self.join_counter)
+    }
 }
 
 pub fn into_order(prisma_order: &SortOrder, nulls_order: Option<&NullsOrder>, reverse: bool) -> Order {

--- a/query-engine/connectors/sql-query-connector/src/query_builder/read.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_builder/read.rs
@@ -1,6 +1,6 @@
 use crate::{
-    cursor_condition, filter_conversion::AliasedCondition, model_extensions::*, nested_aggregations, ordering,
-    sql_trace::SqlTraceComment,
+    cursor_condition, filter_conversion::AliasedCondition, model_extensions::*, nested_aggregations,
+    ordering::OrderByBuilder, sql_trace::SqlTraceComment,
 };
 use connector_interface::{filter::Filter, AggregationSelection, QueryArguments, RelAggregationSelection};
 use itertools::Itertools;
@@ -58,7 +58,7 @@ impl SelectDefinition for QueryArguments {
         aggr_selections: &[RelAggregationSelection],
         trace_id: Option<String>,
     ) -> (Select<'static>, Vec<Expression<'static>>) {
-        let order_by_definitions = ordering::build(&self, &model);
+        let order_by_definitions = OrderByBuilder::default().build(&self);
         let (table_opt, cursor_condition) = cursor_condition::build(&self, &model, &order_by_definitions);
         let aggregation_joins = nested_aggregations::build(aggr_selections);
 


### PR DESCRIPTION
## Overview

fixes https://github.com/prisma/prisma/issues/12003
fixes https://github.com/prisma/prisma/issues/9929

In the case of self-relation ordering, we weren't generating unique join aliases when hoping through multiple relations (of the same table) which was causing a SQL error (because the same aliased table was joined multiple times)