### PR TITLE
fix(qe) Retry upsert on unique index failure

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/mod.rs
@@ -8,3 +8,4 @@ mod native_types;
 mod occ;
 mod ref_actions;
 mod regressions;
+mod upsert_retry;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/upsert_retry.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/upsert_retry.rs
@@ -1,0 +1,88 @@
+use query_engine_tests::test_suite;
+
+#[test_suite]
+mod upsert_retry {
+    use std::sync::Arc;
+
+    use query_engine_tests::*;
+
+    pub fn upsert_schema() -> String {
+        let schema = indoc! {
+            r#"
+            model Post {
+                #id(id, Int, @id)
+                title     String
+                content   String?
+                author    User     @relation(fields: [authorId], references: [id])
+                authorId  Int
+              }
+              
+              model User {
+                #id(id, Int, @id)
+                email   String   @unique
+                name    String?
+                posts   Post[]
+              }
+            
+            "#
+        };
+
+        schema.to_owned()
+    }
+
+    #[connector_test(schema(upsert_schema))]
+    async fn upsert_retry_should_work(runner: Runner) -> TestResult<()> {
+        let runner = Arc::new(runner);
+
+        let mut set = tokio::task::JoinSet::new();
+
+        set.spawn(run_upsert(runner.clone()));
+        set.spawn(run_upsert(runner.clone()));
+        set.spawn(run_upsert(runner.clone()));
+        set.spawn(run_upsert(runner.clone()));
+        set.spawn(run_upsert(runner.clone()));
+        set.spawn(run_upsert(runner.clone()));
+        set.spawn(run_upsert(runner.clone()));
+        set.spawn(run_upsert(runner.clone()));
+
+        let mut updated = 0;
+        let mut created = 0;
+        while let Some(res) = set.join_next().await {
+            let name_update = res.unwrap();
+
+            if name_update == "update".to_string() {
+                updated += 1;
+            } else if name_update == "create".to_string() {
+                created += 1;
+            }
+        }
+
+        assert_eq!(created, 1);
+        assert_eq!(updated, 7);
+        Ok(())
+    }
+
+    async fn run_upsert(runner: Arc<Runner>) -> String {
+        let upsert_user = r#"
+            mutation {
+                upsertOneUser(where: {email: "user-email@test.com"},
+                create: {
+                    name: "create",
+                    id: 1,
+                    email: "user-email@test.com",
+                    posts: {
+                        createMany: { data: [{ id: 1, title: "post1" }, { id: 2, title: "post2" }] },
+                    }
+                }, update: {
+                    name: "update"
+                }    
+            ) {
+                id,
+                name
+            }
+        }
+        "#;
+        let res = runner.query(upsert_user).await.unwrap().to_json_value();
+        res["data"]["upsertOneUser"]["name"].as_str().unwrap().to_string()
+    }
+}

--- a/query-engine/core/src/error.rs
+++ b/query-engine/core/src/error.rs
@@ -74,6 +74,22 @@ impl CoreError {
             field_name
         ))
     }
+
+    pub fn is_unqiue_constraint_error(&self) -> bool {
+        match self {
+            Self::InterpreterError(e) => match e {
+                InterpreterError::ConnectorError(conn_err) => {
+                    if let Some(user_facing) = &conn_err.user_facing_error {
+                        user_facing.error_code == "P2002"
+                    } else {
+                        false
+                    }
+                }
+                _ => false,
+            },
+            _ => false,
+        }
+    }
 }
 
 impl From<QueryGraphBuilderError> for CoreError {

--- a/query-engine/core/src/query_document/operation.rs
+++ b/query-engine/core/src/query_document/operation.rs
@@ -14,6 +14,13 @@ impl Operation {
         }
     }
 
+    pub fn is_upsert(&self) -> bool {
+        match self {
+            Self::Write(selection) => selection.is_upsert(),
+            _ => false,
+        }
+    }
+
     pub fn into_read(self) -> Option<Selection> {
         match self {
             Self::Read(sel) => Some(sel),

--- a/query-engine/core/src/query_document/selection.rs
+++ b/query-engine/core/src/query_document/selection.rs
@@ -61,6 +61,10 @@ impl Selection {
         self.name.starts_with("findUnique")
     }
 
+    pub fn is_upsert(&self) -> bool {
+        self.name.starts_with("upsert")
+    }
+
     pub fn arguments(&self) -> &[(String, QueryValue)] {
         &self.arguments
     }


### PR DESCRIPTION
A unique index failure happens on an upsert when two concurrent transactions race to do an upsert in the engine. The first one will insert the row and the second will try and insert and fail with a unique index error. In those situations we rety the upsert operation so that it will do an update.