### PR TITLE
qe: don't discard the error message provided by MongoDB driver

### DIFF
--- a/query-engine/connectors/mongodb-query-connector/src/interface/mod.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/interface/mod.rs
@@ -29,8 +29,8 @@ impl MongoDb {
     pub async fn new(_source: &Datasource, url: &str) -> connector_interface::Result<Self> {
         let client = mongodb_client::create(&url).await.map_err(|err| {
             let kind = match err.kind {
-                mongodb_client::ErrorKind::InvalidArgument { .. } => ErrorKind::InvalidDatabaseUrl {
-                    details: "Unable to parse URL.".to_owned(),
+                mongodb_client::ErrorKind::InvalidArgument { message } => ErrorKind::InvalidDatabaseUrl {
+                    details: format!("MongoDB connection string error: {message}"),
                     url: url.to_owned(),
                 },
                 mongodb_client::ErrorKind::Other(err) => ErrorKind::ConnectionError(err.into()),

--- a/query-engine/connectors/mongodb-query-connector/src/interface/mod.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/interface/mod.rs
@@ -115,7 +115,9 @@ mod tests {
 
         let error = MongoDb::new(&datasource, url).await.err().unwrap();
 
-        assert!(error.to_string().contains("a port cannot be specified with 'mongodb+srv'"));
+        assert!(error
+            .to_string()
+            .contains("a port cannot be specified with 'mongodb+srv'"));
     }
 
     /// Regression test for https://github.com/prisma/prisma/issues/11883


### PR DESCRIPTION
Before: "The provided database string is invalid. **Unable to parse URL. in database URL.** Please refer to the documentation in https://www.prisma.io/docs/reference/database-reference/connection-urls for constructing a correct connection string. In some cases, certain characters must be escaped. Please check the string for any illegal characters."

After: "The provided database string is invalid. **MongoDB connection string error: a port cannot be specified with 'mongodb+srv' in database URL.** Please refer to the documentation in https://www.prisma.io/docs/reference/database-reference/connection-urls for constructing a correct connection string. In some cases, certain characters must be escaped. Please check the string for any illegal characters."

Fixes: https://github.com/prisma/prisma/issues/13388
Fixes: https://github.com/prisma/prisma/issues/11883
