### PR TITLE
Fix clippy warnings

### DIFF
--- a/libs/datamodel/parser-database/src/attributes.rs
+++ b/libs/datamodel/parser-database/src/attributes.rs
@@ -389,7 +389,7 @@ fn visit_relation_field_attributes<'db>(
             1 => format!(" Did you mean to put it on `{field}`?", field = suggested_fields[0],),
             _ => {
                 format!(
-                    " Did you mean to provide `@@unique([{}])`?",
+                    " Did you mean to provide `@@unique([{field}])`?",
                     field = suggested_fields.join(", ")
                 )
             }

--- a/libs/datamodel/parser-database/src/coerce_expression.rs
+++ b/libs/datamodel/parser-database/src/coerce_expression.rs
@@ -104,5 +104,5 @@ pub fn coerce_array<'a, T>(
         _ => out.push(coercion(expr, diagnostics)?),
     }
 
-    is_valid.then(|| out)
+    is_valid.then_some(out)
 }

--- a/query-engine/schema/src/enum_type.rs
+++ b/query-engine/schema/src/enum_type.rs
@@ -56,7 +56,7 @@ impl StringEnumType {
 
     /// Attempts to find an enum value for the given value key.
     pub fn value_for(&self, name: &str) -> Option<&str> {
-        self.values.iter().find_map(|val| (val == name).then(|| val.as_str()))
+        self.values.iter().find_map(|val| (val == name).then_some(val.as_str()))
     }
 
     pub fn values(&self) -> &[String] {
@@ -119,7 +119,7 @@ impl FieldRefEnumType {
 
     /// Attempts to find an enum value for the given value key.
     pub fn value_for(&self, name: &str) -> Option<&ScalarFieldRef> {
-        self.values.iter().find_map(|val| (val.0 == name).then(|| &val.1))
+        self.values.iter().find_map(|val| (val.0 == name).then_some(&val.1))
     }
 
     pub fn values(&self) -> Vec<String> {


### PR DESCRIPTION
With Rust 1.64.0 out today, the CI is now red because of new Clippy warnings.
This PR fixes that.
