### PR TITLE
qe: map write conflict errors to an error code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3077,7 +3077,7 @@ dependencies = [
 [[package]]
 name = "quaint"
 version = "0.2.0-alpha.13"
-source = "git+https://github.com/prisma/quaint#34d170cc04c50cc8c4f3ac01d638720f404fb49b"
+source = "git+https://github.com/prisma/quaint#abefaf7995e046b3811d4a5e56ca4acb76cf461c"
 dependencies = [
  "async-trait",
  "base64 0.12.3",

--- a/libs/user-facing-errors/src/query_engine.rs
+++ b/libs/user-facing-errors/src/query_engine.rs
@@ -331,3 +331,10 @@ pub struct MissingFieldsInModel {
 pub struct ValueFitError {
     pub details: String,
 }
+
+#[derive(Debug, UserFacingError, Serialize)]
+#[user_facing(
+    code = "P2034",
+    message = "Transaction failed due to a write conflict or a deadlock. Please retry your transaction"
+)]
+pub struct TransactionWriteConflict {}

--- a/query-engine/connectors/mongodb-query-connector/src/error.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/error.rs
@@ -138,6 +138,10 @@ impl MongoError {
                     ConnectorError::from_kind(ErrorKind::MongoReplicaSetRequired)
                 }
 
+                mongodb::error::ErrorKind::Command(CommandError { code, .. }) if *code == 112 => {
+                    ConnectorError::from_kind(ErrorKind::TransactionWriteConflict)
+                }
+
                 mongodb::error::ErrorKind::Write(write_failure) => match write_failure {
                     mongodb::error::WriteFailure::WriteConcernError(concern_error) => match concern_error.code {
                         11000 => ConnectorError::from_kind(unique_violation_error(concern_error.message.as_str())),

--- a/query-engine/connectors/query-connector/src/error.rs
+++ b/query-engine/connectors/query-connector/src/error.rs
@@ -89,6 +89,9 @@ impl ConnectorError {
             ErrorKind::TransactionAborted { message } => Some(KnownError::new(
                 user_facing_errors::query_engine::InteractiveTransactionError { error: message.clone() },
             )),
+            ErrorKind::TransactionWriteConflict => Some(KnownError::new(
+                user_facing_errors::query_engine::TransactionWriteConflict {},
+            )),
             ErrorKind::MongoReplicaSetRequired => Some(KnownError::new(
                 user_facing_errors::query_engine::MongoReplicaSetRequired {},
             )),
@@ -215,6 +218,9 @@ pub enum ErrorKind {
 
     #[error("{}", message)]
     TransactionAlreadyClosed { message: String },
+
+    #[error("Transaction write conflict")]
+    TransactionWriteConflict,
 
     #[error("The query parameter limit supported by your database is exceeded: {0}.")]
     QueryParameterLimitExceeded(String),

--- a/query-engine/connectors/sql-query-connector/src/error.rs
+++ b/query-engine/connectors/sql-query-connector/src/error.rs
@@ -159,6 +159,9 @@ pub enum SqlError {
     #[error("{}", _0)]
     InvalidIsolationLevel(String),
 
+    #[error("Transaction write conflict")]
+    TransactionWriteConflict,
+
     #[error("Query parameter limit exceeded error: {0}.")]
     QueryParameterLimitExceeded(String),
 
@@ -254,6 +257,13 @@ impl SqlError {
                 )),
                 kind: ErrorKind::TransactionAlreadyClosed { message },
             },
+
+            SqlError::TransactionWriteConflict => ConnectorError {
+                user_facing_error: Some(user_facing_errors::KnownError::new(
+                    user_facing_errors::query_engine::TransactionWriteConflict {},
+                )),
+                kind: ErrorKind::TransactionWriteConflict,
+            },
             SqlError::QueryParameterLimitExceeded(e) => {
                 ConnectorError::from_kind(ErrorKind::QueryParameterLimitExceeded(e))
             }
@@ -293,6 +303,7 @@ impl From<quaint::error::Error> for SqlError {
             QuaintKind::TableDoesNotExist { table } => SqlError::TableDoesNotExist(format!("{}", table)),
             QuaintKind::ConnectionClosed => SqlError::ConnectionClosed,
             QuaintKind::InvalidIsolationLevel(msg) => Self::InvalidIsolationLevel(msg),
+            QuaintKind::TransactionWriteConflict => Self::TransactionWriteConflict,
             e @ QuaintKind::UnsupportedColumnType { .. } => SqlError::ConversionError(e.into()),
             e @ QuaintKind::TransactionAlreadyClosed(_) => SqlError::TransactionAlreadyClosed(format!("{}", e)),
             e @ QuaintKind::IncorrectNumberOfParameters { .. } => SqlError::QueryError(e.into()),


### PR DESCRIPTION
For higher isolation levels, users should be able to catch them and
react accordingly.
