### PR TITLE
feat(postgres): reduced default batch size by 1

### DIFF
--- a/query-engine/connectors/sql-query-connector/src/sql_info.rs
+++ b/query-engine/connectors/sql-query-connector/src/sql_info.rs
@@ -77,8 +77,7 @@ impl SqlInfo {
         Self {
             family: SqlFamily::Postgres,
             max_rows: None,
-            // TODO: this threshold is not tight
-            max_bind_values: get_batch_size(25000),
+            max_bind_values: get_batch_size(32766),
             capabilities: ConnectorCapabilities::new(psl::builtin_connectors::POSTGRES.capabilities().to_owned()),
         }
     }

--- a/query-engine/connectors/sql-query-connector/src/sql_info.rs
+++ b/query-engine/connectors/sql-query-connector/src/sql_info.rs
@@ -77,7 +77,8 @@ impl SqlInfo {
         Self {
             family: SqlFamily::Postgres,
             max_rows: None,
-            max_bind_values: get_batch_size(32766),
+            // TODO: this threshold is not tight
+            max_bind_values: get_batch_size(25000),
             capabilities: ConnectorCapabilities::new(psl::builtin_connectors::POSTGRES.capabilities().to_owned()),
         }
     }

--- a/query-engine/connectors/sql-query-connector/src/sql_info.rs
+++ b/query-engine/connectors/sql-query-connector/src/sql_info.rs
@@ -74,7 +74,7 @@ impl SqlInfo {
         Self {
             family: SqlFamily::Postgres,
             max_rows: None,
-            max_bind_values: get_batch_size(32767),
+            max_bind_values: get_batch_size(32766),
             capabilities: ConnectorCapabilities::new(psl::builtin_connectors::POSTGRES.capabilities().to_owned()),
         }
     }


### PR DESCRIPTION
- Context: https://www.notion.so/prismaio/Postgres-parameters-length-validation-ffc127b887984e02b9d931fcec4d6d15#62014932a75e438e9eb07306aee43224
- Companion TS regression PR: https://github.com/prisma/prisma/pull/15522
- This PR deprecates the previous TS regression PR: https://github.com/prisma/prisma/pull/15490
- You can quickly see the differences between the two TS PRs [here](https://github.com/prisma/prisma/compare/integration/engines-4.4.0-61.integration-smaller-pg-batch-size-d648eeea3754295b57706d66257a7fe7be19c7c9...integration/engines-4.4.0-54.integration-database-assertion-violation-error-2-4eff3e6e5529e98980308c423c302b1fcfc72e6a) (focus on the #8832 reproduction).