### PR TITLE
qe: use same uuidfilters on postgres and crdb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,8 @@ buildkite-script-*
 # Dev setup
 datamodel_v2.prisma
 dev_datamodel.prisma
-target/
 .tmp/
+/target/
+/result
 
 dmmf.json

--- a/psl/builtin-connectors/src/cockroach_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/cockroach_datamodel_connector.rs
@@ -7,7 +7,7 @@ use psl_core::{
     datamodel_connector::{
         helper::{arg_vec_from_opt, args_vec_from_opt, parse_one_opt_u32, parse_two_opt_u32},
         Connector, ConnectorCapability, ConstraintScope, NativeTypeConstructor, NativeTypeInstance,
-        ReferentialIntegrity,
+        ReferentialIntegrity, StringFilter,
     },
     diagnostics::{DatamodelError, Diagnostics},
     parser_database::{
@@ -18,6 +18,7 @@ use psl_core::{
         IndexAlgorithm, ParserDatabase, ReferentialAction, ScalarType,
     },
 };
+use std::borrow::Cow;
 
 const BIT_TYPE_NAME: &str = "Bit";
 const BOOL_TYPE_NAME: &str = "Bool";
@@ -337,6 +338,20 @@ impl Connector for CockroachDatamodelConnector {
             NativeTypeInstance::new(constructor.name, args, native_type.to_json())
         } else {
             unreachable!()
+        }
+    }
+
+    fn scalar_filter_name(&self, scalar_type_name: String, native_type_name: Option<&str>) -> Cow<'_, str> {
+        match native_type_name {
+            Some(name) if name.eq_ignore_ascii_case("uuid") => "Uuid".into(),
+            _ => scalar_type_name.into(),
+        }
+    }
+
+    fn string_filters(&self, input_object_name: &str) -> BitFlags<StringFilter> {
+        match input_object_name {
+            "Uuid" => BitFlags::empty(),
+            _ => BitFlags::all(),
         }
     }
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/uuid_filters.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/uuid_filters.rs
@@ -1,6 +1,6 @@
 use query_engine_tests::*;
 
-#[test_suite(schema(schema), only(Postgres))]
+#[test_suite(schema(schema), only(Postgres, CockroachDb))]
 mod uuid_filter_spec {
     fn schema() -> String {
         r#"


### PR DESCRIPTION
We only implemented the fix for postgres in
7e0dbcd. This does the same for
cockroachdb. The test that was used to confirm that cockroachdb does not
support LIKE queries on UUID columns is the following:

```
You are now connected to database "test_uuid_like" as user "prisma".
test_uuid_like=> CREATE TABLE tests (id SERIAL PRIMARY KEY, uuid_col UUID);
NOTICE:  using sequential values in a primary key does not perform as well as using random UUIDs. See https://www.cockroachlabs.com/docs/v22.1/serial.html
CREATE TABLE
test_uuid_like=> SELECT * FROM tests;
 id | uuid_col
----+----------
(0 rows)

test_uuid_like=> SELECT * FROM tests WHERE uuid_col LIKE 'fff*';
ERROR:  unsupported comparison operator: <uuid> LIKE <string>
```