### PR TITLE
qe: don't panic when conversion from BigDecimal to i64 fails

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
@@ -9,6 +9,7 @@ mod prisma_13405;
 mod prisma_14001;
 mod prisma_14696;
 mod prisma_14703;
+mod prisma_15204;
 mod prisma_5952;
 mod prisma_6173;
 mod prisma_7010;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_15204.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_15204.rs
@@ -1,0 +1,55 @@
+use query_engine_tests::*;
+
+#[test_suite(only(Sqlite))]
+mod conversion_error {
+    fn schema_int() -> String {
+        let schema = indoc! {
+            r#"model TestModel {
+                #id(id, Int, @id)
+                field Int
+            }"#
+        };
+
+        schema.to_owned()
+    }
+
+    fn schema_bigint() -> String {
+        let schema = indoc! {
+            r#"model TestModel {
+                #id(id, Int, @id)
+                field BigInt
+            }"#
+        };
+
+        schema.to_owned()
+    }
+
+    async fn test(runner: Runner) -> TestResult<()> {
+        run_query!(
+            runner,
+            fmt_query_raw(
+                r#"INSERT INTO "TestModel" ("id", "field") VALUES (1, 1.84467440724388e+19)"#,
+                vec![]
+            )
+        );
+
+        let res = runner.query(r#"query { findManyTestModel { field } }"#).await?;
+
+        res.assert_failure(
+            2020,
+            Some("Unable to convert BigDecimal value \"18446744072438800000\" to type i64".into()),
+        );
+
+        Ok(())
+    }
+
+    #[connector_test(schema(schema_int))]
+    async fn convert_to_int(runner: Runner) -> TestResult<()> {
+        test(runner).await
+    }
+
+    #[connector_test(schema(schema_bigint))]
+    async fn convert_to_bigint(runner: Runner) -> TestResult<()> {
+        test(runner).await
+    }
+}

--- a/query-engine/core/src/error.rs
+++ b/query-engine/core/src/error.rs
@@ -146,6 +146,7 @@ impl From<CoreError> for user_facing_errors::Error {
                 })
                 .into()
             }
+
             CoreError::ConnectorError(ConnectorError {
                 user_facing_error: Some(user_facing_error),
                 ..
@@ -154,6 +155,7 @@ impl From<CoreError> for user_facing_errors::Error {
                 user_facing_error: Some(user_facing_error),
                 ..
             })) => user_facing_error.into(),
+
             CoreError::QueryParserError(query_parser_error)
             | CoreError::QueryGraphBuilderError(QueryGraphBuilderError::QueryParserError(query_parser_error)) => {
                 let known_error = match query_parser_error.error_kind {
@@ -170,6 +172,7 @@ impl From<CoreError> for user_facing_errors::Error {
 
                 known_error.into()
             }
+
             CoreError::QueryGraphBuilderError(QueryGraphBuilderError::MissingRequiredArgument {
                 argument_name,
                 object_name,
@@ -180,6 +183,7 @@ impl From<CoreError> for user_facing_errors::Error {
                 object_name,
             })
             .into(),
+
             CoreError::QueryGraphBuilderError(QueryGraphBuilderError::RelationViolation(RelationViolation {
                 relation_name,
                 model_a_name,
@@ -197,6 +201,7 @@ impl From<CoreError> for user_facing_errors::Error {
                 model_b_name,
             })
             .into(),
+
             CoreError::QueryGraphBuilderError(QueryGraphBuilderError::RecordNotFound(details))
             | CoreError::InterpreterError(InterpreterError::QueryGraphBuilderError(
                 QueryGraphBuilderError::RecordNotFound(details),
@@ -204,9 +209,11 @@ impl From<CoreError> for user_facing_errors::Error {
                 details,
             })
             .into(),
+
             CoreError::QueryGraphBuilderError(QueryGraphBuilderError::InputError(details)) => {
                 user_facing_errors::KnownError::new(user_facing_errors::query_engine::InputError { details }).into()
             }
+
             CoreError::InterpreterError(InterpreterError::InterpretationError(msg, Some(cause))) => {
                 match cause.as_ref() {
                     InterpreterError::QueryGraphBuilderError(QueryGraphBuilderError::RecordNotFound(cause)) => {
@@ -243,6 +250,7 @@ impl From<CoreError> for user_facing_errors::Error {
                     .into(),
                 }
             }
+
             CoreError::FieldConversionError(FieldConversionError {
                 field,
                 expected_type,
@@ -253,6 +261,14 @@ impl From<CoreError> for user_facing_errors::Error {
                 found,
             })
             .into(),
+
+            CoreError::ConversionError { .. } => {
+                user_facing_errors::KnownError::new(user_facing_errors::query_engine::ValueOutOfRange {
+                    details: err.to_string(),
+                })
+                .into()
+            }
+
             _ => user_facing_errors::Error::from_dyn_error(&err),
         }
     }

--- a/query-engine/core/src/error.rs
+++ b/query-engine/core/src/error.rs
@@ -2,6 +2,7 @@ use crate::{
     InterpreterError, QueryGraphBuilderError, QueryGraphError, QueryParserError, QueryParserErrorKind,
     RelationViolation, TransactionError,
 };
+use bigdecimal::BigDecimal;
 use connector::error::ConnectorError;
 use prisma_models::DomainError;
 use thiserror::Error;
@@ -48,8 +49,12 @@ pub enum CoreError {
     #[error("Unsupported feature: {}", _0)]
     UnsupportedFeatureError(String),
 
-    #[error("{}", _0)]
-    ConversionError(String),
+    #[error("Unable to convert {from_type} value \"{value}\" to type {to_type}")]
+    ConversionError {
+        value: String,
+        from_type: String,
+        to_type: String,
+    },
 
     #[error("{}", _0)]
     SerializationError(String),
@@ -73,6 +78,14 @@ impl CoreError {
             "Inconsistent query result: Field {} is required to return data, got `null` instead.",
             field_name
         ))
+    }
+
+    pub fn decimal_conversion_error(decimal: &BigDecimal, to_type: &str) -> Self {
+        CoreError::ConversionError {
+            value: decimal.to_string(),
+            from_type: "BigDecimal".into(),
+            to_type: to_type.into(),
+        }
     }
 }
 

--- a/query-engine/core/src/response_ir/internal.rs
+++ b/query-engine/core/src/response_ir/internal.rs
@@ -540,20 +540,22 @@ fn convert_prisma_value(field: &OutputFieldRef, value: PrismaValue, st: &ScalarT
         (ScalarType::Json, PrismaValue::String(s)) => PrismaValue::Json(s),
         (ScalarType::Json, PrismaValue::Json(s)) => PrismaValue::Json(s),
 
-        (ScalarType::Int, PrismaValue::Float(f)) => PrismaValue::Int(f.to_i64().unwrap()),
+        (ScalarType::Int, PrismaValue::Float(f)) => {
+            PrismaValue::Int(f.to_i64().ok_or(CoreError::decimal_conversion_error(&f, "i64"))?)
+        }
         (ScalarType::Int, PrismaValue::Int(i)) => PrismaValue::Int(i),
 
         (ScalarType::Float, PrismaValue::Float(f)) => PrismaValue::Float(f),
-        (ScalarType::Float, PrismaValue::Int(i)) => {
-            PrismaValue::Int(i.to_i64().expect("Unable to convert BigDecimal to i64."))
-        }
+        (ScalarType::Float, PrismaValue::Int(i)) => PrismaValue::Int(i),
 
         (ScalarType::Decimal, PrismaValue::Int(i)) => PrismaValue::String(i.to_string()),
         (ScalarType::Decimal, PrismaValue::Float(f)) => PrismaValue::String(f.to_string()),
 
         (ScalarType::BigInt, PrismaValue::BigInt(i)) => PrismaValue::BigInt(i),
         (ScalarType::BigInt, PrismaValue::Int(i)) => PrismaValue::BigInt(i),
-        (ScalarType::BigInt, PrismaValue::Float(f)) => PrismaValue::BigInt(f.to_i64().unwrap()),
+        (ScalarType::BigInt, PrismaValue::Float(f)) => {
+            PrismaValue::BigInt(f.to_i64().ok_or(CoreError::decimal_conversion_error(&f, "i64"))?)
+        }
 
         (ScalarType::Boolean, PrismaValue::Boolean(b)) => PrismaValue::Boolean(b),
         (ScalarType::Int, PrismaValue::Boolean(b)) => PrismaValue::Int(b as i64),


### PR DESCRIPTION
Return an error instead of panicking when representing a `BigDecimal` as
an `i64` is not possible.

This was fixed for two cases that tried to `unwrap()` the resulting
`Option<i64>` after conversion.

Additionally, I removed the conversion altogether in the
`(ScalarType::Float, PrismaValue::Int(i))` case: it was a no-op since
`i` there is already an `i64` and not a `BigDecimal`.

Fixes: https://github.com/prisma/prisma/issues/15204
