### PR TITLE
qe: Correctly handle rollback on mssql when transaction have been automatically rolled back

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3075,7 +3075,7 @@ dependencies = [
 [[package]]
 name = "quaint"
 version = "0.2.0-alpha.13"
-source = "git+https://github.com/prisma/quaint#246d4700bc04213615a486fcab1250ec04e8cdf5"
+source = "git+https://github.com/prisma/quaint#9f98460095259475dea894aaef4b3a40873c2562"
 dependencies = [
  "async-trait",
  "base64 0.12.3",
@@ -4329,9 +4329,9 @@ dependencies = [
 
 [[package]]
 name = "tiberius"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dd129ffe1a5339d666be4b9c98525a9fb4df211f0c7061b58b34fcde86502e"
+checksum = "0b01df772356f892073752d7e9d5b42798cd330477ce6d18b92b4a82d98d31a2"
 dependencies = [
  "async-native-tls",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3075,7 +3075,7 @@ dependencies = [
 [[package]]
 name = "quaint"
 version = "0.2.0-alpha.13"
-source = "git+https://github.com/prisma/quaint#0895b68669f76cc18bbcbe5e9aa126a8a12bf775"
+source = "git+https://github.com/prisma/quaint#246d4700bc04213615a486fcab1250ec04e8cdf5"
 dependencies = [
  "async-trait",
  "base64 0.12.3",
@@ -4329,8 +4329,9 @@ dependencies = [
 
 [[package]]
 name = "tiberius"
-version = "0.11.0"
-source = "git+https://github.com/prisma/tiberius?branch=fix/read-stream-on-error#cadfda913ee8cadefe06ea4e9b9c925e056c1867"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07dd129ffe1a5339d666be4b9c98525a9fb4df211f0c7061b58b34fcde86502e"
 dependencies = [
  "async-native-tls",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4330,8 +4330,7 @@ dependencies = [
 [[package]]
 name = "tiberius"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f9232bb2d5c2e28c922c1247c9e8cf0bec361ae1865300308387ced5d0a922d"
+source = "git+https://github.com/prisma/tiberius?branch=fix/read-stream-on-error#cadfda913ee8cadefe06ea4e9b9c925e056c1867"
 dependencies = [
  "async-native-tls",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2436,9 +2436,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
+checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
 name = "opaque-debug"
@@ -3065,6 +3065,7 @@ dependencies = [
  "migration-core",
  "mongodb",
  "mongodb-client",
+ "parking_lot 0.12.1",
  "psl",
  "quaint",
  "tempfile",
@@ -3295,6 +3296,7 @@ dependencies = [
  "colored",
  "indoc",
  "insta",
+ "once_cell",
  "prisma-value",
  "psl",
  "query-engine-metrics",
@@ -3304,6 +3306,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-futures",
+ "user-facing-errors",
  "uuid 1.1.2",
 ]
 

--- a/migration-engine/qe-setup/Cargo.toml
+++ b/migration-engine/qe-setup/Cargo.toml
@@ -9,6 +9,7 @@ mongodb-client = { path = "../../libs/mongodb-client" }
 migration-core = { path = "../core" }
 test-setup = { path = "../../libs/test-setup" }
 
+parking_lot = { version = "0.12", features = ["send_guard"] }
 connection-string = "*"
 enumflags2 = "*"
 mongodb = "2.3.0"

--- a/migration-engine/qe-setup/src/lib.rs
+++ b/migration-engine/qe-setup/src/lib.rs
@@ -87,12 +87,12 @@ pub async fn teardown(prisma_schema: &str, db_schemas: &[&str]) -> ConnectorResu
 
 #[derive(Default)]
 struct LoggingHost {
-    printed: std::sync::Mutex<Vec<String>>,
+    printed: parking_lot::Mutex<Vec<String>>,
 }
 
 impl migration_core::migration_connector::ConnectorHost for LoggingHost {
     fn print(&self, text: &str) -> BoxFuture<'_, ConnectorResult<()>> {
-        let mut msgs = self.printed.lock().unwrap();
+        let mut msgs = self.printed.lock();
         msgs.push(text.to_owned());
         Box::pin(std::future::ready(Ok(())))
     }
@@ -117,7 +117,7 @@ async fn diff_and_apply(schema: &str) {
     })
     .await
     .unwrap();
-    let migrations = host.printed.lock().unwrap();
+    let migrations = host.printed.lock();
     let migration = migrations[0].clone();
     drop(migrations);
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/Cargo.toml
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/Cargo.toml
@@ -18,8 +18,10 @@ psl.workspace = true
 base64 = "0.13"
 uuid.workspace = true
 tokio.workspace = true
+user-facing-errors.workspace = true
 prisma-value = { path = "../../../libs/prisma-value" }
 query-engine-metrics = { path = "../../metrics"}
+once_cell = "1.15.0"
 
 [dev-dependencies]
 insta = "1.7.1"

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
@@ -12,6 +12,7 @@ mod prisma_14703;
 mod prisma_15204;
 mod prisma_15264;
 mod prisma_15581;
+mod prisma_15607;
 mod prisma_5952;
 mod prisma_6173;
 mod prisma_7010;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_15607.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_15607.rs
@@ -1,0 +1,286 @@
+//! Testing deadlocks on SQL Server deadlocks and deadlock recovery.
+//! Due to certain queries hanging forever until the second
+//! transaction progresses, the test uses separate engines inside
+//! actors to allow test to continue even if one query is blocking.
+
+use std::future::Future;
+
+use indoc::indoc;
+use once_cell::sync::Lazy;
+use query_engine_tests::{
+    query_core::TxId, render_test_datamodel, setup_metrics, setup_project, test_tracing_subscriber, ConnectorTag,
+    QueryResult, Runner, TestConfig, TestError, TestResult, TryFrom, WithSubscriber, ENV_LOG_LEVEL,
+};
+use tokio::sync::mpsc;
+
+static CONFIG: Lazy<TestConfig> = Lazy::new(|| TestConfig::load().unwrap());
+
+const SCHEMA: &str = indoc! {r#"
+    model Country {
+      id         Int    @id
+      name       String
+      cities     City[]
+    }
+
+    model City {
+      id         Int    @id
+      country_id Int
+      name       String
+      country    Country @relation(fields: [country_id], references: [id])
+    }
+"#};
+
+struct Actor {
+    query_sender: mpsc::Sender<Message>,
+    response_receiver: mpsc::Receiver<Response>,
+}
+
+#[derive(Debug, Clone)]
+enum Message {
+    Query(&'static str),
+    BeginTransaction,
+    RollbackTransaction(TxId),
+    SetActiveTx(TxId),
+}
+
+#[derive(Debug)]
+enum Response {
+    Query(TestResult<QueryResult>),
+    Tx(TestResult<TxId>),
+    Rollback(Result<(), user_facing_errors::Error>),
+}
+
+impl Actor {
+    /// Spawns a new query engine to the runtime.
+    pub async fn spawn() -> TestResult<Self> {
+        async fn with_logs<T>(fut: impl Future<Output = T>) -> T {
+            fut.with_subscriber(test_tracing_subscriber(&ENV_LOG_LEVEL, setup_metrics()))
+                .await
+        }
+
+        let (query_sender, mut query_receiver) = mpsc::channel(100);
+        let (response_sender, response_receiver) = mpsc::channel(100);
+
+        let tag = ConnectorTag::try_from(("sqlserver", None))?;
+
+        let datamodel = render_test_datamodel(
+            &*CONFIG,
+            "sql_server_deadlocks_test",
+            SCHEMA.to_owned(),
+            &[],
+            None,
+            &[],
+            Some("READ COMMITTED"),
+        );
+
+        setup_project(&datamodel, &[]).await?;
+
+        let mut runner = Runner::load("direct", datamodel, tag, setup_metrics()).await?;
+
+        tokio::spawn(async move {
+            while let Some(message) = query_receiver.recv().await {
+                match message {
+                    Message::Query(query) => {
+                        let result = with_logs(runner.query(query)).await;
+                        response_sender.send(Response::Query(result)).await.unwrap();
+                    }
+                    Message::BeginTransaction => {
+                        let response = with_logs(runner.start_tx(10000, 10000, None)).await;
+                        response_sender.send(Response::Tx(response)).await.unwrap();
+                    }
+                    Message::RollbackTransaction(tx_id) => {
+                        let response = with_logs(runner.rollback_tx(tx_id)).await?;
+                        response_sender.send(Response::Rollback(response)).await.unwrap();
+                    }
+                    Message::SetActiveTx(tx_id) => {
+                        runner.set_active_tx(tx_id);
+                    }
+                }
+            }
+
+            Result::<(), TestError>::Ok(())
+        });
+
+        Ok(Self {
+            query_sender,
+            response_receiver,
+        })
+    }
+
+    /// Starts a transaction.
+    pub async fn begin_tx(&mut self) -> TestResult<TxId> {
+        self.query_sender.send(Message::BeginTransaction).await.unwrap();
+
+        match self.response_receiver.recv().await.unwrap() {
+            Response::Tx(res) => res,
+            Response::Query(_) => Err(TestError::ParseError(
+                "Got query response, expected a transaction response".into(),
+            )),
+            Response::Rollback(_) => Err(TestError::ParseError(
+                "Got rollback response, expected a transaction response".into(),
+            )),
+        }
+    }
+
+    /// Rollback the given transaction.
+    pub async fn rollback(&mut self, tx_id: TxId) -> TestResult<()> {
+        self.query_sender
+            .send(Message::RollbackTransaction(tx_id))
+            .await
+            .unwrap();
+
+        match self.response_receiver.recv().await.unwrap() {
+            Response::Rollback(res) => res.map_err(|e| TestError::InteractiveTransactionError(e.message().into())),
+            Response::Query(_) => Err(TestError::ParseError(
+                "Got query response, expected a rollback response".into(),
+            )),
+            Response::Tx(_) => Err(TestError::ParseError(
+                "Got transaction response, expected a rollback response".into(),
+            )),
+        }
+    }
+
+    /// Sets the given transaction to be active.
+    pub async fn set_active_tx_id(&mut self, tx_id: TxId) {
+        self.query_sender.send(Message::SetActiveTx(tx_id)).await.unwrap();
+    }
+
+    /// Send a query to be executed in the engine. Response must be
+    /// fetched in a subsequent call using `recv_query_response`.
+    pub async fn send_query(&mut self, query: &'static str) {
+        self.query_sender.send(Message::Query(query)).await.unwrap();
+    }
+
+    /// Returns the last query response.
+    pub async fn recv_query_response(&mut self) -> TestResult<QueryResult> {
+        match self.response_receiver.recv().await.unwrap() {
+            Response::Query(res) => Ok(res.unwrap()),
+            Response::Tx(_) => Err(TestError::ParseError(
+                "Got transaction response, expected a query response".into(),
+            )),
+            Response::Rollback(_) => Err(TestError::ParseError(
+                "Got rollback response, expected a query response".into(),
+            )),
+        }
+    }
+
+    /// A helper to run a query and return its response. The query
+    /// must be successful.
+    pub async fn run_query(&mut self, query: &'static str) -> TestResult<QueryResult> {
+        self.send_query(query).await;
+
+        let res = self.recv_query_response().await?;
+        res.assert_success();
+
+        Ok(res)
+    }
+}
+
+#[tokio::test]
+async fn sqlserver_can_recover_from_deadlocks() -> TestResult<()> {
+    if CONFIG.connector() != "sqlserver" {
+        return Ok(());
+    }
+
+    let (mut conn1, mut conn2) = (Actor::spawn().await?, Actor::spawn().await?);
+    let (tx1, tx2) = (conn1.begin_tx().await?, conn2.begin_tx().await?);
+
+    conn1.set_active_tx_id(tx1.clone()).await;
+    conn2.set_active_tx_id(tx2.clone()).await;
+
+    // Queries until the next comment will be successful.
+    conn1
+        .run_query(r#"mutation { createOneCountry(data: { id: 1, name: "USA" }) { id } }"#)
+        .await?;
+
+    conn2
+        .run_query(r#"mutation { createOneCountry(data: { id: 2, name: "Finland" }) { id } }"#)
+        .await?;
+
+    conn1
+        .run_query(r#"query { findUniqueCountry(where: { id: 1 }) { id } }"#)
+        .await?;
+
+    conn2
+        .run_query(r#"query { findUniqueCountry(where: { id: 2 }) { id } }"#)
+        .await?;
+
+    conn1
+        .run_query(
+            r#"mutation { createOneCity(data: { id: 1, name: "Oakland", country: { connect: { id: 1 } } }) { id } }"#,
+        )
+        .await?;
+
+    conn2
+        .run_query(
+            r#"mutation { createOneCity(data: { id: 2, name: "Tampere", country: { connect: { id: 2 } } }) { id } }"#,
+        )
+        .await?;
+
+    // This will block until the second transaction causes a deadlock.
+    conn1
+        .send_query(r#"query { findManyCity(where: { country_id: 1 }) { id } }"#)
+        .await;
+
+    // Query causes a deadlock.
+    conn2
+        .send_query(r#"query { findManyCity(where: { country_id: 2 }) { id } }"#)
+        .await;
+
+    // Either one of these can be in deadlock, the other being
+    // successful.
+    let res1 = conn1.recv_query_response().await?;
+    let res2 = conn2.recv_query_response().await?;
+
+    if res1.failed() {
+        insta::assert_snapshot!(&res1.to_string_pretty(), @r###"
+        {
+          "errors": [
+            {
+              "error": "Error occurred during query execution:\nConnectorError(ConnectorError { user_facing_error: Some(KnownError { message: \"Transaction failed due to a write conflict or a deadlock. Please retry your transaction\", meta: Object {}, error_code: \"P2034\" }), kind: TransactionWriteConflict })",
+              "user_facing_error": {
+                "is_panic": false,
+                "message": "Transaction failed due to a write conflict or a deadlock. Please retry your transaction",
+                "meta": {},
+                "error_code": "P2034"
+              }
+            }
+          ]
+        }
+        "###);
+
+        // Rollback the successful transaction, so the failed one can continue.
+        conn2.rollback(tx2.clone()).await?;
+
+        // The deadlocked query triggers an automatic rollback. The
+        // connection must be usable at this point.
+        conn1.run_query(r#"query { findManyCity(where: {}) { id } }"#).await?;
+    } else if res2.failed() {
+        insta::assert_snapshot!(&res2.to_string_pretty(), @r###"
+        {
+          "errors": [
+            {
+              "error": "Error occurred during query execution:\nConnectorError(ConnectorError { user_facing_error: Some(KnownError { message: \"Transaction failed due to a write conflict or a deadlock. Please retry your transaction\", meta: Object {}, error_code: \"P2034\" }), kind: TransactionWriteConflict })",
+              "user_facing_error": {
+                "is_panic": false,
+                "message": "Transaction failed due to a write conflict or a deadlock. Please retry your transaction",
+                "meta": {},
+                "error_code": "P2034"
+              }
+            }
+          ]
+        }
+        "###);
+
+        // Rollback the successful transaction, so the failed one can continue.
+        conn1.rollback(tx1.clone()).await?;
+
+        // The deadlocked query triggers an automatic rollback. The
+        // connection must be usable at this point.
+        conn2.run_query(r#"query { findManyCity(where: {}) { id } }"#).await?;
+    } else {
+        panic!("Expected one of the queries to fail.");
+    }
+
+    Ok(())
+}

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/cockroachdb.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/cockroachdb.rs
@@ -15,7 +15,13 @@ impl ConnectorTagInterface for CockroachDbConnectorTag {
         Box::new(SqlDatamodelRenderer::new())
     }
 
-    fn connection_string(&self, database: &str, is_ci: bool, _is_multi_schema: bool) -> String {
+    fn connection_string(
+        &self,
+        database: &str,
+        is_ci: bool,
+        _is_multi_schema: bool,
+        _: Option<&'static str>,
+    ) -> String {
         // Use the same database and schema name for CockroachDB - unfortunately CockroachDB
         // can't handle 1 schema per test in a database well at this point in time.
         if is_ci {

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mod.rs
@@ -33,7 +33,13 @@ pub trait ConnectorTagInterface {
     ///   implementing connector, like a file or a schema.
     /// - `is_ci` signals whether or not the test run is done on CI or not. May be important if local
     ///   test run connection strings and CI connection strings differ because of networking.
-    fn connection_string(&self, test_database: &str, is_ci: bool, is_multi_schema: bool) -> String;
+    fn connection_string(
+        &self,
+        test_database: &str,
+        is_ci: bool,
+        is_multi_schema: bool,
+        isolation_level: Option<&'static str>,
+    ) -> String;
 
     /// Capabilities of the implementing connector.
     fn capabilities(&self) -> &[ConnectorCapability];

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mongodb.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mongodb.rs
@@ -17,7 +17,13 @@ impl ConnectorTagInterface for MongoDbConnectorTag {
         Box::new(MongoDbSchemaRenderer::new())
     }
 
-    fn connection_string(&self, database: &str, is_ci: bool, _is_multi_schema: bool) -> String {
+    fn connection_string(
+        &self,
+        database: &str,
+        is_ci: bool,
+        _is_multi_schema: bool,
+        _: Option<&'static str>,
+    ) -> String {
         match self.version {
             Some(MongoDbVersion::V4_2) if is_ci => format!(
                 "mongodb://prisma:prisma@test-db-mongodb-4-2:27016/{}?authSource=admin&retryWrites=true",

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mysql.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mysql.rs
@@ -23,7 +23,13 @@ impl ConnectorTagInterface for MySqlConnectorTag {
         Box::new(SqlDatamodelRenderer::new())
     }
 
-    fn connection_string(&self, database: &str, is_ci: bool, _is_multi_schema: bool) -> String {
+    fn connection_string(
+        &self,
+        database: &str,
+        is_ci: bool,
+        _is_multi_schema: bool,
+        _: Option<&'static str>,
+    ) -> String {
         match self.version {
             Some(MySqlVersion::V5_6) if is_ci => format!("mysql://root:prisma@test-db-mysql-5-6:3306/{}", database),
             Some(MySqlVersion::V5_7) if is_ci => format!("mysql://root:prisma@test-db-mysql-5-7:3306/{}", database),

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/postgres.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/postgres.rs
@@ -16,7 +16,7 @@ impl ConnectorTagInterface for PostgresConnectorTag {
         Box::new(SqlDatamodelRenderer::new())
     }
 
-    fn connection_string(&self, database: &str, is_ci: bool, is_multi_schema: bool) -> String {
+    fn connection_string(&self, database: &str, is_ci: bool, is_multi_schema: bool, _: Option<&'static str>) -> String {
         let database = if is_multi_schema {
             database.to_string()
         } else {

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/sql_server.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/sql_server.rs
@@ -17,22 +17,30 @@ impl ConnectorTagInterface for SqlServerConnectorTag {
         Box::new(SqlDatamodelRenderer::new())
     }
 
-    fn connection_string(&self, database: &str, is_ci: bool, is_multi_schema: bool) -> String {
+    fn connection_string(
+        &self,
+        database: &str,
+        is_ci: bool,
+        is_multi_schema: bool,
+        isolation_level: Option<&'static str>,
+    ) -> String {
         let database = if is_multi_schema {
             format!("database={};schema=dbo", database)
         } else {
             format!("database=master;schema={}", database)
         };
 
+        let isolation_level = isolation_level.unwrap_or("READ UNCOMMITTED");
+
         match self.version {
-            Some(SqlServerVersion::V2017) if is_ci => format!("sqlserver://test-db-sqlserver-2017:1433;{};user=SA;password=<YourStrong@Passw0rd>;trustServerCertificate=true;isolationLevel=READ UNCOMMITTED", database),
-            Some(SqlServerVersion::V2017) => format!("sqlserver://127.0.0.1:1434;{};user=SA;password=<YourStrong@Passw0rd>;trustServerCertificate=true;isolationLevel=READ UNCOMMITTED", database),
+            Some(SqlServerVersion::V2017) if is_ci => format!("sqlserver://test-db-sqlserver-2017:1433;{};user=SA;password=<YourStrong@Passw0rd>;trustServerCertificate=true;isolationLevel={isolation_level}", database),
+            Some(SqlServerVersion::V2017) => format!("sqlserver://127.0.0.1:1434;{};user=SA;password=<YourStrong@Passw0rd>;trustServerCertificate=true;isolationLevel={isolation_level}", database),
 
-            Some(SqlServerVersion::V2019) if is_ci => format!("sqlserver://test-db-sqlserver-2019:1433;{};user=SA;password=<YourStrong@Passw0rd>;trustServerCertificate=true;isolationLevel=READ UNCOMMITTED", database),
-            Some(SqlServerVersion::V2019) => format!("sqlserver://127.0.0.1:1433;{};user=SA;password=<YourStrong@Passw0rd>;trustServerCertificate=true;isolationLevel=READ UNCOMMITTED", database),
+            Some(SqlServerVersion::V2019) if is_ci => format!("sqlserver://test-db-sqlserver-2019:1433;{};user=SA;password=<YourStrong@Passw0rd>;trustServerCertificate=true;isolationLevel={isolation_level}", database),
+            Some(SqlServerVersion::V2019) => format!("sqlserver://127.0.0.1:1433;{};user=SA;password=<YourStrong@Passw0rd>;trustServerCertificate=true;isolationLevel={isolation_level}", database),
 
-            Some(SqlServerVersion::V2022) if is_ci => format!("sqlserver://test-db-sqlserver-2022:1433;{};user=SA;password=<YourStrong@Passw0rd>;trustServerCertificate=true;isolationLevel=READ UNCOMMITTED", database),
-            Some(SqlServerVersion::V2022) => format!("sqlserver://127.0.0.1:1435;{};user=SA;password=<YourStrong@Passw0rd>;trustServerCertificate=true;isolationLevel=READ UNCOMMITTED", database),
+            Some(SqlServerVersion::V2022) if is_ci => format!("sqlserver://test-db-sqlserver-2022:1433;{};user=SA;password=<YourStrong@Passw0rd>;trustServerCertificate=true;isolationLevel={isolation_level}", database),
+            Some(SqlServerVersion::V2022) => format!("sqlserver://127.0.0.1:1435;{};user=SA;password=<YourStrong@Passw0rd>;trustServerCertificate=true;isolationLevel={isolation_level}", database),
 
             None => unreachable!("A versioned connector must have a concrete version to run."),
         }

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/sqlite.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/sqlite.rs
@@ -15,7 +15,13 @@ impl ConnectorTagInterface for SqliteConnectorTag {
         Box::new(SqlDatamodelRenderer::new())
     }
 
-    fn connection_string(&self, database: &str, _is_ci: bool, _is_multi_schema: bool) -> String {
+    fn connection_string(
+        &self,
+        database: &str,
+        _is_ci: bool,
+        _is_multi_schema: bool,
+        _: Option<&'static str>,
+    ) -> String {
         let workspace_root = std::env::var("WORKSPACE_ROOT")
             .unwrap_or_else(|_| ".".to_owned())
             .trim_end_matches('/')

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/vitess.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/vitess.rs
@@ -17,7 +17,13 @@ impl ConnectorTagInterface for VitessConnectorTag {
         Box::new(SqlDatamodelRenderer::new())
     }
 
-    fn connection_string(&self, _database: &str, _is_ci: bool, _is_multi_schema: bool) -> String {
+    fn connection_string(
+        &self,
+        _database: &str,
+        _is_ci: bool,
+        _is_multi_schema: bool,
+        _: Option<&'static str>,
+    ) -> String {
         match self.version {
             Some(VitessVersion::V5_7) => "mysql://root@localhost:33577/test".into(),
             Some(VitessVersion::V8_0) => "mysql://root@localhost:33807/test".into(),

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/datamodel_rendering/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/datamodel_rendering/mod.rs
@@ -37,6 +37,7 @@ pub fn render_test_datamodel(
     excluded_features: &[&str],
     relation_mode_override: Option<String>,
     db_schemas: &[&str],
+    isolation_level: Option<&'static str>,
 ) -> String {
     let tag = config.test_connector_tag().unwrap();
     let preview_features = render_preview_features(excluded_features);
@@ -64,7 +65,7 @@ pub fn render_test_datamodel(
             }}
         "#},
         tag.datamodel_provider(),
-        tag.connection_string(test_database, config.is_ci(), is_multi_schema),
+        tag.connection_string(test_database, config.is_ci(), is_multi_schema, isolation_level),
         relation_mode_override.unwrap_or_else(|| tag.relation_mode().to_string()),
         schema_def,
         preview_features

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/lib.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/lib.rs
@@ -151,7 +151,7 @@ fn run_relation_link_test_impl(
     let dm_with_params_json: DatamodelWithParams = dm_with_params.parse().unwrap();
 
     if ConnectorTag::should_run(config, enabled_connectors, capabilities, test_name) {
-        let datamodel = render_test_datamodel(config, test_database, template, &[], None, Default::default());
+        let datamodel = render_test_datamodel(config, test_database, template, &[], None, Default::default(), None);
         let connector = config.test_connector_tag().unwrap();
         let requires_teardown = connector.requires_teardown();
         let metrics = setup_metrics();
@@ -255,6 +255,7 @@ pub fn run_connector_test_impl(
         excluded_features,
         referential_override,
         db_schemas,
+        None,
     );
     let connector = config.test_connector_tag().unwrap();
     let metrics = crate::setup_metrics();

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/query_result.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/query_result.rs
@@ -1,5 +1,6 @@
 use request_handlers::{GQLError, PrismaResponse};
 
+#[derive(Debug)]
 pub struct QueryResult {
     response: PrismaResponse,
 }

--- a/query-engine/connectors/query-connector/src/error.rs
+++ b/query-engine/connectors/query-connector/src/error.rs
@@ -230,6 +230,9 @@ pub enum ErrorKind {
     #[error("Transaction write conflict")]
     TransactionWriteConflict,
 
+    #[error("ROLLBACK statement has no corresponding BEGIN statement")]
+    RollbackWithoutBegin,
+
     #[error("The query parameter limit supported by your database is exceeded: {0}.")]
     QueryParameterLimitExceeded(String),
 

--- a/query-engine/connectors/sql-query-connector/src/database/transaction.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/transaction.rs
@@ -49,10 +49,9 @@ impl<'tx> Transaction for SqlConnectorTransaction<'tx> {
         catch(self.connection_info.clone(), async move {
             let res = self.inner.rollback().await.map_err(SqlError::from);
 
-            if matches!(res, Err(SqlError::TransactionAlreadyClosed(_))) {
-                Ok(())
-            } else {
-                res
+            match res {
+                Err(SqlError::TransactionAlreadyClosed(_)) | Err(SqlError::RollbackWithoutBegin) => Ok(()),
+                _ => res,
             }
         })
         .await

--- a/query-engine/connectors/sql-query-connector/src/error.rs
+++ b/query-engine/connectors/sql-query-connector/src/error.rs
@@ -168,6 +168,9 @@ pub enum SqlError {
     #[error("Transaction write conflict")]
     TransactionWriteConflict,
 
+    #[error("ROLLBACK statement has no corresponding BEGIN statement")]
+    RollbackWithoutBegin,
+
     #[error("Query parameter limit exceeded error: {0}.")]
     QueryParameterLimitExceeded(String),
 
@@ -271,6 +274,7 @@ impl SqlError {
                 )),
                 kind: ErrorKind::TransactionWriteConflict,
             },
+            SqlError::RollbackWithoutBegin => ConnectorError::from_kind(ErrorKind::RollbackWithoutBegin),
             SqlError::QueryParameterLimitExceeded(e) => {
                 ConnectorError::from_kind(ErrorKind::QueryParameterLimitExceeded(e))
             }
@@ -312,6 +316,7 @@ impl From<quaint::error::Error> for SqlError {
             QuaintKind::ConnectionClosed => SqlError::ConnectionClosed,
             QuaintKind::InvalidIsolationLevel(msg) => Self::InvalidIsolationLevel(msg),
             QuaintKind::TransactionWriteConflict => Self::TransactionWriteConflict,
+            QuaintKind::RollbackWithoutBegin => Self::RollbackWithoutBegin,
             e @ QuaintKind::UnsupportedColumnType { .. } => SqlError::ConversionError(e.into()),
             e @ QuaintKind::TransactionAlreadyClosed(_) => SqlError::TransactionAlreadyClosed(format!("{}", e)),
             e @ QuaintKind::IncorrectNumberOfParameters { .. } => SqlError::QueryError(e.into()),

--- a/shell.nix
+++ b/shell.nix
@@ -20,6 +20,7 @@ mkShell {
   buildInputs = with pkgs; [
     comment-out-qe-crates
     moldy-cargo
+    cargo-insta
 
     gcc
     openssl


### PR DESCRIPTION
Tiberius PR: https://github.com/prisma/tiberius/pull/245
Quaint PR: https://github.com/prisma/quaint/pull/405

After fixes in tiberius in quaint, manual rollback after transaction
have been closed automatically because of error will fail with a
different message/code. This commit adapts the engine to the changes.

Part of: https://github.com/prisma/prisma/issues/15607
