### PR TITLE
fix(psl): validate that sort is not a string in @@unique

### DIFF
--- a/psl/parser-database/src/types/index_fields.rs
+++ b/psl/parser-database/src/types/index_fields.rs
@@ -1,4 +1,4 @@
-use crate::{ast, types::SortOrder, DatamodelError};
+use crate::{ast, coerce, types::SortOrder, DatamodelError};
 
 pub(crate) enum OperatorClass<'a> {
     Constant(crate::OperatorClass),
@@ -36,14 +36,7 @@ pub(crate) fn coerce_field_array_with_args<'a>(
                 ..Default::default()
             }),
             ast::Expression::Function(field_name, args, _) => {
-                let args = match field_args(&args.arguments) {
-                    Ok(args) => args,
-                    Err(err) => {
-                        diagnostics.push_error(err);
-                        return None;
-                    }
-                };
-
+                let args = field_args(&args.arguments, diagnostics);
                 let attrs = IndexFieldAttributes {
                     field_name,
                     sort_order: args.sort_order,
@@ -68,127 +61,137 @@ pub(crate) fn coerce_field_array_with_args<'a>(
     crate::coerce_array(expr, &f, diagnostics)
 }
 
-fn field_args(args: &[ast::Argument]) -> Result<FieldArguments<'_>, DatamodelError> {
+fn field_args<'a>(args: &'a [ast::Argument], diagnostics: &mut diagnostics::Diagnostics) -> FieldArguments<'a> {
     let sort_order = args
         .iter()
         .find(|arg| arg.name.as_ref().map(|n| n.name.as_str()) == Some("sort"))
-        .map(|arg| match arg.value.as_constant_value() {
-            Some(("Asc", _)) => Ok(Some(SortOrder::Asc)),
-            Some(("Desc", _)) => Ok(Some(SortOrder::Desc)),
-            None => Ok(None),
-            _ => Err(DatamodelError::new_parser_error("Asc, Desc".to_owned(), arg.span)),
-        })
-        .transpose()?
-        .flatten();
+        .and_then(|arg| match coerce::constant(&arg.value, diagnostics) {
+            Some("Asc") => Some(SortOrder::Asc),
+            Some("Desc") => Some(SortOrder::Desc),
+            Some(_) => {
+                diagnostics.push_error(DatamodelError::new_parser_error("Asc, Desc".to_owned(), arg.span));
+                None
+            }
+            None => None,
+        });
 
     let length = args
         .iter()
         .find(|arg| arg.name.as_ref().map(|n| n.name.as_str()) == Some("length"))
-        .map(|arg| match &arg.value {
-            ast::Expression::NumericValue(s, _) => s
-                .parse::<u32>()
-                .map_err(|_| DatamodelError::new_parser_error("valid integer".to_owned(), arg.span)),
-            _ => Err(DatamodelError::new_parser_error("valid integer".to_owned(), arg.span)),
-        })
-        .transpose()?;
+        .and_then(|arg| coerce::integer(&arg.value, diagnostics))
+        .filter(|i| *i >= 0)
+        .map(|i| i as u32);
 
     let operator_class = args
         .iter()
         .find(|arg| arg.name.as_ref().map(|n| n.name.as_str()) == Some("ops"))
-        .map(|arg| match &arg.value {
+        .and_then(|arg| match &arg.value {
             ast::Expression::ConstantValue(s, span) => match s.as_str() {
                 // gist
-                "InetOps" => Ok(OperatorClass::from(crate::OperatorClass::InetOps)),
+                "InetOps" => Some(OperatorClass::from(crate::OperatorClass::InetOps)),
 
                 // gin
-                "JsonbOps" => Ok(OperatorClass::from(crate::OperatorClass::JsonbOps)),
-                "JsonbPathOps" => Ok(OperatorClass::from(crate::OperatorClass::JsonbPathOps)),
-                "ArrayOps" => Ok(OperatorClass::from(crate::OperatorClass::ArrayOps)),
+                "JsonbOps" => Some(OperatorClass::from(crate::OperatorClass::JsonbOps)),
+                "JsonbPathOps" => Some(OperatorClass::from(crate::OperatorClass::JsonbPathOps)),
+                "ArrayOps" => Some(OperatorClass::from(crate::OperatorClass::ArrayOps)),
 
                 // sp-gist
-                "TextOps" => Ok(OperatorClass::from(crate::OperatorClass::TextOps)),
+                "TextOps" => Some(OperatorClass::from(crate::OperatorClass::TextOps)),
 
                 // brin
-                "BitMinMaxOps" => Ok(OperatorClass::from(crate::OperatorClass::BitMinMaxOps)),
-                "VarBitMinMaxOps" => Ok(OperatorClass::from(crate::OperatorClass::VarBitMinMaxOps)),
-                "BpcharBloomOps" => Ok(OperatorClass::from(crate::OperatorClass::BpcharBloomOps)),
-                "BpcharMinMaxOps" => Ok(OperatorClass::from(crate::OperatorClass::BpcharMinMaxOps)),
-                "ByteaBloomOps" => Ok(OperatorClass::from(crate::OperatorClass::ByteaBloomOps)),
-                "ByteaMinMaxOps" => Ok(OperatorClass::from(crate::OperatorClass::ByteaMinMaxOps)),
-                "DateBloomOps" => Ok(OperatorClass::from(crate::OperatorClass::DateBloomOps)),
-                "DateMinMaxOps" => Ok(OperatorClass::from(crate::OperatorClass::DateMinMaxOps)),
-                "DateMinMaxMultiOps" => Ok(OperatorClass::from(crate::OperatorClass::DateMinMaxMultiOps)),
-                "Float4BloomOps" => Ok(OperatorClass::from(crate::OperatorClass::Float4BloomOps)),
-                "Float4MinMaxOps" => Ok(OperatorClass::from(crate::OperatorClass::Float4MinMaxOps)),
-                "Float4MinMaxMultiOps" => Ok(OperatorClass::from(crate::OperatorClass::Float4MinMaxMultiOps)),
-                "Float8BloomOps" => Ok(OperatorClass::from(crate::OperatorClass::Float8BloomOps)),
-                "Float8MinMaxOps" => Ok(OperatorClass::from(crate::OperatorClass::Float8MinMaxOps)),
-                "Float8MinMaxMultiOps" => Ok(OperatorClass::from(crate::OperatorClass::Float8MinMaxMultiOps)),
-                "InetInclusionOps" => Ok(OperatorClass::from(crate::OperatorClass::InetInclusionOps)),
-                "InetBloomOps" => Ok(OperatorClass::from(crate::OperatorClass::InetBloomOps)),
-                "InetMinMaxOps" => Ok(OperatorClass::from(crate::OperatorClass::InetMinMaxOps)),
-                "InetMinMaxMultiOps" => Ok(OperatorClass::from(crate::OperatorClass::InetMinMaxMultiOps)),
-                "Int2BloomOps" => Ok(OperatorClass::from(crate::OperatorClass::Int2BloomOps)),
-                "Int2MinMaxOps" => Ok(OperatorClass::from(crate::OperatorClass::Int2MinMaxOps)),
-                "Int2MinMaxMultiOps" => Ok(OperatorClass::from(crate::OperatorClass::Int2MinMaxMultiOps)),
-                "Int4BloomOps" => Ok(OperatorClass::from(crate::OperatorClass::Int4BloomOps)),
-                "Int4MinMaxOps" => Ok(OperatorClass::from(crate::OperatorClass::Int4MinMaxOps)),
-                "Int4MinMaxMultiOps" => Ok(OperatorClass::from(crate::OperatorClass::Int4MinMaxMultiOps)),
-                "Int8BloomOps" => Ok(OperatorClass::from(crate::OperatorClass::Int8BloomOps)),
-                "Int8MinMaxOps" => Ok(OperatorClass::from(crate::OperatorClass::Int8MinMaxOps)),
-                "Int8MinMaxMultiOps" => Ok(OperatorClass::from(crate::OperatorClass::Int8MinMaxMultiOps)),
-                "NumericBloomOps" => Ok(OperatorClass::from(crate::OperatorClass::NumericBloomOps)),
-                "NumericMinMaxOps" => Ok(OperatorClass::from(crate::OperatorClass::NumericMinMaxOps)),
-                "NumericMinMaxMultiOps" => Ok(OperatorClass::from(crate::OperatorClass::NumericMinMaxMultiOps)),
-                "OidBloomOps" => Ok(OperatorClass::from(crate::OperatorClass::OidBloomOps)),
-                "OidMinMaxOps" => Ok(OperatorClass::from(crate::OperatorClass::OidMinMaxOps)),
-                "OidMinMaxMultiOps" => Ok(OperatorClass::from(crate::OperatorClass::OidMinMaxMultiOps)),
-                "TextBloomOps" => Ok(OperatorClass::from(crate::OperatorClass::TextBloomOps)),
-                "TextMinMaxOps" => Ok(OperatorClass::from(crate::OperatorClass::TextMinMaxOps)),
-                "TimestampBloomOps" => Ok(OperatorClass::from(crate::OperatorClass::TimestampBloomOps)),
-                "TimestampMinMaxOps" => Ok(OperatorClass::from(crate::OperatorClass::TimestampMinMaxOps)),
-                "TimestampMinMaxMultiOps" => Ok(OperatorClass::from(crate::OperatorClass::TimestampMinMaxMultiOps)),
-                "TimestampTzBloomOps" => Ok(OperatorClass::from(crate::OperatorClass::TimestampTzBloomOps)),
-                "TimestampTzMinMaxOps" => Ok(OperatorClass::from(crate::OperatorClass::TimestampTzMinMaxOps)),
-                "TimestampTzMinMaxMultiOps" => Ok(OperatorClass::from(crate::OperatorClass::TimestampTzMinMaxMultiOps)),
-                "TimeBloomOps" => Ok(OperatorClass::from(crate::OperatorClass::TimeBloomOps)),
-                "TimeMinMaxOps" => Ok(OperatorClass::from(crate::OperatorClass::TimeMinMaxOps)),
-                "TimeMinMaxMultiOps" => Ok(OperatorClass::from(crate::OperatorClass::TimeMinMaxMultiOps)),
-                "TimeTzBloomOps" => Ok(OperatorClass::from(crate::OperatorClass::TimeTzBloomOps)),
-                "TimeTzMinMaxOps" => Ok(OperatorClass::from(crate::OperatorClass::TimeTzMinMaxOps)),
-                "TimeTzMinMaxMultiOps" => Ok(OperatorClass::from(crate::OperatorClass::TimeTzMinMaxMultiOps)),
-                "UuidBloomOps" => Ok(OperatorClass::from(crate::OperatorClass::UuidBloomOps)),
-                "UuidMinMaxOps" => Ok(OperatorClass::from(crate::OperatorClass::UuidMinMaxOps)),
-                "UuidMinMaxMultiOps" => Ok(OperatorClass::from(crate::OperatorClass::UuidMinMaxMultiOps)),
+                "BitMinMaxOps" => Some(OperatorClass::from(crate::OperatorClass::BitMinMaxOps)),
+                "VarBitMinMaxOps" => Some(OperatorClass::from(crate::OperatorClass::VarBitMinMaxOps)),
+                "BpcharBloomOps" => Some(OperatorClass::from(crate::OperatorClass::BpcharBloomOps)),
+                "BpcharMinMaxOps" => Some(OperatorClass::from(crate::OperatorClass::BpcharMinMaxOps)),
+                "ByteaBloomOps" => Some(OperatorClass::from(crate::OperatorClass::ByteaBloomOps)),
+                "ByteaMinMaxOps" => Some(OperatorClass::from(crate::OperatorClass::ByteaMinMaxOps)),
+                "DateBloomOps" => Some(OperatorClass::from(crate::OperatorClass::DateBloomOps)),
+                "DateMinMaxOps" => Some(OperatorClass::from(crate::OperatorClass::DateMinMaxOps)),
+                "DateMinMaxMultiOps" => Some(OperatorClass::from(crate::OperatorClass::DateMinMaxMultiOps)),
+                "Float4BloomOps" => Some(OperatorClass::from(crate::OperatorClass::Float4BloomOps)),
+                "Float4MinMaxOps" => Some(OperatorClass::from(crate::OperatorClass::Float4MinMaxOps)),
+                "Float4MinMaxMultiOps" => Some(OperatorClass::from(crate::OperatorClass::Float4MinMaxMultiOps)),
+                "Float8BloomOps" => Some(OperatorClass::from(crate::OperatorClass::Float8BloomOps)),
+                "Float8MinMaxOps" => Some(OperatorClass::from(crate::OperatorClass::Float8MinMaxOps)),
+                "Float8MinMaxMultiOps" => Some(OperatorClass::from(crate::OperatorClass::Float8MinMaxMultiOps)),
+                "InetInclusionOps" => Some(OperatorClass::from(crate::OperatorClass::InetInclusionOps)),
+                "InetBloomOps" => Some(OperatorClass::from(crate::OperatorClass::InetBloomOps)),
+                "InetMinMaxOps" => Some(OperatorClass::from(crate::OperatorClass::InetMinMaxOps)),
+                "InetMinMaxMultiOps" => Some(OperatorClass::from(crate::OperatorClass::InetMinMaxMultiOps)),
+                "Int2BloomOps" => Some(OperatorClass::from(crate::OperatorClass::Int2BloomOps)),
+                "Int2MinMaxOps" => Some(OperatorClass::from(crate::OperatorClass::Int2MinMaxOps)),
+                "Int2MinMaxMultiOps" => Some(OperatorClass::from(crate::OperatorClass::Int2MinMaxMultiOps)),
+                "Int4BloomOps" => Some(OperatorClass::from(crate::OperatorClass::Int4BloomOps)),
+                "Int4MinMaxOps" => Some(OperatorClass::from(crate::OperatorClass::Int4MinMaxOps)),
+                "Int4MinMaxMultiOps" => Some(OperatorClass::from(crate::OperatorClass::Int4MinMaxMultiOps)),
+                "Int8BloomOps" => Some(OperatorClass::from(crate::OperatorClass::Int8BloomOps)),
+                "Int8MinMaxOps" => Some(OperatorClass::from(crate::OperatorClass::Int8MinMaxOps)),
+                "Int8MinMaxMultiOps" => Some(OperatorClass::from(crate::OperatorClass::Int8MinMaxMultiOps)),
+                "NumericBloomOps" => Some(OperatorClass::from(crate::OperatorClass::NumericBloomOps)),
+                "NumericMinMaxOps" => Some(OperatorClass::from(crate::OperatorClass::NumericMinMaxOps)),
+                "NumericMinMaxMultiOps" => Some(OperatorClass::from(crate::OperatorClass::NumericMinMaxMultiOps)),
+                "OidBloomOps" => Some(OperatorClass::from(crate::OperatorClass::OidBloomOps)),
+                "OidMinMaxOps" => Some(OperatorClass::from(crate::OperatorClass::OidMinMaxOps)),
+                "OidMinMaxMultiOps" => Some(OperatorClass::from(crate::OperatorClass::OidMinMaxMultiOps)),
+                "TextBloomOps" => Some(OperatorClass::from(crate::OperatorClass::TextBloomOps)),
+                "TextMinMaxOps" => Some(OperatorClass::from(crate::OperatorClass::TextMinMaxOps)),
+                "TimestampBloomOps" => Some(OperatorClass::from(crate::OperatorClass::TimestampBloomOps)),
+                "TimestampMinMaxOps" => Some(OperatorClass::from(crate::OperatorClass::TimestampMinMaxOps)),
+                "TimestampMinMaxMultiOps" => Some(OperatorClass::from(crate::OperatorClass::TimestampMinMaxMultiOps)),
+                "TimestampTzBloomOps" => Some(OperatorClass::from(crate::OperatorClass::TimestampTzBloomOps)),
+                "TimestampTzMinMaxOps" => Some(OperatorClass::from(crate::OperatorClass::TimestampTzMinMaxOps)),
+                "TimestampTzMinMaxMultiOps" => {
+                    Some(OperatorClass::from(crate::OperatorClass::TimestampTzMinMaxMultiOps))
+                }
+                "TimeBloomOps" => Some(OperatorClass::from(crate::OperatorClass::TimeBloomOps)),
+                "TimeMinMaxOps" => Some(OperatorClass::from(crate::OperatorClass::TimeMinMaxOps)),
+                "TimeMinMaxMultiOps" => Some(OperatorClass::from(crate::OperatorClass::TimeMinMaxMultiOps)),
+                "TimeTzBloomOps" => Some(OperatorClass::from(crate::OperatorClass::TimeTzBloomOps)),
+                "TimeTzMinMaxOps" => Some(OperatorClass::from(crate::OperatorClass::TimeTzMinMaxOps)),
+                "TimeTzMinMaxMultiOps" => Some(OperatorClass::from(crate::OperatorClass::TimeTzMinMaxMultiOps)),
+                "UuidBloomOps" => Some(OperatorClass::from(crate::OperatorClass::UuidBloomOps)),
+                "UuidMinMaxOps" => Some(OperatorClass::from(crate::OperatorClass::UuidMinMaxOps)),
+                "UuidMinMaxMultiOps" => Some(OperatorClass::from(crate::OperatorClass::UuidMinMaxMultiOps)),
 
-                s => Err(DatamodelError::new_parser_error(
-                    format!("Invalid operator class: {s}"),
-                    *span,
-                )),
+                s => {
+                    diagnostics.push_error(DatamodelError::new_parser_error(
+                        format!("Invalid operator class: {s}"),
+                        *span,
+                    ));
+                    None
+                }
             },
             ast::Expression::Function(fun, args, span) => match fun.as_str() {
                 "raw" => match args.arguments.as_slice() {
                     [arg] => match &arg.value {
-                        ast::Expression::StringValue(s, _) => Ok(OperatorClass::Raw(s.as_str())),
-                        _ => Err(DatamodelError::new_parser_error(
-                            "Invalid parameter type: expected string".into(),
-                            *span,
-                        )),
+                        ast::Expression::StringValue(s, _) => Some(OperatorClass::Raw(s.as_str())),
+                        _ => {
+                            diagnostics.push_error(DatamodelError::new_parser_error(
+                                "Invalid parameter type: expected string".into(),
+                                *span,
+                            ));
+                            None
+                        }
                     },
-                    args => Err(DatamodelError::new_parser_error(
-                        format!("Wrong number of arguments. Expected: 1, got: {}", args.len()),
-                        *span,
-                    )),
+                    args => {
+                        diagnostics.push_error(DatamodelError::new_parser_error(
+                            format!("Wrong number of arguments. Expected: 1, got: {}", args.len()),
+                            *span,
+                        ));
+                        None
+                    }
                 },
                 _ => panic!(),
             },
-            _ => Err(DatamodelError::new_parser_error("operator class".to_owned(), arg.span)),
-        })
-        .transpose()?;
+            _ => {
+                diagnostics.push_error(DatamodelError::new_parser_error("operator class".to_owned(), arg.span));
+                None
+            }
+        });
 
-    Ok(FieldArguments {
+    FieldArguments {
         sort_order,
         length,
         operator_class,
-    })
+    }
 }

--- a/psl/psl/tests/validation/attributes/index/unique_sort_order_as_string.prisma
+++ b/psl/psl/tests/validation/attributes/index/unique_sort_order_as_string.prisma
@@ -1,0 +1,24 @@
+datasource test {
+    provider = "postgresql"
+    url = env("TEST_DATABASE_URL")
+}
+
+model Post {
+  title      String   @db.VarChar(300)
+  slug       String   @unique(sort: "Desc", length: 42) @db.VarChar(3000)
+
+  @@unique([title(length: 100, sort: "Desc")])
+}
+
+// [1;91merror[0m: [1mExpected a constant value, but received string value `"Desc"`.[0m
+//   [1;94m-->[0m  [4mschema.prisma:8[0m
+// [1;94m   | [0m
+// [1;94m 7 | [0m  title      String   @db.VarChar(300)
+// [1;94m 8 | [0m  slug       String   @unique(sort: [1;91m"Desc"[0m, length: 42) @db.VarChar(3000)
+// [1;94m   | [0m
+// [1;91merror[0m: [1mExpected a constant value, but received string value `"Desc"`.[0m
+//   [1;94m-->[0m  [4mschema.prisma:10[0m
+// [1;94m   | [0m
+// [1;94m 9 | [0m
+// [1;94m10 | [0m  @@unique([title(length: 100, sort: [1;91m"Desc"[0m)])
+// [1;94m   | [0m


### PR DESCRIPTION
- test that @unique(sort: "Desc") is rejected.
- observe that it isn't rejected for `@@unique`.
- move the @@unique code in the pdb attributes module to the right coercion code instead of an old AST method.
- voilà, things are consistent again now