### PR TITLE
everything: start using Cargo workspace dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1456,7 +1456,6 @@ dependencies = [
  "mongodb-introspection-connector",
  "psl",
  "serde",
- "serde_derive",
  "serde_json",
  "sql-introspection-connector",
  "tokio",
@@ -2904,7 +2903,6 @@ dependencies = [
  "prisma-value",
  "psl",
  "serde",
- "serde_derive",
  "serde_json",
  "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,31 @@ members = [
   "psl/*",
 ]
 
+[workspace.dependencies]
+psl = { path = "./psl/psl" }
+serde_json = { version = "1", features = ["float_roundtrip", "preserve_order"] }
+serde = { version = "1", features = ["derive"] }
+tokio = { version = "1.15", features = ["rt-multi-thread", "macros", "sync", "io-std", "io-util", "parking_lot", "time"] }
+user-facing-errors = { path = "./libs/user-facing-errors" }
+uuid = { version = "1", features = ["serde"] }
+
+[workspace.dependencies.quaint]
+git = "https://github.com/prisma/quaint"
+features = [
+  "bigdecimal",
+  "chrono",
+  "expose-drivers",
+  "fmt-sql",
+  "json",
+  "mssql",
+  "mysql",
+  "pooled",
+  "postgresql",
+  "sqlite",
+  "uuid",
+  "vendored-openssl",
+]
+
 [profile.dev]
 split-debuginfo = "unpacked"
 
@@ -41,4 +66,3 @@ opt-level = 3
 [profile.release.package.introspection-core]
 codegen-units = 1
 opt-level = 'z' # Optimize for size.
-#strip="symbols"

--- a/introspection-engine/connectors/introspection-connector/Cargo.toml
+++ b/introspection-engine/connectors/introspection-connector/Cargo.toml
@@ -5,11 +5,11 @@ edition = "2021"
 
 [dependencies]
 async-trait = "0.1.17"
-psl = { path = "../../../psl/psl" }
+psl.workspace = true
 thiserror = "1.0.9"
 anyhow = "1.0.26"
 enumflags2 = "0.7"
 
-serde = { version = "1.0", features = ["derive"]}
-serde_json = { version = "1.0", features = ["float_roundtrip"] }
-user-facing-errors = { path = "../../../libs/user-facing-errors" }
+serde.workspace = true
+serde_json.workspace = true
+user-facing-errors.workspace = true

--- a/introspection-engine/connectors/mongodb-introspection-connector/Cargo.toml
+++ b/introspection-engine/connectors/mongodb-introspection-connector/Cargo.toml
@@ -8,7 +8,7 @@ mongodb = "2.3.0"
 thiserror = "1.0"
 async-trait = "0.1"
 mongodb-client = { path = "../../../libs/mongodb-client" }
-psl = { path = "../../../psl/psl" }
+psl.workspace = true
 introspection-connector = { path = "../introspection-connector" }
 user-facing-errors = { path = "../../../libs/user-facing-errors" }
 native-types = { path = "../../../libs/native-types" }
@@ -22,7 +22,7 @@ once_cell = "1"
 convert_case = "0.5"
 
 [dev-dependencies]
-tokio = { version = "1", features = ["rt-multi-thread"] }
+tokio.workspace = true
 names = { version = "0.12", default-features = false }
 expect-test = "1"
 url = "2"

--- a/introspection-engine/connectors/sql-introspection-connector/Cargo.toml
+++ b/introspection-engine/connectors/sql-introspection-connector/Cargo.toml
@@ -10,33 +10,22 @@ vendored-openssl = ["quaint/vendored-openssl"]
 [dependencies]
 anyhow = "1.0.26"
 async-trait = "0.1.17"
-psl = { path = "../../../psl/psl" }
+psl.workspace = true
 native-types = { path = "../../../libs/native-types" }
 introspection-connector = { path = "../introspection-connector" }
 once_cell = "1.3"
 regex = "1.2"
 bigdecimal = "0.3"
-serde = { version = "1", features = ["derive"] }
-serde_json = { version = "1.0", features = ["float_roundtrip"] }
+serde.workspace = true
+serde_json.workspace = true
 sql-schema-describer = { path = "../../../libs/sql-schema-describer" }
 thiserror = "1.0.9"
 tracing = "0.1"
 tracing-futures = "0.2"
 user-facing-errors = { path = "../../../libs/user-facing-errors", features = ["sql"] }
 enumflags2 = "0.7.1"
+quaint.workspace = true
 
-[dependencies.quaint]
-git = "https://github.com/prisma/quaint"
-features = [
-    "postgresql",
-    "mysql",
-    "mssql",
-    "sqlite",
-    "json",
-    "uuid",
-    "chrono",
-    "bigdecimal"
-]
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"

--- a/introspection-engine/core/Cargo.toml
+++ b/introspection-engine/core/Cargo.toml
@@ -8,27 +8,23 @@ vendored-openssl = ["sql-introspection-connector/vendored-openssl"]
 
 # Please keep the pyramid form
 [dependencies]
-psl = { path = "../../psl/psl" }
+psl.workspace = true
 user-facing-errors = { path = "../../libs/user-facing-errors" }
 introspection-connector = { path = "../connectors/introspection-connector" }
 sql-introspection-connector = { path = "../connectors/sql-introspection-connector" }
 mongodb-introspection-connector = { path = "../connectors/mongodb-introspection-connector" }
 
-serde = "1.0"
-serde_json = { version = "1.0", features = ["float_roundtrip"] }
-serde_derive = "1.0"
+serde.workspace = true
+serde_json.workspace = true
 async-trait = "0.1.17"
 jsonrpc-core = "17.0"
 jsonrpc-derive = "17.0"
 json-rpc-stdio = { path = "../../libs/json-rpc-stdio" }
+tokio.workspace = true
 
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-futures = "0.2"
-
-[dependencies.tokio]
-version = "1.0"
-features = ["macros"]
 
 [[bin]]
 name = "introspection-engine"

--- a/introspection-engine/core/src/rpc.rs
+++ b/introspection-engine/core/src/rpc.rs
@@ -7,7 +7,7 @@ use jsonrpc_core::BoxFuture;
 use jsonrpc_derive::rpc;
 use mongodb_introspection_connector::MongoDbIntrospectionConnector;
 use psl::{dml::Datamodel, Configuration};
-use serde_derive::*;
+use serde::*;
 use sql_introspection_connector::SqlIntrospectionConnector;
 
 type RpcError = jsonrpc_core::Error;

--- a/introspection-engine/introspection-engine-tests/Cargo.toml
+++ b/introspection-engine/introspection-engine-tests/Cargo.toml
@@ -11,7 +11,7 @@ sql-migration-connector = { path = "../../migration-engine/connectors/sql-migrat
 introspection-connector = { path = "../connectors/introspection-connector" }
 introspection-core = { path = "../core" }
 sql-schema-describer = { path = "../../libs/sql-schema-describer" }
-psl = { path = "../../psl/psl" }
+psl.workspace = true
 test-macros = { path = "../../libs/test-macros" }
 user-facing-errors = { path = "../../libs/user-facing-errors" }
 test-setup = { path = "../../libs/test-setup" }
@@ -19,28 +19,15 @@ test-setup = { path = "../../libs/test-setup" }
 enumflags2 = "0.7"
 pretty_assertions = "0.6.1"
 tracing-futures = "0.2"
-tokio = { version = "1.0", features = ["macros"] }
+tokio.workspace = true
 serde_json = { version = "1.0", features = ["float_roundtrip"] }
 tracing = "0.1"
 indoc = "1"
 expect-test = "1.1.0"
 url = "2"
+quaint.workspace = true
 
 [dependencies.barrel]
 git = "https://github.com/prisma/barrel.git"
 features = ["sqlite3", "mysql", "pg", "mssql"]
 branch = "mssql-support"
-
-[dependencies.quaint]
-git = "https://github.com/prisma/quaint"
-features = [
-    "postgresql",
-    "mysql",
-    "mssql",
-    "sqlite",
-    "json",
-    "uuid",
-    "chrono",
-    "bigdecimal",
-    "vendored-openssl"
-]

--- a/libs/dml/Cargo.toml
+++ b/libs/dml/Cargo.toml
@@ -9,11 +9,11 @@ psl-core = { path = "../../psl/psl-core" }
 schema-ast = { path = "../../psl/schema-ast" }
 native-types = { path = "../native-types" }
 
-uuid = { version = "1", features = ["serde", "v4"], optional = true }
+uuid.workspace = true
 cuid = { version = "1.2", optional = true }
 chrono = { version = "0.4.6", features = ["serde"] }
-serde = { version = "1.0.90", features = ["derive"] }
-serde_json = { version = "1.0", features = ["float_roundtrip"] }
+serde.workspace = true
+serde_json.workspace = true
 enumflags2 = "0.7"
 indoc = "1"
 either = "1.6"
@@ -21,4 +21,4 @@ either = "1.6"
 [features]
 # Support for generating default UUID and CUID default values. This implies
 # random number generation works, so it doesn't compile on targets like wasm32.
-default_generators = ["uuid", "cuid"]
+default_generators = ["uuid/v4", "cuid"]

--- a/libs/json-rpc-stdio/Cargo.toml
+++ b/libs/json-rpc-stdio/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 jsonrpc-core = "17"
-serde_json = "1.0"
-serde = { version = "1.0", features = ["derive"] }
-tokio = { version = "1.0", features = ["io-std", "io-util", "macros", "sync"] }
+serde_json.workspace = true
+serde.workspace = true
+tokio.workspace = true
 tracing = "0.1.12"

--- a/libs/mongodb-schema-describer/Cargo.toml
+++ b/libs/mongodb-schema-describer/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2021"
 [dependencies]
 mongodb = "2.3.0"
 futures = "0.3"
-serde = "1"
+serde.workspace = true

--- a/libs/native-types/Cargo.toml
+++ b/libs/native-types/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-serde = { version = "1", features = ["derive"] }
-serde_json = { version = "1.0", features = ["float_roundtrip"] }
+serde.workspace = true
+serde_json.workspace = true

--- a/libs/prisma-value/Cargo.toml
+++ b/libs/prisma-value/Cargo.toml
@@ -4,15 +4,12 @@ edition = "2021"
 name = "prisma-value"
 version = "0.1.0"
 
-[features]
-default = []
-
 [dependencies]
 base64 = "0.12"
 chrono = { version = "0.4", features = ["serde"] }
 once_cell = "1.3"
 regex = "1.2"
 bigdecimal = "0.3"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = { version = "1.0", features = ["float_roundtrip"] }
-uuid = { version = "1", features = ["serde"] }
+serde.workspace = true
+serde_json.workspace = true
+uuid.workspace = true

--- a/libs/sql-schema-describer/Cargo.toml
+++ b/libs/sql-schema-describer/Cargo.toml
@@ -14,27 +14,16 @@ indexmap = { version = "1.9.1", default_features = false }
 indoc = "1"
 once_cell = "1.3"
 regex = "1.2"
-serde = "1"
-serde_json = "1.0"
+serde.workspace = true
+serde_json.workspace = true
 tracing = "0.1"
 tracing-error = "0.2"
 tracing-futures = "0.2"
-
-[dependencies.quaint]
-git = "https://github.com/prisma/quaint"
-features = [
-    "expose-drivers",
-    "chrono",
-    "sqlite",
-    "postgresql",
-    "mysql",
-    "mssql",
-    "bigdecimal"
-]
+quaint.workspace = true
 
 [dev-dependencies]
 expect-test = "1.2.2"
 pretty_assertions = "0.6"
 test-macros = { path = "../test-macros" }
 test-setup = { path = "../test-setup" }
-tokio = { version = "1.0", default_features = false }
+tokio.workspace = true

--- a/libs/test-cli/Cargo.toml
+++ b/libs/test-cli/Cargo.toml
@@ -12,8 +12,8 @@ migration-core = { path = "../../migration-engine/core" }
 migration-connector = { path = "../../migration-engine/connectors/migration-connector" }
 introspection-core = { path = "../../introspection-engine/core" }
 introspection-connector = { path = "../../introspection-engine/connectors/introspection-connector" }
-psl = { path = "../../psl/psl" }
-tokio = "1.0"
+psl.workspace = true
+tokio.workspace = true
 serde_json = { version = "1.0", features = ["float_roundtrip"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/libs/test-setup/Cargo.toml
+++ b/libs/test-setup/Cargo.toml
@@ -9,25 +9,12 @@ connection-string = "0.1.10"
 dissimilar = "1.0.3"
 enumflags2 = "0.7"
 once_cell = "1.3.1"
-tokio = { version = "1.0", optional = true, features = ["rt-multi-thread"] }
+tokio = { workspace = true, optional = true }
 tracing = "0.1"
 tracing-error = "0.2"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 url = "2.1.1"
-
-[dependencies.quaint]
-git = "https://github.com/prisma/quaint"
-optional = true
-features = [
-    "postgresql",
-    "mysql",
-    "mssql",
-    "sqlite",
-    "json",
-    "uuid",
-    "chrono",
-    "bigdecimal",
-]
+quaint = { workspace = true, optional = true }
 
 [features]
 default = ["sql"]

--- a/libs/user-facing-errors/Cargo.toml
+++ b/libs/user-facing-errors/Cargo.toml
@@ -1,21 +1,16 @@
 [package]
 name = "user-facing-errors"
 version = "0.1.0"
-authors = ["Tom Houlé <tom@tomhoule.com>"]
 edition = "2021"
 
 [dependencies]
 user-facing-error-macros = { path = "../user-facing-error-macros" }
-serde_json = { version = "1.0", features = ["float_roundtrip"] }
-serde = { version = "1.0.102", features = ["derive"] }
+serde_json.workspace = true
+serde.workspace = true
 backtrace = "0.3.40"
 tracing = "0.1"
 indoc = "1"
-
-[dependencies.quaint]
-git = "https://github.com/prisma/quaint"
-features = ["mysql", "postgresql", "sqlite", "mssql"]
-optional = true
+quaint = { workspace = true, optional = true }
 
 [features]
 default = []

--- a/migration-engine/cli/Cargo.toml
+++ b/migration-engine/cli/Cargo.toml
@@ -12,7 +12,7 @@ backtrace = "0.3.59"
 base64 = "0.13"
 json-rpc-stdio = { path = "../../libs/json-rpc-stdio" }
 structopt = "0.3.8"
-tokio = { version = "1.0", default-features = false, features = ["macros"] }
+tokio.workspace = true
 tracing = "0.1"
 tracing-error = "0.2"
 tracing-subscriber = { version = "0.3", features = [ "fmt", "json", "time", "env-filter" ] }
@@ -24,9 +24,7 @@ test-setup = { path = "../../libs/test-setup" }
 test-macros = { path = "../../libs/test-macros" }
 url = "2.1.1"
 connection-string = "0.1"
-
-[dev-dependencies.quaint]
-git = "https://github.com/prisma/quaint"
+quaint.workspace = true
 
 [[bin]]
 name = "migration-engine"

--- a/migration-engine/connectors/migration-connector/Cargo.toml
+++ b/migration-engine/connectors/migration-connector/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-psl = { path = "../../../psl/psl" }
+psl.workspace = true
 introspection-connector = { path = "../../../introspection-engine/connectors/introspection-connector" }
 user-facing-errors = { path = "../../../libs/user-facing-errors" }
 

--- a/migration-engine/connectors/mongodb-migration-connector/Cargo.toml
+++ b/migration-engine/connectors/mongodb-migration-connector/Cargo.toml
@@ -4,7 +4,7 @@ name = "mongodb-migration-connector"
 version = "0.1.0"
 
 [dependencies]
-psl = { path = "../../../psl/psl" }
+psl.workspace = true
 mongodb-client = { path = "../../../libs/mongodb-client" }
 mongodb-schema-describer = { path = "../../../libs/mongodb-schema-describer" }
 migration-connector = { path = "../migration-connector" }
@@ -14,11 +14,11 @@ enumflags2 = "0.7"
 futures = "0.3"
 mongodb = "2.3.0"
 serde_json = "1"
-tokio = { version = "1.0", features = ["parking_lot"] }
+tokio.workspace = true
 tracing = "0.1"
 
 [dev-dependencies]
 dissimilar = "1.0.3"
 once_cell = "1.8.0"
-serde = "1"
+serde.workspace = true
 url = "2"

--- a/migration-engine/connectors/sql-migration-connector/Cargo.toml
+++ b/migration-engine/connectors/sql-migration-connector/Cargo.toml
@@ -4,7 +4,7 @@ name = "sql-migration-connector"
 version = "0.1.0"
 
 [dependencies]
-psl = { path = "../../../psl/psl" }
+psl.workspace = true
 migration-connector = { path = "../migration-connector" }
 native-types = { path = "../../../libs/native-types" }
 sql-schema-describer = { path = "../../../libs/sql-schema-describer" }
@@ -19,23 +19,10 @@ indoc = "1.0"
 once_cell = "1.3"
 regex = "1"
 serde_json = { version = "1.0" }
-tokio = { version = "1.0", default-features = false, features = ["time"] }
+tokio.workspace = true
 tracing = "0.1"
 tracing-futures = "0.2"
 url = "2.1.1"
-uuid = { version = "1", features = ["v4"] }
+uuid.workspace = true
 either = "1.6"
-
-[dependencies.quaint]
-git = "https://github.com/prisma/quaint"
-features = [
-    "json",
-    "uuid",
-    "chrono",
-    "sqlite",
-    "bigdecimal",
-    "postgresql",
-    "mysql",
-    "mssql",
-    "expose-drivers",
-]
+quaint.workspace = true

--- a/migration-engine/core/Cargo.toml
+++ b/migration-engine/core/Cargo.toml
@@ -4,7 +4,7 @@ name = "migration-core"
 version = "0.1.0"
 
 [dependencies]
-psl = { path = "../../psl/psl" }
+psl.workspace = true
 migration-connector = { path = "../connectors/migration-connector" }
 mongodb-migration-connector = { path = "../connectors/mongodb-migration-connector" }
 sql-migration-connector = { path = "../connectors/sql-migration-connector" }
@@ -14,9 +14,9 @@ async-trait = "0.1.17"
 chrono = { version = "0.4", features = ["serde"] }
 enumflags2 = "0.7.1"
 jsonrpc-core = "17.0"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = { version = "1.0", features = ["float_roundtrip"] }
-tokio = { version = "1.0", default_features = false }
+serde.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
 tracing = "0.1"
 tracing-subscriber = "0.3"
 tracing-futures = "0.2"

--- a/migration-engine/json-rpc-api-build/Cargo.toml
+++ b/migration-engine/json-rpc-api-build/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 [dependencies]
 backtrace = "0.3"
 heck = "0.3.3"
-serde = { version = "1", features = ["derive"] }
+serde.workspace = true
 toml = "0.5"
 

--- a/migration-engine/migration-engine-tests/Cargo.toml
+++ b/migration-engine/migration-engine-tests/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-psl = { path = "../../psl/psl" }
+psl.workspace = true
 migration-core = { path = "../core" }
 sql-migration-connector = { path = "../connectors/sql-migration-connector" }
 sql-schema-describer = { path = "../../libs/sql-schema-describer" }
@@ -22,14 +22,11 @@ indoc = "1.0.3"
 jsonrpc-core = "17.0.0"
 once_cell = "1.8.0"
 pretty_assertions = "0.6"
-serde = "1"
-serde_json = { version = "1.0", features = ["float_roundtrip"] }
+serde.workspace = true
+serde_json.workspace = true
 tempfile = "3.1.0"
-tokio = { version = "1.0" }
+tokio.workspace = true
 tracing = "0.1"
 tracing-futures = "0.2"
 url = "2.1.1"
-
-[dependencies.quaint]
-git = "https://github.com/prisma/quaint"
-features = ["vendored-openssl"]
+quaint.workspace = true

--- a/migration-engine/qe-setup/Cargo.toml
+++ b/migration-engine/qe-setup/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-psl = { path = "../../psl/psl" }
+psl.workspace = true
 mongodb-client = { path = "../../libs/mongodb-client" }
 migration-core = { path = "../core" }
 test-setup = { path = "../../libs/test-setup" }
@@ -14,12 +14,4 @@ enumflags2 = "*"
 mongodb = "2.3.0"
 tempfile = "3.3.0"
 url = "2"
-
-[dependencies.quaint]
-git = "https://github.com/prisma/quaint"
-features = [
-    "sqlite",
-    "postgresql",
-    "mysql",
-    "mssql",
-]
+quaint.workspace = true

--- a/prisma-fmt/Cargo.toml
+++ b/prisma-fmt/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-psl = { path = "../psl/psl" }
+psl.workspace = true
 
-serde_json = { version = "1.0", features = ["float_roundtrip"] }
-serde = { version = "1.0.90", features = ["derive"] }
+serde_json.workspace = true
+serde.workspace = true
 lsp-types = "0.91.1"
 log = "0.4.14"
 indoc = "1"

--- a/psl/psl-core/Cargo.toml
+++ b/psl/psl-core/Cargo.toml
@@ -14,8 +14,8 @@ chrono = { version = "0.4.6", default_features = false }
 itertools = "0.10"
 once_cell = "1.3.1"
 regex = "1.3.7"
-serde = { version = "1.0.90", features = ["derive"] }
-serde_json = { version = "1.0", features = ["preserve_order", "float_roundtrip"] }
+serde.workspace = true
+serde_json.workspace = true
 enumflags2 = "0.7"
 indoc = "1"
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/Cargo.toml
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/Cargo.toml
@@ -14,10 +14,10 @@ tracing = "0.1"
 tracing-futures = "0.2"
 colored = "2"
 chrono = "0.4"
-psl = { path = "../../../psl/psl" }
+psl.workspace = true
 base64 = "0.13"
-uuid = "1"
-tokio = "1.21.0"
+uuid.workspace = true
+tokio.workspace = true
 prisma-value = { path = "../../../libs/prisma-value" }
 query-engine-metrics = { path = "../../metrics"}
 

--- a/query-engine/connector-test-kit-rs/query-tests-setup/Cargo.toml
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/Cargo.toml
@@ -5,23 +5,23 @@ authors = ["Dominic Petrick <dompetrick@gmail.com>"]
 edition = "2021"
 
 [dependencies]
-serde_json = "1.0"
+serde_json.workspace = true
 prisma-models = { path = "../../prisma-models" }
 lazy_static = "1.4"
 enum_dispatch = "0.3"
 qe-setup = { path = "../../../migration-engine/qe-setup" }
 request-handlers = { path = "../../request-handlers" }
-tokio = "1.0"
+tokio.workspace = true
 query-core = { path = "../../core" }
 query-engine = { path = "../../query-engine"}
-psl = { path = "../../../psl/psl" }
+psl.workspace = true
 user-facing-errors = { path = "../../../libs/user-facing-errors" }
 thiserror = "1.0"
 async-trait = "0.1"
 nom = "7.1"
 itertools = "0.10"
 regex = "1"
-serde = "1.0"
+serde.workspace = true
 tracing = "0.1"
 tracing-futures = "0.2"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }

--- a/query-engine/connectors/mongodb-query-connector/Cargo.toml
+++ b/query-engine/connectors/mongodb-query-connector/Cargo.toml
@@ -16,10 +16,10 @@ rand = "0.7"
 regex = "1"
 serde_json = { version = "1.0", features = ["float_roundtrip"] }
 thiserror = "1.0"
-tokio = "1.0"
+tokio.workspace = true
 tracing = "0.1"
 tracing-futures = "0.2"
-uuid = "1"
+uuid.workspace = true
 indexmap = "1.7"
 query-engine-metrics = {path = "../../metrics"}
 

--- a/query-engine/connectors/query-connector/Cargo.toml
+++ b/query-engine/connectors/query-connector/Cargo.toml
@@ -11,8 +11,8 @@ futures = "0.3"
 itertools = "0.10"
 prisma-models = {path = "../../prisma-models"}
 prisma-value = {path = "../../../libs/prisma-value"}
-serde = {version = "1.0", features = ["derive"]}
-serde_json = {version = "1.0", features = ["float_roundtrip"]}
+serde.workspace = true
+serde_json.workspace = true
 thiserror = "1.0"
 user-facing-errors = {path = "../../../libs/user-facing-errors"}
 uuid = "1"

--- a/query-engine/connectors/sql-query-connector/Cargo.toml
+++ b/query-engine/connectors/sql-query-connector/Cargo.toml
@@ -16,27 +16,13 @@ once_cell = "1.3"
 rand = "0.7"
 serde_json = {version = "1.0", features = ["float_roundtrip"]}
 thiserror = "1.0"
-tokio = "1.0"
+tokio.workspace = true
 tracing = "0.1"
 tracing-futures = "0.2"
-uuid = "1"
+uuid.workspace = true
 opentelemetry = { version = "0.17", features = ["tokio"] }
 tracing-opentelemetry = "0.17.3"
-
-[dependencies.quaint]
-features = [
-  "pooled",
-  "json",
-  "uuid",
-  "chrono",
-  "sqlite",
-  "postgresql",
-  "mysql",
-  "mssql",
-  "bigdecimal",
-  "fmt-sql"
-]
-git = "https://github.com/prisma/quaint"
+quaint.workspace = true
 
 [dependencies.connector-interface]
 package = "query-connector"
@@ -53,7 +39,7 @@ features = ["serde"]
 version = "0.4"
 
 [dependencies.psl]
-path = "../../../psl/psl"
+workspace = true
 features = ["default_generators"]
 
 [dependencies.serde]

--- a/query-engine/core/Cargo.toml
+++ b/query-engine/core/Cargo.toml
@@ -18,7 +18,7 @@ connection-string = "0.1"
 connector = { path = "../connectors/query-connector", package = "query-connector" }
 crossbeam-queue = "0.3.5"
 mongodb-client = { path = "../../libs/mongodb-client/" }
-psl = { path = "../../psl/psl" }
+psl.workspace = true
 futures = "0.3"
 im = "15.1.0"
 indexmap = { version = "1.7", features = ["serde-1"] }
@@ -30,11 +30,11 @@ prisma-models = { path = "../prisma-models" }
 prisma-value = { path = "../../libs/prisma-value" }
 opentelemetry = { version = "0.17"}
 query-engine-metrics = {path = "../metrics"}
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde.workspace = true
+serde_json.workspace = true
 sql-connector = { path = "../connectors/sql-query-connector", package = "sql-query-connector", optional = true }
 thiserror = "1.0"
-tokio = { version = "1.8" }
+tokio.workspace = true
 tracing = { version = "0.1", features = ["attributes"] }
 tracing-futures = "0.2"
 tracing-subscriber = "0.3.11"

--- a/query-engine/dmmf/Cargo.toml
+++ b/query-engine/dmmf/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2021"
 
 [dependencies]
 bigdecimal = "0.3.0"
-psl = { path = "../../psl/psl" }
-serde = { version = "1.0.136", features = ["derive"] }
-serde_json = "1.0.78"
+psl.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 schema = { path = "../schema" }
 schema-builder = { path = "../schema-builder" }
 indexmap = { version = "1.7", features = ["serde-1"] }

--- a/query-engine/metrics/Cargo.toml
+++ b/query-engine/metrics/Cargo.toml
@@ -8,7 +8,7 @@ metrics = "0.18"
 metrics-util = "0.12.1"
 metrics-exporter-prometheus = "0.10.0"
 once_cell = "1.3"
-serde = { version = "1", features = ["derive"] }
+serde.workspace = true
 serde_json = "1"
 tracing = { version = "0.1" }
 tracing-futures = "0.2"
@@ -17,4 +17,4 @@ parking_lot = "0.12"
 
 [dev-dependencies]
 expect-test = "1"
-tokio = { version = "1.8", features = ["rt-multi-thread"]}
+tokio.workspace = true

--- a/query-engine/prisma-models/Cargo.toml
+++ b/query-engine/prisma-models/Cargo.toml
@@ -5,12 +5,11 @@ version = "0.0.0"
 
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
-psl = { path = "../../psl/psl" }
+psl.workspace = true
 itertools = "0.10"
 once_cell = "1.3"
 prisma-value = { path = "../../libs/prisma-value" }
 bigdecimal = "0.3"
-serde = "1.0"
-serde_derive = "1.0"
+serde.workspace = true
 serde_json = { version = "1.0", features = ["float_roundtrip"] }
 thiserror = "1.0"

--- a/query-engine/query-engine-node-api/Cargo.toml
+++ b/query-engine/query-engine-node-api/Cargo.toml
@@ -19,7 +19,7 @@ query-core = { path = "../core" }
 request-handlers = { path = "../request-handlers" }
 query-connector = { path = "../connectors/query-connector" }
 user-facing-errors = { path = "../../libs/user-facing-errors" }
-psl = { path = "../../psl/psl" }
+psl.workspace = true
 sql-connector = { path = "../connectors/sql-query-connector", package = "sql-query-connector" }
 prisma-models = { path = "../prisma-models" }
 
@@ -29,8 +29,8 @@ napi-derive = "2"
 thiserror = "1"
 connection-string = "0.1"
 url = "2"
-serde_json = { version = "1", features = ["preserve_order", "float_roundtrip"] }
-serde = "1"
+serde_json.workspace = true
+serde.workspace = true
 
 tracing = "0.1"
 tracing-subscriber = { version = "0.3" }
@@ -38,7 +38,7 @@ tracing-futures = "0.2"
 tracing-opentelemetry = "0.17.3"
 opentelemetry = { version = "0.17"}
 
-tokio = { version = "1", features = ["sync"] }
+tokio.workspace = true
 futures = "0.3"
 query-engine-metrics = {path = "../metrics"}
 

--- a/query-engine/query-engine/Cargo.toml
+++ b/query-engine/query-engine/Cargo.toml
@@ -12,13 +12,13 @@ vendored-openssl = ["quaint/vendored-openssl"]
 
 [dependencies]
 futures = "0.3"
-tokio = { version = "1.15", features = ["rt-multi-thread", "macros"] }
+tokio.workspace = true
 anyhow = "1.0"
 async-trait = "0.1"
 base64 = "0.12"
 connection-string = "0.1.10"
 connector = { path = "../connectors/query-connector", package = "query-connector" }
-psl = { path = "../../psl/psl" }
+psl.workspace = true
 graphql-parser = { git = "https://github.com/prisma/graphql-parser" }
 indexmap = { version = "1.7", features = ["serde-1"] }
 itertools = "0.10"
@@ -27,8 +27,8 @@ once_cell = "1.3"
 prisma-models = { path = "../prisma-models" }
 query-core = { path = "../core" }
 request-handlers = { path = "../request-handlers" }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = { version = "1.0", features = ["preserve_order", "float_roundtrip"] }
+serde.workspace = true
+serde_json.workspace = true
 sql-connector = { path = "../connectors/sql-query-connector", optional = true, package = "sql-query-connector" }
 structopt = "0.3"
 thiserror = "1.0"
@@ -55,17 +55,4 @@ anyhow = "1"
 chrono = "0.4"
 indoc = "1"
 serial_test = "*"
-
-[dev-dependencies.quaint]
-features = [
-  "pooled",
-  "json",
-  "uuid",
-  "chrono",
-  "sqlite",
-  "postgresql",
-  "mysql",
-  "mssql",
-  "bigdecimal",
-]
-git = "https://github.com/prisma/quaint"
+quaint.workspace = true

--- a/query-engine/request-handlers/Cargo.toml
+++ b/query-engine/request-handlers/Cargo.toml
@@ -7,12 +7,12 @@ edition = "2021"
 [dependencies]
 query-core = { path = "../core" }
 user-facing-errors = { path = "../../libs/user-facing-errors" }
-psl = { path = "../../psl/psl" }
+psl.workspace = true
 dmmf_crate = { path = "../dmmf", package = "dmmf" }
 itertools = "0.10"
 graphql-parser = { git = "https://github.com/prisma/graphql-parser" }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1"
+serde.workspace = true
+serde_json.workspace = true
 futures = "0.3"
 indexmap = { version = "1.7", features = ["serde-1"] }
 bigdecimal = "0.3"

--- a/query-engine/schema-builder/Cargo.toml
+++ b/query-engine/schema-builder/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-psl = { path = "../../psl/psl" }
+psl.workspace = true
 schema = { path = "../schema" }
 prisma-models = { path = "../prisma-models" }
 once_cell = "1.3"

--- a/query-engine/schema/Cargo.toml
+++ b/query-engine/schema/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 [dependencies]
 prisma-models = { path = "../prisma-models" }
 once_cell = "1.3"
-psl = { path = "../../psl/psl" }
+psl.workspace = true


### PR DESCRIPTION
- They were introduced in Rust 1.64.0 (https://blog.rust-lang.org/2022/09/22/Rust-1.64.0.html). The idea is that dependencies, their versions and features can be declared in the workspace Cargo.toml, and member crates can depend on these. That way, we are sure they depend on the same versions and features.
- This is convenient for us for crates where we have to keep track of many feature flags, like quaint. It makes declaring these dependencies terser and a lot more consistent.
- Another important benefit we should see (I see it on this branch) is faster iteration cycles in development. Previously, if you ran `cargo test` in `migration-engine-tests` and then `cargo test` in `query-engine-tests`, because the feature flags on `tokio` are different in these two crates, you would compile tokio twice, then all the crates that depend on it twice, that is most drivers, and transitively quaint and a large part of prisma engines. Starting with this commit, the same build is reused.
- For workspace dependencies within the workspace, it frees us from awkward relative paths. It also makes it clearer which crates are the public API of a particular group of crates (`psl` for example). We could have cargo-deny rules about forbidding importing anything from the `psl` folder for example, which would guarantee that workspace crates only depend on the intended public API.