### PR TITLE
Cargo.toml: remove vendored-openssl from quaint default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,6 @@ features = [
   "postgresql",
   "sqlite",
   "uuid",
-  "vendored-openssl",
 ]
 
 [profile.dev]


### PR DESCRIPTION
This should revert the repo to the state where it was before 84518359f31ec6c74398c1d1a400066be38f29fc regarding static or dynamic linking of libssl.