### PR TITLE
Cargo.toml: start using workspace.package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,12 @@ members = [
   "psl/*",
 ]
 
+[workspace.package]
+documentation = "https://prisma.github.io/prisma-engines/"
+edition = "2021"
+homepage = "https://github.com/prisma/prisma-engines"
+repository =  "https://github.com/prisma/prisma-engines"
+
 [workspace.dependencies]
 psl = { path = "./psl/psl" }
 serde_json = { version = "1", features = ["float_roundtrip", "preserve_order"] }
@@ -55,6 +61,7 @@ features = [
   "sqlite",
   "uuid",
 ]
+
 
 [profile.dev]
 split-debuginfo = "unpacked"

--- a/introspection-engine/connectors/introspection-connector/Cargo.toml
+++ b/introspection-engine/connectors/introspection-connector/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "introspection-connector"
 version = "0.1.0"
-edition = "2021"
 
 [dependencies]
 async-trait = "0.1.17"

--- a/introspection-engine/connectors/mongodb-introspection-connector/Cargo.toml
+++ b/introspection-engine/connectors/mongodb-introspection-connector/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "mongodb-introspection-connector"
 version = "0.1.0"
-edition = "2021"
 
 [dependencies]
 mongodb = "2.3.0"

--- a/introspection-engine/connectors/sql-introspection-connector/Cargo.toml
+++ b/introspection-engine/connectors/sql-introspection-connector/Cargo.toml
@@ -1,6 +1,4 @@
 [package]
-authors = ["Marcus Böhm <boehm@prisma.io>"]
-edition = "2021"
 name = "sql-introspection-connector"
 version = "0.1.0"
 

--- a/introspection-engine/core/Cargo.toml
+++ b/introspection-engine/core/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "introspection-core"
 version = "0.1.0"
-edition = "2021"
 
 [features]
 vendored-openssl = ["sql-introspection-connector/vendored-openssl"]

--- a/introspection-engine/introspection-engine-tests/Cargo.toml
+++ b/introspection-engine/introspection-engine-tests/Cargo.toml
@@ -1,8 +1,6 @@
 [package]
 name = "introspection-engine-tests"
 version = "0.1.0"
-authors = ["Julius de Bruijn <julius+github@nauk.io>"]
-edition = "2021"
 
 [dependencies]
 sql-introspection-connector = { path = "../connectors/sql-introspection-connector" }

--- a/libs/dml/Cargo.toml
+++ b/libs/dml/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "dml"
 version = "0.1.0"
-edition = "2021"
 
 [dependencies]
 prisma-value = { path = "../prisma-value" }

--- a/libs/json-rpc-stdio/Cargo.toml
+++ b/libs/json-rpc-stdio/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "json-rpc-stdio"
 version = "0.1.0"
-edition = "2021"
 
 [dependencies]
 jsonrpc-core = "17"

--- a/libs/mongodb-client/Cargo.toml
+++ b/libs/mongodb-client/Cargo.toml
@@ -1,9 +1,6 @@
 [package]
 name = "mongodb-client"
 version = "0.1.0"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 mongodb = "2.3.0"

--- a/libs/mongodb-schema-describer/Cargo.toml
+++ b/libs/mongodb-schema-describer/Cargo.toml
@@ -1,9 +1,6 @@
 [package]
 name = "mongodb-schema-describer"
 version = "0.1.0"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 mongodb = "2.3.0"

--- a/libs/native-types/Cargo.toml
+++ b/libs/native-types/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "native-types"
 version = "0.1.0"
-edition = "2021"
 
 [dependencies]
 serde.workspace = true

--- a/libs/prisma-value/Cargo.toml
+++ b/libs/prisma-value/Cargo.toml
@@ -1,6 +1,4 @@
 [package]
-authors = ["Marcus Böhm <boehm@prisma.io>"]
-edition = "2021"
 name = "prisma-value"
 version = "0.1.0"
 

--- a/libs/sql-ddl/Cargo.toml
+++ b/libs/sql-ddl/Cargo.toml
@@ -1,8 +1,6 @@
 [package]
 name = "sql-ddl"
 version = "0.1.0"
-authors = ["Tom Houlé <tom@tomhoule.com>"]
-edition = "2021"
 
 [features]
 postgres = []

--- a/libs/sql-schema-describer/Cargo.toml
+++ b/libs/sql-schema-describer/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-edition = "2021"
 name = "sql-schema-describer"
 version = "0.1.0"
 

--- a/libs/test-cli/Cargo.toml
+++ b/libs/test-cli/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "test-cli"
 version = "0.1.0"
-edition = "2021"
 
 [dependencies]
 anyhow = "1.0.26"

--- a/libs/test-macros/Cargo.toml
+++ b/libs/test-macros/Cargo.toml
@@ -1,8 +1,6 @@
 [package]
 name = "test-macros"
 version = "0.1.0"
-authors = ["Tom Houlé <tom@tomhoule.com>"]
-edition = "2021"
 
 [lib]
 proc-macro = true

--- a/libs/test-setup/Cargo.toml
+++ b/libs/test-setup/Cargo.toml
@@ -1,8 +1,6 @@
 [package]
 name = "test-setup"
 version = "0.1.0"
-authors = ["Tom Houlé <tom@tomhoule.com>"]
-edition = "2021"
 
 [dependencies]
 connection-string = "0.1.10"

--- a/libs/user-facing-error-macros/Cargo.toml
+++ b/libs/user-facing-error-macros/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "user-facing-error-macros"
 version = "0.1.0"
-edition = "2021"
 
 [lib]
 proc-macro = true

--- a/libs/user-facing-errors/Cargo.toml
+++ b/libs/user-facing-errors/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "user-facing-errors"
 version = "0.1.0"
-edition = "2021"
 
 [dependencies]
 user-facing-error-macros = { path = "../user-facing-error-macros" }

--- a/migration-engine/cli/Cargo.toml
+++ b/migration-engine/cli/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "migration-engine-cli"
 version = "0.1.0"
-edition = "2021"
 
 [dependencies]
 migration-connector = { path = "../connectors/migration-connector" }

--- a/migration-engine/connectors/migration-connector/Cargo.toml
+++ b/migration-engine/connectors/migration-connector/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "migration-connector"
 version = "0.1.0"
-edition = "2021"
 
 [dependencies]
 psl.workspace = true

--- a/migration-engine/connectors/mongodb-migration-connector/Cargo.toml
+++ b/migration-engine/connectors/mongodb-migration-connector/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-edition = "2021"
 name = "mongodb-migration-connector"
 version = "0.1.0"
 

--- a/migration-engine/connectors/sql-migration-connector/Cargo.toml
+++ b/migration-engine/connectors/sql-migration-connector/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-edition = "2021"
 name = "sql-migration-connector"
 version = "0.1.0"
 

--- a/migration-engine/core/Cargo.toml
+++ b/migration-engine/core/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-edition = "2021"
 name = "migration-core"
 version = "0.1.0"
 

--- a/migration-engine/json-rpc-api-build/Cargo.toml
+++ b/migration-engine/json-rpc-api-build/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "json-rpc-api-build"
 version = "0.1.0"
-edition = "2021"
 
 [dependencies]
 backtrace = "0.3"

--- a/migration-engine/migration-engine-tests/Cargo.toml
+++ b/migration-engine/migration-engine-tests/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "migration-engine-tests"
 version = "0.1.0"
-edition = "2021"
 
 [dependencies]
 psl.workspace = true

--- a/migration-engine/qe-setup/Cargo.toml
+++ b/migration-engine/qe-setup/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "qe-setup"
 version = "0.1.0"
-edition = "2021"
 
 [dependencies]
 psl.workspace = true

--- a/prisma-fmt/Cargo.toml
+++ b/prisma-fmt/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "prisma-fmt"
 version = "0.1.0"
-edition = "2021"
 
 [dependencies]
 psl.workspace = true

--- a/psl/builtin-connectors/Cargo.toml
+++ b/psl/builtin-connectors/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "builtin-psl-connectors"
 version = "0.1.0"
-edition = "2021"
 
 [dependencies]
 psl-core = { path = "../psl-core" }

--- a/psl/diagnostics/Cargo.toml
+++ b/psl/diagnostics/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "diagnostics"
 version = "0.1.0"
-edition = "2021"
 
 [dependencies]
 colored = "2"

--- a/psl/parser-database/Cargo.toml
+++ b/psl/parser-database/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "parser-database"
 version = "0.1.0"
-edition = "2021"
 
 [dependencies]
 diagnostics = { path = "../diagnostics" }

--- a/psl/psl-core/Cargo.toml
+++ b/psl/psl-core/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-edition = "2021"
 name = "psl-core"
 version = "0.1.0"
 

--- a/psl/psl/Cargo.toml
+++ b/psl/psl/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "psl"
 version = "0.1.0"
-edition = "2021"
 
 [dependencies]
 builtin-psl-connectors = { path = "../builtin-connectors" }

--- a/psl/schema-ast/Cargo.toml
+++ b/psl/schema-ast/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "schema-ast"
 version = "0.1.0"
-edition = "2021"
 
 [dependencies]
 diagnostics = { path = "../diagnostics" }

--- a/query-engine/connector-test-kit-rs/query-engine-tests/Cargo.toml
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/Cargo.toml
@@ -1,6 +1,4 @@
 [package]
-authors = ["Dominic Petrick <dompetrick@gmail.com>"]
-edition = "2018"
 name = "query-engine-tests"
 version = "0.1.0"
 

--- a/query-engine/connector-test-kit-rs/query-test-macros/Cargo.toml
+++ b/query-engine/connector-test-kit-rs/query-test-macros/Cargo.toml
@@ -1,8 +1,6 @@
 [package]
 name = "query-test-macros"
 version = "0.1.0"
-authors = ["Dominic Petrick <dompetrick@gmail.com>"]
-edition = "2021"
 
 [lib]
 proc-macro = true

--- a/query-engine/connector-test-kit-rs/query-tests-setup/Cargo.toml
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/Cargo.toml
@@ -1,8 +1,6 @@
 [package]
 name = "query-tests-setup"
 version = "0.1.0"
-authors = ["Dominic Petrick <dompetrick@gmail.com>"]
-edition = "2021"
 
 [dependencies]
 serde_json.workspace = true

--- a/query-engine/connectors/mongodb-query-connector/Cargo.toml
+++ b/query-engine/connectors/mongodb-query-connector/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-edition = "2021"
 name = "mongodb-query-connector"
 version = "0.1.0"
 

--- a/query-engine/connectors/query-connector/Cargo.toml
+++ b/query-engine/connectors/query-connector/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-edition = "2021"
 name = "query-connector"
 version = "0.1.0"
 

--- a/query-engine/connectors/sql-query-connector/Cargo.toml
+++ b/query-engine/connectors/sql-query-connector/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-edition = "2021"
 name = "sql-query-connector"
 version = "0.1.0"
 

--- a/query-engine/core/Cargo.toml
+++ b/query-engine/core/Cargo.toml
@@ -1,6 +1,4 @@
 [package]
-authors = ["Dominic Petrick <dompetrick@gmail.com>", "Katharina Fey <kookie@spacekookie.de>"]
-edition = "2021"
 name = "query-core"
 version = "0.1.0"
 

--- a/query-engine/dmmf/Cargo.toml
+++ b/query-engine/dmmf/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "dmmf"
 version = "0.1.0"
-edition = "2021"
 
 [dependencies]
 bigdecimal = "0.3.0"

--- a/query-engine/metrics/Cargo.toml
+++ b/query-engine/metrics/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "query-engine-metrics"
 version = "0.1.0"
-edition = "2021"
 
 [dependencies]
 metrics = "0.18"

--- a/query-engine/prisma-models/Cargo.toml
+++ b/query-engine/prisma-models/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-edition = "2021"
 name = "prisma-models"
 version = "0.0.0"
 

--- a/query-engine/query-engine-node-api/Cargo.toml
+++ b/query-engine/query-engine-node-api/Cargo.toml
@@ -1,8 +1,6 @@
 [package]
 name = "query-engine-node-api"
 version = "0.1.0"
-authors = ["Julius de Bruijn <bruijn@prisma.io>"]
-edition = "2021"
 
 [lib]
 doc = false

--- a/query-engine/query-engine/Cargo.toml
+++ b/query-engine/query-engine/Cargo.toml
@@ -1,6 +1,4 @@
 [package]
-authors = ["Dominic Petrick <dompetrick@gmail.com>", "Katharina Fey <kookie@spacekookie.de>"]
-edition = "2021"
 name = "query-engine"
 version = "0.1.0"
 

--- a/query-engine/request-handlers/Cargo.toml
+++ b/query-engine/request-handlers/Cargo.toml
@@ -1,8 +1,6 @@
 [package]
 name = "request-handlers"
 version = "0.1.0"
-authors = ["Julius de Bruijn <julius+github@nauk.io>"]
-edition = "2021"
 
 [dependencies]
 query-core = { path = "../core" }

--- a/query-engine/schema-builder/Cargo.toml
+++ b/query-engine/schema-builder/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "schema-builder"
 version = "0.1.0"
-edition = "2021"
 
 [dependencies]
 psl.workspace = true

--- a/query-engine/schema/Cargo.toml
+++ b/query-engine/schema/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "schema"
 version = "0.1.0"
-edition = "2021"
 
 [dependencies]
 prisma-models = { path = "../prisma-models" }


### PR DESCRIPTION
It's new in rust 1.64.0.

It saves us repetition.

Also remove remaining `authors` fields in Cargo.toml files, as decided a while back in a rust group meeting.