### PR TITLE
ie: unify and enrich internal introspection params

### DIFF
--- a/introspection-engine/connectors/mongodb-introspection-connector/src/lib.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/src/lib.rs
@@ -13,7 +13,7 @@ use introspection_connector::{
 };
 use mongodb::{Client, Database};
 use mongodb_schema_describer::MongoSchema;
-use psl::{common::preview_features::PreviewFeature, dml::Datamodel};
+use psl::common::preview_features::PreviewFeature;
 use user_facing_errors::{common::InvalidConnectionString, KnownError};
 
 #[derive(Debug)]
@@ -123,12 +123,7 @@ impl IntrospectionConnector for MongoDbIntrospectionConnector {
         Ok(self.version().await.unwrap())
     }
 
-    async fn introspect(
-        &self,
-        // TODO: Re-introspection.
-        _existing_data_model: &Datamodel,
-        ctx: IntrospectionContext,
-    ) -> ConnectorResult<IntrospectionResult> {
+    async fn introspect(&self, ctx: &IntrospectionContext) -> ConnectorResult<IntrospectionResult> {
         let schema = self.describe(ctx.preview_features).await?;
         Ok(sampler::sample(self.database(), ctx.composite_type_depth, schema).await?)
     }

--- a/introspection-engine/connectors/sql-introspection-connector/src/calculate_datamodel.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/calculate_datamodel.rs
@@ -31,11 +31,11 @@ impl CalculateDatamodelContext<'_> {
 /// Calculate a data model from a database schema.
 pub fn calculate_datamodel(
     schema: &SqlSchema,
-    previous_datamodel: &Datamodel,
-    ctx: IntrospectionContext,
+    ctx: &IntrospectionContext,
 ) -> SqlIntrospectionResult<IntrospectionResult> {
     debug!("Calculating data model.");
 
+    let previous_datamodel = &ctx.previous_data_model;
     let mut datamodel = Datamodel::new();
 
     let mut context = CalculateDatamodelContext {
@@ -59,18 +59,18 @@ pub fn calculate_datamodel(
 
     let mut warnings = vec![];
     if !previous_datamodel.is_empty() {
-        enrich(previous_datamodel, &mut datamodel, &ctx, &mut warnings);
+        enrich(previous_datamodel, &mut datamodel, ctx, &mut warnings);
         debug!("Enriching datamodel is done.");
     }
 
     // commenting out models, fields, enums, enum values
-    warnings.append(&mut commenting_out_guardrails(&mut datamodel, &ctx));
+    warnings.append(&mut commenting_out_guardrails(&mut datamodel, ctx));
 
     // try to identify whether the schema was created by a previous Prisma version
-    let version = version_checker::check_prisma_version(schema, &ctx, &mut warnings);
+    let version = version_checker::check_prisma_version(schema, ctx, &mut warnings);
 
     // if based on a previous Prisma version add id default opinionations
-    add_prisma_1_id_defaults(&version, &mut datamodel, schema, &mut warnings, &ctx);
+    add_prisma_1_id_defaults(&version, &mut datamodel, schema, &mut warnings, ctx);
 
     debug!("Done calculating datamodel.");
     Ok(IntrospectionResult {

--- a/introspection-engine/connectors/sql-introspection-connector/src/lib.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/lib.rs
@@ -22,7 +22,7 @@ use introspection_connector::{
     ConnectorError, ConnectorResult, DatabaseMetadata, ErrorKind, IntrospectionConnector, IntrospectionContext,
     IntrospectionResult,
 };
-use psl::{common::preview_features::PreviewFeature, dml::Datamodel};
+use psl::common::preview_features::PreviewFeature;
 use quaint::prelude::SqlFamily;
 use quaint::{prelude::ConnectionInfo, single::Quaint};
 use schema_describer_loading::load_describer;
@@ -146,15 +146,11 @@ impl IntrospectionConnector for SqlIntrospectionConnector {
         Ok(description)
     }
 
-    async fn introspect(
-        &self,
-        previous_data_model: &Datamodel,
-        ctx: IntrospectionContext,
-    ) -> ConnectorResult<IntrospectionResult> {
+    async fn introspect(&self, ctx: &IntrospectionContext) -> ConnectorResult<IntrospectionResult> {
         let sql_schema = self.catch(self.describe(Some(ctx.source.active_provider))).await?;
 
-        let introspection_result = calculate_datamodel::calculate_datamodel(&sql_schema, previous_data_model, ctx)
-            .map_err(|sql_introspection_error| {
+        let introspection_result =
+            calculate_datamodel::calculate_datamodel(&sql_schema, ctx).map_err(|sql_introspection_error| {
                 sql_introspection_error.into_connector_error(self.connection.connection_info())
             })?;
 

--- a/introspection-engine/introspection-engine-tests/tests/cockroachdb/mod.rs
+++ b/introspection-engine/introspection-engine-tests/tests/cockroachdb/mod.rs
@@ -3,7 +3,6 @@ mod gin;
 use indoc::indoc;
 use introspection_connector::{CompositeTypeDepth, IntrospectionConnector, IntrospectionContext};
 use introspection_engine_tests::test_api::*;
-use psl::parse_configuration;
 
 #[test_connector(tags(CockroachDb))]
 async fn introspecting_cockroach_db_with_postgres_provider(api: TestApi) {
@@ -27,19 +26,9 @@ async fn introspecting_cockroach_db_with_postgres_provider(api: TestApi) {
 
     api.raw_cmd(setup).await;
 
-    let ctx = IntrospectionContext {
-        preview_features: Default::default(),
-        source: parse_configuration(&schema)
-            .unwrap()
-            .datasources
-            .into_iter()
-            .next()
-            .unwrap(),
-        composite_type_depth: CompositeTypeDepth::Infinite,
-    };
-
     let schema = psl::parse_schema(schema).unwrap();
-    api.api.introspect(&psl::lift(&schema), ctx).await.unwrap();
+    let ctx = IntrospectionContext::new_config_only(schema, CompositeTypeDepth::Infinite);
+    api.api.introspect(&ctx).await.unwrap();
 }
 
 #[test_connector(tags(CockroachDb))]

--- a/introspection-engine/introspection-engine-tests/tests/re_introspection/mod.rs
+++ b/introspection-engine/introspection-engine-tests/tests/re_introspection/mod.rs
@@ -1108,21 +1108,16 @@ async fn virtual_cuid_default(api: &TestApi) {
         .await
         .unwrap();
 
-    let input_dm = format!(
-        r#"
-        {datasource}
-
-        model User {{
+    let input_dm = r#"
+        model User {
             id        String    @id @default(cuid()) @db.VarChar(30)
             non_id    String    @default(cuid()) @db.VarChar(30)
-        }}
+        }
 
-        model User2 {{
+        model User2 {
             id        String    @id @default(uuid()) @db.VarChar(36)
-        }}
-        "#,
-        datasource = api.datasource_block()
-    );
+        }
+        "#;
 
     let final_dm = indoc! {r#"
         model User {
@@ -1139,7 +1134,7 @@ async fn virtual_cuid_default(api: &TestApi) {
         }
     "#};
 
-    api.assert_eq_datamodels(final_dm, &api.re_introspect(&input_dm).await.unwrap());
+    api.assert_eq_datamodels(final_dm, &api.re_introspect(input_dm).await.unwrap());
 }
 
 #[test_connector(tags(CockroachDb))]
@@ -1162,21 +1157,16 @@ async fn virtual_cuid_default_cockroach(api: &TestApi) {
         .await
         .unwrap();
 
-    let input_dm = format!(
-        r#"
-        {datasource}
-
-        model User {{
+    let input_dm = r#"
+        model User {
             id        String    @id @default(cuid()) @db.String(30)
             non_id    String    @default(cuid()) @db.String(30)
-        }}
+        }
 
-        model User2 {{
+        model User2 {
             id        String    @id @default(uuid()) @db.String(36)
-        }}
-        "#,
-        datasource = api.datasource_block()
-    );
+        }
+        "#;
 
     let final_dm = indoc! {r#"
         model User {
@@ -1193,7 +1183,7 @@ async fn virtual_cuid_default_cockroach(api: &TestApi) {
         }
     "#};
 
-    api.assert_eq_datamodels(final_dm, &api.re_introspect(&input_dm).await.unwrap());
+    api.assert_eq_datamodels(final_dm, &api.re_introspect(input_dm).await.unwrap());
 }
 
 #[test_connector(tags(Postgres), exclude(CockroachDb))]
@@ -1288,15 +1278,11 @@ async fn updated_at(api: &TestApi) {
         ""
     };
     let input_dm = formatdoc! {r#"
-        {datasource}
-
         model User {{
             id           Int @id @default(autoincrement())
             lastupdated  DateTime?  @updatedAt {native_datetime}
         }}
         "#,
-        native_datetime = native_datetime,
-        datasource = api.datasource_block(),
     };
 
     let final_dm = formatdoc! {r#"
@@ -1821,8 +1807,7 @@ async fn re_introspecting_custom_compound_id_names(api: &TestApi) -> TestResult 
         })
         .await?;
 
-    let input_dm = api.dm_with_sources(
-        r#"
+    let input_dm = r#"
          model User {
              first  Int
              last   Int
@@ -1836,8 +1821,7 @@ async fn re_introspecting_custom_compound_id_names(api: &TestApi) -> TestResult 
 
              @@id([first, last], name: "compound")
          }
-     "#,
-    );
+     "#;
 
     let final_dm = r#"
          model User {
@@ -1859,7 +1843,7 @@ async fn re_introspecting_custom_compound_id_names(api: &TestApi) -> TestResult 
          }
      "#;
 
-    let re_introspected = api.re_introspect(&input_dm).await?;
+    let re_introspected = api.re_introspect(input_dm).await?;
 
     api.assert_eq_datamodels(final_dm, &re_introspected);
 
@@ -1872,7 +1856,7 @@ async fn re_introspecting_custom_compound_id_names(api: &TestApi) -> TestResult 
         ]
     }]);
 
-    assert_eq_json!(expected, api.re_introspect_warnings(&input_dm).await?);
+    assert_eq_json!(expected, api.re_introspect_warnings(input_dm).await?);
 
     Ok(())
 }
@@ -1891,7 +1875,7 @@ async fn re_introspecting_custom_index_order(api: &TestApi) -> TestResult {
     api.database().raw_cmd(&create_idx_b).await?;
     api.database().raw_cmd(&create_idx_c).await?;
 
-    let dm = indoc! {r#"
+    let input_dm = indoc! {r#"
          model A {
            id Int   @id
            a  Json
@@ -1902,9 +1886,7 @@ async fn re_introspecting_custom_index_order(api: &TestApi) -> TestResult {
          }
     "#};
 
-    let input_dm = api.dm_with_sources(dm);
-    let input_dm = api.dm_with_generator_and_preview_flags(&input_dm);
-    let re_introspected = api.re_introspect_dml(&input_dm).await?;
+    let re_introspected = api.re_introspect_dml(input_dm).await?;
 
     let expected = expect![[r#"
         model A {

--- a/introspection-engine/introspection-engine-tests/tests/re_introspection/mssql.rs
+++ b/introspection-engine/introspection-engine-tests/tests/re_introspection/mssql.rs
@@ -250,11 +250,6 @@ async fn updated_at(api: &TestApi) {
     api.raw_cmd(&setup).await;
 
     let input_dm = indoc! {r#"
-        datasource db {
-            provider = "sqlserver"
-            url = env("TEST_DATABASE_URL")
-        }
-
         model User {
             id           Int    @id
             lastupdated  DateTime? @updatedAt

--- a/introspection-engine/introspection-engine-tests/tests/tables/mysql.rs
+++ b/introspection-engine/introspection-engine-tests/tests/tables/mysql.rs
@@ -1,7 +1,6 @@
 use indoc::{formatdoc, indoc};
 use introspection_connector::{IntrospectionConnector, IntrospectionContext};
 use introspection_engine_tests::test_api::*;
-use psl::dml::Datamodel;
 use sql_introspection_connector::SqlIntrospectionConnector;
 use url::Url;
 
@@ -411,15 +410,11 @@ async fn missing_select_rights(api: &TestApi) -> TestResult {
     "#
     );
 
-    let config = psl::parse_configuration(&datasource).unwrap();
+    let config = psl::parse_schema(datasource).unwrap();
 
-    let ctx = IntrospectionContext {
-        source: config.datasources.into_iter().next().unwrap(),
-        composite_type_depth: Default::default(),
-        preview_features: Default::default(),
-    };
+    let ctx = IntrospectionContext::new(config, Default::default());
 
-    let res = conn.introspect(&Datamodel::new(), ctx).await.unwrap();
+    let res = conn.introspect(&ctx).await.unwrap();
     assert!(res.data_model.is_empty());
 
     Ok(())

--- a/migration-engine/connectors/migration-connector/src/lib.rs
+++ b/migration-engine/connectors/migration-connector/src/lib.rs
@@ -194,9 +194,8 @@ pub trait MigrationConnector: Send + Sync + 'static {
     /// In-tro-spec-shon.
     fn introspect<'a>(
         &'a mut self,
-        schema: &'a ValidatedSchema,
-        ctx: introspection_connector::IntrospectionContext,
-    ) -> BoxFuture<'_, ConnectorResult<introspection_connector::IntrospectionResult>>;
+        ctx: &'a introspection_connector::IntrospectionContext,
+    ) -> BoxFuture<'a, ConnectorResult<introspection_connector::IntrospectionResult>>;
 
     /// If possible, check that the passed in migrations apply cleanly.
     fn validate_migrations<'a>(

--- a/migration-engine/connectors/sql-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/lib.rs
@@ -223,18 +223,12 @@ impl MigrationConnector for SqlMigrationConnector {
 
     fn introspect<'a>(
         &'a mut self,
-        schema: &'a ValidatedSchema,
-        ctx: IntrospectionContext,
+        ctx: &'a IntrospectionContext,
     ) -> BoxFuture<'a, ConnectorResult<IntrospectionResult>> {
         Box::pin(async move {
             let sql_schema = self.flavour.describe_schema().await?;
-            let previous_datamodel = psl::lift(schema);
-            let datamodel = sql_introspection_connector::calculate_datamodel::calculate_datamodel(
-                &sql_schema,
-                &previous_datamodel,
-                ctx,
-            )
-            .map_err(|err| ConnectorError::from_source(err, "Introspection error"))?;
+            let datamodel = sql_introspection_connector::calculate_datamodel::calculate_datamodel(&sql_schema, ctx)
+                .map_err(|err| ConnectorError::from_source(err, "Introspection error"))?;
             Ok(datamodel)
         })
     }

--- a/migration-engine/core/src/state.rs
+++ b/migration-engine/core/src/state.rs
@@ -305,15 +305,12 @@ impl GenericApi for EngineState {
             &params.schema,
             None,
             Box::new(move |connector| {
-                let ctx = migration_connector::IntrospectionContext {
-                    composite_type_depth: From::from(params.composite_type_depth as isize),
-                    preview_features: schema.configuration.preview_features(),
-                    source: schema.configuration.datasources[0].clone(),
-                };
+                let composite_type_depth = From::from(params.composite_type_depth as isize);
+                let ctx = migration_connector::IntrospectionContext::new(schema, composite_type_depth);
                 Box::pin(async move {
-                    let result = connector.introspect(&schema, ctx).await?;
+                    let result = connector.introspect(&ctx).await?;
                     let rendered_result =
-                        psl::render_datamodel_and_config_to_string(&result.data_model, &schema.configuration);
+                        psl::render_datamodel_and_config_to_string(&result.data_model, ctx.configuration());
                     Ok(IntrospectResult {
                         datamodel: rendered_result,
                         version: format!("{:?}", result.version),


### PR DESCRIPTION
This is an internal change that does not alter the public API of the introspection engine.

We took only the dml of the previous schema previously, now we take the ValidatedSchema as well. It has much more context in a much nicer API for reintrospection. Taking a `ValidatedSchema` directly to construct an IntrospectionContext instead of a variety of inputs also ensures that the datasource, preview features, datamodel, schema source string and validated schema all come from the same input string, that they are consistent.