### PR TITLE
qe: fix create w/ @default(now())/@updatedAt in id

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
@@ -11,6 +11,7 @@ mod prisma_14696;
 mod prisma_14703;
 mod prisma_15204;
 mod prisma_15264;
+mod prisma_15581;
 mod prisma_5952;
 mod prisma_6173;
 mod prisma_7010;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_12572.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_12572.rs
@@ -1,5 +1,7 @@
 use query_engine_tests::*;
 
+// The fix for this issue caused problems with `create` operations. See the comment and tests in
+// `prisma_15581.rs`.
 #[test_suite(schema(schema))]
 mod prisma_12572 {
     fn schema() -> String {

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_15581.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_15581.rs
@@ -1,0 +1,111 @@
+use query_engine_tests::*;
+
+// issue: https://github.com/prisma/prisma/issues/15581
+// notion doc: https://www.notion.so/prismaio/Single-create-with-default-now-or-updatedAt-in-id-fail-d6550337014c4e5ab81d4d362228aa14
+// original issue
+// https://www.notion.so/prismaio/QE-now-changes-within-the-same-request-280b56d1075f43dea5c5dd82b755541b
+// and its issue https://github.com/prisma/prisma/issues/12572
+//
+// Matching tests for the original issue in prisma_12572.rs
+#[test_suite(schema(schema))]
+mod prisma_15581 {
+    fn schema() -> String {
+        r#"
+            model test {
+                reference Int
+                created_at DateTime @default(now())
+                other String?
+
+                @@id([reference, created_at])
+            }
+
+            model test2 {
+                updated_at DateTime @updatedAt
+                other String?
+                reference Int
+
+                @@id([reference, updated_at])
+            }
+        "#
+        .to_owned()
+    }
+
+    #[connector_test(exclude(Mongodb))]
+    async fn create_one_model_with_datetime_default_now_in_id(runner: Runner) -> TestResult<()> {
+        run_query!(
+            runner,
+            r#"mutation { createOnetest(data: { reference: 3 }) { reference created_at other } }"#
+        );
+        Ok(())
+    }
+
+    #[connector_test(exclude(Mongodb))]
+    async fn create_one_model_with_updated_at_in_id(runner: Runner) -> TestResult<()> {
+        run_query!(
+            runner,
+            r#"mutation { createOnetest2(data: { reference: 3 }) { reference updated_at other } }"#
+        );
+        Ok(())
+    }
+
+    fn pg_schema() -> String {
+        r#"
+            model test {
+                reference Int
+                created_at DateTime @default(now()) @test.Timestamptz(1)
+                other String?
+
+                @@id([reference, created_at])
+            }
+        "#
+        .to_owned()
+    }
+
+    #[connector_test(only(Postgres), schema(pg_schema))]
+    async fn create_one_model_with_low_precision_datetime_in_id(runner: Runner) -> TestResult<()> {
+        let result = runner
+            .query(r#"mutation { createOnetest(data: { reference: 3 }) { reference created_at other } }"#)
+            .await?
+            .to_string_pretty();
+
+        // This is a test that confirms the current behaviour. Ideally, the create mutation above
+        // should work.
+        assert!(
+            result.contains("\"error\": \"Query createOnetest is required to return data, but found no record(s).\"")
+        );
+        Ok(())
+    }
+
+    fn single_field_id_schema() -> String {
+        r#"
+            model test {
+                #id(created_at, DateTime, @default(now()) @id)
+                other String?
+            }
+
+            model test2 {
+                #id(updated_at, DateTime, @updatedAt @id)
+                reference Int
+            }
+        "#
+        .to_owned()
+    }
+
+    #[connector_test(schema(single_field_id_schema))]
+    async fn single_create_one_model_with_default_now_in_id(runner: Runner) -> TestResult<()> {
+        run_query!(
+            runner,
+            r#"mutation { createOnetest(data: { other: "meow" }) { created_at other } }"#
+        );
+        Ok(())
+    }
+
+    #[connector_test(schema(single_field_id_schema))]
+    async fn single_create_one_model_with_updated_at_in_id(runner: Runner) -> TestResult<()> {
+        run_query!(
+            runner,
+            r#"mutation { createOnetest2(data: { reference: 2 }) { updated_at reference } }"#
+        );
+        Ok(())
+    }
+}

--- a/query-engine/connectors/query-connector/src/write_args.rs
+++ b/query-engine/connectors/query-connector/src/write_args.rs
@@ -396,6 +396,7 @@ impl WriteArgs {
         self.args.len()
     }
 
+    // @updatedAt
     pub fn add_datetimes(&mut self, model: &ModelRef) {
         let updated_at_fields = model.fields().updated_at();
         let value = &self.request_now;


### PR DESCRIPTION
This is a regression introduced in
fcf3572335e1fd8e0cd0fff9322345dae114f071. `@default(now())` and `@updatedAt` timestamps became more precise. This caused an issue with create queries. Schematically, this is what we do:

- INSERT with the high precision timestamp
- SELECT back the record using its primary key columns (the id fields)
  - the SELECT has a WHERE clause that uses the high precision timestamp we used

The catch with this process is that the database has stored a _lower precision_ timestamp in the column, so the WHERE does not match the record that was just inserted, and we get the error from https://github.com/prisma/prisma/issues/15581

This commit makes the timestamps for `@default(now())` and `@updatedAt` values less precise (millisecond precision only), re-establishing the equality comparisons. This approach was proposed and originally decided against in
https://www.notion.so/prismaio/QE-now-changes-within-the-same-request-280b56d1075f43dea5c5dd82b755541b

Internal design doc: https://www.notion.so/prismaio/Single-create-with-default-now-or-updatedAt-in-id-fail-d6550337014c4e5ab81d4d362228aa14

closes https://github.com/prisma/prisma/issues/15581