### PR TITLE
psl: fix reformatter crash on type aliases

### DIFF
--- a/psl/psl/tests/reformat/reformat.rs
+++ b/psl/psl/tests/reformat/reformat.rs
@@ -1498,3 +1498,43 @@ fn block_attribute_comments_are_preserved() {
 
     expected.assert_eq(&reformat(schema));
 }
+
+#[test]
+fn reformat_type_aliases() {
+    let schema = r#"
+        generator client {
+          provider = "prisma-client-js"
+        }
+
+        datasource db {
+          provider = "mongodb"
+          url = env("TEST_DB_URL")
+        }
+
+        type MongoID = String @id @default(dbgenerated()) @map("_id") @db.ObjectId
+
+        model User {
+          id           MongoID
+          email     String   @unique
+        }
+    "#;
+
+    let expected = expect![[r#"
+        generator client {
+          provider = "prisma-client-js"
+        }
+
+        datasource db {
+          provider = "mongodb"
+          url      = env("TEST_DB_URL")
+        }
+
+        type MongoID = String @id @default(dbgenerated()) @map("_id") @db.ObjectId
+        model User {
+          id    MongoID
+          email String  @unique
+        }
+    "#]];
+
+    expected.assert_eq(&reformat(schema));
+}

--- a/psl/schema-ast/src/reformat.rs
+++ b/psl/schema-ast/src/reformat.rs
@@ -42,7 +42,7 @@ fn reformat_top(target: &mut Renderer, pair: Pair<'_>) {
                     _ => target.end_line(),
                 }
             }
-            Rule::CATCH_ALL | Rule::BLOCK_LEVEL_CATCH_ALL | Rule::arbitrary_block => {
+            Rule::CATCH_ALL | Rule::BLOCK_LEVEL_CATCH_ALL | Rule::arbitrary_block | Rule::type_alias => {
                 target.write(current.as_str());
             }
             Rule::EOI => {}


### PR DESCRIPTION
This part of the code shouldn't have been removed in prisma 4.

closes https://github.com/prisma/prisma/issues/15151