### PR TITLE
feat: rename 'referentialIntegrity' to 'relationMode'

### DIFF
--- a/introspection-engine/connectors/introspection-connector/src/lib.rs
+++ b/introspection-engine/connectors/introspection-connector/src/lib.rs
@@ -112,7 +112,7 @@ impl IntrospectionContext {
     }
 
     pub fn foreign_keys_enabled(&self) -> bool {
-        self.source.referential_integrity().uses_foreign_keys()
+        self.source.relation_mode().uses_foreign_keys()
     }
 
     pub fn schema_string(&self) -> &str {

--- a/introspection-engine/introspection-engine-tests/src/test_api.rs
+++ b/introspection-engine/introspection-engine-tests/src/test_api.rs
@@ -250,12 +250,11 @@ impl TestApi {
     }
 
     pub fn datasource_block(&self) -> DatasourceBlock<'_> {
-        let no_foreign_keys =
-            self.is_vitess() && self.preview_features().contains(PreviewFeature::ReferentialIntegrity);
+        let no_foreign_keys = self.is_vitess() && self.preview_features().contains(PreviewFeature::RelationMode);
 
         if no_foreign_keys {
             self.args
-                .datasource_block(&self.connection_string, &[("referentialIntegrity", r#""prisma""#)])
+                .datasource_block(&self.connection_string, &[("relationMode", r#""prisma""#)])
         } else {
             self.args.datasource_block(r#"env(TEST_DATABASE_URL)"#, &[])
         }

--- a/introspection-engine/introspection-engine-tests/tests/re_introspection/mysql.rs
+++ b/introspection-engine/introspection-engine-tests/tests/re_introspection/mysql.rs
@@ -2,10 +2,10 @@ use barrel::types;
 use indoc::indoc;
 use introspection_engine_tests::test_api::*;
 
-#[test_connector(tags(Mysql), exclude(Vitess), preview_features("referentialIntegrity"))]
-async fn referential_integrity_parameter_is_not_added(api: &TestApi) -> TestResult {
+#[test_connector(tags(Mysql), exclude(Vitess), preview_features("relationMode"))]
+async fn relation_mode_parameter_is_not_added(api: &TestApi) -> TestResult {
     let result = api.re_introspect("").await?;
-    assert!(!result.contains(r#"referentialIntegrity = "#));
+    assert!(!result.contains(r#"relationMode = "#));
 
     Ok(())
 }

--- a/introspection-engine/introspection-engine-tests/tests/re_introspection/vitess.rs
+++ b/introspection-engine/introspection-engine-tests/tests/re_introspection/vitess.rs
@@ -4,15 +4,15 @@ use introspection_engine_tests::test_api::*;
 use quaint::prelude::Queryable;
 use test_macros::test_connector;
 
-#[test_connector(tags(Vitess), preview_features("referentialIntegrity"))]
-async fn referential_integrity_parameter_is_not_removed(api: &TestApi) -> TestResult {
+#[test_connector(tags(Vitess), preview_features("relationMode"))]
+async fn relation_mode_parameter_is_not_removed(api: &TestApi) -> TestResult {
     let result = api.re_introspect("").await?;
-    assert!(result.contains(r#"referentialIntegrity = "prisma""#));
+    assert!(result.contains(r#"relationMode = "prisma""#));
 
     Ok(())
 }
 
-#[test_connector(tags(Vitess), preview_features("referentialIntegrity"))]
+#[test_connector(tags(Vitess), preview_features("relationMode"))]
 async fn relations_are_not_removed(api: &TestApi) -> TestResult {
     let dml = indoc! {r#"
         CREATE TABLE `A` (
@@ -58,7 +58,7 @@ async fn relations_are_not_removed(api: &TestApi) -> TestResult {
     Ok(())
 }
 
-#[test_connector(tags(Vitess), preview_features("referentialIntegrity"))]
+#[test_connector(tags(Vitess), preview_features("relationMode"))]
 async fn warning_is_given_for_copied_relations(api: &TestApi) -> TestResult {
     let dml = indoc! {r#"
         CREATE TABLE `A` (
@@ -108,7 +108,7 @@ async fn warning_is_given_for_copied_relations(api: &TestApi) -> TestResult {
     Ok(())
 }
 
-#[test_connector(tags(Vitess), preview_features("referentialIntegrity"))]
+#[test_connector(tags(Vitess), preview_features("relationMode"))]
 async fn no_warnings_are_given_for_if_no_relations_were_copied(api: &TestApi) -> TestResult {
     let dml = indoc! {r#"
         CREATE TABLE `A` (
@@ -141,7 +141,7 @@ async fn no_warnings_are_given_for_if_no_relations_were_copied(api: &TestApi) ->
     Ok(())
 }
 
-#[test_connector(tags(Vitess), preview_features("referentialIntegrity"))]
+#[test_connector(tags(Vitess), preview_features("relationMode"))]
 async fn relations_field_order_is_kept(api: &TestApi) -> TestResult {
     let dml = indoc! {r#"
         CREATE TABLE `A` (
@@ -187,7 +187,7 @@ async fn relations_field_order_is_kept(api: &TestApi) -> TestResult {
     Ok(())
 }
 
-#[test_connector(tags(Vitess), preview_features("referentialIntegrity"))]
+#[test_connector(tags(Vitess), preview_features("relationMode"))]
 async fn relations_field_order_is_kept_if_having_new_fields(api: &TestApi) -> TestResult {
     let dml = indoc! {r#"
         CREATE TABLE `A` (
@@ -235,7 +235,7 @@ async fn relations_field_order_is_kept_if_having_new_fields(api: &TestApi) -> Te
     Ok(())
 }
 
-#[test_connector(tags(Vitess), preview_features("referentialIntegrity"))]
+#[test_connector(tags(Vitess), preview_features("relationMode"))]
 async fn relations_field_order_is_kept_if_removing_fields(api: &TestApi) -> TestResult {
     let dml = indoc! {r#"
         CREATE TABLE `A` (
@@ -282,7 +282,7 @@ async fn relations_field_order_is_kept_if_removing_fields(api: &TestApi) -> Test
     Ok(())
 }
 
-#[test_connector(tags(Vitess), preview_features("referentialIntegrity"))]
+#[test_connector(tags(Vitess), preview_features("relationMode"))]
 async fn deleting_models_will_delete_relations(api: &TestApi) -> TestResult {
     let dml = indoc! {r#"
         CREATE TABLE `A` (
@@ -335,7 +335,7 @@ async fn deleting_models_will_delete_relations(api: &TestApi) -> TestResult {
     Ok(())
 }
 
-#[test_connector(tags(Vitess), preview_features("referentialIntegrity"))]
+#[test_connector(tags(Vitess), preview_features("relationMode"))]
 async fn field_renames_keeps_the_relation_intact(api: &TestApi) -> TestResult {
     let dml = indoc! {r#"
         CREATE TABLE `A` (
@@ -381,7 +381,7 @@ async fn field_renames_keeps_the_relation_intact(api: &TestApi) -> TestResult {
     Ok(())
 }
 
-#[test_connector(tags(Vitess), preview_features("referentialIntegrity"))]
+#[test_connector(tags(Vitess), preview_features("relationMode"))]
 async fn referential_actions_are_kept_intact(api: &TestApi) -> TestResult {
     let dml = indoc! {r#"
         CREATE TABLE `A` (

--- a/libs/dml/src/lib.rs
+++ b/libs/dml/src/lib.rs
@@ -35,7 +35,7 @@ pub fn find_model_by_db_name<'a>(datamodel: &'a Datamodel, db_name: &str) -> Opt
 
 /// Validated schema -> dml::Datamodel.
 pub fn lift(schema: &ValidatedSchema) -> crate::Datamodel {
-    lift::LiftAstToDml::new(&schema.db, schema.connector, schema.referential_integrity()).lift()
+    lift::LiftAstToDml::new(&schema.db, schema.connector, schema.relation_mode()).lift()
 }
 
 /// Renders the datamodel _without configuration blocks_.

--- a/libs/dml/src/render/render_configuration.rs
+++ b/libs/dml/src/render/render_configuration.rs
@@ -33,12 +33,8 @@ fn render_datasource(datasource: &Datasource, out: &mut String) -> fmt::Result {
         out.push('\n');
     }
 
-    if let Some(referential_integrity) = datasource.referential_integrity {
-        writeln!(
-            out,
-            "referentialIntegrity = {}",
-            string_literal(&referential_integrity.to_string())
-        )?;
+    if let Some(relation_mode) = datasource.relation_mode {
+        writeln!(out, "relationMode = {}", string_literal(&relation_mode.to_string()))?;
     }
 
     out.write_str("}\n")

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
@@ -46,7 +46,7 @@ pub(crate) fn calculate_sql_schema(datamodel: &ValidatedSchema, flavour: &dyn Sq
     // Two types of tables: model tables and implicit M2M relation tables (a.k.a. join tables.).
     push_model_tables(&mut context);
 
-    if context.datamodel.referential_integrity().uses_foreign_keys() {
+    if context.datamodel.relation_mode().uses_foreign_keys() {
         push_inline_relations(&mut context);
     }
 
@@ -144,7 +144,7 @@ fn push_inline_relations(ctx: &mut Context<'_>) {
         let referenced_model = ctx.model_id_to_table_id[&relation.referenced_model().model_id()];
         let on_delete_action = relation_field.explicit_on_delete().unwrap_or_else(|| {
             relation_field.default_on_delete_action(
-                ctx.datamodel.configuration.referential_integrity().unwrap_or_default(),
+                ctx.datamodel.configuration.relation_mode().unwrap_or_default(),
                 ctx.flavour.datamodel_connector(),
             )
         });
@@ -296,7 +296,7 @@ fn push_relation_tables(ctx: &mut Context<'_>) {
             });
         }
 
-        if ctx.datamodel.referential_integrity().uses_foreign_keys() {
+        if ctx.datamodel.relation_mode().uses_foreign_keys() {
             let fkid = ctx.schema.describer_schema.push_foreign_key(
                 Some(model_a_fk_name),
                 [table_id, ctx.model_id_to_table_id[&model_a.model_id()]],

--- a/migration-engine/migration-engine-tests/src/test_api.rs
+++ b/migration-engine/migration-engine-tests/src/test_api.rs
@@ -305,14 +305,10 @@ impl TestApi {
 
     /// Render a valid datasource block, including database URL.
     pub fn write_datasource_block(&self, out: &mut dyn std::fmt::Write) {
-        let no_foreign_keys = self.is_vitess()
-            && self
-                .root
-                .preview_features()
-                .contains(PreviewFeature::ReferentialIntegrity);
+        let no_foreign_keys = self.is_vitess() && self.root.preview_features().contains(PreviewFeature::RelationMode);
 
         let params = if no_foreign_keys {
-            vec![("referentialIntegrity", r#""prisma""#)]
+            vec![("relationMode", r#""prisma""#)]
         } else {
             Vec::new()
         };

--- a/migration-engine/migration-engine-tests/tests/existing_data/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_data/mod.rs
@@ -779,7 +779,7 @@ fn set_default_current_timestamp_on_existing_column_works(api: TestApi) {
 }
 
 // exclude: there is a cockroach-specific test. It's unexecutable there.
-#[test_connector(preview_features("referentialIntegrity"), exclude(CockroachDb))]
+#[test_connector(preview_features("relationMode"), exclude(CockroachDb))]
 fn primary_key_migrations_do_not_cause_data_loss(api: TestApi) {
     let dm1 = r#"
         model Dog {

--- a/migration-engine/migration-engine-tests/tests/migrations/basic.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/basic.rs
@@ -52,7 +52,7 @@ fn adding_multiple_optional_fields_to_an_existing_model_works(api: TestApi) {
     });
 }
 
-#[test_connector(preview_features("referentialIntegrity"))]
+#[test_connector(preview_features("relationMode"))]
 fn a_model_can_be_removed(api: TestApi) {
     let directory = api.create_migrations_directory();
 

--- a/migration-engine/migration-engine-tests/tests/migrations/basic/vitess.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/basic/vitess.rs
@@ -1,6 +1,6 @@
 use migration_engine_tests::test_api::*;
 
-#[test_connector(tags(Vitess), preview_features("referentialIntegrity"))]
+#[test_connector(tags(Vitess), preview_features("relationMode"))]
 fn reordering_and_altering_models_at_the_same_time_works(api: TestApi) {
     let dm1 = r#"
         model A {

--- a/migration-engine/migration-engine-tests/tests/migrations/enums.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/enums.rs
@@ -82,7 +82,7 @@ fn adding_an_enum_field_must_work_with_native_types_off(api: TestApi) {
     api.schema_push_w_datasource(dm).send().assert_no_steps();
 }
 
-#[test_connector(capabilities(Enums), preview_features("referentialIntegrity"))]
+#[test_connector(capabilities(Enums), preview_features("relationMode"))]
 fn an_enum_can_be_turned_into_a_model(api: TestApi) {
     api.schema_push_w_datasource(BASIC_ENUM_DM).send().assert_green();
 

--- a/migration-engine/migration-engine-tests/tests/migrations/foreign_keys.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/foreign_keys.rs
@@ -1,7 +1,7 @@
 use migration_engine_tests::test_api::*;
 use sql_schema_describer::ForeignKeyAction;
 
-#[test_connector(preview_features("referentialIntegrity"))]
+#[test_connector(preview_features("relationMode"))]
 fn foreign_keys_of_inline_one_to_one_relations_have_a_unique_constraint(api: TestApi) {
     let dm = r#"
         model Cat {
@@ -284,7 +284,7 @@ fn changing_a_foreign_key_constrained_column_from_nullable_to_required_and_back_
     api.schema_push_w_datasource(dm).send().assert_green();
 }
 
-#[test_connector(exclude(CockroachDb), preview_features("referentialIntegrity"))]
+#[test_connector(exclude(CockroachDb), preview_features("relationMode"))]
 fn changing_all_referenced_columns_of_foreign_key_works(api: TestApi) {
     let dm1 = r#"
        model Post {

--- a/migration-engine/migration-engine-tests/tests/migrations/id.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/id.rs
@@ -154,7 +154,7 @@ fn changing_the_type_of_an_id_field_must_work(api: TestApi) {
     });
 }
 
-#[test_connector(exclude(Sqlite, CockroachDb), preview_features("referentialIntegrity"))]
+#[test_connector(exclude(Sqlite, CockroachDb), preview_features("relationMode"))]
 fn models_with_an_autoincrement_field_as_part_of_a_multi_field_id_can_be_created(api: TestApi) {
     let dm = r#"
         model List {

--- a/migration-engine/migration-engine-tests/tests/migrations/id/cockroachdb.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/id/cockroachdb.rs
@@ -23,7 +23,7 @@ fn flipping_autoincrement_on_and_off_works(api: TestApi) {
     }
 }
 
-#[test_connector(tags(CockroachDb), preview_features("referentialIntegrity"))]
+#[test_connector(tags(CockroachDb), preview_features("relationMode"))]
 fn models_with_an_autoincrement_field_as_part_of_a_multi_field_id_can_be_created(api: TestApi) {
     let dm = r#"
         model List {

--- a/migration-engine/migration-engine-tests/tests/migrations/id/vitess.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/id/vitess.rs
@@ -1,6 +1,6 @@
 use migration_engine_tests::test_api::*;
 
-#[test_connector(tags(Vitess), preview_features("referentialIntegrity"))]
+#[test_connector(tags(Vitess), preview_features("relationMode"))]
 fn changing_the_type_of_an_id_field_must_work(api: TestApi) {
     let dm1 = r#"
         model A {

--- a/migration-engine/migration-engine-tests/tests/migrations/indexes.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/indexes.rs
@@ -6,7 +6,7 @@ use indoc::{formatdoc, indoc};
 use migration_engine_tests::test_api::*;
 use sql_schema_describer::SQLSortOrder;
 
-#[test_connector(preview_features("referentialIntegrity"))]
+#[test_connector(preview_features("relationMode"))]
 fn index_on_compound_relation_fields_must_work(api: TestApi) {
     let dm = r#"
         model User {
@@ -84,7 +84,7 @@ fn index_settings_must_be_migrated(api: TestApi) {
     });
 }
 
-#[test_connector(preview_features("referentialIntegrity"))]
+#[test_connector(preview_features("relationMode"))]
 fn unique_directive_on_required_one_to_one_relation_creates_one_index(api: TestApi) {
     // We want to test that only one index is created, because of the implicit unique index on
     // required 1:1 relations.
@@ -133,7 +133,7 @@ fn one_to_many_self_relations_do_not_create_a_unique_index(api: TestApi) {
     }
 }
 
-#[test_connector(preview_features("referentialIntegrity"))]
+#[test_connector(preview_features("relationMode"))]
 fn model_with_multiple_indexes_works(api: TestApi) {
     let dm = r#"
     model User {
@@ -425,7 +425,7 @@ fn indexes_with_an_automatically_truncated_name_are_idempotent(api: TestApi) {
     api.schema_push_w_datasource(dm).send().assert_green().assert_no_steps();
 }
 
-#[test_connector(preview_features("referentialIntegrity"))]
+#[test_connector(preview_features("relationMode"))]
 fn new_index_with_same_name_as_index_from_dropped_table_works(api: TestApi) {
     let dm1 = r#"
         model Cat {

--- a/migration-engine/migration-engine-tests/tests/migrations/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/mod.rs
@@ -21,7 +21,7 @@ mod migration_persistence_tests;
 mod mssql;
 mod mysql;
 mod postgres;
-mod referential_integrity;
+mod relation_mode;
 mod relations;
 mod reset_tests;
 mod shadow_database_url_configuration;

--- a/migration-engine/migration-engine-tests/tests/migrations/relation_mode.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/relation_mode.rs
@@ -8,7 +8,7 @@ fn schema_push_referential_integrity_prisma_works(api: TestApi) {
 
         generator client {{
             provider = "prisma-client-js"
-            previewFeatures = ["referentialIntegrity"]
+            previewFeatures = ["relationMode"]
         }}
 
         model Post {{
@@ -32,7 +32,7 @@ fn schema_push_referential_integrity_prisma_works(api: TestApi) {
             post        Post @relation(fields: [postId], references: [id])
         }}
         "#,
-        datasource = api.datasource_block_with(&[("referentialIntegrity", "\"prisma\"")]),
+        datasource = api.datasource_block_with(&[("relationMode", "\"prisma\"")]),
     );
 
     api.schema_push(&dm).send().assert_green();
@@ -54,7 +54,7 @@ fn create_migration_referential_integrity_prisma_works(api: TestApi) {
 
         generator client {{
             provider = "prisma-client-js"
-            previewFeatures = ["referentialIntegrity"]
+            previewFeatures = ["relationMode"]
         }}
 
         model Post {{
@@ -78,7 +78,7 @@ fn create_migration_referential_integrity_prisma_works(api: TestApi) {
             post        Post @relation(fields: [postId], references: [id])
         }}
         "#,
-        datasource = api.datasource_block_with(&[("referentialIntegrity", "\"prisma\"")]),
+        datasource = api.datasource_block_with(&[("relationMode", "\"prisma\"")]),
     );
 
     api.create_migration("01init", &dm, &migrations_directory)
@@ -117,7 +117,7 @@ fn switching_from_foreign_keys_to_prisma_integrity_drops_the_foreign_keys(api: T
 
         generator client {{
             provider = "prisma-client-js"
-            previewFeatures = ["referentialIntegrity"]
+            previewFeatures = ["relationMode"]
         }}
 
         model A {{
@@ -131,7 +131,7 @@ fn switching_from_foreign_keys_to_prisma_integrity_drops_the_foreign_keys(api: T
             as A[]
         }}
         "#,
-        datasource = api.datasource_block_with(&[("referentialIntegrity", "\"foreignKeys\"")]),
+        datasource = api.datasource_block_with(&[("relationMode", "\"foreignKeys\"")]),
     );
 
     api.schema_push(&dm).send().assert_green();
@@ -145,7 +145,7 @@ fn switching_from_foreign_keys_to_prisma_integrity_drops_the_foreign_keys(api: T
 
         generator client {{
             provider = "prisma-client-js"
-            previewFeatures = ["referentialIntegrity"]
+            previewFeatures = ["relationMode"]
         }}
 
         model A {{
@@ -159,7 +159,7 @@ fn switching_from_foreign_keys_to_prisma_integrity_drops_the_foreign_keys(api: T
             as A[]
         }}
         "#,
-        datasource = api.datasource_block_with(&[("referentialIntegrity", "\"prisma\"")]),
+        datasource = api.datasource_block_with(&[("relationMode", "\"prisma\"")]),
     );
 
     api.schema_push(&dm).send().assert_green();
@@ -176,7 +176,7 @@ fn switching_from_prisma_integrity_to_foreign_keys_drops_the_foreign_keys(api: T
 
         generator client {{
             provider = "prisma-client-js"
-            previewFeatures = ["referentialIntegrity"]
+            previewFeatures = ["relationMode"]
         }}
 
         model A {{
@@ -190,7 +190,7 @@ fn switching_from_prisma_integrity_to_foreign_keys_drops_the_foreign_keys(api: T
             as A[]
         }}
         "#,
-        datasource = api.datasource_block_with(&[("referentialIntegrity", "\"prisma\"")]),
+        datasource = api.datasource_block_with(&[("relationMode", "\"prisma\"")]),
     );
 
     api.schema_push(&dm).send().assert_green();
@@ -204,7 +204,7 @@ fn switching_from_prisma_integrity_to_foreign_keys_drops_the_foreign_keys(api: T
 
         generator client {{
             provider = "prisma-client-js"
-            previewFeatures = ["referentialIntegrity"]
+            previewFeatures = ["relationMode"]
         }}
 
         model A {{
@@ -218,7 +218,7 @@ fn switching_from_prisma_integrity_to_foreign_keys_drops_the_foreign_keys(api: T
             as A[]
         }}
         "#,
-        datasource = api.datasource_block_with(&[("referentialIntegrity", "\"foreignKeys\"")]),
+        datasource = api.datasource_block_with(&[("relationMode", "\"foreignKeys\"")]),
     );
 
     api.schema_push(&dm).send().assert_green();

--- a/migration-engine/migration-engine-tests/tests/migrations/relations.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/relations.rs
@@ -968,7 +968,7 @@ fn adding_mutual_references_on_existing_tables_works(api: TestApi) {
     };
 }
 
-#[test_connector(preview_features("referentialIntegrity"))]
+#[test_connector(preview_features("relationMode"))]
 fn migrations_with_many_to_many_related_models_must_not_recreate_indexes(api: TestApi) {
     // test case for https://github.com/prisma/lift/issues/148
     let dm_1 = r#"
@@ -1029,7 +1029,7 @@ fn migrations_with_many_to_many_related_models_must_not_recreate_indexes(api: Te
         .assert_no_steps();
 }
 
-#[test_connector(preview_features("referentialIntegrity"))]
+#[test_connector(preview_features("relationMode"))]
 fn removing_a_relation_field_must_work(api: TestApi) {
     let dm_1 = r#"
         model User {

--- a/migration-engine/migration-engine-tests/tests/migrations/relations/vitess.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/relations/vitess.rs
@@ -1,6 +1,6 @@
 use migration_engine_tests::test_api::*;
 
-#[test_connector(tags(Vitess), preview_features("referentialIntegrity"))]
+#[test_connector(tags(Vitess), preview_features("relationMode"))]
 fn adding_mutual_references_on_existing_tables_works(api: TestApi) {
     let dm1 = r#"
         model A {

--- a/migration-engine/migration-engine-tests/tests/migrations/sql.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/sql.rs
@@ -345,7 +345,7 @@ fn remapped_multi_field_id_as_part_of_relation_must_work(api: TestApi) {
     });
 }
 
-#[test_connector(preview_features("referentialIntegrity"))]
+#[test_connector(preview_features("relationMode"))]
 fn unique_constraints_on_composite_relation_fields(api: TestApi) {
     let dm = r##"
         model Parent {
@@ -374,7 +374,7 @@ fn unique_constraints_on_composite_relation_fields(api: TestApi) {
     });
 }
 
-#[test_connector(preview_features("referentialIntegrity"))]
+#[test_connector(preview_features("relationMode"))]
 fn indexes_on_composite_relation_fields(api: TestApi) {
     let dm = r##"
         model User {
@@ -403,7 +403,7 @@ fn indexes_on_composite_relation_fields(api: TestApi) {
     });
 }
 
-#[test_connector(exclude(Vitess), preview_features("referentialIntegrity"))]
+#[test_connector(exclude(Vitess), preview_features("relationMode"))]
 fn dropping_mutually_referencing_tables_works(api: TestApi) {
     let dm1 = r#"
     model A {

--- a/migration-engine/migration-engine-tests/tests/migrations/sql/vitess.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/sql/vitess.rs
@@ -1,6 +1,6 @@
 use migration_engine_tests::test_api::*;
 
-#[test_connector(tags(Vitess), preview_features("referentialIntegrity"))]
+#[test_connector(tags(Vitess), preview_features("relationMode"))]
 fn dropping_mutually_referencing_tables_works(api: TestApi) {
     let dm1 = r#"
     model A {

--- a/migration-engine/migration-engine-tests/tests/native_types/common.rs
+++ b/migration-engine/migration-engine-tests/tests/native_types/common.rs
@@ -1,6 +1,6 @@
 use migration_engine_tests::test_api::*;
 
-#[test_connector(exclude(CockroachDb), preview_features("referentialIntegrity"))]
+#[test_connector(exclude(CockroachDb), preview_features("relationMode"))]
 fn typescript_starter_schema_is_idempotent_without_native_type_annotations(api: TestApi) {
     let dm = r#"
         model Post {

--- a/migration-engine/migration-engine-tests/tests/native_types/mysql.rs
+++ b/migration-engine/migration-engine-tests/tests/native_types/mysql.rs
@@ -909,7 +909,7 @@ fn impossible_casts_with_existing_data_should_warn(api: TestApi) {
     }
 }
 
-#[test_connector(tags(Mysql), preview_features("referentialIntegrity"))]
+#[test_connector(tags(Mysql), preview_features("relationMode"))]
 fn typescript_starter_schema_with_native_types_is_idempotent(api: TestApi) {
     let dm = r#"
         model Post {
@@ -965,7 +965,7 @@ fn typescript_starter_schema_with_native_types_is_idempotent(api: TestApi) {
         .assert_no_steps();
 }
 
-#[test_connector(tags(Mysql), preview_features("referentialIntegrity"))]
+#[test_connector(tags(Mysql), preview_features("relationMode"))]
 fn typescript_starter_schema_with_different_native_types_is_idempotent(api: TestApi) {
     let dm = r#"
         model Post {

--- a/migration-engine/migration-engine-tests/tests/schema_push/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/schema_push/mod.rs
@@ -16,7 +16,7 @@ model Box {
 }
 "#;
 
-#[test_connector(preview_features("referentialIntegrity"))]
+#[test_connector(preview_features("relationMode"))]
 fn schema_push_happy_path(api: TestApi) {
     api.schema_push_w_datasource(SCHEMA)
         .send()
@@ -62,7 +62,7 @@ fn schema_push_happy_path(api: TestApi) {
         });
 }
 
-#[test_connector(preview_features("referentialIntegrity"))]
+#[test_connector(preview_features("relationMode"))]
 fn schema_push_warns_about_destructive_changes(api: TestApi) {
     api.schema_push_w_datasource(SCHEMA)
         .send()
@@ -97,7 +97,7 @@ fn schema_push_warns_about_destructive_changes(api: TestApi) {
         .assert_has_executed_steps();
 }
 
-#[test_connector(preview_features("referentialIntegrity"))]
+#[test_connector(preview_features("relationMode"))]
 fn schema_push_with_an_unexecutable_migration_returns_a_message_and_aborts(api: TestApi) {
     api.schema_push_w_datasource(SCHEMA)
         .send()

--- a/prisma-fmt/src/actions.rs
+++ b/prisma-fmt/src/actions.rs
@@ -6,10 +6,10 @@ pub(crate) fn run(schema: &str) -> String {
             if validated_configuration.datasources.len() != 1 {
                 "[]".to_string()
             } else if let Some(datasource) = validated_configuration.datasources.first() {
-                let referential_integrity = datasource.referential_integrity();
+                let relation_mode = datasource.relation_mode();
                 let available_referential_actions = datasource
                     .active_connector
-                    .referential_actions(&referential_integrity)
+                    .referential_actions(&relation_mode)
                     .iter()
                     .map(|act| format!("{:?}", act))
                     .collect::<Vec<_>>();

--- a/psl/builtin-connectors/src/cockroach_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/cockroach_datamodel_connector.rs
@@ -6,8 +6,8 @@ use native_types::{CockroachType, NativeType};
 use psl_core::{
     datamodel_connector::{
         helper::{arg_vec_from_opt, args_vec_from_opt, parse_one_opt_u32, parse_two_opt_u32},
-        Connector, ConnectorCapability, ConstraintScope, NativeTypeConstructor, NativeTypeInstance,
-        ReferentialIntegrity, StringFilter,
+        Connector, ConnectorCapability, ConstraintScope, NativeTypeConstructor, NativeTypeInstance, RelationMode,
+        StringFilter,
     },
     diagnostics::{DatamodelError, Diagnostics},
     parser_database::{
@@ -133,10 +133,10 @@ impl Connector for CockroachDatamodelConnector {
         63
     }
 
-    fn referential_actions(&self, referential_integrity: &ReferentialIntegrity) -> BitFlags<ReferentialAction> {
+    fn referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
         use ReferentialAction::*;
 
-        referential_integrity.allowed_referential_actions(NoAction | Restrict | Cascade | SetNull | SetDefault)
+        relation_mode.allowed_referential_actions(NoAction | Restrict | Cascade | SetNull | SetDefault)
     }
 
     fn scalar_type_for_native_type(&self, native_type: serde_json::Value) -> ScalarType {

--- a/psl/builtin-connectors/src/mongodb.rs
+++ b/psl/builtin-connectors/src/mongodb.rs
@@ -6,8 +6,7 @@ use mongodb_types::*;
 use native_types::{MongoDbType, NativeType};
 use psl_core::{
     datamodel_connector::{
-        Connector, ConnectorCapability, ConstraintScope, NativeTypeConstructor, NativeTypeInstance,
-        ReferentialIntegrity,
+        Connector, ConnectorCapability, ConstraintScope, NativeTypeConstructor, NativeTypeInstance, RelationMode,
     },
     diagnostics::{DatamodelError, Diagnostics, Span},
     parser_database::{walkers::*, ReferentialAction, ScalarType},
@@ -55,8 +54,8 @@ impl Connector for MongoDbDatamodelConnector {
         &[ConstraintScope::ModelKeyIndex]
     }
 
-    fn referential_actions(&self, referential_integrity: &ReferentialIntegrity) -> BitFlags<ReferentialAction> {
-        referential_integrity.allowed_referential_actions(BitFlags::empty())
+    fn referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
+        relation_mode.allowed_referential_actions(BitFlags::empty())
     }
 
     fn validate_model(&self, model: ModelWalker<'_>, errors: &mut Diagnostics) {
@@ -125,11 +124,11 @@ impl Connector for MongoDbDatamodelConnector {
         Ok(())
     }
 
-    fn default_referential_integrity(&self) -> ReferentialIntegrity {
-        ReferentialIntegrity::Prisma
+    fn default_relation_mode(&self) -> RelationMode {
+        RelationMode::Prisma
     }
 
-    fn allowed_referential_integrity_settings(&self) -> enumflags2::BitFlags<ReferentialIntegrity> {
-        ReferentialIntegrity::Prisma.into()
+    fn allowed_relation_mode_settings(&self) -> enumflags2::BitFlags<RelationMode> {
+        RelationMode::Prisma.into()
     }
 }

--- a/psl/builtin-connectors/src/mssql_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/mssql_datamodel_connector.rs
@@ -8,8 +8,7 @@ use once_cell::sync::Lazy;
 use psl_core::{
     datamodel_connector::{
         helper::{arg_vec_from_opt, args_vec_from_opt, parse_one_opt_u32, parse_two_opt_u32},
-        Connector, ConnectorCapability, ConstraintScope, NativeTypeConstructor, NativeTypeInstance,
-        ReferentialIntegrity,
+        Connector, ConnectorCapability, ConstraintScope, NativeTypeConstructor, NativeTypeInstance, RelationMode,
     },
     diagnostics::{DatamodelError, Diagnostics, Span},
     parser_database::{self, ast, ParserDatabase, ReferentialAction, ScalarType},
@@ -172,10 +171,10 @@ impl Connector for MsSqlDatamodelConnector {
         128
     }
 
-    fn referential_actions(&self, referential_integrity: &ReferentialIntegrity) -> BitFlags<ReferentialAction> {
+    fn referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
         use ReferentialAction::*;
 
-        referential_integrity.allowed_referential_actions(NoAction | Cascade | SetNull | SetDefault)
+        relation_mode.allowed_referential_actions(NoAction | Cascade | SetNull | SetDefault)
     }
 
     fn scalar_type_for_native_type(&self, native_type: serde_json::Value) -> ScalarType {

--- a/psl/builtin-connectors/src/mysql_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/mysql_datamodel_connector.rs
@@ -8,8 +8,7 @@ use native_types::{
 use psl_core::{
     datamodel_connector::{
         helper::{args_vec_from_opt, parse_one_opt_u32, parse_one_u32, parse_two_opt_u32},
-        Connector, ConnectorCapability, ConstraintScope, NativeTypeConstructor, NativeTypeInstance,
-        ReferentialIntegrity,
+        Connector, ConnectorCapability, ConstraintScope, NativeTypeConstructor, NativeTypeInstance, RelationMode,
     },
     diagnostics::{DatamodelError, Diagnostics, Span},
     parser_database::{walkers, ReferentialAction, ScalarType},
@@ -161,10 +160,10 @@ impl Connector for MySqlDatamodelConnector {
         64
     }
 
-    fn referential_actions(&self, referential_integrity: &ReferentialIntegrity) -> BitFlags<ReferentialAction> {
+    fn referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
         use ReferentialAction::*;
 
-        referential_integrity.allowed_referential_actions(Restrict | Cascade | SetNull | NoAction | SetDefault)
+        relation_mode.allowed_referential_actions(Restrict | Cascade | SetNull | NoAction | SetDefault)
     }
 
     fn scalar_type_for_native_type(&self, native_type: serde_json::Value) -> ScalarType {

--- a/psl/builtin-connectors/src/postgres_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/postgres_datamodel_connector.rs
@@ -9,8 +9,8 @@ use native_types::{
 use psl_core::{
     datamodel_connector::{
         helper::{arg_vec_from_opt, args_vec_from_opt, parse_one_opt_u32, parse_two_opt_u32},
-        Connector, ConnectorCapability, ConstraintScope, NativeTypeConstructor, NativeTypeInstance,
-        ReferentialIntegrity, StringFilter,
+        Connector, ConnectorCapability, ConstraintScope, NativeTypeConstructor, NativeTypeInstance, RelationMode,
+        StringFilter,
     },
     diagnostics::{DatamodelError, Diagnostics},
     parser_database::{ast, walkers, IndexAlgorithm, OperatorClass, ParserDatabase, ReferentialAction, ScalarType},
@@ -154,10 +154,10 @@ impl Connector for PostgresDatamodelConnector {
         63
     }
 
-    fn referential_actions(&self, referential_integrity: &ReferentialIntegrity) -> BitFlags<ReferentialAction> {
+    fn referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
         use ReferentialAction::*;
 
-        referential_integrity.allowed_referential_actions(NoAction | Restrict | Cascade | SetNull | SetDefault)
+        relation_mode.allowed_referential_actions(NoAction | Restrict | Cascade | SetNull | SetDefault)
     }
 
     fn scalar_type_for_native_type(&self, native_type: serde_json::Value) -> ScalarType {

--- a/psl/builtin-connectors/src/sqlite_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/sqlite_datamodel_connector.rs
@@ -1,8 +1,7 @@
 use enumflags2::BitFlags;
 use psl_core::{
     datamodel_connector::{
-        Connector, ConnectorCapability, ConstraintScope, NativeTypeConstructor, NativeTypeInstance,
-        ReferentialIntegrity,
+        Connector, ConnectorCapability, ConstraintScope, NativeTypeConstructor, NativeTypeInstance, RelationMode,
     },
     diagnostics::{DatamodelError, Span},
     parser_database::{ReferentialAction, ScalarType},
@@ -44,10 +43,10 @@ impl Connector for SqliteDatamodelConnector {
         10000
     }
 
-    fn referential_actions(&self, referential_integrity: &ReferentialIntegrity) -> BitFlags<ReferentialAction> {
+    fn referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
         use ReferentialAction::*;
 
-        referential_integrity.allowed_referential_actions(SetNull | SetDefault | Cascade | Restrict | NoAction)
+        relation_mode.allowed_referential_actions(SetNull | SetDefault | Cascade | Restrict | NoAction)
     }
 
     fn scalar_type_for_native_type(&self, _native_type: serde_json::Value) -> ScalarType {

--- a/psl/psl-core/src/common/preview_features.rs
+++ b/psl/psl-core/src/common/preview_features.rs
@@ -52,6 +52,7 @@ features!(
     OrderByAggregateGroup,
     FilterJson,
     ReferentialIntegrity,
+    RelationMode,
     ReferentialActions,
     InteractiveTransactions,
     NamedConstraints,
@@ -72,7 +73,7 @@ features!(
 /// Generator preview features
 pub const GENERATOR: FeatureMap = FeatureMap {
     active: enumflags2::make_bitflags!(PreviewFeature::{
-         ReferentialIntegrity
+        RelationMode
          | InteractiveTransactions
          | FullTextSearch
          | FullTextIndex
@@ -107,7 +108,10 @@ pub const GENERATOR: FeatureMap = FeatureMap {
         | ImprovedQueryRaw
         | DataProxy
     }),
-    hidden: enumflags2::make_bitflags!(PreviewFeature::{MultiSchema}),
+    hidden: enumflags2::make_bitflags!(PreviewFeature::{
+        MultiSchema
+        | ReferentialIntegrity
+    }),
 };
 
 #[derive(Debug)]

--- a/psl/psl-core/src/configuration/configuration_struct.rs
+++ b/psl/psl-core/src/configuration/configuration_struct.rs
@@ -1,7 +1,7 @@
 use super::{Datasource, Generator};
 use crate::{
     common::preview_features::PreviewFeature,
-    datamodel_connector::ReferentialIntegrity,
+    datamodel_connector::RelationMode,
     diagnostics::{DatamodelError, Diagnostics},
 };
 use enumflags2::BitFlags;
@@ -26,8 +26,8 @@ impl Configuration {
         }
     }
 
-    pub fn referential_integrity(&self) -> Option<ReferentialIntegrity> {
-        self.datasources.first().map(|source| source.referential_integrity())
+    pub fn relation_mode(&self) -> Option<RelationMode> {
+        self.datasources.first().map(|source| source.relation_mode())
     }
 
     pub fn max_identifier_length(&self) -> usize {

--- a/psl/psl-core/src/configuration/datasource.rs
+++ b/psl/psl-core/src/configuration/datasource.rs
@@ -21,7 +21,7 @@ pub struct Datasource {
     /// An optional user-defined shadow database URL.
     pub shadow_database_url: Option<(StringFromEnvVar, Span)>,
     /// In which layer referential actions are handled.
-    #[deprecated(since = "4.5.0", note = "Use `relation_mode` instead")]
+    // #[deprecated(since = "4.5.0", note = "Use `relation_mode` instead")]
     pub referential_integrity: Option<RelationMode>,
     /// In which layer referential actions are handled.
     pub relation_mode: Option<RelationMode>,

--- a/psl/psl-core/src/configuration/datasource.rs
+++ b/psl/psl-core/src/configuration/datasource.rs
@@ -1,6 +1,6 @@
 use crate::{
     configuration::StringFromEnvVar,
-    datamodel_connector::{Connector, ConnectorCapabilities, ReferentialIntegrity},
+    datamodel_connector::{Connector, ConnectorCapabilities, RelationMode},
     diagnostics::{DatamodelError, Diagnostics, Span},
 };
 use std::{borrow::Cow, path::Path};
@@ -21,7 +21,10 @@ pub struct Datasource {
     /// An optional user-defined shadow database URL.
     pub shadow_database_url: Option<(StringFromEnvVar, Span)>,
     /// In which layer referential actions are handled.
-    pub referential_integrity: Option<ReferentialIntegrity>,
+    #[deprecated(since = "4.5.0", note = "Use `relation_mode` instead")]
+    pub referential_integrity: Option<RelationMode>,
+    /// In which layer referential actions are handled.
+    pub relation_mode: Option<RelationMode>,
     /// _Sorted_ vec of schemas defined in the schemas property.
     pub schemas: Vec<(String, Span)>,
     pub(crate) schemas_span: Option<Span>,
@@ -37,7 +40,8 @@ impl std::fmt::Debug for Datasource {
             .field("documentation", &self.documentation)
             .field("active_connector", &&"...")
             .field("shadow_database_url", &"<shadow_database_url>")
-            .field("referential_integrity", &self.referential_integrity)
+            .field("referential_integrity [deprecated]", &self.referential_integrity)
+            .field("relation_mode", &self.relation_mode)
             .field("schemas", &self.schemas)
             .finish()
     }
@@ -54,11 +58,12 @@ impl Datasource {
         ConnectorCapabilities::new(capabilities)
     }
 
-    /// The applicable referential integrity mode for this datasource.
+    /// The applicable relation mode for this datasource.
     #[allow(clippy::or_fun_call)] // not applicable in this case
-    pub fn referential_integrity(&self) -> ReferentialIntegrity {
-        self.referential_integrity
-            .unwrap_or(self.active_connector.default_referential_integrity())
+    pub fn relation_mode(&self) -> RelationMode {
+        self.relation_mode
+            .or(self.referential_integrity)
+            .unwrap_or(self.active_connector.default_relation_mode())
     }
 
     /// Load the database URL, validating it and resolving env vars in the

--- a/psl/psl-core/src/datamodel_connector.rs
+++ b/psl/psl-core/src/datamodel_connector.rs
@@ -13,7 +13,7 @@ mod empty_connector;
 mod filters;
 mod native_type_constructor;
 mod native_type_instance;
-mod referential_integrity;
+mod relation_mode;
 
 pub use self::{
     capabilities::{ConnectorCapabilities, ConnectorCapability},
@@ -21,7 +21,7 @@ pub use self::{
     filters::*,
     native_type_constructor::NativeTypeConstructor,
     native_type_instance::NativeTypeInstance,
-    referential_integrity::ReferentialIntegrity,
+    relation_mode::RelationMode,
 };
 
 use diagnostics::{DatamodelError, Diagnostics, NativeTypeErrorFactory, Span};
@@ -55,23 +55,23 @@ pub trait Connector: Send + Sync {
     /// limit should return usize::MAX.
     fn max_identifier_length(&self) -> usize;
 
-    // Referential integrity
+    // Relation mode
 
-    /// The referential integrity modes that can be set through the referentialIntegrity datasource
+    /// The relation modes that can be set through the relationMode datasource
     /// argument.
-    fn allowed_referential_integrity_settings(&self) -> BitFlags<ReferentialIntegrity> {
-        use ReferentialIntegrity::*;
+    fn allowed_relation_mode_settings(&self) -> BitFlags<RelationMode> {
+        use RelationMode::*;
 
         ForeignKeys | Prisma
     }
 
-    /// The default referential integrity mode to assume for this connector.
-    fn default_referential_integrity(&self) -> ReferentialIntegrity {
-        ReferentialIntegrity::ForeignKeys
+    /// The default relation mode to assume for this connector.
+    fn default_relation_mode(&self) -> RelationMode {
+        RelationMode::ForeignKeys
     }
 
     /// The referential actions supported by the connector.
-    fn referential_actions(&self, referential_integrity: &ReferentialIntegrity) -> BitFlags<ReferentialAction>;
+    fn referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction>;
 
     fn supports_composite_types(&self) -> bool {
         self.has_capability(ConnectorCapability::CompositeTypes)
@@ -89,8 +89,8 @@ pub trait Connector: Send + Sync {
         self.has_capability(ConnectorCapability::NamedDefaultValues)
     }
 
-    fn supports_referential_action(&self, integrity: &ReferentialIntegrity, action: ReferentialAction) -> bool {
-        self.referential_actions(integrity).contains(action)
+    fn supports_referential_action(&self, relation_mode: &RelationMode, action: ReferentialAction) -> bool {
+        self.referential_actions(relation_mode).contains(action)
     }
 
     /// This is used by the query engine schema builder.

--- a/psl/psl-core/src/datamodel_connector/empty_connector.rs
+++ b/psl/psl-core/src/datamodel_connector/empty_connector.rs
@@ -15,7 +15,7 @@ impl Connector for EmptyDatamodelConnector {
         std::any::type_name::<EmptyDatamodelConnector>()
     }
 
-    fn referential_actions(&self, _referential_integrity: &ReferentialIntegrity) -> BitFlags<ReferentialAction> {
+    fn referential_actions(&self, _relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
         BitFlags::all()
     }
 

--- a/psl/psl-core/src/datamodel_connector/relation_mode.rs
+++ b/psl/psl-core/src/datamodel_connector/relation_mode.rs
@@ -6,7 +6,7 @@ use std::fmt;
 #[bitflags]
 #[repr(u8)]
 #[derive(Debug, Copy, Clone, PartialEq)]
-pub enum ReferentialIntegrity {
+pub enum RelationMode {
     /// Enforced in the database. Needs support from the underlying database
     /// server.
     ForeignKeys,
@@ -15,7 +15,7 @@ pub enum ReferentialIntegrity {
     Prisma,
 }
 
-impl ReferentialIntegrity {
+impl RelationMode {
     /// Returns either the given actions if foreign keys are used, or the
     /// allowed emulated actions if referential integrity happens in Prisma.
     pub fn allowed_referential_actions(
@@ -32,7 +32,7 @@ impl ReferentialIntegrity {
     }
 
     pub fn is_prisma(&self) -> bool {
-        matches!(self, ReferentialIntegrity::Prisma)
+        matches!(self, Self::Prisma)
     }
 
     /// True, if integrity is in database foreign keys
@@ -41,17 +41,17 @@ impl ReferentialIntegrity {
     }
 }
 
-impl Default for ReferentialIntegrity {
+impl Default for RelationMode {
     fn default() -> Self {
         Self::ForeignKeys
     }
 }
 
-impl fmt::Display for ReferentialIntegrity {
+impl fmt::Display for RelationMode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ReferentialIntegrity::ForeignKeys => write!(f, "foreignKeys"),
-            ReferentialIntegrity::Prisma => write!(f, "prisma"),
+            RelationMode::ForeignKeys => write!(f, "foreignKeys"),
+            RelationMode::Prisma => write!(f, "prisma"),
         }
     }
 }

--- a/psl/psl-core/src/lib.rs
+++ b/psl/psl-core/src/lib.rs
@@ -35,12 +35,12 @@ pub struct ValidatedSchema {
     pub db: parser_database::ParserDatabase,
     pub connector: &'static dyn datamodel_connector::Connector,
     pub diagnostics: Diagnostics,
-    referential_integrity: datamodel_connector::ReferentialIntegrity,
+    relation_mode: datamodel_connector::RelationMode,
 }
 
 impl ValidatedSchema {
-    pub fn referential_integrity(&self) -> datamodel_connector::ReferentialIntegrity {
-        self.referential_integrity
+    pub fn relation_mode(&self) -> datamodel_connector::RelationMode {
+        self.relation_mode
     }
 }
 
@@ -58,7 +58,7 @@ pub fn validate(file: SourceFile, connectors: ConnectorRegistry) -> ValidatedSch
         configuration,
         connector: out.connector,
         db: out.db,
-        referential_integrity: out.referential_integrity,
+        relation_mode: out.relation_mode,
     }
 }
 

--- a/psl/psl-core/src/validate/validation_pipeline.rs
+++ b/psl/psl-core/src/validate/validation_pipeline.rs
@@ -4,7 +4,7 @@ mod validations;
 use crate::{
     common::preview_features::PreviewFeature,
     configuration,
-    datamodel_connector::{Connector, EmptyDatamodelConnector, ReferentialIntegrity},
+    datamodel_connector::{Connector, EmptyDatamodelConnector, RelationMode},
     diagnostics::Diagnostics,
 };
 use enumflags2::BitFlags;
@@ -13,7 +13,7 @@ use parser_database::ParserDatabase;
 pub struct ValidateOutput {
     pub(crate) db: ParserDatabase,
     pub(crate) diagnostics: Diagnostics,
-    pub(crate) referential_integrity: ReferentialIntegrity,
+    pub(crate) relation_mode: RelationMode,
     pub(crate) connector: &'static dyn Connector,
 }
 
@@ -26,12 +26,12 @@ pub(crate) fn validate(
 ) -> ValidateOutput {
     let source = sources.first();
     let connector = source.map(|s| s.active_connector).unwrap_or(&EmptyDatamodelConnector);
-    let referential_integrity = source.map(|s| s.referential_integrity()).unwrap_or_default();
+    let relation_mode = source.map(|s| s.relation_mode()).unwrap_or_default();
 
     let mut output = ValidateOutput {
         db,
         diagnostics,
-        referential_integrity,
+        relation_mode,
         connector,
     };
 
@@ -45,7 +45,7 @@ pub(crate) fn validate(
         datasource: source,
         preview_features,
         connector,
-        referential_integrity,
+        relation_mode,
         diagnostics: &mut output.diagnostics,
     };
 

--- a/psl/psl-core/src/validate/validation_pipeline/context.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/context.rs
@@ -1,5 +1,5 @@
 use crate::{
-    datamodel_connector::{Connector, ReferentialIntegrity},
+    datamodel_connector::{Connector, RelationMode},
     Datasource, PreviewFeature,
 };
 use diagnostics::{DatamodelError, Diagnostics};
@@ -13,9 +13,9 @@ pub(crate) struct Context<'a> {
     pub(super) datasource: Option<&'a Datasource>,
     pub(super) preview_features: BitFlags<PreviewFeature>,
     pub(super) connector: &'static dyn Connector,
-    /// Referential integrity is a pure function of the datasource, but since there are defaults,
+    /// Relation mode is a pure function of the datasource, but since there are defaults,
     /// it's more consistent to resolve it once, here.
-    pub(super) referential_integrity: ReferentialIntegrity,
+    pub(super) relation_mode: RelationMode,
     pub(super) diagnostics: &'a mut Diagnostics,
 }
 

--- a/psl/psl-core/src/validate/validation_pipeline/validations/relation_fields.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/relation_fields.rs
@@ -139,10 +139,10 @@ pub(super) fn ignored_related_model(field: RelationFieldWalker<'_>, ctx: &mut Co
 /// Does the connector support the given referential actions.
 pub(super) fn referential_actions(field: RelationFieldWalker<'_>, ctx: &mut Context<'_>) {
     let connector = ctx.connector;
-    let referential_integrity = ctx.referential_integrity;
+    let relation_mode = ctx.relation_mode;
     let msg = |action: ReferentialAction| {
         let allowed_values = connector
-            .referential_actions(&referential_integrity)
+            .referential_actions(&relation_mode)
             .iter()
             .map(|f| format!("`{}`", f.as_str()))
             .join(", ");
@@ -155,10 +155,7 @@ pub(super) fn referential_actions(field: RelationFieldWalker<'_>, ctx: &mut Cont
     };
 
     if let Some(on_delete) = field.explicit_on_delete() {
-        if !ctx
-            .connector
-            .supports_referential_action(&ctx.referential_integrity, on_delete)
-        {
+        if !ctx.connector.supports_referential_action(&ctx.relation_mode, on_delete) {
             let span = field
                 .ast_field()
                 .span_for_argument("relation", "onDelete")
@@ -169,10 +166,7 @@ pub(super) fn referential_actions(field: RelationFieldWalker<'_>, ctx: &mut Cont
     }
 
     if let Some(on_update) = field.explicit_on_update() {
-        if !ctx
-            .connector
-            .supports_referential_action(&ctx.referential_integrity, on_update)
-        {
+        if !ctx.connector.supports_referential_action(&ctx.relation_mode, on_update) {
             let span = field
                 .ast_field()
                 .span_for_argument("relation", "onUpdate")

--- a/psl/psl/tests/attributes/relations/referential_actions.rs
+++ b/psl/psl/tests/attributes/relations/referential_actions.rs
@@ -2,7 +2,7 @@ mod cycle_detection;
 
 use crate::common::*;
 use psl::{
-    datamodel_connector::ReferentialIntegrity,
+    datamodel_connector::RelationMode,
     dml::ReferentialAction::{self, *},
 };
 
@@ -96,7 +96,7 @@ fn actions_on_mongo() {
 }
 
 #[test]
-fn on_delete_actions_should_work_on_prisma_referential_integrity() {
+fn on_delete_actions_should_work_on_prisma_relation_mode() {
     let actions = &[Restrict, SetNull, Cascade, NoAction];
 
     for action in actions {
@@ -104,13 +104,13 @@ fn on_delete_actions_should_work_on_prisma_referential_integrity() {
             r#"
             datasource db {{
                 provider = "mysql"
-                referentialIntegrity = "prisma"
+                relationMode = "prisma"
                 url = "mysql://root:prisma@localhost:3306/mydb"
             }}
 
             generator client {{
                 provider = "prisma-client-js"
-                previewFeatures = ["referentialIntegrity"]
+                previewFeatures = ["relationMode"]
             }}
 
             model A {{
@@ -135,17 +135,17 @@ fn on_delete_actions_should_work_on_prisma_referential_integrity() {
 }
 
 #[test]
-fn on_update_no_action_should_work_on_prisma_referential_integrity() {
+fn on_update_no_action_should_work_on_prisma_relation_mode() {
     let dml = indoc! { r#"
         datasource db {
           provider = "mysql"
           url = "mysql://"
-          referentialIntegrity = "prisma"
+          relationMode = "prisma"
         }
 
         generator client {
           provider = "prisma-client-js"
-          previewFeatures = ["referentialIntegrity"]
+          previewFeatures = ["relationMode"]
         }
 
         model A {
@@ -171,13 +171,13 @@ fn foreign_keys_not_allowed_on_mongo() {
     let dml = indoc! {r#"
         datasource db {
           provider = "mongodb"
-          referentialIntegrity = "foreignKeys"
+          relationMode = "foreignKeys"
           url = "mongodb://"
         }
 
         generator client {
           provider = "prisma-client-js"
-          previewFeatures = ["referentialIntegrity"]
+          previewFeatures = ["relationMode"]
         }
 
         model A {
@@ -193,11 +193,11 @@ fn foreign_keys_not_allowed_on_mongo() {
     "#};
 
     let expected = expect![[r#"
-        [1;91merror[0m: [1mError validating datasource `referentialIntegrity`: Invalid referential integrity setting: "foreignKeys". Supported values: "prisma"[0m
+        [1;91merror[0m: [1mError validating datasource `relationMode`: Invalid relation mode setting: "foreignKeys". Supported values: "prisma"[0m
           [1;94m-->[0m  [4mschema.prisma:3[0m
         [1;94m   | [0m
         [1;94m 2 | [0m  provider = "mongodb"
-        [1;94m 3 | [0m  referentialIntegrity = [1;91m"foreignKeys"[0m
+        [1;94m 3 | [0m  relationMode = [1;91m"foreignKeys"[0m
         [1;94m   | [0m
     "#]];
 
@@ -209,13 +209,13 @@ fn prisma_level_integrity_should_be_allowed_on_mongo() {
     let dml = indoc! {r#"
         datasource db {
           provider = "mongodb"
-          referentialIntegrity = "prisma"
+          relationMode = "prisma"
           url = "mongodb://"
         }
 
         generator client {
           provider = "prisma-client-js"
-          previewFeatures = ["referentialIntegrity"]
+          previewFeatures = ["relationMode"]
         }
 
         model A {
@@ -234,7 +234,7 @@ fn prisma_level_integrity_should_be_allowed_on_mongo() {
 }
 
 #[test]
-fn mongo_uses_prisma_referential_integrity_by_default() {
+fn mongo_uses_prisma_relation_mode_by_default() {
     let dml = indoc! {r#"
         datasource db {
           provider = "mongodb"
@@ -253,14 +253,11 @@ fn mongo_uses_prisma_referential_integrity_by_default() {
         }
     "#};
 
-    assert_eq!(
-        Some(ReferentialIntegrity::Prisma),
-        parse_config(dml).unwrap().referential_integrity()
-    );
+    assert_eq!(Some(RelationMode::Prisma), parse_config(dml).unwrap().relation_mode());
 }
 
 #[test]
-fn sql_databases_use_foreign_keys_referential_integrity_by_default() {
+fn sql_databases_use_foreign_keys_relation_mode_by_default() {
     for db in ["postgres", "mysql", "sqlserver", "sqlite"] {
         let dml = formatdoc! {r#"
             datasource db {{
@@ -281,8 +278,8 @@ fn sql_databases_use_foreign_keys_referential_integrity_by_default() {
         "#, db = db};
 
         assert_eq!(
-            Some(ReferentialIntegrity::ForeignKeys),
-            parse_config(&dml).unwrap().referential_integrity()
+            Some(RelationMode::ForeignKeys),
+            parse_config(&dml).unwrap().relation_mode()
         );
     }
 }
@@ -420,18 +417,18 @@ fn actions_should_be_defined_only_from_one_side() {
 }
 
 #[test]
-fn set_default_action_should_not_work_on_prisma_level_referential_integrity() {
+fn set_default_action_should_not_work_on_prisma_level_relation_mode() {
     let dml = indoc!(
         r#"
             datasource db {
                 provider = "mysql"
-                referentialIntegrity = "prisma"
+                relationMode = "prisma"
                 url = "mysql://root:prisma@localhost:3306/mydb"
             }
 
             generator client {
                 provider = "prisma-client-js"
-                previewFeatures = ["referentialIntegrity"]
+                previewFeatures = ["relationMode"]
             }
 
             model A {{

--- a/psl/psl/tests/attributes/relations/referential_actions/cycle_detection.rs
+++ b/psl/psl/tests/attributes/relations/referential_actions/cycle_detection.rs
@@ -91,7 +91,7 @@ fn cycles_are_allowed_outside_of_emulation_and_sqlserver() {
 
         generator js1 {
           provider = "javascript"
-          previewFeatures = ["referentialIntegrity"]
+          previewFeatures = ["relationMode"]
         }
 
         model A {
@@ -112,12 +112,12 @@ fn emulated_cascading_on_delete_self_relations() {
         datasource db {
             provider = "mysql"
             url = "mysql://"
-            referentialIntegrity = "prisma"
+            relationMode = "prisma"
         }
 
         generator js1 {
           provider = "javascript"
-          previewFeatures = ["referentialIntegrity"]
+          previewFeatures = ["relationMode"]
         }
 
         model A {
@@ -178,12 +178,12 @@ fn emulated_cascading_on_update_self_relations() {
         datasource db {
             provider = "mysql"
             url = "mysql://"
-            referentialIntegrity = "prisma"
+            relationMode = "prisma"
         }
 
         generator js1 {
           provider = "javascript"
-          previewFeatures = ["referentialIntegrity"]
+          previewFeatures = ["relationMode"]
         }
 
         model A {
@@ -244,12 +244,12 @@ fn emulated_null_setting_on_delete_self_relations() {
         datasource db {
             provider = "mysql"
             url = "mysql://"
-            referentialIntegrity = "prisma"
+            relationMode = "prisma"
         }
 
         generator js1 {
           provider = "javascript"
-          previewFeatures = ["referentialIntegrity"]
+          previewFeatures = ["relationMode"]
         }
 
         model A {
@@ -310,12 +310,12 @@ fn emulated_null_setting_on_update_self_relations() {
         datasource db {
             provider = "mysql"
             url = "mysql://"
-            referentialIntegrity = "prisma"
+            relationMode = "prisma"
         }
 
         generator js1 {
           provider = "javascript"
-          previewFeatures = ["referentialIntegrity"]
+          previewFeatures = ["relationMode"]
         }
 
         model A {
@@ -376,12 +376,12 @@ fn emulated_default_setting_on_delete_self_relations() {
         datasource db {
             provider = "mysql"
             url = "mysql://"
-            referentialIntegrity = "prisma"
+            relationMode = "prisma"
         }
 
         generator js1 {
           provider = "javascript"
-          previewFeatures = ["referentialIntegrity"]
+          previewFeatures = ["relationMode"]
         }
 
         model A {
@@ -448,12 +448,12 @@ fn emulated_default_setting_on_update_self_relations() {
         datasource db {
             provider = "mysql"
             url = "mysql://"
-            referentialIntegrity = "prisma"
+            relationMode = "prisma"
         }
 
         generator js1 {
           provider = "javascript"
-          previewFeatures = ["referentialIntegrity"]
+          previewFeatures = ["relationMode"]
         }
 
         model A {
@@ -534,12 +534,12 @@ fn emulated_cascading_cyclic_one_hop_relations() {
         datasource db {
             provider = "mysql"
             url = "mysql://"
-            referentialIntegrity = "prisma"
+            relationMode = "prisma"
         }
 
         generator js1 {
           provider = "javascript"
-          previewFeatures = ["referentialIntegrity"]
+          previewFeatures = ["relationMode"]
         }
 
         model A {

--- a/psl/psl/tests/config/generators.rs
+++ b/psl/psl/tests/config/generators.rs
@@ -259,7 +259,7 @@ fn nice_error_for_unknown_generator_preview_feature() {
         .unwrap_err();
 
     let expectation = expect![[r#"
-        [1;91merror[0m: [1mThe preview feature "foo" is not known. Expected one of: referentialIntegrity, interactiveTransactions, fullTextSearch, fullTextIndex, tracing, metrics, orderByNulls, filteredRelationCount, fieldReference[0m
+        [1;91merror[0m: [1mThe preview feature "foo" is not known. Expected one of: relationMode, interactiveTransactions, fullTextSearch, fullTextIndex, tracing, metrics, orderByNulls, filteredRelationCount, fieldReference[0m
           [1;94m-->[0m  [4mschema.prisma:3[0m
         [1;94m   | [0m
         [1;94m 2 | [0m  provider = "prisma-client-js"

--- a/psl/psl/tests/parsing/comments.rs
+++ b/psl/psl/tests/parsing/comments.rs
@@ -4,14 +4,14 @@ use crate::common::*;
 fn trailing_comments_allowed_in_configuration_blocks() {
     let schema = r#"
       datasource db {
-        provider             = "postgres" // "mysql" | "sqlite" ...
-        url                  = env("TEST_POSTGRES_URI")
-        referentialIntegrity = "prisma" // = on or set to "foreignKeys" to turn off emulation
+        provider     = "postgres" // "mysql" | "sqlite" ...
+        url          = env("TEST_POSTGRES_URI")
+        relationMode = "prisma" // = on or set to "foreignKeys" to turn off emulation
       }
 
       generator js {
         provider        = "prisma-client-js" // optional
-        previewFeatures = ["referentialIntegrity"] // []
+        previewFeatures = ["relationMode"] // []
       }     
     "#;
     assert_valid(schema);

--- a/psl/psl/tests/reformat/comments.rs
+++ b/psl/psl/tests/reformat/comments.rs
@@ -4,27 +4,27 @@ use crate::common::*;
 fn trailing_comments_allowed_in_configuration_blocks() {
     let input = r#"
       datasource db {
-        provider = "postgres" // "mysql" | "sqlite" ...
-        url                  = env("TEST_POSTGRES_URI")
-        referentialIntegrity = "prisma" // = on or set to "foreignKeys" to turn off emulation
+        provider     = "postgres" // "mysql" | "sqlite" ...
+        url          = env("TEST_POSTGRES_URI")
+        relationMode = "prisma" // = on or set to "foreignKeys" to turn off emulation
       }
 
       generator js {
         provider        = "prisma-client-js" // optional
-        previewFeatures = ["referentialIntegrity"] // []
+        previewFeatures = ["relationMode"] // []
       }     
     "#;
 
     let expected = expect![[r#"
       datasource db {
-        provider             = "postgres" // "mysql" | "sqlite" ...
-        url                  = env("TEST_POSTGRES_URI")
-        referentialIntegrity = "prisma" // = on or set to "foreignKeys" to turn off emulation
+        provider     = "postgres" // "mysql" | "sqlite" ...
+        url          = env("TEST_POSTGRES_URI")
+        relationMode = "prisma" // = on or set to "foreignKeys" to turn off emulation
       }
       
       generator js {
         provider        = "prisma-client-js" // optional
-        previewFeatures = ["referentialIntegrity"] // []
+        previewFeatures = ["relationMode"] // []
       }
     "#]];
 

--- a/query-engine/connector-test-kit-rs/query-test-macros/src/args/connector_test.rs
+++ b/query-engine/connector-test-kit-rs/query-test-macros/src/args/connector_test.rs
@@ -28,7 +28,7 @@ pub struct ConnectorTestArgs {
     #[darling(default)]
     pub capabilities: RunOnlyForCapabilities,
 
-    #[deprecated(since = "4.5.0", note = "Use `relation_mode` instead")]
+    // #[deprecated(since = "4.5.0", note = "Use `relation_mode` instead")]
     #[darling(default)]
     pub referential_integrity: Option<RelationMode>,
 

--- a/query-engine/connector-test-kit-rs/query-test-macros/src/args/connector_test.rs
+++ b/query-engine/connector-test-kit-rs/query-test-macros/src/args/connector_test.rs
@@ -28,8 +28,12 @@ pub struct ConnectorTestArgs {
     #[darling(default)]
     pub capabilities: RunOnlyForCapabilities,
 
+    #[deprecated(since = "4.5.0", note = "Use `relation_mode` instead")]
     #[darling(default)]
-    pub referential_integrity: Option<ReferentialIntegrity>,
+    pub referential_integrity: Option<RelationMode>,
+
+    #[darling(default)]
+    pub relation_mode: Option<RelationMode>,
 
     #[darling(default)]
     pub db_schemas: DbSchemas,
@@ -56,12 +60,12 @@ impl ConnectorTestArgs {
 
 #[allow(dead_code)]
 #[derive(Debug)]
-pub enum ReferentialIntegrity {
+pub enum RelationMode {
     ForeignKeys,
     Prisma,
 }
 
-impl darling::FromMeta for ReferentialIntegrity {
+impl darling::FromMeta for RelationMode {
     fn from_string(value: &str) -> darling::Result<Self> {
         match value.to_lowercase().as_str() {
             "prisma" => Ok(Self::Prisma),
@@ -71,11 +75,11 @@ impl darling::FromMeta for ReferentialIntegrity {
     }
 }
 
-impl ToString for ReferentialIntegrity {
+impl ToString for RelationMode {
     fn to_string(&self) -> String {
         match self {
-            ReferentialIntegrity::Prisma => "prisma".to_string(),
-            ReferentialIntegrity::ForeignKeys => "foreignKeys".to_string(),
+            Self::Prisma => "prisma".to_string(),
+            Self::ForeignKeys => "foreignKeys".to_string(),
         }
     }
 }

--- a/query-engine/connector-test-kit-rs/query-test-macros/src/connector_test.rs
+++ b/query-engine/connector-test-kit-rs/query-test-macros/src/connector_test.rs
@@ -57,7 +57,7 @@ pub fn connector_test_impl(attr: TokenStream, input: TokenStream) -> TokenStream
     let test_database_name = format!("{}_{}", suite_name, test_name);
     let capabilities = args.capabilities.idents;
 
-    let referential_override = match args.referential_integrity {
+    let referential_override = match args.relation_mode.or(args.referential_integrity) {
         Some(ref_override) => {
             let wat = ref_override.to_string();
             quote! { Some(#wat.to_string()) }

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mod.rs
@@ -53,7 +53,7 @@ pub trait ConnectorTagInterface {
     /// Defines where relational constraints are handled:
     ///   - "prisma" is handled in the Query Engine core
     ///   - "foreignKeys" lets the database handle them
-    fn referential_integrity(&self) -> &'static str {
+    fn relation_mode(&self) -> &'static str {
         "foreignKeys"
     }
 }

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mongodb.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mongodb.rs
@@ -66,7 +66,7 @@ impl ConnectorTagInterface for MongoDbConnectorTag {
         true
     }
 
-    fn referential_integrity(&self) -> &'static str {
+    fn relation_mode(&self) -> &'static str {
         "prisma"
     }
 }

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/vitess.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/vitess.rs
@@ -38,7 +38,7 @@ impl ConnectorTagInterface for VitessConnectorTag {
         true
     }
 
-    fn referential_integrity(&self) -> &'static str {
+    fn relation_mode(&self) -> &'static str {
         "prisma"
     }
 }

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/datamodel_rendering/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/datamodel_rendering/mod.rs
@@ -35,7 +35,7 @@ pub fn render_test_datamodel(
     test_database: &str,
     template: String,
     excluded_features: &[&str],
-    referential_integrity_override: Option<String>,
+    relation_mode_override: Option<String>,
     db_schemas: &[&str],
 ) -> String {
     let tag = config.test_connector_tag().unwrap();
@@ -54,7 +54,7 @@ pub fn render_test_datamodel(
             datasource test {{
                 provider = "{}"
                 url = "{}"
-                referentialIntegrity = "{}"
+                relationMode = "{}"
                 {}
             }}
 
@@ -65,7 +65,7 @@ pub fn render_test_datamodel(
         "#},
         tag.datamodel_provider(),
         tag.connection_string(test_database, config.is_ci(), is_multi_schema),
-        referential_integrity_override.unwrap_or_else(|| tag.referential_integrity().to_string()),
+        relation_mode_override.unwrap_or_else(|| tag.relation_mode().to_string()),
         schema_def,
         preview_features
     );

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/direct.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/direct.rs
@@ -30,7 +30,7 @@ impl RunnerInterface for DirectRunner {
             true,
             data_source.active_connector,
             preview_features,
-            data_source.referential_integrity(),
+            data_source.relation_mode(),
         ));
 
         Ok(Self {

--- a/query-engine/core/src/query_graph_builder/write/update.rs
+++ b/query-engine/core/src/query_graph_builder/write/update.rs
@@ -31,7 +31,7 @@ pub fn update_record(
     let read_query = read::find_unique(field, model.clone())?;
     let read_node = graph.create_node(Query::Read(read_query));
 
-    if connector_ctx.referential_integrity.is_prisma() {
+    if connector_ctx.relation_mode.is_prisma() {
         let read_parent_node = graph.create_node(utils::read_ids_infallible(
             model.clone(),
             model.primary_identifier(),
@@ -101,7 +101,7 @@ pub fn update_many_records(
     let data_argument = field.arguments.lookup(args::DATA).unwrap();
     let data_map: ParsedInputMap = data_argument.value.try_into()?;
 
-    if connector_ctx.referential_integrity.uses_foreign_keys() {
+    if connector_ctx.relation_mode.uses_foreign_keys() {
         update_many_record_node(graph, connector_ctx, filter, model, data_map)?;
     } else {
         let pre_read_node = graph.create_node(utils::read_ids_infallible(

--- a/query-engine/core/src/query_graph_builder/write/utils.rs
+++ b/query-engine/core/src/query_graph_builder/write/utils.rs
@@ -313,12 +313,12 @@ pub fn insert_emulated_on_delete(
     parent_node: &NodeRef,
     child_node: &NodeRef,
 ) -> QueryGraphBuilderResult<()> {
-    // If the connector uses the `ReferentialIntegrity::ForeignKeys` mode, we do not do any checks / emulation.
-    if connector_ctx.referential_integrity.uses_foreign_keys() {
+    // If the connector uses the `RelationMode::ForeignKeys` mode, we do not do any checks / emulation.
+    if connector_ctx.relation_mode.uses_foreign_keys() {
         return Ok(());
     }
 
-    // If the connector uses the `ReferentialIntegrity::Prisma` mode, then the emulation will kick in.
+    // If the connector uses the `RelationMode::Prisma` mode, then the emulation will kick in.
     let internal_model = model_to_delete.internal_data_model();
     let relation_fields = internal_model.fields_pointing_to_model(model_to_delete, false);
 
@@ -865,12 +865,12 @@ pub fn insert_emulated_on_update_with_intermediary_node(
     parent_node: &NodeRef,
     child_node: &NodeRef,
 ) -> QueryGraphBuilderResult<Option<NodeRef>> {
-    // If the connector uses the `ReferentialIntegrity::ForeignKeys` mode, we do not do any checks / emulation.
-    if connector_ctx.referential_integrity.uses_foreign_keys() {
+    // If the connector uses the `RelationMode::ForeignKeys` mode, we do not do any checks / emulation.
+    if connector_ctx.relation_mode.uses_foreign_keys() {
         return Ok(None);
     }
 
-    // If the connector uses the `ReferentialIntegrity::Prisma` mode, then the emulation will kick in.
+    // If the connector uses the `RelationMode::Prisma` mode, then the emulation will kick in.
     let internal_model = model_to_update.internal_data_model();
     let relation_fields = internal_model.fields_pointing_to_model(model_to_update, false);
 
@@ -913,12 +913,12 @@ pub fn insert_emulated_on_update(
     parent_node: &NodeRef,
     child_node: &NodeRef,
 ) -> QueryGraphBuilderResult<()> {
-    // If the connector uses the `ReferentialIntegrity::ForeignKeys` mode, we do not do any checks / emulation.
-    if connector_ctx.referential_integrity.uses_foreign_keys() {
+    // If the connector uses the `RelationMode::ForeignKeys` mode, we do not do any checks / emulation.
+    if connector_ctx.relation_mode.uses_foreign_keys() {
         return Ok(());
     }
 
-    // If the connector uses the `ReferentialIntegrity::Prisma` mode, then the emulation will kick in.
+    // If the connector uses the `RelationMode::Prisma` mode, then the emulation will kick in.
     let internal_model = model_to_update.internal_data_model();
     let relation_fields = internal_model.fields_pointing_to_model(model_to_update, false);
 

--- a/query-engine/dmmf/src/lib.rs
+++ b/query-engine/dmmf/src/lib.rs
@@ -29,7 +29,7 @@ pub fn dmmf_from_schema(schema: &str) -> DataModelMetaFormat {
         true, // todo
         data_source.active_connector,
         preview_features,
-        data_source.referential_integrity(),
+        data_source.relation_mode(),
     ));
 
     from_precomputed_parts(&dml, query_schema)

--- a/query-engine/query-engine-node-api/src/engine.rs
+++ b/query-engine/query-engine-node-api/src/engine.rs
@@ -237,7 +237,7 @@ impl QueryEngine {
                     true, // enable raw queries
                     data_source.active_connector,
                     preview_features,
-                    data_source.referential_integrity(),
+                    data_source.relation_mode(),
                 );
 
                 Ok(ConnectedEngine {

--- a/query-engine/query-engine-node-api/src/functions.rs
+++ b/query-engine/query-engine-node-api/src/functions.rs
@@ -39,7 +39,7 @@ pub fn dmmf(datamodel_string: String) -> napi::Result<String> {
         .map(|ds| ds.active_connector)
         .unwrap_or(&psl::datamodel_connector::EmptyDatamodelConnector);
 
-    let referential_integrity = datasource.map(|ds| ds.referential_integrity()).unwrap_or_default();
+    let relation_mode = datasource.map(|ds| ds.relation_mode()).unwrap_or_default();
 
     let internal_data_model = prisma_models::convert(&schema, "".into());
 
@@ -48,7 +48,7 @@ pub fn dmmf(datamodel_string: String) -> napi::Result<String> {
         true,
         connector,
         schema.configuration.preview_features().iter().collect(),
-        referential_integrity,
+        relation_mode,
     ));
 
     let dmmf = dmmf::render_dmmf(&datamodel, query_schema);

--- a/query-engine/query-engine/src/cli.rs
+++ b/query-engine/query-engine/src/cli.rs
@@ -85,7 +85,7 @@ impl CliCommand {
         let connector = datasource
             .map(|ds| ds.active_connector)
             .unwrap_or(&psl::datamodel_connector::EmptyDatamodelConnector);
-        let referential_integrity = datasource.map(|ds| ds.referential_integrity()).unwrap_or_default();
+        let relation_mode = datasource.map(|ds| ds.relation_mode()).unwrap_or_default();
 
         // temporary code duplication
         let internal_data_model = prisma_models::convert(&request.schema, "".into());
@@ -94,7 +94,7 @@ impl CliCommand {
             request.enable_raw_queries,
             connector,
             request.schema.configuration.preview_features().iter().collect(),
-            referential_integrity,
+            relation_mode,
         ));
 
         let dmmf = dmmf::render_dmmf(&psl::lift(&request.schema), query_schema);

--- a/query-engine/query-engine/src/context.rs
+++ b/query-engine/query-engine/src/context.rs
@@ -73,7 +73,7 @@ impl PrismaContext {
             enable_raw_queries,
             data_source.active_connector,
             preview_features,
-            data_source.referential_integrity(),
+            data_source.relation_mode(),
         ));
 
         let context = Self {

--- a/query-engine/query-engine/src/tests/dmmf.rs
+++ b/query-engine/query-engine/src/tests/dmmf.rs
@@ -15,7 +15,7 @@ pub fn get_query_schema(datamodel_string: &str) -> (QuerySchema, psl::dml::Datam
     let connector = datasource
         .map(|ds| ds.active_connector)
         .unwrap_or(&psl::datamodel_connector::EmptyDatamodelConnector);
-    let referential_integrity = datasource.map(|ds| ds.referential_integrity()).unwrap_or_default();
+    let relation_mode = datasource.map(|ds| ds.relation_mode()).unwrap_or_default();
 
     let internal_ref = prisma_models::convert(&dm, "db".to_owned());
     let schema = schema_builder::build(
@@ -23,7 +23,7 @@ pub fn get_query_schema(datamodel_string: &str) -> (QuerySchema, psl::dml::Datam
         false,
         connector,
         config.preview_features().iter().collect(),
-        referential_integrity,
+        relation_mode,
     );
 
     (schema, psl::lift(&dm))

--- a/query-engine/request-handlers/src/tests/dmmf/helpers.rs
+++ b/query-engine/request-handlers/src/tests/dmmf/helpers.rs
@@ -13,7 +13,7 @@ pub fn get_query_schema(datamodel_string: &str) -> (QuerySchema, psl::dml::Datam
         .map(|ds| ds.capabilities())
         .unwrap_or_else(ConnectorCapabilities::empty);
 
-    let referential_integrity = datasource.map(|ds| ds.referential_integrity()).unwrap_or_default();
+    let relation_mode = datasource.map(|ds| ds.relation_mode()).unwrap_or_default();
 
     let internal_dm_template = InternalDataModelBuilder::new(datamodel_string);
     let internal_ref = internal_dm_template.build("db".to_owned());
@@ -22,7 +22,7 @@ pub fn get_query_schema(datamodel_string: &str) -> (QuerySchema, psl::dml::Datam
         false,
         capabilities,
         config.subject.preview_features().iter().collect(),
-        referential_integrity,
+        relation_mode,
     );
 
     (schema, dm)

--- a/query-engine/schema-builder/src/lib.rs
+++ b/query-engine/schema-builder/src/lib.rs
@@ -45,7 +45,7 @@ use prisma_models::{
     psl::common::preview_features::PreviewFeature, CompositeTypeRef, Field as ModelField, Index, InternalDataModelRef,
     ModelRef, RelationFieldRef, TypeIdentifier,
 };
-use psl::datamodel_connector::{Connector, ConnectorCapability, ReferentialIntegrity};
+use psl::datamodel_connector::{Connector, ConnectorCapability, RelationMode};
 use schema::*;
 use std::sync::Arc;
 
@@ -177,7 +177,7 @@ pub fn build(
     enable_raw_queries: bool,
     connector: &'static dyn Connector,
     preview_features: Vec<PreviewFeature>,
-    referential_integrity: ReferentialIntegrity,
+    relation_mode: RelationMode,
 ) -> QuerySchema {
     let mut ctx = BuilderContext::new(
         internal_data_model,
@@ -213,7 +213,7 @@ pub fn build(
         ctx.internal_data_model,
         ctx.connector.capabilities().to_owned(),
         preview_features,
-        referential_integrity,
+        relation_mode,
     )
 }
 

--- a/query-engine/schema/src/query_schema.rs
+++ b/query-engine/schema/src/query_schema.rs
@@ -1,7 +1,7 @@
 use super::*;
 use fmt::Debug;
 use prisma_models::{psl::common::preview_features::PreviewFeature, InternalDataModelRef, ModelRef};
-use psl::datamodel_connector::{ConnectorCapability, ReferentialIntegrity};
+use psl::datamodel_connector::{ConnectorCapability, RelationMode};
 use std::{borrow::Borrow, fmt};
 
 /// The query schema.
@@ -50,20 +50,20 @@ pub struct ConnectorContext {
     /// Enabled preview features.
     pub features: Vec<PreviewFeature>,
 
-    /// Referential integrity mode of the provider
-    pub referential_integrity: ReferentialIntegrity,
+    /// Relation mode of the provider
+    pub relation_mode: RelationMode,
 }
 
 impl ConnectorContext {
     pub fn new(
         capabilities: Vec<ConnectorCapability>,
         features: Vec<PreviewFeature>,
-        referential_integrity: ReferentialIntegrity,
+        relation_mode: RelationMode,
     ) -> Self {
         Self {
             capabilities,
             features,
-            referential_integrity,
+            relation_mode,
         }
     }
 }
@@ -79,7 +79,7 @@ impl QuerySchema {
         internal_data_model: InternalDataModelRef,
         capabilities: Vec<ConnectorCapability>,
         features: Vec<PreviewFeature>,
-        referential_integrity: ReferentialIntegrity,
+        relation_mode: RelationMode,
     ) -> Self {
         QuerySchema {
             query,
@@ -88,7 +88,7 @@ impl QuerySchema {
             _output_object_types,
             _enum_types,
             internal_data_model,
-            context: ConnectorContext::new(capabilities, features, referential_integrity),
+            context: ConnectorContext::new(capabilities, features, relation_mode),
         }
     }
 


### PR DESCRIPTION
Rename the `referentialIntegrity` preview feature to `relationMode` in a backwards-compatible fashion.

**Context**: [internal doc](https://www.notion.so/How-do-we-GA-the-referentialIntegrity-preview-feature-8a656fe445ae4a69ad19c5000e5c7191#72322949b0ab4343a63b6c39e4d61f19).

- Small code impact on the actual logic
- Large diff on variable/function names
- Additional tests ensure backward compatibility at the `psl`/`psl-core` layer
