### PR TITLE
me: handle sqlite describer errors instead of panicking

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/flavour/sqlite/connection.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/sqlite/connection.rs
@@ -26,7 +26,9 @@ impl Connection {
             .describe_impl()
             .await
             .map_err(|err| match err.into_kind() {
-                DescriberErrorKind::QuaintError(err) => panic!("{}", err),
+                DescriberErrorKind::QuaintError(err) => {
+                    ConnectorError::from_source(err, "Error describing the database.")
+                }
                 DescriberErrorKind::CrossSchemaReference { .. } => {
                     unreachable!("No schemas on SQLite")
                 }


### PR DESCRIPTION
Return them to the user. Noticed through the crash reporting meeting. Hard to reproduce in tests.