### PR TITLE
test-setup: slightly improve compile times

### DIFF
--- a/libs/test-setup/src/lib.rs
+++ b/libs/test-setup/src/lib.rs
@@ -27,6 +27,7 @@ pub use test_api_args::{DatasourceBlock, TestApiArgs};
 
 type AnyError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
+#[inline(never)]
 pub fn should_skip_test(
     include_tagged: BitFlags<Tags>,
     exclude_tags: BitFlags<Tags>,

--- a/migration-engine/migration-engine-tests/compile-bench.md
+++ b/migration-engine/migration-engine-tests/compile-bench.md
@@ -1,3 +1,3 @@
 | Command | Mean [s] | Min [s] | Max [s] | Relative |
 |:---|---:|---:|---:|---:|
-| `cargo build --tests` | 16.043 ± 0.265 | 15.785 | 16.509 | 1.00 |
+| `cargo build --tests` | 15.901 ± 0.328 | 15.483 | 16.585 | 1.00 |

--- a/migration-engine/migration-engine-tests/compile-bench.md
+++ b/migration-engine/migration-engine-tests/compile-bench.md
@@ -1,3 +1,3 @@
 | Command | Mean [s] | Min [s] | Max [s] | Relative |
 |:---|---:|---:|---:|---:|
-| `cargo build --tests` | 10.814 ± 0.032 | 10.769 | 10.864 | 1.00 |
+| `cargo build --tests` | 16.043 ± 0.265 | 15.785 | 16.509 | 1.00 |


### PR DESCRIPTION
Through inlining hints.

The first commit is about recording the new baseline for migration-engine-tests. It's not good.