### PR TITLE
psl: fix database name clash validation with multiSchema

### DIFF
--- a/psl/parser-database/src/attributes.rs
+++ b/psl/parser-database/src/attributes.rs
@@ -155,7 +155,7 @@ fn resolve_model_attributes<'db>(model_id: ast::ModelId, ast_model: &'db ast::Mo
 
     // @@map
     if ctx.visit_optional_single_attr("map") {
-        map::model(&mut model_attributes, model_id, ctx);
+        map::model(&mut model_attributes, ctx);
         ctx.validate_visited_arguments();
     }
 

--- a/psl/parser-database/src/attributes/map.rs
+++ b/psl/parser-database/src/attributes/map.rs
@@ -6,31 +6,13 @@ use crate::{
     DatamodelError, StringId,
 };
 
-pub(super) fn model(model_attributes: &mut ModelAttributes, model_id: ast::ModelId, ctx: &mut Context<'_>) {
+pub(super) fn model(model_attributes: &mut ModelAttributes, ctx: &mut Context<'_>) {
     let mapped_name = match visit_map_attribute(ctx) {
         Some(name) => name,
         None => return,
     };
 
     model_attributes.mapped_name = Some(mapped_name);
-
-    if let Some(existing_model_id) = ctx.mapped_model_names.insert(mapped_name, model_id) {
-        let existing_model_name = ctx.ast[existing_model_id].name();
-        ctx.push_error(DatamodelError::new_duplicate_model_database_name_error(
-            &ctx[mapped_name],
-            existing_model_name,
-            ctx.ast[model_id].span(),
-        ));
-    }
-
-    if let Some(existing_model_id) = ctx.names.tops.get(&mapped_name).and_then(|id| id.as_model_id()) {
-        let existing_model_name = ctx.ast[existing_model_id].name();
-        ctx.push_error(DatamodelError::new_duplicate_model_database_name_error(
-            &ctx[mapped_name],
-            existing_model_name,
-            ctx.current_attribute().span,
-        ));
-    }
 }
 
 pub(super) fn scalar_field(

--- a/psl/parser-database/src/context.rs
+++ b/psl/parser-database/src/context.rs
@@ -30,7 +30,6 @@ pub(crate) struct Context<'db> {
     attributes: AttributesValidationState, // state machine for attribute validation
 
     // @map'ed names indexes. These are not in the db because they are only used for validation.
-    pub(super) mapped_model_names: HashMap<StringId, ast::ModelId>,
     pub(super) mapped_model_scalar_field_names: HashMap<(ast::ModelId, StringId), ast::FieldId>,
     pub(super) mapped_composite_type_names: HashMap<(ast::CompositeTypeId, StringId), ast::FieldId>,
     pub(super) mapped_enum_names: HashMap<StringId, ast::EnumId>,
@@ -55,7 +54,6 @@ impl<'db> Context<'db> {
             diagnostics,
             attributes: AttributesValidationState::default(),
 
-            mapped_model_names: Default::default(),
             mapped_model_scalar_field_names: Default::default(),
             mapped_enum_names: Default::default(),
             mapped_enum_value_names: Default::default(),

--- a/psl/parser-database/src/lib.rs
+++ b/psl/parser-database/src/lib.rs
@@ -140,7 +140,7 @@ impl ParserDatabase {
         &self.ast
     }
 
-    /// The total number of models.
+    /// The total number of models. This is O(1).
     pub fn models_count(&self) -> usize {
         self.types.model_attributes.len()
     }

--- a/psl/psl-core/src/validate/validation_pipeline/validations.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations.rs
@@ -36,9 +36,11 @@ pub(super) fn validate(ctx: &mut Context<'_>) {
         }
     }
 
-    // Model validations
     ctx.connector
         .validate_scalar_field_unknown_default_functions(ctx.db, ctx.diagnostics);
+
+    // Model validations
+    models::database_name_clashes(ctx);
 
     for model in db.walk_models() {
         models::has_a_strict_unique_criteria(model, ctx);

--- a/psl/psl/tests/validation/attributes/map/duplicate_models_with_map_on_both_sides.prisma
+++ b/psl/psl/tests/validation/attributes/map/duplicate_models_with_map_on_both_sides.prisma
@@ -1,0 +1,23 @@
+datasource mydb {
+    provider = "sqlite"
+    url = env("TEST_DB_URL")
+}
+
+model Dog {
+  id Int @id
+
+  @@map("pets")
+}
+
+model Cat {
+  id Int @id
+
+  @@map("pets")
+}
+
+// [1;91merror[0m: [1mThe model with database name "pets" could not be defined because another model with this name exists: "Dog"[0m
+//   [1;94m-->[0m  [4mschema.prisma:15[0m
+// [1;94m   | [0m
+// [1;94m14 | [0m
+// [1;94m15 | [0m  [1;91m@@map("pets")[0m
+// [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/schema/tables_in_different_schemas_with_same_mapped_name.prisma
+++ b/psl/psl/tests/validation/attributes/schema/tables_in_different_schemas_with_same_mapped_name.prisma
@@ -1,0 +1,30 @@
+// issue: https://github.com/prisma/prisma/issues/15009
+
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["multiSchema"]
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("TEST_DATABASE_URL")
+  schemas  = ["base", "transactional"]
+}
+
+model User {
+  id    String @id
+  email String
+  posts Post[]
+
+  @@map("some_table")
+  @@schema("base")
+}
+
+model Post {
+  title    String
+  authorId String @unique
+  author   User?  @relation(fields: [authorId], references: [id])
+
+  @@map("some_table")
+  @@schema("transactional")
+}

--- a/psl/psl/tests/validation/attributes/schema/tables_in_same_schema_with_same_mapped_name.prisma
+++ b/psl/psl/tests/validation/attributes/schema/tables_in_same_schema_with_same_mapped_name.prisma
@@ -1,0 +1,32 @@
+datasource mydb {
+  provider = "sqlserver"
+  url = env("TEST_DB_URL")
+  schemas  = ["base", "transactional"]
+}
+
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["multiSchema"]
+}
+
+
+model Dog {
+  id Int @id
+
+  @@map("pets")
+  @@schema("base")
+}
+
+model Cat {
+  id Int @id(map: "cat_pets_pkey")
+
+  @@map("pets")
+  @@schema("base")
+}
+
+// [1;91merror[0m: [1mThe model with database name "pets" could not be defined because another model with this name exists: "Dog"[0m
+//   [1;94m-->[0m  [4mschema.prisma:23[0m
+// [1;94m   | [0m
+// [1;94m22 | [0m
+// [1;94m23 | [0m  [1;91m@@map("pets")[0m
+// [1;94m   | [0m


### PR DESCRIPTION
The validation we have validates that no two models in the whole schema have the same database name. Database name is defined as the contents of the model's `@@map` attribute, or the model name if the model name does not have an `@@map` attribute. It is the name we give to the table/collection corresponding to the model in the database.

When the `multiSchema` preview feature is turned on, the tables in the database can be in different schemas, so we have to adapt the validation to allow multiple models to have the same database name, as long as they are in a different schema. This is what this commit does.

closes https://github.com/prisma/prisma/issues/15009