### PR TITLE
Native/Atomic upserts

### DIFF
--- a/psl/builtin-connectors/src/cockroach_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/cockroach_datamodel_connector.rs
@@ -49,6 +49,7 @@ const CAPABILITIES: &[ConnectorCapability] = &[
     ConnectorCapability::DecimalType,
     ConnectorCapability::OrderByNullsFirstLast,
     ConnectorCapability::SupportsTxIsolationSerializable,
+    ConnectorCapability::NativeUpsert,
 ];
 
 const SCALAR_TYPE_DEFAULTS: &[(ScalarType, CockroachType)] = &[

--- a/psl/builtin-connectors/src/postgres_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/postgres_datamodel_connector.rs
@@ -58,6 +58,7 @@ const CAPABILITIES: &[ConnectorCapability] = &[
     ConnectorCapability::SupportsTxIsolationReadCommitted,
     ConnectorCapability::SupportsTxIsolationRepeatableRead,
     ConnectorCapability::SupportsTxIsolationSerializable,
+    ConnectorCapability::NativeUpsert,
 ];
 
 pub struct PostgresDatamodelConnector;

--- a/psl/builtin-connectors/src/sqlite_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/sqlite_datamodel_connector.rs
@@ -20,6 +20,7 @@ const CAPABILITIES: &[ConnectorCapability] = &[
     ConnectorCapability::BackwardCompatibleQueryRaw,
     ConnectorCapability::OrderByNullsFirstLast,
     ConnectorCapability::SupportsTxIsolationSerializable,
+    ConnectorCapability::NativeUpsert,
 ];
 
 pub struct SqliteDatamodelConnector;

--- a/psl/psl-core/src/datamodel_connector/capabilities.rs
+++ b/psl/psl-core/src/datamodel_connector/capabilities.rs
@@ -97,6 +97,7 @@ capabilities!(
     SupportsTxIsolationRepeatableRead,
     SupportsTxIsolationSerializable,
     SupportsTxIsolationSnapshot,
+    NativeUpsert
 );
 
 /// Contains all capabilities that the connector is able to serve.

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/mod.rs
@@ -6,6 +6,7 @@ mod interactive_tx;
 mod metrics;
 mod multi_schema;
 mod native_types;
+mod native_upsert;
 mod occ;
 mod ref_actions;
 mod regressions;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/native_upsert.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/native_upsert.rs
@@ -1,0 +1,242 @@
+use query_engine_tests::*;
+
+#[test_suite(capabilities(NativeUpsert))]
+mod native_upsert {
+
+    #[connector_test(schema(user))]
+    async fn should_upsert_on_single_unique(mut runner: Runner) -> TestResult<()> {
+        let upsert = r#"
+          mutation {
+            upsertOneUser(
+              where: {email: "hello@example.com"},
+              create: {
+                id: 1,
+                email: "hello@example.com",
+                first_name: "hello",
+                last_name: "world"
+              },
+              update: {
+                last_name: "world-updated"
+              }
+            ) {
+              id,
+              last_name
+            }
+          }
+        "#;
+
+        insta::assert_snapshot!(
+          run_query!(&runner, upsert),
+          @r###"{"data":{"upsertOneUser":{"id":1,"last_name":"world"}}}"###
+        );
+
+        assert_used_native_upsert(&mut runner).await;
+
+        insta::assert_snapshot!(
+          run_query!(&runner, upsert),
+          @r###"{"data":{"upsertOneUser":{"id":1,"last_name":"world-updated"}}}"###
+        );
+
+        assert_used_native_upsert(&mut runner).await;
+
+        Ok(())
+    }
+
+    #[connector_test(schema(user))]
+    async fn should_upsert_on_id(mut runner: Runner) -> TestResult<()> {
+        let upsert = r#"
+          mutation {
+            upsertOneUser(
+              where: {id: 1},
+              create: {
+                id: 1,
+                email: "hello@example.com",
+                first_name: "hello",
+                last_name: "world"
+              },
+              update: {
+                last_name: "world-updated",
+                email: "hello-updated@example.com",
+                id: 2
+              }
+            ) {
+              id,
+              last_name,
+              first_name,
+              email
+            }
+          }
+        "#;
+
+        insta::assert_snapshot!(
+          run_query!(&runner, upsert),
+          @r###"{"data":{"upsertOneUser":{"id":1,"last_name":"world","first_name":"hello","email":"hello@example.com"}}}"###
+        );
+
+        assert_used_native_upsert(&mut runner).await;
+
+        insta::assert_snapshot!(
+          run_query!(&runner, upsert),
+          @r###"{"data":{"upsertOneUser":{"id":2,"last_name":"world-updated","first_name":"hello","email":"hello-updated@example.com"}}}"###
+        );
+
+        assert_used_native_upsert(&mut runner).await;
+
+        Ok(())
+    }
+
+    #[connector_test(schema(user))]
+    async fn should_upsert_on_unique_list(mut runner: Runner) -> TestResult<()> {
+        let upsert = r#"
+          mutation {
+            upsertOneUser(
+              where: {first_name_last_name: {
+                first_name: "hello",
+                last_name: "world"
+              }},
+              create: {
+                id: 1,
+                email: "hello@example.com",
+                first_name: "hello",
+                last_name: "world"
+              },
+              update: {
+                email: "hello-updated@example.com",
+              }
+            ) {
+              id,
+              last_name,
+              first_name,
+              email
+            }
+          }
+        "#;
+
+        insta::assert_snapshot!(
+          run_query!(&runner, upsert),
+          @r###"{"data":{"upsertOneUser":{"id":1,"last_name":"world","first_name":"hello","email":"hello@example.com"}}}"###
+        );
+
+        assert_used_native_upsert(&mut runner).await;
+
+        insta::assert_snapshot!(
+          run_query!(&runner, upsert),
+          @r###"{"data":{"upsertOneUser":{"id":1,"last_name":"world","first_name":"hello","email":"hello-updated@example.com"}}}"###
+        );
+
+        assert_used_native_upsert(&mut runner).await;
+
+        Ok(())
+    }
+
+    #[connector_test(schema(user))]
+    async fn should_not_use_native_upsert_on_two_uniques(mut runner: Runner) -> TestResult<()> {
+        let upsert = r#"
+          mutation {
+            upsertOneUser(
+              where: {
+                id: 1,
+                email: "hello@example.com",
+              },
+              create: {
+                id: 1,
+                email: "hello@example.com",
+                first_name: "hello",
+                last_name: "world"
+              },
+              update: {
+                email: "hello-updated@example.com",
+              }
+            ) {
+              id,
+              last_name,
+              first_name,
+              email
+            }
+          }
+        "#;
+
+        insta::assert_snapshot!(
+          run_query!(&runner, upsert),
+          @r###"{"data":{"upsertOneUser":{"id":1,"last_name":"world","first_name":"hello","email":"hello@example.com"}}}"###
+        );
+
+        assert_not_used_native_upsert(&mut runner).await;
+
+        insta::assert_snapshot!(
+          run_query!(&runner, upsert),
+          @r###"{"data":{"upsertOneUser":{"id":1,"last_name":"world","first_name":"hello","email":"hello-updated@example.com"}}}"###
+        );
+
+        assert_not_used_native_upsert(&mut runner).await;
+
+        Ok(())
+    }
+
+    // Should not use native upsert when the unique field values defined in the where clause
+    // do not match the same uniques fields in the create clause
+    #[connector_test(schema(user))]
+    async fn should_not_use_if_where_and_create_different(mut runner: Runner) -> TestResult<()> {
+        run_query!(
+            &runner,
+            r#"mutation {
+                createOneUser(
+                  data: {
+                    id: 1,
+                    first_name: "first",
+                    last_name: "last",
+                    email: "email1"
+                  }
+                ) {
+                  id
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"mutation {
+            upsertOneUser(
+              where: {email: "email1"}
+              create: {
+                id: 1,
+                email: "another-email",
+                first_name: "first",
+                last_name: "last",
+              }
+              update: {
+                email: { set:"email-updated" }
+              }
+            ){
+              id,
+              email
+            }
+          }"#),
+          @r###"{"data":{"upsertOneUser":{"id":1,"email":"email-updated"}}}"###
+        );
+
+        assert_not_used_native_upsert(&mut runner).await;
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{
+            findUniqueUser(where: {id: 1}){
+              email
+            }
+          }"#),
+          @r###"{"data":{"findUniqueUser":{"email":"email-updated"}}}"###
+        );
+
+        Ok(())
+    }
+
+    async fn assert_used_native_upsert(runner: &mut Runner) {
+        let logs = runner.get_logs().await;
+        let did_upsert = logs.iter().any(|l| l.contains("ON CONFLICT"));
+        assert!(did_upsert);
+    }
+
+    async fn assert_not_used_native_upsert(runner: &mut Runner) {
+        let logs = runner.get_logs().await;
+        let did_upsert = logs.iter().any(|l| l.contains("ON CONFLICT"));
+        assert!(!did_upsert);
+    }
+}

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/native_upsert.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/native_upsert.rs
@@ -228,6 +228,32 @@ mod native_upsert {
         Ok(())
     }
 
+    #[connector_test(schema(user))]
+    async fn should_not_if_missing_update(mut runner: Runner) -> TestResult<()> {
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"mutation {
+            upsertOneUser(
+              where: {email: "email1"}
+              create: {
+                id: 1,
+                email: "email1",
+                first_name: "first",
+                last_name: "last",
+              }
+              update: {
+              }
+            ){
+              id,
+              email
+            }
+          }"#),
+          @r###"{"data":{"upsertOneUser":{"id":1,"email":"email1"}}}"###
+        );
+
+        assert_not_used_native_upsert(&mut runner).await;
+        Ok(())
+    }
+
     pub fn compound_id() -> String {
         let schema = indoc! {
             "model TestModel {

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/simple/multi_field_unique.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/simple/multi_field_unique.rs
@@ -107,7 +107,7 @@ mod multi_field_unique {
             }
             "# },
             2012,
-            "Missing a required value at `Query.findUniqueUser.where.UserWhereUniqueInput.FirstName_LastName.UserFirstName_LastNameCompoundUniqueInput.LastName"
+            "Missing a required value at `Query.findUniqueUser.where.UserWhereUniqueInput.FirstName_LastName.UserFirstNameLastNameCompoundUniqueInput.LastName"
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/simple/multi_field_unique.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/simple/multi_field_unique.rs
@@ -107,7 +107,7 @@ mod multi_field_unique {
             }
             "# },
             2012,
-            "Missing a required value at `Query.findUniqueUser.where.UserWhereUniqueInput.FirstName_LastName.UserFirstNameLastNameCompoundUniqueInput.LastName"
+            "Missing a required value at `Query.findUniqueUser.where.UserWhereUniqueInput.FirstName_LastName.UserFirstName_LastNameCompoundUniqueInput.LastName"
         );
 
         Ok(())

--- a/query-engine/connectors/mongodb-query-connector/src/interface/connection.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/interface/connection.rs
@@ -159,6 +159,14 @@ impl WriteOperations for MongoDbConnection {
     ) -> connector_interface::Result<serde_json::Value> {
         catch(async move { write::query_raw(&self.database, &mut self.session, model, inputs, query_type).await }).await
     }
+
+    async fn native_upsert_record(
+        &mut self,
+        _upsert: connector_interface::NativeUpsert,
+        _trace_id: Option<String>,
+    ) -> connector_interface::Result<SingleRecord> {
+        unimplemented!("Native upsert is not currently supported.")
+    }
 }
 
 #[async_trait]

--- a/query-engine/connectors/mongodb-query-connector/src/interface/transaction.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/interface/transaction.rs
@@ -163,6 +163,14 @@ impl<'conn> WriteOperations for MongoDbTransaction<'conn> {
         .await
     }
 
+    async fn native_upsert_record(
+        &mut self,
+        _upsert: connector_interface::NativeUpsert,
+        _trace_id: Option<String>,
+    ) -> connector_interface::Result<SingleRecord> {
+        unimplemented!("Native upsert is not currently supported.")
+    }
+
     async fn m2m_connect(
         &mut self,
         field: &RelationFieldRef,

--- a/query-engine/connectors/query-connector/src/filter/scalar/mod.rs
+++ b/query-engine/connectors/query-connector/src/filter/scalar/mod.rs
@@ -133,4 +133,16 @@ impl ScalarFilter {
 
         fields
     }
+
+    pub fn is_unique(&self) -> bool {
+        if let Some(sf) = self.scalar_ref() {
+            sf.unique()
+        } else {
+            false
+        }
+    }
+
+    pub fn scalar_ref(&self) -> Option<&ScalarFieldRef> {
+        self.projection.as_single()
+    }
 }

--- a/query-engine/connectors/query-connector/src/interface.rs
+++ b/query-engine/connectors/query-connector/src/interface.rs
@@ -1,4 +1,4 @@
-use crate::{coerce_null_to_zero_value, Filter, QueryArguments, WriteArgs};
+use crate::{coerce_null_to_zero_value, Filter, NativeUpsert, QueryArguments, WriteArgs};
 use async_trait::async_trait;
 use dml::FieldArity;
 use prisma_models::*;
@@ -314,6 +314,14 @@ pub trait WriteOperations {
         args: WriteArgs,
         trace_id: Option<String>,
     ) -> crate::Result<Option<SelectionResult>>;
+
+    /// Native upsert
+    /// Use the connectors native upsert to upsert the `Model`
+    async fn native_upsert_record(
+        &mut self,
+        upsert: NativeUpsert,
+        trace_id: Option<String>,
+    ) -> crate::Result<SingleRecord>;
 
     /// Delete records in the `Model` with the given `Filter`.
     async fn delete_records(

--- a/query-engine/connectors/query-connector/src/lib.rs
+++ b/query-engine/connectors/query-connector/src/lib.rs
@@ -8,6 +8,7 @@ mod coerce;
 mod compare;
 mod interface;
 mod query_arguments;
+mod upsert;
 mod write_args;
 
 pub use coerce::*;
@@ -15,6 +16,7 @@ pub use compare::*;
 pub use filter::*;
 pub use interface::*;
 pub use query_arguments::*;
+pub use upsert::*;
 pub use write_args::*;
 
 pub type Result<T> = std::result::Result<T, error::ConnectorError>;

--- a/query-engine/connectors/query-connector/src/upsert.rs
+++ b/query-engine/connectors/query-connector/src/upsert.rs
@@ -52,13 +52,18 @@ impl NativeUpsert {
     pub fn unique_constraint(&self) -> Vec<ScalarFieldRef> {
         let compound_indexes = self.model.unique_indexes();
         let scalars = self.record_filter.filter.scalars();
-        let unique_index = compound_indexes.into_iter().find(|index| {
-            let index_fields = index.fields();
-            index_fields.into_iter().all(|f| scalars.contains(&f))
-        });
+        let unique_index = compound_indexes
+            .into_iter()
+            .find(|index| index.fields().iter().all(|f| scalars.contains(f)));
 
         if let Some(index) = unique_index {
             return index.fields();
+        }
+
+        if let Some(ids) = self.model.fields().compound_id() {
+            if ids.fields().iter().all(|f| scalars.contains(f)) {
+                return ids.fields();
+            }
         }
 
         self.record_filter.filter.unique_scalars()

--- a/query-engine/connectors/query-connector/src/upsert.rs
+++ b/query-engine/connectors/query-connector/src/upsert.rs
@@ -1,0 +1,88 @@
+use crate::{Filter, RecordFilter, WriteArgs};
+use prisma_models::{FieldSelection, ModelRef, ScalarFieldRef};
+
+#[derive(Debug, Clone)]
+pub struct NativeUpsert {
+    name: String,
+    model: ModelRef,
+    record_filter: RecordFilter,
+    create: WriteArgs,
+    update: WriteArgs,
+    selected_fields: FieldSelection,
+    selection_order: Vec<String>,
+}
+
+impl NativeUpsert {
+    pub fn new(
+        name: String,
+        model: ModelRef,
+        record_filter: RecordFilter,
+        create: WriteArgs,
+        update: WriteArgs,
+        selected_fields: FieldSelection,
+        selection_order: Vec<String>,
+    ) -> Self {
+        Self {
+            name,
+            model,
+            record_filter,
+            create,
+            update,
+            selected_fields,
+            selection_order,
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn model(&self) -> &ModelRef {
+        &self.model
+    }
+
+    pub fn update(&self) -> &WriteArgs {
+        &self.update
+    }
+
+    pub fn create(&self) -> &WriteArgs {
+        &self.create
+    }
+
+    pub fn unique_constraint(&self) -> Vec<ScalarFieldRef> {
+        let compound_indexes = self.model.unique_indexes();
+        let scalars = self.record_filter.filter.scalars();
+        let unique_index = compound_indexes.into_iter().find(|index| {
+            let index_fields = index.fields();
+            index_fields.into_iter().all(|f| scalars.contains(&f))
+        });
+
+        if let Some(index) = unique_index {
+            return index.fields();
+        }
+
+        self.record_filter.filter.unique_scalars()
+    }
+
+    pub fn filter(&self) -> &Filter {
+        &self.record_filter.filter
+    }
+
+    pub fn selected_fields(&self) -> &FieldSelection {
+        &self.selected_fields
+    }
+
+    pub fn selection_order(&self) -> &[String] {
+        &self.selection_order
+    }
+}
+
+impl std::fmt::Display for NativeUpsert {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "Upsert(model: {}, filter: {:?}, create: {:?}, update: {:?}",
+            self.model.name, self.record_filter, self.create, self.update
+        )
+    }
+}

--- a/query-engine/connectors/query-connector/src/upsert.rs
+++ b/query-engine/connectors/query-connector/src/upsert.rs
@@ -49,7 +49,7 @@ impl NativeUpsert {
         &self.create
     }
 
-    pub fn unique_constraint(&self) -> Vec<ScalarFieldRef> {
+    pub fn unique_constraints(&self) -> Vec<ScalarFieldRef> {
         let compound_indexes = self.model.unique_indexes();
         let scalars = self.record_filter.filter.scalars();
         let unique_index = compound_indexes

--- a/query-engine/connectors/sql-query-connector/src/database/connection.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/connection.rs
@@ -1,5 +1,5 @@
 use super::{catch, transaction::SqlConnectorTransaction};
-use crate::{database::operations::*, sql_info::SqlInfo, QueryExt, SqlError};
+use crate::{database::operations::*, operations::upsert::native_upsert, sql_info::SqlInfo, QueryExt, SqlError};
 use async_trait::async_trait;
 use connector::{ConnectionLike, RelAggregationSelection};
 use connector_interface::{
@@ -236,6 +236,17 @@ where
     ) -> connector::Result<usize> {
         catch(self.connection_info.clone(), async move {
             write::delete_records(&self.inner, model, record_filter, trace_id).await
+        })
+        .await
+    }
+
+    async fn native_upsert_record(
+        &mut self,
+        upsert: connector_interface::NativeUpsert,
+        trace_id: Option<String>,
+    ) -> connector::Result<SingleRecord> {
+        catch(self.connection_info.clone(), async move {
+            native_upsert(&self.inner, upsert, trace_id).await
         })
         .await
     }

--- a/query-engine/connectors/sql-query-connector/src/database/operations/mod.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/mod.rs
@@ -1,2 +1,3 @@
 pub mod read;
+pub mod upsert;
 pub mod write;

--- a/query-engine/connectors/sql-query-connector/src/database/operations/upsert.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/upsert.rs
@@ -1,0 +1,41 @@
+use connector_interface::NativeUpsert;
+use prisma_models::{ModelProjection, Record, SingleRecord};
+use quaint::prelude::{OnConflict, Query};
+
+use crate::{
+    column_metadata,
+    filter_conversion::AliasedCondition,
+    model_extensions::AsColumns,
+    query_builder::{build_update_and_set_query, create_record},
+    query_ext::QueryExt,
+    row::ToSqlRow,
+};
+
+pub async fn native_upsert(
+    conn: &dyn QueryExt,
+    upsert: NativeUpsert,
+    trace_id: Option<String>,
+) -> crate::Result<SingleRecord> {
+    let selected_fields: ModelProjection = upsert.selected_fields().into();
+    let field_names: Vec<_> = selected_fields.db_names().collect();
+    let idents = selected_fields.type_identifiers_with_arities();
+
+    let meta = column_metadata::create(&field_names, &idents);
+
+    let where_condition = upsert.filter().aliased_condition_from(None, false);
+    let update = build_update_and_set_query(upsert.model(), upsert.update().clone(), None).so_that(where_condition);
+
+    let insert = create_record(&upsert.model(), upsert.create().clone(), trace_id);
+
+    let constraints: Vec<_> = upsert.unique_constraint().as_columns().collect();
+    let query: Query = insert
+        .on_conflict(OnConflict::Update(update, constraints))
+        .returning(selected_fields.as_columns())
+        .into();
+
+    let result_set = conn.query(query).await?;
+
+    let row = result_set.into_single()?;
+    let record = Record::from(row.to_sql_row(&meta)?);
+    Ok(SingleRecord { record, field_names })
+}

--- a/query-engine/connectors/sql-query-connector/src/database/operations/upsert.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/upsert.rs
@@ -27,7 +27,7 @@ pub async fn native_upsert(
 
     let insert = create_record(&upsert.model(), upsert.create().clone(), trace_id);
 
-    let constraints: Vec<_> = upsert.unique_constraint().as_columns().collect();
+    let constraints: Vec<_> = upsert.unique_constraints().as_columns().collect();
     let query: Query = insert
         .on_conflict(OnConflict::Update(update, constraints))
         .returning(selected_fields.as_columns())

--- a/query-engine/connectors/sql-query-connector/src/database/transaction.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/transaction.rs
@@ -1,5 +1,5 @@
 use super::catch;
-use crate::{database::operations::*, sql_info::SqlInfo, SqlError};
+use crate::{database::operations::*, operations::upsert::native_upsert, sql_info::SqlInfo, SqlError};
 use async_trait::async_trait;
 use connector::{ConnectionLike, RelAggregationSelection};
 use connector_interface::{
@@ -216,6 +216,17 @@ impl<'tx> WriteOperations for SqlConnectorTransaction<'tx> {
     ) -> connector::Result<usize> {
         catch(self.connection_info.clone(), async move {
             write::delete_records(&self.inner, model, record_filter, trace_id).await
+        })
+        .await
+    }
+
+    async fn native_upsert_record(
+        &mut self,
+        upsert: connector_interface::NativeUpsert,
+        trace_id: Option<String>,
+    ) -> connector::Result<SingleRecord> {
+        catch(self.connection_info.clone(), async move {
+            native_upsert(&self.inner, upsert, trace_id).await
         })
         .await
     }

--- a/query-engine/connectors/sql-query-connector/src/query_builder/write.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_builder/write.rs
@@ -100,10 +100,11 @@ pub fn create_records_empty(model: &ModelRef, skip_duplicates: bool, trace_id: O
 
 pub fn build_update_and_set_query(model: &ModelRef, args: WriteArgs, trace_id: Option<String>) -> Update<'static> {
     let scalar_fields = model.fields().scalar();
+    let table = model.as_table();
     let query = args
         .args
         .into_iter()
-        .fold(Update::table(model.as_table()), |acc, (field_name, val)| {
+        .fold(Update::table(table.clone()), |acc, (field_name, val)| {
             let DatasourceFieldName(name) = field_name;
             let field = scalar_fields
                 .iter()
@@ -124,22 +125,22 @@ pub fn build_update_and_set_query(model: &ModelRef, args: WriteArgs, trace_id: O
                     e.compare_raw("||", Value::array(vals)).into()
                 }
                 ScalarWriteOperation::Add(rhs) => {
-                    let e: Expression<'_> = Column::from(name.clone()).into();
+                    let e: Expression<'_> = Column::from((table.clone(), name.clone())).into();
                     e + field.value(rhs).into()
                 }
 
                 ScalarWriteOperation::Substract(rhs) => {
-                    let e: Expression<'_> = Column::from(name.clone()).into();
+                    let e: Expression<'_> = Column::from((table.clone(), name.clone())).into();
                     e - field.value(rhs).into()
                 }
 
                 ScalarWriteOperation::Multiply(rhs) => {
-                    let e: Expression<'_> = Column::from(name.clone()).into();
+                    let e: Expression<'_> = Column::from((table.clone(), name.clone())).into();
                     e * field.value(rhs).into()
                 }
 
                 ScalarWriteOperation::Divide(rhs) => {
-                    let e: Expression<'_> = Column::from(name.clone()).into();
+                    let e: Expression<'_> = Column::from((table.clone(), name.clone())).into();
                     e / field.value(rhs).into()
                 }
 

--- a/query-engine/core/src/query_document/parse_ast.rs
+++ b/query-engine/core/src/query_document/parse_ast.rs
@@ -98,23 +98,25 @@ pub struct ParsedField {
 }
 
 impl ParsedField {
-    pub fn where_args(&mut self) -> Option<QueryParserResult<ParsedInputMap>> {
+    pub fn where_arg(&mut self) -> QueryParserResult<Option<ParsedInputMap>> {
         self.look_arg("where")
     }
 
-    pub fn create_args(&mut self) -> Option<QueryParserResult<ParsedInputMap>> {
+    pub fn create_arg(&mut self) -> QueryParserResult<Option<ParsedInputMap>> {
         self.look_arg("create")
     }
 
-    pub fn update_args(&mut self) -> Option<QueryParserResult<ParsedInputMap>> {
+    pub fn update_arg(&mut self) -> QueryParserResult<Option<ParsedInputMap>> {
         self.look_arg("update")
     }
 
-    fn look_arg(&mut self, arg_name: &str) -> Option<QueryParserResult<ParsedInputMap>> {
-        self.arguments
-            .lookup(arg_name)
-            .as_ref()
-            .map(|arg| arg.value.clone().try_into())
+    fn look_arg(&mut self, arg_name: &str) -> QueryParserResult<Option<ParsedInputMap>> {
+        Option::transpose(
+            self.arguments
+                .lookup(arg_name)
+                .as_ref()
+                .map(|arg| arg.value.clone().try_into()),
+        )
     }
 }
 

--- a/query-engine/core/src/query_document/parse_ast.rs
+++ b/query-engine/core/src/query_document/parse_ast.rs
@@ -111,12 +111,11 @@ impl ParsedField {
     }
 
     fn look_arg(&mut self, arg_name: &str) -> QueryParserResult<Option<ParsedInputMap>> {
-        Option::transpose(
-            self.arguments
-                .lookup(arg_name)
-                .as_ref()
-                .map(|arg| arg.value.clone().try_into()),
-        )
+        self.arguments
+            .lookup(arg_name)
+            .as_ref()
+            .map(|arg| arg.value.clone().try_into())
+            .transpose()
     }
 }
 

--- a/query-engine/core/src/query_graph_builder/extractors/mod.rs
+++ b/query-engine/core/src/query_graph_builder/extractors/mod.rs
@@ -6,5 +6,6 @@ mod utils;
 pub use filters::*;
 pub use query_arguments::*;
 pub use rel_aggregations::*;
+pub use utils::resolve_compound_field;
 
 use crate::query_document::*;

--- a/query-engine/core/src/query_graph_builder/write/upsert.rs
+++ b/query-engine/core/src/query_graph_builder/write/upsert.rs
@@ -214,6 +214,8 @@ fn can_use_connector_native_upsert(
         .iter()
         .any(|(field_name, _)| model.fields().find_from_relation_fields(&field_name).is_ok());
 
+    let empty_update = update_argument.iter().len() == 0;
+
     let has_one_unique = where_field
         .iter()
         .filter(|(field_name, _)| is_unique_field(field_name, model))
@@ -228,6 +230,7 @@ fn can_use_connector_native_upsert(
         && has_one_unique
         && !has_nested_create
         && !has_nested_update
+        && !empty_update
         && where_values_same_as_create
 }
 

--- a/query-engine/core/src/query_graph_builder/write/upsert.rs
+++ b/query-engine/core/src/query_graph_builder/write/upsert.rs
@@ -57,9 +57,9 @@ pub fn upsert_record(
     model: ModelRef,
     mut field: ParsedField,
 ) -> QueryGraphBuilderResult<()> {
-    let where_argument = field.where_args().unwrap()?;
-    let create_argument = field.create_args().unwrap()?;
-    let update_argument = field.update_args().unwrap()?;
+    let where_argument = field.where_arg()?.unwrap();
+    let create_argument = field.create_arg()?.unwrap();
+    let update_argument = field.update_arg()?.unwrap();
 
     let can_use_native_upsert = can_use_connector_native_upsert(
         &model,
@@ -221,8 +221,7 @@ fn can_use_connector_native_upsert(
         == 1;
 
     let where_values_same_as_create = where_field
-        .clone()
-        .into_iter()
+        .iter()
         .all(|(field_name, input)| where_and_create_equal(&field_name, &input, &create_argument));
 
     connector_ctx.can_native_upsert()

--- a/query-engine/prisma-models/src/builders/index_builder.rs
+++ b/query-engine/prisma-models/src/builders/index_builder.rs
@@ -10,20 +10,13 @@ pub struct IndexBuilder {
 
 impl IndexBuilder {
     pub fn build(self, fields: &[ScalarFieldRef]) -> Index {
-        let name = if self.name.is_none() {
-            let fields_name = self.fields.join("_");
-            Some(fields_name)
-        } else {
-            self.name
-        };
-
         let fields = match self.typ {
             IndexType::Unique => Self::map_fields(self.fields, fields),
             IndexType::Normal => Self::map_fields(self.fields, fields),
         };
 
         Index {
-            name,
+            name: self.name,
             typ: self.typ,
             fields,
         }

--- a/query-engine/prisma-models/src/builders/index_builder.rs
+++ b/query-engine/prisma-models/src/builders/index_builder.rs
@@ -10,13 +10,20 @@ pub struct IndexBuilder {
 
 impl IndexBuilder {
     pub fn build(self, fields: &[ScalarFieldRef]) -> Index {
+        let name = if self.name.is_none() {
+            let fields_name = self.fields.join("_");
+            Some(fields_name)
+        } else {
+            self.name
+        };
+
         let fields = match self.typ {
             IndexType::Unique => Self::map_fields(self.fields, fields),
             IndexType::Normal => Self::map_fields(self.fields, fields),
         };
 
         Index {
-            name: self.name,
+            name,
             typ: self.typ,
             fields,
         }

--- a/query-engine/schema/src/query_schema.rs
+++ b/query-engine/schema/src/query_schema.rs
@@ -66,6 +66,10 @@ impl ConnectorContext {
             relation_mode,
         }
     }
+
+    pub fn can_native_upsert(&self) -> bool {
+        self.capabilities.contains(&ConnectorCapability::NativeUpsert)
+    }
 }
 
 impl QuerySchema {


### PR DESCRIPTION
This adds support for using the built in `INSERT ... ON CONFLICT SET .. WHERE` 
This will work for Postgres, sqlite and CockroachDB. Internally when building an upsert, we check if it meets these conditions:
 1. The data connector supports it
 2. The create and update arguments do not have any nested queries
 3. There is only 1 unique field in the where clause
 4. The unique field defined in where clause has the same value as defined in the create arguments

Then the query engine can use `ON CONFLICT`