### PR TITLE
ie: check that invalid schemas can be introspection inputs

### DIFF
--- a/introspection-engine/core/src/rpc.rs
+++ b/introspection-engine/core/src/rpc.rs
@@ -9,6 +9,7 @@ use mongodb_introspection_connector::MongoDbIntrospectionConnector;
 use psl::Configuration;
 use serde::*;
 use sql_introspection_connector::SqlIntrospectionConnector;
+use std::sync::Arc;
 
 type RpcError = jsonrpc_core::Error;
 type RpcResult<T> = Result<T, RpcError>;
@@ -103,7 +104,7 @@ impl RpcImpl {
         composite_type_depth: CompositeTypeDepth,
     ) -> RpcResult<IntrospectionResultOutput> {
         let (config, _url, connector) = RpcImpl::load_connector(&schema).await?;
-        let previous_schema = psl::parse_schema(schema.as_str()).map_err(Error::DatamodelError)?;
+        let previous_schema = psl::validate(psl::SourceFile::new_allocated(Arc::from(schema.into_boxed_str())));
 
         let ctx = if !force {
             IntrospectionContext::new(previous_schema, composite_type_depth)

--- a/introspection-engine/introspection-engine-tests/tests/introspect/mod.rs
+++ b/introspection-engine/introspection-engine-tests/tests/introspect/mod.rs
@@ -1,0 +1,53 @@
+use expect_test::expect;
+use quaint::connector::rusqlite;
+use test_setup::runtime::run_with_tokio as tok;
+
+#[test]
+fn introspect_force_with_invalid_schema() {
+    test_setup::only!(Sqlite);
+
+    let db_path = test_setup::sqlite_test_url("introspect_force_with_invalid_schema");
+
+    {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute_batch("CREATE TABLE corgis (bites BOOLEAN)").unwrap();
+    }
+
+    let schema = format!(
+        r#"
+        datasource sqlitedb {{
+            provider = "sqlite"
+            url = "{db_path}"
+        }}
+
+        model This_Is_Blatantly_Not_Valid_and_An_Outrage {{
+            pk Bytes @unknownAttributeThisIsNotValid
+        }}
+    "#
+    );
+
+    let result = &tok(introspection_core::RpcImpl::introspect_internal(
+        schema,
+        true,
+        Default::default(),
+    ))
+    .unwrap()
+    .datamodel
+    .replace(db_path.as_str(), "<db_path>");
+
+    let expected = expect![[r#"
+        datasource sqlitedb {
+          provider = "sqlite"
+          url      = "<db_path>"
+        }
+
+        /// The underlying table does not contain a valid unique identifier and can therefore currently not be handled by the Prisma Client.
+        model corgis {
+          bites Boolean?
+
+          @@ignore
+        }
+    "#]];
+
+    expected.assert_eq(result);
+}

--- a/introspection-engine/introspection-engine-tests/tests/introspection_tests.rs
+++ b/introspection-engine/introspection-engine-tests/tests/introspection_tests.rs
@@ -4,6 +4,7 @@ mod commenting_out;
 mod enums;
 mod errors;
 mod identify_version;
+mod introspect;
 mod lists;
 mod model_renames;
 mod mssql;

--- a/libs/test-setup/src/lib.rs
+++ b/libs/test-setup/src/lib.rs
@@ -29,15 +29,16 @@ type AnyError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 #[macro_export]
 macro_rules! only {
-    ($($tag:ident),* $(;)?) => {
-        only!($($tag,)* ; exclude: )
+    ($($tag:ident),*) => {
+        ::test_setup::only!($($tag,)* ; exclude: )
     };
 
-    ($($tag:ident),* ; exclude: $($excludeTag:ident),*) => {
+    ($($tag:ident,)* ; exclude: $($excludeTag:ident),*) => {
         {
-            let (skip, db) = only_impl(
-                enumflags2::bitflags!($($tag |)*),
-                enumflags2::bitflag!($($excludeTag |)*)
+            use ::test_setup::Tags;
+            let (skip, db) = ::test_setup::only_impl(
+                ::enumflags2::make_bitflags!(Tags::{$($tag)|*}),
+                ::enumflags2::make_bitflags!(Tags::{$($excludeTag)|*})
             );
             if skip { return }
             db


### PR DESCRIPTION
With --force. PSL validation errors outside of the config blocks should
not prevent introspection.

Relevant: https://github.com/prisma/prisma/pull/15649#issuecomment-1266755333