### PR TITLE
PSL: Datamodel loader does not need a struct

### DIFF
--- a/psl/psl-core/src/lib.rs
+++ b/psl/psl-core/src/lib.rs
@@ -22,7 +22,7 @@ pub use parser_database::{self, is_reserved_type_name};
 
 use self::{
     common::preview_features::PreviewFeature,
-    validate::{DatasourceLoader, GeneratorLoader},
+    validate::{datasource_loader, GeneratorLoader},
 };
 use diagnostics::Diagnostics;
 use parser_database::{ast, ParserDatabase, SourceFile};
@@ -80,7 +80,9 @@ fn validate_configuration(
 ) -> Configuration {
     let generators = GeneratorLoader::load_generators_from_ast(schema_ast, diagnostics);
     let preview_features = generators.iter().filter_map(|gen| gen.preview_features).collect();
-    let datasources = DatasourceLoader.load_datasources_from_ast(schema_ast, preview_features, diagnostics, connectors);
+
+    let datasources =
+        datasource_loader::load_datasources_from_ast(schema_ast, preview_features, diagnostics, connectors);
 
     Configuration {
         generators,

--- a/psl/psl-core/src/lib.rs
+++ b/psl/psl-core/src/lib.rs
@@ -22,7 +22,7 @@ pub use parser_database::{self, is_reserved_type_name};
 
 use self::{
     common::preview_features::PreviewFeature,
-    validate::{datasource_loader, GeneratorLoader},
+    validate::{datasource_loader, generator_loader},
 };
 use diagnostics::Diagnostics;
 use parser_database::{ast, ParserDatabase, SourceFile};
@@ -78,7 +78,7 @@ fn validate_configuration(
     diagnostics: &mut Diagnostics,
     connectors: ConnectorRegistry,
 ) -> Configuration {
-    let generators = GeneratorLoader::load_generators_from_ast(schema_ast, diagnostics);
+    let generators = generator_loader::load_generators_from_ast(schema_ast, diagnostics);
     let preview_features = generators.iter().filter_map(|gen| gen.preview_features).collect();
 
     let datasources =

--- a/psl/psl-core/src/validate.rs
+++ b/psl/psl-core/src/validate.rs
@@ -1,7 +1,7 @@
-mod datasource_loader;
+pub mod datasource_loader;
+
 mod generator_loader;
 mod validation_pipeline;
 
-pub(crate) use datasource_loader::DatasourceLoader;
 pub(crate) use generator_loader::GeneratorLoader;
 pub(crate) use validation_pipeline::validate;

--- a/psl/psl-core/src/validate.rs
+++ b/psl/psl-core/src/validate.rs
@@ -1,7 +1,5 @@
-pub mod datasource_loader;
-
-mod generator_loader;
+pub(crate) mod datasource_loader;
+pub(crate) mod generator_loader;
 mod validation_pipeline;
 
-pub(crate) use generator_loader::GeneratorLoader;
 pub(crate) use validation_pipeline::validate;

--- a/psl/psl-core/src/validate/datasource_loader.rs
+++ b/psl/psl-core/src/validate/datasource_loader.rs
@@ -18,7 +18,7 @@ const URL_KEY: &str = "url";
 /// Loads all datasources from the provided schema AST.
 /// - `ignore_datasource_urls`: datasource URLs are not parsed. They are replaced with dummy values.
 /// - `datasource_url_overrides`: datasource URLs are not parsed and overridden with the provided ones.
-pub fn load_datasources_from_ast(
+pub(crate) fn load_datasources_from_ast(
     ast_schema: &ast::SchemaAst,
     preview_features: BitFlags<PreviewFeature>,
     diagnostics: &mut Diagnostics,

--- a/psl/psl-core/src/validate/datasource_loader.rs
+++ b/psl/psl-core/src/validate/datasource_loader.rs
@@ -15,233 +15,226 @@ const SCHEMAS_KEY: &str = "schemas";
 const SHADOW_DATABASE_URL_KEY: &str = "shadowDatabaseUrl";
 const URL_KEY: &str = "url";
 
-/// Is responsible for loading and validating Datasources defined in an AST.
-pub(crate) struct DatasourceLoader;
+/// Loads all datasources from the provided schema AST.
+/// - `ignore_datasource_urls`: datasource URLs are not parsed. They are replaced with dummy values.
+/// - `datasource_url_overrides`: datasource URLs are not parsed and overridden with the provided ones.
+pub fn load_datasources_from_ast(
+    ast_schema: &ast::SchemaAst,
+    preview_features: BitFlags<PreviewFeature>,
+    diagnostics: &mut Diagnostics,
+    connectors: crate::ConnectorRegistry,
+) -> Vec<Datasource> {
+    let mut sources = Vec::new();
 
-impl DatasourceLoader {
-    /// Loads all datasources from the provided schema AST.
-    /// - `ignore_datasource_urls`: datasource URLs are not parsed. They are replaced with dummy values.
-    /// - `datasource_url_overrides`: datasource URLs are not parsed and overridden with the provided ones.
-    pub fn load_datasources_from_ast(
-        &self,
-        ast_schema: &ast::SchemaAst,
-        preview_features: BitFlags<PreviewFeature>,
-        diagnostics: &mut Diagnostics,
-        connectors: crate::ConnectorRegistry,
-    ) -> Vec<Datasource> {
-        let mut sources = Vec::new();
-
-        for src in ast_schema.sources() {
-            if let Some(source) = self.lift_datasource(src, preview_features, diagnostics, connectors) {
-                sources.push(source)
-            }
+    for src in ast_schema.sources() {
+        if let Some(source) = lift_datasource(src, preview_features, diagnostics, connectors) {
+            sources.push(source)
         }
-
-        if sources.len() > 1 {
-            for src in ast_schema.sources() {
-                diagnostics.push_error(DatamodelError::new_source_validation_error(
-                    "You defined more than one datasource. This is not allowed yet because support for multiple databases has not been implemented yet.",
-                    &src.name.name,
-                    src.span,
-                ));
-            }
-        }
-
-        sources
     }
 
-    fn lift_datasource(
-        &self,
-        ast_source: &ast::SourceConfig,
-        preview_features: BitFlags<PreviewFeature>,
-        diagnostics: &mut Diagnostics,
-        connectors: crate::ConnectorRegistry,
-    ) -> Option<Datasource> {
-        let source_name = &ast_source.name.name;
-        let mut args: HashMap<_, _> = ast_source
-            .properties
-            .iter()
-            .map(|arg| (arg.name.name.as_str(), (arg.span, &arg.value)))
-            .collect();
+    if sources.len() > 1 {
+        for src in ast_schema.sources() {
+            diagnostics.push_error(DatamodelError::new_source_validation_error(
+                "You defined more than one datasource. This is not allowed yet because support for multiple databases has not been implemented yet.",
+                &src.name.name,
+                src.span,
+            ));
+        }
+    }
 
-        let (_, provider_arg) = match args.remove("provider") {
-            Some(provider) => provider,
-            None => {
-                diagnostics.push_error(DatamodelError::new_source_argument_not_found_error(
-                    "provider",
-                    &ast_source.name.name,
-                    ast_source.span,
-                ));
-                return None;
-            }
-        };
+    sources
+}
 
-        if provider_arg.is_env_expression() {
-            let msg = Cow::Borrowed("A datasource must not use the env() function in the provider argument.");
-            diagnostics.push_error(DatamodelError::new_functional_evaluation_error(msg, ast_source.span));
+fn lift_datasource(
+    ast_source: &ast::SourceConfig,
+    preview_features: BitFlags<PreviewFeature>,
+    diagnostics: &mut Diagnostics,
+    connectors: crate::ConnectorRegistry,
+) -> Option<Datasource> {
+    let source_name = &ast_source.name.name;
+    let mut args: HashMap<_, _> = ast_source
+        .properties
+        .iter()
+        .map(|arg| (arg.name.name.as_str(), (arg.span, &arg.value)))
+        .collect();
+
+    let (_, provider_arg) = match args.remove("provider") {
+        Some(provider) => provider,
+        None => {
+            diagnostics.push_error(DatamodelError::new_source_argument_not_found_error(
+                "provider",
+                &ast_source.name.name,
+                ast_source.span,
+            ));
             return None;
         }
+    };
 
-        let provider = match coerce_opt::string(provider_arg) {
-            Some("") => {
-                diagnostics.push_error(DatamodelError::new_source_validation_error(
-                    "The provider argument in a datasource must not be empty",
-                    source_name,
-                    provider_arg.span(),
-                ));
-                return None;
-            }
-            None => {
-                diagnostics.push_error(DatamodelError::new_source_validation_error(
-                    "The provider argument in a datasource must be a string literal",
-                    source_name,
-                    provider_arg.span(),
-                ));
-                return None;
-            }
-            Some(provider) => provider,
-        };
-
-        let (_, url_arg) = match args.remove(URL_KEY) {
-            Some(url_arg) => url_arg,
-            None => {
-                diagnostics.push_error(DatamodelError::new_source_argument_not_found_error(
-                    URL_KEY,
-                    &ast_source.name.name,
-                    ast_source.span,
-                ));
-                return None;
-            }
-        };
-
-        let url = StringFromEnvVar::coerce(url_arg, diagnostics)?;
-        let shadow_database_url_arg = args.remove(SHADOW_DATABASE_URL_KEY);
-
-        let shadow_database_url: Option<(StringFromEnvVar, Span)> =
-            if let Some((_, shadow_database_url_arg)) = shadow_database_url_arg.as_ref() {
-                match StringFromEnvVar::coerce(shadow_database_url_arg, diagnostics) {
-                    Some(shadow_database_url) => Some(shadow_database_url)
-                        .filter(|s| !s.as_literal().map(|lit| lit.is_empty()).unwrap_or(false))
-                        .map(|url| (url, shadow_database_url_arg.span())),
-                    None => None,
-                }
-            } else {
-                None
-            };
-
-        preview_features_guardrail(&args, diagnostics);
-
-        let documentation = ast_source.documentation().map(String::from);
-        let referential_integrity = get_referential_integrity(&args, preview_features, ast_source, diagnostics);
-        let relation_mode = get_relation_mode(&args, preview_features, ast_source, diagnostics);
-
-        let active_connector: &'static dyn crate::datamodel_connector::Connector =
-            match connectors.iter().find(|c| c.is_provider(provider)) {
-                Some(c) => *c,
-                None => {
-                    diagnostics.push_error(DatamodelError::new_datasource_provider_not_known_error(
-                        provider,
-                        provider_arg.span(),
-                    ));
-
-                    return None;
-                }
-            };
-
-        // TODO: deprecated, keeping here since the "referentialIntegrity" preview feature
-        // is still silently supported.
-        if let Some(integrity) = referential_integrity {
-            if !active_connector.allowed_relation_mode_settings().contains(integrity) {
-                let span = args
-                    .get("referentialIntegrity")
-                    .map(|(_, v)| v.span())
-                    .unwrap_or_else(Span::empty);
-
-                let supported_values = active_connector
-                    .allowed_relation_mode_settings()
-                    .iter()
-                    .map(|v| format!(r#""{}""#, v))
-                    .collect::<Vec<_>>()
-                    .join(", ");
-
-                let message = format!(
-                    "Invalid referential integrity setting: \"{}\". Supported values: {}",
-                    integrity, supported_values,
-                );
-
-                let error = DatamodelError::new_source_validation_error(&message, "referentialIntegrity", span);
-
-                diagnostics.push_error(error);
-            }
-        }
-
-        if let Some(integrity) = relation_mode {
-            if !active_connector.allowed_relation_mode_settings().contains(integrity) {
-                let span = args
-                    .get("relationMode")
-                    .map(|(_, v)| v.span())
-                    .unwrap_or_else(Span::empty);
-
-                let supported_values = active_connector
-                    .allowed_relation_mode_settings()
-                    .iter()
-                    .map(|v| format!(r#""{}""#, v))
-                    .collect::<Vec<_>>()
-                    .join(", ");
-
-                let message = format!(
-                    "Invalid relation mode setting: \"{}\". Supported values: {}",
-                    integrity, supported_values,
-                );
-
-                let error = DatamodelError::new_source_validation_error(&message, "relationMode", span);
-
-                diagnostics.push_error(error);
-            }
-        }
-
-        let (schemas, schemas_span) = args
-            .remove(SCHEMAS_KEY)
-            .and_then(|(_, expr)| coerce_array(expr, &coerce::string_with_span, diagnostics).map(|b| (b, expr.span())))
-            .map(|(mut schemas, span)| {
-                schemas.sort_by(|(a, _), (b, _)| a.cmp(b));
-
-                for pair in schemas.windows(2) {
-                    if pair[0].0 == pair[1].0 {
-                        diagnostics.push_error(DatamodelError::new_static(
-                            "Duplicated schema names are not allowed",
-                            pair[0].1,
-                        ))
-                    }
-                }
-
-                (schemas, Some(span))
-            })
-            .unwrap_or_default();
-
-        // we handle these elsewhere
-        args.remove("previewFeatures");
-        args.remove("referentialIntegrity");
-        args.remove("relationMode");
-        for (name, (span, _)) in args.into_iter() {
-            diagnostics.push_error(DatamodelError::new_property_not_known_error(name, span));
-        }
-
-        Some(Datasource {
-            schemas: schemas.into_iter().map(|(s, span)| (s.to_owned(), span)).collect(),
-            schemas_span,
-            name: source_name.to_string(),
-            provider: provider.to_owned(),
-            active_provider: active_connector.provider_name(),
-            url,
-            url_span: url_arg.span(),
-            documentation,
-            active_connector,
-            shadow_database_url,
-            referential_integrity,
-            relation_mode,
-        })
+    if provider_arg.is_env_expression() {
+        let msg = Cow::Borrowed("A datasource must not use the env() function in the provider argument.");
+        diagnostics.push_error(DatamodelError::new_functional_evaluation_error(msg, ast_source.span));
+        return None;
     }
+
+    let provider = match coerce_opt::string(provider_arg) {
+        Some("") => {
+            diagnostics.push_error(DatamodelError::new_source_validation_error(
+                "The provider argument in a datasource must not be empty",
+                source_name,
+                provider_arg.span(),
+            ));
+            return None;
+        }
+        None => {
+            diagnostics.push_error(DatamodelError::new_source_validation_error(
+                "The provider argument in a datasource must be a string literal",
+                source_name,
+                provider_arg.span(),
+            ));
+            return None;
+        }
+        Some(provider) => provider,
+    };
+
+    let (_, url_arg) = match args.remove(URL_KEY) {
+        Some(url_arg) => url_arg,
+        None => {
+            diagnostics.push_error(DatamodelError::new_source_argument_not_found_error(
+                URL_KEY,
+                &ast_source.name.name,
+                ast_source.span,
+            ));
+            return None;
+        }
+    };
+
+    let url = StringFromEnvVar::coerce(url_arg, diagnostics)?;
+    let shadow_database_url_arg = args.remove(SHADOW_DATABASE_URL_KEY);
+
+    let shadow_database_url: Option<(StringFromEnvVar, Span)> =
+        if let Some((_, shadow_database_url_arg)) = shadow_database_url_arg.as_ref() {
+            match StringFromEnvVar::coerce(shadow_database_url_arg, diagnostics) {
+                Some(shadow_database_url) => Some(shadow_database_url)
+                    .filter(|s| !s.as_literal().map(|lit| lit.is_empty()).unwrap_or(false))
+                    .map(|url| (url, shadow_database_url_arg.span())),
+                None => None,
+            }
+        } else {
+            None
+        };
+
+    preview_features_guardrail(&args, diagnostics);
+
+    let documentation = ast_source.documentation().map(String::from);
+    let referential_integrity = get_referential_integrity(&args, preview_features, ast_source, diagnostics);
+    let relation_mode = get_relation_mode(&args, preview_features, ast_source, diagnostics);
+
+    let active_connector: &'static dyn crate::datamodel_connector::Connector =
+        match connectors.iter().find(|c| c.is_provider(provider)) {
+            Some(c) => *c,
+            None => {
+                diagnostics.push_error(DatamodelError::new_datasource_provider_not_known_error(
+                    provider,
+                    provider_arg.span(),
+                ));
+
+                return None;
+            }
+        };
+
+    // TODO: deprecated, keeping here since the "referentialIntegrity" preview feature
+    // is still silently supported.
+    if let Some(integrity) = referential_integrity {
+        if !active_connector.allowed_relation_mode_settings().contains(integrity) {
+            let span = args
+                .get("referentialIntegrity")
+                .map(|(_, v)| v.span())
+                .unwrap_or_else(Span::empty);
+
+            let supported_values = active_connector
+                .allowed_relation_mode_settings()
+                .iter()
+                .map(|v| format!(r#""{}""#, v))
+                .collect::<Vec<_>>()
+                .join(", ");
+
+            let message = format!(
+                "Invalid referential integrity setting: \"{}\". Supported values: {}",
+                integrity, supported_values,
+            );
+
+            let error = DatamodelError::new_source_validation_error(&message, "referentialIntegrity", span);
+
+            diagnostics.push_error(error);
+        }
+    }
+
+    if let Some(integrity) = relation_mode {
+        if !active_connector.allowed_relation_mode_settings().contains(integrity) {
+            let span = args
+                .get("relationMode")
+                .map(|(_, v)| v.span())
+                .unwrap_or_else(Span::empty);
+
+            let supported_values = active_connector
+                .allowed_relation_mode_settings()
+                .iter()
+                .map(|v| format!(r#""{}""#, v))
+                .collect::<Vec<_>>()
+                .join(", ");
+
+            let message = format!(
+                "Invalid relation mode setting: \"{}\". Supported values: {}",
+                integrity, supported_values,
+            );
+
+            let error = DatamodelError::new_source_validation_error(&message, "relationMode", span);
+
+            diagnostics.push_error(error);
+        }
+    }
+
+    let (schemas, schemas_span) = args
+        .remove(SCHEMAS_KEY)
+        .and_then(|(_, expr)| coerce_array(expr, &coerce::string_with_span, diagnostics).map(|b| (b, expr.span())))
+        .map(|(mut schemas, span)| {
+            schemas.sort_by(|(a, _), (b, _)| a.cmp(b));
+
+            for pair in schemas.windows(2) {
+                if pair[0].0 == pair[1].0 {
+                    diagnostics.push_error(DatamodelError::new_static(
+                        "Duplicated schema names are not allowed",
+                        pair[0].1,
+                    ))
+                }
+            }
+
+            (schemas, Some(span))
+        })
+        .unwrap_or_default();
+
+    // we handle these elsewhere
+    args.remove("previewFeatures");
+    args.remove("referentialIntegrity");
+    args.remove("relationMode");
+    for (name, (span, _)) in args.into_iter() {
+        diagnostics.push_error(DatamodelError::new_property_not_known_error(name, span));
+    }
+
+    Some(Datasource {
+        schemas: schemas.into_iter().map(|(s, span)| (s.to_owned(), span)).collect(),
+        schemas_span,
+        name: source_name.to_string(),
+        provider: provider.to_owned(),
+        active_provider: active_connector.provider_name(),
+        url,
+        url_span: url_arg.span(),
+        documentation,
+        active_connector,
+        shadow_database_url,
+        referential_integrity,
+        relation_mode,
+    })
 }
 
 const REFERENTIAL_INTEGRITY_PREVIEW_FEATURE_ERR: &str = r#"

--- a/psl/psl-core/src/validate/generator_loader.rs
+++ b/psl/psl-core/src/validate/generator_loader.rs
@@ -27,97 +27,93 @@ const FIRST_CLASS_PROPERTIES: &[&str] = &[
     PREVIEW_FEATURES_KEY,
 ];
 
-/// Is responsible for loading and validating Generators defined in an AST.
-pub(crate) struct GeneratorLoader;
+/// Load and validate Generators defined in an AST.
+pub(crate) fn load_generators_from_ast(ast_schema: &ast::SchemaAst, diagnostics: &mut Diagnostics) -> Vec<Generator> {
+    let mut generators: Vec<Generator> = Vec::new();
 
-impl GeneratorLoader {
-    pub fn load_generators_from_ast(ast_schema: &ast::SchemaAst, diagnostics: &mut Diagnostics) -> Vec<Generator> {
-        let mut generators: Vec<Generator> = Vec::new();
-
-        for gen in ast_schema.generators() {
-            if let Some(generator) = Self::lift_generator(gen, diagnostics) {
-                generators.push(generator)
-            }
+    for gen in ast_schema.generators() {
+        if let Some(generator) = lift_generator(gen, diagnostics) {
+            generators.push(generator)
         }
-
-        generators
     }
 
-    fn lift_generator(ast_generator: &ast::GeneratorConfig, diagnostics: &mut Diagnostics) -> Option<Generator> {
-        let args: HashMap<_, _> = ast_generator
-            .properties
-            .iter()
-            .map(|arg| (arg.name.name.as_str(), &arg.value))
-            .collect();
+    generators
+}
 
-        if let Some(expr) = args.get(ENGINE_TYPE_KEY) {
-            if !expr.is_string() {
-                diagnostics.push_error(DatamodelError::new_type_mismatch_error(
-                    "String",
-                    expr.describe_value_type(),
-                    &expr.to_string(),
-                    expr.span(),
-                ))
-            }
+fn lift_generator(ast_generator: &ast::GeneratorConfig, diagnostics: &mut Diagnostics) -> Option<Generator> {
+    let args: HashMap<_, _> = ast_generator
+        .properties
+        .iter()
+        .map(|arg| (arg.name.name.as_str(), &arg.value))
+        .collect();
+
+    if let Some(expr) = args.get(ENGINE_TYPE_KEY) {
+        if !expr.is_string() {
+            diagnostics.push_error(DatamodelError::new_type_mismatch_error(
+                "String",
+                expr.describe_value_type(),
+                &expr.to_string(),
+                expr.span(),
+            ))
+        }
+    }
+
+    let provider = match args.get(PROVIDER_KEY) {
+        Some(val) => StringFromEnvVar::coerce(val, diagnostics)?,
+        None => {
+            diagnostics.push_error(DatamodelError::new_generator_argument_not_found_error(
+                PROVIDER_KEY,
+                &ast_generator.name.name,
+                ast_generator.span(),
+            ));
+            return None;
+        }
+    };
+
+    let output = args
+        .get(OUTPUT_KEY)
+        .and_then(|v| StringFromEnvVar::coerce(v, diagnostics));
+
+    let mut properties: HashMap<String, String> = HashMap::new();
+
+    let binary_targets = args
+        .get(BINARY_TARGETS_KEY)
+        .and_then(|arg| coerce_array(arg, &StringFromEnvVar::coerce, diagnostics))
+        .unwrap_or_default();
+
+    // for compatibility reasons we still accept the old experimental key
+    let preview_features = args
+        .get(PREVIEW_FEATURES_KEY)
+        .or_else(|| args.get(EXPERIMENTAL_FEATURES_KEY))
+        .and_then(|v| coerce_array(v, &coerce::string, diagnostics).map(|arr| (arr, v.span())))
+        .map(|(arr, span)| parse_and_validate_preview_features(arr, &GENERATOR, span, diagnostics));
+
+    for prop in &ast_generator.properties {
+        let is_first_class_prop = FIRST_CLASS_PROPERTIES.iter().any(|k| *k == prop.name.name);
+        if is_first_class_prop {
+            continue;
         }
 
-        let provider = match args.get(PROVIDER_KEY) {
-            Some(val) => StringFromEnvVar::coerce(val, diagnostics)?,
-            None => {
-                diagnostics.push_error(DatamodelError::new_generator_argument_not_found_error(
-                    PROVIDER_KEY,
-                    &ast_generator.name.name,
-                    ast_generator.span(),
-                ));
-                return None;
-            }
+        let value = match &prop.value {
+            ast::Expression::NumericValue(val, _) => val.clone(),
+            ast::Expression::StringValue(val, _) => val.clone(),
+            ast::Expression::ConstantValue(val, _) => val.clone(),
+            ast::Expression::Function(_, _, _) => String::from("(function)"),
+            ast::Expression::Array(_, _) => String::from("(array)"),
         };
 
-        let output = args
-            .get(OUTPUT_KEY)
-            .and_then(|v| StringFromEnvVar::coerce(v, diagnostics));
-
-        let mut properties: HashMap<String, String> = HashMap::new();
-
-        let binary_targets = args
-            .get(BINARY_TARGETS_KEY)
-            .and_then(|arg| coerce_array(arg, &StringFromEnvVar::coerce, diagnostics))
-            .unwrap_or_default();
-
-        // for compatibility reasons we still accept the old experimental key
-        let preview_features = args
-            .get(PREVIEW_FEATURES_KEY)
-            .or_else(|| args.get(EXPERIMENTAL_FEATURES_KEY))
-            .and_then(|v| coerce_array(v, &coerce::string, diagnostics).map(|arr| (arr, v.span())))
-            .map(|(arr, span)| parse_and_validate_preview_features(arr, &GENERATOR, span, diagnostics));
-
-        for prop in &ast_generator.properties {
-            let is_first_class_prop = FIRST_CLASS_PROPERTIES.iter().any(|k| *k == prop.name.name);
-            if is_first_class_prop {
-                continue;
-            }
-
-            let value = match &prop.value {
-                ast::Expression::NumericValue(val, _) => val.clone(),
-                ast::Expression::StringValue(val, _) => val.clone(),
-                ast::Expression::ConstantValue(val, _) => val.clone(),
-                ast::Expression::Function(_, _, _) => String::from("(function)"),
-                ast::Expression::Array(_, _) => String::from("(array)"),
-            };
-
-            properties.insert(prop.name.name.clone(), value);
-        }
-
-        Some(Generator {
-            name: ast_generator.name.name.clone(),
-            provider,
-            output,
-            binary_targets,
-            preview_features,
-            config: properties,
-            documentation: ast_generator.documentation().map(String::from),
-        })
+        properties.insert(prop.name.name.clone(), value);
     }
+
+    Some(Generator {
+        name: ast_generator.name.name.clone(),
+        provider,
+        output,
+        binary_targets,
+        preview_features,
+        config: properties,
+        documentation: ast_generator.documentation().map(String::from),
+    })
 }
 
 fn parse_and_validate_preview_features(


### PR DESCRIPTION
We save no state in the loader, and hopefully will not be. Also it looks much better if we just call `module::function` instead of `Struct.function`.

Opportunistic refactoring, while reading the code.