### PR TITLE
ie: check that invalid schemas cannot be reintropsection inputs

### DIFF
--- a/introspection-engine/core/src/rpc.rs
+++ b/introspection-engine/core/src/rpc.rs
@@ -104,11 +104,13 @@ impl RpcImpl {
         composite_type_depth: CompositeTypeDepth,
     ) -> RpcResult<IntrospectionResultOutput> {
         let (_config, _url, connector) = RpcImpl::load_connector(&schema).await?;
-        let previous_schema = psl::validate(psl::SourceFile::new_allocated(Arc::from(schema.into_boxed_str())));
+        let source = psl::SourceFile::new_allocated(Arc::from(schema.into_boxed_str()));
 
         let ctx = if force {
+            let previous_schema = psl::validate(source);
             IntrospectionContext::new_config_only(previous_schema, composite_type_depth)
         } else {
+            let previous_schema = psl::parse_schema(source).map_err(Error::DatamodelError)?;
             IntrospectionContext::new(previous_schema, composite_type_depth)
         };
 

--- a/introspection-engine/introspection-engine-tests/tests/introspect/mod.rs
+++ b/introspection-engine/introspection-engine-tests/tests/introspect/mod.rs
@@ -51,3 +51,50 @@ fn introspect_force_with_invalid_schema() {
 
     expected.assert_eq(result);
 }
+
+#[test]
+fn introspect_no_force_with_invalid_schema() {
+    test_setup::only!(Sqlite);
+
+    let db_path = test_setup::sqlite_test_url("introspect_no_force_with_invalid_schema");
+
+    {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute_batch("CREATE TABLE corgis (bites BOOLEAN)").unwrap();
+    }
+
+    let schema = format!(
+        r#"
+        datasource sqlitedb {{
+            provider = "sqlite"
+            url = "{db_path}"
+        }}
+
+        model This_Is_Blatantly_Not_Valid_and_An_Outrage {{
+            pk Bytes @unknownAttributeThisIsNotValid
+        }}
+    "#
+    );
+
+    let result = &tok(introspection_core::RpcImpl::introspect_internal(
+        schema,
+        false,
+        Default::default(),
+    ))
+    .unwrap_err()
+    .data
+    .unwrap();
+
+    let expected = expect![[r#"
+        Object {
+            "is_panic": Bool(false),
+            "message": String("\u{1b}[1;91merror\u{1b}[0m: \u{1b}[1mAttribute not known: \"@unknownAttributeThisIsNotValid\".\u{1b}[0m\n  \u{1b}[1;94m-->\u{1b}[0m  \u{1b}[4mschema.prisma:8\u{1b}[0m\n\u{1b}[1;94m   | \u{1b}[0m\n\u{1b}[1;94m 7 | \u{1b}[0m        model This_Is_Blatantly_Not_Valid_and_An_Outrage {\n\u{1b}[1;94m 8 | \u{1b}[0m            pk Bytes \u{1b}[1;91m@unknownAttributeThisIsNotValid\u{1b}[0m\n\u{1b}[1;94m   | \u{1b}[0m\n"),
+            "meta": Object {
+                "full_error": String("\u{1b}[1;91merror\u{1b}[0m: \u{1b}[1mAttribute not known: \"@unknownAttributeThisIsNotValid\".\u{1b}[0m\n  \u{1b}[1;94m-->\u{1b}[0m  \u{1b}[4mschema.prisma:8\u{1b}[0m\n\u{1b}[1;94m   | \u{1b}[0m\n\u{1b}[1;94m 7 | \u{1b}[0m        model This_Is_Blatantly_Not_Valid_and_An_Outrage {\n\u{1b}[1;94m 8 | \u{1b}[0m            pk Bytes \u{1b}[1;91m@unknownAttributeThisIsNotValid\u{1b}[0m\n\u{1b}[1;94m   | \u{1b}[0m\n"),
+            },
+            "error_code": String("P1012"),
+        }
+    "#]];
+
+    expected.assert_debug_eq(result);
+}


### PR DESCRIPTION
follow up to 25711b8caf58c63dc7773c928592d1b8662ed6df

Without --force, PSL validation errors outside of the config blocks should prevent (re)introspection.