### PR TITLE
chore: revert relationMode preview feature flag to referentialIntegrity

### DIFF
--- a/introspection-engine/introspection-engine-tests/src/test_api.rs
+++ b/introspection-engine/introspection-engine-tests/src/test_api.rs
@@ -236,7 +236,7 @@ impl TestApi {
     }
 
     pub fn datasource_block(&self) -> DatasourceBlock<'_> {
-        let no_foreign_keys = self.is_vitess() && self.preview_features().contains(PreviewFeature::RelationMode);
+        let no_foreign_keys = self.is_vitess() && self.preview_features().contains(PreviewFeature::ReferentialIntegrity);
 
         if no_foreign_keys {
             self.args

--- a/introspection-engine/introspection-engine-tests/src/test_api.rs
+++ b/introspection-engine/introspection-engine-tests/src/test_api.rs
@@ -236,7 +236,8 @@ impl TestApi {
     }
 
     pub fn datasource_block(&self) -> DatasourceBlock<'_> {
-        let no_foreign_keys = self.is_vitess() && self.preview_features().contains(PreviewFeature::ReferentialIntegrity);
+        let no_foreign_keys =
+            self.is_vitess() && self.preview_features().contains(PreviewFeature::ReferentialIntegrity);
 
         if no_foreign_keys {
             self.args

--- a/introspection-engine/introspection-engine-tests/tests/re_introspection/mysql.rs
+++ b/introspection-engine/introspection-engine-tests/tests/re_introspection/mysql.rs
@@ -2,7 +2,7 @@ use barrel::types;
 use indoc::indoc;
 use introspection_engine_tests::test_api::*;
 
-#[test_connector(tags(Mysql), exclude(Vitess), preview_features("relationMode"))]
+#[test_connector(tags(Mysql), exclude(Vitess), preview_features("referentialIntegrity"))]
 async fn relation_mode_parameter_is_not_added(api: &TestApi) -> TestResult {
     let result = api.re_introspect("").await?;
     assert!(!result.contains(r#"relationMode = "#));

--- a/introspection-engine/introspection-engine-tests/tests/re_introspection/vitess.rs
+++ b/introspection-engine/introspection-engine-tests/tests/re_introspection/vitess.rs
@@ -4,7 +4,7 @@ use introspection_engine_tests::test_api::*;
 use quaint::prelude::Queryable;
 use test_macros::test_connector;
 
-#[test_connector(tags(Vitess), preview_features("relationMode"))]
+#[test_connector(tags(Vitess), preview_features("referentialIntegrity"))]
 async fn relation_mode_parameter_is_not_removed(api: &TestApi) -> TestResult {
     let result = api.re_introspect("").await?;
     assert!(result.contains(r#"relationMode = "prisma""#));
@@ -12,7 +12,7 @@ async fn relation_mode_parameter_is_not_removed(api: &TestApi) -> TestResult {
     Ok(())
 }
 
-#[test_connector(tags(Vitess), preview_features("relationMode"))]
+#[test_connector(tags(Vitess), preview_features("referentialIntegrity"))]
 async fn relations_are_not_removed(api: &TestApi) -> TestResult {
     let dml = indoc! {r#"
         CREATE TABLE `A` (
@@ -58,7 +58,7 @@ async fn relations_are_not_removed(api: &TestApi) -> TestResult {
     Ok(())
 }
 
-#[test_connector(tags(Vitess), preview_features("relationMode"))]
+#[test_connector(tags(Vitess), preview_features("referentialIntegrity"))]
 async fn warning_is_given_for_copied_relations(api: &TestApi) -> TestResult {
     let dml = indoc! {r#"
         CREATE TABLE `A` (
@@ -108,7 +108,7 @@ async fn warning_is_given_for_copied_relations(api: &TestApi) -> TestResult {
     Ok(())
 }
 
-#[test_connector(tags(Vitess), preview_features("relationMode"))]
+#[test_connector(tags(Vitess), preview_features("referentialIntegrity"))]
 async fn no_warnings_are_given_for_if_no_relations_were_copied(api: &TestApi) -> TestResult {
     let dml = indoc! {r#"
         CREATE TABLE `A` (
@@ -141,7 +141,7 @@ async fn no_warnings_are_given_for_if_no_relations_were_copied(api: &TestApi) ->
     Ok(())
 }
 
-#[test_connector(tags(Vitess), preview_features("relationMode"))]
+#[test_connector(tags(Vitess), preview_features("referentialIntegrity"))]
 async fn relations_field_order_is_kept(api: &TestApi) -> TestResult {
     let dml = indoc! {r#"
         CREATE TABLE `A` (
@@ -187,7 +187,7 @@ async fn relations_field_order_is_kept(api: &TestApi) -> TestResult {
     Ok(())
 }
 
-#[test_connector(tags(Vitess), preview_features("relationMode"))]
+#[test_connector(tags(Vitess), preview_features("referentialIntegrity"))]
 async fn relations_field_order_is_kept_if_having_new_fields(api: &TestApi) -> TestResult {
     let dml = indoc! {r#"
         CREATE TABLE `A` (
@@ -235,7 +235,7 @@ async fn relations_field_order_is_kept_if_having_new_fields(api: &TestApi) -> Te
     Ok(())
 }
 
-#[test_connector(tags(Vitess), preview_features("relationMode"))]
+#[test_connector(tags(Vitess), preview_features("referentialIntegrity"))]
 async fn relations_field_order_is_kept_if_removing_fields(api: &TestApi) -> TestResult {
     let dml = indoc! {r#"
         CREATE TABLE `A` (
@@ -282,7 +282,7 @@ async fn relations_field_order_is_kept_if_removing_fields(api: &TestApi) -> Test
     Ok(())
 }
 
-#[test_connector(tags(Vitess), preview_features("relationMode"))]
+#[test_connector(tags(Vitess), preview_features("referentialIntegrity"))]
 async fn deleting_models_will_delete_relations(api: &TestApi) -> TestResult {
     let dml = indoc! {r#"
         CREATE TABLE `A` (
@@ -335,7 +335,7 @@ async fn deleting_models_will_delete_relations(api: &TestApi) -> TestResult {
     Ok(())
 }
 
-#[test_connector(tags(Vitess), preview_features("relationMode"))]
+#[test_connector(tags(Vitess), preview_features("referentialIntegrity"))]
 async fn field_renames_keeps_the_relation_intact(api: &TestApi) -> TestResult {
     let dml = indoc! {r#"
         CREATE TABLE `A` (
@@ -381,7 +381,7 @@ async fn field_renames_keeps_the_relation_intact(api: &TestApi) -> TestResult {
     Ok(())
 }
 
-#[test_connector(tags(Vitess), preview_features("relationMode"))]
+#[test_connector(tags(Vitess), preview_features("referentialIntegrity"))]
 async fn referential_actions_are_kept_intact(api: &TestApi) -> TestResult {
     let dml = indoc! {r#"
         CREATE TABLE `A` (

--- a/migration-engine/migration-engine-tests/src/test_api.rs
+++ b/migration-engine/migration-engine-tests/src/test_api.rs
@@ -305,7 +305,7 @@ impl TestApi {
 
     /// Render a valid datasource block, including database URL.
     pub fn write_datasource_block(&self, out: &mut dyn std::fmt::Write) {
-        let no_foreign_keys = self.is_vitess() && self.root.preview_features().contains(PreviewFeature::RelationMode);
+        let no_foreign_keys = self.is_vitess() && self.root.preview_features().contains(PreviewFeature::ReferentialIntegrity);
 
         let params = if no_foreign_keys {
             vec![("relationMode", r#""prisma""#)]

--- a/migration-engine/migration-engine-tests/src/test_api.rs
+++ b/migration-engine/migration-engine-tests/src/test_api.rs
@@ -305,7 +305,11 @@ impl TestApi {
 
     /// Render a valid datasource block, including database URL.
     pub fn write_datasource_block(&self, out: &mut dyn std::fmt::Write) {
-        let no_foreign_keys = self.is_vitess() && self.root.preview_features().contains(PreviewFeature::ReferentialIntegrity);
+        let no_foreign_keys = self.is_vitess()
+            && self
+                .root
+                .preview_features()
+                .contains(PreviewFeature::ReferentialIntegrity);
 
         let params = if no_foreign_keys {
             vec![("relationMode", r#""prisma""#)]

--- a/migration-engine/migration-engine-tests/tests/existing_data/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_data/mod.rs
@@ -779,7 +779,7 @@ fn set_default_current_timestamp_on_existing_column_works(api: TestApi) {
 }
 
 // exclude: there is a cockroach-specific test. It's unexecutable there.
-#[test_connector(preview_features("relationMode"), exclude(CockroachDb))]
+#[test_connector(preview_features("referentialIntegrity"), exclude(CockroachDb))]
 fn primary_key_migrations_do_not_cause_data_loss(api: TestApi) {
     let dm1 = r#"
         model Dog {

--- a/migration-engine/migration-engine-tests/tests/migrations/basic.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/basic.rs
@@ -52,7 +52,7 @@ fn adding_multiple_optional_fields_to_an_existing_model_works(api: TestApi) {
     });
 }
 
-#[test_connector(preview_features("relationMode"))]
+#[test_connector(preview_features("referentialIntegrity"))]
 fn a_model_can_be_removed(api: TestApi) {
     let directory = api.create_migrations_directory();
 

--- a/migration-engine/migration-engine-tests/tests/migrations/basic/vitess.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/basic/vitess.rs
@@ -1,6 +1,6 @@
 use migration_engine_tests::test_api::*;
 
-#[test_connector(tags(Vitess), preview_features("relationMode"))]
+#[test_connector(tags(Vitess), preview_features("referentialIntegrity"))]
 fn reordering_and_altering_models_at_the_same_time_works(api: TestApi) {
     let dm1 = r#"
         model A {

--- a/migration-engine/migration-engine-tests/tests/migrations/enums.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/enums.rs
@@ -82,7 +82,7 @@ fn adding_an_enum_field_must_work_with_native_types_off(api: TestApi) {
     api.schema_push_w_datasource(dm).send().assert_no_steps();
 }
 
-#[test_connector(capabilities(Enums), preview_features("relationMode"))]
+#[test_connector(capabilities(Enums), preview_features("referentialIntegrity"))]
 fn an_enum_can_be_turned_into_a_model(api: TestApi) {
     api.schema_push_w_datasource(BASIC_ENUM_DM).send().assert_green();
 

--- a/migration-engine/migration-engine-tests/tests/migrations/foreign_keys.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/foreign_keys.rs
@@ -1,7 +1,7 @@
 use migration_engine_tests::test_api::*;
 use sql_schema_describer::ForeignKeyAction;
 
-#[test_connector(preview_features("relationMode"))]
+#[test_connector(preview_features("referentialIntegrity"))]
 fn foreign_keys_of_inline_one_to_one_relations_have_a_unique_constraint(api: TestApi) {
     let dm = r#"
         model Cat {
@@ -284,7 +284,7 @@ fn changing_a_foreign_key_constrained_column_from_nullable_to_required_and_back_
     api.schema_push_w_datasource(dm).send().assert_green();
 }
 
-#[test_connector(exclude(CockroachDb), preview_features("relationMode"))]
+#[test_connector(exclude(CockroachDb), preview_features("referentialIntegrity"))]
 fn changing_all_referenced_columns_of_foreign_key_works(api: TestApi) {
     let dm1 = r#"
        model Post {

--- a/migration-engine/migration-engine-tests/tests/migrations/id.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/id.rs
@@ -154,7 +154,7 @@ fn changing_the_type_of_an_id_field_must_work(api: TestApi) {
     });
 }
 
-#[test_connector(exclude(Sqlite, CockroachDb), preview_features("relationMode"))]
+#[test_connector(exclude(Sqlite, CockroachDb), preview_features("referentialIntegrity"))]
 fn models_with_an_autoincrement_field_as_part_of_a_multi_field_id_can_be_created(api: TestApi) {
     let dm = r#"
         model List {

--- a/migration-engine/migration-engine-tests/tests/migrations/id/cockroachdb.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/id/cockroachdb.rs
@@ -23,7 +23,7 @@ fn flipping_autoincrement_on_and_off_works(api: TestApi) {
     }
 }
 
-#[test_connector(tags(CockroachDb), preview_features("relationMode"))]
+#[test_connector(tags(CockroachDb), preview_features("referentialIntegrity"))]
 fn models_with_an_autoincrement_field_as_part_of_a_multi_field_id_can_be_created(api: TestApi) {
     let dm = r#"
         model List {

--- a/migration-engine/migration-engine-tests/tests/migrations/id/vitess.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/id/vitess.rs
@@ -1,6 +1,6 @@
 use migration_engine_tests::test_api::*;
 
-#[test_connector(tags(Vitess), preview_features("relationMode"))]
+#[test_connector(tags(Vitess), preview_features("referentialIntegrity"))]
 fn changing_the_type_of_an_id_field_must_work(api: TestApi) {
     let dm1 = r#"
         model A {

--- a/migration-engine/migration-engine-tests/tests/migrations/indexes.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/indexes.rs
@@ -6,7 +6,7 @@ use indoc::{formatdoc, indoc};
 use migration_engine_tests::test_api::*;
 use sql_schema_describer::SQLSortOrder;
 
-#[test_connector(preview_features("relationMode"))]
+#[test_connector(preview_features("referentialIntegrity"))]
 fn index_on_compound_relation_fields_must_work(api: TestApi) {
     let dm = r#"
         model User {
@@ -84,7 +84,7 @@ fn index_settings_must_be_migrated(api: TestApi) {
     });
 }
 
-#[test_connector(preview_features("relationMode"))]
+#[test_connector(preview_features("referentialIntegrity"))]
 fn unique_directive_on_required_one_to_one_relation_creates_one_index(api: TestApi) {
     // We want to test that only one index is created, because of the implicit unique index on
     // required 1:1 relations.
@@ -133,7 +133,7 @@ fn one_to_many_self_relations_do_not_create_a_unique_index(api: TestApi) {
     }
 }
 
-#[test_connector(preview_features("relationMode"))]
+#[test_connector(preview_features("referentialIntegrity"))]
 fn model_with_multiple_indexes_works(api: TestApi) {
     let dm = r#"
     model User {
@@ -425,7 +425,7 @@ fn indexes_with_an_automatically_truncated_name_are_idempotent(api: TestApi) {
     api.schema_push_w_datasource(dm).send().assert_green().assert_no_steps();
 }
 
-#[test_connector(preview_features("relationMode"))]
+#[test_connector(preview_features("referentialIntegrity"))]
 fn new_index_with_same_name_as_index_from_dropped_table_works(api: TestApi) {
     let dm1 = r#"
         model Cat {

--- a/migration-engine/migration-engine-tests/tests/migrations/relation_mode.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/relation_mode.rs
@@ -8,7 +8,7 @@ fn schema_push_referential_integrity_prisma_works(api: TestApi) {
 
         generator client {{
             provider = "prisma-client-js"
-            previewFeatures = ["relationMode"]
+            previewFeatures = ["referentialIntegrity"]
         }}
 
         model Post {{
@@ -54,7 +54,7 @@ fn create_migration_referential_integrity_prisma_works(api: TestApi) {
 
         generator client {{
             provider = "prisma-client-js"
-            previewFeatures = ["relationMode"]
+            previewFeatures = ["referentialIntegrity"]
         }}
 
         model Post {{
@@ -117,7 +117,7 @@ fn switching_from_foreign_keys_to_prisma_integrity_drops_the_foreign_keys(api: T
 
         generator client {{
             provider = "prisma-client-js"
-            previewFeatures = ["relationMode"]
+            previewFeatures = ["referentialIntegrity"]
         }}
 
         model A {{
@@ -145,7 +145,7 @@ fn switching_from_foreign_keys_to_prisma_integrity_drops_the_foreign_keys(api: T
 
         generator client {{
             provider = "prisma-client-js"
-            previewFeatures = ["relationMode"]
+            previewFeatures = ["referentialIntegrity"]
         }}
 
         model A {{
@@ -176,7 +176,7 @@ fn switching_from_prisma_integrity_to_foreign_keys_drops_the_foreign_keys(api: T
 
         generator client {{
             provider = "prisma-client-js"
-            previewFeatures = ["relationMode"]
+            previewFeatures = ["referentialIntegrity"]
         }}
 
         model A {{
@@ -204,7 +204,7 @@ fn switching_from_prisma_integrity_to_foreign_keys_drops_the_foreign_keys(api: T
 
         generator client {{
             provider = "prisma-client-js"
-            previewFeatures = ["relationMode"]
+            previewFeatures = ["referentialIntegrity"]
         }}
 
         model A {{

--- a/migration-engine/migration-engine-tests/tests/migrations/relations.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/relations.rs
@@ -968,7 +968,7 @@ fn adding_mutual_references_on_existing_tables_works(api: TestApi) {
     };
 }
 
-#[test_connector(preview_features("relationMode"))]
+#[test_connector(preview_features("referentialIntegrity"))]
 fn migrations_with_many_to_many_related_models_must_not_recreate_indexes(api: TestApi) {
     // test case for https://github.com/prisma/lift/issues/148
     let dm_1 = r#"
@@ -1029,7 +1029,7 @@ fn migrations_with_many_to_many_related_models_must_not_recreate_indexes(api: Te
         .assert_no_steps();
 }
 
-#[test_connector(preview_features("relationMode"))]
+#[test_connector(preview_features("referentialIntegrity"))]
 fn removing_a_relation_field_must_work(api: TestApi) {
     let dm_1 = r#"
         model User {

--- a/migration-engine/migration-engine-tests/tests/migrations/relations/vitess.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/relations/vitess.rs
@@ -1,6 +1,6 @@
 use migration_engine_tests::test_api::*;
 
-#[test_connector(tags(Vitess), preview_features("relationMode"))]
+#[test_connector(tags(Vitess), preview_features("referentialIntegrity"))]
 fn adding_mutual_references_on_existing_tables_works(api: TestApi) {
     let dm1 = r#"
         model A {

--- a/migration-engine/migration-engine-tests/tests/migrations/sql.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/sql.rs
@@ -345,7 +345,7 @@ fn remapped_multi_field_id_as_part_of_relation_must_work(api: TestApi) {
     });
 }
 
-#[test_connector(preview_features("relationMode"))]
+#[test_connector(preview_features("referentialIntegrity"))]
 fn unique_constraints_on_composite_relation_fields(api: TestApi) {
     let dm = r##"
         model Parent {
@@ -374,7 +374,7 @@ fn unique_constraints_on_composite_relation_fields(api: TestApi) {
     });
 }
 
-#[test_connector(preview_features("relationMode"))]
+#[test_connector(preview_features("referentialIntegrity"))]
 fn indexes_on_composite_relation_fields(api: TestApi) {
     let dm = r##"
         model User {
@@ -403,7 +403,7 @@ fn indexes_on_composite_relation_fields(api: TestApi) {
     });
 }
 
-#[test_connector(exclude(Vitess), preview_features("relationMode"))]
+#[test_connector(exclude(Vitess), preview_features("referentialIntegrity"))]
 fn dropping_mutually_referencing_tables_works(api: TestApi) {
     let dm1 = r#"
     model A {

--- a/migration-engine/migration-engine-tests/tests/migrations/sql/vitess.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/sql/vitess.rs
@@ -1,6 +1,6 @@
 use migration_engine_tests::test_api::*;
 
-#[test_connector(tags(Vitess), preview_features("relationMode"))]
+#[test_connector(tags(Vitess), preview_features("referentialIntegrity"))]
 fn dropping_mutually_referencing_tables_works(api: TestApi) {
     let dm1 = r#"
     model A {

--- a/migration-engine/migration-engine-tests/tests/native_types/common.rs
+++ b/migration-engine/migration-engine-tests/tests/native_types/common.rs
@@ -1,6 +1,6 @@
 use migration_engine_tests::test_api::*;
 
-#[test_connector(exclude(CockroachDb), preview_features("relationMode"))]
+#[test_connector(exclude(CockroachDb), preview_features("referentialIntegrity"))]
 fn typescript_starter_schema_is_idempotent_without_native_type_annotations(api: TestApi) {
     let dm = r#"
         model Post {

--- a/migration-engine/migration-engine-tests/tests/native_types/mysql.rs
+++ b/migration-engine/migration-engine-tests/tests/native_types/mysql.rs
@@ -909,7 +909,7 @@ fn impossible_casts_with_existing_data_should_warn(api: TestApi) {
     }
 }
 
-#[test_connector(tags(Mysql), preview_features("relationMode"))]
+#[test_connector(tags(Mysql), preview_features("referentialIntegrity"))]
 fn typescript_starter_schema_with_native_types_is_idempotent(api: TestApi) {
     let dm = r#"
         model Post {
@@ -965,7 +965,7 @@ fn typescript_starter_schema_with_native_types_is_idempotent(api: TestApi) {
         .assert_no_steps();
 }
 
-#[test_connector(tags(Mysql), preview_features("relationMode"))]
+#[test_connector(tags(Mysql), preview_features("referentialIntegrity"))]
 fn typescript_starter_schema_with_different_native_types_is_idempotent(api: TestApi) {
     let dm = r#"
         model Post {

--- a/migration-engine/migration-engine-tests/tests/schema_push/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/schema_push/mod.rs
@@ -16,7 +16,7 @@ model Box {
 }
 "#;
 
-#[test_connector(preview_features("relationMode"))]
+#[test_connector(preview_features("referentialIntegrity"))]
 fn schema_push_happy_path(api: TestApi) {
     api.schema_push_w_datasource(SCHEMA)
         .send()
@@ -62,7 +62,7 @@ fn schema_push_happy_path(api: TestApi) {
         });
 }
 
-#[test_connector(preview_features("relationMode"))]
+#[test_connector(preview_features("referentialIntegrity"))]
 fn schema_push_warns_about_destructive_changes(api: TestApi) {
     api.schema_push_w_datasource(SCHEMA)
         .send()
@@ -97,7 +97,7 @@ fn schema_push_warns_about_destructive_changes(api: TestApi) {
         .assert_has_executed_steps();
 }
 
-#[test_connector(preview_features("relationMode"))]
+#[test_connector(preview_features("referentialIntegrity"))]
 fn schema_push_with_an_unexecutable_migration_returns_a_message_and_aborts(api: TestApi) {
     api.schema_push_w_datasource(SCHEMA)
         .send()

--- a/psl/psl-core/src/common/preview_features.rs
+++ b/psl/psl-core/src/common/preview_features.rs
@@ -108,10 +108,7 @@ pub const GENERATOR: FeatureMap = FeatureMap {
         | ImprovedQueryRaw
         | DataProxy
     }),
-    hidden: enumflags2::make_bitflags!(PreviewFeature::{
-        MultiSchema
-        | ReferentialIntegrity
-    }),
+    hidden: enumflags2::make_bitflags!(PreviewFeature::{MultiSchema}),
 };
 
 #[derive(Debug)]

--- a/psl/psl-core/src/common/preview_features.rs
+++ b/psl/psl-core/src/common/preview_features.rs
@@ -52,7 +52,6 @@ features!(
     OrderByAggregateGroup,
     FilterJson,
     ReferentialIntegrity,
-    RelationMode,
     ReferentialActions,
     InteractiveTransactions,
     NamedConstraints,
@@ -73,7 +72,7 @@ features!(
 /// Generator preview features
 pub const GENERATOR: FeatureMap = FeatureMap {
     active: enumflags2::make_bitflags!(PreviewFeature::{
-        RelationMode
+        ReferentialIntegrity
          | InteractiveTransactions
          | FullTextSearch
          | FullTextIndex

--- a/psl/psl-core/src/validate/datasource_loader.rs
+++ b/psl/psl-core/src/validate/datasource_loader.rs
@@ -142,7 +142,7 @@ fn lift_datasource(
             }
         };
 
-    // TODO: deprecated, keeping here since the "referentialIntegrity" preview feature
+    // TODO: deprecated, keeping here since the "referentialIntegrity" datasource property
     // is still silently supported.
     if let Some(integrity) = referential_integrity {
         if !active_connector.allowed_relation_mode_settings().contains(integrity) {
@@ -292,7 +292,7 @@ Example:
 
 generator client {
     provider = "prisma-client-js"
-    previewFeatures = ["relationMode"]
+    previewFeatures = ["referentialIntegrity"]
 }
 "#;
 
@@ -303,7 +303,7 @@ fn get_relation_mode(
     diagnostics: &mut Diagnostics,
 ) -> Option<RelationMode> {
     args.get("relationMode").and_then(|(span, value)| {
-        if !preview_features.contains(PreviewFeature::RelationMode) {
+        if !preview_features.contains(PreviewFeature::ReferentialIntegrity) {
             diagnostics.push_error(DatamodelError::new_source_validation_error(
                 RELATION_MODE_PREVIEW_FEATURE_ERR,
                 &source.name.name,

--- a/psl/psl/tests/attributes/relations/referential_actions.rs
+++ b/psl/psl/tests/attributes/relations/referential_actions.rs
@@ -110,7 +110,7 @@ fn on_delete_actions_should_work_on_prisma_relation_mode() {
 
             generator client {{
                 provider = "prisma-client-js"
-                previewFeatures = ["relationMode"]
+                previewFeatures = ["referentialIntegrity"]
             }}
 
             model A {{
@@ -145,7 +145,7 @@ fn on_update_no_action_should_work_on_prisma_relation_mode() {
 
         generator client {
           provider = "prisma-client-js"
-          previewFeatures = ["relationMode"]
+          previewFeatures = ["referentialIntegrity"]
         }
 
         model A {
@@ -177,7 +177,7 @@ fn foreign_keys_not_allowed_on_mongo() {
 
         generator client {
           provider = "prisma-client-js"
-          previewFeatures = ["relationMode"]
+          previewFeatures = ["referentialIntegrity"]
         }
 
         model A {
@@ -215,7 +215,7 @@ fn prisma_level_integrity_should_be_allowed_on_mongo() {
 
         generator client {
           provider = "prisma-client-js"
-          previewFeatures = ["relationMode"]
+          previewFeatures = ["referentialIntegrity"]
         }
 
         model A {
@@ -428,7 +428,7 @@ fn set_default_action_should_not_work_on_prisma_level_relation_mode() {
 
             generator client {
                 provider = "prisma-client-js"
-                previewFeatures = ["relationMode"]
+                previewFeatures = ["referentialIntegrity"]
             }
 
             model A {{

--- a/psl/psl/tests/attributes/relations/referential_actions/cycle_detection.rs
+++ b/psl/psl/tests/attributes/relations/referential_actions/cycle_detection.rs
@@ -91,7 +91,7 @@ fn cycles_are_allowed_outside_of_emulation_and_sqlserver() {
 
         generator js1 {
           provider = "javascript"
-          previewFeatures = ["relationMode"]
+          previewFeatures = ["referentialIntegrity"]
         }
 
         model A {
@@ -117,7 +117,7 @@ fn emulated_cascading_on_delete_self_relations() {
 
         generator js1 {
           provider = "javascript"
-          previewFeatures = ["relationMode"]
+          previewFeatures = ["referentialIntegrity"]
         }
 
         model A {
@@ -183,7 +183,7 @@ fn emulated_cascading_on_update_self_relations() {
 
         generator js1 {
           provider = "javascript"
-          previewFeatures = ["relationMode"]
+          previewFeatures = ["referentialIntegrity"]
         }
 
         model A {
@@ -249,7 +249,7 @@ fn emulated_null_setting_on_delete_self_relations() {
 
         generator js1 {
           provider = "javascript"
-          previewFeatures = ["relationMode"]
+          previewFeatures = ["referentialIntegrity"]
         }
 
         model A {
@@ -315,7 +315,7 @@ fn emulated_null_setting_on_update_self_relations() {
 
         generator js1 {
           provider = "javascript"
-          previewFeatures = ["relationMode"]
+          previewFeatures = ["referentialIntegrity"]
         }
 
         model A {
@@ -381,7 +381,7 @@ fn emulated_default_setting_on_delete_self_relations() {
 
         generator js1 {
           provider = "javascript"
-          previewFeatures = ["relationMode"]
+          previewFeatures = ["referentialIntegrity"]
         }
 
         model A {
@@ -453,7 +453,7 @@ fn emulated_default_setting_on_update_self_relations() {
 
         generator js1 {
           provider = "javascript"
-          previewFeatures = ["relationMode"]
+          previewFeatures = ["referentialIntegrity"]
         }
 
         model A {
@@ -539,7 +539,7 @@ fn emulated_cascading_cyclic_one_hop_relations() {
 
         generator js1 {
           provider = "javascript"
-          previewFeatures = ["relationMode"]
+          previewFeatures = ["referentialIntegrity"]
         }
 
         model A {

--- a/psl/psl/tests/config/generators.rs
+++ b/psl/psl/tests/config/generators.rs
@@ -259,7 +259,7 @@ fn nice_error_for_unknown_generator_preview_feature() {
         .unwrap_err();
 
     let expectation = expect![[r#"
-        [1;91merror[0m: [1mThe preview feature "foo" is not known. Expected one of: relationMode, interactiveTransactions, fullTextSearch, fullTextIndex, tracing, metrics, orderByNulls, filteredRelationCount, fieldReference[0m
+        [1;91merror[0m: [1mThe preview feature "foo" is not known. Expected one of: referentialIntegrity, interactiveTransactions, fullTextSearch, fullTextIndex, tracing, metrics, orderByNulls, filteredRelationCount, fieldReference[0m
           [1;94m-->[0m  [4mschema.prisma:3[0m
         [1;94m   | [0m
         [1;94m 2 | [0m  provider = "prisma-client-js"

--- a/psl/psl/tests/config/sources.rs
+++ b/psl/psl/tests/config/sources.rs
@@ -702,7 +702,7 @@ fn relation_mode_with_preview_feature_works() {
 }
 
 #[test]
-fn referential_integrity_default() {
+fn relation_mode_default() {
     let schema = indoc! {r#"
         datasource ps {
           provider = "sqlserver"
@@ -721,13 +721,14 @@ fn referential_integrity_default() {
 }
 
 #[test]
-fn relation_mode_default() {
+fn relation_mode_prisma_has_precedence_over_referential_integrity() {
     let schema = indoc! {r#"
         datasource ps {
           provider = "sqlserver"
           url = "mysql://root:prisma@localhost:3306/mydb"
+          relationMode = "prisma"
+          referentialIntegrity = "foreignKeys"
         }
-
         generator client {
           provider = "prisma-client-js"
           previewFeatures = ["referentialIntegrity"]
@@ -736,7 +737,7 @@ fn relation_mode_default() {
 
     let config = parse_configuration(schema);
 
-    assert_eq!(config.relation_mode(), Some(RelationMode::ForeignKeys));
+    assert_eq!(config.relation_mode(), Some(RelationMode::Prisma));
 }
 
 fn load_env_var(key: &str) -> Option<String> {

--- a/psl/psl/tests/config/sources.rs
+++ b/psl/psl/tests/config/sources.rs
@@ -647,7 +647,7 @@ fn relation_mode_without_preview_feature_errors() {
 
         generator client {
             provider = "prisma-client-js"
-            previewFeatures = ["relationMode"]
+            previewFeatures = ["referentialIntegrity"]
         }
         [0m
           [1;94m-->[0m  [4mschema.prisma:3[0m
@@ -692,7 +692,7 @@ fn relation_mode_with_preview_feature_works() {
 
         generator client {
           provider = "prisma-client-js"
-          previewFeatures = ["relationMode"]
+          previewFeatures = ["referentialIntegrity"]
         }
     "#};
 
@@ -730,73 +730,13 @@ fn relation_mode_default() {
 
         generator client {
           provider = "prisma-client-js"
-          previewFeatures = ["relationMode"]
+          previewFeatures = ["referentialIntegrity"]
         }
     "#};
 
     let config = parse_configuration(schema);
 
     assert_eq!(config.relation_mode(), Some(RelationMode::ForeignKeys));
-}
-
-#[test]
-fn relation_mode_and_referential_integrity_can_coexist() {
-    let schema = indoc! {r#"
-        datasource ps {
-          provider = "sqlserver"
-          url = "mysql://root:prisma@localhost:3306/mydb"
-        }
-
-        generator client {
-          provider = "prisma-client-js"
-          previewFeatures = ["referentialIntegrity", "relationMode"]
-        }
-    "#};
-
-    let config = parse_configuration(schema);
-
-    assert_eq!(config.relation_mode(), Some(RelationMode::ForeignKeys));
-}
-
-#[test]
-fn relation_mode_prisma_has_precedence_over_referential_integrity() {
-    let schema = indoc! {r#"
-        datasource ps {
-          provider = "sqlserver"
-          url = "mysql://root:prisma@localhost:3306/mydb"
-          relationMode = "prisma"
-          referentialIntegrity = "foreignKeys"
-        }
-
-        generator client {
-          provider = "prisma-client-js"
-          previewFeatures = ["referentialIntegrity", "relationMode"]
-        }
-    "#};
-
-    let config = parse_configuration(schema);
-
-    assert_eq!(config.relation_mode(), Some(RelationMode::Prisma));
-}
-
-#[test]
-fn referential_integrity_is_used_if_relation_mode_is_default() {
-    let schema = indoc! {r#"
-        datasource ps {
-          provider = "sqlserver"
-          url = "mysql://root:prisma@localhost:3306/mydb"
-          referentialIntegrity = "prisma"
-        }
-
-        generator client {
-          provider = "prisma-client-js"
-          previewFeatures = ["referentialIntegrity", "relationMode"]
-        }
-    "#};
-
-    let config = parse_configuration(schema);
-
-    assert_eq!(config.relation_mode(), Some(RelationMode::Prisma));
 }
 
 fn load_env_var(key: &str) -> Option<String> {

--- a/psl/psl/tests/parsing/comments.rs
+++ b/psl/psl/tests/parsing/comments.rs
@@ -11,7 +11,7 @@ fn trailing_comments_allowed_in_configuration_blocks() {
 
       generator js {
         provider        = "prisma-client-js" // optional
-        previewFeatures = ["relationMode"] // []
+        previewFeatures = ["referentialIntegrity"] // []
       }     
     "#;
     assert_valid(schema);

--- a/psl/psl/tests/reformat/comments.rs
+++ b/psl/psl/tests/reformat/comments.rs
@@ -11,7 +11,7 @@ fn trailing_comments_allowed_in_configuration_blocks() {
 
       generator js {
         provider        = "prisma-client-js" // optional
-        previewFeatures = ["relationMode"] // []
+        previewFeatures = ["referentialIntegrity"] // []
       }     
     "#;
 
@@ -24,7 +24,7 @@ fn trailing_comments_allowed_in_configuration_blocks() {
       
       generator js {
         provider        = "prisma-client-js" // optional
-        previewFeatures = ["relationMode"] // []
+        previewFeatures = ["referentialIntegrity"] // []
       }
     "#]];
 


### PR DESCRIPTION
Backward compatible rename of the `referentialIntegrity` preview feature was done in https://github.com/prisma/prisma-engines/pull/3249, but it's not needed. 

We only needed to rename the datasource property (and have it backward compatible)

This PR reverts the preview feature to its original name `referentialIntegrity`