### PR TITLE
PostgresExtensions flag and basic validation

### DIFF
--- a/introspection-engine/connectors/introspection-connector/src/lib.rs
+++ b/introspection-engine/connectors/introspection-connector/src/lib.rs
@@ -70,9 +70,7 @@ pub struct IntrospectionContext {
     /// This should always be true. TODO: change everything where it's
     /// set to false to take the config into account.
     pub render_config: bool,
-    pub source: Datasource,
     pub composite_type_depth: CompositeTypeDepth,
-    pub preview_features: BitFlags<PreviewFeature>,
     previous_schema: psl::ValidatedSchema,
 }
 
@@ -104,21 +102,20 @@ impl IntrospectionContext {
     }
 
     fn new_naive(previous_schema: psl::ValidatedSchema, composite_type_depth: CompositeTypeDepth) -> Self {
-        let source = previous_schema.configuration.datasources.clone().pop().unwrap();
-        let preview_features = previous_schema.configuration.preview_features();
-
         IntrospectionContext {
             previous_data_model: psl::dml::Datamodel::new(),
             previous_schema,
-            source,
             composite_type_depth,
-            preview_features,
             render_config: true,
         }
     }
 
+    pub fn datasource(&self) -> &Datasource {
+        self.previous_schema.configuration.datasources.first().unwrap()
+    }
+
     pub fn foreign_keys_enabled(&self) -> bool {
-        self.source.relation_mode().uses_foreign_keys()
+        self.datasource().relation_mode().uses_foreign_keys()
     }
 
     pub fn schema_string(&self) -> &str {
@@ -127,6 +124,10 @@ impl IntrospectionContext {
 
     pub fn configuration(&self) -> &psl::Configuration {
         &self.previous_schema.configuration
+    }
+
+    pub fn preview_features(&self) -> BitFlags<PreviewFeature> {
+        self.previous_schema.configuration.preview_features()
     }
 }
 

--- a/introspection-engine/connectors/mongodb-introspection-connector/src/lib.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/src/lib.rs
@@ -124,7 +124,7 @@ impl IntrospectionConnector for MongoDbIntrospectionConnector {
     }
 
     async fn introspect(&self, ctx: &IntrospectionContext) -> ConnectorResult<IntrospectionResult> {
-        let schema = self.describe(ctx.preview_features).await?;
+        let schema = self.describe(ctx.preview_features()).await?;
         Ok(sampler::sample(self.database(), schema, ctx).await?)
     }
 }

--- a/introspection-engine/connectors/sql-introspection-connector/src/introspection_helpers.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/introspection_helpers.rs
@@ -156,7 +156,7 @@ pub(crate) fn calculate_index(index: sql::walkers::IndexWalker<'_>, ctx: &Contex
     let tpe = match index.index_type() {
         IndexType::Unique => psl::dml::IndexType::Unique,
         IndexType::Normal => psl::dml::IndexType::Normal,
-        IndexType::Fulltext if ctx.preview_features.contains(PreviewFeature::FullTextIndex) => {
+        IndexType::Fulltext if ctx.config.preview_features().contains(PreviewFeature::FullTextIndex) => {
             psl::dml::IndexType::Fulltext
         }
         IndexType::Fulltext => psl::dml::IndexType::Normal,
@@ -384,7 +384,7 @@ pub(crate) fn calculate_scalar_field_type_with_native_types(column: sql::ColumnW
         FieldType::Scalar(scal_type, _) => match &column.column_type().native_type {
             None => scalar_type,
             Some(native_type) => {
-                let native_type_instance = ctx.source.active_connector.introspect_native_type(native_type.clone());
+                let native_type_instance = ctx.active_connector().introspect_native_type(native_type.clone());
                 FieldType::Scalar(
                     scal_type,
                     Some(psl::dml::NativeTypeInstance {

--- a/introspection-engine/connectors/sql-introspection-connector/src/lib.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/lib.rs
@@ -147,7 +147,9 @@ impl IntrospectionConnector for SqlIntrospectionConnector {
     }
 
     async fn introspect(&self, ctx: &IntrospectionContext) -> ConnectorResult<IntrospectionResult> {
-        let sql_schema = self.catch(self.describe(Some(ctx.source.active_provider))).await?;
+        let sql_schema = self
+            .catch(self.describe(Some(ctx.datasource().active_provider)))
+            .await?;
 
         let introspection_result =
             calculate_datamodel::calculate_datamodel(&sql_schema, ctx).map_err(|sql_introspection_error| {
@@ -164,7 +166,7 @@ trait SqlFamilyTrait {
 
 impl SqlFamilyTrait for IntrospectionContext {
     fn sql_family(&self) -> SqlFamily {
-        match self.source.active_provider {
+        match self.datasource().active_provider {
             "postgresql" => SqlFamily::Postgres,
             "cockroachdb" => SqlFamily::Postgres,
             "sqlite" => SqlFamily::Sqlite,

--- a/introspection-engine/connectors/sql-introspection-connector/src/version_checker.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/version_checker.rs
@@ -57,7 +57,7 @@ const MYSQL_TYPES: &[MySqlType] = &[
 pub(crate) fn check_prisma_version(ctx: &CalculateDatamodelContext, warnings: &mut Vec<Warning>) -> Version {
     let mut version_checker = VersionChecker {
         sql_family: ctx.sql_family(),
-        is_cockroachdb: ctx.source.active_provider == "cockroachdb",
+        is_cockroachdb: ctx.is_cockroach(),
         has_migration_table: ctx.schema.table_walkers().any(is_old_migration_table),
         has_relay_table: ctx.schema.table_walkers().any(is_relay_table),
         has_prisma_1_join_table: ctx.schema.table_walkers().any(is_prisma_1_point_0_join_table),

--- a/libs/dml/src/render/render_configuration.rs
+++ b/libs/dml/src/render/render_configuration.rs
@@ -37,6 +37,10 @@ fn render_datasource(datasource: &Datasource, out: &mut String) -> fmt::Result {
         writeln!(out, "relationMode = {}", string_literal(&relation_mode.to_string()))?;
     }
 
+    datasource
+        .active_connector
+        .render_datasource_properties(&datasource.connector_data, out)?;
+
     out.write_str("}\n")
 }
 

--- a/migration-engine/connectors/mongodb-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/mongodb-migration-connector/src/lib.rs
@@ -163,7 +163,7 @@ impl MigrationConnector for MongoDbMigrationConnector {
         ctx: &'a IntrospectionContext,
     ) -> BoxFuture<'a, ConnectorResult<IntrospectionResult>> {
         Box::pin(async move {
-            let url: String = ctx.source.load_url(|v| std::env::var(v).ok()).map_err(|err| {
+            let url: String = ctx.datasource().load_url(|v| std::env::var(v).ok()).map_err(|err| {
                 migration_connector::ConnectorError::new_schema_parser_error(
                     err.to_pretty_string("schema.prisma", ctx.schema_string()),
                 )

--- a/psl/builtin-connectors/src/lib.rs
+++ b/psl/builtin-connectors/src/lib.rs
@@ -1,11 +1,11 @@
 #![deny(rust_2018_idioms, unsafe_code)]
 
 pub mod cockroach_datamodel_connector;
+pub mod postgres_datamodel_connector;
 
 mod mongodb;
 mod mssql_datamodel_connector;
 mod mysql_datamodel_connector;
-mod postgres_datamodel_connector;
 mod sqlite_datamodel_connector;
 
 use psl_core::{datamodel_connector::Connector, ConnectorRegistry};

--- a/psl/builtin-connectors/src/postgres_datamodel_connector/datasource.rs
+++ b/psl/builtin-connectors/src/postgres_datamodel_connector/datasource.rs
@@ -1,0 +1,94 @@
+use super::PostgresExtensions;
+use crate::postgres_datamodel_connector::PostgresExtension;
+use psl_core::{
+    datamodel_connector::EXTENSIONS_KEY,
+    diagnostics::{DatamodelError, Diagnostics},
+    parser_database::{ast, coerce, coerce_array},
+};
+use std::collections::{HashMap, HashSet};
+
+pub(super) fn parse_extensions(
+    args: &mut HashMap<&str, (ast::Span, &ast::Expression)>,
+    diagnostics: &mut Diagnostics,
+) -> Option<PostgresExtensions> {
+    args.remove(EXTENSIONS_KEY).and_then(|(span, expr)| {
+        let mut extensions = Vec::new();
+
+        for (name, args, span) in coerce_array(expr, &coerce::function_or_constant_with_span, diagnostics)? {
+            let mut args = filter_args(args, diagnostics);
+
+            let db_name = fetch_string_arg(&mut args, "map", diagnostics);
+            let schema = fetch_string_arg(&mut args, "schema", diagnostics);
+            let version = fetch_string_arg(&mut args, "version", diagnostics);
+
+            for (name, (span, _)) in args.into_iter() {
+                diagnostics.push_error(DatamodelError::new_argument_not_known_error(name, span));
+            }
+
+            let extension = PostgresExtension {
+                name: name.to_string(),
+                span,
+                db_name,
+                schema,
+                version,
+            };
+
+            extensions.push(extension)
+        }
+
+        extensions.sort_by(|a, b| a.name.cmp(&b.name));
+
+        Some(PostgresExtensions { extensions, span })
+    })
+}
+
+fn filter_args<'a>(
+    args: &'a [ast::Argument],
+    diagnostics: &mut Diagnostics,
+) -> HashMap<&'a str, (ast::Span, Option<&'a str>)> {
+    let mut dups = HashSet::new();
+
+    args.iter()
+        .filter_map(|arg| match arg.name.as_ref() {
+            Some(name) if dups.contains(name.name.as_str()) => {
+                diagnostics.push_error(DatamodelError::new_validation_error(
+                    &format!("The argument `{}` can only be defined once", name.name),
+                    arg.span,
+                ));
+
+                None
+            }
+            Some(name) => {
+                dups.insert(name.name.as_str());
+                Some((name.name.as_str(), (arg.span, coerce::string(&arg.value, diagnostics))))
+            }
+            None => {
+                diagnostics.push_error(DatamodelError::new_validation_error(
+                    "The argument must have a name",
+                    arg.span,
+                ));
+
+                None
+            }
+        })
+        .collect()
+}
+
+fn fetch_string_arg(
+    args: &mut HashMap<&str, (ast::Span, Option<&str>)>,
+    name: &str,
+    diagnostics: &mut Diagnostics,
+) -> Option<String> {
+    match args.remove(name) {
+        Some((_, Some(val))) => Some(val.to_string()),
+        Some((span, None)) => {
+            diagnostics.push_error(DatamodelError::new_validation_error(
+                &format!("The `{name}` argument must be a string literal"),
+                span,
+            ));
+
+            None
+        }
+        None => None,
+    }
+}

--- a/psl/diagnostics/src/error.rs
+++ b/psl/diagnostics/src/error.rs
@@ -284,6 +284,10 @@ impl DatamodelError {
         Self::new(format!("Property not known: \"{property_name}\"."), span)
     }
 
+    pub fn new_argument_not_known_error(property_name: &str, span: Span) -> DatamodelError {
+        Self::new(format!("Argument not known: \"{property_name}\"."), span)
+    }
+
     pub fn new_default_unknown_function(function_name: &str, span: Span) -> DatamodelError {
         DatamodelError::new(format!(
                 "Unknown function in @default(): `{function_name}` is not known. You can read about the available functions here: https://pris.ly/d/attribute-functions"

--- a/psl/psl-core/src/common/preview_features.rs
+++ b/psl/psl-core/src/common/preview_features.rs
@@ -66,7 +66,8 @@ features!(
     OrderByNulls,
     MultiSchema,
     FilteredRelationCount,
-    FieldReference
+    FieldReference,
+    PostgresExtensions,
 );
 
 /// Generator preview features
@@ -107,7 +108,10 @@ pub const GENERATOR: FeatureMap = FeatureMap {
         | ImprovedQueryRaw
         | DataProxy
     }),
-    hidden: enumflags2::make_bitflags!(PreviewFeature::{MultiSchema}),
+    hidden: enumflags2::make_bitflags!(PreviewFeature::{
+        MultiSchema
+        | PostgresExtensions
+    }),
 };
 
 #[derive(Debug)]

--- a/psl/psl-core/src/configuration/datasource.rs
+++ b/psl/psl-core/src/configuration/datasource.rs
@@ -3,10 +3,9 @@ use crate::{
     datamodel_connector::{Connector, ConnectorCapabilities, RelationMode},
     diagnostics::{DatamodelError, Diagnostics, Span},
 };
-use std::{borrow::Cow, path::Path};
+use std::{any::Any, borrow::Cow, path::Path};
 
 /// a `datasource` from the prisma schema.
-#[derive(Clone)]
 pub struct Datasource {
     pub name: String,
     /// The provider string
@@ -28,6 +27,23 @@ pub struct Datasource {
     /// _Sorted_ vec of schemas defined in the schemas property.
     pub schemas: Vec<(String, Span)>,
     pub(crate) schemas_span: Option<Span>,
+    pub connector_data: DatasourceConnectorData,
+}
+
+#[derive(Default)]
+pub struct DatasourceConnectorData {
+    data: Option<Box<dyn Any + Send + Sync + 'static>>,
+}
+
+impl DatasourceConnectorData {
+    pub fn new(data: Box<dyn Any + Send + Sync + 'static>) -> Self {
+        Self { data: Some(data) }
+    }
+
+    #[track_caller]
+    pub fn downcast_ref<T: 'static>(&self) -> Option<&T> {
+        self.data.as_ref().map(|data| data.downcast_ref().unwrap())
+    }
 }
 
 impl std::fmt::Debug for Datasource {
@@ -48,6 +64,12 @@ impl std::fmt::Debug for Datasource {
 }
 
 impl Datasource {
+    /// Extract connector-specific constructs. The type parameter must be the right one.
+    #[track_caller]
+    pub fn downcast_connector_data<T: 'static>(&self) -> Option<&T> {
+        self.connector_data.downcast_ref()
+    }
+
     pub(crate) fn has_schema(&self, name: &str) -> bool {
         self.schemas.binary_search_by_key(&name, |(s, _)| s).is_ok()
     }

--- a/psl/psl-core/src/lib.rs
+++ b/psl/psl-core/src/lib.rs
@@ -14,7 +14,7 @@ mod reformat;
 mod validate;
 
 pub use crate::{
-    configuration::{Configuration, Datasource, Generator, StringFromEnvVar},
+    configuration::{Configuration, Datasource, DatasourceConnectorData, Generator, StringFromEnvVar},
     reformat::reformat,
 };
 pub use diagnostics;

--- a/psl/psl-core/src/validate/datasource_loader.rs
+++ b/psl/psl-core/src/validate/datasource_loader.rs
@@ -213,10 +213,13 @@ fn lift_datasource(
         })
         .unwrap_or_default();
 
+    let connector_data = active_connector.parse_datasource_properties(&mut args, diagnostics);
+
     // we handle these elsewhere
     args.remove("previewFeatures");
     args.remove("referentialIntegrity");
     args.remove("relationMode");
+
     for (name, (span, _)) in args.into_iter() {
         diagnostics.push_error(DatamodelError::new_property_not_known_error(name, span));
     }
@@ -234,6 +237,7 @@ fn lift_datasource(
         shadow_database_url,
         referential_integrity,
         relation_mode,
+        connector_data,
     })
 }
 

--- a/psl/psl-core/src/validate/validation_pipeline/validations.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations.rs
@@ -2,6 +2,7 @@ mod autoincrement;
 mod composite_types;
 mod constraint_namespace;
 mod database_name;
+mod datasource;
 mod default_value;
 mod enums;
 mod fields;
@@ -12,7 +13,6 @@ mod relation_fields;
 mod relations;
 
 use super::context::Context;
-use diagnostics::DatamodelError;
 use names::Names;
 use parser_database::walkers::RefinedRelationWalker;
 
@@ -36,6 +36,13 @@ pub(super) fn validate(ctx: &mut Context<'_>) {
     ctx.connector
         .validate_scalar_field_unknown_default_functions(ctx.db, ctx.diagnostics);
 
+    if let Some(ds) = ctx.datasource {
+        datasource::schemas_property_without_preview_feature(ds, ctx);
+        datasource::schemas_property_with_no_connector_support(ds, ctx);
+        ctx.connector
+            .validate_datasource(ctx.preview_features, ds, ctx.diagnostics);
+    }
+
     // Model validations
     models::database_name_clashes(ctx);
 
@@ -49,7 +56,12 @@ pub(super) fn validate(ctx: &mut Context<'_>) {
         models::primary_key_length_prefix_supported(model, ctx);
         models::primary_key_sort_order_supported(model, ctx);
         models::only_one_fulltext_attribute_allowed(model, ctx);
+        models::multischema_feature_flag_needed(model, ctx);
+        models::schema_is_defined_in_the_datasource(model, ctx);
+        models::schema_attribute_supported_in_connector(model, ctx);
+        models::schema_attribute_missing(model, ctx);
         models::connector_specific(model, ctx);
+
         autoincrement::validate_auto_increment(model, ctx);
 
         if let Some(pk) = model.primary_key() {
@@ -114,72 +126,18 @@ pub(super) fn validate(ctx: &mut Context<'_>) {
         }
     }
 
-    if !ctx.connector.supports_enums() {
-        for r#enum in ctx.db.ast().iter_tops().filter_map(|(_, top)| top.as_enum()) {
-            ctx.push_error(DatamodelError::new_validation_error(
-                &format!(
-                    "You defined the enum `{}`. But the current connector does not support enums.",
-                    &r#enum.name.name
-                ),
-                r#enum.span,
-            ));
-        }
-    } else {
+    if ctx.connector.supports_enums() {
         enums::database_name_clashes(ctx);
-        for r#enum in ctx.db.walk_enums() {
-            ctx.connector.validate_enum(r#enum, ctx.diagnostics);
-        }
     }
 
-    if !ctx.preview_features.contains(crate::PreviewFeature::MultiSchema) {
-        for model in ctx.db.walk_models() {
-            if let Some((_, span)) = model.schema() {
-                ctx.push_error(DatamodelError::new_static(
-                    "@@schema is only available with the `multiSchema` preview feature.",
-                    span,
-                ))
-            }
-        }
+    for r#enum in ctx.db.walk_enums() {
+        enums::connector_supports_enums(r#enum, ctx);
+        enums::multischema_feature_flag_needed(r#enum, ctx);
+        enums::schema_is_defined_in_the_datasource(r#enum, ctx);
+        enums::schema_attribute_supported_in_connector(r#enum, ctx);
+        enums::schema_attribute_missing(r#enum, ctx);
 
-        for enm in ctx.db.walk_enums() {
-            if let Some((_, span)) = enm.schema() {
-                ctx.push_error(DatamodelError::new_static(
-                    "@@schema is only available with the `multiSchema` preview feature.",
-                    span,
-                ))
-            }
-        }
-
-        if let Some(ds) = ctx.datasource {
-            if let Some(span) = ds.schemas_span {
-                ctx.push_error(DatamodelError::new_static(
-                    "The `schemas` property is only availably with the `multiSchema` preview feature.",
-                    span,
-                ))
-            }
-        }
-    } else {
-        for model in ctx.db.walk_models() {
-            models::schema_attribute(model, ctx);
-        }
-
-        for r#enum in ctx.db.walk_enums() {
-            enums::schema_attribute(r#enum, ctx);
-        }
-
-        if !ctx
-            .connector
-            .has_capability(crate::datamodel_connector::ConnectorCapability::MultiSchema)
-        {
-            if let Some(ds) = ctx.datasource {
-                if let Some(span) = ds.schemas_span {
-                    ctx.push_error(DatamodelError::new_static(
-                        "The `schemas` property is not supported on the current connector.",
-                        span,
-                    ))
-                }
-            }
-        }
+        ctx.connector.validate_enum(r#enum, ctx.diagnostics);
     }
 
     for relation in ctx.db.walk_relations() {

--- a/psl/psl-core/src/validate/validation_pipeline/validations/datasource.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/datasource.rs
@@ -1,0 +1,36 @@
+use diagnostics::DatamodelError;
+
+use crate::{validate::validation_pipeline::context::Context, Datasource};
+
+pub(super) fn schemas_property_without_preview_feature(datasource: &Datasource, ctx: &mut Context<'_>) {
+    if ctx.preview_features.contains(crate::PreviewFeature::MultiSchema) {
+        return;
+    }
+
+    if let Some(span) = datasource.schemas_span {
+        ctx.push_error(DatamodelError::new_static(
+            "The `schemas` property is only availably with the `multiSchema` preview feature.",
+            span,
+        ))
+    }
+}
+
+pub(super) fn schemas_property_with_no_connector_support(datasource: &Datasource, ctx: &mut Context<'_>) {
+    if !ctx.preview_features.contains(crate::PreviewFeature::MultiSchema) {
+        return;
+    }
+
+    if ctx
+        .connector
+        .has_capability(crate::datamodel_connector::ConnectorCapability::MultiSchema)
+    {
+        return;
+    }
+
+    if let Some(span) = datasource.schemas_span {
+        ctx.push_error(DatamodelError::new_static(
+            "The `schemas` property is not supported on the current connector.",
+            span,
+        ))
+    }
+}

--- a/psl/psl-core/src/validate/validation_pipeline/validations/enums.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/enums.rs
@@ -18,21 +18,109 @@ pub(super) fn database_name_clashes(ctx: &mut Context<'_>) {
     }
 }
 
-pub(super) fn schema_attribute(enm: EnumWalker<'_>, ctx: &mut Context<'_>) {
-    match (enm.schema(), ctx.datasource) {
-        (Some((schema_name, span)), Some(ds)) if !ds.has_schema(schema_name) => {
-            ctx.push_error(DatamodelError::new_static(
-                "This schema is not defined in the datasource. Read more on `@@schema` at https://pris.ly/d/multi-schema",
-                span,
-            ))
-        },
-        (Some((_, span)), _) if !ctx.connector.has_capability(ConnectorCapability::MultiSchema) => {
-            ctx.push_error(DatamodelError::new_static(
-                "@@schema is not supported on the current datasource provider",
-                span,
-            ))
-        }
-        (None, _) if ctx.db.schema_flags().contains(parser_database::SchemaFlags::UsesSchemaAttribute) && !ctx.connector.is_provider("mysql") => ctx.push_error(DatamodelError::new_static("This enum is missing an `@@schema` attribute.", enm.ast_enum().span)),
-        _ => (),
+pub(super) fn schema_is_defined_in_the_datasource(r#enum: EnumWalker<'_>, ctx: &mut Context<'_>) {
+    if !ctx.preview_features.contains(crate::PreviewFeature::MultiSchema) {
+        return;
     }
+
+    if !ctx.connector.has_capability(ConnectorCapability::MultiSchema) {
+        return;
+    }
+
+    let datasource = match ctx.datasource {
+        Some(ds) => ds,
+        None => return,
+    };
+
+    let (schema_name, span) = match r#enum.schema() {
+        Some(tuple) => tuple,
+        None => return,
+    };
+
+    if datasource.has_schema(schema_name) {
+        return;
+    }
+
+    ctx.push_error(DatamodelError::new_static(
+        "This schema is not defined in the datasource. Read more on `@@schema` at https://pris.ly/d/multi-schema",
+        span,
+    ))
+}
+
+pub(super) fn schema_attribute_supported_in_connector(r#enum: EnumWalker<'_>, ctx: &mut Context<'_>) {
+    if !ctx.preview_features.contains(crate::PreviewFeature::MultiSchema) {
+        return;
+    }
+
+    if ctx.connector.has_capability(ConnectorCapability::MultiSchema) {
+        return;
+    }
+
+    let (_, span) = match r#enum.schema() {
+        Some(tuple) => tuple,
+        None => return,
+    };
+
+    ctx.push_error(DatamodelError::new_static(
+        "@@schema is not supported on the current datasource provider",
+        span,
+    ));
+}
+
+pub(super) fn schema_attribute_missing(r#enum: EnumWalker<'_>, ctx: &mut Context<'_>) {
+    if !ctx.preview_features.contains(crate::PreviewFeature::MultiSchema) {
+        return;
+    }
+
+    if !ctx.connector.has_capability(ConnectorCapability::MultiSchema) {
+        return;
+    }
+
+    if !ctx
+        .db
+        .schema_flags()
+        .contains(parser_database::SchemaFlags::UsesSchemaAttribute)
+    {
+        return;
+    }
+
+    if ctx.connector.is_provider("mysql") {
+        return;
+    }
+
+    if r#enum.schema().is_some() {
+        return;
+    }
+
+    ctx.push_error(DatamodelError::new_static(
+        "This enum is missing an `@@schema` attribute.",
+        r#enum.ast_enum().span,
+    ))
+}
+
+pub(super) fn multischema_feature_flag_needed(r#enum: EnumWalker<'_>, ctx: &mut Context<'_>) {
+    if ctx.preview_features.contains(crate::PreviewFeature::MultiSchema) {
+        return;
+    }
+
+    if let Some((_, span)) = r#enum.schema() {
+        ctx.push_error(DatamodelError::new_static(
+            "@@schema is only available with the `multiSchema` preview feature.",
+            span,
+        ));
+    }
+}
+
+pub(crate) fn connector_supports_enums(r#enum: EnumWalker<'_>, ctx: &mut Context<'_>) {
+    if ctx.connector.supports_enums() {
+        return;
+    }
+
+    ctx.push_error(DatamodelError::new_validation_error(
+        &format!(
+            "You defined the enum `{}`. But the current connector does not support enums.",
+            r#enum.name()
+        ),
+        r#enum.ast_enum().span,
+    ));
 }

--- a/psl/psl/tests/validation/attributes/schema/on_sqlite.prisma
+++ b/psl/psl/tests/validation/attributes/schema/on_sqlite.prisma
@@ -16,15 +16,15 @@ model Test {
 }
 
 
-// [1;91merror[0m: [1m@@schema is not supported on the current datasource provider[0m
-//   [1;94m-->[0m  [4mschema.prisma:15[0m
-// [1;94m   | [0m
-// [1;94m14 | [0m
-// [1;94m15 | [0m  @@schema([1;91m"public"[0m)
-// [1;94m   | [0m
 // [1;91merror[0m: [1mThe `schemas` property is not supported on the current connector.[0m
 //   [1;94m-->[0m  [4mschema.prisma:4[0m
 // [1;94m   | [0m
 // [1;94m 3 | [0m    url = env("TEST_DATABASE_URL")
 // [1;94m 4 | [0m    schemas = [1;91m["public", "sphere"][0m
+// [1;94m   | [0m
+// [1;91merror[0m: [1m@@schema is not supported on the current datasource provider[0m
+//   [1;94m-->[0m  [4mschema.prisma:15[0m
+// [1;94m   | [0m
+// [1;94m14 | [0m
+// [1;94m15 | [0m  @@schema([1;91m"public"[0m)
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/postgres_extensions/extensions_are_not_numbers.prisma
+++ b/psl/psl/tests/validation/postgres_extensions/extensions_are_not_numbers.prisma
@@ -1,0 +1,16 @@
+generator js {
+  provider = "prisma-client-js"
+  previewFeatures = [ "postgresExtensions" ]
+}
+
+datasource mypg {
+  provider   = "postgresql"
+  url        = env("TEST_DATABASE_URL")
+  extensions = [ 1 ]
+}
+// [1;91merror[0m: [1mExpected a constant or function value, but received numeric value `1`.[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
+// [1;94m   | [0m
+// [1;94m 8 | [0m  url        = env("TEST_DATABASE_URL")
+// [1;94m 9 | [0m  extensions = [ [1;91m1[0m ]
+// [1;94m   | [0m

--- a/psl/psl/tests/validation/postgres_extensions/extensions_are_not_strings.prisma
+++ b/psl/psl/tests/validation/postgres_extensions/extensions_are_not_strings.prisma
@@ -1,0 +1,16 @@
+generator js {
+  provider = "prisma-client-js"
+  previewFeatures = [ "postgresExtensions" ]
+}
+
+datasource mypg {
+  provider   = "postgresql"
+  url        = env("TEST_DATABASE_URL")
+  extensions = [ "postgis" ]
+}
+// [1;91merror[0m: [1mExpected a constant or function value, but received string value `"postgis"`.[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
+// [1;94m   | [0m
+// [1;94m 8 | [0m  url        = env("TEST_DATABASE_URL")
+// [1;94m 9 | [0m  extensions = [ [1;91m"postgis"[0m ]
+// [1;94m   | [0m

--- a/psl/psl/tests/validation/postgres_extensions/extensions_do_not_work_on_mongodb.prisma
+++ b/psl/psl/tests/validation/postgres_extensions/extensions_do_not_work_on_mongodb.prisma
@@ -1,0 +1,17 @@
+generator js {
+  provider        = "prisma-client-js"
+  previewFeatures = ["postgresExtensions"]
+}
+
+datasource mypg {
+  provider   = "mongodb"
+  url        = env("TEST_DATABASE_URL")
+  extensions = [postgis]
+}
+// [1;91merror[0m: [1mProperty not known: "extensions".[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
+// [1;94m   | [0m
+// [1;94m 8 | [0m  url        = env("TEST_DATABASE_URL")
+// [1;94m 9 | [0m  [1;91mextensions = [postgis][0m
+// [1;94m10 | [0m}
+// [1;94m   | [0m

--- a/psl/psl/tests/validation/postgres_extensions/extensions_do_not_work_on_mysql.prisma
+++ b/psl/psl/tests/validation/postgres_extensions/extensions_do_not_work_on_mysql.prisma
@@ -1,0 +1,17 @@
+generator js {
+  provider        = "prisma-client-js"
+  previewFeatures = ["postgresExtensions"]
+}
+
+datasource db {
+  provider   = "mysql"
+  url        = env("TEST_DATABASE_URL")
+  extensions = [postgis]
+}
+// [1;91merror[0m: [1mProperty not known: "extensions".[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
+// [1;94m   | [0m
+// [1;94m 8 | [0m  url        = env("TEST_DATABASE_URL")
+// [1;94m 9 | [0m  [1;91mextensions = [postgis][0m
+// [1;94m10 | [0m}
+// [1;94m   | [0m

--- a/psl/psl/tests/validation/postgres_extensions/extensions_do_not_work_on_sqlite.prisma
+++ b/psl/psl/tests/validation/postgres_extensions/extensions_do_not_work_on_sqlite.prisma
@@ -1,0 +1,17 @@
+generator js {
+  provider        = "prisma-client-js"
+  previewFeatures = ["postgresExtensions"]
+}
+
+datasource db {
+  provider   = "sqlite"
+  url        = env("TEST_DATABASE_URL")
+  extensions = [postgis]
+}
+// [1;91merror[0m: [1mProperty not known: "extensions".[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
+// [1;94m   | [0m
+// [1;94m 8 | [0m  url        = env("TEST_DATABASE_URL")
+// [1;94m 9 | [0m  [1;91mextensions = [postgis][0m
+// [1;94m10 | [0m}
+// [1;94m   | [0m

--- a/psl/psl/tests/validation/postgres_extensions/extensions_do_not_work_on_sqlserver.prisma
+++ b/psl/psl/tests/validation/postgres_extensions/extensions_do_not_work_on_sqlserver.prisma
@@ -1,0 +1,17 @@
+generator js {
+  provider        = "prisma-client-js"
+  previewFeatures = ["postgresExtensions"]
+}
+
+datasource db {
+  provider   = "sqlserver"
+  url        = env("TEST_DATABASE_URL")
+  extensions = [postgis]
+}
+// [1;91merror[0m: [1mProperty not known: "extensions".[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
+// [1;94m   | [0m
+// [1;94m 8 | [0m  url        = env("TEST_DATABASE_URL")
+// [1;94m 9 | [0m  [1;91mextensions = [postgis][0m
+// [1;94m10 | [0m}
+// [1;94m   | [0m

--- a/psl/psl/tests/validation/postgres_extensions/extensions_require_feature_flag.prisma
+++ b/psl/psl/tests/validation/postgres_extensions/extensions_require_feature_flag.prisma
@@ -1,0 +1,16 @@
+generator js {
+  provider = "prisma-client-js"
+}
+
+datasource mypg {
+  provider   = "postgresql"
+  url        = env("TEST_DATABASE_URL")
+  extensions = [ postgis ]
+}
+// [1;91merror[0m: [1mThe `extensions` property is only available with the `postgresExtensions` preview feature.[0m
+//   [1;94m-->[0m  [4mschema.prisma:8[0m
+// [1;94m   | [0m
+// [1;94m 7 | [0m  url        = env("TEST_DATABASE_URL")
+// [1;94m 8 | [0m  [1;91mextensions = [ postgis ][0m
+// [1;94m 9 | [0m}
+// [1;94m   | [0m

--- a/psl/psl/tests/validation/postgres_extensions/extensions_with_arguments.prisma
+++ b/psl/psl/tests/validation/postgres_extensions/extensions_with_arguments.prisma
@@ -1,0 +1,10 @@
+generator js {
+  provider        = "prisma-client-js"
+  previewFeatures = ["postgresExtensions"]
+}
+
+datasource mypg {
+  provider   = "postgresql"
+  url        = env("TEST_DATABASE_URL")
+  extensions = [uuid_ossp(map: "uuid-ossp", schema: "meow", version: "2.1")]
+}

--- a/psl/psl/tests/validation/postgres_extensions/extensions_with_duplicate_arguments.prisma
+++ b/psl/psl/tests/validation/postgres_extensions/extensions_with_duplicate_arguments.prisma
@@ -1,0 +1,16 @@
+generator js {
+  provider        = "prisma-client-js"
+  previewFeatures = ["postgresExtensions"]
+}
+
+datasource mypg {
+  provider   = "postgresql"
+  url        = env("TEST_DATABASE_URL")
+  extensions = [postgis(version: "2.1", version: "1.0")]
+}
+// [1;91merror[0m: [1mError validating: The argument `version` can only be defined once[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
+// [1;94m   | [0m
+// [1;94m 8 | [0m  url        = env("TEST_DATABASE_URL")
+// [1;94m 9 | [0m  extensions = [postgis(version: "2.1", [1;91mversion: "1.0"[0m)]
+// [1;94m   | [0m

--- a/psl/psl/tests/validation/postgres_extensions/extensions_with_float_arguments.prisma
+++ b/psl/psl/tests/validation/postgres_extensions/extensions_with_float_arguments.prisma
@@ -1,0 +1,22 @@
+generator js {
+  provider        = "prisma-client-js"
+  previewFeatures = ["postgresExtensions"]
+}
+
+datasource mypg {
+  provider   = "postgresql"
+  url        = env("TEST_DATABASE_URL")
+  extensions = [postgis(version: 2.1)]
+}
+// [1;91merror[0m: [1mExpected a string value, but received numeric value `2.1`.[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
+// [1;94m   | [0m
+// [1;94m 8 | [0m  url        = env("TEST_DATABASE_URL")
+// [1;94m 9 | [0m  extensions = [postgis(version: [1;91m2.1[0m)]
+// [1;94m   | [0m
+// [1;91merror[0m: [1mError validating: The `version` argument must be a string literal[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
+// [1;94m   | [0m
+// [1;94m 8 | [0m  url        = env("TEST_DATABASE_URL")
+// [1;94m 9 | [0m  extensions = [postgis([1;91mversion: 2.1[0m)]
+// [1;94m   | [0m

--- a/psl/psl/tests/validation/postgres_extensions/extensions_with_garbage_arguments.prisma
+++ b/psl/psl/tests/validation/postgres_extensions/extensions_with_garbage_arguments.prisma
@@ -1,0 +1,16 @@
+generator js {
+  provider        = "prisma-client-js"
+  previewFeatures = ["postgresExtensions"]
+}
+
+datasource mypg {
+  provider   = "postgresql"
+  url        = env("TEST_DATABASE_URL")
+  extensions = [postgis(version: "2.1", foobar: "1.0")]
+}
+// [1;91merror[0m: [1mArgument not known: "foobar".[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
+// [1;94m   | [0m
+// [1;94m 8 | [0m  url        = env("TEST_DATABASE_URL")
+// [1;94m 9 | [0m  extensions = [postgis(version: "2.1", [1;91mfoobar: "1.0"[0m)]
+// [1;94m   | [0m

--- a/psl/psl/tests/validation/postgres_extensions/extensions_with_unnamed_arguments.prisma
+++ b/psl/psl/tests/validation/postgres_extensions/extensions_with_unnamed_arguments.prisma
@@ -1,0 +1,16 @@
+generator js {
+  provider        = "prisma-client-js"
+  previewFeatures = ["postgresExtensions"]
+}
+
+datasource mypg {
+  provider   = "postgresql"
+  url        = env("TEST_DATABASE_URL")
+  extensions = [postgis("2.1")]
+}
+// [1;91merror[0m: [1mError validating: The argument must have a name[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
+// [1;94m   | [0m
+// [1;94m 8 | [0m  url        = env("TEST_DATABASE_URL")
+// [1;94m 9 | [0m  extensions = [postgis([1;91m"2.1"[0m)]
+// [1;94m   | [0m

--- a/psl/psl/tests/validation/postgres_extensions/feature_flag.prisma
+++ b/psl/psl/tests/validation/postgres_extensions/feature_flag.prisma
@@ -1,0 +1,9 @@
+generator js {
+  provider = "prisma-client-js"
+  previewFeatures = [ "postgresExtensions" ]
+}
+
+datasource mypg {
+  provider   = "postgresql"
+  url        = env("TEST_DATABASE_URL")
+}

--- a/psl/psl/tests/validation/postgres_extensions/simple_single_extension.prisma
+++ b/psl/psl/tests/validation/postgres_extensions/simple_single_extension.prisma
@@ -1,0 +1,10 @@
+generator js {
+  provider = "prisma-client-js"
+  previewFeatures = [ "postgresExtensions" ]
+}
+
+datasource mypg {
+  provider   = "postgresql"
+  url        = env("TEST_DATABASE_URL")
+  extensions = [ postgis ]
+}

--- a/psl/psl/tests/validation/postgres_extensions/single_extension_does_not_need_an_array.prisma
+++ b/psl/psl/tests/validation/postgres_extensions/single_extension_does_not_need_an_array.prisma
@@ -1,0 +1,10 @@
+generator js {
+  provider        = "prisma-client-js"
+  previewFeatures = ["postgresExtensions"]
+}
+
+datasource mypg {
+  provider   = "postgresql"
+  url        = env("TEST_DATABASE_URL")
+  extensions = postgis
+}


### PR DESCRIPTION
Few things that do not work as expected:
- `psl/psl/tests/validation/postgres_extensions/extensions_are_not_constants.prisma` should either be renamed (remove the _not) or make it not succeed
- `psl/psl/tests/validation/postgres_extensions/extensions_require_feature_flag.prisma` does not fail as it should, see datasource_loader.rs:219 in the first commit

There's a few warnings of unused functions that will probably be useful later but are unused now.

Closes: https://github.com/prisma/prisma/issues/15627