### PR TITLE
prisma-fmt-wasm: move the project and pipelines to this repo

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -10,27 +10,15 @@ on:
       - 'LICENSE'
       - 'CODEOWNERS'
       - 'renovate.json'
+      - 'query-engine/**'
 
 jobs:
   build:
-    name: "WebAssembly build ${{ github.event.ref }} for commit ${{ github.event.inputs.commit }}"
+    name: "prisma-fmt-wasm build ${{ github.event.ref }} for commit ${{ github.event.inputs.commit }}"
     runs-on: buildjet-16vcpu-ubuntu-2004
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: wasm32-unknown-unknown
-          default: true
+      - uses: cachix/install-nix-action@v16
 
-      - name: Build the migration-connector crate with default features
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: -p migration-connector --release --target=wasm32-unknown-unknown
-
-      - name: Build the prisma-fmt crate
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: -p prisma-fmt --lib --release --target=wasm32-unknown-unknown
+      - run: nix build .#prisma-fmt-wasm
+      - run: nix flake check

--- a/.github/workflows/publish-prisma-fmt-wasm.yml
+++ b/.github/workflows/publish-prisma-fmt-wasm.yml
@@ -3,6 +3,7 @@ name: Build and publish @prisma/prisma-fmt-wasm
 concurrency: build-prisma-fmt-wasm
 
 on:
+  # usually triggered via GH Actions Workflow in prisma/engines-wrapper repo
   workflow_dispatch:
     inputs:
       enginesWrapperVersion:
@@ -65,4 +66,4 @@ jobs:
         env:
           SLACK_TITLE: 'prisma-fmt-wasm publishing failed :x:'
           SLACK_COLOR: '#FF0000'
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_WASM_FAILING }}

--- a/.github/workflows/publish-prisma-fmt-wasm.yml
+++ b/.github/workflows/publish-prisma-fmt-wasm.yml
@@ -1,0 +1,68 @@
+name: Build and publish @prisma/prisma-fmt-wasm
+
+concurrency: build-prisma-fmt-wasm
+
+on:
+  workflow_dispatch:
+    inputs:
+      enginesWrapperVersion:
+        required: true
+      enginesHash:
+        required: true
+      npmDistTag:
+        required: true
+        default: 'latest'
+
+jobs:
+  build:
+    name: Build and publish @prisma/prisma-fmt-wasm
+    runs-on: ubuntu-latest
+    steps:
+      - name: Print input
+        env:
+          THE_INPUT: '${{ toJson(github.event.inputs) }}'
+        run: |
+          echo $THE_INPUT
+
+      - uses: actions/checkout@v3
+        ref: ${{ github.event.inputs.enginesHash }}
+      - uses: cachix/install-nix-action@v16
+
+      #
+      # Build
+      #
+
+      - run: nix build .#prisma-fmt-wasm
+
+      #
+      # Publish
+      #
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14.x'
+
+      - name: Set up NPM token
+        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+
+      - run: |
+          PACKAGE_DIR=$( nix run .#renderPrismaFmtWasmPackage ${{ github.event.inputs.enginesWrapperVersion }})
+          npm publish "$PACKAGE_DIR" --access public --tag ${{ github.event.inputs.npmDistTag }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      #
+      # Failure handlers
+      #
+
+      - name: Set current job url in SLACK_FOOTER env var
+        if: ${{ failure() }}
+        run: echo "SLACK_FOOTER=<$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID|Click here to go to the job logs>" >> $GITHUB_ENV
+
+      - name: Slack Notification on Failure
+        if: ${{ failure() }}
+        uses: rtCamp/action-slack-notify@v2.2.0
+        env:
+          SLACK_TITLE: 'prisma-fmt-wasm publishing failed :x:'
+          SLACK_COLOR: '#FF0000'
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,11 +419,10 @@ dependencies = [
 
 [[package]]
 name = "connection-string"
-version = "0.1.14"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c4ecb0dc8c35d2c626e45ae70bbfcb1050b302f42bcdf025d913cc0c5a0b443"
+checksum = "b97faeec45f49581c458f8bf81992c5e3ec17d82cda99f59d3cea14eff62698d"
 dependencies = [
- "js-sys",
  "wasm-bindgen",
 ]
 
@@ -2893,6 +2892,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "prisma-fmt-build"
+version = "0.1.0"
+dependencies = [
+ "prisma-fmt",
+ "wasm-bindgen",
+ "wasm-logger",
+]
+
+[[package]]
 name = "prisma-models"
 version = "0.0.0"
 dependencies = [
@@ -5018,9 +5026,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.79"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25f1af7423d8588a3d840681122e72e6a24ddbcb3f0ec385cac0d12d24256c06"
+checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -5028,13 +5036,13 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.79"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b21c0df030f5a177f3cba22e9bc4322695ec43e7257d865302900290bcdedca"
+checksum = "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
 dependencies = [
  "bumpalo",
- "lazy_static",
  "log",
+ "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -5043,9 +5051,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.79"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4203d69e40a52ee523b2529a773d5ffc1dc0071801c87b3d270b471b80ed01"
+checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5053,9 +5061,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.79"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa8a30d46208db204854cadbb5d4baf5fcf8071ba5bf48190c3e59937962ebc"
+checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5066,9 +5074,20 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.79"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d958d035c4438e28c70e4321a2911302f10135ce78a9c7834c0cab4123d06a2"
+checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
+
+[[package]]
+name = "wasm-logger"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "074649a66bb306c8f2068c9016395fa65d8e08d2affcbf95acf3c24c3ab19718"
+dependencies = [
+ "log",
+ "wasm-bindgen",
+ "web-sys",
+]
 
 [[package]]
 name = "web-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = [
   "query-engine/schema-builder",
   "libs/*",
   "prisma-fmt",
+  "prisma-fmt-wasm",
   "psl/*",
 ]
 

--- a/flake.nix
+++ b/flake.nix
@@ -27,14 +27,24 @@
           pkgs = import nixpkgs { inherit system overlays; };
           craneLib = crane.mkLib pkgs;
 
-          prismaEnginesCommonArgs =
+          src =
             let
               enginesSourceFilter = path: type: (builtins.match "\\.pest$" path != null) ||
                 (builtins.match "\\.README.md$" path != null) ||
                 (builtins.match "^\\.git/HEAD" path != null) ||
                 (builtins.match "^\\.git/refs" path != null) ||
                 (craneLib.filterCargoSources path type != null);
+            in
+            lib.cleanSourceWith {
+              filter = enginesSourceFilter;
+              src = builtins.path {
+                path = ./.;
+                name = "prisma-engines-workspace-root-path";
+              };
+            };
 
+          prismaEnginesCommonArgs =
+            let
               excludeFlags = [
                 "--workspace"
                 "--exclude mongodb-introspection-connector" # requires running mongo
@@ -48,13 +58,7 @@
               pname = "prisma-engines";
               version = "0.1.0";
 
-              src = lib.cleanSourceWith {
-                filter = enginesSourceFilter;
-                src = builtins.path {
-                  path = ./.;
-                  name = "prisma-engines-workspace-root-path";
-                };
-              };
+              inherit src;
 
               buildInputs = [ pkgs.openssl ];
 
@@ -78,12 +82,17 @@
             };
 
           prisma-engines-deps = craneLib.buildDepsOnly prismaEnginesCommonArgs;
+
+          prisma-fmt-wasm = import ./prisma-fmt-wasm { inherit crane nixpkgs rust-overlay system src; };
+
           inherit (pkgs) lib;
         in
         {
           packages = {
             prisma-engines = craneLib.buildPackage (prismaEnginesCommonArgs // { cargoArtifacts = prisma-engines-deps; });
-          };
+          } // prisma-fmt-wasm.packages;
+
+          checks = prisma-fmt-wasm.checks;
 
           devShells.default = pkgs.mkShell { inputsFrom = [ prisma-engines-deps ]; };
         }

--- a/prisma-fmt-wasm/Cargo.toml
+++ b/prisma-fmt-wasm/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "prisma-fmt-build"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wasm-bindgen = "=0.2.82"
+wasm-logger = { version = "0.2.0", optional = true }
+prisma-fmt = { path = "../prisma-fmt" }

--- a/prisma-fmt-wasm/README.md
+++ b/prisma-fmt-wasm/README.md
@@ -1,0 +1,26 @@
+# @prisma/prisma-fmt-wasm
+
+[![Publish pipeline](https://github.com/prisma/prisma-engines/actions/workflows/publish-prisma-fmt-wasm.yml/badge.svg)](https://github.com/prisma/prisma-engines/actions/workflows/publish-prisma-fmt-wasm.yml)
+[![npm package](https://img.shields.io/npm/v/@prisma/prisma-fmt-wasm/latest)](https://www.npmjs.com/package/@prisma/prisma-fmt-wasm)
+[![install size](https://packagephobia.com/badge?p=@prisma/prisma-fmt-wasm)](https://packagephobia.com/result?p=@prisma/prisma-fmt-wasm)
+
+This directory only contains build logic to package the `prisma-fmt` engine
+into a Node package as a WASM module. All the functionality is implemented in
+other parts of prisma-engines.
+
+The published NPM package is internal to Prisma. Its API will break without prior warning.
+
+## Example
+
+```bash
+node -e "const prismaFmt = require('@prisma/prisma-fmt-wasm'); console.log(prismaFmt.version())"
+```
+
+## Components
+
+- The GitHub Actions workflow that publishes the NPM package: https://github.com/prisma/prisma-engines/blob/main/.github/workflows/publish-prisma-fmt-wasm.yml
+    - It is triggered from the https://github.com/prisma/engines-wrapper publish action.
+- The [Rust source code](https://github.com/prisma/prisma-engines/tree/main/prisma-fmt-wasm/src) for the wasm module
+- The [nix build definition](https://github.com/prisma/prisma-engines/blob/main/prisma-fmt-wasm/default.nix)
+    - It gives us a fully reproducible, thoroughly described build process and environment. The alternative would be a bash script with installs through `rustup`, `cargo install` and `apt`, with underspecified system dependencies and best-effort version pinning.
+    - You can read more about nix on [nix.dev](https://nix.dev/) and the [official website](https://nixos.org/).

--- a/prisma-fmt-wasm/default.nix
+++ b/prisma-fmt-wasm/default.nix
@@ -1,0 +1,65 @@
+{ crane, nixpkgs, rust-overlay, system, src }:
+
+let
+  overlays = [
+    rust-overlay.overlays.default
+    (self: super:
+      let toolchain = super.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml; in
+      { cargo = toolchain; rustc = toolchain; })
+  ];
+  pkgs = import nixpkgs { inherit system overlays; };
+  craneLib = crane.mkLib pkgs;
+
+  inherit (pkgs) jq nodejs coreutils rustPlatform wasm-bindgen-cli;
+  inherit (builtins) readFile replaceStrings;
+in
+rec {
+  packages = {
+    prisma-fmt-wasm = craneLib.buildPackage {
+      pname = "prisma-fmt-wasm";
+      version = "0.1.0";
+
+      nativeBuildInputs = with pkgs; [ git wasm-bindgen-cli ];
+
+      cargoBuildCommand = "cargo build --release --target=wasm32-unknown-unknown --manifest-path=prisma-fmt-wasm/Cargo.toml";
+      cargoCheckCommand = "cargo check --target=wasm32-unknown-unknown --manifest-path=prisma-fmt-wasm/Cargo.toml";
+      doCheck = false; # do not run cargo test
+      cargoArtifacts = null; # do not cache dependencies
+
+      installPhase = readFile ./scripts/install.sh;
+
+      inherit src;
+    };
+
+    # Takes a package version as its single argument, and produces
+    # prisma-fmt-wasm with the right package.json in a temporary directory,
+    # then prints the directory's path. This is used by the publish pipeline in CI.
+    renderPrismaFmtWasmPackage =
+      pkgs.writeShellApplication {
+        name = "renderPrismaFmtWasmPackage";
+        runtimeInputs = [ jq ];
+        text = ''
+          set -euxo pipefail
+
+          PACKAGE_DIR=$(mktemp -d)
+          cp -r --no-target-directory ${packages.prisma-fmt-wasm} "$PACKAGE_DIR"
+          rm -f "$PACKAGE_DIR/package.json"
+          jq ".version = \"$1\"" ${packages.prisma-fmt-wasm}/package.json > "$PACKAGE_DIR/package.json"
+          echo "$PACKAGE_DIR"
+        '';
+      };
+
+    syncWasmBindgenVersions = let template = readFile ./scripts/syncWasmBindgenVersions.sh; in
+      pkgs.writeShellApplication {
+        name = "syncWasmBindgenVersions";
+        runtimeInputs = [ coreutils ];
+        text = replaceStrings [ "$WASM_BINDGEN_VERSION" ] [ wasm-bindgen-cli.version ] template;
+      };
+  };
+
+  checks = {
+    prismaFmtWasmE2E = pkgs.runCommand "prismaFmtWasmE2E"
+      { prisma_fmt_wasm = packages.prisma-fmt-wasm; node = "${nodejs}/bin/node"; }
+      (readFile ./scripts/check.sh);
+  };
+}

--- a/prisma-fmt-wasm/package.json
+++ b/prisma-fmt-wasm/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@prisma/prisma-fmt-wasm",
+  "version": null,
+  "description": "",
+  "main": "src/prisma_fmt_build.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/prisma/prisma-engines"
+  },
+  "author": "Prisma",
+  "license": "MIT",
+  "homepage": "https://github.com/prisma/prisma-engines"
+}

--- a/prisma-fmt-wasm/package.json
+++ b/prisma-fmt-wasm/package.json
@@ -1,16 +1,17 @@
 {
   "name": "@prisma/prisma-fmt-wasm",
   "version": null,
-  "description": "",
+  "description": "The WASM package for prisma-fmt",
   "main": "src/prisma_fmt_build.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma-engines"
+    "url": "https://github.com/prisma/prisma-engines",
+    "directory": "prisma-fmt-wasm"
   },
   "author": "Prisma",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "homepage": "https://github.com/prisma/prisma-engines"
 }

--- a/prisma-fmt-wasm/rust-toolchain.toml
+++ b/prisma-fmt-wasm/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "stable"
+components = []
+targets = [ "wasm32-unknown-unknown" ]
+profile = "minimal"

--- a/prisma-fmt-wasm/scripts/check.sh
+++ b/prisma-fmt-wasm/scripts/check.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# Check that the build worked.
+
+set -euo pipefail
+
+echo -n '1. The final wasm file is not empty: '
+
+EXPECTED_FINAL_WASM_FILE_PATH="$prisma_fmt_wasm/src/prisma_fmt_build_bg.wasm";
+WASM_FILE_SIZE=`wc -c $EXPECTED_FINAL_WASM_FILE_PATH | sed 's/ .*$//'`
+
+if [[ $WASM_FILE_SIZE == '0' ]]; then
+    echo "Check phase failed: expected a non empty EXPECTED_FINAL_WASM_FILE_PAT"
+    exit 1
+fi
+
+echo 'ok.'
+
+# ~_~_~_~ #
+
+echo '2. We can call the module directly and get back a valid result.'
+
+VERSION_FROM_MODULE=`$node -e "const prismaFmt = require('$prisma_fmt_wasm'); console.log(prismaFmt.version())"`
+
+echo "VERSION_FROM_MODULE=$VERSION_FROM_MODULE"
+
+if [[ $VERSION_FROM_MODULE != 'wasm' ]]; then
+    echo "Check phase failed: expected the module version to be 'wasm', but got $VERSION_FROM_MODULE"
+    exit 1
+fi
+
+echo ' ok.'
+
+# Signal to nix that the check is a success.
+mkdir -p $out

--- a/prisma-fmt-wasm/scripts/install.sh
+++ b/prisma-fmt-wasm/scripts/install.sh
@@ -1,0 +1,16 @@
+set -euxo pipefail
+
+echo 'Creating out dir...'
+mkdir -p $out/src;
+
+echo 'Copying package.json...'
+cp ./prisma-fmt-wasm/package.json $out/;
+
+echo 'Copying README.md...'
+cp ./prisma-fmt-wasm/README.md $out/;
+
+echo 'Generating node package...'
+wasm-bindgen \
+  --target nodejs \
+  --out-dir $out/src \
+  target/wasm32-unknown-unknown/release/prisma_fmt_build.wasm;

--- a/prisma-fmt-wasm/scripts/syncWasmBindgenVersions.sh
+++ b/prisma-fmt-wasm/scripts/syncWasmBindgenVersions.sh
@@ -1,0 +1,3 @@
+echo 'Syncing wasm-bindgen version in crate with that of the installed CLI...'
+sed -i "s/^wasm-bindgen\ =.*$/wasm-bindgen = \"=$WASM_BINDGEN_VERSION\"/" ./prisma-fmt-wasm/Cargo.toml
+cargo update --package wasm-bindgen

--- a/prisma-fmt-wasm/src/lib.rs
+++ b/prisma-fmt-wasm/src/lib.rs
@@ -1,0 +1,69 @@
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub fn format(schema: String, params: String) -> String {
+    prisma_fmt::format(&schema, &params)
+}
+
+/// Docs: https://prisma.github.io/prisma-engines/doc/prisma_fmt/fn.get_config.html
+#[wasm_bindgen]
+pub fn get_config(params: String) -> String {
+    prisma_fmt::get_config(params)
+}
+
+#[wasm_bindgen]
+pub fn lint(input: String) -> String {
+    prisma_fmt::lint(input)
+}
+
+#[wasm_bindgen]
+pub fn native_types(input: String) -> String {
+    prisma_fmt::native_types(input)
+}
+
+#[wasm_bindgen]
+pub fn referential_actions(input: String) -> String {
+    prisma_fmt::referential_actions(input)
+}
+
+#[wasm_bindgen]
+pub fn preview_features() -> String {
+    prisma_fmt::preview_features()
+}
+
+/// The API is modelled on an LSP [completion
+/// request](https://github.com/microsoft/language-server-protocol/blob/gh-pages/_specifications/specification-3-16.md#textDocument_completion).
+/// Input and output are both JSON, the request being a `CompletionParams` object and the response
+/// being a `CompletionList` object.
+#[wasm_bindgen]
+pub fn text_document_completion(schema: String, params: String) -> String {
+    prisma_fmt::text_document_completion(schema, &params)
+}
+
+/// This API is modelled on an LSP [code action
+/// request](https://github.com/microsoft/language-server-protocol/blob/gh-pages/_specifications/specification-3-16.md#textDocument_codeAction=).
+/// Input and output are both JSON, the request being a
+/// `CodeActionParams` object and the response being a list of
+/// `CodeActionOrCommand` objects.
+#[wasm_bindgen]
+pub fn code_actions(schema: String, params: String) -> String {
+    prisma_fmt::code_actions(schema, &params)
+}
+
+#[wasm_bindgen]
+pub fn version() -> String {
+    String::from("wasm")
+}
+
+/// Trigger a panic inside the wasm module. This is only useful in development for testing panic
+/// handling.
+#[wasm_bindgen]
+pub fn debug_panic() {
+    panic!("This is the panic triggered by `prisma_fmt::debug_panic()`");
+}
+
+#[cfg(feature = "wasm_logger")]
+#[wasm_bindgen]
+pub fn enable_logs() {
+    wasm_logger::init(wasm_logger::Config::default());
+}


### PR DESCRIPTION
prisma-fmt-wasm: move the project and pipelines to this repo

Until now, we have built and published prisma-fmt-wasm from a separate
repository: https://github.com/prisma/prisma-fmt-wasm/

The way it works is that when prisma-engines is published,
engines-wrapper starts its build, publishes its own npm packages, then
triggers the prisma-fmt-wasm publish pipeline. This is complicated.

Starting with this commit, prisma-fmt-wasm lives in prisma-engines. The
publish action is now much simpler, and can be triggered in exactly the
same way from engines-wrapper, but now we know that prisma-fmt-wasm
works

This also lets us drop all the logic to update engines hashes and npm
package versions from the build definitions.
