### PR TITLE
feat(relation-mode): remove emulated `NoAction` for `postgres` and `sqlite`

### DIFF
--- a/prisma-fmt/src/actions.rs
+++ b/prisma-fmt/src/actions.rs
@@ -6,10 +6,9 @@ pub(crate) fn run(schema: &str) -> String {
             if validated_configuration.datasources.len() != 1 {
                 "[]".to_string()
             } else if let Some(datasource) = validated_configuration.datasources.first() {
-                let relation_mode = datasource.relation_mode();
                 let available_referential_actions = datasource
                     .active_connector
-                    .referential_actions(&relation_mode)
+                    .referential_actions()
                     .iter()
                     .map(|act| format!("{:?}", act))
                     .collect::<Vec<_>>();

--- a/prisma-fmt/src/text_document_completion.rs
+++ b/prisma-fmt/src/text_document_completion.rs
@@ -53,7 +53,7 @@ pub(crate) fn completion(schema: String, params: CompletionParams) -> Completion
 fn push_ast_completions(
     completion_list: &mut CompletionList,
     connector: &'static dyn Connector,
-    relation_mode: RelationMode,
+    _relation_mode: RelationMode,
     db: &ParserDatabase,
     position: usize,
 ) {
@@ -62,7 +62,7 @@ fn push_ast_completions(
             _model_id,
             ast::ModelPosition::Field(_, ast::FieldPosition::Attribute("relation", _, Some(attr_name))),
         ) if attr_name == "onDelete" || attr_name == "onUpdate" => {
-            for referential_action in connector.referential_actions(&relation_mode).iter() {
+            for referential_action in connector.referential_actions().iter() {
                 completion_list.items.push(CompletionItem {
                     label: referential_action.as_str().to_owned(),
                     kind: Some(CompletionItemKind::ENUM),

--- a/psl/builtin-connectors/src/cockroach_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/cockroach_datamodel_connector.rs
@@ -139,10 +139,6 @@ impl Connector for CockroachDatamodelConnector {
         NoAction | Restrict | Cascade | SetNull | SetDefault
     }
 
-    fn emulated_referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
-        relation_mode.allowed_emulated_referential_actions_default()
-    }
-
     fn scalar_type_for_native_type(&self, native_type: serde_json::Value) -> ScalarType {
         let native_type: CockroachType = serde_json::from_value(native_type).unwrap();
 

--- a/psl/builtin-connectors/src/cockroach_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/cockroach_datamodel_connector.rs
@@ -133,10 +133,14 @@ impl Connector for CockroachDatamodelConnector {
         63
     }
 
-    fn referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
+    fn referential_actions(&self, _relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
         use ReferentialAction::*;
 
-        relation_mode.allowed_referential_actions(NoAction | Restrict | Cascade | SetNull | SetDefault)
+        NoAction | Restrict | Cascade | SetNull | SetDefault
+    }
+
+    fn simulated_referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
+        relation_mode.allowed_simulated_referential_actions_default()
     }
 
     fn scalar_type_for_native_type(&self, native_type: serde_json::Value) -> ScalarType {

--- a/psl/builtin-connectors/src/cockroach_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/cockroach_datamodel_connector.rs
@@ -6,8 +6,7 @@ use native_types::{CockroachType, NativeType};
 use psl_core::{
     datamodel_connector::{
         helper::{arg_vec_from_opt, args_vec_from_opt, parse_one_opt_u32, parse_two_opt_u32},
-        Connector, ConnectorCapability, ConstraintScope, NativeTypeConstructor, NativeTypeInstance, RelationMode,
-        StringFilter,
+        Connector, ConnectorCapability, ConstraintScope, NativeTypeConstructor, NativeTypeInstance, StringFilter,
     },
     diagnostics::{DatamodelError, Diagnostics},
     parser_database::{

--- a/psl/builtin-connectors/src/cockroach_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/cockroach_datamodel_connector.rs
@@ -133,7 +133,7 @@ impl Connector for CockroachDatamodelConnector {
         63
     }
 
-    fn referential_actions(&self, _relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
+    fn referential_actions(&self) -> BitFlags<ReferentialAction> {
         use ReferentialAction::*;
 
         NoAction | Restrict | Cascade | SetNull | SetDefault

--- a/psl/builtin-connectors/src/cockroach_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/cockroach_datamodel_connector.rs
@@ -139,8 +139,8 @@ impl Connector for CockroachDatamodelConnector {
         NoAction | Restrict | Cascade | SetNull | SetDefault
     }
 
-    fn simulated_referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
-        relation_mode.allowed_simulated_referential_actions_default()
+    fn emulated_referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
+        relation_mode.allowed_emulated_referential_actions_default()
     }
 
     fn scalar_type_for_native_type(&self, native_type: serde_json::Value) -> ScalarType {

--- a/psl/builtin-connectors/src/mongodb.rs
+++ b/psl/builtin-connectors/src/mongodb.rs
@@ -58,8 +58,8 @@ impl Connector for MongoDbDatamodelConnector {
         BitFlags::empty()
     }
 
-    fn simulated_referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
-        relation_mode.allowed_simulated_referential_actions_default()
+    fn emulated_referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
+        relation_mode.allowed_emulated_referential_actions_default()
     }
 
     fn validate_model(&self, model: ModelWalker<'_>, errors: &mut Diagnostics) {

--- a/psl/builtin-connectors/src/mongodb.rs
+++ b/psl/builtin-connectors/src/mongodb.rs
@@ -58,10 +58,6 @@ impl Connector for MongoDbDatamodelConnector {
         BitFlags::empty()
     }
 
-    fn emulated_referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
-        relation_mode.allowed_emulated_referential_actions_default()
-    }
-
     fn validate_model(&self, model: ModelWalker<'_>, errors: &mut Diagnostics) {
         validations::id_must_be_defined(model, errors);
 

--- a/psl/builtin-connectors/src/mongodb.rs
+++ b/psl/builtin-connectors/src/mongodb.rs
@@ -54,7 +54,7 @@ impl Connector for MongoDbDatamodelConnector {
         &[ConstraintScope::ModelKeyIndex]
     }
 
-    fn referential_actions(&self, _relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
+    fn referential_actions(&self) -> BitFlags<ReferentialAction> {
         BitFlags::empty()
     }
 

--- a/psl/builtin-connectors/src/mongodb.rs
+++ b/psl/builtin-connectors/src/mongodb.rs
@@ -54,8 +54,12 @@ impl Connector for MongoDbDatamodelConnector {
         &[ConstraintScope::ModelKeyIndex]
     }
 
-    fn referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
-        relation_mode.allowed_referential_actions(BitFlags::empty())
+    fn referential_actions(&self, _relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
+        BitFlags::empty()
+    }
+
+    fn simulated_referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
+        relation_mode.allowed_simulated_referential_actions_default()
     }
 
     fn validate_model(&self, model: ModelWalker<'_>, errors: &mut Diagnostics) {

--- a/psl/builtin-connectors/src/mssql_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/mssql_datamodel_connector.rs
@@ -171,7 +171,7 @@ impl Connector for MsSqlDatamodelConnector {
         128
     }
 
-    fn referential_actions(&self, _relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
+    fn referential_actions(&self) -> BitFlags<ReferentialAction> {
         use ReferentialAction::*;
 
         NoAction | Cascade | SetNull | SetDefault

--- a/psl/builtin-connectors/src/mssql_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/mssql_datamodel_connector.rs
@@ -8,7 +8,7 @@ use once_cell::sync::Lazy;
 use psl_core::{
     datamodel_connector::{
         helper::{arg_vec_from_opt, args_vec_from_opt, parse_one_opt_u32, parse_two_opt_u32},
-        Connector, ConnectorCapability, ConstraintScope, NativeTypeConstructor, NativeTypeInstance, RelationMode,
+        Connector, ConnectorCapability, ConstraintScope, NativeTypeConstructor, NativeTypeInstance,
     },
     diagnostics::{DatamodelError, Diagnostics, Span},
     parser_database::{self, ast, ParserDatabase, ReferentialAction, ScalarType},

--- a/psl/builtin-connectors/src/mssql_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/mssql_datamodel_connector.rs
@@ -177,8 +177,8 @@ impl Connector for MsSqlDatamodelConnector {
         NoAction | Cascade | SetNull | SetDefault
     }
 
-    fn simulated_referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
-        relation_mode.allowed_simulated_referential_actions_default()
+    fn emulated_referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
+        relation_mode.allowed_emulated_referential_actions_default()
     }
 
     fn scalar_type_for_native_type(&self, native_type: serde_json::Value) -> ScalarType {

--- a/psl/builtin-connectors/src/mssql_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/mssql_datamodel_connector.rs
@@ -171,10 +171,14 @@ impl Connector for MsSqlDatamodelConnector {
         128
     }
 
-    fn referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
+    fn referential_actions(&self, _relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
         use ReferentialAction::*;
 
-        relation_mode.allowed_referential_actions(NoAction | Cascade | SetNull | SetDefault)
+        NoAction | Cascade | SetNull | SetDefault
+    }
+
+    fn simulated_referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
+        relation_mode.allowed_simulated_referential_actions_default()
     }
 
     fn scalar_type_for_native_type(&self, native_type: serde_json::Value) -> ScalarType {

--- a/psl/builtin-connectors/src/mssql_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/mssql_datamodel_connector.rs
@@ -177,10 +177,6 @@ impl Connector for MsSqlDatamodelConnector {
         NoAction | Cascade | SetNull | SetDefault
     }
 
-    fn emulated_referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
-        relation_mode.allowed_emulated_referential_actions_default()
-    }
-
     fn scalar_type_for_native_type(&self, native_type: serde_json::Value) -> ScalarType {
         let native_type: MsSqlType = serde_json::from_value(native_type).unwrap();
 

--- a/psl/builtin-connectors/src/mysql_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/mysql_datamodel_connector.rs
@@ -166,10 +166,6 @@ impl Connector for MySqlDatamodelConnector {
         Restrict | Cascade | SetNull | NoAction | SetDefault
     }
 
-    fn emulated_referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
-        relation_mode.allowed_emulated_referential_actions_default()
-    }
-
     fn scalar_type_for_native_type(&self, native_type: serde_json::Value) -> ScalarType {
         let native_type: MySqlType = serde_json::from_value(native_type).unwrap();
 

--- a/psl/builtin-connectors/src/mysql_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/mysql_datamodel_connector.rs
@@ -8,7 +8,7 @@ use native_types::{
 use psl_core::{
     datamodel_connector::{
         helper::{args_vec_from_opt, parse_one_opt_u32, parse_one_u32, parse_two_opt_u32},
-        Connector, ConnectorCapability, ConstraintScope, NativeTypeConstructor, NativeTypeInstance, RelationMode,
+        Connector, ConnectorCapability, ConstraintScope, NativeTypeConstructor, NativeTypeInstance,
     },
     diagnostics::{DatamodelError, Diagnostics, Span},
     parser_database::{walkers, ReferentialAction, ScalarType},

--- a/psl/builtin-connectors/src/mysql_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/mysql_datamodel_connector.rs
@@ -160,7 +160,7 @@ impl Connector for MySqlDatamodelConnector {
         64
     }
 
-    fn referential_actions(&self, _relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
+    fn referential_actions(&self) -> BitFlags<ReferentialAction> {
         use ReferentialAction::*;
 
         Restrict | Cascade | SetNull | NoAction | SetDefault

--- a/psl/builtin-connectors/src/mysql_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/mysql_datamodel_connector.rs
@@ -160,10 +160,14 @@ impl Connector for MySqlDatamodelConnector {
         64
     }
 
-    fn referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
+    fn referential_actions(&self, _relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
         use ReferentialAction::*;
 
-        relation_mode.allowed_referential_actions(Restrict | Cascade | SetNull | NoAction | SetDefault)
+        Restrict | Cascade | SetNull | NoAction | SetDefault
+    }
+
+    fn simulated_referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
+        relation_mode.allowed_simulated_referential_actions_default()
     }
 
     fn scalar_type_for_native_type(&self, native_type: serde_json::Value) -> ScalarType {

--- a/psl/builtin-connectors/src/mysql_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/mysql_datamodel_connector.rs
@@ -166,8 +166,8 @@ impl Connector for MySqlDatamodelConnector {
         Restrict | Cascade | SetNull | NoAction | SetDefault
     }
 
-    fn simulated_referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
-        relation_mode.allowed_simulated_referential_actions_default()
+    fn emulated_referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
+        relation_mode.allowed_emulated_referential_actions_default()
     }
 
     fn scalar_type_for_native_type(&self, native_type: serde_json::Value) -> ScalarType {

--- a/psl/builtin-connectors/src/postgres_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/postgres_datamodel_connector.rs
@@ -154,7 +154,7 @@ impl Connector for PostgresDatamodelConnector {
         63
     }
 
-    fn referential_actions(&self, _relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
+    fn referential_actions(&self) -> BitFlags<ReferentialAction> {
         use ReferentialAction::*;
 
         NoAction | Restrict | Cascade | SetNull | SetDefault

--- a/psl/builtin-connectors/src/postgres_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/postgres_datamodel_connector.rs
@@ -154,10 +154,16 @@ impl Connector for PostgresDatamodelConnector {
         63
     }
 
-    fn referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
+    fn referential_actions(&self, _relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
         use ReferentialAction::*;
 
-        relation_mode.allowed_referential_actions(NoAction | Restrict | Cascade | SetNull | SetDefault)
+        NoAction | Restrict | Cascade | SetNull | SetDefault
+    }
+
+    fn simulated_referential_actions(&self, _relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
+        use ReferentialAction::*;
+
+        Restrict | SetNull | Cascade
     }
 
     fn scalar_type_for_native_type(&self, native_type: serde_json::Value) -> ScalarType {

--- a/psl/builtin-connectors/src/postgres_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/postgres_datamodel_connector.rs
@@ -9,8 +9,7 @@ use native_types::{
 use psl_core::{
     datamodel_connector::{
         helper::{arg_vec_from_opt, args_vec_from_opt, parse_one_opt_u32, parse_two_opt_u32},
-        Connector, ConnectorCapability, ConstraintScope, NativeTypeConstructor, NativeTypeInstance, RelationMode,
-        StringFilter,
+        Connector, ConnectorCapability, ConstraintScope, NativeTypeConstructor, NativeTypeInstance, StringFilter,
     },
     diagnostics::{DatamodelError, Diagnostics},
     parser_database::{ast, walkers, IndexAlgorithm, OperatorClass, ParserDatabase, ReferentialAction, ScalarType},
@@ -160,7 +159,7 @@ impl Connector for PostgresDatamodelConnector {
         NoAction | Restrict | Cascade | SetNull | SetDefault
     }
 
-    fn emulated_referential_actions(&self, _relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
+    fn emulated_referential_actions(&self) -> BitFlags<ReferentialAction> {
         use ReferentialAction::*;
 
         Restrict | SetNull | Cascade

--- a/psl/builtin-connectors/src/postgres_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/postgres_datamodel_connector.rs
@@ -160,7 +160,7 @@ impl Connector for PostgresDatamodelConnector {
         NoAction | Restrict | Cascade | SetNull | SetDefault
     }
 
-    fn simulated_referential_actions(&self, _relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
+    fn emulated_referential_actions(&self, _relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
         use ReferentialAction::*;
 
         Restrict | SetNull | Cascade

--- a/psl/builtin-connectors/src/sqlite_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/sqlite_datamodel_connector.rs
@@ -49,7 +49,7 @@ impl Connector for SqliteDatamodelConnector {
         SetNull | SetDefault | Cascade | Restrict | NoAction
     }
 
-    fn simulated_referential_actions(&self, _relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
+    fn emulated_referential_actions(&self, _relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
         use ReferentialAction::*;
 
         Restrict | SetNull | Cascade

--- a/psl/builtin-connectors/src/sqlite_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/sqlite_datamodel_connector.rs
@@ -43,10 +43,16 @@ impl Connector for SqliteDatamodelConnector {
         10000
     }
 
-    fn referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
+    fn referential_actions(&self, _relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
         use ReferentialAction::*;
 
-        relation_mode.allowed_referential_actions(SetNull | SetDefault | Cascade | Restrict | NoAction)
+        SetNull | SetDefault | Cascade | Restrict | NoAction
+    }
+
+    fn simulated_referential_actions(&self, _relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
+        use ReferentialAction::*;
+
+        Restrict | SetNull | Cascade
     }
 
     fn scalar_type_for_native_type(&self, _native_type: serde_json::Value) -> ScalarType {

--- a/psl/builtin-connectors/src/sqlite_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/sqlite_datamodel_connector.rs
@@ -43,7 +43,7 @@ impl Connector for SqliteDatamodelConnector {
         10000
     }
 
-    fn referential_actions(&self, _relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
+    fn referential_actions(&self) -> BitFlags<ReferentialAction> {
         use ReferentialAction::*;
 
         SetNull | SetDefault | Cascade | Restrict | NoAction

--- a/psl/builtin-connectors/src/sqlite_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/sqlite_datamodel_connector.rs
@@ -1,8 +1,6 @@
 use enumflags2::BitFlags;
 use psl_core::{
-    datamodel_connector::{
-        Connector, ConnectorCapability, ConstraintScope, NativeTypeConstructor, NativeTypeInstance, RelationMode,
-    },
+    datamodel_connector::{Connector, ConnectorCapability, ConstraintScope, NativeTypeConstructor, NativeTypeInstance},
     diagnostics::{DatamodelError, Span},
     parser_database::{ReferentialAction, ScalarType},
 };
@@ -49,7 +47,7 @@ impl Connector for SqliteDatamodelConnector {
         SetNull | SetDefault | Cascade | Restrict | NoAction
     }
 
-    fn emulated_referential_actions(&self, _relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
+    fn emulated_referential_actions(&self) -> BitFlags<ReferentialAction> {
         use ReferentialAction::*;
 
         Restrict | SetNull | Cascade

--- a/psl/psl-core/src/datamodel_connector.rs
+++ b/psl/psl-core/src/datamodel_connector.rs
@@ -71,9 +71,14 @@ pub trait Connector: Send + Sync {
     }
 
     /// The referential actions supported by the connector.
-    fn referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction>;
+    fn referential_actions(&self) -> BitFlags<ReferentialAction>;
 
     /// The referential actions supported when using relationMode = "prisma" by the connector.
+    /// There are in fact scenarios in which the set of emulated referential actions supported may change
+    /// depending on the connector. For example, Postgres' NoAction mode behaves similarly to Restrict
+    /// (raising an error if any referencing rows still exist when the constraint is checked), but with
+    /// a subtle twist we decided not to emulate: NO ACTION allows the check to be deferred until later
+    /// in the transaction, whereas RESTRICT does not.
     fn emulated_referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction>;
 
     fn supports_composite_types(&self) -> bool {
@@ -94,7 +99,7 @@ pub trait Connector: Send + Sync {
 
     fn supports_referential_action(&self, relation_mode: &RelationMode, action: ReferentialAction) -> bool {
         match relation_mode {
-            RelationMode::ForeignKeys => self.referential_actions(relation_mode).contains(action),
+            RelationMode::ForeignKeys => self.referential_actions().contains(action),
             RelationMode::Prisma => self.emulated_referential_actions(relation_mode).contains(action),
         }
     }

--- a/psl/psl-core/src/datamodel_connector.rs
+++ b/psl/psl-core/src/datamodel_connector.rs
@@ -73,6 +73,9 @@ pub trait Connector: Send + Sync {
     /// The referential actions supported by the connector.
     fn referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction>;
 
+    /// The referential actions supported when using relationMode = "prisma" by the connector.
+    fn simulated_referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction>;
+
     fn supports_composite_types(&self) -> bool {
         self.has_capability(ConnectorCapability::CompositeTypes)
     }
@@ -90,7 +93,10 @@ pub trait Connector: Send + Sync {
     }
 
     fn supports_referential_action(&self, relation_mode: &RelationMode, action: ReferentialAction) -> bool {
-        self.referential_actions(relation_mode).contains(action)
+        match relation_mode {
+            RelationMode::ForeignKeys => self.referential_actions(relation_mode).contains(action),
+            RelationMode::Prisma => self.simulated_referential_actions(relation_mode).contains(action),
+        }
     }
 
     /// This is used by the query engine schema builder.

--- a/psl/psl-core/src/datamodel_connector.rs
+++ b/psl/psl-core/src/datamodel_connector.rs
@@ -79,8 +79,8 @@ pub trait Connector: Send + Sync {
     /// (raising an error if any referencing rows still exist when the constraint is checked), but with
     /// a subtle twist we decided not to emulate: NO ACTION allows the check to be deferred until later
     /// in the transaction, whereas RESTRICT does not.
-    fn emulated_referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
-        relation_mode.allowed_emulated_referential_actions_default()
+    fn emulated_referential_actions(&self) -> BitFlags<ReferentialAction> {
+        RelationMode::allowed_emulated_referential_actions_default()
     }
 
     fn supports_composite_types(&self) -> bool {
@@ -102,7 +102,7 @@ pub trait Connector: Send + Sync {
     fn supports_referential_action(&self, relation_mode: &RelationMode, action: ReferentialAction) -> bool {
         match relation_mode {
             RelationMode::ForeignKeys => self.referential_actions().contains(action),
-            RelationMode::Prisma => self.emulated_referential_actions(relation_mode).contains(action),
+            RelationMode::Prisma => self.emulated_referential_actions().contains(action),
         }
     }
 

--- a/psl/psl-core/src/datamodel_connector.rs
+++ b/psl/psl-core/src/datamodel_connector.rs
@@ -74,7 +74,7 @@ pub trait Connector: Send + Sync {
     fn referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction>;
 
     /// The referential actions supported when using relationMode = "prisma" by the connector.
-    fn simulated_referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction>;
+    fn emulated_referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction>;
 
     fn supports_composite_types(&self) -> bool {
         self.has_capability(ConnectorCapability::CompositeTypes)
@@ -95,7 +95,7 @@ pub trait Connector: Send + Sync {
     fn supports_referential_action(&self, relation_mode: &RelationMode, action: ReferentialAction) -> bool {
         match relation_mode {
             RelationMode::ForeignKeys => self.referential_actions(relation_mode).contains(action),
-            RelationMode::Prisma => self.simulated_referential_actions(relation_mode).contains(action),
+            RelationMode::Prisma => self.emulated_referential_actions(relation_mode).contains(action),
         }
     }
 

--- a/psl/psl-core/src/datamodel_connector.rs
+++ b/psl/psl-core/src/datamodel_connector.rs
@@ -79,7 +79,9 @@ pub trait Connector: Send + Sync {
     /// (raising an error if any referencing rows still exist when the constraint is checked), but with
     /// a subtle twist we decided not to emulate: NO ACTION allows the check to be deferred until later
     /// in the transaction, whereas RESTRICT does not.
-    fn emulated_referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction>;
+    fn emulated_referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
+        relation_mode.allowed_emulated_referential_actions_default()
+    }
 
     fn supports_composite_types(&self) -> bool {
         self.has_capability(ConnectorCapability::CompositeTypes)

--- a/psl/psl-core/src/datamodel_connector/empty_connector.rs
+++ b/psl/psl-core/src/datamodel_connector/empty_connector.rs
@@ -19,6 +19,10 @@ impl Connector for EmptyDatamodelConnector {
         BitFlags::all()
     }
 
+    fn simulated_referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
+        relation_mode.allowed_simulated_referential_actions_default()
+    }
+
     fn capabilities(&self) -> &'static [ConnectorCapability] {
         &[
             ConnectorCapability::AutoIncrement,

--- a/psl/psl-core/src/datamodel_connector/empty_connector.rs
+++ b/psl/psl-core/src/datamodel_connector/empty_connector.rs
@@ -19,8 +19,8 @@ impl Connector for EmptyDatamodelConnector {
         BitFlags::all()
     }
 
-    fn simulated_referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
-        relation_mode.allowed_simulated_referential_actions_default()
+    fn emulated_referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
+        relation_mode.allowed_emulated_referential_actions_default()
     }
 
     fn capabilities(&self) -> &'static [ConnectorCapability] {

--- a/psl/psl-core/src/datamodel_connector/empty_connector.rs
+++ b/psl/psl-core/src/datamodel_connector/empty_connector.rs
@@ -19,10 +19,6 @@ impl Connector for EmptyDatamodelConnector {
         BitFlags::all()
     }
 
-    fn emulated_referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
-        relation_mode.allowed_emulated_referential_actions_default()
-    }
-
     fn capabilities(&self) -> &'static [ConnectorCapability] {
         &[
             ConnectorCapability::AutoIncrement,

--- a/psl/psl-core/src/datamodel_connector/empty_connector.rs
+++ b/psl/psl-core/src/datamodel_connector/empty_connector.rs
@@ -15,7 +15,7 @@ impl Connector for EmptyDatamodelConnector {
         std::any::type_name::<EmptyDatamodelConnector>()
     }
 
-    fn referential_actions(&self, _relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
+    fn referential_actions(&self) -> BitFlags<ReferentialAction> {
         BitFlags::all()
     }
 

--- a/psl/psl-core/src/datamodel_connector/relation_mode.rs
+++ b/psl/psl-core/src/datamodel_connector/relation_mode.rs
@@ -16,7 +16,7 @@ pub enum RelationMode {
 }
 
 impl RelationMode {
-    pub fn allowed_simulated_referential_actions_default(self) -> BitFlags<ReferentialAction> {
+    pub fn allowed_emulated_referential_actions_default(self) -> BitFlags<ReferentialAction> {
         use ReferentialAction::*;
 
         Restrict | SetNull | NoAction | Cascade

--- a/psl/psl-core/src/datamodel_connector/relation_mode.rs
+++ b/psl/psl-core/src/datamodel_connector/relation_mode.rs
@@ -16,7 +16,7 @@ pub enum RelationMode {
 }
 
 impl RelationMode {
-    pub fn allowed_emulated_referential_actions_default(self) -> BitFlags<ReferentialAction> {
+    pub fn allowed_emulated_referential_actions_default() -> BitFlags<ReferentialAction> {
         use ReferentialAction::*;
 
         Restrict | SetNull | NoAction | Cascade

--- a/psl/psl-core/src/datamodel_connector/relation_mode.rs
+++ b/psl/psl-core/src/datamodel_connector/relation_mode.rs
@@ -16,19 +16,10 @@ pub enum RelationMode {
 }
 
 impl RelationMode {
-    /// Returns either the given actions if foreign keys are used, or the
-    /// allowed emulated actions if referential integrity happens in Prisma.
-    pub fn allowed_referential_actions(
-        &self,
-        from_connector: BitFlags<ReferentialAction>,
-    ) -> BitFlags<ReferentialAction> {
+    pub fn allowed_simulated_referential_actions_default(self) -> BitFlags<ReferentialAction> {
         use ReferentialAction::*;
 
-        match self {
-            Self::ForeignKeys => from_connector,
-            // The emulated modes should be listed here.
-            Self::Prisma => Restrict | SetNull | NoAction | Cascade,
-        }
+        Restrict | SetNull | NoAction | Cascade
     }
 
     pub fn is_prisma(&self) -> bool {

--- a/psl/psl-core/src/validate/validation_pipeline/validations/relation_fields.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/relation_fields.rs
@@ -1,9 +1,11 @@
 use super::{database_name::validate_db_name, names::Names};
 use crate::{
     ast::{self, WithName, WithSpan},
+    datamodel_connector::RelationMode,
     diagnostics::DatamodelError,
     validate::validation_pipeline::context::Context,
 };
+use enumflags2::BitFlags;
 use itertools::Itertools;
 use parser_database::{
     walkers::{ModelWalker, RelationFieldWalker, RelationName},
@@ -140,39 +142,77 @@ pub(super) fn ignored_related_model(field: RelationFieldWalker<'_>, ctx: &mut Co
 pub(super) fn referential_actions(field: RelationFieldWalker<'_>, ctx: &mut Context<'_>) {
     let connector = ctx.connector;
     let relation_mode = ctx.relation_mode;
-    let msg = |action: ReferentialAction| {
-        let allowed_values = connector
-            .referential_actions(&relation_mode)
-            .iter()
-            .map(|f| format!("`{}`", f.as_str()))
-            .join(", ");
+
+    fn fmt_allowed_actions(allowed_actions: BitFlags<ReferentialAction>) -> String {
+        allowed_actions.iter().map(|f| format!("`{}`", f.as_str())).join(", ")
+    }
+
+    // validation template for relationMode = "foreignKeys"
+    let msg_foreign_keys = |action: ReferentialAction| {
+        let allowed_actions = connector.referential_actions(&relation_mode);
 
         format!(
             "Invalid referential action: `{}`. Allowed values: ({})",
             action.as_str(),
-            allowed_values,
+            fmt_allowed_actions(allowed_actions),
         )
     };
 
-    if let Some(on_delete) = field.explicit_on_delete() {
-        if !ctx.connector.supports_referential_action(&ctx.relation_mode, on_delete) {
-            let span = field
-                .ast_field()
-                .span_for_argument("relation", "onDelete")
-                .unwrap_or_else(|| field.ast_field().span());
+    // validation template for relationMode = "prisma"
+    let msg_prisma = |action: ReferentialAction| {
+        let allowed_actions = connector.simulated_referential_actions(&relation_mode);
 
-            ctx.push_error(DatamodelError::new_validation_error(&msg(on_delete), span));
+        let additional_info = match action {
+            ReferentialAction::NoAction => {
+                if ctx
+                    .connector
+                    .supports_referential_action(&relation_mode, ReferentialAction::Restrict)
+                {
+                    Some(format!(
+                        ". NoAction is not implemented for {}, you could try using Restrict, which behaves the same if you do not need to defer constraint checks in a transaction",
+                        connector.name(),
+                    ))
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        };
+        let additional_info = additional_info.unwrap_or_else(|| String::new());
+
+        format!(
+            "Invalid referential action: `{}`. Allowed values: ({}){additional_info}",
+            action.as_str(),
+            fmt_allowed_actions(allowed_actions),
+        )
+    };
+
+    let msg_template = |action: ReferentialAction| -> String {
+        match relation_mode {
+            RelationMode::ForeignKeys => msg_foreign_keys(action),
+            RelationMode::Prisma => msg_prisma(action),
+        }
+    };
+
+    if let Some(on_delete) = field.explicit_on_delete() {
+        let span = field
+            .ast_field()
+            .span_for_argument("relation", "onDelete")
+            .unwrap_or_else(|| field.ast_field().span());
+
+        if !ctx.connector.supports_referential_action(&ctx.relation_mode, on_delete) {
+            ctx.push_error(DatamodelError::new_validation_error(&msg_template(on_delete), span));
         }
     }
 
     if let Some(on_update) = field.explicit_on_update() {
-        if !ctx.connector.supports_referential_action(&ctx.relation_mode, on_update) {
-            let span = field
-                .ast_field()
-                .span_for_argument("relation", "onUpdate")
-                .unwrap_or_else(|| field.ast_field().span());
+        let span = field
+            .ast_field()
+            .span_for_argument("relation", "onUpdate")
+            .unwrap_or_else(|| field.ast_field().span());
 
-            ctx.push_error(DatamodelError::new_validation_error(&msg(on_update), span));
+        if !ctx.connector.supports_referential_action(&ctx.relation_mode, on_update) {
+            ctx.push_error(DatamodelError::new_validation_error(&msg_template(on_update), span));
         }
     }
 }

--- a/psl/psl-core/src/validate/validation_pipeline/validations/relation_fields.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/relation_fields.rs
@@ -180,7 +180,7 @@ pub(super) fn referential_actions(field: RelationFieldWalker<'_>, ctx: &mut Cont
             }
             _ => None,
         };
-        let additional_info = additional_info.unwrap_or_else(|| String::new());
+        let additional_info = additional_info.unwrap_or("".to_owned());
 
         format!(
             "Invalid referential action: `{}`. Allowed values: ({}){additional_info}",

--- a/psl/psl-core/src/validate/validation_pipeline/validations/relation_fields.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/relation_fields.rs
@@ -180,7 +180,7 @@ pub(super) fn referential_actions(field: RelationFieldWalker<'_>, ctx: &mut Cont
             }
             _ => None,
         };
-        let additional_info = additional_info.unwrap_or_else(String::new);
+        let additional_info = additional_info.unwrap_or_default();
 
         format!(
             "Invalid referential action: `{}`. Allowed values: ({}){additional_info}",

--- a/psl/psl-core/src/validate/validation_pipeline/validations/relation_fields.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/relation_fields.rs
@@ -160,7 +160,7 @@ pub(super) fn referential_actions(field: RelationFieldWalker<'_>, ctx: &mut Cont
 
     // validation template for relationMode = "prisma"
     let msg_prisma = |action: ReferentialAction| {
-        let allowed_actions = connector.simulated_referential_actions(&relation_mode);
+        let allowed_actions = connector.emulated_referential_actions(&relation_mode);
 
         let additional_info = match action {
             ReferentialAction::NoAction => {
@@ -169,7 +169,7 @@ pub(super) fn referential_actions(field: RelationFieldWalker<'_>, ctx: &mut Cont
                     .supports_referential_action(&relation_mode, ReferentialAction::Restrict)
                 {
                     Some(format!(
-                        ". `{}` is not implemented for {}, you could try using `{}`, which behaves the same if you do not need to defer constraint checks in a transaction",
+                        ". `{}` is not implemented for {} when using `relationMode = \"prisma\"`, you could try using `{}`, which behaves the same if you do not need to defer constraint checks in a transaction. Learn more at https://pris.ly/d/relationMode",
                         ReferentialAction::NoAction.as_str(),
                         connector.name(),
                         ReferentialAction::Restrict.as_str(),

--- a/psl/psl-core/src/validate/validation_pipeline/validations/relation_fields.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/relation_fields.rs
@@ -149,7 +149,7 @@ pub(super) fn referential_actions(field: RelationFieldWalker<'_>, ctx: &mut Cont
 
     // validation template for relationMode = "foreignKeys"
     let msg_foreign_keys = |action: ReferentialAction| {
-        let allowed_actions = connector.referential_actions(&relation_mode);
+        let allowed_actions = connector.referential_actions();
 
         format!(
             "Invalid referential action: `{}`. Allowed values: ({})",

--- a/psl/psl-core/src/validate/validation_pipeline/validations/relation_fields.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/relation_fields.rs
@@ -180,7 +180,7 @@ pub(super) fn referential_actions(field: RelationFieldWalker<'_>, ctx: &mut Cont
             }
             _ => None,
         };
-        let additional_info = additional_info.unwrap_or("".to_owned());
+        let additional_info = additional_info.unwrap_or_else(String::new);
 
         format!(
             "Invalid referential action: `{}`. Allowed values: ({}){additional_info}",

--- a/psl/psl-core/src/validate/validation_pipeline/validations/relation_fields.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/relation_fields.rs
@@ -166,7 +166,8 @@ pub(super) fn referential_actions(field: RelationFieldWalker<'_>, ctx: &mut Cont
             ReferentialAction::NoAction => {
                 if ctx
                     .connector
-                    .supports_referential_action(&relation_mode, ReferentialAction::Restrict)
+                    .emulated_referential_actions(&relation_mode)
+                    .contains(ReferentialAction::Restrict)
                 {
                     Some(format!(
                         ". `{}` is not implemented for {} when using `relationMode = \"prisma\"`, you could try using `{}`, which behaves the same if you do not need to defer constraint checks in a transaction. Learn more at https://pris.ly/d/relationMode",

--- a/psl/psl-core/src/validate/validation_pipeline/validations/relation_fields.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/relation_fields.rs
@@ -160,13 +160,13 @@ pub(super) fn referential_actions(field: RelationFieldWalker<'_>, ctx: &mut Cont
 
     // validation template for relationMode = "prisma"
     let msg_prisma = |action: ReferentialAction| {
-        let allowed_actions = connector.emulated_referential_actions(&relation_mode);
+        let allowed_actions = connector.emulated_referential_actions();
 
         let additional_info = match action {
             ReferentialAction::NoAction => {
                 if ctx
                     .connector
-                    .emulated_referential_actions(&relation_mode)
+                    .emulated_referential_actions()
                     .contains(ReferentialAction::Restrict)
                 {
                     Some(format!(

--- a/psl/psl-core/src/validate/validation_pipeline/validations/relation_fields.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/relation_fields.rs
@@ -169,8 +169,10 @@ pub(super) fn referential_actions(field: RelationFieldWalker<'_>, ctx: &mut Cont
                     .supports_referential_action(&relation_mode, ReferentialAction::Restrict)
                 {
                     Some(format!(
-                        ". NoAction is not implemented for {}, you could try using Restrict, which behaves the same if you do not need to defer constraint checks in a transaction",
+                        ". `{}` is not implemented for {}, you could try using `{}`, which behaves the same if you do not need to defer constraint checks in a transaction",
+                        ReferentialAction::NoAction.as_str(),
                         connector.name(),
+                        ReferentialAction::Restrict.as_str(),
                     ))
                 } else {
                     None

--- a/psl/psl-core/src/validate/validation_pipeline/validations/relation_fields.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/relation_fields.rs
@@ -164,13 +164,14 @@ pub(super) fn referential_actions(field: RelationFieldWalker<'_>, ctx: &mut Cont
 
         let additional_info = match action {
             ReferentialAction::NoAction => {
+                // we don't want to suggest the users to use Restrict instead, if the connector doesn't support it
                 if ctx
                     .connector
                     .emulated_referential_actions()
                     .contains(ReferentialAction::Restrict)
                 {
                     Some(format!(
-                        ". `{}` is not implemented for {} when using `relationMode = \"prisma\"`, you could try using `{}`, which behaves the same if you do not need to defer constraint checks in a transaction. Learn more at https://pris.ly/d/relationMode",
+                        ". `{}` is not implemented for {} when using `relationMode = \"prisma\"`, you could try using `{}` instead. Learn more at https://pris.ly/d/relationMode",
                         ReferentialAction::NoAction.as_str(),
                         connector.name(),
                         ReferentialAction::Restrict.as_str(),

--- a/psl/psl/tests/attributes/relations/referential_actions.rs
+++ b/psl/psl/tests/attributes/relations/referential_actions.rs
@@ -598,7 +598,7 @@ fn on_update_no_action_should_not_work_on_postgres_with_prisma_relation_mode() {
     "#};
 
     let expected = expect![[r#"
-        [1;91merror[0m: [1mError validating: Invalid referential action: `NoAction`. Allowed values: (`Cascade`, `Restrict`, `SetNull`). `NoAction` is not implemented for Postgres when using `relationMode = "prisma"`, you could try using `Restrict`, which behaves the same if you do not need to defer constraint checks in a transaction. Learn more at https://pris.ly/d/relationMode[0m
+        [1;91merror[0m: [1mError validating: Invalid referential action: `NoAction`. Allowed values: (`Cascade`, `Restrict`, `SetNull`). `NoAction` is not implemented for Postgres when using `relationMode = "prisma"`, you could try using `Restrict` instead. Learn more at https://pris.ly/d/relationMode[0m
           [1;94m-->[0m  [4mschema.prisma:20[0m
         [1;94m   | [0m
         [1;94m19 | [0m    aId Int
@@ -636,7 +636,7 @@ fn on_delete_no_action_should_not_work_on_postgres_with_prisma_relation_mode() {
     "#};
 
     let expected = expect!([r#"
-        [1;91merror[0m: [1mError validating: Invalid referential action: `NoAction`. Allowed values: (`Cascade`, `Restrict`, `SetNull`). `NoAction` is not implemented for Postgres when using `relationMode = "prisma"`, you could try using `Restrict`, which behaves the same if you do not need to defer constraint checks in a transaction. Learn more at https://pris.ly/d/relationMode[0m
+        [1;91merror[0m: [1mError validating: Invalid referential action: `NoAction`. Allowed values: (`Cascade`, `Restrict`, `SetNull`). `NoAction` is not implemented for Postgres when using `relationMode = "prisma"`, you could try using `Restrict` instead. Learn more at https://pris.ly/d/relationMode[0m
           [1;94m-->[0m  [4mschema.prisma:20[0m
         [1;94m   | [0m
         [1;94m19 | [0m    aId Int
@@ -674,7 +674,7 @@ fn on_update_no_action_should_not_work_on_sqlite_with_prisma_relation_mode() {
     "#};
 
     let expected = expect![[r#"
-        [1;91merror[0m: [1mError validating: Invalid referential action: `NoAction`. Allowed values: (`Cascade`, `Restrict`, `SetNull`). `NoAction` is not implemented for sqlite when using `relationMode = "prisma"`, you could try using `Restrict`, which behaves the same if you do not need to defer constraint checks in a transaction. Learn more at https://pris.ly/d/relationMode[0m
+        [1;91merror[0m: [1mError validating: Invalid referential action: `NoAction`. Allowed values: (`Cascade`, `Restrict`, `SetNull`). `NoAction` is not implemented for sqlite when using `relationMode = "prisma"`, you could try using `Restrict` instead. Learn more at https://pris.ly/d/relationMode[0m
           [1;94m-->[0m  [4mschema.prisma:20[0m
         [1;94m   | [0m
         [1;94m19 | [0m    aId Int
@@ -712,7 +712,7 @@ fn on_delete_no_action_should_not_work_on_sqlite_with_prisma_relation_mode() {
     "#};
 
     let expected = expect!([r#"
-        [1;91merror[0m: [1mError validating: Invalid referential action: `NoAction`. Allowed values: (`Cascade`, `Restrict`, `SetNull`). `NoAction` is not implemented for sqlite when using `relationMode = "prisma"`, you could try using `Restrict`, which behaves the same if you do not need to defer constraint checks in a transaction. Learn more at https://pris.ly/d/relationMode[0m
+        [1;91merror[0m: [1mError validating: Invalid referential action: `NoAction`. Allowed values: (`Cascade`, `Restrict`, `SetNull`). `NoAction` is not implemented for sqlite when using `relationMode = "prisma"`, you could try using `Restrict` instead. Learn more at https://pris.ly/d/relationMode[0m
           [1;94m-->[0m  [4mschema.prisma:20[0m
         [1;94m   | [0m
         [1;94m19 | [0m    aId Int

--- a/psl/psl/tests/attributes/relations/referential_actions.rs
+++ b/psl/psl/tests/attributes/relations/referential_actions.rs
@@ -599,7 +599,7 @@ fn on_update_no_action_should_not_work_on_postgres_with_prisma_relation_mode() {
     "#};
 
     let expected = expect![[r#"
-        [1;91merror[0m: [1mError validating: Invalid referential action: `NoAction`. Allowed values: (`Cascade`, `Restrict`, `SetNull`). `NoAction` is not implemented for Postgres, you could try using `Restrict`, which behaves the same if you do not need to defer constraint checks in a transaction[0m
+        [1;91merror[0m: [1mError validating: Invalid referential action: `NoAction`. Allowed values: (`Cascade`, `Restrict`, `SetNull`). `NoAction` is not implemented for Postgres when using `relationMode = "prisma"`, you could try using `Restrict`, which behaves the same if you do not need to defer constraint checks in a transaction. Learn more at https://pris.ly/d/relationMode[0m
           [1;94m-->[0m  [4mschema.prisma:20[0m
         [1;94m   | [0m
         [1;94m19 | [0m    aId Int
@@ -637,7 +637,7 @@ fn on_delete_no_action_should_not_work_on_postgres_with_prisma_relation_mode() {
     "#};
 
     let expected = expect!([r#"
-        [1;91merror[0m: [1mError validating: Invalid referential action: `NoAction`. Allowed values: (`Cascade`, `Restrict`, `SetNull`). `NoAction` is not implemented for Postgres, you could try using `Restrict`, which behaves the same if you do not need to defer constraint checks in a transaction[0m
+        [1;91merror[0m: [1mError validating: Invalid referential action: `NoAction`. Allowed values: (`Cascade`, `Restrict`, `SetNull`). `NoAction` is not implemented for Postgres when using `relationMode = "prisma"`, you could try using `Restrict`, which behaves the same if you do not need to defer constraint checks in a transaction. Learn more at https://pris.ly/d/relationMode[0m
           [1;94m-->[0m  [4mschema.prisma:20[0m
         [1;94m   | [0m
         [1;94m19 | [0m    aId Int
@@ -675,7 +675,7 @@ fn on_update_no_action_should_not_work_on_sqlite_with_prisma_relation_mode() {
     "#};
 
     let expected = expect![[r#"
-        [1;91merror[0m: [1mError validating: Invalid referential action: `NoAction`. Allowed values: (`Cascade`, `Restrict`, `SetNull`). `NoAction` is not implemented for sqlite, you could try using `Restrict`, which behaves the same if you do not need to defer constraint checks in a transaction[0m
+        [1;91merror[0m: [1mError validating: Invalid referential action: `NoAction`. Allowed values: (`Cascade`, `Restrict`, `SetNull`). `NoAction` is not implemented for sqlite when using `relationMode = "prisma"`, you could try using `Restrict`, which behaves the same if you do not need to defer constraint checks in a transaction. Learn more at https://pris.ly/d/relationMode[0m
           [1;94m-->[0m  [4mschema.prisma:20[0m
         [1;94m   | [0m
         [1;94m19 | [0m    aId Int
@@ -713,7 +713,7 @@ fn on_delete_no_action_should_not_work_on_sqlite_with_prisma_relation_mode() {
     "#};
 
     let expected = expect!([r#"
-        [1;91merror[0m: [1mError validating: Invalid referential action: `NoAction`. Allowed values: (`Cascade`, `Restrict`, `SetNull`). `NoAction` is not implemented for sqlite, you could try using `Restrict`, which behaves the same if you do not need to defer constraint checks in a transaction[0m
+        [1;91merror[0m: [1mError validating: Invalid referential action: `NoAction`. Allowed values: (`Cascade`, `Restrict`, `SetNull`). `NoAction` is not implemented for sqlite when using `relationMode = "prisma"`, you could try using `Restrict`, which behaves the same if you do not need to defer constraint checks in a transaction. Learn more at https://pris.ly/d/relationMode[0m
           [1;94m-->[0m  [4mschema.prisma:20[0m
         [1;94m   | [0m
         [1;94m19 | [0m    aId Int

--- a/psl/psl/tests/attributes/relations/referential_actions.rs
+++ b/psl/psl/tests/attributes/relations/referential_actions.rs
@@ -599,7 +599,7 @@ fn on_update_no_action_should_not_work_on_postgres_with_prisma_relation_mode() {
     "#};
 
     let expected = expect![[r#"
-        [1;91merror[0m: [1mError validating: Invalid referential action: `NoAction`. Allowed values: (`Cascade`, `Restrict`, `SetNull`). NoAction is not implemented for Postgres, you could try using Restrict, which behaves the same if you do not need to defer constraint checks in a transaction[0m
+        [1;91merror[0m: [1mError validating: Invalid referential action: `NoAction`. Allowed values: (`Cascade`, `Restrict`, `SetNull`). `NoAction` is not implemented for Postgres, you could try using `Restrict`, which behaves the same if you do not need to defer constraint checks in a transaction[0m
           [1;94m-->[0m  [4mschema.prisma:20[0m
         [1;94m   | [0m
         [1;94m19 | [0m    aId Int
@@ -637,7 +637,7 @@ fn on_delete_no_action_should_not_work_on_postgres_with_prisma_relation_mode() {
     "#};
 
     let expected = expect!([r#"
-        [1;91merror[0m: [1mError validating: Invalid referential action: `NoAction`. Allowed values: (`Cascade`, `Restrict`, `SetNull`). NoAction is not implemented for Postgres, you could try using Restrict, which behaves the same if you do not need to defer constraint checks in a transaction[0m
+        [1;91merror[0m: [1mError validating: Invalid referential action: `NoAction`. Allowed values: (`Cascade`, `Restrict`, `SetNull`). `NoAction` is not implemented for Postgres, you could try using `Restrict`, which behaves the same if you do not need to defer constraint checks in a transaction[0m
           [1;94m-->[0m  [4mschema.prisma:20[0m
         [1;94m   | [0m
         [1;94m19 | [0m    aId Int
@@ -675,7 +675,7 @@ fn on_update_no_action_should_not_work_on_sqlite_with_prisma_relation_mode() {
     "#};
 
     let expected = expect![[r#"
-        [1;91merror[0m: [1mError validating: Invalid referential action: `NoAction`. Allowed values: (`Cascade`, `Restrict`, `SetNull`). NoAction is not implemented for sqlite, you could try using Restrict, which behaves the same if you do not need to defer constraint checks in a transaction[0m
+        [1;91merror[0m: [1mError validating: Invalid referential action: `NoAction`. Allowed values: (`Cascade`, `Restrict`, `SetNull`). `NoAction` is not implemented for sqlite, you could try using `Restrict`, which behaves the same if you do not need to defer constraint checks in a transaction[0m
           [1;94m-->[0m  [4mschema.prisma:20[0m
         [1;94m   | [0m
         [1;94m19 | [0m    aId Int
@@ -713,7 +713,7 @@ fn on_delete_no_action_should_not_work_on_sqlite_with_prisma_relation_mode() {
     "#};
 
     let expected = expect!([r#"
-        [1;91merror[0m: [1mError validating: Invalid referential action: `NoAction`. Allowed values: (`Cascade`, `Restrict`, `SetNull`). NoAction is not implemented for sqlite, you could try using Restrict, which behaves the same if you do not need to defer constraint checks in a transaction[0m
+        [1;91merror[0m: [1mError validating: Invalid referential action: `NoAction`. Allowed values: (`Cascade`, `Restrict`, `SetNull`). `NoAction` is not implemented for sqlite, you could try using `Restrict`, which behaves the same if you do not need to defer constraint checks in a transaction[0m
           [1;94m-->[0m  [4mschema.prisma:20[0m
         [1;94m   | [0m
         [1;94m19 | [0m    aId Int

--- a/psl/psl/tests/attributes/relations/referential_actions.rs
+++ b/psl/psl/tests/attributes/relations/referential_actions.rs
@@ -96,6 +96,201 @@ fn actions_on_mongo() {
 }
 
 #[test]
+fn actions_on_mysql_with_prisma_relation_mode() {
+    let actions = &[Cascade, Restrict, NoAction, SetNull];
+
+    for action in actions {
+        let dml = formatdoc!(
+            r#"
+            generator client {{
+                provider = "prisma-client-js"
+                previewFeatures = ["referentialIntegrity"]
+            }}
+    
+            datasource db {{
+                provider = "mysql"
+                url = "mysql://"
+                relationMode = "prisma"
+            }}
+
+            model A {{
+                id Int @id
+                bs B[]
+            }}
+
+            model B {{
+                id Int @id
+                aId Int
+                a A @relation(fields: [aId], references: [id], onDelete: {action})
+            }}
+        "#,
+            action = action
+        );
+
+        parse(&dml)
+            .assert_has_model("B")
+            .assert_has_relation_field("a")
+            .assert_relation_delete_strategy(*action);
+    }
+}
+
+#[test]
+fn actions_on_sqlserver_with_prisma_relation_mode() {
+    let actions = &[Cascade, NoAction, SetNull];
+
+    for action in actions {
+        let dml = formatdoc!(
+            r#"
+            generator client {{
+                provider = "prisma-client-js"
+                previewFeatures = ["referentialIntegrity"]
+            }}
+    
+            datasource db {{
+                provider = "sqlserver"
+                url = "sqlserver://"
+                relationMode = "prisma"
+            }}
+
+            model A {{
+                id Int @id
+                bs B[]
+            }}
+
+            model B {{
+                id Int @id
+                aId Int
+                a A @relation(fields: [aId], references: [id], onDelete: {action})
+            }}
+        "#,
+            action = action
+        );
+
+        parse(&dml)
+            .assert_has_model("B")
+            .assert_has_relation_field("a")
+            .assert_relation_delete_strategy(*action);
+    }
+}
+
+#[test]
+fn actions_on_cockroachdb_with_prisma_relation_mode() {
+    let actions = &[Cascade, Restrict, NoAction, SetNull];
+
+    for action in actions {
+        let dml = formatdoc!(
+            r#"
+            generator client {{
+                provider = "prisma-client-js"
+                previewFeatures = ["referentialIntegrity"]
+            }}
+    
+            datasource db {{
+                provider = "cockroachdb"
+                url = "sqlserver://"
+                relationMode = "prisma"
+            }}
+
+            model A {{
+                id Int @id
+                bs B[]
+            }}
+
+            model B {{
+                id Int @id
+                aId Int
+                a A @relation(fields: [aId], references: [id], onDelete: {action})
+            }}
+        "#,
+            action = action
+        );
+
+        parse(&dml)
+            .assert_has_model("B")
+            .assert_has_relation_field("a")
+            .assert_relation_delete_strategy(*action);
+    }
+}
+
+#[test]
+fn actions_on_postgres_with_prisma_relation_mode() {
+    let actions = &[Cascade, Restrict, SetNull];
+
+    for action in actions {
+        let dml = formatdoc!(
+            r#"
+            generator client {{
+                provider = "prisma-client-js"
+                previewFeatures = ["referentialIntegrity"]
+            }}
+    
+            datasource db {{
+                provider = "postgres"
+                url = "postgres://"
+                relationMode = "prisma"
+            }}
+
+            model A {{
+                id Int @id
+                bs B[]
+            }}
+
+            model B {{
+                id Int @id
+                aId Int
+                a A @relation(fields: [aId], references: [id], onDelete: {action})
+            }}
+        "#,
+            action = action
+        );
+
+        parse(&dml)
+            .assert_has_model("B")
+            .assert_has_relation_field("a")
+            .assert_relation_delete_strategy(*action);
+    }
+}
+
+#[test]
+fn actions_on_sqlite_with_prisma_relation_mode() {
+    let actions = &[Cascade, Restrict, SetNull];
+
+    for action in actions {
+        let dml = formatdoc!(
+            r#"
+            generator client {{
+                provider = "prisma-client-js"
+                previewFeatures = ["referentialIntegrity"]
+            }}
+    
+            datasource db {{
+                provider = "sqlite"
+                url = "./dev.db"
+                relationMode = "prisma"
+            }}
+
+            model A {{
+                id Int @id
+                bs B[]
+            }}
+
+            model B {{
+                id Int @id
+                aId Int
+                a A @relation(fields: [aId], references: [id], onDelete: {action})
+            }}
+        "#,
+            action = action
+        );
+
+        parse(&dml)
+            .assert_has_model("B")
+            .assert_has_relation_field("a")
+            .assert_relation_delete_strategy(*action);
+    }
+}
+
+#[test]
 fn on_delete_actions_should_work_on_prisma_relation_mode() {
     let actions = &[Restrict, SetNull, Cascade, NoAction];
 

--- a/psl/psl/tests/attributes/relations/referential_actions.rs
+++ b/psl/psl/tests/attributes/relations/referential_actions.rs
@@ -4,7 +4,6 @@ use crate::common::*;
 use psl::{
     datamodel_connector::RelationMode,
     dml::ReferentialAction::{self, *},
-    parse_schema,
 };
 
 #[test]
@@ -607,7 +606,7 @@ fn on_update_no_action_should_not_work_on_postgres_with_prisma_relation_mode() {
         [1;94m   | [0m
     "#]];
 
-    expected.assert_eq(&parse_schema(dml).map(drop).unwrap_err())
+    expect_error(dml, &expected);
 }
 
 #[test]
@@ -645,7 +644,7 @@ fn on_delete_no_action_should_not_work_on_postgres_with_prisma_relation_mode() {
         [1;94m   | [0m
     "#]);
 
-    expected.assert_eq(&parse_schema(dml).map(drop).unwrap_err())
+    expect_error(dml, &expected);
 }
 
 #[test]
@@ -683,7 +682,7 @@ fn on_update_no_action_should_not_work_on_sqlite_with_prisma_relation_mode() {
         [1;94m   | [0m
     "#]];
 
-    expected.assert_eq(&parse_schema(dml).map(drop).unwrap_err())
+    expect_error(dml, &expected);
 }
 
 #[test]
@@ -721,7 +720,7 @@ fn on_delete_no_action_should_not_work_on_sqlite_with_prisma_relation_mode() {
         [1;94m   | [0m
     "#]);
 
-    expected.assert_eq(&parse_schema(dml).map(drop).unwrap_err())
+    expect_error(dml, &expected);
 }
 
 #[test]


### PR DESCRIPTION
With this PR:
- `NoAction` becomes invalid for PostgreSQL and SQLite when `relationMode = "prisma"` with a standard validation message, e.g.:
  > Invalid referential action: `NoAction`. Allowed values: (`Cascade`, `Restrict`, `SetNull`)

- When `relationMode = "prisma"`, `NoAction` is not supported, but `Restrict` is supported, the validation error message shows more information:
  > Invalid referential action: `NoAction`. Allowed values: (`Cascade`, `Restrict`, `SetNull`). `NoAction` is not implemented for Postgres, you could try using `Restrict`, which behaves the same if you do not need to defer constraint checks in a transaction

Contributes to https://github.com/prisma/prisma/issues/15655.