### PR TITLE
Integration: remove simulated `NoAction` for postgres and sqlite

### DIFF
--- a/psl/builtin-connectors/src/cockroach_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/cockroach_datamodel_connector.rs
@@ -133,10 +133,14 @@ impl Connector for CockroachDatamodelConnector {
         63
     }
 
-    fn referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
+    fn referential_actions(&self, _relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
         use ReferentialAction::*;
 
-        relation_mode.allowed_referential_actions(NoAction | Restrict | Cascade | SetNull | SetDefault)
+        NoAction | Restrict | Cascade | SetNull | SetDefault
+    }
+
+    fn simulated_referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
+        relation_mode.allowed_simulated_referential_actions_default()
     }
 
     fn scalar_type_for_native_type(&self, native_type: serde_json::Value) -> ScalarType {

--- a/psl/builtin-connectors/src/mongodb.rs
+++ b/psl/builtin-connectors/src/mongodb.rs
@@ -54,8 +54,12 @@ impl Connector for MongoDbDatamodelConnector {
         &[ConstraintScope::ModelKeyIndex]
     }
 
-    fn referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
-        relation_mode.allowed_referential_actions(BitFlags::empty())
+    fn referential_actions(&self, _relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
+        BitFlags::empty()
+    }
+
+    fn simulated_referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
+        relation_mode.allowed_simulated_referential_actions_default()
     }
 
     fn validate_model(&self, model: ModelWalker<'_>, errors: &mut Diagnostics) {

--- a/psl/builtin-connectors/src/mssql_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/mssql_datamodel_connector.rs
@@ -171,10 +171,14 @@ impl Connector for MsSqlDatamodelConnector {
         128
     }
 
-    fn referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
+    fn referential_actions(&self, _relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
         use ReferentialAction::*;
 
-        relation_mode.allowed_referential_actions(NoAction | Cascade | SetNull | SetDefault)
+        NoAction | Cascade | SetNull | SetDefault
+    }
+
+    fn simulated_referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
+        relation_mode.allowed_simulated_referential_actions_default()
     }
 
     fn scalar_type_for_native_type(&self, native_type: serde_json::Value) -> ScalarType {

--- a/psl/builtin-connectors/src/mysql_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/mysql_datamodel_connector.rs
@@ -160,10 +160,14 @@ impl Connector for MySqlDatamodelConnector {
         64
     }
 
-    fn referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
+    fn referential_actions(&self, _relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
         use ReferentialAction::*;
 
-        relation_mode.allowed_referential_actions(Restrict | Cascade | SetNull | NoAction | SetDefault)
+        Restrict | Cascade | SetNull | NoAction | SetDefault
+    }
+
+    fn simulated_referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
+        relation_mode.allowed_simulated_referential_actions_default()
     }
 
     fn scalar_type_for_native_type(&self, native_type: serde_json::Value) -> ScalarType {

--- a/psl/builtin-connectors/src/postgres_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/postgres_datamodel_connector.rs
@@ -154,10 +154,16 @@ impl Connector for PostgresDatamodelConnector {
         63
     }
 
-    fn referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
+    fn referential_actions(&self, _relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
         use ReferentialAction::*;
 
-        relation_mode.allowed_referential_actions(NoAction | Restrict | Cascade | SetNull | SetDefault)
+        NoAction | Restrict | Cascade | SetNull | SetDefault
+    }
+
+    fn simulated_referential_actions(&self, _relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
+        use ReferentialAction::*;
+
+        Restrict | SetNull | Cascade
     }
 
     fn scalar_type_for_native_type(&self, native_type: serde_json::Value) -> ScalarType {

--- a/psl/builtin-connectors/src/sqlite_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/sqlite_datamodel_connector.rs
@@ -43,10 +43,16 @@ impl Connector for SqliteDatamodelConnector {
         10000
     }
 
-    fn referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
+    fn referential_actions(&self, _relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
         use ReferentialAction::*;
 
-        relation_mode.allowed_referential_actions(SetNull | SetDefault | Cascade | Restrict | NoAction)
+        SetNull | SetDefault | Cascade | Restrict | NoAction
+    }
+
+    fn simulated_referential_actions(&self, _relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
+        use ReferentialAction::*;
+
+        Restrict | SetNull | Cascade
     }
 
     fn scalar_type_for_native_type(&self, _native_type: serde_json::Value) -> ScalarType {

--- a/psl/psl-core/src/datamodel_connector.rs
+++ b/psl/psl-core/src/datamodel_connector.rs
@@ -73,6 +73,9 @@ pub trait Connector: Send + Sync {
     /// The referential actions supported by the connector.
     fn referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction>;
 
+    /// The referential actions supported when using relationMode = "prisma" by the connector.
+    fn simulated_referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction>;
+
     fn supports_composite_types(&self) -> bool {
         self.has_capability(ConnectorCapability::CompositeTypes)
     }
@@ -90,7 +93,10 @@ pub trait Connector: Send + Sync {
     }
 
     fn supports_referential_action(&self, relation_mode: &RelationMode, action: ReferentialAction) -> bool {
-        self.referential_actions(relation_mode).contains(action)
+        match relation_mode {
+            RelationMode::ForeignKeys => self.referential_actions(relation_mode).contains(action),
+            RelationMode::Prisma => self.simulated_referential_actions(relation_mode).contains(action),
+        }
     }
 
     /// This is used by the query engine schema builder.

--- a/psl/psl-core/src/datamodel_connector/empty_connector.rs
+++ b/psl/psl-core/src/datamodel_connector/empty_connector.rs
@@ -19,6 +19,10 @@ impl Connector for EmptyDatamodelConnector {
         BitFlags::all()
     }
 
+    fn simulated_referential_actions(&self, relation_mode: &RelationMode) -> BitFlags<ReferentialAction> {
+        relation_mode.allowed_simulated_referential_actions_default()
+    }
+
     fn capabilities(&self) -> &'static [ConnectorCapability] {
         &[
             ConnectorCapability::AutoIncrement,

--- a/psl/psl-core/src/datamodel_connector/relation_mode.rs
+++ b/psl/psl-core/src/datamodel_connector/relation_mode.rs
@@ -16,19 +16,10 @@ pub enum RelationMode {
 }
 
 impl RelationMode {
-    /// Returns either the given actions if foreign keys are used, or the
-    /// allowed emulated actions if referential integrity happens in Prisma.
-    pub fn allowed_referential_actions(
-        &self,
-        from_connector: BitFlags<ReferentialAction>,
-    ) -> BitFlags<ReferentialAction> {
+    pub fn allowed_simulated_referential_actions_default(self) -> BitFlags<ReferentialAction> {
         use ReferentialAction::*;
 
-        match self {
-            Self::ForeignKeys => from_connector,
-            // The emulated modes should be listed here.
-            Self::Prisma => Restrict | SetNull | NoAction | Cascade,
-        }
+        Restrict | SetNull | NoAction | Cascade
     }
 
     pub fn is_prisma(&self) -> bool {

--- a/psl/psl-core/src/validate/validation_pipeline/validations/relation_fields.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/relation_fields.rs
@@ -1,9 +1,11 @@
 use super::{database_name::validate_db_name, names::Names};
 use crate::{
     ast::{self, WithName, WithSpan},
+    datamodel_connector::RelationMode,
     diagnostics::DatamodelError,
     validate::validation_pipeline::context::Context,
 };
+use enumflags2::BitFlags;
 use itertools::Itertools;
 use parser_database::{
     walkers::{ModelWalker, RelationFieldWalker, RelationName},
@@ -140,39 +142,77 @@ pub(super) fn ignored_related_model(field: RelationFieldWalker<'_>, ctx: &mut Co
 pub(super) fn referential_actions(field: RelationFieldWalker<'_>, ctx: &mut Context<'_>) {
     let connector = ctx.connector;
     let relation_mode = ctx.relation_mode;
-    let msg = |action: ReferentialAction| {
-        let allowed_values = connector
-            .referential_actions(&relation_mode)
-            .iter()
-            .map(|f| format!("`{}`", f.as_str()))
-            .join(", ");
+
+    fn fmt_allowed_actions(allowed_actions: BitFlags<ReferentialAction>) -> String {
+        allowed_actions.iter().map(|f| format!("`{}`", f.as_str())).join(", ")
+    }
+
+    // validation template for relationMode = "foreignKeys"
+    let msg_foreign_keys = |action: ReferentialAction| {
+        let allowed_actions = connector.referential_actions(&relation_mode);
 
         format!(
             "Invalid referential action: `{}`. Allowed values: ({})",
             action.as_str(),
-            allowed_values,
+            fmt_allowed_actions(allowed_actions),
         )
     };
 
-    if let Some(on_delete) = field.explicit_on_delete() {
-        if !ctx.connector.supports_referential_action(&ctx.relation_mode, on_delete) {
-            let span = field
-                .ast_field()
-                .span_for_argument("relation", "onDelete")
-                .unwrap_or_else(|| field.ast_field().span());
+    // validation template for relationMode = "prisma"
+    let msg_prisma = |action: ReferentialAction| {
+        let allowed_actions = connector.simulated_referential_actions(&relation_mode);
 
-            ctx.push_error(DatamodelError::new_validation_error(&msg(on_delete), span));
+        let additional_info = match action {
+            ReferentialAction::NoAction => {
+                if ctx
+                    .connector
+                    .supports_referential_action(&relation_mode, ReferentialAction::Restrict)
+                {
+                    Some(format!(
+                        ". NoAction is not implemented for {}, you could try using Restrict, which behaves the same if you do not need to defer constraint checks in a transaction",
+                        connector.name(),
+                    ))
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        };
+        let additional_info = additional_info.unwrap_or_else(|| String::new());
+
+        format!(
+            "Invalid referential action: `{}`. Allowed values: ({}){additional_info}",
+            action.as_str(),
+            fmt_allowed_actions(allowed_actions),
+        )
+    };
+
+    let msg_template = |action: ReferentialAction| -> String {
+        match relation_mode {
+            RelationMode::ForeignKeys => msg_foreign_keys(action),
+            RelationMode::Prisma => msg_prisma(action),
+        }
+    };
+
+    if let Some(on_delete) = field.explicit_on_delete() {
+        let span = field
+            .ast_field()
+            .span_for_argument("relation", "onDelete")
+            .unwrap_or_else(|| field.ast_field().span());
+
+        if !ctx.connector.supports_referential_action(&ctx.relation_mode, on_delete) {
+            ctx.push_error(DatamodelError::new_validation_error(&msg_template(on_delete), span));
         }
     }
 
     if let Some(on_update) = field.explicit_on_update() {
-        if !ctx.connector.supports_referential_action(&ctx.relation_mode, on_update) {
-            let span = field
-                .ast_field()
-                .span_for_argument("relation", "onUpdate")
-                .unwrap_or_else(|| field.ast_field().span());
+        let span = field
+            .ast_field()
+            .span_for_argument("relation", "onUpdate")
+            .unwrap_or_else(|| field.ast_field().span());
 
-            ctx.push_error(DatamodelError::new_validation_error(&msg(on_update), span));
+        if !ctx.connector.supports_referential_action(&ctx.relation_mode, on_update) {
+            ctx.push_error(DatamodelError::new_validation_error(&msg_template(on_update), span));
         }
     }
 }

--- a/psl/psl-core/src/validate/validation_pipeline/validations/relation_fields.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/relation_fields.rs
@@ -180,7 +180,7 @@ pub(super) fn referential_actions(field: RelationFieldWalker<'_>, ctx: &mut Cont
             }
             _ => None,
         };
-        let additional_info = additional_info.unwrap_or_else(|| String::new());
+        let additional_info = additional_info.unwrap_or("".to_owned());
 
         format!(
             "Invalid referential action: `{}`. Allowed values: ({}){additional_info}",

--- a/psl/psl-core/src/validate/validation_pipeline/validations/relation_fields.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/relation_fields.rs
@@ -169,8 +169,10 @@ pub(super) fn referential_actions(field: RelationFieldWalker<'_>, ctx: &mut Cont
                     .supports_referential_action(&relation_mode, ReferentialAction::Restrict)
                 {
                     Some(format!(
-                        ". NoAction is not implemented for {}, you could try using Restrict, which behaves the same if you do not need to defer constraint checks in a transaction",
+                        ". `{}` is not implemented for {}, you could try using `{}`, which behaves the same if you do not need to defer constraint checks in a transaction",
+                        ReferentialAction::NoAction.as_str(),
                         connector.name(),
+                        ReferentialAction::Restrict.as_str(),
                     ))
                 } else {
                     None

--- a/psl/psl/tests/attributes/relations/referential_actions.rs
+++ b/psl/psl/tests/attributes/relations/referential_actions.rs
@@ -599,7 +599,7 @@ fn on_update_no_action_should_not_work_on_postgres_with_prisma_relation_mode() {
     "#};
 
     let expected = expect![[r#"
-        [1;91merror[0m: [1mError validating: Invalid referential action: `NoAction`. Allowed values: (`Cascade`, `Restrict`, `SetNull`). NoAction is not implemented for Postgres, you could try using Restrict, which behaves the same if you do not need to defer constraint checks in a transaction[0m
+        [1;91merror[0m: [1mError validating: Invalid referential action: `NoAction`. Allowed values: (`Cascade`, `Restrict`, `SetNull`). `NoAction` is not implemented for Postgres, you could try using `Restrict`, which behaves the same if you do not need to defer constraint checks in a transaction[0m
           [1;94m-->[0m  [4mschema.prisma:20[0m
         [1;94m   | [0m
         [1;94m19 | [0m    aId Int
@@ -637,7 +637,7 @@ fn on_delete_no_action_should_not_work_on_postgres_with_prisma_relation_mode() {
     "#};
 
     let expected = expect!([r#"
-        [1;91merror[0m: [1mError validating: Invalid referential action: `NoAction`. Allowed values: (`Cascade`, `Restrict`, `SetNull`). NoAction is not implemented for Postgres, you could try using Restrict, which behaves the same if you do not need to defer constraint checks in a transaction[0m
+        [1;91merror[0m: [1mError validating: Invalid referential action: `NoAction`. Allowed values: (`Cascade`, `Restrict`, `SetNull`). `NoAction` is not implemented for Postgres, you could try using `Restrict`, which behaves the same if you do not need to defer constraint checks in a transaction[0m
           [1;94m-->[0m  [4mschema.prisma:20[0m
         [1;94m   | [0m
         [1;94m19 | [0m    aId Int
@@ -675,7 +675,7 @@ fn on_update_no_action_should_not_work_on_sqlite_with_prisma_relation_mode() {
     "#};
 
     let expected = expect![[r#"
-        [1;91merror[0m: [1mError validating: Invalid referential action: `NoAction`. Allowed values: (`Cascade`, `Restrict`, `SetNull`). NoAction is not implemented for sqlite, you could try using Restrict, which behaves the same if you do not need to defer constraint checks in a transaction[0m
+        [1;91merror[0m: [1mError validating: Invalid referential action: `NoAction`. Allowed values: (`Cascade`, `Restrict`, `SetNull`). `NoAction` is not implemented for sqlite, you could try using `Restrict`, which behaves the same if you do not need to defer constraint checks in a transaction[0m
           [1;94m-->[0m  [4mschema.prisma:20[0m
         [1;94m   | [0m
         [1;94m19 | [0m    aId Int
@@ -713,7 +713,7 @@ fn on_delete_no_action_should_not_work_on_sqlite_with_prisma_relation_mode() {
     "#};
 
     let expected = expect!([r#"
-        [1;91merror[0m: [1mError validating: Invalid referential action: `NoAction`. Allowed values: (`Cascade`, `Restrict`, `SetNull`). NoAction is not implemented for sqlite, you could try using Restrict, which behaves the same if you do not need to defer constraint checks in a transaction[0m
+        [1;91merror[0m: [1mError validating: Invalid referential action: `NoAction`. Allowed values: (`Cascade`, `Restrict`, `SetNull`). `NoAction` is not implemented for sqlite, you could try using `Restrict`, which behaves the same if you do not need to defer constraint checks in a transaction[0m
           [1;94m-->[0m  [4mschema.prisma:20[0m
         [1;94m   | [0m
         [1;94m19 | [0m    aId Int

--- a/psl/psl/tests/attributes/relations/referential_actions.rs
+++ b/psl/psl/tests/attributes/relations/referential_actions.rs
@@ -96,6 +96,201 @@ fn actions_on_mongo() {
 }
 
 #[test]
+fn actions_on_mysql_with_prisma_relation_mode() {
+    let actions = &[Cascade, Restrict, NoAction, SetNull];
+
+    for action in actions {
+        let dml = formatdoc!(
+            r#"
+            generator client {{
+                provider = "prisma-client-js"
+                previewFeatures = ["referentialIntegrity"]
+            }}
+    
+            datasource db {{
+                provider = "mysql"
+                url = "mysql://"
+                relationMode = "prisma"
+            }}
+
+            model A {{
+                id Int @id
+                bs B[]
+            }}
+
+            model B {{
+                id Int @id
+                aId Int
+                a A @relation(fields: [aId], references: [id], onDelete: {action})
+            }}
+        "#,
+            action = action
+        );
+
+        parse(&dml)
+            .assert_has_model("B")
+            .assert_has_relation_field("a")
+            .assert_relation_delete_strategy(*action);
+    }
+}
+
+#[test]
+fn actions_on_sqlserver_with_prisma_relation_mode() {
+    let actions = &[Cascade, NoAction, SetNull];
+
+    for action in actions {
+        let dml = formatdoc!(
+            r#"
+            generator client {{
+                provider = "prisma-client-js"
+                previewFeatures = ["referentialIntegrity"]
+            }}
+    
+            datasource db {{
+                provider = "sqlserver"
+                url = "sqlserver://"
+                relationMode = "prisma"
+            }}
+
+            model A {{
+                id Int @id
+                bs B[]
+            }}
+
+            model B {{
+                id Int @id
+                aId Int
+                a A @relation(fields: [aId], references: [id], onDelete: {action})
+            }}
+        "#,
+            action = action
+        );
+
+        parse(&dml)
+            .assert_has_model("B")
+            .assert_has_relation_field("a")
+            .assert_relation_delete_strategy(*action);
+    }
+}
+
+#[test]
+fn actions_on_cockroachdb_with_prisma_relation_mode() {
+    let actions = &[Cascade, Restrict, NoAction, SetNull];
+
+    for action in actions {
+        let dml = formatdoc!(
+            r#"
+            generator client {{
+                provider = "prisma-client-js"
+                previewFeatures = ["referentialIntegrity"]
+            }}
+    
+            datasource db {{
+                provider = "cockroachdb"
+                url = "sqlserver://"
+                relationMode = "prisma"
+            }}
+
+            model A {{
+                id Int @id
+                bs B[]
+            }}
+
+            model B {{
+                id Int @id
+                aId Int
+                a A @relation(fields: [aId], references: [id], onDelete: {action})
+            }}
+        "#,
+            action = action
+        );
+
+        parse(&dml)
+            .assert_has_model("B")
+            .assert_has_relation_field("a")
+            .assert_relation_delete_strategy(*action);
+    }
+}
+
+#[test]
+fn actions_on_postgres_with_prisma_relation_mode() {
+    let actions = &[Cascade, Restrict, SetNull];
+
+    for action in actions {
+        let dml = formatdoc!(
+            r#"
+            generator client {{
+                provider = "prisma-client-js"
+                previewFeatures = ["referentialIntegrity"]
+            }}
+    
+            datasource db {{
+                provider = "postgres"
+                url = "postgres://"
+                relationMode = "prisma"
+            }}
+
+            model A {{
+                id Int @id
+                bs B[]
+            }}
+
+            model B {{
+                id Int @id
+                aId Int
+                a A @relation(fields: [aId], references: [id], onDelete: {action})
+            }}
+        "#,
+            action = action
+        );
+
+        parse(&dml)
+            .assert_has_model("B")
+            .assert_has_relation_field("a")
+            .assert_relation_delete_strategy(*action);
+    }
+}
+
+#[test]
+fn actions_on_sqlite_with_prisma_relation_mode() {
+    let actions = &[Cascade, Restrict, SetNull];
+
+    for action in actions {
+        let dml = formatdoc!(
+            r#"
+            generator client {{
+                provider = "prisma-client-js"
+                previewFeatures = ["referentialIntegrity"]
+            }}
+    
+            datasource db {{
+                provider = "sqlite"
+                url = "./dev.db"
+                relationMode = "prisma"
+            }}
+
+            model A {{
+                id Int @id
+                bs B[]
+            }}
+
+            model B {{
+                id Int @id
+                aId Int
+                a A @relation(fields: [aId], references: [id], onDelete: {action})
+            }}
+        "#,
+            action = action
+        );
+
+        parse(&dml)
+            .assert_has_model("B")
+            .assert_has_relation_field("a")
+            .assert_relation_delete_strategy(*action);
+    }
+}
+
+#[test]
 fn on_delete_actions_should_work_on_prisma_relation_mode() {
     let actions = &[Restrict, SetNull, Cascade, NoAction];
 


### PR DESCRIPTION
Integration PR for https://github.com/prisma/prisma-engines/pull/3274.