### PR TITLE
psl: common::preview_features::PreviewFeature -> PreviewFeature

### DIFF
--- a/introspection-engine/connectors/introspection-connector/src/lib.rs
+++ b/introspection-engine/connectors/introspection-connector/src/lib.rs
@@ -3,7 +3,7 @@ mod error;
 pub use error::{ConnectorError, ErrorKind};
 
 use enumflags2::BitFlags;
-use psl::{common::preview_features::PreviewFeature, dml::Datamodel, Datasource};
+use psl::{dml::Datamodel, Datasource, PreviewFeature};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 

--- a/introspection-engine/connectors/mongodb-introspection-connector/src/lib.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/src/lib.rs
@@ -13,7 +13,7 @@ use introspection_connector::{
 };
 use mongodb::{Client, Database};
 use mongodb_schema_describer::MongoSchema;
-use psl::common::preview_features::PreviewFeature;
+use psl::PreviewFeature;
 use user_facing_errors::{common::InvalidConnectionString, KnownError};
 
 #[derive(Debug)]

--- a/introspection-engine/connectors/mongodb-introspection-connector/tests/test_api/mod.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/tests/test_api/mod.rs
@@ -4,7 +4,7 @@ use mongodb::Database;
 use mongodb_introspection_connector::MongoDbIntrospectionConnector;
 use names::Generator;
 use once_cell::sync::Lazy;
-use psl::common::preview_features::PreviewFeature;
+use psl::PreviewFeature;
 use std::{future::Future, io::Write};
 use tokio::runtime::Runtime;
 

--- a/introspection-engine/connectors/sql-introspection-connector/src/introspection_helpers.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/introspection_helpers.rs
@@ -1,10 +1,10 @@
 use crate::{calculate_datamodel::CalculateDatamodelContext as Context, SqlError, SqlFamilyTrait};
 use psl::{
-    common::{preview_features::PreviewFeature, RelationNames},
     dml::{
         Datamodel, FieldArity, FieldType, IndexAlgorithm, IndexDefinition, IndexField, Model, OperatorClass,
         PrimaryKeyField, ReferentialAction, RelationField, RelationInfo, ScalarField, ScalarType, SortOrder,
     },
+    PreviewFeature, RelationNames,
 };
 use sql::walkers::{ColumnWalker, ForeignKeyWalker, TableWalker};
 use sql_schema_describer::{

--- a/introspection-engine/connectors/sql-introspection-connector/src/lib.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/lib.rs
@@ -22,7 +22,7 @@ use introspection_connector::{
     ConnectorError, ConnectorResult, DatabaseMetadata, ErrorKind, IntrospectionConnector, IntrospectionContext,
     IntrospectionResult,
 };
-use psl::common::preview_features::PreviewFeature;
+use psl::PreviewFeature;
 use quaint::prelude::SqlFamily;
 use quaint::{prelude::ConnectionInfo, single::Quaint};
 use schema_describer_loading::load_describer;

--- a/introspection-engine/introspection-engine-tests/src/test_api.rs
+++ b/introspection-engine/introspection-engine-tests/src/test_api.rs
@@ -11,8 +11,8 @@ use introspection_connector::{
     IntrospectionResult, Version,
 };
 use migration_connector::{ConnectorParams, MigrationConnector};
-use psl::common::preview_features::PreviewFeature;
 use psl::Configuration;
+use psl::PreviewFeature;
 use quaint::{prelude::SqlFamily, single::Quaint};
 use sql_introspection_connector::SqlIntrospectionConnector;
 use sql_migration_connector::SqlMigrationConnector;

--- a/libs/dml/src/render/render_datamodel.rs
+++ b/libs/dml/src/render/render_datamodel.rs
@@ -1,6 +1,6 @@
 use crate::*;
 use psl_core::datamodel_connector::{constraint_names::ConstraintNames, Connector, EmptyDatamodelConnector};
-use psl_core::{common::RelationNames, parser_database as db, Datasource};
+use psl_core::{parser_database as db, Datasource, RelationNames};
 use schema_ast::string_literal;
 use std::fmt::Write;
 

--- a/migration-engine/connectors/migration-connector/src/connector_params.rs
+++ b/migration-engine/connectors/migration-connector/src/connector_params.rs
@@ -1,5 +1,5 @@
 use enumflags2::BitFlags;
-use psl::common::preview_features::PreviewFeature;
+use psl::PreviewFeature;
 
 /// Parameters passed from the core to connectors on initialization.
 pub struct ConnectorParams {

--- a/migration-engine/connectors/mongodb-migration-connector/src/client_wrapper.rs
+++ b/migration-engine/connectors/mongodb-migration-connector/src/client_wrapper.rs
@@ -3,7 +3,7 @@ use migration_connector::{ConnectorError, ConnectorResult};
 use mongodb::{error::Error as MongoError, options::WriteConcern};
 use mongodb_client::MongoConnectionString;
 use mongodb_schema_describer::MongoSchema;
-use psl::common::preview_features::PreviewFeature;
+use psl::PreviewFeature;
 
 /// Abstraction over a mongodb connection (exposed for tests).
 pub struct Client {

--- a/migration-engine/connectors/mongodb-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/mongodb-migration-connector/src/lib.rs
@@ -16,7 +16,7 @@ use enumflags2::BitFlags;
 use migration::MongoDbMigration;
 use migration_connector::{migrations_directory::MigrationDirectory, *};
 use mongodb_schema_describer::MongoSchema;
-use psl::common::preview_features::PreviewFeature;
+use psl::PreviewFeature;
 use std::{future, sync::Arc};
 use tokio::sync::OnceCell;
 

--- a/migration-engine/connectors/mongodb-migration-connector/tests/migrations/test_api.rs
+++ b/migration-engine/connectors/mongodb-migration-connector/tests/migrations/test_api.rs
@@ -4,7 +4,7 @@ use migration_connector::{ConnectorParams, DiffTarget, MigrationConnector};
 use mongodb::bson::{self, doc};
 use mongodb_migration_connector::MongoDbMigrationConnector;
 use once_cell::sync::Lazy;
-use psl::{common::preview_features::PreviewFeature, parser_database::SourceFile};
+use psl::{parser_database::SourceFile, PreviewFeature};
 use std::{
     collections::BTreeMap,
     fmt::Write as _,

--- a/migration-engine/connectors/sql-migration-connector/src/flavour.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour.rs
@@ -21,7 +21,7 @@ use migration_connector::{
     migrations_directory::MigrationDirectory, BoxFuture, ConnectorError, ConnectorParams, ConnectorResult,
     MigrationRecord, PersistenceNotInitializedError,
 };
-use psl::{common::preview_features::PreviewFeature, ValidatedSchema};
+use psl::{PreviewFeature, ValidatedSchema};
 use quaint::prelude::{ConnectionInfo, Table};
 use sql_schema_describer::SqlSchema;
 use std::fmt::Debug;

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
@@ -30,7 +30,7 @@ pub(crate) fn calculate_sql_schema(datamodel: &ValidatedSchema, flavour: &dyn Sq
     if datamodel
         .configuration
         .preview_features()
-        .contains(psl::common::preview_features::PreviewFeature::MultiSchema)
+        .contains(psl::PreviewFeature::MultiSchema)
     {
         if let Some(ds) = context.datamodel.configuration.datasources.get(0) {
             for (schema, _) in &ds.namespaces {

--- a/migration-engine/core/src/lib.rs
+++ b/migration-engine/core/src/lib.rs
@@ -22,10 +22,7 @@ pub use migration_connector;
 use enumflags2::BitFlags;
 use migration_connector::ConnectorParams;
 use mongodb_migration_connector::MongoDbMigrationConnector;
-use psl::{
-    builtin_connectors::*, common::preview_features::PreviewFeature, parser_database::SourceFile, Datasource,
-    ValidatedSchema,
-};
+use psl::{builtin_connectors::*, parser_database::SourceFile, Datasource, PreviewFeature, ValidatedSchema};
 use sql_migration_connector::SqlMigrationConnector;
 use std::{env, path::Path};
 use user_facing_errors::common::InvalidConnectionString;

--- a/migration-engine/migration-engine-tests/src/multi_engine_test_api.rs
+++ b/migration-engine/migration-engine-tests/src/multi_engine_test_api.rs
@@ -12,7 +12,7 @@ use crate::{
     commands::{ApplyMigrations, CreateMigration, DiagnoseMigrationHistory, Reset, SchemaPush},
 };
 use migration_core::migration_connector::{ConnectorParams, MigrationConnector};
-use psl::common::preview_features::PreviewFeature;
+use psl::PreviewFeature;
 use quaint::{
     prelude::{ConnectionInfo, Queryable, ResultSet},
     single::Quaint,

--- a/migration-engine/migration-engine-tests/src/test_api.rs
+++ b/migration-engine/migration-engine-tests/src/test_api.rs
@@ -13,7 +13,7 @@ use migration_core::{
         BoxFuture, ConnectorHost, ConnectorResult, DiffTarget, MigrationConnector, MigrationPersistence,
     },
 };
-use psl::{common::preview_features::PreviewFeature, parser_database::SourceFile};
+use psl::{parser_database::SourceFile, PreviewFeature};
 use quaint::{
     prelude::{ConnectionInfo, ResultSet},
     Value,

--- a/migration-engine/qe-setup/src/lib.rs
+++ b/migration-engine/qe-setup/src/lib.rs
@@ -13,10 +13,10 @@ use migration_core::{
     json_rpc::types::*,
     migration_connector::{BoxFuture, ConnectorResult},
 };
-use psl::{builtin_connectors::*, common::preview_features::*, Datasource};
+use psl::{builtin_connectors::*, Datasource};
 use std::{env, sync::Arc};
 
-fn parse_configuration(datamodel: &str) -> ConnectorResult<(Datasource, String, BitFlags<PreviewFeature>)> {
+fn parse_configuration(datamodel: &str) -> ConnectorResult<(Datasource, String, BitFlags<psl::PreviewFeature>)> {
     let config = psl::parse_configuration(datamodel)
         .map_err(|err| ConnectorError::new_schema_parser_error(err.to_pretty_string("schema.prisma", datamodel)))?;
 

--- a/prisma-fmt/src/preview.rs
+++ b/prisma-fmt/src/preview.rs
@@ -1,5 +1,5 @@
-use psl::common::preview_features::GENERATOR;
+use psl::ALL_PREVIEW_FEATURES;
 
 pub fn run() -> String {
-    serde_json::to_string(&GENERATOR.active_features().iter().collect::<Vec<_>>()).unwrap()
+    serde_json::to_string(&ALL_PREVIEW_FEATURES.active_features().iter().collect::<Vec<_>>()).unwrap()
 }

--- a/psl/builtin-connectors/src/postgres_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/postgres_datamodel_connector.rs
@@ -8,14 +8,13 @@ use native_types::{
     PostgresType::{self, *},
 };
 use psl_core::{
-    common::preview_features::PreviewFeature,
     datamodel_connector::{
         helper::{arg_vec_from_opt, args_vec_from_opt, parse_one_opt_u32, parse_two_opt_u32},
         Connector, ConnectorCapability, ConstraintScope, NativeTypeConstructor, NativeTypeInstance, StringFilter,
     },
     diagnostics::{DatamodelError, Diagnostics},
     parser_database::{ast, walkers, IndexAlgorithm, OperatorClass, ParserDatabase, ReferentialAction, ScalarType},
-    Datasource, DatasourceConnectorData,
+    Datasource, DatasourceConnectorData, PreviewFeature,
 };
 use std::{borrow::Cow, collections::HashMap, fmt};
 

--- a/psl/builtin-connectors/src/postgres_datamodel_connector/validations.rs
+++ b/psl/builtin-connectors/src/postgres_datamodel_connector/validations.rs
@@ -1,10 +1,10 @@
 use enumflags2::BitFlags;
 use native_types::PostgresType;
 use psl_core::{
-    common::preview_features::PreviewFeature,
     datamodel_connector::{walker_ext_traits::*, Connector},
     diagnostics::{DatamodelError, Diagnostics},
     parser_database::{ast::WithSpan, walkers::IndexWalker, IndexAlgorithm, OperatorClass},
+    PreviewFeature,
 };
 
 use super::PostgresDatasourceProperties;

--- a/psl/psl-core/src/common.rs
+++ b/psl/psl-core/src/common.rs
@@ -1,7 +1,9 @@
 //! This module contains shared constants and logic that can be used by engines.
 
+mod preview_features;
 mod relation_names;
 
-pub mod preview_features;
-
-pub use self::relation_names::RelationNames;
+pub use self::{
+    preview_features::{FeatureMap, PreviewFeature, ALL_PREVIEW_FEATURES},
+    relation_names::RelationNames,
+};

--- a/psl/psl-core/src/common/preview_features.rs
+++ b/psl/psl-core/src/common/preview_features.rs
@@ -71,7 +71,7 @@ features!(
 );
 
 /// Generator preview features
-pub const GENERATOR: FeatureMap = FeatureMap {
+pub const ALL_PREVIEW_FEATURES: FeatureMap = FeatureMap {
     active: enumflags2::make_bitflags!(PreviewFeature::{
         ReferentialIntegrity
          | InteractiveTransactions

--- a/psl/psl-core/src/configuration/configuration_struct.rs
+++ b/psl/psl-core/src/configuration/configuration_struct.rs
@@ -1,8 +1,8 @@
 use super::{Datasource, Generator};
 use crate::{
-    common::preview_features::PreviewFeature,
     datamodel_connector::RelationMode,
     diagnostics::{DatamodelError, Diagnostics},
+    PreviewFeature,
 };
 use enumflags2::BitFlags;
 

--- a/psl/psl-core/src/configuration/generator.rs
+++ b/psl/psl-core/src/configuration/generator.rs
@@ -1,4 +1,4 @@
-use crate::{common::preview_features::PreviewFeature, configuration::StringFromEnvVar};
+use crate::{configuration::StringFromEnvVar, PreviewFeature};
 use enumflags2::BitFlags;
 use serde::{ser::SerializeSeq, Serialize, Serializer};
 use std::collections::HashMap;

--- a/psl/psl-core/src/datamodel_connector.rs
+++ b/psl/psl-core/src/datamodel_connector.rs
@@ -15,8 +15,6 @@ mod native_type_constructor;
 mod native_type_instance;
 mod relation_mode;
 
-use crate::{common::preview_features::PreviewFeature, configuration::DatasourceConnectorData, Datasource};
-
 pub use self::{
     capabilities::{ConnectorCapabilities, ConnectorCapability},
     empty_connector::EmptyDatamodelConnector,
@@ -26,6 +24,7 @@ pub use self::{
     relation_mode::RelationMode,
 };
 
+use crate::{configuration::DatasourceConnectorData, Datasource, PreviewFeature};
 use diagnostics::{DatamodelError, Diagnostics, NativeTypeErrorFactory, Span};
 use enumflags2::BitFlags;
 use lsp_types::CompletionList;

--- a/psl/psl-core/src/lib.rs
+++ b/psl/psl-core/src/lib.rs
@@ -2,28 +2,26 @@
 #![deny(rust_2018_idioms, unsafe_code)]
 #![allow(clippy::derive_partial_eq_without_eq)]
 
-pub mod common;
 pub mod datamodel_connector;
 
 /// `mcf`: Turns a collection of `configuration::Datasource` and `configuration::Generator` into a
 /// JSON representation. This is the `get_config()` representation.
 pub mod mcf;
 
+mod common;
 mod configuration;
 mod reformat;
 mod validate;
 
 pub use crate::{
+    common::{PreviewFeature, RelationNames, ALL_PREVIEW_FEATURES},
     configuration::{Configuration, Datasource, DatasourceConnectorData, Generator, StringFromEnvVar},
     reformat::reformat,
 };
 pub use diagnostics;
 pub use parser_database::{self, is_reserved_type_name};
 
-use self::{
-    common::preview_features::PreviewFeature,
-    validate::{datasource_loader, generator_loader},
-};
+use self::validate::{datasource_loader, generator_loader};
 use diagnostics::Diagnostics;
 use parser_database::{ast, ParserDatabase, SourceFile};
 

--- a/psl/psl-core/src/validate/datasource_loader.rs
+++ b/psl/psl-core/src/validate/datasource_loader.rs
@@ -1,10 +1,9 @@
 use crate::{
     ast::{self, SourceConfig, Span},
-    common::preview_features::PreviewFeature,
     configuration::StringFromEnvVar,
     datamodel_connector::RelationMode,
     diagnostics::{DatamodelError, Diagnostics},
-    Datasource,
+    Datasource, PreviewFeature,
 };
 use enumflags2::BitFlags;
 use parser_database::{ast::WithDocumentation, coerce, coerce_array, coerce_opt};

--- a/psl/psl-core/src/validate/generator_loader.rs
+++ b/psl/psl-core/src/validate/generator_loader.rs
@@ -1,6 +1,6 @@
 use crate::{
     ast::WithSpan,
-    common::preview_features::{FeatureMap, PreviewFeature, GENERATOR},
+    common::{FeatureMap, PreviewFeature, ALL_PREVIEW_FEATURES},
     configuration::{Generator, StringFromEnvVar},
     diagnostics::*,
 };
@@ -86,7 +86,7 @@ fn lift_generator(ast_generator: &ast::GeneratorConfig, diagnostics: &mut Diagno
         .get(PREVIEW_FEATURES_KEY)
         .or_else(|| args.get(EXPERIMENTAL_FEATURES_KEY))
         .and_then(|v| coerce_array(v, &coerce::string, diagnostics).map(|arr| (arr, v.span())))
-        .map(|(arr, span)| parse_and_validate_preview_features(arr, &GENERATOR, span, diagnostics));
+        .map(|(arr, span)| parse_and_validate_preview_features(arr, &ALL_PREVIEW_FEATURES, span, diagnostics));
 
     for prop in &ast_generator.properties {
         let is_first_class_prop = FIRST_CLASS_PROPERTIES.iter().any(|k| *k == prop.name.name);

--- a/psl/psl-core/src/validate/validation_pipeline.rs
+++ b/psl/psl-core/src/validate/validation_pipeline.rs
@@ -2,10 +2,10 @@ mod context;
 mod validations;
 
 use crate::{
-    common::preview_features::PreviewFeature,
     configuration,
     datamodel_connector::{Connector, EmptyDatamodelConnector, RelationMode},
     diagnostics::Diagnostics,
+    PreviewFeature,
 };
 use enumflags2::BitFlags;
 use parser_database::ParserDatabase;

--- a/psl/psl-core/src/validate/validation_pipeline/validations/indexes.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/indexes.rs
@@ -1,9 +1,9 @@
 use super::{constraint_namespace::ConstraintName, database_name::validate_db_name};
 use crate::{
-    common::preview_features::PreviewFeature,
     datamodel_connector::{walker_ext_traits::*, ConnectorCapability},
     diagnostics::DatamodelError,
     validate::validation_pipeline::context::Context,
+    PreviewFeature,
 };
 use itertools::Itertools;
 use parser_database::{walkers::IndexWalker, IndexAlgorithm};

--- a/psl/psl-core/src/validate/validation_pipeline/validations/models.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/models.rs
@@ -1,11 +1,11 @@
 use super::database_name::validate_db_name;
 use crate::{
     ast,
-    common::preview_features::PreviewFeature,
     datamodel_connector::{walker_ext_traits::*, ConnectorCapability},
     diagnostics::DatamodelError,
     parser_database::ast::{WithName, WithSpan},
     validate::validation_pipeline::context::Context,
+    PreviewFeature,
 };
 use parser_database::walkers::{ModelWalker, PrimaryKeyWalker};
 use std::{borrow::Cow, collections::HashMap};

--- a/psl/psl/src/lib.rs
+++ b/psl/psl/src/lib.rs
@@ -4,7 +4,6 @@
 pub use builtin_psl_connectors as builtin_connectors;
 pub use dml::{self, lift, render_datamodel_and_config_to_string, render_datamodel_to_string};
 pub use psl_core::{
-    common,
     datamodel_connector,
     diagnostics::{self, Diagnostics},
     is_reserved_type_name,
@@ -15,8 +14,11 @@ pub use psl_core::{
     Configuration,
     Datasource,
     Generator,
+    PreviewFeature,
+    RelationNames,
     StringFromEnvVar,
     ValidatedSchema,
+    ALL_PREVIEW_FEATURES,
 };
 
 /// The implementation of the CLI getConfig() utility and its JSON format.

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/datamodel_rendering/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/datamodel_rendering/mod.rs
@@ -8,7 +8,7 @@ use crate::{templating, ConnectorTagInterface, DatamodelFragment, IdFragment, M2
 use indoc::indoc;
 use itertools::Itertools;
 use lazy_static::lazy_static;
-use psl::common::preview_features::GENERATOR;
+use psl::ALL_PREVIEW_FEATURES;
 use regex::Regex;
 
 lazy_static! {
@@ -95,10 +95,10 @@ fn process_template(template: String, renderer: Box<dyn DatamodelRenderer>) -> S
 fn render_preview_features(excluded_features: &[&str]) -> String {
     let excluded_features: Vec<_> = excluded_features.iter().map(|f| format!(r#""{}""#, f)).collect();
 
-    GENERATOR
+    ALL_PREVIEW_FEATURES
         .active_features()
         .iter()
-        .chain(GENERATOR.hidden_features())
+        .chain(ALL_PREVIEW_FEATURES.hidden_features())
         .map(|f| format!(r#""{}""#, f))
         .filter(|f| !excluded_features.contains(f))
         .join(", ")

--- a/query-engine/connectors/sql-query-connector/src/database/connection.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/connection.rs
@@ -8,7 +8,7 @@ use connector_interface::{
 };
 use prisma_models::{prelude::*, SelectionResult};
 use prisma_value::PrismaValue;
-use psl::common::preview_features::PreviewFeature;
+use psl::PreviewFeature;
 use quaint::{
     connector::{IsolationLevel, TransactionCapable},
     prelude::ConnectionInfo,

--- a/query-engine/connectors/sql-query-connector/src/database/mod.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/mod.rs
@@ -9,7 +9,7 @@ pub(crate) mod operations;
 
 use async_trait::async_trait;
 use connector_interface::{error::ConnectorError, Connector};
-use psl::{common::preview_features::PreviewFeature, Datasource};
+use psl::{Datasource, PreviewFeature};
 
 pub use mssql::*;
 pub use mysql::*;

--- a/query-engine/connectors/sql-query-connector/src/database/mssql.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/mssql.rs
@@ -6,7 +6,7 @@ use connector_interface::{
     error::{ConnectorError, ErrorKind},
     Connection, Connector,
 };
-use psl::{common::preview_features::PreviewFeature, Datasource};
+use psl::{Datasource, PreviewFeature};
 use quaint::{pooled::Quaint, prelude::ConnectionInfo};
 use std::time::Duration;
 

--- a/query-engine/connectors/sql-query-connector/src/database/mysql.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/mysql.rs
@@ -6,7 +6,7 @@ use connector_interface::{
     error::{ConnectorError, ErrorKind},
     Connection, Connector,
 };
-use psl::{common::preview_features::PreviewFeature, Datasource};
+use psl::{Datasource, PreviewFeature};
 use quaint::{pooled::Quaint, prelude::ConnectionInfo};
 use std::time::Duration;
 

--- a/query-engine/connectors/sql-query-connector/src/database/operations/write.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/write.rs
@@ -5,8 +5,8 @@ use crate::{error::SqlError, model_extensions::*, query_builder::write, sql_info
 use connector_interface::*;
 use itertools::Itertools;
 use prisma_models::*;
-use psl::common::preview_features::PreviewFeature;
 use psl::dml::prisma_value::PrismaValue;
+use psl::PreviewFeature;
 use quaint::{
     error::ErrorKind,
     prelude::{native_uuid, uuid_to_bin, uuid_to_bin_swapped, Aliasable, Select, SqlFamily},

--- a/query-engine/connectors/sql-query-connector/src/database/postgresql.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/postgresql.rs
@@ -5,7 +5,7 @@ use connector_interface::{
     error::{ConnectorError, ErrorKind},
     Connection, Connector,
 };
-use psl::{common::preview_features::PreviewFeature, Datasource};
+use psl::{Datasource, PreviewFeature};
 use quaint::{pooled::Quaint, prelude::ConnectionInfo};
 use std::time::Duration;
 

--- a/query-engine/connectors/sql-query-connector/src/database/sqlite.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/sqlite.rs
@@ -6,7 +6,7 @@ use connector_interface::{
     error::{ConnectorError, ErrorKind},
     Connection, Connector,
 };
-use psl::{common::preview_features::PreviewFeature, Datasource};
+use psl::{Datasource, PreviewFeature};
 use quaint::{connector::SqliteParams, error::ErrorKind as QuaintKind, pooled::Quaint, prelude::ConnectionInfo};
 use std::{convert::TryFrom, time::Duration};
 

--- a/query-engine/connectors/sql-query-connector/src/database/transaction.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/transaction.rs
@@ -8,7 +8,7 @@ use connector_interface::{
 };
 use prisma_models::{prelude::*, SelectionResult};
 use prisma_value::PrismaValue;
-use psl::common::preview_features::PreviewFeature;
+use psl::PreviewFeature;
 use quaint::prelude::ConnectionInfo;
 use std::collections::HashMap;
 

--- a/query-engine/connectors/sql-query-connector/src/query_ext.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_ext.rs
@@ -8,7 +8,7 @@ use futures::future::FutureExt;
 use itertools::Itertools;
 use opentelemetry::trace::TraceFlags;
 use prisma_models::*;
-use psl::common::preview_features::PreviewFeature;
+use psl::PreviewFeature;
 use quaint::{
     ast::*,
     connector::{self, Queryable},

--- a/query-engine/core/src/executor/loader.rs
+++ b/query-engine/core/src/executor/loader.rs
@@ -3,7 +3,7 @@ use crate::CoreError;
 use connection_string::JdbcString;
 use connector::Connector;
 use mongodb_client::MongoConnectionString;
-use psl::{builtin_connectors::*, common::preview_features::PreviewFeature, Datasource};
+use psl::{builtin_connectors::*, Datasource, PreviewFeature};
 use sql_connector::*;
 use std::collections::HashMap;
 use std::str::FromStr;

--- a/query-engine/query-engine-node-api/src/engine.rs
+++ b/query-engine/query-engine-node-api/src/engine.rs
@@ -1,6 +1,6 @@
 use crate::{error::ApiError, log_callback::LogCallback, logger::Logger};
 use futures::FutureExt;
-use psl::common::preview_features::PreviewFeature;
+use psl::PreviewFeature;
 use query_core::{
     executor,
     schema::{QuerySchema, QuerySchemaRenderer},

--- a/query-engine/query-engine/src/server/mod.rs
+++ b/query-engine/query-engine/src/server/mod.rs
@@ -2,7 +2,7 @@ use crate::{context::PrismaContext, opt::PrismaOpt, PrismaResult};
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{header::CONTENT_TYPE, Body, HeaderMap, Method, Request, Response, Server, StatusCode};
 use opentelemetry::{global, propagation::Extractor, Context};
-use psl::common::preview_features::PreviewFeature;
+use psl::PreviewFeature;
 use query_core::{schema::QuerySchemaRenderer, TxId};
 use query_engine_metrics::{MetricFormat, MetricRegistry};
 use request_handlers::{dmmf, GraphQLSchemaRenderer, GraphQlHandler, TxInput};

--- a/query-engine/schema-builder/src/lib.rs
+++ b/query-engine/schema-builder/src/lib.rs
@@ -42,8 +42,8 @@ mod utils;
 
 use cache::TypeRefCache;
 use prisma_models::{
-    psl::common::preview_features::PreviewFeature, CompositeTypeRef, Field as ModelField, Index, InternalDataModelRef,
-    ModelRef, RelationFieldRef, TypeIdentifier,
+    psl::PreviewFeature, CompositeTypeRef, Field as ModelField, Index, InternalDataModelRef, ModelRef,
+    RelationFieldRef, TypeIdentifier,
 };
 use psl::datamodel_connector::{Connector, ConnectorCapability, RelationMode};
 use schema::*;

--- a/query-engine/schema/src/query_schema.rs
+++ b/query-engine/schema/src/query_schema.rs
@@ -1,6 +1,6 @@
 use super::*;
 use fmt::Debug;
-use prisma_models::{psl::common::preview_features::PreviewFeature, InternalDataModelRef, ModelRef};
+use prisma_models::{psl::PreviewFeature, InternalDataModelRef, ModelRef};
 use psl::datamodel_connector::{ConnectorCapability, RelationMode};
 use std::{borrow::Borrow, fmt};
 


### PR DESCRIPTION
Less nesting makes for less noise, a more readable public API surface. `common` is not informative and `preview_features::PreviewFeature` is redundant.

This commit removes `common` as a top level export, reexporting its contents directly. No change in functionality expected.