### PR TITLE
Revert napi update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2283,9 +2283,9 @@ dependencies = [
 
 [[package]]
 name = "napi"
-version = "2.10.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bace9a4026eaa6631804e2ff9030c47beb0483fbb12dc17950fe1530c4961f84"
+checksum = "0e2f9ad803cde148d81d0ca9e5fd4d80773d15e992d09e3a44f62f41b9af4558"
 dependencies = [
  "bitflags",
  "ctor",
@@ -2305,9 +2305,9 @@ checksum = "ebd4419172727423cf30351406c54f6cc1b354a2cfb4f1dba3e6cd07f6d5522b"
 
 [[package]]
 name = "napi-derive"
-version = "2.9.1"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39f3d8b02ef355898ea98f69082d9a183c8701c836942c2daf3e92364e88a0fa"
+checksum = "1be75210f300e9fbf386ccac1c8eaaed23410e2f7f7aa9295b78c436a172ef51"
 dependencies = [
  "convert_case",
  "napi-derive-backend",
@@ -2318,9 +2318,9 @@ dependencies = [
 
 [[package]]
 name = "napi-derive-backend"
-version = "1.0.38"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c35640513eb442fcbd1653a1c112fb6b2cc12b54d82f9c141f5859c721cab36"
+checksum = "92ba4800264fac8a7726b208d5dd4c6d637d1027d73b026061a69d3339a0a930"
 dependencies = [
  "convert_case",
  "once_cell",

--- a/query-engine/query-engine-node-api/Cargo.toml
+++ b/query-engine/query-engine-node-api/Cargo.toml
@@ -23,8 +23,8 @@ psl.workspace = true
 sql-connector = { path = "../connectors/sql-query-connector", package = "sql-query-connector" }
 prisma-models = { path = "../prisma-models" }
 
-napi = { version = "2.9.0", default-features = false, features = ["napi8", "tokio_rt", "serde-json"] }
-napi-derive = "2.9.0"
+napi = { version = "=2.9.0", default-features = false, features = ["napi8", "tokio_rt", "serde-json"] }
+napi-derive = "=2.9.0"
 
 thiserror = "1"
 connection-string = "0.1"

--- a/query-engine/query-engine-node-api/Cargo.toml
+++ b/query-engine/query-engine-node-api/Cargo.toml
@@ -23,8 +23,8 @@ psl.workspace = true
 sql-connector = { path = "../connectors/sql-query-connector", package = "sql-query-connector" }
 prisma-models = { path = "../prisma-models" }
 
-napi = { version = "2", default-features = false, features = ["napi8", "tokio_rt", "serde-json"] }
-napi-derive = "2"
+napi = { version = "2.9.0", default-features = false, features = ["napi8", "tokio_rt", "serde-json"] }
+napi-derive = "2.9.0"
 
 thiserror = "1"
 connection-string = "0.1"


### PR DESCRIPTION
See prisma/prisma#15772 (engines from https://github.com/prisma/prisma-engines/pull/3278). After `napi` 2.10 update, every memory test started
leaking around 20-100kb per iteration. Reverting napi, napi-derive and
napi-derive-backend to previous versions fixes the issue.
