### PR TITLE
psl: Add hidden preview feature for client extensions

### DIFF
--- a/psl/psl-core/src/common/preview_features.rs
+++ b/psl/psl-core/src/common/preview_features.rs
@@ -68,6 +68,7 @@ features!(
     FilteredRelationCount,
     FieldReference,
     PostgresqlExtensions,
+    ClientExtensions
 );
 
 /// Generator preview features
@@ -111,6 +112,7 @@ pub const ALL_PREVIEW_FEATURES: FeatureMap = FeatureMap {
     hidden: enumflags2::make_bitflags!(PreviewFeature::{
         MultiSchema
         | PostgresqlExtensions
+        | ClientExtensions
     }),
 };
 


### PR DESCRIPTION
We want to start merging parts of extension work into main client branch
to avoid quarter long feature branch. Since we are not planning to ship
anything yet, we'd like to hide it under hidden preview feature flag for
now.
