### PR TITLE
[wip] - quaint postgres statement cache parameter conversion errors

### DIFF
--- a/multi-track-drifting.norg
+++ b/multi-track-drifting.norg
@@ -2,7 +2,8 @@
 
 * Context
 
-   - Original issue: https://github.com/prisma/prisma/issues/15133
+  - {https://github.com/prisma/prisma/issues/15133}[Original issue]
+  - Pull request with test repro: TODO
 
 * Diagnosis
 
@@ -48,16 +49,46 @@
 
 ** The Bug
 
-   Since Prisma 4.0, the following scenario can happen:
+   @code prisma
+   model TestModel {
+       id  Int @id @default(autoincrement())
+       col String? @test.Uuid
+   }
+   @end
 
-   - We
+   Since Prisma 4.0, given the schema above, the following scenario can happen with raw queries:
 
-   See this test: ...
+   - First insert a row in `TestModel` with `null` or `undefined` in the `col` column.
+   -- The SQL looks like this: `INSERT INTO "TestModel" (col) VALUES ($1)`
+   -- The prepared statement cached in quaint has the type of the `$1` parameter inferred, to the same as the column type: `UUID`.
+   - Now insert a second row with the same query, but with a string parameter (as that would naturally happen with the typescript Prisma Client).
+   -- The inferred parameter type is `UUID`, but the one we send is `TEXT`, leading to a database error: 
+    > ERROR: column "col" is of type uuid but expression is of type text. HINT: You will need to rewrite or cast the expression."
+
+   This is easily reproducible in QE tests.
 
 * Solution exploration
 
-*** Document the workaround
-*** Make the param types part of the cache key
+** Document the workaround
+
+   This is what the `HINT` section recommends in the postgres error. The user
+   can adapt their query to signal intent to send values of a certain type. In
+   the example above, `TEXT`.
+
+   The fixed query looks like this:
+
+   @code sql
+   INSERT INTO "TestModel" (col) VALUES ($1::TEXT::UUID)
+   @end
+
+   This is a relatively general solution. Julius also suggested it in
+   {https://github.com/prisma/prisma/issues/15133#issuecomment-1234242370}[this
+   issue comment].
+
+** Make the param types part of the cache key
 
     Hash the discriminants. Overhead of x bytes.
+
+** Coerce the parameters
+
 

--- a/multi-track-drifting.norg
+++ b/multi-track-drifting.norg
@@ -1,0 +1,63 @@
+= TOC Table of contents
+
+* Context
+
+   - Original issue: https://github.com/prisma/prisma/issues/15133
+
+* Diagnosis
+
+   Note that all of the following is specific to PostgreSQL. Other databases handle prepared statements differently.
+
+** The prepared statement cache
+
+   In order to resolve a Prisma Client request, the Query Engine issues database queries. The queries consist of SQL and bound parameters:
+
+   @code sql
+   INSERT INTO test (col1, col2) VALUES ($1, $2)
+   @end
+
+   With quaint, the database library used by the query engine, this is a single call:
+
+   @code rust
+   conn.query_raw("INSERT INTO test (col1, col2) VALUES ($1, $2)", &[param1, param2]).await?
+   @end
+
+   One might expect that this matches one network roundtrip between the client
+   and the database, but there are potentially two roundtrips involved.
+
+   - The first with the SQL string to /prepare/ the statement. The client /may/
+     choose to also indicate what type of parameter it will send for each of
+     the numbered placeholders. The database returns a /prepared statement
+   object/ that consists mainly of an identifier and of the types of the
+     parameters it expects for each of the placeholders (`$1` and `$2` in this
+     case).
+   - The second with the prepared statement identifier and the parameter values.
+
+   For an application using PostgreSQL directly, the expected workflow is that
+   a given query will be prepared once, then reused while the database
+   connection on which it was prepared lasts.
+
+   In Prisma, since we do not want to expose that to the users or even to the
+   query engine, we rely on /prepared statement caching/ in quaint. We have a
+   LRU cache mapping a SQL string to its corresponding prepared statement.
+
+   This was fine until we started sending type information when preparing
+   queries, with Prisma 4
+   ({https://github.com/prisma/prisma/releases/tag/4.0.0}[Prisma 4.0.0 — improvedQueryRaw is
+   now generally available]).
+
+** The Bug
+
+   Since Prisma 4.0, the following scenario can happen:
+
+   - We
+
+   See this test: ...
+
+* Solution exploration
+
+*** Document the workaround
+*** Make the param types part of the cache key
+
+    Hash the discriminants. Overhead of x bytes.
+

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/query_engine_tests.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/query_engine_tests.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::module_inception, clippy::too_many_arguments)]
 
-mod new;
-mod queries;
+// mod new;
+// mod queries;
 mod raw;
-mod writes;
+// mod writes;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/raw/sql/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/raw/sql/mod.rs
@@ -3,3 +3,4 @@ mod errors;
 mod input_coercion;
 mod null_list;
 mod typed_output;
+mod param_type_changes;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/raw/sql/param_type_changes.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/raw/sql/param_type_changes.rs
@@ -1,0 +1,11 @@
+use query_engine_tests::*;
+
+#[test_suite(only(Postgres))]
+mod param_type_changes {
+    #[connector_test(schema(common_numeric_types))]
+    async fn null_scalar_lists(runner: Runner) -> TestResult<()> {
+        let sql = r#""#;
+        let params_1 = todo!();
+        let params_2 = todo!();
+    }
+}

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/raw/sql/param_type_changes.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/raw/sql/param_type_changes.rs
@@ -2,10 +2,25 @@ use query_engine_tests::*;
 
 #[test_suite(only(Postgres))]
 mod param_type_changes {
-    #[connector_test(schema(common_numeric_types))]
-    async fn null_scalar_lists(runner: Runner) -> TestResult<()> {
-        let sql = r#""#;
-        let params_1 = todo!();
-        let params_2 = todo!();
+    fn schema() -> String {
+        r#"
+            model TestModel {
+                id  Int @id @default(autoincrement())
+                col String? @test.Uuid
+            }
+        "#
+        .to_owned()
+    }
+
+    // MULTI TRACK DRIFTING!
+    #[connector_test(schema(schema))]
+    async fn param_type_changes(runner: Runner) -> TestResult<()> {
+        let sql = r#"INSERT INTO "TestModel" (col) VALUES ($1::TEXT::UUID)"#;
+        let params_1 = vec![RawParam::Null];
+        let params_2 = vec![RawParam::from("71a4d621-8342-4aff-b658-5e65047335b0")];
+        run_query!(&runner, fmt_execute_raw(sql, params_1));
+        run_query!(&runner, fmt_execute_raw(sql, params_2));
+
+        Ok(())
     }
 }


### PR DESCRIPTION
Internal writeup: https://www.notion.so/prismaio/Quaint-prepared-statement-cache-causes-parameter-serialization-failures-79890407a65d4260987da1a8531fab81

Original issue: https://github.com/prisma/prisma/issues/15133

This just contains a test repro. The next steps to explore ways to fix this are outlined in the notion doc.