### PR TITLE
Make the Array type to use a generic type param. Documentation.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,6 +673,7 @@ name = "datamodel-renderer"
 version = "0.1.0"
 dependencies = [
  "expect-test",
+ "indoc",
  "psl",
 ]
 

--- a/introspection-engine/connectors/sql-introspection-connector/src/introspection/postgres.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/introspection/postgres.rs
@@ -25,7 +25,7 @@ pub(super) fn add_extensions<'a>(
         .downcast_ref::<PostgresDatasourceProperties>();
 
     let previous_extensions = connector_data.and_then(|p| p.extensions());
-    let mut next_extensions = render::Array::default();
+    let mut next_extensions = render::Array::new();
 
     for ext in pg_schema_ext.extension_walkers() {
         let sanitized_name = sanitize_string(ext.name());

--- a/introspection-engine/datamodel-renderer/Cargo.toml
+++ b/introspection-engine/datamodel-renderer/Cargo.toml
@@ -10,3 +10,4 @@ psl.workspace = true
 
 [dev-dependencies]
 expect-test = "1.4.0"
+indoc = "1.0.7"

--- a/introspection-engine/datamodel-renderer/src/lib.rs
+++ b/introspection-engine/datamodel-renderer/src/lib.rs
@@ -3,6 +3,64 @@
 //! the functionality of prisma-fmt for that.
 //!
 //! All structs implement `std::fmt::Display` for easy usage.
+//!
+//! An example use case to render a datasource as a string:
+//!
+//! ```
+//! use datamodel_renderer::{Datasource, Env};
+//! use indoc::{indoc, formatdoc};
+//!
+//! fn main() {
+//!     let datasource = Datasource::new(
+//!         "db",
+//!         "postgres",
+//!         Env::variable("DATABASE_URL")
+//!     );
+//!
+//!     // We get a string rendering without proper formatting
+//!     // by calling the `to_string()` method:
+//!     let rendered = datasource.to_string();
+//!
+//!     // The output is not formatted, so we call the reformat
+//!     // function to the result to make it look more kosher.
+//!     let rendered = psl::reformat(&rendered, 2).unwrap();
+//!
+//!     let expected = indoc! {r#"
+//!         datasource db {
+//!           provider = "postgres"
+//!           url      = env("DATABASE_URL")
+//!         }
+//!     "#};
+//!
+//!     assert_eq!(expected, &rendered);
+//!
+//!     // Additionally we can just pass the datasource to any
+//!     // format block to include it in the resulting string:
+//!     let rendered = formatdoc!(r#"
+//!         {datasource}
+//!
+//!         model A {{
+//!           id Int @id
+//!         }}
+//!     "#);
+//!
+//!     // Again, making the result indentation and spacing to
+//!     // look prettier.
+//!     let rendered = psl::reformat(&rendered, 2).unwrap();
+//!
+//!     let expected = indoc! {r#"
+//!         datasource db {
+//!           provider = "postgres"
+//!           url      = env("DATABASE_URL")
+//!         }
+//!
+//!         model A {
+//!           id Int @id
+//!         }
+//!     "#};
+//!
+//!     assert_eq!(expected, &rendered);
+//! }
 
 #![warn(missing_docs)]
 

--- a/introspection-engine/datamodel-renderer/src/lib.rs
+++ b/introspection-engine/datamodel-renderer/src/lib.rs
@@ -10,57 +10,58 @@
 //! use datamodel_renderer::{Datasource, Env};
 //! use indoc::{indoc, formatdoc};
 //!
-//! fn main() {
-//!     let datasource = Datasource::new(
-//!         "db",
-//!         "postgres",
-//!         Env::variable("DATABASE_URL")
-//!     );
+//! let datasource = Datasource::new(
+//!     "db",
+//!     "postgres",
+//!     Env::variable("DATABASE_URL")
+//! );
 //!
-//!     // We get a string rendering without proper formatting
-//!     // by calling the `to_string()` method:
-//!     let rendered = datasource.to_string();
+//! // We get a string rendering without proper formatting
+//! // by calling the `to_string()` method:
+//! let rendered = datasource.to_string();
 //!
-//!     // The output is not formatted, so we call the reformat
-//!     // function to the result to make it look more kosher.
-//!     let rendered = psl::reformat(&rendered, 2).unwrap();
+//! // The output is not formatted, so we call the reformat
+//! // function to the result to make it look more kosher.
+//! let rendered = psl::reformat(&rendered, 2).unwrap();
 //!
-//!     let expected = indoc! {r#"
-//!         datasource db {
-//!           provider = "postgres"
-//!           url      = env("DATABASE_URL")
-//!         }
-//!     "#};
+//! let expected = indoc! {r#"
+//!     datasource db {
+//!       provider = "postgres"
+//!       url      = env("DATABASE_URL")
+//!     }
 //!
-//!     assert_eq!(expected, &rendered);
+//! "#};
 //!
-//!     // Additionally we can just pass the datasource to any
-//!     // format block to include it in the resulting string:
-//!     let rendered = formatdoc!(r#"
-//!         {datasource}
+//! assert_eq!(expected, &rendered);
 //!
-//!         model A {{
-//!           id Int @id
-//!         }}
-//!     "#);
+//! // Additionally we can just pass the datasource to any
+//! // format block to include it in the resulting string:
+//! let rendered = formatdoc!(r#"
+//!     {datasource}
 //!
-//!     // Again, making the result indentation and spacing to
-//!     // look prettier.
-//!     let rendered = psl::reformat(&rendered, 2).unwrap();
+//!     model A {{
+//!       id Int @id
+//!     }}
+//! "#);
 //!
-//!     let expected = indoc! {r#"
-//!         datasource db {
-//!           provider = "postgres"
-//!           url      = env("DATABASE_URL")
-//!         }
+//! // Again, making the result indentation and spacing to
+//! // look prettier.
+//! let rendered = psl::reformat(&rendered, 2).unwrap();
 //!
-//!         model A {
-//!           id Int @id
-//!         }
-//!     "#};
+//! let expected = indoc! {r#"
+//!     datasource db {
+//!       provider = "postgres"
+//!       url      = env("DATABASE_URL")
+//!     }
 //!
-//!     assert_eq!(expected, &rendered);
-//! }
+//!     model A {
+//!       id Int @id
+//!     }
+//!
+//! "#};
+//!
+//! assert_eq!(expected, &rendered);
+//! ```
 
 #![warn(missing_docs)]
 

--- a/introspection-engine/datamodel-renderer/src/value.rs
+++ b/introspection-engine/datamodel-renderer/src/value.rs
@@ -12,7 +12,7 @@ impl<'a> fmt::Display for Text<&'a str> {
     }
 }
 
-impl<'a> fmt::Display for Text<PreviewFeature> {
+impl fmt::Display for Text<PreviewFeature> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("\"")?;
         self.0.fmt(f)?;


### PR DESCRIPTION
In almost all our cases, the arrays in the PSL will only contain of one type. We should not have array having a value inside because every instance of the array will only use one variant of it.

Making the `Array` as `Array<T>`, the structs read better when the reader knows "ah, this one is an array of strings and that one is having preview features inside".