### PR TITLE
Keep empty preview features array intact on re-intro.

### DIFF
--- a/introspection-engine/datamodel-renderer/src/generator.rs
+++ b/introspection-engine/datamodel-renderer/src/generator.rs
@@ -37,7 +37,7 @@ impl<'a> Generator<'a> {
 
     /// Add a new preview feature to the generator block.
     pub fn push_preview_feature(&mut self, feature: PreviewFeature) {
-        let features = self.preview_features.get_or_insert_with(|| Array::default());
+        let features = self.preview_features.get_or_insert_with(Array::default);
         features.push(Value::Feature(feature));
     }
 

--- a/introspection-engine/introspection-engine-tests/tests/re_introspection/mysql.rs
+++ b/introspection-engine/introspection-engine-tests/tests/re_introspection/mysql.rs
@@ -2,6 +2,37 @@ use barrel::types;
 use indoc::indoc;
 use introspection_engine_tests::test_api::*;
 
+#[test_connector(tags(Mysql))]
+async fn empty_preview_features_are_kept(api: &TestApi) -> TestResult {
+    let schema = indoc! {r#"
+        generator client {
+          provider        = "prisma-client-js"
+          previewFeatures = []
+        }
+
+        datasource db {
+          provider   = "mysql"
+          url        = "env(TEST_DATABASE_URL)"
+        }
+    "#};
+
+    let expectation = expect![[r#"
+        generator client {
+          provider        = "prisma-client-js"
+          previewFeatures = []
+        }
+
+        datasource db {
+          provider   = "mysql"
+          url        = "env(TEST_DATABASE_URL)"
+        }
+    "#]];
+
+    expectation.assert_eq(&api.re_introspect_config(schema).await?);
+
+    Ok(())
+}
+
 #[test_connector(tags(Mysql), exclude(Vitess), preview_features("referentialIntegrity"))]
 async fn relation_mode_parameter_is_not_added(api: &TestApi) -> TestResult {
     let result = api.re_introspect("").await?;

--- a/introspection-engine/introspection-engine-tests/tests/re_introspection/mysql.rs
+++ b/introspection-engine/introspection-engine-tests/tests/re_introspection/mysql.rs
@@ -23,8 +23,8 @@ async fn empty_preview_features_are_kept(api: &TestApi) -> TestResult {
         }
 
         datasource db {
-          provider   = "mysql"
-          url        = "env(TEST_DATABASE_URL)"
+          provider = "mysql"
+          url      = "env(TEST_DATABASE_URL)"
         }
     "#]];
 


### PR DESCRIPTION
Fixing a regression in the new renderer.