### PR TITLE
test: trigger CI in vitess reintrospection test

### DIFF
--- a/introspection-engine/introspection-engine-tests/tests/re_introspection/vitess.rs
+++ b/introspection-engine/introspection-engine-tests/tests/re_introspection/vitess.rs
@@ -381,6 +381,7 @@ async fn field_renames_keeps_the_relation_intact(api: &TestApi) -> TestResult {
     Ok(())
 }
 
+// trigger CI here.
 #[test_connector(tags(Vitess), preview_features("referentialIntegrity"))]
 async fn referential_actions_are_kept_intact(api: &TestApi) -> TestResult {
     let dml = indoc! {r#"


### PR DESCRIPTION
Temporary branch to check a possible regression on CI, look away