### PR TITLE
fix(qe): filter-in debug traces for mongo db queries regardless of global logger level

### DIFF
--- a/query-engine/query-engine/src/logger.rs
+++ b/query-engine/query-engine/src/logger.rs
@@ -142,7 +142,10 @@ fn create_env_filter(log_queries: bool) -> EnvFilter {
     }
 
     if log_queries {
-        filter = filter.add_directive("quaint[{is_query}]=trace".parse().unwrap());
+        // even when mongo queries are logged in debug mode, we want to log them if the log level is higher
+        filter = filter
+            .add_directive("quaint[{is_query}]=trace".parse().unwrap())
+            .add_directive("mongodb_query_connector=debug".parse().unwrap());
     }
 
     filter


### PR DESCRIPTION
Fixes https://github.com/prisma/prisma/issues/15084

https://github.com/prisma/prisma-engines/pull/2752 added mongo logging, and as part of that it changed the logging configuration for the node API to ensure that regardless of their level, mongo queries were always logged:

https://github.com/prisma/prisma-engines/blob/abd71fc98e2bebd709f558459d9b3ab1a60e4030/query-engine/query-engine-node-api/src/logger.rs#L39-L48

However, the same change wasn't added to the query-engine server logging configuration. And because mongo logs queries using the [tracing's debug macro](https://github.com/tokio-rs/tracing/blob/196e83e1f3d6d55fa55a5b82e7d36104d56ab4fd/tracing/src/macros.rs#L1271-L1273). Those traces weren't emitted to standard output, and eventually processed by the Prisma client.

This patch fixes the situation by configuring the logger for the query-engine server to select queries logged in debug mode.