### PR TITLE
chore: improve `indoc!` indentation in psl-core

### DIFF
--- a/psl/psl-core/src/validate/validation_pipeline/validations/relations.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/relations.rs
@@ -547,8 +547,8 @@ pub(crate) fn required_relation_cannot_use_set_null(relation: InlineRelationWalk
 
     if let Some(ReferentialAction::SetNull) = forward.explicit_on_delete() {
         ctx.push_error(DatamodelError::new_attribute_validation_error(
-            indoc! {"The `onDelete` referential action of a relation must not be set to `SetNull` when a referenced field is required.
-Either choose another referential action, or make the referenced fields optional."},
+            indoc! {r#"The `onDelete` referential action of a relation must not be set to `SetNull` when a referenced field is required.
+Either choose another referential action, or make the referenced fields optional."#},
             RELATION_ATTRIBUTE_NAME,
             forward.ast_field().span(),
         ))
@@ -556,8 +556,8 @@ Either choose another referential action, or make the referenced fields optional
 
     if let Some(ReferentialAction::SetNull) = forward.explicit_on_update() {
         ctx.push_error(DatamodelError::new_attribute_validation_error(
-            indoc! {"The `onUpdate` referential action of a relation must not be set to `SetNull` when a referenced field is required.
-Either choose another referential action, or make the referenced fields optional."},
+            indoc! {r#"The `onUpdate` referential action of a relation must not be set to `SetNull` when a referenced field is required.
+Either choose another referential action, or make the referenced fields optional."#},
             RELATION_ATTRIBUTE_NAME,
             forward.ast_field().span(),
         ))

--- a/psl/psl-core/src/validate/validation_pipeline/validations/relations.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/relations.rs
@@ -547,8 +547,10 @@ pub(crate) fn required_relation_cannot_use_set_null(relation: InlineRelationWalk
 
     if let Some(ReferentialAction::SetNull) = forward.explicit_on_delete() {
         ctx.push_error(DatamodelError::new_attribute_validation_error(
-            indoc! {r#"The `onDelete` referential action of a relation must not be set to `SetNull` when a referenced field is required.
-Either choose another referential action, or make the referenced fields optional."#},
+            indoc! {r#"
+                The `onDelete` referential action of a relation must not be set to `SetNull` when a referenced field is required.
+                Either choose another referential action, or make the referenced fields optional.
+            "#},
             RELATION_ATTRIBUTE_NAME,
             forward.ast_field().span(),
         ))
@@ -556,8 +558,10 @@ Either choose another referential action, or make the referenced fields optional
 
     if let Some(ReferentialAction::SetNull) = forward.explicit_on_update() {
         ctx.push_error(DatamodelError::new_attribute_validation_error(
-            indoc! {r#"The `onUpdate` referential action of a relation must not be set to `SetNull` when a referenced field is required.
-Either choose another referential action, or make the referenced fields optional."#},
+            indoc! {r#"
+                The `onUpdate` referential action of a relation must not be set to `SetNull` when a referenced field is required.
+                Either choose another referential action, or make the referenced fields optional.
+            "#},
             RELATION_ATTRIBUTE_NAME,
             forward.ast_field().span(),
         ))

--- a/psl/psl/tests/validation/relations/set_null_is_not_valid_on_mixed_fields.prisma
+++ b/psl/psl/tests/validation/relations/set_null_is_not_valid_on_mixed_fields.prisma
@@ -15,7 +15,8 @@ model Profile {
   @@unique([user_id, user_ref])
 }
 // [1;91merror[0m: [1mError parsing attribute "@relation": The `onDelete` referential action of a relation must not be set to `SetNull` when a referenced field is required.
-// Either choose another referential action, or make the referenced fields optional.[0m
+// Either choose another referential action, or make the referenced fields optional.
+// [0m
 //   [1;94m-->[0m  [4mschema.prisma:11[0m
 // [1;94m   | [0m
 // [1;94m10 | [0m  id       Int       @id
@@ -23,7 +24,8 @@ model Profile {
 // [1;94m12 | [0m  user_id  Int?
 // [1;94m   | [0m
 // [1;91merror[0m: [1mError parsing attribute "@relation": The `onUpdate` referential action of a relation must not be set to `SetNull` when a referenced field is required.
-// Either choose another referential action, or make the referenced fields optional.[0m
+// Either choose another referential action, or make the referenced fields optional.
+// [0m
 //   [1;94m-->[0m  [4mschema.prisma:11[0m
 // [1;94m   | [0m
 // [1;94m10 | [0m  id       Int       @id

--- a/psl/psl/tests/validation/relations/set_null_is_not_valid_on_required_fields.prisma
+++ b/psl/psl/tests/validation/relations/set_null_is_not_valid_on_required_fields.prisma
@@ -9,7 +9,8 @@ model Profile {
   user_id Int       @unique
 }
 // [1;91merror[0m: [1mError parsing attribute "@relation": The `onDelete` referential action of a relation must not be set to `SetNull` when a referenced field is required.
-// Either choose another referential action, or make the referenced fields optional.[0m
+// Either choose another referential action, or make the referenced fields optional.
+// [0m
 //   [1;94m-->[0m  [4mschema.prisma:8[0m
 // [1;94m   | [0m
 // [1;94m 7 | [0m  id      Int       @id
@@ -17,7 +18,8 @@ model Profile {
 // [1;94m 9 | [0m  user_id Int       @unique
 // [1;94m   | [0m
 // [1;91merror[0m: [1mError parsing attribute "@relation": The `onUpdate` referential action of a relation must not be set to `SetNull` when a referenced field is required.
-// Either choose another referential action, or make the referenced fields optional.[0m
+// Either choose another referential action, or make the referenced fields optional.
+// [0m
 //   [1;94m-->[0m  [4mschema.prisma:8[0m
 // [1;94m   | [0m
 // [1;94m 7 | [0m  id      Int       @id


### PR DESCRIPTION
Improves `indoc!` indentation added in https://github.com/prisma/prisma-engines/pull/3298/commits/2f30b37180af57902dd1338bfbad5d3bc89ef4a5.