### PR TITLE
Log Capture in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,12 @@ checksum = "b9a8f622bcf6ff3df478e9deba3e03e4e04b300f8e6a139e192c05fa3490afc7"
 
 [[package]]
 name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
+name = "arrayvec"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
@@ -3352,6 +3358,7 @@ dependencies = [
  "request-handlers",
  "serde",
  "serde_json",
+ "strip-ansi-escapes",
  "thiserror",
  "tokio",
  "tracing",
@@ -3593,7 +3600,7 @@ version = "1.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee9164faf726e4f3ece4978b25ca877ddc6802fa77f38cdccb32c7f805ecd70c"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.7.2",
  "num-traits",
  "serde",
 ]
@@ -4146,6 +4153,15 @@ checksum = "8ee348cb74b87454fff4b551cbf727025810a004f88aeacae7f85b87f4e9a1c1"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "strip-ansi-escapes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "011cbb39cf7c1f62871aea3cc46e5817b0937b49e9447370c93cacbe93a766d8"
+dependencies = [
+ "vte",
 ]
 
 [[package]]
@@ -4941,6 +4957,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5190c9442dcdaf0ddd50f37420417d219ae5261bbf5db120d0f9bab996c9cba1"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
+
+[[package]]
 name = "uuid"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4988,6 +5010,27 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "vte"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cbce692ab4ca2f1f3047fcf732430249c0e971bfdd2b234cf2c47ad93af5983"
+dependencies = [
+ "arrayvec 0.5.2",
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte_generate_state_changes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d257817081c7dffcdbab24b9e62d2def62e2ff7d00b1c20062551e6cccc145ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "want"

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/mod.rs
@@ -9,3 +9,4 @@ mod native_types;
 mod occ;
 mod ref_actions;
 mod regressions;
+mod update_no_select;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/update_no_select.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/update_no_select.rs
@@ -1,0 +1,28 @@
+use query_engine_tests::*;
+
+#[test_suite]
+mod update_with_no_select {
+    pub fn occ_simple() -> String {
+        include_str!("occ_simple.prisma").to_owned()
+    }
+
+    #[connector_test(schema(occ_simple))]
+    async fn update_with_no_select(mut runner: Runner) -> TestResult<()> {
+        let create_one_resource = r#"
+        mutation {
+            createOneResource(data: {id: 1}) {
+              id
+            }
+          }"#;
+
+        runner.query(create_one_resource).await.unwrap().to_json_value();
+
+        let logs = runner.get_logs().await;
+
+        let has_select = logs.contains(&"SELECT".to_string());
+
+        assert!(!has_select);
+
+        Ok(())
+    }
+}

--- a/query-engine/connector-test-kit-rs/query-tests-setup/Cargo.toml
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/Cargo.toml
@@ -36,3 +36,4 @@ query-engine-metrics = {path = "../../metrics"}
 # Only this version is vetted, upgrade only after going through the code,
 # as this is a small crate with little user base.
 parse-hyperlinks = "0.23.3"
+strip-ansi-escapes = "0.1.1"

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/lib.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/lib.rs
@@ -28,6 +28,7 @@ use query_engine_metrics::MetricRegistry;
 use std::future::Future;
 use std::sync::Once;
 use tokio::runtime::Builder;
+use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use tracing_futures::WithSubscriber;
 
 pub type TestResult<T> = Result<T, TestError>;
@@ -156,13 +157,14 @@ fn run_relation_link_test_impl(
         let requires_teardown = connector.requires_teardown();
         let metrics = setup_metrics();
         let metrics_for_subscriber = metrics.clone();
+        let (log_capture, log_tx) = TestLogCapture::new();
 
         run_with_tokio(
             async move {
                 tracing::debug!("Used datamodel:\n {}", datamodel.clone().yellow());
                 setup_project(&datamodel, Default::default()).await.unwrap();
 
-                let runner = Runner::load(config.runner(), datamodel.clone(), connector, metrics)
+                let runner = Runner::load(config.runner(), datamodel.clone(), connector, metrics, log_capture)
                     .await
                     .unwrap();
 
@@ -172,7 +174,7 @@ fn run_relation_link_test_impl(
                     teardown_project(&datamodel, Default::default()).await.unwrap();
                 }
             }
-            .with_subscriber(test_tracing_subscriber(&ENV_LOG_LEVEL, metrics_for_subscriber)),
+            .with_subscriber(test_tracing_subscriber(&ENV_LOG_LEVEL, metrics_for_subscriber, log_tx)),
         );
     }
 }
@@ -261,14 +263,22 @@ pub fn run_connector_test_impl(
     let metrics = crate::setup_metrics();
     let metrics_for_subscriber = metrics.clone();
 
+    let (log_capture, log_tx) = TestLogCapture::new();
+
     crate::run_with_tokio(
         async {
             crate::setup_project(&datamodel, db_schemas).await.unwrap();
 
             let requires_teardown = connector.requires_teardown();
-            let runner = Runner::load(crate::CONFIG.runner(), datamodel.clone(), connector, metrics)
-                .await
-                .unwrap();
+            let runner = Runner::load(
+                crate::CONFIG.runner(),
+                datamodel.clone(),
+                connector,
+                metrics,
+                log_capture,
+            )
+            .await
+            .unwrap();
 
             test_fn(runner).await.unwrap();
 
@@ -276,6 +286,27 @@ pub fn run_connector_test_impl(
                 crate::teardown_project(&datamodel, db_schemas).await.unwrap();
             }
         }
-        .with_subscriber(test_tracing_subscriber(&ENV_LOG_LEVEL, metrics_for_subscriber)),
+        .with_subscriber(test_tracing_subscriber(&ENV_LOG_LEVEL, metrics_for_subscriber, log_tx)),
     );
+}
+
+pub type LogEmit = UnboundedSender<String>;
+pub struct TestLogCapture {
+    rx: UnboundedReceiver<String>,
+}
+
+impl TestLogCapture {
+    pub fn new() -> (Self, LogEmit) {
+        let (tx, rx) = unbounded_channel();
+        (Self { rx }, tx)
+    }
+
+    pub async fn get_logs(&mut self) -> Vec<String> {
+        let mut logs = Vec::new();
+        while let Ok(log_line) = self.rx.try_recv() {
+            logs.push(log_line)
+        }
+
+        logs
+    }
 }

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/logging.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/logging.rs
@@ -1,6 +1,8 @@
 use query_engine_metrics::MetricRegistry;
 use tracing_error::ErrorLayer;
-use tracing_subscriber::{layer::Layered, prelude::*, EnvFilter, Registry};
+use tracing_subscriber::{layer::Layered, prelude::*, EnvFilter, Layer, Registry};
+
+use crate::LogEmit;
 
 // Pretty ugly. I'm not sure how to make this better
 type Sub = Layered<
@@ -25,11 +27,11 @@ type Sub = Layered<
     >,
 >;
 
-pub fn test_tracing_subscriber(log_config: &str, metrics: MetricRegistry) -> Sub {
+pub fn test_tracing_subscriber(log_config: &str, metrics: MetricRegistry, log_tx: LogEmit) -> Sub {
     let filter = create_env_filter(true, log_config);
 
     let fmt_layer = tracing_subscriber::fmt::layer()
-        .with_writer(PrintWriter)
+        .with_writer(PrintWriter::new(log_tx))
         .with_filter(filter);
 
     tracing_subscriber::registry()
@@ -66,19 +68,34 @@ fn create_env_filter(log_queries: bool, qe_log_level: &str) -> EnvFilter {
 /// specific test outputs for readability.
 ///
 /// It is used from test_macros.
-pub struct PrintWriter;
+pub struct PrintWriter {
+    tx: LogEmit,
+}
+
+impl PrintWriter {
+    fn new(tx: LogEmit) -> Self {
+        Self { tx }
+    }
+}
 
 impl tracing_subscriber::fmt::MakeWriter<'_> for PrintWriter {
     type Writer = PrintWriter;
 
     fn make_writer(&self) -> Self::Writer {
-        PrintWriter
+        PrintWriter::new(self.tx.clone())
     }
 }
 
 impl std::io::Write for PrintWriter {
     fn write(&mut self, buf: &[u8]) -> Result<usize, std::io::Error> {
-        eprint!("{}", std::str::from_utf8(buf).unwrap_or("<invalid UTF-8>"));
+        let log = std::str::from_utf8(buf).unwrap_or("<invalid UTF-8>");
+
+        if log.contains("quaint") || log.contains("mongodb_query_connector") {
+            let plain_bytes = strip_ansi_escapes::strip(buf)?;
+            let plain_log = std::str::from_utf8(&plain_bytes).unwrap_or("<invalid UTF-8>");
+            let _ = self.tx.send(plain_log.to_string());
+        }
+        eprint!("{}", log);
         Ok(buf.len())
     }
 


### PR DESCRIPTION
It is often useful to capture the sql query logs for a test so that we can check they are what we expect them to be. This sets up a basic system to capture them and get them from the test runner