### PR TITLE
me: make MigrationConnector::diff() infallible

### DIFF
--- a/migration-engine/connectors/migration-connector/src/lib.rs
+++ b/migration-engine/connectors/migration-connector/src/lib.rs
@@ -115,9 +115,8 @@ pub trait MigrationConnector: Send + Sync + 'static {
     /// Send a command to the database directly.
     fn db_execute(&mut self, script: String) -> BoxFuture<'_, ConnectorResult<()>>;
 
-    /// Create a migration by comparing two database schemas. See
-    /// [DiffTarget](/enum.DiffTarget.html) for possible inputs.
-    fn diff(&self, from: DatabaseSchema, to: DatabaseSchema) -> ConnectorResult<Migration>;
+    /// Create a migration by comparing two database schemas.
+    fn diff(&self, from: DatabaseSchema, to: DatabaseSchema) -> Migration;
 
     /// Drop the database referenced by Prisma schema that was used to initialize the connector.
     fn drop_database(&mut self) -> BoxFuture<'_, ConnectorResult<()>>;

--- a/migration-engine/connectors/mongodb-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/mongodb-migration-connector/src/lib.rs
@@ -120,10 +120,10 @@ impl MigrationConnector for MongoDbMigrationConnector {
         Box::pin(future::ready(Ok("4 or 5".to_owned())))
     }
 
-    fn diff(&self, from: DatabaseSchema, to: DatabaseSchema) -> ConnectorResult<Migration> {
+    fn diff(&self, from: DatabaseSchema, to: DatabaseSchema) -> Migration {
         let from: Box<MongoSchema> = from.downcast();
         let to: Box<MongoSchema> = to.downcast();
-        Ok(Migration::new(differ::diff(from, to)))
+        Migration::new(differ::diff(from, to))
     }
 
     fn drop_database(&mut self) -> BoxFuture<'_, ConnectorResult<()>> {

--- a/migration-engine/connectors/mongodb-migration-connector/tests/migrations/test_api.rs
+++ b/migration-engine/connectors/mongodb-migration-connector/tests/migrations/test_api.rs
@@ -188,7 +188,7 @@ pub(crate) fn test_scenario(scenario_name: &str) {
             .database_schema_from_diff_target(DiffTarget::Datamodel(schema.clone()), None)
             .await
             .unwrap();
-        let migration = connector.diff(from, to).unwrap();
+        let migration = connector.diff(from, to);
 
         connector.apply_migration(&migration).await.unwrap();
 
@@ -230,7 +230,7 @@ Snapshot comparison failed. Run the test again with UPDATE_EXPECT=1 in the envir
             .database_schema_from_diff_target(DiffTarget::Datamodel(schema), None)
             .await
             .unwrap();
-        let migration = connector.diff(from, to).unwrap();
+        let migration = connector.diff(from, to);
 
         assert!(
             connector.migration_is_empty(&migration),

--- a/migration-engine/connectors/sql-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/lib.rs
@@ -204,17 +204,17 @@ impl MigrationConnector for SqlMigrationConnector {
     }
 
     #[tracing::instrument(skip(self, from, to))]
-    fn diff(&self, from: DatabaseSchema, to: DatabaseSchema) -> ConnectorResult<Migration> {
+    fn diff(&self, from: DatabaseSchema, to: DatabaseSchema) -> Migration {
         let previous = SqlDatabaseSchema::from_erased(from);
         let next = SqlDatabaseSchema::from_erased(to);
         let steps = sql_schema_differ::calculate_steps(Pair::new(&previous, &next), self.flavour.as_ref());
         tracing::debug!(?steps, "Inferred migration steps.");
 
-        Ok(Migration::new(SqlMigration {
+        Migration::new(SqlMigration {
             before: previous.describer_schema,
             after: next.describer_schema,
             steps,
-        }))
+        })
     }
 
     fn drop_database(&mut self) -> BoxFuture<'_, ConnectorResult<()>> {

--- a/migration-engine/core/src/commands/create_migration.rs
+++ b/migration-engine/core/src/commands/create_migration.rs
@@ -32,7 +32,7 @@ pub async fn create_migration(
             None,
         )
         .await?;
-    let migration = connector.diff(from, to)?;
+    let migration = connector.diff(from, to);
 
     if connector.migration_is_empty(&migration) && !input.draft {
         tracing::info!("Database is up-to-date, returning without creating new migration.");

--- a/migration-engine/core/src/commands/diagnose_migration_history.rs
+++ b/migration-engine/core/src/commands/diagnose_migration_history.rs
@@ -135,15 +135,13 @@ pub async fn diagnose_migration_history(
             let to = connector
                 .database_schema_from_diff_target(DiffTarget::Database, None)
                 .await;
-            let drift = match from
-                .and_then(|from| to.and_then(|to| connector.diff(from, to)))
-                .map(|mig| {
-                    if connector.migration_is_empty(&mig) {
-                        None
-                    } else {
-                        Some(mig)
-                    }
-                }) {
+            let drift = match from.and_then(|from| to.map(|to| connector.diff(from, to))).map(|mig| {
+                if connector.migration_is_empty(&mig) {
+                    None
+                } else {
+                    Some(mig)
+                }
+            }) {
                 Ok(Some(drift)) => Some(DriftDiagnostic::DriftDetected {
                     summary: connector.migration_summary(&drift),
                 }),

--- a/migration-engine/core/src/commands/diff.rs
+++ b/migration-engine/core/src/commands/diff.rs
@@ -37,7 +37,7 @@ pub async fn diff(params: DiffParams, host: Arc<dyn ConnectorHost>) -> CoreResul
         }
     };
 
-    let migration = connector.diff(from, to)?;
+    let migration = connector.diff(from, to);
 
     if params.script {
         let mut script_string = connector.render_script(&migration, &Default::default())?;

--- a/migration-engine/core/src/commands/evaluate_data_loss.rs
+++ b/migration-engine/core/src/commands/evaluate_data_loss.rs
@@ -23,7 +23,7 @@ pub async fn evaluate_data_loss(
     let to = connector
         .database_schema_from_diff_target(DiffTarget::Datamodel(source_file), None)
         .await?;
-    let migration = connector.diff(from, to)?;
+    let migration = connector.diff(from, to);
 
     let migration_steps = connector.migration_len(&migration) as u32;
     let diagnostics = connector.destructive_change_checker().check(&migration).await?;

--- a/migration-engine/core/src/commands/schema_push.rs
+++ b/migration-engine/core/src/commands/schema_push.rs
@@ -25,7 +25,7 @@ pub async fn schema_push(
         .database_schema_from_diff_target(DiffTarget::Datamodel(source), None)
         .instrument(tracing::debug_span!("Calculate `to`"))
         .await?;
-    let database_migration = connector.diff(from, to)?;
+    let database_migration = connector.diff(from, to);
 
     tracing::debug!(migration = connector.migration_summary(&database_migration).as_str());
 

--- a/migration-engine/migration-engine-tests/src/test_api.rs
+++ b/migration-engine/migration-engine-tests/src/test_api.rs
@@ -236,7 +236,7 @@ impl TestApi {
     pub fn connector_diff(&mut self, from: DiffTarget<'_>, to: DiffTarget<'_>) -> String {
         let from = tok(self.connector.database_schema_from_diff_target(from, None)).unwrap();
         let to = tok(self.connector.database_schema_from_diff_target(to, None)).unwrap();
-        let migration = self.connector.diff(from, to).unwrap();
+        let migration = self.connector.diff(from, to);
         self.connector.render_script(&migration, &Default::default()).unwrap()
     }
 


### PR DESCRIPTION
- Make it always return a migration. Diffing two schemas does not perform IO, it is not an operation that can fail. The signature should reflect that.
- Delete misleading sentence from method docstring.