### PR TITLE
fix: batching should work with non unique scalar filters

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_5952.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_5952.rs
@@ -39,8 +39,8 @@ mod regression {
             .assert_success();
 
         let queries = vec![
-            r#"query {findUniqueArtist(where:{firstName_lastName_birth:{firstName:"Michael",netWorth:"236600000.12409"}}) {firstName netWorth}}"#.to_string(),
-            r#"query {findUniqueArtist(where:{firstName_lastName_birth:{firstName:"George",netWorth:"-0.23660010012409"}}) {firstName netWorth}}"#.to_string(),
+            r#"query {findUniqueArtist(where:{firstName_netWorth:{firstName:"Michael",netWorth:"236600000.12409"}}) {firstName netWorth}}"#.to_string(),
+            r#"query {findUniqueArtist(where:{firstName_netWorth:{firstName:"George",netWorth:"-0.23660010012409"}}) {firstName netWorth}}"#.to_string(),
         ];
 
         let batch_results = runner.batch(queries, false, None).await?;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/batch/select_one_compound.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/batch/select_one_compound.rs
@@ -3,12 +3,14 @@ use query_engine_tests::*;
 #[test_suite(schema(schema), capabilities(AnyId))]
 mod compound_batch {
     use indoc::indoc;
+    use query_engine_tests::query_core::{BatchDocument, QueryDocument};
 
     fn schema() -> String {
         let schema = indoc! {
             r#"model Artist {
                 firstName String
                 lastName  String
+                non_unique Int?
 
                 @@unique([firstName, lastName])
               }"#
@@ -24,11 +26,20 @@ mod compound_batch {
         let queries = vec![
             r#"query { findUniqueArtist(where: { firstName_lastName: { firstName:"Musti", lastName:"Naukio" }}) { firstName lastName }}"#.to_string()
         ];
-
         let batch_results = runner.batch(queries, false, None).await?;
         insta::assert_snapshot!(
             batch_results.to_string(),
             @r###"{"batchResult":[{"data":{"findUniqueArtist":{"firstName":"Musti","lastName":"Naukio"}}}]}"###
+        );
+
+        // With non unique filters
+        let queries = vec![
+            r#"query { findUniqueArtist(where: { firstName_lastName: { firstName:"Musti", lastName:"Naukio", non_unique: 0 }}) { firstName lastName non_unique }}"#.to_string()
+        ];
+        let batch_results = runner.batch(queries, false, None).await?;
+        insta::assert_snapshot!(
+            batch_results.to_string(),
+            @r###"{"batchResult":[{"data":{"findUniqueArtist":{"firstName":"Musti","lastName":"Naukio","non_unique":0}}}]}"###
         );
 
         Ok(())
@@ -43,7 +54,18 @@ mod compound_batch {
             r#"query {findUniqueArtist(where:{firstName_lastName:{firstName:"NO",lastName:"AVAIL"}}) {firstName lastName}}"#.to_string(),
             r#"query {findUniqueArtist(where:{firstName_lastName:{firstName:"Naukio",lastName:"Musti"}}) {firstName lastName}}"#.to_string(),
         ];
+        let batch_results = runner.batch(queries, false, None).await?;
+        insta::assert_snapshot!(
+            batch_results.to_string(),
+            @r###"{"batchResult":[{"data":{"findUniqueArtist":{"firstName":"Musti","lastName":"Naukio"}}},{"data":{"findUniqueArtist":null}},{"data":{"findUniqueArtist":{"firstName":"Naukio","lastName":"Musti"}}}]}"###
+        );
 
+        // With non unique filters
+        let queries = vec![
+            r#"query {findUniqueArtist(where:{firstName_lastName:{firstName:"Musti",lastName:"Naukio", non_unique: 0}}) {firstName lastName}}"#.to_string(),
+            r#"query {findUniqueArtist(where:{firstName_lastName:{firstName:"Musti",lastName:"Naukio", non_unique: 1}}) {firstName lastName}}"#.to_string(),
+            r#"query {findUniqueArtist(where:{firstName_lastName:{firstName:"Naukio",lastName:"Musti", non_unique: null}}) {firstName lastName}}"#.to_string(),
+        ];
         let batch_results = runner.batch(queries, false, None).await?;
         insta::assert_snapshot!(
             batch_results.to_string(),
@@ -68,6 +90,18 @@ mod compound_batch {
             @r###"{"batchResult":[{"data":{"findUniqueArtist":{"firstName":"Musti","lastName":"Naukio"}}},{"data":{"findUniqueArtist":{"firstName":"Naukio","lastName":"Musti"}}}]}"###
         );
 
+        // With non unique filters
+        let queries = vec![
+            r#"query {findUniqueArtist(where:{firstName_lastName:{firstName:"Musti",lastName:"Naukio"}, non_unique: 0}) {non_unique firstName lastName}}"#.to_string(),
+            r#"query {findUniqueArtist(where:{firstName_lastName:{firstName:"Naukio",lastName:"Musti"}, non_unique: null}) {lastName firstName}}"#.to_string(),
+        ];
+
+        let batch_results = runner.batch(queries, false, None).await?;
+        insta::assert_snapshot!(
+            batch_results.to_string(),
+            @r###"{"batchResult":[{"data":{"findUniqueArtist":{"non_unique":0,"firstName":"Musti","lastName":"Naukio"}}},{"data":{"findUniqueArtist":{"lastName":"Musti","firstName":"Naukio"}}}]}"###
+        );
+
         Ok(())
     }
 
@@ -81,6 +115,19 @@ mod compound_batch {
            r#"query {findUniqueArtist(where:{firstName_lastName:{firstName:"NO",lastName:"AVAIL"}}) {lastName}}"#.to_string(),
            r#"query {findUniqueArtist(where:{firstName_lastName:{firstName:"Naukio",lastName:"Musti"}}) {firstName lastName}}"#.to_string(),
         ];
+
+        let batch_results = runner.batch(queries, false, None).await?;
+        insta::assert_snapshot!(
+            batch_results.to_string(),
+            @r###"{"batchResult":[{"data":{"findUniqueArtist":{"firstName":"Musti","lastName":"Naukio"}}},{"data":{"findUniqueArtist":null}},{"data":{"findUniqueArtist":{"firstName":"Naukio","lastName":"Musti"}}}]}"###
+        );
+
+        // With non unique filters
+        let queries = vec![
+            r#"query {findUniqueArtist(where:{firstName_lastName:{firstName:"Musti",lastName:"Naukio"}, non_unique: { equals: 0 }}) {firstName lastName}}"#.to_string(),
+            r#"query {findUniqueArtist(where:{firstName_lastName:{firstName:"NO",lastName:"AVAIL"}, non_unique: 1}) {lastName}}"#.to_string(),
+            r#"query {findUniqueArtist(where:{firstName_lastName:{firstName:"Naukio",lastName:"Musti"}, non_unique: null}) {firstName lastName}}"#.to_string(),
+         ];
 
         let batch_results = runner.batch(queries, false, None).await?;
         insta::assert_snapshot!(
@@ -127,9 +174,166 @@ mod compound_batch {
         Ok(())
     }
 
+    #[connector_test]
+    async fn no_compact_but_works_as_batch(runner: Runner) -> TestResult<()> {
+        create_test_data(&runner).await?;
+
+        let queries = vec![
+            r#"query {findUniqueArtist(where:{firstName_lastName:{firstName:"Musti",lastName:"Naukio"}, non_unique: { gte: 0 }}) {firstName lastName}}"#.to_string(),
+            r#"query {findUniqueArtist(where:{firstName_lastName:{firstName:"Naukio",lastName:"Musti"}, non_unique: null}) {firstName lastName}}"#.to_string(),
+        ];
+
+        let batch_results = runner.batch(queries, false, None).await?;
+        insta::assert_snapshot!(
+            batch_results.to_string(),
+            @r###"{"batchResult":[{"data":{"findUniqueArtist":{"firstName":"Musti","lastName":"Naukio"}}},{"data":{"findUniqueArtist":{"firstName":"Naukio","lastName":"Musti"}}}]}"###
+        );
+
+        Ok(())
+    }
+
+    fn should_batch_schema() -> String {
+        let schema = indoc! {
+            r#"model Artist {
+                #id(id, Int, @id)
+                firstName String
+                lastName  String
+                non_unique Int?
+
+                songs Song[]
+
+                @@unique([firstName, lastName])
+              }
+
+              model Song {
+                #id(id, Int, @id)
+                title String
+
+                artistId Int?
+                artist Artist? @relation(fields: [artistId], references: [id])
+              }
+              "#
+        };
+
+        schema.to_owned()
+    }
+
+    // Ensures non compactable batch are not compacted
+    #[connector_test(schema(should_batch_schema))]
+    async fn should_only_batch_if_possible(runner: Runner) -> TestResult<()> {
+        // COMPACT: Queries use compound unique
+        let doc = compact_batch(&runner, vec![
+            r#"query {findUniqueArtist(where:{firstName_lastName:{firstName:"Musti",lastName:"Naukio"}}) {firstName lastName}}"#.to_string(),
+            r#"query {findUniqueArtist(where:{firstName_lastName:{firstName:"NO",lastName:"AVAIL"}}) {firstName lastName}}"#.to_string(),
+        ]).await?;
+        assert!(doc.is_compact());
+
+        // COMPACT: Queries use compound unique + non unique equal filter (shorthand syntax)
+        let doc = compact_batch(&runner, vec![
+            r#"query {findUniqueArtist(where:{firstName_lastName:{firstName:"Musti",lastName:"Naukio"}, non_unique: 0}) {firstName lastName}}"#.to_string(),
+            r#"query {findUniqueArtist(where:{firstName_lastName:{firstName:"NO",lastName:"AVAIL"}, non_unique: 1}) {firstName lastName}}"#.to_string(),
+        ]).await?;
+        assert!(doc.is_compact());
+
+        // COMPACT: Queries use compound unique + non unique equal filter
+        let doc = compact_batch(&runner, vec![
+            r#"query {findUniqueArtist(where:{firstName_lastName:{firstName:"Musti",lastName:"Naukio"}, non_unique: 0}) {firstName lastName}}"#.to_string(),
+            r#"query {findUniqueArtist(where:{firstName_lastName:{firstName:"NO",lastName:"AVAIL"}, non_unique: { equals: 1 }}) {firstName lastName}}"#.to_string(),
+        ]).await?;
+        assert!(doc.is_compact());
+
+        // COMPACT: Queries use compound unique + non unique equal filter
+        let doc = compact_batch(&runner, vec![
+            r#"query {findUniqueArtist(where:{firstName_lastName:{firstName:"Musti",lastName:"Naukio"}, non_unique: 0}) {firstName lastName}}"#.to_string(),
+            r#"query {findUniqueArtist(where:{firstName_lastName:{firstName:"NO",lastName:"AVAIL"}}) {firstName lastName}}"#.to_string(),
+        ]).await?;
+        assert!(doc.is_compact());
+
+        // COMPACT: Queries use compound unique + non unique equal filter (null)
+        let doc = compact_batch(&runner, vec![
+            r#"query {findUniqueArtist(where:{firstName_lastName:{firstName:"Musti",lastName:"Naukio"}, non_unique: null}) {firstName lastName}}"#.to_string(),
+            r#"query {findUniqueArtist(where:{firstName_lastName:{firstName:"NO",lastName:"AVAIL"}, non_unique: { equals: null }}) {firstName lastName}}"#.to_string(),
+        ]).await?;
+        assert!(doc.is_compact());
+
+        // NO COMPACT: Queries use boolean operators
+        let doc = compact_batch(&runner, vec![
+            r#"query {findUniqueArtist(where:{firstName_lastName:{firstName:"Musti",lastName:"Naukio"}, OR: [{ non_unique: 0 }] }) {firstName lastName}}"#.to_string(),
+            r#"query {findUniqueArtist(where:{firstName_lastName:{firstName:"NO",lastName:"AVAIL"}, OR: [{ non_unique: 0 }] }) {firstName lastName}}"#.to_string(),
+        ]).await?;
+        assert!(doc.is_compact() == false);
+
+        // NO COMPACT: Queries use boolean operators
+        let doc = compact_batch(&runner, vec![
+            r#"query {findUniqueArtist(where:{firstName_lastName:{firstName:"Musti",lastName:"Naukio"}, AND: [{ non_unique: 0 }] }) {firstName lastName}}"#.to_string(),
+            r#"query {findUniqueArtist(where:{firstName_lastName:{firstName:"NO",lastName:"AVAIL"}, AND: [{ non_unique: 0 }] }) {firstName lastName}}"#.to_string(),
+        ]).await?;
+        assert!(doc.is_compact() == false);
+
+        // NO COMPACT: Queries use boolean operators
+        let doc = compact_batch(&runner, vec![
+            r#"query {findUniqueArtist(where:{firstName_lastName:{firstName:"Musti",lastName:"Naukio"}, NOT: [{ non_unique: 0 }] }) {firstName lastName}}"#.to_string(),
+            r#"query {findUniqueArtist(where:{firstName_lastName:{firstName:"NO",lastName:"AVAIL"}, NOT: [{ non_unique: 1 }] }) {firstName lastName}}"#.to_string(),
+        ]).await?;
+        assert!(doc.is_compact() == false);
+
+        // NO COMPACT: Queries use relation
+        let doc = compact_batch(&runner, vec![
+            r#"query {findUniqueArtist(where:{firstName_lastName:{firstName:"Musti",lastName:"Naukio"}, songs: { some: { title: "Bohemian Rapsody" } } }) {firstName lastName}}"#.to_string(),
+            r#"query {findUniqueArtist(where:{firstName_lastName:{firstName:"NO",lastName:"AVAIL"}, songs: { some: { title: "Somebody To Love" } } }) {firstName lastName}}"#.to_string(),
+        ]).await?;
+        assert!(doc.is_compact() == false);
+
+        // NO COMPACT: Queries use non unique filter that's not EQUALS
+        let doc = compact_batch(&runner, vec![
+            r#"query {findUniqueArtist(where:{firstName_lastName:{firstName:"Musti",lastName:"Naukio"}, non_unique: { gt: 1 } }) {firstName lastName}}"#.to_string(),
+            r#"query {findUniqueArtist(where:{firstName_lastName:{firstName:"NO",lastName:"AVAIL"}, non_unique: { gt: 1 } }) {firstName lastName}}"#.to_string(),
+        ]).await?;
+        assert!(doc.is_compact() == false);
+
+        Ok(())
+    }
+
+    #[connector_test(schema(common_list_types), capabilities(ScalarLists))]
+    async fn should_only_batch_if_possible_list(runner: Runner) -> TestResult<()> {
+        // COMPACT: Queries use compound unique
+        let doc = compact_batch(
+            &runner,
+            vec![
+                r#"query {findUniqueTestModel(where:{ id: 1, str_list: [1, 2, 3] }) {id}}"#.to_string(),
+                r#"query {findUniqueTestModel(where:{ id: 2, str_list: [1, 3, 4] }}) {id}}"#.to_string(),
+            ],
+        )
+        .await?;
+        assert!(doc.is_compact());
+
+        Ok(())
+    }
+
+    async fn compact_batch(runner: &Runner, queries: Vec<String>) -> TestResult<BatchDocument> {
+        // Ensure queries are valid
+        for q in queries.iter() {
+            run_query!(runner, q.to_string());
+        }
+
+        let doc = GraphQlBody::Multi(MultiQuery::new(
+            queries.into_iter().map(Into::into).collect(),
+            false,
+            None,
+        ))
+        .into_doc()
+        .unwrap();
+        let batch = match doc {
+            QueryDocument::Multi(batch) => batch.compact(runner.query_schema()),
+            _ => unreachable!(),
+        };
+
+        Ok(batch.compact(runner.query_schema()))
+    }
+
     async fn create_test_data(runner: &Runner) -> TestResult<()> {
         runner
-            .query(r#"mutation { createOneArtist(data: { firstName: "Musti" lastName: "Naukio" }) { firstName }}"#)
+            .query(r#"mutation { createOneArtist(data: { firstName: "Musti" lastName: "Naukio", non_unique: 0 }) { firstName }}"#)
             .await?
             .assert_success();
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/batch/select_one_compound.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/batch/select_one_compound.rs
@@ -291,6 +291,20 @@ mod compound_batch {
         ]).await?;
         assert!(doc.is_compact() == false);
 
+        // NO COMPACT: One of the query uses a non unique filter that's not EQUALS
+        let doc = compact_batch(&runner, vec![
+            r#"query {findUniqueArtist(where:{firstName_lastName:{firstName:"Musti",lastName:"Naukio"} }) {firstName lastName}}"#.to_string(),
+            r#"query {findUniqueArtist(where:{firstName_lastName:{firstName:"NO",lastName:"AVAIL"}, non_unique: { gt: 1 } }) {firstName lastName}}"#.to_string(),
+        ]).await?;
+        assert!(doc.is_compact() == false);
+
+        // NO COMPACT: One of the query is not a findUnique
+        let doc = compact_batch(&runner, vec![
+            r#"query {findManyArtist {firstName lastName}}"#.to_string(),
+            r#"query {findUniqueArtist(where:{firstName_lastName:{firstName:"NO",lastName:"AVAIL"}, non_unique: { gt: 1 } }) {firstName lastName}}"#.to_string(),
+        ]).await?;
+        assert!(doc.is_compact() == false);
+
         Ok(())
     }
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/batch/select_one_singular.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/batch/select_one_singular.rs
@@ -1,7 +1,7 @@
 use query_engine_tests::*;
 
 #[test_suite(schema(schema))]
-mod singlular_batch {
+mod singular_batch {
     use indoc::indoc;
 
     fn schema() -> String {
@@ -41,6 +41,17 @@ mod singlular_batch {
             @r###"{"batchResult":[{"data":{"findUniqueArtist":{"Name":"ArtistWithoutAlbums"}}}]}"###
         );
 
+        // With non-unique filter
+        let queries = vec![
+            r#"query { findUniqueArtist(where: { ArtistId: 1, Name: "ArtistWithoutAlbums" }){ Name }}"#.to_string(),
+        ];
+
+        let batch_results = runner.batch(queries, false, None).await?;
+        insta::assert_snapshot!(
+            batch_results.to_string(),
+            @r###"{"batchResult":[{"data":{"findUniqueArtist":{"Name":"ArtistWithoutAlbums"}}}]}"###
+        );
+
         Ok(())
     }
 
@@ -52,6 +63,19 @@ mod singlular_batch {
             r#"query { findUniqueArtist(where: { ArtistId: 1 }) { Name, ArtistId }}"#.to_string(),
             r#"query { findUniqueArtist(where: { ArtistId: 420 }) { Name, ArtistId }}"#.to_string(),
             r#"query { findUniqueArtist(where: { ArtistId: 2 }) { ArtistId, Name }}"#.to_string(),
+        ];
+
+        let batch_results = runner.batch(queries, false, None).await?;
+        insta::assert_snapshot!(
+            batch_results.to_string(),
+            @r###"{"batchResult":[{"data":{"findUniqueArtist":{"Name":"ArtistWithoutAlbums","ArtistId":1}}},{"data":{"findUniqueArtist":null}},{"data":{"findUniqueArtist":{"Name":"ArtistWithOneAlbumWithoutTracks","ArtistId":2}}}]}"###
+        );
+
+        // With non-unique filters
+        let queries = vec![
+            r#"query { findUniqueArtist(where: { ArtistId: 1, Name: "ArtistWithoutAlbums" }) { Name, ArtistId }}"#.to_string(),
+            r#"query { findUniqueArtist(where: { ArtistId: 420, Name: "Bonamassa" }) { Name, ArtistId }}"#.to_string(),
+            r#"query { findUniqueArtist(where: { ArtistId: 2, Name: { equals: "ArtistWithOneAlbumWithoutTracks" } }) { ArtistId, Name }}"#.to_string(),
         ];
 
         let batch_results = runner.batch(queries, false, None).await?;
@@ -99,6 +123,19 @@ mod singlular_batch {
             @r###"{"batchResult":[{"data":{"findUniqueArtist":{"Albums":[{"AlbumId":2,"Title":"TheAlbumWithoutTracks"}]}}},{"data":{"findUniqueArtist":{"Albums":[]}}},{"data":{"findUniqueArtist":null}}]}"###
         );
 
+        // With non-unique filter
+        let queries = vec![
+            r#"query { findUniqueArtist(where: { ArtistId: 2, Name: "ArtistWithOneAlbumWithoutTracks" }) { Albums { AlbumId, Title }}}"#.to_string(),
+            r#"query { findUniqueArtist(where: { ArtistId: 1, Name: "ArtistWithoutAlbums" }) { Albums { Title, AlbumId }}}"#.to_string(),
+            r#"query { findUniqueArtist(where: { ArtistId: 420, Name: "Bonamassa" }) { Albums { AlbumId, Title }}}"#.to_string(),
+        ];
+
+        let batch_results = runner.batch(queries, false, None).await?;
+        insta::assert_snapshot!(
+            batch_results.to_string(),
+            @r###"{"batchResult":[{"data":{"findUniqueArtist":{"Albums":[{"AlbumId":2,"Title":"TheAlbumWithoutTracks"}]}}},{"data":{"findUniqueArtist":{"Albums":[]}}},{"data":{"findUniqueArtist":null}}]}"###
+        );
+
         Ok(())
     }
 
@@ -110,6 +147,19 @@ mod singlular_batch {
             r#"query { findUniqueArtist(where: { ArtistId: 2 }) { Albums(where: { AlbumId: { equals: 2 }}) { AlbumId, Title }}}"#.to_string(),
             r#"query { findUniqueArtist(where: { ArtistId: 1 }) { Albums(where: { AlbumId: { equals: 2 }}) { Title, AlbumId }}}"#.to_string(),
             r#"query { findUniqueArtist(where: { ArtistId: 420 }) { Albums(where: { AlbumId: { equals: 2 }}) { AlbumId, Title }}}"#.to_string(),
+        ];
+
+        let batch_results = runner.batch(queries, false, None).await?;
+        insta::assert_snapshot!(
+            batch_results.to_string(),
+            @r###"{"batchResult":[{"data":{"findUniqueArtist":{"Albums":[{"AlbumId":2,"Title":"TheAlbumWithoutTracks"}]}}},{"data":{"findUniqueArtist":{"Albums":[]}}},{"data":{"findUniqueArtist":null}}]}"###
+        );
+
+        // With non-unique filter
+        let queries = vec![
+            r#"query { findUniqueArtist(where: { ArtistId: 2, Name: "ArtistWithOneAlbumWithoutTracks" }) { Albums(where: { AlbumId: { equals: 2 }}) { AlbumId, Title }}}"#.to_string(),
+            r#"query { findUniqueArtist(where: { ArtistId: 1, Name: "ArtistWithoutAlbums" }) { Albums(where: { AlbumId: { equals: 2 }}) { Title, AlbumId }}}"#.to_string(),
+            r#"query { findUniqueArtist(where: { ArtistId: 420, Name: "Bonamassa" }) { Albums(where: { AlbumId: { equals: 2 }}) { AlbumId, Title }}}"#.to_string(),
         ];
 
         let batch_results = runner.batch(queries, false, None).await?;

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/lib.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/lib.rs
@@ -17,6 +17,7 @@ pub use error::*;
 pub use logging::*;
 pub use query_core;
 pub use query_result::*;
+pub use request_handlers::{GraphQlBody, MultiQuery};
 pub use runner::*;
 pub use schema_gen::*;
 pub use templating::*;

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/binary.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/binary.rs
@@ -1,6 +1,6 @@
 use crate::{ConnectorTag, RunnerInterface, TestError, TestResult, TxResult};
 use hyper::{Body, Method, Request, Response};
-use query_core::TxId;
+use query_core::{schema::QuerySchemaRef, TxId};
 use query_engine::opt::PrismaOpt;
 use query_engine::server::{routes, setup, State};
 use query_engine_metrics::MetricRegistry;
@@ -183,6 +183,10 @@ impl RunnerInterface for BinaryRunner {
 
     fn get_metrics(&self) -> MetricRegistry {
         self.state.get_metrics()
+    }
+
+    fn query_schema(&self) -> &QuerySchemaRef {
+        self.state.query_schema()
     }
 }
 

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/direct.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/direct.rs
@@ -118,4 +118,8 @@ impl RunnerInterface for DirectRunner {
     fn get_metrics(&self) -> MetricRegistry {
         self.metrics.clone()
     }
+
+    fn query_schema(&self) -> &QuerySchemaRef {
+        &self.query_schema
+    }
 }

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/mod.rs
@@ -5,7 +5,7 @@ mod node_api;
 pub use binary::*;
 pub use direct::*;
 pub use node_api::*;
-use query_core::TxId;
+use query_core::{schema::QuerySchemaRef, TxId};
 use query_engine_metrics::MetricRegistry;
 
 use crate::{ConnectorTag, ConnectorVersion, QueryResult, TestError, TestLogCapture, TestResult};
@@ -53,6 +53,9 @@ pub trait RunnerInterface: Sized {
     fn clear_active_tx(&mut self);
 
     fn get_metrics(&self) -> MetricRegistry;
+
+    /// The query schema used for the test.
+    fn query_schema(&self) -> &QuerySchemaRef;
 }
 
 enum RunnerType {
@@ -213,5 +216,13 @@ impl Runner {
 
     pub async fn get_logs(&mut self) -> Vec<String> {
         self.log_capture.get_logs().await
+    }
+
+    pub fn query_schema(&self) -> &QuerySchemaRef {
+        match &self.inner {
+            RunnerType::Direct(r) => r.query_schema(),
+            RunnerType::NodeApi(_) => todo!(),
+            RunnerType::Binary(r) => r.query_schema(),
+        }
     }
 }

--- a/query-engine/core/src/query_document/mod.rs
+++ b/query-engine/core/src/query_document/mod.rs
@@ -30,7 +30,11 @@ pub use query_value::*;
 pub use selection::*;
 pub use transformers::*;
 
-use schema_builder::constants::args;
+use crate::resolve_compound_field;
+use indexmap::IndexMap;
+use prisma_models::ModelRef;
+use schema::QuerySchemaRef;
+use schema_builder::constants::*;
 
 pub type QueryParserResult<T> = std::result::Result<T, QueryParserError>;
 
@@ -60,29 +64,62 @@ impl BatchDocument {
         Self::Multi(operations, transaction)
     }
 
-    fn can_compact(&self) -> bool {
+    fn can_compact(&self, schema: &QuerySchemaRef) -> bool {
         match self {
             Self::Multi(operations, _) => match operations.split_first() {
-                Some((first, rest)) if first.is_find_unique() => rest.iter().all(|op| {
-                    op.is_find_unique()
-                        && first.name() == op.name()
-                        && first.nested_selections().len() == op.nested_selections().len()
-                        && first
-                            .nested_selections()
-                            .iter()
-                            .all(|fop| op.nested_selections().contains(fop))
-                }),
+                Some((first, rest)) if first.is_find_unique() => {
+                    let all_operations_identical = rest.iter().all(|op| {
+                        op.is_find_unique()
+                            && first.name() == op.name()
+                            && first.nested_selections().len() == op.nested_selections().len()
+                            && first
+                                .nested_selections()
+                                .iter()
+                                .all(|fop| op.nested_selections().contains(fop))
+                    });
+
+                    let where_obj = first.as_read().unwrap().arguments()[0].1.clone().into_object().unwrap();
+                    let field = schema.find_query_field(first.name()).unwrap();
+                    let model = field.model().unwrap();
+
+                    // Skip the compact optimization if the operation contains:
+                    // - non scalar filters (ie: relation filters, boolean operators...)
+                    // - any scalar filters that is not EQUAL
+                    let contains_non_scalar = where_obj.iter().any(|(key, val)| match val {
+                        // If it's a compound, then it's still considered as scalar
+                        QueryValue::Object(_) if resolve_compound_field(key, model).is_some() => false,
+                        // Otherwise, we just look for a scalar field inside the model. If it's not one, then we break.
+                        val => match model.fields().find_from_scalar(&key) {
+                            Ok(_) => match val {
+                                // Consider scalar _only_ if the filter object contains "equals". eg: `{ scalar_field: { equals: 1 } }`
+                                QueryValue::Object(obj) => !obj.contains_key(filters::EQUALS),
+                                _ => false,
+                            },
+                            Err(_) => true,
+                        },
+                    });
+
+                    all_operations_identical && !contains_non_scalar
+                }
                 _ => false,
             },
             Self::Compact(_) => false,
         }
     }
 
-    pub fn compact(self) -> Self {
+    pub fn compact(self, schema: &QuerySchemaRef) -> Self {
         match self {
-            Self::Multi(operations, _) if self.can_compact() => Self::Compact(CompactedDocument::from(operations)),
+            Self::Multi(operations, _) if self.can_compact(schema) => {
+                Self::Compact(CompactedDocument::from_operations(operations, schema))
+            }
             _ => self,
         }
+    }
+
+    /// Returns `true` if the batch document is [`Compact`].
+    #[must_use]
+    pub fn is_compact(&self) -> bool {
+        matches!(self, Self::Compact(..))
     }
 }
 
@@ -118,11 +155,11 @@ impl CompactedDocument {
     pub fn plural_name(&self) -> String {
         format!("findMany{}", self.name)
     }
-}
 
-/// Here be the dragons. Ay caramba!
-impl From<Vec<Operation>> for CompactedDocument {
-    fn from(ops: Vec<Operation>) -> Self {
+    /// Here be the dragons. Ay caramba!
+    pub fn from_operations(ops: Vec<Operation>, schema: &QuerySchemaRef) -> Self {
+        let field = schema.find_query_field(ops.first().unwrap().name()).unwrap();
+        let model = field.model().unwrap();
         // Unpack all read queries (an enum) into a collection of selections.
         // We already took care earlier that all operations here must be reads.
         let selections: Vec<Selection> = ops
@@ -144,24 +181,20 @@ impl From<Vec<Operation>> for CompactedDocument {
 
             // The query arguments are extracted here. Combine all query
             // arguments from the different queries into a one large argument.
-            let selection_set = selections.iter().fold(SelectionSet::new(), |acc, selection| {
+            let selection_set = selections.iter().fold(SelectionSet::new(), |mut acc, selection| {
                 // findUnique always has only one argument. We know it must be an object, otherwise this will panic.
-                let obj = selection.arguments()[0]
+                let where_obj = selection.arguments()[0]
                     .1
                     .clone()
                     .into_object()
                     .expect("Trying to compact a selection with non-object argument");
+                let filters = extract_filter(where_obj, model);
 
-                // A "funny" trick to detect a compound key.
-                match obj.values().next() {
-                    // This means our query has a nested object, meaning we have
-                    // a compound filter in a form of {"col1_col2": {"col1": .., "col2": ..}}
-                    Some(QueryValue::Object(obj)) => obj
-                        .iter()
-                        .fold(acc, |acc, (key, val)| acc.push(key.clone(), val.clone())),
-                    // ...or a singular argument in a form of {"col1": ..}
-                    _ => obj.into_iter().fold(acc, |acc, (key, val)| acc.push(key, val)),
+                for (field, filter) in filters {
+                    acc = acc.push(field, filter);
                 }
+
+                acc
             });
 
             // We must select all unique fields in the query so we can
@@ -198,33 +231,20 @@ impl From<Vec<Operation>> for CompactedDocument {
         let arguments: Vec<Vec<(String, QueryValue)>> = selections
             .into_iter()
             .map(|mut sel| {
-                let mut obj: Vec<(String, QueryValue)> = sel
-                    .pop_argument()
-                    .unwrap()
-                    .1
-                    .into_object()
-                    .unwrap()
-                    .into_iter()
-                    .collect();
+                let where_obj = sel.pop_argument().unwrap().1.into_object().unwrap();
 
-                // The trick again to detect if we have a compound key or not. (sigh)
-                match obj.pop() {
-                    Some((_, QueryValue::Object(obj))) => obj.into_iter().collect(),
-                    Some(pair) => {
-                        obj.push(pair);
-                        obj
-                    }
-                    None => unreachable!("No arguments!"),
-                }
+                extract_filter(where_obj, model)
             })
             .collect();
 
-        // The trick again to detect if we have a compound key or not. (sigh)
         // Gets the argument keys for later mapping.
-        let keys = match arguments[0].get(0) {
-            Some((_, QueryValue::Object(obj))) => obj.iter().map(|(k, _)| k.to_string()).collect(),
-            _ => arguments[0].iter().map(|(k, _)| k.to_string()).collect(),
-        };
+        let keys: Vec<_> = arguments[0]
+            .iter()
+            .flat_map(|pair| match pair {
+                (_, QueryValue::Object(obj)) => obj.keys().map(ToOwned::to_owned).collect(),
+                (key, _) => vec![key.to_owned()],
+            })
+            .collect();
 
         Self {
             name,
@@ -234,4 +254,34 @@ impl From<Vec<Operation>> for CompactedDocument {
             operation: Operation::Read(selection),
         }
     }
+}
+
+/// Takes in a unique filter, extract the scalar filters and return a simple list of field/filter.
+/// This list is used to build a findMany query from multiple findUnique queries.
+/// Therefore, compound unique filters walked and each individual field is added. eg:
+/// { field1_field2: { field1: 1, field2: 2 } } -> [(field1, 1), (field2, 2)]
+/// This is because findMany filters don't have the special compound unique syntax.
+///
+/// Furthermore, this list is used to match the results of the findMany query back to the original findUnique queries.
+/// Because of that, we only extract EQUALS filters or else we would have to manually implement other filters.
+/// This is a limitation that _could_ technically be lifted but that's not worth it for now.
+fn extract_filter(where_obj: IndexMap<String, QueryValue>, model: &ModelRef) -> Vec<(String, QueryValue)> {
+    where_obj
+        .into_iter()
+        .flat_map(|(key, val)| match val {
+            // This means our query has a compound field in the form of: {co1_col2: { col1_col2: { col1: <val>, col2: <val> } }}
+            QueryValue::Object(obj) if resolve_compound_field(&key, model).is_some() => obj.into_iter().collect(),
+            // This means our query has a scalar filter in the form of {col1: { equals: <val> }}
+            QueryValue::Object(obj) => {
+                // This is safe because it's been validated before in the `.can_compact` method.
+                let equal_val = obj.get(filters::EQUALS).expect("we only support scalar equals filters");
+
+                vec![(key, equal_val.clone())]
+            }
+            // ...or a singular argument in a form of {col1: <val>}
+            x => {
+                vec![(key, x)]
+            }
+        })
+        .collect()
 }

--- a/query-engine/core/src/query_document/operation.rs
+++ b/query-engine/core/src/query_document/operation.rs
@@ -27,6 +27,14 @@ impl Operation {
             _ => None,
         }
     }
+
+    pub fn as_read(&self) -> Option<&Selection> {
+        if let Self::Read(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
 }
 
 impl Operation {

--- a/query-engine/core/src/response_ir/mod.rs
+++ b/query-engine/core/src/response_ir/mod.rs
@@ -133,6 +133,19 @@ impl Item {
         match self {
             Self::Value(pv) => Some(pv),
             Self::Ref(r) => Arc::try_unwrap(r).ok().and_then(|r| r.into_value()),
+            Self::List(list) => {
+                let mut values = vec![];
+
+                for item in list {
+                    if let Some(pv) = item.into_value() {
+                        values.push(pv)
+                    } else {
+                        return None;
+                    }
+                }
+
+                Some(PrismaValue::List(values))
+            }
             _ => None,
         }
     }

--- a/query-engine/query-engine/src/server/mod.rs
+++ b/query-engine/query-engine/src/server/mod.rs
@@ -3,6 +3,7 @@ use hyper::service::{make_service_fn, service_fn};
 use hyper::{header::CONTENT_TYPE, Body, HeaderMap, Method, Request, Response, Server, StatusCode};
 use opentelemetry::{global, propagation::Extractor, Context};
 use psl::PreviewFeature;
+use query_core::schema::QuerySchemaRef;
 use query_core::{schema::QuerySchemaRenderer, TxId};
 use query_engine_metrics::{MetricFormat, MetricRegistry};
 use request_handlers::{dmmf, GraphQLSchemaRenderer, GraphQlHandler, TxInput};
@@ -45,6 +46,10 @@ impl State {
 
     pub fn get_metrics(&self) -> MetricRegistry {
         self.cx.metrics.clone()
+    }
+
+    pub fn query_schema(&self) -> &QuerySchemaRef {
+        self.cx.query_schema()
     }
 }
 

--- a/query-engine/request-handlers/src/graphql/body.rs
+++ b/query-engine/request-handlers/src/graphql/body.rs
@@ -54,7 +54,7 @@ impl From<&str> for SingleQuery {
 
 impl GraphQlBody {
     /// Convert a `GraphQlBody` into a `QueryDocument`.
-    pub(crate) fn into_doc(self) -> crate::Result<QueryDocument> {
+    pub fn into_doc(self) -> crate::Result<QueryDocument> {
         match self {
             GraphQlBody::Single(body) => {
                 let operation = GraphQLProtocolAdapter::convert_query_to_operation(&body.query, body.operation_name)?;

--- a/query-engine/request-handlers/src/graphql/handler.rs
+++ b/query-engine/request-handlers/src/graphql/handler.rs
@@ -25,11 +25,11 @@ impl<'a> GraphQlHandler<'a> {
     }
 
     pub async fn handle(&self, body: GraphQlBody, tx_id: Option<TxId>, trace_id: Option<String>) -> PrismaResponse {
-        tracing::debug!("Incoming GraphQL query: {:?}", body);
+        tracing::debug!("Incoming GraphQL query: {:?}", &body);
 
         match body.into_doc() {
             Ok(QueryDocument::Single(query)) => self.handle_single(query, tx_id, trace_id).await,
-            Ok(QueryDocument::Multi(batch)) => match batch.compact() {
+            Ok(QueryDocument::Multi(batch)) => match batch.compact(self.query_schema) {
                 BatchDocument::Multi(batch, transaction) => {
                     self.handle_batch(batch, transaction, tx_id, trace_id).await
                 }

--- a/query-engine/schema/src/output_types.rs
+++ b/query-engine/schema/src/output_types.rs
@@ -187,4 +187,8 @@ impl OutputField {
 
         self
     }
+
+    pub fn model(&self) -> Option<&ModelRef> {
+        self.query_info.as_ref().and_then(|info| info.model.as_ref())
+    }
 }


### PR DESCRIPTION
## Overview

fixes https://github.com/prisma/prisma/issues/15934

With the extension of where unique inputs, which now allow non-unique filters, the batching logic was broken. Here are the new rules:

A batched query is compacted, only if:
- the findUnique queries only deal with EQUALS scalar filters
	- Both syntaxes are supported: `{ field: <val> }` or `{ field: { equals: <val> } }`
	- That includes compound filters as well: `{ field1_field2: { field1: <val>, field2: <val> } }`

If the condition above is not fulfilled, then we fall back to a simple batch, which executes all findUnique queries separately.

Concretely, this means:
- All “previous” queries (as-in, queries that don’t use the extended where unique) will still be supported
- Queries using extended where which only use equal scalar filters (of the same model) will now be supported as well (eg: the issue above which simply adds` { deletedAt: null }`
- As soon as a boolean operator, a relation filter or any scalar filter that's not using equal is present in the where arg, queries will be processed individually instead of being compacted.