### PR TITLE
feat: support where on nested optional 1-1 read

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/one_relation.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/one_relation.rs
@@ -162,6 +162,60 @@ mod one_relation {
         Ok(())
     }
 
+    // nested to-one-relation read filters.
+    #[connector_test]
+    async fn nested_to_one_filter(runner: Runner) -> TestResult<()> {
+        test_data(&runner).await?;
+
+        insta::assert_snapshot!(
+            run_query!(&runner, r#"query { findManyBlog { name, post(where: { title: "post1" }) { title } }}"#),
+            @r###"{"data":{"findManyBlog":[{"name":"blog 1","post":null},{"name":"blog 2","post":null},{"name":"blog 3","post":null}]}}"###
+        );
+
+        insta::assert_snapshot!(
+            run_query!(&runner, r#"query { findManyBlog { name, post(where: { title: "post 1", comment: { is: { text: "comment 1" } } }) { title, comment { text } } }}"#),
+            @r###"{"data":{"findManyBlog":[{"name":"blog 1","post":{"title":"post 1","comment":{"text":"comment 1"}}},{"name":"blog 2","post":null},{"name":"blog 3","post":null}]}}"###
+        );
+
+        Ok(())
+    }
+
+    fn to_one_req() -> String {
+        let schema = indoc! {
+            r#"
+            model Blog {
+                #id(id, String, @id, @default(cuid()))
+                name   String
+                post   Post   @relation(fields: [postId], references: [id])
+                postId String @unique
+              }
+              
+              model Post {
+                #id(id, String, @id, @default(cuid()))
+                title      String
+                popularity Int
+                blog       Blog?
+              }
+              
+            "#
+        };
+
+        schema.to_owned()
+    }
+
+    // nested to-one-relation read filters.
+    #[connector_test(schema(to_one_req))]
+    async fn nested_req_to_one_filter_should_fail(runner: Runner) -> TestResult<()> {
+        assert_error!(
+            runner,
+            r#"query { findManyBlog { post(where: { title: "title 1" }) { title } } }"#,
+            2009,
+            "Failed to validate the query: `Argument does not exist on enclosing type."
+        );
+
+        Ok(())
+    }
+
     // Note: Only the original author knows why this is considered crazy.
     #[connector_test]
     async fn crazy_filters(runner: Runner) -> TestResult<()> {

--- a/query-engine/schema-builder/src/input_types/fields/arguments.rs
+++ b/query-engine/schema-builder/src/input_types/fields/arguments.rs
@@ -76,9 +76,16 @@ pub(crate) fn many_records_output_field_arguments(ctx: &mut BuilderContext, fiel
         ModelField::Scalar(_) => vec![],
 
         // To-many relation.
-        ModelField::Relation(rf) if rf.is_list() => relation_selection_arguments(ctx, &rf.related_model(), true),
+        ModelField::Relation(rf) if rf.is_list() => {
+            relation_to_many_selection_arguments(ctx, &rf.related_model(), true)
+        }
 
-        // To-one relation.
+        // To-one optional relation.
+        ModelField::Relation(rf) if !rf.is_required() && ctx.has_feature(&PreviewFeature::ExtendedWhereUnique) => {
+            relation_to_one_selection_arguments(ctx, &rf.related_model())
+        }
+
+        // To-one required relation.
         ModelField::Relation(_) => vec![],
 
         // To-many composite.
@@ -90,7 +97,7 @@ pub(crate) fn many_records_output_field_arguments(ctx: &mut BuilderContext, fiel
 }
 
 /// Builds "many records where" arguments for to-many relation selection sets.
-pub(crate) fn relation_selection_arguments(
+pub(crate) fn relation_to_many_selection_arguments(
     ctx: &mut BuilderContext,
     model: &ModelRef,
     include_distinct: bool,
@@ -122,6 +129,11 @@ pub(crate) fn relation_selection_arguments(
     }
 
     args
+}
+
+/// Builds "many records where" arguments for to-many relation selection sets.
+pub(crate) fn relation_to_one_selection_arguments(ctx: &mut BuilderContext, model: &ModelRef) -> Vec<InputField> {
+    vec![where_argument(ctx, model)]
 }
 
 /// Builds "many composite where" arguments for to-many composite selection sets.

--- a/query-engine/schema-builder/src/input_types/fields/arguments.rs
+++ b/query-engine/schema-builder/src/input_types/fields/arguments.rs
@@ -81,7 +81,7 @@ pub(crate) fn many_records_output_field_arguments(ctx: &mut BuilderContext, fiel
         }
 
         // To-one optional relation.
-        ModelField::Relation(rf) if !rf.is_required() && ctx.has_feature(&PreviewFeature::ExtendedWhereUnique) => {
+        ModelField::Relation(rf) if !rf.is_required() && ctx.has_feature(PreviewFeature::ExtendedWhereUnique) => {
             relation_to_one_selection_arguments(ctx, &rf.related_model())
         }
 

--- a/query-engine/schema-builder/src/output_types/query_type.rs
+++ b/query-engine/schema-builder/src/output_types/query_type.rs
@@ -91,7 +91,7 @@ fn find_first_field(ctx: &mut BuilderContext, model: &ModelRef) -> OutputField {
 /// Builds a find first item field for given model that throws a NotFoundError in case the item does
 /// not exist
 fn find_first_or_throw_field(ctx: &mut BuilderContext, model: &ModelRef) -> OutputField {
-    let args = arguments::relation_selection_arguments(ctx, model, true);
+    let args = arguments::relation_to_many_selection_arguments(ctx, model, true);
     let field_name = format!("findFirst{}OrThrow", model.name);
 
     field(

--- a/query-engine/schema-builder/src/output_types/query_type.rs
+++ b/query-engine/schema-builder/src/output_types/query_type.rs
@@ -73,7 +73,7 @@ fn find_unique_or_throw_field(ctx: &mut BuilderContext, model: &ModelRef) -> Opt
 
 /// Builds a find first item field for given model.
 fn find_first_field(ctx: &mut BuilderContext, model: &ModelRef) -> OutputField {
-    let args = arguments::relation_selection_arguments(ctx, model, true);
+    let args = arguments::relation_to_many_selection_arguments(ctx, model, true);
     let field_name = format!("findFirst{}", model.name);
 
     field(
@@ -108,7 +108,7 @@ fn find_first_or_throw_field(ctx: &mut BuilderContext, model: &ModelRef) -> Outp
 
 /// Builds a "multiple" query arity items field (e.g. "users", "posts", ...) for given model.
 fn all_items_field(ctx: &mut BuilderContext, model: &ModelRef) -> OutputField {
-    let args = arguments::relation_selection_arguments(ctx, model, true);
+    let args = arguments::relation_to_many_selection_arguments(ctx, model, true);
     let field_name = format!("findMany{}", model.name);
     let object_type = objects::model::map_type(ctx, model);
 
@@ -127,7 +127,7 @@ fn all_items_field(ctx: &mut BuilderContext, model: &ModelRef) -> OutputField {
 fn plain_aggregation_field(ctx: &mut BuilderContext, model: &ModelRef) -> OutputField {
     field(
         format!("aggregate{}", model.name),
-        arguments::relation_selection_arguments(ctx, model, false),
+        arguments::relation_to_many_selection_arguments(ctx, model, false),
         OutputType::object(aggregation::plain::aggregation_object_type(ctx, model)),
         Some(QueryInfo {
             model: Some(Arc::clone(model)),


### PR DESCRIPTION
## Overview

Adds a `where` argument to nested optional 1-1 relations.

Feature flagged behind `extendedWhereUnique`.

This is an oversight of the original work.

Known use-cases are:
- Permission checks
- Soft-deletes

## Example (not a very relevant example)

**Datamodel**

```prisma
model User {
  id Int @id
  name String
  addressId Int
  address Address? @relation(fields: [addressId], references: [id])
}

model Address {
  id Int @id
  street String
  user User?
}
```

**Query**
```ts
await prisma.User.findUnique({
  include: { address: { where: { street: "toto" } } }
})
```