### PR TITLE
refactor(introspection): introspect enums in the right order

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,12 @@
 [workspace]
 resolver = "2"
 members = [
-  "introspection-engine/connectors/introspection-connector",
-  "introspection-engine/connectors/sql-introspection-connector",
-  "introspection-engine/connectors/mongodb-introspection-connector",
+  "introspection-engine/connectors/*",
   "introspection-engine/core",
   "introspection-engine/datamodel-renderer",
   "introspection-engine/introspection-engine-tests",
   "migration-engine/cli",
-  "migration-engine/connectors/migration-connector",
-  "migration-engine/connectors/sql-migration-connector",
-  "migration-engine/connectors/mongodb-migration-connector",
+  "migration-engine/connectors/*",
   "migration-engine/core",
   "migration-engine/json-rpc-api-build",
   "migration-engine/migration-engine-tests",

--- a/introspection-engine/connectors/introspection-connector/src/lib.rs
+++ b/introspection-engine/connectors/introspection-connector/src/lib.rs
@@ -110,6 +110,10 @@ impl IntrospectionContext {
         }
     }
 
+    pub fn previous_schema(&self) -> &psl::ValidatedSchema {
+        &self.previous_schema
+    }
+
     pub fn datasource(&self) -> &Datasource {
         self.previous_schema.configuration.datasources.first().unwrap()
     }

--- a/introspection-engine/connectors/sql-introspection-connector/src/calculate_datamodel.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/calculate_datamodel.rs
@@ -11,9 +11,14 @@ pub(crate) struct CalculateDatamodelContext<'a> {
     pub previous_datamodel: &'a Datamodel,
     pub schema: &'a SqlSchema,
     pub sql_family: SqlFamily,
+    previous_schema: &'a psl::ValidatedSchema,
 }
 
-impl CalculateDatamodelContext<'_> {
+impl<'a> CalculateDatamodelContext<'a> {
+    pub(crate) fn previous_schema(&self) -> &'a psl::ValidatedSchema {
+        self.previous_schema
+    }
+
     pub(crate) fn is_cockroach(&self) -> bool {
         self.active_connector().provider_name() == COCKROACH.provider_name()
     }
@@ -46,6 +51,7 @@ pub fn calculate_datamodel(
         previous_datamodel,
         schema,
         sql_family: ctx.sql_family(),
+        previous_schema: ctx.previous_schema(),
     };
 
     let mut warnings = Vec::new();

--- a/introspection-engine/connectors/sql-introspection-connector/src/introspection_helpers.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/introspection_helpers.rs
@@ -11,8 +11,19 @@ use sql_schema_describer::{
     self as sql, mssql::MssqlSchemaExt, postgres::PostgresSchemaExt, ColumnArity, ColumnTypeFamily, ForeignKeyAction,
     IndexType, SQLSortOrder, SqlSchema,
 };
-use std::collections::HashSet;
+use std::{cmp, collections::HashSet};
 use tracing::debug;
+
+/// This function implements the reverse behaviour of the `Ord` implementation for `Option`: it
+/// puts `None` values last, and otherwise orders `Some`s by their contents, like the `Ord` impl.
+pub(crate) fn compare_options_none_last<T: cmp::Ord>(a: Option<T>, b: Option<T>) -> cmp::Ordering {
+    match (a, b) {
+        (Some(a), Some(b)) => a.cmp(&b),
+        (Some(_), None) => cmp::Ordering::Less,
+        (None, Some(_)) => cmp::Ordering::Greater,
+        (None, None) => cmp::Ordering::Equal,
+    }
+}
 
 pub(crate) fn is_old_migration_table(table: TableWalker<'_>) -> bool {
     table.name() == "_Migration"

--- a/introspection-engine/connectors/sql-introspection-connector/src/re_introspection.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/re_introspection.rs
@@ -1,15 +1,14 @@
 use crate::{
     calculate_datamodel::CalculateDatamodelContext,
-    introspection_helpers::{replace_index_field_names, replace_pk_field_names, replace_relation_info_field_names},
+    introspection_helpers::{
+        compare_options_none_last, replace_index_field_names, replace_pk_field_names, replace_relation_info_field_names,
+    },
     warnings::*,
     SqlFamilyTrait,
 };
 use introspection_connector::Warning;
 use psl::dml::{self, Datamodel, DefaultValue, Field, FieldType, Ignorable, PrismaValue, ValueGenerator, WithName};
-use std::{
-    cmp::Ordering::{self, Equal, Greater, Less},
-    collections::{BTreeSet, HashMap},
-};
+use std::collections::{BTreeSet, HashMap};
 
 pub(crate) fn enrich(
     old_data_model: &Datamodel,
@@ -43,15 +42,7 @@ pub(crate) fn enrich(
         let model_a_idx = old_data_model.models().position(|model| model.name == model_a.name);
         let model_b_idx = old_data_model.models().position(|model| model.name == model_b.name);
 
-        re_order_putting_new_ones_last(model_a_idx, model_b_idx)
-    });
-
-    // restore old enum order
-    new_data_model.enums.sort_by(|enum_a, enum_b| {
-        let enum_a_idx = old_data_model.enums().position(|enm| enm.name == enum_a.name);
-        let enum_b_idx = old_data_model.enums().position(|enm| enm.name == enum_b.name);
-
-        re_order_putting_new_ones_last(enum_a_idx, enum_b_idx)
+        compare_options_none_last(model_a_idx, model_b_idx)
     });
 }
 
@@ -133,17 +124,8 @@ fn keep_index_ordering(old_data_model: &Datamodel, new_data_model: &mut Datamode
             let idx_a_idx = old_model.indices.iter().position(|idx| idx.db_name == idx_a.db_name);
             let idx_b_idx = old_model.indices.iter().position(|idx| idx.db_name == idx_b.db_name);
 
-            re_order_putting_new_ones_last(idx_a_idx, idx_b_idx)
+            compare_options_none_last(idx_a_idx, idx_b_idx)
         });
-    }
-}
-
-fn re_order_putting_new_ones_last(enum_a_idx: Option<usize>, enum_b_idx: Option<usize>) -> Ordering {
-    match (enum_a_idx, enum_b_idx) {
-        (None, None) => Equal,
-        (None, Some(_)) => Greater,
-        (Some(_), None) => Less,
-        (Some(a_idx), Some(b_idx)) => a_idx.cmp(&b_idx),
     }
 }
 

--- a/introspection-engine/introspection-engine-tests/tests/re_introspection/mod.rs
+++ b/introspection-engine/introspection-engine-tests/tests/re_introspection/mod.rs
@@ -934,26 +934,16 @@ async fn custom_model_order(api: &TestApi) -> TestResult {
 
 #[test_connector(tags(Postgres))]
 async fn custom_enum_order(api: &TestApi) -> TestResult {
-    let sql = "CREATE Type a as ENUM ( \'id\')".to_string();
-    api.database().execute_raw(&sql, &[]).await?;
-
-    let sql = "CREATE Type b as ENUM ( \'id\')".to_string();
-    api.database().execute_raw(&sql, &[]).await?;
-
-    let sql = "CREATE Type j as ENUM ( \'id\')".to_string();
-    api.database().execute_raw(&sql, &[]).await?;
-
-    let sql = "CREATE Type f as ENUM ( \'id\')".to_string();
-    api.database().execute_raw(&sql, &[]).await?;
-
-    let sql = "CREATE Type z as ENUM ( \'id\')".to_string();
-    api.database().execute_raw(&sql, &[]).await?;
-
-    let sql = "CREATE Type m as ENUM ( \'id\')".to_string();
-    api.database().execute_raw(&sql, &[]).await?;
-
-    let sql = "CREATE Type l as ENUM ( \'id\')".to_string();
-    api.database().execute_raw(&sql, &[]).await?;
+    let sql = r#"
+        CREATE TYPE a AS ENUM ('id');
+        CREATE TYPE b AS ENUM ('id');
+        CREATE TYPE j AS ENUM ('id');
+        CREATE TYPE f AS ENUM ('id');
+        CREATE TYPE z AS ENUM ('id');
+        CREATE TYPE m AS ENUM ('id');
+        CREATE TYPE l AS ENUM ('id');
+    "#;
+    api.raw_cmd(sql).await;
 
     let input_dm = indoc! {r#"
         enum b {

--- a/libs/dml/src/datamodel.rs
+++ b/libs/dml/src/datamodel.rs
@@ -27,11 +27,6 @@ impl Datamodel {
         self.enums.is_empty() && self.models.is_empty()
     }
 
-    /// Adds an enum to this datamodel.
-    pub fn add_enum(&mut self, en: Enum) {
-        self.enums.push(en);
-    }
-
     /// Adds a model to this datamodel.
     pub fn add_model(&mut self, model: Model) {
         self.models.push(model);

--- a/libs/dml/src/lift.rs
+++ b/libs/dml/src/lift.rs
@@ -65,7 +65,7 @@ impl<'a> LiftAstToDml<'a> {
         }
 
         for r#enum in self.db.walk_enums() {
-            schema.add_enum(self.lift_enum(r#enum))
+            schema.enums.push(self.lift_enum(r#enum))
         }
 
         self.lift_relations(&mut schema, &mut field_ids_for_sorting);

--- a/libs/sql-schema-describer/src/lib.rs
+++ b/libs/sql-schema-describer/src/lib.rs
@@ -253,13 +253,6 @@ impl SqlSchema {
         Some(self.walk(NamespaceId(namespace_idx as u32)))
     }
 
-    pub fn namespace_walkers(&self) -> impl Iterator<Item = NamespaceWalker<'_>> {
-        (0..self.namespaces.len()).map(move |namespace_index| NamespaceWalker {
-            schema: self,
-            id: NamespaceId(namespace_index as u32),
-        })
-    }
-
     pub fn tables_count(&self) -> usize {
         self.tables.len()
     }
@@ -295,10 +288,7 @@ impl SqlSchema {
     }
 
     pub fn enum_walkers(&self) -> impl Iterator<Item = EnumWalker<'_>> {
-        (0..self.enums.len()).map(move |enum_index| EnumWalker {
-            schema: self,
-            id: EnumId(enum_index as u32),
-        })
+        (0..self.enums.len()).map(move |enum_index| self.walk(EnumId(enum_index as u32)))
     }
 
     pub fn walk_foreign_keys(&self) -> impl Iterator<Item = ForeignKeyWalker<'_>> {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/differ_database.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/differ_database.rs
@@ -59,7 +59,7 @@ impl<'a> DifferDatabase<'a> {
         };
 
         // First insert all namespaces from the previous schema.
-        for namespace in schemas.previous.describer_schema.namespace_walkers() {
+        for namespace in schemas.previous.describer_schema.walk_namespaces() {
             let namespace_name = if flavour.lower_cases_table_names() {
                 namespace.name().to_ascii_lowercase().into()
             } else {
@@ -70,7 +70,7 @@ impl<'a> DifferDatabase<'a> {
         }
 
         // Then insert all namespaces from the next schema.
-        for namespace in schemas.next.describer_schema.namespace_walkers() {
+        for namespace in schemas.next.describer_schema.walk_namespaces() {
             let namespace_name = if flavour.lower_cases_table_names() {
                 namespace.name().to_ascii_lowercase().into()
             } else {


### PR DESCRIPTION
Instead of reordering the enums after introspection in the re-introspection phase, this commit gives the introspected enums the right order from the start.

This is important because the enum index in the schema becomes a stable identifier.

This is a test run before we do this for models, which we will want for multi-schema introspection.