### PR TITLE
sql-introspection-connector: introspect models in the right order

### DIFF
--- a/introspection-engine/connectors/mongodb-introspection-connector/src/sampler/statistics.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/src/sampler/statistics.rs
@@ -75,7 +75,7 @@ impl<'a> Statistics<'a> {
         add_missing_ids_to_models(&mut models);
 
         for (_, model) in models.into_iter() {
-            data_model.add_model(model);
+            data_model.models.push(model);
         }
 
         for (_, mut composite_type) in types.into_iter() {

--- a/introspection-engine/connectors/sql-introspection-connector/src/introspection.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/introspection.rs
@@ -24,100 +24,7 @@ pub(crate) fn introspect(ctx: &Context, warnings: &mut Vec<Warning>) -> Result<(
     let schema = ctx.schema;
 
     introspect_enums(&mut datamodel, ctx);
-
-    // collect m2m table names
-    let m2m_tables: Vec<String> = schema
-        .table_walkers()
-        .filter(|table| is_prisma_1_point_1_or_2_join_table(*table) || is_prisma_1_point_0_join_table(*table))
-        .map(|table| table.name()[1..].to_string())
-        .collect();
-
-    for table in schema
-        .table_walkers()
-        .filter(|table| !is_old_migration_table(*table))
-        .filter(|table| !is_new_migration_table(*table))
-        .filter(|table| !is_prisma_1_point_1_or_2_join_table(*table))
-        .filter(|table| !is_prisma_1_point_0_join_table(*table))
-        .filter(|table| !is_relay_table(*table))
-    {
-        debug!("Calculating model: {}", table.name());
-        let mut model = Model::new(table.name().to_owned(), None);
-
-        for column in table.columns() {
-            let field = calculate_scalar_field(column, ctx);
-            model.add_field(Field::ScalarField(field));
-        }
-
-        let duplicated_foreign_keys: HashSet<ForeignKeyId> = table
-            .foreign_keys()
-            .enumerate()
-            .filter(|(idx, left)| {
-                let mut already_visited = table.foreign_keys().take(*idx);
-                already_visited.any(|right| {
-                    let (left_constrained, right_constrained) =
-                        (left.constrained_columns(), right.constrained_columns());
-                    left_constrained.len() == right_constrained.len()
-                        && left_constrained
-                            .zip(right_constrained)
-                            .all(|(left, right)| left.id == right.id)
-                        && left
-                            .referenced_columns()
-                            .zip(right.referenced_columns())
-                            .all(|(left, right)| left.id == right.id)
-                })
-            })
-            .map(|(_, fk)| fk.id)
-            .collect();
-
-        for foreign_key in table
-            .foreign_keys()
-            .filter(|fk| !duplicated_foreign_keys.contains(&fk.id))
-        {
-            let mut relation_field = calculate_relation_field(foreign_key, &m2m_tables, &duplicated_foreign_keys);
-
-            relation_field.supports_restrict_action(!ctx.sql_family().is_mssql());
-
-            model.add_field(Field::RelationField(relation_field));
-        }
-
-        for index in table.indexes() {
-            if let Some(index) = calculate_index(index, ctx) {
-                model.add_index(index);
-            }
-        }
-
-        if let Some(pk) = table.primary_key() {
-            let clustered = primary_key_is_clustered(pk.id, ctx);
-
-            model.primary_key = Some(PrimaryKeyDefinition {
-                name: None,
-                db_name: Some(pk.name().to_owned()),
-                fields: pk
-                    .columns()
-                    .map(|c| {
-                        let sort_order = c.sort_order().map(|sort| match sort {
-                            SQLSortOrder::Asc => SortOrder::Asc,
-                            SQLSortOrder::Desc => SortOrder::Desc,
-                        });
-
-                        PrimaryKeyField {
-                            name: c.name().to_string(),
-                            sort_order,
-                            length: c.length(),
-                        }
-                    })
-                    .collect(),
-                defined_on_field: pk.columns().len() == 1,
-                clustered,
-            });
-        }
-
-        if matches!(ctx.config.datasources.first(), Some(ds) if !ds.namespaces.is_empty()) {
-            model.schema = table.namespace().map(|n| n.to_string());
-        }
-
-        datamodel.add_model(model);
-    }
+    introspect_models(&mut datamodel, ctx);
 
     let mut fields_to_be_added = Vec::new();
 
@@ -261,4 +168,121 @@ fn sql_enum_to_dml_enum(sql_enum: sql::EnumWalker<'_>, ctx: &Context) -> dml::En
         None
     };
     dml::Enum::new(sql_enum.name(), values, schema)
+}
+
+fn introspect_models(datamodel: &mut Datamodel, ctx: &Context) {
+    // collect m2m table names
+    let m2m_tables: Vec<String> = ctx
+        .schema
+        .table_walkers()
+        .filter(|table| is_prisma_1_point_1_or_2_join_table(*table) || is_prisma_1_point_0_join_table(*table))
+        .map(|table| table.name()[1..].to_string())
+        .collect();
+
+    for table in ctx
+        .schema
+        .table_walkers()
+        .filter(|table| !is_old_migration_table(*table))
+        .filter(|table| !is_new_migration_table(*table))
+        .filter(|table| !is_prisma_1_point_1_or_2_join_table(*table))
+        .filter(|table| !is_prisma_1_point_0_join_table(*table))
+        .filter(|table| !is_relay_table(*table))
+    {
+        debug!("Calculating model: {}", table.name());
+        let mut model = Model::new(table.name().to_owned(), None);
+
+        for column in table.columns() {
+            let field = calculate_scalar_field(column, ctx);
+            model.add_field(Field::ScalarField(field));
+        }
+
+        let duplicated_foreign_keys: HashSet<ForeignKeyId> = table
+            .foreign_keys()
+            .enumerate()
+            .filter(|(idx, left)| {
+                let mut already_visited = table.foreign_keys().take(*idx);
+                already_visited.any(|right| {
+                    let (left_constrained, right_constrained) =
+                        (left.constrained_columns(), right.constrained_columns());
+                    left_constrained.len() == right_constrained.len()
+                        && left_constrained
+                            .zip(right_constrained)
+                            .all(|(left, right)| left.id == right.id)
+                        && left
+                            .referenced_columns()
+                            .zip(right.referenced_columns())
+                            .all(|(left, right)| left.id == right.id)
+                })
+            })
+            .map(|(_, fk)| fk.id)
+            .collect();
+
+        for foreign_key in table
+            .foreign_keys()
+            .filter(|fk| !duplicated_foreign_keys.contains(&fk.id))
+        {
+            let mut relation_field = calculate_relation_field(foreign_key, &m2m_tables, &duplicated_foreign_keys);
+
+            relation_field.supports_restrict_action(!ctx.sql_family().is_mssql());
+
+            model.add_field(Field::RelationField(relation_field));
+        }
+
+        for index in table.indexes() {
+            if let Some(index) = calculate_index(index, ctx) {
+                model.add_index(index);
+            }
+        }
+
+        if let Some(pk) = table.primary_key() {
+            let clustered = primary_key_is_clustered(pk.id, ctx);
+
+            model.primary_key = Some(PrimaryKeyDefinition {
+                name: None,
+                db_name: Some(pk.name().to_owned()),
+                fields: pk
+                    .columns()
+                    .map(|c| {
+                        let sort_order = c.sort_order().map(|sort| match sort {
+                            SQLSortOrder::Asc => SortOrder::Asc,
+                            SQLSortOrder::Desc => SortOrder::Desc,
+                        });
+
+                        PrimaryKeyField {
+                            name: c.name().to_string(),
+                            sort_order,
+                            length: c.length(),
+                        }
+                    })
+                    .collect(),
+                defined_on_field: pk.columns().len() == 1,
+                clustered,
+            });
+        }
+
+        if matches!(ctx.config.datasources.first(), Some(ds) if !ds.namespaces.is_empty()) {
+            model.schema = table.namespace().map(|n| n.to_string());
+        }
+
+        datamodel.models.push(model);
+    }
+
+    sort_models(datamodel, ctx)
+}
+
+fn sort_models(datamodel: &mut Datamodel, ctx: &Context) {
+    let existing_models_by_database_name: HashMap<&str, _> = ctx
+        .previous_schema()
+        .db
+        .walk_models()
+        .map(|model| (model.database_name(), model.id))
+        .collect();
+
+    datamodel.models.sort_by(|a, b| {
+        let existing = |model: &dml::Model| -> Option<_> {
+            existing_models_by_database_name.get(model.database_name.as_deref().unwrap_or(&model.name))
+        };
+
+        compare_options_none_last(existing(a), existing(b))
+    });
 }

--- a/introspection-engine/connectors/sql-introspection-connector/src/re_introspection.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/re_introspection.rs
@@ -36,14 +36,6 @@ pub(crate) fn enrich(
     merge_ignores(old_data_model, new_data_model, warnings);
     merge_comments(old_data_model, new_data_model);
     keep_index_ordering(old_data_model, new_data_model);
-
-    // restore old model order
-    new_data_model.models.sort_by(|model_a, model_b| {
-        let model_a_idx = old_data_model.models().position(|model| model.name == model_a.name);
-        let model_b_idx = old_data_model.models().position(|model| model.name == model_b.name);
-
-        compare_options_none_last(model_a_idx, model_b_idx)
-    });
 }
 
 /// If we have to map the enum values, this makes sure we handle them

--- a/libs/dml/src/datamodel.rs
+++ b/libs/dml/src/datamodel.rs
@@ -27,11 +27,6 @@ impl Datamodel {
         self.enums.is_empty() && self.models.is_empty()
     }
 
-    /// Adds a model to this datamodel.
-    pub fn add_model(&mut self, model: Model) {
-        self.models.push(model);
-    }
-
     /// Gets an iterator over all models.
     pub fn models(&self) -> std::slice::Iter<Model> {
         self.models.iter()

--- a/libs/dml/src/lift.rs
+++ b/libs/dml/src/lift.rs
@@ -57,7 +57,7 @@ impl<'a> LiftAstToDml<'a> {
         let mut field_ids_for_sorting: HashMap<(&str, &str), ast::FieldId> = HashMap::new();
 
         for model in self.db.walk_models() {
-            schema.add_model(self.lift_model(model, &mut field_ids_for_sorting));
+            schema.models.push(self.lift_model(model, &mut field_ids_for_sorting));
         }
 
         for composite_type in self.db.walk_composite_types() {


### PR DESCRIPTION
Follow up to https://github.com/prisma/prisma-engines/pull/3334 — same thing but for models. This is important because we can now treat the index of the model in DML as a stable identifier for reintrospection.