### PR TITLE
fix: re-introspection now preserves 'referentialIntegrity' policy

### DIFF
--- a/introspection-engine/datamodel-renderer/src/configuration/datasource.rs
+++ b/introspection-engine/datamodel-renderer/src/configuration/datasource.rs
@@ -11,6 +11,7 @@ pub struct Datasource<'a> {
     url: Env<'a>,
     shadow_database_url: Option<Env<'a>>,
     relation_mode: Option<RelationMode>,
+    referential_integrity: Option<RelationMode>,
     custom_properties: Vec<(&'a str, Value<'a>)>,
     documentation: Option<Documentation<'a>>,
     namespaces: Array<Text<&'a str>>,
@@ -35,6 +36,7 @@ impl<'a> Datasource<'a> {
             url: url.into(),
             shadow_database_url: None,
             relation_mode: None,
+            referential_integrity: None,
             custom_properties: Default::default(),
             documentation: None,
             namespaces: Array::new(),
@@ -114,6 +116,7 @@ impl<'a> Datasource<'a> {
             url: Env::from(&psl_ds.url),
             shadow_database_url,
             relation_mode: psl_ds.relation_mode,
+            referential_integrity: psl_ds.referential_integrity,
             documentation: psl_ds.documentation.as_deref().map(Documentation),
             custom_properties: Default::default(),
             namespaces: Array::from(namespaces),
@@ -137,6 +140,8 @@ impl<'a> fmt::Display for Datasource<'a> {
 
         if let Some(relation_mode) = self.relation_mode {
             writeln!(f, "relationMode = \"{}\"", relation_mode)?;
+        } else if let Some(referential_integrity) = self.referential_integrity {
+            writeln!(f, "referentialIntegrity = \"{}\"", referential_integrity)?;
         }
 
         for (key, value) in self.custom_properties.iter() {

--- a/introspection-engine/introspection-engine-tests/tests/re_introspection/mod.rs
+++ b/introspection-engine/introspection-engine-tests/tests/re_introspection/mod.rs
@@ -1,5 +1,6 @@
 mod mssql;
 mod mysql;
+mod relation_mode;
 mod sqlite;
 mod vitess;
 

--- a/introspection-engine/introspection-engine-tests/tests/re_introspection/relation_mode/mod.rs
+++ b/introspection-engine/introspection-engine-tests/tests/re_introspection/relation_mode/mod.rs
@@ -1,0 +1,4 @@
+mod mssql;
+mod mysql;
+mod postgres;
+mod sqlite;

--- a/introspection-engine/introspection-engine-tests/tests/re_introspection/relation_mode/mssql.rs
+++ b/introspection-engine/introspection-engine-tests/tests/re_introspection/relation_mode/mssql.rs
@@ -1,0 +1,361 @@
+use indoc::indoc;
+use introspection_engine_tests::test_api::*;
+
+// referentialIntegrity = "prisma" preserves the relation policy ("prisma") as well as @relations.
+#[test_connector(tags(Mssql))]
+async fn referential_integrity_prisma(api: &TestApi) -> TestResult {
+    let init = formatdoc! {r#"
+        CREATE TABLE [dbo].[Foo] (
+            [id] INT NOT NULL,
+            [bar_id] INT NOT NULL,
+            CONSTRAINT [Foo_pkey] PRIMARY KEY CLUSTERED ([id]),
+            CONSTRAINT [Foo_bar_id_key] UNIQUE NONCLUSTERED ([bar_id])
+        );
+        
+        CREATE TABLE [dbo].[Bar] (
+            [id] INT NOT NULL,
+            CONSTRAINT [Bar_pkey] PRIMARY KEY CLUSTERED ([id])
+        );
+    "#};
+
+    api.raw_cmd(&init).await;
+
+    let input = indoc! {r#"
+        generator client {
+            provider        = "prisma-client-js"
+            previewFeatures = ["referentialIntegrity"]
+        }
+
+        datasource db {
+            provider             = "sqlserver"
+            url                  = env("TEST_DATABASE_URL")
+            referentialIntegrity = "prisma"
+        }
+
+        model Foo {
+            id     Int @id
+            bar    Bar @relation(fields: [bar_id], references: [id])
+            bar_id Int @unique
+        }
+
+        model Bar {
+            id  Int  @id
+            foo Foo?
+        }
+    "#};
+
+    let expected = expect![[r#"
+        generator client {
+          provider        = "prisma-client-js"
+          previewFeatures = ["referentialIntegrity"]
+        }
+
+        datasource db {
+          provider             = "sqlserver"
+          url                  = env("TEST_DATABASE_URL")
+          referentialIntegrity = "prisma"
+        }
+
+        model Foo {
+          id     Int @id
+          bar    Bar @relation(fields: [bar_id], references: [id])
+          bar_id Int @unique
+        }
+
+        model Bar {
+          id  Int  @id
+          foo Foo?
+        }
+    "#]];
+
+    let result = api.re_introspect_config(input).await?;
+    expected.assert_eq(&result);
+
+    Ok(())
+}
+
+// referentialIntegrity = "prisma" preserves the relation policy ("foreignKeys") as well as @relations, which are moved to the bottom.
+#[test_connector(tags(Mssql))]
+async fn referential_integrity_foreign_keys(api: &TestApi) -> TestResult {
+    let init = formatdoc! {r#"
+        CREATE TABLE [dbo].[Foo] (
+            [id] INT NOT NULL,
+            [bar_id] INT NOT NULL,
+            CONSTRAINT [Foo_pkey] PRIMARY KEY CLUSTERED ([id]),
+            CONSTRAINT [Foo_bar_id_key] UNIQUE NONCLUSTERED ([bar_id])
+        );
+        
+        CREATE TABLE [dbo].[Bar] (
+            [id] INT NOT NULL,
+            CONSTRAINT [Bar_pkey] PRIMARY KEY CLUSTERED ([id])
+        );
+        
+        ALTER TABLE [dbo].[Foo] ADD CONSTRAINT [Foo_bar_id_fkey] FOREIGN KEY ([bar_id]) REFERENCES [dbo].[Bar]([id]) ON DELETE NO ACTION ON UPDATE CASCADE;
+    "#};
+
+    api.raw_cmd(&init).await;
+
+    let input = indoc! {r#"
+        generator client {
+            provider        = "prisma-client-js"
+            previewFeatures = ["referentialIntegrity"]
+        }
+
+        datasource db {
+            provider             = "sqlserver"
+            url                  = env("TEST_DATABASE_URL")
+            referentialIntegrity = "foreignKeys"
+        }
+
+        model Foo {
+            id     Int @id
+            bar    Bar @relation(fields: [bar_id], references: [id])
+            bar_id Int @unique
+        }
+
+        model Bar {
+            id  Int  @id
+            foo Foo?
+        }
+    "#};
+
+    let expected = expect![[r#"
+        generator client {
+          provider        = "prisma-client-js"
+          previewFeatures = ["referentialIntegrity"]
+        }
+
+        datasource db {
+          provider             = "sqlserver"
+          url                  = env("TEST_DATABASE_URL")
+          referentialIntegrity = "foreignKeys"
+        }
+
+        model Foo {
+          id     Int @id
+          bar_id Int @unique
+          bar    Bar @relation(fields: [bar_id], references: [id])
+        }
+
+        model Bar {
+          id  Int  @id
+          foo Foo?
+        }
+    "#]];
+
+    let result = api.re_introspect_config(input).await?;
+    expected.assert_eq(&result);
+
+    Ok(())
+}
+
+// relationMode = "prisma" preserves the relation policy ("prisma") as well as @relations.
+#[test_connector(tags(Mssql))]
+async fn relation_mode_prisma(api: &TestApi) -> TestResult {
+    let init = formatdoc! {r#"
+        CREATE TABLE [dbo].[Foo] (
+            [id] INT NOT NULL,
+            [bar_id] INT NOT NULL,
+            CONSTRAINT [Foo_pkey] PRIMARY KEY CLUSTERED ([id]),
+            CONSTRAINT [Foo_bar_id_key] UNIQUE NONCLUSTERED ([bar_id])
+        );
+        
+        CREATE TABLE [dbo].[Bar] (
+            [id] INT NOT NULL,
+            CONSTRAINT [Bar_pkey] PRIMARY KEY CLUSTERED ([id])
+        );
+    "#};
+
+    api.raw_cmd(&init).await;
+
+    let input = indoc! {r#"
+        generator client {
+            provider        = "prisma-client-js"
+            previewFeatures = ["referentialIntegrity"]
+        }
+
+        datasource db {
+            provider     = "sqlserver"
+            url          = env("TEST_DATABASE_URL")
+            relationMode = "prisma"
+        }
+
+        model Foo {
+            id     Int @id
+            bar    Bar @relation(fields: [bar_id], references: [id])
+            bar_id Int @unique
+        }
+
+        model Bar {
+            id  Int  @id
+            foo Foo?
+        }
+    "#};
+
+    let expected = expect![[r#"
+        generator client {
+          provider        = "prisma-client-js"
+          previewFeatures = ["referentialIntegrity"]
+        }
+
+        datasource db {
+          provider     = "sqlserver"
+          url          = env("TEST_DATABASE_URL")
+          relationMode = "prisma"
+        }
+
+        model Foo {
+          id     Int @id
+          bar    Bar @relation(fields: [bar_id], references: [id])
+          bar_id Int @unique
+        }
+
+        model Bar {
+          id  Int  @id
+          foo Foo?
+        }
+    "#]];
+
+    let result = api.re_introspect_config(input).await?;
+    expected.assert_eq(&result);
+
+    Ok(())
+}
+
+// relationMode = "foreignKeys" preserves the relation policy ("foreignKeys") as well as @relations, which are moved to the bottom.
+#[test_connector(tags(Mssql))]
+async fn relation_mode_foreign_keys(api: &TestApi) -> TestResult {
+    let init = formatdoc! {r#"
+        CREATE TABLE [dbo].[Foo] (
+            [id] INT NOT NULL,
+            [bar_id] INT NOT NULL,
+            CONSTRAINT [Foo_pkey] PRIMARY KEY CLUSTERED ([id]),
+            CONSTRAINT [Foo_bar_id_key] UNIQUE NONCLUSTERED ([bar_id])
+        );
+        
+        CREATE TABLE [dbo].[Bar] (
+            [id] INT NOT NULL,
+            CONSTRAINT [Bar_pkey] PRIMARY KEY CLUSTERED ([id])
+        );
+        
+        ALTER TABLE [dbo].[Foo] ADD CONSTRAINT [Foo_bar_id_fkey] FOREIGN KEY ([bar_id]) REFERENCES [dbo].[Bar]([id]) ON DELETE NO ACTION ON UPDATE CASCADE;
+    "#};
+
+    api.raw_cmd(&init).await;
+
+    let input = indoc! {r#"
+        generator client {
+            provider        = "prisma-client-js"
+            previewFeatures = ["referentialIntegrity"]
+        }
+
+        datasource db {
+            provider     = "sqlserver"
+            url          = env("TEST_DATABASE_URL")
+            relationMode = "foreignKeys"
+        }
+
+        model Foo {
+            id     Int @id
+            bar    Bar @relation(fields: [bar_id], references: [id])
+            bar_id Int @unique
+        }
+
+        model Bar {
+            id  Int  @id
+            foo Foo?
+        }
+    "#};
+
+    let expected = expect![[r#"
+        generator client {
+          provider        = "prisma-client-js"
+          previewFeatures = ["referentialIntegrity"]
+        }
+
+        datasource db {
+          provider     = "sqlserver"
+          url          = env("TEST_DATABASE_URL")
+          relationMode = "foreignKeys"
+        }
+
+        model Foo {
+          id     Int @id
+          bar_id Int @unique
+          bar    Bar @relation(fields: [bar_id], references: [id])
+        }
+
+        model Bar {
+          id  Int  @id
+          foo Foo?
+        }
+    "#]];
+
+    let result = api.re_introspect_config(input).await?;
+    expected.assert_eq(&result);
+
+    Ok(())
+}
+
+// @relations are moved to the bottom of the model even when no referentialIntegrity/relationMode is used.
+#[test_connector(tags(Mssql))]
+async fn no_relation_mode(api: &TestApi) -> TestResult {
+    let init = formatdoc! {r#"
+        CREATE TABLE [dbo].[Foo] (
+            [id] INT NOT NULL,
+            [bar_id] INT NOT NULL,
+            CONSTRAINT [Foo_pkey] PRIMARY KEY CLUSTERED ([id]),
+            CONSTRAINT [Foo_bar_id_key] UNIQUE NONCLUSTERED ([bar_id])
+        );
+        
+        CREATE TABLE [dbo].[Bar] (
+            [id] INT NOT NULL,
+            CONSTRAINT [Bar_pkey] PRIMARY KEY CLUSTERED ([id])
+        );
+        
+        ALTER TABLE [dbo].[Foo] ADD CONSTRAINT [Foo_bar_id_fkey] FOREIGN KEY ([bar_id]) REFERENCES [dbo].[Bar]([id]) ON DELETE NO ACTION ON UPDATE CASCADE;
+    "#};
+
+    api.raw_cmd(&init).await;
+
+    let input = indoc! {r#"
+        datasource db {
+            provider = "sqlserver"
+            url      = env("TEST_DATABASE_URL")
+        }
+
+        model Foo {
+            id     Int @id
+            bar    Bar @relation(fields: [bar_id], references: [id])
+            bar_id Int @unique
+        }
+
+        model Bar {
+            id  Int  @id
+            foo Foo?
+        }
+    "#};
+
+    let expected = expect![[r#"
+        datasource db {
+          provider = "sqlserver"
+          url      = env("TEST_DATABASE_URL")
+        }
+
+        model Foo {
+          id     Int @id
+          bar_id Int @unique
+          bar    Bar @relation(fields: [bar_id], references: [id])
+        }
+
+        model Bar {
+          id  Int  @id
+          foo Foo?
+        }
+    "#]];
+
+    let result = api.re_introspect_config(input).await?;
+    expected.assert_eq(&result);
+
+    Ok(())
+}

--- a/introspection-engine/introspection-engine-tests/tests/re_introspection/relation_mode/mysql.rs
+++ b/introspection-engine/introspection-engine-tests/tests/re_introspection/relation_mode/mysql.rs
@@ -1,0 +1,371 @@
+use indoc::indoc;
+use introspection_engine_tests::test_api::*;
+
+// referentialIntegrity = "prisma" preserves the relation policy ("prisma") as well as @relations.
+#[test_connector(tags(Mysql), exclude(Vitess))]
+async fn referential_integrity_prisma(api: &TestApi) -> TestResult {
+    let init = formatdoc! {r#"
+        CREATE TABLE `Foo` (
+            `id` INTEGER NOT NULL,
+            `bar_id` INTEGER NOT NULL,
+        
+            UNIQUE INDEX `Foo_bar_id_key`(`bar_id`),
+            PRIMARY KEY (`id`)
+        );
+
+        CREATE TABLE `Bar` (
+            `id` INTEGER NOT NULL,
+        
+            PRIMARY KEY (`id`)
+        );
+    "#};
+
+    api.raw_cmd(&init).await;
+
+    let input = indoc! {r#"
+        generator client {
+            provider        = "prisma-client-js"
+            previewFeatures = ["referentialIntegrity"]
+        }
+
+        datasource db {
+            provider             = "mysql"
+            url                  = env("TEST_DATABASE_URL")
+            referentialIntegrity = "prisma"
+        }
+
+        model Foo {
+            id     Int @id
+            bar    Bar @relation(fields: [bar_id], references: [id])
+            bar_id Int @unique
+        }
+
+        model Bar {
+            id  Int  @id
+            foo Foo?
+        }
+    "#};
+
+    let expected = expect![[r#"
+        generator client {
+          provider        = "prisma-client-js"
+          previewFeatures = ["referentialIntegrity"]
+        }
+
+        datasource db {
+          provider             = "mysql"
+          url                  = env("TEST_DATABASE_URL")
+          referentialIntegrity = "prisma"
+        }
+
+        model Foo {
+          id     Int @id
+          bar    Bar @relation(fields: [bar_id], references: [id])
+          bar_id Int @unique
+        }
+
+        model Bar {
+          id  Int  @id
+          foo Foo?
+        }
+    "#]];
+
+    let result = api.re_introspect_config(input).await?;
+    expected.assert_eq(&result);
+
+    Ok(())
+}
+
+// referentialIntegrity = "prisma" preserves the relation policy ("foreignKeys") as well as @relations, which are moved to the bottom.
+#[test_connector(tags(Mysql), exclude(Vitess))]
+async fn referential_integrity_foreign_keys(api: &TestApi) -> TestResult {
+    let init = formatdoc! {r#"
+        CREATE TABLE `Foo` (
+            `id` INTEGER NOT NULL,
+            `bar_id` INTEGER NOT NULL,
+        
+            UNIQUE INDEX `Foo_bar_id_key`(`bar_id`),
+            PRIMARY KEY (`id`)
+        );
+
+        CREATE TABLE `Bar` (
+            `id` INTEGER NOT NULL,
+        
+            PRIMARY KEY (`id`)
+        );
+
+        ALTER TABLE `Foo` ADD CONSTRAINT `Foo_bar_id_fkey` FOREIGN KEY (`bar_id`) REFERENCES `Bar`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+    "#};
+
+    api.raw_cmd(&init).await;
+
+    let input = indoc! {r#"
+        generator client {
+            provider        = "prisma-client-js"
+            previewFeatures = ["referentialIntegrity"]
+        }
+
+        datasource db {
+            provider             = "mysql"
+            url                  = env("TEST_DATABASE_URL")
+            referentialIntegrity = "foreignKeys"
+        }
+
+        model Foo {
+            id     Int @id
+            bar    Bar @relation(fields: [bar_id], references: [id])
+            bar_id Int @unique
+        }
+
+        model Bar {
+            id  Int  @id
+            foo Foo?
+        }
+    "#};
+
+    let expected = expect![[r#"
+        generator client {
+          provider        = "prisma-client-js"
+          previewFeatures = ["referentialIntegrity"]
+        }
+
+        datasource db {
+          provider             = "mysql"
+          url                  = env("TEST_DATABASE_URL")
+          referentialIntegrity = "foreignKeys"
+        }
+
+        model Foo {
+          id     Int @id
+          bar_id Int @unique
+          bar    Bar @relation(fields: [bar_id], references: [id])
+        }
+
+        model Bar {
+          id  Int  @id
+          foo Foo?
+        }
+    "#]];
+
+    let result = api.re_introspect_config(input).await?;
+    expected.assert_eq(&result);
+
+    Ok(())
+}
+
+// relationMode = "prisma" preserves the relation policy ("prisma") as well as @relations.
+#[test_connector(tags(Mysql), exclude(Vitess))]
+async fn relation_mode_prisma(api: &TestApi) -> TestResult {
+    let init = formatdoc! {r#"
+        CREATE TABLE `Foo` (
+            `id` INTEGER NOT NULL,
+            `bar_id` INTEGER NOT NULL,
+        
+            UNIQUE INDEX `Foo_bar_id_key`(`bar_id`),
+            PRIMARY KEY (`id`)
+        );
+
+        CREATE TABLE `Bar` (
+            `id` INTEGER NOT NULL,
+        
+            PRIMARY KEY (`id`)
+        );
+    "#};
+
+    api.raw_cmd(&init).await;
+
+    let input = indoc! {r#"
+        generator client {
+            provider        = "prisma-client-js"
+            previewFeatures = ["referentialIntegrity"]
+        }
+
+        datasource db {
+            provider     = "mysql"
+            url          = env("TEST_DATABASE_URL")
+            relationMode = "prisma"
+        }
+
+        model Foo {
+            id     Int @id
+            bar    Bar @relation(fields: [bar_id], references: [id])
+            bar_id Int @unique
+        }
+
+        model Bar {
+            id  Int  @id
+            foo Foo?
+        }
+    "#};
+
+    let expected = expect![[r#"
+        generator client {
+          provider        = "prisma-client-js"
+          previewFeatures = ["referentialIntegrity"]
+        }
+
+        datasource db {
+          provider     = "mysql"
+          url          = env("TEST_DATABASE_URL")
+          relationMode = "prisma"
+        }
+
+        model Foo {
+          id     Int @id
+          bar    Bar @relation(fields: [bar_id], references: [id])
+          bar_id Int @unique
+        }
+
+        model Bar {
+          id  Int  @id
+          foo Foo?
+        }
+    "#]];
+
+    let result = api.re_introspect_config(input).await?;
+    expected.assert_eq(&result);
+
+    Ok(())
+}
+
+// relationMode = "foreignKeys" preserves the relation policy ("foreignKeys") as well as @relations, which are moved to the bottom.
+#[test_connector(tags(Mysql), exclude(Vitess))]
+async fn relation_mode_foreign_keys(api: &TestApi) -> TestResult {
+    let init = formatdoc! {r#"
+        CREATE TABLE `Foo` (
+            `id` INTEGER NOT NULL,
+            `bar_id` INTEGER NOT NULL,
+        
+            UNIQUE INDEX `Foo_bar_id_key`(`bar_id`),
+            PRIMARY KEY (`id`)
+        );
+
+        CREATE TABLE `Bar` (
+            `id` INTEGER NOT NULL,
+        
+            PRIMARY KEY (`id`)
+        );
+
+        ALTER TABLE `Foo` ADD CONSTRAINT `Foo_bar_id_fkey` FOREIGN KEY (`bar_id`) REFERENCES `Bar`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+    "#};
+
+    api.raw_cmd(&init).await;
+
+    let input = indoc! {r#"
+        generator client {
+            provider        = "prisma-client-js"
+            previewFeatures = ["referentialIntegrity"]
+        }
+
+        datasource db {
+            provider     = "mysql"
+            url          = env("TEST_DATABASE_URL")
+            relationMode = "foreignKeys"
+        }
+
+        model Foo {
+            id     Int @id
+            bar    Bar @relation(fields: [bar_id], references: [id])
+            bar_id Int @unique
+        }
+
+        model Bar {
+            id  Int  @id
+            foo Foo?
+        }
+    "#};
+
+    let expected = expect![[r#"
+        generator client {
+          provider        = "prisma-client-js"
+          previewFeatures = ["referentialIntegrity"]
+        }
+
+        datasource db {
+          provider     = "mysql"
+          url          = env("TEST_DATABASE_URL")
+          relationMode = "foreignKeys"
+        }
+
+        model Foo {
+          id     Int @id
+          bar_id Int @unique
+          bar    Bar @relation(fields: [bar_id], references: [id])
+        }
+
+        model Bar {
+          id  Int  @id
+          foo Foo?
+        }
+    "#]];
+
+    let result = api.re_introspect_config(input).await?;
+    expected.assert_eq(&result);
+
+    Ok(())
+}
+
+// @relations are moved to the bottom of the model even when no referentialIntegrity/relationMode is used.
+#[test_connector(tags(Mysql), exclude(Vitess))]
+async fn no_relation_mode(api: &TestApi) -> TestResult {
+    let init = formatdoc! {r#"
+        CREATE TABLE `Foo` (
+            `id` INTEGER NOT NULL,
+            `bar_id` INTEGER NOT NULL,
+        
+            UNIQUE INDEX `Foo_bar_id_key`(`bar_id`),
+            PRIMARY KEY (`id`)
+        );
+
+        CREATE TABLE `Bar` (
+            `id` INTEGER NOT NULL,
+        
+            PRIMARY KEY (`id`)
+        );
+
+        ALTER TABLE `Foo` ADD CONSTRAINT `Foo_bar_id_fkey` FOREIGN KEY (`bar_id`) REFERENCES `Bar`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+    "#};
+
+    api.raw_cmd(&init).await;
+
+    let input = indoc! {r#"
+        datasource db {
+            provider = "mysql"
+            url      = env("TEST_DATABASE_URL")
+        }
+
+        model Foo {
+            id     Int @id
+            bar    Bar @relation(fields: [bar_id], references: [id])
+            bar_id Int @unique
+        }
+
+        model Bar {
+            id  Int  @id
+            foo Foo?
+        }
+    "#};
+
+    let expected = expect![[r#"
+        datasource db {
+          provider = "mysql"
+          url      = env("TEST_DATABASE_URL")
+        }
+
+        model Foo {
+          id     Int @id
+          bar_id Int @unique
+          bar    Bar @relation(fields: [bar_id], references: [id])
+        }
+
+        model Bar {
+          id  Int  @id
+          foo Foo?
+        }
+    "#]];
+
+    let result = api.re_introspect_config(input).await?;
+    expected.assert_eq(&result);
+
+    Ok(())
+}

--- a/introspection-engine/introspection-engine-tests/tests/re_introspection/relation_mode/postgres.rs
+++ b/introspection-engine/introspection-engine-tests/tests/re_introspection/relation_mode/postgres.rs
@@ -1,0 +1,376 @@
+use indoc::indoc;
+use introspection_engine_tests::test_api::*;
+
+// referentialIntegrity = "prisma" preserves the relation policy ("prisma") as well as @relations.
+#[test_connector(tags(Postgres))]
+async fn referential_integrity_prisma(api: &TestApi) -> TestResult {
+    let init = formatdoc! {r#"
+        CREATE TABLE "Foo" (
+            "id" INTEGER NOT NULL,
+            "bar_id" INTEGER NOT NULL,
+        
+            CONSTRAINT "Foo_pkey" PRIMARY KEY ("id")
+        );
+        
+        CREATE TABLE "Bar" (
+            "id" INTEGER NOT NULL,
+        
+            CONSTRAINT "Bar_pkey" PRIMARY KEY ("id")
+        );
+        
+        CREATE UNIQUE INDEX "Foo_bar_id_key" ON "Foo"("bar_id");
+    "#};
+
+    api.raw_cmd(&init).await;
+
+    let input = indoc! {r#"
+        generator client {
+            provider        = "prisma-client-js"
+            previewFeatures = ["referentialIntegrity"]
+        }
+
+        datasource db {
+            provider             = "postgres"
+            url                  = env("TEST_DATABASE_URL")
+            referentialIntegrity = "prisma"
+        }
+
+        model Foo {
+            id     Int @id
+            bar    Bar @relation(fields: [bar_id], references: [id])
+            bar_id Int @unique
+        }
+
+        model Bar {
+            id  Int  @id
+            foo Foo?
+        }
+    "#};
+
+    let expected = expect![[r#"
+        generator client {
+          provider        = "prisma-client-js"
+          previewFeatures = ["referentialIntegrity"]
+        }
+
+        datasource db {
+          provider             = "postgres"
+          url                  = env("TEST_DATABASE_URL")
+          referentialIntegrity = "prisma"
+        }
+
+        model Foo {
+          id     Int @id
+          bar    Bar @relation(fields: [bar_id], references: [id])
+          bar_id Int @unique
+        }
+
+        model Bar {
+          id  Int  @id
+          foo Foo?
+        }
+    "#]];
+
+    let result = api.re_introspect_config(input).await?;
+    expected.assert_eq(&result);
+
+    Ok(())
+}
+
+// referentialIntegrity = "prisma" preserves the relation policy ("foreignKeys") as well as @relations, which are moved to the bottom.
+#[test_connector(tags(Postgres))]
+async fn referential_integrity_foreign_keys(api: &TestApi) -> TestResult {
+    let init = formatdoc! {r#"
+        CREATE TABLE "Foo" (
+            "id" INTEGER NOT NULL,
+            "bar_id" INTEGER NOT NULL,
+        
+            CONSTRAINT "Foo_pkey" PRIMARY KEY ("id")
+        );
+        
+        CREATE TABLE "Bar" (
+            "id" INTEGER NOT NULL,
+        
+            CONSTRAINT "Bar_pkey" PRIMARY KEY ("id")
+        );
+        
+        CREATE UNIQUE INDEX "Foo_bar_id_key" ON "Foo"("bar_id");
+
+        ALTER TABLE "Foo" ADD CONSTRAINT "Foo_bar_id_fkey" FOREIGN KEY ("bar_id") REFERENCES "Bar"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+    "#};
+
+    api.raw_cmd(&init).await;
+
+    let input = indoc! {r#"
+        generator client {
+            provider        = "prisma-client-js"
+            previewFeatures = ["referentialIntegrity"]
+        }
+
+        datasource db {
+            provider             = "postgres"
+            url                  = env("TEST_DATABASE_URL")
+            referentialIntegrity = "foreignKeys"
+        }
+
+        model Foo {
+            id     Int @id
+            bar    Bar @relation(fields: [bar_id], references: [id])
+            bar_id Int @unique
+        }
+
+        model Bar {
+            id  Int  @id
+            foo Foo?
+        }
+    "#};
+
+    let expected = expect![[r#"
+        generator client {
+          provider        = "prisma-client-js"
+          previewFeatures = ["referentialIntegrity"]
+        }
+
+        datasource db {
+          provider             = "postgres"
+          url                  = env("TEST_DATABASE_URL")
+          referentialIntegrity = "foreignKeys"
+        }
+
+        model Foo {
+          id     Int @id
+          bar_id Int @unique
+          bar    Bar @relation(fields: [bar_id], references: [id])
+        }
+
+        model Bar {
+          id  Int  @id
+          foo Foo?
+        }
+    "#]];
+
+    let result = api.re_introspect_config(input).await?;
+    expected.assert_eq(&result);
+
+    Ok(())
+}
+
+// relationMode = "prisma" preserves the relation policy ("prisma") as well as @relations.
+#[test_connector(tags(Postgres))]
+async fn relation_mode_prisma(api: &TestApi) -> TestResult {
+    let init = formatdoc! {r#"
+        CREATE TABLE "Foo" (
+            "id" INTEGER NOT NULL,
+            "bar_id" INTEGER NOT NULL,
+        
+            CONSTRAINT "Foo_pkey" PRIMARY KEY ("id")
+        );
+        
+        CREATE TABLE "Bar" (
+            "id" INTEGER NOT NULL,
+        
+            CONSTRAINT "Bar_pkey" PRIMARY KEY ("id")
+        );
+        
+        CREATE UNIQUE INDEX "Foo_bar_id_key" ON "Foo"("bar_id");
+    "#};
+
+    api.raw_cmd(&init).await;
+
+    let input = indoc! {r#"
+        generator client {
+            provider        = "prisma-client-js"
+            previewFeatures = ["referentialIntegrity"]
+        }
+
+        datasource db {
+            provider     = "postgres"
+            url          = env("TEST_DATABASE_URL")
+            relationMode = "prisma"
+        }
+
+        model Foo {
+            id     Int @id
+            bar    Bar @relation(fields: [bar_id], references: [id])
+            bar_id Int @unique
+        }
+
+        model Bar {
+            id  Int  @id
+            foo Foo?
+        }
+    "#};
+
+    let expected = expect![[r#"
+        generator client {
+          provider        = "prisma-client-js"
+          previewFeatures = ["referentialIntegrity"]
+        }
+
+        datasource db {
+          provider     = "postgres"
+          url          = env("TEST_DATABASE_URL")
+          relationMode = "prisma"
+        }
+
+        model Foo {
+          id     Int @id
+          bar    Bar @relation(fields: [bar_id], references: [id])
+          bar_id Int @unique
+        }
+
+        model Bar {
+          id  Int  @id
+          foo Foo?
+        }
+    "#]];
+
+    let result = api.re_introspect_config(input).await?;
+    expected.assert_eq(&result);
+
+    Ok(())
+}
+
+// relationMode = "foreignKeys" preserves the relation policy ("foreignKeys") as well as @relations, which are moved to the bottom.
+#[test_connector(tags(Postgres))]
+async fn relation_mode_foreign_keys(api: &TestApi) -> TestResult {
+    let init = formatdoc! {r#"
+        CREATE TABLE "Foo" (
+            "id" INTEGER NOT NULL,
+            "bar_id" INTEGER NOT NULL,
+        
+            CONSTRAINT "Foo_pkey" PRIMARY KEY ("id")
+        );
+        
+        CREATE TABLE "Bar" (
+            "id" INTEGER NOT NULL,
+        
+            CONSTRAINT "Bar_pkey" PRIMARY KEY ("id")
+        );
+        
+        CREATE UNIQUE INDEX "Foo_bar_id_key" ON "Foo"("bar_id");
+
+        ALTER TABLE "Foo" ADD CONSTRAINT "Foo_bar_id_fkey" FOREIGN KEY ("bar_id") REFERENCES "Bar"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+    "#};
+
+    api.raw_cmd(&init).await;
+
+    let input = indoc! {r#"
+        generator client {
+            provider        = "prisma-client-js"
+            previewFeatures = ["referentialIntegrity"]
+        }
+
+        datasource db {
+            provider     = "postgres"
+            url          = env("TEST_DATABASE_URL")
+            relationMode = "foreignKeys"
+        }
+
+        model Foo {
+            id     Int @id
+            bar    Bar @relation(fields: [bar_id], references: [id])
+            bar_id Int @unique
+        }
+
+        model Bar {
+            id  Int  @id
+            foo Foo?
+        }
+    "#};
+
+    let expected = expect![[r#"
+        generator client {
+          provider        = "prisma-client-js"
+          previewFeatures = ["referentialIntegrity"]
+        }
+
+        datasource db {
+          provider     = "postgres"
+          url          = env("TEST_DATABASE_URL")
+          relationMode = "foreignKeys"
+        }
+
+        model Foo {
+          id     Int @id
+          bar_id Int @unique
+          bar    Bar @relation(fields: [bar_id], references: [id])
+        }
+
+        model Bar {
+          id  Int  @id
+          foo Foo?
+        }
+    "#]];
+
+    let result = api.re_introspect_config(input).await?;
+    expected.assert_eq(&result);
+
+    Ok(())
+}
+
+// @relations are moved to the bottom of the model even when no referentialIntegrity/relationMode is used.
+#[test_connector(tags(Postgres))]
+async fn no_relation_mode(api: &TestApi) -> TestResult {
+    let init = formatdoc! {r#"
+        CREATE TABLE "Foo" (
+            "id" INTEGER NOT NULL,
+            "bar_id" INTEGER NOT NULL,
+        
+            CONSTRAINT "Foo_pkey" PRIMARY KEY ("id")
+        );
+        
+        CREATE TABLE "Bar" (
+            "id" INTEGER NOT NULL,
+        
+            CONSTRAINT "Bar_pkey" PRIMARY KEY ("id")
+        );
+        
+        CREATE UNIQUE INDEX "Foo_bar_id_key" ON "Foo"("bar_id");
+
+        ALTER TABLE "Foo" ADD CONSTRAINT "Foo_bar_id_fkey" FOREIGN KEY ("bar_id") REFERENCES "Bar"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+    "#};
+
+    api.raw_cmd(&init).await;
+
+    let input = indoc! {r#"
+        datasource db {
+            provider = "postgres"
+            url      = env("TEST_DATABASE_URL")
+        }
+
+        model Foo {
+            id     Int @id
+            bar    Bar @relation(fields: [bar_id], references: [id])
+            bar_id Int @unique
+        }
+
+        model Bar {
+            id  Int  @id
+            foo Foo?
+        }
+    "#};
+
+    let expected = expect![[r#"
+        datasource db {
+          provider = "postgres"
+          url      = env("TEST_DATABASE_URL")
+        }
+
+        model Foo {
+          id     Int @id
+          bar_id Int @unique
+          bar    Bar @relation(fields: [bar_id], references: [id])
+        }
+
+        model Bar {
+          id  Int  @id
+          foo Foo?
+        }
+    "#]];
+
+    let result = api.re_introspect_config(input).await?;
+    expected.assert_eq(&result);
+
+    Ok(())
+}

--- a/introspection-engine/introspection-engine-tests/tests/re_introspection/relation_mode/sqlite.rs
+++ b/introspection-engine/introspection-engine-tests/tests/re_introspection/relation_mode/sqlite.rs
@@ -1,0 +1,353 @@
+use indoc::indoc;
+use introspection_engine_tests::test_api::*;
+
+// referentialIntegrity = "prisma" preserves the relation policy ("prisma") as well as @relations.
+#[test_connector(tags(Sqlite))]
+async fn referential_integrity_prisma(api: &TestApi) -> TestResult {
+    let init = formatdoc! {r#"
+        CREATE TABLE "Foo" (
+            "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+            "bar_id" INTEGER NOT NULL
+        );
+        
+        CREATE TABLE "Bar" (
+            "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT
+        );
+        
+        CREATE UNIQUE INDEX "Foo_bar_id_key" ON "Foo"("bar_id");
+    "#};
+
+    api.raw_cmd(&init).await;
+
+    let input = indoc! {r#"
+        generator client {
+            provider        = "prisma-client-js"
+            previewFeatures = ["referentialIntegrity"]
+        }
+
+        datasource db {
+            provider             = "sqlite"
+            url                  = env("TEST_DATABASE_URL")
+            referentialIntegrity = "prisma"
+        }
+
+        model Foo {
+            id     Int @id
+            bar    Bar @relation(fields: [bar_id], references: [id])
+            bar_id Int @unique
+        }
+
+        model Bar {
+            id  Int  @id
+            foo Foo?
+        }
+    "#};
+
+    let expected = expect![[r#"
+        generator client {
+          provider        = "prisma-client-js"
+          previewFeatures = ["referentialIntegrity"]
+        }
+
+        datasource db {
+          provider             = "sqlite"
+          url                  = env("TEST_DATABASE_URL")
+          referentialIntegrity = "prisma"
+        }
+
+        model Foo {
+          id     Int @id @default(autoincrement())
+          bar    Bar @relation(fields: [bar_id], references: [id])
+          bar_id Int @unique
+        }
+
+        model Bar {
+          id  Int  @id @default(autoincrement())
+          foo Foo?
+        }
+    "#]];
+
+    let result = api.re_introspect_config(input).await?;
+    expected.assert_eq(&result);
+
+    Ok(())
+}
+
+// referentialIntegrity = "prisma" preserves the relation policy ("foreignKeys") as well as @relations, which are moved to the bottom.
+#[test_connector(tags(Sqlite))]
+async fn referential_integrity_foreign_keys(api: &TestApi) -> TestResult {
+    let init = formatdoc! {r#"
+        CREATE TABLE "Foo" (
+            "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+            "bar_id" INTEGER NOT NULL,
+            CONSTRAINT "Foo_bar_id_fkey" FOREIGN KEY ("bar_id") REFERENCES "Bar" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+        );
+        
+        CREATE TABLE "Bar" (
+            "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT
+        );
+        
+        CREATE UNIQUE INDEX "Foo_bar_id_key" ON "Foo"("bar_id");
+    "#};
+
+    api.raw_cmd(&init).await;
+
+    let input = indoc! {r#"
+        generator client {
+            provider        = "prisma-client-js"
+            previewFeatures = ["referentialIntegrity"]
+        }
+
+        datasource db {
+            provider             = "sqlite"
+            url                  = env("TEST_DATABASE_URL")
+            referentialIntegrity = "foreignKeys"
+        }
+
+        model Foo {
+            id     Int @id
+            bar    Bar @relation(fields: [bar_id], references: [id])
+            bar_id Int @unique
+        }
+
+        model Bar {
+            id  Int  @id
+            foo Foo?
+        }
+    "#};
+
+    let expected = expect![[r#"
+        generator client {
+          provider        = "prisma-client-js"
+          previewFeatures = ["referentialIntegrity"]
+        }
+
+        datasource db {
+          provider             = "sqlite"
+          url                  = env("TEST_DATABASE_URL")
+          referentialIntegrity = "foreignKeys"
+        }
+
+        model Foo {
+          id     Int @id @default(autoincrement())
+          bar_id Int @unique
+          bar    Bar @relation(fields: [bar_id], references: [id])
+        }
+
+        model Bar {
+          id  Int  @id @default(autoincrement())
+          foo Foo?
+        }
+    "#]];
+
+    let result = api.re_introspect_config(input).await?;
+    expected.assert_eq(&result);
+
+    Ok(())
+}
+
+// relationMode = "prisma" preserves the relation policy ("prisma") as well as @relations.
+#[test_connector(tags(Sqlite))]
+async fn relation_mode_prisma(api: &TestApi) -> TestResult {
+    let init = formatdoc! {r#"
+        CREATE TABLE "Foo" (
+            "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+            "bar_id" INTEGER NOT NULL
+        );
+        
+        CREATE TABLE "Bar" (
+            "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT
+        );
+        
+        CREATE UNIQUE INDEX "Foo_bar_id_key" ON "Foo"("bar_id");
+    "#};
+
+    api.raw_cmd(&init).await;
+
+    let input = indoc! {r#"
+        generator client {
+            provider        = "prisma-client-js"
+            previewFeatures = ["referentialIntegrity"]
+        }
+
+        datasource db {
+            provider     = "sqlite"
+            url          = env("TEST_DATABASE_URL")
+            relationMode = "prisma"
+        }
+
+        model Foo {
+            id     Int @id
+            bar    Bar @relation(fields: [bar_id], references: [id])
+            bar_id Int @unique
+        }
+
+        model Bar {
+            id  Int  @id
+            foo Foo?
+        }
+    "#};
+
+    let expected = expect![[r#"
+        generator client {
+          provider        = "prisma-client-js"
+          previewFeatures = ["referentialIntegrity"]
+        }
+
+        datasource db {
+          provider     = "sqlite"
+          url          = env("TEST_DATABASE_URL")
+          relationMode = "prisma"
+        }
+
+        model Foo {
+          id     Int @id @default(autoincrement())
+          bar    Bar @relation(fields: [bar_id], references: [id])
+          bar_id Int @unique
+        }
+
+        model Bar {
+          id  Int  @id @default(autoincrement())
+          foo Foo?
+        }
+    "#]];
+
+    let result = api.re_introspect_config(input).await?;
+    expected.assert_eq(&result);
+
+    Ok(())
+}
+
+// relationMode = "foreignKeys" preserves the relation policy ("foreignKeys") as well as @relations, which are moved to the bottom.
+#[test_connector(tags(Sqlite))]
+async fn relation_mode_foreign_keys(api: &TestApi) -> TestResult {
+    let init = formatdoc! {r#"
+        CREATE TABLE "Foo" (
+            "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+            "bar_id" INTEGER NOT NULL,
+            CONSTRAINT "Foo_bar_id_fkey" FOREIGN KEY ("bar_id") REFERENCES "Bar" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+        );
+        
+        CREATE TABLE "Bar" (
+            "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT
+        );
+        
+        CREATE UNIQUE INDEX "Foo_bar_id_key" ON "Foo"("bar_id");
+    "#};
+
+    api.raw_cmd(&init).await;
+
+    let input = indoc! {r#"
+        generator client {
+            provider        = "prisma-client-js"
+            previewFeatures = ["referentialIntegrity"]
+        }
+
+        datasource db {
+            provider     = "sqlite"
+            url          = env("TEST_DATABASE_URL")
+            relationMode = "foreignKeys"
+        }
+
+        model Foo {
+            id     Int @id
+            bar    Bar @relation(fields: [bar_id], references: [id])
+            bar_id Int @unique
+        }
+
+        model Bar {
+            id  Int  @id
+            foo Foo?
+        }
+    "#};
+
+    let expected = expect![[r#"
+        generator client {
+          provider        = "prisma-client-js"
+          previewFeatures = ["referentialIntegrity"]
+        }
+
+        datasource db {
+          provider     = "sqlite"
+          url          = env("TEST_DATABASE_URL")
+          relationMode = "foreignKeys"
+        }
+
+        model Foo {
+          id     Int @id @default(autoincrement())
+          bar_id Int @unique
+          bar    Bar @relation(fields: [bar_id], references: [id])
+        }
+
+        model Bar {
+          id  Int  @id @default(autoincrement())
+          foo Foo?
+        }
+    "#]];
+
+    let result = api.re_introspect_config(input).await?;
+    expected.assert_eq(&result);
+
+    Ok(())
+}
+
+// @relations are moved to the bottom of the model even when no referentialIntegrity/relationMode is used.
+#[test_connector(tags(Sqlite))]
+async fn no_relation_mode(api: &TestApi) -> TestResult {
+    let init = formatdoc! {r#"
+        CREATE TABLE "Foo" (
+            "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+            "bar_id" INTEGER NOT NULL,
+            CONSTRAINT "Foo_bar_id_fkey" FOREIGN KEY ("bar_id") REFERENCES "Bar" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+        );
+        
+        CREATE TABLE "Bar" (
+            "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT
+        );
+        
+        CREATE UNIQUE INDEX "Foo_bar_id_key" ON "Foo"("bar_id");
+    "#};
+
+    api.raw_cmd(&init).await;
+
+    let input = indoc! {r#"
+        datasource db {
+            provider = "sqlite"
+            url      = env("TEST_DATABASE_URL")
+        }
+
+        model Foo {
+            id     Int @id
+            bar    Bar @relation(fields: [bar_id], references: [id])
+            bar_id Int @unique
+        }
+
+        model Bar {
+            id  Int  @id
+            foo Foo?
+        }
+    "#};
+
+    let expected = expect![[r#"
+        datasource db {
+          provider = "sqlite"
+          url      = env("TEST_DATABASE_URL")
+        }
+
+        model Foo {
+          id     Int @id @default(autoincrement())
+          bar_id Int @unique
+          bar    Bar @relation(fields: [bar_id], references: [id])
+        }
+
+        model Bar {
+          id  Int  @id @default(autoincrement())
+          foo Foo?
+        }
+    "#]];
+
+    let result = api.re_introspect_config(input).await?;
+    expected.assert_eq(&result);
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes https://github.com/prisma/prisma/issues/16007.