### PR TITLE
test-setup: delete run_with_tokio()

### DIFF
--- a/introspection-engine/introspection-engine-tests/tests/introspect/mod.rs
+++ b/introspection-engine/introspection-engine-tests/tests/introspect/mod.rs
@@ -1,6 +1,6 @@
 use expect_test::expect;
 use quaint::connector::rusqlite;
-use test_setup::runtime::run_with_tokio as tok;
+use test_setup::runtime::run_with_thread_local_runtime as tok;
 
 #[test]
 fn introspect_force_with_invalid_schema() {

--- a/libs/test-macros/src/lib.rs
+++ b/libs/test-macros/src/lib.rs
@@ -83,7 +83,7 @@ pub fn test_connector(attr: TokenStream, input: TokenStream) -> TokenStream {
                     BitFlags::empty() #(| Capabilities::#capabilities)*,
                 ) { return }
 
-                test_setup::runtime::run_with_tokio::<#return_ty, _>(async {
+                test_setup::runtime::run_with_thread_local_runtime::<#return_ty>(async {
                     let #arg_name = &#arg_type::new(args).await;
 
                     #body

--- a/libs/test-setup/src/mssql.rs
+++ b/libs/test-setup/src/mssql.rs
@@ -1,4 +1,4 @@
-use crate::{runtime::run_with_tokio, Tags};
+use crate::{runtime::run_with_thread_local_runtime as tok, Tags};
 use connection_string::JdbcString;
 use enumflags2::BitFlags;
 use quaint::{error::Error, prelude::Queryable, single::Quaint};
@@ -23,7 +23,7 @@ pub(crate) fn get_mssql_tags(database_url: &str) -> Result<BitFlags<Tags>, Strin
         Ok(tags)
     };
 
-    run_with_tokio(fut)
+    tok(fut)
 }
 
 pub async fn init_mssql_database(original_url: &str, db_name: &str) -> Result<(Quaint, String), Error> {

--- a/libs/test-setup/src/mysql.rs
+++ b/libs/test-setup/src/mysql.rs
@@ -1,4 +1,4 @@
-use crate::{runtime::run_with_tokio, AnyError, Tags};
+use crate::{runtime::run_with_thread_local_runtime as tok, AnyError, Tags};
 use enumflags2::BitFlags;
 use quaint::{prelude::Queryable, single::Quaint};
 use url::Url;
@@ -72,7 +72,7 @@ pub(crate) fn get_mysql_tags(database_url: &str) -> Result<BitFlags<Tags>, Strin
         }
     };
 
-    run_with_tokio(fut)
+    tok(fut)
 }
 
 /// Returns a connection to the new database, as well as the corresponding

--- a/libs/test-setup/src/postgres.rs
+++ b/libs/test-setup/src/postgres.rs
@@ -1,4 +1,4 @@
-use crate::{runtime::run_with_tokio, AnyError, Tags};
+use crate::{runtime::run_with_thread_local_runtime as tok, AnyError, Tags};
 use enumflags2::BitFlags;
 use quaint::{prelude::Queryable, single::Quaint};
 use url::Url;
@@ -41,7 +41,7 @@ pub(crate) fn get_postgres_tags(database_url: &str) -> Result<BitFlags<Tags>, St
         }
     };
 
-    run_with_tokio(fut)
+    tok(fut)
 }
 
 pub(crate) async fn create_postgres_database(database_url: &str, db_name: &str) -> Result<(Quaint, String), AnyError> {

--- a/libs/test-setup/src/runtime.rs
+++ b/libs/test-setup/src/runtime.rs
@@ -1,9 +1,5 @@
 use once_cell::sync::Lazy;
 
-pub fn run_with_tokio<O, F: std::future::Future<Output = O>>(fut: F) -> O {
-    test_tokio_runtime().block_on(fut)
-}
-
 static RT: Lazy<tokio::runtime::Runtime> = Lazy::new(|| {
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -13,11 +9,4 @@ static RT: Lazy<tokio::runtime::Runtime> = Lazy::new(|| {
 
 pub fn run_with_thread_local_runtime<O>(fut: impl std::future::Future<Output = O>) -> O {
     RT.block_on(fut)
-}
-
-pub fn test_tokio_runtime() -> tokio::runtime::Runtime {
-    tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .unwrap()
 }

--- a/migration-engine/cli/tests/cli_tests.rs
+++ b/migration-engine/cli/tests/cli_tests.rs
@@ -1,7 +1,7 @@
 use connection_string::JdbcString;
 use std::process::{Command, Output};
 use test_macros::test_connector;
-use test_setup::{BitFlags, Tags, TestApiArgs};
+use test_setup::{runtime::run_with_thread_local_runtime as tok, BitFlags, Tags, TestApiArgs};
 use url::Url;
 use user_facing_errors::{common::DatabaseDoesNotExist, UserFacingError};
 
@@ -29,14 +29,13 @@ impl TestApi {
 
     fn connection_string(&self) -> String {
         let args = &self.args;
-        let rt = test_setup::runtime::test_tokio_runtime();
 
         if args.tags().contains(Tags::Postgres) {
-            rt.block_on(args.create_postgres_database()).2
+            tok(args.create_postgres_database()).2
         } else if args.tags().contains(Tags::Mysql) {
-            rt.block_on(args.create_mysql_database()).1
+            tok(args.create_mysql_database()).1
         } else if args.tags().contains(Tags::Mssql) {
-            rt.block_on(args.create_mssql_database()).1
+            tok(args.create_mssql_database()).1
         } else if args.tags().contains(Tags::Sqlite) {
             args.database_url().to_owned()
         } else {

--- a/migration-engine/migration-engine-tests/tests/migrations/diff.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/diff.rs
@@ -720,7 +720,7 @@ fn diff_with_non_existing_sqlite_database_from_datasource() {
 // Call diff, and expect it to error. Return the error.
 pub(crate) fn diff_error(params: DiffParams) -> String {
     let api = migration_core::migration_api(None, None).unwrap();
-    let result = test_setup::runtime::run_with_tokio(api.diff(params));
+    let result = test_setup::runtime::run_with_thread_local_runtime(api.diff(params));
     result.unwrap_err().to_string()
 }
 
@@ -728,7 +728,7 @@ pub(crate) fn diff_error(params: DiffParams) -> String {
 pub(crate) fn diff_result(params: DiffParams) -> (DiffResult, String) {
     let host = Arc::new(TestConnectorHost::default());
     let api = migration_core::migration_api(None, Some(host.clone())).unwrap();
-    let result = test_setup::runtime::run_with_tokio(api.diff(params)).unwrap();
+    let result = test_setup::runtime::run_with_thread_local_runtime(api.diff(params)).unwrap();
     let printed_messages = host.printed_messages.lock().unwrap();
     assert!(printed_messages.len() == 1, "{:?}", printed_messages);
     (result, printed_messages[0].clone())

--- a/migration-engine/migration-engine-tests/tests/migrations/drift_summary.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/drift_summary.rs
@@ -20,7 +20,7 @@ fn check(from: &str, to: &str, expectation: Expect) {
 
     let host = Arc::new(TestConnectorHost::default());
     let api = migration_core::migration_api(None, Some(host.clone())).unwrap();
-    test_setup::runtime::run_with_tokio(api.diff(params)).unwrap();
+    test_setup::runtime::run_with_thread_local_runtime(api.diff(params)).unwrap();
     let printed_messages = host.printed_messages.lock().unwrap();
     assert!(printed_messages.len() == 1, "{:?}", printed_messages);
     expectation.assert_eq(&printed_messages[0]);


### PR DESCRIPTION
Its usages are replaced with
`test_setup::runtime::run_with_thread_local_runtime()`.

The `run_with_tokio()` is brittle in subtle ways, because it creates a single-threaded tokio runtime _for each call_. This means the same future (think database connections) may be polled on one runtime, then another, leading to confusing errors about closed connections due to missing file descriptors. The `run_with_thread_local_runtime()` alternative does not suffer from this problem.