### PR TITLE
feat(validation): referentialIntegrity and relationMode attributes cannot be used together

### DIFF
--- a/psl/diagnostics/src/error.rs
+++ b/psl/diagnostics/src/error.rs
@@ -359,6 +359,11 @@ impl DatamodelError {
         Self::new(msg, span)
     }
 
+    pub fn new_referential_integrity_and_relation_mode_cooccur_error(span: Span) -> DatamodelError {
+        let msg = "The `referentialIntegrity` and `relationMode` attributes cannot be used together. Please use only `relationMode` instead.".to_string();
+        Self::new(msg, span)
+    }
+
     pub fn span(&self) -> Span {
         self.span
     }

--- a/psl/psl-core/src/validate/datasource_loader.rs
+++ b/psl/psl-core/src/validate/datasource_loader.rs
@@ -220,6 +220,16 @@ fn lift_datasource(
 
     let connector_data = active_connector.parse_datasource_properties(&mut args, diagnostics);
 
+    // referentialIntegrity and relationMode cannot co-occur
+    if referential_integrity.and(relation_mode).is_some() {
+        let span = args
+            .get("referentialIntegrity")
+            .map(|(_, v)| v.span())
+            .unwrap_or_else(Span::empty);
+
+        diagnostics.push_error(DatamodelError::new_referential_integrity_and_relation_mode_cooccur_error(span));
+    }
+
     // we handle these elsewhere
     args.remove("previewFeatures");
     args.remove("referentialIntegrity");


### PR DESCRIPTION
Before this PR, the following schema was considered valid:

```prisma
datasource db {
  provider = "sqlite"
  url = "..."
  relationMode = "prisma" // we take relationMode in priority
  referentialIntegrity = "foreignKeys" // is ignored
}
```

This PR makes it invalid, as only one attribute between `relationMode` or `referentialIntegrity` (or none) should be used.
The validation error is:

> The `referentialIntegrity` and `relationMode` attributes cannot be used together. Please use only `relationMode` instead.

Closes https://github.com/prisma/prisma/issues/15735.