### PR TITLE
nix: add rust-analyzer to the flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -60,7 +60,7 @@
 
               inherit src;
 
-              buildInputs = [ pkgs.openssl ];
+              buildInputs = [ pkgs.openssl pkgs.rust-analyzer ];
 
               nativeBuildInputs = with pkgs; [
                 git # for our build scripts that bake in the git hash


### PR DESCRIPTION
We've talked about this, and this would definitely make my local setup easier. Since we're pinning nixpkgs/unstable, it's always going to be a rather recent `rust-analyzer`, which is nice.

This is prompted by `rust-analyzer` just started crashing locally for me, and updating it fixed it.