### PR TITLE
prisma-fmt-wasm: remove `version()` method stub

### DIFF
--- a/prisma-fmt-wasm/scripts/check.sh
+++ b/prisma-fmt-wasm/scripts/check.sh
@@ -20,12 +20,12 @@ echo 'ok.'
 
 echo '2. We can call the module directly and get back a valid result.'
 
-VERSION_FROM_MODULE=`$node -e "const prismaFmt = require('$prisma_fmt_wasm'); console.log(prismaFmt.version())"`
+REFORMATTED_MEOW=`$node -e "const prismaFmt = require('$prisma_fmt_wasm'); console.log(prismaFmt.format('meow', '{}'))"`
 
-echo "VERSION_FROM_MODULE=$VERSION_FROM_MODULE"
+echo "REFORMATTED_MEOW=$REFORMATTED_MEOW"
 
-if [[ $VERSION_FROM_MODULE != 'wasm' ]]; then
-    echo "Check phase failed: expected the module version to be 'wasm', but got $VERSION_FROM_MODULE"
+if [[ $REFORMATTED_MEOW != 'meow' ]]; then
+    echo "Check phase failed: expected the module version to be 'wasm', but got '$REFORMATTED_MEOW'"
     exit 1
 fi
 

--- a/prisma-fmt-wasm/src/lib.rs
+++ b/prisma-fmt-wasm/src/lib.rs
@@ -50,11 +50,6 @@ pub fn code_actions(schema: String, params: String) -> String {
     prisma_fmt::code_actions(schema, &params)
 }
 
-#[wasm_bindgen]
-pub fn version() -> String {
-    String::from("wasm")
-}
-
 /// Trigger a panic inside the wasm module. This is only useful in development for testing panic
 /// handling.
 #[wasm_bindgen]


### PR DESCRIPTION
We do not use it in the CLI, so it is unnecessary.

closes https://github.com/prisma/prisma-engines/issues/3302