### PR TITLE
test: make postgres docker image version explicit

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       - "6432:6432"
 
   postgres9:
-    image: postgres:9.5
+    image: postgres:9.6
     restart: always
     command: postgres -c 'max_connections=1000'
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       - "6432:6432"
 
   postgres9:
-    image: postgres:9
+    image: postgres:9.4
     restart: always
     command: postgres -c 'max_connections=1000'
     environment:
@@ -159,7 +159,7 @@ services:
     tmpfs: /var/lib/mysql8
 
   mariadb-10-0:
-    image: mariadb:10
+    image: mariadb:10.3
     restart: always
     environment:
       MYSQL_USER: root
@@ -219,17 +219,6 @@ services:
       MYSQL_BIND_HOST: "0.0.0.0"
       FOREIGN_KEY_MODE: "disallow"
 
-  mssql-2019:
-    image: mcr.microsoft.com/mssql/server:2019-latest
-    restart: always
-    environment:
-      ACCEPT_EULA: "Y"
-      SA_PASSWORD: "<YourStrong@Passw0rd>"
-    ports:
-      - "1433:1433"
-    networks:
-      - databases
-
   mssql-2017:
     image: mcr.microsoft.com/mssql/server:2017-latest
     restart: always
@@ -238,6 +227,17 @@ services:
       SA_PASSWORD: "<YourStrong@Passw0rd>"
     ports:
       - "1434:1433"
+    networks:
+      - databases
+      
+  mssql-2019:
+    image: mcr.microsoft.com/mssql/server:2019-latest
+    restart: always
+    environment:
+      ACCEPT_EULA: "Y"
+      SA_PASSWORD: "<YourStrong@Passw0rd>"
+    ports:
+      - "1433:1433"
     networks:
       - databases
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -159,7 +159,7 @@ services:
     tmpfs: /var/lib/mysql8
 
   mariadb-10-0:
-    image: mariadb:10.0
+    image: mariadb:10
     restart: always
     environment:
       MYSQL_USER: root

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       - "6432:6432"
 
   postgres9:
-    image: postgres:9.4
+    image: postgres:9.5
     restart: always
     command: postgres -c 'max_connections=1000'
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -159,7 +159,7 @@ services:
     tmpfs: /var/lib/mysql8
 
   mariadb-10-0:
-    image: mariadb:10.3
+    image: mariadb:10.0
     restart: always
     environment:
       MYSQL_USER: root


### PR DESCRIPTION
PostgreSQL 9.4 fails in Introspection many times, but then tests are stopped and Migrate is not tested
See related issue https://github.com/prisma/prisma/issues/15320
Introspection Engine + Migration Engine + sql_schema_describer
https://github.com/prisma/prisma-engines/actions/runs/3337675005/jobs/5524321278#step:6:1104
```
failures:

---- add_prisma1_defaults::add_uuid_default_postgres stdout ----
version: "PostgreSQL 9.4.26 on x86_64-pc-linux-gnu (Debian 9.4.26-1.pgdg90+1), compiled by gcc (Debian 6.3.0-18+deb9u1) 6.3.0 20170516, 64-bit"
Inferred tags: BitFlags<Tags>(0b1000000000001000, Postgres | Postgres9)
thread 'add_prisma1_defaults::add_uuid_default_postgres' panicked at 'called `Result::unwrap()` on an `Err` value: ConnectorError { user_facing_error: None, kind: QueryError(Error querying the database: Error querying the database: db error: ERROR: function array_position(smallint[], smallint) does not exist
HINT: No function matches the given name and argument types. You might need to add explicit type casts.
```

PostgreSQL 9.5 fails in Introspection with only 1 failure, but then tests are stopped and Migrate is not tested 
Introspection Engine + Migration Engine + sql_schema_describer
https://github.com/prisma/prisma-engines/actions/runs/3338558372/jobs/5526363806#step:6:1104
```
failures:

---- postgres::spgist::spgist_raw_ops stdout ----
thread 'postgres::spgist::spgist_raw_ops' panicked at 'called `Result::unwrap()` on an `Err` value: Error { kind: QueryError(Error { kind: Db, cause: Some(DbError { severity: "ERROR", parsed_severity: None, code: SqlState(E42704), message: "data type box has no default operator class for access method \"spgist\"", detail: None, hint: Some("You must specify an operator class for the index or define a default operator class for the data type."), position: None, where_: None, schema: None, table: None, column: None, datatype: None, constraint: None, file: Some("indexcmds.c"), line: Some(1290), routine: Some("GetIndexOpClass") }) }), original_code: Some("42704"), original_message: Some("db error: ERROR: data type box has no default operator class for access method \"spgist\"\nHINT: You must specify an operator class for the index or define a default operator class for the data type.") }', introspection-engine/introspection-engine-tests/tests/postgres/spgist.rs:6:1
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    postgres::spgist::spgist_raw_ops

test result: FAILED. 499 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.20s
```

PostgreSQL 9.6 passes all the tests, as expected, as it was the version tested when version was set to `9` 
