### PR TITLE
Fix tests on main

### DIFF
--- a/migration-engine/migration-engine-tests/tests/single_migration_tests/postgres/enum_basic.prisma
+++ b/migration-engine/migration-engine-tests/tests/single_migration_tests/postgres/enum_basic.prisma
@@ -1,6 +1,11 @@
 // tags=postgres
 // exclude=cockroachdb
 
+datasource pg {
+    provider = "postgresql"
+    url = env("TEST_DATABASE_URL")
+}
+
 model Test {
     id String @id @default(cuid())
     enum MyEnum


### PR DESCRIPTION
See this comment https://github.com/prisma/prisma-engines/pull/3347/files#r1007951554

And this slack message:

It doesn't happen very often but it has happened a few times in the past, and just now we have another case (https://github.com/prisma/prisma-engines/pull/3347/files#r1007951554): sometimes PRs aren't rebased, the tests are green, but once they are merged, they fail on main. In this case because one test made assumptions that worked with the older main the branch was based on, but not the new ones. All without merge conflict. [...]