### PR TITLE
nix: sync rust-analyzer version and rustc version in devShell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,8 +22,8 @@
           overlays = [
             rust-overlay.overlays.default
             (self: super:
-              let toolchain = pkgs.rust-bin.stable.latest.default; in
-              { cargo = toolchain; rustc = toolchain; })
+              let toolchain = pkgs.rust-bin.stable.latest; in
+              { cargo = toolchain.minimal; rustc = toolchain.minimal; rustToolchain = toolchain; })
           ];
           pkgs = import nixpkgs { inherit system overlays; };
           craneLib = crane.mkLib pkgs;
@@ -61,7 +61,7 @@
 
               inherit src;
 
-              buildInputs = [ pkgs.openssl pkgs.rust-analyzer ];
+              buildInputs = [ pkgs.openssl ];
 
               nativeBuildInputs = with pkgs; [
                 git # for our build scripts that bake in the git hash
@@ -88,7 +88,10 @@
 
           checks = prisma-fmt-wasm.checks;
 
-          devShells.default = pkgs.mkShell { inputsFrom = [ prisma-engines-deps ]; };
+          devShells.default = pkgs.mkShell {
+            packages = [ (pkgs.rustToolchain.default.override { extensions = [ "rust-analyzer" "rust-src" ]; }) ];
+            inputsFrom = [ prisma-engines-deps ];
+          };
         }
       );
 }


### PR DESCRIPTION
Two changes:

- Moves the rust-analyzer dependency to the devShell only, and use the minimal profile for building the engines. We don't need rust-analyzer nor rustfmt, clippy, etc. to build the engines, but we want them in the development shell.
- Syncs the version of rust-analyzer with that of rustc and cargo: we were using rust-analyzer from upstream nixpkgs and rustc/cargo from rust-overlay. This commit makes rust-analyzer come from the overlay as well.