### PR TITLE
migration-engine: improve single_migration_tests

### DIFF
--- a/migration-engine/migration-engine-tests/tests/single_migration_tests/postgres/empty_dbgenerated.prisma
+++ b/migration-engine/migration-engine-tests/tests/single_migration_tests/postgres/empty_dbgenerated.prisma
@@ -10,7 +10,7 @@ model table {
     id String @id
     hereBeDragons String @default(dbgenerated())
 }
-
+// Expected Migration:
 // -- CreateTable
 // CREATE TABLE "table" (
 //     "id" TEXT NOT NULL,

--- a/migration-engine/migration-engine-tests/tests/single_migration_tests/postgres/enum_basic.prisma
+++ b/migration-engine/migration-engine-tests/tests/single_migration_tests/postgres/enum_basic.prisma
@@ -11,6 +11,7 @@ enum MyEnum {
     B
 }
 
+// Expected Migration:
 // -- CreateEnum
 // CREATE TYPE "MyEnum" AS ENUM ('A', 'B');
 // 

--- a/migration-engine/migration-engine-tests/tests/single_migration_tests/postgres/multi_schema_unused_namespace.prisma
+++ b/migration-engine/migration-engine-tests/tests/single_migration_tests/postgres/multi_schema_unused_namespace.prisma
@@ -4,7 +4,7 @@
 datasource testds {
     provider = "postgresql"
     url = env("TEST_DATABASE_URL")
-    schemas = ["public", "security", "users"]
+    schemas = ["public", "security", "users", "unused"]
 }
 
 generator js {
@@ -49,12 +49,16 @@ model Test5 {
   test4 Test4[]
   @@schema("security")
 }
+
 // Expected Migration:
 // -- CreateSchema
 // CREATE SCHEMA IF NOT EXISTS "public";
 // 
 // -- CreateSchema
 // CREATE SCHEMA IF NOT EXISTS "security";
+// 
+// -- CreateSchema
+// CREATE SCHEMA IF NOT EXISTS "unused";
 // 
 // -- CreateSchema
 // CREATE SCHEMA IF NOT EXISTS "users";

--- a/migration-engine/migration-engine-tests/tests/single_migration_tests/postgres/scalar_lists_with_enum_and_int_id.prisma
+++ b/migration-engine/migration-engine-tests/tests/single_migration_tests/postgres/scalar_lists_with_enum_and_int_id.prisma
@@ -16,7 +16,7 @@ enum Status {
     OK
     ERROR
 }
-
+// Expected Migration:
 // -- CreateEnum
 // CREATE TYPE "Status" AS ENUM ('OK', 'ERROR');
 // 

--- a/migration-engine/migration-engine-tests/tests/single_migration_tests/sqlite/constraint_names_basic.prisma
+++ b/migration-engine/migration-engine-tests/tests/single_migration_tests/sqlite/constraint_names_basic.prisma
@@ -25,6 +25,7 @@ model B {
   @@id([a, b])
 }
 
+// Expected Migration:
 // -- CreateTable
 // CREATE TABLE "A" (
 //     "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,


### PR DESCRIPTION
Added a new test to verify that having a namespace with no associated models works as expected. Ended up cleaning the test expectations a bit.