### PR TITLE
feat(qe): Implement findFirstOrThrow and findUniqeOrThrow in the engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3172,6 +3172,7 @@ dependencies = [
  "connection-string",
  "crossbeam-queue",
  "cuid",
+ "enumflags2",
  "futures",
  "im",
  "indexmap",

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/simple/find_first.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/simple/find_first.rs
@@ -5,7 +5,7 @@ mod find_first_query {
     use query_engine_tests::assert_query;
 
     #[connector_test]
-    async fn fetch_first_matching(runner: Runner) -> TestResult<()> {
+    async fn find_first_matching(runner: Runner) -> TestResult<()> {
         test_data(&runner).await?;
 
         assert_query!(
@@ -30,6 +30,19 @@ mod find_first_query {
             runner,
             "query { findFirstTestModel(where: { field: { not: null }}, cursor: { id: 1 }, take: 1, skip: 1, orderBy: { id: asc }) { id }}",
             r#"{"data":{"findFirstTestModel":{"id":2}}}"#
+        );
+
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn find_first_not_matching(runner: Runner) -> TestResult<()> {
+        test_data(&runner).await?;
+
+        assert_query!(
+            runner,
+            "query { findFirstTestModel(where: { id: 6 }) { id }}",
+            r#"{"data":{"findFirstTestModel":null}}"#
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/simple/find_first_or_throw.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/simple/find_first_or_throw.rs
@@ -1,0 +1,69 @@
+use query_engine_tests::*;
+
+#[test_suite(schema(schemas::generic))]
+mod find_first_or_throw_query {
+    use query_engine_tests::assert_query;
+
+    #[connector_test]
+    async fn find_first_or_throw_matching(runner: Runner) -> TestResult<()> {
+        test_data(&runner).await?;
+
+        assert_query!(
+            runner,
+            "query { findFirstOrThrowTestModel(where: { id: 1 }) { id }}",
+            r#"{"data":{"findFirstOrThrowTestModel":{"id":1}}}"#
+        );
+
+        assert_query!(
+            runner,
+            "query { findFirstOrThrowTestModel(where: { field: { not: null }}) { id }}",
+            r#"{"data":{"findFirstOrThrowTestModel":{"id":1}}}"#
+        );
+
+        assert_query!(
+            runner,
+            "query { findFirstOrThrowTestModel(where: { field: { not: null }}, orderBy: { id: desc }) { id }}",
+            r#"{"data":{"findFirstOrThrowTestModel":{"id":5}}}"#
+        );
+
+        assert_query!(
+            runner,
+            "query { findFirstOrThrowTestModel(where: { field: { not: null }}, cursor: { id: 1 }, take: 1, skip: 1, orderBy: { id: asc }) { id }}",
+            r#"{"data":{"findFirstOrThrowTestModel":{"id":2}}}"#
+        );
+
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn find_first_or_throw_not_matching(runner: Runner) -> TestResult<()> {
+        test_data(&runner).await?;
+
+        assert_error!(
+          &runner,
+          "query { findFirstOrThrowTestModel(where: { id: 6 }) { id }}",
+          2025,
+          "An operation failed because it depends on one or more records that were required but not found. Expected a record, found none."
+        );
+
+        Ok(())
+    }
+
+    async fn test_data(runner: &Runner) -> TestResult<()> {
+        test_row(runner, r#"{ id: 1, field: "test1" }"#).await?;
+        test_row(runner, r#"{ id: 2, field: "test2" }"#).await?;
+        test_row(runner, r#"{ id: 3 }"#).await?;
+        test_row(runner, r#"{ id: 4 }"#).await?;
+        test_row(runner, r#"{ id: 5, field: "test3" }"#).await?;
+
+        Ok(())
+    }
+
+    async fn test_row(runner: &Runner, data: &str) -> TestResult<()> {
+        runner
+            .query(format!("mutation {{ createOneTestModel(data: {}) {{ id }} }}", data))
+            .await?
+            .assert_success();
+        Ok(())
+    }
+}

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/simple/find_first_or_throw.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/simple/find_first_or_throw.rs
@@ -10,26 +10,26 @@ mod find_first_or_throw_query {
 
         assert_query!(
             runner,
-            "query { findFirstOrThrowTestModel(where: { id: 1 }) { id }}",
-            r#"{"data":{"findFirstOrThrowTestModel":{"id":1}}}"#
+            "query { findFirstTestModelOrThrow(where: { id: 1 }) { id }}",
+            r#"{"data":{"findFirstTestModelOrThrow":{"id":1}}}"#
         );
 
         assert_query!(
             runner,
-            "query { findFirstOrThrowTestModel(where: { field: { not: null }}) { id }}",
-            r#"{"data":{"findFirstOrThrowTestModel":{"id":1}}}"#
+            "query { findFirstTestModelOrThrow(where: { field: { not: null }}) { id }}",
+            r#"{"data":{"findFirstTestModelOrThrow":{"id":1}}}"#
         );
 
         assert_query!(
             runner,
-            "query { findFirstOrThrowTestModel(where: { field: { not: null }}, orderBy: { id: desc }) { id }}",
-            r#"{"data":{"findFirstOrThrowTestModel":{"id":5}}}"#
+            "query { findFirstTestModelOrThrow(where: { field: { not: null }}, orderBy: { id: desc }) { id }}",
+            r#"{"data":{"findFirstTestModelOrThrow":{"id":5}}}"#
         );
 
         assert_query!(
             runner,
-            "query { findFirstOrThrowTestModel(where: { field: { not: null }}, cursor: { id: 1 }, take: 1, skip: 1, orderBy: { id: asc }) { id }}",
-            r#"{"data":{"findFirstOrThrowTestModel":{"id":2}}}"#
+            "query { findFirstTestModelOrThrow(where: { field: { not: null }}, cursor: { id: 1 }, take: 1, skip: 1, orderBy: { id: asc }) { id }}",
+            r#"{"data":{"findFirstTestModelOrThrow":{"id":2}}}"#
         );
 
         Ok(())
@@ -41,7 +41,7 @@ mod find_first_or_throw_query {
 
         assert_error!(
           &runner,
-          "query { findFirstOrThrowTestModel(where: { id: 6 }) { id }}",
+          "query { findFirstTestModelOrThrow(where: { id: 6 }) { id }}",
           2025,
           "An operation failed because it depends on one or more records that were required but not found. Expected a record, found none."
         );

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/simple/find_unique.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/simple/find_unique.rs
@@ -5,7 +5,7 @@ mod find_unique {
     use query_engine_tests::assert_query;
 
     #[connector_test]
-    async fn fetch_unique_by_id(runner: Runner) -> TestResult<()> {
+    async fn find_unique_by_id(runner: Runner) -> TestResult<()> {
         test_user(&runner).await?;
 
         assert_query!(
@@ -18,7 +18,7 @@ mod find_unique {
     }
 
     #[connector_test]
-    async fn fetch_unique_by_single_unique(runner: Runner) -> TestResult<()> {
+    async fn find_unique_by_single_unique(runner: Runner) -> TestResult<()> {
         test_user(&runner).await?;
 
         assert_query!(
@@ -31,7 +31,7 @@ mod find_unique {
     }
 
     #[connector_test]
-    async fn fetch_unique_by_multi_unique(runner: Runner) -> TestResult<()> {
+    async fn find_unique_by_multi_unique(runner: Runner) -> TestResult<()> {
         test_user(&runner).await?;
 
         assert_query!(
@@ -44,7 +44,7 @@ mod find_unique {
     }
 
     #[connector_test]
-    async fn no_result_fetch_unique_by_id(runner: Runner) -> TestResult<()> {
+    async fn no_result_find_unique_by_id(runner: Runner) -> TestResult<()> {
         test_user(&runner).await?;
 
         assert_query!(
@@ -57,7 +57,7 @@ mod find_unique {
     }
 
     #[connector_test]
-    async fn no_result_fetch_unique_by_single_unique(runner: Runner) -> TestResult<()> {
+    async fn no_result_find_unique_by_single_unique(runner: Runner) -> TestResult<()> {
         test_user(&runner).await?;
 
         assert_query!(
@@ -70,7 +70,7 @@ mod find_unique {
     }
 
     #[connector_test]
-    async fn no_result_fetch_unique_by_multi_unique(runner: Runner) -> TestResult<()> {
+    async fn no_result_find_unique_by_multi_unique(runner: Runner) -> TestResult<()> {
         test_user(&runner).await?;
 
         assert_query!(

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/simple/find_unique_or_throw.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/simple/find_unique_or_throw.rs
@@ -10,20 +10,20 @@ mod find_unique_or_throw {
 
         assert_query!(
             &runner,
-            r#"query { findUniqueOrThrowUser(where: { email: "a@b.com" }) { id } }"#,
-            r#"{"data":{"findUniqueOrThrowUser":{"id":1}}}"#
+            r#"query { findUniqueUserOrThrow(where: { email: "a@b.com" }) { id } }"#,
+            r#"{"data":{"findUniqueUserOrThrow":{"id":1}}}"#
         );
 
         assert_query!(
             &runner,
-            r#"query { findUniqueOrThrowUser(where: { first_name_last_name: { first_name: "Elongated", last_name: "Muskrat" } }) { id } }"#,
-            r#"{"data":{"findUniqueOrThrowUser":{"id":1}}}"#
+            r#"query { findUniqueUserOrThrow(where: { first_name_last_name: { first_name: "Elongated", last_name: "Muskrat" } }) { id } }"#,
+            r#"{"data":{"findUniqueUserOrThrow":{"id":1}}}"#
         );
 
         assert_query!(
             runner,
-            "query { findUniqueOrThrowUser(where: { id: 1 }) { id } }",
-            r#"{"data":{"findUniqueOrThrowUser":{"id":1}}}"#
+            "query { findUniqueUserOrThrow(where: { id: 1 }) { id } }",
+            r#"{"data":{"findUniqueUserOrThrow":{"id":1}}}"#
         );
 
         Ok(())
@@ -35,7 +35,7 @@ mod find_unique_or_throw {
 
         assert_error!(
             &runner,
-            "query { findUniqueOrThrowUser(where: { id: 2 }) { id } }",
+            "query { findUniqueUserOrThrow(where: { id: 2 }) { id } }",
             2025,
             "An operation failed because it depends on one or more records that were required but not found. Expected a record, found none."
         );
@@ -49,7 +49,7 @@ mod find_unique_or_throw {
 
         assert_error!(
           &runner,
-          r#"query { findUniqueOrThrowUser(where: { email: "b@a.com" }) { id } }"#,
+          r#"query { findUniqueUserOrThrow(where: { email: "b@a.com" }) { id } }"#,
           2025,
           "An operation failed because it depends on one or more records that were required but not found. Expected a record, found none."
         );
@@ -63,7 +63,7 @@ mod find_unique_or_throw {
 
         assert_error!(
           &runner,
-          r#"query { findUniqueOrThrowUser(where: { first_name_last_name: { first_name: "Doesn't", last_name: "Exist" } }) { id } }"#,
+          r#"query { findUniqueUserOrThrow(where: { first_name_last_name: { first_name: "Doesn't", last_name: "Exist" } }) { id } }"#,
           2025,
           "An operation failed because it depends on one or more records that were required but not found. Expected a record, found none."
         );

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/simple/find_unique_or_throw.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/simple/find_unique_or_throw.rs
@@ -1,0 +1,81 @@
+use query_engine_tests::*;
+
+#[test_suite(schema(schemas::user))]
+mod find_unique_or_throw {
+    use query_engine_tests::assert_query;
+
+    #[connector_test]
+    async fn find_unique_or_throw_when_record_is_found(runner: Runner) -> TestResult<()> {
+        test_user(&runner).await?;
+
+        assert_query!(
+            &runner,
+            r#"query { findUniqueOrThrowUser(where: { email: "a@b.com" }) { id } }"#,
+            r#"{"data":{"findUniqueOrThrowUser":{"id":1}}}"#
+        );
+
+        assert_query!(
+            &runner,
+            r#"query { findUniqueOrThrowUser(where: { first_name_last_name: { first_name: "Elongated", last_name: "Muskrat" } }) { id } }"#,
+            r#"{"data":{"findUniqueOrThrowUser":{"id":1}}}"#
+        );
+
+        assert_query!(
+            runner,
+            "query { findUniqueOrThrowUser(where: { id: 1 }) { id } }",
+            r#"{"data":{"findUniqueOrThrowUser":{"id":1}}}"#
+        );
+
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn no_result_find_unique_by_id(runner: Runner) -> TestResult<()> {
+        test_user(&runner).await?;
+
+        assert_error!(
+            &runner,
+            "query { findUniqueOrThrowUser(where: { id: 2 }) { id } }",
+            2025,
+            "An operation failed because it depends on one or more records that were required but not found. Expected a record, found none."
+        );
+
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn no_result_find_unique_by_single_unique(runner: Runner) -> TestResult<()> {
+        test_user(&runner).await?;
+
+        assert_error!(
+          &runner,
+          r#"query { findUniqueOrThrowUser(where: { email: "b@a.com" }) { id } }"#,
+          2025,
+          "An operation failed because it depends on one or more records that were required but not found. Expected a record, found none."
+        );
+
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn no_result_find_unique_by_multi_unique(runner: Runner) -> TestResult<()> {
+        test_user(&runner).await?;
+
+        assert_error!(
+          &runner,
+          r#"query { findUniqueOrThrowUser(where: { first_name_last_name: { first_name: "Doesn't", last_name: "Exist" } }) { id } }"#,
+          2025,
+          "An operation failed because it depends on one or more records that were required but not found. Expected a record, found none."
+        );
+
+        Ok(())
+    }
+
+    async fn test_user(runner: &Runner) -> TestResult<()> {
+        runner
+            .query(r#"mutation { createOneUser(data: { id: 1, email: "a@b.com", first_name: "Elongated", last_name: "Muskrat" }) { id } }"#)
+            .await?.assert_success();
+
+        Ok(())
+    }
+}

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/simple/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/simple/mod.rs
@@ -1,7 +1,9 @@
 mod composite_default_value;
 mod find_first;
+mod find_first_or_throw;
 mod find_many;
 mod find_unique;
+mod find_unique_or_throw;
 mod json_result;
 mod m2m;
 mod mongo_incorrect_fields;

--- a/query-engine/core/Cargo.toml
+++ b/query-engine/core/Cargo.toml
@@ -49,3 +49,4 @@ schema = { path = "../schema" }
 schema-builder = { path = "../schema-builder" }
 parking_lot = "0.12"
 lru = "0.7.7"
+enumflags2 = "0.7"

--- a/query-engine/core/src/interpreter/query_interpreters/read.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/read.rs
@@ -65,7 +65,7 @@ fn read_one(
                 .into())
             }
 
-            None if query.options.throw_on_empty() => record_not_found(),
+            None if query.options.contains(QueryOption::ThrowOnEmpty) => record_not_found(),
 
             None => Ok(QueryResult::RecordSelection(Box::new(RecordSelection {
                 name: query.name,
@@ -118,7 +118,7 @@ fn read_many(
 
         let (scalars, aggregation_rows) = extract_aggregation_rows_from_scalars(scalars, query.aggregation_selections);
 
-        if scalars.records.is_empty() && query.options.throw_on_empty() {
+        if scalars.records.is_empty() && query.options.contains(QueryOption::ThrowOnEmpty) {
             record_not_found()
         } else {
             let nested: Vec<QueryResult> = process_nested(tx, query.nested, Some(&scalars)).await?;

--- a/query-engine/core/src/query_ast/read.rs
+++ b/query-engine/core/src/query_ast/read.rs
@@ -86,6 +86,12 @@ impl Display for ReadQuery {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum QueryOption {
+    ThrowOnEmpty,
+}
+pub const THROW_ON_EMPTY: [QueryOption; 1] = [QueryOption::ThrowOnEmpty];
+
 #[derive(Debug, Clone)]
 pub struct RecordQuery {
     pub name: String,
@@ -96,6 +102,7 @@ pub struct RecordQuery {
     pub nested: Vec<ReadQuery>,
     pub selection_order: Vec<String>,
     pub aggregation_selections: Vec<RelAggregationSelection>,
+    pub options: Vec<QueryOption>,
 }
 
 #[derive(Debug, Clone)]
@@ -108,6 +115,7 @@ pub struct ManyRecordsQuery {
     pub nested: Vec<ReadQuery>,
     pub selection_order: Vec<String>,
     pub aggregation_selections: Vec<RelAggregationSelection>,
+    pub options: Vec<QueryOption>,
 }
 
 #[derive(Debug, Clone)]

--- a/query-engine/core/src/query_ast/read.rs
+++ b/query-engine/core/src/query_ast/read.rs
@@ -93,6 +93,33 @@ pub enum QueryOption {
 pub const THROW_ON_EMPTY: [QueryOption; 1] = [QueryOption::ThrowOnEmpty];
 
 #[derive(Debug, Clone)]
+pub struct QueryOptions(pub Vec<QueryOption>);
+
+impl QueryOptions {
+    pub fn throw_on_empty(&self) -> bool {
+        self.contains(&QueryOption::ThrowOnEmpty)
+    }
+
+    pub fn contains(&self, option: &QueryOption) -> bool {
+        self.0.contains(option)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &QueryOption> {
+        self.0.iter()
+    }
+
+    pub fn none() -> Self {
+        Self(Vec::new())
+    }
+}
+
+impl From<Vec<QueryOption>> for QueryOptions {
+    fn from(options: Vec<QueryOption>) -> Self {
+        Self(options)
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct RecordQuery {
     pub name: String,
     pub alias: Option<String>,
@@ -102,7 +129,7 @@ pub struct RecordQuery {
     pub nested: Vec<ReadQuery>,
     pub selection_order: Vec<String>,
     pub aggregation_selections: Vec<RelAggregationSelection>,
-    pub options: Vec<QueryOption>,
+    pub options: QueryOptions,
 }
 
 #[derive(Debug, Clone)]
@@ -115,7 +142,7 @@ pub struct ManyRecordsQuery {
     pub nested: Vec<ReadQuery>,
     pub selection_order: Vec<String>,
     pub aggregation_selections: Vec<RelAggregationSelection>,
-    pub options: Vec<QueryOption>,
+    pub options: QueryOptions,
 }
 
 #[derive(Debug, Clone)]

--- a/query-engine/core/src/query_ast/read.rs
+++ b/query-engine/core/src/query_ast/read.rs
@@ -92,6 +92,34 @@ impl Display for ReadQuery {
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum QueryOption {
     ThrowOnEmpty,
+    Other,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct QueryOptions(BitFlags<QueryOption>);
+
+// Allows for: QueryOption::ThrowOnEmpty.into()  to be a QueryOptions
+impl From<QueryOption> for QueryOptions {
+    fn from(options: QueryOption) -> Self {
+        QueryOptions(options.into())
+    }
+}
+
+// Allows for: (QueryOption::ThrowOnEmpty | QueryOption::Other).into()  to be a QueryOptions
+impl From<BitFlags<QueryOption>> for QueryOptions {
+    fn from(options: BitFlags<QueryOption>) -> Self {
+        QueryOptions(options)
+    }
+}
+
+impl QueryOptions {
+    pub fn none() -> Self {
+        Self(BitFlags::empty())
+    }
+
+    pub fn contains(&self, option: QueryOption) -> bool {
+        self.0.contains(option)
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -104,7 +132,7 @@ pub struct RecordQuery {
     pub nested: Vec<ReadQuery>,
     pub selection_order: Vec<String>,
     pub aggregation_selections: Vec<RelAggregationSelection>,
-    pub options: BitFlags<QueryOption>,
+    pub options: QueryOptions,
 }
 
 #[derive(Debug, Clone)]
@@ -117,7 +145,7 @@ pub struct ManyRecordsQuery {
     pub nested: Vec<ReadQuery>,
     pub selection_order: Vec<String>,
     pub aggregation_selections: Vec<RelAggregationSelection>,
-    pub options: BitFlags<QueryOption>,
+    pub options: QueryOptions,
 }
 
 #[derive(Debug, Clone)]

--- a/query-engine/core/src/query_ast/read.rs
+++ b/query-engine/core/src/query_ast/read.rs
@@ -1,6 +1,7 @@
 //! Prisma read query AST
 use super::FilteredQuery;
 use connector::{filter::Filter, AggregationSelection, QueryArguments, RelAggregationSelection};
+use enumflags2::BitFlags;
 use prisma_models::prelude::*;
 use std::fmt::Display;
 
@@ -86,37 +87,11 @@ impl Display for ReadQuery {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[enumflags2::bitflags]
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum QueryOption {
     ThrowOnEmpty,
-}
-pub const THROW_ON_EMPTY: [QueryOption; 1] = [QueryOption::ThrowOnEmpty];
-
-#[derive(Debug, Clone)]
-pub struct QueryOptions(pub Vec<QueryOption>);
-
-impl QueryOptions {
-    pub fn throw_on_empty(&self) -> bool {
-        self.contains(&QueryOption::ThrowOnEmpty)
-    }
-
-    pub fn contains(&self, option: &QueryOption) -> bool {
-        self.0.contains(option)
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = &QueryOption> {
-        self.0.iter()
-    }
-
-    pub fn none() -> Self {
-        Self(Vec::new())
-    }
-}
-
-impl From<Vec<QueryOption>> for QueryOptions {
-    fn from(options: Vec<QueryOption>) -> Self {
-        Self(options)
-    }
 }
 
 #[derive(Debug, Clone)]
@@ -129,7 +104,7 @@ pub struct RecordQuery {
     pub nested: Vec<ReadQuery>,
     pub selection_order: Vec<String>,
     pub aggregation_selections: Vec<RelAggregationSelection>,
-    pub options: QueryOptions,
+    pub options: BitFlags<QueryOption>,
 }
 
 #[derive(Debug, Clone)]
@@ -142,7 +117,7 @@ pub struct ManyRecordsQuery {
     pub nested: Vec<ReadQuery>,
     pub selection_order: Vec<String>,
     pub aggregation_selections: Vec<RelAggregationSelection>,
-    pub options: QueryOptions,
+    pub options: BitFlags<QueryOption>,
 }
 
 #[derive(Debug, Clone)]

--- a/query-engine/core/src/query_graph/mod.rs
+++ b/query-engine/core/src/query_graph/mod.rs
@@ -8,7 +8,8 @@ pub use formatters::*;
 pub use transformers::*;
 
 use crate::{
-    interpreter::ExpressionResult, FilteredQuery, ManyRecordsQuery, Query, QueryGraphBuilderResult, ReadQuery,
+    interpreter::ExpressionResult, FilteredQuery, ManyRecordsQuery, Query, QueryGraphBuilderResult, QueryOptions,
+    ReadQuery,
 };
 use connector::{IntoFilter, QueryArguments};
 use guard::*;
@@ -818,7 +819,7 @@ impl QueryGraph {
                 nested: vec![],
                 selection_order: vec![],
                 aggregation_selections: vec![],
-                options: vec![],
+                options: QueryOptions::none(),
             });
 
             let query = Query::Read(read_query);

--- a/query-engine/core/src/query_graph/mod.rs
+++ b/query-engine/core/src/query_graph/mod.rs
@@ -3,13 +3,13 @@ mod formatters;
 mod guard;
 mod transformers;
 
+use enumflags2::BitFlags;
 pub use error::*;
 pub use formatters::*;
 pub use transformers::*;
 
 use crate::{
-    interpreter::ExpressionResult, FilteredQuery, ManyRecordsQuery, Query, QueryGraphBuilderResult, QueryOptions,
-    ReadQuery,
+    interpreter::ExpressionResult, FilteredQuery, ManyRecordsQuery, Query, QueryGraphBuilderResult, ReadQuery,
 };
 use connector::{IntoFilter, QueryArguments};
 use guard::*;
@@ -819,7 +819,7 @@ impl QueryGraph {
                 nested: vec![],
                 selection_order: vec![],
                 aggregation_selections: vec![],
-                options: QueryOptions::none(),
+                options: BitFlags::EMPTY,
             });
 
             let query = Query::Read(read_query);

--- a/query-engine/core/src/query_graph/mod.rs
+++ b/query-engine/core/src/query_graph/mod.rs
@@ -3,13 +3,13 @@ mod formatters;
 mod guard;
 mod transformers;
 
-use enumflags2::BitFlags;
 pub use error::*;
 pub use formatters::*;
 pub use transformers::*;
 
 use crate::{
-    interpreter::ExpressionResult, FilteredQuery, ManyRecordsQuery, Query, QueryGraphBuilderResult, ReadQuery,
+    interpreter::ExpressionResult, FilteredQuery, ManyRecordsQuery, Query, QueryGraphBuilderResult, QueryOptions,
+    ReadQuery,
 };
 use connector::{IntoFilter, QueryArguments};
 use guard::*;
@@ -819,7 +819,7 @@ impl QueryGraph {
                 nested: vec![],
                 selection_order: vec![],
                 aggregation_selections: vec![],
-                options: BitFlags::EMPTY,
+                options: QueryOptions::none(),
             });
 
             let query = Query::Read(read_query);

--- a/query-engine/core/src/query_graph/mod.rs
+++ b/query-engine/core/src/query_graph/mod.rs
@@ -818,6 +818,7 @@ impl QueryGraph {
                 nested: vec![],
                 selection_order: vec![],
                 aggregation_selections: vec![],
+                options: vec![],
             });
 
             let query = Query::Read(read_query);

--- a/query-engine/core/src/query_graph_builder/builder.rs
+++ b/query-engine/core/src/query_graph_builder/builder.rs
@@ -63,7 +63,9 @@ impl QueryGraphBuilder {
 
         let mut graph = match (&query_info.tag, query_info.model.clone()) {
             (QueryTag::FindUnique, Some(m)) => read::find_unique(parsed_field, m).map(Into::into),
+            (QueryTag::FindUniqueOrThrow, Some(m)) => read::find_unique_or_throw(parsed_field, m).map(Into::into),
             (QueryTag::FindFirst, Some(m)) => read::find_first(parsed_field, m).map(Into::into),
+            (QueryTag::FindFirstOrThrow, Some(m)) => read::find_first_or_throw(parsed_field, m).map(Into::into),
             (QueryTag::FindMany, Some(m)) => read::find_many(parsed_field, m).map(Into::into),
             (QueryTag::Aggregate, Some(m)) => read::aggregate(parsed_field, m).map(Into::into),
             (QueryTag::GroupBy, Some(m)) => read::group_by(parsed_field, m).map(Into::into),

--- a/query-engine/core/src/query_graph_builder/read/first.rs
+++ b/query-engine/core/src/query_graph_builder/read/first.rs
@@ -4,14 +4,22 @@ use super::*;
 use crate::ParsedField;
 
 pub fn find_first(field: ParsedField, model: ModelRef) -> QueryGraphBuilderResult<ReadQuery> {
-    let mut many_query = many::find_many(field, model)?;
+    let many_query = many::find_many(field, model)?;
+    try_limit_to_one(many_query)
+}
 
-    // Optimization: Add `take: 1` to the query to reduce fetched result set size if possible.
-    Ok(match many_query {
+pub fn find_first_or_throw(field: ParsedField, model: ModelRef) -> QueryGraphBuilderResult<ReadQuery> {
+    let many_query = many::find_many_or_throw(field, model)?;
+    try_limit_to_one(many_query)
+}
+
+#[inline]
+fn try_limit_to_one(mut query: ReadQuery) -> QueryGraphBuilderResult<ReadQuery> {
+    Ok(match query {
         ReadQuery::ManyRecordsQuery(ref mut m) if m.args.take.is_none() => {
             m.args.take = Some(1);
-            many_query
+            query
         }
-        _ => many_query,
+        _ => query,
     })
 }

--- a/query-engine/core/src/query_graph_builder/read/many.rs
+++ b/query-engine/core/src/query_graph_builder/read/many.rs
@@ -1,21 +1,20 @@
 use super::*;
-use crate::{query_document::ParsedField, ManyRecordsQuery, QueryOption, ReadQuery};
-use enumflags2::BitFlags;
+use crate::{query_document::ParsedField, ManyRecordsQuery, QueryOption, QueryOptions, ReadQuery};
 use prisma_models::ModelRef;
 
 pub fn find_many(field: ParsedField, model: ModelRef) -> QueryGraphBuilderResult<ReadQuery> {
-    find_many_with_options(field, model, BitFlags::EMPTY)
+    find_many_with_options(field, model, QueryOptions::none())
 }
 
 pub fn find_many_or_throw(field: ParsedField, model: ModelRef) -> QueryGraphBuilderResult<ReadQuery> {
-    find_many_with_options(field, model, BitFlags::from_flag(QueryOption::ThrowOnEmpty))
+    find_many_with_options(field, model, QueryOption::ThrowOnEmpty.into())
 }
 
 #[inline]
 fn find_many_with_options(
     field: ParsedField,
     model: ModelRef,
-    options: BitFlags<QueryOption>,
+    options: QueryOptions,
 ) -> QueryGraphBuilderResult<ReadQuery> {
     let args = extractors::extract_query_args(field.arguments, &model)?;
     let name = field.name;

--- a/query-engine/core/src/query_graph_builder/read/many.rs
+++ b/query-engine/core/src/query_graph_builder/read/many.rs
@@ -1,20 +1,21 @@
 use super::*;
-use crate::{query_document::ParsedField, ManyRecordsQuery, QueryOptions, ReadQuery, THROW_ON_EMPTY};
+use crate::{query_document::ParsedField, ManyRecordsQuery, QueryOption, ReadQuery};
+use enumflags2::BitFlags;
 use prisma_models::ModelRef;
 
 pub fn find_many(field: ParsedField, model: ModelRef) -> QueryGraphBuilderResult<ReadQuery> {
-    find_many_with_options(field, model, QueryOptions::none())
+    find_many_with_options(field, model, BitFlags::EMPTY)
 }
 
 pub fn find_many_or_throw(field: ParsedField, model: ModelRef) -> QueryGraphBuilderResult<ReadQuery> {
-    find_many_with_options(field, model, THROW_ON_EMPTY.to_vec().into())
+    find_many_with_options(field, model, BitFlags::from_flag(QueryOption::ThrowOnEmpty))
 }
 
 #[inline]
 fn find_many_with_options(
     field: ParsedField,
     model: ModelRef,
-    options: QueryOptions,
+    options: BitFlags<QueryOption>,
 ) -> QueryGraphBuilderResult<ReadQuery> {
     let args = extractors::extract_query_args(field.arguments, &model)?;
     let name = field.name;

--- a/query-engine/core/src/query_graph_builder/read/many.rs
+++ b/query-engine/core/src/query_graph_builder/read/many.rs
@@ -1,20 +1,20 @@
 use super::*;
-use crate::{query_document::ParsedField, ManyRecordsQuery, QueryOption, ReadQuery, THROW_ON_EMPTY};
+use crate::{query_document::ParsedField, ManyRecordsQuery, QueryOptions, ReadQuery, THROW_ON_EMPTY};
 use prisma_models::ModelRef;
 
 pub fn find_many(field: ParsedField, model: ModelRef) -> QueryGraphBuilderResult<ReadQuery> {
-    find_many_with_options(field, model, vec![])
+    find_many_with_options(field, model, QueryOptions::none())
 }
 
 pub fn find_many_or_throw(field: ParsedField, model: ModelRef) -> QueryGraphBuilderResult<ReadQuery> {
-    find_many_with_options(field, model, THROW_ON_EMPTY.to_vec())
+    find_many_with_options(field, model, THROW_ON_EMPTY.to_vec().into())
 }
 
 #[inline]
 fn find_many_with_options(
     field: ParsedField,
     model: ModelRef,
-    options: Vec<QueryOption>,
+    options: QueryOptions,
 ) -> QueryGraphBuilderResult<ReadQuery> {
     let args = extractors::extract_query_args(field.arguments, &model)?;
     let name = field.name;

--- a/query-engine/core/src/query_graph_builder/read/many.rs
+++ b/query-engine/core/src/query_graph_builder/read/many.rs
@@ -1,8 +1,21 @@
 use super::*;
-use crate::{query_document::ParsedField, ManyRecordsQuery, ReadQuery};
+use crate::{query_document::ParsedField, ManyRecordsQuery, QueryOption, ReadQuery, THROW_ON_EMPTY};
 use prisma_models::ModelRef;
 
 pub fn find_many(field: ParsedField, model: ModelRef) -> QueryGraphBuilderResult<ReadQuery> {
+    find_many_with_options(field, model, vec![])
+}
+
+pub fn find_many_or_throw(field: ParsedField, model: ModelRef) -> QueryGraphBuilderResult<ReadQuery> {
+    find_many_with_options(field, model, THROW_ON_EMPTY.to_vec())
+}
+
+#[inline]
+fn find_many_with_options(
+    field: ParsedField,
+    model: ModelRef,
+    options: Vec<QueryOption>,
+) -> QueryGraphBuilderResult<ReadQuery> {
     let args = extractors::extract_query_args(field.arguments, &model)?;
     let name = field.name;
     let alias = field.alias;
@@ -26,5 +39,6 @@ pub fn find_many(field: ParsedField, model: ModelRef) -> QueryGraphBuilderResult
         nested,
         selection_order,
         aggregation_selections,
+        options,
     }))
 }

--- a/query-engine/core/src/query_graph_builder/read/one.rs
+++ b/query-engine/core/src/query_graph_builder/read/one.rs
@@ -1,11 +1,24 @@
 use super::*;
-use crate::{query_document::*, ReadQuery, RecordQuery};
+use crate::{query_document::*, QueryOption, ReadQuery, RecordQuery, THROW_ON_EMPTY};
 use prisma_models::ModelRef;
 use schema_builder::constants::args;
 use std::convert::TryInto;
 
+pub fn find_unique(field: ParsedField, model: ModelRef) -> QueryGraphBuilderResult<ReadQuery> {
+    find_unique_with_options(field, model, vec![])
+}
+
+pub fn find_unique_or_throw(field: ParsedField, model: ModelRef) -> QueryGraphBuilderResult<ReadQuery> {
+    find_unique_with_options(field, model, THROW_ON_EMPTY.to_vec())
+}
+
 /// Builds a read query from a parsed incoming read query field.
-pub fn find_unique(mut field: ParsedField, model: ModelRef) -> QueryGraphBuilderResult<ReadQuery> {
+#[inline]
+pub fn find_unique_with_options(
+    mut field: ParsedField,
+    model: ModelRef,
+    options: Vec<QueryOption>,
+) -> QueryGraphBuilderResult<ReadQuery> {
     let filter = match field.arguments.lookup(args::WHERE) {
         Some(where_arg) => {
             let arg: ParsedInputMap = where_arg.value.try_into()?;
@@ -34,5 +47,6 @@ pub fn find_unique(mut field: ParsedField, model: ModelRef) -> QueryGraphBuilder
         nested,
         selection_order,
         aggregation_selections,
+        options,
     }))
 }

--- a/query-engine/core/src/query_graph_builder/read/one.rs
+++ b/query-engine/core/src/query_graph_builder/read/one.rs
@@ -1,16 +1,15 @@
 use super::*;
-use crate::{query_document::*, QueryOption, ReadQuery, RecordQuery};
-use enumflags2::BitFlags;
+use crate::{query_document::*, QueryOption, QueryOptions, ReadQuery, RecordQuery};
 use prisma_models::ModelRef;
 use schema_builder::constants::args;
 use std::convert::TryInto;
 
 pub fn find_unique(field: ParsedField, model: ModelRef) -> QueryGraphBuilderResult<ReadQuery> {
-    find_unique_with_options(field, model, BitFlags::EMPTY)
+    find_unique_with_options(field, model, QueryOptions::none())
 }
 
 pub fn find_unique_or_throw(field: ParsedField, model: ModelRef) -> QueryGraphBuilderResult<ReadQuery> {
-    find_unique_with_options(field, model, BitFlags::from_flag(QueryOption::ThrowOnEmpty))
+    find_unique_with_options(field, model, QueryOption::ThrowOnEmpty.into())
 }
 
 /// Builds a read query from a parsed incoming read query field.
@@ -18,7 +17,7 @@ pub fn find_unique_or_throw(field: ParsedField, model: ModelRef) -> QueryGraphBu
 pub fn find_unique_with_options(
     mut field: ParsedField,
     model: ModelRef,
-    options: BitFlags<QueryOption>,
+    options: QueryOptions,
 ) -> QueryGraphBuilderResult<ReadQuery> {
     let filter = match field.arguments.lookup(args::WHERE) {
         Some(where_arg) => {

--- a/query-engine/core/src/query_graph_builder/read/one.rs
+++ b/query-engine/core/src/query_graph_builder/read/one.rs
@@ -1,15 +1,15 @@
 use super::*;
-use crate::{query_document::*, QueryOption, ReadQuery, RecordQuery, THROW_ON_EMPTY};
+use crate::{query_document::*, QueryOptions, ReadQuery, RecordQuery, THROW_ON_EMPTY};
 use prisma_models::ModelRef;
 use schema_builder::constants::args;
 use std::convert::TryInto;
 
 pub fn find_unique(field: ParsedField, model: ModelRef) -> QueryGraphBuilderResult<ReadQuery> {
-    find_unique_with_options(field, model, vec![])
+    find_unique_with_options(field, model, QueryOptions::none())
 }
 
 pub fn find_unique_or_throw(field: ParsedField, model: ModelRef) -> QueryGraphBuilderResult<ReadQuery> {
-    find_unique_with_options(field, model, THROW_ON_EMPTY.to_vec())
+    find_unique_with_options(field, model, THROW_ON_EMPTY.to_vec().into())
 }
 
 /// Builds a read query from a parsed incoming read query field.
@@ -17,7 +17,7 @@ pub fn find_unique_or_throw(field: ParsedField, model: ModelRef) -> QueryGraphBu
 pub fn find_unique_with_options(
     mut field: ParsedField,
     model: ModelRef,
-    options: Vec<QueryOption>,
+    options: QueryOptions,
 ) -> QueryGraphBuilderResult<ReadQuery> {
     let filter = match field.arguments.lookup(args::WHERE) {
         Some(where_arg) => {

--- a/query-engine/core/src/query_graph_builder/read/one.rs
+++ b/query-engine/core/src/query_graph_builder/read/one.rs
@@ -1,15 +1,16 @@
 use super::*;
-use crate::{query_document::*, QueryOptions, ReadQuery, RecordQuery, THROW_ON_EMPTY};
+use crate::{query_document::*, QueryOption, ReadQuery, RecordQuery};
+use enumflags2::BitFlags;
 use prisma_models::ModelRef;
 use schema_builder::constants::args;
 use std::convert::TryInto;
 
 pub fn find_unique(field: ParsedField, model: ModelRef) -> QueryGraphBuilderResult<ReadQuery> {
-    find_unique_with_options(field, model, QueryOptions::none())
+    find_unique_with_options(field, model, BitFlags::EMPTY)
 }
 
 pub fn find_unique_or_throw(field: ParsedField, model: ModelRef) -> QueryGraphBuilderResult<ReadQuery> {
-    find_unique_with_options(field, model, THROW_ON_EMPTY.to_vec().into())
+    find_unique_with_options(field, model, BitFlags::from_flag(QueryOption::ThrowOnEmpty))
 }
 
 /// Builds a read query from a parsed incoming read query field.
@@ -17,7 +18,7 @@ pub fn find_unique_or_throw(field: ParsedField, model: ModelRef) -> QueryGraphBu
 pub fn find_unique_with_options(
     mut field: ParsedField,
     model: ModelRef,
-    options: QueryOptions,
+    options: BitFlags<QueryOption>,
 ) -> QueryGraphBuilderResult<ReadQuery> {
     let filter = match field.arguments.lookup(args::WHERE) {
         Some(where_arg) => {

--- a/query-engine/core/src/query_graph_builder/write/utils.rs
+++ b/query-engine/core/src/query_graph_builder/write/utils.rs
@@ -44,6 +44,7 @@ where
         nested: vec![],
         selection_order: vec![],
         aggregation_selections: vec![],
+        options: vec![],
     });
 
     Query::Read(read_query)

--- a/query-engine/core/src/query_graph_builder/write/utils.rs
+++ b/query-engine/core/src/query_graph_builder/write/utils.rs
@@ -4,6 +4,7 @@ use crate::{
     ParsedInputValue, QueryGraphBuilderError, QueryGraphBuilderResult,
 };
 use connector::{DatasourceFieldName, Filter, RecordFilter, WriteArgs, WriteOperation};
+use enumflags2::BitFlags;
 use indexmap::IndexMap;
 use prisma_models::{FieldSelection, ModelRef, PrismaValue, RelationFieldRef, SelectionResult};
 use psl::dml::ReferentialAction;
@@ -44,7 +45,7 @@ where
         nested: vec![],
         selection_order: vec![],
         aggregation_selections: vec![],
-        options: QueryOptions::none(),
+        options: BitFlags::EMPTY,
     });
 
     Query::Read(read_query)

--- a/query-engine/core/src/query_graph_builder/write/utils.rs
+++ b/query-engine/core/src/query_graph_builder/write/utils.rs
@@ -44,7 +44,7 @@ where
         nested: vec![],
         selection_order: vec![],
         aggregation_selections: vec![],
-        options: vec![],
+        options: QueryOptions::none(),
     });
 
     Query::Read(read_query)

--- a/query-engine/core/src/query_graph_builder/write/utils.rs
+++ b/query-engine/core/src/query_graph_builder/write/utils.rs
@@ -4,7 +4,6 @@ use crate::{
     ParsedInputValue, QueryGraphBuilderError, QueryGraphBuilderResult,
 };
 use connector::{DatasourceFieldName, Filter, RecordFilter, WriteArgs, WriteOperation};
-use enumflags2::BitFlags;
 use indexmap::IndexMap;
 use prisma_models::{FieldSelection, ModelRef, PrismaValue, RelationFieldRef, SelectionResult};
 use psl::dml::ReferentialAction;
@@ -45,7 +44,7 @@ where
         nested: vec![],
         selection_order: vec![],
         aggregation_selections: vec![],
-        options: BitFlags::EMPTY,
+        options: QueryOptions::none(),
     });
 
     Query::Read(read_query)

--- a/query-engine/schema-builder/src/output_types/query_type.rs
+++ b/query-engine/schema-builder/src/output_types/query_type.rs
@@ -56,7 +56,7 @@ fn find_unique_field(ctx: &mut BuilderContext, model: &ModelRef) -> Option<Outpu
 /// that will throw a NotFoundError if the item is not found
 fn find_unique_or_throw_field(ctx: &mut BuilderContext, model: &ModelRef) -> Option<OutputField> {
     arguments::where_unique_argument(ctx, model).map(|arg| {
-        let field_name = format!("findUniqueOrThrow{}", model.name);
+        let field_name = format!("findUnique{}OrThrow", model.name);
 
         field(
             field_name,
@@ -92,7 +92,7 @@ fn find_first_field(ctx: &mut BuilderContext, model: &ModelRef) -> OutputField {
 /// not exist
 fn find_first_or_throw_field(ctx: &mut BuilderContext, model: &ModelRef) -> OutputField {
     let args = arguments::relation_selection_arguments(ctx, model, true);
-    let field_name = format!("findFirstOrThrow{}", model.name);
+    let field_name = format!("findFirst{}OrThrow", model.name);
 
     field(
         field_name,

--- a/query-engine/schema/src/query_schema.rs
+++ b/query-engine/schema/src/query_schema.rs
@@ -146,7 +146,9 @@ pub struct QueryInfo {
 #[derive(Debug, Clone, PartialEq)]
 pub enum QueryTag {
     FindUnique,
+    FindUniqueOrThrow,
     FindFirst,
+    FindFirstOrThrow,
     FindMany,
     CreateOne,
     CreateMany,
@@ -165,7 +167,9 @@ impl fmt::Display for QueryTag {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let s = match self {
             Self::FindUnique => "findUnique",
+            Self::FindUniqueOrThrow => "findUniqueOrThrow",
             Self::FindFirst => "findFirst",
+            Self::FindFirstOrThrow => "findFirstOrThrow",
             Self::FindMany => "findMany",
             Self::CreateOne => "createOne",
             Self::CreateMany => "createMany",


### PR DESCRIPTION
Fixes: https://github.com/prisma/prisma/issues/14933

This PR implements the following APIs in the engine:
* `findFirstOrThrowModelName`
* `findUniqueOrThrowModelName`

Both APIs are currently implemented in the client side using `findFirstModelName` and `findUniqueModelName` engine APIs, and throwing an error in case they return 0 results.

After this change is merged, the client would need to remove the code that handles `findUniqueOrThrow` and `findFirstOrThrow` to use instead the newly created query-engine APIs. 

I will work on a PR in prisma/prisma to address client changes next. 