### PR TITLE
schema-describer: correctly gather namespaces from databases

### DIFF
--- a/libs/sql-schema-describer/src/postgres.rs
+++ b/libs/sql-schema-describer/src/postgres.rs
@@ -596,7 +596,7 @@ impl<'a> SqlSchemaDescriber<'a> {
             .conn
             .query_raw(
                 sql,
-                &[Array(Some(namespaces.iter().map(|s| s.clone().into()).collect()))],
+                &[Array(Some(namespaces.iter().map(|s| (*s).into()).collect()))],
             )
             .await?;
 

--- a/libs/sql-schema-describer/src/postgres.rs
+++ b/libs/sql-schema-describer/src/postgres.rs
@@ -600,9 +600,7 @@ impl<'a> SqlSchemaDescriber<'a> {
             )
             .await?;
 
-        let names = rows
-            .into_iter()
-            .map(|row| (row.get_expect_string("namespace_name")));
+        let names = rows.into_iter().map(|row| (row.get_expect_string("namespace_name")));
 
         for namespace in names {
             sql_schema.push_namespace(namespace);

--- a/libs/sql-schema-describer/src/postgres.rs
+++ b/libs/sql-schema-describer/src/postgres.rs
@@ -440,10 +440,12 @@ impl<'a> super::SqlSchemaDescriberBackend for SqlSchemaDescriber<'a> {
         Ok(self.get_databases().await?)
     }
 
+    // TODO(MultiSchema): this going to provide wrong results with respect to MultiSchema,
+    // but this function does not seem to be called all that much. Should probably look into
+    // either updating or removing it.
     async fn get_metadata(&self, schema: &str) -> DescriberResult<SqlMetadata> {
         let mut sql_schema = SqlSchema::default();
 
-        // TODO(MultiSchema): is this correct?
         self.get_namespaces(&mut sql_schema, &[schema]).await?;
 
         let table_count = self.get_table_names(&mut sql_schema).await?.len();
@@ -594,10 +596,7 @@ impl<'a> SqlSchemaDescriber<'a> {
 
         let rows = self
             .conn
-            .query_raw(
-                sql,
-                &[Array(Some(namespaces.iter().map(|s| (*s).into()).collect()))],
-            )
+            .query_raw(sql, &[Array(Some(namespaces.iter().map(|s| (*s).into()).collect()))])
             .await?;
 
         let names = rows.into_iter().map(|row| (row.get_expect_string("namespace_name")));

--- a/libs/sql-schema-describer/src/postgres/namespaces_query.sql
+++ b/libs/sql-schema-describer/src/postgres/namespaces_query.sql
@@ -1,0 +1,4 @@
+SELECT namespace.nspname as namespace_name
+FROM pg_namespace as namespace
+WHERE namespace.nspname = ANY ( $1 )
+ORDER BY namespace_name;

--- a/libs/sql-schema-describer/tests/describers/postgres_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/postgres_describer_tests.rs
@@ -5,6 +5,22 @@ use pretty_assertions::assert_eq;
 use psl::dml::PrismaValue;
 use sql_schema_describer::{postgres::PostgresSchemaExt, *};
 
+#[test_connector(tags(Postgres))]
+fn postgres_detects_namespaces(api: TestApi) {
+    let full_sql = r#"
+        CREATE SCHEMA "one";
+        CREATE SCHEMA "two";
+    "#;
+
+    api.raw_cmd(full_sql);
+    let schema = api.describe_with_schemas(&["one", "three"]);
+
+    schema
+        .assert_namespace("one")
+        .assert_not_namespace("two")
+        .assert_not_namespace("three");
+}
+
 #[test_connector(tags(Postgres), exclude(CockroachDb))]
 fn views_can_be_described(api: TestApi) {
     let full_sql = r#"

--- a/libs/sql-schema-describer/tests/describers/postgres_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/postgres_describer_tests.rs
@@ -14,9 +14,7 @@ fn postgres_skips_nonexisting_namespaces(api: TestApi) {
     api.raw_cmd(full_sql);
     let schema = api.describe_with_schemas(&["one", "two"]);
 
-    schema
-        .assert_namespace("one")
-        .assert_not_namespace("two");
+    schema.assert_namespace("one").assert_not_namespace("two");
 }
 
 #[test_connector(tags(Postgres))]
@@ -29,9 +27,7 @@ fn postgres_skips_ignored_namespaces(api: TestApi) {
     api.raw_cmd(full_sql);
     let schema = api.describe_with_schemas(&["one"]);
 
-    schema
-        .assert_namespace("one")
-        .assert_not_namespace("two");
+    schema.assert_namespace("one").assert_not_namespace("two");
 }
 
 #[test_connector(tags(Postgres))]
@@ -44,9 +40,7 @@ fn postgres_skips_public_when_ignored_namespaces(api: TestApi) {
     api.raw_cmd(full_sql);
     let schema = api.describe_with_schemas(&["one"]);
 
-    schema
-        .assert_namespace("one")
-        .assert_not_namespace("public");
+    schema.assert_namespace("one").assert_not_namespace("public");
 }
 
 #[test_connector(tags(Postgres))]
@@ -65,7 +59,6 @@ fn postgres_many_namespaces(api: TestApi) {
         .assert_namespace("two")
         .assert_namespace("three");
 }
-
 
 #[test_connector(tags(Postgres), exclude(CockroachDb))]
 fn views_can_be_described(api: TestApi) {

--- a/libs/sql-schema-describer/tests/test_api/mod.rs
+++ b/libs/sql-schema-describer/tests/test_api/mod.rs
@@ -138,6 +138,10 @@ pub trait SqlSchemaAssertionsExt {
         table_name: &str,
         assertions: impl for<'a> FnOnce(&'a TableAssertion<'a>) -> &'a TableAssertion<'a>,
     ) -> &Self;
+
+    fn assert_namespace(&self, namespace_name: &str) -> &Self;
+
+    fn assert_not_namespace(&self, namespace_name: &str) -> &Self;
 }
 
 impl SqlSchemaAssertionsExt for SqlSchema {
@@ -152,6 +156,16 @@ impl SqlSchemaAssertionsExt for SqlSchema {
 
         assertions(&mut table);
 
+        self
+    }
+
+    fn assert_namespace(&self, namespace_name: &str) -> &Self {
+        self.namespace_walker(namespace_name).or_else(|| panic!("Could not find namespace '{namespace_name}'"));
+        self
+    }
+
+    fn assert_not_namespace(&self, namespace_name: &str) -> &Self {
+        self.walk_namespaces().find(|ns| ns.name() == namespace_name).and_then::<(), _>(|_x| panic!("Found unexpected namespace '{namespace_name}'"));
         self
     }
 }

--- a/libs/sql-schema-describer/tests/test_api/mod.rs
+++ b/libs/sql-schema-describer/tests/test_api/mod.rs
@@ -160,12 +160,15 @@ impl SqlSchemaAssertionsExt for SqlSchema {
     }
 
     fn assert_namespace(&self, namespace_name: &str) -> &Self {
-        self.namespace_walker(namespace_name).or_else(|| panic!("Could not find namespace '{namespace_name}'"));
+        self.namespace_walker(namespace_name)
+            .or_else(|| panic!("Could not find namespace '{namespace_name}'"));
         self
     }
 
     fn assert_not_namespace(&self, namespace_name: &str) -> &Self {
-        self.walk_namespaces().find(|ns| ns.name() == namespace_name).and_then::<(), _>(|_x| panic!("Found unexpected namespace '{namespace_name}'"));
+        self.walk_namespaces()
+            .find(|ns| ns.name() == namespace_name)
+            .and_then::<(), _>(|_x| panic!("Found unexpected namespace '{namespace_name}'"));
         self
     }
 }


### PR DESCRIPTION
Problem originally reported by @Jolg42 in slack (a failing `prisma/prisma` test). See https://github.com/prisma/prisma/actions/runs/3360055877/jobs/5568789836#step:10:3076 for more details.

The problem here is that we're automagically pushing all the declared schemas in the database, as if they already exist, which is not the case. We need to double check, which is what this PR is fixing.