### PR TITLE
ie: replicate pre-datamodel-renderer single-field unique behaviour

### DIFF
--- a/introspection-engine/datamodel-renderer/src/datamodel/model.rs
+++ b/introspection-engine/datamodel-renderer/src/datamodel/model.rs
@@ -254,6 +254,7 @@ impl<'a> Model<'a> {
         let uniques: HashMap<&str, IndexFieldOptions> = dml_model
             .indices
             .iter()
+            .rev() // replicate existing behaviour on duplicate unique constraints
             .filter(|ix| ix.is_unique())
             .filter(|ix| ix.defined_on_field)
             .map(|ix| {

--- a/introspection-engine/introspection-engine-tests/tests/simple/postgres/multiple_single_field_unique_indexes.sql
+++ b/introspection-engine/introspection-engine-tests/tests/simple/postgres/multiple_single_field_unique_indexes.sql
@@ -1,0 +1,27 @@
+-- tags=postgres
+-- exclude=cockroachdb
+
+CREATE TABLE mymodel (
+    id UUID PRIMARY KEY,
+    thefield TEXT
+);
+
+CREATE UNIQUE INDEX unq2 ON mymodel(thefield);
+CREATE UNIQUE INDEX unq3 ON mymodel(thefield);
+CREATE UNIQUE INDEX unq1 ON mymodel(thefield);
+
+/*
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = "env(TEST_DATABASE_URL)"
+}
+
+model mymodel {
+  id       String  @id @db.Uuid
+  thefield String? @unique(map: "unq1")
+}
+*/


### PR DESCRIPTION
The first unique index defined on the field wins. This became visible in [introspection CI](https://prisma-company.slack.com/archives/C01778YKS00/p1667210096895049) after
https://github.com/prisma/prisma-engines/pull/3333/ was merged.

Arguably, we should instead introspect `@@unique()`s on the model for extra single-field uniques, but that would be a change.