### PR TITLE
migration-engine-tests: add a few basic multiSchema tests

### DIFF
--- a/introspection-engine/introspection-engine-tests/tests/multi_schema/mod.rs
+++ b/introspection-engine/introspection-engine-tests/tests/multi_schema/mod.rs
@@ -34,7 +34,7 @@ async fn multiple_schemas_without_schema_property_are_not_introspected(api: &Tes
     Ok(())
 }
 
-#[test_connector(tags(Postgres), preview_features("multiSchema"), db_schemas("first", "second"))]
+#[test_connector(tags(Postgres), preview_features("multiSchema"), namespaces("first", "second"))]
 async fn multiple_schemas_w_tables_are_introspected(api: &TestApi) -> TestResult {
     let schema_name = "first";
     let other_name = "second";
@@ -117,7 +117,7 @@ async fn multiple_schemas_w_tables_are_introspected(api: &TestApi) -> TestResult
 //     Ok(())
 // }
 
-#[test_connector(tags(Postgres), preview_features("multiSchema"), db_schemas("first", "second"))]
+#[test_connector(tags(Postgres), preview_features("multiSchema"), namespaces("first", "second"))]
 async fn multiple_schemas_w_cross_schema_are_introspected(api: &TestApi) -> TestResult {
     let schema_name = "first";
     let other_name = "second";
@@ -202,7 +202,7 @@ async fn multiple_schemas_w_cross_schema_are_introspected(api: &TestApi) -> Test
 //     Ok(())
 // }
 
-#[test_connector(tags(Postgres), preview_features("multiSchema"), db_schemas("first", "second"))]
+#[test_connector(tags(Postgres), preview_features("multiSchema"), namespaces("first", "second"))]
 async fn multiple_schemas_w_enums_are_introspected(api: &TestApi) -> TestResult {
     let schema_name = "first";
     let other_name = "second";

--- a/libs/test-macros/src/lib.rs
+++ b/libs/test-macros/src/lib.rs
@@ -143,7 +143,7 @@ impl TestConnectorAttrs {
 
                 return Ok(());
             }
-            p if p.is_ident("db_schemas") => {
+            p if p.is_ident("namespaces") => {
                 self.namespaces.reserve(list.nested.len());
 
                 for item in list.nested {

--- a/migration-engine/migration-engine-tests/src/test_api.rs
+++ b/migration-engine/migration-engine-tests/src/test_api.rs
@@ -223,6 +223,12 @@ impl TestApi {
         SchemaAssertion::new(schema, self.root.args.tags())
     }
 
+    #[track_caller]
+    pub fn assert_schema_with_namespaces(&mut self, namespaces: Option<Namespaces>) -> SchemaAssertion {
+        let schema: SqlSchema = tok(self.connector.describe_schema(namespaces)).unwrap();
+        SchemaAssertion::new(schema, self.root.args.tags())
+    }
+
     /// Render a valid datasource block, including database URL.
     pub fn datasource_block(&self) -> DatasourceBlock<'_> {
         self.root.datasource_block()

--- a/migration-engine/migration-engine-tests/tests/migrations/postgres.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/postgres.rs
@@ -1,4 +1,5 @@
 mod extensions;
+mod multi_schema;
 
 use migration_core::migration_connector::DiffTarget;
 use migration_engine_tests::test_api::*;

--- a/migration-engine/migration-engine-tests/tests/migrations/postgres/multi_schema.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/postgres/multi_schema.rs
@@ -128,4 +128,3 @@ fn multi_schema_add_table(api: TestApi) {
         .assert_has_table("Second")
         .assert_has_table("Third");
 }
-

--- a/migration-engine/migration-engine-tests/tests/migrations/postgres/multi_schema.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/postgres/multi_schema.rs
@@ -1,0 +1,131 @@
+use indoc::indoc;
+use migration_core::migration_connector::Namespaces;
+use migration_engine_tests::test_api::*;
+
+#[test_connector(
+    tags(Postgres),
+    exclude(CockroachDb),
+    preview_features("multiSchema"),
+    namespaces("one", "two")
+)]
+fn multi_schema_basic(api: TestApi) {
+    let dm = indoc! {r#"
+        datasource db {
+          provider   = "postgresql"
+          url        = env("TEST_DATABASE_URL")
+          schemas    = ["one", "two"]
+        }
+
+        generator js {
+          provider        = "prisma-client-js"
+          previewFeatures = ["multiSchema"]
+        }
+
+        model First {
+          id Int @id
+          @@schema("one")
+        }
+
+        model Second {
+          id Int @id
+          @@schema("two")
+        }
+    "#};
+
+    let mut vec_namespaces = vec![String::from("one"), String::from("two")];
+    let namespaces = Namespaces::from_vec(&mut vec_namespaces);
+
+    api.schema_push(dm).send().assert_green().assert_has_executed_steps();
+
+    api.assert_schema_with_namespaces(namespaces)
+        .assert_has_table("First")
+        .assert_has_table("Second");
+}
+
+#[test_connector(
+    tags(Postgres),
+    exclude(CockroachDb),
+    preview_features("multiSchema"),
+    namespaces("one", "two")
+)]
+fn multi_schema_idempotent(api: TestApi) {
+    let dm = indoc! {r#"
+        datasource db {
+          provider   = "postgresql"
+          url        = env("TEST_DATABASE_URL")
+          schemas    = ["one", "two"]
+        }
+
+        generator js {
+          provider        = "prisma-client-js"
+          previewFeatures = ["multiSchema"]
+        }
+
+        model First {
+          id Int @id
+          @@schema("one")
+        }
+
+        model Second {
+          id Int @id
+          @@schema("two")
+        }
+    "#};
+
+    api.schema_push(dm).send().assert_green().assert_has_executed_steps();
+    api.schema_push(dm).send().assert_green().assert_no_steps();
+}
+
+#[test_connector(
+    tags(Postgres),
+    exclude(CockroachDb),
+    preview_features("multiSchema"),
+    namespaces("one", "two")
+)]
+fn multi_schema_add_table(api: TestApi) {
+    let first = indoc! {r#"
+        datasource db {
+          provider   = "postgresql"
+          url        = env("TEST_DATABASE_URL")
+          schemas    = ["one", "two"]
+        }
+
+        generator js {
+          provider        = "prisma-client-js"
+          previewFeatures = ["multiSchema"]
+        }
+
+        model First {
+          id Int @id
+          @@schema("one")
+        }
+
+        model Second {
+          id Int @id
+          @@schema("two")
+        }
+    "#};
+    let second = first.to_owned()
+        + indoc! {r#"
+
+        model Third {
+          id Int @id
+          @@schema("one")
+        }
+    "#};
+
+    api.schema_push(first).send().assert_green().assert_has_executed_steps();
+    api.schema_push(second)
+        .send()
+        .assert_green()
+        .assert_has_executed_steps();
+
+    let mut vec_namespaces = vec![String::from("one"), String::from("two")];
+    let namespaces = Namespaces::from_vec(&mut vec_namespaces);
+
+    api.assert_schema_with_namespaces(namespaces)
+        .assert_has_table("First")
+        .assert_has_table("Second")
+        .assert_has_table("Third");
+}
+


### PR DESCRIPTION
This PR adds a few basic `multiSchema` tests and renames `db_schemas` to `namespaces` in the arguments for `test_connector`.