### PR TITLE
nix: update to Rust 1.65.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,9 +54,6 @@ features = [
   "uuid",
 ]
 
-[profile.dev]
-split-debuginfo = "unpacked"
-
 [profile.dev.package.backtrace]
 opt-level = 3
 

--- a/flake.lock
+++ b/flake.lock
@@ -14,11 +14,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1666567222,
-        "narHash": "sha256-AVySilLW+eNM409GSIJYsF6wg5NsxK12Ht2DMSYAgO0=",
+        "lastModified": 1667356260,
+        "narHash": "sha256-Hh2yQESz6G0qYA2Dw8aoua52z2iojI+qhsGkyuxJ/zw=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "2ce1a3313e299b0db63b11f94c863af74b0b08ad",
+        "rev": "0ac39916b32a01d05b9a0219ad4b108a510bb265",
         "type": "github"
       },
       "original": {
@@ -45,11 +45,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
         "type": "github"
       },
       "original": {
@@ -60,11 +60,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1666703756,
-        "narHash": "sha256-GwpMJ1hT+z1fMAUkaGtvbvofJQwdVFDEGVhfE82+AUk=",
+        "lastModified": 1667231093,
+        "narHash": "sha256-RERXruzBEBuf0c7OfZeX1hxEKB+PTCUNxWeB6C1jd8Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f994293d1eb8812f032e8919e10a594567cf6ef7",
+        "rev": "d40fea9aeb8840fea0d377baa4b38e39b9582458",
         "type": "github"
       },
       "original": {
@@ -91,11 +91,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1666839029,
-        "narHash": "sha256-gmSmf3bDS9oR4OHsvKHEErqje228XXP22uKIQWZj4Jo=",
+        "lastModified": 1667487142,
+        "narHash": "sha256-bVuzLs1ZVggJAbJmEDVO9G6p8BH3HRaolK70KXvnWnU=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "c095030cf6c84e304f867ad066d8d5b051131af5",
+        "rev": "cf668f737ac986c0a89e83b6b2e3c5ddbd8cf33b",
         "type": "github"
       },
       "original": {

--- a/introspection-engine/connectors/sql-introspection-connector/src/warnings.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/warnings.rs
@@ -73,7 +73,7 @@ pub(crate) fn warning_models_without_identifier(affected: &[Model]) -> Warning {
     Warning {
         code: 1,
         message: "The following models were commented out as they do not have a valid unique identifier or id. This is currently not supported by the Prisma Client.".into(),
-        affected: serde_json::to_value(&affected).unwrap(),
+        affected: serde_json::to_value(affected).unwrap(),
     }
 }
 
@@ -82,7 +82,7 @@ pub(crate) fn warning_fields_with_empty_names(affected: &[ModelAndField]) -> War
         code: 2,
         message: "These fields were commented out because their names are currently not supported by Prisma. Please provide valid ones that match [a-zA-Z][a-zA-Z0-9_]* using the `@map` attribute."
             .into(),
-        affected: serde_json::to_value(&affected).unwrap(),
+        affected: serde_json::to_value(affected).unwrap(),
     }
 }
 
@@ -90,7 +90,7 @@ pub(crate) fn warning_unsupported_types(affected: &[ModelAndFieldAndType]) -> Wa
     Warning {
         code: 3,
         message: "These fields are not supported by the Prisma Client, because Prisma currently does not support their types.".into(),
-        affected: serde_json::to_value(&affected).unwrap(),
+        affected: serde_json::to_value(affected).unwrap(),
     }
 }
 
@@ -99,7 +99,7 @@ pub(crate) fn warning_enum_values_with_empty_names(affected: &[EnumAndValue]) ->
         code: 4,
         message: "These enum values were commented out because their names are currently not supported by Prisma. Please provide valid ones that match [a-zA-Z][a-zA-Z0-9_]* using the `@map` attribute."
             .into(),
-        affected: serde_json::to_value(&affected).unwrap(),
+        affected: serde_json::to_value(affected).unwrap(),
     }
 }
 
@@ -109,7 +109,7 @@ pub(crate) fn warning_default_cuid_warning(affected: &[ModelAndField]) -> Warnin
         message:
             "These id fields had a `@default(cuid())` added because we believe the schema was created by Prisma 1."
                 .into(),
-        affected: serde_json::to_value(&affected).unwrap(),
+        affected: serde_json::to_value(affected).unwrap(),
     }
 }
 
@@ -119,7 +119,7 @@ pub(crate) fn warning_default_uuid_warning(affected: &[ModelAndField]) -> Warnin
         message:
             "These id fields had a `@default(uuid())` added because we believe the schema was created by Prisma 1."
                 .into(),
-        affected: serde_json::to_value(&affected).unwrap(),
+        affected: serde_json::to_value(affected).unwrap(),
     }
 }
 
@@ -127,7 +127,7 @@ pub(crate) fn warning_enriched_with_map_on_model(affected: &[Model]) -> Warning 
     Warning {
         code: 7,
         message: "These models were enriched with `@@map` information taken from the previous Prisma schema.".into(),
-        affected: serde_json::to_value(&affected).unwrap(),
+        affected: serde_json::to_value(affected).unwrap(),
     }
 }
 
@@ -135,7 +135,7 @@ pub(crate) fn warning_enriched_with_map_on_field(affected: &[ModelAndField]) -> 
     Warning {
         code: 8,
         message: "These fields were enriched with `@map` information taken from the previous Prisma schema.".into(),
-        affected: serde_json::to_value(&affected).unwrap(),
+        affected: serde_json::to_value(affected).unwrap(),
     }
 }
 
@@ -143,7 +143,7 @@ pub(crate) fn warning_enriched_with_map_on_enum(affected: &[Enum]) -> Warning {
     Warning {
         code: 9,
         message: "These enums were enriched with `@@map` information taken from the previous Prisma schema.".into(),
-        affected: serde_json::to_value(&affected).unwrap(),
+        affected: serde_json::to_value(affected).unwrap(),
     }
 }
 
@@ -152,7 +152,7 @@ pub(crate) fn warning_enriched_with_map_on_enum_value(affected: &[EnumAndValue])
         code: 10,
         message: "These enum values were enriched with `@map` information taken from the previous Prisma schema."
             .into(),
-        affected: serde_json::to_value(&affected).unwrap(),
+        affected: serde_json::to_value(affected).unwrap(),
     }
 }
 
@@ -162,7 +162,7 @@ pub(crate) fn warning_enriched_with_cuid(affected: &[ModelAndField]) -> Warning 
         message:
             "These id fields were enriched with `@default(cuid())` information taken from the previous Prisma schema."
                 .into(),
-        affected: serde_json::to_value(&affected).unwrap(),
+        affected: serde_json::to_value(affected).unwrap(),
     }
 }
 
@@ -172,7 +172,7 @@ pub(crate) fn warning_enriched_with_uuid(affected: &[ModelAndField]) -> Warning 
         message:
             "These id fields were enriched with `@default(uuid())` information taken from the previous Prisma schema."
                 .into(),
-        affected: serde_json::to_value(&affected).unwrap(),
+        affected: serde_json::to_value(affected).unwrap(),
     }
 }
 
@@ -182,7 +182,7 @@ pub(crate) fn warning_enriched_with_updated_at(affected: &[ModelAndField]) -> Wa
         message:
             "These DateTime fields were enriched with `@updatedAt` information taken from the previous Prisma schema."
                 .into(),
-        affected: serde_json::to_value(&affected).unwrap(),
+        affected: serde_json::to_value(affected).unwrap(),
     }
 }
 
@@ -192,7 +192,7 @@ pub(crate) fn warning_models_without_columns(affected: &[Model]) -> Warning {
     Warning {
         code: 14,
         message: "The following models were commented out as we could not retrieve columns for them. Please check your privileges.".into(),
-        affected: serde_json::to_value(&affected).unwrap(),
+        affected: serde_json::to_value(affected).unwrap(),
     }
 }
 
@@ -200,7 +200,7 @@ pub(crate) fn warning_enriched_with_custom_index_names(affected: &[ModelAndIndex
     Warning {
         code: 17,
         message: "These Indices were enriched with custom index names taken from the previous Prisma schema.".into(),
-        affected: serde_json::to_value(&affected).unwrap(),
+        affected: serde_json::to_value(affected).unwrap(),
     }
 }
 
@@ -209,7 +209,7 @@ pub(crate) fn warning_enriched_with_custom_primary_key_names(affected: &[Model])
         code: 18,
         message: "These models were enriched with custom compound id names taken from the previous Prisma schema."
             .into(),
-        affected: serde_json::to_value(&affected).unwrap(),
+        affected: serde_json::to_value(affected).unwrap(),
     }
 }
 

--- a/introspection-engine/core/build.rs
+++ b/introspection-engine/core/build.rs
@@ -1,7 +1,7 @@
 use std::process::Command;
 
 fn store_git_commit_hash() {
-    let output = Command::new("git").args(&["rev-parse", "HEAD"]).output().unwrap();
+    let output = Command::new("git").args(["rev-parse", "HEAD"]).output().unwrap();
     let git_hash = String::from_utf8(output.stdout).unwrap();
     println!("cargo:rustc-env=GIT_HASH={}", git_hash);
 }

--- a/introspection-engine/datamodel-renderer/src/datamodel/model.rs
+++ b/introspection-engine/datamodel-renderer/src/datamodel/model.rs
@@ -506,14 +506,14 @@ mod tests {
         id.clustered(false);
         model.id(id);
 
-        let unique = IndexDefinition::unique(["foo", "bar"].iter().map(|s| IndexFieldInput::new(*s)));
+        let unique = IndexDefinition::unique(["foo", "bar"].iter().map(|s| IndexFieldInput::new(s)));
         model.push_index(unique);
 
-        let mut index = IndexDefinition::index(["foo", "bar"].iter().map(|s| IndexFieldInput::new(*s)));
+        let mut index = IndexDefinition::index(["foo", "bar"].iter().map(|s| IndexFieldInput::new(s)));
         index.index_type("BTree");
         model.push_index(index);
 
-        let fulltext = IndexDefinition::fulltext(["foo", "bar"].iter().map(|s| IndexFieldInput::new(*s)));
+        let fulltext = IndexDefinition::fulltext(["foo", "bar"].iter().map(|s| IndexFieldInput::new(s)));
         model.push_index(fulltext);
 
         model.schema("public");

--- a/introspection-engine/introspection-engine-tests/build.rs
+++ b/introspection-engine/introspection-engine-tests/build.rs
@@ -14,7 +14,7 @@ fn main() {
 
     for sql_file in &all_sql_files {
         let test_name = sql_file.trim_start_matches('/').trim_end_matches(".sql");
-        let test_name = test_name.replace(&['/', '\\'], "_");
+        let test_name = test_name.replace(['/', '\\'], "_");
         let file_path = sql_file.trim_start_matches('/');
         writeln!(
             out_file,

--- a/introspection-engine/introspection-engine-tests/tests/commenting_out/cockroachdb.rs
+++ b/introspection-engine/introspection-engine-tests/tests/commenting_out/cockroachdb.rs
@@ -12,7 +12,7 @@ async fn a_table_without_uniques_should_ignore(api: &TestApi) -> TestResult {
             migration.create_table("Post", |t| {
                 t.add_column("id", types::integer());
                 t.add_column("user_id", types::integer().nullable(false));
-                t.add_index("Post_user_id_idx", types::index(&["user_id"]));
+                t.add_index("Post_user_id_idx", types::index(["user_id"]));
                 t.add_foreign_key(&["user_id"], "User", &["id"]);
             });
         })

--- a/introspection-engine/introspection-engine-tests/tests/commenting_out/mod.rs
+++ b/introspection-engine/introspection-engine-tests/tests/commenting_out/mod.rs
@@ -17,7 +17,7 @@ async fn a_table_without_uniques_should_ignore(api: &TestApi) -> TestResult {
             migration.create_table("Post", |t| {
                 t.add_column("id", types::integer());
                 t.add_column("user_id", types::integer().nullable(false));
-                t.add_index("Post_user_id_idx", types::index(&["user_id"]));
+                t.add_index("Post_user_id_idx", types::index(["user_id"]));
                 t.add_foreign_key(&["user_id"], "User", &["id"]);
             });
         })

--- a/introspection-engine/introspection-engine-tests/tests/commenting_out/mssql.rs
+++ b/introspection-engine/introspection-engine-tests/tests/commenting_out/mssql.rs
@@ -12,7 +12,7 @@ async fn a_table_without_uniques_should_ignore(api: &TestApi) -> TestResult {
             migration.create_table("Post", |t| {
                 t.add_column("id", types::integer());
                 t.add_column("user_id", types::integer().nullable(false));
-                t.add_index("Post_user_id_idx", types::index(&["user_id"]));
+                t.add_index("Post_user_id_idx", types::index(["user_id"]));
                 t.add_constraint(
                     "thefk",
                     types::foreign_constraint(&["user_id"], "User", &["id"], None, None),

--- a/introspection-engine/introspection-engine-tests/tests/commenting_out/mysql.rs
+++ b/introspection-engine/introspection-engine-tests/tests/commenting_out/mysql.rs
@@ -37,7 +37,7 @@ async fn a_table_without_uniques_should_ignore(api: &TestApi) -> TestResult {
             migration.create_table("Post", |t| {
                 t.add_column("id", types::integer());
                 t.add_column("user_id", types::integer().nullable(false));
-                t.add_index("Post_user_id_idx", types::index(&["user_id"]));
+                t.add_index("Post_user_id_idx", types::index(["user_id"]));
 
                 t.inject_custom(
                     "CONSTRAINT user_id FOREIGN KEY (user_id) REFERENCES `User`(id) ON DELETE RESTRICT ON UPDATE CASCADE",

--- a/introspection-engine/introspection-engine-tests/tests/named_constraints/mod.rs
+++ b/introspection-engine/introspection-engine-tests/tests/named_constraints/mod.rs
@@ -18,13 +18,13 @@ async fn introspecting_non_default_pkey_names_works(api: &TestApi) -> TestResult
         .execute(|migration| {
             migration.create_table("Single", move |t| {
                 t.add_column("id", types::integer().increments(true).nullable(false));
-                t.add_constraint("SomethingCustom", types::primary_constraint(&["id"]));
+                t.add_constraint("SomethingCustom", types::primary_constraint(["id"]));
             });
 
             migration.create_table("Compound", move |t| {
                 t.add_column("a", types::integer().increments(false).nullable(false));
                 t.add_column("b", types::integer().increments(false).nullable(false));
-                t.add_constraint("SomethingCustomCompound", types::primary_constraint(&["a", "b"]));
+                t.add_constraint("SomethingCustomCompound", types::primary_constraint(["a", "b"]));
             });
         })
         .await?;
@@ -53,13 +53,13 @@ async fn introspecting_default_pkey_names_works(api: &TestApi) -> TestResult {
         .execute(|migration| {
             migration.create_table("Single", move |t| {
                 t.add_column("id", types::integer().increments(true).nullable(false));
-                t.add_constraint("Single_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("Single_pkey", types::primary_constraint(["id"]));
             });
 
             migration.create_table("Compound", move |t| {
                 t.add_column("a", types::integer().increments(false).nullable(false));
                 t.add_column("b", types::integer().increments(false).nullable(false));
-                t.add_constraint("Compound_pkey", types::primary_constraint(&["a", "b"]));
+                t.add_constraint("Compound_pkey", types::primary_constraint(["a", "b"]));
             });
         })
         .await?;
@@ -88,13 +88,13 @@ async fn introspecting_non_default_unique_constraint_names_works(api: &TestApi) 
         .execute(|migration| {
             migration.create_table("Single", move |t| {
                 t.add_column("id", types::integer().increments(true).nullable(false));
-                t.add_constraint("SomethingCustom", types::unique_constraint(&["id"]));
+                t.add_constraint("SomethingCustom", types::unique_constraint(["id"]));
             });
 
             migration.create_table("Compound", move |t| {
                 t.add_column("a", types::integer().increments(false).nullable(false));
                 t.add_column("b", types::integer().increments(false).nullable(false));
-                t.add_constraint("SomethingCustomCompound", types::unique_constraint(&["a", "b"]));
+                t.add_constraint("SomethingCustomCompound", types::unique_constraint(["a", "b"]));
             });
         })
         .await?;
@@ -123,13 +123,13 @@ async fn introspecting_default_unique_names_works(api: &TestApi) -> TestResult {
         .execute(|migration| {
             migration.create_table("Single", move |t| {
                 t.add_column("id", types::integer().increments(true).nullable(false));
-                t.add_constraint("Single_id_key", types::unique_constraint(&["id"]));
+                t.add_constraint("Single_id_key", types::unique_constraint(["id"]));
             });
 
             migration.create_table("Compound", move |t| {
                 t.add_column("a", types::integer().increments(false).nullable(false));
                 t.add_column("b", types::integer().increments(false).nullable(false));
-                t.add_constraint("Compound_a_b_key", types::unique_constraint(&["a", "b"]));
+                t.add_constraint("Compound_a_b_key", types::unique_constraint(["a", "b"]));
             });
         })
         .await?;
@@ -158,13 +158,13 @@ async fn introspecting_non_default_index_names_works(api: &TestApi) -> TestResul
         .execute(|migration| {
             migration.create_table("Single", move |t| {
                 t.add_column("id", types::integer().increments(true).nullable(false));
-                t.add_index("SomethingCustom", types::index(&["id"]));
+                t.add_index("SomethingCustom", types::index(["id"]));
             });
 
             migration.create_table("Compound", move |t| {
                 t.add_column("a", types::integer().increments(false).nullable(false));
                 t.add_column("b", types::integer().increments(false).nullable(false));
-                t.add_index("SomethingCustomCompound", types::index(&["a", "b"]));
+                t.add_index("SomethingCustomCompound", types::index(["a", "b"]));
             });
         })
         .await?;
@@ -199,13 +199,13 @@ async fn introspecting_default_index_names_works(api: &TestApi) -> TestResult {
         .execute(|migration| {
             migration.create_table("Single", move |t| {
                 t.add_column("id", types::integer().increments(true).nullable(false));
-                t.add_index("Single_id_idx", types::index(&["id"]));
+                t.add_index("Single_id_idx", types::index(["id"]));
             });
 
             migration.create_table("Compound", move |t| {
                 t.add_column("a", types::integer().increments(false).nullable(false));
                 t.add_column("b", types::integer().increments(false).nullable(false));
-                t.add_index("Compound_a_b_idx", types::index(&["a", "b"]));
+                t.add_index("Compound_a_b_idx", types::index(["a", "b"]));
             });
         })
         .await?;
@@ -240,14 +240,14 @@ async fn introspecting_default_fk_names_works(api: &TestApi) -> TestResult {
         .execute(move |migration| {
             migration.create_table("User", |t| {
                 t.add_column("id", types::integer().increments(true).nullable(false));
-                t.add_constraint("User_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("User_pkey", types::primary_constraint(["id"]));
             });
 
             migration.create_table("Post", move |t| {
                 t.add_column("id", types::integer().increments(true).nullable(false));
-                t.add_constraint("Post_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("Post_pkey", types::primary_constraint(["id"]));
                 t.add_column("user_id", types::integer().nullable(false));
-                t.add_index("Post_user_id_idx", types::index(&["user_id"]));
+                t.add_index("Post_user_id_idx", types::index(["user_id"]));
                 t.add_constraint(
                     "Post_user_id_fkey",
                     types::foreign_constraint(&["user_id"], "User", &["id"], None, None),
@@ -282,14 +282,14 @@ async fn introspecting_custom_fk_names_works(api: &TestApi) -> TestResult {
         .execute(move |migration| {
             migration.create_table("User", |t| {
                 t.add_column("id", types::integer().increments(true).nullable(false));
-                t.add_constraint("User_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("User_pkey", types::primary_constraint(["id"]));
             });
 
             migration.create_table("Post", move |t| {
                 t.add_column("id", types::integer().increments(true).nullable(false));
-                t.add_constraint("Post_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("Post_pkey", types::primary_constraint(["id"]));
                 t.add_column("user_id", types::integer().nullable(false));
-                t.add_index("Post_user_id_idx", types::index(&["user_id"]));
+                t.add_index("Post_user_id_idx", types::index(["user_id"]));
                 t.add_constraint(
                     "CustomFKName",
                     types::foreign_constraint(&["user_id"], "User", &["id"], None, None),

--- a/introspection-engine/introspection-engine-tests/tests/named_constraints/mssql.rs
+++ b/introspection-engine/introspection-engine-tests/tests/named_constraints/mssql.rs
@@ -10,14 +10,14 @@ async fn introspecting_custom_fk_names_works(api: &TestApi) -> TestResult {
         .execute(move |migration| {
             migration.create_table("User", |t| {
                 t.add_column("id", types::integer().increments(true).nullable(false));
-                t.add_constraint("User_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("User_pkey", types::primary_constraint(["id"]));
             });
 
             migration.create_table("Post", move |t| {
                 t.add_column("id", types::integer().increments(true).nullable(false));
-                t.add_constraint("Post_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("Post_pkey", types::primary_constraint(["id"]));
                 t.add_column("user_id", types::integer().nullable(false));
-                t.add_index("Post_user_id_idx", types::index(&["user_id"]));
+                t.add_index("Post_user_id_idx", types::index(["user_id"]));
                 t.add_constraint(
                     "CustomFKName",
                     types::foreign_constraint(&["user_id"], "User", &["id"], None, None),
@@ -52,14 +52,14 @@ async fn introspecting_default_fk_names_works(api: &TestApi) -> TestResult {
         .execute(move |migration| {
             migration.create_table("User", |t| {
                 t.add_column("id", types::integer().increments(true).nullable(false));
-                t.add_constraint("User_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("User_pkey", types::primary_constraint(["id"]));
             });
 
             migration.create_table("Post", move |t| {
                 t.add_column("id", types::integer().increments(true).nullable(false));
-                t.add_constraint("Post_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("Post_pkey", types::primary_constraint(["id"]));
                 t.add_column("user_id", types::integer().nullable(false));
-                t.add_index("Post_user_id_idx", types::index(&["user_id"]));
+                t.add_index("Post_user_id_idx", types::index(["user_id"]));
                 t.add_constraint(
                     "Post_user_id_fkey",
                     types::foreign_constraint(&["user_id"], "User", &["id"], None, None),

--- a/introspection-engine/introspection-engine-tests/tests/named_constraints/mysql.rs
+++ b/introspection-engine/introspection-engine-tests/tests/named_constraints/mysql.rs
@@ -13,14 +13,14 @@ async fn introspecting_custom_fk_names_works(api: &TestApi) -> TestResult {
         .execute(move |migration| {
             migration.create_table("User", |t| {
                 t.add_column("id", types::integer().increments(true).nullable(false));
-                t.add_constraint("User_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("User_pkey", types::primary_constraint(["id"]));
             });
 
             migration.create_table("Post", move |t| {
                 t.add_column("id", types::integer().increments(true).nullable(false));
-                t.add_constraint("Post_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("Post_pkey", types::primary_constraint(["id"]));
                 t.add_column("user_id", types::integer().nullable(false));
-                t.add_index("Post_user_id_idx", types::index(&["user_id"]));
+                t.add_index("Post_user_id_idx", types::index(["user_id"]));
                 t.inject_custom(
                     "CONSTRAINT CustomFKName FOREIGN KEY (user_id) REFERENCES `User`(id) ON DELETE RESTRICT ON UPDATE CASCADE",
                 );
@@ -54,14 +54,14 @@ async fn introspecting_default_fk_names_works(api: &TestApi) -> TestResult {
         .execute(move |migration| {
             migration.create_table("User", |t| {
                 t.add_column("id", types::integer().increments(true).nullable(false));
-                t.add_constraint("User_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("User_pkey", types::primary_constraint(["id"]));
             });
 
             migration.create_table("Post", move |t| {
                 t.add_column("id", types::integer().increments(true).nullable(false));
-                t.add_constraint("Post_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("Post_pkey", types::primary_constraint(["id"]));
                 t.add_column("user_id", types::integer().nullable(false));
-                t.add_index("Post_user_id_idx", types::index(&["user_id"]));
+                t.add_index("Post_user_id_idx", types::index(["user_id"]));
                 t.inject_custom(
                     "CONSTRAINT Post_user_id_fkey FOREIGN KEY (user_id) REFERENCES `User`(id) ON DELETE RESTRICT ON UPDATE CASCADE",
                 );

--- a/introspection-engine/introspection-engine-tests/tests/named_constraints/sqlite.rs
+++ b/introspection-engine/introspection-engine-tests/tests/named_constraints/sqlite.rs
@@ -10,14 +10,14 @@ async fn introspecting_custom_fk_names_does_not_return_them(api: &TestApi) -> Te
         .execute(move |migration| {
             migration.create_table("User", |t| {
                 t.add_column("id", types::integer().increments(true).nullable(false));
-                t.add_constraint("User_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("User_pkey", types::primary_constraint(["id"]));
             });
 
             migration.create_table("Post", move |t| {
                 t.add_column("id", types::integer().increments(true).nullable(false));
-                t.add_constraint("Post_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("Post_pkey", types::primary_constraint(["id"]));
                 t.add_column("user_id", types::integer().nullable(false));
-                t.add_index("Post_user_id_idx", types::index(&["user_id"]));
+                t.add_index("Post_user_id_idx", types::index(["user_id"]));
                 t.add_constraint(
                     "CustomFKName",
                     types::foreign_constraint(&["user_id"], "User", &["id"], None, None),

--- a/introspection-engine/introspection-engine-tests/tests/re_introspection/mod.rs
+++ b/introspection-engine/introspection-engine-tests/tests/re_introspection/mod.rs
@@ -69,12 +69,12 @@ async fn manually_overwritten_mapped_field_name(api: &TestApi) -> TestResult {
                 t.add_column("id", types::integer().increments(true));
                 t.add_column("_test", types::integer());
 
-                t.add_constraint("User_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("User_pkey", types::primary_constraint(["id"]));
             });
 
             migration.create_table("Unrelated", |t| {
                 t.add_column("id", types::integer().increments(true));
-                t.add_constraint("Unrelated_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("Unrelated_pkey", types::primary_constraint(["id"]));
             });
         })
         .await?;
@@ -261,7 +261,7 @@ async fn mapped_field_name(api: &TestApi) -> TestResult {
 
                 t.add_index("test2", types::index(vec!["index"]));
 
-                t.add_constraint("User_pkey", types::primary_constraint(&["id_1", "id_2"]));
+                t.add_constraint("User_pkey", types::primary_constraint(["id_1", "id_2"]));
             });
 
             migration.create_table("Unrelated", |t| {
@@ -1570,7 +1570,7 @@ async fn do_not_try_to_keep_custom_many_to_many_self_relation_names(api: &TestAp
         .execute(|migration| {
             migration.create_table("User", move |t| {
                 t.add_column("id", types::integer().increments(true));
-                t.add_constraint("User_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("User_pkey", types::primary_constraint(["id"]));
             });
 
             migration.create_table("_FollowRelation", |t| {
@@ -1613,18 +1613,18 @@ async fn re_introspecting_custom_compound_unique_names(api: &TestApi) -> TestRes
         .execute(|migration| {
             migration.create_table("User", |t| {
                 t.add_column("id", types::integer().increments(true).nullable(false));
-                t.add_constraint("User_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("User_pkey", types::primary_constraint(["id"]));
                 t.add_column("first", types::integer());
                 t.add_column("last", types::integer());
                 t.add_index(
                     "User.something@invalid-and/weird",
-                    types::index(&["first", "last"]).unique(true),
+                    types::index(["first", "last"]).unique(true),
                 );
             });
 
             migration.create_table("Unrelated", |t| {
                 t.add_column("id", types::integer().increments(true).nullable(false));
-                t.add_constraint("Unrelated_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("Unrelated_pkey", types::primary_constraint(["id"]));
             });
         })
         .await?;
@@ -1674,15 +1674,15 @@ async fn re_introspecting_custom_compound_unique_upgrade(api: &TestApi) -> TestR
         .execute(|migration| {
             migration.create_table("User", |t| {
                 t.add_column("id", types::integer().increments(true).nullable(false));
-                t.add_constraint("User_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("User_pkey", types::primary_constraint(["id"]));
                 t.add_column("first", types::integer());
                 t.add_column("last", types::integer());
-                t.add_index("compound", types::index(&["first", "last"]).unique(true));
+                t.add_index("compound", types::index(["first", "last"]).unique(true));
             });
 
             migration.create_table("Unrelated", |t| {
                 t.add_column("id", types::integer().increments(true).nullable(false));
-                t.add_constraint("Unrelated_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("Unrelated_pkey", types::primary_constraint(["id"]));
             });
         })
         .await?;
@@ -1735,19 +1735,19 @@ async fn re_introspecting_custom_compound_id_names(api: &TestApi) -> TestResult 
                 t.add_column("last", types::integer());
                 t.add_constraint(
                     "User.something@invalid-and/weird",
-                    types::primary_constraint(&["first", "last"]),
+                    types::primary_constraint(["first", "last"]),
                 );
             });
 
             migration.create_table("User2", |t| {
                 t.add_column("first", types::integer());
                 t.add_column("last", types::integer());
-                t.add_constraint("User2_pkey", types::primary_constraint(&["first", "last"]));
+                t.add_constraint("User2_pkey", types::primary_constraint(["first", "last"]));
             });
 
             migration.create_table("Unrelated", |t| {
                 t.add_column("id", types::integer().increments(true).nullable(false));
-                t.add_constraint("Unrelated_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("Unrelated_pkey", types::primary_constraint(["id"]));
             });
         })
         .await?;

--- a/introspection-engine/introspection-engine-tests/tests/re_introspection/mssql.rs
+++ b/introspection-engine/introspection-engine-tests/tests/re_introspection/mssql.rs
@@ -81,7 +81,7 @@ async fn multiple_changed_relation_names_due_to_mapped_models(api: &TestApi) -> 
         .execute(|migration| {
             migration.create_table("User", |t| {
                 t.add_column("id", types::integer().increments(true));
-                t.add_constraint("User_pkey", types::primary_constraint(&["id"]))
+                t.add_constraint("User_pkey", types::primary_constraint(["id"]))
             });
 
             migration.create_table("Post", |t| {
@@ -97,14 +97,14 @@ async fn multiple_changed_relation_names_due_to_mapped_models(api: &TestApi) -> 
                     "post_userid2_fk",
                     types::foreign_constraint(&["user_id2"], "User", &["id"], None, None),
                 );
-                t.add_constraint("Post_pkey", types::primary_constraint(&["id"]));
-                t.add_constraint("Post_user_id_key", types::unique_constraint(&["user_id"]));
-                t.add_constraint("Post_user_id2_key", types::unique_constraint(&["user_id2"]));
+                t.add_constraint("Post_pkey", types::primary_constraint(["id"]));
+                t.add_constraint("Post_user_id_key", types::unique_constraint(["user_id"]));
+                t.add_constraint("Post_user_id2_key", types::unique_constraint(["user_id2"]));
             });
 
             migration.create_table("Unrelated", |t| {
                 t.add_column("id", types::integer().increments(true));
-                t.add_constraint("Unrelated_pkey", types::primary_constraint(&["id"]))
+                t.add_constraint("Unrelated_pkey", types::primary_constraint(["id"]))
             });
         })
         .await?;
@@ -160,7 +160,7 @@ async fn mapped_model_and_field_name(api: &TestApi) -> TestResult {
         .execute(|migration| {
             migration.create_table("User", |t| {
                 t.add_column("id", types::integer().increments(true));
-                t.add_constraint("User_pkey", types::primary_constraint(&["id"]))
+                t.add_constraint("User_pkey", types::primary_constraint(["id"]))
             });
 
             migration.create_table("Post", |t| {
@@ -171,12 +171,12 @@ async fn mapped_model_and_field_name(api: &TestApi) -> TestResult {
                     "Post_fkey",
                     types::foreign_constraint(&["user_id"], "User", &["id"], None, None),
                 );
-                t.add_constraint("Post_pkey", types::primary_constraint(&["id"]))
+                t.add_constraint("Post_pkey", types::primary_constraint(["id"]))
             });
 
             migration.create_table("Unrelated", |t| {
                 t.add_column("id", types::integer().increments(true));
-                t.add_constraint("Unrelated_pkey", types::primary_constraint(&["id"]))
+                t.add_constraint("Unrelated_pkey", types::primary_constraint(["id"]))
             });
         })
         .await?;

--- a/introspection-engine/introspection-engine-tests/tests/relations/cockroachdb.rs
+++ b/introspection-engine/introspection-engine-tests/tests/relations/cockroachdb.rs
@@ -96,7 +96,7 @@ async fn a_self_relation(api: &TestApi) -> TestResult {
                     "direct_report_fkey",
                     types::foreign_constraint(&["direct_report"], "User", &["id"], None, None),
                 );
-                t.add_constraint("User_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("User_pkey", types::primary_constraint(["id"]));
             });
         })
         .await?;

--- a/introspection-engine/introspection-engine-tests/tests/relations/mod.rs
+++ b/introspection-engine/introspection-engine-tests/tests/relations/mod.rs
@@ -125,7 +125,7 @@ async fn a_one_to_one_relation(api: &TestApi) -> TestResult {
         .execute(|migration| {
             migration.create_table("User", |t| {
                 t.add_column("id", types::integer().increments(true));
-                t.add_constraint("User_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("User_pkey", types::primary_constraint(["id"]));
             });
 
             migration.create_table("Post", |t| {
@@ -136,8 +136,8 @@ async fn a_one_to_one_relation(api: &TestApi) -> TestResult {
                     "Post_user_id_fkey",
                     types::foreign_constraint(&["user_id"], "User", &["id"], None, None),
                 );
-                t.add_constraint("Post_pkey", types::primary_constraint(&["id"]));
-                t.add_constraint("Post_user_id_key", types::unique_constraint(&["user_id"]));
+                t.add_constraint("Post_pkey", types::primary_constraint(["id"]));
+                t.add_constraint("Post_user_id_key", types::unique_constraint(["user_id"]));
             });
         })
         .await?;
@@ -211,7 +211,7 @@ async fn a_one_to_many_relation(api: &TestApi) -> TestResult {
         .execute(|migration| {
             migration.create_table("User", |t| {
                 t.add_column("id", types::integer().increments(true));
-                t.add_constraint("User_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("User_pkey", types::primary_constraint(["id"]));
             });
 
             migration.create_table("Post", |t| {
@@ -221,7 +221,7 @@ async fn a_one_to_many_relation(api: &TestApi) -> TestResult {
                     "user_id_fkey",
                     types::foreign_constraint(&["user_id"], "User", &["id"], None, None),
                 );
-                t.add_constraint("Post_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("Post_pkey", types::primary_constraint(["id"]));
             });
         })
         .await?;
@@ -284,12 +284,12 @@ async fn a_prisma_many_to_many_relation(api: &TestApi) -> TestResult {
         .execute(|migration| {
             migration.create_table("User", |t| {
                 t.add_column("id", types::integer().increments(true));
-                t.add_constraint("User_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("User_pkey", types::primary_constraint(["id"]));
             });
 
             migration.create_table("Post", |t| {
                 t.add_column("id", types::integer().increments(true));
-                t.add_constraint("Post_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("Post_pkey", types::primary_constraint(["id"]));
             });
 
             migration.create_table("_PostToUser", |t| {
@@ -387,7 +387,7 @@ async fn a_self_relation(api: &TestApi) -> TestResult {
                     "direct_report_fkey",
                     types::foreign_constraint(&["direct_report"], "User", &["id"], None, None),
                 );
-                t.add_constraint("User_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("User_pkey", types::primary_constraint(["id"]));
             });
         })
         .await?;
@@ -449,14 +449,14 @@ async fn duplicate_fks_should_ignore_one_of_them(api: &TestApi) -> TestResult {
         .execute(|migration| {
             migration.create_table("User", |t| {
                 t.add_column("id", types::integer().increments(true));
-                t.add_constraint("User_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("User_pkey", types::primary_constraint(["id"]));
             });
 
             migration.create_table("Post", |t| {
                 t.add_column("id", types::integer().increments(true));
                 t.add_column("user_id", types::integer().nullable(true));
 
-                t.add_constraint("Post_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("Post_pkey", types::primary_constraint(["id"]));
             });
 
             migration.change_table("Post", |t| {
@@ -631,14 +631,14 @@ async fn one_to_one_req_relation_with_custom_fk_name(api: &TestApi) -> TestResul
         .execute(move |migration| {
             migration.create_table("User", |t| {
                 t.add_column("id", types::integer().increments(true).nullable(false));
-                t.add_constraint("User_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("User_pkey", types::primary_constraint(["id"]));
             });
 
             migration.create_table("Post", move |t| {
                 t.add_column("id", types::integer().increments(true).nullable(false));
-                t.add_constraint("Post_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("Post_pkey", types::primary_constraint(["id"]));
                 t.add_column("user_id", types::integer().nullable(false));
-                t.add_index("Post_user_id_key", types::index(&["user_id"]).unique(true));
+                t.add_index("Post_user_id_key", types::index(["user_id"]).unique(true));
                 t.add_constraint(
                     "CustomFKName",
                     types::foreign_constraint(&["user_id"], "User", &["id"], None, None),

--- a/introspection-engine/introspection-engine-tests/tests/relations/mssql.rs
+++ b/introspection-engine/introspection-engine-tests/tests/relations/mssql.rs
@@ -12,19 +12,19 @@ async fn two_one_to_one_relations_between_the_same_models(api: &TestApi) -> Test
             migration.create_table("User", move |t| {
                 t.add_column("id", types::integer().increments(true));
                 t.add_column("post_id", types::integer().nullable(false));
-                t.add_constraint("User_post_id_key", types::unique_constraint(&["post_id"]));
-                t.add_constraint("User_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("User_post_id_key", types::unique_constraint(["post_id"]));
+                t.add_constraint("User_pkey", types::primary_constraint(["id"]));
             });
 
             migration.create_table("Post", |t| {
                 t.add_column("id", types::integer().increments(true));
                 t.add_column("user_id", types::integer().nullable(false));
-                t.add_constraint("Post_user_id_key", types::unique_constraint(&["user_id"]));
+                t.add_constraint("Post_user_id_key", types::unique_constraint(["user_id"]));
                 t.add_constraint(
                     "post_fk",
                     types::foreign_constraint(&["user_id"], "User", &["id"], None, None),
                 );
-                t.add_constraint("Post_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("Post_pkey", types::primary_constraint(["id"]));
             });
 
             migration.change_table("User", |t| {
@@ -63,12 +63,12 @@ async fn a_many_to_many_relation_with_an_id(api: &TestApi) -> TestResult {
         .execute(|migration| {
             migration.create_table("User", |t| {
                 t.add_column("id", types::integer().increments(true));
-                t.add_constraint("User_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("User_pkey", types::primary_constraint(["id"]));
             });
 
             migration.create_table("Post", |t| {
                 t.add_column("id", types::integer().increments(true));
-                t.add_constraint("Post_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("Post_pkey", types::primary_constraint(["id"]));
             });
 
             migration.create_table("PostsToUsers", |t| {
@@ -85,7 +85,7 @@ async fn a_many_to_many_relation_with_an_id(api: &TestApi) -> TestResult {
                     types::foreign_constraint(&["post_id"], "Post", &["id"], None, None),
                 );
 
-                t.add_constraint("PostsToUsers_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("PostsToUsers_pkey", types::primary_constraint(["id"]));
             });
         })
         .await?;
@@ -121,7 +121,7 @@ async fn a_one_req_to_many_relation(api: &TestApi) -> TestResult {
         .execute(|migration| {
             migration.create_table("User", |t| {
                 t.add_column("id", types::integer().increments(true));
-                t.add_constraint("User_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("User_pkey", types::primary_constraint(["id"]));
             });
 
             migration.create_table("Post", |t| {
@@ -131,7 +131,7 @@ async fn a_one_req_to_many_relation(api: &TestApi) -> TestResult {
                     "Post_user_id_fkey",
                     types::foreign_constraint(&["user_id"], "User", &["id"], None, None),
                 );
-                t.add_constraint("Post_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("Post_pkey", types::primary_constraint(["id"]));
             });
         })
         .await?;
@@ -160,7 +160,7 @@ async fn id_fields_with_foreign_key(api: &TestApi) -> TestResult {
         .execute(|migration| {
             migration.create_table("User", |t| {
                 t.add_column("id", types::integer().increments(true));
-                t.add_constraint("User_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("User_pkey", types::primary_constraint(["id"]));
             });
             migration.create_table("Post", move |t| {
                 t.add_column("user_id", types::integer());
@@ -168,7 +168,7 @@ async fn id_fields_with_foreign_key(api: &TestApi) -> TestResult {
                     "Post_user_id_fkey",
                     types::foreign_constraint(&["user_id"], "User", &["id"], None, None),
                 );
-                t.add_constraint("Post_pkey", types::primary_constraint(&["user_id"]));
+                t.add_constraint("Post_pkey", types::primary_constraint(["user_id"]));
             });
         })
         .await?;
@@ -198,7 +198,7 @@ async fn one_to_many_relation_field_names_do_not_conflict_with_many_to_many_rela
         .execute(move |migration| {
             migration.create_table("User", |table| {
                 table.add_column("id", types::integer().increments(true));
-                table.add_constraint("User_pkey", types::primary_constraint(&["id"]));
+                table.add_constraint("User_pkey", types::primary_constraint(["id"]));
             });
 
             migration.create_table("Event", |table| {
@@ -209,7 +209,7 @@ async fn one_to_many_relation_field_names_do_not_conflict_with_many_to_many_rela
                     "Event_host_id_fkey",
                     types::foreign_constraint(&["host_id"], "User", &["id"], None, None),
                 );
-                table.add_constraint("Event_pkey", types::primary_constraint(&["id"]));
+                table.add_constraint("Event_pkey", types::primary_constraint(["id"]));
             });
 
             migration.create_table("_EventToUser", |table| {
@@ -255,7 +255,7 @@ async fn one_to_one_relation_on_a_singular_primary_key(api: &TestApi) -> TestRes
         .execute(|migration| {
             migration.create_table("User", |t| {
                 t.add_column("id", types::integer().increments(true));
-                t.add_constraint("User_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("User_pkey", types::primary_constraint(["id"]));
             });
 
             migration.create_table("Post", |t| {
@@ -264,7 +264,7 @@ async fn one_to_one_relation_on_a_singular_primary_key(api: &TestApi) -> TestRes
                     "Post_id_fkey",
                     types::foreign_constraint(&["id"], "User", &["id"], None, None),
                 );
-                t.add_constraint("Post_id_key", types::unique_constraint(&["id"]));
+                t.add_constraint("Post_id_key", types::unique_constraint(["id"]));
             });
         })
         .await?;
@@ -292,14 +292,14 @@ async fn one_to_one_req_relation_with_custom_fk_name(api: &TestApi) -> TestResul
         .execute(move |migration| {
             migration.create_table("User", |t| {
                 t.add_column("id", types::integer().increments(true).nullable(false));
-                t.add_constraint("User_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("User_pkey", types::primary_constraint(["id"]));
             });
 
             migration.create_table("Post", move |t| {
                 t.add_column("id", types::integer().increments(true).nullable(false));
-                t.add_constraint("Post_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("Post_pkey", types::primary_constraint(["id"]));
                 t.add_column("user_id", types::integer().nullable(false));
-                t.add_index("Post_user_id_key", types::index(&["user_id"]).unique(true));
+                t.add_index("Post_user_id_key", types::index(["user_id"]).unique(true));
                 t.add_constraint(
                     "CustomFKName",
                     types::foreign_constraint(&["user_id"], "User", &["id"], None, None),
@@ -332,18 +332,18 @@ async fn one_to_one_req_relation(api: &TestApi) -> TestResult {
         .execute(|migration| {
             migration.create_table("User", |t| {
                 t.add_column("id", types::integer().increments(true));
-                t.add_constraint("User_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("User_pkey", types::primary_constraint(["id"]));
             });
 
             migration.create_table("Post", move |t| {
                 t.add_column("id", types::integer().increments(true));
                 t.add_column("user_id", types::integer().nullable(false));
-                t.add_constraint("Post_user_id_key", types::unique_constraint(&["user_id"]));
+                t.add_constraint("Post_user_id_key", types::unique_constraint(["user_id"]));
                 t.add_constraint(
                     "Post_user_id_fkey",
                     types::foreign_constraint(&["user_id"], "User", &["id"], None, None),
                 );
-                t.add_constraint("Post_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("Post_pkey", types::primary_constraint(["id"]));
             });
         })
         .await?;
@@ -419,7 +419,7 @@ async fn relations_should_avoid_name_clashes_2(api: &TestApi) -> TestResult {
                 t.add_column("id", types::integer().increments(true));
                 t.add_column("y", types::integer().nullable(false));
                 t.add_index("unique_y_id", types::index(vec!["id", "y"]).unique(true));
-                t.add_constraint("x_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("x_pkey", types::primary_constraint(["id"]));
             });
 
             migration.create_table("y", move |t| {
@@ -427,7 +427,7 @@ async fn relations_should_avoid_name_clashes_2(api: &TestApi) -> TestResult {
                 t.add_column("x", types::integer().nullable(false));
                 t.add_column("fk_x_1", types::integer().nullable(false));
                 t.add_column("fk_x_2", types::integer().nullable(false));
-                t.add_constraint("y_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("y_pkey", types::primary_constraint(["id"]));
             });
 
             migration.change_table("x", |t| {

--- a/introspection-engine/introspection-engine-tests/tests/relations/mysql.rs
+++ b/introspection-engine/introspection-engine-tests/tests/relations/mysql.rs
@@ -221,7 +221,7 @@ async fn one_to_many_relation_field_names_do_not_conflict_with_many_to_many_rela
         .execute(move |migration| {
             migration.create_table("User", |table| {
                 table.add_column("id", types::integer().increments(true));
-                table.add_constraint("User_pkey", types::primary_constraint(&["id"]));
+                table.add_constraint("User_pkey", types::primary_constraint(["id"]));
             });
 
             migration.create_table("Event", |table| {
@@ -231,7 +231,7 @@ async fn one_to_many_relation_field_names_do_not_conflict_with_many_to_many_rela
                 table.inject_custom(
                     "CONSTRAINT host_id FOREIGN KEY (host_id) REFERENCES `User`(id) ON DELETE RESTRICT ON UPDATE CASCADE",
                 );
-                table.add_constraint("Event_pkey", types::primary_constraint(&["id"]));
+                table.add_constraint("Event_pkey", types::primary_constraint(["id"]));
             });
 
             migration.create_table("_EventToUser", |table| {
@@ -540,14 +540,14 @@ async fn one_to_one_req_relation_with_custom_fk_name(api: &TestApi) -> TestResul
         .execute(move |migration| {
             migration.create_table("User", |t| {
                 t.add_column("id", types::integer().increments(true).nullable(false));
-                t.add_constraint("User_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("User_pkey", types::primary_constraint(["id"]));
             });
 
             migration.create_table("Post", move |t| {
                 t.add_column("id", types::integer().increments(true).nullable(false));
-                t.add_constraint("Post_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("Post_pkey", types::primary_constraint(["id"]));
                 t.add_column("user_id", types::integer().nullable(false));
-                t.add_index("Post_user_id_key", types::index(&["user_id"]).unique(true));
+                t.add_index("Post_user_id_key", types::index(["user_id"]).unique(true));
                 t.inject_custom(
                     "CONSTRAINT CustomFKName FOREIGN KEY (user_id) REFERENCES `User`(id) ON DELETE RESTRICT ON UPDATE CASCADE",
                 );

--- a/introspection-engine/introspection-engine-tests/tests/relations/sqlite.rs
+++ b/introspection-engine/introspection-engine-tests/tests/relations/sqlite.rs
@@ -313,7 +313,7 @@ async fn a_self_relation(api: &TestApi) -> TestResult {
                     "direct_report_fkey",
                     types::foreign_constraint(&["direct_report"], "User", &["id"], None, None),
                 );
-                t.add_constraint("User_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("User_pkey", types::primary_constraint(["id"]));
             });
         })
         .await?;

--- a/introspection-engine/introspection-engine-tests/tests/relations_with_compound_fk/mod.rs
+++ b/introspection-engine/introspection-engine-tests/tests/relations_with_compound_fk/mod.rs
@@ -18,7 +18,7 @@ async fn compound_foreign_keys_for_one_to_one_relations(api: &TestApi) -> TestRe
                 t.add_column("age", types::integer());
 
                 t.add_index("user_unique", types::index(vec!["id", "age"]).unique(true));
-                t.add_constraint("User_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("User_pkey", types::primary_constraint(["id"]));
             });
 
             migration.create_table("Post", move |t| {
@@ -35,7 +35,7 @@ async fn compound_foreign_keys_for_one_to_one_relations(api: &TestApi) -> TestRe
                     "post_user_unique",
                     types::unique_constraint(vec!["user_id", "user_age"]),
                 );
-                t.add_constraint("Post_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("Post_pkey", types::primary_constraint(["id"]));
             });
         })
         .await?;
@@ -162,7 +162,7 @@ async fn compound_foreign_keys_for_self_relations(api: &TestApi) -> TestResult {
                     types::foreign_constraint(&["partner_id", "partner_age"], "Person", &["id", "age"], None, None),
                 );
                 t.add_constraint("post_user_unique", types::unique_constraint(vec!["id", "age"]));
-                t.add_constraint("Person_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("Person_pkey", types::primary_constraint(["id"]));
             });
         })
         .await?;
@@ -285,8 +285,8 @@ async fn compound_foreign_keys_for_duplicate_one_to_many_relations(api: &TestApi
                 t.add_column("id", types::integer().increments(true));
                 t.add_column("age", types::integer());
 
-                t.add_constraint("user_unique", types::unique_constraint(&["id", "age"]));
-                t.add_constraint("User_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("user_unique", types::unique_constraint(["id", "age"]));
+                t.add_constraint("User_pkey", types::primary_constraint(["id"]));
             });
 
             migration.create_table("Post", |t| {
@@ -304,7 +304,7 @@ async fn compound_foreign_keys_for_duplicate_one_to_many_relations(api: &TestApi
                     "Post_fk2",
                     types::foreign_constraint(&["other_user_id", "other_user_age"], "User", &["id", "age"], None, None),
                 );
-                t.add_constraint("Post_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("Post_pkey", types::primary_constraint(["id"]));
             });
         })
         .await?;

--- a/introspection-engine/introspection-engine-tests/tests/relations_with_compound_fk/mssql.rs
+++ b/introspection-engine/introspection-engine-tests/tests/relations_with_compound_fk/mssql.rs
@@ -12,7 +12,7 @@ async fn compound_foreign_keys_for_required_one_to_one_relations(api: &TestApi) 
                 t.add_column("age", types::integer());
 
                 t.add_index("user_unique", types::index(vec!["id", "age"]).unique(true));
-                t.add_constraint("User_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("User_pkey", types::primary_constraint(["id"]));
             });
 
             migration.create_table("Post", move |t| {
@@ -22,14 +22,14 @@ async fn compound_foreign_keys_for_required_one_to_one_relations(api: &TestApi) 
 
                 t.add_constraint(
                     "Post_user_id_user_age_fkey",
-                    types::foreign_constraint(&["user_id", "user_age"], "User", &["id", "age"], None, None),
+                    types::foreign_constraint(["user_id", "user_age"], "User", ["id", "age"], None, None),
                 );
 
                 t.add_constraint(
                     "post_user_unique",
                     types::unique_constraint(vec!["user_id", "user_age"]),
                 );
-                t.add_constraint("Post_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("Post_pkey", types::primary_constraint(["id"]));
             });
         })
         .await?;
@@ -66,7 +66,7 @@ async fn a_compound_fk_pk_with_overlapping_primary_key(api: &TestApi) -> TestRes
                 t.add_column("one", types::integer().nullable(false));
                 t.add_column("two", types::integer().nullable(false));
 
-                t.add_constraint("a_pkey", types::primary_constraint(&["one", "two"]));
+                t.add_constraint("a_pkey", types::primary_constraint(["one", "two"]));
             });
             migration.create_table("b", |t| {
                 t.add_column("dummy", types::integer().nullable(false));
@@ -75,9 +75,9 @@ async fn a_compound_fk_pk_with_overlapping_primary_key(api: &TestApi) -> TestRes
 
                 t.add_constraint(
                     "b_one_two_fkey",
-                    types::foreign_constraint(&["one", "two"], "a", &["one", "two"], None, None),
+                    types::foreign_constraint(["one", "two"], "a", ["one", "two"], None, None),
                 );
-                t.add_constraint("b_pkey", types::primary_constraint(&["dummy", "one", "two"]));
+                t.add_constraint("b_pkey", types::primary_constraint(["dummy", "one", "two"]));
             });
         })
         .await?;
@@ -115,7 +115,7 @@ async fn compound_foreign_keys_for_one_to_many_relations_with_mixed_requiredness
                 t.add_column("age", types::integer());
 
                 t.add_index("user_unique", types::index(vec!["id", "age"]).unique(true));
-                t.add_constraint("User_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("User_pkey", types::primary_constraint(["id"]));
             });
 
             migration.create_table("Post", move |t| {
@@ -125,9 +125,9 @@ async fn compound_foreign_keys_for_one_to_many_relations_with_mixed_requiredness
 
                 t.add_constraint(
                     "Post_fkey",
-                    types::foreign_constraint(&["user_id", "user_age"], "User", &["id", "age"], None, None),
+                    types::foreign_constraint(["user_id", "user_age"], "User", ["id", "age"], None, None),
                 );
-                t.add_constraint("Post_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("Post_pkey", types::primary_constraint(["id"]));
             });
         })
         .await?;
@@ -163,7 +163,7 @@ async fn compound_foreign_keys_for_required_one_to_many_relations(api: &TestApi)
                 t.add_column("age", types::integer());
 
                 t.add_index("user_unique", types::index(vec!["id", "age"]).unique(true));
-                t.add_constraint("User_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("User_pkey", types::primary_constraint(["id"]));
             });
 
             migration.create_table("Post", |t| {
@@ -173,9 +173,9 @@ async fn compound_foreign_keys_for_required_one_to_many_relations(api: &TestApi)
 
                 t.add_constraint(
                     "Post_user_id_user_age_fkey",
-                    types::foreign_constraint(&["user_id", "user_age"], "User", &["id", "age"], None, None),
+                    types::foreign_constraint(["user_id", "user_age"], "User", ["id", "age"], None, None),
                 );
-                t.add_constraint("Post_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("Post_pkey", types::primary_constraint(["id"]));
             });
         })
         .await?;
@@ -209,7 +209,7 @@ async fn repro_matt_references_on_wrong_side(api: &TestApi) -> TestResult {
             migration.create_table("a", |t| {
                 t.add_column("one", types::integer().nullable(false));
                 t.add_column("two", types::integer().nullable(false));
-                t.add_constraint("a_pkey", types::primary_constraint(&["one", "two"]));
+                t.add_constraint("a_pkey", types::primary_constraint(["one", "two"]));
             });
 
             migration.create_table("b", |t| {
@@ -218,9 +218,9 @@ async fn repro_matt_references_on_wrong_side(api: &TestApi) -> TestResult {
                 t.add_column("two", types::integer().nullable(false));
                 t.add_constraint(
                     "b_one_two_fkey",
-                    types::foreign_constraint(&["one", "two"], "a", &["one", "two"], None, None),
+                    types::foreign_constraint(["one", "two"], "a", ["one", "two"], None, None),
                 );
-                t.add_constraint("b_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("b_pkey", types::primary_constraint(["id"]));
             });
         })
         .await?;
@@ -256,7 +256,7 @@ async fn compound_foreign_keys_for_one_to_many_relations_with_non_unique_index(a
                 t.add_column("age", types::integer());
 
                 t.add_constraint("post_user_unique", types::unique_constraint(vec!["id", "age"]));
-                t.add_constraint("User_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("User_pkey", types::primary_constraint(["id"]));
             });
 
             migration.create_table("Post", |t| {
@@ -266,9 +266,9 @@ async fn compound_foreign_keys_for_one_to_many_relations_with_non_unique_index(a
 
                 t.add_constraint(
                     "Post_user_id_user_face_fkey",
-                    types::foreign_constraint(&["user_id", "user_age"], "User", &["id", "age"], None, None),
+                    types::foreign_constraint(["user_id", "user_age"], "User", ["id", "age"], None, None),
                 );
-                t.add_constraint("Post_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("Post_pkey", types::primary_constraint(["id"]));
             });
         })
         .await?;
@@ -307,10 +307,10 @@ async fn compound_foreign_keys_for_required_self_relations(api: &TestApi) -> Tes
 
                 t.add_constraint(
                     "person_fkey",
-                    types::foreign_constraint(&["partner_id", "partner_age"], "Person", &["id", "age"], None, None),
+                    types::foreign_constraint(["partner_id", "partner_age"], "Person", ["id", "age"], None, None),
                 );
                 t.add_constraint("post_user_unique", types::unique_constraint(vec!["id", "age"]));
-                t.add_constraint("Person_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("Person_pkey", types::primary_constraint(["id"]));
             });
         })
         .await?;
@@ -380,7 +380,7 @@ async fn compound_foreign_keys_for_one_to_many_relations(api: &TestApi) -> TestR
                 t.add_column("age", types::integer());
 
                 t.add_index("user_unique", types::index(vec!["id", "age"]).unique(true));
-                t.add_constraint("User_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("User_pkey", types::primary_constraint(["id"]));
             });
 
             migration.create_table("Post", move |t| {
@@ -390,9 +390,9 @@ async fn compound_foreign_keys_for_one_to_many_relations(api: &TestApi) -> TestR
 
                 t.add_constraint(
                     "Post_fk",
-                    types::foreign_constraint(&["user_id", "user_age"], "User", &["id", "age"], None, None),
+                    types::foreign_constraint(["user_id", "user_age"], "User", ["id", "age"], None, None),
                 );
-                t.add_constraint("Post_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("Post_pkey", types::primary_constraint(["id"]));
             });
         })
         .await?;

--- a/introspection-engine/introspection-engine-tests/tests/relations_with_compound_fk/mysql.rs
+++ b/introspection-engine/introspection-engine-tests/tests/relations_with_compound_fk/mysql.rs
@@ -57,7 +57,7 @@ async fn compound_foreign_keys_for_duplicate_one_to_many_relations(api: &TestApi
             migration.create_table("User", move |t| {
                 t.add_column("id", types::primary());
                 t.add_column("age", types::integer());
-                t.add_constraint("user_unique", types::unique_constraint(&["id", "age"]));
+                t.add_constraint("user_unique", types::unique_constraint(["id", "age"]));
             });
 
             migration.create_table("Post", |t| {

--- a/introspection-engine/introspection-engine-tests/tests/relations_with_compound_fk/postgres.rs
+++ b/introspection-engine/introspection-engine-tests/tests/relations_with_compound_fk/postgres.rs
@@ -12,7 +12,7 @@ async fn compound_foreign_keys_for_one_to_many_relations(api: &TestApi) -> TestR
                 t.add_column("age", types::integer());
 
                 t.add_index("user_unique", types::index(vec!["id", "age"]).unique(true));
-                t.add_constraint("User_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("User_pkey", types::primary_constraint(["id"]));
             });
 
             migration.create_table("Post", move |t| {
@@ -24,7 +24,7 @@ async fn compound_foreign_keys_for_one_to_many_relations(api: &TestApi) -> TestR
                     "Post_fk",
                     types::foreign_constraint(&["user_id", "user_age"], "User", &["id", "age"], None, None),
                 );
-                t.add_constraint("Post_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("Post_pkey", types::primary_constraint(["id"]));
             });
         })
         .await?;

--- a/introspection-engine/introspection-engine-tests/tests/relations_with_compound_fk/sqlite.rs
+++ b/introspection-engine/introspection-engine-tests/tests/relations_with_compound_fk/sqlite.rs
@@ -10,7 +10,7 @@ async fn compound_foreign_keys_for_duplicate_one_to_many_relations(api: &TestApi
             migration.create_table("User", move |t| {
                 t.add_column("id", types::primary());
                 t.add_column("age", types::integer());
-                t.add_constraint("sqlite_autoindex_User_1", types::unique_constraint(&["id", "age"]));
+                t.add_constraint("sqlite_autoindex_User_1", types::unique_constraint(["id", "age"]));
             });
 
             migration.create_table("Post", |t| {
@@ -306,7 +306,7 @@ async fn compound_foreign_keys_for_one_to_many_relations(api: &TestApi) -> TestR
                 t.add_column("age", types::integer());
 
                 t.add_index("user_unique", types::index(vec!["id", "age"]).unique(true));
-                t.add_constraint("User_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("User_pkey", types::primary_constraint(["id"]));
             });
 
             migration.create_table("Post", move |t| {
@@ -318,7 +318,7 @@ async fn compound_foreign_keys_for_one_to_many_relations(api: &TestApi) -> TestR
                     "Post_fk",
                     types::foreign_constraint(&["user_id", "user_age"], "User", &["id", "age"], None, None),
                 );
-                t.add_constraint("Post_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("Post_pkey", types::primary_constraint(["id"]));
             });
         })
         .await?;

--- a/introspection-engine/introspection-engine-tests/tests/remapping_database_names/mod.rs
+++ b/introspection-engine/introspection-engine-tests/tests/remapping_database_names/mod.rs
@@ -432,12 +432,12 @@ async fn not_automatically_remapping_invalid_compound_unique_key_names(api: &Tes
         .execute(|migration| {
             migration.create_table("User", |t| {
                 t.add_column("id", types::integer().increments(true).nullable(false));
-                t.add_constraint("User_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("User_pkey", types::primary_constraint(["id"]));
                 t.add_column("first", types::integer());
                 t.add_column("last", types::integer());
                 t.add_index(
                     "User.something@invalid-and/weird",
-                    types::index(&["first", "last"]).unique(true),
+                    types::index(["first", "last"]).unique(true),
                 );
             });
         })
@@ -467,7 +467,7 @@ async fn not_automatically_remapping_invalid_compound_primary_key_names(api: &Te
                 t.add_column("last", types::integer());
                 t.add_constraint(
                     "User.something@invalid-and/weird",
-                    types::primary_constraint(&["first", "last"]).unique(true),
+                    types::primary_constraint(["first", "last"]).unique(true),
                 );
             });
         })

--- a/introspection-engine/introspection-engine-tests/tests/remapping_database_names/mssql.rs
+++ b/introspection-engine/introspection-engine-tests/tests/remapping_database_names/mssql.rs
@@ -52,7 +52,7 @@ async fn remapping_models_in_relations(api: &TestApi) -> TestResult {
         .execute(|migration| {
             migration.create_table("User with Space", |t| {
                 t.add_column("id", types::integer().increments(true));
-                t.add_constraint("User with Space_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("User with Space_pkey", types::primary_constraint(["id"]));
             });
 
             migration.create_table("Post", |t| {
@@ -67,7 +67,7 @@ async fn remapping_models_in_relations(api: &TestApi) -> TestResult {
                     "post_user_unique",
                     types::unique_constraint(vec!["user_id"]).unique(true),
                 );
-                t.add_constraint("Post_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("Post_pkey", types::primary_constraint(["id"]));
             });
         })
         .await?;
@@ -104,7 +104,7 @@ async fn remapping_fields_in_compound_relations(api: &TestApi) -> TestResult {
                     "user_unique",
                     types::unique_constraint(vec!["id", "age-that-is-invalid"]),
                 );
-                t.add_constraint("User_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("User_pkey", types::primary_constraint(["id"]));
             });
 
             migration.create_table("Post", move |t| {
@@ -127,7 +127,7 @@ async fn remapping_fields_in_compound_relations(api: &TestApi) -> TestResult {
                     "post_user_unique",
                     types::unique_constraint(vec!["user_id", "user_age"]),
                 );
-                t.add_constraint("Post_pkey", types::primary_constraint(&["id"]));
+                t.add_constraint("Post_pkey", types::primary_constraint(["id"]));
             });
         })
         .await?;

--- a/libs/dml/src/lib.rs
+++ b/libs/dml/src/lib.rs
@@ -1,7 +1,7 @@
 //! This module contains the models representing the Datamodel part of a Prisma schema.
 //! It contains the main data structures that the engines can build upon.
 
-#![allow(clippy::derive_partial_eq_without_eq)]
+#![allow(clippy::derive_partial_eq_without_eq, clippy::expect_fun_call)]
 
 mod datamodel;
 mod lift;

--- a/libs/dml/src/model.rs
+++ b/libs/dml/src/model.rs
@@ -442,20 +442,18 @@ impl Model {
     /// Finds a field by name and returns a mutable reference.
     pub fn find_scalar_field_mut(&mut self, name: &str) -> &mut ScalarField {
         let model_name = &self.name.clone();
-        self.scalar_fields_mut().find(|rf| rf.name == *name).expect(&*format!(
-            "Could not find scalar field {} on model {}.",
-            name, model_name
-        ))
+        self.scalar_fields_mut()
+            .find(|rf| rf.name == *name)
+            .unwrap_or_else(|| panic!("Could not find scalar field {} on model {}.", name, model_name))
     }
 
     /// Finds a relation field by name and returns a mutable reference.
     #[track_caller]
     pub fn find_relation_field_mut(&mut self, name: &str) -> &mut RelationField {
         let model_name = &self.name.clone();
-        self.relation_fields_mut().find(|rf| rf.name == *name).expect(&*format!(
-            "Could not find relation field {} on model {}.",
-            name, model_name
-        ))
+        self.relation_fields_mut()
+            .find(|rf| rf.name == *name)
+            .unwrap_or_else(|| panic!("Could not find relation field {} on model {}.", name, model_name))
     }
 
     /// This should match the logic in `prisma_models::Model::primary_identifier`.

--- a/libs/test-cli/build.rs
+++ b/libs/test-cli/build.rs
@@ -1,7 +1,7 @@
 use std::process::Command;
 
 fn main() {
-    let output = Command::new("git").args(&["rev-parse", "HEAD"]).output().unwrap();
+    let output = Command::new("git").args(["rev-parse", "HEAD"]).output().unwrap();
     let git_hash = String::from_utf8(output.stdout).unwrap();
     println!("cargo:rustc-env=GIT_HASH={}", git_hash);
 }

--- a/migration-engine/cli/build.rs
+++ b/migration-engine/cli/build.rs
@@ -1,7 +1,7 @@
 use std::process::Command;
 
 fn store_git_commit_hash() {
-    let output = Command::new("git").args(&["rev-parse", "HEAD"]).output().unwrap();
+    let output = Command::new("git").args(["rev-parse", "HEAD"]).output().unwrap();
     let git_hash = String::from_utf8(output.stdout).unwrap();
     println!("cargo:rustc-env=GIT_HASH={}", git_hash);
 }

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/mysql.rs
@@ -443,7 +443,7 @@ where
     C: (FnOnce(&'a mut Params, BitFlags<Circumstances>, &'a mut Connection) -> F) + Send + 'a,
 {
     static MYSQL_SYSTEM_DATABASES: Lazy<regex::RegexSet> = Lazy::new(|| {
-        RegexSet::new(&[
+        RegexSet::new([
             "(?i)^mysql$",
             "(?i)^information_schema$",
             "(?i)^performance_schema$",

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
@@ -598,7 +598,7 @@ fn render_column_type_postgres(col: ColumnWalker<'_>) -> Cow<'static, str> {
     };
 
     if t.arity.is_list() {
-        format!("{}[]", tpe.to_owned()).into()
+        format!("{tpe}[]").into()
     } else {
         tpe
     }
@@ -639,7 +639,7 @@ fn render_column_type_cockroachdb(col: ColumnWalker<'_>) -> Cow<'static, str> {
     };
 
     if t.arity.is_list() {
-        format!("{}[]", tpe.to_owned()).into()
+        format!("{tpe}[]").into()
     } else {
         tpe
     }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/postgres.rs
@@ -20,7 +20,7 @@ use sql_schema_describer::{
 
 /// These can be tables or views, depending on the PostGIS version. In both cases, they should be ignored.
 static POSTGIS_TABLES_OR_VIEWS: Lazy<RegexSet> = Lazy::new(|| {
-    RegexSet::new(&[
+    RegexSet::new([
         // PostGIS. Reference: https://postgis.net/docs/manual-1.4/ch04.html#id418599
         "(?i)^spatial_ref_sys$",
         "(?i)^geometry_columns$",
@@ -33,7 +33,7 @@ static POSTGIS_TABLES_OR_VIEWS: Lazy<RegexSet> = Lazy::new(|| {
 });
 
 // https://www.postgresql.org/docs/12/pgbuffercache.html
-static EXTENSION_VIEWS: Lazy<RegexSet> = Lazy::new(|| RegexSet::new(&["(?i)^pg_buffercache$"]).unwrap());
+static EXTENSION_VIEWS: Lazy<RegexSet> = Lazy::new(|| RegexSet::new(["(?i)^pg_buffercache$"]).unwrap());
 
 impl SqlSchemaDifferFlavour for PostgresFlavour {
     fn can_alter_primary_keys(&self) -> bool {

--- a/migration-engine/core/src/commands/diff.rs
+++ b/migration-engine/core/src/commands/diff.rs
@@ -98,7 +98,7 @@ fn namespaces_and_preview_features_from_diff_targets(
             DiffTarget::Migrations(_) | DiffTarget::Empty | DiffTarget::Url(_) => (),
             DiffTarget::SchemaDatasource(SchemaContainer { schema })
             | DiffTarget::SchemaDatamodel(SchemaContainer { schema }) => {
-                let schema_str: String = std::fs::read_to_string(&schema).map_err(|err| {
+                let schema_str: String = std::fs::read_to_string(schema).map_err(|err| {
                     ConnectorError::from_source_with_context(
                         err,
                         format!("Error trying to read Prisma schema file at `{}`.", schema).into_boxed_str(),

--- a/migration-engine/core/src/state.rs
+++ b/migration-engine/core/src/state.rs
@@ -219,7 +219,7 @@ impl GenericApi for EngineState {
         let url: String = match &params.datasource_type {
             DbExecuteDatasourceType::Url(UrlContainer { url }) => url.clone(),
             DbExecuteDatasourceType::Schema(SchemaContainer { schema: file_path }) => {
-                let mut schema_file = std::fs::File::open(&file_path)
+                let mut schema_file = std::fs::File::open(file_path)
                     .map_err(|err| ConnectorError::from_source(err, "Opening Prisma schema file."))?;
                 let mut schema_string = String::new();
                 schema_file

--- a/migration-engine/migration-engine-tests/build.rs
+++ b/migration-engine/migration-engine-tests/build.rs
@@ -14,7 +14,7 @@ fn main() {
 
     for schema_path in &all_schemas {
         let test_name = schema_path.trim_start_matches('/').trim_end_matches(".prisma");
-        let test_name = test_name.replace(&['/', '\\'], "_");
+        let test_name = test_name.replace(['/', '\\'], "_");
         let file_path = schema_path.trim_start_matches('/');
         writeln!(
             out_file,

--- a/migration-engine/migration-engine-tests/tests/create_migration/create_migration_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/create_migration/create_migration_tests.rs
@@ -314,7 +314,7 @@ fn creating_a_migration_with_a_non_existent_migrations_directory_should_work(api
 
     let dir = api.create_migrations_directory();
 
-    std::fs::remove_dir_all(&dir.path()).unwrap();
+    std::fs::remove_dir_all(dir.path()).unwrap();
 
     api.create_migration("create-cats", &dm, &dir)
         .send_sync()

--- a/migration-engine/migration-engine-tests/tests/errors/error_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/errors/error_tests.rs
@@ -298,7 +298,7 @@ fn unique_constraint_errors_in_migrations_must_return_a_known_error(api: TestApi
 
     api.schema_push_w_datasource(dm).send().assert_green();
 
-    let insert = Insert::multi_into(api.render_table_name("Fruit"), &["name"])
+    let insert = Insert::multi_into(api.render_table_name("Fruit"), ["name"])
         .values(("banana",))
         .values(("apple",))
         .values(("banana",));

--- a/migration-engine/migration-engine-tests/tests/evaluate_data_loss/evaluate_data_loss_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/evaluate_data_loss/evaluate_data_loss_tests.rs
@@ -275,6 +275,8 @@ fn evaluate_data_loss_maps_warnings_to_the_right_steps(api: TestApi) {
     );
 
     let is_postgres = api.is_postgres();
+
+    #[allow(clippy::bool_to_int_with_if)]
     api.evaluate_data_loss(&directory, dm2)
         .send()
         .assert_warnings_with_indices(&[(warn.into(), if is_postgres { 1 } else { 0 })])

--- a/migration-engine/migration-engine-tests/tests/existing_data/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_data/mod.rs
@@ -46,7 +46,7 @@ fn dropping_a_column_with_non_null_values_should_warn(api: TestApi) {
 
     api.schema_push_w_datasource(dm).send().assert_green();
 
-    let insert = Insert::multi_into(api.render_table_name("Test"), &["id", "puppiesCount"])
+    let insert = Insert::multi_into(api.render_table_name("Test"), ["id", "puppiesCount"])
         .values(("a", 7))
         .values(("b", 8));
 
@@ -81,7 +81,7 @@ fn altering_a_column_without_non_null_values_should_not_warn(api: TestApi) {
 
     api.schema_push_w_datasource(dm).send().assert_green();
 
-    let insert = Insert::multi_into(api.render_table_name("Test"), &["id"])
+    let insert = Insert::multi_into(api.render_table_name("Test"), ["id"])
         .values(("a",))
         .values(("b",));
 
@@ -289,7 +289,7 @@ fn changing_a_column_from_required_to_optional_should_work(api: TestApi) {
 
     api.schema_push_w_datasource(dm).send().assert_green();
 
-    let insert = Insert::multi_into(api.render_table_name("Test"), &["id", "age"])
+    let insert = Insert::multi_into(api.render_table_name("Test"), ["id", "age"])
         .values(("a", 12))
         .values(("b", 22));
 
@@ -331,7 +331,7 @@ fn changing_a_column_from_optional_to_required_is_unexecutable(api: TestApi) {
 
     api.schema_push_w_datasource(dm).send().assert_green();
 
-    let insert = Insert::multi_into(api.render_table_name("Test"), &["id", "age"])
+    let insert = Insert::multi_into(api.render_table_name("Test"), ["id", "age"])
         .values(("a", 12))
         .values(("b", 22))
         .values(("c", Value::Int32(None)));
@@ -658,7 +658,7 @@ fn enum_variants_can_be_dropped_without_data_loss(api: TestApi) {
         .assert_green();
 
     {
-        let cat_inserts = quaint::ast::Insert::multi_into(api.render_table_name("Cat"), &["id", "mood"])
+        let cat_inserts = quaint::ast::Insert::multi_into(api.render_table_name("Cat"), ["id", "mood"])
             .values((Value::text("felix"), Value::enum_variant("HUNGRY")))
             .values((Value::text("mittens"), Value::enum_variant("HAPPY")));
 

--- a/migration-engine/migration-engine-tests/tests/existing_data/sqlite_existing_data_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_data/sqlite_existing_data_tests.rs
@@ -13,7 +13,7 @@ fn changing_a_column_from_optional_to_required_with_a_default_is_safe(api: TestA
 
     api.schema_push_w_datasource(dm).send().assert_green();
 
-    let insert = Insert::multi_into(api.render_table_name("Test"), &["id", "age"])
+    let insert = Insert::multi_into(api.render_table_name("Test"), ["id", "age"])
         .values(("a", 12))
         .values(("b", 22))
         .values(("c", Value::Int32(None)));

--- a/migration-engine/migration-engine-tests/tests/migrations/cockroachdb.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/cockroachdb.rs
@@ -860,7 +860,7 @@ fn unique_constraint_errors_in_migrations_must_return_a_known_error(api: TestApi
 
     api.schema_push_w_datasource(dm).send().assert_green();
 
-    let insert = Insert::multi_into(api.render_table_name("Fruit"), &["name"])
+    let insert = Insert::multi_into(api.render_table_name("Fruit"), ["name"])
         .values(("banana",))
         .values(("apple",))
         .values(("banana",));

--- a/migration-engine/migration-engine-tests/tests/migrations/diff.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/diff.rs
@@ -420,9 +420,9 @@ fn diff_sqlite_migration_directories() {
     let base_dir_str_2 = base_dir_2.path().to_str().unwrap();
 
     let migrations_lock_path = base_dir.path().join("migration_lock.toml");
-    std::fs::write(&migrations_lock_path, &"provider = \"sqlite\"").unwrap();
+    std::fs::write(&migrations_lock_path, "provider = \"sqlite\"").unwrap();
     let migrations_lock_path = base_dir_2.path().join("migration_lock.toml");
-    std::fs::write(&migrations_lock_path, &"provider = \"sqlite\"").unwrap();
+    std::fs::write(&migrations_lock_path, "provider = \"sqlite\"").unwrap();
 
     let params = DiffParams {
         exit_code: None,

--- a/migration-engine/migration-engine-tests/tests/migrations/id/mssql.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/id/mssql.rs
@@ -304,7 +304,7 @@ fn making_an_existing_id_field_autoincrement_works_with_foreign_keys(api: TestAp
         let insert = Insert::single_into(api.render_table_name("Author"));
 
         let author_id = api
-            .query(Insert::from(insert).returning(&["id"]).into())
+            .query(Insert::from(insert).returning(["id"]).into())
             .into_single()
             .unwrap()
             .into_single()

--- a/migration-engine/migration-engine-tests/tests/migrations/postgres.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/postgres.rs
@@ -421,7 +421,7 @@ fn failing_enum_migrations_should_not_be_partially_applied(api: TestApi) {
         .assert_green();
 
     {
-        let cat_inserts = quaint::ast::Insert::multi_into(api.render_table_name("Cat"), &["id", "mood"])
+        let cat_inserts = quaint::ast::Insert::multi_into(api.render_table_name("Cat"), ["id", "mood"])
             .values((Value::text("felix"), Value::enum_variant("HUNGRY")))
             .values((Value::text("mittens"), Value::enum_variant("HAPPY")));
 

--- a/migration-engine/migration-engine-tests/tests/migrations/sqlite.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/sqlite.rs
@@ -161,7 +161,7 @@ fn unique_constraint_errors_in_migrations(api: TestApi) {
 
     api.schema_push_w_datasource(dm).send().assert_green();
 
-    let insert = Insert::multi_into(api.render_table_name("Fruit"), &["name"])
+    let insert = Insert::multi_into(api.render_table_name("Fruit"), ["name"])
         .values(("banana",))
         .values(("apple",))
         .values(("banana",));

--- a/prisma-fmt/build.rs
+++ b/prisma-fmt/build.rs
@@ -1,7 +1,7 @@
 use std::process::Command;
 
 fn store_git_commit_hash() {
-    let output = Command::new("git").args(&["rev-parse", "HEAD"]).output().unwrap();
+    let output = Command::new("git").args(["rev-parse", "HEAD"]).output().unwrap();
     let git_hash = String::from_utf8(output.stdout).unwrap();
     println!("cargo:rustc-env=GIT_HASH={}", git_hash);
 }

--- a/psl/builtin-connectors/src/mssql_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/mssql_datamodel_connector.rs
@@ -166,7 +166,7 @@ impl Connector for MsSqlDatamodelConnector {
             let path = std::path::Path::new(&path);
 
             if path.is_relative() {
-                Some(config_dir.join(&path).to_str().map(ToString::to_string).unwrap())
+                Some(config_dir.join(path).to_str().map(ToString::to_string).unwrap())
             } else {
                 Some(path.to_str().unwrap().to_string())
             }

--- a/psl/builtin-connectors/src/sqlite_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/sqlite_datamodel_connector.rs
@@ -101,7 +101,7 @@ impl Connector for SqliteDatamodelConnector {
             let path = std::path::Path::new(path);
 
             if path.is_relative() {
-                Some(config_dir.join(&path).to_str().map(ToString::to_string).unwrap())
+                Some(config_dir.join(path).to_str().map(ToString::to_string).unwrap())
             } else {
                 None
             }

--- a/psl/psl-core/src/datamodel_connector.rs
+++ b/psl/psl-core/src/datamodel_connector.rs
@@ -209,7 +209,7 @@ pub trait Connector: Send + Sync {
             let path = std::path::Path::new(path);
 
             if path.is_relative() {
-                Some(config_dir.join(&path).to_str().map(ToString::to_string).unwrap())
+                Some(config_dir.join(path).to_str().map(ToString::to_string).unwrap())
             } else {
                 None
             }

--- a/psl/psl/build.rs
+++ b/psl/psl/build.rs
@@ -78,5 +78,5 @@ fn test_name(schema_file_path: &str) -> String {
     schema_file_path
         .trim_start_matches('/')
         .trim_end_matches(".prisma")
-        .replace(&['/', '\\'], "_")
+        .replace(['/', '\\'], "_")
 }

--- a/psl/schema-ast/src/source_file.rs
+++ b/psl/schema-ast/src/source_file.rs
@@ -22,7 +22,7 @@ impl SourceFile {
     pub fn as_str(&self) -> &str {
         match self.contents {
             Contents::Static(s) => s,
-            Contents::Allocated(ref s) => &**s,
+            Contents::Allocated(ref s) => s,
         }
     }
 }

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_15607.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_15607.rs
@@ -66,7 +66,7 @@ impl Actor {
         let tag = ConnectorTag::try_from(("sqlserver", None))?;
 
         let datamodel = render_test_datamodel(
-            &*CONFIG,
+            &CONFIG,
             "sql_server_deadlocks_test",
             SCHEMA.to_owned(),
             &[],

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent.rs
@@ -426,11 +426,7 @@ mod order_by_dependent {
         };
 
         let model_c = match c_id {
-            Some(id) => format!(
-                "c: {{ create: {{ id: {} \n {} }} }}",
-                id,
-                inline.unwrap_or_else(|| "".to_string())
-            ),
+            Some(id) => format!("c: {{ create: {{ id: {} \n {} }} }}", id, inline.unwrap_or_default()),
             None => "".to_string(),
         };
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent_pagination.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_dependent_pagination.rs
@@ -362,11 +362,7 @@ mod order_by_dependent_pag {
         };
 
         let model_c = match c_id {
-            Some(id) => format!(
-                "c: {{ create: {{ id: {} \n {} }} }}",
-                id,
-                inline.unwrap_or_else(|| "".to_string())
-            ),
+            Some(id) => format!("c: {{ create: {{ id: {} \n {} }} }}", id, inline.unwrap_or_default()),
             None => "".to_string(),
         };
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/simple/raw_mongo.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/simple/raw_mongo.rs
@@ -241,8 +241,8 @@ mod raw_mongo {
             (q, o) => {
                 format!(
                     r#"query {{ findTestModelRaw({} {}) }}"#,
-                    q.unwrap_or_else(|| "".to_string()),
-                    o.unwrap_or_else(|| "".to_string())
+                    q.unwrap_or_default(),
+                    o.unwrap_or_default()
                 )
             }
         }
@@ -262,8 +262,8 @@ mod raw_mongo {
             (p, o) => {
                 format!(
                     r#"query {{ aggregateTestModelRaw({} {}) }}"#,
-                    p.unwrap_or_else(|| "".to_string()),
-                    o.unwrap_or_else(|| "".to_string())
+                    p.unwrap_or_default(),
+                    o.unwrap_or_default()
                 )
             }
         }

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/datamodel_rendering/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/datamodel_rendering/mod.rs
@@ -85,7 +85,7 @@ fn process_template(template: String, renderer: Box<dyn DatamodelRenderer>) -> S
         fragment_defs.push(fragment);
     }
 
-    let preprocessed = FRAGMENT_RE.replace_all(&template, "#{}").to_owned();
+    let preprocessed = FRAGMENT_RE.replace_all(&template, "#{}");
 
     fragment_defs.into_iter().fold(preprocessed.to_string(), |aggr, next| {
         aggr.replacen("#{}", &renderer.render(next), 1)

--- a/query-engine/query-engine-node-api/build.rs
+++ b/query-engine/query-engine-node-api/build.rs
@@ -3,7 +3,7 @@ extern crate napi_build;
 use std::process::Command;
 
 fn store_git_commit_hash() {
-    let output = Command::new("git").args(&["rev-parse", "HEAD"]).output().unwrap();
+    let output = Command::new("git").args(["rev-parse", "HEAD"]).output().unwrap();
     let git_hash = String::from_utf8(output.stdout).unwrap();
     println!("cargo:rustc-env=GIT_HASH={}", git_hash);
 }

--- a/query-engine/query-engine/build.rs
+++ b/query-engine/query-engine/build.rs
@@ -17,7 +17,7 @@ fn check_rust_version() {
 }
 
 fn store_git_commit_hash() {
-    let output = Command::new("git").args(&["rev-parse", "HEAD"]).output().unwrap();
+    let output = Command::new("git").args(["rev-parse", "HEAD"]).output().unwrap();
     let git_hash = String::from_utf8(output.stdout).unwrap();
     println!("cargo:rustc-env=GIT_HASH={}", git_hash);
 }

--- a/query-engine/request-handlers/src/graphql/schema_renderer/type_renderer.rs
+++ b/query-engine/request-handlers/src/graphql/schema_renderer/type_renderer.rs
@@ -15,6 +15,7 @@ impl<'a> Renderer for GqlTypeRenderer<'a> {
     }
 }
 
+#[allow(clippy::only_used_in_recursion)]
 impl<'a> GqlTypeRenderer<'a> {
     fn render_input_type(&self, i: &InputType, ctx: &mut RenderContext) -> String {
         match i {


### PR DESCRIPTION
It's a big one.

https://blog.rust-lang.org/2022/11/03/Rust-1.65.0.html

Also includes:

- [Fix new clippy warnings after Rust 1.65 upgrade](https://github.com/prisma/prisma-engines/pull/3361/commits/c4b0998780231fd1c49bcd38e9463194acb1c2b7)
- [Cargo.toml: remove split-debuginfo](https://github.com/prisma/prisma-engines/pull/3361/commits/fa05f7e9c2e0a1a848c7835c4bb701d599e3fba9)