### PR TITLE
migration-engine: fix drop table for multiSchema

### DIFF
--- a/libs/sql-ddl/src/postgres.rs
+++ b/libs/sql-ddl/src/postgres.rs
@@ -251,7 +251,9 @@ impl Display for ForeignKeyAction {
 
 #[derive(Debug)]
 pub enum PostgresIdentifier<'a> {
+    /// Simple identifier without a schema(namespace).
     Simple(Cow<'a, str>),
+    /// Identifier with a schema(namespace). The first field is the schema.
     WithSchema(Cow<'a, str>, Cow<'a, str>),
 }
 

--- a/migration-engine/connectors/sql-migration-connector/src/apply_migration.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/apply_migration.rs
@@ -138,7 +138,11 @@ fn render_raw_sql(
 
             vec![renderer.render_create_table(table)]
         }
-        SqlMigrationStep::DropTable { table_id } => renderer.render_drop_table(schemas.previous.walk(*table_id).name()),
+        SqlMigrationStep::DropTable { table_id } => {
+            let table = schemas.previous.walk(*table_id);
+
+            renderer.render_drop_table(table.namespace(), table.name())
+        }
         SqlMigrationStep::RedefineIndex { index } => renderer.render_drop_and_recreate_index(schemas.walk(*index)),
         SqlMigrationStep::AddForeignKey { foreign_key_id } => {
             let foreign_key = schemas.next.walk(*foreign_key_id);

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/check.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/check.rs
@@ -1,16 +1,52 @@
 use super::database_inspection_results::DatabaseInspectionResults;
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Table {
+    pub table: String,
+    pub namespace: Option<String>,
+}
+
+impl Table {
+    pub fn new(table: String, namespace: Option<String>) -> Self {
+        Self { table, namespace }
+    }
+
+    pub fn from_column(column: &Column) -> Self {
+        Self {
+            table: column.table.clone(),
+            namespace: column.namespace.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Column {
+    pub table: String,
+    pub namespace: Option<String>,
+    pub column: String,
+}
+
+impl Column {
+    pub fn new(table: String, namespace: Option<String>, column: String) -> Self {
+        Self {
+            table,
+            namespace,
+            column,
+        }
+    }
+}
+
 /// This trait should be implemented by warning and unexecutable migration types. It lets them
 /// describe what data they need from the current state of the database to be as accurate and
 /// informative as possible.
 pub(super) trait Check {
     /// Indicates that the row count for the table with the returned name should be inspected.
-    fn needed_table_row_count(&self) -> Option<&str> {
+    fn needed_table_row_count(&self) -> Option<Table> {
         None
     }
 
     /// Indicates that the the number of non-null values should be inspected for the returned table and column.
-    fn needed_column_value_count(&self) -> Option<(&str, &str)> {
+    fn needed_column_value_count(&self) -> Option<Column> {
         None
     }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/database_inspection_results.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/database_inspection_results.rs
@@ -1,33 +1,34 @@
-use std::{borrow::Cow, collections::HashMap};
+use std::collections::HashMap;
+
+use super::check::{Column, Table};
 
 /// The information about the current state of the database gathered by the destructive change checker.
 #[derive(Debug, Default)]
 pub(super) struct DatabaseInspectionResults {
     /// HashMap from table name to row count.
-    row_counts: HashMap<String, i64>,
+    row_counts: HashMap<Table, i64>,
     /// HashMap from (table name, column name) to non-null values count.
-    value_counts: HashMap<(Cow<'static, str>, Cow<'static, str>), i64>,
+    value_counts: HashMap<Column, i64>,
 }
 
 impl DatabaseInspectionResults {
-    pub(super) fn get_row_count(&self, table: &str) -> Option<i64> {
+    pub(super) fn get_row_count(&self, table: &Table) -> Option<i64> {
         self.row_counts.get(table).copied()
     }
 
-    pub(super) fn set_row_count(&mut self, table: String, row_count: i64) {
+    pub(super) fn set_row_count(&mut self, table: Table, row_count: i64) {
         self.row_counts.insert(table, row_count);
     }
 
-    pub(super) fn get_row_and_non_null_value_count(&self, table: &str, column: &str) -> (Option<i64>, Option<i64>) {
+    pub(super) fn get_row_and_non_null_value_count(&self, column: &Column) -> (Option<i64>, Option<i64>) {
+        let table = Table::from_column(column);
         (
-            self.row_counts.get(table).copied(),
-            self.value_counts
-                .get(&(Cow::Borrowed(table), Cow::Borrowed(column)))
-                .copied(),
+            self.row_counts.get(&table).copied(),
+            self.value_counts.get(column).copied(),
         )
     }
 
-    pub(super) fn set_value_count(&mut self, table: Cow<'static, str>, column: Cow<'static, str>, count: i64) {
-        self.value_counts.insert((table, column), count);
+    pub(super) fn set_value_count(&mut self, column: Column, count: i64) {
+        self.value_counts.insert(column, count);
     }
 }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour.rs
@@ -3,7 +3,10 @@ mod mysql;
 mod postgres;
 mod sqlite;
 
-use super::DestructiveCheckPlan;
+use super::{
+    check::{Column, Table},
+    DestructiveCheckPlan,
+};
 use crate::{pair::Pair, sql_migration::AlterColumn, sql_schema_differ::ColumnChanges};
 use migration_connector::{BoxFuture, ConnectorError, ConnectorResult};
 use sql_schema_describer::walkers::ColumnWalker;
@@ -28,12 +31,9 @@ pub(crate) trait DestructiveChangeCheckerFlavour {
         step_index: usize,
     );
 
-    fn count_rows_in_table<'a>(&'a mut self, table_name: &'a str) -> BoxFuture<'a, ConnectorResult<i64>>;
+    fn count_rows_in_table<'a>(&'a mut self, table: &'a Table) -> BoxFuture<'a, ConnectorResult<i64>>;
 
-    fn count_values_in_column<'a>(
-        &'a mut self,
-        table_and_column: (&'a str, &'a str),
-    ) -> BoxFuture<'a, ConnectorResult<i64>>;
+    fn count_values_in_column<'a>(&'a mut self, column: &'a Column) -> BoxFuture<'a, ConnectorResult<i64>>;
 }
 
 /// Display a column type for warnings/errors.
@@ -47,13 +47,13 @@ fn display_column_type(
     }
 }
 
-fn extract_table_rows_count(table_name: &str, result_set: quaint::prelude::ResultSet) -> ConnectorResult<i64> {
+fn extract_table_rows_count(table: &Table, result_set: quaint::prelude::ResultSet) -> ConnectorResult<i64> {
     result_set
         .first()
         .ok_or_else(|| {
             ConnectorError::from_msg(format!(
                 "No row was returned when checking for existing rows in the `{}` table.",
-                table_name
+                table.table
             ))
         })?
         .at(0)
@@ -61,7 +61,7 @@ fn extract_table_rows_count(table_name: &str, result_set: quaint::prelude::Resul
         .ok_or_else(|| {
             ConnectorError::from_msg(format!(
                 "No count was returned when checking for existing rows in the `{}` table.",
-                table_name
+                table.table
             ))
         })
 }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/mssql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/mssql.rs
@@ -3,7 +3,9 @@ use crate::{
     flavour::{MssqlFlavour, SqlFlavour},
     pair::Pair,
     sql_destructive_change_checker::{
-        destructive_check_plan::DestructiveCheckPlan, unexecutable_step_check::UnexecutableStepCheck,
+        check::{Column, Table},
+        destructive_check_plan::DestructiveCheckPlan,
+        unexecutable_step_check::UnexecutableStepCheck,
         warning_check::SqlMigrationWarningCheck,
     },
     sql_migration::{AlterColumn, ColumnTypeChange},
@@ -51,6 +53,7 @@ impl DestructiveChangeCheckerFlavour for MssqlFlavour {
                 plan.push_warning(
                     SqlMigrationWarningCheck::RiskyCast {
                         table: columns.previous.table().name().to_owned(),
+                        namespace: None,
                         column: columns.previous.name().to_owned(),
                         previous_type,
                         next_type,
@@ -62,6 +65,7 @@ impl DestructiveChangeCheckerFlavour for MssqlFlavour {
                 plan.push_warning(
                     SqlMigrationWarningCheck::NotCastable {
                         table: columns.previous.table().name().to_owned(),
+                        namespace: None,
                         column: columns.previous.name().to_owned(),
                         previous_type: format!("{:?}", columns.previous.column_type_family()),
                         next_type: format!("{:?}", columns.next.column_type_family()),
@@ -105,33 +109,33 @@ impl DestructiveChangeCheckerFlavour for MssqlFlavour {
                 SqlMigrationWarningCheck::DropAndRecreateColumn {
                     column: columns.previous.name().to_owned(),
                     table: columns.previous.table().name().to_owned(),
+                    namespace: None,
                 },
                 step_index,
             )
         }
     }
 
-    fn count_rows_in_table<'a>(&'a mut self, table_name: &'a str) -> BoxFuture<'a, ConnectorResult<i64>> {
+    fn count_rows_in_table<'a>(&'a mut self, table: &'a Table) -> BoxFuture<'a, ConnectorResult<i64>> {
         Box::pin(async move {
             let query = {
+                // TODO(MultiSchema): replace this when implementing MSSQL.
                 let schema_name = self.schema_name();
-                format!("SELECT COUNT(*) FROM [{}].[{}]", schema_name, table_name)
+                format!("SELECT COUNT(*) FROM [{}].[{}]", schema_name, table.table)
             };
             let result_set = self.query_raw(&query, &[]).await?;
-            super::extract_table_rows_count(table_name, result_set)
+            super::extract_table_rows_count(table, result_set)
         })
     }
 
-    fn count_values_in_column<'a>(
-        &'a mut self,
-        (table, column): (&'a str, &'a str),
-    ) -> BoxFuture<'a, ConnectorResult<i64>> {
+    fn count_values_in_column<'a>(&'a mut self, column: &'a Column) -> BoxFuture<'a, ConnectorResult<i64>> {
         Box::pin(async move {
             let query = {
+                // TODO(MultiSchema): replace this when implementing MSSQL.
                 let schema_name = self.schema_name();
                 format!(
                     "SELECT COUNT(*) FROM [{}].[{}] WHERE [{}] IS NOT NULL",
-                    schema_name, table, column
+                    schema_name, column.table, column.column
                 )
             };
             let result_set = self.query_raw(&query, &[]).await?;

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/mysql.rs
@@ -3,7 +3,9 @@ use crate::{
     flavour::{MysqlFlavour, SqlFlavour},
     pair::Pair,
     sql_destructive_change_checker::{
-        destructive_check_plan::DestructiveCheckPlan, unexecutable_step_check::UnexecutableStepCheck,
+        check::{Column, Table},
+        destructive_check_plan::DestructiveCheckPlan,
+        unexecutable_step_check::UnexecutableStepCheck,
         warning_check::SqlMigrationWarningCheck,
     },
     sql_migration::{AlterColumn, ColumnTypeChange},
@@ -59,6 +61,7 @@ impl DestructiveChangeCheckerFlavour for MysqlFlavour {
                 plan.push_warning(
                     SqlMigrationWarningCheck::RiskyCast {
                         table: columns.previous.table().name().to_owned(),
+                        namespace: None,
                         column: columns.previous.name().to_owned(),
                         previous_type,
                         next_type,
@@ -70,6 +73,7 @@ impl DestructiveChangeCheckerFlavour for MysqlFlavour {
                 plan.push_warning(
                     SqlMigrationWarningCheck::NotCastable {
                         table: columns.previous.table().name().to_owned(),
+                        namespace: None,
                         column: columns.previous.name().to_owned(),
                         previous_type,
                         next_type,
@@ -114,26 +118,29 @@ impl DestructiveChangeCheckerFlavour for MysqlFlavour {
                 SqlMigrationWarningCheck::DropAndRecreateColumn {
                     column: columns.previous.name().to_owned(),
                     table: columns.previous.table().name().to_owned(),
+                    namespace: None,
                 },
                 step_index,
             )
         }
     }
 
-    fn count_rows_in_table<'a>(&'a mut self, table_name: &'a str) -> BoxFuture<'a, ConnectorResult<i64>> {
+    fn count_rows_in_table<'a>(&'a mut self, table: &'a Table) -> BoxFuture<'a, ConnectorResult<i64>> {
         Box::pin(async move {
-            let query = format!("SELECT COUNT(*) FROM `{}`", table_name);
+            // TODO(MultiSchema): replace this when implementing MySQL.
+            let query = format!("SELECT COUNT(*) FROM `{}`", table.table);
             let result_set = self.query_raw(&query, &[]).await?;
-            super::extract_table_rows_count(table_name, result_set)
+            super::extract_table_rows_count(table, result_set)
         })
     }
 
-    fn count_values_in_column<'a>(
-        &'a mut self,
-        (table, column): (&'a str, &'a str),
-    ) -> BoxFuture<'a, ConnectorResult<i64>> {
+    fn count_values_in_column<'a>(&'a mut self, column: &'a Column) -> BoxFuture<'a, ConnectorResult<i64>> {
         Box::pin(async move {
-            let query = format!("SELECT COUNT(*) FROM `{}` WHERE `{}` IS NOT NULL", table, column);
+            // TODO(MultiSchema): replace this when implementing MySQL.
+            let query = format!(
+                "SELECT COUNT(*) FROM `{}` WHERE `{}` IS NOT NULL",
+                column.table, column.column
+            );
             let result_set = self.query_raw(&query, &[]).await?;
             super::extract_column_values_count(result_set)
         })

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_check_plan.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_check_plan.rs
@@ -96,16 +96,16 @@ impl DestructiveCheckPlan {
         results: &mut DatabaseInspectionResults,
     ) -> ConnectorResult<()> {
         if let Some(table) = check.needed_table_row_count() {
-            if results.get_row_count(table).is_none() {
-                let count = flavour.count_rows_in_table(table).await?;
+            if results.get_row_count(&table).is_none() {
+                let count = flavour.count_rows_in_table(&table).await?;
                 results.set_row_count(table.to_owned(), count)
             }
         }
 
-        if let Some((table, column)) = check.needed_column_value_count() {
-            if let (_, None) = results.get_row_and_non_null_value_count(table, column) {
-                let count = flavour.count_values_in_column((table, column)).await?;
-                results.set_value_count(table.to_owned().into(), column.to_owned().into(), count);
+        if let Some(column) = check.needed_column_value_count() {
+            if let (_, None) = results.get_row_and_non_null_value_count(&column) {
+                let count = flavour.count_values_in_column(&column).await?;
+                results.set_value_count(column, count);
             }
         }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/warning_check.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/warning_check.rs
@@ -1,32 +1,41 @@
-use super::{check::Check, database_inspection_results::DatabaseInspectionResults};
+use super::{
+    check::{Check, Column, Table},
+    database_inspection_results::DatabaseInspectionResults,
+};
 
 #[derive(Debug)]
 pub(super) enum SqlMigrationWarningCheck {
     DropAndRecreateColumn {
         table: String,
+        namespace: Option<String>,
         column: String,
     },
     NonEmptyColumnDrop {
         table: String,
+        namespace: Option<String>,
         column: String,
     },
     NonEmptyTableDrop {
         table: String,
+        namespace: Option<String>,
     },
     RiskyCast {
         table: String,
+        namespace: Option<String>,
         column: String,
         previous_type: String,
         next_type: String,
     },
     NotCastable {
         table: String,
+        namespace: Option<String>,
         column: String,
         previous_type: String,
         next_type: String,
     },
     PrimaryKeyChange {
         table: String,
+        namespace: Option<String>,
     },
     UniqueConstraintAddition {
         table: String,
@@ -39,21 +48,38 @@ pub(super) enum SqlMigrationWarningCheck {
 }
 
 impl Check for SqlMigrationWarningCheck {
-    fn needed_table_row_count(&self) -> Option<&str> {
+    fn needed_table_row_count(&self) -> Option<Table> {
         match self {
-            SqlMigrationWarningCheck::NonEmptyTableDrop { table }
-            | SqlMigrationWarningCheck::PrimaryKeyChange { table }
-            | SqlMigrationWarningCheck::DropAndRecreateColumn { table, column: _ } => Some(table),
+            SqlMigrationWarningCheck::NonEmptyTableDrop { table, namespace }
+            | SqlMigrationWarningCheck::PrimaryKeyChange { table, namespace }
+            | SqlMigrationWarningCheck::DropAndRecreateColumn {
+                table,
+                column: _,
+                namespace,
+            } => Some(Table::new(table.clone(), namespace.clone())),
             SqlMigrationWarningCheck::NonEmptyColumnDrop { .. } | SqlMigrationWarningCheck::RiskyCast { .. } => None,
             _ => None,
         }
     }
 
-    fn needed_column_value_count(&self) -> Option<(&str, &str)> {
+    fn needed_column_value_count(&self) -> Option<Column> {
         match self {
-            SqlMigrationWarningCheck::NonEmptyColumnDrop { table, column }
-            | SqlMigrationWarningCheck::RiskyCast { table, column, .. }
-            | SqlMigrationWarningCheck::DropAndRecreateColumn { table, column } => Some((table, column)),
+            SqlMigrationWarningCheck::NonEmptyColumnDrop {
+                table,
+                column,
+                namespace,
+            }
+            | SqlMigrationWarningCheck::RiskyCast {
+                table,
+                column,
+                namespace,
+                ..
+            }
+            | SqlMigrationWarningCheck::DropAndRecreateColumn {
+                table,
+                column,
+                namespace,
+            } => Some(Column::new(table.clone(), namespace.clone(), column.clone())),
 
             SqlMigrationWarningCheck::NonEmptyTableDrop { .. } | SqlMigrationWarningCheck::PrimaryKeyChange { .. } => {
                 None
@@ -64,8 +90,8 @@ impl Check for SqlMigrationWarningCheck {
 
     fn evaluate(&self, database_check_results: &DatabaseInspectionResults) -> Option<String> {
         match self {
-            SqlMigrationWarningCheck::DropAndRecreateColumn { table, column } => {
-                match database_check_results.get_row_and_non_null_value_count(table, column) {
+            SqlMigrationWarningCheck::DropAndRecreateColumn { table, column, namespace } => {
+                match database_check_results.get_row_and_non_null_value_count(&Column::new(table.clone(), namespace.clone(), column.clone())) {
                 (Some(0), _) => None,
                 (_, Some(0)) => None,
                 (_, None) => Some(format!("The `{}` column on the `{}` table would be dropped and recreated. This will lead to data loss if there is data in the column.", column, table)),
@@ -73,18 +99,18 @@ impl Check for SqlMigrationWarningCheck {
 
             }
         },
-            SqlMigrationWarningCheck::NonEmptyTableDrop { table } => match database_check_results.get_row_count(table) {
+            SqlMigrationWarningCheck::NonEmptyTableDrop { table, namespace } => match database_check_results.get_row_count(&Table::new(table.clone(), namespace.clone())) {
                 Some(0) => None, // dropping the table is safe if it's empty
                 Some(rows_count) => Some(format!("You are about to drop the `{table_name}` table, which is not empty ({rows_count} rows).", table_name = table, rows_count = rows_count)),
                 None => Some(format!("You are about to drop the `{}` table. If the table is not empty, all the data it contains will be lost.", table)),
             },
-            SqlMigrationWarningCheck::NonEmptyColumnDrop { table, column } => match database_check_results.get_row_and_non_null_value_count(table, column) {
+            SqlMigrationWarningCheck::NonEmptyColumnDrop { table, column, namespace } => match database_check_results.get_row_and_non_null_value_count(&Column::new(table.clone(), namespace.clone(), column.clone())) {
                 (Some(0), _) => None, // it's safe to drop a column on an empty table
                 (_, Some(0)) => None, // it's safe to drop a column if it only contains null values
                 (_, Some(value_count)) => Some(format!("You are about to drop the column `{column_name}` on the `{table_name}` table, which still contains {value_count} non-null values.", column_name = column, table_name = table, value_count = value_count)),
                 (_, _) => Some(format!("You are about to drop the column `{column_name}` on the `{table_name}` table. All the data in the column will be lost.", column_name = column, table_name = table)),
             },
-            SqlMigrationWarningCheck::RiskyCast { table, column, previous_type, next_type } => match database_check_results.get_row_and_non_null_value_count(table, column) {
+            SqlMigrationWarningCheck::RiskyCast { table, column, previous_type, next_type, namespace } => match database_check_results.get_row_and_non_null_value_count(&Column::new(table.clone(), namespace.clone(), column.clone())) {
                 (Some(0), _) => None, // it's safe to alter a column on an empty table
                 (_, Some(0)) => None, // it's safe to alter a column if it only contains null values
                 (_, Some(value_count)) => Some(format!("You are about to alter the column `{column_name}` on the `{table_name}` table, which contains {value_count} non-null values. The data in that column will be cast from `{old_type}` to `{new_type}`.", column_name = column, table_name = table, value_count = value_count, old_type = previous_type, new_type = next_type)),
@@ -93,14 +119,14 @@ impl Check for SqlMigrationWarningCheck {
             },
 
             // todo this seems to not be reached when only a table is dropped and recreated
-            SqlMigrationWarningCheck::NotCastable { table, column, previous_type, next_type } => match database_check_results.get_row_and_non_null_value_count(table, column) {
+            SqlMigrationWarningCheck::NotCastable { table, column, previous_type, next_type, namespace } => match database_check_results.get_row_and_non_null_value_count(&Column::new(table.clone(), namespace.clone(), column.clone())) {
                 (Some(0), _) => None, // it's safe to alter a column on an empty table
                 (_, Some(0)) => None, // it's safe to alter a column if it only contains null values
                 (_, Some(value_count)) => Some(format!("You are about to alter the column `{column_name}` on the `{table_name}` table, which contains {value_count} non-null values. The data in that column will be cast from `{old_type}` to `{new_type}`. This cast may fail. Please make sure the data in the column can be cast.", column_name = column, table_name = table, value_count = value_count, old_type = previous_type, new_type = next_type)),
                 (_, _) => Some(format!("You are about to alter the column `{column_name}` on the `{table_name}` table. The data in that column will be cast from `{old_type}` to `{new_type}`. This cast may fail. Please make sure the data in the column can be cast.", column_name = column, table_name = table, old_type = previous_type, new_type = next_type)),
 
             },
-            SqlMigrationWarningCheck::PrimaryKeyChange { table } => match database_check_results.get_row_count(table) {
+            SqlMigrationWarningCheck::PrimaryKeyChange { table, namespace } => match database_check_results.get_row_count(&Table::new(table.clone(), namespace.clone())) {
                 Some(0) => None,
                 _ => Some(format!("The primary key for the `{table}` table will be changed. If it partially fails, the table could be left without primary key constraint.", table = table)),
             },

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer.rs
@@ -79,8 +79,12 @@ pub(crate) trait SqlRenderer {
     fn render_drop_index(&self, index: IndexWalker<'_>) -> String;
 
     /// Render a `DropTable` step.
-    fn render_drop_table(&self, table_name: &str) -> Vec<String> {
-        vec![format!("DROP TABLE {}", self.quote(table_name))]
+    fn render_drop_table(&self, namespace: Option<&str>, table_name: &str) -> Vec<String> {
+        let name = match namespace {
+            Some(namespace) => format!("{}.{}", self.quote(namespace), self.quote(table_name)),
+            None => format!("{}", self.quote(table_name)),
+        };
+        vec![format!("DROP TABLE {}", name)]
     }
 
     /// Render a `RedefineTables` step.

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mssql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mssql_renderer.rs
@@ -331,7 +331,7 @@ impl SqlRenderer for MssqlFlavour {
             }
 
             // Drop the old, now empty table.
-            result.extend(self.render_drop_table(tables.previous.name()));
+            result.extend(self.render_drop_table(None, tables.previous.name()));
 
             // Rename the temporary table with the name defined in the migration.
             result.push(self.render_rename_table(&temporary_table_name, tables.next.name()));
@@ -394,7 +394,7 @@ impl SqlRenderer for MssqlFlavour {
         add_constraint
     }
 
-    fn render_drop_table(&self, table_name: &str) -> Vec<String> {
+    fn render_drop_table(&self, _namespace: Option<&str>, table_name: &str) -> Vec<String> {
         vec![format!("DROP TABLE {}", self.quote_with_schema(table_name))]
     }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
@@ -303,7 +303,7 @@ impl SqlRenderer for MysqlFlavour {
         .to_string()
     }
 
-    fn render_drop_table(&self, table_name: &str) -> Vec<String> {
+    fn render_drop_table(&self, _namespace: Option<&str>, table_name: &str) -> Vec<String> {
         render_step(&mut |step| {
             step.render_statement(&mut |stmt| {
                 stmt.push_display(&sql_ddl::mysql::DropTable {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
@@ -10,7 +10,10 @@ use crate::{
 };
 use psl::builtin_connectors::{CockroachType, PostgresType};
 use psl::dml::PrismaValue;
-use sql_ddl::{postgres as ddl, IndexColumn, SortOrder};
+use sql_ddl::{
+    postgres::{self as ddl, PostgresIdentifier},
+    IndexColumn, SortOrder,
+};
 use sql_schema_describer::{
     postgres::{PostgresSchemaExt, SqlIndexAlgorithm},
     walkers::*,
@@ -442,11 +445,14 @@ impl SqlRenderer for PostgresFlavour {
         .to_string()
     }
 
-    fn render_drop_table(&self, table_name: &str) -> Vec<String> {
+    fn render_drop_table(&self, namespace: Option<&str>, table_name: &str) -> Vec<String> {
         render_step(&mut |step| {
             step.render_statement(&mut |stmt| {
                 stmt.push_display(&ddl::DropTable {
-                    table_name: table_name.into(),
+                    table_name: match namespace {
+                        Some(namespace) => PostgresIdentifier::WithSchema(namespace.into(), table_name.into()),
+                        None => table_name.into(),
+                    },
                     cascade: false,
                 })
             })

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
@@ -164,7 +164,7 @@ impl SqlRenderer for SqliteFlavour {
         ]
     }
 
-    fn render_drop_table(&self, table_name: &str) -> Vec<String> {
+    fn render_drop_table(&self, _namespace: Option<&str>, table_name: &str) -> Vec<String> {
         // Turning off the pragma is safe, because schema validation would forbid foreign keys
         // to a non-existent model. There appears to be no other way to deal with cyclic
         // dependencies in the dropping order of tables in the presence of foreign key

--- a/migration-engine/migration-engine-tests/tests/migrations/postgres/multi_schema.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/postgres/multi_schema.rs
@@ -133,7 +133,7 @@ fn multi_schema_add_table(api: TestApi) {
     tags(Postgres),
     exclude(CockroachDb),
     preview_features("multiSchema"),
-    namespaces("one", "two"),
+    namespaces("one", "two")
 )]
 fn multi_schema_remove_table(api: TestApi) {
     let base = indoc! {r#"

--- a/migration-engine/migration-engine-tests/tests/migrations/postgres/multi_schema.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/postgres/multi_schema.rs
@@ -128,3 +128,48 @@ fn multi_schema_add_table(api: TestApi) {
         .assert_has_table("Second")
         .assert_has_table("Third");
 }
+
+#[test_connector(
+    tags(Postgres),
+    exclude(CockroachDb),
+    preview_features("multiSchema"),
+    namespaces("one", "two"),
+)]
+fn multi_schema_remove_table(api: TestApi) {
+    let base = indoc! {r#"
+        datasource db {
+          provider   = "postgresql"
+          url        = env("TEST_DATABASE_URL")
+          schemas    = ["one", "two"]
+        }
+        generator js {
+          provider        = "prisma-client-js"
+          previewFeatures = ["multiSchema"]
+        }
+        model First {
+          id Int @id
+          @@schema("one")
+        }
+    "#};
+    let first = base.to_owned()
+        + indoc! {r#"
+        model Second {
+          id Int @id
+          @@schema("two")
+        }
+    "#};
+    let second = base;
+
+    api.schema_push(first).send().assert_green().assert_has_executed_steps();
+    api.schema_push(second)
+        .send()
+        .assert_warnings(&[])
+        .assert_has_executed_steps();
+
+    let mut vec_namespaces = vec![String::from("one"), String::from("two")];
+    let namespaces = Namespaces::from_vec(&mut vec_namespaces);
+
+    api.assert_schema_with_namespaces(namespaces)
+        .assert_has_table("First")
+        .assert_has_no_table("Second");
+}


### PR DESCRIPTION
There were two things that were fixed, next to the test that proves it works:
- the warning check for when the table isn't empty (we were doing `SELECT COUNT(*) FROM <table>` without taking the namespace name into account
- the actual `DROP TABLE` command did not correctly apply the namespace