### PR TITLE
feat(psl): remove 'SetDefault' support on MySQL

### DIFF
--- a/introspection-engine/introspection-engine-tests/tests/referential_actions/mod.rs
+++ b/introspection-engine/introspection-engine-tests/tests/referential_actions/mod.rs
@@ -1,4 +1,5 @@
 mod cockroachdb;
+mod mysql;
 mod sqlite;
 
 use barrel::types;

--- a/introspection-engine/introspection-engine-tests/tests/referential_actions/mysql.rs
+++ b/introspection-engine/introspection-engine-tests/tests/referential_actions/mysql.rs
@@ -1,6 +1,6 @@
 use introspection_engine_tests::test_api::*;
 
-// Older versions of MySQL (5.6+) raise a syntax error on CREATE TABLE declarations with `SET DEFAULT` referential actions,
+// Older versions of MySQL (5.6+) raise a syntax error on `CREATE TABLE` declarations with `SET DEFAULT` referential actions,
 // so we can skip introspecting those. MariaDb 10.0 suffers from the same issue.
 #[test_connector(tags(Mysql8))]
 async fn introspect_set_default_should_fail(api: &TestApi) -> TestResult {

--- a/introspection-engine/introspection-engine-tests/tests/referential_actions/mysql.rs
+++ b/introspection-engine/introspection-engine-tests/tests/referential_actions/mysql.rs
@@ -1,6 +1,8 @@
 use introspection_engine_tests::test_api::*;
 
-#[test_connector(tags(Mysql))]
+// Older versions of MySQL (5.6+) raise a syntax error on CREATE TABLE declarations with `SET DEFAULT` referential actions,
+// so we can skip introspecting those. MariaDb 10.0 suffers from the same issue.
+#[test_connector(tags(Mysql8))]
 async fn introspect_set_default_should_fail(api: &TestApi) -> TestResult {
     let setup = r#"
       CREATE TABLE `SomeUser` (

--- a/introspection-engine/introspection-engine-tests/tests/referential_actions/mysql.rs
+++ b/introspection-engine/introspection-engine-tests/tests/referential_actions/mysql.rs
@@ -1,0 +1,76 @@
+use introspection_engine_tests::test_api::*;
+
+#[test_connector(tags(Mysql))]
+async fn introspect_set_default_should_fail(api: &TestApi) -> TestResult {
+    let setup = r#"
+      CREATE TABLE `SomeUser` (
+          `id` INTEGER NOT NULL AUTO_INCREMENT,
+      
+          PRIMARY KEY (`id`)
+      ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+      
+      CREATE TABLE `Post` (
+          `id` INTEGER NOT NULL AUTO_INCREMENT,
+          `userId` INTEGER NULL DEFAULT 3,
+      
+          PRIMARY KEY (`id`)
+      ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+      
+      ALTER TABLE `Post` ADD CONSTRAINT `Post_userId_fkey`
+        FOREIGN KEY (`userId`) REFERENCES `SomeUser`(`id`)
+        ON DELETE SET DEFAULT ON UPDATE SET DEFAULT;
+    "#;
+
+    api.raw_cmd(setup).await;
+
+    // TODO: this is currently succeeding, but should fail instead.
+    // That is, unless
+    let expected_schema = expect![[r#"
+        generator client {
+          provider = "prisma-client-js"
+        }
+
+        datasource db {
+          provider = "mysql"
+          url      = "env(TEST_DATABASE_URL)"
+        }
+
+        model Post {
+          id       Int       @id @default(autoincrement())
+          userId   Int?      @default(3)
+          SomeUser SomeUser? @relation(fields: [userId], references: [id], onDelete: SetDefault, onUpdate: SetDefault)
+
+          @@index([userId], map: "Post_userId_fkey")
+        }
+
+        model SomeUser {
+          id   Int    @id @default(autoincrement())
+          Post Post[]
+        }
+    "#]];
+
+    expected_schema.assert_eq(&api.introspect().await?);
+    let validation = psl::parse_schema(expected_schema.data());
+
+    let expected_validation = expect![[r#"
+        [1;91merror[0m: [1mError validating: Invalid referential action: `SetDefault`. Allowed values: (`Cascade`, `Restrict`, `NoAction`, `SetNull`). `SetDefault` is invalid for MySQL when using `relationMode = \"foreignKeys\"`, as MySQL does not support the
+        `SET DEFAULT` referential action. Learn more at https://github.com/prisma/prisma/issues/11498
+        [0m
+          [1;94m-->[0m  [4mschema.prisma:14[0m
+        [1;94m   | [0m
+        [1;94m13 | [0m          userId   Int?      @default(3)
+        [1;94m14 | [0m          SomeUser SomeUser? @relation(fields: [userId], references: [id], [1;91monDelete: SetDefault[0m, onUpdate: SetDefault)
+        [1;94m   | [0m
+        [1;91merror[0m: [1mError validating: Invalid referential action: `SetDefault`. Allowed values: (`Cascade`, `Restrict`, `NoAction`, `SetNull`). `SetDefault` is invalid for MySQL when using `relationMode = \"foreignKeys\"`, as MySQL does not support the
+        `SET DEFAULT` referential action. Learn more at https://github.com/prisma/prisma/issues/11498
+        [0m
+          [1;94m-->[0m  [4mschema.prisma:14[0m
+        [1;94m   | [0m
+        [1;94m13 | [0m          userId   Int?      @default(3)
+        [1;94m14 | [0m          SomeUser SomeUser? @relation(fields: [userId], references: [id], onDelete: SetDefault, [1;91monUpdate: SetDefault[0m)
+        [1;94m   | [0m
+    "#]];
+    expected_validation.assert_eq(&validation.err().unwrap());
+
+    Ok(())
+}

--- a/introspection-engine/introspection-engine-tests/tests/referential_actions/mysql.rs
+++ b/introspection-engine/introspection-engine-tests/tests/referential_actions/mysql.rs
@@ -23,8 +23,6 @@ async fn introspect_set_default_should_fail(api: &TestApi) -> TestResult {
 
     api.raw_cmd(setup).await;
 
-    // TODO: this is currently succeeding, but should fail instead.
-    // That is, unless
     let expected_schema = expect![[r#"
         generator client {
           provider = "prisma-client-js"
@@ -53,16 +51,16 @@ async fn introspect_set_default_should_fail(api: &TestApi) -> TestResult {
     let validation = psl::parse_schema(expected_schema.data());
 
     let expected_validation = expect![[r#"
-        [1;91merror[0m: [1mError validating: Invalid referential action: `SetDefault`. Allowed values: (`Cascade`, `Restrict`, `NoAction`, `SetNull`). `SetDefault` is invalid for MySQL when using `relationMode = \"foreignKeys\"`, as MySQL does not support the
-        `SET DEFAULT` referential action. Learn more at https://github.com/prisma/prisma/issues/11498
+        [1;91merror[0m: [1mError validating: Invalid referential action: `SetDefault`. Allowed values: (`Cascade`, `Restrict`, `NoAction`, `SetNull`). `SetDefault` is invalid for MySQL when using `relationMode = \"foreignKeys\"`, as MySQL does not support the `SET DEFAULT` referential action.
+        Learn more at https://github.com/prisma/prisma/issues/11498
         [0m
           [1;94m-->[0m  [4mschema.prisma:14[0m
         [1;94m   | [0m
         [1;94m13 | [0m          userId   Int?      @default(3)
         [1;94m14 | [0m          SomeUser SomeUser? @relation(fields: [userId], references: [id], [1;91monDelete: SetDefault[0m, onUpdate: SetDefault)
         [1;94m   | [0m
-        [1;91merror[0m: [1mError validating: Invalid referential action: `SetDefault`. Allowed values: (`Cascade`, `Restrict`, `NoAction`, `SetNull`). `SetDefault` is invalid for MySQL when using `relationMode = \"foreignKeys\"`, as MySQL does not support the
-        `SET DEFAULT` referential action. Learn more at https://github.com/prisma/prisma/issues/11498
+        [1;91merror[0m: [1mError validating: Invalid referential action: `SetDefault`. Allowed values: (`Cascade`, `Restrict`, `NoAction`, `SetNull`). `SetDefault` is invalid for MySQL when using `relationMode = \"foreignKeys\"`, as MySQL does not support the `SET DEFAULT` referential action.
+        Learn more at https://github.com/prisma/prisma/issues/11498
         [0m
           [1;94m-->[0m  [4mschema.prisma:14[0m
         [1;94m   | [0m

--- a/migration-engine/migration-engine-tests/tests/migrations/relations.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/relations.rs
@@ -572,9 +572,11 @@ fn on_delete_referential_actions_should_work(api: TestApi) {
     }
 }
 
-// 5.6 and 5.7 doesn't let you `SET DEFAULT` without setting the default value
-// (even if nullable). Maria will silently just use `RESTRICT` instead.
-#[test_connector(exclude(Mysql56, Mysql57, Mariadb, Mssql, Vitess, CockroachDb))]
+// "mysql" provider bug: https://github.com/prisma/prisma/issues/11498
+// MySQL 5.6+ raises a syntax error when declaring `SET DEFAULT` in a `CREATE TABLE`/`ALTER TABLE` statement.
+// MySQL 8.0+ & MariaDB 10.0 allow you to create a table with `SET DEFAULT` referential action, but as soon as such action
+// is triggered, a runtime foreign key constraint error is raised, due to the databases silently using `NO ACTION`/`RESTRICT` instead.
+#[test_connector(exclude(Mysql, Mariadb, Mssql, Vitess, CockroachDb))]
 fn on_delete_set_default_should_work(api: TestApi) {
     let dm = r#"
         model A {
@@ -660,9 +662,11 @@ fn on_update_referential_actions_should_work(api: TestApi) {
     }
 }
 
-// 5.6 and 5.7 doesn't let you `SET DEFAULT` without setting the default value
-// (even if nullable). Maria will silently just use `RESTRICT` instead.
-#[test_connector(exclude(Mysql56, Mysql57, Mariadb, Mssql, Vitess, CockroachDb))]
+// "mysql" provider bug: https://github.com/prisma/prisma/issues/11498
+// MySQL 5.6+ raises a syntax error when declaring `SET DEFAULT` in a `CREATE TABLE`/`ALTER TABLE` statement.
+// MySQL 8.0+ & MariaDB 10.0 allow you to create a table with `SET DEFAULT` referential action, but as soon as such action
+// is triggered, a runtime foreign key constraint error is raised, due to the databases silently using `NO ACTION`/`RESTRICT` instead.
+#[test_connector(exclude(Mysql, Mariadb, Mssql, Vitess, CockroachDb))]
 fn on_update_set_default_should_work(api: TestApi) {
     let dm = r#"
         model A {

--- a/psl/builtin-connectors/src/mysql_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/mysql_datamodel_connector.rs
@@ -90,7 +90,7 @@ impl Connector for MySqlDatamodelConnector {
     fn referential_actions(&self) -> BitFlags<ReferentialAction> {
         use ReferentialAction::*;
 
-        Restrict | Cascade | SetNull | NoAction | SetDefault
+        Restrict | Cascade | SetNull | NoAction
     }
 
     fn scalar_type_for_native_type(&self, native_type: &NativeTypeInstance) -> ScalarType {

--- a/psl/psl-core/src/validate/validation_pipeline/validations/relation_fields.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/relation_fields.rs
@@ -155,8 +155,8 @@ pub(super) fn referential_actions(field: RelationFieldWalker<'_>, ctx: &mut Cont
         let additional_info = match (action, connector.provider_name()) {
             (ReferentialAction::SetDefault, "mysql") => Some(formatdoc! {
                 r#"
-                    . `{set_default}` is invalid for {provider} when using `relationMode = \"foreignKeys\"`, as {provider} does not support the
-                    `SET DEFAULT` referential action. Learn more at https://github.com/prisma/prisma/issues/11498
+                    . `{set_default}` is invalid for {provider} when using `relationMode = \"foreignKeys\"`, as {provider} does not support the `SET DEFAULT` referential action.
+                    Learn more at https://github.com/prisma/prisma/issues/11498
                     "#,
                 set_default = ReferentialAction::SetDefault.as_str(),
                 provider = connector.name(),

--- a/psl/psl/tests/attributes/relations/referential_actions.rs
+++ b/psl/psl/tests/attributes/relations/referential_actions.rs
@@ -534,48 +534,6 @@ fn invalid_on_update_action() {
 }
 
 #[test]
-fn set_default_should_not_work_on_mysql() {
-    let dml = indoc! { r#"
-        datasource db {
-            provider = "mysql"
-            url = "mysql://"
-        }
-
-        model A {
-            id Int @id
-            bs B[]
-        }
-
-        model B {
-            id Int   @id
-            aId Int? @default(3)
-            a   A?   @relation(fields: [aId], references: [id], onUpdate: SetDefault, onDelete: SetDefault)
-        }
-    "#};
-
-    let expected = expect![[r#"
-        [1;91merror[0m: [1mError validating: Invalid referential action: `SetDefault`. Allowed values: (`Cascade`, `Restrict`, `NoAction`, `SetNull`). `SetDefault` is invalid for MySQL when using `relationMode = \"foreignKeys\"`, as MySQL does not support the `SET DEFAULT` referential action.
-        Learn more at https://github.com/prisma/prisma/issues/11498
-        [0m
-          [1;94m-->[0m  [4mschema.prisma:14[0m
-        [1;94m   | [0m
-        [1;94m13 | [0m    aId Int? @default(3)
-        [1;94m14 | [0m    a   A?   @relation(fields: [aId], references: [id], onUpdate: SetDefault, [1;91monDelete: SetDefault[0m)
-        [1;94m   | [0m
-        [1;91merror[0m: [1mError validating: Invalid referential action: `SetDefault`. Allowed values: (`Cascade`, `Restrict`, `NoAction`, `SetNull`). `SetDefault` is invalid for MySQL when using `relationMode = \"foreignKeys\"`, as MySQL does not support the `SET DEFAULT` referential action.
-        Learn more at https://github.com/prisma/prisma/issues/11498
-        [0m
-          [1;94m-->[0m  [4mschema.prisma:14[0m
-        [1;94m   | [0m
-        [1;94m13 | [0m    aId Int? @default(3)
-        [1;94m14 | [0m    a   A?   @relation(fields: [aId], references: [id], [1;91monUpdate: SetDefault[0m, onDelete: SetDefault)
-        [1;94m   | [0m
-    "#]];
-
-    expected.assert_eq(&parse_unwrap_err(dml));
-}
-
-#[test]
 fn restrict_should_not_work_on_sql_server() {
     let dml = indoc! { r#"
         datasource db {

--- a/psl/psl/tests/attributes/relations/referential_actions.rs
+++ b/psl/psl/tests/attributes/relations/referential_actions.rs
@@ -554,16 +554,16 @@ fn set_default_should_not_work_on_mysql() {
     "#};
 
     let expected = expect![[r#"
-        [1;91merror[0m: [1mError validating: Invalid referential action: `SetDefault`. Allowed values: (`Cascade`, `Restrict`, `NoAction`, `SetNull`). `SetDefault` is invalid for MySQL when using `relationMode = \"foreignKeys\"`, as MySQL does not support the
-        `SET DEFAULT` referential action. Learn more at https://github.com/prisma/prisma/issues/11498
+        [1;91merror[0m: [1mError validating: Invalid referential action: `SetDefault`. Allowed values: (`Cascade`, `Restrict`, `NoAction`, `SetNull`). `SetDefault` is invalid for MySQL when using `relationMode = \"foreignKeys\"`, as MySQL does not support the `SET DEFAULT` referential action.
+        Learn more at https://github.com/prisma/prisma/issues/11498
         [0m
           [1;94m-->[0m  [4mschema.prisma:14[0m
         [1;94m   | [0m
         [1;94m13 | [0m    aId Int? @default(3)
         [1;94m14 | [0m    a   A?   @relation(fields: [aId], references: [id], onUpdate: SetDefault, [1;91monDelete: SetDefault[0m)
         [1;94m   | [0m
-        [1;91merror[0m: [1mError validating: Invalid referential action: `SetDefault`. Allowed values: (`Cascade`, `Restrict`, `NoAction`, `SetNull`). `SetDefault` is invalid for MySQL when using `relationMode = \"foreignKeys\"`, as MySQL does not support the
-        `SET DEFAULT` referential action. Learn more at https://github.com/prisma/prisma/issues/11498
+        [1;91merror[0m: [1mError validating: Invalid referential action: `SetDefault`. Allowed values: (`Cascade`, `Restrict`, `NoAction`, `SetNull`). `SetDefault` is invalid for MySQL when using `relationMode = \"foreignKeys\"`, as MySQL does not support the `SET DEFAULT` referential action.
+        Learn more at https://github.com/prisma/prisma/issues/11498
         [0m
           [1;94m-->[0m  [4mschema.prisma:14[0m
         [1;94m   | [0m

--- a/psl/psl/tests/validation/mysql/set_default_disabled.prisma
+++ b/psl/psl/tests/validation/mysql/set_default_disabled.prisma
@@ -1,0 +1,31 @@
+datasource db {
+    provider = "mysql"
+    url = "mysql://"
+}
+
+model A {
+    id Int @id
+    bs B[]
+}
+
+model B {
+    id Int   @id
+    aId Int? @default(3)
+    a   A?   @relation(fields: [aId], references: [id], onUpdate: SetDefault, onDelete: SetDefault)
+}
+// [1;91merror[0m: [1mError validating: Invalid referential action: `SetDefault`. Allowed values: (`Cascade`, `Restrict`, `NoAction`, `SetNull`). `SetDefault` is invalid for MySQL when using `relationMode = \"foreignKeys\"`, as MySQL does not support the `SET DEFAULT` referential action.
+// Learn more at https://github.com/prisma/prisma/issues/11498
+// [0m
+//   [1;94m-->[0m  [4mschema.prisma:14[0m
+// [1;94m   | [0m
+// [1;94m13 | [0m    aId Int? @default(3)
+// [1;94m14 | [0m    a   A?   @relation(fields: [aId], references: [id], onUpdate: SetDefault, [1;91monDelete: SetDefault[0m)
+// [1;94m   | [0m
+// [1;91merror[0m: [1mError validating: Invalid referential action: `SetDefault`. Allowed values: (`Cascade`, `Restrict`, `NoAction`, `SetNull`). `SetDefault` is invalid for MySQL when using `relationMode = \"foreignKeys\"`, as MySQL does not support the `SET DEFAULT` referential action.
+// Learn more at https://github.com/prisma/prisma/issues/11498
+// [0m
+//   [1;94m-->[0m  [4mschema.prisma:14[0m
+// [1;94m   | [0m
+// [1;94m13 | [0m    aId Int? @default(3)
+// [1;94m14 | [0m    a   A?   @relation(fields: [aId], references: [id], [1;91monUpdate: SetDefault[0m, onDelete: SetDefault)
+// [1;94m   | [0m

--- a/psl/psl/tests/validation/mysql/set_default_disabled_when_relation_mode_foreign_keys.prisma
+++ b/psl/psl/tests/validation/mysql/set_default_disabled_when_relation_mode_foreign_keys.prisma
@@ -1,0 +1,37 @@
+generator client {
+    provider = "prisma-client-js"
+    previewFeatures = ["referentialIntegrity"]
+}
+
+datasource db {
+    provider = "mysql"
+    url = "mysql://"
+    relationMode = "foreignKeys"
+}
+
+model A {
+    id Int @id
+    bs B[]
+}
+
+model B {
+    id Int   @id
+    aId Int? @default(3)
+    a   A?   @relation(fields: [aId], references: [id], onUpdate: SetDefault, onDelete: SetDefault)
+}
+// [1;91merror[0m: [1mError validating: Invalid referential action: `SetDefault`. Allowed values: (`Cascade`, `Restrict`, `NoAction`, `SetNull`). `SetDefault` is invalid for MySQL when using `relationMode = \"foreignKeys\"`, as MySQL does not support the `SET DEFAULT` referential action.
+// Learn more at https://github.com/prisma/prisma/issues/11498
+// [0m
+//   [1;94m-->[0m  [4mschema.prisma:20[0m
+// [1;94m   | [0m
+// [1;94m19 | [0m    aId Int? @default(3)
+// [1;94m20 | [0m    a   A?   @relation(fields: [aId], references: [id], onUpdate: SetDefault, [1;91monDelete: SetDefault[0m)
+// [1;94m   | [0m
+// [1;91merror[0m: [1mError validating: Invalid referential action: `SetDefault`. Allowed values: (`Cascade`, `Restrict`, `NoAction`, `SetNull`). `SetDefault` is invalid for MySQL when using `relationMode = \"foreignKeys\"`, as MySQL does not support the `SET DEFAULT` referential action.
+// Learn more at https://github.com/prisma/prisma/issues/11498
+// [0m
+//   [1;94m-->[0m  [4mschema.prisma:20[0m
+// [1;94m   | [0m
+// [1;94m19 | [0m    aId Int? @default(3)
+// [1;94m20 | [0m    a   A?   @relation(fields: [aId], references: [id], [1;91monUpdate: SetDefault[0m, onDelete: SetDefault)
+// [1;94m   | [0m


### PR DESCRIPTION
See the [internal document](https://www.notion.so/prismaio/SetDefault-referential-action-on-MySQL-68d7bdbe6fc947cf8829d7ca7dc2b001) for reference.

Validation message:
> Invalid referential action: `SetDefault`. Allowed values: (`Cascade`, `Restrict`, `NoAction`, `SetNull`). `SetDefault` is invalid for MySQL when using `relationMode = "foreignKeys"`, as MySQL does not support the `SET DEFAULT` referential action.
        Learn more at https://github.com/prisma/prisma/issues/11498

TODO:
- [x] test validation
- [x] test introspection
- [ ] add clear final comment to https://github.com/prisma/prisma/issues/11498
  - [ ] add link to [pris.ly](https://github.com/prisma/pris.ly/blob/main/vercel.json)

Contributes to https://github.com/prisma/prisma/issues/11498.