### PR TITLE
sql-schema-describer: normalize enum variants

### DIFF
--- a/introspection-engine/introspection-engine-tests/tests/rpc_calls/get_database_description.rs
+++ b/introspection-engine/introspection-engine-tests/tests/rpc_calls/get_database_description.rs
@@ -30,6 +30,7 @@ async fn database_description_for_mysql_should_work(api: &TestApi) -> TestResult
             }
           ],
           "enums": [],
+          "enum_variants": [],
           "columns": [
             [
               0,
@@ -100,6 +101,7 @@ async fn database_description_for_mysql_8_should_work(api: &TestApi) -> TestResu
             }
           ],
           "enums": [],
+          "enum_variants": [],
           "columns": [
             [
               0,
@@ -172,6 +174,7 @@ async fn database_description_for_postgres_should_work(api: &TestApi) -> TestRes
             }
           ],
           "enums": [],
+          "enum_variants": [],
           "columns": [
             [
               0,
@@ -247,6 +250,7 @@ async fn database_description_for_sqlite_should_work(api: &TestApi) -> TestResul
             }
           ],
           "enums": [],
+          "enum_variants": [],
           "columns": [
             [
               0,

--- a/libs/sql-schema-describer/src/ids.rs
+++ b/libs/sql-schema-describer/src/ids.rs
@@ -8,6 +8,10 @@ pub struct TableId(pub(crate) u32);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct EnumId(pub(crate) u32);
 
+/// The identifier for an enum variant in a SqlSchema.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct EnumVariantId(pub(crate) u32);
+
 /// The identifier for a column in a SqlSchema.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct ColumnId(pub(crate) u32);

--- a/libs/sql-schema-describer/src/lib.rs
+++ b/libs/sql-schema-describer/src/lib.rs
@@ -61,6 +61,7 @@ pub struct SqlSchema {
     tables: Vec<Table>,
     /// The schema's enums.
     enums: Vec<Enum>,
+    enum_variants: Vec<EnumVariant>,
     /// The schema's columns.
     columns: Vec<(TableId, Column)>,
     /// All foreign keys.
@@ -167,14 +168,15 @@ impl SqlSchema {
         self.enums.push(Enum {
             namespace_id,
             name: enum_name,
-            values: Vec::new(),
         });
         id
     }
 
     /// Add a variant to an enum.
-    pub fn push_enum_variant(&mut self, enum_id: EnumId, variant: String) {
-        self.enums[enum_id.0 as usize].values.push(variant)
+    pub fn push_enum_variant(&mut self, enum_id: EnumId, variant_name: String) -> EnumVariantId {
+        let id = EnumVariantId(self.enum_variants.len() as u32);
+        self.enum_variants.push(EnumVariant { enum_id, variant_name });
+        id
     }
 
     /// Add a fulltext index to the schema.
@@ -611,13 +613,17 @@ struct ForeignKeyColumn {
 }
 
 /// A SQL enum.
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 struct Enum {
     /// The namespace the enum type belongs to, if applicable.
     namespace_id: NamespaceId,
     name: String,
-    /// Possible enum values.
-    values: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct EnumVariant {
+    enum_id: EnumId,
+    variant_name: String,
 }
 
 /// An SQL view.

--- a/libs/sql-schema-describer/src/walkers.rs
+++ b/libs/sql-schema-describer/src/walkers.rs
@@ -454,8 +454,9 @@ impl<'a> EnumWalker<'a> {
     }
 
     /// The values of the enum
-    pub fn values(self) -> &'a [String] {
-        &self.get().values
+    pub fn values(self) -> impl ExactSizeIterator<Item = &'a str> {
+        range_for_key(&self.schema.enum_variants, self.id, |variant| variant.enum_id)
+            .map(move |idx| self.schema.enum_variants[idx].variant_name.as_str())
     }
 }
 

--- a/libs/sql-schema-describer/tests/describers/mssql_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/mssql_describer_tests.rs
@@ -137,6 +137,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                 },
             ],
             enums: [],
+            enum_variants: [],
             columns: [
                 (
                     TableId(

--- a/libs/sql-schema-describer/tests/describers/mysql_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/mysql_describer_tests.rs
@@ -104,10 +104,20 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                         0,
                     ),
                     name: "User_enum_col",
-                    values: [
-                        "a",
-                        "b",
-                    ],
+                },
+            ],
+            enum_variants: [
+                EnumVariant {
+                    enum_id: EnumId(
+                        0,
+                    ),
+                    variant_name: "a",
+                },
+                EnumVariant {
+                    enum_id: EnumId(
+                        0,
+                    ),
+                    variant_name: "b",
                 },
             ],
             columns: [
@@ -916,10 +926,20 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                         0,
                     ),
                     name: "User_enum_col",
-                    values: [
-                        "a",
-                        "b",
-                    ],
+                },
+            ],
+            enum_variants: [
+                EnumVariant {
+                    enum_id: EnumId(
+                        0,
+                    ),
+                    variant_name: "a",
+                },
+                EnumVariant {
+                    enum_id: EnumId(
+                        0,
+                    ),
+                    variant_name: "b",
                 },
             ],
             columns: [
@@ -1731,10 +1751,20 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                         0,
                     ),
                     name: "User_enum_col",
-                    values: [
-                        "a",
-                        "b",
-                    ],
+                },
+            ],
+            enum_variants: [
+                EnumVariant {
+                    enum_id: EnumId(
+                        0,
+                    ),
+                    variant_name: "a",
+                },
+                EnumVariant {
+                    enum_id: EnumId(
+                        0,
+                    ),
+                    variant_name: "b",
                 },
             ],
             columns: [
@@ -2606,6 +2636,7 @@ fn constraints_from_other_databases_should_not_be_introspected(api: TestApi) {
                 },
             ],
             enums: [],
+            enum_variants: [],
             columns: [
                 (
                     TableId(
@@ -2781,6 +2812,7 @@ fn introspected_default_strings_should_be_unescaped(api: TestApi) {
                 },
             ],
             enums: [],
+            enum_variants: [],
             columns: [
                 (
                     TableId(
@@ -2845,6 +2877,7 @@ fn escaped_quotes_in_string_defaults_must_be_unescaped(api: TestApi) {
                 },
             ],
             enums: [],
+            enum_variants: [],
             columns: [
                 (
                     TableId(
@@ -2936,6 +2969,7 @@ fn escaped_backslashes_in_string_literals_must_be_unescaped(api: TestApi) {
                 },
             ],
             enums: [],
+            enum_variants: [],
             columns: [
                 (
                     TableId(
@@ -3016,9 +3050,14 @@ fn function_expression_defaults_are_described_as_dbgenerated(api: TestApi) {
                         0,
                     ),
                     name: "game_enum_col",
-                    values: [
-                        "x-small",
-                    ],
+                },
+            ],
+            enum_variants: [
+                EnumVariant {
+                    enum_id: EnumId(
+                        0,
+                    ),
+                    variant_name: "x-small",
                 },
             ],
             columns: [

--- a/libs/sql-schema-describer/tests/describers/postgres_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/postgres_describer_tests.rs
@@ -142,6 +142,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                 },
             ],
             enums: [],
+            enum_variants: [],
             columns: [
                 (
                     TableId(
@@ -1152,7 +1153,11 @@ fn postgres_enums_must_work(api: TestApi) {
     let values = &["sad", "ok", "happy"];
 
     assert_eq!(got_enum.name(), "mood");
-    assert_eq!(got_enum.values(), values);
+    let found_values = got_enum.values();
+    assert_eq!(found_values.len(), values.len());
+    for (a, b) in found_values.zip(values) {
+        assert_eq!(a, *b)
+    }
 }
 
 #[test_connector(tags(Postgres), exclude(CockroachDb))]
@@ -1272,6 +1277,7 @@ fn escaped_quotes_in_string_defaults_must_be_unescaped(api: TestApi) {
                 },
             ],
             enums: [],
+            enum_variants: [],
             columns: [
                 (
                     TableId(
@@ -1431,6 +1437,7 @@ fn seemingly_escaped_backslashes_in_string_literals_must_not_be_unescaped(api: T
                 },
             ],
             enums: [],
+            enum_variants: [],
             columns: [
                 (
                     TableId(
@@ -1780,6 +1787,7 @@ fn multiple_schemas_with_same_table_names_are_described(api: TestApi) {
                 },
             ],
             enums: [],
+            enum_variants: [],
             columns: [
                 (
                     TableId(
@@ -1999,6 +2007,7 @@ fn multiple_schemas_with_same_foreign_key_are_described(api: TestApi) {
                 },
             ],
             enums: [],
+            enum_variants: [],
             columns: [
                 (
                     TableId(

--- a/libs/sql-schema-describer/tests/describers/postgres_describer_tests/cockroach_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/postgres_describer_tests/cockroach_describer_tests.rs
@@ -240,6 +240,7 @@ fn multi_field_indexes_must_be_inferred_in_the_right_order(api: TestApi) {
                 },
             ],
             enums: [],
+            enum_variants: [],
             columns: [
                 (
                     TableId(

--- a/libs/sql-schema-describer/tests/describers/sqlite_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/sqlite_describer_tests.rs
@@ -72,6 +72,7 @@ fn sqlite_column_types_must_work(api: TestApi) {
                 },
             ],
             enums: [],
+            enum_variants: [],
             columns: [
                 (
                     TableId(
@@ -280,6 +281,7 @@ fn escaped_quotes_in_string_defaults_must_be_unescaped(api: TestApi) {
                 },
             ],
             enums: [],
+            enum_variants: [],
             columns: [
                 (
                     TableId(
@@ -367,6 +369,7 @@ fn backslashes_in_string_literals(api: TestApi) {
                 },
             ],
             enums: [],
+            enum_variants: [],
             columns: [
                 (
                     TableId(
@@ -447,6 +450,7 @@ fn broken_relations_are_filtered_out(api: TestApi) {
                 },
             ],
             enums: [],
+            enum_variants: [],
             columns: [
                 (
                     TableId(

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/mysql.rs
@@ -155,14 +155,8 @@ fn is_safe_enum_change(columns: &Pair<ColumnWalker<'_>>, plan: &mut DestructiveC
     ) {
         let removed_values: Vec<String> = previous_enum
             .values()
-            .iter()
-            .filter(|previous_value| {
-                !next_enum
-                    .values()
-                    .iter()
-                    .any(|next_value| previous_value.as_str() == next_value.as_str())
-            })
-            .cloned()
+            .filter(|previous_value| !next_enum.values().any(|next_value| *previous_value == next_value))
+            .map(ToOwned::to_owned)
             .collect();
 
         if !removed_values.is_empty() {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
@@ -386,12 +386,7 @@ fn render_mysql_modify(
 
 fn render_column_type(column: ColumnWalker<'_>) -> Cow<'static, str> {
     if let ColumnTypeFamily::Enum(enum_id) = column.column_type_family() {
-        let variants: String = column
-            .walk(*enum_id)
-            .values()
-            .iter()
-            .map(Quoted::mysql_string)
-            .join(", ");
+        let variants: String = column.walk(*enum_id).values().map(Quoted::mysql_string).join(", ");
 
         return format!("ENUM({})", variants).into();
     }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
@@ -341,7 +341,7 @@ impl SqlRenderer for PostgresFlavour {
                     Quoted::postgres_ident(enm.name()),
                 ));
                 stmt.push_str(" AS ENUM (");
-                let mut values = enm.values().iter().peekable();
+                let mut values = enm.values().peekable();
                 while let Some(value) = values.next() {
                     stmt.push_display(&Quoted::postgres_string(value));
                     if values.peek().is_some() {
@@ -925,7 +925,7 @@ fn render_postgres_alter_enum(alter_enum: &AlterEnum, schemas: Pair<&SqlSchema>)
         let create_new_enum = format!(
             "CREATE TYPE {enum_name} AS ENUM ({variants})",
             enum_name = Quoted::postgres_ident(&tmp_name),
-            variants = enums.next.values().iter().map(Quoted::postgres_string).join(", ")
+            variants = enums.next.values().map(Quoted::postgres_string).join(", ")
         );
 
         stmts.push(create_new_enum);
@@ -1052,7 +1052,7 @@ fn render_cockroach_alter_enum(alter_enum: &AlterEnum, schemas: Pair<&SqlSchema>
                 .and_then(|v| v.as_enum_value())
                 .map(|value| (col, value))
         })
-        .filter(|(_, value)| !enums.next.values().iter().any(|v| v == value));
+        .filter(|(_, value)| !enums.next.values().any(|v| v == *value));
 
     for (col, _) in defaults_to_drop {
         renderer.render_statement(&mut |stmt| {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/mysql.rs
@@ -19,7 +19,7 @@ impl SqlSchemaCalculatorFlavour for MysqlFlavour {
             let sql_enum_id = ctx.schema.describer_schema.push_enum(Default::default(), name);
             ctx.enum_ids.insert(enum_tpe.id, sql_enum_id);
             for variant in enum_tpe.values().map(|v| v.database_name().to_owned()) {
-                ctx.schema.describer_schema.push_enum_variant(sql_enum_id, variant)
+                ctx.schema.describer_schema.push_enum_variant(sql_enum_id, variant);
             }
         }
     }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ.rs
@@ -312,9 +312,7 @@ fn push_alter_primary_key(differ: &TableDiffer<'_, '_>, steps: &mut Vec<SqlMigra
         _ => return,
     };
 
-    if previous.column_names().len() == next.column_names().len()
-        && previous.column_names().zip(next.column_names()).all(|(p, n)| p == n)
-    {
+    if all_match(&mut previous.column_names(), &mut next.column_names()) {
         return;
     }
 
@@ -533,4 +531,8 @@ fn is_prisma_implicit_m2m_fk(fk: ForeignKeyWalker<'_>) -> bool {
     }
 
     table.column("A").is_some() && table.column("B").is_some()
+}
+
+fn all_match<T: PartialEq>(a: &mut dyn ExactSizeIterator<Item = T>, b: &mut dyn ExactSizeIterator<Item = T>) -> bool {
+    a.len() == b.len() && a.zip(b).all(|(a, b)| a == b)
 }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/enums.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/enums.rs
@@ -8,35 +8,23 @@ pub(crate) struct EnumDiffer<'a> {
 
 impl<'a> EnumDiffer<'a> {
     pub(crate) fn created_values<'b>(&'b self) -> impl Iterator<Item = &'a str> + 'b {
-        self.enums
-            .next
-            .values()
-            .iter()
-            .filter(move |next_value| {
-                !self
-                    .enums
-                    .previous
-                    .values()
-                    .iter()
-                    .any(|previous_value| values_match(previous_value, next_value))
-            })
-            .map(String::as_str)
+        self.enums.next.values().filter(move |next_value| {
+            !self
+                .enums
+                .previous
+                .values()
+                .any(|previous_value| values_match(previous_value, next_value))
+        })
     }
 
     pub(crate) fn dropped_values<'b>(&'b self) -> impl Iterator<Item = &'a str> + 'b {
-        self.enums
-            .previous
-            .values()
-            .iter()
-            .filter(move |previous_value| {
-                !self
-                    .enums
-                    .next
-                    .values()
-                    .iter()
-                    .any(|next_value| values_match(previous_value, next_value))
-            })
-            .map(String::as_str)
+        self.enums.previous.values().filter(move |previous_value| {
+            !self
+                .enums
+                .next
+                .values()
+                .any(|next_value| values_match(previous_value, next_value))
+        })
     }
 }
 

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/mysql.rs
@@ -1,5 +1,9 @@
 use super::SqlSchemaDifferFlavour;
-use crate::{flavour::MysqlFlavour, pair::Pair, sql_schema_differ::ColumnTypeChange};
+use crate::{
+    flavour::MysqlFlavour,
+    pair::Pair,
+    sql_schema_differ::{all_match, ColumnTypeChange},
+};
 use psl::builtin_connectors::MySqlType;
 use sql_schema_describer::{
     walkers::{ColumnWalker, IndexWalker},
@@ -40,14 +44,13 @@ impl SqlSchemaDifferFlavour for MysqlFlavour {
             differ.next.column_type_family_as_enum(),
         ) {
             (Some(previous_enum), Some(next_enum)) => {
-                if previous_enum.values() == next_enum.values() {
+                if all_match(&mut previous_enum.values(), &mut next_enum.values()) {
                     return None;
                 }
 
                 return if previous_enum
                     .values()
-                    .iter()
-                    .all(|previous_value| next_enum.values().iter().any(|next_value| previous_value == next_value))
+                    .all(|previous_value| next_enum.values().any(|next_value| previous_value == next_value))
                 {
                     Some(ColumnTypeChange::SafeCast)
                 } else {

--- a/migration-engine/migration-engine-tests/src/assertions.rs
+++ b/migration-engine/migration-engine-tests/src/assertions.rs
@@ -171,11 +171,11 @@ pub struct EnumAssertion<'a>(sql::EnumWalker<'a>);
 impl<'a> EnumAssertion<'a> {
     pub fn assert_values(self, expected_values: &[&'static str]) -> Self {
         assert!(
-            self.0.values() == expected_values,
+            self.0.values().len() == expected_values.len() && self.0.values().zip(expected_values).all(|(a, b)| a == *b),
             "Assertion failed. The `{}` enum does not contain the expected variants.\nExpected:\n{:#?}\n\nFound:\n{:#?}\n",
             self.0.name(),
             expected_values,
-            self.0.values(),
+            self.0.values().collect::<Vec<_>>(),
         );
         self
     }


### PR DESCRIPTION
- Enums now have the same layout as the rest of SqlSchema.
- Enum variants get a typed stable identifier (EnumVariantId).