### PR TITLE
migration-engine: fix migrations for some UnexecutableStepChecks with multiSchema

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker.rs
@@ -87,11 +87,13 @@ impl SqlMigrationConnector {
             UnexecutableStepCheck::AddedRequiredFieldToTableWithPrismaLevelDefault {
                 table: column.table().name().to_owned(),
                 column: column.name().to_owned(),
+                namespace: column.table().namespace().map(str::to_owned),
             }
         } else {
             UnexecutableStepCheck::AddedRequiredFieldToTable {
                 column: column.name().to_owned(),
                 table: column.table().name().to_owned(),
+                namespace: column.table().namespace().map(str::to_owned),
             }
         };
 
@@ -207,6 +209,7 @@ impl SqlMigrationConnector {
                                     UnexecutableStepCheck::MadeOptionalFieldRequired {
                                         table: columns.previous.table().name().to_owned(),
                                         column: columns.previous.name().to_owned(),
+                                        namespace: columns.previous.table().namespace().map(str::to_owned),
                                     },
                                     step_index,
                                 );

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker.rs
@@ -35,6 +35,8 @@ use sql_schema_describer::{walkers::ColumnWalker, ColumnArity};
 use unexecutable_step_check::UnexecutableStepCheck;
 use warning_check::SqlMigrationWarningCheck;
 
+use self::check::Column;
+
 impl SqlMigrationConnector {
     fn check_table_drop(
         &self,
@@ -84,17 +86,17 @@ impl SqlMigrationConnector {
         }
 
         let typed_unexecutable = if has_virtual_default {
-            UnexecutableStepCheck::AddedRequiredFieldToTableWithPrismaLevelDefault {
-                table: column.table().name().to_owned(),
-                column: column.name().to_owned(),
-                namespace: column.table().namespace().map(str::to_owned),
-            }
+            UnexecutableStepCheck::AddedRequiredFieldToTableWithPrismaLevelDefault(Column::new(
+                column.table().name().to_owned(),
+                column.table().namespace().map(str::to_owned),
+                column.name().to_owned(),
+            ))
         } else {
-            UnexecutableStepCheck::AddedRequiredFieldToTable {
-                column: column.name().to_owned(),
-                table: column.table().name().to_owned(),
-                namespace: column.table().namespace().map(str::to_owned),
-            }
+            UnexecutableStepCheck::AddedRequiredFieldToTable(Column::new(
+                column.table().name().to_owned(),
+                column.table().namespace().map(str::to_owned),
+                column.name().to_owned(),
+            ))
         };
 
         plan.push_unexecutable(typed_unexecutable, step_index);
@@ -206,11 +208,11 @@ impl SqlMigrationConnector {
                                 && columns.next.default().is_none()
                             {
                                 plan.push_unexecutable(
-                                    UnexecutableStepCheck::MadeOptionalFieldRequired {
-                                        table: columns.previous.table().name().to_owned(),
-                                        column: columns.previous.name().to_owned(),
-                                        namespace: columns.previous.table().namespace().map(str::to_owned),
-                                    },
+                                    UnexecutableStepCheck::MadeOptionalFieldRequired(Column::new(
+                                        columns.previous.table().name().to_owned(),
+                                        columns.previous.table().namespace().map(str::to_owned),
+                                        columns.previous.name().to_owned(),
+                                    )),
                                     step_index,
                                 );
                             }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker.rs
@@ -86,17 +86,17 @@ impl SqlMigrationConnector {
         }
 
         let typed_unexecutable = if has_virtual_default {
-            UnexecutableStepCheck::AddedRequiredFieldToTableWithPrismaLevelDefault(Column::new(
-                column.table().name().to_owned(),
-                column.table().namespace().map(str::to_owned),
-                column.name().to_owned(),
-            ))
+            UnexecutableStepCheck::AddedRequiredFieldToTableWithPrismaLevelDefault(Column {
+                table: column.table().name().to_owned(),
+                namespace: column.table().namespace().map(str::to_owned),
+                column: column.name().to_owned(),
+            })
         } else {
-            UnexecutableStepCheck::AddedRequiredFieldToTable(Column::new(
-                column.table().name().to_owned(),
-                column.table().namespace().map(str::to_owned),
-                column.name().to_owned(),
-            ))
+            UnexecutableStepCheck::AddedRequiredFieldToTable(Column {
+                table: column.table().name().to_owned(),
+                namespace: column.table().namespace().map(str::to_owned),
+                column: column.name().to_owned(),
+            })
         };
 
         plan.push_unexecutable(typed_unexecutable, step_index);
@@ -208,11 +208,11 @@ impl SqlMigrationConnector {
                                 && columns.next.default().is_none()
                             {
                                 plan.push_unexecutable(
-                                    UnexecutableStepCheck::MadeOptionalFieldRequired(Column::new(
-                                        columns.previous.table().name().to_owned(),
-                                        columns.previous.table().namespace().map(str::to_owned),
-                                        columns.previous.name().to_owned(),
-                                    )),
+                                    UnexecutableStepCheck::MadeOptionalFieldRequired(Column {
+                                        table: columns.previous.table().name().to_owned(),
+                                        namespace: columns.previous.table().namespace().map(str::to_owned),
+                                        column: columns.previous.name().to_owned(),
+                                    }),
                                     step_index,
                                 );
                             }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/check.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/check.rs
@@ -7,10 +7,6 @@ pub struct Table {
 }
 
 impl Table {
-    pub fn new(table: String, namespace: Option<String>) -> Self {
-        Self { table, namespace }
-    }
-
     pub fn from_column(column: &Column) -> Self {
         Self {
             table: column.table.clone(),
@@ -24,16 +20,6 @@ pub struct Column {
     pub table: String,
     pub namespace: Option<String>,
     pub column: String,
-}
-
-impl Column {
-    pub fn new(table: String, namespace: Option<String>, column: String) -> Self {
-        Self {
-            table,
-            namespace,
-            column,
-        }
-    }
 }
 
 /// This trait should be implemented by warning and unexecutable migration types. It lets them

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/mssql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/mssql.rs
@@ -34,11 +34,11 @@ impl DestructiveChangeCheckerFlavour for MssqlFlavour {
 
         if changes.arity_changed() && columns.next.arity().is_required() {
             plan.push_unexecutable(
-                UnexecutableStepCheck::MadeOptionalFieldRequired {
-                    column: columns.previous.name().to_owned(),
-                    table: columns.previous.table().name().to_owned(),
-                    namespace: columns.previous.table().namespace().map(str::to_owned),
-                },
+                UnexecutableStepCheck::MadeOptionalFieldRequired(Column::new(
+                    columns.previous.table().name().to_owned(),
+                    columns.previous.table().namespace().map(str::to_owned),
+                    columns.previous.name().to_owned(),
+                )),
                 step_index,
             );
 
@@ -91,20 +91,20 @@ impl DestructiveChangeCheckerFlavour for MssqlFlavour {
             && columns.next.default().is_none()
         {
             plan.push_unexecutable(
-                UnexecutableStepCheck::AddedRequiredFieldToTable {
-                    column: columns.previous.name().to_owned(),
-                    table: columns.previous.table().name().to_owned(),
-                    namespace: columns.previous.table().namespace().map(str::to_owned),
-                },
+                UnexecutableStepCheck::AddedRequiredFieldToTable(Column::new(
+                    columns.previous.table().name().to_owned(),
+                    columns.previous.table().namespace().map(str::to_owned),
+                    columns.previous.name().to_owned(),
+                )),
                 step_index,
             )
         } else if columns.next.arity().is_required() && columns.next.default().is_none() {
             plan.push_unexecutable(
-                UnexecutableStepCheck::DropAndRecreateRequiredColumn {
-                    column: columns.previous.name().to_owned(),
-                    table: columns.previous.table().name().to_owned(),
-                    namespace: columns.previous.table().namespace().map(str::to_owned),
-                },
+                UnexecutableStepCheck::DropAndRecreateRequiredColumn(Column::new(
+                    columns.previous.table().name().to_owned(),
+                    columns.previous.table().namespace().map(str::to_owned),
+                    columns.previous.name().to_owned(),
+                )),
                 step_index,
             )
         } else {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/mssql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/mssql.rs
@@ -34,11 +34,11 @@ impl DestructiveChangeCheckerFlavour for MssqlFlavour {
 
         if changes.arity_changed() && columns.next.arity().is_required() {
             plan.push_unexecutable(
-                UnexecutableStepCheck::MadeOptionalFieldRequired(Column::new(
-                    columns.previous.table().name().to_owned(),
-                    columns.previous.table().namespace().map(str::to_owned),
-                    columns.previous.name().to_owned(),
-                )),
+                UnexecutableStepCheck::MadeOptionalFieldRequired(Column {
+                    table: columns.previous.table().name().to_owned(),
+                    namespace: columns.previous.table().namespace().map(str::to_owned),
+                    column: columns.previous.name().to_owned(),
+                }),
                 step_index,
             );
 
@@ -91,20 +91,20 @@ impl DestructiveChangeCheckerFlavour for MssqlFlavour {
             && columns.next.default().is_none()
         {
             plan.push_unexecutable(
-                UnexecutableStepCheck::AddedRequiredFieldToTable(Column::new(
-                    columns.previous.table().name().to_owned(),
-                    columns.previous.table().namespace().map(str::to_owned),
-                    columns.previous.name().to_owned(),
-                )),
+                UnexecutableStepCheck::AddedRequiredFieldToTable(Column {
+                    table: columns.previous.table().name().to_owned(),
+                    namespace: columns.previous.table().namespace().map(str::to_owned),
+                    column: columns.previous.name().to_owned(),
+                }),
                 step_index,
             )
         } else if columns.next.arity().is_required() && columns.next.default().is_none() {
             plan.push_unexecutable(
-                UnexecutableStepCheck::DropAndRecreateRequiredColumn(Column::new(
-                    columns.previous.table().name().to_owned(),
-                    columns.previous.table().namespace().map(str::to_owned),
-                    columns.previous.name().to_owned(),
-                )),
+                UnexecutableStepCheck::DropAndRecreateRequiredColumn(Column {
+                    table: columns.previous.table().name().to_owned(),
+                    namespace: columns.previous.table().namespace().map(str::to_owned),
+                    column: columns.previous.name().to_owned(),
+                }),
                 step_index,
             )
         } else {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/mssql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/mssql.rs
@@ -37,6 +37,7 @@ impl DestructiveChangeCheckerFlavour for MssqlFlavour {
                 UnexecutableStepCheck::MadeOptionalFieldRequired {
                     column: columns.previous.name().to_owned(),
                     table: columns.previous.table().name().to_owned(),
+                    namespace: columns.previous.table().namespace().map(str::to_owned),
                 },
                 step_index,
             );
@@ -93,6 +94,7 @@ impl DestructiveChangeCheckerFlavour for MssqlFlavour {
                 UnexecutableStepCheck::AddedRequiredFieldToTable {
                     column: columns.previous.name().to_owned(),
                     table: columns.previous.table().name().to_owned(),
+                    namespace: columns.previous.table().namespace().map(str::to_owned),
                 },
                 step_index,
             )
@@ -101,6 +103,7 @@ impl DestructiveChangeCheckerFlavour for MssqlFlavour {
                 UnexecutableStepCheck::DropAndRecreateRequiredColumn {
                     column: columns.previous.name().to_owned(),
                     table: columns.previous.table().name().to_owned(),
+                    namespace: columns.previous.table().namespace().map(str::to_owned),
                 },
                 step_index,
             )

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/mysql.rs
@@ -41,6 +41,7 @@ impl DestructiveChangeCheckerFlavour for MysqlFlavour {
                 UnexecutableStepCheck::MadeOptionalFieldRequired {
                     column: columns.previous.name().to_owned(),
                     table: columns.previous.table().name().to_owned(),
+                    namespace: columns.previous.table().namespace().map(str::to_owned),
                 },
                 step_index,
             );
@@ -101,6 +102,7 @@ impl DestructiveChangeCheckerFlavour for MysqlFlavour {
                 UnexecutableStepCheck::AddedRequiredFieldToTable {
                     column: columns.previous.name().to_owned(),
                     table: columns.previous.table().name().to_owned(),
+                    namespace: columns.previous.table().namespace().map(str::to_owned),
                 },
                 step_index,
             )
@@ -109,6 +111,7 @@ impl DestructiveChangeCheckerFlavour for MysqlFlavour {
                 UnexecutableStepCheck::DropAndRecreateRequiredColumn {
                     column: columns.previous.name().to_owned(),
                     table: columns.previous.table().name().to_owned(),
+                    namespace: columns.previous.table().namespace().map(str::to_owned),
                 },
                 step_index,
             )

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/mysql.rs
@@ -38,11 +38,11 @@ impl DestructiveChangeCheckerFlavour for MysqlFlavour {
         // empty or the column has no existing NULLs.
         if changes.arity_changed() && columns.next.arity().is_required() {
             plan.push_unexecutable(
-                UnexecutableStepCheck::MadeOptionalFieldRequired {
-                    column: columns.previous.name().to_owned(),
-                    table: columns.previous.table().name().to_owned(),
-                    namespace: columns.previous.table().namespace().map(str::to_owned),
-                },
+                UnexecutableStepCheck::MadeOptionalFieldRequired(Column::new(
+                    columns.previous.table().name().to_owned(),
+                    columns.previous.table().namespace().map(str::to_owned),
+                    columns.previous.name().to_owned(),
+                )),
                 step_index,
             );
 
@@ -99,20 +99,20 @@ impl DestructiveChangeCheckerFlavour for MysqlFlavour {
             && columns.next.default().is_none()
         {
             plan.push_unexecutable(
-                UnexecutableStepCheck::AddedRequiredFieldToTable {
-                    column: columns.previous.name().to_owned(),
-                    table: columns.previous.table().name().to_owned(),
-                    namespace: columns.previous.table().namespace().map(str::to_owned),
-                },
+                UnexecutableStepCheck::AddedRequiredFieldToTable(Column::new(
+                    columns.previous.table().name().to_owned(),
+                    columns.previous.table().namespace().map(str::to_owned),
+                    columns.previous.name().to_owned(),
+                )),
                 step_index,
             )
         } else if columns.next.arity().is_required() && columns.next.default().is_none() {
             plan.push_unexecutable(
-                UnexecutableStepCheck::DropAndRecreateRequiredColumn {
-                    column: columns.previous.name().to_owned(),
-                    table: columns.previous.table().name().to_owned(),
-                    namespace: columns.previous.table().namespace().map(str::to_owned),
-                },
+                UnexecutableStepCheck::DropAndRecreateRequiredColumn(Column::new(
+                    columns.previous.table().name().to_owned(),
+                    columns.previous.table().namespace().map(str::to_owned),
+                    columns.previous.name().to_owned(),
+                )),
                 step_index,
             )
         } else {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/mysql.rs
@@ -38,11 +38,11 @@ impl DestructiveChangeCheckerFlavour for MysqlFlavour {
         // empty or the column has no existing NULLs.
         if changes.arity_changed() && columns.next.arity().is_required() {
             plan.push_unexecutable(
-                UnexecutableStepCheck::MadeOptionalFieldRequired(Column::new(
-                    columns.previous.table().name().to_owned(),
-                    columns.previous.table().namespace().map(str::to_owned),
-                    columns.previous.name().to_owned(),
-                )),
+                UnexecutableStepCheck::MadeOptionalFieldRequired(Column {
+                    table: columns.previous.table().name().to_owned(),
+                    namespace: columns.previous.table().namespace().map(str::to_owned),
+                    column: columns.previous.name().to_owned(),
+                }),
                 step_index,
             );
 
@@ -99,20 +99,20 @@ impl DestructiveChangeCheckerFlavour for MysqlFlavour {
             && columns.next.default().is_none()
         {
             plan.push_unexecutable(
-                UnexecutableStepCheck::AddedRequiredFieldToTable(Column::new(
-                    columns.previous.table().name().to_owned(),
-                    columns.previous.table().namespace().map(str::to_owned),
-                    columns.previous.name().to_owned(),
-                )),
+                UnexecutableStepCheck::AddedRequiredFieldToTable(Column {
+                    table: columns.previous.table().name().to_owned(),
+                    namespace: columns.previous.table().namespace().map(str::to_owned),
+                    column: columns.previous.name().to_owned(),
+                }),
                 step_index,
             )
         } else if columns.next.arity().is_required() && columns.next.default().is_none() {
             plan.push_unexecutable(
-                UnexecutableStepCheck::DropAndRecreateRequiredColumn(Column::new(
-                    columns.previous.table().name().to_owned(),
-                    columns.previous.table().namespace().map(str::to_owned),
-                    columns.previous.name().to_owned(),
-                )),
+                UnexecutableStepCheck::DropAndRecreateRequiredColumn(Column {
+                    table: columns.previous.table().name().to_owned(),
+                    namespace: columns.previous.table().namespace().map(str::to_owned),
+                    column: columns.previous.name().to_owned(),
+                }),
                 step_index,
             )
         } else {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/postgres.rs
@@ -30,22 +30,22 @@ impl DestructiveChangeCheckerFlavour for PostgresFlavour {
 
         if changes.arity_changed() && columns.previous.arity().is_nullable() && columns.next.arity().is_required() {
             plan.push_unexecutable(
-                UnexecutableStepCheck::MadeOptionalFieldRequired {
-                    column: columns.previous.name().to_owned(),
-                    table: columns.previous.table().name().to_owned(),
-                    namespace: columns.previous.table().namespace().map(str::to_owned),
-                },
+                UnexecutableStepCheck::MadeOptionalFieldRequired(Column::new(
+                    columns.previous.table().name().to_owned(),
+                    columns.previous.table().namespace().map(str::to_owned),
+                    columns.previous.name().to_owned(),
+                )),
                 step_index,
             )
         }
 
         if changes.arity_changed() && !columns.previous.arity().is_list() && columns.next.arity().is_list() {
             plan.push_unexecutable(
-                UnexecutableStepCheck::MadeScalarFieldIntoArrayField {
-                    table: columns.previous.table().name().to_owned(),
-                    column: columns.previous.name().to_owned(),
-                    namespace: columns.previous.table().namespace().map(str::to_owned),
-                },
+                UnexecutableStepCheck::MadeScalarFieldIntoArrayField(Column::new(
+                    columns.previous.table().name().to_owned(),
+                    columns.previous.table().namespace().map(str::to_owned),
+                    columns.previous.name().to_owned(),
+                )),
                 step_index,
             )
         }
@@ -96,20 +96,20 @@ impl DestructiveChangeCheckerFlavour for PostgresFlavour {
             && columns.next.default().is_none()
         {
             plan.push_unexecutable(
-                UnexecutableStepCheck::AddedRequiredFieldToTable {
-                    column: columns.previous.name().to_owned(),
-                    table: columns.previous.table().name().to_owned(),
-                    namespace: columns.previous.table().namespace().map(str::to_owned),
-                },
+                UnexecutableStepCheck::AddedRequiredFieldToTable(Column::new(
+                    columns.previous.table().name().to_owned(),
+                    columns.previous.table().namespace().map(str::to_owned),
+                    columns.previous.name().to_owned(),
+                )),
                 step_index,
             )
         } else if columns.next.arity().is_required() && columns.next.default().is_none() {
             plan.push_unexecutable(
-                UnexecutableStepCheck::DropAndRecreateRequiredColumn {
-                    column: columns.previous.name().to_owned(),
-                    table: columns.previous.table().name().to_owned(),
-                    namespace: columns.previous.table().namespace().map(str::to_owned),
-                },
+                UnexecutableStepCheck::DropAndRecreateRequiredColumn(Column::new(
+                    columns.previous.table().name().to_owned(),
+                    columns.previous.table().namespace().map(str::to_owned),
+                    columns.previous.name().to_owned(),
+                )),
                 step_index,
             )
         } else {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/postgres.rs
@@ -30,22 +30,22 @@ impl DestructiveChangeCheckerFlavour for PostgresFlavour {
 
         if changes.arity_changed() && columns.previous.arity().is_nullable() && columns.next.arity().is_required() {
             plan.push_unexecutable(
-                UnexecutableStepCheck::MadeOptionalFieldRequired(Column::new(
-                    columns.previous.table().name().to_owned(),
-                    columns.previous.table().namespace().map(str::to_owned),
-                    columns.previous.name().to_owned(),
-                )),
+                UnexecutableStepCheck::MadeOptionalFieldRequired(Column {
+                    table: columns.previous.table().name().to_owned(),
+                    namespace: columns.previous.table().namespace().map(str::to_owned),
+                    column: columns.previous.name().to_owned(),
+                }),
                 step_index,
             )
         }
 
         if changes.arity_changed() && !columns.previous.arity().is_list() && columns.next.arity().is_list() {
             plan.push_unexecutable(
-                UnexecutableStepCheck::MadeScalarFieldIntoArrayField(Column::new(
-                    columns.previous.table().name().to_owned(),
-                    columns.previous.table().namespace().map(str::to_owned),
-                    columns.previous.name().to_owned(),
-                )),
+                UnexecutableStepCheck::MadeScalarFieldIntoArrayField(Column {
+                    table: columns.previous.table().name().to_owned(),
+                    namespace: columns.previous.table().namespace().map(str::to_owned),
+                    column: columns.previous.name().to_owned(),
+                }),
                 step_index,
             )
         }
@@ -96,20 +96,20 @@ impl DestructiveChangeCheckerFlavour for PostgresFlavour {
             && columns.next.default().is_none()
         {
             plan.push_unexecutable(
-                UnexecutableStepCheck::AddedRequiredFieldToTable(Column::new(
-                    columns.previous.table().name().to_owned(),
-                    columns.previous.table().namespace().map(str::to_owned),
-                    columns.previous.name().to_owned(),
-                )),
+                UnexecutableStepCheck::AddedRequiredFieldToTable(Column {
+                    table: columns.previous.table().name().to_owned(),
+                    namespace: columns.previous.table().namespace().map(str::to_owned),
+                    column: columns.previous.name().to_owned(),
+                }),
                 step_index,
             )
         } else if columns.next.arity().is_required() && columns.next.default().is_none() {
             plan.push_unexecutable(
-                UnexecutableStepCheck::DropAndRecreateRequiredColumn(Column::new(
-                    columns.previous.table().name().to_owned(),
-                    columns.previous.table().namespace().map(str::to_owned),
-                    columns.previous.name().to_owned(),
-                )),
+                UnexecutableStepCheck::DropAndRecreateRequiredColumn(Column {
+                    table: columns.previous.table().name().to_owned(),
+                    namespace: columns.previous.table().namespace().map(str::to_owned),
+                    column: columns.previous.name().to_owned(),
+                }),
                 step_index,
             )
         } else {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/postgres.rs
@@ -33,6 +33,7 @@ impl DestructiveChangeCheckerFlavour for PostgresFlavour {
                 UnexecutableStepCheck::MadeOptionalFieldRequired {
                     column: columns.previous.name().to_owned(),
                     table: columns.previous.table().name().to_owned(),
+                    namespace: columns.previous.table().namespace().map(str::to_owned),
                 },
                 step_index,
             )
@@ -43,6 +44,7 @@ impl DestructiveChangeCheckerFlavour for PostgresFlavour {
                 UnexecutableStepCheck::MadeScalarFieldIntoArrayField {
                     table: columns.previous.table().name().to_owned(),
                     column: columns.previous.name().to_owned(),
+                    namespace: columns.previous.table().namespace().map(str::to_owned),
                 },
                 step_index,
             )
@@ -97,6 +99,7 @@ impl DestructiveChangeCheckerFlavour for PostgresFlavour {
                 UnexecutableStepCheck::AddedRequiredFieldToTable {
                     column: columns.previous.name().to_owned(),
                     table: columns.previous.table().name().to_owned(),
+                    namespace: columns.previous.table().namespace().map(str::to_owned),
                 },
                 step_index,
             )
@@ -105,6 +108,7 @@ impl DestructiveChangeCheckerFlavour for PostgresFlavour {
                 UnexecutableStepCheck::DropAndRecreateRequiredColumn {
                     column: columns.previous.name().to_owned(),
                     table: columns.previous.table().name().to_owned(),
+                    namespace: columns.previous.table().namespace().map(str::to_owned),
                 },
                 step_index,
             )

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/sqlite.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/sqlite.rs
@@ -45,6 +45,7 @@ impl DestructiveChangeCheckerFlavour for SqliteFlavour {
                 UnexecutableStepCheck::MadeOptionalFieldRequired {
                     table: columns.previous.table().name().to_owned(),
                     column: columns.previous.name().to_owned(),
+                    namespace: columns.previous.table().namespace().map(str::to_owned),
                 },
                 step_index,
             );

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/sqlite.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/sqlite.rs
@@ -42,11 +42,11 @@ impl DestructiveChangeCheckerFlavour for SqliteFlavour {
             && columns.next.default().is_none()
         {
             plan.push_unexecutable(
-                UnexecutableStepCheck::MadeOptionalFieldRequired {
-                    table: columns.previous.table().name().to_owned(),
-                    column: columns.previous.name().to_owned(),
-                    namespace: columns.previous.table().namespace().map(str::to_owned),
-                },
+                UnexecutableStepCheck::MadeOptionalFieldRequired(Column::new(
+                    columns.previous.table().name().to_owned(),
+                    columns.previous.table().namespace().map(str::to_owned),
+                    columns.previous.name().to_owned(),
+                )),
                 step_index,
             );
         }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/sqlite.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/destructive_change_checker_flavour/sqlite.rs
@@ -42,11 +42,11 @@ impl DestructiveChangeCheckerFlavour for SqliteFlavour {
             && columns.next.default().is_none()
         {
             plan.push_unexecutable(
-                UnexecutableStepCheck::MadeOptionalFieldRequired(Column::new(
-                    columns.previous.table().name().to_owned(),
-                    columns.previous.table().namespace().map(str::to_owned),
-                    columns.previous.name().to_owned(),
-                )),
+                UnexecutableStepCheck::MadeOptionalFieldRequired(Column {
+                    table: columns.previous.table().name().to_owned(),
+                    namespace: columns.previous.table().namespace().map(str::to_owned),
+                    column: columns.previous.name().to_owned(),
+                }),
                 step_index,
             );
         }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/unexecutable_step_check.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/unexecutable_step_check.rs
@@ -5,52 +5,28 @@ use super::{
 
 #[derive(Debug)]
 pub(crate) enum UnexecutableStepCheck {
-    AddedRequiredFieldToTable {
-        table: String,
-        column: String,
-        namespace: Option<String>,
-    },
-    AddedRequiredFieldToTableWithPrismaLevelDefault {
-        table: String,
-        column: String,
-        namespace: Option<String>,
-    },
-    MadeOptionalFieldRequired {
-        table: String,
-        column: String,
-        namespace: Option<String>,
-    },
-    MadeScalarFieldIntoArrayField {
-        table: String,
-        column: String,
-        namespace: Option<String>,
-    },
-    DropAndRecreateRequiredColumn {
-        table: String,
-        column: String,
-        namespace: Option<String>,
-    },
+    AddedRequiredFieldToTable(Column),
+    AddedRequiredFieldToTableWithPrismaLevelDefault(Column),
+    MadeOptionalFieldRequired(Column),
+    MadeScalarFieldIntoArrayField(Column),
+    DropAndRecreateRequiredColumn(Column),
 }
 
 impl Check for UnexecutableStepCheck {
     fn needed_table_row_count(&self) -> Option<Table> {
         match self {
-            UnexecutableStepCheck::AddedRequiredFieldToTableWithPrismaLevelDefault { table, column: _, namespace }
-            | UnexecutableStepCheck::MadeOptionalFieldRequired { table, column: _, namespace }
-            | UnexecutableStepCheck::MadeScalarFieldIntoArrayField { table, column: _, namespace }
-            | UnexecutableStepCheck::AddedRequiredFieldToTable { table, column: _, namespace }
-            | UnexecutableStepCheck::DropAndRecreateRequiredColumn { table, column: _, namespace } => {
-                Some(Table::new(table.clone(), namespace.clone()))
-            }
+            UnexecutableStepCheck::AddedRequiredFieldToTableWithPrismaLevelDefault(column)
+            | UnexecutableStepCheck::MadeOptionalFieldRequired(column)
+            | UnexecutableStepCheck::MadeScalarFieldIntoArrayField(column)
+            | UnexecutableStepCheck::AddedRequiredFieldToTable(column)
+            | UnexecutableStepCheck::DropAndRecreateRequiredColumn(column) => Some(Table::from_column(column)),
         }
     }
 
     fn needed_column_value_count(&self) -> Option<Column> {
         match self {
-            UnexecutableStepCheck::MadeOptionalFieldRequired { table, column, namespace }
-            | UnexecutableStepCheck::MadeScalarFieldIntoArrayField { table, column, namespace } => {
-                Some(Column::new(table.clone(), namespace.clone(), column.clone()))
-            }
+            UnexecutableStepCheck::MadeOptionalFieldRequired(column)
+            | UnexecutableStepCheck::MadeScalarFieldIntoArrayField(column) => Some(column.clone()),
             UnexecutableStepCheck::AddedRequiredFieldToTable { .. }
             | UnexecutableStepCheck::AddedRequiredFieldToTableWithPrismaLevelDefault { .. }
             | UnexecutableStepCheck::DropAndRecreateRequiredColumn { .. } => None,
@@ -59,18 +35,17 @@ impl Check for UnexecutableStepCheck {
 
     fn evaluate<'a>(&self, database_checks: &DatabaseInspectionResults) -> Option<String> {
         match self {
-            UnexecutableStepCheck::AddedRequiredFieldToTable { table, column, namespace: _ } => {
+            UnexecutableStepCheck::AddedRequiredFieldToTable(column) => {
                 let message = |details| {
                     format!(
                         "Added the required column `{column}` to the `{table}` table without a default value. {details}",
-                        table = table,
-                        column = column,
+                        table = column.table,
+                        column = column.column,
                         details = details,
                     )
                 };
 
-                // TODO(MultiSchema): test this is fine
-                let message = match database_checks.get_row_count(&Table::new(table.clone(), None)) {
+                let message = match database_checks.get_row_count(&Table::from_column(column)) {
                     Some(0) => return None, // Adding a required column is possible if there is no data
                     Some(row_count) => message(format_args!(
                         "There are {row_count} rows in this table, it is not possible to execute this step.",
@@ -81,18 +56,17 @@ impl Check for UnexecutableStepCheck {
 
                 Some(message)
             }
-            UnexecutableStepCheck::AddedRequiredFieldToTableWithPrismaLevelDefault { table, column, namespace: _ } => {
+            UnexecutableStepCheck::AddedRequiredFieldToTableWithPrismaLevelDefault(column) => {
                 let message = |details| {
                     format!(
                         "The required column `{column}` was added to the `{table}` table with a prisma-level default value. {details} Please add this column as optional, then populate it before making it required.",
-                        table = table,
-                        column = column,
+                        table = column.table,
+                        column = column.column,
                         details = details,
                     )
                 };
 
-                // TODO(MultiSchema): test this is fine
-                let message = match database_checks.get_row_count(&Table::new(table.clone(), None)) {
+                let message = match database_checks.get_row_count(&Table::from_column(column)) {
                     Some(0) => return None, // Adding a required column is possible if there is no data
                     Some(row_count) => message(format_args!(
                         "There are {row_count} rows in this table, it is not possible to execute this step.",
@@ -103,8 +77,8 @@ impl Check for UnexecutableStepCheck {
 
                 Some(message)
             }
-            UnexecutableStepCheck::MadeOptionalFieldRequired { table, column, namespace } => {
-                match database_checks.get_row_and_non_null_value_count(&Column::new(table.clone(), namespace.clone(), column.clone())) {
+            UnexecutableStepCheck::MadeOptionalFieldRequired(column) => {
+                match database_checks.get_row_and_non_null_value_count(column) {
                     (Some(0), _) => None,
                     (Some(row_count), Some(value_count)) => {
                         let null_value_count = row_count - value_count;
@@ -115,29 +89,27 @@ impl Check for UnexecutableStepCheck {
 
                         Some(format!(
                             "Made the column `{column}` on table `{table}` required, but there are {null_value_count} existing NULL values.",
-                            column = column,
-                            table = table,
+                            column = column.column,
+                            table = column.table,
                             null_value_count = null_value_count,
                         ))
                     },
                     (_, _) => Some(format!(
                         "Made the column `{column}` on table `{table}` required. This step will fail if there are existing NULL values in that column.",
-                        column = column,
-                        table = table
+                        column = column.column,
+                        table = column.table
                     )),
                 }
             }
-            UnexecutableStepCheck::MadeScalarFieldIntoArrayField { table, column, namespace: _ } => {
+            UnexecutableStepCheck::MadeScalarFieldIntoArrayField(column) => {
                 let message = |details| {
-                    format!("Changed the column `{column}` on the `{table}` table from a scalar field to a list field. {details}", column = column, table = table, details = details)
+                    format!("Changed the column `{column}` on the `{table}` table from a scalar field to a list field. {details}",
+                            column = column.column,
+                            table = column.table,
+                            details = details)
                 };
 
-                // TODO(MultiSchema): test this is fine
-                match database_checks.get_row_and_non_null_value_count(&Column::new(
-                    table.clone(),
-                    None,
-                    column.clone(),
-                )) {
+                match database_checks.get_row_and_non_null_value_count(column) {
                     (Some(0), _) => None,
                     (_, Some(0)) => None,
                     (_, Some(value_count)) => Some(message(format_args!(
@@ -149,11 +121,11 @@ impl Check for UnexecutableStepCheck {
                     ))),
                 }
             }
-            UnexecutableStepCheck::DropAndRecreateRequiredColumn { table, column, namespace } => {
-                match database_checks.get_row_count(&Table::new(table.clone(), namespace.clone())) {
-                    None => Some(format!("Changed the type of `{column}` on the `{table}` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.", column = column, table = table)),
+            UnexecutableStepCheck::DropAndRecreateRequiredColumn(column) => {
+                match database_checks.get_row_count(&Table::from_column(column)) {
+                    None => Some(format!("Changed the type of `{column}` on the `{table}` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.", column = column.column, table = column.table)),
                     Some(0) => None,
-                    Some(_) => Some(format!("Changed the type of `{column}` on the `{table}` table. No cast exists, the column would be dropped and recreated, which cannot be done since the column is required and there is data in the table.", column = column, table = table)),
+                    Some(_) => Some(format!("Changed the type of `{column}` on the `{table}` table. No cast exists, the column would be dropped and recreated, which cannot be done since the column is required and there is data in the table.", column = column.column, table = column.table)),
                 }
             }
         }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/warning_check.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_destructive_change_checker/warning_check.rs
@@ -56,7 +56,10 @@ impl Check for SqlMigrationWarningCheck {
                 table,
                 column: _,
                 namespace,
-            } => Some(Table::new(table.clone(), namespace.clone())),
+            } => Some(Table {
+                table: table.clone(),
+                namespace: namespace.clone(),
+            }),
             SqlMigrationWarningCheck::NonEmptyColumnDrop { .. } | SqlMigrationWarningCheck::RiskyCast { .. } => None,
             _ => None,
         }
@@ -79,7 +82,11 @@ impl Check for SqlMigrationWarningCheck {
                 table,
                 column,
                 namespace,
-            } => Some(Column::new(table.clone(), namespace.clone(), column.clone())),
+            } => Some(Column {
+                table: table.clone(),
+                namespace: namespace.clone(),
+                column: column.clone(),
+            }),
 
             SqlMigrationWarningCheck::NonEmptyTableDrop { .. } | SqlMigrationWarningCheck::PrimaryKeyChange { .. } => {
                 None
@@ -91,7 +98,10 @@ impl Check for SqlMigrationWarningCheck {
     fn evaluate(&self, database_check_results: &DatabaseInspectionResults) -> Option<String> {
         match self {
             SqlMigrationWarningCheck::DropAndRecreateColumn { table, column, namespace } => {
-                match database_check_results.get_row_and_non_null_value_count(&Column::new(table.clone(), namespace.clone(), column.clone())) {
+                match database_check_results.get_row_and_non_null_value_count(&Column{
+                        table: table.clone(),
+                        namespace: namespace.clone(),
+                        column: column.clone()}) {
                 (Some(0), _) => None,
                 (_, Some(0)) => None,
                 (_, None) => Some(format!("The `{}` column on the `{}` table would be dropped and recreated. This will lead to data loss if there is data in the column.", column, table)),
@@ -99,18 +109,29 @@ impl Check for SqlMigrationWarningCheck {
 
             }
         },
-            SqlMigrationWarningCheck::NonEmptyTableDrop { table, namespace } => match database_check_results.get_row_count(&Table::new(table.clone(), namespace.clone())) {
+            SqlMigrationWarningCheck::NonEmptyTableDrop { table, namespace } =>
+                match database_check_results.get_row_count(&Table{
+                    table: table.clone(),
+                    namespace: namespace.clone()}) {
                 Some(0) => None, // dropping the table is safe if it's empty
                 Some(rows_count) => Some(format!("You are about to drop the `{table_name}` table, which is not empty ({rows_count} rows).", table_name = table, rows_count = rows_count)),
                 None => Some(format!("You are about to drop the `{}` table. If the table is not empty, all the data it contains will be lost.", table)),
             },
-            SqlMigrationWarningCheck::NonEmptyColumnDrop { table, column, namespace } => match database_check_results.get_row_and_non_null_value_count(&Column::new(table.clone(), namespace.clone(), column.clone())) {
+            SqlMigrationWarningCheck::NonEmptyColumnDrop { table, column, namespace } =>
+                match database_check_results.get_row_and_non_null_value_count(&Column{
+                    table: table.clone(),
+                    namespace: namespace.clone(),
+                    column: column.clone()}) {
                 (Some(0), _) => None, // it's safe to drop a column on an empty table
                 (_, Some(0)) => None, // it's safe to drop a column if it only contains null values
                 (_, Some(value_count)) => Some(format!("You are about to drop the column `{column_name}` on the `{table_name}` table, which still contains {value_count} non-null values.", column_name = column, table_name = table, value_count = value_count)),
                 (_, _) => Some(format!("You are about to drop the column `{column_name}` on the `{table_name}` table. All the data in the column will be lost.", column_name = column, table_name = table)),
             },
-            SqlMigrationWarningCheck::RiskyCast { table, column, previous_type, next_type, namespace } => match database_check_results.get_row_and_non_null_value_count(&Column::new(table.clone(), namespace.clone(), column.clone())) {
+            SqlMigrationWarningCheck::RiskyCast { table, column, previous_type, next_type, namespace } =>
+                match database_check_results.get_row_and_non_null_value_count(&Column{
+                    table: table.clone(),
+                    namespace: namespace.clone(),
+                    column: column.clone()}) {
                 (Some(0), _) => None, // it's safe to alter a column on an empty table
                 (_, Some(0)) => None, // it's safe to alter a column if it only contains null values
                 (_, Some(value_count)) => Some(format!("You are about to alter the column `{column_name}` on the `{table_name}` table, which contains {value_count} non-null values. The data in that column will be cast from `{old_type}` to `{new_type}`.", column_name = column, table_name = table, value_count = value_count, old_type = previous_type, new_type = next_type)),
@@ -119,18 +140,26 @@ impl Check for SqlMigrationWarningCheck {
             },
 
             // todo this seems to not be reached when only a table is dropped and recreated
-            SqlMigrationWarningCheck::NotCastable { table, column, previous_type, next_type, namespace } => match database_check_results.get_row_and_non_null_value_count(&Column::new(table.clone(), namespace.clone(), column.clone())) {
+            SqlMigrationWarningCheck::NotCastable { table, column, previous_type, next_type, namespace } =>
+                match database_check_results.get_row_and_non_null_value_count(&Column{
+                    table: table.clone(),
+                    namespace: namespace.clone(),
+                    column: column.clone()}) {
                 (Some(0), _) => None, // it's safe to alter a column on an empty table
                 (_, Some(0)) => None, // it's safe to alter a column if it only contains null values
                 (_, Some(value_count)) => Some(format!("You are about to alter the column `{column_name}` on the `{table_name}` table, which contains {value_count} non-null values. The data in that column will be cast from `{old_type}` to `{new_type}`. This cast may fail. Please make sure the data in the column can be cast.", column_name = column, table_name = table, value_count = value_count, old_type = previous_type, new_type = next_type)),
                 (_, _) => Some(format!("You are about to alter the column `{column_name}` on the `{table_name}` table. The data in that column will be cast from `{old_type}` to `{new_type}`. This cast may fail. Please make sure the data in the column can be cast.", column_name = column, table_name = table, old_type = previous_type, new_type = next_type)),
 
             },
-            SqlMigrationWarningCheck::PrimaryKeyChange { table, namespace } => match database_check_results.get_row_count(&Table::new(table.clone(), namespace.clone())) {
+            SqlMigrationWarningCheck::PrimaryKeyChange { table, namespace } =>
+                match database_check_results.get_row_count(&Table{
+                        table: table.clone(),
+                        namespace: namespace.clone()}) {
                 Some(0) => None,
                 _ => Some(format!("The primary key for the `{table}` table will be changed. If it partially fails, the table could be left without primary key constraint.", table = table)),
             },
-            SqlMigrationWarningCheck::UniqueConstraintAddition { table, columns } =>  Some(format!("A unique constraint covering the columns `[{columns}]` on the table `{table}` will be added. If there are existing duplicate values, this will fail.", table = table, columns = columns.join(","))),
+            SqlMigrationWarningCheck::UniqueConstraintAddition { table, columns } =>
+                Some(format!("A unique constraint covering the columns `[{columns}]` on the table `{table}` will be added. If there are existing duplicate values, this will fail.", table = table, columns = columns.join(","))),
             SqlMigrationWarningCheck::EnumValueRemoval { enm, values } =>  Some(format!("The values [{values}] on the enum `{enm}` will be removed. If these variants are still used in the database, this will fail.", enm = enm, values = values.join(","))),
 
         }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/common.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/common.rs
@@ -6,6 +6,12 @@ pub(super) const SQL_INDENTATION: &str = "    ";
 /// A table name with an optional schema prefix.
 pub(crate) struct TableName<T>(pub(crate) Option<Quoted<T>>, pub(crate) Quoted<T>);
 
+impl<T> TableName<T> {
+  pub(crate) fn new(namespace: Option<Quoted<T>>, name: Quoted<T>) -> Self {
+      TableName(namespace, name)
+  }
+}
+
 impl<T> Display for TableName<T>
 where
     T: Display,

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/common.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/common.rs
@@ -7,9 +7,9 @@ pub(super) const SQL_INDENTATION: &str = "    ";
 pub(crate) struct TableName<T>(pub(crate) Option<Quoted<T>>, pub(crate) Quoted<T>);
 
 impl<T> TableName<T> {
-  pub(crate) fn new(namespace: Option<Quoted<T>>, name: Quoted<T>) -> Self {
-      TableName(namespace, name)
-  }
+    pub(crate) fn new(namespace: Option<Quoted<T>>, name: Quoted<T>) -> Self {
+        TableName(namespace, name)
+    }
 }
 
 impl<T> Display for TableName<T>

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
@@ -320,7 +320,10 @@ impl SqlRenderer for PostgresFlavour {
         } else {
             let alter_table = format!(
                 "ALTER TABLE {} {}",
-                self.quote(tables.previous.name()),
+                TableName::new(
+                    tables.previous.namespace().map(|ns| self.quote(ns)),
+                    self.quote(tables.previous.name())
+                ),
                 lines.join(",\n")
             );
 

--- a/migration-engine/migration-engine-tests/tests/migrations/postgres/multi_schema.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/postgres/multi_schema.rs
@@ -173,3 +173,56 @@ fn multi_schema_remove_table(api: TestApi) {
         .assert_has_table("First")
         .assert_has_no_table("Second");
 }
+
+#[test_connector(
+    tags(Postgres),
+    exclude(CockroachDb),
+    preview_features("multiSchema"),
+    namespaces("one", "two")
+)]
+fn multi_schema_drop_and_recreate_column(api: TestApi) {
+    let base = indoc! {r#"
+        datasource db {
+          provider   = "postgresql"
+          url        = env("TEST_DATABASE_URL")
+          schemas    = ["one", "two"]
+        }
+        generator js {
+          provider        = "prisma-client-js"
+          previewFeatures = ["multiSchema"]
+        }
+        model First {
+          id Int @id
+          @@schema("one")
+        }
+    "#};
+    let first = base.to_owned()
+        + indoc! {r#"
+        model Second {
+          id Int @id
+          name String?
+          @@schema("two")
+        }
+    "#};
+    let second = base.to_owned()
+        + indoc! {r#"
+        model Second {
+          id Int @id
+          name String
+          @@schema("two")
+        }
+    "#};
+
+    api.schema_push(first).send().assert_green().assert_has_executed_steps();
+    api.schema_push(second)
+        .send()
+        .assert_warnings(&[])
+        .assert_has_executed_steps();
+
+    let mut vec_namespaces = vec![String::from("one"), String::from("two")];
+    let namespaces = Namespaces::from_vec(&mut vec_namespaces);
+
+    api.assert_schema_with_namespaces(namespaces)
+        .assert_has_table("First")
+        .assert_has_table("Second");
+}

--- a/migration-engine/migration-engine-tests/tests/migrations/postgres/multi_schema.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/postgres/multi_schema.rs
@@ -273,7 +273,9 @@ fn multi_schema_drop_and_recreate_not_null_column_with_null_value(api: TestApi) 
     api.schema_push(second)
         .send()
         .assert_warnings(&[])
-        .assert_unexecutable(&["Made the column `name` on table `Second` required, but there are 1 existing NULL values.".to_owned()])
+        .assert_unexecutable(&[
+            "Made the column `name` on table `Second` required, but there are 1 existing NULL values.".to_owned(),
+        ])
         .assert_no_steps();
 
     let mut vec_namespaces = vec![String::from("one"), String::from("two")];


### PR DESCRIPTION
Fix a couple more migrations for `multiSchema`, specifically for `AlterTable` (and `AlterColumn`).