### PR TITLE
Revert "chore(deps): update vitess/vttestserver:mysql57 docker digest to c861f3b"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -172,7 +172,7 @@ services:
     tmpfs: /var/lib/mariadb
 
   vitess-test-5_7:
-    image: vitess/vttestserver:mysql57@sha256:c861f3b668dbadfc19af1c4382a294af0ebb07d2c9acaf5247d68d3393c909a9
+    image: vitess/vttestserver:mysql57@sha256:2b132a22d08b3b227d9391f8f58ed7ab5c081ca07bf0f87a0c166729124d360a
     restart: always
     ports:
       - 33577:33577
@@ -196,7 +196,7 @@ services:
       FOREIGN_KEY_MODE: "disallow"
 
   vitess-shadow-5_7:
-    image: vitess/vttestserver:mysql57@sha256:c861f3b668dbadfc19af1c4382a294af0ebb07d2c9acaf5247d68d3393c909a9
+    image: vitess/vttestserver:mysql57@sha256:2b132a22d08b3b227d9391f8f58ed7ab5c081ca07bf0f87a0c166729124d360a
     restart: always
     ports:
       - 33578:33577


### PR DESCRIPTION
Reverts prisma/prisma-engines#3129

It introduced test failures we do not understand and look like a race condition / asynchronous operations pertaining to migrations inside vitess.