### PR TITLE
me: delete default impl for SqlSchemaDifferFlavour::column_type_change

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour.rs
@@ -42,13 +42,7 @@ pub(crate) trait SqlSchemaDifferFlavour {
     }
 
     /// Return whether a column's type needs to be migrated, and how.
-    fn column_type_change(&self, differ: Pair<ColumnWalker<'_>>) -> Option<ColumnTypeChange> {
-        if differ.previous.column_type_family() != differ.next.column_type_family() {
-            Some(ColumnTypeChange::RiskyCast)
-        } else {
-            None
-        }
-    }
+    fn column_type_change(&self, differ: Pair<ColumnWalker<'_>>) -> Option<ColumnTypeChange>;
 
     /// Push enum-related steps.
     fn push_enum_steps(&self, _steps: &mut Vec<SqlMigrationStep>, _db: &DifferDatabase<'_>) {}


### PR DESCRIPTION
This is dead code, and dangerous dead code because it relies on a PartialEq implementation that compares IDs.

follow up issue: https://github.com/prisma/prisma-engines/issues/3373