### PR TITLE
fix: compacting should only be done on findUnique queries

### DIFF
--- a/query-engine/core/src/query_document/mod.rs
+++ b/query-engine/core/src/query_document/mod.rs
@@ -71,6 +71,10 @@ impl BatchDocument {
     /// - non scalar filters (ie: relation filters, boolean operators...)
     /// - any scalar filters that is not `EQUALS`
     fn invalid_compact_filter(op: &Operation, schema: &QuerySchemaRef) -> bool {
+        if !op.is_find_unique() {
+            return true;
+        }
+
         let where_obj = op.as_read().unwrap().arguments()[0].1.clone().into_object().unwrap();
         let field = schema.find_query_field(op.name()).unwrap();
         let model = field.model().unwrap();


### PR DESCRIPTION
## Overview

fixes https://github.com/prisma/prisma/issues/16195

Under some precise circumstances (that is, when the first item of the batch is a findUnique but others aren't), the code could lead us to attempt reading filters from an operation that did not contain any.