### PR TITLE
migration-engine: fix a bunch of multiSchema migrations

### DIFF
--- a/libs/sql-ddl/src/postgres.rs
+++ b/libs/sql-ddl/src/postgres.rs
@@ -100,13 +100,13 @@ impl Display for Column<'_> {
 #[derive(Debug)]
 pub struct DropIndex<'a> {
     /// The name of the index to be dropped.
-    pub index_name: Cow<'a, str>,
+    pub index_name: PostgresIdentifier<'a>,
 }
 
 impl Display for DropIndex<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("DROP INDEX ")?;
-        Display::fmt(&PostgresIdentifier::from(self.index_name.as_ref()), f)
+        write!(f, "{}", self.index_name)
     }
 }
 

--- a/libs/sql-schema-describer/src/walkers.rs
+++ b/libs/sql-schema-describer/src/walkers.rs
@@ -173,6 +173,14 @@ impl<'a> ViewWalker<'a> {
         self.view().definition.as_deref()
     }
 
+    /// The namespace of the view
+    pub fn namespace(self) -> Option<&'a str> {
+        self.schema
+            .namespaces
+            .get(self.view().namespace_id.0 as usize)
+            .map(|s| s.as_str())
+    }
+
     fn view(self) -> &'a View {
         &self.schema.views[self.id.0 as usize]
     }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
@@ -443,15 +443,18 @@ impl SqlRenderer for PostgresFlavour {
     }
 
     fn render_drop_foreign_key(&self, foreign_key: ForeignKeyWalker<'_>) -> String {
-        // TODO(PR): I guess namespace should be here somewhere
         format!(
             "ALTER TABLE {table} DROP CONSTRAINT {constraint_name}",
-            table = self.quote(foreign_key.table().name()),
+            table = match foreign_key.table().namespace() {
+              Some(namespace) => PostgresIdentifier::WithSchema(namespace.into(), foreign_key.table().name().into()),
+              None => foreign_key.table().name().into(),
+            },
             constraint_name = Quoted::postgres_ident(foreign_key.constraint_name().unwrap()),
         )
     }
 
     fn render_drop_index(&self, index: IndexWalker<'_>) -> String {
+        // TODO(PR): I guess namespace should be here somewhere
         ddl::DropIndex {
             index_name: index.name().into(),
         }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
@@ -222,8 +222,13 @@ impl SqlRenderer for PostgresFlavour {
     fn render_rename_index(&self, indexes: Pair<IndexWalker<'_>>) -> Vec<String> {
         render_step(&mut |step| {
             step.render_statement(&mut |stmt| {
+                let previous_table = indexes.previous.table();
+                let index_previous_name = match previous_table.namespace() {
+                    Some(ns) => format!("{}.{}", self.quote(ns), self.quote(indexes.previous.name())),
+                    None => format!("{}", self.quote(indexes.previous.name())),
+                };
                 stmt.push_str("ALTER INDEX ");
-                stmt.push_display(&Quoted::postgres_ident(indexes.previous.name()));
+                stmt.push_str(&index_previous_name);
                 stmt.push_str(" RENAME TO ");
                 stmt.push_display(&Quoted::postgres_ident(indexes.next.name()));
             })

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
@@ -446,8 +446,8 @@ impl SqlRenderer for PostgresFlavour {
         format!(
             "ALTER TABLE {table} DROP CONSTRAINT {constraint_name}",
             table = match foreign_key.table().namespace() {
-              Some(namespace) => PostgresIdentifier::WithSchema(namespace.into(), foreign_key.table().name().into()),
-              None => foreign_key.table().name().into(),
+                Some(namespace) => PostgresIdentifier::WithSchema(namespace.into(), foreign_key.table().name().into()),
+                None => foreign_key.table().name().into(),
             },
             constraint_name = Quoted::postgres_ident(foreign_key.constraint_name().unwrap()),
         )
@@ -456,8 +456,8 @@ impl SqlRenderer for PostgresFlavour {
     fn render_drop_index(&self, index: IndexWalker<'_>) -> String {
         ddl::DropIndex {
             index_name: match index.table().namespace() {
-              Some(namespace) => PostgresIdentifier::WithSchema(namespace.into(), index.name().into()),
-              None => index.name().into(),
+                Some(namespace) => PostgresIdentifier::WithSchema(namespace.into(), index.name().into()),
+                None => index.name().into(),
             },
         }
         .to_string()
@@ -480,8 +480,8 @@ impl SqlRenderer for PostgresFlavour {
     fn render_drop_view(&self, view: ViewWalker<'_>) -> String {
         ddl::DropView {
             view_name: match view.namespace() {
-              Some(namespace) => PostgresIdentifier::WithSchema(namespace.into(), view.name().into()),
-              None => view.name().into(),
+                Some(namespace) => PostgresIdentifier::WithSchema(namespace.into(), view.name().into()),
+                None => view.name().into(),
             },
         }
         .to_string()
@@ -916,8 +916,11 @@ fn render_postgres_alter_enum(
                 format!(
                     "ALTER TYPE {enum_name} ADD VALUE {value}",
                     enum_name = match schemas.walk(alter_enum.id).previous.namespace() {
-                      Some(namespace) => PostgresIdentifier::WithSchema(namespace.into(), schemas.walk(alter_enum.id).previous.name().into()),
-                      None => schemas.walk(alter_enum.id).previous.name().into(),
+                        Some(namespace) => PostgresIdentifier::WithSchema(
+                            namespace.into(),
+                            schemas.walk(alter_enum.id).previous.name().into()
+                        ),
+                        None => schemas.walk(alter_enum.id).previous.name().into(),
                     },
                     value = Quoted::postgres_string(created_value)
                 )

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
@@ -225,7 +225,7 @@ impl SqlRenderer for PostgresFlavour {
                 let previous_table = indexes.previous.table();
                 let index_previous_name = match previous_table.namespace() {
                     Some(ns) => format!("{}.{}", self.quote(ns), self.quote(indexes.previous.name())),
-                    None => format!("{}", self.quote(indexes.previous.name())),
+                    None => self.quote(indexes.previous.name()).to_string(),
                 };
                 stmt.push_str("ALTER INDEX ");
                 stmt.push_str(&index_previous_name);

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
@@ -454,9 +454,11 @@ impl SqlRenderer for PostgresFlavour {
     }
 
     fn render_drop_index(&self, index: IndexWalker<'_>) -> String {
-        // TODO(PR): I guess namespace should be here somewhere
         ddl::DropIndex {
-            index_name: index.name().into(),
+            index_name: match index.table().namespace() {
+              Some(namespace) => PostgresIdentifier::WithSchema(namespace.into(), index.name().into()),
+              None => index.name().into(),
+            },
         }
         .to_string()
     }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
@@ -479,7 +479,10 @@ impl SqlRenderer for PostgresFlavour {
 
     fn render_drop_view(&self, view: ViewWalker<'_>) -> String {
         ddl::DropView {
-            view_name: view.name().into(),
+            view_name: match view.namespace() {
+              Some(namespace) => PostgresIdentifier::WithSchema(namespace.into(), view.name().into()),
+              None => view.name().into(),
+            },
         }
         .to_string()
     }

--- a/migration-engine/migration-engine-tests/src/commands/reset.rs
+++ b/migration-engine/migration-engine-tests/src/commands/reset.rs
@@ -1,4 +1,4 @@
-use migration_core::{migration_connector::MigrationConnector, CoreResult};
+use migration_core::{migration_connector::{MigrationConnector, Namespaces}, CoreResult};
 
 #[must_use = "This struct does nothing on its own. See Reset::send()"]
 pub struct Reset<'a> {
@@ -16,17 +16,16 @@ impl<'a> Reset<'a> {
         self
     }
 
-    pub async fn send(self) -> CoreResult<ResetAssertion> {
-        // TODO(MultiSchema): should we somehow send Namespaces here?
-        self.api.reset(self.soft, None).await?;
+    pub async fn send(self, namespaces: Option<Namespaces>) -> CoreResult<ResetAssertion> {
+        self.api.reset(self.soft, namespaces).await?;
 
         Ok(ResetAssertion {})
     }
 
     /// Execute the command and expect it to succeed.
     #[track_caller]
-    pub fn send_sync(self) -> ResetAssertion {
-        test_setup::runtime::run_with_thread_local_runtime(self.send()).unwrap()
+    pub fn send_sync(self, namespaces: Option<Namespaces>) -> ResetAssertion {
+        test_setup::runtime::run_with_thread_local_runtime(self.send(namespaces)).unwrap()
     }
 }
 

--- a/migration-engine/migration-engine-tests/src/commands/reset.rs
+++ b/migration-engine/migration-engine-tests/src/commands/reset.rs
@@ -1,4 +1,7 @@
-use migration_core::{migration_connector::{MigrationConnector, Namespaces}, CoreResult};
+use migration_core::{
+    migration_connector::{MigrationConnector, Namespaces},
+    CoreResult,
+};
 
 #[must_use = "This struct does nothing on its own. See Reset::send()"]
 pub struct Reset<'a> {

--- a/migration-engine/migration-engine-tests/tests/migrations/cockroachdb.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/cockroachdb.rs
@@ -55,7 +55,7 @@ fn soft_resets_work_on_cockroachdb(mut api: TestApi) {
 
     api.raw_cmd(initial);
     api.assert_schema().assert_tables_count(1).assert_has_table("Cat");
-    api.reset().soft(true).send_sync();
+    api.reset().soft(true).send_sync(None);
     api.assert_schema().assert_tables_count(0);
 }
 

--- a/migration-engine/migration-engine-tests/tests/migrations/enums.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/enums.rs
@@ -585,7 +585,7 @@ fn alter_enum_and_change_default_must_work(api: TestApi) {
     });
 
     // we repeat the same tests with migrations, so we can observe the generated SQL statements.
-    api.reset().send_sync();
+    api.reset().send_sync(None);
     api.assert_schema().assert_tables_count(0);
 
     let dir = api.create_migrations_directory();

--- a/migration-engine/migration-engine-tests/tests/migrations/mssql.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/mssql.rs
@@ -17,7 +17,7 @@ fn reset_clears_udts(api: TestApi) {
     );
     assert_eq!(1, schemas.len());
 
-    api.reset().send_sync();
+    api.reset().send_sync(None);
 
     let schemas = api.query_raw(
         &format!(

--- a/migration-engine/migration-engine-tests/tests/migrations/postgres/multi_schema.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/postgres/multi_schema.rs
@@ -606,3 +606,62 @@ fn multi_schema_drop_enum(api: TestApi) {
         .assert_has_table("First")
         .assert_has_no_enum("Second");
 }
+
+#[test_connector(
+    tags(Postgres),
+    exclude(CockroachDb),
+    preview_features("multiSchema"),
+    namespaces("one", "two")
+)]
+fn multi_schema_drop_foreign_key(api: TestApi) {
+    let base = indoc! {r#"
+        datasource db {
+          provider   = "postgresql"
+          url        = env("TEST_DATABASE_URL")
+          schemas    = ["one", "two"]
+        }
+        generator js {
+          provider        = "prisma-client-js"
+          previewFeatures = ["multiSchema"]
+        }
+    "#};
+    let first = base.to_owned()
+        + indoc! {r#"
+        model First {
+          id Int @id
+          seconds Second[]
+          @@schema("one")
+        }
+        model Second {
+          id Int @id
+          first_id Int
+          first First? @relation(fields: [first_id], references: [id])
+          @@schema("one")
+        }
+    "#};
+    let second = base.to_owned()
+        + indoc! {r#"
+        model First {
+          id Int @id
+          @@schema("one")
+        }
+        model Second {
+          id Int @id
+          @@schema("one")
+        }
+        "#};
+
+    api.schema_push(first).send().assert_green().assert_has_executed_steps();
+    api.schema_push(second)
+        .send()
+        .assert_warnings(&[])
+        .assert_unexecutable(&[])
+        .assert_has_executed_steps();
+
+    let mut vec_namespaces = vec![String::from("one"), String::from("two")];
+    let namespaces = Namespaces::from_vec(&mut vec_namespaces);
+
+    api.assert_schema_with_namespaces(namespaces)
+        .assert_has_table("First")
+        .assert_has_table("Second");
+}

--- a/migration-engine/migration-engine-tests/tests/migrations/postgres/multi_schema.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/postgres/multi_schema.rs
@@ -446,3 +446,59 @@ fn multi_schema_remove_field_array(api: TestApi) {
         .assert_has_table("First")
         .assert_has_table("Second");
 }
+
+#[test_connector(
+    tags(Postgres),
+    exclude(CockroachDb),
+    preview_features("multiSchema"),
+    namespaces("one", "two")
+)]
+fn multi_schema_rename_index(api: TestApi) {
+    let base = indoc! {r#"
+        datasource db {
+          provider   = "postgresql"
+          url        = env("TEST_DATABASE_URL")
+          schemas    = ["one", "two"]
+        }
+        generator js {
+          provider        = "prisma-client-js"
+          previewFeatures = ["multiSchema"]
+        }
+        model First {
+          id Int @id
+          @@schema("one")
+        }
+    "#};
+    let first = base.to_owned()
+        + indoc! {r#"
+        model Second {
+          id Int @id
+          name String
+          @@index(fields: [name], map: "index_name")
+          @@schema("two")
+        }
+    "#};
+    let second = base.to_owned()
+        + indoc! {r#"
+        model Second {
+          id Int @id
+          name String
+          @@index(fields: [name], map: "new_index_name")
+          @@schema("two")
+        }
+    "#};
+
+    api.schema_push(first).send().assert_green().assert_has_executed_steps();
+    api.schema_push(second)
+        .send()
+        .assert_warnings(&[])
+        .assert_unexecutable(&[])
+        .assert_has_executed_steps();
+
+    let mut vec_namespaces = vec![String::from("one"), String::from("two")];
+    let namespaces = Namespaces::from_vec(&mut vec_namespaces);
+
+    api.assert_schema_with_namespaces(namespaces)
+        .assert_has_table("First")
+        .assert_has_table("Second");
+}

--- a/migration-engine/migration-engine-tests/tests/migrations/postgres/multi_schema.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/postgres/multi_schema.rs
@@ -665,3 +665,58 @@ fn multi_schema_drop_foreign_key(api: TestApi) {
         .assert_has_table("First")
         .assert_has_table("Second");
 }
+
+#[test_connector(
+    tags(Postgres),
+    exclude(CockroachDb),
+    preview_features("multiSchema"),
+    namespaces("one", "two")
+)]
+fn multi_schema_drop_index(api: TestApi) {
+    let base = indoc! {r#"
+        datasource db {
+          provider   = "postgresql"
+          url        = env("TEST_DATABASE_URL")
+          schemas    = ["one", "two"]
+        }
+        generator js {
+          provider        = "prisma-client-js"
+          previewFeatures = ["multiSchema"]
+        }
+        model First {
+          id Int @id
+          @@schema("one")
+        }
+    "#};
+    let first = base.to_owned()
+        + indoc! {r#"
+        model Second {
+          id Int @id
+          name String
+          @@index(fields: [name], map: "index_name")
+          @@schema("two")
+        }
+    "#};
+    let second = base.to_owned()
+        + indoc! {r#"
+        model Second {
+          id Int @id
+          name String
+          @@schema("two")
+        }
+    "#};
+
+    api.schema_push(first).send().assert_green().assert_has_executed_steps();
+    api.schema_push(second)
+        .send()
+        .assert_warnings(&[])
+        .assert_unexecutable(&[])
+        .assert_has_executed_steps();
+
+    let mut vec_namespaces = vec![String::from("one"), String::from("two")];
+    let namespaces = Namespaces::from_vec(&mut vec_namespaces);
+
+    api.assert_schema_with_namespaces(namespaces)
+        .assert_has_table("First")
+        .assert_has_table("Second");
+}

--- a/migration-engine/migration-engine-tests/tests/migrations/reset_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/reset_tests.rs
@@ -15,7 +15,7 @@ fn reset_works(api: TestApi) {
 
     api.insert("Cat").value("id", 1).value("name", "Garfield").result_raw();
 
-    api.reset().send_sync();
+    api.reset().send_sync(None);
 
     api.assert_schema().assert_tables_count(0);
 
@@ -46,7 +46,7 @@ fn reset_then_apply_with_migrations_directory_works(api: TestApi) {
 
     api.insert("Cat").value("id", 1).value("name", "Garfield").result_raw();
 
-    api.reset().send_sync();
+    api.reset().send_sync(None);
 
     api.assert_schema().assert_tables_count(0);
 
@@ -80,7 +80,7 @@ fn reset_then_diagnostics_with_migrations_directory_works(api: TestApi) {
 
     api.insert("Cat").value("id", 1).value("name", "Garfield").result_raw();
 
-    api.reset().send_sync();
+    api.reset().send_sync(None);
 
     api.assert_schema().assert_tables_count(0);
 

--- a/migration-engine/migration-engine-tests/tests/migrations/soft_resets.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/soft_resets.rs
@@ -67,14 +67,14 @@ fn soft_resets_work_on_postgres(mut api: TestApi) {
             .assert_has_table("_prisma_migrations")
             .assert_has_table("Cat");
 
-        engine.reset().send_sync();
+        engine.reset().send_sync(None);
         engine.assert_schema().assert_tables_count(0);
 
         engine.schema_push(dm).send().assert_has_executed_steps().assert_green();
 
         engine.assert_schema().assert_tables_count(1).assert_has_table("Cat");
 
-        engine.reset().send_sync();
+        engine.reset().send_sync(None);
         engine.assert_schema().assert_tables_count(0);
     }
 }
@@ -169,14 +169,14 @@ fn soft_resets_work_on_sql_server(api: TestApi) {
             .assert_has_table("specialLitter")
             .assert_has_table("Cat");
 
-        engine.reset().send_sync();
+        engine.reset().send_sync(None);
         engine.assert_schema().assert_tables_count(0);
 
         engine.schema_push(dm).send().assert_has_executed_steps().assert_green();
 
         engine.assert_schema().assert_tables_count(1).assert_has_table("Cat");
 
-        engine.reset().send_sync();
+        engine.reset().send_sync(None);
         engine.assert_schema().assert_tables_count(0);
     }
 }
@@ -249,14 +249,14 @@ fn soft_resets_work_on_mysql(api: TestApi) {
     {
         let mut engine = api.new_engine_with_connection_strings(test_user_connection_string, None);
 
-        engine.reset().send_sync();
+        engine.reset().send_sync(None);
         engine.assert_schema().assert_tables_count(0);
 
         engine.schema_push(dm).send().assert_has_executed_steps().assert_green();
 
         engine.assert_schema().assert_tables_count(1).assert_has_table("Cat");
 
-        engine.reset().send_sync();
+        engine.reset().send_sync(None);
         engine.assert_schema().assert_tables_count(0);
     }
 }


### PR DESCRIPTION
This is probably easiest to follow on a commit-by-commit basis. Each commit fixes a single case by adding a test and fixing the code.

In most cases, it was just a matter of making sure we correctly pass or use the `namespace`.