### PR TITLE
fix: migrating after altering an Enum type and chaing the default value of an Enum[] column no longer crashes on Postgres

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
@@ -390,8 +390,6 @@ fn push_column_for_model_enum_scalar_field(
         table_id,
         sql::Column {
             name: field.database_name().to_owned(),
-
-            // TODO: replace "pure" with "with_full_data_type"
             tpe: sql::ColumnType::pure(
                 sql::ColumnTypeFamily::Enum(ctx.enum_ids[&r#enum.id]),
                 column_arity(field.ast_field().arity),

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
@@ -390,6 +390,8 @@ fn push_column_for_model_enum_scalar_field(
         table_id,
         sql::Column {
             name: field.database_name().to_owned(),
+
+            // TODO: replace "pure" with "with_full_data_type"
             tpe: sql::ColumnType::pure(
                 sql::ColumnTypeFamily::Enum(ctx.enum_ids[&r#enum.id]),
                 column_arity(field.ast_field().arity),

--- a/migration-engine/migration-engine-tests/src/commands/schema_push.rs
+++ b/migration-engine/migration-engine-tests/src/commands/schema_push.rs
@@ -76,6 +76,7 @@ impl SchemaPushAssertion {
         self.assert_no_warning().assert_executable()
     }
 
+    #[track_caller]
     pub fn assert_no_warning(self) -> Self {
         assert!(
             self.result.warnings.is_empty(),


### PR DESCRIPTION
This PR deprecates https://github.com/prisma/prisma-engines/pull/3347.

Closes https://github.com/prisma/prisma/issues/15705. 