### PR TITLE
nix: tiny simplification

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -77,7 +77,7 @@
 
           prisma-engines-deps = craneLib.buildDepsOnly prismaEnginesCommonArgs;
 
-          prisma-fmt-wasm = import ./prisma-fmt-wasm { inherit crane nixpkgs rust-overlay system src; };
+          prisma-fmt-wasm = import ./prisma-fmt-wasm { inherit craneLib pkgs system src; };
 
           inherit (pkgs) lib;
         in

--- a/prisma-fmt-wasm/default.nix
+++ b/prisma-fmt-wasm/default.nix
@@ -1,14 +1,8 @@
-{ crane, nixpkgs, rust-overlay, system, src }:
+args@{ pkgs, system, src, ... }:
 
 let
-  overlays = [
-    rust-overlay.overlays.default
-    (self: super:
-      let toolchain = super.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml; in
-      { cargo = toolchain; rustc = toolchain; })
-  ];
-  pkgs = import nixpkgs { inherit system overlays; };
-  craneLib = crane.mkLib pkgs;
+  toolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+  craneLib = args.craneLib.overrideToolchain toolchain;
 
   inherit (pkgs) jq nodejs coreutils rustPlatform wasm-bindgen-cli;
   inherit (builtins) readFile replaceStrings;


### PR DESCRIPTION
We do not need to define overlays twice (once for engines, once for prisma-fmt-wasm), we can reuse the overlay and override the toolchain to use wasm.