### PR TITLE
qe: Identify which request in a batch caused error

### DIFF
--- a/libs/user-facing-errors/src/lib.rs
+++ b/libs/user-facing-errors/src/lib.rs
@@ -96,6 +96,10 @@ impl Error {
         }
     }
 
+    pub fn batch_request_idx(&self) -> Option<usize> {
+        self.batch_request_idx
+    }
+
     pub fn new_non_panic_with_current_backtrace(message: String) -> Self {
         Error {
             inner: ErrorType::Unknown(UnknownError {

--- a/libs/user-facing-errors/src/lib.rs
+++ b/libs/user-facing-errors/src/lib.rs
@@ -68,6 +68,9 @@ pub struct Error {
     is_panic: bool,
     #[serde(flatten)]
     inner: ErrorType,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    batch_request_idx: Option<usize>,
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
@@ -100,6 +103,7 @@ impl Error {
                 backtrace: Some(format!("{:?}", backtrace::Backtrace::new())),
             }),
             is_panic: false,
+            batch_request_idx: None,
         }
     }
 
@@ -110,6 +114,7 @@ impl Error {
                 backtrace: None,
             }),
             is_panic: false,
+            batch_request_idx: None,
         }
     }
 
@@ -135,6 +140,7 @@ impl Error {
                 backtrace,
             }),
             is_panic: true,
+            batch_request_idx: None,
         }
     }
 
@@ -143,6 +149,7 @@ impl Error {
         Error {
             inner: ErrorType::Known(err),
             is_panic: false,
+            batch_request_idx: None,
         }
     }
 
@@ -155,6 +162,7 @@ impl Error {
                 backtrace: None,
             }),
             is_panic: true,
+            batch_request_idx: None,
         }
     }
 
@@ -172,6 +180,10 @@ impl Error {
             err @ ErrorType::Unknown(_) => panic!("Expected known error, got {:?}", err),
         }
     }
+
+    pub fn set_batch_request_idx(&mut self, batch_request_idx: usize) {
+        self.batch_request_idx = Some(batch_request_idx)
+    }
 }
 
 pub fn new_backtrace() -> backtrace::Backtrace {
@@ -183,6 +195,7 @@ impl From<UnknownError> for Error {
         Error {
             inner: ErrorType::Unknown(unknown_error),
             is_panic: false,
+            batch_request_idx: None,
         }
     }
 }
@@ -192,6 +205,7 @@ impl From<KnownError> for Error {
         Error {
             is_panic: false,
             inner: ErrorType::Known(known_error),
+            batch_request_idx: None,
         }
     }
 }

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/batch/transactional_batch.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/batch/transactional_batch.rs
@@ -52,7 +52,10 @@ mod transactional {
         ];
 
         let batch_results = runner.batch(queries, true, None).await?;
-        batch_results.assert_failure(2002, None);
+        insta::assert_snapshot!(
+            batch_results.to_string(),
+            @r###"{"errors":[{"error":"Error in batch request 1: Error occurred during query execution:\nConnectorError(ConnectorError { user_facing_error: Some(KnownError { message: \"Unique constraint failed on the fields: (`id`)\", meta: Object {\"target\": Array [String(\"id\")]}, error_code: \"P2002\" }), kind: UniqueConstraintViolation { constraint: Fields([\"id\"]) } })","user_facing_error":{"is_panic":false,"message":"Unique constraint failed on the fields: (`id`)","meta":{"target":["id"]},"error_code":"P2002","batch_request_idx":1}}]}"###
+        );
 
         insta::assert_snapshot!(
             run_query!(&runner, r#"{ findManyModelA { id } }"#),

--- a/query-engine/core/src/error.rs
+++ b/query-engine/core/src/error.rs
@@ -70,6 +70,9 @@ pub enum CoreError {
 
     #[error("{}", _0)]
     FieldConversionError(#[from] FieldConversionError),
+
+    #[error("Error in batch request {request_idx}: {error}")]
+    BatchError { request_idx: usize, error: Box<CoreError> },
 }
 
 impl CoreError {
@@ -267,6 +270,12 @@ impl From<CoreError> for user_facing_errors::Error {
                     details: err.to_string(),
                 })
                 .into()
+            }
+
+            CoreError::BatchError { request_idx, error } => {
+                let mut inner_error = user_facing_errors::Error::from(*error);
+                inner_error.set_batch_request_idx(request_idx);
+                inner_error
             }
 
             _ => user_facing_errors::Error::from_dyn_error(&err),

--- a/query-engine/request-handlers/src/graphql/response.rs
+++ b/query-engine/request-handlers/src/graphql/response.rs
@@ -38,6 +38,10 @@ impl GQLError {
     pub fn message(&self) -> &str {
         self.user_facing_error.message()
     }
+
+    pub fn batch_request_idx(&self) -> Option<usize> {
+        self.user_facing_error.batch_request_idx()
+    }
 }
 
 impl GQLResponse {


### PR DESCRIPTION
Adds `batch_request_idx` property to user facing errors. On the client,
that would allow us to build correct error message for `$transaction`
errors.

Ref: prisma/prisma#15433, prisma/prisma#14373
