### PR TITLE
bump napi & napi-derive dependencies to 2.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2288,9 +2288,9 @@ dependencies = [
 
 [[package]]
 name = "napi"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e2f9ad803cde148d81d0ca9e5fd4d80773d15e992d09e3a44f62f41b9af4558"
+checksum = "743fece4c26c5132f8559080145fde9ba88700c0f1aa30a1ab3e057ab105814d"
 dependencies = [
  "bitflags",
  "ctor",
@@ -2310,9 +2310,9 @@ checksum = "ebd4419172727423cf30351406c54f6cc1b354a2cfb4f1dba3e6cd07f6d5522b"
 
 [[package]]
 name = "napi-derive"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1be75210f300e9fbf386ccac1c8eaaed23410e2f7f7aa9295b78c436a172ef51"
+checksum = "39f3d8b02ef355898ea98f69082d9a183c8701c836942c2daf3e92364e88a0fa"
 dependencies = [
  "convert_case",
  "napi-derive-backend",
@@ -2323,9 +2323,9 @@ dependencies = [
 
 [[package]]
 name = "napi-derive-backend"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ba4800264fac8a7726b208d5dd4c6d637d1027d73b026061a69d3339a0a930"
+checksum = "6c35640513eb442fcbd1653a1c112fb6b2cc12b54d82f9c141f5859c721cab36"
 dependencies = [
  "convert_case",
  "once_cell",

--- a/query-engine/query-engine-node-api/Cargo.toml
+++ b/query-engine/query-engine-node-api/Cargo.toml
@@ -23,8 +23,8 @@ psl.workspace = true
 sql-connector = { path = "../connectors/sql-query-connector", package = "sql-query-connector" }
 prisma-models = { path = "../prisma-models" }
 
-napi = { version = "=2.9.0", default-features = false, features = ["napi8", "tokio_rt", "serde-json"] }
-napi-derive = "=2.9.0"
+napi = { version = "=2.9.1", default-features = false, features = ["napi8", "tokio_rt", "serde-json"] }
+napi-derive = "=2.9.1"
 
 thiserror = "1"
 connection-string = "0.1"


### PR DESCRIPTION
The current version of napi is `2.9.0`

We see Prisma Client memory tests failing since `2.10.0`, see more details in https://github.com/prisma/prisma-engines/pull/3387

This PR goal is to check if these started to fail in 2.9.1, or not.
https://github.com/napi-rs/napi-rs/releases/tag/napi%402.9.1

Conclusion: It seems that `2.9.1` passes all the tests. Let's merge it!

Later we would need to investigate what we should do for `2.10.0` and up.