### PR TITLE
dml: delete IndexType

### DIFF
--- a/libs/dml/src/lib.rs
+++ b/libs/dml/src/lib.rs
@@ -21,6 +21,7 @@ pub use self::{
     relation_info::*, scalars::*, traits::*,
 };
 pub use prisma_value::{self, PrismaValue};
+pub use psl_core::parser_database::IndexType;
 
 use psl_core::ValidatedSchema;
 

--- a/libs/dml/src/lift.rs
+++ b/libs/dml/src/lift.rs
@@ -370,12 +370,6 @@ impl<'a> LiftAstToDml<'a> {
                     })
                     .collect();
 
-                let tpe = match idx.index_type() {
-                    db::IndexType::Unique => IndexType::Unique,
-                    db::IndexType::Normal => IndexType::Normal,
-                    db::IndexType::Fulltext => IndexType::Fulltext,
-                };
-
                 let algorithm = idx.algorithm().map(|using| match using {
                     IndexAlgorithm::BTree => model::IndexAlgorithm::BTree,
                     IndexAlgorithm::Hash => model::IndexAlgorithm::Hash,
@@ -389,7 +383,7 @@ impl<'a> LiftAstToDml<'a> {
                     name: idx.name().map(String::from),
                     db_name: Some(idx.constraint_name(self.connector).into_owned()),
                     fields,
-                    tpe,
+                    tpe: idx.index_type(),
                     algorithm,
                     defined_on_field: idx.is_defined_on_field(),
                     // By default an index that is not a primary key is always non-clustered in any database.

--- a/libs/dml/src/model.rs
+++ b/libs/dml/src/model.rs
@@ -3,6 +3,7 @@ use crate::field::{Field, FieldType, RelationField, ScalarField};
 use crate::scalars::ScalarType;
 use crate::traits::{Ignorable, WithDatabaseName, WithName};
 use indoc::formatdoc;
+use psl_core::parser_database::IndexType;
 use std::{borrow::Cow, fmt};
 
 /// Represents a model in a prisma schema.
@@ -306,19 +307,6 @@ impl PrimaryKeyField {
             sort_order: None,
             length: None,
         }
-    }
-}
-
-#[derive(Debug, PartialEq, Clone, Copy)]
-pub enum IndexType {
-    Unique,
-    Normal,
-    Fulltext,
-}
-
-impl IndexType {
-    pub fn is_fulltext(self) -> bool {
-        matches!(self, IndexType::Fulltext)
     }
 }
 

--- a/psl/parser-database/src/types.rs
+++ b/psl/parser-database/src/types.rs
@@ -355,20 +355,15 @@ impl Default for IndexAlgorithm {
 }
 
 /// The different types of indexes supported in the Prisma Schema Language.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub enum IndexType {
     /// @@index
+    #[default]
     Normal,
     /// @(@)unique
     Unique,
     /// @(@)fulltext
     Fulltext,
-}
-
-impl Default for IndexType {
-    fn default() -> Self {
-        Self::Normal
-    }
 }
 
 #[derive(Debug, Default)]


### PR DESCRIPTION
It is the same as parser_database::IndexType. We are moving away from DML, so we can use the other one to make the transition more progressive.

These two types needed to be separate in the past because dml could not depend on psl_core (the reverse was the case).