### PR TITLE
fix: batched queries with same args in diff order

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/batch/select_one_singular.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/batch/select_one_singular.rs
@@ -228,8 +228,20 @@ mod singular_batch {
         create_test_data(&runner).await?;
 
         let queries = vec![
-            r#"query { findUniqueArtist(where: { ArtistId: 1}) { Name }}"#.to_string(),
-            r#"query { findUniqueArtist(where: { ArtistId: 1}) { Name }}"#.to_string(),
+            r#"query { findUniqueArtist(where: { ArtistId: 1 }) { Name }}"#.to_string(),
+            r#"query { findUniqueArtist(where: { ArtistId: 1 }) { Name }}"#.to_string(),
+        ];
+
+        let batch_results = runner.batch(queries, false, None).await?;
+        insta::assert_snapshot!(
+            batch_results.to_string(),
+            @r###"{"batchResult":[{"data":{"findUniqueArtist":{"Name":"ArtistWithoutAlbums"}}},{"data":{"findUniqueArtist":{"Name":"ArtistWithoutAlbums"}}}]}"###
+        );
+
+        // With non unique filters
+        let queries = vec![
+            r#"query { findUniqueArtist(where: { ArtistId: 1, Name: "ArtistWithoutAlbums" }) { Name }}"#.to_string(),
+            r#"query { findUniqueArtist(where: { Name: "ArtistWithoutAlbums", ArtistId: 1 }) { Name }}"#.to_string(),
         ];
 
         let batch_results = runner.batch(queries, false, None).await?;

--- a/query-engine/core/src/response_ir/mod.rs
+++ b/query-engine/core/src/response_ir/mod.rs
@@ -16,7 +16,7 @@ use crate::QueryValue;
 use indexmap::IndexMap;
 use prisma_models::PrismaValue;
 use serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer};
-use std::{fmt, sync::Arc};
+use std::{collections::HashMap, fmt, sync::Arc};
 
 pub use ir_serializer::*;
 pub use response::*;
@@ -44,16 +44,15 @@ impl List {
         self.len() == 0
     }
 
-    pub fn index_by(self, keys: &[String]) -> Vec<(Vec<QueryValue>, Map)> {
-        let mut map = Vec::with_capacity(self.len());
+    pub fn index_by(self, keys: &[String]) -> Vec<(HashMap<String, QueryValue>, Map)> {
+        let mut map: Vec<(HashMap<String, QueryValue>, Map)> = Vec::with_capacity(self.len());
 
         for item in self.into_iter() {
             let inner = item.into_map().unwrap();
-
-            let key: Vec<QueryValue> = keys
+            let key: HashMap<String, QueryValue> = keys
                 .iter()
-                .map(|key| inner.get(key).unwrap().clone().into_value().unwrap())
-                .map(QueryValue::from)
+                .map(|key| (key.clone(), inner.get(key).unwrap().clone().into_value().unwrap()))
+                .map(|(key, val)| (key, QueryValue::from(val)))
                 .collect();
 
             map.push((key, inner));

--- a/query-engine/request-handlers/src/graphql/handler.rs
+++ b/query-engine/request-handlers/src/graphql/handler.rs
@@ -4,7 +4,7 @@ use futures::FutureExt;
 use indexmap::IndexMap;
 use query_core::{
     schema::QuerySchemaRef, BatchDocument, BatchDocumentTransaction, CompactedDocument, Item, Operation, QueryDocument,
-    QueryExecutor, QueryValue, ResponseData, TxId,
+    QueryExecutor, ResponseData, TxId,
 };
 use std::{fmt, panic::AssertUnwindSafe};
 
@@ -123,8 +123,29 @@ impl<'a> GraphQlHandler<'a> {
             Ok(Ok(response_data)) => {
                 let mut gql_response: GQLResponse = response_data.into();
 
-                // We find the response data and make a hash from the given unique keys.
-                let data = gql_response
+                // At this point, many findUnique queries were converted to a single findMany query and that query was run.
+                // This means we have a list of results and we need to map each result back to their original findUnique query.
+                // `data` is the piece of logic that allows us to do that mapping.
+                // It takes the findMany response and converts it to a map of arguments to result.
+                // Let's take an example. Given the following batched queries:
+                // [
+                //    findUnique(where: { id: 1, name: "Bob" }) { id name age },
+                //    findUnique(where: { id: 2, name: "Alice" }) { id name age }
+                // ]
+                // 1. This gets converted to: findMany(where: { OR: [{ id: 1, name: "Bob" }, { id: 2, name: "Alice" }] }) { id name age }
+                // 2. Say we get the following result back: [{ id: 1, name: "Bob", age: 18 }, { id: 2, name: "Alice", age: 27 }]
+                // 3. We know the inputted arguments are ["id", "name"]
+                // 4. So we go over the result and build the following list:
+                // [
+                //  ({ id: 1, name: "Bob" },   { id: 1, name: "Bob", age: 18 }),
+                //  ({ id: 2, name: "Alice" }, { id: 2, name: "Alice", age: 27 })
+                // ]
+                // 5. Now, given the original findUnique queries and that list, we can easily find back which arguments maps to which result
+                // [
+                //    findUnique(where: { id: 1, name: "Bob" }) { id name age } -> { id: 1, name: "Bob", age: 18 }
+                //    findUnique(where: { id: 2, name: "Alice" }) { id name age } -> { id: 2, name: "Alice", age: 27 }
+                // ]
+                let args_to_results = gql_response
                     .take_data(plural_name)
                     .unwrap()
                     .into_list()
@@ -134,13 +155,13 @@ impl<'a> GraphQlHandler<'a> {
                 let results: Vec<GQLResponse> = arguments
                     .into_iter()
                     .map(|args| {
-                        let vals: Vec<QueryValue> = args.into_iter().map(|(_, v)| v).collect();
                         let mut responses = GQLResponse::with_capacity(1);
 
+                        // This is step 5 of the comment above.
                         // Copying here is mandatory due to some of the queries
                         // might be repeated with the same arguments in the original
                         // batch. We need to give the same answer for both of them.
-                        match data.iter().find(|(k, _)| k == &vals) {
+                        match args_to_results.iter().find(|(a, _)| *a == args) {
                             Some((_, result)) => {
                                 // Filter out all the keys not selected in the
                                 // original query.


### PR DESCRIPTION
## Overview

fixes https://github.com/prisma/prisma/issues/16267

Query arguments were stored as a list of tuple, preventing queries with the same arguments in different order to be compared properly.

For instance, those two queries:
```
findUnique(where: { id: 1, name: "Bob" })
findUnique(where: { name: "Bob", id: 1 })
```

Were transformed to the following list of args:
```js
[
  [("id", 1), ("name", "Bob")],
  [("name", "Bob"), ("id", 1)]
]
```

When building the map of arguments to results from the result of the findMany query though, this is what we used to construct (note: findMany would return a single result since we're batching the same query twice, so there's, expectedly, a single element in that list):

```js
[
  ([("id", 1), ("name", "Bob")], <query result>)
]
```

Unfortunately, `[("id", 1), ("name", "Bob")]` is _not_ equal to `[("name", "Bob"), ("id", 1)]`, so we'd never find the result for the second query, resulting in a `null` (or vice-versa, depending on the order of the selection set of the findMany query).

This PR fixes this issue by storing the query arguments as `HashMap`s so that they can be compared regardless of order: `{ id: 1, name: "Bob" }` == `{ name: "Bob", id: 1 }`.

Note that the `PartialEq` impl. for HashMap is not magic and requires iterating over all (k,v) of one of the hashmaps:

```rust
#[stable(feature = "rust1", since = "1.0.0")]
impl<K, V, S> PartialEq for HashMap<K, V, S>
where
    K: Eq + Hash,
    V: PartialEq,
    S: BuildHasher,
{
    fn eq(&self, other: &HashMap<K, V, S>) -> bool {
        if self.len() != other.len() {
            return false;
        }

        self.iter().all(|(key, value)| other.get(key).map_or(false, |v| *value == *v))
    }
}
```

It still remains far more efficient than doing the comparison with two `Vec`s.