### PR TITLE
ie: make sure self-relation names are never implicit

### DIFF
--- a/introspection-engine/introspection-engine-tests/tests/re_introspection/sqlite.rs
+++ b/introspection-engine/introspection-engine-tests/tests/re_introspection/sqlite.rs
@@ -70,7 +70,7 @@ async fn multiple_changed_relation_names_due_to_mapped_models(api: &TestApi) -> 
 }
 
 #[test_connector(tags(Sqlite))]
-async fn do_not_try_to_keep_custom_many_to_many_self_relation_names(api: &TestApi) -> TestResult {
+async fn do_not_try_to_keep_custom_many_to_many_self_relation_field_names(api: &TestApi) -> TestResult {
     // We do not have enough information to correctly assign which field should point to column A in the
     // join table and which one to B
     // Upon table creation this is dependant on lexicographic order of the names of the fields, but we

--- a/introspection-engine/introspection-engine-tests/tests/relations_with_compound_fk/cockroachdb.rs
+++ b/introspection-engine/introspection-engine-tests/tests/relations_with_compound_fk/cockroachdb.rs
@@ -26,8 +26,8 @@ async fn compound_foreign_keys_with_defaults(api: &TestApi) -> TestResult {
           age          Int
           partner_id   Int      @default(0)
           partner_age  Int      @default(0)
-          Person       Person   @relation(fields: [partner_id, partner_age], references: [id, age], onDelete: NoAction, onUpdate: NoAction)
-          other_Person Person[]
+          Person       Person   @relation("PersonToPerson", fields: [partner_id, partner_age], references: [id, age], onDelete: NoAction, onUpdate: NoAction)
+          other_Person Person[] @relation("PersonToPerson")
 
           @@unique([id, age], map: "post_user_unique")
         }

--- a/introspection-engine/introspection-engine-tests/tests/relations_with_compound_fk/mod.rs
+++ b/introspection-engine/introspection-engine-tests/tests/relations_with_compound_fk/mod.rs
@@ -135,8 +135,8 @@ async fn compound_foreign_keys_for_required_self_relations(api: &TestApi) -> Tes
           age          Int
           partner_id   Int
           partner_age  Int
-          Person       Person   @relation(fields: [partner_id, partner_age], references: [id, age], onDelete: NoAction, onUpdate: NoAction, map: "Person_pid_page_fkey")
-          other_Person Person[]
+          Person       Person   @relation("PersonToPerson", fields: [partner_id, partner_age], references: [id, age], onDelete: NoAction, onUpdate: NoAction, map: "Person_pid_page_fkey")
+          other_Person Person[] @relation("PersonToPerson")
 
           @@unique([id, age], map: "post_user_unique")
         }
@@ -173,8 +173,8 @@ async fn compound_foreign_keys_for_self_relations(api: &TestApi) -> TestResult {
           age          Int
           partner_id   Int?
           partner_age  Int?
-          Person       Person?  @relation(fields: [partner_id, partner_age], references: [id, age], onDelete: NoAction, onUpdate: NoAction, map: "Person_fkey")
-          other_Person Person[]
+          Person       Person?  @relation("PersonToPerson", fields: [partner_id, partner_age], references: [id, age], onDelete: NoAction, onUpdate: NoAction, map: "Person_fkey")
+          other_Person Person[] @relation("PersonToPerson")
 
           @@unique([id, age], map: "post_user_unique")
         }

--- a/introspection-engine/introspection-engine-tests/tests/relations_with_compound_fk/mssql.rs
+++ b/introspection-engine/introspection-engine-tests/tests/relations_with_compound_fk/mssql.rs
@@ -321,8 +321,8 @@ async fn compound_foreign_keys_for_required_self_relations(api: &TestApi) -> Tes
           age          Int
           partner_id   Int
           partner_age  Int
-          Person       Person   @relation(fields: [partner_id, partner_age], references: [id, age], onUpdate: NoAction, map: "person_fkey")
-          other_Person Person[]
+          Person       Person   @relation("PersonToPerson", fields: [partner_id, partner_age], references: [id, age], onUpdate: NoAction, map: "person_fkey")
+          other_Person Person[] @relation("PersonToPerson")
 
           @@unique([id, age], map: "post_user_unique")
         }
@@ -359,8 +359,8 @@ async fn compound_foreign_keys_with_defaults(api: &TestApi) -> TestResult {
           age          Int
           partner_id   Int      @default(0, map: "partner_id_default")
           partner_age  Int      @default(0, map: "partner_age_default")
-          Person       Person   @relation(fields: [partner_id, partner_age], references: [id, age], onUpdate: NoAction, map: "partner_id_age_fkey")
-          other_Person Person[]
+          Person       Person   @relation("PersonToPerson", fields: [partner_id, partner_age], references: [id, age], onUpdate: NoAction, map: "partner_id_age_fkey")
+          other_Person Person[] @relation("PersonToPerson")
 
           @@unique([id, age], map: "post_user_unique")
         }

--- a/introspection-engine/introspection-engine-tests/tests/relations_with_compound_fk/mysql.rs
+++ b/introspection-engine/introspection-engine-tests/tests/relations_with_compound_fk/mysql.rs
@@ -424,8 +424,8 @@ async fn compound_foreign_keys_for_required_self_relations(api: &TestApi) -> Tes
           age          Int
           partner_id   Int
           partner_age  Int
-          Person       Person   @relation(fields: [partner_id, partner_age], references: [id, age], map: "partner_id")
-          other_Person Person[]
+          Person       Person   @relation("PersonToPerson", fields: [partner_id, partner_age], references: [id, age], map: "partner_id")
+          other_Person Person[] @relation("PersonToPerson")
 
           @@unique([id, age], map: "post_user_unique")
           @@index([partner_id, partner_age], map: "partner_id")
@@ -462,8 +462,8 @@ async fn compound_foreign_keys_for_self_relations(api: &TestApi) -> TestResult {
           age          Int
           partner_id   Int?
           partner_age  Int?
-          Person       Person?  @relation(fields: [partner_id, partner_age], references: [id, age], map: "partner_id")
-          other_Person Person[]
+          Person       Person?  @relation("PersonToPerson", fields: [partner_id, partner_age], references: [id, age], map: "partner_id")
+          other_Person Person[] @relation("PersonToPerson")
 
           @@unique([id, age], map: "post_user_unique")
           @@index([partner_id, partner_age], map: "partner_id")
@@ -500,8 +500,8 @@ async fn compound_foreign_keys_with_defaults(api: &TestApi) -> TestResult {
           age          Int
           partner_id   Int      @default(0)
           partner_age  Int      @default(0)
-          Person       Person   @relation(fields: [partner_id, partner_age], references: [id, age], map: "partner_id")
-          other_Person Person[]
+          Person       Person   @relation("PersonToPerson", fields: [partner_id, partner_age], references: [id, age], map: "partner_id")
+          other_Person Person[] @relation("PersonToPerson")
 
           @@unique([id, age], map: "post_user_unique")
           @@index([partner_id, partner_age], map: "partner_id")

--- a/introspection-engine/introspection-engine-tests/tests/relations_with_compound_fk/postgres.rs
+++ b/introspection-engine/introspection-engine-tests/tests/relations_with_compound_fk/postgres.rs
@@ -216,8 +216,8 @@ async fn compound_foreign_keys_with_defaults(api: &TestApi) -> TestResult {
           age          Int
           partner_id   Int      @default(0)
           partner_age  Int      @default(0)
-          Person       Person   @relation(fields: [partner_id, partner_age], references: [id, age], onDelete: NoAction, onUpdate: NoAction)
-          other_Person Person[]
+          Person       Person   @relation("PersonToPerson", fields: [partner_id, partner_age], references: [id, age], onDelete: NoAction, onUpdate: NoAction)
+          other_Person Person[] @relation("PersonToPerson")
 
           @@unique([id, age], map: "post_user_unique")
         }

--- a/introspection-engine/introspection-engine-tests/tests/relations_with_compound_fk/sqlite.rs
+++ b/introspection-engine/introspection-engine-tests/tests/relations_with_compound_fk/sqlite.rs
@@ -217,8 +217,8 @@ async fn compound_foreign_keys_for_required_self_relations(api: &TestApi) -> Tes
           age          Int
           partner_id   Int
           partner_age  Int
-          Person       Person   @relation(fields: [partner_id, partner_age], references: [id, age], onDelete: NoAction, onUpdate: NoAction)
-          other_Person Person[]
+          Person       Person   @relation("PersonToPerson", fields: [partner_id, partner_age], references: [id, age], onDelete: NoAction, onUpdate: NoAction)
+          other_Person Person[] @relation("PersonToPerson")
 
           @@unique([id, age], map: "sqlite_autoindex_Person_1")
         }
@@ -251,8 +251,8 @@ async fn compound_foreign_keys_for_self_relations(api: &TestApi) -> TestResult {
           age          Int
           partner_id   Int?
           partner_age  Int?
-          Person       Person?  @relation(fields: [partner_id, partner_age], references: [id, age], onDelete: NoAction, onUpdate: NoAction)
-          other_Person Person[]
+          Person       Person?  @relation("PersonToPerson", fields: [partner_id, partner_age], references: [id, age], onDelete: NoAction, onUpdate: NoAction)
+          other_Person Person[] @relation("PersonToPerson")
 
           @@unique([id, age], map: "sqlite_autoindex_Person_1")
         }
@@ -285,8 +285,8 @@ async fn compound_foreign_keys_with_defaults(api: &TestApi) -> TestResult {
           age          Int
           partner_id   Int      @default(0)
           partner_age  Int      @default(0)
-          Person       Person   @relation(fields: [partner_id, partner_age], references: [id, age], onDelete: NoAction, onUpdate: NoAction)
-          other_Person Person[]
+          Person       Person   @relation("PersonToPerson", fields: [partner_id, partner_age], references: [id, age], onDelete: NoAction, onUpdate: NoAction)
+          other_Person Person[] @relation("PersonToPerson")
 
           @@unique([id, age], map: "sqlite_autoindex_Person_1")
         }

--- a/introspection-engine/introspection-engine-tests/tests/simple/postgres/relations/inline_self_relation.sql
+++ b/introspection-engine/introspection-engine-tests/tests/simple/postgres/relations/inline_self_relation.sql
@@ -1,0 +1,26 @@
+-- tags=postgres
+-- exclude=cockroachdb
+
+CREATE TABLE "Biscuit" (
+    id SERIAL PRIMARY KEY,
+    next_biscuit_id INTEGER REFERENCES "Biscuit"("id")
+);
+
+
+/*
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = "env(TEST_DATABASE_URL)"
+}
+
+model Biscuit {
+  id              Int       @id @default(autoincrement())
+  next_biscuit_id Int?
+  Biscuit         Biscuit?  @relation("BiscuitToBiscuit", fields: [next_biscuit_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  other_Biscuit   Biscuit[] @relation("BiscuitToBiscuit")
+}
+*/

--- a/introspection-engine/introspection-engine-tests/tests/simple/postgres/relations/many_to_many_relation.sql
+++ b/introspection-engine/introspection-engine-tests/tests/simple/postgres/relations/many_to_many_relation.sql
@@ -1,0 +1,31 @@
+-- tags=postgres
+-- exclude=cockroachdb
+
+CREATE TABLE "Biscuit" (
+    id SERIAL PRIMARY KEY
+);
+
+CREATE TABLE "_BiscuitToBiscuit" (
+    "A" INTEGER REFERENCES "Biscuit"("id"),
+    "B" INTEGER REFERENCES "Biscuit"("id")
+);
+
+CREATE UNIQUE INDEX "AB_unique" ON "_BiscuitToBiscuit"("A","B");
+CREATE INDEX "B_index" ON "_BiscuitToBiscuit"("B");
+
+/*
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = "env(TEST_DATABASE_URL)"
+}
+
+model Biscuit {
+  id        Int       @id @default(autoincrement())
+  Biscuit_A Biscuit[] @relation("BiscuitToBiscuit")
+  Biscuit_B Biscuit[] @relation("BiscuitToBiscuit")
+}
+*/

--- a/introspection-engine/introspection-engine-tests/tests/tables/cockroachdb.rs
+++ b/introspection-engine/introspection-engine-tests/tests/tables/cockroachdb.rs
@@ -423,9 +423,9 @@ async fn northwind(api: TestApi) {
           notes                String?
           reports_to           Int?                   @db.Int2
           photo_path           String?                @db.String(255)
-          employees            employees?             @relation(fields: [reports_to], references: [employee_id], onDelete: NoAction, onUpdate: NoAction, map: "fk_employees_employees")
+          employees            employees?             @relation("employeesToemployees", fields: [reports_to], references: [employee_id], onDelete: NoAction, onUpdate: NoAction, map: "fk_employees_employees")
           employee_territories employee_territories[]
-          other_employees      employees[]
+          other_employees      employees[]            @relation("employeesToemployees")
           orders               orders[]
         }
 

--- a/introspection-engine/introspection-engine-tests/tests/tables/postgres.rs
+++ b/introspection-engine/introspection-engine-tests/tests/tables/postgres.rs
@@ -360,9 +360,9 @@ async fn northwind(api: TestApi) {
           notes                String?
           reports_to           Int?                   @db.SmallInt
           photo_path           String?                @db.VarChar(255)
-          employees            employees?             @relation(fields: [reports_to], references: [employee_id], onDelete: NoAction, onUpdate: NoAction, map: "fk_employees_employees")
+          employees            employees?             @relation("employeesToemployees", fields: [reports_to], references: [employee_id], onDelete: NoAction, onUpdate: NoAction, map: "fk_employees_employees")
           employee_territories employee_territories[]
-          other_employees      employees[]
+          other_employees      employees[]            @relation("employeesToemployees")
           orders               orders[]
         }
 


### PR DESCRIPTION
The implicitness in self-relation names was introduced in https://github.com/prisma/prisma-engines/pull/3381

The reasoning was that if the relation is not ambiguous (there is only
one relation between the model and itself), we don't need to
disambiguate.

I still think the reasoning is valid, but there is a PSL validation
against doing this, which made introspection-ci fail. See
https://github.com/prisma/introspection-ci/commit/79a822f54f93f4be601d49b80e6535d2bce6e876

We do not have time to reconsider this now, since we are just
implementing multiSchema. This PR reverts that change.