### PR TITLE
chore: add dataproxy-metric-override to query engine

### DIFF
--- a/query-engine/query-engine/src/main.rs
+++ b/query-engine/query-engine/src/main.rs
@@ -37,7 +37,7 @@ async fn main() -> Result<(), AnyError> {
 
         logger.install().unwrap();
 
-        if opts.enable_metrics {
+        if opts.enable_metrics || opts.dataproxy_metric_override {
             query_engine_metrics::setup();
         }
 

--- a/query-engine/query-engine/src/opt.rs
+++ b/query-engine/query-engine/src/opt.rs
@@ -86,6 +86,11 @@ pub struct PrismaOpt {
     #[structopt(long, short = "m")]
     pub enable_metrics: bool,
 
+    // Enable the metrics without having to enable the feature in the
+    // schema. Used by data proxy to count interactive transactions.
+    #[structopt(long)]
+    pub dataproxy_metric_override: bool,
+
     /// Enable query logging [env: LOG_QUERIES=y]
     #[structopt(long, short = "o")]
     pub log_queries: bool,

--- a/query-engine/query-engine/src/server/mod.rs
+++ b/query-engine/query-engine/src/server/mod.rs
@@ -76,7 +76,7 @@ pub async fn setup(opts: &PrismaOpt, metrics: MetricRegistry) -> PrismaResult<St
         .preview_features()
         .contains(PreviewFeature::InteractiveTransactions);
 
-    let enable_metrics = config.preview_features().contains(PreviewFeature::Metrics);
+    let enable_metrics = config.preview_features().contains(PreviewFeature::Metrics) || opts.dataproxy_metric_override;
 
     let cx = PrismaContext::builder(datamodel)
         .set_metrics(metrics)


### PR DESCRIPTION
This allows the data proxy to run query engines with metrics enabled to determine if there are any interactive transactions running.