### PR TITLE
ie: prepare datamodel renderer for dml-free introspection

### DIFF
--- a/introspection-engine/connectors/sql-introspection-connector/src/sanitize_datamodel_names.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/sanitize_datamodel_names.rs
@@ -5,11 +5,11 @@ use std::borrow::Cow;
 static RE_START: Lazy<Regex> = Lazy::new(|| Regex::new("^[^a-zA-Z]+").unwrap());
 static RE: Lazy<Regex> = Lazy::new(|| Regex::new("[^_a-zA-Z0-9]").unwrap());
 
-fn needs_sanitation(s: &str) -> bool {
+pub(crate) fn needs_sanitation(s: &str) -> bool {
     RE_START.is_match(s) || RE.is_match(s)
 }
 
-fn sanitize_string(s: &str) -> String {
+pub(crate) fn sanitize_string(s: &str) -> String {
     if needs_sanitation(s) {
         let start_cleaned = RE_START.replace_all(s, "");
         RE.replace_all(start_cleaned.as_ref(), "_").into_owned()

--- a/introspection-engine/datamodel-renderer/src/configuration/generator.rs
+++ b/introspection-engine/datamodel-renderer/src/configuration/generator.rs
@@ -1,6 +1,6 @@
 use crate::value::{Array, Documentation, Env, Text};
 use psl::PreviewFeature;
-use std::fmt;
+use std::{borrow::Cow, fmt};
 
 /// The generator block of the datasource.
 #[derive(Debug)]
@@ -81,8 +81,8 @@ impl<'a> Generator<'a> {
     ///   provider = "prisma-client-js"
     /// }
     /// ```
-    pub fn documentation(&mut self, docs: &'a str) {
-        self.documentation = Some(Documentation(docs));
+    pub fn documentation(&mut self, docs: impl Into<Cow<'a, str>>) {
+        self.documentation = Some(Documentation(docs.into()));
     }
 
     /// Add a custom config value to the block. For now we support any
@@ -121,7 +121,7 @@ impl<'a> Generator<'a> {
             output: psl_gen.output.as_ref().map(Env::from),
             preview_features,
             binary_targets: Array::from(binary_targets),
-            documentation: psl_gen.documentation.as_deref().map(Documentation),
+            documentation: psl_gen.documentation.as_deref().map(Cow::Borrowed).map(Documentation),
             config,
         }
     }

--- a/introspection-engine/datamodel-renderer/src/datamodel/composite_type.rs
+++ b/introspection-engine/datamodel-renderer/src/datamodel/composite_type.rs
@@ -3,7 +3,7 @@ mod field;
 use crate::value::{Constant, Documentation};
 pub use field::CompositeTypeField;
 use psl::dml;
-use std::fmt;
+use std::{borrow::Cow, fmt};
 
 /// A type block in a PSL file.
 #[derive(Debug)]
@@ -40,8 +40,8 @@ impl<'a> CompositeType<'a> {
     ///   ....
     /// }
     /// ```
-    pub fn documentation(&mut self, documentation: &'a str) {
-        self.documentation = Some(Documentation(documentation));
+    pub fn documentation(&mut self, documentation: impl Into<Cow<'a, str>>) {
+        self.documentation = Some(Documentation(documentation.into()));
     }
 
     /// Add a new field to the type.
@@ -115,10 +115,13 @@ mod tests {
         let field = CompositeTypeField::new_array("Other", "String");
         composite_type.push_field(field);
 
-        let field = CompositeTypeField::new_required("1Invalid", "Float");
+        let mut field = CompositeTypeField::new_required("Invalid", "Float");
+        field.map("1Invalid");
         composite_type.push_field(field);
 
-        let field = CompositeTypeField::new_required("11111", "Float");
+        let mut field = CompositeTypeField::new_required("11111", "Float");
+        field.commented_out();
+        field.map("11111");
         composite_type.push_field(field);
 
         let expected = expect![[r#"

--- a/introspection-engine/datamodel-renderer/src/datamodel/default.rs
+++ b/introspection-engine/datamodel-renderer/src/datamodel/default.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{borrow::Cow, fmt};
 
 use psl::dml;
 
@@ -38,9 +38,9 @@ impl<'a> DefaultValue<'a> {
     ///                          ^^^^ this
     /// }
     /// ```
-    pub fn text(value: &'a str) -> Self {
+    pub fn text(value: impl Into<Cow<'a, str>>) -> Self {
         let mut inner = Function::new("default");
-        inner.push_param(Value::from(Text(value)));
+        inner.push_param(Value::from(Text::new(value)));
 
         Self::new(inner)
     }
@@ -53,9 +53,9 @@ impl<'a> DefaultValue<'a> {
     ///                          ^^^^^^^^ this
     /// }
     /// ```
-    pub fn bytes(value: &'a [u8]) -> Self {
+    pub fn bytes(value: impl Into<Cow<'a, [u8]>>) -> Self {
         let mut inner = Function::new("default");
-        inner.push_param(Value::from(value));
+        inner.push_param(Value::from(value.into().into_owned()));
 
         Self::new(inner)
     }
@@ -73,7 +73,7 @@ impl<'a> DefaultValue<'a> {
         T: fmt::Display + 'a,
     {
         let mut inner = Function::new("default");
-        inner.push_param(Value::Constant(Constant::new_no_validate(Box::new(value))));
+        inner.push_param(Value::from(Constant::new_no_validate(value)));
 
         Self::new(inner)
     }
@@ -93,7 +93,7 @@ impl<'a> DefaultValue<'a> {
         let mut inner = Function::new("default");
         let constant = Box::new(Array::from(values));
 
-        inner.push_param(Value::Constant(Constant::new_no_validate(constant)));
+        inner.push_param(Value::from(Constant::new_no_validate(constant)));
 
         Self::new(inner)
     }
@@ -106,38 +106,40 @@ impl<'a> DefaultValue<'a> {
     ///                                      ^^^^^^^^^^ this
     /// }
     /// ```
-    pub fn map(&mut self, mapped_name: &'a str) {
-        self.0.push_param(("map", Text(mapped_name)));
+    pub fn map(&mut self, mapped_name: impl Into<Cow<'a, str>>) {
+        self.0.push_param(("map", Text::new(mapped_name)));
     }
 
     /// Here to cope with the initial issue of needing the DML
     /// structures. Remove when we don't generate DML in intro
     /// anymore.
-    pub fn from_dml(val: &'a dml::DefaultValue) -> Self {
+    pub fn from_dml(val: &dml::DefaultValue) -> Self {
         let mut dv = match &val.kind {
-            dml::DefaultKind::Single(dml::PrismaValue::String(ref val)) => Self::text(val),
-            dml::DefaultKind::Single(dml::PrismaValue::Boolean(val)) => Self::constant(val),
-            dml::DefaultKind::Single(dml::PrismaValue::Enum(val)) => Self::constant(val.as_str()),
-            dml::DefaultKind::Single(dml::PrismaValue::Int(val)) => Self::constant(val),
-            dml::DefaultKind::Single(dml::PrismaValue::Uuid(val)) => Self::constant(val.as_hyphenated()),
+            dml::DefaultKind::Single(dml::PrismaValue::String(val)) => Self::text(val.clone()),
+            dml::DefaultKind::Single(dml::PrismaValue::Boolean(val)) => Self::constant(*val),
+            dml::DefaultKind::Single(dml::PrismaValue::Enum(val)) => {
+                Self::constant(Cow::<str>::Owned(String::clone(val)))
+            }
+            dml::DefaultKind::Single(dml::PrismaValue::Int(val)) => Self::constant(*val),
+            dml::DefaultKind::Single(dml::PrismaValue::Uuid(val)) => Self::constant(val.as_hyphenated().to_string()),
             dml::DefaultKind::Single(dml::PrismaValue::List(ref vals)) => {
                 Self::array(vals.iter().map(Value::from).collect())
             }
-            dml::DefaultKind::Single(dml::PrismaValue::Json(ref val)) => Self::text(val),
-            dml::DefaultKind::Single(dml::PrismaValue::Xml(ref val)) => Self::text(val),
-            dml::DefaultKind::Single(dml::PrismaValue::Float(ref val)) => Self::constant(val),
-            dml::DefaultKind::Single(dml::PrismaValue::BigInt(val)) => Self::constant(val),
-            dml::DefaultKind::Single(dml::PrismaValue::Bytes(ref val)) => Self::bytes(val),
-            dml::DefaultKind::Single(dml::PrismaValue::DateTime(val)) => Self::constant(val),
+            dml::DefaultKind::Single(dml::PrismaValue::Json(val)) => Self::text(val.clone()),
+            dml::DefaultKind::Single(dml::PrismaValue::Xml(val)) => Self::text(val.clone()),
+            dml::DefaultKind::Single(dml::PrismaValue::Float(ref val)) => Self::constant(val.clone()),
+            dml::DefaultKind::Single(dml::PrismaValue::BigInt(val)) => Self::constant(*val),
+            dml::DefaultKind::Single(dml::PrismaValue::Bytes(val)) => Self::bytes(Cow::Owned(val.clone())),
+            dml::DefaultKind::Single(dml::PrismaValue::DateTime(val)) => Self::constant(*val),
             dml::DefaultKind::Single(dml::PrismaValue::Object(_)) => unreachable!(),
             dml::DefaultKind::Single(dml::PrismaValue::Null) => unreachable!(),
             dml::DefaultKind::Expression(ref expr) => {
-                let mut fun = Function::new(expr.name());
+                let mut fun = Function::new(expr.name().to_owned());
                 fun.render_empty_parentheses();
 
                 for (arg_name, value) in expr.args() {
                     match arg_name {
-                        Some(name) => fun.push_param((name.as_str(), Value::from(value))),
+                        Some(name) => fun.push_param((Cow::Owned(name.clone()), Value::from(value))),
                         None => fun.push_param(Value::from(value)),
                     }
                 }
@@ -147,7 +149,7 @@ impl<'a> DefaultValue<'a> {
         };
 
         if let Some(s) = val.db_name() {
-            dv.map(s);
+            dv.map(s.to_owned());
         }
 
         dv
@@ -159,28 +161,28 @@ impl<'a> DefaultValue<'a> {
 }
 
 // TODO: remove when dml is dead.
-impl<'a> From<&'a dml::PrismaValue> for Value<'a> {
-    fn from(value: &'a dml::PrismaValue) -> Self {
+impl From<&dml::PrismaValue> for Value<'static> {
+    fn from(value: &dml::PrismaValue) -> Self {
         match value {
-            dml::PrismaValue::String(ref s) => Value::Text(Text(s)),
-            dml::PrismaValue::Boolean(v) => Value::Constant(Constant::new_no_validate(Box::new(v))),
-            dml::PrismaValue::Enum(val) => Value::Constant(Constant::new_no_validate(Box::new(val.as_str()))),
-            dml::PrismaValue::Int(val) => Value::Constant(Constant::new_no_validate(Box::new(val))),
-            dml::PrismaValue::Uuid(val) => Value::Constant(Constant::new_no_validate(Box::new(val.as_hyphenated()))),
+            dml::PrismaValue::String(s) => Value::Text(Text(s.clone().into())),
+            dml::PrismaValue::Boolean(v) => Value::from(Constant::new_no_validate(v)),
+            dml::PrismaValue::Enum(val) => Value::from(Constant::new_no_validate(val)),
+            dml::PrismaValue::Int(val) => Value::from(Constant::new_no_validate(val)),
+            dml::PrismaValue::Uuid(val) => Value::from(Constant::new_no_validate(val.as_hyphenated())),
             dml::PrismaValue::List(vals) => {
                 let vals = vals.iter().collect::<Vec<_>>();
                 let constant = Box::new(Array::from(vals));
 
-                Value::Constant(Constant::new_no_validate(constant))
+                Value::from(Constant::new_no_validate(constant))
             }
-            dml::PrismaValue::Json(ref val) => Value::Text(Text(val)),
-            dml::PrismaValue::Xml(ref val) => Value::Text(Text(val)),
+            dml::PrismaValue::Json(val) => Value::Text(Text(val.clone().into())),
+            dml::PrismaValue::Xml(val) => Value::Text(Text(val.clone().into())),
             dml::PrismaValue::Object(_) => unreachable!(),
             dml::PrismaValue::Null => unreachable!(),
-            dml::PrismaValue::DateTime(val) => Value::Constant(Constant::new_no_validate(Box::new(val))),
-            dml::PrismaValue::Float(val) => Value::Constant(Constant::new_no_validate(Box::new(val))),
-            dml::PrismaValue::BigInt(val) => Value::Constant(Constant::new_no_validate(Box::new(val))),
-            dml::PrismaValue::Bytes(val) => Value::from(val.as_slice()),
+            dml::PrismaValue::DateTime(val) => Value::from(Constant::new_no_validate(val)),
+            dml::PrismaValue::Float(val) => Value::from(Constant::new_no_validate(val)),
+            dml::PrismaValue::BigInt(val) => Value::from(Constant::new_no_validate(val)),
+            dml::PrismaValue::Bytes(val) => Value::from(val.clone()),
         }
     }
 }

--- a/introspection-engine/datamodel-renderer/src/datamodel/field_type.rs
+++ b/introspection-engine/datamodel-renderer/src/datamodel/field_type.rs
@@ -8,9 +8,9 @@ enum FieldKind<'a> {
     Required(Constant<Cow<'a, str>>),
     Optional(Constant<Cow<'a, str>>),
     Array(Constant<Cow<'a, str>>),
-    RequiredUnsupported(Text<&'a str>),
-    OptionalUnsupported(Text<&'a str>),
-    ArrayUnsupported(Text<&'a str>),
+    RequiredUnsupported(Text<Cow<'a, str>>),
+    OptionalUnsupported(Text<Cow<'a, str>>),
+    ArrayUnsupported(Text<Cow<'a, str>>),
 }
 
 /// A type of a field in the datamodel.
@@ -24,12 +24,8 @@ impl<'a> FieldType<'a> {
     /// type. For example: `Int`.
     ///
     /// The name will be sanitized, removing unsupported characters.
-    pub fn required(name: &'a str) -> Self {
-        let name = match Constant::new(name) {
-            Ok(name) => name,
-            Err(crate::value::ConstantNameValidationError::WasSanitized { sanitized }) => sanitized,
-            Err(_) => Constant::new_no_validate(Cow::Borrowed(name)),
-        };
+    pub fn required(name: impl Into<Cow<'a, str>>) -> Self {
+        let name = Constant::new_no_validate(name.into());
 
         Self {
             inner: FieldKind::Required(name),
@@ -40,13 +36,8 @@ impl<'a> FieldType<'a> {
     /// type name. For example: `Int?`.
     ///
     /// The name will be sanitized, removing unsupported characters.
-    pub fn optional(name: &'a str) -> Self {
-        let name = match Constant::new(name) {
-            Ok(name) => name,
-            Err(crate::value::ConstantNameValidationError::WasSanitized { sanitized }) => sanitized,
-            Err(_) => Constant::new_no_validate(Cow::Borrowed(name)),
-        };
-
+    pub fn optional(name: impl Into<Cow<'a, str>>) -> Self {
+        let name = Constant::new_no_validate(name.into());
         Self {
             inner: FieldKind::Optional(name),
         }
@@ -56,13 +47,8 @@ impl<'a> FieldType<'a> {
     /// type name. For example: `Int[]`.
     ///
     /// The name will be sanitized, removing unsupported characters.
-    pub fn array(name: &'a str) -> Self {
-        let name = match Constant::new(name) {
-            Ok(name) => name,
-            Err(crate::value::ConstantNameValidationError::WasSanitized { sanitized }) => sanitized,
-            Err(_) => Constant::new_no_validate(Cow::Borrowed(name)),
-        };
-
+    pub fn array(name: impl Into<Cow<'a, str>>) -> Self {
+        let name = Constant::new_no_validate(name.into());
         Self {
             inner: FieldKind::Array(name),
         }
@@ -70,25 +56,25 @@ impl<'a> FieldType<'a> {
 
     /// The field is required, but not supported by Prisma, rendered
     /// as `Unsupported(ts_vector)`.
-    pub fn required_unsupported(name: &'a str) -> Self {
+    pub fn required_unsupported(name: impl Into<Cow<'a, str>>) -> Self {
         Self {
-            inner: FieldKind::RequiredUnsupported(Text(name)),
+            inner: FieldKind::RequiredUnsupported(Text(name.into())),
         }
     }
 
     /// The field is optional, but not supported by Prisma, rendered
     /// as `Unsupported(ts_vector)?`.
-    pub fn optional_unsupported(name: &'a str) -> Self {
+    pub fn optional_unsupported(name: impl Into<Cow<'a, str>>) -> Self {
         Self {
-            inner: FieldKind::OptionalUnsupported(Text(name)),
+            inner: FieldKind::OptionalUnsupported(Text(name.into())),
         }
     }
 
     /// The field is optional, but not supported by Prisma, rendered
     /// as `Unsupported(ts_vector)?`.
-    pub fn array_unsupported(name: &'a str) -> Self {
+    pub fn array_unsupported(name: impl Into<Cow<'a, str>>) -> Self {
         Self {
-            inner: FieldKind::ArrayUnsupported(Text(name)),
+            inner: FieldKind::ArrayUnsupported(Text(name.into())),
         }
     }
 }

--- a/introspection-engine/datamodel-renderer/src/datamodel/model/id.rs
+++ b/introspection-engine/datamodel-renderer/src/datamodel/model/id.rs
@@ -34,7 +34,7 @@ impl<'a> IdDefinition<'a> {
     /// //                     ^^^^^ here
     /// ```
     pub fn name(&mut self, name: &'a str) {
-        self.0.push_param(("name", Text(name)));
+        self.0.push_param(("name", Text::new(name)));
     }
 
     /// The primary key constraint name.
@@ -44,7 +44,7 @@ impl<'a> IdDefinition<'a> {
     /// //                    ^^^^^ here
     /// ```
     pub fn map(&mut self, map: &'a str) {
-        self.0.push_param(("map", Text(map)));
+        self.0.push_param(("map", Text::new(map)));
     }
 
     /// The constraint clustering setting.
@@ -86,7 +86,7 @@ impl<'a> IdFieldDefinition<'a> {
     /// //                 ^^^^^ here
     /// ```
     pub fn map(&mut self, map: &'a str) {
-        self.0.push_param(("map", Text(map)));
+        self.0.push_param(("map", Text::new(map)));
     }
 
     /// The constraint clustering setting.

--- a/introspection-engine/datamodel-renderer/src/datamodel/model/index.rs
+++ b/introspection-engine/datamodel-renderer/src/datamodel/model/index.rs
@@ -30,13 +30,13 @@ impl<'a> IndexDefinition<'a> {
     /// The client name of the index, defined as the `name` argument
     /// inside the attribute.
     pub fn name(&mut self, name: &'a str) {
-        self.0.push_param(("name", Text(name)));
+        self.0.push_param(("name", Text::new(name)));
     }
 
     /// The constraint name in the database, defined as the `map`
     /// argument inside the attribute.
     pub fn map(&mut self, map: &'a str) {
-        self.0.push_param(("map", Text(map)));
+        self.0.push_param(("map", Text::new(map)));
     }
 
     /// Defines the `clustered` argument inside the attribute.

--- a/introspection-engine/datamodel-renderer/src/datamodel/model/index_field_input.rs
+++ b/introspection-engine/datamodel-renderer/src/datamodel/model/index_field_input.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use super::IndexOps;
-use crate::value::{Constant, ConstantNameValidationError, Function};
+use crate::value::{Constant, Function};
 
 /// Input parameters for a field in a model index definition.
 #[derive(Debug, Clone)]
@@ -105,11 +105,7 @@ impl<'a> From<IndexFieldInput<'a>> for Function<'a> {
         let name: Vec<_> = definition
             .name
             .split('.')
-            .map(|name| match Constant::new(name) {
-                Ok(c) => c,
-                Err(ConstantNameValidationError::WasSanitized { sanitized }) => sanitized,
-                Err(_) => Constant::new_no_validate(Cow::Borrowed(name)),
-            })
+            .map(|name| Constant::new_no_validate(Cow::Borrowed(name)))
             .map(|constant| constant.into_inner())
             .collect();
 

--- a/introspection-engine/datamodel-renderer/src/datamodel/model/relation.rs
+++ b/introspection-engine/datamodel-renderer/src/datamodel/model/relation.rs
@@ -58,7 +58,7 @@ impl<'a> Relation<'a> {
     /// //              ^^^^^^ this
     /// ```
     pub fn map(&mut self, name: &'a str) {
-        self.0.push_param(("map", Text(name)));
+        self.0.push_param(("map", Text::new(name)));
     }
 
     /// Defines the fields array.
@@ -82,15 +82,7 @@ impl<'a> Relation<'a> {
     }
 
     fn push_array_parameter(&mut self, param_name: &'static str, data: impl Iterator<Item = &'a str>) {
-        let fields: Vec<_> = data
-            .map(|name| match Constant::new(name) {
-                Ok(name) => name,
-                Err(crate::value::ConstantNameValidationError::WasSanitized { sanitized }) => sanitized,
-                Err(_) => Constant::new_no_validate(Cow::Borrowed(name)),
-            })
-            .map(|c| c.boxed())
-            .map(Value::Constant)
-            .collect();
+        let fields: Vec<_> = data.map(Cow::Borrowed).map(Value::Constant).collect();
 
         if !fields.is_empty() {
             self.0.push_param((param_name, Array::from(fields)));

--- a/introspection-engine/datamodel-renderer/src/lib.rs
+++ b/introspection-engine/datamodel-renderer/src/lib.rs
@@ -71,3 +71,5 @@ pub mod value;
 
 pub use configuration::Configuration;
 pub use datamodel::Datamodel;
+
+use std::borrow::Cow;

--- a/introspection-engine/datamodel-renderer/src/value/constant.rs
+++ b/introspection-engine/datamodel-renderer/src/value/constant.rs
@@ -1,10 +1,6 @@
 use std::{borrow::Cow, fmt};
 
-use once_cell::sync::Lazy;
-use regex::Regex;
-
-/// A constant value. Should be used if a value has certain naming
-/// standards.
+/// A unquoted identifier. Should be used if a value has certain naming standards.
 #[derive(Debug)]
 pub struct Constant<T: fmt::Display>(T);
 
@@ -28,67 +24,16 @@ impl<'a> AsRef<str> for Constant<Cow<'a, str>> {
     }
 }
 
-/// Thrown if a constant cannot be cleanly created with the given
-/// input value.
-#[derive(Debug)]
-pub enum ConstantNameValidationError<'a> {
-    /// Constant was invalid but could be sanitized.
-    WasSanitized {
-        /// A sanitized value to be used as a valid constant.
-        sanitized: Constant<Cow<'a, str>>,
-    },
-    /// The given value was empty and cannot be used as a constant.
-    OriginalEmpty,
-    /// Constant was invalid impossible to sanitize as something that
-    /// is valid in the PSL.
-    SanitizedEmpty,
-}
-
-impl<'a, T: fmt::Display + 'a> Constant<T> {
+impl<T> Constant<T>
+where
+    T: fmt::Display,
+{
     pub(crate) fn new_no_validate(value: T) -> Self {
         Self(value)
     }
 
-    pub(crate) fn boxed(self) -> Constant<Box<dyn fmt::Display + 'a>> {
-        Constant(Box::new(self.0) as Box<dyn fmt::Display + 'a>)
-    }
-
     pub(crate) fn into_inner(self) -> T {
         self.0
-    }
-}
-
-impl<'a> Constant<Cow<'a, str>> {
-    /// Creates a new constant value. The result has to be checked. If
-    /// resulting an error, the error value gives a constant with a
-    /// standardized value, and the right side of the tuple is the
-    /// actual input value. This input value must be used in a
-    /// corresponding `@map`, `@@map` or `map:` declaration, depending
-    /// on the position of the constant.
-    pub fn new(value: impl Into<Cow<'a, str>>) -> Result<Self, ConstantNameValidationError<'a>> {
-        static CONSTANT_START: Lazy<Regex> = Lazy::new(|| Regex::new("^[^a-zA-Z]+").unwrap());
-        static CONSTANT: Lazy<Regex> = Lazy::new(|| Regex::new("[^_a-zA-Z0-9]").unwrap());
-
-        let value = value.into();
-
-        if value.is_empty() {
-            Err(ConstantNameValidationError::OriginalEmpty)
-        } else if CONSTANT_START.is_match(&value) || CONSTANT.is_match(&value) {
-            let start_cleaned: String = CONSTANT_START.replace_all(&value, "").parse().unwrap();
-            let sanitized: String = CONSTANT.replace_all(start_cleaned.as_str(), "_").parse().unwrap();
-
-            if !sanitized.is_empty() {
-                let err = ConstantNameValidationError::WasSanitized {
-                    sanitized: Self(Cow::Owned(sanitized)),
-                };
-
-                Err(err)
-            } else {
-                Err(ConstantNameValidationError::SanitizedEmpty)
-            }
-        } else {
-            Ok(Self(value))
-        }
     }
 }
 

--- a/introspection-engine/datamodel-renderer/src/value/documentation.rs
+++ b/introspection-engine/datamodel-renderer/src/value/documentation.rs
@@ -1,8 +1,8 @@
-use std::fmt;
+use std::{borrow::Cow, fmt};
 
 /// A documentation block on top of an item in the PSL.
 #[derive(Debug)]
-pub struct Documentation<'a>(pub(crate) &'a str);
+pub struct Documentation<'a>(pub(crate) Cow<'a, str>);
 
 impl<'a> fmt::Display for Documentation<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/introspection-engine/datamodel-renderer/src/value/text.rs
+++ b/introspection-engine/datamodel-renderer/src/value/text.rs
@@ -1,15 +1,27 @@
-use std::fmt;
-
 use base64::display::Base64Display;
 use psl::PreviewFeature;
+use std::{borrow::Cow, fmt};
 
 /// Represents a string value in the PSL.
 #[derive(Debug, Clone, Copy)]
-pub struct Text<T: fmt::Display>(pub T);
+pub struct Text<T: fmt::Display>(pub(crate) T);
+
+impl<'a> Text<Cow<'a, str>> {
+    /// Construct a `Text` value from a string.
+    pub fn new(s: impl Into<Cow<'a, str>>) -> Self {
+        Text(s.into())
+    }
+}
 
 impl<'a> fmt::Display for Text<&'a str> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&psl::schema_ast::string_literal(self.0), f)
+    }
+}
+
+impl<'a> fmt::Display for Text<Cow<'a, str>> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&psl::schema_ast::string_literal(self.0.as_ref()), f)
     }
 }
 


### PR DESCRIPTION
Two main themes:

- Lifetimes.
- Constant validation.

**Lifetimes**

The situation before this commit is the following: all strings in the renderer data structure come from the DML data structure. They can all be borrowed.

Once we remove the DML, this won't work anymore, because we will render strings that do _not_ come from either the SQL schema or the initial Prisma schema in the renderer. Two examples: default values and sanitized names. So we need the renderer to accept owned strings. Alternatively, we could do interning, which is probably a better approach long term, but larger refactoring. In this commit, we replace borrowed strings with Cow<str> in many places.

**Constant validation**

We have to do constant validation earlier in the process to guarantee that:

- We do it only in one place
- We can emit warnings

So they do not work in the renderer. Since we already do it earlier in the process, in this PR, we can just remove the constant validation code from the renderer. The only exception is extensions in the datasource, which we port in this commit.