### PR TITLE
fix: nested connect should disconnect only optional fields

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
@@ -21,3 +21,4 @@ mod prisma_7010;
 mod prisma_7072;
 mod prisma_7434;
 mod prisma_8265;
+mod prisma_8858;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_8858.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_8858.rs
@@ -1,0 +1,73 @@
+use query_engine_tests::*;
+
+#[test_suite(schema(schema))]
+mod prisma_8858 {
+    fn schema() -> String {
+        r#"
+        model Object {
+          clientId  Int
+          uuid      String
+          otherUuid String?
+        
+          otherObject        Object? @relation("objectToobject", fields: [clientId, otherUuid], references: [clientId, uuid])
+          otherObjectReverse Object? @relation("objectToobject")
+        
+          @@id([clientId, uuid])
+          @@unique([clientId, otherUuid])
+        }
+        
+        "#
+        .to_owned()
+    }
+
+    #[connector_test]
+    async fn regression_8858(runner: Runner) -> TestResult<()> {
+        run_query!(
+            &runner,
+            r#"mutation { createOneObject(data: { clientId: 1, uuid: "1" }) { clientId } }"#
+        );
+        run_query!(
+            &runner,
+            r#"mutation { createOneObject(data: { clientId: 1, uuid: "2", otherUuid: "1" }) { clientId } }"#
+        );
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"mutation { updateOneObject(
+          where: {
+            clientId_uuid: {
+              clientId: 1,
+              uuid: "1",
+            },
+          },
+          data: {
+            otherUuid: "2",
+          },
+        ) { clientId uuid otherUuid } }"#),
+          @r###"{"data":{"updateOneObject":{"clientId":1,"uuid":"1","otherUuid":"2"}}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"mutation { updateOneObject(
+          where: {
+            clientId_uuid: {
+              clientId: 1,
+              uuid: "1",
+            },
+          },
+          data: {
+            otherObject: {
+              connect: {
+                clientId_uuid: {
+                  clientId: 1,
+                  uuid: "2",
+                },
+              },
+            },
+          }
+        ) { clientId uuid otherObject { clientId uuid } } }"#),
+          @r###"{"data":{"updateOneObject":{"clientId":1,"uuid":"1","otherObject":{"clientId":1,"uuid":"2"}}}}"###
+        );
+
+        Ok(())
+    }
+}

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_8858.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_8858.rs
@@ -10,7 +10,7 @@ mod prisma_8858 {
           otherUuid String?
         
           otherObject        Object? @relation("objectToobject", fields: [clientId, otherUuid], references: [clientId, uuid], onDelete: NoAction, onUpdate: NoAction)
-          otherObjectReverse Object? @relation("objectToobject", onDelete: NoAction, onUpdate: NoAction)
+          otherObjectReverse Object? @relation("objectToobject")
         
           @@id([clientId, uuid])
           @@unique([clientId, otherUuid])

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_8858.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_8858.rs
@@ -1,6 +1,6 @@
 use query_engine_tests::*;
 
-#[test_suite(schema(schema))]
+#[test_suite(schema(schema), capabilities(CompoundIds))]
 mod prisma_8858 {
     fn schema() -> String {
         r#"
@@ -9,8 +9,8 @@ mod prisma_8858 {
           uuid      String
           otherUuid String?
         
-          otherObject        Object? @relation("objectToobject", fields: [clientId, otherUuid], references: [clientId, uuid])
-          otherObjectReverse Object? @relation("objectToobject")
+          otherObject        Object? @relation("objectToobject", fields: [clientId, otherUuid], references: [clientId, uuid], onDelete: NoAction, onUpdate: NoAction)
+          otherObjectReverse Object? @relation("objectToobject", onDelete: NoAction, onUpdate: NoAction)
         
           @@id([clientId, uuid])
           @@unique([clientId, otherUuid])

--- a/query-engine/core/src/query_graph_builder/write/utils.rs
+++ b/query-engine/core/src/query_graph_builder/write/utils.rs
@@ -4,7 +4,9 @@ use crate::{
     ParsedInputValue, QueryGraphBuilderError, QueryGraphBuilderResult,
 };
 use connector::{DatasourceFieldName, Filter, RecordFilter, WriteArgs, WriteOperation};
+
 use indexmap::IndexMap;
+use itertools::Itertools;
 use prisma_models::{FieldSelection, ModelRef, PrismaValue, RelationFieldRef, SelectionResult};
 use psl::dml::ReferentialAction;
 use schema::ConnectorContext;
@@ -253,7 +255,12 @@ pub fn insert_existing_1to1_related_model_checks(
             }?;
 
             if let Node::Query(Query::Write(ref mut wq)) = update_existing_child {
-                wq.inject_result_into_args(SelectionResult::from(&child_linking_fields));
+                // Only set optional linking fields to null. Not all linking fields have to be optional for the relation to be optional.
+                // NOTE: This can most likely be optimized better.
+                let nullable_linking_fields = child_linking_fields.as_fields().into_iter().filter(|f| !f.is_required()).collect_vec();
+                let nullable_linking_fields = FieldSelection::from(nullable_linking_fields);
+
+                wq.inject_result_into_args(SelectionResult::from(&nullable_linking_fields));
             }
 
             if let Node::Query(Query::Write(WriteQuery::UpdateManyRecords(ref mut ur))) = update_existing_child {


### PR DESCRIPTION
## Overview

fixes https://github.com/prisma/prisma/issues/8858

When a nested connect is performed, we first disconnect the inlined side of the relation. This logic set _all_ linking fields to null, without making sure that those fields were nullable.