### PR TITLE
datamodel-renderer: no borrowing from dml

### DIFF
--- a/introspection-engine/connectors/mongodb-introspection-connector/src/sampler.rs
+++ b/introspection-engine/connectors/mongodb-introspection-connector/src/sampler.rs
@@ -51,16 +51,15 @@ pub(super) async fn sample(
 
     let data_model = statistics.into_datamodel(&mut warnings);
     let is_empty = data_model.is_empty();
-
-    let data_model = if ctx.render_config {
-        format!(
-            "{}\n{}",
-            render::Configuration::from_psl(ctx.configuration()),
-            render::Datamodel::from_dml(ctx.datasource(), &data_model),
-        )
+    let mut rendered = render::Datamodel::default();
+    rendered.push_dml(ctx.datasource(), &data_model);
+    let config = if ctx.render_config {
+        render::Configuration::from_psl(ctx.configuration()).to_string()
     } else {
-        render::Datamodel::from_dml(ctx.datasource(), &data_model).to_string()
+        String::new()
     };
+
+    let data_model = format!("{config}\n{rendered}");
 
     Ok(IntrospectionResult {
         data_model: psl::reformat(&data_model, 2).unwrap(),

--- a/introspection-engine/connectors/sql-introspection-connector/src/introspection.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/introspection.rs
@@ -53,11 +53,10 @@ pub(crate) fn introspect(ctx: &mut Context) -> Result<(String, bool), SqlError> 
         String::new()
     };
 
-    let rendered = format!(
-        "{}\n{}",
-        config,
-        render::Datamodel::from_dml(&ctx.config.datasources[0], &datamodel),
-    );
+    let mut rendered_datamodel = render::Datamodel::default();
+    rendered_datamodel.push_dml(&ctx.config.datasources[0], &datamodel);
+
+    let rendered = format!("{config}\n{rendered_datamodel}");
 
     ctx.finalize_warnings();
 

--- a/introspection-engine/datamodel-renderer/src/datamodel.rs
+++ b/introspection-engine/datamodel-renderer/src/datamodel.rs
@@ -70,22 +70,18 @@ impl<'a> Datamodel<'a> {
     /// A throwaway function to help generate a rendering from the DML structures.
     ///
     /// Delete when removing DML.
-    pub fn from_dml(datasource: &'a psl::Datasource, dml_data_model: &'a dml::Datamodel) -> Datamodel<'a> {
-        let mut data_model = Self::new();
-
+    pub fn push_dml(&mut self, datasource: &'a psl::Datasource, dml_data_model: &dml::Datamodel) {
         for dml_model in dml_data_model.models() {
-            data_model.push_model(Model::from_dml(datasource, dml_model));
+            self.push_model(Model::from_dml(datasource, dml_model));
         }
 
         for dml_ct in dml_data_model.composite_types() {
-            data_model.push_composite_type(CompositeType::from_dml(datasource, dml_ct));
+            self.push_composite_type(CompositeType::from_dml(datasource, dml_ct));
         }
 
-        for dml_enum in dml_data_model.enums() {
-            data_model.push_enum(Enum::from_dml(dml_enum));
+        for r#enum in dml_data_model.enums() {
+            self.push_enum(Enum::from_dml(r#enum));
         }
-
-        data_model
     }
 }
 

--- a/introspection-engine/datamodel-renderer/src/datamodel/attributes.rs
+++ b/introspection-engine/datamodel-renderer/src/datamodel/attributes.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{borrow::Cow, fmt};
 
 use crate::value::{Function, FunctionParam};
 
@@ -13,7 +13,7 @@ use crate::value::{Function, FunctionParam};
 #[derive(Debug)]
 pub(super) struct FieldAttribute<'a> {
     attribute: Function<'a>,
-    prefix: Option<&'a str>,
+    prefix: Option<Cow<'a, str>>,
 }
 
 impl<'a> FieldAttribute<'a> {
@@ -27,8 +27,8 @@ impl<'a> FieldAttribute<'a> {
     /// Adds a prefix to the field attribute. Useful for native types,
     /// e.g. `attr.prefix("db")` for a type attribute renders as
     /// `@db.Type`.
-    pub(super) fn prefix(&mut self, prefix: &'a str) {
-        self.prefix = Some(prefix);
+    pub(super) fn prefix(&mut self, prefix: impl Into<Cow<'a, str>>) {
+        self.prefix = Some(prefix.into());
     }
 
     /// Add a new parameter to the attribute function.
@@ -41,7 +41,7 @@ impl<'a> fmt::Display for FieldAttribute<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("@")?;
 
-        if let Some(prefix) = self.prefix {
+        if let Some(prefix) = &self.prefix {
             f.write_str(prefix)?;
             f.write_str(".")?;
         }

--- a/introspection-engine/datamodel-renderer/src/datamodel/composite_type.rs
+++ b/introspection-engine/datamodel-renderer/src/datamodel/composite_type.rs
@@ -8,7 +8,7 @@ use std::{borrow::Cow, fmt};
 /// A type block in a PSL file.
 #[derive(Debug)]
 pub struct CompositeType<'a> {
-    name: Constant<&'a str>,
+    name: Constant<Cow<'a, str>>,
     documentation: Option<Documentation<'a>>,
     fields: Vec<CompositeTypeField<'a>>,
 }
@@ -22,8 +22,8 @@ impl<'a> CompositeType<'a> {
     /// //   ^^^^^^^ name
     /// }
     /// ```
-    pub fn new(name: &'a str) -> Self {
-        let name = Constant::new_no_validate(name);
+    pub fn new(name: impl Into<Cow<'a, str>>) -> Self {
+        let name = Constant::new_no_validate(name.into());
 
         Self {
             name,
@@ -59,8 +59,8 @@ impl<'a> CompositeType<'a> {
     /// Generate a composite type rendering from the deprecated DML structure.
     ///
     /// Remove when destroying the DML.
-    pub fn from_dml(datasource: &'a psl::Datasource, dml_ct: &'a dml::CompositeType) -> Self {
-        let mut composite_type = CompositeType::new(&dml_ct.name);
+    pub fn from_dml(datasource: &'a psl::Datasource, dml_ct: &dml::CompositeType) -> Self {
+        let mut composite_type = CompositeType::new(dml_ct.name.clone());
 
         for dml_field in dml_ct.fields.iter() {
             composite_type.push_field(CompositeTypeField::from_dml(datasource, dml_field));

--- a/introspection-engine/datamodel-renderer/src/datamodel/model/field.rs
+++ b/introspection-engine/datamodel-renderer/src/datamodel/model/field.rs
@@ -35,7 +35,7 @@ impl<'a> ModelField<'a> {
     /// //^^^^ name
     /// }
     /// ```
-    pub fn new_required(name: &'a str, type_name: &'a str) -> Self {
+    pub fn new_required(name: impl Into<Cow<'a, str>>, type_name: impl Into<Cow<'a, str>>) -> Self {
         Self::new(name, FieldType::required(type_name))
     }
 
@@ -48,7 +48,7 @@ impl<'a> ModelField<'a> {
     /// //^^^^^^ name
     /// }
     /// ```
-    pub fn new_optional(name: &'a str, type_name: &'a str) -> Self {
+    pub fn new_optional(name: impl Into<Cow<'a, str>>, type_name: impl Into<Cow<'a, str>>) -> Self {
         Self::new(name, FieldType::optional(type_name))
     }
 
@@ -61,7 +61,7 @@ impl<'a> ModelField<'a> {
     /// //^^^^^^ name
     /// }
     /// ```
-    pub fn new_array(name: &'a str, type_name: &'a str) -> Self {
+    pub fn new_array(name: impl Into<Cow<'a, str>>, type_name: impl Into<Cow<'a, str>>) -> Self {
         Self::new(name, FieldType::array(type_name))
     }
 
@@ -74,7 +74,7 @@ impl<'a> ModelField<'a> {
     /// //^^^^^^ name
     /// }
     /// ```
-    pub fn new_required_unsupported(name: &'a str, type_name: &'a str) -> Self {
+    pub fn new_required_unsupported(name: impl Into<Cow<'a, str>>, type_name: impl Into<Cow<'a, str>>) -> Self {
         Self::new(name, FieldType::required_unsupported(type_name))
     }
 
@@ -87,7 +87,7 @@ impl<'a> ModelField<'a> {
     /// //^^^^^^ name
     /// }
     /// ```
-    pub fn new_optional_unsupported(name: &'a str, type_name: &'a str) -> Self {
+    pub fn new_optional_unsupported(name: impl Into<Cow<'a, str>>, type_name: impl Into<Cow<'a, str>>) -> Self {
         Self::new(name, FieldType::optional_unsupported(type_name))
     }
 
@@ -100,8 +100,8 @@ impl<'a> ModelField<'a> {
     /// //^^^^^^ name
     /// }
     /// ```
-    pub fn new_array_unsupported(name: &'a str, type_name: &'a str) -> Self {
-        Self::new(name, FieldType::array_unsupported(type_name))
+    pub fn new_array_unsupported(name: impl Into<Cow<'a, str>>, type_name: impl Into<Cow<'a, str>>) -> Self {
+        Self::new(name.into(), FieldType::array_unsupported(type_name.into()))
     }
 
     /// Sets the field map attribute.
@@ -112,9 +112,9 @@ impl<'a> ModelField<'a> {
     ///                       ^^^^^^ value
     /// }
     /// ```
-    pub fn map(&mut self, value: &'a str) {
+    pub fn map(&mut self, value: impl Into<Cow<'a, str>>) {
         let mut map = Function::new("map");
-        map.push_param(value);
+        map.push_param(value.into());
 
         self.map = Some(FieldAttribute::new(map));
     }
@@ -155,7 +155,12 @@ impl<'a> ModelField<'a> {
     /// ```
     ///
     /// TODO: `params` as `&[&str]` when we get rid of the DML.
-    pub fn native_type(&mut self, prefix: &'a str, r#type: &'a str, params: Vec<String>) {
+    pub fn native_type(
+        &mut self,
+        prefix: impl Into<Cow<'a, str>>,
+        r#type: impl Into<Cow<'a, str>>,
+        params: Vec<String>,
+    ) {
         let mut native_type = FieldAttribute::new(Function::new(r#type));
 
         for param in params {
@@ -250,8 +255,8 @@ impl<'a> ModelField<'a> {
         self.commented_out = true;
     }
 
-    fn new(name: &'a str, r#type: FieldType<'a>) -> Self {
-        let name = Constant::new_no_validate(Cow::Borrowed(name));
+    fn new(name: impl Into<Cow<'a, str>>, r#type: FieldType<'a>) -> Self {
+        let name = Constant::new_no_validate(name.into());
 
         Self {
             name,
@@ -277,39 +282,40 @@ impl<'a> ModelField<'a> {
     pub(super) fn from_dml(
         datasource: &'a psl::Datasource,
         _dml_model: &dml::Model,
-        dml_field: &'a dml::Field,
-        uniques: &HashMap<&'a str, IndexFieldOptions<'a>>,
-        id: Option<IdFieldDefinition<'a>>,
-    ) -> Self {
+        dml_field: &dml::Field,
+        uniques: &HashMap<&str, IndexFieldOptions<'static>>,
+        id: Option<IdFieldDefinition<'static>>,
+    ) -> ModelField<'a> {
         match dml_field {
             dml::Field::ScalarField(ref sf) => {
-                let (r#type, native_type) = match sf.field_type {
-                    dml::FieldType::Enum(ref ct) => (ct.as_str(), None),
-                    dml::FieldType::Relation(ref info) => (info.referenced_model.as_str(), None),
-                    dml::FieldType::Unsupported(ref s) => (s.as_str(), None),
+                let field_name = sf.name.clone();
+                let (r#type, native_type): (String, _) = match sf.field_type {
+                    dml::FieldType::Enum(ref ct) => (ct.clone(), None),
+                    dml::FieldType::Relation(ref info) => (info.referenced_model.clone(), None),
+                    dml::FieldType::Unsupported(ref s) => (s.clone(), None),
                     dml::FieldType::Scalar(ref st, ref nt) => {
-                        (st.as_ref(), nt.as_ref().map(|nt| (nt.name(), nt.args())))
+                        (st.as_ref().to_owned(), nt.as_ref().map(|nt| (nt.name(), nt.args())))
                     }
-                    dml::FieldType::CompositeType(ref ct) => (ct.as_str(), None),
+                    dml::FieldType::CompositeType(ref ct) => (ct.clone(), None),
                 };
 
                 let mut field = match sf.arity {
                     dml::FieldArity::Required if sf.field_type.is_unsupported() => {
-                        Self::new_required_unsupported(&sf.name, r#type)
+                        Self::new_required_unsupported(sf.name.clone(), r#type)
                     }
                     dml::FieldArity::Optional if sf.field_type.is_unsupported() => {
-                        Self::new_optional_unsupported(&sf.name, r#type)
+                        Self::new_optional_unsupported(sf.name.clone(), r#type)
                     }
                     dml::FieldArity::List if sf.field_type.is_unsupported() => {
-                        Self::new_array_unsupported(&sf.name, r#type)
+                        Self::new_array_unsupported(sf.name.clone(), r#type)
                     }
-                    dml::FieldArity::Required => Self::new_required(&sf.name, r#type),
-                    dml::FieldArity::Optional => Self::new_optional(&sf.name, r#type),
-                    dml::FieldArity::List => Self::new_array(&sf.name, r#type),
+                    dml::FieldArity::Required => Self::new_required(field_name, r#type),
+                    dml::FieldArity::Optional => Self::new_optional(field_name, r#type),
+                    dml::FieldArity::List => Self::new_array(field_name, r#type),
                 };
 
                 if let Some(ref docs) = sf.documentation {
-                    field.documentation(docs);
+                    field.documentation(docs.clone());
                 }
 
                 if let Some(dv) = sf.default_value() {
@@ -325,7 +331,7 @@ impl<'a> ModelField<'a> {
                 }
 
                 if let Some(unique) = uniques.get(sf.name.as_str()) {
-                    field.unique(*unique);
+                    field.unique(unique.clone());
                 }
 
                 if sf.is_ignored {
@@ -337,7 +343,7 @@ impl<'a> ModelField<'a> {
                 }
 
                 if let Some(ref map) = sf.database_name {
-                    field.map(map);
+                    field.map(map.clone());
                 }
 
                 if let Some(id) = id {
@@ -347,14 +353,16 @@ impl<'a> ModelField<'a> {
                 field
             }
             dml::Field::RelationField(rf) => {
+                let field_name = rf.name.clone();
+                let referenced_model = rf.relation_info.referenced_model.clone();
                 let mut field = match rf.arity {
-                    dml::FieldArity::Required => Self::new_required(&rf.name, &rf.relation_info.referenced_model),
-                    dml::FieldArity::Optional => Self::new_optional(&rf.name, &rf.relation_info.referenced_model),
-                    dml::FieldArity::List => Self::new_array(&rf.name, &rf.relation_info.referenced_model),
+                    dml::FieldArity::Required => Self::new_required(field_name, referenced_model),
+                    dml::FieldArity::Optional => Self::new_optional(field_name, referenced_model),
+                    dml::FieldArity::List => Self::new_array(field_name, referenced_model),
                 };
 
                 if let Some(ref docs) = rf.documentation {
-                    field.documentation(docs);
+                    field.documentation(docs.clone());
                 }
 
                 if rf.is_commented_out {
@@ -373,22 +381,22 @@ impl<'a> ModelField<'a> {
                     let mut relation = Relation::new();
 
                     if !relation_name.is_empty() {
-                        relation.name(relation_name);
+                        relation.name(relation_name.to_owned());
                     }
 
-                    relation.fields(dml_info.fields.iter().map(AsRef::as_ref));
-                    relation.references(dml_info.references.iter().map(AsRef::as_ref));
+                    relation.fields(dml_info.fields.iter().map(Clone::clone).map(Cow::Owned));
+                    relation.references(dml_info.references.iter().map(Clone::clone).map(Cow::Owned));
 
                     if let Some(ref action) = dml_info.on_delete {
-                        relation.on_delete(action.as_ref());
+                        relation.on_delete(action.as_ref().to_owned());
                     }
 
                     if let Some(ref action) = dml_info.on_update {
-                        relation.on_update(action.as_ref());
+                        relation.on_update(action.as_ref().to_owned());
                     }
 
                     if let Some(ref map) = &dml_info.fk_name {
-                        relation.map(map);
+                        relation.map(map.clone());
                     }
 
                     field.relation(relation);
@@ -397,18 +405,20 @@ impl<'a> ModelField<'a> {
                 field
             }
             dml::Field::CompositeField(cf) => {
+                let name = cf.name.clone();
+                let ct = cf.composite_type.clone();
                 let mut field = match cf.arity {
-                    dml::FieldArity::Required => Self::new_required(&cf.name, &cf.composite_type),
-                    dml::FieldArity::Optional => Self::new_optional(&cf.name, &cf.composite_type),
-                    dml::FieldArity::List => Self::new_array(&cf.name, &cf.composite_type),
+                    dml::FieldArity::Required => Self::new_required(name, ct),
+                    dml::FieldArity::Optional => Self::new_optional(name, ct),
+                    dml::FieldArity::List => Self::new_array(name, ct),
                 };
 
                 if let Some(ref docs) = cf.documentation {
-                    field.documentation(docs);
+                    field.documentation(docs.clone());
                 }
 
                 if let Some(ref map) = cf.database_name {
-                    field.map(map);
+                    field.map(map.clone());
                 }
 
                 if cf.is_commented_out {

--- a/introspection-engine/datamodel-renderer/src/datamodel/model/id.rs
+++ b/introspection-engine/datamodel-renderer/src/datamodel/model/id.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{borrow::Cow, fmt};
 
 use crate::{
     datamodel::attributes::{BlockAttribute, FieldAttribute},
@@ -33,8 +33,8 @@ impl<'a> IdDefinition<'a> {
     /// @@id([foo, bar], name: "Foo")
     /// //                     ^^^^^ here
     /// ```
-    pub fn name(&mut self, name: &'a str) {
-        self.0.push_param(("name", Text::new(name)));
+    pub fn name(&mut self, name: impl Into<Cow<'a, str>>) {
+        self.0.push_param(("name", Text::new(name.into())));
     }
 
     /// The primary key constraint name.
@@ -43,7 +43,7 @@ impl<'a> IdDefinition<'a> {
     /// @@id([foo, bar], map: "Foo")
     /// //                    ^^^^^ here
     /// ```
-    pub fn map(&mut self, map: &'a str) {
+    pub fn map(&mut self, map: impl Into<Cow<'a, str>>) {
         self.0.push_param(("map", Text::new(map)));
     }
 
@@ -85,8 +85,8 @@ impl<'a> IdFieldDefinition<'a> {
     /// field Int @id(map: "Foo")
     /// //                 ^^^^^ here
     /// ```
-    pub fn map(&mut self, map: &'a str) {
-        self.0.push_param(("map", Text::new(map)));
+    pub fn map(&mut self, map: impl Into<Cow<'a, str>>) {
+        self.0.push_param(("map", Text::new(map.into())));
     }
 
     /// The constraint clustering setting.
@@ -105,8 +105,8 @@ impl<'a> IdFieldDefinition<'a> {
     /// field Int @id(sort: Desc)
     /// //                  ^^^^ here
     /// ```
-    pub(crate) fn sort_order(&mut self, sort: &'a str) {
-        self.0.push_param(("sort", Constant::new_no_validate(sort)));
+    pub(crate) fn sort_order(&mut self, sort: impl Into<Cow<'a, str>>) {
+        self.0.push_param(("sort", Constant::new_no_validate(sort.into())));
     }
 
     /// The constraint length setting.

--- a/introspection-engine/datamodel-renderer/src/datamodel/model/index.rs
+++ b/introspection-engine/datamodel-renderer/src/datamodel/model/index.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{borrow::Cow, fmt};
 
 use crate::{
     datamodel::attributes::BlockAttribute,
@@ -29,13 +29,13 @@ impl<'a> IndexDefinition<'a> {
 
     /// The client name of the index, defined as the `name` argument
     /// inside the attribute.
-    pub fn name(&mut self, name: &'a str) {
+    pub fn name(&mut self, name: impl Into<Cow<'a, str>>) {
         self.0.push_param(("name", Text::new(name)));
     }
 
     /// The constraint name in the database, defined as the `map`
     /// argument inside the attribute.
-    pub fn map(&mut self, map: &'a str) {
+    pub fn map(&mut self, map: impl Into<Cow<'a, str>>) {
         self.0.push_param(("map", Text::new(map)));
     }
 
@@ -45,8 +45,9 @@ impl<'a> IndexDefinition<'a> {
     }
 
     /// Defines the `type` argument inside the attribute.
-    pub fn index_type(&mut self, index_type: &'a str) {
-        self.0.push_param(("type", Constant::new_no_validate(index_type)));
+    pub fn index_type(&mut self, index_type: impl Into<Cow<'a, str>>) {
+        self.0
+            .push_param(("type", Constant::new_no_validate(index_type.into())));
     }
 
     fn new(index_type: &'static str, fields: impl Iterator<Item = IndexFieldInput<'a>>) -> Self {
@@ -66,7 +67,7 @@ impl<'a> fmt::Display for IndexDefinition<'a> {
 }
 
 /// Index type definition.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub enum IndexOps<'a> {
     /// Managed and known by Prisma. Renders as-is as a constant.
     ///
@@ -74,14 +75,14 @@ pub enum IndexOps<'a> {
     /// @@index([field(ops: Int2BloomOps)], type: Brin)
     /// //                  ^^^^^^^^^^^^ like this
     /// ```
-    Managed(&'a str),
+    Managed(Cow<'a, str>),
     /// A type we don't handle yet. Renders as raw.
     ///
     /// ```ignore
     /// @@index([field(ops: raw("tsvector_ops"))], type: Gist)
     /// //                  ^^^^^^^^^^^^^^^^^^^ like this
     /// ```
-    Raw(Text<&'a str>),
+    Raw(Text<Cow<'a, str>>),
 }
 
 impl<'a> fmt::Display for IndexOps<'a> {

--- a/introspection-engine/datamodel-renderer/src/datamodel/model/index_field_input.rs
+++ b/introspection-engine/datamodel-renderer/src/datamodel/model/index_field_input.rs
@@ -7,7 +7,7 @@ use crate::value::{Constant, Function};
 #[derive(Debug, Clone)]
 pub struct IndexFieldInput<'a> {
     pub(super) name: Cow<'a, str>,
-    pub(super) sort_order: Option<&'a str>,
+    pub(super) sort_order: Option<Cow<'a, str>>,
     pub(super) length: Option<u32>,
     pub(super) ops: Option<IndexOps<'a>>,
 }
@@ -34,8 +34,8 @@ impl<'a> IndexFieldInput<'a> {
     /// @@index([foobar(sort: Desc)])
     /// //                    ^^^^ here
     /// ```
-    pub fn sort_order(&mut self, sort_order: &'a str) {
-        self.sort_order = Some(sort_order);
+    pub fn sort_order(&mut self, sort_order: impl Into<Cow<'a, str>>) {
+        self.sort_order = Some(sort_order.into());
     }
 
     /// Define the length of the indexed field.
@@ -50,12 +50,12 @@ impl<'a> IndexFieldInput<'a> {
 }
 
 /// Options for a field-level index attribute.
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone)]
 pub struct IndexFieldOptions<'a> {
-    pub(super) sort_order: Option<&'a str>,
+    pub(super) sort_order: Option<Cow<'a, str>>,
     pub(super) length: Option<u32>,
     pub(super) clustered: Option<bool>,
-    pub(super) map: Option<&'a str>,
+    pub(super) map: Option<Cow<'a, str>>,
 }
 
 impl<'a> IndexFieldOptions<'a> {
@@ -65,8 +65,8 @@ impl<'a> IndexFieldOptions<'a> {
     /// @unique(sort: Asc)
     /// //            ^^^ here
     /// ```
-    pub fn sort_order(&mut self, sort_order: &'a str) {
-        self.sort_order = Some(sort_order);
+    pub fn sort_order(&mut self, sort_order: impl Into<Cow<'a, str>>) {
+        self.sort_order = Some(sort_order.into());
     }
 
     /// Define the length of the inline field index.
@@ -95,8 +95,8 @@ impl<'a> IndexFieldOptions<'a> {
     /// @unique(map: "key_foo")
     /// //            ^^^^^^^ here
     /// ```
-    pub fn map(&mut self, value: &'a str) {
-        self.map = Some(value);
+    pub fn map(&mut self, value: impl Into<Cow<'a, str>>) {
+        self.map = Some(value.into());
     }
 }
 

--- a/introspection-engine/datamodel-renderer/src/datamodel/model/relation.rs
+++ b/introspection-engine/datamodel-renderer/src/datamodel/model/relation.rs
@@ -27,8 +27,8 @@ impl<'a> Relation<'a> {
     /// @relation("foo")
     /// //         ^^^ this
     /// ```
-    pub fn name(&mut self, name: &'a str) {
-        self.0.push_param(name);
+    pub fn name(&mut self, name: impl Into<Cow<'a, str>>) {
+        self.0.push_param(name.into());
     }
 
     /// Defines the `ON DELETE` referential action.
@@ -37,8 +37,9 @@ impl<'a> Relation<'a> {
     /// @relation(onDelete: DoNothing)
     /// //                  ^^^^^^^^^ this
     /// ```
-    pub fn on_delete(&mut self, action: &'a str) {
-        self.0.push_param(("onDelete", Constant::new_no_validate(action)));
+    pub fn on_delete(&mut self, action: impl Into<Cow<'a, str>>) {
+        self.0
+            .push_param(("onDelete", Constant::new_no_validate(action.into())));
     }
 
     /// Defines the `ON UPDATE` referential action.
@@ -47,8 +48,9 @@ impl<'a> Relation<'a> {
     /// @relation(onUpdate: DoNothing)
     /// //                  ^^^^^^^^^ this
     /// ```
-    pub fn on_update(&mut self, action: &'a str) {
-        self.0.push_param(("onUpdate", Constant::new_no_validate(action)));
+    pub fn on_update(&mut self, action: impl Into<Cow<'a, str>>) {
+        self.0
+            .push_param(("onUpdate", Constant::new_no_validate(action.into())));
     }
 
     /// Defines the foreign key constraint name.
@@ -57,7 +59,7 @@ impl<'a> Relation<'a> {
     /// @relation(map: "FK_foo")
     /// //              ^^^^^^ this
     /// ```
-    pub fn map(&mut self, name: &'a str) {
+    pub fn map(&mut self, name: impl Into<Cow<'a, str>>) {
         self.0.push_param(("map", Text::new(name)));
     }
 
@@ -67,7 +69,7 @@ impl<'a> Relation<'a> {
     /// @relation(fields: [foo, bar])
     /// //                ^^^^^^^^^^ this
     /// ```
-    pub fn fields(&mut self, fields: impl Iterator<Item = &'a str>) {
+    pub fn fields(&mut self, fields: impl Iterator<Item = Cow<'a, str>>) {
         self.push_array_parameter("fields", fields);
     }
 
@@ -77,12 +79,12 @@ impl<'a> Relation<'a> {
     /// @relation(references: [foo, bar])
     /// //                    ^^^^^^^^^^ this
     /// ```
-    pub fn references(&mut self, fields: impl Iterator<Item = &'a str>) {
+    pub fn references(&mut self, fields: impl Iterator<Item = Cow<'a, str>>) {
         self.push_array_parameter("references", fields);
     }
 
-    fn push_array_parameter(&mut self, param_name: &'static str, data: impl Iterator<Item = &'a str>) {
-        let fields: Vec<_> = data.map(Cow::Borrowed).map(Value::Constant).collect();
+    fn push_array_parameter(&mut self, param_name: &'static str, data: impl Iterator<Item = Cow<'a, str>>) {
+        let fields: Vec<_> = data.map(Value::Constant).collect();
 
         if !fields.is_empty() {
             self.0.push_param((param_name, Array::from(fields)));


### PR DESCRIPTION
More of the refactoring that should have been finished in b8ec99079b7320cd43405d0aac280927bbf01a81 — so we don't need to borrow from the dml struct, since we are removing it.