### PR TITLE
ie: fix warning about empty field names

### DIFF
--- a/introspection-engine/connectors/sql-introspection-connector/src/introspection_helpers.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/introspection_helpers.rs
@@ -214,7 +214,7 @@ pub(crate) fn calculate_scalar_field(
         if prisma_name.is_empty() {
             ctx.fields_with_empty_names.push(crate::warnings::ModelAndField {
                 model: ctx.table_prisma_name(column.table().id).prisma_name().into_owned(),
-                field: ctx.column_prisma_name(column.id).prisma_name().into_owned(),
+                field: column.name().to_owned(),
             });
             documentation = Some("This field was commented out because of an invalid name. Please provide a valid one that matches [a-zA-Z][a-zA-Z0-9_]*".to_owned());
             (mapped_name.clone().unwrap_or(prisma_name), mapped_name, true)


### PR DESCRIPTION
Before this commit, we use the field name, which by definition is empty. This commit changes that to use the column name. Thanks @Jolg42 for noticing.