### PR TITLE
Fix compile error in query-engine tests

### DIFF
--- a/query-engine/query-engine/src/tests/dmmf.rs
+++ b/query-engine/query-engine/src/tests/dmmf.rs
@@ -110,6 +110,7 @@ fn test_dmmf_cli_command(schema: &str) -> PrismaResult<()> {
         subcommand: Some(Subcommand::Cli(CliOpt::Dmmf)),
         enable_open_telemetry: false,
         open_telemetry_endpoint: String::new(),
+        dataproxy_metric_override: false,
     };
 
     let cli_cmd = CliCommand::from_opt(&prisma_opt)?.unwrap();


### PR DESCRIPTION
Add missing `dataproxy_metric_override` field that was added to `PrismaOpt` struct in <https://github.com/prisma/prisma-engines/pull/3412>.

You can reproduce the compile error by running `cargo test -p query-engine` on `main`.
I suddenly encountered it at some point when running the iTX tests (I assume I probably ran `cargo test interactive_tx` instead of `cargo test -p query-engine-tests interactive_tx` which caused all tests across the whole workspace to be compiled).
We should check if the tests in `query-engine` crate are being run on CI at all.
