### PR TITLE
ie: introspect inline relations without dml

### DIFF
--- a/introspection-engine/connectors/sql-introspection-connector/src/calculate_datamodel.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/calculate_datamodel.rs
@@ -22,7 +22,7 @@ pub(crate) struct CalculateDatamodelContext<'a> {
     pub(crate) enum_values_with_empty_names: Vec<warnings::EnumAndValue>,
     pub(crate) rendered_schema: datamodel_renderer::Datamodel<'a>,
     pub(crate) target_models: HashMap<sql::TableId, usize>,
-    introspection_map: crate::introspection_map::IntrospectionMap,
+    pub(crate) introspection_map: crate::introspection_map::IntrospectionMap,
 }
 
 impl<'a> CalculateDatamodelContext<'a> {
@@ -30,13 +30,12 @@ impl<'a> CalculateDatamodelContext<'a> {
         self.active_connector().provider_name() == COCKROACH.provider_name()
     }
 
+    pub(crate) fn relation_mode(&self) -> psl::datamodel_connector::RelationMode {
+        self.config.datasources.first().unwrap().relation_mode()
+    }
+
     pub(crate) fn foreign_keys_enabled(&self) -> bool {
-        self.config
-            .datasources
-            .first()
-            .unwrap()
-            .relation_mode()
-            .uses_foreign_keys()
+        self.relation_mode().uses_foreign_keys()
     }
 
     pub(crate) fn active_connector(&self) -> &'static dyn Connector {

--- a/introspection-engine/connectors/sql-introspection-connector/src/introspection.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/introspection.rs
@@ -19,15 +19,15 @@ pub(crate) fn introspect(ctx: &mut Context) -> Result<(String, bool), SqlError> 
     enums::introspect_enums(ctx);
     models::introspect_models(&mut datamodel, ctx);
 
+    ctx.rendered_schema.push_dml(&ctx.config.datasources[0], &datamodel);
+
     let relation_names = relation_names::introspect_relation_names(ctx);
 
     if ctx.foreign_keys_enabled() {
-        inline_relations::introspect_inline_relations(&relation_names, &mut datamodel, ctx);
+        inline_relations::introspect_inline_relations(&relation_names, ctx);
     } else {
-        prisma_relation_mode::reintrospect_relations(&mut datamodel, ctx);
+        prisma_relation_mode::reintrospect_relations(ctx);
     }
-
-    ctx.rendered_schema.push_dml(&ctx.config.datasources[0], &datamodel);
 
     m2m_relations::introspect_m2m_relations(&relation_names, ctx);
 

--- a/introspection-engine/datamodel-renderer/src/datamodel/model/field.rs
+++ b/introspection-engine/datamodel-renderer/src/datamodel/model/field.rs
@@ -365,10 +365,6 @@ impl<'a> ModelField<'a> {
                     field.documentation(docs.clone());
                 }
 
-                if rf.is_commented_out {
-                    field.commented_out();
-                }
-
                 if rf.is_ignored {
                     field.ignore();
                 }

--- a/introspection-engine/introspection-engine-tests/tests/remapping_database_names/mod.rs
+++ b/introspection-engine/introspection-engine-tests/tests/remapping_database_names/mod.rs
@@ -11,50 +11,6 @@ use introspection_engine_tests::test_api::*;
 use quaint::prelude::Queryable;
 use test_macros::test_connector;
 
-#[test_connector(tags(Postgres12), exclude(CockroachDb))]
-async fn should_not_remap_if_renaming_would_lead_to_duplicate_names(api: &TestApi) -> TestResult {
-    let sql = r#"
-        CREATE TABLE nodes(id serial primary key);
-        CREATE TABLE _nodes(
-            node_a int NOT NULL,
-            node_b int NOT NULL,
-            CONSTRAINT _nodes_node_a_fkey FOREIGN KEY(node_a) REFERENCES nodes(id) ON DELETE CASCADE ON UPDATE CASCADE,
-            CONSTRAINT _nodes_node_b_fkey FOREIGN KEY(node_b) REFERENCES nodes(id) ON DELETE CASCADE ON UPDATE CASCADE
-        );
-    "#;
-    api.raw_cmd(sql).await;
-
-    let expected = expect![[r#"
-        generator client {
-          provider = "prisma-client-js"
-        }
-
-        datasource db {
-          provider = "postgresql"
-          url      = "env(TEST_DATABASE_URL)"
-        }
-
-        /// The underlying table does not contain a valid unique identifier and can therefore currently not be handled by the Prisma Client.
-        model nodes {
-          node_a Int
-          node_b Int
-
-          @@map("_nodes")
-          @@ignore
-        }
-
-        model nodes {
-          id                        Int     @id @default(autoincrement())
-          nodes_nodes_node_aTonodes nodes   @relation("nodes_node_aTonodes", fields: [node_a], references: [id], onDelete: Cascade)
-          nodes_nodes_node_aTonodes nodes[] @relation("nodes_node_aTonodes") @ignore
-          nodes_nodes_node_bTonodes nodes   @relation("nodes_node_bTonodes", fields: [node_b], references: [id], onDelete: Cascade)
-          nodes_nodes_node_bTonodes nodes[] @relation("nodes_node_bTonodes") @ignore
-        }
-    "#]];
-    api.expect_datamodel(&expected).await;
-    Ok(())
-}
-
 #[test_connector(exclude(CockroachDb))]
 async fn remapping_fields_with_invalid_characters(api: &TestApi) -> TestResult {
     api.barrel()

--- a/introspection-engine/introspection-engine-tests/tests/simple/postgres/should_not_remap_if_renaming_would_lead_to_duplicate_names.sql
+++ b/introspection-engine/introspection-engine-tests/tests/simple/postgres/should_not_remap_if_renaming_would_lead_to_duplicate_names.sql
@@ -1,0 +1,38 @@
+-- tags=postgres
+-- exclude=cockroachdb
+
+CREATE TABLE nodes(id serial primary key);
+CREATE TABLE _nodes(
+    node_a int NOT NULL,
+    node_b int NOT NULL,
+    CONSTRAINT _nodes_node_a_fkey FOREIGN KEY(node_a) REFERENCES nodes(id) ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT _nodes_node_b_fkey FOREIGN KEY(node_b) REFERENCES nodes(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+/*
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = "env(TEST_DATABASE_URL)"
+}
+
+/// The underlying table does not contain a valid unique identifier and can therefore currently not be handled by the Prisma Client.
+model nodes {
+  node_a                    Int
+  node_b                    Int
+  nodes_nodes_node_aTonodes nodes @relation("nodes_node_aTonodes", fields: [node_a], references: [id], onDelete: Cascade)
+  nodes_nodes_node_bTonodes nodes @relation("nodes_node_bTonodes", fields: [node_b], references: [id], onDelete: Cascade)
+
+  @@map("_nodes")
+  @@ignore
+}
+
+model nodes {
+  id                        Int     @id @default(autoincrement())
+  nodes_nodes_node_aTonodes nodes[] @relation("nodes_node_aTonodes") @ignore
+  nodes_nodes_node_bTonodes nodes[] @relation("nodes_node_bTonodes") @ignore
+}
+*/

--- a/libs/dml/src/field.rs
+++ b/libs/dml/src/field.rs
@@ -182,8 +182,8 @@ impl Field {
     pub fn is_commented_out(&self) -> bool {
         match self {
             Field::ScalarField(sf) => sf.is_commented_out,
-            Field::RelationField(rf) => rf.is_commented_out,
             Field::CompositeField(cf) => cf.is_commented_out,
+            _ => false,
         }
     }
 
@@ -215,14 +215,6 @@ impl Field {
         match &self {
             Field::ScalarField(sf) => sf.is_updated_at,
             Field::RelationField(_) => false,
-            Field::CompositeField(_) => false,
-        }
-    }
-
-    pub fn is_generated(&self) -> bool {
-        match &self {
-            Field::ScalarField(sf) => sf.is_generated,
-            Field::RelationField(rf) => rf.is_generated,
             Field::CompositeField(_) => false,
         }
     }
@@ -299,12 +291,6 @@ pub struct RelationField {
     /// Comments associated with this field.
     pub documentation: Option<String>,
 
-    /// signals that this field was internally generated (only back relation fields as of now)
-    pub is_generated: bool,
-
-    /// Indicates if this field has to be commented out.
-    pub is_commented_out: bool,
-
     /// Indicates if this field has to be ignored by the Client.
     pub is_ignored: bool,
 
@@ -324,8 +310,6 @@ impl RelationField {
             referential_arity,
             relation_info,
             documentation: None,
-            is_generated: false,
-            is_commented_out: false,
             is_ignored: false,
             supports_restrict_action: None,
             emulates_referential_actions: None,
@@ -340,20 +324,6 @@ impl RelationField {
     /// The referential actions should be handled by the core.
     pub fn emulates_referential_actions(&mut self, value: bool) {
         self.emulates_referential_actions = Some(value);
-    }
-
-    /// Creates a new field with the given name and type, marked as generated and optional.
-    pub fn new_generated(name: &str, info: RelationInfo, required: bool) -> Self {
-        let arity = if required {
-            FieldArity::Required
-        } else {
-            FieldArity::Optional
-        };
-
-        let mut field = Self::new(name, arity, arity, info);
-        field.is_generated = true;
-
-        field
     }
 
     pub fn points_to_model(&self, name: &str) -> bool {

--- a/psl/psl/tests/common/mod.rs
+++ b/psl/psl/tests/common/mod.rs
@@ -16,7 +16,6 @@ pub(crate) trait DatasourceAsserts {
 pub(crate) trait FieldAsserts {
     fn assert_arity(&self, arity: &dml::FieldArity) -> &Self;
     fn assert_with_documentation(&self, t: &str) -> &Self;
-    fn assert_is_generated(&self, b: bool) -> &Self;
 }
 
 pub(crate) trait ScalarFieldAsserts {
@@ -109,11 +108,6 @@ impl FieldAsserts for dml::ScalarField {
 
     fn assert_with_documentation(&self, t: &str) -> &Self {
         assert_eq!(self.documentation, Some(t.to_owned()));
-        self
-    }
-
-    fn assert_is_generated(&self, b: bool) -> &Self {
-        assert_eq!(self.is_generated, b);
         self
     }
 }
@@ -215,11 +209,6 @@ impl FieldAsserts for dml::RelationField {
 
     fn assert_with_documentation(&self, t: &str) -> &Self {
         assert_eq!(self.documentation, Some(t.to_owned()));
-        self
-    }
-
-    fn assert_is_generated(&self, b: bool) -> &Self {
-        assert_eq!(self.is_generated, b);
         self
     }
 }

--- a/query-engine/dmmf/src/ast_builders/datamodel_ast_builder.rs
+++ b/query-engine/dmmf/src/ast_builders/datamodel_ast_builder.rs
@@ -173,7 +173,7 @@ fn field_to_dmmf(model: &dml::Model, field: &dml::Field) -> Field {
         relation_to_fields: get_relation_to_fields(field),
         relation_on_delete: get_relation_delete_strategy(field),
         field_type: get_field_type(field),
-        is_generated: Some(field.is_generated()),
+        is_generated: Some(false),
         is_updated_at: Some(field.is_updated_at()),
         documentation: field.documentation().map(|v| v.to_owned()),
     }


### PR DESCRIPTION
We are getting very close to finishing removing DML from sql-introspection-connector.

One test expectation changed. If you look at the SQL, it is clear we fixed a bug by eschewing matching models and tables by name.