### PR TITLE
chore: make referentialIntegrity preview feature GA

### DIFF
--- a/introspection-engine/introspection-engine-tests/src/test_api.rs
+++ b/introspection-engine/introspection-engine-tests/src/test_api.rs
@@ -256,7 +256,7 @@ impl TestApi {
 
     pub fn datasource_block_string(&self) -> String {
         let relation_mode =
-            if self.is_vitess() && self.preview_features().contains(PreviewFeature::ReferentialIntegrity) {
+            if self.is_vitess() {
                 "\nrelationMode = \"prisma\""
             } else {
                 ""
@@ -284,7 +284,7 @@ impl TestApi {
     pub fn datasource_block(&self) -> DatasourceBlock<'_> {
         self.args.datasource_block(
             "env(TEST_DATABASE_URL)",
-            if self.is_vitess() && self.preview_features().contains(PreviewFeature::ReferentialIntegrity) {
+            if self.is_vitess() {
                 &[("relationMode", r#""prisma""#)]
             } else {
                 &[]

--- a/introspection-engine/introspection-engine-tests/tests/re_introspection/mysql.rs
+++ b/introspection-engine/introspection-engine-tests/tests/re_introspection/mysql.rs
@@ -33,7 +33,7 @@ async fn empty_preview_features_are_kept(api: &TestApi) -> TestResult {
     Ok(())
 }
 
-#[test_connector(tags(Mysql), exclude(Vitess), preview_features("referentialIntegrity"))]
+#[test_connector(tags(Mysql), exclude(Vitess))]
 async fn relation_mode_parameter_is_not_added(api: &TestApi) -> TestResult {
     let result = api.re_introspect("").await?;
     assert!(!result.contains(r#"relationMode = "#));

--- a/introspection-engine/introspection-engine-tests/tests/re_introspection/relation_mode/mssql.rs
+++ b/introspection-engine/introspection-engine-tests/tests/re_introspection/relation_mode/mssql.rs
@@ -23,7 +23,6 @@ async fn referential_integrity_prisma(api: &TestApi) -> TestResult {
     let input = indoc! {r#"
         generator client {
             provider        = "prisma-client-js"
-            previewFeatures = ["referentialIntegrity"]
         }
 
         datasource db {
@@ -47,7 +46,6 @@ async fn referential_integrity_prisma(api: &TestApi) -> TestResult {
     let expected = expect![[r#"
         generator client {
           provider        = "prisma-client-js"
-          previewFeatures = ["referentialIntegrity"]
         }
 
         datasource db {
@@ -98,7 +96,6 @@ async fn referential_integrity_foreign_keys(api: &TestApi) -> TestResult {
     let input = indoc! {r#"
         generator client {
             provider        = "prisma-client-js"
-            previewFeatures = ["referentialIntegrity"]
         }
 
         datasource db {
@@ -122,7 +119,6 @@ async fn referential_integrity_foreign_keys(api: &TestApi) -> TestResult {
     let expected = expect![[r#"
         generator client {
           provider        = "prisma-client-js"
-          previewFeatures = ["referentialIntegrity"]
         }
 
         datasource db {
@@ -171,7 +167,6 @@ async fn relation_mode_prisma(api: &TestApi) -> TestResult {
     let input = indoc! {r#"
         generator client {
             provider        = "prisma-client-js"
-            previewFeatures = ["referentialIntegrity"]
         }
 
         datasource db {
@@ -195,7 +190,6 @@ async fn relation_mode_prisma(api: &TestApi) -> TestResult {
     let expected = expect![[r#"
         generator client {
           provider        = "prisma-client-js"
-          previewFeatures = ["referentialIntegrity"]
         }
 
         datasource db {
@@ -246,7 +240,6 @@ async fn relation_mode_foreign_keys(api: &TestApi) -> TestResult {
     let input = indoc! {r#"
         generator client {
             provider        = "prisma-client-js"
-            previewFeatures = ["referentialIntegrity"]
         }
 
         datasource db {
@@ -270,7 +263,6 @@ async fn relation_mode_foreign_keys(api: &TestApi) -> TestResult {
     let expected = expect![[r#"
         generator client {
           provider        = "prisma-client-js"
-          previewFeatures = ["referentialIntegrity"]
         }
 
         datasource db {
@@ -324,7 +316,6 @@ mod at_at_map {
         let input = indoc! {r#"
             generator client {
                 provider        = "prisma-client-js"
-                previewFeatures = ["referentialIntegrity"]
             }
 
             datasource db {
@@ -352,7 +343,6 @@ mod at_at_map {
         let expected = expect![[r#"
             generator client {
               provider        = "prisma-client-js"
-              previewFeatures = ["referentialIntegrity"]
             }
 
             datasource db {
@@ -407,7 +397,6 @@ mod at_at_map {
         let input = indoc! {r#"
             generator client {
                 provider        = "prisma-client-js"
-                previewFeatures = ["referentialIntegrity"]
             }
 
             datasource db {
@@ -435,7 +424,6 @@ mod at_at_map {
         let expected = expect![[r#"
             generator client {
               provider        = "prisma-client-js"
-              previewFeatures = ["referentialIntegrity"]
             }
 
             datasource db {
@@ -488,7 +476,6 @@ mod at_at_map {
         let input = indoc! {r#"
             generator client {
                 provider        = "prisma-client-js"
-                previewFeatures = ["referentialIntegrity"]
             }
 
             datasource db {
@@ -516,7 +503,6 @@ mod at_at_map {
         let expected = expect![[r#"
             generator client {
               provider        = "prisma-client-js"
-              previewFeatures = ["referentialIntegrity"]
             }
 
             datasource db {
@@ -571,7 +557,6 @@ mod at_at_map {
         let input = indoc! {r#"
             generator client {
                 provider        = "prisma-client-js"
-                previewFeatures = ["referentialIntegrity"]
             }
 
             datasource db {
@@ -599,7 +584,6 @@ mod at_at_map {
         let expected = expect![[r#"
             generator client {
               provider        = "prisma-client-js"
-              previewFeatures = ["referentialIntegrity"]
             }
 
             datasource db {

--- a/introspection-engine/introspection-engine-tests/tests/re_introspection/relation_mode/mysql.rs
+++ b/introspection-engine/introspection-engine-tests/tests/re_introspection/relation_mode/mysql.rs
@@ -25,7 +25,6 @@ async fn referential_integrity_prisma(api: &TestApi) -> TestResult {
     let input = indoc! {r#"
         generator client {
             provider        = "prisma-client-js"
-            previewFeatures = ["referentialIntegrity"]
         }
 
         datasource db {
@@ -49,7 +48,6 @@ async fn referential_integrity_prisma(api: &TestApi) -> TestResult {
     let expected = expect![[r#"
         generator client {
           provider        = "prisma-client-js"
-          previewFeatures = ["referentialIntegrity"]
         }
 
         datasource db {
@@ -102,7 +100,6 @@ async fn referential_integrity_foreign_keys(api: &TestApi) -> TestResult {
     let input = indoc! {r#"
         generator client {
             provider        = "prisma-client-js"
-            previewFeatures = ["referentialIntegrity"]
         }
 
         datasource db {
@@ -126,7 +123,6 @@ async fn referential_integrity_foreign_keys(api: &TestApi) -> TestResult {
     let expected = expect![[r#"
         generator client {
           provider        = "prisma-client-js"
-          previewFeatures = ["referentialIntegrity"]
         }
 
         datasource db {
@@ -177,7 +173,6 @@ async fn relation_mode_prisma(api: &TestApi) -> TestResult {
     let input = indoc! {r#"
         generator client {
             provider        = "prisma-client-js"
-            previewFeatures = ["referentialIntegrity"]
         }
 
         datasource db {
@@ -201,7 +196,6 @@ async fn relation_mode_prisma(api: &TestApi) -> TestResult {
     let expected = expect![[r#"
         generator client {
           provider        = "prisma-client-js"
-          previewFeatures = ["referentialIntegrity"]
         }
 
         datasource db {
@@ -254,7 +248,6 @@ async fn relation_mode_foreign_keys(api: &TestApi) -> TestResult {
     let input = indoc! {r#"
         generator client {
             provider        = "prisma-client-js"
-            previewFeatures = ["referentialIntegrity"]
         }
 
         datasource db {
@@ -278,7 +271,6 @@ async fn relation_mode_foreign_keys(api: &TestApi) -> TestResult {
     let expected = expect![[r#"
         generator client {
           provider        = "prisma-client-js"
-          previewFeatures = ["referentialIntegrity"]
         }
 
         datasource db {
@@ -334,7 +326,6 @@ mod at_at_map {
         let input = indoc! {r#"
             generator client {
                 provider        = "prisma-client-js"
-                previewFeatures = ["referentialIntegrity"]
             }
 
             datasource db {
@@ -362,7 +353,6 @@ mod at_at_map {
         let expected = expect![[r#"
             generator client {
               provider        = "prisma-client-js"
-              previewFeatures = ["referentialIntegrity"]
             }
 
             datasource db {
@@ -419,7 +409,6 @@ mod at_at_map {
         let input = indoc! {r#"
             generator client {
                 provider        = "prisma-client-js"
-                previewFeatures = ["referentialIntegrity"]
             }
 
             datasource db {
@@ -447,7 +436,6 @@ mod at_at_map {
         let expected = expect![[r#"
             generator client {
               provider        = "prisma-client-js"
-              previewFeatures = ["referentialIntegrity"]
             }
 
             datasource db {
@@ -502,7 +490,6 @@ mod at_at_map {
         let input = indoc! {r#"
             generator client {
                 provider        = "prisma-client-js"
-                previewFeatures = ["referentialIntegrity"]
             }
 
             datasource db {
@@ -530,7 +517,6 @@ mod at_at_map {
         let expected = expect![[r#"
             generator client {
               provider        = "prisma-client-js"
-              previewFeatures = ["referentialIntegrity"]
             }
 
             datasource db {
@@ -587,7 +573,6 @@ mod at_at_map {
         let input = indoc! {r#"
             generator client {
                 provider        = "prisma-client-js"
-                previewFeatures = ["referentialIntegrity"]
             }
 
             datasource db {
@@ -615,7 +600,6 @@ mod at_at_map {
         let expected = expect![[r#"
             generator client {
               provider        = "prisma-client-js"
-              previewFeatures = ["referentialIntegrity"]
             }
 
             datasource db {

--- a/introspection-engine/introspection-engine-tests/tests/re_introspection/relation_mode/postgres.rs
+++ b/introspection-engine/introspection-engine-tests/tests/re_introspection/relation_mode/postgres.rs
@@ -26,7 +26,6 @@ async fn referential_integrity_prisma(api: &TestApi) -> TestResult {
     let input = indoc! {r#"
         generator client {
             provider        = "prisma-client-js"
-            previewFeatures = ["referentialIntegrity"]
         }
 
         datasource db {
@@ -50,7 +49,6 @@ async fn referential_integrity_prisma(api: &TestApi) -> TestResult {
     let expected = expect![[r#"
         generator client {
           provider        = "prisma-client-js"
-          previewFeatures = ["referentialIntegrity"]
         }
 
         datasource db {
@@ -104,7 +102,6 @@ async fn referential_integrity_foreign_keys(api: &TestApi) -> TestResult {
     let input = indoc! {r#"
         generator client {
             provider        = "prisma-client-js"
-            previewFeatures = ["referentialIntegrity"]
         }
 
         datasource db {
@@ -128,7 +125,6 @@ async fn referential_integrity_foreign_keys(api: &TestApi) -> TestResult {
     let expected = expect![[r#"
         generator client {
           provider        = "prisma-client-js"
-          previewFeatures = ["referentialIntegrity"]
         }
 
         datasource db {
@@ -180,7 +176,6 @@ async fn relation_mode_prisma(api: &TestApi) -> TestResult {
     let input = indoc! {r#"
         generator client {
             provider        = "prisma-client-js"
-            previewFeatures = ["referentialIntegrity"]
         }
 
         datasource db {
@@ -204,7 +199,6 @@ async fn relation_mode_prisma(api: &TestApi) -> TestResult {
     let expected = expect![[r#"
         generator client {
           provider        = "prisma-client-js"
-          previewFeatures = ["referentialIntegrity"]
         }
 
         datasource db {
@@ -258,7 +252,6 @@ async fn relation_mode_foreign_keys(api: &TestApi) -> TestResult {
     let input = indoc! {r#"
         generator client {
             provider        = "prisma-client-js"
-            previewFeatures = ["referentialIntegrity"]
         }
 
         datasource db {
@@ -282,7 +275,6 @@ async fn relation_mode_foreign_keys(api: &TestApi) -> TestResult {
     let expected = expect![[r#"
         generator client {
           provider        = "prisma-client-js"
-          previewFeatures = ["referentialIntegrity"]
         }
 
         datasource db {
@@ -339,7 +331,6 @@ mod at_at_map {
         let input = indoc! {r#"
             generator client {
                 provider        = "prisma-client-js"
-                previewFeatures = ["referentialIntegrity"]
             }
 
             datasource db {
@@ -367,7 +358,6 @@ mod at_at_map {
         let expected = expect![[r#"
             generator client {
               provider        = "prisma-client-js"
-              previewFeatures = ["referentialIntegrity"]
             }
 
             datasource db {
@@ -425,7 +415,6 @@ mod at_at_map {
         let input = indoc! {r#"
             generator client {
                 provider        = "prisma-client-js"
-                previewFeatures = ["referentialIntegrity"]
             }
 
             datasource db {
@@ -453,7 +442,6 @@ mod at_at_map {
         let expected = expect![[r#"
             generator client {
               provider        = "prisma-client-js"
-              previewFeatures = ["referentialIntegrity"]
             }
 
             datasource db {
@@ -509,7 +497,6 @@ mod at_at_map {
         let input = indoc! {r#"
             generator client {
                 provider        = "prisma-client-js"
-                previewFeatures = ["referentialIntegrity"]
             }
 
             datasource db {
@@ -537,7 +524,6 @@ mod at_at_map {
         let expected = expect![[r#"
             generator client {
               provider        = "prisma-client-js"
-              previewFeatures = ["referentialIntegrity"]
             }
 
             datasource db {
@@ -595,7 +581,6 @@ mod at_at_map {
         let input = indoc! {r#"
             generator client {
                 provider        = "prisma-client-js"
-                previewFeatures = ["referentialIntegrity"]
             }
 
             datasource db {
@@ -623,7 +608,6 @@ mod at_at_map {
         let expected = expect![[r#"
             generator client {
               provider        = "prisma-client-js"
-              previewFeatures = ["referentialIntegrity"]
             }
 
             datasource db {

--- a/introspection-engine/introspection-engine-tests/tests/re_introspection/relation_mode/sqlite.rs
+++ b/introspection-engine/introspection-engine-tests/tests/re_introspection/relation_mode/sqlite.rs
@@ -22,7 +22,6 @@ async fn referential_integrity_prisma(api: &TestApi) -> TestResult {
     let input = indoc! {r#"
         generator client {
             provider        = "prisma-client-js"
-            previewFeatures = ["referentialIntegrity"]
         }
 
         datasource db {
@@ -46,7 +45,6 @@ async fn referential_integrity_prisma(api: &TestApi) -> TestResult {
     let expected = expect![[r#"
         generator client {
           provider        = "prisma-client-js"
-          previewFeatures = ["referentialIntegrity"]
         }
 
         datasource db {
@@ -95,7 +93,6 @@ async fn referential_integrity_foreign_keys(api: &TestApi) -> TestResult {
     let input = indoc! {r#"
         generator client {
             provider        = "prisma-client-js"
-            previewFeatures = ["referentialIntegrity"]
         }
 
         datasource db {
@@ -119,7 +116,6 @@ async fn referential_integrity_foreign_keys(api: &TestApi) -> TestResult {
     let expected = expect![[r#"
         generator client {
           provider        = "prisma-client-js"
-          previewFeatures = ["referentialIntegrity"]
         }
 
         datasource db {
@@ -167,7 +163,6 @@ async fn relation_mode_prisma(api: &TestApi) -> TestResult {
     let input = indoc! {r#"
         generator client {
             provider        = "prisma-client-js"
-            previewFeatures = ["referentialIntegrity"]
         }
 
         datasource db {
@@ -191,7 +186,6 @@ async fn relation_mode_prisma(api: &TestApi) -> TestResult {
     let expected = expect![[r#"
         generator client {
           provider        = "prisma-client-js"
-          previewFeatures = ["referentialIntegrity"]
         }
 
         datasource db {
@@ -240,7 +234,6 @@ async fn relation_mode_foreign_keys(api: &TestApi) -> TestResult {
     let input = indoc! {r#"
         generator client {
             provider        = "prisma-client-js"
-            previewFeatures = ["referentialIntegrity"]
         }
 
         datasource db {
@@ -264,7 +257,6 @@ async fn relation_mode_foreign_keys(api: &TestApi) -> TestResult {
     let expected = expect![[r#"
         generator client {
           provider        = "prisma-client-js"
-          previewFeatures = ["referentialIntegrity"]
         }
 
         datasource db {
@@ -317,7 +309,6 @@ mod at_at_map {
         let input = indoc! {r#"
             generator client {
                 provider        = "prisma-client-js"
-                previewFeatures = ["referentialIntegrity"]
             }
 
             datasource db {
@@ -345,7 +336,6 @@ mod at_at_map {
         let expected = expect![[r#"
             generator client {
               provider        = "prisma-client-js"
-              previewFeatures = ["referentialIntegrity"]
             }
 
             datasource db {
@@ -398,7 +388,6 @@ mod at_at_map {
         let input = indoc! {r#"
             generator client {
                 provider        = "prisma-client-js"
-                previewFeatures = ["referentialIntegrity"]
             }
 
             datasource db {
@@ -426,7 +415,6 @@ mod at_at_map {
         let expected = expect![[r#"
             generator client {
               provider        = "prisma-client-js"
-              previewFeatures = ["referentialIntegrity"]
             }
 
             datasource db {
@@ -478,7 +466,6 @@ mod at_at_map {
         let input = indoc! {r#"
             generator client {
                 provider        = "prisma-client-js"
-                previewFeatures = ["referentialIntegrity"]
             }
 
             datasource db {
@@ -506,7 +493,6 @@ mod at_at_map {
         let expected = expect![[r#"
             generator client {
               provider        = "prisma-client-js"
-              previewFeatures = ["referentialIntegrity"]
             }
 
             datasource db {
@@ -559,7 +545,6 @@ mod at_at_map {
         let input = indoc! {r#"
             generator client {
                 provider        = "prisma-client-js"
-                previewFeatures = ["referentialIntegrity"]
             }
 
             datasource db {
@@ -587,7 +572,6 @@ mod at_at_map {
         let expected = expect![[r#"
             generator client {
               provider        = "prisma-client-js"
-              previewFeatures = ["referentialIntegrity"]
             }
 
             datasource db {

--- a/introspection-engine/introspection-engine-tests/tests/re_introspection/vitess.rs
+++ b/introspection-engine/introspection-engine-tests/tests/re_introspection/vitess.rs
@@ -4,7 +4,7 @@ use introspection_engine_tests::test_api::*;
 use quaint::prelude::Queryable;
 use test_macros::test_connector;
 
-#[test_connector(tags(Vitess), preview_features("referentialIntegrity"))]
+#[test_connector(tags(Vitess))]
 async fn relation_mode_parameter_is_not_removed(api: &TestApi) -> TestResult {
     let result = api.re_introspect("").await?;
     assert!(result.contains(r#"relationMode = "prisma""#));
@@ -12,7 +12,7 @@ async fn relation_mode_parameter_is_not_removed(api: &TestApi) -> TestResult {
     Ok(())
 }
 
-#[test_connector(tags(Vitess), preview_features("referentialIntegrity"))]
+#[test_connector(tags(Vitess))]
 async fn relations_are_not_removed(api: &TestApi) -> TestResult {
     let dml = indoc! {r#"
         CREATE TABLE `A` (
@@ -58,7 +58,7 @@ async fn relations_are_not_removed(api: &TestApi) -> TestResult {
     Ok(())
 }
 
-#[test_connector(tags(Vitess), preview_features("referentialIntegrity"))]
+#[test_connector(tags(Vitess))]
 async fn warning_is_given_for_copied_relations(api: &TestApi) -> TestResult {
     let dml = indoc! {r#"
         CREATE TABLE `A` (
@@ -108,7 +108,7 @@ async fn warning_is_given_for_copied_relations(api: &TestApi) -> TestResult {
     Ok(())
 }
 
-#[test_connector(tags(Vitess), preview_features("referentialIntegrity"))]
+#[test_connector(tags(Vitess))]
 async fn no_warnings_are_given_for_if_no_relations_were_copied(api: &TestApi) -> TestResult {
     let dml = indoc! {r#"
         CREATE TABLE `A` (
@@ -141,7 +141,7 @@ async fn no_warnings_are_given_for_if_no_relations_were_copied(api: &TestApi) ->
     Ok(())
 }
 
-#[test_connector(tags(Vitess), preview_features("referentialIntegrity"))]
+#[test_connector(tags(Vitess))]
 async fn relations_field_order_is_kept(api: &TestApi) -> TestResult {
     let dml = indoc! {r#"
         CREATE TABLE `A` (
@@ -187,7 +187,7 @@ async fn relations_field_order_is_kept(api: &TestApi) -> TestResult {
     Ok(())
 }
 
-#[test_connector(tags(Vitess), preview_features("referentialIntegrity"))]
+#[test_connector(tags(Vitess))]
 async fn relations_field_order_is_kept_if_having_new_fields(api: &TestApi) -> TestResult {
     let dml = indoc! {r#"
         CREATE TABLE `A` (
@@ -235,7 +235,7 @@ async fn relations_field_order_is_kept_if_having_new_fields(api: &TestApi) -> Te
     Ok(())
 }
 
-#[test_connector(tags(Vitess), preview_features("referentialIntegrity"))]
+#[test_connector(tags(Vitess))]
 async fn relations_field_order_is_kept_if_removing_fields(api: &TestApi) -> TestResult {
     let dml = indoc! {r#"
         CREATE TABLE `A` (
@@ -282,7 +282,7 @@ async fn relations_field_order_is_kept_if_removing_fields(api: &TestApi) -> Test
     Ok(())
 }
 
-#[test_connector(tags(Vitess), preview_features("referentialIntegrity"))]
+#[test_connector(tags(Vitess))]
 async fn deleting_models_will_delete_relations(api: &TestApi) -> TestResult {
     let dml = indoc! {r#"
         CREATE TABLE `A` (
@@ -335,7 +335,7 @@ async fn deleting_models_will_delete_relations(api: &TestApi) -> TestResult {
     Ok(())
 }
 
-#[test_connector(tags(Vitess), preview_features("referentialIntegrity"))]
+#[test_connector(tags(Vitess))]
 async fn field_renames_keeps_the_relation_intact(api: &TestApi) -> TestResult {
     let dml = indoc! {r#"
         CREATE TABLE `A` (
@@ -381,7 +381,7 @@ async fn field_renames_keeps_the_relation_intact(api: &TestApi) -> TestResult {
     Ok(())
 }
 
-#[test_connector(tags(Vitess), preview_features("referentialIntegrity"))]
+#[test_connector(tags(Vitess))]
 async fn referential_actions_are_kept_intact(api: &TestApi) -> TestResult {
     let dml = indoc! {r#"
         CREATE TABLE `A` (

--- a/migration-engine/migration-engine-tests/src/test_api.rs
+++ b/migration-engine/migration-engine-tests/src/test_api.rs
@@ -320,11 +320,7 @@ impl TestApi {
 
     /// Render a valid datasource block, including database URL.
     pub fn write_datasource_block(&self, out: &mut dyn std::fmt::Write) {
-        let no_foreign_keys = self.is_vitess()
-            && self
-                .root
-                .preview_features()
-                .contains(PreviewFeature::ReferentialIntegrity);
+        let no_foreign_keys = self.is_vitess();
 
         let params = if no_foreign_keys {
             vec![("relationMode", r#""prisma""#)]

--- a/migration-engine/migration-engine-tests/tests/existing_data/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_data/mod.rs
@@ -779,7 +779,7 @@ fn set_default_current_timestamp_on_existing_column_works(api: TestApi) {
 }
 
 // exclude: there is a cockroach-specific test. It's unexecutable there.
-#[test_connector(preview_features("referentialIntegrity"), exclude(CockroachDb))]
+#[test_connector(exclude(CockroachDb))]
 fn primary_key_migrations_do_not_cause_data_loss(api: TestApi) {
     let dm1 = r#"
         model Dog {

--- a/migration-engine/migration-engine-tests/tests/migrations/basic.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/basic.rs
@@ -52,7 +52,7 @@ fn adding_multiple_optional_fields_to_an_existing_model_works(api: TestApi) {
     });
 }
 
-#[test_connector(preview_features("referentialIntegrity"))]
+#[test_connector]
 fn a_model_can_be_removed(api: TestApi) {
     let directory = api.create_migrations_directory();
 

--- a/migration-engine/migration-engine-tests/tests/migrations/basic/vitess.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/basic/vitess.rs
@@ -1,6 +1,6 @@
 use migration_engine_tests::test_api::*;
 
-#[test_connector(tags(Vitess), preview_features("referentialIntegrity"))]
+#[test_connector(tags(Vitess))]
 fn reordering_and_altering_models_at_the_same_time_works(api: TestApi) {
     let dm1 = r#"
         model A {

--- a/migration-engine/migration-engine-tests/tests/migrations/enums.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/enums.rs
@@ -15,7 +15,7 @@ enum CatMood {
 }
 "#;
 
-#[test_connector(capabilities(Enums), preview_features("referentialIntegrity"))]
+#[test_connector(capabilities(Enums))]
 fn an_enum_can_be_turned_into_a_model(api: TestApi) {
     api.schema_push_w_datasource(BASIC_ENUM_DM).send().assert_green();
 

--- a/migration-engine/migration-engine-tests/tests/migrations/foreign_keys.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/foreign_keys.rs
@@ -1,7 +1,7 @@
 use migration_engine_tests::test_api::*;
 use sql_schema_describer::ForeignKeyAction;
 
-#[test_connector(preview_features("referentialIntegrity"))]
+#[test_connector]
 fn foreign_keys_of_inline_one_to_one_relations_have_a_unique_constraint(api: TestApi) {
     let dm = r#"
         model Cat {
@@ -284,7 +284,7 @@ fn changing_a_foreign_key_constrained_column_from_nullable_to_required_and_back_
     api.schema_push_w_datasource(dm).send().assert_green();
 }
 
-#[test_connector(exclude(CockroachDb), preview_features("referentialIntegrity"))]
+#[test_connector(exclude(CockroachDb))]
 fn changing_all_referenced_columns_of_foreign_key_works(api: TestApi) {
     let dm1 = r#"
        model Post {

--- a/migration-engine/migration-engine-tests/tests/migrations/id.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/id.rs
@@ -154,7 +154,7 @@ fn changing_the_type_of_an_id_field_must_work(api: TestApi) {
     });
 }
 
-#[test_connector(exclude(Sqlite, CockroachDb), preview_features("referentialIntegrity"))]
+#[test_connector(exclude(Sqlite, CockroachDb))]
 fn models_with_an_autoincrement_field_as_part_of_a_multi_field_id_can_be_created(api: TestApi) {
     let dm = r#"
         model List {

--- a/migration-engine/migration-engine-tests/tests/migrations/id/cockroachdb.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/id/cockroachdb.rs
@@ -23,7 +23,7 @@ fn flipping_autoincrement_on_and_off_works(api: TestApi) {
     }
 }
 
-#[test_connector(tags(CockroachDb), preview_features("referentialIntegrity"))]
+#[test_connector(tags(CockroachDb))]
 fn models_with_an_autoincrement_field_as_part_of_a_multi_field_id_can_be_created(api: TestApi) {
     let dm = r#"
         model List {

--- a/migration-engine/migration-engine-tests/tests/migrations/id/vitess.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/id/vitess.rs
@@ -1,6 +1,6 @@
 use migration_engine_tests::test_api::*;
 
-#[test_connector(tags(Vitess), preview_features("referentialIntegrity"))]
+#[test_connector(tags(Vitess))]
 fn changing_the_type_of_an_id_field_must_work(api: TestApi) {
     let dm1 = r#"
         model A {

--- a/migration-engine/migration-engine-tests/tests/migrations/indexes.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/indexes.rs
@@ -6,7 +6,7 @@ use indoc::{formatdoc, indoc};
 use migration_engine_tests::test_api::*;
 use sql_schema_describer::SQLSortOrder;
 
-#[test_connector(preview_features("referentialIntegrity"))]
+#[test_connector]
 fn index_on_compound_relation_fields_must_work(api: TestApi) {
     let dm = r#"
         model User {
@@ -84,7 +84,7 @@ fn index_settings_must_be_migrated(api: TestApi) {
     });
 }
 
-#[test_connector(preview_features("referentialIntegrity"))]
+#[test_connector]
 fn unique_directive_on_required_one_to_one_relation_creates_one_index(api: TestApi) {
     // We want to test that only one index is created, because of the implicit unique index on
     // required 1:1 relations.
@@ -133,7 +133,7 @@ fn one_to_many_self_relations_do_not_create_a_unique_index(api: TestApi) {
     }
 }
 
-#[test_connector(preview_features("referentialIntegrity"))]
+#[test_connector]
 fn model_with_multiple_indexes_works(api: TestApi) {
     let dm = r#"
     model User {
@@ -425,7 +425,7 @@ fn indexes_with_an_automatically_truncated_name_are_idempotent(api: TestApi) {
     api.schema_push_w_datasource(dm).send().assert_green().assert_no_steps();
 }
 
-#[test_connector(preview_features("referentialIntegrity"))]
+#[test_connector]
 fn new_index_with_same_name_as_index_from_dropped_table_works(api: TestApi) {
     let dm1 = r#"
         model Cat {

--- a/migration-engine/migration-engine-tests/tests/migrations/relation_mode.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/relation_mode.rs
@@ -8,7 +8,6 @@ fn schema_push_referential_integrity_prisma_works(api: TestApi) {
 
         generator client {{
             provider = "prisma-client-js"
-            previewFeatures = ["referentialIntegrity"]
         }}
 
         model Post {{
@@ -54,7 +53,6 @@ fn create_migration_referential_integrity_prisma_works(api: TestApi) {
 
         generator client {{
             provider = "prisma-client-js"
-            previewFeatures = ["referentialIntegrity"]
         }}
 
         model Post {{
@@ -117,7 +115,6 @@ fn switching_from_foreign_keys_to_prisma_integrity_drops_the_foreign_keys(api: T
 
         generator client {{
             provider = "prisma-client-js"
-            previewFeatures = ["referentialIntegrity"]
         }}
 
         model A {{
@@ -145,7 +142,6 @@ fn switching_from_foreign_keys_to_prisma_integrity_drops_the_foreign_keys(api: T
 
         generator client {{
             provider = "prisma-client-js"
-            previewFeatures = ["referentialIntegrity"]
         }}
 
         model A {{
@@ -176,7 +172,6 @@ fn switching_from_prisma_integrity_to_foreign_keys_drops_the_foreign_keys(api: T
 
         generator client {{
             provider = "prisma-client-js"
-            previewFeatures = ["referentialIntegrity"]
         }}
 
         model A {{
@@ -204,7 +199,6 @@ fn switching_from_prisma_integrity_to_foreign_keys_drops_the_foreign_keys(api: T
 
         generator client {{
             provider = "prisma-client-js"
-            previewFeatures = ["referentialIntegrity"]
         }}
 
         model A {{

--- a/migration-engine/migration-engine-tests/tests/migrations/relations.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/relations.rs
@@ -968,7 +968,7 @@ fn adding_mutual_references_on_existing_tables_works(api: TestApi) {
     };
 }
 
-#[test_connector(preview_features("referentialIntegrity"))]
+#[test_connector]
 fn migrations_with_many_to_many_related_models_must_not_recreate_indexes(api: TestApi) {
     // test case for https://github.com/prisma/lift/issues/148
     let dm_1 = r#"
@@ -1029,7 +1029,7 @@ fn migrations_with_many_to_many_related_models_must_not_recreate_indexes(api: Te
         .assert_no_steps();
 }
 
-#[test_connector(preview_features("referentialIntegrity"))]
+#[test_connector]
 fn removing_a_relation_field_must_work(api: TestApi) {
     let dm_1 = r#"
         model User {

--- a/migration-engine/migration-engine-tests/tests/migrations/relations/vitess.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/relations/vitess.rs
@@ -1,6 +1,6 @@
 use migration_engine_tests::test_api::*;
 
-#[test_connector(tags(Vitess), preview_features("referentialIntegrity"))]
+#[test_connector(tags(Vitess))]
 fn adding_mutual_references_on_existing_tables_works(api: TestApi) {
     let dm1 = r#"
         model A {

--- a/migration-engine/migration-engine-tests/tests/migrations/sql.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/sql.rs
@@ -345,7 +345,7 @@ fn remapped_multi_field_id_as_part_of_relation_must_work(api: TestApi) {
     });
 }
 
-#[test_connector(preview_features("referentialIntegrity"))]
+#[test_connector]
 fn unique_constraints_on_composite_relation_fields(api: TestApi) {
     let dm = r##"
         model Parent {
@@ -374,7 +374,7 @@ fn unique_constraints_on_composite_relation_fields(api: TestApi) {
     });
 }
 
-#[test_connector(preview_features("referentialIntegrity"))]
+#[test_connector]
 fn indexes_on_composite_relation_fields(api: TestApi) {
     let dm = r##"
         model User {
@@ -403,7 +403,7 @@ fn indexes_on_composite_relation_fields(api: TestApi) {
     });
 }
 
-#[test_connector(exclude(Vitess), preview_features("referentialIntegrity"))]
+#[test_connector(exclude(Vitess))]
 fn dropping_mutually_referencing_tables_works(api: TestApi) {
     let dm1 = r#"
     model A {

--- a/migration-engine/migration-engine-tests/tests/migrations/sql/vitess.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/sql/vitess.rs
@@ -1,6 +1,6 @@
 use migration_engine_tests::test_api::*;
 
-#[test_connector(tags(Vitess), preview_features("referentialIntegrity"))]
+#[test_connector(tags(Vitess))]
 fn dropping_mutually_referencing_tables_works(api: TestApi) {
     let dm1 = r#"
     model A {

--- a/migration-engine/migration-engine-tests/tests/native_types/common.rs
+++ b/migration-engine/migration-engine-tests/tests/native_types/common.rs
@@ -1,6 +1,6 @@
 use migration_engine_tests::test_api::*;
 
-#[test_connector(exclude(CockroachDb), preview_features("referentialIntegrity"))]
+#[test_connector(exclude(CockroachDb))]
 fn typescript_starter_schema_is_idempotent_without_native_type_annotations(api: TestApi) {
     let dm = r#"
         model Post {

--- a/migration-engine/migration-engine-tests/tests/native_types/mysql.rs
+++ b/migration-engine/migration-engine-tests/tests/native_types/mysql.rs
@@ -909,7 +909,7 @@ fn impossible_casts_with_existing_data_should_warn(api: TestApi) {
     }
 }
 
-#[test_connector(tags(Mysql), preview_features("referentialIntegrity"))]
+#[test_connector(tags(Mysql))]
 fn typescript_starter_schema_with_native_types_is_idempotent(api: TestApi) {
     let dm = r#"
         model Post {
@@ -965,7 +965,7 @@ fn typescript_starter_schema_with_native_types_is_idempotent(api: TestApi) {
         .assert_no_steps();
 }
 
-#[test_connector(tags(Mysql), preview_features("referentialIntegrity"))]
+#[test_connector(tags(Mysql))]
 fn typescript_starter_schema_with_different_native_types_is_idempotent(api: TestApi) {
     let dm = r#"
         model Post {

--- a/migration-engine/migration-engine-tests/tests/schema_push/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/schema_push/mod.rs
@@ -16,7 +16,7 @@ model Box {
 }
 "#;
 
-#[test_connector(preview_features("referentialIntegrity"))]
+#[test_connector]
 fn schema_push_happy_path(api: TestApi) {
     api.schema_push_w_datasource(SCHEMA)
         .send()
@@ -62,7 +62,7 @@ fn schema_push_happy_path(api: TestApi) {
         });
 }
 
-#[test_connector(preview_features("referentialIntegrity"))]
+#[test_connector]
 fn schema_push_warns_about_destructive_changes(api: TestApi) {
     api.schema_push_w_datasource(SCHEMA)
         .send()
@@ -97,7 +97,7 @@ fn schema_push_warns_about_destructive_changes(api: TestApi) {
         .assert_has_executed_steps();
 }
 
-#[test_connector(preview_features("referentialIntegrity"))]
+#[test_connector]
 fn schema_push_with_an_unexecutable_migration_returns_a_message_and_aborts(api: TestApi) {
     api.schema_push_w_datasource(SCHEMA)
         .send()

--- a/psl/psl-core/src/common/preview_features.rs
+++ b/psl/psl-core/src/common/preview_features.rs
@@ -76,7 +76,7 @@ features!(
 /// Generator preview features
 pub const ALL_PREVIEW_FEATURES: FeatureMap = FeatureMap {
     active: enumflags2::make_bitflags!(PreviewFeature::{
-        ReferentialIntegrity
+        Deno
          | InteractiveTransactions
          | FullTextSearch
          | FullTextIndex
@@ -86,7 +86,6 @@ pub const ALL_PREVIEW_FEATURES: FeatureMap = FeatureMap {
          | FilteredRelationCount
          | FieldReference
          | PostgresqlExtensions
-         | Deno
          | ExtendedWhereUnique
     }),
     deprecated: enumflags2::make_bitflags!(PreviewFeature::{
@@ -110,6 +109,7 @@ pub const ALL_PREVIEW_FEATURES: FeatureMap = FeatureMap {
         | OrderByAggregateGroup
         | OrderByRelation
         | ReferentialActions
+        | ReferentialIntegrity
         | NApi
         | ImprovedQueryRaw
         | DataProxy

--- a/psl/psl-core/src/validate/datasource_loader.rs
+++ b/psl/psl-core/src/validate/datasource_loader.rs
@@ -188,17 +188,6 @@ fn lift_datasource(
     })
 }
 
-const RELATION_MODE_PREVIEW_FEATURE_ERR: &str = r#"
-This option can only be set if the preview feature is enabled in a generator block.
-
-Example:
-
-generator client {
-    provider = "prisma-client-js"
-    previewFeatures = ["referentialIntegrity"]
-}
-"#;
-
 fn get_relation_mode(
     args: &mut HashMap<&str, (Span, &ast::Expression)>,
     preview_features: BitFlags<PreviewFeature>,
@@ -212,45 +201,36 @@ fn get_relation_mode(
             diagnostics.push_error(DatamodelError::new_referential_integrity_and_relation_mode_cooccur_error(span));
             None
         }
-        (Some((span, rm)), None) | (None, Some((span, rm))) => {
-            if !preview_features.contains(PreviewFeature::ReferentialIntegrity) {
-                diagnostics.push_error(DatamodelError::new_source_validation_error(
-                    RELATION_MODE_PREVIEW_FEATURE_ERR,
-                    &source.name.name,
-                    span,
-                ));
-                None
-            } else {
-                let integrity = match coerce::string(rm, diagnostics)? {
-                    "prisma" => RelationMode::Prisma,
-                    "foreignKeys" => RelationMode::ForeignKeys,
-                    other => {
-                        let message = format!(
-                            "Invalid relation mode setting: \"{other}\". Supported values: \"prisma\", \"foreignKeys\"",
-                        );
-                        let error = DatamodelError::new_source_validation_error(&message, "relationMode", source.span);
-                        diagnostics.push_error(error);
-                        return None;
-                    }
-                };
-
-                if !connector.allowed_relation_mode_settings().contains(integrity) {
-                    let supported_values = connector
-                        .allowed_relation_mode_settings()
-                        .iter()
-                        .map(|v| format!(r#""{}""#, v))
-                        .collect::<Vec<_>>()
-                        .join(", ");
-
+        (Some((_span, rm)), None) | (None, Some((_span, rm))) => {
+            let integrity = match coerce::string(rm, diagnostics)? {
+                "prisma" => RelationMode::Prisma,
+                "foreignKeys" => RelationMode::ForeignKeys,
+                other => {
                     let message = format!(
-                        "Invalid relation mode setting: \"{integrity}\". Supported values: {supported_values}",
+                        "Invalid relation mode setting: \"{other}\". Supported values: \"prisma\", \"foreignKeys\"",
                     );
-                    let error = DatamodelError::new_source_validation_error(&message, "relationMode", rm.span());
+                    let error = DatamodelError::new_source_validation_error(&message, "relationMode", source.span);
                     diagnostics.push_error(error);
+                    return None;
                 }
+            };
 
-                Some(integrity)
+            if !connector.allowed_relation_mode_settings().contains(integrity) {
+                let supported_values = connector
+                    .allowed_relation_mode_settings()
+                    .iter()
+                    .map(|v| format!(r#""{}""#, v))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+
+                let message = format!(
+                    "Invalid relation mode setting: \"{integrity}\". Supported values: {supported_values}",
+                );
+                let error = DatamodelError::new_source_validation_error(&message, "relationMode", rm.span());
+                diagnostics.push_error(error);
             }
+
+            Some(integrity)
         }
     }
 }

--- a/psl/psl-core/src/validate/datasource_loader.rs
+++ b/psl/psl-core/src/validate/datasource_loader.rs
@@ -139,7 +139,7 @@ fn lift_datasource(
             }
         };
 
-    let relation_mode = get_relation_mode(&mut args, preview_features, ast_source, diagnostics, active_connector);
+    let relation_mode = get_relation_mode(&mut args, ast_source, diagnostics, active_connector);
 
     let (schemas, schemas_span) = args
         .remove(SCHEMAS_KEY)
@@ -190,7 +190,6 @@ fn lift_datasource(
 
 fn get_relation_mode(
     args: &mut HashMap<&str, (Span, &ast::Expression)>,
-    preview_features: BitFlags<PreviewFeature>,
     source: &SourceConfig,
     diagnostics: &mut Diagnostics,
     connector: &'static dyn crate::datamodel_connector::Connector,

--- a/psl/psl/tests/attributes/relations/referential_actions.rs
+++ b/psl/psl/tests/attributes/relations/referential_actions.rs
@@ -104,7 +104,6 @@ fn actions_on_mysql_with_prisma_relation_mode() {
             r#"
             generator client {{
                 provider = "prisma-client-js"
-                previewFeatures = ["referentialIntegrity"]
             }}
     
             datasource db {{
@@ -143,7 +142,6 @@ fn actions_on_sqlserver_with_prisma_relation_mode() {
             r#"
             generator client {{
                 provider = "prisma-client-js"
-                previewFeatures = ["referentialIntegrity"]
             }}
     
             datasource db {{
@@ -182,7 +180,6 @@ fn actions_on_cockroachdb_with_prisma_relation_mode() {
             r#"
             generator client {{
                 provider = "prisma-client-js"
-                previewFeatures = ["referentialIntegrity"]
             }}
     
             datasource db {{
@@ -221,7 +218,6 @@ fn actions_on_postgres_with_prisma_relation_mode() {
             r#"
             generator client {{
                 provider = "prisma-client-js"
-                previewFeatures = ["referentialIntegrity"]
             }}
     
             datasource db {{
@@ -260,7 +256,6 @@ fn actions_on_sqlite_with_prisma_relation_mode() {
             r#"
             generator client {{
                 provider = "prisma-client-js"
-                previewFeatures = ["referentialIntegrity"]
             }}
     
             datasource db {{
@@ -305,7 +300,6 @@ fn on_delete_actions_should_work_on_prisma_relation_mode() {
 
             generator client {{
                 provider = "prisma-client-js"
-                previewFeatures = ["referentialIntegrity"]
             }}
 
             model A {{
@@ -340,7 +334,6 @@ fn on_update_no_action_should_work_on_prisma_relation_mode() {
 
         generator client {
           provider = "prisma-client-js"
-          previewFeatures = ["referentialIntegrity"]
         }
 
         model A {
@@ -372,7 +365,6 @@ fn foreign_keys_not_allowed_on_mongo() {
 
         generator client {
           provider = "prisma-client-js"
-          previewFeatures = ["referentialIntegrity"]
         }
 
         model A {
@@ -410,7 +402,6 @@ fn prisma_level_integrity_should_be_allowed_on_mongo() {
 
         generator client {
           provider = "prisma-client-js"
-          previewFeatures = ["referentialIntegrity"]
         }
 
         model A {
@@ -576,7 +567,6 @@ fn on_update_no_action_should_not_work_on_postgres_with_prisma_relation_mode() {
     let dml = indoc! { r#"
         generator client {
             provider = "prisma-client-js"
-            previewFeatures = ["referentialIntegrity"]
         }
 
         datasource db {
@@ -614,7 +604,6 @@ fn on_delete_no_action_should_not_work_on_postgres_with_prisma_relation_mode() {
     let dml = indoc! { r#"
         generator client {
             provider = "prisma-client-js"
-            previewFeatures = ["referentialIntegrity"]
         }
 
         datasource db {
@@ -652,7 +641,6 @@ fn on_update_no_action_should_not_work_on_sqlite_with_prisma_relation_mode() {
     let dml = indoc! { r#"
         generator client {
             provider = "prisma-client-js"
-            previewFeatures = ["referentialIntegrity"]
         }
 
         datasource db {
@@ -690,7 +678,6 @@ fn on_delete_no_action_should_not_work_on_sqlite_with_prisma_relation_mode() {
     let dml = indoc! { r#"
         generator client {
             provider = "prisma-client-js"
-            previewFeatures = ["referentialIntegrity"]
         }
 
         datasource db {
@@ -775,7 +762,6 @@ fn set_default_action_should_not_work_on_prisma_level_relation_mode() {
 
             generator client {
                 provider = "prisma-client-js"
-                previewFeatures = ["referentialIntegrity"]
             }
 
             model A {{

--- a/psl/psl/tests/attributes/relations/referential_actions/cycle_detection.rs
+++ b/psl/psl/tests/attributes/relations/referential_actions/cycle_detection.rs
@@ -91,7 +91,6 @@ fn cycles_are_allowed_outside_of_emulation_and_sqlserver() {
 
         generator js1 {
           provider = "javascript"
-          previewFeatures = ["referentialIntegrity"]
         }
 
         model A {
@@ -117,7 +116,6 @@ fn emulated_cascading_on_delete_self_relations() {
 
         generator js1 {
           provider = "javascript"
-          previewFeatures = ["referentialIntegrity"]
         }
 
         model A {
@@ -183,7 +181,6 @@ fn emulated_cascading_on_update_self_relations() {
 
         generator js1 {
           provider = "javascript"
-          previewFeatures = ["referentialIntegrity"]
         }
 
         model A {
@@ -249,7 +246,6 @@ fn emulated_null_setting_on_delete_self_relations() {
 
         generator js1 {
           provider = "javascript"
-          previewFeatures = ["referentialIntegrity"]
         }
 
         model A {
@@ -315,7 +311,6 @@ fn emulated_null_setting_on_update_self_relations() {
 
         generator js1 {
           provider = "javascript"
-          previewFeatures = ["referentialIntegrity"]
         }
 
         model A {
@@ -381,7 +376,6 @@ fn emulated_default_setting_on_delete_self_relations() {
 
         generator js1 {
           provider = "javascript"
-          previewFeatures = ["referentialIntegrity"]
         }
 
         model A {
@@ -453,7 +447,6 @@ fn emulated_default_setting_on_update_self_relations() {
 
         generator js1 {
           provider = "javascript"
-          previewFeatures = ["referentialIntegrity"]
         }
 
         model A {
@@ -539,7 +532,6 @@ fn emulated_cascading_cyclic_one_hop_relations() {
 
         generator js1 {
           provider = "javascript"
-          previewFeatures = ["referentialIntegrity"]
         }
 
         model A {

--- a/psl/psl/tests/config/generators.rs
+++ b/psl/psl/tests/config/generators.rs
@@ -258,7 +258,7 @@ fn nice_error_for_unknown_generator_preview_feature() {
         .unwrap_err();
 
     let expectation = expect![[r#"
-        [1;91merror[0m: [1mThe preview feature "foo" is not known. Expected one of: referentialIntegrity, interactiveTransactions, fullTextSearch, fullTextIndex, tracing, metrics, orderByNulls, filteredRelationCount, fieldReference, postgresqlExtensions, deno, extendedWhereUnique[0m
+        [1;91merror[0m: [1mThe preview feature "foo" is not known. Expected one of: deno, interactiveTransactions, fullTextSearch, fullTextIndex, tracing, metrics, orderByNulls, filteredRelationCount, fieldReference, postgresqlExtensions, extendedWhereUnique[0m
           [1;94m-->[0m  [4mschema.prisma:3[0m
         [1;94m   | [0m
         [1;94m 2 | [0m  provider = "prisma-client-js"

--- a/psl/psl/tests/config/sources.rs
+++ b/psl/psl/tests/config/sources.rs
@@ -615,7 +615,6 @@ fn relation_mode_works() {
 
         generator client {
           provider = "prisma-client-js"
-          previewFeatures = ["referentialIntegrity"]
         }
     "#};
 
@@ -634,7 +633,6 @@ fn relation_mode_default() {
 
         generator client {
           provider = "prisma-client-js"
-          previewFeatures = ["referentialIntegrity"]
         }
     "#};
 
@@ -654,7 +652,6 @@ fn relation_mode_and_referential_integrity_cannot_cooccur() {
         }
         generator client {
           provider = "prisma-client-js"
-          previewFeatures = ["referentialIntegrity"]
         }
     "#};
 

--- a/psl/psl/tests/config/sources.rs
+++ b/psl/psl/tests/config/sources.rs
@@ -586,7 +586,7 @@ fn fail_when_no_source_is_declared() {
 }
 
 #[test]
-fn referential_integrity_without_preview_feature_errors() {
+fn referential_integrity_works() {
     let schema = indoc! {r#"
         datasource ps {
           provider = "sqlserver"
@@ -596,83 +596,6 @@ fn referential_integrity_without_preview_feature_errors() {
 
         generator client {
           provider = "prisma-client-js"
-        }
-    "#};
-
-    let error = parse_config(schema).map(drop).unwrap_err();
-
-    let expectation = expect![[r#"
-        [1;91merror[0m: [1mError validating datasource `ps`: 
-        This option can only be set if the preview feature is enabled in a generator block.
-
-        Example:
-
-        generator client {
-            provider = "prisma-client-js"
-            previewFeatures = ["referentialIntegrity"]
-        }
-        [0m
-          [1;94m-->[0m  [4mschema.prisma:3[0m
-        [1;94m   | [0m
-        [1;94m 2 | [0m  provider = "sqlserver"
-        [1;94m 3 | [0m  [1;91mreferentialIntegrity = "prisma"[0m
-        [1;94m 4 | [0m  url = "mysql://root:prisma@localhost:3306/mydb"
-        [1;94m   | [0m
-    "#]];
-
-    expectation.assert_eq(&error)
-}
-
-#[test]
-fn relation_mode_without_preview_feature_errors() {
-    let schema = indoc! {r#"
-        datasource ps {
-          provider = "sqlserver"
-          relationMode = "prisma"
-          url = "mysql://root:prisma@localhost:3306/mydb"
-        }
-
-        generator client {
-          provider = "prisma-client-js"
-        }
-    "#};
-
-    let error = parse_config(schema).map(drop).unwrap_err();
-
-    let expectation = expect![[r#"
-        [1;91merror[0m: [1mError validating datasource `ps`: 
-        This option can only be set if the preview feature is enabled in a generator block.
-
-        Example:
-
-        generator client {
-            provider = "prisma-client-js"
-            previewFeatures = ["referentialIntegrity"]
-        }
-        [0m
-          [1;94m-->[0m  [4mschema.prisma:3[0m
-        [1;94m   | [0m
-        [1;94m 2 | [0m  provider = "sqlserver"
-        [1;94m 3 | [0m  [1;91mrelationMode = "prisma"[0m
-        [1;94m 4 | [0m  url = "mysql://root:prisma@localhost:3306/mydb"
-        [1;94m   | [0m
-    "#]];
-
-    expectation.assert_eq(&error)
-}
-
-#[test]
-fn referential_integrity_with_preview_feature_works() {
-    let schema = indoc! {r#"
-        datasource ps {
-          provider = "sqlserver"
-          referentialIntegrity = "prisma"
-          url = "mysql://root:prisma@localhost:3306/mydb"
-        }
-
-        generator client {
-          provider = "prisma-client-js"
-          previewFeatures = ["referentialIntegrity"]
         }
     "#};
 
@@ -682,7 +605,7 @@ fn referential_integrity_with_preview_feature_works() {
 }
 
 #[test]
-fn relation_mode_with_preview_feature_works() {
+fn relation_mode_works() {
     let schema = indoc! {r#"
         datasource ps {
           provider = "sqlserver"

--- a/query-engine/prisma-models/tests/datamodel_converter_tests.rs
+++ b/query-engine/prisma-models/tests/datamodel_converter_tests.rs
@@ -8,7 +8,6 @@ fn no_action_is_alias_for_restrict_when_prisma_relation_mode() {
         r#"
         generator client {
             provider = "prisma-client-js"
-            previewFeatures = ["referentialIntegrity"]
         }
 
         datasource db {
@@ -44,7 +43,6 @@ fn no_action_is_not_alias_for_restrict_when_foreign_keys_relation_mode() {
         r#"
         generator client {
             provider = "prisma-client-js"
-            previewFeatures = ["referentialIntegrity"]
         }
 
         datasource db {


### PR DESCRIPTION
Related https://github.com/prisma/prisma/issues/16224

Changes
- deprecated the preview feature
- removed error if preview feature is missing but the datasource property is set
- removed unneeded tests
- updated test-api
- remove all mentions of the preview feature flag