### PR TITLE
feat(psl): support warnings in tests

### DIFF
--- a/psl/diagnostics/src/error.rs
+++ b/psl/diagnostics/src/error.rs
@@ -378,12 +378,12 @@ impl DatamodelError {
     }
 
     pub fn pretty_print(&self, f: &mut dyn std::io::Write, file_name: &str, text: &str) -> std::io::Result<()> {
-        let colorer = DatamodelErrorColorer {};
-        pretty_print(f, file_name, text, self.span(), self.message.as_ref(), colorer)
+        pretty_print(f, file_name, text, self.span(), self.message.as_ref(), &COLORER)
     }
 }
 
 struct DatamodelErrorColorer {}
+static COLORER: DatamodelErrorColorer = DatamodelErrorColorer {};
 
 impl DiagnosticColorer for DatamodelErrorColorer {
     fn title(&self) -> &'static str {

--- a/psl/diagnostics/src/error.rs
+++ b/psl/diagnostics/src/error.rs
@@ -1,4 +1,9 @@
-use crate::{pretty_print::pretty_print, Span};
+use colored::{ColoredString, Colorize};
+
+use crate::{
+    pretty_print::{pretty_print, DiagnosticColorer},
+    Span,
+};
 use std::borrow::Cow;
 
 #[derive(Debug, Clone)]
@@ -373,6 +378,22 @@ impl DatamodelError {
     }
 
     pub fn pretty_print(&self, f: &mut dyn std::io::Write, file_name: &str, text: &str) -> std::io::Result<()> {
-        pretty_print(f, file_name, text, self.span(), self.message.as_ref())
+        let colorer = Box::new(DatamodelErrorColorer {});
+        pretty_print(f, file_name, text, self.span(), self.message.as_ref(), colorer)
+    }
+}
+
+struct DatamodelErrorColorer {}
+
+impl DiagnosticColorer for DatamodelErrorColorer {
+    fn title(&self) -> &'static str {
+        "error"
+    }
+
+    fn primary_color<S>(&self, token: S) -> ColoredString
+    where
+        S: Sized + AsRef<str>,
+    {
+        token.as_ref().bright_red()
     }
 }

--- a/psl/diagnostics/src/error.rs
+++ b/psl/diagnostics/src/error.rs
@@ -390,10 +390,7 @@ impl DiagnosticColorer for DatamodelErrorColorer {
         "error"
     }
 
-    fn primary_color<S>(&self, token: S) -> ColoredString
-    where
-        S: Sized + AsRef<str>,
-    {
-        token.as_ref().bright_red()
+    fn primary_color(&self, token: &'_ str) -> ColoredString {
+        token.bright_red()
     }
 }

--- a/psl/diagnostics/src/error.rs
+++ b/psl/diagnostics/src/error.rs
@@ -378,12 +378,18 @@ impl DatamodelError {
     }
 
     pub fn pretty_print(&self, f: &mut dyn std::io::Write, file_name: &str, text: &str) -> std::io::Result<()> {
-        pretty_print(f, file_name, text, self.span(), self.message.as_ref(), &COLORER)
+        pretty_print(
+            f,
+            file_name,
+            text,
+            self.span(),
+            self.message.as_ref(),
+            &DatamodelErrorColorer {},
+        )
     }
 }
 
 struct DatamodelErrorColorer {}
-static COLORER: DatamodelErrorColorer = DatamodelErrorColorer {};
 
 impl DiagnosticColorer for DatamodelErrorColorer {
     fn title(&self) -> &'static str {

--- a/psl/diagnostics/src/error.rs
+++ b/psl/diagnostics/src/error.rs
@@ -378,7 +378,7 @@ impl DatamodelError {
     }
 
     pub fn pretty_print(&self, f: &mut dyn std::io::Write, file_name: &str, text: &str) -> std::io::Result<()> {
-        let colorer = Box::new(DatamodelErrorColorer {});
+        let colorer = DatamodelErrorColorer {};
         pretty_print(f, file_name, text, self.span(), self.message.as_ref(), colorer)
     }
 }

--- a/psl/diagnostics/src/pretty_print.rs
+++ b/psl/diagnostics/src/pretty_print.rs
@@ -4,9 +4,7 @@ use colored::{ColoredString, Colorize};
 pub trait DiagnosticColorer {
     fn title(&self) -> &'static str;
 
-    fn primary_color<S>(&self, token: S) -> ColoredString
-    where
-        S: Sized + AsRef<str>;
+    fn primary_color(&self, token: &'_ str) -> ColoredString;
 }
 
 /// Given the datamodel text representation, pretty prints an error or warning, including

--- a/psl/diagnostics/src/pretty_print.rs
+++ b/psl/diagnostics/src/pretty_print.rs
@@ -15,7 +15,7 @@ pub(crate) fn pretty_print(
     text: &str,
     span: Span,
     description: &str,
-    colorer: impl DiagnosticColorer,
+    colorer: &'static dyn DiagnosticColorer,
 ) -> std::io::Result<()> {
     let start_line_number = text[..span.start].matches('\n').count();
     let end_line_number = text[..span.end].matches('\n').count();

--- a/psl/diagnostics/src/pretty_print.rs
+++ b/psl/diagnostics/src/pretty_print.rs
@@ -1,5 +1,13 @@
 use crate::Span;
-use colored::Colorize;
+use colored::{ColoredString, Colorize};
+
+pub trait DiagnosticColorer {
+    fn title(&self) -> &'static str;
+
+    fn primary_color<S>(&self, token: S) -> ColoredString
+    where
+        S: Sized + AsRef<str>;
+}
 
 /// Given the datamodel text representation, pretty prints an error or warning, including
 /// the offending portion of the source code, for human-friendly reading.
@@ -9,6 +17,7 @@ pub(crate) fn pretty_print(
     text: &str,
     span: Span,
     description: &str,
+    colorer: Box<impl DiagnosticColorer>,
 ) -> std::io::Result<()> {
     let start_line_number = text[..span.start].matches('\n').count();
     let end_line_number = text[..span.end].matches('\n').count();
@@ -24,13 +33,18 @@ pub(crate) fn pretty_print(
     let end_in_line = std::cmp::min(start_in_line + (span.end - span.start), line.len());
 
     let prefix = &line[..start_in_line];
-    let offending = &line[start_in_line..end_in_line].bright_red().bold();
+    let offending = colorer.primary_color(&line[start_in_line..end_in_line]).bold();
     let suffix = &line[end_in_line..];
 
     let arrow = "-->".bright_blue().bold();
     let file_path = format!("{}:{}", file_name, start_line_number + 1).underline();
 
-    writeln!(f, "{}: {}", "error".bright_red().bold(), description.bold())?;
+    writeln!(
+        f,
+        "{}: {}",
+        colorer.primary_color(colorer.title()).bold(),
+        description.bold()
+    )?;
     writeln!(f, "  {}  {}", arrow, file_path)?;
     writeln!(f, "{}", format_line_number(0))?;
 
@@ -50,7 +64,7 @@ pub(crate) fn pretty_print(
             "{}{}{}",
             format_line_number(0),
             spacing,
-            "^ Unexpected token.".bold().bright_red()
+            colorer.primary_color("^ Unexpected token.").bold()
         )?;
     }
 

--- a/psl/diagnostics/src/pretty_print.rs
+++ b/psl/diagnostics/src/pretty_print.rs
@@ -17,7 +17,7 @@ pub(crate) fn pretty_print(
     text: &str,
     span: Span,
     description: &str,
-    colorer: Box<impl DiagnosticColorer>,
+    colorer: impl DiagnosticColorer,
 ) -> std::io::Result<()> {
     let start_line_number = text[..span.start].matches('\n').count();
     let end_line_number = text[..span.end].matches('\n').count();

--- a/psl/diagnostics/src/warning.rs
+++ b/psl/diagnostics/src/warning.rs
@@ -1,4 +1,9 @@
-use crate::Span;
+use colored::{ColoredString, Colorize};
+
+use crate::{
+    pretty_print::{pretty_print, DiagnosticColorer},
+    Span,
+};
 
 /// A non-fatal warning emitted by the schema parser.
 /// For fancy printing, please use the `pretty_print_error` function.
@@ -28,5 +33,25 @@ impl DatamodelWarning {
     /// The source span the warning applies to.
     pub fn span(&self) -> Span {
         self.span
+    }
+
+    pub fn pretty_print(&self, f: &mut dyn std::io::Write, file_name: &str, text: &str) -> std::io::Result<()> {
+        let colorer = Box::new(DatamodelWarningColorer {});
+        pretty_print(f, file_name, text, self.span(), self.message.as_ref(), colorer)
+    }
+}
+
+struct DatamodelWarningColorer {}
+
+impl DiagnosticColorer for DatamodelWarningColorer {
+    fn title(&self) -> &'static str {
+        "warning"
+    }
+
+    fn primary_color<S>(&self, token: S) -> ColoredString
+    where
+        S: Sized + AsRef<str>,
+    {
+        token.as_ref().bright_yellow()
     }
 }

--- a/psl/diagnostics/src/warning.rs
+++ b/psl/diagnostics/src/warning.rs
@@ -48,10 +48,7 @@ impl DiagnosticColorer for DatamodelWarningColorer {
         "warning"
     }
 
-    fn primary_color<S>(&self, token: S) -> ColoredString
-    where
-        S: Sized + AsRef<str>,
-    {
-        token.as_ref().bright_yellow()
+    fn primary_color(&self, token: &'_ str) -> ColoredString {
+        token.bright_yellow()
     }
 }

--- a/psl/diagnostics/src/warning.rs
+++ b/psl/diagnostics/src/warning.rs
@@ -36,12 +36,12 @@ impl DatamodelWarning {
     }
 
     pub fn pretty_print(&self, f: &mut dyn std::io::Write, file_name: &str, text: &str) -> std::io::Result<()> {
-        let colorer = DatamodelWarningColorer {};
-        pretty_print(f, file_name, text, self.span(), self.message.as_ref(), colorer)
+        pretty_print(f, file_name, text, self.span(), self.message.as_ref(), &COLORER)
     }
 }
 
 struct DatamodelWarningColorer {}
+static COLORER: DatamodelWarningColorer = DatamodelWarningColorer {};
 
 impl DiagnosticColorer for DatamodelWarningColorer {
     fn title(&self) -> &'static str {

--- a/psl/diagnostics/src/warning.rs
+++ b/psl/diagnostics/src/warning.rs
@@ -36,7 +36,7 @@ impl DatamodelWarning {
     }
 
     pub fn pretty_print(&self, f: &mut dyn std::io::Write, file_name: &str, text: &str) -> std::io::Result<()> {
-        let colorer = Box::new(DatamodelWarningColorer {});
+        let colorer = DatamodelWarningColorer {};
         pretty_print(f, file_name, text, self.span(), self.message.as_ref(), colorer)
     }
 }

--- a/psl/diagnostics/src/warning.rs
+++ b/psl/diagnostics/src/warning.rs
@@ -36,12 +36,18 @@ impl DatamodelWarning {
     }
 
     pub fn pretty_print(&self, f: &mut dyn std::io::Write, file_name: &str, text: &str) -> std::io::Result<()> {
-        pretty_print(f, file_name, text, self.span(), self.message.as_ref(), &COLORER)
+        pretty_print(
+            f,
+            file_name,
+            text,
+            self.span(),
+            self.message.as_ref(),
+            &DatamodelWarningColorer {},
+        )
     }
 }
 
 struct DatamodelWarningColorer {}
-static COLORER: DatamodelWarningColorer = DatamodelWarningColorer {};
 
 impl DiagnosticColorer for DatamodelWarningColorer {
     fn title(&self) -> &'static str {

--- a/psl/psl/tests/validation_tests.rs
+++ b/psl/psl/tests/validation_tests.rs
@@ -69,7 +69,6 @@ fn run_validation_test(test_file_path: &str) {
 
     let source_file = psl::parser_database::SourceFile::new_allocated(Arc::from(text.into_boxed_str()));
 
-    // let validation_result = psl::parse_schema(source_file.clone());
     let validation_result = parse_schema_fail_on_diagnostics(source_file.clone());
 
     let diagnostics = match (last_comment_contents.is_empty(), validation_result) {
@@ -94,29 +93,6 @@ fn run_validation_test(test_file_path: &str) {
     }
 
     panic_with_diff::panic_with_diff(&last_comment_contents, &diagnostics)
-
-    // let errors = match (last_comment_contents.is_empty(), validation_result) {
-    //     (true, Ok(_)) => return, // expected and got a valid schema
-    //     (false, Err(errors)) if last_comment_contents == errors => return, // we expected the errors we got
-    //     (_, Err(errors)) => errors,
-    //     (false, Ok(_)) => String::new(), // expected errors, got none
-    // };
-
-    // if std::env::var("UPDATE_EXPECT").is_ok() {
-    //     let mut file = fs::File::create(&file_path).unwrap(); // truncate
-    //
-    //     let schema = last_comment_idx
-    //         .map(|idx| &source_file.as_str()[..idx])
-    //         .unwrap_or(source_file.as_str());
-    //     file.write_all(schema.as_bytes()).unwrap();
-    //
-    //     for line in errors.lines() {
-    //         writeln!(file, "// {line}").unwrap();
-    //     }
-    //     return;
-    // }
-
-    // panic_with_diff::panic_with_diff(&last_comment_contents, &errors)
 }
 
 include!(concat!(env!("OUT_DIR"), "/validation_tests.rs"));

--- a/psl/psl/tests/validation_tests.rs
+++ b/psl/psl/tests/validation_tests.rs
@@ -2,7 +2,36 @@ mod panic_with_diff;
 
 use std::{fs, io::Write as _, path, sync::Arc};
 
+use psl::{SourceFile, ValidatedSchema};
+
 const TESTS_ROOT: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/validation");
+
+/// Parse and analyze a Prisma schema, returning Err if there are any diagnostics (warnings or errors).
+fn parse_schema_fail_on_diagnostics(file: impl Into<SourceFile>) -> Result<ValidatedSchema, String> {
+    let schema = psl::validate(file.into());
+
+    let file_name = "schema.prisma";
+    let datamodel_string = schema.db.source();
+
+    match (schema.diagnostics.warnings(), schema.diagnostics.errors()) {
+        ([], []) => Ok(schema),
+        (warnings, errors) => {
+            let mut message: Vec<u8> = Vec::new();
+
+            for warn in warnings {
+                warn.pretty_print(&mut message, file_name, datamodel_string)
+                    .expect("printing datamodel warning");
+            }
+
+            for err in errors {
+                err.pretty_print(&mut message, file_name, datamodel_string)
+                    .expect("printing datamodel error");
+            }
+
+            Err(String::from_utf8_lossy(&message).into_owned())
+        }
+    }
+}
 
 #[inline(never)] // we want to compile fast
 fn run_validation_test(test_file_path: &str) {
@@ -39,13 +68,15 @@ fn run_validation_test(test_file_path: &str) {
         .unwrap_or_default();
 
     let source_file = psl::parser_database::SourceFile::new_allocated(Arc::from(text.into_boxed_str()));
-    let validation_result = psl::parse_schema(source_file.clone());
 
-    let errors = match (last_comment_contents.is_empty(), validation_result) {
+    // let validation_result = psl::parse_schema(source_file.clone());
+    let validation_result = parse_schema_fail_on_diagnostics(source_file.clone());
+
+    let diagnostics = match (last_comment_contents.is_empty(), validation_result) {
         (true, Ok(_)) => return, // expected and got a valid schema
-        (false, Err(errors)) if last_comment_contents == errors => return, // we expected the errors we got
-        (_, Err(errors)) => errors,
-        (false, Ok(_)) => String::new(), // expected errors, got none
+        (false, Err(diagnostics)) if last_comment_contents == diagnostics => return, // we expected the diagnostics we got
+        (_, Err(diagnostics)) => diagnostics,
+        (false, Ok(_)) => String::new(), // expected diagnostics, got none
     };
 
     if std::env::var("UPDATE_EXPECT").is_ok() {
@@ -56,13 +87,36 @@ fn run_validation_test(test_file_path: &str) {
             .unwrap_or(source_file.as_str());
         file.write_all(schema.as_bytes()).unwrap();
 
-        for line in errors.lines() {
+        for line in diagnostics.lines() {
             writeln!(file, "// {line}").unwrap();
         }
         return;
     }
 
-    panic_with_diff::panic_with_diff(&last_comment_contents, &errors)
+    panic_with_diff::panic_with_diff(&last_comment_contents, &diagnostics)
+
+    // let errors = match (last_comment_contents.is_empty(), validation_result) {
+    //     (true, Ok(_)) => return, // expected and got a valid schema
+    //     (false, Err(errors)) if last_comment_contents == errors => return, // we expected the errors we got
+    //     (_, Err(errors)) => errors,
+    //     (false, Ok(_)) => String::new(), // expected errors, got none
+    // };
+
+    // if std::env::var("UPDATE_EXPECT").is_ok() {
+    //     let mut file = fs::File::create(&file_path).unwrap(); // truncate
+    //
+    //     let schema = last_comment_idx
+    //         .map(|idx| &source_file.as_str()[..idx])
+    //         .unwrap_or(source_file.as_str());
+    //     file.write_all(schema.as_bytes()).unwrap();
+    //
+    //     for line in errors.lines() {
+    //         writeln!(file, "// {line}").unwrap();
+    //     }
+    //     return;
+    // }
+
+    // panic_with_diff::panic_with_diff(&last_comment_contents, &errors)
 }
 
 include!(concat!(env!("OUT_DIR"), "/validation_tests.rs"));


### PR DESCRIPTION
This PR adds support for `psl` warning diagnostics to the `validation_tests` test suite (which previously only supported error diagnostics)

Context: https://github.com/prisma/prisma-engines/pull/3429 introduced a new kind of validation warning that we wanted to test. As `validation_tests` is the place where the Schema team should write new validation unit tests, this PR fixes such a shortcoming.