### PR TITLE
migration-engine: fix FK renaming and enum alter for multiSchema

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
@@ -40,6 +40,7 @@ impl PostgresFlavour {
 }
 
 impl SqlRenderer for PostgresFlavour {
+    // TODO(MultiSchema): We only do alter_sequence on CockroachDB.
     fn render_alter_sequence(
         &self,
         sequence_idx: Pair<u32>,

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
@@ -561,10 +561,13 @@ impl SqlRenderer for PostgresFlavour {
 
     fn render_rename_foreign_key(&self, fks: Pair<ForeignKeyWalker<'_>>) -> String {
         format!(
-            r#"ALTER TABLE "{table}" RENAME CONSTRAINT "{previous}" TO "{next}""#,
-            table = fks.previous.table().name(),
-            previous = fks.previous.constraint_name().unwrap(),
-            next = fks.next.constraint_name().unwrap(),
+            r#"ALTER TABLE {table} RENAME CONSTRAINT {previous} TO {next}"#,
+            table = TableName(
+                fks.previous.table().namespace().map(Quoted::postgres_ident),
+                Quoted::postgres_ident(fks.previous.table().name()),
+            ),
+            previous = self.quote(fks.previous.constraint_name().unwrap()),
+            next = self.quote(fks.next.constraint_name().unwrap()),
         )
     }
 }

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs
@@ -962,7 +962,11 @@ fn render_postgres_alter_enum(
 
     let mut stmts = Vec::with_capacity(10);
 
-    let tmp_name = format!("{}_new", &enums.next.name());
+    let temporary_enum_name = format!("{}_new", &enums.next.name());
+    let tmp_name = TableName::new(
+        enums.next.namespace().map(Quoted::postgres_ident),
+        Quoted::postgres_ident(temporary_enum_name.as_str()),
+    );
     let tmp_old_name = format!("{}_old", &enums.previous.name());
 
     stmts.push("BEGIN".to_string());
@@ -971,7 +975,7 @@ fn render_postgres_alter_enum(
     {
         let create_new_enum = format!(
             "CREATE TYPE {enum_name} AS ENUM ({variants})",
-            enum_name = Quoted::postgres_ident(&tmp_name),
+            enum_name = tmp_name,
             variants = enums.next.values().map(Quoted::postgres_string).join(", ")
         );
 
@@ -984,9 +988,12 @@ fn render_postgres_alter_enum(
             let column = schemas.previous.walk(*colid);
 
             let drop_default = format!(
-                r#"ALTER TABLE "{table_name}" ALTER COLUMN "{column_name}" DROP DEFAULT"#,
-                table_name = column.table().name(),
-                column_name = column.name(),
+                r#"ALTER TABLE {table_name} ALTER COLUMN {column_name} DROP DEFAULT"#,
+                table_name = TableName::new(
+                    column.table().namespace().map(Quoted::postgres_ident),
+                    Quoted::postgres_ident(column.table().name())
+                ),
+                column_name = Quoted::postgres_ident(column.name()),
             );
 
             stmts.push(drop_default);
@@ -1006,9 +1013,11 @@ fn render_postgres_alter_enum(
                 "ALTER TABLE {table_name} \
                             ALTER COLUMN {column_name} TYPE {tmp_name}{array} \
                                 USING ({column_name}::text::{tmp_name}{array})",
-                table_name = Quoted::postgres_ident(column.table().name()),
+                table_name = TableName::new(
+                    column.table().namespace().map(Quoted::postgres_ident),
+                    Quoted::postgres_ident(column.table().name())
+                ),
                 column_name = Quoted::postgres_ident(column.name()),
-                tmp_name = Quoted::postgres_ident(&tmp_name),
                 array = array,
             );
 
@@ -1020,7 +1029,10 @@ fn render_postgres_alter_enum(
     {
         let sql = format!(
             "ALTER TYPE {enum_name} RENAME TO {tmp_old_name}",
-            enum_name = Quoted::postgres_ident(enums.previous.name()),
+            enum_name = TableName::new(
+                enums.previous.namespace().map(Quoted::postgres_ident),
+                Quoted::postgres_ident(enums.previous.name())
+            ),
             tmp_old_name = Quoted::postgres_ident(&tmp_old_name)
         );
 
@@ -1031,7 +1043,6 @@ fn render_postgres_alter_enum(
     {
         let sql = format!(
             "ALTER TYPE {tmp_name} RENAME TO {enum_name}",
-            tmp_name = Quoted::postgres_ident(&tmp_name),
             enum_name = Quoted::postgres_ident(enums.next.name())
         );
 
@@ -1066,7 +1077,10 @@ fn render_postgres_alter_enum(
 
             let set_default = format!(
                 "ALTER TABLE {table_name} ALTER COLUMN {column_name} SET DEFAULT {default}",
-                table_name = Quoted::postgres_ident(&table_name),
+                table_name = TableName::new(
+                    columns.previous.table().namespace().map(Quoted::postgres_ident),
+                    Quoted::postgres_ident(table_name)
+                ),
                 column_name = Quoted::postgres_ident(&column_name),
                 default = default_str,
             );

--- a/migration-engine/migration-engine-tests/tests/migrations/postgres/multi_schema.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/postgres/multi_schema.rs
@@ -896,6 +896,53 @@ fn multi_schema_tests(_api: TestApi) {
             skip: None,
         },
         TestData {
+            name: "rename foreign key",
+            description: "Rename a foreign key in a table inside a namespace",
+            schema: Schema {
+                common: base_schema.to_owned(),
+                first: indoc! {r#"
+        model First {
+          id Int @id
+          some_field String
+          seconds Second[]
+          @@schema("one")
+        }
+        model Second {
+          id Int @id
+          other_field String
+          first_id Int @unique
+          first First @relation(fields: [first_id], references: [id])
+          @@schema("two")
+        }"#}.into(),
+                second: Some( indoc! {r#"
+        model First {
+          id Int @id
+          some_field String
+          seconds Second[]
+          @@schema("one")
+        }
+        model Second {
+          id Int @id
+          other_field String
+          first_id Int @unique
+          first First @relation(fields: [first_id], references: [id], map: "new_name")
+          @@schema("two")
+        } "#}.into()),
+            },
+            namespaces: &namespaces,
+            schema_push: SchemaPush::PushAnd(WithSchema::First,
+                           &SchemaPush::PushAnd(WithSchema::Second,
+                              &SchemaPush::Done)),
+            assertion: Box::new(|assert| {
+                assert
+                    .assert_has_table_with_ns("one", "First")
+                    .assert_table_with_ns("two", "Second", |table|
+                               table.assert_fk_with_name("new_name")
+                        );
+            }),
+            skip: None,
+        },
+        TestData {
             name: "add explicit many-to-many cross-namespace relation",
             description: "add an explicit many-to-many relationship for tables in different namespaces",
             schema: Schema {


### PR DESCRIPTION
Fixes and adds test cases for renaming foreign keys and altering enums in the context of multiSchema.

We went through the whole `migration-engine/connectors/sql-migration-connector/src/sql_renderer/postgres_renderer.rs` module.

There is one more test we thought of that is failing, which I will add in a separate PR.