### PR TITLE
feat(psl): add warning when `SetDefault` is used on `mysql` with `relationMode = "foreignKeys"`

### DIFF
--- a/introspection-engine/introspection-engine-tests/tests/referential_actions/mod.rs
+++ b/introspection-engine/introspection-engine-tests/tests/referential_actions/mod.rs
@@ -1,4 +1,5 @@
 mod cockroachdb;
+mod mysql;
 mod sqlite;
 
 use barrel::types;

--- a/introspection-engine/introspection-engine-tests/tests/referential_actions/mysql.rs
+++ b/introspection-engine/introspection-engine-tests/tests/referential_actions/mysql.rs
@@ -3,7 +3,7 @@ use introspection_engine_tests::test_api::*;
 // Older versions of MySQL (5.6+) raise a syntax error on `CREATE TABLE` declarations with `SET DEFAULT` referential actions,
 // so we can skip introspecting those. MariaDb 10.0 suffers from the same issue.
 // We should see validation warnings on MySQL 8+.
-#[test_connector(tags(Mysql8))]
+#[test_connector(tags(Mysql8), exclude(Vitess))]
 async fn introspect_set_default_should_warn(api: &TestApi) -> TestResult {
     let setup = r#"
       CREATE TABLE `SomeUser` (

--- a/introspection-engine/introspection-engine-tests/tests/referential_actions/mysql.rs
+++ b/introspection-engine/introspection-engine-tests/tests/referential_actions/mysql.rs
@@ -1,0 +1,77 @@
+use introspection_engine_tests::test_api::*;
+
+// Older versions of MySQL (5.6+) raise a syntax error on `CREATE TABLE` declarations with `SET DEFAULT` referential actions,
+// so we can skip introspecting those. MariaDb 10.0 suffers from the same issue.
+// We should see validation warnings on MySQL 8+.
+#[test_connector(tags(Mysql8))]
+async fn introspect_set_default_should_warn(api: &TestApi) -> TestResult {
+    let setup = r#"
+      CREATE TABLE `SomeUser` (
+          `id` INTEGER NOT NULL AUTO_INCREMENT,
+      
+          PRIMARY KEY (`id`)
+      ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+      
+      CREATE TABLE `Post` (
+          `id` INTEGER NOT NULL AUTO_INCREMENT,
+          `userId` INTEGER NULL DEFAULT 3,
+      
+          PRIMARY KEY (`id`)
+      ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+      
+      ALTER TABLE `Post` ADD CONSTRAINT `Post_userId_fkey`
+        FOREIGN KEY (`userId`) REFERENCES `SomeUser`(`id`)
+        ON DELETE SET DEFAULT ON UPDATE SET DEFAULT;
+    "#;
+
+    api.raw_cmd(setup).await;
+
+    let expected_schema = expect![[r#"
+        generator client {
+          provider = "prisma-client-js"
+        }
+
+        datasource db {
+          provider = "mysql"
+          url      = "env(TEST_DATABASE_URL)"
+        }
+
+        model Post {
+          id       Int       @id @default(autoincrement())
+          userId   Int?      @default(3)
+          SomeUser SomeUser? @relation(fields: [userId], references: [id], onDelete: SetDefault, onUpdate: SetDefault)
+
+          @@index([userId], map: "Post_userId_fkey")
+        }
+
+        model SomeUser {
+          id   Int    @id @default(autoincrement())
+          Post Post[]
+        }
+    "#]];
+
+    expected_schema.assert_eq(&api.introspect().await?);
+    let schema = psl::parse_schema(expected_schema.data())?;
+
+    let warning_messages = schema
+        .diagnostics
+        .warnings_to_pretty_string("schema.prisma", &schema.db.source());
+
+    let expected_validation = expect![[r#"
+        [1;93mwarning[0m: [1mUsing SetDefault on MySQL may yield to unexpected results, as the database will silently change the referential action to `NoAction`.[0m
+          [1;94m-->[0m  [4mschema.prisma:14[0m
+        [1;94m   | [0m
+        [1;94m13 | [0m          userId   Int?      @default(3)
+        [1;94m14 | [0m          SomeUser SomeUser? @relation(fields: [userId], references: [id], [1;93monDelete: SetDefault[0m, onUpdate: SetDefault)
+        [1;94m   | [0m
+        [1;93mwarning[0m: [1mUsing SetDefault on MySQL may yield to unexpected results, as the database will silently change the referential action to `NoAction`.[0m
+          [1;94m-->[0m  [4mschema.prisma:14[0m
+        [1;94m   | [0m
+        [1;94m13 | [0m          userId   Int?      @default(3)
+        [1;94m14 | [0m          SomeUser SomeUser? @relation(fields: [userId], references: [id], onDelete: SetDefault, [1;93monUpdate: SetDefault[0m)
+        [1;94m   | [0m
+    "#]];
+    expected_validation.assert_eq(&warning_messages);
+
+    Ok(())
+}

--- a/migration-engine/migration-engine-tests/tests/migrations/relations.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/relations.rs
@@ -573,7 +573,8 @@ fn on_delete_referential_actions_should_work(api: TestApi) {
 }
 
 // 5.6 and 5.7 doesn't let you `SET DEFAULT` without setting the default value
-// (even if nullable). Maria will silently just use `RESTRICT` instead.
+// (even if nullable). MySQL 8.0+ & MariaDB 10.0 allow you to create a table with
+// `SET DEFAULT`, but will silently use `NO ACTION` / `RESTRICT` instead.
 #[test_connector(exclude(Mysql56, Mysql57, Mariadb, Mssql, Vitess, CockroachDb))]
 fn on_delete_set_default_should_work(api: TestApi) {
     let dm = r#"
@@ -661,7 +662,8 @@ fn on_update_referential_actions_should_work(api: TestApi) {
 }
 
 // 5.6 and 5.7 doesn't let you `SET DEFAULT` without setting the default value
-// (even if nullable). Maria will silently just use `RESTRICT` instead.
+// (even if nullable). MySQL 8.0+ & MariaDB 10.0 allow you to create a table with
+// `SET DEFAULT`, but will silently use `NO ACTION` / `RESTRICT` instead.
 #[test_connector(exclude(Mysql56, Mysql57, Mariadb, Mssql, Vitess, CockroachDb))]
 fn on_update_set_default_should_work(api: TestApi) {
     let dm = r#"

--- a/psl/builtin-connectors/src/cockroach_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/cockroach_datamodel_connector.rs
@@ -7,7 +7,8 @@ use enumflags2::BitFlags;
 use lsp_types::{CompletionItem, CompletionItemKind, CompletionList};
 use psl_core::{
     datamodel_connector::{
-        Connector, ConnectorCapability, ConstraintScope, NativeTypeConstructor, NativeTypeInstance, StringFilter,
+        Connector, ConnectorCapability, ConstraintScope, NativeTypeConstructor, NativeTypeInstance, RelationMode,
+        StringFilter,
     },
     diagnostics::{DatamodelError, Diagnostics},
     parser_database::{
@@ -192,7 +193,7 @@ impl Connector for CockroachDatamodelConnector {
         }
     }
 
-    fn validate_model(&self, model: ModelWalker<'_>, diagnostics: &mut Diagnostics) {
+    fn validate_model(&self, model: ModelWalker<'_>, _: RelationMode, diagnostics: &mut Diagnostics) {
         validations::autoincrement_validations(model, diagnostics);
 
         for index in model.indexes() {

--- a/psl/builtin-connectors/src/mongodb.rs
+++ b/psl/builtin-connectors/src/mongodb.rs
@@ -59,7 +59,7 @@ impl Connector for MongoDbDatamodelConnector {
         BitFlags::empty()
     }
 
-    fn validate_model(&self, model: ModelWalker<'_>, errors: &mut Diagnostics) {
+    fn validate_model(&self, model: ModelWalker<'_>, _: RelationMode, errors: &mut Diagnostics) {
         validations::id_must_be_defined(model, errors);
 
         if let Some(pk) = model.primary_key() {

--- a/psl/builtin-connectors/src/mssql_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/mssql_datamodel_connector.rs
@@ -7,7 +7,9 @@ use connection_string::JdbcString;
 use enumflags2::BitFlags;
 use lsp_types::{CompletionItem, CompletionItemKind, CompletionList};
 use psl_core::{
-    datamodel_connector::{Connector, ConnectorCapability, ConstraintScope, NativeTypeConstructor, NativeTypeInstance},
+    datamodel_connector::{
+        Connector, ConnectorCapability, ConstraintScope, NativeTypeConstructor, NativeTypeInstance, RelationMode,
+    },
     diagnostics::{Diagnostics, Span},
     parser_database::{self, ast, ParserDatabase, ReferentialAction, ScalarType},
 };
@@ -228,7 +230,12 @@ impl Connector for MsSqlDatamodelConnector {
         }
     }
 
-    fn validate_model(&self, model: parser_database::walkers::ModelWalker<'_>, errors: &mut Diagnostics) {
+    fn validate_model(
+        &self,
+        model: parser_database::walkers::ModelWalker<'_>,
+        _: RelationMode,
+        errors: &mut Diagnostics,
+    ) {
         for index in model.indexes() {
             validations::index_uses_correct_field_types(self, index, errors);
         }

--- a/psl/builtin-connectors/src/mysql_datamodel_connector/validations.rs
+++ b/psl/builtin-connectors/src/mysql_datamodel_connector/validations.rs
@@ -114,17 +114,13 @@ pub(crate) fn uses_native_referential_action_set_default(
         )
     };
 
-    if let Some(on_delete) = field.explicit_on_delete() {
-        if on_delete == ReferentialAction::SetDefault {
-            let span = get_span("onDelete");
-            diagnostics.push_warning(DatamodelWarning::new(warning_msg(), span));
-        }
+    if let Some(ReferentialAction::SetDefault) = field.explicit_on_delete() {
+        let span = get_span("onDelete");
+        diagnostics.push_warning(DatamodelWarning::new(warning_msg(), span));
     }
 
-    if let Some(on_update) = field.explicit_on_update() {
-        if on_update == ReferentialAction::SetDefault {
-            let span = get_span("onUpdate");
-            diagnostics.push_warning(DatamodelWarning::new(warning_msg(), span));
-        }
+    if let Some(ReferentialAction::SetDefault) = field.explicit_on_update() {
+        let span = get_span("onUpdate");
+        diagnostics.push_warning(DatamodelWarning::new(warning_msg(), span));
     }
 }

--- a/psl/builtin-connectors/src/postgres_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/postgres_datamodel_connector.rs
@@ -8,7 +8,8 @@ use enumflags2::BitFlags;
 use lsp_types::{CompletionItem, CompletionItemKind, CompletionList, InsertTextFormat};
 use psl_core::{
     datamodel_connector::{
-        Connector, ConnectorCapability, ConstraintScope, NativeTypeConstructor, NativeTypeInstance, StringFilter,
+        Connector, ConnectorCapability, ConstraintScope, NativeTypeConstructor, NativeTypeInstance, RelationMode,
+        StringFilter,
     },
     diagnostics::Diagnostics,
     parser_database::{ast, walkers, IndexAlgorithm, OperatorClass, ParserDatabase, ReferentialAction, ScalarType},
@@ -361,7 +362,7 @@ impl Connector for PostgresDatamodelConnector {
         }
     }
 
-    fn validate_model(&self, model: walkers::ModelWalker<'_>, errors: &mut Diagnostics) {
+    fn validate_model(&self, model: walkers::ModelWalker<'_>, _: RelationMode, errors: &mut Diagnostics) {
         for index in model.indexes() {
             validations::compatible_native_types(index, self, errors);
             validations::generalized_index_validations(index, self, errors);

--- a/psl/diagnostics/src/collection.rs
+++ b/psl/diagnostics/src/collection.rs
@@ -62,6 +62,17 @@ impl Diagnostics {
 
         String::from_utf8_lossy(&message).into_owned()
     }
+
+    pub fn warnings_to_pretty_string(&self, file_name: &str, datamodel_string: &str) -> String {
+        let mut message: Vec<u8> = Vec::new();
+
+        for warn in self.warnings() {
+            warn.pretty_print(&mut message, file_name, datamodel_string)
+                .expect("printing datamodel warning");
+        }
+
+        String::from_utf8_lossy(&message).into_owned()
+    }
 }
 
 impl From<DatamodelError> for Diagnostics {

--- a/psl/diagnostics/src/warning.rs
+++ b/psl/diagnostics/src/warning.rs
@@ -14,7 +14,9 @@ pub struct DatamodelWarning {
 }
 
 impl DatamodelWarning {
-    fn new(message: String, span: Span) -> DatamodelWarning {
+    /// You should avoid using this constructor directly when possible, and define warnings as public methods of this class.
+    /// The constructor is only left public for supporting connector-specific warnings (which should not live in the core).
+    pub fn new(message: String, span: Span) -> DatamodelWarning {
         DatamodelWarning { message, span }
     }
 

--- a/psl/psl-core/src/datamodel_connector.rs
+++ b/psl/psl-core/src/datamodel_connector.rs
@@ -148,7 +148,7 @@ pub trait Connector: Send + Sync {
     }
 
     fn validate_enum(&self, _enum: walkers::EnumWalker<'_>, _: &mut Diagnostics) {}
-    fn validate_model(&self, _model: walkers::ModelWalker<'_>, _: &mut Diagnostics) {}
+    fn validate_model(&self, _model: walkers::ModelWalker<'_>, _: RelationMode, _: &mut Diagnostics) {}
     fn validate_datasource(&self, _: BitFlags<PreviewFeature>, _: &Datasource, _: &mut Diagnostics) {}
 
     fn validate_scalar_field_unknown_default_functions(

--- a/psl/psl-core/src/validate/validation_pipeline/validations/models.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/models.rs
@@ -240,7 +240,7 @@ pub(crate) fn primary_key_connector_specific(model: ModelWalker<'_>, ctx: &mut C
 }
 
 pub(super) fn connector_specific(model: ModelWalker<'_>, ctx: &mut Context<'_>) {
-    ctx.connector.validate_model(model, ctx.diagnostics)
+    ctx.connector.validate_model(model, ctx.relation_mode, ctx.diagnostics)
 }
 
 pub(super) fn id_has_fields(model: ModelWalker<'_>, ctx: &mut Context<'_>) {

--- a/psl/psl/tests/validation/mysql/set_default_no_warning_when_relation_mode_prisma.prisma
+++ b/psl/psl/tests/validation/mysql/set_default_no_warning_when_relation_mode_prisma.prisma
@@ -1,6 +1,5 @@
 generator client {
     provider = "prisma-client-js"
-    previewFeatures = ["referentialIntegrity"]
 }
 
 datasource db {

--- a/psl/psl/tests/validation/mysql/set_default_no_warning_when_relation_mode_prisma.prisma
+++ b/psl/psl/tests/validation/mysql/set_default_no_warning_when_relation_mode_prisma.prisma
@@ -1,0 +1,33 @@
+generator client {
+    provider = "prisma-client-js"
+    previewFeatures = ["referentialIntegrity"]
+}
+
+datasource db {
+    provider = "mysql"
+    url = "mysql://"
+    relationMode = "prisma"
+}
+
+model A {
+    id Int @id
+    bs B[]
+}
+
+model B {
+    id Int   @id
+    aId Int? @default(3)
+    a   A?   @relation(fields: [aId], references: [id], onUpdate: SetDefault, onDelete: SetDefault)
+}
+// [1;91merror[0m: [1mError validating: Invalid referential action: `SetDefault`. Allowed values: (`Cascade`, `Restrict`, `NoAction`, `SetNull`)[0m
+//   [1;94m-->[0m  [4mschema.prisma:20[0m
+// [1;94m   | [0m
+// [1;94m19 | [0m    aId Int? @default(3)
+// [1;94m20 | [0m    a   A?   @relation(fields: [aId], references: [id], onUpdate: SetDefault, [1;91monDelete: SetDefault[0m)
+// [1;94m   | [0m
+// [1;91merror[0m: [1mError validating: Invalid referential action: `SetDefault`. Allowed values: (`Cascade`, `Restrict`, `NoAction`, `SetNull`)[0m
+//   [1;94m-->[0m  [4mschema.prisma:20[0m
+// [1;94m   | [0m
+// [1;94m19 | [0m    aId Int? @default(3)
+// [1;94m20 | [0m    a   A?   @relation(fields: [aId], references: [id], [1;91monUpdate: SetDefault[0m, onDelete: SetDefault)
+// [1;94m   | [0m

--- a/psl/psl/tests/validation/mysql/set_default_no_warning_when_relation_mode_prisma.prisma
+++ b/psl/psl/tests/validation/mysql/set_default_no_warning_when_relation_mode_prisma.prisma
@@ -19,14 +19,14 @@ model B {
     a   A?   @relation(fields: [aId], references: [id], onUpdate: SetDefault, onDelete: SetDefault)
 }
 // [1;91merror[0m: [1mError validating: Invalid referential action: `SetDefault`. Allowed values: (`Cascade`, `Restrict`, `NoAction`, `SetNull`)[0m
-//   [1;94m-->[0m  [4mschema.prisma:20[0m
+//   [1;94m-->[0m  [4mschema.prisma:19[0m
 // [1;94m   | [0m
-// [1;94m19 | [0m    aId Int? @default(3)
-// [1;94m20 | [0m    a   A?   @relation(fields: [aId], references: [id], onUpdate: SetDefault, [1;91monDelete: SetDefault[0m)
+// [1;94m18 | [0m    aId Int? @default(3)
+// [1;94m19 | [0m    a   A?   @relation(fields: [aId], references: [id], onUpdate: SetDefault, [1;91monDelete: SetDefault[0m)
 // [1;94m   | [0m
 // [1;91merror[0m: [1mError validating: Invalid referential action: `SetDefault`. Allowed values: (`Cascade`, `Restrict`, `NoAction`, `SetNull`)[0m
-//   [1;94m-->[0m  [4mschema.prisma:20[0m
+//   [1;94m-->[0m  [4mschema.prisma:19[0m
 // [1;94m   | [0m
-// [1;94m19 | [0m    aId Int? @default(3)
-// [1;94m20 | [0m    a   A?   @relation(fields: [aId], references: [id], [1;91monUpdate: SetDefault[0m, onDelete: SetDefault)
+// [1;94m18 | [0m    aId Int? @default(3)
+// [1;94m19 | [0m    a   A?   @relation(fields: [aId], references: [id], [1;91monUpdate: SetDefault[0m, onDelete: SetDefault)
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/mysql/set_default_warning.prisma
+++ b/psl/psl/tests/validation/mysql/set_default_warning.prisma
@@ -1,0 +1,27 @@
+datasource db {
+    provider = "mysql"
+    url = "mysql://"
+}
+
+model A {
+    id Int @id
+    bs B[]
+}
+
+model B {
+    id Int   @id
+    aId Int? @default(3)
+    a   A?   @relation(fields: [aId], references: [id], onUpdate: SetDefault, onDelete: SetDefault)
+}
+// [1;93mwarning[0m: [1mUsing SetDefault on MySQL may yield to unexpected results, as the database will silently change the referential action to `NoAction`.[0m
+//   [1;94m-->[0m  [4mschema.prisma:14[0m
+// [1;94m   | [0m
+// [1;94m13 | [0m    aId Int? @default(3)
+// [1;94m14 | [0m    a   A?   @relation(fields: [aId], references: [id], onUpdate: SetDefault, [1;93monDelete: SetDefault[0m)
+// [1;94m   | [0m
+// [1;93mwarning[0m: [1mUsing SetDefault on MySQL may yield to unexpected results, as the database will silently change the referential action to `NoAction`.[0m
+//   [1;94m-->[0m  [4mschema.prisma:14[0m
+// [1;94m   | [0m
+// [1;94m13 | [0m    aId Int? @default(3)
+// [1;94m14 | [0m    a   A?   @relation(fields: [aId], references: [id], [1;93monUpdate: SetDefault[0m, onDelete: SetDefault)
+// [1;94m   | [0m

--- a/psl/psl/tests/validation/mysql/set_default_warning_when_relation_mode_foreignkeys.prisma
+++ b/psl/psl/tests/validation/mysql/set_default_warning_when_relation_mode_foreignkeys.prisma
@@ -1,6 +1,5 @@
 generator client {
     provider = "prisma-client-js"
-    previewFeatures = ["referentialIntegrity"]
 }
 
 datasource db {

--- a/psl/psl/tests/validation/mysql/set_default_warning_when_relation_mode_foreignkeys.prisma
+++ b/psl/psl/tests/validation/mysql/set_default_warning_when_relation_mode_foreignkeys.prisma
@@ -1,0 +1,33 @@
+generator client {
+    provider = "prisma-client-js"
+    previewFeatures = ["referentialIntegrity"]
+}
+
+datasource db {
+    provider = "mysql"
+    url = "mysql://"
+    relationMode = "foreignKeys"
+}
+
+model A {
+    id Int @id
+    bs B[]
+}
+
+model B {
+    id Int   @id
+    aId Int? @default(3)
+    a   A?   @relation(fields: [aId], references: [id], onUpdate: SetDefault, onDelete: SetDefault)
+}
+// [1;93mwarning[0m: [1mUsing SetDefault on MySQL may yield to unexpected results, as the database will silently change the referential action to `NoAction`.[0m
+//   [1;94m-->[0m  [4mschema.prisma:20[0m
+// [1;94m   | [0m
+// [1;94m19 | [0m    aId Int? @default(3)
+// [1;94m20 | [0m    a   A?   @relation(fields: [aId], references: [id], onUpdate: SetDefault, [1;93monDelete: SetDefault[0m)
+// [1;94m   | [0m
+// [1;93mwarning[0m: [1mUsing SetDefault on MySQL may yield to unexpected results, as the database will silently change the referential action to `NoAction`.[0m
+//   [1;94m-->[0m  [4mschema.prisma:20[0m
+// [1;94m   | [0m
+// [1;94m19 | [0m    aId Int? @default(3)
+// [1;94m20 | [0m    a   A?   @relation(fields: [aId], references: [id], [1;93monUpdate: SetDefault[0m, onDelete: SetDefault)
+// [1;94m   | [0m

--- a/psl/psl/tests/validation/mysql/set_default_warning_when_relation_mode_foreignkeys.prisma
+++ b/psl/psl/tests/validation/mysql/set_default_warning_when_relation_mode_foreignkeys.prisma
@@ -19,14 +19,14 @@ model B {
     a   A?   @relation(fields: [aId], references: [id], onUpdate: SetDefault, onDelete: SetDefault)
 }
 // [1;93mwarning[0m: [1mUsing SetDefault on MySQL may yield to unexpected results, as the database will silently change the referential action to `NoAction`.[0m
-//   [1;94m-->[0m  [4mschema.prisma:20[0m
+//   [1;94m-->[0m  [4mschema.prisma:19[0m
 // [1;94m   | [0m
-// [1;94m19 | [0m    aId Int? @default(3)
-// [1;94m20 | [0m    a   A?   @relation(fields: [aId], references: [id], onUpdate: SetDefault, [1;93monDelete: SetDefault[0m)
+// [1;94m18 | [0m    aId Int? @default(3)
+// [1;94m19 | [0m    a   A?   @relation(fields: [aId], references: [id], onUpdate: SetDefault, [1;93monDelete: SetDefault[0m)
 // [1;94m   | [0m
 // [1;93mwarning[0m: [1mUsing SetDefault on MySQL may yield to unexpected results, as the database will silently change the referential action to `NoAction`.[0m
-//   [1;94m-->[0m  [4mschema.prisma:20[0m
+//   [1;94m-->[0m  [4mschema.prisma:19[0m
 // [1;94m   | [0m
-// [1;94m19 | [0m    aId Int? @default(3)
-// [1;94m20 | [0m    a   A?   @relation(fields: [aId], references: [id], [1;93monUpdate: SetDefault[0m, onDelete: SetDefault)
+// [1;94m18 | [0m    aId Int? @default(3)
+// [1;94m19 | [0m    a   A?   @relation(fields: [aId], references: [id], [1;93monUpdate: SetDefault[0m, onDelete: SetDefault)
 // [1;94m   | [0m


### PR DESCRIPTION
Context: see [internal Notion document](https://www.notion.so/prismaio/SetDefault-referential-action-on-MySQL-68d7bdbe6fc947cf8829d7ca7dc2b001)

Closes https://github.com/prisma/prisma/issues/16259.

- [x] test validation
- [x] test introspection
- [x] test migration

**TODOs** (which do not block the PR):
- [ ] agree on the warning message