### PR TITLE
nix: try flake-parts

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -43,6 +43,26 @@
         "type": "github"
       }
     },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1668450977,
+        "narHash": "sha256-cfLhMhnvXn6x1vPm+Jow3RiFAUSCw/l1utktCw5rVA4=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "d591857e9d7dd9ddbfba0ea02b43b927c3c0f1fa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
         "lastModified": 1667395993,
@@ -76,6 +96,7 @@
     "root": {
       "inputs": {
         "crane": "crane",
+        "flake-parts": "flake-parts",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"

--- a/flake.nix
+++ b/flake.nix
@@ -3,10 +3,14 @@
     crane = {
       url = "github:ipetkov/crane";
       inputs.nixpkgs.follows = "nixpkgs";
-      inputs.flake-utils.follows = "flake-utils";
       inputs.rust-overlay.follows = "rust-overlay";
+      inputs.flake-utils.follows = "flake-utils";
     };
     flake-utils.url = "github:numtide/flake-utils";
+    flake-parts = {
+      url = "github:hercules-ci/flake-parts";
+      inputs.nixpkgs-lib.follows = "nixpkgs";
+    };
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -15,83 +19,17 @@
     nixpkgs.url = "nixpkgs/nixos-unstable";
   };
 
-  outputs = { self, nixpkgs, rust-overlay, flake-utils, crane }:
-    flake-utils.lib.eachDefaultSystem
-      (system:
-        let
-          overlays = [
-            rust-overlay.overlays.default
-            (self: super:
-              let toolchain = pkgs.rust-bin.stable.latest; in
-              { cargo = toolchain.minimal; rustc = toolchain.minimal; rustToolchain = toolchain; })
-          ];
-          pkgs = import nixpkgs { inherit system overlays; };
-          craneLib = crane.mkLib pkgs;
-
-          src =
-            let
-              enginesSourceFilter = path: type: (builtins.match "\\.pest$" path != null) ||
-                (builtins.match "\\.README.md$" path != null) ||
-                (builtins.match "^\\.git/HEAD" path != null) ||
-                (builtins.match "^\\.git/refs" path != null) ||
-                (craneLib.filterCargoSources path type != null);
-            in
-            lib.cleanSourceWith {
-              filter = enginesSourceFilter;
-              src = builtins.path {
-                path = ./.;
-                name = "prisma-engines-workspace-root-path";
-              };
-            };
-
-          prismaEnginesCommonArgs =
-            let
-              excludeFlags = [
-                "--workspace"
-                "--exclude mongodb-introspection-connector" # requires running mongo
-                "--exclude mongodb-migration-connector" # requires running mongo
-                "--exclude query-engine-tests" # too slow to compile
-                "--exclude query-tests-setup" # too slow to compile
-                "--exclude query-test-macros" # too slow to compile
-              ];
-            in
-            {
-              pname = "prisma-engines";
-              version = "0.1.0";
-
-              inherit src;
-
-              buildInputs = [ pkgs.openssl ];
-
-              nativeBuildInputs = with pkgs; [
-                git # for our build scripts that bake in the git hash
-                perl # for openssl-sys
-                pkg-config
-                protobuf # for tonic
-              ];
-
-              cargoBuildCommand = "cargo build --release ${builtins.toString excludeFlags}";
-              cargoCheckCommand = "cargo check --all-features ${builtins.toString excludeFlags}";
-              cargoTestCommand = "TEST_DATABASE_URL=sqlite RUST_LOG=debug cargo test ${builtins.toString excludeFlags}";
-            };
-
-          prisma-engines-deps = craneLib.buildDepsOnly prismaEnginesCommonArgs;
-
-          prisma-fmt-wasm = import ./prisma-fmt-wasm { inherit craneLib pkgs system src; };
-
-          inherit (pkgs) lib;
-        in
-        {
-          packages = {
-            prisma-engines = craneLib.buildPackage (prismaEnginesCommonArgs // { cargoArtifacts = prisma-engines-deps; });
-          } // prisma-fmt-wasm.packages;
-
-          checks = prisma-fmt-wasm.checks;
-
-          devShells.default = pkgs.mkShell {
-            packages = [ (pkgs.rustToolchain.default.override { extensions = [ "rust-analyzer" "rust-src" ]; }) ];
-            inputsFrom = [ prisma-engines-deps ];
-          };
-        }
-      );
+  outputs = inputs@{ self, nixpkgs, rust-overlay, flake-parts, crane, ... }:
+    flake-parts.lib.mkFlake { inherit self; } {
+      systems = [ "x86_64-linux" ];
+      perSystem = { config, system, pkgs, craneLib, ... }: {
+        config._module.args.inputs = inputs;
+        imports = [
+          ./nix/all-engines.nix
+          ./nix/args.nix
+          ./nix/shell.nix
+          ./prisma-fmt-wasm
+        ];
+      };
+    };
 }

--- a/nix/all-engines.nix
+++ b/nix/all-engines.nix
@@ -1,0 +1,35 @@
+{ craneLib, pkgs, ... }:
+
+let
+  enginesSourceFilter = path: type: (builtins.match "\\.pest$" path != null) ||
+    (builtins.match "\\.README.md$" path != null) ||
+    (builtins.match "^\\.git/HEAD" path != null) ||
+    (builtins.match "^\\.git/refs" path != null) ||
+    (craneLib.filterCargoSources path type != null);
+  src = pkgs.lib.cleanSourceWith {
+    filter = enginesSourceFilter;
+    src = builtins.path {
+      path = ../.;
+      name = "prisma-engines-workspace-root-path";
+    };
+  };
+
+  craneArgs = {
+    pname = "prisma-engines";
+    version = "0.1.0";
+    buildInputs = [ pkgs.openssl ];
+    cargoExtraArgs = "--workspace --all-features --bins";
+    nativeBuildInputs = with pkgs; [
+      git # for our build scripts that bake in the git hash
+      perl # for openssl-sys
+      pkg-config
+      protobuf # for tonic
+    ];
+    doCheck = false;
+    inherit src;
+  };
+in
+  {
+    packages.prisma-engines-deps = craneLib.buildDepsOnly craneArgs;
+    packages.prisma-engines = craneLib.buildPackage craneArgs;
+  }

--- a/nix/args.nix
+++ b/nix/args.nix
@@ -1,0 +1,17 @@
+{ inputs, system, ... }:
+{
+  config._module.args =
+    let
+      overlays = [
+        inputs.rust-overlay.overlays.default
+        (self: super:
+          let toolchain = super.rust-bin.stable.latest; in
+          { cargo = toolchain.minimal; rustc = toolchain.minimal; rustToolchain = toolchain; })
+      ];
+
+      pkgs = import inputs.nixpkgs { inherit system overlays; };
+
+      craneLib = inputs.crane.mkLib pkgs;
+    in
+    { inherit craneLib pkgs; };
+}

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,0 +1,8 @@
+{ config, pkgs, ... }:
+
+{
+  devShells.default = pkgs.mkShell {
+    packages = [ (pkgs.rustToolchain.default.override { extensions = [ "rust-analyzer" "rust-src" ]; }) ];
+    inputsFrom = [ config.packages.prisma-engines-deps ];
+  };
+}

--- a/prisma-fmt-wasm/default.nix
+++ b/prisma-fmt-wasm/default.nix
@@ -1,59 +1,53 @@
-args@{ pkgs, system, src, ... }:
+args@{ pkgs, system, craneLib, ... }:
 
 let
   toolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
   craneLib = args.craneLib.overrideToolchain toolchain;
 
-  inherit (pkgs) jq nodejs coreutils rustPlatform wasm-bindgen-cli;
+  inherit (pkgs) jq nodejs coreutils wasm-bindgen-cli;
   inherit (builtins) readFile replaceStrings;
 in
 rec {
-  packages = {
-    prisma-fmt-wasm = craneLib.buildPackage {
-      pname = "prisma-fmt-wasm";
-      version = "0.1.0";
+  packages.prisma-fmt-wasm = craneLib.buildPackage {
+    pname = "prisma-fmt-wasm";
+    version = "0.1.0";
 
-      nativeBuildInputs = with pkgs; [ git wasm-bindgen-cli ];
+    src = ../.;
+    nativeBuildInputs = with pkgs; [ git wasm-bindgen-cli ];
 
-      cargoBuildCommand = "cargo build --release --target=wasm32-unknown-unknown --manifest-path=prisma-fmt-wasm/Cargo.toml";
-      cargoCheckCommand = "cargo check --target=wasm32-unknown-unknown --manifest-path=prisma-fmt-wasm/Cargo.toml";
-      doCheck = false; # do not run cargo test
-      cargoArtifacts = null; # do not cache dependencies
+    cargoBuildCommand = "cargo build --release --target=wasm32-unknown-unknown --manifest-path=prisma-fmt-wasm/Cargo.toml";
+    cargoCheckCommand = "cargo check --target=wasm32-unknown-unknown --manifest-path=prisma-fmt-wasm/Cargo.toml";
+    cargoArtifacts = null; # do not cache dependencies
+    doCheck = false; # do not run tests
+    installPhase = readFile ./scripts/install.sh;
+  };
 
-      installPhase = readFile ./scripts/install.sh;
+  # Takes a package version as its single argument, and produces
+  # prisma-fmt-wasm with the right package.json in a temporary directory,
+  # then prints the directory's path. This is used by the publish pipeline in CI.
+  packages.renderPrismaFmtWasmPackage =
+    pkgs.writeShellApplication {
+      name = "renderPrismaFmtWasmPackage";
+      runtimeInputs = [ jq ];
+      text = ''
+        set -euxo pipefail
 
-      inherit src;
+        PACKAGE_DIR=$(mktemp -d)
+        cp -r --no-target-directory ${packages.prisma-fmt-wasm} "$PACKAGE_DIR"
+        rm -f "$PACKAGE_DIR/package.json"
+        jq ".version = \"$1\"" ${packages.prisma-fmt-wasm}/package.json > "$PACKAGE_DIR/package.json"
+        echo "$PACKAGE_DIR"
+      '';
     };
 
-    # Takes a package version as its single argument, and produces
-    # prisma-fmt-wasm with the right package.json in a temporary directory,
-    # then prints the directory's path. This is used by the publish pipeline in CI.
-    renderPrismaFmtWasmPackage =
-      pkgs.writeShellApplication {
-        name = "renderPrismaFmtWasmPackage";
-        runtimeInputs = [ jq ];
-        text = ''
-          set -euxo pipefail
+  packages.syncWasmBindgenVersions = let template = readFile ./scripts/syncWasmBindgenVersions.sh; in
+    pkgs.writeShellApplication {
+      name = "syncWasmBindgenVersions";
+      runtimeInputs = [ coreutils toolchain ];
+      text = replaceStrings [ "$WASM_BINDGEN_VERSION" ] [ wasm-bindgen-cli.version ] template;
+    };
 
-          PACKAGE_DIR=$(mktemp -d)
-          cp -r --no-target-directory ${packages.prisma-fmt-wasm} "$PACKAGE_DIR"
-          rm -f "$PACKAGE_DIR/package.json"
-          jq ".version = \"$1\"" ${packages.prisma-fmt-wasm}/package.json > "$PACKAGE_DIR/package.json"
-          echo "$PACKAGE_DIR"
-        '';
-      };
-
-    syncWasmBindgenVersions = let template = readFile ./scripts/syncWasmBindgenVersions.sh; in
-      pkgs.writeShellApplication {
-        name = "syncWasmBindgenVersions";
-        runtimeInputs = [ coreutils ];
-        text = replaceStrings [ "$WASM_BINDGEN_VERSION" ] [ wasm-bindgen-cli.version ] template;
-      };
-  };
-
-  checks = {
-    prismaFmtWasmE2E = pkgs.runCommand "prismaFmtWasmE2E"
-      { PRISMA_FMT_WASM = packages.prisma-fmt-wasm; NODE = "${nodejs}/bin/node"; }
-      (readFile ./scripts/check.sh);
-  };
+  checks.prismaFmtWasmE2E = pkgs.runCommand "prismaFmtWasmE2E"
+    { PRISMA_FMT_WASM = packages.prisma-fmt-wasm; NODE = "${nodejs}/bin/node"; }
+    (readFile ./scripts/check.sh);
 }


### PR DESCRIPTION
https://github.com/hercules-ci/flake-parts/

- The library is small, and the main value proposition is the modules system, that many/most nix users are already very familiar with from home-manager/nixos configuration.
- Gluing different projects in a repo together becomes standardized, and not manual like what I had implemented for prisma-fmt-wasm.
- The modules are more composable and easier to isolate in smaller files. We can add more options to the modules if we want.
- The config options are typed and validated.