### PR TITLE
feat(psl): downgraded error to warning when using SetNull on non-nullable referenced field on Postgres with relationMode="foreignKeys"

### DIFF
--- a/psl/builtin-connectors/src/postgres_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/postgres_datamodel_connector.rs
@@ -267,6 +267,12 @@ impl Connector for PostgresDatamodelConnector {
         Restrict | SetNull | Cascade
     }
 
+    /// Postgres accepts table definitions with a SET NULL referential action referencing a non-nullable field,
+    /// although that would lead to a runtime error once the action is actually triggered.
+    fn allows_set_null_referential_action_on_non_nullable_fields(&self, relation_mode: RelationMode) -> bool {
+        relation_mode.uses_foreign_keys()
+    }
+
     fn scalar_type_for_native_type(&self, native_type: &NativeTypeInstance) -> ScalarType {
         let native_type: &PostgresType = native_type.downcast_ref();
 

--- a/psl/psl-core/src/datamodel_connector.rs
+++ b/psl/psl-core/src/datamodel_connector.rs
@@ -88,6 +88,15 @@ pub trait Connector: Send + Sync {
         RelationMode::allowed_emulated_referential_actions_default()
     }
 
+    /// Most SQL databases reject table definitions with a SET NULL referential action referencing a non-nullable field,
+    /// but that's not true for all of them.
+    /// This was introduced because Postgres accepts data definition language statements with the SET NULL
+    /// referential action referencing non-nullable fields, although this would lead to a runtime error once
+    /// the action is actually triggered.
+    fn allows_set_null_referential_action_on_non_nullable_fields(&self, _relation_mode: RelationMode) -> bool {
+        false
+    }
+
     fn supports_composite_types(&self) -> bool {
         self.has_capability(ConnectorCapability::CompositeTypes)
     }

--- a/psl/psl-core/src/validate/validation_pipeline/validations/relations.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/relations.rs
@@ -557,7 +557,7 @@ pub(crate) fn required_relation_cannot_use_set_null(relation: InlineRelationWalk
             let set_null = ReferentialAction::SetNull.as_str();
             let msg = formatdoc! {r#"
                 The `{referential_action_type}` referential action of a relation should not be set to `{set_null}` when a referenced field is required.
-                We recommend to either choose another referential action, or make the referenced fields optional.
+                We recommend either to choose another referential action, or to make the referenced fields optional.
             "#};
             msg
         };

--- a/psl/psl-core/src/validate/validation_pipeline/validations/relations.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/relations.rs
@@ -556,8 +556,8 @@ pub(crate) fn required_relation_cannot_use_set_null(relation: InlineRelationWalk
         let warning_template = |referential_action_type: &str| {
             let set_null = ReferentialAction::SetNull.as_str();
             let msg = formatdoc! {r#"
-                The `{referential_action_type}` referential action of a relation must not be set to `{set_null}` when a referenced field is required.
-                Either choose another referential action, or make the referenced fields optional.
+                The `{referential_action_type}` referential action of a relation should not be set to `{set_null}` when a referenced field is required.
+                We recommend to either choose another referential action, or make the referenced fields optional.
             "#};
             msg
         };

--- a/psl/psl-core/src/validate/validation_pipeline/validations/relations.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/relations.rs
@@ -556,8 +556,7 @@ pub(crate) fn required_relation_cannot_use_set_null(relation: InlineRelationWalk
         let warning_template = |referential_action_type: &str| {
             let set_null = ReferentialAction::SetNull.as_str();
             let msg = formatdoc! {r#"
-                The `{referential_action_type}` referential action of a relation should not be set to `{set_null}` when a referenced field is required.
-                We recommend either to choose another referential action, or to make the referenced fields optional.
+                The `{referential_action_type}` referential action of a relation should not be set to `{set_null}` when a referenced field is required. We recommend either to choose another referential action, or to make the referenced fields optional. Read more at https://pris.ly/d/postgres-set-null
             "#};
             msg
         };

--- a/psl/psl/tests/validation/mysql/set_default_no_warning_when_relation_mode_prisma.prisma
+++ b/psl/psl/tests/validation/mysql/set_default_no_warning_when_relation_mode_prisma.prisma
@@ -18,6 +18,14 @@ model B {
     aId Int? @default(3)
     a   A?   @relation(fields: [aId], references: [id], onUpdate: SetDefault, onDelete: SetDefault)
 }
+// [1;93mwarning[0m: [1mWith `relationMode = \"prisma\"`, no foreign keys are used, so relation fields will not benefit from the index usually created by the relational database under the hood.
+// This can lead to poor performance when querying these fields. We recommend adding an index manually.
+// Learn more at https://pris.ly/d/relation-mode#indexes[0m
+//   [1;94m-->[0m  [4mschema.prisma:19[0m
+// [1;94m   | [0m
+// [1;94m18 | [0m    aId Int? @default(3)
+// [1;94m19 | [0m    a   A?   [1;93m@relation(fields: [aId], references: [id], onUpdate: SetDefault, onDelete: SetDefault)[0m
+// [1;94m   | [0m
 // [1;91merror[0m: [1mError validating: Invalid referential action: `SetDefault`. Allowed values: (`Cascade`, `Restrict`, `NoAction`, `SetNull`)[0m
 //   [1;94m-->[0m  [4mschema.prisma:19[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/relations/postgres/set_null_is_not_valid_on_mixed_fields_when_relation_mode_prisma.prisma
+++ b/psl/psl/tests/validation/relations/postgres/set_null_is_not_valid_on_mixed_fields_when_relation_mode_prisma.prisma
@@ -1,0 +1,40 @@
+datasource db {
+  provider     = "postgresql"
+  url          = env("DATABASE_URL")
+  relationMode = "prisma"
+}
+
+model SomeUser {
+  id      Int      @id
+  ref     Int
+  profile Profile?
+
+  @@unique([id, ref])
+}
+
+model Profile {
+  id       Int       @id
+  user     SomeUser? @relation(fields: [user_id, user_ref], references: [id, ref], onUpdate: SetNull, onDelete: SetNull)
+  user_id  Int?
+  user_ref Int
+
+  @@unique([user_id, user_ref])
+}
+// [1;91merror[0m: [1mError parsing attribute "@relation": The `onDelete` referential action of a relation must not be set to `SetNull` when a referenced field is required.
+// Either choose another referential action, or make the referenced fields optional.
+// [0m
+//   [1;94m-->[0m  [4mschema.prisma:17[0m
+// [1;94m   | [0m
+// [1;94m16 | [0m  id       Int       @id
+// [1;94m17 | [0m  [1;91muser     SomeUser? @relation(fields: [user_id, user_ref], references: [id, ref], onUpdate: SetNull, onDelete: SetNull)[0m
+// [1;94m18 | [0m  user_id  Int?
+// [1;94m   | [0m
+// [1;91merror[0m: [1mError parsing attribute "@relation": The `onUpdate` referential action of a relation must not be set to `SetNull` when a referenced field is required.
+// Either choose another referential action, or make the referenced fields optional.
+// [0m
+//   [1;94m-->[0m  [4mschema.prisma:17[0m
+// [1;94m   | [0m
+// [1;94m16 | [0m  id       Int       @id
+// [1;94m17 | [0m  [1;91muser     SomeUser? @relation(fields: [user_id, user_ref], references: [id, ref], onUpdate: SetNull, onDelete: SetNull)[0m
+// [1;94m18 | [0m  user_id  Int?
+// [1;94m   | [0m

--- a/psl/psl/tests/validation/relations/postgres/set_null_is_not_valid_on_required_fields_when_relation_mode_prisma.prisma
+++ b/psl/psl/tests/validation/relations/postgres/set_null_is_not_valid_on_required_fields_when_relation_mode_prisma.prisma
@@ -1,0 +1,34 @@
+datasource db {
+  provider     = "postgresql"
+  url          = env("DATABASE_URL")
+  relationMode = "prisma"
+}
+
+model SomeUser {
+  id      Int      @id
+  profile Profile?
+}
+
+model Profile {
+  id      Int       @id
+  user    SomeUser? @relation(fields: [user_id], references: [id], onUpdate: SetNull, onDelete: SetNull)
+  user_id Int       @unique
+}
+// [1;91merror[0m: [1mError parsing attribute "@relation": The `onDelete` referential action of a relation must not be set to `SetNull` when a referenced field is required.
+// Either choose another referential action, or make the referenced fields optional.
+// [0m
+//   [1;94m-->[0m  [4mschema.prisma:14[0m
+// [1;94m   | [0m
+// [1;94m13 | [0m  id      Int       @id
+// [1;94m14 | [0m  [1;91muser    SomeUser? @relation(fields: [user_id], references: [id], onUpdate: SetNull, onDelete: SetNull)[0m
+// [1;94m15 | [0m  user_id Int       @unique
+// [1;94m   | [0m
+// [1;91merror[0m: [1mError parsing attribute "@relation": The `onUpdate` referential action of a relation must not be set to `SetNull` when a referenced field is required.
+// Either choose another referential action, or make the referenced fields optional.
+// [0m
+//   [1;94m-->[0m  [4mschema.prisma:14[0m
+// [1;94m   | [0m
+// [1;94m13 | [0m  id      Int       @id
+// [1;94m14 | [0m  [1;91muser    SomeUser? @relation(fields: [user_id], references: [id], onUpdate: SetNull, onDelete: SetNull)[0m
+// [1;94m15 | [0m  user_id Int       @unique
+// [1;94m   | [0m

--- a/psl/psl/tests/validation/relations/postgres/set_null_warns_on_mixed_fields.prisma
+++ b/psl/psl/tests/validation/relations/postgres/set_null_warns_on_mixed_fields.prisma
@@ -19,8 +19,8 @@ model Profile {
 
   @@unique([user_id, user_ref])
 }
-// [1;93mwarning[0m: [1mThe `onDelete` referential action of a relation must not be set to `SetNull` when a referenced field is required.
-// Either choose another referential action, or make the referenced fields optional.
+// [1;93mwarning[0m: [1mThe `onDelete` referential action of a relation should not be set to `SetNull` when a referenced field is required.
+// We recommend to either choose another referential action, or make the referenced fields optional.
 // [0m
 //   [1;94m-->[0m  [4mschema.prisma:16[0m
 // [1;94m   | [0m
@@ -28,8 +28,8 @@ model Profile {
 // [1;94m16 | [0m  [1;93muser     SomeUser? @relation(fields: [user_id, user_ref], references: [id, ref], onUpdate: SetNull, onDelete: SetNull)[0m
 // [1;94m17 | [0m  user_id  Int?
 // [1;94m   | [0m
-// [1;93mwarning[0m: [1mThe `onUpdate` referential action of a relation must not be set to `SetNull` when a referenced field is required.
-// Either choose another referential action, or make the referenced fields optional.
+// [1;93mwarning[0m: [1mThe `onUpdate` referential action of a relation should not be set to `SetNull` when a referenced field is required.
+// We recommend to either choose another referential action, or make the referenced fields optional.
 // [0m
 //   [1;94m-->[0m  [4mschema.prisma:16[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/relations/postgres/set_null_warns_on_mixed_fields.prisma
+++ b/psl/psl/tests/validation/relations/postgres/set_null_warns_on_mixed_fields.prisma
@@ -19,8 +19,7 @@ model Profile {
 
   @@unique([user_id, user_ref])
 }
-// [1;93mwarning[0m: [1mThe `onDelete` referential action of a relation should not be set to `SetNull` when a referenced field is required.
-// We recommend either to choose another referential action, or to make the referenced fields optional.
+// [1;93mwarning[0m: [1mThe `onDelete` referential action of a relation should not be set to `SetNull` when a referenced field is required. We recommend either to choose another referential action, or to make the referenced fields optional. Read more at https://pris.ly/d/postgres-set-null
 // [0m
 //   [1;94m-->[0m  [4mschema.prisma:16[0m
 // [1;94m   | [0m
@@ -28,8 +27,7 @@ model Profile {
 // [1;94m16 | [0m  [1;93muser     SomeUser? @relation(fields: [user_id, user_ref], references: [id, ref], onUpdate: SetNull, onDelete: SetNull)[0m
 // [1;94m17 | [0m  user_id  Int?
 // [1;94m   | [0m
-// [1;93mwarning[0m: [1mThe `onUpdate` referential action of a relation should not be set to `SetNull` when a referenced field is required.
-// We recommend either to choose another referential action, or to make the referenced fields optional.
+// [1;93mwarning[0m: [1mThe `onUpdate` referential action of a relation should not be set to `SetNull` when a referenced field is required. We recommend either to choose another referential action, or to make the referenced fields optional. Read more at https://pris.ly/d/postgres-set-null
 // [0m
 //   [1;94m-->[0m  [4mschema.prisma:16[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/relations/postgres/set_null_warns_on_mixed_fields.prisma
+++ b/psl/psl/tests/validation/relations/postgres/set_null_warns_on_mixed_fields.prisma
@@ -1,0 +1,39 @@
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model SomeUser {
+  id      Int      @id
+  ref     Int
+  profile Profile?
+
+  @@unique([id, ref])
+}
+
+model Profile {
+  id       Int       @id
+  user     SomeUser? @relation(fields: [user_id, user_ref], references: [id, ref], onUpdate: SetNull, onDelete: SetNull)
+  user_id  Int?
+  user_ref Int
+
+  @@unique([user_id, user_ref])
+}
+// [1;93mwarning[0m: [1mThe `onDelete` referential action of a relation must not be set to `SetNull` when a referenced field is required.
+// Either choose another referential action, or make the referenced fields optional.
+// [0m
+//   [1;94m-->[0m  [4mschema.prisma:16[0m
+// [1;94m   | [0m
+// [1;94m15 | [0m  id       Int       @id
+// [1;94m16 | [0m  [1;93muser     SomeUser? @relation(fields: [user_id, user_ref], references: [id, ref], onUpdate: SetNull, onDelete: SetNull)[0m
+// [1;94m17 | [0m  user_id  Int?
+// [1;94m   | [0m
+// [1;93mwarning[0m: [1mThe `onUpdate` referential action of a relation must not be set to `SetNull` when a referenced field is required.
+// Either choose another referential action, or make the referenced fields optional.
+// [0m
+//   [1;94m-->[0m  [4mschema.prisma:16[0m
+// [1;94m   | [0m
+// [1;94m15 | [0m  id       Int       @id
+// [1;94m16 | [0m  [1;93muser     SomeUser? @relation(fields: [user_id, user_ref], references: [id, ref], onUpdate: SetNull, onDelete: SetNull)[0m
+// [1;94m17 | [0m  user_id  Int?
+// [1;94m   | [0m

--- a/psl/psl/tests/validation/relations/postgres/set_null_warns_on_mixed_fields.prisma
+++ b/psl/psl/tests/validation/relations/postgres/set_null_warns_on_mixed_fields.prisma
@@ -20,7 +20,7 @@ model Profile {
   @@unique([user_id, user_ref])
 }
 // [1;93mwarning[0m: [1mThe `onDelete` referential action of a relation should not be set to `SetNull` when a referenced field is required.
-// We recommend to either choose another referential action, or make the referenced fields optional.
+// We recommend either to choose another referential action, or to make the referenced fields optional.
 // [0m
 //   [1;94m-->[0m  [4mschema.prisma:16[0m
 // [1;94m   | [0m
@@ -29,7 +29,7 @@ model Profile {
 // [1;94m17 | [0m  user_id  Int?
 // [1;94m   | [0m
 // [1;93mwarning[0m: [1mThe `onUpdate` referential action of a relation should not be set to `SetNull` when a referenced field is required.
-// We recommend to either choose another referential action, or make the referenced fields optional.
+// We recommend either to choose another referential action, or to make the referenced fields optional.
 // [0m
 //   [1;94m-->[0m  [4mschema.prisma:16[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/relations/postgres/set_null_warns_on_required_fields.prisma
+++ b/psl/psl/tests/validation/relations/postgres/set_null_warns_on_required_fields.prisma
@@ -14,7 +14,7 @@ model Profile {
   user_id Int       @unique
 }
 // [1;93mwarning[0m: [1mThe `onDelete` referential action of a relation should not be set to `SetNull` when a referenced field is required.
-// We recommend to either choose another referential action, or make the referenced fields optional.
+// We recommend either to choose another referential action, or to make the referenced fields optional.
 // [0m
 //   [1;94m-->[0m  [4mschema.prisma:13[0m
 // [1;94m   | [0m
@@ -23,7 +23,7 @@ model Profile {
 // [1;94m14 | [0m  user_id Int       @unique
 // [1;94m   | [0m
 // [1;93mwarning[0m: [1mThe `onUpdate` referential action of a relation should not be set to `SetNull` when a referenced field is required.
-// We recommend to either choose another referential action, or make the referenced fields optional.
+// We recommend either to choose another referential action, or to make the referenced fields optional.
 // [0m
 //   [1;94m-->[0m  [4mschema.prisma:13[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/relations/postgres/set_null_warns_on_required_fields.prisma
+++ b/psl/psl/tests/validation/relations/postgres/set_null_warns_on_required_fields.prisma
@@ -1,0 +1,33 @@
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model SomeUser {
+  id      Int      @id
+  profile Profile?
+}
+
+model Profile {
+  id      Int       @id
+  user    SomeUser? @relation(fields: [user_id], references: [id], onUpdate: SetNull, onDelete: SetNull)
+  user_id Int       @unique
+}
+// [1;93mwarning[0m: [1mThe `onDelete` referential action of a relation must not be set to `SetNull` when a referenced field is required.
+// Either choose another referential action, or make the referenced fields optional.
+// [0m
+//   [1;94m-->[0m  [4mschema.prisma:13[0m
+// [1;94m   | [0m
+// [1;94m12 | [0m  id      Int       @id
+// [1;94m13 | [0m  [1;93muser    SomeUser? @relation(fields: [user_id], references: [id], onUpdate: SetNull, onDelete: SetNull)[0m
+// [1;94m14 | [0m  user_id Int       @unique
+// [1;94m   | [0m
+// [1;93mwarning[0m: [1mThe `onUpdate` referential action of a relation must not be set to `SetNull` when a referenced field is required.
+// Either choose another referential action, or make the referenced fields optional.
+// [0m
+//   [1;94m-->[0m  [4mschema.prisma:13[0m
+// [1;94m   | [0m
+// [1;94m12 | [0m  id      Int       @id
+// [1;94m13 | [0m  [1;93muser    SomeUser? @relation(fields: [user_id], references: [id], onUpdate: SetNull, onDelete: SetNull)[0m
+// [1;94m14 | [0m  user_id Int       @unique
+// [1;94m   | [0m

--- a/psl/psl/tests/validation/relations/postgres/set_null_warns_on_required_fields.prisma
+++ b/psl/psl/tests/validation/relations/postgres/set_null_warns_on_required_fields.prisma
@@ -13,8 +13,7 @@ model Profile {
   user    SomeUser? @relation(fields: [user_id], references: [id], onUpdate: SetNull, onDelete: SetNull)
   user_id Int       @unique
 }
-// [1;93mwarning[0m: [1mThe `onDelete` referential action of a relation should not be set to `SetNull` when a referenced field is required.
-// We recommend either to choose another referential action, or to make the referenced fields optional.
+// [1;93mwarning[0m: [1mThe `onDelete` referential action of a relation should not be set to `SetNull` when a referenced field is required. We recommend either to choose another referential action, or to make the referenced fields optional. Read more at https://pris.ly/d/postgres-set-null
 // [0m
 //   [1;94m-->[0m  [4mschema.prisma:13[0m
 // [1;94m   | [0m
@@ -22,8 +21,7 @@ model Profile {
 // [1;94m13 | [0m  [1;93muser    SomeUser? @relation(fields: [user_id], references: [id], onUpdate: SetNull, onDelete: SetNull)[0m
 // [1;94m14 | [0m  user_id Int       @unique
 // [1;94m   | [0m
-// [1;93mwarning[0m: [1mThe `onUpdate` referential action of a relation should not be set to `SetNull` when a referenced field is required.
-// We recommend either to choose another referential action, or to make the referenced fields optional.
+// [1;93mwarning[0m: [1mThe `onUpdate` referential action of a relation should not be set to `SetNull` when a referenced field is required. We recommend either to choose another referential action, or to make the referenced fields optional. Read more at https://pris.ly/d/postgres-set-null
 // [0m
 //   [1;94m-->[0m  [4mschema.prisma:13[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/relations/postgres/set_null_warns_on_required_fields.prisma
+++ b/psl/psl/tests/validation/relations/postgres/set_null_warns_on_required_fields.prisma
@@ -13,8 +13,8 @@ model Profile {
   user    SomeUser? @relation(fields: [user_id], references: [id], onUpdate: SetNull, onDelete: SetNull)
   user_id Int       @unique
 }
-// [1;93mwarning[0m: [1mThe `onDelete` referential action of a relation must not be set to `SetNull` when a referenced field is required.
-// Either choose another referential action, or make the referenced fields optional.
+// [1;93mwarning[0m: [1mThe `onDelete` referential action of a relation should not be set to `SetNull` when a referenced field is required.
+// We recommend to either choose another referential action, or make the referenced fields optional.
 // [0m
 //   [1;94m-->[0m  [4mschema.prisma:13[0m
 // [1;94m   | [0m
@@ -22,8 +22,8 @@ model Profile {
 // [1;94m13 | [0m  [1;93muser    SomeUser? @relation(fields: [user_id], references: [id], onUpdate: SetNull, onDelete: SetNull)[0m
 // [1;94m14 | [0m  user_id Int       @unique
 // [1;94m   | [0m
-// [1;93mwarning[0m: [1mThe `onUpdate` referential action of a relation must not be set to `SetNull` when a referenced field is required.
-// Either choose another referential action, or make the referenced fields optional.
+// [1;93mwarning[0m: [1mThe `onUpdate` referential action of a relation should not be set to `SetNull` when a referenced field is required.
+// We recommend to either choose another referential action, or make the referenced fields optional.
 // [0m
 //   [1;94m-->[0m  [4mschema.prisma:13[0m
 // [1;94m   | [0m


### PR DESCRIPTION
Closes https://github.com/prisma/prisma-private/issues/198.

Warning message:
"""
The `onDelete` referential action of a relation should not be set to `SetNull` when a referenced field is required. We recommend either to choose another referential action, or to make the referenced fields optional. Read more at https://pris.ly/d/postgres-set-null
"""

Error message:
"""
The `onDelete` referential action of a relation must not be set to `SetNull` when a referenced field is required. Either choose another referential action, or make the referenced fields optional.
"""

(idem for `onUpdate`)