### PR TITLE
test: add missing warning

### DIFF
--- a/psl/psl/tests/validation/mysql/set_default_no_warning_when_relation_mode_prisma.prisma
+++ b/psl/psl/tests/validation/mysql/set_default_no_warning_when_relation_mode_prisma.prisma
@@ -18,6 +18,14 @@ model B {
     aId Int? @default(3)
     a   A?   @relation(fields: [aId], references: [id], onUpdate: SetDefault, onDelete: SetDefault)
 }
+// [1;93mwarning[0m: [1mWith `relationMode = \"prisma\"`, no foreign keys are used, so relation fields will not benefit from the index usually created by the relational database under the hood.
+// This can lead to poor performance when querying these fields. We recommend adding an index manually.
+// Learn more at https://pris.ly/d/relation-mode#indexes[0m
+//   [1;94m-->[0m  [4mschema.prisma:19[0m
+// [1;94m   | [0m
+// [1;94m18 | [0m    aId Int? @default(3)
+// [1;94m19 | [0m    a   A?   [1;93m@relation(fields: [aId], references: [id], onUpdate: SetDefault, onDelete: SetDefault)[0m
+// [1;94m   | [0m
 // [1;91merror[0m: [1mError validating: Invalid referential action: `SetDefault`. Allowed values: (`Cascade`, `Restrict`, `NoAction`, `SetNull`)[0m
 //   [1;94m-->[0m  [4mschema.prisma:19[0m
 // [1;94m   | [0m


### PR DESCRIPTION
`main` was failing as a validation snapshot should have been updated between the time https://github.com/prisma/prisma-engines/pull/3429 and https://github.com/prisma/prisma-engines/pull/3435 were merged. This is a quick fix for that.