### PR TITLE
fix: nested 1-1 connect shouldn't error if idempotent

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -21,6 +21,7 @@ export SIMPLE_TEST_MODE="yes" # Reduces the amount of generated `relation_link_t
 ### QE specific logging vars ###
 export QE_LOG_LEVEL=debug # Set it to "trace" to enable query-graph debugging logs
 export FMT_SQL=1 # Uncomment it to enable logging formatted SQL queries
+# export PRISMA_RENDER_DOT_FILE=1 # Uncomment to enable rendering a dot file of the Query Graph from an executed query.
 
 # Mongo image requires additional wait time on arm arch for some reason.
 if uname -a | grep -q 'arm64'; then

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ dev_datamodel.prisma
 /result
 
 dmmf.json
+graph.dot

--- a/query-engine/connectors/query-connector/src/upsert.rs
+++ b/query-engine/connectors/query-connector/src/upsert.rs
@@ -80,14 +80,8 @@ impl NativeUpsert {
     pub fn selection_order(&self) -> &[String] {
         &self.selection_order
     }
-}
 
-impl std::fmt::Display for NativeUpsert {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(
-            f,
-            "Upsert(model: {}, filter: {:?}, create: {:?}, update: {:?}",
-            self.model.name, self.record_filter, self.create, self.update
-        )
+    pub fn record_filter(&self) -> &RecordFilter {
+        &self.record_filter
     }
 }

--- a/query-engine/core/src/interpreter/interpreter.rs
+++ b/query-engine/core/src/interpreter/interpreter.rs
@@ -43,7 +43,7 @@ pub struct DiffResult {
 }
 
 impl DiffResult {
-    pub fn has_no_diff(&self) -> bool {
+    pub fn is_empty(&self) -> bool {
         self.left.is_empty() && self.right.is_empty()
     }
 }

--- a/query-engine/core/src/interpreter/interpreter.rs
+++ b/query-engine/core/src/interpreter/interpreter.rs
@@ -42,6 +42,12 @@ pub struct DiffResult {
     pub right: Vec<SelectionResult>,
 }
 
+impl DiffResult {
+    pub fn has_no_diff(&self) -> bool {
+        self.left.is_empty() && self.right.is_empty()
+    }
+}
+
 impl ExpressionResult {
     /// Attempts to transform this `ExpressionResult` into a vector of `SelectionResult`s corresponding to the passed desired selection shape.
     /// A vector is returned as some expression results return more than one result row at once.

--- a/query-engine/core/src/query_ast/mod.rs
+++ b/query-engine/core/src/query_ast/mod.rs
@@ -4,6 +4,7 @@ mod write;
 pub use read::*;
 pub use write::*;
 
+use crate::ToGraphviz;
 use connector::filter::Filter;
 use prisma_models::{FieldSelection, ModelRef, SelectionResult};
 
@@ -96,6 +97,15 @@ impl std::fmt::Display for Query {
         match self {
             Self::Read(q) => write!(f, "{}", q),
             Self::Write(q) => write!(f, "{}", q),
+        }
+    }
+}
+
+impl ToGraphviz for Query {
+    fn to_graphviz(&self) -> String {
+        match self {
+            Self::Read(q) => q.to_graphviz(),
+            Self::Write(q) => q.to_graphviz(),
         }
     }
 }

--- a/query-engine/core/src/query_ast/read.rs
+++ b/query-engine/core/src/query_ast/read.rs
@@ -1,5 +1,6 @@
 //! Prisma read query AST
 use super::FilteredQuery;
+use crate::ToGraphviz;
 use connector::{filter::Filter, AggregationSelection, QueryArguments, RelAggregationSelection};
 use enumflags2::BitFlags;
 use prisma_models::prelude::*;
@@ -83,6 +84,26 @@ impl Display for ReadQuery {
                 q.selected_fields
             ),
             Self::AggregateRecordsQuery(q) => write!(f, "AggregateRecordsQuery: {}", q.name),
+        }
+    }
+}
+
+impl ToGraphviz for ReadQuery {
+    fn to_graphviz(&self) -> String {
+        match self {
+            Self::RecordQuery(q) => format!("RecordQuery(name: '{}', selection: {})", q.name, q.selected_fields),
+            Self::ManyRecordsQuery(q) => format!(
+                r#"ManyRecordsQuery(name: '{}', model: '{}', selection: {})"#,
+                q.name, q.model.name, q.selected_fields
+            ),
+            Self::RelatedRecordsQuery(q) => format!(
+                "RelatedRecordsQuery(name: '{}', parent model: '{}', parent relation field: {}, selection: {})",
+                q.name,
+                q.parent_field.model().name,
+                q.parent_field.name,
+                q.selected_fields
+            ),
+            Self::AggregateRecordsQuery(q) => format!("AggregateRecordsQuery: {}", q.name),
         }
     }
 }

--- a/query-engine/core/src/query_ast/write.rs
+++ b/query-engine/core/src/query_ast/write.rs
@@ -1,6 +1,6 @@
 //! Write query AST
 use super::{FilteredNestedMutation, FilteredQuery};
-use crate::RecordQuery;
+use crate::{RecordQuery, ToGraphviz};
 use connector::{filter::Filter, DatasourceFieldName, NativeUpsert, RecordFilter, WriteArgs};
 use prisma_models::prelude::*;
 use std::{collections::HashMap, sync::Arc};
@@ -146,7 +146,32 @@ impl std::fmt::Display for WriteQuery {
             Self::DisconnectRecords(_) => write!(f, "DisconnectRecords"),
             Self::ExecuteRaw(r) => write!(f, "ExecuteRaw: {:?}", r.inputs),
             Self::QueryRaw(r) => write!(f, "QueryRaw: {:?}", r.inputs),
-            Self::Upsert(q) => q.fmt(f),
+            Self::Upsert(q) => write!(
+                f,
+                "Upsert(model: {}, filter: {:?}, create: {:?}, update: {:?}",
+                q.model().name,
+                q.record_filter(),
+                q.create(),
+                q.update()
+            ),
+        }
+    }
+}
+
+impl ToGraphviz for WriteQuery {
+    fn to_graphviz(&self) -> String {
+        match self {
+            Self::CreateRecord(q) => format!("CreateRecord(model: {}, args: {:?})", q.model.name, q.args),
+            Self::CreateManyRecords(q) => format!("CreateManyRecord(model: {})", q.model.name),
+            Self::UpdateRecord(q) => format!("UpdateRecord(model: {})", q.model.name,),
+            Self::DeleteRecord(q) => format!("DeleteRecord: {}, {:?}", q.model.name, q.record_filter),
+            Self::UpdateManyRecords(q) => format!("UpdateManyRecords(model: {}, args: {:?})", q.model.name, q.args),
+            Self::DeleteManyRecords(q) => format!("DeleteManyRecords: {}", q.model.name),
+            Self::ConnectRecords(_) => "ConnectRecords".to_string(),
+            Self::DisconnectRecords(_) => "DisconnectRecords".to_string(),
+            Self::ExecuteRaw(r) => format!("ExecuteRaw: {:?}", r.inputs),
+            Self::QueryRaw(r) => format!("QueryRaw: {:?}", r.inputs),
+            Self::Upsert(q) => format!("Upsert(model: {}", q.model().name),
         }
     }
 }

--- a/query-engine/core/src/query_graph/formatters.rs
+++ b/query-engine/core/src/query_graph/formatters.rs
@@ -79,6 +79,17 @@ impl Display for Node {
     }
 }
 
+impl ToGraphviz for Node {
+    fn to_graphviz(&self) -> String {
+        match self {
+            Node::Query(q) => q.to_graphviz(),
+            Node::Flow(f) => format!("{}", f),
+            Node::Computation(c) => format!("{}", c),
+            Node::Empty => "Empty".to_string(),
+        }
+    }
+}
+
 impl Display for NodeRef {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Node {}", self.id())

--- a/query-engine/core/src/query_graph_builder/builder.rs
+++ b/query-engine/core/src/query_graph_builder/builder.rs
@@ -1,7 +1,13 @@
-use std::fmt;
+use once_cell::sync::Lazy;
+use std::{fmt, fs::File, io::Write};
 
 use super::*;
 use crate::{query_document::*, query_graph::*, schema::*, IrSerializer};
+
+pub static PRISMA_RENDER_DOT_FILE: Lazy<bool> = Lazy::new(|| match std::env::var("PRISMA_RENDER_DOT_FILE") {
+    Ok(enabled) => enabled == *("true") || enabled == *("1"),
+    Err(_) => false,
+});
 
 pub struct QueryGraphBuilder {
     pub query_schema: QuerySchemaRef,
@@ -84,6 +90,14 @@ impl QueryGraphBuilder {
         // Run final transformations.
         graph.finalize()?;
         trace!("{}", graph);
+    
+        // Used to debug generated graph.
+        if *PRISMA_RENDER_DOT_FILE {
+            let mut f = File::create("graph.dot").unwrap();
+            let output = graph.to_graphviz();
+
+            f.write_all(&output.as_bytes()).unwrap();
+        }
 
         Ok(graph)
     }

--- a/query-engine/core/src/query_graph_builder/builder.rs
+++ b/query-engine/core/src/query_graph_builder/builder.rs
@@ -90,7 +90,7 @@ impl QueryGraphBuilder {
         // Run final transformations.
         graph.finalize()?;
         trace!("{}", graph);
-    
+
         // Used to debug generated graph.
         if *PRISMA_RENDER_DOT_FILE {
             let mut f = File::create("graph.dot").unwrap();

--- a/query-engine/core/src/query_graph_builder/write/nested/connect_nested.rs
+++ b/query-engine/core/src/query_graph_builder/write/nested/connect_nested.rs
@@ -367,10 +367,18 @@ fn handle_one_to_one(
     // We always start with the read node in a nested connect 1:1 scenario.
     graph.mark_nodes(&parent_node, &read_new_child_node);
 
+    // If the new child is the same as the old child, we stop the execution before performing the update.
+    let idempotent_check_node =
+        utils::insert_1to1_idempotent_connect_checks(graph, &parent_node, &read_new_child_node, parent_relation_field)?;
+
     // Next is the check for (and possible disconnect of) an existing parent.
     // Those checks are performed on the new child node, hence we use the child relation field side ("backrelation").
     if parent_side_required || relation_inlined_parent {
-        utils::insert_existing_1to1_related_model_checks(graph, &read_new_child_node, &child_relation_field)?;
+        let node =
+            utils::insert_existing_1to1_related_model_checks(graph, &read_new_child_node, &child_relation_field)?;
+
+        // We do those checks only if the old & new child are different.
+        graph.create_edge(&idempotent_check_node, &node, QueryGraphDependency::ExecutionOrder)?;
     }
 
     let relation_name = parent_relation_field.relation().name.clone();
@@ -383,6 +391,7 @@ fn handle_one_to_one(
         QueryGraphDependency::ProjectedDataDependency(
             child_linking_fields.clone(),
             Box::new(move |mut read_new_child_node, mut child_links| {
+                dbg!(&child_links);
                 // This takes care of cases where the relation is inlined, CREATE ONLY. See doc comment for explanation.
                 if relation_inlined_parent && parent_is_create {
                     let child_link = match child_links.pop() {
@@ -409,7 +418,10 @@ fn handle_one_to_one(
     // We only need to do those checks if the parent operation is not a create, the reason being that
     // if the parent is a create, it can't have an existing child already.
     if !parent_is_create && (child_side_required || !relation_inlined_parent) {
-        utils::insert_existing_1to1_related_model_checks(graph, &parent_node, parent_relation_field)?;
+        let node = utils::insert_existing_1to1_related_model_checks(graph, &parent_node, parent_relation_field)?;
+
+        // We do those checks only if the old & new child are different.
+        graph.create_edge(&idempotent_check_node, &node, QueryGraphDependency::ExecutionOrder)?;
     }
 
     // If the relation is inlined on the child, we also need to update the child to connect it to the parent.
@@ -449,6 +461,12 @@ fn handle_one_to_one(
         let relation_name = parent_relation_field.relation().name.clone();
         let parent_model_name = parent_relation_field.model().name.clone();
         let child_model_name = child_model.name.clone();
+
+        graph.create_edge(
+            &idempotent_check_node,
+            &update_children_node,
+            QueryGraphDependency::ExecutionOrder,
+        )?;
 
         graph.create_edge(
              &parent_node,
@@ -507,6 +525,12 @@ fn handle_one_to_one(
         let relation_name = parent_relation_field.relation().name.clone();
         let parent_model_name = parent_model.name.clone();
         let child_model_name = child_model.name.clone();
+
+        graph.create_edge(
+            &idempotent_check_node,
+            &update_parent_node,
+            QueryGraphDependency::ExecutionOrder,
+        )?;
 
         graph.create_edge(
             &parent_node,

--- a/query-engine/core/src/query_graph_builder/write/nested/connect_nested.rs
+++ b/query-engine/core/src/query_graph_builder/write/nested/connect_nested.rs
@@ -391,7 +391,6 @@ fn handle_one_to_one(
         QueryGraphDependency::ProjectedDataDependency(
             child_linking_fields.clone(),
             Box::new(move |mut read_new_child_node, mut child_links| {
-                dbg!(&child_links);
                 // This takes care of cases where the relation is inlined, CREATE ONLY. See doc comment for explanation.
                 if relation_inlined_parent && parent_is_create {
                     let child_link = match child_links.pop() {

--- a/query-engine/core/src/query_graph_builder/write/utils.rs
+++ b/query-engine/core/src/query_graph_builder/write/utils.rs
@@ -197,7 +197,7 @@ pub fn insert_1to1_idempotent_connect_checks(
         &if_node,
         QueryGraphDependency::DataDependency(Box::new(move |if_node, result| {
             let diff_result = result.as_diff_result().unwrap();
-            let should_connect = !diff_result.has_no_diff();
+            let should_connect = !diff_result.is_empty();
 
             if let Node::Flow(Flow::If(_)) = if_node {
                 Ok(Node::Flow(Flow::If(Box::new(move || should_connect))))

--- a/query-engine/core/src/query_graph_builder/write/utils.rs
+++ b/query-engine/core/src/query_graph_builder/write/utils.rs
@@ -1,7 +1,7 @@
 use crate::{
     query_ast::*,
     query_graph::{Flow, Node, NodeRef, QueryGraph, QueryGraphDependency},
-    ParsedInputValue, QueryGraphBuilderError, QueryGraphBuilderResult,
+    Computation, ParsedInputValue, QueryGraphBuilderError, QueryGraphBuilderResult,
 };
 use connector::{DatasourceFieldName, Filter, RecordFilter, WriteArgs, WriteOperation};
 
@@ -136,6 +136,81 @@ where
     )?;
 
     Ok(read_children_node)
+}
+
+/// Adds a node to read the old child, compare it to the new child and continues the graph execution only if there are diffences between the old & the new child.
+/// This function is tailored for 1-1 nested connect.
+pub fn insert_1to1_idempotent_connect_checks(
+    graph: &mut QueryGraph,
+    parent_node: &NodeRef,
+    read_new_child_node: &NodeRef,
+    parent_relation_field: &RelationFieldRef,
+) -> QueryGraphBuilderResult<NodeRef> {
+    let child_model = parent_relation_field.related_model();
+    let child_model_identifier = child_model.primary_identifier();
+    let relation_name = parent_relation_field.relation().name.clone();
+
+    let diff_node = graph.create_node(Node::Computation(Computation::empty_diff()));
+
+    graph.create_edge(
+        read_new_child_node,
+        &diff_node,
+        QueryGraphDependency::ProjectedDataDependency(
+            child_model_identifier.clone(),
+            Box::new(move |mut diff_node, child_ids| {
+                if child_ids.is_empty() {
+                    return Err(QueryGraphBuilderError::RecordNotFound(format!(
+                        "No '{}' record to connect was found was found for a nested connect on one-to-one relation '{}'.",
+                        &child_model.name, relation_name
+                    )))
+                }
+
+                if let Node::Computation(Computation::Diff(ref mut diff)) = diff_node {
+                    diff.right = child_ids.into_iter().collect();
+                }
+
+                Ok(diff_node)
+            }),
+        ),
+    )?;
+    let read_old_child_node =
+        insert_find_children_by_parent_node(graph, &parent_node, parent_relation_field, Filter::empty())?;
+
+    graph.create_edge(
+        &read_old_child_node,
+        &diff_node,
+        QueryGraphDependency::ProjectedDataDependency(
+            child_model_identifier.clone(),
+            Box::new(move |mut diff_node, child_ids| {
+                if let Node::Computation(Computation::Diff(ref mut diff)) = diff_node {
+                    diff.left = child_ids.into_iter().collect();
+                }
+
+                Ok(diff_node)
+            }),
+        ),
+    )?;
+    let if_node = graph.create_node(Flow::default_if());
+
+    graph.create_edge(
+        &diff_node,
+        &if_node,
+        QueryGraphDependency::DataDependency(Box::new(move |if_node, result| {
+            let diff_result = result.as_diff_result().unwrap();
+            let should_connect = !diff_result.has_no_diff();
+
+            if let Node::Flow(Flow::If(_)) = if_node {
+                Ok(Node::Flow(Flow::If(Box::new(move || should_connect))))
+            } else {
+                unreachable!()
+            }
+        })),
+    )?;
+    let empty_node = graph.create_node(Node::Empty);
+
+    graph.create_edge(&if_node, &empty_node, QueryGraphDependency::Then)?;
+
+    Ok(empty_node)
 }
 
 /// Creates an update many records query node and adds it to the query graph.


### PR DESCRIPTION
## Overview

fixes https://github.com/prisma/prisma/issues/14759

- When doing a nested 1-1 connect, we're now checking whether the old child is different than the new. If they're no different, then no update happens.
- Added a new env var to generate a graphviz dot file in dev to ease debugging the query graph

## Graph visualization
<img width="1686" alt="image" src="https://user-images.githubusercontent.com/25233379/203850353-d7a5efec-2ab9-4e73-94de-74fc2b843758.png">
