### PR TITLE
feat(psl): polish validation warnings before `relationMode` GA

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,6 +302,7 @@ dependencies = [
  "connection-string",
  "either",
  "enumflags2",
+ "indoc",
  "lsp-types",
  "once_cell",
  "psl-core",

--- a/introspection-engine/introspection-engine-tests/tests/referential_actions/mysql.rs
+++ b/introspection-engine/introspection-engine-tests/tests/referential_actions/mysql.rs
@@ -58,13 +58,13 @@ async fn introspect_set_default_should_warn(api: &TestApi) -> TestResult {
         .warnings_to_pretty_string("schema.prisma", &schema.db.source());
 
     let expected_validation = expect![[r#"
-        [1;93mwarning[0m: [1mUsing SetDefault on MySQL may yield to unexpected results, as the database will silently change the referential action to `NoAction`.[0m
+        [1;93mwarning[0m: [1m`MySQL` does not actually support the `SetDefault` referential action, so using it may result in unexpected errors. Read more at https://pris.ly/d/mysql-set-default [0m
           [1;94m-->[0m  [4mschema.prisma:14[0m
         [1;94m   | [0m
         [1;94m13 | [0m          userId   Int?      @default(3)
         [1;94m14 | [0m          SomeUser SomeUser? @relation(fields: [userId], references: [id], [1;93monDelete: SetDefault[0m, onUpdate: SetDefault)
         [1;94m   | [0m
-        [1;93mwarning[0m: [1mUsing SetDefault on MySQL may yield to unexpected results, as the database will silently change the referential action to `NoAction`.[0m
+        [1;93mwarning[0m: [1m`MySQL` does not actually support the `SetDefault` referential action, so using it may result in unexpected errors. Read more at https://pris.ly/d/mysql-set-default [0m
           [1;94m-->[0m  [4mschema.prisma:14[0m
         [1;94m   | [0m
         [1;94m13 | [0m          userId   Int?      @default(3)

--- a/introspection-engine/introspection-engine-tests/tests/referential_actions/mysql.rs
+++ b/introspection-engine/introspection-engine-tests/tests/referential_actions/mysql.rs
@@ -58,13 +58,13 @@ async fn introspect_set_default_should_warn(api: &TestApi) -> TestResult {
         .warnings_to_pretty_string("schema.prisma", &schema.db.source());
 
     let expected_validation = expect![[r#"
-        [1;93mwarning[0m: [1m`MySQL` does not actually support the `SetDefault` referential action, so using it may result in unexpected errors. Read more at https://pris.ly/d/mysql-set-default [0m
+        [1;93mwarning[0m: [1mMySQL does not actually support the `SetDefault` referential action, so using it may result in unexpected errors. Read more at https://pris.ly/d/mysql-set-default [0m
           [1;94m-->[0m  [4mschema.prisma:14[0m
         [1;94m   | [0m
         [1;94m13 | [0m          userId   Int?      @default(3)
         [1;94m14 | [0m          SomeUser SomeUser? @relation(fields: [userId], references: [id], [1;93monDelete: SetDefault[0m, onUpdate: SetDefault)
         [1;94m   | [0m
-        [1;93mwarning[0m: [1m`MySQL` does not actually support the `SetDefault` referential action, so using it may result in unexpected errors. Read more at https://pris.ly/d/mysql-set-default [0m
+        [1;93mwarning[0m: [1mMySQL does not actually support the `SetDefault` referential action, so using it may result in unexpected errors. Read more at https://pris.ly/d/mysql-set-default [0m
           [1;94m-->[0m  [4mschema.prisma:14[0m
         [1;94m   | [0m
         [1;94m13 | [0m          userId   Int?      @default(3)

--- a/psl/builtin-connectors/Cargo.toml
+++ b/psl/builtin-connectors/Cargo.toml
@@ -9,6 +9,7 @@ psl-core = { path = "../psl-core" }
 connection-string = "0.1"
 either = "1.6.1"
 enumflags2 = "0.7"
+indoc = "1"
 lsp-types = "0.91.1"
 once_cell = "1.3"
 regex = "1"

--- a/psl/builtin-connectors/src/mysql_datamodel_connector/validations.rs
+++ b/psl/builtin-connectors/src/mysql_datamodel_connector/validations.rs
@@ -109,7 +109,7 @@ pub(crate) fn uses_native_referential_action_set_default(
     let warning_msg = || {
         formatdoc!(
             r#"
-            `{connector_name}` does not actually support the `{set_default}` referential action, so using it may result in unexpected errors.
+            {connector_name} does not actually support the `{set_default}` referential action, so using it may result in unexpected errors.
             Read more at https://pris.ly/d/mysql-set-default
             "#,
             connector_name = connector.name(),

--- a/psl/builtin-connectors/src/mysql_datamodel_connector/validations.rs
+++ b/psl/builtin-connectors/src/mysql_datamodel_connector/validations.rs
@@ -1,3 +1,4 @@
+use indoc::formatdoc;
 use psl_core::diagnostics::{DatamodelWarning, Span};
 use psl_core::parser_database::ast::WithSpan;
 use psl_core::parser_database::ReferentialAction;
@@ -106,12 +107,16 @@ pub(crate) fn uses_native_referential_action_set_default(
     };
 
     let warning_msg = || {
-        format!(
-            "Using {set_default} on {connector} may yield to unexpected results, as the database will silently change the referential action to `{no_action}`.",
+        let details = formatdoc!(
+            r#"
+            `{connector_name}` does not actually support the `{set_default}` referential action, so using it may result in unexpected errors.
+            Read more at https://pris.ly/d/mysql-set-default
+            "#,
+            connector_name = connector.name(),
             set_default = ReferentialAction::SetDefault.as_str(),
-            connector = connector.name(),
-            no_action = ReferentialAction::NoAction.as_str(),
         )
+        .replace('\n', " ");
+        details
     };
 
     if let Some(ReferentialAction::SetDefault) = field.explicit_on_delete() {

--- a/psl/builtin-connectors/src/mysql_datamodel_connector/validations.rs
+++ b/psl/builtin-connectors/src/mysql_datamodel_connector/validations.rs
@@ -107,16 +107,14 @@ pub(crate) fn uses_native_referential_action_set_default(
     };
 
     let warning_msg = || {
-        let details = formatdoc!(
+        formatdoc!(
             r#"
             `{connector_name}` does not actually support the `{set_default}` referential action, so using it may result in unexpected errors.
             Read more at https://pris.ly/d/mysql-set-default
             "#,
             connector_name = connector.name(),
             set_default = ReferentialAction::SetDefault.as_str(),
-        )
-        .replace('\n', " ");
-        details
+        ).replace('\n', " ")
     };
 
     if let Some(ReferentialAction::SetDefault) = field.explicit_on_delete() {

--- a/psl/diagnostics/src/warning.rs
+++ b/psl/diagnostics/src/warning.rs
@@ -29,9 +29,7 @@ impl DatamodelWarning {
 
     pub fn new_missing_index_on_emulated_relation(span: Span) -> DatamodelWarning {
         let message = indoc! {
-            r#"With `relationMode = \"prisma\"`, no foreign keys are used, so relation fields will not benefit from the index usually created by the relational database under the hood.
-            This can lead to poor performance when querying these fields. We recommend adding an index manually.
-            Learn more at https://pris.ly/d/relation-mode#indexes"#
+            r#"With `relationMode = "prisma"`, no foreign keys are used, so relation fields will not benefit from the index usually created by the relational database under the hood. This can lead to poor performance when querying these fields. We recommend adding an index manually. Learn more at https://pris.ly/d/relation-mode-prisma-indexes"#
         };
         Self::new(message.to_owned(), span)
     }

--- a/psl/diagnostics/src/warning.rs
+++ b/psl/diagnostics/src/warning.rs
@@ -36,7 +36,7 @@ impl DatamodelWarning {
             "#,
         )
         .replace('\n', " ");
-        Self::new(message.to_owned(), span)
+        Self::new(message, span)
     }
 
     /// The user-facing warning message.

--- a/psl/diagnostics/src/warning.rs
+++ b/psl/diagnostics/src/warning.rs
@@ -28,9 +28,14 @@ impl DatamodelWarning {
     }
 
     pub fn new_missing_index_on_emulated_relation(span: Span) -> DatamodelWarning {
-        let message = indoc! {
-            r#"With `relationMode = "prisma"`, no foreign keys are used, so relation fields will not benefit from the index usually created by the relational database under the hood. This can lead to poor performance when querying these fields. We recommend adding an index manually. Learn more at https://pris.ly/d/relation-mode-prisma-indexes"#
-        };
+        let message = indoc!(
+            r#"
+            With `relationMode = "prisma"`, no foreign keys are used, so relation fields will not benefit from the index usually created by the relational database under the hood.
+            This can lead to poor performance when querying these fields. We recommend adding an index manually.
+            Learn more at https://pris.ly/d/relation-mode-prisma-indexes"
+            "#,
+        )
+        .replace('\n', " ");
         Self::new(message.to_owned(), span)
     }
 

--- a/psl/psl-core/src/validate/validation_pipeline/validations/relations.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/relations.rs
@@ -554,11 +554,16 @@ pub(crate) fn required_relation_cannot_use_set_null(relation: InlineRelationWalk
     {
         // the database allows SetNull on non-nullable fields, we add a validation warning to avoid breaking changes
         let warning_template = |referential_action_type: &str| {
-            let set_null = ReferentialAction::SetNull.as_str();
-            let msg = formatdoc! {r#"
-                The `{referential_action_type}` referential action of a relation should not be set to `{set_null}` when a referenced field is required. We recommend either to choose another referential action, or to make the referenced fields optional. Read more at https://pris.ly/d/postgres-set-null
-            "#};
-            msg
+            let details = formatdoc!(
+                    r#"
+                    The `{referential_action_type}` referential action of a relation should not be set to `{set_null}` when a referenced field is required.
+                    We recommend either to choose another referential action, or to make the referenced fields optional.
+                    Read more at https://pris.ly/d/postgres-set-null
+                    "#,
+                    set_null = ReferentialAction::SetNull.as_str(),
+                )
+                .replace('\n', " ");
+            details
         };
 
         if let Some(ReferentialAction::SetNull) = forward.explicit_on_delete() {

--- a/psl/psl-core/src/validate/validation_pipeline/validations/relations.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/relations.rs
@@ -554,16 +554,14 @@ pub(crate) fn required_relation_cannot_use_set_null(relation: InlineRelationWalk
     {
         // the database allows SetNull on non-nullable fields, we add a validation warning to avoid breaking changes
         let warning_template = |referential_action_type: &str| {
-            let details = formatdoc!(
+            formatdoc!(
                     r#"
                     The `{referential_action_type}` referential action of a relation should not be set to `{set_null}` when a referenced field is required.
                     We recommend either to choose another referential action, or to make the referenced fields optional.
                     Read more at https://pris.ly/d/postgres-set-null
                     "#,
                     set_null = ReferentialAction::SetNull.as_str(),
-                )
-                .replace('\n', " ");
-            details
+                ).replace('\n', " ")
         };
 
         if let Some(ReferentialAction::SetNull) = forward.explicit_on_delete() {

--- a/psl/psl/tests/validation/attributes/index/missing_index_warning/relation_mode_prisma/one_field_no_index.prisma
+++ b/psl/psl/tests/validation/attributes/index/missing_index_warning/relation_mode_prisma/one_field_no_index.prisma
@@ -16,7 +16,7 @@ model Post {
     userId Int
     user SomeUser @relation(fields: [userId], references: [id])
 }
-// [1;93mwarning[0m: [1mWith `relationMode = "prisma"`, no foreign keys are used, so relation fields will not benefit from the index usually created by the relational database under the hood. This can lead to poor performance when querying these fields. We recommend adding an index manually. Learn more at https://pris.ly/d/relation-mode-prisma-indexes[0m
+// [1;93mwarning[0m: [1mWith `relationMode = "prisma"`, no foreign keys are used, so relation fields will not benefit from the index usually created by the relational database under the hood. This can lead to poor performance when querying these fields. We recommend adding an index manually. Learn more at https://pris.ly/d/relation-mode-prisma-indexes" [0m
 //   [1;94m-->[0m  [4mschema.prisma:17[0m
 // [1;94m   | [0m
 // [1;94m16 | [0m    userId Int

--- a/psl/psl/tests/validation/attributes/index/missing_index_warning/relation_mode_prisma/one_field_no_index.prisma
+++ b/psl/psl/tests/validation/attributes/index/missing_index_warning/relation_mode_prisma/one_field_no_index.prisma
@@ -16,9 +16,7 @@ model Post {
     userId Int
     user SomeUser @relation(fields: [userId], references: [id])
 }
-// [1;93mwarning[0m: [1mWith `relationMode = \"prisma\"`, no foreign keys are used, so relation fields will not benefit from the index usually created by the relational database under the hood.
-// This can lead to poor performance when querying these fields. We recommend adding an index manually.
-// Learn more at https://pris.ly/d/relation-mode#indexes[0m
+// [1;93mwarning[0m: [1mWith `relationMode = "prisma"`, no foreign keys are used, so relation fields will not benefit from the index usually created by the relational database under the hood. This can lead to poor performance when querying these fields. We recommend adding an index manually. Learn more at https://pris.ly/d/relation-mode-prisma-indexes[0m
 //   [1;94m-->[0m  [4mschema.prisma:17[0m
 // [1;94m   | [0m
 // [1;94m16 | [0m    userId Int

--- a/psl/psl/tests/validation/attributes/index/missing_index_warning/relation_mode_prisma/three_fields_index_leftmost.prisma
+++ b/psl/psl/tests/validation/attributes/index/missing_index_warning/relation_mode_prisma/three_fields_index_leftmost.prisma
@@ -24,7 +24,7 @@ model Post {
 
     @@index([userIdA, userIdB])
 }
-// [1;93mwarning[0m: [1mWith `relationMode = "prisma"`, no foreign keys are used, so relation fields will not benefit from the index usually created by the relational database under the hood. This can lead to poor performance when querying these fields. We recommend adding an index manually. Learn more at https://pris.ly/d/relation-mode-prisma-indexes[0m
+// [1;93mwarning[0m: [1mWith `relationMode = "prisma"`, no foreign keys are used, so relation fields will not benefit from the index usually created by the relational database under the hood. This can lead to poor performance when querying these fields. We recommend adding an index manually. Learn more at https://pris.ly/d/relation-mode-prisma-indexes" [0m
 //   [1;94m-->[0m  [4mschema.prisma:23[0m
 // [1;94m   | [0m
 // [1;94m22 | [0m    userIdC Int

--- a/psl/psl/tests/validation/attributes/index/missing_index_warning/relation_mode_prisma/three_fields_index_leftmost.prisma
+++ b/psl/psl/tests/validation/attributes/index/missing_index_warning/relation_mode_prisma/three_fields_index_leftmost.prisma
@@ -24,9 +24,7 @@ model Post {
 
     @@index([userIdA, userIdB])
 }
-// [1;93mwarning[0m: [1mWith `relationMode = \"prisma\"`, no foreign keys are used, so relation fields will not benefit from the index usually created by the relational database under the hood.
-// This can lead to poor performance when querying these fields. We recommend adding an index manually.
-// Learn more at https://pris.ly/d/relation-mode#indexes[0m
+// [1;93mwarning[0m: [1mWith `relationMode = "prisma"`, no foreign keys are used, so relation fields will not benefit from the index usually created by the relational database under the hood. This can lead to poor performance when querying these fields. We recommend adding an index manually. Learn more at https://pris.ly/d/relation-mode-prisma-indexes[0m
 //   [1;94m-->[0m  [4mschema.prisma:23[0m
 // [1;94m   | [0m
 // [1;94m22 | [0m    userIdC Int

--- a/psl/psl/tests/validation/attributes/index/missing_index_warning/relation_mode_prisma/three_fields_index_rightmost.prisma
+++ b/psl/psl/tests/validation/attributes/index/missing_index_warning/relation_mode_prisma/three_fields_index_rightmost.prisma
@@ -24,9 +24,7 @@ model Post {
 
     @@index([userIdB, userIdC])
 }
-// [1;93mwarning[0m: [1mWith `relationMode = \"prisma\"`, no foreign keys are used, so relation fields will not benefit from the index usually created by the relational database under the hood.
-// This can lead to poor performance when querying these fields. We recommend adding an index manually.
-// Learn more at https://pris.ly/d/relation-mode#indexes[0m
+// [1;93mwarning[0m: [1mWith `relationMode = "prisma"`, no foreign keys are used, so relation fields will not benefit from the index usually created by the relational database under the hood. This can lead to poor performance when querying these fields. We recommend adding an index manually. Learn more at https://pris.ly/d/relation-mode-prisma-indexes[0m
 //   [1;94m-->[0m  [4mschema.prisma:23[0m
 // [1;94m   | [0m
 // [1;94m22 | [0m    userIdC Int

--- a/psl/psl/tests/validation/attributes/index/missing_index_warning/relation_mode_prisma/three_fields_index_rightmost.prisma
+++ b/psl/psl/tests/validation/attributes/index/missing_index_warning/relation_mode_prisma/three_fields_index_rightmost.prisma
@@ -24,7 +24,7 @@ model Post {
 
     @@index([userIdB, userIdC])
 }
-// [1;93mwarning[0m: [1mWith `relationMode = "prisma"`, no foreign keys are used, so relation fields will not benefit from the index usually created by the relational database under the hood. This can lead to poor performance when querying these fields. We recommend adding an index manually. Learn more at https://pris.ly/d/relation-mode-prisma-indexes[0m
+// [1;93mwarning[0m: [1mWith `relationMode = "prisma"`, no foreign keys are used, so relation fields will not benefit from the index usually created by the relational database under the hood. This can lead to poor performance when querying these fields. We recommend adding an index manually. Learn more at https://pris.ly/d/relation-mode-prisma-indexes" [0m
 //   [1;94m-->[0m  [4mschema.prisma:23[0m
 // [1;94m   | [0m
 // [1;94m22 | [0m    userIdC Int

--- a/psl/psl/tests/validation/attributes/index/missing_index_warning/relation_mode_prisma/three_fields_mixed_unique.prisma
+++ b/psl/psl/tests/validation/attributes/index/missing_index_warning/relation_mode_prisma/three_fields_mixed_unique.prisma
@@ -24,9 +24,7 @@ model Post {
 
     @@unique([userIdA, userIdB])
 }
-// [1;93mwarning[0m: [1mWith `relationMode = \"prisma\"`, no foreign keys are used, so relation fields will not benefit from the index usually created by the relational database under the hood.
-// This can lead to poor performance when querying these fields. We recommend adding an index manually.
-// Learn more at https://pris.ly/d/relation-mode#indexes[0m
+// [1;93mwarning[0m: [1mWith `relationMode = "prisma"`, no foreign keys are used, so relation fields will not benefit from the index usually created by the relational database under the hood. This can lead to poor performance when querying these fields. We recommend adding an index manually. Learn more at https://pris.ly/d/relation-mode-prisma-indexes[0m
 //   [1;94m-->[0m  [4mschema.prisma:23[0m
 // [1;94m   | [0m
 // [1;94m22 | [0m    userIdC Int @unique

--- a/psl/psl/tests/validation/attributes/index/missing_index_warning/relation_mode_prisma/three_fields_mixed_unique.prisma
+++ b/psl/psl/tests/validation/attributes/index/missing_index_warning/relation_mode_prisma/three_fields_mixed_unique.prisma
@@ -24,7 +24,7 @@ model Post {
 
     @@unique([userIdA, userIdB])
 }
-// [1;93mwarning[0m: [1mWith `relationMode = "prisma"`, no foreign keys are used, so relation fields will not benefit from the index usually created by the relational database under the hood. This can lead to poor performance when querying these fields. We recommend adding an index manually. Learn more at https://pris.ly/d/relation-mode-prisma-indexes[0m
+// [1;93mwarning[0m: [1mWith `relationMode = "prisma"`, no foreign keys are used, so relation fields will not benefit from the index usually created by the relational database under the hood. This can lead to poor performance when querying these fields. We recommend adding an index manually. Learn more at https://pris.ly/d/relation-mode-prisma-indexes" [0m
 //   [1;94m-->[0m  [4mschema.prisma:23[0m
 // [1;94m   | [0m
 // [1;94m22 | [0m    userIdC Int @unique

--- a/psl/psl/tests/validation/attributes/index/missing_index_warning/relation_mode_prisma/three_fields_no_index.prisma
+++ b/psl/psl/tests/validation/attributes/index/missing_index_warning/relation_mode_prisma/three_fields_no_index.prisma
@@ -22,9 +22,7 @@ model Post {
     userIdC Int
     user SomeUser @relation(fields: [userIdA, userIdB, userIdC], references: [idA, idB, idC])
 }
-// [1;93mwarning[0m: [1mWith `relationMode = \"prisma\"`, no foreign keys are used, so relation fields will not benefit from the index usually created by the relational database under the hood.
-// This can lead to poor performance when querying these fields. We recommend adding an index manually.
-// Learn more at https://pris.ly/d/relation-mode#indexes[0m
+// [1;93mwarning[0m: [1mWith `relationMode = "prisma"`, no foreign keys are used, so relation fields will not benefit from the index usually created by the relational database under the hood. This can lead to poor performance when querying these fields. We recommend adding an index manually. Learn more at https://pris.ly/d/relation-mode-prisma-indexes[0m
 //   [1;94m-->[0m  [4mschema.prisma:23[0m
 // [1;94m   | [0m
 // [1;94m22 | [0m    userIdC Int

--- a/psl/psl/tests/validation/attributes/index/missing_index_warning/relation_mode_prisma/three_fields_no_index.prisma
+++ b/psl/psl/tests/validation/attributes/index/missing_index_warning/relation_mode_prisma/three_fields_no_index.prisma
@@ -22,7 +22,7 @@ model Post {
     userIdC Int
     user SomeUser @relation(fields: [userIdA, userIdB, userIdC], references: [idA, idB, idC])
 }
-// [1;93mwarning[0m: [1mWith `relationMode = "prisma"`, no foreign keys are used, so relation fields will not benefit from the index usually created by the relational database under the hood. This can lead to poor performance when querying these fields. We recommend adding an index manually. Learn more at https://pris.ly/d/relation-mode-prisma-indexes[0m
+// [1;93mwarning[0m: [1mWith `relationMode = "prisma"`, no foreign keys are used, so relation fields will not benefit from the index usually created by the relational database under the hood. This can lead to poor performance when querying these fields. We recommend adding an index manually. Learn more at https://pris.ly/d/relation-mode-prisma-indexes" [0m
 //   [1;94m-->[0m  [4mschema.prisma:23[0m
 // [1;94m   | [0m
 // [1;94m22 | [0m    userIdC Int

--- a/psl/psl/tests/validation/mysql/set_default_no_warning_when_relation_mode_prisma.prisma
+++ b/psl/psl/tests/validation/mysql/set_default_no_warning_when_relation_mode_prisma.prisma
@@ -18,7 +18,7 @@ model B {
     aId Int? @default(3)
     a   A?   @relation(fields: [aId], references: [id], onUpdate: SetDefault, onDelete: SetDefault)
 }
-// [1;93mwarning[0m: [1mWith `relationMode = "prisma"`, no foreign keys are used, so relation fields will not benefit from the index usually created by the relational database under the hood. This can lead to poor performance when querying these fields. We recommend adding an index manually. Learn more at https://pris.ly/d/relation-mode-prisma-indexes[0m
+// [1;93mwarning[0m: [1mWith `relationMode = "prisma"`, no foreign keys are used, so relation fields will not benefit from the index usually created by the relational database under the hood. This can lead to poor performance when querying these fields. We recommend adding an index manually. Learn more at https://pris.ly/d/relation-mode-prisma-indexes" [0m
 //   [1;94m-->[0m  [4mschema.prisma:19[0m
 // [1;94m   | [0m
 // [1;94m18 | [0m    aId Int? @default(3)

--- a/psl/psl/tests/validation/mysql/set_default_no_warning_when_relation_mode_prisma.prisma
+++ b/psl/psl/tests/validation/mysql/set_default_no_warning_when_relation_mode_prisma.prisma
@@ -18,9 +18,7 @@ model B {
     aId Int? @default(3)
     a   A?   @relation(fields: [aId], references: [id], onUpdate: SetDefault, onDelete: SetDefault)
 }
-// [1;93mwarning[0m: [1mWith `relationMode = \"prisma\"`, no foreign keys are used, so relation fields will not benefit from the index usually created by the relational database under the hood.
-// This can lead to poor performance when querying these fields. We recommend adding an index manually.
-// Learn more at https://pris.ly/d/relation-mode#indexes[0m
+// [1;93mwarning[0m: [1mWith `relationMode = "prisma"`, no foreign keys are used, so relation fields will not benefit from the index usually created by the relational database under the hood. This can lead to poor performance when querying these fields. We recommend adding an index manually. Learn more at https://pris.ly/d/relation-mode-prisma-indexes[0m
 //   [1;94m-->[0m  [4mschema.prisma:19[0m
 // [1;94m   | [0m
 // [1;94m18 | [0m    aId Int? @default(3)

--- a/psl/psl/tests/validation/mysql/set_default_warning.prisma
+++ b/psl/psl/tests/validation/mysql/set_default_warning.prisma
@@ -13,13 +13,13 @@ model B {
     aId Int? @default(3)
     a   A?   @relation(fields: [aId], references: [id], onUpdate: SetDefault, onDelete: SetDefault)
 }
-// [1;93mwarning[0m: [1m`MySQL` does not actually support the `SetDefault` referential action, so using it may result in unexpected errors. Read more at https://pris.ly/d/mysql-set-default [0m
+// [1;93mwarning[0m: [1mMySQL does not actually support the `SetDefault` referential action, so using it may result in unexpected errors. Read more at https://pris.ly/d/mysql-set-default [0m
 //   [1;94m-->[0m  [4mschema.prisma:14[0m
 // [1;94m   | [0m
 // [1;94m13 | [0m    aId Int? @default(3)
 // [1;94m14 | [0m    a   A?   @relation(fields: [aId], references: [id], onUpdate: SetDefault, [1;93monDelete: SetDefault[0m)
 // [1;94m   | [0m
-// [1;93mwarning[0m: [1m`MySQL` does not actually support the `SetDefault` referential action, so using it may result in unexpected errors. Read more at https://pris.ly/d/mysql-set-default [0m
+// [1;93mwarning[0m: [1mMySQL does not actually support the `SetDefault` referential action, so using it may result in unexpected errors. Read more at https://pris.ly/d/mysql-set-default [0m
 //   [1;94m-->[0m  [4mschema.prisma:14[0m
 // [1;94m   | [0m
 // [1;94m13 | [0m    aId Int? @default(3)

--- a/psl/psl/tests/validation/mysql/set_default_warning.prisma
+++ b/psl/psl/tests/validation/mysql/set_default_warning.prisma
@@ -13,13 +13,13 @@ model B {
     aId Int? @default(3)
     a   A?   @relation(fields: [aId], references: [id], onUpdate: SetDefault, onDelete: SetDefault)
 }
-// [1;93mwarning[0m: [1mUsing SetDefault on MySQL may yield to unexpected results, as the database will silently change the referential action to `NoAction`.[0m
+// [1;93mwarning[0m: [1m`MySQL` does not actually support the `SetDefault` referential action, so using it may result in unexpected errors. Read more at https://pris.ly/d/mysql-set-default [0m
 //   [1;94m-->[0m  [4mschema.prisma:14[0m
 // [1;94m   | [0m
 // [1;94m13 | [0m    aId Int? @default(3)
 // [1;94m14 | [0m    a   A?   @relation(fields: [aId], references: [id], onUpdate: SetDefault, [1;93monDelete: SetDefault[0m)
 // [1;94m   | [0m
-// [1;93mwarning[0m: [1mUsing SetDefault on MySQL may yield to unexpected results, as the database will silently change the referential action to `NoAction`.[0m
+// [1;93mwarning[0m: [1m`MySQL` does not actually support the `SetDefault` referential action, so using it may result in unexpected errors. Read more at https://pris.ly/d/mysql-set-default [0m
 //   [1;94m-->[0m  [4mschema.prisma:14[0m
 // [1;94m   | [0m
 // [1;94m13 | [0m    aId Int? @default(3)

--- a/psl/psl/tests/validation/mysql/set_default_warning_when_relation_mode_foreignkeys.prisma
+++ b/psl/psl/tests/validation/mysql/set_default_warning_when_relation_mode_foreignkeys.prisma
@@ -18,13 +18,13 @@ model B {
     aId Int? @default(3)
     a   A?   @relation(fields: [aId], references: [id], onUpdate: SetDefault, onDelete: SetDefault)
 }
-// [1;93mwarning[0m: [1mUsing SetDefault on MySQL may yield to unexpected results, as the database will silently change the referential action to `NoAction`.[0m
+// [1;93mwarning[0m: [1m`MySQL` does not actually support the `SetDefault` referential action, so using it may result in unexpected errors. Read more at https://pris.ly/d/mysql-set-default [0m
 //   [1;94m-->[0m  [4mschema.prisma:19[0m
 // [1;94m   | [0m
 // [1;94m18 | [0m    aId Int? @default(3)
 // [1;94m19 | [0m    a   A?   @relation(fields: [aId], references: [id], onUpdate: SetDefault, [1;93monDelete: SetDefault[0m)
 // [1;94m   | [0m
-// [1;93mwarning[0m: [1mUsing SetDefault on MySQL may yield to unexpected results, as the database will silently change the referential action to `NoAction`.[0m
+// [1;93mwarning[0m: [1m`MySQL` does not actually support the `SetDefault` referential action, so using it may result in unexpected errors. Read more at https://pris.ly/d/mysql-set-default [0m
 //   [1;94m-->[0m  [4mschema.prisma:19[0m
 // [1;94m   | [0m
 // [1;94m18 | [0m    aId Int? @default(3)

--- a/psl/psl/tests/validation/mysql/set_default_warning_when_relation_mode_foreignkeys.prisma
+++ b/psl/psl/tests/validation/mysql/set_default_warning_when_relation_mode_foreignkeys.prisma
@@ -18,13 +18,13 @@ model B {
     aId Int? @default(3)
     a   A?   @relation(fields: [aId], references: [id], onUpdate: SetDefault, onDelete: SetDefault)
 }
-// [1;93mwarning[0m: [1m`MySQL` does not actually support the `SetDefault` referential action, so using it may result in unexpected errors. Read more at https://pris.ly/d/mysql-set-default [0m
+// [1;93mwarning[0m: [1mMySQL does not actually support the `SetDefault` referential action, so using it may result in unexpected errors. Read more at https://pris.ly/d/mysql-set-default [0m
 //   [1;94m-->[0m  [4mschema.prisma:19[0m
 // [1;94m   | [0m
 // [1;94m18 | [0m    aId Int? @default(3)
 // [1;94m19 | [0m    a   A?   @relation(fields: [aId], references: [id], onUpdate: SetDefault, [1;93monDelete: SetDefault[0m)
 // [1;94m   | [0m
-// [1;93mwarning[0m: [1m`MySQL` does not actually support the `SetDefault` referential action, so using it may result in unexpected errors. Read more at https://pris.ly/d/mysql-set-default [0m
+// [1;93mwarning[0m: [1mMySQL does not actually support the `SetDefault` referential action, so using it may result in unexpected errors. Read more at https://pris.ly/d/mysql-set-default [0m
 //   [1;94m-->[0m  [4mschema.prisma:19[0m
 // [1;94m   | [0m
 // [1;94m18 | [0m    aId Int? @default(3)

--- a/psl/psl/tests/validation/relations/postgres/set_null_warns_on_mixed_fields.prisma
+++ b/psl/psl/tests/validation/relations/postgres/set_null_warns_on_mixed_fields.prisma
@@ -19,16 +19,14 @@ model Profile {
 
   @@unique([user_id, user_ref])
 }
-// [1;93mwarning[0m: [1mThe `onDelete` referential action of a relation should not be set to `SetNull` when a referenced field is required. We recommend either to choose another referential action, or to make the referenced fields optional. Read more at https://pris.ly/d/postgres-set-null
-// [0m
+// [1;93mwarning[0m: [1mThe `onDelete` referential action of a relation should not be set to `SetNull` when a referenced field is required. We recommend either to choose another referential action, or to make the referenced fields optional. Read more at https://pris.ly/d/postgres-set-null [0m
 //   [1;94m-->[0m  [4mschema.prisma:16[0m
 // [1;94m   | [0m
 // [1;94m15 | [0m  id       Int       @id
 // [1;94m16 | [0m  [1;93muser     SomeUser? @relation(fields: [user_id, user_ref], references: [id, ref], onUpdate: SetNull, onDelete: SetNull)[0m
 // [1;94m17 | [0m  user_id  Int?
 // [1;94m   | [0m
-// [1;93mwarning[0m: [1mThe `onUpdate` referential action of a relation should not be set to `SetNull` when a referenced field is required. We recommend either to choose another referential action, or to make the referenced fields optional. Read more at https://pris.ly/d/postgres-set-null
-// [0m
+// [1;93mwarning[0m: [1mThe `onUpdate` referential action of a relation should not be set to `SetNull` when a referenced field is required. We recommend either to choose another referential action, or to make the referenced fields optional. Read more at https://pris.ly/d/postgres-set-null [0m
 //   [1;94m-->[0m  [4mschema.prisma:16[0m
 // [1;94m   | [0m
 // [1;94m15 | [0m  id       Int       @id

--- a/psl/psl/tests/validation/relations/postgres/set_null_warns_on_required_fields.prisma
+++ b/psl/psl/tests/validation/relations/postgres/set_null_warns_on_required_fields.prisma
@@ -13,16 +13,14 @@ model Profile {
   user    SomeUser? @relation(fields: [user_id], references: [id], onUpdate: SetNull, onDelete: SetNull)
   user_id Int       @unique
 }
-// [1;93mwarning[0m: [1mThe `onDelete` referential action of a relation should not be set to `SetNull` when a referenced field is required. We recommend either to choose another referential action, or to make the referenced fields optional. Read more at https://pris.ly/d/postgres-set-null
-// [0m
+// [1;93mwarning[0m: [1mThe `onDelete` referential action of a relation should not be set to `SetNull` when a referenced field is required. We recommend either to choose another referential action, or to make the referenced fields optional. Read more at https://pris.ly/d/postgres-set-null [0m
 //   [1;94m-->[0m  [4mschema.prisma:13[0m
 // [1;94m   | [0m
 // [1;94m12 | [0m  id      Int       @id
 // [1;94m13 | [0m  [1;93muser    SomeUser? @relation(fields: [user_id], references: [id], onUpdate: SetNull, onDelete: SetNull)[0m
 // [1;94m14 | [0m  user_id Int       @unique
 // [1;94m   | [0m
-// [1;93mwarning[0m: [1mThe `onUpdate` referential action of a relation should not be set to `SetNull` when a referenced field is required. We recommend either to choose another referential action, or to make the referenced fields optional. Read more at https://pris.ly/d/postgres-set-null
-// [0m
+// [1;93mwarning[0m: [1mThe `onUpdate` referential action of a relation should not be set to `SetNull` when a referenced field is required. We recommend either to choose another referential action, or to make the referenced fields optional. Read more at https://pris.ly/d/postgres-set-null [0m
 //   [1;94m-->[0m  [4mschema.prisma:13[0m
 // [1;94m   | [0m
 // [1;94m12 | [0m  id      Int       @id


### PR DESCRIPTION
Closes https://github.com/prisma/prisma/issues/16440.

- [x] `SetDefault` on `mysql`
  """
  `MySQL` does not actually support the `SetDefault` referential action, so using it may result in unexpected errors. Read more at https://pris.ly/d/mysql-set-default
  """

- [x] `SetNull` on `postgres`
  """
  The `onDelete` referential action of a relation should not be set to `SetNull` when a referenced field is required. We recommend either to choose another referential action, or to make the referenced fields optional. Read more at https://pris.ly/d/postgres-set-null
  """

- [x] Missing indexes on `relationMode = "prisma"`
  """
  With `relationMode = "prisma"`, no foreign keys are used, so relation fields will not benefit from the index usually created by the relational database under the hood. This can lead to poor performance when querying these fields. We recommend adding an index manually. Learn more at https://pris.ly/d/relation-mode-prisma-indexes
  """