### PR TITLE
Test warnings for commenting out invalid variants

### DIFF
--- a/introspection-engine/connectors/sql-introspection-connector/src/introspection/enums.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/introspection/enums.rs
@@ -41,11 +41,8 @@ fn render_enum<'a>(r#enum: EnumPair<'a>, output: &mut OutputContext<'a>) -> rend
     if let Some(mapped_name) = r#enum.mapped_name() {
         rendered_enum.map(mapped_name);
 
-        output
-            .warnings
-            .push(warnings::warning_enriched_with_map_on_enum(&[warnings::Enum::new(
-                &r#enum.name(),
-            )]));
+        let warning = warnings::warning_enriched_with_map_on_enum(&[warnings::Enum::new(&r#enum.name())]);
+        output.warnings.push(warning);
     }
 
     if let Some(docs) = r#enum.documentation() {
@@ -65,11 +62,6 @@ fn render_enum<'a>(r#enum: EnumPair<'a>, output: &mut OutputContext<'a>) -> rend
             };
 
             output.warnings.enum_values_with_empty_names.push(warning);
-        } else if variant.mapped_name().is_some() {
-            remapped_values.push(warnings::EnumAndValue {
-                value: variant.name().to_string(),
-                enm: r#enum.name().to_string(),
-            });
         }
 
         let mut rendered_variant = renderer::EnumVariant::new(variant.name());
@@ -83,7 +75,18 @@ fn render_enum<'a>(r#enum: EnumPair<'a>, output: &mut OutputContext<'a>) -> rend
         }
 
         if variant.name().is_empty() || sanitize_datamodel_names::needs_sanitation(&variant.name()) {
+            let warning = warnings::EnumAndValue {
+                enm: r#enum.name().to_string(),
+                value: variant.name().to_string(),
+            };
+
+            output.warnings.enum_values_with_empty_names.push(warning);
             rendered_variant.comment_out();
+        } else if variant.mapped_name().is_some() {
+            remapped_values.push(warnings::EnumAndValue {
+                value: variant.name().to_string(),
+                enm: r#enum.name().to_string(),
+            });
         }
 
         rendered_enum.push_variant(rendered_variant);

--- a/introspection-engine/connectors/sql-introspection-connector/src/pair/enumerator.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/pair/enumerator.rs
@@ -87,21 +87,23 @@ impl<'a> EnumVariantPair<'a> {
     /// it contains characters that are not allowed in the PSL
     /// definition.
     pub(crate) fn name(self) -> Cow<'a, str> {
-        self.previous
-            .map(|variant| Cow::Borrowed(variant.name()))
-            .unwrap_or_else(|| match self.next.name() {
-                name if name.is_empty() => Cow::Borrowed("EMPTY_ENUM_VALUE"),
-                name if sanitize_datamodel_names::needs_sanitation(name) => {
-                    let sanitized = sanitize_datamodel_names::sanitize_string(name);
+        if let Some(name) = self.previous.map(|variant| variant.name()) {
+            return Cow::Borrowed(name);
+        }
 
-                    if sanitized.is_empty() {
-                        Cow::Borrowed(name)
-                    } else {
-                        Cow::Owned(sanitized)
-                    }
+        match self.next.name() {
+            name if name.is_empty() => Cow::Borrowed("EMPTY_ENUM_VALUE"),
+            name if sanitize_datamodel_names::needs_sanitation(name) => {
+                let sanitized = sanitize_datamodel_names::sanitize_string(name);
+
+                if sanitized.is_empty() {
+                    Cow::Borrowed(name)
+                } else {
+                    Cow::Owned(sanitized)
                 }
-                name => Cow::Borrowed(name),
-            })
+            }
+            name => Cow::Borrowed(name),
+        }
     }
 
     /// The mapped name, if defined, is the actual name of the variant in

--- a/introspection-engine/introspection-engine-tests/src/test_api.rs
+++ b/introspection-engine/introspection-engine-tests/src/test_api.rs
@@ -306,6 +306,14 @@ impl TestApi {
     }
 
     #[track_caller]
+    pub async fn expect_warnings(&self, expectation: &expect_test::Expect) {
+        let previous_schema = psl::validate(self.pure_config().into());
+        let introspection_result = self.test_introspect_internal(previous_schema, true).await.unwrap();
+
+        expectation.assert_eq(&serde_json::to_string_pretty(&introspection_result.warnings).unwrap());
+    }
+
+    #[track_caller]
     pub async fn expect_re_introspected_datamodel(&self, schema: &str, expectation: expect_test::Expect) {
         let data_model = parse_datamodel(&format!("{}{}", self.pure_config(), schema));
         let reintrospected = self.test_introspect_internal(data_model, false).await.unwrap();


### PR DESCRIPTION
Fixes test failures in [prisma/prisma@`b1843d7` (#16459)](https://github.com/prisma/prisma/pull/16459/commits/b1843d734befdcde7737a356554836b516a501e5)