### PR TITLE
feat(psl): add deprecation warning for the "referentialIntegrity" attribute

### DIFF
--- a/psl/diagnostics/src/warning.rs
+++ b/psl/diagnostics/src/warning.rs
@@ -27,6 +27,11 @@ impl DatamodelWarning {
         Self::new(message, span)
     }
 
+    pub fn new_referential_integrity_attr_deprecation_warning(span: Span) -> DatamodelWarning {
+        let message = "The `referentialIntegrity` attribute is deprecated. Please use `relationMode` instead. Learn more at https://pris.ly/d/relation-mode";
+        Self::new(message.to_string(), span)
+    }
+
     pub fn new_missing_index_on_emulated_relation(span: Span) -> DatamodelWarning {
         let message = indoc!(
             r#"

--- a/psl/psl/tests/config/sources.rs
+++ b/psl/psl/tests/config/sources.rs
@@ -641,35 +641,6 @@ fn relation_mode_default() {
     assert_eq!(config.relation_mode(), Some(RelationMode::ForeignKeys));
 }
 
-#[test]
-fn relation_mode_and_referential_integrity_cannot_cooccur() {
-    let schema = indoc! {r#"
-        datasource ps {
-          provider = "sqlite"
-          url = "sqlite"
-          relationMode = "prisma"
-          referentialIntegrity = "foreignKeys"
-        }
-        generator client {
-          provider = "prisma-client-js"
-        }
-    "#};
-
-    let config = parse_config(schema);
-    let error = config.unwrap_err();
-
-    let expectation = expect![[r#"
-        [1;91merror[0m: [1mThe `referentialIntegrity` and `relationMode` attributes cannot be used together. Please use only `relationMode` instead.[0m
-          [1;94m-->[0m  [4mschema.prisma:5[0m
-        [1;94m   | [0m
-        [1;94m 4 | [0m  relationMode = "prisma"
-        [1;94m 5 | [0m  [1;91mreferentialIntegrity = "foreignKeys"[0m
-        [1;94m 6 | [0m}
-        [1;94m   | [0m
-    "#]];
-    expectation.assert_eq(&error);
-}
-
 fn load_env_var(key: &str) -> Option<String> {
     std::env::var(key).ok()
 }

--- a/psl/psl/tests/validation/attributes/relation_mode/referential_integrity_attr_is_deprecated.prisma
+++ b/psl/psl/tests/validation/attributes/relation_mode/referential_integrity_attr_is_deprecated.prisma
@@ -1,0 +1,12 @@
+datasource db {
+  provider = "sqlite"
+  url = "sqlite"
+  referentialIntegrity = "foreignKeys"
+}
+// [1;93mwarning[0m: [1mThe `referentialIntegrity` attribute is deprecated. Please use `relationMode` instead. Learn more at https://pris.ly/d/relation-mode[0m
+//   [1;94m-->[0m  [4mschema.prisma:4[0m
+// [1;94m   | [0m
+// [1;94m 3 | [0m  url = "sqlite"
+// [1;94m 4 | [0m  [1;93mreferentialIntegrity = "foreignKeys"[0m
+// [1;94m 5 | [0m}
+// [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/relation_mode/relation_mode_and_referential_integrity_cannot_cooccur.prisma
+++ b/psl/psl/tests/validation/attributes/relation_mode/relation_mode_and_referential_integrity_cannot_cooccur.prisma
@@ -4,6 +4,13 @@ datasource db {
   relationMode = "prisma"
   referentialIntegrity = "foreignKeys"
 }
+// [1;93mwarning[0m: [1mThe `referentialIntegrity` attribute is deprecated. Please use `relationMode` instead. Learn more at https://pris.ly/d/relation-mode[0m
+//   [1;94m-->[0m  [4mschema.prisma:5[0m
+// [1;94m   | [0m
+// [1;94m 4 | [0m  relationMode = "prisma"
+// [1;94m 5 | [0m  [1;93mreferentialIntegrity = "foreignKeys"[0m
+// [1;94m 6 | [0m}
+// [1;94m   | [0m
 // [1;91merror[0m: [1mThe `referentialIntegrity` and `relationMode` attributes cannot be used together. Please use only `relationMode` instead.[0m
 //   [1;94m-->[0m  [4mschema.prisma:5[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/relation_mode/relation_mode_and_referential_integrity_cannot_cooccur.prisma
+++ b/psl/psl/tests/validation/attributes/relation_mode/relation_mode_and_referential_integrity_cannot_cooccur.prisma
@@ -1,0 +1,13 @@
+datasource db {
+  provider = "sqlite"
+  url = "sqlite"
+  relationMode = "prisma"
+  referentialIntegrity = "foreignKeys"
+}
+// [1;91merror[0m: [1mThe `referentialIntegrity` and `relationMode` attributes cannot be used together. Please use only `relationMode` instead.[0m
+//   [1;94m-->[0m  [4mschema.prisma:5[0m
+// [1;94m   | [0m
+// [1;94m 4 | [0m  relationMode = "prisma"
+// [1;94m 5 | [0m  [1;91mreferentialIntegrity = "foreignKeys"[0m
+// [1;94m 6 | [0m}
+// [1;94m   | [0m


### PR DESCRIPTION
The `referentialIntegrity` attribute to set the `foreignKeys`|`prisma` settings is deprecated in favor of `relationMode` as of https://github.com/prisma/prisma-engines/pull/3428.
This PR adds a validation warning when `referentialIntegrity` appears as a `datasource` attribute in a Prisma schema:

"""
The `referentialIntegrity` attribute is deprecated. Please use `relationMode` instead. Learn more at https://pris.ly/d/relation-mode
"""

Closes https://github.com/prisma/prisma/issues/15689.