### PR TITLE
migration-engine: fix multiSchema tests for CockroachDB

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer.rs
@@ -91,7 +91,7 @@ pub(crate) trait SqlRenderer {
     fn render_redefine_tables(&self, tables: &[RedefineTable], schemas: Pair<&SqlSchema>) -> Vec<String>;
 
     /// Render a table renaming step.
-    fn render_rename_table(&self, name: &str, new_name: &str) -> String;
+    fn render_rename_table(&self, namespace: Option<&str>, name: &str, new_name: &str) -> String;
 
     /// Render a drop view step.
     fn render_drop_view(&self, view: ViewWalker<'_>) -> String;

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/common.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/common.rs
@@ -4,6 +4,7 @@ use std::fmt::{Display, Write as _};
 pub(super) const SQL_INDENTATION: &str = "    ";
 
 /// A quoted identifier with an optional schema prefix.
+#[derive(Clone, Copy)]
 pub(crate) struct QuotedWithPrefix<T>(pub(crate) Option<Quoted<T>>, pub(crate) Quoted<T>);
 
 impl QuotedWithPrefix<&str> {
@@ -32,7 +33,7 @@ where
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub(crate) enum Quoted<T> {
     Double(T),
     Single(T),

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mssql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mssql_renderer.rs
@@ -334,7 +334,7 @@ impl SqlRenderer for MssqlFlavour {
             result.extend(self.render_drop_table(None, tables.previous.name()));
 
             // Rename the temporary table with the name defined in the migration.
-            result.push(self.render_rename_table(&temporary_table_name, tables.next.name()));
+            result.push(self.render_rename_table(tables.next.namespace(), &temporary_table_name, tables.next.name()));
 
             // Recreate the indexes.
             for index in tables.next.indexes().filter(|i| !i.is_unique() && !i.is_primary_key()) {
@@ -347,7 +347,7 @@ impl SqlRenderer for MssqlFlavour {
         result
     }
 
-    fn render_rename_table(&self, name: &str, new_name: &str) -> String {
+    fn render_rename_table(&self, _namespace: Option<&str>, name: &str, new_name: &str) -> String {
         let with_schema = format!("{}.{}", self.schema_name(), name);
 
         format!(

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
@@ -319,7 +319,7 @@ impl SqlRenderer for MysqlFlavour {
         unreachable!("render_redefine_table on MySQL")
     }
 
-    fn render_rename_table(&self, name: &str, new_name: &str) -> String {
+    fn render_rename_table(&self, _namespace: Option<&str>, name: &str, new_name: &str) -> String {
         sql_ddl::mysql::AlterTable {
             table_name: name.into(),
             changes: vec![sql_ddl::mysql::AlterTableClause::RenameTo {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/sqlite_renderer.rs
@@ -217,7 +217,7 @@ impl SqlRenderer for SqliteFlavour {
         result
     }
 
-    fn render_rename_table(&self, name: &str, new_name: &str) -> String {
+    fn render_rename_table(&self, _namespace: Option<&str>, name: &str, new_name: &str) -> String {
         format!(r#"ALTER TABLE "{}" RENAME TO "{}""#, name, new_name)
     }
 

--- a/migration-engine/migration-engine-tests/tests/migrations/postgres/multi_schema.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/postgres/multi_schema.rs
@@ -84,12 +84,7 @@ struct TestData {
 
 // This is the only "top" level test in this module. It defines a list of tests and executes them.
 // If you want to look at the tests, see the `tests` variable below.
-#[test_connector(
-    tags(Postgres),
-    exclude(CockroachDb),
-    preview_features("multiSchema"),
-    namespaces("one", "two")
-)]
+#[test_connector(tags(Postgres), preview_features("multiSchema"), namespaces("one", "two"))]
 fn multi_schema_tests(_api: TestApi) {
     let namespaces: &'static [&'static str] = &["one", "two"];
     let base_schema = indoc! {r#"
@@ -352,9 +347,8 @@ fn multi_schema_tests(_api: TestApi) {
             assertion: Box::new(|assert| {
                 assert.assert_has_table_with_ns("one", "First")
                       .assert_table_with_ns("two", "Second", |table|
-                          table.assert_column("id", |column|
-                              column.assert_is_required()
-                                    .assert_auto_increments()
+                          table.assert_pk(|pk|
+                              pk.assert_has_autoincrement()
                           ));
             }),
             skip: None,


### PR DESCRIPTION
This turned out to be easier than I thought. Still have to see if there are other Cockroach-db-specific scenarios we should be testing.