### PR TITLE
qe: simplify handling of preview features

### DIFF
--- a/psl/psl-core/src/common.rs
+++ b/psl/psl-core/src/common.rs
@@ -2,4 +2,4 @@
 
 mod preview_features;
 
-pub use self::preview_features::{FeatureMap, PreviewFeature, ALL_PREVIEW_FEATURES};
+pub use self::preview_features::{FeatureMap, PreviewFeature, PreviewFeatures, ALL_PREVIEW_FEATURES};

--- a/psl/psl-core/src/common/preview_features.rs
+++ b/psl/psl-core/src/common/preview_features.rs
@@ -1,6 +1,8 @@
-use enumflags2::BitFlags;
 use serde::{Serialize, Serializer};
 use std::fmt;
+
+/// A set of preview features.
+pub type PreviewFeatures = enumflags2::BitFlags<PreviewFeature>;
 
 macro_rules! features {
     ($( $variant:ident $(,)? ),*) => {
@@ -123,22 +125,22 @@ pub const ALL_PREVIEW_FEATURES: FeatureMap = FeatureMap {
 #[derive(Debug)]
 pub struct FeatureMap {
     /// Valid, visible features.
-    active: BitFlags<PreviewFeature>,
+    active: PreviewFeatures,
 
     /// Deprecated features.
-    deprecated: BitFlags<PreviewFeature>,
+    deprecated: PreviewFeatures,
 
     /// Hidden preview features are valid features, but are not propagated into the tooling
     /// (as autocomplete or similar) or into error messages (eg. showing a list of valid features).
-    hidden: BitFlags<PreviewFeature>,
+    hidden: PreviewFeatures,
 }
 
 impl FeatureMap {
-    pub const fn active_features(&self) -> BitFlags<PreviewFeature> {
+    pub const fn active_features(&self) -> PreviewFeatures {
         self.active
     }
 
-    pub const fn hidden_features(&self) -> BitFlags<PreviewFeature> {
+    pub const fn hidden_features(&self) -> PreviewFeatures {
         self.hidden
     }
 

--- a/psl/psl-core/src/lib.rs
+++ b/psl/psl-core/src/lib.rs
@@ -14,7 +14,7 @@ mod reformat;
 mod validate;
 
 pub use crate::{
-    common::{PreviewFeature, ALL_PREVIEW_FEATURES},
+    common::{PreviewFeature, PreviewFeatures, ALL_PREVIEW_FEATURES},
     configuration::{Configuration, Datasource, DatasourceConnectorData, Generator, StringFromEnvVar},
     reformat::reformat,
 };

--- a/psl/psl/src/lib.rs
+++ b/psl/psl/src/lib.rs
@@ -17,6 +17,7 @@ pub use psl_core::{
     DatasourceConnectorData,
     Generator,
     PreviewFeature,
+    PreviewFeatures,
     StringFromEnvVar,
     ValidatedSchema,
     ALL_PREVIEW_FEATURES,

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/direct.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/direct.rs
@@ -20,16 +20,15 @@ impl RunnerInterface for DirectRunner {
     async fn load(datamodel: String, connector_tag: ConnectorTag, metrics: MetricRegistry) -> TestResult<Self> {
         let schema = psl::parse_schema(datamodel).unwrap();
         let data_source = schema.configuration.datasources.first().unwrap();
-        let preview_features: Vec<_> = schema.configuration.preview_features().iter().collect();
         let url = data_source.load_url(|key| env::var(key).ok()).unwrap();
-        let (db_name, executor) = executor::load(data_source, &preview_features, &url).await?;
+        let (db_name, executor) = executor::load(data_source, schema.configuration.preview_features(), &url).await?;
         let internal_data_model = prisma_models::convert(&schema, db_name);
 
         let query_schema: QuerySchemaRef = Arc::new(schema_builder::build(
             internal_data_model,
             true,
             data_source.active_connector,
-            preview_features,
+            schema.configuration.preview_features(),
             data_source.relation_mode(),
         ));
 

--- a/query-engine/connectors/sql-query-connector/src/database/mod.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/mod.rs
@@ -9,7 +9,6 @@ pub(crate) mod operations;
 
 use async_trait::async_trait;
 use connector_interface::{error::ConnectorError, Connector};
-use psl::{Datasource, PreviewFeature};
 
 pub use mssql::*;
 pub use mysql::*;
@@ -29,9 +28,9 @@ pub trait FromSource {
     ///
     /// 2. The url may be modified with the config dir, in the case of Node-API.
     async fn from_source(
-        source: &Datasource,
+        source: &psl::Datasource,
         url: &str,
-        features: &[PreviewFeature],
+        features: psl::PreviewFeatures,
     ) -> connector_interface::Result<Self>
     where
         Self: Connector + Sized;

--- a/query-engine/connectors/sql-query-connector/src/database/mysql.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/mysql.rs
@@ -6,30 +6,29 @@ use connector_interface::{
     error::{ConnectorError, ErrorKind},
     Connection, Connector,
 };
-use psl::{Datasource, PreviewFeature};
 use quaint::{pooled::Quaint, prelude::ConnectionInfo};
 use std::time::Duration;
 
 pub struct Mysql {
     pool: Quaint,
     connection_info: ConnectionInfo,
-    features: Vec<PreviewFeature>,
+    features: psl::PreviewFeatures,
 }
 
 impl Mysql {
     /// Get MySQL's preview features.
-    pub fn features(&self) -> &[PreviewFeature] {
-        self.features.as_ref()
+    pub fn features(&self) -> psl::PreviewFeatures {
+        self.features
     }
 }
 
 #[async_trait]
 impl FromSource for Mysql {
     async fn from_source(
-        _source: &Datasource,
+        _source: &psl::Datasource,
         url: &str,
-        features: &[PreviewFeature],
-    ) -> connector_interface::Result<Self> {
+        features: psl::PreviewFeatures,
+    ) -> connector_interface::Result<Mysql> {
         let database_str = url;
 
         let connection_info = ConnectionInfo::from_url(database_str).map_err(|err| {
@@ -62,7 +61,7 @@ impl Connector for Mysql {
     async fn get_connection<'a>(&'a self) -> connector::Result<Box<dyn Connection + Send + Sync + 'static>> {
         super::catch(self.connection_info.clone(), async move {
             let conn = self.pool.check_out().await.map_err(SqlError::from)?;
-            let conn = SqlConnection::new(conn, &self.connection_info, self.features.clone());
+            let conn = SqlConnection::new(conn, &self.connection_info, self.features);
 
             Ok(Box::new(conn) as Box<dyn Connection + Send + Sync + 'static>)
         })

--- a/query-engine/connectors/sql-query-connector/src/database/operations/write.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/write.rs
@@ -6,7 +6,6 @@ use connector_interface::*;
 use itertools::Itertools;
 use prisma_models::*;
 use psl::dml::prisma_value::PrismaValue;
-use psl::PreviewFeature;
 use quaint::{
     error::ErrorKind,
     prelude::{native_uuid, uuid_to_bin, uuid_to_bin_swapped, Aliasable, Select, SqlFamily},
@@ -460,7 +459,7 @@ pub async fn m2m_disconnect(
 /// affected rows.
 pub async fn execute_raw(
     conn: &dyn QueryExt,
-    features: &[PreviewFeature],
+    features: psl::PreviewFeatures,
     inputs: HashMap<String, PrismaValue>,
 ) -> crate::Result<usize> {
     let value = conn.raw_count(inputs, features).await?;
@@ -473,7 +472,7 @@ pub async fn execute_raw(
 pub async fn query_raw(
     conn: &dyn QueryExt,
     sql_info: SqlInfo,
-    features: &[PreviewFeature],
+    features: psl::PreviewFeatures,
     inputs: HashMap<String, PrismaValue>,
 ) -> crate::Result<serde_json::Value> {
     let value = conn.raw_json(sql_info, features, inputs).await?;

--- a/query-engine/connectors/sql-query-connector/src/query_ext.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_ext.rs
@@ -8,7 +8,6 @@ use futures::future::FutureExt;
 use itertools::Itertools;
 use opentelemetry::trace::TraceFlags;
 use prisma_models::*;
-use psl::PreviewFeature;
 use quaint::{
     ast::*,
     connector::{self, Queryable},
@@ -70,7 +69,7 @@ pub trait QueryExt: Queryable + Send + Sync {
     async fn raw_json<'a>(
         &'a self,
         _sql_info: SqlInfo,
-        _features: &[PreviewFeature],
+        _features: psl::PreviewFeatures,
         mut inputs: HashMap<String, PrismaValue>,
     ) -> std::result::Result<Value, crate::error::RawError> {
         // Unwrapping query & params is safe since it's already passed the query parsing stage
@@ -105,7 +104,7 @@ pub trait QueryExt: Queryable + Send + Sync {
     async fn raw_count<'a>(
         &'a self,
         mut inputs: HashMap<String, PrismaValue>,
-        _features: &[PreviewFeature],
+        _features: psl::PreviewFeatures,
     ) -> std::result::Result<usize, crate::error::RawError> {
         // Unwrapping query & params is safe since it's already passed the query parsing stage
         let query = inputs.remove("query").unwrap().into_string().unwrap();

--- a/query-engine/core/src/executor/loader.rs
+++ b/query-engine/core/src/executor/loader.rs
@@ -3,7 +3,7 @@ use crate::CoreError;
 use connection_string::JdbcString;
 use connector::Connector;
 use mongodb_client::MongoConnectionString;
-use psl::{builtin_connectors::*, Datasource, PreviewFeature};
+use psl::{builtin_connectors::*, Datasource, PreviewFeatures};
 use sql_connector::*;
 use std::collections::HashMap;
 use std::str::FromStr;
@@ -17,7 +17,7 @@ const DEFAULT_SQLITE_DB_NAME: &str = "main";
 /// Loads a query executor based on the parsed Prisma schema (datasource).
 pub async fn load(
     source: &Datasource,
-    features: &[PreviewFeature],
+    features: PreviewFeatures,
     url: &str,
 ) -> crate::Result<(String, Box<dyn QueryExecutor + Send + Sync>)> {
     match source.active_provider {
@@ -96,7 +96,7 @@ pub fn db_name(source: &Datasource, url: &str) -> crate::Result<String> {
 async fn sqlite(
     source: &Datasource,
     url: &str,
-    features: &[PreviewFeature],
+    features: PreviewFeatures,
 ) -> crate::Result<(String, Box<dyn QueryExecutor + Send + Sync>)> {
     trace!("Loading SQLite query connector...");
 
@@ -111,7 +111,7 @@ async fn sqlite(
 async fn postgres(
     source: &Datasource,
     url: &str,
-    features: &[PreviewFeature],
+    features: PreviewFeatures,
 ) -> crate::Result<(String, Box<dyn QueryExecutor + Send + Sync>)> {
     trace!("Loading Postgres query connector...");
 
@@ -135,7 +135,7 @@ async fn postgres(
 async fn mysql(
     source: &Datasource,
     url: &str,
-    features: &[PreviewFeature],
+    features: PreviewFeatures,
 ) -> crate::Result<(String, Box<dyn QueryExecutor + Send + Sync>)> {
     trace!("Loading MySQL query connector...");
 
@@ -150,7 +150,7 @@ async fn mysql(
 async fn mssql(
     source: &Datasource,
     url: &str,
-    features: &[PreviewFeature],
+    features: PreviewFeatures,
 ) -> crate::Result<(String, Box<dyn QueryExecutor + Send + Sync>)> {
     trace!("Loading SQL Server query connector...");
 
@@ -173,7 +173,7 @@ where
 async fn mongodb(
     source: &Datasource,
     url: &str,
-    _features: &[PreviewFeature],
+    _features: PreviewFeatures,
 ) -> crate::Result<(String, Box<dyn QueryExecutor + Send + Sync>)> {
     trace!("Loading MongoDB query connector...");
 

--- a/query-engine/dmmf/src/lib.rs
+++ b/query-engine/dmmf/src/lib.rs
@@ -15,21 +15,16 @@ pub fn dmmf_json_from_schema(schema: &str) -> String {
 // enable raw param?
 pub fn dmmf_from_schema(schema: &str) -> DataModelMetaFormat {
     let schema = psl::parse_schema(schema).unwrap();
-    let config = &schema.configuration;
     let dml = psl::lift(&schema);
-
-    // We only support one data source at the moment, so take the first one (default not exposed yet).
-    let data_source = config.datasources.first().unwrap();
-    let preview_features: Vec<_> = config.preview_features().iter().collect();
     let internal_data_model = prisma_models::convert(&schema, "dummy".to_owned());
 
     // Construct query schema
     let query_schema = Arc::new(schema_builder::build(
         internal_data_model,
         true, // todo
-        data_source.active_connector,
-        preview_features,
-        data_source.relation_mode(),
+        schema.connector,
+        schema.configuration.preview_features(),
+        schema.relation_mode(),
     ));
 
     from_precomputed_parts(&dml, query_schema)

--- a/query-engine/query-engine-node-api/src/engine.rs
+++ b/query-engine/query-engine-node-api/src/engine.rs
@@ -220,12 +220,12 @@ impl QueryEngine {
                     .first()
                     .ok_or_else(|| ApiError::configuration("No valid data source found"))?;
 
-                let preview_features: Vec<_> = builder.schema.configuration.preview_features().iter().collect();
+                let preview_features = builder.schema.configuration.preview_features();
                 let url = data_source
                     .load_url_with_config_dir(&builder.config_dir, |key| builder.env.get(key).map(ToString::to_string))
                     .map_err(|err| crate::error::ApiError::Conversion(err, builder.schema.db.source().to_owned()))?;
 
-                let (db_name, executor) = executor::load(data_source, &preview_features, &url).await?;
+                let (db_name, executor) = executor::load(data_source, preview_features, &url).await?;
                 let connector = executor.primary_connector();
                 connector.get_connection().await?;
 

--- a/query-engine/query-engine/src/context.rs
+++ b/query-engine/query-engine/src/context.rs
@@ -61,8 +61,7 @@ impl PrismaContext {
         let url = data_source.load_url(|key| env::var(key).ok())?;
 
         // Load executor
-        let preview_features: Vec<_> = config.preview_features().iter().collect();
-        let (db_name, executor) = executor::load(data_source, &preview_features, &url).await?;
+        let (db_name, executor) = executor::load(data_source, config.preview_features(), &url).await?;
 
         // Build internal data model
         let internal_data_model = prisma_models::convert(&schema, db_name);
@@ -72,7 +71,7 @@ impl PrismaContext {
             internal_data_model,
             enable_raw_queries,
             data_source.active_connector,
-            preview_features,
+            config.preview_features(),
             data_source.relation_mode(),
         ));
 

--- a/query-engine/schema-builder/src/input_types/fields/field_ref_type.rs
+++ b/query-engine/schema-builder/src/input_types/fields/field_ref_type.rs
@@ -1,5 +1,4 @@
 use super::*;
-
 use crate::constants::filters;
 
 pub(crate) trait WithFieldRefInputExt {
@@ -10,7 +9,7 @@ impl WithFieldRefInputExt for InputType {
     fn with_field_ref_input(self, ctx: &mut BuilderContext) -> Vec<InputType> {
         let mut field_types: Vec<InputType> = vec![self.clone()];
 
-        if ctx.has_feature(&PreviewFeature::FieldReference) {
+        if ctx.has_feature(PreviewFeature::FieldReference) {
             field_types.push(InputType::object(field_ref_input_object_type(ctx, self)));
         }
 

--- a/query-engine/schema-builder/src/input_types/fields/input_fields.rs
+++ b/query-engine/schema-builder/src/input_types/fields/input_fields.rs
@@ -165,7 +165,7 @@ pub(crate) fn nested_disconnect_input_field(
         (false, false) => {
             let mut types = vec![InputType::boolean()];
 
-            if ctx.has_feature(&PreviewFeature::ExtendedWhereUnique) {
+            if ctx.has_feature(PreviewFeature::ExtendedWhereUnique) {
                 types.push(InputType::object(filter_objects::where_object_type(
                     ctx,
                     &parent_field.related_model(),
@@ -188,7 +188,7 @@ pub(crate) fn nested_delete_input_field(
         (false, false) => {
             let mut types = vec![InputType::boolean()];
 
-            if ctx.has_feature(&PreviewFeature::ExtendedWhereUnique) {
+            if ctx.has_feature(PreviewFeature::ExtendedWhereUnique) {
                 types.push(InputType::object(filter_objects::where_object_type(
                     ctx,
                     &parent_field.related_model(),
@@ -215,7 +215,7 @@ pub(crate) fn nested_update_input_field(ctx: &mut BuilderContext, parent_field: 
             update_one_objects::update_one_where_combination_object(ctx, update_shorthand_types.clone(), parent_field);
 
         list_union_object_type(to_many_update_full_type, true)
-    } else if ctx.has_feature(&PreviewFeature::ExtendedWhereUnique) {
+    } else if ctx.has_feature(PreviewFeature::ExtendedWhereUnique) {
         let to_one_update_full_type = update_one_objects::update_to_one_rel_where_combination_object(
             ctx,
             update_shorthand_types.clone(),

--- a/query-engine/schema-builder/src/input_types/objects/filter_objects.rs
+++ b/query-engine/schema-builder/src/input_types/objects/filter_objects.rs
@@ -133,7 +133,7 @@ pub(crate) fn where_unique_object_type(ctx: &mut BuilderContext, model: &ModelRe
 
     let mut x = init_input_object_type(ident.clone());
 
-    if ctx.has_feature(&PreviewFeature::ExtendedWhereUnique) {
+    if ctx.has_feature(PreviewFeature::ExtendedWhereUnique) {
         x.require_at_least_one_field();
         x.apply_constraints_on_fields(constrained_fields);
     } else {
@@ -189,7 +189,7 @@ pub(crate) fn where_unique_object_type(ctx: &mut BuilderContext, model: &ModelRe
     fields.extend(compound_unique_fields);
     fields.extend(compound_id_field);
 
-    if ctx.has_feature(&PreviewFeature::ExtendedWhereUnique) {
+    if ctx.has_feature(PreviewFeature::ExtendedWhereUnique) {
         fields.extend(boolean_operators);
         fields.extend(rest_fields);
     }

--- a/query-engine/schema-builder/src/input_types/objects/order_by_objects.rs
+++ b/query-engine/schema-builder/src/input_types/objects/order_by_objects.rs
@@ -138,7 +138,7 @@ fn orderby_field_mapper(field: &ModelField, ctx: &mut BuilderContext, options: &
         ModelField::Scalar(sf) => {
             let mut types = vec![InputType::Enum(sort_order_enum(ctx))];
 
-            if ctx.has_feature(&PreviewFeature::OrderByNulls)
+            if ctx.has_feature(PreviewFeature::OrderByNulls)
                 && ctx.has_capability(ConnectorCapability::OrderByNullsFirstLast)
                 && !sf.is_required()
                 && !sf.is_list()

--- a/query-engine/schema-builder/src/input_types/objects/upsert_objects.rs
+++ b/query-engine/schema-builder/src/input_types/objects/upsert_objects.rs
@@ -88,7 +88,7 @@ fn nested_upsert_nonlist_input_object(
                 input_field(args::CREATE, create_types, None),
             ];
 
-            if ctx.has_feature(&PreviewFeature::ExtendedWhereUnique) {
+            if ctx.has_feature(PreviewFeature::ExtendedWhereUnique) {
                 fields.push(where_argument(ctx, &related_model));
             }
 

--- a/query-engine/schema-builder/src/output_types/field.rs
+++ b/query-engine/schema-builder/src/output_types/field.rs
@@ -119,7 +119,7 @@ where
         .map(|rf| {
             let mut args = vec![];
 
-            if ctx.has_feature(&PreviewFeature::FilteredRelationCount) {
+            if ctx.has_feature(PreviewFeature::FilteredRelationCount) {
                 args.push(arguments::where_argument(ctx, &rf.related_model()))
             }
 

--- a/query-engine/schema/src/query_schema.rs
+++ b/query-engine/schema/src/query_schema.rs
@@ -1,7 +1,10 @@
 use super::*;
 use fmt::Debug;
-use prisma_models::{psl::PreviewFeature, InternalDataModelRef, ModelRef};
-use psl::datamodel_connector::{ConnectorCapability, RelationMode};
+use prisma_models::{InternalDataModelRef, ModelRef};
+use psl::{
+    datamodel_connector::{ConnectorCapability, RelationMode},
+    PreviewFeatures,
+};
 use std::{borrow::Borrow, fmt};
 
 /// The query schema.
@@ -48,18 +51,14 @@ pub struct ConnectorContext {
     pub capabilities: Vec<ConnectorCapability>,
 
     /// Enabled preview features.
-    pub features: Vec<PreviewFeature>,
+    pub features: PreviewFeatures,
 
     /// Relation mode of the provider
     pub relation_mode: RelationMode,
 }
 
 impl ConnectorContext {
-    pub fn new(
-        capabilities: Vec<ConnectorCapability>,
-        features: Vec<PreviewFeature>,
-        relation_mode: RelationMode,
-    ) -> Self {
+    pub fn new(capabilities: Vec<ConnectorCapability>, features: PreviewFeatures, relation_mode: RelationMode) -> Self {
         Self {
             capabilities,
             features,
@@ -82,7 +81,7 @@ impl QuerySchema {
         _enum_types: Vec<EnumTypeRef>,
         internal_data_model: InternalDataModelRef,
         capabilities: Vec<ConnectorCapability>,
-        features: Vec<PreviewFeature>,
+        features: PreviewFeatures,
         relation_mode: RelationMode,
     ) -> Self {
         QuerySchema {


### PR DESCRIPTION
by aligning with what the rest of engines does.

Whether a given preview feature is enabled or not is a single bit of information. We can store that information for all preview features in a single small integer. Before this commit, the query engine uses heap-allocated vectors, which has the following downsides:

- Ownership and lifetimes matter, the compiler will force you to think about them. Anytime you use preview features, you have to think about ownership, references, etc.
- It introduces heap allocations and copies that do not need to happen.
- It's not consistent with what the rest of prisma-engines does, namely the small integer approach.