### PR TITLE
qe: keep the schema around in InternalDataModel

### DIFF
--- a/psl/psl-core/src/lib.rs
+++ b/psl/psl-core/src/lib.rs
@@ -37,6 +37,12 @@ pub struct ValidatedSchema {
     relation_mode: datamodel_connector::RelationMode,
 }
 
+impl std::fmt::Debug for ValidatedSchema {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("<Prisma schema>")
+    }
+}
+
 impl ValidatedSchema {
     pub fn relation_mode(&self) -> datamodel_connector::RelationMode {
         self.relation_mode

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/direct.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/direct.rs
@@ -22,15 +22,9 @@ impl RunnerInterface for DirectRunner {
         let data_source = schema.configuration.datasources.first().unwrap();
         let url = data_source.load_url(|key| env::var(key).ok()).unwrap();
         let (db_name, executor) = executor::load(data_source, schema.configuration.preview_features(), &url).await?;
-        let internal_data_model = prisma_models::convert(&schema, db_name);
+        let internal_data_model = prisma_models::convert(Arc::new(schema), db_name);
 
-        let query_schema: QuerySchemaRef = Arc::new(schema_builder::build(
-            internal_data_model,
-            true,
-            data_source.active_connector,
-            schema.configuration.preview_features(),
-            data_source.relation_mode(),
-        ));
+        let query_schema: QuerySchemaRef = Arc::new(schema_builder::build(internal_data_model, true));
 
         Ok(Self {
             executor,

--- a/query-engine/dmmf/src/lib.rs
+++ b/query-engine/dmmf/src/lib.rs
@@ -14,25 +14,14 @@ pub fn dmmf_json_from_schema(schema: &str) -> String {
 
 // enable raw param?
 pub fn dmmf_from_schema(schema: &str) -> DataModelMetaFormat {
-    let schema = psl::parse_schema(schema).unwrap();
-    let dml = psl::lift(&schema);
-    let internal_data_model = prisma_models::convert(&schema, "dummy".to_owned());
-
-    // Construct query schema
-    let query_schema = Arc::new(schema_builder::build(
-        internal_data_model,
-        true, // todo
-        schema.connector,
-        schema.configuration.preview_features(),
-        schema.relation_mode(),
-    ));
-
-    from_precomputed_parts(&dml, query_schema)
+    let schema = Arc::new(psl::parse_schema(schema).unwrap());
+    let internal_data_model = prisma_models::convert(schema, "dummy".to_owned());
+    from_precomputed_parts(Arc::new(schema_builder::build(internal_data_model, true)))
 }
 
-pub fn from_precomputed_parts(dml: &psl::dml::Datamodel, query_schema: QuerySchemaRef) -> DataModelMetaFormat {
+pub fn from_precomputed_parts(query_schema: QuerySchemaRef) -> DataModelMetaFormat {
+    let data_model = schema_to_dmmf(&psl::lift(&query_schema.internal_data_model.schema));
     let (schema, mappings) = DmmfQuerySchemaRenderer::render(query_schema);
-    let data_model = schema_to_dmmf(dml);
 
     DataModelMetaFormat {
         data_model,

--- a/query-engine/prisma-models/src/convert.rs
+++ b/query-engine/prisma-models/src/convert.rs
@@ -2,8 +2,8 @@ use crate::{builders, InternalDataModel, InternalDataModelRef};
 use once_cell::sync::OnceCell;
 use std::sync::Arc;
 
-pub fn convert(schema: &psl::ValidatedSchema, db_name: String) -> InternalDataModelRef {
-    let datamodel = psl::lift(schema);
+pub fn convert(schema: Arc<psl::ValidatedSchema>, db_name: String) -> InternalDataModelRef {
+    let datamodel = psl::lift(&schema);
     let relation_mode = schema.relation_mode();
 
     let relation_placeholders = builders::relation_placeholders(&datamodel);
@@ -22,6 +22,7 @@ pub fn convert(schema: &psl::ValidatedSchema, db_name: String) -> InternalDataMo
         relation_fields: OnceCell::new(),
         db_name,
         enums: enums.into_iter().map(Arc::new).collect(),
+        schema,
     });
 
     let composite_types = builders::build_composites(composite_types, Arc::downgrade(&internal_data_model));

--- a/query-engine/prisma-models/src/internal_data_model.rs
+++ b/query-engine/prisma-models/src/internal_data_model.rs
@@ -19,6 +19,7 @@ pub struct InternalDataModel {
     /// influence the `database` part instead.
     pub db_name: String,
     pub enums: Vec<InternalEnumRef>,
+    pub schema: Arc<psl::ValidatedSchema>,
 }
 
 impl InternalDataModel {

--- a/query-engine/prisma-models/tests/datamodel_converter_tests.rs
+++ b/query-engine/prisma-models/tests/datamodel_converter_tests.rs
@@ -538,8 +538,7 @@ fn duplicate_relation_name() {
           
         "#;
 
-    let dml = psl::parse_schema(schema).unwrap();
-    prisma_models::convert(&dml, String::new());
+    convert(schema);
 }
 
 #[test]
@@ -562,7 +561,7 @@ fn implicit_many_to_many_relation() {
 
 fn convert(datamodel: &str) -> Arc<InternalDataModel> {
     let schema = psl::parse_schema(datamodel).unwrap();
-    prisma_models::convert(&schema, "not_important".to_string())
+    prisma_models::convert(Arc::new(schema), "not_important".to_string())
 }
 
 trait DatamodelAssertions {

--- a/query-engine/query-engine-node-api/src/engine.rs
+++ b/query-engine/query-engine-node-api/src/engine.rs
@@ -230,15 +230,10 @@ impl QueryEngine {
                 connector.get_connection().await?;
 
                 // Build internal data model
-                let internal_data_model = prisma_models::convert(&builder.schema, db_name);
+                let internal_data_model = prisma_models::convert(Arc::clone(&builder.schema), db_name);
 
-                let query_schema = schema_builder::build(
-                    internal_data_model,
-                    true, // enable raw queries
-                    data_source.active_connector,
-                    preview_features,
-                    data_source.relation_mode(),
-                );
+                let enable_raw_queries = true;
+                let query_schema = schema_builder::build(internal_data_model, enable_raw_queries);
 
                 Ok(ConnectedEngine {
                     schema: builder.schema.clone(),

--- a/query-engine/query-engine-node-api/src/functions.rs
+++ b/query-engine/query-engine-node-api/src/functions.rs
@@ -32,26 +32,9 @@ pub fn dmmf(datamodel_string: String) -> napi::Result<String> {
         .to_result()
         .map_err(|errors| ApiError::conversion(errors, schema.db.source()))?;
 
-    let datasource = schema.configuration.datasources.first();
-    let datamodel = psl::lift(&schema);
-
-    let connector = datasource
-        .map(|ds| ds.active_connector)
-        .unwrap_or(&psl::datamodel_connector::EmptyDatamodelConnector);
-
-    let relation_mode = datasource.map(|ds| ds.relation_mode()).unwrap_or_default();
-
-    let internal_data_model = prisma_models::convert(&schema, "".into());
-
-    let query_schema: QuerySchemaRef = Arc::new(schema_builder::build(
-        internal_data_model,
-        true,
-        connector,
-        schema.configuration.preview_features().iter().collect(),
-        relation_mode,
-    ));
-
-    let dmmf = dmmf::render_dmmf(&datamodel, query_schema);
+    let internal_data_model = prisma_models::convert(Arc::new(schema), "".into());
+    let query_schema: QuerySchemaRef = Arc::new(schema_builder::build(internal_data_model, true));
+    let dmmf = dmmf::render_dmmf(query_schema);
 
     Ok(serde_json::to_string(&dmmf)?)
 }

--- a/query-engine/query-engine/src/context.rs
+++ b/query-engine/query-engine/src/context.rs
@@ -1,5 +1,4 @@
 use crate::{PrismaError, PrismaResult};
-use psl::dml::Datamodel;
 use query_core::{executor, schema::QuerySchemaRef, schema_builder, QueryExecutor};
 use query_engine_metrics::MetricRegistry;
 use std::{env, fmt, sync::Arc};
@@ -9,8 +8,6 @@ use std::{env, fmt, sync::Arc};
 pub struct PrismaContext {
     /// The api query schema.
     query_schema: QuerySchemaRef,
-    /// DML-based v2 datamodel.
-    dm: Datamodel,
     pub metrics: MetricRegistry,
     /// Central query executor.
     pub executor: Box<dyn QueryExecutor + Send + Sync + 'static>,
@@ -64,20 +61,13 @@ impl PrismaContext {
         let (db_name, executor) = executor::load(data_source, config.preview_features(), &url).await?;
 
         // Build internal data model
-        let internal_data_model = prisma_models::convert(&schema, db_name);
+        let internal_data_model = prisma_models::convert(Arc::new(schema), db_name);
 
         // Construct query schema
-        let query_schema: QuerySchemaRef = Arc::new(schema_builder::build(
-            internal_data_model,
-            enable_raw_queries,
-            data_source.active_connector,
-            config.preview_features(),
-            data_source.relation_mode(),
-        ));
+        let query_schema: QuerySchemaRef = Arc::new(schema_builder::build(internal_data_model, enable_raw_queries));
 
         let context = Self {
             query_schema,
-            dm: psl::lift(&schema),
             executor,
             metrics,
         };
@@ -102,10 +92,6 @@ impl PrismaContext {
 
     pub fn query_schema(&self) -> &QuerySchemaRef {
         &self.query_schema
-    }
-
-    pub fn datamodel(&self) -> &Datamodel {
-        &self.dm
     }
 
     pub fn primary_connector(&self) -> String {

--- a/query-engine/query-engine/src/server/mod.rs
+++ b/query-engine/query-engine/src/server/mod.rs
@@ -152,7 +152,7 @@ pub async fn routes(state: State, req: Request<Body>) -> Result<Response<Body>, 
         }
 
         (&Method::GET, "/dmmf") => {
-            let schema = dmmf::render_dmmf(state.cx.datamodel(), Arc::clone(state.cx.query_schema()));
+            let schema = dmmf::render_dmmf(Arc::clone(state.cx.query_schema()));
 
             Response::builder()
                 .status(StatusCode::OK)

--- a/query-engine/request-handlers/src/dmmf/mod.rs
+++ b/query-engine/request-handlers/src/dmmf/mod.rs
@@ -1,6 +1,6 @@
 use dmmf_crate::DataModelMetaFormat;
 use query_core::schema::QuerySchemaRef;
 
-pub fn render_dmmf(dml: &psl::dml::Datamodel, query_schema: QuerySchemaRef) -> DataModelMetaFormat {
-    dmmf_crate::from_precomputed_parts(dml, query_schema)
+pub fn render_dmmf(query_schema: QuerySchemaRef) -> DataModelMetaFormat {
+    dmmf_crate::from_precomputed_parts(query_schema)
 }

--- a/query-engine/schema-builder/src/lib.rs
+++ b/query-engine/schema-builder/src/lib.rs
@@ -45,7 +45,7 @@ use prisma_models::{
     CompositeTypeRef, Field as ModelField, Index, InternalDataModelRef, ModelRef, RelationFieldRef, TypeIdentifier,
 };
 use psl::{
-    datamodel_connector::{Connector, ConnectorCapability, RelationMode},
+    datamodel_connector::{Connector, ConnectorCapability},
     PreviewFeature, PreviewFeatures,
 };
 use schema::*;
@@ -65,12 +65,9 @@ pub(crate) struct BuilderContext {
 }
 
 impl BuilderContext {
-    pub fn new(
-        internal_data_model: InternalDataModelRef,
-        enable_raw_queries: bool,
-        connector: &'static dyn Connector,
-        preview_features: PreviewFeatures,
-    ) -> Self {
+    pub fn new(internal_data_model: InternalDataModelRef, enable_raw_queries: bool) -> Self {
+        let connector = internal_data_model.schema.connector;
+        let preview_features = internal_data_model.schema.configuration.preview_features();
         Self {
             internal_data_model,
             enable_raw_queries,
@@ -174,14 +171,8 @@ impl TypeCache {
     }
 }
 
-pub fn build(
-    internal_data_model: InternalDataModelRef,
-    enable_raw_queries: bool,
-    connector: &'static dyn Connector,
-    preview_features: PreviewFeatures,
-    relation_mode: RelationMode,
-) -> QuerySchema {
-    let mut ctx = BuilderContext::new(internal_data_model, enable_raw_queries, connector, preview_features);
+pub fn build(internal_data_model: InternalDataModelRef, enable_raw_queries: bool) -> QuerySchema {
+    let mut ctx = BuilderContext::new(internal_data_model, enable_raw_queries);
 
     output_types::objects::initialize_caches(&mut ctx);
 
@@ -209,8 +200,6 @@ pub fn build(
         enum_types,
         ctx.internal_data_model,
         ctx.connector.capabilities().to_owned(),
-        preview_features,
-        relation_mode,
     )
 }
 

--- a/query-engine/schema/src/query_schema.rs
+++ b/query-engine/schema/src/query_schema.rs
@@ -81,9 +81,9 @@ impl QuerySchema {
         _enum_types: Vec<EnumTypeRef>,
         internal_data_model: InternalDataModelRef,
         capabilities: Vec<ConnectorCapability>,
-        features: PreviewFeatures,
-        relation_mode: RelationMode,
     ) -> Self {
+        let features = internal_data_model.schema.configuration.preview_features();
+        let relation_mode = internal_data_model.schema.relation_mode();
         QuerySchema {
             query,
             mutation,


### PR DESCRIPTION
Before this commit:

We pass a psl::ValidatedSchema to prisma_models::convert, then promptly drop the schema. We need a psl::ValidatedSchema around later in the process in all (?) the places where we have an InternalDataModel, so we pass it separately.

After this commit:

- The psl::ValidatedSchema is kept around, since know we are going to need it later.
- We can simplify how we construct query schemas.
- We don't pass dml::Datamodel's around anymore, we construct it in the few places where we need it (convert, dmmf).
- Having this in InternalDataModel opens the door to simplifying how prisma-models exposes the API it exposes (the whole builders business).