### PR TITLE
qe: remove rustc version check in build script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3237,7 +3237,6 @@ dependencies = [
  "query-engine-metrics",
  "rand 0.8.5",
  "request-handlers",
- "rustc_version",
  "serde",
  "serde_json",
  "serial_test",

--- a/query-engine/query-engine/Cargo.toml
+++ b/query-engine/query-engine/Cargo.toml
@@ -46,9 +46,6 @@ rand = "0.8"
 
 user-facing-errors = {path = "../../libs/user-facing-errors"}
 
-[build-dependencies]
-rustc_version = "0.2.3"
-
 [dev-dependencies]
 anyhow = "1"
 chrono = "0.4"

--- a/query-engine/query-engine/build.rs
+++ b/query-engine/query-engine/build.rs
@@ -1,20 +1,4 @@
-use rustc_version::version;
 use std::process::Command;
-
-fn check_rust_version() {
-    let rust_version = version().expect("Could not get rustc version");
-    let expected_major_version = 1;
-    let expected_minor_version = 40;
-
-    assert_eq!(rust_version.major, expected_major_version);
-
-    if rust_version.minor < expected_minor_version {
-        panic!(
-            "You don't have the right Rust version installed. This build expects at least version {}.{}.x",
-            expected_major_version, expected_minor_version,
-        )
-    }
-}
 
 fn store_git_commit_hash() {
     let output = Command::new("git").args(["rev-parse", "HEAD"]).output().unwrap();
@@ -23,6 +7,5 @@ fn store_git_commit_hash() {
 }
 
 fn main() {
-    check_rust_version();
     store_git_commit_hash();
 }


### PR DESCRIPTION
- It is out of date — MSRV is a lot higher now.
- Makes compilation slower (extra dependency to compile, link, build script execution)
- If we want that feature, it is built-in in cargo now (https://rust-lang.github.io/rfcs/2495-min-rust-version.html)