### PR TITLE
Reduce BuildJet usage in places we don't really need it

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   build:
     name: "prisma-fmt-wasm build ${{ github.event.ref }} for commit ${{ github.event.inputs.commit }}"
-    runs-on: buildjet-16vcpu-ubuntu-2004
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v18

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   clippy:
-    runs-on: buildjet-16vcpu-ubuntu-2004
+    runs-on: ubuntu-latest
     env:
       RUSTFLAGS: "-Dwarnings"
     steps:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
 
-    runs-on: buildjet-16vcpu-ubuntu-2004
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
- Clippy
- WASM build of prisma-fmt
- Unit tests

Closes: https://github.com/prisma/prisma-engines/issues/3370