### PR TITLE
me: pass namespaces to diff in devDiagnostic->diagnoseMigrationHistory

### DIFF
--- a/libs/test-setup/src/lib.rs
+++ b/libs/test-setup/src/lib.rs
@@ -5,6 +5,7 @@
 //! engines.
 
 pub mod mysql;
+pub mod postgres;
 /// Tokio test runtime utils.
 pub mod runtime;
 
@@ -12,7 +13,6 @@ mod capabilities;
 mod diff;
 mod logging;
 mod mssql;
-mod postgres;
 mod sqlite;
 mod tags;
 mod test_api_args;
@@ -47,6 +47,12 @@ macro_rules! only {
 }
 
 pub struct TestDb(&'static test_api_args::DbUnderTest);
+
+impl TestDb {
+    pub fn url(&self) -> &'static str {
+        &self.0.database_url
+    }
+}
 
 #[doc(hidden)]
 #[inline(never)]

--- a/libs/test-setup/src/postgres.rs
+++ b/libs/test-setup/src/postgres.rs
@@ -44,7 +44,7 @@ pub(crate) fn get_postgres_tags(database_url: &str) -> Result<BitFlags<Tags>, St
     tok(fut)
 }
 
-pub(crate) async fn create_postgres_database(database_url: &str, db_name: &str) -> Result<(Quaint, String), AnyError> {
+pub async fn create_postgres_database(database_url: &str, db_name: &str) -> Result<(Quaint, String), AnyError> {
     let mut url: Url = database_url.parse()?;
     let mut postgres_db_url = url.clone();
 

--- a/libs/test-setup/src/test_api_args.rs
+++ b/libs/test-setup/src/test_api_args.rs
@@ -7,7 +7,7 @@ use std::{fmt::Display, io::Write as _};
 #[derive(Debug)]
 pub(crate) struct DbUnderTest {
     pub(crate) capabilities: BitFlags<Capabilities>,
-    database_url: String,
+    pub(crate) database_url: String,
     shadow_database_url: Option<String>,
     provider: &'static str,
     pub(crate) tags: BitFlags<Tags>,

--- a/migration-engine/core/src/commands/dev_diagnostic.rs
+++ b/migration-engine/core/src/commands/dev_diagnostic.rs
@@ -3,12 +3,13 @@ use super::{
     HistoryDiagnostic,
 };
 use crate::json_rpc::types::{DevAction, DevActionReset, DevDiagnosticInput, DevDiagnosticOutput};
-use migration_connector::{migrations_directory, ConnectorResult, MigrationConnector};
+use migration_connector::{migrations_directory, ConnectorResult, MigrationConnector, Namespaces};
 
 /// Method called at the beginning of `migrate dev` to decide the course of
 /// action based on the current state of the workspace.
 pub async fn dev_diagnostic(
     input: DevDiagnosticInput,
+    namespaces: Option<Namespaces>,
     connector: &mut dyn MigrationConnector,
 ) -> ConnectorResult<DevDiagnosticOutput> {
     migrations_directory::error_on_changed_provider(&input.migrations_directory_path, connector.connector_type())?;
@@ -18,7 +19,7 @@ pub async fn dev_diagnostic(
         opt_in_to_shadow_database: true,
     };
 
-    let diagnose_migration_history_output = diagnose_migration_history(diagnose_input, connector).await?;
+    let diagnose_migration_history_output = diagnose_migration_history(diagnose_input, namespaces, connector).await?;
 
     check_for_broken_migrations(&diagnose_migration_history_output)?;
 

--- a/migration-engine/core/src/commands/diagnose_migration_history.rs
+++ b/migration-engine/core/src/commands/diagnose_migration_history.rs
@@ -1,6 +1,6 @@
 use crate::CoreResult;
 use migration_connector::{
-    migrations_directory::*, ConnectorError, DiffTarget, MigrationConnector, MigrationRecord,
+    migrations_directory::*, ConnectorError, DiffTarget, MigrationConnector, MigrationRecord, Namespaces,
     PersistenceNotInitializedError,
 };
 use serde::{Deserialize, Serialize};
@@ -65,6 +65,7 @@ impl DiagnoseMigrationHistoryOutput {
 /// reads, it does not write to the dev database nor the migrations directory.
 pub async fn diagnose_migration_history(
     input: DiagnoseMigrationHistoryInput,
+    namespaces: Option<Namespaces>,
     connector: &mut dyn MigrationConnector,
 ) -> CoreResult<DiagnoseMigrationHistoryOutput> {
     tracing::debug!("Diagnosing migration history");
@@ -132,10 +133,10 @@ pub async fn diagnose_migration_history(
             // TODO(MultiSchema): this should probably fill the following namespaces from the CLI since there is
             // no schema to grab the namespaces off, in the case of MultiSchema.
             let from = connector
-                .database_schema_from_diff_target(DiffTarget::Migrations(&applied_migrations), None, None)
+                .database_schema_from_diff_target(DiffTarget::Migrations(&applied_migrations), None, namespaces.clone())
                 .await;
             let to = connector
-                .database_schema_from_diff_target(DiffTarget::Database, None, None)
+                .database_schema_from_diff_target(DiffTarget::Database, None, namespaces)
                 .await;
             let drift = match from.and_then(|from| to.map(|to| connector.diff(from, to))).map(|mig| {
                 if connector.migration_is_empty(&mig) {

--- a/migration-engine/migration-engine-tests/src/commands/dev_diagnostic.rs
+++ b/migration-engine/migration-engine-tests/src/commands/dev_diagnostic.rs
@@ -22,6 +22,7 @@ impl<'a> DevDiagnostic<'a> {
             DevDiagnosticInput {
                 migrations_directory_path: self.migrations_directory.path().to_str().unwrap().to_owned(),
             },
+            None,
             self.api,
         );
         let output = test_setup::runtime::run_with_thread_local_runtime(fut)?;

--- a/migration-engine/migration-engine-tests/src/commands/diagnose_migration_history.rs
+++ b/migration-engine/migration-engine-tests/src/commands/diagnose_migration_history.rs
@@ -34,6 +34,7 @@ impl<'a> DiagnoseMigrationHistory<'a> {
                 migrations_directory_path: self.migrations_directory.path().to_str().unwrap().to_owned(),
                 opt_in_to_shadow_database: self.opt_in_to_shadow_database,
             },
+            None,
             self.api,
         )
         .await?;


### PR DESCRIPTION
The namespaces are from the schema the engine was started with

This should address https://github.com/prisma/prisma/issues/16634 and https://github.com/prisma/prisma/issues/16585