### PR TITLE
nix: support multiple systems in the flake again

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -19,9 +19,9 @@
     nixpkgs.url = "nixpkgs/nixos-unstable";
   };
 
-  outputs = inputs@{ self, nixpkgs, rust-overlay, flake-parts, crane, ... }:
+  outputs = inputs@{ self, nixpkgs, rust-overlay, flake-parts, flake-utils, crane, ... }:
     flake-parts.lib.mkFlake { inherit self; } {
-      systems = [ "x86_64-linux" ];
+      systems = flake-utils.lib.defaultSystems;
       perSystem = { config, system, pkgs, craneLib, ... }: {
         config._module.args.inputs = inputs;
         imports = [


### PR DESCRIPTION
After https://github.com/prisma/prisma-engines/pull/3437, `nix develop` fails with:

```
error: flake 'git+file:///home/aqrln/prisma/prisma-engines' does not
provide attribute 'devShells.aarch64-linux.default',
'devShell.aarch64-linux', 'packages.aarch64-linux.default' or
'defaultPackage.aarch64-linux'
```

This commit adds back support for all four of the default systems (i.e., `[ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ]`).

I used `flake-utils.lib.defaultSystems` since `flake-utils` was still in inputs. If it was left there accidentally and we don't want to keep it just for this list alone, we can remove it and hardcode the list instead. `flake-parts` doesn't provide a similar utility, as far as I can tell.