### PR TITLE
fix(migration-engine): changed type of "compositeTypeDepth" from `u32` to `isize`

### DIFF
--- a/migration-engine/core/src/state.rs
+++ b/migration-engine/core/src/state.rs
@@ -322,7 +322,7 @@ impl GenericApi for EngineState {
             &params.schema,
             None,
             Box::new(move |connector| {
-                let composite_type_depth = From::from(params.composite_type_depth as isize);
+                let composite_type_depth = From::from(params.composite_type_depth);
                 let ctx = migration_connector::IntrospectionContext::new(schema, composite_type_depth);
                 Box::pin(async move {
                     // TODO(MultiSchema): Grab namespaces from introspect params?

--- a/migration-engine/json-rpc-api-build/methods/introspect.toml
+++ b/migration-engine/json-rpc-api-build/methods/introspect.toml
@@ -13,7 +13,7 @@ shape = "string"
 shape = "bool"
 
 [recordShapes.introspectParams.fields.compositeTypeDepth]
-shape = "u32"
+shape = "isize"
 
 [recordShapes.introspectResult]
 description = "Result type for the introspect method."

--- a/migration-engine/json-rpc-api-build/src/lib.rs
+++ b/migration-engine/json-rpc-api-build/src/lib.rs
@@ -85,7 +85,7 @@ fn validate(api: &Api) {
 }
 
 fn shape_exists(shape: &str, api: &Api) -> bool {
-    let builtin_scalars = ["string", "bool", "u32"];
+    let builtin_scalars = ["string", "bool", "u32", "isize"];
 
     if builtin_scalars.contains(&shape) {
         return true;

--- a/migration-engine/json-rpc-api-build/src/rust_crate.rs
+++ b/migration-engine/json-rpc-api-build/src/rust_crate.rs
@@ -156,6 +156,7 @@ fn rustify_type_name(name: &str) -> Cow<'static, str> {
     match name {
         "bool" => Cow::Borrowed("bool"),
         "u32" => Cow::Borrowed("u32"),
+        "isize" => Cow::Borrowed("isize"),
         "string" => Cow::Borrowed("String"),
         other => other.to_camel_case().into(),
     }


### PR DESCRIPTION
I’ve noticed a type mismatch between the `compositeTypeDepth` parameter defined [here](https://github.com/prisma/prisma-engines/blob/0bc2e3827f1a572183f70c8d26a3608415c3313d/migration-engine/json-rpc-api-build/methods/introspect.toml#L15-L16) as u32, and the original `composite_type_depth` definition [here](https://github.com/prisma/prisma-engines/blob/7634fccaf14fd77a5c3b61246b9ae06faac352a1/introspection-engine/core/src/rpc.rs#L161-L162) as Option<isize>.
In particular, the TypeScript CLI currently passes -1 as a default value for `compositeTypeDepth`, which of course isn’t a valid `u32` value.

This PR should fix type mismatch issues with the TS cli.

Context: deprecating `introspection-engine` in favor of `migrate-engine` ([internal notion](https://www.notion.so/prismaio/Rewiring-Introspection-Engine-from-Prisma-CLI-e19d790e4b914870ac73665db9aa95b2)).