### PR TITLE
nix: add a `cli-shell` package for development

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,7 @@
         imports = [
           ./nix/all-engines.nix
           ./nix/args.nix
+          ./nix/cli-shell.nix
           ./nix/shell.nix
           ./prisma-fmt-wasm
         ];

--- a/nix/cli-shell.nix
+++ b/nix/cli-shell.nix
@@ -1,0 +1,16 @@
+{ config, pkgs, self', ... }:
+
+let engines = self'.packages.prisma-engines; in {
+  devShells.cli-shell = pkgs.mkShell {
+    packages = [ pkgs.cowsay pkgs.nodejs engines ];
+    shellHook = ''
+      cowsay -f turtle "Run prisma using \`npx prisma\`. In this shell, engines binaries built from source in this repo will automatically be used."
+
+      export PRISMA_MIGRATION_ENGINE_BINARY=${engines}/bin/migration-engine
+      export PRISMA_QUERY_ENGINE_BINARY=${engines}/bin/query-engine
+      export PRISMA_QUERY_ENGINE_LIBRARY=${engines}/lib/libquery_engine.node
+      export PRISMA_INTROSPECTION_ENGINE_BINARY=${engines}/bin/introspection-engine
+      export PRISMA_FMT_BINARY=${engines}/bin/prisma-fmt
+    '';
+  };
+}

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ self', pkgs, ... }:
 
 let
   devToolchain = pkgs.rustToolchain.default.override { extensions = [ "rust-analyzer" "rust-src" ]; };
@@ -6,7 +6,7 @@ in
 {
   devShells.default = pkgs.mkShell {
     packages = [ devToolchain pkgs.llvmPackages.bintools ];
-    inputsFrom = [ config.packages.prisma-engines ];
+    inputsFrom = [ self'.packages.prisma-engines ];
     shellHook = "export RUSTFLAGS='-C link-arg=-fuse-ld=lld'";
   };
 }


### PR DESCRIPTION
The idea is to use the built typescript code from npm (using `npx`), but
with local engines built from source. This is meant to simplify manual
testing of the impact of engines changes on the whole CLI/client.

Run it with nix develop .#cli-shell.

The reason we don't go further than telling the user what command to run
is that we want to make it easy to select a specific version of the npm
package.

closes https://github.com/prisma/prisma/issues/16767