### PR TITLE
feat(migration-engine): support "affected" JSON prop in introspection warnings

### DIFF
--- a/migration-engine/core/src/state.rs
+++ b/migration-engine/core/src/state.rs
@@ -337,6 +337,7 @@ impl GenericApi for EngineState {
                             .map(|warning| crate::json_rpc::types::IntrospectionWarning {
                                 code: warning.code as u32,
                                 message: warning.message,
+                                affected: warning.affected,
                             })
                             .collect(),
                     })

--- a/migration-engine/json-rpc-api-build/methods/introspect.toml
+++ b/migration-engine/json-rpc-api-build/methods/introspect.toml
@@ -35,3 +35,6 @@ shape = "u32"
 
 [recordShapes.introspectionWarning.fields.message]
 shape = "string"
+
+[recordShapes.introspectionWarning.fields.affected]
+shape = "serde_json::Value"

--- a/migration-engine/json-rpc-api-build/src/lib.rs
+++ b/migration-engine/json-rpc-api-build/src/lib.rs
@@ -85,7 +85,7 @@ fn validate(api: &Api) {
 }
 
 fn shape_exists(shape: &str, api: &Api) -> bool {
-    let builtin_scalars = ["string", "bool", "u32", "isize"];
+    let builtin_scalars = ["string", "bool", "u32", "isize", "serde_json::Value"];
 
     if builtin_scalars.contains(&shape) {
         return true;

--- a/migration-engine/json-rpc-api-build/src/rust_crate.rs
+++ b/migration-engine/json-rpc-api-build/src/rust_crate.rs
@@ -158,6 +158,7 @@ fn rustify_type_name(name: &str) -> Cow<'static, str> {
         "u32" => Cow::Borrowed("u32"),
         "isize" => Cow::Borrowed("isize"),
         "string" => Cow::Borrowed("String"),
+        "serde_json::Value" => Cow::Borrowed("serde_json::Value"),
         other => other.to_camel_case().into(),
     }
 }


### PR DESCRIPTION
The affected property in [introspection warnings](https://github.com/prisma/prisma-engines/blob/b5a1e814c11f68346141127705831bc69857f0f7/introspection-engine/connectors/introspection-connector/src/lib.rs#L57-L62) wasn’t ported to `migration-engine`, resulting in errors in the `prisma/prisma` integration tests:

![Screenshot 2022-12-13 at 12 26 32](https://user-images.githubusercontent.com/12381818/207312926-8d9bdffd-248d-4161-8685-0c2274dbd69e.png)
