### PR TITLE
Allow static linking of ssl in migration-engine

### DIFF
--- a/migration-engine/cli/Cargo.toml
+++ b/migration-engine/cli/Cargo.toml
@@ -31,4 +31,4 @@ name = "migration-engine"
 path = "src/main.rs"
 
 [features]
-vendored-openssl = []
+vendored-openssl = ["migration-core/vendored-openssl"]

--- a/migration-engine/connectors/sql-migration-connector/Cargo.toml
+++ b/migration-engine/connectors/sql-migration-connector/Cargo.toml
@@ -3,6 +3,9 @@ edition = "2021"
 name = "sql-migration-connector"
 version = "0.1.0"
 
+[features]
+vendored-openssl = ["quaint/vendored-openssl"]
+
 [dependencies]
 psl.workspace = true
 migration-connector = { path = "../migration-connector" }

--- a/migration-engine/core/Cargo.toml
+++ b/migration-engine/core/Cargo.toml
@@ -24,3 +24,6 @@ url = "2.1.1"
 
 [build-dependencies]
 json-rpc-api-build = { path = "../json-rpc-api-build" }
+
+[features]
+vendored-openssl = ["sql-migration-connector/vendored-openssl"]


### PR DESCRIPTION
Part of: https://github.com/prisma/prisma/issues/16772

On OpenSSL 1.0 platforms, we vendor the OpenSSL version in Introspection and Query engines. Migration engine has this flag too, but it does nothing. Let's change that.