### PR TITLE
me: correctly pass namespaces to introspect

### DIFF
--- a/migration-engine/connectors/migration-connector/src/lib.rs
+++ b/migration-engine/connectors/migration-connector/src/lib.rs
@@ -208,7 +208,6 @@ pub trait MigrationConnector: Send + Sync + 'static {
     fn introspect<'a>(
         &'a mut self,
         ctx: &'a introspection_connector::IntrospectionContext,
-        namespaces: Option<Namespaces>,
     ) -> BoxFuture<'a, ConnectorResult<introspection_connector::IntrospectionResult>>;
 
     /// If possible, check that the passed in migrations apply cleanly.

--- a/migration-engine/connectors/mongodb-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/mongodb-migration-connector/src/lib.rs
@@ -166,7 +166,6 @@ impl MigrationConnector for MongoDbMigrationConnector {
     fn introspect<'a>(
         &'a mut self,
         ctx: &'a IntrospectionContext,
-        _namespaces: Option<Namespaces>,
     ) -> BoxFuture<'a, ConnectorResult<IntrospectionResult>> {
         Box::pin(async move {
             let url: String = ctx.datasource().load_url(|v| std::env::var(v).ok()).map_err(|err| {

--- a/migration-engine/connectors/sql-migration-connector/src/lib.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/lib.rs
@@ -235,9 +235,10 @@ impl MigrationConnector for SqlMigrationConnector {
     fn introspect<'a>(
         &'a mut self,
         ctx: &'a IntrospectionContext,
-        namespaces: Option<Namespaces>,
     ) -> BoxFuture<'a, ConnectorResult<IntrospectionResult>> {
         Box::pin(async move {
+            let mut namespace_names = ctx.datasource().namespaces.iter().map(|(s, _)| s.clone()).collect();
+            let namespaces = Namespaces::from_vec(&mut namespace_names);
             let sql_schema = self.flavour.describe_schema(namespaces).await?;
             let datamodel = datamodel_calculator::calculate(&sql_schema, ctx)
                 .map_err(|err| ConnectorError::from_source(err, "Introspection error"))?;

--- a/migration-engine/core/src/state.rs
+++ b/migration-engine/core/src/state.rs
@@ -325,8 +325,7 @@ impl GenericApi for EngineState {
                 let composite_type_depth = From::from(params.composite_type_depth);
                 let ctx = migration_connector::IntrospectionContext::new(schema, composite_type_depth);
                 Box::pin(async move {
-                    // TODO(MultiSchema): Grab namespaces from introspect params?
-                    let result = connector.introspect(&ctx, None).await?;
+                    let result = connector.introspect(&ctx).await?;
 
                     Ok(IntrospectResult {
                         datamodel: result.data_model,


### PR DESCRIPTION
How we do this was left pending in the initial multiSchema work, that happened after we added the introspect method to the migration engine.

This commit passes the namespaces from the schema from the IntrospectionContext to `describe_schema`.