### PR TITLE
 nix: simplify prisma-fmt-wasm derivation 

### DIFF
--- a/nix/all-engines.nix
+++ b/nix/all-engines.nix
@@ -1,8 +1,9 @@
-{ craneLib, pkgs, ... }:
+{ craneLib, pkgs, inputs, ... }:
 
 let
   srcPath = builtins.path { path = ../.; name = "prisma-engines-workspace-root-path"; };
   src = pkgs.lib.cleanSourceWith { filter = enginesSourceFilter; src = srcPath; };
+  craneLib = inputs.crane.mkLib pkgs;
   deps = craneLib.vendorCargoDeps { inherit src; };
 
   enginesSourceFilter = path: type: (builtins.match "\\.pest$" path != null) ||

--- a/nix/args.nix
+++ b/nix/args.nix
@@ -8,10 +8,6 @@
           let toolchain = super.rust-bin.stable.latest; in
           { cargo = toolchain.minimal; rustc = toolchain.minimal; rustToolchain = toolchain; })
       ];
-
-      pkgs = import inputs.nixpkgs { inherit system overlays; };
-
-      craneLib = inputs.crane.mkLib pkgs;
     in
-    { inherit craneLib pkgs; };
+    { pkgs = import inputs.nixpkgs { inherit system overlays; }; };
 }


### PR DESCRIPTION
Use stdenv.mkDerivation, we gain nothing from using crane.