### PR TITLE
fix(psl): Updated validation for multi-schema attribute detection

### DIFF
--- a/introspection-engine/introspection-engine-tests/tests/multi_schema/sql_server.rs
+++ b/introspection-engine/introspection-engine-tests/tests/multi_schema/sql_server.rs
@@ -171,10 +171,14 @@ async fn multiple_schemas_w_tables_are_reintrospected(api: &TestApi) -> TestResu
     let input = indoc! {r#"
         model A {
           id   Int  @id @default(autoincrement())
+
+          @@schema("first")
         }
 
         model B {
           id   Int  @id @default(autoincrement())
+
+          @@schema("second")
         }
     "#};
 

--- a/psl/psl-core/src/validate/validation_pipeline/validations/enums.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/enums.rs
@@ -1,7 +1,7 @@
 use crate::{
     datamodel_connector::ConnectorCapability,
     diagnostics::DatamodelError,
-    parser_database::{self, ast::WithSpan, walkers::EnumWalker},
+    parser_database::{ast::WithSpan, walkers::EnumWalker},
     validate::validation_pipeline::context::Context,
 };
 use std::collections::HashSet;
@@ -76,11 +76,12 @@ pub(super) fn schema_attribute_missing(r#enum: EnumWalker<'_>, ctx: &mut Context
         return;
     }
 
-    if !ctx
-        .db
-        .schema_flags()
-        .contains(parser_database::SchemaFlags::UsesSchemaAttribute)
-    {
+    let datasource = match ctx.datasource {
+        Some(datasource) => datasource,
+        None => return,
+    };
+
+    if datasource.schemas_span.is_none() {
         return;
     }
 

--- a/psl/psl-core/src/validate/validation_pipeline/validations/models.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/models.rs
@@ -333,11 +333,12 @@ pub(super) fn schema_attribute_missing(model: ModelWalker<'_>, ctx: &mut Context
         return;
     }
 
-    if !ctx
-        .db
-        .schema_flags()
-        .contains(parser_database::SchemaFlags::UsesSchemaAttribute)
-    {
+    let datasource = match ctx.datasource {
+        Some(datasource) => datasource,
+        None => return,
+    };
+
+    if datasource.schemas_span.is_none() {
         return;
     }
 

--- a/psl/psl/tests/validation/attributes/schema/no_schema_attributes.prisma
+++ b/psl/psl/tests/validation/attributes/schema/no_schema_attributes.prisma
@@ -1,0 +1,53 @@
+// This is _not_ valid: once @@schema is specified once, it has to be
+// specified for every model and enum.
+
+datasource testds {
+    provider = "postgresql"
+    url      = env("TEST_DATABASE_URL")
+    schemas  = ["public", "security", "users"]
+}
+
+generator js {
+    provider        = "prisma-client-js"
+    previewFeatures = ["multiSchema"]
+}
+
+model Test {
+    id Int @id
+}
+
+model Test2 {
+    id Int @id
+}
+
+enum UserType {
+    Bacteria
+    Archea
+    Eukaryote
+}
+// [1;91merror[0m: [1mThis model is missing an `@@schema` attribute.[0m
+//   [1;94m-->[0m  [4mschema.prisma:15[0m
+// [1;94m   | [0m
+// [1;94m14 | [0m
+// [1;94m15 | [0m[1;91mmodel Test {[0m
+// [1;94m16 | [0m    id Int @id
+// [1;94m17 | [0m}
+// [1;94m   | [0m
+// [1;91merror[0m: [1mThis model is missing an `@@schema` attribute.[0m
+//   [1;94m-->[0m  [4mschema.prisma:19[0m
+// [1;94m   | [0m
+// [1;94m18 | [0m
+// [1;94m19 | [0m[1;91mmodel Test2 {[0m
+// [1;94m20 | [0m    id Int @id
+// [1;94m21 | [0m}
+// [1;94m   | [0m
+// [1;91merror[0m: [1mThis enum is missing an `@@schema` attribute.[0m
+//   [1;94m-->[0m  [4mschema.prisma:23[0m
+// [1;94m   | [0m
+// [1;94m22 | [0m
+// [1;94m23 | [0m[1;91menum UserType {[0m
+// [1;94m24 | [0m    Bacteria
+// [1;94m25 | [0m    Archea
+// [1;94m26 | [0m    Eukaryote
+// [1;94m27 | [0m}
+// [1;94m   | [0m


### PR DESCRIPTION
Will now error when no models or enums contain `@@schema` as opposed to just one.

closes #3502

