### PR TITLE
nix devShell: use lld to link rust programs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2474,9 +2474,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.75"
+version = "0.9.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5f9bd0c2710541a3cda73d6f9ac4f1b240de4ae261065d309dbe73d9dceb42f"
+checksum = "5454462c0eced1e97f2ec09036abc8da362e66802f66fd20f86854d9d8cbcbc4"
 dependencies = [
  "autocfg",
  "cc",

--- a/nix/all-engines.nix
+++ b/nix/all-engines.nix
@@ -17,13 +17,13 @@ in
     name = "prisma-engines";
     inherit src;
 
-    buildInputs = [ pkgs.openssl ];
+    buildInputs = [ pkgs.openssl.out ];
     nativeBuildInputs = with pkgs; [
-      git # for our build scripts that bake in the git hash
-      perl # for openssl-sys
-      pkg-config
-      protobuf # for tonic
       cargo
+      git # for our build scripts that bake in the git hash
+      protobuf # for tonic
+      openssl.dev
+      pkg-config
     ];
 
     buildPhase = ''

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,8 +1,12 @@
 { config, pkgs, ... }:
 
+let
+  devToolchain = pkgs.rustToolchain.default.override { extensions = [ "rust-analyzer" "rust-src" ]; };
+in
 {
   devShells.default = pkgs.mkShell {
-    packages = [ (pkgs.rustToolchain.default.override { extensions = [ "rust-analyzer" "rust-src" ]; }) ];
-    inputsFrom = [ config.packages.prisma-engines-deps ];
+    packages = [ devToolchain pkgs.llvmPackages.bintools ];
+    inputsFrom = [ config.packages.prisma-engines ];
+    shellHook = "export RUSTFLAGS='-C link-arg=-fuse-ld=lld'";
   };
 }


### PR DESCRIPTION
lld is very noticeably faster than gold. This commit makes users of the nix devShell link with lld transparently: the devShell takes care of installing it, and making rustc use it (through RUSTFLAGS).

This commit also fixes the out-of-date inputsFrom that broke in ad193ffaf4416fcf82ff5ce1c214f798c14a50cf.