### PR TITLE
Strip symbols on query-engine and query-engine-node-api

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,9 +57,11 @@ features = [
 [profile.dev.package.backtrace]
 opt-level = 3
 
-[profile.release.package.introspection-core]
-codegen-units = 1
-opt-level = 'z' # Optimize for size.
+[profile.release.package.query-engine-node-api]
+strip = "symbols"
+
+[profile.release.package.query-engine]
+strip = "symbols"
 
 [profile.release]
 lto = "fat"


### PR DESCRIPTION
for release builds.

On 2eeed5ba6d8cff65feb1b768a3c0d80a61881846

1. pre-strip:
	```
	-rwxr-xr-x 2 tom users 27008104 Dec 15 10:40 target/release/libquery_engine.so
	```
2. with strip = "symbols"
	```
	-rwxr-xr-x 2 tom users 21206280 Dec 15 10:46 target/release/libquery_engine.so
	```
3. with strip = "debuginfo"
	```
	-rwxr-xr-x 2 tom users 24165888 Dec 15 10:51 target/release/libquery_engine.so
	```
So that's a ~22% improvement.