### PR TITLE
psl: delete SchemaFlags

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
@@ -9,7 +9,7 @@ use psl::{
     parser_database::{
         ast,
         walkers::{ModelWalker, ScalarFieldWalker},
-        ReferentialAction, ScalarFieldType, ScalarType, SchemaFlags, SortOrder,
+        ReferentialAction, ScalarFieldType, ScalarType, SortOrder,
     },
     ValidatedSchema,
 };
@@ -28,13 +28,11 @@ pub(crate) fn calculate_sql_schema(datamodel: &ValidatedSchema, flavour: &dyn Sq
         schemas: Default::default(),
     };
 
-    if datamodel.db.schema_flags().contains(SchemaFlags::UsesSchemaAttribute) {
-        if let Some(ds) = context.datamodel.configuration.datasources.get(0) {
-            for (schema, _) in &ds.namespaces {
-                context
-                    .schemas
-                    .insert(schema, context.schema.describer_schema.push_namespace(schema.clone()));
-            }
+    if let Some(ds) = context.datamodel.configuration.datasources.get(0) {
+        for (schema, _) in &ds.namespaces {
+            context
+                .schemas
+                .insert(schema, context.schema.describer_schema.push_namespace(schema.clone()));
         }
     }
 

--- a/psl/parser-database/src/attributes/schema.rs
+++ b/psl/parser-database/src/attributes/schema.rs
@@ -17,6 +17,5 @@ fn visit_schema_attribute(ctx: &mut Context<'_>) -> Option<(StringId, ast::Span)
         }
     };
     let name = coerce::string(arg, ctx.diagnostics)?;
-    ctx.types.flags |= crate::types::SchemaFlags::UsesSchemaAttribute;
     Some((ctx.interner.intern(name), arg.span()))
 }

--- a/psl/parser-database/src/lib.rs
+++ b/psl/parser-database/src/lib.rs
@@ -40,9 +40,7 @@ pub use coerce_expression::{coerce, coerce_array, coerce_opt};
 pub use names::is_reserved_type_name;
 pub use relations::{ManyToManyRelationId, ReferentialAction, RelationId};
 pub use schema_ast::{ast, SourceFile};
-pub use types::{
-    IndexAlgorithm, IndexFieldPath, IndexType, OperatorClass, ScalarFieldType, ScalarType, SchemaFlags, SortOrder,
-};
+pub use types::{IndexAlgorithm, IndexFieldPath, IndexType, OperatorClass, ScalarFieldType, ScalarType, SortOrder};
 
 use self::{context::Context, interner::StringId, relations::Relations, types::Types};
 use diagnostics::{DatamodelError, Diagnostics};
@@ -153,11 +151,6 @@ impl ParserDatabase {
     /// The source file contents.
     pub fn source(&self) -> &str {
         self.file.as_str()
-    }
-
-    /// Global properties of the schema.
-    pub fn schema_flags(&self) -> enumflags2::BitFlags<types::SchemaFlags> {
-        self.types.flags
     }
 }
 

--- a/psl/parser-database/src/types.rs
+++ b/psl/parser-database/src/types.rs
@@ -2,7 +2,7 @@ pub(crate) mod index_fields;
 
 use crate::{context::Context, interner::StringId, walkers::IndexFieldWalker, DatamodelError};
 use either::Either;
-use enumflags2::{bitflags, BitFlags};
+use enumflags2::bitflags;
 use schema_ast::ast::{self, WithName};
 use std::{
     collections::{BTreeMap, HashMap},
@@ -23,7 +23,6 @@ pub(super) fn resolve_types(ctx: &mut Context<'_>) {
 
 #[derive(Debug, Default)]
 pub(super) struct Types {
-    pub(super) flags: BitFlags<SchemaFlags>,
     pub(super) composite_type_fields: BTreeMap<(ast::CompositeTypeId, ast::FieldId), CompositeTypeField>,
     pub(super) scalar_fields: BTreeMap<(ast::ModelId, ast::FieldId), ScalarField>,
     /// This contains only the relation fields actually present in the schema
@@ -58,15 +57,6 @@ impl Types {
     ) -> Option<RelationField> {
         self.relation_fields.remove(&(model_id, field_id))
     }
-}
-
-/// Global properties of a PSL document.
-#[derive(Debug, Clone, Copy)]
-#[bitflags]
-#[repr(u8)]
-pub enum SchemaFlags {
-    /// Is there at least one `@@schema` in the schema?
-    UsesSchemaAttribute = 0b1,
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
We can simplify. The new validation rule is that if the datasource has the `schemas` property, then we are in multiSchema mode (since 2ff0967e37b302c66a0086e5a9a1b767cf089731).