### PR TITLE
Fix a crash with a special case of dbgenerated()

### DIFF
--- a/libs/sql-schema-describer/src/lib.rs
+++ b/libs/sql-schema-describer/src/lib.rs
@@ -742,6 +742,12 @@ impl DefaultValue {
         self.constraint_name = constraint_name;
         self
     }
+
+    /// If the default value is the deprecated `dbgenerated()`
+    /// variant.
+    pub fn is_empty_dbgenerated(&self) -> bool {
+        matches!(self.kind, DefaultKind::DbGenerated(None))
+    }
 }
 
 fn unquote_string(val: &str) -> String {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_renderer/mysql_renderer.rs
@@ -363,6 +363,7 @@ fn render_mysql_modify(
         .unwrap_or_else(|| render_column_type(next_column));
 
     let default = new_default
+        .filter(|default| !default.is_empty_dbgenerated())
         .map(|default| render_default(next_column, default))
         .filter(|expr| !expr.is_empty())
         .map(|expression| format!(" DEFAULT {}", expression))

--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/mysql.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_differ/sql_schema_differ_flavour/mysql.rs
@@ -863,6 +863,7 @@ fn native_type_change(types: Pair<&MySqlType>) -> Option<ColumnTypeChange> {
         },
 
         MySqlType::Time(n) => match next {
+            MySqlType::Time(None) if n.unwrap_or(0) == 0 => return None,
             MySqlType::Time(m) if n == m => return None,
             MySqlType::Time(_) => safe(),
 

--- a/migration-engine/migration-engine-tests/tests/migrations/defaults.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/defaults.rs
@@ -299,6 +299,24 @@ fn schemas_with_dbgenerated_work(api: TestApi) {
         .assert_no_steps();
 }
 
+#[test_connector(tags(Mysql))]
+fn schemas_with_empty_dbgenerated_work_together_with_time_native_type(api: TestApi) {
+    // https://github.com/prisma/prisma/issues/16340
+
+    let dm1 = indoc::indoc! {r#"
+        model Class {
+          id    Int      @id
+          when  DateTime @default(dbgenerated()) @db.Time
+        }
+    "#};
+
+    api.schema_push_w_datasource(dm1).send().assert_green();
+    api.schema_push_w_datasource(dm1)
+        .send()
+        .assert_green()
+        .assert_no_steps();
+}
+
 #[test_connector(tags(Mysql8, Mariadb), exclude(Vitess))]
 fn schemas_with_dbgenerated_expressions_work(api: TestApi) {
     let dm1 = r#"

--- a/migration-engine/migration-engine-tests/tests/native_types/mysql.rs
+++ b/migration-engine/migration-engine-tests/tests/native_types/mysql.rs
@@ -1025,3 +1025,35 @@ fn typescript_starter_schema_with_different_native_types_is_idempotent(api: Test
         .assert_green()
         .assert_no_steps();
 }
+
+#[test_connector(tags(Mysql))]
+fn time_zero_is_indepodent(api: TestApi) {
+    let dm1 = indoc::indoc! {r#"
+        model Class {
+          id    Int      @id
+          when  DateTime @db.Time(0)
+        }
+    "#};
+
+    api.schema_push_w_datasource(dm1).send().assert_green();
+    api.schema_push_w_datasource(dm1)
+        .send()
+        .assert_green()
+        .assert_no_steps();
+}
+
+#[test_connector(tags(Mysql))]
+fn time_is_indepodent(api: TestApi) {
+    let dm1 = indoc::indoc! {r#"
+        model Class {
+          id    Int      @id
+          when  DateTime @db.Time
+        }
+    "#};
+
+    api.schema_push_w_datasource(dm1).send().assert_green();
+    api.schema_push_w_datasource(dm1)
+        .send()
+        .assert_green()
+        .assert_no_steps();
+}

--- a/migration-engine/migration-engine-tests/tests/native_types/mysql.rs
+++ b/migration-engine/migration-engine-tests/tests/native_types/mysql.rs
@@ -1027,7 +1027,7 @@ fn typescript_starter_schema_with_different_native_types_is_idempotent(api: Test
 }
 
 #[test_connector(tags(Mysql))]
-fn time_zero_is_indepodent(api: TestApi) {
+fn time_zero_is_idempotent(api: TestApi) {
     let dm1 = indoc::indoc! {r#"
         model Class {
           id    Int      @id
@@ -1043,7 +1043,7 @@ fn time_zero_is_indepodent(api: TestApi) {
 }
 
 #[test_connector(tags(Mysql))]
-fn time_is_indepodent(api: TestApi) {
+fn time_is_idempotent(api: TestApi) {
     let dm1 = indoc::indoc! {r#"
         model Class {
           id    Int      @id


### PR DESCRIPTION
This bug is triggered by the following combination of _things_:

- MySQL
- Use of `dbgenerated()` (a deliberatly empty one)
- Native type of `Time`

If you have this in the PSL, pushing twice will panic.

What happens is two things: we think the value `time(0)` from the database is diffed as a different value what is `Time` in the PSL. This is unneeded drift and should not happen.

The second issue is when the change is adding a `dbgenerated()` to a field, which is not really done by the users due to it not being very useful (and a legacy structure). Now, our MySQL rendering does not think somebody would _add_ a `dbgenerated()` to the PSL. But, if you combine it with thinking `db.Time` and `time(0)` are different, getting another migration from the second push... Now we hit the `unreachable()` and crash.

Closes: https://github.com/prisma/prisma/issues/16340
Closes: https://github.com/prisma/prisma/issues/9769
Closes: https://github.com/prisma/prisma/issues/6382