### PR TITLE
Use opt-level = s

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,3 +66,4 @@ strip = "symbols"
 [profile.release]
 lto = "fat"
 codegen-units = 1
+opt-level = 's' # Optimize for size.


### PR DESCRIPTION
Use opt-level = s
 
Let LLVM optimize for size.
 
---- Size Measurements ----
 
Before:
 
prisma-desktop.tom.~/src/gh/prisma-engines λ ls -lh result/bin result/lib && git rev-parse HEAD
result/bin:
total 67M
-r-xr-xr-x 2 root root  19M Jan  1  1970 introspection-engine
-r-xr-xr-x 2 root root  22M Jan  1  1970 migration-engine
-r-xr-xr-x 2 root root 3.5M Jan  1  1970 prisma-fmt
-r-xr-xr-x 2 root root  23M Jan  1  1970 query-engine
 
result/lib:
total 21M
-r-xr-xr-x 2 root root 21M Jan  1  1970 libquery_engine.node
c9e863f2d8de6fa0c4bcd609df078ea2dde3c2b2
 
After:
 
prisma-desktop.tom.~/src/gh/prisma-engines λ ls -lh result/bin result/lib && git rev-parse HEAD
result/bin:
total 48M
-r-xr-xr-x 2 root root  14M Jan  1  1970 introspection-engine
-r-xr-xr-x 2 root root  16M Jan  1  1970 migration-engine
-r-xr-xr-x 2 root root 3.0M Jan  1  1970 prisma-fmt
-r-xr-xr-x 2 root root  16M Jan  1  1970 query-engine
 
result/lib:
total 14M
-r-xr-xr-x 2 root root 14M Jan  1  1970 libquery_engine.node
000390e56ecad32684db9b5c825ef658a1b209f2
 
--- Performance measurements ---
 
We measured a significant performance difference with -Oz. With -Os, the
performance difference is a lot smaller, and the size gains are still
very substantial. This is the reason we are not going for -Oz.
 
Extra details in this internal slack thread: https://prisma-company.slack.com/archives/C04DC5VEN02/p1671104433443399