### PR TITLE
ArrayOps should be default for GIN index arrays

### DIFF
--- a/psl/builtin-connectors/src/postgres_datamodel_connector/validations.rs
+++ b/psl/builtin-connectors/src/postgres_datamodel_connector/validations.rs
@@ -147,6 +147,10 @@ pub(super) fn generalized_index_validations(
             match (&native_type, opclass) {
                 // Jsonb / JsonbOps + JsonbPathOps
                 (None, None) if r#type.is_json() => (),
+
+                // Array fields + ArrayOps
+                (_, None) if field.as_index_field().is_list() => (),
+
                 (Some(PostgresType::JsonB), Some(JsonbOps | JsonbPathOps) | None) => (),
 
                 (None, Some(JsonbOps | JsonbPathOps)) => {

--- a/psl/parser-database/src/walkers/index.rs
+++ b/psl/parser-database/src/walkers/index.rs
@@ -231,6 +231,14 @@ impl<'db> IndexFieldWalker<'db> {
         }
     }
 
+    /// Is the field a list?
+    pub fn is_list(self) -> bool {
+        match self.inner {
+            InnerIndexFieldWalker::Scalar(sf) => sf.is_list(),
+            InnerIndexFieldWalker::Composite(cf) => cf.arity().is_list(),
+        }
+    }
+
     /// Is the type of the field `Unsupported("...")`?
     pub fn is_unsupported(self) -> bool {
         match self.inner {

--- a/psl/parser-database/src/walkers/scalar_field.rs
+++ b/psl/parser-database/src/walkers/scalar_field.rs
@@ -83,6 +83,11 @@ impl<'db> ScalarFieldWalker<'db> {
         self.ast_field().arity.is_optional()
     }
 
+    /// Is the field a list
+    pub fn is_list(self) -> bool {
+        self.ast_field().arity.is_list()
+    }
+
     /// Is there an `@updatedAt` attribute on the field?
     pub fn is_updated_at(self) -> bool {
         self.attributes().is_updated_at

--- a/psl/psl/tests/validation/postgres_indexes/gin/array_ops_default_ops.prisma
+++ b/psl/psl/tests/validation/postgres_indexes/gin/array_ops_default_ops.prisma
@@ -1,0 +1,11 @@
+datasource test {
+  provider = "postgresql"
+  url      = env("TEST_DATABASE_URL")
+}
+
+model A {
+  id Int      @id
+  a  String[] @test.Uuid
+
+  @@index([a], type: Gin)
+}


### PR DESCRIPTION
We don't need to validate operator class here.

Closes: https://github.com/prisma/prisma/issues/14587