### PR TITLE
feat(migration-engine): prepare getDatabaseVersion to read datasource after engine was initialized

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1901,6 +1901,7 @@ dependencies = [
  "backtrace",
  "base64 0.13.1",
  "connection-string",
+ "indoc",
  "json-rpc-stdio",
  "migration-connector",
  "migration-core",

--- a/migration-engine/cli/Cargo.toml
+++ b/migration-engine/cli/Cargo.toml
@@ -19,6 +19,7 @@ tracing-subscriber = { version = "0.3", features = [ "fmt", "json", "time", "env
 serde_json = "1.0.74"
 
 [dev-dependencies]
+indoc = "1.0"
 tempfile = "3.1.0"
 test-setup = { path = "../../libs/test-setup" }
 test-macros = { path = "../../libs/test-macros" }

--- a/migration-engine/cli/tests/cli_tests.rs
+++ b/migration-engine/cli/tests/cli_tests.rs
@@ -311,7 +311,7 @@ fn basic_jsonrpc_roundtrip_works(_api: TestApi) {
     }
 }
 
-#[test_connector(tags(Postgres))]
+#[test_connector(tags(Sqlite))]
 fn get_database_version_works_without_datamodel_init_arg(_api: TestApi) {
     use std::io::{BufRead, BufReader, Write as _};
     let schema = r#"

--- a/migration-engine/core/src/api.rs
+++ b/migration-engine/core/src/api.rs
@@ -6,7 +6,7 @@ use crate::{commands, json_rpc::types::*, CoreResult};
 #[async_trait::async_trait]
 pub trait GenericApi: Send + Sync + 'static {
     /// Return the database version as a string.
-    async fn version(&self) -> CoreResult<String>;
+    async fn version(&self, input: GetDatabaseVersionInput) -> CoreResult<String>;
 
     /// Apply all the unapplied migrations from the migrations folder.
     async fn apply_migrations(&self, input: ApplyMigrationsInput) -> CoreResult<ApplyMigrationsOutput>;

--- a/migration-engine/core/src/rpc.rs
+++ b/migration-engine/core/src/rpc.rs
@@ -35,7 +35,7 @@ async fn run_command(
         DIAGNOSE_MIGRATION_HISTORY => render(executor.diagnose_migration_history(params.parse()?).await),
         ENSURE_CONNECTION_VALIDITY => render(executor.ensure_connection_validity(params.parse()?).await),
         EVALUATE_DATA_LOSS => render(executor.evaluate_data_loss(params.parse()?).await),
-        GET_DATABASE_VERSION => render(executor.version().await),
+        GET_DATABASE_VERSION => render(executor.version(params.parse()?).await),
         INTROSPECT => render(executor.introspect(params.parse()?).await),
         LIST_MIGRATION_DIRECTORIES => render(executor.list_migration_directories(params.parse()?).await),
         MARK_MIGRATION_APPLIED => render(executor.mark_migration_applied(params.parse()?).await),

--- a/migration-engine/core/src/state.rs
+++ b/migration-engine/core/src/state.rs
@@ -186,8 +186,8 @@ impl EngineState {
 
 #[async_trait::async_trait]
 impl GenericApi for EngineState {
-    async fn version(&self) -> CoreResult<String> {
-        self.with_default_connector(Box::new(|connector| connector.version()))
+    async fn version(&self, input: GetDatabaseVersionInput) -> CoreResult<String> {
+        self.with_connector_from_datasource_param(&input.datasource, Box::new(|connector| connector.version()))
             .await
     }
 

--- a/migration-engine/json-rpc-api-build/methods/getDatabaseVersion.toml
+++ b/migration-engine/json-rpc-api-build/methods/getDatabaseVersion.toml
@@ -3,7 +3,8 @@ description = "Get the database version for error reporting."
 requestShape = "getDatabaseVersionInput"
 responseShape = "getDatabaseVersionOutput"
 
-[recordShapes.getDatabaseVersionInput]
+[recordShapes.getDatabaseVersionInput.fields.datasource]
+shape = "DatasourceParam"
 
 [recordShapes.getDatabaseVersionOutput.fields.version]
 shape = "string"


### PR DESCRIPTION
Contributes to https://github.com/prisma/prisma-private/issues/203.