### PR TITLE
qe: fix implicit many-to-many relations in multiSchema context

### DIFF
--- a/migration-engine/migration-engine-tests/tests/single_migration_tests/postgres/multi_schema_implicit_many_to_many_join_table_is_in_first_model_schema.prisma
+++ b/migration-engine/migration-engine-tests/tests/single_migration_tests/postgres/multi_schema_implicit_many_to_many_join_table_is_in_first_model_schema.prisma
@@ -1,0 +1,64 @@
+// tags=postgres
+// exclude=cockroachdb
+
+datasource testds {
+    provider = "postgresql"
+    url = env("TEST_DATABASE_URL")
+    schemas = ["veggies", "roots"]
+}
+
+generator js {
+    provider = "prisma-client-js"
+    previewFeatures = ["multiSchema"]
+}
+
+model zoodles {
+  id Int @id
+  shiratakies shirataki[]
+  @@schema("veggies")
+}
+
+model shirataki {
+  id Int @id
+  zoodles zoodles[]
+  @@schema("roots")
+}
+
+// Expected Migration:
+// -- CreateSchema
+// CREATE SCHEMA IF NOT EXISTS "roots";
+// 
+// -- CreateSchema
+// CREATE SCHEMA IF NOT EXISTS "veggies";
+// 
+// -- CreateTable
+// CREATE TABLE "veggies"."zoodles" (
+//     "id" INTEGER NOT NULL,
+// 
+//     CONSTRAINT "zoodles_pkey" PRIMARY KEY ("id")
+// );
+// 
+// -- CreateTable
+// CREATE TABLE "roots"."shirataki" (
+//     "id" INTEGER NOT NULL,
+// 
+//     CONSTRAINT "shirataki_pkey" PRIMARY KEY ("id")
+// );
+// 
+// -- CreateTable
+// CREATE TABLE "roots"."_shiratakiTozoodles" (
+//     "A" INTEGER NOT NULL,
+//     "B" INTEGER NOT NULL
+// );
+// 
+// -- CreateIndex
+// CREATE UNIQUE INDEX "_shiratakiTozoodles_AB_unique" ON "roots"."_shiratakiTozoodles"("A", "B");
+// 
+// -- CreateIndex
+// CREATE INDEX "_shiratakiTozoodles_B_index" ON "roots"."_shiratakiTozoodles"("B");
+// 
+// -- AddForeignKey
+// ALTER TABLE "roots"."_shiratakiTozoodles" ADD CONSTRAINT "_shiratakiTozoodles_A_fkey" FOREIGN KEY ("A") REFERENCES "roots"."shirataki"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+// 
+// -- AddForeignKey
+// ALTER TABLE "roots"."_shiratakiTozoodles" ADD CONSTRAINT "_shiratakiTozoodles_B_fkey" FOREIGN KEY ("B") REFERENCES "veggies"."zoodles"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/query-engine/connectors/sql-query-connector/src/model_extensions/relation.rs
+++ b/query-engine/connectors/sql-query-connector/src/model_extensions/relation.rs
@@ -67,8 +67,11 @@ impl AsTable for Relation {
             // table, so MSSQL can convert the `INSERT .. ON CONFLICT IGNORE` into
             // a `MERGE` statement.
             RelationLinkManifestation::RelationTable(ref m) => {
-                let db = self.model_a().internal_data_model().db_name.clone();
-                let table: Table = (db, m.table.clone()).into();
+                let model_a = self.model_a();
+                let prefix = model_a
+                    .schema_name()
+                    .unwrap_or_else(|| model_a.internal_data_model().db_name.clone());
+                let table: Table = (prefix, m.table.clone()).into();
 
                 table.add_unique_index(vec![Column::from("A"), Column::from("B")])
             }


### PR DESCRIPTION
We did not add any schema prefix there.

We now add the correct one (the schema of the first model).

closes https://github.com/prisma/prisma/issues/16761