### PR TITLE
ie: Pass warnings instead of output in rendering

### DIFF
--- a/introspection-engine/connectors/sql-introspection-connector/src/datamodel_calculator/context.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/datamodel_calculator/context.rs
@@ -54,6 +54,10 @@ impl<'a> InputContext<'a> {
         self.config.datasources.first().unwrap().active_connector
     }
 
+    pub(crate) fn uses_namespaces(self) -> bool {
+        matches!(self.config.datasources.first(), Some(ds) if !ds.namespaces.is_empty())
+    }
+
     /// Iterate over the database enums, combined together with a
     /// possible existing enum in the PSL.
     pub(crate) fn enum_pairs(self) -> impl ExactSizeIterator<Item = EnumPair<'a>> {

--- a/introspection-engine/connectors/sql-introspection-connector/src/pair/enumerator.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/pair/enumerator.rs
@@ -12,26 +12,9 @@ pub(crate) type EnumPair<'a> = Pair<'a, walkers::EnumWalker<'a>, sql::EnumWalker
 pub(crate) type EnumVariantPair<'a> = Pair<'a, walkers::EnumValueWalker<'a>, sql::EnumVariantWalker<'a>>;
 
 impl<'a> EnumPair<'a> {
-    /// The position of the enum from the PSL, if existing. Used for
-    /// sorting the enums in the final introspected data model.
-    pub(crate) fn previous_position(self) -> Option<ast::EnumId> {
-        self.previous.map(|e| e.id)
-    }
-
-    /// The namespace of the enumerator, if using the multi-schema feature.
-    pub(crate) fn namespace(self) -> Option<&'a str> {
-        if matches!(self.context.config.datasources.first(), Some(ds) if !ds.namespaces.is_empty()) {
-            self.next.namespace()
-        } else {
-            None
-        }
-    }
-
-    /// Name of the enum in the PSL. The value can be sanitized if it
-    /// contains characters that are not allowed in the PSL
-    /// definition.
-    pub(crate) fn name(self) -> Cow<'a, str> {
-        self.context.enum_prisma_name(self.next.id).prisma_name()
+    /// The documentation on top of the enum.
+    pub(crate) fn documentation(self) -> Option<&'a str> {
+        self.previous.and_then(|enm| enm.ast_enum().documentation())
     }
 
     /// The mapped name, if defined, is the actual name of the enum in
@@ -45,9 +28,26 @@ impl<'a> EnumPair<'a> {
         }
     }
 
-    /// The documentation on top of the enum.
-    pub(crate) fn documentation(self) -> Option<&'a str> {
-        self.previous.and_then(|enm| enm.ast_enum().documentation())
+    /// Name of the enum in the PSL. The value can be sanitized if it
+    /// contains characters that are not allowed in the PSL
+    /// definition.
+    pub(crate) fn name(self) -> Cow<'a, str> {
+        self.context.enum_prisma_name(self.next.id).prisma_name()
+    }
+
+    /// The namespace of the enumerator, if using the multi-schema feature.
+    pub(crate) fn namespace(self) -> Option<&'a str> {
+        if self.context.uses_namespaces() {
+            self.next.namespace()
+        } else {
+            None
+        }
+    }
+
+    /// The position of the enum from the PSL, if existing. Used for
+    /// sorting the enums in the final introspected data model.
+    pub(crate) fn previous_position(self) -> Option<ast::EnumId> {
+        self.previous.map(|e| e.id)
     }
 
     /// Iterates all of the variants that are part of the enum.
@@ -67,6 +67,17 @@ impl<'a> EnumPair<'a> {
 }
 
 impl<'a> EnumVariantPair<'a> {
+    /// The documentation on top of the enum.
+    pub(crate) fn documentation(self) -> Option<&'a str> {
+        self.previous.and_then(|variant| variant.documentation())
+    }
+
+    /// The mapped name, if defined, is the actual name of the variant in
+    /// the database.
+    pub(crate) fn mapped_name(self) -> Option<&'a str> {
+        self.context.enum_variant_name(self.next.id).mapped_name()
+    }
+
     /// Name of the variant in the PSL. The value can be sanitized if
     /// it contains characters that are not allowed in the PSL
     /// definition.
@@ -83,16 +94,5 @@ impl<'a> EnumVariantPair<'a> {
         } else {
             name
         }
-    }
-
-    /// The mapped name, if defined, is the actual name of the variant in
-    /// the database.
-    pub(crate) fn mapped_name(self) -> Option<&'a str> {
-        self.context.enum_variant_name(self.next.id).mapped_name()
-    }
-
-    /// The documentation on top of the enum.
-    pub(crate) fn documentation(self) -> Option<&'a str> {
-        self.previous.and_then(|variant| variant.documentation())
     }
 }

--- a/introspection-engine/connectors/sql-introspection-connector/src/rendering/defaults.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/rendering/defaults.rs
@@ -1,8 +1,8 @@
 //! The `@default` attribute rendering.
 
 use crate::{
-    datamodel_calculator::OutputContext,
     pair::{DefaultKind, ScalarFieldPair},
+    warnings::Warnings,
 };
 use datamodel_renderer::{
     datamodel as renderer,
@@ -10,10 +10,7 @@ use datamodel_renderer::{
 };
 
 /// Render a default value for the given scalar field.
-pub(crate) fn render<'a>(
-    field: ScalarFieldPair<'a>,
-    output: &mut OutputContext<'a>,
-) -> Option<renderer::DefaultValue<'a>> {
+pub(crate) fn render<'a>(field: ScalarFieldPair<'a>, warnings: &mut Warnings) -> Option<renderer::DefaultValue<'a>> {
     let mut rendered = match field.default().kind() {
         Some(kind) => match kind {
             DefaultKind::Sequence(sequence) => {
@@ -73,7 +70,7 @@ pub(crate) fn render<'a>(
                     field: field.name().to_string(),
                 };
 
-                output.warnings.prisma_1_uuid_defaults.push(warn);
+                warnings.prisma_1_uuid_defaults.push(warn);
                 Some(renderer::DefaultValue::function(Function::new("uuid")))
             }
             DefaultKind::Prisma1Cuid => {
@@ -82,7 +79,7 @@ pub(crate) fn render<'a>(
                     field: field.name().to_string(),
                 };
 
-                output.warnings.prisma_1_cuid_defaults.push(warn);
+                warnings.prisma_1_cuid_defaults.push(warn);
                 Some(renderer::DefaultValue::function(Function::new("cuid")))
             }
         },

--- a/introspection-engine/connectors/sql-introspection-connector/src/rendering/models.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/rendering/models.rs
@@ -5,7 +5,7 @@ use crate::{
     datamodel_calculator::{InputContext, OutputContext},
     introspection_helpers as helpers,
     pair::{IdPair, ModelPair},
-    warnings,
+    warnings::{self, Warnings},
 };
 use datamodel_renderer::datamodel as renderer;
 
@@ -16,7 +16,10 @@ pub(super) fn render<'a>(input: InputContext<'a>, output: &mut OutputContext<'a>
     let mut models_with_idx: Vec<(Option<_>, renderer::Model<'a>)> = Vec::with_capacity(input.schema.tables_count());
 
     for model in input.model_pairs() {
-        models_with_idx.push((model.previous_position(), render_model(model, input, output)));
+        models_with_idx.push((
+            model.previous_position(),
+            render_model(model, input, &mut output.warnings),
+        ));
     }
 
     models_with_idx.sort_by(|(a, _), (b, _)| helpers::compare_options_none_last(*a, *b));
@@ -27,11 +30,7 @@ pub(super) fn render<'a>(input: InputContext<'a>, output: &mut OutputContext<'a>
 }
 
 /// Render a single model.
-fn render_model<'a>(
-    model: ModelPair<'a>,
-    input: InputContext<'a>,
-    output: &mut OutputContext<'a>,
-) -> renderer::Model<'a> {
+fn render_model<'a>(model: ModelPair<'a>, input: InputContext<'a>, warnings: &mut Warnings) -> renderer::Model<'a> {
     let mut rendered = renderer::Model::new(model.name());
 
     if let Some(docs) = model.documentation() {
@@ -61,14 +60,14 @@ fn render_model<'a>(
     }
 
     if let Some(id) = model.id() {
-        rendered.id(render_id(model, id, output));
+        rendered.id(render_id(model, id, warnings));
     }
 
     if model.scalar_fields().len() == 0 {
         rendered.documentation(empty_table_comment(input));
         rendered.comment_out();
 
-        output.warnings.models_without_columns.push(warnings::Model {
+        warnings.models_without_columns.push(warnings::Model {
             model: model.name().to_string(),
         });
     } else if !model.has_usable_identifier() {
@@ -76,23 +75,23 @@ fn render_model<'a>(
 
         rendered.documentation(docs);
 
-        output.warnings.models_without_identifiers.push(warnings::Model {
+        warnings.models_without_identifiers.push(warnings::Model {
             model: model.name().to_string(),
         });
     }
 
     if model.remapped_name() {
-        output.warnings.remapped_models.push(warnings::Model {
+        warnings.remapped_models.push(warnings::Model {
             model: model.name().to_string(),
         });
     }
 
     for field in model.scalar_fields() {
-        rendered.push_field(scalar_field::render(field, output));
+        rendered.push_field(scalar_field::render(field, warnings));
     }
 
     for field in model.relation_fields() {
-        rendered.push_field(relation_field::render(field, output));
+        rendered.push_field(relation_field::render(field, warnings));
     }
 
     indexes::render(model, &mut rendered);
@@ -101,7 +100,7 @@ fn render_model<'a>(
 }
 
 /// Render a model level `@@id` definition.
-fn render_id<'a>(model: ModelPair<'a>, id: IdPair<'a>, output: &mut OutputContext) -> renderer::IdDefinition<'a> {
+fn render_id<'a>(model: ModelPair<'a>, id: IdPair<'a>, warnings: &mut Warnings) -> renderer::IdDefinition<'a> {
     let fields = id.fields().map(|field| {
         let mut rendered = renderer::IndexFieldInput::new(field.name());
 
@@ -121,7 +120,7 @@ fn render_id<'a>(model: ModelPair<'a>, id: IdPair<'a>, output: &mut OutputContex
     if let Some(name) = id.name() {
         definition.name(name);
 
-        output.warnings.reintrospected_id_names.push(warnings::Model {
+        warnings.reintrospected_id_names.push(warnings::Model {
             model: model.name().to_string(),
         });
     }

--- a/introspection-engine/connectors/sql-introspection-connector/src/rendering/relation_field.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/rendering/relation_field.rs
@@ -1,10 +1,10 @@
 //! Rendering of relation fields.
 
-use crate::{datamodel_calculator::OutputContext, pair::RelationFieldPair};
+use crate::{pair::RelationFieldPair, warnings::Warnings};
 use datamodel_renderer::datamodel as renderer;
 
 /// Render a relation field to be added in a model.
-pub(super) fn render<'a>(field: RelationFieldPair<'a>, output: &mut OutputContext<'a>) -> renderer::ModelField<'a> {
+pub(super) fn render<'a>(field: RelationFieldPair<'a>, warnings: &mut Warnings) -> renderer::ModelField<'a> {
     let mut rendered = renderer::ModelField::new(field.field_name(), field.prisma_type());
 
     if field.is_optional() {
@@ -48,7 +48,7 @@ pub(super) fn render<'a>(field: RelationFieldPair<'a>, output: &mut OutputContex
     }
 
     if field.reintrospected_relation() {
-        output.warnings.reintrospected_relations.push(crate::warnings::Model {
+        warnings.reintrospected_relations.push(crate::warnings::Model {
             model: field.prisma_type().into_owned(),
         });
     }

--- a/introspection-engine/connectors/sql-introspection-connector/src/rendering/scalar_field.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/rendering/scalar_field.rs
@@ -1,15 +1,15 @@
 //! Rendering of model scalar fields.
 
 use crate::{
-    datamodel_calculator::OutputContext,
     pair::{IdPair, IndexPair, ScalarFieldPair},
     rendering::defaults,
+    warnings::Warnings,
 };
 use datamodel_renderer::datamodel as renderer;
 use sql_schema_describer::ColumnArity;
 
 /// Render a scalar field to be added in a model.
-pub(crate) fn render<'a>(field: ScalarFieldPair<'a>, output: &mut OutputContext<'a>) -> renderer::ModelField<'a> {
+pub(crate) fn render<'a>(field: ScalarFieldPair<'a>, warnings: &mut Warnings) -> renderer::ModelField<'a> {
     let mut rendered = renderer::ModelField::new(field.name(), field.prisma_type());
 
     match field.arity() {
@@ -34,7 +34,7 @@ pub(crate) fn render<'a>(field: ScalarFieldPair<'a>, output: &mut OutputContext<
         rendered.documentation(docs);
     }
 
-    if let Some(default) = defaults::render(field, output) {
+    if let Some(default) = defaults::render(field, warnings) {
         rendered.default(default);
     }
 
@@ -60,7 +60,7 @@ pub(crate) fn render<'a>(field: ScalarFieldPair<'a>, output: &mut OutputContext<
             field: field.name().to_string(),
         };
 
-        output.warnings.remapped_fields.push(mf);
+        warnings.remapped_fields.push(mf);
     }
 
     if field.is_unsupported() {
@@ -70,7 +70,7 @@ pub(crate) fn render<'a>(field: ScalarFieldPair<'a>, output: &mut OutputContext<
             tpe: field.prisma_type().to_string(),
         };
 
-        output.warnings.unsupported_types.push(mf)
+        warnings.unsupported_types.push(mf)
     }
 
     if field.remapped_name_empty() {
@@ -83,7 +83,7 @@ pub(crate) fn render<'a>(field: ScalarFieldPair<'a>, output: &mut OutputContext<
             field: field.name().to_string(),
         };
 
-        output.warnings.fields_with_empty_names.push(mf);
+        warnings.fields_with_empty_names.push(mf);
     }
 
     rendered


### PR DESCRIPTION
Most of the rendering functions do not need the whole `OutputContext`. Having it available is a bit confusing for the user, because the functions only mutate the warnings, not the actual rendering output.

Let's just pass the warnings to these functions to be more clear for our intention.