### PR TITLE
Add qe-node-api make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,13 @@ CONFIG_PATH = ./query-engine/connector-test-kit-rs/test-configs
 CONFIG_FILE = .test_config
 SCHEMA_EXAMPLES_PATH = ./query-engine/example_schemas
 DEV_SCHEMA_FILE = dev_datamodel.prisma
-LIBRARY_EXT := $(shell [[ "$$(uname -s)" == "Darwin" ]] && echo "dylib" || echo "so")
+
+LIBRARY_EXT := $(shell                            \
+    case "$$(uname -s)" in                        \
+        (Darwin)               echo "dylib" ;;    \
+        (MINGW*|MSYS*|CYGWIN*) echo "dll"   ;;    \
+        (*)                    echo "so"    ;;    \
+    esac)
 
 default: build
 

--- a/Makefile
+++ b/Makefile
@@ -249,7 +249,7 @@ show-metrics:
 otel:
 	docker compose up --remove-orphans -d otel
 
-# Building debug version of Query Engine Node-API library ready to be consumed by Node.js
+# Build the debug version of Query Engine Node-API library ready to be consumed by Node.js
 .PHONY: qe-node-api
 qe-node-api: build target/debug/libquery_engine.node
 

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ CONFIG_PATH = ./query-engine/connector-test-kit-rs/test-configs
 CONFIG_FILE = .test_config
 SCHEMA_EXAMPLES_PATH = ./query-engine/example_schemas
 DEV_SCHEMA_FILE = dev_datamodel.prisma
+LIBRARY_EXT := $(shell [[ "$$(uname -s)" == "Darwin" ]] && echo "dylib" || echo "so")
 
 default: build
 
@@ -241,3 +242,13 @@ show-metrics:
 ## OpenTelemetry
 otel:
 	docker compose up --remove-orphans -d otel
+
+# Building debug version of Query Engine Node-API library ready to be consumed by Node.js
+.PHONY: qe-node-api
+qe-node-api: build target/debug/libquery_engine.node
+
+%.node: %.$(LIBRARY_EXT)
+# Remove the file first to work around a macOS bug: https://openradar.appspot.com/FB8914243
+# otherwise macOS gatekeeper may kill the Node.js process when it tries to load the library
+	if [[ "$$(uname -sm)" == "Darwin arm64" ]]; then rm -f $@; fi
+	cp $< $@


### PR DESCRIPTION
Add `qe-node-api` make target to make it easier to work on the engine and the client at the same time. This allows setting the `PRISMA_QUERY_ENGINE_LIBRARY` env var in the client once (e.g. in `.envrc`) and running a single `make qe-node-api` command in the engines directory to make the engine changes immediately available in the client.

Tested with both BSD make and GNU make.