### PR TITLE
migration-engine: fix mssql not properly initiating/resetting namespaces in shadowdb

### DIFF
--- a/introspection-engine/introspection-engine-tests/src/test_api.rs
+++ b/introspection-engine/introspection-engine-tests/src/test_api.rs
@@ -288,6 +288,7 @@ impl TestApi {
             } else {
                 &[]
             },
+            &[],
         )
     }
 

--- a/libs/test-setup/src/test_api_args.rs
+++ b/libs/test-setup/src/test_api_args.rs
@@ -117,8 +117,6 @@ pub struct TestApiArgs {
     db: &'static DbUnderTest,
 }
 
-const EMPTY_PREVIEW_FEATURES: &[&str] = &[];
-
 impl TestApiArgs {
     pub fn new(
         test_function_name: &'static str,
@@ -172,12 +170,17 @@ impl TestApiArgs {
         self.db.database_url.as_str()
     }
 
-    pub fn datasource_block<'a>(&'a self, url: &'a str, params: &'a [(&'a str, &'a str)]) -> DatasourceBlock<'a> {
+    pub fn datasource_block<'a>(
+        &'a self,
+        url: &'a str,
+        params: &'a [(&'a str, &'a str)],
+        preview_features: &'static [&'static str],
+    ) -> DatasourceBlock<'a> {
         DatasourceBlock {
             provider: self.db.provider,
             url,
             params,
-            preview_features: EMPTY_PREVIEW_FEATURES,
+            preview_features,
         }
     }
 

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/mssql/shadow_db.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/mssql/shadow_db.rs
@@ -5,6 +5,7 @@ use sql_schema_describer::SqlSchema;
 pub(super) async fn sql_schema_from_migrations_history(
     migrations: &[MigrationDirectory],
     mut shadow_db: MssqlFlavour,
+    namespaces: Option<Namespaces>,
 ) -> ConnectorResult<SqlSchema> {
     for migration in migrations {
         let script = migration.read_migration_script()?;
@@ -23,5 +24,5 @@ pub(super) async fn sql_schema_from_migrations_history(
             })?;
     }
 
-    shadow_db.describe_schema(None).await
+    shadow_db.describe_schema(namespaces).await
 }

--- a/migration-engine/migration-engine-tests/src/multi_engine_test_api.rs
+++ b/migration-engine/migration-engine-tests/src/multi_engine_test_api.rs
@@ -105,7 +105,7 @@ impl TestApi {
 
     /// Render a valid datasource block, including database URL.
     pub fn datasource_block(&self) -> DatasourceBlock<'_> {
-        self.args.datasource_block(self.args.database_url(), &[])
+        self.args.datasource_block(self.args.database_url(), &[], &[])
     }
 
     /// Returns true only when testing on MSSQL.
@@ -227,7 +227,12 @@ impl TestApi {
 
     /// Render a valid datasource block, including database URL.
     pub fn write_datasource_block(&self, out: &mut dyn std::fmt::Write) {
-        write!(out, "{}", self.args.datasource_block(self.args.database_url(), &[])).unwrap()
+        write!(
+            out,
+            "{}",
+            self.args.datasource_block(self.args.database_url(), &[], &[])
+        )
+        .unwrap()
     }
 
     /// Currently enabled preview features.

--- a/migration-engine/migration-engine-tests/src/test_api.rs
+++ b/migration-engine/migration-engine-tests/src/test_api.rs
@@ -238,7 +238,9 @@ impl TestApi {
     }
 
     pub fn datasource_block_with<'a>(&'a self, params: &'a [(&'a str, &'a str)]) -> DatasourceBlock<'a> {
-        self.root.args.datasource_block(self.root.connection_string(), params)
+        self.root
+            .args
+            .datasource_block(self.root.connection_string(), params, &[])
     }
 
     /// Generate a migration script using `MigrationConnector::diff()`.
@@ -322,21 +324,26 @@ impl TestApi {
     }
 
     /// Render a valid datasource block, including database URL.
-    pub fn write_datasource_block(&self, out: &mut dyn std::fmt::Write) {
+    pub fn write_datasource_block(
+        &self,
+        out: &mut dyn std::fmt::Write,
+        params: &[(&str, &str)],
+        preview_features: &'static [&'static str],
+    ) {
         let no_foreign_keys = self.is_vitess();
 
-        let params = if no_foreign_keys {
+        let used_params = if no_foreign_keys && params.is_empty() {
             vec![("relationMode", r#""prisma""#)]
         } else {
-            Vec::new()
+            params.to_vec()
         };
 
-        write!(
-            out,
-            "{}",
-            self.root.args.datasource_block(self.root.args.database_url(), &params)
-        )
-        .unwrap()
+        let ds_block = self
+            .root
+            .args
+            .datasource_block(self.root.args.database_url(), &used_params, preview_features);
+
+        write!(out, "{}", ds_block).unwrap()
     }
 
     fn generator_block(&self) -> String {
@@ -365,7 +372,23 @@ impl TestApi {
     pub fn datamodel_with_provider(&self, schema: &str) -> String {
         let mut out = String::with_capacity(320 + schema.len());
 
-        self.write_datasource_block(&mut out);
+        self.write_datasource_block(&mut out, &[], &[]);
+        out.push('\n');
+        out.push_str(&self.generator_block());
+        out.push_str(schema);
+
+        out
+    }
+
+    pub fn datamodel_with_provider_and_features(
+        &self,
+        schema: &str,
+        params: &[(&str, &str)],
+        preview_features: &'static [&'static str],
+    ) -> String {
+        let mut out = String::with_capacity(320 + schema.len());
+
+        self.write_datasource_block(&mut out, params, preview_features);
         out.push('\n');
         out.push_str(&self.generator_block());
         out.push_str(schema);

--- a/migration-engine/migration-engine-tests/tests/apply_migrations/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/apply_migrations/mod.rs
@@ -114,14 +114,37 @@ fn multi_schema_two_migrations_drop_fks(api: TestApi) {
         .send_sync()
         .assert_applied_migrations(&["initial"]);
 
-    let dm2 = api.datamodel_with_provider_and_features("", &[("schemas", "[\"one\", \"two\"]")], &["multiSchema"]);
-
-    api.create_migration("second-migration", &dm2, &migrations_directory)
-        .send_sync();
-
     api.raw_cmd("INSERT INTO one.First (id, name, r2_secondId) VALUES(1, 'first', NULL)");
     api.raw_cmd("INSERT INTO two.Second (id, name, r1_firstId) VALUES(1, 'second', 1)");
     api.raw_cmd("INSERT INTO one.First (id, name, r2_secondId) VALUES(2, 'other', 1)");
+
+    let dm2 = api.datamodel_with_provider_and_features(r#"
+        model First {
+            id      Int @id
+            name    String
+
+            r1_second Second? @relation("r1")
+
+            r2_second Second? @relation("r2", fields: [r2_secondId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+            r2_secondId Int? @unique
+
+            @@schema("two")
+        }
+        model Second {
+            id      Int @id
+            name    String
+
+            r1_first First @relation("r1", fields: [r1_firstId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+            r1_firstId Int @unique
+
+            r2_first First? @relation("r2")
+
+            @@schema("one")
+        }
+      "#, &[("schemas", "[\"one\", \"two\"]")], &["multiSchema"]);
+
+    api.create_migration("second-migration", &dm2, &migrations_directory)
+        .send_sync();
 
     api.apply_migrations(&migrations_directory)
         .send_sync()

--- a/migration-engine/migration-engine-tests/tests/apply_migrations/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/apply_migrations/mod.rs
@@ -155,6 +155,94 @@ fn multi_schema_two_migrations_drop_fks(api: TestApi) {
         .assert_applied_migrations(&[]);
 }
 
+#[test_connector(tags(Mssql), preview_features("multiSchema"), namespaces("one", "two"))]
+fn multi_schema_two_migrations_reset(api: TestApi) {
+    let dm1 = api.datamodel_with_provider_and_features(
+        r#"
+        model First {
+            id      Int @id
+            name    String
+
+            r1_second Second? @relation("r1")
+
+            r2_second Second? @relation("r2", fields: [r2_secondId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+            r2_secondId Int? @unique
+
+            @@schema("one")
+        }
+        model Second {
+            id      Int @id
+            name    String
+
+            r1_first First @relation("r1", fields: [r1_firstId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+            r1_firstId Int @unique
+
+            r2_first First? @relation("r2")
+
+            @@schema("two")
+        }
+    "#,
+        &[("schemas", "[\"one\", \"two\"]")],
+        &["multiSchema"],
+    );
+
+    let migrations_directory = api.create_migrations_directory();
+
+    api.create_migration("initial", &dm1, &migrations_directory).send_sync();
+
+    api.apply_migrations(&migrations_directory)
+        .send_sync()
+        .assert_applied_migrations(&["initial"]);
+
+    api.raw_cmd("INSERT INTO one.First (id, name, r2_secondId) VALUES(1, 'first', NULL)");
+    api.raw_cmd("INSERT INTO two.Second (id, name, r1_firstId) VALUES(1, 'second', 1)");
+    api.raw_cmd("INSERT INTO one.First (id, name, r2_secondId) VALUES(2, 'other', 1)");
+
+    let dm2 = api.datamodel_with_provider_and_features(r#"
+        model First {
+            id      Int @id
+            name    String
+
+            r1_second Second? @relation("r1")
+
+            r2_second Second? @relation("r2", fields: [r2_secondId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+            r2_secondId Int? @unique
+
+            @@schema("two")
+        }
+        model Second {
+            id      Int @id
+            name    String
+
+            r1_first First @relation("r1", fields: [r1_firstId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+            r1_firstId Int @unique
+
+            r2_first First? @relation("r2")
+
+            @@schema("one")
+        }
+      "#, &[("schemas", "[\"one\", \"two\"]")], &["multiSchema"]);
+
+    api.create_migration("second-migration", &dm2, &migrations_directory)
+        .send_sync();
+
+    api.apply_migrations(&migrations_directory)
+        .send_sync()
+        .assert_applied_migrations(&["second-migration"]);
+
+    api.apply_migrations(&migrations_directory)
+        .send_sync()
+        .assert_applied_migrations(&[]);
+
+    let mut vec = vec![String::from("one"), String::from("two")];
+    let namespaces = Namespaces::from_vec(&mut vec);
+    api.reset().send_sync(namespaces.clone());
+
+    api.assert_schema_with_namespaces(namespaces)
+        .assert_has_no_table("First")
+        .assert_has_no_table("Second");
+}
+
 #[test_connector]
 fn applying_two_migrations_works(api: TestApi) {
     let dm1 = api.datamodel_with_provider(

--- a/migration-engine/migration-engine-tests/tests/apply_migrations/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/apply_migrations/mod.rs
@@ -119,9 +119,9 @@ fn multi_schema_two_migrations_drop_fks(api: TestApi) {
     api.create_migration("second-migration", &dm2, &migrations_directory)
         .send_sync();
 
-    api.raw_cmd("INSERT INTO [one].[First] (id, name, r2_secondId) VALUES(1, 'first', NULL)");
-    api.raw_cmd("INSERT INTO [two].[Second] (id, name, r1_firstId) VALUES(1, 'second', 1)");
-    api.raw_cmd("INSERT INTO [one].[First] (id, name, r2_secondId) VALUES(2, 'other', 1)");
+    api.raw_cmd("INSERT INTO one.First (id, name, r2_secondId) VALUES(1, 'first', NULL)");
+    api.raw_cmd("INSERT INTO two.Second (id, name, r1_firstId) VALUES(1, 'second', 1)");
+    api.raw_cmd("INSERT INTO one.First (id, name, r2_secondId) VALUES(2, 'other', 1)");
 
     api.apply_migrations(&migrations_directory)
         .send_sync()

--- a/migration-engine/migration-engine-tests/tests/apply_migrations/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/apply_migrations/mod.rs
@@ -75,7 +75,7 @@ fn multi_schema_applying_two_migrations_works(api: TestApi) {
         .assert_applied_migrations(&[]);
 }
 
-#[test_connector(tags(Mssql, Postgres), preview_features("multiSchema"), namespaces("one", "two"))]
+#[test_connector(tags(Mssql), preview_features("multiSchema"), namespaces("one", "two"))]
 fn multi_schema_two_migrations_drop_fks(api: TestApi) {
     let dm1 = api.datamodel_with_provider_and_features(
         r#"

--- a/migration-engine/migration-engine-tests/tests/migrations/mssql/multi_schema.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/mssql/multi_schema.rs
@@ -15,7 +15,7 @@ fn multi_schema_tests(_api: TestApi) {
     let namespaces: &'static [&'static str] = &["one", "two"];
     let base_schema = indoc! {r#"
         datasource db {
-          provider   = "postgresql"
+          provider   = "sqlserver"
           url        = env("TEST_DATABASE_URL")
           schemas    = ["one", "two"]
         }


### PR DESCRIPTION
I'm very curious as to why the tests were not affected by this.