### PR TITLE
psl: multiSchema preview flag should be visible

### DIFF
--- a/psl/psl-core/src/common/preview_features.rs
+++ b/psl/psl-core/src/common/preview_features.rs
@@ -1,3 +1,4 @@
+use enumflags2::BitFlags;
 use serde::{Serialize, Serializer};
 use std::fmt;
 
@@ -89,6 +90,7 @@ pub const ALL_PREVIEW_FEATURES: FeatureMap = FeatureMap {
          | PostgresqlExtensions
          | ExtendedWhereUnique
          | ClientExtensions
+         | MultiSchema
     }),
     deprecated: enumflags2::make_bitflags!(PreviewFeature::{
         AtomicNumberOperations
@@ -117,9 +119,7 @@ pub const ALL_PREVIEW_FEATURES: FeatureMap = FeatureMap {
         | DataProxy
         | InteractiveTransactions
     }),
-    hidden: enumflags2::make_bitflags!(PreviewFeature::{
-        MultiSchema
-    }),
+    hidden: BitFlags::EMPTY,
 };
 
 #[derive(Debug)]

--- a/psl/psl/tests/config/generators.rs
+++ b/psl/psl/tests/config/generators.rs
@@ -258,7 +258,7 @@ fn nice_error_for_unknown_generator_preview_feature() {
         .unwrap_err();
 
     let expectation = expect![[r#"
-        [1;91merror[0m: [1mThe preview feature "foo" is not known. Expected one of: fullTextSearch, fullTextIndex, tracing, metrics, orderByNulls, filteredRelationCount, fieldReference, postgresqlExtensions, clientExtensions, deno, extendedWhereUnique[0m
+        [1;91merror[0m: [1mThe preview feature "foo" is not known. Expected one of: fullTextSearch, fullTextIndex, tracing, metrics, orderByNulls, multiSchema, filteredRelationCount, fieldReference, postgresqlExtensions, clientExtensions, deno, extendedWhereUnique[0m
           [1;94m-->[0m  [4mschema.prisma:3[0m
         [1;94m   | [0m
         [1;94m 2 | [0m  provider = "prisma-client-js"


### PR DESCRIPTION
Closes: https://github.com/prisma/schema-team/issues/380