### PR TITLE
intro: Prefix duplicate top level names with the schema

### DIFF
--- a/introspection-engine/connectors/sql-introspection-connector/src/datamodel_calculator/context.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/datamodel_calculator/context.rs
@@ -177,9 +177,11 @@ impl<'a> InputContext<'a> {
     }
 
     pub(crate) fn name_is_unique(self, name: &'a str) -> bool {
+        let name = crate::sanitize_datamodel_names::sanitize_string(name);
+
         self.introspection_map
             .top_level_names
-            .get(name)
+            .get(&name)
             .map(|val| *val <= 1)
             .unwrap_or(true)
     }

--- a/introspection-engine/connectors/sql-introspection-connector/src/pair/enumerator.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/pair/enumerator.rs
@@ -44,6 +44,12 @@ impl<'a> EnumPair<'a> {
         self.previous.map(|e| e.id)
     }
 
+    /// True, if enum uses the same name as another top-level item from
+    /// a different namespace.
+    pub(crate) fn uses_duplicate_name(self) -> bool {
+        self.previous.is_none() && !self.context.name_is_unique(self.next.name())
+    }
+
     /// Iterates all of the variants that are part of the enum.
     pub(crate) fn variants(self) -> impl ExactSizeIterator<Item = EnumVariantPair<'a>> + 'a {
         self.next.variants().map(move |next| {

--- a/introspection-engine/connectors/sql-introspection-connector/src/pair/enumerator.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/pair/enumerator.rs
@@ -1,4 +1,3 @@
-use crate::sanitize_datamodel_names::ModelName;
 use psl::{
     parser_database::walkers,
     schema_ast::ast::{self, WithDocumentation},
@@ -20,12 +19,7 @@ impl<'a> EnumPair<'a> {
     /// The mapped name, if defined, is the actual name of the enum in
     /// the database.
     pub(crate) fn mapped_name(self) -> Option<&'a str> {
-        match self.context.enum_prisma_name(self.next.id) {
-            ModelName::FromPsl { mapped_name, .. } => mapped_name,
-            ModelName::RenamedReserved { mapped_name } => Some(mapped_name),
-            ModelName::RenamedSanitized { mapped_name } => Some(mapped_name),
-            ModelName::FromSql { .. } => None,
-        }
+        self.context.enum_prisma_name(self.next.id).mapped_name()
     }
 
     /// Name of the enum in the PSL. The value can be sanitized if it

--- a/introspection-engine/connectors/sql-introspection-connector/src/pair/model.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/pair/model.rs
@@ -125,6 +125,12 @@ impl<'a> ModelPair<'a> {
             })
     }
 
+    /// True, if the model uses the same name as another top-level item from
+    /// a different namespace.
+    pub(crate) fn uses_duplicate_name(self) -> bool {
+        self.previous.is_none() && !self.context.name_is_unique(self.next.name())
+    }
+
     /// If the model is marked as ignored. Can happen either if user
     /// explicitly sets the model attribute, or if the model has no
     /// usable identifiers.

--- a/introspection-engine/connectors/sql-introspection-connector/src/rendering/enums.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/rendering/enums.rs
@@ -53,6 +53,13 @@ fn render_enum<'a>(r#enum: EnumPair<'a>, warnings: &mut Warnings) -> renderer::E
         rendered_enum.documentation(docs);
     }
 
+    if r#enum.uses_duplicate_name() {
+        warnings.duplicate_names.push(warnings::TopLevelItem {
+            r#type: warnings::TopLevelType::Enum,
+            name: r#enum.name().to_string(),
+        })
+    }
+
     for variant in r#enum.variants() {
         if variant.name().is_empty() {
             let value = variant

--- a/introspection-engine/connectors/sql-introspection-connector/src/rendering/models.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/rendering/models.rs
@@ -80,6 +80,13 @@ fn render_model<'a>(model: ModelPair<'a>, input: InputContext<'a>, warnings: &mu
         });
     }
 
+    if model.uses_duplicate_name() {
+        warnings.duplicate_names.push(warnings::TopLevelItem {
+            r#type: warnings::TopLevelType::Model,
+            name: model.name().to_string(),
+        })
+    }
+
     if model.remapped_name() {
         warnings.remapped_models.push(warnings::Model {
             model: model.name().to_string(),

--- a/introspection-engine/introspection-engine-tests/tests/multi_schema/cockroach.rs
+++ b/introspection-engine/introspection-engine-tests/tests/multi_schema/cockroach.rs
@@ -88,15 +88,17 @@ async fn multiple_schemas_w_duplicate_table_names_are_introspected(api: &TestApi
           schemas  = ["first", "second"]
         }
 
-        model A {
+        model first_A {
           id String @id
 
+          @@map("A")
           @@schema("first")
         }
 
-        model A {
+        model second_A {
           id String @id
 
+          @@map("A")
           @@schema("second")
         }
     "#]];
@@ -242,33 +244,37 @@ async fn multiple_schemas_w_duplicate_enums_are_introspected(api: &TestApi) -> T
           schemas  = ["first", "second"]
         }
 
-        model HappyPerson {
-          mood HappyMood @id
+        model first_HappyPerson {
+          mood first_HappyMood @id
 
+          @@map("HappyPerson")
           @@schema("first")
         }
 
-        model HappyPerson {
-          mood HappyMood @id
+        model second_HappyPerson {
+          mood first_HappyMood @id
 
+          @@map("HappyPerson")
           @@schema("second")
         }
 
         model VeryHappyPerson {
-          mood HappyMood @id
+          mood second_HappyMood @id
 
           @@schema("second")
         }
 
-        enum HappyMood {
+        enum first_HappyMood {
           happy
 
+          @@map("HappyMood")
           @@schema("first")
         }
 
-        enum HappyMood {
+        enum second_HappyMood {
           veryHappy
 
+          @@map("HappyMood")
           @@schema("second")
         }
     "#]];
@@ -304,18 +310,20 @@ async fn same_table_name_with_relation_in_two_schemas(api: &TestApi) -> TestResu
           schemas  = ["first", "second_schema"]
         }
 
-        model tbl {
-          id  BigInt @id @default(autoincrement())
-          tbl tbl[]
+        model first_tbl {
+          id  BigInt              @id @default(autoincrement())
+          tbl second_schema_tbl[]
 
+          @@map("tbl")
           @@schema("first")
         }
 
-        model tbl {
-          id  BigInt @id @default(autoincrement())
+        model second_schema_tbl {
+          id  BigInt     @id @default(autoincrement())
           fst Int?
-          tbl tbl?   @relation(fields: [fst], references: [id], onDelete: NoAction, onUpdate: NoAction)
+          tbl first_tbl? @relation(fields: [fst], references: [id], onDelete: NoAction, onUpdate: NoAction)
 
+          @@map("tbl")
           @@schema("second_schema")
         }
     "#]];

--- a/introspection-engine/introspection-engine-tests/tests/multi_schema/postgres.rs
+++ b/introspection-engine/introspection-engine-tests/tests/multi_schema/postgres.rs
@@ -191,6 +191,27 @@ async fn multiple_schemas_w_duplicate_table_names_are_introspected(api: &TestApi
     "#]];
 
     api.expect_datamodel(&expected).await;
+
+    let expected = expect![[r#"
+        [
+          {
+            "code": 20,
+            "message": "These models were renamed due to their names being duplicates in the Prisma Schema Language.",
+            "affected": [
+              {
+                "type": "Model",
+                "name": "first_A"
+              },
+              {
+                "type": "Model",
+                "name": "second_A"
+              }
+            ]
+          }
+        ]"#]];
+
+    api.expect_warnings(&expected).await;
+
     Ok(())
 }
 
@@ -462,6 +483,53 @@ async fn multiple_schemas_w_duplicate_enums_are_introspected(api: &TestApi) -> T
     "#]];
 
     api.expect_datamodel(&expected).await;
+
+    let expected = expect![[r#"
+        [
+          {
+            "code": 9,
+            "message": "These enums were enriched with `@@map` information taken from the previous Prisma schema.",
+            "affected": [
+              {
+                "enm": "first_HappyMood"
+              }
+            ]
+          },
+          {
+            "code": 9,
+            "message": "These enums were enriched with `@@map` information taken from the previous Prisma schema.",
+            "affected": [
+              {
+                "enm": "second_HappyMood"
+              }
+            ]
+          },
+          {
+            "code": 20,
+            "message": "These models and enums were renamed due to their names being duplicates in the Prisma Schema Language.",
+            "affected": [
+              {
+                "type": "Enum",
+                "name": "first_HappyMood"
+              },
+              {
+                "type": "Enum",
+                "name": "second_HappyMood"
+              },
+              {
+                "type": "Model",
+                "name": "first_HappyPerson"
+              },
+              {
+                "type": "Model",
+                "name": "second_HappyPerson"
+              }
+            ]
+          }
+        ]"#]];
+
+    api.expect_warnings(&expected).await;
+
     Ok(())
 }
 
@@ -519,6 +587,21 @@ async fn multiple_schemas_w_duplicate_models_are_reintrospected(api: &TestApi) -
 
     api.expect_re_introspected_datamodel(input, expected).await;
 
+    let expected = expect![[r#"
+        [
+          {
+            "code": 7,
+            "message": "These models were enriched with `@@map` information taken from the previous Prisma schema.",
+            "affected": [
+              {
+                "model": "FooBar"
+              }
+            ]
+          }
+        ]"#]];
+
+    api.expect_re_introspect_warnings(input, expected).await;
+
     Ok(())
 }
 
@@ -569,6 +652,22 @@ async fn multiple_schemas_w_duplicate_models_are_reintrospected_never_renamed(ap
 
     api.expect_re_introspected_datamodel(input, expected).await;
 
+    let expected = expect![[r#"
+        [
+          {
+            "code": 20,
+            "message": "These models were renamed due to their names being duplicates in the Prisma Schema Language.",
+            "affected": [
+              {
+                "type": "Model",
+                "name": "second_HappyPerson"
+              }
+            ]
+          }
+        ]"#]];
+
+    api.expect_re_introspect_warnings(input, expected).await;
+
     Ok(())
 }
 
@@ -618,6 +717,21 @@ async fn multiple_schemas_w_duplicate_enums_are_reintrospected(api: &TestApi) ->
     "#]];
 
     api.expect_re_introspected_datamodel(input, expected).await;
+
+    let expected = expect![[r#"
+        [
+          {
+            "code": 9,
+            "message": "These enums were enriched with `@@map` information taken from the previous Prisma schema.",
+            "affected": [
+              {
+                "enm": "RenamedMood"
+              }
+            ]
+          }
+        ]"#]];
+
+    api.expect_re_introspect_warnings(input, expected).await;
 
     Ok(())
 }

--- a/introspection-engine/introspection-engine-tests/tests/multi_schema/sql_server.rs
+++ b/introspection-engine/introspection-engine-tests/tests/multi_schema/sql_server.rs
@@ -230,15 +230,17 @@ async fn multiple_schemas_w_duplicate_table_names_are_introspected(api: &TestApi
           schemas  = ["first", "second"]
         }
 
-        model A {
+        model first_A {
           id Int @id @default(autoincrement())
 
+          @@map("A")
           @@schema("first")
         }
 
-        model A {
+        model second_A {
           id Int @id @default(autoincrement())
 
+          @@map("A")
           @@schema("second")
         }
     "#]];
@@ -401,18 +403,20 @@ async fn multiple_schemas_w_cross_schema_fks_w_duplicate_names_are_introspected(
           schemas  = ["first", "second"]
         }
 
-        model A {
-          id Int @id @default(autoincrement())
-          A  A[]
+        model first_A {
+          id Int        @id @default(autoincrement())
+          A  second_A[]
 
+          @@map("A")
           @@schema("first")
         }
 
-        model A {
-          id Int  @id @default(autoincrement())
+        model second_A {
+          id Int      @id @default(autoincrement())
           fk Int?
-          A  A?   @relation(fields: [fk], references: [id], onDelete: NoAction, onUpdate: NoAction)
+          A  first_A? @relation(fields: [fk], references: [id], onDelete: NoAction, onUpdate: NoAction)
 
+          @@map("A")
           @@schema("second")
         }
     "#]];

--- a/introspection-engine/introspection-engine-tests/tests/simple/postgres/should_not_remap_if_renaming_would_lead_to_duplicate_names.sql
+++ b/introspection-engine/introspection-engine-tests/tests/simple/postgres/should_not_remap_if_renaming_would_lead_to_duplicate_names.sql
@@ -9,6 +9,7 @@ CREATE TABLE _nodes(
     CONSTRAINT _nodes_node_b_fkey FOREIGN KEY(node_b) REFERENCES nodes(id) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
+
 /*
 generator client {
   provider = "prisma-client-js"
@@ -20,19 +21,21 @@ datasource db {
 }
 
 /// The underlying table does not contain a valid unique identifier and can therefore currently not be handled by the Prisma Client.
-model nodes {
+model prisma_tests__nodes {
   node_a                    Int
   node_b                    Int
-  nodes_nodes_node_aTonodes nodes @relation("nodes_node_aTonodes", fields: [node_a], references: [id], onDelete: Cascade)
-  nodes_nodes_node_bTonodes nodes @relation("nodes_node_bTonodes", fields: [node_b], references: [id], onDelete: Cascade)
+  nodes_nodes_node_aTonodes prisma_tests_nodes @relation("nodes_node_aTonodes", fields: [node_a], references: [id], onDelete: Cascade)
+  nodes_nodes_node_bTonodes prisma_tests_nodes @relation("nodes_node_bTonodes", fields: [node_b], references: [id], onDelete: Cascade)
 
   @@map("_nodes")
   @@ignore
 }
 
-model nodes {
-  id                        Int     @id @default(autoincrement())
-  nodes_nodes_node_aTonodes nodes[] @relation("nodes_node_aTonodes") @ignore
-  nodes_nodes_node_bTonodes nodes[] @relation("nodes_node_bTonodes") @ignore
+model prisma_tests_nodes {
+  id                        Int                   @id @default(autoincrement())
+  nodes_nodes_node_aTonodes prisma_tests__nodes[] @relation("nodes_node_aTonodes") @ignore
+  nodes_nodes_node_bTonodes prisma_tests__nodes[] @relation("nodes_node_bTonodes") @ignore
+
+  @@map("nodes")
 }
 */

--- a/libs/sql-schema-describer/src/lib.rs
+++ b/libs/sql-schema-describer/src/lib.rs
@@ -118,15 +118,29 @@ impl SqlSchema {
     }
 
     /// Try to find an enum by name.
-    pub fn find_enum(&self, name: &str) -> Option<EnumId> {
-        self.enums.iter().position(|e| e.name == name).map(|i| EnumId(i as u32))
+    pub fn find_enum(&self, name: &str, namespace: Option<&str>) -> Option<EnumId> {
+        let ns_id = namespace.and_then(|ns| self.get_namespace(ns));
+
+        self.enums
+            .iter()
+            .position(|e| e.name == name && ns_id.map(|id| id == e.namespace_id).unwrap_or(true))
+            .map(|i| EnumId(i as u32))
+    }
+
+    fn get_namespace(&self, name: &str) -> Option<NamespaceId> {
+        self.namespaces
+            .iter()
+            .position(|ns| ns == name)
+            .map(|i| NamespaceId(i as u32))
     }
 
     /// Try to find a table by name.
-    pub fn find_table(&self, name: &str) -> Option<TableId> {
+    pub fn find_table(&self, name: &str, namespace: Option<&str>) -> Option<TableId> {
+        let ns_id = namespace.and_then(|ns| self.get_namespace(ns));
+
         self.tables
             .iter()
-            .position(|t| t.name == name)
+            .position(|t| t.name == name && ns_id.map(|id| id == t.namespace_id).unwrap_or(true))
             .map(|i| TableId(i as u32))
     }
 

--- a/libs/sql-schema-describer/tests/describers/postgres_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/postgres_describer_tests.rs
@@ -1183,7 +1183,7 @@ fn postgres_enums_must_work(api: TestApi) {
         api.schema_name()
     ));
     let schema = api.describe();
-    let got_enum = schema.walk(schema.find_enum("mood").expect("get enum"));
+    let got_enum = schema.walk(schema.find_enum("mood", None).expect("get enum"));
     let values = &["sad", "ok", "happy"];
 
     assert_eq!(got_enum.name(), "mood");

--- a/migration-engine/migration-engine-tests/src/assertions.rs
+++ b/migration-engine/migration-engine-tests/src/assertions.rs
@@ -207,7 +207,7 @@ impl SchemaAssertion {
     where
         F: for<'a> FnOnce(EnumAssertion<'a>) -> EnumAssertion<'a>,
     {
-        let r#enum = match self.schema.find_enum(enum_name) {
+        let r#enum = match self.schema.find_enum(enum_name, None) {
             Some(enm) => self.schema.walk(enm),
             None => {
                 self.print_context();
@@ -681,6 +681,7 @@ impl<'a> ColumnAssertion<'a> {
         self
     }
 
+    #[track_caller]
     pub fn assert_type_is_enum(self) -> Self {
         let found = &self.column.column_type_family();
 


### PR DESCRIPTION
Rules:

- First intro: all duplicates are prefixed with the schema and an underscore.
- Re-intro: The name of the existing item is kept. User renames are kept.
- Re-intro: If a new item clashes with an existing model or enum, only the new items are prefixed with namespace so the user code does not break

Closes: https://github.com/prisma/prisma/issues/16454