### PR TITLE
psl: add directUrl to datasource blocks

### DIFF
--- a/psl/psl-core/src/configuration/datasource.rs
+++ b/psl/psl-core/src/configuration/datasource.rs
@@ -14,6 +14,8 @@ pub struct Datasource {
     pub active_provider: &'static str,
     pub url: StringFromEnvVar,
     pub url_span: Span,
+    pub direct_url: Option<StringFromEnvVar>,
+    pub direct_url_span: Option<Span>,
     pub documentation: Option<String>,
     /// the connector of the active provider
     pub active_connector: &'static dyn Connector,

--- a/psl/psl-core/src/validate/datasource_loader.rs
+++ b/psl/psl-core/src/validate/datasource_loader.rs
@@ -13,6 +13,7 @@ const PREVIEW_FEATURES_KEY: &str = "previewFeatures";
 const SCHEMAS_KEY: &str = "schemas";
 const SHADOW_DATABASE_URL_KEY: &str = "shadowDatabaseUrl";
 const URL_KEY: &str = "url";
+const DIRECT_URL_KEY: &str = "directUrl";
 
 /// Loads all datasources from the provided schema AST.
 /// - `ignore_datasource_urls`: datasource URLs are not parsed. They are replaced with dummy values.
@@ -108,6 +109,9 @@ fn lift_datasource(
     let url = StringFromEnvVar::coerce(url_arg, diagnostics)?;
     let shadow_database_url_arg = args.remove(SHADOW_DATABASE_URL_KEY);
 
+    let direct_url_arg = args.remove(DIRECT_URL_KEY).map(|(_, url)| url);
+    let direct_url = direct_url_arg.and_then(|url_arg| StringFromEnvVar::coerce(url_arg, diagnostics));
+
     let shadow_database_url: Option<(StringFromEnvVar, Span)> =
         if let Some((_, shadow_database_url_arg)) = shadow_database_url_arg.as_ref() {
             match StringFromEnvVar::coerce(shadow_database_url_arg, diagnostics) {
@@ -178,6 +182,8 @@ fn lift_datasource(
         active_provider: active_connector.provider_name(),
         url,
         url_span: url_arg.span(),
+        direct_url,
+        direct_url_span: direct_url_arg.map(|arg| arg.span()),
         documentation,
         active_connector,
         shadow_database_url,

--- a/psl/psl/tests/config/datasources.rs
+++ b/psl/psl/tests/config/datasources.rs
@@ -273,3 +273,30 @@ fn render_schema_json(schema: &str) -> String {
     let config = parse_configuration(schema);
     psl::get_config::render_sources_to_json(&config.datasources)
 }
+
+#[test]
+fn parse_direct_url_should_work() {
+    let schema = indoc! {r#"
+        generator js {
+          provider        = "prisma-client-js"
+        }
+
+        datasource ds {
+          provider   = "postgres"
+          url        = env("DATABASE_URL")
+          directUrl = env("DIRECT_DATABASE_URL")
+        }
+    "#};
+
+    // assert_valid(schema);
+    let config = parse_configuration(schema);
+
+    let result = config
+        .datasources
+        .first()
+        .and_then(|ds| ds.direct_url.clone())
+        .and_then(|url| url.from_env_var)
+        .unwrap();
+
+    assert_eq!("DIRECT_DATABASE_URL", result);
+}


### PR DESCRIPTION
This is part one, adding it to the AST.

Follow-up PRs will use this property in the migration and introspection engines.