### PR TITLE
feat(psl): Recognizing the view keyword

### DIFF
--- a/libs/dml/src/lift.rs
+++ b/libs/dml/src/lift.rs
@@ -323,6 +323,7 @@ impl<'a> LiftAstToDml<'a> {
         model.database_name = walker.mapped_name().map(String::from);
         model.is_ignored = walker.is_ignored();
         model.schema = walker.schema().map(|(s, _)| s.to_owned());
+        model.is_view = walker.ast_model().is_view();
 
         model.primary_key = walker.primary_key().map(|pk| PrimaryKeyDefinition {
             name: pk.name().map(String::from),

--- a/libs/dml/src/model.rs
+++ b/libs/dml/src/model.rs
@@ -29,6 +29,8 @@ pub struct Model {
     pub is_ignored: bool,
     /// The contents of the `@@schema("...")` attribute.
     pub schema: Option<String>,
+    /// If the model is defined as a view in the database.
+    pub is_view: bool,
 }
 
 #[derive(Debug, PartialEq, Clone, Copy)]
@@ -350,6 +352,7 @@ impl Model {
             is_generated: false,
             is_commented_out: false,
             is_ignored: false,
+            is_view: false,
             schema: None,
         }
     }

--- a/psl/diagnostics/src/error.rs
+++ b/psl/diagnostics/src/error.rs
@@ -183,11 +183,13 @@ impl DatamodelError {
         Self::new(msg, span)
     }
 
-    pub fn new_duplicate_field_error(model_name: &str, field_name: &str, span: Span) -> DatamodelError {
-        let msg = format!(
-            "Field \"{}\" is already defined on {} \"{}\".",
-            field_name, "model", model_name
-        );
+    pub fn new_duplicate_field_error(
+        model_name: &str,
+        field_name: &str,
+        container: &'static str,
+        span: Span,
+    ) -> DatamodelError {
+        let msg = format!("Field \"{field_name}\" is already defined on {container} \"{model_name}\".",);
         Self::new(msg, span)
     }
 

--- a/psl/parser-database/src/attributes/map.rs
+++ b/psl/parser-database/src/attributes/map.rs
@@ -38,6 +38,7 @@ pub(super) fn scalar_field(
         ctx.push_error(DatamodelError::new_duplicate_field_error(
             ast_model.name(),
             ast_field.name(),
+            if ast_model.is_view() { "view" } else { "model" },
             ast_field.span(),
         ));
     }
@@ -58,6 +59,7 @@ pub(super) fn scalar_field(
             _ => ctx.push_error(DatamodelError::new_duplicate_field_error(
                 ast_model.name(),
                 ast_field.name(),
+                if ast_model.is_view() { "view" } else { "model" },
                 ast_field.span(),
             )),
         }

--- a/psl/parser-database/src/names/reserved_model_names.rs
+++ b/psl/parser-database/src/names/reserved_model_names.rs
@@ -8,14 +8,14 @@ pub fn is_reserved_type_name(name: &str) -> bool {
     RESERVED_NAMES.contains(&name)
 }
 
-pub(crate) fn validate_model_name(ast_model: &ast::Model, diagnostics: &mut Diagnostics) {
+pub(crate) fn validate_model_name(ast_model: &ast::Model, block_type: &'static str, diagnostics: &mut Diagnostics) {
     if !is_reserved_type_name(ast_model.name()) {
         return;
     }
 
     diagnostics.push_error(DatamodelError::new_model_validation_error(
         &format!(
-            "The model name `{}` is invalid. It is a reserved name. Please change it. Read more at https://pris.ly/d/naming-models",
+            "The {block_type} name `{}` is invalid. It is a reserved name. Please change it. Read more at https://pris.ly/d/naming-models",
             ast_model.name()
         ),
         ast_model.name(),

--- a/psl/parser-database/src/walkers/model.rs
+++ b/psl/parser-database/src/walkers/model.rs
@@ -63,6 +63,7 @@ impl<'db> ModelWalker<'db> {
     }
 
     /// The parsed attributes.
+    #[track_caller]
     pub(crate) fn attributes(self) -> &'db ModelAttributes {
         &self.db.types.model_attributes[&self.id]
     }

--- a/psl/psl-core/src/common/preview_features.rs
+++ b/psl/psl-core/src/common/preview_features.rs
@@ -1,4 +1,3 @@
-use enumflags2::BitFlags;
 use serde::{Serialize, Serializer};
 use std::fmt;
 
@@ -73,7 +72,8 @@ features!(
     PostgresqlExtensions,
     ClientExtensions,
     Deno,
-    ExtendedWhereUnique
+    ExtendedWhereUnique,
+    Views,
 );
 
 /// Generator preview features
@@ -119,7 +119,9 @@ pub const ALL_PREVIEW_FEATURES: FeatureMap = FeatureMap {
         | DataProxy
         | InteractiveTransactions
     }),
-    hidden: BitFlags::EMPTY,
+    hidden: enumflags2::make_bitflags!(PreviewFeature::{
+        Views
+    }),
 };
 
 #[derive(Debug)]

--- a/psl/psl-core/src/validate/validation_pipeline/validations.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations.rs
@@ -64,6 +64,10 @@ pub(super) fn validate(ctx: &mut Context<'_>) {
 
         autoincrement::validate_auto_increment(model, ctx);
 
+        if model.ast_model().is_view() {
+            models::view_definition_without_preview_flag(model, ctx);
+        }
+
         if let Some(pk) = model.primary_key() {
             for field_attribute in pk.scalar_field_attributes() {
                 let span = pk.ast_attribute().span;

--- a/psl/psl-core/src/validate/validation_pipeline/validations/models.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/models.rs
@@ -411,3 +411,18 @@ pub(super) fn multischema_feature_flag_needed(model: ModelWalker<'_>, ctx: &mut 
         ));
     }
 }
+
+pub(crate) fn view_definition_without_preview_flag(model: ModelWalker<'_>, ctx: &mut Context<'_>) {
+    if ctx.preview_features.contains(crate::PreviewFeature::Views) {
+        return;
+    }
+
+    if !model.ast_model().is_view() {
+        return;
+    }
+
+    ctx.push_error(DatamodelError::new_validation_error(
+        "View definitions are only available with the `views` preview feature.",
+        model.ast_model().span(),
+    ));
+}

--- a/psl/psl/tests/parsing/nice_errors.rs
+++ b/psl/psl/tests/parsing/nice_errors.rs
@@ -9,7 +9,7 @@ fn nice_error_for_missing_model_keyword() {
     "#};
 
     let expectation = expect![[r#"
-        [1;91merror[0m: [1mError validating: This block is invalid. It does not start with any known Prisma schema keyword. Valid keywords include 'model', 'enum', 'datasource' and 'generator'.[0m
+        [1;91merror[0m: [1mError validating: This block is invalid. It does not start with any known Prisma schema keyword. Valid keywords include 'model', 'enum', 'type', 'datasource' and 'generator'.[0m
           [1;94m-->[0m  [4mschema.prisma:1[0m
         [1;94m   | [0m
         [1;94m   | [0m
@@ -35,7 +35,7 @@ fn nice_error_for_missing_model_keyword_2() {
     "#};
 
     let expectation = expect![[r#"
-        [1;91merror[0m: [1mError validating: This block is invalid. It does not start with any known Prisma schema keyword. Valid keywords include 'model', 'enum', 'datasource' and 'generator'.[0m
+        [1;91merror[0m: [1mError validating: This block is invalid. It does not start with any known Prisma schema keyword. Valid keywords include 'model', 'enum', 'type', 'datasource' and 'generator'.[0m
           [1;94m-->[0m  [4mschema.prisma:5[0m
         [1;94m   | [0m
         [1;94m 4 | [0m

--- a/psl/psl/tests/validation/views/basic_view.prisma
+++ b/psl/psl/tests/validation/views/basic_view.prisma
@@ -1,0 +1,14 @@
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator js {
+  provider = "prisma-client-js"
+  previewFeatures = ["views"]
+}
+
+view Mountain {
+  id Int @unique
+  val String
+}

--- a/psl/psl/tests/validation/views/duplicate_field.prisma
+++ b/psl/psl/tests/validation/views/duplicate_field.prisma
@@ -1,0 +1,21 @@
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator js {
+  provider = "prisma-client-js"
+  previewFeatures = ["views"]
+}
+
+view Mountain {
+  id Int @unique
+  id Int
+}
+
+// [1;91merror[0m: [1mField "id" is already defined on view "Mountain".[0m
+//   [1;94m-->[0m  [4mschema.prisma:13[0m
+// [1;94m   | [0m
+// [1;94m12 | [0m  id Int @unique
+// [1;94m13 | [0m  [1;91mid[0m Int
+// [1;94m   | [0m

--- a/psl/psl/tests/validation/views/field_name_starts_with_number.prisma
+++ b/psl/psl/tests/validation/views/field_name_starts_with_number.prisma
@@ -1,0 +1,15 @@
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+view foo {
+  1id Int @unique
+}
+
+// [1;91merror[0m: [1mError validating: The name of a field must not start with a number.[0m
+//   [1;94m-->[0m  [4mschema.prisma:7[0m
+// [1;94m   | [0m
+// [1;94m 6 | [0mview foo {
+// [1;94m 7 | [0m  [1;91m1id[0m Int @unique
+// [1;94m   | [0m

--- a/psl/psl/tests/validation/views/name_starts_with_number.prisma
+++ b/psl/psl/tests/validation/views/name_starts_with_number.prisma
@@ -1,0 +1,15 @@
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+view 1foo {
+  id Int @unique
+}
+
+// [1;91merror[0m: [1mError validating: The name of a view must not start with a number.[0m
+//   [1;94m-->[0m  [4mschema.prisma:6[0m
+// [1;94m   | [0m
+// [1;94m 5 | [0m
+// [1;94m 6 | [0mview [1;91m1foo[0m {
+// [1;94m   | [0m

--- a/psl/psl/tests/validation/views/no_preview_feature.prisma
+++ b/psl/psl/tests/validation/views/no_preview_feature.prisma
@@ -1,0 +1,19 @@
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+view Mountain {
+  id  Int    @unique
+  val String
+}
+
+// [1;91merror[0m: [1mError validating: View definitions are only available with the `views` preview feature.[0m
+//   [1;94m-->[0m  [4mschema.prisma:6[0m
+// [1;94m   | [0m
+// [1;94m 5 | [0m
+// [1;94m 6 | [0m[1;91mview Mountain {[0m
+// [1;94m 7 | [0m  id  Int    @unique
+// [1;94m 8 | [0m  val String
+// [1;94m 9 | [0m}
+// [1;94m   | [0m

--- a/psl/psl/tests/validation/views/reserved_name.prisma
+++ b/psl/psl/tests/validation/views/reserved_name.prisma
@@ -1,0 +1,16 @@
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+view Cat {
+  id Int @unique
+  id Int
+}
+
+// [1;91merror[0m: [1mField "id" is already defined on view "Cat".[0m
+//   [1;94m-->[0m  [4mschema.prisma:8[0m
+// [1;94m   | [0m
+// [1;94m 7 | [0m  id Int @unique
+// [1;94m 8 | [0m  [1;91mid[0m Int
+// [1;94m   | [0m

--- a/psl/schema-ast/src/ast/model.rs
+++ b/psl/schema-ast/src/ast/model.rs
@@ -66,6 +66,14 @@ pub struct Model {
     /// }
     /// ```
     pub(crate) documentation: Option<Comment>,
+    /// Is the model defined as a view in the database.
+    ///
+    /// ```ignore
+    /// view Foo {
+    ///   val Int @unique
+    /// }
+    /// ```
+    pub(crate) is_view: bool,
     /// The location of this model in the text representation.
     pub(crate) span: Span,
 }
@@ -76,6 +84,10 @@ impl Model {
             .iter()
             .enumerate()
             .map(|(idx, field)| (FieldId(idx as u32), field))
+    }
+
+    pub fn is_view(&self) -> bool {
+        self.is_view
     }
 }
 

--- a/psl/schema-ast/src/parser.rs
+++ b/psl/schema-ast/src/parser.rs
@@ -10,6 +10,7 @@ mod parse_model;
 mod parse_schema;
 mod parse_source_and_generator;
 mod parse_types;
+mod parse_view;
 
 pub use parse_schema::parse_schema;
 

--- a/psl/schema-ast/src/parser/datamodel.pest
+++ b/psl/schema-ast/src/parser/datamodel.pest
@@ -27,7 +27,7 @@ schema = {
 
 // At the syntax level, models and composite types are the same.
 model_declaration = { 
-    (MODEL_KEYWORD | TYPE_KEYWORD)
+    (MODEL_KEYWORD | TYPE_KEYWORD | VIEW_KEYWORD)
     ~ identifier
     ~ BLOCK_OPEN
     ~ (field_declaration | (block_attribute ~ NEWLINE) | comment_block | empty_lines | BLOCK_LEVEL_CATCH_ALL)*
@@ -132,6 +132,7 @@ BLOCK_CLOSE = { "}" }
 ENUM_KEYWORD = { "enum" }
 MODEL_KEYWORD = { "model" }
 TYPE_KEYWORD = { "type" }
+VIEW_KEYWORD = { "view" }
 GENERATOR_KEYWORD = { "generator" }
 DATASOURCE_KEYWORD = { "datasource" }
 LEGACY_COLON = { ":" }

--- a/psl/schema-ast/src/parser/parse_schema.rs
+++ b/psl/schema-ast/src/parser/parse_schema.rs
@@ -1,6 +1,6 @@
 use super::{
     parse_composite_type::parse_composite_type, parse_enum::parse_enum, parse_model::parse_model,
-    parse_source_and_generator::parse_config_block, PrismaDatamodelParser, Rule,
+    parse_source_and_generator::parse_config_block, parse_view::parse_view, PrismaDatamodelParser, Rule,
 };
 use crate::ast::*;
 use diagnostics::{DatamodelError, Diagnostics};
@@ -20,7 +20,7 @@ pub fn parse_schema(datamodel_string: &str, diagnostics: &mut Diagnostics) -> Sc
             while let Some(current) = pairs.next() {
                 match current.as_rule() {
                     Rule::model_declaration => {
-                        let keyword = current.clone().into_inner().find(|pair| matches!(pair.as_rule(), Rule::TYPE_KEYWORD | Rule::MODEL_KEYWORD) ).expect("Expected model or type keyword");
+                        let keyword = current.clone().into_inner().find(|pair| matches!(pair.as_rule(), Rule::TYPE_KEYWORD | Rule::MODEL_KEYWORD | Rule::VIEW_KEYWORD) ).expect("Expected model, type or view keyword");
 
                         match keyword.as_rule() {
                             Rule::TYPE_KEYWORD => {
@@ -28,6 +28,9 @@ pub fn parse_schema(datamodel_string: &str, diagnostics: &mut Diagnostics) -> Sc
                             }
                             Rule::MODEL_KEYWORD => {
                                 top_level_definitions.push(Top::Model(parse_model(current, pending_block_comment.take(), diagnostics)))
+                            }
+                            Rule::VIEW_KEYWORD => {
+                                top_level_definitions.push(Top::Model(parse_view(current, pending_block_comment.take(), diagnostics)))
                             }
                             _ => unreachable!(),
                         }
@@ -61,8 +64,9 @@ pub fn parse_schema(datamodel_string: &str, diagnostics: &mut Diagnostics) -> Sc
                         "This line is invalid. It does not start with any known Prisma schema keyword.",
                         current.as_span().into(),
                     )),
+                    // TODO: Add view when we want it to be more visible as a feature.
                     Rule::arbitrary_block => diagnostics.push_error(DatamodelError::new_validation_error(
-                        "This block is invalid. It does not start with any known Prisma schema keyword. Valid keywords include \'model\', \'enum\', \'datasource\' and \'generator\'.",
+                        "This block is invalid. It does not start with any known Prisma schema keyword. Valid keywords include \'model\', \'enum\', \'type\', \'datasource\' and \'generator\'.",
                         current.as_span().into(),
                     )),
                     Rule::empty_lines => (),


### PR DESCRIPTION
We'll treat them as models now for the MVP. This allows us to skip them in migrations, and include them in the re-introspection. The Query Engine can decide what to do with them, but this way we get the minimum definition of views working quickly.

After the MVP, when we actually start realizing how the views should be used, we might want to differ from using the `ast::Model`.

Closes: https://github.com/prisma/prisma/issues/17115