### PR TITLE
Ignore views in the migrations

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
@@ -132,6 +132,10 @@ fn push_model_indexes(model: ModelWalker<'_>, table_id: sql::TableId, ctx: &mut 
 
 fn push_inline_relations(ctx: &mut Context<'_>) {
     for relation in ctx.datamodel.db.walk_relations().filter_map(|r| r.refine().as_inline()) {
+        if relation.referencing_model().ast_model().is_view() || relation.referenced_model().ast_model().is_view() {
+            continue;
+        }
+
         let relation_field = relation
             .forward_relation_field()
             .expect("Expecting a complete relation in sql_schmea_calculator");

--- a/migration-engine/migration-engine-tests/tests/migrations/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/mod.rs
@@ -34,3 +34,4 @@ mod timeouts;
 mod types;
 mod unique;
 mod unsupported_types;
+mod views;

--- a/migration-engine/migration-engine-tests/tests/migrations/views.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/views.rs
@@ -1,0 +1,20 @@
+use indoc::indoc;
+use migration_engine_tests::test_api::*;
+
+#[test_connector(preview_features("views"))]
+fn nothing_gets_written_in_migrations(api: TestApi) {
+    let dm = indoc! {r#"
+        generator js {
+          provider = "prisma-client-javascript"
+          previewFeatures = ["views"]
+        }
+
+        view Mountain {
+          id   Int    @unique
+          name String
+        }
+    "#};
+
+    let expected_sql = expect!["-- This is an empty migration."];
+    api.expect_sql_for_schema(dm, &expected_sql);
+}

--- a/migration-engine/migration-engine-tests/tests/schema_push/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/schema_push/mod.rs
@@ -1,3 +1,5 @@
+mod views;
+
 use indoc::indoc;
 use migration_engine_tests::test_api::*;
 use sql_schema_describer::ColumnTypeFamily;

--- a/migration-engine/migration-engine-tests/tests/schema_push/views.rs
+++ b/migration-engine/migration-engine-tests/tests/schema_push/views.rs
@@ -1,0 +1,60 @@
+use indoc::indoc;
+use migration_engine_tests::test_api::*;
+
+#[test_connector(preview_features("views"))]
+fn views_are_ignored(api: TestApi) {
+    let dm = indoc! {r#"
+        view Dog {
+          val Int @unique
+        }
+    "#};
+
+    api.schema_push_w_datasource(dm).send().assert_green().assert_no_steps();
+    api.assert_schema().assert_has_no_table("Dog").assert_has_no_view("Dog");
+}
+
+#[test_connector(preview_features("views"))]
+fn relations_from_view_are_ignored(api: TestApi) {
+    let dm = indoc! {r#"
+        model Leash {
+          id   Int   @id
+          dogs Dog[]        
+        }
+
+        view Dog {
+          val     Int   @unique
+          leashId Int
+          leash   Leash @relation(fields: [leashId], references: [id])
+        }
+    "#};
+
+    api.schema_push_w_datasource(dm)
+        .send()
+        .assert_green()
+        .assert_has_executed_steps();
+
+    api.assert_schema().assert_table("Leash", |table| table.assert_no_fks());
+}
+
+#[test_connector(preview_features("views"))]
+fn relations_to_view_are_ignored(api: TestApi) {
+    let dm = indoc! {r#"
+        model Leash {
+          id    Int @id
+          dogId Int
+          dog   Dog @relation(fields: [dogId], references: [val])
+        }
+
+        view Dog {
+          val     Int     @unique
+          leashes Leash[]
+        }
+    "#};
+
+    api.schema_push_w_datasource(dm)
+        .send()
+        .assert_green()
+        .assert_has_executed_steps();
+
+    api.assert_schema().assert_table("Leash", |table| table.assert_no_fks());
+}

--- a/psl/builtin-connectors/src/mongodb/validations.rs
+++ b/psl/builtin-connectors/src/mongodb/validations.rs
@@ -16,8 +16,15 @@ pub(super) fn objectid_type_required_with_auto_attribute(field: ScalarFieldWalke
         return;
     }
 
+    let container = if field.model().ast_model().is_view() {
+        "view"
+    } else {
+        "model"
+    };
+
     let err = DatamodelError::new_field_validation_error(
         "MongoDB `@default(auto())` fields must have `ObjectId` native type.",
+        container,
         field.model().name(),
         field.name(),
         field.ast_field().span(),
@@ -36,8 +43,15 @@ pub(super) fn auto_attribute_must_be_an_id(field: ScalarFieldWalker<'_>, errors:
         return;
     }
 
+    let container = if field.model().ast_model().is_view() {
+        "view"
+    } else {
+        "model"
+    };
+
     let err = DatamodelError::new_field_validation_error(
         "MongoDB `@default(auto())` fields must have the `@id` attribute.",
+        container,
         field.model().name(),
         field.name(),
         field.ast_field().span(),
@@ -52,8 +66,15 @@ pub(super) fn dbgenerated_attribute_is_not_allowed(field: ScalarFieldWalker<'_>,
         return;
     }
 
+    let container = if field.model().ast_model().is_view() {
+        "view"
+    } else {
+        "model"
+    };
+
     let err = DatamodelError::new_field_validation_error(
         "The `dbgenerated()` function is not allowed with MongoDB. Please use `auto()` instead.",
+        container,
         field.model().name(),
         field.name(),
         field.ast_field().span(),
@@ -76,12 +97,19 @@ pub(super) fn id_field_must_have_a_correct_mapped_name(pk: PrimaryKeyWalker<'_>,
         return;
     }
 
+    let container = if field.model().ast_model().is_view() {
+        "view"
+    } else {
+        "model"
+    };
+
     let error = match field.mapped_name() {
         Some(name) => {
             let msg = format!("MongoDB model IDs must have a @map(\"_id\") annotation, found @map(\"{name}\").",);
 
             DatamodelError::new_field_validation_error(
                 &msg,
+                container,
                 field.model().name(),
                 field.name(),
                 field.ast_field().span(),
@@ -89,6 +117,7 @@ pub(super) fn id_field_must_have_a_correct_mapped_name(pk: PrimaryKeyWalker<'_>,
         }
         None => DatamodelError::new_field_validation_error(
             "MongoDB model IDs must have a @map(\"_id\") annotations.",
+            container,
             field.model().name(),
             field.name(),
             field.ast_field().span(),

--- a/psl/builtin-connectors/src/postgres_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/postgres_datamodel_connector.rs
@@ -478,6 +478,7 @@ impl Connector for PostgresDatamodelConnector {
 
                 let index_field = db
                     .walk_models()
+                    .chain(db.walk_views())
                     .find(|model| model.model_id() == model_id)
                     .and_then(|model| {
                         model.indexes().find(|index| {

--- a/psl/diagnostics/src/error.rs
+++ b/psl/diagnostics/src/error.rs
@@ -137,7 +137,19 @@ impl DatamodelError {
         existing_model_name: &str,
         span: Span,
     ) -> DatamodelError {
-        let msg = format!("The model with database name \"{}\" could not be defined because another model with this name exists: \"{}\"",
+        let msg = format!("The model with database name \"{}\" could not be defined because another model or view with this name exists: \"{}\"",
+          model_database_name,
+          existing_model_name
+        );
+        Self::new(msg, span)
+    }
+
+    pub fn new_duplicate_view_database_name_error(
+        model_database_name: &str,
+        existing_model_name: &str,
+        span: Span,
+    ) -> DatamodelError {
+        let msg = format!("The view with database name \"{}\" could not be defined because another model or view with this name exists: \"{}\"",
           model_database_name,
           existing_model_name
         );
@@ -193,13 +205,26 @@ impl DatamodelError {
         Self::new(msg, span)
     }
 
-    pub fn new_scalar_list_fields_are_not_supported(model_name: &str, field_name: &str, span: Span) -> DatamodelError {
-        let msg = format!("Field \"{}\" in model \"{}\" can't be a list. The current connector does not support lists of primitive types.", field_name, model_name);
+    pub fn new_scalar_list_fields_are_not_supported(
+        container: &str,
+        container_name: &str,
+        field_name: &str,
+        span: Span,
+    ) -> DatamodelError {
+        let msg = format!("Field \"{field_name}\" in {container} \"{container_name}\" can't be a list. The current connector does not support lists of primitive types.");
         Self::new(msg, span)
     }
 
-    pub fn new_model_validation_error(message: &str, model_name: &str, span: Span) -> DatamodelError {
-        Self::new(format!("Error validating model \"{model_name}\": {message}"), span)
+    pub fn new_model_validation_error(
+        message: &str,
+        block_type: &'static str,
+        model_name: &str,
+        span: Span,
+    ) -> DatamodelError {
+        Self::new(
+            format!("Error validating {block_type} \"{model_name}\": {message}"),
+            span,
+        )
     }
 
     pub fn new_composite_type_validation_error(message: &str, composite_type_name: &str, span: Span) -> DatamodelError {
@@ -227,11 +252,14 @@ impl DatamodelError {
         Self::new(msg, span)
     }
 
-    pub fn new_field_validation_error(message: &str, model: &str, field: &str, span: Span) -> DatamodelError {
-        let msg = format!(
-            "Error validating field `{}` in {} `{}`: {}",
-            field, "model", model, message
-        );
+    pub fn new_field_validation_error(
+        message: &str,
+        container_type: &str,
+        container_name: &str,
+        field: &str,
+        span: Span,
+    ) -> DatamodelError {
+        let msg = format!("Error validating field `{field}` in {container_type} `{container_name}`: {message}",);
         Self::new(msg, span)
     }
 

--- a/psl/parser-database/src/attributes.rs
+++ b/psl/parser-database/src/attributes.rs
@@ -634,7 +634,7 @@ fn common_index_validations(
                         fields.join(", "),
                     );
                     let model_name = ctx.ast[model_id].name();
-                    DatamodelError::new_model_validation_error(message, model_name, current_attribute.span)
+                    DatamodelError::new_model_validation_error(message, "model", model_name, current_attribute.span)
                 });
             }
 
@@ -665,6 +665,7 @@ fn common_index_validations(
                         the_fields = relation_fields.iter().map(|(f, _)| f.name()).collect::<Vec<_>>().join(", "),
                         suggestion = suggestion
                     ),
+                    "model",
                     ctx.ast[model_id].name(),
                     current_attribute.span,
                 ));
@@ -867,6 +868,7 @@ fn resolve_field_array_without_args<'db>(
                     "The unique index definition refers to the field {} multiple times.",
                     ast_model[field_id].name()
                 ),
+                "model",
                 ast_model.name(),
                 attribute_span,
             ));
@@ -1011,6 +1013,7 @@ fn resolve_field_array_with_args<'db>(
 
             ctx.push_error(DatamodelError::new_model_validation_error(
                 &format!("The unique index definition refers to the field {path_str} multiple times.",),
+                "model",
                 ast_model.name(),
                 attribute_span,
             ));
@@ -1083,6 +1086,7 @@ fn validate_client_name(span: Span, object_name: &str, name: StringId, attribute
             "The `name` property within the `{}` attribute only allows for the following characters: `_a-zA-Z0-9`.",
             attribute
         ),
+        "model",
         object_name,
         span,
     ))

--- a/psl/parser-database/src/attributes/id.rs
+++ b/psl/parser-database/src/attributes/id.rs
@@ -42,7 +42,8 @@ pub(super) fn model(model_data: &mut ModelAttributes, model_id: ast::ModelId, ct
                     .join(", ");
 
                 let msg = format!("The multi field id declaration refers to the unknown fields {fields_str}.");
-                let error = DatamodelError::new_model_validation_error(&msg, ctx.ast[model_id].name(), fields.span());
+                let error =
+                    DatamodelError::new_model_validation_error(&msg, "model", ctx.ast[model_id].name(), fields.span());
 
                 ctx.push_error(error);
             }
@@ -58,6 +59,7 @@ pub(super) fn model(model_data: &mut ModelAttributes, model_id: ast::ModelId, ct
 
                 ctx.push_error(DatamodelError::new_model_validation_error(
                     &msg,
+                    "model",
                     ctx.ast[model_id].name(),
                     attr.span,
                 ));
@@ -104,6 +106,7 @@ pub(super) fn model(model_data: &mut ModelAttributes, model_id: ast::ModelId, ct
                 "The id definition refers to the optional fields {}. ID definitions must reference only required fields.",
                 fields_that_are_not_required.join(", ")
             ),
+            "model",
             ast_model.name(),
             attr.span,
         ))
@@ -112,6 +115,7 @@ pub(super) fn model(model_data: &mut ModelAttributes, model_id: ast::ModelId, ct
     if model_data.primary_key.is_some() {
         ctx.push_error(DatamodelError::new_model_validation_error(
             "Each model must have at most one id criteria. You can't have `@id` and `@@id` at the same time.",
+            "model",
             ast_model.name(),
             ast_model.span(),
         ))
@@ -149,6 +153,7 @@ pub(super) fn field<'db>(
     match model_attributes.primary_key {
         Some(_) => ctx.push_error(DatamodelError::new_model_validation_error(
             "At most one field must be marked as the id field with the `@id` attribute.",
+            "model",
             ast_model.name(),
             ast_model.span(),
         )),

--- a/psl/parser-database/src/names/reserved_model_names.rs
+++ b/psl/parser-database/src/names/reserved_model_names.rs
@@ -18,6 +18,7 @@ pub(crate) fn validate_model_name(ast_model: &ast::Model, block_type: &'static s
             "The {block_type} name `{}` is invalid. It is a reserved name. Please change it. Read more at https://pris.ly/d/naming-models",
             ast_model.name()
         ),
+        "model",
         ast_model.name(),
         ast_model.span(),
     ))

--- a/psl/parser-database/src/walkers.rs
+++ b/psl/parser-database/src/walkers.rs
@@ -69,6 +69,16 @@ impl crate::ParserDatabase {
             .iter_tops()
             .filter_map(|(top_id, _)| top_id.as_model_id())
             .map(move |model_id| self.walk(model_id))
+            .filter(|m| !m.ast_model().is_view())
+    }
+
+    /// Walk all the views in the schema.
+    pub fn walk_views(&self) -> impl Iterator<Item = ModelWalker<'_>> + '_ {
+        self.ast()
+            .iter_tops()
+            .filter_map(|(top_id, _)| top_id.as_model_id())
+            .map(move |model_id| self.walk(model_id))
+            .filter(|m| m.ast_model().is_view())
     }
 
     /// Walk all the composite types in the schema.

--- a/psl/psl-core/src/datamodel_connector/constraint_names.rs
+++ b/psl/psl-core/src/datamodel_connector/constraint_names.rs
@@ -125,6 +125,7 @@ impl ConstraintNames {
                 let ats = if double_at { "@@" } else { "@" };
                 return Some(DatamodelError::new_model_validation_error(
                     &format!("The constraint name '{}' specified in the `map` argument for the `{}{}` constraint is too long for your chosen provider. The maximum allowed length is {} bytes.", name, ats, attribute, connector.max_identifier_length()),
+                    "model",
                     object_name,
                     span,
                 ));

--- a/psl/psl-core/src/validate/validation_pipeline/validations/indexes.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/indexes.rs
@@ -402,8 +402,15 @@ pub(super) fn unique_client_name_does_not_clash_with_field(index: IndexWalker<'_
     if index.model().scalar_fields().any(|f| f.name() == idx_client_name) {
         let attr_name = index.attribute_name();
 
+        let container_type = if index.model().ast_model().is_view() {
+            "view"
+        } else {
+            "model"
+        };
+
         ctx.push_error(DatamodelError::new_model_validation_error(
             &format!("The field `{idx_client_name}` clashes with the `{attr_name}` name. Please resolve the conflict by providing a custom id name: `{attr_name}([...], name: \"custom_name\")`"),
+            container_type,
             index.model().name(),
             index.ast_attribute().span,
         ));

--- a/psl/psl-core/src/validate/validation_pipeline/validations/names.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/names.rs
@@ -27,7 +27,7 @@ impl<'db> Names<'db> {
         let mut unique_names: HashSet<(ModelId, &'db str)> = HashSet::new();
         let mut primary_key_names: HashMap<ModelId, &'db str> = HashMap::new();
 
-        for model in ctx.db.walk_models() {
+        for model in ctx.db.walk_models().chain(ctx.db.walk_views()) {
             let model_id = model.model_id();
 
             for field in model.relation_fields() {

--- a/psl/psl-core/src/validate/validation_pipeline/validations/relation_fields.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/relation_fields.rs
@@ -108,8 +108,11 @@ pub(super) fn ambiguity(field: RelationFieldWalker<'_>, names: &Names<'_>) -> Re
                 }
             };
 
+            let container_type = if model.ast_model().is_view() { "view" } else { "model" };
+
             Err(DatamodelError::new_model_validation_error(
                 &message,
+                container_type,
                 model.name(),
                 field.ast_field().span(),
             ))
@@ -284,6 +287,10 @@ pub(super) fn validate_missing_relation_indexes(relation_field: RelationFieldWal
     }
 }
 
+pub(super) fn connector_specific(field: RelationFieldWalker<'_>, ctx: &mut Context<'_>) {
+    ctx.connector.validate_relation_field(field, ctx.diagnostics)
+}
+
 /// An subgroup is left-wise included in a supergroup if the subgroup is contained in the supergroup, and all the entries of
 /// the left-most entries of the supergroup match the order of definitions of the subgroup.
 /// More formally: { x_1, x_2, ..., x_n } is left-wise included in { y_1, y_2, ..., y_m } if and only if
@@ -313,8 +320,4 @@ mod tests {
         let group = vec![1, 2, 3, 4];
         assert_eq!(is_leftwise_included_it(item.iter(), group.iter()), false);
     }
-}
-
-pub(super) fn connector_specific(field: RelationFieldWalker<'_>, ctx: &mut Context<'_>) {
-    ctx.connector.validate_relation_field(field, ctx.diagnostics)
 }

--- a/psl/psl-core/src/validate/validation_pipeline/validations/relations/one_to_many.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/relations/one_to_many.rs
@@ -9,15 +9,22 @@ use parser_database::{
 /// referential actions, the other side just as a list.
 pub(crate) fn both_sides_are_defined(relation: InlineRelationWalker<'_>, ctx: &mut Context<'_>) {
     let mut error_fn = |relation_field: RelationFieldWalker<'_>| {
+        let container = if relation_field.model().ast_model().is_view() {
+            "view"
+        } else {
+            "model"
+        };
+
         let message = format!(
-            "The relation field `{}` on Model `{}` is missing an opposite relation field on the model `{}`. Either run `prisma format` or add it manually.",
+            "The relation field `{}` on {container} `{}` is missing an opposite relation field on the model `{}`. Either run `prisma format` or add it manually.",
             &relation_field.name(),
             &relation_field.model().name(),
             &relation_field.related_model().name(),
-            );
+        );
 
         ctx.push_error(DatamodelError::new_field_validation_error(
             &message,
+            container,
             relation_field.model().name(),
             relation_field.name(),
             relation_field.ast_field().span(),

--- a/psl/psl-core/src/validate/validation_pipeline/validations/relations/one_to_one.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/relations/one_to_one.rs
@@ -10,8 +10,14 @@ pub(crate) fn both_sides_are_defined(relation: InlineRelationWalker<'_>, ctx: &m
 
     let field = relation.forward_relation_field().expect(STATE_ERROR);
 
+    let container = if field.model().ast_model().is_view() {
+        "view"
+    } else {
+        "model"
+    };
+
     let message = format!(
-        "The relation field `{}` on Model `{}` is missing an opposite relation field on the model `{}`. Either run `prisma format` or add it manually.",
+        "The relation field `{}` on {container} `{}` is missing an opposite relation field on the model `{}`. Either run `prisma format` or add it manually.",
         field.name(),
         field.model().name(),
         field.related_model().name(),
@@ -19,6 +25,7 @@ pub(crate) fn both_sides_are_defined(relation: InlineRelationWalker<'_>, ctx: &m
 
     ctx.push_error(DatamodelError::new_field_validation_error(
         &message,
+        container,
         field.model().name(),
         field.name(),
         field.ast_field().span(),

--- a/psl/psl-core/src/validate/validation_pipeline/validations/views.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/views.rs
@@ -1,0 +1,19 @@
+use diagnostics::DatamodelError;
+use parser_database::{ast::WithSpan, walkers::ModelWalker};
+
+use crate::validate::validation_pipeline::context::Context;
+
+pub(crate) fn view_definition_without_preview_flag(model: ModelWalker<'_>, ctx: &mut Context<'_>) {
+    if ctx.preview_features.contains(crate::PreviewFeature::Views) {
+        return;
+    }
+
+    if !model.ast_model().is_view() {
+        return;
+    }
+
+    ctx.push_error(DatamodelError::new_validation_error(
+        "View definitions are only available with the `views` preview feature.",
+        model.ast_model().span(),
+    ));
+}

--- a/psl/psl/tests/attributes/relations/relations_negative.rs
+++ b/psl/psl/tests/attributes/relations/relations_negative.rs
@@ -355,7 +355,7 @@ fn should_fail_on_conflicting_back_relation_field_name() {
     "#};
 
     let expect = expect![[r#"
-        [1;91merror[0m: [1mError validating field `more_posts` in model `User`: The relation field `more_posts` on Model `User` is missing an opposite relation field on the model `Post`. Either run `prisma format` or add it manually.[0m
+        [1;91merror[0m: [1mError validating field `more_posts` in model `User`: The relation field `more_posts` on model `User` is missing an opposite relation field on the model `Post`. Either run `prisma format` or add it manually.[0m
           [1;94m-->[0m  [4mschema.prisma:4[0m
         [1;94m   | [0m
         [1;94m 3 | [0m  posts Post[] @relation(name: "test")
@@ -449,21 +449,21 @@ fn should_fail_on_conflicting_generated_back_relation_fields() {
     "#};
 
     let expect = expect![[r#"
-        [1;91merror[0m: [1mError validating field `author` in model `Todo`: The relation field `author` on Model `Todo` is missing an opposite relation field on the model `Owner`. Either run `prisma format` or add it manually.[0m
+        [1;91merror[0m: [1mError validating field `author` in model `Todo`: The relation field `author` on model `Todo` is missing an opposite relation field on the model `Owner`. Either run `prisma format` or add it manually.[0m
           [1;94m-->[0m  [4mschema.prisma:3[0m
         [1;94m   | [0m
         [1;94m 2 | [0m  id Int @id
         [1;94m 3 | [0m  [1;91mauthor Owner @relation(name: "AuthorTodo")[0m
         [1;94m 4 | [0m  delegatedTo Owner? @relation(name: "DelegatedToTodo")
         [1;94m   | [0m
-        [1;91merror[0m: [1mError validating field `delegatedTo` in model `Todo`: The relation field `delegatedTo` on Model `Todo` is missing an opposite relation field on the model `Owner`. Either run `prisma format` or add it manually.[0m
+        [1;91merror[0m: [1mError validating field `delegatedTo` in model `Todo`: The relation field `delegatedTo` on model `Todo` is missing an opposite relation field on the model `Owner`. Either run `prisma format` or add it manually.[0m
           [1;94m-->[0m  [4mschema.prisma:4[0m
         [1;94m   | [0m
         [1;94m 3 | [0m  author Owner @relation(name: "AuthorTodo")
         [1;94m 4 | [0m  [1;91mdelegatedTo Owner? @relation(name: "DelegatedToTodo")[0m
         [1;94m 5 | [0m}
         [1;94m   | [0m
-        [1;91merror[0m: [1mError validating field `todos` in model `Owner`: The relation field `todos` on Model `Owner` is missing an opposite relation field on the model `Todo`. Either run `prisma format` or add it manually.[0m
+        [1;91merror[0m: [1mError validating field `todos` in model `Owner`: The relation field `todos` on model `Owner` is missing an opposite relation field on the model `Todo`. Either run `prisma format` or add it manually.[0m
           [1;94m-->[0m  [4mschema.prisma:9[0m
         [1;94m   | [0m
         [1;94m 8 | [0m  id Int @id
@@ -493,7 +493,7 @@ fn must_generate_forward_relation_fields_for_named_relation_fields() {
     "#};
 
     let expect = expect![[r#"
-        [1;91merror[0m: [1mError validating field `assignees` in model `Todo`: The relation field `assignees` on Model `Todo` is missing an opposite relation field on the model `User`. Either run `prisma format` or add it manually.[0m
+        [1;91merror[0m: [1mError validating field `assignees` in model `Todo`: The relation field `assignees` on model `Todo` is missing an opposite relation field on the model `User`. Either run `prisma format` or add it manually.[0m
           [1;94m-->[0m  [4mschema.prisma:3[0m
         [1;94m   | [0m
         [1;94m 2 | [0m  id Int @id
@@ -522,7 +522,7 @@ fn issue4850() {
     "#};
 
     let expect = expect![[r#"
-        [1;91merror[0m: [1mError validating field `postableEntities` in model `Post`: The relation field `postableEntities` on Model `Post` is missing an opposite relation field on the model `PostableEntity`. Either run `prisma format` or add it manually.[0m
+        [1;91merror[0m: [1mError validating field `postableEntities` in model `Post`: The relation field `postableEntities` on model `Post` is missing an opposite relation field on the model `PostableEntity`. Either run `prisma format` or add it manually.[0m
           [1;94m-->[0m  [4mschema.prisma:7[0m
         [1;94m   | [0m
         [1;94m 6 | [0m  id String @id
@@ -553,14 +553,14 @@ fn issue4822() {
     "#};
 
     let expect = expect![[r#"
-        [1;91merror[0m: [1mError validating field `custom_User` in model `Post`: The relation field `custom_User` on Model `Post` is missing an opposite relation field on the model `User`. Either run `prisma format` or add it manually.[0m
+        [1;91merror[0m: [1mError validating field `custom_User` in model `Post`: The relation field `custom_User` on model `Post` is missing an opposite relation field on the model `User`. Either run `prisma format` or add it manually.[0m
           [1;94m-->[0m  [4mschema.prisma:4[0m
         [1;94m   | [0m
         [1;94m 3 | [0m  user_id     Int    @unique
         [1;94m 4 | [0m  [1;91mcustom_User User   @relation("CustomName", fields: [user_id], references: [id])[0m
         [1;94m 5 | [0m}
         [1;94m   | [0m
-        [1;91merror[0m: [1mError validating field `custom_Post` in model `User`: The relation field `custom_Post` on Model `User` is missing an opposite relation field on the model `Post`. Either run `prisma format` or add it manually.[0m
+        [1;91merror[0m: [1mError validating field `custom_Post` in model `User`: The relation field `custom_Post` on model `User` is missing an opposite relation field on the model `Post`. Either run `prisma format` or add it manually.[0m
           [1;94m-->[0m  [4mschema.prisma:9[0m
         [1;94m   | [0m
         [1;94m 8 | [0m  id          Int    @id
@@ -627,7 +627,7 @@ fn issue5069() {
     "#};
 
     let expect = expect![[r#"
-        [1;91merror[0m: [1mError validating field `createdBy` in model `Code`: The relation field `createdBy` on Model `Code` is missing an opposite relation field on the model `User`. Either run `prisma format` or add it manually.[0m
+        [1;91merror[0m: [1mError validating field `createdBy` in model `Code`: The relation field `createdBy` on model `Code` is missing an opposite relation field on the model `User`. Either run `prisma format` or add it manually.[0m
           [1;94m-->[0m  [4mschema.prisma:4[0m
         [1;94m   | [0m
         [1;94m 3 | [0m  createdById String?
@@ -902,7 +902,7 @@ fn a_typoed_relation_should_fail_gracefully() {
     "#};
 
     let expect = expect![[r#"
-        [1;91merror[0m: [1mError validating field `self` in model `TestParent`: The relation field `self` on Model `TestParent` is missing an opposite relation field on the model `TestParent`. Either run `prisma format` or add it manually.[0m
+        [1;91merror[0m: [1mError validating field `self` in model `TestParent`: The relation field `self` on model `TestParent` is missing an opposite relation field on the model `TestParent`. Either run `prisma format` or add it manually.[0m
           [1;94m-->[0m  [4mschema.prisma:17[0m
         [1;94m   | [0m
         [1;94m16 | [0m  fk   Int

--- a/psl/psl/tests/attributes/relations/relations_new.rs
+++ b/psl/psl/tests/attributes/relations/relations_new.rs
@@ -783,7 +783,7 @@ fn must_error_nicely_when_a_many_to_many_is_not_possible() {
     }"#;
 
     let expect = expect![[r#"
-        [1;91merror[0m: [1mError validating field `posts` in model `Category`: The relation field `posts` on Model `Category` references `Post` which does not have an `@id` field. Models without `@id` cannot be part of a many to many relation. Use an explicit intermediate Model to represent this relationship.[0m
+        [1;91merror[0m: [1mError validating field `posts` in model `Category`: The relation field `posts` on model `Category` references `Post` which does not have an `@id` field. Models without `@id` cannot be part of a many to many relation. Use an explicit intermediate Model to represent this relationship.[0m
           [1;94m-->[0m  [4mschema.prisma:12[0m
         [1;94m   | [0m
         [1;94m11 | [0m      id    Int    @id @default(autoincrement())
@@ -811,7 +811,7 @@ fn must_error_when_many_to_many_is_not_possible_due_to_missing_id() {
     "#;
 
     let expect = expect![[r#"
-        [1;91merror[0m: [1mError validating field `posts` in model `Category`: The relation field `posts` on Model `Category` references `Post` which does not have an `@id` field. Models without `@id` cannot be part of a many to many relation. Use an explicit intermediate Model to represent this relationship.[0m
+        [1;91merror[0m: [1mError validating field `posts` in model `Category`: The relation field `posts` on model `Category` references `Post` which does not have an `@id` field. Models without `@id` cannot be part of a many to many relation. Use an explicit intermediate Model to represent this relationship.[0m
           [1;94m-->[0m  [4mschema.prisma:10[0m
         [1;94m   | [0m
         [1;94m 9 | [0m      id    Int    @id @default(autoincrement())

--- a/psl/psl/tests/base/duplicates.rs
+++ b/psl/psl/tests/base/duplicates.rs
@@ -39,7 +39,7 @@ fn fail_on_duplicate_models_with_map() {
     "#};
 
     let expectation = expect![[r#"
-        [1;91merror[0m: [1mThe model with database name "User" could not be defined because another model with this name exists: "User"[0m
+        [1;91merror[0m: [1mThe model with database name "User" could not be defined because another model or view with this name exists: "User"[0m
           [1;94m-->[0m  [4mschema.prisma:4[0m
         [1;94m   | [0m
         [1;94m 3 | [0m

--- a/psl/psl/tests/validation/attributes/map/duplicate_models_with_map_on_both_sides.prisma
+++ b/psl/psl/tests/validation/attributes/map/duplicate_models_with_map_on_both_sides.prisma
@@ -15,7 +15,7 @@ model Cat {
   @@map("pets")
 }
 
-// [1;91merror[0m: [1mThe model with database name "pets" could not be defined because another model with this name exists: "Dog"[0m
+// [1;91merror[0m: [1mThe model with database name "pets" could not be defined because another model or view with this name exists: "Dog"[0m
 //   [1;94m-->[0m  [4mschema.prisma:15[0m
 // [1;94m   | [0m
 // [1;94m14 | [0m

--- a/psl/psl/tests/validation/attributes/schema/tables_in_same_schema_with_same_constraint_names.prisma
+++ b/psl/psl/tests/validation/attributes/schema/tables_in_same_schema_with_same_constraint_names.prisma
@@ -28,7 +28,7 @@ model Post {
     @@schema("transactional")
 }
 
-// [1;91merror[0m: [1mThe model with database name "some_table" could not be defined because another model with this name exists: "User"[0m
+// [1;91merror[0m: [1mThe model with database name "some_table" could not be defined because another model or view with this name exists: "User"[0m
 //   [1;94m-->[0m  [4mschema.prisma:27[0m
 // [1;94m   | [0m
 // [1;94m26 | [0m

--- a/psl/psl/tests/validation/attributes/schema/tables_in_same_schema_with_same_mapped_name.prisma
+++ b/psl/psl/tests/validation/attributes/schema/tables_in_same_schema_with_same_mapped_name.prisma
@@ -24,7 +24,7 @@ model Cat {
   @@schema("base")
 }
 
-// [1;91merror[0m: [1mThe model with database name "pets" could not be defined because another model with this name exists: "Dog"[0m
+// [1;91merror[0m: [1mThe model with database name "pets" could not be defined because another model or view with this name exists: "Dog"[0m
 //   [1;94m-->[0m  [4mschema.prisma:23[0m
 // [1;94m   | [0m
 // [1;94m22 | [0m

--- a/psl/psl/tests/validation/views/no_preview_feature.prisma
+++ b/psl/psl/tests/validation/views/no_preview_feature.prisma
@@ -8,6 +8,7 @@ view Mountain {
   val String
 }
 
+
 // [1;91merror[0m: [1mError validating: View definitions are only available with the `views` preview feature.[0m
 //   [1;94m-->[0m  [4mschema.prisma:6[0m
 // [1;94m   | [0m

--- a/psl/schema-ast/src/parser/parse_composite_type.rs
+++ b/psl/schema-ast/src/parser/parse_composite_type.rs
@@ -70,6 +70,7 @@ pub(crate) fn parse_composite_type(
             }
             Rule::field_declaration => match parse_field(
                 &name.as_ref().unwrap().name,
+                "type",
                 current,
                 pending_field_comment.take(),
                 diagnostics,

--- a/psl/schema-ast/src/parser/parse_field.rs
+++ b/psl/schema-ast/src/parser/parse_field.rs
@@ -10,6 +10,7 @@ use diagnostics::{DatamodelError, Diagnostics};
 
 pub(crate) fn parse_field(
     model_name: &str,
+    container_type: &'static str,
     pair: Pair<'_>,
     block_comment: Option<Pair<'_>>,
     diagnostics: &mut Diagnostics,
@@ -54,6 +55,7 @@ pub(crate) fn parse_field(
         }),
         _ => Err(DatamodelError::new_model_validation_error(
             "This field declaration is invalid. It is either missing a name or a type.",
+            container_type,
             model_name,
             pair_span.into(),
         )),

--- a/psl/schema-ast/src/parser/parse_model.rs
+++ b/psl/schema-ast/src/parser/parse_model.rs
@@ -22,6 +22,7 @@ pub(crate) fn parse_model(pair: Pair<'_>, doc_comment: Option<Pair<'_>>, diagnos
             Rule::block_attribute => attributes.push(parse_attribute(current, diagnostics)),
             Rule::field_declaration => match parse_field(
                 &name.as_ref().unwrap().name,
+                "model",
                 current,
                 pending_field_comment.take(),
                 diagnostics,

--- a/psl/schema-ast/src/parser/parse_view.rs
+++ b/psl/schema-ast/src/parser/parse_view.rs
@@ -22,6 +22,7 @@ pub(crate) fn parse_view(pair: Pair<'_>, doc_comment: Option<Pair<'_>>, diagnost
             Rule::block_attribute => attributes.push(parse_attribute(current, diagnostics)),
             Rule::field_declaration => match parse_field(
                 &name.as_ref().unwrap().name,
+                "view",
                 current,
                 pending_field_comment.take(),
                 diagnostics,


### PR DESCRIPTION
Check the commits separately for review.

For the minimal product, we decided to prevent using relations in views with @janpio until we know better how to do them. This also prevents migration engine on doing anything with views in the PSL.

Closes: https://github.com/prisma/prisma/issues/17117