### PR TITLE
qe: remove #[deny(warnings)] occurrences

### DIFF
--- a/query-engine/connectors/query-connector/src/lib.rs
+++ b/query-engine/connectors/query-connector/src/lib.rs
@@ -1,6 +1,4 @@
-#![deny(warnings)]
 #![allow(clippy::derive_partial_eq_without_eq)]
-#![allow(rustdoc::invalid_html_tags)]
 
 pub mod error;
 pub mod filter;

--- a/query-engine/prisma-models/src/lib.rs
+++ b/query-engine/prisma-models/src/lib.rs
@@ -1,6 +1,3 @@
-#![deny(warnings)]
-#![allow(rustdoc::broken_intra_doc_links)]
-#![allow(clippy::from_over_into)]
 #![allow(clippy::derive_partial_eq_without_eq)]
 
 mod builders;

--- a/query-engine/prisma-models/src/record.rs
+++ b/query-engine/prisma-models/src/record.rs
@@ -8,11 +8,11 @@ pub struct SingleRecord {
     pub field_names: Vec<String>,
 }
 
-impl Into<ManyRecords> for SingleRecord {
-    fn into(self) -> ManyRecords {
+impl From<SingleRecord> for ManyRecords {
+    fn from(single: SingleRecord) -> ManyRecords {
         ManyRecords {
-            records: vec![self.record],
-            field_names: self.field_names,
+            records: vec![single.record],
+            field_names: single.field_names,
         }
     }
 }

--- a/query-engine/request-handlers/src/lib.rs
+++ b/query-engine/request-handlers/src/lib.rs
@@ -1,9 +1,4 @@
-#![allow(
-    clippy::upper_case_acronyms,
-    clippy::bool_assert_comparison,
-    clippy::mem_replace_with_default,
-    clippy::needless_borrow
-)]
+#![allow(clippy::upper_case_acronyms)]
 
 pub mod dmmf;
 


### PR DESCRIPTION
...and un-allow some ignored clippy warnings.

The rationale for removing #[deny(warnings)] is:

1. It makes iterating harder. Unused imports, unused variables, etc. lead to compilation errors.
2. It breaks `cargo build` on new rust versions when warnings are added. This is somewhat moot for us because we already face that with clippy lints in CI.