### PR TITLE
psl+introspection: align nanoid methods with conventions

### DIFF
--- a/introspection-engine/connectors/sql-introspection-connector/src/pair/default.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/pair/default.rs
@@ -128,7 +128,7 @@ impl<'a> DefaultValuePair<'a> {
                     let length = previous.value().as_function().and_then(|(_, args, _)| {
                         args.arguments
                             .get(0)
-                            .and_then(|arg| arg.value.to_string().parse::<u8>().ok())
+                            .map(|arg| arg.value.as_numeric_value().unwrap().0.parse::<u8>().unwrap())
                     });
 
                     Some(DefaultKind::Nanoid(length))

--- a/libs/dml/src/default_value.rs
+++ b/libs/dml/src/default_value.rs
@@ -202,10 +202,10 @@ impl ValueGenerator {
     }
 
     pub fn new_nanoid(length: Option<u8>) -> Self {
-        if length.is_some() {
+        if let Some(length) = length {
             ValueGenerator::new(
-                format!("nanoid({})", length.unwrap()),
-                vec![(None, PrismaValue::Int(length.unwrap().into()))],
+                format!("nanoid({})", length),
+                vec![(None, PrismaValue::Int(length.into()))],
             )
             .unwrap()
         } else {

--- a/libs/dml/src/lift.rs
+++ b/libs/dml/src/lift.rs
@@ -581,8 +581,7 @@ fn dml_default_kind(default_value: &ast::Expression, scalar_type: Option<ScalarT
                 args.arguments
                     .get(0)
                     .and_then(|arg| arg.value.as_numeric_value())
-                    .map(|(val, _)| val.to_owned().parse::<u8>().ok())
-                    .unwrap_or(None),
+                    .map(|(val, _)| val.parse::<u8>().unwrap()),
             ))
         }
         ast::Expression::Function(funcname, _args, _) if funcname == "now" => {


### PR DESCRIPTION
follow up to https://github.com/prisma/prisma-engines/pull/3556

- avoid unnecessary unwraps
- panic on logic errors
- avoid unnecessary allocations

Next step: migrate support.