### PR TITLE
sql-query-connector: take trace ids by reference

### DIFF
--- a/query-engine/connectors/sql-query-connector/src/cursor_condition.rs
+++ b/query-engine/connectors/sql-query-connector/src/cursor_condition.rs
@@ -118,7 +118,7 @@ struct CursorOrderForeignKey {
 ///     OR `ModelA`.`modelB_id` IS NULL -- >>> Additional check for the nullable foreign key
 ///   )
 /// ```
-pub fn build(
+pub(crate) fn build(
     query_arguments: &QueryArguments,
     model: &ModelRef,
     order_by_defs: &[OrderByDefinition],

--- a/query-engine/connectors/sql-query-connector/src/database/connection.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/connection.rs
@@ -95,7 +95,7 @@ where
                 filter,
                 &selected_fields.into(),
                 aggr_selections,
-                trace_id,
+                trace_id.as_deref(),
             )
             .await
         })
@@ -118,7 +118,7 @@ where
                 &selected_fields.into(),
                 aggr_selections,
                 SqlInfo::from(&self.connection_info),
-                trace_id,
+                trace_id.as_deref(),
             )
             .await
         })
@@ -132,7 +132,7 @@ where
         trace_id: Option<String>,
     ) -> connector::Result<Vec<(SelectionResult, SelectionResult)>> {
         catch(self.connection_info.clone(), async move {
-            read::get_related_m2m_record_ids(&self.inner, from_field, from_record_ids, trace_id).await
+            read::get_related_m2m_record_ids(&self.inner, from_field, from_record_ids, trace_id.as_deref()).await
         })
         .await
     }
@@ -154,7 +154,7 @@ where
                 selections,
                 group_by,
                 having,
-                trace_id,
+                trace_id.as_deref(),
             )
             .await
         })
@@ -174,7 +174,14 @@ where
         trace_id: Option<String>,
     ) -> connector::Result<SelectionResult> {
         catch(self.connection_info.clone(), async move {
-            write::create_record(&self.inner, &self.connection_info.sql_family(), model, args, trace_id).await
+            write::create_record(
+                &self.inner,
+                &self.connection_info.sql_family(),
+                model,
+                args,
+                trace_id.as_deref(),
+            )
+            .await
         })
         .await
     }
@@ -193,7 +200,7 @@ where
                 model,
                 args,
                 skip_duplicates,
-                trace_id,
+                trace_id.as_deref(),
             )
             .await
         })
@@ -208,7 +215,7 @@ where
         trace_id: Option<String>,
     ) -> connector::Result<usize> {
         catch(self.connection_info.clone(), async move {
-            write::update_records(&self.inner, model, record_filter, args, trace_id).await
+            write::update_records(&self.inner, model, record_filter, args, trace_id.as_deref()).await
         })
         .await
     }
@@ -221,7 +228,7 @@ where
         trace_id: Option<String>,
     ) -> connector::Result<Option<SelectionResult>> {
         catch(self.connection_info.clone(), async move {
-            let mut res = write::update_record(&self.inner, model, record_filter, args, trace_id).await?;
+            let mut res = write::update_record(&self.inner, model, record_filter, args, trace_id.as_deref()).await?;
             Ok(res.pop())
         })
         .await
@@ -234,7 +241,7 @@ where
         trace_id: Option<String>,
     ) -> connector::Result<usize> {
         catch(self.connection_info.clone(), async move {
-            write::delete_records(&self.inner, model, record_filter, trace_id).await
+            write::delete_records(&self.inner, model, record_filter, trace_id.as_deref()).await
         })
         .await
     }
@@ -245,7 +252,7 @@ where
         trace_id: Option<String>,
     ) -> connector::Result<SingleRecord> {
         catch(self.connection_info.clone(), async move {
-            native_upsert(&self.inner, upsert, trace_id).await
+            native_upsert(&self.inner, upsert, trace_id.as_deref()).await
         })
         .await
     }
@@ -270,7 +277,7 @@ where
         trace_id: Option<String>,
     ) -> connector::Result<()> {
         catch(self.connection_info.clone(), async move {
-            write::m2m_disconnect(&self.inner, field, parent_id, child_ids, trace_id).await
+            write::m2m_disconnect(&self.inner, field, parent_id, child_ids, trace_id.as_deref()).await
         })
         .await
     }

--- a/query-engine/connectors/sql-query-connector/src/database/operations/upsert.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/upsert.rs
@@ -1,20 +1,19 @@
-use connector_interface::NativeUpsert;
-use prisma_models::{ModelProjection, Record, SingleRecord};
-use quaint::prelude::{OnConflict, Query};
-
 use crate::{
     column_metadata,
     filter_conversion::AliasedCondition,
     model_extensions::AsColumns,
-    query_builder::{build_update_and_set_query, create_record},
+    query_builder::write::{build_update_and_set_query, create_record},
     query_ext::QueryExt,
     row::ToSqlRow,
 };
+use connector_interface::NativeUpsert;
+use prisma_models::{ModelProjection, Record, SingleRecord};
+use quaint::prelude::{OnConflict, Query};
 
-pub async fn native_upsert(
+pub(crate) async fn native_upsert(
     conn: &dyn QueryExt,
     upsert: NativeUpsert,
-    trace_id: Option<String>,
+    trace_id: Option<&str>,
 ) -> crate::Result<SingleRecord> {
     let selected_fields: ModelProjection = upsert.selected_fields().into();
     let field_names: Vec<_> = selected_fields.db_names().collect();

--- a/query-engine/connectors/sql-query-connector/src/database/transaction.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/transaction.rs
@@ -78,7 +78,7 @@ impl<'tx> ReadOperations for SqlConnectorTransaction<'tx> {
                 filter,
                 &selected_fields.into(),
                 aggr_selections,
-                trace_id,
+                trace_id.as_deref(),
             )
             .await
         })
@@ -101,7 +101,7 @@ impl<'tx> ReadOperations for SqlConnectorTransaction<'tx> {
                 &selected_fields.into(),
                 aggr_selections,
                 SqlInfo::from(&self.connection_info),
-                trace_id,
+                trace_id.as_deref(),
             )
             .await
         })
@@ -115,7 +115,7 @@ impl<'tx> ReadOperations for SqlConnectorTransaction<'tx> {
         trace_id: Option<String>,
     ) -> connector::Result<Vec<(SelectionResult, SelectionResult)>> {
         catch(self.connection_info.clone(), async move {
-            read::get_related_m2m_record_ids(&self.inner, from_field, from_record_ids, trace_id).await
+            read::get_related_m2m_record_ids(&self.inner, from_field, from_record_ids, trace_id.as_deref()).await
         })
         .await
     }
@@ -137,7 +137,7 @@ impl<'tx> ReadOperations for SqlConnectorTransaction<'tx> {
                 selections,
                 group_by,
                 having,
-                trace_id,
+                trace_id.as_deref(),
             )
             .await
         })
@@ -154,7 +154,14 @@ impl<'tx> WriteOperations for SqlConnectorTransaction<'tx> {
         trace_id: Option<String>,
     ) -> connector::Result<SelectionResult> {
         catch(self.connection_info.clone(), async move {
-            write::create_record(&self.inner, &self.connection_info.sql_family(), model, args, trace_id).await
+            write::create_record(
+                &self.inner,
+                &self.connection_info.sql_family(),
+                model,
+                args,
+                trace_id.as_deref(),
+            )
+            .await
         })
         .await
     }
@@ -173,7 +180,7 @@ impl<'tx> WriteOperations for SqlConnectorTransaction<'tx> {
                 model,
                 args,
                 skip_duplicates,
-                trace_id,
+                trace_id.as_deref(),
             )
             .await
         })
@@ -188,7 +195,7 @@ impl<'tx> WriteOperations for SqlConnectorTransaction<'tx> {
         trace_id: Option<String>,
     ) -> connector::Result<usize> {
         catch(self.connection_info.clone(), async move {
-            write::update_records(&self.inner, model, record_filter, args, trace_id).await
+            write::update_records(&self.inner, model, record_filter, args, trace_id.as_deref()).await
         })
         .await
     }
@@ -201,7 +208,7 @@ impl<'tx> WriteOperations for SqlConnectorTransaction<'tx> {
         trace_id: Option<String>,
     ) -> connector::Result<Option<SelectionResult>> {
         catch(self.connection_info.clone(), async move {
-            let mut res = write::update_record(&self.inner, model, record_filter, args, trace_id).await?;
+            let mut res = write::update_record(&self.inner, model, record_filter, args, trace_id.as_deref()).await?;
             Ok(res.pop())
         })
         .await
@@ -214,7 +221,7 @@ impl<'tx> WriteOperations for SqlConnectorTransaction<'tx> {
         trace_id: Option<String>,
     ) -> connector::Result<usize> {
         catch(self.connection_info.clone(), async move {
-            write::delete_records(&self.inner, model, record_filter, trace_id).await
+            write::delete_records(&self.inner, model, record_filter, trace_id.as_deref()).await
         })
         .await
     }
@@ -225,7 +232,7 @@ impl<'tx> WriteOperations for SqlConnectorTransaction<'tx> {
         trace_id: Option<String>,
     ) -> connector::Result<SingleRecord> {
         catch(self.connection_info.clone(), async move {
-            native_upsert(&self.inner, upsert, trace_id).await
+            native_upsert(&self.inner, upsert, trace_id.as_deref()).await
         })
         .await
     }
@@ -250,7 +257,7 @@ impl<'tx> WriteOperations for SqlConnectorTransaction<'tx> {
         trace_id: Option<String>,
     ) -> connector::Result<()> {
         catch(self.connection_info.clone(), async move {
-            write::m2m_disconnect(&self.inner, field, parent_id, child_ids, trace_id).await
+            write::m2m_disconnect(&self.inner, field, parent_id, child_ids, trace_id.as_deref()).await
         })
         .await
     }

--- a/query-engine/connectors/sql-query-connector/src/ordering.rs
+++ b/query-engine/connectors/sql-query-connector/src/ordering.rs
@@ -8,7 +8,7 @@ static ORDER_JOIN_PREFIX: &str = "orderby_";
 static ORDER_AGGREGATOR_ALIAS: &str = "orderby_aggregator";
 
 #[derive(Debug, Clone)]
-pub struct OrderByDefinition {
+pub(crate) struct OrderByDefinition {
     /// Final column identifier to be used for the scalar field to order by
     pub(crate) order_column: Expression<'static>,
     /// Defines ordering for an `ORDER BY` statement.
@@ -18,14 +18,14 @@ pub struct OrderByDefinition {
 }
 
 #[derive(Debug, Default)]
-pub struct OrderByBuilder {
+pub(crate) struct OrderByBuilder {
     // Used to generate unique join alias
     join_counter: usize,
 }
 
 impl OrderByBuilder {
     /// Builds all expressions for an `ORDER BY` clause based on the query arguments.
-    pub fn build(&mut self, query_arguments: &QueryArguments) -> Vec<OrderByDefinition> {
+    pub(crate) fn build(&mut self, query_arguments: &QueryArguments) -> Vec<OrderByDefinition> {
         let needs_reversed_order = query_arguments.needs_reversed_order();
 
         // The index is used to differentiate potentially separate relations to the same model.

--- a/query-engine/connectors/sql-query-connector/src/query_arguments_ext.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_arguments_ext.rs
@@ -1,6 +1,6 @@
 use connector_interface::QueryArguments;
 
-pub trait QueryArgumentsExt {
+pub(crate) trait QueryArgumentsExt {
     /// If we need to take rows before a cursor position, then we need to reverse the order in SQL.
     fn needs_reversed_order(&self) -> bool;
 }

--- a/query-engine/connectors/sql-query-connector/src/query_builder/mod.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_builder/mod.rs
@@ -1,8 +1,5 @@
-pub mod read;
-pub mod write;
-
-pub use read::*;
-pub use write::*;
+pub(crate) mod read;
+pub(crate) mod write;
 
 use crate::model_extensions::SelectionResultExt;
 use prisma_models::SelectionResult;

--- a/query-engine/connectors/sql-query-connector/src/sql_trace.rs
+++ b/query-engine/connectors/sql-query-connector/src/sql_trace.rs
@@ -13,7 +13,7 @@ pub fn trace_parent_to_string(context: &SpanContext) -> String {
 
 pub trait SqlTraceComment: Sized {
     fn append_trace(self, span: &Span) -> Self;
-    fn add_trace_id(self, trace_id: Option<String>) -> Self;
+    fn add_trace_id(self, trace_id: Option<&str>) -> Self;
 }
 
 macro_rules! sql_trace {
@@ -31,7 +31,7 @@ macro_rules! sql_trace {
                 }
             }
             // Temporary method to pass the traceid in an operation
-            fn add_trace_id(self, trace_id: Option<String>) -> Self {
+            fn add_trace_id(self, trace_id: Option<&str>) -> Self {
                 if let Some(traceparent) = trace_id {
                     if should_sample(&traceparent) {
                         self.comment(format!("traceparent={}", traceparent))


### PR DESCRIPTION
This commit is limited to sql-query-connector, it should not interfere with https://github.com/prisma/prisma-engines/pull/3505.

In general, we do not need ownership of the trace id in sql-query-connector, since we only re-render it in comments. Working with a reference is easier (it ii `Copy`, etc.), and it already saves us string copies and allocations with this commit.

The other purpose of this PR is that we discussed yesterday about introducing a `QueryContext<'_>` type struct to hold things like the trace id and connection info. Experience from designing similar context structs in the schema team showed it is much easier to do if everything in the context can be a reference.

On the side, I could not resist making a few public items crate-public, to make the public surface of the crate smaller and clearer.